### PR TITLE
security: bearer token auth on dashboard /api/* routes

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -2,7 +2,7 @@ import http from 'node:http'
 import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, mkdirSync, rmSync, statSync, lstatSync, copyFileSync } from 'node:fs'
 import { join, extname, resolve, sep } from 'node:path'
 import { homedir } from 'node:os'
-import { randomUUID } from 'node:crypto'
+import { randomUUID, randomBytes, timingSafeEqual } from 'node:crypto'
 import { spawn, execSync, type ChildProcess } from 'node:child_process'
 import { CronExpressionParser } from 'cron-parser'
 import { PROJECT_ROOT } from './config.js'
@@ -47,6 +47,39 @@ const MIME: Record<string, string> = {
 
 function ensureDirs() {
   mkdirSync(AGENTS_BASE_DIR, { recursive: true })
+}
+
+// --- Dashboard auth ---
+// A single bearer token gates every /api/* route. It is loaded from
+// DASHBOARD_TOKEN if set, otherwise persisted at store/.dashboard-token
+// (mode 0600) and auto-generated on first run. Static assets (/, /index.html,
+// /style.css, /app.js, /avatars/*) and the auth-status endpoint stay public
+// so the UI can bootstrap itself.
+const DASHBOARD_TOKEN_PATH = join(PROJECT_ROOT, 'store', '.dashboard-token')
+
+function loadOrCreateDashboardToken(): string {
+  const fromEnv = process.env.DASHBOARD_TOKEN?.trim()
+  if (fromEnv) return fromEnv
+  try {
+    if (existsSync(DASHBOARD_TOKEN_PATH)) {
+      const cached = readFileSync(DASHBOARD_TOKEN_PATH, 'utf-8').trim()
+      if (cached) return cached
+    }
+  } catch { /* fall through and regenerate */ }
+  const fresh = randomBytes(32).toString('hex')
+  mkdirSync(join(PROJECT_ROOT, 'store'), { recursive: true })
+  writeFileSync(DASHBOARD_TOKEN_PATH, fresh, { mode: 0o600 })
+  return fresh
+}
+
+function checkBearerToken(header: string | undefined, expected: string): boolean {
+  if (!header) return false
+  const m = /^Bearer\s+(.+)$/.exec(header)
+  if (!m) return false
+  const provided = Buffer.from(m[1].trim())
+  const wanted = Buffer.from(expected)
+  if (provided.length !== wanted.length) return false
+  return timingSafeEqual(provided, wanted)
 }
 
 // --- Agent management ---
@@ -848,6 +881,7 @@ export function startWebServer(port = 3420): http.Server {
   // from malicious websites the user may visit while the dashboard is running.
   ensureDirs()
 
+  const DASHBOARD_TOKEN = loadOrCreateDashboardToken()
   const allowedOrigins = new Set([
     `http://localhost:${port}`,
     `http://127.0.0.1:${port}`,
@@ -877,6 +911,28 @@ export function startWebServer(port = 3420): http.Server {
       res.writeHead(403, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({ error: 'Origin not allowed' }))
       return
+    }
+
+    // Auth gate: every /api/* route requires a bearer token in the Authorization
+    // header. Exceptions: the auth-status probe (so the client can tell whether
+    // it needs to prompt the user), and GET requests for avatar images (loaded
+    // via <img src> which can't carry headers -- these are non-sensitive assets).
+    const isPublicApi =
+      (path === '/api/auth/status' && method === 'GET') ||
+      (method === 'GET' && (
+        path === '/api/marveen/avatar' ||
+        /^\/api\/agents\/[^/]+\/avatar$/.test(path)
+      ))
+    if (path === '/api/auth/status' && method === 'GET') {
+      const ok = checkBearerToken(req.headers.authorization, DASHBOARD_TOKEN)
+      return json(res, { authenticated: ok })
+    }
+    if (path.startsWith('/api/') && !isPublicApi) {
+      if (!checkBearerToken(req.headers.authorization, DASHBOARD_TOKEN)) {
+        res.writeHead(401, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Unauthorized' }))
+        return
+      }
     }
 
     try {
@@ -2389,6 +2445,11 @@ Respond ONLY with JSON, nothing else:
 
   server.listen(port, '127.0.0.1', () => {
     logger.info({ port }, `Web dashboard: http://localhost:${port}`)
+    // Access URL embeds the token so the browser can bootstrap auth on first
+    // visit. The client strips the token from the URL after storing it.
+    logger.info(
+      `Dashboard access URL (paste into browser, token is stored afterward):\n  http://127.0.0.1:${port}/?token=${DASHBOARD_TOKEN}`
+    )
   })
 
   // Start message router

--- a/web/app.js
+++ b/web/app.js
@@ -1,3 +1,52 @@
+// === Dashboard auth bootstrap ===
+// The server prints an URL like http://127.0.0.1:3420/?token=XXX on startup.
+// On first visit we pluck the token out of the URL, store it in localStorage,
+// strip it from the visible URL, and then inject it into every /api/* fetch
+// as a Bearer header so the server lets us through.
+(() => {
+  const TOKEN_KEY = 'marveen-dashboard-token'
+  const urlParams = new URLSearchParams(window.location.search)
+  const urlToken = urlParams.get('token')
+  if (urlToken) {
+    localStorage.setItem(TOKEN_KEY, urlToken)
+    urlParams.delete('token')
+    const clean = window.location.pathname + (urlParams.toString() ? '?' + urlParams : '') + window.location.hash
+    window.history.replaceState({}, '', clean)
+  }
+
+  const originalFetch = window.fetch.bind(window)
+  window.fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : (input instanceof Request ? input.url : String(input))
+    // Only attach the token to same-origin API calls. Relative paths always
+    // resolve to same-origin; absolute URLs must match the current origin.
+    const isSameOriginApi =
+      url.startsWith('/api/') ||
+      (url.startsWith(window.location.origin + '/api/'))
+    if (isSameOriginApi) {
+      const token = localStorage.getItem(TOKEN_KEY)
+      if (token) {
+        init = init || {}
+        const headers = new Headers(init.headers || (input instanceof Request ? input.headers : undefined))
+        headers.set('Authorization', 'Bearer ' + token)
+        init.headers = headers
+      }
+    }
+    const res = await originalFetch(input, init)
+    if (res.status === 401 && isSameOriginApi) {
+      // Token missing, wrong, or revoked. Wipe and prompt once per page load.
+      localStorage.removeItem(TOKEN_KEY)
+      if (!window.__marveenAuthPrompted) {
+        window.__marveenAuthPrompted = true
+        alert(
+          'Dashboard authentication failed. Check the server log for the access URL ' +
+          '(look for "Dashboard access URL" with ?token=...), then reopen it in your browser.'
+        )
+      }
+    }
+    return res
+  }
+})()
+
 // === Theme ===
 const html = document.documentElement
 const themeToggle = document.getElementById('themeToggle')


### PR DESCRIPTION
Stack-elve a #1 PR tetején (CSRF + path traversal).

## Mit javít

A dashboard `/api/*` útvonalai eddig autentikáció nélkül elérhetőek voltak. 127.0.0.1-re kötés **nem véd** más helyi felhasználóktól (SSH, shared gép, véletlen port forward).

## Fix

**Szerver (`src/web.ts`):**
- 32-bájt véletlen token generálás első induláskor → `store/.dashboard-token` (0600). `DASHBOARD_TOKEN` env override.
- `timingSafeEqual` bearer-token ellenőrzés minden `/api/*` útvonalon.
- Kivétel: statikus assetek, `/api/auth/status` probe, és `GET /api/*/avatar` (utóbbit `<img src>` tölti, nem visz headert; az avatar kép nem érzékeny).
- Induláskor log-ba írt bootstrap URL: `http://127.0.0.1:3420/?token=...`

**Kliens (`web/app.js`):**
- Token kinyerése `?token=` URL param-ból, localStorage-be mentés, URL tisztítás.
- `window.fetch` wrapper ami ráilleszti a `Authorization: Bearer ...` headert — egy helyen javít 67 meglévő fetch hívást.
- 401-nél token törlés + prompt.

## Tesztelve (curl smoke)

| Kérés | Várt | Kapott |
|---|---|---|
| `GET /api/agents` (no token) | 401 | 401 ✅ |
| `GET /api/agents` (bad token) | 401 | 401 ✅ |
| `GET /api/agents` (good token) | 200 | 200 ✅ |
| `GET /api/auth/status` | `{authenticated: bool}` | ✅ |
| `GET /` | 200 | 200 ✅ |
| `POST /api/agents` foreign Origin | 403 | 403 ✅ (PR #1 CSRF gate) |

- [x] `npx tsc --noEmit` átmegy
- [x] `npm test` — 25/25 zöld

## Threat model megjegyzés

A token localStorage-ben — XSS-sel kinyerhető. A dashboard nem renderel user-generated HTML-t nyersen (agent névsorok escape-eltek), de ha jövőben egy új feature-ben felbukkanna, a token veszélybe kerül. Következő iteráció: httpOnly cookie + CSRF token, de a jelenlegi fenyegetési modell (helyi multi-user) ellen a bearer token elégséges.