### PR TITLE
security: lock token .env files to mode 0600

### DIFF
--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -171,13 +171,14 @@ wsl bash -c @"
 cd $installPath
 
 # Create .env
-cat > .env << 'ENVEOF'
+(umask 077 && cat > .env << 'ENVEOF'
 TELEGRAM_BOT_TOKEN=$botToken
 ALLOWED_CHAT_ID=$chatId
 OWNER_NAME=$ownerName
 ENVEOF
-
-echo '  ✓ .env létrehozva'
+)
+chmod 600 .env
+echo '  ✓ .env létrehozva (chmod 600)'
 
 # Generate CLAUDE.md from template
 if [ -f templates/CLAUDE.md.template ]; then
@@ -191,7 +192,8 @@ mkdir -p store agents
 # Setup Telegram
 if [ -n '$botToken' ]; then
     mkdir -p ~/.claude/channels/telegram
-    echo 'TELEGRAM_BOT_TOKEN=$botToken' > ~/.claude/channels/telegram/.env
+    (umask 077 && echo 'TELEGRAM_BOT_TOKEN=$botToken' > ~/.claude/channels/telegram/.env)
+    chmod 600 ~/.claude/channels/telegram/.env
     echo '{"dmPolicy":"allowlist","allowFrom":["$chatId"],"groups":{},"pending":{}}' > ~/.claude/channels/telegram/access.json
     echo '  ✓ Telegram csatorna konfigurálva'
 fi

--- a/install.sh
+++ b/install.sh
@@ -122,13 +122,15 @@ echo ""
 echo -e "${BOLD}[6/7] Konfiguracio letrehozasa...${NC}"
 
 # Create .env
-cat > "$INSTALL_DIR/.env" << ENVEOF
+(umask 077 && cat > "$INSTALL_DIR/.env" << ENVEOF
 # Marveen konfiguracio
 TELEGRAM_BOT_TOKEN=${BOT_TOKEN}
 ALLOWED_CHAT_ID=${CHAT_ID}
 OWNER_NAME=${OWNER_NAME}
 ENVEOF
-echo -e "  ${GREEN}✓${NC} .env letrehozva"
+)
+chmod 600 "$INSTALL_DIR/.env"
+echo -e "  ${GREEN}✓${NC} .env letrehozva (chmod 600)"
 
 # Create store directory
 mkdir -p "$INSTALL_DIR/store"
@@ -148,7 +150,8 @@ fi
 if [ -n "$BOT_TOKEN" ] && [ "$BOT_TOKEN" != "" ]; then
   TELEGRAM_DIR="$HOME/.claude/channels/telegram"
   mkdir -p "$TELEGRAM_DIR"
-  echo "TELEGRAM_BOT_TOKEN=$BOT_TOKEN" > "$TELEGRAM_DIR/.env"
+  (umask 077 && echo "TELEGRAM_BOT_TOKEN=$BOT_TOKEN" > "$TELEGRAM_DIR/.env")
+  chmod 600 "$TELEGRAM_DIR/.env"
   cat > "$TELEGRAM_DIR/access.json" << ACCESSEOF
 {
   "dmPolicy": "allowlist",

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -123,8 +123,8 @@ async function main() {
   for (const [key, value] of Object.entries(config)) {
     envContent += `${key}=${value}\n`
   }
-  writeFileSync(envPath, envContent)
-  ok('.env fajl letrehozva')
+  writeFileSync(envPath, envContent, { mode: 0o600 })
+  ok('.env fajl letrehozva (0600)')
 
   // CLAUDE.md szerkesztes
   header('5. CLAUDE.md testreszabas')

--- a/src/web.ts
+++ b/src/web.ts
@@ -1062,7 +1062,7 @@ export function startWebServer(port = 3420): http.Server {
 
         const tgDir = join(agentDir(name), '.claude', 'channels', 'telegram')
         mkdirSync(tgDir, { recursive: true })
-        writeFileSync(join(tgDir, '.env'), `TELEGRAM_BOT_TOKEN=${botToken.trim()}\n`)
+        writeFileSync(join(tgDir, '.env'), `TELEGRAM_BOT_TOKEN=${botToken.trim()}\n`, { mode: 0o600 })
         writeFileSync(join(tgDir, 'access.json'), JSON.stringify({
           dmPolicy: 'allowlist',
           allowFrom: [ALLOWED_CHAT_ID],


### PR DESCRIPTION
## Mit javít

A bot tokeneket tartalmazó `.env` fájlok a default umask-szal (tipikus devgépen 0644 / world-readable) jöttek létre. Multi-user gépen (közös VPS, devbox, shared droplet) **bármely helyi user `cat`-tel megszerezhette** a Telegram bot tokent, és azzal:

- leolvashatta az összes bot-chat történetét (`getUpdates`)
- üzenetet küldhetett a bot nevében
- a Telegram channel plugin permission relay-jét kihasználva **más helyett jóváhagyhatott tool-call-okat** az operátor ágensein

## Érintett fájlok

| Fájl | Mi íródott | Javítás |
|---|---|---|
| `install.sh` | `$INSTALL_DIR/.env`, `$TELEGRAM_DIR/.env` | `(umask 077 && ... )` + `chmod 600` |
| `install-windows.ps1` | ugyanez WSL alatt | ugyanaz (ext4, chmod normálisan működik) |
| `scripts/setup.ts` | projekt `.env` | `writeFileSync(..., { mode: 0o600 })` |
| `src/web.ts:1065` | per-ágens Telegram `.env` (dashboard action) | `writeFileSync(..., { mode: 0o600 })` |

## Miért umask ÉS chmod

Egyik önmagában is elég volna, de redundánsan mindkettő:
- `umask 077`: már létrehozáskor 0600, nincs rés a race window-ban
- `chmod 600`: fallback ha umask valamiért nem terjed be (pl. későbbi append)

## Nem változtatott

`access.json` a default jogokon marad — csak chat ID-ket tárol, azok amúgy is Telegram-oldali publikus adatok.

## Tesztelés
- [x] `bash -n install.sh` — syntax OK
- [x] `npx tsc --noEmit` — OK
- [x] `npm test` — 25/25 zöld
- [x] Manuális: `(umask 077 && cat > test << EOF ... EOF)` → `-rw-------` ✅