### PR TITLE
security: harden FTS5 sanitizer + strip personal path from .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,3 @@
 {
-  "mcpServers": {
-    "aiam-blog": {
-      "command": "node",
-      "args": ["/Users/marvin/ClaudeClaw/mcp-servers/aiam-blog/server.mjs"]
-    }
-  }
+  "mcpServers": {}
 }

--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -8,6 +8,7 @@ import {
   recentMemories,
   decayMemories,
   getMemoriesForChat,
+  buildFtsMatchExpression,
 } from '../db.js'
 
 beforeAll(() => {
@@ -59,5 +60,53 @@ describe('memories', () => {
 
   it('leepulesi soprest vegrehajt hiba nelkul', () => {
     expect(() => decayMemories()).not.toThrow()
+  })
+})
+
+describe('buildFtsMatchExpression', () => {
+  it('produces prefix-matched tokens for a plain query', () => {
+    expect(buildFtsMatchExpression('hello world')).toBe('hello* world*')
+  })
+
+  it('returns empty string for whitespace-only or empty input', () => {
+    expect(buildFtsMatchExpression('')).toBe('')
+    expect(buildFtsMatchExpression('   ')).toBe('')
+    expect(buildFtsMatchExpression('!!!***???')).toBe('')
+  })
+
+  it('lowercases to neutralize FTS5 AND/OR/NOT/NEAR operators', () => {
+    const out = buildFtsMatchExpression('foo OR bar AND baz NOT qux')
+    // No uppercase operator keywords should survive as standalone tokens.
+    expect(out).not.toMatch(/\bOR\b/)
+    expect(out).not.toMatch(/\bAND\b/)
+    expect(out).not.toMatch(/\bNOT\b/)
+    expect(out).toBe('foo* or* bar* and* baz* not* qux*')
+  })
+
+  it('strips FTS5 punctuation (quotes, parens, colons); * is ours', () => {
+    const out = buildFtsMatchExpression('"foo" (bar) baz qux:zap')
+    expect(out).not.toMatch(/["():]/)
+    // Every * in the output is our own prefix-match suffix, appended to a token.
+    // No bare *, no doubled **.
+    expect(out).not.toMatch(/\*\*/)
+    expect(out).not.toMatch(/(^| )\*/)
+    expect(out).toBe('foo* bar* baz* quxzap*')
+  })
+
+  it('caps at 20 tokens', () => {
+    const many = Array.from({ length: 30 }, (_, i) => `word${i}`).join(' ')
+    const out = buildFtsMatchExpression(many)
+    expect(out.split(' ').length).toBe(20)
+  })
+
+  it('truncates individual tokens longer than 64 chars', () => {
+    const long = 'a'.repeat(200)
+    const out = buildFtsMatchExpression(long)
+    // 64 'a's + '*'
+    expect(out).toBe('a'.repeat(64) + '*')
+  })
+
+  it('preserves unicode letters and digits', () => {
+    expect(buildFtsMatchExpression('Árvíztűrő 42')).toBe('árvíztűrő* 42*')
   })
 })

--- a/src/db.ts
+++ b/src/db.ts
@@ -280,13 +280,32 @@ export function saveMemory(
   ).run(chatId, topicKey ?? null, content, sector, now, now)
 }
 
-export function searchMemories(query: string, chatId: string, limit = 3): Memory[] {
-  const sanitized = query.replace(/[^\p{L}\p{N}\s]/gu, '').trim()
-  if (!sanitized) return []
-  const terms = sanitized
+// Build a safe FTS5 MATCH expression from a free-form user query.
+//
+// FTS5 treats AND / OR / NOT / NEAR as reserved operators only when uppercase
+// and unquoted -- so we lowercase everything, which turns them into ordinary
+// search terms. We also cap the number and length of tokens to bound query
+// cost (the sanitizer previously allowed an arbitrary-length prefix expansion
+// that could make a single request scan the entire index).
+export function buildFtsMatchExpression(query: string): string {
+  const MAX_TOKENS = 20
+  const MAX_TOKEN_LEN = 64
+  const sanitized = query
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, '')
+    .trim()
+  if (!sanitized) return ''
+  const tokens = sanitized
     .split(/\s+/)
-    .map((t) => t + '*')
-    .join(' ')
+    .filter((t) => t.length > 0)
+    .slice(0, MAX_TOKENS)
+    .map((t) => t.slice(0, MAX_TOKEN_LEN) + '*')
+  return tokens.join(' ')
+}
+
+export function searchMemories(query: string, chatId: string, limit = 3): Memory[] {
+  const terms = buildFtsMatchExpression(query)
+  if (!terms) return []
   try {
     return db
       .prepare(
@@ -358,9 +377,8 @@ export function getAgentMemories(agentId: string, limit: number = 20): Memory[] 
 }
 
 export function searchAgentMemories(agentId: string, query: string, limit: number = 10): Memory[] {
-  const sanitized = query.replace(/[^\p{L}\p{N}\s]/gu, '').trim()
-  if (!sanitized) return []
-  const terms = sanitized.split(/\s+/).map(t => t + '*').join(' ')
+  const terms = buildFtsMatchExpression(query)
+  if (!terms) return []
   try {
     return db.prepare(
       `SELECT m.* FROM memories m


### PR DESCRIPTION
Két apró, független tétel egy PR-ban.

## 1. FTS5 query sanitizer (`src/db.ts`)

**Mi volt rossz:**
```ts
const sanitized = query.replace(/[^\p{L}\p{N}\s]/gu, '').trim()
const terms = sanitized.split(/\s+/).map(t => t + '*').join(' ')
```

- **Case nem normalizált** — FTS5 az `AND`/`OR`/`NOT`/`NEAR`-t **operátorként** kezeli ha uppercase és unquoted. Egy `"foo OR bar"` keresés után a MATCH kifejezés `"foo* OR bar*"` lett, ami operátorként értelmeződött → eredmény szemantikája átalakult („mindkét szó" → „bármelyik").
- **Token-szám/hossz nincs korlátozva** — egy beillesztett hosszú szöveg hatalmas prefix-expression-t generált, skálázódó query cost.

**Fix:** kiemelem `buildFtsMatchExpression()` helperré mindkét hívó helyről (`searchMemories`, `searchAgentMemories`; `hybridSearch` közvetve). A helper:
- lowercase → minden operátor-kulcsszó ártalmatlan keresési szó lesz
- max 20 token per query
- max 64 char per token

**7 új teszt** (41/41 zöld): plain, empty, AND/OR/NOT neutralizálás, punctuation stripping, token cap, token-length truncation, Unicode megőrzés.

## 2. `.mcp.json` személyes path eltávolítása

**Mi volt rossz:**
```json
"args": [\"/Users/marvin/ClaudeClaw/mcp-servers/aiam-blog/server.mjs\"]
```

- Leak: egy másik fejlesztő usernev-e (`marvin`) a repo-ban.
- Törés: **minden** nem-`marvin` user gépén a Claude Code csendben failel, mert a path nem létezik.
- Logikai inkonzisztencia: a `mcp-servers/` a `.gitignore`-ban user-specifikusként kizárva.

**Fix:** `.mcp.json` → `{ \"mcpServers\": {} }`. Akinek kell az aiam-blog (vagy bármi más) MCP, az saját telepítésben hozzáadja.

## Checklist
- [x] `npx tsc --noEmit` OK
- [x] `npm test` — 41/41 zöld