### PR TITLE
feat: Linux compatibility (issue #6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,7 @@ OWNER_NAME=Your Name
 HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # Opcionális:
 # WEB_PORT=3420
+# WEB_HOST=127.0.0.1       # 0.0.0.0 ha szerveren távelérés kell
+# OLLAMA_URL=http://localhost:11434
+# MARVEEN_ENV=linux-server  # platform override: macos | linux-server | linux-gui
 # GOOGLE_API_KEY=your_google_api_key

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ OWNER_NAME=Your Name
 HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # Opcionális:
 # WEB_PORT=3420
-# WEB_HOST=127.0.0.1       # 0.0.0.0 ha szerveren távelérés kell
+# WEB_HOST=127.0.0.1       # FONTOS: 0.0.0.0-val a dashboard elérhető a hálózatról. Használj DASHBOARD_TOKEN-t!
 # OLLAMA_URL=http://localhost:11434
 # MARVEEN_ENV=linux-server  # platform override: macos | linux-server | linux-gui
 # GOOGLE_API_KEY=your_google_api_key

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+# Marveen telepito -- Ubuntu/Debian
+# Hasznalat: bash install-linux.sh
+
+set -e
+
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+DIM='\033[2m'
+NC='\033[0m'
+
+ok()   { echo -e "  ${GREEN}✓${NC} $*"; }
+warn() { echo -e "  ${YELLOW}!${NC} $*"; }
+fail() { echo -e "  ${RED}✗${NC} $*"; exit 1; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo ""
+echo -e "${BOLD}Marveen telepito -- Ubuntu/Debian${NC}"
+echo ""
+
+# --- [1/6] Elofeltetelek ---
+echo -e "${BOLD}[1/6] Elofeltetelek ellenorzese...${NC}"
+
+if ! command -v apt-get &>/dev/null; then
+  fail "Ez a telepito csak Ubuntu/Debian rendszeren fut (apt-get szukseges)"
+fi
+
+MISSING_PKGS=""
+for pkg in git tmux lsof curl python3; do
+  if ! command -v "$pkg" &>/dev/null; then
+    MISSING_PKGS="$MISSING_PKGS $pkg"
+  fi
+done
+
+# Node.js v20+ ellenorzes
+NODE_OK=false
+if command -v node &>/dev/null; then
+  NODE_VER=$(node -e 'process.stdout.write(process.version.slice(1).split(".")[0])' 2>/dev/null || echo "0")
+  [ "$NODE_VER" -ge 20 ] && NODE_OK=true
+fi
+$NODE_OK || MISSING_PKGS="$MISSING_PKGS nodejs"
+
+if [ -n "$MISSING_PKGS" ]; then
+  warn "Hianyzo csomagok:$MISSING_PKGS"
+  echo -e "  Telepites sudo-val..."
+  sudo apt-get update -qq
+  # Node.js v20 (nem a regi apt verzio)
+  if echo "$MISSING_PKGS" | grep -q nodejs; then
+    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - >/dev/null 2>&1
+    MISSING_PKGS=$(echo "$MISSING_PKGS" | sed 's/ nodejs//')
+  fi
+  # shellcheck disable=SC2086
+  sudo apt-get install -y $MISSING_PKGS -qq
+fi
+
+ok "git $(git --version | awk '{print $3}')"
+ok "node $(node --version)"
+ok "npm $(npm --version)"
+ok "tmux $(tmux -V | awk '{print $2}')"
+ok "lsof"
+
+# --- [2/6] Claude Code telepites ---
+echo ""
+echo -e "${BOLD}[2/6] Claude Code telepitese...${NC}"
+
+if command -v claude &>/dev/null; then
+  ok "claude mar telepitve: $(claude --version 2>/dev/null || echo 'ok')"
+else
+  echo -e "  Letoltes: https://claude.ai/install.sh"
+  curl -fsSL https://claude.ai/install.sh | bash
+  ok "claude telepitve -> ~/.local/bin/claude"
+fi
+
+# ~/.local/bin hozzaadasa PATH-hoz (ha meg nincs)
+if ! grep -q '\.local/bin' ~/.bashrc 2>/dev/null; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+  warn "PATH bovitve: ~/.local/bin hozzaadva ~/.bashrc-hez (forras: source ~/.bashrc)"
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- [3/6] Ollama telepites ---
+echo ""
+echo -e "${BOLD}[3/6] Ollama telepitese...${NC}"
+
+if command -v ollama &>/dev/null; then
+  ok "ollama mar telepitve"
+else
+  echo -e "  Letoltes: https://ollama.com/install.sh"
+  curl -fsSL https://ollama.com/install.sh | sh
+  ok "ollama telepitve"
+fi
+
+# Ollama service elinditasa (ha meg nem fut)
+if ! pgrep -x ollama &>/dev/null; then
+  echo -e "  Ollama inditasa hatterben..."
+  ollama serve &>/dev/null &
+  sleep 3
+fi
+
+echo -e "  nomic-embed-text modell letoltese (szukseges a memoria rendszerhez)..."
+ollama pull nomic-embed-text --quiet 2>/dev/null || warn "nomic-embed-text letoltese sikertelen (kezzel: ollama pull nomic-embed-text)"
+
+# --- [4/6] Marveen telepites ---
+echo ""
+echo -e "${BOLD}[4/6] Marveen build...${NC}"
+
+cd "$INSTALL_DIR"
+
+echo -e "  npm ci..."
+npm ci --silent
+
+echo -e "  TypeScript build..."
+npm run build --silent
+
+mkdir -p store
+ok "build kesz"
+
+# .env beallitas
+if [ ! -f "$INSTALL_DIR/.env" ]; then
+  cp "$INSTALL_DIR/.env.example" "$INSTALL_DIR/.env"
+  chmod 600 "$INSTALL_DIR/.env"
+  warn ".env fajl letrehozva a peldabol -- szerkeszd meg: $INSTALL_DIR/.env"
+else
+  chmod 600 "$INSTALL_DIR/.env"
+  ok ".env mar letezik"
+fi
+
+# --- [5/6] Systemd user unitok ---
+echo ""
+echo -e "${BOLD}[5/6] Systemd user unitok generalasa...${NC}"
+
+SYSTEMD_DIR="$HOME/.config/systemd/user"
+mkdir -p "$SYSTEMD_DIR"
+
+# marveen-dashboard.service
+cat > "$SYSTEMD_DIR/marveen-dashboard.service" << EOF
+[Unit]
+Description=Marveen Dashboard
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$INSTALL_DIR
+ExecStart=/usr/bin/env node $INSTALL_DIR/dist/index.js
+Restart=on-failure
+RestartSec=5
+Environment=PATH=$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target
+EOF
+
+# marveen-channels.service
+cat > "$SYSTEMD_DIR/marveen-channels.service" << EOF
+[Unit]
+Description=Marveen Channels (Telegram bridge)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$INSTALL_DIR/scripts/channels.sh
+Restart=on-failure
+RestartSec=5
+Environment=PATH=$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target
+EOF
+
+# marveen-morning.service (a timer hivja)
+cat > "$SYSTEMD_DIR/marveen-morning.service" << EOF
+[Unit]
+Description=Marveen Reggeli Napindito
+
+[Service]
+Type=oneshot
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$INSTALL_DIR/scripts/morning-briefing.sh
+Environment=PATH=$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin
+EOF
+
+# marveen-morning.timer
+cat > "$SYSTEMD_DIR/marveen-morning.timer" << EOF
+[Unit]
+Description=Marveen Reggeli Napindito Timer
+Requires=marveen-morning.service
+
+[Timer]
+OnCalendar=*-*-* 07:27:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable marveen-dashboard marveen-channels marveen-morning.timer
+
+ok "systemd unitok generalva es engedelyezve"
+
+# loginctl enable-linger: headless szerveren szukseges (user session boot utan is el)
+if ! loginctl show-user "$USER" 2>/dev/null | grep -q "Linger=yes"; then
+  if sudo loginctl enable-linger "$USER" 2>/dev/null; then
+    ok "loginctl linger engedelyezve ($USER)"
+  else
+    warn "loginctl linger nem sikerult -- headless szerveren a servicek nem indulnak el automatikusan boot utan"
+  fi
+fi
+
+# --- [6/6] Konfiguracio es ellenorzes ---
+echo ""
+echo -e "${BOLD}[6/6] Ellenorzes...${NC}"
+
+# .env tartalma OK?
+if grep -q "your_telegram_bot_token_here" "$INSTALL_DIR/.env"; then
+  warn ".env nincs kitoltve! Szerkeszd meg: $INSTALL_DIR/.env"
+  echo ""
+  echo -e "  Szukseges valtozok:"
+  echo -e "    TELEGRAM_BOT_TOKEN=..."
+  echo -e "    ALLOWED_CHAT_ID=..."
+  echo -e "    OWNER_NAME=..."
+else
+  # Service inditas
+  systemctl --user start marveen-dashboard marveen-channels 2>/dev/null || true
+  sleep 2
+
+  # Dashboard ellenorzes
+  if curl -s http://localhost:3420/api/auth/status &>/dev/null; then
+    ok "Dashboard fut"
+  else
+    warn "Dashboard meg nem valaszol (indulas folyamatban lehet)"
+    echo -e "  Ellenorzes: curl http://localhost:3420/api/auth/status"
+    echo -e "  Logok: journalctl --user -u marveen-dashboard -f"
+  fi
+
+  # Dashboard token URL megjelenitese
+  DASH_TOKEN=""
+  if [ -f "$INSTALL_DIR/store/.dashboard-token" ]; then
+    DASH_TOKEN=$(cat "$INSTALL_DIR/store/.dashboard-token")
+  fi
+  if [ -n "$DASH_TOKEN" ]; then
+    echo -e "  ${BOLD}Dashboard:${NC} ${BLUE}http://localhost:3420/?token=${DASH_TOKEN}${NC}"
+    echo -e "  ${DIM}(Nyisd meg egyszer, utana a bongeszo megjegyzi a tokent)${NC}"
+  else
+    echo -e "  ${BOLD}Dashboard:${NC} http://localhost:3420"
+    echo -e "  ${DIM}(A tokenes URL-t a szerver logban talalod)${NC}"
+  fi
+fi
+
+echo ""
+echo -e "${BOLD}Telepites kesz!${NC}"
+echo ""
+echo -e "  Hasznos parancsok:"
+echo -e "    ${DIM}bash scripts/start.sh${NC}          -- inditas"
+echo -e "    ${DIM}bash scripts/stop.sh${NC}           -- leallitas"
+echo -e "    ${DIM}tmux attach -t marveen-channels${NC} -- Telegram bridge konzol"
+echo -e "    ${DIM}journalctl --user -u marveen-dashboard -f${NC} -- dashboard logok"
+echo -e "    ${DIM}journalctl --user -u marveen-channels -f${NC}  -- channels logok"
+echo ""

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -10,10 +10,13 @@
 # Kézzel rácsatlakozás: tmux attach -t marveen-channels
 
 SESSION="marveen-channels"
-CLAUDE="/opt/homebrew/bin/claude"
-TMUX="/opt/homebrew/bin/tmux"
 
-export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH="$HOME/.local/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+CLAUDE="$(command -v claude)"
+TMUX="$(command -v tmux)"
+[ -z "$CLAUDE" ] && echo "ERROR: claude not found on PATH" >&2 && exit 1
+[ -z "$TMUX" ]   && echo "ERROR: tmux not found on PATH" >&2 && exit 1
 
 INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 

--- a/scripts/morning-briefing.sh
+++ b/scripts/morning-briefing.sh
@@ -2,10 +2,11 @@
 # Marveen - Reggeli napindító
 # LaunchAgent hívja minden nap 7:27-kor
 
-export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH="$HOME/.local/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-CLAUDE="/opt/homebrew/bin/claude"
+CLAUDE="$(command -v claude)"
+[ -z "$CLAUDE" ] && echo "ERROR: claude not found on PATH" >&2 && exit 1
 LOG="$INSTALL_DIR/store/morning.log"
 
 # Load config

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -4,8 +4,13 @@
 INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 echo "Marveen inditas..."
-launchctl load "$HOME/Library/LaunchAgents/com.marveen.dashboard.plist" 2>/dev/null || true
-launchctl load "$HOME/Library/LaunchAgents/com.marveen.channels.plist" 2>/dev/null || true
+OS="$(uname -s)"
+if [ "$OS" = "Darwin" ]; then
+  launchctl load "$HOME/Library/LaunchAgents/com.marveen.dashboard.plist" 2>/dev/null || true
+  launchctl load "$HOME/Library/LaunchAgents/com.marveen.channels.plist" 2>/dev/null || true
+elif [ "$OS" = "Linux" ]; then
+  systemctl --user start marveen-dashboard marveen-channels
+fi
 
 echo "✓ Dashboard: http://localhost:3420"
 echo "✓ Telegram csatorna inditva"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -2,11 +2,16 @@
 # Stop Marveen services
 
 echo "Marveen leallitas..."
-launchctl unload "$HOME/Library/LaunchAgents/com.marveen.dashboard.plist" 2>/dev/null
-launchctl unload "$HOME/Library/LaunchAgents/com.marveen.channels.plist" 2>/dev/null
+OS="$(uname -s)"
+if [ "$OS" = "Darwin" ]; then
+  launchctl unload "$HOME/Library/LaunchAgents/com.marveen.dashboard.plist" 2>/dev/null
+  launchctl unload "$HOME/Library/LaunchAgents/com.marveen.channels.plist" 2>/dev/null
+elif [ "$OS" = "Linux" ]; then
+  systemctl --user stop marveen-dashboard marveen-channels 2>/dev/null || true
+fi
 
-# Kill tmux sessions
-tmux kill-session -t claudeclaw-channels 2>/dev/null || true
+# Kill tmux sessions (mindkét platformon)
+tmux kill-session -t marveen-channels 2>/dev/null || true
 for session in $(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^agent-'); do
   tmux kill-session -t "$session" 2>/dev/null || true
 done

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,9 @@ export const OWNER_NAME = env['OWNER_NAME'] ?? 'Szabolcs'
 
 export const WEB_PORT = parseInt(env['WEB_PORT'] ?? '3420', 10)
 
+export const WEB_HOST = env['WEB_HOST'] ?? '127.0.0.1'
+export const OLLAMA_URL = env['OLLAMA_URL'] ?? 'http://localhost:11434'
+
 // Heartbeat
 export const HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
 export const HEARTBEAT_START_HOUR = 9

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3'
 import { join } from 'node:path'
 import { mkdirSync } from 'node:fs'
-import { STORE_DIR, ALLOWED_CHAT_ID } from './config.js'
+import { STORE_DIR, ALLOWED_CHAT_ID, OLLAMA_URL } from './config.js'
 
 let db: Database.Database
 
@@ -705,7 +705,6 @@ export function getActiveScheduledTaskCount(): { count: number; nextRun: number 
 
 // --- Vector Search (Ollama + nomic-embed-text) ---
 
-const OLLAMA_URL = 'http://localhost:11434'
 const EMBED_MODEL = 'nomic-embed-text'
 
 export async function generateEmbedding(text: string): Promise<number[] | null> {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -16,6 +16,7 @@ function detect(): PlatformType {
 export const PLATFORM: PlatformType = detect()
 
 export function resolveFromPath(name: string): string {
+  if (!/^[a-zA-Z0-9._-]+$/.test(name)) throw new Error('Invalid binary name: ' + name)
   try {
     return execSync(`which ${name}`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
   } catch {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,24 @@
+import { execSync } from 'node:child_process'
+
+export type PlatformType = 'macos' | 'linux-server' | 'linux-gui'
+
+function detect(): PlatformType {
+  const override = process.env['MARVEEN_ENV']
+  if (override === 'macos' || override === 'linux-server' || override === 'linux-gui') return override
+  if (process.platform === 'darwin') return 'macos'
+  if (process.platform === 'linux') {
+    const hasDisplay = !!(process.env['DISPLAY'] || process.env['WAYLAND_DISPLAY'] || process.env['XDG_SESSION_TYPE'])
+    return hasDisplay ? 'linux-gui' : 'linux-server'
+  }
+  return 'linux-server'
+}
+
+export const PLATFORM: PlatformType = detect()
+
+export function resolveFromPath(name: string): string {
+  try {
+    return execSync(`which ${name}`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
+  } catch {
+    throw new Error(`Required binary not found on PATH: ${name}`)
+  }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -893,6 +893,7 @@ export function startWebServer(port = 3420): http.Server {
   const allowedOrigins = new Set([
     `http://localhost:${port}`,
     `http://127.0.0.1:${port}`,
+    ...( WEB_HOST !== 'localhost' && WEB_HOST !== '127.0.0.1' ? [`http://${WEB_HOST}:${port}`] : []),
   ])
   const isSafeMethod = (m: string) => m === 'GET' || m === 'HEAD' || m === 'OPTIONS'
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -5,7 +5,8 @@ import { homedir } from 'node:os'
 import { randomUUID, randomBytes, timingSafeEqual } from 'node:crypto'
 import { spawn, execSync, type ChildProcess } from 'node:child_process'
 import { CronExpressionParser } from 'cron-parser'
-import { PROJECT_ROOT } from './config.js'
+import { PROJECT_ROOT, OLLAMA_URL, WEB_HOST } from './config.js'
+import { resolveFromPath } from './platform.js'
 import { runAgent } from './agent.js'
 import { logger } from './logger.js'
 import {
@@ -253,8 +254,8 @@ function listAgentSummaries(): AgentSummary[] {
 
 // --- Agent process management (tmux-based) ---
 
-const TMUX = '/opt/homebrew/bin/tmux'
-const CLAUDE = '/opt/homebrew/bin/claude'
+const TMUX = resolveFromPath('tmux')
+const CLAUDE = resolveFromPath('claude')
 
 function agentSessionName(name: string): string {
   return `agent-${name}`
@@ -292,7 +293,7 @@ function startAgentProcess(name: string): { ok: boolean; pid?: number; error?: s
     // because tmux new-session does not inherit the caller's environment
     const model = readAgentModel(name)
     const isOllama = !model.startsWith('claude-')
-    const ollamaEnv = isOllama ? `export ANTHROPIC_AUTH_TOKEN=ollama && export ANTHROPIC_BASE_URL=http://localhost:11434 && ` : ''
+    const ollamaEnv = isOllama ? `export ANTHROPIC_AUTH_TOKEN=ollama && export ANTHROPIC_BASE_URL=${OLLAMA_URL} && ` : ''
     const cmd = `export TELEGRAM_STATE_DIR="${tgStateDir}" && ${ollamaEnv}cd "${dir}" && ${CLAUDE} --dangerously-skip-permissions --model ${model} --channels plugin:telegram@claude-plugins-official`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
@@ -1771,7 +1772,7 @@ Rovid leiras: "${finalPrompt}"`
         // Try to find a suitable Ollama model for categorization
         let categorizeModel: string | null = null
         try {
-          const ollamaModels = await fetch('http://localhost:11434/api/tags', { signal: AbortSignal.timeout(3000) })
+          const ollamaModels = await fetch(`${OLLAMA_URL}/api/tags`, { signal: AbortSignal.timeout(3000) })
             .then(r => r.json())
             .then((d: any) => (d.models || []).filter((m: any) => !m.name.includes('embed')).map((m: any) => m.name))
             .catch(() => [] as string[])
@@ -1802,7 +1803,7 @@ Rovid leiras: "${finalPrompt}"`
             const controller = new AbortController()
             const timeout = setTimeout(() => controller.abort(), 90000)
 
-            const catResponse = await fetch('http://localhost:11434/api/generate', {
+            const catResponse = await fetch(`${OLLAMA_URL}/api/generate`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({
@@ -2135,7 +2136,7 @@ Respond ONLY with JSON, nothing else:
       // === Ollama API ===
       if (path === '/api/ollama/models' && method === 'GET') {
         try {
-          const resp = await fetch('http://localhost:11434/api/tags', { signal: AbortSignal.timeout(5000) })
+          const resp = await fetch(`${OLLAMA_URL}/api/tags`, { signal: AbortSignal.timeout(5000) })
           const data = await resp.json() as { models?: { name: string; size: number; details?: { parameter_size?: string } }[] }
           const models = (data.models || []).filter(m => !m.name.includes('embed')).map(m => ({
             name: m.name,
@@ -2319,7 +2320,7 @@ Respond ONLY with JSON, nothing else:
           // Determine Ollama model
           let categorizeModel: string | null = null
           try {
-            const modelsResp = await fetch('http://localhost:11434/api/tags', { signal: AbortSignal.timeout(3000) })
+            const modelsResp = await fetch(`${OLLAMA_URL}/api/tags`, { signal: AbortSignal.timeout(3000) })
             const modelsData = await modelsResp.json() as { models?: { name: string }[] }
             const available = (modelsData.models || []).filter(m => !m.name.includes('embed')).map(m => m.name)
             categorizeModel = available.find(m => m.includes('gemma4')) || available[0] || null
@@ -2331,7 +2332,7 @@ Respond ONLY with JSON, nothing else:
               let keywords = ''
 
               if (categorizeModel) {
-                const catResp = await fetch('http://localhost:11434/api/generate', {
+                const catResp = await fetch(`${OLLAMA_URL}/api/generate`, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify({
@@ -2441,7 +2442,7 @@ Respond ONLY with JSON, nothing else:
       logger.warn({ port }, 'Web port foglalt, probalok felszabaditani...')
       import('node:child_process').then(({ execSync }) => {
         try {
-          execSync(`lsof -ti :${port} | xargs kill -9`, { timeout: 5000 })
+          execSync(`lsof -ti :${port} 2>/dev/null | xargs kill -9 2>/dev/null || true`, { timeout: 5000 })
         } catch { /* ignored */ }
         setTimeout(() => server.listen(port), 1500)
       })
@@ -2450,7 +2451,7 @@ Respond ONLY with JSON, nothing else:
     }
   })
 
-  server.listen(port, '127.0.0.1', () => {
+  server.listen(port, WEB_HOST, () => {
     logger.info({ port }, `Web dashboard: http://localhost:${port}`)
     // Access URL embeds the token so the browser can bootstrap auth on first
     // visit. The client strips the token from the URL after storing it.

--- a/update.sh
+++ b/update.sh
@@ -40,10 +40,8 @@ npm run build --silent
 
 # Restart services
 echo -e "  Szolgaltatasok ujrainditasa..."
-launchctl unload "$HOME/Library/LaunchAgents/com.marveen.dashboard.plist" 2>/dev/null || true
-launchctl load "$HOME/Library/LaunchAgents/com.marveen.dashboard.plist" 2>/dev/null || true
-launchctl unload "$HOME/Library/LaunchAgents/com.marveen.channels.plist" 2>/dev/null || true
-launchctl load "$HOME/Library/LaunchAgents/com.marveen.channels.plist" 2>/dev/null || true
+"$INSTALL_DIR/scripts/stop.sh"
+"$INSTALL_DIR/scripts/start.sh"
 
 echo ""
 echo -e "${GREEN}✓ Frissitve: ${OLD_VERSION} -> ${NEW_VERSION}${NC}"


### PR DESCRIPTION
## Summary

- Add cross-platform support: macOS, Linux server (headless), Linux GUI
- Replace all hardcoded `/opt/homebrew/bin/` paths with dynamic `resolveFromPath()` using PATH lookup
- Add `src/platform.ts` with 3-way platform detection and `MARVEEN_ENV` override
- Export `WEB_HOST` and `OLLAMA_URL` from config (previously hardcoded in web.ts/db.ts)
- Make all shell scripts platform-aware: extended PATH, `command -v` binary guards, `launchctl`/`systemctl` branching
- Add `install-linux.sh`: Ubuntu/Debian installer with systemd user units (dashboard, channels, morning timer)
- Portable `xargs` (drop GNU-only `-r` flag)
- Security hardening: `resolveFromPath()` input validation, dynamic `allowedOrigins` for non-localhost `WEB_HOST`, `.env.example` warning for network-exposed setups

Based on patches by @gezabenko (issue #6), with manual conflict resolution against security PRs #1-#5 and additional hardening.

Closes #6

## Test plan

- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm run build` succeeds
- [x] `npm test` passes (41/41 tests green)
- [ ] Verify on macOS: `scripts/start.sh` uses launchctl
- [ ] Verify on Linux: `bash install-linux.sh` creates systemd units
- [ ] Verify `WEB_HOST=0.0.0.0` adds the host to allowedOrigins
- [ ] Verify `OLLAMA_URL` override propagates to all Ollama fetch calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)