### PR TITLE
Auto-sanitize connector names and surface the rewrite in the toast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ workspace/
 agents/
 reports/
 .claude/
+.config/
 
 # Database
 *.db

--- a/src/web.ts
+++ b/src/web.ts
@@ -3236,20 +3236,32 @@ Respond ONLY with JSON, nothing else:
 
         if (!data.name?.trim()) return json(res, { error: 'Name is required' }, 400)
 
+        // `claude mcp add` rejects any name with chars outside [A-Za-z0-9_-].
+        // Auto-sanitize so UI entries like "Google Drive" become "Google-Drive"
+        // instead of failing with a raw CLI error.
+        const rawName = data.name.trim()
+        const sanitizedName = rawName.replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '')
+        if (!sanitizedName) {
+          return json(res, { error: 'Name must contain at least one letter, number, hyphen, or underscore' }, 400)
+        }
+        const nameChanged = sanitizedName !== rawName
+
         try {
           const scopeFlag = data.scope === 'project' ? '-s project' : '-s user'
 
           if (data.type === 'remote' && data.url) {
-            execSync(`claude mcp add --transport http ${scopeFlag} ${shellEscape(data.name)} ${shellEscape(data.url)} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
+            execSync(`claude mcp add --transport http ${scopeFlag} ${shellEscape(sanitizedName)} ${shellEscape(data.url)} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
           } else if (data.type === 'local' && data.command) {
+            // `-e` flags MUST come AFTER the name — commander's variadic
+            // `<env...>` greedily consumes the name token if -e appears before it.
             const envFlags = data.env ? Object.entries(data.env).map(([k, v]) => `-e ${shellEscape(k)}=${shellEscape(v)}`).join(' ') : ''
             const argsStr = data.args ? shellEscape(data.args) : ''
-            execSync(`claude mcp add ${scopeFlag} ${envFlags} ${shellEscape(data.name)} -- ${shellEscape(data.command)} ${argsStr} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
+            execSync(`claude mcp add ${scopeFlag} ${shellEscape(sanitizedName)} ${envFlags} -- ${shellEscape(data.command)} ${argsStr} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
           } else {
             return json(res, { error: 'URL (remote) or command (local) required' }, 400)
           }
 
-          return json(res, { ok: true })
+          return json(res, { ok: true, name: sanitizedName, nameChanged })
         } catch (err: any) {
           return json(res, { error: err.message || 'Failed to add connector' }, 500)
         }
@@ -3359,8 +3371,14 @@ Respond ONLY with JSON, nothing else:
             if (parsed.env) envData = parsed.env
           } catch { /* no body or invalid json - that's ok */ }
 
+          // Use the catalog `id` (already slug-form) as the CLI name.
+          // `item.name` is the human display label and may contain spaces or
+          // dots that `claude mcp add` rejects.
+          const cliName = item.id
+
           if (item.type === 'local') {
-            // Build env flags
+            // Build env flags. `-e` MUST come AFTER the name — commander's
+            // variadic `<env...>` eats the name token otherwise.
             const allEnv = { ...item.env, ...envData }
             const envFlags = Object.entries(allEnv)
               .filter(([, v]) => v !== '')
@@ -3368,12 +3386,12 @@ Respond ONLY with JSON, nothing else:
               .join(' ')
 
             const argsStr = (item.args || []).map((a: string) => shellEscape(a)).join(' ')
-            const cmd = `claude mcp add --scope user ${envFlags} ${shellEscape(item.name)} -- ${shellEscape(item.command)} ${argsStr} 2>&1`
+            const cmd = `claude mcp add --scope user ${shellEscape(cliName)} ${envFlags} -- ${shellEscape(item.command)} ${argsStr} 2>&1`
             execSync(cmd, { timeout: 30000, encoding: 'utf-8' })
           } else if (item.type === 'remote') {
             const url = item.url
             if (!url) return json(res, { error: 'Remote item has no URL' }, 400)
-            execSync(`claude mcp add --transport sse --scope user ${shellEscape(item.name)} ${shellEscape(url)} 2>&1`, { timeout: 30000, encoding: 'utf-8' })
+            execSync(`claude mcp add --transport sse --scope user ${shellEscape(cliName)} ${shellEscape(url)} 2>&1`, { timeout: 30000, encoding: 'utf-8' })
           }
 
           let message = 'Telepítve'
@@ -3398,11 +3416,13 @@ Respond ONLY with JSON, nothing else:
           const item = catalog.find(c => c.id === id)
           if (!item) return json(res, { error: 'Item not found in catalog' }, 404)
 
+          // Match the install path: the CLI entry is registered under `item.id`.
+          const cliName = item.id
           try {
-            execSync(`claude mcp remove ${shellEscape(item.name)} -s user 2>&1`, { timeout: 15000 })
+            execSync(`claude mcp remove ${shellEscape(cliName)} -s user 2>&1`, { timeout: 15000 })
           } catch {
             try {
-              execSync(`claude mcp remove ${shellEscape(item.name)} -s project 2>&1`, { timeout: 15000 })
+              execSync(`claude mcp remove ${shellEscape(cliName)} -s project 2>&1`, { timeout: 15000 })
             } catch { /* ignore if not found anywhere */ }
           }
 

--- a/web/app.js
+++ b/web/app.js
@@ -3749,8 +3749,13 @@ document.getElementById('saveConnectorBtn').addEventListener('click', async () =
       const err = await res.json()
       throw new Error(err.error || 'Hiba')
     }
+    const result = await res.json()
     closeModal(connectorModalOverlay)
-    showToast('Connector hozzáadva!')
+    if (result.nameChanged) {
+      showToast(`Connector hozzáadva "${result.name}" néven (szóköz/speciális karakter nem engedélyezett)`)
+    } else {
+      showToast('Connector hozzáadva!')
+    }
     loadConnectors()
   } catch (err) {
     showToast(`Hiba: ${err.message}`)

--- a/web/index.html
+++ b/web/index.html
@@ -1145,8 +1145,8 @@
       </div>
       <div class="modal-body">
         <div class="form-group">
-          <label for="connectorName">Név</label>
-          <input type="text" id="connectorName" placeholder="pl. my-api-server">
+          <label for="connectorName">Név <span style="font-weight:400;color:var(--text-muted);font-size:12px">(betűk, számok, kötőjel, aláhúzás — szóköz nem!)</span></label>
+          <input type="text" id="connectorName" placeholder="pl. google-drive">
         </div>
         <div class="form-row">
           <div class="form-group form-half">


### PR DESCRIPTION
## Summary
- POST /api/connectors auto-sanitizes the submitted name (replaces any char outside [A-Za-z0-9_-] with a hyphen) so UI entries like "Google Drive" land as "Google-Drive" instead of surfacing the raw `claude mcp add` CLI error. Response now returns `{ok, name, nameChanged}` so the UI can tell the user what name was actually used.
- POST /api/mcp-catalog/:id/install uses `item.id` (already slug-form) as the CLI name instead of `item.name` (display label, may have spaces or dots). Uninstall path matched to stay symmetric.
- Both endpoints move `-e` env flags to **after** the server name. Commander's variadic `<env...>` greedily consumes the name token if `-e` appears before it, producing an opaque "Invalid environment variable format: <name>" error.
- `.gitignore`: add `.config/` so project-local OAuth credential dirs (google-drive-mcp, gmail-mcp, …) never reach upstream.
- Companion UI: web/app.js shows a toast with the final name when `nameChanged` is true; web/index.html gets a hint next to the Név label and a more accurate placeholder (`google-drive`).

## Test plan
- [ ] Add a connector named "Google Drive" via the UI — toast should say the name was normalized to `Google-Drive`.
- [ ] Install any catalog entry that has spaces/dots in its display label — connector should land under the slug `id`.
- [ ] Install a connector with env vars — no "Invalid environment variable format" regression.
- [ ] Confirm `.config/` is still ignored after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)