### PR TITLE
Route agent messages to the main agent via MAIN_CHANNELS_SESSION

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -1078,9 +1078,20 @@ function startMessageRouter(): NodeJS.Timeout {
   return setInterval(() => {
     const pending = getPendingMessages()
     for (const msg of pending) {
-      const session = agentSessionName(msg.to_agent)
-      if (!isAgentRunning(msg.to_agent)) {
-        // Agent not running, skip for now (will retry next cycle)
+      // The main agent runs in `${MAIN_AGENT_ID}-channels`, not `agent-${name}`,
+      // so agentSessionName() would miss it and strand every sub-agent → main
+      // message as pending forever. Mirror the scheduler's session resolution.
+      const isMainAgent = msg.to_agent === MAIN_AGENT_ID
+      const session = isMainAgent ? MAIN_CHANNELS_SESSION : agentSessionName(msg.to_agent)
+
+      let sessionExists = false
+      try {
+        const sessions = execSync(`${TMUX} list-sessions -F "#{session_name}"`, { timeout: 3000, encoding: 'utf-8' })
+        sessionExists = sessions.split('\n').some(s => s.trim() === session)
+      } catch { /* no tmux */ }
+
+      if (!sessionExists) {
+        // Target session not running, skip for now (will retry next cycle).
         continue
       }
 


### PR DESCRIPTION
## Summary
`startMessageRouter()` resolved the target session with `agentSessionName(msg.to_agent)`, which prepends `"agent-"`. That's right for sub-agents, but the main agent runs in `${MAIN_AGENT_ID}-channels` (e.g. `marveen-channels`), so every sub-agent → main-agent message pointed at a nonexistent `agent-${MAIN_AGENT_ID}` session. `isAgentRunning()` then returned false on the same mismatched name, so the message sat in the queue as `pending` forever.

This PR mirrors the scheduler's session-resolution logic (the `isMainAgent ? MAIN_CHANNELS_SESSION : agentSessionName(agentName)` branch in the schedule runner): route main-agent targets to `MAIN_CHANNELS_SESSION`, and replace the `isAgentRunning()` check with the same inline `tmux list-sessions` test the scheduler already uses. That way sub-agent → main-agent messages actually reach the main session, and the router stays consistent with the scheduler.

## Observed
On an install with four sub-agents actively messaging the main agent, five queue rows sat in `pending` across multiple `from_agent`s, all with `to_agent = MAIN_AGENT_ID`. No new stuck rows appear after this fix.

## Test plan
- [ ] Send an inter-agent message from any sub-agent to `MAIN_AGENT_ID` (e.g. `POST /api/messages {from: "albi", to: "marveen", content: "ping"}`).
- [ ] Within one router tick (≤5s) the message should be delivered, not stuck in `pending`.
- [ ] Sub-agent → sub-agent messaging still works as before.
- [ ] Main-agent → sub-agent messaging still works as before (this path was already correct, just sanity-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)