### PR TITLE
backup.sh: warn that archives contain sensitive tokens

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -64,6 +64,12 @@ fi
 tar -czf "${ARCHIVE}" -T "${TMPLIST}"
 echo "backup: wrote ${ARCHIVE} ($(wc -c < "${ARCHIVE}" | awk '{print $1}') bytes)"
 
+# The archive contains sensitive tokens (dashboard bearer, Telegram bot
+# tokens, project .env secrets). Do not auto-sync ${BACKUP_DIR} to iCloud,
+# Dropbox, Google Drive, or any other cloud-backup folder. Keep it local
+# (Time Machine is fine because it stays on your encrypted-volume backup).
+echo "backup: WARNING -- archive contains sensitive tokens; keep ${BACKUP_DIR} out of cloud-sync folders (iCloud / Dropbox / Google Drive)." >&2
+
 # Keep the newest ${KEEP} archives, drop the rest.
 # Use a while-read loop instead of mapfile so this works on macOS's default
 # bash 3.2 (mapfile is a bash-4 builtin).


### PR DESCRIPTION
## Summary

`scripts/backup.sh` tars up the dashboard bearer, every agent's Telegram `.env`, and the project `.env` alongside the DB. Without an explicit warning a user may drop the `backups/` folder into iCloud / Dropbox / Google Drive and the tokens leave the machine.

## Change

Added a stderr warning after each successful archive, plus an inline comment explaining the risk. No behavior change to what gets archived; purely additive output.

## Test plan

- [x] Ran `scripts/backup.sh` locally; warning appears on stderr after the `backup: wrote ...` line.
- [x] Archive contents unchanged vs. main.

## Context

Part of a broader audit pass on `8163b9b`. Findings collected in a private report; this one ranks as low-severity, but a three-line addition closes the cloud-sync leak class cleanly.