### PR TITLE
agentDir: route through safeJoin for defense-in-depth

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -157,7 +157,12 @@ function shellEscape(s: string): string {
 }
 
 function agentDir(name: string): string {
-  return join(AGENTS_BASE_DIR, name)
+  // safeJoin rejects path-traversal components. The first line of defense is
+  // still sanitizeAgentName() at the create-endpoint, but going through
+  // safeJoin turns every non-whitelisted `name` (e.g. a buggy internal caller
+  // that forgot to sanitize) into an explicit throw instead of silently
+  // writing outside AGENTS_BASE_DIR.
+  return safeJoin(AGENTS_BASE_DIR, name)
 }
 
 function readFileOr(path: string, fallback: string): string {


### PR DESCRIPTION
## Summary

`safeJoin()` is defined in `src/web.ts:146` (rejects path-traversal components), but nothing calls it. The only actual traversal defense today is `sanitizeAgentName()` at the create endpoint, plus implicit 404 shielding via `listAgentNames()` filters on most read paths.

## Change

One-line swap: `agentDir(name)` now goes through `safeJoin(AGENTS_BASE_DIR, name)`. For valid (sanitized) names the resolved path stays inside `AGENTS_BASE_DIR`, so behavior is identical. For a future internal caller that forgets to sanitize, `safeJoin` throws explicitly instead of silently writing outside the base.

## Test plan

- [x] `npm run typecheck` clean.
- [x] All `/api/agents/:name` routes (get/put/start/stop/telegram) work for valid names.
- [x] `..%2F..%2Fetc%2Fpasswd` still returns "Agent not found" via the existing listAgentNames filter.

## Severity

Low — current behavior is safe because the sanitizer covers all entry points. This is defense-in-depth, not a fix for an open vulnerability.