### PR TITLE
db: debug-log embedding generation failures

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3'
 import { join } from 'node:path'
 import { existsSync, mkdirSync, readFileSync, renameSync } from 'node:fs'
 import { STORE_DIR, ALLOWED_CHAT_ID, OLLAMA_URL } from './config.js'
+import { logger } from './logger.js'
 
 let db: Database.Database
 
@@ -803,7 +804,11 @@ export async function generateEmbedding(text: string): Promise<number[] | null> 
     })
     const data = await resp.json() as { embedding?: number[] }
     return data.embedding || null
-  } catch {
+  } catch (err) {
+    // Debug-level so it doesn't spam default INFO logs when Ollama isn't
+    // running (the common case on most user machines). Enables "why does
+    // hybrid search only return FTS results?" diagnostics without noise.
+    logger.debug({ err, ollamaUrl: OLLAMA_URL }, 'Embedding generation failed (Ollama not running?)')
     return null
   }
 }


### PR DESCRIPTION
## Summary

`generateEmbedding()` silently returned `null` on any error. A developer debugging *"why is hybrid search only using FTS?"* had no way to tell whether Ollama is down, misconfigured, or returning malformed responses.

## Change

Add a `logger.debug()` in the catch. DEBUG level keeps INFO logs quiet in the common case (Ollama not running on most user machines) while enabling on-demand diagnostics via `LOG_LEVEL=debug`.

Also adds the `logger` import to `src/db.ts`, which was missing.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `LOG_LEVEL=debug` locally; triggering a memory save with Ollama off emits the DEBUG line.

## Severity

Low — silent-catch hygiene; no user-visible bug, but saves future debugging time.