### PR TITLE
writeScheduledTask: atomic writes for SKILL.md and task-config.json

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -1044,7 +1044,7 @@ function writeScheduledTask(
   const desc = data.description ?? existing?.description ?? ''
   const prompt = data.prompt ?? existing?.prompt ?? ''
   const skillContent = `---\nname: ${taskName}\ndescription: ${desc}\n---\n\n${prompt}\n`
-  writeFileSync(skillPath, skillContent)
+  atomicWriteFileSync(skillPath, skillContent)
 
   // Write/update config
   let config: Record<string, unknown> = {}
@@ -1054,7 +1054,7 @@ function writeScheduledTask(
   if (data.enabled !== undefined) config.enabled = data.enabled
   if (data.type !== undefined) config.type = data.type
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
-  writeFileSync(configPath, JSON.stringify(config, null, 2))
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
 // --- HTTP szerver ---


### PR DESCRIPTION
## Summary

`writeScheduledTask()` writes `SKILL.md` and `task-config.json` with two plain `writeFileSync()` calls. A crash between them leaves the task split-brained: new prompt + old config (or vice versa). The scheduler still runs the task with the surviving half.

## Change

Both calls now use `atomicWriteFileSync()`. Not a true two-phase commit across the pair, but each file individually can no longer be half-written.

## Test plan

- [x] `npm run typecheck` clean.
- [x] Manual smoke: edited a scheduled task via `/api/schedules/:name` PUT; both files end up with matching content.

## Severity

Medium — low-probability, low-damage (a failed edit, the task still runs), but the fix is a two-line drop-in on top of the existing `atomicWriteFileSync` helper.