### PR TITLE
handleMarveenDown: honour a real 60s memory-save window before hard restart

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -1255,7 +1255,12 @@ interface MarveenDownState {
   stage: MarveenRecoveryStage
   lastAlertAt: number
   softAttempts: number
+  // When we last transitioned to the current stage. Used by 'save' to
+  // honour the announced ~60s memory-save grace before jumping to 'hard'.
+  stageStartedAt?: number
 }
+
+const SAVE_WINDOW_MS = 60_000
 let marveenDownState: MarveenDownState | null = null
 
 async function sendMarveenAlert(text: string): Promise<void> {
@@ -1363,6 +1368,7 @@ function handleMarveenDown(): void {
     }
     // Soft didn't help; ask Marveen to persist memory before we pull the plug.
     marveenDownState.stage = 'save'
+    marveenDownState.stageStartedAt = now
     marveenDownState.lastAlertAt = now
     logger.warn('Marveen Telegram plugin still down -- stage 2 (memory save)')
     sendMarveenAlert('⚠️ /mcp nem segített. Szólok Marveennek hogy mentsen memóriát hard restart előtt (~60s türelmi idő).').catch(() => {})
@@ -1370,8 +1376,14 @@ function handleMarveenDown(): void {
     return
   }
   if (marveenDownState.stage === 'save') {
-    // Save window elapsed; hard restart now.
+    // Give the memory-save prompt a real ~60s window to land a turn before
+    // we hard-restart. Without this check, the next monitor tick (also 60s
+    // cadence, so effectively immediate) jumps straight to 'hard' and the
+    // save prompt either hasn't started or is mid-turn when we pull the plug.
+    const saveStartedAt = marveenDownState.stageStartedAt ?? marveenDownState.downSince
+    if (now - saveStartedAt < SAVE_WINDOW_MS) return
     marveenDownState.stage = 'hard'
+    marveenDownState.stageStartedAt = now
     marveenDownState.lastAlertAt = now
     logger.warn('Marveen Telegram plugin still down -- stage 3 (hard restart)')
     sendMarveenAlert(`⚠️ Memória mentés türelmi idő lejárt. Hard restart most a ${MAIN_CHANNELS_SESSION} session-ön (új session a SQLite memóriával indul).`).catch(() => {})


### PR DESCRIPTION
## Summary

The plugin-monitor runs on a 60s cadence. The existing `handleMarveenDown` state machine transitions `soft → save → hard` by "the next tick elapsed" — which means `save → hard` fires on the tick *immediately* after entering `save`. The announced "~60s grace" was just the tick gap; the memory-save prompt typically hasn't even finished landing.

## Change

Track `stageStartedAt` on `MarveenDownState` and gate the `save → hard` transition on a real `now - stageStartedAt >= SAVE_WINDOW_MS` (60s):

1. **Interface:** `MarveenDownState` gets an optional `stageStartedAt`.
2. **`soft → save`:** sets `stageStartedAt = now` when entering `save`.
3. **`save → hard`:** early-returns if the window hasn't elapsed.

Falls back to `downSince` if `stageStartedAt` somehow is absent — otherwise an outage lingering in `soft` for >60s would immediately jump the save stage because `now - downSince` already exceeds the window.

## Test plan

- [x] `npm run typecheck` clean.
- [x] Code review: the three edits compose; `stageStartedAt` is set at every transition that matters.

## Severity

Medium — the memory-save prompt is the last chance to persist context before the hard restart wipes the session. Skipping its window defeats the whole stage.