### PR TITLE
extend atomicWriteFileSync coverage to remaining state files

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -212,7 +212,7 @@ function writeAgentModel(name: string, model: string): void {
   let config: Record<string, unknown> = {}
   try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
   config.model = model
-  writeFileSync(configPath, JSON.stringify(config, null, 2))
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
 function readAgentDisplayName(name: string): string {
@@ -231,7 +231,7 @@ function writeAgentDisplayName(name: string, displayName: string): void {
   let config: Record<string, unknown> = {}
   try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
   config.displayName = displayName
-  writeFileSync(configPath, JSON.stringify(config, null, 2))
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
 // --- Security profiles ---
@@ -298,7 +298,7 @@ function writeAgentSecurityProfile(name: string, profileId: string): void {
   let config: Record<string, unknown> = {}
   try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
   config.securityProfile = profileId
-  writeFileSync(configPath, JSON.stringify(config, null, 2))
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
 function resolveProfilePlaceholders(value: string, ctx: { HOME: string; AGENT_DIR: string }): string {
@@ -350,7 +350,7 @@ function writeAgentTeam(name: string, team: TeamConfig): void {
   let config: Record<string, unknown> = {}
   try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
   config.team = team
-  writeFileSync(configPath, JSON.stringify(config, null, 2))
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
 // Removing an agent leaves dangling references in other agents' team configs.
@@ -397,7 +397,7 @@ function ensureAgentHooks(name: string): boolean {
   if (existing.hooks) return false  // user already has hooks, leave alone
   existing.hooks = tpl.hooks
   mkdirSync(join(agentDir(name), '.claude'), { recursive: true })
-  writeFileSync(settingsPath, JSON.stringify(existing, null, 2))
+  atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
   return true
 }
 
@@ -415,7 +415,7 @@ function writeAgentSettingsFromProfile(name: string, profile: ProfileTemplate): 
     allow: profile.filesystem.allow.map(p => resolveProfilePlaceholders(p, ctx)),
     deny: profile.filesystem.deny.map(p => resolveProfilePlaceholders(p, ctx)),
   }
-  writeFileSync(settingsPath, JSON.stringify(existing, null, 2))
+  atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
 }
 
 function readAgentTelegramConfig(name: string): { hasTelegram: boolean; botUsername?: string } {
@@ -656,7 +656,7 @@ function scaffoldAgentDir(name: string) {
       copyFileSync(sharedMcp, mcpJson)
     } else {
       // Valid empty shape -- `claude /doctor` rejects plain "{}"
-      writeFileSync(mcpJson, JSON.stringify({ mcpServers: {} }, null, 2))
+      atomicWriteFileSync(mcpJson, JSON.stringify({ mcpServers: {} }, null, 2))
     }
   }
   // Seed settings.json from template so the agent gets the PreCompact
@@ -2585,7 +2585,7 @@ export function startWebServer(port = 3420): http.Server {
 
         try {
           const skillMd = await generateSkillMd(skillName, description)
-          writeFileSync(join(skillDir, 'SKILL.md'), skillMd)
+          atomicWriteFileSync(join(skillDir, 'SKILL.md'), skillMd)
         } catch (err) {
           rmSync(skillDir, { recursive: true, force: true })
           return json(res, { error: 'Failed to generate skill' }, 500)
@@ -2769,7 +2769,7 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
         try { config = JSON.parse(readFileOr(configPath, '{}')) } catch { /* use empty */ }
         const newEnabled = !(config.enabled !== false)
         config.enabled = newEnabled
-        writeFileSync(configPath, JSON.stringify(config, null, 2))
+        atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
         logger.info({ name, enabled: newEnabled }, 'Scheduled task toggled')
         return json(res, { ok: true, enabled: newEnabled })
       }
@@ -3478,7 +3478,7 @@ Respond ONLY with JSON, nothing else:
           try { mcpConfig = JSON.parse(readFileSync(mcpPath, 'utf-8')) } catch {}
           if (!mcpConfig.mcpServers) mcpConfig.mcpServers = {}
           mcpConfig.mcpServers[connectorName] = connectorConfig
-          writeFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2))
+          atomicWriteFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2))
         }
         return json(res, { ok: true })
       }


### PR DESCRIPTION
## Summary

`57bd7d2` introduced `atomicWriteFileSync()` and routed 7 call sites through it. 10 more state-file writes still used plain `writeFileSync`, so a crash or SIGKILL mid-write could zero-byte them.

## Callsites routed through `atomicWriteFileSync`

- `agent-config.json` — 4 writers: \`writeAgentModel\`, \`writeAgentDisplayName\`, \`writeAgentSecurityProfile\`, \`writeAgentTeam\`
- `settings.json` — 2 writers: hooks seeding, profile allow/deny rewrite
- `.mcp.json` — initial empty-shape create for new agents
- `SKILL.md` — `generateSkillMd` save path
- `task-config.json` — scheduled-task enable/disable toggle
- `.mcp.json` — bulk connector update (runs across every sub-agent)

**The one worth extra eyes:** `writeAgentSecurityProfile`. A 0-byte truncation there means `securityProfile` reads as empty on next boot, which falls back to the `default` permissive profile. A strict sub-agent would silently lose its sandbox.

## What I skipped

- `atomicWriteFileSync` itself (writes the tmp file -- inside the helper)
- Skill-install zip temp files (sandbox-temp, not state)
- 0-byte `approved/<senderId>` sentinel (no payload to corrupt)
- `writeScheduledTask`'s pair -- covered in a separate PR

## Test plan

- [x] `npm run typecheck` clean.
- [x] Manual smoke: created an agent, renamed it, switched its security profile, toggled a scheduled task, ran the MCP bulk update. All writes visible as expected (rename(2) atomicity means no change to the happy path).

## Severity

Critical — the `securityProfile` truncation is the specific regression risk that warrants this as the first follow-up to 57bd7d2. Everything else is the same class of partial-write risk the original commit addressed for a subset of files.