### PR TITLE
developer-junior: allow curl so inter-agent replies don't deadlock

### DIFF
--- a/templates/profiles/developer-junior.json
+++ b/templates/profiles/developer-junior.json
@@ -17,6 +17,7 @@
       "Bash(ls:*)",
       "Bash(cat:*)",
       "Bash(pwd:*)",
+      "Bash(curl:*)",
       "WebFetch(*)",
       "WebSearch(*)"
     ],


### PR DESCRIPTION
## Summary

A strict-profile sub-agent (e.g. `developer-junior`) that tries to reply to an inter-agent message needs to POST back to `/api/messages` via curl. The `developer-junior.json` allow list didn't include `Bash(curl:*)`, so Claude Code raises a per-call permission prompt. If the user isn't watching Telegram when it fires (or the plugin is disconnected), the prompt is never answered, the agent sits mid-turn, and the 60-min `e2d7e01` abandon window eventually marks the inter-agent message failed. The sender never gets a reply.

Live-reproduced during an audit pass: sent a routing test to a junior-profile agent, watched its pane sit on `Do you want to proceed? 1. Yes / 2. Yes, and allow... / 3. No` for the full test window.

## Change

Add `"Bash(curl:*)"` to the `developer-junior` `allow` list. Everything else in the sandbox (SSH/AWS/.gnupg denies, no sudo, no force-push, AGENT_DIR-only writes, etc.) is unchanged.

## Why not a tighter pattern?

A narrower allow like `Bash(curl -s -X POST http://localhost:3420/api/messages:*)` would be preferable, but Claude Code's permission matcher keys on the leading command + prefix glob, not the full argument string — a hyper-specific pattern like that wouldn't match the actual call.

## What about marketer / researcher?

Same scenario applies to them, but their ideal reply path isn't Bash at all (they read web content; adding curl widens the prompt-injection surface unnecessarily). The real fix there is a dedicated reply mechanism — an MCP tool or a file-drop the router consumes — which is a bigger change. Tracking separately.

## Test plan

- [x] Re-ran the routing test: junior-profile agent receives message, executes the curl reply without a permission prompt, sender gets the reply as expected.
- [x] No other permission prompts regressed (WebFetch / WebSearch / git / npm / node paths still work and still prompt on non-allowed tools).

## Severity

Critical — without it, strict-profile sub-agents are effectively unreachable via inter-agent messaging in any setup where the operator can't answer permission prompts in real time.