### PR TITLE
TeamConfig: add optional trustFrom + sanitize self/unknown with warnings

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -345,6 +345,11 @@ interface TeamConfig {
   reportsTo: string | null
   delegatesTo: string[]
   autoDelegation: boolean
+  // Optional override so an operator can grant "trusted peer" status to an
+  // agent outside the usual reportsTo / delegatesTo derivation -- e.g. a
+  // cross-team collaborator. Unknown names and self-references are stripped
+  // at write time (see writeAgentTeam + sanitizeTeamConfig).
+  trustFrom?: string[]
 }
 
 const DEFAULT_TEAM: TeamConfig = {
@@ -352,6 +357,7 @@ const DEFAULT_TEAM: TeamConfig = {
   reportsTo: null,
   delegatesTo: [],
   autoDelegation: false,
+  trustFrom: [],
 }
 
 function readAgentTeam(name: string): TeamConfig {
@@ -364,10 +370,11 @@ function readAgentTeam(name: string): TeamConfig {
       const reportsTo = typeof raw.reportsTo === 'string' && raw.reportsTo.trim() ? raw.reportsTo.trim() : null
       const delegatesTo = Array.isArray(raw.delegatesTo) ? raw.delegatesTo.filter((x: unknown) => typeof x === 'string') : []
       const autoDelegation = !!raw.autoDelegation
-      return { role, reportsTo, delegatesTo, autoDelegation }
+      const trustFrom = Array.isArray(raw.trustFrom) ? raw.trustFrom.filter((x: unknown) => typeof x === 'string') : []
+      return { role, reportsTo, delegatesTo, autoDelegation, trustFrom }
     }
   } catch { /* fall through */ }
-  return { ...DEFAULT_TEAM }
+  return { ...DEFAULT_TEAM, trustFrom: [] }
 }
 
 function writeAgentTeam(name: string, team: TeamConfig): void {
@@ -376,6 +383,60 @@ function writeAgentTeam(name: string, team: TeamConfig): void {
   try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
   config.team = team
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
+// Scrub self-references and unknown agent names from a TeamConfig's name
+// fields. Returns the cleaned config plus a warnings object the caller
+// (the PUT handler) can surface to the UI so an operator isn't silently
+// missing the name they just typed.
+interface TeamSanitizeWarnings {
+  droppedSelf: string[]   // field names that referenced the agent itself
+  droppedUnknown: string[]  // agent ids not present on disk + not MAIN
+}
+
+function sanitizeTeamConfig(
+  agentName: string,
+  team: TeamConfig,
+): { team: TeamConfig; warnings: TeamSanitizeWarnings } {
+  const known = new Set<string>(listAgentNames())
+  known.add(MAIN_AGENT_ID)
+  const warnings: TeamSanitizeWarnings = { droppedSelf: [], droppedUnknown: [] }
+
+  const cleanList = (ids: string[], fieldName: string): string[] => {
+    const out: string[] = []
+    for (const id of ids) {
+      if (id === agentName) {
+        if (!warnings.droppedSelf.includes(fieldName)) warnings.droppedSelf.push(fieldName)
+        continue
+      }
+      if (!known.has(id)) {
+        warnings.droppedUnknown.push(id)
+        continue
+      }
+      if (!out.includes(id)) out.push(id)  // de-dupe too
+    }
+    return out
+  }
+
+  let reportsTo = team.reportsTo
+  if (reportsTo === agentName) {
+    warnings.droppedSelf.push('reportsTo')
+    reportsTo = null
+  } else if (reportsTo && !known.has(reportsTo)) {
+    warnings.droppedUnknown.push(reportsTo)
+    reportsTo = null
+  }
+
+  return {
+    team: {
+      role: team.role,
+      reportsTo,
+      delegatesTo: cleanList(team.delegatesTo, 'delegatesTo'),
+      autoDelegation: team.autoDelegation,
+      trustFrom: cleanList(team.trustFrom ?? [], 'trustFrom'),
+    },
+    warnings,
+  }
 }
 
 // Removing an agent leaves dangling references in other agents' team configs.
@@ -389,9 +450,14 @@ function cleanupTeamReferences(removedName: string): void {
       team.reportsTo = removedName === MAIN_AGENT_ID ? null : MAIN_AGENT_ID
       dirty = true
     }
-    const filtered = team.delegatesTo.filter(n => n !== removedName)
-    if (filtered.length !== team.delegatesTo.length) {
-      team.delegatesTo = filtered
+    const filteredDelegates = team.delegatesTo.filter(n => n !== removedName)
+    if (filteredDelegates.length !== team.delegatesTo.length) {
+      team.delegatesTo = filteredDelegates
+      dirty = true
+    }
+    const filteredTrust = (team.trustFrom ?? []).filter(n => n !== removedName)
+    if (filteredTrust.length !== (team.trustFrom ?? []).length) {
+      team.trustFrom = filteredTrust
       dirty = true
     }
     if (dirty) writeAgentTeam(other, team)
@@ -2399,7 +2465,7 @@ export function startWebServer(port = 3420): http.Server {
         const body = await readBody(req)
         const data = JSON.parse(body.toString())
         const current = readAgentTeam(name)
-        const next: TeamConfig = {
+        const proposed: TeamConfig = {
           role: data.role === 'leader' ? 'leader' : (data.role === 'member' ? 'member' : current.role),
           reportsTo: typeof data.reportsTo === 'string'
             ? (data.reportsTo.trim() || null)
@@ -2408,9 +2474,15 @@ export function startWebServer(port = 3420): http.Server {
             ? data.delegatesTo.filter((x: unknown) => typeof x === 'string')
             : current.delegatesTo,
           autoDelegation: typeof data.autoDelegation === 'boolean' ? data.autoDelegation : current.autoDelegation,
+          trustFrom: Array.isArray(data.trustFrom)
+            ? data.trustFrom.filter((x: unknown) => typeof x === 'string')
+            : (current.trustFrom ?? []),
         }
+        // Silently-dropped names would confuse an operator who just typed
+        // them; include them in the response so the UI can toast.
+        const { team: next, warnings } = sanitizeTeamConfig(name, proposed)
         writeAgentTeam(name, next)
-        return json(res, { ok: true, team: next })
+        return json(res, { ok: true, team: next, warnings })
       }
 
       // GET /api/agents/:name/telegram/pending - List pending pairing codes.


### PR DESCRIPTION
## Why this matters

Today the team config mesh (`reportsTo`, `delegatesTo`, `autoDelegation`) is metadata: the dashboard renders a nice graph from it, but nothing in the runtime actually uses those edges. V3-4 will change that -- the inter-agent router will consult the graph to decide between `<trusted-peer>` and `<untrusted>` wrapping. Before that wiring can land, the config model needs two small upgrades:

1. An **optional `trustFrom` field** so operators who don't fit the strict reportsTo/delegatesTo hierarchy (cross-team collaborators, custom topologies) can still grant trusted-peer status case-by-case.
2. **Server-side sanitisation with operator feedback.** Right now the PUT handler writes whatever the caller sent -- a self-reference (reportsTo equal to the agent's own name) or an unknown agent id passes through to disk and silently poisons the graph. The operator sees "saved" but the data is wrong.

## Change

**Interface:**
```ts
interface TeamConfig {
  role: 'leader' | 'member'
  reportsTo: string | null
  delegatesTo: string[]
  autoDelegation: boolean
  trustFrom?: string[]   // NEW
}
```

`readAgentTeam` gracefully handles the field's absence (old configs read as `trustFrom: []`); `DEFAULT_TEAM` ships an empty list.

**New helper: `sanitizeTeamConfig(agentName, team)`**

Walks the name fields against `listAgentNames() ∪ {MAIN_AGENT_ID}`, returns a cleaned `TeamConfig` plus a `warnings: { droppedSelf[], droppedUnknown[] }` object. Called by the PUT handler, which now includes `warnings` in its response:

```json
{
  "ok": true,
  "team": { ... },
  "warnings": {
    "droppedSelf": ["delegatesTo"],
    "droppedUnknown": ["ghost-agent"]
  }
}
```

The dashboard UI (V3-5) will toast on non-empty warnings.

**`cleanupTeamReferences` (agent deletion path)** also scrubs the deleted name from any other agent's `trustFrom`, same way it already scrubs `reportsTo` and `delegatesTo`. Prevents stale-trust entries after a delete.

## Scope / compatibility

- Field is optional; agents without a `team.trustFrom` in their config keep behaving exactly as before.
- No behaviour change yet in the router, heartbeat, scheduler, or UI -- those wire up in V3-3 / V3-4 / V3-5.
- Existing callers of `PUT /api/agents/:name/team` that don't know about `warnings` just ignore the extra response field; `ok` + `team` stay the same shape.

## Test plan

- [x] `npm run typecheck` clean
- [x] Manual smoke via curl:
  - PUT with a valid `trustFrom` list → team saved, `warnings.droppedSelf/droppedUnknown` empty
  - PUT with `reportsTo` set to the agent's own name → saved as `null`, `warnings.droppedSelf: ["reportsTo"]`
  - PUT with `trustFrom: ["ghost-agent"]` → saved as `[]`, `warnings.droppedUnknown: ["ghost-agent"]`
  - GET after each PUT returns the cleaned config
- [x] Agent deletion flow still works; verified `trustFrom` references to the deleted agent vanish from other agents' configs.

## Part of the V3 series

| PR | What it does | Depends on |
|----|--------------|-----------|
| V3-1 (#24) | `wrapTrustedPeer` + cross-tag scrubbing in prompt-safety | -- |
| **V3-2 (this)** | `TeamConfig.trustFrom` + sanitize + warnings | -- |
| V3-3 | `isKnownAgent` / `isTrustedPeer` helpers | V3-2 |
| V3-4 | Router switches to trust-aware wrapping | V3-1 + V3-3 |
| V3-5 | Dashboard UI: trustFrom picker + warnings toast | V3-2 |

V3-1 and this PR are independent; V3-3 / V3-5 wait on this one.