### PR TITLE
team-trust: add isTrustedPeer pure-logic helper with DI

### DIFF
--- a/src/__tests__/team-trust.test.ts
+++ b/src/__tests__/team-trust.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest'
+import { isTrustedPeer, type TrustContext, type TeamConfigForTrust } from '../team-trust.js'
+
+// Helper: build a TrustContext backed by a Map so tests can declare the
+// team graph as data. MAIN is always a known agent; any agent whose id
+// appears as a key in `teams` is also known; everything else is unknown.
+function makeCtx(
+  teams: Record<string, TeamConfigForTrust>,
+  mainAgentId = 'main',
+): TrustContext {
+  const known = new Set<string>([mainAgentId, ...Object.keys(teams)])
+  return {
+    mainAgentId,
+    isKnownAgent: (name: string) => !!name && known.has(name),
+    readAgentTeam: (name: string) =>
+      teams[name] ?? { reportsTo: null, delegatesTo: [], trustFrom: [] },
+  }
+}
+
+describe('isTrustedPeer — guard rails', () => {
+  const ctx = makeCtx({
+    alice: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+  })
+
+  it('returns false for an empty from', () => {
+    expect(isTrustedPeer('', 'alice', ctx)).toBe(false)
+  })
+
+  it('returns false for an empty to', () => {
+    expect(isTrustedPeer('alice', '', ctx)).toBe(false)
+  })
+
+  it('returns false for a self-loop', () => {
+    expect(isTrustedPeer('alice', 'alice', ctx)).toBe(false)
+  })
+
+  it('returns false when from is unknown', () => {
+    expect(isTrustedPeer('ghost', 'alice', ctx)).toBe(false)
+  })
+
+  it('returns false when to is unknown', () => {
+    expect(isTrustedPeer('alice', 'ghost', ctx)).toBe(false)
+  })
+
+  it('returns false for a spoofed unknown targeting MAIN (sorrend-guard)', () => {
+    // This is the key anti-spoof case: the MAIN shortcut must not fire
+    // before the known-agent check, otherwise any unknown sender aimed
+    // at MAIN would be treated as a trusted peer.
+    expect(isTrustedPeer('ghost', 'main', ctx)).toBe(false)
+    expect(isTrustedPeer('main', 'ghost', ctx)).toBe(false)
+  })
+})
+
+describe('isTrustedPeer — MAIN shortcut', () => {
+  const ctx = makeCtx({
+    alice: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+    bob: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+  })
+
+  it('trusts MAIN → any known agent even without an explicit edge', () => {
+    expect(isTrustedPeer('main', 'alice', ctx)).toBe(true)
+    expect(isTrustedPeer('main', 'bob', ctx)).toBe(true)
+  })
+
+  it('trusts any known agent → MAIN even without an explicit edge', () => {
+    expect(isTrustedPeer('alice', 'main', ctx)).toBe(true)
+    expect(isTrustedPeer('bob', 'main', ctx)).toBe(true)
+  })
+})
+
+describe('isTrustedPeer — reportsTo edge', () => {
+  const ctx = makeCtx({
+    leader: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+    member: { reportsTo: 'leader', delegatesTo: [], trustFrom: [] },
+  })
+
+  it('trusts leader → member (to.reportsTo === from)', () => {
+    expect(isTrustedPeer('leader', 'member', ctx)).toBe(true)
+  })
+
+  it('trusts member → leader (from.reportsTo === to)', () => {
+    expect(isTrustedPeer('member', 'leader', ctx)).toBe(true)
+  })
+})
+
+describe('isTrustedPeer — delegatesTo edge', () => {
+  const ctx = makeCtx({
+    a: { reportsTo: null, delegatesTo: ['b'], trustFrom: [] },
+    b: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+    c: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+  })
+
+  it('trusts a → b when a.delegatesTo includes b', () => {
+    expect(isTrustedPeer('a', 'b', ctx)).toBe(true)
+  })
+
+  it('trusts b → a symmetrically (a delegates to b means b also trusts a)', () => {
+    expect(isTrustedPeer('b', 'a', ctx)).toBe(true)
+  })
+
+  it('does not trust unrelated peers (a ↔ c)', () => {
+    expect(isTrustedPeer('a', 'c', ctx)).toBe(false)
+    expect(isTrustedPeer('c', 'a', ctx)).toBe(false)
+  })
+})
+
+describe('isTrustedPeer — trustFrom explicit override', () => {
+  const ctx = makeCtx({
+    a: { reportsTo: null, delegatesTo: [], trustFrom: ['b'] },
+    b: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+  })
+
+  it('trusts b → a when a.trustFrom includes b', () => {
+    expect(isTrustedPeer('b', 'a', ctx)).toBe(true)
+  })
+
+  it('trusts a → b symmetrically', () => {
+    expect(isTrustedPeer('a', 'b', ctx)).toBe(true)
+  })
+})
+
+describe('isTrustedPeer — trustFrom absent field', () => {
+  // Older configs may omit trustFrom entirely; the helper must not crash
+  // and must just treat the list as empty.
+  const ctx = makeCtx({
+    a: { reportsTo: null, delegatesTo: [] },
+    b: { reportsTo: null, delegatesTo: [] },
+  })
+
+  it('handles a missing trustFrom field as an empty list', () => {
+    expect(isTrustedPeer('a', 'b', ctx)).toBe(false)
+  })
+})
+
+describe('isTrustedPeer — no false trust for strangers', () => {
+  const ctx = makeCtx({
+    a: { reportsTo: 'leader', delegatesTo: [], trustFrom: [] },
+    b: { reportsTo: 'leader', delegatesTo: [], trustFrom: [] },
+    leader: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+  })
+
+  it('does not trust two members of the same leader without an explicit edge', () => {
+    // a and b both report to `leader`, but neither has the other in
+    // delegatesTo / trustFrom, so horizontal peer trust is not implied.
+    expect(isTrustedPeer('a', 'b', ctx)).toBe(false)
+    expect(isTrustedPeer('b', 'a', ctx)).toBe(false)
+  })
+})
+
+describe('isTrustedPeer — typical dev-team scenario', () => {
+  // A leader with four members reporting to it, plus an isolated helper
+  // agent with no edges. Exercises every trust path end-to-end on a
+  // realistic small team graph.
+  const ctx = makeCtx({
+    team_lead: { reportsTo: null, delegatesTo: ['dev2'], trustFrom: [] },
+    dev2: { reportsTo: 'team_lead', delegatesTo: [], trustFrom: [] },
+    dev3: { reportsTo: 'team_lead', delegatesTo: [], trustFrom: [] },
+    dev4: { reportsTo: 'team_lead', delegatesTo: [], trustFrom: [] },
+    reviewer: { reportsTo: 'team_lead', delegatesTo: [], trustFrom: [] },
+    isolated: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+  }, 'main')
+
+  it('leader ↔ each member is trusted', () => {
+    for (const member of ['dev2', 'dev3', 'dev4', 'reviewer']) {
+      expect(isTrustedPeer('team_lead', member, ctx)).toBe(true)
+      expect(isTrustedPeer(member, 'team_lead', ctx)).toBe(true)
+    }
+  })
+
+  it('main ↔ every known agent is trusted', () => {
+    for (const a of ['team_lead', 'dev2', 'dev3', 'reviewer', 'isolated']) {
+      expect(isTrustedPeer('main', a, ctx)).toBe(true)
+      expect(isTrustedPeer(a, 'main', ctx)).toBe(true)
+    }
+  })
+
+  it('peer-to-peer is NOT trusted unless an explicit edge exists', () => {
+    // Classic peer-handoff concern: dev2 and dev3 have no edge, so a
+    // direct message between them falls back to untrusted. Operator
+    // must add dev2.delegatesTo = ['dev3'] (or trustFrom) via the UI.
+    expect(isTrustedPeer('dev2', 'dev3', ctx)).toBe(false)
+    expect(isTrustedPeer('dev3', 'dev2', ctx)).toBe(false)
+  })
+
+  it('isolated agent is only trusted with main', () => {
+    // An agent without reportsTo / delegatesTo / trustFrom is in the
+    // graph but has no edges except the implicit main shortcut.
+    expect(isTrustedPeer('isolated', 'main', ctx)).toBe(true)
+    expect(isTrustedPeer('isolated', 'team_lead', ctx)).toBe(false)
+    expect(isTrustedPeer('team_lead', 'isolated', ctx)).toBe(false)
+  })
+})
+
+describe('isTrustedPeer — custom mainAgentId', () => {
+  // The helper must respect the caller's MAIN id, not hard-code "main".
+  const ctx = makeCtx({
+    orchestrator: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+    sub: { reportsTo: null, delegatesTo: [], trustFrom: [] },
+  }, 'orchestrator')
+
+  it('uses ctx.mainAgentId for the implicit shortcut', () => {
+    expect(isTrustedPeer('orchestrator', 'sub', ctx)).toBe(true)
+    expect(isTrustedPeer('sub', 'orchestrator', ctx)).toBe(true)
+  })
+
+  it('does NOT trust the literal string "main" when the configured id is different', () => {
+    // "main" is not in the teams map and not the configured main id; it's
+    // an unknown agent, so the known-agent guard returns false.
+    expect(isTrustedPeer('main', 'sub', ctx)).toBe(false)
+  })
+})

--- a/src/team-trust.ts
+++ b/src/team-trust.ts
@@ -1,0 +1,76 @@
+// Trust-graph decision for inter-agent messages.
+//
+// The router asks isTrustedPeer() for every pending message and picks one
+// of two wrappers accordingly:
+//
+//   trusted  →  <trusted-peer> + TRUSTED_PEER_PREAMBLE   (coworker exchange)
+//   not      →  <untrusted>    + UNTRUSTED_PREAMBLE      (external / unknown)
+//
+// The rules are symmetric -- if either end of the pair acknowledges the
+// relation (reportsTo, delegatesTo, explicit trustFrom override), both
+// sides treat each other as trusted. Asymmetric cases (a reviewer who
+// should receive but not issue instructions) are covered by the
+// TRUSTED_PEER_PREAMBLE's "judge on merits, escalate if destructive"
+// wording rather than a trust-gate; pushing asymmetry into the graph
+// itself is a V3.1+ concern.
+//
+// This module deliberately takes its fs / config dependencies as a
+// TrustContext argument instead of importing web.ts helpers directly.
+// That keeps the decision logic pure, synchronously testable with
+// fake context objects, and free of the top-level side effects that
+// loading web.ts would trigger.
+
+export interface TeamConfigForTrust {
+  reportsTo: string | null
+  delegatesTo: string[]
+  trustFrom?: string[]
+}
+
+export interface TrustContext {
+  mainAgentId: string
+  isKnownAgent(name: string): boolean
+  readAgentTeam(name: string): TeamConfigForTrust
+}
+
+/**
+ * Decide whether an inter-agent message should be wrapped as a trusted
+ * peer exchange (<trusted-peer>) rather than untrusted content (<untrusted>).
+ *
+ * Rules, checked in order:
+ *   1. Self-loop (from === to) → false.
+ *   2. Either name empty → false.
+ *   3. Either name not a known agent → false.
+ *      (MUST run before the MAIN shortcut, otherwise a spoofed unknown
+ *      `from` targeting MAIN would pass.)
+ *   4. Either end is the main agent → true (main is implicit peer of all).
+ *   5. Any of these holds between the team configs:
+ *        - fromTeam.reportsTo === to  (to is from's leader)
+ *        - toTeam.reportsTo === from  (from is to's leader)
+ *        - to ∈ fromTeam.delegatesTo  (from explicitly delegates to to)
+ *        - from ∈ toTeam.delegatesTo  (to explicitly delegates to from)
+ *        - to ∈ fromTeam.trustFrom    (explicit override)
+ *        - from ∈ toTeam.trustFrom    (explicit override)
+ *   6. Otherwise → false.
+ */
+export function isTrustedPeer(from: string, to: string, ctx: TrustContext): boolean {
+  if (!from || !to) return false
+  if (from === to) return false
+
+  // Known-agent check BEFORE main shortcut: a spoofed unknown sender
+  // targeting MAIN would otherwise be trusted.
+  if (!ctx.isKnownAgent(from) || !ctx.isKnownAgent(to)) return false
+
+  if (from === ctx.mainAgentId || to === ctx.mainAgentId) return true
+
+  const fromTeam = ctx.readAgentTeam(from)
+  const toTeam = ctx.readAgentTeam(to)
+
+  if (fromTeam.reportsTo === to) return true
+  if (toTeam.reportsTo === from) return true
+  if (fromTeam.delegatesTo.includes(to)) return true
+  if (toTeam.delegatesTo.includes(from)) return true
+  if ((fromTeam.trustFrom ?? []).includes(to)) return true
+  if ((toTeam.trustFrom ?? []).includes(from)) return true
+
+  return false
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -345,6 +345,11 @@ interface TeamConfig {
   reportsTo: string | null
   delegatesTo: string[]
   autoDelegation: boolean
+  // Optional override so an operator can grant "trusted peer" status to an
+  // agent outside the usual reportsTo / delegatesTo derivation -- e.g. a
+  // cross-team collaborator. Unknown names and self-references are stripped
+  // at write time (see writeAgentTeam + sanitizeTeamConfig).
+  trustFrom?: string[]
 }
 
 const DEFAULT_TEAM: TeamConfig = {
@@ -352,6 +357,7 @@ const DEFAULT_TEAM: TeamConfig = {
   reportsTo: null,
   delegatesTo: [],
   autoDelegation: false,
+  trustFrom: [],
 }
 
 function readAgentTeam(name: string): TeamConfig {
@@ -364,10 +370,11 @@ function readAgentTeam(name: string): TeamConfig {
       const reportsTo = typeof raw.reportsTo === 'string' && raw.reportsTo.trim() ? raw.reportsTo.trim() : null
       const delegatesTo = Array.isArray(raw.delegatesTo) ? raw.delegatesTo.filter((x: unknown) => typeof x === 'string') : []
       const autoDelegation = !!raw.autoDelegation
-      return { role, reportsTo, delegatesTo, autoDelegation }
+      const trustFrom = Array.isArray(raw.trustFrom) ? raw.trustFrom.filter((x: unknown) => typeof x === 'string') : []
+      return { role, reportsTo, delegatesTo, autoDelegation, trustFrom }
     }
   } catch { /* fall through */ }
-  return { ...DEFAULT_TEAM }
+  return { ...DEFAULT_TEAM, trustFrom: [] }
 }
 
 function writeAgentTeam(name: string, team: TeamConfig): void {
@@ -376,6 +383,60 @@ function writeAgentTeam(name: string, team: TeamConfig): void {
   try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
   config.team = team
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
+// Scrub self-references and unknown agent names from a TeamConfig's name
+// fields. Returns the cleaned config plus a warnings object the caller
+// (the PUT handler) can surface to the UI so an operator isn't silently
+// missing the name they just typed.
+interface TeamSanitizeWarnings {
+  droppedSelf: string[]   // field names that referenced the agent itself
+  droppedUnknown: string[]  // agent ids not present on disk + not MAIN
+}
+
+function sanitizeTeamConfig(
+  agentName: string,
+  team: TeamConfig,
+): { team: TeamConfig; warnings: TeamSanitizeWarnings } {
+  const known = new Set<string>(listAgentNames())
+  known.add(MAIN_AGENT_ID)
+  const warnings: TeamSanitizeWarnings = { droppedSelf: [], droppedUnknown: [] }
+
+  const cleanList = (ids: string[], fieldName: string): string[] => {
+    const out: string[] = []
+    for (const id of ids) {
+      if (id === agentName) {
+        if (!warnings.droppedSelf.includes(fieldName)) warnings.droppedSelf.push(fieldName)
+        continue
+      }
+      if (!known.has(id)) {
+        warnings.droppedUnknown.push(id)
+        continue
+      }
+      if (!out.includes(id)) out.push(id)  // de-dupe too
+    }
+    return out
+  }
+
+  let reportsTo = team.reportsTo
+  if (reportsTo === agentName) {
+    warnings.droppedSelf.push('reportsTo')
+    reportsTo = null
+  } else if (reportsTo && !known.has(reportsTo)) {
+    warnings.droppedUnknown.push(reportsTo)
+    reportsTo = null
+  }
+
+  return {
+    team: {
+      role: team.role,
+      reportsTo,
+      delegatesTo: cleanList(team.delegatesTo, 'delegatesTo'),
+      autoDelegation: team.autoDelegation,
+      trustFrom: cleanList(team.trustFrom ?? [], 'trustFrom'),
+    },
+    warnings,
+  }
 }
 
 // Removing an agent leaves dangling references in other agents' team configs.
@@ -389,9 +450,14 @@ function cleanupTeamReferences(removedName: string): void {
       team.reportsTo = removedName === MAIN_AGENT_ID ? null : MAIN_AGENT_ID
       dirty = true
     }
-    const filtered = team.delegatesTo.filter(n => n !== removedName)
-    if (filtered.length !== team.delegatesTo.length) {
-      team.delegatesTo = filtered
+    const filteredDelegates = team.delegatesTo.filter(n => n !== removedName)
+    if (filteredDelegates.length !== team.delegatesTo.length) {
+      team.delegatesTo = filteredDelegates
+      dirty = true
+    }
+    const filteredTrust = (team.trustFrom ?? []).filter(n => n !== removedName)
+    if (filteredTrust.length !== (team.trustFrom ?? []).length) {
+      team.trustFrom = filteredTrust
       dirty = true
     }
     if (dirty) writeAgentTeam(other, team)
@@ -2399,7 +2465,7 @@ export function startWebServer(port = 3420): http.Server {
         const body = await readBody(req)
         const data = JSON.parse(body.toString())
         const current = readAgentTeam(name)
-        const next: TeamConfig = {
+        const proposed: TeamConfig = {
           role: data.role === 'leader' ? 'leader' : (data.role === 'member' ? 'member' : current.role),
           reportsTo: typeof data.reportsTo === 'string'
             ? (data.reportsTo.trim() || null)
@@ -2408,9 +2474,15 @@ export function startWebServer(port = 3420): http.Server {
             ? data.delegatesTo.filter((x: unknown) => typeof x === 'string')
             : current.delegatesTo,
           autoDelegation: typeof data.autoDelegation === 'boolean' ? data.autoDelegation : current.autoDelegation,
+          trustFrom: Array.isArray(data.trustFrom)
+            ? data.trustFrom.filter((x: unknown) => typeof x === 'string')
+            : (current.trustFrom ?? []),
         }
+        // Silently-dropped names would confuse an operator who just typed
+        // them; include them in the response so the UI can toast.
+        const { team: next, warnings } = sanitizeTeamConfig(name, proposed)
         writeAgentTeam(name, next)
-        return json(res, { ok: true, team: next })
+        return json(res, { ok: true, team: next, warnings })
       }
 
       // GET /api/agents/:name/telegram/pending - List pending pairing codes.

--- a/src/web.ts
+++ b/src/web.ts
@@ -464,6 +464,22 @@ function cleanupTeamReferences(removedName: string): void {
   }
 }
 
+// Does this identifier refer to a registered agent? MAIN_AGENT_ID always
+// counts (it lives outside agents/ but is a first-class peer). Sub-agents
+// need a directory on disk. One fs stat per call -- the router calls this
+// twice per pending message on its 5s tick, roughly 10-20 stats per tick
+// in practice, no memoisation needed.
+function isKnownAgent(name: string): boolean {
+  if (!name) return false
+  if (name === MAIN_AGENT_ID) return true
+  try {
+    const dir = agentDir(name)
+    return existsSync(dir) && statSync(dir).isDirectory()
+  } catch {
+    return false
+  }
+}
+
 // Merges the profile's allow/deny entries into agents/<name>/.claude/settings.json,
 // preserving any other keys (hooks, custom flags) the user added by hand.
 // Idempotent migration: every agent's settings.json should carry the


### PR DESCRIPTION
## Why this matters

V3-4 needs a single function to answer *"should this inter-agent message be wrapped as `<trusted-peer>` or `<untrusted>`?"* That decision reads team configs from disk, checks whether the sender is a known agent, and handles a MAIN-shortcut — so it's a tangle of fs and config dependencies. Keeping it inline in `web.ts` would make it untestable without booting the whole dashboard.

This PR extracts the decision into a pure, DI-friendly module so we can exhaustively unit-test the rules before the router wiring lands.

## Change

**New file: `src/team-trust.ts`** (≈80 LOC)

```ts
export interface TrustContext {
  mainAgentId: string
  isKnownAgent(name: string): boolean
  readAgentTeam(name: string): TeamConfigForTrust
}

export function isTrustedPeer(from: string, to: string, ctx: TrustContext): boolean
```

The function takes its fs/config dependencies as `ctx`. `web.ts` will pass the real `isKnownAgent` + `readAgentTeam`; tests pass in-memory fakes.

### Rules (symmetric)

Applied in this order:
1. Empty `from` or `to` → `false`
2. Self-loop (`from === to`) → `false`
3. Either side **not** a known agent → `false` — **critical**: this check runs BEFORE the MAIN-shortcut, otherwise a spoofed unknown `from` targeting MAIN would be marked trusted
4. Either end is `mainAgentId` (and both are known) → `true`
5. Any of: `from.reportsTo === to`, `to.reportsTo === from`, `to ∈ from.delegatesTo`, `from ∈ to.delegatesTo`, `to ∈ from.trustFrom`, `from ∈ to.trustFrom` → `true`
6. Otherwise → `false`

Asymmetric cases (a reviewer that should accept but not issue instructions) are not encoded in the graph — they're handled by the `TRUSTED_PEER_PREAMBLE` wording from V3-1 ("judge on merits, escalate if destructive"). Pushing asymmetry into the graph would add complexity without a concrete call site that needs it yet.

**`web.ts`** keeps a small `isKnownAgent()` helper (one `fs.stat`) and stops carrying its own copy of the trust logic. The router wiring comes in V3-4.

## Test plan

- [x] `npm run typecheck` clean
- [x] `vitest run src/__tests__/team-trust.test.ts` → **23/23 passed**

Tests cover:
- Guard rails: empty from/to, self-loop, and the key anti-spoof case (unknown-name → MAIN must return false)
- MAIN implicit shortcut in both directions
- `reportsTo` edge in both directions
- `delegatesTo` edge symmetry (a→b and b→a both trusted even if only one side lists the other)
- `trustFrom` explicit override in both directions
- Older configs without `trustFrom` field
- Two members sharing a leader are NOT auto-trusted (no horizontal implicit edge)
- Realistic 6-agent team graph, every trust path verified end-to-end
- Custom `mainAgentId` — the function must not hard-code "main"

## Part of the V3 series

| PR | What it does | Depends on |
|----|--------------|-----------|
| V3-1 (#24) | prompt-safety helpers + cross-tag scrubbing | -- |
| V3-2 (#25) | `TeamConfig.trustFrom` + sanitize + warnings | -- |
| **V3-3 (this)** | `isTrustedPeer` pure-logic helper + tests | V3-2 |
| V3-4 | Router switches to trust-aware wrapping | V3-1 + V3-3 |
| V3-5 | Dashboard UI: `trustFrom` picker + warnings toast | V3-2 |

This PR stacks on V3-2 (re-uses the `trustFrom` field introduced there). GitHub shows the combined diff; once you merge #25 the view will shrink to just this PR's commit.