### PR TITLE
Fix isSessionReadyForPrompt regex that classified every idle session as busy

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -1483,8 +1483,13 @@ function isSessionReadyForPrompt(session: string): boolean {
     const lines = pane.split('\n')
     const footerIdx = lines.findIndex(l => /bypass permissions on \(shift\+tab to cycle\)/.test(l))
     const start = Math.max(0, footerIdx - 20)
-    const slice = lines.slice(start, footerIdx === -1 ? undefined : footerIdx).join('\n')
-    if (/❯\s+\S/.test(slice)) return false
+    const sliceLines = lines.slice(start, footerIdx === -1 ? undefined : footerIdx)
+    // Match ❯ followed by non-whitespace ON THE SAME LINE. The previous
+    // version joined the lines with \n and used /❯\s+\S/, where \s matches
+    // newlines and so the regex happily spanned from an idle "❯ " into
+    // the horizontal-rule "─" character on the line below -- classifying
+    // every idle session as "busy".
+    if (sliceLines.some(line => /❯[^\n]*\S/.test(line))) return false
     return true
   } catch {
     return false


### PR DESCRIPTION
## Summary
`isSessionReadyForPrompt` guards against text already parked in the input buffer with:

```ts
const slice = lines.slice(start, footerIdx === -1 ? undefined : footerIdx).join('\n')
if (/❯\s+\S/.test(slice)) return false
```

Because the lines are joined with `\n` and `\s` matches `\n`, the regex spans from an idle input line (`"❯ "`) across the newline into the decorative horizontal-rule `─` character on the line below — so `/❯\s+\S/` matches **every** idle pane.

Net effect: `startMessageRouter` and the schedule runner both call `isSessionReadyForPrompt` before sending; with every session reporting busy, every outbound message sat in `pending` forever, even on completely idle agents.

## Fix
Iterate the candidate lines and test `/❯[^\n]*\S/` *within each line*. That keeps the intent — "the ❯ input prompt has non-whitespace content after it" — while refusing to span newlines.

## Observed
On an install with four idle sub-agents plus an idle main agent, `tmux capture-pane` for every session showed the `bypass permissions` footer and an empty `❯` input line, yet every router tick logged `Router skip: session busy`. After the fix, messages drain normally.

## Test plan
- [ ] Leave all agents idle. Post an inter-agent message via `POST /api/messages`. Verify the next router tick delivers it (not `session busy`).
- [ ] Type some text into an agent's tmux input (without pressing Enter). Verify `isSessionReadyForPrompt` still returns false for that session.
- [ ] Verify `[Pasted text #N]` detection still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)