### PR TITLE
dashboard UI: trustFrom multi-select + warnings toast

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -345,6 +345,11 @@ interface TeamConfig {
   reportsTo: string | null
   delegatesTo: string[]
   autoDelegation: boolean
+  // Optional override so an operator can grant "trusted peer" status to an
+  // agent outside the usual reportsTo / delegatesTo derivation -- e.g. a
+  // cross-team collaborator. Unknown names and self-references are stripped
+  // at write time (see writeAgentTeam + sanitizeTeamConfig).
+  trustFrom?: string[]
 }
 
 const DEFAULT_TEAM: TeamConfig = {
@@ -352,6 +357,7 @@ const DEFAULT_TEAM: TeamConfig = {
   reportsTo: null,
   delegatesTo: [],
   autoDelegation: false,
+  trustFrom: [],
 }
 
 function readAgentTeam(name: string): TeamConfig {
@@ -364,10 +370,11 @@ function readAgentTeam(name: string): TeamConfig {
       const reportsTo = typeof raw.reportsTo === 'string' && raw.reportsTo.trim() ? raw.reportsTo.trim() : null
       const delegatesTo = Array.isArray(raw.delegatesTo) ? raw.delegatesTo.filter((x: unknown) => typeof x === 'string') : []
       const autoDelegation = !!raw.autoDelegation
-      return { role, reportsTo, delegatesTo, autoDelegation }
+      const trustFrom = Array.isArray(raw.trustFrom) ? raw.trustFrom.filter((x: unknown) => typeof x === 'string') : []
+      return { role, reportsTo, delegatesTo, autoDelegation, trustFrom }
     }
   } catch { /* fall through */ }
-  return { ...DEFAULT_TEAM }
+  return { ...DEFAULT_TEAM, trustFrom: [] }
 }
 
 function writeAgentTeam(name: string, team: TeamConfig): void {
@@ -376,6 +383,60 @@ function writeAgentTeam(name: string, team: TeamConfig): void {
   try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
   config.team = team
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
+// Scrub self-references and unknown agent names from a TeamConfig's name
+// fields. Returns the cleaned config plus a warnings object the caller
+// (the PUT handler) can surface to the UI so an operator isn't silently
+// missing the name they just typed.
+interface TeamSanitizeWarnings {
+  droppedSelf: string[]   // field names that referenced the agent itself
+  droppedUnknown: string[]  // agent ids not present on disk + not MAIN
+}
+
+function sanitizeTeamConfig(
+  agentName: string,
+  team: TeamConfig,
+): { team: TeamConfig; warnings: TeamSanitizeWarnings } {
+  const known = new Set<string>(listAgentNames())
+  known.add(MAIN_AGENT_ID)
+  const warnings: TeamSanitizeWarnings = { droppedSelf: [], droppedUnknown: [] }
+
+  const cleanList = (ids: string[], fieldName: string): string[] => {
+    const out: string[] = []
+    for (const id of ids) {
+      if (id === agentName) {
+        if (!warnings.droppedSelf.includes(fieldName)) warnings.droppedSelf.push(fieldName)
+        continue
+      }
+      if (!known.has(id)) {
+        warnings.droppedUnknown.push(id)
+        continue
+      }
+      if (!out.includes(id)) out.push(id)  // de-dupe too
+    }
+    return out
+  }
+
+  let reportsTo = team.reportsTo
+  if (reportsTo === agentName) {
+    warnings.droppedSelf.push('reportsTo')
+    reportsTo = null
+  } else if (reportsTo && !known.has(reportsTo)) {
+    warnings.droppedUnknown.push(reportsTo)
+    reportsTo = null
+  }
+
+  return {
+    team: {
+      role: team.role,
+      reportsTo,
+      delegatesTo: cleanList(team.delegatesTo, 'delegatesTo'),
+      autoDelegation: team.autoDelegation,
+      trustFrom: cleanList(team.trustFrom ?? [], 'trustFrom'),
+    },
+    warnings,
+  }
 }
 
 // Removing an agent leaves dangling references in other agents' team configs.
@@ -389,9 +450,14 @@ function cleanupTeamReferences(removedName: string): void {
       team.reportsTo = removedName === MAIN_AGENT_ID ? null : MAIN_AGENT_ID
       dirty = true
     }
-    const filtered = team.delegatesTo.filter(n => n !== removedName)
-    if (filtered.length !== team.delegatesTo.length) {
-      team.delegatesTo = filtered
+    const filteredDelegates = team.delegatesTo.filter(n => n !== removedName)
+    if (filteredDelegates.length !== team.delegatesTo.length) {
+      team.delegatesTo = filteredDelegates
+      dirty = true
+    }
+    const filteredTrust = (team.trustFrom ?? []).filter(n => n !== removedName)
+    if (filteredTrust.length !== (team.trustFrom ?? []).length) {
+      team.trustFrom = filteredTrust
       dirty = true
     }
     if (dirty) writeAgentTeam(other, team)
@@ -2399,7 +2465,7 @@ export function startWebServer(port = 3420): http.Server {
         const body = await readBody(req)
         const data = JSON.parse(body.toString())
         const current = readAgentTeam(name)
-        const next: TeamConfig = {
+        const proposed: TeamConfig = {
           role: data.role === 'leader' ? 'leader' : (data.role === 'member' ? 'member' : current.role),
           reportsTo: typeof data.reportsTo === 'string'
             ? (data.reportsTo.trim() || null)
@@ -2408,9 +2474,15 @@ export function startWebServer(port = 3420): http.Server {
             ? data.delegatesTo.filter((x: unknown) => typeof x === 'string')
             : current.delegatesTo,
           autoDelegation: typeof data.autoDelegation === 'boolean' ? data.autoDelegation : current.autoDelegation,
+          trustFrom: Array.isArray(data.trustFrom)
+            ? data.trustFrom.filter((x: unknown) => typeof x === 'string')
+            : (current.trustFrom ?? []),
         }
+        // Silently-dropped names would confuse an operator who just typed
+        // them; include them in the response so the UI can toast.
+        const { team: next, warnings } = sanitizeTeamConfig(name, proposed)
         writeAgentTeam(name, next)
-        return json(res, { ok: true, team: next })
+        return json(res, { ok: true, team: next, warnings })
       }
 
       // GET /api/agents/:name/telegram/pending - List pending pairing codes.

--- a/web/app.js
+++ b/web/app.js
@@ -4457,7 +4457,7 @@ const refreshTeamBtn = document.getElementById('refreshTeamBtn')
 if (refreshTeamBtn) refreshTeamBtn.addEventListener('click', loadTeamGraph)
 
 function renderTeamEditor(agent, allAgents) {
-  const team = agent.team || { role: 'member', reportsTo: null, delegatesTo: [], autoDelegation: false }
+  const team = agent.team || { role: 'member', reportsTo: null, delegatesTo: [], autoDelegation: false, trustFrom: [] }
   document.getElementById('editTeamRole').value = team.role || 'member'
   const reportsSel = document.getElementById('editTeamReportsTo')
   reportsSel.innerHTML = ''
@@ -4473,22 +4473,26 @@ function renderTeamEditor(agent, allAgents) {
     if (team.reportsTo === other.name) opt.selected = true
     reportsSel.appendChild(opt)
   }
-  const delegatesBox = document.getElementById('editTeamDelegatesList')
-  delegatesBox.innerHTML = ''
-  for (const other of allAgents) {
-    if (other.name === agent.name) continue
-    const label = document.createElement('label')
-    label.style.cssText = 'display:flex;align-items:center;gap:8px;cursor:pointer;font-size:13px'
-    const cb = document.createElement('input')
-    cb.type = 'checkbox'
-    cb.value = other.name
-    cb.checked = team.delegatesTo && team.delegatesTo.includes(other.name)
-    label.appendChild(cb)
-    const span = document.createElement('span')
-    span.textContent = other.displayName || other.name
-    label.appendChild(span)
-    delegatesBox.appendChild(label)
+  const buildCheckboxList = (boxId, selected) => {
+    const box = document.getElementById(boxId)
+    box.innerHTML = ''
+    for (const other of allAgents) {
+      if (other.name === agent.name) continue
+      const label = document.createElement('label')
+      label.style.cssText = 'display:flex;align-items:center;gap:8px;cursor:pointer;font-size:13px'
+      const cb = document.createElement('input')
+      cb.type = 'checkbox'
+      cb.value = other.name
+      cb.checked = !!(selected && selected.includes(other.name))
+      label.appendChild(cb)
+      const span = document.createElement('span')
+      span.textContent = other.displayName || other.name
+      label.appendChild(span)
+      box.appendChild(label)
+    }
   }
+  buildCheckboxList('editTeamDelegatesList', team.delegatesTo)
+  buildCheckboxList('editTeamTrustFromList', team.trustFrom)
   document.getElementById('editTeamAutoDelegation').checked = !!team.autoDelegation
   // Only leaders make sense to delegate from -- hide the lists for members.
   const updateLeaderVisibility = () => {
@@ -4506,6 +4510,7 @@ document.getElementById('saveTeamBtn').addEventListener('click', async () => {
   const role = document.getElementById('editTeamRole').value
   const reportsToRaw = document.getElementById('editTeamReportsTo').value
   const delegates = Array.from(document.querySelectorAll('#editTeamDelegatesList input[type=checkbox]:checked')).map(cb => cb.value)
+  const trustFrom = Array.from(document.querySelectorAll('#editTeamTrustFromList input[type=checkbox]:checked')).map(cb => cb.value)
   const autoDelegation = document.getElementById('editTeamAutoDelegation').checked
   const originalText = btn.textContent
   btn.disabled = true
@@ -4518,11 +4523,30 @@ document.getElementById('saveTeamBtn').addEventListener('click', async () => {
         role,
         reportsTo: reportsToRaw || null,
         delegatesTo: role === 'leader' ? delegates : [],
+        trustFrom,
         autoDelegation: role === 'leader' ? autoDelegation : false,
       }),
     })
     if (!res.ok) throw new Error()
-    showToast('Csapat mentve')
+    // The server sanitizes the team config (strips self-references and
+    // unknown agent ids) and reports what it dropped in `warnings`. Surface
+    // that to the operator so a mistyped name isn't silently lost.
+    let warningMsg = ''
+    try {
+      const body = await res.json()
+      const w = body && body.warnings
+      if (w) {
+        const parts = []
+        if (Array.isArray(w.droppedSelf) && w.droppedSelf.length) {
+          parts.push(`önreferenciák: ${w.droppedSelf.join(', ')}`)
+        }
+        if (Array.isArray(w.droppedUnknown) && w.droppedUnknown.length) {
+          parts.push(`ismeretlen nevek: ${w.droppedUnknown.join(', ')}`)
+        }
+        if (parts.length) warningMsg = parts.join(' · ')
+      }
+    } catch { /* body already consumed or not JSON -- OK, no warnings to show */ }
+    showToast(warningMsg ? `Csapat mentve (kivett: ${warningMsg})` : 'Csapat mentve')
     btn.textContent = '✓ Mentve'
     setTimeout(() => { btn.textContent = originalText; btn.disabled = false }, 1800)
     loadAgents()

--- a/web/index.html
+++ b/web/index.html
@@ -910,6 +910,11 @@
             </label>
             <small style="display:block;margin-top:6px;color:var(--text-muted);font-size:12px">Ha nincs bepipálva, a vezető csak javaslatot ad, te hagyod jóvá Telegramon.</small>
           </div>
+          <div class="form-group" id="editTeamTrustFromGroup">
+            <label>Explicit megbízható kapcsolatok (opcionális)</label>
+            <div id="editTeamTrustFromList" style="display:flex;flex-direction:column;gap:6px"></div>
+            <small style="display:block;margin-top:6px;color:var(--text-muted);font-size:12px">A router alapból a jelent-kapcsolat és a delegálási lista alapján dönti el, hogy egy üzenet megbízható csapattárstól jön-e. Itt további ügynököket jelölhetsz kézzel &mdash; pl. egy cross-team együttműködő partner, akivel nincs hierarchikus kapcsolat, de a levelezése mégis csapattársi.</small>
+          </div>
           <button class="btn-secondary btn-compact agent-save-section" id="saveTeamBtn">Mentés</button>
         </div>
 


### PR DESCRIPTION
## Why this matters

V3-2 introduced `TeamConfig.trustFrom` (optional explicit trust overrides) and V3-4 makes the router use it, but neither has a UI path — an operator would have to PUT the JSON by hand. This PR adds the missing dashboard bits so non-technical operators can manage the trust graph like they already manage `reportsTo` and `delegatesTo`.

It also closes a rough edge from V3-2: the PUT handler now returns a `warnings` object when it strips self-references or unknown agent ids from the posted team config, and without a UI change the operator still sees a plain "Csapat mentve" message while the server silently drops their typo. This PR surfaces the drops.

## Change

**`web/index.html`** — new form-group under the delegates block in the team editor. Checkbox list of all other agents; a `<small>` tooltip explains that trustFrom is for cross-team / custom trust edges outside the normal reportsTo + delegatesTo hierarchy.

**`web/app.js`** — two edits:

1. `renderTeamEditor()` — factored the checkbox-list DOM builder into a small helper (`buildCheckboxList(boxId, selected)`) so delegatesTo and trustFrom share render code.
2. `saveTeamBtn` click handler —
   - POSTs the `trustFrom` selection alongside the existing fields
   - Reads the response `warnings` object; if the server dropped anything, toasts `"Csapat mentve (kivett: önreferenciák: ... · ismeretlen nevek: ...)"` so the operator sees which entries were rejected. Happy path stays `"Csapat mentve"`.

## Scope

- Non-leader agents also get the trustFrom picker (unlike delegatesTo, which is leader-only), because trust edges can go in either direction.
- No change to the GET path; `agent.team.trustFrom` either comes from the agent-config.json (V3-2 readAgentTeam) or defaults to `[]`.
- No migration or data format change; everything is additive.

## Test plan

- [x] `npm run typecheck` clean
- [x] Full test suite: `vitest run` → 41/41 passed (no new tests here; this is UI-only, covered by V3-2's server-side sanitizer tests)
- [ ] Manual smoke (to do after merge + dashboard reload):
  - open agent details → Team tab → trustFrom checkboxes render for every other agent
  - tick one, save → toast says "Csapat mentve"
  - reload page → checkbox stays ticked (confirms the PUT round-tripped + readAgentTeam picks up the new field)
  - tick the agent's own name programmatically (curl PUT) → save from UI after → toast says "kivett: önreferenciák: trustFrom"
  - add an unknown agent id via curl PUT → save from UI → toast says "kivett: ismeretlen nevek: …"

## Part of the V3 series

| PR | What it does | Depends on | Status |
|----|--------------|-----------|--------|
| V3-1 (#24) | prompt-safety helpers + cross-tag scrubbing | -- | OPEN |
| V3-2 (#25) | `TeamConfig.trustFrom` + sanitize + warnings | -- | OPEN |
| V3-3 (#26) | `isTrustedPeer` pure-logic helper + tests | V3-2 | OPEN |
| V3-4 (#28) | Router switches to trust-aware wrapping | V3-1 + V3-3 | OPEN |
| **V3-5 (this)** | Dashboard UI: trustFrom picker + warnings toast | V3-2 | this PR |

This PR stacks on V3-2. GitHub shows the combined diff until #25 merges, then only the UI commit remains. The V3 series ships as five independently-reviewable pieces; this one is the user-visible endpoint that lets an operator drive the trust graph from the dashboard.