### PR TITLE
Surface runAgent errors instead of returning fallback strings

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -56,7 +56,7 @@ export async function runAgent(
       resultText = `A feldolgozas tullepte a ${mins} perces idokorlatot. Probald rovidebben megfogalmazni, vagy bontsd tobb lepesre.`
     } else {
       logger.error({ err }, 'Agent hiba')
-      resultText = 'Hiba tortent a feldolgozas soran.'
+      throw err instanceof Error ? err : new Error(String(err))
     }
   } finally {
     clearTimeout(timeout)

--- a/src/web.ts
+++ b/src/web.ts
@@ -2855,14 +2855,18 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
         let finalPrompt = prompt.trim()
         if (expand) {
           logger.info({ prompt: finalPrompt }, 'Prompt kibovites...')
-          const { text } = await runAgent(
-            `Bovitsd ki ezt a rovid feladat-leirast egy reszletes, egyertelmu promptta amit egy AI asszisztens vegre tud hajtani.
+          try {
+            const { text } = await runAgent(
+              `Bovitsd ki ezt a rovid feladat-leirast egy reszletes, egyertelmu promptta amit egy AI asszisztens vegre tud hajtani.
 A prompt legyen magyar nyelvu, konkret utasitasokkal.
 Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas.
 
 Rovid leiras: "${finalPrompt}"`
-          )
-          if (text) finalPrompt = text.trim()
+            )
+            if (text) finalPrompt = text.trim()
+          } catch (err) {
+            logger.warn({ err }, 'Prompt expand failed, using original')
+          }
         }
         try {
           const nextRun = computeNextRun(schedule)


### PR DESCRIPTION
## Summary
`runAgent` (src/agent.ts) catches any exception from the underlying Claude Code SDK and returns the truthy string `'Hiba tortent a feldolgozas soran.'` as `text`. Every caller then checks `if (!text) throw ...`, which the fallback passes. The error silently propagates as if it were valid output:

- `generateClaudeMd` / `generateSoulMd` (agent creation): the 33-byte "Hiba tortent..." string gets written into the new agent's CLAUDE.md and SOUL.md, while the dashboard logs `Agent created successfully`.
- `memory.ts` daily-log generator: the string is saved as the day's digest in SQLite.
- `heartbeat.ts`: the string is sent to Telegram as if it were a heartbeat notification.

Observed live: creating an Emil agent on 2026-04-22 11:40 resulted in `Claude Code process exited with code 1` (SDK subprocess crash), followed 500 ms later by `Agent created successfully` and two files containing only the error string.

## Fix
Change `runAgent`'s catch block to **re-throw** on non-timeout errors so callers that already have `try/catch` handle failures properly. The timeout path keeps its user-friendly fallback string (it's a soft limit that UI callers want to surface to the user verbatim).

The `/api/schedules` prompt-expand code path previously called `runAgent` without a surrounding `try/catch`; that's fixed too — expand failure now falls back to the raw prompt with a warning log instead of crashing the schedule creation.

## Test plan
- [ ] Force an SDK error during agent creation (e.g. revoke the Anthropic API key). `POST /api/agents` should return HTTP 500, not silently create an agent with a broken CLAUDE.md/SOUL.md.
- [ ] With a working SDK, agent creation still produces well-formed CLAUDE.md/SOUL.md.
- [ ] Heartbeat `runAgent` failures log the error and stay silent on Telegram instead of sending the fallback string.
- [ ] `POST /api/schedules` with `expand=true` and a broken SDK still creates the task with the raw prompt (error logged, not crashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)