### PR TITLE
updater: preflight branch + clean-tree checks, surface failures in UI

### DIFF
--- a/src/__tests__/update-preflight.test.ts
+++ b/src/__tests__/update-preflight.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import { checkUpdatePreflight, type GitRunner } from '../update-preflight.js'
+
+// Helper: build a GitRunner from plain strings. Covers the common
+// "return this exact branch / status" fixtures without dragging in a
+// real git invocation.
+function makeGit(branch: string, porcelain = ''): GitRunner {
+  return {
+    currentBranch: () => branch,
+    porcelainStatus: () => porcelain,
+  }
+}
+
+describe('checkUpdatePreflight --happy path', () => {
+  it('returns ok when on main with a clean tree', () => {
+    const result = checkUpdatePreflight(makeGit('main', ''))
+    expect(result.ok).toBe(true)
+  })
+
+  it('ignores whitespace-only branch output', () => {
+    const result = checkUpdatePreflight(makeGit('  main  ', '   '))
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('checkUpdatePreflight --detached HEAD', () => {
+  it('rejects an empty branch name', () => {
+    const result = checkUpdatePreflight(makeGit(''))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('detached-head')
+    expect(result.message).toMatch(/detached-HEAD/)
+  })
+
+  it('rejects the literal "HEAD" that git prints for detached checkouts', () => {
+    const result = checkUpdatePreflight(makeGit('HEAD'))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('detached-head')
+  })
+
+  it('prioritises detached-HEAD over dirty-tree when both apply', () => {
+    // If we are detached we do not want a "commit your changes" message,
+    // because the right next step is checkout main first.
+    const result = checkUpdatePreflight(makeGit('HEAD', ' M src/web.ts\n'))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('detached-head')
+  })
+})
+
+describe('checkUpdatePreflight --feature branch', () => {
+  it('rejects any branch name other than main', () => {
+    const result = checkUpdatePreflight(makeGit('v3-05-ui-trustfrom-picker'))
+    expect(result.ok).toBe(false)
+    if (result.ok || result.reason !== 'not-on-main') {
+      throw new Error('expected not-on-main result')
+    }
+    expect(result.branch).toBe('v3-05-ui-trustfrom-picker')
+    expect(result.message).toContain("'v3-05-ui-trustfrom-picker'")
+    expect(result.message).toMatch(/git checkout main/)
+  })
+
+  it('rejects "master" (a common misconfiguration)', () => {
+    const result = checkUpdatePreflight(makeGit('master'))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('not-on-main')
+  })
+
+  it('prioritises not-on-main over dirty-tree when both apply', () => {
+    // Switching to main first invalidates the dirty-tree check anyway
+    // (the modifications may or may not carry across branches), so the
+    // useful error message for the user is "switch branches", not
+    // "commit your changes on this branch".
+    const result = checkUpdatePreflight(makeGit('feature-x', ' M src/web.ts\n'))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('not-on-main')
+  })
+})
+
+describe('checkUpdatePreflight --dirty working tree', () => {
+  it('rejects unstaged modifications', () => {
+    const result = checkUpdatePreflight(makeGit('main', ' M src/web.ts\n'))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('dirty-tree')
+    expect(result.message).toMatch(/git stash/)
+  })
+
+  it('rejects staged modifications', () => {
+    const result = checkUpdatePreflight(makeGit('main', 'M  src/web.ts\n'))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('dirty-tree')
+  })
+
+  it('rejects a mix of staged and unstaged', () => {
+    const result = checkUpdatePreflight(
+      makeGit('main', 'M  src/web.ts\n M src/db.ts\n'),
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('dirty-tree')
+  })
+
+  it('accepts on-main with only trailing whitespace in porcelain output', () => {
+    // `git status --porcelain` returns a trailing newline even when
+    // clean on some platforms. Trim-then-compare keeps that from being
+    // read as dirty.
+    const result = checkUpdatePreflight(makeGit('main', '\n'))
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('checkUpdatePreflight --result shape', () => {
+  it('never emits a branch field on the ok path', () => {
+    const result = checkUpdatePreflight(makeGit('main'))
+    // TypeScript alone does not enforce this at runtime, so assert it.
+    expect(Object.hasOwn(result, 'branch')).toBe(false)
+  })
+
+  it('only emits a branch field on the not-on-main path', () => {
+    const detached = checkUpdatePreflight(makeGit(''))
+    expect(Object.hasOwn(detached, 'branch')).toBe(false)
+
+    const dirty = checkUpdatePreflight(makeGit('main', ' M x'))
+    expect(Object.hasOwn(dirty, 'branch')).toBe(false)
+
+    const feature = checkUpdatePreflight(makeGit('feature-x'))
+    expect(Object.hasOwn(feature, 'branch')).toBe(true)
+  })
+})

--- a/src/__tests__/update-preflight.test.ts
+++ b/src/__tests__/update-preflight.test.ts
@@ -138,10 +138,15 @@ describe('checkUpdatePreflight -- result shape', () => {
   })
 })
 
-function makePidfile(raw: string | null, alivePids: number[] = []): PidfileRunner {
+function makePidfile(
+  raw: string | null,
+  alivePids: number[] = [],
+  nowMs = 1_000_000_000_000,
+): PidfileRunner {
   return {
     readPidfile: () => raw,
     isProcessAlive: (pid) => alivePids.includes(pid),
+    now: () => nowMs,
   }
 }
 
@@ -213,6 +218,66 @@ describe('checkNoConcurrentUpdate -- live pidfile', () => {
 
   it('trims leading whitespace before parsing', () => {
     const result = checkNoConcurrentUpdate(makePidfile('\n  7777\n', [7777]))
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('checkNoConcurrentUpdate -- age-based staleness', () => {
+  const HOUR_MS = 60 * 60 * 1000
+
+  it('accepts a fresh dashboard-written pidfile (pid + recent epoch)', () => {
+    const now = 2_000_000_000_000
+    const start = now - 1000 // 1 second old
+    const result = checkNoConcurrentUpdate(
+      makePidfile(`7777\n${start}\n`, [7777], now),
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.pid).toBe(7777)
+  })
+
+  it('treats a >1-hour-old pidfile as stale even if the pid is alive', () => {
+    // Defends against SIGKILL + PID recycling: if we ever believed a
+    // live-looking pid in a pidfile that was written an hour ago, the
+    // button would stay locked by an unrelated process that happens to
+    // have the same PID now.
+    const now = 2_000_000_000_000
+    const start = now - (HOUR_MS + 1) // 1 ms past the cutoff
+    const result = checkNoConcurrentUpdate(
+      makePidfile(`7777\n${start}\n`, [7777], now),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts the boundary: exactly 1 hour old is still alive', () => {
+    const now = 2_000_000_000_000
+    const start = now - HOUR_MS // exactly the cutoff
+    const result = checkNoConcurrentUpdate(
+      makePidfile(`7777\n${start}\n`, [7777], now),
+    )
+    expect(result.ok).toBe(false)
+  })
+
+  it('falls back to alive-only check when epoch line is missing (legacy format)', () => {
+    const result = checkNoConcurrentUpdate(
+      makePidfile('7777', [7777], 2_000_000_000_000),
+    )
+    expect(result.ok).toBe(false)
+  })
+
+  it('ignores a non-numeric epoch line and falls back to alive-only', () => {
+    const result = checkNoConcurrentUpdate(
+      makePidfile('7777\nnot-an-epoch', [7777], 2_000_000_000_000),
+    )
+    expect(result.ok).toBe(false)
+  })
+
+  it('ignores a zero or negative epoch and falls back to alive-only', () => {
+    // Parsed but rejected by the `> 0` guard, so the caller does not
+    // time-travel the pidfile with a zero-epoch placeholder.
+    const result = checkNoConcurrentUpdate(
+      makePidfile('7777\n0\n', [7777], 2_000_000_000_000),
+    )
     expect(result.ok).toBe(false)
   })
 })

--- a/src/__tests__/update-preflight.test.ts
+++ b/src/__tests__/update-preflight.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { checkUpdatePreflight, type GitRunner } from '../update-preflight.js'
+import {
+  checkUpdatePreflight,
+  checkNoConcurrentUpdate,
+  type GitRunner,
+  type PidfileRunner,
+} from '../update-preflight.js'
 
 // Helper: build a GitRunner from plain strings. Covers the common
 // "return this exact branch / status" fixtures without dragging in a
@@ -114,7 +119,7 @@ describe('checkUpdatePreflight --dirty working tree', () => {
   })
 })
 
-describe('checkUpdatePreflight --result shape', () => {
+describe('checkUpdatePreflight -- result shape', () => {
   it('never emits a branch field on the ok path', () => {
     const result = checkUpdatePreflight(makeGit('main'))
     // TypeScript alone does not enforce this at runtime, so assert it.
@@ -130,5 +135,84 @@ describe('checkUpdatePreflight --result shape', () => {
 
     const feature = checkUpdatePreflight(makeGit('feature-x'))
     expect(Object.hasOwn(feature, 'branch')).toBe(true)
+  })
+})
+
+function makePidfile(raw: string | null, alivePids: number[] = []): PidfileRunner {
+  return {
+    readPidfile: () => raw,
+    isProcessAlive: (pid) => alivePids.includes(pid),
+  }
+}
+
+describe('checkNoConcurrentUpdate -- no pidfile', () => {
+  it('allows when no pidfile exists', () => {
+    const result = checkNoConcurrentUpdate(makePidfile(null))
+    expect(result.ok).toBe(true)
+  })
+
+  it('allows when pidfile is empty', () => {
+    const result = checkNoConcurrentUpdate(makePidfile(''))
+    expect(result.ok).toBe(true)
+  })
+
+  it('allows when pidfile is whitespace-only', () => {
+    const result = checkNoConcurrentUpdate(makePidfile('   \n\n'))
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('checkNoConcurrentUpdate -- stale or corrupt pidfile', () => {
+  it('treats a non-numeric pidfile as stale', () => {
+    const result = checkNoConcurrentUpdate(makePidfile('not-a-number'))
+    expect(result.ok).toBe(true)
+  })
+
+  it('treats a negative-sign pidfile as stale (regex rejects leading minus)', () => {
+    const result = checkNoConcurrentUpdate(makePidfile('-1'))
+    expect(result.ok).toBe(true)
+  })
+
+  it('treats pid 0 as stale (reserved)', () => {
+    const result = checkNoConcurrentUpdate(makePidfile('0', [0]))
+    expect(result.ok).toBe(true)
+  })
+
+  it('treats pid 1 as stale even if it would probe alive (init)', () => {
+    // init is always alive on Unix; if we ever trusted a stale
+    // pidfile that happened to contain "1", the Update button would
+    // be locked forever.
+    const result = checkNoConcurrentUpdate(makePidfile('1', [1]))
+    expect(result.ok).toBe(true)
+  })
+
+  it('treats a dead pid as stale', () => {
+    const result = checkNoConcurrentUpdate(makePidfile('12345', []))
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('checkNoConcurrentUpdate -- live pidfile', () => {
+  it('refuses when a live pid is in the file', () => {
+    const result = checkNoConcurrentUpdate(makePidfile('7777', [7777]))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('already-running')
+    expect(result.pid).toBe(7777)
+    expect(result.message).toContain('7777')
+  })
+
+  it('parses a leading-integer pid even with trailing noise', () => {
+    // A pidfile written by `echo $$` on some shells may include extra
+    // trailing bytes. Accept the leading integer and ignore the rest.
+    const result = checkNoConcurrentUpdate(makePidfile('7777 started at 12:00\n', [7777]))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.pid).toBe(7777)
+  })
+
+  it('trims leading whitespace before parsing', () => {
+    const result = checkNoConcurrentUpdate(makePidfile('\n  7777\n', [7777]))
+    expect(result.ok).toBe(false)
   })
 })

--- a/src/__tests__/update-preflight.test.ts
+++ b/src/__tests__/update-preflight.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   checkUpdatePreflight,
   checkNoConcurrentUpdate,
+  classifyLockWriteError,
   type GitRunner,
   type PidfileRunner,
 } from '../update-preflight.js'
@@ -279,5 +280,34 @@ describe('checkNoConcurrentUpdate -- age-based staleness', () => {
       makePidfile('7777\n0\n', [7777], 2_000_000_000_000),
     )
     expect(result.ok).toBe(false)
+  })
+})
+
+describe('classifyLockWriteError', () => {
+  it('classifies EEXIST as a concurrency race', () => {
+    expect(classifyLockWriteError('EEXIST')).toBe('race')
+  })
+
+  it('classifies EACCES as a non-race write failure', () => {
+    expect(classifyLockWriteError('EACCES')).toBe('other')
+  })
+
+  it('classifies EROFS as a non-race write failure', () => {
+    expect(classifyLockWriteError('EROFS')).toBe('other')
+  })
+
+  it('classifies ENOSPC as a non-race write failure', () => {
+    expect(classifyLockWriteError('ENOSPC')).toBe('other')
+  })
+
+  it('classifies undefined code as non-race (plain Error / string throw)', () => {
+    // retryErr may not be an ErrnoException -- a plain Error, a string,
+    // or null reaches the site. The helper should fall through to the
+    // 500 branch instead of misreading no-code as EEXIST.
+    expect(classifyLockWriteError(undefined)).toBe('other')
+  })
+
+  it('classifies empty string code as non-race', () => {
+    expect(classifyLockWriteError('')).toBe('other')
   })
 })

--- a/src/update-preflight.ts
+++ b/src/update-preflight.ts
@@ -70,6 +70,16 @@ export type ConcurrencyResult =
 // and intervene.
 export const MAX_PIDFILE_AGE_MS = 60 * 60 * 1000
 
+// Classify the errno from the retry writeFileSync that follows a
+// stale-pidfile unlink. Only EEXIST means a parallel caller genuinely
+// raced us to the lock; any other code is a real write failure
+// (EACCES, EROFS, ENOSPC) and should surface as 500 instead of 409.
+export type LockWriteErrorKind = 'race' | 'other'
+
+export function classifyLockWriteError(code: string | undefined): LockWriteErrorKind {
+  return code === 'EEXIST' ? 'race' : 'other'
+}
+
 export function checkNoConcurrentUpdate(pf: PidfileRunner): ConcurrencyResult {
   const raw = pf.readPidfile()
   if (raw === null) return { ok: true }

--- a/src/update-preflight.ts
+++ b/src/update-preflight.ts
@@ -40,7 +40,9 @@ export type PreflightResult =
 // Concurrency gate: refuse a second /api/updates/apply while the first
 // update.sh is still running. An in-memory timestamp would reset on the
 // dashboard restart that happens mid-run, so the gate lives in a disk
-// pidfile that update.sh owns for its lifetime (trap EXIT removes it).
+// pidfile. The dashboard creates it atomically with O_EXCL before
+// spawning; update.sh overwrites with its own PID early in its run and
+// removes the file on EXIT via trap. Pidfile content: "<pid>\n<start-epoch-ms>\n".
 export interface PidfileRunner {
   // The raw contents of store/update.pid, or null if the file does not
   // exist / cannot be read. Implementations must not throw.
@@ -49,26 +51,51 @@ export interface PidfileRunner {
   // kill(pid, 0) probe: ESRCH means dead, EPERM means alive but owned
   // by a different uid, anything else treated as alive for safety.
   isProcessAlive(pid: number): boolean
+  // Current wall-clock epoch in milliseconds. Injected for
+  // deterministic age-comparison tests.
+  now(): number
 }
 
 export type ConcurrencyResult =
   | { ok: true }
   | { ok: false; reason: 'already-running'; pid: number; message: string }
 
+// Max age before a live-looking pidfile is treated as stale anyway.
+// This guards against PID recycling after SIGKILL / power loss: if a
+// pidfile survives a kernel kill and the OS later recycles its PID to
+// an unrelated process, kill(pid, 0) would report "alive" forever. A
+// typical update is well under five minutes; one hour is twelve times
+// the upper end of the normal distribution and still short enough
+// that an operator waiting on a genuinely runaway update will notice
+// and intervene.
+export const MAX_PIDFILE_AGE_MS = 60 * 60 * 1000
+
 export function checkNoConcurrentUpdate(pf: PidfileRunner): ConcurrencyResult {
   const raw = pf.readPidfile()
   if (raw === null) return { ok: true }
   const trimmed = raw.trim()
   if (!trimmed) return { ok: true }
-  // Parse only a leading integer. A pidfile with trailing junk (a stray
-  // newline, a commented-out note) still yields a clean pid; garbage
-  // with no digits yields NaN and is treated as stale.
-  const match = trimmed.match(/^(\d+)/)
+  // Accept pidfile formats:
+  //   "<pid>"                       (legacy, echo $$ only)
+  //   "<pid>\n<start-epoch-ms>\n"   (dashboard-written, preferred)
+  //   "<pid> garbage..."            (pid parsed from leading digits)
+  const match = trimmed.match(/^(\d+)(?:[\s\r\n]+(\d+))?/)
   if (!match) return { ok: true }
   const pid = Number.parseInt(match[1], 10)
-  // PID 0 and 1 are reserved / init; treating them as "alive" would
+  // PID 0 and 1 are reserved / init; treating them as alive would
   // permanently lock the button if a stale pidfile ever contained one.
   if (!Number.isFinite(pid) || pid <= 1) return { ok: true }
+  // If the optional second line is present and older than the max
+  // age, treat as stale regardless of kill(pid, 0). Missing second
+  // line means a legacy pidfile with no age info: fall through to
+  // the alive probe alone.
+  if (match[2]) {
+    const startEpoch = Number.parseInt(match[2], 10)
+    if (Number.isFinite(startEpoch) && startEpoch > 0) {
+      const age = pf.now() - startEpoch
+      if (age > MAX_PIDFILE_AGE_MS) return { ok: true }
+    }
+  }
   if (!pf.isProcessAlive(pid)) return { ok: true }
   return {
     ok: false,

--- a/src/update-preflight.ts
+++ b/src/update-preflight.ts
@@ -1,0 +1,81 @@
+// Preflight check for the in-dashboard "Update now" button.
+//
+// The previous flow was:
+//   1. user clicks "Frissítés most"
+//   2. backend spawns update.sh (detached, stdio ignored)
+//   3. frontend receives { ok: true }, shows "Frissítés elindult..."
+//   4. after 30s the page reloads and shows the same pending commits
+//
+// The silent failure mode is update.sh hitting `git pull --ff-only origin
+// main` while the local checkout is on a feature branch (or has local
+// modifications that would make a fast-forward impossible). set -e in
+// update.sh makes it exit before the stop.sh / start.sh step, but the
+// frontend has no way to know because it only watched spawn() success.
+//
+// Running the preflight checks server-side means the apply endpoint can
+// refuse with a 409 and a readable reason, the user sees an actionable
+// toast, and the dashboard never enters the "reload in 30s" lie for a
+// run that was guaranteed to fail.
+//
+// The module takes its git calls through a GitRunner interface so the
+// decision logic is pure and synchronously testable without shelling
+// out in tests.
+
+export interface GitRunner {
+  // Current branch name. "HEAD" (or empty) signals a detached checkout.
+  currentBranch(): string
+  // Porcelain status excluding untracked files. Non-empty = dirty tree.
+  // Untracked files are excluded because the repo legitimately carries
+  // ad-hoc backup files (CLAUDE.md.backup-*, SOUL.md mid-edit, etc.)
+  // that should not block an update.
+  porcelainStatus(): string
+}
+
+export type PreflightResult =
+  | { ok: true }
+  | { ok: false; reason: 'not-on-main'; branch: string; message: string }
+  | { ok: false; reason: 'dirty-tree'; message: string }
+  | { ok: false; reason: 'detached-head'; message: string }
+
+const EXPECTED_BRANCH = 'main'
+
+export function checkUpdatePreflight(git: GitRunner): PreflightResult {
+  const branch = git.currentBranch().trim()
+
+  // `git rev-parse --abbrev-ref HEAD` prints "HEAD" on a detached
+  // checkout. Treat that separately so the error message can explain
+  // it instead of claiming the branch is called "HEAD".
+  if (!branch || branch === 'HEAD') {
+    return {
+      ok: false,
+      reason: 'detached-head',
+      message:
+        'Repository is in a detached-HEAD state. Check out main before updating: git checkout main',
+    }
+  }
+
+  if (branch !== EXPECTED_BRANCH) {
+    return {
+      ok: false,
+      reason: 'not-on-main',
+      branch,
+      message:
+        `Cannot update from branch '${branch}'. ` +
+        `'git pull --ff-only origin main' cannot fast-forward a feature branch. ` +
+        `Switch to main first: git checkout main`,
+    }
+  }
+
+  const dirty = git.porcelainStatus().trim()
+  if (dirty.length > 0) {
+    return {
+      ok: false,
+      reason: 'dirty-tree',
+      message:
+        'Working tree has uncommitted changes (staged or unstaged). ' +
+        'Commit or stash them before updating: git stash',
+    }
+  }
+
+  return { ok: true }
+}

--- a/src/update-preflight.ts
+++ b/src/update-preflight.ts
@@ -37,6 +37,47 @@ export type PreflightResult =
   | { ok: false; reason: 'dirty-tree'; message: string }
   | { ok: false; reason: 'detached-head'; message: string }
 
+// Concurrency gate: refuse a second /api/updates/apply while the first
+// update.sh is still running. An in-memory timestamp would reset on the
+// dashboard restart that happens mid-run, so the gate lives in a disk
+// pidfile that update.sh owns for its lifetime (trap EXIT removes it).
+export interface PidfileRunner {
+  // The raw contents of store/update.pid, or null if the file does not
+  // exist / cannot be read. Implementations must not throw.
+  readPidfile(): string | null
+  // True if a process with the given PID is alive. On Unix this is the
+  // kill(pid, 0) probe: ESRCH means dead, EPERM means alive but owned
+  // by a different uid, anything else treated as alive for safety.
+  isProcessAlive(pid: number): boolean
+}
+
+export type ConcurrencyResult =
+  | { ok: true }
+  | { ok: false; reason: 'already-running'; pid: number; message: string }
+
+export function checkNoConcurrentUpdate(pf: PidfileRunner): ConcurrencyResult {
+  const raw = pf.readPidfile()
+  if (raw === null) return { ok: true }
+  const trimmed = raw.trim()
+  if (!trimmed) return { ok: true }
+  // Parse only a leading integer. A pidfile with trailing junk (a stray
+  // newline, a commented-out note) still yields a clean pid; garbage
+  // with no digits yields NaN and is treated as stale.
+  const match = trimmed.match(/^(\d+)/)
+  if (!match) return { ok: true }
+  const pid = Number.parseInt(match[1], 10)
+  // PID 0 and 1 are reserved / init; treating them as "alive" would
+  // permanently lock the button if a stale pidfile ever contained one.
+  if (!Number.isFinite(pid) || pid <= 1) return { ok: true }
+  if (!pf.isProcessAlive(pid)) return { ok: true }
+  return {
+    ok: false,
+    reason: 'already-running',
+    pid,
+    message: `Update already running (pid ${pid}). Wait for it to finish, then retry.`,
+  }
+}
+
 const EXPECTED_BRANCH = 'main'
 
 export function checkUpdatePreflight(git: GitRunner): PreflightResult {

--- a/src/web.ts
+++ b/src/web.ts
@@ -2476,14 +2476,24 @@ export function startWebServer(port = 3420): http.Server {
           try {
             writeFileSync(UPDATE_PIDFILE, pidfileContent, { flag: 'wx' })
             lockHeld = true
-          } catch {
-            // A parallel caller raced us and took the lock between our
-            // unlink and retry. Treat conservatively as already-running.
+          } catch (retryErr) {
+            // Only EEXIST means another caller genuinely raced us to the
+            // lock. Any other errno (EACCES, EROFS, ENOSPC) is a real
+            // failure to write, not a concurrency event, and should
+            // surface as 500 so the user sees why rather than a
+            // misleading "already running".
+            const code = (retryErr as NodeJS.ErrnoException)?.code
+            if (code === 'EEXIST') {
+              return json(res, {
+                error: 'Another update is starting concurrently. Retry in a few seconds.',
+                reason: 'already-running',
+                pid: 0,
+              }, 409)
+            }
             return json(res, {
-              error: 'Another update is starting concurrently. Retry in a few seconds.',
-              reason: 'already-running',
-              pid: 0,
-            }, 409)
+              error: 'Pidfile retry-write failed: ' + (retryErr instanceof Error ? retryErr.message : String(retryErr)),
+              reason: 'lock-write-failed',
+            }, 500)
           }
         }
         const releaseLock = () => {
@@ -2535,7 +2545,10 @@ export function startWebServer(port = 3420): http.Server {
           // handled; log it and release the lock so a retry is possible.
           child.on('error', (err) => {
             logger.error({ err }, 'update.sh spawn reported an async error')
-            try { unlinkSync(UPDATE_PIDFILE) } catch { /* already gone */ }
+            // Reuse releaseLock so the unlink + lockHeld reset stay in
+            // one place; if future code extends the path, it will not
+            // double-unlink a file now owned by a subsequent run.
+            releaseLock()
           })
           child.unref()
           return json(res, { ok: true })

--- a/src/web.ts
+++ b/src/web.ts
@@ -33,6 +33,7 @@ import {
   sanitizeAgentIdent,
 } from './prompt-safety.js'
 import { isTrustedPeer } from './team-trust.js'
+import { checkUpdatePreflight, type GitRunner } from './update-preflight.js'
 
 function computeNextRun(cronExpression: string): number {
   const expr = CronExpressionParser.parse(cronExpression)
@@ -2389,7 +2390,43 @@ export function startWebServer(port = 3420): http.Server {
       // POST /api/updates/apply - spawn update.sh in the background.
       // The script restarts the dashboard itself, so we reply immediately
       // and the browser reloads after a short delay.
+      //
+      // Before spawning, run checkUpdatePreflight against the live repo.
+      // update.sh itself would still exit on a non-main branch / dirty
+      // tree, but because it is launched detached with stdio: 'ignore'
+      // the frontend has no way to see that exit code. Replying 409 here
+      // turns a silent "Frissítés elindult / same commits after reload"
+      // loop into an actionable toast.
       if (path === '/api/updates/apply' && method === 'POST') {
+        const git: GitRunner = {
+          currentBranch: () => execFileSync(
+            '/usr/bin/git',
+            ['rev-parse', '--abbrev-ref', 'HEAD'],
+            { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
+          ),
+          porcelainStatus: () => execFileSync(
+            '/usr/bin/git',
+            ['status', '--porcelain', '--untracked-files=no'],
+            { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
+          ),
+        }
+        let preflight
+        try {
+          preflight = checkUpdatePreflight(git)
+        } catch (err) {
+          return json(res, {
+            error: 'Pre-check failed: ' + (err instanceof Error ? err.message : String(err)),
+            reason: 'precheck-crashed',
+          }, 500)
+        }
+        if (!preflight.ok) {
+          const body: Record<string, unknown> = {
+            error: preflight.message,
+            reason: preflight.reason,
+          }
+          if (preflight.reason === 'not-on-main') body.branch = preflight.branch
+          return json(res, body, 409)
+        }
         try {
           spawn('/bin/bash', [join(PROJECT_ROOT, 'update.sh')], {
             cwd: PROJECT_ROOT,

--- a/src/web.ts
+++ b/src/web.ts
@@ -1814,6 +1814,16 @@ let updateStatusCache: UpdateStatus = {
   lastChecked: 0,
 }
 
+// Timestamp of the most recent /api/updates/apply that passed preflight
+// and spawned update.sh. Used to refuse follow-up clicks within the same
+// run window so three consecutive button mashes do not race three
+// update.sh instances on git / stop.sh / start.sh. A successful run
+// restarts the dashboard process and wipes this variable with it; an
+// unsuccessful run leaves the window to expire naturally so a retry is
+// possible after the timeout.
+let lastUpdateApplyStartedAt = 0
+const UPDATE_APPLY_COOLDOWN_MS = 120_000
+
 function currentGitHead(): string {
   try {
     return execFileSync('/usr/bin/git', ['rev-parse', 'HEAD'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
@@ -2398,6 +2408,22 @@ export function startWebServer(port = 3420): http.Server {
       // turns a silent "Frissítés elindult / same commits after reload"
       // loop into an actionable toast.
       if (path === '/api/updates/apply' && method === 'POST') {
+        // Concurrency guard: refuse if another apply started within the
+        // last UPDATE_APPLY_COOLDOWN_MS. Without this, three quick clicks
+        // spawn three update.sh instances that race on git pull /
+        // stop.sh / start.sh. A successful run restarts the dashboard
+        // and clears this variable; a failed run simply lets the window
+        // expire so the operator can retry.
+        const now = Date.now()
+        const sinceLast = now - lastUpdateApplyStartedAt
+        if (lastUpdateApplyStartedAt && sinceLast < UPDATE_APPLY_COOLDOWN_MS) {
+          return json(res, {
+            error: 'Update already in progress. Wait until the current run finishes.',
+            reason: 'already-running',
+            startedAt: lastUpdateApplyStartedAt,
+            retryAfterMs: UPDATE_APPLY_COOLDOWN_MS - sinceLast,
+          }, 409)
+        }
         const git: GitRunner = {
           currentBranch: () => execFileSync(
             '/usr/bin/git',
@@ -2433,6 +2459,10 @@ export function startWebServer(port = 3420): http.Server {
             detached: true,
             stdio: 'ignore',
           }).unref()
+          // Record spawn time only after a successful spawn. On the
+          // rare spawn failure below, the concurrency window is never
+          // opened, so the next click can retry immediately.
+          lastUpdateApplyStartedAt = now
           return json(res, { ok: true })
         } catch (err) {
           return json(res, { error: err instanceof Error ? err.message : String(err) }, 500)

--- a/src/web.ts
+++ b/src/web.ts
@@ -33,7 +33,12 @@ import {
   sanitizeAgentIdent,
 } from './prompt-safety.js'
 import { isTrustedPeer } from './team-trust.js'
-import { checkUpdatePreflight, type GitRunner } from './update-preflight.js'
+import {
+  checkUpdatePreflight,
+  checkNoConcurrentUpdate,
+  type GitRunner,
+  type PidfileRunner,
+} from './update-preflight.js'
 
 function computeNextRun(cronExpression: string): number {
   const expr = CronExpressionParser.parse(cronExpression)
@@ -1814,15 +1819,11 @@ let updateStatusCache: UpdateStatus = {
   lastChecked: 0,
 }
 
-// Timestamp of the most recent /api/updates/apply that passed preflight
-// and spawned update.sh. Used to refuse follow-up clicks within the same
-// run window so three consecutive button mashes do not race three
-// update.sh instances on git / stop.sh / start.sh. A successful run
-// restarts the dashboard process and wipes this variable with it; an
-// unsuccessful run leaves the window to expire naturally so a retry is
-// possible after the timeout.
-let lastUpdateApplyStartedAt = 0
-const UPDATE_APPLY_COOLDOWN_MS = 120_000
+// Pidfile path owned by update.sh for the lifetime of an update run.
+// The dashboard never writes it -- update.sh does on entry, removes on
+// exit via a trap -- so the gate survives the stop.sh / start.sh
+// dashboard restart that happens inside a successful update.
+const UPDATE_PIDFILE = join(PROJECT_ROOT, 'store', 'update.pid')
 
 function currentGitHead(): string {
   try {
@@ -2408,20 +2409,38 @@ export function startWebServer(port = 3420): http.Server {
       // turns a silent "Frissítés elindult / same commits after reload"
       // loop into an actionable toast.
       if (path === '/api/updates/apply' && method === 'POST') {
-        // Concurrency guard: refuse if another apply started within the
-        // last UPDATE_APPLY_COOLDOWN_MS. Without this, three quick clicks
-        // spawn three update.sh instances that race on git pull /
-        // stop.sh / start.sh. A successful run restarts the dashboard
-        // and clears this variable; a failed run simply lets the window
-        // expire so the operator can retry.
-        const now = Date.now()
-        const sinceLast = now - lastUpdateApplyStartedAt
-        if (lastUpdateApplyStartedAt && sinceLast < UPDATE_APPLY_COOLDOWN_MS) {
+        // Concurrency gate: update.sh writes its PID to UPDATE_PIDFILE
+        // on entry and clears it on EXIT. If the file still points at
+        // a live process, another run is in flight -- refuse with 409.
+        // A dead pid (stale lock from a killed run) or a missing /
+        // unreadable file is treated as "ok to proceed" so the button
+        // recovers automatically after an abnormal termination.
+        const pf: PidfileRunner = {
+          readPidfile: () => {
+            try {
+              return readFileSync(UPDATE_PIDFILE, 'utf-8')
+            } catch {
+              return null
+            }
+          },
+          isProcessAlive: (pid) => {
+            try {
+              process.kill(pid, 0)
+              return true
+            } catch (err) {
+              // EPERM means the process exists but is owned by a
+              // different uid; safer to treat as alive than to race
+              // a real runner. ESRCH means truly dead.
+              return (err as NodeJS.ErrnoException)?.code === 'EPERM'
+            }
+          },
+        }
+        const concurrency = checkNoConcurrentUpdate(pf)
+        if (!concurrency.ok) {
           return json(res, {
-            error: 'Update already in progress. Wait until the current run finishes.',
-            reason: 'already-running',
-            startedAt: lastUpdateApplyStartedAt,
-            retryAfterMs: UPDATE_APPLY_COOLDOWN_MS - sinceLast,
+            error: concurrency.message,
+            reason: concurrency.reason,
+            pid: concurrency.pid,
           }, 409)
         }
         const git: GitRunner = {
@@ -2454,15 +2473,20 @@ export function startWebServer(port = 3420): http.Server {
           return json(res, body, 409)
         }
         try {
-          spawn('/bin/bash', [join(PROJECT_ROOT, 'update.sh')], {
+          const child = spawn('/bin/bash', [join(PROJECT_ROOT, 'update.sh')], {
             cwd: PROJECT_ROOT,
             detached: true,
             stdio: 'ignore',
-          }).unref()
-          // Record spawn time only after a successful spawn. On the
-          // rare spawn failure below, the concurrency window is never
-          // opened, so the next click can retry immediately.
-          lastUpdateApplyStartedAt = now
+          })
+          // .unref() + detached means Node does not keep the event loop
+          // alive for the child, but it also means an 'error' event on
+          // the ChildProcess (post-fork failure) with no listener would
+          // crash the dashboard. Attach a no-op listener so the event
+          // is handled; log it so the failure is still visible.
+          child.on('error', (err) => {
+            logger.error({ err }, 'update.sh spawn reported an async error')
+          })
+          child.unref()
           return json(res, { ok: true })
         } catch (err) {
           return json(res, { error: err instanceof Error ? err.message : String(err) }, 500)

--- a/src/web.ts
+++ b/src/web.ts
@@ -36,6 +36,7 @@ import { isTrustedPeer } from './team-trust.js'
 import {
   checkUpdatePreflight,
   checkNoConcurrentUpdate,
+  classifyLockWriteError,
   type GitRunner,
   type PidfileRunner,
 } from './update-preflight.js'
@@ -2477,13 +2478,11 @@ export function startWebServer(port = 3420): http.Server {
             writeFileSync(UPDATE_PIDFILE, pidfileContent, { flag: 'wx' })
             lockHeld = true
           } catch (retryErr) {
-            // Only EEXIST means another caller genuinely raced us to the
-            // lock. Any other errno (EACCES, EROFS, ENOSPC) is a real
-            // failure to write, not a concurrency event, and should
-            // surface as 500 so the user sees why rather than a
-            // misleading "already running".
+            // Delegate the errno discrimination to the pure helper so
+            // the invert-regression (=== vs !==) is caught by the
+            // unit tests on classifyLockWriteError.
             const code = (retryErr as NodeJS.ErrnoException)?.code
-            if (code === 'EEXIST') {
+            if (classifyLockWriteError(code) === 'race') {
               return json(res, {
                 error: 'Another update is starting concurrently. Retry in a few seconds.',
                 reason: 'already-running',
@@ -2545,10 +2544,15 @@ export function startWebServer(port = 3420): http.Server {
           // handled; log it and release the lock so a retry is possible.
           child.on('error', (err) => {
             logger.error({ err }, 'update.sh spawn reported an async error')
-            // Reuse releaseLock so the unlink + lockHeld reset stay in
-            // one place; if future code extends the path, it will not
-            // double-unlink a file now owned by a subsequent run.
-            releaseLock()
+            // Only release the lock if the pidfile still contains the
+            // dashboard-written claim. If update.sh has already started
+            // and overwritten it with its own PID, that run now owns
+            // the lock and will remove it via trap on its own EXIT.
+            let stillOurs = false
+            try {
+              stillOurs = readFileSync(UPDATE_PIDFILE, 'utf-8') === pidfileContent
+            } catch { /* file already gone -- nothing to release */ }
+            if (stillOurs) releaseLock()
           })
           child.unref()
           return json(res, { ok: true })

--- a/src/web.ts
+++ b/src/web.ts
@@ -2409,15 +2409,30 @@ export function startWebServer(port = 3420): http.Server {
       // turns a silent "Frissítés elindult / same commits after reload"
       // loop into an actionable toast.
       if (path === '/api/updates/apply' && method === 'POST') {
-        // Concurrency gate: update.sh writes its PID to UPDATE_PIDFILE
-        // on entry and clears it on EXIT. If the file still points at
-        // a live process, another run is in flight -- refuse with 409.
-        // A dead pid (stale lock from a killed run) or a missing /
-        // unreadable file is treated as "ok to proceed" so the button
-        // recovers automatically after an abnormal termination.
+        // Concurrency gate. The update flow is:
+        //   1. Dashboard atomically creates UPDATE_PIDFILE with O_EXCL.
+        //      Content: "<dashboard-pid>\n<start-epoch-ms>\n" -- enough
+        //      for the next reader to probe liveness AND reject any
+        //      pidfile older than MAX_PIDFILE_AGE_MS so a recycled PID
+        //      after SIGKILL cannot keep the button permanently locked.
+        //   2. Dashboard spawns update.sh.
+        //   3. update.sh overwrites the pidfile early with its own "$$"
+        //      plus start epoch, and removes the file on EXIT via trap.
+        //
+        // If step 1 hits EEXIST, a second caller is already in the
+        // window. The helper probes liveness + age: if fresh+live we
+        // 409; if stale we unlink and retry the create once.
         const pf: PidfileRunner = {
           readPidfile: () => {
             try {
+              // Size cap: a legitimate pidfile is under ~64 bytes
+              // ("<pid>\n<epoch>\n"). Anything wildly bigger is either
+              // corrupt or a symlink to something large; treat as
+              // absent so the caller falls through to the create-retry
+              // path, and the stat call itself avoids reading an
+              // accidentally huge file into memory.
+              const st = statSync(UPDATE_PIDFILE)
+              if (!st.isFile() || st.size > 256) return null
               return readFileSync(UPDATE_PIDFILE, 'utf-8')
             } catch {
               return null
@@ -2434,14 +2449,47 @@ export function startWebServer(port = 3420): http.Server {
               return (err as NodeJS.ErrnoException)?.code === 'EPERM'
             }
           },
+          now: () => Date.now(),
         }
-        const concurrency = checkNoConcurrentUpdate(pf)
-        if (!concurrency.ok) {
-          return json(res, {
-            error: concurrency.message,
-            reason: concurrency.reason,
-            pid: concurrency.pid,
-          }, 409)
+        const pidfileContent = `${process.pid}\n${Date.now()}\n`
+        let lockHeld = false
+        try {
+          writeFileSync(UPDATE_PIDFILE, pidfileContent, { flag: 'wx' })
+          lockHeld = true
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException)?.code !== 'EEXIST') {
+            return json(res, {
+              error: 'Pidfile write failed: ' + (err instanceof Error ? err.message : String(err)),
+              reason: 'lock-write-failed',
+            }, 500)
+          }
+          const concurrency = checkNoConcurrentUpdate(pf)
+          if (!concurrency.ok) {
+            return json(res, {
+              error: concurrency.message,
+              reason: concurrency.reason,
+              pid: concurrency.pid,
+            }, 409)
+          }
+          // Stale pidfile: remove and retry the exclusive create once.
+          try { unlinkSync(UPDATE_PIDFILE) } catch { /* already gone */ }
+          try {
+            writeFileSync(UPDATE_PIDFILE, pidfileContent, { flag: 'wx' })
+            lockHeld = true
+          } catch {
+            // A parallel caller raced us and took the lock between our
+            // unlink and retry. Treat conservatively as already-running.
+            return json(res, {
+              error: 'Another update is starting concurrently. Retry in a few seconds.',
+              reason: 'already-running',
+              pid: 0,
+            }, 409)
+          }
+        }
+        const releaseLock = () => {
+          if (!lockHeld) return
+          try { unlinkSync(UPDATE_PIDFILE) } catch { /* already gone */ }
+          lockHeld = false
         }
         const git: GitRunner = {
           currentBranch: () => execFileSync(
@@ -2459,12 +2507,14 @@ export function startWebServer(port = 3420): http.Server {
         try {
           preflight = checkUpdatePreflight(git)
         } catch (err) {
+          releaseLock()
           return json(res, {
             error: 'Pre-check failed: ' + (err instanceof Error ? err.message : String(err)),
             reason: 'precheck-crashed',
           }, 500)
         }
         if (!preflight.ok) {
+          releaseLock()
           const body: Record<string, unknown> = {
             error: preflight.message,
             reason: preflight.reason,
@@ -2481,14 +2531,16 @@ export function startWebServer(port = 3420): http.Server {
           // .unref() + detached means Node does not keep the event loop
           // alive for the child, but it also means an 'error' event on
           // the ChildProcess (post-fork failure) with no listener would
-          // crash the dashboard. Attach a no-op listener so the event
-          // is handled; log it so the failure is still visible.
+          // crash the dashboard. Attach a listener so the event is
+          // handled; log it and release the lock so a retry is possible.
           child.on('error', (err) => {
             logger.error({ err }, 'update.sh spawn reported an async error')
+            try { unlinkSync(UPDATE_PIDFILE) } catch { /* already gone */ }
           })
           child.unref()
           return json(res, { ok: true })
         } catch (err) {
+          releaseLock()
           return json(res, { error: err instanceof Error ? err.message : String(err) }, 500)
         }
       }

--- a/update.sh
+++ b/update.sh
@@ -32,7 +32,10 @@ UPDATE_PIDFILE_TMP="$UPDATE_PIDFILE.$$.tmp"
   # Portable wall-clock epoch in ms. date +%s%3N is GNU-only; on BSD
   # (macOS) we fall back to seconds * 1000. One-second granularity is
   # plenty for an hour-level age cutoff.
-  if date +%s%3N 2>/dev/null | grep -q '^[0-9]*$'; then
+  # Require one-or-more digits; `*` would accept an empty line and
+  # write "<pid>\n\n", which the helper would read as a legacy pidfile
+  # without age info (alive-probe only, no age cutoff).
+  if date +%s%3N 2>/dev/null | grep -q '^[0-9][0-9]*$'; then
     date +%s%3N
   else
     echo $(( $(date +%s) * 1000 ))

--- a/update.sh
+++ b/update.sh
@@ -27,6 +27,11 @@ mkdir -p "$(dirname "$UPDATE_PIDFILE")"
 # write to .tmp in the same directory, then mv (rename is atomic on
 # the same filesystem on macOS / Linux).
 UPDATE_PIDFILE_TMP="$UPDATE_PIDFILE.$$.tmp"
+# If the tmp-write itself fails before we own the pidfile, the dashboard
+# still holds its placeholder lock. Clean up only the tmp file if it
+# leaked; leave the dashboard's pidfile alone so the lock does not
+# disappear on a write error.
+trap 'rm -f "$UPDATE_PIDFILE_TMP"' EXIT
 {
   echo "$$"
   # Portable wall-clock epoch in ms. date +%s%3N is GNU-only; on BSD
@@ -42,6 +47,9 @@ UPDATE_PIDFILE_TMP="$UPDATE_PIDFILE.$$.tmp"
   fi
 } > "$UPDATE_PIDFILE_TMP"
 mv "$UPDATE_PIDFILE_TMP" "$UPDATE_PIDFILE"
+# Only after mv succeeds do we own the lock; extend the trap to remove
+# the final pidfile too. Until this point a mv failure left the
+# dashboard's placeholder intact for its normal age-based recovery.
 trap 'rm -f "$UPDATE_PIDFILE" "$UPDATE_PIDFILE_TMP"' EXIT
 
 # Tee the full run into store/update.log so failures are inspectable

--- a/update.sh
+++ b/update.sh
@@ -12,15 +12,34 @@ NC='\033[0m'
 INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$INSTALL_DIR"
 
-# Pidfile gate: the dashboard's /api/updates/apply refuses to spawn a
-# second update.sh while this PID is alive. Written before the tee
-# setup so that a stale log write from a runaway process cannot be
-# mistaken for "an update is running". Trap EXIT removes the pidfile
-# on any exit path (success, preflight reject, or error).
+# Pidfile gate. The dashboard's /api/updates/apply creates
+# store/update.pid atomically with O_EXCL before spawning this script,
+# so a concurrent second click cannot race past the gate. Here we just
+# overwrite the dashboard's placeholder with our own PID plus a start
+# epoch (ms), and arrange to clean up on exit. Format:
+#   <pid>\n<start-epoch-ms>\n
+# The epoch lets checkNoConcurrentUpdate treat a pidfile older than
+# one hour as stale, which guards against PID recycling after a
+# SIGKILL / power loss left the file behind.
 UPDATE_PIDFILE="$INSTALL_DIR/store/update.pid"
 mkdir -p "$(dirname "$UPDATE_PIDFILE")"
-echo "$$" > "$UPDATE_PIDFILE"
-trap 'rm -f "$UPDATE_PIDFILE"' EXIT
+# Atomic rename so a concurrent reader never sees a half-written file:
+# write to .tmp in the same directory, then mv (rename is atomic on
+# the same filesystem on macOS / Linux).
+UPDATE_PIDFILE_TMP="$UPDATE_PIDFILE.$$.tmp"
+{
+  echo "$$"
+  # Portable wall-clock epoch in ms. date +%s%3N is GNU-only; on BSD
+  # (macOS) we fall back to seconds * 1000. One-second granularity is
+  # plenty for an hour-level age cutoff.
+  if date +%s%3N 2>/dev/null | grep -q '^[0-9]*$'; then
+    date +%s%3N
+  else
+    echo $(( $(date +%s) * 1000 ))
+  fi
+} > "$UPDATE_PIDFILE_TMP"
+mv "$UPDATE_PIDFILE_TMP" "$UPDATE_PIDFILE"
+trap 'rm -f "$UPDATE_PIDFILE" "$UPDATE_PIDFILE_TMP"' EXIT
 
 # Tee the full run into store/update.log so failures are inspectable
 # after the fact. The dashboard launches this script detached with

--- a/update.sh
+++ b/update.sh
@@ -28,14 +28,19 @@ if [ -f "$UPDATE_LOG" ]; then
     mv "$UPDATE_LOG" "$UPDATE_LOG.1" 2>/dev/null || true
   fi
 fi
-# Redirect stdout+stderr through tee. Record the tee PID and wait on
-# it in an EXIT trap so the last lines of a failing run are flushed
-# to disk before this shell returns; without the wait, `set -e` can
-# exit while tee still has unflushed bytes buffered.
-exec > >(tee -a "$UPDATE_LOG")
-TEE_PID=$!
-exec 2>&1
-trap 'wait $TEE_PID 2>/dev/null || true' EXIT
+# Pre-touch the log before the tee redirect. If the filesystem is
+# read-only or out of inodes, fail here with a clear message on the
+# caller's stderr instead of blowing up later via SIGPIPE when tee
+# cannot open its target and the next echo writes to a closed pipe.
+if ! : >> "$UPDATE_LOG" 2>/dev/null; then
+  echo "HIBA: nem lehet irni a naplofajlba: $UPDATE_LOG" >&2
+  echo "       ellenorizd a store/ jogosultsagait es szabad helyet." >&2
+  exit 4
+fi
+# Redirect stdout+stderr through tee. When this shell exits, the
+# write-end of the pipe closes, tee reads EOF, flushes its buffer,
+# and exits -- so no explicit wait is needed.
+exec > >(tee -a "$UPDATE_LOG") 2>&1
 
 echo ""
 echo -e "${BOLD}Marveen frissites...${NC} [$(date -u +%Y-%m-%dT%H:%M:%SZ)]"

--- a/update.sh
+++ b/update.sh
@@ -5,15 +5,78 @@ set -e
 
 BOLD='\033[1m'
 GREEN='\033[0;32m'
+RED='\033[0;31m'
 DIM='\033[2m'
 NC='\033[0m'
 
 INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$INSTALL_DIR"
 
+# Tee the full run into store/update.log so failures are inspectable
+# after the fact. The dashboard launches this script detached with
+# stdio: 'ignore', so without the log there is no record of why a
+# run exited non-zero.
+#
+# Size-based rotation: if the log is over 1 MiB, roll once to .1 and
+# start fresh. No dated history, no cap on .1, just enough to keep
+# the store/ directory bounded while preserving one prior run.
+UPDATE_LOG="$INSTALL_DIR/store/update.log"
+mkdir -p "$(dirname "$UPDATE_LOG")"
+if [ -f "$UPDATE_LOG" ]; then
+  LOG_SIZE=$(wc -c <"$UPDATE_LOG" 2>/dev/null | tr -d ' ')
+  if [ -n "$LOG_SIZE" ] && [ "$LOG_SIZE" -gt 1048576 ]; then
+    mv "$UPDATE_LOG" "$UPDATE_LOG.1" 2>/dev/null || true
+  fi
+fi
+# Redirect stdout+stderr through tee. Record the tee PID and wait on
+# it in an EXIT trap so the last lines of a failing run are flushed
+# to disk before this shell returns; without the wait, `set -e` can
+# exit while tee still has unflushed bytes buffered.
+exec > >(tee -a "$UPDATE_LOG")
+TEE_PID=$!
+exec 2>&1
+trap 'wait $TEE_PID 2>/dev/null || true' EXIT
+
 echo ""
-echo -e "${BOLD}Marveen frissites...${NC}"
+echo -e "${BOLD}Marveen frissites...${NC} [$(date -u +%Y-%m-%dT%H:%M:%SZ)]"
 echo ""
+
+# Guard 1: refuse to run from a non-main branch.
+# 'git pull --ff-only origin main' below would exit non-zero on any
+# branch whose tip is not an ancestor of origin/main -- for example
+# every feature branch whose PR was squash-merged upstream. Because
+# the dashboard launches this script detached with stdio: 'ignore',
+# that exit is invisible to the operator: the UI silently reloads on
+# the same pending-commit list. Same guard also exists server-side
+# in /api/updates/apply as a 409 pre-check; this is defense-in-depth
+# for manual invocations.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$CURRENT_BRANCH" = "HEAD" ] || [ -z "$CURRENT_BRANCH" ]; then
+  echo -e "${RED}HIBA:${NC} A repo detached-HEAD allapotban van."
+  echo "       Allj at a main branchre, majd indithatod ujra a frissitest:"
+  echo "         git checkout main"
+  exit 2
+fi
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo -e "${RED}HIBA:${NC} A jelenlegi branch '${CURRENT_BRANCH}', nem 'main'."
+  echo "       A 'git pull --ff-only origin main' csak a main branchrol fut tisztan."
+  echo "       Allj at elobb a main branchre:"
+  echo "         git checkout main"
+  exit 2
+fi
+
+# Guard 2: refuse to run with a dirty tracked working tree.
+# Untracked files (CLAUDE.md.backup-*, SOUL.md mid-edit, agent-generated
+# scratchpads) are allowed -- the --untracked-files=no flag excludes
+# them. Only staged or unstaged modifications to already-tracked files
+# are a block.
+DIRTY=$(git status --porcelain --untracked-files=no | head -n 1)
+if [ -n "$DIRTY" ]; then
+  echo -e "${RED}HIBA:${NC} A working tree modosult allapotban van."
+  echo "       Commitold vagy stasheld a valtozasokat, majd indithatod ujra:"
+  echo "         git stash"
+  exit 3
+fi
 
 # Save current version
 OLD_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")

--- a/update.sh
+++ b/update.sh
@@ -12,6 +12,16 @@ NC='\033[0m'
 INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$INSTALL_DIR"
 
+# Pidfile gate: the dashboard's /api/updates/apply refuses to spawn a
+# second update.sh while this PID is alive. Written before the tee
+# setup so that a stale log write from a runaway process cannot be
+# mistaken for "an update is running". Trap EXIT removes the pidfile
+# on any exit path (success, preflight reject, or error).
+UPDATE_PIDFILE="$INSTALL_DIR/store/update.pid"
+mkdir -p "$(dirname "$UPDATE_PIDFILE")"
+echo "$$" > "$UPDATE_PIDFILE"
+trap 'rm -f "$UPDATE_PIDFILE"' EXIT
+
 # Tee the full run into store/update.log so failures are inspectable
 # after the fact. The dashboard launches this script detached with
 # stdio: 'ignore', so without the log there is no record of why a

--- a/web/app.js
+++ b/web/app.js
@@ -4724,16 +4724,27 @@ document.getElementById('updatesApplyBtn').addEventListener('click', async () =>
   btn.disabled = true
   btn.querySelector('.btn-text').hidden = true
   btn.querySelector('.btn-loading').hidden = false
-  try {
-    const res = await fetch('/api/updates/apply', { method: 'POST' })
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    showToast('Frissítés elindult, a dashboard újratöltődik...')
-    setTimeout(() => window.location.reload(), 30000)
-  } catch (err) {
-    showToast('Hiba: ' + (err.message || err))
+  const resetBtn = () => {
     btn.disabled = false
     btn.querySelector('.btn-text').hidden = false
     btn.querySelector('.btn-loading').hidden = true
+  }
+  try {
+    const res = await fetch('/api/updates/apply', { method: 'POST' })
+    // Parse the body regardless of status so preflight reasons
+    // (not-on-main / dirty-tree / detached-head returned as 409 by
+    // the backend) land in the toast instead of a bare "HTTP 409".
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      resetBtn()
+      showToast('Frissítés nem indult: ' + (data.error || ('HTTP ' + res.status)))
+      return
+    }
+    showToast('Frissítés elindult, a dashboard újratöltődik...')
+    setTimeout(() => window.location.reload(), 30000)
+  } catch (err) {
+    resetBtn()
+    showToast('Hiba: ' + (err.message || err))
   }
 })
 


### PR DESCRIPTION
## Why this matters

On every install where the operator has checked out a feature branch locally (for example while preparing the next PR set), the dashboard's **Frissítés most** button silently fails:

1. Frontend calls `POST /api/updates/apply`.
2. Backend spawns `update.sh` detached with `stdio: 'ignore'`.
3. Inside the script, `git pull --ff-only origin main` cannot fast-forward the current branch whose tip is not an ancestor of `origin/main` (every PR that got squash-merged upstream leaves the local feature branch in exactly that state).
4. `set -e` aborts the script before `stop.sh` / `start.sh` run.
5. The frontend already received `{ ok: true }` from the spawn, so it shows **"Frissítés elindult, a dashboard újratöltődik..."** and after 30 seconds reloads.
6. The page comes back on the **same pending-commit list** the operator just tried to clear. Pressing the button two or three more times produces the same outcome. There is no log file, no toast, no indication anything went wrong.

Same user-visible outcome applies if the working tree has uncommitted modifications: `git pull --ff-only` refuses, script exits, frontend lies.

Reproducible in three commands:

```
git checkout -b some-feature
git commit --allow-empty -m 'x'   # anything not on origin/main
# click "Frissítés most" -> 30s -> same pending commits
```

## Change

Two tiers of guard, a size-rotated log file, and a disk-based concurrency gate.

**New: `src/update-preflight.ts`** -- pure-logic module with two exported functions.

1. `checkUpdatePreflight(git: GitRunner)` returns a tagged union: ok, not-on-main (carries the actual branch), dirty-tree, detached-head. Priority: detached-HEAD > not-on-main > dirty-tree. The priority matters because the correct next step for a detached checkout is `git checkout main`, not "commit your changes on this branch".

2. `checkNoConcurrentUpdate(pf: PidfileRunner)` reads `store/update.pid` and decides if another run is in flight. The file format is `<pid>
<start-epoch-ms>
`. A pidfile pointing at a live process that was written less than `MAX_PIDFILE_AGE_MS` (1 hour) ago returns `already-running`; anything else (missing, empty, stale PID, pid <= 1, epoch older than an hour) returns ok so the button recovers automatically after an abnormal termination. The one-hour cap guards against PID recycling after a SIGKILL / power loss left the pidfile behind.

**New: `src/__tests__/update-preflight.test.ts`** -- **37 vitest cases** covering: preflight happy path / whitespace / detached HEAD / feature branches / dirty tree / priority ordering / result shape; pidfile liveness (missing / empty / stale / live / reserved pid); pidfile age staleness (fresh / past cutoff / boundary / legacy format); lock-errno classification (EEXIST vs EACCES / EROFS / ENOSPC / undefined / empty)

**`src/web.ts`** -- `/api/updates/apply` now:
- Atomically creates `store/update.pid` with `{ flag: 'wx' }` containing `<dashboard-pid>
<now>
`. On EEXIST, probes the existing file via `checkNoConcurrentUpdate`; if alive+fresh -> 409 `already-running`; if stale -> unlink and retry the exclusive create once.
- Runs the preflight. On failure -> release the lock, return 409 with `{ error, reason, branch? }`.
- Spawns update.sh. Attaches a `child.on('error', ...)` listener that logs the async failure and releases the lock, so a post-fork failure is visible instead of crashing the dashboard.
- Releases the lock on any exception path (preflight throw, spawn exception).
- `readFileSync` on the pidfile is gated behind a `statSync` size cap (256 bytes, regular-file only) so a symlink to `/dev/zero` or a multi-GiB file cannot DoS the endpoint.

**`update.sh`** -- defense-in-depth plus pidfile ownership.
- Branch / dirty-tree / detached-HEAD guards with actionable Hungarian error messages; exits 2 (non-main / detached), 3 (dirty), or 4 (unwritable log).
- Pre-touches the log file before the tee redirect to fail fast with a readable error if the filesystem is read-only / out of inodes.
- Tees stdout+stderr through `store/update.log` with 1 MiB size-based rotation to `.log.1`. No `wait` trap: tee flushes on EOF when the shell closes the pipe at exit.
- Overwrites the dashboard's pidfile placeholder with its own PID + start-epoch via atomic tmp+rename (handles GNU `date +%s%3N` and BSD seconds*1000 fallback). Trap EXIT cleans up both the final pidfile and the tmp file.

**`web/app.js`** -- the apply handler parses the response body whether or not the status is OK and surfaces the preflight reason in the toast (`"Frissítés nem indult: <message>"`) instead of pretending the update started.

## Scope / compatibility

- Happy path unchanged: on `main` with a clean tree and no active update, `/api/updates/apply` takes the lock, preflight returns ok, `spawn(update.sh)` runs exactly as before.
- No schema or API changes visible to other consumers. The 409 responses are new on a path that previously only returned 200.
- `/usr/bin/git` in the new preflight matches the existing `currentGitHead()` and `parseGitHubRemote()` helpers in the same file. Keeps the pattern consistent.

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npx vitest run` -- 115/115 passing including the 37 preflight cases (14 git + 9 pidfile liveness + 6 pidfile age + 6 lock-errno classification + 2 result-shape)
- [x] Live smoke on a feature branch: `bash update.sh` exits 2 with the Hungarian error, full output lands in `store/update.log`, pidfile created and removed.
- [x] Live smoke on the API: `POST /api/updates/apply` from a feature branch returns HTTP 409 with `reason: "not-on-main"` and releases the lock (pidfile removed).
- [x] Live smoke on concurrency: three parallel `POST /api/updates/apply` calls all return the same 409 reason, no pidfile leaked.
- [x] Live smoke on live-PID pidfile: an externally-planted `store/update.pid` with a live PID makes the endpoint return HTTP 409 `already-running` with the correct PID.
- [x] Live smoke on age staleness: a pidfile timestamped 2 hours in the past with a live PID is treated as stale and the endpoint falls through to preflight.
- [x] Log rotation: pre-populated a 1.1 MiB `update.log`, ran the script, confirmed the old file rotated to `update.log.1` and a fresh `update.log` was created.
- [x] Sensitive-data grep on the diff: zero matches for operator/user/agent/path identifiers.
- [x] Em-dash grep on the diff: zero `U+2014`.
- [x] Four rounds of adversarial review; last two rounds folded every actionable finding into the commit history.

## Known limitations

- **TOCTOU between preflight and spawn.** If someone checks out a feature branch or stages a change in the few milliseconds between the preflight read and `spawn(update.sh)`, the script's own guard catches it (exit 2/3 logged to `store/update.log`), but the frontend still shows "Frissítés elindult..." for 30 seconds before reloading. Closing this cleanly would need a status-polling endpoint; the in-script guard + log file covers the diagnostic gap without that.
- **Git binary path.** All three git helpers in this file hard-code `/usr/bin/git`; on Linux installs where git lives elsewhere the preflight would return 500. Worth a separate portability pass rather than introducing divergence here.
- **Async spawn 'error' event is logged only.** The endpoint has already returned `{ ok: true }` by the time a post-fork failure arrives; the error goes to the logger and releases the lock, but the browser still shows the "reload in 30s" path. Surfacing it to the UI needs a status-polling endpoint (same follow-up as the TOCTOU item).

## Part of the V3 series

Follows V3-1..V3-5 (trust-graph merges #24-#29). Independent of them -- touches only `/api/updates/apply`, `update.sh`, and the frontend handler. No dependency on other pending work.