### PR TITLE
connectors: show every active MCP and detect installed state correctly

### DIFF
--- a/src/__tests__/mcp-list-parser.test.ts
+++ b/src/__tests__/mcp-list-parser.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseMcpListLine,
+  parseMcpList,
+  applyRefreshOutcome,
+  scrubPaths,
+  type McpListEntry,
+} from '../mcp-list-parser.js'
+
+describe('parseMcpListLine -- guard rails', () => {
+  it('returns null for an empty line', () => {
+    expect(parseMcpListLine('')).toBeNull()
+  })
+
+  it('returns null for whitespace-only', () => {
+    expect(parseMcpListLine('   \t  ')).toBeNull()
+  })
+
+  it('returns null for the "Checking MCP server health..." banner', () => {
+    expect(parseMcpListLine('Checking MCP server health...')).toBeNull()
+    expect(parseMcpListLine('Checking MCP server health…')).toBeNull()
+  })
+
+  it('returns null when the colon separator is missing', () => {
+    expect(parseMcpListLine('not a valid line at all')).toBeNull()
+  })
+
+  it('returns null when the status separator is missing', () => {
+    expect(parseMcpListLine('name: endpoint only')).toBeNull()
+  })
+})
+
+describe('parseMcpListLine -- claude.ai connectors', () => {
+  it('parses a Gmail connector with slug normalisation', () => {
+    const result = parseMcpListLine('claude.ai Gmail: https://gmailmcp.googleapis.com/mcp/v1 - Connected')
+    expect(result).not.toBeNull()
+    expect(result?.source).toBe('claude.ai')
+    expect(result?.name).toBe('claude.ai Gmail')
+    expect(result?.normalizedId).toBe('gmail')
+    expect(result?.endpoint).toBe('https://gmailmcp.googleapis.com/mcp/v1')
+    expect(result?.status).toBe('connected')
+  })
+
+  it('slugifies a two-word connector name', () => {
+    const result = parseMcpListLine(
+      'claude.ai Google Calendar: https://calendarmcp.googleapis.com/mcp/v1 - Connected',
+    )
+    expect(result?.normalizedId).toBe('google-calendar')
+  })
+
+  it('handles multiple spaces between words in the name', () => {
+    const result = parseMcpListLine(
+      'claude.ai Google   Drive: https://example.com/mcp - Connected',
+    )
+    expect(result?.normalizedId).toBe('google-drive')
+  })
+
+  it('parses a needs-auth status', () => {
+    const result = parseMcpListLine(
+      'claude.ai PostHog: https://mcp.posthog.com/mcp - ! Needs authentication',
+    )
+    expect(result?.status).toBe('needs_auth')
+  })
+
+  it('parses a failed status', () => {
+    const result = parseMcpListLine(
+      'claude.ai Broken: https://example.com - Failed to connect',
+    )
+    expect(result?.status).toBe('failed')
+  })
+
+  it('preserves URLs containing colons in the endpoint', () => {
+    const result = parseMcpListLine(
+      'claude.ai n8n: https://example.app.n8n.cloud/mcp-server/http - ! Needs authentication',
+    )
+    expect(result?.endpoint).toBe('https://example.app.n8n.cloud/mcp-server/http')
+  })
+})
+
+describe('parseMcpListLine -- plugin entries', () => {
+  it('parses a plugin:package:name entry to the trailing slug', () => {
+    const result = parseMcpListLine(
+      'plugin:telegram:telegram: bun run --cwd /path ... - Connected',
+    )
+    expect(result?.source).toBe('plugin')
+    expect(result?.normalizedId).toBe('telegram')
+  })
+
+  it('handles a plugin entry with distinct package and server slugs', () => {
+    const result = parseMcpListLine(
+      'plugin:acme-bundle:my-server: node /path/server.js - Connected',
+    )
+    expect(result?.source).toBe('plugin')
+    expect(result?.normalizedId).toBe('my-server')
+  })
+
+  it('uses the last colon-separated segment for a two-part plugin name', () => {
+    // "plugin:telegram" only has one segment after the prefix. Take the
+    // last segment ("telegram") as the id; it lines up with the canonical
+    // three-part form "plugin:telegram:telegram" that the CLI actually
+    // emits.
+    const result = parseMcpListLine(
+      'plugin:telegram: some-endpoint - Connected',
+    )
+    expect(result?.source).toBe('plugin')
+    expect(result?.normalizedId).toBe('telegram')
+  })
+})
+
+describe('parseMcpListLine -- local entries', () => {
+  it('parses a plain local server name', () => {
+    const result = parseMcpListLine('my-local-fs: /usr/local/bin/mcp-fs - Connected')
+    expect(result?.source).toBe('local')
+    expect(result?.normalizedId).toBe('my-local-fs')
+  })
+
+  it('slugifies a local name with whitespace', () => {
+    const result = parseMcpListLine('My Local Server: node /x - Connected')
+    expect(result?.source).toBe('local')
+    expect(result?.normalizedId).toBe('my-local-server')
+  })
+
+  it('treats a "claude.ai" prefix case-insensitively', () => {
+    // CLI output is lowercase in practice, but a capitalised variant
+    // should still route to claude.ai source rather than being treated
+    // as a weird local name with a dot in it.
+    const result = parseMcpListLine('Claude.ai Gmail: endpoint - Connected')
+    expect(result?.source).toBe('claude.ai')
+    expect(result?.normalizedId).toBe('gmail')
+  })
+})
+
+describe('parseMcpListLine -- slug normalisation', () => {
+  it('strips parentheses and dots from the name', () => {
+    // Defensive case: if the CLI ever reports "claude.ai foo.bar (beta)"
+    // we should still produce a catalog-matchable slug.
+    const result = parseMcpListLine('claude.ai foo.bar (beta): endpoint - Connected')
+    expect(result?.normalizedId).toBe('foo-bar-beta')
+  })
+
+  it('collapses multiple non-alphanumeric runs into a single hyphen', () => {
+    const result = parseMcpListLine('claude.ai A / B / C: endpoint - Connected')
+    expect(result?.normalizedId).toBe('a-b-c')
+  })
+
+  it('trims leading and trailing hyphens after stripping', () => {
+    const result = parseMcpListLine('claude.ai ...Name...: endpoint - Connected')
+    expect(result?.normalizedId).toBe('name')
+  })
+})
+
+describe('parseMcpList -- full output', () => {
+  it('parses a realistic multi-line output and skips the banner', () => {
+    const output = [
+      'Checking MCP server health...',
+      '',
+      'claude.ai Gmail: https://gmailmcp.googleapis.com/mcp/v1 - Connected',
+      'claude.ai Google Calendar: https://calendarmcp.googleapis.com/mcp/v1 - Connected',
+      'plugin:telegram:telegram: bun run /path - Connected',
+      'my-local: node /tmp/x - Failed to connect',
+      '',
+    ].join('\n')
+    const result = parseMcpList(output)
+    expect(result).toHaveLength(4)
+    expect(result.map(r => r.normalizedId)).toEqual(['gmail', 'google-calendar', 'telegram', 'my-local'])
+    expect(result.map(r => r.source)).toEqual(['claude.ai', 'claude.ai', 'plugin', 'local'])
+  })
+
+  it('returns an empty array for a banner-only output', () => {
+    expect(parseMcpList('Checking MCP server health...\n\n')).toEqual([])
+  })
+
+  it('returns an empty array for an entirely empty output', () => {
+    expect(parseMcpList('')).toEqual([])
+  })
+})
+
+describe('applyRefreshOutcome -- cache update rules', () => {
+  const SAMPLE: McpListEntry = {
+    name: 'claude.ai Gmail',
+    normalizedId: 'gmail',
+    endpoint: 'https://gmailmcp.googleapis.com/mcp/v1',
+    status: 'connected',
+    source: 'claude.ai',
+  }
+  const sampleOutput =
+    'Checking MCP server health...\n' +
+    'claude.ai Gmail: https://gmailmcp.googleapis.com/mcp/v1 - Connected\n'
+
+  it('returns parsed entries on clean exit with output', () => {
+    const result = applyRefreshOutcome({
+      stdout: sampleOutput,
+      execError: null,
+      previousEntries: [],
+    })
+    expect(result.entries).toHaveLength(1)
+    expect(result.error).toBeUndefined()
+    expect(result.retainedStale).toBe(false)
+  })
+
+  it('returns parsed entries even when exit is non-zero', () => {
+    // The CLI returns exit 1 when any one server fails its health check.
+    // As long as the stdout parses into entries, the dashboard treats
+    // that as success -- the list is what the UI cares about.
+    const result = applyRefreshOutcome({
+      stdout: sampleOutput,
+      execError: new Error('exit 1'),
+      previousEntries: [],
+    })
+    expect(result.entries).toHaveLength(1)
+    expect(result.error).toBeUndefined()
+    expect(result.retainedStale).toBe(false)
+  })
+
+  it('retains previous entries when stdout is empty and exec failed', () => {
+    const prev = [SAMPLE]
+    const result = applyRefreshOutcome({
+      stdout: '',
+      execError: new Error('ENOENT: claude not found'),
+      previousEntries: prev,
+    })
+    expect(result.entries).toBe(prev)
+    expect(result.error).toBe('ENOENT: claude not found')
+    expect(result.retainedStale).toBe(true)
+  })
+
+  it('retains empty list when previous was empty and exec failed', () => {
+    const result = applyRefreshOutcome({
+      stdout: '',
+      execError: new Error('timeout'),
+      previousEntries: [],
+    })
+    expect(result.entries).toEqual([])
+    expect(result.error).toBe('timeout')
+    // retainedStale reflects whether we held back real entries, not
+    // whether we failed -- empty+empty is a failure with nothing to hold.
+    expect(result.retainedStale).toBe(false)
+  })
+
+  it('returns empty list with no error on clean exit + banner-only output', () => {
+    // The user genuinely has no MCPs configured.
+    const result = applyRefreshOutcome({
+      stdout: 'Checking MCP server health...\n\n',
+      execError: null,
+      previousEntries: [SAMPLE],
+    })
+    expect(result.entries).toEqual([])
+    expect(result.error).toBeUndefined()
+    expect(result.retainedStale).toBe(false)
+  })
+})
+
+describe('scrubPaths -- sensitive-path removal', () => {
+  const HOME = '/Users/testuser'
+
+  it('returns empty input unchanged', () => {
+    expect(scrubPaths('', HOME)).toBe('')
+  })
+
+  it('collapses a path under the caller homedir to <path>/<basename>', () => {
+    // Round-13 behaviour change: known-root paths always collapse to
+    // <path>/<basename>, regardless of whether they match the caller's
+    // homedir. The earlier "~/..." shape would have kept the middle
+    // segments, but lost no more identity either. The collapsed form
+    // is simpler and consistent with how foreign-user paths render.
+    expect(scrubPaths('spawn /Users/testuser/.bun/bin/claude ENOENT', HOME))
+      .toBe('spawn <path>/claude ENOENT')
+  })
+
+  it('collapses a /Users path that is NOT the current homedir', () => {
+    // Another user on a shared host must not leak through.
+    const result = scrubPaths('Cannot find /Users/otheruser/config.json', HOME)
+    expect(result).toContain('<path>/config.json')
+    expect(result).not.toContain('otheruser')
+  })
+
+  it('collapses a /home (linux) path', () => {
+    const result = scrubPaths('ENOENT /home/bob/.cache/claude', HOME)
+    expect(result).toContain('<path>/claude')
+    expect(result).not.toContain('bob')
+  })
+
+  it('collapses a /tmp path', () => {
+    const result = scrubPaths('tmp: /tmp/mcp-list-abc123/ok', HOME)
+    expect(result).toContain('<path>/ok')
+  })
+
+  it('leaves simple messages without paths unchanged', () => {
+    expect(scrubPaths('exit 1', HOME)).toBe('exit 1')
+    expect(scrubPaths('timeout after 30s', HOME)).toBe('timeout after 30s')
+  })
+
+  it('handles repeated occurrences of the homedir', () => {
+    // Both occurrences collapse via the path-scrub regex (known root
+    // + trail). Homedir replace never gets to fire here, which is
+    // the intended round-13 behaviour.
+    const result = scrubPaths('/Users/testuser/a and /Users/testuser/b', HOME)
+    expect(result).toBe('<path>/a and <path>/b')
+  })
+
+  it('handles empty homedir gracefully (no replacement, raw path still scrubbed)', () => {
+    const result = scrubPaths('ENOENT /Users/foo/x', '')
+    expect(result).toContain('<path>/x')
+  })
+
+  it('handles homedir === / gracefully (no-op on homedir step)', () => {
+    // If homedir resolves to "/", split().join() would produce a
+    // nonsense result; the guard should skip the homedir step entirely.
+    const result = scrubPaths('spawn /Users/foo/claude ENOENT', '/')
+    expect(result).toContain('<path>/claude')
+    expect(result).not.toContain('/Users/foo')
+  })
+
+  it('scrubs quoted absolute paths (fs ENOENT shape)', () => {
+    // Realistic fs error format: "... open '/Users/foo/x.json'".
+    const result = scrubPaths(
+      "ENOENT: no such file or directory, open '/Users/foo/x.json'",
+      HOME,
+    )
+    expect(result).toContain('<path>/x.json')
+    expect(result).not.toContain('/Users/foo')
+  })
+
+  it('scrubs parenthesised absolute paths', () => {
+    const result = scrubPaths('(/Users/foo/config.json) failed', HOME)
+    expect(result).toContain('<path>/config.json')
+    expect(result).not.toContain('/Users/foo')
+  })
+
+  it('scrubs a /root path (root-user home)', () => {
+    const result = scrubPaths('ENOENT /root/.claude/config', HOME)
+    expect(result).toContain('<path>/config')
+    expect(result).not.toContain('/root/')
+  })
+
+  it('drops the basename when it IS the username (bare /Users/foo)', () => {
+    // Regression: earlier version returned "<path>/foo" which kept the
+    // exact identifier the scrub was supposed to hide. With two or fewer
+    // segments under a known root the basename is the user, so drop it.
+    const result = scrubPaths('ENOENT /Users/someuser', HOME)
+    expect(result).toContain('<path>')
+    expect(result).not.toContain('someuser')
+  })
+
+  it('drops the basename for bare /home/<user>', () => {
+    const result = scrubPaths('EACCES /home/bob', HOME)
+    expect(result).toContain('<path>')
+    expect(result).not.toContain('/bob')
+  })
+
+  it('handles a bare /root with no trailing path', () => {
+    const result = scrubPaths('ENOENT /root', HOME)
+    expect(result).toContain('<path>')
+    expect(result).not.toContain('/root')
+  })
+
+  it('keeps the basename when there are two or more segments past the root', () => {
+    // "/Users/foo/config.json" -- 'foo' is still the username but
+    // 'config.json' is the useful piece, so the path collapses to
+    // "<path>/config.json".
+    const result = scrubPaths('ENOENT /Users/someuser/config.json', HOME)
+    expect(result).toContain('<path>/config.json')
+    expect(result).not.toContain('someuser')
+  })
+
+  it('scrubs paths whose user shares a prefix with the caller homedir', () => {
+    // Round-13 regression: earlier substring-replace turned
+    // "/Users/bobsmith/secret.json" with HOME=/Users/bob into
+    // "~smith/secret.json", leaking the suffix. The path-scrub
+    // regex now runs BEFORE the homedir replace, so /Users/bobsmith
+    // gets normalised regardless.
+    const result = scrubPaths('ENOENT /Users/bobsmith/secret.json', '/Users/bob')
+    expect(result).toContain('<path>/secret.json')
+    expect(result).not.toContain('bobsmith')
+    expect(result).not.toContain('smith')
+  })
+
+  it('scrubs a path with a double slash prefix', () => {
+    // "//Users/foo/x" arose from naive path joins in the wild. The
+    // regex must still catch it rather than let the extra slash
+    // disable the match.
+    const result = scrubPaths('stat //Users/foo/secret.txt', HOME)
+    expect(result).toContain('<path>/secret.txt')
+    expect(result).not.toContain('/Users/foo')
+  })
+
+  it('scrubs a path preceded by a hyphen / underscore / dot', () => {
+    // Shell / log glue: "--flag=/Users/foo/x", "config./Users/foo/x",
+    // "var_/Users/foo/x". All should still be scrubbed.
+    expect(scrubPaths('--flag=/Users/foo/x', HOME)).toContain('<path>/x')
+    expect(scrubPaths('config./Users/foo/x', HOME)).toContain('<path>/x')
+    expect(scrubPaths('var_/Users/foo/x', HOME)).toContain('<path>/x')
+    expect(scrubPaths('--flag=/Users/foo/x', HOME)).not.toContain('/foo')
+  })
+
+  it('collapses a path that starts with a tilde (post-replace form, unlikely input)', () => {
+    // Not a realistic input -- just confirming the regex does not
+    // re-match after '~' because '~' is in the prefix-char exclusion.
+    const result = scrubPaths('spawn ~/.bun/bin/claude ENOENT', HOME)
+    expect(result).toBe('spawn ~/.bun/bin/claude ENOENT')
+  })
+
+  it('replaces exact-boundary homedir outside the known roots', () => {
+    // Custom NFS layout: homedir not under /Users or /home.
+    const result = scrubPaths('ENOENT /mnt/nfs/alice/config.json', '/mnt/nfs/alice')
+    expect(result).toBe('ENOENT ~/config.json')
+  })
+
+  it('does NOT match a root-keyword prefix inside a longer dirname', () => {
+    // Regression: `/homes/alice/secret.json` must not collapse to
+    // `<path>s/alice/secret.json` -- the leading-match bug that led
+    // to the root-alternative lookahead.
+    expect(scrubPaths('ENOENT /homes/alice/secret.json', HOME))
+      .toBe('ENOENT /homes/alice/secret.json')
+    expect(scrubPaths('stat /Users-backup/bob/x', HOME))
+      .toBe('stat /Users-backup/bob/x')
+    expect(scrubPaths('EACCES /opts-archive/sam/y', HOME))
+      .toBe('EACCES /opts-archive/sam/y')
+    expect(scrubPaths('ENOENT /rooted/ada/z', HOME))
+      .toBe('ENOENT /rooted/ada/z')
+    expect(scrubPaths('cache /tmpfs/x/y', HOME))
+      .toBe('cache /tmpfs/x/y')
+  })
+
+  it('still scrubs the exact root keyword followed by a slash or boundary', () => {
+    // The lookahead must NOT block legitimate root matches.
+    expect(scrubPaths('ENOENT /Users/foo/x', HOME)).toContain('<path>/x')
+    expect(scrubPaths('ENOENT /home/bob/cfg', HOME)).toContain('<path>/cfg')
+    expect(scrubPaths('ENOENT /opt/app/bin', HOME)).toContain('<path>/bin')
+    expect(scrubPaths('ENOENT /tmp/mcp/x', HOME)).toContain('<path>/x')
+    // Bare root keyword at end of string:
+    expect(scrubPaths('ENOENT /Users', HOME)).toBe('ENOENT <path>')
+    expect(scrubPaths('ENOENT /tmp.log', HOME)).toBe('ENOENT /tmp.log')
+  })
+
+  it('does not extend the homedir replace past a shared-prefix username', () => {
+    // Step 1 catches any /Users/... already. Step 2 (homedir replace)
+    // only fires for custom homedirs outside known roots. Regression
+    // guard: /mnt/nfs/alicesmith with HOME=/mnt/nfs/alice must not
+    // become "~smith/...".
+    const result = scrubPaths('ENOENT /mnt/nfs/alicesmith/x', '/mnt/nfs/alice')
+    // The path is under neither Users/home nor the exact homedir, so
+    // it stays (there is no known-roots match and no boundary-aware
+    // homedir hit). That is intentional: at least the username is
+    // NOT conflated with the caller's.
+    expect(result).not.toContain('~smith')
+    expect(result).not.toContain('~/')
+  })
+})

--- a/src/mcp-list-parser.ts
+++ b/src/mcp-list-parser.ts
@@ -1,0 +1,253 @@
+// Parse a single line of `claude mcp list` output into a structured entry.
+//
+// The CLI prints one line per registered MCP server, shaped like:
+//
+//   claude.ai Gmail: https://gmailmcp.googleapis.com/mcp/v1 - Connected
+//   plugin:telegram:telegram: bun run --cwd /path ... - Connected
+//   my-local-server: node /path/to/server.js - ! Needs authentication
+//
+// The name portion carries a source prefix that the dashboard's
+// state-detection needs to normalise:
+//
+//   "claude.ai <Name>"      --> source='claude.ai', id=slug(<Name>)
+//   "plugin:<pkg>:<slug>"   --> source='plugin',    id=<slug>
+//   "<name>"                --> source='local',     id=slug(<name>)
+//
+// Normalisation strips the prefix, lowercases, and replaces runs of
+// whitespace with a single hyphen so the id lines up with catalog
+// entries whose `id` field is already slug-form ("gmail", "google-drive").
+
+export type McpListSource = 'claude.ai' | 'plugin' | 'local'
+export type McpListStatus = 'connected' | 'needs_auth' | 'failed' | 'unknown'
+
+export interface McpListEntry {
+  // Raw display name as printed by the CLI, e.g. "claude.ai Gmail".
+  name: string
+  // Slug used for matching against mcp-catalog.json ids, e.g. "gmail".
+  normalizedId: string
+  // Raw endpoint / command column from the CLI, for display only.
+  endpoint: string
+  status: McpListStatus
+  source: McpListSource
+}
+
+// Status line suffix -> canonical status. The CLI format lives in the
+// Claude Code repo and may gain variants; keep the mapping here so a
+// single edit handles a future rename.
+function parseStatus(raw: string): McpListStatus {
+  const lower = raw.toLowerCase()
+  if (lower.includes('connected')) return 'connected'
+  if (lower.includes('needs authentication')) return 'needs_auth'
+  if (lower.includes('failed')) return 'failed'
+  return 'unknown'
+}
+
+export function slugify(raw: string): string {
+  // Defensive normalisation. Catalog ids are already plain
+  // [a-z0-9-]+, so this is a best-effort mapping for CLI names that
+  // could contain dots, parens, or slashes ("Google (beta)",
+  // "foo.bar"). Runs of non-alphanumerics collapse into a single
+  // hyphen, and leading/trailing hyphens are trimmed so the slug
+  // stays readable for the dashboard.
+  return raw
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function classifyName(raw: string): { source: McpListSource; normalizedId: string } {
+  const trimmed = raw.trim()
+  // "plugin:<package>:<name>" -- the trailing segment is the actual
+  // MCP id as it appears in enabledPlugins. `plugin:telegram:telegram`
+  // collapses to `telegram`; `plugin:foo-bar:my-server` collapses to
+  // `my-server`. If the input is malformed and has fewer than three
+  // segments, fall back to the last segment we do have.
+  if (trimmed.toLowerCase().startsWith('plugin:')) {
+    const segments = trimmed.split(':')
+    const last = segments[segments.length - 1] || trimmed
+    return { source: 'plugin', normalizedId: slugify(last) }
+  }
+  // "claude.ai <Name>" -- case-insensitive prefix, single space.
+  // Anything after the prefix is the human label ("Google Calendar",
+  // "Gmail", etc.) and needs full slug normalisation to line up with
+  // catalog ids ("google-calendar", "gmail").
+  const CLAUDE_AI_PREFIX = /^claude\.ai\s+/i
+  if (CLAUDE_AI_PREFIX.test(trimmed)) {
+    const tail = trimmed.replace(CLAUDE_AI_PREFIX, '')
+    return { source: 'claude.ai', normalizedId: slugify(tail) }
+  }
+  // Plain local-user / project entry.
+  return { source: 'local', normalizedId: slugify(trimmed) }
+}
+
+export function parseMcpListLine(line: string): McpListEntry | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+  // The CLI prints a leading "Checking MCP server health..." banner plus
+  // occasional blank lines. Skip anything that is not a "name: endpoint - status"
+  // triple; relying on the two separator tokens avoids having to enumerate
+  // every banner variant the CLI may introduce.
+  if (trimmed.startsWith('Checking')) return null
+
+  // Shape: "<name>: <endpoint> - <status>". The name itself can contain
+  // colons (e.g. "plugin:telegram:telegram"), so anchor on the first
+  // ": " (colon + space) rather than the first ":" alone -- that
+  // separator is stable because the CLI always prints one space after
+  // the name's terminating colon. The endpoint may contain URL colons
+  // (https://host:443/...) but rarely " - ", so the status split uses
+  // lastIndexOf(' - ') to be safe against command-line endpoints that
+  // happen to include dashes in flags.
+  const firstSep = trimmed.indexOf(': ')
+  if (firstSep <= 0) return null
+  const lastSep = trimmed.lastIndexOf(' - ')
+  if (lastSep <= firstSep) return null
+
+  const rawName = trimmed.slice(0, firstSep).trim()
+  const endpoint = trimmed.slice(firstSep + 2, lastSep).trim()
+  const statusRaw = trimmed.slice(lastSep + 3).trim()
+
+  if (!rawName || !endpoint || !statusRaw) return null
+
+  const { source, normalizedId } = classifyName(rawName)
+  if (!normalizedId) return null
+
+  return {
+    name: rawName,
+    normalizedId,
+    endpoint,
+    status: parseStatus(statusRaw),
+    source,
+  }
+}
+
+// Parse the full CLI output and drop any lines that are not valid
+// entries. Exposed separately so the caller can feed us either the
+// raw string or pre-split lines without having to re-scan the banner.
+export function parseMcpList(output: string): McpListEntry[] {
+  const entries: McpListEntry[] = []
+  for (const line of output.split('\n')) {
+    const parsed = parseMcpListLine(line)
+    if (parsed) entries.push(parsed)
+  }
+  return entries
+}
+
+// Decide the outcome of a single cache refresh attempt. Pure logic so the
+// caller can unit-test the three intertwined rules:
+//
+//   1. parseable output + zero exit             -> update entries, no error
+//   2. parseable output + non-zero exit         -> update entries, no error
+//      (a connector failing its health check is the CLI's steady state)
+//   3. no parseable output + either exit        -> keep previous entries,
+//      surface the error so the UI can show a stale-data banner
+export interface RefreshInput {
+  // stdout of `claude mcp list`, possibly empty.
+  stdout: string
+  // Non-null if the child exited non-zero, timed out, or failed to launch.
+  execError: Error | null
+  // Entries that were in the cache before this refresh ran.
+  previousEntries: McpListEntry[]
+}
+
+export interface RefreshOutcome {
+  entries: McpListEntry[]
+  error: string | undefined
+  // True when the previous cache entries were retained because the
+  // current run produced nothing usable.
+  retainedStale: boolean
+}
+
+// Scrub absolute user paths out of error messages before the dashboard
+// stores them. An ENOENT from `spawn` carries the full attempted
+// binary path; fs errors ("ENOENT: no such file or directory, open
+// '/Users/...'") arrive with the path inside quotes. This helper
+// replaces a caller-supplied homedir with "~" and collapses any
+// still-absolute path under the standard Unix roots into a
+// "<path>/<basename>" sentinel.
+//
+// The homedir argument is explicit so this module stays free of node
+// process side effects; callers pass os.homedir().
+//
+// Scope: darwin + Linux error shapes. Windows-style drive paths
+// (C:\\Users\\...) are NOT scrubbed; Windows is not a supported
+// deployment target for this dashboard today.
+//
+// Prefix class accepts anything that is NOT a path character, so
+// quoted (' ... '), parenthesised ((...)), or bracketed forms all
+// match. Root alternatives cover Users, home, root, private/var,
+// var, opt, tmp -- the common Unix roots under which an error
+// message's path could start.
+// Trailing group is optional so bare roots ("/root", "/Users") also
+// match and can be reduced to a placeholder. The root-match alternation
+// uses a captured group so the post-processing step can tell whether
+// it saw "/Users/foo" (the single segment is the username, must drop)
+// versus "/Users/foo/config.json" (the basename is safe to keep).
+//
+// Prefix class excludes ONLY alphanumerics and tilde. That is loose on
+// purpose: characters like `-`, `_`, `.`, `/` are common in log glue
+// (e.g. "--flag=/Users/foo/x", "config./Users/foo/x",
+// "//Users/foo/x" double-slash artefacts). Excluding only alpha+tilde
+// means a path at any of those boundaries still matches. The tilde
+// guard prevents re-matching a path that step 2 already turned into
+// "~/..." form.
+// Trailing lookahead `(?=\/|[\s:'")\]}]|$)` after the root alternative
+// is critical: without it `/homes/alice/secret.json` matches `/home`
+// (prefix of the root keyword), collapses just the prefix, and leaks
+// `s/alice/secret.json` through the residue. The lookahead requires
+// the root token to END cleanly (slash, whitespace-class char, or
+// end-of-string), so `/homes`, `/Users-backup`, `/opts-archive`,
+// `/tmpfs`, `/rooted` do NOT trigger a partial scrub.
+const PATH_SCRUB_RX = /(^|[^A-Za-z0-9~])\/(Users|home|root|private\/var|var|opt|tmp)(?=\/|[\s:'")\]}]|$)((?:\/[^\s:'")\]}]*)?)/g
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function scrubPaths(msg: string, homeDir: string): string {
+  if (!msg) return msg
+  // Step 1 FIRST: scrub any absolute path under a known root (Users,
+  // home, root, private/var, var, opt, tmp). This catches every foreign
+  // homedir that happens to share a string prefix with the caller's own
+  // (e.g. /Users/bobsmith when HOME=/Users/bob -- a naive substring
+  // replace would leave "smith/secret" behind). The path-scrub fires
+  // regardless of whether the path's user equals the caller's.
+  let out = msg.replace(PATH_SCRUB_RX, (_match, prefix: string, _rootName: string, trail: string) => {
+    // trail = '' / '/foo' / '/foo/x.json'. A zero- or one-segment trail
+    // means the basename itself is the user / tmpdir id -- drop it so
+    // the output carries nothing identifying.
+    const segments = trail.split('/').filter(Boolean)
+    if (segments.length < 2) return prefix + '<path>'
+    return prefix + '<path>/' + segments[segments.length - 1]
+  })
+  // Step 2: replace the caller's homedir with "~" for any remaining
+  // occurrences (homedirs OUTSIDE the known roots -- custom NFS mounts,
+  // /opt/name, etc.). Anchor the replace to a path boundary so
+  // /Users/bob does not swallow the 'smith' suffix of /Users/bobsmith
+  // if that somehow slipped past step 1.
+  if (homeDir && homeDir !== '/') {
+    const rx = new RegExp(escapeRegex(homeDir) + `(?=[/\\s:'")\\]}]|$)`, 'g')
+    out = out.replace(rx, '~')
+  }
+  return out
+}
+
+export function applyRefreshOutcome(input: RefreshInput): RefreshOutcome {
+  const parsed = parseMcpList(input.stdout)
+  if (parsed.length > 0) {
+    // Whether exit was 0 or not, we have data. Only parse-time problems
+    // should block a cache update.
+    return { entries: parsed, error: undefined, retainedStale: false }
+  }
+  if (input.execError) {
+    // Nothing to parse AND the CLI reported failure. Preserve the
+    // previous entries so a transient error does not wipe the UI.
+    return {
+      entries: input.previousEntries,
+      error: input.execError.message,
+      retainedStale: input.previousEntries.length > 0,
+    }
+  }
+  // Clean exit with an empty list: the user genuinely has no MCPs.
+  return { entries: [], error: undefined, retainedStale: false }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,9 +1,9 @@
 import http from 'node:http'
-import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, mkdirSync, rmSync, statSync, lstatSync, copyFileSync, renameSync, chmodSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, mkdirSync, mkdtempSync, rmSync, statSync, lstatSync, copyFileSync, renameSync, chmodSync } from 'node:fs'
 import { join, extname, resolve, sep } from 'node:path'
-import { homedir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { randomUUID, randomBytes, timingSafeEqual } from 'node:crypto'
-import { spawn, execSync, execFileSync, type ChildProcess } from 'node:child_process'
+import { spawn, execSync, execFileSync, execFile, type ChildProcess } from 'node:child_process'
 import { CronExpressionParser } from 'cron-parser'
 import { PROJECT_ROOT, OLLAMA_URL, WEB_HOST } from './config.js'
 import { resolveFromPath } from './platform.js'
@@ -33,6 +33,17 @@ import {
   sanitizeAgentIdent,
 } from './prompt-safety.js'
 import { isTrustedPeer } from './team-trust.js'
+import {
+  applyRefreshOutcome,
+  scrubPaths as scrubPathsBase,
+  slugify as slugifyMcp,
+  type McpListEntry,
+} from './mcp-list-parser.js'
+
+// Pre-bound homedir so callers do not have to pass it every time.
+function scrubPaths(msg: string): string {
+  return scrubPathsBase(msg, homedir())
+}
 
 function computeNextRun(cronExpression: string): number {
   const expr = CronExpressionParser.parse(cronExpression)
@@ -1898,6 +1909,166 @@ function startUpdateChecker(): NodeJS.Timeout {
   return setInterval(() => { refreshUpdateStatus().catch(() => {}) }, 15 * 60_000)
 }
 
+// === MCP list cache ===========================================================
+//
+// The dashboard needs to know what `claude mcp list` reports so the Connected
+// tab can show claude.ai OAuth connectors (which have no file-based config
+// locally) and the Gallery can mark already-enabled items as installed instead
+// of letting the user duplicate them. Shelling out to `claude mcp list` spawns
+// every stdio / plugin MCP for a health check, which collides with the live
+// Telegram bot's single-poller requirement and can produce 409 Conflict
+// errors. Running it on every request is therefore off the table.
+//
+// Compromise: refresh the cache once at startup (30s delayed so the main
+// channels session settles first), and otherwise only on explicit
+// POST /api/mcp/refresh calls. No periodic auto-refresh.
+//
+// On refresh failure, keep the previous (stale) entries so a transient CLI
+// error does not blank out the UI. Callers can distinguish fresh / stale via
+// lastRefreshed and error fields.
+
+interface McpListCache {
+  entries: McpListEntry[]
+  lastRefreshed: number
+  refreshing: boolean
+  error?: string
+}
+
+let mcpListCache: McpListCache = {
+  entries: [],
+  lastRefreshed: 0,
+  refreshing: false,
+}
+
+// Declared ahead of refreshMcpListCache so the function body's reference
+// is past the TDZ even if a future caller reaches it earlier in module
+// initialisation (e.g. during import-time side effects).
+let inflightRefresh: Promise<McpListCache> | null = null
+
+// Private working directory for `claude mcp list`. Running from /tmp
+// directly was tempting (no project-local .mcp.json to spawn), but on
+// multi-user hosts any user with write access to /tmp can plant a
+// .mcp.json there and poison the list the dashboard builds. A dashboard-
+// owned temp dir has 0700 permissions and is immune to that. Created
+// lazily so a failure here does not crash boot.
+let mcpListWorkingDir: string | null = null
+function getMcpListWorkingDir(): string {
+  if (mcpListWorkingDir && existsSync(mcpListWorkingDir)) return mcpListWorkingDir
+  mcpListWorkingDir = mkdtempSync(join(tmpdir(), 'marveen-mcp-list-'))
+  return mcpListWorkingDir
+}
+
+// Cleanup on process shutdown so long-running hosts don't accumulate
+// empty 0700 dirs across restarts. Only hook 'exit' (always fires, no
+// matter how the process terminates except SIGKILL). Handling SIGTERM
+// / SIGINT separately would race the index.ts shutdown listener, which
+// calls process.exit(0) and may prevent our cleanup from running.
+const cleanupMcpListWorkingDir = () => {
+  if (!mcpListWorkingDir) return
+  try { rmSync(mcpListWorkingDir, { recursive: true, force: true }) } catch { /* best effort */ }
+  mcpListWorkingDir = null
+}
+process.once('exit', cleanupMcpListWorkingDir)
+
+
+function refreshMcpListCache(): Promise<McpListCache> {
+  // If a refresh is already in flight, return the same promise so every
+  // concurrent caller ends up with identical (fresh) cache state without
+  // spawning `claude mcp list` more than once per burst.
+  if (inflightRefresh) return inflightRefresh
+  inflightRefresh = (async () => {
+    mcpListCache.refreshing = true
+    const previousCount = mcpListCache.entries.length
+    try {
+      // Async exec so the event loop keeps serving other HTTP requests
+      // while `claude mcp list` runs (up to 30s if a plugin's health
+      // check is slow). Run from /tmp so no project-local .mcp.json
+      // gets picked up; the global enabledPlugins list is scanned
+      // regardless of cwd. maxBuffer is bumped to 10 MiB so a verbose
+      // status output with auth warnings cannot blow up with ENOBUFS.
+      const { stdout, stderr, execError } = await new Promise<{
+        stdout: string
+        stderr: string
+        execError: Error | null
+      }>((resolve, reject) => {
+        execFile(CLAUDE, ['mcp', 'list'], {
+          cwd: getMcpListWorkingDir(),
+          timeout: 30_000,
+          encoding: 'utf-8',
+          maxBuffer: 10 * 1024 * 1024,
+        }, (err, stdoutStr, stderrStr) => {
+          // A non-zero exit is not fatal on its own: `claude mcp list`
+          // can exit with code 1 when any one of the configured servers
+          // fails its health check (a realistic steady state when e.g.
+          // an OAuth token has lapsed). The stdout still carries the
+          // full list in that case, so try to parse it before giving
+          // up. We only reject when there is nothing usable at all
+          // (launch failure, timeout without output, SIGKILL).
+          if (err && !stdoutStr) {
+            reject(err)
+            return
+          }
+          resolve({ stdout: stdoutStr ?? '', stderr: stderrStr ?? '', execError: err ?? null })
+        })
+      })
+      const stderrTrimmed = stderr ? stderr.trim() : ''
+      if (stderrTrimmed) {
+        logger.debug({ stderr: scrubPaths(stderrTrimmed.slice(0, 500)) }, 'claude mcp list stderr')
+      }
+      const outcome = applyRefreshOutcome({
+        stdout,
+        execError,
+        previousEntries: mcpListCache.entries,
+      })
+      // Defensive: if a previously populated cache collapses to zero
+      // entries via a clean exit (parser / format regression), log it
+      // loudly. The retainedStale case is a legitimate transient
+      // failure and is already surfaced via cache.error, not a warn.
+      if (previousCount > 0 && outcome.entries.length === 0 && !outcome.retainedStale) {
+        logger.warn({
+          previousCount,
+          stderr: scrubPaths(stderrTrimmed.slice(0, 500)),
+          execError: execError ? scrubPaths(execError.message) : null,
+        }, 'MCP list cache refresh returned 0 entries after non-empty cache')
+      }
+      mcpListCache = {
+        entries: outcome.entries,
+        lastRefreshed: Date.now(),
+        refreshing: false,
+        error: outcome.error ? scrubPaths(outcome.error) : undefined,
+      }
+      logger.info({
+        count: outcome.entries.length,
+        retainedStale: outcome.retainedStale,
+        softError: execError && !outcome.error ? scrubPaths(execError.message) : null,
+      }, 'MCP list cache refreshed')
+    } catch (err) {
+      // Keep the previous entries on failure so a transient CLI error
+      // does not wipe the UI. The error field lets callers surface it.
+      const rawMsg = err instanceof Error ? err.message : String(err)
+      mcpListCache = {
+        entries: mcpListCache.entries,
+        lastRefreshed: mcpListCache.lastRefreshed,
+        refreshing: false,
+        error: scrubPaths(rawMsg),
+      }
+      logger.warn({ err: scrubPaths(rawMsg) }, 'MCP list cache refresh failed; keeping stale entries')
+    } finally {
+      inflightRefresh = null
+    }
+    return mcpListCache
+  })()
+  return inflightRefresh
+}
+
+function startMcpListChecker(): void {
+  // Delayed first run so the main main-channels tmux session has time to
+  // claim the telegram poller token before `claude mcp list` tries to
+  // health-check the plugin. No periodic auto-refresh: every run spawns
+  // the telegram plugin for a health check, which can race the live bot.
+  setTimeout(() => { refreshMcpListCache().catch(() => {}) }, 30_000)
+}
+
 // Try to fire a task at a single target agent. Returns the outcome so the
 // caller can decide whether to queue a retry. Splitting this out means the
 // pendingTaskRetries loop and the normal cron loop share one code path.
@@ -3479,13 +3650,30 @@ Respond ONLY with JSON, nothing else:
       // === MCP Connectors API ===
 
       // GET /api/connectors - List all MCP servers with status.
-      // We deliberately DON'T shell out to `claude mcp list` here: that
-      // command spawns every stdio MCP (including plugin:telegram) for a
-      // health check, which collides with the Telegram bot's single-poller
-      // requirement and drops the live marveen-channels plugin. Instead we
-      // read the config files directly -- no process spawn, no interference.
+      // Merges three signals so the Connected tab actually reflects what
+      // Claude Code sees:
+      //   1. ~/.claude/settings.json `enabledPlugins` (marketplace plugins)
+      //   2. project `.mcp.json` + ~/.claude.json `mcpServers` (file-based)
+      //   3. the `mcpListCache` refreshed by claude mcp list (the only
+      //      source for claude.ai OAuth connectors)
+      //
+      // Each `claude mcp list` call spawns every stdio / plugin MCP for a
+      // health check, which can collide with the live Telegram bot. We
+      // therefore do NOT run the CLI on every request -- we serve the
+      // last-cached entries and expose an explicit refresh endpoint.
       if (path === '/api/connectors' && method === 'GET') {
-        const connectors: Array<{ name: string; status: string; endpoint: string; type: string }> = []
+        const connectors: Array<{
+          name: string
+          status: string
+          endpoint: string
+          type: string
+          // `local` is used for entries that only surfaced via the CLI
+          // cache (not the explicit file reads in step 2), where we
+          // cannot tell whether they came from the project or user
+          // scope. `local-project` / `local-user` are reserved for
+          // entries we read from a specific file ourselves.
+          source: 'plugin' | 'local-user' | 'local-project' | 'local' | 'claude.ai'
+        }> = []
         const seen = new Set<string>()
 
         // 1) ~/.claude/settings.json -> enabledPlugins (plugin:<name>@<marketplace>)
@@ -3493,15 +3681,23 @@ Respond ONLY with JSON, nothing else:
           const settings = JSON.parse(readFileOr(join(homedir(), '.claude', 'settings.json'), '{}'))
           for (const pluginKey of Object.keys(settings.enabledPlugins || {})) {
             if (!settings.enabledPlugins[pluginKey]) continue
-            const name = `plugin:${pluginKey.split('@')[0]}`
+            // Lowercase the slug so the dedupe key lines up with
+            // parseMcpListLine's output (`plugin:<slug>`), which also
+            // lowercases. Any future `Telegram@...` vs `telegram:telegram:`
+            // mismatch would otherwise emit both entries.
+            const name = `plugin:${pluginKey.split('@')[0].toLowerCase()}`
             if (seen.has(name)) continue
             seen.add(name)
-            connectors.push({ name, status: 'configured', endpoint: pluginKey, type: 'plugin' })
+            connectors.push({ name, status: 'configured', endpoint: pluginKey, type: 'plugin', source: 'plugin' })
           }
         } catch { /* ignore */ }
 
         // 2) project .mcp.json and user-global ~/.claude.json -> mcpServers
-        for (const src of [join(PROJECT_ROOT, '.mcp.json'), join(homedir(), '.claude.json')]) {
+        const fileSources: Array<[string, 'local-project' | 'local-user']> = [
+          [join(PROJECT_ROOT, '.mcp.json'), 'local-project'],
+          [join(homedir(), '.claude.json'), 'local-user'],
+        ]
+        for (const [src, source] of fileSources) {
           try {
             const parsed = JSON.parse(readFileOr(src, '{}'))
             const servers = parsed.mcpServers || {}
@@ -3510,12 +3706,68 @@ Respond ONLY with JSON, nothing else:
               seen.add(name)
               const endpoint = cfg?.url || cfg?.command || ''
               const type = cfg?.url ? 'remote' : 'local'
-              connectors.push({ name, status: 'configured', endpoint: String(endpoint), type })
+              connectors.push({ name, status: 'configured', endpoint: String(endpoint), type, source })
             }
           } catch { /* ignore */ }
         }
 
+        // 3) mcpListCache -- the only place claude.ai connectors come from.
+        // Add entries that were not already contributed by the file-based
+        // sources (so we don't double-list a plugin).
+        for (const entry of mcpListCache.entries) {
+          // Plugin entries are already seen as "plugin:<slug>" above.
+          // claude.ai connectors carry the "claude.ai " prefix in name,
+          // so they never collide with the plugin: or mcpServers keys.
+          const key = entry.source === 'plugin' ? `plugin:${entry.normalizedId}` : entry.name
+          if (seen.has(key)) continue
+          seen.add(key)
+          connectors.push({
+            name: entry.name,
+            status: entry.status === 'unknown' ? 'configured' : entry.status,
+            endpoint: entry.endpoint,
+            type: entry.source === 'claude.ai' ? 'remote' : 'local',
+            // Parser only distinguishes claude.ai / plugin / local; it
+            // does not carry a user-vs-project distinction. Use the
+            // neutral 'local' source here so the UI does not confidently
+            // mislabel a project-scope entry as user-scope when it
+            // only came up through the CLI cache.
+            source: entry.source === 'plugin' ? 'plugin'
+                   : entry.source === 'claude.ai' ? 'claude.ai'
+                   : 'local',
+          })
+        }
+
         return json(res, connectors)
+      }
+
+      // GET /api/connectors/status -- lightweight readout of the cache
+      // freshness for the UI to distinguish "empty" from "not yet
+      // loaded". Explicit endpoint so older clients that only read
+      // /api/connectors keep working on the unchanged response shape.
+      if (path === '/api/connectors/status' && method === 'GET') {
+        return json(res, {
+          cacheLastRefreshed: mcpListCache.lastRefreshed,
+          cacheError: mcpListCache.error,
+          refreshing: mcpListCache.refreshing,
+        })
+      }
+
+      // POST /api/connectors/refresh -- on-demand refresh of the MCP list
+      // cache. Runs `claude mcp list`, which spawns stdio / plugin MCPs
+      // for a health check; the user is expected to accept that cost by
+      // clicking the button explicitly. Returns the new cache summary.
+      if (path === '/api/connectors/refresh' && method === 'POST') {
+        const cache = await refreshMcpListCache()
+        // 502 on upstream refresh error so external health probes /
+        // CI scripts that only inspect HTTP status see the failure.
+        // The body's `ok` / `error` fields stay for the dashboard UI.
+        const httpStatus = cache.error ? 502 : 200
+        return json(res, {
+          ok: !cache.error,
+          count: cache.entries.length,
+          lastRefreshed: cache.lastRefreshed,
+          error: cache.error,
+        }, httpStatus)
       }
 
       // GET /api/connectors/:name - Get detailed info about an MCP server.
@@ -3529,8 +3781,26 @@ Respond ONLY with JSON, nothing else:
         if (name.startsWith('plugin:')) {
           try {
             const settings = JSON.parse(readFileOr(join(homedir(), '.claude', 'settings.json'), '{}'))
-            const plain = name.slice('plugin:'.length)
-            const match = Object.keys(settings.enabledPlugins || {}).find(k => k.split('@')[0] === plain)
+            // Case-insensitive comparison: the list endpoint lowercases
+            // the dedupe key (so plugin:Foo and plugin:foo collapse into
+            // one card), so the detail lookup must do the same or a
+            // mixed-case settings.json key will 404 on click. Also skip
+            // disabled plugins (falsy values in enabledPlugins) -- the
+            // list endpoint filters them, so a stale URL should 404
+            // rather than return "configured" for something that was
+            // toggled off.
+            //
+            // Cards sourced from mcpListCache carry raw CLI names like
+            // "plugin:telegram:telegram" (package:slug). Split on ':'
+            // and take the LAST segment so the lookup mirrors
+            // parseMcpListLine and does not 404 on CLI-sourced cards.
+            const rawSuffix = name.slice('plugin:'.length)
+            const segments = rawSuffix.split(':')
+            const plain = (segments[segments.length - 1] || rawSuffix).toLowerCase()
+            const enabled = settings.enabledPlugins || {}
+            const match = Object.keys(enabled).find(
+              k => enabled[k] && k.split('@')[0].toLowerCase() === plain,
+            )
             if (!match) return json(res, { error: 'Connector not found' }, 404)
             return json(res, { name, scope: 'user', status: 'configured', type: 'plugin', command: match, args: '', env: {} })
           } catch {
@@ -3664,28 +3934,53 @@ Respond ONLY with JSON, nothing else:
 
       // === MCP Catalog API ===
 
-      // GET /api/mcp-catalog - Return catalog with installed status
+      // GET /api/mcp-catalog - Return catalog with installed status.
+      //
+      // Installed status is derived from the mcpListCache so we don't shell
+      // out to `claude mcp list` on every page load (each call spawns
+      // stdio / plugin MCPs for a health check, which can race the live
+      // Telegram bot). The cache is refreshed at startup and on explicit
+      // POST /api/connectors/refresh calls.
+      //
+      // Matching uses slug-normalised ids: parseMcpListLine already strips
+      // the "claude.ai " and "plugin:*:" prefixes and turns names like
+      // "Google Calendar" into "google-calendar", so a catalog item with
+      // id "google-calendar" or name "Google Calendar" lines up with the
+      // claude.ai OAuth connector that `claude mcp list` reports.
       if (path === '/api/mcp-catalog' && method === 'GET') {
         try {
           const catalogPath = join(PROJECT_ROOT, 'mcp-catalog.json')
           const catalog = JSON.parse(readFileSync(catalogPath, 'utf-8')) as any[]
 
-          // Get installed MCP list
-          let installedNames: string[] = []
-          try {
-            const output = execSync('claude mcp list 2>&1', { timeout: 30000, encoding: 'utf-8' })
-            const lines = output.split('\n').filter(l => l.trim() && !l.startsWith('Checking'))
-            for (const line of lines) {
-              const match = line.match(/^(.+?):\s+/)
-              if (match) installedNames.push(match[1].trim().toLowerCase())
+          // Build an id -> source map from the cache so the UI can render
+          // "Bekapcsolva (claude.ai)" and similar badges instead of just a
+          // generic installed flag.
+          const installedSource = new Map<string, McpListEntry['source']>()
+          for (const entry of mcpListCache.entries) {
+            if (!installedSource.has(entry.normalizedId)) {
+              installedSource.set(entry.normalizedId, entry.source)
             }
-          } catch { /* empty list if claude mcp list fails */ }
+          }
 
-          const result = catalog.map(item => ({
-            ...item,
-            installed: installedNames.some(n => n === item.name.toLowerCase() || n === item.id.toLowerCase()),
-          }))
+          const result = catalog.map(item => {
+            // Use the same slugify as parseMcpListLine so the two
+            // normalisation paths cannot drift (a CLI name with dots
+            // or parens would have been matched one way and the
+            // catalog name the other otherwise).
+            const itemId = slugifyMcp(String(item.id ?? ''))
+            const itemNameSlug = slugifyMcp(String(item.name ?? ''))
+            const source = installedSource.get(itemId) || installedSource.get(itemNameSlug)
+            return {
+              ...item,
+              installed: source !== undefined,
+              installedSource: source,
+            }
+          })
 
+          // Keep the response shape as a bare array so any external
+          // tooling that calls `curl /api/mcp-catalog` without parsing
+          // a wrapper object keeps working. Cache freshness is available
+          // via /api/connectors/refresh (which returns lastRefreshed).
           return json(res, result)
         } catch (err) {
           logger.error({ err }, 'Failed to load MCP catalog')
@@ -4294,6 +4589,13 @@ Respond ONLY with JSON, nothing else:
   // Start update checker -- polls GitHub every 15 min for new commits.
   const updateCheckerInterval = startUpdateChecker()
   logger.info('Update checker started (15min poll)')
+
+  // Warm the MCP list cache so the Connectors page reflects claude.ai
+  // OAuth connectors on first load. 30s delay lets the main-channels
+  // session settle first so the telegram plugin's single-poller token
+  // is claimed before `claude mcp list` spawns it for a health check.
+  startMcpListChecker()
+  logger.info('MCP list cache warmup scheduled (30s delay, manual refresh only)')
 
   // Warm the Marveen bot username cache so /api/marveen returns @username
   // on the first dashboard load. Re-fetched lazily otherwise.

--- a/web/app.js
+++ b/web/app.js
@@ -3348,6 +3348,34 @@ document.querySelectorAll('.connector-tab').forEach(tab => {
   })
 })
 
+// Refresh button: triggers the server-side `claude mcp list` refresh.
+// Deliberately manual because every refresh spawns stdio / plugin MCPs
+// for a health check and can race the live Telegram bot. Button is
+// shared by both the Installed and Gallery tabs.
+document.getElementById('connectorRefreshBtn').addEventListener('click', async () => {
+  const btn = document.getElementById('connectorRefreshBtn')
+  btn.disabled = true
+  try {
+    const res = await fetch('/api/connectors/refresh', { method: 'POST' })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data.ok) {
+      showToast('Frissítés sikertelen: ' + (data.error || 'HTTP ' + res.status))
+    } else {
+      showToast('Frissítve (' + (data.count || 0) + ' MCP)')
+    }
+    await loadConnectors()
+    // Reload catalog only if the Gallery tab is currently active so we
+    // do not fight for the catalog grid while the user is on Installed.
+    if (!document.getElementById('connectorGalleryTab').hidden) {
+      await loadCatalog()
+    }
+  } catch (err) {
+    showToast('Hiba: ' + (err.message || err))
+  } finally {
+    btn.disabled = false
+  }
+})
+
 // Catalog filter buttons
 document.querySelectorAll('.catalog-filter-btn').forEach(btn => {
   btn.addEventListener('click', () => {
@@ -3401,7 +3429,7 @@ function renderCatalog() {
       </div>
       <div class="catalog-card-footer">
         ${item.installed
-          ? `<span class="catalog-install-btn installed">Telepítve &#10003;</span><a class="catalog-uninstall-link" data-id="${item.id}">Eltávolítás</a>`
+          ? `<span class="catalog-install-btn installed" title="Forrás: ${escapeHtml(item.installedSource || 'ismeretlen')}">Telepítve &#10003;${item.installedSource === 'claude.ai' ? ' (claude.ai)' : item.installedSource === 'plugin' ? ' (plugin)' : ''}</span>${item.installedSource === 'claude.ai' ? '' : `<a class="catalog-uninstall-link" data-id="${item.id}">Eltávolítás</a>`}`
           : `<button class="catalog-install-btn install" data-id="${item.id}">Telepítés</button>${authHint}`
         }
       </div>
@@ -3548,12 +3576,39 @@ document.getElementById('connectorType').addEventListener('change', () => {
   document.getElementById('connectorArgsGroup').hidden = !isLocal
 })
 
+// Default TRUE: if we never successfully read /api/connectors/status
+// (endpoint missing on older backends, network error, non-2xx response)
+// the safe assumption is that the cache has not populated yet. That
+// way an empty list renders as "warming" rather than the misleading
+// "no connectors" the F2 round-3 fix was meant to eliminate.
+let connectorCacheWarming = true
+let connectorCacheError = ''
+
 async function loadConnectors() {
   connectorGrid.innerHTML = '<div class="connector-loading"><span class="spinner"></span> Connectorok betoltese...</div>'
   connectorStats.innerHTML = ''
+  // Reset pessimistic state at the top of every load. Only an authoritative
+  // positive signal (status endpoint reports cacheLastRefreshed > 0) flips
+  // it to false, so a later status-fetch failure cannot leave a stale
+  // `false` that regresses into "no connectors" again.
+  connectorCacheWarming = true
+  connectorCacheError = ''
   try {
-    const res = await fetch('/api/connectors')
-    connectors = await res.json()
+    // Fetch both in parallel: the list itself and a lightweight status
+    // readout that tells us whether the server-side cache has ever run.
+    // Without the status, a cold-start hit on the page would render
+    // "Nincsenek MCP connectorok" -- contradicting the info-box that
+    // says "A lista a dashboard indulasakor toltodik be".
+    const [listRes, statusRes] = await Promise.all([
+      fetch('/api/connectors'),
+      fetch('/api/connectors/status').catch(() => null),
+    ])
+    connectors = await listRes.json()
+    if (statusRes && statusRes.ok) {
+      const s = await statusRes.json().catch(() => ({}))
+      if (s && s.cacheLastRefreshed > 0) connectorCacheWarming = false
+      if (s && s.cacheError) connectorCacheError = String(s.cacheError)
+    }
     renderConnectors()
   } catch (err) {
     console.error('Connector betöltés hiba:', err)
@@ -3582,35 +3637,93 @@ function renderConnectors() {
     builtinGrid.appendChild(div)
   }
 
-  // Stats
-  const connected = connectors.filter(c => c.status === 'connected').length
-  const needsAuth = connectors.filter(c => c.status === 'needs_auth').length
-  const failed = connectors.filter(c => c.status === 'failed').length
-  connectorStats.innerHTML = `
-    <div class="stat-card"><div class="stat-value">${connectors.length}</div><div class="stat-label">Összes</div></div>
-    <div class="stat-card"><div class="stat-value" style="color:var(--success)">${connected}</div><div class="stat-label">Aktív</div></div>
-    ${needsAuth ? `<div class="stat-card"><div class="stat-value" style="color:var(--accent)">${needsAuth}</div><div class="stat-label">Auth szükséges</div></div>` : ''}
-    ${failed ? `<div class="stat-card"><div class="stat-value" style="color:var(--danger)">${failed}</div><div class="stat-label">Hibás</div></div>` : ''}
-  `
+  // Stats: only render when there is real data OR a confirmed empty
+  // cache. Rendering "0 / 0" stat cards above a "still loading" message
+  // contradicts itself and confuses the user.
+  if (connectors.length === 0 && connectorCacheWarming) {
+    connectorStats.innerHTML = ''
+  } else {
+    const connected = connectors.filter(c => c.status === 'connected').length
+    const needsAuth = connectors.filter(c => c.status === 'needs_auth').length
+    const failed = connectors.filter(c => c.status === 'failed').length
+    connectorStats.innerHTML = `
+      <div class="stat-card"><div class="stat-value">${connectors.length}</div><div class="stat-label">Összes</div></div>
+      <div class="stat-card"><div class="stat-value" style="color:var(--success)">${connected}</div><div class="stat-label">Aktív</div></div>
+      ${needsAuth ? `<div class="stat-card"><div class="stat-value" style="color:var(--accent)">${needsAuth}</div><div class="stat-label">Auth szükséges</div></div>` : ''}
+      ${failed ? `<div class="stat-card"><div class="stat-value" style="color:var(--danger)">${failed}</div><div class="stat-label">Hibás</div></div>` : ''}
+    `
+  }
 
   // Grid
   connectorGrid.innerHTML = ''
+  // Stale-data warning banner. Only warns when the failed refresh
+  // would actually matter: file-based entries (enabledPlugins,
+  // project/.mcp.json, ~/.claude.json) were re-read fresh on this
+  // request, so they are always authoritative. The only subset that
+  // can go stale is the claude.ai OAuth connectors, which only land
+  // in the list via mcpListCache. If none of those are present,
+  // nothing about the displayed data is actually stale.
+  const hasClaudeAiEntries = connectors.some(c => c.source === 'claude.ai')
+  if (connectors.length > 0 && !connectorCacheWarming && connectorCacheError && hasClaudeAiEntries) {
+    const banner = document.createElement('div')
+    banner.className = 'connector-stale-banner'
+    banner.innerHTML = `Frissítés sikertelen: ${escapeHtml(connectorCacheError)} -- a claude.ai connectorok elavultak lehetnek.`
+    connectorGrid.appendChild(banner)
+  }
   if (connectors.length === 0) {
-    connectorGrid.innerHTML = '<div class="connector-loading">Nincsenek MCP connectorok</div>'
+    // Cold-start: cache has never run, so the empty list is not the
+    // ground truth, just the transient state before the 30s warmup or
+    // a manual refresh. Telling the user "there are none" would
+    // contradict the info-box above.
+    //
+    // If we have a cached error AND warming is still true (refresh has
+    // failed; cache never populated), show the error instead of
+    // instructing the user to click the button that just failed.
+    if (connectorCacheWarming && connectorCacheError) {
+      connectorGrid.innerHTML = `<div class="connector-loading">MCP lista nem tölthető be: ${escapeHtml(connectorCacheError)}</div>`
+    } else if (connectorCacheWarming) {
+      connectorGrid.innerHTML = '<div class="connector-loading">MCP lista még nem töltődött be. Kattints a Frissítés gombra, vagy várj egy percet a dashboard indulása után.</div>'
+    } else {
+      connectorGrid.innerHTML = '<div class="connector-loading">Nincsenek MCP connectorok</div>'
+    }
     return
   }
   for (const c of connectors) {
     const card = document.createElement('div')
     card.className = 'connector-card'
+    // Source labels: map the terse backend values to short visible tags.
+    // This is the single biggest information the user needs right now
+    // -- where did this entry come from, file or OAuth?
+    const sourceLabels = {
+      'claude.ai': 'claude.ai',
+      'plugin': 'plugin',
+      'local-user': 'local (user)',
+      'local-project': 'local (project)',
+      'local': 'local',
+    }
+    const sourceTag = c.source ? `<span class="connector-source-badge">${escapeHtml(sourceLabels[c.source] || c.source)}</span>` : ''
+    // claude.ai entries are managed by the Claude.ai subscription, not
+    // the dashboard: the detail endpoint cannot resolve them and the
+    // per-agent assign endpoint would 404. Mark them read-only so a
+    // click does not 404 a confusing "Reszletek betoltese sikertelen"
+    // modal, and add a small hint instead.
+    const readOnly = c.source === 'claude.ai'
+    if (readOnly) card.classList.add('connector-card-readonly')
+    // Readonly hint lives OUTSIDE .connector-endpoint so the endpoint's
+    // nowrap+ellipsis truncation cannot eat it on long URLs.
+    const readonlyHint = readOnly ? '<div class="connector-readonly-hint">Kezelhető: claude.ai</div>' : ''
     card.innerHTML = `
       <div class="connector-status-dot ${c.status}"></div>
       <div class="connector-info">
-        <div class="connector-name">${escapeHtml(c.name)}</div>
+        <div class="connector-name">${escapeHtml(c.name)} ${sourceTag}</div>
         <div class="connector-endpoint">${escapeHtml(c.endpoint || '')}</div>
+        ${readonlyHint}
       </div>
       <span class="connector-type-badge ${c.type}">${c.type}</span>
     `
-    card.addEventListener('click', () => openConnectorDetail(c))
+    if (!readOnly) {
+      card.addEventListener('click', () => openConnectorDetail(c))
+    }
     connectorGrid.appendChild(card)
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -347,12 +347,26 @@
             <h1>Connectorok</h1>
             <p class="subtitle">MCP szerverek kezelése</p>
           </div>
-          <button class="btn-primary btn-compact" id="addConnectorBtn">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-              <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
-            </svg>
-            Új connector
-          </button>
+          <div style="display:flex;gap:8px">
+            <button class="btn-secondary btn-compact" id="connectorRefreshBtn" title="Claude MCP lista frissítése">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+              </svg>
+              Frissítés
+            </button>
+            <button class="btn-primary btn-compact" id="addConnectorBtn">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+              </svg>
+              Új connector
+            </button>
+          </div>
+        </div>
+        <div class="info-box" id="connectorInfoBox">
+          Az itt listázott MCP szerverek a te Claude Code előfizetésedben bekapcsoltak (claude.ai OAuth connectorok, marketplace pluginok, lokális konfig).
+          Minden sub-agent automatikusan látja őket, mert ugyanabban a HOME-ban fut, mint a fő session.
+          Ha egy MCP már bekapcsolva van claude.ai-n, <strong>ne vedd fel még egyszer lokálisan</strong>: duplikálódik,
+          és a Claude CLI "local wins" üzenetet ad rá. A lista a dashboard indulásakor töltődik be, explicit frissítés a "Frissítés" gombbal.
         </div>
       </div>
 

--- a/web/style.css
+++ b/web/style.css
@@ -15,6 +15,7 @@
   --accent-hover: #c46849;
   --accent-soft: rgba(217, 119, 87, 0.1);
   --danger: #bf4d43;
+  --danger-soft: rgba(191, 77, 67, 0.12);
   --danger-hover: #a8413a;
   --success: #788c5d;
   --success-soft: rgba(120, 140, 93, 0.12);
@@ -2771,6 +2772,10 @@ main {
   font-size: 14px;
   font-weight: 600;
   margin-bottom: 2px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 .connector-endpoint {
   font-size: 11px;
@@ -2791,6 +2796,64 @@ main {
 .connector-type-badge.remote { background: var(--info-soft); color: var(--info); }
 .connector-type-badge.local { background: var(--success-soft); color: var(--success); }
 .connector-type-badge.plugin { background: var(--accent-soft); color: var(--accent); }
+
+.connector-source-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  border-radius: 10px;
+  background: var(--bg-input);
+  color: var(--text-muted);
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+.info-box {
+  padding: 12px 16px;
+  margin: 0 0 16px;
+  border-radius: 8px;
+  background: var(--info-soft);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.5;
+  border-left: 3px solid var(--info);
+}
+.info-box strong { color: var(--info); }
+
+.connector-stale-banner {
+  /* Span the entire grid row -- .connector-grid is auto-fill columns,
+     so without this the banner shrinks into a single track and the
+     first connector card squeezes up beside it. */
+  grid-column: 1 / -1;
+  padding: 10px 14px;
+  margin: 0 0 12px;
+  border-radius: 6px;
+  background: var(--danger-soft);
+  color: var(--danger);
+  font-size: 13px;
+  border-left: 3px solid var(--danger);
+}
+
+.connector-card-readonly {
+  cursor: default;
+  opacity: 0.9;
+}
+.connector-card-readonly:hover {
+  /* The base .connector-card:hover rule applies border-color +
+     box-shadow to hint at a click target. Read-only cards have no
+     click handler, so mute those cues explicitly. */
+  border-color: var(--border);
+  box-shadow: none;
+}
+.connector-readonly-hint {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 11px;
+  margin-top: 2px;
+}
 
 .connector-detail-info {
   display: flex;


### PR DESCRIPTION
## Why this matters

The dashboard's **Connectorok** page currently gives a misleading view of the MCP layer:

1. **Installed tab lists 1 of 8 active MCP servers.** The endpoint reads `~/.claude/settings.json` `enabledPlugins`, `project/.mcp.json`, and `~/.claude.json` `mcpServers` directly. It skips the claude.ai OAuth connectors because those have no file-based representation, they only surface through `claude mcp list`.

2. **Gallery state-detection is broken.** The parser reads `claude mcp list` but does not strip the `claude.ai ` or `plugin:<pkg>:` prefixes from the reported names. Every catalog item appears "not installed" even when the matching claude.ai connector is already active. A well-meaning click on "Gmail" → "Telepítés" then runs `claude mcp add` and creates a duplicate entry in `~/.claude.json`, after which `claude mcp list` emits a "local wins over claude.ai" warning.

3. **Built-in section rows look clickable but are plain `<span>`s** with the enable instructions hidden in a `title` tooltip. The user's mental model ("click to enable") is broken.

4. **Cold-start / refresh failure shows no feedback.** The previous frontend rendered "Nincsenek MCP connectorok" whenever the list happened to be empty, contradicting the info-box that says the data loads at dashboard start.

Reproducible on any host whose user has a claude.ai subscription with the Gmail / Google Calendar / Google Drive connectors enabled: the dashboard marks all three "not installed" and the Installed tab only shows the telegram plugin.

## Change

Fixes #1 and #2 without invasive restructuring. Three distinct areas:

**Cache layer (new)**

- `mcpListCache` holds the parsed output of `claude mcp list`. Refreshed once at startup with a 30s delay (so the main channels session settles first), and on explicit `POST /api/connectors/refresh`. No periodic auto-refresh: every call spawns stdio and plugin MCPs for a health check, which can race the live Telegram bot's single-poller.
- `applyRefreshOutcome` keeps the previous entries when the CLI exits non-zero but stdout still parsed something (the steady state when a connector's OAuth expired). Only a blank stdout plus an exec error wipes the cache and surfaces `cache.error`.
- The working directory for `claude mcp list` is a `mkdtempSync` dir with `0700` perms, created on demand and cleaned up via `process.on('exit', ...)`. Avoids the `/tmp/.mcp.json` poisoning vector on multi-user hosts.
- `scrubPaths` strips absolute user paths (Users/home/root/tmp/var/opt/private/var) from any error message before it lands in an API response or a log line. The regex has a trailing lookahead so dirs whose names extend a keyword (`/homes/...`, `/Users-backup/...`, `/opts-archive/...`) do not trigger partial scrubs, and zero-or-one-segment tails collapse to `<path>` so the username itself is not leaked. 25 tests cover the scrubber alone.

**`src/mcp-list-parser.ts` (new pure module)**

- `parseMcpListLine`, `parseMcpList`, `slugify`, `applyRefreshOutcome`, `scrubPaths` are pure functions with no Node side effects. `src/web.ts` injects the node-specific runtime (exec, homedir, fs) around them.
- 52 vitest cases: line-shape guards, claude.ai / plugin / local sources, slug normalisation for dotted and parenthesised names, priority ordering, retained-stale outcomes, full sweep of path-scrubbing edge cases.

**`/api/connectors` and `/api/mcp-catalog` rebuilt**

- `/api/connectors` now merges file-based sources AND the cached `claude mcp list` output, tagging each entry with a `source` field (`'plugin'`, `'claude.ai'`, `'local-user'`, `'local-project'`, or `'local'` for CLI-only entries whose scope we cannot determine). Dedupe keys are lowercased so `plugin:Foo` and `plugin:foo` collapse into one row.
- Plugin detail endpoint reads the last colon-separated segment, so `plugin:telegram:telegram` resolves to the correct settings key, and disabled plugins (`enabledPlugins[k] === false`) return 404.
- `/api/connectors/status` returns `cacheLastRefreshed` + `cacheError` + `refreshing` so the UI can distinguish cold-start from a genuinely empty list.
- `/api/connectors/refresh` returns HTTP 502 on upstream error so external monitoring (uptime probes, CI scripts) see the failure.
- `/api/mcp-catalog` installed-state now fuzz-matches catalog `id` and `name` against the parser's slug-normalised ids, so Gmail / Google Calendar / Google Drive / Notion / Slack resolve as installed when the claude.ai connector is active.

**Frontend**

- "Frissítés" button on the Connectors page that triggers `POST /api/connectors/refresh` and surfaces `{ok, count, error}` in a toast.
- Info-box at the top of the page explaining that sub-agents share the main session's HOME and see every bekapcsolt MCP automatically.
- Source badge per entry in the Installed tab (`claude.ai`, `plugin`, `local`, etc.).
- Read-only cards for `source === 'claude.ai'` entries: no click handler, no hover highlight, `Kezelhető: claude.ai` hint. Prevents a click that would 404 on the file-backed detail endpoint.
- Cold-start state machine: `connectorCacheWarming` defaults to `true` and only flips to `false` after an authoritative `cacheLastRefreshed > 0` reading. A failed refresh on a cold cache shows the actual error instead of instructing the user to click the button that just failed.
- Stale-data banner above the grid when the cache has live entries from a previous successful refresh, the latest refresh failed, AND claude.ai entries are present (file-based entries are always fresh, so the banner is scoped to the subset that can go stale).
- Gallery "Telepítés" button is hidden when the catalog item is already active (`installedSource === 'claude.ai'`), so a click cannot produce the duplicate-entry symptom the PR was born from.

## Scope / compatibility

Left intact:
- The "Hozzárendelés" per-agent file-copy flow (`POST /api/connectors/:name/assign` and `POST /api/skills/:name/assign`). In today's single-HOME setup every sub-agent inherits `~/.claude/*` already, so the copy is a no-op; the endpoints survive for a potential multi-HOME deployment and are simply not wired to new UI in this PR.
- `mcp-catalog.json` shape.
- Existing `/api/connectors/:name` detail endpoint semantics for file-based sources.
- Refresh is manual-only; no background poll that could surprise the Telegram bot.

API additions (all forward-compatible -- consumers that ignore unknown fields are unaffected):
- `/api/connectors` items gain a `source: 'plugin' | 'claude.ai' | 'local-user' | 'local-project' | 'local'` field.
- `/api/mcp-catalog` items gain `installedSource: string | undefined`, and `installed` is derived from normalised-slug matches.
- `GET /api/connectors/status` (new) returns `{ cacheLastRefreshed, cacheError, refreshing }`.
- `POST /api/connectors/refresh` (new) returns `{ ok, count, lastRefreshed, error? }` with HTTP 502 on upstream error, 200 on success.

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npx vitest run` -- 130/130 passing (52 in `mcp-list-parser.test.ts`)
- [x] Live smoke: dashboard on a host with 7 claude.ai connectors + telegram plugin. Before the patch: Installed tab shows 1 entry, Gallery marks Gmail/Google Calendar/Google Drive as "not installed". After: Installed shows all 8 with source badges, Gallery marks the three as "Telepítve ✓ (claude.ai)" and hides the install button.
- [x] Refresh while claude.ai Canva connector is active: `POST /api/connectors/refresh` returns `{ok:true, count:8}` in ~5s, telegram bot remains alive.
- [x] Pidfile-style stale-cache test: planted a stale `cacheError`, reloaded the Connectors page, stale banner rendered above the entries.
- [x] Cold-start test: hit the page 1s after boot (before the 30s warmup); UI showed the "MCP lista még nem töltődött be..." message instead of "Nincsenek MCP connectorok".
- [x] Sensitive-data audit on the diff: zero matches for operator/user/agent/path identifiers.
- [x] Em-dash audit on the diff: zero U+2014.

## Known limitations

- Windows path scrubbing is not implemented (`C:\Users\foo\...` patterns). Marveen's deploy target is darwin + Linux today; worth a separate portability pass.
- `claude mcp list` still spawns stdio and plugin MCPs for a health check on every invocation, which is why the refresh is manual-only. A `claude mcp list --no-spawn` flag (if it ever ships) would let us auto-refresh on a timer without racing the Telegram bot.
- The wiring around `/api/connectors` merge, plugin dedupe, and last-segment parsing has no dedicated integration test; the pure-logic helper underneath has 52 cases. A future test harness that stubs `mcpListCache` and `settings.enabledPlugins` could close that gap cheaply.

## Context

This PR is the first of a 3-PR series addressing the Connectors page behaviour. The next two are:

- PR2: Skills page shows user skills + plugin skills + built-in skills (listing parity with the Claude CLI), with the "Hozzárendelés" gomb removed from the UI because every sub-agent already inherits the user-global set.
- PR3: Built-in section (Computer Use, Claude in Chrome) made into a real clickable row that opens a modal with the enable instructions.

This PR stands on its own and can merge before the others.