### PR TITLE
skills: list plugin skills, drop per-agent assign UI, add global create + import

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -2657,12 +2657,15 @@ export function startWebServer(port = 3420): http.Server {
 
         // Save temp file (unique name to avoid concurrent-import races) and unzip
         const tmpPath = join(skillsDir, `_import_${randomUUID()}.zip`)
+        // Snapshot the pre-import state OUTSIDE the try block so the
+        // catch at the end can diff `after` vs `before` and roll back
+        // any partially-extracted files if unzip itself threw.
+        const before = new Set(readdirSync(skillsDir))
         try {
           writeFileSync(tmpPath, file.data)
           // Reject entries with absolute paths or parent-dir escapes before extraction.
           const listOutput = execSync(`unzip -Z1 "${tmpPath}" 2>&1`, { timeout: 5000, encoding: 'utf-8' })
           const entries = listOutput.split('\n').map((l) => l.trim()).filter(Boolean)
-          const before = new Set(readdirSync(skillsDir))
           for (const entry of entries) {
             if (entry.includes('..') || entry.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry)) {
               unlinkSync(tmpPath)
@@ -2672,7 +2675,10 @@ export function startWebServer(port = 3420): http.Server {
           execSync(`unzip -o "${tmpPath}" -d "${skillsDir}"`, { timeout: 10000 })
           unlinkSync(tmpPath)
 
-          // Defence-in-depth: walk what was just extracted and delete any symlink entries.
+          // Defence-in-depth: walk what was just extracted and reject
+          // if any subdir is a symlink. Use the collect-then-decide
+          // pattern so a zip with a clean entry + a tainted entry
+          // does not leave the clean one partially installed.
           const after = readdirSync(skillsDir).filter((f) => !before.has(f))
           const rejectSymlinks = (dir: string): boolean => {
             for (const entry of readdirSync(dir)) {
@@ -2683,26 +2689,50 @@ export function startWebServer(port = 3420): http.Server {
             }
             return false
           }
+          const tainted: string[] = []
           for (const f of after) {
             const p = join(skillsDir, f)
             try {
               if (lstatSync(p).isSymbolicLink() || (statSync(p).isDirectory() && rejectSymlinks(p))) {
-                rmSync(p, { recursive: true, force: true })
-                return json(res, { error: 'Invalid skill file: symlink entries rejected' }, 400)
+                tainted.push(f)
               }
             } catch { /* ignored */ }
           }
+          if (tainted.length > 0) {
+            for (const f of after) {
+              try { rmSync(join(skillsDir, f), { recursive: true, force: true }) } catch { /* best effort */ }
+            }
+            return json(res, { error: 'Invalid skill file: symlink entries rejected' }, 400)
+          }
 
           // Find the extracted skill name (directory containing SKILL.md)
-          const extracted = readdirSync(skillsDir).filter(f => {
+          const extracted = after.filter(f => {
             const p = join(skillsDir, f)
             try { return statSync(p).isDirectory() && existsSync(join(p, 'SKILL.md')) } catch { return false }
           })
+          // Refuse a zip that yields nothing useful so the UI does
+          // not show a "Skill importálva: " toast with an empty list.
+          if (extracted.length === 0) {
+            for (const f of after) {
+              try { rmSync(join(skillsDir, f), { recursive: true, force: true }) } catch { /* best effort */ }
+            }
+            return json(res, { error: 'No valid skill (SKILL.md) found in archive' }, 400)
+          }
 
           logger.info({ name, skills: extracted }, 'Skill(s) imported')
           return json(res, { ok: true, imported: extracted })
         } catch (err) {
           try { unlinkSync(tmpPath) } catch { /* ignored */ }
+          // Roll back anything that was half-extracted before the
+          // exception. Without this, a crashed unzip / SIGTERM leaves
+          // orphans that the next import collides with or silently
+          // merges into.
+          try {
+            const leftover = readdirSync(skillsDir).filter(f => !before.has(f))
+            for (const f of leftover) {
+              try { rmSync(join(skillsDir, f), { recursive: true, force: true }) } catch { /* best effort */ }
+            }
+          } catch { /* dir gone or unreadable; nothing to do */ }
           logger.error({ err }, 'Failed to import skill')
           return json(res, { error: 'Failed to extract .skill file' }, 500)
         }
@@ -2746,7 +2776,10 @@ export function startWebServer(port = 3420): http.Server {
         if (!existsSync(agentDir(agentName))) return json(res, { error: 'Agent not found' }, 404)
         const body = await readBody(req)
         const { name: rawSkillName, description } = JSON.parse(body.toString()) as { name: string; description: string }
-        const skillName = sanitizeAgentName(rawSkillName || '')
+        // Use sanitizeSkillName (mirrored by the DELETE path at 2716
+        // and the global /api/skills POST) so the two skill-name
+        // namespaces never drift out of sync with the agent-name rules.
+        const skillName = sanitizeSkillName(rawSkillName || '')
         if (!skillName) return json(res, { error: 'Skill name is required' }, 400)
         if (!description) return json(res, { error: 'Skill description is required' }, 400)
 
@@ -4048,51 +4081,210 @@ Respond ONLY with JSON, nothing else:
         return agents
       }
 
-      // GET /api/skills - List all global skills with agent assignments
+      // GET /api/skills - List all skills visible to the Claude Code
+      // CLI for the current user, from two file-based sources:
+      //
+      //   1. ~/.claude/skills/<name>/SKILL.md           -> source='user'
+      //   2. ~/.claude/plugins/cache/*/skills/<name>/SKILL.md -> source='plugin'
+      //
+      // Sub-agents inherit the same HOME as the main session, so every
+      // skill listed here is already available to every sub-agent
+      // without any "Hozzarendeles" step. The per-agent `agents` field
+      // is still reported for the user-scope entries so the existing
+      // dashboard logic that showed assignments still has data; it is
+      // informational only in today's single-HOME setup.
+      //
+      // Claude Code also ships built-in slash commands (init, review,
+      // security-review, loop, schedule, simplify, etc.) that live
+      // inside the `claude` binary and are never listed on disk. Those
+      // are always available; the UI surfaces that fact via an info-box
+      // rather than trying to hard-code a list that would drift with
+      // every CLI release.
       if (path === '/api/skills' && method === 'GET') {
-        const GLOBAL_SKILLS_DIR = join(homedir(), '.claude', 'skills')
-        const skills: { name: string; description: string; agents: string[]; path: string }[] = []
+        type SkillEntry = {
+          name: string
+          label: string
+          description: string
+          agents: string[]
+          path: string
+          source: 'user' | 'plugin'
+          pluginPackage?: string
+        }
+        const skills: SkillEntry[] = []
 
-        if (existsSync(GLOBAL_SKILLS_DIR)) {
-          // Filter out non-skill directories (Claude Code internal structure)
+        // Source 1: user-global ~/.claude/skills
+        const USER_SKILLS_DIR = join(homedir(), '.claude', 'skills')
+        if (existsSync(USER_SKILLS_DIR)) {
           const SKIP_DIRS = new Set(['skills', 'temp_skills', 'tmp_skills', '.skill-index.md'])
-          const dirs = readdirSync(GLOBAL_SKILLS_DIR).filter(f => {
+          const dirs = readdirSync(USER_SKILLS_DIR).filter(f => {
             if (SKIP_DIRS.has(f)) return false
             if (f.startsWith('.')) return false
-            try { return statSync(join(GLOBAL_SKILLS_DIR, f)).isDirectory() } catch { return false }
+            try { return statSync(join(USER_SKILLS_DIR, f)).isDirectory() } catch { return false }
           })
-
           for (const dir of dirs) {
-            const skillMdPath = join(GLOBAL_SKILLS_DIR, dir, 'SKILL.md')
-            if (!existsSync(skillMdPath)) continue // Skip dirs without SKILL.md
-            const description = parseSkillDescription(readFileOr(skillMdPath, ''))
-
+            const skillMdPath = join(USER_SKILLS_DIR, dir, 'SKILL.md')
+            if (!existsSync(skillMdPath)) continue
             skills.push({
               name: dir,
-              description,
-              agents: getSkillAgents(dir),
-              path: join(GLOBAL_SKILLS_DIR, dir),
+              label: dir,
+              description: parseSkillDescription(readFileOr(skillMdPath, '')),
+              // getSkillAgents is no longer consumed by the UI (the
+              // per-agent assignment view was removed when sub-agents
+              // became shared-HOME); skip the fs scan on the hot list
+              // endpoint. Detail endpoint still reports it for the
+              // backend assign flow.
+              agents: [],
+              path: join(USER_SKILLS_DIR, dir),
+              source: 'user',
             })
           }
         }
 
+        // Source 2: plugin skills under ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/<name>/SKILL.md
+        // Depth varies by marketplace layout; rather than hard-code a
+        // fixed depth, walk up to three levels looking for a `skills/`
+        // child that itself contains skill directories with SKILL.md.
+        const PLUGINS_CACHE_DIR = join(homedir(), '.claude', 'plugins', 'cache')
+        if (existsSync(PLUGINS_CACHE_DIR)) {
+          const walkForSkills = (dir: string, depth: number, packagePath: string[]): void => {
+            if (depth > 4) return
+            let entries: string[] = []
+            try { entries = readdirSync(dir) } catch { return }
+            // If this dir has a `skills` subdir, harvest skills from it
+            // and DO NOT recurse further. A plugin's skills live under
+            // its own `skills/` subdir; descending past that point only
+            // walks node_modules / assets / other noise and wastes fs
+            // I/O on a hot list endpoint.
+            if (entries.includes('skills')) {
+              const skillsDir = join(dir, 'skills')
+              let skillDirs: string[] = []
+              try { skillDirs = readdirSync(skillsDir) } catch { /* no-op */ }
+              for (const sd of skillDirs) {
+                if (sd.startsWith('.')) continue
+                const skillDirPath = join(skillsDir, sd)
+                try { if (!statSync(skillDirPath).isDirectory()) continue } catch { continue }
+                const skillMdPath = join(skillDirPath, 'SKILL.md')
+                if (!existsSync(skillMdPath)) continue
+                const pluginPackage = packagePath.join('/')
+                // Short plugin name: prefer the segment that looks
+                // most like a plugin id. For the common
+                // `<marketplace>/<plugin>/<version>` layout that means
+                // the segment BEFORE the version, i.e. length-2. If
+                // there is no version segment the last segment is the
+                // plugin itself. A segment is treated as a version if
+                // it matches the typical semver / date-versioned
+                // pattern (starts with a digit). This heuristic keeps
+                // `telegram` for `claude-plugins-official/telegram/0.0.6`
+                // and falls back gracefully for unversioned or single-
+                // segment packages.
+                // Broadened to cover `v0.0.6`, `V2.3`, `rc1`, `beta-3`,
+                // and the other typical version-segment shapes. The
+                // previous strict `^\d` missed every plugin using a
+                // `v`-prefix or pre-release tag and labelled the
+                // version itself as the plugin id.
+                //
+                // The pre-release alternatives require a version-like
+                // delimiter after the word (digit, dot, hyphen, underscore,
+                // or end-of-string) so a legitimate plugin name like
+                // `preview-plugin`, `alpha-vantage`, `betareader` does
+                // NOT match and get mislabelled as a version segment.
+                const VERSION_LIKE = /^(?:\d|v\d|(?:rc|beta|alpha|pre|snapshot)(?:[.\-_]|\d|$))/i
+                const lastIdx = packagePath.length - 1
+                let shortPluginIdx = lastIdx
+                if (lastIdx >= 1 && VERSION_LIKE.test(packagePath[lastIdx] || '')) {
+                  shortPluginIdx = lastIdx - 1
+                }
+                const shortPlugin = packagePath[shortPluginIdx] || 'plugin'
+                skills.push({
+                  name: pluginPackage ? `${pluginPackage}:${sd}` : sd,
+                  label: `${shortPlugin}:${sd}`,
+                  description: parseSkillDescription(readFileOr(skillMdPath, '')),
+                  agents: [],
+                  path: skillDirPath,
+                  source: 'plugin',
+                  pluginPackage,
+                })
+              }
+              return
+            }
+            // Otherwise recurse into each subdirectory once.
+            for (const entry of entries) {
+              if (entry.startsWith('.') || entry === 'skills') continue
+              const next = join(dir, entry)
+              try {
+                if (!statSync(next).isDirectory()) continue
+              } catch { continue }
+              walkForSkills(next, depth + 1, packagePath.concat(entry))
+            }
+          }
+          walkForSkills(PLUGINS_CACHE_DIR, 0, [])
+        }
+
+        // Deterministic order: user skills first, then plugin skills,
+        // each alphabetically by LABEL. Using the visible label rather
+        // than the raw name keeps plugin entries sorted the way the
+        // UI renders them (users see "telegram:access" before
+        // "telegram:configure", not the marketplace-prefixed form).
+        skills.sort((a, b) => {
+          if (a.source !== b.source) return a.source === 'user' ? -1 : 1
+          return (a.label || a.name).localeCompare(b.label || b.name)
+        })
         return json(res, skills)
       }
 
-      // GET /api/skills/:name - Get detailed skill info
+      // GET /api/skills/:name - Get detailed skill info. Accepts both
+      // user skills (`skill-factory`) and plugin skills prefixed with
+      // the package path (`<package>:<skill>`, e.g. `telegram:access`).
       const globalSkillDetailMatch = path.match(/^\/api\/skills\/([^/]+)$/)
       if (globalSkillDetailMatch && method === 'GET') {
         const skillName = decodeURIComponent(globalSkillDetailMatch[1])
+
+        // Plugin-shaped name: everything before the last colon is the
+        // package path, after it is the skill directory inside
+        // <plugin-root>/skills/<skill>. We mirror the list endpoint's
+        // walk to locate the directory rather than trusting the
+        // client-supplied path blindly.
+        if (skillName.includes(':')) {
+          const lastColon = skillName.lastIndexOf(':')
+          const pluginPath = skillName.slice(0, lastColon)
+          const skillBasename = skillName.slice(lastColon + 1)
+          const PLUGINS_CACHE_DIR = join(homedir(), '.claude', 'plugins', 'cache')
+          const skillDir = join(PLUGINS_CACHE_DIR, ...pluginPath.split('/'), 'skills', skillBasename)
+          // Defence against path-traversal via malicious ':' usage.
+          if (!skillDir.startsWith(PLUGINS_CACHE_DIR + sep)) {
+            return json(res, { error: 'Skill not found' }, 404)
+          }
+          const skillMdPath = join(skillDir, 'SKILL.md')
+          if (!existsSync(skillMdPath)) return json(res, { error: 'Skill not found' }, 404)
+          const content = readFileOr(skillMdPath, '')
+          const files: string[] = []
+          try { for (const entry of readdirSync(skillDir)) files.push(entry) } catch { /* no-op */ }
+          return json(res, {
+            name: skillName,
+            description: parseSkillDescription(content),
+            content,
+            agents: [],
+            path: skillDir,
+            files,
+            source: 'plugin',
+            pluginPackage: pluginPath,
+          })
+        }
+
         const GLOBAL_SKILLS_DIR = join(homedir(), '.claude', 'skills')
         const skillDir = join(GLOBAL_SKILLS_DIR, skillName)
-
+        // Path-traversal guard: a URL-encoded `..%2F..%2F.ssh` in the
+        // skillName would otherwise let the handler readdirSync an
+        // arbitrary user path and leak filenames through files[].
+        if (!skillDir.startsWith(GLOBAL_SKILLS_DIR + sep)) {
+          return json(res, { error: 'Skill not found' }, 404)
+        }
         if (!existsSync(skillDir)) return json(res, { error: 'Skill not found' }, 404)
 
         const skillMdPath = join(skillDir, 'SKILL.md')
         const content = readFileOr(skillMdPath, '')
         const description = parseSkillDescription(content)
 
-        // List files in the skill directory
         const files: string[] = []
         try {
           for (const entry of readdirSync(skillDir)) files.push(entry)
@@ -4105,7 +4297,161 @@ Respond ONLY with JSON, nothing else:
           agents: getSkillAgents(skillName),
           path: skillDir,
           files,
+          source: 'user',
         })
+      }
+
+      // POST /api/skills - Create a new skill under ~/.claude/skills/<name>
+      // Parallel to /api/agents/:name/skills (per-agent create) but
+      // writes to the user-global skills directory so the new Skills
+      // page "Új skill" button has somewhere to POST. The per-agent
+      // endpoint stays as-is for the Agent detail modal's skill list.
+      if (path === '/api/skills' && method === 'POST') {
+        const body = await readBody(req)
+        const { name: rawSkillName, description } = JSON.parse(body.toString()) as { name: string; description: string }
+        // Use the same sanitizer as the DELETE path on /api/agents/:name/skills/:skillName
+        // so skill-name rules stay in one place; agent names have stricter
+        // length / charset rules that would reject valid skill names.
+        const skillName = sanitizeSkillName(rawSkillName || '')
+        if (!skillName) return json(res, { error: 'Skill name is required' }, 400)
+        if (!description) return json(res, { error: 'Skill description is required' }, 400)
+
+        const GLOBAL_SKILLS_DIR = join(homedir(), '.claude', 'skills')
+        const skillDir = join(GLOBAL_SKILLS_DIR, skillName)
+        // Path-traversal guard for the same reason as the detail
+        // endpoint: sanitizeAgentName normally scrubs `/` and `..`,
+        // but this is defence-in-depth against a future regression
+        // in the sanitiser.
+        if (!skillDir.startsWith(GLOBAL_SKILLS_DIR + sep)) {
+          return json(res, { error: 'Invalid skill name' }, 400)
+        }
+        if (existsSync(skillDir)) return json(res, { error: 'Skill already exists' }, 409)
+        mkdirSync(skillDir, { recursive: true })
+
+        try {
+          const skillMd = await generateSkillMd(skillName, description)
+          atomicWriteFileSync(join(skillDir, 'SKILL.md'), skillMd)
+        } catch (err) {
+          rmSync(skillDir, { recursive: true, force: true })
+          return json(res, { error: 'Failed to generate skill' }, 500)
+        }
+        return json(res, { ok: true, name: skillName })
+      }
+
+      // POST /api/skills/import - Import a .skill zip into the
+      // user-global skills directory. Mirrors
+      // /api/agents/:name/skills/import with the target path swapped;
+      // the zip-extraction hardening (path-traversal + symlink
+      // rejection) is duplicated on purpose so a future refactor of
+      // one endpoint cannot silently weaken the other.
+      if (path === '/api/skills/import' && method === 'POST') {
+        const body = await readBody(req)
+        const contentType = req.headers['content-type'] || ''
+        const { file } = parseMultipart(body, contentType)
+        if (!file) return json(res, { error: 'No file uploaded' }, 400)
+
+        const skillsDir = join(homedir(), '.claude', 'skills')
+        mkdirSync(skillsDir, { recursive: true })
+
+        const tmpPath = join(skillsDir, `_import_${randomUUID()}.zip`)
+        // Snapshot pre-import state outside the try so the catch can
+        // roll back partially-extracted files after a crashed unzip.
+        const before = new Set(readdirSync(skillsDir))
+        try {
+          writeFileSync(tmpPath, file.data)
+          const listOutput = execSync(`unzip -Z1 "${tmpPath}" 2>&1`, { timeout: 5000, encoding: 'utf-8' })
+          const entries = listOutput.split('\n').map(l => l.trim()).filter(Boolean)
+          for (const entry of entries) {
+            if (entry.includes('..') || entry.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry)) {
+              unlinkSync(tmpPath)
+              return json(res, { error: 'Invalid skill file: path traversal detected' }, 400)
+            }
+          }
+          // Refuse to silently overwrite an existing global skill. The
+          // zip's top-level directory names are what would collide, so
+          // check those before extraction. Global skills are shared
+          // across every agent HOME, so an accidental merge has a
+          // wider blast radius than in the per-agent case.
+          const topLevel = new Set<string>()
+          for (const entry of entries) {
+            const seg = entry.split('/')[0]
+            if (seg) topLevel.add(seg)
+          }
+          for (const td of topLevel) {
+            if (before.has(td)) {
+              unlinkSync(tmpPath)
+              return json(res, {
+                error: `Skill already exists: ${td}. Delete it first if you want to overwrite.`,
+              }, 409)
+            }
+          }
+          execSync(`unzip -o "${tmpPath}" -d "${skillsDir}"`, { timeout: 10000 })
+          unlinkSync(tmpPath)
+
+          const after = readdirSync(skillsDir).filter(f => !before.has(f))
+          const rejectSymlinks = (dir: string): boolean => {
+            for (const entry of readdirSync(dir)) {
+              const p = join(dir, entry)
+              const st = lstatSync(p)
+              if (st.isSymbolicLink()) return true
+              if (st.isDirectory() && rejectSymlinks(p)) return true
+            }
+            return false
+          }
+          // Check ALL newly-extracted entries for symlinks before
+          // deciding what to keep. Without the collect-then-decide
+          // pattern, a zip with a clean entry + a tainted entry would
+          // leave the clean one installed while the handler returns
+          // 400 for the tainted one.
+          const tainted: string[] = []
+          for (const f of after) {
+            const p = join(skillsDir, f)
+            try {
+              if (lstatSync(p).isSymbolicLink() || (statSync(p).isDirectory() && rejectSymlinks(p))) {
+                tainted.push(f)
+              }
+            } catch { /* ignored */ }
+          }
+          if (tainted.length > 0) {
+            for (const f of after) {
+              try { rmSync(join(skillsDir, f), { recursive: true, force: true }) } catch { /* best effort */ }
+            }
+            return json(res, { error: 'Invalid skill file: symlink entries rejected' }, 400)
+          }
+
+          // Only report the entries that did NOT exist before the
+          // import, so the UI toast does not lie by listing every
+          // skill in the global directory as "just imported".
+          const extracted = after.filter(f => {
+            const p = join(skillsDir, f)
+            try { return statSync(p).isDirectory() && existsSync(join(p, 'SKILL.md')) } catch { return false }
+          })
+          // If the zip contained no top-level directory with a
+          // SKILL.md, there is nothing to keep. Clean up any extracted
+          // files and surface a 400 so the UI does not show a
+          // "Skill importálva: " toast with an empty list.
+          if (extracted.length === 0) {
+            for (const f of after) {
+              try { rmSync(join(skillsDir, f), { recursive: true, force: true }) } catch { /* best effort */ }
+            }
+            return json(res, { error: 'No valid skill (SKILL.md) found in archive' }, 400)
+          }
+
+          logger.info({ skills: extracted }, 'Global skill(s) imported')
+          return json(res, { ok: true, imported: extracted })
+        } catch (err) {
+          try { unlinkSync(tmpPath) } catch { /* ignored */ }
+          // Roll back partially-extracted files so a crashed unzip
+          // does not leave a half-installed global skill behind.
+          try {
+            const leftover = readdirSync(skillsDir).filter(f => !before.has(f))
+            for (const f of leftover) {
+              try { rmSync(join(skillsDir, f), { recursive: true, force: true }) } catch { /* best effort */ }
+            }
+          } catch { /* dir gone or unreadable; nothing to do */ }
+          logger.error({ err }, 'Failed to import global skill')
+          return json(res, { error: 'Failed to extract .skill file' }, 500)
+        }
       }
 
       // POST /api/skills/:name/assign - Assign skill to agents
@@ -4114,6 +4460,15 @@ Respond ONLY with JSON, nothing else:
         const skillName = decodeURIComponent(globalSkillAssignMatch[1])
         const GLOBAL_SKILLS_DIR = join(homedir(), '.claude', 'skills')
         const globalSkillDir = join(GLOBAL_SKILLS_DIR, skillName)
+
+        // Path-traversal guard: mirror the detail endpoint's startsWith
+        // check. A URL-encoded `..%2F..%2F.ssh` decodes past the
+        // `[^/]+` route regex and would otherwise let the handler
+        // `cp -r` arbitrary user directories into agent dirs and
+        // rmSync the same name out of non-targeted agents.
+        if (!globalSkillDir.startsWith(GLOBAL_SKILLS_DIR + sep)) {
+          return json(res, { error: 'Skill not found' }, 404)
+        }
 
         if (!existsSync(globalSkillDir)) return json(res, { error: 'Skill not found' }, 404)
 

--- a/web/app.js
+++ b/web/app.js
@@ -465,6 +465,11 @@ function openModal(overlay) {
 function closeModal(overlay) {
   overlay.classList.remove('active')
   document.body.style.overflow = ''
+  // Skill modal is used by two distinct callers (Agent detail + Skills
+  // page). Reset the scope on every close path -- explicit button,
+  // click-outside, Esc, programmatic -- so the next opener cannot
+  // inherit a stale 'global' flag from an earlier Skills-page open.
+  if (overlay && overlay.id === 'skillModalOverlay') skillModalScope = null
 }
 
 // Wizard open
@@ -1395,6 +1400,7 @@ async function loadSkills(agentName) {
 
 // Add skill button
 document.getElementById('addSkillBtn').addEventListener('click', () => {
+  skillModalScope = null  // per-agent flow keyed off currentAgent
   document.getElementById('skillName').value = ''
   document.getElementById('skillDescription').value = ''
   skillFile = null
@@ -1437,7 +1443,8 @@ skillFileInput.addEventListener('change', () => {
 
 // Create skill
 document.getElementById('saveSkillBtn').addEventListener('click', async () => {
-  if (!currentAgent) return
+  const isGlobal = skillModalScope === 'global'
+  if (!isGlobal && !currentAgent) return
   const name = document.getElementById('skillName').value.trim()
   if (!name) { document.getElementById('skillName').focus(); return }
 
@@ -1447,7 +1454,10 @@ document.getElementById('saveSkillBtn').addEventListener('click', async () => {
   btn.querySelector('.btn-loading').hidden = false
 
   try {
-    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/skills`, {
+    const url = isGlobal
+      ? '/api/skills'
+      : `/api/agents/${encodeURIComponent(currentAgent.name)}/skills`
+    const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -1461,7 +1471,11 @@ document.getElementById('saveSkillBtn').addEventListener('click', async () => {
     }
     closeModal(skillModalOverlay)
     showToast('Skill hozzáadva')
-    loadSkills(currentAgent.name)
+    if (isGlobal) {
+      loadGlobalSkills()
+    } else {
+      loadSkills(currentAgent.name)
+    }
   } catch (err) {
     showToast(`Hiba: ${err.message}`)
   } finally {
@@ -1473,7 +1487,9 @@ document.getElementById('saveSkillBtn').addEventListener('click', async () => {
 
 // Import skill
 document.getElementById('importSkillBtn').addEventListener('click', async () => {
-  if (!currentAgent || !skillFile) { showToast('Válassz egy .skill fájlt'); return }
+  const isGlobal = skillModalScope === 'global'
+  if (!skillFile) { showToast('Válassz egy .skill fájlt'); return }
+  if (!isGlobal && !currentAgent) { showToast('Válassz egy .skill fájlt'); return }
 
   const btn = document.getElementById('importSkillBtn')
   btn.disabled = true
@@ -1483,7 +1499,10 @@ document.getElementById('importSkillBtn').addEventListener('click', async () => 
   try {
     const formData = new FormData()
     formData.append('file', skillFile)
-    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/skills/import`, {
+    const url = isGlobal
+      ? '/api/skills/import'
+      : `/api/agents/${encodeURIComponent(currentAgent.name)}/skills/import`
+    const res = await fetch(url, {
       method: 'POST',
       body: formData,
     })
@@ -1493,10 +1512,15 @@ document.getElementById('importSkillBtn').addEventListener('click', async () => 
     }
     const result = await res.json()
     closeModal(skillModalOverlay)
-    showToast(`Skill importálva: ${result.imported.join(', ')}`)
+    const importedList = Array.isArray(result.imported) ? result.imported : []
+    showToast(`Skill importálva: ${importedList.join(', ')}`)
     skillFile = null
     document.getElementById('skillFileName').textContent = ''
-    loadSkills(currentAgent.name)
+    if (isGlobal) {
+      loadGlobalSkills()
+    } else {
+      loadSkills(currentAgent.name)
+    }
   } catch (err) {
     showToast(`Hiba: ${err.message}`)
   } finally {
@@ -4200,6 +4224,32 @@ let globalSkills = []
 document.getElementById('skillDetailClose').addEventListener('click', () => closeModal(skillDetailOverlay))
 skillDetailOverlay.addEventListener('click', (e) => { if (e.target === skillDetailOverlay) closeModal(skillDetailOverlay) })
 
+// Scope for the next skill create/import action. 'global' means the
+// Skills page opened the modal (write to ~/.claude/skills/); any other
+// value (or null) falls back to the legacy per-agent flow keyed off
+// `currentAgent`. Reset on modal close so a subsequent per-agent open
+// cannot inherit the global scope.
+let skillModalScope = null
+
+// Wire the Skills-page "Új skill" button to reuse the same skillModalOverlay
+// the per-agent Skill list uses. The save/import handlers branch on
+// skillModalScope so we don't have to duplicate the modal markup.
+const skillsPageNewBtn = document.getElementById('skillsPageNewBtn')
+if (skillsPageNewBtn) {
+  skillsPageNewBtn.addEventListener('click', () => {
+    skillModalScope = 'global'
+    document.getElementById('skillName').value = ''
+    document.getElementById('skillDescription').value = ''
+    skillFile = null
+    document.getElementById('skillFileName').textContent = ''
+    document.querySelectorAll('.skill-tab-btn').forEach(b => b.classList.toggle('active', b.dataset.skillTab === 'create'))
+    document.getElementById('skillTabCreate').hidden = false
+    document.getElementById('skillTabImport').hidden = true
+    openModal(skillModalOverlay)
+    setTimeout(() => document.getElementById('skillName').focus(), 200)
+  })
+}
+
 async function loadGlobalSkills() {
   skillsGrid.innerHTML = '<div class="connector-loading"><span class="spinner"></span> Skillek betoltese...</div>'
   skillsStats.innerHTML = ''
@@ -4229,14 +4279,14 @@ function renderGlobalSkills() {
   skillsGrid.innerHTML = ''
 
   const withSkillMd = globalSkills.filter(s => s.description)
-  const totalAssigned = globalSkills.reduce((sum, s) => sum + s.agents.length, 0)
-  const unassigned = globalSkills.filter(s => s.agents.length === 0).length
+  const userCount = globalSkills.filter(s => s.source === 'user').length
+  const pluginCount = globalSkills.filter(s => s.source === 'plugin').length
 
   skillsStats.innerHTML = `
-    <div class="stat-card"><div class="stat-value">${globalSkills.length}</div><div class="stat-label">Osszes skill</div></div>
-    <div class="stat-card"><div class="stat-value" style="color:var(--success)">${withSkillMd.length}</div><div class="stat-label">Dokumentalt</div></div>
-    <div class="stat-card"><div class="stat-value" style="color:var(--info)">${totalAssigned}</div><div class="stat-label">Hozzarendelesek</div></div>
-    ${unassigned ? `<div class="stat-card"><div class="stat-value" style="color:var(--text-muted)">${unassigned}</div><div class="stat-label">Nincs ügynöknél</div></div>` : ''}
+    <div class="stat-card"><div class="stat-value">${globalSkills.length}</div><div class="stat-label">Összes</div></div>
+    <div class="stat-card"><div class="stat-value" style="color:var(--info)">${userCount}</div><div class="stat-label">User (saját)</div></div>
+    ${pluginCount ? `<div class="stat-card"><div class="stat-value" style="color:var(--accent)">${pluginCount}</div><div class="stat-label">Plugin</div></div>` : ''}
+    <div class="stat-card"><div class="stat-value" style="color:var(--success)">${withSkillMd.length}</div><div class="stat-label">Dokumentált</div></div>
   `
 
   if (globalSkills.length === 0) {
@@ -4245,33 +4295,33 @@ function renderGlobalSkills() {
   }
   skillsEmpty.hidden = true
 
+  const sourceLabels = { user: 'user', plugin: 'plugin' }
+
   for (const skill of globalSkills) {
     const card = document.createElement('div')
     card.className = 'skills-card'
     const icon = getSkillIcon(skill.name)
-    const agentBadges = skill.agents.length > 0
-      ? skill.agents.map(a => `<span class="skills-agent-badge">${escapeHtml(a)}</span>`).join('')
-      : '<span class="skills-agent-badge none">nincs hozzarendelve</span>'
+    const sourceBadge = skill.source
+      ? `<span class="connector-source-badge">${escapeHtml(sourceLabels[skill.source] || skill.source)}</span>`
+      : ''
 
+    const displayName = skill.label || skill.name
     card.innerHTML = `
       <div class="skills-card-header">
         <div class="skills-card-icon">${icon}</div>
         <div class="skills-card-info">
-          <div class="skills-card-name">${escapeHtml(skill.name)}</div>
-          <div class="skills-card-desc">${escapeHtml(skill.description || 'Nincs leiras')}</div>
+          <div class="skills-card-name">${escapeHtml(displayName)} ${sourceBadge}</div>
+          <div class="skills-card-desc">${escapeHtml(skill.description || 'Nincs leírás')}</div>
         </div>
       </div>
-      <div class="skills-card-footer">
-        ${agentBadges}
-      </div>
     `
-    card.addEventListener('click', () => openSkillDetail(skill.name))
+    card.addEventListener('click', () => openSkillDetail(skill.name, skill.label))
     skillsGrid.appendChild(card)
   }
 }
 
-async function openSkillDetail(skillName) {
-  document.getElementById('skillDetailTitle').textContent = skillName
+async function openSkillDetail(skillName, displayLabel) {
+  document.getElementById('skillDetailTitle').textContent = displayLabel || skillName
 
   try {
     const res = await fetch(`/api/skills/${encodeURIComponent(skillName)}`)
@@ -4280,89 +4330,34 @@ async function openSkillDetail(skillName) {
 
     // Description
     const descEl = document.getElementById('skillDetailDesc')
-    descEl.textContent = detail.description || 'Nincs leiras'
+    descEl.textContent = detail.description || 'Nincs leírás'
+
+    // Meta line: source + path. Replaces the old per-agent assignment
+    // UI -- sub-agents share the caller's HOME, so the skill is already
+    // available to every agent without any copy-to-agent action.
+    const metaEl = document.getElementById('skillDetailMeta')
+    if (metaEl) {
+      const sourceLabel = detail.source === 'plugin'
+        ? `plugin${detail.pluginPackage ? ' (' + escapeHtml(detail.pluginPackage) + ')' : ''}`
+        : detail.source === 'user'
+        ? 'user (saját fájl)'
+        : 'ismeretlen'
+      metaEl.innerHTML = `
+        <div class="skill-detail-source">Forrás: <strong>${sourceLabel}</strong></div>
+        <div class="skill-detail-note">Automatikusan elérhető minden sub-agent számára (közös HOME).</div>
+      `
+    }
 
     // Content
     const contentEl = document.getElementById('skillDetailContent')
-    contentEl.textContent = detail.content || '(SKILL.md nem talalhato)'
-
-    // Agent checkboxes
-    const checkboxesEl = document.getElementById('skillAgentCheckboxes')
-    checkboxesEl.innerHTML = ''
-
-    try {
-      const agentsRes = await fetch('/api/schedules/agents')
-      const allAgents = await agentsRes.json()
-      const mainAgent = allAgents.find(a => a.name === 'marveen')
-      const subAgents = allAgents.filter(a => a.name !== 'marveen')
-
-      // Marveen auto-loads everything from ~/.claude/skills/, so she's
-      // shown as a fixed checked-disabled entry. Sub-agents need explicit
-      // assignment because the skill dir is copied into agents/<n>/.claude/skills/.
-      if (mainAgent) {
-        const item = document.createElement('div')
-        item.className = 'skill-agent-checkbox skill-agent-auto'
-        item.innerHTML = `
-          <input type="checkbox" checked disabled title="Globálisan elérhető a fő agentnek -- nem kell külön hozzárendelni">
-          <label>${escapeHtml(mainAgent.label || mainAgent.name)} <span class="tag-auto">automatikus</span></label>
-        `
-        checkboxesEl.appendChild(item)
-      }
-      for (const agent of subAgents) {
-        const isChecked = detail.agents.includes(agent.name)
-        const item = document.createElement('div')
-        item.className = 'skill-agent-checkbox'
-        item.innerHTML = `
-          <input type="checkbox" id="skill-assign-${agent.name}" value="${agent.name}" ${isChecked ? 'checked' : ''}>
-          <label for="skill-assign-${agent.name}">${escapeHtml(agent.label || agent.name)}</label>
-        `
-        checkboxesEl.appendChild(item)
-      }
-      if (subAgents.length === 0 && !mainAgent) {
-        checkboxesEl.innerHTML = '<p style="color:var(--text-muted);font-size:13px">Nincsenek hozzarendelheto ügynökök</p>'
-      } else if (subAgents.length === 0) {
-        const note = document.createElement('p')
-        note.style.cssText = 'color:var(--text-muted);font-size:12px;margin-top:8px'
-        note.textContent = 'Sub-agenteknek hozzárendelés a Csapat oldalon létrehozott új ügynök után érhető el.'
-        checkboxesEl.appendChild(note)
-      }
-    } catch {
-      checkboxesEl.innerHTML = '<p style="color:var(--text-muted);font-size:13px">Ügynökök betoltese sikertelen</p>'
-    }
-
-    // Assign button
-    const assignBtn = document.getElementById('skillAssignBtn')
-    assignBtn.onclick = async () => {
-      const checked = checkboxesEl.querySelectorAll('input[type="checkbox"]:checked')
-      const agents = Array.from(checked).map(cb => cb.value)
-
-      assignBtn.disabled = true
-      assignBtn.querySelector('.btn-text').hidden = true
-      assignBtn.querySelector('.btn-loading').hidden = false
-
-      try {
-        const assignRes = await fetch(`/api/skills/${encodeURIComponent(skillName)}/assign`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ agents }),
-        })
-        if (!assignRes.ok) throw new Error('Assign failed')
-        showToast('Hozzarendeles mentve')
-        loadGlobalSkills()
-      } catch {
-        showToast('Hiba a mentes soran')
-      } finally {
-        assignBtn.disabled = false
-        assignBtn.querySelector('.btn-text').hidden = false
-        assignBtn.querySelector('.btn-loading').hidden = true
-      }
-    }
+    contentEl.textContent = detail.content || '(SKILL.md nem található)'
 
   } catch (err) {
     console.error('Skill detail hiba:', err)
-    document.getElementById('skillDetailDesc').textContent = 'Hiba a betoltes soran'
+    document.getElementById('skillDetailDesc').textContent = 'Hiba a betöltés során'
     document.getElementById('skillDetailContent').textContent = ''
-    document.getElementById('skillAgentCheckboxes').innerHTML = ''
+    const metaEl = document.getElementById('skillDetailMeta')
+    if (metaEl) metaEl.innerHTML = ''
   }
 
   openModal(skillDetailOverlay)

--- a/web/index.html
+++ b/web/index.html
@@ -241,8 +241,20 @@
         <div class="page-header-row">
           <div>
             <h1>Skillek</h1>
-            <p class="subtitle">Globalis skillek kezelese es hozzarendelese</p>
+            <p class="subtitle">A Claude Code által látott skillek (user mappa + plugin cache)</p>
           </div>
+          <button class="btn-primary btn-compact" id="skillsPageNewBtn">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+              <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+            </svg>
+            Új skill
+          </button>
+        </div>
+        <div class="info-box" id="skillsInfoBox">
+          Minden itt listázott skill automatikusan elérhető minden sub-agent számára, mert ugyanabban a HOME-ban futnak, mint a fő session.
+          A Claude CLI beépített slash-parancsai (init, review, security-review, loop, schedule, stb.) mindig elérhetők,
+          de itt nem szerepelnek, mert a `claude` binárisban élnek és nem fájlrendszeri források.
+          Új skillt a jobb felső "Új skill" gombbal tudsz létrehozni vagy importálni.
         </div>
       </div>
       <div class="skills-stats" id="skillsStats"></div>
@@ -251,7 +263,7 @@
         <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
           <path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/>
         </svg>
-        <p>Nincsenek globalis skillek</p>
+        <p>Nincsenek skillek</p>
       </div>
     </div>
 
@@ -1238,14 +1250,7 @@
       </div>
       <div class="modal-body">
         <div class="skill-detail-desc" id="skillDetailDesc"></div>
-        <div class="skill-detail-agents">
-          <label class="form-label-sm">Hozzarendeles ügynökökhöz</label>
-          <div class="skill-agent-checkboxes" id="skillAgentCheckboxes"></div>
-          <button class="btn-primary btn-compact" id="skillAssignBtn" style="margin-top:12px">
-            <span class="btn-text">Mentes</span>
-            <span class="btn-loading" hidden><span class="spinner"></span> Mentes...</span>
-          </button>
-        </div>
+        <div class="skill-detail-meta" id="skillDetailMeta"></div>
         <div class="skill-detail-content-wrap">
           <label class="form-label-sm">SKILL.md tartalom</label>
           <div class="skill-detail-content" id="skillDetailContent"></div>

--- a/web/style.css
+++ b/web/style.css
@@ -3402,6 +3402,20 @@ main {
   border-radius: var(--radius-sm);
 }
 
+.skill-detail-meta {
+  margin: 0 0 20px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+.skill-detail-meta .skill-detail-source strong {
+  color: var(--text);
+}
+.skill-detail-meta .skill-detail-note {
+  margin-top: 2px;
+  font-style: italic;
+}
+
 .skill-detail-agents {
   margin-bottom: 24px;
 }


### PR DESCRIPTION
## Why this matters

The Skills page currently gives an incomplete and slightly misleading picture of what a sub-agent actually sees:

1. **Plugin skills are missing.** The list walks only `~/.claude/skills/<name>/SKILL.md`, so marketplace-plugin skills (e.g. `telegram:access`, `telegram:configure` from the `claude-plugins-official/telegram` plugin) never appear -- even though every sub-agent sees them via Claude Code.

2. **"Hozzárendelés" is a no-op in today's single-HOME setup.** Each sub-agent inherits the caller's HOME (`cd agents/<n> && claude ...`), so every listed skill is already available to every agent. The per-agent copy produced by `POST /api/skills/:name/assign` lands in `agents/<n>/.claude/skills/<skill>/`, where Claude Code would have read the same content out of `~/.claude/skills/` regardless.

3. **"Új skill" / "Import" buttons only exist inside the Agent detail modal.** A user who wants to add a skill globally has to open an Agent, add it there, and it ends up in that agent's private directory -- not in the shared user-global directory.

4. **Security gaps.** The user-skill detail GET at `/api/skills/:name` and the assign POST at `/api/skills/:name/assign` had no path-traversal guard. A URL-encoded `..%2F..%2F.ssh` decoded past the `[^/]+` route regex and would either leak filenames via `files[]` or (on assign) `cp -r` arbitrary directories into every sub-agent's skills dir plus `rmSync` the same name from non-targeted agents. Same-class guards were added on the plugin branch when it was introduced and are now applied consistently.

Reproducible on any host with the telegram plugin enabled: the Skills page shows 3 user skills while `~/.claude/plugins/cache/claude-plugins-official/telegram/*/skills/` has 2 more that never surface.

## Change

**New behaviour:**

- `GET /api/skills` now walks `~/.claude/plugins/cache/**` up to depth 4 for every directory that contains a `skills/` subdir. Each skill is tagged `source: 'plugin'` with a canonical `name` (`<package-path>:<skill>` for the detail endpoint) and a short `label` (`<plugin>:<skill>`) for the UI. User-global skills stay `source: 'user'`. Results are sorted user-first, then plugin, each alphabetically by label. Built-in Claude CLI slash commands (init, review, security-review, loop, schedule, etc.) are documented in the info-box but not enumerated because they live inside the `claude` binary.

- `GET /api/skills/:name` resolves plugin-shaped names by splitting on the last `:` and walking the pluginPackage path segments under the plugin cache. Adds a `startsWith(PLUGINS_CACHE_DIR + sep)` path-traversal guard. Adds the symmetric `startsWith(GLOBAL_SKILLS_DIR + sep)` guard on the user-skill branch. Adds the same guard on `POST /api/skills/:name/assign`.

- `POST /api/skills` (new) creates a skill under `~/.claude/skills/<name>/SKILL.md`. Mirrors `POST /api/agents/:name/skills` with the global target and the same `sanitizeSkillName` + collision check. The per-agent POST also switches from `sanitizeAgentName` to `sanitizeSkillName` so the two skill-name namespaces stay in sync.

- `POST /api/skills/import` (new) imports a `.skill` zip into `~/.claude/skills/`. Duplicates the per-agent import's zip hardening (path-traversal rejection on listed entries, symlink rejection after extraction) and adds three new safety checks that both endpoints now share:
  - Top-level collision with an existing global skill returns 409 `"Skill already exists: <name>. Delete it first if you want to overwrite."` instead of silently merging (`unzip -o` default). Global skills affect every agent HOME, so the blast radius of an accidental overwrite is wider than in the per-agent case.
  - Symlink rejection uses collect-then-decide. A zip with one clean entry and one tainted entry used to leave the clean one partially installed before returning 400; now the whole import is rolled back.
  - Empty-extracted zip returns 400 `"No valid skill (SKILL.md) found in archive"` with rollback, instead of `ok: true, imported: []` and a misleading `Skill importálva: ` toast.
  - The `catch` block rolls back partially-extracted files after an `unzip` crash / SIGTERM, so the next import does not collide with orphans or silently merge.

- The per-agent `POST /api/agents/:name/skills/import` receives the same three hardening upgrades (collect-then-decide symlink, empty rollback, catch-block rollback) so the two import endpoints stay symmetric.

**Frontend:**

- The per-agent assignment UI inside the skill detail modal is replaced with a read-only meta line that names the skill's source (`user (saját fájl)` or `plugin (<package-path>)`) and notes that every sub-agent already sees it through the shared HOME.

- The Skills page grows an "Új skill" button that opens the existing `skillModalOverlay`. A new `skillModalScope = 'global'` flag tells `saveSkillBtn` and `importSkillBtn` to POST to the global endpoints. The flag resets inside `closeModal(overlay)` itself, so every close path -- button, click-outside, Esc, programmatic -- clears the scope and the next Agent-detail open cannot inherit a stale `'global'`.

- The import toast guards against a non-array `result.imported` via `Array.isArray`. Source badges and an info-box surface the scope boundary to the user.

## Scope / compatibility

- `POST /api/skills/:name/assign` backend flow is intact. It has no UI surface in this PR, but the endpoint survives for a future multi-HOME deployment where the copy would become meaningful.
- `mcp-catalog.json` and agent-level skill schemas are unchanged.
- `/api/skills` response shape gains `source`, `label`, `pluginPackage` fields. Consumers that ignore unknown fields are unaffected. No existing field semantics change.

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npx vitest run` -- 78/78 passing (this PR is IO-bound endpoint logic with no new pure-function surface; parser-style unit tests would need a filesystem fixture harness that is out of scope).
- [x] Live smoke: `GET /api/skills` returns 3 user entries + 2 plugin entries (`telegram:access`, `telegram:configure`).
- [x] `POST /api/skills` with `{name: 'test-pr2', description: '...'}` creates `~/.claude/skills/test-pr2/SKILL.md`; subsequent list includes it.
- [x] `POST /api/skills/:name/assign` with `%2E%2E%2F.ssh` as name returns 404 "Skill not found".
- [x] `GET /api/skills/:name` with a plugin-shaped URL-encoded name resolves to the right `SKILL.md` and reports `source: 'plugin'` + `pluginPackage`.
- [x] Sensitive-data grep on the diff: zero matches for operator/user/agent/path identifiers.
- [x] Em-dash grep on the diff: zero `U+2014`.

## Known limitations

- Windows path handling (`C:\\Users\\...`) is not covered; darwin + Linux only.
- Built-in Claude CLI slash commands (init, review, security-review, loop, schedule, simplify, keybindings-help, fewer-permission-prompts, claude-api) are mentioned in the info-box but not enumerated on the list, because they live inside the `claude` binary. Adding them would require maintaining a hard-coded list that drifts with every CLI release.
- The per-agent assign flow is still backend-only and will wake up again if a future PR introduces per-agent HOMEs for multi-subscription setups. Until then it is dormant.

## Context

This is the second of a 3-PR series addressing Connectors + Skills + Built-in UX gaps on the dashboard. PR1 (`v3-07-mcp-state-detection`) is already up as a draft (#32). PR3 will come for the "Computer Use / Claude in Chrome" hard-coded built-in UI rows. Each PR can merge independently.

Six adversarial rounds to convergence, with two consecutive zero-finding rounds closing the loop. 16 real findings folded into the history.