### PR TITLE
connectors: make built-in Computer Use / Chrome rows actually clickable

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -3561,24 +3561,94 @@ async function loadConnectors() {
   }
 }
 
+// Built-in MCPs: features that live inside the Claude Code binary or
+// app rather than as a registered MCP server. They cannot be detected
+// via `claude mcp list`, so the "Aktív / Kikapcsolva" label used to
+// always read "Kikapcsolva" regardless of the real state. Replace the
+// misleading state badge with a "Részletek" button that opens a modal
+// carrying the real enable instructions (which previously hid inside
+// a `title` tooltip the user had to hover to discover).
 const BUILTIN_MCPS = [
-  { name: 'computer-use', label: 'Computer Use', desc: 'Képernyő vezérlés, kattintás, gépelés', enableHint: 'Engedélyezés: tmux attach -> /mcp -> computer-use -> Enable' },
-  { name: 'chrome', label: 'Claude in Chrome', desc: 'Böngésző automatizálás', enableHint: '--chrome flag-gel indítva' },
+  {
+    name: 'computer-use',
+    label: 'Computer Use',
+    desc: 'Képernyő vezérlés, kattintás, gépelés',
+    detailHtml: `
+      <p>A Computer Use egy natív Claude képesség, amit nem a Marveen kezel, hanem maga a Claude Code CLI / Claude alkalmazás.
+      Nem jelenik meg a <code>claude mcp list</code> kimenetében, ezért a dashboard sem tudja automatikusan detektálni.</p>
+      <p><strong>Bekapcsolás:</strong> a pontos folyamat a Claude verziójától függ és változhat verziók között.
+      Kövesd az Anthropic hivatalos dokumentációját és a Claude Code changelogot.
+      A fő session tmux-nevét az "Ügynökök" oldalon találod -- oda <code>tmux attach</code>-al tudsz belépni manuálisan.</p>
+      <p style="color:var(--text-muted)">Ez a képesség engedélyt ad az ügynöknek a képernyő vezérlésére és kattintásra, ezért csak megbízható környezetben használd.</p>
+    `,
+  },
+  {
+    name: 'chrome',
+    label: 'Claude in Chrome',
+    desc: 'Böngésző automatizálás',
+    detailHtml: `
+      <p>A Claude in Chrome egy indítás-idejű flag a Claude Code CLI-n, nem egy bekapcsolható MCP szerver.
+      Ezért nem jelenik meg a <code>claude mcp list</code> kimenetében, és a dashboard sem tudja automatikusan detektálni.</p>
+      <p><strong>Bekapcsolás:</strong> indítsd a Claude-ot a <code>--chrome</code> flaggel:</p>
+      <pre style="background:var(--bg-input);padding:8px 12px;border-radius:4px;font-size:12px;overflow-x:auto">claude --chrome</pre>
+      <p style="color:var(--text-muted)">A Chrome integráció lehetővé teszi a böngészőautomatizálást. A Marveen sub-agentek indítása jelenleg nem adja át ezt a flaget, így csak a manuálisan indított fő session használhatja.</p>
+    `,
+  },
 ]
+
+function openBuiltinDetail(item) {
+  const overlay = document.getElementById('builtinDetailOverlay')
+  if (!overlay) return
+  document.getElementById('builtinDetailTitle').textContent = item.label
+  document.getElementById('builtinDetailDesc').textContent = item.desc
+  // Static strings only. Never interpolate user or server input here
+  // without passing it through escapeHtml first -- detailHtml is a
+  // raw HTML sink.
+  document.getElementById('builtinDetailBody').innerHTML = item.detailHtml
+  openModal(overlay)
+  // Move focus into the dialog so keyboard users land inside the new
+  // surface instead of keeping the Részletek button focused behind
+  // the overlay. Same pattern the other modals in this file skip, but
+  // cheap to add for accessibility.
+  const closeBtn = document.getElementById('builtinDetailClose')
+  if (closeBtn) setTimeout(() => closeBtn.focus(), 50)
+}
+
+// Wire close paths for the built-in detail modal once per load. Guarded
+// so a future refactor that moves the script tag above the modal HTML
+// (e.g. deferred <head> load) does not fire a silent null-ref here.
+function wireBuiltinDetailModal() {
+  const overlay = document.getElementById('builtinDetailOverlay')
+  const closeBtn = document.getElementById('builtinDetailClose')
+  if (!overlay || !closeBtn) return
+  closeBtn.addEventListener('click', () => closeModal(overlay))
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) closeModal(overlay)
+  })
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', wireBuiltinDetailModal, { once: true })
+} else {
+  wireBuiltinDetailModal()
+}
 
 function renderConnectors() {
   // Builtin grid
   const builtinGrid = document.getElementById('connectorBuiltinGrid')
   builtinGrid.innerHTML = ''
   for (const b of BUILTIN_MCPS) {
-    const isActive = connectors.some(c => c.name.toLowerCase().includes(b.name))
     const div = document.createElement('div')
     div.className = 'connector-builtin'
+    // No state dot: we cannot reliably detect whether the feature is
+    // currently enabled. Show a dash placeholder so the row still
+    // aligns with other connector cards.
     div.innerHTML = `
-      <div class="connector-status-dot ${isActive ? 'connected' : 'unknown'}"></div>
+      <div class="connector-status-dot unknown" title="A dashboard nem tudja automatikusan detektálni ezt a képességet"></div>
       <div class="connector-builtin-name">${escapeHtml(b.label)}<br><span style="font-size:11px;color:var(--text-muted);font-weight:400">${escapeHtml(b.desc)}</span></div>
-      <span class="connector-builtin-action" title="${escapeHtml(b.enableHint)}">${isActive ? 'Aktív' : 'Kikapcsolva'}</span>
+      <button type="button" class="connector-builtin-action btn-link" data-builtin="${escapeHtml(b.name)}">Részletek</button>
     `
+    const btn = div.querySelector('button[data-builtin]')
+    if (btn) btn.addEventListener('click', () => openBuiltinDetail(b))
     builtinGrid.appendChild(div)
   }
 

--- a/web/index.html
+++ b/web/index.html
@@ -1254,6 +1254,22 @@
     </div>
   </div>
 
+  <!-- Built-in connector detail modal: enable instructions for
+       features that live inside the Claude Code CLI / app rather than
+       as a registered MCP server (Computer Use, Claude in Chrome). -->
+  <div class="modal-overlay" id="builtinDetailOverlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h2 id="builtinDetailTitle">Beépített képesség</h2>
+        <button class="modal-close" id="builtinDetailClose">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p id="builtinDetailDesc" style="color:var(--text-muted);font-size:13px;margin-bottom:12px"></p>
+        <div id="builtinDetailBody"></div>
+      </div>
+    </div>
+  </div>
+
   <div class="toast" id="toast"></div>
 
   <script src="/app.js"></script>

--- a/web/style.css
+++ b/web/style.css
@@ -2730,6 +2730,47 @@ main {
 }
 .connector-builtin-action:hover { text-decoration: underline; }
 
+/* Built-in row's "Részletek" button: carries the same action styling
+   but presents as an actual <button> with focus ring for keyboard
+   users. The bare <span> it replaced was unreachable by tab and
+   lacked a click handler despite looking like a control. */
+.connector-builtin-action.btn-link {
+  background: none;
+  border: none;
+  /* Inherit base .connector-builtin-action sizing so both visual
+     heights stay identical across built-in rows regardless of
+     whether a row ends with a span or a button. */
+  padding: 4px 8px;
+  font: inherit;
+  font-size: 11px;
+  color: var(--accent);
+  cursor: pointer;
+  border-radius: 4px;
+}
+.connector-builtin-action.btn-link:hover {
+  background: var(--bg-input);
+  text-decoration: underline;
+}
+.connector-builtin-action.btn-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* Inline <code> inside the built-in detail modal: give it a
+   distinct background so the command text stands out from the
+   surrounding prose in both light and dark themes. Scoped to the
+   new modal's body specifically; .modal-body is shared by ~13
+   other modals with their own <code> styling (Agent detail
+   Settings, Telegram instructions, etc.) that we must not
+   override. */
+#builtinDetailBody code {
+  background: var(--bg-input);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.92em;
+}
+
 .connector-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));


### PR DESCRIPTION
## Why this matters

The Built-in section of the Connectors page has two rows (Computer Use and Claude in Chrome). Both suffered three distinct UX problems:

1. **The "Kikapcsolva / Aktív" label always read "Kikapcsolva".** The state-detection logic was `connectors.some(c => c.name.toLowerCase().includes(b.name))`, matched against entries harvested from `claude mcp list`. Computer Use is a Claude Code runtime capability with no MCP-list presence; Claude in Chrome is a `--chrome` CLI flag at startup. Neither ever surfaces through `claude mcp list`, so the comparison was always false and the label was always misleading regardless of the actual feature state.

2. **The row looked like a control but was a plain `<span>`.** No click handler, no tab focus, no keyboard activation. Users clicked it expecting something to happen; nothing did.

3. **Enable instructions hid in a `title` tooltip.** The `enableHint` string ("Engedélyezés: tmux attach -> /mcp -> computer-use -> Enable") was only discoverable via hover, and even then only as a single-line tooltip. Non-obvious to new users, unreachable via keyboard.

Reproducible: click "Kikapcsolva" on Computer Use → absolutely nothing happens. Hover for ~0.5s → terse tooltip appears. Neither gets the user any closer to actually enabling the feature.

## Change

**Frontend only**, no backend surface:

- **Replaces the `<span>` with `<button type="button" class="connector-builtin-action btn-link">Részletek</button>`.** Keyboard-activatable, tab-focusable, `focus-visible` outline.

- **New `#builtinDetailOverlay` modal** populated by `openBuiltinDetail(item)`. Each `BUILTIN_MCPS` entry gains a `detailHtml` field carrying the full Hungarian enable instructions (much richer than the one-line tooltip). Title, description, and body render inside a standard modal shell.

- **Focus moves to the modal's close button** after open with a 50ms setTimeout, so keyboard users land inside the dialog instead of behind it.

- **Drops the misleading state label entirely.** The status dot now always reads `unknown` with a tooltip explaining the dashboard cannot detect these features, consistent with how other unknown-state rows render on the page.

- **Wiring guarded by `document.readyState`** so a future refactor that moves the script tag above the modal HTML (deferred head load, `type="module"`, etc.) still wires the close handlers correctly via `DOMContentLoaded`.

- **CSS is properly scoped.** `.connector-builtin-action.btn-link` normalises to the 11px base font-size of the surrounding row so both visual heights stay identical. A new `#builtinDetailBody code` rule gives inline `<code>` snippets a distinct background for the command text (e.g. `claude --chrome`, `claude mcp list`) in both light and dark themes; scoped to the new modal body specifically so the ~13 other modals in the file (Agent detail Settings, Telegram instructions, etc.) keep their existing `<code>` styling.

- **`detailHtml` is a static module-level template literal** with no user-input interpolation. An inline comment on the `innerHTML = item.detailHtml` sink warns future editors never to mix user or server data in without `escapeHtml` first.

## Scope / compatibility

- No backend surface, no new endpoints, no schema changes.
- `BUILTIN_MCPS` constant gains a `detailHtml` field and loses the `enableHint` tooltip field. Only callsite is `renderConnectors` and `openBuiltinDetail`; not exported.
- Dark-theme + light-theme verified via CSS variable usage (`--bg-input`, `--accent`).

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npx vitest run` -- 78/78 passing (no new pure-logic surface; IO-bound frontend change).
- [x] Live smoke: click "Részletek" on Computer Use -> modal opens with title "Computer Use", the Hungarian enable instructions, and an inline `<code>` snippet visually distinct from surrounding prose. Tab into the modal lands on close button. Esc / X / click-outside all close the modal.
- [x] Same for Claude in Chrome: `<pre>` code block shows `claude --chrome` with a readable background in both themes.
- [x] Grep on 13 other modals' `<code>` elements (Agent detail Settings `CLAUDE.md`, `SOUL.md`, `.mcp.json`, Telegram `/newbot`, etc.) -- unchanged appearance confirmed by CSS scope.
- [x] Sensitive-data grep on the diff: zero matches for operator / user / agent / path identifiers.
- [x] Em-dash grep on the diff: zero `U+2014`.

## Known limitations

- Windows instruction variants (`tmux` is Unix-only) are not surfaced; Marveen's deploy target is darwin + Linux.
- The modal has no `role="dialog"` / `aria-modal="true"` ARIA annotations. Neither does any other modal in this file; bringing that up is out of scope for this PR.
- Computer Use's exact enable flow may evolve with future Claude Code releases, so the instructions deliberately point at the Anthropic documentation and the Agents page (which already surfaces the main-agent's tmux session name) rather than prescribing a fixed sequence of commands that could go stale.

## Context

This is the third of a 3-PR series addressing Connectors + Skills + Built-in UX gaps on the dashboard.

- PR1 (`v3-07-mcp-state-detection`, #32) -- Connectors page state-detection and claude.ai OAuth connector listing.
- PR2 (`v3-08-skills-listing`, #33) -- Skills page plugin listing and global create/import.
- PR3 (this) -- Built-in section click behaviour.

Each PR can merge independently.

Three adversarial review rounds to convergence, with two consecutive zero-finding rounds closing the loop. Eight real findings folded into the history (misleading state label removed, hard-coded tmux session name, CSS specificity overrides bleeding into unrelated modals, font-size mismatch, focus management, DOMContentLoaded guard, XSS sink comment, keyboard accessibility).