### PR TITLE
startup: zombie-proof dashboard lock + graceful shutdown

### DIFF
--- a/src/__tests__/process-lock.test.ts
+++ b/src/__tests__/process-lock.test.ts
@@ -1,0 +1,689 @@
+import { describe, it, expect } from 'vitest'
+import {
+  findOwnNodeHolders,
+  findOwnBinaryMatches,
+  terminateProcesses,
+  acquirePortLock,
+  acquirePidfileLock,
+  writeBufferFully,
+  DeferToPeerError,
+  type ProcessLockContext,
+  type PidfileLockContext,
+} from '../process-lock.js'
+
+// Build a mock context backed by a mutable process table. Tests drive the
+// table directly so we can simulate PIDs dying at specific points, foreign
+// UIDs, non-node commands, etc. without ever touching real processes.
+
+interface MockProc { pid: number; uid: number; cmd: string; args?: string; alive: boolean }
+
+interface MockOptions {
+  currentPid?: number
+  uid?: number | null
+  procs?: MockProc[]
+  portHolders?: Record<number, number[]>
+  /** signal-probe override so tests can simulate EPERM etc. */
+  signalOverride?: ProcessLockContext['signal']
+}
+
+function makeCtx(options: MockOptions): {
+  ctx: ProcessLockContext
+  table: Map<number, MockProc>
+  sleptFor: number[]
+  logs: Array<{ level: string; msg: string; obj: Record<string, unknown> }>
+  signalCalls: Array<{ pid: number; sig: string }>
+} {
+  const table = new Map<number, MockProc>()
+  for (const p of options.procs ?? []) table.set(p.pid, { ...p })
+  const sleptFor: number[] = []
+  const logs: Array<{ level: string; msg: string; obj: Record<string, unknown> }> = []
+  const signalCalls: Array<{ pid: number; sig: string }> = []
+  const log = (level: string) => (obj: Record<string, unknown>, msg?: string) => {
+    logs.push({ level, msg: msg ?? '', obj })
+  }
+  const currentPid = options.currentPid ?? 100
+  const uid = options.uid === undefined ? 501 : options.uid
+  const defaultSignal: ProcessLockContext['signal'] = (pid, sig) => {
+    const p = table.get(pid)
+    if (!p || !p.alive) return 'gone'
+    if (sig === 0) return 'sent'
+    p.alive = false
+    return 'sent'
+  }
+  const ctx: ProcessLockContext = {
+    currentPid,
+    uid,
+    listPortHolders: (port: number) => options.portHolders?.[port] ?? [],
+    listOwnProcessesMatching: (pattern: RegExp) => {
+      const out: number[] = []
+      for (const p of table.values()) {
+        if (!p.alive) continue
+        if (p.pid === currentPid) continue
+        if (uid != null && p.uid !== uid) continue
+        const argv = p.args ?? p.cmd
+        if (pattern.test(argv)) out.push(p.pid)
+      }
+      return out
+    },
+    getProcessCommand: (pid: number) => table.get(pid)?.cmd ?? null,
+    getProcessUid: (pid: number) => {
+      const p = table.get(pid)
+      return p ? p.uid : null
+    },
+    signal: (pid, sig) => {
+      signalCalls.push({ pid, sig: String(sig) })
+      if (options.signalOverride) return options.signalOverride(pid, sig)
+      return defaultSignal(pid, sig)
+    },
+    sleep: async (ms: number) => {
+      sleptFor.push(ms)
+    },
+    log: { info: log('info'), warn: log('warn'), error: log('error') },
+  }
+  return { ctx, table, sleptFor, logs, signalCalls }
+}
+
+describe('findOwnNodeHolders', () => {
+  it('returns an empty list when no one holds the port', () => {
+    const { ctx } = makeCtx({ portHolders: { 3420: [] } })
+    expect(findOwnNodeHolders(3420, ctx)).toEqual([])
+  })
+
+  it('excludes the current PID even if it appears in the holder list', () => {
+    const procs: MockProc[] = [
+      { pid: 100, uid: 501, cmd: 'node', alive: true },
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+    ]
+    const { ctx } = makeCtx({ currentPid: 100, procs, portHolders: { 3420: [100, 200] } })
+    expect(findOwnNodeHolders(3420, ctx)).toEqual([200])
+  })
+
+  it('excludes processes owned by a different UID', () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 502, cmd: 'node', alive: true },
+      { pid: 300, uid: 501, cmd: 'node', alive: true },
+    ]
+    const { ctx, logs } = makeCtx({ uid: 501, procs, portHolders: { 3420: [200, 300] } })
+    expect(findOwnNodeHolders(3420, ctx)).toEqual([300])
+    expect(logs.some(l => l.level === 'warn' && /different UID/.test(l.msg))).toBe(true)
+  })
+
+  it('excludes non-node commands', () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'nginx', alive: true },
+      { pid: 300, uid: 501, cmd: 'node', alive: true },
+      { pid: 400, uid: 501, cmd: 'tsx', alive: true },
+    ]
+    const { ctx, logs } = makeCtx({ procs, portHolders: { 3420: [200, 300, 400] } })
+    expect(findOwnNodeHolders(3420, ctx)).toEqual([300, 400])
+    expect(logs.some(l => l.level === 'warn' && /not a node\/tsx/.test(l.msg))).toBe(true)
+  })
+
+  it('skips PIDs that are gone between lsof and ps', () => {
+    const procs: MockProc[] = [
+      { pid: 300, uid: 501, cmd: 'node', alive: true },
+    ]
+    const { ctx } = makeCtx({ procs, portHolders: { 3420: [200, 300] } })
+    expect(findOwnNodeHolders(3420, ctx)).toEqual([300])
+  })
+
+  it('skips non-positive or non-finite PIDs defensively', () => {
+    const { ctx } = makeCtx({ portHolders: { 3420: [0, -1, NaN as unknown as number] } })
+    expect(findOwnNodeHolders(3420, ctx)).toEqual([])
+  })
+
+  it('skips UID check when the platform has no getuid (uid=null)', () => {
+    const procs: MockProc[] = [
+      { pid: 300, uid: 0, cmd: 'node', alive: true },
+    ]
+    const { ctx } = makeCtx({ uid: null, procs, portHolders: { 3420: [300] } })
+    expect(findOwnNodeHolders(3420, ctx)).toEqual([300])
+  })
+
+  it('deduplicates PIDs that appear twice in the holder list', () => {
+    const procs: MockProc[] = [
+      { pid: 300, uid: 501, cmd: 'node', alive: true },
+    ]
+    const { ctx } = makeCtx({ procs, portHolders: { 3420: [300, 300] } })
+    expect(findOwnNodeHolders(3420, ctx)).toEqual([300])
+  })
+})
+
+describe('findOwnBinaryMatches', () => {
+  it('returns own-UID node processes matching the argv pattern', () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true },
+      { pid: 300, uid: 501, cmd: 'node', args: 'node other.js', alive: true },
+    ]
+    const { ctx } = makeCtx({ procs })
+    expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([200])
+  })
+
+  it('excludes the current PID even if its argv matches', () => {
+    const procs: MockProc[] = [
+      { pid: 100, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true },
+      { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true },
+    ]
+    const { ctx } = makeCtx({ currentPid: 100, procs })
+    expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([200])
+  })
+
+  it('excludes foreign-UID processes even with matching argv', () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 999, cmd: 'node', args: 'node dist/index.js', alive: true },
+    ]
+    const { ctx } = makeCtx({ uid: 501, procs })
+    expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([])
+  })
+})
+
+describe('terminateProcesses', () => {
+  it('is a no-op on empty input', async () => {
+    const { ctx, sleptFor } = makeCtx({})
+    await terminateProcesses([], ctx, { graceMs: 1500 })
+    expect(sleptFor).toEqual([])
+  })
+
+  it('sends SIGTERM, waits the grace window, does not escalate if process died', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+    ]
+    const { ctx, table, sleptFor, signalCalls } = makeCtx({ procs })
+    await terminateProcesses([200], ctx, { graceMs: 1500 })
+    expect(sleptFor).toEqual([1500])
+    expect(table.get(200)!.alive).toBe(false)
+    expect(signalCalls.filter(c => c.sig === 'SIGKILL')).toEqual([])
+  })
+
+  it('escalates to SIGKILL if SIGTERM did not kill the process', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+    ]
+    const signalOverride: ProcessLockContext['signal'] = (pid, sig) => {
+      const p = procs.find(x => x.pid === pid)!
+      if (sig === 'SIGTERM') return 'sent' // no-op (hung process)
+      if (sig === 0) return p.alive ? 'sent' : 'gone'
+      if (sig === 'SIGKILL') { p.alive = false; return 'sent' }
+      return 'gone'
+    }
+    const { ctx, signalCalls } = makeCtx({ procs, signalOverride })
+    await terminateProcesses([200], ctx, { graceMs: 10 })
+    expect(signalCalls.map(c => c.sig)).toEqual(['SIGTERM', '0', 'SIGKILL'])
+  })
+
+  it('escalates to SIGKILL when signal(0) throws EPERM (process alive, we just cannot probe)', async () => {
+    // The process table still shows alive, but the liveness probe throws.
+    // The real ctx rethrows anything that isn't ESRCH. We must treat that as
+    // "still alive" and escalate, otherwise a zombie we can't probe would
+    // survive startup.
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+    ]
+    const signalOverride: ProcessLockContext['signal'] = (pid, sig) => {
+      const p = procs.find(x => x.pid === pid)!
+      if (sig === 'SIGTERM') return 'sent' // ignored
+      if (sig === 0) throw Object.assign(new Error('EPERM'), { code: 'EPERM' })
+      if (sig === 'SIGKILL') { p.alive = false; return 'sent' }
+      return 'gone'
+    }
+    const { ctx, signalCalls } = makeCtx({ procs, signalOverride })
+    await terminateProcesses([200], ctx, { graceMs: 10 })
+    expect(signalCalls.map(c => c.sig)).toEqual(['SIGTERM', '0', 'SIGKILL'])
+  })
+
+  it('does not escalate when signal(0) returns gone (ESRCH)', async () => {
+    const signalOverride: ProcessLockContext['signal'] = (_pid, sig) => {
+      if (sig === 'SIGTERM') return 'sent'
+      if (sig === 0) return 'gone'
+      return 'sent'
+    }
+    const { ctx, signalCalls } = makeCtx({ signalOverride })
+    await terminateProcesses([200], ctx, { graceMs: 10 })
+    expect(signalCalls.filter(c => c.sig === 'SIGKILL')).toEqual([])
+  })
+
+  it('handles several victims in parallel -- all get SIGTERM before the grace wait', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+      { pid: 300, uid: 501, cmd: 'node', alive: true },
+      { pid: 400, uid: 501, cmd: 'node', alive: true },
+    ]
+    const { ctx, table, signalCalls } = makeCtx({ procs })
+    await terminateProcesses([200, 300, 400], ctx, { graceMs: 10 })
+    expect(signalCalls.slice(0, 3)).toEqual([
+      { pid: 200, sig: 'SIGTERM' },
+      { pid: 300, sig: 'SIGTERM' },
+      { pid: 400, sig: 'SIGTERM' },
+    ])
+    expect(table.get(200)!.alive).toBe(false)
+    expect(table.get(300)!.alive).toBe(false)
+    expect(table.get(400)!.alive).toBe(false)
+  })
+
+  it('SIGTERM failure does not block SIGKILL escalation', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+    ]
+    const signalOverride: ProcessLockContext['signal'] = (pid, sig) => {
+      const p = procs.find(x => x.pid === pid)!
+      if (sig === 'SIGTERM') throw new Error('kaboom')
+      if (sig === 0) return p.alive ? 'sent' : 'gone'
+      if (sig === 'SIGKILL') { p.alive = false; return 'sent' }
+      return 'gone'
+    }
+    const { ctx, signalCalls } = makeCtx({ procs, signalOverride })
+    await terminateProcesses([200], ctx, { graceMs: 10 })
+    expect(signalCalls.find(c => c.sig === 'SIGKILL')).toBeTruthy()
+  })
+})
+
+describe('acquirePortLock', () => {
+  it('returns immediately if no one holds the port and no binary pattern is given', async () => {
+    const { ctx, sleptFor } = makeCtx({ portHolders: { 3420: [] } })
+    await acquirePortLock(3420, ctx)
+    expect(sleptFor).toEqual([])
+  })
+
+  it('returns immediately if the only holder is the current PID', async () => {
+    const procs: MockProc[] = [
+      { pid: 100, uid: 501, cmd: 'node', alive: true },
+    ]
+    const { ctx, sleptFor } = makeCtx({ currentPid: 100, procs, portHolders: { 3420: [100] } })
+    await acquirePortLock(3420, ctx)
+    expect(sleptFor).toEqual([])
+  })
+
+  it('kills an old dashboard instance holding the port', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+    ]
+    const { ctx, table } = makeCtx({ procs, portHolders: { 3420: [200] } })
+    await acquirePortLock(3420, ctx, { graceMs: 10 })
+    expect(table.get(200)!.alive).toBe(false)
+  })
+
+  it('kills a zombie that lost the port but still runs the binary', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true },
+    ]
+    const { ctx, table } = makeCtx({ procs, portHolders: { 3420: [] } })
+    await acquirePortLock(3420, ctx, { graceMs: 10, binaryPattern: /dist\/index\.js/ })
+    expect(table.get(200)!.alive).toBe(false)
+  })
+
+  it('deduplicates a zombie that both holds the port AND matches the binary', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true },
+    ]
+    const { ctx, signalCalls } = makeCtx({ procs, portHolders: { 3420: [200] } })
+    await acquirePortLock(3420, ctx, { graceMs: 10, binaryPattern: /dist\/index\.js/ })
+    // SIGTERM should only be sent once per victim, not twice
+    expect(signalCalls.filter(c => c.sig === 'SIGTERM' && c.pid === 200)).toHaveLength(1)
+  })
+
+  it('kills multiple zombie instances in one pass', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+      { pid: 300, uid: 501, cmd: 'node', alive: true },
+    ]
+    const { ctx, table } = makeCtx({ procs, portHolders: { 3420: [200, 300] } })
+    await acquirePortLock(3420, ctx, { graceMs: 10 })
+    expect(table.get(200)!.alive).toBe(false)
+    expect(table.get(300)!.alive).toBe(false)
+  })
+
+  it('leaves a foreign-UID process alone and does not sleep', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 999, cmd: 'node', alive: true },
+    ]
+    const { ctx, table, sleptFor } = makeCtx({ uid: 501, procs, portHolders: { 3420: [200] } })
+    await acquirePortLock(3420, ctx, { graceMs: 10, postKillDrainMs: 0 })
+    expect(table.get(200)!.alive).toBe(true)
+    expect(sleptFor).toEqual([])
+  })
+
+  it('polls listPortHolders after kill until the port is free (drain)', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+    ]
+    // Port holder list reflects the mutable table -- once 200 dies, it
+    // "drops" off the port. Simulate this by wiring listPortHolders to
+    // return 200 only while alive.
+    const portHolders: Record<number, number[]> = { 3420: [200] }
+    const { ctx, table } = makeCtx({ procs, portHolders })
+    // Override listPortHolders to reflect alive-ness dynamically.
+    const liveOnly: ProcessLockContext = {
+      ...ctx,
+      listPortHolders(port: number) {
+        const holders = portHolders[port] ?? []
+        return holders.filter(pid => table.get(pid)?.alive)
+      },
+    }
+    await acquirePortLock(3420, liveOnly, { graceMs: 10, postKillDrainMs: 200, postKillPollMs: 10 })
+    expect(table.get(200)!.alive).toBe(false)
+  })
+
+  it('logs a warning if the port stays held past the drain window', async () => {
+    const procs: MockProc[] = [
+      { pid: 200, uid: 501, cmd: 'node', alive: true },
+    ]
+    const portHolders: Record<number, number[]> = { 3420: [200] }
+    // signal() marks the proc dead, but listPortHolders keeps returning
+    // 200 -- simulates kernel still holding the socket in TIME_WAIT.
+    const { ctx, logs } = makeCtx({ procs, portHolders })
+    const stickyPort: ProcessLockContext = {
+      ...ctx,
+      listPortHolders() { return [200] },
+    }
+    await acquirePortLock(3420, stickyPort, { graceMs: 10, postKillDrainMs: 30, postKillPollMs: 10 })
+    expect(logs.some(l => l.level === 'warn' && /still held after drain/.test(l.msg))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// acquirePidfileLock
+
+interface PidfileState {
+  path: string
+  files: Map<string, number>
+  livePids: Set<number>
+  legitimatePids: Set<number>
+  termed: number[]
+  unlinks: string[]
+  sleptFor: number[]
+  logs: Array<{ level: string; msg: string; obj: Record<string, unknown> }>
+  probeAliveOverride?: (pid: number) => boolean
+}
+
+function makePidfileCtx(state: PidfileState): PidfileLockContext {
+  const log = (level: string) => (obj: Record<string, unknown>, msg?: string) => {
+    state.logs.push({ level, msg: msg ?? '', obj })
+  }
+  return {
+    tryCreateExclusive(path, pid) {
+      if (state.files.has(path)) return 'exists'
+      state.files.set(path, pid)
+      return 'created'
+    },
+    readRecordedPid(path) {
+      return state.files.get(path) ?? null
+    },
+    unlinkIfMatches(path, expected) {
+      const raw = state.files.get(path)
+      // The mock only stores numeric PIDs; a "non-parseable" file state
+      // is outside its scope (real I/O produces it, the abstract mock
+      // does not). expected === null never matches the mock's state,
+      // which is fine: those branches are exercised by the real impl.
+      const current = raw === undefined ? undefined : raw
+      if (current !== expected) return
+      state.unlinks.push(path)
+      state.files.delete(path)
+    },
+    probeAlive(pid) {
+      if (state.probeAliveOverride) return state.probeAliveOverride(pid)
+      return state.livePids.has(pid)
+    },
+    sendTerm(pid) {
+      state.termed.push(pid)
+      state.livePids.delete(pid)
+    },
+    isLegitimatePredecessor(pid) {
+      return state.legitimatePids.has(pid)
+    },
+    sleep: async (ms) => { state.sleptFor.push(ms) },
+    log: { info: log('info'), warn: log('warn'), error: log('error') },
+  }
+}
+
+function baseState(): PidfileState {
+  return {
+    path: '/tmp/test.pid',
+    files: new Map(),
+    livePids: new Set(),
+    legitimatePids: new Set(),
+    termed: [],
+    unlinks: [],
+    sleptFor: [],
+    logs: [],
+  }
+}
+
+describe('acquirePidfileLock', () => {
+  it('creates the pidfile atomically when the path is free', async () => {
+    const state = baseState()
+    const ctx = makePidfileCtx(state)
+    await acquirePidfileLock(state.path, 100, ctx)
+    expect(state.files.get(state.path)).toBe(100)
+    expect(state.termed).toEqual([])
+    expect(state.unlinks).toEqual([])
+  })
+
+  it('unlinks a stale file whose recorded PID is gone, then retries', async () => {
+    const state = baseState()
+    state.files.set(state.path, 999) // stale, 999 is not in livePids
+    const ctx = makePidfileCtx(state)
+    await acquirePidfileLock(state.path, 100, ctx, { graceMs: 10 })
+    expect(state.unlinks).toEqual([state.path])
+    expect(state.files.get(state.path)).toBe(100)
+    expect(state.termed).toEqual([])
+  })
+
+  it('SIGTERMs a live, legitimate predecessor and retries', async () => {
+    const state = baseState()
+    state.files.set(state.path, 999)
+    state.livePids.add(999)
+    state.legitimatePids.add(999)
+    const ctx = makePidfileCtx(state)
+    await acquirePidfileLock(state.path, 100, ctx, { graceMs: 20 })
+    expect(state.termed).toEqual([999])
+    expect(state.sleptFor).toEqual([20])
+    expect(state.unlinks).toEqual([state.path])
+    expect(state.files.get(state.path)).toBe(100)
+  })
+
+  it('does NOT SIGTERM a live but illegitimate PID (PID was recycled)', async () => {
+    // Stale pidfile with PID=999, but PID 999 has been recycled to some
+    // unrelated program (e.g. a shell). We must not kill it.
+    const state = baseState()
+    state.files.set(state.path, 999)
+    state.livePids.add(999)
+    // legitimatePids EMPTY -- not a dashboard process
+    const ctx = makePidfileCtx(state)
+    await acquirePidfileLock(state.path, 100, ctx, { graceMs: 10 })
+    expect(state.termed).toEqual([])
+    expect(state.files.get(state.path)).toBe(100)
+    expect(state.logs.some(l => /not a dashboard process/.test(l.msg))).toBe(true)
+  })
+
+  it('unlinks a self-recorded file (recorded === selfPid) and retries', async () => {
+    const state = baseState()
+    state.files.set(state.path, 100) // our own PID somehow already in there
+    const ctx = makePidfileCtx(state)
+    await acquirePidfileLock(state.path, 100, ctx, { graceMs: 10 })
+    expect(state.unlinks).toEqual([state.path])
+    expect(state.files.get(state.path)).toBe(100)
+  })
+
+  it('gives up after maxAttempts if every attempt keeps seeing EEXIST', async () => {
+    const state = baseState()
+    // Override tryCreateExclusive to always fail; a concurrent writer keeps
+    // recreating the file immediately after each unlink.
+    state.files.set(state.path, 999)
+    state.livePids.add(999)
+    state.legitimatePids.add(999)
+    const ctx = makePidfileCtx(state)
+    // Monkey-patch: every successful unlink immediately replaces the
+    // file, simulating a pathological writer that never relents.
+    const origUnlinkIfMatches = ctx.unlinkIfMatches
+    ctx.unlinkIfMatches = (path, expected) => {
+      const before = state.files.get(path)
+      origUnlinkIfMatches(path, expected)
+      const after = state.files.get(path)
+      if (before !== undefined && after === undefined) {
+        state.files.set(path, 999)
+        state.livePids.add(999)
+      }
+    }
+    await expect(
+      acquirePidfileLock(state.path, 100, ctx, { graceMs: 5, maxAttempts: 3 }),
+    ).rejects.toThrow(/Failed to acquire pidfile lock/)
+  })
+
+  it('treats a probeAlive throw as "still alive" (conservative)', async () => {
+    const state = baseState()
+    state.files.set(state.path, 999)
+    state.legitimatePids.add(999)
+    state.probeAliveOverride = () => { throw new Error('EPERM') }
+    const ctx = makePidfileCtx(state)
+    await acquirePidfileLock(state.path, 100, ctx, { graceMs: 10 })
+    // Because probeAlive threw, we assumed alive, SIGTERMed, waited, then
+    // unlinked.
+    expect(state.termed).toEqual([999])
+    expect(state.files.get(state.path)).toBe(100)
+  })
+
+  it('throws DeferToPeerError when onLiveLegitimate=defer and peer is alive-legit', async () => {
+    const state = baseState()
+    state.files.set(state.path, 999)
+    state.livePids.add(999)
+    state.legitimatePids.add(999)
+    const ctx = makePidfileCtx(state)
+    await expect(
+      acquirePidfileLock(state.path, 100, ctx, { graceMs: 10, onLiveLegitimate: 'defer' }),
+    ).rejects.toBeInstanceOf(DeferToPeerError)
+    // Defer MUST NOT SIGTERM the winner
+    expect(state.termed).toEqual([])
+  })
+
+  it('defer mode still unlinks stale (dead) entries', async () => {
+    const state = baseState()
+    state.files.set(state.path, 999) // recorded pid, but not alive
+    const ctx = makePidfileCtx(state)
+    await acquirePidfileLock(state.path, 100, ctx, { graceMs: 10, onLiveLegitimate: 'defer' })
+    expect(state.files.get(state.path)).toBe(100)
+  })
+
+  it('does NOT unlink a third peer that took the slot during our SIGTERM-wait', async () => {
+    // Regression for round-8 finding: a third startup can write its own
+    // PID between our SIGTERM and our post-sleep unlink. An unconditional
+    // unlink would erase it and let two dashboards run concurrently.
+    const state = baseState()
+    state.files.set(state.path, 999) // predecessor
+    state.livePids.add(999)
+    state.legitimatePids.add(999)
+    const ctx = makePidfileCtx(state)
+    // During the SIGTERM-wait in attempt 1, predecessor 999 cleanly exits
+    // (releaseLock'd its own pidfile) and a third startup (PID 777) wins
+    // the O_EXCL race with its own lock. The post-sleep unlinkIfMatches
+    // must NOT erase 777's file even though we went in expecting to
+    // remove 999.
+    const origSleep = ctx.sleep
+    ctx.sleep = async (ms) => {
+      await origSleep(ms)
+      state.files.delete(state.path)
+      state.livePids.delete(999)
+      state.files.set(state.path, 777)
+      state.livePids.add(777)
+      state.legitimatePids.add(777)
+    }
+    // Cap at 1 attempt so the test isolates the first-iteration
+    // unlinkIfMatches behavior. With maxAttempts=1, acquirePidfileLock
+    // throws "Failed to acquire" after a single SIGTERM + sleep pass.
+    await expect(
+      acquirePidfileLock(state.path, 100, ctx, { graceMs: 5, maxAttempts: 1 }),
+    ).rejects.toThrow(/Failed to acquire pidfile lock/)
+    // The third peer's file MUST still be intact.
+    expect(state.files.get(state.path)).toBe(777)
+  })
+
+  it('defer mode still unlinks illegitimate (recycled) PIDs', async () => {
+    const state = baseState()
+    state.files.set(state.path, 999)
+    state.livePids.add(999) // alive but NOT legitimate
+    const ctx = makePidfileCtx(state)
+    await acquirePidfileLock(state.path, 100, ctx, { graceMs: 10, onLiveLegitimate: 'defer' })
+    expect(state.files.get(state.path)).toBe(100)
+    expect(state.termed).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DASHBOARD_BINARY_PATTERN correctness
+//
+// Regression: the first version used `/\b(dist\/index\.js|src\/index\.ts)\b/`,
+// which false-positive matched `dist/index.js.map`, `dist/index.js.bak`,
+// `dist/index.js.old`, etc. because `\b` after `.js` boundaries between the
+// 's' word-char and the next non-word '.'. The tightened form requires the
+// dashboard filename to be followed by whitespace or end-of-string so
+// editors/bundlers/watchers opening sibling files don't get SIGKILLed.
+
+const DASHBOARD_BINARY_PATTERN = /(?:^|[\s/])(?:dist\/index\.js|src\/index\.ts)(?:\s|$)/
+
+describe('writeBufferFully', () => {
+  it('writes the whole buffer in a single shot when the writer accepts it all', () => {
+    const chunks: Array<{ off: number; len: number }> = []
+    const buf = Buffer.from('12345')
+    writeBufferFully((_b, off, len) => { chunks.push({ off, len }); return len }, buf)
+    expect(chunks).toEqual([{ off: 0, len: 5 }])
+  })
+
+  it('loops through short writes until the buffer is drained', () => {
+    const chunks: number[] = []
+    const buf = Buffer.from('12345')
+    const sequence = [2, 1, 2] // simulate three short writes summing to 5
+    let call = 0
+    writeBufferFully((_b, off, len) => {
+      const n = Math.min(sequence[call++], len)
+      chunks.push(n)
+      return n
+    }, buf)
+    expect(chunks).toEqual([2, 1, 2])
+  })
+
+  it('throws if the writer returns 0', () => {
+    expect(() =>
+      writeBufferFully(() => 0, Buffer.from('x')),
+    ).toThrow(/returned 0/)
+  })
+
+  it('throws if the writer returns a negative number', () => {
+    expect(() =>
+      writeBufferFully(() => -1, Buffer.from('x')),
+    ).toThrow(/returned -1/)
+  })
+
+  it('throws if the writer returns NaN', () => {
+    expect(() =>
+      writeBufferFully(() => NaN, Buffer.from('x')),
+    ).toThrow(/returned NaN/)
+  })
+
+  it('handles an empty buffer without calling the writer', () => {
+    let called = false
+    writeBufferFully(() => { called = true; return 0 }, Buffer.alloc(0))
+    expect(called).toBe(false)
+  })
+})
+
+describe('DASHBOARD_BINARY_PATTERN', () => {
+  it.each([
+    'node dist/index.js',
+    '/usr/local/bin/node /opt/repo/dist/index.js',
+    'node --inspect dist/index.js',
+    'tsx src/index.ts',
+    'node dist/index.js --flag',
+  ])('matches the canonical dashboard argv: %s', (argv) => {
+    expect(DASHBOARD_BINARY_PATTERN.test(argv)).toBe(true)
+  })
+
+  it.each([
+    'vim dist/index.js.bak',
+    'node dist/index.js.map',
+    'tail dist/index.js.old',
+    'grep dist/index.jsx',
+    'sh -c "cp dist/index.js.tmp dist/index.js.staged"',
+    'prettier --write src/index.tsx',
+  ])('does NOT match unrelated argvs that merely contain the name as a prefix: %s', (argv) => {
+    expect(DASHBOARD_BINARY_PATTERN.test(argv)).toBe(false)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,28 @@
-import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs'
+import {
+  readFileSync,
+  unlinkSync,
+  mkdirSync,
+  openSync,
+  closeSync,
+  writeSync,
+} from 'node:fs'
 import { join } from 'node:path'
-import { PROJECT_ROOT, STORE_DIR, WEB_PORT, ALLOWED_CHAT_ID } from './config.js'
+import { execFileSync, execSync } from 'node:child_process'
+import type { Server as HttpServer } from 'node:http'
+import { STORE_DIR, WEB_PORT, ALLOWED_CHAT_ID } from './config.js'
 import { initDatabase } from './db.js'
 import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
+import {
+  acquirePortLock,
+  acquirePidfileLock,
+  writeBufferFully,
+  DeferToPeerError,
+  type ProcessLockContext,
+  type PidfileLockContext,
+} from './process-lock.js'
 
 const BANNER = `
  ██████╗██╗      █████╗ ██╗   ██╗██████╗ ███████╗
@@ -23,39 +40,358 @@ const BANNER = `
 `
 
 const PID_FILE = join(STORE_DIR, 'claudeclaw.pid')
+// Hard-kill timeout: if graceful shutdown (HTTP drain + releaseLock) has not
+// finished in this window, exit so launchd's KeepAlive isn't blocked by a
+// hung socket. closeAllConnections (Node 18.2+) normally drains in ms, but
+// a browser tab holding a chunked response might still stall close().
+const SHUTDOWN_HARD_KILL_MS = 5000
+// Match own-UID node processes whose argv contains the dashboard binary
+// path, followed by whitespace or end-of-string. The delimiters are load-
+// bearing: without them, `\b` matched `dist/index.js.map`, `dist/index.js.bak`
+// and other sibling files, and unrelated editor/bundler processes touching
+// those files would get SIGKILLed on startup.
+const DASHBOARD_BINARY_PATTERN = /(?:^|[\s/])(?:dist\/index\.js|src\/index\.ts)(?:\s|$)/
 
-function acquireLock(): void {
-  mkdirSync(STORE_DIR, { recursive: true })
-
-  if (existsSync(PID_FILE)) {
-    const oldPid = parseInt(readFileSync(PID_FILE, 'utf-8').trim(), 10)
-    if (oldPid) {
+// Build the I/O surface used by process-lock.ts. Kept here so the pure
+// module stays testable with a mock ctx and never imports node:child_process
+// or node:fs directly.
+function buildProcessLockContext(): ProcessLockContext {
+  const uid = typeof process.getuid === 'function' ? process.getuid() : null
+  return {
+    currentPid: process.pid,
+    uid,
+    listPortHolders(port: number): number[] {
       try {
-        process.kill(oldPid, 0)
-        logger.warn({ oldPid }, 'Korabbi peldany megallitasa...')
-        process.kill(oldPid, 'SIGTERM')
+        const raw = execSync(`lsof -ti :${port} 2>/dev/null || true`, { timeout: 3000, encoding: 'utf-8' }).trim()
+        if (!raw) return []
+        return raw.split('\n').map((s) => parseInt(s.trim(), 10)).filter((n) => Number.isFinite(n) && n > 0)
       } catch {
-        // nem fut már, rendben
+        return []
       }
-    }
+    },
+    listOwnProcessesMatching(pattern: RegExp): number[] {
+      // `ps -A -o pid=,uid=,args=` emits `<pid> <uid> <full argv>` per row.
+      // Filter to own-UID rows whose argv matches `pattern`. Known edge
+      // case: an argv that contains a literal newline will be split across
+      // physical lines; such rows are dropped. Not a practical concern for
+      // node/tsx invocations, but worth noting.
+      try {
+        const raw = execFileSync('/bin/ps', ['-Ao', 'pid=,uid=,args='], { timeout: 3000, encoding: 'utf-8' })
+        const out: number[] = []
+        for (const line of raw.split('\n')) {
+          const trimmed = line.trimStart()
+          if (!trimmed) continue
+          const m = trimmed.match(/^(\d+)\s+(\d+)\s+(.*)$/)
+          if (!m) continue
+          const pid = parseInt(m[1], 10)
+          const rowUid = parseInt(m[2], 10)
+          const argv = m[3]
+          if (!Number.isFinite(pid) || pid <= 0) continue
+          if (pid === process.pid) continue
+          if (uid != null && rowUid !== uid) continue
+          if (!pattern.test(argv)) continue
+          out.push(pid)
+        }
+        return out
+      } catch {
+        return []
+      }
+    },
+    getProcessCommand(pid: number): string | null {
+      try {
+        return execFileSync('/bin/ps', ['-p', String(pid), '-o', 'comm='], { timeout: 2000, encoding: 'utf-8' }).trim() || null
+      } catch {
+        return null
+      }
+    },
+    getProcessUid(pid: number): number | null {
+      try {
+        const out = execFileSync('/bin/ps', ['-p', String(pid), '-o', 'uid='], { timeout: 2000, encoding: 'utf-8' }).trim()
+        const parsed = parseInt(out, 10)
+        return Number.isFinite(parsed) ? parsed : null
+      } catch {
+        return null
+      }
+    },
+    signal(pid: number, sig): 'sent' | 'gone' {
+      try {
+        process.kill(pid, sig as NodeJS.Signals | 0)
+        return 'sent'
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code
+        if (code === 'ESRCH') return 'gone'
+        // EPERM and others: the process exists but we can't probe. Rethrow
+        // so callers treat it as "still alive".
+        throw err
+      }
+    },
+    sleep(ms: number): Promise<void> {
+      return new Promise((resolve) => setTimeout(resolve, ms))
+    },
+    log: {
+      info: (obj, msg) => logger.info(obj, msg),
+      warn: (obj, msg) => logger.warn(obj, msg),
+      error: (obj, msg) => logger.error(obj, msg),
+    },
   }
-
-  writeFileSync(PID_FILE, String(process.pid))
-  logger.info({ pid: process.pid }, 'Zarolasi fajl letrehozva')
 }
 
+function readRecordedPidFrom(path: string): number | null {
+  try {
+    const raw = readFileSync(path, 'utf-8').trim()
+    // Strict parse: only pure digits. Guards against truncated writes
+    // ("12345" partially landed as "1"), empty files from a crash between
+    // openSync and writeSync, or accidental free-form content.
+    if (!/^\d+$/.test(raw)) return null
+    const parsed = parseInt(raw, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+// Legitimacy check for the PID recorded in the pidfile. True only if the PID
+// looks like a previous dashboard instance (own UID + node/tsx + argv
+// matches the binary pattern). Prevents the acquire loop from SIGTERMing an
+// unrelated process whose PID happens to appear in a stale pidfile (PID
+// recycling on long-lived systems is routine).
+function isLegitimateDashboardPid(pid: number, procCtx: ProcessLockContext): boolean {
+  const cmd = procCtx.getProcessCommand(pid)
+  if (cmd == null) return false
+  if (procCtx.uid != null) {
+    const ownerUid = procCtx.getProcessUid(pid)
+    if (ownerUid == null || ownerUid !== procCtx.uid) return false
+  }
+  if (!/node|tsx/i.test(cmd)) return false
+  const matches = procCtx.listOwnProcessesMatching(DASHBOARD_BINARY_PATTERN)
+  return matches.includes(pid)
+}
+
+function buildPidfileLockContext(procCtx: ProcessLockContext): PidfileLockContext {
+  return {
+    tryCreateExclusive(path, pid) {
+      try {
+        const fd = openSync(path, 'wx')
+        try {
+          // Short-writes can legally return fewer bytes than requested.
+          // writeBufferFully loops until the buffer is fully drained; if
+          // we crash mid-write the file is left truncated and
+          // readRecordedPidFrom will reject it as non-digits.
+          writeBufferFully(
+            (b, off, len) => writeSync(fd, b, off, len),
+            Buffer.from(String(pid)),
+          )
+        } finally {
+          closeSync(fd)
+        }
+        return 'created'
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException)?.code === 'EEXIST') return 'exists'
+        throw err
+      }
+    },
+    readRecordedPid(path) {
+      return readRecordedPidFrom(path)
+    },
+    unlinkIfMatches(path, expected) {
+      // Re-read just before unlink so a third party's freshly-won lock
+      // (O_EXCL'd after our SIGTERM'd predecessor exited) survives. Not
+      // atomic w.r.t. an interleaved rewrite: if the file is rewritten
+      // between our read and the unlink, we could still delete the new
+      // file. The winning side's openSync('wx') is atomic, so the worst
+      // case is a spurious removal plus one more acquire-loop iteration,
+      // not a double-acquire.
+      try {
+        const raw = readFileSync(path, 'utf-8').trim()
+        const current: number | null = /^\d+$/.test(raw) ? parseInt(raw, 10) : null
+        if (current !== expected) return
+        unlinkSync(path)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return
+        throw err
+      }
+    },
+    probeAlive(pid) {
+      try {
+        process.kill(pid, 0)
+        return true
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code
+        if (code === 'ESRCH') return false
+        // Non-ESRCH: rethrow so the caller is conservative (assumes alive).
+        throw err
+      }
+    },
+    sendTerm(pid) {
+      try {
+        process.kill(pid, 'SIGTERM')
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code
+        if (code === 'ESRCH') return
+        throw err
+      }
+    },
+    isLegitimatePredecessor(pid) {
+      return isLegitimateDashboardPid(pid, procCtx)
+    },
+    sleep(ms) {
+      return new Promise((resolve) => setTimeout(resolve, ms))
+    },
+    log: {
+      info: (obj, msg) => logger.info(obj, msg),
+      warn: (obj, msg) => logger.warn(obj, msg),
+      error: (obj, msg) => logger.error(obj, msg),
+    },
+  }
+}
+
+// Fresh-startup race short-circuit. When two dashboard processes start
+// near-simultaneously, acquirePortLock would see the loser's peer as a
+// zombie (alive + binary-pattern match, but not yet listening on the port)
+// and SIGKILL it before the peer ever got a chance to install its signal
+// handlers. That's exactly the "startup race kills the winner mid-init"
+// scenario. Check the pidfile FIRST: if it already records a legitimate
+// alive peer that isn't listening on the port yet, the peer is mid-init
+// and we're the loser -- defer.
+function checkFreshStartupRace(procCtx: ProcessLockContext): void {
+  const recorded = readRecordedPidFrom(PID_FILE)
+  if (recorded == null || recorded === process.pid) return
+
+  let alive = false
+  try {
+    const out = procCtx.signal(recorded, 0)
+    alive = out === 'sent'
+  } catch {
+    // Probe failed (e.g. EPERM). We cannot positively detect the race, so
+    // we fall through to acquirePortLock which will SIGTERM the matching
+    // binary-pattern process. That peer's early signal handler (installed
+    // before acquireLock in main) runs graceful shutdown, so even if the
+    // peer was mid-init the state is flushed cleanly rather than lost.
+    return
+  }
+  if (!alive) return
+
+  if (!isLegitimateDashboardPid(recorded, procCtx)) return
+
+  // If the peer already holds the listening port, it's a fully-up
+  // predecessor (not a mid-init winner). acquirePortLock will handle it.
+  const portHolders = procCtx.listPortHolders(WEB_PORT)
+  if (portHolders.includes(recorded)) return
+
+  throw new DeferToPeerError(recorded)
+}
+
+async function acquireLock(): Promise<void> {
+  mkdirSync(STORE_DIR, { recursive: true })
+
+  const procCtx = buildProcessLockContext()
+
+  // Defer BEFORE we start killing things: if the pidfile records a peer
+  // that is alive, legitimate, and not yet on the port, we're the loser
+  // of a fresh-startup race -- exit 0 without disturbing the winner.
+  checkFreshStartupRace(procCtx)
+
+  // Kill any previous instance(s) next: anything holding WEB_PORT, and
+  // anything running the dashboard binary (for the zombie case where the
+  // port was released but the process survived). The pidfile alone can
+  // lie under launchd KeepAlive because each restart overwrites it.
+  await acquirePortLock(WEB_PORT, procCtx, { binaryPattern: DASHBOARD_BINARY_PATTERN })
+
+  // Atomic O_EXCL claim on PID_FILE. Serializes any two fresh startups
+  // that race past the port check. `onLiveLegitimate: 'defer'` is a
+  // belt-and-braces backup -- checkFreshStartupRace above should have
+  // already caught the common case, but if the winner wrote its pidfile
+  // between those two checks, defer here too.
+  await acquirePidfileLock(PID_FILE, process.pid, buildPidfileLockContext(procCtx), {
+    onLiveLegitimate: 'defer',
+  })
+}
+
+// Delete the PID file ONLY if it still points at this process. A zombie
+// shutdown path must not nuke the successor's pidfile after the successor
+// already overwrote it.
 function releaseLock(): void {
   try {
+    const recordedPid = readRecordedPidFrom(PID_FILE)
+    if (recordedPid !== process.pid) return
     unlinkSync(PID_FILE)
   } catch {
-    // ignorálható
+    // best-effort: the pidfile may already be gone (successor unlinked it)
+  }
+}
+
+// Module-scope runtime state + shutdown hook. Kept out of main() so the
+// main().catch handler can reach shutdown when an async init step rejects
+// after partial state was already wired up (e.g. initDatabase throws after
+// acquireLock wrote the pidfile -- we still need to drop the heartbeat /
+// digest timers and release the pidfile on the way out).
+let decayInterval: NodeJS.Timeout | null = null
+let digestTimer: NodeJS.Timeout | null = null
+let digestInterval: NodeJS.Timeout | null = null
+let heartbeatStarted = false
+let webServer: HttpServer | null = null
+let shuttingDown = false
+let exitCode = 0
+
+const shutdown = (): void => {
+  if (shuttingDown) return
+  try {
+    shuttingDown = true
+    logger.info('Leallitas...')
+    if (heartbeatStarted) {
+      try { stopHeartbeat() } catch (err) { logger.warn({ err }, 'stopHeartbeat threw during shutdown') }
+    }
+    if (decayInterval) clearInterval(decayInterval)
+    if (digestTimer) clearTimeout(digestTimer)
+    if (digestInterval) clearInterval(digestInterval)
+
+    const hardKill = setTimeout(() => {
+      logger.warn({ timeoutMs: SHUTDOWN_HARD_KILL_MS }, 'Graceful shutdown timeout, hard exit')
+      releaseLock()
+      process.exit(exitCode || 1)
+    }, SHUTDOWN_HARD_KILL_MS)
+
+    if (webServer) {
+      try { webServer.closeIdleConnections?.() } catch { /* older node */ }
+      try { webServer.closeAllConnections?.() } catch { /* older node */ }
+      webServer.close(() => {
+        clearTimeout(hardKill)
+        releaseLock()
+        process.exit(exitCode)
+      })
+    } else {
+      // Early shutdown, before startWebServer ran. Nothing to drain.
+      clearTimeout(hardKill)
+      releaseLock()
+      process.exit(exitCode)
+    }
+  } catch (err) {
+    logger.error({ err }, 'Shutdown threw, exiting anyway')
+    releaseLock()
+    process.exit(1)
   }
 }
 
 async function main(): Promise<void> {
   console.log(BANNER)
 
-  acquireLock()
+  // Install signal handlers EARLIEST so we can respond cleanly to SIGTERM
+  // during init. Required to close the fresh-startup race: a concurrent
+  // startup will SIGTERM this process via acquirePortLock's binary-pattern
+  // kill; without an early handler, default SIGTERM behavior terminates
+  // us mid-init with no chance to flush SQLite WAL or drop the pidfile.
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+  process.on('uncaughtException', (err) => {
+    logger.error({ err }, 'uncaughtException')
+    exitCode = 1
+    shutdown()
+  })
+  process.on('unhandledRejection', (reason) => {
+    logger.error({ err: reason }, 'unhandledRejection')
+  })
+
+  await acquireLock()
 
   // Database
   initDatabase()
@@ -63,21 +399,21 @@ async function main(): Promise<void> {
 
   // Memory decay (24h cycle)
   runDecaySweep()
-  const decayInterval = setInterval(runDecaySweep, 24 * 60 * 60 * 1000)
+  decayInterval = setInterval(runDecaySweep, 24 * 60 * 60 * 1000)
   logger.info('Memoria leepulesi ciklus beallitva (24 oras)')
 
-  // Daily digest at 23:00
+  // Daily digest at 23:00. Timer handles kept so shutdown can drop them.
   function scheduleDailyDigest() {
     const now = new Date()
     const target = new Date(now)
     target.setHours(23, 0, 0, 0)
     if (target <= now) target.setDate(target.getDate() + 1)
     const msUntil = target.getTime() - now.getTime()
-    setTimeout(() => {
+    digestTimer = setTimeout(() => {
       runDailyDigest(ALLOWED_CHAT_ID).catch((err) =>
         logger.error({ err }, 'Napi naplo hiba')
       )
-      setInterval(() => {
+      digestInterval = setInterval(() => {
         runDailyDigest(ALLOWED_CHAT_ID).catch((err) =>
           logger.error({ err }, 'Napi naplo hiba')
         )
@@ -89,30 +425,28 @@ async function main(): Promise<void> {
 
   // Heartbeat
   initHeartbeat()
+  heartbeatStarted = true
   logger.info('Heartbeat utemezo elindult')
 
   // Web dashboard
-  const webServer = startWebServer(WEB_PORT)
-
-  // Shutdown handlers
-  const shutdown = () => {
-    logger.info('Leallitas...')
-    stopHeartbeat()
-    clearInterval(decayInterval)
-    webServer.close()
-    releaseLock()
-    process.exit(0)
-  }
-
-  process.on('SIGINT', shutdown)
-  process.on('SIGTERM', shutdown)
+  webServer = startWebServer(WEB_PORT)
 
   logger.info(`ClaudeClaw Lite fut! Dashboard: http://localhost:${WEB_PORT}`)
   logger.info('Telegram kommunikacio: Claude Code Channels kezeli')
 }
 
 main().catch((err) => {
+  if (err instanceof DeferToPeerError) {
+    logger.info({ peerPid: err.peerPid }, 'Peer dashboard already claimed the pidfile, exiting quietly')
+    process.exit(0)
+  }
+  // Route through shutdown() so any partial init (heartbeat, digest
+  // timers, decay interval) is drained before exit. shutdown() is
+  // idempotent and no-ops if a signal handler already ran; in that case
+  // we must NOT overwrite the exit code the handler already chose --
+  // otherwise a clean SIGTERM plus a concurrent unrelated async rejection
+  // would report crash when the operator expected 0.
   logger.error({ err }, 'Vegzetes hiba')
-  releaseLock()
-  process.exit(1)
+  if (!shuttingDown) exitCode = 1
+  shutdown()
 })

--- a/src/process-lock.ts
+++ b/src/process-lock.ts
@@ -1,0 +1,363 @@
+// Pure-logic module for acquiring an exclusive lock on a TCP port.
+//
+// Context: when the dashboard restarts under macOS launchd KeepAlive, a
+// previous instance whose shutdown hung on live HTTP connections can remain
+// alive in zombie state -- event loop still ticking, scheduled-task timers
+// still firing, but the listening socket is already released (taken by a
+// successor, or closed by server.close with closeAllConnections). The new
+// instance then runs in parallel, the scheduler's tmux pane snapshots see
+// conflicting state, and scheduled prompts land in the wrong place or never
+// submit. This helper takes over the port deterministically on startup:
+// find every own-UID node/tsx process that is either holding WEB_PORT or
+// whose command line matches the dashboard binary, SIGTERM them, wait a
+// grace period, and SIGKILL survivors.
+//
+// The logic is split from the I/O so the ctx can be mocked in tests --
+// SIGKILL escalation ordering is impossible to unit-test against the real
+// process table.
+
+type LogFn = (obj: Record<string, unknown>, msg?: string) => void
+
+/** Outcome of signal(). 'sent' = delivered to a live process. 'gone' = the
+ * process is already dead (ESRCH). Any other error must throw so callers
+ * can distinguish "probably still alive but we can't probe" from "gone". */
+export type SignalOutcome = 'sent' | 'gone'
+
+export interface ProcessLockContext {
+  currentPid: number
+  /** Effective UID of the current process, or null on platforms without getuid. */
+  uid: number | null
+  /** List PIDs currently bound to the given TCP port (typically via `lsof -ti`). */
+  listPortHolders(port: number): number[]
+  /** List own-UID PIDs whose argv matches `pattern` (typically via `ps -A -o pid,uid,args`).
+   * Used to catch zombies that have already lost the listening socket but
+   * are still running. Must exclude the current PID. */
+  listOwnProcessesMatching(pattern: RegExp): number[]
+  /** Return the command/comm of the PID, or null if the process is gone. */
+  getProcessCommand(pid: number): string | null
+  /** Return the owning UID of the PID, or null if the process is gone. */
+  getProcessUid(pid: number): number | null
+  /**
+   * Send a signal. Signal 0 is the liveness probe. Returns:
+   *  - 'sent' if the signal was delivered (process alive for sig 0)
+   *  - 'gone' only for ESRCH (the process no longer exists)
+   * Any other failure (EPERM, EINVAL, ...) MUST throw so the caller can
+   * assume the process is still alive and escalate to SIGKILL.
+   */
+  signal(pid: number, sig: 'SIGTERM' | 'SIGKILL' | 0): SignalOutcome
+  sleep(ms: number): Promise<void>
+  log: { info: LogFn; warn: LogFn; error: LogFn }
+}
+
+export interface AcquirePortLockOptions {
+  /** How long to wait between SIGTERM and the liveness probe before SIGKILL. */
+  graceMs?: number
+  /** If set, also terminate own-UID processes whose argv matches this regex,
+   * regardless of port holding. Catches zombies that already lost the port. */
+  binaryPattern?: RegExp
+  /** After SIGKILL, poll listPortHolders until the port is free or this
+   * timeout elapses. Prevents a TIME_WAIT / LAST_ACK kernel state from
+   * triggering EADDRINUSE on server.listen() immediately after a hard kill.
+   * Default 2000ms. Set to 0 to disable polling. */
+  postKillDrainMs?: number
+  /** Poll interval for the post-kill drain. Default 100ms. */
+  postKillPollMs?: number
+}
+
+const DEFAULT_GRACE_MS = 1500
+const DEFAULT_POST_KILL_DRAIN_MS = 2000
+const DEFAULT_POST_KILL_POLL_MS = 100
+
+/**
+ * Enumerate port holders that are safe to terminate: own-UID node/tsx
+ * processes, excluding the current PID. Foreign-UID holders and non-node
+ * commands are left alone and logged so the caller doesn't silently kill
+ * an unrelated process (e.g. a dev server that happens to share the port).
+ */
+export function findOwnNodeHolders(port: number, ctx: ProcessLockContext): number[] {
+  const raw = ctx.listPortHolders(port)
+  return filterOwnNodeCandidates(raw, ctx)
+}
+
+/**
+ * Enumerate own-UID node/tsx processes whose argv matches `pattern`,
+ * excluding the current PID. Complements `findOwnNodeHolders` for the
+ * case where a previous dashboard is still running but already lost its
+ * listening socket.
+ */
+export function findOwnBinaryMatches(pattern: RegExp, ctx: ProcessLockContext): number[] {
+  const raw = ctx.listOwnProcessesMatching(pattern)
+  return filterOwnNodeCandidates(raw, ctx)
+}
+
+function filterOwnNodeCandidates(pids: number[], ctx: ProcessLockContext): number[] {
+  const seen = new Set<number>()
+  const holders: number[] = []
+  for (const pid of pids) {
+    if (!Number.isFinite(pid) || pid <= 0) continue
+    if (pid === ctx.currentPid) continue
+    if (seen.has(pid)) continue
+    seen.add(pid)
+    const cmd = ctx.getProcessCommand(pid)
+    if (cmd == null) continue
+    if (ctx.uid != null) {
+      const ownerUid = ctx.getProcessUid(pid)
+      if (ownerUid == null) continue
+      if (ownerUid !== ctx.uid) {
+        ctx.log.warn({ pid, ownerUid }, 'Port/binary holder owned by different UID, leaving alone')
+        continue
+      }
+    }
+    if (!/node|tsx/i.test(cmd)) {
+      ctx.log.warn({ pid, cmd }, 'Port/binary holder is not a node/tsx process, leaving alone')
+      continue
+    }
+    holders.push(pid)
+  }
+  return holders
+}
+
+/**
+ * Best-effort terminate every PID in the list. Sends SIGTERM in parallel,
+ * waits the grace window, then SIGKILLs any survivors. A liveness-probe
+ * error that isn't ESRCH is treated as "still alive" so we escalate rather
+ * than silently assume death (EPERM means the process exists but we can't
+ * signal it; guessing 'gone' would leave a zombie running).
+ */
+export async function terminateProcesses(
+  pids: number[],
+  ctx: ProcessLockContext,
+  opts: { graceMs: number },
+): Promise<void> {
+  if (!pids.length) return
+  for (const pid of pids) {
+    try {
+      const out = ctx.signal(pid, 'SIGTERM')
+      if (out === 'sent') ctx.log.info({ pid }, 'SIGTERM sent to previous instance')
+    } catch (err) {
+      ctx.log.warn({ pid, err }, 'SIGTERM failed, will still try SIGKILL after grace')
+    }
+  }
+  await ctx.sleep(opts.graceMs)
+  for (const pid of pids) {
+    let alive = true
+    try {
+      const out = ctx.signal(pid, 0)
+      alive = out !== 'gone'
+    } catch {
+      // Non-ESRCH error: assume still alive and escalate. Missing a SIGKILL
+      // to an already-dead process is harmless; skipping SIGKILL on a live
+      // zombie is the bug this helper exists to prevent.
+      alive = true
+    }
+    if (!alive) continue
+    try {
+      ctx.log.warn({ pid }, 'Previous instance still alive after SIGTERM, escalating to SIGKILL')
+      ctx.signal(pid, 'SIGKILL')
+    } catch (err) {
+      ctx.log.error({ pid, err }, 'SIGKILL failed')
+    }
+  }
+}
+
+/**
+ * Make sure we are the only node/tsx dashboard process. If any own-UID
+ * holders exist (listening on `port` OR matching `binaryPattern`), SIGTERM
+ * then SIGKILL them. Returns once every holder is dead; the caller is free
+ * to call server.listen() afterwards.
+ */
+export async function acquirePortLock(
+  port: number,
+  ctx: ProcessLockContext,
+  opts: AcquirePortLockOptions = {},
+): Promise<void> {
+  const graceMs = opts.graceMs ?? DEFAULT_GRACE_MS
+  const drainMs = opts.postKillDrainMs ?? DEFAULT_POST_KILL_DRAIN_MS
+  const pollMs = opts.postKillPollMs ?? DEFAULT_POST_KILL_POLL_MS
+  const byPort = findOwnNodeHolders(port, ctx)
+  const byBinary = opts.binaryPattern ? findOwnBinaryMatches(opts.binaryPattern, ctx) : []
+  const victims = Array.from(new Set([...byPort, ...byBinary]))
+  if (!victims.length) return
+  ctx.log.warn({ port, victims, matchedBy: { byPort, byBinary } }, 'Previous dashboard instance(s) detected, taking over')
+  await terminateProcesses(victims, ctx, { graceMs })
+  if (drainMs <= 0 || pollMs <= 0) return
+  // Poll for the kernel to release the listening socket. Without this, a
+  // SIGKILLed predecessor can leave the port in TIME_WAIT / LAST_ACK and
+  // server.listen() will fail EADDRINUSE immediately after we return. The
+  // post-sleep re-check matters: without it, the port might clear during
+  // the final sleep and we'd still log "still held" noise.
+  let waited = 0
+  while (true) {
+    if (!findOwnNodeHolders(port, ctx).length) return
+    if (waited >= drainMs) break
+    await ctx.sleep(pollMs)
+    waited += pollMs
+  }
+  ctx.log.warn({ port }, 'Port still held after drain window, server.listen may hit EADDRINUSE and recover via reclaim')
+}
+
+/**
+ * Drive a synchronous writer until the entire buffer is written. `writer`
+ * is expected to behave like Node's writeSync (returns bytes written; may
+ * be less than requested). Throws on `writer` returning 0 or negative,
+ * which is not a legitimate "would block" for regular files.
+ *
+ * Extracted so the retry/slice logic is unit-testable without an fd.
+ */
+export function writeBufferFully(
+  writer: (buf: Buffer, offset: number, length: number) => number,
+  buf: Buffer,
+): void {
+  let written = 0
+  while (written < buf.length) {
+    const n = writer(buf, written, buf.length - written)
+    if (!Number.isFinite(n) || n <= 0) {
+      throw new Error(`writer returned ${n} with ${buf.length - written} bytes remaining`)
+    }
+    written += n
+  }
+}
+
+// --- Exclusive pidfile lock (O_EXCL-based) ----------------------------------
+
+/** Outcome of a single tryCreateExclusive attempt. */
+export type ExclusiveCreateOutcome = 'created' | 'exists'
+
+export interface PidfileLockContext {
+  /** Try to create `path` atomically (O_EXCL) and write `pid` into it.
+   * Returns 'created' on success, 'exists' if the file already exists.
+   * Any other I/O error MUST throw so the caller fails loud. */
+  tryCreateExclusive(path: string, pid: number): ExclusiveCreateOutcome
+  /** Parse the PID recorded in `path`, or null if the file is missing /
+   * corrupt. */
+  readRecordedPid(path: string): number | null
+  /** Remove `path` ONLY if its current content matches `expected`:
+   *   - number: unlink only if the file parses to that PID
+   *   - null:   unlink only if the file exists but is still non-parseable
+   * Guards every unlink against a third peer racing a fresh O_EXCL win
+   * into the slot while we were mid-decision. Silent on ENOENT and on
+   * state-mismatch. */
+  unlinkIfMatches(path: string, expected: number | null): void
+  /** True if signal 0 to `pid` succeeds (process exists and we can signal
+   * it). Non-ESRCH errors MUST throw so the caller can be defensive. */
+  probeAlive(pid: number): boolean
+  /** Send SIGTERM to `pid`. Silent on ESRCH. */
+  sendTerm(pid: number): void
+  /** Gate used to decide whether to SIGTERM the recorded PID. Returns true
+   * only if the PID really looks like a previous instance (own UID + node/
+   * tsx + argv matches the dashboard binary). When false, the file is
+   * treated as stale from a crash whose PID was recycled to an unrelated
+   * process. */
+  isLegitimatePredecessor(pid: number): boolean
+  sleep(ms: number): Promise<void>
+  log: { info: LogFn; warn: LogFn; error: LogFn }
+}
+
+export interface AcquirePidfileLockOptions {
+  /** Abort after this many failed attempts (default 5). */
+  maxAttempts?: number
+  /** How long to wait between SIGTERM and the retry. Default 1500ms. */
+  graceMs?: number
+  /** What to do when the recorded PID is alive AND legitimately a peer
+   * dashboard process. Default 'sigterm' (kill predecessor, take over).
+   * 'defer' throws DeferToPeerError instead; the caller should exit(0)
+   * quietly. Used to resolve fresh-startup races where the winner is
+   * already partway through init and SIGTERMing them could corrupt state
+   * (e.g. SQLite WAL) before they installed their signal handlers. */
+  onLiveLegitimate?: 'sigterm' | 'defer'
+}
+
+/** Thrown by acquirePidfileLock when a legitimate peer already holds the
+ * pidfile and the caller asked for `onLiveLegitimate: 'defer'`. */
+export class DeferToPeerError extends Error {
+  readonly peerPid: number
+  constructor(peerPid: number) {
+    super(`Pidfile held by legitimate peer PID ${peerPid}`)
+    this.name = 'DeferToPeerError'
+    this.peerPid = peerPid
+  }
+}
+
+/**
+ * Atomically claim an O_EXCL pidfile, serialising two concurrent startups
+ * even if they both passed the port check. If the file exists, inspect the
+ * recorded PID: alive-and-legitimate -> SIGTERM and wait; alive-but-not-
+ * legitimate (PID recycled to an unrelated process) -> treat as stale and
+ * unlink; gone -> unlink. Bounded retry so a permanent problem fails loud
+ * instead of spinning.
+ */
+export async function acquirePidfileLock(
+  path: string,
+  selfPid: number,
+  ctx: PidfileLockContext,
+  opts: AcquirePidfileLockOptions = {},
+): Promise<void> {
+  const maxAttempts = opts.maxAttempts ?? 5
+  const graceMs = opts.graceMs ?? DEFAULT_GRACE_MS
+  const onLiveLegitimate = opts.onLiveLegitimate ?? 'sigterm'
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const outcome = ctx.tryCreateExclusive(path, selfPid)
+    if (outcome === 'created') {
+      ctx.log.info({ pid: selfPid, path }, 'Pidfile lock acquired')
+      return
+    }
+
+    const recorded = ctx.readRecordedPid(path)
+    if (recorded == null) {
+      // File exists but parses to nothing (truncated write, corrupt). Only
+      // unlink if the content is still non-parseable: a concurrent peer
+      // may have rewritten it between our read and this call.
+      ctx.unlinkIfMatches(path, null)
+      continue
+    }
+    if (recorded === selfPid) {
+      // Self-recorded from an earlier run whose PID happened to match
+      // ours after recycling. Drop and retry (only if still unchanged).
+      ctx.unlinkIfMatches(path, selfPid)
+      continue
+    }
+
+    let alive = false
+    try {
+      alive = ctx.probeAlive(recorded)
+    } catch {
+      // Can't probe -- be conservative and assume alive.
+      alive = true
+    }
+    if (!alive) {
+      ctx.log.warn({ recorded }, 'Pidfile references dead PID, unlinking stale file')
+      ctx.unlinkIfMatches(path, recorded)
+      continue
+    }
+
+    if (!ctx.isLegitimatePredecessor(recorded)) {
+      // PID was recycled to an unrelated program. SIGTERMing it would be
+      // dangerous; instead treat the file as stale and move on.
+      ctx.log.warn({ recorded }, 'Pidfile PID alive but not a dashboard process, treating as stale')
+      ctx.unlinkIfMatches(path, recorded)
+      continue
+    }
+
+    if (onLiveLegitimate === 'defer') {
+      // Fresh-startup race: the peer won the O_EXCL race and is mid-init.
+      // SIGTERMing them here could corrupt state (e.g. SQLite WAL, half-
+      // applied migrations) because they have not yet installed their
+      // signal handlers. Back off and let them proceed.
+      ctx.log.info({ recorded }, 'Pidfile held by legitimate peer, deferring')
+      throw new DeferToPeerError(recorded)
+    }
+
+    ctx.log.warn({ recorded }, 'Pidfile held by live predecessor, sending SIGTERM and retrying')
+    try { ctx.sendTerm(recorded) } catch (err) {
+      ctx.log.warn({ recorded, err }, 'SIGTERM to predecessor failed')
+    }
+    await ctx.sleep(graceMs)
+    // Important: only unlink if the file still records THIS predecessor.
+    // During our sleep, the predecessor's own releaseLock may have removed
+    // it and a third startup's tryCreateExclusive may have written its
+    // own PID into the slot -- unconditional unlink would nuke that
+    // peer's legitimate lock and let two dashboards run concurrently.
+    ctx.unlinkIfMatches(path, recorded)
+  }
+  throw new Error(`Failed to acquire pidfile lock at ${path} after ${maxAttempts} attempts`)
+}


### PR DESCRIPTION
## Why this matters

Under macOS launchd with `KeepAlive=true`, a dashboard whose shutdown path got stuck on a live HTTP keep-alive connection (a browser tab with the dashboard open was enough) would linger as a zombie: listening socket gone, but event loop still ticking, scheduler and heartbeat timers still firing. Meanwhile launchd happily spawned a successor. We observed up to three dashboards alive at once. Each instance polled tmux panes and each other's state, so scheduled prompts ended up either in the wrong pane or dropped entirely -- a scheduled morning summary that never arrived is hard to debug and easy to lose.

This PR does two things so that exactly one dashboard is alive at any moment:

1. **Shutdown that actually exits.** `webServer.close()` only refuses new connections; it does not drain existing ones. We now call `closeIdleConnections()` + `closeAllConnections()` (Node 18.2+) to force sockets shut, then `close(callback)`, with a 5s hard-kill timer as a backstop. The signal handler tree (SIGINT, SIGTERM, uncaughtException, unhandledRejection) is installed at the very top of `main()` so even a mid-init peer responds cleanly.

2. **Startup that actually takes over.** The old `acquireLock` read one PID from the pidfile, SIGTERMed it, and overwrote the file immediately -- no wait, no SIGKILL fallback, and nothing if more than one predecessor existed. The new flow enumerates every own-UID node/tsx process that is either listening on `WEB_PORT` or matches the dashboard binary pattern, SIGTERMs them all in parallel, waits a grace window, and SIGKILLs survivors. An atomic O_EXCL pidfile claim then serialises any two fresh startups. A "defer to peer" mode handles the narrow window where the pidfile already names a live legitimate peer that hasn't yet bound the port (fresh-startup race): we exit 0 and let launchd's winner finish instead of SIGTERMing them mid-init.

## Change

**New file `src/process-lock.ts` (pure logic + DI, 363 lines).** Four exports:

- `acquirePortLock(port, ctx, opts)` -- find own-UID node/tsx holders of `port` plus optional argv-pattern matches, SIGTERM them, sleep, SIGKILL survivors, then poll until the kernel drops the listening socket.
- `acquirePidfileLock(path, selfPid, ctx, opts)` -- atomic O_EXCL claim with a bounded retry loop. `onLiveLegitimate: 'defer'` throws `DeferToPeerError` instead of killing when the current holder is a legit peer (used for the fresh-startup race).
- `writeBufferFully(writer, buf)` -- short-write-resilient loop around any synchronous writer that returns bytes-written.
- `DeferToPeerError` -- named error class so `main().catch` can distinguish "loser of a race, exit 0 quietly" from a real crash.

Every I/O operation (lsof, ps, process.kill, sleep, file read/write/unlink) is behind a `ctx` interface so the module has zero node-builtin imports and the kill/sleep/escalate ordering is unit-testable.

**`src/index.ts` rewired.** `acquireLock` is now: (1) `checkFreshStartupRace` -- defer if the pidfile names a live legitimate peer that isn't on the port yet, (2) `acquirePortLock` with `binaryPattern`, (3) `acquirePidfileLock` with `onLiveLegitimate: 'defer'`. `releaseLock` only unlinks the pidfile if it still records our PID. Signal handlers installed before `acquireLock`. Partial-init state (heartbeat, decay interval, digest timers, webServer) is module-scope so `main().catch` can route through `shutdown()` instead of leaking timers on crash. `writeSync` claim goes through `writeBufferFully` to handle short writes.

**Tests: 55 new vitest cases in `src/__tests__/process-lock.test.ts`.** Coverage:

- `findOwnNodeHolders` / `findOwnBinaryMatches`: current-PID exclusion, foreign-UID skip, non-node skip, deduplication, UID=null (non-Unix) fallback.
- `terminateProcesses`: no-op on empty, SIGTERM-only on cooperative kill, escalation on hung process, EPERM-on-probe treated as "still alive", parallel SIGTERM ordering before any sleep.
- `acquirePortLock`: no-holders fast path, self-only no-op, single/multiple zombie kill, binary-pattern catching off-port zombies, deduplication of port+binary overlap, foreign-UID left alone, post-kill drain polling, warn on drain timeout.
- `acquirePidfileLock`: happy path, stale unlink + retry, live-legitimate SIGTERM + retry, PID-recycling protection (alive but not legitimate = stale, no SIGTERM), self-recorded unlink, maxAttempts exhaustion, EPERM-on-probe = conservative alive, defer mode for live-legitimate peer, defer still clears stale/illegitimate, third-peer race protection (regression test).
- `writeBufferFully`: single-shot, looped short writes, 0/negative/NaN return throws, empty buffer no-op.
- `DASHBOARD_BINARY_PATTERN`: 5 positive cases (canonical argvs including `--inspect`, absolute paths, tsx), 6 negative cases (`.bak`, `.map`, `.old`, `.jsx`, `.tmp`/`.staged`, `tsx` wrong extension). Prevents the original `\b`-word-boundary false-positive that would SIGKILL any editor/bundler watching the built artifact.

## Scope / compatibility

- No public API changes. The dashboard HTTP surface, tmux interactions, scheduled-task execution, heartbeat semantics, and memory/kanban endpoints are untouched.
- Startup adds ~0ms on the happy path (no holders -> `findOwnNodeHolders` returns immediately), and up to ~3.5s worst case when a zombie needs SIGTERM + 1.5s grace + SIGKILL + 2s drain. Well under launchd's default 20s ExitTimeOut.
- The existing EADDRINUSE reclaim path in `src/web.ts` is unchanged and acts as a backstop for any microsecond-scale race the pidfile path doesn't close.

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npx vitest run` -- 133/133 tests passing (78 prior + 55 new in `process-lock.test.ts`)
- [x] `npm run build` -- clean
- [x] **Live smoke 1 (zombie-kill)**: on a combined branch containing both this PR and the companion scheduler-queue PR, STOP-ed the running dashboard (PID 1928) to simulate the zombie state, then launched a concurrent instance as PID 2015. The new instance logged:
  ```
  Previous dashboard instance(s) detected, taking over (victims: [1928], matchedBy: byPort + byBinary)
  SIGTERM sent to previous instance
  Previous instance still alive after SIGTERM, escalating to SIGKILL
  Pidfile references dead PID, unlinking stale file
  ```
  Unrelated own-UID processes (Google Chrome Helper, `/bin/zsh`) that showed up in `lsof` were correctly left alone: `Port/binary holder is not a node/tsx process, leaving alone`. Final state: single dashboard, pidfile matches.
- [x] **Live smoke 2 (graceful shutdown with held HTTP connection)**: held a `curl` on `/api/schedules`, sent SIGTERM to the dashboard. Sub-second exit via the `closeAllConnections` path, pidfile released cleanly (releaseLock's PID-match guard worked).
- [ ] Live smoke 3 (uncaughtException exit(1) for launchd restart semantics): covered by unit test + manual inspection of the exitCode branch, not exercised in live smoke.

## Part of the V3 series

Standalone -- does not depend on any of #25-#30.

## Known limitations

- `DASHBOARD_BINARY_PATTERN` matches by argv, which assumes the dashboard is invoked as `node dist/index.js` or `tsx src/index.ts`. A pkg-bundled or bun-compiled single-file binary whose argv is e.g. `/opt/marveen/dashboard` would not match the binary pattern; in that case the port-holder check is the only way in, which is still correct for the common case but can miss a zombie that lost the port. Not a regression relative to today.
- `unlinkIfMatches` is read + unlink, not atomic. A microsecond-scale interleave between the read and the unlink could theoretically erase a concurrent peer's fresh O_EXCL lock. If that ever happens, the existing EADDRINUSE reclaim resolves the double-listener. Documented inline.
- Related but out of scope: the scheduler's `isSessionReadyForPrompt` regex can still false-positive when a Claude Code pane is in a transient thinking state. This PR eliminates the zombie-dashboard class of the original incident (the three-instance-stomping), but the scheduler's pane-state detection is a separate module that a follow-up PR should address.