### PR TITLE
scheduler: persistent busy-retry queue, never abandons

### DIFF
--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import {
   initDatabase,
   getSession,
@@ -9,6 +9,16 @@ import {
   decayMemories,
   getMemoriesForChat,
   buildFtsMatchExpression,
+  getDb,
+  upsertPendingTaskRetry,
+  insertPendingTaskRetryIfNew,
+  updatePendingTaskRetry,
+  listPendingTaskRetries,
+  getPendingTaskRetry,
+  deletePendingTaskRetry,
+  deletePendingTaskRetryById,
+  markPendingTaskRetryAlert,
+  clearPendingTaskRetryAlert,
 } from '../db.js'
 
 beforeAll(() => {
@@ -108,5 +118,119 @@ describe('buildFtsMatchExpression', () => {
 
   it('preserves unicode letters and digits', () => {
     expect(buildFtsMatchExpression('Árvíztűrő 42')).toBe('árvíztűrő* 42*')
+  })
+})
+
+describe('pending task retries', () => {
+  // The persistent test DB is shared with the running dashboard (both
+  // resolve STORE_DIR to the same absolute path), so a blanket DELETE
+  // would wipe the operator's real pending retries. Scope the cleanup to
+  // the exact fixture names used below, and run it both before and after
+  // so a re-run cleans up after itself even if an assertion throws.
+  const FIXTURE_NAMES = [
+    'task-a', 'task-b', 'task-c', 'task-d', 'task-e', 'task-f',
+    'task-old', 'task-new', 'task-new-only', 'task-upd-only',
+    'task-clear-alert',
+  ]
+  const wipeFixtures = () => {
+    const stmt = getDb().prepare('DELETE FROM pending_task_retries WHERE task_name = ?')
+    for (const n of FIXTURE_NAMES) stmt.run(n)
+  }
+  beforeAll(wipeFixtures)
+  afterAll(wipeFixtures)
+
+  it('inserts a new row on first upsert', () => {
+    upsertPendingTaskRetry('task-a', 'main', 1_000_000, 'busy')
+    const row = getPendingTaskRetry('task-a', 'main')
+    expect(row).toMatchObject({
+      task_name: 'task-a',
+      agent_name: 'main',
+      first_attempt: 1_000_000,
+      last_attempt: 1_000_000,
+      attempt_count: 1,
+      last_reason: 'busy',
+      alert_sent_at: null,
+    })
+  })
+
+  it('bumps attempt_count and last_attempt on subsequent upserts, preserves first_attempt', () => {
+    upsertPendingTaskRetry('task-b', 'main', 2_000_000, 'busy')
+    upsertPendingTaskRetry('task-b', 'main', 2_000_500, 'busy')
+    upsertPendingTaskRetry('task-b', 'main', 2_001_000, 'busy')
+    const row = getPendingTaskRetry('task-b', 'main')!
+    expect(row.first_attempt).toBe(2_000_000)
+    expect(row.last_attempt).toBe(2_001_000)
+    expect(row.attempt_count).toBe(3)
+  })
+
+  it('lists entries ordered by first_attempt ASC', () => {
+    upsertPendingTaskRetry('task-old', 'main', 3_000_000, 'busy')
+    upsertPendingTaskRetry('task-new', 'main', 4_000_000, 'busy')
+    const rows = listPendingTaskRetries().filter(r => ['task-old', 'task-new'].includes(r.task_name))
+    expect(rows[0].task_name).toBe('task-old')
+    expect(rows[1].task_name).toBe('task-new')
+  })
+
+  it('deletes by (name, agent) returning true; false when absent', () => {
+    upsertPendingTaskRetry('task-c', 'main', 5_000_000, 'busy')
+    expect(deletePendingTaskRetry('task-c', 'main')).toBe(true)
+    expect(deletePendingTaskRetry('task-c', 'main')).toBe(false)
+  })
+
+  it('deletes by id returning true; false when absent', () => {
+    upsertPendingTaskRetry('task-d', 'main', 6_000_000, 'busy')
+    const row = getPendingTaskRetry('task-d', 'main')!
+    expect(deletePendingTaskRetryById(row.id)).toBe(true)
+    expect(deletePendingTaskRetryById(row.id)).toBe(false)
+  })
+
+  it('markAlert sets alert_sent_at only once (subsequent calls no-op)', () => {
+    upsertPendingTaskRetry('task-e', 'main', 7_000_000, 'busy')
+    expect(markPendingTaskRetryAlert('task-e', 'main', 7_000_100)).toBe(true)
+    expect(markPendingTaskRetryAlert('task-e', 'main', 7_000_200)).toBe(false)
+    const row = getPendingTaskRetry('task-e', 'main')!
+    expect(row.alert_sent_at).toBe(7_000_100)
+  })
+
+  it('separate (name, agent) pairs are distinct rows', () => {
+    upsertPendingTaskRetry('task-f', 'agent-1', 8_000_000, 'busy')
+    upsertPendingTaskRetry('task-f', 'agent-2', 8_000_000, 'busy')
+    const rows = listPendingTaskRetries().filter(r => r.task_name === 'task-f')
+    expect(rows).toHaveLength(2)
+  })
+
+  it('insertPendingTaskRetryIfNew inserts once then refuses', () => {
+    expect(insertPendingTaskRetryIfNew('task-new-only', 'main', 9_000_000, 'busy')).toBe(true)
+    expect(insertPendingTaskRetryIfNew('task-new-only', 'main', 9_000_100, 'busy')).toBe(false)
+    const row = getPendingTaskRetry('task-new-only', 'main')!
+    // first_attempt stays at the original (9_000_000), not the second call
+    expect(row.first_attempt).toBe(9_000_000)
+    expect(row.attempt_count).toBe(1)
+  })
+
+  it('updatePendingTaskRetry only mutates existing rows (no insert)', () => {
+    // No row yet -> returns false, no row created
+    expect(updatePendingTaskRetry('task-upd-only', 'main', 10_000_000, 'busy')).toBe(false)
+    expect(getPendingTaskRetry('task-upd-only', 'main')).toBeUndefined()
+
+    // After insert, update bumps attempt_count + last_attempt
+    insertPendingTaskRetryIfNew('task-upd-only', 'main', 10_000_000, 'busy')
+    expect(updatePendingTaskRetry('task-upd-only', 'main', 10_000_500, 'error')).toBe(true)
+    const row = getPendingTaskRetry('task-upd-only', 'main')!
+    expect(row.last_attempt).toBe(10_000_500)
+    expect(row.attempt_count).toBe(2)
+    expect(row.last_reason).toBe('error')
+  })
+
+  it('clearPendingTaskRetryAlert resets alert_sent_at so the next tick can retry', () => {
+    insertPendingTaskRetryIfNew('task-clear-alert', 'main', 11_000_000, 'busy')
+    markPendingTaskRetryAlert('task-clear-alert', 'main', 11_000_100)
+    expect(getPendingTaskRetry('task-clear-alert', 'main')!.alert_sent_at).toBe(11_000_100)
+
+    expect(clearPendingTaskRetryAlert('task-clear-alert', 'main')).toBe(true)
+    expect(getPendingTaskRetry('task-clear-alert', 'main')!.alert_sent_at).toBeNull()
+
+    // After clear, markAlert succeeds again
+    expect(markPendingTaskRetryAlert('task-clear-alert', 'main', 11_000_200)).toBe(true)
   })
 })

--- a/src/__tests__/pending-retries.test.ts
+++ b/src/__tests__/pending-retries.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  shouldSendAlert,
+  toPendingRetryView,
+  ALERT_THRESHOLD_MS,
+} from '../pending-retries.js'
+
+describe('shouldSendAlert', () => {
+  const firstAttempt = 1_000_000
+  const threshold = 60 * 60 * 1000 // 1 hour
+
+  it('returns false when no time has passed', () => {
+    expect(shouldSendAlert(firstAttempt, firstAttempt, null, threshold)).toBe(false)
+  })
+
+  it('returns false while the waiting window is below the threshold', () => {
+    expect(shouldSendAlert(firstAttempt + threshold / 2, firstAttempt, null, threshold)).toBe(false)
+  })
+
+  it('returns false exactly at the threshold (strict >)', () => {
+    expect(shouldSendAlert(firstAttempt + threshold, firstAttempt, null, threshold)).toBe(false)
+  })
+
+  it('returns true once the waiting window exceeds the threshold', () => {
+    expect(shouldSendAlert(firstAttempt + threshold + 1, firstAttempt, null, threshold)).toBe(true)
+  })
+
+  it('returns false if an alert was already sent', () => {
+    expect(
+      shouldSendAlert(firstAttempt + 10 * threshold, firstAttempt, firstAttempt + threshold + 1, threshold),
+    ).toBe(false)
+  })
+
+  it('uses the default threshold (1 hour) when not supplied', () => {
+    expect(shouldSendAlert(firstAttempt + ALERT_THRESHOLD_MS + 1, firstAttempt, null)).toBe(true)
+    expect(shouldSendAlert(firstAttempt + ALERT_THRESHOLD_MS - 1, firstAttempt, null)).toBe(false)
+  })
+
+  it('returns false if firstAttempt is zero / non-positive (corrupt row)', () => {
+    expect(shouldSendAlert(Date.now(), 0, null, threshold)).toBe(false)
+    expect(shouldSendAlert(Date.now(), -1, null, threshold)).toBe(false)
+  })
+
+  it('returns false if now < firstAttempt (clock skew or bad input)', () => {
+    expect(shouldSendAlert(firstAttempt - 1000, firstAttempt, null, threshold)).toBe(false)
+  })
+
+  it('returns false on non-finite inputs', () => {
+    expect(shouldSendAlert(NaN, firstAttempt, null, threshold)).toBe(false)
+    expect(shouldSendAlert(firstAttempt + threshold + 1, NaN, null, threshold)).toBe(false)
+  })
+})
+
+describe('toPendingRetryView', () => {
+  const baseRow = {
+    id: 42,
+    task_name: 'morning-summary',
+    agent_name: 'main',
+    first_attempt: 1_000_000,
+    last_attempt: 1_000_500,
+    attempt_count: 5,
+    last_reason: 'busy',
+    alert_sent_at: null as number | null,
+  }
+
+  it('maps snake_case DB fields to camelCase UI view', () => {
+    const view = toPendingRetryView(baseRow, 1_001_000)
+    expect(view).toMatchObject({
+      id: 42,
+      taskName: 'morning-summary',
+      agentName: 'main',
+      firstAttempt: 1_000_000,
+      lastAttempt: 1_000_500,
+      attemptCount: 5,
+      lastReason: 'busy',
+      alertSentAt: null,
+    })
+  })
+
+  it('derives ageMs as now - firstAttempt, clamped at zero', () => {
+    expect(toPendingRetryView(baseRow, 1_000_000 + 12345).ageMs).toBe(12345)
+    // Negative age (clock skew): clamp to 0
+    expect(toPendingRetryView(baseRow, 999_000).ageMs).toBe(0)
+  })
+
+  it('sets alertDue=true once past the threshold and no alert yet', () => {
+    const view = toPendingRetryView(baseRow, 1_000_000 + ALERT_THRESHOLD_MS + 1)
+    expect(view.alertDue).toBe(true)
+  })
+
+  it('sets alertDue=false if an alert was already sent', () => {
+    const view = toPendingRetryView(
+      { ...baseRow, alert_sent_at: 1_000_000 + ALERT_THRESHOLD_MS + 100 },
+      1_000_000 + 2 * ALERT_THRESHOLD_MS,
+    )
+    expect(view.alertDue).toBe(false)
+  })
+
+  it('honors a custom threshold', () => {
+    const view = toPendingRetryView(baseRow, 1_000_100, 50)
+    expect(view.alertDue).toBe(true)
+    const viewUnder = toPendingRetryView(baseRow, 1_000_100, 200)
+    expect(viewUnder.alertDue).toBe(false)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -252,6 +252,32 @@ export function initDatabase(): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_task_runs_ts ON task_runs(ts)`)
 
+  // --- Pending Scheduled Task Retries ---
+  // Busy-skipped scheduled tasks used to live in an in-memory Map. On a
+  // dashboard restart (or crash), the queue was lost -- even though the
+  // operator had asked for the task to run, it silently disappeared.
+  // This table persists each busy-retry across restarts so nothing is
+  // dropped. When a row crosses the alert threshold, the alerting layer
+  // stamps alert_sent_at before each Telegram send and clears it on
+  // delivery failure, yielding at-least-once delivery with no double-
+  // alerting on concurrent ticks. The scheduler itself never abandons:
+  // it keeps retrying until the session frees up or the operator
+  // cancels from the UI.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pending_task_retries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_name TEXT NOT NULL,
+      agent_name TEXT NOT NULL,
+      first_attempt INTEGER NOT NULL,
+      last_attempt INTEGER NOT NULL,
+      attempt_count INTEGER NOT NULL DEFAULT 1,
+      last_reason TEXT,
+      alert_sent_at INTEGER,
+      UNIQUE(task_name, agent_name)
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_pending_retries_first_attempt ON pending_task_retries(first_attempt)`)
+
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
   // re-importing. Wrapped in a transaction so a crash mid-import is safe.
@@ -789,6 +815,111 @@ export function getActiveScheduledTaskCount(): { count: number; nextRun: number 
     .prepare("SELECT COUNT(*) as count, MIN(next_run) as next_run FROM scheduled_tasks WHERE status = 'active'")
     .get() as { count: number; next_run: number | null }
   return { count: row.count, nextRun: row.next_run }
+}
+
+// --- Pending scheduled-task retries ------------------------------------
+
+export interface PendingTaskRetryRow {
+  id: number
+  task_name: string
+  agent_name: string
+  first_attempt: number
+  last_attempt: number
+  attempt_count: number
+  last_reason: string | null
+  alert_sent_at: number | null
+}
+
+/**
+ * Insert a busy-skipped scheduled task into the retry queue if and only if
+ * no row exists for the (task_name, agent_name) pair. Returns true on
+ * insert, false if a row already existed. Used for the first "busy" hit
+ * from the cron loop.
+ */
+export function insertPendingTaskRetryIfNew(
+  taskName: string,
+  agentName: string,
+  now: number,
+  reason: string,
+): boolean {
+  return db.prepare(`
+    INSERT OR IGNORE INTO pending_task_retries
+      (task_name, agent_name, first_attempt, last_attempt, attempt_count, last_reason)
+    VALUES (?, ?, ?, ?, 1, ?)
+  `).run(taskName, agentName, now, now, reason).changes > 0
+}
+
+/**
+ * Update an existing retry row's last_attempt / attempt_count / last_reason.
+ * Returns true if a row was updated, false if none existed (e.g. the
+ * operator cancelled the row between a tick loading it and this call).
+ * Used from the retry loop so a cancelled row isn't silently re-created.
+ */
+export function updatePendingTaskRetry(
+  taskName: string,
+  agentName: string,
+  now: number,
+  reason: string,
+): boolean {
+  return db.prepare(`
+    UPDATE pending_task_retries
+       SET last_attempt = ?,
+           attempt_count = attempt_count + 1,
+           last_reason = ?
+     WHERE task_name = ? AND agent_name = ?
+  `).run(now, reason, taskName, agentName).changes > 0
+}
+
+/** Back-compat shim used by tests written against the original upsert
+ * semantics. Internal code should use the explicit insert-if-new /
+ * update-if-exists pair above. */
+export function upsertPendingTaskRetry(
+  taskName: string,
+  agentName: string,
+  now: number,
+  reason: string,
+): void {
+  if (!updatePendingTaskRetry(taskName, agentName, now, reason)) {
+    insertPendingTaskRetryIfNew(taskName, agentName, now, reason)
+  }
+}
+
+/** Clear the alert timestamp so the next tick is free to re-alert. Used
+ * when a Telegram send failed after we stamped the row optimistically. */
+export function clearPendingTaskRetryAlert(taskName: string, agentName: string): boolean {
+  return db
+    .prepare('UPDATE pending_task_retries SET alert_sent_at = NULL WHERE task_name = ? AND agent_name = ?')
+    .run(taskName, agentName).changes > 0
+}
+
+export function listPendingTaskRetries(): PendingTaskRetryRow[] {
+  return db
+    .prepare('SELECT * FROM pending_task_retries ORDER BY first_attempt ASC')
+    .all() as PendingTaskRetryRow[]
+}
+
+export function getPendingTaskRetry(taskName: string, agentName: string): PendingTaskRetryRow | undefined {
+  return db
+    .prepare('SELECT * FROM pending_task_retries WHERE task_name = ? AND agent_name = ?')
+    .get(taskName, agentName) as PendingTaskRetryRow | undefined
+}
+
+export function deletePendingTaskRetry(taskName: string, agentName: string): boolean {
+  return db
+    .prepare('DELETE FROM pending_task_retries WHERE task_name = ? AND agent_name = ?')
+    .run(taskName, agentName).changes > 0
+}
+
+export function deletePendingTaskRetryById(id: number): boolean {
+  return db
+    .prepare('DELETE FROM pending_task_retries WHERE id = ?')
+    .run(id).changes > 0
+}
+
+export function markPendingTaskRetryAlert(taskName: string, agentName: string, ts: number): boolean {
+  return db
+    .prepare('UPDATE pending_task_retries SET alert_sent_at = ? WHERE task_name = ? AND agent_name = ? AND alert_sent_at IS NULL')
+    .run(ts, taskName, agentName).changes > 0
 }
 
 // --- Vector Search (Ollama + nomic-embed-text) ---

--- a/src/pending-retries.ts
+++ b/src/pending-retries.ts
@@ -1,0 +1,105 @@
+// Pure-logic helpers for the persistent scheduled-task retry queue.
+//
+// The scheduler used to keep busy-skipped tasks in an in-memory Map and
+// abandon them after 15-60 minutes, silently. That failure mode is fatal
+// for business-critical schedules (a morning summary that never arrives
+// is only noticed hours later). The replacement policy is:
+//
+//   1. Every busy retry is upserted into `pending_task_retries` (persists
+//      across dashboard restarts, so nothing is dropped).
+//   2. On every tick, the scheduler tries to fire every pending row. On
+//      success, the row is deleted; on continued busy, attempt_count ++.
+//   3. If a row has been waiting longer than `ALERT_THRESHOLD_MS` and
+//      `alert_sent_at` is null, the alerting layer stamps the row BEFORE
+//      sending the Telegram message (so concurrent ticks do not
+//      double-alert) and clears the stamp if the send fails (so the next
+//      tick can retry). Net guarantee: one stamp per delivery attempt,
+//      at-least-once delivery until success. The scheduled task itself
+//      keeps retrying forever -- we do NOT abandon.
+//
+// This module contains the decision logic only; the I/O (DB + Telegram)
+// lives in src/web.ts alongside the rest of the scheduler, but is wrapped
+// behind small pure functions here so the "should we alert" decision can
+// be unit-tested without a DB and without an HTTP mock.
+
+/**
+ * How long a busy-skipped scheduled task can wait before we escalate the
+ * operator via Telegram. The retry itself continues forever: this is the
+ * alerting threshold, not an abandon threshold.
+ */
+export const ALERT_THRESHOLD_MS = 60 * 60 * 1000
+
+/**
+ * Decide whether the alerting layer should fire a Telegram notification
+ * for a pending retry row.
+ *
+ * Returns true only when:
+ *   - the row has been waiting longer than `thresholdMs`, AND
+ *   - no alert is currently stamped (`alertSentAt` is null).
+ *
+ * Callers are responsible for stamping `alert_sent_at` before the Telegram
+ * send (race guard against concurrent ticks) and clearing it on delivery
+ * failure so the next tick can retry.
+ */
+export function shouldSendAlert(
+  now: number,
+  firstAttempt: number,
+  alertSentAt: number | null,
+  thresholdMs: number = ALERT_THRESHOLD_MS,
+): boolean {
+  if (alertSentAt != null) return false
+  if (!Number.isFinite(firstAttempt) || firstAttempt <= 0) return false
+  if (!Number.isFinite(now) || now < firstAttempt) return false
+  return now - firstAttempt > thresholdMs
+}
+
+/**
+ * Shape of a pending retry used by the UI + the alert layer. A small
+ * subset of the DB row, decoupled from the DB type so tests don't need
+ * better-sqlite3.
+ */
+export interface PendingRetryView {
+  id: number
+  taskName: string
+  agentName: string
+  firstAttempt: number
+  lastAttempt: number
+  attemptCount: number
+  lastReason: string | null
+  alertSentAt: number | null
+  ageMs: number
+  alertDue: boolean
+}
+
+/**
+ * Project a raw DB row into the UI view, including the derived `ageMs`
+ * (for display) and `alertDue` (= shouldSendAlert). Keeping the derivation
+ * here means the UI never has to carry the alert policy.
+ */
+export function toPendingRetryView(
+  row: {
+    id: number
+    task_name: string
+    agent_name: string
+    first_attempt: number
+    last_attempt: number
+    attempt_count: number
+    last_reason: string | null
+    alert_sent_at: number | null
+  },
+  now: number,
+  thresholdMs: number = ALERT_THRESHOLD_MS,
+): PendingRetryView {
+  return {
+    id: row.id,
+    taskName: row.task_name,
+    agentName: row.agent_name,
+    firstAttempt: row.first_attempt,
+    lastAttempt: row.last_attempt,
+    attemptCount: row.attempt_count,
+    lastReason: row.last_reason,
+    alertSentAt: row.alert_sent_at,
+    ageMs: Math.max(0, now - row.first_attempt),
+    alertDue: shouldSendAlert(now, row.first_attempt, row.alert_sent_at, thresholdMs),
+  }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -22,8 +22,13 @@ import {
   createAgentMessage, getPendingMessages, markMessageDelivered,
   markMessageDone, markMessageFailed, listAgentMessages, getAgentMessage,
   appendTaskRun, countTaskRunsBetween,
+  insertPendingTaskRetryIfNew, updatePendingTaskRetry,
+  listPendingTaskRetries, deletePendingTaskRetry,
+  deletePendingTaskRetryById, markPendingTaskRetryAlert,
+  clearPendingTaskRetryAlert,
   type Memory, type AgentMessage,
 } from './db.js'
+import { toPendingRetryView, type PendingRetryView } from './pending-retries.js'
 import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, ALLOWED_CHAT_ID, HEARTBEAT_CALENDAR_ID } from './config.js'
 import {
   wrapUntrusted,
@@ -911,11 +916,19 @@ Output ONLY the markdown content, no code fences.`
 }
 
 async function sendTelegramMessage(token: string, chatId: string, text: string): Promise<void> {
-  await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+  const resp = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ chat_id: chatId, text }),
   })
+  // fetch does not throw on 4xx -- a wrong chat_id or revoked token resolves
+  // silently, which historically made "alert sent" log lines lies. Throw so
+  // the existing try/catch blocks at every call site log the real failure
+  // and the alerting path can clear its per-attempt stamp to retry.
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    throw new Error(`Telegram API ${resp.status}: ${body.slice(0, 200)}`)
+  }
 }
 
 async function sendTelegramPhoto(token: string, chatId: string, photoPath: string, caption: string): Promise<void> {
@@ -1627,15 +1640,16 @@ function startTelegramPluginMonitor(): NodeJS.Timeout {
 
 const scheduleLastRun: Map<string, number> = new Map()
 
-// Tasks that matched their cron but found the target session busy. The
-// cron-matcher only fires on an exact minute boundary, so without a retry
-// queue the task would be skipped for the whole day. Keep it here and
-// retry on subsequent 60s ticks until the session frees up or the window
-// expires. 60 min accommodates long-running audits and multi-agent turns
-// that can span 40-70 minutes without letting a missed noon run land at 14:00.
-interface PendingRetry { firstAttempt: number; task: ScheduledTask; agent: string }
-const pendingTaskRetries: Map<string, PendingRetry> = new Map()
-const PENDING_RETRY_WINDOW_MS = 60 * 60 * 1000
+// Tasks that matched their cron but found the target session busy are
+// persisted in the `pending_task_retries` DB table and retried on every
+// subsequent 60s tick until the session frees up or the operator cancels
+// them from the UI. The previous design kept them in an in-memory Map
+// and abandoned them after an hour -- which silently dropped business-
+// critical schedules. The new policy never abandons; once the age
+// crosses ALERT_THRESHOLD_MS the alerting layer stamps alert_sent_at
+// before each Telegram send and clears the stamp on delivery failure,
+// giving exactly-one stamp per attempt and at-least-once delivery until
+// success. See sendPendingRetryAlert below.
 
 // Persistent task run history so the overview's "tasksToday" number survives
 // dashboard restarts. Keep the last 30 days.
@@ -1973,6 +1987,51 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
   }
 }
 
+// Fire a Telegram alert when a pending retry has been stuck past the
+// threshold. Stamps `alert_sent_at` BEFORE the network call so concurrent
+// ticks and crash-restarts cannot race into double-alerting on the same
+// attempt. If the send fails, the stamp is cleared so the next tick can
+// retry -- that way a transient Telegram outage or a bad token doesn't
+// silently suppress every future alert on this row. Net semantics:
+// exactly-one stamp per delivery attempt, at-least-once delivery with a
+// 60s retry cadence until success.
+function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
+  // Stamp first. If another tick raced us, markPendingTaskRetryAlert
+  // returns false (the WHERE alert_sent_at IS NULL guards it) and we
+  // skip the send entirely.
+  const claimed = markPendingTaskRetryAlert(view.taskName, view.agentName, nowMs)
+  if (!claimed) return
+
+  const ageMinutes = Math.floor(view.ageMs / 60000)
+  const firstAttempt = new Date(view.firstAttempt).toLocaleString('hu-HU')
+  const text = [
+    `[Marveen scheduler] A(z) "${view.taskName}" (${view.agentName}) utemezett feladat ${ageMinutes} perce varakozik.`,
+    `Elso probalkozas: ${firstAttempt}.`,
+    'A rendszer tovabb probalkozik; a dashboard /Utemezesek oldalan visszavonhato.',
+  ].join('\n')
+  ;(async () => {
+    try {
+      const envPath = join(PROJECT_ROOT, '.env')
+      const envContent = readFileOr(envPath, '')
+      const tokenMatch = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)
+      const token = tokenMatch?.[1]?.trim()
+      if (!token) {
+        logger.warn({ task: view.taskName, agent: view.agentName }, 'Pending-retry alert skipped: no TELEGRAM_BOT_TOKEN, clearing stamp for retry')
+        clearPendingTaskRetryAlert(view.taskName, view.agentName)
+        return
+      }
+      await sendTelegramMessage(token, ALLOWED_CHAT_ID, text)
+      logger.info({ task: view.taskName, agent: view.agentName, ageMinutes }, 'Pending-retry Telegram alert sent')
+    } catch (err) {
+      // Real send failure (network error, 4xx from Telegram). Clear the
+      // per-attempt stamp so the next tick can legitimately retry --
+      // otherwise a bad token silently wedges the alerting forever.
+      logger.warn({ err, task: view.taskName, agent: view.agentName }, 'Pending-retry alert delivery failed, clearing stamp for retry')
+      clearPendingTaskRetryAlert(view.taskName, view.agentName)
+    }
+  })()
+}
+
 function startScheduleRunner(): NodeJS.Timeout {
   let firstRun = true
 
@@ -1983,21 +2042,48 @@ function startScheduleRunner(): NodeJS.Timeout {
     const catchUp = firstRun ? 30 * 60000 : 60000
     firstRun = false
 
-    // Retry tasks that were busy-skipped on earlier ticks. cronMatchesNow
-    // only matches on the exact minute boundary, so without this the noon
+    // Retry tasks that were busy-skipped on earlier ticks (persisted in
+    // pending_task_retries so they survive dashboard restart). cronMatchesNow
+    // only fires on an exact minute boundary, so without this the noon
     // check skipped because the session was busy at 12:00:50 would never
-    // run that day.
-    for (const [key, pending] of Array.from(pendingTaskRetries.entries())) {
-      if (now - pending.firstAttempt > PENDING_RETRY_WINDOW_MS) {
-        logger.warn({ task: pending.task.name, agent: pending.agent, windowMs: PENDING_RETRY_WINDOW_MS }, 'Pending scheduled task retry window expired, abandoning')
-        pendingTaskRetries.delete(key)
-        // Clear lastRun so the next cron match for this task is free to fire
-        // even if the abandoned window overlaps the next scheduled boundary.
-        scheduleLastRun.delete(pending.task.name)
+    // run that day. We NEVER abandon -- the operator can cancel from the
+    // UI if a retry has become obsolete.
+    const pendingRows = listPendingTaskRetries()
+    const pendingKeys = new Set<string>()
+    for (const row of pendingRows) {
+      // Locate the task definition. If it was deleted meanwhile, drop the
+      // retry silently -- nothing to fire.
+      const taskDef = tasks.find(t => t.name === row.task_name)
+      if (!taskDef) {
+        deletePendingTaskRetry(row.task_name, row.agent_name)
         continue
       }
-      const result = attemptFireTask(pending.task, pending.agent, now)
-      if (result !== 'busy') pendingTaskRetries.delete(key)
+      // Honor the operator's disable action: if the task was toggled off
+      // while the retry sat in the queue, drop the retry so a long-stuck
+      // task doesn't surprise-fire the moment the session frees up.
+      if (!taskDef.enabled) {
+        deletePendingTaskRetry(row.task_name, row.agent_name)
+        continue
+      }
+
+      // Register the key only once we know the retry is live, so the cron
+      // loop below doesn't treat a dead row as a reason to skip.
+      const key = `${row.task_name}@${row.agent_name}`
+      pendingKeys.add(key)
+
+      const view = toPendingRetryView(row, now)
+      const result = attemptFireTask(taskDef, row.agent_name, now)
+      if (result === 'fired' || result === 'missing') {
+        deletePendingTaskRetry(row.task_name, row.agent_name)
+        continue
+      }
+      // Still busy or errored: refresh the retry row and alert ONCE if
+      // the age crossed the threshold. `updatePendingTaskRetry` returns
+      // false when the row has been cancelled between load and now --
+      // in that case, do not re-insert (the operator's cancel wins) and
+      // do not alert.
+      const stillPresent = updatePendingTaskRetry(row.task_name, row.agent_name, now, result)
+      if (stillPresent && view.alertDue) sendPendingRetryAlert(view, now)
     }
 
     for (const task of tasks) {
@@ -2020,12 +2106,15 @@ function startScheduleRunner(): NodeJS.Timeout {
 
       for (const agentName of targetAgents) {
         const key = `${task.name}@${agentName}`
-        // If already queued for retry from an earlier tick, leave it to the
-        // retry handler -- don't re-queue or double-fire.
-        if (pendingTaskRetries.has(key)) continue
+        // If already queued for retry from an earlier tick, leave it to
+        // the retry handler -- don't re-queue or double-fire.
+        if (pendingKeys.has(key)) continue
         const result = attemptFireTask(task, agentName, now)
         if (result === 'busy') {
-          pendingTaskRetries.set(key, { firstAttempt: now, task, agent: agentName })
+          // First encounter -- insert a new pending row. If somehow a
+          // row already exists (race with a just-cancelled retry), do
+          // nothing so the cancel wins the tiebreak.
+          insertPendingTaskRetryIfNew(task.name, agentName, now, 'busy')
         }
       }
     }
@@ -2947,6 +3036,24 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
         atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
         logger.info({ name, enabled: newEnabled }, 'Scheduled task toggled')
         return json(res, { ok: true, enabled: newEnabled })
+      }
+
+      // GET /api/schedules/pending - List pending (busy-skipped) retries
+      if (path === '/api/schedules/pending' && method === 'GET') {
+        const now = Date.now()
+        const rows = listPendingTaskRetries().map(r => toPendingRetryView(r, now))
+        return json(res, rows)
+      }
+
+      // DELETE /api/schedules/pending/:id - Cancel a single pending retry
+      const pendingCancelMatch = path.match(/^\/api\/schedules\/pending\/(\d+)$/)
+      if (pendingCancelMatch && method === 'DELETE') {
+        const id = parseInt(pendingCancelMatch[1], 10)
+        if (!Number.isFinite(id)) return json(res, { error: 'Invalid id' }, 400)
+        const removed = deletePendingTaskRetryById(id)
+        if (!removed) return json(res, { error: 'Pending retry not found' }, 404)
+        logger.info({ id }, 'Pending scheduled-task retry cancelled via API')
+        return json(res, { ok: true })
       }
 
       // === Tasks API (legacy, kept for backward compat) ===

--- a/web/app.js
+++ b/web/app.js
@@ -1759,9 +1759,89 @@ async function loadSchedules() {
     schedules = await schedulesRes.json()
     renderScheduleList(schedules)
     if (currentScheduleView === 'timeline') renderTimeline(schedules)
+    loadPendingRetries()
   } catch (err) {
     console.error('Ütemezés betöltés hiba:', err)
   }
+}
+
+async function loadPendingRetries() {
+  const container = document.getElementById('pendingRetriesSection')
+  if (!container) return
+  try {
+    const res = await fetch('/api/schedules/pending')
+    if (!res.ok) { container.hidden = true; return }
+    const rows = await res.json()
+    renderPendingRetries(container, Array.isArray(rows) ? rows : [])
+  } catch (err) {
+    console.error('Pending retry betöltés hiba:', err)
+    container.hidden = true
+  }
+}
+
+function formatPendingAge(ms) {
+  const mins = Math.floor(ms / 60000)
+  if (mins < 1) return 'kevesebb, mint 1 perce'
+  if (mins < 60) return `${mins} perce`
+  const hours = Math.floor(mins / 60)
+  const remMins = mins % 60
+  return remMins ? `${hours} ó ${remMins} p-e` : `${hours} órája`
+}
+
+function renderPendingRetries(container, rows) {
+  if (!rows.length) {
+    container.hidden = true
+    container.innerHTML = ''
+    return
+  }
+  container.hidden = false
+  const items = rows.map(r => `
+    <div class="pending-retry-row" data-id="${r.id}">
+      <div class="pending-retry-info">
+        <div class="pending-retry-title">
+          ${escapeHtml(r.taskName)}
+          <span class="badge badge-paused">${escapeHtml(r.agentName)}</span>
+          ${r.alertSentAt
+            ? '<span class="badge badge-heartbeat" title="Telegram riasztás elküldve">⚠️ riasztás elküldve</span>'
+            : r.alertDue
+              ? '<span class="badge badge-heartbeat" title="Riasztás esedékes, a következő tick küldi">⏳ riasztás esedékes</span>'
+              : ''}
+        </div>
+        <div class="pending-retry-meta">
+          <span>${formatPendingAge(r.ageMs)} vár (${r.attemptCount} próbálkozás)</span>
+          ${r.lastReason ? `<span>ok: ${escapeHtml(r.lastReason)}</span>` : ''}
+        </div>
+      </div>
+      <button class="btn-icon btn-icon-danger" data-action="cancel-pending" title="Visszavonás">
+        ${trashIcon()}
+      </button>
+    </div>
+  `).join('')
+  container.innerHTML = `
+    <div class="pending-retries-banner">
+      <div class="pending-retries-header">
+        <span class="pending-retries-title">Függőben lévő ütemezett feladatok (${rows.length})</span>
+        <span class="pending-retries-hint">Busy cél-session, a rendszer tovább próbálkozik. Nyilvánvaló hibánál visszavonhatod.</span>
+      </div>
+      <div class="pending-retries-list">${items}</div>
+    </div>
+  `
+  container.querySelectorAll('[data-action="cancel-pending"]').forEach(btn => {
+    btn.addEventListener('click', async (e) => {
+      e.stopPropagation()
+      const row = e.currentTarget.closest('.pending-retry-row')
+      const id = row?.dataset.id
+      if (!id) return
+      if (!confirm('Biztosan visszavonod ezt a várakozó ütemezett feladatot?')) return
+      try {
+        const res = await fetch(`/api/schedules/pending/${encodeURIComponent(id)}`, { method: 'DELETE' })
+        if (!res.ok) throw new Error('cancel failed')
+        loadPendingRetries()
+      } catch (err) {
+        console.error('Pending retry cancel hiba:', err)
+      }
+    })
+  })
 }
 
 function renderScheduleList(tasks) {

--- a/web/index.html
+++ b/web/index.html
@@ -210,6 +210,11 @@
         </div>
       </div>
 
+      <!-- Pending retries banner (rendered only when the persistent retry
+           queue has entries; the scheduler adds a row for any busy-skipped
+           task so the operator can see and cancel stuck items). -->
+      <div id="pendingRetriesSection" hidden></div>
+
       <!-- List view -->
       <div class="schedule-view" id="scheduleListView">
         <div class="schedule-list" id="scheduleList"></div>

--- a/web/style.css
+++ b/web/style.css
@@ -2239,6 +2239,63 @@ main {
   gap: 8px;
 }
 
+.pending-retries-banner {
+  margin-bottom: 16px;
+  padding: 14px 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 3px solid #e5a43a;
+  border-radius: var(--radius);
+}
+.pending-retries-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+.pending-retries-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.pending-retries-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.pending-retries-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.pending-retry-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) - 2px);
+}
+.pending-retry-info { flex: 1; min-width: 0; }
+.pending-retry-title {
+  font-size: 13px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.pending-retry-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  display: flex;
+  gap: 12px;
+  margin-top: 3px;
+  flex-wrap: wrap;
+}
+
 .schedule-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Why this matters

The scheduler used to keep busy-skipped tasks in an in-memory Map and drop them after 60 minutes without a word. In practice: an operator who set up a business-critical daily schedule (morning summary, invoice reminder, incident heartbeat) had no way to notice that a stuck target session caused the whole day's run to disappear. A dashboard restart also nuked every in-flight retry. Operator quote from the triage: *"Mi van, ha életbevágó fontos ütemezett feladatot állítottam volna be a vállalkozásomhoz, és nem kapom meg?"*

This PR replaces that in-memory queue with a persistent SQLite table, removes the silent-abandon policy, and adds a visible operator surface (Telegram alert after 1h + dashboard UI with a cancel button). Nothing is ever dropped: the scheduler keeps retrying until the session frees up or the operator explicitly cancels.

## Change

**New table `pending_task_retries` in `src/db.ts`** keyed by `(task_name, agent_name)`, persists across dashboard restart. Fields: `first_attempt`, `last_attempt`, `attempt_count`, `last_reason` (busy|missing|error), `alert_sent_at`.

**New module `src/pending-retries.ts`** (pure logic, DI-free):
- `shouldSendAlert(now, firstAttempt, alertSentAt, thresholdMs)` -- strict `>` boundary, guards NaN / clock-skew / non-positive firstAttempt.
- `toPendingRetryView(row, now, threshold)` -- DB row to UI view, computes `ageMs` + `alertDue`.
- `ALERT_THRESHOLD_MS = 60 * 60 * 1000`.

**`src/db.ts` helpers (all parameterized):**
- `insertPendingTaskRetryIfNew(name, agent, now, reason)` -- `INSERT OR IGNORE`, returns whether a row was inserted. Used on the first busy hit from the cron loop; a just-cancelled row stays cancelled.
- `updatePendingTaskRetry(name, agent, now, reason)` -- UPDATE-only, returns false when no row exists. Used from the retry loop so a mid-tick cancel wins the tiebreak.
- `upsertPendingTaskRetry` -- back-compat shim kept for test ergonomics.
- `listPendingTaskRetries()` -- ORDER BY first_attempt ASC (indexed).
- `getPendingTaskRetry(name, agent)`, `deletePendingTaskRetry(name, agent)`, `deletePendingTaskRetryById(id)`.
- `markPendingTaskRetryAlert(name, agent, ts)` -- conditional UPDATE `WHERE alert_sent_at IS NULL`, returns whether the stamp was claimed (race-free against concurrent ticks).
- `clearPendingTaskRetryAlert(name, agent)` -- used to reset the stamp when a Telegram send fails so the next tick can retry.

**`src/web.ts` scheduler rewrite (`startScheduleRunner`):**
- Reads the pending queue from DB on every tick. Rows whose task definition was deleted OR whose task is disabled are dropped (honoring the operator's pause/delete intent).
- `attemptFireTask` returns: `fired` / `missing` -> row deleted. `busy` / `error` -> `updatePendingTaskRetry` (false = cancelled, no re-insert, no alert).
- Cron-match loop uses `insertPendingTaskRetryIfNew` with the existing `pendingKeys` guard.
- `sendPendingRetryAlert` stamps `alert_sent_at` BEFORE the Telegram send (race guard against concurrent ticks and restart crashes), clears the stamp on delivery failure. Net semantics: exactly-one stamp per attempt, at-least-once delivery with a 60s retry cadence until success.
- `sendTelegramMessage` now throws on `!resp.ok` (it silently swallowed 4xx before, making "alert sent" log lines lies when the token was wrong). All five existing call sites already wrapped the call in try/catch, so no behavioral regression outside that silent-failure path.

**New API endpoints (bearer-gated, same as the rest of `/api/schedules`):**
- `GET /api/schedules/pending` -- list + derived `ageMs` / `alertDue` per row.
- `DELETE /api/schedules/pending/:id` -- operator cancel.

**Dashboard UI (`web/index.html` + `web/app.js` + `web/style.css`):**
- New banner on the Utemezesek page: lists stuck rows with task name, agent, waiting age (human-formatted), attempt count, last reason, alert status badge (`esedekes` vs `elkuldve` with distinct tooltips), and a trash button that posts the DELETE. Hidden entirely when the queue is empty. `escapeHtml` applied to every user-derived field.

## Scope / compatibility

- Happy path unchanged. A task whose cron match lands on a ready session fires and returns as before -- no new DB writes in the non-busy path.
- Dashboard restart now imports (rather than drops) any pending retries from the previous run. First tick after boot re-attempts each one.
- The breaking change to `sendTelegramMessage` (throw on !resp.ok) makes existing callers surface the real reason for a failed send instead of logging "sent" and moving on. Net strict improvement; every call site already had a catch.
- No migration needed for existing installs: `CREATE TABLE IF NOT EXISTS` runs on every init, and the in-memory Map had nothing to persist.

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npx vitest run` -- 102/102 tests passing (14 new in `pending-retries.test.ts` + 10 new in `db.test.ts` covering insertIfNew/update/upsert/markAlert/clearAlert)
- [x] `npm run build` -- clean
- [x] **Live smoke 1 (scheduler fires on a ready session)**: on a combined branch containing both this PR and the zombie-proof-lock PR, created `smoke-test-11-10` with cron `10 11 * * *`. The 11:10:40 tick logged `Scheduled task fired task: smoke-test-11-10 agent: <main>`. Pending queue stayed empty -- the happy path correctly skips the retry table.
- [x] **Live smoke 2 (persistent retry queue under forced-busy)**: created `smoke-busy-retry` with `*/1 * * * *` targeting an `agent-dev2` session that was held in a thinking state. At 11:15:39 the scheduler logged `Schedule target session busy or has pending input, will retry task: smoke-busy-retry`. `GET /api/schedules/pending` returned:
  ```
  [{"id":217,"taskName":"smoke-busy-retry","agentName":"dev2","firstAttempt":...,"lastAttempt":...,"attemptCount":1,"lastReason":"busy","alertSentAt":null,"ageMs":2980,"alertDue":false}]
  ```
  Confirms the `insertPendingTaskRetryIfNew` + `toPendingRetryView` path end-to-end.
- [x] **Live smoke 3 (operator cancel via API)**: `DELETE /api/schedules/pending/217` returned `{"ok":true}`; subsequent `GET /api/schedules/pending` returned `[]`; log confirmed `Pending scheduled-task retry cancelled via API`. UI-bound cancel path verified.
- [ ] Telegram alert threshold (>1h stuck): not exercised in live smoke (would require either a 1h wait or temporarily lowering the constant). Covered by 10 unit tests in `shouldSendAlert` including strict `>` boundary, clock-skew, non-finite inputs, and the `null -> stamp -> clear -> stamp again` lifecycle.

## Independence from #35

This PR is scoped to the scheduler queue; PR #35 is scoped to the dashboard startup/shutdown lock. They share no modules and can be reviewed or merged in either order. Both were live-tested together on an integration branch that merged them cleanly.

## Known limitations

- The retry cadence is fixed at 60s (the schedule runner's outer interval). Heavy queues would run serially, one tmux capture-pane per row per tick. Not a concern for the expected operator workload (handful of schedules) but worth flagging if the queue ever grows to hundreds.
- Telegram send failure retry has no attempt cap. If a token is permanently revoked, every tick will log a Telegram API error until the operator fixes the token or cancels the row.
- `isSessionReadyForPrompt` (pre-existing, unchanged here) can false-positive when a Claude Code pane is in a transient thinking state. When that happens, the scheduler reports `fired` without actually submitting the prompt and the PR2 retry queue is not activated. Follow-up PR will tighten that regex -- this PR is additive: when the scheduler DOES report busy correctly, the retry is now persistent instead of silently abandoned.
