### PR TITLE
scheduler: tighten pane-state detection so mid-thinking is never seen as ready

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest'
+import { detectPaneState, isReadyForPrompt } from '../pane-state.js'
+
+// Realistic pane fixtures modelled on actual `tmux capture-pane -p`
+// output from shipping Claude Code builds. Whitespace and box-drawing
+// characters (U+2500 ─, U+2771 ❯, U+23F5 ⏵) preserved exactly so the
+// regex matches exercise the same byte sequences they would in prod.
+
+const SEP = '─'.repeat(80)
+
+const IDLE_BYPASS = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+const IDLE_STRICT = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ? for shortcuts',
+].join('\n')
+
+const BUSY_FULL_FOOTER = [
+  '✢ Combobulating… (52s · ↓ 2.6k tokens · thinking some more)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+].join('\n')
+
+// The smoke-test bug scenario: spinner rendered, but the footer is still
+// in its one-frame idle state before `· esc to interrupt` is appended.
+const BUSY_FOOTER_FRAME_GAP = [
+  '✢ Combobulating… (52s · ↓ 2.6k tokens · thinking some more)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Spinner label missing (older/newer Claude Code build). Only the
+// token-count pattern is present. Must still classify as busy.
+const BUSY_TOKENS_ONLY = [
+  '✶ (4s · ↓ 120 tokens)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Tool-use summary lines persist in the scrollback AFTER a turn ends --
+// Claude Code does not overwrite them. Including them as busy signals
+// would classify an otherwise idle agent as busy forever, starving
+// the scheduler. This fixture models the post-turn idle state: the tool
+// summary is on screen but no spinner, no tokens, no esc-to-interrupt.
+const IDLE_AFTER_TOOL_USE = [
+  '  Searched for 3 patterns, listed 4 directories (ctrl+o to expand)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Real busy-with-tool-use: spinner line present alongside the tool summary.
+const BUSY_TOOL_USE_ACTIVE = [
+  '  Searched for 3 patterns, listed 4 directories (ctrl+o to expand)',
+  '✢ Combobulating… (12s · ↓ 480 tokens)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+].join('\n')
+
+const TYPING_PARKED = [
+  '',
+  SEP,
+  '❯ Valami amit a felhasznalo elkezdett geppelni, meg nem kuldte el',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+const PENDING_PASTE = [
+  '',
+  SEP,
+  '❯ [Pasted text #1 +234 chars]',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Historical ❯ above the separators (scrollback). Must NOT count as
+// parked input -- the input box is strictly the region between the two
+// most recent separators.
+const IDLE_WITH_SCROLLBACK_CARET = [
+  '  ❯ some old echoed command from scrollback',
+  '  output of that command',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A pane that is not Claude Code at all (regular shell).
+const NON_CLAUDE = [
+  'zino@marveen ~ $ ls',
+  'README.md  src/  test/',
+].join('\n')
+
+describe('detectPaneState', () => {
+  it('returns unknown for empty input', () => {
+    expect(detectPaneState('')).toBe('unknown')
+    expect(detectPaneState('   \n\n  ')).toBe('unknown')
+  })
+
+  it('detects idle on bypass-mode footer with empty input box', () => {
+    expect(detectPaneState(IDLE_BYPASS)).toBe('idle')
+  })
+
+  it('detects idle on strict-mode footer ("? for shortcuts")', () => {
+    expect(detectPaneState(IDLE_STRICT)).toBe('idle')
+  })
+
+  it('detects busy when "esc to interrupt" footer marker is present', () => {
+    expect(detectPaneState(BUSY_FULL_FOOTER)).toBe('busy')
+  })
+
+  it('detects busy even when the footer frame-gap hides "esc to interrupt"', () => {
+    // Regression for the smoke-test-11-10 bug: spinner + tokens visible,
+    // footer still shows plain idle. Old single-regex detector said idle
+    // (false positive). New detector catches via BUSY_INDICATORS.
+    expect(detectPaneState(BUSY_FOOTER_FRAME_GAP)).toBe('busy')
+  })
+
+  it('detects busy from the token-count pattern alone (unknown spinner label)', () => {
+    // A Claude Code release could rename "Combobulating" to anything. The
+    // (Ns · ↓N tokens) pattern is the load-bearing fallback.
+    expect(detectPaneState(BUSY_TOKENS_ONLY)).toBe('busy')
+  })
+
+  it('detects busy when a tool-use summary is paired with a live spinner', () => {
+    expect(detectPaneState(BUSY_TOOL_USE_ACTIVE)).toBe('busy')
+  })
+
+  it('does NOT classify idle-with-stale-tool-use-scrollback as busy', () => {
+    // Tool-use summary lines survive into the scrollback after the turn
+    // ends. Classifying them as busy would starve the scheduler after
+    // any agent's tool call. Only active-turn signals (spinner, tokens,
+    // esc-to-interrupt, footer-scoped) count.
+    expect(detectPaneState(IDLE_AFTER_TOOL_USE)).toBe('idle')
+  })
+
+  it('detects typing when text is parked in the input box', () => {
+    expect(detectPaneState(TYPING_PARKED)).toBe('typing')
+  })
+
+  it('merges typing into busy when mergeTypingAsBusy is set', () => {
+    expect(detectPaneState(TYPING_PARKED, { mergeTypingAsBusy: true })).toBe('busy')
+  })
+
+  it('treats a pending-paste placeholder as busy', () => {
+    expect(detectPaneState(PENDING_PASTE)).toBe('busy')
+  })
+
+  it('does NOT confuse a historical ❯ in scrollback for a parked input', () => {
+    expect(detectPaneState(IDLE_WITH_SCROLLBACK_CARET)).toBe('idle')
+  })
+
+  it('returns unknown for a pane that is not a Claude Code surface', () => {
+    expect(detectPaneState(NON_CLAUDE)).toBe('unknown')
+  })
+
+  it.each([
+    'Pondering…',
+    'Beaming…',
+    'Thinking…',
+    'Reticulating…',
+    'Configuring…',
+    'Noodling…',
+    'Ruminating…',
+    'Percolating…',
+    'Cogitating…',
+    'Deliberating…',
+    'Contemplating…',
+    'Musing…',
+    'Brewing…',
+    'Synthesizing…',
+    'Distilling…',
+    'Refining…',
+    'Simmering…',
+    'Crafting…',
+    'Formulating…',
+    'Consulting…',
+    'Unfurling…',
+    'Unspooling…',
+    'Unraveling…',
+  ])('matches a busy spinner label paired with the runtime tail: %s', (label) => {
+    // The label regex requires the `(Ns · ↓` tail on the same line so
+    // prose like a Markdown heading `# Thinking…` does not false-positive.
+    const snap = [
+      `✢ ${label} (3s · ↓ 42 tokens)`,
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectPaneState(snap)).toBe('busy')
+  })
+
+  it('does NOT classify a bare spinner-label word as busy (Markdown heading in reply text)', () => {
+    // Regression: spinner labels followed by U+2026 ellipsis must not
+    // false-positive on prose that happens to contain the word.
+    // Without the `(Ns · ↓` tail requirement, any of these would stall
+    // the scheduler forever once they landed in scrollback.
+    const snaps = [
+      '# Thinking…',
+      'Step 1: Crafting… the plan',
+      'Beaming… a message through the router',
+    ]
+    for (const prose of snaps) {
+      const snap = [
+        prose,
+        SEP,
+        '❯ ',
+        SEP,
+        '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+      ].join('\n')
+      expect(detectPaneState(snap)).toBe('idle')
+    }
+  })
+
+  it('busy indicator wins over a visible idle footer', () => {
+    // Both signals present: spinner says busy, footer says idle. Caller
+    // must trust busy (it's a superset constraint).
+    const snap = [
+      '✢ Combobulating… (7s · ↓ 80 tokens)',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectPaneState(snap)).toBe('busy')
+  })
+
+  it('does not match the token-count pattern in unrelated numeric text', () => {
+    const snap = [
+      'Some unrelated log line: latency 5s, count 42',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectPaneState(snap)).toBe('idle')
+  })
+
+  it('handles pane without any separators gracefully', () => {
+    const snap = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+    // Footer alone (no box) -> treat as idle. No parked input to detect.
+    expect(detectPaneState(snap)).toBe('idle')
+  })
+
+  it('handles footer with missing bottom separator', () => {
+    // Defensive: only one separator visible -- no input box detection,
+    // but footer + no busy indicators still means idle.
+    const snap = [
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectPaneState(snap)).toBe('idle')
+  })
+})
+
+describe('isReadyForPrompt', () => {
+  it('is true only when state === idle', () => {
+    expect(isReadyForPrompt(IDLE_BYPASS)).toBe(true)
+    expect(isReadyForPrompt(IDLE_STRICT)).toBe(true)
+    expect(isReadyForPrompt(BUSY_FULL_FOOTER)).toBe(false)
+    expect(isReadyForPrompt(BUSY_FOOTER_FRAME_GAP)).toBe(false)
+    expect(isReadyForPrompt(TYPING_PARKED)).toBe(false)
+    expect(isReadyForPrompt(PENDING_PASTE)).toBe(false)
+    expect(isReadyForPrompt(NON_CLAUDE)).toBe(false)
+    expect(isReadyForPrompt('')).toBe(false)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1,0 +1,150 @@
+// Pure-logic detector for a tmux pane running Claude Code.
+//
+// Motivation: the scheduler used a single regex (`/esc to interrupt/`) to
+// decide whether a target session could accept a new prompt. Between a
+// user turn's submission and the spinner's first render there is a frame-
+// scale window where the footer shows only `⏵⏵ bypass permissions on
+// (shift+tab to cycle)` WITHOUT the `· esc to interrupt` suffix. A
+// scheduler tick landing in that window mis-detected "ready", called
+// sendPromptToSession, and the prompt sat in the input buffer until the
+// post-send retry gave up. The new detector:
+//
+//   - Recognises a wider range of positive busy indicators (spinner
+//     glyph labels + token-count pattern + tool-use mid-turn lines)
+//     so the frame-level footer gap no longer yields a false positive.
+//   - Returns a discrete state so the caller can distinguish idle /
+//     busy / typing / unknown and react per state.
+//
+// The module has ZERO imports so it is trivially unit-testable against
+// captured pane fixtures. The I/O (capture-pane + double-sample) lives
+// in src/web.ts alongside the rest of the scheduler.
+
+export type PaneState = 'idle' | 'busy' | 'typing' | 'unknown'
+
+// Claude Code shows the footer in one of two modes: the default "bypass"
+// permissions mode (permissive) and the "strict" mode. Both are "idle"
+// surfaces. If neither is visible the pane is not a recognised Claude
+// Code surface and we report 'unknown' rather than guess.
+const IDLE_FOOTER_RX = /bypass permissions on \(shift\+tab to cycle\)|\? for shortcuts/
+
+// Positive busy signals. ANY match anywhere in the pane means the turn
+// is mid-flight, even if the footer looks idle for a frame.
+//
+// Deliberately narrow: only signals that disappear THE MOMENT a turn
+// ends. Two failure modes we explicitly avoid:
+//
+//   (A) Scrollback persistence. Tool-use summary lines (`Searched for /
+//       Listed / Read`) stay rendered above the input box after the
+//       turn ends, and Claude Code never overwrites them. A regex
+//       matching those would starve the scheduler forever.
+//
+//   (B) Prose false positive. The standalone word "Thinking…" or
+//       "Crafting…" could legitimately appear in Claude's reply text
+//       (Markdown headings, list items, quoted content). Matching the
+//       label alone would read that prose as mid-turn. To avoid this
+//       we require the label to be followed by the parenthesised
+//       runtime marker `(Ns · ↓` -- an UI chrome signature that
+//       cannot appear in reply text.
+//
+// The load-bearing signal is the tokens-down-arrow pattern `(Ns · ↓N`,
+// which every extended-thinking turn renders regardless of spinner
+// label. `esc to interrupt` is the footer-scoped fallback. A future
+// Claude Code release that renames the spinner labels will miss the
+// label regex but still be caught by the tokens pattern.
+const BUSY_INDICATORS: RegExp[] = [
+  /\besc to interrupt\b/,
+  // Tokens-down-arrow counter: "(52s · ↓ 2.6k tokens ..." Turn-scoped,
+  // overwritten with whitespace the moment the turn completes.
+  /\(\s*\d+s\s*·\s*↓\s*\d/,
+  // Known spinner labels paired with the turn-scoped `(Ns · ↓` tail on
+  // the same line. The tail requirement kills the "Thinking…" prose
+  // false positive. Non-exhaustive by design; the bare tokens pattern
+  // above is the authoritative fallback.
+  /\b(?:Combobulating|Beaming|Thinking|Pondering|Reticulating|Configuring|Noodling|Ruminating|Percolating|Cogitating|Deliberating|Contemplating|Musing|Brewing|Synthesizing|Distilling|Refining|Simmering|Crafting|Formulating|Consulting|Unfurling|Unspooling|Unraveling)…\s*\(\s*\d+s\s*·\s*↓/,
+]
+
+// Pasted-text placeholder. Claude Code lifts bursts of input keys into
+// `[Pasted text #N +X chars]` stubs, which sit in the input buffer and
+// never auto-submit on Enter. Treat as busy so the scheduler doesn't pile
+// a second prompt on top.
+const PENDING_PASTE_RX = /\[Pasted text #\d+/
+
+// Input-box separator lines are made of U+2500 BOX DRAWINGS LIGHT
+// HORIZONTAL. At least 10 in a run to ignore stray `-` glyphs.
+const BOX_SEP_RX = /^─{10,}/
+
+// Prompt line inside the input box. `❯` followed by at least one tab/
+// space and then a non-whitespace character means the user (or a
+// send-keys that didn't submit) parked text there. Single-line match
+// ([ \t] not \s) to avoid crossing into the next line.
+const PARKED_INPUT_RX = /❯[ \t]+\S/
+
+export interface DetectPaneStateOptions {
+  /** If true, the 'typing' state (text parked in input box) is
+   * merged into 'busy'. Default false -- callers that care about
+   * "user actively composing" vs "mid-turn" can distinguish. */
+  mergeTypingAsBusy?: boolean
+}
+
+/**
+ * Classify a raw `tmux capture-pane -p` string into a pane state.
+ *
+ * Algorithm, in order:
+ *   1. Empty / whitespace-only -> 'unknown'.
+ *   2. Any BUSY_INDICATOR matches anywhere -> 'busy'. This includes the
+ *      wider spinner/token-count fallbacks that catch the frame-level
+ *      footer gap.
+ *   3. No idle footer visible -> 'unknown' (pane is not Claude Code).
+ *   4. Pending paste placeholder -> 'busy'.
+ *   5. Text parked inside the bottom input box -> 'typing'.
+ *   6. Otherwise -> 'idle'.
+ */
+export function detectPaneState(
+  pane: string,
+  opts: DetectPaneStateOptions = {},
+): PaneState {
+  if (!pane || !pane.trim()) return 'unknown'
+
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(pane)) return 'busy'
+  }
+
+  if (!IDLE_FOOTER_RX.test(pane)) return 'unknown'
+
+  if (PENDING_PASTE_RX.test(pane)) return 'busy'
+
+  // Find the input box: two BOX_SEP_RX lines framing the current prompt.
+  // Scan UPWARDS from the footer so we stay inside the live box and
+  // don't pick up historical ❯ lines from scrollback.
+  const lines = pane.split('\n')
+  const footerIdx = lines.findIndex(l => IDLE_FOOTER_RX.test(l))
+  if (footerIdx >= 0) {
+    let bottomSep = -1
+    for (let i = footerIdx - 1; i >= 0; i--) {
+      if (BOX_SEP_RX.test(lines[i])) { bottomSep = i; break }
+    }
+    let topSep = -1
+    if (bottomSep > 0) {
+      for (let i = bottomSep - 1; i >= 0; i--) {
+        if (BOX_SEP_RX.test(lines[i])) { topSep = i; break }
+      }
+    }
+    if (topSep >= 0 && bottomSep > topSep) {
+      const inputLines = lines.slice(topSep + 1, bottomSep)
+      if (inputLines.some(l => PARKED_INPUT_RX.test(l))) {
+        return opts.mergeTypingAsBusy ? 'busy' : 'typing'
+      }
+    }
+  }
+
+  return 'idle'
+}
+
+/**
+ * True when the pane is in the specific "accepting a new prompt" state.
+ * 'typing' counts as not-ready because the user has unsubmitted text
+ * in the input box and a new prompt would concatenate into it.
+ */
+export function isReadyForPrompt(pane: string): boolean {
+  return detectPaneState(pane) === 'idle'
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -33,6 +33,7 @@ import {
   sanitizeAgentIdent,
 } from './prompt-safety.js'
 import { isTrustedPeer } from './team-trust.js'
+import { detectPaneState } from './pane-state.js'
 
 function computeNextRun(cronExpression: string): number {
   const expr = CronExpressionParser.parse(cronExpression)
@@ -1731,54 +1732,50 @@ function sendPromptToSession(session: string, text: string): void {
   execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
 }
 
-// Idle footer pattern. Two variants exist: the permissive (bypass) mode agent
-// shows "bypass permissions on (shift+tab to cycle)"; a strict-profile agent
-// shows "? for shortcuts". Both must match, otherwise strict-profile agents
-// are invisible to the router and the scheduler.
-const IDLE_FOOTER_RX = /bypass permissions on \(shift\+tab to cycle\)|\? for shortcuts/
+// How long to wait between the two capture samples when the first one
+// looks idle. The Claude Code UI renders the "idle footer without `esc
+// to interrupt`" line for ~1 frame after a turn submits before the
+// spinner lands; a quarter-second settle window is well past that.
+const PANE_READY_CONFIRM_DELAY_S = '0.25'
+
+// Capture a pane snapshot with an execSync timeout. Null on any error so
+// the caller can treat "capture failed" as "not ready".
+function capturePane(session: string): string | null {
+  try {
+    return execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
+  } catch {
+    return null
+  }
+}
 
 // Check if a Claude Code tmux session is ready to accept a new prompt.
-// During Anthropic API outages or long-running tasks, scheduled prompts can pile up
-// in the input buffer because send-keys appends but Enter never submits.
+//
+// The detection has two layers, both needed to close the frame-level
+// false-positive that let PR1+PR2's smoke test fire a prompt into a pane
+// that was actually mid-thinking:
+//
+//   1. detectPaneState() looks for a set of turn-scoped busy signals
+//      (spinner glyph labels paired with the runtime tail, token-count
+//      pattern, and the footer's `esc to interrupt` marker) so even the
+//      single frame where the footer lacks `· esc to interrupt` is
+//      classified busy by the spinner that is already rendered above
+//      the input box.
+//
+//   2. Double-sample confirmation: if the first capture looks idle, we
+//      sleep 250ms and re-capture. Only agreement from both samples
+//      returns true. Cost on the ready path: ~250ms sleep plus a second
+//      tmux capture-pane round-trip (typically tens of ms). Busy pass
+//      through layer 1 and return immediately without the delay.
 function isSessionReadyForPrompt(session: string): boolean {
-  try {
-    const pane = execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
-    const hasIdleFooter = IDLE_FOOTER_RX.test(pane)
-    const hasPendingPaste = /\[Pasted text #\d+/.test(pane)
-    // "esc to interrupt" is Claude Code's mid-turn marker in both bypass and
-    // strict permission modes. If it's on-screen, the agent is busy even if
-    // the footer is also visible (some intermediate renders show both).
-    const isBusy = /esc to interrupt/.test(pane)
-    if (!hasIdleFooter || hasPendingPaste || isBusy) return false
+  const first = capturePane(session)
+  if (first == null) return false
+  if (detectPaneState(first) !== 'idle') return false
 
-    // Guard against text already parked in the input buffer. Only scan INSIDE
-    // the current input box, which is framed by two ──── separator lines
-    // (U+2500 BOX DRAWINGS LIGHT HORIZONTAL, 10+ in a run). The previous
-    // implementation scanned the 20 lines above the footer, which also
-    // matched historical ❯ lines left in scrollback (e.g. from wrapUntrusted
-    // output) -- making every session look busy after the first inter-agent
-    // message. Also: `\s+\S` with the scrollback slice joined by \n would
-    // straddle newlines and match `❯ \n───`, marking every idle session busy.
-    const lines = pane.split('\n')
-    const footerIdx = lines.findIndex(l => IDLE_FOOTER_RX.test(l))
-    const SEP_RX = /^─{10,}/
-    let bottomSep = -1
-    for (let i = footerIdx - 1; i >= 0; i--) {
-      if (SEP_RX.test(lines[i])) { bottomSep = i; break }
-    }
-    let topSep = -1
-    for (let i = bottomSep - 1; i >= 0; i--) {
-      if (SEP_RX.test(lines[i])) { topSep = i; break }
-    }
-    if (topSep >= 0 && bottomSep > topSep) {
-      const inputLines = lines.slice(topSep + 1, bottomSep)
-      // [ \t] not \s so the check stays on one line.
-      if (inputLines.some(l => /❯[ \t]+\S/.test(l))) return false
-    }
-    return true
-  } catch {
-    return false
-  }
+  try { execFileSync('/bin/sleep', [PANE_READY_CONFIRM_DELAY_S], { timeout: 2000 }) } catch { /* best effort */ }
+
+  const second = capturePane(session)
+  if (second == null) return false
+  return detectPaneState(second) === 'idle'
 }
 
 // --- Update checker ---


### PR DESCRIPTION
## Why this matters

Live smoke testing of the PR #35 (zombie-proof startup lock) and #36 (persistent busy-retry queue) pair revealed a third failure mode in the same incident class that the operator triaged as Bug 3. The scheduler's `isSessionReadyForPrompt` relied on a single regex, `/esc to interrupt/`, to decide whether a target Claude Code tmux session could accept a new scheduled prompt. Between a user turn's submission and the spinner's first render there is a ~1-frame window where the footer shows plain `⏵⏵ bypass permissions on (shift+tab to cycle)` WITHOUT the `· esc to interrupt` suffix. A scheduler tick landing in that window mis-detected "ready", called `sendPromptToSession`, and the prompt sat in the input buffer until the post-send retry gave up after 5 Enter attempts. Reproduced cleanly in the PR #35+#36 live smoke log:

```
[11:10:40.583] INFO: Scheduled task fired task: smoke-test-11-10 agent: <main>
[11:10:57.723] WARN: Scheduled prompt still stuck after 5 Enter retries -- giving up
```

PR #36's persistent retry queue only activates on the `busy` path. When the frame-gap classified the pane as ready, the task flowed through the `fired` path and was lost -- exactly the silent-schedule failure the operator called out, just triggered by a different race than the zombie-dashboard one PR #35 fixed.

This PR closes that gap so PR #35 + #36 + this one, together, fully resolve the Bug 1 + Bug 2 + Bug 3 class.

## Change

**New module `src/pane-state.ts` (pure logic, zero imports).** Single entry point `detectPaneState(pane: string)` classifies a raw `tmux capture-pane -p` string into `'idle' | 'busy' | 'typing' | 'unknown'`. Plus `isReadyForPrompt(pane)` = `detectPaneState(pane) === 'idle'`.

Busy indicators are deliberately narrow and **lifetime-scoped**, so they disappear the moment a turn ends and do NOT starve the scheduler from stale scrollback content:

1. `/\besc to interrupt\b/` -- footer-scoped. Claude Code overwrites the footer the instant the turn completes.
2. `/\(\s*\d+s\s*·\s*↓\s*\d/` -- the tokens-down-arrow runtime counter. Load-bearing active-turn signal; only rendered while the agent is generating.
3. `/\b(?:Combobulating|Beaming|Thinking|...)…\s*\(\s*\d+s\s*·\s*↓/` -- 23 known spinner labels paired with the runtime tail on the same line. The tail requirement kills the Markdown-heading false positive (`# Thinking…` / `Step 1: Crafting…`).

Tool-use summary lines (`Searched for N patterns`, `Listed N directories`, `Read N files`) are explicitly NOT busy indicators: Claude Code leaves them rendered in scrollback after the turn ends, so matching them would classify an otherwise idle agent as busy forever and starve the scheduler -- the exact Bug-3-class silent loss this PR is supposed to eliminate.

**`src/web.ts` refactor.** The old `IDLE_FOOTER_RX` constant and inline regex logic are gone. `isSessionReadyForPrompt(session)` is now:

```ts
1. capturePane(session) -> detectPaneState -> if not 'idle', return false
2. sleep 250ms (PANE_READY_CONFIRM_DELAY_S)
3. capturePane(session) -> detectPaneState -> must also be 'idle'
```

Double-sample confirmation closes the one-frame race: if the first capture lands in the footer-gap window, the 250ms settle has us safely past the spinner's first render on the second sample. Busy paths pass through layer 1 immediately with no delay, so only the ready path pays the ~250ms cost.

**Tests: 42 vitest cases in `src/__tests__/pane-state.test.ts`.**

- Positive: `IDLE_BYPASS`, `IDLE_STRICT` (different footer variants), `IDLE_AFTER_TOOL_USE` (post-turn scrollback, must still be idle), `IDLE_WITH_SCROLLBACK_CARET` (historical ❯ in scrollback must not register as parked input).
- Busy: `BUSY_FULL_FOOTER`, `BUSY_FOOTER_FRAME_GAP` (regression for the smoke-test-11-10 bug), `BUSY_TOKENS_ONLY` (unknown spinner label but tokens tail present), `BUSY_TOOL_USE_ACTIVE` (tool summary + live spinner).
- Typing: `TYPING_PARKED` (text in input box), plus `mergeTypingAsBusy` option.
- Pending paste: `PENDING_PASTE`.
- Non-Claude: `NON_CLAUDE` returns 'unknown'.
- 23-label `it.each` covering Combobulating/Beaming/Thinking/Pondering/Reticulating/Configuring/Noodling/Ruminating/Percolating/Cogitating/Deliberating/Contemplating/Musing/Brewing/Synthesizing/Distilling/Refining/Simmering/Crafting/Formulating/Consulting/Unfurling/Unspooling/Unraveling.
- Negative regression: `does NOT classify a bare spinner-label word as busy (Markdown heading in reply text)` -- covers `# Thinking…`, `Step 1: Crafting… the plan`, `Beaming… a message through the router`.
- Edge cases: empty pane, whitespace-only, single separator, no separators, unrelated numerics (`latency 5s, count 42`).

## Scope / compatibility

- No public API changes. `isSessionReadyForPrompt` keeps the same signature and return contract (false-on-ambiguity). The 3 call sites (`web.ts:1248` agent-message router, `web.ts:1435` marveen plugin reconnect, `web.ts:1914` scheduler) all want the stricter ready semantics.
- Ready-path overhead: ~250ms sleep + a second `tmux capture-pane` round-trip (typically tens of ms). Scheduler runs on a 60s interval, so the added latency is immaterial.
- Busy-path overhead: zero -- the first sample short-circuits before the sleep.

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npx vitest run` -- 120/120 passing (78 prior + 42 new in `pane-state.test.ts`)
- [x] `npm run build` -- clean
- [x] **Live smoke (combined branch with this PR + #35 + #36)**: created cron task `smoke-pr3-busy` with `*/1 * * * *` targeting an agent held in a mid-thinking state. Three consecutive scheduler ticks produced the exact end-to-end behavior this series promises:
  - 11:45:44 tick: `Schedule target session busy or has pending input, will retry` -- PR3 correctly classified the mid-thinking pane as busy. Without this PR, the single-regex detector would have reported ready and the prompt would have been lost.
  - Pending row inserted: `{"id":231,"taskName":"smoke-pr3-busy","agentName":"dev2","attemptCount":1,"lastReason":"busy",...}` -- PR #36's `insertPendingTaskRetryIfNew` handled the first miss.
  - 11:46:44 tick: still busy. Pending row updated to `attemptCount=2, lastAttempt` refreshed -- PR #36's `updatePendingTaskRetry` validated.
  - Agent freed (ESC sent). 11:47:45 tick: `Scheduled task fired`. Pending queue returned to `[]` -- success-path delete validated.
- [ ] Run against a real Anthropic API outage for multi-hour stuck scenarios (can't fabricate in smoke; covered by PR #36's unit tests for the >1h alert threshold).

## Independence and merge order

Standalone -- this PR only touches `src/pane-state.ts` (new), `src/web.ts` (surgical edit of `isSessionReadyForPrompt`), and a test file. Zero conflict with #35 or #36. Any merge order works; the combined branch used for the live smoke above merged all three cleanly.

## Known limitations

- The 23-label spinner list is a snapshot of shipping Claude Code UI. A future Claude Code release that adds a new spinner label will miss the label regex until we update the list, but the tokens-down-arrow fallback (`(Ns · ↓N ...`) catches every extended-thinking turn regardless of label.
- The token-count regex will miss a Claude Code release that changes the runtime counter format. If that happens, the `esc to interrupt` footer marker still catches the busy state; the detector degrades to the old behavior rather than silently ignoring busy.
- Tool-use summary scrollback persistence means a just-idle agent whose last output was a tool call is classified idle (correct), but any same-pane output that coincidentally matches a BUSY_INDICATOR regex (e.g. a literal `(Ns · ↓N` string pasted into an inter-agent message) would classify busy until the scrollback rolls it out. Extremely unlikely in practice.