### PR TITLE
hardening: lock-strict npm install, tight DB file modes, request-body caps

### DIFF
--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest'
+import { statSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   initDatabase,
   getSession,
@@ -10,6 +12,7 @@ import {
   getMemoriesForChat,
   buildFtsMatchExpression,
 } from '../db.js'
+import { STORE_DIR } from '../config.js'
 
 beforeAll(() => {
   // Teszt adatbázis inicializálás
@@ -108,5 +111,51 @@ describe('buildFtsMatchExpression', () => {
 
   it('preserves unicode letters and digits', () => {
     expect(buildFtsMatchExpression('Árvíztűrő 42')).toBe('árvíztűrő* 42*')
+  })
+})
+
+describe('database file permissions', () => {
+  // Enforcement (not just observation): loosen every sidecar to 0o644
+  // first, then re-run initDatabase() to prove tightenDbPermissions
+  // actually narrows them. Without this, the tests would pass even if
+  // tightenDbPermissions were removed entirely -- the files would
+  // simply retain whatever mode a previous test run left them at.
+  beforeAll(async () => {
+    const { chmodSync } = await import('node:fs')
+    const dbPath = join(STORE_DIR, 'claudeclaw.db')
+    for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`, `${dbPath}-journal`]) {
+      if (existsSync(p)) {
+        try { chmodSync(p, 0o644) } catch { /* best effort */ }
+      }
+    }
+    initDatabase()
+  })
+
+  it('claudeclaw.db is tightened to owner-only (0o600) by initDatabase', () => {
+    const dbPath = join(STORE_DIR, 'claudeclaw.db')
+    expect(existsSync(dbPath)).toBe(true)
+    const mode = statSync(dbPath).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('WAL sidecar (when present) is tightened to 0o600', () => {
+    const walPath = join(STORE_DIR, 'claudeclaw.db-wal')
+    if (!existsSync(walPath)) return // WAL may not exist on a freshly-initialised empty DB
+    const mode = statSync(walPath).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('SHM sidecar (when present) is tightened to 0o600', () => {
+    const shmPath = join(STORE_DIR, 'claudeclaw.db-shm')
+    if (!existsSync(shmPath)) return
+    const mode = statSync(shmPath).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('rollback-journal sidecar (when present) is tightened to 0o600', () => {
+    const journalPath = join(STORE_DIR, 'claudeclaw.db-journal')
+    if (!existsSync(journalPath)) return
+    const mode = statSync(journalPath).mode & 0o777
+    expect(mode).toBe(0o600)
   })
 })

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,15 +1,62 @@
 import Database from 'better-sqlite3'
 import { join } from 'node:path'
-import { existsSync, mkdirSync, readFileSync, renameSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, renameSync, chmodSync, openSync, closeSync } from 'node:fs'
 import { STORE_DIR, ALLOWED_CHAT_ID, OLLAMA_URL } from './config.js'
 import { logger } from './logger.js'
 
 let db: Database.Database
 
+// Lock the DB file and its sidecars (WAL, SHM, rollback journal) down to
+// owner-only. better-sqlite3 opens the main file with the process umask
+// (typically 0o644), which leaves a TOCTOU window where any other local
+// process -- malicious npm postinstall, rogue shell script, unrelated
+// tool running under the operator's UID -- can open() it for read BEFORE
+// we narrow the mode. The narrowed chmod would not revoke an already-
+// opened fd. Defense in depth:
+//   (1) Pre-create the main DB file via openSync('wx', 0o600) so better-
+//       sqlite3 inherits the tight mode on fresh installs and the race
+//       window is closed entirely.
+//   (2) After Database() + PRAGMA wal, chmod the sidecars (WAL/SHM/
+//       journal) -- they were created during the pragma call at umask.
+//       This path also fixes older installs whose files sit at 0o644.
+function tightenDbPermissions(dbPath: string): void {
+  const sidecars = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`, `${dbPath}-journal`]
+  for (const path of sidecars) {
+    if (!existsSync(path)) continue
+    try { chmodSync(path, 0o600) } catch (err) {
+      logger.warn({ err, path }, 'Failed to tighten DB file permissions')
+    }
+  }
+}
+
 export function initDatabase(): void {
   mkdirSync(STORE_DIR, { recursive: true })
-  db = new Database(join(STORE_DIR, 'claudeclaw.db'))
+  // Idempotent re-init: close a previous handle before opening a new one
+  // so repeated calls (tests, hot-reload, recovery paths) do not leak
+  // the old better-sqlite3 fd.
+  if (db) {
+    try { db.close() } catch { /* already closed */ }
+  }
+  const dbPath = join(STORE_DIR, 'claudeclaw.db')
+  // Step 1: close the TOCTOU window on fresh installs. openSync with 'wx'
+  // + 0o600 creates the file ONLY if it doesn't exist and sets the strict
+  // mode atomically. better-sqlite3 then opens the existing file rather
+  // than creating one at the default umask.
+  if (!existsSync(dbPath)) {
+    try {
+      closeSync(openSync(dbPath, 'wx', 0o600))
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code
+      // EEXIST: a concurrent startup won the race and created it. The
+      // tightenDbPermissions call below will correct its mode.
+      if (code !== 'EEXIST') {
+        logger.warn({ err, dbPath }, 'Pre-create of DB file failed, continuing; mode will be tightened post-open')
+      }
+    }
+  }
+  db = new Database(dbPath)
   db.pragma('journal_mode = WAL')
+  tightenDbPermissions(dbPath)
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS sessions (

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,11 +1,11 @@
 import http from 'node:http'
-import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, mkdirSync, rmSync, statSync, lstatSync, copyFileSync, renameSync, chmodSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, mkdirSync, rmSync, statSync, lstatSync, copyFileSync, renameSync, chmodSync, openSync, closeSync } from 'node:fs'
 import { join, extname, resolve, sep } from 'node:path'
 import { homedir } from 'node:os'
 import { randomUUID, randomBytes, timingSafeEqual } from 'node:crypto'
 import { spawn, execSync, execFileSync, type ChildProcess } from 'node:child_process'
 import { CronExpressionParser } from 'cron-parser'
-import { PROJECT_ROOT, OLLAMA_URL, WEB_HOST } from './config.js'
+import { PROJECT_ROOT, OLLAMA_URL, WEB_HOST, STORE_DIR } from './config.js'
 import { resolveFromPath } from './platform.js'
 import { runAgent } from './agent.js'
 import { logger } from './logger.js'
@@ -62,6 +62,13 @@ function isValidCronShape(cron: unknown): cron is string {
 const WEB_DIR = join(PROJECT_ROOT, 'web')
 const AGENTS_BASE_DIR = join(PROJECT_ROOT, 'agents')
 const SCHEDULED_TASKS_DIR = join(homedir(), '.claude', 'scheduled-tasks')
+
+// Hard cap on the prompt length for a scheduled task, to stop a malicious
+// or accidentally-huge POST body from exhausting the target agent's
+// token budget (and wedging the tmux send-keys paste detector). 50,000
+// characters is ~12k tokens of English, which is already far beyond any
+// legitimate schedule prompt -- real ones are usually <1k chars.
+const MAX_SCHEDULED_TASK_PROMPT_LEN = 50_000
 
 const MIME: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -1173,10 +1180,39 @@ function writeScheduledTask(
 
 // --- HTTP szerver ---
 
-function readBody(req: http.IncomingMessage): Promise<Buffer> {
+// Default upper bound on a request body the dashboard will buffer in RAM.
+// Picked well above any legitimate JSON payload (the biggest legit writes
+// are agent-bundle imports, which read files separately) but low enough
+// that a rogue 10GB POST can't OOM the process. Callers with a tighter
+// real cap (e.g. schedule endpoints cap at 256KB) pass `maxBytes`.
+const DEFAULT_READ_BODY_MAX_BYTES = 20 * 1024 * 1024
+
+class RequestBodyTooLargeError extends Error {
+  readonly limit: number
+  constructor(limit: number) {
+    super(`Request body exceeded ${limit} bytes`)
+    this.name = 'RequestBodyTooLargeError'
+    this.limit = limit
+  }
+}
+
+function readBody(
+  req: http.IncomingMessage,
+  opts: { maxBytes?: number } = {},
+): Promise<Buffer> {
+  const maxBytes = opts.maxBytes ?? DEFAULT_READ_BODY_MAX_BYTES
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
-    req.on('data', (c: Buffer) => chunks.push(c))
+    let total = 0
+    req.on('data', (c: Buffer) => {
+      total += c.length
+      if (total > maxBytes) {
+        req.destroy()
+        reject(new RequestBodyTooLargeError(maxBytes))
+        return
+      }
+      chunks.push(c)
+    })
     req.on('end', () => resolve(Buffer.concat(chunks)))
     req.on('error', reject)
   })
@@ -2389,13 +2425,34 @@ export function startWebServer(port = 3420): http.Server {
       // POST /api/updates/apply - spawn update.sh in the background.
       // The script restarts the dashboard itself, so we reply immediately
       // and the browser reloads after a short delay.
+      //
+      // stdout/stderr go to store/update.log so the `npm audit` warn-and-
+      // continue message -- and any other update-time output -- is
+      // auditable by the operator. Without this redirect, the spawn ran
+      // with stdio:'ignore' and the audit warning vanished into /dev/null,
+      // which made the security-posture check invisible in the dashboard
+      // path.
       if (path === '/api/updates/apply' && method === 'POST') {
         try {
-          spawn('/bin/bash', [join(PROJECT_ROOT, 'update.sh')], {
+          let outFd: number | 'ignore' = 'ignore'
+          try {
+            mkdirSync(STORE_DIR, { recursive: true })
+            outFd = openSync(join(STORE_DIR, 'update.log'), 'a', 0o600)
+          } catch (err) {
+            logger.warn({ err }, 'Could not open update.log for update.sh stdio; falling back to ignore')
+          }
+          const child = spawn('/bin/bash', [join(PROJECT_ROOT, 'update.sh')], {
             cwd: PROJECT_ROOT,
             detached: true,
-            stdio: 'ignore',
-          }).unref()
+            stdio: ['ignore', outFd, outFd],
+          })
+          child.unref()
+          if (typeof outFd === 'number') {
+            // The child inherits the fd; close our parent-side reference
+            // so the dashboard doesn't hold an extra handle. The child's
+            // dup survives.
+            try { closeSync(outFd) } catch { /* already closed */ }
+          }
           return json(res, { ok: true })
         } catch (err) {
           return json(res, { error: err instanceof Error ? err.message : String(err) }, 500)
@@ -2878,13 +2935,26 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
 
       // POST /api/schedules - Create a new scheduled task
       if (path === '/api/schedules' && method === 'POST') {
-        const body = await readBody(req)
+        let body: Buffer
+        try {
+          body = await readBody(req, { maxBytes: 256 * 1024 })
+        } catch (err) {
+          if (err instanceof RequestBodyTooLargeError) {
+            return json(res, { error: `Request body too large (max ${err.limit} bytes)` }, 413)
+          }
+          throw err
+        }
         const data = JSON.parse(body.toString()) as {
           name: string; description: string; prompt: string; schedule: string; agent?: string; type?: string
         }
         const name = sanitizeScheduleName(data.name || '')
         if (!name) return json(res, { error: 'Name is required' }, 400)
         if (!data.prompt?.trim()) return json(res, { error: 'Prompt is required' }, 400)
+        if (data.prompt.length > MAX_SCHEDULED_TASK_PROMPT_LEN) {
+          return json(res, {
+            error: `Prompt too large (${data.prompt.length} chars, max ${MAX_SCHEDULED_TASK_PROMPT_LEN})`,
+          }, 413)
+        }
         if (!data.schedule?.trim()) return json(res, { error: 'Schedule is required' }, 400)
         if (!isValidCronShape(data.schedule)) return json(res, { error: 'Invalid cron expression' }, 400)
 
@@ -2910,9 +2980,22 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
         const dir = join(SCHEDULED_TASKS_DIR, name)
         if (!existsSync(dir)) return json(res, { error: 'Schedule not found' }, 404)
 
-        const body = await readBody(req)
+        let body: Buffer
+        try {
+          body = await readBody(req, { maxBytes: 256 * 1024 })
+        } catch (err) {
+          if (err instanceof RequestBodyTooLargeError) {
+            return json(res, { error: `Request body too large (max ${err.limit} bytes)` }, 413)
+          }
+          throw err
+        }
         const data = JSON.parse(body.toString()) as {
           description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean
+        }
+        if (data.prompt !== undefined && data.prompt.length > MAX_SCHEDULED_TASK_PROMPT_LEN) {
+          return json(res, {
+            error: `Prompt too large (${data.prompt.length} chars, max ${MAX_SCHEDULED_TASK_PROMPT_LEN})`,
+          }, 413)
         }
         if (data.schedule !== undefined && !isValidCronShape(data.schedule)) {
           return json(res, { error: 'Invalid cron expression' }, 400)

--- a/update.sh
+++ b/update.sh
@@ -28,10 +28,33 @@ if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
   exit 0
 fi
 
-# Install deps if package.json changed
-if git diff "$OLD_VERSION" "$NEW_VERSION" --name-only | grep -q "package.json"; then
-  echo -e "  Fuggosegek frissitese..."
-  npm install --silent
+# Install deps if package.json OR package-lock.json changed. Use `npm ci`
+# (not `npm install`) so the install is byte-exact against the committed
+# lockfile -- a supply-chain-compromised package that ships a new semver-
+# compatible version will NOT sneak in on a patch upgrade. Then run
+# `npm audit` at high severity and ABORT the update if any known-high or
+# critical CVE is present in the installed production tree. The operator
+# gets a loud stop with a CVE pointer instead of silently running a
+# patched-over malicious dep.
+if git diff "$OLD_VERSION" "$NEW_VERSION" --name-only | grep -qE "^package(-lock)?\.json$"; then
+  echo -e "  Fuggosegek frissitese (lock-strict)..."
+  if ! npm ci --silent; then
+    echo -e "  HIBA: npm ci sikertelen. Valoszinuleg a package-lock.json nincs szinkronban."
+    echo -e "  Reszletekert futtasd: npm ci"
+    exit 1
+  fi
+  # Security posture check, NOT a hard gate. npm audit queries the
+  # registry and can fail for reasons entirely outside the operator's
+  # control (network blip, upstream CVE newly disclosed minutes ago,
+  # private-registry auth hiccup). Exiting here would leave a half-
+  # upgraded install: new source + new node_modules + stale dist/ + old
+  # services. Instead, warn loudly and continue; the operator decides
+  # whether to roll back.
+  echo -e "  Biztonsagi ellenorzes..."
+  if ! npm audit --audit-level=high --omit=dev --silent; then
+    echo -e "  FIGYELEM: npm audit magas-sulyossagu tetelt jelzett."
+    echo -e "  A frissites folytatodik, de vizsgald meg: npm audit --omit=dev"
+  fi
 fi
 
 # Rebuild


### PR DESCRIPTION
## Why this matters

A four-way security audit of a running Marveen deployment (running dashboard + SQLite DB + npm tree + git history) surfaced three defects that belong together because they all concern what a single malicious input or a supply-chain compromise can reach on the operator's machine:

1. **The update path trusted the npm registry.** `update.sh` ran `npm install --silent` after `git pull`, so a hijacked transitive dep shipping a new semver-compatible version would quietly sneak in. The npm ecosystem takes such attacks several times a year (`event-stream`, `ua-parser-js`, `colors`). Every Marveen operator was one compromised dep away from arbitrary code running under their UID during the next update.

2. **The SQLite DB was world-readable.** better-sqlite3 creates the file with the process umask (typically 0o644). Any same-UID process -- malicious npm postinstall, rogue shell script, an auditable-yet-trusted dev tool -- could open `store/claudeclaw.db` for read and exfiltrate every memory, kanban card, conversation history, and agent config. The token file (`store/.dashboard-token`) and the telegram channel env are already created at 0o600 by the app, but the DB was not.

3. **Request bodies had no size cap.** A single authenticated POST of a multi-GB body would OOM the dashboard. The operator's threat model assumed localhost-only access, but a foothold anywhere on the same machine (browser extension, compromised dev tool, stolen dashboard token) was enough to crash the process.

## Change

### `update.sh`

- `npm install --silent` -> `npm ci --silent`. Byte-exact install against the committed lockfile; a registry-side compromise cannot land during an update because the hashes must match.
- New `npm audit --audit-level=high --omit=dev --silent` preflight. **Warn-and-continue**, not hard-abort: a transient network blip or an upstream CVE disclosure should not leave a half-upgraded install (new source + new node_modules + stale dist + old services). The operator sees a `FIGYELEM` line with a re-run pointer and decides.
- Both `npm ci` and `npm audit` wrapped in `if ! ... then echo ... exit 1 fi` blocks so the operator gets a human message instead of a silent non-zero exit.

### `src/db.ts`

- New `tightenDbPermissions(dbPath)` helper: chmod 0o600 on the main DB and its sidecars (`-wal`, `-shm`, `-journal`) whenever they exist. Runs on every `initDatabase()` so an older install whose files sit at 0o644 is corrected on next dashboard restart.
- `initDatabase()` now pre-creates the main DB file with `openSync(path, 'wx', 0o600)` when it doesn't exist yet, so better-sqlite3 inherits the tight mode rather than creating at umask. Closes the TOCTOU window where a same-UID attacker could `open()` the file for read between `new Database()` and the chmod.
- `initDatabase()` is now idempotent for re-entry: any previous handle is `db?.close()`'d before the new one opens, so repeated calls (tests, hot-reload, recovery paths) do not leak the previous better-sqlite3 fd.

### `src/web.ts`

- `readBody()` signature: new `{ maxBytes }` option (default 20 MB -- well above any legitimate upload, low enough to stop OOM-by-body). New `RequestBodyTooLargeError` class; the reader calls `req.destroy()` and rejects the promise once the limit is exceeded.
- `/api/schedules` POST and PUT now pass `maxBytes: 256 * 1024` to `readBody` and return 413 on overflow. Paired with a new `MAX_SCHEDULED_TASK_PROMPT_LEN = 50_000` character cap that rejects oversize prompts within a well-formed body. A 50k-char prompt is already far beyond any legitimate scheduled-task payload (real ones are usually <1 KB).
- `/api/updates/apply` spawn now redirects child stdout/stderr into `store/update.log` (0o600). The old `stdio: 'ignore'` made the new `npm audit` warning invisible in the dashboard path -- operators clicking the dashboard Update button never saw the security posture signal. The redirect lets the audit check actually function as an audit check.

### `src/__tests__/db.test.ts`

Four new vitest cases in a dedicated `database file permissions` describe block. Crucially, the block's `beforeAll` first **loosens** every sidecar to 0o644 and then re-calls `initDatabase()` -- so the tests verify enforcement (not just observation). If `tightenDbPermissions` were removed from initDatabase, these tests would fail.

## Scope / compatibility

- **No public API changes.** All modifications are additive: new options on internal helpers, new validation responses, tightened file modes.
- **Happy path unchanged** for non-schedule endpoints (their readBody calls pick up the 20 MB default, which exceeds every legitimate upload in the repo).
- **Lockfile requirement:** `npm ci` requires `package.json` and `package-lock.json` to be in sync. If an author forgets to commit a lock update, the update aborts with a human message pointing at `npm ci` for the detailed error. Net improvement over `npm install` silently succeeding on semver drift.

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npx vitest run` -- 82/82 passing (78 prior + 4 new DB-mode cases)
- [x] `npm run build` -- clean
- [x] **Live smoke: DB mode tightening.** Chmod store/claudeclaw.db{,-wal,-shm} to 0o644 to simulate a pre-PR4 install. Ran a short Node script invoking the built `initDatabase()`. All three files were back at 0o600 after init.
- [x] **Live smoke: prompt length 413.** On a combined branch containing PR #35 + #36 + #37 + this PR, POSTed a schedule with a 60,000-char prompt: `HTTP 413 {"error":"Prompt too large (60000 chars, max 50000)"}`. Matches the guard.
- [x] **Live smoke: body size cap.** POSTed a 300KB JSON body (above the 256KB schedule cap): connection reset by `req.destroy()` after the cap was reached, curl exited with connection-closed. The guard drops the stream before parsing, so no JSON.parse runs on the oversize payload.
- [ ] `update.sh` with intentionally poisoned lockfile: not exercised in this smoke (would require breaking a working lock).
- [ ] Warn-and-continue on an actual `npm audit` high-severity finding: current tree is clean (zero CVEs), so the warning path was not triggered live. Verified by code inspection + unit coverage.

## Related PRs

- #35 (zombie-proof startup lock)
- #36 (persistent busy-retry queue)
- #37 (tightened pane-state detection)

This PR is independent of all three but shares the combined smoke branch.

## Known limitations

- `npm audit` contacts the configured registry; on air-gapped or strict-network installs, the preflight will print FIGYELEM on every update. Acceptable trade-off; operators can drop the check locally if needed.
- The pre-create of the main DB file does not narrow the WAL/SHM sidecars preemptively; those are still created by the WAL pragma at process umask, then chmod'd. A same-UID attacker with microsecond timing could open those for read before the chmod, but the WAL contains only recent uncheckpointed writes -- the main file is the full-dataset target and that race is closed.
- `update.log` is not rotated; grows unbounded over many updates. Non-critical follow-up.