### PR TITLE
refactor(web): move MIME table to http-helpers where it belongs

### DIFF
--- a/src/web/atomic-write.ts
+++ b/src/web/atomic-write.ts
@@ -17,15 +17,3 @@ export function atomicWriteFileSync(
   }
   renameSync(tmp, path)
 }
-
-export const MIME: Record<string, string> = {
-  '.html': 'text/html; charset=utf-8',
-  '.css': 'text/css; charset=utf-8',
-  '.js': 'application/javascript; charset=utf-8',
-  '.json': 'application/json; charset=utf-8',
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.webp': 'image/webp',
-  '.svg': 'image/svg+xml',
-}

--- a/src/web/http-helpers.ts
+++ b/src/web/http-helpers.ts
@@ -1,7 +1,18 @@
 import http from 'node:http'
 import { readFileSync } from 'node:fs'
 import { extname } from 'node:path'
-import { MIME } from './atomic-write.js'
+
+export const MIME: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+}
 
 // Default upper bound on a request body the dashboard will buffer in RAM.
 // Picked well above any legitimate JSON payload (the biggest legit writes


### PR DESCRIPTION
## Summary
- Move the `MIME` extension→content-type lookup out of `atomic-write.ts` (where it had no business living) and into `http-helpers.ts`, the only file that uses it.
- Drop the resulting cross-module import.
- Follow-up to #39 — flagged during review as a non-blocking smell.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 292/292 passing
- [x] No behavior change; only a constant moved one file over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)