### PR TITLE
refactor(web): extract update checker

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -72,6 +72,12 @@ import {
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './web/main-agent.js'
 import { startMessageRouter } from './web/message-router.js'
 import {
+  getUpdateStatus,
+  refreshUpdateStatus,
+  startUpdateChecker,
+  type UpdateStatus,
+} from './web/update-checker.js'
+import {
   SCHEDULED_TASKS_DIR,
   MAX_SCHEDULED_TASK_PROMPT_LEN,
   parseSkillMdFrontmatter,
@@ -611,128 +617,11 @@ function countUserTurns(fromMs: number, toMs: number = Number.POSITIVE_INFINITY)
   return total
 }
 
-// --- Update checker ---
-// Polls the GitHub repo's main branch for new commits and compares to the
-// local HEAD. Lets the dashboard show a "new version available" badge
-// without anyone having to SSH in and run update.sh.
-
-interface UpdateCommit {
-  sha: string
-  short: string
-  message: string
-  author: string
-  date: string
-}
-
-interface UpdateStatus {
-  current: string
-  latest: string
-  behind: number
-  commits: UpdateCommit[]
-  remote: string
-  lastChecked: number
-  error?: string
-}
-
-let updateStatusCache: UpdateStatus = {
-  current: '',
-  latest: '',
-  behind: 0,
-  commits: [],
-  remote: 'Szotasz/marveen',
-  lastChecked: 0,
-}
-
 // Pidfile path owned by update.sh for the lifetime of an update run.
 // The dashboard never writes it -- update.sh does on entry, removes on
 // exit via a trap -- so the gate survives the stop.sh / start.sh
 // dashboard restart that happens inside a successful update.
 const UPDATE_PIDFILE = join(PROJECT_ROOT, 'store', 'update.pid')
-
-function currentGitHead(): string {
-  try {
-    return execFileSync('/usr/bin/git', ['rev-parse', 'HEAD'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
-  } catch {
-    return ''
-  }
-}
-
-function parseGitHubRemote(): string {
-  try {
-    const url = execFileSync('/usr/bin/git', ['config', '--get', 'remote.origin.url'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
-    // Normalize "git@github.com:Owner/Repo.git" or "https://github.com/Owner/Repo.git" to "Owner/Repo"
-    const m = url.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/i)
-    if (m) return m[1]
-  } catch { /* fall through */ }
-  return 'Szotasz/marveen'
-}
-
-async function refreshUpdateStatus(): Promise<UpdateStatus> {
-  const current = currentGitHead()
-  const remote = parseGitHubRemote()
-  const status: UpdateStatus = {
-    current,
-    latest: '',
-    behind: 0,
-    commits: [],
-    remote,
-    lastChecked: Date.now(),
-  }
-  if (!current) {
-    status.error = 'Not a git checkout'
-    updateStatusCache = status
-    return status
-  }
-  try {
-    // 1) find HEAD of default branch (main) via the commits endpoint
-    const latestRes = await fetch(`https://api.github.com/repos/${remote}/commits/main`, {
-      headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'marveen-update-check' },
-    })
-    if (!latestRes.ok) throw new Error(`GitHub /commits/main -> ${latestRes.status}`)
-    const latestJson = await latestRes.json() as { sha?: string }
-    if (!latestJson.sha) throw new Error('No sha on commits/main response')
-    status.latest = latestJson.sha
-
-    if (status.latest === current) {
-      updateStatusCache = status
-      return status
-    }
-
-    // 2) list commits between current and latest via the compare endpoint
-    const cmpRes = await fetch(`https://api.github.com/repos/${remote}/compare/${current}...${status.latest}`, {
-      headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'marveen-update-check' },
-    })
-    if (cmpRes.ok) {
-      const cmp = await cmpRes.json() as {
-        ahead_by?: number
-        commits?: { sha: string; commit: { message: string; author: { name: string; date: string } } }[]
-      }
-      status.behind = cmp.ahead_by ?? 0
-      // GitHub returns commits oldest-first; flip to newest-first for the UI.
-      const raw = (cmp.commits ?? []).slice().reverse()
-      status.commits = raw.map(c => ({
-        sha: c.sha,
-        short: c.sha.slice(0, 7),
-        message: (c.commit.message || '').split('\n')[0],
-        author: c.commit.author?.name || '',
-        date: c.commit.author?.date || '',
-      }))
-    } else if (cmpRes.status === 404) {
-      // Local HEAD not on the remote (detached local commit / different base).
-      status.error = 'Local HEAD not found on GitHub -- different fork or unpushed commits?'
-    }
-  } catch (err) {
-    status.error = err instanceof Error ? err.message : String(err)
-  }
-  updateStatusCache = status
-  return status
-}
-
-function startUpdateChecker(): NodeJS.Timeout {
-  // First check shortly after startup; then every 15 minutes.
-  setTimeout(() => { refreshUpdateStatus().catch(() => {}) }, 10_000)
-  return setInterval(() => { refreshUpdateStatus().catch(() => {}) }, 15 * 60_000)
-}
 
 // === MCP list cache ===========================================================
 //
@@ -1448,7 +1337,7 @@ export function startWebServer(port = 3420): http.Server {
 
       // GET /api/updates - current vs GitHub main, with commit list between
       if (path === '/api/updates' && method === 'GET') {
-        return json(res, updateStatusCache)
+        return json(res, getUpdateStatus())
       }
 
       // POST /api/updates/check - force an immediate refresh

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from 'node:child_process'
+import { PROJECT_ROOT } from '../config.js'
+
+export interface UpdateCommit {
+  sha: string
+  short: string
+  message: string
+  author: string
+  date: string
+}
+
+export interface UpdateStatus {
+  current: string
+  latest: string
+  behind: number
+  commits: UpdateCommit[]
+  remote: string
+  lastChecked: number
+  error?: string
+}
+
+let updateStatusCache: UpdateStatus = {
+  current: '',
+  latest: '',
+  behind: 0,
+  commits: [],
+  remote: 'Szotasz/marveen',
+  lastChecked: 0,
+}
+
+export function getUpdateStatus(): UpdateStatus {
+  return updateStatusCache
+}
+
+export function currentGitHead(): string {
+  try {
+    return execFileSync('/usr/bin/git', ['rev-parse', 'HEAD'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+  } catch {
+    return ''
+  }
+}
+
+export function parseGitHubRemote(): string {
+  try {
+    const url = execFileSync('/usr/bin/git', ['config', '--get', 'remote.origin.url'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+    // Normalize "git@github.com:Owner/Repo.git" or "https://github.com/Owner/Repo.git" to "Owner/Repo"
+    const m = url.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/i)
+    if (m) return m[1]
+  } catch { /* fall through */ }
+  return 'Szotasz/marveen'
+}
+
+export async function refreshUpdateStatus(): Promise<UpdateStatus> {
+  const current = currentGitHead()
+  const remote = parseGitHubRemote()
+  const status: UpdateStatus = {
+    current,
+    latest: '',
+    behind: 0,
+    commits: [],
+    remote,
+    lastChecked: Date.now(),
+  }
+  if (!current) {
+    status.error = 'Not a git checkout'
+    updateStatusCache = status
+    return status
+  }
+  try {
+    // 1) find HEAD of default branch (main) via the commits endpoint
+    const latestRes = await fetch(`https://api.github.com/repos/${remote}/commits/main`, {
+      headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'marveen-update-check' },
+    })
+    if (!latestRes.ok) throw new Error(`GitHub /commits/main -> ${latestRes.status}`)
+    const latestJson = await latestRes.json() as { sha?: string }
+    if (!latestJson.sha) throw new Error('No sha on commits/main response')
+    status.latest = latestJson.sha
+
+    if (status.latest === current) {
+      updateStatusCache = status
+      return status
+    }
+
+    // 2) list commits between current and latest via the compare endpoint
+    const cmpRes = await fetch(`https://api.github.com/repos/${remote}/compare/${current}...${status.latest}`, {
+      headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'marveen-update-check' },
+    })
+    if (cmpRes.ok) {
+      const cmp = await cmpRes.json() as {
+        ahead_by?: number
+        commits?: { sha: string; commit: { message: string; author: { name: string; date: string } } }[]
+      }
+      status.behind = cmp.ahead_by ?? 0
+      // GitHub returns commits oldest-first; flip to newest-first for the UI.
+      const raw = (cmp.commits ?? []).slice().reverse()
+      status.commits = raw.map(c => ({
+        sha: c.sha,
+        short: c.sha.slice(0, 7),
+        message: (c.commit.message || '').split('\n')[0],
+        author: c.commit.author?.name || '',
+        date: c.commit.author?.date || '',
+      }))
+    } else if (cmpRes.status === 404) {
+      // Local HEAD not on the remote (detached local commit / different base).
+      status.error = 'Local HEAD not found on GitHub -- different fork or unpushed commits?'
+    }
+  } catch (err) {
+    status.error = err instanceof Error ? err.message : String(err)
+  }
+  updateStatusCache = status
+  return status
+}
+
+// Polls the GitHub repo's main branch for new commits and compares to the
+// local HEAD. Lets the dashboard show a "new version available" badge
+// without anyone having to SSH in and run update.sh.
+export function startUpdateChecker(): NodeJS.Timeout {
+  // First check shortly after startup; then every 15 minutes.
+  setTimeout(() => { refreshUpdateStatus().catch(() => {}) }, 10_000)
+  return setInterval(() => { refreshUpdateStatus().catch(() => {}) }, 15 * 60_000)
+}


### PR DESCRIPTION
## Summary
- Extract update-checker (GitHub poll for new commits on main) into src/web/update-checker.ts
- Cache is module-private; route reads via getUpdateStatus()
- web.ts: 4091 -> 3980 lines (-111)
- Pure code move; no behavior change

## Test plan
- [x] tsc --noEmit passes
- [x] vitest: 292 tests pass
- [ ] Manual: dashboard "new version available" badge still updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)