### PR TITLE
feat(web): scope-based MCP connector grouping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ reports/
 *.log
 *.pid
 
+# Test artifacts
+test-results/
+
 # macOS
 .DS_Store
 

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync } from 'node:child_process'
@@ -9,7 +9,7 @@ import {
   type McpListEntry,
 } from '../../mcp-list-parser.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
-import { readFileOr } from '../agent-config.js'
+import { readFileOr, AGENTS_BASE_DIR, listAgentNames } from '../agent-config.js'
 import { getMcpListCache, refreshMcpListCache } from '../mcp-list.js'
 import { readBody, json } from '../http-helpers.js'
 import { shellEscape } from '../sanitize.js'
@@ -23,48 +23,50 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   // output. The CLI is not invoked here -- spawning every stdio / plugin
   // MCP for a health check would race the live Telegram bot.
   if (path === '/api/connectors' && method === 'GET') {
-    const connectors: Array<{
+    type ConnectorEntry = {
       name: string
       status: string
       endpoint: string
       type: string
-      source: 'plugin' | 'local-user' | 'local-project' | 'local' | 'claude.ai'
-    }> = []
-    const seen = new Set<string>()
+      source: 'plugin' | 'local-user' | 'local-project' | 'local' | 'claude.ai' | 'agent' | 'agent-project'
+      scope: string
+    }
+    const connectors: ConnectorEntry[] = []
+    const globalSeen = new Set<string>()
 
     try {
       const settings = JSON.parse(readFileOr(join(homedir(), '.claude', 'settings.json'), '{}'))
       for (const pluginKey of Object.keys(settings.enabledPlugins || {})) {
         if (!settings.enabledPlugins[pluginKey]) continue
         const name = `plugin:${pluginKey.split('@')[0].toLowerCase()}`
-        if (seen.has(name)) continue
-        seen.add(name)
-        connectors.push({ name, status: 'configured', endpoint: pluginKey, type: 'plugin', source: 'plugin' })
+        if (globalSeen.has(name)) continue
+        globalSeen.add(name)
+        connectors.push({ name, status: 'configured', endpoint: pluginKey, type: 'plugin', source: 'plugin', scope: 'plugin' })
       }
     } catch { /* ignore */ }
 
-    const fileSources: Array<[string, 'local-project' | 'local-user']> = [
-      [join(PROJECT_ROOT, '.mcp.json'), 'local-project'],
-      [join(homedir(), '.claude.json'), 'local-user'],
+    const fileSources: Array<[string, 'local-project' | 'local-user', string]> = [
+      [join(PROJECT_ROOT, '.mcp.json'), 'local-project', 'global'],
+      [join(homedir(), '.claude.json'), 'local-user', 'global'],
     ]
-    for (const [src, source] of fileSources) {
+    for (const [src, source, scope] of fileSources) {
       try {
         const parsed = JSON.parse(readFileOr(src, '{}'))
         const servers = parsed.mcpServers || {}
         for (const [name, cfg] of Object.entries(servers) as Array<[string, any]>) {
-          if (seen.has(name)) continue
-          seen.add(name)
+          if (globalSeen.has(name)) continue
+          globalSeen.add(name)
           const endpoint = cfg?.url || cfg?.command || ''
           const type = cfg?.url ? 'remote' : 'local'
-          connectors.push({ name, status: 'configured', endpoint: String(endpoint), type, source })
+          connectors.push({ name, status: 'configured', endpoint: String(endpoint), type, source, scope })
         }
       } catch { /* ignore */ }
     }
 
     for (const entry of getMcpListCache().entries) {
       const key = entry.source === 'plugin' ? `plugin:${entry.normalizedId}` : entry.name
-      if (seen.has(key)) continue
-      seen.add(key)
+      if (globalSeen.has(key)) continue
+      globalSeen.add(key)
       connectors.push({
         name: entry.name,
         status: entry.status === 'unknown' ? 'configured' : entry.status,
@@ -73,7 +75,40 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
         source: entry.source === 'plugin' ? 'plugin'
                : entry.source === 'claude.ai' ? 'claude.ai'
                : 'local',
+        scope: entry.source === 'claude.ai' ? 'global' : 'global',
       })
+    }
+
+    for (const agentName of listAgentNames()) {
+      const agentMcpPath = join(AGENTS_BASE_DIR, agentName, '.mcp.json')
+      try {
+        const parsed = JSON.parse(readFileOr(agentMcpPath, '{}'))
+        const servers = parsed.mcpServers || {}
+        for (const [name, cfg] of Object.entries(servers) as Array<[string, any]>) {
+          const endpoint = cfg?.url || cfg?.command || ''
+          const type = cfg?.url ? 'remote' : 'local'
+          connectors.push({ name, status: 'configured', endpoint: String(endpoint), type, source: 'agent', scope: `agent:${agentName}` })
+        }
+      } catch { /* ignore */ }
+
+      const projectsDir = join(AGENTS_BASE_DIR, agentName, 'projects')
+      if (existsSync(projectsDir)) {
+        try {
+          for (const proj of readdirSync(projectsDir)) {
+            if (!statSync(join(projectsDir, proj)).isDirectory()) continue
+            const projMcpPath = join(projectsDir, proj, '.mcp.json')
+            try {
+              const parsed = JSON.parse(readFileOr(projMcpPath, '{}'))
+              const servers = parsed.mcpServers || {}
+              for (const [name, cfg] of Object.entries(servers) as Array<[string, any]>) {
+                const endpoint = cfg?.url || cfg?.command || ''
+                const type = cfg?.url ? 'remote' : 'local'
+                connectors.push({ name, status: 'configured', endpoint: String(endpoint), type, source: 'agent-project', scope: `project:${agentName}/${proj}` })
+              }
+            } catch { /* ignore */ }
+          }
+        } catch { /* ignore */ }
+      }
     }
 
     json(res, connectors)
@@ -123,7 +158,23 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
         return true
       }
     }
-    for (const [src, scope] of [[join(PROJECT_ROOT, '.mcp.json'), 'project' as const], [join(homedir(), '.claude.json'), 'user' as const]]) {
+    const searchPaths: Array<[string, string]> = [
+      [join(PROJECT_ROOT, '.mcp.json'), 'project'],
+      [join(homedir(), '.claude.json'), 'user'],
+    ]
+    for (const agentName of listAgentNames()) {
+      searchPaths.push([join(AGENTS_BASE_DIR, agentName, '.mcp.json'), `agent:${agentName}`])
+      const projectsDir = join(AGENTS_BASE_DIR, agentName, 'projects')
+      if (existsSync(projectsDir)) {
+        try {
+          for (const proj of readdirSync(projectsDir)) {
+            if (!statSync(join(projectsDir, proj)).isDirectory()) continue
+            searchPaths.push([join(projectsDir, proj, '.mcp.json'), `project:${agentName}/${proj}`])
+          }
+        } catch { /* ignore */ }
+      }
+    }
+    for (const [src, scope] of searchPaths) {
       try {
         const parsed = JSON.parse(readFileOr(src, '{}'))
         const cfg = (parsed.mcpServers || {})[name]

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -75,7 +75,7 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
         source: entry.source === 'plugin' ? 'plugin'
                : entry.source === 'claude.ai' ? 'claude.ai'
                : 'local',
-        scope: entry.source === 'claude.ai' ? 'global' : 'global',
+        scope: 'global',
       })
     }
 

--- a/web/app.js
+++ b/web/app.js
@@ -3830,13 +3830,6 @@ function renderConnectors() {
 
   // Grid
   connectorGrid.innerHTML = ''
-  // Stale-data warning banner. Only warns when the failed refresh
-  // would actually matter: file-based entries (enabledPlugins,
-  // project/.mcp.json, ~/.claude.json) were re-read fresh on this
-  // request, so they are always authoritative. The only subset that
-  // can go stale is the claude.ai OAuth connectors, which only land
-  // in the list via mcpListCache. If none of those are present,
-  // nothing about the displayed data is actually stale.
   const hasClaudeAiEntries = connectors.some(c => c.source === 'claude.ai')
   if (connectors.length > 0 && !connectorCacheWarming && connectorCacheError && hasClaudeAiEntries) {
     const banner = document.createElement('div')
@@ -3845,14 +3838,6 @@ function renderConnectors() {
     connectorGrid.appendChild(banner)
   }
   if (connectors.length === 0) {
-    // Cold-start: cache has never run, so the empty list is not the
-    // ground truth, just the transient state before the 30s warmup or
-    // a manual refresh. Telling the user "there are none" would
-    // contradict the info-box above.
-    //
-    // If we have a cached error AND warming is still true (refresh has
-    // failed; cache never populated), show the error instead of
-    // instructing the user to click the button that just failed.
     if (connectorCacheWarming && connectorCacheError) {
       connectorGrid.innerHTML = `<div class="connector-loading">MCP lista nem tölthető be: ${escapeHtml(connectorCacheError)}</div>`
     } else if (connectorCacheWarming) {
@@ -3862,43 +3847,115 @@ function renderConnectors() {
     }
     return
   }
+
+  // Group by scope
+  const groups = new Map()
   for (const c of connectors) {
-    const card = document.createElement('div')
-    card.className = 'connector-card'
-    // Source labels: map the terse backend values to short visible tags.
-    // This is the single biggest information the user needs right now
-    // -- where did this entry come from, file or OAuth?
-    const sourceLabels = {
-      'claude.ai': 'claude.ai',
-      'plugin': 'plugin',
-      'local-user': 'local (user)',
-      'local-project': 'local (project)',
-      'local': 'local',
+    const scope = c.scope || 'global'
+    if (!groups.has(scope)) groups.set(scope, [])
+    groups.get(scope).push(c)
+  }
+
+  const scopeOrder = ['global', 'plugin']
+  const agentScopes = []
+  const projectScopes = []
+  for (const scope of groups.keys()) {
+    if (scope.startsWith('agent:')) agentScopes.push(scope)
+    else if (scope.startsWith('project:')) projectScopes.push(scope)
+    else if (!scopeOrder.includes(scope)) scopeOrder.push(scope)
+  }
+  agentScopes.sort()
+  projectScopes.sort()
+  const orderedScopes = [...scopeOrder, ...agentScopes, ...projectScopes]
+
+  const scopeLabels = {
+    'global': 'Globális',
+    'plugin': 'Plugin',
+  }
+
+  function getScopeLabel(scope) {
+    if (scopeLabels[scope]) return scopeLabels[scope]
+    if (scope.startsWith('agent:')) return scope.slice('agent:'.length)
+    if (scope.startsWith('project:')) return scope.slice('project:'.length)
+    return scope
+  }
+
+  function getScopeIcon(scope) {
+    if (scope === 'global' || scope === 'plugin') return '🌐'
+    if (scope.startsWith('agent:')) return '🤖'
+    if (scope.startsWith('project:')) return '📁'
+    return '📦'
+  }
+
+  for (const scope of orderedScopes) {
+    const items = groups.get(scope)
+    if (!items || items.length === 0) continue
+
+    const isCollapsible = scope.startsWith('agent:') || scope.startsWith('project:')
+    const section = document.createElement('div')
+    section.className = 'connector-scope-section'
+
+    const header = document.createElement('div')
+    header.className = 'connector-section-header connector-scope-header'
+    const icon = getScopeIcon(scope)
+    const label = getScopeLabel(scope)
+    const count = items.length
+    if (isCollapsible) {
+      header.classList.add('collapsible')
+      header.innerHTML = `<span class="connector-scope-toggle">▶</span> ${icon} ${escapeHtml(label)} <span class="connector-scope-count">${count}</span>`
+      header.addEventListener('click', () => {
+        const grid = section.querySelector('.connector-scope-grid')
+        const toggle = header.querySelector('.connector-scope-toggle')
+        if (grid.hidden) {
+          grid.hidden = false
+          toggle.textContent = '▼'
+        } else {
+          grid.hidden = true
+          toggle.textContent = '▶'
+        }
+      })
+    } else {
+      header.innerHTML = `${icon} ${escapeHtml(label)} <span class="connector-scope-count">${count}</span>`
     }
-    const sourceTag = c.source ? `<span class="connector-source-badge">${escapeHtml(sourceLabels[c.source] || c.source)}</span>` : ''
-    // claude.ai entries are managed by the Claude.ai subscription, not
-    // the dashboard: the detail endpoint cannot resolve them and the
-    // per-agent assign endpoint would 404. Mark them read-only so a
-    // click does not 404 a confusing "Reszletek betoltese sikertelen"
-    // modal, and add a small hint instead.
-    const readOnly = c.source === 'claude.ai'
-    if (readOnly) card.classList.add('connector-card-readonly')
-    // Readonly hint lives OUTSIDE .connector-endpoint so the endpoint's
-    // nowrap+ellipsis truncation cannot eat it on long URLs.
-    const readonlyHint = readOnly ? '<div class="connector-readonly-hint">Kezelhető: claude.ai</div>' : ''
-    card.innerHTML = `
-      <div class="connector-status-dot ${c.status}"></div>
-      <div class="connector-info">
-        <div class="connector-name">${escapeHtml(c.name)} ${sourceTag}</div>
-        <div class="connector-endpoint">${escapeHtml(c.endpoint || '')}</div>
-        ${readonlyHint}
-      </div>
-      <span class="connector-type-badge ${c.type}">${c.type}</span>
-    `
-    if (!readOnly) {
-      card.addEventListener('click', () => openConnectorDetail(c))
+    section.appendChild(header)
+
+    const grid = document.createElement('div')
+    grid.className = 'connector-scope-grid'
+    if (isCollapsible) grid.hidden = true
+
+    for (const c of items) {
+      const card = document.createElement('div')
+      card.className = 'connector-card'
+      const sourceLabels = {
+        'claude.ai': 'claude.ai',
+        'plugin': 'plugin',
+        'local-user': 'local (user)',
+        'local-project': 'local (project)',
+        'local': 'local',
+        'agent': 'agent',
+        'agent-project': 'project',
+      }
+      const sourceTag = c.source ? `<span class="connector-source-badge">${escapeHtml(sourceLabels[c.source] || c.source)}</span>` : ''
+      const readOnly = c.source === 'claude.ai'
+      if (readOnly) card.classList.add('connector-card-readonly')
+      const readonlyHint = readOnly ? '<div class="connector-readonly-hint">Kezelhető: claude.ai</div>' : ''
+      card.innerHTML = `
+        <div class="connector-status-dot ${c.status}"></div>
+        <div class="connector-info">
+          <div class="connector-name">${escapeHtml(c.name)} ${sourceTag}</div>
+          <div class="connector-endpoint">${escapeHtml(c.endpoint || '')}</div>
+          ${readonlyHint}
+        </div>
+        <span class="connector-type-badge ${c.type}">${c.type}</span>
+      `
+      if (!readOnly) {
+        card.addEventListener('click', () => openConnectorDetail(c))
+      }
+      grid.appendChild(card)
     }
-    connectorGrid.appendChild(card)
+
+    section.appendChild(grid)
+    connectorGrid.appendChild(section)
   }
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -3792,28 +3792,7 @@ if (document.readyState === 'loading') {
 }
 
 function renderConnectors() {
-  // Builtin grid
-  const builtinGrid = document.getElementById('connectorBuiltinGrid')
-  builtinGrid.innerHTML = ''
-  for (const b of BUILTIN_MCPS) {
-    const div = document.createElement('div')
-    div.className = 'connector-builtin'
-    // No state dot: we cannot reliably detect whether the feature is
-    // currently enabled. Show a dash placeholder so the row still
-    // aligns with other connector cards.
-    div.innerHTML = `
-      <div class="connector-status-dot unknown" title="A dashboard nem tudja automatikusan detektálni ezt a képességet"></div>
-      <div class="connector-builtin-name">${escapeHtml(b.label)}<br><span style="font-size:11px;color:var(--text-muted);font-weight:400">${escapeHtml(b.desc)}</span></div>
-      <button type="button" class="connector-builtin-action btn-link" data-builtin="${escapeHtml(b.name)}">Részletek</button>
-    `
-    const btn = div.querySelector('button[data-builtin]')
-    if (btn) btn.addEventListener('click', () => openBuiltinDetail(b))
-    builtinGrid.appendChild(div)
-  }
-
-  // Stats: only render when there is real data OR a confirmed empty
-  // cache. Rendering "0 / 0" stat cards above a "still loading" message
-  // contradicts itself and confuses the user.
+  // Stats
   if (connectors.length === 0 && connectorCacheWarming) {
     connectorStats.innerHTML = ''
   } else {
@@ -3828,7 +3807,6 @@ function renderConnectors() {
     `
   }
 
-  // Grid
   connectorGrid.innerHTML = ''
   const hasClaudeAiEntries = connectors.some(c => c.source === 'claude.ai')
   if (connectors.length > 0 && !connectorCacheWarming && connectorCacheError && hasClaudeAiEntries) {
@@ -3837,7 +3815,7 @@ function renderConnectors() {
     banner.innerHTML = `Frissítés sikertelen: ${escapeHtml(connectorCacheError)} -- a claude.ai connectorok elavultak lehetnek.`
     connectorGrid.appendChild(banner)
   }
-  if (connectors.length === 0) {
+  if (connectors.length === 0 && !BUILTIN_MCPS.length) {
     if (connectorCacheWarming && connectorCacheError) {
       connectorGrid.innerHTML = `<div class="connector-loading">MCP lista nem tölthető be: ${escapeHtml(connectorCacheError)}</div>`
     } else if (connectorCacheWarming) {
@@ -3856,106 +3834,121 @@ function renderConnectors() {
     groups.get(scope).push(c)
   }
 
-  const scopeOrder = ['global', 'plugin']
+  const globalScopes = ['global', 'plugin']
   const agentScopes = []
   const projectScopes = []
   for (const scope of groups.keys()) {
     if (scope.startsWith('agent:')) agentScopes.push(scope)
     else if (scope.startsWith('project:')) projectScopes.push(scope)
-    else if (!scopeOrder.includes(scope)) scopeOrder.push(scope)
+    else if (!globalScopes.includes(scope)) globalScopes.push(scope)
   }
   agentScopes.sort()
   projectScopes.sort()
-  const orderedScopes = [...scopeOrder, ...agentScopes, ...projectScopes]
 
-  const scopeLabels = {
-    'global': 'Globális',
-    'plugin': 'Plugin',
+  const sourceLabels = {
+    'claude.ai': 'claude.ai',
+    'plugin': 'plugin',
+    'local-user': 'local (user)',
+    'local-project': 'local (project)',
+    'local': 'local',
+    'agent': 'agent',
+    'agent-project': 'project',
   }
 
-  function getScopeLabel(scope) {
-    if (scopeLabels[scope]) return scopeLabels[scope]
-    if (scope.startsWith('agent:')) return scope.slice('agent:'.length)
-    if (scope.startsWith('project:')) return scope.slice('project:'.length)
-    return scope
+  function renderCard(c, container) {
+    const card = document.createElement('div')
+    card.className = 'connector-card'
+    const sourceTag = c.source ? `<span class="connector-source-badge">${escapeHtml(sourceLabels[c.source] || c.source)}</span>` : ''
+    const readOnly = c.source === 'claude.ai'
+    if (readOnly) card.classList.add('connector-card-readonly')
+    const readonlyHint = readOnly ? '<div class="connector-readonly-hint">Kezelhető: claude.ai</div>' : ''
+    card.innerHTML = `
+      <div class="connector-status-dot ${c.status}"></div>
+      <div class="connector-info">
+        <div class="connector-name">${escapeHtml(c.name)} ${sourceTag}</div>
+        <div class="connector-endpoint">${escapeHtml(c.endpoint || '')}</div>
+        ${readonlyHint}
+      </div>
+      <span class="connector-type-badge ${c.type}">${c.type}</span>
+    `
+    if (!readOnly) card.addEventListener('click', () => openConnectorDetail(c))
+    container.appendChild(card)
   }
 
-  function getScopeIcon(scope) {
-    if (scope === 'global' || scope === 'plugin') return '🌐'
-    if (scope.startsWith('agent:')) return '🤖'
-    if (scope.startsWith('project:')) return '📁'
-    return '📦'
-  }
-
-  for (const scope of orderedScopes) {
-    const items = groups.get(scope)
-    if (!items || items.length === 0) continue
-
-    const isCollapsible = scope.startsWith('agent:') || scope.startsWith('project:')
+  function renderCollapsible(label, icon, items, container) {
     const section = document.createElement('div')
     section.className = 'connector-scope-section'
-
     const header = document.createElement('div')
-    header.className = 'connector-section-header connector-scope-header'
-    const icon = getScopeIcon(scope)
-    const label = getScopeLabel(scope)
-    const count = items.length
-    if (isCollapsible) {
-      header.classList.add('collapsible')
-      header.innerHTML = `<span class="connector-scope-toggle">▶</span> ${icon} ${escapeHtml(label)} <span class="connector-scope-count">${count}</span>`
-      header.addEventListener('click', () => {
-        const grid = section.querySelector('.connector-scope-grid')
-        const toggle = header.querySelector('.connector-scope-toggle')
-        if (grid.hidden) {
-          grid.hidden = false
-          toggle.textContent = '▼'
-        } else {
-          grid.hidden = true
-          toggle.textContent = '▶'
-        }
-      })
-    } else {
-      header.innerHTML = `${icon} ${escapeHtml(label)} <span class="connector-scope-count">${count}</span>`
-    }
+    header.className = 'connector-scope-header collapsible'
+    header.innerHTML = `<span class="connector-scope-toggle">▶</span> ${icon} ${escapeHtml(label)} <span class="connector-scope-count">${items.length}</span>`
+    header.addEventListener('click', () => {
+      const grid = section.querySelector('.connector-scope-grid')
+      const toggle = header.querySelector('.connector-scope-toggle')
+      if (grid.hidden) { grid.hidden = false; toggle.textContent = '▼' }
+      else { grid.hidden = true; toggle.textContent = '▶' }
+    })
     section.appendChild(header)
-
     const grid = document.createElement('div')
     grid.className = 'connector-scope-grid'
-    if (isCollapsible) grid.hidden = true
-
-    for (const c of items) {
-      const card = document.createElement('div')
-      card.className = 'connector-card'
-      const sourceLabels = {
-        'claude.ai': 'claude.ai',
-        'plugin': 'plugin',
-        'local-user': 'local (user)',
-        'local-project': 'local (project)',
-        'local': 'local',
-        'agent': 'agent',
-        'agent-project': 'project',
-      }
-      const sourceTag = c.source ? `<span class="connector-source-badge">${escapeHtml(sourceLabels[c.source] || c.source)}</span>` : ''
-      const readOnly = c.source === 'claude.ai'
-      if (readOnly) card.classList.add('connector-card-readonly')
-      const readonlyHint = readOnly ? '<div class="connector-readonly-hint">Kezelhető: claude.ai</div>' : ''
-      card.innerHTML = `
-        <div class="connector-status-dot ${c.status}"></div>
-        <div class="connector-info">
-          <div class="connector-name">${escapeHtml(c.name)} ${sourceTag}</div>
-          <div class="connector-endpoint">${escapeHtml(c.endpoint || '')}</div>
-          ${readonlyHint}
-        </div>
-        <span class="connector-type-badge ${c.type}">${c.type}</span>
-      `
-      if (!readOnly) {
-        card.addEventListener('click', () => openConnectorDetail(c))
-      }
-      grid.appendChild(card)
-    }
-
+    grid.hidden = true
+    for (const c of items) renderCard(c, grid)
     section.appendChild(grid)
-    connectorGrid.appendChild(section)
+    container.appendChild(section)
+  }
+
+  // === Claude globális ===
+  const globalHeading = document.createElement('div')
+  globalHeading.className = 'connector-group-heading'
+  globalHeading.textContent = 'Claude globális'
+  connectorGrid.appendChild(globalHeading)
+
+  const builtinGrid = document.createElement('div')
+  builtinGrid.className = 'connector-builtin-grid'
+  for (const b of BUILTIN_MCPS) {
+    const div = document.createElement('div')
+    div.className = 'connector-builtin'
+    div.innerHTML = `
+      <div class="connector-status-dot unknown" title="A dashboard nem tudja automatikusan detektálni ezt a képességet"></div>
+      <div class="connector-builtin-name">${escapeHtml(b.label)}<br><span style="font-size:11px;color:var(--text-muted);font-weight:400">${escapeHtml(b.desc)}</span></div>
+      <button type="button" class="connector-builtin-action btn-link" data-builtin="${escapeHtml(b.name)}">Részletek</button>
+    `
+    const btn = div.querySelector('button[data-builtin]')
+    if (btn) btn.addEventListener('click', () => openBuiltinDetail(b))
+    builtinGrid.appendChild(div)
+  }
+  connectorGrid.appendChild(builtinGrid)
+
+  const globalGrid = document.createElement('div')
+  globalGrid.className = 'connector-scope-grid'
+  for (const scope of globalScopes) {
+    for (const c of (groups.get(scope) || [])) renderCard(c, globalGrid)
+  }
+  if (globalGrid.children.length > 0) connectorGrid.appendChild(globalGrid)
+
+  // === Ágensek ===
+  if (agentScopes.length > 0) {
+    const agentHeading = document.createElement('div')
+    agentHeading.className = 'connector-group-heading'
+    agentHeading.textContent = 'Ágensek'
+    connectorGrid.appendChild(agentHeading)
+
+    for (const ag of agentScopes) {
+      const agentName = ag.slice('agent:'.length)
+      renderCollapsible(agentName, '🤖', groups.get(ag), connectorGrid)
+    }
+  }
+
+  // === Projektek ===
+  if (projectScopes.length > 0) {
+    const projectHeading = document.createElement('div')
+    projectHeading.className = 'connector-group-heading'
+    projectHeading.textContent = 'Projektek'
+    connectorGrid.appendChild(projectHeading)
+
+    for (const ps of projectScopes) {
+      const projLabel = ps.slice('project:'.length)
+      renderCollapsible(projLabel, '📁', groups.get(ps), connectorGrid)
+    }
   }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -397,9 +397,6 @@
       <div class="connector-tab-content" id="connectorInstalledTab">
         <div class="connector-stats" id="connectorStats"></div>
 
-        <div class="connector-section-header">Beépített</div>
-        <div class="connector-builtin-grid" id="connectorBuiltinGrid"></div>
-
         <div class="connector-grid" id="connectorGrid"></div>
       </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -400,7 +400,6 @@
         <div class="connector-section-header">Beépített</div>
         <div class="connector-builtin-grid" id="connectorBuiltinGrid"></div>
 
-        <div class="connector-section-header">Telepített</div>
         <div class="connector-grid" id="connectorGrid"></div>
       </div>
 

--- a/web/style.css
+++ b/web/style.css
@@ -2760,6 +2760,33 @@ main {
 }
 .connector-section-header:first-of-type { margin-top: 0; }
 
+.connector-scope-section { margin-bottom: 4px; }
+.connector-scope-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.connector-scope-header.collapsible { cursor: pointer; user-select: none; }
+.connector-scope-header.collapsible:hover { color: var(--text); }
+.connector-scope-toggle {
+  font-size: 10px;
+  width: 12px;
+  display: inline-block;
+  transition: transform 0.15s;
+}
+.connector-scope-count {
+  font-weight: 400;
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-left: 4px;
+}
+.connector-scope-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
 .connector-builtin-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));

--- a/web/style.css
+++ b/web/style.css
@@ -2760,6 +2760,16 @@ main {
 }
 .connector-section-header:first-of-type { margin-top: 0; }
 
+.connector-group-heading {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  margin-top: 24px;
+  margin-bottom: 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.connector-group-heading:first-child { margin-top: 0; }
 .connector-scope-section { margin-bottom: 4px; }
 .connector-scope-header {
   display: flex;
@@ -2786,6 +2796,7 @@ main {
   gap: 12px;
   margin-bottom: 8px;
 }
+.connector-scope-grid[hidden] { display: none; }
 
 .connector-builtin-grid {
   display: grid;
@@ -2857,9 +2868,7 @@ main {
 }
 
 .connector-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 12px;
+  display: block;
 }
 
 .connector-card {
@@ -2949,10 +2958,6 @@ main {
 .info-box strong { color: var(--info); }
 
 .connector-stale-banner {
-  /* Span the entire grid row -- .connector-grid is auto-fill columns,
-     so without this the banner shrinks into a single track and the
-     first connector card squeezes up beside it. */
-  grid-column: 1 / -1;
   padding: 10px 14px;
   margin: 0 0 12px;
   border-radius: 6px;
@@ -3722,7 +3727,7 @@ main {
   .timeline-hours { margin-left: 70px; }
   .timeline-marker { width: 24px; height: 24px; top: 10px; }
   .timeline-marker-tooltip { font-size: 10px; }
-  .connector-grid { grid-template-columns: 1fr; }
+  .connector-scope-grid { grid-template-columns: 1fr; }
   .connector-stats { gap: 8px; }
   .catalog-grid { grid-template-columns: 1fr; }
   .catalog-filters { gap: 4px; }


### PR DESCRIPTION
## Summary
- **Backend**: `GET /api/connectors` extended with a `scope` field. Scans `agents/*/.mcp.json` and `agents/*/projects/*/.mcp.json` to discover agent-level and project-level MCP configurations. Detail endpoint also extended to resolve connectors from agent/project configs.
- **Frontend**: MCP dashboard reorganized into three distinct sections with clear headings:
  - **Claude global** -- built-in capabilities + global/plugin MCPs
  - **Agents** -- per-agent collapsible sections showing their MCP servers
  - **Projects** -- per-project collapsible sections (visually separated from agents)
- Collapsible sections with toggle arrows for agent and project scopes
- New `source` types: `agent`, `agent-project` for origin tracking

## Test plan
- [ ] Open dashboard MCP page, verify three section headings appear
- [ ] Verify global MCPs (gmail, telegram plugin) appear under "Claude global"
- [ ] Verify agent-specific MCPs appear under "Agents" with correct agent names
- [ ] Verify project MCPs appear under "Projects" with `agent/project` labels
- [ ] Click collapsible headers to toggle open/closed
- [ ] Click a connector card to open detail view
- [ ] Verify responsive layout on narrow viewport
- [ ] `GET /api/connectors` returns `scope` field for all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)