### PR TITLE
feat(web): external project paths for MCP connector scanning

### DIFF
--- a/src/web/dashboard-settings.ts
+++ b/src/web/dashboard-settings.ts
@@ -1,0 +1,45 @@
+import { existsSync, statSync } from 'node:fs'
+import { join, resolve, isAbsolute } from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+import { readFileOr } from './agent-config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+
+const SETTINGS_PATH = join(PROJECT_ROOT, 'store', 'dashboard-settings.json')
+
+interface DashboardSettings {
+  externalProjectPaths?: string[]
+}
+
+function read(): DashboardSettings {
+  try { return JSON.parse(readFileOr(SETTINGS_PATH, '{}')) }
+  catch { return {} }
+}
+
+function write(s: DashboardSettings): void {
+  atomicWriteFileSync(SETTINGS_PATH, JSON.stringify(s, null, 2) + '\n')
+}
+
+export function getExternalProjectPaths(): string[] {
+  return read().externalProjectPaths || []
+}
+
+export function addExternalProjectPath(raw: string): { paths: string[], error?: string } {
+  if (!raw || !isAbsolute(raw)) return { paths: getExternalProjectPaths(), error: 'Absolute path required' }
+  const p = resolve(raw)
+  if (!existsSync(p) || !statSync(p).isDirectory()) return { paths: getExternalProjectPaths(), error: 'Directory does not exist' }
+  const s = read()
+  const list = s.externalProjectPaths || []
+  if (list.includes(p)) return { paths: list }
+  list.push(p)
+  s.externalProjectPaths = list
+  write(s)
+  return { paths: list }
+}
+
+export function removeExternalProjectPath(raw: string): string[] {
+  const p = resolve(raw)
+  const s = read()
+  s.externalProjectPaths = (s.externalProjectPaths || []).filter(x => x !== p)
+  write(s)
+  return s.externalProjectPaths
+}

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync } from 'node:child_process'
 import { PROJECT_ROOT, OLLAMA_URL } from '../../config.js'
@@ -13,6 +13,7 @@ import { readFileOr, AGENTS_BASE_DIR, listAgentNames } from '../agent-config.js'
 import { getMcpListCache, refreshMcpListCache } from '../mcp-list.js'
 import { readBody, json } from '../http-helpers.js'
 import { shellEscape } from '../sanitize.js'
+import { getExternalProjectPaths, addExternalProjectPath, removeExternalProjectPath } from '../dashboard-settings.js'
 import type { RouteContext } from './types.js'
 
 export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
@@ -28,7 +29,7 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
       status: string
       endpoint: string
       type: string
-      source: 'plugin' | 'local-user' | 'local-project' | 'local' | 'claude.ai' | 'agent' | 'agent-project'
+      source: 'plugin' | 'local-user' | 'local-project' | 'local' | 'claude.ai' | 'agent' | 'agent-project' | 'external-project'
       scope: string
     }
     const connectors: ConnectorEntry[] = []
@@ -111,6 +112,19 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
       }
     }
 
+    for (const extPath of getExternalProjectPaths()) {
+      try {
+        const parsed = JSON.parse(readFileOr(join(extPath, '.mcp.json'), '{}'))
+        const servers = parsed.mcpServers || {}
+        const projName = basename(extPath)
+        for (const [name, cfg] of Object.entries(servers) as Array<[string, any]>) {
+          const endpoint = cfg?.url || cfg?.command || ''
+          const type = cfg?.url ? 'remote' : 'local'
+          connectors.push({ name, status: 'configured', endpoint: String(endpoint), type, source: 'external-project', scope: `project:external/${projName}` })
+        }
+      } catch { /* ignore */ }
+    }
+
     json(res, connectors)
     return true
   }
@@ -134,6 +148,28 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
       lastRefreshed: cache.lastRefreshed,
       error: cache.error,
     }, httpStatus)
+    return true
+  }
+
+  if (path === '/api/connectors/external-paths' && method === 'GET') {
+    json(res, { paths: getExternalProjectPaths() })
+    return true
+  }
+
+  if (path === '/api/connectors/external-paths' && method === 'POST') {
+    const body = await readBody(req)
+    const { path: p } = JSON.parse(body.toString()) as { path: string }
+    const result = addExternalProjectPath(p)
+    if (result.error) { json(res, { error: result.error }, 400); return true }
+    json(res, { ok: true, paths: result.paths })
+    return true
+  }
+
+  if (path === '/api/connectors/external-paths' && method === 'DELETE') {
+    const body = await readBody(req)
+    const { path: p } = JSON.parse(body.toString()) as { path: string }
+    const paths = removeExternalProjectPath(p)
+    json(res, { ok: true, paths })
     return true
   }
 
@@ -173,6 +209,9 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
           }
         } catch { /* ignore */ }
       }
+    }
+    for (const extPath of getExternalProjectPaths()) {
+      searchPaths.push([join(extPath, '.mcp.json'), `project:external/${basename(extPath)}`])
     }
     for (const [src, scope] of searchPaths) {
       try {

--- a/web/app.js
+++ b/web/app.js
@@ -3714,6 +3714,7 @@ async function loadConnectors() {
       if (s && s.cacheError) connectorCacheError = String(s.cacheError)
     }
     renderConnectors()
+    loadExternalPaths()
   } catch (err) {
     console.error('Connector betöltés hiba:', err)
     connectorGrid.innerHTML = '<div class="connector-loading">Hiba a betöltés során</div>'
@@ -3853,6 +3854,7 @@ function renderConnectors() {
     'local': 'local',
     'agent': 'agent',
     'agent-project': 'project',
+    'external-project': 'external',
   }
 
   function renderCard(c, container) {
@@ -3951,6 +3953,61 @@ function renderConnectors() {
     }
   }
 }
+
+// --- External project paths management ---
+async function loadExternalPaths() {
+  try {
+    const res = await fetch('/api/connectors/external-paths')
+    const data = await res.json()
+    const paths = data.paths || []
+    document.getElementById('externalPathCount').textContent = String(paths.length)
+    const list = document.getElementById('externalPathList')
+    list.innerHTML = ''
+    for (const p of paths) {
+      const item = document.createElement('div')
+      item.className = 'connector-external-item'
+      item.innerHTML = `<span>${escapeHtml(p)}</span><button title="Torles">&times;</button>`
+      item.querySelector('button').addEventListener('click', async () => {
+        await fetch('/api/connectors/external-paths', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ path: p }),
+        })
+        loadExternalPaths()
+        loadConnectors()
+      })
+      list.appendChild(item)
+    }
+  } catch { /* ignore */ }
+}
+
+;(function wireExternalPaths() {
+  const toggle = document.getElementById('externalPathsToggle')
+  const body = document.getElementById('externalPathsBody')
+  if (!toggle || !body) return
+  toggle.addEventListener('click', () => {
+    const arrow = toggle.querySelector('.connector-scope-toggle')
+    if (body.hidden) { body.hidden = false; arrow.textContent = '▼' }
+    else { body.hidden = true; arrow.textContent = '▶' }
+  })
+  const addBtn = document.getElementById('externalPathAddBtn')
+  const input = document.getElementById('externalPathInput')
+  addBtn.addEventListener('click', async () => {
+    const val = input.value.trim()
+    if (!val) return
+    const res = await fetch('/api/connectors/external-paths', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: val }),
+    })
+    const data = await res.json()
+    if (data.error) { alert(data.error); return }
+    input.value = ''
+    loadExternalPaths()
+    loadConnectors()
+  })
+  input.addEventListener('keydown', (e) => { if (e.key === 'Enter') addBtn.click() })
+})()
 
 async function openConnectorDetail(connector) {
   document.getElementById('connectorDetailTitle').textContent = connector.name

--- a/web/index.html
+++ b/web/index.html
@@ -398,6 +398,20 @@
         <div class="connector-stats" id="connectorStats"></div>
 
         <div class="connector-grid" id="connectorGrid"></div>
+
+        <div class="connector-external-paths">
+          <div class="connector-external-header" id="externalPathsToggle">
+            <span class="connector-scope-toggle">▶</span>
+            Kulso projekt utvonalak <span class="connector-scope-count" id="externalPathCount">0</span>
+          </div>
+          <div class="connector-external-body" id="externalPathsBody" hidden>
+            <div id="externalPathList"></div>
+            <div class="connector-external-add">
+              <input type="text" id="externalPathInput" class="input" placeholder="/Users/...">
+              <button class="btn-secondary btn-compact" id="externalPathAddBtn">Hozzaad</button>
+            </div>
+          </div>
+        </div>
       </div>
 
       <!-- Gallery tab -->

--- a/web/style.css
+++ b/web/style.css
@@ -2798,6 +2798,50 @@ main {
 }
 .connector-scope-grid[hidden] { display: none; }
 
+.connector-external-paths {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.connector-external-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+.connector-external-header:hover { color: var(--text); }
+.connector-external-body[hidden] { display: none; }
+.connector-external-body { margin-top: 10px; }
+.connector-external-add { display: flex; gap: 8px; margin-top: 8px; }
+.connector-external-add .input { flex: 1; }
+.connector-external-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 4px;
+  font-size: 13px;
+  font-family: monospace;
+}
+.connector-external-item button {
+  background: none;
+  border: none;
+  color: var(--danger);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 6px;
+}
+.connector-external-item button:hover { opacity: 0.7; }
+
 .connector-builtin-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));


### PR DESCRIPTION
## Summary
- Extends the MCP dashboard (shipped in #51) to scan `.mcp.json` files from directories outside the project tree
- Paths stored in `store/dashboard-settings.json`, managed via `GET/POST/DELETE /api/connectors/external-paths`
- External project MCPs appear under the "Projektek" section with `external/<dirname>` labels and collapsible toggle
- Dashboard UI: collapsible panel at the bottom of the MCP page with input field to add paths and X button to remove

## Test plan
- [ ] Open MCP page, scroll to bottom, expand "Külső projekt útvonalak" panel
- [ ] Add an external path (must be absolute, existing directory)
- [ ] Verify connectors from that path appear under "Projektek" with `external` badge
- [ ] Remove the path, verify connectors disappear on reload
- [ ] Try adding non-existent path -- should show error
- [ ] Try adding relative path -- should show error
- [ ] Verify `store/dashboard-settings.json` persists across dashboard restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)