### PR TITLE
fix(web): MCP connector fixes and lost feature restoration

### DIFF
--- a/src/web/mcp-list.ts
+++ b/src/web/mcp-list.ts
@@ -41,6 +41,15 @@ export function getMcpListCache(): McpListCache {
   return mcpListCache
 }
 
+export function purgeFromMcpListCache(name: string): boolean {
+  const before = mcpListCache.entries.length
+  mcpListCache = {
+    ...mcpListCache,
+    entries: mcpListCache.entries.filter(e => e.name !== name),
+  }
+  return mcpListCache.entries.length < before
+}
+
 // Private working directory for `claude mcp list`. Running from /tmp
 // directly was tempting (no project-local .mcp.json to spawn), but on
 // multi-user hosts any user with write access to /tmp can plant a

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -10,7 +10,7 @@ import {
 } from '../../mcp-list-parser.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { readFileOr, AGENTS_BASE_DIR, listAgentNames } from '../agent-config.js'
-import { getMcpListCache, refreshMcpListCache } from '../mcp-list.js'
+import { getMcpListCache, refreshMcpListCache, purgeFromMcpListCache } from '../mcp-list.js'
 import { readBody, json } from '../http-helpers.js'
 import { shellEscape } from '../sanitize.js'
 import { getExternalProjectPaths, addExternalProjectPath, removeExternalProjectPath, getGitHubRepos, installGitHubRepo, removeGitHubRepo, updateGitHubRepo, detectRequiredEnvVars } from '../dashboard-settings.js'
@@ -357,7 +357,10 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
       } catch { /* skip unreadable files */ }
     }
     if (removed > 0) {
+      purgeFromMcpListCache(name)
       json(res, { ok: true, removed })
+    } else if (purgeFromMcpListCache(name)) {
+      json(res, { ok: true, removed: 0, purgedFromCache: true })
     } else {
       json(res, { error: 'Connector not found in any config' }, 404)
     }

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -284,7 +284,7 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
     const body = await readBody(req)
     const data = JSON.parse(body.toString()) as {
       name: string
-      type: 'remote' | 'local'
+      type: 'stdio' | 'http' | 'sse'
       url?: string
       command?: string
       args?: string
@@ -305,14 +305,15 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
     try {
       const scopeFlag = data.scope === 'project' ? '-s project' : '-s user'
 
-      if (data.type === 'remote' && data.url) {
-        execSync(`claude mcp add --transport http ${scopeFlag} ${shellEscape(sanitizedName)} ${shellEscape(data.url)} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
-      } else if (data.type === 'local' && data.command) {
+      if ((data.type === 'http' || data.type === 'sse') && data.url) {
+        const transport = data.type === 'sse' ? 'sse' : 'http'
+        execSync(`claude mcp add --transport ${transport} ${scopeFlag} ${shellEscape(sanitizedName)} ${shellEscape(data.url)} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
+      } else if (data.type === 'stdio' && data.command) {
         const envFlags = data.env ? Object.entries(data.env).map(([k, v]) => `-e ${shellEscape(k)}=${shellEscape(v)}`).join(' ') : ''
-        const argsStr = data.args ? shellEscape(data.args) : ''
+        const argsStr = data.args ? data.args.split(/\s+/).filter(Boolean).map(a => shellEscape(a)).join(' ') : ''
         execSync(`claude mcp add ${scopeFlag} ${shellEscape(sanitizedName)} ${envFlags} -- ${shellEscape(data.command)} ${argsStr} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
       } else {
-        json(res, { error: 'URL (remote) or command (local) required' }, 400)
+        json(res, { error: 'URL (http/sse) or command (stdio) required' }, 400)
         return true
       }
 
@@ -371,7 +372,7 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   if (connectorAssignMatch && method === 'POST') {
     const connectorName = decodeURIComponent(connectorAssignMatch[1])
     const body = await readBody(req)
-    const { agents: targetAgents } = JSON.parse(body.toString()) as { agents: string[] }
+    const { agents: targetAgents, allAgents: visibleAgents } = JSON.parse(body.toString()) as { agents: string[], allAgents?: string[] }
 
     if (connectorName.startsWith('plugin:')) {
       json(res, { ok: true, note: 'plugin:* connectors are global to every agent -- nothing to assign.' })
@@ -379,7 +380,27 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
     }
 
     let connectorConfig: any = null
-    for (const src of [join(PROJECT_ROOT, '.mcp.json'), join(homedir(), '.claude.json')]) {
+    const configSources = [
+      join(PROJECT_ROOT, '.mcp.json'),
+      join(homedir(), '.claude.json'),
+    ]
+    for (const agentName of listAgentNames()) {
+      configSources.push(join(AGENTS_BASE_DIR, agentName, '.mcp.json'))
+      const projectsDir = join(AGENTS_BASE_DIR, agentName, 'projects')
+      if (existsSync(projectsDir)) {
+        try {
+          for (const proj of readdirSync(projectsDir)) {
+            if (statSync(join(projectsDir, proj)).isDirectory()) {
+              configSources.push(join(projectsDir, proj, '.mcp.json'))
+            }
+          }
+        } catch { /* ignore */ }
+      }
+    }
+    for (const extPath of getExternalProjectPaths()) {
+      configSources.push(join(extPath, '.mcp.json'))
+    }
+    for (const src of configSources) {
       try {
         const parsed = JSON.parse(readFileOr(src, '{}'))
         if (parsed.mcpServers && parsed.mcpServers[connectorName]) {
@@ -390,16 +411,30 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
     }
     if (!connectorConfig) { json(res, { error: 'Connector not found' }, 404); return true }
 
-    const AGENTS_BASE = join(PROJECT_ROOT, 'agents')
+    const targetSet = new Set(targetAgents)
     for (const agentName of targetAgents) {
-      const mcpPath = join(AGENTS_BASE, agentName, '.mcp.json')
-      if (!existsSync(mcpPath)) continue
+      const mcpPath = join(AGENTS_BASE_DIR, agentName, '.mcp.json')
       let mcpConfig: any = {}
-      try { mcpConfig = JSON.parse(readFileSync(mcpPath, 'utf-8')) } catch {}
+      try { mcpConfig = JSON.parse(readFileOr(mcpPath, '{}')) } catch {}
       if (!mcpConfig.mcpServers) mcpConfig.mcpServers = {}
       mcpConfig.mcpServers[connectorName] = connectorConfig
       atomicWriteFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2))
     }
+
+    if (visibleAgents) {
+      for (const agentName of visibleAgents) {
+        if (targetSet.has(agentName)) continue
+        const mcpPath = join(AGENTS_BASE_DIR, agentName, '.mcp.json')
+        try {
+          const mcpConfig = JSON.parse(readFileOr(mcpPath, '{}'))
+          if (mcpConfig.mcpServers && mcpConfig.mcpServers[connectorName]) {
+            delete mcpConfig.mcpServers[connectorName]
+            atomicWriteFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2))
+          }
+        } catch { /* skip */ }
+      }
+    }
+
     json(res, { ok: true })
     return true
   }

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -325,15 +325,41 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
 
   if (connectorDetailMatch && method === 'DELETE' && !path.includes('/assign')) {
     const name = decodeURIComponent(connectorDetailMatch[1])
-    try {
-      try {
-        execSync(`claude mcp remove ${shellEscape(name)} -s project 2>&1`, { timeout: 10000 })
-      } catch {
-        execSync(`claude mcp remove ${shellEscape(name)} -s user 2>&1`, { timeout: 10000 })
+    let removed = 0
+    const mcpFiles = [
+      join(PROJECT_ROOT, '.mcp.json'),
+      join(homedir(), '.claude.json'),
+    ]
+    for (const agentName of listAgentNames()) {
+      mcpFiles.push(join(AGENTS_BASE_DIR, agentName, '.mcp.json'))
+      const projectsDir = join(AGENTS_BASE_DIR, agentName, 'projects')
+      if (existsSync(projectsDir)) {
+        try {
+          for (const proj of readdirSync(projectsDir)) {
+            if (statSync(join(projectsDir, proj)).isDirectory()) {
+              mcpFiles.push(join(projectsDir, proj, '.mcp.json'))
+            }
+          }
+        } catch { /* ignore */ }
       }
-      json(res, { ok: true })
-    } catch {
-      json(res, { error: 'Failed to remove connector' }, 500)
+    }
+    for (const extPath of getExternalProjectPaths()) {
+      mcpFiles.push(join(extPath, '.mcp.json'))
+    }
+    for (const mcpPath of mcpFiles) {
+      try {
+        const parsed = JSON.parse(readFileOr(mcpPath, '{}'))
+        if (parsed.mcpServers && parsed.mcpServers[name]) {
+          delete parsed.mcpServers[name]
+          atomicWriteFileSync(mcpPath, JSON.stringify(parsed, null, 2))
+          removed++
+        }
+      } catch { /* skip unreadable files */ }
+    }
+    if (removed > 0) {
+      json(res, { ok: true, removed })
+    } else {
+      json(res, { error: 'Connector not found in any config' }, 404)
     }
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -3466,7 +3466,7 @@ document.getElementById('connectorRefreshBtn').addEventListener('click', async (
     if (!res.ok || !data.ok) {
       showToast('Frissítés sikertelen: ' + (data.error || 'HTTP ' + res.status))
     } else {
-      showToast('Frissítve (' + (data.count || 0) + ' MCP)')
+      showToast('MCP lista frissítve (' + (data.count || 0) + ' globális connector)')
     }
     await loadConnectors()
     // Reload catalog only if the Gallery tab is currently active so we
@@ -3661,11 +3661,14 @@ document.getElementById('addConnectorBtn').addEventListener('click', () => {
   document.getElementById('connectorUrl').value = ''
   document.getElementById('connectorCmd').value = ''
   document.getElementById('connectorArgs').value = ''
-  document.getElementById('connectorType').value = 'remote'
+  document.getElementById('connectorType').value = 'stdio'
   document.getElementById('connectorScope').value = 'user'
-  document.getElementById('connectorUrlGroup').hidden = false
-  document.getElementById('connectorCmdGroup').hidden = true
-  document.getElementById('connectorArgsGroup').hidden = true
+  document.getElementById('connectorUrlGroup').hidden = true
+  document.getElementById('connectorCmdGroup').hidden = false
+  document.getElementById('connectorArgsGroup').hidden = false
+  document.getElementById('connectorEnvGroup').hidden = false
+  document.getElementById('connectorEnvList').innerHTML = ''
+  loadNewConnectorAgents()
   openModal(connectorModalOverlay)
 })
 document.getElementById('connectorModalClose').addEventListener('click', () => closeModal(connectorModalOverlay))
@@ -3675,10 +3678,11 @@ connectorDetailOverlay.addEventListener('click', (e) => { if (e.target === conne
 
 // Type toggle
 document.getElementById('connectorType').addEventListener('change', () => {
-  const isLocal = document.getElementById('connectorType').value === 'local'
-  document.getElementById('connectorUrlGroup').hidden = isLocal
-  document.getElementById('connectorCmdGroup').hidden = !isLocal
-  document.getElementById('connectorArgsGroup').hidden = !isLocal
+  const isStdio = document.getElementById('connectorType').value === 'stdio'
+  document.getElementById('connectorUrlGroup').hidden = isStdio
+  document.getElementById('connectorCmdGroup').hidden = !isStdio
+  document.getElementById('connectorArgsGroup').hidden = !isStdio
+  document.getElementById('connectorEnvGroup').hidden = !isStdio
 })
 
 // Default TRUE: if we never successfully read /api/connectors/status
@@ -3840,14 +3844,17 @@ function renderConnectors() {
 
   const globalScopes = ['global', 'plugin']
   const agentScopes = []
-  const projectScopes = []
+  const internalProjectScopes = []
+  const externalProjectScopes = []
   for (const scope of groups.keys()) {
     if (scope.startsWith('agent:')) agentScopes.push(scope)
-    else if (scope.startsWith('project:')) projectScopes.push(scope)
+    else if (scope.startsWith('project:external/')) externalProjectScopes.push(scope)
+    else if (scope.startsWith('project:')) internalProjectScopes.push(scope)
     else if (!globalScopes.includes(scope)) globalScopes.push(scope)
   }
   agentScopes.sort()
-  projectScopes.sort()
+  internalProjectScopes.sort()
+  externalProjectScopes.sort()
 
   const sourceLabels = {
     'claude.ai': 'claude.ai',
@@ -3930,11 +3937,11 @@ function renderConnectors() {
   }
   if (globalGrid.children.length > 0) connectorGrid.appendChild(globalGrid)
 
-  // === Ágensek ===
+  // === Ügynökök ===
   if (agentScopes.length > 0) {
     const agentHeading = document.createElement('div')
     agentHeading.className = 'connector-group-heading'
-    agentHeading.textContent = 'Ágensek'
+    agentHeading.textContent = 'Ügynökök'
     connectorGrid.appendChild(agentHeading)
 
     for (const ag of agentScopes) {
@@ -3943,16 +3950,33 @@ function renderConnectors() {
     }
   }
 
-  // === Projektek ===
-  if (projectScopes.length > 0) {
+  // === Projektek (belső) ===
+  if (internalProjectScopes.length > 0) {
     const projectHeading = document.createElement('div')
     projectHeading.className = 'connector-group-heading'
     projectHeading.textContent = 'Projektek'
     connectorGrid.appendChild(projectHeading)
 
-    for (const ps of projectScopes) {
-      const projLabel = ps.slice('project:'.length)
+    for (const ps of internalProjectScopes) {
+      const parts = ps.slice('project:'.length).split('/')
+      const projLabel = parts[parts.length - 1]
       renderCollapsible(projLabel, '📁', groups.get(ps), connectorGrid)
+    }
+  }
+
+  // === Külső projektek ===
+  if (externalProjectScopes.length > 0 || document.getElementById('externalPathsToggle')) {
+    const extHeading = document.createElement('div')
+    extHeading.className = 'connector-group-heading'
+    extHeading.textContent = 'Külső projektek'
+    connectorGrid.appendChild(extHeading)
+
+    const extPathsPanel = document.getElementById('externalPathsSection')
+    if (extPathsPanel) connectorGrid.appendChild(extPathsPanel)
+
+    for (const ps of externalProjectScopes) {
+      const projLabel = ps.slice('project:external/'.length)
+      renderCollapsible(projLabel, '📂', groups.get(ps), connectorGrid)
     }
   }
 }
@@ -4337,12 +4361,19 @@ async function openConnectorDetail(connector) {
     document.getElementById('connectorDetailInfo').innerHTML = '<p>Részletek betöltése sikertelen</p>'
   }
 
-  // Agent assignment. Marveen auto-loads global connectors via the project
-  // .mcp.json, so she shows up as a fixed disabled-checked entry; sub-agents
-  // need explicit assignment because the file gets copied into their dir.
   try {
-    const agentsRes = await fetch('/api/schedules/agents')
+    const [agentsRes, connectorsRes] = await Promise.all([
+      fetch('/api/schedules/agents'),
+      fetch('/api/connectors'),
+    ])
     const allAgents = await agentsRes.json()
+    const allConnectors = await connectorsRes.json()
+    const assignedAgents = new Set()
+    for (const c of allConnectors) {
+      if (c.name === connector.name && c.source === 'agent') {
+        assignedAgents.add(c.scope.replace('agent:', ''))
+      }
+    }
     const mainAgent = allAgents.find(a => a.name === 'marveen')
     const subAgents = allAgents.filter(a => a.name !== 'marveen')
 
@@ -4358,21 +4389,17 @@ async function openConnectorDetail(connector) {
       listEl.appendChild(item)
     }
     for (const agent of subAgents) {
+      const isAssigned = assignedAgents.has(agent.name)
       const item = document.createElement('div')
       item.className = 'connector-agent-item'
       item.innerHTML = `
-        <input type="checkbox" id="assign-${agent.name}" value="${agent.name}">
+        <input type="checkbox" id="assign-${agent.name}" value="${agent.name}" ${isAssigned ? 'checked' : ''}>
         <label for="assign-${agent.name}">${escapeHtml(agent.label || agent.name)}</label>
       `
       listEl.appendChild(item)
     }
     if (subAgents.length === 0 && !mainAgent) {
       listEl.innerHTML = '<p style="color:var(--text-muted);font-size:13px">Nincsenek hozzarendelheto ügynökök</p>'
-    } else if (subAgents.length === 0) {
-      const note = document.createElement('p')
-      note.style.cssText = 'color:var(--text-muted);font-size:12px;margin-top:8px'
-      note.textContent = 'Sub-agentekhez hozzárendelés a Csapat oldalon létrehozott új ügynök után érhető el.'
-      listEl.appendChild(note)
     }
   } catch {
     document.getElementById('connectorAgentList').innerHTML = ''
@@ -4393,21 +4420,56 @@ async function openConnectorDetail(connector) {
 
   // Assign button
   document.getElementById('connectorAssignBtn').onclick = async () => {
-    const checked = [...document.querySelectorAll('#connectorAgentList input:checked')].map(i => i.value)
-    if (checked.length === 0) { showToast('Válassz legalább egy ügynököt'); return }
+    const checked = [...document.querySelectorAll('#connectorAgentList input:checked:not(:disabled)')].map(i => i.value)
+    const allVisible = [...document.querySelectorAll('#connectorAgentList input:not(:disabled)')].map(i => i.value)
     try {
       await fetch(`/api/connectors/${encodeURIComponent(connector.name)}/assign`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ agents: checked }),
+        body: JSON.stringify({ agents: checked, allAgents: allVisible }),
       })
-      showToast('Connector hozzarendelve')
+      showToast('Ügynök-hozzárendelés frissítve')
+      closeModal(connectorDetailOverlay)
+      loadConnectors()
     } catch {
       showToast('Hiba a hozzárendelés során')
     }
   }
 
   openModal(connectorDetailOverlay)
+}
+
+// ENV row management for new connector form
+document.getElementById('connectorEnvAddBtn').addEventListener('click', () => {
+  const list = document.getElementById('connectorEnvList')
+  const row = document.createElement('div')
+  row.className = 'connector-env-row'
+  row.innerHTML = `
+    <input type="text" class="input env-key" placeholder="KULCS" style="flex:1">
+    <span style="color:var(--text-muted)">=</span>
+    <input type="text" class="input env-val" placeholder="érték" style="flex:2">
+    <button type="button" class="btn-link" style="color:var(--danger);padding:2px 6px">&times;</button>
+  `
+  row.querySelector('button').addEventListener('click', () => row.remove())
+  list.appendChild(row)
+})
+
+async function loadNewConnectorAgents() {
+  try {
+    const res = await fetch('/api/schedules/agents')
+    const agents = await res.json()
+    const list = document.getElementById('connectorNewAssignList')
+    list.innerHTML = ''
+    for (const agent of agents) {
+      const item = document.createElement('div')
+      item.className = 'connector-agent-item'
+      item.innerHTML = `
+        <input type="checkbox" id="new-assign-${agent.name}" value="${agent.name}">
+        <label for="new-assign-${agent.name}">${escapeHtml(agent.label || agent.name)}</label>
+      `
+      list.appendChild(item)
+    }
+  } catch { /* ignore */ }
 }
 
 // Save new connector
@@ -4419,13 +4481,23 @@ document.getElementById('saveConnectorBtn').addEventListener('click', async () =
   if (!name) { document.getElementById('connectorName').focus(); return }
 
   const data = { name, type, scope }
-  if (type === 'remote') {
+  if (type === 'http' || type === 'sse') {
     data.url = document.getElementById('connectorUrl').value.trim()
     if (!data.url) { document.getElementById('connectorUrl').focus(); return }
   } else {
     data.command = document.getElementById('connectorCmd').value.trim()
     data.args = document.getElementById('connectorArgs').value.trim()
     if (!data.command) { document.getElementById('connectorCmd').focus(); return }
+    const envRows = document.querySelectorAll('#connectorEnvList .connector-env-row')
+    if (envRows.length > 0) {
+      const env = {}
+      for (const row of envRows) {
+        const k = row.querySelector('.env-key').value.trim()
+        const v = row.querySelector('.env-val').value.trim()
+        if (k) env[k] = v
+      }
+      if (Object.keys(env).length > 0) data.env = env
+    }
   }
 
   const btn = document.getElementById('saveConnectorBtn')

--- a/web/index.html
+++ b/web/index.html
@@ -433,10 +433,10 @@
           </div>
         </div>
 
-        <div class="connector-external-paths">
+        <div class="connector-external-paths" id="externalPathsSection">
           <div class="connector-external-header" id="externalPathsToggle">
             <span class="connector-scope-toggle">▶</span>
-            Kulso projekt utvonalak <span class="connector-scope-count" id="externalPathCount">0</span>
+            Utvonalak <span class="connector-scope-count" id="externalPathCount">0</span>
           </div>
           <div class="connector-external-body" id="externalPathsBody" hidden>
             <div id="externalPathList"></div>
@@ -1330,8 +1330,9 @@
           <div class="form-group form-half">
             <label for="connectorType">Típus</label>
             <select id="connectorType">
-              <option value="remote">Távoli (HTTP URL)</option>
-              <option value="local">Lokális (parancs)</option>
+              <option value="stdio">stdio (parancs)</option>
+              <option value="http">HTTP (streamable)</option>
+              <option value="sse">SSE (legacy HTTP)</option>
             </select>
           </div>
           <div class="form-group form-half">
@@ -1353,6 +1354,15 @@
         <div class="form-group" id="connectorArgsGroup" hidden>
           <label for="connectorArgs">Argumentumok <span class="hint">(opcionális)</span></label>
           <input type="text" id="connectorArgs" placeholder="--port 3000">
+        </div>
+        <div class="form-group" id="connectorEnvGroup" hidden>
+          <label>Környezeti változók <span class="hint">(opcionális)</span></label>
+          <div id="connectorEnvList"></div>
+          <button type="button" class="btn-link" id="connectorEnvAddBtn" style="font-size:12px;margin-top:4px">+ Változó hozzáadása</button>
+        </div>
+        <div class="form-group" id="connectorAssignGroup">
+          <label>Hozzárendelés ügynökökhöz <span class="hint">(opcionális)</span></label>
+          <div id="connectorNewAssignList"></div>
         </div>
         <button class="btn-primary" id="saveConnectorBtn">
           <span class="btn-text">Hozzáadás</span>

--- a/web/index.html
+++ b/web/index.html
@@ -403,6 +403,8 @@
 
         <div class="connector-grid" id="connectorGrid"></div>
 
+        <div class="connector-group-heading" style="margin-top:24px">Eszközök</div>
+
         <div class="connector-external-paths">
           <div class="connector-external-header" id="githubReposToggle">
             <span class="connector-scope-toggle">▶</span>

--- a/web/style.css
+++ b/web/style.css
@@ -2799,9 +2799,7 @@ main {
 .connector-scope-grid[hidden] { display: none; }
 
 .connector-external-paths {
-  margin-top: 24px;
-  padding-top: 16px;
-  border-top: 1px solid var(--border);
+  margin-bottom: 12px;
 }
 .connector-external-header {
   display: flex;
@@ -2841,6 +2839,13 @@ main {
   padding: 2px 6px;
 }
 .connector-external-item button:hover { opacity: 0.7; }
+
+.connector-env-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
 
 .github-repo-item {
   display: flex;


### PR DESCRIPTION
## Summary
- **Delete from all scopes**: the DELETE handler only ran `claude mcp remove` for project and user scope, leaving agent-specific .mcp.json files, agent-project dirs, and external project configs untouched. Now iterates every config source and removes the connector from all of them.
- **Cache purge on delete**: connectors that only exist in the in-memory MCP list cache (ghost entries) can now be deleted.
- **Restore lost squash-merge changes**: the squash merge of #52 (e8fe4d2) only carried the first commit; five subsequent commits were lost:
  - Split "Projektek" into internal and "Külső projektek" sections (📁 vs 📂)
  - Rename "Ágensek" to "Ügynökök"
  - Pre-check agent assignment checkboxes for already-assigned agents
  - Sync unchecked agents on assign (remove connector from unchecked)
  - Connector types: stdio/http/sse instead of remote/local
  - Env vars and agent assignment in new connector form
  - Backend: search all config sources for connector assignment
  - Proper args splitting for stdio connectors
- **UI separation**: GitHub repos and Vault panels now have their own "Eszközök" heading, separated from "Külső projektek"

## Test plan
- [x] Delete a connector assigned to multiple agents -- disappears from all
- [x] Delete a ghost entry (cache-only) -- disappears after refresh
- [x] External projects appear under separate "Külső projektek" heading with 📂 icon
- [x] Internal projects appear under "Projektek" with 📁 icon
- [x] GitHub repos and Vault appear under "Eszközök", not under "Külső projektek"
- [x] Agent assignment pre-checks existing assignments
- [x] Unchecking an agent removes the connector from that agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)