### PR TITLE
feat(web): vault env auto-sync and sensitive key scan & import

### DIFF
--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -15,6 +15,10 @@ import { readBody, json } from '../http-helpers.js'
 import { shellEscape } from '../sanitize.js'
 import { getExternalProjectPaths, addExternalProjectPath, removeExternalProjectPath, getGitHubRepos, installGitHubRepo, removeGitHubRepo, updateGitHubRepo, detectRequiredEnvVars } from '../dashboard-settings.js'
 import { listSecrets, setSecret, getSecret, deleteSecret } from '../vault.js'
+import {
+  getBindings, addBinding, removeBinding, removeBindingsForSecret,
+  syncSecret, syncAllBindings, scanMcpConfigs,
+} from '../vault-bindings.js'
 import type { RouteContext } from './types.js'
 
 export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
@@ -491,7 +495,8 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
     const { id, label, value } = JSON.parse(body.toString()) as { id: string, label: string, value: string }
     if (!id?.trim() || !value) { json(res, { error: 'id and value required' }, 400); return true }
     setSecret(id.trim(), label || id.trim(), value)
-    json(res, { ok: true })
+    const syncResult = syncSecret(id.trim())
+    json(res, { ok: true, synced: syncResult.updated })
     return true
   }
 
@@ -507,7 +512,91 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   if (vaultMatch && method === 'DELETE') {
     const id = decodeURIComponent(vaultMatch[1])
     if (!deleteSecret(id)) { json(res, { error: 'Not found' }, 404); return true }
+    removeBindingsForSecret(id)
     json(res, { ok: true })
+    return true
+  }
+
+  // === Vault Bindings ===
+  if (path === '/api/vault/bindings' && method === 'GET') {
+    json(res, { bindings: getBindings() })
+    return true
+  }
+
+  if (path === '/api/vault/bindings' && method === 'POST') {
+    const body = await readBody(req)
+    const data = JSON.parse(body.toString()) as {
+      vaultSecretId: string
+      envVar: string
+      targets: Array<{ mcpFilePath: string, serverName: string }>
+    }
+    if (!data.vaultSecretId || !data.envVar || !data.targets?.length) {
+      json(res, { error: 'vaultSecretId, envVar, and targets required' }, 400)
+      return true
+    }
+    addBinding(data)
+    const syncResult = syncSecret(data.vaultSecretId)
+    json(res, { ok: true, synced: syncResult.updated, errors: syncResult.errors })
+    return true
+  }
+
+  const bindingDeleteMatch = path.match(/^\/api\/vault\/bindings\/([^/]+)\/([^/]+)$/)
+  if (bindingDeleteMatch && method === 'DELETE') {
+    const secretId = decodeURIComponent(bindingDeleteMatch[1])
+    const envVar = decodeURIComponent(bindingDeleteMatch[2])
+    if (!removeBinding(secretId, envVar)) { json(res, { error: 'Binding not found' }, 404); return true }
+    json(res, { ok: true })
+    return true
+  }
+
+  if (path === '/api/vault/sync' && method === 'POST') {
+    const result = syncAllBindings()
+    json(res, { ok: true, ...result })
+    return true
+  }
+
+  // === Vault Scan & Import ===
+  if (path === '/api/vault/scan' && method === 'GET') {
+    json(res, { findings: scanMcpConfigs() })
+    return true
+  }
+
+  if (path === '/api/vault/import' && method === 'POST') {
+    const body = await readBody(req)
+    const { imports: importRequests } = JSON.parse(body.toString()) as {
+      imports: Array<{
+        serverName: string
+        envVar: string
+        vaultId: string
+        label: string
+        createBinding: boolean
+        targets: Array<{ mcpFilePath: string, serverName: string }>
+      }>
+    }
+    let imported = 0
+    let bound = 0
+    const errors: string[] = []
+    for (const imp of importRequests) {
+      let value: string | null = null
+      for (const target of imp.targets) {
+        try {
+          const content = JSON.parse(readFileOr(target.mcpFilePath, '{}'))
+          const envVal = content?.mcpServers?.[target.serverName]?.env?.[imp.envVar]
+          if (envVal && typeof envVal === 'string') { value = envVal; break }
+        } catch { /* skip */ }
+      }
+      if (!value) {
+        errors.push(`Could not read value for ${imp.envVar} from ${imp.serverName}`)
+        continue
+      }
+      setSecret(imp.vaultId, imp.label, value)
+      imported++
+      if (imp.createBinding && imp.targets.length > 0) {
+        addBinding({ vaultSecretId: imp.vaultId, envVar: imp.envVar, targets: imp.targets })
+        bound++
+      }
+    }
+    json(res, { ok: true, imported, bound, errors })
     return true
   }
 

--- a/src/web/vault-bindings.ts
+++ b/src/web/vault-bindings.ts
@@ -1,0 +1,229 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, basename } from 'node:path'
+import { homedir } from 'node:os'
+import { PROJECT_ROOT } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+import { readFileOr, AGENTS_BASE_DIR, listAgentNames } from './agent-config.js'
+import { getSecret, listSecrets } from './vault.js'
+import { getExternalProjectPaths } from './dashboard-settings.js'
+import { logger } from '../logger.js'
+
+const BINDINGS_PATH = join(PROJECT_ROOT, 'store', 'vault-bindings.json')
+
+export interface VaultBindingTarget {
+  mcpFilePath: string
+  serverName: string
+}
+
+export interface VaultBinding {
+  vaultSecretId: string
+  envVar: string
+  targets: VaultBindingTarget[]
+}
+
+interface BindingsStore {
+  bindings: VaultBinding[]
+}
+
+const SENSITIVE_PATTERNS = [
+  /_KEY$/i, /_TOKEN$/i, /_SECRET$/i, /_PASSWORD$/i, /_PASS$/i,
+  /^API_/i, /^AUTH_/i, /^OAUTH_/i,
+  /PASSWORD/i, /CREDENTIAL/i, /ACCESS_KEY/i,
+]
+
+const NON_SENSITIVE_VALUE_PATTERNS = [
+  /^(true|false)$/i,
+  /^https?:\/\//,
+  /^\d+$/,
+  /^\//,
+  /^\$\{/,
+]
+
+export interface ScanFinding {
+  mcpFilePath: string
+  serverName: string
+  envVar: string
+  maskedValue: string
+  suggestedVaultId: string
+  alreadyInVault: boolean
+  existingVaultId?: string
+}
+
+export interface SyncResult {
+  updated: number
+  errors: string[]
+}
+
+function readBindings(): BindingsStore {
+  try { return JSON.parse(readFileSync(BINDINGS_PATH, 'utf-8')) }
+  catch { return { bindings: [] } }
+}
+
+function writeBindings(store: BindingsStore): void {
+  atomicWriteFileSync(BINDINGS_PATH, JSON.stringify(store, null, 2) + '\n')
+}
+
+export function getBindings(): VaultBinding[] {
+  return readBindings().bindings
+}
+
+export function addBinding(binding: VaultBinding): void {
+  const store = readBindings()
+  const idx = store.bindings.findIndex(
+    b => b.vaultSecretId === binding.vaultSecretId && b.envVar === binding.envVar,
+  )
+  if (idx >= 0) {
+    store.bindings[idx] = binding
+  } else {
+    store.bindings.push(binding)
+  }
+  writeBindings(store)
+}
+
+export function removeBinding(vaultSecretId: string, envVar: string): boolean {
+  const store = readBindings()
+  const before = store.bindings.length
+  store.bindings = store.bindings.filter(
+    b => !(b.vaultSecretId === vaultSecretId && b.envVar === envVar),
+  )
+  if (store.bindings.length === before) return false
+  writeBindings(store)
+  return true
+}
+
+export function removeBindingsForSecret(vaultSecretId: string): void {
+  const store = readBindings()
+  store.bindings = store.bindings.filter(b => b.vaultSecretId !== vaultSecretId)
+  writeBindings(store)
+}
+
+export function collectAllMcpFilePaths(): Array<{ path: string, label: string }> {
+  const paths: Array<{ path: string, label: string }> = []
+  const projectMcp = join(PROJECT_ROOT, '.mcp.json')
+  if (existsSync(projectMcp)) paths.push({ path: projectMcp, label: 'project' })
+  const userMcp = join(homedir(), '.claude.json')
+  if (existsSync(userMcp)) paths.push({ path: userMcp, label: 'user' })
+
+  for (const agentName of listAgentNames()) {
+    const agentMcp = join(AGENTS_BASE_DIR, agentName, '.mcp.json')
+    if (existsSync(agentMcp)) paths.push({ path: agentMcp, label: `agent:${agentName}` })
+    const projectsDir = join(AGENTS_BASE_DIR, agentName, 'projects')
+    if (existsSync(projectsDir)) {
+      try {
+        for (const proj of readdirSync(projectsDir)) {
+          if (!statSync(join(projectsDir, proj)).isDirectory()) continue
+          const projMcp = join(projectsDir, proj, '.mcp.json')
+          if (existsSync(projMcp)) paths.push({ path: projMcp, label: `project:${agentName}/${proj}` })
+        }
+      } catch { /* ignore */ }
+    }
+  }
+  for (const extPath of getExternalProjectPaths()) {
+    const extMcp = join(extPath, '.mcp.json')
+    if (existsSync(extMcp)) paths.push({ path: extMcp, label: `external:${basename(extPath)}` })
+  }
+  return paths
+}
+
+function maskValue(val: string): string {
+  if (val.length <= 6) return '***'
+  return val.slice(0, 3) + '...' + val.slice(-3)
+}
+
+function looksLikeSensitiveValue(val: string): boolean {
+  if (!val || val.length < 8) return false
+  for (const p of NON_SENSITIVE_VALUE_PATTERNS) {
+    if (p.test(val)) return false
+  }
+  return true
+}
+
+function looksLikeSensitiveKey(key: string): boolean {
+  return SENSITIVE_PATTERNS.some(p => p.test(key))
+}
+
+export function scanMcpConfigs(): ScanFinding[] {
+  const findings: ScanFinding[] = []
+  const mcpFiles = collectAllMcpFilePaths()
+  const existingSecrets = listSecrets()
+
+  const vaultValues = new Map<string, string>()
+  for (const s of existingSecrets) {
+    const val = getSecret(s.id)
+    if (val) vaultValues.set(val, s.id)
+  }
+
+  for (const { path: mcpPath } of mcpFiles) {
+    try {
+      const parsed = JSON.parse(readFileOr(mcpPath, '{}'))
+      const servers = parsed.mcpServers || {}
+      for (const [serverName, cfg] of Object.entries(servers) as Array<[string, any]>) {
+        const env = cfg?.env || {}
+        for (const [envVar, envVal] of Object.entries(env) as Array<[string, string]>) {
+          if (!looksLikeSensitiveKey(envVar)) continue
+          if (!looksLikeSensitiveValue(String(envVal))) continue
+
+          const existingVaultId = vaultValues.get(String(envVal))
+          findings.push({
+            mcpFilePath: mcpPath,
+            serverName,
+            envVar,
+            maskedValue: maskValue(String(envVal)),
+            suggestedVaultId: `${serverName}-${envVar}`,
+            alreadyInVault: !!existingVaultId,
+            existingVaultId,
+          })
+        }
+      }
+    } catch { /* skip unreadable files */ }
+  }
+  return findings
+}
+
+export function syncSecret(vaultSecretId: string): SyncResult {
+  const bindings = getBindings().filter(b => b.vaultSecretId === vaultSecretId)
+  if (bindings.length === 0) return { updated: 0, errors: [] }
+
+  const value = getSecret(vaultSecretId)
+  if (value === null) return { updated: 0, errors: [`Vault secret "${vaultSecretId}" not found`] }
+
+  let updated = 0
+  const errors: string[] = []
+
+  for (const binding of bindings) {
+    for (const target of binding.targets) {
+      try {
+        const content = JSON.parse(readFileOr(target.mcpFilePath, '{}'))
+        if (!content.mcpServers?.[target.serverName]) {
+          errors.push(`Server "${target.serverName}" not found in ${target.mcpFilePath}`)
+          continue
+        }
+        if (!content.mcpServers[target.serverName].env) {
+          content.mcpServers[target.serverName].env = {}
+        }
+        content.mcpServers[target.serverName].env[binding.envVar] = value
+        atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
+        updated++
+      } catch (err: any) {
+        errors.push(`Failed to update ${target.mcpFilePath}: ${err.message}`)
+      }
+    }
+  }
+
+  if (updated > 0) logger.info({ vaultSecretId, updated }, 'Vault secret synced to .mcp.json files')
+  return { updated, errors }
+}
+
+export function syncAllBindings(): SyncResult {
+  const allBindings = getBindings()
+  const secretIds = new Set(allBindings.map(b => b.vaultSecretId))
+  let totalUpdated = 0
+  const allErrors: string[] = []
+
+  for (const id of secretIds) {
+    const result = syncSecret(id)
+    totalUpdated += result.updated
+    allErrors.push(...result.errors)
+  }
+  return { updated: totalUpdated, errors: allErrors }
+}

--- a/web/app.js
+++ b/web/app.js
@@ -4162,12 +4162,20 @@ function showEnvVarModal(envVars) {
 // --- Vault Page ---
 let _vaultSecrets = []
 
+let _vaultBindings = []
+
 async function loadVaultPage() {
   try {
-    const res = await fetch('/api/vault')
-    const data = await res.json()
-    _vaultSecrets = data.secrets || []
+    const [secretsRes, bindingsRes] = await Promise.all([
+      fetch('/api/vault'),
+      fetch('/api/vault/bindings'),
+    ])
+    const secretsData = await secretsRes.json()
+    const bindingsData = await bindingsRes.json()
+    _vaultSecrets = secretsData.secrets || []
+    _vaultBindings = bindingsData.bindings || []
     document.getElementById('vaultStatTotal').textContent = String(_vaultSecrets.length)
+    document.getElementById('vaultStatBindings').textContent = String(_vaultBindings.length)
     renderVaultGrid(_vaultSecrets)
   } catch { /* ignore */ }
 }
@@ -4182,7 +4190,9 @@ function renderVaultGrid(secrets) {
     const card = document.createElement('div')
     card.className = 'vault-card'
     const date = new Date(s.updatedAt).toLocaleDateString('hu-HU')
-    card.innerHTML = `<div class="vault-card-header"><div class="vault-card-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div><div class="vault-card-title"><div class="vault-card-id">${escapeHtml(s.id)}</div>${s.label !== s.id ? `<div class="vault-card-label">${escapeHtml(s.label)}</div>` : ''}</div><div class="vault-card-meta">${date}</div></div><div class="vault-card-actions"><button class="btn-secondary btn-compact vault-card-reveal" data-id="${escapeHtml(s.id)}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg> Mutat</button><button class="btn-secondary btn-compact vault-card-delete" data-id="${escapeHtml(s.id)}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg> Torles</button></div>`
+    const bindingCount = _vaultBindings.filter(b => b.vaultSecretId === s.id).length
+    const bindingBadge = bindingCount > 0 ? `<span class="vault-binding-badge" title="${bindingCount} kotes">${bindingCount} kotes</span>` : ''
+    card.innerHTML = `<div class="vault-card-header"><div class="vault-card-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div><div class="vault-card-title"><div class="vault-card-id">${escapeHtml(s.id)} ${bindingBadge}</div>${s.label !== s.id ? `<div class="vault-card-label">${escapeHtml(s.label)}</div>` : ''}</div><div class="vault-card-meta">${date}</div></div><div class="vault-card-actions"><button class="btn-secondary btn-compact vault-card-reveal" data-id="${escapeHtml(s.id)}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg> Mutat</button><button class="btn-secondary btn-compact vault-card-delete" data-id="${escapeHtml(s.id)}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg> Torles</button></div>`
     list.appendChild(card)
   }
   list.querySelectorAll('.vault-card-reveal').forEach(btn => {
@@ -4251,6 +4261,158 @@ function renderVaultGrid(secrets) {
     const q = e.target.value.toLowerCase().trim()
     if (!q) { renderVaultGrid(_vaultSecrets); return }
     renderVaultGrid(_vaultSecrets.filter(s => s.id.toLowerCase().includes(q) || s.label.toLowerCase().includes(q)))
+  })
+})()
+
+// --- Vault Scan & Import ---
+;(function wireVaultScan() {
+  const scanBtn = document.getElementById('vaultScanBtn')
+  const syncBtn = document.getElementById('vaultSyncBtn')
+  const overlay = document.getElementById('vaultScanOverlay')
+  const closeBtn = document.getElementById('vaultScanClose')
+  const importBtn = document.getElementById('vaultScanImportBtn')
+  if (!scanBtn || !overlay) return
+
+  scanBtn.addEventListener('click', async () => {
+    scanBtn.disabled = true
+    scanBtn.textContent = 'Kereses...'
+    try {
+      const res = await fetch('/api/vault/scan')
+      const data = await res.json()
+      const findings = data.findings || []
+      renderScanResults(findings)
+      overlay.hidden = false
+    } finally {
+      scanBtn.disabled = false
+      scanBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg> Scan &amp; Import'
+    }
+  })
+
+  closeBtn?.addEventListener('click', () => { overlay.hidden = true })
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.hidden = true })
+
+  syncBtn?.addEventListener('click', async () => {
+    syncBtn.disabled = true
+    syncBtn.textContent = 'Szinkron...'
+    try {
+      const res = await fetch('/api/vault/sync', { method: 'POST' })
+      const data = await res.json()
+      if (data.updated > 0) {
+        showToast(`${data.updated} .mcp.json frissitve`)
+      } else {
+        showToast('Nincs szinkronizalando kotes')
+      }
+      if (data.errors?.length) {
+        showToast('Hibak: ' + data.errors.join(', '))
+      }
+    } finally {
+      syncBtn.disabled = false
+      syncBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg> Szinkron'
+    }
+  })
+
+  function renderScanResults(findings) {
+    const results = document.getElementById('vaultScanResults')
+    const empty = document.getElementById('vaultScanEmpty')
+    const footer = document.getElementById('vaultScanFooter')
+    results.innerHTML = ''
+
+    const actionable = findings.filter(f => !f.alreadyInVault)
+    if (actionable.length === 0) {
+      empty.hidden = false
+      footer.hidden = true
+      if (findings.length > 0) {
+        empty.textContent = `${findings.length} erzekeny ertek talalva, de mind mar a Vault-ban van.`
+      }
+      return
+    }
+    empty.hidden = true
+    footer.hidden = false
+
+    const grouped = new Map()
+    for (const f of actionable) {
+      const key = `${f.serverName}|${f.envVar}`
+      if (!grouped.has(key)) grouped.set(key, { ...f, allTargets: [] })
+      grouped.get(key).allTargets.push({ mcpFilePath: f.mcpFilePath, serverName: f.serverName })
+    }
+
+    for (const [key, f] of grouped) {
+      const row = document.createElement('div')
+      row.className = 'vault-scan-row'
+      row.innerHTML = `
+        <label class="vault-scan-check">
+          <input type="checkbox" checked data-key="${escapeHtml(key)}">
+        </label>
+        <div class="vault-scan-info">
+          <div class="vault-scan-server">${escapeHtml(f.serverName)}</div>
+          <div class="vault-scan-env">${escapeHtml(f.envVar)} = <code>${escapeHtml(f.maskedValue)}</code></div>
+          <div class="vault-scan-targets">${f.allTargets.length} fajlban</div>
+        </div>
+        <div class="vault-scan-id">
+          <input type="text" class="input vault-scan-vault-id" value="${escapeHtml(f.suggestedVaultId)}" data-key="${escapeHtml(key)}" style="font-size:12px;width:180px">
+        </div>
+      `
+      results.appendChild(row)
+    }
+  }
+
+  importBtn?.addEventListener('click', async () => {
+    const results = document.getElementById('vaultScanResults')
+    const rows = results.querySelectorAll('.vault-scan-row')
+    const imports = []
+
+    const scanRes = await fetch('/api/vault/scan')
+    const scanData = await scanRes.json()
+    const allFindings = scanData.findings || []
+
+    for (const row of rows) {
+      const cb = row.querySelector('input[type="checkbox"]')
+      if (!cb?.checked) continue
+      const key = cb.getAttribute('data-key')
+      const [serverName, envVar] = key.split('|')
+      const vaultIdInput = row.querySelector('.vault-scan-vault-id')
+      const vaultId = vaultIdInput?.value?.trim() || key
+
+      const matchingFindings = allFindings.filter(
+        f => f.serverName === serverName && f.envVar === envVar && !f.alreadyInVault,
+      )
+      if (matchingFindings.length === 0) continue
+
+      imports.push({
+        serverName,
+        envVar,
+        vaultId,
+        label: `${envVar} (${serverName})`,
+        createBinding: true,
+        targets: matchingFindings.map(f => ({ mcpFilePath: f.mcpFilePath, serverName: f.serverName })),
+      })
+    }
+
+    if (imports.length === 0) { showToast('Nincs kivalasztott elem'); return }
+
+    importBtn.disabled = true
+    importBtn.textContent = 'Importalas...'
+
+    try {
+      const res = await fetch('/api/vault/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ imports }),
+      })
+      const data = await res.json()
+      if (data.imported > 0) {
+        showToast(`${data.imported} kulcs importalva, ${data.bound} kotes letrehozva`)
+      }
+      if (data.errors?.length) {
+        showToast('Hibak: ' + data.errors.join(', '))
+      }
+    } finally {
+      importBtn.disabled = false
+      importBtn.textContent = 'Kivalasztottak importalasa'
+    }
+    overlay.hidden = true
+    loadVaultPage()
+    loadVault()
   })
 })()
 

--- a/web/index.html
+++ b/web/index.html
@@ -600,12 +600,22 @@
             <h1>Vault</h1>
             <p class="subtitle">Titkositott kulcsok es API tokenek</p>
           </div>
-          <button class="btn-primary btn-compact" id="vaultPageNewBtn">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-              <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
-            </svg>
-            Uj kulcs
-          </button>
+          <div style="display:flex;gap:8px">
+            <button class="btn-secondary btn-compact" id="vaultScanBtn" title="MCP konfigok atvizsgalasa erzekeny kulcsokert">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+              Scan &amp; Import
+            </button>
+            <button class="btn-secondary btn-compact" id="vaultSyncBtn" title="Vault ertekek szinkronizalasa a .mcp.json fajlokba">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+              Szinkron
+            </button>
+            <button class="btn-primary btn-compact" id="vaultPageNewBtn">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+              </svg>
+              Uj kulcs
+            </button>
+          </div>
         </div>
         <div class="info-box">
           <strong>AES-256-GCM</strong> titkositas &middot; A kulcsok kizarolag a helyi gepen tarolodnak, soha nem hagyjak el a rendszert. MCP szerverek telepitesekor a szukseges API kulcsokat itt tarolhatod biztonsagosan.
@@ -620,6 +630,10 @@
         <div class="stat-card">
           <div class="stat-value" id="vaultStatEncryption">AES-256</div>
           <div class="stat-label">Titkositas</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" id="vaultStatBindings">0</div>
+          <div class="stat-label">Kotes</div>
         </div>
         <div class="stat-card">
           <div class="stat-value" id="vaultStatStorage">Helyi</div>
@@ -669,6 +683,24 @@
         </svg>
         <p>Meg nincs tarolt kulcs</p>
         <p class="vault-empty-hint">Adj hozza egyet az "Uj kulcs" gombbal</p>
+      </div>
+
+      <!-- Scan modal -->
+      <div class="modal-overlay" id="vaultScanOverlay" hidden>
+        <div class="modal" style="max-width:700px">
+          <div class="modal-header">
+            <h2>MCP titkok keresese</h2>
+            <button class="modal-close" id="vaultScanClose">&times;</button>
+          </div>
+          <div class="modal-body">
+            <p class="vault-scan-desc">A rendszer atvizsgalja az osszes .mcp.json fajlt es megkeresi az erzekeny konfiguracios ertekeket (API kulcsok, tokenek, jelszo-szeru ertekek).</p>
+            <div id="vaultScanResults"></div>
+            <div id="vaultScanEmpty" hidden style="text-align:center;color:var(--text-muted);padding:24px">Nem talaltam erzekeny erteket a konfiguraciokban.</div>
+          </div>
+          <div class="modal-footer" id="vaultScanFooter" hidden>
+            <button class="btn-primary" id="vaultScanImportBtn">Kivalasztottak importalasa</button>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/web/style.css
+++ b/web/style.css
@@ -3048,6 +3048,65 @@ main {
 .vault-empty p { margin: 4px 0; font-size: 14px; }
 .vault-empty-hint { font-size: 12px !important; opacity: 0.6; }
 
+.vault-binding-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--accent);
+  color: white;
+  vertical-align: middle;
+  margin-left: 6px;
+}
+
+.vault-scan-desc {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+}
+.vault-scan-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 6px;
+  background: var(--bg-card);
+}
+.vault-scan-check { flex-shrink: 0; }
+.vault-scan-info { flex: 1; min-width: 0; }
+.vault-scan-server {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.vault-scan-env {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: monospace;
+}
+.vault-scan-env code {
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+.vault-scan-targets {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.vault-scan-id { flex-shrink: 0; }
+
+.modal-footer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .modal-overlay {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- **Vault bindings**: link vault secrets to MCP connector env vars. When a vault secret is updated, its decrypted value automatically syncs to all bound `.mcp.json` files
- **Scan & Import**: dashboard button scans all `.mcp.json` files for sensitive env vars (`*_KEY`, `*_TOKEN`, `*_SECRET`, etc.) and imports them into the encrypted vault with binding auto-creation
- **Manual sync**: force re-sync all vault bindings to `.mcp.json` files via dashboard button
- Plaintext values never reach the browser -- the server reads them directly from config files during import

## New files
- `src/web/vault-bindings.ts` -- bindings store, scan logic, sync engine

## New API endpoints
- `GET/POST/DELETE /api/vault/bindings` -- manage vault-to-env bindings
- `POST /api/vault/sync` -- force sync all bindings
- `GET /api/vault/scan` -- scan configs for sensitive env vars
- `POST /api/vault/import` -- server-side import from .mcp.json to vault

## Test plan
- [ ] Add a vault secret, create a binding to a connector env var, verify .mcp.json is updated
- [ ] Update a vault secret, verify bound .mcp.json files auto-update
- [ ] Click "Scan & Import", verify sensitive env vars are detected
- [ ] Import detected keys, verify they appear in vault with bindings
- [ ] Click "Szinkron", verify all bindings are re-synced
- [ ] Delete a vault secret, verify its bindings are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)