### PR TITLE
feat(agent-process): per-agent CLAUDE_CONFIG_DIR via agent-config.json

### DIFF
--- a/src/__tests__/claude-config-dir.test.ts
+++ b/src/__tests__/claude-config-dir.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest'
+import { resolveClaudeConfigDir } from '../web/agent-config.js'
+
+// Stable fake homedir so the expansion path is identical across hosts.
+const HOME = '/tmp/fake-home'
+
+describe('resolveClaudeConfigDir -- guard rails', () => {
+  it('returns null for empty JSON', () => {
+    expect(resolveClaudeConfigDir('{}', HOME)).toBeNull()
+  })
+
+  it('returns null for unparseable JSON', () => {
+    expect(resolveClaudeConfigDir('not json', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('', HOME)).toBeNull()
+  })
+
+  it('returns null when JSON parses to non-object (array, primitive, null)', () => {
+    expect(resolveClaudeConfigDir('null', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('[]', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('"string"', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('42', HOME)).toBeNull()
+  })
+
+  it('returns null when claudeConfigDir field is missing', () => {
+    expect(resolveClaudeConfigDir('{"model":"sonnet"}', HOME)).toBeNull()
+  })
+
+  it('returns null when claudeConfigDir is not a string', () => {
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":null}', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":42}', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":true}', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":[]}', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":{}}', HOME)).toBeNull()
+  })
+
+  it('returns null for empty or whitespace-only string', () => {
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":""}', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":"   "}', HOME)).toBeNull()
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":"\\t\\n"}', HOME)).toBeNull()
+  })
+})
+
+describe('resolveClaudeConfigDir -- tilde expansion', () => {
+  it('expands a bare ~ to the home directory', () => {
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":"~"}', HOME)).toBe(HOME)
+  })
+
+  it('expands ~/ prefix against the home directory', () => {
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":"~/.claude-coding"}', HOME))
+      .toBe('/tmp/fake-home/.claude-coding')
+  })
+
+  it('expands ~/ even with nested subpaths', () => {
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":"~/configs/claude/alt"}', HOME))
+      .toBe('/tmp/fake-home/configs/claude/alt')
+  })
+
+  it('rejects a tilde in the middle of the string', () => {
+    // The runtime shell would re-expand mid-string tildes at assignment
+    // time (`X=/opt/foo~bar` becomes `X=/opt/foo/var/<...>` if `~bar` is a
+    // real account), so the resolver rejects them rather than silently
+    // routing the launcher elsewhere.
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":"/opt/foo~bar"}', HOME))
+      .toBeNull()
+  })
+})
+
+describe('resolveClaudeConfigDir -- character whitelist', () => {
+  // The launcher inlines the path into a nested-quoted tmux command, so the
+  // path actually lands partly inside and partly outside double-quote
+  // context. We allow only a conservative whitelist of characters that
+  // survive both layers safely: alphanumerics, dot, slash, hyphen,
+  // underscore, tilde.
+  const baseJson = (v: string) =>
+    `{"claudeConfigDir":${JSON.stringify(v)}}`
+
+  it('rejects values containing a double quote', () => {
+    expect(resolveClaudeConfigDir(baseJson('~/x";rm -rf /tmp/y;"'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs/with"quote'), HOME)).toBeNull()
+  })
+
+  it('rejects values containing a single quote', () => {
+    expect(resolveClaudeConfigDir(baseJson("/abs/with'quote"), HOME)).toBeNull()
+  })
+
+  it('rejects values containing parentheses (subshell when unquoted)', () => {
+    expect(resolveClaudeConfigDir(baseJson('/abs/with(parens)'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('~/foo(bar'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('~/foo)bar'), HOME)).toBeNull()
+  })
+
+  it('rejects values containing whitespace (would split the unquoted segment)', () => {
+    expect(resolveClaudeConfigDir(baseJson('/abs path/with spaces'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs\twith\ttabs'), HOME)).toBeNull()
+  })
+
+  it('rejects values containing a dollar sign (variable expansion)', () => {
+    expect(resolveClaudeConfigDir(baseJson('/abs/$HOME/x'), HOME)).toBeNull()
+  })
+
+  it('rejects values containing a backtick (command substitution)', () => {
+    expect(resolveClaudeConfigDir(baseJson('/abs/`whoami`/x'), HOME)).toBeNull()
+  })
+
+  it('rejects values containing a semicolon (command separator)', () => {
+    expect(resolveClaudeConfigDir(baseJson('/abs;rm -rf /tmp/x'), HOME)).toBeNull()
+  })
+
+  it('rejects values containing a backslash', () => {
+    expect(resolveClaudeConfigDir(baseJson('/abs\\path'), HOME)).toBeNull()
+  })
+
+  it('rejects values containing a newline or carriage return', () => {
+    expect(resolveClaudeConfigDir(baseJson('/abs\nbad'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs\rbad'), HOME)).toBeNull()
+  })
+
+  it('rejects other shell-significant characters (&, |, *, ?, <, >, !)', () => {
+    expect(resolveClaudeConfigDir(baseJson('/abs&bg'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs|pipe'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs*glob'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs?glob'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs<redir'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs>redir'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs!hist'), HOME)).toBeNull()
+  })
+
+  it('accepts a path with a hyphen, dot, underscore (common in real names)', () => {
+    expect(resolveClaudeConfigDir(baseJson('~/.claude-coding_v2'), HOME))
+      .toBe('/tmp/fake-home/.claude-coding_v2')
+  })
+
+  it('accepts an alphanumeric absolute path', () => {
+    expect(resolveClaudeConfigDir(baseJson('/var/lib/claude_alt-config2'), HOME))
+      .toBe('/var/lib/claude_alt-config2')
+  })
+})
+
+describe('resolveClaudeConfigDir -- parent-traversal rejection', () => {
+  // path.join collapses `..` segments silently, so without this guard a
+  // value like "~/../../../etc/passwd" would resolve to "/etc/passwd"
+  // instead of staying under the home directory. The operator can still
+  // point at any absolute path outside home -- this just rejects the
+  // ".."-laundered version, which is almost always a config typo.
+  const baseJson = (v: string) =>
+    `{"claudeConfigDir":${JSON.stringify(v)}}`
+
+  it('rejects a tilde path that escapes home via `..`', () => {
+    expect(resolveClaudeConfigDir(baseJson('~/../../../etc/passwd'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('~/../etc'), HOME)).toBeNull()
+  })
+
+  it('rejects an absolute path containing `..` segments', () => {
+    expect(resolveClaudeConfigDir(baseJson('/var/lib/foo/../bar'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('/abs/path/..'), HOME)).toBeNull()
+  })
+
+  it('rejects a relative path with `..` segments', () => {
+    expect(resolveClaudeConfigDir(baseJson('../escape'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('foo/../bar'), HOME)).toBeNull()
+  })
+
+  it('accepts paths where `..` appears only inside a longer segment', () => {
+    // e.g. ".." is not a SEGMENT here, just a substring. We only reject
+    // proper path segments equal to `..`, not arbitrary occurrences.
+    expect(resolveClaudeConfigDir(baseJson('/abs/path..foo'), HOME))
+      .toBe('/abs/path..foo')
+    expect(resolveClaudeConfigDir(baseJson('/abs/foo..bar/baz'), HOME))
+      .toBe('/abs/foo..bar/baz')
+  })
+
+  it('accepts a legitimate absolute path outside home', () => {
+    // Home-escape via `..` is rejected, but operators can still point at
+    // any absolute path they like (e.g. a system-wide config dir).
+    expect(resolveClaudeConfigDir(baseJson('/var/lib/claude-coding'), HOME))
+      .toBe('/var/lib/claude-coding')
+  })
+
+  // Only `..` is treated as a traversal segment. `.` and `//` are accepted
+  // because they are no-op path components -- the OS and `path.join`
+  // normalize them away without altering where the path points. Documented
+  // as tests so future reviewers do not need to reverse-engineer this.
+
+  it('accepts a tilde path with a trailing single dot (path.join normalizes)', () => {
+    // `~/foo/.` -> path.join expands AND normalizes -> `<home>/foo`.
+    expect(resolveClaudeConfigDir(baseJson('~/foo/.'), HOME))
+      .toBe('/tmp/fake-home/foo')
+  })
+
+  it('accepts a path containing a single-dot segment in the middle', () => {
+    // Absolute paths are returned verbatim, so the `.` is preserved in the
+    // string and the OS resolves it at use time.
+    expect(resolveClaudeConfigDir(baseJson('/var/lib/./claude'), HOME))
+      .toBe('/var/lib/./claude')
+  })
+
+  it('accepts a path with consecutive slashes (`//`)', () => {
+    // Empty segments from doubled slashes are also no-ops; we leave them
+    // in the absolute-path string for the OS to normalize at use time.
+    expect(resolveClaudeConfigDir(baseJson('/var/lib//claude'), HOME))
+      .toBe('/var/lib//claude')
+  })
+})
+
+describe('resolveClaudeConfigDir -- absolute and relative paths', () => {
+  it('returns absolute paths verbatim', () => {
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":"/abs/path"}', HOME))
+      .toBe('/abs/path')
+  })
+
+  it('returns relative paths verbatim (caller responsibility)', () => {
+    // Relative paths are unusual but not rejected. Claude Code itself will
+    // resolve them against its CWD if it gets one.
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":"./relative/path"}', HOME))
+      .toBe('./relative/path')
+  })
+
+  it('trims surrounding whitespace before resolving', () => {
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":"  /abs/path  "}', HOME))
+      .toBe('/abs/path')
+    expect(resolveClaudeConfigDir('{"claudeConfigDir":" ~/.claude-x "}', HOME))
+      .toBe('/tmp/fake-home/.claude-x')
+  })
+})
+
+describe('resolveClaudeConfigDir -- tilde position and post-expansion safety', () => {
+  // The runtime shell expands `~` and `~user` in assignment context even when
+  // the value is wrapped in our outer template literal, because the inner
+  // shell sees the value unquoted (the JS template does not escape the
+  // embedded `"` characters). So tilde is only safe at position 0 in the
+  // exact forms `~` and `~/...` -- anything else is rejected.
+  const baseJson = (v: string) =>
+    `{"claudeConfigDir":${JSON.stringify(v)}}`
+
+  it('rejects `~user/path` (named-user home, would be re-expanded by runtime shell)', () => {
+    expect(resolveClaudeConfigDir(baseJson('~root/.claude-x'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('~admin/foo'), HOME)).toBeNull()
+  })
+
+  it('rejects a tilde appearing mid-string', () => {
+    expect(resolveClaudeConfigDir(baseJson('/abs/foo~bar'), HOME)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('~/foo~bar'), HOME)).toBeNull()
+  })
+
+  it('still accepts the two safe tilde forms', () => {
+    expect(resolveClaudeConfigDir(baseJson('~'), HOME)).toBe(HOME)
+    expect(resolveClaudeConfigDir(baseJson('~/.claude-x'), HOME))
+      .toBe('/tmp/fake-home/.claude-x')
+  })
+
+  it('rejects a tilde-expanded path when homeDir itself is unsafe', () => {
+    // Operator hosts may have a space in their home dir name. The raw input
+    // `~/.claude-x` passes the whitelist, but after expansion the space
+    // sneaks in. Re-validating the resolved path catches this.
+    const unsafeHome = '/home/with spaces'
+    expect(resolveClaudeConfigDir(baseJson('~/.claude-x'), unsafeHome)).toBeNull()
+    expect(resolveClaudeConfigDir(baseJson('~'), unsafeHome)).toBeNull()
+  })
+
+  it('still resolves a tilde path when homeDir is safe', () => {
+    // Sanity: the post-expansion check does not over-reject normal homes.
+    const safeHome = '/home/normal'
+    expect(resolveClaudeConfigDir(baseJson('~/.claude-x'), safeHome))
+      .toBe('/home/normal/.claude-x')
+  })
+})
+
+describe('resolveClaudeConfigDir -- realistic agent-config shapes', () => {
+  it('handles a full agent-config.json with the field present', () => {
+    const json = JSON.stringify({
+      model: 'claude-opus-4-7',
+      displayName: 'Dev 2',
+      securityProfile: 'developer-senior',
+      claudeConfigDir: '~/.claude-coding',
+    })
+    expect(resolveClaudeConfigDir(json, HOME)).toBe('/tmp/fake-home/.claude-coding')
+  })
+
+  it('handles a full agent-config.json without the field', () => {
+    const json = JSON.stringify({
+      model: 'claude-opus-4-7',
+      displayName: 'Dev 2',
+      securityProfile: 'developer-senior',
+    })
+    expect(resolveClaudeConfigDir(json, HOME)).toBeNull()
+  })
+
+  it('uses the supplied homeDir, not process.env.HOME', () => {
+    // Two different homeDirs must produce two different results -- proves
+    // the function does not silently fall back to process.env.HOME.
+    const json = '{"claudeConfigDir":"~/.claude-x"}'
+    expect(resolveClaudeConfigDir(json, '/home/alice')).toBe('/home/alice/.claude-x')
+    expect(resolveClaudeConfigDir(json, '/home/charlie')).toBe('/home/charlie/.claude-x')
+  })
+})

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { homedir } from 'node:os'
 import { PROJECT_ROOT, MAIN_AGENT_ID } from '../config.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { safeJoin } from './sanitize.js'
@@ -94,6 +95,93 @@ export function readAgentSecurityProfile(name: string): string {
     }
   } catch { /* fall through */ }
   return 'default'
+}
+
+// Pure-logic resolver for the optional per-agent claudeConfigDir field.
+// Takes the raw agent-config.json text (or `{}` when no file exists) plus an
+// explicit home-dir, and returns the absolute path to use as
+// CLAUDE_CONFIG_DIR, or null when the field is missing/blank/non-string or
+// the JSON is unparseable. Tilde forms are expanded against the supplied
+// homeDir. Kept dependency-free so it can be unit-tested without the fs.
+//
+// Allowed character set for the path: alphanumerics, dot, slash, hyphen,
+// underscore, tilde. Anything else is rejected.
+//
+// This is a whitelist rather than a blacklist for a reason. The launcher
+// inlines the path into a tmux command via nested template literals, which
+// produces a shell string with both an outer and an inner double-quoted
+// region. Bash treats the inner `"` as a quote delimiter, not a literal,
+// so the path actually lands partly inside and partly outside double-quote
+// context. Inside double quotes most metachars are tame; outside, almost
+// anything (parens, single quote, spaces, semicolons, &, |) is shell-
+// significant. Enumerating "safe outside double quotes" by blacklist is a
+// trap -- a whitelist of characters that survive both layers is far
+// shorter to write and more robust to future changes in the launcher.
+//
+// Local config is only writable by the host operator, so this is defense-
+// in-depth rather than a hard security boundary, but it cheaply removes
+// the trivial way to break the launcher with a config typo.
+//
+// Path values containing `..` segments are also rejected. Without this
+// guard `path.join` would silently collapse them ("~/../../../etc/passwd"
+// resolves to "/etc/passwd"), which is almost never what the operator
+// meant. Absolute paths without `..` remain accepted, so legitimate non-
+// home locations like "/var/lib/claude-coding" still work.
+const CLAUDE_CONFIG_DIR_ALLOWED = /^[A-Za-z0-9_./~-]+$/
+
+// Only `..` segments are rejected, not `.` (current dir) or empty segments
+// from doubled slashes (`//`). Both of those are no-ops -- the OS and
+// `path.join` normalize them away without changing where the path points.
+// `..` is the only segment that meaningfully alters the destination, so
+// it's the only one we treat as suspicious.
+function hasParentTraversal(raw: string): boolean {
+  return raw.split('/').some(segment => segment === '..')
+}
+
+export function resolveClaudeConfigDir(
+  rawConfigJson: string,
+  homeDir: string,
+): string | null {
+  let config: unknown
+  try { config = JSON.parse(rawConfigJson) } catch { return null }
+  if (!config || typeof config !== 'object') return null
+  const value = (config as Record<string, unknown>).claudeConfigDir
+  if (typeof value !== 'string') return null
+  const raw = value.trim()
+  if (!raw) return null
+  if (!CLAUDE_CONFIG_DIR_ALLOWED.test(raw)) return null
+  if (hasParentTraversal(raw)) return null
+  // Tilde may appear at most once, and only as the bare `~` or as the
+  // leading `~/` of a `~/...` form. `~user`, mid-string `~`, double tildes
+  // -- all rejected because the runtime shell would re-expand them at
+  // assignment time even though our resolver does not, and we do not want
+  // the launcher to silently route an agent to a different user's home
+  // directory or to a path the operator did not write.
+  if (raw.includes('~')) {
+    const tildeCount = raw.split('~').length - 1
+    const validForm = raw === '~' || raw.startsWith('~/')
+    if (!validForm || tildeCount > 1) return null
+  }
+  let resolved: string
+  if (raw === '~') resolved = homeDir
+  else if (raw.startsWith('~/')) resolved = join(homeDir, raw.slice(2))
+  else resolved = raw
+  // Re-validate after expansion: if `homeDir` itself contains a character
+  // outside the whitelist (e.g. a space in a multi-word account name), the
+  // resolved path would land in unquoted shell context and break the
+  // launcher cmd. Reject rather than ship a broken export.
+  if (!CLAUDE_CONFIG_DIR_ALLOWED.test(resolved)) return null
+  return resolved
+}
+
+// Optional per-agent override for the Claude Code config directory. When set,
+// the launcher injects CLAUDE_CONFIG_DIR into the tmux command, letting that
+// agent use a different login (credentials, plugins, sessions) than the host
+// default. When null, no env var is injected and Claude Code uses its built-in
+// default location (`~/.claude/` on macOS/Linux).
+export function readAgentClaudeConfigDir(name: string): string | null {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  return resolveClaudeConfigDir(readFileOr(configPath, '{}'), homedir())
 }
 
 export function writeAgentSecurityProfile(name: string, profileId: string): void {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -5,7 +5,7 @@ import { OLLAMA_URL } from '../config.js'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
 import { detectPaneState } from '../pane-state.js'
-import { agentDir, readAgentModel, readAgentSecurityProfile } from './agent-config.js'
+import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir } from './agent-config.js'
 import { parseTelegramToken } from './telegram.js'
 import { loadProfileTemplate } from './profiles.js'
 import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
@@ -53,6 +53,12 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     const profile = loadProfileTemplate(readAgentSecurityProfile(name))
     writeAgentSettingsFromProfile(name, profile)
     const skipFlag = profile.permissionMode === 'strict' ? '' : '--dangerously-skip-permissions '
+    // Optional per-agent CLAUDE_CONFIG_DIR (alternate Claude Code config dir,
+    // e.g. for routing this agent to a separate Anthropic login). When the
+    // agent-config field is missing or blank, claudeConfigDir is null and we
+    // emit no export, preserving the default Claude Code behavior.
+    const claudeConfigDir = readAgentClaudeConfigDir(name)
+    const claudeConfigEnv = claudeConfigDir ? `export CLAUDE_CONFIG_DIR="${claudeConfigDir}" && ` : ''
     // bun lives under ~/.bun/bin, which isn't in the dashboard's launchd PATH.
     // The Claude plugin launcher spawns `bun`, so we must prepend it here.
     // Defensive unset of TELEGRAM_BOT_TOKEN: if anything ever pollutes the
@@ -60,7 +66,7 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     // sourcing .env), the sub-agent would otherwise inherit the main
     // agent's token and trigger a 409 Conflict loop. The per-agent .env
     // in TELEGRAM_STATE_DIR is still the intended source of truth.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && unset TELEGRAM_BOT_TOKEN && export TELEGRAM_STATE_DIR="${tgStateDir}" && ${ollamaEnv}cd "${dir}" && ${CLAUDE} ${skipFlag}--model ${model} --channels plugin:telegram@claude-plugins-official`
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && unset TELEGRAM_BOT_TOKEN && export TELEGRAM_STATE_DIR="${tgStateDir}" && ${claudeConfigEnv}${ollamaEnv}cd "${dir}" && ${CLAUDE} ${skipFlag}--model ${model} --channels plugin:telegram@claude-plugins-official`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }


### PR DESCRIPTION
## Why this matters

Hosts running a fleet of Marveen agents currently share a single Claude Code login. When the host has multiple Claude subscriptions and wants to split them per-agent (e.g., heavy-coding agents on a secondary login so they do not burn the primary's weekly quota), there is no native way to do it -- `claude auth login` is global.

This PR lets each agent point at its own Claude config dir via an optional `claudeConfigDir` field in `agent-config.json`. Distinct logins per agent group, capacity effectively multiplied, zero impact on existing single-subscription installs.

## Change

- **`src/web/agent-config.ts`**: new exported helper `readAgentClaudeConfigDir(name)` plus the pure-logic `resolveClaudeConfigDir(rawConfigJson, homeDir)` it wraps. Tilde expansion supported. The resolver applies four guards in order:
  1. Character whitelist `^[A-Za-z0-9_./~-]+$`. The launcher inlines the path into a nested-quoted tmux command, so the path lands partly inside and partly outside double-quote context. A whitelist of safe chars is more robust than a metachar blacklist.
  2. `..` segment rejection (so `~/../../../etc/passwd` does not silently collapse to `/etc/passwd`). Absolute paths without `..` remain accepted.
  3. Tilde-position guard. Honors only bare `~` or the leading `~/...`. `~user`, mid-string `~`, double tildes are all rejected because the runtime shell would re-expand them at assignment time even though our resolver does not.
  4. Post-expansion re-validation. If `homeDir` itself contains an unsafe char (e.g. a space in a multi-word account name), the resolved path would break the launcher cmd. We reject rather than ship a broken export.
- **`src/web/agent-process.ts`**: when `readAgentClaudeConfigDir` returns a path, the launcher injects `export CLAUDE_CONFIG_DIR=\"...\"` into the tmux command. When null, no change to the command (byte-identical to pre-patch).
- **`src/__tests__/claude-config-dir.test.ts`**: 41 vitest cases covering guard rails, tilde expansion, parent traversal, the character whitelist (incl. shell-significant chars and unicode), tilde-position rejection, post-expansion safety with unsafe homedirs, and realistic agent-config shapes.

## Scope / compatibility

- The field is optional. Configs without it behave identically to current code. Verified by an end-to-end smoke test against a real ad-hoc agent dir: an existing agent without the field returns null, and the launcher's cmd-fragment is byte-identical to pre-patch (the conditional `claudeConfigEnv` evaluates to the empty string, and the cmd-template concatenation produces exactly the pre-patch string).
- No UI, no settings.json schema changes, no auth automation, not exposed in `/api/agents` response. Operators edit `agent-config.json` manually for now. Could be follow-up PRs if there is user demand.
- Underlying mechanism is Claude Code's `CLAUDE_CONFIG_DIR` env var. Verified working in practice on macOS (separate login per config dir, credentials isolated, plugins per-config-dir).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` all green: existing 292 tests + 41 new = **333 total passing**
- [x] Manual integration smoke test against a real ad-hoc `agent-config.json` file:
  - With `claudeConfigDir: \"~/.claude-smoke-test-target\"`, verified `readAgentClaudeConfigDir` returns the expanded absolute path.
  - With an existing agent that does not set the field, verified the function returns null.
  - Replicated the exact line-60 cmd-fragment building from the launcher: when set, the fragment contains `export CLAUDE_CONFIG_DIR=\"...\"`; when null, the fragment is byte-identical to the pre-patch cmd (no env var injection).
- [x] Adversarial review with hostile Explore-agents over 7 rounds, ending with 2 consecutive 0-finding rounds. Iterations along the way found and fixed: a `..`-segment traversal gap, a shell-injection vector via paren / quote / space characters in the unquoted region of the cmd template, and a home-dir leak in the success-path logger.
- [x] External adversarial review via Codex (2 iterations, iter-2 returned 0 findings). Codex caught two extra subtleties beyond the internal review: tilde re-expansion at runtime for `~user/...` paths, and homedir-with-spaces breaking the launcher cmd. Both addressed by the tilde-position guard and the post-expansion re-validation.

## Known limitations

- The path the operator provides must already exist with a logged-in Claude Code session in it. This PR does not bootstrap empty config dirs. The recommended setup is `cp -r ~/.claude ~/.claude-coding` first (preserves plugins and skills), then `CLAUDE_CONFIG_DIR=~/.claude-coding claude auth logout && claude auth login` to switch the login.
- Plugins and skills are config-dir-scoped. If you point an agent at a fresh empty config dir, plugins from the default config are not inherited automatically; use the clone-then-relogin recipe above.