### PR TITLE
fix: restore --continue flag + PR#53/#54 post-testing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,52 @@ Időzített feladatok és heartbeat monitorok beállítása:
 - Feladat: mindig szól az eredménnyel
 - Heartbeat: csendes ellenőrzés, csak fontosnál értesít
 
+### Vault & Titkosítás
+
+Az MCP szerverek API kulcsait, tokenjeit és jelszavait a Vault kezeli. A titkok AES-256-GCM titkosítással vannak tárolva, a master key macOS-en a Keychain-ben él (egyéb platformon fájl-alapú fallback).
+
+**Miért Vault?** A Claude Code `.mcp.json` fájljai alapértelmezetten plaintext-ben tárolják az API kulcsokat és tokeneket. Ez biztonsági kockázat: a fájlok olvashatóak bármely process által, prompt injection támadással kiolvashatóak, és git-be is véletlenül bekerülhetnek. A Vault ezt úgy oldja meg, hogy a `.mcp.json`-ben csak `vault:SECRET_ID` referenciák állnak, a tényleges értékek titkosítva vannak, és csak induláskor, memóriában oldódnak fel.
+
+**Master key tárolás:**
+- **macOS**: A vault master key a macOS Keychain-ben van tárolva (`com.marveen.vault` service). A Keychain az operációs rendszer titkosított kulcstárolója -- a disk encryption részeként védett, és a felhasználói bejelentkezéshez kötött. Nem kér külön jelszót, transzparens. Ha korábban fájl-alapú kulcs volt használatban (`.vault-key`), az első induláskor automatikusan migrálódik a Keychain-be.
+- **Linux**: A Keychain nem elérhető, ezért a master key fájl-alapú (`store/.vault-key`, `chmod 600`). A titkosítás továbbra is AES-256-GCM, de a master key védelme az OS fájljogosultságokra és disk encryption-re hárul. Éles környezetben érdemes LUKS vagy hasonló disk-level titkosítást használni.
+
+**Működés:**
+- A dashboard Vault oldalán hozhatod létre és kezelheted a titkokat
+- A **Scan & Import** gomb megkeresi a `.mcp.json` fájlokban lévő plaintext titkokat és felajánlja az importálást
+- Importálás után a `.mcp.json`-ben `vault:SECRET_ID` referencia áll a plaintext helyett
+- Az MCP szerver parancs automatikusan becsomagolódik a `vault-env-wrapper.sh` scripttel, ami induláskor feloldja a referenciákat
+
+**Mit érzékel a scanner:**
+- Csak a `.mcp.json` fájlok `env` szekciójában lévő érzékeny kulcsokat (`_KEY`, `_TOKEN`, `_SECRET`, `_PASSWORD`, `_PASS`, `PASSWORD`, `CREDENTIAL`, `ACCESS_KEY`, `API_*`, `AUTH_*`, `OAUTH_*`)
+- Az `args`-ban átadott titkokat (pl. `--api-key`) nem érzékeli -- ezeket manuálisan kell env var-ra átállítani
+
+**Vault struktúra:**
+```
+store/vault.json          # Titkosított titkok (AES-256-GCM)
+store/vault-bindings.json # Titok ↔ MCP szerver hozzárendelések
+scripts/vault-env-wrapper.sh  # Runtime feloldó wrapper
+scripts/vault-resolve.mjs     # Secret ID → plaintext feloldás
+```
+
+### Ágens monitorozás
+
+A `monitor_agents.sh` script összefogja az összes futó ágens tmux session-jét egyetlen `monitor` session-be, iTerm2 Control Mode-dal (`-CC`) minden ágens külön iTerm tab-ként jelenik meg.
+
+```bash
+# Lokálisan (a gépen ahol az ágensek futnak):
+./scripts/monitor_agents.sh
+
+# Távolról (laptopról SSH-n, iTerm2-vel):
+ssh macmini -t "~/marveen/scripts/monitor_agents.sh"
+
+# Ha új ágens indult és nem látod a monitorban -- kill + újraindítás:
+ssh macmini "/opt/homebrew/bin/tmux kill-session -t monitor" && \
+  ssh macmini -t "~/marveen/scripts/monitor_agents.sh"
+```
+
+A script automatikusan felderíti a futó `agent-*` és `marveen-channels` session-öket. A monitor session törlése nem érinti az ágens session-öket -- csak a linked-window referenciákat szünteti meg.
+
 ### Frissítés
 ```bash
 ./update.sh

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -41,7 +41,7 @@ $TMUX kill-session -t "$SESSION" 2>/dev/null
 
 # Tmux session indítás
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "$CLAUDE --dangerously-skip-permissions --channels plugin:telegram@claude-plugins-official"
+  "$CLAUDE --dangerously-skip-permissions --continue --channels plugin:telegram@claude-plugins-official"
 
 # Session startup guard: if the --dangerously-skip-permissions confirmation
 # dialog appears (despite the settings.json flag, e.g. on a Claude Code

--- a/scripts/vault-env-wrapper.sh
+++ b/scripts/vault-env-wrapper.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Resolve vault: references in env vars, then exec the real command.
+# Claude Code launches this as the MCP server "command". The actual
+# server command + args are passed as arguments to this script.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Find node binary
+NODE=""
+for candidate in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+  if [ -x "$candidate" ]; then NODE="$candidate"; break; fi
+done
+if [ -z "$NODE" ]; then
+  NODE="$(command -v node 2>/dev/null || true)"
+fi
+if [ -z "$NODE" ]; then
+  echo "vault-env-wrapper: node not found" >&2
+  exit 1
+fi
+
+# Collect vault: references from env
+REFS=""
+for var in $(env | grep '=vault:' | cut -d= -f1); do
+  val="${!var}"
+  secret_id="${val#vault:}"
+  REFS="${REFS}${var}=${secret_id}"$'\n'
+done
+
+if [ -n "$REFS" ]; then
+  RESOLVED=$(printf '%s' "$REFS" | "$NODE" "$PROJECT_ROOT/scripts/vault-resolve.mjs")
+  while IFS='=' read -r key value; do
+    [ -n "$key" ] && export "$key"="$value"
+  done <<< "$RESOLVED"
+fi
+
+exec "$@"

--- a/scripts/vault-resolve.mjs
+++ b/scripts/vault-resolve.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Resolve vault secret IDs to plaintext values.
+// Reads "ENV_VAR=secret_id" lines from stdin, outputs "ENV_VAR=value" lines.
+import { createRequire } from 'node:module'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const projectRoot = join(__dirname, '..')
+
+// Dynamic import from compiled dist
+const { getSecret } = await import(join(projectRoot, 'dist', 'web', 'vault.js'))
+
+const input = await new Promise(resolve => {
+  let data = ''
+  process.stdin.setEncoding('utf-8')
+  process.stdin.on('data', chunk => { data += chunk })
+  process.stdin.on('end', () => resolve(data))
+})
+
+for (const line of input.trim().split('\n')) {
+  if (!line.trim()) continue
+  const eq = line.indexOf('=')
+  if (eq < 0) continue
+  const envVar = line.slice(0, eq)
+  const secretId = line.slice(eq + 1)
+  const value = getSecret(secretId)
+  if (value !== null) {
+    process.stdout.write(`${envVar}=${value}\n`)
+  }
+}

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -66,7 +66,7 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     // sourcing .env), the sub-agent would otherwise inherit the main
     // agent's token and trigger a 409 Conflict loop. The per-agent .env
     // in TELEGRAM_STATE_DIR is still the intended source of truth.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && unset TELEGRAM_BOT_TOKEN && export TELEGRAM_STATE_DIR="${tgStateDir}" && ${claudeConfigEnv}${ollamaEnv}cd "${dir}" && ${CLAUDE} ${skipFlag}--model ${model} --channels plugin:telegram@claude-plugins-official`
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && unset TELEGRAM_BOT_TOKEN && export TELEGRAM_STATE_DIR="${tgStateDir}" && ${claudeConfigEnv}${ollamaEnv}cd "${dir}" && ${CLAUDE} --continue ${skipFlag}--model ${model} --channels plugin:telegram@claude-plugins-official`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }

--- a/src/web/keychain.ts
+++ b/src/web/keychain.ts
@@ -1,0 +1,48 @@
+import { execFileSync } from 'node:child_process'
+import { platform } from 'node:os'
+
+const SECURITY = '/usr/bin/security'
+const SERVICE = 'com.marveen.vault'
+const ACCOUNT = 'master-key'
+
+export function isKeychainAvailable(): boolean {
+  return platform() === 'darwin'
+}
+
+export function keychainStore(value: string): void {
+  execFileSync(SECURITY, [
+    'add-generic-password',
+    '-U',
+    '-s', SERVICE,
+    '-a', ACCOUNT,
+    '-w', value,
+    '-A',
+  ], { stdio: ['ignore', 'ignore', 'ignore'] })
+}
+
+export function keychainRetrieve(): string | null {
+  try {
+    const out = execFileSync(SECURITY, [
+      'find-generic-password',
+      '-s', SERVICE,
+      '-a', ACCOUNT,
+      '-w',
+    ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] })
+    return out.trim() || null
+  } catch {
+    return null
+  }
+}
+
+export function keychainDelete(): boolean {
+  try {
+    execFileSync(SECURITY, [
+      'delete-generic-password',
+      '-s', SERVICE,
+      '-a', ACCOUNT,
+    ], { stdio: ['ignore', 'ignore', 'ignore'] })
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -17,7 +17,7 @@ import { getExternalProjectPaths, addExternalProjectPath, removeExternalProjectP
 import { listSecrets, setSecret, getSecret, deleteSecret } from '../vault.js'
 import {
   getBindings, addBinding, removeBinding, removeBindingsForSecret,
-  syncSecret, syncAllBindings, scanMcpConfigs,
+  syncSecret, syncAllBindings, scanMcpConfigs, unsyncBinding,
 } from '../vault-bindings.js'
 import type { RouteContext } from './types.js'
 
@@ -646,6 +646,7 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   if (bindingDeleteMatch && method === 'DELETE') {
     const secretId = decodeURIComponent(bindingDeleteMatch[1])
     const envVar = decodeURIComponent(bindingDeleteMatch[2])
+    unsyncBinding(secretId, envVar)
     if (!removeBinding(secretId, envVar)) { json(res, { error: 'Binding not found' }, 404); return true }
     json(res, { ok: true })
     return true

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -696,7 +696,9 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
       imported++
       if (imp.createBinding && imp.targets.length > 0) {
         addBinding({ vaultSecretId: imp.vaultId, envVar: imp.envVar, targets: imp.targets })
+        const sync = syncSecret(imp.vaultId)
         bound++
+        errors.push(...sync.errors)
       }
     }
     json(res, { ok: true, imported, bound, errors })

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -565,7 +565,8 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   }
 
   const vaultMatch = path.match(/^\/api\/vault\/([^/]+)$/)
-  if (vaultMatch && method === 'GET') {
+  const isVaultSubroute = vaultMatch && ['bindings', 'sync', 'scan', 'import'].includes(vaultMatch[1])
+  if (vaultMatch && !isVaultSubroute && method === 'GET') {
     const id = decodeURIComponent(vaultMatch[1])
     const val = getSecret(id)
     if (val === null) { json(res, { error: 'Not found' }, 404); return true }
@@ -573,7 +574,7 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
     return true
   }
 
-  if (vaultMatch && method === 'DELETE') {
+  if (vaultMatch && !isVaultSubroute && method === 'DELETE') {
     const id = decodeURIComponent(vaultMatch[1])
     if (!deleteSecret(id)) { json(res, { error: 'Not found' }, 404); return true }
     removeBindingsForSecret(id)
@@ -592,13 +593,50 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
     const data = JSON.parse(body.toString()) as {
       vaultSecretId: string
       envVar: string
-      targets: Array<{ mcpFilePath: string, serverName: string }>
+      serverName?: string
+      targets?: Array<{ mcpFilePath: string, serverName: string }>
     }
-    if (!data.vaultSecretId || !data.envVar || !data.targets?.length) {
-      json(res, { error: 'vaultSecretId, envVar, and targets required' }, 400)
+    if (!data.vaultSecretId || !data.envVar) {
+      json(res, { error: 'vaultSecretId and envVar required' }, 400)
       return true
     }
-    addBinding(data)
+
+    let targets = data.targets || []
+    if (data.serverName && targets.length === 0) {
+      const searchPaths: Array<[string, string]> = [
+        [join(PROJECT_ROOT, '.mcp.json'), 'project'],
+        [join(homedir(), '.claude.json'), 'user'],
+      ]
+      for (const agentName of listAgentNames()) {
+        searchPaths.push([join(AGENTS_BASE_DIR, agentName, '.mcp.json'), `agent:${agentName}`])
+        const projectsDir = join(AGENTS_BASE_DIR, agentName, 'projects')
+        if (existsSync(projectsDir)) {
+          try {
+            for (const proj of readdirSync(projectsDir)) {
+              if (!statSync(join(projectsDir, proj)).isDirectory()) continue
+              searchPaths.push([join(projectsDir, proj, '.mcp.json'), `project:${agentName}/${proj}`])
+            }
+          } catch { /* ignore */ }
+        }
+      }
+      for (const extPath of getExternalProjectPaths()) {
+        searchPaths.push([join(extPath, '.mcp.json'), `project:external/${basename(extPath)}`])
+      }
+      for (const [src] of searchPaths) {
+        try {
+          const parsed = JSON.parse(readFileOr(src, '{}'))
+          if (parsed.mcpServers?.[data.serverName]) {
+            targets.push({ mcpFilePath: src, serverName: data.serverName })
+          }
+        } catch { /* skip */ }
+      }
+    }
+
+    if (targets.length === 0) {
+      json(res, { error: 'No targets found for this server' }, 400)
+      return true
+    }
+    addBinding({ vaultSecretId: data.vaultSecretId, envVar: data.envVar, targets })
     const syncResult = syncSecret(data.vaultSecretId)
     json(res, { ok: true, synced: syncResult.updated, errors: syncResult.errors })
     return true

--- a/src/web/vault-bindings.ts
+++ b/src/web/vault-bindings.ts
@@ -9,6 +9,7 @@ import { getExternalProjectPaths } from './dashboard-settings.js'
 import { logger } from '../logger.js'
 
 const BINDINGS_PATH = join(PROJECT_ROOT, 'store', 'vault-bindings.json')
+const VAULT_WRAPPER_PATH = join(PROJECT_ROOT, 'scripts', 'vault-env-wrapper.sh')
 
 export interface VaultBindingTarget {
   mcpFilePath: string
@@ -93,6 +94,19 @@ export function removeBinding(vaultSecretId: string, envVar: string): boolean {
 
 export function removeBindingsForSecret(vaultSecretId: string): void {
   const store = readBindings()
+  const toRemove = store.bindings.filter(b => b.vaultSecretId === vaultSecretId)
+  for (const binding of toRemove) {
+    for (const target of binding.targets) {
+      try {
+        const content = JSON.parse(readFileOr(target.mcpFilePath, '{}'))
+        const serverCfg = content.mcpServers?.[target.serverName]
+        if (!serverCfg?.env) continue
+        delete serverCfg.env[binding.envVar]
+        if (!serverHasVaultRefs(serverCfg.env)) unwrapCommand(serverCfg)
+        atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
+      } catch { /* skip */ }
+    }
+  }
   store.bindings = store.bindings.filter(b => b.vaultSecretId !== vaultSecretId)
   writeBindings(store)
 }
@@ -132,6 +146,7 @@ function maskValue(val: string): string {
 
 function looksLikeSensitiveValue(val: string): boolean {
   if (!val || val.length < 8) return false
+  if (val.startsWith('vault:')) return false
   for (const p of NON_SENSITIVE_VALUE_PATTERNS) {
     if (p.test(val)) return false
   }
@@ -180,12 +195,34 @@ export function scanMcpConfigs(): ScanFinding[] {
   return findings
 }
 
+function wrapCommand(serverCfg: any): void {
+  if (serverCfg.command === VAULT_WRAPPER_PATH) return
+  serverCfg._vaultOriginalCommand = serverCfg.command
+  if (serverCfg.args?.length) serverCfg._vaultOriginalArgs = serverCfg.args
+  serverCfg.args = [serverCfg.command, ...(serverCfg.args || [])]
+  serverCfg.command = VAULT_WRAPPER_PATH
+}
+
+function unwrapCommand(serverCfg: any): void {
+  if (serverCfg.command !== VAULT_WRAPPER_PATH) return
+  if (!serverCfg._vaultOriginalCommand) return
+  serverCfg.command = serverCfg._vaultOriginalCommand
+  serverCfg.args = serverCfg._vaultOriginalArgs || []
+  delete serverCfg._vaultOriginalCommand
+  delete serverCfg._vaultOriginalArgs
+}
+
+function serverHasVaultRefs(env: Record<string, string> | undefined): boolean {
+  if (!env) return false
+  return Object.values(env).some(v => typeof v === 'string' && v.startsWith('vault:'))
+}
+
 export function syncSecret(vaultSecretId: string): SyncResult {
   const bindings = getBindings().filter(b => b.vaultSecretId === vaultSecretId)
   if (bindings.length === 0) return { updated: 0, errors: [] }
 
-  const value = getSecret(vaultSecretId)
-  if (value === null) return { updated: 0, errors: [`Vault secret "${vaultSecretId}" not found`] }
+  const secret = getSecret(vaultSecretId)
+  if (secret === null) return { updated: 0, errors: [`Vault secret "${vaultSecretId}" not found`] }
 
   let updated = 0
   const errors: string[] = []
@@ -194,14 +231,14 @@ export function syncSecret(vaultSecretId: string): SyncResult {
     for (const target of binding.targets) {
       try {
         const content = JSON.parse(readFileOr(target.mcpFilePath, '{}'))
-        if (!content.mcpServers?.[target.serverName]) {
+        const serverCfg = content.mcpServers?.[target.serverName]
+        if (!serverCfg) {
           errors.push(`Server "${target.serverName}" not found in ${target.mcpFilePath}`)
           continue
         }
-        if (!content.mcpServers[target.serverName].env) {
-          content.mcpServers[target.serverName].env = {}
-        }
-        content.mcpServers[target.serverName].env[binding.envVar] = value
+        if (!serverCfg.env) serverCfg.env = {}
+        serverCfg.env[binding.envVar] = `vault:${vaultSecretId}`
+        if (serverCfg.command && !serverCfg.url) wrapCommand(serverCfg)
         atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
         updated++
       } catch (err: any) {
@@ -212,6 +249,24 @@ export function syncSecret(vaultSecretId: string): SyncResult {
 
   if (updated > 0) logger.info({ vaultSecretId, updated }, 'Vault secret synced to .mcp.json files')
   return { updated, errors }
+}
+
+export function unsyncBinding(vaultSecretId: string, envVar: string): void {
+  const bindings = getBindings().filter(
+    b => b.vaultSecretId === vaultSecretId && b.envVar === envVar,
+  )
+  for (const binding of bindings) {
+    for (const target of binding.targets) {
+      try {
+        const content = JSON.parse(readFileOr(target.mcpFilePath, '{}'))
+        const serverCfg = content.mcpServers?.[target.serverName]
+        if (!serverCfg?.env) continue
+        delete serverCfg.env[envVar]
+        if (!serverHasVaultRefs(serverCfg.env)) unwrapCommand(serverCfg)
+        atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
+      } catch { /* skip */ }
+    }
+  }
 }
 
 export function syncAllBindings(): SyncResult {

--- a/src/web/vault.ts
+++ b/src/web/vault.ts
@@ -1,11 +1,14 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, renameSync } from 'node:fs'
 import { join } from 'node:path'
 import { randomBytes, createCipheriv, createDecipheriv, scryptSync } from 'node:crypto'
 import { PROJECT_ROOT } from '../config.js'
 import { atomicWriteFileSync } from './atomic-write.js'
+import { isKeychainAvailable, keychainStore, keychainRetrieve } from './keychain.js'
+import { logger } from '../logger.js'
 
 const VAULT_PATH = join(PROJECT_ROOT, 'store', 'vault.json')
 const VAULT_KEY_PATH = join(PROJECT_ROOT, 'store', '.vault-key')
+const VAULT_KEY_MIGRATED = join(PROJECT_ROOT, 'store', '.vault-key.migrated')
 const ALGORITHM = 'aes-256-gcm'
 const KEY_LENGTH = 32
 const IV_LENGTH = 16
@@ -25,6 +28,33 @@ interface VaultStore {
 }
 
 function getMasterKey(): Buffer {
+  if (isKeychainAvailable()) {
+    if (existsSync(VAULT_KEY_PATH)) {
+      const fileKey = readFileSync(VAULT_KEY_PATH, 'utf-8').trim()
+      try {
+        keychainStore(fileKey)
+        renameSync(VAULT_KEY_PATH, VAULT_KEY_MIGRATED)
+        logger.info('Vault master key migrated from file to macOS Keychain')
+      } catch (err: any) {
+        logger.warn({ err: err.message }, 'Keychain migration failed, keeping file-based key')
+      }
+      return Buffer.from(fileKey, 'base64')
+    }
+
+    const existing = keychainRetrieve()
+    if (existing) return Buffer.from(existing, 'base64')
+
+    const newKey = randomBytes(64).toString('base64')
+    try {
+      keychainStore(newKey)
+      logger.info('New vault master key stored in macOS Keychain')
+    } catch (err: any) {
+      logger.warn({ err: err.message }, 'Keychain store failed, falling back to file')
+      atomicWriteFileSync(VAULT_KEY_PATH, newKey, { mode: 0o600 })
+    }
+    return Buffer.from(newKey, 'base64')
+  }
+
   if (!existsSync(VAULT_KEY_PATH)) {
     const key = randomBytes(64).toString('base64')
     atomicWriteFileSync(VAULT_KEY_PATH, key, { mode: 0o600 })

--- a/web/app.js
+++ b/web/app.js
@@ -3800,6 +3800,10 @@ if (document.readyState === 'loading') {
 }
 
 function renderConnectors() {
+  // Detach panels that live inside connectorGrid before innerHTML wipes them
+  const _extPathsPanel = document.getElementById('externalPathsSection')
+  if (_extPathsPanel) _extPathsPanel.remove()
+
   // Stats
   if (connectors.length === 0 && connectorCacheWarming) {
     connectorStats.innerHTML = ''
@@ -3965,14 +3969,13 @@ function renderConnectors() {
   }
 
   // === Külső projektek ===
-  if (externalProjectScopes.length > 0 || document.getElementById('externalPathsToggle')) {
+  if (externalProjectScopes.length > 0 || _extPathsPanel) {
     const extHeading = document.createElement('div')
     extHeading.className = 'connector-group-heading'
     extHeading.textContent = 'Külső projektek'
     connectorGrid.appendChild(extHeading)
 
-    const extPathsPanel = document.getElementById('externalPathsSection')
-    if (extPathsPanel) connectorGrid.appendChild(extPathsPanel)
+    if (_extPathsPanel) connectorGrid.appendChild(_extPathsPanel)
 
     for (const ps of externalProjectScopes) {
       const projLabel = ps.slice('project:external/'.length)

--- a/web/app.js
+++ b/web/app.js
@@ -4462,15 +4462,15 @@ function renderVaultGrid(secrets) {
       const data = await res.json()
       const findings = data.findings || []
       renderScanResults(findings)
-      overlay.hidden = false
+      openModal(overlay)
     } finally {
       scanBtn.disabled = false
       scanBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg> Scan &amp; Import'
     }
   })
 
-  closeBtn?.addEventListener('click', () => { overlay.hidden = true })
-  overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.hidden = true })
+  closeBtn?.addEventListener('click', () => { closeModal(overlay) })
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(overlay) })
 
   syncBtn?.addEventListener('click', async () => {
     syncBtn.disabled = true
@@ -4591,7 +4591,7 @@ function renderVaultGrid(secrets) {
       importBtn.disabled = false
       importBtn.textContent = 'Kivalasztottak importalasa'
     }
-    overlay.hidden = true
+    closeModal(overlay)
     loadVaultPage()
     loadVault()
   })

--- a/web/app.js
+++ b/web/app.js
@@ -4681,9 +4681,21 @@ document.getElementById('saveConnectorBtn').addEventListener('click', async () =
       throw new Error(err.error || 'Hiba')
     }
     const result = await res.json()
+    const savedName = result.name || name
+
+    const checkedAgents = Array.from(document.querySelectorAll('#connectorNewAssignList input[type=checkbox]:checked')).map(cb => cb.value)
+    const allAgents = Array.from(document.querySelectorAll('#connectorNewAssignList input[type=checkbox]')).map(cb => cb.value)
+    if (checkedAgents.length > 0) {
+      await fetch(`/api/connectors/${encodeURIComponent(savedName)}/assign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agents: checkedAgents, allAgents }),
+      }).catch(() => {})
+    }
+
     closeModal(connectorModalOverlay)
     if (result.nameChanged) {
-      showToast(`Connector hozzáadva "${result.name}" néven (szóköz/speciális karakter nem engedélyezett)`)
+      showToast(`Connector hozzáadva "${savedName}" néven (szóköz/speciális karakter nem engedélyezett)`)
     } else {
       showToast('Connector hozzáadva!')
     }

--- a/web/app.js
+++ b/web/app.js
@@ -4298,6 +4298,107 @@ function renderVaultGrid(secrets) {
   })
 })()
 
+// --- Vault Binding modal ---
+;(function wireVaultBind() {
+  const bindBtn = document.getElementById('vaultBindBtn')
+  const overlay = document.getElementById('vaultBindOverlay')
+  const closeBtn = document.getElementById('vaultBindClose')
+  const saveBtn = document.getElementById('vaultBindSaveBtn')
+  const secretSelect = document.getElementById('vaultBindSecret')
+  const serverSelect = document.getElementById('vaultBindServer')
+  const envVarInput = document.getElementById('vaultBindEnvVar')
+  const statusEl = document.getElementById('vaultBindStatus')
+  if (!bindBtn || !overlay) return
+
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.hidden = true })
+  closeBtn.addEventListener('click', () => { overlay.hidden = true })
+
+  bindBtn.addEventListener('click', async () => {
+    statusEl.hidden = true
+    envVarInput.value = ''
+
+    const [secretsRes, connectorsRes] = await Promise.all([
+      fetch('/api/vault'),
+      fetch('/api/connectors'),
+    ])
+    const secrets = (await secretsRes.json()).secrets || []
+    const connectors = await connectorsRes.json()
+
+    secretSelect.innerHTML = ''
+    for (const s of secrets) {
+      const opt = document.createElement('option')
+      opt.value = s.id
+      opt.textContent = s.label !== s.id ? `${s.id} (${s.label})` : s.id
+      secretSelect.appendChild(opt)
+    }
+    if (secrets.length === 0) {
+      const opt = document.createElement('option')
+      opt.textContent = '-- Nincs vault kulcs --'
+      opt.disabled = true
+      secretSelect.appendChild(opt)
+    }
+
+    const mcpConnectors = connectors.filter(c => c.source !== 'plugin' && c.source !== 'claude.ai')
+    serverSelect.innerHTML = ''
+    for (const c of mcpConnectors) {
+      const opt = document.createElement('option')
+      opt.value = c.name
+      opt.textContent = c.scope !== 'global' ? `${c.name} (${c.scope})` : c.name
+      serverSelect.appendChild(opt)
+    }
+    if (mcpConnectors.length === 0) {
+      const opt = document.createElement('option')
+      opt.textContent = '-- Nincs MCP szerver --'
+      opt.disabled = true
+      serverSelect.appendChild(opt)
+    }
+
+    overlay.hidden = false
+  })
+
+  saveBtn.addEventListener('click', async () => {
+    const vaultSecretId = secretSelect.value
+    const serverName = serverSelect.value
+    const envVar = envVarInput.value.trim()
+    if (!vaultSecretId || !serverName || !envVar) {
+      statusEl.textContent = 'Minden mezo kitoltese kotelezo'
+      statusEl.className = 'vault-bind-status error'
+      statusEl.hidden = false
+      return
+    }
+
+    saveBtn.disabled = true
+    saveBtn.textContent = 'Mentes...'
+    try {
+      const res = await fetch('/api/vault/bindings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vaultSecretId, envVar, serverName }),
+      })
+      const data = await res.json()
+      if (data.ok) {
+        statusEl.textContent = `Hozzarendelve! ${data.synced || 0} fajl frissitve.`
+        statusEl.className = 'vault-bind-status success'
+        statusEl.hidden = false
+        loadVaultPage()
+        loadVault()
+        setTimeout(() => { overlay.hidden = true }, 1500)
+      } else {
+        statusEl.textContent = data.error || 'Hiba tortent'
+        statusEl.className = 'vault-bind-status error'
+        statusEl.hidden = false
+      }
+    } catch (err) {
+      statusEl.textContent = 'Halozati hiba'
+      statusEl.className = 'vault-bind-status error'
+      statusEl.hidden = false
+    } finally {
+      saveBtn.disabled = false
+      saveBtn.textContent = 'Hozzarendeles'
+    }
+  })
+})()
+
 // --- Vault Scan & Import ---
 ;(function wireVaultScan() {
   const scanBtn = document.getElementById('vaultScanBtn')

--- a/web/app.js
+++ b/web/app.js
@@ -3668,6 +3668,7 @@ document.getElementById('addConnectorBtn').addEventListener('click', () => {
   document.getElementById('connectorArgsGroup').hidden = false
   document.getElementById('connectorEnvGroup').hidden = false
   document.getElementById('connectorEnvList').innerHTML = ''
+  document.getElementById('connectorAssignGroup').hidden = true
   loadNewConnectorAgents()
   openModal(connectorModalOverlay)
 })
@@ -3683,6 +3684,12 @@ document.getElementById('connectorType').addEventListener('change', () => {
   document.getElementById('connectorCmdGroup').hidden = !isStdio
   document.getElementById('connectorArgsGroup').hidden = !isStdio
   document.getElementById('connectorEnvGroup').hidden = !isStdio
+})
+
+// Scope toggle: hide agent assignment for global scope
+document.getElementById('connectorScope').addEventListener('change', () => {
+  const isProject = document.getElementById('connectorScope').value === 'project'
+  document.getElementById('connectorAssignGroup').hidden = !isProject
 })
 
 // Default TRUE: if we never successfully read /api/connectors/status

--- a/web/app.js
+++ b/web/app.js
@@ -4226,7 +4226,7 @@ function renderVaultGrid(secrets) {
     const date = new Date(s.updatedAt).toLocaleDateString('hu-HU')
     const bindingCount = _vaultBindings.filter(b => b.vaultSecretId === s.id).length
     const bindingBadge = bindingCount > 0 ? `<span class="vault-binding-badge" title="${bindingCount} kotes">${bindingCount} kotes</span>` : ''
-    card.innerHTML = `<div class="vault-card-header"><div class="vault-card-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div><div class="vault-card-title"><div class="vault-card-id">${escapeHtml(s.id)} ${bindingBadge}</div>${s.label !== s.id ? `<div class="vault-card-label">${escapeHtml(s.label)}</div>` : ''}</div><div class="vault-card-meta">${date}</div></div><div class="vault-card-actions"><button class="btn-secondary btn-compact vault-card-reveal" data-id="${escapeHtml(s.id)}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg> Mutat</button><button class="btn-secondary btn-compact vault-card-delete" data-id="${escapeHtml(s.id)}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg> Torles</button></div>`
+    card.innerHTML = `<div class="vault-card-header"><div class="vault-card-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div><div class="vault-card-title"><div class="vault-card-id">${escapeHtml(s.id)} ${bindingBadge}</div>${s.label !== s.id ? `<div class="vault-card-label">${escapeHtml(s.label)}</div>` : ''}</div><div class="vault-card-meta">${date}</div></div><div class="vault-card-actions"><button class="btn-secondary btn-compact vault-card-reveal" data-id="${escapeHtml(s.id)}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg> Mutat</button><button class="btn-secondary btn-compact vault-card-edit" data-id="${escapeHtml(s.id)}" data-label="${escapeHtml(s.label)}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg> Modosit</button><button class="btn-secondary btn-compact vault-card-delete" data-id="${escapeHtml(s.id)}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg> Torles</button></div>`
     list.appendChild(card)
   }
   list.querySelectorAll('.vault-card-reveal').forEach(btn => {
@@ -4244,6 +4244,47 @@ function renderVaultGrid(secrets) {
         card.appendChild(valEl)
         btn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg> Elrejt'
       }
+    })
+  })
+  list.querySelectorAll('.vault-card-edit').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const id = btn.getAttribute('data-id')
+      const label = btn.getAttribute('data-label')
+      const card = btn.closest('.vault-card')
+      const existing = card.querySelector('.vault-card-edit-form')
+      if (existing) { existing.remove(); return }
+      card.querySelector('.vault-card-value')?.remove()
+      const res = await fetch(`/api/vault/${encodeURIComponent(id)}`)
+      const data = await res.json()
+      if (!data.value) return
+      const form = document.createElement('div')
+      form.className = 'vault-card-edit-form'
+      form.innerHTML = `<input type="password" class="input vault-edit-value" value="${escapeHtml(data.value)}" style="font-size:13px;margin-bottom:6px"><button class="btn-primary btn-compact vault-edit-save">Mentes</button> <button class="btn-secondary btn-compact vault-edit-cancel">Megse</button>`
+      card.appendChild(form)
+      const input = form.querySelector('.vault-edit-value')
+      input.focus()
+      input.select()
+      form.querySelector('.vault-edit-cancel').addEventListener('click', () => form.remove())
+      form.querySelector('.vault-edit-save').addEventListener('click', async () => {
+        const newVal = input.value
+        if (!newVal) return
+        const saveBtn = form.querySelector('.vault-edit-save')
+        saveBtn.disabled = true
+        saveBtn.textContent = '...'
+        await fetch('/api/vault', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id, label, value: newVal }),
+        })
+        form.remove()
+        showToast('Kulcs frissitve es szinkronizalva')
+        loadVaultPage()
+        loadVault()
+      })
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') form.querySelector('.vault-edit-save').click()
+        if (e.key === 'Escape') form.remove()
+      })
     })
   })
   list.querySelectorAll('.vault-card-delete').forEach(btn => {

--- a/web/app.js
+++ b/web/app.js
@@ -4310,50 +4310,55 @@ function renderVaultGrid(secrets) {
   const statusEl = document.getElementById('vaultBindStatus')
   if (!bindBtn || !overlay) return
 
-  overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.hidden = true })
-  closeBtn.addEventListener('click', () => { overlay.hidden = true })
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(overlay) })
+  closeBtn.addEventListener('click', () => { closeModal(overlay) })
 
   bindBtn.addEventListener('click', async () => {
-    statusEl.hidden = true
-    envVarInput.value = ''
+    try {
+      statusEl.hidden = true
+      envVarInput.value = ''
 
-    const [secretsRes, connectorsRes] = await Promise.all([
-      fetch('/api/vault'),
-      fetch('/api/connectors'),
-    ])
-    const secrets = (await secretsRes.json()).secrets || []
-    const connectors = await connectorsRes.json()
+      const [secretsRes, connectorsRes] = await Promise.all([
+        fetch('/api/vault'),
+        fetch('/api/connectors'),
+      ])
+      const secrets = (await secretsRes.json()).secrets || []
+      const connectors = await connectorsRes.json()
 
-    secretSelect.innerHTML = ''
-    for (const s of secrets) {
-      const opt = document.createElement('option')
-      opt.value = s.id
-      opt.textContent = s.label !== s.id ? `${s.id} (${s.label})` : s.id
-      secretSelect.appendChild(opt)
-    }
-    if (secrets.length === 0) {
-      const opt = document.createElement('option')
-      opt.textContent = '-- Nincs vault kulcs --'
-      opt.disabled = true
-      secretSelect.appendChild(opt)
-    }
+      secretSelect.innerHTML = ''
+      for (const s of secrets) {
+        const opt = document.createElement('option')
+        opt.value = s.id
+        opt.textContent = s.label !== s.id ? `${s.id} (${s.label})` : s.id
+        secretSelect.appendChild(opt)
+      }
+      if (secrets.length === 0) {
+        const opt = document.createElement('option')
+        opt.textContent = '-- Nincs vault kulcs --'
+        opt.disabled = true
+        secretSelect.appendChild(opt)
+      }
 
-    const mcpConnectors = connectors.filter(c => c.source !== 'plugin' && c.source !== 'claude.ai')
-    serverSelect.innerHTML = ''
-    for (const c of mcpConnectors) {
-      const opt = document.createElement('option')
-      opt.value = c.name
-      opt.textContent = c.scope !== 'global' ? `${c.name} (${c.scope})` : c.name
-      serverSelect.appendChild(opt)
-    }
-    if (mcpConnectors.length === 0) {
-      const opt = document.createElement('option')
-      opt.textContent = '-- Nincs MCP szerver --'
-      opt.disabled = true
-      serverSelect.appendChild(opt)
-    }
+      const mcpConnectors = connectors.filter(c => c.source !== 'plugin' && c.source !== 'claude.ai')
+      serverSelect.innerHTML = ''
+      for (const c of mcpConnectors) {
+        const opt = document.createElement('option')
+        opt.value = c.name
+        opt.textContent = c.scope !== 'global' ? `${c.name} (${c.scope})` : c.name
+        serverSelect.appendChild(opt)
+      }
+      if (mcpConnectors.length === 0) {
+        const opt = document.createElement('option')
+        opt.textContent = '-- Nincs MCP szerver --'
+        opt.disabled = true
+        serverSelect.appendChild(opt)
+      }
 
-    overlay.hidden = false
+      openModal(overlay)
+    } catch (err) {
+      console.error('Vault bind modal error:', err)
+      showToast('Hiba a hozzarendeles betoltesekor: ' + err.message)
+    }
   })
 
   saveBtn.addEventListener('click', async () => {
@@ -4382,7 +4387,7 @@ function renderVaultGrid(secrets) {
         statusEl.hidden = false
         loadVaultPage()
         loadVault()
-        setTimeout(() => { overlay.hidden = true }, 1500)
+        setTimeout(() => { closeModal(overlay) }, 1500)
       } else {
         statusEl.textContent = data.error || 'Hiba tortent'
         statusEl.className = 'vault-bind-status error'

--- a/web/index.html
+++ b/web/index.html
@@ -692,7 +692,7 @@
       </div>
 
       <!-- Binding modal -->
-      <div class="modal-overlay" id="vaultBindOverlay" hidden>
+      <div class="modal-overlay" id="vaultBindOverlay">
         <div class="modal" style="max-width:500px">
           <div class="modal-header">
             <h2>Kulcs hozzarendelese</h2>

--- a/web/index.html
+++ b/web/index.html
@@ -720,7 +720,7 @@
       </div>
 
       <!-- Scan modal -->
-      <div class="modal-overlay" id="vaultScanOverlay" hidden>
+      <div class="modal-overlay" id="vaultScanOverlay">
         <div class="modal" style="max-width:700px">
           <div class="modal-header">
             <h2>MCP titkok keresese</h2>

--- a/web/index.html
+++ b/web/index.html
@@ -603,6 +603,10 @@
             <p class="subtitle">Titkositott kulcsok es API tokenek</p>
           </div>
           <div style="display:flex;gap:8px">
+            <button class="btn-secondary btn-compact" id="vaultBindBtn" title="Vault kulcs hozzarendelese MCP szerverhez">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+              Hozzarendeles
+            </button>
             <button class="btn-secondary btn-compact" id="vaultScanBtn" title="MCP konfigok atvizsgalasa erzekeny kulcsokert">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
               Scan &amp; Import
@@ -685,6 +689,34 @@
         </svg>
         <p>Meg nincs tarolt kulcs</p>
         <p class="vault-empty-hint">Adj hozza egyet az "Uj kulcs" gombbal</p>
+      </div>
+
+      <!-- Binding modal -->
+      <div class="modal-overlay" id="vaultBindOverlay" hidden>
+        <div class="modal" style="max-width:500px">
+          <div class="modal-header">
+            <h2>Kulcs hozzarendelese</h2>
+            <button class="modal-close" id="vaultBindClose">&times;</button>
+          </div>
+          <div class="modal-body">
+            <div class="form-group">
+              <label for="vaultBindSecret">Vault kulcs</label>
+              <select id="vaultBindSecret" class="input"></select>
+            </div>
+            <div class="form-group">
+              <label for="vaultBindServer">MCP szerver</label>
+              <select id="vaultBindServer" class="input"></select>
+            </div>
+            <div class="form-group">
+              <label for="vaultBindEnvVar">Kornyezeti valtozo neve</label>
+              <input type="text" id="vaultBindEnvVar" class="input" placeholder="pl. API_KEY">
+            </div>
+            <div id="vaultBindStatus" hidden class="vault-bind-status"></div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn-primary" id="vaultBindSaveBtn">Hozzarendeles</button>
+          </div>
+        </div>
       </div>
 
       <!-- Scan modal -->

--- a/web/style.css
+++ b/web/style.css
@@ -3065,6 +3065,15 @@ main {
   margin-left: 6px;
 }
 
+.vault-card-edit-form {
+  padding: 10px 12px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.vault-card-edit-form .input { flex: 1; }
+
 .vault-bind-status {
   font-size: 13px;
   padding: 8px 12px;

--- a/web/style.css
+++ b/web/style.css
@@ -3065,6 +3065,15 @@ main {
   margin-left: 6px;
 }
 
+.vault-bind-status {
+  font-size: 13px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  margin-top: 8px;
+}
+.vault-bind-status.success { background: rgba(34,197,94,.12); color: var(--success); }
+.vault-bind-status.error { background: rgba(239,68,68,.12); color: var(--danger); }
+
 .vault-scan-desc {
   font-size: 13px;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- Restored `--continue` flag in `channels.sh` and `agent-process.ts` -- removed accidentally by the 409-conflict fix (89d4cc0), causing session amnesia on every watchdog/launchd restart
- Vault binding UI: modal fixes, secret edit button, keychain integration, env auto-sync after import
- MCP connector fixes: agent assignment on creation, externalPathsSection preservation, scope-based visibility
- Vault & keychain security docs, agent monitor usage in README

## Test plan
- [x] Vault binding modal opens and assigns secrets correctly
- [x] Secret edit inline form works
- [x] macOS Keychain stores/retrieves vault master key
- [x] Env auto-sync replaces plaintext with vault refs after import
- [x] Agent assignment visible on connector creation (non-global scope)
- [x] `--continue` flag present in both channels.sh and agent-process.ts
- [ ] Verify session continuity survives a watchdog restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)