### PR TITLE
feat(web): add DeepSeek-V4-Pro model support

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -117,6 +117,23 @@ async function main() {
     warn('ElevenLabs kihagyva — hangos valaszok nem lesznek elerhetoek')
   }
 
+  // DeepSeek-V4-Pro (alternativ modell a Claude mellett)
+  console.log('\nDeepSeek-V4-Pro alternativ modell tamogatas (opcionalis).')
+  console.log('A DeepSeek olcsobb mint a Claude, kompatibilis Anthropic API-t kinal,')
+  console.log('1M token kontextussal. API kulcsot itt szerezhetsz: https://api.deepseek.com')
+  const dsKey = await ask('DeepSeek API kulcs (Enter a kihagyashoz):')
+  if (dsKey) {
+    // Mentsuk a vault-ba (titkositott tarolas), nem a sima .env-be:
+    // a kulcs igy a dashboard felulet rotacios kontrollja ala kerul es
+    // nem jelenik meg a .env fajl tartalmaban hat hosszan.
+    const { setSecret } = await import('../dist/web/vault.js')
+    setSecret('DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY', dsKey)
+    ok('DeepSeek API kulcs mentve a vault-ba (DEEPSEEK_API_KEY)')
+    ok('A deepseek-v4-pro modell most mar elerheto agensekhez')
+  } else {
+    warn('DeepSeek kihagyva — kesobb a dashboard /vault oldalrol hozzaadhato')
+  }
+
   // .env iras
   header('4. .env fajl irasa')
   let envContent = '# ClaudeClaw konfiguracio\n'

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { homedir } from 'node:os'
 import { execSync, execFileSync } from 'node:child_process'
 import { OLLAMA_URL } from '../config.js'
 import { resolveFromPath } from '../platform.js'
@@ -9,6 +10,7 @@ import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConf
 import { parseTelegramToken } from './telegram.js'
 import { loadProfileTemplate } from './profiles.js'
 import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
+import { getSecret } from './vault.js'
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
@@ -45,8 +47,19 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     } catch { /* ok */ }
 
     const model = readAgentModel(name)
-    const isOllama = !model.startsWith('claude-')
+    const isClaude = model.startsWith('claude-')
+    const isDeepseek = model.startsWith('deepseek-')
+    const isOllama = !isClaude && !isDeepseek
     const ollamaEnv = isOllama ? `export ANTHROPIC_AUTH_TOKEN=ollama && export ANTHROPIC_BASE_URL=${OLLAMA_URL} && ` : ''
+    // DeepSeek's /anthropic base URL accepts the literal Anthropic SDK
+    // request format, so Claude Code talks to it as if it were Anthropic.
+    // We pull the API key from the encrypted vault (entry id: DEEPSEEK_API_KEY)
+    // rather than process.env so operators can rotate it from the dashboard
+    // without restarting. We do NOT fail-fast on missing key here -- a 401
+    // from the upstream gives a clearer signal in the agent's tmux pane
+    // than a pre-flight error string the operator would have to dig out of logs.
+    const deepseekKey = isDeepseek ? (getSecret('DEEPSEEK_API_KEY') ?? '') : ''
+    const deepseekEnv = isDeepseek ? `export ANTHROPIC_AUTH_TOKEN="${deepseekKey}" && export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic && ` : ''
     // Apply security profile: write allow/deny list into settings.json, and
     // skip the dangerously-skip-permissions flag for strict profiles so
     // Claude Code enforces the list rather than bypassing it.
@@ -59,6 +72,18 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     // emit no export, preserving the default Claude Code behavior.
     const claudeConfigDir = readAgentClaudeConfigDir(name)
     const claudeConfigEnv = claudeConfigDir ? `export CLAUDE_CONFIG_DIR="${claudeConfigDir}" && ` : ''
+    // `--continue` requires an existing session; on a brand-new agent the
+    // Claude Code projects directory does not yet exist and `claude` exits
+    // immediately with an obscure "No deferred tool marker found" error
+    // that is silent inside tmux. Detect first launch by probing for the
+    // encoded project dir and skip `--continue` only then. The encoding
+    // mirrors Claude Code's own scheme: replace every `/` with `-`.
+    const projectsRoot = claudeConfigDir
+      ? join(claudeConfigDir, 'projects')
+      : join(homedir(), '.claude', 'projects')
+    const encodedProject = dir.replace(/\//g, '-')
+    const hasPriorSession = existsSync(join(projectsRoot, encodedProject))
+    const continueFlag = hasPriorSession ? '--continue ' : ''
     // bun lives under ~/.bun/bin, which isn't in the dashboard's launchd PATH.
     // The Claude plugin launcher spawns `bun`, so we must prepend it here.
     // Defensive unset of TELEGRAM_BOT_TOKEN: if anything ever pollutes the
@@ -66,7 +91,7 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     // sourcing .env), the sub-agent would otherwise inherit the main
     // agent's token and trigger a 409 Conflict loop. The per-agent .env
     // in TELEGRAM_STATE_DIR is still the intended source of truth.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && unset TELEGRAM_BOT_TOKEN && export TELEGRAM_STATE_DIR="${tgStateDir}" && ${claudeConfigEnv}${ollamaEnv}cd "${dir}" && ${CLAUDE} --continue ${skipFlag}--model ${model} --channels plugin:telegram@claude-plugins-official`
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && unset TELEGRAM_BOT_TOKEN && export TELEGRAM_STATE_DIR="${tgStateDir}" && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:telegram@claude-plugins-official`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -6,6 +6,7 @@ import { logger } from '../../logger.js'
 import { MAIN_AGENT_ID, BOT_NAME } from '../../config.js'
 import { createAgentMessage } from '../../db.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
+import { getSecret } from '../vault.js'
 import {
   agentDir,
   DEFAULT_MODEL,
@@ -141,6 +142,29 @@ function listAgentSummaries(): AgentSummary[] {
 
 export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promise<boolean> {
   const { req, res, path, method } = ctx
+
+  // Lists every model the dashboard is willing to serve up to an agent.
+  // Claude IDs are static. DeepSeek is gated behind a vault secret because
+  // the agent-process launcher reads the key from there at start time --
+  // surfacing the option in the UI without the key would let the operator
+  // pick a model that 401s on first prompt. The frontend renders this list
+  // both in the "new agent" wizard and the agent edit panel.
+  if (path === '/api/models/available' && method === 'GET') {
+    const hasDeepseek = getSecret('DEEPSEEK_API_KEY') !== null
+    json(res, {
+      claude: [
+        { id: 'claude-opus-4-7', label: 'Opus 4.7 (legújabb, legjobb)' },
+        { id: 'claude-opus-4-6', label: 'Opus 4.6' },
+        { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6 (alapértelmezett)' },
+        { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5 (leggyorsabb)' },
+      ],
+      deepseek: hasDeepseek
+        ? [{ id: 'deepseek-v4-pro', label: 'DeepSeek-V4-Pro (1M kontextus)' }]
+        : [],
+      deepseekConfigured: hasDeepseek,
+    })
+    return true
+  }
 
   if (path === '/api/agents' && method === 'GET') {
     json(res, listAgentSummaries())

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -159,7 +159,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
         { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5 (leggyorsabb)' },
       ],
       deepseek: hasDeepseek
-        ? [{ id: 'deepseek-v4-pro', label: 'DeepSeek-V4-Pro (1M kontextus)' }]
+        ? [
+            { id: 'deepseek-v4-pro', label: 'DeepSeek-V4-Pro (1M kontextus, erősebb)' },
+            { id: 'deepseek-v4-flash', label: 'DeepSeek-V4-Flash (1M kontextus, gyorsabb/olcsóbb)' },
+          ]
         : [],
       deepseekConfigured: hasDeepseek,
     })

--- a/web/app.js
+++ b/web/app.js
@@ -551,6 +551,7 @@ function resetWizard() {
   agentName.value = ''
   agentDesc.value = ''
   agentModel.value = 'inherit'
+  loadAvailableModels()
   selectedAvatar = null
   document.querySelectorAll('#avatarGrid .avatar-grid-item').forEach(i => i.classList.remove('selected'))
   generatedClaudeMd = ''
@@ -909,7 +910,8 @@ async function openAgentDetail(agentName) {
   const tgConnected = currentAgent.hasTelegram || false
   document.getElementById('agentDetailTgStatus').innerHTML = `<span class="tg-status"><span class="tg-dot ${tgConnected ? 'connected' : 'disconnected'}"></span>${tgConnected ? 'Csatlakozva' : 'Nincs bekötve'}</span>`
 
-  // Settings tab - load Ollama models then set value
+  // Settings tab - load Ollama + DeepSeek models then set value
+  loadAvailableModels()
   loadOllamaModels().then(() => {
     document.getElementById('editAgentModel').value = currentAgent.model || 'claude-sonnet-4-6'
   })
@@ -1148,6 +1150,38 @@ async function loadOllamaModels() {
       group.appendChild(opt)
     }
   } catch { /* Ollama not available */ }
+}
+
+// Populates the DeepSeek optgroups in both the wizard and the agent edit
+// panel. Backend gates the list behind a vault entry, so an empty array
+// here means the operator has not configured an API key yet -- in that
+// case we hide the optgroup and surface a hint pointing to the Vault page.
+async function loadAvailableModels() {
+  try {
+    const res = await fetch('/api/models/available')
+    if (!res.ok) return
+    const data = await res.json()
+    const deepseekModels = Array.isArray(data.deepseek) ? data.deepseek : []
+    const editGroup = document.getElementById('deepseekModelGroup')
+    const wizardGroup = document.getElementById('agentModelDeepseekGroup')
+    const hint = document.getElementById('deepseekHint')
+    for (const group of [editGroup, wizardGroup]) {
+      if (!group) continue
+      group.innerHTML = ''
+      if (deepseekModels.length === 0) {
+        group.style.display = 'none'
+        continue
+      }
+      group.style.display = ''
+      for (const m of deepseekModels) {
+        const opt = document.createElement('option')
+        opt.value = m.id
+        opt.textContent = m.label
+        group.appendChild(opt)
+      }
+    }
+    if (hint) hint.style.display = deepseekModels.length === 0 ? 'block' : 'none'
+  } catch { /* dashboard not available */ }
 }
 
 document.getElementById('saveModelBtn').addEventListener('click', async () => {
@@ -5825,3 +5859,12 @@ setInterval(pollUpdatesBadge, 5 * 60_000)
 populateAvatarGrid()
 loadMemAgents()
 loadOverview()
+loadAvailableModels()
+
+// "DeepSeek API kulcs hozzáadása" link az agent edit panel-en --
+// a Vault page-re visz, ahol a felhasználó egy DEEPSEEK_API_KEY
+// secret-et tud felvenni, és visszatérve frissítjük a model listát.
+document.getElementById('deepseekConfigLink')?.addEventListener('click', (e) => {
+  e.preventDefault()
+  switchPage('vault')
+})

--- a/web/index.html
+++ b/web/index.html
@@ -882,10 +882,14 @@
             <label for="agentModel">Modell</label>
             <select id="agentModel">
               <option value="inherit">Öröklött (alapértelmezett)</option>
-              <option value="claude-opus-4-7">Opus 4.7 (legújabb, legjobb)</option>
-              <option value="claude-opus-4-6">Opus 4.6</option>
-              <option value="claude-sonnet-4-6">Sonnet 4.6 (gyors és okos)</option>
-              <option value="claude-haiku-4-5-20251001">Haiku 4.5 (leggyorsabb)</option>
+              <optgroup label="☁️ Claude (felhő)">
+                <option value="claude-opus-4-7">Opus 4.7 (legújabb, legjobb)</option>
+                <option value="claude-opus-4-6">Opus 4.6</option>
+                <option value="claude-sonnet-4-6">Sonnet 4.6 (gyors és okos)</option>
+                <option value="claude-haiku-4-5-20251001">Haiku 4.5 (leggyorsabb)</option>
+              </optgroup>
+              <optgroup label="🌊 DeepSeek (alternatív)" id="agentModelDeepseekGroup">
+              </optgroup>
             </select>
           </div>
           <div class="form-group">
@@ -1019,10 +1023,15 @@
                 <option value="claude-sonnet-4-6">Sonnet 4.6 (alapértelmezett)</option>
                 <option value="claude-haiku-4-5-20251001">Haiku 4.5 (leggyorsabb)</option>
               </optgroup>
+              <optgroup label="🌊 DeepSeek (alternatív)" id="deepseekModelGroup">
+              </optgroup>
               <optgroup label="🏠 Ollama (lokális)" id="ollamaModelGroup">
               </optgroup>
             </select>
             <button class="btn-secondary btn-compact agent-save-section" id="saveModelBtn">Mentés</button>
+            <small id="deepseekHint" style="display:none;margin-top:6px;color:var(--text-muted);font-size:12px;line-height:1.4">
+              DeepSeek-V4-Pro nincs konfigurálva. <a href="#" id="deepseekConfigLink">API kulcs hozzáadása</a> a Vault oldalon.
+            </small>
           </div>
           <div class="form-group">
             <label for="editAgentProfile">Biztonsági profil</label>


### PR DESCRIPTION
## Summary
- Three-way model-prefix detection (claude-/deepseek-/ollama) in `agent-process.ts`; DeepSeek pulls the API key from the encrypted vault, not `process.env`, so it can be rotated from the dashboard without a restart.
- Skip `--continue` on first launch when the agent has no Claude Code projects dir yet — fixes the silent "No deferred tool marker found" exit that masked itself as a no-op Start in tmux.
- New `GET /api/models/available` endpoint gates `deepseek-v4-pro` behind the vault entry, so the UI can't offer a model that would 401 on first prompt.
- Wizard + edit panel render a 🌊 DeepSeek optgroup populated dynamically; missing key surfaces a hint linking to the Vault page.
- `setup.ts` adds an optional DeepSeek API key prompt after ElevenLabs (saved to the vault, not `.env`).

## Test plan
- [ ] Fresh clone + `bun run setup`: skip DeepSeek → existing flow unchanged. Provide a key → vault entry `DEEPSEEK_API_KEY` is created.
- [ ] `bun run typecheck` + `bun run build` clean (verified locally).
- [ ] Dashboard restart → wizard model dropdown shows DeepSeek group only when key is in vault.
- [ ] Edit existing agent → switch to `deepseek-v4-pro` → Stop/Start → tmux pane shows `claude --model deepseek-v4-pro` running and replies via Telegram.
- [ ] Without API key in vault: edit panel shows the "API kulcs hozzáadása" hint linking to the Vault page.
- [ ] First launch (no `~/.claude/projects/<encoded>/`) → no `--continue` flag, agent boots cleanly. Second launch → `--continue` is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)