### PR TITLE
fix(web): dismiss 'How is Claude doing this session' modal pre-flight

### DIFF
--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -143,10 +143,34 @@ export function getAgentProcessInfo(name: string): { running: boolean; session?:
   }
 }
 
+// Claude Code occasionally pops a "How is Claude doing this session? (optional)"
+// rating modal above the prompt input. The footer line still reads
+// "bypass permissions on (shift+tab to cycle)" so detectPaneState() classifies
+// the pane as idle, but the modal swallows the next keystroke and pinches off
+// every scheduled prompt + agent message until a human dismisses it. We strip
+// it pre-flight by sending "0" (Dismiss) when the marker is visible, so any
+// caller writing a prompt has a clear input field.
+const SURVEY_MODAL_RX = /How is Claude doing this session/
+
+function dismissSurveyModalIfPresent(session: string): void {
+  try {
+    const pane = execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
+    if (!SURVEY_MODAL_RX.test(pane)) return
+    execFileSync(TMUX, ['send-keys', '-t', session, '0'], { timeout: 5000 })
+    // Modal close is one frame; settle window so the next send-keys lands in
+    // the prompt input, not the now-stale modal handler.
+    execFileSync('/bin/sleep', ['0.3'], { timeout: 2000 })
+    logger.info({ session }, 'Dismissed Claude Code session-rating modal before sending prompt')
+  } catch (err) {
+    logger.warn({ err, session }, 'Failed to probe/dismiss session-rating modal')
+  }
+}
+
 // Send text to a tmux session as if typed at the prompt.
 // Uses execFileSync so callers can pass raw text -- tmux send-keys -l treats
 // the argument as literal characters, bypassing shell quoting entirely.
 export function sendPromptToSession(session: string, text: string): void {
+  dismissSurveyModalIfPresent(session)
   const oneLine = text.replace(/\r?\n/g, ' ')
   const CHUNK = 80
   // tmux send-keys doesn't support `--` option-terminator, so a chunk that


### PR DESCRIPTION
## Summary
Claude Code occasionally pops a session-rating modal ('1: Bad / 2: Fine / 3: Good / 0: Dismiss') above the prompt input. The footer still reads 'bypass permissions on (shift+tab to cycle)', so `detectPaneState()` classifies the pane as idle and `isSessionReadyForPrompt()` returns true — but the modal swallows keystrokes and every scheduled task + agent message piles up for ~30+ min ('Schedule target session busy or has pending input, will retry' loop) until a human dismisses it by hand.

`sendPromptToSession()` now probes for the modal marker pre-flight and presses '0' when present, with a 300ms settle window. Probe is one extra `capture-pane` per send (cheap); dismiss is a no-op when absent. One call site fixes both the message router and the scheduled-task launcher.

## Repro steps
1. Leave any agent session running long enough that Claude Code surfaces the rating modal.
2. Send any inter-agent message or wait for a scheduled task to fire.
3. Without this patch: pile-up of 'busy or has pending input, will retry' WARNs every 60s indefinitely.
4. With this patch: probe sees the modal, sends '0', waits 300ms, then the chunked prompt lands in the input box normally.

## Test plan
- [ ] Manually surface the modal in one agent (`How is Claude doing this session?` block visible in pane).
- [ ] Trigger an inter-agent message → confirm log line `Dismissed Claude Code session-rating modal before sending prompt`, modal disappears, agent processes the message.
- [ ] Healthy agent (no modal) still receives messages with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)