### PR TITLE
fix(memory): run daily digest sub-agent in a dedicated cwd

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,7 +17,8 @@ export async function runAgent(
   message: string,
   sessionId?: string,
   onTyping?: () => void,
-  allowTools = false
+  allowTools = false,
+  cwd: string = PROJECT_ROOT
 ): Promise<{ text: string | null; newSessionId?: string }> {
   let newSessionId: string | undefined
   let resultText: string | null = null
@@ -34,7 +35,7 @@ export async function runAgent(
       prompt: message,
       options: {
         abortController,
-        cwd: PROJECT_ROOT,
+        cwd,
         permissionMode: 'bypassPermissions',
         ...(allowTools ? {} : { disallowedTools: DEFAULT_DISALLOWED_TOOLS }),
         ...(sessionId ? { resume: sessionId } : {}),

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,3 +1,6 @@
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir, tmpdir } from 'node:os'
 import {
   searchMemories,
   recentMemories,
@@ -11,6 +14,29 @@ import {
 import { runAgent } from './agent.js'
 import { logger } from './logger.js'
 import { wrapUntrusted, UNTRUSTED_PREAMBLE } from './prompt-safety.js'
+
+// Dedicated cwd for the daily-digest sub-agent. We can't reuse PROJECT_ROOT
+// here -- the Marveen Telegram channels session runs claude --continue in
+// PROJECT_ROOT, and the SDK's per-cwd session/lock state collides with it
+// when two Claude Code processes share the same project dir, dropping the
+// channels plugin every night at 23:00. A throwaway dir under the user's
+// `~/.claude/projects/` tree avoids the collision while keeping the SDK
+// happy (it expects a writable cwd to place its session jsonl into).
+//
+// We honor TMPDIR via os.tmpdir() as a last-resort fallback so a hardened
+// host with a read-only home still has somewhere to land.
+function ensureDigestCwd(): string {
+  const candidates = [join(homedir(), '.claude', 'tmp', 'marveen-digest'), join(tmpdir(), 'marveen-digest')]
+  for (const dir of candidates) {
+    try {
+      mkdirSync(dir, { recursive: true })
+      return dir
+    } catch { /* try next */ }
+  }
+  // Last resort: tmpdir itself. Worst case we share with whatever else is
+  // in /tmp, but that still doesn't collide with the Marveen project dir.
+  return tmpdir()
+}
 
 // Semantic: user preferences, facts about themselves, persistent info
 const SEMANTIC_PATTERN =
@@ -133,13 +159,14 @@ Mai emlekek:
 ${memoryLines}`
 
   try {
-    const { text } = await runAgent(prompt)
+    const digestCwd = ensureDigestCwd()
+    const { text } = await runAgent(prompt, undefined, undefined, false, digestCwd)
     if (!text) return null
 
     const digest = text.trim()
     const today = new Date().toLocaleDateString('hu-HU')
     saveMemory(chatId, `[Napi naplo ${today}] ${digest}`, 'episodic')
-    logger.info({ chatId }, `Napi naplo mentve: ${today}`)
+    logger.info({ chatId, digestCwd }, `Napi naplo mentve: ${today}`)
     return digest
   } catch (err) {
     logger.error({ err }, 'Napi naplo generalas hiba')


### PR DESCRIPTION
## Summary
The 23:00 daily-digest timer in `src/index.ts` was running the sub-Claude-Code SDK call with `cwd = PROJECT_ROOT` — the same dir Marveen's Telegram channels session is sitting in. The SDK's per-cwd session/lock state collided with the running channels session and dropped the plugin's MCP connection every single night at 23:00, triggering the `telegram-monitor.ts` 4-stage recovery cascade. Switching the digest to a dedicated throwaway dir (`~/.claude/tmp/marveen-digest`, fallback `os.tmpdir()`) eliminates the collision without changing what the digest produces.

## Repro
Wait for 23:00. Without the patch, in the bot chat you see:
- 23:00 "Marveen Telegram plugin lecsatlakozott. Próbálok /mcp-vel reconnectálni..."
- 23:01 "/mcp nem segített. Szólok Marveennek hogy mentsen memóriát session resume előtt (~60s türelmi idő)."
- 23:02 "Memória mentés lejárt. Session resume (claude --continue) most..."

## Test plan
- [ ] `bun run typecheck` and `bun run build` clean (verified locally).
- [ ] Manually trigger a digest at a non-23:00 time (e.g. via REPL or test stub) and confirm `~/.claude/tmp/marveen-digest/` is created and the call completes.
- [ ] Wait one full overnight cycle: at 23:00, no `Marveen Telegram plugin lecsatlakozott` alert in the bot chat, no `Marveen Telegram plugin down -- stage 1` lines in `dashboard.log`.
- [ ] Confirm a `[Napi naplo YYYY.MM.DD.] ...` memory is still saved.

## Notes
- `runAgent` gains an optional `cwd` parameter, defaulting to `PROJECT_ROOT` so every existing caller is unchanged.
- `ensureDigestCwd()` falls through `~/.claude/tmp/marveen-digest` → `${tmpdir()}/marveen-digest` → bare `tmpdir()`. No-op when the first dir already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)