### PR TITLE
fix(pane-state): recognize background-shells footer variant

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -3,7 +3,7 @@ import { detectPaneState, isReadyForPrompt } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
 // output from shipping Claude Code builds. Whitespace and box-drawing
-// characters (U+2500 ─, U+2771 ❯, U+23F5 ⏵) preserved exactly so the
+// characters (U+2500 ─, U+276F ❯, U+23F5 ⏵) preserved exactly so the
 // regex matches exercise the same byte sequences they would in prod.
 
 const SEP = '─'.repeat(80)
@@ -115,6 +115,33 @@ const NON_CLAUDE = [
   'README.md  src/  test/',
 ].join('\n')
 
+// Background-shells footer variant. Claude Code rewrites the bypass-mode
+// footer when the session has one or more BashTool background shells
+// running: the "(shift+tab to cycle)" hint is replaced with the
+// "· N shells · ctrl+t to hide tasks · ↓ to manage" indicator. The pane
+// is still idle and must accept a new prompt -- otherwise inter-agent
+// messages and scheduled tasks pile up in pending forever for any agent
+// that polls (gh run list, watchers, etc.) in the background.
+const IDLE_BACKGROUND_SHELLS = [
+  '  85 tasks (84 done, 1 in progress, 0 open)',
+  '   … +80 completed',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on · 3 shells · ctrl+t to hide tasks · ↓ to manage',
+].join('\n')
+
+// Same variant with a single shell (singular form). Defensive: the regex
+// must accept both "shell" and "shells" so a 1-shell session is not stuck.
+const IDLE_BACKGROUND_ONE_SHELL = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on · 1 shell · ctrl+t to hide tasks · ↓ to manage',
+].join('\n')
+
 describe('detectPaneState', () => {
   it('returns unknown for empty input', () => {
     expect(detectPaneState('')).toBe('unknown')
@@ -127,6 +154,47 @@ describe('detectPaneState', () => {
 
   it('detects idle on strict-mode footer ("? for shortcuts")', () => {
     expect(detectPaneState(IDLE_STRICT)).toBe('idle')
+  })
+
+  it('detects idle when the footer shows the multi-shell indicator', () => {
+    // Regression: Claude Code rewrites "(shift+tab to cycle)" to
+    // "· N shells · ctrl+t to hide tasks · ↓ to manage" when the session
+    // has BashTool background shells running. The old strict regex did
+    // not match this variant, so any session with a background poll
+    // was classified 'unknown' and never received inter-agent messages.
+    expect(detectPaneState(IDLE_BACKGROUND_SHELLS)).toBe('idle')
+  })
+
+  it('detects idle when the footer shows the singular "1 shell" form', () => {
+    // The footer uses the singular "1 shell" (not "1 shells") for a
+    // single background shell. Split from the multi-shell test so a
+    // future regression on either form fails with a precise signal.
+    expect(detectPaneState(IDLE_BACKGROUND_ONE_SHELL)).toBe('idle')
+  })
+
+  it('does NOT classify a truncated "· N shell" prefix as idle', () => {
+    // Defense in depth: the shells-variant requires the full
+    // "· N shells · ctrl+t" marker, not just the bare prefix. Two
+    // reasons we pin this down with an explicit negative test:
+    //   1. A malformed or partially rendered footer (terminal
+    //      corruption, mid-render frame) must classify as 'unknown'
+    //      so we do not deliver a prompt into a pane that is not
+    //      really ready.
+    //   2. The "bypass permissions on · 1 shell" substring could
+    //      appear in scrollback as quoted log output or an echoed
+    //      message, and the regex must not be tricked into treating
+    //      that as a live footer.
+    // The fixture is deliberately minimal: no other idle markers
+    // (no "(shift+tab to cycle)", no "? for shortcuts") so the
+    // assertion isolates the truncated-shells path specifically.
+    const truncated = [
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on · 1 shell',
+    ].join('\n')
+    expect(detectPaneState(truncated)).toBe('unknown')
   })
 
   it('detects busy when "esc to interrupt" footer marker is present', () => {
@@ -285,6 +353,8 @@ describe('isReadyForPrompt', () => {
   it('is true only when state === idle', () => {
     expect(isReadyForPrompt(IDLE_BYPASS)).toBe(true)
     expect(isReadyForPrompt(IDLE_STRICT)).toBe(true)
+    expect(isReadyForPrompt(IDLE_BACKGROUND_SHELLS)).toBe(true)
+    expect(isReadyForPrompt(IDLE_BACKGROUND_ONE_SHELL)).toBe(true)
     expect(isReadyForPrompt(BUSY_FULL_FOOTER)).toBe(false)
     expect(isReadyForPrompt(BUSY_FOOTER_FRAME_GAP)).toBe(false)
     expect(isReadyForPrompt(TYPING_PARKED)).toBe(false)

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -25,7 +25,25 @@ export type PaneState = 'idle' | 'busy' | 'typing' | 'unknown'
 // permissions mode (permissive) and the "strict" mode. Both are "idle"
 // surfaces. If neither is visible the pane is not a recognised Claude
 // Code surface and we report 'unknown' rather than guess.
-const IDLE_FOOTER_RX = /bypass permissions on \(shift\+tab to cycle\)|\? for shortcuts/
+//
+// The bypass-mode footer has two known trailing variants after the
+// "bypass permissions on" prefix: the original "(shift+tab to cycle)"
+// hint, and the newer background-shells indicator "· N shells · ctrl+t
+// to hide tasks · ↓ to manage" which Claude Code substitutes when one
+// or more BashTool background shells are running in the session. Both
+// must classify as idle, otherwise sessions that spawn background
+// shells (gh poll, file watchers, long-running build) get stuck
+// pending forever.
+//
+// The shells-variant requires the "· ctrl+t" marker after the shell
+// count rather than just the bare "· N shell(s)" prefix. Two reasons:
+//   (a) the full marker is what Claude Code actually renders, so
+//       insisting on it rejects malformed or mid-render frames;
+//   (b) it disambiguates the footer from scrollback content that
+//       happens to contain "bypass permissions on · 1 shell" verbatim
+//       (an echoed log line, a quoted message, etc.) which would
+//       otherwise be misread as idle.
+const IDLE_FOOTER_RX = /bypass permissions on(?: \(shift\+tab to cycle\)| · \d+ shells? · ctrl\+t)|\? for shortcuts/
 
 // Positive busy signals. ANY match anywhere in the pane means the turn
 // is mid-flight, even if the footer looks idle for a frame.


### PR DESCRIPTION
## Why this matters

A Claude Code session that runs one or more BashTool background shells (e.g. `gh run list` polling, file watchers, long-running build) gets a dynamically rewritten footer: the original `bypass permissions on (shift+tab to cycle)` becomes `bypass permissions on · N shells · ctrl+t to hide tasks · ↓ to manage`. The existing `IDLE_FOOTER_RX` in `src/pane-state.ts` only matched the original suffix, so any session in this state classified as `'unknown'`, `isSessionReadyForPrompt` returned `false`, and the message router plus scheduled-task runner refused to deliver. Inter-agent messages and scheduled tasks then queued in the database for up to the abandon window (60 minutes) before being marked failed.

Live reproduction observed: a session running three background polls had four inbound messages stuck for 28, 33, 17, and 15 minutes respectively. After the patched dashboard restart, all four delivered within 90 seconds as the recipient pane became free between turns.

## Change

- `src/pane-state.ts` -- `IDLE_FOOTER_RX` widened from `/bypass permissions on \(shift\+tab to cycle\)|\? for shortcuts/` to `/bypass permissions on(?: \(shift\+tab to cycle\)| · \d+ shells? · ctrl\+t)|\? for shortcuts/`. Comment block above the regex expanded to document the two trailing variants and the rationale for requiring the `· ctrl+t` marker rather than the bare `· N shell(s)` prefix (full marker is what Claude Code actually renders, plus it disambiguates the footer from scrollback lines that contain the bare prefix verbatim).
- `src/__tests__/pane-state.test.ts` -- two positive fixtures (multi-shell `IDLE_BACKGROUND_SHELLS` and singular `IDLE_BACKGROUND_ONE_SHELL`), one negative fixture (truncated `· 1 shell` without the `· ctrl+t` tail), three new `it()` blocks on `detectPaneState`, plus two new assertions added to the existing `isReadyForPrompt` block to pin the public-API contract end-to-end. The header comment is also corrected: the old comment listed `U+2771` but the glyph used by every fixture is `U+276F` (`❯`). The codepoint fix is bundled in this commit because it documents the characters used by the new fixtures.

## Scope and compatibility

No change to:
- Busy-state detection (BUSY_INDICATORS scanned first, unchanged)
- Strict-mode footer detection (`? for shortcuts` still recognised)
- Parked-input typing detection (`PARKED_INPUT_RX` scan unchanged)
- Pending-paste handling (`PENDING_PASTE_RX` unchanged)
- The `IDLE_FOOTER_RX` strict-mode alternation precedence (the `\? for shortcuts` branch matches in isolation as before, intentional, exercised by the existing `IDLE_STRICT` fixture)

Backwards compatible: a session whose footer still uses the old `(shift+tab to cycle)` form continues to classify as idle, and every existing test passes unchanged.

## Test plan

- `npm run typecheck` -- clean
- `npx vitest run --root . --dir src/__tests__` -- 336 passed (was 333, +3 new)
- Live reproduction: 4 inbound messages had been stuck for 28 to 55 minutes; all four delivered within 90 seconds after the patched dashboard restart

## Known limitations and follow-ups

- A pre-existing race exists in the input-box scan: `findIndex` returns the first `IDLE_FOOTER_RX` match in the pane string. If a long-history tmux session retains a previous Claude Code footer in scrollback, the scan can lock onto the stale footer and misread the corresponding stale input box. This patch widens `IDLE_FOOTER_RX`, so the practical surface of this race grows from one pattern to two. The race itself is out of scope for this PR; a follow-up will switch `findIndex` -> `findLastIndex` to anchor on the live (bottom-most) footer. Tracked separately.
- ANSI escape sequences in the captured pane: current callers of `capture-pane` do not pass `-e`, so escapes are stripped. If a future caller adds `-e` and Claude Code injects colour escapes between `bypass permissions on` and the trailing variant, the regex will silently miss the footer. Out of scope here.
