### PR TITLE
feat(install): scaffold default scheduled tasks (folyamatos-ellenorzes)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -378,6 +378,33 @@ if [ -f "$INSTALL_DIR/templates/SOUL.md.template" ] && [ ! -f "$INSTALL_DIR/SOUL
   ok "SOUL.md generalva"
 fi
 
+# Default scheduled tasks scaffoldolasa ~/.claude/scheduled-tasks/ ala. A
+# template-ek {{MAIN_AGENT_ID}} placeholdert hasznalnak, igy a felhasznalo
+# valasztott agent slugja kerul be a hardcoded "marveen" helyett. Letezo task
+# konyvtarakat soha nem irjuk felul.
+SCHED_TPL_DIR="$INSTALL_DIR/templates/scheduled-tasks"
+SCHED_TARGET_DIR="$HOME/.claude/scheduled-tasks"
+if [ -d "$SCHED_TPL_DIR" ]; then
+  mkdir -p "$SCHED_TARGET_DIR"
+  for tpl in "$SCHED_TPL_DIR"/*/; do
+    [ -d "$tpl" ] || continue
+    task_name=$(basename "$tpl")
+    target="$SCHED_TARGET_DIR/$task_name"
+    if [ -d "$target" ]; then
+      continue
+    fi
+    mkdir -p "$target"
+    for f in "$tpl"*; do
+      [ -f "$f" ] || continue
+      sed -e "s/{{MAIN_AGENT_ID}}/$MAIN_AGENT_ID/g" \
+          -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
+          -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
+          "$f" > "$target/$(basename "$f")"
+    done
+    ok "Utemezett feladat scaffoldolva: $task_name"
+  done
+fi
+
 # Telegram csatorna konfiguralasa
 if [ -n "$BOT_TOKEN" ] && [ "$BOT_TOKEN" != "" ]; then
   TELEGRAM_DIR="$HOME/.claude/channels/telegram"

--- a/install.sh
+++ b/install.sh
@@ -252,6 +252,33 @@ if [ -f "$INSTALL_DIR/templates/SOUL.md.template" ] && [ ! -f "$INSTALL_DIR/SOUL
   echo -e "  ${GREEN}✓${NC} SOUL.md generalva"
 fi
 
+# Scaffold default scheduled tasks into ~/.claude/scheduled-tasks/. Templates
+# carry {{MAIN_AGENT_ID}} placeholders so tasks target the user's chosen agent
+# slug rather than hardcoded "marveen". Skip task dirs that already exist --
+# never overwrite user customizations.
+SCHED_TPL_DIR="$INSTALL_DIR/templates/scheduled-tasks"
+SCHED_TARGET_DIR="$HOME/.claude/scheduled-tasks"
+if [ -d "$SCHED_TPL_DIR" ]; then
+  mkdir -p "$SCHED_TARGET_DIR"
+  for tpl in "$SCHED_TPL_DIR"/*/; do
+    [ -d "$tpl" ] || continue
+    task_name=$(basename "$tpl")
+    target="$SCHED_TARGET_DIR/$task_name"
+    if [ -d "$target" ]; then
+      continue
+    fi
+    mkdir -p "$target"
+    for f in "$tpl"*; do
+      [ -f "$f" ] || continue
+      sed -e "s/{{MAIN_AGENT_ID}}/$MAIN_AGENT_ID/g" \
+          -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
+          -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
+          "$f" > "$target/$(basename "$f")"
+    done
+    echo -e "  ${GREEN}✓${NC} Utemezett feladat scaffoldolva: $task_name"
+  done
+fi
+
 # Setup Telegram channel
 if [ -n "$BOT_TOKEN" ] && [ "$BOT_TOKEN" != "" ]; then
   TELEGRAM_DIR="$HOME/.claude/channels/telegram"

--- a/templates/scheduled-tasks/folyamatos-ellenorzes/SKILL.md
+++ b/templates/scheduled-tasks/folyamatos-ellenorzes/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: folyamatos-ellenorzes
+description: Teljes ellenőrzés
+---
+
+Ellenorizd: 1) Naptar - van-e meeting 1 oran belul? 2) Email - jott-e surgos level az elmult oraban? 3) Kanban - van-e mai hataridovel kartya? Ha BARMIT talalsz ami fontos, szolj Telegramon tomoren. Ha minden csendes, ne irj semmit.

--- a/templates/scheduled-tasks/folyamatos-ellenorzes/task-config.json
+++ b/templates/scheduled-tasks/folyamatos-ellenorzes/task-config.json
@@ -1,0 +1,6 @@
+{
+  "schedule": "*/30 * * * *",
+  "agent": "{{MAIN_AGENT_ID}}",
+  "enabled": false,
+  "type": "heartbeat"
+}


### PR DESCRIPTION
## Summary
- New `templates/scheduled-tasks/` directory carrying default scheduled task scaffolds. First entry: **folyamatos-ellenorzes** (calendar/email/kanban check every 30 min, `enabled: false`).
- `install.sh` and `install-linux.sh` extended with a copy-and-substitute loop after the SOUL.md generation: for each template task dir, if it doesn't already exist under `~/.claude/scheduled-tasks/`, copy it and `sed`-replace `{{MAIN_AGENT_ID}}`, `{{BOT_NAME}}`, `{{OWNER_NAME}}`.
- Existing user task dirs are NEVER overwritten — the scaffold is opt-in via the dashboard.

## Why
Before this PR, fresh installs landed with zero scheduled tasks. The `folyamatos-ellenorzes` (continuous calendar/email/kanban check) is broadly useful and was previously buried in user-side configuration. Users with non-default agent slugs (anything other than "marveen") would have had to wire it up manually.

## Test plan
- [x] `bash -n install.sh` and `bash -n install-linux.sh` pass syntax check
- [x] `sed` substitution test: `MAIN_AGENT_ID=testbot` → output JSON valid, `"agent": "testbot"`
- [ ] On a fresh install, verify `~/.claude/scheduled-tasks/folyamatos-ellenorzes/` is created with the user's agent slug and `enabled: false`
- [ ] Re-running the installer leaves an existing user-modified task dir intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)