### PR TITLE
fix(pane-state): widen shells-variant tail to recognize hidden-tasks footer

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -142,6 +142,33 @@ const IDLE_BACKGROUND_ONE_SHELL = [
   '  ⏵⏵ bypass permissions on · 1 shell · ctrl+t to hide tasks · ↓ to manage',
 ].join('\n')
 
+// Background-shells footer with the tasks panel HIDDEN. When the
+// operator (or the agent) presses ctrl+t to hide the tasks panel,
+// Claude Code drops the "ctrl+t to hide tasks" segment and renders a
+// shorter footer: "· N shells · ↓ to manage". The pane is still idle;
+// the only difference is that the toggle hint is gone because the panel
+// it would toggle is already hidden. Observed in production on a sub-
+// agent session where the operator had hidden the tasks panel.
+const IDLE_BACKGROUND_SHELLS_HIDDEN = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on · 3 shells · ↓ to manage',
+].join('\n')
+
+// Same hidden-tasks variant with a single shell (singular form).
+// Defensive: covers the corner where a session has exactly one
+// background shell AND the tasks panel is hidden, so neither the
+// plural form nor the ctrl+t segment is present.
+const IDLE_BACKGROUND_ONE_SHELL_HIDDEN = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on · 1 shell · ↓ to manage',
+].join('\n')
+
 describe('detectPaneState', () => {
   it('returns unknown for empty input', () => {
     expect(detectPaneState('')).toBe('unknown')
@@ -172,10 +199,22 @@ describe('detectPaneState', () => {
     expect(detectPaneState(IDLE_BACKGROUND_ONE_SHELL)).toBe('idle')
   })
 
+  it('detects idle when the tasks panel is HIDDEN (no "ctrl+t" segment)', () => {
+    // Claude Code drops the "ctrl+t to hide tasks" segment when the
+    // tasks panel is already hidden, leaving "· N shells · ↓ to manage"
+    // as the only suffix. The pane is still idle, just with a shorter
+    // footer. The previous regex only matched the "ctrl+t" form, so
+    // sessions with the tasks panel hidden were classified 'unknown'
+    // and inter-agent messages stalled until the next manual toggle.
+    expect(detectPaneState(IDLE_BACKGROUND_SHELLS_HIDDEN)).toBe('idle')
+    expect(detectPaneState(IDLE_BACKGROUND_ONE_SHELL_HIDDEN)).toBe('idle')
+  })
+
   it('does NOT classify a truncated "· N shell" prefix as idle', () => {
-    // Defense in depth: the shells-variant requires the full
-    // "· N shells · ctrl+t" marker, not just the bare prefix. Two
-    // reasons we pin this down with an explicit negative test:
+    // Defense in depth: the shells-variant requires either the
+    // "· N shells · ctrl+t" marker or the "· N shells · ↓ to manage"
+    // marker, not just the bare "· N shell(s)" prefix. Two reasons we
+    // pin this down with an explicit negative test:
     //   1. A malformed or partially rendered footer (terminal
     //      corruption, mid-render frame) must classify as 'unknown'
     //      so we do not deliver a prompt into a pane that is not
@@ -355,6 +394,8 @@ describe('isReadyForPrompt', () => {
     expect(isReadyForPrompt(IDLE_STRICT)).toBe(true)
     expect(isReadyForPrompt(IDLE_BACKGROUND_SHELLS)).toBe(true)
     expect(isReadyForPrompt(IDLE_BACKGROUND_ONE_SHELL)).toBe(true)
+    expect(isReadyForPrompt(IDLE_BACKGROUND_SHELLS_HIDDEN)).toBe(true)
+    expect(isReadyForPrompt(IDLE_BACKGROUND_ONE_SHELL_HIDDEN)).toBe(true)
     expect(isReadyForPrompt(BUSY_FULL_FOOTER)).toBe(false)
     expect(isReadyForPrompt(BUSY_FOOTER_FRAME_GAP)).toBe(false)
     expect(isReadyForPrompt(TYPING_PARKED)).toBe(false)

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -26,24 +26,28 @@ export type PaneState = 'idle' | 'busy' | 'typing' | 'unknown'
 // surfaces. If neither is visible the pane is not a recognised Claude
 // Code surface and we report 'unknown' rather than guess.
 //
-// The bypass-mode footer has two known trailing variants after the
+// The bypass-mode footer has known trailing variants after the
 // "bypass permissions on" prefix: the original "(shift+tab to cycle)"
-// hint, and the newer background-shells indicator "· N shells · ctrl+t
-// to hide tasks · ↓ to manage" which Claude Code substitutes when one
-// or more BashTool background shells are running in the session. Both
-// must classify as idle, otherwise sessions that spawn background
-// shells (gh poll, file watchers, long-running build) get stuck
-// pending forever.
+// hint, and the background-shells indicator which Claude Code
+// substitutes when one or more BashTool background shells are running
+// in the session. The background-shells indicator itself comes in two
+// shapes depending on whether the tasks panel is visible:
+//   - tasks visible:  "· N shells · ctrl+t to hide tasks · ↓ to manage"
+//   - tasks hidden:   "· N shells · ↓ to manage"
+// All variants must classify as idle, otherwise sessions that spawn
+// background shells (gh poll, file watchers, long-running build) get
+// stuck pending forever.
 //
-// The shells-variant requires the "· ctrl+t" marker after the shell
-// count rather than just the bare "· N shell(s)" prefix. Two reasons:
-//   (a) the full marker is what Claude Code actually renders, so
-//       insisting on it rejects malformed or mid-render frames;
+// The shells-variant requires either the "· ctrl+t" marker or the
+// "· ↓ to manage" tail after the shell count, rather than just the
+// bare "· N shell(s)" prefix. Two reasons:
+//   (a) one of these tails is always what Claude Code actually renders,
+//       so insisting on either rejects malformed or mid-render frames;
 //   (b) it disambiguates the footer from scrollback content that
 //       happens to contain "bypass permissions on · 1 shell" verbatim
 //       (an echoed log line, a quoted message, etc.) which would
 //       otherwise be misread as idle.
-const IDLE_FOOTER_RX = /bypass permissions on(?: \(shift\+tab to cycle\)| · \d+ shells? · ctrl\+t)|\? for shortcuts/
+const IDLE_FOOTER_RX = /bypass permissions on(?: \(shift\+tab to cycle\)| · \d+ shells? · (?:ctrl\+t|↓ to manage))|\? for shortcuts/
 
 // Positive busy signals. ANY match anywhere in the pane means the turn
 // is mid-flight, even if the footer looks idle for a frame.


### PR DESCRIPTION
## Why this matters

Follow-up to #61. After #61 widened `IDLE_FOOTER_RX` for the background-shells footer (`bypass permissions on · N shells · ctrl+t to hide tasks · ↓ to manage`), live observation showed Claude Code actually emits a SHORTER form when the tasks panel is hidden: `bypass permissions on · N shells · ↓ to manage` (the `· ctrl+t to hide tasks` segment is dropped because the panel it would toggle is already hidden).

The post-#61 regex required `· ctrl+t` after `· N shells`, so a session with the tasks panel hidden classified as `'unknown'`, `isSessionReadyForPrompt` returned `false`, and the message router refused to deliver. Inter-agent messages and scheduled tasks queued in the database for up to the abandon window (60 minutes) before being marked failed.

Live reproduction observed: a session in this state had four inbound messages stuck for 28, 33, 17, and 15 minutes respectively before delivery resumed when the next pane state allowed it. Multi-snapshot tmux capture-pane confirmed the footer is stably in the tasks-hidden form for that session.

## Change

- `src/pane-state.ts` -- the shells-variant tail in `IDLE_FOOTER_RX` was widened from `· ctrl\+t` to `(?:ctrl\+t|↓ to manage)`. The full regex is now `/bypass permissions on(?: \(shift\+tab to cycle\)| · \d+ shells? · (?:ctrl\+t|↓ to manage))|\? for shortcuts/`. The comment block above the regex was extended to document both subforms (tasks visible vs tasks hidden) and to update the rationale paragraph (the requirement is now "either ctrl+t or ↓ to manage", not just "ctrl+t").
- `src/__tests__/pane-state.test.ts` -- two new fixtures (`IDLE_BACKGROUND_SHELLS_HIDDEN` and `IDLE_BACKGROUND_ONE_SHELL_HIDDEN`, the tasks-hidden subform with multi-shell and singular-shell counts) plus a new `it()` block covering both, plus two new assertions added to the existing `isReadyForPrompt` block to pin the public-API contract end-to-end.

## Scope and compatibility

No change to:
- Busy-state detection (BUSY_INDICATORS scanned first, unchanged)
- Strict-mode footer detection (`? for shortcuts` still recognised)
- The original bypass-mode footer (`(shift+tab to cycle)`) remains recognised
- The tasks-visible shells-variant from #61 (`· N shells · ctrl+t to hide tasks · ↓ to manage`) remains recognised via the `ctrl\+t` branch of the new alternation
- Parked-input typing detection (PARKED_INPUT_RX scan unchanged)
- Pending-paste handling (PENDING_PASTE_RX unchanged)

Backwards compatible: every existing test passes unchanged. The negative test (truncated `bypass permissions on · 1 shell` without either tail marker) continues to classify as `'unknown'` because neither alternation member is satisfied.

## Test plan

- `npm run typecheck` -- clean
- `npx vitest run --root . --dir src/__tests__` -- 337 passed (was 336 after #61, +1 new it block)
- Five known real-world variants verified to match (legacy bypass, bypass + PR-suffix, shells with ctrl+t, shells without ctrl+t, strict-mode)
- Negative test (truncated prefix) verified to NOT match

## Known limitations and follow-ups

- The pre-existing `findIndex` race in the input-box scan (locks onto the first `IDLE_FOOTER_RX` match in the pane string, which can be a stale footer in scrollback for long-history tmux sessions) remains out of scope. The widened regex grows the surface of this race from two to three patterns; a follow-up will switch to `findLastIndex` to anchor on the bottom-most footer.
- ANSI escape sequences in the captured pane: current callers do not pass `-e` to `capture-pane`, so escapes are stripped. If a future caller adds `-e` and Claude Code injects colour escapes between `bypass permissions on` and the trailing variant, the regex will silently miss the footer. Out of scope here.
