### PR TITLE
fix(scheduler): heartbeat tasks skip on busy instead of queueing

### DIFF
--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -254,6 +254,16 @@ export function startScheduleRunner(): NodeJS.Timeout {
         if (pendingKeys.has(key)) continue
         const result = attemptFireTask(task, agentName, now)
         if (result === 'busy') {
+          // Heartbeat tasks fire on their own cron cadence (typically every
+          // 30 minutes) and are explicitly best-effort: a single skipped
+          // tick is fine because the next one is already on the way.
+          // Queueing them produces spurious "60 perce varakozik" Telegram
+          // alerts whenever the operator is having an active conversation
+          // in the channels session, which is the exact situation in which
+          // a heartbeat is least useful anyway. Real tasks (type !==
+          // 'heartbeat') still queue + alert so nothing business-critical
+          // is dropped silently.
+          if (task.type === 'heartbeat') continue
           // First encounter -- insert a new pending row. If somehow a
           // row already exists (race with a just-cancelled retry), do
           // nothing so the cancel wins the tiebreak.


### PR DESCRIPTION
## Summary
- Heartbeat scheduled tasks now drop the current tick silently when the target session is busy, instead of being inserted into the pending-retry queue and eventually escalating via Telegram.
- Real tasks (type !== 'heartbeat') keep the queue + 60-min Telegram alert behavior unchanged.

## Why
Heartbeat tasks already fire on a ~30-min cron cadence and are best-effort by design — if the operator has a live conversation in the channels session, the very next tick will re-attempt anyway. Queueing them up produced a Telegram "60 perce varakozik" alert every time the operator did >1h of focused work, which is the exact moment a heartbeat is least useful. Twice in the same session today the alert fired for `memoria-heartbeat (marveen)` while the operator was actively driving the agent through a stack of PRs.

## Test plan
- [x] `npm run build` passes
- [ ] After merge + dashboard restart: leave the channels session busy through one heartbeat tick, verify no row appears in `/api/schedules/pending` and no Telegram alert fires
- [ ] Schedule a non-heartbeat task with `agent: marveen`, leave the session busy, verify the row IS queued and the existing 60-min alert path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)