### PR TITLE
feat(scheduler): add skipIfBusy task flag to drop short-cadence ticks silently

### DIFF
--- a/src/web/routes/schedules.ts
+++ b/src/web/routes/schedules.ts
@@ -110,7 +110,7 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
       throw err
     }
     const data = JSON.parse(body.toString()) as {
-      name: string; description: string; prompt: string; schedule: string; agent?: string; type?: string
+      name: string; description: string; prompt: string; schedule: string; agent?: string; type?: string; skipIfBusy?: boolean
     }
     const name = sanitizeScheduleName(data.name || '')
     if (!name) { json(res, { error: 'Name is required' }, 400); return true }
@@ -134,6 +134,7 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
       agent: data.agent || MAIN_AGENT_ID,
       enabled: true,
       type: data.type || 'task',
+      skipIfBusy: data.skipIfBusy === true,
     })
     logger.info({ name, schedule: data.schedule }, 'Scheduled task created')
     json(res, { ok: true, name })
@@ -157,7 +158,7 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
       throw err
     }
     const data = JSON.parse(body.toString()) as {
-      description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean
+      description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean
     }
     if (data.prompt !== undefined && data.prompt.length > MAX_SCHEDULED_TASK_PROMPT_LEN) {
       json(res, {

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -254,6 +254,17 @@ export function startScheduleRunner(): NodeJS.Timeout {
         if (pendingKeys.has(key)) continue
         const result = attemptFireTask(task, agentName, now)
         if (result === 'busy') {
+          if (task.skipIfBusy) {
+            // Opt-in skip for short-cadence tasks (e.g. 30-min heartbeats):
+            // a single missed tick is harmless because the next one is
+            // already on the way, and queueing them produces spurious
+            // "60 perce varakozik" Telegram alerts whenever the operator
+            // is having an active conversation in the channels session.
+            // Daily/weekly schedules keep skipIfBusy=false so the queue
+            // + alert path catches a long-running busy state.
+            logger.info({ task: task.name, agent: agentName }, 'Schedule busy, skipIfBusy=true: dropping tick silently')
+            continue
+          }
           // First encounter -- insert a new pending row. If somehow a
           // row already exists (race with a just-cancelled retry), do
           // nothing so the cancel wins the tiebreak.

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -22,6 +22,13 @@ export interface ScheduledTask {
   enabled: boolean
   createdAt: number
   type?: 'task' | 'heartbeat'  // heartbeat = silent unless important
+  // When true, a tick whose target session is busy is dropped silently
+  // instead of queued. Use ONLY for cron schedules that fire often enough
+  // (every 30-60 min) that losing a single tick is harmless because the
+  // next one is already on the way. Daily/weekly schedules must keep
+  // skipIfBusy false (default) so the queue + alert path catches a
+  // long-running busy state and nothing business-critical is lost.
+  skipIfBusy?: boolean
 }
 
 function readFileOr(path: string, fallback: string): string {
@@ -51,7 +58,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const skillContent = readFileOr(skillPath, '')
   const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
@@ -65,6 +72,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
     enabled: config.enabled !== false,
     createdAt: config.createdAt || 0,
     type: (config.type as 'task' | 'heartbeat') || 'task',
+    skipIfBusy: config.skipIfBusy === true,
   }
 }
 
@@ -83,7 +91,7 @@ export function listScheduledTasks(): ScheduledTask[] {
 
 export function writeScheduledTask(
   taskName: string,
-  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string },
+  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean },
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
@@ -107,6 +115,7 @@ export function writeScheduledTask(
   if (data.agent !== undefined) config.agent = data.agent
   if (data.enabled !== undefined) config.enabled = data.enabled
   if (data.type !== undefined) config.type = data.type
+  if (data.skipIfBusy !== undefined) config.skipIfBusy = data.skipIfBusy
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }

--- a/templates/scheduled-tasks/folyamatos-ellenorzes/task-config.json
+++ b/templates/scheduled-tasks/folyamatos-ellenorzes/task-config.json
@@ -2,5 +2,6 @@
   "schedule": "*/30 * * * *",
   "agent": "{{MAIN_AGENT_ID}}",
   "enabled": false,
-  "type": "heartbeat"
+  "type": "heartbeat",
+  "skipIfBusy": true
 }


### PR DESCRIPTION
## Summary
- New optional `skipIfBusy` boolean on each scheduled task. When true, a tick whose target session is busy is dropped silently instead of queued — no row in `pending_task_retries`, no 60-min Telegram alert.
- Default false everywhere. Daily and weekly schedules keep the existing queue + alert path so nothing business-critical is lost.
- Wired through the `ScheduledTask` interface, the schedules POST/PUT routes (so the dashboard can edit the flag), and the busy branch of `schedule-runner.ts`.
- The bundled `templates/scheduled-tasks/folyamatos-ellenorzes/task-config.json` opts in (every-30-min cadence, losing one tick is harmless).

## Why
The earlier "skip all heartbeat-typed tasks on busy" approach (closed PR) was too coarse: several daily 1× tasks (billing, financial alerts, daily invoice processing) are also typed `heartbeat` and skipping them would mean that day's processing simply doesn't run. The granular opt-in lets short-cadence pulse tasks (every 30 min) drop silently while preserving the queue-and-alert safety net for everything else.

## Test plan
- [x] `npm run build` passes
- [ ] After merge + dashboard restart: leave the channels session busy through one `memoria-heartbeat` tick (skipIfBusy=true), verify NO row in `/api/schedules/pending` and NO Telegram alert
- [ ] Schedule a non-skip task with `agent: marveen`, leave the session busy, verify the row IS queued and the existing 60-min alert path still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)