### PR TITLE
fix(memory): isolate daily-digest sub-agent from telegram plugin

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -18,7 +18,8 @@ export async function runAgent(
   sessionId?: string,
   onTyping?: () => void,
   allowTools = false,
-  cwd: string = PROJECT_ROOT
+  cwd: string = PROJECT_ROOT,
+  env?: Record<string, string | undefined>,
 ): Promise<{ text: string | null; newSessionId?: string }> {
   let newSessionId: string | undefined
   let resultText: string | null = null
@@ -39,6 +40,7 @@ export async function runAgent(
         permissionMode: 'bypassPermissions',
         ...(allowTools ? {} : { disallowedTools: DEFAULT_DISALLOWED_TOOLS }),
         ...(sessionId ? { resume: sessionId } : {}),
+        ...(env ? { env: { ...process.env, ...env } } : {}),
       },
     })
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from 'node:fs'
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir, tmpdir } from 'node:os'
 import {
@@ -35,6 +35,35 @@ function ensureDigestCwd(): string {
   }
   // Last resort: tmpdir itself. Worst case we share with whatever else is
   // in /tmp, but that still doesn't collide with the Marveen project dir.
+  return tmpdir()
+}
+
+// The daily digest sub-agent inherits the host's CLAUDE_CONFIG_DIR
+// (~/.claude/) by default, which means it loads the user's globally
+// enabled plugins -- including telegram@claude-plugins-official. The
+// Telegram Bot API only allows ONE active getUpdates connection per
+// token, so the sub-agent's plugin steals the connection from the
+// long-running marveen-channels session, which then logs as
+// "plugin lecsatlakozott" at 23:00 every night when runDailyDigest
+// fires. Workaround: hand the sub-agent a private CLAUDE_CONFIG_DIR
+// with `enabledPlugins: {}` so it never spawns the Telegram MCP. The
+// dir is created idempotently on first use; the settings.json is
+// written only if missing so the user can edit it later if needed.
+function ensureDigestConfigDir(): string {
+  const candidates = [
+    join(homedir(), '.claude', 'tmp', 'marveen-digest-config'),
+    join(tmpdir(), 'marveen-digest-config'),
+  ]
+  for (const dir of candidates) {
+    try {
+      mkdirSync(dir, { recursive: true })
+      const settingsPath = join(dir, 'settings.json')
+      if (!existsSync(settingsPath)) {
+        writeFileSync(settingsPath, JSON.stringify({ enabledPlugins: {} }, null, 2))
+      }
+      return dir
+    } catch { /* try next */ }
+  }
   return tmpdir()
 }
 
@@ -160,13 +189,16 @@ ${memoryLines}`
 
   try {
     const digestCwd = ensureDigestCwd()
-    const { text } = await runAgent(prompt, undefined, undefined, false, digestCwd)
+    const digestConfigDir = ensureDigestConfigDir()
+    const { text } = await runAgent(prompt, undefined, undefined, false, digestCwd, {
+      CLAUDE_CONFIG_DIR: digestConfigDir,
+    })
     if (!text) return null
 
     const digest = text.trim()
     const today = new Date().toLocaleDateString('hu-HU')
     saveMemory(chatId, `[Napi naplo ${today}] ${digest}`, 'episodic')
-    logger.info({ chatId, digestCwd }, `Napi naplo mentve: ${today}`)
+    logger.info({ chatId, digestCwd, digestConfigDir }, `Napi naplo mentve: ${today}`)
     return digest
   } catch (err) {
     logger.error({ err }, 'Napi naplo generalas hiba')


### PR DESCRIPTION
## Summary
- Daily-digest sub-agent now runs with a private `CLAUDE_CONFIG_DIR` (`~/.claude/tmp/marveen-digest-config/`) that has `enabledPlugins: {}`. The sub-agent therefore never loads the Telegram plugin and cannot steal the bot connection from the long-running channels session.
- Added optional `env` parameter to `runAgent` that flows into the SDK's `Options.env` (merged on top of `process.env`) so the override is scoped to the spawned Claude Code child only — the parent dashboard's `process.env` is untouched.

## Why
PR #59 fixed the SDK session-lock collision by giving the digest its own CWD, but the bigger issue stayed: the sub-agent inherited the host's `~/.claude/` and loaded every globally enabled plugin. Telegram's Bot API allows only ONE active `getUpdates` connection per bot token, so when the sub-agent fired up its own `telegram@claude-plugins-official` MCP, the server-side connection token migrated, the long-running channels session lost its connection, and the operator saw a 23:00 disconnect every night. Logs show the timing precisely: `Napi naplo mentve` at 23:00:18, `Marveen Telegram plugin down` at 23:00:34.

## Test plan
- [x] `npm run build` passes
- [ ] After merge + dashboard restart: wait for the next 23:00 digest, verify the channels session does NOT disconnect (no `Marveen Telegram plugin down` warn around 23:00:30)
- [ ] Confirm `[Napi naplo YYYY-MM-DD]` memory still gets saved (digest itself still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)