### PR TITLE
fix(agent-process): post-restart pre-flight modal dismiss

### DIFF
--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -98,6 +98,30 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     )
 
     logger.info({ name, session, tgStateDir }, 'Agent tmux session started')
+
+    // After a restart with --continue, a session that's been idle for >24h
+    // shows the "Resume from summary" modal before the prompt input is ready
+    // (113.6k tokens at 2d age in observed cases). Until the operator either
+    // sends a new prompt or dismisses the modal, every scheduled task and
+    // every inter-agent message stalls because isSessionReadyForPrompt sees
+    // a non-idle pane state. The pre-flight dismiss baked into
+    // sendPromptToSession only fires on outgoing traffic -- so on a fresh
+    // restart with no inbound, the modal can sit indefinitely.
+    //
+    // Fire a delayed dismiss after Claude Code has had time to render the
+    // modal. 8 seconds is a comfortable margin in observed restarts (modal
+    // typically appears within 4-6s). Survey-rating modals from prior
+    // sessions can also be present, so dismiss both. Errors are swallowed
+    // -- the outbound pre-flight remains the safety net if this misses.
+    setTimeout(() => {
+      try {
+        dismissSurveyModalIfPresent(session)
+        dismissResumeSummaryModalIfPresent(session)
+      } catch (err) {
+        logger.warn({ err, name, session }, 'Post-restart modal dismiss failed')
+      }
+    }, 8000)
+
     return { ok: true }
   } catch (err) {
     logger.error({ err, name }, 'Failed to start agent tmux session')


### PR DESCRIPTION
## Summary
- After a tmux restart with \`--continue\` lands on a stale (>24h) session, Claude Code pops the "Resume from summary" modal **before** the prompt input is ready. Until the operator dismisses it, scheduled tasks and inter-agent messages stall on \`isSessionReadyForPrompt\`.
- The existing pre-flight dismiss in \`sendPromptToSession\` only fires on outbound traffic, so a fresh restart with no inbound can sit on the modal indefinitely.
- Schedule a delayed dismiss 8s after the tmux spawn (modal typically appears within 4-6s). Both \`Resume from summary\` and \`How is Claude doing this session\` (the older rating modal) are checked. Errors are swallowed — the outbound pre-flight remains the safety net if this misses.

## Why
Observed today on Iris: restart with \`--continue\` brought up a 2d-old, 113.6k-token session, hung on the modal. Operator had to dismiss manually. Same pattern likely on any agent restarted after a long idle.

## Test plan
- [x] \`npm run build\` passes
- [ ] After merge + dashboard restart: stop and start any agent that has a >24h session, verify the modal auto-dismisses within ~10s and the pane settles into bypass-permissions idle state without operator action.
- [ ] Inbound flow still works (existing pre-flight): scheduled task fires into the freshly-restarted session, no double-dismiss issues, no missed prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)