### PR TITLE
fix(telegram-monitor): soft reconnect via Up wraparound to Telegram entry

### DIFF
--- a/src/web/telegram-monitor.ts
+++ b/src/web/telegram-monitor.ts
@@ -150,6 +150,14 @@ function navigateToMenuItem(session: string, pattern: RegExp, maxSteps: number =
 }
 
 function softReconnectMarveen(): boolean {
+  // The /mcp picker highlights the selected entry with a background colour
+  // (not a `❯` prefix), so `tmux capture-pane -p` (ASCII) cannot read which
+  // row the cursor is on. The picker does, however, wrap around: a single
+  // `Up` press from the default top-of-list position lands on the very last
+  // entry — which is `plugin:telegram:telegram` because Built-in MCPs come
+  // after all claude.ai connectors. Then Enter opens the Telegram submenu,
+  // where `❯ 1. View tools` is the default highlight; one Down moves to
+  // `2. Reconnect`, Enter triggers it.
   try {
     // Escape interrupts any in-progress turn, making the session ready
     execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
@@ -164,43 +172,38 @@ function softReconnectMarveen(): boolean {
       execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
       return false
     }
-    logger.info({ paneContent: pane1.slice(-500) }, 'soft reconnect: /mcp pane')
-
-    if (!navigateToMenuItem(MAIN_CHANNELS_SESSION, /telegram/i)) {
-      logger.warn('soft reconnect: Telegram not found in /mcp menu')
+    if (!/plugin:telegram:telegram/i.test(pane1)) {
+      logger.warn({ paneContent: pane1.slice(-500) }, 'soft reconnect: /mcp picker did not render telegram entry')
       execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
       return false
     }
+
+    // Wraparound: Up from top → last entry (plugin:telegram:telegram)
+    execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Up'], { timeout: 3000 })
+    execFileSync('/bin/sleep', ['0.3'], { timeout: 1000 })
 
     execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Enter'], { timeout: 3000 })
     execFileSync('/bin/sleep', ['1'], { timeout: 3000 })
 
-    // Verify we entered the Telegram submenu, not Gmail/Calendar/Drive
+    // Verify: the submenu header reads "Plugin:telegram:telegram MCP Server"
     const pane2 = capturePane(MAIN_CHANNELS_SESSION)
-    if (!pane2) {
-      logger.warn('soft reconnect: failed to capture submenu')
-      execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
-      return false
-    }
-    logger.info({ paneContent: pane2.slice(-500) }, 'soft reconnect: submenu after Enter')
-
-    if (!/telegram/i.test(pane2)) {
-      logger.warn('soft reconnect: entered wrong submenu (not Telegram), backing out')
+    if (!pane2 || !/Plugin:telegram:telegram MCP Server/i.test(pane2)) {
+      logger.warn(
+        { paneContent: pane2 ? pane2.slice(-500) : 'null' },
+        'soft reconnect: did not enter Telegram submenu (Up+Enter wrong target?)',
+      )
       execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
       return false
     }
 
-    if (!navigateToMenuItem(MAIN_CHANNELS_SESSION, /reconnect/i)) {
-      logger.warn('soft reconnect: Reconnect not found in Telegram submenu')
-      execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
-      return false
-    }
-
+    // Submenu cursor defaults to "❯ 1. View tools"; one Down → "2. Reconnect"
+    execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Down'], { timeout: 3000 })
+    execFileSync('/bin/sleep', ['0.3'], { timeout: 1000 })
     execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Enter'], { timeout: 3000 })
     execFileSync('/bin/sleep', ['2'], { timeout: 4000 })
 
     execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
-    logger.info('soft reconnect: /mcp → Telegram → Reconnect completed')
+    logger.info('soft reconnect: /mcp → Up (telegram) → Enter → Down (Reconnect) → Enter completed')
     return true
   } catch (err) {
     logger.warn({ err }, 'Marveen soft reconnect failed')


### PR DESCRIPTION
## Summary

The previous `softReconnectMarveen()` used `navigateToMenuItem(/telegram/i)` which scans for the `❯` cursor in the captured pane. But the `/mcp` picker highlights the selected row with a background colour (only the submenu uses `❯`), so the regex never matched the telegram row and recovery always escalated to stage 2 (memory save) even though the plugin could have been reconnected with two keystrokes.

Replace the per-step search with a deterministic flow that exploits two TUI properties:

1. The `/mcp` picker wraps around: from the default top-of-list (first claude.ai connector), a single `Up` press lands on the last entry, which is `plugin:telegram:telegram` (Built-in MCPs come last, computer-use is second-to-last).
2. The submenu cursor defaults to `❯ 1. View tools`; one `Down` moves to `2. Reconnect`, Enter triggers it.

So the sequence is: `/mcp` → `Up` → `Enter` → submenu-title-verify → `Down` → `Enter` → `Esc`. Pre-flight check that `plugin:telegram:telegram` is even rendered in the picker; submenu-title check that the Up+Enter landed in the right place (defensive: protects against future picker re-orderings).

## Test plan

- [x] `npm run build` typechecks clean
- [x] Manually verified the Up-wraparound + submenu-Down flow on agent-zara session: `/mcp` + Up + Enter lands on `Plugin:telegram:telegram MCP Server` submenu
- [ ] After merge + dashboard restart, observe the next 30-min TUI MCP idle reconnect cycle and confirm soft reconnect succeeds (no stage 2/3 escalation in dashboard.log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)