### PR TITLE
feat(update): auto-stash dirty working tree on opt-in

### DIFF
--- a/src/web/routes/updates.ts
+++ b/src/web/routes/updates.ts
@@ -12,7 +12,7 @@ import {
   checkUpdatePreflight, checkNoConcurrentUpdate, classifyLockWriteError,
   type GitRunner, type PidfileRunner,
 } from '../../update-preflight.js'
-import { json } from '../http-helpers.js'
+import { json, readBody } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
 
 // Pidfile path owned by update.sh for the lifetime of an update run.
@@ -36,6 +36,20 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
   }
 
   if (path === '/api/updates/apply' && method === 'POST') {
+    // Optional body { autoStash: true } turns the dirty-tree precheck
+    // failure into a managed stash + pop pattern inside update.sh.
+    // Without it, a dirty working tree returns 409 'dirty-tree' as before.
+    let autoStash = false
+    try {
+      const buf = await readBody(ctx.req)
+      if (buf.length > 0) {
+        const parsed = JSON.parse(buf.toString()) as { autoStash?: unknown }
+        autoStash = parsed.autoStash === true
+      }
+    } catch {
+      // Empty/invalid body: treat as autoStash=false. Real validation lives
+      // at update.sh's own dirty-tree check; this is just a hint.
+    }
     const pf: PidfileRunner = {
       readPidfile: () => {
         try {
@@ -128,14 +142,20 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
       return true
     }
     if (!preflight.ok) {
-      releaseLock()
-      const body: Record<string, unknown> = {
-        error: preflight.message,
-        reason: preflight.reason,
+      // dirty-tree + autoStash=true: skip the dashboard-side block and let
+      // update.sh handle the stash+pop. Other failure reasons (detached HEAD,
+      // not-on-main, …) still hard-block since stash cannot rescue them.
+      const skipForAutoStash = preflight.reason === 'dirty-tree' && autoStash
+      if (!skipForAutoStash) {
+        releaseLock()
+        const body: Record<string, unknown> = {
+          error: preflight.message,
+          reason: preflight.reason,
+        }
+        if (preflight.reason === 'not-on-main') body.branch = preflight.branch
+        json(res, body, 409)
+        return true
       }
-      if (preflight.reason === 'not-on-main') body.branch = preflight.branch
-      json(res, body, 409)
-      return true
     }
     try {
       let outFd: number | 'ignore' = 'ignore'
@@ -149,6 +169,7 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
         cwd: PROJECT_ROOT,
         detached: true,
         stdio: ['ignore', outFd, outFd],
+        env: { ...process.env, AUTO_STASH: autoStash ? '1' : '0' },
       })
       child.on('error', (err) => {
         logger.error({ err }, 'update.sh spawn reported an async error')

--- a/update.sh
+++ b/update.sh
@@ -115,12 +115,29 @@ fi
 # scratchpads) are allowed -- the --untracked-files=no flag excludes
 # them. Only staged or unstaged modifications to already-tracked files
 # are a block.
+#
+# AUTO_STASH=1 (set by the dashboard's "Frissítés stash-elve" button)
+# turns the block into a managed stash + pop pattern: stash before
+# pulling, restore after a successful update. If the pop fails because
+# the upstream change conflicts with the stash, we drop the stash and
+# emit a warning so the operator does not lose work silently -- the
+# stash entry is also kept in `git stash list` for manual recovery.
+STASHED_AUTO=0
 DIRTY=$(git status --porcelain --untracked-files=no | head -n 1)
 if [ -n "$DIRTY" ]; then
-  echo -e "${RED}HIBA:${NC} A working tree modosult allapotban van."
-  echo "       Commitold vagy stasheld a valtozasokat, majd indithatod ujra:"
-  echo "         git stash"
-  exit 3
+  if [ "${AUTO_STASH:-0}" = "1" ]; then
+    echo -e "  Lokalis valtozasok stash-elve (auto-stash)..."
+    if ! git stash push --keep-index -m "marveen-update-auto-stash $(date +%Y%m%d-%H%M%S)"; then
+      echo -e "${RED}HIBA:${NC} Auto-stash sikertelen. Nezd meg: git status"
+      exit 3
+    fi
+    STASHED_AUTO=1
+  else
+    echo -e "${RED}HIBA:${NC} A working tree modosult allapotban van."
+    echo "       Commitold vagy stasheld a valtozasokat, majd indithatod ujra:"
+    echo "         git stash"
+    exit 3
+  fi
 fi
 
 # Save current version
@@ -175,6 +192,19 @@ npm run build --silent
 # token and loop on 409 Conflict. Safe to run every update.
 if command -v tmux >/dev/null 2>&1; then
   tmux set-environment -g -u TELEGRAM_BOT_TOKEN 2>/dev/null || true
+fi
+
+# Restore auto-stashed local changes before restarting services.
+# A stash conflict here typically means the upstream rebase touched
+# the same lines the operator had locally; we drop and warn rather
+# than block the restart, but the entry stays in `git stash list`
+# until the operator deals with it.
+if [ "$STASHED_AUTO" = "1" ]; then
+  echo -e "  Auto-stash visszaallitasa..."
+  if ! git stash pop; then
+    echo -e "${RED}FIGYELEM:${NC} Auto-stash pop konfliktusos -- a stash benne marad a 'git stash list'-ben."
+    echo -e "          Manualisan kezeld: git stash list / git stash apply / git stash drop"
+  fi
 fi
 
 # Restart services

--- a/web/app.js
+++ b/web/app.js
@@ -5820,8 +5820,7 @@ document.getElementById('updatesCheckBtn').addEventListener('click', async () =>
   btn.disabled = false
 })
 
-document.getElementById('updatesApplyBtn').addEventListener('click', async () => {
-  if (!confirm('Frissítés most. A szolgáltatások újraindulnak, a dashboard ~30 másodpercig nem érhető el. Folytatod?')) return
+async function runUpdate(autoStash) {
   const btn = document.getElementById('updatesApplyBtn')
   btn.disabled = true
   btn.querySelector('.btn-text').hidden = true
@@ -5832,13 +5831,24 @@ document.getElementById('updatesApplyBtn').addEventListener('click', async () =>
     btn.querySelector('.btn-loading').hidden = true
   }
   try {
-    const res = await fetch('/api/updates/apply', { method: 'POST' })
+    const res = await fetch('/api/updates/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ autoStash: autoStash === true }),
+    })
     // Parse the body regardless of status so preflight reasons
     // (not-on-main / dirty-tree / detached-head returned as 409 by
     // the backend) land in the toast instead of a bare "HTTP 409".
     const data = await res.json().catch(() => ({}))
     if (!res.ok) {
       resetBtn()
+      // dirty-tree without autoStash: offer the auto-stash retry inline.
+      if (data.reason === 'dirty-tree' && !autoStash) {
+        if (confirm('A working tree-ben lokális változtatások vannak. Stash-eljem őket automatikusan, frissítsek, majd visszaállítsam?')) {
+          await runUpdate(true)
+        }
+        return
+      }
       showToast('Frissítés nem indult: ' + (data.error || ('HTTP ' + res.status)))
       return
     }
@@ -5848,6 +5858,11 @@ document.getElementById('updatesApplyBtn').addEventListener('click', async () =>
     resetBtn()
     showToast('Hiba: ' + (err.message || err))
   }
+}
+
+document.getElementById('updatesApplyBtn').addEventListener('click', async () => {
+  if (!confirm('Frissítés most. A szolgáltatások újraindulnak, a dashboard ~30 másodpercig nem érhető el. Folytatod?')) return
+  await runUpdate(false)
 })
 
 // Poll the badge on startup and every 5 min so the nav link reflects


### PR DESCRIPTION
Adds an opt-in auto-stash flow so operators with local tracked-file edits can run the dashboard updater without hand-stashing on the terminal. Backend forwards AUTO_STASH=1 to update.sh; UI retries with one confirm on the dirty-tree 409.