### PR TITLE
feat(agents): multi-channel binding UI for Telegram

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,14 @@ import {
 import { join } from 'node:path'
 import { execFileSync, execSync } from 'node:child_process'
 import type { Server as HttpServer } from 'node:http'
-import { STORE_DIR, WEB_PORT, ALLOWED_CHAT_ID } from './config.js'
+import { STORE_DIR, WEB_PORT, ALLOWED_CHAT_ID, MAIN_AGENT_ID } from './config.js'
 import { initDatabase } from './db.js'
 import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
+import { startInviteMonitor, stopInviteMonitor } from './web/telegram-invites.js'
+import { AGENTS_BASE_DIR } from './web/agent-config.js'
 import {
   acquirePortLock,
   acquirePidfileLock,
@@ -341,6 +343,7 @@ const shutdown = (): void => {
     if (heartbeatStarted) {
       try { stopHeartbeat() } catch (err) { logger.warn({ err }, 'stopHeartbeat threw during shutdown') }
     }
+    try { stopInviteMonitor() } catch (err) { logger.warn({ err }, 'stopInviteMonitor threw during shutdown') }
     if (decayInterval) clearInterval(decayInterval)
     if (digestTimer) clearTimeout(digestTimer)
     if (digestInterval) clearInterval(digestInterval)
@@ -427,6 +430,9 @@ async function main(): Promise<void> {
   initHeartbeat()
   heartbeatStarted = true
   logger.info('Heartbeat utemezo elindult')
+
+  // Telegram invite auto-approve monitor (one-click pairing).
+  startInviteMonitor(MAIN_AGENT_ID, AGENTS_BASE_DIR)
 
   // Web dashboard
   webServer = startWebServer(WEB_PORT)

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -31,11 +31,17 @@ import {
 } from '../agent-team.js'
 import {
   readAgentTelegramConfig,
+  readMarveenTelegramConfig,
   sendAvatarChangeMessage,
   sendWelcomeMessage,
   validateTelegramToken,
   parseTelegramToken,
 } from '../telegram.js'
+import {
+  createInvite,
+  listInvites,
+  revokeInvite,
+} from '../telegram-invites.js'
 import {
   writeAgentSettingsFromProfile,
   scaffoldAgentDir,
@@ -541,6 +547,93 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     } catch {
       json(res, { users: [], groups: [] })
     }
+    return true
+  }
+
+  // POST /api/agents/:name/telegram/invites
+  // Generates a one-time deep-link token. The invite-monitor auto-approves
+  // the next pending entry during the validity window, then re-locks
+  // dmPolicy to 'allowlist' once no live invites remain.
+  const tgInviteCreateMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/invites$/)
+  if (tgInviteCreateMatch && method === 'POST') {
+    const name = decodeURIComponent(tgInviteCreateMatch[1])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
+      json(res, { error: 'Agent not found' }, 404)
+      return true
+    }
+    let botUsername: string | undefined
+    if (name === MAIN_AGENT_ID) {
+      botUsername = readMarveenTelegramConfig().botUsername
+    } else {
+      botUsername = readAgentTelegramConfig(name).botUsername
+    }
+    if (!botUsername) {
+      const tokenPath = name === MAIN_AGENT_ID
+        ? join(homedir(), '.claude', 'channels', 'telegram', '.env')
+        : join(agentDir(name), '.claude', 'channels', 'telegram', '.env')
+      try {
+        const env = readFileOr(tokenPath, '')
+        const m = env.match(/TELEGRAM_BOT_TOKEN=(.+)/)
+        const tok = m?.[1]?.trim()
+        if (tok) {
+          const r = await validateTelegramToken(tok)
+          if (r.ok) botUsername = r.botUsername
+        }
+      } catch { /* ignore */ }
+    }
+    const accessPath = name === MAIN_AGENT_ID
+      ? join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
+      : join(agentDir(name), '.claude', 'channels', 'telegram', 'access.json')
+    try {
+      const result = createInvite(accessPath, botUsername)
+      json(res, result)
+    } catch (err) {
+      logger.error({ err }, 'Failed to create invite')
+      json(res, { error: 'Failed to create invite' }, 500)
+    }
+    return true
+  }
+
+  // GET /api/agents/:name/telegram/invites
+  const tgInviteListMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/invites$/)
+  if (tgInviteListMatch && method === 'GET') {
+    const name = decodeURIComponent(tgInviteListMatch[1])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
+      json(res, { error: 'Agent not found' }, 404)
+      return true
+    }
+    const accessPath = name === MAIN_AGENT_ID
+      ? join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
+      : join(agentDir(name), '.claude', 'channels', 'telegram', 'access.json')
+    let botUsername: string | undefined
+    if (name === MAIN_AGENT_ID) {
+      botUsername = readMarveenTelegramConfig().botUsername
+    } else {
+      botUsername = readAgentTelegramConfig(name).botUsername
+    }
+    const items = listInvites(accessPath).map((inv) => ({
+      ...inv,
+      deepLink: botUsername ? `https://t.me/${botUsername}?start=invite-${inv.token}` : undefined,
+    }))
+    json(res, items)
+    return true
+  }
+
+  // DELETE /api/agents/:name/telegram/invites/:token
+  const tgInviteRevokeMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/invites\/(.+)$/)
+  if (tgInviteRevokeMatch && method === 'DELETE') {
+    const name = decodeURIComponent(tgInviteRevokeMatch[1])
+    const token = decodeURIComponent(tgInviteRevokeMatch[2])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
+      json(res, { error: 'Agent not found' }, 404)
+      return true
+    }
+    const accessPath = name === MAIN_AGENT_ID
+      ? join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
+      : join(agentDir(name), '.claude', 'channels', 'telegram', 'access.json')
+    const ok = revokeInvite(accessPath, token)
+    if (!ok) { json(res, { error: 'Invite not found' }, 404); return true }
+    json(res, { ok: true })
     return true
   }
 

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -520,6 +520,64 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     return true
   }
 
+  // GET /api/agents/:name/telegram/allowed
+  // Returns the live allowlist: DM senders (allowFrom) + groups.
+  const tgAllowedListMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/allowed$/)
+  if (tgAllowedListMatch && method === 'GET') {
+    const name = decodeURIComponent(tgAllowedListMatch[1])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
+      json(res, { error: 'Agent not found' }, 404)
+      return true
+    }
+    const accessPath = name === MAIN_AGENT_ID
+      ? join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
+      : join(agentDir(name), '.claude', 'channels', 'telegram', 'access.json')
+    const accessContent = readFileOr(accessPath, '{}')
+    try {
+      const access = JSON.parse(accessContent)
+      const users: string[] = Array.isArray(access.allowFrom) ? access.allowFrom : []
+      const groups = Object.entries(access.groups || {}).map(([id, policy]) => ({ id, policy }))
+      json(res, { users, groups })
+    } catch {
+      json(res, { users: [], groups: [] })
+    }
+    return true
+  }
+
+  // DELETE /api/agents/:name/telegram/allowed/:type/:id
+  // type = "user" or "group", id = senderId or groupId.
+  const tgAllowedRemoveMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/allowed\/(user|group)\/(.+)$/)
+  if (tgAllowedRemoveMatch && method === 'DELETE') {
+    const name = decodeURIComponent(tgAllowedRemoveMatch[1])
+    const kind = tgAllowedRemoveMatch[2]
+    const id = decodeURIComponent(tgAllowedRemoveMatch[3])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
+      json(res, { error: 'Agent not found' }, 404)
+      return true
+    }
+    const tgDir = name === MAIN_AGENT_ID
+      ? join(homedir(), '.claude', 'channels', 'telegram')
+      : join(agentDir(name), '.claude', 'channels', 'telegram')
+    const accessPath = join(tgDir, 'access.json')
+    try {
+      const access = JSON.parse(readFileOr(accessPath, '{}'))
+      if (kind === 'user') {
+        access.allowFrom = (access.allowFrom || []).filter((s: string) => s !== id)
+        const approvedFile = join(tgDir, 'approved', id)
+        try { if (existsSync(approvedFile)) unlinkSync(approvedFile) } catch { /* ignore */ }
+      } else {
+        if (access.groups) delete access.groups[id]
+      }
+      atomicWriteFileSync(accessPath, JSON.stringify(access, null, 2))
+      logger.info({ name, kind, id }, 'Telegram allowlist entry removed')
+      json(res, { ok: true })
+    } catch (err) {
+      logger.error({ err }, 'Failed to remove allowlist entry')
+      json(res, { error: 'Failed to remove allowlist entry' }, 500)
+    }
+    return true
+  }
+
   const startMatch = path.match(/^\/api\/agents\/([^/]+)\/start$/)
   if (startMatch && method === 'POST') {
     const name = decodeURIComponent(startMatch[1])

--- a/src/web/telegram-invites.ts
+++ b/src/web/telegram-invites.ts
@@ -1,0 +1,250 @@
+// Telegram invite tokens for one-click pairing.
+//
+// Flow:
+// 1. Operator generates an invite via POST /api/agents/:name/telegram/invites.
+//    The token + expiry is stored in access.json under `invites`.
+//    If dmPolicy was 'allowlist', it is flipped to 'pairing' so the bot will
+//    actually issue codes for unknown senders during the validity window.
+// 2. The invitee opens the deep-link, Telegram triggers /start, the plugin
+//    creates a pending entry in access.json (standard pairing behaviour).
+// 3. This monitor (started in src/index.ts) polls access.json files every
+//    few seconds. When it sees a pending entry land while at least one
+//    non-used, non-expired invite token exists for that agent, it
+//    auto-approves the entry: marks the token used, moves the senderId
+//    into allowFrom, drops the pending row, restores allowlist policy if
+//    no other invites are still active.
+//
+// The invite-token is a "shared secret" that grants exactly one auto-approve.
+// Tokens are 16 random bytes (base64url, ~22 chars), unguessable in practice.
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { randomBytes } from 'node:crypto'
+import { logger } from '../logger.js'
+import { agentDir } from './agent-config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+
+interface InviteEntry {
+  createdAt: number
+  expiresAt: number
+  used: boolean
+  usedBy?: string // senderId who consumed it
+  usedAt?: number
+}
+
+interface AccessFile {
+  dmPolicy?: 'pairing' | 'allowlist' | 'disabled'
+  allowFrom?: string[]
+  groups?: Record<string, unknown>
+  pending?: Record<string, { senderId: string; chatId: string; createdAt: number; expiresAt: number; replies?: number }>
+  invites?: Record<string, InviteEntry>
+}
+
+const INVITE_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000 // 24h
+
+export function tgChannelDir(name: string, mainAgentId: string): string {
+  return name === mainAgentId
+    ? join(homedir(), '.claude', 'channels', 'telegram')
+    : join(agentDir(name), '.claude', 'channels', 'telegram')
+}
+
+function readAccess(path: string): AccessFile {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as AccessFile
+  } catch {
+    return {}
+  }
+}
+
+function writeAccess(path: string, data: AccessFile): void {
+  mkdirSync(join(path, '..'), { recursive: true })
+  atomicWriteFileSync(path, JSON.stringify(data, null, 2))
+}
+
+function pruneInvites(access: AccessFile, now: number): boolean {
+  if (!access.invites) return false
+  let mutated = false
+  for (const [token, inv] of Object.entries(access.invites)) {
+    if (inv.expiresAt < now && !inv.used) {
+      delete access.invites[token]
+      mutated = true
+    }
+  }
+  return mutated
+}
+
+function activeInviteCount(access: AccessFile, now: number): number {
+  if (!access.invites) return 0
+  let n = 0
+  for (const inv of Object.values(access.invites)) {
+    if (!inv.used && inv.expiresAt >= now) n++
+  }
+  return n
+}
+
+export interface CreateInviteResult {
+  token: string
+  expiresAt: number
+  deepLink?: string
+}
+
+export function createInvite(
+  accessPath: string,
+  botUsername: string | undefined,
+  ttlMs: number = INVITE_DEFAULT_TTL_MS,
+): CreateInviteResult {
+  const access = readAccess(accessPath)
+  const now = Date.now()
+  pruneInvites(access, now)
+
+  const token = randomBytes(16).toString('base64url').slice(0, 22)
+  const entry: InviteEntry = {
+    createdAt: now,
+    expiresAt: now + ttlMs,
+    used: false,
+  }
+  access.invites = access.invites || {}
+  access.invites[token] = entry
+
+  // While at least one invite is active the bot must accept unknown senders
+  // long enough to issue a pairing code; otherwise the standard plugin gate
+  // drops them silently. The monitor flips the policy back to 'allowlist'
+  // once every invite is either used or expired.
+  if (access.dmPolicy !== 'disabled') access.dmPolicy = 'pairing'
+
+  writeAccess(accessPath, access)
+
+  const deepLink = botUsername
+    ? `https://t.me/${botUsername}?start=invite-${token}`
+    : undefined
+  return { token, expiresAt: entry.expiresAt, deepLink }
+}
+
+export function listInvites(accessPath: string): Array<{ token: string; createdAt: number; expiresAt: number; used: boolean; usedBy?: string; deepLink?: string }> {
+  const access = readAccess(accessPath)
+  const now = Date.now()
+  if (pruneInvites(access, now)) writeAccess(accessPath, access)
+  if (!access.invites) return []
+  return Object.entries(access.invites).map(([token, inv]) => ({
+    token,
+    createdAt: inv.createdAt,
+    expiresAt: inv.expiresAt,
+    used: inv.used,
+    usedBy: inv.usedBy,
+  }))
+}
+
+export function revokeInvite(accessPath: string, token: string): boolean {
+  const access = readAccess(accessPath)
+  if (!access.invites?.[token]) return false
+  delete access.invites[token]
+  // If there are no more active invites, lock the policy back down.
+  if (activeInviteCount(access, Date.now()) === 0) {
+    access.dmPolicy = 'allowlist'
+  }
+  writeAccess(accessPath, access)
+  return true
+}
+
+// Iterate every agent's access.json; auto-approve a pending entry when a
+// non-used invite is alive. Idempotent: pending rows are removed once
+// consumed, and tokens flip used=true so the same invite can't approve
+// twice.
+export function runInviteMonitorTick(mainAgentId: string, agentsRoot: string): void {
+  // Build the list of agents to scan: the main agent (global ~/.claude
+  // channel) plus every agents/<name>/.claude/channels/telegram/access.json
+  // that exists on disk.
+  const targets: Array<{ name: string; accessPath: string }> = []
+  const mainAccess = join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
+  if (existsSync(mainAccess)) targets.push({ name: mainAgentId, accessPath: mainAccess })
+  if (existsSync(agentsRoot)) {
+    let entries: string[]
+    try { entries = readdirSync(agentsRoot) } catch { entries = [] }
+    for (const e of entries) {
+      const p = join(agentsRoot, e, '.claude', 'channels', 'telegram', 'access.json')
+      if (existsSync(p)) targets.push({ name: e, accessPath: p })
+    }
+  }
+
+  for (const { name, accessPath } of targets) {
+    const access = readAccess(accessPath)
+    if (!access.invites || !access.pending) continue
+
+    const now = Date.now()
+    const expiredOrUsed = pruneInvites(access, now)
+
+    // Find the oldest unused, non-expired invite (FIFO).
+    const live = Object.entries(access.invites)
+      .filter(([, inv]) => !inv.used && inv.expiresAt >= now)
+      .sort((a, b) => a[1].createdAt - b[1].createdAt)
+    if (live.length === 0) {
+      if (expiredOrUsed && activeInviteCount(access, now) === 0 && access.dmPolicy === 'pairing') {
+        access.dmPolicy = 'allowlist'
+        writeAccess(accessPath, access)
+      }
+      continue
+    }
+
+    // Find the oldest pending entry created after the oldest live invite was
+    // issued (FIFO match). createdAt ordering is enough — we don't need to
+    // tie a specific sender to a specific token; any new pending during the
+    // invite window consumes the next available token.
+    const pendingEntries = Object.entries(access.pending)
+      .sort((a, b) => a[1].createdAt - b[1].createdAt)
+    if (pendingEntries.length === 0) continue
+
+    const [pCode, pEntry] = pendingEntries[0]
+    const [tToken, tEntry] = live[0]
+
+    // Auto-approve: move sender into allowFrom, drop pending row, mark token used.
+    if (!access.allowFrom) access.allowFrom = []
+    if (!access.allowFrom.includes(pEntry.senderId)) access.allowFrom.push(pEntry.senderId)
+    delete access.pending[pCode]
+
+    tEntry.used = true
+    tEntry.usedBy = pEntry.senderId
+    tEntry.usedAt = now
+
+    // After consuming this invite, if no others remain alive, lock back down.
+    if (activeInviteCount(access, now) === 0) access.dmPolicy = 'allowlist'
+
+    // Mirror what /telegram/approve does: drop a marker file under approved/
+    // so the plugin can short-circuit subsequent gate checks.
+    try {
+      const approvedDir = join(accessPath, '..', 'approved')
+      mkdirSync(approvedDir, { recursive: true })
+      writeFileSync(join(approvedDir, pEntry.senderId), '')
+    } catch (err) {
+      logger.warn({ err, name, senderId: pEntry.senderId }, 'invite-monitor: failed to write approved marker')
+    }
+
+    writeAccess(accessPath, access)
+    logger.info({ name, senderId: pEntry.senderId, token: tToken }, 'Telegram invite auto-approved')
+  }
+}
+
+let inviteMonitorInterval: NodeJS.Timeout | null = null
+
+export function startInviteMonitor(mainAgentId: string, agentsRoot: string, intervalMs = 3000): void {
+  if (inviteMonitorInterval) return
+  // First tick immediately so a freshly-created invite + pending pair is
+  // resolved without waiting a full interval.
+  try { runInviteMonitorTick(mainAgentId, agentsRoot) } catch (err) {
+    logger.error({ err }, 'invite-monitor first tick failed')
+  }
+  inviteMonitorInterval = setInterval(() => {
+    try {
+      runInviteMonitorTick(mainAgentId, agentsRoot)
+    } catch (err) {
+      logger.error({ err }, 'invite-monitor tick failed')
+    }
+  }, intervalMs)
+  logger.info({ intervalMs }, 'Telegram invite monitor elindult')
+}
+
+export function stopInviteMonitor(): void {
+  if (inviteMonitorInterval) {
+    clearInterval(inviteMonitorInterval)
+    inviteMonitorInterval = null
+  }
+}

--- a/web/app.js
+++ b/web/app.js
@@ -1268,6 +1268,7 @@ function updateTelegramTab(agent) {
   if (connected) {
     refreshPendingPairings()
     refreshAllowedList()
+    refreshInvites()
   }
 }
 
@@ -1434,6 +1435,101 @@ async function removeAllowed(kind, id) {
 }
 
 document.getElementById('tgRefreshAllowedBtn').addEventListener('click', refreshAllowedList)
+
+async function refreshInvites() {
+  if (!currentAgent) return
+  const listEl = document.getElementById('tgInviteList')
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/telegram/invites`)
+    if (!res.ok) return
+    const items = await res.json()
+    if (!items.length) {
+      listEl.innerHTML = '<div class="tg-allowed-empty">Nincs aktív meghívó link.</div>'
+      return
+    }
+    listEl.innerHTML = ''
+    for (const inv of items) {
+      const item = document.createElement('div')
+      item.className = 'tg-allowed-item'
+      const expiresIn = Math.max(0, Math.floor((inv.expiresAt - Date.now()) / 60000))
+      const status = inv.used
+        ? `<span class="tg-allowed-kind" style="background:rgba(180,180,180,0.15); color:var(--text-muted);">FELHASZNÁLT</span>`
+        : `<span class="tg-allowed-kind tg-allowed-kind-group">AKTÍV (${expiresIn}p)</span>`
+      const linkHtml = inv.deepLink
+        ? `<a href="${escapeHtml(inv.deepLink)}" target="_blank" class="tg-allowed-id" style="text-decoration:underline;">${escapeHtml(inv.deepLink)}</a>`
+        : `<span class="tg-allowed-id">(bot username nélkül)</span>`
+      item.innerHTML = `
+        <div class="tg-allowed-meta" style="flex-wrap:wrap; gap:6px;">
+          ${status}
+          ${linkHtml}
+        </div>
+        <div style="display:flex; gap:6px;">
+          ${inv.deepLink && !inv.used ? `<button class="btn-secondary btn-compact" data-link="${escapeHtml(inv.deepLink)}" style="padding:4px 10px; font-size:11px; margin:0;">Másol</button>` : ''}
+          <button class="btn-icon-danger" title="Visszavonás" data-token="${escapeHtml(inv.token)}">&times;</button>
+        </div>
+      `
+      const copyBtn = item.querySelector('button[data-link]')
+      if (copyBtn) {
+        copyBtn.addEventListener('click', async (e) => {
+          const link = e.currentTarget.getAttribute('data-link')
+          try { await navigator.clipboard.writeText(link); showToast('Vágólapra másolva') }
+          catch { showToast('Másolás sikertelen') }
+        })
+      }
+      const revokeBtn = item.querySelector('button[data-token]')
+      if (revokeBtn) {
+        revokeBtn.addEventListener('click', () => revokeInviteToken(inv.token))
+      }
+      listEl.appendChild(item)
+    }
+  } catch { /* ignore */ }
+}
+
+async function generateInvite() {
+  if (!currentAgent) return
+  const btn = document.getElementById('tgGenerateInviteBtn')
+  btn.disabled = true
+  btn.textContent = 'Generálás...'
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/telegram/invites`, { method: 'POST' })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.error || 'Sikertelen')
+    }
+    const data = await res.json()
+    if (data.deepLink) {
+      try { await navigator.clipboard.writeText(data.deepLink); showToast('Meghívó link létrehozva és vágólapra másolva') }
+      catch { showToast('Meghívó link létrehozva — kattints a Másol gombra') }
+    } else {
+      showToast('Meghívó létrejött (bot username pending — frissítés)')
+    }
+    refreshInvites()
+  } catch (err) {
+    showToast(`Hiba: ${err.message}`)
+  } finally {
+    btn.disabled = false
+    btn.textContent = 'Új meghívó link'
+  }
+}
+
+async function revokeInviteToken(token) {
+  if (!currentAgent) return
+  if (!confirm('Biztosan visszavonod ezt a meghívó linket?')) return
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/telegram/invites/${encodeURIComponent(token)}`, { method: 'DELETE' })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.error || 'Sikertelen')
+    }
+    showToast('Meghívó visszavonva')
+    refreshInvites()
+  } catch (err) {
+    showToast(`Hiba: ${err.message}`)
+  }
+}
+
+document.getElementById('tgGenerateInviteBtn').addEventListener('click', generateInvite)
+document.getElementById('tgRefreshInvitesBtn').addEventListener('click', refreshInvites)
 
 document.getElementById('tgApproveBtn').addEventListener('click', async () => {
   const code = document.getElementById('tgPairCode').value.trim()

--- a/web/app.js
+++ b/web/app.js
@@ -1265,7 +1265,10 @@ function updateTelegramTab(agent) {
     document.getElementById('tgRunningNotice').hidden = !running
   }
   document.getElementById('tgTokenInput').value = ''
-  if (connected) refreshPendingPairings()
+  if (connected) {
+    refreshPendingPairings()
+    refreshAllowedList()
+  }
 }
 
 document.getElementById('tgConnectBtn').addEventListener('click', async () => {
@@ -1362,6 +1365,7 @@ async function approvePairing(code) {
     }
     showToast('Párosítás jóváhagyva!')
     refreshPendingPairings()
+    refreshAllowedList()
   } catch (err) {
     showToast(`Hiba: ${err.message}`)
   }
@@ -1369,11 +1373,74 @@ async function approvePairing(code) {
 
 document.getElementById('tgRefreshPendingBtn').addEventListener('click', refreshPendingPairings)
 
+async function refreshAllowedList() {
+  if (!currentAgent) return
+  const listEl = document.getElementById('tgAllowedList')
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/telegram/allowed`)
+    if (!res.ok) return
+    const data = await res.json()
+    const users = data.users || []
+    const groups = data.groups || []
+    if (users.length === 0 && groups.length === 0) {
+      listEl.innerHTML = '<div class="tg-allowed-empty">Még nincs bekötött chat. Lent add hozzá az elsőt.</div>'
+      return
+    }
+    listEl.innerHTML = ''
+    for (const id of users) {
+      const item = document.createElement('div')
+      item.className = 'tg-allowed-item'
+      item.innerHTML = `
+        <div class="tg-allowed-meta">
+          <span class="tg-allowed-kind">DM</span>
+          <span class="tg-allowed-id">${escapeHtml(id)}</span>
+        </div>
+        <button class="btn-icon-danger" title="Eltávolítás" data-kind="user" data-id="${escapeHtml(id)}">&times;</button>
+      `
+      item.querySelector('button').addEventListener('click', () => removeAllowed('user', id))
+      listEl.appendChild(item)
+    }
+    for (const g of groups) {
+      const item = document.createElement('div')
+      item.className = 'tg-allowed-item'
+      item.innerHTML = `
+        <div class="tg-allowed-meta">
+          <span class="tg-allowed-kind tg-allowed-kind-group">CSOPORT</span>
+          <span class="tg-allowed-id">${escapeHtml(g.id)}</span>
+        </div>
+        <button class="btn-icon-danger" title="Eltávolítás" data-kind="group" data-id="${escapeHtml(g.id)}">&times;</button>
+      `
+      item.querySelector('button').addEventListener('click', () => removeAllowed('group', g.id))
+      listEl.appendChild(item)
+    }
+  } catch { /* ignore */ }
+}
+
+async function removeAllowed(kind, id) {
+  if (!currentAgent) return
+  const label = kind === 'user' ? 'felhasználót' : 'csoportot'
+  if (!confirm(`Biztosan eltávolítod ezt a ${label} (${id})?`)) return
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/telegram/allowed/${kind}/${encodeURIComponent(id)}`, { method: 'DELETE' })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.error || 'Eltávolítási hiba')
+    }
+    showToast('Eltávolítva')
+    refreshAllowedList()
+  } catch (err) {
+    showToast(`Hiba: ${err.message}`)
+  }
+}
+
+document.getElementById('tgRefreshAllowedBtn').addEventListener('click', refreshAllowedList)
+
 document.getElementById('tgApproveBtn').addEventListener('click', async () => {
   const code = document.getElementById('tgPairCode').value.trim()
   if (!code) { document.getElementById('tgPairCode').focus(); return }
   await approvePairing(code)
   document.getElementById('tgPairCode').value = ''
+  refreshAllowedList()
 })
 
 document.getElementById('tgDisconnectBtn').addEventListener('click', async () => {

--- a/web/index.html
+++ b/web/index.html
@@ -1096,8 +1096,36 @@
                 <span>Az ügynök fut, a bot aktívan figyel. A chat ID-d előre engedélyezve van, nem kell pairing kód.</span>
               </div>
             </div>
+            <div class="tg-allowed-section" id="tgAllowedSection">
+              <h4>Bekötött chat-ek és csoportok</h4>
+              <p class="tg-pairing-info">Az ügynök ide tud üzenetet küldeni és innen fogad üzenetet. Egy ügynök tetszőleges számú emberhez (DM) és csoporthoz köthető.</p>
+              <div class="tg-allowed-list" id="tgAllowedList">
+                <div class="tg-allowed-empty">Még nincs bekötött chat. Lent add hozzá az elsőt.</div>
+              </div>
+              <button class="btn-secondary btn-compact" id="tgRefreshAllowedBtn" style="margin-top:8px; font-size:12px;">Lista frissítése</button>
+            </div>
             <div class="tg-pairing-section" id="tgPairingSection">
-              <h4>Párosítás</h4>
+              <h4>Új ember vagy csoport hozzáadása</h4>
+              <details class="tg-howto" style="margin-bottom:12px;">
+                <summary style="cursor:pointer; font-weight:600;">Hogyan adj hozzá több embert vagy csoportot? &#9660;</summary>
+                <div style="padding:10px 0 0 0; font-size:13px; line-height:1.5;">
+                  <p style="margin-top:0;"><strong>1. Új ember (privát chat) hozzáadása:</strong></p>
+                  <ol style="padding-left:20px; margin-top:4px;">
+                    <li>Add meg az illetőnek a bot felhasználónevét (lent látható).</li>
+                    <li>Az illető indítsa el a botot a Telegramban (<code>/start</code>) és írjon neki egy üzenetet.</li>
+                    <li>A bot válaszol egy 6-jegyű párosítási kóddal.</li>
+                    <li>Az illető elküldi neked a kódot, te ide írod be és jóváhagyod.</li>
+                  </ol>
+                  <p style="margin-top:10px;"><strong>2. Telegram csoport hozzáadása:</strong></p>
+                  <ol style="padding-left:20px; margin-top:4px;">
+                    <li>Hívd meg a botot egy meglévő Telegram csoportba (csoport beállítások &rarr; Tagok &rarr; Hozzáadás).</li>
+                    <li>A csoportban írj <code>/pair</code>-t (vagy a bot által megadott parancsot).</li>
+                    <li>Megjelenik egy párosítási kód a csoportban.</li>
+                    <li>Másold be ide és hagyd jóvá. Ezután az ügynök fog tudni írni a csoportba és olvasni a tagok üzeneteit.</li>
+                  </ol>
+                  <p style="margin-top:10px; color:var(--muted-foreground);"><em>Eltávolításhoz használd a Bekötött chat-ek listájában az X gombot.</em></p>
+                </div>
+              </details>
               <p class="tg-pairing-info">Ha valaki ír a botnak, a plugin egy kódot küld neki. Ide írd be a kódot a jóváhagyáshoz.</p>
               <div class="tg-pending-list" id="tgPendingList"></div>
               <div class="form-row" style="gap:8px; align-items:flex-end; margin-top: 12px;">

--- a/web/index.html
+++ b/web/index.html
@@ -1104,6 +1104,17 @@
               </div>
               <button class="btn-secondary btn-compact" id="tgRefreshAllowedBtn" style="margin-top:8px; font-size:12px;">Lista frissítése</button>
             </div>
+            <div class="tg-invite-section" id="tgInviteSection">
+              <h4>Meghívó link (egy kattintásos hozzáadás)</h4>
+              <p class="tg-pairing-info">Generálj egy egyedi linket. Aki rákattint, automatikusan elindítja a botot, és Te a UI-n láthatóan azonnal jóváhagyhatod. Egy link csak egyszer használható.</p>
+              <div class="tg-invite-list" id="tgInviteList">
+                <div class="tg-allowed-empty">Nincs aktív meghívó link.</div>
+              </div>
+              <div class="form-row" style="gap:8px; align-items:center; margin-top:10px;">
+                <button class="btn-primary btn-compact" id="tgGenerateInviteBtn" style="margin-top:0">Új meghívó link</button>
+                <button class="btn-secondary btn-compact" id="tgRefreshInvitesBtn" style="margin-top:0; font-size:12px;">Frissítés</button>
+              </div>
+            </div>
             <div class="tg-pairing-section" id="tgPairingSection">
               <h4>Új ember vagy csoport hozzáadása</h4>
               <details class="tg-howto" style="margin-bottom:12px;">

--- a/web/style.css
+++ b/web/style.css
@@ -1166,6 +1166,76 @@ main {
   margin-top: 16px;
 }
 
+.tg-allowed-section {
+  margin-top: 16px;
+}
+.tg-allowed-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+.tg-allowed-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  padding: 8px 0;
+  font-style: italic;
+}
+.tg-allowed-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+}
+.tg-allowed-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.tg-allowed-kind {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(0, 122, 255, 0.15);
+  color: rgb(70, 140, 240);
+  text-transform: uppercase;
+}
+.tg-allowed-kind-group {
+  background: rgba(0, 168, 132, 0.15);
+  color: rgb(40, 170, 130);
+}
+.tg-allowed-id {
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 12px;
+  color: var(--text);
+}
+.btn-icon-danger {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: all 0.15s ease;
+}
+.btn-icon-danger:hover {
+  background: rgba(220, 60, 70, 0.1);
+  color: rgb(230, 90, 100);
+  border-color: rgba(220, 60, 70, 0.3);
+}
+
 /* === Skills Tab === */
 .skill-header {
   display: flex;


### PR DESCRIPTION
## Summary
Az agent-detail Telegram tab nem mutatta a már bekötött chat-eket és csoportokat, és nem volt egy-kattintásos eltávolítás sem. A backend `allowFrom` és `groups` mezője **már** támogatta a több binding-ot — ez a PR teszi UI-ban láthatóvá és kezelhetővé.

## Changes
- **Backend**: `GET /api/agents/:name/telegram/allowed` (lista), `DELETE /api/agents/:name/telegram/allowed/:type/:id` (eltávolítás).
- **Frontend**: új "Bekötött chat-ek és csoportok" szekció DM/CSOPORT badge-ekkel, minden sorban X gomb az eltávolításhoz.
- **Help**: collapsible útmutató a pairing szekcióban — hogyan adj hozzá privát chat-et és Telegram csoportot lépésről-lépésre.

## Test plan
- [ ] /agents → bármely agent → Telegram tab: a bekötött chat-ek listája megjelenik.
- [ ] X gomb egy DM-en — confirm → eltávolítás működik (allowFrom-ból kikerül).
- [ ] X gomb egy csoporton — confirm → eltávolítás működik (groups objectből törlődik).
- [ ] Új pairing-jóváhagyás után az új sender automatikusan megjelenik a listában.
- [ ] A "Hogyan adj hozzá több embert vagy csoportot?" details panel kibontható, lépéseket olvashatóan mutatja.