### PR TITLE
fix(agents): auto-poll telegram tab so pending shows up without click

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1126,6 +1126,21 @@ document.getElementById('agentTabNav').addEventListener('click', (e) => {
   switchAgentTab(btn.dataset.tab)
 })
 
+let telegramAutoPollTimer = null
+function startTelegramAutoPoll() {
+  if (telegramAutoPollTimer) return
+  telegramAutoPollTimer = setInterval(() => {
+    if (!currentAgent) return
+    if (document.getElementById('tabTelegram').hidden) return
+    refreshPendingPairings()
+    refreshAllowedList()
+    refreshInvites()
+  }, 4000)
+}
+function stopTelegramAutoPoll() {
+  if (telegramAutoPollTimer) { clearInterval(telegramAutoPollTimer); telegramAutoPollTimer = null }
+}
+
 function switchAgentTab(tab) {
   document.querySelectorAll('#agentTabNav .tab-btn').forEach((b) => b.classList.toggle('active', b.dataset.tab === tab))
   document.getElementById('tabOverview').hidden = tab !== 'overview'
@@ -1133,6 +1148,8 @@ function switchAgentTab(tab) {
   document.getElementById('tabTelegram').hidden = tab !== 'telegram'
   document.getElementById('tabSkills').hidden = tab !== 'skills'
   document.getElementById('tabTeam').hidden = tab !== 'team'
+  if (tab === 'telegram') startTelegramAutoPoll()
+  else stopTelegramAutoPoll()
 }
 
 // === Settings save buttons ===


### PR DESCRIPTION
## Summary
A Telegram tab eddig CSAK a "Várakozók frissítése" gombra mutatott újabb pending kódot. Az invite-link auto-approve race miatt időnként visszaesik kézi flow-ra, és ilyenkor mostanáig nem volt láthatóan a UI-n a pending. Ezzel a PR-ral a tab nyitva tartása alatt 4 mp-enként frissít.

## Changes
- web/app.js: `startTelegramAutoPoll`/`stopTelegramAutoPoll` (4 mp interval). Bekapcsol amikor switchAgentTab('telegram'), kikapcsol bármely más tabra váltáskor. Refreshes: pending pairings, allowed (DM/group lista), invites.

## Test plan
- [ ] Telegram tab megnyitása → 4 mp után frissítés látszik a Network tab-on (3 GET request).
- [ ] Más tabra váltás → nincs több poll.
- [ ] Új invite-link generálása → tesztalany kattint → ha auto-approve fut, allowFrom-ban feltűnik / ha nem, pending listán automatikusan feltűnik 4 mp-en belül.