### PR TITLE
fix(heartbeat): quiet window after 22:00 -- only db-warning escalates

### DIFF
--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -86,6 +86,11 @@ function shouldNotify(data: HeartbeatData): boolean {
 
   if (data.system.dbWarning) return true
 
+  // 22:00 utan csendes ablak -- csak igazi rendszer-vesz (dbWarning, fent
+  // mar return-olt) lephet at. Stale urgent kanban-kartyak este nem zavarjak
+  // a felhasznalot.
+  if (hour >= 22) return false
+
   if (hour >= 21) {
     return data.kanban.urgent > 0
   }


### PR DESCRIPTION
## Summary
A 22:00-kor érkezett heartbeat üzenet stale urgent miatt mégis kiment Telegramra. A 22:00 utáni órák így csak igazi rendszer-vész (DB warning) esetén notify-olnak.

## Test plan
- [ ] 22:00 után heartbeat fut, csak HEARTBEAT.md frissül -- nincs Telegram értesítés stale urgent miatt.
- [ ] DB warning teszt esetén (manuál szimuláció) viszont triggerel.
- [ ] 21:59 munkanap tipikusan urgent-en továbbra is notify-ol (a 21-es ág változatlan).