### PR TITLE
fix(install): unstick first-run dialogs on fresh Mac/Windows installs

### DIFF
--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -209,6 +209,26 @@ fi
 # Install Telegram plugin
 claude plugin install telegram@claude-plugins-official 2>/dev/null || true
 echo '  ✓ Telegram plugin'
+
+# Pre-accept Claude Code first-run dialogs so the tmux-spawned headless
+# session (Telegram bridge) doesn't park on them forever. Without this,
+# the first launch hits "Bypass Permissions mode" + "Trust this folder"
+# prompts on a non-interactive TTY and stays stuck.
+mkdir -p ~/.claude
+node -e '
+const fs = require("fs"), os = require("os"), path = require("path");
+const cj = path.join(os.homedir(), ".claude.json");
+let d = {}; try { d = JSON.parse(fs.readFileSync(cj, "utf8")); } catch {}
+d.hasCompletedOnboarding = true;
+if (!d.theme) d.theme = "dark";
+fs.writeFileSync(cj, JSON.stringify(d, null, 2), { mode: 0o600 });
+const sj = path.join(os.homedir(), ".claude", "settings.json");
+let s = {}; try { s = JSON.parse(fs.readFileSync(sj, "utf8")); } catch {}
+s.skipDangerousModePermissionPrompt = true;
+fs.mkdirSync(path.dirname(sj), { recursive: true });
+fs.writeFileSync(sj, JSON.stringify(s, null, 2), { mode: 0o600 });
+console.log("  ✓ Claude Code first-run flags");
+'
 "@
 
 # Done!
@@ -224,7 +244,8 @@ Write-Host "  Dashboard:" -ForegroundColor White
 Write-Host "    http://localhost:3420" -ForegroundColor Cyan
 Write-Host ""
 Write-Host "  Telegram bridge indítása:" -ForegroundColor White
-Write-Host "    wsl bash -c 'cd $installPath && tmux new-session -d -s marveen-channels ""claude --dangerously-skip-permissions --channels plugin:telegram@claude-plugins-official""'" -ForegroundColor Cyan
+Write-Host "    wsl bash -c 'cd $installPath && bash scripts/channels.sh &'" -ForegroundColor Cyan
+Write-Host "    (a channels.sh tartalmazza a first-run dialog auto-accept guardot)" -ForegroundColor DarkGray
 Write-Host ""
 Write-Host "  Frissítés:" -ForegroundColor White
 Write-Host "    wsl bash -c 'cd $installPath && ./update.sh'" -ForegroundColor Cyan

--- a/install.sh
+++ b/install.sh
@@ -105,18 +105,14 @@ if ! command -v claude &>/dev/null; then
 fi
 echo -e "  ${GREEN}✓${NC} Claude Code CLI"
 
-# Step 2: Claude authentication
-echo ""
-echo -e "${BOLD}[2/7] Claude bejelentkezes${NC}"
-echo -e "${DIM}  Ha meg nem jelentkeztel be, most megteheted.${NC}"
-read -p "  Szeretned most bejelentkezni? (i/n) " DO_AUTH
-if [ "$DO_AUTH" = "i" ]; then
-  claude auth login
-fi
-
-# Mark the Claude Code first-run wizard as completed so the tmux-spawned
-# `claude --channels ...` process doesn't stop on the theme picker and
-# block the Telegram plugin from ever initializing.
+# Step 2: Claude Code first-run flags (BEFORE auth login)
+#
+# Reason: ha a `claude auth login` browser-flow megakad (timeout, Ctrl+C,
+# vagy a felhasznalo nem klikkel a "Trust this browser?"-ben), a `set -e`
+# alatt a script kilep es a flag-set NEM fut le -- onnantol a tmux-spawned
+# headless session orokre parkol a "Trust this folder" / theme-picker /
+# Bypass Permissions promptokon. Tehat a flag-set FOLY-RA `auth login`
+# ELOTT, hogy ezek a defensive default-ok mindenkeppen a helyukre keruljenek.
 mkdir -p "$HOME/.claude"
 python3 - <<'PYEOF'
 import json, os, pathlib
@@ -136,12 +132,6 @@ try:
 except Exception:
     pass
 PYEOF
-
-# Pre-accept the --dangerously-skip-permissions confirmation dialog so the
-# headless `claude --channels ...` session in scripts/channels.sh doesn't
-# park on it forever (the dialog needs interactive Enter and there's no TTY
-# attached). Claude Code maintains this flag itself once accepted manually,
-# but we have to seed it before the first launchd-spawned session.
 python3 - <<'PYEOF'
 import json, os, pathlib
 p = pathlib.Path(os.path.expanduser("~/.claude/settings.json"))
@@ -159,6 +149,25 @@ try:
 except Exception:
     pass
 PYEOF
+echo -e "  ${GREEN}✓${NC} Claude Code first-run flags pre-set"
+
+# Step 2b: Claude authentication (kept tolerant -- ha megakad, folytatjuk)
+echo ""
+echo -e "${BOLD}[2/7] Claude bejelentkezes${NC}"
+echo -e "${DIM}  Ha meg nem jelentkeztel be, most megteheted.${NC}"
+echo -e "${DIM}  Ha a browser-os authorize-flow megakad, Ctrl+C-vel kilephetsz${NC}"
+echo -e "${DIM}  -- a telepites folytatodik, kesobb manualisan tudsz belepni.${NC}"
+read -p "  Szeretned most bejelentkezni? (i/n) " DO_AUTH
+if [ "$DO_AUTH" = "i" ]; then
+  set +e
+  claude auth login
+  AUTH_RC=$?
+  set -e
+  if [ "$AUTH_RC" -ne 0 ]; then
+    echo -e "  ${ORANGE}⚠${NC} Auth login nem fejezodott be sikeresen (exit $AUTH_RC)."
+    echo -e "  ${DIM}A telepites folytatodik. Belepheted kesobb: ${BOLD}claude auth login${NC}"
+  fi
+fi
 echo -e "  ${GREEN}✓${NC} Claude Code first-run beallitas kesz"
 
 # Step 3: Personal info

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -40,23 +40,53 @@ TMUX="$(command -v tmux)"
 $TMUX kill-session -t "$SESSION" 2>/dev/null
 
 # Tmux session indítás
-$TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "$CLAUDE --dangerously-skip-permissions --continue --channels plugin:telegram@claude-plugins-official"
+#
+# --continue csak akkor mukodik ha mar van mentett session log a
+# .claude/projects/<this-cwd>/*.jsonl alatt. Friss telepitesnel nincs ->
+# Claude Code "No conversation found to continue" hibaval kilep, a launchd
+# tight-loopban ujraindit. Ezert csak akkor adjuk meg, ha latjuk hogy van
+# mentett session, kulonben szuretlenul indul (uj beszelgetes).
+PROJECT_KEY="$(echo "$INSTALL_DIR" | sed 's|/|-|g')"
+CLAUDE_PROJECT_DIR="$HOME/.claude/projects/${PROJECT_KEY}"
+CONTINUE_FLAG=""
+if [ -d "$CLAUDE_PROJECT_DIR" ] && ls "$CLAUDE_PROJECT_DIR"/*.jsonl >/dev/null 2>&1; then
+  CONTINUE_FLAG="--continue"
+fi
 
-# Session startup guard: if the --dangerously-skip-permissions confirmation
-# dialog appears (despite the settings.json flag, e.g. on a Claude Code
-# version that renamed the key), auto-accept it. Without this the headless
-# session would park forever and the Telegram plugin would never load.
-for i in 1 2 3 4 5 6; do
+$TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
+  "$CLAUDE --dangerously-skip-permissions $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official"
+
+# Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
+# kulonben a headless session orokre parkolna a prompton es a Telegram plugin
+# soha nem toltodne be. Tobb fajta dialog elofordulhat:
+#  - "Bypass Permissions mode" (--dangerously-skip-permissions confirmation,
+#    valasz: 2 Enter = "Yes, I accept")
+#  - "Do you trust the files in this folder?" / "trust" prompts (Y Enter)
+#  - "Welcome to Claude Code" / kezdo vezetes (Enter a folytatashoz)
+# 12 sec timeout ket retry-jal, mert WSL/tmux paint slow lehet first-run-on.
+for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
   sleep 1
   pane=$($TMUX capture-pane -t "$SESSION" -p 2>/dev/null || true)
-  if echo "$pane" | grep -q "Bypass Permissions mode"; then
-    $TMUX send-keys -t "$SESSION" "2" Enter
-    break
-  fi
-  if echo "$pane" | grep -q "Listening for channel messages"; then
-    break
-  fi
+  case "$pane" in
+    *"Bypass Permissions mode"*)
+      $TMUX send-keys -t "$SESSION" "2" Enter
+      sleep 1
+      continue
+      ;;
+    *"trust"*|*"Trust"*)
+      $TMUX send-keys -t "$SESSION" "1" Enter
+      sleep 1
+      continue
+      ;;
+    *"Welcome to Claude Code"*)
+      $TMUX send-keys -t "$SESSION" Enter
+      sleep 1
+      continue
+      ;;
+    *"Listening for channel messages"*)
+      break
+      ;;
+  esac
 done
 
 # Bot menü beállítás (15 sec késleltetéssel, a plugin után)


### PR DESCRIPTION
## Summary

A fresh tmux-spawned Telegram bridge session was getting stuck forever on Claude Code first-run prompts (Trust this folder, theme picker, Bypass Permissions mode). Three related fixes so the headless session reliably reaches the channel-listening state on first install.

## Root cause

On a fresh Mac install (just hit yesterday by a teammate of @Szotasz), `install.sh` runs `claude auth login` interactively. If the browser-based auth flow stalls — timeout, Ctrl+C, or the user not clicking "Trust this browser?" in time — the `set -e` shell aborts the installer **before** the first-run flag-set runs. From that moment on, every subsequent headless launch parks on `Trust this folder` / theme picker / `Bypass Permissions mode` prompts on the non-interactive TTY.

A second issue: `scripts/channels.sh` always passes `--continue`, but on a fresh install there's no saved session, so Claude Code exits with `No conversation found to continue` and launchd's `KeepAlive` ends up in a tight restart loop.

A third issue: `install-windows.ps1` was missing the first-run flag pre-set entirely, so WSL installs hit the same trust/permissions trap.

## Changes

**install.sh**
- Move first-run flag pre-set (`hasCompletedOnboarding`, `skipDangerousModePermissionPrompt`) **before** the optional `claude auth login` step. Defensive defaults always land regardless of auth-flow outcome.
- Make `claude auth login` tolerant: `set +e` + exit-code logging, so a half-finished auth doesn't abort the rest of the installer. User can re-run `claude auth login` manually later.

**scripts/channels.sh**
- `--continue` is now conditional — only passed if a saved session log actually exists under `~/.claude/projects/<install-dir>/*.jsonl`.
- Startup guard extended from 6s to 12s, and now recognizes `Trust this folder` and `Welcome to Claude Code` prompts in addition to `Bypass Permissions mode`. Each is auto-accepted with the appropriate keystroke.

**install-windows.ps1**
- Add the same first-run flag pre-set the macOS/Linux installers already had (missing on Windows/WSL only). Uses `node -e` to write `~/.claude.json` + `~/.claude/settings.json` with mode 0600.
- Recommend `bash scripts/channels.sh` for the Telegram bridge instead of a direct `claude` invocation, so the startup guard always runs.

## Test plan
- [x] `bash -n scripts/channels.sh` syntax OK
- [x] `bash -n install.sh` syntax OK
- [ ] Fresh Mac install: `./install.sh` → bridge starts even if `claude auth login` is interrupted mid-browser-flow
- [ ] Fresh Mac install: `bash scripts/channels.sh` → no `--continue` flag passed, no `No conversation found` exit
- [ ] Fresh WSL install: `install-windows.ps1` → bridge auto-accepts trust + bypass dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)