### PR TITLE
fix(heartbeat): make no-op tool call the FIRST mandatory step

### DIFF
--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -81,7 +81,7 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
   try {
     let prefix: string
     if (task.type === 'heartbeat') {
-      prefix = `[Heartbeat: ${task.name}] FONTOS: Ez egy csendes ellenorzes. CSAK AKKOR irj Telegramon (chat_id: ${ALLOWED_CHAT_ID}), ha tenyleg fontos/surgos dolgot talalsz. Ha minden rendben, NE kuldj Telegram uzenetet -- DE: a Telegram-bun MCP-stdio-pipe-jat keep-alive-ben tartani, hivj meg pontosan EGY no-op MCP-tool-t (peldaul Read tool egy meglevo fajlra, vagy Bash echo). Igy a Claude Code MCP-stdio-state aktiv marad, es a Telegram-bun-process nem stale-el-ki long-idle-on. NE Telegram-tool-t hivj meg (mert az zajt eredmenyezne) -- helyette local-only tool-t. Egy rovid 'csendes heartbeat' sor a transzkriptbe + a tool-call elég. `
+      prefix = `[Heartbeat: ${task.name}] *** KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ: hivj meg pontosan EGY local-only tool-t (peldaul Bash 'echo keepalive >> /tmp/marveen-keepalive.log' VAGY Read tool egy meglevo fajlra mint /Users/marvin/ClaudeClaw/HEARTBEAT.md). NE Telegram-tool-t -- az zajt eredmenyezne. Ezt a Telegram-bun MCP-stdio-pipe keep-alive-ehez kell, ha kihagyod, a Telegram-conn 30 percen belul disconnect-el. *** Aztan: ez egy csendes ellenorzes. CSAK AKKOR irj Telegramon (chat_id: ${ALLOWED_CHAT_ID}), ha tenyleg fontos/surgos dolgot talalsz. Ha minden rendben, NE kuldj Telegram uzenetet -- a kotelezo no-op tool-call mar megfelelo aktivitas. Egy rovid 'csendes heartbeat' sor a transzkriptbe + a tool-call elég. `
     } else {
       prefix = `[Utemezett feladat: ${task.name}] Az eredmenyt kuldd el Telegramon (chat_id: ${ALLOWED_CHAT_ID}, reply tool). `
     }


### PR DESCRIPTION
## Summary

PR #80 added the requirement that agents fire one local-only no-op tool per heartbeat to keep the Telegram bun stdio pipe alive. The instruction was correct — but it was buried in the middle of the prompt, after the "stay silent if nothing's wrong" rule. Agents read the silence rule first, write "Csendes heartbeat" to the transcript, and skip the tool call entirely.

Witnessed in production today (2026-05-09 22:00 heartbeat): Marveen received the new PR #80 prompt, didn't fire any local tool, the Telegram bun stdio went idle, and the connection dropped at 22:05 — exactly the failure mode PR #80 was meant to prevent.

## Fix

Reorder the heartbeat prompt:
- The no-op tool call is now announced as the FIRST required step (`*** KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ ***`).
- Explicit, copy-pasteable examples (Bash echo or Read on `HEARTBEAT.md`) instead of the vague "Read tool egy meglevo fajlra" pointer.
- Explicit warning that skipping it causes the disconnect within ~30 min.
- The silence rule moves to second position with a note that the mandatory tool call already counts as the required activity.

## Test plan

- [ ] Restart Marveen so the new prompt takes effect
- [ ] Watch 2+ heartbeat cycles (~60 min) on the dashboard MCP-status panel
- [ ] Verify Marveen actually fires a local tool every heartbeat (Bash log should show `keepalive` lines)
- [ ] Verify Telegram MCP stays Connected through the cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)