### PR TITLE
fix(dashboard): route main agent CLAUDE.md to project root

### DIFF
--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -26,6 +26,11 @@ export function agentDir(name: string): string {
   return safeJoin(AGENTS_BASE_DIR, name)
 }
 
+export function agentConfigRoot(name: string): string {
+  if (name === MAIN_AGENT_ID) return PROJECT_ROOT
+  return agentDir(name)
+}
+
 export function readFileOr(path: string, fallback: string): string {
   try { return readFileSync(path, 'utf-8') } catch { return fallback }
 }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -9,6 +9,7 @@ import { atomicWriteFileSync } from '../atomic-write.js'
 import { getSecret } from '../vault.js'
 import {
   agentDir,
+  agentConfigRoot,
   DEFAULT_MODEL,
   readFileOr,
   extractDescriptionFromClaudeMd,
@@ -21,6 +22,7 @@ import {
   readAgentSecurityProfile,
   writeAgentSecurityProfile,
   listAgentNames,
+  isKnownAgent,
 } from '../agent-config.js'
 import {
   readAgentTeam,
@@ -88,7 +90,8 @@ interface AgentDetail extends AgentSummary {
 
 function getAgentSummary(name: string): AgentSummary {
   const dir = agentDir(name)
-  const claudeMd = readFileOr(join(dir, 'CLAUDE.md'), '')
+  const configRoot = agentConfigRoot(name)
+  const claudeMd = readFileOr(join(configRoot, 'CLAUDE.md'), '')
   const soulMd = readFileOr(join(dir, 'SOUL.md'), '')
   const tg = readAgentTelegramConfig(name)
   const hasClaudeMd = claudeMd.trim().length > 0
@@ -114,8 +117,9 @@ function getAgentSummary(name: string): AgentSummary {
 
 function getAgentDetail(name: string): AgentDetail {
   const dir = agentDir(name)
+  const configRoot = agentConfigRoot(name)
   const summary = getAgentSummary(name)
-  const claudeMd = readFileOr(join(dir, 'CLAUDE.md'), '')
+  const claudeMd = readFileOr(join(configRoot, 'CLAUDE.md'), '')
   const soulMd = readFileOr(join(dir, 'SOUL.md'), '')
   const mcpJson = readFileOr(join(dir, '.mcp.json'), '{}')
 
@@ -701,17 +705,18 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   const agentMatch = path.match(/^\/api\/agents\/([^/]+)$/)
   if (agentMatch && method === 'GET') {
     const name = decodeURIComponent(agentMatch[1])
-    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (!isKnownAgent(name)) { json(res, { error: 'Agent not found' }, 404); return true }
     json(res, getAgentDetail(name))
     return true
   }
 
   if (agentMatch && method === 'PUT') {
     const name = decodeURIComponent(agentMatch[1])
-    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (!isKnownAgent(name)) { json(res, { error: 'Agent not found' }, 404); return true }
     const body = await readBody(req)
+    const configRoot = agentConfigRoot(name)
     const data = JSON.parse(body.toString()) as { claudeMd?: string; soulMd?: string; mcpJson?: string; model?: string }
-    if (data.claudeMd !== undefined) atomicWriteFileSync(join(agentDir(name), 'CLAUDE.md'), data.claudeMd)
+    if (data.claudeMd !== undefined) atomicWriteFileSync(join(configRoot, 'CLAUDE.md'), data.claudeMd)
     if (data.soulMd !== undefined) atomicWriteFileSync(join(agentDir(name), 'SOUL.md'), data.soulMd)
     if (data.mcpJson !== undefined) atomicWriteFileSync(join(agentDir(name), '.mcp.json'), data.mcpJson)
     if (data.model !== undefined) writeAgentModel(name, data.model)


### PR DESCRIPTION
## Summary
- Add `agentConfigRoot()` helper that returns `PROJECT_ROOT` for `MAIN_AGENT_ID`, `agentDir(name)` for sub-agents
- Route CLAUDE.md read/write through `agentConfigRoot()` in GET detail, GET summary, and PUT handlers
- Switch agent existence checks to `isKnownAgent()` (already handles main agent)
- Fixes: dashboard config saves for main agent silently not persisting (card 7569D1C3)

## Test plan
- [ ] Open dashboard agent config for main agent (Marveen)
- [ ] Edit CLAUDE.md and save
- [ ] Verify the project-root CLAUDE.md was updated (not agents/marveen/CLAUDE.md)
- [ ] Verify sub-agent CLAUDE.md saves still work normally

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>