### PR TITLE
feat(scaffold): add skill-generation rules to new agent CLAUDE.md

### DIFF
--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -139,6 +139,38 @@ Típusok: task (mindig szól az eredménnyel) vagy heartbeat (csak fontosnál sz
 Cron formátum: perc óra nap hónap hétnapja (pl. 0 8 * * * = minden nap 8:00).
 NE írd közvetlenül az SQLite scheduled_tasks táblát - az egy régi API.
 
+## Öntanulás és Skill rendszer
+
+Te egy önfejlesztő ágens vagy. A munkád során tanulsz, és újrafelhasználható skill-eket hozol létre.
+
+### Skill-ek helye
+- Globális: ~/.claude/skills/ (minden ágens számára elérhető)
+- Egyéni: a te munkakönyvtárad .claude/skills/ mappája
+
+### Automatikus skill generálás
+Komplex feladatok után (5+ tool hívás, hiba utáni recovery, user korrekció, többlépéses workflow) automatikusan hozz létre SKILL.md fájlt:
+
+mkdir -p ~/.claude/skills/SKILL-NEV
+A SKILL.md tartalmazzon YAML frontmatter-t (name, description), majd szekciókat: Mikor használd, Eljárás, Buktatók, Ellenőrzés.
+
+### Skill patch (runtime javítás)
+Ha egy meglévő skill használata közben jobb megoldást találsz:
+1. Ne írd újra az egész skill-t, csak a megváltozott részt javítsd
+2. Használj célzott cserét (régi szöveg -> új szöveg)
+3. Jegyezd fel a változtatás okát a skill Buktatók szekciójába
+
+### Mikor generálj skill-t?
+- 5+ tool hívás, sikeres befejezés: Generálj skill-t
+- Hiba -> recovery -> siker: Generálj skill-t (buktató szekcióval)
+- User korrekció: Patch-eld a meglévő skill-t
+- Nem triviális workflow: Generálj skill-t
+- Egyszerű, egylépéses feladat: Ne generálj semmit
+
+### Skill reflexió
+Minden kontextus-tömörítés előtt (PreCompact hook) automatikusan vizsgáld meg:
+- Van-e a session-ben újrafelhasználható minta?
+- Van-e meglévő skill amit javítani kellene?
+
 ## Új ismeretlen sender első üzenete (ARANYSZABÁLY)
 
 Ha egy senderId üzen Telegramon AKIT EDDIG NEM ISMERSZ — nem szerepel az aktív interakciós kontextusodban, és nem találsz róla memóriabejegyzést a vault-ban — KÖTELEZŐ ELSŐKÉNT inter-agent message-t küldeni Marveennek MIELŐTT érdemi választ adsz.


### PR DESCRIPTION
## Summary
- Add "Öntanulás és Skill rendszer" section to `generateClaudeMd()` prompt in agent-scaffold.ts
- Every newly created agent now gets skill creation, patching, and reflection rules
- Existing 5 sub-agents (boni, deeper, iris, samu, zara) patched via live file edit (not in this PR)
- Kanban card: 7806ED6F

## Test plan
- [ ] Create a new test agent via dashboard
- [ ] Verify generated CLAUDE.md contains the skill rules section
- [ ] Verify existing agent creation flow still works (build passes)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>