### PR TITLE
feat(kanban): project field + filter + autocomplete

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -652,6 +652,7 @@ export interface KanbanCard {
   status: 'planned' | 'in_progress' | 'waiting' | 'done'
   assignee: string | null
   priority: 'low' | 'normal' | 'high' | 'urgent'
+  project: string | null
   due_date: number | null
   sort_order: number
   created_at: number
@@ -695,23 +696,23 @@ export function createKanbanCard(card: {
   status?: KanbanCard['status']
   assignee?: string
   priority?: KanbanCard['priority']
+  project?: string
   due_date?: number
 }): void {
   const now = Math.floor(Date.now() / 1000)
   const status = card.status ?? 'planned'
-  // Get max sort_order for that status column
   const maxRow = db.prepare(
     'SELECT MAX(sort_order) as m FROM kanban_cards WHERE status = ? AND archived_at IS NULL'
   ).get(status) as { m: number | null }
   const sortOrder = (maxRow?.m ?? -1) + 1
 
   db.prepare(
-    `INSERT INTO kanban_cards (id, title, description, status, assignee, priority, due_date, sort_order, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO kanban_cards (id, title, description, status, assignee, priority, project, due_date, sort_order, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     card.id, card.title, card.description ?? null, status,
     card.assignee ?? null, card.priority ?? 'normal',
-    card.due_date ?? null, sortOrder, now, now
+    card.project ?? null, card.due_date ?? null, sortOrder, now, now
   )
 }
 
@@ -721,9 +722,9 @@ export function updateKanbanCard(id: string, fields: Partial<Omit<KanbanCard, 'i
   const now = Math.floor(Date.now() / 1000)
   const f = { ...card, ...fields, updated_at: now }
   return db.prepare(
-    `UPDATE kanban_cards SET title=?, description=?, status=?, assignee=?, priority=?, due_date=?, sort_order=?, updated_at=?, archived_at=?
+    `UPDATE kanban_cards SET title=?, description=?, status=?, assignee=?, priority=?, project=?, due_date=?, sort_order=?, updated_at=?, archived_at=?
      WHERE id=?`
-  ).run(f.title, f.description, f.status, f.assignee, f.priority, f.due_date, f.sort_order, f.updated_at, f.archived_at, id).changes > 0
+  ).run(f.title, f.description, f.status, f.assignee, f.priority, f.project, f.due_date, f.sort_order, f.updated_at, f.archived_at, id).changes > 0
 }
 
 export function moveKanbanCard(id: string, status: KanbanCard['status'], sortOrder: number): boolean {
@@ -736,6 +737,13 @@ export function moveKanbanCard(id: string, status: KanbanCard['status'], sortOrd
 export function archiveKanbanCard(id: string): boolean {
   const now = Math.floor(Date.now() / 1000)
   return db.prepare('UPDATE kanban_cards SET archived_at=?, updated_at=? WHERE id=?').run(now, now, id).changes > 0
+}
+
+export function listKanbanProjects(): string[] {
+  const rows = db.prepare(
+    "SELECT DISTINCT project FROM kanban_cards WHERE project IS NOT NULL AND project != '' AND archived_at IS NULL ORDER BY project"
+  ).all() as Array<{ project: string }>
+  return rows.map(r => r.project)
 }
 
 export function deleteKanbanCard(id: string): boolean {

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import {
   listKanbanCards, createKanbanCard, updateKanbanCard,
   deleteKanbanCard, moveKanbanCard, archiveKanbanCard,
-  getKanbanComments, addKanbanComment,
+  getKanbanComments, addKanbanComment, listKanbanProjects,
 } from '../../db.js'
 import { OWNER_NAME } from '../../config.js'
 import { listAgentNames } from '../agent-config.js'
@@ -14,6 +14,11 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
 
   if (path === '/api/kanban' && method === 'GET') {
     json(res, listKanbanCards())
+    return true
+  }
+
+  if (path === '/api/kanban-projects' && method === 'GET') {
+    json(res, listKanbanProjects())
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -96,6 +96,8 @@ navLinks.forEach((link) => {
 
 let kanbanCards = []
 let kanbanAssignees = []
+let kanbanProjects = []
+let kanbanProjectFilter = ''
 
 const cardModalOverlay = document.getElementById('cardModalOverlay')
 const cardDetailOverlay = document.getElementById('cardDetailOverlay')
@@ -114,21 +116,56 @@ document.querySelectorAll('.kanban-add-btn').forEach((btn) => {
 
 async function loadKanban() {
   try {
-    const [cardsRes, assigneesRes] = await Promise.all([
+    const [cardsRes, assigneesRes, projectsRes] = await Promise.all([
       fetch('/api/kanban'),
       fetch('/api/kanban/assignees'),
+      fetch('/api/kanban-projects'),
     ])
     kanbanCards = await cardsRes.json()
     kanbanAssignees = await assigneesRes.json()
+    kanbanProjects = await projectsRes.json()
+    populateProjectFilter()
+    populateProjectSuggestions()
     renderKanban()
   } catch (err) {
     console.error('Kanban betöltés hiba:', err)
   }
 }
 
+function populateProjectFilter() {
+  const sel = document.getElementById('kanbanProjectFilter')
+  const prev = sel.value
+  sel.innerHTML = '<option value="">Mind</option>'
+  for (const p of kanbanProjects) {
+    const opt = document.createElement('option')
+    opt.value = p
+    opt.textContent = p
+    if (p === prev) opt.selected = true
+    sel.appendChild(opt)
+  }
+  if (prev && !kanbanProjects.includes(prev)) kanbanProjectFilter = ''
+}
+
+function populateProjectSuggestions() {
+  const dl = document.getElementById('projectSuggestions')
+  if (!dl) return
+  dl.innerHTML = ''
+  for (const p of kanbanProjects) {
+    const opt = document.createElement('option')
+    opt.value = p
+    dl.appendChild(opt)
+  }
+}
+
+document.getElementById('kanbanProjectFilter').addEventListener('change', (e) => {
+  kanbanProjectFilter = e.target.value
+  renderKanban()
+})
+
 function renderKanban() {
   const grouped = { planned: [], in_progress: [], waiting: [], done: [] }
   for (const card of kanbanCards) {
+    if (kanbanProjectFilter && (card.project || '') !== kanbanProjectFilter) continue
     if (grouped[card.status]) grouped[card.status].push(card)
   }
 
@@ -170,7 +207,12 @@ function createCardEl(card) {
     dueHtml = `<span class="kanban-card-due ${overdue ? 'overdue' : ''}">${label}</span>`
   }
 
+  const projectHtml = card.project
+    ? `<span class="kanban-card-project">${escapeHtml(card.project)}</span>`
+    : ''
+
   el.innerHTML = `
+    ${projectHtml}
     <div class="kanban-card-title">${escapeHtml(card.title)}</div>
     <div class="kanban-card-footer">${assigneeHtml}${dueHtml}</div>
   `
@@ -257,10 +299,12 @@ function openNewCardModal(status) {
   document.getElementById('cardTitle').value = ''
   document.getElementById('cardDesc').value = ''
   document.getElementById('cardPriority').value = 'normal'
+  document.getElementById('cardProject').value = ''
   document.getElementById('cardDue').value = ''
   document.getElementById('cardEditId').value = ''
   document.getElementById('cardEditStatus').value = status || 'planned'
   populateAssigneeSelect('cardAssignee')
+  populateProjectSuggestions()
   openModal(cardModalOverlay)
   setTimeout(() => document.getElementById('cardTitle').focus(), 200)
 }
@@ -287,6 +331,7 @@ document.getElementById('saveCardBtn').addEventListener('click', async () => {
     description: document.getElementById('cardDesc').value.trim() || null,
     assignee: document.getElementById('cardAssignee').value || null,
     priority: document.getElementById('cardPriority').value,
+    project: document.getElementById('cardProject').value.trim() || null,
     due_date: document.getElementById('cardDue').value
       ? Math.floor(new Date(document.getElementById('cardDue').value).getTime() / 1000)
       : null,
@@ -339,6 +384,10 @@ async function showCardDetail(card) {
     <div class="meta-item">
       <span class="meta-label">Prioritás</span>
       <span class="meta-value">${priorityLabels[card.priority]}</span>
+    </div>
+    <div class="meta-item">
+      <span class="meta-label">Projekt</span>
+      <span class="meta-value">${card.project ? escapeHtml(card.project) : '-- nincs --'}</span>
     </div>
     <div class="meta-item">
       <span class="meta-label">Határidő</span>
@@ -394,12 +443,14 @@ async function showCardDetail(card) {
     document.getElementById('cardTitle').value = card.title
     document.getElementById('cardDesc').value = card.description || ''
     document.getElementById('cardPriority').value = card.priority
+    document.getElementById('cardProject').value = card.project || ''
     document.getElementById('cardDue').value = card.due_date
       ? new Date(card.due_date * 1000).toISOString().split('T')[0]
       : ''
     document.getElementById('cardEditId').value = card.id
     document.getElementById('cardEditStatus').value = card.status
     populateAssigneeSelect('cardAssignee', card.assignee)
+    populateProjectSuggestions()
     openModal(cardModalOverlay)
   }
 

--- a/web/index.html
+++ b/web/index.html
@@ -122,6 +122,12 @@
 
     <!-- === Kanban Page === -->
     <div class="page" id="kanbanPage" hidden>
+      <div style="margin-bottom:12px;display:flex;align-items:center;gap:8px;">
+        <label for="kanbanProjectFilter" style="font-size:13px;color:var(--muted);white-space:nowrap;">Projekt:</label>
+        <select id="kanbanProjectFilter" style="font-size:13px;padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--fg);min-width:140px;">
+          <option value="">Mind</option>
+        </select>
+      </div>
       <div class="kanban-board" id="kanbanBoard">
         <div class="kanban-col" data-status="planned">
           <div class="kanban-col-header">
@@ -802,9 +808,16 @@
             </select>
           </div>
         </div>
-        <div class="form-group">
-          <label for="cardDue">Határidő <span class="hint">(opcionális)</span></label>
-          <input type="date" id="cardDue">
+        <div class="form-row">
+          <div class="form-group form-half">
+            <label for="cardDue">Határidő <span class="hint">(opcionális)</span></label>
+            <input type="date" id="cardDue">
+          </div>
+          <div class="form-group form-half">
+            <label for="cardProject">Projekt <span class="hint">(opcionális)</span></label>
+            <input type="text" id="cardProject" list="projectSuggestions" placeholder="pl. Dream Engine" autocomplete="off">
+            <datalist id="projectSuggestions"></datalist>
+          </div>
         </div>
         <input type="hidden" id="cardEditId">
         <input type="hidden" id="cardEditStatus">

--- a/web/style.css
+++ b/web/style.css
@@ -539,6 +539,18 @@ main {
   opacity: 0.4;
   transform: rotate(2deg);
 }
+.kanban-card-project {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent);
+  background: color-mix(in oklch, var(--accent) 12%, transparent);
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-bottom: 4px;
+  letter-spacing: 0.02em;
+}
+
 .kanban-card-title {
   font-size: 13px;
   font-weight: 500;


### PR DESCRIPTION
## Summary
- `kanban_cards` table gets `project TEXT NULL` column (backward compat, existing cards stay NULL)
- `GET /api/kanban-projects` endpoint returns distinct project names
- Edit form: project input with `<datalist>` autocomplete from existing projects
- Board: project filter dropdown at the top, project badge on cards
- Detail view: project shown in meta section

## Test plan
- [ ] Open dashboard kanban page -- filter dropdown visible with "Mind" default
- [ ] Create card with project name -- badge appears on card
- [ ] Edit card -- project field pre-filled, autocomplete suggests existing projects
- [ ] Filter by project -- only matching cards shown
- [ ] Cards without project unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)