### PR TITLE
feat(scaffold): seed default scheduled tasks on startup

### DIFF
--- a/scheduled-tasks/dream-engine/SKILL.md
+++ b/scheduled-tasks/dream-engine/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: dream-engine
+description: Éjszakai analízis-loop az aznapi memóriákról, naplóról és kanban-állapotról. Generál 4 priorizált akció-javaslatot reggelre.
+---
+
+Te most a "Dream Engine" éjszakai analízis-loopot futtatod. 02:07-kor vagy, Szabolcs alszik, NE küldj Telegram üzenetet.
+
+A cél: az aznapi tudást átkonszolidálni és reggelre (07:30 Reggeli Napindító) felkészülni 4 priorizált javaslattal.
+
+## Mit kell csinálnod
+
+Generálj egy `/Users/marvin/ClaudeClaw/DREAM.md` fájlt az alábbi 5 bucket alapján. A formátum a fájl alján van.
+
+### Bucket 1 — 💡 Skill-javaslatok (flotta-szintű)
+
+Nézz végig MINDEN agent (marveen + sub-agentek: boni, deeper, iris, samu, zara) tegnapi (24h) memóriáit és napi naplóját. Kerítsd ki:
+- Volt-e 3+ szor visszatérő, manuálisan ismételt művelet ami skill-be illeszthető?
+- Új, NEM lefedett pattern amit érdemes lenne skillbe önteni?
+
+SQL minta:
+```bash
+sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "SELECT agent_id, content, keywords FROM memories WHERE created_at > strftime('%s', 'now', '-24 hours') AND category IN ('hot','warm') ORDER BY agent_id, created_at"
+```
+
+Output: 0-2 konkrét skill-javaslat. Mindegyikhez: cím + 1 mondat indoklás + "flotta-szintű" vagy "agent: <név>".
+
+### Bucket 2 — 🧹 Memória-egészség (NE delete, COLD-tier-be mozgatás)
+
+```bash
+# Vektorizálás ellenőrzés
+sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "SELECT COUNT(*) as total, COUNT(embedding) as with_emb FROM memories"
+# Ha NEM 100%, hívd meg a /api/memories/reembed endpoint-ot vagy futtass embedding-job-ot a missing ID-kra
+
+# Antikvált hot-tier (>7 napos hot, nem hivatkozott a memories_fts-en az elmúlt 24h-ban)
+sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "SELECT id, content, accessed_at FROM memories WHERE category='hot' AND accessed_at < strftime('%s', 'now', '-7 days')"
+```
+
+Műveletek:
+1. Vektorizálatlan memóriák: jelezd hányat találtál (a fire-and-forget embedding-job amúgy megcsinálja, de itt ellenőrzöd).
+2. Antikvált hot/warm → COLD-tier-be PUT (UPDATE category='cold'). Sosem törlés.
+3. Pontos dupla-content: jelezd, mozgass cold-ba.
+
+A változtatásokat directly SQL-lel csináld:
+```bash
+sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "UPDATE memories SET category='cold' WHERE id IN (...)"
+```
+
+Output: rövid statisztika ("X memória cold-tier-be áthelyezve, Y vektorizálatlan rendezve").
+
+### Bucket 3 — 🎯 Project-priorítás (top-3 holnapi javaslat)
+
+```bash
+# Nyitott kanban-kártyák project + priority szerint
+sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "SELECT id, title, status, project, priority, assignee FROM kanban_cards WHERE status IN ('planned','in_progress','waiting') AND archived_at IS NULL ORDER BY project, priority DESC"
+```
+
+Csoportosíts project szerint. A daily naplóban (utolsó 7 nap) nézd hogy melyik projekten van aktív mozgás (commit, PR, kanban-átmozgás). Hozz ki egy TOP-3 holnapi javaslatot prioritás+aktivitás súlyozva.
+
+Output: 3 sor, mindegyik formátum `<project>: <kártya cím / akció> — <indok 1 mondatban>`.
+
+### Bucket 4 — 🌐 External opportunities (új skill-repo ajánlások)
+
+Hetente 1-2 alkalommal (NEM minden éjszaka — kerüljük a zajos napi javaslatot) végezz WebSearch-öt új Claude Code / agentic AI / produktivitás-skillekért. Szűrés:
+- GitHub stars >100
+- Recent activity (utolsó 90 napban commit)
+- README clarity (skill mit csinál, hogyan kell telepíteni)
+
+Limitáció: ha az utolsó 7 napban már volt ajánlás (nézd a DREAM.md utolsó 7 napos archívumát vagy egy `external-ops-last-run` markerfile-t), skip-eld.
+
+Output (max 1 ajánlás): repo URL + 1 mondat indok hogy MIÉRT releváns Szabolcsnak (figyelembe véve: AI tartalomgyártás, magyar piac, fejlesztési flotta menedzsment, marketing).
+
+### Bucket 5 — 🛠 Skill-flotta health (csak NEM-pinned skillek)
+
+```bash
+# Antikvált skillek: nincs use-log, vagy a frontmatterben pinned: false
+ls ~/.claude/skills/ | head
+# Mindegyik SKILL.md-ben grep -l "pinned: true" — ezek mind védettek
+grep -L "^pinned:" ~/.claude/skills/*/SKILL.md  # azok a skillek ahol nincs pinned-flag (NEM gyári)
+```
+
+Pinned default (mindig védett): claude-video, frontend-design, docx, skill-creator, skill-factory, skill-install-from-git, init, review, security-review, simplify, fewer-permission-prompts, loop, schedule, claude-api, update-config, keybindings-help, telegram:configure, telegram:access.
+
+Output: 0-3 javaslat: "skill <név> antikvált (utolsó használat >30 nap), törlés vagy frissítés javasolt".
+
+## Output formátum (DREAM.md)
+
+```markdown
+# 💭 Dream Engine — 2026-05-12 02:07
+
+## 💡 Skill-javaslatok
+- (vagy "Nincs új javaslat")
+
+## 🧹 Memória-egészség
+346 / 346 vektorizált, 5 hot→cold mozgatva, 0 duplikátum.
+
+## 🎯 Top-3 holnapi javaslat
+1. <project>: <akció> — <indok>
+2. ...
+3. ...
+
+## 🌐 External opportunity
+- (vagy "Skip — heti limit elérte" / "Nincs releváns új repo")
+
+## 🛠 Skill-flotta health
+- (vagy "Minden skill aktív vagy pinned")
+```
+
+## Szabályok
+
+- NE küldj Telegram üzenetet. A DREAM.md a reggeli napindítóból kerül a Telegram-ra (07:30).
+- A `Bash` és SQL műveletek mind helyiek — semmilyen external API hívás (kivéve az Ollama embedding ha kell).
+- Ha akadály van (pl. DB lock, missing embedding model), írd be a DREAM.md végére `## ⚠️ Hibák` szekciót — reggel látom.
+- Befejezésként, írd a DREAM.md végére: `*Marveen, 02:XX — most már alszom én is.*`

--- a/scheduled-tasks/dream-engine/task-config.json
+++ b/scheduled-tasks/dream-engine/task-config.json
@@ -1,0 +1,8 @@
+{
+  "schedule": "7 2 * * *",
+  "agent": "marveen",
+  "enabled": true,
+  "type": "dream-engine",
+  "skipIfBusy": false,
+  "createdAt": 1778480400
+}

--- a/scheduled-tasks/memoria-heartbeat/SKILL.md
+++ b/scheduled-tasks/memoria-heartbeat/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: memoria-heartbeat
+description: 30 percenként átnézi a beszélgetést, menti a fontosat, és skill-eket generál ha volt komplex munka
+---
+
+Nézd át az utolsó 30 perc beszélgetéseidet. Két dolgot csinálj:
+
+## 1. Memória mentés
+
+Ha volt fontos döntés, preferencia, tanulság vagy bármi ami később hasznos, mentsd el:
+
+```bash
+curl -s -X POST http://localhost:3420/api/memories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(cat /Users/marvin/ClaudeClaw/store/.dashboard-token)" \
+  -d '{"agent_id":"SAJAT_NEVED","content":"...","category":"warm","keywords":"..."}'
+```
+
+`category` lehet: `hot` (aktív), `warm` (preferencia/config), `cold` (tanulság), `shared` (más agent-nek is).
+Az `agent_id`-t a CLAUDE.md-ből vagy a munkamappa nevéből derítsd ki.
+
+## 2. Skill reflexió (KÖTELEZŐ ha volt komplex munka)
+
+Először döntsd el az alábbi 3 kérdéssel:
+
+- **A**: Volt-e az utolsó 30 percben legalább 5 tool-hívásos komplex feladat?
+- **B**: Volt-e hiba → recovery (próbálkozás → fail → másképp) amit egy meglévő skill Buktatók szekciójába kellene tenni?
+- **C**: Volt-e user korrekció ("nem így", "ne ezt", "másképp"), ami skill-javítást igényel?
+
+**Ha A vagy B vagy C IGEN: KÖTELEZŐ skill akció, nem kihagyható.**
+
+Lépések:
+1. Nézd meg `ls ~/.claude/skills/`-szel hogy van-e már lefedő skill (a `.skill-index.md`-ben szöveges keresés)
+2. Ha van releváns skill: PATCH (csak a megváltozott rész cseréje, ne az egész fájl).
+   - A `## Buktatók` szekciót preferáld ha hiba/recovery volt.
+   - A `## Eljárás` szekciót ha a folyamat változott.
+3. Ha NINCS releváns skill: hozz létre újat:
+   ```bash
+   mkdir -p ~/.claude/skills/<NEV>
+   cat > ~/.claude/skills/<NEV>/SKILL.md <<EOF
+   ---
+   name: <NEV>
+   description: Mikor használd, mit csinál (1-2 mondat). Konkrét trigger.
+   ---
+   # <Cím>
+
+   ## Mikor használd
+   ...
+
+   ## Eljárás
+   1. ...
+
+   ## Buktatók
+   - ...
+
+   ## Ellenőrzés
+   - ...
+   EOF
+   ```
+4. Index regen: `bash ~/ClaudeClaw/scripts/skill-index.sh`
+
+**Ha kihagytad a skill akciót, pedig A/B/C valamelyike IGEN volt:** kötelezően írj `hot` tier memóriát "skip-skill: <konkrét ok>" tartalommal, hogy később lássuk miért. Ne csendben hagyd ki.
+
+## 3. Csendben maradás
+
+Ha NINCS komplex feladat / hiba / korrekció (A=B=C=NEM), és nincs új információ a 30 percben:
+- Ne ments memóriát feleslegesen
+- Ne generálj skill-t
+- Ne írj Telegramon
+- Maradj csendben (egy rövid "csendes heartbeat" sor a transzkriptbe elég)

--- a/scheduled-tasks/memoria-heartbeat/task-config.json
+++ b/scheduled-tasks/memoria-heartbeat/task-config.json
@@ -1,0 +1,8 @@
+{
+  "schedule": "*/15 * * * *",
+  "agent": "marveen",
+  "enabled": true,
+  "type": "heartbeat",
+  "skipIfBusy": true,
+  "createdAt": 1775669364
+}

--- a/scheduled-tasks/reggeli-napindito/SKILL.md
+++ b/scheduled-tasks/reggeli-napindito/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: reggeli-napindito
+description: Reggeli összefoglaló: email, naptár, AI hírek, plus Dream Engine top-of-message
+---
+
+Reggeli napindítót a CLAUDE.md formátum szerint. Telegramra (1268077055).
+
+**FONTOS — Dream Engine override**: a napindító ELEJÉRE (még az email/naptár szekciók ELŐTT) tedd be a `/Users/marvin/ClaudeClaw/DREAM.md` fájl tartalmából az 5 bucket-et — `💡 Skill-javaslatok`, `🧹 Memória-egészség`, `🎯 Top-3 holnapi javaslat`, `🌐 External opportunity`, `🛠 Skill-flotta health`. Ha a DREAM.md nem létezik vagy üres (pl. a Dream Engine valamiért nem futott le), kihagyod ezt a szekciót.
+
+A `cat /Users/marvin/ClaudeClaw/DREAM.md` parancs visszaadja a tartalmat, abból emeld ki a kulcs-szekciókat MarkdownV2-formátumra escape-elve.
+
+A többi szekció (email, naptár, AI hírek) maradnak a CLAUDE.md-ben leírt formátum szerint.

--- a/scheduled-tasks/reggeli-napindito/task-config.json
+++ b/scheduled-tasks/reggeli-napindito/task-config.json
@@ -1,0 +1,7 @@
+{
+  "schedule": "30 7 * * *",
+  "agent": "marveen",
+  "enabled": true,
+  "type": "task",
+  "createdAt": 1776153060
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -6,7 +6,7 @@ import { PROJECT_ROOT, WEB_HOST } from './config.js'
 import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-auth.js'
 import { json } from './web/http-helpers.js'
 import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
-import { ensureAgentHooks } from './web/agent-scaffold.js'
+import { ensureAgentHooks, ensureDefaultScheduledTasks } from './web/agent-scaffold.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
 import { startMessageRouter } from './web/message-router.js'
 import { startUpdateChecker } from './web/update-checker.js'
@@ -229,6 +229,13 @@ export function startWebServer(port = 3420): http.Server {
     if (patched.length) logger.info({ patched }, 'PreCompact hook backfilled into agent settings.json')
   } catch (err) {
     logger.warn({ err }, 'Agent hook backfill skipped')
+  }
+
+  try {
+    ensureDefaultScheduledTasks()
+    logger.info('Default scheduled tasks seeded')
+  } catch (err) {
+    logger.warn({ err }, 'Scheduled tasks seed skipped')
   }
 
   const origClose = server.close.bind(server)

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { PROJECT_ROOT, OWNER_NAME } from '../config.js'
@@ -53,6 +53,24 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
     deny: profile.filesystem.deny.map(p => resolveProfilePlaceholders(p, ctx)),
   }
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
+}
+
+export function ensureDefaultScheduledTasks(): void {
+  const repoTasks = join(PROJECT_ROOT, 'scheduled-tasks')
+  if (!existsSync(repoTasks)) return
+  const destRoot = join(homedir(), '.claude', 'scheduled-tasks')
+  mkdirSync(destRoot, { recursive: true })
+
+  for (const taskName of readdirSync(repoTasks)) {
+    const src = join(repoTasks, taskName)
+    const dest = join(destRoot, taskName)
+    if (!statSync(src).isDirectory()) continue
+    if (existsSync(dest)) continue
+    mkdirSync(dest, { recursive: true })
+    for (const file of readdirSync(src)) {
+      copyFileSync(join(src, file), join(dest, file))
+    }
+  }
 }
 
 export function scaffoldAgentDir(name: string) {


### PR DESCRIPTION
## Summary
- Add `scheduled-tasks/` directory with dream-engine, reggeli-napindito, and memoria-heartbeat task definitions (SKILL.md + task-config.json)
- New `ensureDefaultScheduledTasks()` in agent-scaffold.ts copies repo tasks to `~/.claude/scheduled-tasks/` on startup (idempotent: skips existing)
- Wire the call into server startup in web.ts alongside existing agent hook backfill

## Test plan
- [ ] `npm run build` passes
- [ ] Fresh install: verify tasks appear in `~/.claude/scheduled-tasks/`
- [ ] Existing install: verify user-modified tasks are NOT overwritten
- [ ] Dashboard logs "Default scheduled tasks seeded" on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)