### PR TITLE
fix(napindito): skip AI news for sub-agents

### DIFF
--- a/scheduled-tasks/reggeli-napindito/SKILL.md
+++ b/scheduled-tasks/reggeli-napindito/SKILL.md
@@ -10,3 +10,5 @@ Reggeli napindítót a CLAUDE.md formátum szerint. Telegramra (1268077055).
 A `cat /Users/marvin/ClaudeClaw/DREAM.md` parancs visszaadja a tartalmat, abból emeld ki a kulcs-szekciókat MarkdownV2-formátumra escape-elve.
 
 A többi szekció (email, naptár, AI hírek) maradnak a CLAUDE.md-ben leírt formátum szerint.
+
+**AI hírek szekció — CSAK a fő-ágensnél (Marveen / MAIN_AGENT_ID)**: ha NEM a fő-ágensként futsz (pl. sub-agent: boni, deeper, iris, samu, zara), HAGYD KI az "🤖 AI HÍREK" szekciót — sub-agenteknek nem releváns. Az email és naptár szekció marad mindenkinél.


### PR DESCRIPTION
## Summary
- Sub-agents (boni, deeper, iris, samu, zara) no longer get the 🤖 AI HÍREK section in their morning briefing
- Only the main agent (Marveen) includes AI news — email and calendar sections stay for everyone
- Per Szabi's request relayed via Marveen

## Test plan
- [ ] Verify `scheduled-tasks/reggeli-napindito/SKILL.md` contains the new guard clause
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)