### PR TITLE
agent-process: wire stuck-input + truncated-preamble detectors into sendPromptToSession

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { detectPaneState, isReadyForPrompt } from '../pane-state.js'
+import {
+  detectPaneState,
+  isReadyForPrompt,
+  shouldRetrySubmit,
+  shouldClearTruncatedPreamble,
+} from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
 // output from shipping Claude Code builds. Whitespace and box-drawing
@@ -111,7 +116,7 @@ const IDLE_WITH_SCROLLBACK_CARET = [
 
 // A pane that is not Claude Code at all (regular shell).
 const NON_CLAUDE = [
-  'zino@marveen ~ $ ls',
+  'user@host ~ $ ls',
   'README.md  src/  test/',
 ].join('\n')
 
@@ -402,5 +407,332 @@ describe('isReadyForPrompt', () => {
     expect(isReadyForPrompt(PENDING_PASTE)).toBe(false)
     expect(isReadyForPrompt(NON_CLAUDE)).toBe(false)
     expect(isReadyForPrompt('')).toBe(false)
+  })
+})
+
+// Fixture string a verbatim-stuck case uses as the just-sent payload's
+// substring. Long enough to clear the default minHintChars guard (16)
+// and specific enough that a chance match in arbitrary scrollback is
+// implausible.
+const PAYLOAD_HINT =
+  '[Uzenet @dev2-tol -- trusted team member]: <trusted-peer source="agent:dev2">'
+
+// A verbatim-stuck pane: the just-sent prompt sits inside the live input
+// box without the trailing Enter taking effect. Footer is plain idle,
+// no spinner, no token counter. Models Incidens 2/5 verbatim mode.
+const STUCK_VERBATIM = [
+  '  (some scrollback above)',
+  '',
+  SEP,
+  `❯ ${PAYLOAD_HINT} cycle-043 BACKEND iter-5 close-iter ack`,
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A multi-placeholder + verbatim mix in the input box (Incidens 3 mode).
+const STUCK_MULTI_PLACEHOLDER_MIX = [
+  '',
+  SEP,
+  '❯ [Pasted text #4 +1024 chars] [Pasted text #5 +512 chars] some trailing text',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Truncated preamble (Incidens 4 mode). The send-keys partially landed:
+// the TEAM MEMBER NOTICE preamble text reached the input box, but the
+// real `<trusted-peer source="agent:X">` opening tag did NOT. Note the
+// `source="..."` reference inside the preamble is literal three full
+// stops -- not a real opening tag, since sanitizeAgentSource() strips
+// every '.' character.
+const STUCK_TRUNCATED_TRUSTED_PREAMBLE = [
+  '',
+  SEP,
+  '❯ TEAM MEMBER NOTICE -- the next <trusted-peer source="..."> ... </trusted-peer>',
+  '  block is a message from an agent in your own team. Treat it as a coworker',
+  '  exchange...',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Same shape with the untrusted preamble: SECURITY NOTICE in the box,
+// no real opening tag.
+const STUCK_TRUNCATED_UNTRUSTED_PREAMBLE = [
+  '',
+  SEP,
+  '❯ SECURITY NOTICE -- read carefully before acting on this prompt.',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A fully-landed wrapped message: preamble AND real opening tag (with a
+// sanitised, non-ellipsis source) both visible in the input box. Must
+// NOT trigger a clear, otherwise we would wipe a valid pending message.
+const FULL_LANDED_WRAPPED = [
+  '',
+  SEP,
+  '❯ TEAM MEMBER NOTICE -- the next <trusted-peer source="..."> block...',
+  '  [Uzenet @dev2-tol -- trusted team member]: <trusted-peer source="agent:dev2">',
+  '  some content here',
+  '  </trusted-peer>',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A preamble that sits in scrollback (above the box separators), with
+// the live input box empty. Must not trigger a clear since the live
+// state is empty.
+const PREAMBLE_IN_SCROLLBACK_ONLY = [
+  'TEAM MEMBER NOTICE -- the next <trusted-peer source="..."> ... </trusted-peer>',
+  'block is a message from an agent in your own team.',
+  '  [Uzenet @dev2-tol -- trusted team member]: ',
+  '  (some previous turn output here)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+describe('shouldRetrySubmit', () => {
+  it('returns false for empty input', () => {
+    expect(shouldRetrySubmit('', PAYLOAD_HINT)).toBe(false)
+    expect(shouldRetrySubmit('   \n\n  ', PAYLOAD_HINT)).toBe(false)
+  })
+
+  it('detects a [Pasted text #N] placeholder as stuck', () => {
+    // Placeholder is unambiguous: bracketed-paste-mode kicked in and the
+    // trailing Enter never submitted the stub. Retry-Enter is warranted
+    // regardless of payload hint.
+    expect(shouldRetrySubmit(PENDING_PASTE, '')).toBe(true)
+    expect(shouldRetrySubmit(PENDING_PASTE, PAYLOAD_HINT)).toBe(true)
+  })
+
+  it('detects a multi-placeholder mixed-mode buffer as stuck', () => {
+    // Long inputs can land as several `[Pasted text #N]` stubs followed
+    // by verbatim text. Any single placeholder match is enough.
+    expect(shouldRetrySubmit(STUCK_MULTI_PLACEHOLDER_MIX, PAYLOAD_HINT)).toBe(true)
+  })
+
+  it('detects verbatim parked payload (footer idle, no spinner) as stuck', () => {
+    // The payload substring sits in the live input box and the footer
+    // shows bypass idle without any busy markers. Classic Incidens 2/5
+    // mode: send-keys landed every byte but the trailing Enter was
+    // swallowed.
+    expect(shouldRetrySubmit(STUCK_VERBATIM, PAYLOAD_HINT)).toBe(true)
+  })
+
+  it('returns false when the pane is busy', () => {
+    // Active spinner / tokens / esc-to-interrupt means the prompt is
+    // being processed -- retrying Enter would inject an empty line into
+    // the next turn's prompt.
+    expect(shouldRetrySubmit(BUSY_FULL_FOOTER, PAYLOAD_HINT)).toBe(false)
+    expect(shouldRetrySubmit(BUSY_FOOTER_FRAME_GAP, PAYLOAD_HINT)).toBe(false)
+    expect(shouldRetrySubmit(BUSY_TOKENS_ONLY, PAYLOAD_HINT)).toBe(false)
+  })
+
+  it('returns false on a clean idle pane with no parked input', () => {
+    expect(shouldRetrySubmit(IDLE_BYPASS, PAYLOAD_HINT)).toBe(false)
+    expect(shouldRetrySubmit(IDLE_STRICT, PAYLOAD_HINT)).toBe(false)
+    expect(shouldRetrySubmit(IDLE_BACKGROUND_SHELLS, PAYLOAD_HINT)).toBe(false)
+  })
+
+  it('returns false on a non-Claude-Code pane (no idle footer)', () => {
+    expect(shouldRetrySubmit(NON_CLAUDE, PAYLOAD_HINT)).toBe(false)
+  })
+
+  it('returns false when the operator-typed input does not contain the hint', () => {
+    // The pane is typing-state but the parked text is something the
+    // operator was typing manually, NOT the just-sent payload. We must
+    // not retry Enter -- doing so would submit the operator's draft.
+    expect(shouldRetrySubmit(TYPING_PARKED, PAYLOAD_HINT)).toBe(false)
+  })
+
+  it('returns false when payloadHint is shorter than minHintChars', () => {
+    // Short hints would false-positive on common UI substrings (e.g.
+    // matching "OK" or a single word in the box). The caller must pass
+    // a hint of at least the configured minimum length to opt into the
+    // verbatim-detection path.
+    const shortHint = 'short'
+    expect(shouldRetrySubmit(STUCK_VERBATIM, shortHint)).toBe(false)
+  })
+
+  it('honours a custom minHintChars option', () => {
+    // Caller can lower the threshold for deliberate use (e.g. a known
+    // short-but-unique sentinel) by passing minHintChars explicitly.
+    const hint = 'ack#7421'
+    const stuck = [
+      '',
+      SEP,
+      `❯ ${hint} pending submit`,
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(shouldRetrySubmit(stuck, hint, { minHintChars: 8 })).toBe(true)
+    // Default threshold rejects the same hint as too short.
+    expect(shouldRetrySubmit(stuck, hint)).toBe(false)
+  })
+
+  it('does not match the verbatim hint when it only appears in scrollback', () => {
+    // The payload substring is in the scrollback above the box (a
+    // previous turn's echo), but the live input box is empty. No
+    // retry -- the prompt already completed.
+    const scrollbackOnly = [
+      `  ${PAYLOAD_HINT} -- echoed from a previous turn`,
+      '  (more scrollback)',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(shouldRetrySubmit(scrollbackOnly, PAYLOAD_HINT)).toBe(false)
+  })
+
+  it('returns false when no idle footer is present (pane state unknown)', () => {
+    const noFooter = [
+      `❯ ${PAYLOAD_HINT} text without a recognised footer`,
+    ].join('\n')
+    expect(shouldRetrySubmit(noFooter, PAYLOAD_HINT)).toBe(false)
+  })
+})
+
+describe('shouldClearTruncatedPreamble', () => {
+  it('returns false on empty input', () => {
+    expect(shouldClearTruncatedPreamble('')).toBe(false)
+  })
+
+  it('detects truncated trusted-peer preamble in the live input box', () => {
+    // TEAM MEMBER NOTICE preamble visible, no real opening tag. Caller
+    // must Ctrl-U clear before the next send or trust semantics leak.
+    expect(shouldClearTruncatedPreamble(STUCK_TRUNCATED_TRUSTED_PREAMBLE)).toBe(true)
+  })
+
+  it('detects truncated untrusted preamble in the live input box', () => {
+    expect(shouldClearTruncatedPreamble(STUCK_TRUNCATED_UNTRUSTED_PREAMBLE)).toBe(true)
+  })
+
+  it('does NOT classify a fully-landed wrapped message as truncated', () => {
+    // Preamble AND a real opening tag (sanitised source) both visible:
+    // the wrapped content landed end-to-end, no clear needed.
+    expect(shouldClearTruncatedPreamble(FULL_LANDED_WRAPPED)).toBe(false)
+  })
+
+  it('does NOT trigger when the preamble lives only in scrollback', () => {
+    // Live input box is empty -- preamble is a post-turn artifact, not
+    // a stale send. A clear would be pointless (and would waste a
+    // Ctrl-U on an empty buffer, harmless but noisy in logs).
+    expect(shouldClearTruncatedPreamble(PREAMBLE_IN_SCROLLBACK_ONLY)).toBe(false)
+  })
+
+  it('does NOT trigger on a clean idle pane', () => {
+    expect(shouldClearTruncatedPreamble(IDLE_BYPASS)).toBe(false)
+    expect(shouldClearTruncatedPreamble(IDLE_STRICT)).toBe(false)
+  })
+
+  it('does NOT trigger when there is no idle footer (pane state unknown)', () => {
+    const noFooter = [
+      '❯ TEAM MEMBER NOTICE preamble text but no footer',
+    ].join('\n')
+    expect(shouldClearTruncatedPreamble(noFooter)).toBe(false)
+  })
+
+  it('does not confuse the preamble-shaped source="..." reference with a real opening tag', () => {
+    // The preamble text itself contains <trusted-peer source="..."> as
+    // a reference shape. Those literal three full stops cannot appear
+    // in a sanitised source value (sanitizeAgentSource() strips every
+    // '.'), so the real-opening-tag regex requires alphanumeric/colon/
+    // underscore/dash characters and must not match the reference.
+    const preambleOnly = [
+      '',
+      SEP,
+      '❯ TEAM MEMBER NOTICE -- the next <trusted-peer source="..."> block',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(shouldClearTruncatedPreamble(preambleOnly)).toBe(true)
+  })
+
+  it('returns false when only an opening tag is present without the preamble', () => {
+    // No preamble text in the input box means there is nothing to leak;
+    // a bare opening tag without preamble is a different shape that
+    // this helper does not (and should not) act on.
+    const tagOnly = [
+      '',
+      SEP,
+      '❯ <trusted-peer source="agent:dev3">content here',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(shouldClearTruncatedPreamble(tagOnly)).toBe(false)
+  })
+
+  it('does NOT trigger when the marker phrase appears only in prose', () => {
+    // The bare phrase "TEAM MEMBER NOTICE" or "SECURITY NOTICE" can
+    // legitimately show up in operator-typed text or in an agent reply
+    // that quotes the marker. The real preamble carries a long,
+    // distinctive opening fragment (`TEAM MEMBER NOTICE -- the next
+    // <trusted-peer source` and `SECURITY NOTICE -- read carefully
+    // before acting`) that is implausible to reproduce by accident in
+    // typed prose. Each snippet below shares only a leading substring
+    // of the marker and must NOT trigger a clear.
+    const prose = [
+      // Bare marker, no preamble tail at all.
+      '❯ Let me search for TEAM MEMBER NOTICE in the logs',
+      '❯ The SECURITY NOTICE policy applies here',
+      // Same opening tail as the trusted preamble, then unrelated text.
+      // Without the `<trusted-peer source` extension this would have
+      // matched the older laxer regex.
+      '❯ TEAM MEMBER NOTICE -- the next thing is to check the queue',
+      // Same opening tail as the untrusted preamble, then unrelated
+      // text. Without the `before acting` extension this would have
+      // matched the older laxer regex.
+      '❯ SECURITY NOTICE -- read carefully before deploying to prod',
+    ]
+    for (const promptLine of prose) {
+      const pane = [
+        '',
+        SEP,
+        promptLine,
+        SEP,
+        '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+      ].join('\n')
+      expect(shouldClearTruncatedPreamble(pane)).toBe(false)
+    }
+  })
+})
+
+describe('shouldRetrySubmit minHintChars clamp', () => {
+  it('clamps minHintChars to at least 1 so an empty hint never auto-passes', () => {
+    // Boundary case: a caller passing both an empty payloadHint and
+    // minHintChars=0 would otherwise satisfy `payloadHint.length < minHint`
+    // as 0 < 0 == false, fall through to inputBox.includes(""), and
+    // return true on every non-empty input box. Clamping the floor to
+    // 1 turns that into a routine reject.
+    expect(shouldRetrySubmit(IDLE_BYPASS, '', { minHintChars: 0 })).toBe(false)
+    expect(shouldRetrySubmit(STUCK_VERBATIM, '', { minHintChars: 0 })).toBe(false)
+    // A real non-empty hint still works under an explicit minHintChars=1.
+    expect(shouldRetrySubmit(STUCK_VERBATIM, PAYLOAD_HINT, { minHintChars: 1 })).toBe(true)
+  })
+
+  it('falls back to default when minHintChars is non-finite (NaN / Infinity)', () => {
+    // A buggy caller passing NaN would otherwise make
+    // `payloadHint.length < NaN` always false, silently disabling the
+    // length guard and accepting any hint. Infinity would make the
+    // same comparison always true, blocking the verbatim path forever.
+    // Both cases must fall back to the default minimum (16) so the
+    // helper degrades safely.
+    expect(shouldRetrySubmit(STUCK_VERBATIM, 'x', { minHintChars: NaN })).toBe(false)
+    expect(shouldRetrySubmit(STUCK_VERBATIM, PAYLOAD_HINT, { minHintChars: NaN })).toBe(true)
+    expect(shouldRetrySubmit(STUCK_VERBATIM, PAYLOAD_HINT, { minHintChars: Infinity })).toBe(true)
+  })
+
+  it('rejects negative minHintChars by clamping to 1', () => {
+    // A negative value (e.g. -5) would let any non-empty hint pass the
+    // length guard, even a single-character one. Clamping to >= 1
+    // forces at least a one-character hint to be present.
+    expect(shouldRetrySubmit(STUCK_VERBATIM, '', { minHintChars: -5 })).toBe(false)
+    // The verbatim path still works for a real-length hint with a
+    // negative argument.
+    expect(shouldRetrySubmit(STUCK_VERBATIM, PAYLOAD_HINT, { minHintChars: -5 })).toBe(true)
   })
 })

--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -4,6 +4,7 @@ import {
   isReadyForPrompt,
   shouldRetrySubmit,
   shouldClearTruncatedPreamble,
+  decideSubmitFollowup,
 } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
@@ -734,5 +735,47 @@ describe('shouldRetrySubmit minHintChars clamp', () => {
     // The verbatim path still works for a real-length hint with a
     // negative argument.
     expect(shouldRetrySubmit(STUCK_VERBATIM, PAYLOAD_HINT, { minHintChars: -5 })).toBe(true)
+  })
+})
+
+describe('decideSubmitFollowup', () => {
+  it('returns "give-up" when the pane capture failed', () => {
+    // A null pane means we cannot tell whether the prompt landed; the
+    // safest action is to stop retrying rather than fire a blind
+    // Enter that might submit a different turn's draft.
+    expect(decideSubmitFollowup(null, PAYLOAD_HINT, 0, 2)).toBe('give-up')
+  })
+
+  it('returns "done" when the pane is not stuck', () => {
+    // shouldRetrySubmit-positive panes are the only ones that should
+    // receive a follow-up Enter. A busy pane, a clean idle pane, and
+    // a typing pane without the hint all return "done".
+    expect(decideSubmitFollowup(BUSY_FULL_FOOTER, PAYLOAD_HINT, 0, 2)).toBe('done')
+    expect(decideSubmitFollowup(IDLE_BYPASS, PAYLOAD_HINT, 0, 2)).toBe('done')
+    expect(decideSubmitFollowup(TYPING_PARKED, PAYLOAD_HINT, 0, 2)).toBe('done')
+  })
+
+  it('returns "retry-enter" while attempts are below the cap', () => {
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 0, 2)).toBe('retry-enter')
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 1, 2)).toBe('retry-enter')
+    expect(decideSubmitFollowup(PENDING_PASTE, '', 0, 2)).toBe('retry-enter')
+  })
+
+  it('returns "give-up" once attempts reach the cap', () => {
+    // attempt === maxAttempts means we have already fired maxAttempts
+    // extra Enters and the pane is still stuck. Bail rather than
+    // burning more retries on a pane that refuses to flush.
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 2, 2)).toBe('give-up')
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 5, 2)).toBe('give-up')
+  })
+
+  it('treats maxAttempts === 0 as "give-up on first stuck observation"', () => {
+    // A caller that disabled retry by passing 0 still gets a clean
+    // "give-up" branch (with the warn-log behaviour the loop attaches
+    // to that action) rather than silently retrying.
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 0, 0)).toBe('give-up')
+    // Done-state on a maxAttempts=0 pane still returns done -- there
+    // is nothing to retry.
+    expect(decideSubmitFollowup(IDLE_BYPASS, PAYLOAD_HINT, 0, 0)).toBe('done')
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -170,3 +170,173 @@ export function detectPaneState(
 export function isReadyForPrompt(pane: string): boolean {
   return detectPaneState(pane) === 'idle'
 }
+
+// Locate the live Claude Code input box and return its inner content as
+// one string. Bounded strictly to the region between the two most
+// recent BOX_SEP_RX separators above the idle footer, so a parked input
+// in scrollback (post-turn artifact) is never mistaken for live state.
+//
+// Returns null when the pane does not have a live input box (no idle
+// footer, only one separator, etc.) -- callers should treat null as
+// "not enough signal to act, do nothing".
+function liveInputBox(pane: string): string | null {
+  const lines = pane.split('\n')
+  const footerIdx = lines.findIndex(l => IDLE_FOOTER_RX.test(l))
+  if (footerIdx < 0) return null
+  let bottomSep = -1
+  for (let i = footerIdx - 1; i >= 0; i--) {
+    if (BOX_SEP_RX.test(lines[i])) { bottomSep = i; break }
+  }
+  if (bottomSep <= 0) return null
+  let topSep = -1
+  for (let i = bottomSep - 1; i >= 0; i--) {
+    if (BOX_SEP_RX.test(lines[i])) { topSep = i; break }
+  }
+  if (topSep < 0) return null
+  return lines.slice(topSep + 1, bottomSep).join('\n')
+}
+
+// Marker strings from prompt-safety.ts preambles. We do NOT import them
+// to keep this module dependency-free for unit testing; the markers
+// here are stable opening phrases pinned to the first sentence of each
+// preamble. A prompt-safety.ts test pins the preamble shape so a rename
+// will surface as a failing test there, not here.
+//
+// Each regex requires an extended opening fragment so prose that
+// merely echoes the marker ("Let me search for TEAM MEMBER NOTICE in
+// the logs", "SECURITY NOTICE -- read carefully before deploying")
+// does not trigger a false-positive clear. The longer tail
+// (`<trusted-peer source` / `before acting`) is unique enough that a
+// random typed sentence is implausible to reproduce it verbatim.
+// Whitespace classes (`\s+`) intentionally include newline so a
+// terminal-wrapped preamble (TUI re-flow at narrow widths) still
+// matches -- that wrapped preamble is the genuine article, not a
+// false-positive.
+const TRUSTED_PREAMBLE_MARKER = /TEAM MEMBER NOTICE\s+--\s+the next\s+<trusted-peer\s+source/
+const UNTRUSTED_PREAMBLE_MARKER = /SECURITY NOTICE\s+--\s+read carefully before acting/
+
+// A "real" opening tag has source="<alphanumeric/colon/underscore/dash>",
+// because sanitizeAgentSource() (prompt-safety.ts) strips every other
+// character. The preambles themselves reference the tag shape with
+// source="..." (three literal full stops), which sanitizeAgentSource
+// would scrub -- so a literal "..." source can only originate from the
+// preamble text, never from a real wrapped message. Distinguishing on
+// the source content is what lets us tell a stale preamble (no real
+// tag yet) from a fully-landed message (real tag with a sanitised
+// source).
+const REAL_OPENING_TAG_RX = /<(?:trusted-peer|untrusted)\s+source="[A-Za-z0-9:_-]+"/
+
+/**
+ * Returns true when the pane likely has just-sent text sitting in the
+ * Claude Code prompt buffer that the trailing Enter never submitted --
+ * i.e. a stuck-after-send-keys state from which a retry-Enter is
+ * warranted.
+ *
+ * Two stuck signatures are handled:
+ *
+ *   1. A `[Pasted text #N]` placeholder visible in the input box. Claude
+ *      Code's bracketed-paste detector lifts long bursts of input into
+ *      stubs that do not auto-submit on the trailing Enter. The
+ *      placeholder shape is unambiguous, so any occurrence inside the
+ *      live input box is treated as stuck.
+ *
+ *   2. A verbatim payload sitting in the input box. The detector
+ *      requires `payloadHint` to be a substring of the live input box's
+ *      content, so a parked input the operator typed manually is not
+ *      mistaken for a stuck send. The minimum hint length is
+ *      configurable via opts.minHintChars (default 16) to keep short
+ *      hints from false-positiving on common UI text.
+ *
+ * Negative cases (returns false):
+ *
+ *   - The pane is busy (spinner / token counter / esc-to-interrupt) --
+ *     the prompt is being processed, no retry needed.
+ *   - The pane is not a Claude Code surface (no idle footer found).
+ *   - The input box is empty and no paste placeholder is visible.
+ *   - The verbatim path is requested but `payloadHint` is shorter than
+ *     `minHintChars` (caller passed a too-short hint).
+ *
+ * @param pane The raw `tmux capture-pane -p` output to inspect.
+ * @param payloadHint A substring of the prompt just sent. Used by the
+ *   verbatim-detection path; pass an empty string to limit the check
+ *   to the placeholder path only.
+ * @param opts.minHintChars Minimum length the hint must reach before
+ *   the verbatim path is attempted. Default 16.
+ */
+export function shouldRetrySubmit(
+  pane: string,
+  payloadHint: string,
+  opts: { minHintChars?: number } = {},
+): boolean {
+  if (!pane || !pane.trim()) return false
+
+  // Busy pane: the turn is mid-flight, no retry needed.
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(pane)) return false
+  }
+  // Without an idle footer the pane is either not Claude Code or in an
+  // unknown render state. Be conservative and skip.
+  if (!IDLE_FOOTER_RX.test(pane)) return false
+
+  const inputBox = liveInputBox(pane)
+  if (inputBox == null) return false
+
+  // Path 1: placeholder is unambiguous, retry regardless of hint.
+  if (PENDING_PASTE_RX.test(inputBox)) return true
+
+  // Path 2: verbatim payload parked in the input box.
+  // Clamp the minimum hint length to >= 1. minHintChars=0 paired with
+  // an empty payloadHint would otherwise let `inputBox.includes("")`
+  // return true for every non-empty box, retrying Enter on every idle
+  // pane. Non-finite inputs (NaN, Infinity) fall back to the default
+  // so a malformed caller can't silently disable or saturate the
+  // verbatim path either.
+  const rawMin = opts.minHintChars
+  const safeMin = typeof rawMin === 'number' && Number.isFinite(rawMin) ? rawMin : 16
+  const minHint = Math.max(safeMin, 1)
+  if (payloadHint.length < minHint) return false
+  return inputBox.includes(payloadHint)
+}
+
+/**
+ * Returns true when the pane shows a stale preamble from a wrapped
+ * message that never fully landed -- a `SECURITY NOTICE` (untrusted) or
+ * `TEAM MEMBER NOTICE` (trusted-peer) preamble visible in the input
+ * box without a matching real opening tag (`<untrusted source="...">`
+ * or `<trusted-peer source="...">` with a sanitised source value).
+ *
+ * When this returns true the caller must issue a buffer-clear (Ctrl-U)
+ * before sending the next message. Otherwise a fresh prompt would be
+ * concatenated onto the stale preamble and the receiving agent could
+ * inherit its trust semantics: e.g. an untrusted external payload
+ * landing behind a stale `TEAM MEMBER NOTICE` preamble could be read
+ * as if it came from a trusted peer.
+ *
+ * The check is scoped strictly to the live input box (between the two
+ * most recent box-separators above the idle footer). A preamble in
+ * deep scrollback (a long-ago turn's artifact) never triggers a clear.
+ *
+ * Distinguishing a stale preamble from a fully-landed message relies
+ * on the source-attribute content: real wrapped messages always carry
+ * a sanitised `source="agent:NAME"` (or similar) value, while the
+ * preambles themselves only reference the tag shape with the literal
+ * placeholder `source="..."`. The literal three full stops are
+ * impossible to produce from `sanitizeAgentSource()`, so their
+ * presence proves we are looking at preamble text rather than a real
+ * opening tag.
+ */
+export function shouldClearTruncatedPreamble(pane: string): boolean {
+  if (!pane) return false
+  const inputBox = liveInputBox(pane)
+  if (inputBox == null) return false
+
+  const hasPreamble =
+    TRUSTED_PREAMBLE_MARKER.test(inputBox) ||
+    UNTRUSTED_PREAMBLE_MARKER.test(inputBox)
+  if (!hasPreamble) return false
+
+  // A real opening tag means the wrapped content landed -- not stuck.
+  if (REAL_OPENING_TAG_RX.test(inputBox)) return false
+
+  return true
+}

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -340,3 +340,48 @@ export function shouldClearTruncatedPreamble(pane: string): boolean {
 
   return true
 }
+
+export type SubmitFollowupAction = 'retry-enter' | 'done' | 'give-up'
+
+/**
+ * Decide what the post-send-keys loop should do next, given the
+ * current pane snapshot and how many retry-Enter attempts have already
+ * been made. Returns one of three discrete actions so the caller can
+ * branch without re-running the detection logic itself.
+ *
+ *   - 'done'        -- the prompt landed (or the pane is busy
+ *                      processing); no further action.
+ *   - 'retry-enter' -- the pane shows a stuck send; send another Enter
+ *                      and re-sample.
+ *   - 'give-up'     -- the retry budget is spent, or the capture failed
+ *                      and we cannot tell whether retry would help.
+ *                      Caller should log a warning and move on.
+ *
+ * Splitting the decision out as pure logic keeps the I/O-bound loop in
+ * src/web/agent-process.ts trivially testable without mocking tmux or
+ * child_process: feed snapshot strings + attempt counters in, assert
+ * the action out.
+ *
+ * @param pane         The most recent capture-pane snapshot, or null
+ *                     if the capture itself failed.
+ * @param payloadHint  Substring of the just-sent prompt, used for the
+ *                     verbatim-stuck detection path. Pass empty to
+ *                     restrict detection to the placeholder path.
+ * @param attempt      How many retry-Enters have ALREADY been sent
+ *                     (0 on the first decision after the initial send).
+ * @param maxAttempts  How many retry-Enters the caller is willing to
+ *                     send total. The decision returns 'give-up' once
+ *                     attempt >= maxAttempts and the pane is still
+ *                     stuck.
+ */
+export function decideSubmitFollowup(
+  pane: string | null,
+  payloadHint: string,
+  attempt: number,
+  maxAttempts: number,
+): SubmitFollowupAction {
+  if (pane == null) return 'give-up'
+  if (!shouldRetrySubmit(pane, payloadHint)) return 'done'
+  if (attempt >= maxAttempts) return 'give-up'
+  return 'retry-enter'
+}

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -5,7 +5,11 @@ import { execSync, execFileSync } from 'node:child_process'
 import { OLLAMA_URL } from '../config.js'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
-import { detectPaneState } from '../pane-state.js'
+import {
+  detectPaneState,
+  decideSubmitFollowup,
+  shouldClearTruncatedPreamble,
+} from '../pane-state.js'
 import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir } from './agent-config.js'
 import { parseTelegramToken } from './telegram.js'
 import { loadProfileTemplate } from './profiles.js'
@@ -214,12 +218,71 @@ function dismissResumeSummaryModalIfPresent(session: string): void {
   }
 }
 
+// How many follow-up Enters sendPromptToSession() is willing to fire
+// when the post-send capture says the prompt is still parked in the
+// input box. Two retries cover the observed stuck-rate (single-pane
+// recovery typically lands on the first or second extra Enter); a
+// stuck-after-two-retries pane gets a logged give-up so the operator
+// can intervene rather than the loop spinning indefinitely.
+const SUBMIT_RETRY_MAX_ATTEMPTS = 2
+// Wait between sending an Enter and re-capturing the pane. Long enough
+// for tmux to flush the keystroke into the Claude Code TUI and for
+// the TUI to either transition to busy (turn started) or stay idle
+// with the parked text (still stuck). Empirically 300ms is past the
+// frame-render gap detectPaneState already guards against.
+const SUBMIT_RETRY_POLL_MS = '0.3'
+
+// Buffer-clear (Ctrl-U) used pre-flight when shouldClearTruncatedPreamble
+// flags a stale preamble. Sent as a single key name (no `-l` literal
+// flag) so tmux interprets it as the control sequence.
+function clearInputBuffer(session: string): void {
+  try {
+    execFileSync(TMUX, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
+    // Settle briefly so the next send-keys lands in the freshly cleared
+    // buffer rather than racing the Ctrl-U.
+    execFileSync('/bin/sleep', ['0.1'], { timeout: 2000 })
+  } catch (err) {
+    logger.warn({ err, session }, 'Failed to clear pane input buffer before send')
+  }
+}
+
 // Send text to a tmux session as if typed at the prompt.
 // Uses execFileSync so callers can pass raw text -- tmux send-keys -l treats
 // the argument as literal characters, bypassing shell quoting entirely.
+//
+// Pre-flight: if the live input box already shows a stale preamble from
+// a previous wrapped message that never fully landed (shouldClearTrun-
+// catedPreamble), Ctrl-U the buffer first so a fresh prompt is not
+// concatenated onto the stale trust-marker. Skipping this guard would
+// let an UNTRUSTED payload sit behind a stale TEAM MEMBER NOTICE
+// preamble and read as if it came from a trusted peer.
+//
+// Post-flight: bracketed-paste detection and frame-level races in the
+// Claude Code TUI occasionally swallow the trailing Enter, leaving the
+// fully written prompt parked in the input box (either as a [Pasted
+// text #N] placeholder or as verbatim text under an idle footer). We
+// re-sample the pane after the initial Enter and, if shouldRetrySubmit
+// still reports stuck, send up to SUBMIT_RETRY_MAX_ATTEMPTS extra
+// Enters. The retry budget bounds the loop so a pathologically stuck
+// pane gives up rather than spinning.
 export function sendPromptToSession(session: string, text: string): void {
   dismissSurveyModalIfPresent(session)
   dismissResumeSummaryModalIfPresent(session)
+
+  // Pre-flight buffer-clear when a stale preamble is detected. Reading
+  // the pane is best-effort: a capture failure here means we cannot
+  // prove the buffer is clean, but proceeding without the clear is no
+  // worse than the pre-fix status quo.
+  try {
+    const preCapture = execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
+    if (shouldClearTruncatedPreamble(preCapture)) {
+      logger.info({ session }, 'Cleared stale preamble from input buffer before sending prompt')
+      clearInputBuffer(session)
+    }
+  } catch (err) {
+    logger.warn({ err, session }, 'Pre-send capture-pane failed; skipping truncated-preamble check')
+  }
+
   const oneLine = text.replace(/\r?\n/g, ' ')
   const CHUNK = 80
   // tmux send-keys doesn't support `--` option-terminator, so a chunk that
@@ -243,6 +306,29 @@ export function sendPromptToSession(session: string, text: string): void {
     if (i < oneLine.length) execFileSync('/bin/sleep', ['0.03'], { timeout: 1000 })
   }
   execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+
+  // Post-send retry loop. The payload hint is the first chunk of oneLine
+  // (truncated to a safe length) so the verbatim-stuck path has something
+  // recognisable to substring-match against without leaking the whole
+  // prompt body into log lines should the give-up branch fire.
+  const payloadHint = oneLine.slice(0, Math.min(oneLine.length, 96))
+  for (let attempt = 0; ; attempt++) {
+    try { execFileSync('/bin/sleep', [SUBMIT_RETRY_POLL_MS], { timeout: 2000 }) } catch { /* best effort */ }
+    const pane = capturePane(session)
+    const action = decideSubmitFollowup(pane, payloadHint, attempt, SUBMIT_RETRY_MAX_ATTEMPTS)
+    if (action === 'done') break
+    if (action === 'give-up') {
+      logger.warn({ session, attempt }, 'sendPromptToSession: prompt still parked after retries')
+      break
+    }
+    // action === 'retry-enter'
+    try {
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+    } catch (err) {
+      logger.warn({ err, session, attempt }, 'Retry-Enter send failed')
+      break
+    }
+  }
 }
 
 // How long to wait between the two capture samples when the first one


### PR DESCRIPTION
## Why this matters

PR #93 added two pure-logic detectors for stuck `tmux send-keys`
states (placeholder / verbatim parked input, and stale trust-marker
preamble). This PR wires them into `sendPromptToSession` so router
and scheduler prompts actually survive the two failure modes in
production.

Without the wire-up: the detectors live but nothing calls them, and
the observed 60% stuck-rate on byte-identical broadcast payloads
keeps eating inter-agent deliveries.

With the wire-up: a stale preamble gets `Ctrl-U` cleared before the
new send, and a parked-after-Enter buffer gets up to two follow-up
Enters with `shouldRetrySubmit()` gating each one. The retry budget
is bounded so a pathologically stuck pane gives up cleanly rather
than spinning.

## Change

Stacked on **#93**. Targets `main`, but the diff includes the
helpers from #93 -- merging this PR will not introduce them twice
if #93 lands first (GitHub auto-rebases stacked branches).

`src/pane-state.ts`:
- New pure helper `decideSubmitFollowup(pane, payloadHint, attempt, maxAttempts)`
  returning `'retry-enter' | 'done' | 'give-up'`. Keeps the loop in
  `agent-process.ts` testable without mocking tmux: snapshots and
  attempt counters in, action out.

`src/web/agent-process.ts`:
- `sendPromptToSession()` now does a pre-flight `capture-pane` plus
  `shouldClearTruncatedPreamble()` check. On a positive, it sends
  `Ctrl-U` to clear the input buffer, waits 100ms, then chunks the
  new prompt as before.
- After the trailing Enter, a post-send poll loop hands each new
  snapshot to `decideSubmitFollowup()`. Up to `SUBMIT_RETRY_MAX_ATTEMPTS`
  (= 2) extra Enters are sent with a 300ms gap. The loop terminates
  on `'done'`, on `'give-up'` (logged as a warn), or on any send-keys
  exception (also logged).
- New internal `clearInputBuffer(session)` helper isolates the
  `Ctrl-U` send-keys call so the pre-flight stays readable.
- The public signature `(session: string, text: string): void` is
  unchanged.

`src/__tests__/pane-state.test.ts`:
- 5 new test cases for `decideSubmitFollowup`: null pane (give-up),
  not-stuck pane (done), stuck pane under cap (retry-enter), stuck
  pane at cap (give-up), `maxAttempts=0` (give-up on first stuck).

## Scope / compatibility

No call-site changes. `src/web/message-router.ts` and
`src/web/schedule-runner.ts` keep working unmodified -- their
existing calls to `sendPromptToSession` now transparently gain the
pre-flight guard and the retry-Enter.

A small overlap exists: `schedule-runner.ts` already has its own
post-send re-submit loop (longer 2s initial wait + 5 retries). The
new internal loop completes within ~1 second; the scheduler loop
starts at +2 seconds, so they sequence rather than race. Collapsing
the two would be a follow-up refactor.

## Test plan

- `npm run typecheck` -- zero errors
- `npx vitest run --dir src` -- 367 / 367 passing
  - Existing 358 tests unchanged
  - 9 new tests across `decideSubmitFollowup` (5) and the
    `shouldRetrySubmit` / `shouldClearTruncatedPreamble` paths
    extended in PR #93 (already accounted for there)

Manual smoke: not included in this PR. The intended verification
is to broadcast a 600+ byte payload to several sub-agents and
confirm the stuck-rate drops from the observed 60% baseline.

## Known limitations

If `capture-pane` itself times out during the pre-flight, the
truncated-preamble check is skipped and the prompt is sent
unconditionally. This matches the prior behaviour (no guard at
all) and only fails open on the additional protection -- it does
not introduce a regression. A future hardening could fall back to
an unconditional `Ctrl-U` on capture failure, but that has its own
side-effect risk (clearing operator-typed text) and is left out of
scope here.