### PR TITLE
kanban: add project column migration + schema entry

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -136,6 +136,7 @@ export function initDatabase(): void {
       status TEXT NOT NULL DEFAULT 'planned' CHECK(status IN ('planned','in_progress','waiting','done')),
       assignee TEXT,
       priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low','normal','high','urgent')),
+      project TEXT,
       due_date INTEGER,
       sort_order REAL NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL,
@@ -143,6 +144,16 @@ export function initDatabase(): void {
       archived_at INTEGER
     )
   `)
+  // Migration: add project column to kanban_cards for installs created
+  // before #89 (whose CREATE TABLE IF NOT EXISTS ran without `project`
+  // and is a no-op on the next boot). Without this, createKanbanCard
+  // and updateKanbanCard fail with `table kanban_cards has no column
+  // named project` and no card can be saved.
+  try {
+    db.exec('ALTER TABLE kanban_cards ADD COLUMN project TEXT')
+  } catch {
+    // column already exists
+  }
   // Migration: add agent_id, category, auto_generated columns to memories
   try {
     db.exec("ALTER TABLE memories ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'marveen'")


### PR DESCRIPTION
Closes #95.

## Why this matters

PR #89 wired the `project` field into the kanban code paths but
neither updated the `CREATE TABLE IF NOT EXISTS kanban_cards` SQL
nor added an `ALTER TABLE` migration. Card creation now fails on
every install:

- Existing installs keep the pre-#89 schema (IF NOT EXISTS is a
  no-op on subsequent boots), so writes fail with
  `table kanban_cards has no column named project`.
- Fresh installs run the same incomplete CREATE TABLE, so the
  column is missing there too.

Reproduced on both paths with a minimal SQL harness; details and
reproduction commands are in #95.

## Change

In `src/db.ts`, two small additions:

1. `project TEXT` in the `CREATE TABLE IF NOT EXISTS kanban_cards`
   column list, placed right after `priority` to mirror the
   ordering in `KanbanCard` and `createKanbanCard`.
2. An idempotent `ALTER TABLE kanban_cards ADD COLUMN project TEXT`
   migration alongside the existing memories-column migrations
   (try/catch with "column already exists" fall-through).

## Scope / compatibility

11 line diff, single file. Backwards-compatible:

- Pre-#89 installs gain the column on the next boot via the
  migration.
- Post-#89 installs that somehow already added the column
  manually still pass (the ALTER fails, catch swallows the
  "duplicate column name" error).
- No data is touched -- the new column defaults to NULL.

## Test plan

- `npm run typecheck` -- zero errors
- `npx vitest run --dir src` -- 337 / 337 passing
- Manual SQL repro: with the fix applied, the post-#89 INSERT
  succeeds on both a fresh in-memory DB and a pre-existing dev DB
  upgraded from the pre-#89 schema. `SELECT project FROM
  kanban_cards` returns the value that was inserted.