### PR TITLE
feat(update): auto-sync hooks via update.sh

### DIFF
--- a/scripts/hooks/telegram-image-resize.sh
+++ b/scripts/hooks/telegram-image-resize.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# PreToolUse hook: auto-resize Telegram-fogadott nagy képeket a Read tool előtt
+# Védelem: ha egy >500KB Telegram-fogadott kép kerülne a Marveen session-be, a
+# base64-encoded representation megtelítheti a context window-t és /compact-ot
+# kényszerítene. Helyette ez a hook:
+#   1. Az eredetit átmenti `inbox/original/<filename>` alá (ha még nem ott van)
+#   2. Az inbox-beli path-ra resize-ol max 1024x1024-re (sips macOS native)
+#   3. additionalContext-en át értesíti az ágenst az eredeti pathról, hogy ha
+#      részletes elemzés kell (OCR, részletek olvasása, edit-pre-process),
+#      tudatosan tudjon az eredetihez nyúlni.
+#
+# Hatás: minden Marveen-szerű ágens automatikusan védve van az óriás-image-
+# context-megtelítéstől, DE ha kell a full-res original, megtalálja az
+# `inbox/original/`-ban.
+#
+# Trigger: PreToolUse hook a Read tool-ra. Csak akkor reagál ha:
+#   - tool_name == "Read"
+#   - file_path egy /channels/telegram/inbox/X.{jpg|jpeg|png|gif|webp} (de NEM
+#     /inbox/original/X — ott az eredeti, hagyjuk békén)
+#   - file_size > 500KB
+
+set -u
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Csak Read tool-ra reagáljunk
+[ "$TOOL_NAME" = "Read" ] || exit 0
+
+# Ha a path már a `original/` subfolder-be mutat, hagyjuk békén — az ágens
+# explicit kért teljes felbontást.
+case "$FILE_PATH" in
+  */channels/telegram/inbox/original/*) exit 0 ;;
+esac
+
+# Csak Telegram inbox-ban lévő képekre (top-level)
+case "$FILE_PATH" in
+  */channels/telegram/inbox/*.jpg|*/channels/telegram/inbox/*.jpeg|\
+  */channels/telegram/inbox/*.png|*/channels/telegram/inbox/*.gif|\
+  */channels/telegram/inbox/*.webp) ;;
+  *) exit 0 ;;
+esac
+
+# File léteznie kell
+[ -f "$FILE_PATH" ] || exit 0
+
+# Méret-check: csak ha >500KB
+SIZE=$(stat -f%z "$FILE_PATH" 2>/dev/null || stat -c%s "$FILE_PATH" 2>/dev/null || echo 0)
+if [ "$SIZE" -le 524288 ]; then
+  exit 0
+fi
+
+# Original mentés a /original/ subfolder-be (ha még nincs ott)
+INBOX_DIR=$(dirname "$FILE_PATH")
+ORIG_DIR="$INBOX_DIR/original"
+mkdir -p "$ORIG_DIR" 2>/dev/null
+ORIG_PATH="$ORIG_DIR/$(basename "$FILE_PATH")"
+if [ ! -f "$ORIG_PATH" ]; then
+  cp "$FILE_PATH" "$ORIG_PATH" 2>/dev/null || true
+fi
+
+# Resize sips-pal max 1024x1024 (a nagyobb oldal lesz 1024, arány marad)
+sips -Z 1024 "$FILE_PATH" >/dev/null 2>&1 || true
+
+NEW_SIZE=$(stat -f%z "$FILE_PATH" 2>/dev/null || stat -c%s "$FILE_PATH" 2>/dev/null || echo 0)
+
+# Stderr log a Marveen-pane-be (debug)
+echo "[telegram-image-resize] $FILE_PATH: ${SIZE}B → ${NEW_SIZE}B; original kept at $ORIG_PATH" >&2
+
+# additionalContext: tájékoztatja a Claude-ot hogy van full-res original is
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "additionalContext": "Note: this Telegram-received image was auto-resized to max 1024x1024 to protect the context window (was ${SIZE}B, now ${NEW_SIZE}B). The full-resolution original is preserved at: $ORIG_PATH — Read that path if you need detailed analysis (OCR, fine detail inspection, image editing pre-process)."
+  }
+}
+EOF
+
+exit 0

--- a/scripts/install-telegram-image-hook.sh
+++ b/scripts/install-telegram-image-hook.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Telepíti a Telegram-image-resize PreToolUse hook-ot a ~/.claude/-be.
+# Védelem a nagy Telegram-fogadott képek context-megtelítése ellen.
+#
+# Mit csinál:
+#   1. Bemásolja a hook-ot ~/.claude/hooks/telegram-image-resize.sh-ra
+#   2. Beépíti a hook-bejegyzést a ~/.claude/settings.json hooks.PreToolUse-jébe
+#      (idempotens — ha már ott van, nem duplikálja)
+#
+# Használat:
+#   bash ~/ClaudeClaw/scripts/install-telegram-image-hook.sh
+
+set -euo pipefail
+
+REPO_HOOK="$(cd "$(dirname "$0")" && pwd)/hooks/telegram-image-resize.sh"
+DEST_HOOK="$HOME/.claude/hooks/telegram-image-resize.sh"
+SETTINGS="$HOME/.claude/settings.json"
+
+if [ ! -f "$REPO_HOOK" ]; then
+  echo "❌ Source hook not found at $REPO_HOOK" >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/.claude/hooks"
+cp "$REPO_HOOK" "$DEST_HOOK"
+chmod +x "$DEST_HOOK"
+echo "✓ Hook installed: $DEST_HOOK"
+
+if [ ! -f "$SETTINGS" ]; then
+  # Bootstrap minimal settings.json
+  echo '{"hooks":{"PreCompact":[],"PreToolUse":[],"PostToolUse":[]}}' > "$SETTINGS"
+fi
+
+# Patch settings.json idempotently via Python (handles JSON parse + dedup)
+python3 - "$SETTINGS" "$DEST_HOOK" <<'PYEOF'
+import json, sys
+
+settings_path, hook_path = sys.argv[1], sys.argv[2]
+with open(settings_path) as f:
+    cfg = json.load(f)
+
+hooks = cfg.setdefault('hooks', {})
+pre = hooks.setdefault('PreToolUse', [])
+
+# Already installed?
+for matcher in pre:
+    if matcher.get('matcher') != 'Read':
+        continue
+    for h in matcher.get('hooks', []):
+        if h.get('command') == hook_path:
+            print(f"⊙ Already in settings.json — skipping")
+            sys.exit(0)
+
+# Insert
+read_matcher = None
+for matcher in pre:
+    if matcher.get('matcher') == 'Read':
+        read_matcher = matcher
+        break
+
+if read_matcher is None:
+    read_matcher = {'matcher': 'Read', 'hooks': []}
+    pre.append(read_matcher)
+
+read_matcher['hooks'].append({
+    'type': 'command',
+    'command': hook_path,
+    'timeout': 15,
+})
+
+with open(settings_path, 'w') as f:
+    json.dump(cfg, f, indent=2, ensure_ascii=False)
+print(f"✓ Added PreToolUse hook for Read tool in {settings_path}")
+PYEOF
+
+echo ""
+echo "✅ Done. New Marveen sessions will auto-resize Telegram-received images >500KB."
+echo "   Originals preserved at ~/.claude/channels/telegram/inbox/original/<filename>"

--- a/scripts/sync-hooks.sh
+++ b/scripts/sync-hooks.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Master hook-szinkronizáló script. Minden install-*-hook.sh-t lefuttat a
+# scripts/ mappából. Az update.sh-ből hívva auto-deploy-olja az aktuális
+# hook-csomagot minden Béla-szerű Marveen-rendszerre a dashboard
+# Frissítés gomb-jával.
+#
+# Pattern: a scripts/install-*-hook.sh egyenkénti shell-szkriptek
+# idempotensek és exit 0-val térnek vissza akkor is ha már telepítve van.
+# Új hook-féle védelmet hozzáadni: csinálj egy install-XXX-hook.sh-t és
+# commit-old; a következő update auto-futtatja.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Glob — ha nincs match, hagyjuk (shopt nullglob bash 4+ kell, de set -u
+# kontextusban óvatosan; egyszerűbb: explicit for-loop test-tel).
+for installer in "$SCRIPT_DIR"/install-*-hook.sh; do
+  [ -e "$installer" ] || continue
+  echo "→ $(basename "$installer")"
+  bash "$installer" || echo "  ⚠ $(basename "$installer") nem-nulla exit kóddal lépett ki (folytatjuk)"
+done
+
+echo "✓ Hook szinkronizálás kész."

--- a/update.sh
+++ b/update.sh
@@ -186,6 +186,14 @@ fi
 echo -e "  Forditas..."
 npm run build --silent
 
+# Hook-ok szinkronizálása (~/.claude/hooks/ + ~/.claude/settings.json).
+# Minden scripts/install-*-hook.sh idempotens. Új hook-féle védelmet
+# committelve a következő update auto-deploy-olja minden installáción.
+if [ -x "$INSTALL_DIR/scripts/sync-hooks.sh" ]; then
+  echo -e "  Hook-ok szinkronizalasa..."
+  bash "$INSTALL_DIR/scripts/sync-hooks.sh" || echo -e "  FIGYELEM: sync-hooks.sh nem-nulla exit; manualisan ellenorizd."
+fi
+
 # Scrub any polluted TELEGRAM_BOT_TOKEN from the tmux server's global env
 # (legacy installs picked this up via `set -a && source .env` in the old
 # channels.sh). Leaving it there made every sub-agent poll the main bot


### PR DESCRIPTION
## Summary

The dashboard "Frissítés" button → `update.sh` now auto-runs `scripts/sync-hooks.sh` after the build, which runs every `scripts/install-*-hook.sh` (idempotent installers).

## Why

Without this, hook installers (like the new `install-telegram-image-hook.sh` from PR #97) require manual `bash scripts/install-XXX-hook.sh` runs on every Marveen install (Szabi, Béla, future users). Easy to forget — and Béla's incident today shows what happens when protection is missing.

## What changed

- `scripts/sync-hooks.sh` — master orchestrator. Loops over `install-*-hook.sh` glob, runs each, continues on non-zero exit
- `update.sh` — adds `sync-hooks.sh` call after `npm run build` (line ~187). Idempotent — safe to re-run

## Pattern for future hooks

To add a new hook protection:
1. `scripts/hooks/your-hook.sh` — the hook script itself
2. `scripts/install-your-hook.sh` — idempotent installer (copies hook + patches settings.json)
3. Commit. The next dashboard update auto-deploys it everywhere.

## Test plan

- [x] `sync-hooks.sh` runs idempotently (verified — `Already in settings.json — skipping`)
- [x] update.sh has the new sync step after build, before service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)