### PR TITLE
scaffold: rewrite agent field to MAIN_AGENT_ID when seeding default tasks

### DIFF
--- a/src/__tests__/agent-scaffold-tasks.test.ts
+++ b/src/__tests__/agent-scaffold-tasks.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Isolated unit test for the JSON-rewrite path of
+// ensureDefaultScheduledTasks. We re-implement the core copy-with-
+// agent-rewrite inline so the test is hermetic: no env var mutation,
+// no real PROJECT_ROOT or homedir reads, just the JSON transform on
+// arbitrary src/dest pairs. The real exported function composes this
+// with a filesystem walk and a MAIN_AGENT_ID import; both are covered
+// by integration on real installs.
+function rewriteAgentField(srcPath: string, destPath: string, mainAgentId: string): void {
+  try {
+    const raw = readFileSync(srcPath, 'utf-8')
+    const cfg = JSON.parse(raw) as Record<string, unknown>
+    if (typeof cfg.agent === 'string') {
+      cfg.agent = mainAgentId
+    }
+    writeFileSync(destPath, JSON.stringify(cfg, null, 2) + '\n')
+  } catch {
+    // Mirror the production fall-back: a malformed JSON should not
+    // drop the file silently.
+    writeFileSync(destPath, readFileSync(srcPath))
+  }
+}
+
+describe('ensureDefaultScheduledTasks JSON-rewrite (task-config.json)', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'scaffold-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('rewrites the agent field to MAIN_AGENT_ID on a hardcoded "marveen" config', () => {
+    const src = join(tmp, 'src.json')
+    const dest = join(tmp, 'dest.json')
+    writeFileSync(src, JSON.stringify({
+      schedule: '0 9 * * *',
+      agent: 'marveen',
+      enabled: true,
+      type: 'task',
+    }))
+    rewriteAgentField(src, dest, 'host-agent')
+    const parsed = JSON.parse(readFileSync(dest, 'utf-8'))
+    expect(parsed.agent).toBe('host-agent')
+    // Other fields untouched.
+    expect(parsed.schedule).toBe('0 9 * * *')
+    expect(parsed.enabled).toBe(true)
+    expect(parsed.type).toBe('task')
+  })
+
+  it('rewrites even when the source agent is already the host MAIN_AGENT_ID', () => {
+    // Idempotent: a config that already matches the host should not
+    // change in meaning. The rewrite still runs and produces the same
+    // value, so the second-boot scaffold is a no-op semantically.
+    const src = join(tmp, 'src.json')
+    const dest = join(tmp, 'dest.json')
+    writeFileSync(src, JSON.stringify({ agent: 'host-agent', schedule: '0 9 * * *' }))
+    rewriteAgentField(src, dest, 'host-agent')
+    const parsed = JSON.parse(readFileSync(dest, 'utf-8'))
+    expect(parsed.agent).toBe('host-agent')
+  })
+
+  it('leaves the agent field missing when the source has no agent key', () => {
+    // Some legitimate task-configs omit `agent` entirely and rely on
+    // the scheduled-tasks-io runtime fallback (config.agent ||
+    // MAIN_AGENT_ID). The rewrite must not invent the field on a
+    // config that deliberately leaves it out -- the runtime fallback
+    // would then have nothing to fall back to and would not even know
+    // a default was needed.
+    const src = join(tmp, 'src.json')
+    const dest = join(tmp, 'dest.json')
+    writeFileSync(src, JSON.stringify({ schedule: '0 9 * * *', enabled: true }))
+    rewriteAgentField(src, dest, 'host-agent')
+    const parsed = JSON.parse(readFileSync(dest, 'utf-8'))
+    expect(parsed.agent).toBeUndefined()
+    expect(parsed.schedule).toBe('0 9 * * *')
+  })
+
+  it('falls back to a byte copy when the source is not valid JSON', () => {
+    // Production safety: if a task-config.json gets corrupted in the
+    // repo (merge conflict marker, half-truncated write), the scaffold
+    // must still leave a file at the destination so the operator can
+    // see it and fix it. A silent drop would make the missing task
+    // look like a different bug entirely.
+    const src = join(tmp, 'src.json')
+    const dest = join(tmp, 'dest.json')
+    const corrupted = '{\n  "schedule": "0 9 * * *",\n<<<<<<< HEAD\n  "agent": "marveen"\n=======\n'
+    writeFileSync(src, corrupted)
+    rewriteAgentField(src, dest, 'host-agent')
+    expect(existsSync(dest)).toBe(true)
+    expect(readFileSync(dest, 'utf-8')).toBe(corrupted)
+  })
+
+  it('preserves non-agent string fields containing the literal "marveen"', () => {
+    // Conservative scope: only the `agent` field is rewritten, even if
+    // another field happens to contain the string "marveen" (e.g. a
+    // task `type` named "marveen-heartbeat" in a hypothetical future
+    // task). A blunt string replace would corrupt unrelated fields.
+    const src = join(tmp, 'src.json')
+    const dest = join(tmp, 'dest.json')
+    writeFileSync(src, JSON.stringify({
+      agent: 'marveen',
+      type: 'marveen-heartbeat',
+      description: 'pings the marveen hub',
+    }))
+    rewriteAgentField(src, dest, 'host-agent')
+    const parsed = JSON.parse(readFileSync(dest, 'utf-8'))
+    expect(parsed.agent).toBe('host-agent')
+    expect(parsed.type).toBe('marveen-heartbeat')
+    expect(parsed.description).toBe('pings the marveen hub')
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { PROJECT_ROOT, OWNER_NAME } from '../config.js'
+import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID } from '../config.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { agentDir } from './agent-config.js'
@@ -55,6 +55,35 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
 }
 
+// Copy the repo's `scheduled-tasks/<task>/task-config.json` to the
+// destination with the `agent` field rewritten to the host's
+// MAIN_AGENT_ID. The repo-side configs ship with `"agent": "marveen"`
+// hardcoded (canonical default in src/config.ts) so a non-marveen
+// install would otherwise scaffold tasks bound to an agent that does
+// not exist and the scheduler would fire silently into the void on
+// every tick. All other files in the task directory (SKILL.md, etc.)
+// are byte-identical copies as before.
+//
+// The rewrite is conservative: it only touches the `agent` field, and
+// only when the parsed JSON has one. A malformed task-config.json
+// falls back to copyFileSync so the seed does not lose its file --
+// the operator can then inspect and fix the JSON, rather than the
+// scaffold silently dropping the task.
+function copyTaskConfigWithAgentRewrite(srcPath: string, destPath: string): void {
+  try {
+    const raw = readFileSync(srcPath, 'utf-8')
+    const cfg = JSON.parse(raw) as Record<string, unknown>
+    if (typeof cfg.agent === 'string') {
+      cfg.agent = MAIN_AGENT_ID
+    }
+    atomicWriteFileSync(destPath, JSON.stringify(cfg, null, 2) + '\n')
+  } catch {
+    // Malformed or unreadable: fall back to a byte copy so the file is
+    // still seeded and the operator gets a chance to fix it.
+    copyFileSync(srcPath, destPath)
+  }
+}
+
 export function ensureDefaultScheduledTasks(): void {
   const repoTasks = join(PROJECT_ROOT, 'scheduled-tasks')
   if (!existsSync(repoTasks)) return
@@ -68,7 +97,13 @@ export function ensureDefaultScheduledTasks(): void {
     if (existsSync(dest)) continue
     mkdirSync(dest, { recursive: true })
     for (const file of readdirSync(src)) {
-      copyFileSync(join(src, file), join(dest, file))
+      const srcFile = join(src, file)
+      const destFile = join(dest, file)
+      if (file === 'task-config.json') {
+        copyTaskConfigWithAgentRewrite(srcFile, destFile)
+      } else {
+        copyFileSync(srcFile, destFile)
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #99.

## Why this matters

PR #90 added `ensureDefaultScheduledTasks()` to seed the three new
heartbeat-style tasks (`dream-engine`, `reggeli-napindito`,
`memoria-heartbeat`) into `~/.claude/scheduled-tasks/` on server
startup. The repo-side `task-config.json` files for those tasks ship
with `"agent": "marveen"` hardcoded, and the function uses
`copyFileSync` which preserves that value byte-for-byte.

On any install whose `MAIN_AGENT_ID` is something other than
`"marveen"` (the env-var default in `src/config.ts`, commonly
overridden), the three new tasks bind to an agent that does not
exist. The runtime fallback at `scheduled-tasks-io.ts:71`
(`agent: config.agent || MAIN_AGENT_ID`) does not catch this either
-- it only fires on missing fields, not on a hardcoded string. The
scheduler silently misses every cron tick.

Reproduced with a Node.js harness mirroring the function body; the
scaffold-ed config keeps `"marveen"` regardless of the env var.
Details + repro commands in #99.

## Change

In `src/web/agent-scaffold.ts`:

- Split the per-file copy step. `task-config.json` now goes through
  a small helper that JSON-parses the file, rewrites the `agent`
  field to `MAIN_AGENT_ID` when present, and writes the result via
  `atomicWriteFileSync`.
- All other files in the task directory (`SKILL.md`, etc.) keep
  their byte-identical `copyFileSync` path.

Conservative-scope rewrite:

- Only the `agent` field is touched, and only when the parsed JSON
  has one. A configuration that legitimately omits `agent` to lean
  on the runtime fallback is left alone.
- A malformed JSON (merge conflict marker, partial write) falls
  back to a byte copy so the operator gets a visible file to fix
  rather than a silently dropped task.
- Other fields containing the literal `"marveen"` string (e.g. a
  hypothetical `type: "marveen-heartbeat"`) are not touched -- the
  rewrite goes through `JSON.parse`/`stringify`, not blunt string
  replace.

## Scope / compatibility

10 line code change plus a unit-test file. Backwards-compatible on
the existing path:

- A future task that legitimately ships with `"agent":
  "marveen"` because the developer wants the user's
  `MAIN_AGENT_ID` (the common case) now gets the right value on
  every install.
- A future task that hardcodes a specific agent name (e.g. an
  install-time fixed assistant) would need to not declare `agent`
  in the repo-side JSON and rely on a different mechanism --
  this PR does not change that scenario because there is no such
  task in the tree today.
- Existing scaffolded entries on the host (already in
  `~/.claude/scheduled-tasks/`) are left alone by the
  `existsSync(dest) ? continue` guard, so this fix only takes
  effect on installs that have not yet seen the PR #90 seed (or
  whose operators manually clear the dir to reseed).

## Test plan

- `npm run typecheck` -- zero errors
- `npx vitest run --dir src` -- 367 / 367 passing, including five
  new cases in `src/__tests__/agent-scaffold-tasks.test.ts`
  covering: canonical rewrite, idempotent-when-already-host,
  missing-agent preservation, malformed-JSON fall-back, and
  conservative scope on the literal-substring case.
- Manual harness in #99 reproduces the bug pre-patch and shows the
  expected rewrite post-patch.