### PR TITLE
feat(agent-process): wire stuck-input + truncated-preamble detectors into sendPromptToSession

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -4,6 +4,7 @@ import {
   isReadyForPrompt,
   shouldRetrySubmit,
   shouldClearTruncatedPreamble,
+  decideSubmitFollowup,
 } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
@@ -734,5 +735,47 @@ describe('shouldRetrySubmit minHintChars clamp', () => {
     // The verbatim path still works for a real-length hint with a
     // negative argument.
     expect(shouldRetrySubmit(STUCK_VERBATIM, PAYLOAD_HINT, { minHintChars: -5 })).toBe(true)
+  })
+})
+
+describe('decideSubmitFollowup', () => {
+  it('returns "give-up" when the pane capture failed', () => {
+    // A null pane means we cannot tell whether the prompt landed; the
+    // safest action is to stop retrying rather than fire a blind
+    // Enter that might submit a different turn's draft.
+    expect(decideSubmitFollowup(null, PAYLOAD_HINT, 0, 2)).toBe('give-up')
+  })
+
+  it('returns "done" when the pane is not stuck', () => {
+    // shouldRetrySubmit-positive panes are the only ones that should
+    // receive a follow-up Enter. A busy pane, a clean idle pane, and
+    // a typing pane without the hint all return "done".
+    expect(decideSubmitFollowup(BUSY_FULL_FOOTER, PAYLOAD_HINT, 0, 2)).toBe('done')
+    expect(decideSubmitFollowup(IDLE_BYPASS, PAYLOAD_HINT, 0, 2)).toBe('done')
+    expect(decideSubmitFollowup(TYPING_PARKED, PAYLOAD_HINT, 0, 2)).toBe('done')
+  })
+
+  it('returns "retry-enter" while attempts are below the cap', () => {
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 0, 2)).toBe('retry-enter')
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 1, 2)).toBe('retry-enter')
+    expect(decideSubmitFollowup(PENDING_PASTE, '', 0, 2)).toBe('retry-enter')
+  })
+
+  it('returns "give-up" once attempts reach the cap', () => {
+    // attempt === maxAttempts means we have already fired maxAttempts
+    // extra Enters and the pane is still stuck. Bail rather than
+    // burning more retries on a pane that refuses to flush.
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 2, 2)).toBe('give-up')
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 5, 2)).toBe('give-up')
+  })
+
+  it('treats maxAttempts === 0 as "give-up on first stuck observation"', () => {
+    // A caller that disabled retry by passing 0 still gets a clean
+    // "give-up" branch (with the warn-log behaviour the loop attaches
+    // to that action) rather than silently retrying.
+    expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 0, 0)).toBe('give-up')
+    // Done-state on a maxAttempts=0 pane still returns done -- there
+    // is nothing to retry.
+    expect(decideSubmitFollowup(IDLE_BYPASS, PAYLOAD_HINT, 0, 0)).toBe('done')
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -340,3 +340,48 @@ export function shouldClearTruncatedPreamble(pane: string): boolean {
 
   return true
 }
+
+export type SubmitFollowupAction = 'retry-enter' | 'done' | 'give-up'
+
+/**
+ * Decide what the post-send-keys loop should do next, given the
+ * current pane snapshot and how many retry-Enter attempts have already
+ * been made. Returns one of three discrete actions so the caller can
+ * branch without re-running the detection logic itself.
+ *
+ *   - 'done'        -- the prompt landed (or the pane is busy
+ *                      processing); no further action.
+ *   - 'retry-enter' -- the pane shows a stuck send; send another Enter
+ *                      and re-sample.
+ *   - 'give-up'     -- the retry budget is spent, or the capture failed
+ *                      and we cannot tell whether retry would help.
+ *                      Caller should log a warning and move on.
+ *
+ * Splitting the decision out as pure logic keeps the I/O-bound loop in
+ * src/web/agent-process.ts trivially testable without mocking tmux or
+ * child_process: feed snapshot strings + attempt counters in, assert
+ * the action out.
+ *
+ * @param pane         The most recent capture-pane snapshot, or null
+ *                     if the capture itself failed.
+ * @param payloadHint  Substring of the just-sent prompt, used for the
+ *                     verbatim-stuck detection path. Pass empty to
+ *                     restrict detection to the placeholder path.
+ * @param attempt      How many retry-Enters have ALREADY been sent
+ *                     (0 on the first decision after the initial send).
+ * @param maxAttempts  How many retry-Enters the caller is willing to
+ *                     send total. The decision returns 'give-up' once
+ *                     attempt >= maxAttempts and the pane is still
+ *                     stuck.
+ */
+export function decideSubmitFollowup(
+  pane: string | null,
+  payloadHint: string,
+  attempt: number,
+  maxAttempts: number,
+): SubmitFollowupAction {
+  if (pane == null) return 'give-up'
+  if (!shouldRetrySubmit(pane, payloadHint)) return 'done'
+  if (attempt >= maxAttempts) return 'give-up'
+  return 'retry-enter'
+}

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -5,7 +5,11 @@ import { execSync, execFileSync } from 'node:child_process'
 import { OLLAMA_URL } from '../config.js'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
-import { detectPaneState } from '../pane-state.js'
+import {
+  detectPaneState,
+  decideSubmitFollowup,
+  shouldClearTruncatedPreamble,
+} from '../pane-state.js'
 import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir } from './agent-config.js'
 import { parseTelegramToken } from './telegram.js'
 import { loadProfileTemplate } from './profiles.js'
@@ -214,12 +218,71 @@ function dismissResumeSummaryModalIfPresent(session: string): void {
   }
 }
 
+// How many follow-up Enters sendPromptToSession() is willing to fire
+// when the post-send capture says the prompt is still parked in the
+// input box. Two retries cover the observed stuck-rate (single-pane
+// recovery typically lands on the first or second extra Enter); a
+// stuck-after-two-retries pane gets a logged give-up so the operator
+// can intervene rather than the loop spinning indefinitely.
+const SUBMIT_RETRY_MAX_ATTEMPTS = 2
+// Wait between sending an Enter and re-capturing the pane. Long enough
+// for tmux to flush the keystroke into the Claude Code TUI and for
+// the TUI to either transition to busy (turn started) or stay idle
+// with the parked text (still stuck). Empirically 300ms is past the
+// frame-render gap detectPaneState already guards against.
+const SUBMIT_RETRY_POLL_MS = '0.3'
+
+// Buffer-clear (Ctrl-U) used pre-flight when shouldClearTruncatedPreamble
+// flags a stale preamble. Sent as a single key name (no `-l` literal
+// flag) so tmux interprets it as the control sequence.
+function clearInputBuffer(session: string): void {
+  try {
+    execFileSync(TMUX, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
+    // Settle briefly so the next send-keys lands in the freshly cleared
+    // buffer rather than racing the Ctrl-U.
+    execFileSync('/bin/sleep', ['0.1'], { timeout: 2000 })
+  } catch (err) {
+    logger.warn({ err, session }, 'Failed to clear pane input buffer before send')
+  }
+}
+
 // Send text to a tmux session as if typed at the prompt.
 // Uses execFileSync so callers can pass raw text -- tmux send-keys -l treats
 // the argument as literal characters, bypassing shell quoting entirely.
+//
+// Pre-flight: if the live input box already shows a stale preamble from
+// a previous wrapped message that never fully landed (shouldClearTrun-
+// catedPreamble), Ctrl-U the buffer first so a fresh prompt is not
+// concatenated onto the stale trust-marker. Skipping this guard would
+// let an UNTRUSTED payload sit behind a stale TEAM MEMBER NOTICE
+// preamble and read as if it came from a trusted peer.
+//
+// Post-flight: bracketed-paste detection and frame-level races in the
+// Claude Code TUI occasionally swallow the trailing Enter, leaving the
+// fully written prompt parked in the input box (either as a [Pasted
+// text #N] placeholder or as verbatim text under an idle footer). We
+// re-sample the pane after the initial Enter and, if shouldRetrySubmit
+// still reports stuck, send up to SUBMIT_RETRY_MAX_ATTEMPTS extra
+// Enters. The retry budget bounds the loop so a pathologically stuck
+// pane gives up rather than spinning.
 export function sendPromptToSession(session: string, text: string): void {
   dismissSurveyModalIfPresent(session)
   dismissResumeSummaryModalIfPresent(session)
+
+  // Pre-flight buffer-clear when a stale preamble is detected. Reading
+  // the pane is best-effort: a capture failure here means we cannot
+  // prove the buffer is clean, but proceeding without the clear is no
+  // worse than the pre-fix status quo.
+  try {
+    const preCapture = execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
+    if (shouldClearTruncatedPreamble(preCapture)) {
+      logger.info({ session }, 'Cleared stale preamble from input buffer before sending prompt')
+      clearInputBuffer(session)
+    }
+  } catch (err) {
+    logger.warn({ err, session }, 'Pre-send capture-pane failed; skipping truncated-preamble check')
+  }
+
   const oneLine = text.replace(/\r?\n/g, ' ')
   const CHUNK = 80
   // tmux send-keys doesn't support `--` option-terminator, so a chunk that
@@ -243,6 +306,29 @@ export function sendPromptToSession(session: string, text: string): void {
     if (i < oneLine.length) execFileSync('/bin/sleep', ['0.03'], { timeout: 1000 })
   }
   execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+
+  // Post-send retry loop. The payload hint is the first chunk of oneLine
+  // (truncated to a safe length) so the verbatim-stuck path has something
+  // recognisable to substring-match against without leaking the whole
+  // prompt body into log lines should the give-up branch fire.
+  const payloadHint = oneLine.slice(0, Math.min(oneLine.length, 96))
+  for (let attempt = 0; ; attempt++) {
+    try { execFileSync('/bin/sleep', [SUBMIT_RETRY_POLL_MS], { timeout: 2000 }) } catch { /* best effort */ }
+    const pane = capturePane(session)
+    const action = decideSubmitFollowup(pane, payloadHint, attempt, SUBMIT_RETRY_MAX_ATTEMPTS)
+    if (action === 'done') break
+    if (action === 'give-up') {
+      logger.warn({ session, attempt }, 'sendPromptToSession: prompt still parked after retries')
+      break
+    }
+    // action === 'retry-enter'
+    try {
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+    } catch (err) {
+      logger.warn({ err, session, attempt }, 'Retry-Enter send failed')
+      break
+    }
+  }
 }
 
 // How long to wait between the two capture samples when the first one


### PR DESCRIPTION
Rebased from #94 (koorbela/marveen fork) after #93 was merged.

## Summary
- Pre-flight: capture-pane + `shouldClearTruncatedPreamble()` check before sending. Ctrl-U clears stale preamble buffer
- Post-flight: up to 2 retry-Enters via `decideSubmitFollowup()` if prompt gets stuck in input box
- Security: prevents UNTRUSTED payload from inheriting stale TEAM MEMBER NOTICE trust semantics
- Pure helper `decideSubmitFollowup` with 5 unit tests
- No call-site changes, existing callers gain protection transparently

Original author: @koorbela + Claude Opus 4.7

Co-Authored-By: koorbela <173781155+koorbela@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>