### PR TITLE
feat(agents): make agent start/stop and scaffold channel-provider-aware

### DIFF
--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -189,6 +189,25 @@ export function readAgentClaudeConfigDir(name: string): string | null {
   return resolveClaudeConfigDir(readFileOr(configPath, '{}'), homedir())
 }
 
+export function readAgentChannelProvider(name: string): string | null {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  try {
+    const config = JSON.parse(readFileOr(configPath, '{}'))
+    if (typeof config.channelProvider === 'string' && config.channelProvider.trim()) {
+      return config.channelProvider.trim()
+    }
+  } catch { /* fall through */ }
+  return null
+}
+
+export function writeAgentChannelProvider(name: string, provider: string): void {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  let config: Record<string, unknown> = {}
+  try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
+  config.channelProvider = provider
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
 export function writeAgentSecurityProfile(name: string, profileId: string): void {
   const configPath = join(agentDir(name), 'agent-config.json')
   let config: Record<string, unknown> = {}

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -10,14 +10,22 @@ import {
   decideSubmitFollowup,
   shouldClearTruncatedPreamble,
 } from '../pane-state.js'
-import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir } from './agent-config.js'
+import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir, readAgentChannelProvider } from './agent-config.js'
 import { parseTelegramToken } from './telegram.js'
+import { getProvider, getProviderType, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
+import { CHANNEL_PROVIDER } from '../config.js'
 import { loadProfileTemplate } from './profiles.js'
 import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
 import { getSecret } from './vault.js'
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
+
+function resolveAgentProvider(name: string): ChannelProviderType {
+  const perAgent = readAgentChannelProvider(name)
+  if (perAgent === 'slack' || perAgent === 'telegram') return perAgent
+  return CHANNEL_PROVIDER
+}
 
 export function agentSessionName(name: string): string {
   return `agent-${name}`
@@ -38,10 +46,18 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
   const dir = agentDir(name)
   if (!existsSync(dir)) return { ok: false, error: 'Agent not found' }
 
-  const token = parseTelegramToken(name)
-  if (!token) return { ok: false, error: 'Telegram not configured for this agent' }
+  const agentProvider = resolveAgentProvider(name)
+  const provider = getProvider(agentProvider)
+  const agentChannelDir = channelStateDir(agentProvider, dir)
+  const token = readChannelToken(agentProvider, join(agentChannelDir, '.env'))
+  // Backward compat: try legacy Telegram token if provider-aware lookup misses
+  if (!token && agentProvider === 'telegram') {
+    const legacyToken = parseTelegramToken(name)
+    if (!legacyToken) return { ok: false, error: 'Channel not configured for this agent' }
+  } else if (!token) {
+    return { ok: false, error: `${provider.type} channel not configured for this agent` }
+  }
 
-  const tgStateDir = join(dir, '.claude', 'channels', 'telegram')
   const session = agentSessionName(name)
 
   try {
@@ -88,14 +104,9 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     const encodedProject = dir.replace(/\//g, '-')
     const hasPriorSession = existsSync(join(projectsRoot, encodedProject))
     const continueFlag = hasPriorSession ? '--continue ' : ''
-    // bun lives under ~/.bun/bin, which isn't in the dashboard's launchd PATH.
-    // The Claude plugin launcher spawns `bun`, so we must prepend it here.
-    // Defensive unset of TELEGRAM_BOT_TOKEN: if anything ever pollutes the
-    // tmux server's global env again (fresh upgrades, operator manually
-    // sourcing .env), the sub-agent would otherwise inherit the main
-    // agent's token and trigger a 409 Conflict loop. The per-agent .env
-    // in TELEGRAM_STATE_DIR is still the intended source of truth.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && unset TELEGRAM_BOT_TOKEN && export TELEGRAM_STATE_DIR="${tgStateDir}" && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:telegram@claude-plugins-official`
+    const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : 'TELEGRAM_STATE_DIR'
+    const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN'
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}" && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }
@@ -140,19 +151,22 @@ export function stopAgentProcess(name: string): { ok: boolean; error?: string } 
   try {
     execSync(`${TMUX} kill-session -t ${session}`, { timeout: 5000 })
     execSync('sleep 2', { timeout: 4000 })
-    // Reap any orphaned bun server.ts (Telegram plugin) grandchildren that
-    // tmux didn't get. The plugin writes its pid to the agent's telegram
-    // state dir; prefer that, fall back to a token-scoped pkill.
+    // Reap any orphaned plugin grandchildren that tmux didn't get.
+    // The plugin writes its pid to the agent's channel state dir;
+    // prefer that, fall back to a env-var-scoped pkill.
     try {
-      const pidPath = join(agentDir(name), '.claude', 'channels', 'telegram', 'bot.pid')
+      const agentProvider = resolveAgentProvider(name)
+      const dir = agentDir(name)
+      const chanDir = channelStateDir(agentProvider, dir)
+      const pidPath = join(chanDir, 'bot.pid')
       if (existsSync(pidPath)) {
         const pid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10)
         if (pid > 1) {
           try { process.kill(pid, 'SIGTERM') } catch { /* already gone */ }
         }
       }
-      const tgStateDir = join(agentDir(name), '.claude', 'channels', 'telegram')
-      execFileSync('/usr/bin/pkill', ['-f', `TELEGRAM_STATE_DIR=${tgStateDir}`], { timeout: 3000 })
+      const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : 'TELEGRAM_STATE_DIR'
+      execFileSync('/usr/bin/pkill', ['-f', `${stateEnvVar}=${chanDir}`], { timeout: 3000 })
     } catch { /* pkill returns non-zero if no match -- fine */ }
     logger.info({ name, session }, 'Agent tmux session stopped')
     return { ok: true }

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,7 +1,8 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID } from '../config.js'
+import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, CHANNEL_PROVIDER } from '../config.js'
+import { channelStateDir } from '../channel-provider.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { agentDir } from './agent-config.js'
@@ -112,7 +113,7 @@ export function scaffoldAgentDir(name: string) {
   const dir = agentDir(name)
   mkdirSync(join(dir, '.claude', 'skills'), { recursive: true })
   mkdirSync(join(dir, '.claude', 'hooks'), { recursive: true })
-  mkdirSync(join(dir, '.claude', 'channels', 'telegram'), { recursive: true })
+  mkdirSync(channelStateDir(CHANNEL_PROVIDER, dir), { recursive: true })
   mkdirSync(join(dir, 'memory'), { recursive: true })
 
   // Initialize empty files if they don't exist
@@ -237,7 +238,7 @@ Minden kontextus-tömörítés előtt (PreCompact hook) automatikusan vizsgáld 
 MINDIG a megfelelő lokális időt használd (Europe/Budapest CEST/CET).
 
 - **Jelenlegi idő**: \`date\` Bash első lépés időponti feladatoknál (heartbeat, naptár-művelet, scheduled-task analízis)
-- **Telegram channel \`ts\`**: UTC-ben jön (postfix \`Z\`), átkonvertálni Europe/Budapest-re (CEST = UTC+2 nyáron, CET = UTC+1 télen)
+- **Channel message \`ts\`**: UTC-ben jön (postfix \`Z\`), átkonvertálni Europe/Budapest-re (CEST = UTC+2 nyáron, CET = UTC+1 télen)
 - **Google Calendar list_events \`dateTime\`**: már lokál ISO 8601 (\`+02:00\` offset Budapestnek), OK
 - **SQLite \`unixepoch()\`**: UTC, humán-megjelenítéshez \`localtime\` modifier kell
 - **Cron expressions** (scheduled-tasks task-config.json): node lokális TZ, Europe/Budapest
@@ -246,7 +247,7 @@ Heartbeat-eknél és minden időpontot kezelő feladatnál kötelező: \`date\` 
 
 ## Új ismeretlen sender első üzenete (ARANYSZABÁLY)
 
-Ha egy senderId üzen Telegramon AKIT EDDIG NEM ISMERSZ — nem szerepel az aktív interakciós kontextusodban, és nem találsz róla memóriabejegyzést a vault-ban — KÖTELEZŐ ELSŐKÉNT inter-agent message-t küldeni Marveennek MIELŐTT érdemi választ adsz.
+Ha egy senderId üzen a csatornán AKIT EDDIG NEM ISMERSZ — nem szerepel az aktív interakciós kontextusodban, és nem találsz róla memóriabejegyzést a vault-ban — KÖTELEZŐ ELSŐKÉNT inter-agent message-t küldeni Marveennek MIELŐTT érdemi választ adsz.
 
 Az AGENT TULAJDONOSA (az első, aki ezt az ügynököt telepítette és párosította) az ALAPÉRTELMEZETT engedélyezett sender — őt nem kell ellenőrizni. MINDEN további senderId első üzenete (a 2., 3., stb. párosított személy vagy csoport) pinging-trigger.
 


### PR DESCRIPTION
## Summary

PR 2/7 of the Slack channel support series (follows #102).

- **agent-config.ts**: Added `readAgentChannelProvider()` / `writeAgentChannelProvider()` for per-agent `channelProvider` field in agent-config.json
- **agent-process.ts**: `resolveAgentProvider()` helper resolves per-agent config -> global `CHANNEL_PROVIDER` -> default `telegram`. `startAgentProcess` now uses the resolved provider for `--channels plugin:<pluginId>`, env vars, and state dir. `stopAgentProcess` cleans up provider-aware pid path and unsets all channel env vars. Legacy `parseTelegramToken` fallback kept for backward compat.
- **agent-scaffold.ts**: `scaffoldAgentDir` creates channel state dir via `channelStateDir()` instead of hardcoded telegram path. CLAUDE.md template references generalized from "Telegram" to "channel".

3 files changed, 56 insertions(+), 22 deletions(-)

## Risk

Medium-high (hot path: agent start/stop). Backward compatible: existing Telegram-only agents unchanged.

## Test plan

- [ ] Build passes (`bun build --no-bundle src/web/agent-process.ts`)
- [ ] Format tests green (`bun test src/format.test.ts`)
- [ ] Start a Telegram agent -- verify `--channels plugin:telegram@claude-plugins-official` in tmux cmd
- [ ] Scaffold a new agent -- verify `.claude/channels/telegram/` dir created
- [ ] Set `channelProvider: "slack"` in agent-config.json -- verify start uses slack plugin ID and env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)