### PR TITLE
feat(api): provider-aware channel routes and invite system

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
-import { startInviteMonitor, stopInviteMonitor } from './web/telegram-invites.js'
+import { startInviteMonitor, stopInviteMonitor } from './web/channel-invites.js'
 import { AGENTS_BASE_DIR } from './web/agent-config.js'
 import {
   acquirePortLock,

--- a/src/web/channel-invites.ts
+++ b/src/web/channel-invites.ts
@@ -1,12 +1,12 @@
-// Telegram invite tokens for one-click pairing.
+// Channel invite tokens for one-click pairing.
 //
 // Flow:
-// 1. Operator generates an invite via POST /api/agents/:name/telegram/invites.
+// 1. Operator generates an invite via POST /api/agents/:name/channels/:provider/invites.
 //    The token + expiry is stored in access.json under `invites`.
 //    If dmPolicy was 'allowlist', it is flipped to 'pairing' so the bot will
 //    actually issue codes for unknown senders during the validity window.
-// 2. The invitee opens the deep-link, Telegram triggers /start, the plugin
-//    creates a pending entry in access.json (standard pairing behaviour).
+// 2. The invitee opens the deep-link (Telegram: t.me/?start=TOKEN, Slack: CLI pair),
+//    the plugin creates a pending entry in access.json (standard pairing behaviour).
 // 3. This monitor (started in src/index.ts) polls access.json files every
 //    few seconds. When it sees a pending entry land while at least one
 //    non-used, non-expired invite token exists for that agent, it
@@ -18,9 +18,9 @@
 // Tokens are 16 random bytes (base64url, ~22 chars), unguessable in practice.
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 import { randomBytes } from 'node:crypto'
 import { logger } from '../logger.js'
+import { channelStateDir, type ChannelProviderType } from '../channel-provider.js'
 import { agentDir } from './agent-config.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 
@@ -28,7 +28,7 @@ interface InviteEntry {
   createdAt: number
   expiresAt: number
   used: boolean
-  usedBy?: string // senderId who consumed it
+  usedBy?: string
   usedAt?: number
 }
 
@@ -40,12 +40,12 @@ interface AccessFile {
   invites?: Record<string, InviteEntry>
 }
 
-const INVITE_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000 // 24h
+const INVITE_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
 
-export function tgChannelDir(name: string, mainAgentId: string): string {
+export function agentChannelDir(name: string, mainAgentId: string, provider: ChannelProviderType): string {
   return name === mainAgentId
-    ? join(homedir(), '.claude', 'channels', 'telegram')
-    : join(agentDir(name), '.claude', 'channels', 'telegram')
+    ? channelStateDir(provider)
+    : channelStateDir(provider, agentDir(name))
 }
 
 function readAccess(path: string): AccessFile {
@@ -91,6 +91,7 @@ export interface CreateInviteResult {
 export function createInvite(
   accessPath: string,
   botUsername: string | undefined,
+  provider: ChannelProviderType = 'telegram',
   ttlMs: number = INVITE_DEFAULT_TTL_MS,
 ): CreateInviteResult {
   const access = readAccess(accessPath)
@@ -106,17 +107,14 @@ export function createInvite(
   access.invites = access.invites || {}
   access.invites[token] = entry
 
-  // While at least one invite is active the bot must accept unknown senders
-  // long enough to issue a pairing code; otherwise the standard plugin gate
-  // drops them silently. The monitor flips the policy back to 'allowlist'
-  // once every invite is either used or expired.
   if (access.dmPolicy !== 'disabled') access.dmPolicy = 'pairing'
 
   writeAccess(accessPath, access)
 
-  const deepLink = botUsername
-    ? `https://t.me/${botUsername}?start=invite-${token}`
-    : undefined
+  let deepLink: string | undefined
+  if (provider === 'telegram' && botUsername) {
+    deepLink = `https://t.me/${botUsername}?start=invite-${token}`
+  }
   return { token, expiresAt: entry.expiresAt, deepLink }
 }
 
@@ -138,7 +136,6 @@ export function revokeInvite(accessPath: string, token: string): boolean {
   const access = readAccess(accessPath)
   if (!access.invites?.[token]) return false
   delete access.invites[token]
-  // If there are no more active invites, lock the policy back down.
   if (activeInviteCount(access, Date.now()) === 0) {
     access.dmPolicy = 'allowlist'
   }
@@ -146,80 +143,68 @@ export function revokeInvite(accessPath: string, token: string): boolean {
   return true
 }
 
-// Iterate every agent's access.json; auto-approve a pending entry when a
-// non-used invite is alive. Idempotent: pending rows are removed once
-// consumed, and tokens flip used=true so the same invite can't approve
-// twice.
 export function runInviteMonitorTick(mainAgentId: string, agentsRoot: string): void {
-  // Build the list of agents to scan: the main agent (global ~/.claude
-  // channel) plus every agents/<name>/.claude/channels/telegram/access.json
-  // that exists on disk.
-  const targets: Array<{ name: string; accessPath: string }> = []
-  const mainAccess = join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
-  if (existsSync(mainAccess)) targets.push({ name: mainAgentId, accessPath: mainAccess })
-  if (existsSync(agentsRoot)) {
-    let entries: string[]
-    try { entries = readdirSync(agentsRoot) } catch { entries = [] }
-    for (const e of entries) {
-      const p = join(agentsRoot, e, '.claude', 'channels', 'telegram', 'access.json')
-      if (existsSync(p)) targets.push({ name: e, accessPath: p })
-    }
-  }
+  const providerTypes: ChannelProviderType[] = ['telegram', 'slack']
 
-  for (const { name, accessPath } of targets) {
-    const access = readAccess(accessPath)
-    if (!access.invites || !access.pending) continue
-
-    const now = Date.now()
-    const expiredOrUsed = pruneInvites(access, now)
-
-    // Find the oldest unused, non-expired invite (FIFO).
-    const live = Object.entries(access.invites)
-      .filter(([, inv]) => !inv.used && inv.expiresAt >= now)
-      .sort((a, b) => a[1].createdAt - b[1].createdAt)
-    if (live.length === 0) {
-      if (expiredOrUsed && activeInviteCount(access, now) === 0 && access.dmPolicy === 'pairing') {
-        access.dmPolicy = 'allowlist'
-        writeAccess(accessPath, access)
+  for (const provider of providerTypes) {
+    const targets: Array<{ name: string; accessPath: string }> = []
+    const mainAccess = join(channelStateDir(provider), 'access.json')
+    if (existsSync(mainAccess)) targets.push({ name: mainAgentId, accessPath: mainAccess })
+    if (existsSync(agentsRoot)) {
+      let entries: string[]
+      try { entries = readdirSync(agentsRoot) } catch { entries = [] }
+      for (const e of entries) {
+        const p = join(channelStateDir(provider, join(agentsRoot, e)), 'access.json')
+        if (existsSync(p)) targets.push({ name: e, accessPath: p })
       }
-      continue
     }
 
-    // Find the oldest pending entry created after the oldest live invite was
-    // issued (FIFO match). createdAt ordering is enough — we don't need to
-    // tie a specific sender to a specific token; any new pending during the
-    // invite window consumes the next available token.
-    const pendingEntries = Object.entries(access.pending)
-      .sort((a, b) => a[1].createdAt - b[1].createdAt)
-    if (pendingEntries.length === 0) continue
+    for (const { name, accessPath } of targets) {
+      const access = readAccess(accessPath)
+      if (!access.invites || !access.pending) continue
 
-    const [pCode, pEntry] = pendingEntries[0]
-    const [tToken, tEntry] = live[0]
+      const now = Date.now()
+      const expiredOrUsed = pruneInvites(access, now)
 
-    // Auto-approve: move sender into allowFrom, drop pending row, mark token used.
-    if (!access.allowFrom) access.allowFrom = []
-    if (!access.allowFrom.includes(pEntry.senderId)) access.allowFrom.push(pEntry.senderId)
-    delete access.pending[pCode]
+      const live = Object.entries(access.invites)
+        .filter(([, inv]) => !inv.used && inv.expiresAt >= now)
+        .sort((a, b) => a[1].createdAt - b[1].createdAt)
+      if (live.length === 0) {
+        if (expiredOrUsed && activeInviteCount(access, now) === 0 && access.dmPolicy === 'pairing') {
+          access.dmPolicy = 'allowlist'
+          writeAccess(accessPath, access)
+        }
+        continue
+      }
 
-    tEntry.used = true
-    tEntry.usedBy = pEntry.senderId
-    tEntry.usedAt = now
+      const pendingEntries = Object.entries(access.pending)
+        .sort((a, b) => a[1].createdAt - b[1].createdAt)
+      if (pendingEntries.length === 0) continue
 
-    // After consuming this invite, if no others remain alive, lock back down.
-    if (activeInviteCount(access, now) === 0) access.dmPolicy = 'allowlist'
+      const [pCode, pEntry] = pendingEntries[0]
+      const [tToken, tEntry] = live[0]
 
-    // Mirror what /telegram/approve does: drop a marker file under approved/
-    // so the plugin can short-circuit subsequent gate checks.
-    try {
-      const approvedDir = join(accessPath, '..', 'approved')
-      mkdirSync(approvedDir, { recursive: true })
-      writeFileSync(join(approvedDir, pEntry.senderId), '')
-    } catch (err) {
-      logger.warn({ err, name, senderId: pEntry.senderId }, 'invite-monitor: failed to write approved marker')
+      if (!access.allowFrom) access.allowFrom = []
+      if (!access.allowFrom.includes(pEntry.senderId)) access.allowFrom.push(pEntry.senderId)
+      delete access.pending[pCode]
+
+      tEntry.used = true
+      tEntry.usedBy = pEntry.senderId
+      tEntry.usedAt = now
+
+      if (activeInviteCount(access, now) === 0) access.dmPolicy = 'allowlist'
+
+      try {
+        const approvedDir = join(accessPath, '..', 'approved')
+        mkdirSync(approvedDir, { recursive: true })
+        writeFileSync(join(approvedDir, pEntry.senderId), '')
+      } catch (err) {
+        logger.warn({ err, name, senderId: pEntry.senderId }, 'invite-monitor: failed to write approved marker')
+      }
+
+      writeAccess(accessPath, access)
+      logger.info({ name, provider, senderId: pEntry.senderId, token: tToken }, 'Channel invite auto-approved')
     }
-
-    writeAccess(accessPath, access)
-    logger.info({ name, senderId: pEntry.senderId, token: tToken }, 'Telegram invite auto-approved')
   }
 }
 
@@ -227,8 +212,6 @@ let inviteMonitorInterval: NodeJS.Timeout | null = null
 
 export function startInviteMonitor(mainAgentId: string, agentsRoot: string, intervalMs = 3000): void {
   if (inviteMonitorInterval) return
-  // First tick immediately so a freshly-created invite + pending pair is
-  // resolved without waiting a full interval.
   try { runInviteMonitorTick(mainAgentId, agentsRoot) } catch (err) {
     logger.error({ err }, 'invite-monitor first tick failed')
   }
@@ -239,7 +222,7 @@ export function startInviteMonitor(mainAgentId: string, agentsRoot: string, inte
       logger.error({ err }, 'invite-monitor tick failed')
     }
   }, intervalMs)
-  logger.info({ intervalMs }, 'Telegram invite monitor elindult')
+  logger.info({ intervalMs }, 'Channel invite monitor started')
 }
 
 export function stopInviteMonitor(): void {

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -23,6 +23,7 @@ import {
   writeAgentSecurityProfile,
   listAgentNames,
   isKnownAgent,
+  readAgentChannelProvider,
 } from '../agent-config.js'
 import {
   readAgentTeam,
@@ -43,7 +44,14 @@ import {
   createInvite,
   listInvites,
   revokeInvite,
-} from '../telegram-invites.js'
+  agentChannelDir,
+} from '../channel-invites.js'
+import {
+  getProvider,
+  channelStateDir,
+  readChannelToken,
+  type ChannelProviderType,
+} from '../../channel-provider.js'
 import {
   writeAgentSettingsFromProfile,
   scaffoldAgentDir,
@@ -64,6 +72,35 @@ import { sanitizeAgentName } from '../sanitize.js'
 import { parseMultipart } from '../multipart.js'
 import { readBody, json, serveFile } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
+
+const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack'])
+
+function parseChannelProvider(raw: string): ChannelProviderType | null {
+  if (VALID_PROVIDERS.has(raw as ChannelProviderType)) return raw as ChannelProviderType
+  return null
+}
+
+// Match both new /channels/:provider/ and legacy /telegram/ URL patterns.
+// Returns [agentName, provider] or null. Legacy routes always resolve to 'telegram'.
+function matchChannelRoute(path: string, suffix: string): [string, ChannelProviderType] | null {
+  const newPattern = new RegExp(`^/api/agents/([^/]+)/channels/(telegram|slack)${suffix}$`)
+  const newMatch = path.match(newPattern)
+  if (newMatch) {
+    const provider = parseChannelProvider(newMatch[2])
+    if (provider) return [decodeURIComponent(newMatch[1]), provider]
+  }
+  const legacyPattern = new RegExp(`^/api/agents/([^/]+)/telegram${suffix}$`)
+  const legacyMatch = path.match(legacyPattern)
+  if (legacyMatch) return [decodeURIComponent(legacyMatch[1]), 'telegram']
+  return null
+}
+
+function resolveAccessPath(name: string, provider: ChannelProviderType): string {
+  const dir = name === MAIN_AGENT_ID
+    ? channelStateDir(provider)
+    : channelStateDir(provider, agentDir(name))
+  return join(dir, 'access.json')
+}
 
 interface AgentSummary {
   name: string
@@ -277,44 +314,49 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     return true
   }
 
-  const tgTestMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/test$/)
-  if (tgTestMatch && method === 'POST') {
-    const name = decodeURIComponent(tgTestMatch[1])
+  // POST /api/agents/:name/channels/:provider/test (legacy: /telegram/test)
+  const testMatch = matchChannelRoute(path, '/test')
+  if (testMatch && method === 'POST') {
+    const [name, provider] = testMatch
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
-    const token = parseTelegramToken(name)
-    if (!token) { json(res, { error: 'Telegram not configured for this agent' }, 404); return true }
-    const result = await validateTelegramToken(token)
-    if (result.ok) { json(res, { ok: true, botUsername: result.botUsername, botId: result.botId }); return true }
+    const stateDir = channelStateDir(provider, agentDir(name))
+    const envPath = join(stateDir, '.env')
+    const token = readChannelToken(provider, envPath) || (provider === 'telegram' ? parseTelegramToken(name) : null)
+    if (!token) { json(res, { error: `${provider} not configured for this agent` }, 404); return true }
+    const channelProvider = getProvider(provider)
+    const result = await channelProvider.validateToken(token)
+    if (result.ok) { json(res, { ok: true, botName: result.botName }); return true }
     json(res, { error: result.error }, 400)
     return true
   }
 
-  const tgSetupMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram$/)
-  if (tgSetupMatch && method === 'POST') {
-    const name = decodeURIComponent(tgSetupMatch[1])
+  // POST /api/agents/:name/channels/:provider (legacy: /telegram) -- setup
+  const setupMatch = matchChannelRoute(path, '')
+  if (setupMatch && method === 'POST') {
+    const [name, provider] = setupMatch
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
 
     const body = await readBody(req)
     const { botToken } = JSON.parse(body.toString()) as { botToken: string }
     if (!botToken?.trim()) { json(res, { error: 'botToken is required' }, 400); return true }
 
-    const validation = await validateTelegramToken(botToken.trim())
-    if (!validation.ok) { json(res, { error: validation.error || 'Invalid bot token' }, 400); return true }
+    const channelProvider = getProvider(provider)
+    const validation = await channelProvider.validateToken(botToken.trim())
+    if (!validation.ok) { json(res, { error: validation.error || 'Invalid token' }, 400); return true }
 
-    const tgDir = join(agentDir(name), '.claude', 'channels', 'telegram')
-    mkdirSync(tgDir, { recursive: true })
-    atomicWriteFileSync(join(tgDir, '.env'), `TELEGRAM_BOT_TOKEN=${botToken.trim()}\n`, { mode: 0o600 })
-    atomicWriteFileSync(join(tgDir, 'access.json'), JSON.stringify({
+    const stateDir = channelStateDir(provider, agentDir(name))
+    mkdirSync(stateDir, { recursive: true })
+    const tokenKey = provider === 'slack' ? 'SLACK_BOT_TOKEN' : 'TELEGRAM_BOT_TOKEN'
+    atomicWriteFileSync(join(stateDir, '.env'), `${tokenKey}=${botToken.trim()}\n`, { mode: 0o600 })
+    atomicWriteFileSync(join(stateDir, 'access.json'), JSON.stringify({
       dmPolicy: 'pairing',
       allowFrom: [],
       groups: {},
       pending: {},
     }, null, 2))
 
-    sendWelcomeMessage(name, botToken.trim()).catch(() => {})
+    if (provider === 'telegram') sendWelcomeMessage(name, botToken.trim()).catch(() => {})
 
-    // If the agent is running, the already-started bun poller is still using
-    // the OLD token. Restart it so the new token actually goes live.
     const wasRunning = isAgentRunning(name)
     let restarted = false
     if (wasRunning) {
@@ -326,16 +368,17 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       }
     }
 
-    json(res, { ok: true, botUsername: validation.botUsername, botId: validation.botId, restarted, wasRunning })
+    json(res, { ok: true, botName: validation.botName, restarted, wasRunning })
     return true
   }
 
-  if (tgSetupMatch && method === 'DELETE') {
-    const name = decodeURIComponent(tgSetupMatch[1])
+  // DELETE /api/agents/:name/channels/:provider (legacy: /telegram) -- remove
+  if (setupMatch && method === 'DELETE') {
+    const [name, provider] = setupMatch
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
-    const tgDir = join(agentDir(name), '.claude', 'channels', 'telegram')
-    const envFile = join(tgDir, '.env')
-    const accessFile = join(tgDir, 'access.json')
+    const stateDir = channelStateDir(provider, agentDir(name))
+    const envFile = join(stateDir, '.env')
+    const accessFile = join(stateDir, 'access.json')
     if (existsSync(envFile)) unlinkSync(envFile)
     if (existsSync(accessFile)) unlinkSync(accessFile)
     json(res, { ok: true })
@@ -450,16 +493,15 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     return true
   }
 
-  const tgPendingMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/pending$/)
-  if (tgPendingMatch && method === 'GET') {
-    const name = decodeURIComponent(tgPendingMatch[1])
-    const accessPath = name === MAIN_AGENT_ID
-      ? join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
-      : join(agentDir(name), '.claude', 'channels', 'telegram', 'access.json')
+  // GET /api/agents/:name/channels/:provider/pending (legacy: /telegram/pending)
+  const pendingMatch = matchChannelRoute(path, '/pending')
+  if (pendingMatch && method === 'GET') {
+    const [name, provider] = pendingMatch
     if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
       json(res, { error: 'Agent not found' }, 404)
       return true
     }
+    const accessPath = resolveAccessPath(name, provider)
     const accessContent = readFileOr(accessPath, '{}')
     try {
       const access = JSON.parse(accessContent)
@@ -478,9 +520,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     return true
   }
 
-  const tgApproveMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/approve$/)
-  if (tgApproveMatch && method === 'POST') {
-    const name = decodeURIComponent(tgApproveMatch[1])
+  // POST /api/agents/:name/channels/:provider/approve (legacy: /telegram/approve)
+  const approveMatch = matchChannelRoute(path, '/approve')
+  if (approveMatch && method === 'POST') {
+    const [name, provider] = approveMatch
     if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
       json(res, { error: 'Agent not found' }, 404)
       return true
@@ -490,10 +533,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const { code } = JSON.parse(body.toString()) as { code: string }
     if (!code?.trim()) { json(res, { error: 'Code is required' }, 400); return true }
 
-    const tgDir = name === MAIN_AGENT_ID
-      ? join(homedir(), '.claude', 'channels', 'telegram')
-      : join(agentDir(name), '.claude', 'channels', 'telegram')
-    const accessPath = join(tgDir, 'access.json')
+    const chDir = name === MAIN_AGENT_ID
+      ? channelStateDir(provider)
+      : channelStateDir(provider, agentDir(name))
+    const accessPath = join(chDir, 'access.json')
     const accessContent = readFileOr(accessPath, '{}')
 
     try {
@@ -510,18 +553,15 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
 
       delete access.pending[code.trim()]
 
-      // Pairing is one-shot; lock the channel down to allowlist mode now that
-      // we have the sender's id. Matches what install.sh does for the main
-      // agent after the first pairing completes.
       access.dmPolicy = 'allowlist'
 
       atomicWriteFileSync(accessPath, JSON.stringify(access, null, 2))
 
-      const approvedDir = join(tgDir, 'approved')
+      const approvedDir = join(chDir, 'approved')
       mkdirSync(approvedDir, { recursive: true })
       writeFileSync(join(approvedDir, entry.senderId), '')
 
-      logger.info({ name, senderId: entry.senderId, code }, 'Telegram pairing approved')
+      logger.info({ name, provider, senderId: entry.senderId, code }, 'Channel pairing approved')
       json(res, { ok: true, senderId: entry.senderId })
     } catch (err) {
       logger.error({ err }, 'Failed to approve pairing')
@@ -530,18 +570,15 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     return true
   }
 
-  // GET /api/agents/:name/telegram/allowed
-  // Returns the live allowlist: DM senders (allowFrom) + groups.
-  const tgAllowedListMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/allowed$/)
-  if (tgAllowedListMatch && method === 'GET') {
-    const name = decodeURIComponent(tgAllowedListMatch[1])
+  // GET /api/agents/:name/channels/:provider/allowed (legacy: /telegram/allowed)
+  const allowedListMatch = matchChannelRoute(path, '/allowed')
+  if (allowedListMatch && method === 'GET') {
+    const [name, provider] = allowedListMatch
     if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
       json(res, { error: 'Agent not found' }, 404)
       return true
     }
-    const accessPath = name === MAIN_AGENT_ID
-      ? join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
-      : join(agentDir(name), '.claude', 'channels', 'telegram', 'access.json')
+    const accessPath = resolveAccessPath(name, provider)
     const accessContent = readFileOr(accessPath, '{}')
     try {
       const access = JSON.parse(accessContent)
@@ -554,42 +591,31 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     return true
   }
 
-  // POST /api/agents/:name/telegram/invites
-  // Generates a one-time deep-link token. The invite-monitor auto-approves
-  // the next pending entry during the validity window, then re-locks
-  // dmPolicy to 'allowlist' once no live invites remain.
-  const tgInviteCreateMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/invites$/)
-  if (tgInviteCreateMatch && method === 'POST') {
-    const name = decodeURIComponent(tgInviteCreateMatch[1])
+  // POST /api/agents/:name/channels/:provider/invites (legacy: /telegram/invites)
+  const inviteCreateMatch = matchChannelRoute(path, '/invites')
+  if (inviteCreateMatch && method === 'POST') {
+    const [name, provider] = inviteCreateMatch
     if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
       json(res, { error: 'Agent not found' }, 404)
       return true
     }
-    let botUsername: string | undefined
-    if (name === MAIN_AGENT_ID) {
-      botUsername = readMarveenTelegramConfig().botUsername
-    } else {
-      botUsername = readAgentTelegramConfig(name).botUsername
-    }
-    if (!botUsername) {
-      const tokenPath = name === MAIN_AGENT_ID
-        ? join(homedir(), '.claude', 'channels', 'telegram', '.env')
-        : join(agentDir(name), '.claude', 'channels', 'telegram', '.env')
-      try {
-        const env = readFileOr(tokenPath, '')
-        const m = env.match(/TELEGRAM_BOT_TOKEN=(.+)/)
-        const tok = m?.[1]?.trim()
-        if (tok) {
-          const r = await validateTelegramToken(tok)
-          if (r.ok) botUsername = r.botUsername
+    let botName: string | undefined
+    if (provider === 'telegram') {
+      botName = name === MAIN_AGENT_ID
+        ? readMarveenTelegramConfig().botUsername
+        : readAgentTelegramConfig(name).botUsername
+      if (!botName) {
+        const stateDir = name === MAIN_AGENT_ID ? channelStateDir(provider) : channelStateDir(provider, agentDir(name))
+        const token = readChannelToken(provider, join(stateDir, '.env'))
+        if (token) {
+          const r = await getProvider(provider).validateToken(token)
+          if (r.ok) botName = r.botName
         }
-      } catch { /* ignore */ }
+      }
     }
-    const accessPath = name === MAIN_AGENT_ID
-      ? join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
-      : join(agentDir(name), '.claude', 'channels', 'telegram', 'access.json')
+    const accessPath = resolveAccessPath(name, provider)
     try {
-      const result = createInvite(accessPath, botUsername)
+      const result = createInvite(accessPath, botName, provider)
       json(res, result)
     } catch (err) {
       logger.error({ err }, 'Failed to create invite')
@@ -598,75 +624,80 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     return true
   }
 
-  // GET /api/agents/:name/telegram/invites
-  const tgInviteListMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/invites$/)
-  if (tgInviteListMatch && method === 'GET') {
-    const name = decodeURIComponent(tgInviteListMatch[1])
+  // GET /api/agents/:name/channels/:provider/invites (legacy: /telegram/invites)
+  if (inviteCreateMatch && method === 'GET') {
+    const [name, provider] = inviteCreateMatch
     if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
       json(res, { error: 'Agent not found' }, 404)
       return true
     }
-    const accessPath = name === MAIN_AGENT_ID
-      ? join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
-      : join(agentDir(name), '.claude', 'channels', 'telegram', 'access.json')
-    let botUsername: string | undefined
-    if (name === MAIN_AGENT_ID) {
-      botUsername = readMarveenTelegramConfig().botUsername
-    } else {
-      botUsername = readAgentTelegramConfig(name).botUsername
+    const accessPath = resolveAccessPath(name, provider)
+    let botName: string | undefined
+    if (provider === 'telegram') {
+      botName = name === MAIN_AGENT_ID
+        ? readMarveenTelegramConfig().botUsername
+        : readAgentTelegramConfig(name).botUsername
     }
     const items = listInvites(accessPath).map((inv) => ({
       ...inv,
-      deepLink: botUsername ? `https://t.me/${botUsername}?start=invite-${inv.token}` : undefined,
+      deepLink: provider === 'telegram' && botName
+        ? `https://t.me/${botName}?start=invite-${inv.token}`
+        : undefined,
     }))
     json(res, items)
     return true
   }
 
-  // DELETE /api/agents/:name/telegram/invites/:token
-  const tgInviteRevokeMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/invites\/(.+)$/)
-  if (tgInviteRevokeMatch && method === 'DELETE') {
-    const name = decodeURIComponent(tgInviteRevokeMatch[1])
-    const token = decodeURIComponent(tgInviteRevokeMatch[2])
+  // DELETE /api/agents/:name/channels/:provider/invites/:token (legacy: /telegram/invites/:token)
+  const inviteRevokeNewMatch = path.match(/^\/api\/agents\/([^/]+)\/channels\/(telegram|slack)\/invites\/(.+)$/)
+  const inviteRevokeLegacyMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/invites\/(.+)$/)
+  const inviteRevokeMatch = inviteRevokeNewMatch
+    ? { name: decodeURIComponent(inviteRevokeNewMatch[1]), provider: inviteRevokeNewMatch[2] as ChannelProviderType, token: decodeURIComponent(inviteRevokeNewMatch[3]) }
+    : inviteRevokeLegacyMatch
+      ? { name: decodeURIComponent(inviteRevokeLegacyMatch[1]), provider: 'telegram' as ChannelProviderType, token: decodeURIComponent(inviteRevokeLegacyMatch[2]) }
+      : null
+  if (inviteRevokeMatch && method === 'DELETE') {
+    const { name, provider, token } = inviteRevokeMatch
     if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
       json(res, { error: 'Agent not found' }, 404)
       return true
     }
-    const accessPath = name === MAIN_AGENT_ID
-      ? join(homedir(), '.claude', 'channels', 'telegram', 'access.json')
-      : join(agentDir(name), '.claude', 'channels', 'telegram', 'access.json')
+    const accessPath = resolveAccessPath(name, provider)
     const ok = revokeInvite(accessPath, token)
     if (!ok) { json(res, { error: 'Invite not found' }, 404); return true }
     json(res, { ok: true })
     return true
   }
 
-  // DELETE /api/agents/:name/telegram/allowed/:type/:id
-  // type = "user" or "group", id = senderId or groupId.
-  const tgAllowedRemoveMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/allowed\/(user|group)\/(.+)$/)
-  if (tgAllowedRemoveMatch && method === 'DELETE') {
-    const name = decodeURIComponent(tgAllowedRemoveMatch[1])
-    const kind = tgAllowedRemoveMatch[2]
-    const id = decodeURIComponent(tgAllowedRemoveMatch[3])
+  // DELETE /api/agents/:name/channels/:provider/allowed/:type/:id (legacy: /telegram/allowed/:type/:id)
+  const allowedRemoveNewMatch = path.match(/^\/api\/agents\/([^/]+)\/channels\/(telegram|slack)\/allowed\/(user|group)\/(.+)$/)
+  const allowedRemoveLegacyMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/allowed\/(user|group)\/(.+)$/)
+  const allowedRemoveMatch = allowedRemoveNewMatch
+    ? { name: decodeURIComponent(allowedRemoveNewMatch[1]), provider: allowedRemoveNewMatch[2] as ChannelProviderType, kind: allowedRemoveNewMatch[3], id: decodeURIComponent(allowedRemoveNewMatch[4]) }
+    : allowedRemoveLegacyMatch
+      ? { name: decodeURIComponent(allowedRemoveLegacyMatch[1]), provider: 'telegram' as ChannelProviderType, kind: allowedRemoveLegacyMatch[2], id: decodeURIComponent(allowedRemoveLegacyMatch[3]) }
+      : null
+  if (allowedRemoveMatch && method === 'DELETE') {
+    const { name, provider, kind, id } = allowedRemoveMatch
     if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
       json(res, { error: 'Agent not found' }, 404)
       return true
     }
-    const tgDir = name === MAIN_AGENT_ID
-      ? join(homedir(), '.claude', 'channels', 'telegram')
-      : join(agentDir(name), '.claude', 'channels', 'telegram')
-    const accessPath = join(tgDir, 'access.json')
+    const chDir = name === MAIN_AGENT_ID
+      ? channelStateDir(provider)
+      : channelStateDir(provider, agentDir(name))
+    const accessPath = join(chDir, 'access.json')
     try {
       const access = JSON.parse(readFileOr(accessPath, '{}'))
       if (kind === 'user') {
         access.allowFrom = (access.allowFrom || []).filter((s: string) => s !== id)
-        const approvedFile = join(tgDir, 'approved', id)
+        const approvedFile = join(chDir, 'approved', id)
         try { if (existsSync(approvedFile)) unlinkSync(approvedFile) } catch { /* ignore */ }
       } else {
         if (access.groups) delete access.groups[id]
       }
       atomicWriteFileSync(accessPath, JSON.stringify(access, null, 2))
-      logger.info({ name, kind, id }, 'Telegram allowlist entry removed')
+      logger.info({ name, provider, kind, id }, 'Channel allowlist entry removed')
       json(res, { ok: true })
     } catch (err) {
       logger.error({ err }, 'Failed to remove allowlist entry')


### PR DESCRIPTION
## Summary

PR 4/7 of the Slack channel support series (follows #104).

Generalizes all API routes from Telegram-only to provider-aware, with full backward compatibility:

**Route pattern**: `/api/agents/:name/channels/:provider/*` (new) + `/api/agents/:name/telegram/*` (legacy, resolves to `telegram`)

**Affected endpoints** (9 total):
- `POST /channels/:provider/test` -- token validation via provider.validateToken()
- `POST /channels/:provider` -- channel setup (provider-aware token key + state dir)
- `DELETE /channels/:provider` -- channel removal
- `GET /channels/:provider/pending` -- list pending pairings
- `POST /channels/:provider/approve` -- approve pairing
- `GET /channels/:provider/allowed` -- list allowlist
- `POST|GET /channels/:provider/invites` -- create/list invites
- `DELETE /channels/:provider/invites/:token` -- revoke invite
- `DELETE /channels/:provider/allowed/:type/:id` -- remove allowlist entry

**Helpers added**: `matchChannelRoute()` (dual pattern match), `resolveAccessPath()` (provider-aware access.json)

**Rename**: `telegram-invites.ts` -> `channel-invites.ts`
- `agentChannelDir()` uses `channelStateDir()` for provider-aware paths
- `createInvite()` accepts provider param; Telegram deep links only for telegram
- `runInviteMonitorTick()` scans both telegram and slack access.json files
- Old file removed (0 remaining importers)

3 files changed, +214/-200 lines.

## Risk

Medium-high. All 9 access-control endpoints rewritten. Backward compat via legacy regex fallback. Invite monitor now scans both providers.

## Test plan

- [ ] Build passes (bun build --no-bundle for agents.ts, channel-invites.ts, index.ts)
- [ ] Format tests 13/13 green
- [ ] Legacy `/api/agents/samu/telegram/pending` still works (backward compat)
- [ ] New `/api/agents/samu/channels/telegram/pending` returns same data
- [ ] Setup: POST `/channels/telegram` with botToken creates .env + access.json in telegram state dir
- [ ] Invite create/list/revoke endpoints work via new URL pattern
- [ ] Invite monitor scans telegram + slack access.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)