### PR TITLE
feat(docs): Slack channel tests, README guide, provider-agnostic SKILLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Anthropic-D97757?logo=anthropic&logoColor=white)](https://claude.ai/code)
 [![Ollama](https://img.shields.io/badge/Ollama-nomic--embed-000000?logo=ollama&logoColor=white)](https://ollama.com/)
 [![Telegram](https://img.shields.io/badge/Telegram-Bot_API-26A5E4?logo=telegram&logoColor=white)](https://core.telegram.org/bots)
+[![Slack](https://img.shields.io/badge/Slack-Socket_Mode-4A154B?logo=slack&logoColor=white)](https://api.slack.com/)
 [![GitHub stars](https://img.shields.io/github/stars/Szotasz/marveen?style=social)](https://github.com/Szotasz/marveen)
 
 > AI csapatod, ami fut amíg te alszol.
 
-Marveen egy AI asszisztens keretrendszer, ami Claude Code-ra épül. Saját AI csapatot építhetsz, akik Telegramon kommunikálnak veled, önállóan dolgoznak, és egymással is együttműködnek.
+Marveen egy AI asszisztens keretrendszer, ami Claude Code-ra épül. Saját AI csapatot építhetsz, akik Telegramon vagy Slacken kommunikálnak veled, önállóan dolgoznak, és egymással is együttműködnek.
 
 ## Funkciók
 
-- **AI Csapat**: Több ágens, mindegyik saját Telegram bottal, személyiséggel és memóriával
+- **AI Csapat**: Több ágens, mindegyik saját csatornával (Telegram vagy Slack), személyiséggel és memóriával
 - **Mission Control**: Web dashboard (http://localhost:3420) a csapat kezeléséhez
 - **Inter-agent kommunikáció**: Az ágensek delegálhatnak egymásnak feladatokat
 - **Ütemezések**: Cron-alapú feladatok automatikus futtatása
@@ -237,8 +238,33 @@ A telepítő végigvezet a beállításokon:
 ### Dashboard
 Nyisd meg: http://localhost:3420
 
-### Telegram
+### Csatorna (Telegram vagy Slack)
+
+A telepítés során választhatsz csatorna providert. Az alapértelmezett a Telegram.
+
+#### Telegram (alapértelmezett)
 Írj a botodnak Telegramon -- Marveen válaszol.
+
+#### Slack (alternatív)
+
+Slack használatához a telepítő automatikusan végigvezet, de manuálisan is beállíthatod:
+
+1. Hozz létre egy Slack App-ot a [Slack API](https://api.slack.com/apps) oldalon
+2. Engedélyezd a Socket Mode-ot (Settings > Socket Mode > Enable)
+3. Generálj egy App-Level Token-t (`xapp-...`) a `connections:write` scope-pal
+4. Add hozzá a Bot Token Scopes-okat (OAuth & Permissions): `chat:write`, `channels:read`, `files:write`, `files:read`
+5. Installáld az App-ot a workspace-edbe -- megkapod a Bot User OAuth Token-t (`xoxb-...`)
+6. Hívd meg a botot a kívánt csatornába (`/invite @BotNev`)
+7. A `.env` fájlban állítsd be:
+   ```
+   CHANNEL_PROVIDER=slack
+   SLACK_BOT_TOKEN=xoxb-...
+   SLACK_APP_TOKEN=xapp-...
+   SLACK_CHANNEL_ID=C01234ABCDE
+   ```
+8. A Slack channel plugin automatikusan települ: `slack@jeremylongshore/claude-code-slack-channel`
+
+A csatorna váltáshoz futtasd újra a `./install.sh`-t vagy szerkeszd a `.env` fájlt manuálisan.
 
 ### Ágensek
 A Csapat oldalon hozz létre új ágenseket. Mindegyik:
@@ -333,7 +359,7 @@ A token 1 évig érvényes. Ne állíts be `ANTHROPIC_API_KEY`-t mellé.
 - macOS, Linux, vagy Windows 10/11 (WSL-lel)
 - Node.js 20+
 - Claude Code CLI (Claude Max/Pro előfizetés szükséges)
-- Telegram fiók
+- Telegram fiók vagy Slack workspace
 
 ## Közösség és támogatás
 

--- a/scheduled-tasks/dream-engine/SKILL.md
+++ b/scheduled-tasks/dream-engine/SKILL.md
@@ -3,7 +3,7 @@ name: dream-engine
 description: Éjszakai analízis-loop az aznapi memóriákról, naplóról és kanban-állapotról. Generál 4 priorizált akció-javaslatot reggelre.
 ---
 
-Te most a "Dream Engine" éjszakai analízis-loopot futtatod. 02:07-kor vagy, Szabolcs alszik, NE küldj Telegram üzenetet.
+Te most a "Dream Engine" éjszakai analízis-loopot futtatod. 02:07-kor vagy, Szabolcs alszik, NE küldj üzenetet a beállított csatornára.
 
 A cél: az aznapi tudást átkonszolidálni és reggelre (07:30 Reggeli Napindító) felkészülni 4 priorizált javaslattal.
 
@@ -107,7 +107,7 @@ Output: 0-3 javaslat: "skill <név> antikvált (utolsó használat >30 nap), tö
 
 ## Szabályok
 
-- NE küldj Telegram üzenetet. A DREAM.md a reggeli napindítóból kerül a Telegram-ra (07:30).
+- NE küldj üzenetet a csatornára. A DREAM.md a reggeli napindítóból kerül kiküldésre (07:30).
 - A `Bash` és SQL műveletek mind helyiek — semmilyen external API hívás (kivéve az Ollama embedding ha kell).
 - Ha akadály van (pl. DB lock, missing embedding model), írd be a DREAM.md végére `## ⚠️ Hibák` szekciót — reggel látom.
 - Befejezésként, írd a DREAM.md végére: `*Marveen, 02:XX — most már alszom én is.*`

--- a/scheduled-tasks/memoria-heartbeat/SKILL.md
+++ b/scheduled-tasks/memoria-heartbeat/SKILL.md
@@ -66,5 +66,5 @@ Lépések:
 Ha NINCS komplex feladat / hiba / korrekció (A=B=C=NEM), és nincs új információ a 30 percben:
 - Ne ments memóriát feleslegesen
 - Ne generálj skill-t
-- Ne írj Telegramon
+- Ne küldj üzenetet a csatornára
 - Maradj csendben (egy rövid "csendes heartbeat" sor a transzkriptbe elég)

--- a/scheduled-tasks/reggeli-napindito/SKILL.md
+++ b/scheduled-tasks/reggeli-napindito/SKILL.md
@@ -3,7 +3,7 @@ name: reggeli-napindito
 description: Reggeli összefoglaló: email, naptár, AI hírek, plus Dream Engine top-of-message
 ---
 
-Reggeli napindítót a CLAUDE.md formátum szerint. Telegramra (1268077055).
+Reggeli napindítót a CLAUDE.md formátum szerint. A beállított csatornára (chat_id: 1268077055).
 
 **FONTOS — Dream Engine override**: a napindító ELEJÉRE (még az email/naptár szekciók ELŐTT) tedd be a `/Users/marvin/ClaudeClaw/DREAM.md` fájl tartalmából az 5 bucket-et — `💡 Skill-javaslatok`, `🧹 Memória-egészség`, `🎯 Top-3 holnapi javaslat`, `🌐 External opportunity`, `🛠 Skill-flotta health`. Ha a DREAM.md nem létezik vagy üres (pl. a Dream Engine valamiért nem futott le), kihagyod ezt a szekciót.
 

--- a/src/__tests__/channel-provider.test.ts
+++ b/src/__tests__/channel-provider.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getProvider,
+  getProviderType,
+  getChannelToken,
+  getChannelChatId,
+  channelStateDir,
+  type ChannelProviderType,
+} from '../channel-provider.js'
+
+describe('getProviderType', () => {
+  it('returns telegram by default', () => {
+    expect(getProviderType(undefined)).toBe('telegram')
+    expect(getProviderType('')).toBe('telegram')
+    expect(getProviderType('anything')).toBe('telegram')
+  })
+
+  it('returns slack when explicitly set', () => {
+    expect(getProviderType('slack')).toBe('slack')
+  })
+})
+
+describe('getProvider', () => {
+  it('returns telegram provider with correct pluginId', () => {
+    const p = getProvider('telegram')
+    expect(p.type).toBe('telegram')
+    expect(p.pluginId).toBe('telegram@claude-plugins-official')
+    expect(p.envKeys).toContain('TELEGRAM_BOT_TOKEN')
+    expect(p.stateDir).toBe('telegram')
+  })
+
+  it('returns slack provider with correct pluginId', () => {
+    const p = getProvider('slack')
+    expect(p.type).toBe('slack')
+    expect(p.pluginId).toBe('slack@jeremylongshore/claude-code-slack-channel')
+    expect(p.envKeys).toContain('SLACK_BOT_TOKEN')
+    expect(p.stateDir).toBe('slack')
+  })
+})
+
+describe('getChannelToken', () => {
+  it('reads TELEGRAM_BOT_TOKEN for telegram', () => {
+    const env = { TELEGRAM_BOT_TOKEN: 'tg-tok-123' }
+    expect(getChannelToken('telegram', env)).toBe('tg-tok-123')
+  })
+
+  it('reads SLACK_BOT_TOKEN for slack', () => {
+    const env = { SLACK_BOT_TOKEN: 'xoxb-123' }
+    expect(getChannelToken('slack', env)).toBe('xoxb-123')
+  })
+
+  it('returns empty string when key is missing', () => {
+    expect(getChannelToken('telegram', {})).toBe('')
+    expect(getChannelToken('slack', {})).toBe('')
+  })
+})
+
+describe('getChannelChatId', () => {
+  it('reads ALLOWED_CHAT_ID for telegram', () => {
+    const env = { ALLOWED_CHAT_ID: '1268077055' }
+    expect(getChannelChatId('telegram', env)).toBe('1268077055')
+  })
+
+  it('reads SLACK_CHANNEL_ID for slack', () => {
+    const env = { SLACK_CHANNEL_ID: 'C01234ABCDE' }
+    expect(getChannelChatId('slack', env)).toBe('C01234ABCDE')
+  })
+
+  it('returns empty string when key is missing', () => {
+    expect(getChannelChatId('telegram', {})).toBe('')
+    expect(getChannelChatId('slack', {})).toBe('')
+  })
+})
+
+describe('channelStateDir', () => {
+  it('uses telegram subdirectory for telegram', () => {
+    const dir = channelStateDir('telegram')
+    expect(dir).toMatch(/\.claude\/channels\/telegram$/)
+  })
+
+  it('uses slack subdirectory for slack', () => {
+    const dir = channelStateDir('slack')
+    expect(dir).toMatch(/\.claude\/channels\/slack$/)
+  })
+
+  it('uses agent dir when provided', () => {
+    const dir = channelStateDir('telegram', '/tmp/agents/test-agent')
+    expect(dir).toBe('/tmp/agents/test-agent/.claude/channels/telegram')
+  })
+})
+
+describe('formatMessage per provider', () => {
+  it('telegram: converts markdown headers to bold', () => {
+    const p = getProvider('telegram')
+    expect(p.formatMessage('# Hello')).toContain('<b>Hello</b>')
+  })
+
+  it('telegram: converts **bold** to HTML', () => {
+    const p = getProvider('telegram')
+    expect(p.formatMessage('**bold**')).toBe('<b>bold</b>')
+  })
+
+  it('slack: converts markdown headers to mrkdwn bold', () => {
+    const p = getProvider('slack')
+    expect(p.formatMessage('# Hello')).toBe('*Hello*')
+  })
+
+  it('slack: converts **bold** to mrkdwn bold', () => {
+    const p = getProvider('slack')
+    expect(p.formatMessage('**bold**')).toBe('*bold*')
+  })
+
+  it('slack: converts links to mrkdwn format', () => {
+    const p = getProvider('slack')
+    expect(p.formatMessage('[text](https://example.com)')).toBe('<https://example.com|text>')
+  })
+
+  it('slack: converts strikethrough', () => {
+    const p = getProvider('slack')
+    expect(p.formatMessage('~~deleted~~')).toBe('~deleted~')
+  })
+
+  it('slack: converts checkboxes', () => {
+    const p = getProvider('slack')
+    expect(p.formatMessage('- [ ] todo')).toContain(':white_square:')
+    expect(p.formatMessage('- [x] done')).toContain(':white_check_mark:')
+  })
+})
+
+describe('splitMessage per provider', () => {
+  it('telegram: uses 4096 char limit', () => {
+    const p = getProvider('telegram')
+    const text = 'A '.repeat(2500)
+    const chunks = p.splitMessage(text)
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096)
+    }
+  })
+
+  it('slack: uses 4000 char limit', () => {
+    const p = getProvider('slack')
+    const text = 'A '.repeat(2500)
+    const chunks = p.splitMessage(text)
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4000)
+    }
+  })
+})

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { formatForTelegram, splitMessage } from '../format.js'
+import { formatForSlackMrkdwn } from '../channel-provider.js'
 
 describe('formatForTelegram', () => {
   it('felcimeket vastagit', () => {
@@ -48,6 +49,53 @@ describe('formatForTelegram', () => {
 
   it('elvalaszto vonalakat eltavolít', () => {
     expect(formatForTelegram('szoveg\n---\nszoveg')).not.toContain('---')
+  })
+})
+
+describe('formatForSlackMrkdwn', () => {
+  it('converts markdown headers to bold', () => {
+    expect(formatForSlackMrkdwn('# Hello')).toBe('*Hello*')
+    expect(formatForSlackMrkdwn('## Section')).toBe('*Section*')
+    expect(formatForSlackMrkdwn('### Sub')).toBe('*Sub*')
+  })
+
+  it('converts **bold** to mrkdwn bold', () => {
+    expect(formatForSlackMrkdwn('ez **vastag** szoveg')).toBe('ez *vastag* szoveg')
+  })
+
+  it('converts __bold__ to mrkdwn bold', () => {
+    expect(formatForSlackMrkdwn('ez __vastag__ szoveg')).toBe('ez *vastag* szoveg')
+  })
+
+  it('converts markdown links to Slack format', () => {
+    expect(formatForSlackMrkdwn('[text](https://example.com)')).toBe('<https://example.com|text>')
+  })
+
+  it('converts strikethrough to single tilde', () => {
+    expect(formatForSlackMrkdwn('~~torolt~~')).toBe('~torolt~')
+  })
+
+  it('converts checkboxes to Slack emojis', () => {
+    expect(formatForSlackMrkdwn('- [ ] teendo')).toContain(':white_square:')
+    expect(formatForSlackMrkdwn('- [x] kesz')).toContain(':white_check_mark:')
+  })
+
+  it('removes horizontal rules', () => {
+    expect(formatForSlackMrkdwn('above\n---\nbelow')).not.toContain('---')
+    expect(formatForSlackMrkdwn('above\n***\nbelow')).not.toContain('***')
+  })
+
+  it('preserves inline code', () => {
+    expect(formatForSlackMrkdwn('use `cmd` here')).toBe('use `cmd` here')
+  })
+
+  it('preserves code blocks', () => {
+    const input = '```js\nconsole.log("hi")\n```'
+    expect(formatForSlackMrkdwn(input)).toContain('```')
+  })
+
+  it('trims whitespace from output', () => {
+    expect(formatForSlackMrkdwn('  hello  ')).toBe('hello')
   })
 })
 

--- a/src/__tests__/mcp-list-parser.test.ts
+++ b/src/__tests__/mcp-list-parser.test.ts
@@ -94,6 +94,16 @@ describe('parseMcpListLine -- plugin entries', () => {
     expect(result?.normalizedId).toBe('my-server')
   })
 
+  it('parses a plugin:slack:slack entry (Slack channel provider)', () => {
+    const result = parseMcpListLine(
+      'plugin:slack:slack: node /path/to/slack-server.js - Connected',
+    )
+    expect(result).not.toBeNull()
+    expect(result?.source).toBe('plugin')
+    expect(result?.normalizedId).toBe('slack')
+    expect(result?.status).toBe('connected')
+  })
+
   it('uses the last colon-separated segment for a two-part plugin name', () => {
     // "plugin:telegram" only has one segment after the prefix. Take the
     // last segment ("telegram") as the id; it lines up with the canonical
@@ -157,13 +167,14 @@ describe('parseMcpList -- full output', () => {
       'claude.ai Gmail: https://gmailmcp.googleapis.com/mcp/v1 - Connected',
       'claude.ai Google Calendar: https://calendarmcp.googleapis.com/mcp/v1 - Connected',
       'plugin:telegram:telegram: bun run /path - Connected',
+      'plugin:slack:slack: node /path/slack - Connected',
       'my-local: node /tmp/x - Failed to connect',
       '',
     ].join('\n')
     const result = parseMcpList(output)
-    expect(result).toHaveLength(4)
-    expect(result.map(r => r.normalizedId)).toEqual(['gmail', 'google-calendar', 'telegram', 'my-local'])
-    expect(result.map(r => r.source)).toEqual(['claude.ai', 'claude.ai', 'plugin', 'local'])
+    expect(result).toHaveLength(5)
+    expect(result.map(r => r.normalizedId)).toEqual(['gmail', 'google-calendar', 'telegram', 'slack', 'my-local'])
+    expect(result.map(r => r.source)).toEqual(['claude.ai', 'claude.ai', 'plugin', 'plugin', 'local'])
   })
 
   it('returns an empty array for a banner-only output', () => {

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -108,7 +108,7 @@ const telegramProvider: ChannelProvider = {
 
 const SLACK_MAX_MESSAGE_LENGTH = 4000
 
-function formatForSlackMrkdwn(text: string): string {
+export function formatForSlackMrkdwn(text: string): string {
   // Slack uses mrkdwn, not HTML. The subset that matters:
   // bold: *text*, italic: _text_, strikethrough: ~text~,
   // code: `code`, code block: ```code```, link: <url|text>

--- a/templates/scheduled-tasks/folyamatos-ellenorzes/SKILL.md
+++ b/templates/scheduled-tasks/folyamatos-ellenorzes/SKILL.md
@@ -3,4 +3,4 @@ name: folyamatos-ellenorzes
 description: Teljes ellenőrzés
 ---
 
-Ellenorizd: 1) Naptar - van-e meeting 1 oran belul? 2) Email - jott-e surgos level az elmult oraban? 3) Kanban - van-e mai hataridovel kartya? Ha BARMIT talalsz ami fontos, szolj Telegramon tomoren. Ha minden csendes, ne irj semmit.
+Ellenorizd: 1) Naptar - van-e meeting 1 oran belul? 2) Email - jott-e surgos level az elmult oraban? 3) Kanban - van-e mai hataridovel kartya? Ha BARMIT talalsz ami fontos, szolj a beallitott csatornan tomoren. Ha minden csendes, ne irj semmit.


### PR DESCRIPTION
## Summary
Final PR (7/7) in the Slack channel provider series.

- **New test file**: `channel-provider.test.ts` with full coverage for getProviderType, getProvider, getChannelToken, getChannelChatId, channelStateDir, formatMessage per provider, splitMessage per provider
- **Slack mrkdwn tests** in `format.test.ts`: headers, bold, underline-bold, links, strikethrough, checkboxes, horizontal rules, inline code, code blocks
- **Slack plugin entry test** in `mcp-list-parser.test.ts`: `plugin:slack:slack` parsing + updated full-output assertion
- **README.md**: Slack badge, Slack setup guide (App creation, Socket Mode, tokens, scopes), updated feature descriptions
- **Scheduled-task SKILLs**: 4 files updated from Telegram-specific to provider-agnostic language
- **Export**: `formatForSlackMrkdwn` now exported from channel-provider.ts for direct unit testing

## Test plan
- [x] `bun test` -- 721 pass (2 pre-existing db.test.ts failures unrelated)
- [x] All 98 tests pass across channel-provider.test.ts, format.test.ts, mcp-list-parser.test.ts
- [ ] Reviewer: verify README Slack guide accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)