### PR TITLE
fix(updater): ignore HEARTBEAT.md in dirty-tree check

### DIFF
--- a/src/update-preflight.ts
+++ b/src/update-preflight.ts
@@ -144,7 +144,17 @@ export function checkUpdatePreflight(git: GitRunner): PreflightResult {
     }
   }
 
-  const dirty = git.porcelainStatus().trim()
+  // HEARTBEAT.md is self-modifying (rewritten by the agent every heartbeat).
+  // Treating it as a blocker means the update button is almost always
+  // refused in practice. Skip it from the dirty check; the file is
+  // gitignore'd as "tracked-but-mutable" by convention. Any other dirty
+  // file still blocks (see update.sh which stashes HEARTBEAT.md before
+  // git pull and pops it after).
+  const dirty = git.porcelainStatus()
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .filter((l) => !/\sHEARTBEAT\.md$/.test(l))
   if (dirty.length > 0) {
     return {
       ok: false,

--- a/update.sh
+++ b/update.sh
@@ -123,7 +123,10 @@ fi
 # emit a warning so the operator does not lose work silently -- the
 # stash entry is also kept in `git stash list` for manual recovery.
 STASHED_AUTO=0
-DIRTY=$(git status --porcelain --untracked-files=no | head -n 1)
+# HEARTBEAT.md is rewritten by the agent every heartbeat tick (self-modifying).
+# Exclude it from the dirty check; the preflight ignores it too. It will be
+# auto-overwritten on the next heartbeat anyway, so no data loss.
+DIRTY=$(git status --porcelain --untracked-files=no | grep -vE ' HEARTBEAT\.md$' | head -n 1)
 if [ -n "$DIRTY" ]; then
   if [ "${AUTO_STASH:-0}" = "1" ]; then
     echo -e "  Lokalis valtozasok stash-elve (auto-stash)..."


### PR DESCRIPTION
HEARTBEAT.md is rewritten by the agent every heartbeat tick. Skip it in dirty-tree check (preflight + update.sh). Any other tracked file modification still blocks.