### PR TITLE
fix(slack): pass SLACK_APP_TOKEN through dashboard setup flow

### DIFF
--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -337,7 +337,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
 
     const body = await readBody(req)
-    const { botToken } = JSON.parse(body.toString()) as { botToken: string }
+    const { botToken, appToken } = JSON.parse(body.toString()) as { botToken: string; appToken?: string }
     if (!botToken?.trim()) { json(res, { error: 'botToken is required' }, 400); return true }
 
     const channelProvider = getProvider(provider)
@@ -347,7 +347,11 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const stateDir = channelStateDir(provider, agentDir(name))
     mkdirSync(stateDir, { recursive: true })
     const tokenKey = provider === 'slack' ? 'SLACK_BOT_TOKEN' : 'TELEGRAM_BOT_TOKEN'
-    atomicWriteFileSync(join(stateDir, '.env'), `${tokenKey}=${botToken.trim()}\n`, { mode: 0o600 })
+    let envContent = `${tokenKey}=${botToken.trim()}\n`
+    if (provider === 'slack' && appToken?.trim()) {
+      envContent += `SLACK_APP_TOKEN=${appToken.trim()}\n`
+    }
+    atomicWriteFileSync(join(stateDir, '.env'), envContent, { mode: 0o600 })
     atomicWriteFileSync(join(stateDir, 'access.json'), JSON.stringify({
       dmPolicy: 'pairing',
       allowFrom: [],

--- a/web/app.js
+++ b/web/app.js
@@ -1387,6 +1387,12 @@ document.getElementById('chConnectBtn').addEventListener('click', async () => {
     return
   }
 
+  const payload = { botToken: token }
+  if (currentChannelProvider === 'slack') {
+    const appToken = document.getElementById('chSlackAppToken').value.trim()
+    if (appToken) payload.appToken = appToken
+  }
+
   const btn = document.getElementById('chConnectBtn')
   btn.disabled = true
   btn.querySelector('.btn-text').hidden = true
@@ -1396,7 +1402,7 @@ document.getElementById('chConnectBtn').addEventListener('click', async () => {
     const res = await fetch(`${channelApiBase()}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ botToken: token }),
+      body: JSON.stringify(payload),
     })
     if (!res.ok) {
       const err = await res.json()


### PR DESCRIPTION
## Summary
- **Frontend** (web/app.js): read `chSlackAppToken` input when provider is slack, include `appToken` in POST body
- **Backend** (src/web/routes/agents.ts): destructure `appToken` from body, write `SLACK_APP_TOKEN=...` line to state-dir `.env` when provider is slack

Without this fix, the Slack channel plugin cannot establish a Socket Mode connection because `SLACK_APP_TOKEN` (xapp-) was never written to the agent's state directory.

## Test plan
- [x] Existing channel-provider tests pass (22/22)
- [ ] Manual: Slack setup via dashboard writes both tokens to `.env`
- [ ] Manual: Slack bot connects via Socket Mode after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)