### PR TITLE
fix(slack): persist channelProvider in agent-config on setup/disconnect

### DIFF
--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -24,6 +24,7 @@ import {
   listAgentNames,
   isKnownAgent,
   readAgentChannelProvider,
+  writeAgentChannelProvider,
 } from '../agent-config.js'
 import {
   readAgentTeam,
@@ -359,6 +360,8 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       pending: {},
     }, null, 2))
 
+    writeAgentChannelProvider(name, provider)
+
     if (provider === 'telegram') sendWelcomeMessage(name, botToken.trim()).catch(() => {})
 
     const wasRunning = isAgentRunning(name)
@@ -385,6 +388,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const accessFile = join(stateDir, 'access.json')
     if (existsSync(envFile)) unlinkSync(envFile)
     if (existsSync(accessFile)) unlinkSync(accessFile)
+    writeAgentChannelProvider(name, '')
     json(res, { ok: true })
     return true
   }


### PR DESCRIPTION
## Summary
- **Setup** (POST handler): call `writeAgentChannelProvider(name, provider)` after writing tokens to state-dir `.env`
- **Disconnect** (DELETE handler): clear `channelProvider` so agent reverts to global default

Without this, `agent-process` and `channel-monitor` fall back to the global `CHANNEL_PROVIDER` env on next start, ignoring the per-agent provider choice made in the dashboard.

## Test plan
- [x] Existing tests pass (22/22)
- [ ] Manual: after Slack setup via dashboard, `agent-config.json` contains `"channelProvider": "slack"`
- [ ] Manual: after disconnect, `channelProvider` is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)