### PR TITLE
feat(slack): managed-settings pre-flight + enabledPlugins lockdown

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "slack-channel@marveen-marketplace": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ workspace/
 agents/
 reports/
 .claude/
+!.claude/settings.json
 .config/
 
 # Database

--- a/install.sh
+++ b/install.sh
@@ -226,7 +226,7 @@ else
   REQUIRED_JSON="{\"allowedChannelPlugins\":[$SLACK_ENTRY,$TELEGRAM_ENTRY]}"
 
   if [ -f "$MANAGED_FILE" ]; then
-    HAS_SLACK=$(python3 -c "
+    HAS_SLACK=$(sudo python3 -c "
 import json, sys
 try:
   d = json.load(open('$MANAGED_FILE'))
@@ -236,7 +236,7 @@ except: sys.exit(1)
 " 2>/dev/null && echo "yes" || echo "no")
     if [ "$HAS_SLACK" = "no" ]; then
       echo -e "  ${ORANGE}⚠${NC} A managed-settings.json frissítése szükséges (sudo)."
-      echo "$REQUIRED_JSON" | python3 -c "
+      echo "$REQUIRED_JSON" | sudo python3 -c "
 import json, sys
 new = json.loads(sys.stdin.read())
 try:

--- a/install.sh
+++ b/install.sh
@@ -217,6 +217,48 @@ else
   echo ""
   read -p "  Bot Token (xoxb-...): " SLACK_BOT_TOKEN
   read -p "  App-Level Token (xapp-...): " SLACK_APP_TOKEN
+
+  # Managed settings: Claude Code requires allowedChannelPlugins at system level
+  MANAGED_DIR="/Library/Application Support/ClaudeCode"
+  MANAGED_FILE="$MANAGED_DIR/managed-settings.json"
+  SLACK_ENTRY='{"plugin":"slack-channel","marketplace":"marveen-marketplace"}'
+  TELEGRAM_ENTRY='{"plugin":"telegram","marketplace":"claude-plugins-official"}'
+  REQUIRED_JSON="{\"allowedChannelPlugins\":[$SLACK_ENTRY,$TELEGRAM_ENTRY]}"
+
+  if [ -f "$MANAGED_FILE" ]; then
+    HAS_SLACK=$(python3 -c "
+import json, sys
+try:
+  d = json.load(open('$MANAGED_FILE'))
+  plugins = d.get('allowedChannelPlugins', [])
+  sys.exit(0 if any(p.get('plugin')=='slack-channel' and p.get('marketplace')=='marveen-marketplace' for p in plugins) else 1)
+except: sys.exit(1)
+" 2>/dev/null && echo "yes" || echo "no")
+    if [ "$HAS_SLACK" = "no" ]; then
+      echo -e "  ${ORANGE}⚠${NC} A managed-settings.json frissitese szukseges (sudo)."
+      echo "$REQUIRED_JSON" | python3 -c "
+import json, sys
+new = json.loads(sys.stdin.read())
+try:
+  with open('$MANAGED_FILE') as f: existing = json.load(f)
+except: existing = {}
+plugins = existing.get('allowedChannelPlugins', [])
+for entry in new['allowedChannelPlugins']:
+  if not any(p.get('plugin')==entry['plugin'] and p.get('marketplace')==entry['marketplace'] for p in plugins):
+    plugins.append(entry)
+existing['allowedChannelPlugins'] = plugins
+print(json.dumps(existing, indent=2))
+" | sudo tee "$MANAGED_FILE" > /dev/null
+      echo -e "  ${GREEN}✓${NC} managed-settings.json frissitve"
+    else
+      echo -e "  ${GREEN}✓${NC} managed-settings.json mar tartalmazza a Slack plugint"
+    fi
+  else
+    echo -e "  ${ORANGE}⚠${NC} Managed settings letrehozasa szukseges (sudo)."
+    sudo mkdir -p "$MANAGED_DIR"
+    echo "$REQUIRED_JSON" | python3 -c "import json,sys; print(json.dumps(json.loads(sys.stdin.read()),indent=2))" | sudo tee "$MANAGED_FILE" > /dev/null
+    echo -e "  ${GREEN}✓${NC} managed-settings.json letrehozva"
+  fi
 fi
 
 read -p "  Mi legyen a botod neve? [Marveen]: " BOT_NAME

--- a/install.sh
+++ b/install.sh
@@ -53,9 +53,9 @@ fi
 
 if [ "$MISSING" -eq 1 ]; then
   echo ""
-  echo -e "${ORANGE}Hianyzo fuggosegek telepitese Homebrew-val...${NC}"
+  echo -e "${ORANGE}Hianyzo függőségek telepítése Homebrew-val...${NC}"
   if ! command -v brew &>/dev/null; then
-    echo -e "${ORANGE}Homebrew nincs telepitve. Megprobalom most (sudo jelszo kellhet)...${NC}"
+    echo -e "${ORANGE}Homebrew nincs telepítve. Megprobalom most (sudo jelszo kellhet)...${NC}"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     # Homebrew on Apple Silicon installs to /opt/homebrew; add it to PATH now
     # so subsequent `brew` calls in this script succeed without a shell restart.
@@ -65,20 +65,20 @@ if [ "$MISSING" -eq 1 ]; then
       eval "$(/usr/local/bin/brew shellenv)"
     fi
     if ! command -v brew &>/dev/null; then
-      echo -e "${RED}Homebrew telepitese sikertelen. Telepitsd manualisan (https://brew.sh) es futtasd ujra az installert.${NC}"
+      echo -e "${RED}Homebrew telepítése sikertelen. Telepitsd manualisan (https://brew.sh) es futtasd ujra az installert.${NC}"
       exit 1
     fi
   fi
   command -v node &>/dev/null || brew install node@22
   command -v tmux &>/dev/null || brew install tmux
   command -v git &>/dev/null || brew install git
-  echo -e "${GREEN}✓ Fuggosegek telepitve${NC}"
+  echo -e "${GREEN}✓ Függőségek telepítve${NC}"
 fi
 
 # Bun (required by Telegram channels plugin)
 export PATH="$HOME/.bun/bin:$PATH"
 if ! command -v bun &>/dev/null; then
-  echo -e "  ${ORANGE}Bun telepitese (Telegram plugin fuggoseg)...${NC}"
+  echo -e "  ${ORANGE}Bun telepítése (Telegram plugin függőség)...${NC}"
   curl -fsSL https://bun.sh/install | bash 2>/dev/null
   # Source the profile that bun installer modified
   [ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc" 2>/dev/null
@@ -99,7 +99,7 @@ if ! command -v claude &>/dev/null; then
   if [ "$INSTALL_CLAUDE" = "i" ]; then
     npm install -g @anthropic-ai/claude-code
   else
-    echo -e "${RED}Claude Code CLI szukseges a futtatáshoz.${NC}"
+    echo -e "${RED}Claude Code CLI szükséges a futtatáshoz.${NC}"
     exit 1
   fi
 fi
@@ -168,11 +168,11 @@ if [ "$DO_AUTH" = "i" ]; then
     echo -e "  ${DIM}A telepites folytatodik. Belepheted kesobb: ${BOLD}claude auth login${NC}"
   fi
 fi
-echo -e "  ${GREEN}✓${NC} Claude Code first-run beallitas kesz"
+echo -e "  ${GREEN}✓${NC} Claude Code first-run beállítás kész"
 
 # Step 3: Personal info
 echo ""
-echo -e "${BOLD}[3/7] Szemelyes beallitasok${NC}"
+echo -e "${BOLD}[3/7] Személyes beállítások${NC}"
 read -p "  Mi a neved? " OWNER_NAME
 # Chat ID is NOT asked here -- the user doesn't know it yet.
 # It will be set automatically during the Telegram pairing flow.
@@ -180,7 +180,7 @@ CHAT_ID="0"
 
 # Step 4: Channel provider setup
 echo ""
-echo -e "${BOLD}[4/7] Csatorna beallitas${NC}"
+echo -e "${BOLD}[4/7] Csatorna beállítás${NC}"
 echo -e "${DIM}  Melyik csatornan kommunikaljon az AI asszisztensed?${NC}"
 echo -e "  ${BOLD}1.${NC} Telegram (alapertelmezett)"
 echo -e "  ${BOLD}2.${NC} Slack"
@@ -235,7 +235,7 @@ try:
 except: sys.exit(1)
 " 2>/dev/null && echo "yes" || echo "no")
     if [ "$HAS_SLACK" = "no" ]; then
-      echo -e "  ${ORANGE}⚠${NC} A managed-settings.json frissitese szukseges (sudo)."
+      echo -e "  ${ORANGE}⚠${NC} A managed-settings.json frissítése szükséges (sudo)."
       echo "$REQUIRED_JSON" | python3 -c "
 import json, sys
 new = json.loads(sys.stdin.read())
@@ -249,15 +249,15 @@ for entry in new['allowedChannelPlugins']:
 existing['allowedChannelPlugins'] = plugins
 print(json.dumps(existing, indent=2))
 " | sudo tee "$MANAGED_FILE" > /dev/null
-      echo -e "  ${GREEN}✓${NC} managed-settings.json frissitve"
+      echo -e "  ${GREEN}✓${NC} managed-settings.json frissítve"
     else
       echo -e "  ${GREEN}✓${NC} managed-settings.json mar tartalmazza a Slack plugint"
     fi
   else
-    echo -e "  ${ORANGE}⚠${NC} Managed settings letrehozasa szukseges (sudo)."
+    echo -e "  ${ORANGE}⚠${NC} Managed settings létrehozása szükséges (sudo)."
     sudo mkdir -p "$MANAGED_DIR"
     echo "$REQUIRED_JSON" | python3 -c "import json,sys; print(json.dumps(json.loads(sys.stdin.read()),indent=2))" | sudo tee "$MANAGED_FILE" > /dev/null
-    echo -e "  ${GREEN}✓${NC} managed-settings.json letrehozva"
+    echo -e "  ${GREEN}✓${NC} managed-settings.json létrehozva"
   fi
 fi
 
@@ -281,10 +281,10 @@ fi
 
 # Step 5: Install dependencies
 echo ""
-echo -e "${BOLD}[5/7] Fuggosegek telepitese...${NC}"
+echo -e "${BOLD}[5/7] Függőségek telepítése...${NC}"
 cd "$INSTALL_DIR"
 npm install --silent
-echo -e "  ${GREEN}✓${NC} npm csomagok telepitve"
+echo -e "  ${GREEN}✓${NC} npm csomagok telepítve"
 
 # Build TypeScript
 echo -e "  Forditas..."
@@ -293,7 +293,7 @@ echo -e "  ${GREEN}✓${NC} TypeScript leforditva"
 
 # Step 6: Configuration
 echo ""
-echo -e "${BOLD}[6/7] Konfiguracio letrehozasa...${NC}"
+echo -e "${BOLD}[6/7] Konfiguráció létrehozása...${NC}"
 
 # Create .env
 (umask 077 && cat > "$INSTALL_DIR/.env" << ENVEOF
@@ -313,12 +313,12 @@ else
   echo "SLACK_APP_TOKEN=${SLACK_APP_TOKEN}" >> "$INSTALL_DIR/.env"
 fi
 chmod 600 "$INSTALL_DIR/.env"
-echo -e "  ${GREEN}✓${NC} .env letrehozva (chmod 600)"
+echo -e "  ${GREEN}✓${NC} .env létrehozva (chmod 600)"
 
 # Create store directory
 mkdir -p "$INSTALL_DIR/store"
 mkdir -p "$INSTALL_DIR/agents"
-echo -e "  ${GREEN}✓${NC} Konyvtarak letrehozva"
+echo -e "  ${GREEN}✓${NC} Könyvtárak létrehozva"
 
 # Generate CLAUDE.md from template
 if [ -f "$INSTALL_DIR/templates/CLAUDE.md.template" ]; then
@@ -414,12 +414,12 @@ fi
 echo -e "  ${CHANNEL_PROVIDER} plugin telepites..."
 claude plugin marketplace add "$PLUGIN_MARKETPLACE" 2>/dev/null || true
 if claude plugin install "$PLUGIN_ID" 2>/dev/null; then
-  echo -e "  ${GREEN}✓${NC} ${CHANNEL_PROVIDER} plugin telepitve"
+  echo -e "  ${GREEN}✓${NC} ${CHANNEL_PROVIDER} plugin telepítve"
 else
   echo -e "  ${ORANGE}Elso probalkozas sikertelen, ujraprobalok...${NC}"
   sleep 2
   if claude plugin install "$PLUGIN_ID" 2>/dev/null; then
-    echo -e "  ${GREEN}✓${NC} ${CHANNEL_PROVIDER} plugin telepitve (masodik probalkozesal)"
+    echo -e "  ${GREEN}✓${NC} ${CHANNEL_PROVIDER} plugin telepítve (masodik próbálkozással)"
   else
     echo -e "  ${RED}✗${NC} ${CHANNEL_PROVIDER} plugin telepites sikertelen."
     echo -e "  ${BOLD}Futtasd kesobb kezzel:${NC}"
@@ -433,7 +433,7 @@ SKILLS_DIR="$HOME/.claude/skills"
 if [ -d "$INSTALL_DIR/skills/skill-factory" ]; then
   mkdir -p "$SKILLS_DIR/skill-factory"
   cp -r "$INSTALL_DIR/skills/skill-factory/"* "$SKILLS_DIR/skill-factory/"
-  echo -e "  ${GREEN}✓${NC} skill-factory telepitve"
+  echo -e "  ${GREEN}✓${NC} skill-factory telepítve"
 fi
 
 # Ollama + nomic-embed-text (szemantikus kereséshez)
@@ -512,7 +512,7 @@ fi
 
 # Step 7: LaunchAgent setup
 echo ""
-echo -e "${BOLD}[7/7] Automatikus inditas beallitasa...${NC}"
+echo -e "${BOLD}[7/7] Automatikus indítás beállítása...${NC}"
 
 PLIST_DIR="$HOME/Library/LaunchAgents"
 mkdir -p "$PLIST_DIR"
@@ -594,7 +594,7 @@ cat > "$PLIST_DIR/${CHANNELS_PLIST}.plist" << PLISTEOF
 </plist>
 PLISTEOF
 
-echo -e "  ${GREEN}✓${NC} LaunchAgent-ek letrehozva"
+echo -e "  ${GREEN}✓${NC} LaunchAgent-ek létrehozva"
 
 # Load LaunchAgents
 launchctl load "$PLIST_DIR/${DASHBOARD_PLIST}.plist" 2>/dev/null || true
@@ -612,7 +612,7 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ] && ! command -v bun &>/dev/null; then
 fi
 PLUGIN_CHECK_PATTERN="${CHANNEL_PROVIDER}"
 if ! claude plugin list 2>/dev/null | grep -q "$PLUGIN_CHECK_PATTERN"; then
-  echo -e "  ${RED}✗${NC} ${CHANNEL_PROVIDER} plugin nincs telepitve."
+  echo -e "  ${RED}✗${NC} ${CHANNEL_PROVIDER} plugin nincs telepítve."
   echo -e "  ${BOLD}Javitas:${NC} claude plugin install ${PLUGIN_ID}"
   echo -e "  ${DIM}Utana: ./scripts/stop.sh && ./scripts/start.sh${NC}"
 else
@@ -692,7 +692,7 @@ fi
 echo ""
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""
-echo -e "${BOLD}${GREEN}  ✓ Marveen sikeresen telepitve!${NC}"
+echo -e "${BOLD}${GREEN}  ✓ Marveen sikeresen telepítve!${NC}"
 echo ""
 
 # Read dashboard token for access URL

--- a/src/__tests__/channel-provider.test.ts
+++ b/src/__tests__/channel-provider.test.ts
@@ -32,7 +32,7 @@ describe('getProvider', () => {
   it('returns slack provider with correct pluginId', () => {
     const p = getProvider('slack')
     expect(p.type).toBe('slack')
-    expect(p.pluginId).toBe('slack@jeremylongshore/claude-code-slack-channel')
+    expect(p.pluginId).toBe('slack-channel@marveen-marketplace')
     expect(p.envKeys).toContain('SLACK_BOT_TOKEN')
     expect(p.stateDir).toBe('slack')
   })

--- a/src/__tests__/managed-settings.test.ts
+++ b/src/__tests__/managed-settings.test.ts
@@ -1,54 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { execSync } from 'node:child_process'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import {
+  isManagedSettingsReady,
+  getManagedSettingsSudoCommand,
+  setAgentEnabledPlugins,
+  resetAgentEnabledPlugins,
+} from '../web/routes/agents.js'
 
 const SLACK_ENTRY = { plugin: 'slack-channel', marketplace: 'marveen-marketplace' }
 const TELEGRAM_ENTRY = { plugin: 'telegram', marketplace: 'claude-plugins-official' }
-
-function isManagedSettingsReady(path: string): boolean {
-  if (!existsSync(path)) return false
-  try {
-    const data = JSON.parse(readFileSync(path, 'utf-8')) as {
-      allowedChannelPlugins?: Array<{ plugin: string; marketplace: string }>
-    }
-    const plugins = data.allowedChannelPlugins ?? []
-    return plugins.some(
-      p => p.plugin === SLACK_ENTRY.plugin && p.marketplace === SLACK_ENTRY.marketplace
-    )
-  } catch {
-    return false
-  }
-}
-
-function setAgentEnabledPlugins(
-  settingsPath: string,
-  provider: 'slack' | 'telegram'
-): void {
-  const dir = join(settingsPath, '..')
-  mkdirSync(dir, { recursive: true })
-  let existing: Record<string, unknown> = {}
-  if (existsSync(settingsPath)) {
-    try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
-  }
-  const plugins = (existing.enabledPlugins ?? {}) as Record<string, boolean>
-  if (provider === 'slack') {
-    plugins['telegram@claude-plugins-official'] = false
-  } else {
-    plugins['slack-channel@marveen-marketplace'] = false
-  }
-  existing.enabledPlugins = plugins
-  writeFileSync(settingsPath, JSON.stringify(existing, null, 2))
-}
-
-function resetAgentEnabledPlugins(settingsPath: string): void {
-  if (!existsSync(settingsPath)) return
-  try {
-    const existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>
-    delete existing.enabledPlugins
-    writeFileSync(settingsPath, JSON.stringify(existing, null, 2))
-  } catch { /* corrupt */ }
-}
 
 let tmpDir: string
 
@@ -61,76 +24,174 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
-describe('isManagedSettingsReady', () => {
+describe('isManagedSettingsReady (algorithm)', () => {
+  function check(path: string): boolean {
+    if (!existsSync(path)) return false
+    try {
+      const data = JSON.parse(readFileSync(path, 'utf-8')) as {
+        allowedChannelPlugins?: Array<{ plugin: string; marketplace: string }>
+      }
+      const plugins = data.allowedChannelPlugins ?? []
+      return plugins.some(
+        p => p.plugin === SLACK_ENTRY.plugin && p.marketplace === SLACK_ENTRY.marketplace
+      )
+    } catch {
+      return false
+    }
+  }
+
   it('returns false when file does not exist', () => {
-    expect(isManagedSettingsReady(join(tmpDir, 'nonexistent.json'))).toBe(false)
+    expect(check(join(tmpDir, 'nonexistent.json'))).toBe(false)
   })
 
   it('returns false when file has no allowedChannelPlugins', () => {
     const p = join(tmpDir, 'managed.json')
     writeFileSync(p, '{}')
-    expect(isManagedSettingsReady(p)).toBe(false)
+    expect(check(p)).toBe(false)
   })
 
   it('returns false when slack entry is missing', () => {
     const p = join(tmpDir, 'managed.json')
     writeFileSync(p, JSON.stringify({ allowedChannelPlugins: [TELEGRAM_ENTRY] }))
-    expect(isManagedSettingsReady(p)).toBe(false)
+    expect(check(p)).toBe(false)
   })
 
   it('returns true when slack entry is present', () => {
     const p = join(tmpDir, 'managed.json')
     writeFileSync(p, JSON.stringify({ allowedChannelPlugins: [SLACK_ENTRY, TELEGRAM_ENTRY] }))
-    expect(isManagedSettingsReady(p)).toBe(true)
+    expect(check(p)).toBe(true)
   })
 
   it('returns false on corrupt JSON', () => {
     const p = join(tmpDir, 'managed.json')
     writeFileSync(p, 'not json')
-    expect(isManagedSettingsReady(p)).toBe(false)
+    expect(check(p)).toBe(false)
   })
 })
 
-describe('setAgentEnabledPlugins', () => {
+describe('getManagedSettingsSudoCommand merge logic', () => {
+  function runMerge(existingContent: string | null, targetPath: string): Record<string, unknown> {
+    const cmd = getManagedSettingsSudoCommand()
+    const pipeIdx = cmd.indexOf('|')
+    const echoAndPayload = cmd.slice(0, pipeIdx).trim()
+    const pythonPart = cmd.slice(pipeIdx + 1).trim()
+    const innerMatch = pythonPart.match(/python3 -c '(.+?)' \|/)
+    if (!innerMatch) throw new Error('Could not parse python script from command')
+    const script = innerMatch[1]
+      .replace(new RegExp('/Library/Application Support/ClaudeCode/managed-settings\\.json', 'g'), targetPath)
+      .replace(/; /g, '\n')
+
+    if (existingContent !== null) writeFileSync(targetPath, existingContent)
+
+    const payloadMatch = echoAndPayload.match(/echo '(.+)'/)
+    if (!payloadMatch) throw new Error('Could not extract payload')
+
+    const result = execSync(`echo '${payloadMatch[1]}' | python3 -c "${script.replace(/"/g, '\\"')}"`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+    })
+    return JSON.parse(result)
+  }
+
+  it('creates fresh config when file does not exist', () => {
+    const p = join(tmpDir, 'managed.json')
+    const result = runMerge(null, p)
+    expect(result.allowedChannelPlugins).toHaveLength(2)
+  })
+
+  it('merges into existing config preserving other keys', () => {
+    const p = join(tmpDir, 'managed.json')
+    const existing = JSON.stringify({ customKey: 'keep', allowedChannelPlugins: [] })
+    const result = runMerge(existing, p)
+    expect(result.customKey).toBe('keep')
+    expect(result.allowedChannelPlugins).toHaveLength(2)
+  })
+
+  it('is idempotent (running twice yields same result)', () => {
+    const p = join(tmpDir, 'managed.json')
+    const first = runMerge(null, p)
+    writeFileSync(p, JSON.stringify(first, null, 2))
+    const second = runMerge(JSON.stringify(first, null, 2), p)
+    expect(second.allowedChannelPlugins).toHaveLength(2)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+
+  it('does not duplicate existing entries', () => {
+    const p = join(tmpDir, 'managed.json')
+    const existing = JSON.stringify({
+      allowedChannelPlugins: [SLACK_ENTRY],
+    })
+    const result = runMerge(existing, p)
+    const slackEntries = (result.allowedChannelPlugins as Array<{plugin: string}>).filter(
+      e => e.plugin === 'slack-channel'
+    )
+    expect(slackEntries).toHaveLength(1)
+    expect(result.allowedChannelPlugins).toHaveLength(2)
+  })
+})
+
+describe('setAgentEnabledPlugins (algorithm)', () => {
+  function set(settingsPath: string, provider: 'slack' | 'telegram'): void {
+    const dir = join(settingsPath, '..')
+    mkdirSync(dir, { recursive: true })
+    let existing: Record<string, unknown> = {}
+    if (existsSync(settingsPath)) {
+      try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
+    }
+    const plugins = (existing.enabledPlugins ?? {}) as Record<string, boolean>
+    if (provider === 'slack') {
+      plugins['telegram@claude-plugins-official'] = false
+    } else {
+      plugins['slack-channel@marveen-marketplace'] = false
+    }
+    existing.enabledPlugins = plugins
+    writeFileSync(settingsPath, JSON.stringify(existing, null, 2))
+  }
+
   it('disables telegram when provider is slack', () => {
-    const settingsDir = join(tmpDir, '.claude')
-    mkdirSync(settingsDir, { recursive: true })
-    const p = join(settingsDir, 'settings.json')
-    setAgentEnabledPlugins(p, 'slack')
+    const p = join(tmpDir, '.claude', 'settings.json')
+    set(p, 'slack')
     const data = JSON.parse(readFileSync(p, 'utf-8'))
     expect(data.enabledPlugins['telegram@claude-plugins-official']).toBe(false)
     expect(data.enabledPlugins['slack-channel@marveen-marketplace']).toBeUndefined()
   })
 
   it('disables slack when provider is telegram', () => {
-    const settingsDir = join(tmpDir, '.claude')
-    mkdirSync(settingsDir, { recursive: true })
-    const p = join(settingsDir, 'settings.json')
-    setAgentEnabledPlugins(p, 'telegram')
+    const p = join(tmpDir, '.claude', 'settings.json')
+    set(p, 'telegram')
     const data = JSON.parse(readFileSync(p, 'utf-8'))
     expect(data.enabledPlugins['slack-channel@marveen-marketplace']).toBe(false)
     expect(data.enabledPlugins['telegram@claude-plugins-official']).toBeUndefined()
   })
 
   it('preserves existing settings', () => {
-    const settingsDir = join(tmpDir, '.claude')
-    mkdirSync(settingsDir, { recursive: true })
-    const p = join(settingsDir, 'settings.json')
+    const dir = join(tmpDir, '.claude')
+    mkdirSync(dir, { recursive: true })
+    const p = join(dir, 'settings.json')
     writeFileSync(p, JSON.stringify({ existingKey: 'value' }))
-    setAgentEnabledPlugins(p, 'slack')
+    set(p, 'slack')
     const data = JSON.parse(readFileSync(p, 'utf-8'))
     expect(data.existingKey).toBe('value')
     expect(data.enabledPlugins['telegram@claude-plugins-official']).toBe(false)
   })
 })
 
-describe('resetAgentEnabledPlugins', () => {
+describe('resetAgentEnabledPlugins (algorithm)', () => {
+  function reset(settingsPath: string): void {
+    if (!existsSync(settingsPath)) return
+    try {
+      const existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>
+      delete existing.enabledPlugins
+      writeFileSync(settingsPath, JSON.stringify(existing, null, 2))
+    } catch { /* corrupt */ }
+  }
+
   it('removes enabledPlugins key', () => {
-    const settingsDir = join(tmpDir, '.claude')
-    mkdirSync(settingsDir, { recursive: true })
-    const p = join(settingsDir, 'settings.json')
+    const dir = join(tmpDir, '.claude')
+    mkdirSync(dir, { recursive: true })
+    const p = join(dir, 'settings.json')
     writeFileSync(p, JSON.stringify({ enabledPlugins: { 'foo': true }, other: 1 }))
-    resetAgentEnabledPlugins(p)
+    reset(p)
     const data = JSON.parse(readFileSync(p, 'utf-8'))
     expect(data.enabledPlugins).toBeUndefined()
     expect(data.other).toBe(1)
@@ -138,6 +199,6 @@ describe('resetAgentEnabledPlugins', () => {
 
   it('is a no-op when file does not exist', () => {
     const p = join(tmpDir, 'nonexistent.json')
-    expect(() => resetAgentEnabledPlugins(p)).not.toThrow()
+    expect(() => reset(p)).not.toThrow()
   })
 })

--- a/src/__tests__/managed-settings.test.ts
+++ b/src/__tests__/managed-settings.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const SLACK_ENTRY = { plugin: 'slack-channel', marketplace: 'marveen-marketplace' }
+const TELEGRAM_ENTRY = { plugin: 'telegram', marketplace: 'claude-plugins-official' }
+
+function isManagedSettingsReady(path: string): boolean {
+  if (!existsSync(path)) return false
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf-8')) as {
+      allowedChannelPlugins?: Array<{ plugin: string; marketplace: string }>
+    }
+    const plugins = data.allowedChannelPlugins ?? []
+    return plugins.some(
+      p => p.plugin === SLACK_ENTRY.plugin && p.marketplace === SLACK_ENTRY.marketplace
+    )
+  } catch {
+    return false
+  }
+}
+
+function setAgentEnabledPlugins(
+  settingsPath: string,
+  provider: 'slack' | 'telegram'
+): void {
+  const dir = join(settingsPath, '..')
+  mkdirSync(dir, { recursive: true })
+  let existing: Record<string, unknown> = {}
+  if (existsSync(settingsPath)) {
+    try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
+  }
+  const plugins = (existing.enabledPlugins ?? {}) as Record<string, boolean>
+  if (provider === 'slack') {
+    plugins['telegram@claude-plugins-official'] = false
+  } else {
+    plugins['slack-channel@marveen-marketplace'] = false
+  }
+  existing.enabledPlugins = plugins
+  writeFileSync(settingsPath, JSON.stringify(existing, null, 2))
+}
+
+function resetAgentEnabledPlugins(settingsPath: string): void {
+  if (!existsSync(settingsPath)) return
+  try {
+    const existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>
+    delete existing.enabledPlugins
+    writeFileSync(settingsPath, JSON.stringify(existing, null, 2))
+  } catch { /* corrupt */ }
+}
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `managed-settings-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(tmpDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('isManagedSettingsReady', () => {
+  it('returns false when file does not exist', () => {
+    expect(isManagedSettingsReady(join(tmpDir, 'nonexistent.json'))).toBe(false)
+  })
+
+  it('returns false when file has no allowedChannelPlugins', () => {
+    const p = join(tmpDir, 'managed.json')
+    writeFileSync(p, '{}')
+    expect(isManagedSettingsReady(p)).toBe(false)
+  })
+
+  it('returns false when slack entry is missing', () => {
+    const p = join(tmpDir, 'managed.json')
+    writeFileSync(p, JSON.stringify({ allowedChannelPlugins: [TELEGRAM_ENTRY] }))
+    expect(isManagedSettingsReady(p)).toBe(false)
+  })
+
+  it('returns true when slack entry is present', () => {
+    const p = join(tmpDir, 'managed.json')
+    writeFileSync(p, JSON.stringify({ allowedChannelPlugins: [SLACK_ENTRY, TELEGRAM_ENTRY] }))
+    expect(isManagedSettingsReady(p)).toBe(true)
+  })
+
+  it('returns false on corrupt JSON', () => {
+    const p = join(tmpDir, 'managed.json')
+    writeFileSync(p, 'not json')
+    expect(isManagedSettingsReady(p)).toBe(false)
+  })
+})
+
+describe('setAgentEnabledPlugins', () => {
+  it('disables telegram when provider is slack', () => {
+    const settingsDir = join(tmpDir, '.claude')
+    mkdirSync(settingsDir, { recursive: true })
+    const p = join(settingsDir, 'settings.json')
+    setAgentEnabledPlugins(p, 'slack')
+    const data = JSON.parse(readFileSync(p, 'utf-8'))
+    expect(data.enabledPlugins['telegram@claude-plugins-official']).toBe(false)
+    expect(data.enabledPlugins['slack-channel@marveen-marketplace']).toBeUndefined()
+  })
+
+  it('disables slack when provider is telegram', () => {
+    const settingsDir = join(tmpDir, '.claude')
+    mkdirSync(settingsDir, { recursive: true })
+    const p = join(settingsDir, 'settings.json')
+    setAgentEnabledPlugins(p, 'telegram')
+    const data = JSON.parse(readFileSync(p, 'utf-8'))
+    expect(data.enabledPlugins['slack-channel@marveen-marketplace']).toBe(false)
+    expect(data.enabledPlugins['telegram@claude-plugins-official']).toBeUndefined()
+  })
+
+  it('preserves existing settings', () => {
+    const settingsDir = join(tmpDir, '.claude')
+    mkdirSync(settingsDir, { recursive: true })
+    const p = join(settingsDir, 'settings.json')
+    writeFileSync(p, JSON.stringify({ existingKey: 'value' }))
+    setAgentEnabledPlugins(p, 'slack')
+    const data = JSON.parse(readFileSync(p, 'utf-8'))
+    expect(data.existingKey).toBe('value')
+    expect(data.enabledPlugins['telegram@claude-plugins-official']).toBe(false)
+  })
+})
+
+describe('resetAgentEnabledPlugins', () => {
+  it('removes enabledPlugins key', () => {
+    const settingsDir = join(tmpDir, '.claude')
+    mkdirSync(settingsDir, { recursive: true })
+    const p = join(settingsDir, 'settings.json')
+    writeFileSync(p, JSON.stringify({ enabledPlugins: { 'foo': true }, other: 1 }))
+    resetAgentEnabledPlugins(p)
+    const data = JSON.parse(readFileSync(p, 'utf-8'))
+    expect(data.enabledPlugins).toBeUndefined()
+    expect(data.other).toBe(1)
+  })
+
+  it('is a no-op when file does not exist', () => {
+    const p = join(tmpDir, 'nonexistent.json')
+    expect(() => resetAgentEnabledPlugins(p)).not.toThrow()
+  })
+})

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -130,7 +130,7 @@ export function formatForSlackMrkdwn(text: string): string {
 
 const slackProvider: ChannelProvider = {
   type: 'slack',
-  pluginId: 'slack@jeremylongshore/claude-code-slack-channel',
+  pluginId: 'slack-channel@marveen-marketplace',
   envKeys: ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN'],
   stateDir: 'slack',
   chatIdFormat: 'Slack channel/DM ID (e.g. C01234ABCDE)',

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -106,13 +106,15 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     const continueFlag = hasPriorSession ? '--continue ' : ''
     const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : 'TELEGRAM_STATE_DIR'
     const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN'
+    // Slack plugin is third-party; its "not on approved allowlist" check is
+    // bypassed via `allowedChannelPlugins` in ~/.claude/settings.json.
     const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}" && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }
     )
 
-    logger.info({ name, session, tgStateDir }, 'Agent tmux session started')
+    logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')
 
     // After a restart with --continue, a session that's been idle for >24h
     // shows the "Resume from summary" modal before the prompt input is ready

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -107,7 +107,7 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : 'TELEGRAM_STATE_DIR'
     const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN'
     // Slack plugin is third-party; its "not on approved allowlist" check is
-    // bypassed via `allowedChannelPlugins` in ~/.claude/settings.json.
+    // bypassed via `allowedChannelPlugins` in /Library/Application Support/ClaudeCode/managed-settings.json.
     const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}" && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -101,7 +101,7 @@ const MANAGED_SETTINGS_PATH = platform() === 'darwin'
   : '/etc/claude-code/managed-settings.json'
 const SLACK_ALLOWLIST_ENTRY = { plugin: 'slack-channel', marketplace: 'marveen-marketplace' }
 
-function isManagedSettingsReady(): boolean {
+export function isManagedSettingsReady(): boolean {
   if (!existsSync(MANAGED_SETTINGS_PATH)) return false
   try {
     const data = JSON.parse(readFileSync(MANAGED_SETTINGS_PATH, 'utf-8')) as {
@@ -116,7 +116,7 @@ function isManagedSettingsReady(): boolean {
   }
 }
 
-function getManagedSettingsSudoCommand(): string {
+export function getManagedSettingsSudoCommand(): string {
   const mergeScript = [
     'import json, sys',
     'new_plugins = json.loads(sys.stdin.read())["allowedChannelPlugins"]',
@@ -139,7 +139,7 @@ function getManagedSettingsSudoCommand(): string {
   return `echo '${payload}' | sudo python3 -c '${mergeScript}' | sudo tee "${MANAGED_SETTINGS_PATH}" > /dev/null`
 }
 
-function setAgentEnabledPlugins(name: string, provider: ChannelProviderType): void {
+export function setAgentEnabledPlugins(name: string, provider: ChannelProviderType): void {
   const settingsDir = join(agentDir(name), '.claude')
   const settingsPath = join(settingsDir, 'settings.json')
   mkdirSync(settingsDir, { recursive: true })
@@ -157,7 +157,7 @@ function setAgentEnabledPlugins(name: string, provider: ChannelProviderType): vo
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
 }
 
-function resetAgentEnabledPlugins(name: string): void {
+export function resetAgentEnabledPlugins(name: string): void {
   const settingsPath = join(agentDir(name), '.claude', 'settings.json')
   if (!existsSync(settingsPath)) return
   try {

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync } from 'node:fs'
 import { join, extname } from 'node:path'
-import { homedir } from 'node:os'
+import { homedir, platform } from 'node:os'
 import { execSync } from 'node:child_process'
 import { logger } from '../../logger.js'
 import { MAIN_AGENT_ID, BOT_NAME } from '../../config.js'
@@ -96,7 +96,9 @@ function matchChannelRoute(path: string, suffix: string): [string, ChannelProvid
   return null
 }
 
-const MANAGED_SETTINGS_PATH = '/Library/Application Support/ClaudeCode/managed-settings.json'
+const MANAGED_SETTINGS_PATH = platform() === 'darwin'
+  ? '/Library/Application Support/ClaudeCode/managed-settings.json'
+  : '/etc/claude-code/managed-settings.json'
 const SLACK_ALLOWLIST_ENTRY = { plugin: 'slack-channel', marketplace: 'marveen-marketplace' }
 
 function isManagedSettingsReady(): boolean {
@@ -115,13 +117,26 @@ function isManagedSettingsReady(): boolean {
 }
 
 function getManagedSettingsSudoCommand(): string {
+  const mergeScript = [
+    'import json, sys',
+    'new_plugins = json.loads(sys.stdin.read())["allowedChannelPlugins"]',
+    'try:',
+    `  with open("${MANAGED_SETTINGS_PATH}") as f: data = json.load(f)`,
+    'except: data = {}',
+    'existing = data.get("allowedChannelPlugins", [])',
+    'for e in new_plugins:',
+    '  if not any(p.get("plugin")==e["plugin"] and p.get("marketplace")==e["marketplace"] for p in existing):',
+    '    existing.append(e)',
+    'data["allowedChannelPlugins"] = existing',
+    'print(json.dumps(data, indent=2))',
+  ].join('; ')
   const payload = JSON.stringify({
     allowedChannelPlugins: [
       SLACK_ALLOWLIST_ENTRY,
       { plugin: 'telegram', marketplace: 'claude-plugins-official' },
     ],
   })
-  return `echo '${payload}' | sudo tee "${MANAGED_SETTINGS_PATH}"`
+  return `echo '${payload}' | sudo python3 -c '${mergeScript}' | sudo tee "${MANAGED_SETTINGS_PATH}" > /dev/null`
 }
 
 function setAgentEnabledPlugins(name: string, provider: ChannelProviderType): void {
@@ -140,6 +155,16 @@ function setAgentEnabledPlugins(name: string, provider: ChannelProviderType): vo
   }
   existing.enabledPlugins = plugins
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
+}
+
+function resetAgentEnabledPlugins(name: string): void {
+  const settingsPath = join(agentDir(name), '.claude', 'settings.json')
+  if (!existsSync(settingsPath)) return
+  try {
+    const existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>
+    delete existing.enabledPlugins
+    atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
+  } catch { /* settings corrupt, nothing to reset */ }
 }
 
 function resolveAccessPath(name: string, provider: ChannelProviderType): string {
@@ -444,6 +469,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (existsSync(envFile)) unlinkSync(envFile)
     if (existsSync(accessFile)) unlinkSync(accessFile)
     writeAgentChannelProvider(name, '')
+    resetAgentEnabledPlugins(name)
     json(res, { ok: true })
     return true
   }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync } from 'node:fs'
 import { join, extname } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync } from 'node:child_process'
@@ -94,6 +94,52 @@ function matchChannelRoute(path: string, suffix: string): [string, ChannelProvid
   const legacyMatch = path.match(legacyPattern)
   if (legacyMatch) return [decodeURIComponent(legacyMatch[1]), 'telegram']
   return null
+}
+
+const MANAGED_SETTINGS_PATH = '/Library/Application Support/ClaudeCode/managed-settings.json'
+const SLACK_ALLOWLIST_ENTRY = { plugin: 'slack-channel', marketplace: 'marveen-marketplace' }
+
+function isManagedSettingsReady(): boolean {
+  if (!existsSync(MANAGED_SETTINGS_PATH)) return false
+  try {
+    const data = JSON.parse(readFileSync(MANAGED_SETTINGS_PATH, 'utf-8')) as {
+      allowedChannelPlugins?: Array<{ plugin: string; marketplace: string }>
+    }
+    const plugins = data.allowedChannelPlugins ?? []
+    return plugins.some(
+      p => p.plugin === SLACK_ALLOWLIST_ENTRY.plugin && p.marketplace === SLACK_ALLOWLIST_ENTRY.marketplace
+    )
+  } catch {
+    return false
+  }
+}
+
+function getManagedSettingsSudoCommand(): string {
+  const payload = JSON.stringify({
+    allowedChannelPlugins: [
+      SLACK_ALLOWLIST_ENTRY,
+      { plugin: 'telegram', marketplace: 'claude-plugins-official' },
+    ],
+  })
+  return `echo '${payload}' | sudo tee "${MANAGED_SETTINGS_PATH}"`
+}
+
+function setAgentEnabledPlugins(name: string, provider: ChannelProviderType): void {
+  const settingsDir = join(agentDir(name), '.claude')
+  const settingsPath = join(settingsDir, 'settings.json')
+  mkdirSync(settingsDir, { recursive: true })
+  let existing: Record<string, unknown> = {}
+  if (existsSync(settingsPath)) {
+    try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
+  }
+  const plugins = (existing.enabledPlugins ?? {}) as Record<string, boolean>
+  if (provider === 'slack') {
+    plugins['telegram@claude-plugins-official'] = false
+  } else {
+    plugins['slack-channel@marveen-marketplace'] = false
+  }
+  existing.enabledPlugins = plugins
+  atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
 }
 
 function resolveAccessPath(name: string, provider: ChannelProviderType): string {
@@ -345,6 +391,14 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const validation = await channelProvider.validateToken(botToken.trim())
     if (!validation.ok) { json(res, { error: validation.error || 'Invalid token' }, 400); return true }
 
+    if (provider === 'slack' && !isManagedSettingsReady()) {
+      json(res, {
+        error: 'managed-settings-missing',
+        sudoCommand: getManagedSettingsSudoCommand(),
+      }, 409)
+      return true
+    }
+
     const stateDir = channelStateDir(provider, agentDir(name))
     mkdirSync(stateDir, { recursive: true })
     const tokenKey = provider === 'slack' ? 'SLACK_BOT_TOKEN' : 'TELEGRAM_BOT_TOKEN'
@@ -361,6 +415,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     }, null, 2))
 
     writeAgentChannelProvider(name, provider)
+    setAgentEnabledPlugins(name, provider)
 
     if (provider === 'telegram') sendWelcomeMessage(name, botToken.trim()).catch(() => {})
 

--- a/web/app.js
+++ b/web/app.js
@@ -1404,8 +1404,15 @@ document.getElementById('chConnectBtn').addEventListener('click', async () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     })
-    if (!res.ok) {
+    if (res.status === 409) {
       const err = await res.json()
+      if (err.error === 'managed-settings-missing') {
+        showSudoModal(err.sudoCommand)
+        return
+      }
+    }
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
       throw new Error(err.error || 'Kapcsolodasi hiba')
     }
     const result = await res.json()
@@ -6160,3 +6167,44 @@ document.getElementById('deepseekConfigLink')?.addEventListener('click', (e) => 
   e.preventDefault()
   switchPage('vault')
 })
+
+// === Sudo modal for managed-settings.json (Slack setup pre-flight) ===
+function showSudoModal(sudoCommand) {
+  let overlay = document.getElementById('sudoModalOverlay')
+  if (overlay) overlay.remove()
+  overlay = document.createElement('div')
+  overlay.id = 'sudoModalOverlay'
+  overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:9999;display:flex;align-items:center;justify-content:center'
+  const card = document.createElement('div')
+  card.style.cssText = 'background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:24px;max-width:560px;width:90%'
+  card.innerHTML = `
+    <h3 style="margin:0 0 12px">Rendszerszintű beállítás szükséges</h3>
+    <p style="font-size:13px;color:var(--text-muted);margin:0 0 16px">
+      A Claude Code megköveteli, hogy a Slack channel plugin engedélyezve legyen a rendszerszintű managed-settings.json fájlban.
+      Futtasd az alábbi parancsot a Terminálban:
+    </p>
+    <div style="position:relative">
+      <pre id="sudoCmdPre" style="background:var(--bg-main);border:1px solid var(--border);border-radius:8px;padding:12px;font-size:12px;overflow-x:auto;white-space:pre-wrap;word-break:break-all">${escapeHtml(sudoCommand)}</pre>
+      <button id="sudoCopyBtn" style="position:absolute;top:6px;right:6px;padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--border);background:var(--bg-card);cursor:pointer">Másolás</button>
+    </div>
+    <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:16px">
+      <button id="sudoCancelBtn" class="btn btn-secondary" style="padding:6px 16px;font-size:13px">Mégse</button>
+      <button id="sudoDoneBtn" class="btn btn-primary" style="padding:6px 16px;font-size:13px">Kész, újrapróbálom</button>
+    </div>
+  `
+  overlay.appendChild(card)
+  document.body.appendChild(overlay)
+
+  document.getElementById('sudoCopyBtn').addEventListener('click', () => {
+    navigator.clipboard.writeText(sudoCommand).then(() => {
+      document.getElementById('sudoCopyBtn').textContent = 'Másolva!'
+      setTimeout(() => { document.getElementById('sudoCopyBtn').textContent = 'Másolás' }, 1500)
+    })
+  })
+  document.getElementById('sudoCancelBtn').addEventListener('click', () => overlay.remove())
+  document.getElementById('sudoDoneBtn').addEventListener('click', () => {
+    overlay.remove()
+    document.getElementById('chConnectBtn').click()
+  })
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove() })
+}

--- a/web/app.js
+++ b/web/app.js
@@ -1342,8 +1342,8 @@ function updateProviderUI() {
     if (input) input.placeholder = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11'
     if (slackGroup) slackGroup.hidden = true
   } else {
-    if (title) title.textContent = 'Slack app bekotese'
-    if (steps) steps.innerHTML = '<li>Hozz letre egy Slack App-ot a <strong>api.slack.com/apps</strong> oldalon</li><li>Engedeld a Socket Mode-ot es a szukseges scope-okat</li><li>Masold be a Bot Token-t (xoxb-...) es az App Token-t (xapp-...)</li>'
+    if (title) title.textContent = 'Slack app bekötése'
+    if (steps) steps.innerHTML = '<li>Hozz létre egy Slack App-ot a <strong>api.slack.com/apps</strong> oldalon</li><li>Engedélyezd a Socket Mode-ot és a szükséges scope-okat</li><li>Másold be a Bot Token-t (xoxb-...) és az App Token-t (xapp-...)</li>'
     if (label) label.textContent = 'Bot Token (xoxb-...)'
     if (input) input.placeholder = 'xoxb-...'
     if (slackGroup) slackGroup.hidden = false
@@ -4365,7 +4365,7 @@ async function loadGitHubRepos() {
     addBtn.textContent = 'Telepites...'
     status.hidden = false
     status.className = 'github-repo-status loading'
-    status.textContent = 'Klonozas es telepites...'
+    status.textContent = 'Klónozás és telepítés...'
     try {
       const res = await fetch('/api/connectors/github-repos', {
         method: 'POST',
@@ -4380,7 +4380,7 @@ async function loadGitHubRepos() {
       }
       if (data.requiredEnvVars && data.requiredEnvVars.length > 0) {
         status.className = 'github-repo-status loading'
-        status.textContent = 'API kulcsok megadasa szukseges...'
+        status.textContent = 'API kulcsok megadása szükséges...'
         const envValues = await showEnvVarModal(data.requiredEnvVars)
         if (envValues && Object.keys(envValues).length > 0) {
           for (const [key, value] of Object.entries(envValues)) {


### PR DESCRIPTION
## Summary

- **install.sh**: Idempotent managed-settings.json setup with sudo when Slack provider is chosen (system-level `allowedChannelPlugins` required by Claude Code 2.1.143+)
- **agents.ts**: Channel setup returns 409 with `sudoCommand` when Slack managed-settings is missing; on success, disables non-chosen plugin in agent project settings (prevents Socket Mode duplicate connections and Telegram lockfight)
- **channel-provider.ts**: Slack pluginId updated to `slack-channel@marveen-marketplace`
- **.claude/settings.json**: Committed to repo with slack-channel disabled by default
- **web/app.js**: 409 handler shows sudo modal with copy-to-clipboard + retry

## Test plan

- [ ] Fresh install with Slack provider: verify managed-settings.json creation prompt
- [ ] Dashboard Slack channel setup on agent without managed-settings: verify 409 modal
- [ ] After running sudo command: verify retry succeeds
- [ ] Verify agent project-level settings.json has non-chosen plugin set to false
- [ ] All 405 tests pass

Generated with [Claude Code](https://claude.com/claude-code)