### PR TITLE
feat(slack): channel request workflow with audit log watcher

### DIFF
--- a/src/__tests__/channel-request.test.ts
+++ b/src/__tests__/channel-request.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import {
+  initDatabase,
+  getDb,
+  upsertChannelRequest,
+  listPendingChannelRequests,
+  updateChannelRequestStatus,
+  updateChannelRequestName,
+} from '../db.js'
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test'
+  initDatabase()
+})
+
+beforeEach(() => {
+  getDb().exec("DELETE FROM pending_channel_requests")
+})
+
+describe('upsertChannelRequest', () => {
+  it('inserts a new pending request', () => {
+    expect(upsertChannelRequest('test-agent', 'C123', 'U456')).toBe(true)
+    const rows = listPendingChannelRequests('test-agent')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].channel_id).toBe('C123')
+    expect(rows[0].user_id).toBe('U456')
+    expect(rows[0].status).toBe('pending')
+  })
+
+  it('deduplicates pending requests for same agent+channel', () => {
+    upsertChannelRequest('test-agent', 'C123')
+    expect(upsertChannelRequest('test-agent', 'C123')).toBe(false)
+    expect(listPendingChannelRequests('test-agent')).toHaveLength(1)
+  })
+
+  it('allows same channel for different agents', () => {
+    upsertChannelRequest('agent-a', 'C123')
+    expect(upsertChannelRequest('agent-b', 'C123')).toBe(true)
+  })
+
+  it('blocks re-entry for recently denied channels (7-day window)', () => {
+    upsertChannelRequest('test-agent', 'C123')
+    const rows = listPendingChannelRequests('test-agent')
+    updateChannelRequestStatus(rows[0].id, 'denied')
+    expect(upsertChannelRequest('test-agent', 'C123')).toBe(false)
+  })
+
+  it('allows re-entry for denied channels after 7 days', () => {
+    upsertChannelRequest('test-agent', 'C123')
+    const rows = listPendingChannelRequests('test-agent')
+    updateChannelRequestStatus(rows[0].id, 'denied')
+    const eightDaysAgo = Math.floor(Date.now() / 1000) - 8 * 86400
+    getDb().prepare('UPDATE pending_channel_requests SET resolved_at = ? WHERE id = ?').run(eightDaysAgo, rows[0].id)
+    expect(upsertChannelRequest('test-agent', 'C123')).toBe(true)
+  })
+
+  it('allows re-entry for approved channels (new pending)', () => {
+    upsertChannelRequest('test-agent', 'C123')
+    const rows = listPendingChannelRequests('test-agent')
+    updateChannelRequestStatus(rows[0].id, 'approved')
+    expect(upsertChannelRequest('test-agent', 'C123')).toBe(true)
+  })
+})
+
+describe('updateChannelRequestStatus', () => {
+  it('sets resolved_at when approving', () => {
+    upsertChannelRequest('test-agent', 'C123')
+    const rows = listPendingChannelRequests('test-agent')
+    updateChannelRequestStatus(rows[0].id, 'approved')
+    const row = getDb().prepare('SELECT resolved_at, status FROM pending_channel_requests WHERE id = ?').get(rows[0].id) as { resolved_at: number; status: string }
+    expect(row.status).toBe('approved')
+    expect(row.resolved_at).toBeGreaterThan(0)
+  })
+
+  it('sets resolved_at when denying', () => {
+    upsertChannelRequest('test-agent', 'C123')
+    const rows = listPendingChannelRequests('test-agent')
+    updateChannelRequestStatus(rows[0].id, 'denied')
+    const row = getDb().prepare('SELECT resolved_at, status FROM pending_channel_requests WHERE id = ?').get(rows[0].id) as { resolved_at: number; status: string }
+    expect(row.status).toBe('denied')
+    expect(row.resolved_at).toBeGreaterThan(0)
+  })
+
+  it('returns false for non-existent id', () => {
+    expect(updateChannelRequestStatus(99999, 'approved')).toBe(false)
+  })
+
+  it('returns false for already resolved request', () => {
+    upsertChannelRequest('test-agent', 'C123')
+    const rows = listPendingChannelRequests('test-agent')
+    updateChannelRequestStatus(rows[0].id, 'denied')
+    expect(updateChannelRequestStatus(rows[0].id, 'approved')).toBe(false)
+  })
+})
+
+describe('updateChannelRequestName', () => {
+  it('sets channel name on existing request', () => {
+    upsertChannelRequest('test-agent', 'C123')
+    const rows = listPendingChannelRequests('test-agent')
+    updateChannelRequestName(rows[0].id, 'general')
+    const updated = listPendingChannelRequests('test-agent')
+    expect(updated[0].channel_name).toBe('general')
+  })
+})
+
+describe('audit log parsing (algorithm)', () => {
+  it('parses gate.inbound.drop with botMentioned', () => {
+    const line = '{"type":"gate.inbound.drop","reason":"channel-not-allowed","channel":"C123","user":"U456","botMentioned":true}'
+    const entry = JSON.parse(line) as { type?: string; reason?: string; channel?: string; user?: string; botMentioned?: boolean }
+    expect(entry.type).toBe('gate.inbound.drop')
+    expect(entry.reason).toBe('channel-not-allowed')
+    expect(entry.botMentioned).toBe(true)
+    expect(entry.channel).toBe('C123')
+  })
+
+  it('ignores lines without botMentioned', () => {
+    const line = '{"type":"gate.inbound.drop","reason":"channel-not-allowed","channel":"C123"}'
+    const entry = JSON.parse(line) as { botMentioned?: boolean }
+    expect(entry.botMentioned).toBeUndefined()
+  })
+
+  it('handles malformed JSON gracefully', () => {
+    expect(() => JSON.parse('not json')).toThrow()
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -1110,9 +1110,10 @@ export interface PendingChannelRequest {
 
 export function upsertChannelRequest(agent: string, channelId: string, userId?: string): boolean {
   const now = Math.floor(Date.now() / 1000)
+  const sevenDaysAgo = now - 7 * 86400
   const existing = db.prepare(
-    "SELECT id FROM pending_channel_requests WHERE agent = ? AND channel_id = ? AND status = 'pending'"
-  ).get(agent, channelId)
+    "SELECT id FROM pending_channel_requests WHERE agent = ? AND channel_id = ? AND (status = 'pending' OR (status = 'denied' AND requested_at > ?))"
+  ).get(agent, channelId, sevenDaysAgo)
   if (existing) return false
   db.prepare(
     'INSERT INTO pending_channel_requests (agent, channel_id, user_id, requested_at, status) VALUES (?, ?, ?, ?, ?)'

--- a/src/db.ts
+++ b/src/db.ts
@@ -296,6 +296,20 @@ export function initDatabase(): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_messages_status ON agent_messages(status, to_agent)`)
 
+  // --- Pending Channel Requests (Slack channel opt-in workflow) ---
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pending_channel_requests (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent TEXT NOT NULL,
+      channel_id TEXT NOT NULL,
+      channel_name TEXT,
+      user_id TEXT,
+      requested_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','approved','denied'))
+    )
+  `)
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_pcr_agent_channel ON pending_channel_requests(agent, channel_id) WHERE status = 'pending'`)
+
   // --- Task Run History ---
   // Log every scheduled-task firing so the dashboard overview's "tasksToday"
   // survives dashboard restarts. Replaces the old store/task-run-history.json
@@ -1080,4 +1094,44 @@ export async function backfillEmbeddings(): Promise<number> {
     await new Promise(r => setTimeout(r, 100))
   }
   return count
+}
+
+// --- Pending Channel Requests ---
+
+export interface PendingChannelRequest {
+  id: number
+  agent: string
+  channel_id: string
+  channel_name: string | null
+  user_id: string | null
+  requested_at: number
+  status: 'pending' | 'approved' | 'denied'
+}
+
+export function upsertChannelRequest(agent: string, channelId: string, userId?: string): boolean {
+  const now = Math.floor(Date.now() / 1000)
+  const existing = db.prepare(
+    "SELECT id FROM pending_channel_requests WHERE agent = ? AND channel_id = ? AND status = 'pending'"
+  ).get(agent, channelId)
+  if (existing) return false
+  db.prepare(
+    'INSERT INTO pending_channel_requests (agent, channel_id, user_id, requested_at, status) VALUES (?, ?, ?, ?, ?)'
+  ).run(agent, channelId, userId ?? null, now, 'pending')
+  return true
+}
+
+export function listPendingChannelRequests(agent: string): PendingChannelRequest[] {
+  return db.prepare(
+    "SELECT * FROM pending_channel_requests WHERE agent = ? AND status = 'pending' ORDER BY requested_at DESC"
+  ).all(agent) as PendingChannelRequest[]
+}
+
+export function updateChannelRequestStatus(id: number, status: 'approved' | 'denied'): boolean {
+  return db.prepare(
+    'UPDATE pending_channel_requests SET status = ? WHERE id = ? AND status = ?'
+  ).run(status, id, 'pending').changes > 0
+}
+
+export function updateChannelRequestName(id: number, channelName: string): void {
+  db.prepare('UPDATE pending_channel_requests SET channel_name = ? WHERE id = ?').run(channelName, id)
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -305,10 +305,12 @@ export function initDatabase(): void {
       channel_name TEXT,
       user_id TEXT,
       requested_at INTEGER NOT NULL,
+      resolved_at INTEGER,
       status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','approved','denied'))
     )
   `)
   db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_pcr_agent_channel ON pending_channel_requests(agent, channel_id) WHERE status = 'pending'`)
+  try { db.exec('ALTER TABLE pending_channel_requests ADD COLUMN resolved_at INTEGER') } catch { /* already exists */ }
 
   // --- Task Run History ---
   // Log every scheduled-task firing so the dashboard overview's "tasksToday"
@@ -1112,7 +1114,7 @@ export function upsertChannelRequest(agent: string, channelId: string, userId?: 
   const now = Math.floor(Date.now() / 1000)
   const sevenDaysAgo = now - 7 * 86400
   const existing = db.prepare(
-    "SELECT id FROM pending_channel_requests WHERE agent = ? AND channel_id = ? AND (status = 'pending' OR (status = 'denied' AND requested_at > ?))"
+    "SELECT id FROM pending_channel_requests WHERE agent = ? AND channel_id = ? AND (status = 'pending' OR (status = 'denied' AND COALESCE(resolved_at, requested_at) > ?))"
   ).get(agent, channelId, sevenDaysAgo)
   if (existing) return false
   db.prepare(
@@ -1128,9 +1130,10 @@ export function listPendingChannelRequests(agent: string): PendingChannelRequest
 }
 
 export function updateChannelRequestStatus(id: number, status: 'approved' | 'denied'): boolean {
+  const now = Math.floor(Date.now() / 1000)
   return db.prepare(
-    'UPDATE pending_channel_requests SET status = ? WHERE id = ? AND status = ?'
-  ).run(status, id, 'pending').changes > 0
+    'UPDATE pending_channel_requests SET status = ?, resolved_at = ? WHERE id = ? AND status = ?'
+  ).run(status, now, id, 'pending').changes > 0
 }
 
 export function updateChannelRequestName(id: number, channelName: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
 import { startInviteMonitor, stopInviteMonitor } from './web/channel-invites.js'
+import { startChannelRequestWatcher, stopChannelRequestWatcher } from './web/channel-request-watcher.js'
 import { AGENTS_BASE_DIR } from './web/agent-config.js'
 import {
   acquirePortLock,
@@ -344,6 +345,7 @@ const shutdown = (): void => {
       try { stopHeartbeat() } catch (err) { logger.warn({ err }, 'stopHeartbeat threw during shutdown') }
     }
     try { stopInviteMonitor() } catch (err) { logger.warn({ err }, 'stopInviteMonitor threw during shutdown') }
+    try { stopChannelRequestWatcher() } catch (err) { logger.warn({ err }, 'stopChannelRequestWatcher threw during shutdown') }
     if (decayInterval) clearInterval(decayInterval)
     if (digestTimer) clearTimeout(digestTimer)
     if (digestInterval) clearInterval(digestInterval)
@@ -433,6 +435,9 @@ async function main(): Promise<void> {
 
   // Telegram invite auto-approve monitor (one-click pairing).
   startInviteMonitor(MAIN_AGENT_ID, AGENTS_BASE_DIR)
+
+  // Slack channel request watcher (audit.jsonl -> pending_channel_requests).
+  startChannelRequestWatcher()
 
   // Web dashboard
   webServer = startWebServer(WEB_PORT)

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -108,7 +108,8 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN'
     // Slack plugin is third-party; its "not on approved allowlist" check is
     // bypassed via `allowedChannelPlugins` in /Library/Application Support/ClaudeCode/managed-settings.json.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}" && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
+    const auditLogEnv = agentProvider === 'slack' ? ` && export SLACK_AUDIT_LOG="${agentChannelDir}/audit.jsonl"` : ''
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}"${auditLogEnv} && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }

--- a/src/web/channel-request-watcher.ts
+++ b/src/web/channel-request-watcher.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { logger } from '../logger.js'
 import { CHANNEL_PROVIDER } from '../config.js'
@@ -51,12 +51,16 @@ function scanAuditLog(agent: string, auditPath: string): void {
   }
 }
 
-const channelNameCache = new Map<string, { name: string; ts: number }>()
+const channelNameCache = new Map<string, { name: string | null; ts: number }>()
 const CHANNEL_CACHE_TTL = 300_000
+const NEGATIVE_CACHE_TTL = 60_000
 
 async function lookupChannelName(agent: string, channelId: string): Promise<void> {
   const cached = channelNameCache.get(channelId)
-  if (cached && Date.now() - cached.ts < CHANNEL_CACHE_TTL) return
+  if (cached) {
+    const ttl = cached.name ? CHANNEL_CACHE_TTL : NEGATIVE_CACHE_TTL
+    if (Date.now() - cached.ts < ttl) return
+  }
 
   const provider = resolveAgentProvider(agent)
   if (provider !== 'slack') return
@@ -81,6 +85,7 @@ async function lookupChannelName(agent: string, channelId: string): Promise<void
       if (match) updateChannelRequestName(match.id, data.channel.name)
     }
   } catch (err) {
+    channelNameCache.set(channelId, { name: null, ts: Date.now() })
     logger.warn({ err, agent, channelId }, 'Failed to look up Slack channel name')
   }
 }
@@ -94,6 +99,9 @@ function runScanTick(): void {
     const auditPath = join(stateDir, 'audit.jsonl')
     activeAgents.add(auditPath)
     scanAuditLog(name, auditPath)
+    for (const req of listPendingChannelRequests(name)) {
+      if (!req.channel_name) lookupChannelName(name, req.channel_id).catch(() => {})
+    }
   }
   for (const key of fileOffsets.keys()) {
     if (!activeAgents.has(key)) fileOffsets.delete(key)

--- a/src/web/channel-request-watcher.ts
+++ b/src/web/channel-request-watcher.ts
@@ -26,12 +26,12 @@ const fileOffsets = new Map<string, number>()
 function scanAuditLog(agent: string, auditPath: string): void {
   if (!existsSync(auditPath)) return
 
-  const currentSize = readFileSync(auditPath).length
+  const buf = readFileSync(auditPath)
+  const currentSize = buf.length
   const lastOffset = fileOffsets.get(auditPath) ?? 0
   if (currentSize <= lastOffset) return
 
-  const content = readFileSync(auditPath, 'utf-8')
-  const newContent = content.slice(lastOffset)
+  const newContent = buf.subarray(lastOffset).toString('utf-8')
   fileOffsets.set(auditPath, currentSize)
 
   for (const line of newContent.split('\n')) {
@@ -51,7 +51,13 @@ function scanAuditLog(agent: string, auditPath: string): void {
   }
 }
 
+const channelNameCache = new Map<string, { name: string; ts: number }>()
+const CHANNEL_CACHE_TTL = 300_000
+
 async function lookupChannelName(agent: string, channelId: string): Promise<void> {
+  const cached = channelNameCache.get(channelId)
+  if (cached && Date.now() - cached.ts < CHANNEL_CACHE_TTL) return
+
   const provider = resolveAgentProvider(agent)
   if (provider !== 'slack') return
   const stateDir = channelStateDir(provider, agentDir(agent))
@@ -69,6 +75,7 @@ async function lookupChannelName(agent: string, channelId: string): Promise<void
     })
     const data = await resp.json() as { ok: boolean; channel?: { name: string } }
     if (data.ok && data.channel?.name) {
+      channelNameCache.set(channelId, { name: data.channel.name, ts: Date.now() })
       const pending = listPendingChannelRequests(agent)
       const match = pending.find(r => r.channel_id === channelId && !r.channel_name)
       if (match) updateChannelRequestName(match.id, data.channel.name)
@@ -79,12 +86,17 @@ async function lookupChannelName(agent: string, channelId: string): Promise<void
 }
 
 function runScanTick(): void {
+  const activeAgents = new Set<string>()
   for (const name of listAgentNames()) {
     const provider = resolveAgentProvider(name)
     if (provider !== 'slack') continue
     const stateDir = channelStateDir(provider, agentDir(name))
     const auditPath = join(stateDir, 'audit.jsonl')
+    activeAgents.add(auditPath)
     scanAuditLog(name, auditPath)
+  }
+  for (const key of fileOffsets.keys()) {
+    if (!activeAgents.has(key)) fileOffsets.delete(key)
   }
 }
 

--- a/src/web/channel-request-watcher.ts
+++ b/src/web/channel-request-watcher.ts
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { CHANNEL_PROVIDER } from '../config.js'
+import { channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
+import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
+import { upsertChannelRequest, listPendingChannelRequests, updateChannelRequestName } from '../db.js'
+
+function resolveAgentProvider(name: string): ChannelProviderType {
+  const perAgent = readAgentChannelProvider(name)
+  if (perAgent === 'slack' || perAgent === 'telegram') return perAgent
+  return CHANNEL_PROVIDER
+}
+
+interface AuditEntry {
+  type?: string
+  reason?: string
+  channel?: string
+  user?: string
+  ts?: string
+  botMentioned?: boolean
+}
+
+const fileOffsets = new Map<string, number>()
+
+function scanAuditLog(agent: string, auditPath: string): void {
+  if (!existsSync(auditPath)) return
+
+  const currentSize = readFileSync(auditPath).length
+  const lastOffset = fileOffsets.get(auditPath) ?? 0
+  if (currentSize <= lastOffset) return
+
+  const content = readFileSync(auditPath, 'utf-8')
+  const newContent = content.slice(lastOffset)
+  fileOffsets.set(auditPath, currentSize)
+
+  for (const line of newContent.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      const entry = JSON.parse(line) as AuditEntry
+      if (entry.type === 'gate.inbound.drop' && entry.reason === 'channel-not-allowed' && entry.botMentioned && entry.channel) {
+        const inserted = upsertChannelRequest(agent, entry.channel, entry.user)
+        if (inserted) {
+          logger.info({ agent, channel: entry.channel, user: entry.user }, 'New channel request from audit log')
+          lookupChannelName(agent, entry.channel).catch(() => {})
+        }
+      }
+    } catch {
+      // malformed line
+    }
+  }
+}
+
+async function lookupChannelName(agent: string, channelId: string): Promise<void> {
+  const provider = resolveAgentProvider(agent)
+  if (provider !== 'slack') return
+  const stateDir = channelStateDir(provider, agentDir(agent))
+  const token = readChannelToken(provider, join(stateDir, '.env'))
+  if (!token) return
+
+  try {
+    const resp = await fetch('https://slack.com/api/conversations.info', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: `channel=${encodeURIComponent(channelId)}`,
+    })
+    const data = await resp.json() as { ok: boolean; channel?: { name: string } }
+    if (data.ok && data.channel?.name) {
+      const pending = listPendingChannelRequests(agent)
+      const match = pending.find(r => r.channel_id === channelId && !r.channel_name)
+      if (match) updateChannelRequestName(match.id, data.channel.name)
+    }
+  } catch (err) {
+    logger.warn({ err, agent, channelId }, 'Failed to look up Slack channel name')
+  }
+}
+
+function runScanTick(): void {
+  for (const name of listAgentNames()) {
+    const provider = resolveAgentProvider(name)
+    if (provider !== 'slack') continue
+    const stateDir = channelStateDir(provider, agentDir(name))
+    const auditPath = join(stateDir, 'audit.jsonl')
+    scanAuditLog(name, auditPath)
+  }
+}
+
+let intervalId: ReturnType<typeof setInterval> | null = null
+
+export function startChannelRequestWatcher(intervalMs = 10_000): void {
+  if (intervalId) return
+  runScanTick()
+  intervalId = setInterval(runScanTick, intervalMs)
+  logger.info({ intervalMs }, 'Channel request watcher started')
+}
+
+export function stopChannelRequestWatcher(): void {
+  if (intervalId) {
+    clearInterval(intervalId)
+    intervalId = null
+  }
+}

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -812,7 +812,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
 
     const body = await readBody(req)
-    const opts = JSON.parse(body.toString()) as { requireMention?: boolean; allowFromAll?: boolean }
+    const opts = JSON.parse(body.toString() || '{}') as { requireMention?: boolean; allowFromAll?: boolean }
 
     const pending = listPendingChannelRequests(name)
     const request = pending.find(r => r.id === reqId)
@@ -823,7 +823,11 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
 
     const accessPath = resolveAccessPath(name, provider)
     try {
-      const access = existsSync(accessPath) ? JSON.parse(readFileSync(accessPath, 'utf-8')) : { dmPolicy: 'allowlist', allowFrom: [], groups: {} }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let access: any = { dmPolicy: 'allowlist', allowFrom: [], groups: {} }
+      if (existsSync(accessPath)) {
+        try { access = JSON.parse(readFileSync(accessPath, 'utf-8')) } catch { /* start fresh if corrupt */ }
+      }
       if (!access.channels) access.channels = {}
 
       const channelConfig: Record<string, unknown> = { requireMention: opts.requireMention !== false }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -4,7 +4,7 @@ import { homedir, platform } from 'node:os'
 import { execSync } from 'node:child_process'
 import { logger } from '../../logger.js'
 import { MAIN_AGENT_ID, BOT_NAME } from '../../config.js'
-import { createAgentMessage } from '../../db.js'
+import { createAgentMessage, listPendingChannelRequests, updateChannelRequestStatus } from '../../db.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { getSecret } from '../vault.js'
 import {
@@ -791,6 +791,67 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     } catch (err) {
       logger.error({ err }, 'Failed to remove allowlist entry')
       json(res, { error: 'Failed to remove allowlist entry' }, 500)
+    }
+    return true
+  }
+
+  // --- Channel Requests (Slack channel opt-in workflow) ---
+
+  const chReqListMatch = path.match(/^\/api\/agents\/([^/]+)\/channel-requests$/)
+  if (chReqListMatch && method === 'GET') {
+    const name = decodeURIComponent(chReqListMatch[1])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    json(res, listPendingChannelRequests(name))
+    return true
+  }
+
+  const chReqApproveMatch = path.match(/^\/api\/agents\/([^/]+)\/channel-requests\/(\d+)\/approve$/)
+  if (chReqApproveMatch && method === 'POST') {
+    const name = decodeURIComponent(chReqApproveMatch[1])
+    const reqId = Number(chReqApproveMatch[2])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+
+    const body = await readBody(req)
+    const opts = JSON.parse(body.toString()) as { requireMention?: boolean; allowFromAll?: boolean }
+
+    const pending = listPendingChannelRequests(name)
+    const request = pending.find(r => r.id === reqId)
+    if (!request) { json(res, { error: 'Request not found' }, 404); return true }
+
+    const provider = readAgentChannelProvider(name) as ChannelProviderType
+    if (provider !== 'slack') { json(res, { error: 'Only Slack agents support channel requests' }, 400); return true }
+
+    const accessPath = resolveAccessPath(name, provider)
+    try {
+      const access = existsSync(accessPath) ? JSON.parse(readFileSync(accessPath, 'utf-8')) : { dmPolicy: 'allowlist', allowFrom: [], groups: {} }
+      if (!access.channels) access.channels = {}
+
+      const channelConfig: Record<string, unknown> = { requireMention: opts.requireMention !== false }
+      if (!opts.allowFromAll && request.user_id) {
+        channelConfig.allowFrom = [request.user_id]
+      }
+      access.channels[request.channel_id] = channelConfig
+
+      atomicWriteFileSync(accessPath, JSON.stringify(access, null, 2))
+      updateChannelRequestStatus(reqId, 'approved')
+      logger.info({ name, channelId: request.channel_id, channelName: request.channel_name }, 'Channel request approved')
+      json(res, { ok: true })
+    } catch (err) {
+      logger.error({ err }, 'Failed to approve channel request')
+      json(res, { error: 'Failed to approve request' }, 500)
+    }
+    return true
+  }
+
+  const chReqDenyMatch = path.match(/^\/api\/agents\/([^/]+)\/channel-requests\/(\d+)\/deny$/)
+  if (chReqDenyMatch && method === 'POST') {
+    const name = decodeURIComponent(chReqDenyMatch[1])
+    const reqId = Number(chReqDenyMatch[2])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (updateChannelRequestStatus(reqId, 'denied')) {
+      json(res, { ok: true })
+    } else {
+      json(res, { error: 'Request not found or already resolved' }, 404)
     }
     return true
   }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync, renameSync } from 'node:fs'
 import { join, extname } from 'node:path'
 import { homedir, platform } from 'node:os'
 import { execSync } from 'node:child_process'
@@ -812,7 +812,8 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
 
     const body = await readBody(req)
-    const opts = JSON.parse(body.toString() || '{}') as { requireMention?: boolean; allowFromAll?: boolean }
+    let opts: { requireMention?: boolean; allowFromAll?: boolean } = {}
+    try { opts = JSON.parse(body.toString() || '{}') } catch { json(res, { error: 'Invalid JSON body' }, 400); return true }
 
     const pending = listPendingChannelRequests(name)
     const request = pending.find(r => r.id === reqId)
@@ -826,7 +827,13 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let access: any = { dmPolicy: 'allowlist', allowFrom: [], groups: {} }
       if (existsSync(accessPath)) {
-        try { access = JSON.parse(readFileSync(accessPath, 'utf-8')) } catch { /* start fresh if corrupt */ }
+        try {
+          access = JSON.parse(readFileSync(accessPath, 'utf-8'))
+        } catch (parseErr) {
+          const backupPath = `${accessPath}.corrupt-${Math.floor(Date.now() / 1000)}`
+          try { renameSync(accessPath, backupPath) } catch { /* best effort */ }
+          logger.warn({ parseErr, accessPath, backupPath }, 'Corrupt access.json backed up, starting fresh')
+        }
       }
       if (!access.channels) access.channels = {}
 

--- a/web/app.js
+++ b/web/app.js
@@ -1187,6 +1187,7 @@ function startChannelAutoPoll() {
     refreshPendingPairings()
     refreshAllowedList()
     refreshInvites()
+    refreshChannelRequests()
   }, 4000)
 }
 function stopChannelAutoPoll() {
@@ -1368,6 +1369,7 @@ function updateChannelTab(agent) {
     refreshPendingPairings()
     refreshAllowedList()
     refreshInvites()
+    refreshChannelRequests()
   }
 }
 
@@ -1650,6 +1652,76 @@ async function revokeInviteToken(token) {
 
 document.getElementById('chGenerateInviteBtn').addEventListener('click', generateInvite)
 document.getElementById('chRefreshInvitesBtn').addEventListener('click', refreshInvites)
+
+// --- Channel Requests (Slack channel opt-in) ---
+async function refreshChannelRequests() {
+  if (!currentAgent) return
+  const section = document.getElementById('chRequestSection')
+  const listEl = document.getElementById('chRequestList')
+  const badge = document.getElementById('chRequestBadge')
+  if (currentChannelProvider !== 'slack') {
+    section.hidden = true
+    return
+  }
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel-requests`)
+    if (!res.ok) { section.hidden = true; return }
+    const items = await res.json()
+    if (!items.length) {
+      section.hidden = true
+      badge.hidden = true
+      return
+    }
+    section.hidden = false
+    badge.hidden = false
+    badge.textContent = items.length
+    listEl.innerHTML = ''
+    for (const req of items) {
+      const item = document.createElement('div')
+      item.className = 'tg-allowed-item'
+      const name = req.channel_name ? escapeHtml(req.channel_name) : req.channel_id
+      const ts = new Date(req.requested_at * 1000).toLocaleString('hu-HU')
+      const userId = req.user_id ? `<span class="tg-allowed-id">user: ${escapeHtml(req.user_id)}</span>` : ''
+      item.innerHTML = `
+        <div class="tg-allowed-meta">
+          <span class="tg-allowed-kind tg-allowed-kind-group">#${name}</span>
+          ${userId}
+          <span class="tg-allowed-id" style="font-size:11px;color:var(--text-muted)">${ts}</span>
+        </div>
+        <div style="display:flex;gap:6px">
+          <button class="btn-primary btn-compact" data-approve="${req.id}" style="padding:4px 10px;font-size:11px;margin:0">Jóváhagyás</button>
+          <button class="btn-icon-danger" data-deny="${req.id}" title="Elutasítás">&times;</button>
+        </div>
+      `
+      item.querySelector('[data-approve]').addEventListener('click', () => approveChannelRequest(req.id))
+      item.querySelector('[data-deny]').addEventListener('click', () => denyChannelRequest(req.id))
+      listEl.appendChild(item)
+    }
+  } catch { section.hidden = true }
+}
+
+async function approveChannelRequest(id) {
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel-requests/${id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requireMention: true, allowFromAll: false }),
+    })
+    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || 'Hiba')
+    showToast('Csatorna jóváhagyva')
+    refreshChannelRequests()
+  } catch (err) { showToast(`Hiba: ${err.message}`) }
+}
+
+async function denyChannelRequest(id) {
+  if (!confirm('Biztosan elutasítod?')) return
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel-requests/${id}/deny`, { method: 'POST' })
+    if (!res.ok) throw new Error('Hiba')
+    showToast('Kérés elutasítva')
+    refreshChannelRequests()
+  } catch (err) { showToast(`Hiba: ${err.message}`) }
+}
 
 document.getElementById('chApproveBtn').addEventListener('click', async () => {
   const code = document.getElementById('chPairCode').value.trim()

--- a/web/index.html
+++ b/web/index.html
@@ -1172,6 +1172,11 @@
               </div>
               <button class="btn-secondary btn-compact" id="chRefreshPendingBtn" style="margin-top:10px; font-size:12px;">Várakozók frissítése</button>
             </div>
+            <div class="tg-allowed-section" id="chRequestSection" hidden>
+              <h4>Csatorna-kérések <span class="badge badge-warn" id="chRequestBadge" hidden>0</span></h4>
+              <p class="tg-pairing-info">Slack csatornák, amelyekben megemlítették a botot, de még nincsenek engedélyezve.</p>
+              <div id="chRequestList"></div>
+            </div>
             <div class="tg-connected-actions">
               <button class="btn-secondary" id="chTestBtn">Kapcsolat tesztelése</button>
               <button class="btn-danger" id="chDisconnectBtn">Leválasztás</button>


### PR DESCRIPTION
## Summary

- **Audit log watcher**: New `channel-request-watcher.ts` scans Slack agents' `audit.jsonl` every 10s for `gate.inbound.drop` events where the bot was @-mentioned in a non-allowed channel
- **DB table**: `pending_channel_requests` tracks channel ID, name (via Slack API lookup), requesting user, and approval status
- **API endpoints**: `GET/POST channel-requests` for listing pending + approving/denying; approve writes the channel into `access.json` with `requireMention` and optional `allowFrom` filter
- **Dashboard UI**: "Csatorna-kérések" section with badge count, approve/deny buttons, auto-refreshing in channel tab poll cycle
- **Agent launcher**: Exports `SLACK_AUDIT_LOG` env var for Slack agents to enable server-side journaling

## Test plan

- [ ] Start a Slack agent, @-mention it in a non-allowed channel
- [ ] Verify audit.jsonl entry appears in agent's channel state dir
- [ ] Verify pending request shows up in dashboard within 10s
- [ ] Approve request, verify access.json gets channel entry
- [ ] Deny request, verify it disappears from list
- [ ] All 405 tests pass

Generated with [Claude Code](https://claude.com/claude-code)