### PR TITLE
feat(channel-requests): approve modal with requireMention/allowFromAll toggles

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -296,6 +296,20 @@ export function initDatabase(): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_messages_status ON agent_messages(status, to_agent)`)
 
+  // --- Pending Channel Requests (Slack channel opt-in workflow) ---
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pending_channel_requests (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent TEXT NOT NULL,
+      channel_id TEXT NOT NULL,
+      channel_name TEXT,
+      user_id TEXT,
+      requested_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','approved','denied'))
+    )
+  `)
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_pcr_agent_channel ON pending_channel_requests(agent, channel_id) WHERE status = 'pending'`)
+
   // --- Task Run History ---
   // Log every scheduled-task firing so the dashboard overview's "tasksToday"
   // survives dashboard restarts. Replaces the old store/task-run-history.json
@@ -1080,4 +1094,44 @@ export async function backfillEmbeddings(): Promise<number> {
     await new Promise(r => setTimeout(r, 100))
   }
   return count
+}
+
+// --- Pending Channel Requests ---
+
+export interface PendingChannelRequest {
+  id: number
+  agent: string
+  channel_id: string
+  channel_name: string | null
+  user_id: string | null
+  requested_at: number
+  status: 'pending' | 'approved' | 'denied'
+}
+
+export function upsertChannelRequest(agent: string, channelId: string, userId?: string): boolean {
+  const now = Math.floor(Date.now() / 1000)
+  const existing = db.prepare(
+    "SELECT id FROM pending_channel_requests WHERE agent = ? AND channel_id = ? AND status = 'pending'"
+  ).get(agent, channelId)
+  if (existing) return false
+  db.prepare(
+    'INSERT INTO pending_channel_requests (agent, channel_id, user_id, requested_at, status) VALUES (?, ?, ?, ?, ?)'
+  ).run(agent, channelId, userId ?? null, now, 'pending')
+  return true
+}
+
+export function listPendingChannelRequests(agent: string): PendingChannelRequest[] {
+  return db.prepare(
+    "SELECT * FROM pending_channel_requests WHERE agent = ? AND status = 'pending' ORDER BY requested_at DESC"
+  ).all(agent) as PendingChannelRequest[]
+}
+
+export function updateChannelRequestStatus(id: number, status: 'approved' | 'denied'): boolean {
+  return db.prepare(
+    'UPDATE pending_channel_requests SET status = ? WHERE id = ? AND status = ?'
+  ).run(status, id, 'pending').changes > 0
+}
+
+export function updateChannelRequestName(id: number, channelName: string): void {
+  db.prepare('UPDATE pending_channel_requests SET channel_name = ? WHERE id = ?').run(channelName, id)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
 import { startInviteMonitor, stopInviteMonitor } from './web/channel-invites.js'
+import { startChannelRequestWatcher, stopChannelRequestWatcher } from './web/channel-request-watcher.js'
 import { AGENTS_BASE_DIR } from './web/agent-config.js'
 import {
   acquirePortLock,
@@ -344,6 +345,7 @@ const shutdown = (): void => {
       try { stopHeartbeat() } catch (err) { logger.warn({ err }, 'stopHeartbeat threw during shutdown') }
     }
     try { stopInviteMonitor() } catch (err) { logger.warn({ err }, 'stopInviteMonitor threw during shutdown') }
+    try { stopChannelRequestWatcher() } catch (err) { logger.warn({ err }, 'stopChannelRequestWatcher threw during shutdown') }
     if (decayInterval) clearInterval(decayInterval)
     if (digestTimer) clearTimeout(digestTimer)
     if (digestInterval) clearInterval(digestInterval)
@@ -433,6 +435,9 @@ async function main(): Promise<void> {
 
   // Telegram invite auto-approve monitor (one-click pairing).
   startInviteMonitor(MAIN_AGENT_ID, AGENTS_BASE_DIR)
+
+  // Slack channel request watcher (audit.jsonl -> pending_channel_requests).
+  startChannelRequestWatcher()
 
   // Web dashboard
   webServer = startWebServer(WEB_PORT)

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -106,13 +106,14 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     const continueFlag = hasPriorSession ? '--continue ' : ''
     const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : 'TELEGRAM_STATE_DIR'
     const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN'
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}" && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
+    const auditLogEnv = agentProvider === 'slack' ? ` && export SLACK_AUDIT_LOG="${agentChannelDir}/audit.jsonl"` : ''
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}"${auditLogEnv} && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }
     )
 
-    logger.info({ name, session, tgStateDir }, 'Agent tmux session started')
+    logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')
 
     // After a restart with --continue, a session that's been idle for >24h
     // shows the "Resume from summary" modal before the prompt input is ready

--- a/src/web/channel-request-watcher.ts
+++ b/src/web/channel-request-watcher.ts
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { CHANNEL_PROVIDER } from '../config.js'
+import { channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
+import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
+import { upsertChannelRequest, listPendingChannelRequests, updateChannelRequestName } from '../db.js'
+
+function resolveAgentProvider(name: string): ChannelProviderType {
+  const perAgent = readAgentChannelProvider(name)
+  if (perAgent === 'slack' || perAgent === 'telegram') return perAgent
+  return CHANNEL_PROVIDER
+}
+
+interface AuditEntry {
+  type?: string
+  reason?: string
+  channel?: string
+  user?: string
+  ts?: string
+  botMentioned?: boolean
+}
+
+const fileOffsets = new Map<string, number>()
+
+function scanAuditLog(agent: string, auditPath: string): void {
+  if (!existsSync(auditPath)) return
+
+  const currentSize = readFileSync(auditPath).length
+  const lastOffset = fileOffsets.get(auditPath) ?? 0
+  if (currentSize <= lastOffset) return
+
+  const content = readFileSync(auditPath, 'utf-8')
+  const newContent = content.slice(lastOffset)
+  fileOffsets.set(auditPath, currentSize)
+
+  for (const line of newContent.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      const entry = JSON.parse(line) as AuditEntry
+      if (entry.type === 'gate.inbound.drop' && entry.reason === 'channel-not-allowed' && entry.botMentioned && entry.channel) {
+        const inserted = upsertChannelRequest(agent, entry.channel, entry.user)
+        if (inserted) {
+          logger.info({ agent, channel: entry.channel, user: entry.user }, 'New channel request from audit log')
+          lookupChannelName(agent, entry.channel).catch(() => {})
+        }
+      }
+    } catch {
+      // malformed line
+    }
+  }
+}
+
+async function lookupChannelName(agent: string, channelId: string): Promise<void> {
+  const provider = resolveAgentProvider(agent)
+  if (provider !== 'slack') return
+  const stateDir = channelStateDir(provider, agentDir(agent))
+  const token = readChannelToken(provider, join(stateDir, '.env'))
+  if (!token) return
+
+  try {
+    const resp = await fetch('https://slack.com/api/conversations.info', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: `channel=${encodeURIComponent(channelId)}`,
+    })
+    const data = await resp.json() as { ok: boolean; channel?: { name: string } }
+    if (data.ok && data.channel?.name) {
+      const pending = listPendingChannelRequests(agent)
+      const match = pending.find(r => r.channel_id === channelId && !r.channel_name)
+      if (match) updateChannelRequestName(match.id, data.channel.name)
+    }
+  } catch (err) {
+    logger.warn({ err, agent, channelId }, 'Failed to look up Slack channel name')
+  }
+}
+
+function runScanTick(): void {
+  for (const name of listAgentNames()) {
+    const provider = resolveAgentProvider(name)
+    if (provider !== 'slack') continue
+    const stateDir = channelStateDir(provider, agentDir(name))
+    const auditPath = join(stateDir, 'audit.jsonl')
+    scanAuditLog(name, auditPath)
+  }
+}
+
+let intervalId: ReturnType<typeof setInterval> | null = null
+
+export function startChannelRequestWatcher(intervalMs = 10_000): void {
+  if (intervalId) return
+  runScanTick()
+  intervalId = setInterval(runScanTick, intervalMs)
+  logger.info({ intervalMs }, 'Channel request watcher started')
+}
+
+export function stopChannelRequestWatcher(): void {
+  if (intervalId) {
+    clearInterval(intervalId)
+    intervalId = null
+  }
+}

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1,10 +1,10 @@
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync } from 'node:fs'
 import { join, extname } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync } from 'node:child_process'
 import { logger } from '../../logger.js'
 import { MAIN_AGENT_ID, BOT_NAME } from '../../config.js'
-import { createAgentMessage } from '../../db.js'
+import { createAgentMessage, listPendingChannelRequests, updateChannelRequestStatus } from '../../db.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { getSecret } from '../vault.js'
 import {
@@ -710,6 +710,67 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     } catch (err) {
       logger.error({ err }, 'Failed to remove allowlist entry')
       json(res, { error: 'Failed to remove allowlist entry' }, 500)
+    }
+    return true
+  }
+
+  // --- Channel Requests (Slack channel opt-in workflow) ---
+
+  const chReqListMatch = path.match(/^\/api\/agents\/([^/]+)\/channel-requests$/)
+  if (chReqListMatch && method === 'GET') {
+    const name = decodeURIComponent(chReqListMatch[1])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    json(res, listPendingChannelRequests(name))
+    return true
+  }
+
+  const chReqApproveMatch = path.match(/^\/api\/agents\/([^/]+)\/channel-requests\/(\d+)\/approve$/)
+  if (chReqApproveMatch && method === 'POST') {
+    const name = decodeURIComponent(chReqApproveMatch[1])
+    const reqId = Number(chReqApproveMatch[2])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+
+    const body = await readBody(req)
+    const opts = JSON.parse(body.toString()) as { requireMention?: boolean; allowFromAll?: boolean }
+
+    const pending = listPendingChannelRequests(name)
+    const request = pending.find(r => r.id === reqId)
+    if (!request) { json(res, { error: 'Request not found' }, 404); return true }
+
+    const provider = readAgentChannelProvider(name) as ChannelProviderType
+    if (provider !== 'slack') { json(res, { error: 'Only Slack agents support channel requests' }, 400); return true }
+
+    const accessPath = resolveAccessPath(name, provider)
+    try {
+      const access = existsSync(accessPath) ? JSON.parse(readFileSync(accessPath, 'utf-8')) : { dmPolicy: 'allowlist', allowFrom: [], groups: {} }
+      if (!access.channels) access.channels = {}
+
+      const channelConfig: Record<string, unknown> = { requireMention: opts.requireMention !== false }
+      if (!opts.allowFromAll && request.user_id) {
+        channelConfig.allowFrom = [request.user_id]
+      }
+      access.channels[request.channel_id] = channelConfig
+
+      atomicWriteFileSync(accessPath, JSON.stringify(access, null, 2))
+      updateChannelRequestStatus(reqId, 'approved')
+      logger.info({ name, channelId: request.channel_id, channelName: request.channel_name }, 'Channel request approved')
+      json(res, { ok: true })
+    } catch (err) {
+      logger.error({ err }, 'Failed to approve channel request')
+      json(res, { error: 'Failed to approve request' }, 500)
+    }
+    return true
+  }
+
+  const chReqDenyMatch = path.match(/^\/api\/agents\/([^/]+)\/channel-requests\/(\d+)\/deny$/)
+  if (chReqDenyMatch && method === 'POST') {
+    const name = decodeURIComponent(chReqDenyMatch[1])
+    const reqId = Number(chReqDenyMatch[2])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (updateChannelRequestStatus(reqId, 'denied')) {
+      json(res, { ok: true })
+    } else {
+      json(res, { error: 'Request not found or already resolved' }, 404)
     }
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -1737,6 +1737,8 @@ async function submitApproveModal() {
 }
 
 async function denyChannelRequest(id, itemEl) {
+  if (itemEl?.dataset.denying) return
+  if (itemEl) itemEl.dataset.denying = '1'
   if (itemEl) itemEl.remove()
   try {
     const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel-requests/${id}/deny`, { method: 'POST' })
@@ -1749,10 +1751,18 @@ async function denyChannelRequest(id, itemEl) {
   }
 }
 
-document.getElementById('chApproveModalConfirm').addEventListener('click', submitApproveModal)
-document.getElementById('chApproveModalClose').addEventListener('click', () => { document.getElementById('chApproveModalOverlay').hidden = true })
-document.getElementById('chApproveModalCancel').addEventListener('click', () => { document.getElementById('chApproveModalOverlay').hidden = true })
-document.getElementById('chApproveModalOverlay').addEventListener('click', (e) => { if (e.target === e.currentTarget) e.currentTarget.hidden = true })
+;(function initApproveModal() {
+  function closeApproveModal() { document.getElementById('chApproveModalOverlay').hidden = true }
+  document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('chApproveModalConfirm').addEventListener('click', submitApproveModal)
+    document.getElementById('chApproveModalClose').addEventListener('click', closeApproveModal)
+    document.getElementById('chApproveModalCancel').addEventListener('click', closeApproveModal)
+    document.getElementById('chApproveModalOverlay').addEventListener('click', (e) => { if (e.target === e.currentTarget) closeApproveModal() })
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !document.getElementById('chApproveModalOverlay').hidden) closeApproveModal()
+    })
+  })
+})()
 
 document.getElementById('chApproveBtn').addEventListener('click', async () => {
   const code = document.getElementById('chPairCode').value.trim()

--- a/web/app.js
+++ b/web/app.js
@@ -1187,6 +1187,7 @@ function startChannelAutoPoll() {
     refreshPendingPairings()
     refreshAllowedList()
     refreshInvites()
+    refreshChannelRequests()
   }, 4000)
 }
 function stopChannelAutoPoll() {
@@ -1368,6 +1369,7 @@ function updateChannelTab(agent) {
     refreshPendingPairings()
     refreshAllowedList()
     refreshInvites()
+    refreshChannelRequests()
   }
 }
 
@@ -1643,6 +1645,76 @@ async function revokeInviteToken(token) {
 
 document.getElementById('chGenerateInviteBtn').addEventListener('click', generateInvite)
 document.getElementById('chRefreshInvitesBtn').addEventListener('click', refreshInvites)
+
+// --- Channel Requests (Slack channel opt-in) ---
+async function refreshChannelRequests() {
+  if (!currentAgent) return
+  const section = document.getElementById('chRequestSection')
+  const listEl = document.getElementById('chRequestList')
+  const badge = document.getElementById('chRequestBadge')
+  if (currentChannelProvider !== 'slack') {
+    section.hidden = true
+    return
+  }
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel-requests`)
+    if (!res.ok) { section.hidden = true; return }
+    const items = await res.json()
+    if (!items.length) {
+      section.hidden = true
+      badge.hidden = true
+      return
+    }
+    section.hidden = false
+    badge.hidden = false
+    badge.textContent = items.length
+    listEl.innerHTML = ''
+    for (const req of items) {
+      const item = document.createElement('div')
+      item.className = 'tg-allowed-item'
+      const name = req.channel_name ? escapeHtml(req.channel_name) : req.channel_id
+      const ts = new Date(req.requested_at * 1000).toLocaleString('hu-HU')
+      const userId = req.user_id ? `<span class="tg-allowed-id">user: ${escapeHtml(req.user_id)}</span>` : ''
+      item.innerHTML = `
+        <div class="tg-allowed-meta">
+          <span class="tg-allowed-kind tg-allowed-kind-group">#${name}</span>
+          ${userId}
+          <span class="tg-allowed-id" style="font-size:11px;color:var(--text-muted)">${ts}</span>
+        </div>
+        <div style="display:flex;gap:6px">
+          <button class="btn-primary btn-compact" data-approve="${req.id}" style="padding:4px 10px;font-size:11px;margin:0">Jóváhagyás</button>
+          <button class="btn-icon-danger" data-deny="${req.id}" title="Elutasítás">&times;</button>
+        </div>
+      `
+      item.querySelector('[data-approve]').addEventListener('click', () => approveChannelRequest(req.id))
+      item.querySelector('[data-deny]').addEventListener('click', () => denyChannelRequest(req.id))
+      listEl.appendChild(item)
+    }
+  } catch { section.hidden = true }
+}
+
+async function approveChannelRequest(id) {
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel-requests/${id}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requireMention: true, allowFromAll: false }),
+    })
+    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || 'Hiba')
+    showToast('Csatorna jóváhagyva')
+    refreshChannelRequests()
+  } catch (err) { showToast(`Hiba: ${err.message}`) }
+}
+
+async function denyChannelRequest(id) {
+  if (!confirm('Biztosan elutasítod?')) return
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel-requests/${id}/deny`, { method: 'POST' })
+    if (!res.ok) throw new Error('Hiba')
+    showToast('Kérés elutasítva')
+    refreshChannelRequests()
+  } catch (err) { showToast(`Hiba: ${err.message}`) }
+}
 
 document.getElementById('chApproveBtn').addEventListener('click', async () => {
   const code = document.getElementById('chPairCode').value.trim()

--- a/web/app.js
+++ b/web/app.js
@@ -1686,35 +1686,73 @@ async function refreshChannelRequests() {
           <button class="btn-icon-danger" data-deny="${req.id}" title="Elutasítás">&times;</button>
         </div>
       `
-      item.querySelector('[data-approve]').addEventListener('click', () => approveChannelRequest(req.id))
-      item.querySelector('[data-deny]').addEventListener('click', () => denyChannelRequest(req.id))
+      item.dataset.reqId = req.id
+      item.querySelector('[data-approve]').addEventListener('click', () => openApproveModal(req.id, req.channel_name || req.channel_id, req.user_id))
+      item.querySelector('[data-deny]').addEventListener('click', () => denyChannelRequest(req.id, item))
       listEl.appendChild(item)
     }
   } catch { section.hidden = true }
 }
 
-async function approveChannelRequest(id) {
+let _approveReqId = null
+
+function openApproveModal(id, channelName, userId) {
+  _approveReqId = id
+  const desc = document.getElementById('chApproveModalDesc')
+  const userNote = userId ? ` (kérő: ${escapeHtml(userId)})` : ''
+  desc.textContent = `#${escapeHtml(channelName)}${userNote} csatorna engedélyezési beállításai:`
+  document.getElementById('chApproveRequireMention').checked = true
+  document.getElementById('chApproveAllowFromAll').checked = false
+  document.getElementById('chApproveModalOverlay').hidden = false
+}
+
+async function submitApproveModal() {
+  const id = _approveReqId
+  if (!id) return
+  const requireMention = document.getElementById('chApproveRequireMention').checked
+  const allowFromAll = document.getElementById('chApproveAllowFromAll').checked
+  const confirmBtn = document.getElementById('chApproveModalConfirm')
+  confirmBtn.querySelector('.btn-text').hidden = true
+  confirmBtn.querySelector('.btn-loading').hidden = false
+  confirmBtn.disabled = true
   try {
     const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel-requests/${id}/approve`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ requireMention: true, allowFromAll: false }),
+      body: JSON.stringify({ requireMention, allowFromAll }),
     })
     if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || 'Hiba')
-    showToast('Csatorna jóváhagyva')
+    document.getElementById('chApproveModalOverlay').hidden = true
+    const item = document.querySelector(`[data-req-id="${id}"]`)
+    if (item) item.remove()
+    showToast('Csatorna engedélyezve')
     refreshChannelRequests()
-  } catch (err) { showToast(`Hiba: ${err.message}`) }
+  } catch (err) {
+    showToast(`Hiba: ${err.message}`)
+  } finally {
+    confirmBtn.querySelector('.btn-text').hidden = false
+    confirmBtn.querySelector('.btn-loading').hidden = true
+    confirmBtn.disabled = false
+  }
 }
 
-async function denyChannelRequest(id) {
-  if (!confirm('Biztosan elutasítod?')) return
+async function denyChannelRequest(id, itemEl) {
+  if (itemEl) itemEl.remove()
   try {
     const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel-requests/${id}/deny`, { method: 'POST' })
     if (!res.ok) throw new Error('Hiba')
     showToast('Kérés elutasítva')
     refreshChannelRequests()
-  } catch (err) { showToast(`Hiba: ${err.message}`) }
+  } catch (err) {
+    showToast(`Hiba: ${err.message}`)
+    refreshChannelRequests()
+  }
 }
+
+document.getElementById('chApproveModalConfirm').addEventListener('click', submitApproveModal)
+document.getElementById('chApproveModalClose').addEventListener('click', () => { document.getElementById('chApproveModalOverlay').hidden = true })
+document.getElementById('chApproveModalCancel').addEventListener('click', () => { document.getElementById('chApproveModalOverlay').hidden = true })
+document.getElementById('chApproveModalOverlay').addEventListener('click', (e) => { if (e.target === e.currentTarget) e.currentTarget.hidden = true })
 
 document.getElementById('chApproveBtn').addEventListener('click', async () => {
   const code = document.getElementById('chPairCode').value.trim()

--- a/web/index.html
+++ b/web/index.html
@@ -1172,6 +1172,11 @@
               </div>
               <button class="btn-secondary btn-compact" id="chRefreshPendingBtn" style="margin-top:10px; font-size:12px;">Várakozók frissítése</button>
             </div>
+            <div class="tg-allowed-section" id="chRequestSection" hidden>
+              <h4>Csatorna-kérések <span class="badge badge-warn" id="chRequestBadge" hidden>0</span></h4>
+              <p class="tg-pairing-info">Slack csatornák, amelyekben megemlítették a botot, de még nincsenek engedélyezve.</p>
+              <div id="chRequestList"></div>
+            </div>
             <div class="tg-connected-actions">
               <button class="btn-secondary" id="chTestBtn">Kapcsolat tesztelése</button>
               <button class="btn-danger" id="chDisconnectBtn">Leválasztás</button>

--- a/web/index.html
+++ b/web/index.html
@@ -1590,10 +1590,10 @@
   </div>
 
   <!-- Modal: Csatorna-kérés jóváhagyása -->
-  <div class="modal-overlay" id="chApproveModalOverlay" hidden>
+  <div class="modal-overlay" id="chApproveModalOverlay" hidden role="dialog" aria-modal="true" aria-labelledby="chApproveModalTitle">
     <div class="modal" style="max-width:420px">
       <div class="modal-header">
-        <h2>Csatorna engedélyezése</h2>
+        <h2 id="chApproveModalTitle">Csatorna engedélyezése</h2>
         <button class="modal-close" id="chApproveModalClose">&times;</button>
       </div>
       <div class="modal-body">

--- a/web/index.html
+++ b/web/index.html
@@ -1589,6 +1589,42 @@
     </div>
   </div>
 
+  <!-- Modal: Csatorna-kérés jóváhagyása -->
+  <div class="modal-overlay" id="chApproveModalOverlay" hidden>
+    <div class="modal" style="max-width:420px">
+      <div class="modal-header">
+        <h2>Csatorna engedélyezése</h2>
+        <button class="modal-close" id="chApproveModalClose">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p id="chApproveModalDesc" style="font-size:13px;color:var(--text-muted);margin-bottom:20px;"></p>
+        <div class="form-group" style="margin-bottom:14px;">
+          <label style="display:flex;align-items:center;justify-content:space-between;cursor:pointer;gap:12px;">
+            <span style="font-size:13px;line-height:1.4;"><strong>Csak @-tageléskor figyeljen</strong><br>
+              <span style="color:var(--text-muted);font-size:12px;">Az ügynök csak @-tagelt üzenetekre reagál</span>
+            </span>
+            <input type="checkbox" id="chApproveRequireMention" checked style="width:16px;height:16px;accent-color:var(--accent);flex-shrink:0;">
+          </label>
+        </div>
+        <div class="form-group" style="margin-bottom:4px;">
+          <label style="display:flex;align-items:center;justify-content:space-between;cursor:pointer;gap:12px;">
+            <span style="font-size:13px;line-height:1.4;"><strong>Bárkitől fogadjon</strong><br>
+              <span style="color:var(--text-muted);font-size:12px;">Ha ki van kapcsolva, csak a kérést indító felhasználótól fogad</span>
+            </span>
+            <input type="checkbox" id="chApproveAllowFromAll" style="width:16px;height:16px;accent-color:var(--accent);flex-shrink:0;">
+          </label>
+        </div>
+      </div>
+      <div class="modal-footer" style="display:flex;gap:8px;justify-content:flex-end;">
+        <button class="btn-secondary" id="chApproveModalCancel">Mégse</button>
+        <button class="btn-primary btn-compact" id="chApproveModalConfirm">
+          <span class="btn-text">Jóváhagyás</span>
+          <span class="btn-loading" hidden><span class="spinner"></span></span>
+        </button>
+      </div>
+    </div>
+  </div>
+
   <div class="toast" id="toast"></div>
 
   <script src="/app.js"></script>


### PR DESCRIPTION
## Summary

- **Approve modal** a hardcoded approve helyett: a "Jóváhagyás" gomb megnyit egy modalt két toggle-lal
  - *Csak @-tageléskor figyeljen* (requireMention, default: BE)
  - *Bárkitől fogadjon* (allowFromAll, default: KI — csak a kérést indító felhasználótól fogad)
- **Deny without confirm()**: közvetlen POST + "Kérés elutasítva" toast, nincs böngészős confirm dialog
- **Optimistic update deny**: a sor azonnal eltűnik deny esetén (optimistic). Approve esetén a sor csak sikeres API-válasz után tűnik el (biztonságosabb, nincs szükség rollback-re)
- Modal bezárul: backdrop kattintásra, Mégse gombra, Escape billentyűre, sikeres jóváhagyás után
- Deny double-click guard: `dataset.denying` flag megakadályozza a dupla POST-ot
- Accessibility: `role=dialog`, `aria-modal=true`, `aria-labelledby` a modal-overlay-en
- DOMContentLoaded: listener-ek init race ellen védve

## Test plan

- [ ] "Jóváhagyás" gomb → modal nyílik, requireMention BE, allowFromAll KI
- [ ] Toggle-ök átválthatók, Jóváhagy → POST `{requireMention, allowFromAll}` helyes értékekkel
- [ ] Sor csak sikeres API-válasz után tűnik el approve-nál, toast: "Csatorna engedélyezve"
- [ ] × gomb → sor azonnal eltűnik (optimistic), toast: "Kérés elutasítva", nincs confirm() dialóg
- [ ] Gyors dupla × klikk → csak egy POST megy el (denying guard)
- [ ] Backdrop, Mégse, Escape bezárja a modalt, POST nem megy
- [ ] screen reader: modal fókuszálható, role=dialog és aria-labelledby jelen van

🤖 Generated with [Claude Code](https://claude.com/claude-code)