### PR TITLE
feat(slack): app manifest YAML generator and setup modal

### DIFF
--- a/src/__tests__/slack-manifest.test.ts
+++ b/src/__tests__/slack-manifest.test.ts
@@ -37,9 +37,15 @@ describe('generateSlackAppManifest', () => {
     expect(yaml).toContain('is_enabled: true')
   })
 
-  it('handles special characters in app name', () => {
+  it('strips quotes and backslashes from app name for valid YAML', () => {
     const yaml = generateSlackAppManifest('My "Bot"')
-    expect(yaml).toContain('name: "My "Bot""')
+    expect(yaml).toContain('name: "My Bot"')
+    expect(yaml).toContain('display_name: "My Bot"')
+  })
+
+  it('strips backslashes from app name', () => {
+    const yaml = generateSlackAppManifest('Bot\\Name')
+    expect(yaml).toContain('name: "BotName"')
   })
 })
 

--- a/src/__tests__/slack-manifest.test.ts
+++ b/src/__tests__/slack-manifest.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { generateSlackAppManifest, getSlackAppSetupInstructions } from '../channel-provider.js'
+
+describe('generateSlackAppManifest', () => {
+  it('returns valid YAML with the app name', () => {
+    const yaml = generateSlackAppManifest('TestBot')
+    expect(yaml).toContain('name: "TestBot"')
+    expect(yaml).toContain('display_name: "TestBot"')
+  })
+
+  it('includes all required bot scopes', () => {
+    const yaml = generateSlackAppManifest('Bot')
+    for (const scope of [
+      'app_mentions:read', 'channels:history', 'channels:read',
+      'chat:write', 'files:read', 'files:write',
+      'groups:history', 'groups:read', 'im:history',
+      'im:read', 'im:write', 'reactions:write', 'users:read',
+    ]) {
+      expect(yaml).toContain(`- ${scope}`)
+    }
+  })
+
+  it('includes all required bot events', () => {
+    const yaml = generateSlackAppManifest('Bot')
+    for (const event of ['app_mention', 'message.channels', 'message.groups', 'message.im']) {
+      expect(yaml).toContain(`- ${event}`)
+    }
+  })
+
+  it('enables socket mode', () => {
+    const yaml = generateSlackAppManifest('Bot')
+    expect(yaml).toContain('socket_mode_enabled: true')
+  })
+
+  it('enables interactivity', () => {
+    const yaml = generateSlackAppManifest('Bot')
+    expect(yaml).toContain('is_enabled: true')
+  })
+
+  it('handles special characters in app name', () => {
+    const yaml = generateSlackAppManifest('My "Bot"')
+    expect(yaml).toContain('name: "My "Bot""')
+  })
+})
+
+describe('getSlackAppSetupInstructions', () => {
+  it('returns an array of steps', () => {
+    const steps = getSlackAppSetupInstructions()
+    expect(Array.isArray(steps)).toBe(true)
+    expect(steps.length).toBe(7)
+  })
+
+  it('mentions api.slack.com/apps', () => {
+    const steps = getSlackAppSetupInstructions()
+    expect(steps[0]).toContain('api.slack.com/apps')
+  })
+
+  it('mentions bot token (xoxb)', () => {
+    const steps = getSlackAppSetupInstructions()
+    const tokenStep = steps.find(s => s.includes('xoxb'))
+    expect(tokenStep).toBeDefined()
+  })
+
+  it('mentions app-level token (xapp)', () => {
+    const steps = getSlackAppSetupInstructions()
+    const tokenStep = steps.find(s => s.includes('xapp'))
+    expect(tokenStep).toBeDefined()
+  })
+
+  it('mentions connections:write scope', () => {
+    const steps = getSlackAppSetupInstructions()
+    const scopeStep = steps.find(s => s.includes('connections:write'))
+    expect(scopeStep).toBeDefined()
+  })
+})

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -223,6 +223,69 @@ const slackProvider: ChannelProvider = {
   splitMessage: (text) => splitMessage(text, SLACK_MAX_MESSAGE_LENGTH),
 }
 
+// -- Slack App manifest --
+
+const SLACK_BOT_SCOPES = [
+  'app_mentions:read',
+  'channels:history',
+  'channels:read',
+  'chat:write',
+  'files:read',
+  'files:write',
+  'groups:history',
+  'groups:read',
+  'im:history',
+  'im:read',
+  'im:write',
+  'reactions:write',
+  'users:read',
+]
+
+const SLACK_BOT_EVENTS = [
+  'app_mention',
+  'message.channels',
+  'message.groups',
+  'message.im',
+]
+
+export function generateSlackAppManifest(appName: string): string {
+  const scopes = SLACK_BOT_SCOPES.map(s => `        - ${s}`).join('\n')
+  const events = SLACK_BOT_EVENTS.map(e => `        - ${e}`).join('\n')
+  return [
+    'display_information:',
+    `  name: "${appName}"`,
+    'features:',
+    '  bot_user:',
+    `    display_name: "${appName}"`,
+    '    always_online: true',
+    'oauth_config:',
+    '  scopes:',
+    '    bot:',
+    scopes,
+    'settings:',
+    '  event_subscriptions:',
+    '    bot_events:',
+    events,
+    '  interactivity:',
+    '    is_enabled: true',
+    '  org_deploy_enabled: false',
+    '  socket_mode_enabled: true',
+    '  token_rotation_enabled: false',
+  ].join('\n')
+}
+
+export function getSlackAppSetupInstructions(): string[] {
+  return [
+    'Nyisd meg az api.slack.com/apps oldalt',
+    'Kattints a "Create New App" gombra, majd valaszd a "From an app manifest" lehetoseget',
+    'Valaszd ki a workspace-t ahova telepiteni szeretned',
+    'Valts YAML formatumra es illeszd be a manifestet',
+    'Kattints a "Create" gombra, majd az "Install to Workspace" gombra',
+    'Masold ki a Bot User OAuth Token-t (xoxb-...) a "OAuth & Permissions" oldalrol',
+    'Menj a "Basic Information" oldalra, "App-Level Tokens" szekcio, kattints a "Generate Token and Scopes" gombra, adj hozza a connections:write scope-ot, majd masold ki a tokent (xapp-...)',
+  ]
+}
+
 // -- Token resolution --
 
 export function getChannelToken(provider: ChannelProviderType, env: Record<string, string>): string {

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -249,14 +249,15 @@ const SLACK_BOT_EVENTS = [
 ]
 
 export function generateSlackAppManifest(appName: string): string {
+  const safeName = appName.replace(/["\\]/g, '')
   const scopes = SLACK_BOT_SCOPES.map(s => `        - ${s}`).join('\n')
   const events = SLACK_BOT_EVENTS.map(e => `        - ${e}`).join('\n')
   return [
     'display_information:',
-    `  name: "${appName}"`,
+    `  name: ${JSON.stringify(safeName)}`,
     'features:',
     '  bot_user:',
-    `    display_name: "${appName}"`,
+    `    display_name: ${JSON.stringify(safeName)}`,
     '    always_online: true',
     'oauth_config:',
     '  scopes:',
@@ -277,12 +278,12 @@ export function generateSlackAppManifest(appName: string): string {
 export function getSlackAppSetupInstructions(): string[] {
   return [
     'Nyisd meg az api.slack.com/apps oldalt',
-    'Kattints a "Create New App" gombra, majd valaszd a "From an app manifest" lehetoseget',
-    'Valaszd ki a workspace-t ahova telepiteni szeretned',
-    'Valts YAML formatumra es illeszd be a manifestet',
+    'Kattints a "Create New App" gombra, majd válaszd a "From an app manifest" lehetőséget',
+    'Válaszd ki a workspace-t ahova telepíteni szeretnéd',
+    'Válts YAML formátumra és illeszd be a manifestet',
     'Kattints a "Create" gombra, majd az "Install to Workspace" gombra',
-    'Masold ki a Bot User OAuth Token-t (xoxb-...) a "OAuth & Permissions" oldalrol',
-    'Menj a "Basic Information" oldalra, "App-Level Tokens" szekcio, kattints a "Generate Token and Scopes" gombra, adj hozza a connections:write scope-ot, majd masold ki a tokent (xapp-...)',
+    'Másold ki a Bot User OAuth Token-t (xoxb-...) a "OAuth & Permissions" oldalról',
+    'Menj a "Basic Information" oldalra, "App-Level Tokens" szekció, kattints a "Generate Token and Scopes" gombra, adj hozzá a connections:write scope-ot, majd másold ki a tokent (xapp-...)',
   ]
 }
 

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -51,6 +51,8 @@ import {
   getProvider,
   channelStateDir,
   readChannelToken,
+  generateSlackAppManifest,
+  getSlackAppSetupInstructions,
   type ChannelProviderType,
 } from '../../channel-provider.js'
 import {
@@ -386,6 +388,19 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     return true
   }
 
+  // GET /api/agents/:name/channels/slack/manifest
+  const manifestMatch = path.match(/^\/api\/agents\/([^/]+)\/channels\/slack\/manifest$/)
+  if (manifestMatch && method === 'GET') {
+    const name = decodeURIComponent(manifestMatch[1])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    const displayName = readAgentDisplayName(name) || name
+    json(res, {
+      manifest: generateSlackAppManifest(displayName),
+      instructions: getSlackAppSetupInstructions(),
+    })
+    return true
+  }
+
   // POST /api/agents/:name/channels/:provider/test (legacy: /telegram/test)
   const testMatch = matchChannelRoute(path, '/test')
   if (testMatch && method === 'POST') {
@@ -417,9 +432,12 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (!validation.ok) { json(res, { error: validation.error || 'Invalid token' }, 400); return true }
 
     if (provider === 'slack' && !isManagedSettingsReady()) {
+      const displayName = readAgentDisplayName(name) || name
       json(res, {
         error: 'managed-settings-missing',
         sudoCommand: getManagedSettingsSudoCommand(),
+        slackAppManifest: generateSlackAppManifest(displayName),
+        slackAppInstructions: getSlackAppSetupInstructions(),
       }, 409)
       return true
     }

--- a/web/app.js
+++ b/web/app.js
@@ -1335,6 +1335,7 @@ function updateProviderUI() {
   const label = document.getElementById('chTokenLabel')
   const input = document.getElementById('chTokenInput')
   const slackGroup = document.getElementById('chSlackAppTokenGroup')
+  const manifestBtnGroup = document.getElementById('chSlackManifestBtnGroup')
 
   if (isTg) {
     if (title) title.textContent = 'Telegram bot bekotese'
@@ -1342,12 +1343,14 @@ function updateProviderUI() {
     if (label) label.textContent = 'Bot API Token'
     if (input) input.placeholder = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11'
     if (slackGroup) slackGroup.hidden = true
+    if (manifestBtnGroup) manifestBtnGroup.hidden = true
   } else {
-    if (title) title.textContent = 'Slack app bekötése'
-    if (steps) steps.innerHTML = '<li>Hozz létre egy Slack App-ot a <strong>api.slack.com/apps</strong> oldalon</li><li>Engedélyezd a Socket Mode-ot és a szükséges scope-okat</li><li>Másold be a Bot Token-t (xoxb-...) és az App Token-t (xapp-...)</li>'
+    if (title) title.textContent = 'Slack app bekotese'
+    if (steps) steps.innerHTML = '<li>Hozz letre egy Slack App-ot, vagy hasznald a manifest gombot lent</li><li>Masold be a Bot Token-t (xoxb-...) es az App Token-t (xapp-...)</li>'
     if (label) label.textContent = 'Bot Token (xoxb-...)'
     if (input) input.placeholder = 'xoxb-...'
     if (slackGroup) slackGroup.hidden = false
+    if (manifestBtnGroup) manifestBtnGroup.hidden = false
   }
 }
 
@@ -6328,3 +6331,64 @@ function showSudoModal(sudoCommand) {
   })
   overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove() })
 }
+
+// === Slack App manifest modal ===
+function showSlackManifestModal(manifest, instructions) {
+  let overlay = document.getElementById('slackManifestOverlay')
+  if (overlay) overlay.remove()
+  overlay = document.createElement('div')
+  overlay.id = 'slackManifestOverlay'
+  overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:9999;display:flex;align-items:center;justify-content:center'
+  const card = document.createElement('div')
+  card.style.cssText = 'background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:24px;max-width:640px;width:95%;max-height:85vh;overflow-y:auto'
+
+  const stepsHtml = instructions.map((s, i) => `<li style="margin-bottom:6px">${escapeHtml(s)}</li>`).join('')
+
+  card.innerHTML = `
+    <h3 style="margin:0 0 16px">Slack App letrehozasa</h3>
+    <p style="font-size:13px;color:var(--text-muted);margin:0 0 12px">
+      Illeszd be az alabbi YAML manifestet a Slack App letrehozasakor.
+      Ez automatikusan beallitja az osszes szukseges scope-ot, esemenyt es a Socket Mode-ot.
+    </p>
+    <div style="position:relative;margin-bottom:16px">
+      <pre id="slackManifestPre" style="background:var(--bg-main);border:1px solid var(--border);border-radius:8px;padding:12px;font-size:12px;overflow-x:auto;white-space:pre-wrap;word-break:break-all;max-height:240px;overflow-y:auto">${escapeHtml(manifest)}</pre>
+      <button id="slackManifestCopyBtn" style="position:absolute;top:6px;right:6px;padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--border);background:var(--bg-card);cursor:pointer">Masolas</button>
+    </div>
+    <h4 style="margin:0 0 8px;font-size:14px">Lepesek</h4>
+    <ol style="font-size:13px;padding-left:20px;margin:0 0 16px">${stepsHtml}</ol>
+    <div style="display:flex;gap:8px;justify-content:flex-end">
+      <button id="slackManifestCloseBtn" class="btn btn-secondary" style="padding:6px 16px;font-size:13px">Bezaras</button>
+      <a href="https://api.slack.com/apps" target="_blank" rel="noopener" class="btn btn-primary" style="padding:6px 16px;font-size:13px;text-decoration:none;display:inline-flex;align-items:center;gap:4px">
+        Megnyitas (api.slack.com)
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+      </a>
+    </div>
+  `
+  overlay.appendChild(card)
+  document.body.appendChild(overlay)
+
+  document.getElementById('slackManifestCopyBtn').addEventListener('click', () => {
+    navigator.clipboard.writeText(manifest).then(() => {
+      document.getElementById('slackManifestCopyBtn').textContent = 'Masolva!'
+      setTimeout(() => { document.getElementById('slackManifestCopyBtn').textContent = 'Masolas' }, 1500)
+    })
+  })
+  document.getElementById('slackManifestCloseBtn').addEventListener('click', () => overlay.remove())
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove() })
+}
+
+document.getElementById('chSlackManifestBtn').addEventListener('click', async () => {
+  if (!currentAgent) return
+  const btn = document.getElementById('chSlackManifestBtn')
+  btn.disabled = true
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channels/slack/manifest`)
+    if (!res.ok) throw new Error()
+    const data = await res.json()
+    showSlackManifestModal(data.manifest, data.instructions)
+  } catch {
+    showToast('Nem sikerult betolteni a manifestet')
+  } finally {
+    btn.disabled = false
+  }
+})

--- a/web/app.js
+++ b/web/app.js
@@ -1345,8 +1345,8 @@ function updateProviderUI() {
     if (slackGroup) slackGroup.hidden = true
     if (manifestBtnGroup) manifestBtnGroup.hidden = true
   } else {
-    if (title) title.textContent = 'Slack app bekotese'
-    if (steps) steps.innerHTML = '<li>Hozz letre egy Slack App-ot, vagy hasznald a manifest gombot lent</li><li>Masold be a Bot Token-t (xoxb-...) es az App Token-t (xapp-...)</li>'
+    if (title) title.textContent = 'Slack app bekötése'
+    if (steps) steps.innerHTML = '<li>Hozz létre egy Slack App-ot, vagy használd a manifest gombot lent</li><li>Másold be a Bot Token-t (xoxb-...) és az App Token-t (xapp-...)</li>'
     if (label) label.textContent = 'Bot Token (xoxb-...)'
     if (input) input.placeholder = 'xoxb-...'
     if (slackGroup) slackGroup.hidden = false
@@ -6332,6 +6332,27 @@ function showSudoModal(sudoCommand) {
   overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove() })
 }
 
+// === Clipboard fallback (non-secure context / legacy browser) ===
+function fallbackCopyToClipboard(text, btn) {
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.style.cssText = 'position:fixed;left:-9999px'
+  document.body.appendChild(ta)
+  ta.select()
+  try {
+    const ok = document.execCommand('copy')
+    if (ok) {
+      btn.textContent = 'Másolva!'
+      setTimeout(() => { btn.textContent = 'Másolás' }, 1500)
+    } else {
+      showToast('A vágólapra másolás nem sikerült')
+    }
+  } catch {
+    showToast('A vágólapra másolás nem sikerült')
+  }
+  document.body.removeChild(ta)
+}
+
 // === Slack App manifest modal ===
 function showSlackManifestModal(manifest, instructions) {
   let overlay = document.getElementById('slackManifestOverlay')
@@ -6345,21 +6366,21 @@ function showSlackManifestModal(manifest, instructions) {
   const stepsHtml = instructions.map((s, i) => `<li style="margin-bottom:6px">${escapeHtml(s)}</li>`).join('')
 
   card.innerHTML = `
-    <h3 style="margin:0 0 16px">Slack App letrehozasa</h3>
+    <h3 style="margin:0 0 16px">Slack App létrehozása</h3>
     <p style="font-size:13px;color:var(--text-muted);margin:0 0 12px">
-      Illeszd be az alabbi YAML manifestet a Slack App letrehozasakor.
-      Ez automatikusan beallitja az osszes szukseges scope-ot, esemenyt es a Socket Mode-ot.
+      Illeszd be az alábbi YAML manifestet a Slack App létrehozásakor.
+      Ez automatikusan beállítja az összes szükséges scope-ot, eseményt és a Socket Mode-ot.
     </p>
     <div style="position:relative;margin-bottom:16px">
       <pre id="slackManifestPre" style="background:var(--bg-main);border:1px solid var(--border);border-radius:8px;padding:12px;font-size:12px;overflow-x:auto;white-space:pre-wrap;word-break:break-all;max-height:240px;overflow-y:auto">${escapeHtml(manifest)}</pre>
-      <button id="slackManifestCopyBtn" style="position:absolute;top:6px;right:6px;padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--border);background:var(--bg-card);cursor:pointer">Masolas</button>
+      <button id="slackManifestCopyBtn" style="position:absolute;top:6px;right:6px;padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--border);background:var(--bg-card);cursor:pointer">Másolás</button>
     </div>
-    <h4 style="margin:0 0 8px;font-size:14px">Lepesek</h4>
+    <h4 style="margin:0 0 8px;font-size:14px">Lépések</h4>
     <ol style="font-size:13px;padding-left:20px;margin:0 0 16px">${stepsHtml}</ol>
     <div style="display:flex;gap:8px;justify-content:flex-end">
-      <button id="slackManifestCloseBtn" class="btn btn-secondary" style="padding:6px 16px;font-size:13px">Bezaras</button>
+      <button id="slackManifestCloseBtn" class="btn btn-secondary" style="padding:6px 16px;font-size:13px">Bezárás</button>
       <a href="https://api.slack.com/apps" target="_blank" rel="noopener" class="btn btn-primary" style="padding:6px 16px;font-size:13px;text-decoration:none;display:inline-flex;align-items:center;gap:4px">
-        Megnyitas (api.slack.com)
+        Megnyitás (api.slack.com)
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
       </a>
     </div>
@@ -6368,10 +6389,17 @@ function showSlackManifestModal(manifest, instructions) {
   document.body.appendChild(overlay)
 
   document.getElementById('slackManifestCopyBtn').addEventListener('click', () => {
-    navigator.clipboard.writeText(manifest).then(() => {
-      document.getElementById('slackManifestCopyBtn').textContent = 'Masolva!'
-      setTimeout(() => { document.getElementById('slackManifestCopyBtn').textContent = 'Masolas' }, 1500)
-    })
+    const copyBtn = document.getElementById('slackManifestCopyBtn')
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(manifest).then(() => {
+        copyBtn.textContent = 'Másolva!'
+        setTimeout(() => { copyBtn.textContent = 'Másolás' }, 1500)
+      }).catch(() => {
+        fallbackCopyToClipboard(manifest, copyBtn)
+      })
+    } else {
+      fallbackCopyToClipboard(manifest, copyBtn)
+    }
   })
   document.getElementById('slackManifestCloseBtn').addEventListener('click', () => overlay.remove())
   overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove() })
@@ -6387,7 +6415,7 @@ document.getElementById('chSlackManifestBtn').addEventListener('click', async ()
     const data = await res.json()
     showSlackManifestModal(data.manifest, data.instructions)
   } catch {
-    showToast('Nem sikerult betolteni a manifestet')
+    showToast('Nem sikerült betölteni a manifestet')
   } finally {
     btn.disabled = false
   }

--- a/web/index.html
+++ b/web/index.html
@@ -1093,10 +1093,10 @@
             </div>
             <div id="chSlackManifestBtnGroup" hidden style="margin-bottom:12px">
               <button class="btn btn-secondary" id="chSlackManifestBtn" style="font-size:13px;padding:6px 14px">
-                Slack App letrehozasa (manifest)
+                Slack App létrehozása (manifest)
               </button>
               <span id="chSlackManifestHint" style="font-size:12px;color:var(--text-muted);margin-left:8px">
-                Meg nincs Slack App-od? Kattints ide!
+                Még nincs Slack App-od? Kattints ide!
               </span>
             </div>
             <div class="form-group" id="chSlackAppTokenGroup" hidden>

--- a/web/index.html
+++ b/web/index.html
@@ -1091,6 +1091,14 @@
               <label for="chTokenInput" id="chTokenLabel">Bot API Token</label>
               <input type="text" id="chTokenInput" placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11">
             </div>
+            <div id="chSlackManifestBtnGroup" hidden style="margin-bottom:12px">
+              <button class="btn btn-secondary" id="chSlackManifestBtn" style="font-size:13px;padding:6px 14px">
+                Slack App letrehozasa (manifest)
+              </button>
+              <span id="chSlackManifestHint" style="font-size:12px;color:var(--text-muted);margin-left:8px">
+                Meg nincs Slack App-od? Kattints ide!
+              </span>
+            </div>
             <div class="form-group" id="chSlackAppTokenGroup" hidden>
               <label for="chSlackAppToken">App-Level Token (xapp-...)</label>
               <input type="text" id="chSlackAppToken" placeholder="xapp-1-...">


### PR DESCRIPTION
## Summary
- Adds `generateSlackAppManifest(appName)` that produces a ready-to-paste YAML manifest with all required bot scopes, events, Socket Mode, and interactivity pre-configured
- New `GET /api/agents/:name/channels/slack/manifest` endpoint serves the manifest + 7-step setup instructions
- 409 managed-settings-missing response now also includes the manifest and instructions
- Dashboard: "Slack App letrehozasa (manifest)" button + modal with copyable YAML, ordered steps, and direct link to api.slack.com/apps
- 11 new tests (slack-manifest.test.ts), 444 total green

## Test plan
- [ ] Open agent detail, switch to Slack provider, verify "Slack App letrehozasa" button appears
- [ ] Click button, verify modal shows correct YAML with agent display name
- [ ] Click "Masolas", verify clipboard contains the manifest YAML
- [ ] Click "Megnyitas (api.slack.com)" link, verify opens in new tab
- [ ] Switch to Telegram provider, verify manifest button is hidden
- [ ] Trigger 409 managed-settings-missing, verify response includes slackAppManifest and slackAppInstructions fields

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>