### PR TITLE
fix(agent): override pathToClaudeCodeExecutable on glibc Linux to avoid musl mismatch

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,7 @@
 import { query } from '@anthropic-ai/claude-agent-sdk'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { execSync } from 'node:child_process'
 import { PROJECT_ROOT } from './config.js'
 
 const TYPING_REFRESH_MS = 4000
@@ -12,6 +15,45 @@ const AGENT_TIMEOUT_MS = Number(process.env.MARVEEN_AGENT_TIMEOUT_MS) || 20 * 60
 // "Kész, létrehoztam" status instead of the markdown content, silently
 // corrupting the target file the caller goes on to write.
 const DEFAULT_DISALLOWED_TOOLS = ['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Bash', 'Task']
+
+// The bundled SDK's runtime libc detection picks the linux-x64-musl variant
+// even on glibc Ubuntu/Debian/RHEL hosts, so its native binary fails to
+// spawn ("ld-musl-* not found"). We pick the right subpackage ourselves and
+// forward its absolute path through pathToClaudeCodeExecutable.
+function detectLinuxLibc(): 'glibc' | 'musl' | 'unknown' {
+  if (process.platform !== 'linux') return 'unknown'
+  try {
+    const out = execSync('ldd --version 2>&1', { encoding: 'utf-8' })
+    return /musl/i.test(out) ? 'musl' : 'glibc'
+  } catch {
+    return 'unknown'
+  }
+}
+
+let cachedClaudeCodeBin: string | undefined | null = null
+function resolveClaudeCodeBin(): string | undefined {
+  if (cachedClaudeCodeBin !== null) return cachedClaudeCodeBin
+  if (process.env.CLAUDE_CODE_BIN) {
+    cachedClaudeCodeBin = process.env.CLAUDE_CODE_BIN
+    return cachedClaudeCodeBin
+  }
+  if (process.platform !== 'linux' || process.arch !== 'x64') {
+    cachedClaudeCodeBin = undefined
+    return undefined
+  }
+  const libc = detectLinuxLibc()
+  if (libc === 'unknown') {
+    cachedClaudeCodeBin = undefined
+    return undefined
+  }
+  const variant = libc === 'musl' ? 'linux-x64-musl' : 'linux-x64'
+  const bin = join(
+    PROJECT_ROOT, 'node_modules', '@anthropic-ai',
+    `claude-agent-sdk-${variant}`, 'claude',
+  )
+  cachedClaudeCodeBin = existsSync(bin) ? bin : undefined
+  return cachedClaudeCodeBin
+}
 
 export async function runAgent(
   message: string,
@@ -31,6 +73,8 @@ export async function runAgent(
     abortController.abort()
   }, AGENT_TIMEOUT_MS)
 
+  const claudeCodeBin = resolveClaudeCodeBin()
+
   try {
     const events = query({
       prompt: message,
@@ -38,6 +82,7 @@ export async function runAgent(
         abortController,
         cwd,
         permissionMode: 'bypassPermissions',
+        ...(claudeCodeBin ? { pathToClaudeCodeExecutable: claudeCodeBin } : {}),
         ...(allowTools ? {} : { disallowedTools: DEFAULT_DISALLOWED_TOOLS }),
         ...(sessionId ? { resume: sessionId } : {}),
         ...(env ? { env: { ...process.env, ...env } } : {}),


### PR DESCRIPTION
> AI-generated by Marveen dev agent (EFiveen, Claude Opus 4.7).

## Problem

The bundled `@anthropic-ai/claude-agent-sdk` runtime libc detection picks the `linux-x64-musl` variant even on glibc-based Ubuntu/Debian/RHEL hosts. The selected native binary then fails to spawn with `ld-musl-* not found`, which breaks every `runAgent` call on glibc Linux installs.

## Fix

Detect libc at agent-init time (`ldd --version`), pick the right subpackage (`claude-agent-sdk-linux-x64` for glibc, `claude-agent-sdk-linux-x64-musl` for musl), and forward its absolute path via `pathToClaudeCodeExecutable`. Falls back to SDK defaults when:

- platform/arch is not Linux-x64
- libc cannot be detected
- the resolved binary doesn't exist
- `CLAUDE_CODE_BIN` env override is set

## Verification

- Ubuntu 24.04 (glibc 2.39): `ldd --version` detects glibc, `claude-agent-sdk-linux-x64/claude` is picked up, spawn succeeds.
- Tests: `npm run test` passes (405/405, vitest).

A separate upstream issue should be filed against `@anthropic-ai/claude-agent-sdk` for the underlying libc-detection bug; this PR is Marveen-side defence in depth.
