### PR TITLE
feat(channel): generalized MCP reconnect helper + health monitor

### DIFF
--- a/src/__tests__/channel-health-monitor.test.ts
+++ b/src/__tests__/channel-health-monitor.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+  execSync: vi.fn(),
+}))
+
+vi.mock('../platform.js', () => ({
+  resolveFromPath: (name: string) => `/usr/local/bin/${name}`,
+}))
+
+vi.mock('../logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../config.js', () => ({
+  MAIN_AGENT_ID: 'marveen',
+  CHANNEL_PROVIDER: 'telegram',
+  PROJECT_ROOT: '/tmp/test-claudeclaw',
+}))
+
+vi.mock('../web/agent-config.js', () => ({
+  listAgentNames: () => ['samu'],
+  readAgentChannelProvider: () => 'telegram',
+  AGENTS_BASE_DIR: '/tmp/test-claudeclaw/agents',
+}))
+
+const mockCapturePane = vi.fn<(session: string) => string | null>()
+vi.mock('../web/agent-process.js', () => ({
+  isAgentRunning: (name: string) => name === 'samu',
+  capturePane: (session: string) => mockCapturePane(session),
+  agentSessionName: (name: string) => `agent-${name}`,
+}))
+
+vi.mock('../web/main-agent.js', () => ({
+  MAIN_CHANNELS_SESSION: 'marveen-channels',
+}))
+
+const mockReconnect = vi.fn()
+vi.mock('../web/channel-mcp-reconnect.js', () => ({
+  attemptChannelMcpReconnect: (name: string) => mockReconnect(name),
+  resolveAgentSession: (name: string) => name === 'marveen' ? 'marveen-channels' : `agent-${name}`,
+  resolveAgentProviderType: () => 'telegram' as const,
+}))
+
+vi.mock('../channel-provider.js', () => ({
+  getProvider: () => ({
+    pluginId: 'telegram@claude-plugins-official',
+  }),
+}))
+
+import { getChannelHealth, startChannelHealthMonitor } from '../web/channel-health-monitor.js'
+
+describe('getChannelHealth', () => {
+  it('returns healthy when no reconnect state exists', () => {
+    const health = getChannelHealth('unknown-agent')
+    expect(health.healthy).toBe(true)
+    expect(health.reconnectAttempts).toBe(0)
+    expect(health.lastAttemptAt).toBeNull()
+  })
+})
+
+describe('startChannelHealthMonitor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns a timer handle', () => {
+    const timer = startChannelHealthMonitor()
+    expect(timer).toBeDefined()
+    clearInterval(timer)
+  })
+
+  it('does not reconnect when pane shows no failure', () => {
+    const timer = startChannelHealthMonitor()
+    mockCapturePane.mockReturnValue('normal pane content with telegram@claude-plugins-official active')
+
+    vi.advanceTimersByTime(46_000)
+
+    expect(mockReconnect).not.toHaveBeenCalled()
+    clearInterval(timer)
+  })
+
+  it('triggers reconnect when pane shows plugin failure', () => {
+    mockReconnect.mockReturnValue({ ok: false, message: 'test' })
+    const timer = startChannelHealthMonitor()
+    mockCapturePane.mockReturnValue(
+      'plugin:telegram@claude-plugins-official  ✘ failed\nsome other output',
+    )
+
+    vi.advanceTimersByTime(46_000)
+
+    expect(mockReconnect).toHaveBeenCalled()
+    clearInterval(timer)
+  })
+})

--- a/src/__tests__/channel-mcp-reconnect.test.ts
+++ b/src/__tests__/channel-mcp-reconnect.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockExecFileSync = vi.fn()
+vi.mock('node:child_process', () => ({
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+  execSync: vi.fn(),
+}))
+
+vi.mock('../platform.js', () => ({
+  resolveFromPath: (name: string) => `/usr/local/bin/${name}`,
+}))
+
+vi.mock('../logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../config.js', () => ({
+  MAIN_AGENT_ID: 'marveen',
+  CHANNEL_PROVIDER: 'telegram',
+  PROJECT_ROOT: '/tmp/test-claudeclaw',
+}))
+
+vi.mock('../web/agent-config.js', () => ({
+  readAgentChannelProvider: (name: string) => name === 'slacker' ? 'slack' : '',
+  AGENTS_BASE_DIR: '/tmp/test-claudeclaw/agents',
+}))
+
+const mockCapturePane = vi.fn<(session: string) => string | null>()
+vi.mock('../web/agent-process.js', () => ({
+  agentSessionName: (name: string) => `agent-${name}`,
+  capturePane: (session: string) => mockCapturePane(session),
+}))
+
+vi.mock('../web/main-agent.js', () => ({
+  MAIN_CHANNELS_SESSION: 'marveen-channels',
+}))
+
+vi.mock('../channel-provider.js', () => ({
+  getProvider: (type: string) => ({
+    pluginId: type === 'slack'
+      ? 'slack-channel@marveen-marketplace'
+      : 'telegram@claude-plugins-official',
+  }),
+}))
+
+import {
+  attemptChannelMcpReconnect,
+  resolveAgentSession,
+  resolveAgentProviderType,
+} from '../web/channel-mcp-reconnect.js'
+
+describe('resolveAgentSession', () => {
+  it('returns main channels session for main agent', () => {
+    expect(resolveAgentSession('marveen')).toBe('marveen-channels')
+  })
+
+  it('returns agent-NAME for sub-agents', () => {
+    expect(resolveAgentSession('samu')).toBe('agent-samu')
+    expect(resolveAgentSession('zara')).toBe('agent-zara')
+  })
+})
+
+describe('resolveAgentProviderType', () => {
+  it('returns configured provider for agent with explicit config', () => {
+    expect(resolveAgentProviderType('slacker')).toBe('slack')
+  })
+
+  it('falls back to CHANNEL_PROVIDER for unconfigured agents', () => {
+    expect(resolveAgentProviderType('samu')).toBe('telegram')
+  })
+})
+
+describe('attemptChannelMcpReconnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns ok:true when plugin submenu is found on first Up', () => {
+    mockCapturePane
+      .mockReturnValueOnce('/mcp menu content')
+      .mockReturnValueOnce('some content with telegram@claude-plugins-official listed')
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('Up x1')
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      '/usr/local/bin/tmux',
+      ['send-keys', '-t', 'marveen-channels', '/mcp', 'Enter'],
+      expect.any(Object),
+    )
+  })
+
+  it('returns ok:true when plugin found on third Up', () => {
+    mockCapturePane
+      .mockReturnValueOnce('/mcp menu')
+      .mockReturnValueOnce('no match')
+      .mockReturnValueOnce('no match')
+      .mockReturnValueOnce('telegram@claude-plugins-official here')
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('Up x3')
+  })
+
+  it('returns ok:false when capture fails after /mcp', () => {
+    mockCapturePane.mockReturnValueOnce(null)
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('capture')
+  })
+
+  it('returns ok:false when plugin not found within max attempts', () => {
+    mockCapturePane.mockReturnValueOnce('/mcp menu')
+    for (let i = 0; i < 8; i++) {
+      mockCapturePane.mockReturnValueOnce('no match here')
+    }
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('not found')
+  })
+
+  it('uses correct session for sub-agents', () => {
+    mockCapturePane
+      .mockReturnValueOnce('/mcp')
+      .mockReturnValueOnce('slack-channel@marveen-marketplace found')
+
+    attemptChannelMcpReconnect('slacker')
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      '/usr/local/bin/tmux',
+      ['send-keys', '-t', 'agent-slacker', 'Escape'],
+      expect.any(Object),
+    )
+  })
+
+  it('sends Escape on error to clean up menu state', () => {
+    mockExecFileSync.mockImplementationOnce(() => { /* Escape */ })
+    mockExecFileSync.mockImplementationOnce(() => { /* sleep */ })
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('tmux dead') })
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(false)
+    const escapeCalls = mockExecFileSync.mock.calls.filter(
+      (c) => Array.isArray(c[1]) && c[1].includes('Escape'),
+    )
+    expect(escapeCalls.length).toBeGreaterThan(0)
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -13,6 +13,7 @@ import { startUpdateChecker } from './web/update-checker.js'
 import { startMcpListChecker } from './web/mcp-list.js'
 import { startScheduleRunner } from './web/schedule-runner.js'
 import { startChannelPluginMonitor } from './web/channel-monitor.js'
+import { startChannelHealthMonitor } from './web/channel-health-monitor.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
@@ -204,6 +205,9 @@ export function startWebServer(port = 3420): http.Server {
   const pluginMonitorInterval = startChannelPluginMonitor()
   logger.info('Channel plugin health monitor started (60s poll)')
 
+  const channelHealthInterval = startChannelHealthMonitor()
+  logger.info('Channel MCP health monitor started (60s poll, 45s offset)')
+
   const updateCheckerInterval = startUpdateChecker()
   logger.info('Update checker started (15min poll)')
 
@@ -243,6 +247,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(routerInterval)
     clearInterval(scheduleInterval)
     clearInterval(pluginMonitorInterval)
+    clearInterval(channelHealthInterval)
     clearInterval(updateCheckerInterval)
     return origClose(cb)
   }

--- a/src/web/channel-health-monitor.ts
+++ b/src/web/channel-health-monitor.ts
@@ -1,0 +1,130 @@
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID } from '../config.js'
+import { listAgentNames } from './agent-config.js'
+import { isAgentRunning, capturePane } from './agent-process.js'
+import {
+  attemptChannelMcpReconnect,
+  resolveAgentSession,
+  resolveAgentProviderType,
+} from './channel-mcp-reconnect.js'
+import { getProvider } from '../channel-provider.js'
+import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+
+// Detect `plugin:X · ✘ failed` (or ✘ error / ✘ disconnected) in the
+// pane output. Claude Code renders this in the MCP status area when a
+// channel plugin connection drops.
+const PLUGIN_FAILED_RX = /✘\s*(?:failed|error|disconnected)/i
+
+interface AgentReconnectState {
+  attempts: number
+  lastAttemptAt: number
+  nextRetryAt: number
+}
+
+const BACKOFF_BASE_MS = 30_000
+const BACKOFF_MULTIPLIER = 3
+const MAX_RETRIES = 3
+const COOLDOWN_MS = 30 * 60 * 1000
+
+const reconnectState = new Map<string, AgentReconnectState>()
+
+function getBackoffMs(attempt: number): number {
+  return BACKOFF_BASE_MS * Math.pow(BACKOFF_MULTIPLIER, attempt)
+}
+
+function isPluginFailedInPane(pane: string, pluginId: string): boolean {
+  if (!pane.includes(pluginId)) return false
+  return PLUGIN_FAILED_RX.test(pane)
+}
+
+export interface ChannelHealthStatus {
+  healthy: boolean
+  reconnectAttempts: number
+  lastAttemptAt: number | null
+}
+
+export function getChannelHealth(agentName: string): ChannelHealthStatus {
+  const state = reconnectState.get(agentName)
+  if (!state) return { healthy: true, reconnectAttempts: 0, lastAttemptAt: null }
+  return {
+    healthy: false,
+    reconnectAttempts: state.attempts,
+    lastAttemptAt: state.lastAttemptAt,
+  }
+}
+
+function checkAgent(agentName: string, session: string): void {
+  const now = Date.now()
+  const state = reconnectState.get(agentName)
+
+  if (state && state.attempts >= MAX_RETRIES) {
+    if (now - state.lastAttemptAt > COOLDOWN_MS) {
+      reconnectState.delete(agentName)
+    }
+    return
+  }
+
+  if (state && now < state.nextRetryAt) return
+
+  const pane = capturePane(session)
+  if (!pane) return
+
+  const providerType = resolveAgentProviderType(agentName)
+  const provider = getProvider(providerType)
+
+  if (!isPluginFailedInPane(pane, provider.pluginId)) {
+    if (state) {
+      logger.info({ agentName, provider: providerType }, 'channel-health-monitor: plugin recovered')
+      reconnectState.delete(agentName)
+    }
+    return
+  }
+
+  const attempt = state ? state.attempts : 0
+  logger.warn(
+    { agentName, attempt, provider: providerType },
+    'channel-health-monitor: plugin failure detected, attempting reconnect',
+  )
+
+  const result = attemptChannelMcpReconnect(agentName)
+
+  const backoffMs = getBackoffMs(attempt)
+  reconnectState.set(agentName, {
+    attempts: attempt + 1,
+    lastAttemptAt: now,
+    nextRetryAt: now + backoffMs,
+  })
+
+  if (result.ok) {
+    logger.info({ agentName, attempt }, 'channel-health-monitor: reconnect succeeded')
+  } else {
+    logger.warn(
+      { agentName, attempt, message: result.message },
+      'channel-health-monitor: reconnect failed',
+    )
+  }
+}
+
+export function startChannelHealthMonitor(): NodeJS.Timeout {
+  function check() {
+    try {
+      checkAgent(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION)
+    } catch (err) {
+      logger.debug({ err }, 'channel-health-monitor: main agent check error')
+    }
+
+    for (const name of listAgentNames()) {
+      if (!isAgentRunning(name)) continue
+      try {
+        checkAgent(name, resolveAgentSession(name))
+      } catch (err) {
+        logger.debug({ err, agent: name }, 'channel-health-monitor: agent check error')
+      }
+    }
+  }
+
+  // Offset from channel-monitor's 30s initial delay to avoid
+  // overlapping tmux interactions on the same tick.
+  setTimeout(check, 45_000)
+  return setInterval(check, 60_000)
+}

--- a/src/web/channel-mcp-reconnect.ts
+++ b/src/web/channel-mcp-reconnect.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from 'node:child_process'
+import { resolveFromPath } from '../platform.js'
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID, CHANNEL_PROVIDER } from '../config.js'
+import { readAgentChannelProvider } from './agent-config.js'
+import { agentSessionName, capturePane } from './agent-process.js'
+import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { getProvider, type ChannelProviderType } from '../channel-provider.js'
+
+const TMUX = resolveFromPath('tmux')
+const MAX_UP_ATTEMPTS = 8
+
+export interface ReconnectResult {
+  ok: boolean
+  message: string
+}
+
+export function resolveAgentSession(agentName: string): string {
+  if (agentName === MAIN_AGENT_ID) return MAIN_CHANNELS_SESSION
+  return agentSessionName(agentName)
+}
+
+export function resolveAgentProviderType(agentName: string): ChannelProviderType {
+  const perAgent = readAgentChannelProvider(agentName)
+  if (perAgent === 'slack' || perAgent === 'telegram') return perAgent
+  return CHANNEL_PROVIDER
+}
+
+function getPluginPattern(providerType: ChannelProviderType): RegExp {
+  const provider = getProvider(providerType)
+  const escaped = provider.pluginId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(escaped, 'i')
+}
+
+/**
+ * Attempt to reconnect a channel MCP plugin by navigating the /mcp
+ * menu in the agent's tmux session. Generalises the existing
+ * softReconnectMarveen() logic to any agent.
+ *
+ * Sequence: Escape → /mcp Enter → Up×N until plugin found → Enter →
+ * Down (Reconnect) → Enter → Escape.
+ */
+export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
+  const session = resolveAgentSession(agentName)
+  const providerType = resolveAgentProviderType(agentName)
+  const pluginPattern = getPluginPattern(providerType)
+
+  try {
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
+    execFileSync('/bin/sleep', ['1'], { timeout: 2000 })
+
+    execFileSync(TMUX, ['send-keys', '-t', session, '/mcp', 'Enter'], { timeout: 3000 })
+    execFileSync('/bin/sleep', ['1'], { timeout: 3000 })
+
+    const pane1 = capturePane(session)
+    if (!pane1) {
+      logger.warn({ agentName, session }, 'channel-mcp-reconnect: capture failed after /mcp')
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
+      return { ok: false, message: 'Failed to capture pane after /mcp' }
+    }
+
+    let matchedAt = -1
+    for (let upCount = 1; upCount <= MAX_UP_ATTEMPTS; upCount++) {
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Up'], { timeout: 3000 })
+      execFileSync('/bin/sleep', ['0.2'], { timeout: 1000 })
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 3000 })
+      execFileSync('/bin/sleep', ['1'], { timeout: 3000 })
+
+      const pane = capturePane(session)
+      if (pane && pluginPattern.test(pane)) {
+        matchedAt = upCount
+        break
+      }
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
+      execFileSync('/bin/sleep', ['0.5'], { timeout: 1000 })
+    }
+
+    if (matchedAt < 0) {
+      logger.warn(
+        { agentName, session, maxUpAttempts: MAX_UP_ATTEMPTS, pluginPattern: pluginPattern.source },
+        'channel-mcp-reconnect: plugin submenu not found',
+      )
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
+      return { ok: false, message: `Plugin not found within ${MAX_UP_ATTEMPTS} Up attempts` }
+    }
+
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Down'], { timeout: 3000 })
+    execFileSync('/bin/sleep', ['0.3'], { timeout: 1000 })
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 3000 })
+    execFileSync('/bin/sleep', ['2'], { timeout: 4000 })
+
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
+    logger.info({ agentName, session, matchedAt, provider: providerType }, 'channel-mcp-reconnect: completed')
+    return { ok: true, message: `Reconnected via /mcp (Up x${matchedAt})` }
+  } catch (err) {
+    logger.warn({ err, agentName, session }, 'channel-mcp-reconnect failed')
+    try { execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 }) } catch { /* best effort */ }
+    return { ok: false, message: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -16,6 +16,7 @@ import {
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
 import { getProvider, channelStateDir, type ChannelProviderType } from '../channel-provider.js'
+import { attemptChannelMcpReconnect } from './channel-mcp-reconnect.js'
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
@@ -151,68 +152,8 @@ function getMainAgentProvider(): ChannelProviderType {
   return CHANNEL_PROVIDER
 }
 
-function getMainAgentPluginPattern(): RegExp {
-  const provider = getProvider(getMainAgentProvider())
-  const escaped = provider.pluginId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return new RegExp(escaped, 'i')
-}
-
 function softReconnectMarveen(): boolean {
-  const MAX_UP_ATTEMPTS = 8
-  const pluginPattern = getMainAgentPluginPattern()
-
-  try {
-    execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
-    execFileSync('/bin/sleep', ['1'], { timeout: 2000 })
-
-    execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, '/mcp', 'Enter'], { timeout: 3000 })
-    execFileSync('/bin/sleep', ['1'], { timeout: 3000 })
-
-    const pane1 = capturePane(MAIN_CHANNELS_SESSION)
-    if (!pane1) {
-      logger.warn('soft reconnect: failed to capture pane after /mcp')
-      execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
-      return false
-    }
-
-    let matchedAt = -1
-    for (let upCount = 1; upCount <= MAX_UP_ATTEMPTS; upCount++) {
-      execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Up'], { timeout: 3000 })
-      execFileSync('/bin/sleep', ['0.2'], { timeout: 1000 })
-      execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Enter'], { timeout: 3000 })
-      execFileSync('/bin/sleep', ['1'], { timeout: 3000 })
-
-      const pane = capturePane(MAIN_CHANNELS_SESSION)
-      if (pane && pluginPattern.test(pane)) {
-        matchedAt = upCount
-        break
-      }
-      execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
-      execFileSync('/bin/sleep', ['0.5'], { timeout: 1000 })
-    }
-
-    if (matchedAt < 0) {
-      logger.warn(
-        { maxUpAttempts: MAX_UP_ATTEMPTS, pluginPattern: pluginPattern.source },
-        'soft reconnect: did not find channel plugin submenu within Up attempts',
-      )
-      execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
-      return false
-    }
-
-    execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Down'], { timeout: 3000 })
-    execFileSync('/bin/sleep', ['0.3'], { timeout: 1000 })
-    execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Enter'], { timeout: 3000 })
-    execFileSync('/bin/sleep', ['2'], { timeout: 4000 })
-
-    execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 })
-    logger.info({ matchedAt, provider: getMainAgentProvider() }, 'soft reconnect: /mcp → Up × N → Enter → Down (Reconnect) → Enter completed')
-    return true
-  } catch (err) {
-    logger.warn({ err }, 'Marveen soft reconnect failed')
-    try { execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Escape'], { timeout: 3000 }) } catch { /* */ }
-    return false
-  }
+  return attemptChannelMcpReconnect(MAIN_AGENT_ID).ok
 }
 
 function triggerMarveenMemorySave(): void {

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -67,6 +67,8 @@ import {
   stopAgentProcess,
   getAgentProcessInfo,
 } from '../agent-process.js'
+import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
+import { getChannelHealth } from '../channel-health-monitor.js'
 import {
   loadProfileTemplate,
   resolveProfilePlaceholders,
@@ -428,6 +430,32 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       const execErr = err as { stdout?: string; stderr?: string }
       json(res, { ok: false, output: (execErr.stdout || '') + (execErr.stderr || '') }, 200)
     }
+    return true
+  }
+
+  // POST /api/agents/:name/channel/reconnect
+  const reconnectMatch = path.match(/^\/api\/agents\/([^/]+)\/channel\/reconnect$/)
+  if (reconnectMatch && method === 'POST') {
+    const name = decodeURIComponent(reconnectMatch[1])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
+      json(res, { error: 'Agent not found' }, 404); return true
+    }
+    if (name !== MAIN_AGENT_ID && !isAgentRunning(name)) {
+      json(res, { error: 'Agent is not running' }, 400); return true
+    }
+    const result = attemptChannelMcpReconnect(name)
+    json(res, result)
+    return true
+  }
+
+  // GET /api/agents/:name/channel/health
+  const healthMatch = path.match(/^\/api\/agents\/([^/]+)\/channel\/health$/)
+  if (healthMatch && method === 'GET') {
+    const name = decodeURIComponent(healthMatch[1])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) {
+      json(res, { error: 'Agent not found' }, 404); return true
+    }
+    json(res, getChannelHealth(name))
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -1481,7 +1481,7 @@ document.getElementById('chReconnectBtn').addEventListener('click', async () => 
   const btn = document.getElementById('chReconnectBtn')
   const origText = btn.textContent
   btn.disabled = true
-  btn.textContent = 'Reconnect...'
+  btn.textContent = 'Újracsatlakozás...'
   try {
     const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel/reconnect`, { method: 'POST' })
     const data = await res.json()

--- a/web/app.js
+++ b/web/app.js
@@ -1337,6 +1337,7 @@ function updateProviderUI() {
   const slackGroup = document.getElementById('chSlackAppTokenGroup')
   const manifestBtnGroup = document.getElementById('chSlackManifestBtnGroup')
   const smokeTestBtn = document.getElementById('chSmokeTestBtn')
+  const reconnectBtn = document.getElementById('chReconnectBtn')
 
   if (isTg) {
     if (title) title.textContent = 'Telegram bot bekotese'
@@ -1355,6 +1356,9 @@ function updateProviderUI() {
     if (manifestBtnGroup) manifestBtnGroup.hidden = false
     if (smokeTestBtn) smokeTestBtn.hidden = false
   }
+  if (reconnectBtn) {
+    reconnectBtn.hidden = !(currentAgent && currentAgent.running && currentAgent.hasTelegram)
+  }
 }
 
 function updateChannelTab(agent) {
@@ -1371,12 +1375,36 @@ function updateChannelTab(agent) {
   const slackInput = document.getElementById('chSlackAppToken')
   if (slackInput) slackInput.value = ''
   updateProviderUI()
+  if (connected && running) {
+    refreshChannelHealth()
+  } else {
+    document.getElementById('chDisconnectedNotice').hidden = true
+    document.getElementById('chReconnectBtn').hidden = true
+  }
   if (connected) {
     refreshPendingPairings()
     refreshAllowedList()
     refreshInvites()
     refreshChannelRequests()
   }
+}
+
+async function refreshChannelHealth() {
+  if (!currentAgent) return
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel/health`)
+    if (!res.ok) return
+    const data = await res.json()
+    const notice = document.getElementById('chDisconnectedNotice')
+    const btn = document.getElementById('chReconnectBtn')
+    if (!data.healthy) {
+      if (notice) notice.hidden = false
+      if (btn) btn.hidden = false
+    } else {
+      if (notice) notice.hidden = true
+      if (btn) btn.hidden = false
+    }
+  } catch { /* ignore */ }
 }
 
 document.getElementById('chProviderSelect').addEventListener('change', (e) => {
@@ -1445,6 +1473,29 @@ document.getElementById('chTestBtn').addEventListener('click', async () => {
     showToast('Kapcsolat rendben!')
   } catch {
     showToast('Kapcsolat tesztelése sikertelen')
+  }
+})
+
+document.getElementById('chReconnectBtn').addEventListener('click', async () => {
+  if (!currentAgent) return
+  const btn = document.getElementById('chReconnectBtn')
+  const origText = btn.textContent
+  btn.disabled = true
+  btn.textContent = 'Reconnect...'
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/channel/reconnect`, { method: 'POST' })
+    const data = await res.json()
+    if (data.ok) {
+      showToast('Channel-MCP reconnect sikeres')
+      document.getElementById('chDisconnectedNotice').hidden = true
+    } else {
+      showToast(data.message || 'Reconnect sikertelen', true)
+    }
+  } catch {
+    showToast('Reconnect hiba', true)
+  } finally {
+    btn.disabled = false
+    btn.textContent = origText
   }
 })
 

--- a/web/index.html
+++ b/web/index.html
@@ -1189,7 +1189,7 @@
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Csatorna leszakadt. Automatikus ujracsatlakozas folyamatban, vagy hasznald a gombot lent.</span>
+              <span>Csatorna leszakadt. Automatikus újracsatlakozás folyamatban, vagy használd a gombot lent.</span>
             </div>
             <div class="tg-connected-actions">
               <button class="btn-secondary" id="chTestBtn">Kapcsolat tesztelése</button>

--- a/web/index.html
+++ b/web/index.html
@@ -1185,8 +1185,15 @@
               <p class="tg-pairing-info">Slack csatornák, amelyekben megemlítették a botot, de még nincsenek engedélyezve.</p>
               <div id="chRequestList"></div>
             </div>
+            <div class="tg-notice tg-notice-warn" id="chDisconnectedNotice" hidden>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+              </svg>
+              <span>Csatorna leszakadt. Automatikus ujracsatlakozas folyamatban, vagy hasznald a gombot lent.</span>
+            </div>
             <div class="tg-connected-actions">
               <button class="btn-secondary" id="chTestBtn">Kapcsolat tesztelése</button>
+              <button class="btn-secondary" id="chReconnectBtn" hidden>Channel-MCP reconnect</button>
               <button class="btn-secondary" id="chSmokeTestBtn" hidden>Slack csatorna smoke-test</button>
               <button class="btn-danger" id="chDisconnectBtn">Leválasztás</button>
             </div>

--- a/web/style.css
+++ b/web/style.css
@@ -1131,6 +1131,11 @@ main {
   border-color: rgba(120, 140, 93, 0.2);
 }
 .tg-notice-ok svg { color: var(--success); }
+.tg-notice-warn {
+  background: rgba(200, 140, 40, 0.08);
+  border-color: rgba(200, 140, 40, 0.3);
+}
+.tg-notice-warn svg { color: #c88c28; }
 
 .tg-pairing-section {
   margin-top: 20px;


### PR DESCRIPTION
## Summary

- Extract `/mcp` reconnect logic from `softReconnectMarveen()` into reusable `attemptChannelMcpReconnect(agentName)` (works for main agent + sub-agents)
- Add `channel-health-monitor.ts`: 60s pane-based detection of `plugin:X · ✘ failed`, auto-reconnect with exponential backoff (30s/90s/270s), max 3 retries, 30min cooldown
- Add `POST /api/agents/:name/channel/reconnect` endpoint + `GET /api/agents/:name/channel/health` for frontend
- Dashboard: "Channel-MCP reconnect" button + warning badge when channel is detected as disconnected
- 14 new tests (reconnect unit tests + health monitor tests), all 459 suite tests pass

## Changed files

| File | What |
|------|------|
| `src/web/channel-mcp-reconnect.ts` | **NEW** -- `attemptChannelMcpReconnect()`, `resolveAgentSession()`, `resolveAgentProviderType()` |
| `src/web/channel-health-monitor.ts` | **NEW** -- `startChannelHealthMonitor()`, `getChannelHealth()` |
| `src/web/channel-monitor.ts` | `softReconnectMarveen()` now delegates to the new module (1-liner) |
| `src/web/routes/agents.ts` | Two new endpoints: reconnect + health |
| `src/web.ts` | Wire up health monitor lifecycle |
| `web/index.html` | Reconnect button + disconnected warning badge |
| `web/app.js` | Click handler + health status polling |
| `web/style.css` | `.tg-notice-warn` style |

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 459 tests pass (`npx vitest run`)
- [ ] Manual: open dashboard agent channel tab, verify reconnect button appears for running agents
- [ ] Manual: click reconnect button, verify `/mcp` navigation fires in tmux session
- [ ] Verify `softReconnectMarveen()` still works via existing channel-monitor recovery flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)