### PR TITLE
fix(channel-monitor): stage 2+3 recovery Telegram alert spam

### DIFF
--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -240,7 +240,6 @@ function handleMarveenDown(): void {
     marveenDownState.stageStartedAt = now
     marveenDownState.lastAlertAt = now
     logger.warn({ provider: providerLabel }, 'Marveen channel plugin still down -- stage 2 (memory save)')
-    sendAlert(`⚠️ /mcp nem segitett. Szolok Marveennek hogy mentsen memoriat session resume elott (~60s turelmi ido).`)
     triggerMarveenMemorySave()
     return
   }
@@ -251,7 +250,6 @@ function handleMarveenDown(): void {
     marveenDownState.stageStartedAt = now
     marveenDownState.lastAlertAt = now
     logger.warn({ provider: providerLabel }, 'Marveen channel plugin still down -- stage 3 (session resume)')
-    sendAlert('⚠️ Memoria mentes lejart. Session resume (claude --continue) most...')
     resumeMarveenSession()
     return
   }


### PR DESCRIPTION
## Summary

- Stage 2 (memory save): Telegram `sendAlert` torolve. Inter-agent `triggerMarveenMemorySave()` marad.
- Stage 3 (session resume): Telegram `sendAlert` torolve. `logger.warn` marad.
- Stage 4 (hard restart) es stage 5 (gave_up) alert-ek valtozatlanul megmaradnak.

## Motivation

Szabi jelzese: a stage 2+3 alert-ek spam-et okoznak, mert a recovery rendszerint sikerul. Csak a vegso failure eseten kell Telegram ertesites.

## Test plan

- [x] Build clean (`npm run build`)
- [x] Stage 4+5 alert-ek erintetlenek
- [x] `handleMarveenUp` recovery logic erintetlen

🤖 Generated with [Claude Code](https://claude.com/claude-code)