### PR TITLE
feat(recall): session recall API + dashboard napló view

### DIFF
--- a/src/__tests__/recall.test.ts
+++ b/src/__tests__/recall.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { parseDateExpression } from '../web/routes/recall.js'
+
+// Pin "today" to 2026-05-19 (Tuesday) Europe/Budapest for deterministic tests
+const FAKE_TODAY = '2026-05-19'
+
+vi.mock('../web/routes/recall.js', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../web/routes/recall.js')>()
+  return mod
+})
+
+// We can't easily mock todayBudapest inside the module, so we test the parser
+// with inputs that are absolute or relative. For relative tests we accept that
+// results shift with the real date and verify structural correctness instead.
+
+describe('parseDateExpression', () => {
+  describe('ISO dates', () => {
+    it('parses single ISO date', () => {
+      expect(parseDateExpression('2026-05-19')).toEqual({ from: '2026-05-19', to: '2026-05-19' })
+    })
+
+    it('parses ISO date range with dash', () => {
+      expect(parseDateExpression('2026-05-10-2026-05-15')).toEqual({ from: '2026-05-10', to: '2026-05-15' })
+    })
+
+    it('parses ISO date range with en-dash', () => {
+      const r = parseDateExpression('2026-05-01–2026-05-07')
+      expect(r).toEqual({ from: '2026-05-01', to: '2026-05-07' })
+    })
+  })
+
+  describe('relative keywords', () => {
+    it('parses "ma"', () => {
+      const r = parseDateExpression('ma')
+      expect(r).not.toBeNull()
+      expect(r!.from).toBe(r!.to)
+      expect(r!.from).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+
+    it('parses "tegnap"', () => {
+      const r = parseDateExpression('tegnap')
+      expect(r).not.toBeNull()
+      expect(r!.from).toBe(r!.to)
+    })
+
+    it('parses "tegnapelőtt"', () => {
+      const r = parseDateExpression('tegnapelőtt')
+      expect(r).not.toBeNull()
+      expect(r!.from).toBe(r!.to)
+    })
+
+    it('parses "yesterday"', () => {
+      const r = parseDateExpression('yesterday')
+      expect(r).not.toBeNull()
+    })
+  })
+
+  describe('N days/weeks ago', () => {
+    it('parses "3 napja"', () => {
+      const r = parseDateExpression('3 napja')
+      expect(r).not.toBeNull()
+      expect(r!.from).toBe(r!.to)
+    })
+
+    it('parses "5 nappal ezelőtt"', () => {
+      const r = parseDateExpression('5 nappal ezelőtt')
+      expect(r).not.toBeNull()
+    })
+
+    it('parses "2 hete"', () => {
+      const r = parseDateExpression('2 hete')
+      expect(r).not.toBeNull()
+      expect(r!.from).not.toBe(r!.to)
+    })
+
+    it('parses "1 héttel ezelőtt"', () => {
+      const r = parseDateExpression('1 héttel ezelőtt')
+      expect(r).not.toBeNull()
+    })
+  })
+
+  describe('week references', () => {
+    it('parses "múlt héten"', () => {
+      const r = parseDateExpression('múlt héten')
+      expect(r).not.toBeNull()
+      expect(r!.from < r!.to).toBe(true)
+    })
+
+    it('parses "ezen a héten"', () => {
+      const r = parseDateExpression('ezen a héten')
+      expect(r).not.toBeNull()
+    })
+
+    it('parses "ez a hét"', () => {
+      const r = parseDateExpression('ez a hét')
+      expect(r).not.toBeNull()
+    })
+  })
+
+  describe('month references', () => {
+    it('parses "ebben a hónapban"', () => {
+      const r = parseDateExpression('ebben a hónapban')
+      expect(r).not.toBeNull()
+      expect(r!.from.endsWith('-01')).toBe(true)
+    })
+
+    it('parses "múlt hónapban"', () => {
+      const r = parseDateExpression('múlt hónapban')
+      expect(r).not.toBeNull()
+    })
+
+    it('parses "elmúlt 7 nap"', () => {
+      const r = parseDateExpression('elmúlt 7 nap')
+      expect(r).not.toBeNull()
+    })
+
+    it('parses "utolsó 30 nap"', () => {
+      const r = parseDateExpression('utolsó 30 nap')
+      expect(r).not.toBeNull()
+    })
+  })
+
+  describe('Hungarian month names', () => {
+    it('parses "május első hete"', () => {
+      const r = parseDateExpression('május első hete')
+      expect(r).not.toBeNull()
+      expect(r!.from.includes('-05-')).toBe(true)
+      // First week must start ON or AFTER May 1
+      expect(r!.from >= `${r!.from.slice(0, 4)}-05-01`).toBe(true)
+    })
+
+    it('parses "január első hete" (start-of-month edge)', () => {
+      const r = parseDateExpression('január első hete')
+      expect(r).not.toBeNull()
+      expect(r!.from >= `${r!.from.slice(0, 4)}-01-01`).toBe(true)
+    })
+
+    it('parses "március második hete"', () => {
+      const r = parseDateExpression('március második hete')
+      expect(r).not.toBeNull()
+      expect(r!.from.includes('-03-')).toBe(true)
+    })
+
+    it('parses "december utolsó hete"', () => {
+      const r = parseDateExpression('december utolsó hete')
+      expect(r).not.toBeNull()
+      expect(r!.to.includes('-12-3')).toBe(true)
+    })
+
+    it('parses "május 10"', () => {
+      const r = parseDateExpression('május 10')
+      expect(r).not.toBeNull()
+      expect(r!.from.endsWith('-05-10')).toBe(true)
+      expect(r!.from).toBe(r!.to)
+    })
+
+    it('parses "januárban"', () => {
+      const r = parseDateExpression('januárban')
+      expect(r).not.toBeNull()
+      expect(r!.from.endsWith('-01-01')).toBe(true)
+      expect(r!.to.endsWith('-01-31')).toBe(true)
+    })
+
+    it('parses abbreviated "szept"', () => {
+      const r = parseDateExpression('szept')
+      expect(r).not.toBeNull()
+      expect(r!.from.includes('-09-')).toBe(true)
+    })
+  })
+
+  describe('Hungarian day names', () => {
+    it('parses "hétfő"', () => {
+      const r = parseDateExpression('hétfő')
+      expect(r).not.toBeNull()
+      expect(r!.from).toBe(r!.to)
+    })
+
+    it('parses "csütörtök"', () => {
+      const r = parseDateExpression('csütörtök')
+      expect(r).not.toBeNull()
+      expect(r!.from).toBe(r!.to)
+    })
+
+    it('parses "múlt péntek"', () => {
+      const r = parseDateExpression('múlt péntek')
+      expect(r).not.toBeNull()
+    })
+
+    it('parses "vasárnap"', () => {
+      const r = parseDateExpression('vasárnap')
+      expect(r).not.toBeNull()
+    })
+
+    it('parses "szerda"', () => {
+      const r = parseDateExpression('szerda')
+      expect(r).not.toBeNull()
+    })
+  })
+
+  describe('invalid input', () => {
+    it('returns null for empty string', () => {
+      expect(parseDateExpression('')).toBeNull()
+    })
+
+    it('returns null for gibberish', () => {
+      expect(parseDateExpression('xyzzy')).toBeNull()
+    })
+
+    it('returns null for partial date', () => {
+      expect(parseDateExpression('2026-05')).toBeNull()
+    })
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -606,6 +606,26 @@ export interface RecallResult {
   dateRange: { from: string; to: string }
 }
 
+function toBudapestTs(dateStr: string, endOfDay: boolean): number {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Europe/Budapest',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  })
+  const refDate = new Date(`${dateStr}T${endOfDay ? '23:59:59' : '00:00:00'}`)
+  const parts = fmt.formatToParts(refDate)
+  const get = (t: string) => parts.find(p => p.type === t)?.value || '0'
+  const localStr = `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}`
+  const localMs = new Date(localStr + 'Z').getTime()
+  const offsetMs = localMs - refDate.getTime()
+  const target = new Date(`${dateStr}T${endOfDay ? '23:59:59' : '00:00:00'}Z`)
+  return Math.floor((target.getTime() - offsetMs) / 1000)
+}
+
+function escapeLike(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
+}
+
 export function recallByDateRange(from: string, to: string, agentId?: string): RecallResult {
   const logSql = agentId
     ? 'SELECT id, agent_id, date, content, created_at FROM daily_logs WHERE date >= ? AND date <= ? AND agent_id = ? ORDER BY date ASC, created_at ASC'
@@ -613,8 +633,8 @@ export function recallByDateRange(from: string, to: string, agentId?: string): R
   const logParams = agentId ? [from, to, agentId] : [from, to]
   const logs = db.prepare(logSql).all(...logParams) as RecallResult['logs']
 
-  const fromTs = Math.floor(new Date(`${from}T00:00:00+02:00`).getTime() / 1000)
-  const toTs = Math.floor(new Date(`${to}T23:59:59+02:00`).getTime() / 1000)
+  const fromTs = toBudapestTs(from, false)
+  const toTs = toBudapestTs(to, true)
   const memSql = agentId
     ? "SELECT * FROM memories WHERE created_at >= ? AND created_at <= ? AND (agent_id = ? OR category = 'shared') ORDER BY created_at ASC"
     : 'SELECT * FROM memories WHERE created_at >= ? AND created_at <= ? ORDER BY created_at ASC'
@@ -627,6 +647,7 @@ export function recallByDateRange(from: string, to: string, agentId?: string): R
 export function recallSearch(query: string, agentId?: string, limit = 50): RecallResult {
   const terms = buildFtsMatchExpression(query)
   let memories: Memory[] = []
+  const escaped = escapeLike(query)
   if (terms) {
     try {
       const sql = agentId
@@ -637,20 +658,22 @@ export function recallSearch(query: string, agentId?: string, limit = 50): Recal
         : db.prepare(sql).all(terms, limit) as Memory[]
     } catch {
       const sql = agentId
-        ? "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') AND (content LIKE ? OR keywords LIKE ?) ORDER BY created_at DESC LIMIT ?"
-        : 'SELECT * FROM memories WHERE (content LIKE ? OR keywords LIKE ?) ORDER BY created_at DESC LIMIT ?'
+        ? "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') AND (content LIKE ? ESCAPE '\\' OR keywords LIKE ? ESCAPE '\\') ORDER BY created_at DESC LIMIT ?"
+        : "SELECT * FROM memories WHERE (content LIKE ? ESCAPE '\\' OR keywords LIKE ? ESCAPE '\\') ORDER BY created_at DESC LIMIT ?"
+      const pat = `%${escaped}%`
       memories = agentId
-        ? db.prepare(sql).all(agentId, `%${query}%`, `%${query}%`, limit) as Memory[]
-        : db.prepare(sql).all(`%${query}%`, `%${query}%`, limit) as Memory[]
+        ? db.prepare(sql).all(agentId, pat, pat, limit) as Memory[]
+        : db.prepare(sql).all(pat, pat, limit) as Memory[]
     }
   }
 
   const logSql = agentId
-    ? 'SELECT id, agent_id, date, content, created_at FROM daily_logs WHERE content LIKE ? AND agent_id = ? ORDER BY date DESC, created_at DESC LIMIT ?'
-    : 'SELECT id, agent_id, date, content, created_at FROM daily_logs WHERE content LIKE ? ORDER BY date DESC, created_at DESC LIMIT ?'
+    ? "SELECT id, agent_id, date, content, created_at FROM daily_logs WHERE content LIKE ? ESCAPE '\\' AND agent_id = ? ORDER BY date DESC, created_at DESC LIMIT ?"
+    : "SELECT id, agent_id, date, content, created_at FROM daily_logs WHERE content LIKE ? ESCAPE '\\' ORDER BY date DESC, created_at DESC LIMIT ?"
+  const logPat = `%${escaped}%`
   const logs = agentId
-    ? db.prepare(logSql).all(`%${query}%`, agentId, limit) as RecallResult['logs']
-    : db.prepare(logSql).all(`%${query}%`, limit) as RecallResult['logs']
+    ? db.prepare(logSql).all(logPat, agentId, limit) as RecallResult['logs']
+    : db.prepare(logSql).all(logPat, limit) as RecallResult['logs']
 
   const dates = logs.map(l => l.date)
   const from = dates.length ? dates[dates.length - 1] : ''

--- a/src/db.ts
+++ b/src/db.ts
@@ -598,6 +598,67 @@ export function getDailyLogDates(agentId: string, limit: number = 14): string[] 
   return (db.prepare('SELECT DISTINCT date FROM daily_logs WHERE agent_id = ? ORDER BY date DESC LIMIT ?').all(agentId, limit) as { date: string }[]).map(r => r.date)
 }
 
+// --- Session Recall ---
+
+export interface RecallResult {
+  logs: { id: number; agent_id: string; date: string; content: string; created_at: number }[]
+  memories: Memory[]
+  dateRange: { from: string; to: string }
+}
+
+export function recallByDateRange(from: string, to: string, agentId?: string): RecallResult {
+  const logSql = agentId
+    ? 'SELECT id, agent_id, date, content, created_at FROM daily_logs WHERE date >= ? AND date <= ? AND agent_id = ? ORDER BY date ASC, created_at ASC'
+    : 'SELECT id, agent_id, date, content, created_at FROM daily_logs WHERE date >= ? AND date <= ? ORDER BY date ASC, created_at ASC'
+  const logParams = agentId ? [from, to, agentId] : [from, to]
+  const logs = db.prepare(logSql).all(...logParams) as RecallResult['logs']
+
+  const fromTs = Math.floor(new Date(`${from}T00:00:00+02:00`).getTime() / 1000)
+  const toTs = Math.floor(new Date(`${to}T23:59:59+02:00`).getTime() / 1000)
+  const memSql = agentId
+    ? "SELECT * FROM memories WHERE created_at >= ? AND created_at <= ? AND (agent_id = ? OR category = 'shared') ORDER BY created_at ASC"
+    : 'SELECT * FROM memories WHERE created_at >= ? AND created_at <= ? ORDER BY created_at ASC'
+  const memParams = agentId ? [fromTs, toTs, agentId] : [fromTs, toTs]
+  const memories = db.prepare(memSql).all(...memParams) as Memory[]
+
+  return { logs, memories, dateRange: { from, to } }
+}
+
+export function recallSearch(query: string, agentId?: string, limit = 50): RecallResult {
+  const terms = buildFtsMatchExpression(query)
+  let memories: Memory[] = []
+  if (terms) {
+    try {
+      const sql = agentId
+        ? `SELECT m.* FROM memories m JOIN memories_fts f ON m.id = f.rowid WHERE f.memories_fts MATCH ? AND (m.agent_id = ? OR m.category = 'shared') ORDER BY m.created_at DESC LIMIT ?`
+        : `SELECT m.* FROM memories m JOIN memories_fts f ON m.id = f.rowid WHERE f.memories_fts MATCH ? ORDER BY m.created_at DESC LIMIT ?`
+      memories = agentId
+        ? db.prepare(sql).all(terms, agentId, limit) as Memory[]
+        : db.prepare(sql).all(terms, limit) as Memory[]
+    } catch {
+      const sql = agentId
+        ? "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') AND (content LIKE ? OR keywords LIKE ?) ORDER BY created_at DESC LIMIT ?"
+        : 'SELECT * FROM memories WHERE (content LIKE ? OR keywords LIKE ?) ORDER BY created_at DESC LIMIT ?'
+      memories = agentId
+        ? db.prepare(sql).all(agentId, `%${query}%`, `%${query}%`, limit) as Memory[]
+        : db.prepare(sql).all(`%${query}%`, `%${query}%`, limit) as Memory[]
+    }
+  }
+
+  const logSql = agentId
+    ? 'SELECT id, agent_id, date, content, created_at FROM daily_logs WHERE content LIKE ? AND agent_id = ? ORDER BY date DESC, created_at DESC LIMIT ?'
+    : 'SELECT id, agent_id, date, content, created_at FROM daily_logs WHERE content LIKE ? ORDER BY date DESC, created_at DESC LIMIT ?'
+  const logs = agentId
+    ? db.prepare(logSql).all(`%${query}%`, agentId, limit) as RecallResult['logs']
+    : db.prepare(logSql).all(`%${query}%`, limit) as RecallResult['logs']
+
+  const dates = logs.map(l => l.date)
+  const from = dates.length ? dates[dates.length - 1] : ''
+  const to = dates.length ? dates[0] : ''
+
+  return { logs, memories, dateRange: { from, to } }
+}
+
 // --- Ütemezett feladatok ---
 
 export interface ScheduledTask {

--- a/src/web.ts
+++ b/src/web.ts
@@ -28,6 +28,7 @@ import { tryHandleAgentsSkills } from './web/routes/agents-skills.js'
 import { tryHandleSkills } from './web/routes/skills.js'
 import { tryHandleAgents } from './web/routes/agents.js'
 import { tryHandleMarveen } from './web/routes/marveen.js'
+import { tryHandleRecall } from './web/routes/recall.js'
 import { tryHandleOverview } from './web/routes/overview.js'
 import { tryHandleUpdates } from './web/routes/updates.js'
 import { tryHandleStatus } from './web/routes/status.js'
@@ -116,6 +117,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleSkills(routeCtx)) return
       if (await tryHandleAgents(routeCtx, WEB_DIR)) return
       if (await tryHandleMarveen(routeCtx, WEB_DIR)) return
+      if (await tryHandleRecall(routeCtx)) return
       if (await tryHandleOverview(routeCtx)) return
       if (await tryHandleUpdates(routeCtx)) return
       if (await tryHandleStatus(routeCtx)) return

--- a/src/web/routes/recall.ts
+++ b/src/web/routes/recall.ts
@@ -1,0 +1,208 @@
+import { recallByDateRange, recallSearch, getDailyLogDates } from '../../db.js'
+import { MAIN_AGENT_ID } from '../../config.js'
+import { json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+const TZ = 'Europe/Budapest'
+
+function todayBudapest(): string {
+  return new Date().toLocaleDateString('sv-SE', { timeZone: TZ })
+}
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(`${dateStr}T12:00:00`)
+  d.setDate(d.getDate() + days)
+  return d.toISOString().split('T')[0]
+}
+
+function startOfWeek(dateStr: string): string {
+  const d = new Date(`${dateStr}T12:00:00`)
+  const day = d.getDay()
+  const diff = day === 0 ? -6 : 1 - day
+  d.setDate(d.getDate() + diff)
+  return d.toISOString().split('T')[0]
+}
+
+function startOfMonth(dateStr: string): string {
+  return dateStr.slice(0, 8) + '01'
+}
+
+function endOfMonth(dateStr: string): string {
+  const d = new Date(`${dateStr.slice(0, 8)}01T12:00:00`)
+  d.setMonth(d.getMonth() + 1)
+  d.setDate(0)
+  return d.toISOString().split('T')[0]
+}
+
+const HU_MONTHS: Record<string, string> = {
+  'januar': '01', 'februar': '02', 'marcius': '03', 'aprilis': '04',
+  'majus': '05', 'junius': '06', 'julius': '07', 'augusztus': '08',
+  'szeptember': '09', 'oktober': '10', 'november': '11', 'december': '12',
+  'jan': '01', 'feb': '02', 'mar': '03', 'apr': '04',
+  'maj': '05', 'jun': '06', 'jul': '07', 'aug': '08',
+  'szept': '09', 'okt': '10', 'nov': '11', 'dec': '12',
+}
+
+interface DateRange { from: string; to: string }
+
+export function parseDateExpression(input: string): DateRange | null {
+  const s = input.trim().toLowerCase()
+    .replace(/á/g, 'a').replace(/é/g, 'e').replace(/í/g, 'i')
+    .replace(/ó/g, 'o').replace(/ö/g, 'o').replace(/ő/g, 'o')
+    .replace(/ú/g, 'u').replace(/ü/g, 'u').replace(/ű/g, 'u')
+  const today = todayBudapest()
+
+  if (/^(\d{4})-(\d{2})-(\d{2})$/.test(input.trim())) {
+    return { from: input.trim(), to: input.trim() }
+  }
+
+  const rangeMatch = input.trim().match(/^(\d{4}-\d{2}-\d{2})\s*[-–]\s*(\d{4}-\d{2}-\d{2})$/)
+  if (rangeMatch) {
+    return { from: rangeMatch[1], to: rangeMatch[2] }
+  }
+
+  if (s === 'ma' || s === 'today') return { from: today, to: today }
+  if (s === 'tegnap' || s === 'yesterday') {
+    const d = addDays(today, -1)
+    return { from: d, to: d }
+  }
+  if (s === 'tegnapelott') {
+    const d = addDays(today, -2)
+    return { from: d, to: d }
+  }
+
+  const daysAgoMatch = s.match(/^(\d+)\s*nap(?:ja|pal?\s+ezelott)?$/)
+  if (daysAgoMatch) {
+    const d = addDays(today, -parseInt(daysAgoMatch[1], 10))
+    return { from: d, to: d }
+  }
+
+  const weeksAgoMatch = s.match(/^(\d+)\s*het(?:e|tel?\s+ezelott)?$/)
+  if (weeksAgoMatch) {
+    const daysBack = parseInt(weeksAgoMatch[1], 10) * 7
+    const from = addDays(today, -daysBack)
+    const to = addDays(from, 6)
+    return { from, to: to > today ? today : to }
+  }
+
+  if (s === 'ezen a heten' || s === 'ez a het' || s === 'this week') {
+    return { from: startOfWeek(today), to: today }
+  }
+  if (s === 'mult heten' || s === 'elozo het' || s === 'last week') {
+    const lastWeekDay = addDays(today, -7)
+    const from = startOfWeek(lastWeekDay)
+    return { from, to: addDays(from, 6) }
+  }
+
+  if (s === 'ebben a honapban' || s === 'ez a honap' || s === 'this month') {
+    return { from: startOfMonth(today), to: today }
+  }
+  if (s === 'mult honapban' || s === 'elozo honap' || s === 'last month') {
+    const prevMonth = addDays(startOfMonth(today), -1)
+    return { from: startOfMonth(prevMonth), to: prevMonth }
+  }
+
+  const lastNDaysMatch = s.match(/^(?:utolso|elmult)\s+(\d+)\s*nap$/)
+  if (lastNDaysMatch) {
+    return { from: addDays(today, -parseInt(lastNDaysMatch[1], 10)), to: today }
+  }
+
+  for (const [name, num] of Object.entries(HU_MONTHS)) {
+    const weekMatch = s.match(new RegExp(`${name}\\s+(elso|masodik|harmadik|negyedik|utolso)\\s+het`))
+    if (weekMatch) {
+      const year = today.slice(0, 4)
+      const monthStart = `${year}-${num}-01`
+      const monthEnd = endOfMonth(monthStart)
+      const weekMap: Record<string, number> = { elso: 0, masodik: 1, harmadik: 2, negyedik: 3 }
+      if (weekMatch[1] === 'utolso') {
+        const to = monthEnd
+        const from = addDays(to, -6)
+        return { from, to }
+      }
+      const weekIdx = weekMap[weekMatch[1]] ?? 0
+      const from = addDays(startOfWeek(monthStart), weekIdx * 7)
+      const to = addDays(from, 6)
+      return { from, to: to > monthEnd ? monthEnd : to }
+    }
+
+    const dayMatch = s.match(new RegExp(`${name}\\s+(\\d{1,2})`))
+    if (dayMatch) {
+      const year = today.slice(0, 4)
+      const day = dayMatch[1].padStart(2, '0')
+      const d = `${year}-${num}-${day}`
+      return { from: d, to: d }
+    }
+
+    if (s === name || s === `${name}ban` || s === `${name}ben`) {
+      const year = today.slice(0, 4)
+      const monthStart = `${year}-${num}-01`
+      return { from: monthStart, to: endOfMonth(monthStart) }
+    }
+  }
+
+  return null
+}
+
+export async function tryHandleRecall(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method, url } = ctx
+
+  if (path === '/api/recall' && method === 'GET') {
+    const dateExpr = url.searchParams.get('date') || ''
+    const query = url.searchParams.get('q') || ''
+    const agent = url.searchParams.get('agent') || undefined
+    const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200)
+
+    if (query && !dateExpr) {
+      const result = recallSearch(query, agent, limit)
+      const formatted = formatRecallResult(result)
+      json(res, formatted)
+      return true
+    }
+
+    const range = dateExpr ? parseDateExpression(dateExpr) : { from: todayBudapest(), to: todayBudapest() }
+    if (!range) {
+      json(res, { error: `Nem értelmezhető dátum: "${dateExpr}"` }, 400)
+      return true
+    }
+
+    const result = recallByDateRange(range.from, range.to, agent)
+
+    if (query) {
+      const qLower = query.toLowerCase()
+      result.logs = result.logs.filter(l => l.content.toLowerCase().includes(qLower))
+      result.memories = result.memories.filter(m => m.content.toLowerCase().includes(qLower) || (m.keywords || '').toLowerCase().includes(qLower))
+    }
+
+    json(res, formatRecallResult(result))
+    return true
+  }
+
+  if (path === '/api/recall/dates' && method === 'GET') {
+    const agent = url.searchParams.get('agent') || MAIN_AGENT_ID
+    const limit = Math.min(parseInt(url.searchParams.get('limit') || '90', 10), 365)
+    json(res, getDailyLogDates(agent, limit))
+    return true
+  }
+
+  return false
+}
+
+function formatRecallResult(result: { logs: any[]; memories: any[]; dateRange: { from: string; to: string } }) {
+  return {
+    dateRange: result.dateRange,
+    logs: result.logs.map(l => ({
+      ...l,
+      created_label: new Date(l.created_at * 1000).toLocaleString('hu-HU', { timeZone: TZ }),
+    })),
+    memories: result.memories.map(m => ({
+      ...m,
+      embedding: undefined,
+      created_label: new Date(m.created_at * 1000).toLocaleString('hu-HU', { timeZone: TZ }),
+    })),
+    summary: {
+      logCount: result.logs.length,
+      memoryCount: result.memories.length,
+      agents: [...new Set([...result.logs.map(l => l.agent_id), ...result.memories.map(m => m.agent_id)])],
+    },
+  }
+}

--- a/src/web/routes/recall.ts
+++ b/src/web/routes/recall.ts
@@ -6,21 +6,29 @@ import type { RouteContext } from './types.js'
 const TZ = 'Europe/Budapest'
 
 function todayBudapest(): string {
-  return new Date().toLocaleDateString('sv-SE', { timeZone: TZ })
+  return new Intl.DateTimeFormat('sv-SE', { timeZone: TZ }).format(new Date())
+}
+
+function budapestDate(d: Date): string {
+  return new Intl.DateTimeFormat('sv-SE', { timeZone: TZ }).format(d)
 }
 
 function addDays(dateStr: string, days: number): string {
-  const d = new Date(`${dateStr}T12:00:00`)
-  d.setDate(d.getDate() + days)
-  return d.toISOString().split('T')[0]
+  const ms = new Date(`${dateStr}T12:00:00Z`).getTime() + days * 86_400_000
+  return budapestDate(new Date(ms))
+}
+
+function dayOfWeekBudapest(dateStr: string): number {
+  const d = new Date(`${dateStr}T12:00:00Z`)
+  const weekday = new Intl.DateTimeFormat('en-US', { timeZone: TZ, weekday: 'short' }).format(d)
+  const map: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 }
+  return map[weekday] ?? 0
 }
 
 function startOfWeek(dateStr: string): string {
-  const d = new Date(`${dateStr}T12:00:00`)
-  const day = d.getDay()
-  const diff = day === 0 ? -6 : 1 - day
-  d.setDate(d.getDate() + diff)
-  return d.toISOString().split('T')[0]
+  const dow = dayOfWeekBudapest(dateStr)
+  const diff = dow === 0 ? -6 : 1 - dow
+  return addDays(dateStr, diff)
 }
 
 function startOfMonth(dateStr: string): string {
@@ -28,10 +36,9 @@ function startOfMonth(dateStr: string): string {
 }
 
 function endOfMonth(dateStr: string): string {
-  const d = new Date(`${dateStr.slice(0, 8)}01T12:00:00`)
-  d.setMonth(d.getMonth() + 1)
-  d.setDate(0)
-  return d.toISOString().split('T')[0]
+  const [y, m] = dateStr.split('-').map(Number)
+  const last = new Date(Date.UTC(y, m, 0))
+  return budapestDate(last)
 }
 
 const HU_MONTHS: Record<string, string> = {
@@ -43,20 +50,37 @@ const HU_MONTHS: Record<string, string> = {
   'szept': '09', 'okt': '10', 'nov': '11', 'dec': '12',
 }
 
+const HU_DAYS: Record<string, number> = {
+  'hetfo': 1, 'kedd': 2, 'szerda': 3, 'csutortok': 4,
+  'pentek': 5, 'szombat': 6, 'vasarnap': 0,
+}
+
 interface DateRange { from: string; to: string }
 
-export function parseDateExpression(input: string): DateRange | null {
-  const s = input.trim().toLowerCase()
+function stripAccents(s: string): string {
+  return s
     .replace(/á/g, 'a').replace(/é/g, 'e').replace(/í/g, 'i')
     .replace(/ó/g, 'o').replace(/ö/g, 'o').replace(/ő/g, 'o')
     .replace(/ú/g, 'u').replace(/ü/g, 'u').replace(/ű/g, 'u')
+}
+
+function lastOccurrence(targetDow: number, today: string): string {
+  const todayDow = dayOfWeekBudapest(today)
+  let diff = todayDow - targetDow
+  if (diff <= 0) diff += 7
+  return addDays(today, -diff)
+}
+
+export function parseDateExpression(input: string): DateRange | null {
+  const raw = input.trim()
+  const s = stripAccents(raw.toLowerCase())
   const today = todayBudapest()
 
-  if (/^(\d{4})-(\d{2})-(\d{2})$/.test(input.trim())) {
-    return { from: input.trim(), to: input.trim() }
+  if (/^(\d{4})-(\d{2})-(\d{2})$/.test(raw)) {
+    return { from: raw, to: raw }
   }
 
-  const rangeMatch = input.trim().match(/^(\d{4}-\d{2}-\d{2})\s*[-–]\s*(\d{4}-\d{2}-\d{2})$/)
+  const rangeMatch = raw.match(/^(\d{4}-\d{2}-\d{2})\s*[-–]\s*(\d{4}-\d{2}-\d{2})$/)
   if (rangeMatch) {
     return { from: rangeMatch[1], to: rangeMatch[2] }
   }
@@ -69,6 +93,13 @@ export function parseDateExpression(input: string): DateRange | null {
   if (s === 'tegnapelott') {
     const d = addDays(today, -2)
     return { from: d, to: d }
+  }
+
+  for (const [name, dow] of Object.entries(HU_DAYS)) {
+    if (s === name || s === `mult ${name}` || s === `elozo ${name}`) {
+      const d = lastOccurrence(dow, today)
+      return { from: d, to: d }
+    }
   }
 
   const daysAgoMatch = s.match(/^(\d+)\s*nap(?:ja|pal?\s+ezelott)?$/)
@@ -120,7 +151,9 @@ export function parseDateExpression(input: string): DateRange | null {
         return { from, to }
       }
       const weekIdx = weekMap[weekMatch[1]] ?? 0
-      const from = addDays(startOfWeek(monthStart), weekIdx * 7)
+      let weekStart = startOfWeek(monthStart)
+      if (weekStart < monthStart) weekStart = addDays(weekStart, 7)
+      const from = addDays(weekStart, weekIdx * 7)
       const to = addDays(from, 6)
       return { from, to: to > monthEnd ? monthEnd : to }
     }
@@ -141,6 +174,10 @@ export function parseDateExpression(input: string): DateRange | null {
   }
 
   return null
+}
+
+function escapeLike(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
 }
 
 export async function tryHandleRecall(ctx: RouteContext): Promise<boolean> {
@@ -168,7 +205,8 @@ export async function tryHandleRecall(ctx: RouteContext): Promise<boolean> {
     const result = recallByDateRange(range.from, range.to, agent)
 
     if (query) {
-      const qLower = query.toLowerCase()
+      const escaped = escapeLike(query)
+      const qLower = escaped.toLowerCase()
       result.logs = result.logs.filter(l => l.content.toLowerCase().includes(qLower))
       result.memories = result.memories.filter(m => m.content.toLowerCase().includes(qLower) || (m.keywords || '').toLowerCase().includes(qLower))
     }

--- a/web/app.js
+++ b/web/app.js
@@ -6543,8 +6543,25 @@ async function loadRecallPage() {
     document.getElementById('recallBtn').addEventListener('click', doRecall)
     document.getElementById('recallExpr').addEventListener('keydown', e => { if (e.key === 'Enter') doRecall() })
     document.getElementById('recallSearch').addEventListener('keydown', e => { if (e.key === 'Enter') doRecall() })
+
+    loadRecallDates()
   }
   doRecall()
+}
+
+async function loadRecallDates() {
+  try {
+    const agentVal = document.getElementById('recallAgent').value
+    const params = agentVal ? `?agent=${encodeURIComponent(agentVal)}&limit=90` : '?limit=90'
+    const res = await fetch('/api/recall/dates' + params)
+    if (!res.ok) return
+    const dates = await res.json()
+    const dateInput = document.getElementById('recallDate')
+    if (dates.length && !dateInput.value) {
+      dateInput.value = dates[0]
+    }
+    dateInput.setAttribute('title', `${dates.length} nap naplóval`)
+  } catch {}
 }
 
 async function doRecall() {
@@ -6627,7 +6644,7 @@ function renderRecallTimeline(el, data) {
     } else {
       const catColors = { hot: '#ef4444', warm: '#f59e0b', cold: '#3b82f6', shared: '#8b5cf6' }
       const catColor = catColors[item.category] || '#6b7280'
-      html += `<div class="recall-item recall-memory" style="margin-bottom:12px;padding:10px 14px;border-radius:8px;background:var(--surface);border-left:3px solid ${catColor};border:1px solid var(--border);border-left:3px solid ${catColor};">
+      html += `<div class="recall-item recall-memory" style="margin-bottom:12px;padding:10px 14px;border-radius:8px;background:var(--surface);border:1px solid var(--border);border-left:3px solid ${catColor};">
         <div style="display:flex;justify-content:space-between;margin-bottom:4px;">
           <span style="font-size:12px;color:var(--text-muted)">${esc(item.label)}</span>
           <div style="display:flex;gap:6px;">

--- a/web/app.js
+++ b/web/app.js
@@ -78,6 +78,7 @@ function switchPage(pageId) {
   if (pageId === 'connectors') loadConnectors()
   if (pageId === 'migrate') loadMigrateAgents()
   if (pageId === 'status') loadStatus()
+  if (pageId === 'recall') loadRecallPage()
   if (pageId === 'vault') loadVaultPage()
   if (pageId === 'updates') loadUpdates()
   if (pageId === 'team') loadTeamGraph()
@@ -6512,3 +6513,139 @@ document.getElementById('chSlackManifestBtn').addEventListener('click', async ()
     btn.disabled = false
   }
 })
+
+// ============================================================
+// === Recall / Napló ===
+// ============================================================
+
+let recallInitialized = false
+
+async function loadRecallPage() {
+  if (!recallInitialized) {
+    recallInitialized = true
+    const today = new Date().toISOString().split('T')[0]
+    document.getElementById('recallDate').value = today
+
+    try {
+      const res = await fetch('/api/agents')
+      if (res.ok) {
+        const agents = await res.json()
+        const sel = document.getElementById('recallAgent')
+        agents.forEach(a => {
+          const opt = document.createElement('option')
+          opt.value = a.name
+          opt.textContent = a.name
+          sel.appendChild(opt)
+        })
+      }
+    } catch {}
+
+    document.getElementById('recallBtn').addEventListener('click', doRecall)
+    document.getElementById('recallExpr').addEventListener('keydown', e => { if (e.key === 'Enter') doRecall() })
+    document.getElementById('recallSearch').addEventListener('keydown', e => { if (e.key === 'Enter') doRecall() })
+  }
+  doRecall()
+}
+
+async function doRecall() {
+  const dateInput = document.getElementById('recallDate').value
+  const exprInput = document.getElementById('recallExpr').value.trim()
+  const searchInput = document.getElementById('recallSearch').value.trim()
+  const agentInput = document.getElementById('recallAgent').value
+
+  const params = new URLSearchParams()
+  if (exprInput) {
+    params.set('date', exprInput)
+  } else if (dateInput) {
+    params.set('date', dateInput)
+  }
+  if (searchInput) params.set('q', searchInput)
+  if (agentInput) params.set('agent', agentInput)
+
+  const timeline = document.getElementById('recallTimeline')
+  const summary = document.getElementById('recallSummary')
+  timeline.innerHTML = '<p style="color:var(--text-muted)">Betöltés...</p>'
+  summary.innerHTML = ''
+
+  try {
+    const res = await fetch('/api/recall?' + params.toString())
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      timeline.innerHTML = `<p style="color:var(--danger)">${esc(err.error || 'Hiba történt')}</p>`
+      return
+    }
+    const data = await res.json()
+    renderRecallSummary(summary, data)
+    renderRecallTimeline(timeline, data)
+  } catch (err) {
+    timeline.innerHTML = '<p style="color:var(--danger)">Nem sikerült betölteni</p>'
+  }
+}
+
+function renderRecallSummary(el, data) {
+  const { dateRange, summary: s } = data
+  const parts = []
+  if (dateRange.from === dateRange.to) {
+    parts.push(`<strong>${esc(dateRange.from)}</strong>`)
+  } else if (dateRange.from && dateRange.to) {
+    parts.push(`<strong>${esc(dateRange.from)}</strong> &ndash; <strong>${esc(dateRange.to)}</strong>`)
+  }
+  parts.push(`${s.logCount} naplóbejegyzés`)
+  parts.push(`${s.memoryCount} emlék`)
+  if (s.agents.length) parts.push(`Ágensek: ${s.agents.map(esc).join(', ')}`)
+  el.innerHTML = `<div style="display:flex;gap:16px;flex-wrap:wrap;font-size:14px;color:var(--text-muted)">${parts.map(p => `<span>${p}</span>`).join('')}</div>`
+}
+
+function renderRecallTimeline(el, data) {
+  const { logs, memories } = data
+  if (!logs.length && !memories.length) {
+    el.innerHTML = '<p style="color:var(--text-muted)">Nincs találat erre az időszakra.</p>'
+    return
+  }
+
+  const items = []
+  logs.forEach(l => items.push({ type: 'log', ts: l.created_at, agent: l.agent_id, date: l.date, content: l.content, label: l.created_label }))
+  memories.forEach(m => items.push({ type: 'memory', ts: m.created_at, agent: m.agent_id, category: m.category, content: m.content, keywords: m.keywords, label: m.created_label }))
+  items.sort((a, b) => a.ts - b.ts)
+
+  let currentDate = ''
+  let html = ''
+  for (const item of items) {
+    const dateStr = item.date || new Date(item.ts * 1000).toISOString().split('T')[0]
+    if (dateStr !== currentDate) {
+      currentDate = dateStr
+      html += `<div class="recall-date-header" style="margin-top:20px;margin-bottom:8px;font-weight:600;font-size:15px;color:var(--text-primary);border-bottom:1px solid var(--border);padding-bottom:4px;">${esc(dateStr)}</div>`
+    }
+    if (item.type === 'log') {
+      html += `<div class="recall-item recall-log" style="margin-bottom:12px;padding:10px 14px;border-radius:8px;background:var(--surface);border:1px solid var(--border);">
+        <div style="display:flex;justify-content:space-between;margin-bottom:4px;">
+          <span style="font-size:12px;color:var(--text-muted)">${esc(item.label)}</span>
+          <span class="badge" style="font-size:11px;background:var(--primary);color:#fff;padding:2px 8px;border-radius:12px;">${esc(item.agent)}</span>
+        </div>
+        <div style="white-space:pre-wrap;font-size:13px;line-height:1.5;">${esc(item.content)}</div>
+      </div>`
+    } else {
+      const catColors = { hot: '#ef4444', warm: '#f59e0b', cold: '#3b82f6', shared: '#8b5cf6' }
+      const catColor = catColors[item.category] || '#6b7280'
+      html += `<div class="recall-item recall-memory" style="margin-bottom:12px;padding:10px 14px;border-radius:8px;background:var(--surface);border-left:3px solid ${catColor};border:1px solid var(--border);border-left:3px solid ${catColor};">
+        <div style="display:flex;justify-content:space-between;margin-bottom:4px;">
+          <span style="font-size:12px;color:var(--text-muted)">${esc(item.label)}</span>
+          <div style="display:flex;gap:6px;">
+            <span class="badge" style="font-size:11px;background:${catColor};color:#fff;padding:2px 8px;border-radius:12px;">${esc(item.category)}</span>
+            <span class="badge" style="font-size:11px;background:var(--primary);color:#fff;padding:2px 8px;border-radius:12px;">${esc(item.agent)}</span>
+          </div>
+        </div>
+        <div style="white-space:pre-wrap;font-size:13px;line-height:1.5;">${esc(item.content)}</div>
+        ${item.keywords ? `<div style="margin-top:4px;font-size:11px;color:var(--text-muted)">Kulcsszavak: ${esc(item.keywords)}</div>` : ''}
+      </div>`
+    }
+  }
+  el.innerHTML = html
+}
+
+function esc(s) {
+  if (!s) return ''
+  const d = document.createElement('div')
+  d.textContent = String(s)
+  return d.innerHTML
+}

--- a/web/index.html
+++ b/web/index.html
@@ -40,6 +40,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3C7.5 3 4 6.5 4 11v4l-2 3h4v2a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v0a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v-2h4l-2-3v-4c0-4.5-3.5-8-8-8z"/></svg>
         <span class="sb-label">Memória</span>
       </a>
+      <a href="#" class="sb-link" data-page="recall">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        <span class="sb-label">Napló</span>
+      </a>
       <a href="#" class="sb-link" data-page="skills">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15 8.5 22 9.3 17 14.2 18.2 21 12 17.8 5.8 21 7 14.2 2 9.3 9 8.5"/></svg>
         <span class="sb-label">Skillek</span>
@@ -364,6 +368,29 @@
           <p>Nincs naplobejegyzes ezen a napon</p>
         </div>
       </div>
+    </div>
+
+    <!-- === Recall / Napló Page === -->
+    <div class="page" id="recallPage" hidden>
+      <div class="page-header">
+        <div class="page-header-row">
+          <div>
+            <h1>Napló</h1>
+            <p class="subtitle">Session recall: napi naplók és emlékek visszakeresése</p>
+          </div>
+        </div>
+      </div>
+      <div class="recall-controls" style="display:flex;gap:12px;margin-bottom:16px;align-items:center;flex-wrap:wrap;">
+        <input type="date" id="recallDate" class="input" style="width:180px;">
+        <input type="text" id="recallExpr" class="input" placeholder="pl. tegnap, múlt héten, május első hete" style="width:260px;">
+        <input type="text" id="recallSearch" class="input" placeholder="Keresés szövegben..." style="width:220px;">
+        <select id="recallAgent" class="input" style="width:150px;">
+          <option value="">Minden ágens</option>
+        </select>
+        <button class="btn btn-primary" id="recallBtn">Keresés</button>
+      </div>
+      <div class="recall-summary" id="recallSummary" style="margin-bottom:12px;"></div>
+      <div class="recall-timeline" id="recallTimeline"></div>
     </div>
 
     <!-- === Connectors Page === -->


### PR DESCRIPTION
## Summary
- GET /api/recall?date=&q=&agent= endpoint: daily_logs + memories JOIN dátum-tartományra vagy szöveges keresésre
- Magyar természetes nyelv dátum-parser (tegnap, múlt héten, május első hete, elmúlt N nap, stb.)
- Dashboard "Napló" oldal: dátum-szelektor, kifejezés input, szöveg keresés, ágens filter, kronológikus timeline
- GET /api/recall/dates endpoint a dátum-szelektor feltöltéséhez

## Test plan
- [ ] API teszt: `curl /api/recall?date=tegnap` visszaadja a tegnapi naplókat és emlékeket
- [ ] API teszt: `curl /api/recall?date=2026-05-19&q=kanban` szűrt eredmények
- [ ] API teszt: dátum-range `curl /api/recall?date=mult+heten`
- [ ] Dashboard: Napló oldal betöltődik, dátum-szelektor működik
- [ ] Dashboard: keresés szövegben szűr
- [ ] Dashboard: ágens filter működik

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>