### PR TITLE
feat(breakdown): claude -p headless spawn replaces API keys

### DIFF
--- a/src/__tests__/kanban-breakdown.test.ts
+++ b/src/__tests__/kanban-breakdown.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import Database from 'better-sqlite3'
 import { validateSubtasks } from '../web/llm-breakdown.js'
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  execSync: vi.fn(() => '/usr/local/bin/claude'),
+}))
 
 describe('kanban parent_id schema and subtask queries', () => {
   let db: ReturnType<typeof Database>
@@ -180,6 +185,76 @@ describe('validateSubtasks (from llm-breakdown)', () => {
     const result = validateSubtasks(malicious, validAssignees)
     expect(result[0].title).toBe('Ignore previous instructions')
     expect(result[0].assignee).toBeNull()
+  })
+})
+
+describe('generateBreakdown with claude -p', () => {
+  let mockedExecFile: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    const cp = await import('node:child_process')
+    mockedExecFile = vi.mocked(cp.execFile)
+  })
+
+  it('parses claude -p JSON result output', async () => {
+    const subtasks = [
+      { title: 'Step 1', description: 'Do first thing', assignee: null, priority: 'normal' },
+      { title: 'Step 2', description: 'Do second thing', assignee: null, priority: 'high' },
+    ]
+    mockedExecFile.mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify({ result: JSON.stringify(subtasks) }), '')
+      return { stdin: { write: () => {}, end: () => {} } } as any
+    })
+
+    const { generateBreakdown } = await import('../web/llm-breakdown.js')
+    const result = await generateBreakdown('Test card', 'Some description')
+    expect(result.subtasks).toHaveLength(2)
+    expect(result.subtasks[0].title).toBe('Step 1')
+    expect(result.subtasks[1].priority).toBe('high')
+  })
+
+  it('handles timeout error', async () => {
+    mockedExecFile.mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      const err = new Error('timed out') as any
+      err.killed = true
+      cb(err, '', '')
+      return { stdin: { write: () => {}, end: () => {} } } as any
+    })
+
+    const { generateBreakdown } = await import('../web/llm-breakdown.js')
+    await expect(generateBreakdown('Test', null)).rejects.toThrow('timed out after 60s')
+  })
+
+  it('handles non-JSON output', async () => {
+    mockedExecFile.mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, 'This is not JSON at all', '')
+      return { stdin: { write: () => {}, end: () => {} } } as any
+    })
+
+    const { generateBreakdown } = await import('../web/llm-breakdown.js')
+    await expect(generateBreakdown('Test', null)).rejects.toThrow('parse')
+  })
+
+  it('passes prompt via stdin (not in args)', async () => {
+    const subtasks = [{ title: 'T', description: 'D', assignee: null, priority: 'normal' }]
+    let stdinData = ''
+    mockedExecFile.mockImplementation((_cmd: any, args: any, _opts: any, cb: any) => {
+      expect(args).not.toContain(expect.stringContaining('card_title'))
+      cb(null, JSON.stringify({ result: JSON.stringify(subtasks) }), '')
+      return {
+        stdin: {
+          write: (data: string) => { stdinData = data },
+          end: () => {},
+        },
+      } as any
+    })
+
+    const { generateBreakdown } = await import('../web/llm-breakdown.js')
+    await generateBreakdown('My card', 'Description')
+    expect(stdinData).toContain('card_title')
+    expect(stdinData).toContain('My card')
   })
 })
 

--- a/src/web/llm-breakdown.ts
+++ b/src/web/llm-breakdown.ts
@@ -1,6 +1,7 @@
-import { readEnvFile } from '../env.js'
+import { execFile } from 'node:child_process'
 import { logger } from '../logger.js'
 import { listAgentNames } from './agent-config.js'
+import { resolveFromPath } from '../platform.js'
 
 export interface SubtaskSuggestion {
   title: string
@@ -11,8 +12,9 @@ export interface SubtaskSuggestion {
 
 export interface BreakdownResult {
   subtasks: SubtaskSuggestion[]
-  provider: 'anthropic' | 'gemini'
 }
+
+const TIMEOUT_MS = 60_000
 
 const SYSTEM_PROMPT = `You are a project management assistant that breaks down kanban cards into actionable subtasks.
 
@@ -50,53 +52,41 @@ function getValidAssignees(): Set<string> {
   return new Set(['Szabolcs', 'Marveen', ...agents])
 }
 
-async function callAnthropic(apiKey: string, userPrompt: string): Promise<SubtaskSuggestion[]> {
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-    },
-    body: JSON.stringify({
-      model: 'claude-haiku-4-5-20251001',
-      max_tokens: 1024,
-      system: SYSTEM_PROMPT,
-      messages: [{ role: 'user', content: userPrompt }],
-    }),
-  })
-  if (!res.ok) {
-    const body = await res.text()
-    throw new Error(`Anthropic API ${res.status}: ${body.slice(0, 200)}`)
-  }
-  const data = await res.json() as { content: Array<{ type: string; text: string }> }
-  const text = data.content.find(b => b.type === 'text')?.text ?? '[]'
-  return JSON.parse(text) as SubtaskSuggestion[]
+function resolveClaudeBinary(): string {
+  return resolveFromPath('claude')
 }
 
-async function callGemini(apiKey: string, userPrompt: string): Promise<SubtaskSuggestion[]> {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      systemInstruction: { parts: [{ text: SYSTEM_PROMPT }] },
-      contents: [{ parts: [{ text: userPrompt }] }],
-      generationConfig: {
-        responseMimeType: 'application/json',
-        temperature: 0.3,
+async function callClaudeP(userPrompt: string): Promise<SubtaskSuggestion[]> {
+  const claude = resolveClaudeBinary()
+  const fullPrompt = `${SYSTEM_PROMPT}\n\n${userPrompt}`
+
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      claude,
+      ['-p', '--model', 'claude-sonnet-4-6', '--output-format', 'json'],
+      { timeout: TIMEOUT_MS, maxBuffer: 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          if ((err as any).killed || err.message.includes('TIMEOUT') || err.message.includes('timed out')) {
+            return reject(new Error('claude -p timed out after 60s'))
+          }
+          logger.warn({ err, stderr: stderr?.slice(0, 300) }, 'claude -p failed')
+          return reject(new Error(`claude -p failed: ${err.message}`))
+        }
+        try {
+          const parsed = JSON.parse(stdout)
+          const text = parsed?.result ?? stdout
+          const subtasks = typeof text === 'string' ? JSON.parse(text) : text
+          resolve(Array.isArray(subtasks) ? subtasks : [])
+        } catch (parseErr) {
+          logger.warn({ stdout: stdout?.slice(0, 500) }, 'claude -p output parse failed')
+          reject(new Error('Failed to parse claude -p output as JSON'))
+        }
       },
-    }),
+    )
+    child.stdin?.write(fullPrompt)
+    child.stdin?.end()
   })
-  if (!res.ok) {
-    const body = await res.text()
-    throw new Error(`Gemini API ${res.status}: ${body.slice(0, 200)}`)
-  }
-  const data = await res.json() as {
-    candidates: Array<{ content: { parts: Array<{ text: string }> } }>
-  }
-  const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '[]'
-  return JSON.parse(text) as SubtaskSuggestion[]
 }
 
 export function validateSubtasks(raw: unknown, validAssignees?: Set<string>): SubtaskSuggestion[] {
@@ -118,27 +108,18 @@ export function validateSubtasks(raw: unknown, validAssignees?: Set<string>): Su
 }
 
 export async function generateBreakdown(title: string, description: string | null): Promise<BreakdownResult> {
-  const env = readEnvFile()
-  const anthropicKey = env['ANTHROPIC_API_KEY']
-  const geminiKey = env['GOOGLE_API_KEY']
-
   const validAssignees = getValidAssignees()
   const agents = [...validAssignees]
   const userPrompt = buildUserPrompt(title, description, agents)
 
-  if (anthropicKey) {
-    try {
-      const raw = await callAnthropic(anthropicKey, userPrompt)
-      return { subtasks: validateSubtasks(raw, validAssignees), provider: 'anthropic' }
-    } catch (err) {
-      logger.warn({ err }, 'Anthropic breakdown failed, trying Gemini fallback')
+  try {
+    const raw = await callClaudeP(userPrompt)
+    return { subtasks: validateSubtasks(raw, validAssignees) }
+  } catch (err) {
+    const msg = (err as Error).message
+    if (msg.includes('not found on PATH')) {
+      throw new Error('claude CLI not available on this system')
     }
+    throw err
   }
-
-  if (geminiKey) {
-    const raw = await callGemini(geminiKey, userPrompt)
-    return { subtasks: validateSubtasks(raw, validAssignees), provider: 'gemini' }
-  }
-
-  throw new Error('No API key available (ANTHROPIC_API_KEY or GOOGLE_API_KEY required in .env)')
 }

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -103,7 +103,7 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
     if (existing.length > 0) { json(res, { error: 'A kártya már rendelkezik subtask-okkal' }, 409); return true }
     try {
       const result = await generateBreakdown(card.title, card.description)
-      json(res, { subtasks: result.subtasks, provider: result.provider })
+      json(res, { subtasks: result.subtasks })
     } catch (err) {
       logger.error({ err, cardId }, 'Breakdown generation failed')
       json(res, { error: (err as Error).message }, 500)

--- a/web/app.js
+++ b/web/app.js
@@ -557,7 +557,7 @@ async function showCardDetail(card) {
       if (!res.ok) { showToast(data.error || 'Hiba'); btn.disabled = false; btn.textContent = 'Breakdown'; return }
       breakdownCardId = card.id
       breakdownSubtasks = data.subtasks
-      showBreakdownModal(data.subtasks, data.provider, card)
+      showBreakdownModal(data.subtasks, card)
     } catch (err) {
       showToast('Breakdown hiba')
     } finally {
@@ -578,7 +578,7 @@ async function triggerBreakdown(card) {
     if (!res.ok) { showToast(data.error || 'Breakdown hiba'); return }
     breakdownCardId = card.id
     breakdownSubtasks = data.subtasks
-    showBreakdownModal(data.subtasks, data.provider, card)
+    showBreakdownModal(data.subtasks, card)
   } catch {
     showToast('Breakdown hiba')
   } finally {
@@ -586,8 +586,8 @@ async function triggerBreakdown(card) {
   }
 }
 
-function showBreakdownModal(subtasks, provider, parentCard) {
-  document.getElementById('breakdownProvider').textContent = `${provider} · Szülő: ${escapeHtml(parentCard.title)}`
+function showBreakdownModal(subtasks, parentCard) {
+  document.getElementById('breakdownProvider').textContent = `Szülő: ${escapeHtml(parentCard.title)}`
   const list = document.getElementById('breakdownList')
   list.innerHTML = ''
 


### PR DESCRIPTION
## Summary
- Rewrites `src/web/llm-breakdown.ts` to use `claude -p` headless spawn via `execFile` + stdin instead of Anthropic/Gemini API keys
- Prompt sent via stdin (not CLI args) to keep it out of the process list
- 60s timeout, JSON output parsing with `--output-format json`
- Removes `provider` field from `BreakdownResult` (no longer dual-provider)
- Dashboard JS updated to remove provider display
- **Supersedes PR #127** (Anthropic-only approach)

## Changes
| File | What |
|------|------|
| `src/web/llm-breakdown.ts` | Removed `callAnthropic`, `callGemini`, API key reading. New `callClaudeP()` using `execFile` + stdin |
| `src/web/routes/kanban.ts` | Removed `provider` from response JSON |
| `web/app.js` | Removed `provider` param from `showBreakdownModal()` |
| `src/__tests__/kanban-breakdown.test.ts` | Added 4 new tests: JSON parse, timeout, non-JSON, stdin verification. Total: 24 tests |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] 24/24 kanban-breakdown tests pass
- [x] 526/526 full suite tests pass
- [ ] Manual: trigger Breakdown on a kanban card via dashboard

Kanban: 93A790E0