### PR TITLE
feat(autonomy): dashboard UI + API for granular autonomy control

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -442,6 +442,20 @@ if [ -d "$SCHED_TPL_DIR" ]; then
   done
 fi
 
+# Seed config: copy default config files into store/ (idempotent: never overwrite)
+SEED_CONFIG_DIR="$INSTALL_DIR/seed-config"
+if [ -d "$SEED_CONFIG_DIR" ]; then
+  for cfg in "$SEED_CONFIG_DIR"/*.json; do
+    [ -f "$cfg" ] || continue
+    cfg_name=$(basename "$cfg")
+    target="$INSTALL_DIR/store/$cfg_name"
+    if [ ! -f "$target" ]; then
+      cp "$cfg" "$target"
+      ok "Seed config: $cfg_name"
+    fi
+  done
+fi
+
 # Channel state directory setup
 CHANNEL_DIR="$HOME/.claude/channels/$CHANNEL_PROVIDER"
 mkdir -p "$CHANNEL_DIR"

--- a/install.sh
+++ b/install.sh
@@ -502,6 +502,20 @@ if [ -d "$SEED_SCHED_DIR" ]; then
   fi
 fi
 
+# Seed config: copy default config files into store/ (idempotent: never overwrite)
+SEED_CONFIG_DIR="$INSTALL_DIR/seed-config"
+if [ -d "$SEED_CONFIG_DIR" ]; then
+  for cfg in "$SEED_CONFIG_DIR"/*.json; do
+    [ -f "$cfg" ] || continue
+    cfg_name=$(basename "$cfg")
+    target="$INSTALL_DIR/store/$cfg_name"
+    if [ ! -f "$target" ]; then
+      cp "$cfg" "$target"
+      echo -e "  ${GREEN}✓${NC} Seed config: $cfg_name"
+    fi
+  done
+fi
+
 # Ollama + nomic-embed-text (szemantikus kereséshez)
 echo ""
 echo -e "  Ollama ellenőrzés (szemantikus memória kereséshez)..."

--- a/seed-config/autonomy-config.json
+++ b/seed-config/autonomy-config.json
@@ -1,0 +1,98 @@
+{
+  "version": 1,
+  "updated_at": 0,
+  "_doc": "Heartbeat fokozatos autonomia. level: 1=csak jelez, 2=javasol+jovahagyas, 3=autonom+jelent. locked=true eseten a hard safety-szabaly miatt maxLevel=1, nem emelheto.",
+  "categories": [
+    {
+      "key": "kanban_archive_done",
+      "label": "7+ napos done kartya archivalas",
+      "level": 1,
+      "locked": false,
+      "maxLevel": 3
+    },
+    {
+      "key": "kanban_stuck_nudge",
+      "label": "Beakadt task: assignee nudge (2 kor utan eszkalal)",
+      "level": 1,
+      "locked": false,
+      "maxLevel": 3
+    },
+    {
+      "key": "memory_maintenance",
+      "label": "Memoria rendberakas (vektorizalas, teszt-spam cold-ba)",
+      "level": 1,
+      "locked": false,
+      "maxLevel": 3
+    },
+    {
+      "key": "routine_trivial_fix",
+      "label": "Deli/reggeli rutin trivialis javitasai",
+      "level": 1,
+      "locked": false,
+      "maxLevel": 3
+    },
+    {
+      "key": "deploy_retry",
+      "label": "Elbukott deploy/CI ujraprobalkozas",
+      "level": 1,
+      "locked": false,
+      "maxLevel": 3
+    },
+    {
+      "key": "kanban_restructure",
+      "label": "Kanban kartya atstrukturlas / sub-task bontas",
+      "level": 1,
+      "locked": false,
+      "maxLevel": 3
+    },
+    {
+      "key": "skill_patch",
+      "label": "Skill-patch alkalmazas",
+      "level": 1,
+      "locked": false,
+      "maxLevel": 3
+    },
+    {
+      "key": "email_send",
+      "label": "Email kuldes / valasz",
+      "level": 1,
+      "locked": false,
+      "maxLevel": 2
+    },
+    {
+      "key": "publish_content",
+      "label": "Publikalas (Skool / blog / kozosseg)",
+      "level": 1,
+      "locked": true,
+      "maxLevel": 1
+    },
+    {
+      "key": "payment",
+      "label": "Vasarlas / penzmozgas",
+      "level": 1,
+      "locked": true,
+      "maxLevel": 1
+    },
+    {
+      "key": "data_delete",
+      "label": "Fajl / adat torles",
+      "level": 1,
+      "locked": true,
+      "maxLevel": 1
+    },
+    {
+      "key": "permission_change",
+      "label": "Jogosultsag-valtoztatas / megosztas",
+      "level": 1,
+      "locked": true,
+      "maxLevel": 1
+    },
+    {
+      "key": "external_message",
+      "label": "Kulso uzenet kuldes",
+      "level": 1,
+      "locked": true,
+      "maxLevel": 1
+    }
+  ]
+}

--- a/seed-scheduled-tasks/kanban-audit/SKILL.md
+++ b/seed-scheduled-tasks/kanban-audit/SKILL.md
@@ -8,6 +8,16 @@ description: 4 óránkénti kanban-tábla audit. Tisztítás (7+ napos done arch
 ## Mikor fut
 - 8:00, 12:00, 16:00, 20:00 (kanban-audit cron 0 8,12,16,20)
 
+## Autonómia-szint (config-vezérelt, KÖTELEZŐ ELŐSZÖR)
+
+Olvasd be: `jq -r '.categories[]|select(.key=="kanban_archive_done" or .key=="kanban_stuck_nudge")|"\(.key) \(.level)"' /Users/marvin/ClaudeClaw/store/autonomy-config.json`
+
+A két kategória szintje szabályozza a 2. és 4. lépést:
+- **`kanban_archive_done`** (2. lépés): level 3 → archiváld magától (alapért). level 2 → NE archiválj, Telegramon javasold ("X db 7+ napos done archiválásra vár, mehet?") és várj jóváhagyást. level 1 → csak jelezd a számot.
+- **`kanban_stuck_nudge`** (4. lépés): level 3 → pingeld az assignee-t magától, és CSAK 2 eredménytelen audit-kör után eszkalálj Szabihoz (a komment-történetből látod hányszor pingelted). level 2 → ne pingelj magadtól, Telegramon javasold Szabinak. level 1 → csak listázd a beakadt taskokat.
+
+Ha a config hiányzik vagy a kulcs nincs benne → default level 3 (régi viselkedés).
+
 ## Eljárás
 
 1. **State-fájl beolvasás**: `store/kanban-audit-state.json` tartalmazza `last_audit_at` Unix timestampet. Első futáskor null -> ne pingelj senkit, csak állítsd be a state-et.

--- a/src/web.ts
+++ b/src/web.ts
@@ -33,6 +33,7 @@ import { tryHandleBackgroundTasks, sweepOrphanedBackgroundTasks } from './web/ro
 import { tryHandleOverview } from './web/routes/overview.js'
 import { tryHandleUpdates } from './web/routes/updates.js'
 import { tryHandleStatus } from './web/routes/status.js'
+import { tryHandleAutonomy } from './web/routes/autonomy.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import type { RouteContext } from './web/routes/types.js'
 
@@ -123,6 +124,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleOverview(routeCtx)) return
       if (await tryHandleUpdates(routeCtx)) return
       if (await tryHandleStatus(routeCtx)) return
+      if (await tryHandleAutonomy(routeCtx)) return
       if (await tryHandleStatic(routeCtx, WEB_DIR)) return
 
       res.writeHead(404)

--- a/src/web/routes/autonomy.ts
+++ b/src/web/routes/autonomy.ts
@@ -1,0 +1,90 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../../config.js'
+import { readBody, json } from '../http-helpers.js'
+import { logger } from '../../logger.js'
+import type { RouteContext } from './types.js'
+
+const CONFIG_PATH = join(PROJECT_ROOT, 'store', 'autonomy-config.json')
+
+interface AutonomyCategory {
+  key: string
+  label: string
+  level: number
+  locked: boolean
+  maxLevel: number
+}
+
+interface AutonomyConfig {
+  version: number
+  updated_at: number
+  _doc?: string
+  categories: AutonomyCategory[]
+}
+
+function loadConfig(): AutonomyConfig {
+  if (!existsSync(CONFIG_PATH)) {
+    throw new Error('autonomy-config.json not found')
+  }
+  return JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+}
+
+function saveConfig(config: AutonomyConfig): void {
+  config.updated_at = Math.floor(Date.now() / 1000)
+  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + '\n', 'utf-8')
+}
+
+export async function tryHandleAutonomy(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  if (path === '/api/autonomy' && method === 'GET') {
+    try {
+      const config = loadConfig()
+      json(res, config)
+    } catch (err) {
+      logger.error({ err }, 'Failed to load autonomy config')
+      json(res, { error: 'Config not found' }, 404)
+    }
+    return true
+  }
+
+  if (path === '/api/autonomy' && method === 'POST') {
+    try {
+      const body = await readBody(req)
+      const { key, level } = JSON.parse(body.toString())
+
+      if (!key || typeof level !== 'number' || level < 1 || level > 3) {
+        json(res, { error: 'Invalid key or level (must be 1-3)' }, 400)
+        return true
+      }
+
+      const config = loadConfig()
+      const cat = config.categories.find(c => c.key === key)
+      if (!cat) {
+        json(res, { error: `Category "${key}" not found` }, 404)
+        return true
+      }
+
+      if (cat.locked && level > 1) {
+        json(res, { error: `Category "${key}" is locked at level 1 (safety constraint)` }, 403)
+        return true
+      }
+
+      if (level > cat.maxLevel) {
+        json(res, { error: `Category "${key}" max level is ${cat.maxLevel}` }, 400)
+        return true
+      }
+
+      cat.level = level
+      saveConfig(config)
+      logger.info({ key, level }, 'Autonomy level updated')
+      json(res, { ok: true, key, level, updated_at: config.updated_at })
+    } catch (err) {
+      logger.error({ err }, 'Failed to update autonomy config')
+      json(res, { error: 'Failed to update' }, 500)
+    }
+    return true
+  }
+
+  return false
+}

--- a/update.sh
+++ b/update.sh
@@ -276,6 +276,40 @@ if [ -d "$SEED_SCHED_DIR" ]; then
   fi
 fi
 
+# Seed config: merge missing keys into existing store/ configs.
+# Fresh install: copy if target absent. Existing install: merge new
+# categories into autonomy-config.json without touching user-set levels.
+SEED_CONFIG_DIR="$INSTALL_DIR/seed-config"
+if [ -d "$SEED_CONFIG_DIR" ]; then
+  for cfg in "$SEED_CONFIG_DIR"/*.json; do
+    [ -f "$cfg" ] || continue
+    cfg_name=$(basename "$cfg")
+    target="$INSTALL_DIR/store/$cfg_name"
+    if [ ! -f "$target" ]; then
+      cp "$cfg" "$target"
+      echo -e "  ${GREEN}✓${NC} Seed config: $cfg_name"
+    elif [ "$cfg_name" = "autonomy-config.json" ] && command -v node >/dev/null 2>&1; then
+      MERGED=$(node -e "
+        const seed = JSON.parse(require('fs').readFileSync('$cfg','utf8'));
+        const live = JSON.parse(require('fs').readFileSync('$target','utf8'));
+        const existing = new Set(live.categories.map(c => c.key));
+        let added = 0;
+        for (const c of seed.categories) {
+          if (!existing.has(c.key)) { live.categories.push(c); added++; }
+        }
+        if (added) {
+          live.updated_at = Math.floor(Date.now()/1000);
+          require('fs').writeFileSync('$target', JSON.stringify(live,null,2)+'\n');
+        }
+        console.log(added);
+      " 2>/dev/null || echo "0")
+      if [ "$MERGED" != "0" ] && [ -n "$MERGED" ]; then
+        echo -e "  ${GREEN}✓${NC} autonomy-config.json: ${MERGED} uj kategoria merge-elve"
+      fi
+    fi
+  done
+fi
+
 # Slack channel plugin smoke-test: if the marketplace slack-channel ref
 # changed since the last update, and a slack-provider agent exists, run
 # the smoke-test (if SLACK_SMOKE_TEST_ALLOWED=true in its .env).

--- a/web/app.js
+++ b/web/app.js
@@ -81,6 +81,7 @@ function switchPage(pageId) {
   if (pageId === 'recall') loadRecallPage()
   if (pageId === 'bgTasks') loadBgTasksPage()
   if (pageId === 'vault') loadVaultPage()
+  if (pageId === 'autonomy') loadAutonomy()
   if (pageId === 'updates') loadUpdates()
   if (pageId === 'team') loadTeamGraph()
 }
@@ -6992,5 +6993,93 @@ async function cancelBgTask(id) {
     }
   } catch {
     showToast('Hiba')
+  }
+}
+
+// ============================================================
+// === Autonomy ===
+// ============================================================
+
+document.getElementById('refreshAutonomyBtn').addEventListener('click', loadAutonomy)
+
+async function loadAutonomy() {
+  const grid = document.getElementById('autonomyGrid')
+  const footer = document.getElementById('autonomyUpdatedAt')
+  grid.innerHTML = '<p style="color:var(--text-muted);font-size:13px">Betöltés...</p>'
+
+  try {
+    const res = await fetch('/api/autonomy')
+    if (!res.ok) throw new Error('fetch failed')
+    const config = await res.json()
+
+    grid.innerHTML = ''
+    for (const cat of config.categories) {
+      const isCapped = !cat.locked && cat.maxLevel < 3
+      const row = document.createElement('div')
+      row.className = 'autonomy-row' + (cat.locked ? ' locked' : '') + (isCapped ? ' capped' : '')
+
+      const label = document.createElement('div')
+      label.className = 'autonomy-row-label'
+      label.textContent = cat.label
+
+      const levels = document.createElement('div')
+      levels.className = 'autonomy-levels'
+
+      for (let l = 1; l <= 3; l++) {
+        const btn = document.createElement('button')
+        const isOver = l > cat.maxLevel
+        btn.className = 'autonomy-level-btn' + (l === cat.level ? ' active' : '') + (isOver ? ' over-cap' : '')
+        btn.dataset.level = String(l)
+        btn.textContent = String(l)
+        btn.disabled = cat.locked || isOver
+        if (!cat.locked && !isOver) {
+          btn.addEventListener('click', () => setAutonomyLevel(cat.key, l))
+        }
+        levels.appendChild(btn)
+      }
+
+      row.appendChild(label)
+      if (cat.locked) {
+        const lock = document.createElement('div')
+        lock.className = 'autonomy-row-lock'
+        lock.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg> Biztonsági zár'
+        row.appendChild(lock)
+      } else if (isCapped) {
+        const cap = document.createElement('div')
+        cap.className = 'autonomy-row-cap'
+        cap.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg> Max ' + cat.maxLevel + '. szint'
+        row.appendChild(cap)
+      }
+      row.appendChild(levels)
+      grid.appendChild(row)
+    }
+
+    if (config.updated_at > 0) {
+      const d = new Date(config.updated_at * 1000)
+      footer.textContent = 'Utolsó módosítás: ' + d.toLocaleString('hu-HU')
+    } else {
+      footer.textContent = 'Még nem módosított'
+    }
+  } catch (err) {
+    grid.innerHTML = '<p style="color:var(--danger)">Nem sikerült betölteni az autonómia konfigot.</p>'
+    footer.textContent = ''
+  }
+}
+
+async function setAutonomyLevel(key, level) {
+  try {
+    const res = await fetch('/api/autonomy', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key, level }),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      showToast(data.error || 'Hiba')
+      return
+    }
+    loadAutonomy()
+  } catch {
+    showToast('Hiba a mentésnél')
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -64,6 +64,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
         <span class="sb-label">Státusz</span>
       </a>
+      <a href="#" class="sb-link" data-page="autonomy">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        <span class="sb-label">Autonómia</span>
+      </a>
       <a href="#" class="sb-link" data-page="vault">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/><circle cx="12" cy="16" r="1"/></svg>
         <span class="sb-label">Vault</span>
@@ -662,6 +666,42 @@
       <p style="color:var(--text-muted);font-size:12px;margin-top:16px">
         A szerep és a beosztott/vezető kapcsolatok az ügynök részletek &gt; Csapat fülén szerkeszthetők.
       </p>
+    </div>
+
+    <!-- === Autonomy Page === -->
+    <div class="page" id="autonomyPage" hidden>
+      <div class="page-header">
+        <div class="page-header-row">
+          <div>
+            <h1>Autonómia</h1>
+            <p class="subtitle">Heartbeat fokozatos autonómia szintek</p>
+          </div>
+          <button class="btn-secondary btn-compact" id="refreshAutonomyBtn">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+            </svg>
+            Frissítés
+          </button>
+        </div>
+      </div>
+
+      <div class="autonomy-legend">
+        <div class="autonomy-legend-item">
+          <span class="autonomy-level-dot" style="background:var(--text-muted)"></span>
+          <span><strong>1</strong> Csak jelez</span>
+        </div>
+        <div class="autonomy-legend-item">
+          <span class="autonomy-level-dot" style="background:var(--accent)"></span>
+          <span><strong>2</strong> Javasol, jóváhagyásra vár</span>
+        </div>
+        <div class="autonomy-legend-item">
+          <span class="autonomy-level-dot" style="background:var(--success)"></span>
+          <span><strong>3</strong> Autonóm, utólag jelent</span>
+        </div>
+      </div>
+
+      <div class="autonomy-grid" id="autonomyGrid"></div>
+      <p class="autonomy-footer" id="autonomyUpdatedAt"></p>
     </div>
 
     <!-- === Vault Page === -->

--- a/web/style.css
+++ b/web/style.css
@@ -4441,4 +4441,129 @@ main {
   .catalog-filter-btn { padding: 5px 10px; font-size: 12px; }
   .skills-grid { grid-template-columns: 1fr; }
   .skills-stats { gap: 8px; }
+  .autonomy-grid { gap: 8px; }
+  .autonomy-row { flex-wrap: wrap; gap: 10px; }
+  .autonomy-row-label { min-width: unset; flex: 1 1 100%; }
+}
+
+/* === Autonomy Page === */
+.autonomy-legend {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 24px;
+  padding: 14px 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.autonomy-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.autonomy-legend-item strong {
+  font-weight: 600;
+  font-size: 14px;
+}
+.autonomy-level-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.autonomy-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.autonomy-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: border-color var(--transition);
+}
+.autonomy-row:hover { border-color: var(--accent); }
+.autonomy-row.locked {
+  opacity: 0.55;
+  pointer-events: none;
+}
+.autonomy-row.locked:hover { border-color: var(--border); }
+.autonomy-row.capped { border-left: 3px solid var(--accent); }
+.autonomy-row-label {
+  flex: 1;
+  min-width: 260px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+}
+.autonomy-row-lock {
+  color: var(--text-muted);
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.autonomy-row-lock svg { flex-shrink: 0; }
+.autonomy-row-cap {
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+.autonomy-row-cap svg { flex-shrink: 0; }
+.autonomy-levels {
+  display: flex;
+  gap: 4px;
+  background: var(--bg-input);
+  border-radius: 6px;
+  padding: 3px;
+}
+.autonomy-level-btn {
+  padding: 6px 16px;
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  background: transparent;
+  color: var(--text-muted);
+  transition: all var(--transition);
+  min-width: 36px;
+  text-align: center;
+}
+.autonomy-level-btn:hover:not(.active):not(:disabled) {
+  color: var(--text);
+  background: var(--bg-card);
+}
+.autonomy-level-btn.over-cap {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+.autonomy-level-btn.active {
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+.autonomy-level-btn.active[data-level="1"] {
+  background: var(--text-muted);
+}
+.autonomy-level-btn.active[data-level="2"] {
+  background: var(--accent);
+}
+.autonomy-level-btn.active[data-level="3"] {
+  background: var(--success);
+}
+.autonomy-grid > :last-child { margin-bottom: 0; }
+.autonomy-footer {
+  margin-top: 16px;
+  font-size: 12px;
+  color: var(--text-muted);
 }


### PR DESCRIPTION
## Summary

- Backend: `GET/POST /api/autonomy` route for reading and updating per-category autonomy levels (1=notify, 2=suggest+approve, 3=autonomous). Locked categories enforced server-side (403).
- Frontend: segmented-control grid with 3 visual states (FREE/CAPPED/LOCKED), color-coded level buttons, shield/lock indicators. Matches existing Anthropic design tokens.
- Seed config: `seed-config/autonomy-config.json` with 13 default categories (all level 1).
- Install scripts (`install.sh`, `install-linux.sh`): copy seed config to `store/` on fresh install (idempotent, never overwrite).
- Update script (`update.sh`): merge new categories into existing user config without overwriting user-set levels (node-based key merge).
- Kanban audit SKILL.md updated with autonomy-aware section.

## Files changed (10)

| File | Change |
|------|--------|
| `src/web/routes/autonomy.ts` | NEW - API route |
| `src/web.ts` | Import + route registration |
| `web/app.js` | `loadAutonomy()` + `setAutonomyLevel()` |
| `web/index.html` | Sidebar nav + autonomy page markup |
| `web/style.css` | Autonomy grid + segmented control styles |
| `seed-config/autonomy-config.json` | NEW - 13-category default config |
| `install.sh` | Seed config copy block |
| `install-linux.sh` | Seed config copy block |
| `update.sh` | Seed config merge block (missing-key only) |
| `seed-scheduled-tasks/kanban-audit/SKILL.md` | Autonomy-aware audit section |

## Test plan

- [ ] Fresh install: verify `store/autonomy-config.json` is created from seed
- [ ] Existing install update: verify user levels are preserved, only new keys merged
- [ ] Dashboard: navigate to Autonomy page, verify 3 visual states render correctly
- [ ] API: POST locked category with level>1 returns 403
- [ ] API: POST capped category with level>maxLevel returns 400
- [ ] Build: `npm run build` passes clean

Generated with [Claude Code](https://claude.com/claude-code)