### PR TITLE
feat(connectors-hu): one-click CLI installer API endpoints

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -24,6 +24,7 @@ import { tryHandleKanban } from './web/routes/kanban.js'
 import { tryHandleTasks } from './web/routes/tasks.js'
 import { tryHandleSchedules } from './web/routes/schedules.js'
 import { tryHandleConnectors } from './web/routes/connectors.js'
+import { tryHandleConnectorsHu } from './web/routes/connectors-hu.js'
 import { tryHandleAgentsSkills } from './web/routes/agents-skills.js'
 import { tryHandleSkills } from './web/routes/skills.js'
 import { tryHandleAgents } from './web/routes/agents.js'
@@ -114,6 +115,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleKanban(routeCtx)) return
       if (await tryHandleTasks(routeCtx)) return
       if (await tryHandleSchedules(routeCtx)) return
+      if (await tryHandleConnectorsHu(routeCtx)) return
       if (await tryHandleConnectors(routeCtx)) return
       if (await tryHandleAgentsSkills(routeCtx)) return
       if (await tryHandleSkills(routeCtx)) return

--- a/src/web/routes/connectors-hu.ts
+++ b/src/web/routes/connectors-hu.ts
@@ -1,0 +1,107 @@
+import { execFile } from 'node:child_process'
+import { readBody, json } from '../http-helpers.js'
+import { setSecret, getSecret } from '../vault.js'
+import { logger } from '../../logger.js'
+import type { RouteContext } from './types.js'
+
+const VAULT_ID = 'CONNECTORS_HU_TOKEN'
+const VAULT_LABEL = 'connectors.hu API token'
+const INSTALL_TIMEOUT = 60_000
+const SYNC_TIMEOUT = 30_000
+const MAX_OUTPUT = 4096
+
+function which(bin: string): Promise<string | null> {
+  return new Promise(resolve => {
+    execFile('/usr/bin/which', [bin], { timeout: 3000 }, (err, stdout) => {
+      resolve(err ? null : stdout.trim() || null)
+    })
+  })
+}
+
+function isInstalled(): Promise<{ installed: boolean; path: string | null }> {
+  return new Promise(async resolve => {
+    const homeLocal = `${process.env.HOME}/.local/bin/connectors`
+    const p = await which('connectors')
+    resolve({ installed: p !== null, path: p })
+  })
+}
+
+function runCommand(cmd: string, args: string[], opts: { timeout: number; env?: Record<string, string> }): Promise<{ ok: boolean; output: string }> {
+  return new Promise(resolve => {
+    const childEnv = { ...process.env, ...opts.env }
+    execFile(cmd, args, { timeout: opts.timeout, env: childEnv, maxBuffer: 1024 * 1024 }, (err, stdout, stderr) => {
+      const combined = ((stdout || '') + '\n' + (stderr || '')).trim()
+      const output = combined.length > MAX_OUTPUT ? combined.slice(-MAX_OUTPUT) : combined
+      resolve({ ok: !err, output })
+    })
+  })
+}
+
+export async function tryHandleConnectorsHu(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  if (path === '/api/connectors-hu/status' && method === 'GET') {
+    try {
+      const { installed } = await isInstalled()
+      const configured = getSecret(VAULT_ID) !== null
+      let version: string | undefined
+      if (installed) {
+        const result = await runCommand('connectors', ['--version'], { timeout: 5000 })
+        if (result.ok && result.output) version = result.output.split('\n')[0].trim()
+      }
+      json(res, { ok: true, installed, configured, ...(version ? { version } : {}) })
+    } catch (err) {
+      logger.error({ err }, 'connectors-hu status check failed')
+      json(res, { ok: false, installed: false, configured: false }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/connectors-hu/install' && method === 'POST') {
+    try {
+      const result = await runCommand('/bin/sh', ['-c', 'curl -fsSL https://connectors.hu/install.sh | sh'], { timeout: INSTALL_TIMEOUT })
+      const { installed } = await isInstalled()
+      json(res, { ok: result.ok, installed, output: result.output })
+      if (result.ok) logger.info('connectors CLI installed')
+      else logger.warn({ output: result.output }, 'connectors CLI install failed')
+    } catch (err) {
+      logger.error({ err }, 'connectors-hu install failed')
+      json(res, { ok: false, installed: false, output: String(err) }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/connectors-hu/configure' && method === 'POST') {
+    try {
+      const body = await readBody(req)
+      const { token } = JSON.parse(body.toString()) as { token: string }
+      if (!token?.trim()) {
+        json(res, { ok: false, configured: false, syncOutput: 'Token is required' }, 400)
+        return true
+      }
+
+      setSecret(VAULT_ID, VAULT_LABEL, token.trim())
+
+      const { installed } = await isInstalled()
+      if (!installed) {
+        json(res, { ok: true, configured: true, syncOutput: 'Token saved. connectors CLI not installed yet, sync skipped.' })
+        return true
+      }
+
+      const result = await runCommand('connectors', ['sync'], {
+        timeout: SYNC_TIMEOUT,
+        env: { CONNECTORS_HU_TOKEN: token.trim() },
+      })
+
+      json(res, { ok: result.ok, configured: true, syncOutput: result.output })
+      if (result.ok) logger.info('connectors-hu configured and synced')
+      else logger.warn({ output: result.output }, 'connectors sync returned non-zero')
+    } catch (err) {
+      logger.error({ err }, 'connectors-hu configure failed')
+      json(res, { ok: false, configured: false, syncOutput: String(err) }, 500)
+    }
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## Summary

- 3 new Bearer-protected API endpoints for connectors.hu CLI management
- Token stored in encrypted vault (never logged or returned)
- Route registered before `/api/connectors` to avoid path collision

## API Contract (Zara builds frontend against this)

### GET /api/connectors-hu/status
```json
{ "ok": true, "installed": true, "configured": true, "version": "1.2.3" }
```

### POST /api/connectors-hu/install
```json
{ "ok": true, "installed": true, "output": "..." }
```

### POST /api/connectors-hu/configure
Request: `{ "token": "sk-..." }`
```json
{ "ok": true, "configured": true, "syncOutput": "..." }
```

## Files changed (2)

| File | Change |
|------|--------|
| `src/web/routes/connectors-hu.ts` | NEW - 3 API endpoints |
| `src/web.ts` | Import + route registration (before connectors) |

## Test plan

- [ ] GET /api/connectors-hu/status returns installed:false when CLI not present
- [ ] POST /api/connectors-hu/install runs install script successfully
- [ ] POST /api/connectors-hu/configure saves token to vault (verify via /api/vault)
- [ ] POST /api/connectors-hu/configure with empty token returns 400
- [ ] Token never appears in logs or response bodies
- [ ] Build: `npm run build` passes clean

Generated with [Claude Code](https://claude.com/claude-code)