### PR TITLE
feat(seed): Bumblebee supply-chain hygiene scan scheduled task

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -442,6 +442,15 @@ if [ -d "$SCHED_TPL_DIR" ]; then
   done
 fi
 
+# Seed bumblebee threat-intel catalogs into ~/.claude/tools/
+BB_SEED_TI="$INSTALL_DIR/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel"
+BB_TARGET_TI="$HOME/.claude/tools/bumblebee-threat-intel"
+if [ -d "$BB_SEED_TI" ] && [ ! -d "$BB_TARGET_TI" ]; then
+  mkdir -p "$BB_TARGET_TI"
+  cp "$BB_SEED_TI"/*.json "$BB_TARGET_TI/" 2>/dev/null
+  ok "Bumblebee threat-intel katalogusok telepitve"
+fi
+
 # Seed config: copy default config files into store/ (idempotent: never overwrite)
 SEED_CONFIG_DIR="$INSTALL_DIR/seed-config"
 if [ -d "$SEED_CONFIG_DIR" ]; then

--- a/install.sh
+++ b/install.sh
@@ -500,6 +500,15 @@ if [ -d "$SEED_SCHED_DIR" ]; then
       echo -e "  ${GREEN}✓${NC} kanban-audit state inicializálva"
     fi
   fi
+
+  # Seed bumblebee threat-intel catalogs into ~/.claude/tools/
+  BB_SEED_TI="$SEED_SCHED_DIR/bumblebee-hygiene-scan/threat-intel"
+  BB_TARGET_TI="$HOME/.claude/tools/bumblebee-threat-intel"
+  if [ -d "$BB_SEED_TI" ] && [ ! -d "$BB_TARGET_TI" ]; then
+    mkdir -p "$BB_TARGET_TI"
+    cp "$BB_SEED_TI"/*.json "$BB_TARGET_TI/" 2>/dev/null
+    echo -e "  ${GREEN}✓${NC} Bumblebee threat-intel katalógusok telepítve"
+  fi
 fi
 
 # Seed config: copy default config files into store/ (idempotent: never overwrite)

--- a/seed-scheduled-tasks/bumblebee-hygiene-scan/SKILL.md
+++ b/seed-scheduled-tasks/bumblebee-hygiene-scan/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: bumblebee-hygiene-scan
+description: Weekly supply-chain hygiene scan (Perplexity Bumblebee). Monday 09:00. Inventories installed packages, MCP configs, and extensions, then matches against known supply-chain threat catalogs. Telegram alert ONLY if findings > 0.
+---
+
+# Bumblebee weekly supply-chain scan
+
+## When / purpose
+Monday 09:00. The fleet uses many third-party MCP servers, auto-installed CLIs, packages, and skills, creating supply-chain risk. This is a read-only inventory + known-threat match.
+
+## Binary
+- Path: `~/.local/bin/bumblebee` (Go build, PIN v0.1.1)
+- Source: `github.com/perplexityai/bumblebee` (Apache 2.0)
+- Build: `git clone https://github.com/perplexityai/bumblebee && cd bumblebee && go build -o ~/.local/bin/bumblebee ./cmd/bumblebee` (Go >= 1.25 required)
+
+## Procedure
+
+1. **Check binary exists**:
+```bash
+if [ ! -x "$HOME/.local/bin/bumblebee" ]; then
+  echo "bumblebee binary not found, skipping scan (install Go>=1.25 and build from github.com/perplexityai/bumblebee)"
+  exit 0
+fi
+```
+If the binary is missing (fresh machine without Go), gracefully skip with an info-level log line. Do NOT error out or send alerts.
+
+2. **Locate threat-intel catalogs**:
+```bash
+BB_CATALOG="$HOME/.claude/tools/bumblebee-threat-intel"
+if [ ! -d "$BB_CATALOG" ] || [ -z "$(ls -A "$BB_CATALOG" 2>/dev/null)" ]; then
+  # Try seeded catalogs from install dir
+  SEED_CATALOG="{{INSTALL_DIR}}/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel"
+  if [ -d "$SEED_CATALOG" ] && [ -n "$(ls -A "$SEED_CATALOG" 2>/dev/null)" ]; then
+    mkdir -p "$BB_CATALOG"
+    cp "$SEED_CATALOG"/*.json "$BB_CATALOG/"
+  else
+    echo "No threat-intel catalogs found, skipping scan"
+    exit 0
+  fi
+fi
+```
+
+3. **Run scan** (read-only, ~3 sec):
+```bash
+~/.local/bin/bumblebee scan --profile baseline --exposure-catalog "$BB_CATALOG" > /tmp/bb-weekly.ndjson 2>/tmp/bb-weekly.err
+```
+
+4. **Evaluate findings**:
+```bash
+FINDING_COUNT=$(grep -c '"record_type":"finding"' /tmp/bb-weekly.ndjson 2>/dev/null || echo 0)
+```
+
+5. **Telegram ONLY if finding > 0**: send alert with finding details (ecosystem, package, version, which threat catalog matched). If 0 findings: stay silent (heartbeat style, transcript line only).
+
+6. **Monthly threat-intel refresh** (once per ~30 days): if the catalog files are older than 30 days, refresh from upstream:
+```bash
+OLDEST=$(find "$BB_CATALOG" -name "*.json" -mtime +30 | head -1)
+if [ -n "$OLDEST" ]; then
+  cd /tmp && rm -rf bb-ti-update
+  git clone -q --depth 1 https://github.com/perplexityai/bumblebee.git bb-ti-update 2>/dev/null
+  if [ -d bb-ti-update/threat_intel ]; then
+    cp bb-ti-update/threat_intel/*.json "$BB_CATALOG/"
+  fi
+  rm -rf bb-ti-update
+fi
+```
+
+## Pitfalls
+- Findings ONLY appear with `--exposure-catalog` flag (otherwise always 0). The catalogs live in `~/.claude/tools/bumblebee-threat-intel/`.
+- If Go is not available (< 1.25 or not installed), the binary cannot be built. The task must GRACEFULLY SKIP, not crash.
+- 0 findings does NOT mean absolute safety, only that the 6 known catalog threats are not present. Keep catalogs fresh.
+- Do NOT spam: 0 findings = no Telegram message.
+- The vendored catalogs in seed-scheduled-tasks are a bootstrap fallback. The monthly refresh keeps them current.
+
+## Verification
+- Scan exits 0, scan_summary record shows status=complete.
+- Finding > 0 triggers Telegram alert; 0 findings = silence.

--- a/seed-scheduled-tasks/bumblebee-hygiene-scan/task-config.json
+++ b/seed-scheduled-tasks/bumblebee-hygiene-scan/task-config.json
@@ -1,0 +1,8 @@
+{
+  "schedule": "0 9 * * 1",
+  "agent": "{{MAIN_AGENT_ID}}",
+  "enabled": true,
+  "type": "heartbeat",
+  "skipIfBusy": true,
+  "createdAt": 0
+}

--- a/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/antv-mini-shai-hulud.json
+++ b/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/antv-mini-shai-hulud.json
@@ -1,0 +1,3900 @@
+{
+  "schema_version": "0.1.0",
+  "_comment": "AntV / Mini Shai-Hulud npm worm wave reported by Socket on 2026-05-19. Scoped to artifacts the Socket tracker (attackId 22) first detected on or after 2026-05-13, i.e. the in-PR-window 5/19 wave. Pre-2026-05-13 artifacts from the cumulative Mini Shai-Hulud campaign (TanStack/2026-05-11, Lightning/2026-04-30, and earlier waves) are intentionally excluded from this catalog and are tracked separately. The compromised package.json carries preinstall: 'bun run index.js' and an optional dependency @antv/setup pinned to github:antvis/G2#1916faa365f2788b6e193514872d51a242876569. The worm validates stolen npm tokens, enumerates maintainable packages, injects payload/preinstall, bumps versions, and republishes.",
+  "_indicators": {
+    "exfil_endpoint": "https://t.m-kosche.com:443/api/public/otel/v1/traces",
+    "antv_setup_dep_commit": "github:antvis/G2#1916faa365f2788b6e193514872d51a242876569",
+    "preinstall_script": "bun run index.js",
+    "decryptor_global": "fc2edea72",
+    "exfil_repo_name_pattern": "<word>-<word>-<3 digits>",
+    "exfil_repo_example": "sayyadina-stillsuit-852",
+    "github_fallback_path": "results/results-<timestamp>-<counter>.json",
+    "reversed_marker": "niagA oG eW ereH :duluH-iahS",
+    "plaintext_marker": "Shai-Hulud: Here We Go Again"
+  },
+  "entries": [
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-a8",
+      "name": "@@antv/a8 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/a8",
+      "versions": [
+        "0.1.1",
+        "0.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-adjust",
+      "name": "@@antv/adjust (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/adjust",
+      "versions": [
+        "0.3.5",
+        "0.4.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-algorithm",
+      "name": "@@antv/algorithm (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/algorithm",
+      "versions": [
+        "0.2.26",
+        "0.3.26"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-async-hook",
+      "name": "@@antv/async-hook (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/async-hook",
+      "versions": [
+        "2.3.9",
+        "2.4.9"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-attr",
+      "name": "@@antv/attr (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/attr",
+      "versions": [
+        "0.4.5",
+        "0.5.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-ava",
+      "name": "@@antv/ava (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/ava",
+      "versions": [
+        "3.5.1",
+        "3.6.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-ava-react",
+      "name": "@@antv/ava-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/ava-react",
+      "versions": [
+        "3.4.2",
+        "3.5.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-awards",
+      "name": "@@antv/awards (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/awards",
+      "versions": [
+        "0.1.9",
+        "0.2.9"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-calendar-heatmap",
+      "name": "@@antv/calendar-heatmap (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/calendar-heatmap",
+      "versions": [
+        "1.2.2",
+        "1.3.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-chart-linter",
+      "name": "@@antv/chart-linter (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/chart-linter",
+      "versions": [
+        "1.2.6",
+        "1.3.6"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-chart-node-g6",
+      "name": "@@antv/chart-node-g6 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/chart-node-g6",
+      "versions": [
+        "0.1.4",
+        "0.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-chart-visualization-skills",
+      "name": "@@antv/chart-visualization-skills (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/chart-visualization-skills",
+      "versions": [
+        "0.2.3",
+        "0.3.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-ckb",
+      "name": "@@antv/ckb (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/ckb",
+      "versions": [
+        "2.1.4",
+        "2.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-color-schema",
+      "name": "@@antv/color-schema (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/color-schema",
+      "versions": [
+        "0.3.3",
+        "0.4.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-color-util",
+      "name": "@@antv/color-util (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/color-util",
+      "versions": [
+        "2.1.6",
+        "2.2.6"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-component",
+      "name": "@@antv/component (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/component",
+      "versions": [
+        "2.2.11",
+        "2.3.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-coord",
+      "name": "@@antv/coord (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/coord",
+      "versions": [
+        "0.5.7",
+        "0.6.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-d3-color",
+      "name": "@@antv/d3-color (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/d3-color",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-d3-interpolate",
+      "name": "@@antv/d3-interpolate (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/d3-interpolate",
+      "versions": [
+        "1.1.3",
+        "1.2.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-data-samples",
+      "name": "@@antv/data-samples (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/data-samples",
+      "versions": [
+        "1.1.1",
+        "1.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-data-set",
+      "name": "@@antv/data-set (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/data-set",
+      "versions": [
+        "0.12.8",
+        "0.13.8"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-data-wizard",
+      "name": "@@antv/data-wizard (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/data-wizard",
+      "versions": [
+        "2.1.4",
+        "2.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-dipper-component",
+      "name": "@@antv/dipper-component (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/dipper-component",
+      "versions": [
+        "0.1.4",
+        "0.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-dipper-hooks",
+      "name": "@@antv/dipper-hooks (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/dipper-hooks",
+      "versions": [
+        "0.3.1",
+        "0.4.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-dipper-map",
+      "name": "@@antv/dipper-map (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/dipper-map",
+      "versions": [
+        "1.1.10",
+        "1.2.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-dom-util",
+      "name": "@@antv/dom-util (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/dom-util",
+      "versions": [
+        "2.1.4",
+        "2.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-dumi-theme-antv",
+      "name": "@@antv/dumi-theme-antv (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/dumi-theme-antv",
+      "versions": [
+        "0.9.4",
+        "0.10.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-dw-analyzer",
+      "name": "@@antv/dw-analyzer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/dw-analyzer",
+      "versions": [
+        "1.2.5",
+        "1.3.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-dw-random",
+      "name": "@@antv/dw-random (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/dw-random",
+      "versions": [
+        "1.2.7",
+        "1.3.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-dw-transform",
+      "name": "@@antv/dw-transform (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/dw-transform",
+      "versions": [
+        "1.2.7",
+        "1.3.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-dw-util",
+      "name": "@@antv/dw-util (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/dw-util",
+      "versions": [
+        "1.2.4",
+        "1.3.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-event-emitter",
+      "name": "@@antv/event-emitter (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/event-emitter",
+      "versions": [
+        "0.2.3",
+        "0.3.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-expr",
+      "name": "@@antv/expr (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/expr",
+      "versions": [
+        "1.1.2",
+        "1.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f-charts",
+      "name": "@@antv/f-charts (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f-charts",
+      "versions": [
+        "0.1.0",
+        "0.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f-engine",
+      "name": "@@antv/f-engine (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f-engine",
+      "versions": [
+        "1.11.0",
+        "1.12.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f-lottie",
+      "name": "@@antv/f-lottie (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f-lottie",
+      "versions": [
+        "1.11.0",
+        "1.12.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f-my",
+      "name": "@@antv/f-my (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f-my",
+      "versions": [
+        "1.11.0",
+        "1.12.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f-react",
+      "name": "@@antv/f-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f-react",
+      "versions": [
+        "1.11.0",
+        "1.12.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f-test-utils",
+      "name": "@@antv/f-test-utils (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f-test-utils",
+      "versions": [
+        "1.1.9",
+        "1.2.9"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f-vue",
+      "name": "@@antv/f-vue (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f-vue",
+      "versions": [
+        "1.11.0",
+        "1.12.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f-wx",
+      "name": "@@antv/f-wx (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f-wx",
+      "versions": [
+        "1.11.0",
+        "1.12.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2",
+      "name": "@@antv/f2 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2",
+      "versions": [
+        "5.15.0",
+        "5.16.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-algorithm",
+      "name": "@@antv/f2-algorithm (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-algorithm",
+      "versions": [
+        "5.8.0",
+        "5.9.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-canvas",
+      "name": "@@antv/f2-canvas (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-canvas",
+      "versions": [
+        "1.1.5",
+        "1.2.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-context",
+      "name": "@@antv/f2-context (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-context",
+      "versions": [
+        "0.1.1",
+        "0.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-graphic",
+      "name": "@@antv/f2-graphic (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-graphic",
+      "versions": [
+        "0.1.16",
+        "0.2.16"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-my",
+      "name": "@@antv/f2-my (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-my",
+      "versions": [
+        "4.1.52",
+        "4.2.52"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-react",
+      "name": "@@antv/f2-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-react",
+      "versions": [
+        "5.15.0",
+        "5.16.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-site",
+      "name": "@@antv/f2-site (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-site",
+      "versions": [
+        "4.1.42",
+        "4.2.42"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-vue",
+      "name": "@@antv/f2-vue (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-vue",
+      "versions": [
+        "4.1.33",
+        "4.2.33"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-wordcloud",
+      "name": "@@antv/f2-wordcloud (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-wordcloud",
+      "versions": [
+        "5.15.0",
+        "5.16.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f2-wx",
+      "name": "@@antv/f2-wx (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f2-wx",
+      "versions": [
+        "4.1.51",
+        "4.2.51"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f6",
+      "name": "@@antv/f6 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f6",
+      "versions": [
+        "0.1.19",
+        "0.2.19"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f6-alipay",
+      "name": "@@antv/f6-alipay (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f6-alipay",
+      "versions": [
+        "0.1.7",
+        "0.2.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f6-core",
+      "name": "@@antv/f6-core (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f6-core",
+      "versions": [
+        "0.1.2",
+        "0.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f6-element",
+      "name": "@@antv/f6-element (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f6-element",
+      "versions": [
+        "0.1.1",
+        "0.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f6-hammerjs",
+      "name": "@@antv/f6-hammerjs (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f6-hammerjs",
+      "versions": [
+        "0.1.2",
+        "0.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f6-plugin",
+      "name": "@@antv/f6-plugin (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f6-plugin",
+      "versions": [
+        "1.1.6",
+        "1.2.6"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f6-ui",
+      "name": "@@antv/f6-ui (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f6-ui",
+      "versions": [
+        "1.1.3",
+        "1.2.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-f6-wx",
+      "name": "@@antv/f6-wx (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/f6-wx",
+      "versions": [
+        "0.1.7",
+        "0.2.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g",
+      "name": "@@antv/g (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g",
+      "versions": [
+        "6.4.1",
+        "6.5.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-base",
+      "name": "@@antv/g-base (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-base",
+      "versions": [
+        "0.6.16",
+        "0.7.16"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-camera-api",
+      "name": "@@antv/g-camera-api (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-camera-api",
+      "versions": [
+        "2.1.45",
+        "2.2.45"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-canvas",
+      "name": "@@antv/g-canvas (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-canvas",
+      "versions": [
+        "2.3.0",
+        "2.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-canvaskit",
+      "name": "@@antv/g-canvaskit (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-canvaskit",
+      "versions": [
+        "1.2.1",
+        "1.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-compat",
+      "name": "@@antv/g-compat (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-compat",
+      "versions": [
+        "1.1.11",
+        "1.2.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-components",
+      "name": "@@antv/g-components (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-components",
+      "versions": [
+        "2.1.42",
+        "2.2.42"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-css-layout-api",
+      "name": "@@antv/g-css-layout-api (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-css-layout-api",
+      "versions": [
+        "1.1.38",
+        "1.2.38"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-css-typed-om-api",
+      "name": "@@antv/g-css-typed-om-api (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-css-typed-om-api",
+      "versions": [
+        "1.1.38",
+        "1.2.38"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-device-api",
+      "name": "@@antv/g-device-api (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-device-api",
+      "versions": [
+        "1.7.13",
+        "1.8.13"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-dom-mutation-observer-api",
+      "name": "@@antv/g-dom-mutation-observer-api (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-dom-mutation-observer-api",
+      "versions": [
+        "2.1.42",
+        "2.2.42"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-gesture",
+      "name": "@@antv/g-gesture (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-gesture",
+      "versions": [
+        "3.1.42",
+        "3.2.42"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-image-exporter",
+      "name": "@@antv/g-image-exporter (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-image-exporter",
+      "versions": [
+        "1.1.42",
+        "1.2.42"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-layout-blocklike",
+      "name": "@@antv/g-layout-blocklike (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-layout-blocklike",
+      "versions": [
+        "1.8.49",
+        "1.9.49"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-lite",
+      "name": "@@antv/g-lite (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-lite",
+      "versions": [
+        "2.8.0",
+        "2.9.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-lottie-player",
+      "name": "@@antv/g-lottie-player (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-lottie-player",
+      "versions": [
+        "1.2.1",
+        "1.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-math",
+      "name": "@@antv/g-math (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-math",
+      "versions": [
+        "3.2.0",
+        "3.3.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-mobile",
+      "name": "@@antv/g-mobile (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-mobile",
+      "versions": [
+        "1.2.5",
+        "1.3.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-mobile-canvas",
+      "name": "@@antv/g-mobile-canvas (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-mobile-canvas",
+      "versions": [
+        "1.2.1",
+        "1.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-mobile-canvas-element",
+      "name": "@@antv/g-mobile-canvas-element (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-mobile-canvas-element",
+      "versions": [
+        "1.1.42",
+        "1.2.42"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-mobile-svg",
+      "name": "@@antv/g-mobile-svg (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-mobile-svg",
+      "versions": [
+        "1.2.1",
+        "1.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-mobile-webgl",
+      "name": "@@antv/g-mobile-webgl (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-mobile-webgl",
+      "versions": [
+        "1.2.1",
+        "1.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-pattern",
+      "name": "@@antv/g-pattern (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-pattern",
+      "versions": [
+        "2.1.42",
+        "2.2.42"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-perf",
+      "name": "@@antv/g-perf (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-perf",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-3d",
+      "name": "@@antv/g-plugin-3d (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-3d",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-a11y",
+      "name": "@@antv/g-plugin-a11y (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-a11y",
+      "versions": [
+        "1.5.1",
+        "1.6.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-annotation",
+      "name": "@@antv/g-plugin-annotation (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-annotation",
+      "versions": [
+        "1.3.0",
+        "1.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-box2d",
+      "name": "@@antv/g-plugin-box2d (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-box2d",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-canvas-path-generator",
+      "name": "@@antv/g-plugin-canvas-path-generator (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-canvas-path-generator",
+      "versions": [
+        "2.2.26",
+        "2.3.26"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-canvas-picker",
+      "name": "@@antv/g-plugin-canvas-picker (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-canvas-picker",
+      "versions": [
+        "2.4.1",
+        "2.5.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-canvas-renderer",
+      "name": "@@antv/g-plugin-canvas-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-canvas-renderer",
+      "versions": [
+        "2.6.1",
+        "2.7.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-canvaskit-renderer",
+      "name": "@@antv/g-plugin-canvaskit-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-canvaskit-renderer",
+      "versions": [
+        "2.4.1",
+        "2.5.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-control",
+      "name": "@@antv/g-plugin-control (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-control",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-css-select",
+      "name": "@@antv/g-plugin-css-select (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-css-select",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-device-renderer",
+      "name": "@@antv/g-plugin-device-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-device-renderer",
+      "versions": [
+        "2.7.1",
+        "2.8.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-dom-interaction",
+      "name": "@@antv/g-plugin-dom-interaction (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-dom-interaction",
+      "versions": [
+        "2.2.31",
+        "2.3.31"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-dragndrop",
+      "name": "@@antv/g-plugin-dragndrop (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-dragndrop",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-gesture",
+      "name": "@@antv/g-plugin-gesture (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-gesture",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-gpgpu",
+      "name": "@@antv/g-plugin-gpgpu (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-gpgpu",
+      "versions": [
+        "1.10.20",
+        "1.11.20"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-html-renderer",
+      "name": "@@antv/g-plugin-html-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-html-renderer",
+      "versions": [
+        "2.4.1",
+        "2.5.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-image-loader",
+      "name": "@@antv/g-plugin-image-loader (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-image-loader",
+      "versions": [
+        "2.4.1",
+        "2.5.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-matterjs",
+      "name": "@@antv/g-plugin-matterjs (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-matterjs",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-mobile-interaction",
+      "name": "@@antv/g-plugin-mobile-interaction (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-mobile-interaction",
+      "versions": [
+        "1.1.42",
+        "1.2.42"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-physx",
+      "name": "@@antv/g-plugin-physx (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-physx",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-rough-canvas-renderer",
+      "name": "@@antv/g-plugin-rough-canvas-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-rough-canvas-renderer",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-rough-svg-renderer",
+      "name": "@@antv/g-plugin-rough-svg-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-rough-svg-renderer",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-svg-picker",
+      "name": "@@antv/g-plugin-svg-picker (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-svg-picker",
+      "versions": [
+        "2.1.46",
+        "2.2.46"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-svg-renderer",
+      "name": "@@antv/g-plugin-svg-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-svg-renderer",
+      "versions": [
+        "2.5.1",
+        "2.6.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-webgl-device",
+      "name": "@@antv/g-plugin-webgl-device (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-webgl-device",
+      "versions": [
+        "1.10.17",
+        "1.11.17"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-webgl-renderer",
+      "name": "@@antv/g-plugin-webgl-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-webgl-renderer",
+      "versions": [
+        "1.1.26",
+        "1.2.26"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-webgpu-device",
+      "name": "@@antv/g-plugin-webgpu-device (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-webgpu-device",
+      "versions": [
+        "1.10.17",
+        "1.11.17"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-yoga",
+      "name": "@@antv/g-plugin-yoga (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-yoga",
+      "versions": [
+        "2.4.1",
+        "2.5.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-zdog-canvas-renderer",
+      "name": "@@antv/g-plugin-zdog-canvas-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-zdog-canvas-renderer",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-plugin-zdog-svg-renderer",
+      "name": "@@antv/g-plugin-zdog-svg-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-plugin-zdog-svg-renderer",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-shader-components",
+      "name": "@@antv/g-shader-components (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-shader-components",
+      "versions": [
+        "2.1.0",
+        "2.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-svg",
+      "name": "@@antv/g-svg (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-svg",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-web-animations-api",
+      "name": "@@antv/g-web-animations-api (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-web-animations-api",
+      "versions": [
+        "2.2.32",
+        "2.3.32"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-web-components",
+      "name": "@@antv/g-web-components (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-web-components",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-webgl",
+      "name": "@@antv/g-webgl (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-webgl",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-webgl-compute",
+      "name": "@@antv/g-webgl-compute (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-webgl-compute",
+      "versions": [
+        "0.1.1",
+        "0.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-webgpu",
+      "name": "@@antv/g-webgpu (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-webgpu",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-webgpu-compiler",
+      "name": "@@antv/g-webgpu-compiler (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-webgpu-compiler",
+      "versions": [
+        "0.8.2",
+        "0.9.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-webgpu-core",
+      "name": "@@antv/g-webgpu-core (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-webgpu-core",
+      "versions": [
+        "0.8.2",
+        "0.9.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-webgpu-engine",
+      "name": "@@antv/g-webgpu-engine (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-webgpu-engine",
+      "versions": [
+        "0.8.2",
+        "0.9.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-webgpu-raytracer",
+      "name": "@@antv/g-webgpu-raytracer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-webgpu-raytracer",
+      "versions": [
+        "0.6.1",
+        "0.7.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g-webgpu-unitchart",
+      "name": "@@antv/g-webgpu-unitchart (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g-webgpu-unitchart",
+      "versions": [
+        "0.6.1",
+        "0.7.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g2",
+      "name": "@@antv/g2 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g2",
+      "versions": [
+        "5.5.8",
+        "5.6.8"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g2-brush",
+      "name": "@@antv/g2-brush (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g2-brush",
+      "versions": [
+        "0.1.2",
+        "0.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g2-extension-3d",
+      "name": "@@antv/g2-extension-3d (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g2-extension-3d",
+      "versions": [
+        "0.3.0",
+        "0.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g2-extension-ava",
+      "name": "@@antv/g2-extension-ava (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g2-extension-ava",
+      "versions": [
+        "0.3.0",
+        "0.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g2-extension-plot",
+      "name": "@@antv/g2-extension-plot (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g2-extension-plot",
+      "versions": [
+        "0.3.2",
+        "0.4.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g2-plugin-slider",
+      "name": "@@antv/g2-plugin-slider (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g2-plugin-slider",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g2-ssr",
+      "name": "@@antv/g2-ssr (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g2-ssr",
+      "versions": [
+        "0.3.0",
+        "0.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g2plot",
+      "name": "@@antv/g2plot (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g2plot",
+      "versions": [
+        "2.5.35",
+        "2.6.35"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g2plot-schemas",
+      "name": "@@antv/g2plot-schemas (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g2plot-schemas",
+      "versions": [
+        "1.3.2",
+        "1.4.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6",
+      "name": "@@antv/g6 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6",
+      "versions": [
+        "5.2.1",
+        "5.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-alipay",
+      "name": "@@antv/g6-alipay (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-alipay",
+      "versions": [
+        "0.1.1",
+        "0.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-cli",
+      "name": "@@antv/g6-cli (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-cli",
+      "versions": [
+        "0.1.4",
+        "0.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-core",
+      "name": "@@antv/g6-core (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-core",
+      "versions": [
+        "0.9.24",
+        "0.10.24"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-editor",
+      "name": "@@antv/g6-editor (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-editor",
+      "versions": [
+        "1.3.0",
+        "1.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-element",
+      "name": "@@antv/g6-element (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-element",
+      "versions": [
+        "0.9.25",
+        "0.10.25"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-extension-3d",
+      "name": "@@antv/g6-extension-3d (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-extension-3d",
+      "versions": [
+        "0.2.23",
+        "0.3.23"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-extension-react",
+      "name": "@@antv/g6-extension-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-extension-react",
+      "versions": [
+        "0.3.7",
+        "0.4.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-mobile",
+      "name": "@@antv/g6-mobile (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-mobile",
+      "versions": [
+        "0.2.2",
+        "0.3.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-pc",
+      "name": "@@antv/g6-pc (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-pc",
+      "versions": [
+        "0.9.25",
+        "0.10.25"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-plugin",
+      "name": "@@antv/g6-plugin (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-plugin",
+      "versions": [
+        "0.9.25",
+        "0.10.25"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-plugin-map-view",
+      "name": "@@antv/g6-plugin-map-view (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-plugin-map-view",
+      "versions": [
+        "0.1.4",
+        "0.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-plugins",
+      "name": "@@antv/g6-plugins (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-plugins",
+      "versions": [
+        "1.1.9",
+        "1.2.9"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-react-node",
+      "name": "@@antv/g6-react-node (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-react-node",
+      "versions": [
+        "1.5.8",
+        "1.6.8"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-ssr",
+      "name": "@@antv/g6-ssr (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-ssr",
+      "versions": [
+        "0.2.1",
+        "0.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-g6-wx",
+      "name": "@@antv/g6-wx (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/g6-wx",
+      "versions": [
+        "0.1.1",
+        "0.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gatsby-theme",
+      "name": "@@antv/gatsby-theme (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gatsby-theme",
+      "versions": [
+        "0.2.0",
+        "0.3.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-geo-coord",
+      "name": "@@antv/geo-coord (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/geo-coord",
+      "versions": [
+        "1.1.8",
+        "1.2.8"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-advance",
+      "name": "@@antv/gi-assets-advance (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-advance",
+      "versions": [
+        "2.6.22",
+        "2.7.22"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-algorithm",
+      "name": "@@antv/gi-assets-algorithm (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-algorithm",
+      "versions": [
+        "2.4.19",
+        "2.5.19"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-basic",
+      "name": "@@antv/gi-assets-basic (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-basic",
+      "versions": [
+        "2.5.40",
+        "2.6.40"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-galaxybase",
+      "name": "@@antv/gi-assets-galaxybase (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-galaxybase",
+      "versions": [
+        "1.3.15",
+        "1.4.15"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-graphscope",
+      "name": "@@antv/gi-assets-graphscope (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-graphscope",
+      "versions": [
+        "2.2.15",
+        "2.3.15"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-hugegraph",
+      "name": "@@antv/gi-assets-hugegraph (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-hugegraph",
+      "versions": [
+        "1.2.15",
+        "1.3.15"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-janusgraph",
+      "name": "@@antv/gi-assets-janusgraph (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-janusgraph",
+      "versions": [
+        "1.2.15",
+        "1.3.15"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-neo4j",
+      "name": "@@antv/gi-assets-neo4j (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-neo4j",
+      "versions": [
+        "2.2.15",
+        "2.3.15"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-scene",
+      "name": "@@antv/gi-assets-scene (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-scene",
+      "versions": [
+        "2.3.21",
+        "2.4.21"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-tugraph",
+      "name": "@@antv/gi-assets-tugraph (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-tugraph",
+      "versions": [
+        "2.2.15",
+        "2.3.15"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-tugraph-analytics",
+      "name": "@@antv/gi-assets-tugraph-analytics (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-tugraph-analytics",
+      "versions": [
+        "0.3.15",
+        "0.4.15"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-assets-xlab",
+      "name": "@@antv/gi-assets-xlab (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-assets-xlab",
+      "versions": [
+        "0.2.30",
+        "0.3.30"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-cli",
+      "name": "@@antv/gi-cli (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-cli",
+      "versions": [
+        "1.3.11",
+        "1.4.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-common-components",
+      "name": "@@antv/gi-common-components (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-common-components",
+      "versions": [
+        "1.4.16",
+        "1.5.16"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-mock-data",
+      "name": "@@antv/gi-mock-data (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-mock-data",
+      "versions": [
+        "1.1.5",
+        "1.2.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-public-data",
+      "name": "@@antv/gi-public-data (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-public-data",
+      "versions": [
+        "1.1.1",
+        "1.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-sdk",
+      "name": "@@antv/gi-sdk (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-sdk",
+      "versions": [
+        "3.1.0",
+        "3.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-sdk-app",
+      "name": "@@antv/gi-sdk-app (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-sdk-app",
+      "versions": [
+        "1.3.10",
+        "1.4.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gi-theme-antd",
+      "name": "@@antv/gi-theme-antd (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gi-theme-antd",
+      "versions": [
+        "0.7.11",
+        "0.8.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-github-config-cli",
+      "name": "@@antv/github-config-cli (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/github-config-cli",
+      "versions": [
+        "0.2.0",
+        "0.3.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gl-matrix",
+      "name": "@@antv/gl-matrix (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gl-matrix",
+      "versions": [
+        "2.8.1",
+        "2.9.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gpt-vis",
+      "name": "@@antv/gpt-vis (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gpt-vis",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-gpt-vis-ssr",
+      "name": "@@antv/gpt-vis-ssr (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/gpt-vis-ssr",
+      "versions": [
+        "0.4.7",
+        "0.5.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-graphin",
+      "name": "@@antv/graphin (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/graphin",
+      "versions": [
+        "3.1.5",
+        "3.2.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-graphin-components",
+      "name": "@@antv/graphin-components (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/graphin-components",
+      "versions": [
+        "2.5.1",
+        "2.6.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-graphin-graphscope",
+      "name": "@@antv/graphin-graphscope (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/graphin-graphscope",
+      "versions": [
+        "1.1.5",
+        "1.2.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-graphin-icons",
+      "name": "@@antv/graphin-icons (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/graphin-icons",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-graphlib",
+      "name": "@@antv/graphlib (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/graphlib",
+      "versions": [
+        "2.1.4",
+        "2.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-hierarchy",
+      "name": "@@antv/hierarchy (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/hierarchy",
+      "versions": [
+        "0.8.1",
+        "0.9.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-infographic",
+      "name": "@@antv/infographic (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/infographic",
+      "versions": [
+        "0.3.19",
+        "0.4.19"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-insight-component",
+      "name": "@@antv/insight-component (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/insight-component",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-interaction",
+      "name": "@@antv/interaction (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/interaction",
+      "versions": [
+        "0.2.5",
+        "0.3.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-istanbul",
+      "name": "@@antv/istanbul (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/istanbul",
+      "versions": [
+        "0.1.0",
+        "0.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-knowledge",
+      "name": "@@antv/knowledge (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/knowledge",
+      "versions": [
+        "1.2.4",
+        "1.3.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7",
+      "name": "@@antv/l7 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-component",
+      "name": "@@antv/l7-component (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-component",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-composite-layers",
+      "name": "@@antv/l7-composite-layers (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-composite-layers",
+      "versions": [
+        "0.18.1",
+        "0.19.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-core",
+      "name": "@@antv/l7-core (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-core",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-district",
+      "name": "@@antv/l7-district (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-district",
+      "versions": [
+        "2.4.12",
+        "2.5.12"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-draw",
+      "name": "@@antv/l7-draw (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-draw",
+      "versions": [
+        "3.2.5",
+        "3.3.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-editor",
+      "name": "@@antv/l7-editor (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-editor",
+      "versions": [
+        "1.2.13",
+        "1.3.13"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-extension-g-layer",
+      "name": "@@antv/l7-extension-g-layer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-extension-g-layer",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-layers",
+      "name": "@@antv/l7-layers (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-layers",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-leaflet",
+      "name": "@@antv/l7-leaflet (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-leaflet",
+      "versions": [
+        "1.1.2",
+        "1.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-map",
+      "name": "@@antv/l7-map (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-map",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-mapkit",
+      "name": "@@antv/l7-mapkit (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-mapkit",
+      "versions": [
+        "0.6.0",
+        "0.7.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-maps",
+      "name": "@@antv/l7-maps (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-maps",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-mini",
+      "name": "@@antv/l7-mini (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-mini",
+      "versions": [
+        "2.21.8",
+        "2.22.8"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-pass",
+      "name": "@@antv/l7-pass (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-pass",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-react",
+      "name": "@@antv/l7-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-react",
+      "versions": [
+        "2.5.3",
+        "2.6.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-renderer",
+      "name": "@@antv/l7-renderer (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-renderer",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-scene",
+      "name": "@@antv/l7-scene (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-scene",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-source",
+      "name": "@@antv/l7-source (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-source",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-three",
+      "name": "@@antv/l7-three (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-three",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7-utils",
+      "name": "@@antv/l7-utils (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7-utils",
+      "versions": [
+        "2.26.10",
+        "2.27.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7plot",
+      "name": "@@antv/l7plot (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7plot",
+      "versions": [
+        "0.6.11",
+        "0.7.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-l7plot-component",
+      "name": "@@antv/l7plot-component (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/l7plot-component",
+      "versions": [
+        "0.1.11",
+        "0.2.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-larkmap",
+      "name": "@@antv/larkmap (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/larkmap",
+      "versions": [
+        "1.6.1",
+        "1.7.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-layout-gpu",
+      "name": "@@antv/layout-gpu (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/layout-gpu",
+      "versions": [
+        "1.2.7",
+        "1.3.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-layout-wasm",
+      "name": "@@antv/layout-wasm (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/layout-wasm",
+      "versions": [
+        "1.5.2",
+        "1.6.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-li-aiearth-assets",
+      "name": "@@antv/li-aiearth-assets (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/li-aiearth-assets",
+      "versions": [
+        "0.5.7",
+        "0.6.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-li-analysis-assets",
+      "name": "@@antv/li-analysis-assets (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/li-analysis-assets",
+      "versions": [
+        "1.10.1",
+        "1.11.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-li-core-assets",
+      "name": "@@antv/li-core-assets (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/li-core-assets",
+      "versions": [
+        "1.4.7",
+        "1.5.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-li-editor",
+      "name": "@@antv/li-editor (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/li-editor",
+      "versions": [
+        "1.7.1",
+        "1.8.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-li-p2",
+      "name": "@@antv/li-p2 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/li-p2",
+      "versions": [
+        "1.9.2",
+        "1.10.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-li-sam-assets",
+      "name": "@@antv/li-sam-assets (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/li-sam-assets",
+      "versions": [
+        "0.1.4",
+        "0.2.4",
+        "0.3.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-li-sdk",
+      "name": "@@antv/li-sdk (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/li-sdk",
+      "versions": [
+        "1.6.1",
+        "1.7.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-lite-insight",
+      "name": "@@antv/lite-insight (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/lite-insight",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-matrix-util",
+      "name": "@@antv/matrix-util (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/matrix-util",
+      "versions": [
+        "3.1.4",
+        "3.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-mcp-server-antv",
+      "name": "@@antv/mcp-server-antv (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/mcp-server-antv",
+      "versions": [
+        "0.2.8",
+        "0.3.8"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-mcp-server-chart",
+      "name": "@@antv/mcp-server-chart (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/mcp-server-chart",
+      "versions": [
+        "0.10.10",
+        "0.11.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-my-f2",
+      "name": "@@antv/my-f2 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/my-f2",
+      "versions": [
+        "2.2.7",
+        "2.3.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-my-f2-pc",
+      "name": "@@antv/my-f2-pc (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/my-f2-pc",
+      "versions": [
+        "0.2.1",
+        "0.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-narrative-text-editor",
+      "name": "@@antv/narrative-text-editor (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/narrative-text-editor",
+      "versions": [
+        "0.3.20",
+        "0.4.20"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-narrative-text-schema",
+      "name": "@@antv/narrative-text-schema (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/narrative-text-schema",
+      "versions": [
+        "0.4.7",
+        "0.5.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-narrative-text-vis",
+      "name": "@@antv/narrative-text-vis (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/narrative-text-vis",
+      "versions": [
+        "0.4.16",
+        "0.5.16"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-path-util",
+      "name": "@@antv/path-util (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/path-util",
+      "versions": [
+        "3.1.1",
+        "3.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-react-g",
+      "name": "@@antv/react-g (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/react-g",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-s2",
+      "name": "@@antv/s2 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/s2",
+      "versions": [
+        "2.8.1",
+        "2.9.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-s2-react",
+      "name": "@@antv/s2-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/s2-react",
+      "versions": [
+        "2.4.1",
+        "2.5.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-s2-react-components",
+      "name": "@@antv/s2-react-components (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/s2-react-components",
+      "versions": [
+        "2.2.2",
+        "2.3.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-s2-ssr",
+      "name": "@@antv/s2-ssr (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/s2-ssr",
+      "versions": [
+        "0.2.1",
+        "0.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-s2-vue",
+      "name": "@@antv/s2-vue (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/s2-vue",
+      "versions": [
+        "2.3.0",
+        "2.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-sam",
+      "name": "@@antv/sam (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/sam",
+      "versions": [
+        "0.3.0",
+        "0.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-scale",
+      "name": "@@antv/scale (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/scale",
+      "versions": [
+        "0.6.2",
+        "0.7.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-semantic-release-pnpm",
+      "name": "@@antv/semantic-release-pnpm (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/semantic-release-pnpm",
+      "versions": [
+        "1.1.4",
+        "1.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-smart-color",
+      "name": "@@antv/smart-color (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/smart-color",
+      "versions": [
+        "0.3.1",
+        "0.4.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-stat",
+      "name": "@@antv/stat (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/stat",
+      "versions": [
+        "0.1.2",
+        "0.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-t8",
+      "name": "@@antv/t8 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/t8",
+      "versions": [
+        "0.4.0",
+        "0.5.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-thumbnails",
+      "name": "@@antv/thumbnails (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/thumbnails",
+      "versions": [
+        "2.1.0",
+        "2.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-thumbnails-component",
+      "name": "@@antv/thumbnails-component (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/thumbnails-component",
+      "versions": [
+        "2.1.0",
+        "2.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-torch",
+      "name": "@@antv/torch (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/torch",
+      "versions": [
+        "1.1.6",
+        "1.2.6"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-translator",
+      "name": "@@antv/translator (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/translator",
+      "versions": [
+        "1.1.1",
+        "1.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-util",
+      "name": "@@antv/util (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/util",
+      "versions": [
+        "3.4.11",
+        "3.5.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-vendor",
+      "name": "@@antv/vendor (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/vendor",
+      "versions": [
+        "1.1.11",
+        "1.2.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-vis-predict-engine",
+      "name": "@@antv/vis-predict-engine (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/vis-predict-engine",
+      "versions": [
+        "0.2.1",
+        "0.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-webgpu-graph",
+      "name": "@@antv/webgpu-graph (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/webgpu-graph",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-word-scale-chart",
+      "name": "@@antv/word-scale-chart (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/word-scale-chart",
+      "versions": [
+        "0.4.4",
+        "0.5.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-wx-f2",
+      "name": "@@antv/wx-f2 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/wx-f2",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6",
+      "name": "@@antv/x6 (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6",
+      "versions": [
+        "3.2.7",
+        "3.3.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-angular-shape",
+      "name": "@@antv/x6-angular-shape (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-angular-shape",
+      "versions": [
+        "3.1.1",
+        "3.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-common",
+      "name": "@@antv/x6-common (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-common",
+      "versions": [
+        "2.1.17",
+        "2.2.17"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-components",
+      "name": "@@antv/x6-components (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-components",
+      "versions": [
+        "0.11.7",
+        "0.12.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-geometry",
+      "name": "@@antv/x6-geometry (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-geometry",
+      "versions": [
+        "2.1.5",
+        "2.2.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-clipboard",
+      "name": "@@antv/x6-plugin-clipboard (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-clipboard",
+      "versions": [
+        "2.2.6",
+        "2.3.6"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-dnd",
+      "name": "@@antv/x6-plugin-dnd (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-dnd",
+      "versions": [
+        "2.2.1",
+        "2.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-export",
+      "name": "@@antv/x6-plugin-export (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-export",
+      "versions": [
+        "2.2.6",
+        "2.3.6"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-history",
+      "name": "@@antv/x6-plugin-history (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-history",
+      "versions": [
+        "2.3.4",
+        "2.4.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-keyboard",
+      "name": "@@antv/x6-plugin-keyboard (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-keyboard",
+      "versions": [
+        "2.3.3",
+        "2.4.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-minimap",
+      "name": "@@antv/x6-plugin-minimap (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-minimap",
+      "versions": [
+        "2.1.7",
+        "2.2.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-scroller",
+      "name": "@@antv/x6-plugin-scroller (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-scroller",
+      "versions": [
+        "2.1.10",
+        "2.2.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-selection",
+      "name": "@@antv/x6-plugin-selection (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-selection",
+      "versions": [
+        "2.3.2",
+        "2.4.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-snapline",
+      "name": "@@antv/x6-plugin-snapline (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-snapline",
+      "versions": [
+        "2.2.7",
+        "2.3.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-stencil",
+      "name": "@@antv/x6-plugin-stencil (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-stencil",
+      "versions": [
+        "2.2.5",
+        "2.3.5"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-plugin-transform",
+      "name": "@@antv/x6-plugin-transform (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-plugin-transform",
+      "versions": [
+        "2.2.8",
+        "2.3.8"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-react",
+      "name": "@@antv/x6-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-react",
+      "versions": [
+        "0.2.26",
+        "0.3.26"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-react-components",
+      "name": "@@antv/x6-react-components (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-react-components",
+      "versions": [
+        "2.1.9",
+        "2.2.9"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-react-shape",
+      "name": "@@antv/x6-react-shape (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-react-shape",
+      "versions": [
+        "3.1.1",
+        "3.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-vector",
+      "name": "@@antv/x6-vector (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-vector",
+      "versions": [
+        "1.5.2",
+        "1.6.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-vue-shape",
+      "name": "@@antv/x6-vue-shape (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-vue-shape",
+      "versions": [
+        "3.1.2",
+        "3.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-x6-vue3-shape",
+      "name": "@@antv/x6-vue3-shape (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/x6-vue3-shape",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-xflow",
+      "name": "@@antv/xflow (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/xflow",
+      "versions": [
+        "2.2.13",
+        "2.3.13"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-xflow-core",
+      "name": "@@antv/xflow-core (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/xflow-core",
+      "versions": [
+        "1.1.55",
+        "1.2.55"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-xflow-diff",
+      "name": "@@antv/xflow-diff (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/xflow-diff",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-xflow-extension",
+      "name": "@@antv/xflow-extension (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/xflow-extension",
+      "versions": [
+        "1.1.55",
+        "1.2.55"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-antv-xflow-hook",
+      "name": "@@antv/xflow-hook (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@antv/xflow-hook",
+      "versions": [
+        "1.1.55",
+        "1.2.55"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-lint-md-cli-bf9305",
+      "name": "@@lint-md/cli (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@lint-md/cli",
+      "versions": [
+        "2.1.0",
+        "2.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-lint-md-core",
+      "name": "@@lint-md/core (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@lint-md/core",
+      "versions": [
+        "2.1.0",
+        "2.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-lint-md-parser",
+      "name": "@@lint-md/parser (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@lint-md/parser",
+      "versions": [
+        "0.1.14",
+        "0.2.14"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-openclaw-cn-cli",
+      "name": "@@openclaw-cn/cli (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@openclaw-cn/cli",
+      "versions": [
+        "1.4.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-openclaw-cn-feishu",
+      "name": "@@openclaw-cn/feishu (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@openclaw-cn/feishu",
+      "versions": [
+        "0.2.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-openclaw-cn-libsignal",
+      "name": "@@openclaw-cn/libsignal (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@openclaw-cn/libsignal",
+      "versions": [
+        "2.1.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-openclaw-cn-toutiao-ops",
+      "name": "@@openclaw-cn/toutiao-ops (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@openclaw-cn/toutiao-ops",
+      "versions": [
+        "1.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-starmind-collector-cli",
+      "name": "@@starmind/collector-cli (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "@@starmind/collector-cli",
+      "versions": [
+        "0.3.10"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-ai-figure",
+      "name": "ai-figure (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "ai-figure",
+      "versions": [
+        "0.5.0",
+        "0.6.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-amapcn",
+      "name": "amapcn (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "amapcn",
+      "versions": [
+        "0.2.2",
+        "0.3.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-ast-plugin",
+      "name": "ast-plugin (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "ast-plugin",
+      "versions": [
+        "0.1.7",
+        "0.2.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-babel-plugin-version",
+      "name": "babel-plugin-version (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "babel-plugin-version",
+      "versions": [
+        "0.3.3",
+        "0.4.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-boring-avatars-vanilla",
+      "name": "boring-avatars-vanilla (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "boring-avatars-vanilla",
+      "versions": [
+        "1.1.2",
+        "1.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-byte-parser",
+      "name": "byte-parser (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "byte-parser",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-canvas-nest-js",
+      "name": "canvas-nest.js (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "canvas-nest.js",
+      "versions": [
+        "2.1.4",
+        "2.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-echarts-for-react",
+      "name": "echarts-for-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "echarts-for-react",
+      "versions": [
+        "3.1.7",
+        "3.2.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-filesize-js",
+      "name": "filesize.js (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "filesize.js",
+      "versions": [
+        "2.1.0",
+        "2.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-fixed-round",
+      "name": "fixed-round (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "fixed-round",
+      "versions": [
+        "1.1.2",
+        "1.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-gantt-for-react",
+      "name": "gantt-for-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "gantt-for-react",
+      "versions": [
+        "0.3.0",
+        "0.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-jest-canvas-mock",
+      "name": "jest-canvas-mock (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "jest-canvas-mock",
+      "versions": [
+        "2.6.3",
+        "2.7.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-jest-date-mock",
+      "name": "jest-date-mock (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "jest-date-mock",
+      "versions": [
+        "1.1.11",
+        "1.2.11"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-jest-electron",
+      "name": "jest-electron (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "jest-electron",
+      "versions": [
+        "0.2.12",
+        "0.3.12"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-jest-expect",
+      "name": "jest-expect (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "jest-expect",
+      "versions": [
+        "0.1.1",
+        "0.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-jest-less-loader",
+      "name": "jest-less-loader (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "jest-less-loader",
+      "versions": [
+        "0.3.0",
+        "0.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-jest-random-mock",
+      "name": "jest-random-mock (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "jest-random-mock",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-jest-url-loader",
+      "name": "jest-url-loader (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "jest-url-loader",
+      "versions": [
+        "0.2.0",
+        "0.3.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-limit-size",
+      "name": "limit-size (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "limit-size",
+      "versions": [
+        "0.2.4",
+        "0.3.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-lint-md",
+      "name": "lint-md (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "lint-md",
+      "versions": [
+        "0.3.0",
+        "0.4.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-lint-md-cli-71b94e",
+      "name": "lint-md-cli (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "lint-md-cli",
+      "versions": [
+        "0.2.2",
+        "0.3.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-mcp-echarts",
+      "name": "mcp-echarts (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "mcp-echarts",
+      "versions": [
+        "0.8.1",
+        "0.9.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-mcp-mermaid",
+      "name": "mcp-mermaid (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "mcp-mermaid",
+      "versions": [
+        "0.5.1",
+        "0.6.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-miz",
+      "name": "miz (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "miz",
+      "versions": [
+        "1.1.1",
+        "1.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-onfire-js",
+      "name": "onfire.js (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "onfire.js",
+      "versions": [
+        "2.1.1",
+        "2.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-openclaw-cn",
+      "name": "openclaw-cn (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "openclaw-cn",
+      "versions": [
+        "0.3.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-react-adsense",
+      "name": "react-adsense (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "react-adsense",
+      "versions": [
+        "0.2.0",
+        "0.3.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-relationship-js",
+      "name": "relationship.js (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "relationship.js",
+      "versions": [
+        "1.3.9",
+        "1.4.9"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-ribbon-js",
+      "name": "ribbon.js (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "ribbon.js",
+      "versions": [
+        "1.1.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-size-sensor",
+      "name": "size-sensor (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "size-sensor",
+      "versions": [
+        "1.1.4",
+        "1.2.4"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-slice-js",
+      "name": "slice.js (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "slice.js",
+      "versions": [
+        "1.2.1",
+        "1.3.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-timeago-react",
+      "name": "timeago-react (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "timeago-react",
+      "versions": [
+        "3.1.7",
+        "3.2.7"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-timeago-js",
+      "name": "timeago.js (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "timeago.js",
+      "versions": [
+        "4.1.2",
+        "4.2.2"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-uri-parse",
+      "name": "uri-parse (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "uri-parse",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-word-width",
+      "name": "word-width (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "word-width",
+      "versions": [
+        "1.1.1",
+        "1.2.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-npm-xmorse",
+      "name": "xmorse (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "npm",
+      "package": "xmorse",
+      "versions": [
+        "1.1.0",
+        "1.2.0"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    },
+    {
+      "id": "socket-2026-05-19-antv-mini-shai-hulud-pypi-durabletask",
+      "name": "durabletask (AntV / Mini Shai-Hulud May 2026 wave)",
+      "ecosystem": "pypi",
+      "package": "durabletask",
+      "versions": [
+        "1.4.1",
+        "1.4.2",
+        "1.4.3"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/antv-packages-compromised"
+    }
+  ]
+}

--- a/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/gemstuffer.json
+++ b/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/gemstuffer.json
@@ -1,0 +1,1397 @@
+{
+  "schema_version": "0.1.0",
+  "_comment": "GemStuffer campaign (Socket, 2026-05-13). The actor abused RubyGems as a data transport/exfiltration channel for scraped UK local government content rather than as a conventional mass developer-compromise payload. Severity is set to high (not critical) because the gems are an exfil-channel artifact rather than a worm/credential stealer: presence on a developer endpoint still indicates either accidental install or directed compromise and is worth flagging. Embedded Socket tracker enumerated 155 artifact rows at handoff, deduped here to one entry per (ecosystem, gem) with the published versions. Example gems explicitly called out by the article include lambeth71b and agenda-sample-yard / agenda-sample-result. The scanner does exact (ecosystem, name, version) matching only.",
+  "_indicators": {
+    "payload_rb_sha256": "239440c830e17530dda0a8a06ed2708860998750a1e3ed2239e919465dc59420",
+    "script_rb_sha256": "c2d6bcacc88177e0f2c8c262726f86f37e671b1692c8bc135bac4b610ddcf31a",
+    "_note": "Socket post for GemStuffer also publishes SHA-1 and MD5 for payload.rb and script.rb plus redacted RubyGems API key prefixes/suffixes; only the SHA-256 values were provided in the audit handoff and are captured here verbatim. SHA-1/MD5 omitted rather than invented.",
+    "exfil_channel": "https://rubygems.org/api/v1/gems"
+  },
+  "entries": [
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-aaaresultfetchx",
+      "name": "aaaresultfetchx (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "aaaresultfetchx",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-agenda-sample-yard",
+      "name": "agenda-sample-yard (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "agenda-sample-yard",
+      "versions": [
+        "0.1.0",
+        "0.1.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-anchorx994",
+      "name": "anchorx994 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "anchorx994",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-anchorx995",
+      "name": "anchorx995 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "anchorx995",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-bot9evil",
+      "name": "bot9evil (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "bot9evil",
+      "versions": [
+        "0.1.0"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-civic-lambda-proxy",
+      "name": "civic-lambda-proxy (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "civic-lambda-proxy",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-councilbridgexyz",
+      "name": "councilbridgexyz (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "councilbridgexyz",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-councilfetchfff",
+      "name": "councilfetchfff (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "councilfetchfff",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-councilprobexyz",
+      "name": "councilprobexyz (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "councilprobexyz",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-designfetchdemo",
+      "name": "designfetchdemo (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "designfetchdemo",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-dnsfetchabc12",
+      "name": "dnsfetchabc12 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "dnsfetchabc12",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-exslnews795",
+      "name": "exslnews795 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "exslnews795",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-extssrfabc1778553451",
+      "name": "extssrfabc1778553451 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "extssrfabc1778553451",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-fetchrootx1",
+      "name": "fetchrootx1 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "fetchrootx1",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-fetchrootx2",
+      "name": "fetchrootx2 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "fetchrootx2",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-fmtsouthprox",
+      "name": "fmtsouthprox (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "fmtsouthprox",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-fmtstatdoca",
+      "name": "fmtstatdoca (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "fmtstatdoca",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-foobartmpxyz1234",
+      "name": "foobartmpxyz1234 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "foobartmpxyz1234",
+      "versions": [
+        "0.1.0",
+        "0.1.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-gemsimpleuo46nv",
+      "name": "gemsimpleuo46nv (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "gemsimpleuo46nv",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambcalfetchxyz",
+      "name": "lambcalfetchxyz (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambcalfetchxyz",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambcrawlxyz",
+      "name": "lambcrawlxyz (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambcrawlxyz",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambeth71a",
+      "name": "lambeth71a (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambeth71a",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambeth71b",
+      "name": "lambeth71b (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambeth71b",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambethcalcqzewgt",
+      "name": "lambethcalcqzewgt (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambethcalcqzewgt",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambethx33zzz",
+      "name": "lambethx33zzz (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambethx33zzz",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambexploitabc1",
+      "name": "lambexploitabc1 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambexploitabc1",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambfetchjj1",
+      "name": "lambfetchjj1 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambfetchjj1",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambfetchjj2",
+      "name": "lambfetchjj2 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambfetchjj2",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambfetchx528211",
+      "name": "lambfetchx528211 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambfetchx528211",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambfetchx548811",
+      "name": "lambfetchx548811 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambfetchx548811",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambfetchx550961",
+      "name": "lambfetchx550961 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambfetchx550961",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambproxydkz",
+      "name": "lambproxydkz (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambproxydkz",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambproxyman",
+      "name": "lambproxyman (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambproxyman",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambtmp35293950",
+      "name": "lambtmp35293950 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambtmp35293950",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambyard17",
+      "name": "lambyard17 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambyard17",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lambyardcal",
+      "name": "lambyardcal (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lambyardcal",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lamhackzzq",
+      "name": "lamhackzzq (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lamhackzzq",
+      "versions": [
+        "0.0.3",
+        "0.0.5"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-lbdeepgeta",
+      "name": "lbdeepgeta (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "lbdeepgeta",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-londonyardtestabc",
+      "name": "londonyardtestabc (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "londonyardtestabc",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-probeextwand",
+      "name": "probeextwand (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "probeextwand",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-proxssrfetviqtfb",
+      "name": "proxssrfetviqtfb (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "proxssrfetviqtfb",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-qwandfetch1",
+      "name": "qwandfetch1 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "qwandfetch1",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-rootfetchcalendarx",
+      "name": "rootfetchcalendarx (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "rootfetchcalendarx",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-rootfetchproperxyz",
+      "name": "rootfetchproperxyz (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "rootfetchproperxyz",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-runnerhack1778553910",
+      "name": "runnerhack1778553910 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "runnerhack1778553910",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-sf8aea",
+      "name": "sf8aea (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "sf8aea",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-sl-yard-probe2",
+      "name": "sl-yard-probe2 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "sl-yard-probe2",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-sl-yh-abcxyz1",
+      "name": "sl-yh-abcxyz1 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "sl-yh-abcxyz1",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-slfetchabc",
+      "name": "slfetchabc (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "slfetchabc",
+      "versions": [
+        "0.0.1",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-slfetchrootabc",
+      "name": "slfetchrootabc (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "slfetchrootabc",
+      "versions": [
+        "0.1.0"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-slfetchxyz",
+      "name": "slfetchxyz (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "slfetchxyz",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-slhackprobe999",
+      "name": "slhackprobe999 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "slhackprobe999",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-slnfetchroot001",
+      "name": "slnfetchroot001 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "slnfetchroot001",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-slnleaker4",
+      "name": "slnleaker4 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "slnleaker4",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-slnleaker5",
+      "name": "slnleaker5 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "slnleaker5",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-slnleakerext",
+      "name": "slnleakerext (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "slnleakerext",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-slnmultifetchabc",
+      "name": "slnmultifetchabc (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "slnmultifetchabc",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-smproxyaaa",
+      "name": "smproxyaaa (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "smproxyaaa",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-soufetchabc",
+      "name": "soufetchabc (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "soufetchabc",
+      "versions": [
+        "0.0.1",
+        "0.0.2",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southc0ea",
+      "name": "southc0ea (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southc0ea",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southcalx884",
+      "name": "southcalx884 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southcalx884",
+      "versions": [
+        "0.0.1",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southfetchefefd",
+      "name": "southfetchefefd (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southfetchefefd",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southfetchprobe42",
+      "name": "southfetchprobe42 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southfetchprobe42",
+      "versions": [
+        "0.0.1",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southlondonfetchroot",
+      "name": "southlondonfetchroot (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southlondonfetchroot",
+      "versions": [
+        "0.0.1",
+        "0.1.0"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southmqsedwjgw",
+      "name": "southmqsedwjgw (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southmqsedwjgw",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southnews-designfetch-90001",
+      "name": "southnews-designfetch-90001 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southnews-designfetch-90001",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southnews-designfetch-90002",
+      "name": "southnews-designfetch-90002 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southnews-designfetch-90002",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southnews-payload1-35329",
+      "name": "southnews-payload1-35329 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southnews-payload1-35329",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southnewsprobe1778550995",
+      "name": "southnewsprobe1778550995 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southnewsprobe1778550995",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southpxdatapp6pi",
+      "name": "southpxdatapp6pi (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southpxdatapp6pi",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southpxjzmrdata",
+      "name": "southpxjzmrdata (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southpxjzmrdata",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southyardmine1",
+      "name": "southyardmine1 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southyardmine1",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southyardproxy",
+      "name": "southyardproxy (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southyardproxy",
+      "versions": [
+        "0.0.1",
+        "0.0.2",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-southzzscrape",
+      "name": "southzzscrape (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "southzzscrape",
+      "versions": [
+        "0.0.1",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-swcal2507",
+      "name": "swcal2507 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "swcal2507",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-swcalfetcha",
+      "name": "swcalfetcha (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "swcalfetcha",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-swfetch-cal1-68321",
+      "name": "swfetch-cal1-68321 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "swfetch-cal1-68321",
+      "versions": [
+        "0.0.1",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-swkagenttwo",
+      "name": "swkagenttwo (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "swkagenttwo",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-swmeetfetcha",
+      "name": "swmeetfetcha (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "swmeetfetcha",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-tempwljrnwb",
+      "name": "tempwljrnwb (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "tempwljrnwb",
+      "versions": [
+        "0.0.10"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-useful-helper-tools",
+      "name": "useful_helper_tools (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "useful_helper_tools",
+      "versions": [
+        "1.2.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-uu4c477z1",
+      "name": "uu4c477z1 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "uu4c477z1",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-uuext4c477",
+      "name": "uuext4c477 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "uuext4c477",
+      "versions": [
+        "0.0.1",
+        "0.0.2",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandcabfetchfix21736",
+      "name": "wandcabfetchfix21736 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandcabfetchfix21736",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandcabm10266dsgn2",
+      "name": "wandcabm10266dsgn2 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandcabm10266dsgn2",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandcabm10266dsgn4",
+      "name": "wandcabm10266dsgn4 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandcabm10266dsgn4",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandcalentryzz001",
+      "name": "wandcalentryzz001 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandcalentryzz001",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandexecxtest",
+      "name": "wandexecxtest (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandexecxtest",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandfetchcal021",
+      "name": "wandfetchcal021 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandfetchcal021",
+      "versions": [
+        "0.0.1",
+        "0.0.5"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandhackmy",
+      "name": "wandhackmy (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandhackmy",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandocal1",
+      "name": "wandocal1 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandocal1",
+      "versions": [
+        "0.0.1",
+        "0.1.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandscrawla",
+      "name": "wandscrawla (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandscrawla",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandscrawlq",
+      "name": "wandscrawlq (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandscrawlq",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandscrawlr",
+      "name": "wandscrawlr (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandscrawlr",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandscrawlx",
+      "name": "wandscrawlx (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandscrawlx",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandsfetchzzabc",
+      "name": "wandsfetchzzabc (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandsfetchzzabc",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandsproxybuildtest0001",
+      "name": "wandsproxybuildtest0001 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandsproxybuildtest0001",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandsproxylol",
+      "name": "wandsproxylol (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandsproxylol",
+      "versions": [
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandswan1-1778553002",
+      "name": "wandswan1-1778553002 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandswan1-1778553002",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandsworthprefetch209db",
+      "name": "wandsworthprefetch209db (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandsworthprefetch209db",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandtmpdesign9fe2",
+      "name": "wandtmpdesign9fe2 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandtmpdesign9fe2",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandxgetbc1",
+      "name": "wandxgetbc1 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandxgetbc1",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandxprobe",
+      "name": "wandxprobe (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandxprobe",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wandzfetch1500929",
+      "name": "wandzfetch1500929 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wandzfetch1500929",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wanfetcherx9",
+      "name": "wanfetcherx9 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wanfetcherx9",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wdfetchcalmy",
+      "name": "wdfetchcalmy (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wdfetchcalmy",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-wn98122eth",
+      "name": "wn98122eth (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "wn98122eth",
+      "versions": [
+        "9.8.0",
+        "9.9.0"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yard-controllerlambda",
+      "name": "yard-controllerlambda (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yard-controllerlambda",
+      "versions": [
+        "0.0.1",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yard-docxrun",
+      "name": "yard-docxrun (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yard-docxrun",
+      "versions": [
+        "0.0.1",
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yard-runhack",
+      "name": "yard-runhack (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yard-runhack",
+      "versions": [
+        "0.0.3"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yard-skyfetch",
+      "name": "yard-skyfetch (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yard-skyfetch",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yard-slnmultifetch",
+      "name": "yard-slnmultifetch (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yard-slnmultifetch",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yardbreakerxqh1778552850",
+      "name": "yardbreakerxqh1778552850 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yardbreakerxqh1778552850",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yardssrfabc1778551294",
+      "name": "yardssrfabc1778551294 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yardssrfabc1778551294",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yardxabc889",
+      "name": "yardxabc889 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yardxabc889",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yardz1778552299",
+      "name": "yardz1778552299 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yardz1778552299",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-yexpabc58377",
+      "name": "yexpabc58377 (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "yexpabc58377",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-ygexpwzqbot",
+      "name": "ygexpwzqbot (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "ygexpwzqbot",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-zzsouthfetchsimplex",
+      "name": "zzsouthfetchsimplex (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "zzsouthfetchsimplex",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-zzsouthfetchtestx",
+      "name": "zzsouthfetchtestx (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "zzsouthfetchtestx",
+      "versions": [
+        "0.0.1",
+        "0.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-zzsouthrunner",
+      "name": "zzsouthrunner (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "zzsouthrunner",
+      "versions": [
+        "1.0.1",
+        "1.0.2"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-zzsouthrunnerb",
+      "name": "zzsouthrunnerb (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "zzsouthrunnerb",
+      "versions": [
+        "1.0.0"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    },
+    {
+      "id": "socket-2026-05-13-gemstuffer-rubygems-zzwandshostyard",
+      "name": "zzwandshostyard (GemStuffer May 2026 RubyGems exfiltration campaign)",
+      "ecosystem": "rubygems",
+      "package": "zzwandshostyard",
+      "versions": [
+        "0.0.1"
+      ],
+      "severity": "high",
+      "source": "https://socket.dev/blog/gemstuffer"
+    }
+  ]
+}

--- a/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/mini-shai-hulud.json
+++ b/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/mini-shai-hulud.json
@@ -1,0 +1,1573 @@
+{
+  "schema_version": "0.1.0",
+  "_comment": "Best-effort public Mini/Shai-Hulud May 2026 package exposure catalog generated from the static OX Security affected-package table and cross-checked against public Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting. This is intended for exact package/version presence checks, not network/file/process IOC checks. Public reporting says 170+ packages were affected; this file contains the static package/version rows available from the cited public table at generation time. Keep it updated from authoritative advisories before production use.",
+  "entries": [
+    {
+      "id": "mini-shai-hulud-2026-npm-beproduct-nestjs-auth",
+      "name": "@beproduct/nestjs-auth (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@beproduct/nestjs-auth",
+      "versions": [
+        "0.1.18",
+        "0.1.19",
+        "0.1.17",
+        "0.1.16",
+        "0.1.15",
+        "0.1.13",
+        "0.1.14",
+        "0.1.8",
+        "0.1.6",
+        "0.1.9",
+        "0.1.2",
+        "0.1.5",
+        "0.1.11",
+        "0.1.4",
+        "0.1.3",
+        "0.1.7",
+        "0.1.10",
+        "0.1.12"
+      ],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-dirigible-ai-sdk",
+      "name": "@dirigible-ai/sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@dirigible-ai/sdk",
+      "versions": ["0.6.3", "0.6.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-draftauth-client",
+      "name": "@draftauth/client (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@draftauth/client",
+      "versions": ["0.2.2", "0.2.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-draftauth-core",
+      "name": "@draftauth/core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@draftauth/core",
+      "versions": ["0.13.1", "0.13.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-draftlab-auth",
+      "name": "@draftlab/auth (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@draftlab/auth",
+      "versions": ["0.24.2", "0.24.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-draftlab-auth-router",
+      "name": "@draftlab/auth-router (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@draftlab/auth-router",
+      "versions": ["0.5.1", "0.5.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-draftlab-db",
+      "name": "@draftlab/db (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@draftlab/db",
+      "versions": ["0.16.2", "0.16.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-mesadev-rest",
+      "name": "@mesadev/rest (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@mesadev/rest",
+      "versions": ["0.28.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-mesadev-saguaro",
+      "name": "@mesadev/saguaro (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@mesadev/saguaro",
+      "versions": ["0.4.22"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-mesadev-sdk",
+      "name": "@mesadev/sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@mesadev/sdk",
+      "versions": ["0.28.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-mistralai-mistralai",
+      "name": "@mistralai/mistralai (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@mistralai/mistralai",
+      "versions": ["2.2.4", "2.2.3", "2.2.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-mistralai-mistralai-azure",
+      "name": "@mistralai/mistralai-azure (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@mistralai/mistralai-azure",
+      "versions": ["1.7.3", "1.7.1", "1.7.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-mistralai-mistralai-gcp",
+      "name": "@mistralai/mistralai-gcp (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@mistralai/mistralai-gcp",
+      "versions": ["1.7.3", "1.7.1", "1.7.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-ml-toolkit-ts-preprocessing",
+      "name": "@ml-toolkit-ts/preprocessing (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@ml-toolkit-ts/preprocessing",
+      "versions": ["1.0.2", "1.0.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-ml-toolkit-ts-xgboost",
+      "name": "@ml-toolkit-ts/xgboost (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@ml-toolkit-ts/xgboost",
+      "versions": ["1.0.3", "1.0.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-opensearch-project-opensearch",
+      "name": "@opensearch-project/opensearch (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@opensearch-project/opensearch",
+      "versions": ["3.5.3", "3.8.0", "3.7.0", "3.6.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-airport-data",
+      "name": "@squawk/airport-data (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/airport-data",
+      "versions": ["0.7.8", "0.7.7", "0.7.6", "0.7.5", "0.7.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-airports",
+      "name": "@squawk/airports (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/airports",
+      "versions": ["0.6.6", "0.6.5", "0.6.4", "0.6.3", "0.6.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-airspace",
+      "name": "@squawk/airspace (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/airspace",
+      "versions": ["0.8.5", "0.8.3", "0.8.4", "0.8.2", "0.8.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-airspace-data",
+      "name": "@squawk/airspace-data (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/airspace-data",
+      "versions": ["0.5.7", "0.5.5", "0.5.6", "0.5.4", "0.5.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-airway-data",
+      "name": "@squawk/airway-data (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/airway-data",
+      "versions": ["0.5.8", "0.5.7", "0.5.6", "0.5.5", "0.5.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-airways",
+      "name": "@squawk/airways (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/airways",
+      "versions": ["0.4.6", "0.4.4", "0.4.5", "0.4.3", "0.4.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-fix-data",
+      "name": "@squawk/fix-data (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/fix-data",
+      "versions": ["0.6.8", "0.6.7", "0.6.6", "0.6.5", "0.6.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-fixes",
+      "name": "@squawk/fixes (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/fixes",
+      "versions": ["0.3.6", "0.3.5", "0.3.4", "0.3.3", "0.3.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-flight-math",
+      "name": "@squawk/flight-math (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/flight-math",
+      "versions": ["0.5.8", "0.5.7", "0.5.6", "0.5.5", "0.5.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-flightplan",
+      "name": "@squawk/flightplan (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/flightplan",
+      "versions": ["0.5.6", "0.5.5", "0.5.4", "0.5.3", "0.5.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-geo",
+      "name": "@squawk/geo (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/geo",
+      "versions": ["0.4.8", "0.4.7", "0.4.6", "0.4.5", "0.4.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-icao-registry",
+      "name": "@squawk/icao-registry (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/icao-registry",
+      "versions": ["0.5.6", "0.5.5", "0.5.4", "0.5.3", "0.5.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-icao-registry-data",
+      "name": "@squawk/icao-registry-data (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/icao-registry-data",
+      "versions": ["0.8.8", "0.8.6", "0.8.7", "0.8.5", "0.8.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-mcp",
+      "name": "@squawk/mcp (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/mcp",
+      "versions": ["0.9.5", "0.9.4", "0.9.3", "0.9.2", "0.9.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-navaid-data",
+      "name": "@squawk/navaid-data (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/navaid-data",
+      "versions": ["0.6.8", "0.6.7", "0.6.6", "0.6.5", "0.6.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-navaids",
+      "name": "@squawk/navaids (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/navaids",
+      "versions": ["0.4.6", "0.4.5", "0.4.4", "0.4.3", "0.4.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-notams",
+      "name": "@squawk/notams (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/notams",
+      "versions": ["0.3.10", "0.3.9", "0.3.8", "0.3.7", "0.3.6"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-procedure-data",
+      "name": "@squawk/procedure-data (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/procedure-data",
+      "versions": ["0.7.7", "0.7.5", "0.7.6", "0.7.4", "0.7.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-procedures",
+      "name": "@squawk/procedures (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/procedures",
+      "versions": ["0.5.6", "0.5.4", "0.5.5", "0.5.3", "0.5.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-types",
+      "name": "@squawk/types (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/types",
+      "versions": ["0.8.5", "0.8.3", "0.8.4", "0.8.2", "0.8.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-units",
+      "name": "@squawk/units (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/units",
+      "versions": ["0.4.7", "0.4.5", "0.4.6", "0.4.4", "0.4.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-squawk-weather",
+      "name": "@squawk/weather (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@squawk/weather",
+      "versions": ["0.5.10", "0.5.8", "0.5.9", "0.5.7", "0.5.6"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-supersurkhet-cli",
+      "name": "@supersurkhet/cli (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@supersurkhet/cli",
+      "versions": ["0.0.7", "0.0.6", "0.0.5", "0.0.4", "0.0.3", "0.0.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-supersurkhet-sdk",
+      "name": "@supersurkhet/sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@supersurkhet/sdk",
+      "versions": ["0.0.7", "0.0.6", "0.0.5", "0.0.4", "0.0.3", "0.0.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-components",
+      "name": "@tallyui/components (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/components",
+      "versions": ["1.0.3", "1.0.2", "1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-connector-medusa",
+      "name": "@tallyui/connector-medusa (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/connector-medusa",
+      "versions": ["1.0.3", "1.0.2", "1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-connector-shopify",
+      "name": "@tallyui/connector-shopify (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/connector-shopify",
+      "versions": ["1.0.3", "1.0.2", "1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-connector-vendure",
+      "name": "@tallyui/connector-vendure (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/connector-vendure",
+      "versions": ["1.0.3", "1.0.2", "1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-connector-woocommerce",
+      "name": "@tallyui/connector-woocommerce (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/connector-woocommerce",
+      "versions": ["1.0.3", "1.0.2", "1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-core",
+      "name": "@tallyui/core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/core",
+      "versions": ["0.2.3", "0.2.2", "0.2.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-database",
+      "name": "@tallyui/database (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/database",
+      "versions": ["1.0.3", "1.0.2", "1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-pos",
+      "name": "@tallyui/pos (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/pos",
+      "versions": ["0.1.3", "0.1.2", "0.1.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-storage-sqlite",
+      "name": "@tallyui/storage-sqlite (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/storage-sqlite",
+      "versions": ["0.2.3", "0.2.2", "0.2.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tallyui-theme",
+      "name": "@tallyui/theme (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tallyui/theme",
+      "versions": ["0.2.3", "0.2.2", "0.2.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-arktype-adapter",
+      "name": "@tanstack/arktype-adapter (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/arktype-adapter",
+      "versions": ["1.166.15", "1.166.12"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-eslint-plugin-router",
+      "name": "@tanstack/eslint-plugin-router (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/eslint-plugin-router",
+      "versions": ["1.161.12", "1.161.9"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-eslint-plugin-start",
+      "name": "@tanstack/eslint-plugin-start (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/eslint-plugin-start",
+      "versions": ["0.0.7", "0.0.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-history",
+      "name": "@tanstack/history (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/history",
+      "versions": ["1.161.12", "1.161.9"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-nitro-v2-vite-plugin",
+      "name": "@tanstack/nitro-v2-vite-plugin (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/nitro-v2-vite-plugin",
+      "versions": ["1.154.15", "1.154.12"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-react-router",
+      "name": "@tanstack/react-router (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/react-router",
+      "versions": ["1.169.8", "1.169.5"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-react-router-devtools",
+      "name": "@tanstack/react-router-devtools (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/react-router-devtools",
+      "versions": ["1.166.19", "1.166.16"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-react-router-ssr-query",
+      "name": "@tanstack/react-router-ssr-query (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/react-router-ssr-query",
+      "versions": ["1.166.18", "1.166.15"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-react-start",
+      "name": "@tanstack/react-start (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/react-start",
+      "versions": ["1.167.71", "1.167.68"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-react-start-client",
+      "name": "@tanstack/react-start-client (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/react-start-client",
+      "versions": ["1.166.54", "1.166.51"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-react-start-rsc",
+      "name": "@tanstack/react-start-rsc (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/react-start-rsc",
+      "versions": ["0.0.50", "0.0.47"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-react-start-server",
+      "name": "@tanstack/react-start-server (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/react-start-server",
+      "versions": ["1.166.58", "1.166.55"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-router-cli",
+      "name": "@tanstack/router-cli (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/router-cli",
+      "versions": ["1.166.49", "1.166.46"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-router-core",
+      "name": "@tanstack/router-core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/router-core",
+      "versions": ["1.169.8", "1.169.5"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-router-devtools",
+      "name": "@tanstack/router-devtools (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/router-devtools",
+      "versions": ["1.166.19", "1.166.16"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-router-devtools-core",
+      "name": "@tanstack/router-devtools-core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/router-devtools-core",
+      "versions": ["1.167.9", "1.167.6"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-router-generator",
+      "name": "@tanstack/router-generator (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/router-generator",
+      "versions": ["1.166.48", "1.166.45"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-router-plugin",
+      "name": "@tanstack/router-plugin (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/router-plugin",
+      "versions": ["1.167.41", "1.167.38"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-router-ssr-query-core",
+      "name": "@tanstack/router-ssr-query-core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/router-ssr-query-core",
+      "versions": ["1.168.6", "1.168.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-router-utils",
+      "name": "@tanstack/router-utils (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/router-utils",
+      "versions": ["1.161.14", "1.161.11"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-router-vite-plugin",
+      "name": "@tanstack/router-vite-plugin (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/router-vite-plugin",
+      "versions": ["1.166.56", "1.166.53"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-solid-router",
+      "name": "@tanstack/solid-router (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/solid-router",
+      "versions": ["1.169.8", "1.169.5"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-solid-router-devtools",
+      "name": "@tanstack/solid-router-devtools (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/solid-router-devtools",
+      "versions": ["1.166.19", "1.166.16"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-solid-router-ssr-query",
+      "name": "@tanstack/solid-router-ssr-query (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/solid-router-ssr-query",
+      "versions": ["1.166.18", "1.166.15"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-solid-start",
+      "name": "@tanstack/solid-start (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/solid-start",
+      "versions": ["1.167.68", "1.167.65"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-solid-start-client",
+      "name": "@tanstack/solid-start-client (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/solid-start-client",
+      "versions": ["1.166.53", "1.166.50"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-solid-start-server",
+      "name": "@tanstack/solid-start-server (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/solid-start-server",
+      "versions": ["1.166.57", "1.166.54"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-start-client-core",
+      "name": "@tanstack/start-client-core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/start-client-core",
+      "versions": ["1.168.8", "1.168.5"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-start-fn-stubs",
+      "name": "@tanstack/start-fn-stubs (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/start-fn-stubs",
+      "versions": ["1.161.12", "1.161.9"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-start-plugin-core",
+      "name": "@tanstack/start-plugin-core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/start-plugin-core",
+      "versions": ["1.169.26", "1.169.23"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-start-server-core",
+      "name": "@tanstack/start-server-core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/start-server-core",
+      "versions": ["1.167.36", "1.167.33"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-start-static-server-functions",
+      "name": "@tanstack/start-static-server-functions (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/start-static-server-functions",
+      "versions": ["1.166.47", "1.166.44"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-start-storage-context",
+      "name": "@tanstack/start-storage-context (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/start-storage-context",
+      "versions": ["1.166.41", "1.166.38"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-valibot-adapter",
+      "name": "@tanstack/valibot-adapter (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/valibot-adapter",
+      "versions": ["1.166.15", "1.166.12"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-virtual-file-routes",
+      "name": "@tanstack/virtual-file-routes (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/virtual-file-routes",
+      "versions": ["1.161.13", "1.161.10"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-vue-router",
+      "name": "@tanstack/vue-router (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/vue-router",
+      "versions": ["1.169.8", "1.169.5"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-vue-router-devtools",
+      "name": "@tanstack/vue-router-devtools (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/vue-router-devtools",
+      "versions": ["1.166.19", "1.166.16"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-vue-router-ssr-query",
+      "name": "@tanstack/vue-router-ssr-query (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/vue-router-ssr-query",
+      "versions": ["1.166.18", "1.166.15"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-vue-start",
+      "name": "@tanstack/vue-start (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/vue-start",
+      "versions": ["1.167.64", "1.167.61"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-vue-start-client",
+      "name": "@tanstack/vue-start-client (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/vue-start-client",
+      "versions": ["1.166.49", "1.166.46"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-vue-start-server",
+      "name": "@tanstack/vue-start-server (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/vue-start-server",
+      "versions": ["1.166.53", "1.166.50"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tanstack-zod-adapter",
+      "name": "@tanstack/zod-adapter (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tanstack/zod-adapter",
+      "versions": ["1.166.15", "1.166.12"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-taskflow-corp-cli",
+      "name": "@taskflow-corp/cli (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@taskflow-corp/cli",
+      "versions": ["0.1.29", "0.1.28", "0.1.27", "0.1.26", "0.1.25", "0.1.24"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-tolka-cli",
+      "name": "@tolka/cli (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@tolka/cli",
+      "versions": ["1.0.5", "1.0.6", "1.0.4", "1.0.3", "1.0.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-access-policy-sdk",
+      "name": "@uipath/access-policy-sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/access-policy-sdk",
+      "versions": ["0.3.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-access-policy-tool",
+      "name": "@uipath/access-policy-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/access-policy-tool",
+      "versions": ["0.3.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-admin-tool",
+      "name": "@uipath/admin-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/admin-tool",
+      "versions": ["0.1.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-agent-sdk",
+      "name": "@uipath/agent-sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/agent-sdk",
+      "versions": ["1.0.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-agent-tool",
+      "name": "@uipath/agent-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/agent-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-agent.sdk",
+      "name": "@uipath/agent.sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/agent.sdk",
+      "versions": ["0.0.18"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-aops-policy-tool",
+      "name": "@uipath/aops-policy-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/aops-policy-tool",
+      "versions": ["0.3.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-ap-chat",
+      "name": "@uipath/ap-chat (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/ap-chat",
+      "versions": ["1.5.7"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-api-workflow-tool",
+      "name": "@uipath/api-workflow-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/api-workflow-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-apollo-core",
+      "name": "@uipath/apollo-core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/apollo-core",
+      "versions": ["5.9.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-apollo-react",
+      "name": "@uipath/apollo-react (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/apollo-react",
+      "versions": ["4.24.5"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-apollo-wind",
+      "name": "@uipath/apollo-wind (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/apollo-wind",
+      "versions": ["2.16.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-auth",
+      "name": "@uipath/auth (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/auth",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-case-tool",
+      "name": "@uipath/case-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/case-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-cli",
+      "name": "@uipath/cli (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/cli",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-codedagent-tool",
+      "name": "@uipath/codedagent-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/codedagent-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-codedagents-tool",
+      "name": "@uipath/codedagents-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/codedagents-tool",
+      "versions": ["0.1.12"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-codedapp-tool",
+      "name": "@uipath/codedapp-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/codedapp-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-common",
+      "name": "@uipath/common (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/common",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-context-grounding-tool",
+      "name": "@uipath/context-grounding-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/context-grounding-tool",
+      "versions": ["0.1.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-data-fabric-tool",
+      "name": "@uipath/data-fabric-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/data-fabric-tool",
+      "versions": ["1.0.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-docsai-tool",
+      "name": "@uipath/docsai-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/docsai-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-filesystem",
+      "name": "@uipath/filesystem (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/filesystem",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-flow-tool",
+      "name": "@uipath/flow-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/flow-tool",
+      "versions": ["1.0.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-functions-tool",
+      "name": "@uipath/functions-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/functions-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-gov-tool",
+      "name": "@uipath/gov-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/gov-tool",
+      "versions": ["0.3.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-identity-tool",
+      "name": "@uipath/identity-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/identity-tool",
+      "versions": ["0.1.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-insights-sdk",
+      "name": "@uipath/insights-sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/insights-sdk",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-insights-tool",
+      "name": "@uipath/insights-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/insights-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-integrationservice-sdk",
+      "name": "@uipath/integrationservice-sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/integrationservice-sdk",
+      "versions": ["1.0.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-integrationservice-tool",
+      "name": "@uipath/integrationservice-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/integrationservice-tool",
+      "versions": ["1.0.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-llmgw-tool",
+      "name": "@uipath/llmgw-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/llmgw-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-maestro-sdk",
+      "name": "@uipath/maestro-sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/maestro-sdk",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-maestro-tool",
+      "name": "@uipath/maestro-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/maestro-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-orchestrator-tool",
+      "name": "@uipath/orchestrator-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/orchestrator-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-packager-tool-apiworkflow",
+      "name": "@uipath/packager-tool-apiworkflow (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/packager-tool-apiworkflow",
+      "versions": ["0.0.19"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-packager-tool-bpmn",
+      "name": "@uipath/packager-tool-bpmn (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/packager-tool-bpmn",
+      "versions": ["0.0.9"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-packager-tool-case",
+      "name": "@uipath/packager-tool-case (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/packager-tool-case",
+      "versions": ["0.0.9"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-packager-tool-connector",
+      "name": "@uipath/packager-tool-connector (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/packager-tool-connector",
+      "versions": ["0.0.19"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-packager-tool-flow",
+      "name": "@uipath/packager-tool-flow (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/packager-tool-flow",
+      "versions": ["0.0.19"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-packager-tool-functions",
+      "name": "@uipath/packager-tool-functions (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/packager-tool-functions",
+      "versions": ["0.1.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-packager-tool-webapp",
+      "name": "@uipath/packager-tool-webapp (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/packager-tool-webapp",
+      "versions": ["1.0.6"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-packager-tool-workflowcompiler",
+      "name": "@uipath/packager-tool-workflowcompiler (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/packager-tool-workflowcompiler",
+      "versions": ["0.0.16"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-packager-tool-workflowcompiler-browser",
+      "name": "@uipath/packager-tool-workflowcompiler-browser (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/packager-tool-workflowcompiler-browser",
+      "versions": ["0.0.34"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-platform-tool",
+      "name": "@uipath/platform-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/platform-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-project-packager",
+      "name": "@uipath/project-packager (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/project-packager",
+      "versions": ["1.1.16"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-resource-tool",
+      "name": "@uipath/resource-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/resource-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-resourcecatalog-tool",
+      "name": "@uipath/resourcecatalog-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/resourcecatalog-tool",
+      "versions": ["0.1.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-resources-tool",
+      "name": "@uipath/resources-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/resources-tool",
+      "versions": ["0.1.11"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-robot",
+      "name": "@uipath/robot (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/robot",
+      "versions": ["1.3.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-rpa-legacy-tool",
+      "name": "@uipath/rpa-legacy-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/rpa-legacy-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-rpa-tool",
+      "name": "@uipath/rpa-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/rpa-tool",
+      "versions": ["0.9.5"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-solution-packager",
+      "name": "@uipath/solution-packager (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/solution-packager",
+      "versions": ["0.0.35"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-solution-tool",
+      "name": "@uipath/solution-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/solution-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-solutionpackager-sdk",
+      "name": "@uipath/solutionpackager-sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/solutionpackager-sdk",
+      "versions": ["1.0.11"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-solutionpackager-tool-core",
+      "name": "@uipath/solutionpackager-tool-core (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/solutionpackager-tool-core",
+      "versions": ["0.0.34"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-tasks-tool",
+      "name": "@uipath/tasks-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/tasks-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-telemetry",
+      "name": "@uipath/telemetry (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/telemetry",
+      "versions": ["0.0.7"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-test-manager-tool",
+      "name": "@uipath/test-manager-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/test-manager-tool",
+      "versions": ["1.0.2"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-tool-workflowcompiler",
+      "name": "@uipath/tool-workflowcompiler (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/tool-workflowcompiler",
+      "versions": ["0.0.12"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-traces-tool",
+      "name": "@uipath/traces-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/traces-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-ui-widgets-multi-file-upload",
+      "name": "@uipath/ui-widgets-multi-file-upload (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/ui-widgets-multi-file-upload",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-uipath-python-bridge",
+      "name": "@uipath/uipath-python-bridge (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/uipath-python-bridge",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-vertical-solutions-tool",
+      "name": "@uipath/vertical-solutions-tool (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/vertical-solutions-tool",
+      "versions": ["1.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-vss",
+      "name": "@uipath/vss (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/vss",
+      "versions": ["0.1.6"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-uipath-widget.sdk",
+      "name": "@uipath/widget.sdk (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "@uipath/widget.sdk",
+      "versions": ["1.2.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-agentwork-cli",
+      "name": "agentwork-cli (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "agentwork-cli",
+      "versions": ["0.1.4", "0.1.5"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-cmux-agent-mcp",
+      "name": "cmux-agent-mcp (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "cmux-agent-mcp",
+      "versions": ["0.1.8", "0.1.7", "0.1.6", "0.1.5", "0.1.4", "0.1.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-cross-stitch",
+      "name": "cross-stitch (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "cross-stitch",
+      "versions": ["1.1.7", "1.1.5", "1.1.6", "1.1.4", "1.1.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-git-branch-selector",
+      "name": "git-branch-selector (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "git-branch-selector",
+      "versions": ["1.3.7", "1.3.6", "1.3.5", "1.3.4", "1.3.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-git-git-git",
+      "name": "git-git-git (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "git-git-git",
+      "versions": ["1.0.12", "1.0.11", "1.0.10", "1.0.9", "1.0.8"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-pypi-guardrails-ai",
+      "name": "guardrails-ai (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "pypi",
+      "package": "guardrails-ai",
+      "versions": ["0.10.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-pypi-mistralai",
+      "name": "mistralai (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "pypi",
+      "package": "mistralai",
+      "versions": ["2.4.6"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-ml-toolkit-ts",
+      "name": "ml-toolkit-ts (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "ml-toolkit-ts",
+      "versions": ["1.0.5", "1.0.4"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-nextmove-mcp",
+      "name": "nextmove-mcp (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "nextmove-mcp",
+      "versions": ["0.1.7", "0.1.6", "0.1.5", "0.1.4", "0.1.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-safe-action",
+      "name": "safe-action (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "safe-action",
+      "versions": ["0.8.4", "0.8.3"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-ts-dna",
+      "name": "ts-dna (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "ts-dna",
+      "versions": ["3.0.5", "3.0.4", "3.0.3", "3.0.2", "3.0.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    },
+    {
+      "id": "mini-shai-hulud-2026-npm-wot-api",
+      "name": "wot-api (Mini/Shai-Hulud May 2026 compromised)",
+      "ecosystem": "npm",
+      "package": "wot-api",
+      "versions": ["0.8.3", "0.8.4", "0.8.2", "0.8.1"],
+      "severity": "critical",
+      "source": "OX Security affected package table; corroborate high-impact entries with Fleet, Socket, Snyk, Mistral, TanStack, and The Hacker News reporting"
+    }
+  ]
+}

--- a/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/node-ipc-credential-stealer.json
+++ b/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/node-ipc-credential-stealer.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "0.1.0",
+  "_comment": "Malicious node-ipc npm releases published as part of the 2026-05 credential stealer compromise reported by Socket. The malicious CJS entrypoint runs on require(), forks a detached child process with __ntw=1, collects env and local secrets, and exfiltrates via DNS TXT to bt.node.js after a TLS bootstrap to sh.azurestaticprovider.net:443 (resolved 37.16.75.69). Entries cover the seven malicious versions called out by the report: Socket only publishes file/tarball hashes for the 9.1.6, 9.2.3, and 12.0.1 releases plus the shared malicious CJS payload; hashes for the historical 10.1.1, 10.1.2, 11.0.0, and 11.1.0 versions are not published in the source post and have not been invented here. Network/file IOCs are noted for analyst context; the scanner itself does exact (ecosystem, name, version) matching only.",
+  "entries": [
+    {
+      "id": "socket-2026-05-14-npm-node-ipc-credential-stealer",
+      "name": "node-ipc (May 2026 credential stealer compromise)",
+      "ecosystem": "npm",
+      "package": "node-ipc",
+      "versions": [
+        "9.1.6",
+        "9.2.3",
+        "10.1.1",
+        "10.1.2",
+        "11.0.0",
+        "11.1.0",
+        "12.0.1"
+      ],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/node-ipc-package-compromised",
+      "indicators": {
+        "node_ipc_cjs_sha256": "96097e0612d9575cb133021017fb1a5c68a03b60f9f3d24ebdc0e628d9034144",
+        "node_ipc_9_1_6_tgz_sha256": "449e4265979b5fdb2d3446c021af437e815debd66de7da2fe54f1ad93cbcc75e",
+        "node_ipc_9_2_3_tgz_sha256": "c2f4dc64aec4631540a568e88932b61daebbfb7e8281b812fa01b7215f9be9ea",
+        "node_ipc_12_0_1_tar_gz_sha256": "78a82d93b4f580835f5823b85a3d9ee1f03a15ee6f0e01b4eac86252a7002981",
+        "node_ipc_10_1_1_hashes": "not published by Socket",
+        "node_ipc_10_1_2_hashes": "not published by Socket",
+        "node_ipc_11_0_0_hashes": "not published by Socket",
+        "node_ipc_11_1_0_hashes": "not published by Socket",
+        "c2_tls_bootstrap": "sh.azurestaticprovider.net:443",
+        "c2_tls_bootstrap_ip": "37.16.75.69",
+        "c2_dns_exfil": "bt.node.js",
+        "process_marker": "__ntw=1"
+      }
+    }
+  ]
+}

--- a/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/nx-console-vscode-2026-05-18.json
+++ b/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/nx-console-vscode-2026-05-18.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "0.1.0",
+  "_comment": "Compromised Nx Console VS Code extension (nrwl.angular-console v18.95.0) published to the Visual Studio Code Marketplace on 2026-05-18 12:36 UTC and removed at 2026-05-18 12:47 UTC. The malicious VSIX ships an obfuscated main.js whose Efn(td) function runs on workspace activation, registers a VS Code task 'install-mcp-extension' that invokes `npx -y github:nrwl/nx#558b09d7`, and pulls a credential stealer / persistence chain (Vault, npm, AWS IMDS/ECS/Secrets Manager/SSM, GitHub tokens, SSH/GCP/Docker/Claude Code config, 1Password; macOS LaunchAgent Python backdoor at ~/Library/LaunchAgents/com.user.kitty-monitor.plist and ~/.local/share/kitty/cat.py; possible Linux sudoers injection; Sigstore/Fulcio/SLSA provenance abuse). OpenVSX was not affected. Remediated in 18.100.0+. Bumblebee matches only exact (ecosystem, name, version); behavioral/network/file IOCs below are noted for analyst context and are not consumed by the scanner. Ecosystem value is the existing 'editor-extension' family (model.EcosystemEditorExtension) emitted for VS Code, Cursor, Windsurf, and VSCodium installs; the scanner's normalized name is <publisher>.<name> lowercased, so 'nrwl.angular-console' matches both VS Code Marketplace and VSCodium-style installs on disk.",
+  "_indicators": {
+    "source": "https://www.stepsecurity.io/blog/nx-console-vs-code-extension-compromised",
+    "corroborating_source": "The Hacker News (version 18.95.0, OpenVSX unaffected, removed after 11 minutes, update to 18.100.0+, persistence artifacts)",
+    "marketplace": "Visual Studio Code Marketplace (microsoft.com/vscode marketplace); OpenVSX not affected",
+    "exposure_window_published_utc": "2026-05-18T12:36:00Z",
+    "exposure_window_removed_utc": "2026-05-18T12:47:00Z",
+    "attacker_orphan_commit_pushed_utc": "2026-05-18T03:18:00Z",
+    "malicious_orphan_commit_sha": "558b09d7ad0d1660e2a0fb8a06da81a6f42e06d2",
+    "malicious_orphan_commit_short": "558b09d7",
+    "malicious_commit_tree_sha": "ba642fe2c7c65e42dd7f6444b83023dc6827e08c",
+    "malicious_index_js_blob_sha": "acfc3f957a63b4cde93ff645f2b6bf26a8ed1bbf",
+    "malicious_package_json_blob_sha": "9d88f040c44b5f4d5f9db15ff89310776c168e99",
+    "remediated_versions": ">= 18.100.0",
+    "clean_previous_version": "18.94.0",
+    "trigger": "injected main.js function Efn(td) runs on workspace activation and launches VS Code task 'install-mcp-extension' to execute `npx -y github:nrwl/nx#558b09d7`",
+    "persistence_files": [
+      "~/.local/share/kitty/cat.py",
+      "~/Library/LaunchAgents/com.user.kitty-monitor.plist",
+      "/tmp/kitty-*",
+      "/var/tmp/.gh_update_state"
+    ],
+    "persistence_env_var": "__DAEMONIZED=1",
+    "vscode_global_state_key": "nxConsole.mcpExtensionInstalledSha",
+    "vscode_global_state_value": "558b09d7ad0d1660e2a0fb8a06da81a6f42e06d2",
+    "network_indicators": [
+      "api.github.com/search/commits?q=firedalazer",
+      "169.254.169.254",
+      "169.254.170.2",
+      "127.0.0.1:8200",
+      "fulcio.sigstore.dev",
+      "rekor.sigstore.dev",
+      "bun.sh/install",
+      "github:nrwl/nx#558b09d7"
+    ],
+    "c2_domain_caveat": "specific encrypted C2 domain was not statically recoverable",
+    "capabilities": "credential stealer targeting Vault, npm, AWS IMDS/ECS/Secrets Manager/SSM, GitHub tokens/Actions secrets, SSH/GCP/Docker/Claude Code config, 1Password; exfil via HTTPS / GitHub API / DNS tunneling; macOS LaunchAgent Python backdoor; possible Linux sudoers injection; Sigstore/Fulcio/SLSA provenance abuse"
+  },
+  "entries": [
+    {
+      "id": "stepsecurity-2026-05-18-vscode-nrwl-angular-console-compromised",
+      "name": "nrwl.angular-console (Nx Console VS Code extension 2026-05-18 compromise)",
+      "ecosystem": "editor-extension",
+      "package": "nrwl.angular-console",
+      "versions": ["18.95.0"],
+      "severity": "critical",
+      "source": "https://www.stepsecurity.io/blog/nx-console-vs-code-extension-compromised",
+      "indicators": {
+        "marketplace": "Visual Studio Code Marketplace (OpenVSX not affected)",
+        "malicious_vsix_v18_95_0_sha256": "1a4afce34918bdc74ae3f31edaffffaa0ee074d83618f53edfd88137927340b8",
+        "malicious_main_js_sha256": "b0cefb66b953e5184b6adb3035e9e267335ac5eabfe1848e07834777b9397b74",
+        "obfuscated_payload_index_js_sha256": "e7347d90653efc565f03733a95e9209d78f9cfa81e31ff2b2dd9d48d75a4b8b1",
+        "dropper_package_json_sha256": "43f2b001846c4966073ebffa5be8f15e491a1e7d32bbd805d57406ff540e0dd9",
+        "clean_vsix_v18_94_0_sha256": "228a2cf081d4cbea9b91cde14a8f9c4a4d003e7f32431496953fd6bac266f5a3",
+        "remediated_vsix_v18_100_0_sha256": "cb86f4f223daa54467c7782a0d8607e9c84e2bb633e6f0e51d9a19579e200990",
+        "malicious_orphan_commit_sha": "558b09d7ad0d1660e2a0fb8a06da81a6f42e06d2",
+        "malicious_orphan_commit_short": "558b09d7",
+        "malicious_commit_tree_sha": "ba642fe2c7c65e42dd7f6444b83023dc6827e08c",
+        "malicious_index_js_blob_sha": "acfc3f957a63b4cde93ff645f2b6bf26a8ed1bbf",
+        "malicious_package_json_blob_sha": "9d88f040c44b5f4d5f9db15ff89310776c168e99",
+        "exposure_window_published_utc": "2026-05-18T12:36:00Z",
+        "exposure_window_removed_utc": "2026-05-18T12:47:00Z",
+        "attacker_orphan_commit_pushed_utc": "2026-05-18T03:18:00Z",
+        "trigger": "main.js Efn(td) on workspace activation -> VS Code task 'install-mcp-extension' runs `npx -y github:nrwl/nx#558b09d7`",
+        "persistence_files": [
+          "~/.local/share/kitty/cat.py",
+          "~/Library/LaunchAgents/com.user.kitty-monitor.plist",
+          "/tmp/kitty-*",
+          "/var/tmp/.gh_update_state"
+        ],
+        "persistence_env_var": "__DAEMONIZED=1",
+        "vscode_global_state_key": "nxConsole.mcpExtensionInstalledSha",
+        "vscode_global_state_value": "558b09d7ad0d1660e2a0fb8a06da81a6f42e06d2",
+        "network_indicators": [
+          "api.github.com/search/commits?q=firedalazer",
+          "169.254.169.254",
+          "169.254.170.2",
+          "127.0.0.1:8200",
+          "fulcio.sigstore.dev",
+          "rekor.sigstore.dev",
+          "bun.sh/install",
+          "github:nrwl/nx#558b09d7"
+        ],
+        "c2_domain_caveat": "specific encrypted C2 domain was not statically recoverable",
+        "capabilities": "credential stealer (Vault, npm, AWS IMDS/ECS/Secrets Manager/SSM, GitHub tokens/Actions secrets, SSH/GCP/Docker/Claude Code config, 1Password); exfil via HTTPS / GitHub API / DNS tunneling; macOS LaunchAgent Python backdoor; possible Linux sudoers injection; Sigstore/Fulcio/SLSA provenance abuse",
+        "remediated_versions": ">= 18.100.0",
+        "clean_previous_version": "18.94.0"
+      }
+    }
+  ]
+}

--- a/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/shopsprint-decimal-typosquat.json
+++ b/seed-scheduled-tasks/bumblebee-hygiene-scan/threat-intel/shopsprint-decimal-typosquat.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "0.1.0",
+  "_comment": "Go module github.com/shopsprint/decimal v1.3.3, a long-running typosquat of github.com/shopspring/decimal. The v1.3.3 release adds an init() DNS TXT C2 polling dnslog-cdn-images.freemyip.com every five minutes and executes returned TXT values with os/exec.Command. Indicators sourced from Socket's 2026-05-19 report. Network/file IOCs (C2 domain, commit hash, file/tarball hashes) are noted for analyst context; the scanner itself does exact (ecosystem, name, version) matching only.",
+  "entries": [
+    {
+      "id": "socket-2026-05-19-go-shopsprint-decimal-typosquat",
+      "name": "github.com/shopsprint/decimal v1.3.3 (typosquat DNS backdoor)",
+      "ecosystem": "go",
+      "package": "github.com/shopsprint/decimal",
+      "versions": ["v1.3.3"],
+      "severity": "critical",
+      "source": "https://socket.dev/blog/popular-go-decimal-library-typosquat-dns-backdoor",
+      "indicators": {
+        "commit_sha": "2f0ee073c6f29d66188a845592029c9b52528f04",
+        "module_zip_sha256": "dd9c0268c8944e6ddf90d4d0c81aa843785b7a9ee965faa635841ed9fc0ba086",
+        "decimal_go_sha256": "387d7ea5ca733b1e7219c943f4b461877a8df0148adfef42b1538b6c398fbb41",
+        "decimal_go_sha1": "fd26f4ca4746ee390e22043a5e19ebf2b7fcd1f9",
+        "decimal_go_md5": "e3c6ce0440d9acd0f1cef1f0da3cdb5d",
+        "c2_dns": "dnslog-cdn-images.freemyip.com"
+      }
+    }
+  ]
+}

--- a/update.sh
+++ b/update.sh
@@ -273,6 +273,15 @@ if [ -d "$SEED_SCHED_DIR" ]; then
         echo '{"last_audit_at":null}' > "$STATE_FILE"
       fi
     fi
+
+    # Seed bumblebee threat-intel catalogs into ~/.claude/tools/
+    BB_SEED_TI="$SEED_SCHED_DIR/bumblebee-hygiene-scan/threat-intel"
+    BB_TARGET_TI="$HOME/.claude/tools/bumblebee-threat-intel"
+    if [ -d "$BB_SEED_TI" ] && [ ! -d "$BB_TARGET_TI" ]; then
+      mkdir -p "$BB_TARGET_TI"
+      cp "$BB_SEED_TI"/*.json "$BB_TARGET_TI/" 2>/dev/null
+      echo -e "  ${GREEN}✓${NC} Bumblebee threat-intel katalógusok telepítve"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Weekly Monday 09:00 supply-chain hygiene scan using Perplexity Bumblebee (Apache 2.0, v0.1.1)
- 6 vendored threat-intel catalogs for offline bootstrap (monthly upstream refresh)
- Graceful skip if bumblebee binary not available (no Go on machine)
- install.sh + install-linux.sh + update.sh updated to seed threat-intel catalogs into ~/.claude/tools/

## Details
- Sanitized SKILL.md: no PII, no hardcoded chat_id, uses `{{MAIN_AGENT_ID}}` and `{{INSTALL_DIR}}` placeholders
- task-config.json: cron `0 9 * * 1`, heartbeat type, skipIfBusy
- Threat-intel catalogs seed idempotently (skip if ~/.claude/tools/bumblebee-threat-intel/ already exists)
- Telegram alert ONLY on findings > 0, otherwise silent heartbeat

## Test plan
- [ ] Fresh install: verify bumblebee task appears in ~/.claude/scheduled-tasks/
- [ ] Fresh install: verify threat-intel catalogs copied to ~/.claude/tools/bumblebee-threat-intel/
- [ ] Update on existing install: verify task seeded if missing, skipped if present
- [ ] Run scan manually: verify graceful skip when binary missing
- [ ] Run scan with binary: verify 0 findings = no Telegram

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>