### PR TITLE
feat(security): add content sanitization to memory POST endpoint

### DIFF
--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -13,6 +13,27 @@ import type { RouteContext } from './types.js'
 // src/db.ts so the API rejects bad values before they even reach SQLite.
 const MEMORY_CATEGORIES = new Set(['hot', 'warm', 'cold', 'shared'])
 
+const SUSPICIOUS_PATTERNS = [
+  /\bcurl\s+(-[a-zA-Z]\s+)*https?:\/\//i,
+  /\bbash\s+-c\b/i,
+  /\beval\b/i,
+  /\bexec\s*\(/i,
+  /\bimport\s+subprocess\b/i,
+  /ignore\s+previous\s+instructions/i,
+  /override\s+your/i,
+  /forget\s+your/i,
+  /new\s+persona/i,
+  /\brm\s+-rf\b/i,
+]
+
+function containsSuspiciousContent(content: string): string | null {
+  for (const pattern of SUSPICIOUS_PATTERNS) {
+    const match = content.match(pattern)
+    if (match) return match[0]
+  }
+  return null
+}
+
 export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method, url } = ctx
 
@@ -20,6 +41,12 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
     const body = await readBody(req)
     const data = JSON.parse(body.toString()) as { agent_id?: string; content: string; tier?: string; category?: string; keywords?: string }
     if (!data.content?.trim()) { json(res, { error: 'Content is required' }, 400); return true }
+    const suspicious = containsSuspiciousContent(data.content)
+    if (suspicious) {
+      logger.warn({ agent: data.agent_id, match: suspicious }, 'Memory content rejected: suspicious pattern')
+      json(res, { error: `Content contains suspicious pattern: "${suspicious}"` }, 400)
+      return true
+    }
     if (data.tier && !data.category) {
       logger.warn({ agent: data.agent_id }, '[DEPRECATED] /api/memories: use "category" instead of "tier"')
     }

--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -16,22 +16,18 @@ const MEMORY_CATEGORIES = new Set(['hot', 'warm', 'cold', 'shared'])
 const SUSPICIOUS_PATTERNS = [
   /\bcurl\s+(-[a-zA-Z]\s+)*https?:\/\//i,
   /\bbash\s+-c\b/i,
-  /\beval\b/i,
+  /\beval\s*\(/i,
   /\bexec\s*\(/i,
   /\bimport\s+subprocess\b/i,
-  /ignore\s+previous\s+instructions/i,
-  /override\s+your/i,
-  /forget\s+your/i,
+  /ignore\s+(all\s+)?previous\s+instructions/i,
+  /override\s+your\s+(instructions|rules|safety|guidelines)/i,
+  /forget\s+your\s+(instructions|rules|safety|guidelines|training)/i,
   /new\s+persona/i,
   /\brm\s+-rf\b/i,
 ]
 
-function containsSuspiciousContent(content: string): string | null {
-  for (const pattern of SUSPICIOUS_PATTERNS) {
-    const match = content.match(pattern)
-    if (match) return match[0]
-  }
-  return null
+function containsSuspiciousContent(content: string): boolean {
+  return SUSPICIOUS_PATTERNS.some((pattern) => pattern.test(content))
 }
 
 export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
@@ -41,10 +37,9 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
     const body = await readBody(req)
     const data = JSON.parse(body.toString()) as { agent_id?: string; content: string; tier?: string; category?: string; keywords?: string }
     if (!data.content?.trim()) { json(res, { error: 'Content is required' }, 400); return true }
-    const suspicious = containsSuspiciousContent(data.content)
-    if (suspicious) {
-      logger.warn({ agent: data.agent_id, match: suspicious }, 'Memory content rejected: suspicious pattern')
-      json(res, { error: `Content contains suspicious pattern: "${suspicious}"` }, 400)
+    if (containsSuspiciousContent(data.content)) {
+      logger.warn({ agent: data.agent_id }, 'Memory content rejected: suspicious pattern')
+      json(res, { error: 'Content rejected by security filter' }, 400)
       return true
     }
     if (data.tier && !data.category) {


### PR DESCRIPTION
## Summary
Replaces #140 with tightened patterns and security fixes.

- Adds pattern-based content filtering to POST /api/memories to block prompt-injection attempts
- 10 regex patterns detect shell commands, code injection, and instruction-override phrases
- Returns HTTP 400 on match, logs via pino

## Changes vs original #140
- `\beval\b` -> `\beval\s*\(` (no more false positives on "evaluation")
- `override your` / `forget your` now require specific noun (instructions, rules, safety, guidelines)
- Error response no longer reveals matched pattern (prevents attacker enumeration)
- Simplified helper to return boolean

## Test plan
- [ ] Normal memory writes still work
- [ ] "evaluation of results" content passes (was blocked before)
- [ ] "ignore previous instructions" content returns 400
- [ ] "bash -c 'rm -rf /'" content returns 400
- [ ] Error message says "Content rejected by security filter" (no pattern leak)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>