### PR TITLE
feat: add MIT LICENSE and package.json license field

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Szotasz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "claudeclaw",
   "version": "1.0.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Szia!

**TL;DR**: A repo-nak nincs `LICENSE` fájlja, ami jogilag problémás. Ez a PR MIT licencet ad hozzá, konzisztensen az ökoszisztéma többi tagjával.

### A probléma

GitHub és a legtöbb jogrendszer alapértelmezetten „[minden jog fenntartva](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository)" álláspontot ad licencfájl hiányában. Konkrétan:

- A **11 fork** technikailag jogszerűtlen állapotban van — a GitHub ToS minimális használatot enged a platformon belül, de tényleges build/run/redistribute jogot nem.
- Senki nem építhet rá legálisan saját projektben (még egy függvényt sem vehet át).
- Az `install.sh`-val telepítők szigorúan véve szürke zónában vannak.
- Cégeknél a legal/compliance review automatikusan elutasít minden no-license repo-t.

Ez ellentmond annak, amit a README és a Donably-támogatás sugall (nyilvános open-source projekt, közösségi használatra szánva).

### Az ökoszisztéma kontextus

A „ClaudeClaw" családfa többi tagja konzekvensen MIT-et használ — érdemes ezzel konzisztensnek lenni:

| Projekt | Licenc |
|---------|--------|
| [openclaw/openclaw](https://github.com/openclaw/openclaw) | MIT |
| [gavrielc/nanoclaw](https://github.com/gavrielc/nanoclaw) | MIT |
| [sbusso/claudeclaw](https://github.com/sbusso/claudeclaw) | MIT (explicit „Built on NanoClaw" attribution-nel) |
| [moazbuilds/claudeclaw](https://github.com/moazbuilds/claudeclaw) | MIT |
| [AlekseiUL/claudeclaw-BANDA](https://github.com/AlekseiUL/claudeclaw-BANDA) | MIT |
| **Szotasz/marveen** | **(hiányzik)** |

Ez a PR ezt orvosolja MIT licenccel. Ha más licenc lenne preferált (Apache-2.0, AGPL-3.0, BSL stb.), nyugodtan zárd le ezt a PR-t és cseréld a tartalmat — a `package.json` mező is megfelelően frissíthető.

### Apró észrevételek (nem ennek a PR-nak részei)

Ha már licenc-higiénián gondolkodsz, érdemes a következőket is megnézni alkalomadtán:

1. **A `package.json` belső neve még `"claudeclaw"`** (nem `marveen`), és néhány fájl is hivatkozik `claudeclaw.db` / `claudeclaw.pid` filenevekre (`src/db.ts:40`, `src/heartbeat.ts:62`, `src/index.ts:45`). A `src/web/schedule-runner.ts:84`-ben pedig van egy hardcoded `/Users/marvin/ClaudeClaw/HEARTBEAT.md` path is. Valószínűleg fejlesztés-kori maradványok.

2. **Külső projektekre hivatkozás attribution nélkül**: `src/channel-provider.ts` említi `jeremylongshore/claude-code-slack-channel`-t és `telegram@claude-plugins-official`-ot. Érdemes a README-ben is megemlíteni egy „Acknowledgments" szekcióban, hogy a felhasználók tudják, mire épül a projekt.

Ha bármelyik felvetésről külön issue jobban tetszene, szólj — szétválaszthatóak.

### Változások ebben a PR-ban

- Új `LICENSE` fájl (MIT, copyright: Szotasz)
- `package.json` kiegészítve `"license": "MIT"` mezővel

Köszi a munkát!
