### PR TITLE
fix: remove hardcoded paths, centralize config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claudeclaw",
+  "name": "marveen",
   "version": "1.0.0",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -22,7 +22,7 @@ import {
   markPendingTaskRetryAlert,
   clearPendingTaskRetryAlert,
 } from '../db.js'
-import { STORE_DIR } from '../config.js'
+import { STORE_DIR, DB_FILENAME } from '../config.js'
 
 beforeAll(() => {
   // Teszt adatbázis inicializálás
@@ -246,7 +246,7 @@ describe('database file permissions', () => {
   // simply retain whatever mode a previous test run left them at.
   beforeAll(async () => {
     const { chmodSync } = await import('node:fs')
-    const dbPath = join(STORE_DIR, 'claudeclaw.db')
+    const dbPath = join(STORE_DIR, DB_FILENAME)
     for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`, `${dbPath}-journal`]) {
       if (existsSync(p)) {
         try { chmodSync(p, 0o644) } catch { /* best effort */ }
@@ -256,28 +256,28 @@ describe('database file permissions', () => {
   })
 
   it('claudeclaw.db is tightened to owner-only (0o600) by initDatabase', () => {
-    const dbPath = join(STORE_DIR, 'claudeclaw.db')
+    const dbPath = join(STORE_DIR, DB_FILENAME)
     expect(existsSync(dbPath)).toBe(true)
     const mode = statSync(dbPath).mode & 0o777
     expect(mode).toBe(0o600)
   })
 
   it('WAL sidecar (when present) is tightened to 0o600', () => {
-    const walPath = join(STORE_DIR, 'claudeclaw.db-wal')
+    const walPath = join(STORE_DIR, `${DB_FILENAME}-wal`)
     if (!existsSync(walPath)) return // WAL may not exist on a freshly-initialised empty DB
     const mode = statSync(walPath).mode & 0o777
     expect(mode).toBe(0o600)
   })
 
   it('SHM sidecar (when present) is tightened to 0o600', () => {
-    const shmPath = join(STORE_DIR, 'claudeclaw.db-shm')
+    const shmPath = join(STORE_DIR, `${DB_FILENAME}-shm`)
     if (!existsSync(shmPath)) return
     const mode = statSync(shmPath).mode & 0o777
     expect(mode).toBe(0o600)
   })
 
   it('rollback-journal sidecar (when present) is tightened to 0o600', () => {
-    const journalPath = join(STORE_DIR, 'claudeclaw.db-journal')
+    const journalPath = join(STORE_DIR, `${DB_FILENAME}-journal`)
     if (!existsSync(journalPath)) return
     const mode = statSync(journalPath).mode & 0o777
     expect(mode).toBe(0o600)

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export const PROJECT_ROOT = join(__dirname, '..')
 export const STORE_DIR = join(PROJECT_ROOT, 'store')
+export const DB_FILENAME = 'claudeclaw.db'
+export const PID_FILENAME = 'claudeclaw.pid'
 
 const env = readEnvFile()
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3'
 import { join } from 'node:path'
 import { existsSync, mkdirSync, readFileSync, renameSync, chmodSync, openSync, closeSync } from 'node:fs'
-import { STORE_DIR, ALLOWED_CHAT_ID, OLLAMA_URL } from './config.js'
+import { STORE_DIR, DB_FILENAME, ALLOWED_CHAT_ID, OLLAMA_URL } from './config.js'
 import { logger } from './logger.js'
 
 let db: Database.Database
@@ -37,7 +37,7 @@ export function initDatabase(): void {
   if (db) {
     try { db.close() } catch { /* already closed */ }
   }
-  const dbPath = join(STORE_DIR, 'claudeclaw.db')
+  const dbPath = join(STORE_DIR, DB_FILENAME)
   // Step 1: close the TOCTOU window on fresh installs. openSync with 'wx'
   // + 0o600 creates the file ONLY if it doesn't exist and sets the strict
   // mode atomically. better-sqlite3 then opens the existing file rather

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -5,6 +5,7 @@ import {
   HEARTBEAT_END_HOUR,
   HEARTBEAT_CALENDAR_ID,
   STORE_DIR,
+  DB_FILENAME,
 } from './config.js'
 import { getHeartbeatKanbanSummary, getActiveScheduledTaskCount } from './db.js'
 import { getCalendarEvents, type CalendarEvent } from './google-api.js'
@@ -59,7 +60,7 @@ function collectKanban(): HeartbeatData['kanban'] {
 
 function collectSystem(): SystemInfo {
   try {
-    const dbPath = join(STORE_DIR, 'claudeclaw.db')
+    const dbPath = join(STORE_DIR, DB_FILENAME)
     const dbSize = statSync(dbPath).size / (1024 * 1024)
     return { dbSizeMB: Math.round(dbSize * 10) / 10, dbWarning: dbSize > 100 }
   } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
 import { join } from 'node:path'
 import { execFileSync, execSync } from 'node:child_process'
 import type { Server as HttpServer } from 'node:http'
-import { STORE_DIR, WEB_PORT, ALLOWED_CHAT_ID, MAIN_AGENT_ID } from './config.js'
+import { STORE_DIR, PID_FILENAME, WEB_PORT, ALLOWED_CHAT_ID, MAIN_AGENT_ID } from './config.js'
 import { initDatabase } from './db.js'
 import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
@@ -42,7 +42,7 @@ const BANNER = `
  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝  (lite)
 `
 
-const PID_FILE = join(STORE_DIR, 'claudeclaw.pid')
+const PID_FILE = join(STORE_DIR, PID_FILENAME)
 // Hard-kill timeout: if graceful shutdown (HTTP drain + releaseLock) has not
 // finished in this window, exit so launchd's KeepAlive isn't blocked by a
 // hung socket. closeAllConnections (Node 18.2+) normally drains in ms, but

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -81,7 +81,7 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
   try {
     let prefix: string
     if (task.type === 'heartbeat') {
-      prefix = `[Heartbeat: ${task.name}] *** KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ: hivj meg pontosan EGY local-only tool-t (peldaul Bash 'echo keepalive >> /tmp/marveen-keepalive.log' VAGY Read tool egy meglevo fajlra mint /Users/marvin/ClaudeClaw/HEARTBEAT.md). NE Telegram-tool-t -- az zajt eredmenyezne. Ezt a Telegram-bun MCP-stdio-pipe keep-alive-ehez kell, ha kihagyod, a Telegram-conn 30 percen belul disconnect-el. *** Aztan: ez egy csendes ellenorzes. CSAK AKKOR irj Telegramon (chat_id: ${ALLOWED_CHAT_ID}), ha tenyleg fontos/surgos dolgot talalsz. Ha minden rendben, NE kuldj Telegram uzenetet -- a kotelezo no-op tool-call mar megfelelo aktivitas. Egy rovid 'csendes heartbeat' sor a transzkriptbe + a tool-call elég. `
+      prefix = `[Heartbeat: ${task.name}] *** KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ: hivj meg pontosan EGY local-only tool-t (peldaul Bash 'echo keepalive >> /tmp/marveen-keepalive.log' VAGY Read tool egy meglevo fajlra mint ${join(PROJECT_ROOT, 'HEARTBEAT.md')}). NE Telegram-tool-t -- az zajt eredmenyezne. Ezt a Telegram-bun MCP-stdio-pipe keep-alive-ehez kell, ha kihagyod, a Telegram-conn 30 percen belul disconnect-el. *** Aztan: ez egy csendes ellenorzes. CSAK AKKOR irj Telegramon (chat_id: ${ALLOWED_CHAT_ID}), ha tenyleg fontos/surgos dolgot talalsz. Ha minden rendben, NE kuldj Telegram uzenetet -- a kotelezo no-op tool-call mar megfelelo aktivitas. Egy rovid 'csendes heartbeat' sor a transzkriptbe + a tool-call elég. `
     } else {
       prefix = `[Utemezett feladat: ${task.name}] Az eredmenyt kuldd el Telegramon (chat_id: ${ALLOWED_CHAT_ID}, reply tool). `
     }


### PR DESCRIPTION
## Summary

- Centralized `claudeclaw.db` and `claudeclaw.pid` filenames into `config.ts` constants (`DB_FILENAME`, `PID_FILENAME`) -- single source of truth
- Replaced hardcoded `/Users/marvin/ClaudeClaw/HEARTBEAT.md` in `schedule-runner.ts` with dynamic `join(PROJECT_ROOT, 'HEARTBEAT.md')`
- Renamed `package.json` name from `claudeclaw` to `marveen`
- Updated tests to use the new constants

Follow-up from PR #142 observations.

## Test plan

- [x] TypeScript build passes (`tsc --noEmit`)
- [ ] Existing DB file at `store/claudeclaw.db` still works (no rename, just constant extraction)
- [ ] Heartbeat scheduled tasks use dynamic path

Generated with [Claude Code](https://claude.com/claude-code)