### PR TITLE
feat(scheduler): forceSend + targetSession to fix busy-retry loop

### DIFF
--- a/src/web/routes/schedules.ts
+++ b/src/web/routes/schedules.ts
@@ -110,7 +110,7 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
       throw err
     }
     const data = JSON.parse(body.toString()) as {
-      name: string; description: string; prompt: string; schedule: string; agent?: string; type?: string; skipIfBusy?: boolean
+      name: string; description: string; prompt: string; schedule: string; agent?: string; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string
     }
     const name = sanitizeScheduleName(data.name || '')
     if (!name) { json(res, { error: 'Name is required' }, 400); return true }
@@ -135,6 +135,8 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
       enabled: true,
       type: data.type || 'task',
       skipIfBusy: data.skipIfBusy === true,
+      forceSend: data.forceSend === true,
+      targetSession: data.targetSession || undefined,
     })
     logger.info({ name, schedule: data.schedule }, 'Scheduled task created')
     json(res, { ok: true, name })
@@ -158,7 +160,7 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
       throw err
     }
     const data = JSON.parse(body.toString()) as {
-      description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean
+      description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string
     }
     if (data.prompt !== undefined && data.prompt.length > MAX_SCHEDULED_TASK_PROMPT_LEN) {
       json(res, {

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -60,7 +60,11 @@ const scheduleLastRun: Map<string, number> = new Map()
 // pendingTaskRetries loop and the normal cron loop share one code path.
 function attemptFireTask(task: ScheduledTask, agentName: string, now: number): 'fired' | 'busy' | 'missing' | 'error' {
   const isMainAgent = agentName === MAIN_AGENT_ID
-  const session = isMainAgent ? MAIN_CHANNELS_SESSION : agentSessionName(agentName)
+  // Allow per-task session override via targetSession config field.
+  // Falls back to the standard agent session name derivation.
+  const session = task.targetSession
+    ? task.targetSession
+    : isMainAgent ? MAIN_CHANNELS_SESSION : agentSessionName(agentName)
 
   let sessionExists = false
   try {
@@ -73,9 +77,18 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
     return 'missing'
   }
 
-  if (!isSessionReadyForPrompt(session)) {
+  // When forceSend is true, skip the busy-state check entirely and inject
+  // the prompt regardless. The Claude session queues it internally and
+  // will process it at the next idle slot. This prevents the infinite
+  // retry loop observed when the target session stays busy for hours
+  // (275 retries overnight in production).
+  if (!task.forceSend && !isSessionReadyForPrompt(session)) {
     logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session busy or has pending input, will retry')
     return 'busy'
+  }
+
+  if (task.forceSend) {
+    logger.info({ task: task.name, agent: agentName, session }, 'forceSend=true, bypassing busy-state check')
   }
 
   try {

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -29,6 +29,17 @@ export interface ScheduledTask {
   // skipIfBusy false (default) so the queue + alert path catches a
   // long-running busy state and nothing business-critical is lost.
   skipIfBusy?: boolean
+  // When true, skip the busy-state check entirely and inject the prompt
+  // via tmux send-keys regardless. The Claude session will process it at
+  // the next idle slot. Useful for critical tasks that must never be
+  // deferred to a retry queue (e.g. daily briefings, heartbeats during
+  // active conversations).
+  forceSend?: boolean
+  // Override the default tmux session name derived from the agent. When
+  // set, the scheduler targets this exact tmux session instead of
+  // `agent-<name>` or MAIN_CHANNELS_SESSION. Enables dedicated
+  // scheduler-only sessions in the future.
+  targetSession?: string
 }
 
 function readFileOr(path: string, fallback: string): string {
@@ -58,7 +69,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const skillContent = readFileOr(skillPath, '')
   const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
@@ -73,6 +84,8 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
     createdAt: config.createdAt || 0,
     type: (config.type as 'task' | 'heartbeat') || 'task',
     skipIfBusy: config.skipIfBusy === true,
+    forceSend: config.forceSend === true,
+    targetSession: config.targetSession || undefined,
   }
 }
 
@@ -91,7 +104,7 @@ export function listScheduledTasks(): ScheduledTask[] {
 
 export function writeScheduledTask(
   taskName: string,
-  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean },
+  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string },
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
@@ -116,6 +129,8 @@ export function writeScheduledTask(
   if (data.enabled !== undefined) config.enabled = data.enabled
   if (data.type !== undefined) config.type = data.type
   if (data.skipIfBusy !== undefined) config.skipIfBusy = data.skipIfBusy
+  if (data.forceSend !== undefined) config.forceSend = data.forceSend
+  if (data.targetSession !== undefined) config.targetSession = data.targetSession
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }


### PR DESCRIPTION
## Summary

- **`forceSend`** (boolean, per-task): when true, skips the `isSessionReadyForPrompt` check and injects the prompt via tmux send-keys regardless of session state. The Claude session queues it internally and processes at the next idle slot. Fixes the infinite retry problem (275 retries observed overnight when the target session stayed busy).
- **`targetSession`** (string, per-task): overrides the default tmux session name derived from the agent. Enables routing scheduled tasks to a dedicated scheduler-only session in the future.

Both are orthogonal per-task options in `task-config.json`. Existing tasks are unaffected (both default to off/unset).

Refs kanban card 2D5B4E06.

## Changed files

- `src/web/scheduled-tasks-io.ts` -- extended `ScheduledTask` interface, read/write logic
- `src/web/schedule-runner.ts` -- `attemptFireTask` uses `forceSend` and `targetSession`
- `src/web/routes/schedules.ts` -- API accepts the new fields on POST/PUT

## Test plan

- [ ] Set `forceSend: true` on a task, verify it fires even when the session is busy (no retry row created)
- [ ] Set `targetSession: "custom-session"` on a task, verify the scheduler targets that tmux session
- [ ] Verify existing tasks without these fields behave identically (backward compat)
- [ ] `npx tsc --noEmit` passes clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>