### PR TITLE
feat(seed-skills): add retrospective and skill-management skills

### DIFF
--- a/seed-skills/retrospective/SKILL.md
+++ b/seed-skills/retrospective/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: retrospective
+description: Analyze the current session for improvement opportunities in skills, memory, and workflow. Spawns a sub-agent for unbiased analysis. Use when a session involved complex problem-solving, error recovery, user corrections, or multi-step workflows. Trigger on "/retrospective" command or at session end after significant work.
+---
+
+# Retrospective -- Session Analysis & Improvement
+
+## When to use
+
+- After a complex session (5+ tool calls, error recovery, multi-step workflow)
+- When the user corrected your approach ("no, do it this way")
+- After a failed attempt that required a different strategy
+- Before context window exhaustion on a productive session
+- Explicitly via `/retrospective` command
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `scope` | no | What to analyze: `session` (default), `last-task`, `last-hour` |
+| `focus` | no | Narrow analysis: `skills`, `memory`, `workflow`, or `all` (default) |
+
+Examples:
+- `/retrospective` -- full session analysis
+- `/retrospective scope=last-task focus=skills` -- only skill improvements for the last task
+- `/retrospective focus=memory` -- only memory tier/content suggestions
+
+## Procedure
+
+### 1. Gather session data
+
+Collect from the current conversation context:
+- What tasks were attempted
+- Which approaches succeeded vs failed
+- User corrections and their reasoning
+- Tools/skills used and their effectiveness
+- Errors encountered and how they were resolved
+- Time spent on dead ends vs productive work
+
+Also pull external state:
+
+```bash
+AGENT_ID="$(echo $BOT_NAME | tr '[:upper:]' '[:lower:]')"
+
+# Recent memories written this session
+curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  "http://localhost:3420/api/memories?agent=$AGENT_ID&category=hot&limit=20"
+
+# Today's daily log entries
+DATE=$(date +%Y-%m-%d)
+curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  "http://localhost:3420/api/daily-log?agent=$AGENT_ID&date=$DATE"
+
+# Skills that were referenced or used
+ls ~/.claude/skills/ | head -30
+```
+
+### 2. Analyze with A/B/C framework
+
+For each significant event in the session, evaluate:
+
+**A -- What happened?**
+State the fact: what was attempted, what was the outcome.
+
+**B -- Why did it happen that way?**
+Root cause: was it a missing skill, wrong memory tier, incorrect assumption, tooling gap, or communication issue?
+
+**C -- What should change?**
+Concrete action: new skill, skill patch, memory write/update, workflow change, or nothing (if the outcome was correct).
+
+### 3. Generate improvement proposals
+
+Organize findings into categories:
+
+#### Skill proposals
+For each skill-related finding:
+```
+SKILL_ACTION: create | patch | delete
+SKILL_NAME: name-of-skill
+REASON: why this change helps
+CHANGE: what specifically to add/modify/remove
+```
+
+Rules:
+- Only propose a NEW skill if the pattern appeared 2+ times or was complex enough (5+ steps)
+- Prefer PATCH over CREATE -- check if an existing skill covers 80% of the case
+- Check `~/.claude/skills/.skill-index.md` before proposing duplicates
+
+#### Memory proposals
+For each memory-related finding:
+```
+MEMORY_ACTION: save | update | delete | retier
+MEMORY_TIER: hot | warm | cold | shared
+CONTENT: what to remember
+REASON: why this tier, why now
+```
+
+Rules:
+- User corrections -> always save as warm (stable preference)
+- Task-specific findings -> hot (will decay naturally)
+- Architectural decisions -> cold (long-term reference)
+- Cross-agent learnings -> shared
+
+#### Workflow proposals
+For process improvements that don't fit skills or memory:
+```
+WORKFLOW_CHANGE: description of the process change
+APPLIES_TO: this agent | all agents | specific agent
+REASON: what problem it solves
+```
+
+### 4. Present to user for approval
+
+Format the output as a concise action list:
+
+```
+## Retrospective Summary
+
+Session: [brief description]
+Duration: ~[estimate]
+Key events: [count] tasks, [count] corrections, [count] errors
+
+### Proposed Changes
+
+#### Skills
+1. [PATCH] skill-name: add X because Y
+2. [CREATE] new-skill: handles Z pattern (seen 3x this session)
+
+#### Memory
+1. [SAVE warm] "user prefers X over Y" -- correction at [context]
+2. [RETIER hot->cold] "project Z deadline" -- no longer active
+
+#### Workflow
+1. [ALL AGENTS] Always check CI before merging -- 2 failed merges this session
+
+Apply all? (y/n/select)
+```
+
+### 5. Execute approved changes
+
+On user approval:
+- Skills: create/patch SKILL.md files, regenerate `.skill-index.md`
+- Memory: write/update via the memory API
+- Workflow: update CLAUDE.md or inter-agent message to affected agents
+
+After execution, log the retrospective to the daily log:
+```bash
+curl -s -X POST -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  http://localhost:3420/api/daily-log \
+  -H "Content-Type: application/json" \
+  -d "{\"agent_id\":\"$AGENT_ID\",\"content\":\"## $(date +%H:%M) -- Retrospective\n[count] skill changes, [count] memory updates, [count] workflow changes applied.\"}"
+```
+
+## Pitfalls
+
+- Do NOT auto-apply changes without user approval -- always present first
+- Do NOT create skills for one-off tasks that won't repeat
+- Do NOT save ephemeral debugging context as cold memory
+- If the session was straightforward with no issues, say so and skip -- not every session needs changes
+- Keep proposals actionable and specific -- "be better at X" is not a proposal
+
+## Relation to existing mechanisms
+
+| Mechanism | Retrospective's role |
+|-----------|---------------------|
+| memoria-heartbeat | Retrospective is the dedicated, deeper version. Heartbeat does inline A/B/C; retrospective does it thoroughly with user approval |
+| skill-factory | Retrospective proposes skills; skill-factory creates them. Retrospective may invoke skill-factory for CREATE actions |
+| DREAM.md | Nightly consolidation. Retrospective is on-demand, immediate |
+| /handoff | Retrospective analyzes; handoff transfers. Different purposes |

--- a/seed-skills/skill-management/SKILL.md
+++ b/seed-skills/skill-management/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: skill-management
+description: List, inspect, patch, or delete skills from ~/.claude/skills/. Use when the user asks about available skills, wants to modify an existing skill, or when a retrospective proposes skill changes. Trigger on "/skills" command or skill-related retrospective actions.
+---
+
+# Skill Management -- CRUD for the Skill Library
+
+## When to use
+
+- User asks "what skills do I have?" or "list skills"
+- User wants to inspect a specific skill's content
+- A `/retrospective` proposes CREATE, PATCH, or DELETE actions on skills
+- User says "update skill X" or "fix skill Y"
+- Periodic audit: check for stale or duplicate skills
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `action` | YES | One of: `list`, `show`, `create`, `patch`, `delete`, `audit` |
+| `name` | for show/patch/delete | Skill directory name (e.g. `github-pr-rebase-merge`) |
+| `scope` | no | `global` (default, ~/.claude/skills/) or `local` (./claude/skills/) |
+
+Examples:
+- `/skills action=list` -- list all skills with descriptions
+- `/skills action=show name=github-pr-rebase-merge` -- show full SKILL.md
+- `/skills action=create name=new-skill` -- interactive skill creation
+- `/skills action=patch name=existing-skill` -- modify specific sections
+- `/skills action=delete name=old-skill` -- remove with confirmation
+- `/skills action=audit` -- find stale, duplicate, or oversized skills
+
+## Procedure
+
+### action=list
+
+```bash
+SKILL_DIR="${HOME}/.claude/skills"
+if [ "$SCOPE" = "local" ]; then SKILL_DIR="./.claude/skills"; fi
+
+echo "=== Skills in $SKILL_DIR ==="
+for dir in "$SKILL_DIR"/*/; do
+  skill_file="$dir/SKILL.md"
+  if [ -f "$skill_file" ]; then
+    name=$(basename "$dir")
+    # Extract description from frontmatter
+    desc=$(sed -n '/^description:/{ s/^description: *//; p; q; }' "$skill_file")
+    printf "  %-35s %s\n" "$name" "$desc"
+  fi
+done
+```
+
+Present as a compact table. If both global and local exist, show both.
+
+### action=show
+
+1. Read `~/.claude/skills/{name}/SKILL.md`
+2. If it has a `references/` subdirectory, list those files too
+3. Present the full content
+
+### action=create
+
+Interactive skill creation workflow:
+
+1. Ask for trigger context: "When should this skill activate?"
+2. Ask for procedure steps: "What does it do, step by step?"
+3. Generate SKILL.md with proper frontmatter:
+
+```markdown
+---
+name: {name}
+description: {one-line, specific about triggers}
+---
+
+# {Title}
+
+## When to use
+{Concrete triggers and contexts}
+
+## Procedure
+1. {Step}
+2. {Step}
+...
+
+## Pitfalls
+- {Known issues, if any}
+```
+
+4. Write to `~/.claude/skills/{name}/SKILL.md`
+5. Update `.skill-index.md` if it exists
+
+Rules:
+- Keep SKILL.md under 500 lines
+- Large reference material goes in `references/` subdirectory
+- Description must be specific enough for L0 matching (not "does stuff")
+- Procedure steps must be concrete and executable
+
+### action=patch
+
+Targeted modification of an existing skill:
+
+1. Read the current SKILL.md
+2. Identify the section to change based on user input or retrospective proposal
+3. Apply targeted edit (old text -> new text), not full rewrite
+4. If adding a pitfall from a runtime discovery, append to the Pitfalls section
+5. Log the patch reason in the Pitfalls section if it came from an error recovery
+
+Rules:
+- Never rewrite the entire skill for a small change
+- Preserve existing pitfalls and procedure steps unless explicitly removing
+- If the patch changes triggers, update the description in frontmatter too
+
+### action=delete
+
+1. Show the skill content first
+2. Ask for confirmation: "Delete skill '{name}'? This removes the entire directory."
+3. On confirmation:
+```bash
+rm -rf "${HOME}/.claude/skills/${NAME}"
+```
+4. Update `.skill-index.md` if it exists
+
+Rules:
+- Never delete without showing content first
+- Never delete without explicit user confirmation
+- If the skill is referenced by other skills, warn before deleting
+
+### action=audit
+
+Comprehensive skill library health check:
+
+1. **Stale detection**: Skills not referenced in any CLAUDE.md and with no git activity in 60+ days
+```bash
+for dir in ~/.claude/skills/*/; do
+  name=$(basename "$dir")
+  skill_file="$dir/SKILL.md"
+  if [ -f "$skill_file" ]; then
+    mod_date=$(stat -f '%Sm' -t '%Y-%m-%d' "$skill_file" 2>/dev/null || stat -c '%y' "$skill_file" 2>/dev/null | cut -d' ' -f1)
+    echo "$mod_date  $name"
+  fi
+done | sort
+```
+
+2. **Duplicate detection**: Skills with overlapping descriptions or triggers
+```bash
+for dir in ~/.claude/skills/*/; do
+  skill_file="$dir/SKILL.md"
+  if [ -f "$skill_file" ]; then
+    desc=$(sed -n '/^description:/{ s/^description: *//; p; q; }' "$skill_file")
+    echo "$(basename "$dir"): $desc"
+  fi
+done
+```
+Review for semantic overlaps manually.
+
+3. **Size check**: Skills over 500 lines that should be refactored
+```bash
+for dir in ~/.claude/skills/*/; do
+  skill_file="$dir/SKILL.md"
+  if [ -f "$skill_file" ]; then
+    lines=$(wc -l < "$skill_file")
+    if [ "$lines" -gt 500 ]; then
+      echo "OVERSIZED ($lines lines): $(basename "$dir")"
+    fi
+  fi
+done
+```
+
+4. **Index sync**: Check `.skill-index.md` matches actual directories
+```bash
+if [ -f ~/.claude/skills/.skill-index.md ]; then
+  echo "Index exists, checking sync..."
+  # Compare index entries vs actual directories
+  indexed=$(grep -oP '(?<=\[)[^\]]+' ~/.claude/skills/.skill-index.md | sort)
+  actual=$(ls -d ~/.claude/skills/*/ 2>/dev/null | xargs -I{} basename {} | sort)
+  diff <(echo "$indexed") <(echo "$actual")
+fi
+```
+
+Present findings as:
+```
+## Skill Audit Results
+
+Total skills: {count} (global) + {count} (local)
+Disk usage: {size}
+
+### Issues Found
+- [STALE] skill-name: last modified 2025-01-15 (130 days ago)
+- [DUPLICATE] skill-a / skill-b: overlapping trigger "when deploying..."
+- [OVERSIZED] skill-name: 720 lines (max 500)
+- [UNINDEXED] skill-name: exists on disk but not in .skill-index.md
+
+### Recommended Actions
+1. DELETE skill-a (superseded by skill-b)
+2. PATCH skill-c: move 300 lines to references/
+3. REINDEX: regenerate .skill-index.md
+```
+
+## Skill Index Regeneration
+
+When skills are created, patched, or deleted, regenerate the index:
+
+```bash
+INDEX_FILE="${HOME}/.claude/skills/.skill-index.md"
+echo "# Skill Index" > "$INDEX_FILE"
+echo "" >> "$INDEX_FILE"
+echo "Auto-generated. Do not edit manually." >> "$INDEX_FILE"
+echo "" >> "$INDEX_FILE"
+
+for dir in ~/.claude/skills/*/; do
+  skill_file="$dir/SKILL.md"
+  if [ -f "$skill_file" ]; then
+    name=$(basename "$dir")
+    desc=$(sed -n '/^description:/{ s/^description: *//; p; q; }' "$skill_file")
+    echo "- **$name**: $desc" >> "$INDEX_FILE"
+  fi
+done
+```
+
+## Pitfalls
+
+- Do NOT auto-delete skills without user confirmation
+- Do NOT create skills for one-off tasks (check the 2+ occurrence rule)
+- Audit results are advisory, not auto-executed
+- The `.skill-index.md` is for L0 matching only; the full SKILL.md is L1
+- On macOS, `stat` syntax differs from Linux; the audit commands handle both
+- If a skill references external APIs or tokens, never include the actual values
+
+## Relation to other mechanisms
+
+| Mechanism | Skill-management's role |
+|-----------|------------------------|
+| retrospective | Retrospective proposes changes; skill-management executes them |
+| CLAUDE.md | CLAUDE.md references skills; skill-management maintains the library |
+| .skill-index.md | Skill-management regenerates this after mutations |
+| seed-skills/ | Seed skills are templates; once installed they become regular skills managed here |


### PR DESCRIPTION
## Summary

- Adds `/retrospective` seed skill: session analysis with A/B/C framework (What happened / Why / What should change), generates categorized improvement proposals (skills, memory, workflow) for user approval before execution
- Adds `/skill-management` seed skill: CRUD operations for the skill library -- list, show, create, patch, delete, audit actions with stale/duplicate/oversized detection
- Both auto-discovered by install.sh/update.sh via `seed-skills/*/` glob

Part of the Zhutov self-improvement skill package (with `/handoff` in PR #144).

## Test plan

- [ ] Run `./install.sh` on clean env, verify both skills appear in `~/.claude/skills/`
- [ ] Run `./update.sh` on existing install, verify idempotent (no overwrite if dir exists)
- [ ] Invoke `/retrospective` in a session after complex work
- [ ] Invoke `/skills action=list` and verify output
- [ ] Invoke `/skills action=audit` and verify stale/duplicate detection

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>