### PR TITLE
fix: replace hardcoded install path with {{INSTALL_DIR}} placeholder

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -436,10 +436,44 @@ if [ -d "$SCHED_TPL_DIR" ]; then
       sed -e "s/{{MAIN_AGENT_ID}}/$MAIN_AGENT_ID/g" \
           -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
           -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
+          -e "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" \
           "$f" > "$target/$(basename "$f")"
     done
     ok "Utemezett feladat scaffoldolva: $task_name"
   done
+fi
+
+# Seed scheduled tasks: from seed-scheduled-tasks/ into ~/.claude/scheduled-tasks/
+# Idempotent: skip directories that already exist. Templates use {{MAIN_AGENT_ID}},
+# {{BOT_NAME}}, {{OWNER_NAME}}, {{INSTALL_DIR}} placeholders.
+SEED_SCHED_DIR="$INSTALL_DIR/seed-scheduled-tasks"
+if [ -d "$SEED_SCHED_DIR" ]; then
+  mkdir -p "$SCHED_TARGET_DIR"
+  SCHED_NEW=0
+  SCHED_SKIP=0
+  for tpl in "$SEED_SCHED_DIR"/*/; do
+    [ -d "$tpl" ] || continue
+    task_name=$(basename "$tpl")
+    [[ "$task_name" == "bumblebee-hygiene-scan" ]] && continue
+    target="$SCHED_TARGET_DIR/$task_name"
+    if [ -d "$target" ]; then
+      SCHED_SKIP=$((SCHED_SKIP + 1))
+      continue
+    fi
+    mkdir -p "$target"
+    for f in "$tpl"*; do
+      [ -f "$f" ] || continue
+      sed -e "s/{{MAIN_AGENT_ID}}/$MAIN_AGENT_ID/g" \
+          -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
+          -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
+          -e "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" \
+          "$f" > "$target/$(basename "$f")"
+    done
+    SCHED_NEW=$((SCHED_NEW + 1))
+  done
+  if [ "$SCHED_NEW" -gt 0 ] || [ "$SCHED_SKIP" -gt 0 ]; then
+    ok "Seed scheduled tasks: ${SCHED_NEW} uj, ${SCHED_SKIP} kihagyva"
+  fi
 fi
 
 # Seed bumblebee threat-intel catalogs into ~/.claude/tools/

--- a/install.sh
+++ b/install.sh
@@ -362,6 +362,7 @@ if [ -d "$SCHED_TPL_DIR" ]; then
       sed -e "s/{{MAIN_AGENT_ID}}/$MAIN_AGENT_ID/g" \
           -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
           -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
+          -e "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" \
           "$f" > "$target/$(basename "$f")"
     done
     echo -e "  ${GREEN}✓${NC} Utemezett feladat scaffoldolva: $task_name"

--- a/scheduled-tasks/dream-engine/SKILL.md
+++ b/scheduled-tasks/dream-engine/SKILL.md
@@ -9,7 +9,7 @@ A cél: az aznapi tudást átkonszolidálni és reggelre (07:30 Reggeli Napindí
 
 ## Mit kell csinálnod
 
-Generálj egy `/Users/marvin/ClaudeClaw/DREAM.md` fájlt az alábbi 5 bucket alapján. A formátum a fájl alján van.
+Generálj egy `{{INSTALL_DIR}}/DREAM.md` fájlt az alábbi 5 bucket alapján. A formátum a fájl alján van.
 
 ### Bucket 1 — 💡 Skill-javaslatok (flotta-szintű)
 
@@ -19,7 +19,7 @@ Nézz végig MINDEN agent (marveen + sub-agentek: boni, deeper, iris, samu, zara
 
 SQL minta:
 ```bash
-sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "SELECT agent_id, content, keywords FROM memories WHERE created_at > strftime('%s', 'now', '-24 hours') AND category IN ('hot','warm') ORDER BY agent_id, created_at"
+sqlite3 {{INSTALL_DIR}}/store/claudeclaw.db "SELECT agent_id, content, keywords FROM memories WHERE created_at > strftime('%s', 'now', '-24 hours') AND category IN ('hot','warm') ORDER BY agent_id, created_at"
 ```
 
 Output: 0-2 konkrét skill-javaslat. Mindegyikhez: cím + 1 mondat indoklás + "flotta-szintű" vagy "agent: <név>".
@@ -28,11 +28,11 @@ Output: 0-2 konkrét skill-javaslat. Mindegyikhez: cím + 1 mondat indoklás + "
 
 ```bash
 # Vektorizálás ellenőrzés
-sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "SELECT COUNT(*) as total, COUNT(embedding) as with_emb FROM memories"
+sqlite3 {{INSTALL_DIR}}/store/claudeclaw.db "SELECT COUNT(*) as total, COUNT(embedding) as with_emb FROM memories"
 # Ha NEM 100%, hívd meg a /api/memories/reembed endpoint-ot vagy futtass embedding-job-ot a missing ID-kra
 
 # Antikvált hot-tier (>7 napos hot, nem hivatkozott a memories_fts-en az elmúlt 24h-ban)
-sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "SELECT id, content, accessed_at FROM memories WHERE category='hot' AND accessed_at < strftime('%s', 'now', '-7 days')"
+sqlite3 {{INSTALL_DIR}}/store/claudeclaw.db "SELECT id, content, accessed_at FROM memories WHERE category='hot' AND accessed_at < strftime('%s', 'now', '-7 days')"
 ```
 
 Műveletek:
@@ -42,7 +42,7 @@ Műveletek:
 
 A változtatásokat directly SQL-lel csináld:
 ```bash
-sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "UPDATE memories SET category='cold' WHERE id IN (...)"
+sqlite3 {{INSTALL_DIR}}/store/claudeclaw.db "UPDATE memories SET category='cold' WHERE id IN (...)"
 ```
 
 Output: rövid statisztika ("X memória cold-tier-be áthelyezve, Y vektorizálatlan rendezve").
@@ -51,7 +51,7 @@ Output: rövid statisztika ("X memória cold-tier-be áthelyezve, Y vektorizála
 
 ```bash
 # Nyitott kanban-kártyák project + priority szerint
-sqlite3 /Users/marvin/ClaudeClaw/store/claudeclaw.db "SELECT id, title, status, project, priority, assignee FROM kanban_cards WHERE status IN ('planned','in_progress','waiting') AND archived_at IS NULL ORDER BY project, priority DESC"
+sqlite3 {{INSTALL_DIR}}/store/claudeclaw.db "SELECT id, title, status, project, priority, assignee FROM kanban_cards WHERE status IN ('planned','in_progress','waiting') AND archived_at IS NULL ORDER BY project, priority DESC"
 ```
 
 Csoportosíts project szerint. A daily naplóban (utolsó 7 nap) nézd hogy melyik projekten van aktív mozgás (commit, PR, kanban-átmozgás). Hozz ki egy TOP-3 holnapi javaslatot prioritás+aktivitás súlyozva.

--- a/scheduled-tasks/memoria-heartbeat/SKILL.md
+++ b/scheduled-tasks/memoria-heartbeat/SKILL.md
@@ -12,7 +12,7 @@ Ha volt fontos döntés, preferencia, tanulság vagy bármi ami később hasznos
 ```bash
 curl -s -X POST http://localhost:3420/api/memories \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $(cat /Users/marvin/ClaudeClaw/store/.dashboard-token)" \
+  -H "Authorization: Bearer $(cat {{INSTALL_DIR}}/store/.dashboard-token)" \
   -d '{"agent_id":"SAJAT_NEVED","content":"...","category":"warm","keywords":"..."}'
 ```
 

--- a/scheduled-tasks/reggeli-napindito/SKILL.md
+++ b/scheduled-tasks/reggeli-napindito/SKILL.md
@@ -5,9 +5,9 @@ description: Reggeli összefoglaló: email, naptár, AI hírek, plus Dream Engin
 
 Reggeli napindítót a CLAUDE.md formátum szerint. A beállított csatornára (chat_id: 1268077055).
 
-**FONTOS — Dream Engine override**: a napindító ELEJÉRE (még az email/naptár szekciók ELŐTT) tedd be a `/Users/marvin/ClaudeClaw/DREAM.md` fájl tartalmából az 5 bucket-et — `💡 Skill-javaslatok`, `🧹 Memória-egészség`, `🎯 Top-3 holnapi javaslat`, `🌐 External opportunity`, `🛠 Skill-flotta health`. Ha a DREAM.md nem létezik vagy üres (pl. a Dream Engine valamiért nem futott le), kihagyod ezt a szekciót.
+**FONTOS — Dream Engine override**: a napindító ELEJÉRE (még az email/naptár szekciók ELŐTT) tedd be a `{{INSTALL_DIR}}/DREAM.md` fájl tartalmából az 5 bucket-et — `💡 Skill-javaslatok`, `🧹 Memória-egészség`, `🎯 Top-3 holnapi javaslat`, `🌐 External opportunity`, `🛠 Skill-flotta health`. Ha a DREAM.md nem létezik vagy üres (pl. a Dream Engine valamiért nem futott le), kihagyod ezt a szekciót.
 
-A `cat /Users/marvin/ClaudeClaw/DREAM.md` parancs visszaadja a tartalmat, abból emeld ki a kulcs-szekciókat MarkdownV2-formátumra escape-elve.
+A `cat {{INSTALL_DIR}}/DREAM.md` parancs visszaadja a tartalmat, abból emeld ki a kulcs-szekciókat MarkdownV2-formátumra escape-elve.
 
 A többi szekció (email, naptár, AI hírek) maradnak a CLAUDE.md-ben leírt formátum szerint.
 

--- a/seed-scheduled-tasks/kanban-audit/SKILL.md
+++ b/seed-scheduled-tasks/kanban-audit/SKILL.md
@@ -10,7 +10,7 @@ description: 4 óránkénti kanban-tábla audit. Tisztítás (7+ napos done arch
 
 ## Autonómia-szint (config-vezérelt, KÖTELEZŐ ELŐSZÖR)
 
-Olvasd be: `jq -r '.categories[]|select(.key=="kanban_archive_done" or .key=="kanban_stuck_nudge")|"\(.key) \(.level)"' /Users/marvin/ClaudeClaw/store/autonomy-config.json`
+Olvasd be: `jq -r '.categories[]|select(.key=="kanban_archive_done" or .key=="kanban_stuck_nudge")|"\(.key) \(.level)"' {{INSTALL_DIR}}/store/autonomy-config.json`
 
 A két kategória szintje szabályozza a 2. és 4. lépést:
 - **`kanban_archive_done`** (2. lépés): level 3 → archiváld magától (alapért). level 2 → NE archiválj, Telegramon javasold ("X db 7+ napos done archiválásra vár, mehet?") és várj jóváhagyást. level 1 → csak jelezd a számot.


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `/Users/marvin/ClaudeClaw` paths in scheduled-task SKILL.md files with `{{INSTALL_DIR}}` placeholder
- Adds `{{INSTALL_DIR}}` sed substitution to `templates/scheduled-tasks/` processing in both `install.sh` and `install-linux.sh`
- Adds missing `seed-scheduled-tasks/` processing loop to `install-linux.sh` (was only in `install.sh`)

Affected files:
- `scheduled-tasks/dream-engine/SKILL.md` (6 occurrences)
- `scheduled-tasks/reggeli-napindito/SKILL.md` (2 occurrences)
- `scheduled-tasks/memoria-heartbeat/SKILL.md` (1 occurrence)
- `seed-scheduled-tasks/kanban-audit/SKILL.md` (1 occurrence)

Fixes #147

## Test plan

- [ ] Fresh `install-linux.sh` on Ubuntu: verify `~/.claude/scheduled-tasks/*/SKILL.md` files contain the actual install path, not `/Users/marvin/ClaudeClaw`
- [ ] Fresh `install.sh` on macOS: same verification
- [ ] Run `update.sh`: verify seed-scheduled-tasks get `{{INSTALL_DIR}}` substitution
- [ ] Verify heartbeat/dream/napindito run successfully after install

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>