### PR TITLE
fix(install): eliminate silent failures + missing Linux scaffolding

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -362,11 +362,15 @@ echo -e "${BOLD}[5/7] Fuggosegek telepitese...${NC}"
 cd "$INSTALL_DIR"
 
 echo -e "  npm install..."
-npm ci --silent 2>/dev/null || npm install --silent
+if ! (npm ci --loglevel warn 2>/dev/null || npm install --loglevel warn); then
+  fail "npm install sikertelen. Ellenorizd a hibauzeneteket fentebb."
+fi
 ok "npm csomagok telepitve"
 
 echo -e "  TypeScript forditas..."
-npm run build --silent
+if ! npm run build --loglevel warn; then
+  fail "TypeScript forditas sikertelen. Ellenorizd a hibauzeneteket fentebb."
+fi
 ok "TypeScript leforditva"
 
 mkdir -p "$INSTALL_DIR/store"
@@ -405,6 +409,8 @@ if [ -f "$INSTALL_DIR/templates/CLAUDE.md.template" ]; then
     -e "s/{{MAIN_AGENT_ID}}/$MAIN_AGENT_ID/g" \
     "$INSTALL_DIR/templates/CLAUDE.md.template" >"$INSTALL_DIR/CLAUDE.md"
   ok "CLAUDE.md generalva"
+else
+  warn "CLAUDE.md.template nem talalhato, CLAUDE.md nem generalhato"
 fi
 
 # SOUL.md generalasa template-bol (personality definition for the main agent).
@@ -413,6 +419,8 @@ if [ -f "$INSTALL_DIR/templates/SOUL.md.template" ] && [ ! -f "$INSTALL_DIR/SOUL
       -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
       "$INSTALL_DIR/templates/SOUL.md.template" > "$INSTALL_DIR/SOUL.md"
   ok "SOUL.md generalva"
+elif [ ! -f "$INSTALL_DIR/templates/SOUL.md.template" ] && [ ! -f "$INSTALL_DIR/SOUL.md" ]; then
+  warn "SOUL.md.template nem talalhato, SOUL.md nem generalhato"
 fi
 
 # Default scheduled tasks scaffoldolasa ~/.claude/scheduled-tasks/ ala. A
@@ -473,6 +481,13 @@ if [ -d "$SEED_SCHED_DIR" ]; then
   done
   if [ "$SCHED_NEW" -gt 0 ] || [ "$SCHED_SKIP" -gt 0 ]; then
     ok "Seed scheduled tasks: ${SCHED_NEW} uj, ${SCHED_SKIP} kihagyva"
+  fi
+  if [ "$SCHED_NEW" -gt 0 ]; then
+    STATE_FILE="$INSTALL_DIR/store/kanban-audit-state.json"
+    if [ ! -f "$STATE_FILE" ]; then
+      echo '{"last_audit_at":null}' > "$STATE_FILE"
+      ok "kanban-audit state inicializalva"
+    fi
   fi
 fi
 
@@ -566,6 +581,32 @@ if [ -d "$INSTALL_DIR/skills/skill-factory" ]; then
   mkdir -p "$SKILLS_DIR/skill-factory"
   cp -r "$INSTALL_DIR/skills/skill-factory/"* "$SKILLS_DIR/skill-factory/"
   ok "skill-factory telepitve"
+fi
+
+# Seed skills: fleet-level skills from seed-skills/ into ~/.claude/skills/
+# Idempotent: skip directories that already exist (never overwrite user customizations)
+SEED_SKILLS_DIR="$INSTALL_DIR/seed-skills"
+if [ -d "$SEED_SKILLS_DIR" ]; then
+  SEED_NEW=0
+  SEED_SKIP=0
+  for skill_dir in "$SEED_SKILLS_DIR"/*/; do
+    [ -d "$skill_dir" ] || continue
+    skill_name=$(basename "$skill_dir")
+    target="$SKILLS_DIR/$skill_name"
+    if [ -d "$target" ]; then
+      SEED_SKIP=$((SEED_SKIP + 1))
+      continue
+    fi
+    mkdir -p "$target"
+    for f in "$skill_dir"*; do
+      [ -f "$f" ] || continue
+      cp "$f" "$target/$(basename "$f")"
+    done
+    SEED_NEW=$((SEED_NEW + 1))
+  done
+  if [ "$SEED_NEW" -gt 0 ] || [ "$SEED_SKIP" -gt 0 ]; then
+    ok "Seed skills: ${SEED_NEW} uj, ${SEED_SKIP} kihagyva (mar letezik)"
+  fi
 fi
 
 # ─────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -283,12 +283,18 @@ fi
 echo ""
 echo -e "${BOLD}[5/7] Függőségek telepítése...${NC}"
 cd "$INSTALL_DIR"
-npm install --silent
+if ! npm install --loglevel warn; then
+  echo -e "  ${RED}✗${NC} npm install sikertelen. Ellenorizd a hibauzeneteket fentebb."
+  exit 1
+fi
 echo -e "  ${GREEN}✓${NC} npm csomagok telepítve"
 
 # Build TypeScript
 echo -e "  Forditas..."
-npm run build --silent
+if ! npm run build --loglevel warn; then
+  echo -e "  ${RED}✗${NC} TypeScript forditas sikertelen. Ellenorizd a hibauzeneteket fentebb."
+  exit 1
+fi
 echo -e "  ${GREEN}✓${NC} TypeScript leforditva"
 
 # Step 6: Configuration
@@ -329,6 +335,8 @@ if [ -f "$INSTALL_DIR/templates/CLAUDE.md.template" ]; then
       -e "s/{{MAIN_AGENT_ID}}/$MAIN_AGENT_ID/g" \
       "$INSTALL_DIR/templates/CLAUDE.md.template" > "$INSTALL_DIR/CLAUDE.md"
   echo -e "  ${GREEN}✓${NC} CLAUDE.md generalva"
+else
+  echo -e "  ${ORANGE}⚠${NC} CLAUDE.md.template nem talalhato, CLAUDE.md nem generalhato"
 fi
 
 # Generate SOUL.md from template (personality definition for the main agent).
@@ -339,6 +347,8 @@ if [ -f "$INSTALL_DIR/templates/SOUL.md.template" ] && [ ! -f "$INSTALL_DIR/SOUL
       -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
       "$INSTALL_DIR/templates/SOUL.md.template" > "$INSTALL_DIR/SOUL.md"
   echo -e "  ${GREEN}✓${NC} SOUL.md generalva"
+elif [ ! -f "$INSTALL_DIR/templates/SOUL.md.template" ] && [ ! -f "$INSTALL_DIR/SOUL.md" ]; then
+  echo -e "  ${ORANGE}⚠${NC} SOUL.md.template nem talalhato, SOUL.md nem generalhato"
 fi
 
 # Scaffold default scheduled tasks into ~/.claude/scheduled-tasks/. Templates


### PR DESCRIPTION
## Summary

- **BUG-1**: `npm install/build --silent` replaced with `--loglevel warn` + exit code checks. Errors are now visible instead of silently swallowed.
- **BUG-2/3**: Missing `CLAUDE.md.template` or `SOUL.md.template` now shows a warning instead of silent skip.
- **BUG-4**: `kanban-audit-state.json` initialization added to `install-linux.sh` (was only in `install.sh`).
- **BUG-5**: Seed-skills scaffolding loop added to `install-linux.sh` -- fleet-level skills (handoff, retrospective, skill-management) were NOT being installed on Linux at all.

Found during install flow audit requested by Marveen after user report of step 5 issues.

## Test plan

- [ ] Fresh `install-linux.sh`: verify npm errors are visible (not silent)
- [ ] Fresh `install-linux.sh`: verify seed-skills appear in `~/.claude/skills/`
- [ ] Fresh `install-linux.sh`: verify `store/kanban-audit-state.json` is created
- [ ] Remove `templates/CLAUDE.md.template` temporarily, run installer: verify warning shown
- [ ] Fresh `install.sh` (macOS): same npm error visibility check

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>