### PR TITLE
feat(install): Claude Code fallback on installer failure

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -20,10 +20,42 @@ NC='\033[0m'
 
 ok() { echo -e "  ${GREEN}✓${NC} $*"; }
 warn() { echo -e "  ${ORANGE}!${NC} $*"; }
+
+INSTALL_STEP="init"
+
+offer_claude_fallback() {
+  local step="$1" err_msg="$2"
+  if ! command -v claude &>/dev/null; then
+    return
+  fi
+  echo ""
+  echo -e "${ORANGE}Claude Code elerheto a gepen.${NC}"
+  local prompt="Marveen installer failed at step '${step}'. Error: ${err_msg}. OS: $(lsb_release -ds 2>/dev/null || cat /etc/os-release 2>/dev/null | head -1 || echo Linux). Node: $(node -v 2>/dev/null || echo missing). Dir: ${INSTALL_DIR}. Diagnose and suggest fixes."
+  if [ -t 0 ]; then
+    read -p "  Megnyissam Claude Code-ot a hiba diagnosztizalasahoz? (i/n) [n]: " OPEN_CLAUDE
+    OPEN_CLAUDE=${OPEN_CLAUDE:-n}
+    if [ "$OPEN_CLAUDE" = "i" ]; then
+      claude --prompt "$prompt"
+      return
+    fi
+  fi
+  echo -e "  ${DIM}Futtasd manualisan:${NC}"
+  echo -e "  ${DIM}claude --prompt \"$(echo "$prompt" | sed 's/"/\\"/g')\"${NC}"
+}
+
 fail() {
   echo -e "  ${RED}✗${NC} $*"
+  offer_claude_fallback "$INSTALL_STEP" "$*"
   exit 1
 }
+
+on_error() {
+  echo ""
+  echo -e "${RED}Varatlan hiba a(z) '${INSTALL_STEP}' lepesben (sor: $1).${NC}"
+  offer_claude_fallback "$INSTALL_STEP" "Unexpected error at line $1"
+  exit 1
+}
+trap 'on_error $LINENO' ERR
 
 # Ha a <marker> szoveg nem talalhato az rc fajlban, hozzaadja a <sort>.
 # Mindket fajlt kezeli (.bashrc, .zshrc) ha leteznek.
@@ -61,6 +93,7 @@ echo ""
 echo -e "${DIM}  Telepito wizard - Linux (Ubuntu/Debian)${NC}"
 echo ""
 
+INSTALL_STEP="prerequisites"
 # ─────────────────────────────────────────────
 # [1/7] Elofeltetelek
 # ─────────────────────────────────────────────
@@ -114,6 +147,7 @@ ok "python3 $(python3 --version | awk '{print $2}')"
 ok "tmux $(tmux -V | awk '{print $2}')"
 ok "unzip" $(unzip -v | awk 'NR==1 {print $2}')
 
+INSTALL_STEP="claude-bun-install"
 # ─────────────────────────────────────────────
 # [2/7] Claude Code + Bun telepitese
 # ─────────────────────────────────────────────
@@ -178,6 +212,7 @@ fi
 ensure_in_rc 'BUN_INSTALL' 'export BUN_INSTALL="$HOME/.bun"'
 ensure_in_rc '.bun/bin' 'export PATH="$BUN_INSTALL/bin:$PATH"'
 
+INSTALL_STEP="claude-auth"
 # ─────────────────────────────────────────────
 # [3/7] Claude bejelentkezes
 # ─────────────────────────────────────────────
@@ -285,6 +320,7 @@ except Exception:
 PYEOF
 echo -e "  ${GREEN}✓${NC} Claude Code first-run beallitas kesz"
 
+INSTALL_STEP="personal-info"
 # ─────────────────────────────────────────────
 # [4/7] Szemelyes beallitasok
 # ─────────────────────────────────────────────
@@ -354,6 +390,7 @@ if [ "$MAIN_AGENT_ID" != "marveen" ]; then
   echo -e "  ${DIM}Ügynök belső azonosító: ${MAIN_AGENT_ID}${NC}"
 fi
 
+INSTALL_STEP="npm-install"
 # ─────────────────────────────────────────────
 # [5/7] Fuggosegek telepitese + konfiguracic
 # ─────────────────────────────────────────────
@@ -367,6 +404,7 @@ if ! (npm ci --loglevel warn 2>/dev/null || npm install --loglevel warn); then
 fi
 ok "npm csomagok telepitve"
 
+INSTALL_STEP="typescript-build"
 echo -e "  TypeScript forditas..."
 if ! npm run build --loglevel warn; then
   fail "TypeScript forditas sikertelen. Ellenorizd a hibauzeneteket fentebb."
@@ -377,6 +415,7 @@ mkdir -p "$INSTALL_DIR/store"
 mkdir -p "$INSTALL_DIR/agents"
 ok "Konyvtarak letrehozva"
 
+INSTALL_STEP="configuration"
 # .env letrehozasa
 echo ""
 echo -e "${BOLD}  Konfiguracio letrehozasa...${NC}"
@@ -609,6 +648,7 @@ if [ -d "$SEED_SKILLS_DIR" ]; then
   fi
 fi
 
+INSTALL_STEP="ollama-whisper"
 # ─────────────────────────────────────────────
 # [6/7] Ollama + Whisper
 # ─────────────────────────────────────────────
@@ -694,6 +734,7 @@ else
   fi
 fi
 
+INSTALL_STEP="systemd"
 # ─────────────────────────────────────────────
 # [7/7] Automatikus inditas (systemd)
 # ─────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,44 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_STEP="init"
+
+ok() { echo -e "  ${GREEN}✓${NC} $*"; }
+warn() { echo -e "  ${ORANGE}!${NC} $*"; }
+
+offer_claude_fallback() {
+  local step="$1" err_msg="$2"
+  if ! command -v claude &>/dev/null; then
+    return
+  fi
+  echo ""
+  echo -e "${ORANGE}Claude Code elérhető a gépen.${NC}"
+  local prompt="Marveen installer failed at step '${step}'. Error: ${err_msg}. OS: macOS $(sw_vers -productVersion 2>/dev/null || echo unknown). Node: $(node -v 2>/dev/null || echo missing). Dir: ${INSTALL_DIR}. Diagnose and suggest fixes."
+  if [ -t 0 ]; then
+    read -p "  Megnyissam Claude Code-ot a hiba diagnosztizálásához? (i/n) [n]: " OPEN_CLAUDE
+    OPEN_CLAUDE=${OPEN_CLAUDE:-n}
+    if [ "$OPEN_CLAUDE" = "i" ]; then
+      claude --prompt "$prompt"
+      return
+    fi
+  fi
+  echo -e "  ${DIM}Futtasd manuálisan:${NC}"
+  echo -e "  ${DIM}claude --prompt \"$(echo "$prompt" | sed 's/"/\\"/g')\"${NC}"
+}
+
+fail() {
+  echo -e "  ${RED}✗${NC} $*"
+  offer_claude_fallback "$INSTALL_STEP" "$*"
+  exit 1
+}
+
+on_error() {
+  echo ""
+  echo -e "${RED}Varatlan hiba a(z) '${INSTALL_STEP}' lepesben (sor: $1).${NC}"
+  offer_claude_fallback "$INSTALL_STEP" "Unexpected error at line $1"
+  exit 1
+}
+trap 'on_error $LINENO' ERR
 
 clear
 echo ""
@@ -24,6 +62,7 @@ echo -e "${DIM}  Telepito wizard - macOS${NC}"
 echo ""
 
 # Step 1: Check prerequisites
+INSTALL_STEP="prerequisites"
 echo -e "${BOLD}[1/7] Elofeltetelek ellenorzese...${NC}"
 
 check_cmd() {
@@ -65,8 +104,7 @@ if [ "$MISSING" -eq 1 ]; then
       eval "$(/usr/local/bin/brew shellenv)"
     fi
     if ! command -v brew &>/dev/null; then
-      echo -e "${RED}Homebrew telepítése sikertelen. Telepitsd manualisan (https://brew.sh) es futtasd ujra az installert.${NC}"
-      exit 1
+      fail "Homebrew telepitese sikertelen. Telepitsd manualisan (https://brew.sh) es futtasd ujra az installert."
     fi
   fi
   command -v node &>/dev/null || brew install node@22
@@ -99,12 +137,12 @@ if ! command -v claude &>/dev/null; then
   if [ "$INSTALL_CLAUDE" = "i" ]; then
     npm install -g @anthropic-ai/claude-code
   else
-    echo -e "${RED}Claude Code CLI szükséges a futtatáshoz.${NC}"
-    exit 1
+    fail "Claude Code CLI szukseges a futtatashoz. Telepitsd: npm install -g @anthropic-ai/claude-code"
   fi
 fi
 echo -e "  ${GREEN}✓${NC} Claude Code CLI"
 
+INSTALL_STEP="claude-setup"
 # Step 2: Claude Code first-run flags (BEFORE auth login)
 #
 # Reason: ha a `claude auth login` browser-flow megakad (timeout, Ctrl+C,
@@ -151,6 +189,7 @@ except Exception:
 PYEOF
 echo -e "  ${GREEN}✓${NC} Claude Code first-run flags pre-set"
 
+INSTALL_STEP="claude-auth"
 # Step 2b: Claude authentication (kept tolerant -- ha megakad, folytatjuk)
 echo ""
 echo -e "${BOLD}[2/7] Claude bejelentkezes${NC}"
@@ -170,6 +209,7 @@ if [ "$DO_AUTH" = "i" ]; then
 fi
 echo -e "  ${GREEN}✓${NC} Claude Code first-run beállítás kész"
 
+INSTALL_STEP="personal-info"
 # Step 3: Personal info
 echo ""
 echo -e "${BOLD}[3/7] Személyes beállítások${NC}"
@@ -178,6 +218,7 @@ read -p "  Mi a neved? " OWNER_NAME
 # It will be set automatically during the Telegram pairing flow.
 CHAT_ID="0"
 
+INSTALL_STEP="channel-setup"
 # Step 4: Channel provider setup
 echo ""
 echo -e "${BOLD}[4/7] Csatorna beállítás${NC}"
@@ -280,23 +321,24 @@ if [ "$MAIN_AGENT_ID" != "marveen" ]; then
 fi
 
 # Step 5: Install dependencies
+INSTALL_STEP="npm-install"
 echo ""
 echo -e "${BOLD}[5/7] Függőségek telepítése...${NC}"
 cd "$INSTALL_DIR"
 if ! npm install --loglevel warn; then
-  echo -e "  ${RED}✗${NC} npm install sikertelen. Ellenorizd a hibauzeneteket fentebb."
-  exit 1
+  fail "npm install sikertelen. Ellenorizd a hibauzeneteket fentebb."
 fi
-echo -e "  ${GREEN}✓${NC} npm csomagok telepítve"
+ok "npm csomagok telepítve"
 
 # Build TypeScript
+INSTALL_STEP="typescript-build"
 echo -e "  Forditas..."
 if ! npm run build --loglevel warn; then
-  echo -e "  ${RED}✗${NC} TypeScript forditas sikertelen. Ellenorizd a hibauzeneteket fentebb."
-  exit 1
+  fail "TypeScript forditas sikertelen. Ellenorizd a hibauzeneteket fentebb."
 fi
-echo -e "  ${GREEN}✓${NC} TypeScript leforditva"
+ok "TypeScript leforditva"
 
+INSTALL_STEP="configuration"
 # Step 6: Configuration
 echo ""
 echo -e "${BOLD}[6/7] Konfiguráció létrehozása...${NC}"
@@ -610,6 +652,7 @@ else
   echo -e "  ${DIM}Kihagyva. Később: ollama pull qwen3.5:9b${NC}"
 fi
 
+INSTALL_STEP="launchagent"
 # Step 7: LaunchAgent setup
 echo ""
 echo -e "${BOLD}[7/7] Automatikus indítás beállítása...${NC}"


### PR DESCRIPTION
## Summary
- Both installers (macOS + Linux) now offer to launch Claude Code when a step fails
- `INSTALL_STEP` variable tracks current phase for precise error context
- `offer_claude_fallback()` helper: checks claude CLI availability, TTY-aware (interactive prompt vs copy-paste command)
- `on_error` ERR trap catches unexpected failures with line number
- All raw `exit 1` calls replaced with `fail()` that invokes the fallback before exiting
- Diagnostic prompt includes: step name, error message, OS version, Node version, install dir

## Test plan
- [ ] Simulate npm install failure on macOS -- verify fallback prompt appears
- [ ] Simulate failure on Linux -- verify lsb_release info in prompt
- [ ] Verify non-interactive mode (piped stdin) prints command instead of prompting
- [ ] Verify no regression when claude CLI is not installed (fallback silently skipped)
- [ ] Syntax check: `bash -n install.sh && bash -n install-linux.sh`

Closes kanban card 4838AADB.

Generated with [Claude Code](https://claude.com/claude-code)