### PR TITLE
fix(install): enrich fallback prompt with script+line, repo URL, explicit task

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -24,13 +24,13 @@ warn() { echo -e "  ${ORANGE}!${NC} $*"; }
 INSTALL_STEP="init"
 
 offer_claude_fallback() {
-  local step="$1" err_msg="$2"
+  local step="$1" err_msg="$2" line_info="${3:+:$3}"
   if ! command -v claude &>/dev/null; then
     return
   fi
   echo ""
   echo -e "${ORANGE}Claude Code elerheto a gepen.${NC}"
-  local prompt="Marveen installer failed at step '${step}'. Error: ${err_msg}. OS: $(lsb_release -ds 2>/dev/null || cat /etc/os-release 2>/dev/null | head -1 || echo Linux). Node: $(node -v 2>/dev/null || echo missing). Dir: ${INSTALL_DIR}. Diagnose and suggest fixes."
+  local prompt="Marveen installer failed at step \"${step}\". Error: ${err_msg}. Script: install-linux.sh${line_info}. Repo: https://github.com/Szotasz/marveen. OS: $(lsb_release -ds 2>/dev/null || cat /etc/os-release 2>/dev/null | head -1 || echo Linux). Node: $(node -v 2>/dev/null || echo missing). Dir: ${INSTALL_DIR}. Your task: diagnose this Marveen installer failure. The install scripts are install.sh (macOS) and install-linux.sh. Read the relevant section, check for missing dependencies or permission issues, and suggest concrete shell commands to fix."
   if [ -t 0 ]; then
     read -p "  Megnyissam Claude Code-ot a hiba diagnosztizalasahoz? (i/n) [n]: " OPEN_CLAUDE
     OPEN_CLAUDE=${OPEN_CLAUDE:-n}
@@ -45,14 +45,14 @@ offer_claude_fallback() {
 
 fail() {
   echo -e "  ${RED}✗${NC} $*"
-  offer_claude_fallback "$INSTALL_STEP" "$*"
+  offer_claude_fallback "$INSTALL_STEP" "$*" "${BASH_LINENO[0]}"
   exit 1
 }
 
 on_error() {
   echo ""
   echo -e "${RED}Varatlan hiba a(z) '${INSTALL_STEP}' lepesben (sor: $1).${NC}"
-  offer_claude_fallback "$INSTALL_STEP" "Unexpected error at line $1"
+  offer_claude_fallback "$INSTALL_STEP" "Unexpected error at line $1" "$1"
   exit 1
 }
 trap 'on_error $LINENO' ERR

--- a/install.sh
+++ b/install.sh
@@ -19,13 +19,13 @@ ok() { echo -e "  ${GREEN}✓${NC} $*"; }
 warn() { echo -e "  ${ORANGE}!${NC} $*"; }
 
 offer_claude_fallback() {
-  local step="$1" err_msg="$2"
+  local step="$1" err_msg="$2" line_info="${3:+:$3}"
   if ! command -v claude &>/dev/null; then
     return
   fi
   echo ""
   echo -e "${ORANGE}Claude Code elérhető a gépen.${NC}"
-  local prompt="Marveen installer failed at step '${step}'. Error: ${err_msg}. OS: macOS $(sw_vers -productVersion 2>/dev/null || echo unknown). Node: $(node -v 2>/dev/null || echo missing). Dir: ${INSTALL_DIR}. Diagnose and suggest fixes."
+  local prompt="Marveen installer failed at step \"${step}\". Error: ${err_msg}. Script: install.sh${line_info}. Repo: https://github.com/Szotasz/marveen. OS: macOS $(sw_vers -productVersion 2>/dev/null || echo unknown). Node: $(node -v 2>/dev/null || echo missing). Dir: ${INSTALL_DIR}. Your task: diagnose this Marveen installer failure. The install scripts are install.sh (macOS) and install-linux.sh. Read the relevant section, check for missing dependencies or permission issues, and suggest concrete shell commands to fix."
   if [ -t 0 ]; then
     read -p "  Megnyissam Claude Code-ot a hiba diagnosztizálásához? (i/n) [n]: " OPEN_CLAUDE
     OPEN_CLAUDE=${OPEN_CLAUDE:-n}
@@ -40,14 +40,14 @@ offer_claude_fallback() {
 
 fail() {
   echo -e "  ${RED}✗${NC} $*"
-  offer_claude_fallback "$INSTALL_STEP" "$*"
+  offer_claude_fallback "$INSTALL_STEP" "$*" "${BASH_LINENO[0]}"
   exit 1
 }
 
 on_error() {
   echo ""
   echo -e "${RED}Varatlan hiba a(z) '${INSTALL_STEP}' lepesben (sor: $1).${NC}"
-  offer_claude_fallback "$INSTALL_STEP" "Unexpected error at line $1"
+  offer_claude_fallback "$INSTALL_STEP" "Unexpected error at line $1" "$1"
   exit 1
 }
 trap 'on_error $LINENO' ERR


### PR DESCRIPTION
## Summary
- Fallback prompt now includes `Script: install.sh:286` (or `install-linux.sh:NNN`)
- Added `Repo: https://github.com/Szotasz/marveen` for context
- Explicit task description: "diagnose this Marveen installer failure... Read the relevant section, check for missing dependencies or permission issues, and suggest concrete shell commands to fix."
- `fail()` passes `BASH_LINENO[0]`, `on_error()` passes its `$1` (LINENO from ERR trap)
- Third arg is optional -- `${3:+:$3}` only appends `:NNN` if line number is available

Follow-up to PR #153 (4838AADB).

## Test plan
- [ ] `bash -n install.sh && bash -n install-linux.sh` -- syntax OK
- [ ] Verify prompt output format matches the spec from Marveen's request

Generated with [Claude Code](https://claude.com/claude-code)