### PR TITLE
fix(slack): 6-bug chain breaking fresh Slack install (#156)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -434,8 +434,13 @@ else
   echo -e "${DIM}  Az AI asszisztensed Slack-en kommunikal veled.${NC}"
   echo -e "${DIM}  1. Hozz letre egy Slack App-ot: api.slack.com/apps${NC}"
   echo -e "${DIM}  2. Engedeld a Socket Mode-ot${NC}"
-  echo -e "${DIM}  3. Adj hozza scope-okat: chat:write, channels:read, files:write${NC}"
-  echo -e "${DIM}  4. Installald a workspace-be${NC}"
+  echo -e "${DIM}  3. OAuth & Permissions > Bot Token Scopes:${NC}"
+  echo -e "${DIM}     app_mentions:read, channels:history, channels:join,${NC}"
+  echo -e "${DIM}     channels:read, chat:write, files:read, files:write,${NC}"
+  echo -e "${DIM}     groups:history, im:history, reactions:write, users:read${NC}"
+  echo -e "${DIM}  4. Event Subscriptions > Bot Events:${NC}"
+  echo -e "${DIM}     app_mention, message.channels, message.groups, message.im${NC}"
+  echo -e "${DIM}  5. Installald a workspace-be${NC}"
   echo ""
   read -p "  Bot Token (xoxb-...): " SLACK_BOT_TOKEN
   read -p "  App-Level Token (xapp-...): " SLACK_APP_TOKEN
@@ -649,7 +654,7 @@ SLACKENVEOF
 {
   "dmPolicy": "pairing",
   "allowFrom": [],
-  "groups": {},
+  "channels": {},
   "pending": {}
 }
 ACCESSEOF
@@ -660,9 +665,11 @@ fi
 if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   PLUGIN_MARKETPLACE="anthropics/claude-plugins-official"
   PLUGIN_ID="telegram@claude-plugins-official"
+  PLUGIN_SHORT="telegram"
 else
-  PLUGIN_MARKETPLACE="jeremylongshore/claude-code-slack-channel"
-  PLUGIN_ID="slack@jeremylongshore/claude-code-slack-channel"
+  PLUGIN_MARKETPLACE="Szotasz/marveen-marketplace"
+  PLUGIN_ID="slack-channel@marveen-marketplace"
+  PLUGIN_SHORT="slack-channel"
 fi
 
 echo -e "  ${CHANNEL_PROVIDER} plugin telepites..."
@@ -681,6 +688,16 @@ else
     echo -e "  ${BLUE}claude plugin install ${PLUGIN_ID}${NC}"
     echo ""
   fi
+fi
+
+# Enable plugin at project scope so --channels can boot-time activate it
+cd "$INSTALL_DIR"
+if claude plugin enable "$PLUGIN_SHORT@marveen-marketplace" --scope project 2>/dev/null || \
+   claude plugin enable "$PLUGIN_ID" --scope project 2>/dev/null; then
+  ok "${CHANNEL_PROVIDER} plugin project-scope-ban engedelyezve"
+else
+  warn "Plugin project-scope enable sikertelen. Futtasd kezzel:"
+  echo -e "  ${DIM}cd $INSTALL_DIR && claude plugin enable ${PLUGIN_ID} --scope project${NC}"
 fi
 
 # skill-factory telepitese (self-learning meta-skill)

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -253,8 +253,13 @@ else
   echo -e "${DIM}  Az AI asszisztensed Slack-en kommunikal veled.${NC}"
   echo -e "${DIM}  1. Hozz letre egy Slack App-ot: api.slack.com/apps${NC}"
   echo -e "${DIM}  2. Engedeld a Socket Mode-ot${NC}"
-  echo -e "${DIM}  3. Adj hozza scope-okat: chat:write, channels:read, files:write${NC}"
-  echo -e "${DIM}  4. Installald a workspace-be${NC}"
+  echo -e "${DIM}  3. OAuth & Permissions > Bot Token Scopes:${NC}"
+  echo -e "${DIM}     app_mentions:read, channels:history, channels:join,${NC}"
+  echo -e "${DIM}     channels:read, chat:write, files:read, files:write,${NC}"
+  echo -e "${DIM}     groups:history, im:history, reactions:write, users:read${NC}"
+  echo -e "${DIM}  4. Event Subscriptions > Bot Events:${NC}"
+  echo -e "${DIM}     app_mention, message.channels, message.groups, message.im${NC}"
+  echo -e "${DIM}  5. Installald a workspace-be${NC}"
   echo ""
   read -p "  Bot Token (xoxb-...): " SLACK_BOT_TOKEN
   read -p "  App-Level Token (xapp-...): " SLACK_APP_TOKEN
@@ -448,7 +453,7 @@ SLACKENVEOF
 {
   "dmPolicy": "pairing",
   "allowFrom": [],
-  "groups": {},
+  "channels": {},
   "pending": {}
 }
 ACCESSEOF
@@ -459,26 +464,38 @@ fi
 if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   PLUGIN_MARKETPLACE="anthropics/claude-plugins-official"
   PLUGIN_ID="telegram@claude-plugins-official"
+  PLUGIN_SHORT="telegram"
 else
-  PLUGIN_MARKETPLACE="jeremylongshore/claude-code-slack-channel"
-  PLUGIN_ID="slack@jeremylongshore/claude-code-slack-channel"
+  PLUGIN_MARKETPLACE="Szotasz/marveen-marketplace"
+  PLUGIN_ID="slack-channel@marveen-marketplace"
+  PLUGIN_SHORT="slack-channel"
 fi
 
 echo -e "  ${CHANNEL_PROVIDER} plugin telepites..."
 claude plugin marketplace add "$PLUGIN_MARKETPLACE" 2>/dev/null || true
 if claude plugin install "$PLUGIN_ID" 2>/dev/null; then
-  echo -e "  ${GREEN}✓${NC} ${CHANNEL_PROVIDER} plugin telepítve"
+  ok "${CHANNEL_PROVIDER} plugin telepitve"
 else
   echo -e "  ${ORANGE}Elso probalkozas sikertelen, ujraprobalok...${NC}"
   sleep 2
   if claude plugin install "$PLUGIN_ID" 2>/dev/null; then
-    echo -e "  ${GREEN}✓${NC} ${CHANNEL_PROVIDER} plugin telepítve (masodik próbálkozással)"
+    ok "${CHANNEL_PROVIDER} plugin telepitve (masodik probalkozassal)"
   else
     echo -e "  ${RED}✗${NC} ${CHANNEL_PROVIDER} plugin telepites sikertelen."
     echo -e "  ${BOLD}Futtasd kesobb kezzel:${NC}"
     echo -e "  ${BLUE}claude plugin install ${PLUGIN_ID}${NC}"
     echo ""
   fi
+fi
+
+# Enable plugin at project scope so --channels can boot-time activate it
+cd "$INSTALL_DIR"
+if claude plugin enable "$PLUGIN_SHORT@marveen-marketplace" --scope project 2>/dev/null || \
+   claude plugin enable "$PLUGIN_ID" --scope project 2>/dev/null; then
+  ok "${CHANNEL_PROVIDER} plugin project-scope-ban engedelyezve"
+else
+  warn "Plugin project-scope enable sikertelen. Futtasd kezzel:"
+  echo -e "  ${DIM}cd $INSTALL_DIR && claude plugin enable ${PLUGIN_ID} --scope project${NC}"
 fi
 
 # Install skill-factory (self-learning meta-skill)
@@ -690,7 +707,7 @@ cat > "$PLIST_DIR/${DASHBOARD_PLIST}.plist" << PLISTEOF
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <string>${HOME}/.local/bin:/opt/homebrew/bin:${HOME}/.bun/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>
     <string>${HOME}</string>
   </dict>
@@ -725,7 +742,7 @@ cat > "$PLIST_DIR/${CHANNELS_PLIST}.plist" << PLISTEOF
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>/opt/homebrew/bin:${HOME}/.bun/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <string>${HOME}/.local/bin:/opt/homebrew/bin:${HOME}/.bun/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>
     <string>${HOME}</string>
     <key>USER</key>

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -30,7 +30,7 @@ SESSION="${MAIN_AGENT_ID:-marveen}-channels"
 
 # Resolve plugin ID from provider
 case "$CHANNEL_PROVIDER" in
-  slack)  PLUGIN_ID="slack@jeremylongshore/claude-code-slack-channel" ;;
+  slack)  PLUGIN_ID="slack-channel@marveen-marketplace" ;;
   *)      PLUGIN_ID="telegram@claude-plugins-official" ;;
 esac
 
@@ -54,20 +54,12 @@ $TMUX kill-session -t "$SESSION" 2>/dev/null
 
 # Tmux session indítás
 #
-# --continue csak akkor mukodik ha mar van mentett session log a
-# .claude/projects/<this-cwd>/*.jsonl alatt. Friss telepitesnel nincs ->
-# Claude Code "No conversation found to continue" hibaval kilep, a launchd
-# tight-loopban ujraindit. Ezert csak akkor adjuk meg, ha latjuk hogy van
-# mentett session, kulonben szuretlenul indul (uj beszelgetes).
-PROJECT_KEY="$(echo "$INSTALL_DIR" | sed 's|/|-|g')"
-CLAUDE_PROJECT_DIR="$HOME/.claude/projects/${PROJECT_KEY}"
-CONTINUE_FLAG=""
-if [ -d "$CLAUDE_PROJECT_DIR" ] && ls "$CLAUDE_PROJECT_DIR"/*.jsonl >/dev/null 2>&1; then
-  CONTINUE_FLAG="--continue"
-fi
-
+# Always start a fresh conversation. --continue is intentionally omitted:
+# the cwd-based project dir may contain the user's own CLI sessions, and
+# resuming one of those loses the --channels activation state, causing
+# "Channel notifications skipped: server not in --channels list" errors.
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "$CLAUDE --dangerously-skip-permissions $CONTINUE_FLAG --channels plugin:${PLUGIN_ID}"
+  "$CLAUDE --dangerously-skip-permissions --channels plugin:${PLUGIN_ID}"
 
 # Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
 # kulonben a headless session orokre parkolna a prompton es a Telegram plugin


### PR DESCRIPTION
## Summary

Fixes all 6 chained bugs reported in #156 that made fresh Slack installs completely non-functional.

1. **Dashboard plist PATH** -- added `~/.local/bin` so `claude` CLI is found at boot
2. **Slack plugin marketplace** -- switched from `jeremylongshore/claude-code-slack-channel` (SHA-based refs that fail `git clone --branch`) to `Szotasz/marveen-marketplace` (branch-based refs)
3. **Slack `access.json`** -- fixed field name: `"channels": {}` instead of `"groups": {}`
4. **Slack bot scopes** -- wizard now shows complete scope list (11 scopes + 4 event subscriptions)
5. **`--continue` flag removed** -- channels.sh always starts fresh to avoid resuming user CLI sessions that lack `--channels` state
6. **Project-scope plugin enable** -- automatic `claude plugin enable --scope project` after install

## Test plan
- [ ] `bash -n install-macos.sh && bash -n install-linux.sh && bash -n scripts/channels.sh`
- [ ] Fresh Slack install on macOS: verify access.json has `channels` field
- [ ] Verify channels.sh starts without `--continue` flag
- [ ] Verify plugin enable runs with `--scope project`
- [ ] Verify dashboard plist PATH includes `~/.local/bin`

Fixes #156

Generated with [Claude Code](https://claude.com/claude-code)