### PR TITLE
docs(avatar): bot profile pic setup guide + BotFather instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ A Csapat oldalon hozz létre új ágenseket. Mindegyik:
 - Saját utasítások (CLAUDE.md)
 - Saját memória és skillek
 
+### Telegram bot profilkép
+
+A telepítő automatikusan generál egy pixel-art avatart és Telegramon elküldi neked a beállítási utasításokkal. Ha egyedi képet szeretnél:
+
+1. Tedd a fájlt `agents/<AGENT_NEVE>/avatar.png` alá (png/jpg/jpeg/webp)
+2. Indítsd újra a szolgáltatást (`./scripts/stop.sh && ./scripts/start.sh`)
+3. Az install-flow újra elküldi az avatart a Telegram chatbe
+
+**Beállítás a Telegram botodra:**
+1. Nyisd meg a [@BotFather](https://t.me/BotFather) chatet
+2. Küld a `/setuserpic` parancsot
+3. Válaszd ki a botodat a listából
+4. Küldd be a kapott képet
+
+A dashboardon (Csapat oldal) is cserélhetsz avatart: kattints a bot kártyájára, válassz a galériából vagy tölts fel sajátot -- a rendszer automatikusan elküldi a Telegram chatbe.
+
 ### Ütemezések
 Időzített feladatok és heartbeat monitorok beállítása:
 - Lista, napi idővonal és heti nézet

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -92,7 +92,7 @@ export async function sendWelcomeMessage(agentName: string, token: string): Prom
     // Send avatar if exists
     const avatarPath = findAvatarForAgent(agentName)
     if (avatarPath) {
-      await sendTelegramPhoto(token, chatId, avatarPath, '(allitsd be profilkepkent)')
+      await sendTelegramPhoto(token, chatId, avatarPath, 'Allitsd be profilkepkent: nyisd meg @BotFather chatet, /setuserpic, valaszd ki a botodat, kuldd be ezt a kepet.')
     }
     logger.info({ agentName }, 'Welcome message sent via Telegram')
   } catch (err) {
@@ -119,7 +119,7 @@ export async function sendMarveenAvatarChange(avatarPath: string): Promise<void>
     ]
     const msg = messages[Math.floor(Math.random() * messages.length)]
     await sendTelegramMessage(token, chatId, msg)
-    await sendTelegramPhoto(token, chatId, avatarPath, '(allitsd be profilkepkent)')
+    await sendTelegramPhoto(token, chatId, avatarPath, 'Allitsd be profilkepkent: nyisd meg @BotFather chatet, /setuserpic, valaszd ki a botodat, kuldd be ezt a kepet.')
     logger.info('Marveen avatar change message sent')
   } catch (err) {
     logger.warn({ err }, 'Failed to send Marveen avatar change message')
@@ -142,7 +142,7 @@ export async function sendAvatarChangeMessage(agentName: string, avatarPath: str
     ]
     const msg = messages[Math.floor(Math.random() * messages.length)]
     await sendTelegramMessage(token, chatId, msg)
-    await sendTelegramPhoto(token, chatId, avatarPath, '(allitsd be profilkepkent)')
+    await sendTelegramPhoto(token, chatId, avatarPath, 'Allitsd be profilkepkent: nyisd meg @BotFather chatet, /setuserpic, valaszd ki a botodat, kuldd be ezt a kepet.')
     logger.info({ agentName }, 'Avatar change message sent via Telegram')
   } catch (err) {
     logger.warn({ err, agentName }, 'Failed to send avatar change message')


### PR DESCRIPTION
## Summary
- README-be uj "Telegram bot profilkep" szekció: hogyan allitsd be egyedi avatart, BotFather /setuserpic lepesek, dashboard galeria
- Telegram avatar caption bovitve: a korabbi "(allitsd be profilkepkent)" hint helyett explicit BotFather utasitas leirva (3 helyen: welcome message, Marveen avatar change, agent avatar change)

Kanban: 9958D929

## Test plan
- [ ] Build OK (verified)
- [ ] README szekció olvasható
- [ ] Avatar caption szoveg helyes a sendWelcomeMessage, sendMarveenAvatarChange, sendAvatarChangeMessage-ben

🤖 Generated with [Claude Code](https://claude.com/claude-code)