### PR TITLE
feat(dashboard): avatar upload with drag&drop + Telegram notify

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1261,6 +1261,79 @@ document.getElementById('avatarChangeBtn').addEventListener('click', () => {
   }
 })
 
+// === Avatar file upload ===
+;(() => {
+  const zone = document.getElementById('avatarUploadZone')
+  const fileInput = document.getElementById('avatarFileInput')
+  const content = document.getElementById('avatarUploadContent')
+  const preview = document.getElementById('avatarUploadPreview')
+  const previewImg = document.getElementById('avatarPreviewImg')
+  const clearBtn = document.getElementById('avatarPreviewClear')
+  const MAX_SIZE = 1024 * 1024
+
+  zone.addEventListener('click', (e) => {
+    if (e.target === clearBtn || clearBtn.contains(e.target)) return
+    fileInput.click()
+  })
+  zone.addEventListener('dragover', (e) => { e.preventDefault(); zone.classList.add('drag-over') })
+  zone.addEventListener('dragleave', () => zone.classList.remove('drag-over'))
+  zone.addEventListener('drop', (e) => {
+    e.preventDefault()
+    zone.classList.remove('drag-over')
+    const file = e.dataTransfer.files[0]
+    if (file) handleAvatarFile(file)
+  })
+  fileInput.addEventListener('change', () => {
+    if (fileInput.files[0]) handleAvatarFile(fileInput.files[0])
+  })
+  clearBtn.addEventListener('click', (e) => {
+    e.stopPropagation()
+    resetAvatarUpload()
+  })
+
+  function resetAvatarUpload() {
+    fileInput.value = ''
+    content.hidden = false
+    preview.hidden = true
+  }
+
+  async function handleAvatarFile(file) {
+    if (!file.type.match(/^image\/(png|jpe?g|webp)$/)) {
+      showToast('Csak png/jpg/webp formatum')
+      return
+    }
+    if (file.size > MAX_SIZE) {
+      showToast('Max 1 MB meretu kep')
+      return
+    }
+    previewImg.src = URL.createObjectURL(file)
+    content.hidden = true
+    preview.hidden = false
+    await uploadAvatarFile(file)
+  }
+
+  async function uploadAvatarFile(file) {
+    if (!currentAgent) return
+    const isMarveen = currentAgent.role === 'main'
+    const endpoint = isMarveen ? '/api/marveen/avatar' : `/api/agents/${encodeURIComponent(currentAgent.name)}/avatar`
+    const form = new FormData()
+    form.append('avatar', file, file.name)
+    try {
+      const res = await fetch(endpoint, { method: 'POST', body: form })
+      if (!res.ok) throw new Error()
+      showToast('Avatar feltoltve, kep elkuldve Telegramon')
+      const imgUrl = isMarveen ? `/api/marveen/avatar?t=${Date.now()}` : `/api/agents/${encodeURIComponent(currentAgent.name)}/avatar?t=${Date.now()}`
+      document.getElementById('agentDetailAvatar').innerHTML = `<img src="${imgUrl}" alt="">`
+      document.getElementById('detailAvatarGallery').hidden = true
+      resetAvatarUpload()
+      loadAgents()
+    } catch {
+      showToast('Hiba a feltoltes soran')
+      resetAvatarUpload()
+    }
+  }
+})()
+
 // === Process control ===
 function updateProcessControl(agent) {
   const running = agent.running || false

--- a/web/index.html
+++ b/web/index.html
@@ -1166,6 +1166,18 @@
           <div class="detail-avatar-gallery" id="detailAvatarGallery" hidden>
             <label class="form-label-sm">Válassz új avatart</label>
             <div class="avatar-grid" id="detailAvatarGrid"></div>
+            <div class="avatar-upload-divider"><span>vagy</span></div>
+            <div class="avatar-upload-zone" id="avatarUploadZone">
+              <input type="file" id="avatarFileInput" accept=".png,.jpg,.jpeg,.webp" hidden>
+              <div class="avatar-upload-content" id="avatarUploadContent">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                <span>Kep feltoltese (max 1 MB)</span>
+              </div>
+              <div class="avatar-upload-preview" id="avatarUploadPreview" hidden>
+                <img id="avatarPreviewImg" alt="">
+                <button class="avatar-preview-clear" id="avatarPreviewClear" title="Torles">&times;</button>
+              </div>
+            </div>
           </div>
           <div class="agent-overview-grid">
             <div class="agent-overview-item">

--- a/web/style.css
+++ b/web/style.css
@@ -1536,6 +1536,71 @@ main {
   border-radius: var(--radius);
 }
 
+.avatar-upload-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 12px 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.avatar-upload-divider::before,
+.avatar-upload-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.avatar-upload-zone {
+  border: 2px dashed var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.avatar-upload-zone:hover,
+.avatar-upload-zone.drag-over {
+  border-color: var(--accent);
+  background: rgba(217,119,87,0.05);
+}
+.avatar-upload-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.avatar-upload-preview {
+  position: relative;
+  display: inline-block;
+}
+.avatar-upload-preview img {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.avatar-preview-clear {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--danger);
+  color: #fff;
+  border: none;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* === Form === */
 .form-group { margin-bottom: 18px; }
 


### PR DESCRIPTION
## Summary
- Dashboard agent detail oldal: avatar galeria alatti file upload zona (drag&drop + file picker)
- Tamogatott formatumok: png/jpg/jpeg/webp, max 1 MB
- Upload utan preview (kor alaku), aztan POST a meglevo backend endpoint-ra
- Backend automatikusan trigger-eli a Telegram uzenetet BotFather utasitasokkal (PR #158)
- Marveen es sub-agentek egyarant tamogatva (kulon endpoint-ok, kulon uzenetek)

Kanban: 08AAA2BE

## Test plan
- [ ] Build OK (verified)
- [ ] Avatar galeria toggle mukodik (avatarChangeBtn)
- [ ] Drag&drop kep a zona-ra: preview megjelenik, upload elindul
- [ ] File picker: kep valasztas, preview, upload
- [ ] 1 MB feletti fajl: hibauzenet toast
- [ ] Nem-kep fajl: hibauzenet toast
- [ ] Upload utan: agent avatar frissul a dashboard-on + Telegram uzenet megy
- [ ] Marveen avatar upload: /api/marveen/avatar endpoint-ot hasznalja
- [ ] Clear gomb a preview-n: reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)