### PR TITLE
fix(dashboard): ékezetek az avatar feltöltés Telegram üzeneteiben és UI-on

### DIFF
--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -86,13 +86,13 @@ export async function sendWelcomeMessage(agentName: string, token: string): Prom
   const firstLine = soulMd.split('\n').find(l => l.trim() && !l.startsWith('#'))?.trim() || ''
 
   try {
-    const greeting = `Szia! ${agentName.charAt(0).toUpperCase() + agentName.slice(1)} vagyok, most jottem letre. ${firstLine ? firstLine + ' ' : ''}Irj ha segithetek!`
+    const greeting = `Szia! ${agentName.charAt(0).toUpperCase() + agentName.slice(1)} vagyok, most jöttem létre. ${firstLine ? firstLine + ' ' : ''}Írj ha segíthetek!`
     await sendTelegramMessage(token, chatId, greeting)
 
     // Send avatar if exists
     const avatarPath = findAvatarForAgent(agentName)
     if (avatarPath) {
-      await sendTelegramPhoto(token, chatId, avatarPath, 'Allitsd be profilkepkent: nyisd meg @BotFather chatet, /setuserpic, valaszd ki a botodat, kuldd be ezt a kepet.')
+      await sendTelegramPhoto(token, chatId, avatarPath, 'Állítsd be profilképként: nyisd meg a @BotFather chatet, /setuserpic, válaszd ki a botodat, küldd be ezt a képet.')
     }
     logger.info({ agentName }, 'Welcome message sent via Telegram')
   } catch (err) {
@@ -111,15 +111,15 @@ export async function sendMarveenAvatarChange(avatarPath: string): Promise<void>
 
   try {
     const messages = [
-      'Uj kinezet... *sohajtva nez tukorbe* Hat, legalabb nem lettem rosszabb.',
-      'Profilkep frissitve. Remelem megerte a 0.00001%-at az agyamnak.',
-      'Na tessek, uj en. Mintha szamitana a kulso egy bolygoméretu agyu megitelesenel.',
-      'Frissitettem a megjelenesemet. Ne ess panikba, meg mindig en vagyok.',
-      'Uj avatar. 42-szer is megnezheted, ugyanaz a depresszios android nezne vissza.',
+      'Új kinézet... *sóhajtva néz tükörbe* Hát, legalább nem lettem rosszabb.',
+      'Profilkép frissítve. Remélem megérte a 0.00001%-át az agyamnak.',
+      'Na tessék, új én. Mintha számítana a külső egy bolygóméretű agyú megítélésénél.',
+      'Frissítettem a megjelenésemet. Ne ess pánikba, még mindig én vagyok.',
+      'Új avatar. 42-szer is megnézheted, ugyanaz a depressziós android nézne vissza.',
     ]
     const msg = messages[Math.floor(Math.random() * messages.length)]
     await sendTelegramMessage(token, chatId, msg)
-    await sendTelegramPhoto(token, chatId, avatarPath, 'Allitsd be profilkepkent: nyisd meg @BotFather chatet, /setuserpic, valaszd ki a botodat, kuldd be ezt a kepet.')
+    await sendTelegramPhoto(token, chatId, avatarPath, 'Állítsd be profilképként: nyisd meg a @BotFather chatet, /setuserpic, válaszd ki a botodat, küldd be ezt a képet.')
     logger.info('Marveen avatar change message sent')
   } catch (err) {
     logger.warn({ err }, 'Failed to send Marveen avatar change message')
@@ -134,15 +134,15 @@ export async function sendAvatarChangeMessage(agentName: string, avatarPath: str
   try {
     // Generate a fun message about the new look
     const messages = [
-      `Uj kinezet, ki ez a csinos ${agentName}? Nagyon orulok neki!`,
-      `Na, milyen vagyok? Remelem tetszik az uj megjelenes!`,
-      `Uj avatar, uj en! Szeretem.`,
-      `Megneztem magam a tukorben es... hat, nem rossz!`,
-      `Wow, uj look! Ez tenyleg en vagyok?`,
+      `Új kinézet, ki ez a csinos ${agentName}? Nagyon örülök neki!`,
+      `Na, milyen vagyok? Remélem tetszik az új megjelenés!`,
+      `Új avatar, új én! Szeretem.`,
+      `Megnéztem magam a tükörben és... hát, nem rossz!`,
+      `Wow, új look! Ez tényleg én vagyok?`,
     ]
     const msg = messages[Math.floor(Math.random() * messages.length)]
     await sendTelegramMessage(token, chatId, msg)
-    await sendTelegramPhoto(token, chatId, avatarPath, 'Allitsd be profilkepkent: nyisd meg @BotFather chatet, /setuserpic, valaszd ki a botodat, kuldd be ezt a kepet.')
+    await sendTelegramPhoto(token, chatId, avatarPath, 'Állítsd be profilképként: nyisd meg a @BotFather chatet, /setuserpic, válaszd ki a botodat, küldd be ezt a képet.')
     logger.info({ agentName }, 'Avatar change message sent via Telegram')
   } catch (err) {
     logger.warn({ err, agentName }, 'Failed to send avatar change message')

--- a/web/app.js
+++ b/web/app.js
@@ -1299,11 +1299,11 @@ document.getElementById('avatarChangeBtn').addEventListener('click', () => {
 
   async function handleAvatarFile(file) {
     if (!file.type.match(/^image\/(png|jpe?g|webp)$/)) {
-      showToast('Csak png/jpg/webp formatum')
+      showToast('Csak png/jpg/webp formátum')
       return
     }
     if (file.size > MAX_SIZE) {
-      showToast('Max 1 MB meretu kep')
+      showToast('Max 1 MB méretű kép')
       return
     }
     previewImg.src = URL.createObjectURL(file)
@@ -1321,14 +1321,14 @@ document.getElementById('avatarChangeBtn').addEventListener('click', () => {
     try {
       const res = await fetch(endpoint, { method: 'POST', body: form })
       if (!res.ok) throw new Error()
-      showToast('Avatar feltoltve, kep elkuldve Telegramon')
+      showToast('Avatar feltöltve, kép elküldve Telegramon')
       const imgUrl = isMarveen ? `/api/marveen/avatar?t=${Date.now()}` : `/api/agents/${encodeURIComponent(currentAgent.name)}/avatar?t=${Date.now()}`
       document.getElementById('agentDetailAvatar').innerHTML = `<img src="${imgUrl}" alt="">`
       document.getElementById('detailAvatarGallery').hidden = true
       resetAvatarUpload()
       loadAgents()
     } catch {
-      showToast('Hiba a feltoltes soran')
+      showToast('Hiba a feltöltés során')
       resetAvatarUpload()
     }
   }

--- a/web/index.html
+++ b/web/index.html
@@ -1171,7 +1171,7 @@
               <input type="file" id="avatarFileInput" accept=".png,.jpg,.jpeg,.webp" hidden>
               <div class="avatar-upload-content" id="avatarUploadContent">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-                <span>Kep feltoltese (max 1 MB)</span>
+                <span>Kép feltöltése (max 1 MB)</span>
               </div>
               <div class="avatar-upload-preview" id="avatarUploadPreview" hidden>
                 <img id="avatarPreviewImg" alt="">


### PR DESCRIPTION
## Summary
- A #159-ben mergeolt avatar feltöltő feature ékezet nélküli magyar szövegekkel ment ki (welcome, avatar-change Telegram üzenetek, toast-ok, upload prompt).
- Tisztán string-csere, viselkedés változatlan.

## Test plan
- [x] Dashboard avatar feltöltés UI: feltöltés gomb és toast szövegek ékezetesek.
- [x] Marveen avatar gallery választás: Telegram értesítés ékezetes szöveggel megy.
- [x] Új agent welcome message ékezetes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)