### PR TITLE
feat(channels): add Discord as third channel provider

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -30,8 +30,9 @@ SESSION="${MAIN_AGENT_ID:-marveen}-channels"
 
 # Resolve plugin ID from provider
 case "$CHANNEL_PROVIDER" in
-  slack)  PLUGIN_ID="slack-channel@marveen-marketplace" ;;
-  *)      PLUGIN_ID="telegram@claude-plugins-official" ;;
+  slack)    PLUGIN_ID="slack-channel@marveen-marketplace" ;;
+  discord)  PLUGIN_ID="discord@claude-plugins-official" ;;
+  *)        PLUGIN_ID="telegram@claude-plugins-official" ;;
 esac
 
 # Extra safety net for existing installs whose tmux server already has a
@@ -40,7 +41,8 @@ esac
 # ~/.claude/channels/<provider>/.env via the plugin's own bootstrap.
 command -v tmux >/dev/null 2>&1 && tmux set-environment -g -u TELEGRAM_BOT_TOKEN 2>/dev/null || true
 command -v tmux >/dev/null 2>&1 && tmux set-environment -g -u SLACK_BOT_TOKEN 2>/dev/null || true
-unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN
+command -v tmux >/dev/null 2>&1 && tmux set-environment -g -u DISCORD_BOT_TOKEN 2>/dev/null || true
+unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN
 
 export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
 

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -5,7 +5,7 @@ import { homedir } from 'node:os'
 import { logger } from './logger.js'
 import { formatForTelegram, splitMessage } from './format.js'
 
-export type ChannelProviderType = 'telegram' | 'slack'
+export type ChannelProviderType = 'telegram' | 'slack' | 'discord'
 
 export interface ChannelProvider {
   readonly type: ChannelProviderType
@@ -223,6 +223,88 @@ const slackProvider: ChannelProvider = {
   splitMessage: (text) => splitMessage(text, SLACK_MAX_MESSAGE_LENGTH),
 }
 
+// -- Discord implementation --
+
+const DISCORD_MAX_MESSAGE_LENGTH = 2000
+
+function formatForDiscord(text: string): string {
+  // Discord natively renders GFM markdown (bold, italic, code blocks, links).
+  // Only convert task-list checkboxes which Discord does not support.
+  let result = text
+  result = result.replace(/^- \[ \]/gm, '☐')
+  result = result.replace(/^- \[x\]/gm, '☑')
+  return result
+}
+
+const discordProvider: ChannelProvider = {
+  type: 'discord',
+  pluginId: 'discord@claude-plugins-official',
+  envKeys: ['DISCORD_BOT_TOKEN'],
+  stateDir: 'discord',
+  chatIdFormat: 'Discord channel ID (e.g. 1234567890123456789)',
+
+  async sendMessage(token, chatId, text) {
+    const resp = await fetch(`https://discord.com/api/v10/channels/${chatId}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bot ${token}`,
+      },
+      body: JSON.stringify({ content: text }),
+    })
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '')
+      throw new Error(`Discord API ${resp.status}: ${body.slice(0, 200)}`)
+    }
+  },
+
+  async sendPhoto(token, chatId, photoPath, caption) {
+    const fileData = readFileSync(photoPath)
+    const filename = photoPath.split('/').pop() || 'image.png'
+    const boundary = '----FormBoundary' + Date.now()
+    const parts: Buffer[] = []
+    const payloadJson = JSON.stringify({
+      content: caption || undefined,
+      attachments: [{ id: '0', filename }],
+    })
+    parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="payload_json"\r\nContent-Type: application/json\r\n\r\n${payloadJson}\r\n`))
+    parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="files[0]"; filename="${filename}"\r\nContent-Type: application/octet-stream\r\n\r\n`))
+    parts.push(fileData)
+    parts.push(Buffer.from(`\r\n--${boundary}--\r\n`))
+    const body = Buffer.concat(parts)
+    const resp = await fetch(`https://discord.com/api/v10/channels/${chatId}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+        'Authorization': `Bot ${token}`,
+      },
+      body,
+    })
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '')
+      throw new Error(`Discord sendPhoto ${resp.status}: ${text.slice(0, 200)}`)
+    }
+  },
+
+  async validateToken(token) {
+    try {
+      const resp = await fetch('https://discord.com/api/v10/users/@me', {
+        headers: { 'Authorization': `Bot ${token}` },
+      })
+      const data = await resp.json() as { id?: string; username?: string }
+      if (resp.ok && data.username) {
+        return { ok: true, botName: data.username }
+      }
+      return { ok: false, error: 'Invalid bot token' }
+    } catch {
+      return { ok: false, error: 'Failed to connect to Discord API' }
+    }
+  },
+
+  formatMessage: formatForDiscord,
+  splitMessage: (text) => splitMessage(text, DISCORD_MAX_MESSAGE_LENGTH),
+}
+
 // -- Slack App manifest --
 
 const SLACK_BOT_SCOPES = [
@@ -291,11 +373,13 @@ export function getSlackAppSetupInstructions(): string[] {
 
 export function getChannelToken(provider: ChannelProviderType, env: Record<string, string>): string {
   if (provider === 'slack') return env['SLACK_BOT_TOKEN'] ?? ''
+  if (provider === 'discord') return env['DISCORD_BOT_TOKEN'] ?? ''
   return env['TELEGRAM_BOT_TOKEN'] ?? ''
 }
 
 export function getChannelChatId(provider: ChannelProviderType, env: Record<string, string>): string {
   if (provider === 'slack') return env['SLACK_CHANNEL_ID'] ?? ''
+  if (provider === 'discord') return env['DISCORD_CHANNEL_ID'] ?? ''
   return env['ALLOWED_CHAT_ID'] ?? ''
 }
 
@@ -304,6 +388,7 @@ export function getChannelChatId(provider: ChannelProviderType, env: Record<stri
 const providers: Record<ChannelProviderType, ChannelProvider> = {
   telegram: telegramProvider,
   slack: slackProvider,
+  discord: discordProvider,
 }
 
 export function getProvider(type: ChannelProviderType): ChannelProvider {
@@ -312,6 +397,7 @@ export function getProvider(type: ChannelProviderType): ChannelProvider {
 
 export function getProviderType(envValue: string | undefined): ChannelProviderType {
   if (envValue === 'slack') return 'slack'
+  if (envValue === 'discord') return 'discord'
   return 'telegram'
 }
 
@@ -319,7 +405,8 @@ export function channelStateDir(provider: ChannelProviderType, agentDir?: string
   const base = agentDir
     ? join(agentDir, '.claude', 'channels')
     : join(homedir(), '.claude', 'channels')
-  return join(base, provider === 'slack' ? 'slack' : 'telegram')
+  const subdir = provider === 'slack' ? 'slack' : provider === 'discord' ? 'discord' : 'telegram'
+  return join(base, subdir)
 }
 
 export function readChannelToken(provider: ChannelProviderType, envFilePath: string): string | null {
@@ -330,7 +417,7 @@ export function readChannelToken(provider: ChannelProviderType, envFilePath: str
   } catch {
     return null
   }
-  const key = provider === 'slack' ? 'SLACK_BOT_TOKEN' : 'TELEGRAM_BOT_TOKEN'
+  const key = provider === 'slack' ? 'SLACK_BOT_TOKEN' : provider === 'discord' ? 'DISCORD_BOT_TOKEN' : 'TELEGRAM_BOT_TOKEN'
   const match = content.match(new RegExp(`${key}=(.+)`))
   return match ? match[1].trim() : null
 }

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -23,7 +23,7 @@ const CLAUDE = resolveFromPath('claude')
 
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
-  if (perAgent === 'slack' || perAgent === 'telegram') return perAgent
+  if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord') return perAgent
   return CHANNEL_PROVIDER
 }
 
@@ -104,8 +104,8 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     const encodedProject = dir.replace(/\//g, '-')
     const hasPriorSession = existsSync(join(projectsRoot, encodedProject))
     const continueFlag = hasPriorSession ? '--continue ' : ''
-    const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : 'TELEGRAM_STATE_DIR'
-    const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN'
+    const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : 'TELEGRAM_STATE_DIR'
+    const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN'
     // Slack plugin is third-party; its "not on approved allowlist" check is
     // bypassed via `allowedChannelPlugins` in /Library/Application Support/ClaudeCode/managed-settings.json.
     const auditLogEnv = agentProvider === 'slack' ? ` && export SLACK_AUDIT_LOG="${agentChannelDir}/audit.jsonl"` : ''
@@ -168,7 +168,7 @@ export function stopAgentProcess(name: string): { ok: boolean; error?: string } 
           try { process.kill(pid, 'SIGTERM') } catch { /* already gone */ }
         }
       }
-      const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : 'TELEGRAM_STATE_DIR'
+      const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : 'TELEGRAM_STATE_DIR'
       execFileSync('/usr/bin/pkill', ['-f', `${stateEnvVar}=${chanDir}`], { timeout: 3000 })
     } catch { /* pkill returns non-zero if no match -- fine */ }
     logger.info({ name, session }, 'Agent tmux session stopped')

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -23,7 +23,7 @@ const CLAUDE = resolveFromPath('claude')
 
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
-  if (perAgent === 'slack' || perAgent === 'telegram') return perAgent
+  if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord') return perAgent
   return CHANNEL_PROVIDER
 }
 
@@ -77,6 +77,8 @@ function hasChannelPluginAlive(claudePid: number, providerType: ChannelProviderT
       if (providerType === 'telegram') {
         if (cmd.includes('/telegram/') && cmd.includes('bun')) return true
         if (/\bbun\b/.test(cmd) && cmd.includes('server.ts')) return true
+      } else if (providerType === 'discord') {
+        if (cmd.includes('discord') && (cmd.includes('node') || cmd.includes('bun'))) return true
       } else {
         if (cmd.includes('slack') && cmd.includes('node')) return true
         if (cmd.includes('slack-channel') && (cmd.includes('bun') || cmd.includes('node'))) return true
@@ -98,7 +100,9 @@ function hasChannelPluginAlive(claudePid: number, providerType: ChannelProviderT
           const cmd = cmdOf.get(pid) || ''
           const isRelevant = providerType === 'telegram'
             ? (cmd.includes('bun') || cmd.includes('server.ts') || cmd.includes('telegram'))
-            : (cmd.includes('node') || cmd.includes('slack'))
+            : providerType === 'discord'
+              ? (cmd.includes('discord') && (cmd.includes('node') || cmd.includes('bun')))
+              : (cmd.includes('node') || cmd.includes('slack'))
           if (isRelevant) {
             logger.debug({ claudePid, orphanPid: pid, agentName, providerType }, 'Channel plugin alive via bot.pid (reparented)')
             return true
@@ -117,6 +121,20 @@ function hasChannelPluginAlive(claudePid: number, providerType: ChannelProviderT
           try {
             process.kill(pid, 0)
             logger.debug({ claudePid, slackPid: pid, agentName }, 'Slack plugin alive via process scan')
+            return true
+          } catch { /* gone */ }
+        }
+      }
+    }
+
+    // Discord: same heuristic -- no bot.pid, check for discord node/bun process.
+    if (providerType === 'discord') {
+      for (const [pid, cmd] of cmdOf) {
+        if (seen.has(pid)) continue
+        if (cmd.includes('discord') && (cmd.includes('node') || cmd.includes('bun'))) {
+          try {
+            process.kill(pid, 0)
+            logger.debug({ claudePid, discordPid: pid, agentName }, 'Discord plugin alive via process scan')
             return true
           } catch { /* gone */ }
         }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -35,6 +35,7 @@ import {
 } from '../agent-team.js'
 import {
   readAgentTelegramConfig,
+  readAgentDiscordConfig,
   readMarveenTelegramConfig,
   sendAvatarChangeMessage,
   sendWelcomeMessage,
@@ -78,7 +79,7 @@ import { parseMultipart } from '../multipart.js'
 import { readBody, json, serveFile } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
 
-const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack'])
+const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord'])
 
 function parseChannelProvider(raw: string): ChannelProviderType | null {
   if (VALID_PROVIDERS.has(raw as ChannelProviderType)) return raw as ChannelProviderType
@@ -88,7 +89,7 @@ function parseChannelProvider(raw: string): ChannelProviderType | null {
 // Match both new /channels/:provider/ and legacy /telegram/ URL patterns.
 // Returns [agentName, provider] or null. Legacy routes always resolve to 'telegram'.
 function matchChannelRoute(path: string, suffix: string): [string, ChannelProviderType] | null {
-  const newPattern = new RegExp(`^/api/agents/([^/]+)/channels/(telegram|slack)${suffix}$`)
+  const newPattern = new RegExp(`^/api/agents/([^/]+)/channels/(telegram|slack|discord)${suffix}$`)
   const newMatch = path.match(newPattern)
   if (newMatch) {
     const provider = parseChannelProvider(newMatch[2])
@@ -152,10 +153,15 @@ export function setAgentEnabledPlugins(name: string, provider: ChannelProviderTy
     try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
   }
   const plugins = (existing.enabledPlugins ?? {}) as Record<string, boolean>
-  if (provider === 'slack') {
+  if (provider === 'discord') {
     plugins['telegram@claude-plugins-official'] = false
+    plugins['slack-channel@marveen-marketplace'] = false
+  } else if (provider === 'slack') {
+    plugins['telegram@claude-plugins-official'] = false
+    plugins['discord@claude-plugins-official'] = false
   } else {
     plugins['slack-channel@marveen-marketplace'] = false
+    plugins['discord@claude-plugins-official'] = false
   }
   existing.enabledPlugins = plugins
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
@@ -187,6 +193,7 @@ interface AgentSummary {
   team: TeamConfig
   hasTelegram: boolean
   telegramBotUsername?: string
+  hasDiscord: boolean
   status: 'configured' | 'draft'
   running: boolean
   session?: string
@@ -207,6 +214,7 @@ function getAgentSummary(name: string): AgentSummary {
   const claudeMd = readFileOr(join(configRoot, 'CLAUDE.md'), '')
   const soulMd = readFileOr(join(dir, 'SOUL.md'), '')
   const tg = readAgentTelegramConfig(name)
+  const dc = readAgentDiscordConfig(name)
   const hasClaudeMd = claudeMd.trim().length > 0
   const hasSoulMd = soulMd.trim().length > 0
 
@@ -221,6 +229,7 @@ function getAgentSummary(name: string): AgentSummary {
     team: readAgentTeam(name),
     hasTelegram: tg.hasTelegram,
     telegramBotUsername: tg.botUsername,
+    hasDiscord: dc.hasDiscord,
     status: hasClaudeMd && hasSoulMd ? 'configured' : 'draft',
     running: proc.running,
     session: proc.session,
@@ -814,7 +823,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   }
 
   // DELETE /api/agents/:name/channels/:provider/invites/:token (legacy: /telegram/invites/:token)
-  const inviteRevokeNewMatch = path.match(/^\/api\/agents\/([^/]+)\/channels\/(telegram|slack)\/invites\/(.+)$/)
+  const inviteRevokeNewMatch = path.match(/^\/api\/agents\/([^/]+)\/channels\/(telegram|slack|discord)\/invites\/(.+)$/)
   const inviteRevokeLegacyMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/invites\/(.+)$/)
   const inviteRevokeMatch = inviteRevokeNewMatch
     ? { name: decodeURIComponent(inviteRevokeNewMatch[1]), provider: inviteRevokeNewMatch[2] as ChannelProviderType, token: decodeURIComponent(inviteRevokeNewMatch[3]) }
@@ -835,7 +844,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   }
 
   // DELETE /api/agents/:name/channels/:provider/allowed/:type/:id (legacy: /telegram/allowed/:type/:id)
-  const allowedRemoveNewMatch = path.match(/^\/api\/agents\/([^/]+)\/channels\/(telegram|slack)\/allowed\/(user|group)\/(.+)$/)
+  const allowedRemoveNewMatch = path.match(/^\/api\/agents\/([^/]+)\/channels\/(telegram|slack|discord)\/allowed\/(user|group)\/(.+)$/)
   const allowedRemoveLegacyMatch = path.match(/^\/api\/agents\/([^/]+)\/telegram\/allowed\/(user|group)\/(.+)$/)
   const allowedRemoveMatch = allowedRemoveNewMatch
     ? { name: decodeURIComponent(allowedRemoveNewMatch[1]), provider: allowedRemoveNewMatch[2] as ChannelProviderType, kind: allowedRemoveNewMatch[3], id: decodeURIComponent(allowedRemoveNewMatch[4]) }

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -15,6 +15,15 @@ export function readAgentTelegramConfig(name: string): { hasTelegram: boolean; b
   return { hasTelegram: true }
 }
 
+export function readAgentDiscordConfig(name: string): { hasDiscord: boolean; botUsername?: string } {
+  const envPath = join(agentDir(name), '.claude', 'channels', 'discord', '.env')
+  if (!existsSync(envPath)) return { hasDiscord: false }
+  const content = readFileOr(envPath, '')
+  const tokenMatch = content.match(/DISCORD_BOT_TOKEN=(.+)/)
+  if (!tokenMatch || !tokenMatch[1].trim()) return { hasDiscord: false }
+  return { hasDiscord: true }
+}
+
 // Marveen's Telegram channel lives under the global ~/.claude path, not
 // under agents/marveen, because the main agent reuses the system Claude
 // Code channel install. Read it the same way the plugin does.

--- a/web/app.js
+++ b/web/app.js
@@ -1602,6 +1602,14 @@ function updateProviderUI() {
     if (slackGroup) slackGroup.hidden = true
     if (manifestBtnGroup) manifestBtnGroup.hidden = true
     if (smokeTestBtn) smokeTestBtn.hidden = true
+  } else if (currentChannelProvider === 'discord') {
+    if (title) title.textContent = 'Discord bot bekotese'
+    if (steps) steps.innerHTML = '<li>Menj a <strong>Discord Developer Portal</strong>-ra (discord.com/developers)</li><li>Hozz letre egy uj Application-t es Bot-ot</li><li>Masold be a Bot Token-t ide</li>'
+    if (label) label.textContent = 'Bot Token'
+    if (input) input.placeholder = 'MTIzNDU2Nzg5MDEyMzQ1Njc4OQ...'
+    if (slackGroup) slackGroup.hidden = true
+    if (manifestBtnGroup) manifestBtnGroup.hidden = true
+    if (smokeTestBtn) smokeTestBtn.hidden = true
   } else {
     if (title) title.textContent = 'Slack app bekötése'
     if (steps) steps.innerHTML = '<li>Hozz létre egy Slack App-ot, vagy használd a manifest gombot lent</li><li>Másold be a Bot Token-t (xoxb-...) és az App Token-t (xapp-...)</li>'

--- a/web/index.html
+++ b/web/index.html
@@ -1271,6 +1271,7 @@
             <select id="chProviderSelect" style="max-width:200px;">
               <option value="telegram">Telegram</option>
               <option value="slack">Slack</option>
+              <option value="discord">Discord</option>
             </select>
           </div>
           <div id="chNotConnected">


### PR DESCRIPTION
## Summary
- Full Discord channel provider alongside Telegram and Slack
- Discord API v10: sendMessage, sendPhoto (multipart), validateToken (/users/@me)
- formatMessage pass-through (Discord renders GFM natively, only checkbox conversion)
- splitMessage with 2000 char limit
- Route regexes, VALID_PROVIDERS, plugin enable/disable all support discord
- channel-monitor process detection for discord (node/bun heuristic + fallback)
- Token cleanup (DISCORD_BOT_TOKEN unset in channels.sh + agent-process.ts)
- Dashboard UI: Discord option in provider select + setup instructions
- AgentSummary includes hasDiscord field

Closes #162

## Test plan
- [ ] TypeScript build (0 errors confirmed locally)
- [ ] Dashboard: Discord option visible in provider select
- [ ] Discord bot token validation via /channels/discord/test endpoint
- [ ] Message sending to Discord channel
- [ ] Photo/attachment upload to Discord channel
- [ ] Agent start/stop with Discord provider
- [ ] channel-monitor detects Discord plugin crash + auto-recovery
- [ ] Verify Telegram/Slack still work unaffected


Generated with [Claude Code](https://claude.com/claude-code)