### PR TITLE
fix(channel): use pluginPaneId for tmux pane matching in reconnect

### DIFF
--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -10,6 +10,7 @@ export type ChannelProviderType = 'telegram' | 'slack'
 export interface ChannelProvider {
   readonly type: ChannelProviderType
   readonly pluginId: string
+  readonly pluginPaneId: string
   readonly envKeys: string[]
   readonly stateDir: string
   readonly chatIdFormat: string
@@ -51,6 +52,7 @@ function telegramHttpPost(token: string, method: string, body: string, contentTy
 const telegramProvider: ChannelProvider = {
   type: 'telegram',
   pluginId: 'telegram@claude-plugins-official',
+  pluginPaneId: 'plugin:telegram:telegram',
   envKeys: ['TELEGRAM_BOT_TOKEN'],
   stateDir: 'telegram',
   chatIdFormat: 'numeric (e.g. 1268077055)',
@@ -131,6 +133,7 @@ export function formatForSlackMrkdwn(text: string): string {
 const slackProvider: ChannelProvider = {
   type: 'slack',
   pluginId: 'slack-channel@marveen-marketplace',
+  pluginPaneId: 'plugin:slack-channel:marveen-marketplace',
   envKeys: ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN'],
   stateDir: 'slack',
   chatIdFormat: 'Slack channel/DM ID (e.g. C01234ABCDE)',

--- a/src/web/channel-health-monitor.ts
+++ b/src/web/channel-health-monitor.ts
@@ -32,8 +32,8 @@ function getBackoffMs(attempt: number): number {
   return BACKOFF_BASE_MS * Math.pow(BACKOFF_MULTIPLIER, attempt)
 }
 
-function isPluginFailedInPane(pane: string, pluginId: string): boolean {
-  if (!pane.includes(pluginId)) return false
+function isPluginFailedInPane(pane: string, pluginPaneId: string): boolean {
+  if (!pane.includes(pluginPaneId)) return false
   return PLUGIN_FAILED_RX.test(pane)
 }
 
@@ -72,7 +72,7 @@ function checkAgent(agentName: string, session: string): void {
   const providerType = resolveAgentProviderType(agentName)
   const provider = getProvider(providerType)
 
-  if (!isPluginFailedInPane(pane, provider.pluginId)) {
+  if (!isPluginFailedInPane(pane, provider.pluginPaneId)) {
     if (state) {
       logger.info({ agentName, provider: providerType }, 'channel-health-monitor: plugin recovered')
       reconnectState.delete(agentName)

--- a/src/web/channel-mcp-reconnect.ts
+++ b/src/web/channel-mcp-reconnect.ts
@@ -28,7 +28,7 @@ export function resolveAgentProviderType(agentName: string): ChannelProviderType
 
 function getPluginPattern(providerType: ChannelProviderType): RegExp {
   const provider = getProvider(providerType)
-  const escaped = provider.pluginId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const escaped = provider.pluginPaneId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   return new RegExp(escaped, 'i')
 }
 


### PR DESCRIPTION
## Summary
- PR #121 generalized channel reconnect but switched pane matching from the tmux-visible `pluginPaneId` to the internal `pluginId`, which never appears in tmux output
- Added `pluginPaneId` field to `ChannelProvider` interface (Telegram: `plugin:telegram:telegram`, Slack: `plugin:slack-channel:marveen-marketplace`)
- Updated `channel-health-monitor.ts` and `channel-mcp-reconnect.ts` to use `pluginPaneId` for pattern matching

## Root cause
The `pluginId` (e.g. `telegram@claude-plugins-official`) is an internal Claude Code identifier that never shows up in the tmux pane capture. The regex match always failed silently, so auto-reconnect never triggered. Users had to manually `/mcp` reconnect every time.

## Verified
Dashboard restarted with fix deployed. Logs confirm auto-detection and reconnect within 6 seconds:
```
14:35:39 WARN  "Marveen channel plugin down -- stage 1 (soft /mcp reconnect, silent)"
14:35:45 INFO  "channel-mcp-reconnect: completed"
```

## Test plan
- [x] Dashboard restart triggers Telegram MCP disconnect
- [x] Health monitor detects plugin failure via `pluginPaneId` pattern
- [x] Auto-reconnect completes successfully (verified in logs)
- [x] No manual `/mcp` intervention needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>