### PR TITLE
fix(channel): add missing pluginPaneId to Discord provider

### DIFF
--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -242,6 +242,7 @@ function formatForDiscord(text: string): string {
 const discordProvider: ChannelProvider = {
   type: 'discord',
   pluginId: 'discord@claude-plugins-official',
+  pluginPaneId: 'plugin:discord:discord',
   envKeys: ['DISCORD_BOT_TOKEN'],
   stateDir: 'discord',
   chatIdFormat: 'Discord channel ID (e.g. 1234567890123456789)',


### PR DESCRIPTION
## Summary
- Discord provider from #163 merged without the `pluginPaneId` field introduced in #166
- Adds `pluginPaneId: 'plugin:discord:discord'` to fix TypeScript compilation error

## Test plan
- [x] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)