### PR TITLE
fix(linux): propagate API key/OAuth token to channels process

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -288,6 +288,7 @@ else
     if [ -n "$ANTHROPIC_API_KEY_INPUT" ]; then
       export ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY_INPUT"
       ensure_in_rc 'ANTHROPIC_API_KEY' "export ANTHROPIC_API_KEY=\"$ANTHROPIC_API_KEY_INPUT\""
+      CLAUDE_AUTH_ENV_LINE="ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY_INPUT}"
       ok "ANTHROPIC_API_KEY beallitva"
     else
       warn "API key nem lett megadva, kihagyas."
@@ -305,6 +306,7 @@ else
     if [ -n "$OAUTH_TOKEN_INPUT" ]; then
       export CLAUDE_CODE_OAUTH_TOKEN="$OAUTH_TOKEN_INPUT"
       ensure_in_rc 'CLAUDE_CODE_OAUTH_TOKEN' "export CLAUDE_CODE_OAUTH_TOKEN=\"$OAUTH_TOKEN_INPUT\""
+      CLAUDE_AUTH_ENV_LINE="CLAUDE_CODE_OAUTH_TOKEN=${OAUTH_TOKEN_INPUT}"
       # Ellenorzes
       if claude auth status &>/dev/null; then
         ok "OAuth token elfogadva, bejelentkezes sikeres"
@@ -322,10 +324,20 @@ else
   fi
 fi
 
+# Ensure ~/.claude directory tree has correct ownership and permissions.
+# On Ubuntu desktop, umask or prior package installs can leave these dirs
+# world-readable or owned by root, which blocks Claude Code from writing
+# its config/settings files.
+mkdir -p "$HOME/.claude"
+chmod 700 "$HOME/.claude"
+for d in "$HOME/.claude/channels" "$HOME/.claude/skills" "$HOME/.claude/scheduled-tasks"; do
+  mkdir -p "$d"
+  chmod 700 "$d"
+done
+
 # Mark the Claude Code first-run wizard as completed so the tmux-spawned
 # `claude --channels ...` process doesn't stop on the theme picker and
 # block the Telegram plugin from ever initializing.
-mkdir -p "$HOME/.claude"
 python3 - <<'PYEOF'
 import json, os, pathlib
 p = pathlib.Path(os.path.expanduser("~/.claude.json"))
@@ -509,6 +521,11 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
 else
   echo "SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}" >> "$INSTALL_DIR/.env"
   echo "SLACK_APP_TOKEN=${SLACK_APP_TOKEN}" >> "$INSTALL_DIR/.env"
+fi
+# Claude auth credentials (API key or OAuth token) -- channels.sh reads
+# these selectively so the tmux-spawned claude process can authenticate.
+if [ -n "${CLAUDE_AUTH_ENV_LINE:-}" ]; then
+  echo "$CLAUDE_AUTH_ENV_LINE" >> "$INSTALL_DIR/.env"
 fi
 chmod 600 "$INSTALL_DIR/.env"
 ok ".env letrehozva (chmod 600)"

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -24,6 +24,14 @@ INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 if [ -f "$INSTALL_DIR/.env" ]; then
   MAIN_AGENT_ID="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
   CHANNEL_PROVIDER="$(grep -E '^CHANNEL_PROVIDER=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
+  # Claude Code auth: pass API key or OAuth token so the tmux-spawned
+  # claude process can authenticate. These are safe to export -- unlike
+  # TELEGRAM_BOT_TOKEN they don't cause cross-session conflicts.
+  _api_key="$(grep -E '^ANTHROPIC_API_KEY=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
+  [ -n "$_api_key" ] && export ANTHROPIC_API_KEY="$_api_key"
+  _oauth="$(grep -E '^CLAUDE_CODE_OAUTH_TOKEN=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
+  [ -n "$_oauth" ] && export CLAUDE_CODE_OAUTH_TOKEN="$_oauth"
+  unset _api_key _oauth
 fi
 CHANNEL_PROVIDER="${CHANNEL_PROVIDER:-telegram}"
 SESSION="${MAIN_AGENT_ID:-marveen}-channels"


### PR DESCRIPTION
## Summary

- Fix API key / OAuth token not reaching the tmux-spawned `claude` process on Linux
- Fix `~/.claude` directory permissions on Ubuntu desktop
- Closes #165

## Root cause

The installer stored `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` only in `~/.bashrc`, but `channels.sh` (and the systemd unit spawning it) never read these values. The tmux-spawned `claude` process therefore started without auth credentials.

## Changes

- **install-linux.sh**: Store auth credentials in project `.env` file alongside other config. Add explicit `chmod 700` on `~/.claude` directory tree.
- **scripts/channels.sh**: Selectively read and export `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` from `.env` (same grep pattern as `MAIN_AGENT_ID` -- no full `.env` sourcing to avoid `TELEGRAM_BOT_TOKEN` leak to sub-agents).

## Test plan

- [ ] Fresh install on Ubuntu 24.04 with API key auth (option 1)
- [ ] Verify `.env` contains `ANTHROPIC_API_KEY=sk-ant-...` after install
- [ ] Verify `channels.sh` exports the key to the tmux session
- [ ] Verify `~/.claude` has 700 permissions
- [ ] Verify existing OAuth installs still work (no regression)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>