### PR TITLE
fix(channels): make Discord plugin actually work end-to-end (tagged dev-channels flag + channel-group bootstrap)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -35,6 +35,15 @@ case "$CHANNEL_PROVIDER" in
   *)        PLUGIN_ID="telegram@claude-plugins-official" ;;
 esac
 
+# Discord plugin is not on Claude Code's org-approved channels list, so
+# `--channels plugin:discord@...` makes the plugin's MCP server fail at
+# start ("1 MCP server failed" in the pane footer). The dev-channels flag
+# bypasses the allowlist, but REQUIRES a tagged entry -- bare flag exits 1
+# with "entries must be tagged". Telegram + Slack are on the default
+# allowlist and don't need this.
+DEVCHANNELS_FLAG=""
+[ "$CHANNEL_PROVIDER" = "discord" ] && DEVCHANNELS_FLAG="--dangerously-load-development-channels plugin:${PLUGIN_ID}"
+
 # Extra safety net for existing installs whose tmux server already has a
 # polluted global env -- scrub channel tokens so new child sessions don't
 # inherit them. The main agent's plugin will still load its token from
@@ -61,7 +70,7 @@ $TMUX kill-session -t "$SESSION" 2>/dev/null
 # resuming one of those loses the --channels activation state, causing
 # "Channel notifications skipped: server not in --channels list" errors.
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "$CLAUDE --dangerously-skip-permissions --channels plugin:${PLUGIN_ID}"
+  "$CLAUDE --dangerously-skip-permissions $DEVCHANNELS_FLAG --channels plugin:${PLUGIN_ID}"
 
 # Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
 # kulonben a headless session orokre parkolna a prompton es a Telegram plugin
@@ -75,6 +84,11 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
   sleep 1
   pane=$($TMUX capture-pane -t "$SESSION" -p 2>/dev/null || true)
   case "$pane" in
+    *"Loading development channels"*"I am using this for local development"*)
+      $TMUX send-keys -t "$SESSION" "1" Enter
+      sleep 1
+      continue
+      ;;
     *"Bypass Permissions mode"*"Yes, I accept"*)
       $TMUX send-keys -t "$SESSION" "2" Enter
       sleep 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
 import { startInviteMonitor, stopInviteMonitor } from './web/channel-invites.js'
+import { ensureDiscordChannelGroup } from './web/discord-group-bootstrap.js'
 import { startChannelRequestWatcher, stopChannelRequestWatcher } from './web/channel-request-watcher.js'
 import { AGENTS_BASE_DIR } from './web/agent-config.js'
 import {
@@ -432,6 +433,12 @@ async function main(): Promise<void> {
   initHeartbeat()
   heartbeatStarted = true
   logger.info('Heartbeat utemezo elindult')
+
+  // Discord-only: ensure the operator-configured DISCORD_CHANNEL_ID is
+  // in access.groups so the plugin's outbound `reply` tool can send to
+  // server channels without a manual `/discord:access group add` step.
+  // No-op for non-discord providers.
+  ensureDiscordChannelGroup()
 
   // Telegram invite auto-approve monitor (one-click pairing).
   startInviteMonitor(MAIN_AGENT_ID, AGENTS_BASE_DIR)

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -197,6 +197,10 @@ function resumeMarveenSession(): boolean {
     const claudeCmd = [
       'export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"',
       '&&', CLAUDE, '--continue', '--dangerously-skip-permissions',
+      // Discord plugin is not on the org-approved channels allowlist.
+      // Flag REQUIRES a tagged entry -- bare flag exits 1 with
+      // "entries must be tagged". Telegram + Slack don't need this.
+      ...(provider.type === 'discord' ? [`--dangerously-load-development-channels plugin:${provider.pluginId}`] : []),
       `--channels plugin:${provider.pluginId}`,
     ].join(' ')
     execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })

--- a/src/web/discord-group-bootstrap.ts
+++ b/src/web/discord-group-bootstrap.ts
@@ -1,0 +1,62 @@
+// Discord channel-group bootstrap.
+//
+// When CHANNEL_PROVIDER=discord, the plugin's outbound `reply` tool gates
+// server-channel sends on `access.groups[channelId]` (channel-scoped),
+// while DMs gate on `access.allowFrom` (user-scoped). The `/discord:access
+// pair <code>` skill only populates `allowFrom`, so a fresh install where
+// the operator wants the bot to reply in a SERVER channel (not a DM) still
+// gets "channel <id> is not allowlisted -- add via /discord:access" until
+// the operator manually runs `/discord:access group add <channelId>`.
+//
+// When DISCORD_CHANNEL_ID is set in the project .env (the operator already
+// picked the target channel) we can avoid that manual step by inserting
+// the entry on dashboard boot. Boot is also the right point: the plugin
+// re-reads access.json on every read, and we want the entry present before
+// the first inbound message arrives.
+//
+// No-op when:
+//  - CHANNEL_PROVIDER is not 'discord'
+//  - DISCORD_CHANNEL_ID is unset/empty
+//  - the group entry is already present (idempotent)
+import { existsSync, readFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { CHANNEL_PROVIDER, CHANNEL_CHAT_ID } from '../config.js'
+import { channelStateDir } from '../channel-provider.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+import { logger } from '../logger.js'
+
+interface AccessFile {
+  dmPolicy?: 'pairing' | 'allowlist' | 'disabled'
+  allowFrom?: string[]
+  groups?: Record<string, { requireMention?: boolean; allowFrom?: string[] }>
+  pending?: Record<string, unknown>
+  invites?: Record<string, unknown>
+}
+
+export function ensureDiscordChannelGroup(): void {
+  if (CHANNEL_PROVIDER !== 'discord') return
+  if (!CHANNEL_CHAT_ID) return
+  const dir = channelStateDir('discord')
+  const path = join(dir, 'access.json')
+
+  let access: AccessFile
+  if (existsSync(path)) {
+    try {
+      access = JSON.parse(readFileSync(path, 'utf-8'))
+    } catch {
+      // Corrupt file -- safer to leave alone than overwrite.
+      logger.warn({ path }, 'discord-group-bootstrap: access.json unparseable, skipping')
+      return
+    }
+  } else {
+    access = { dmPolicy: 'pairing', allowFrom: [], groups: {}, pending: {} }
+  }
+
+  access.groups = access.groups ?? {}
+  if (CHANNEL_CHAT_ID in access.groups) return
+
+  access.groups[CHANNEL_CHAT_ID] = { requireMention: false, allowFrom: [] }
+  mkdirSync(dir, { recursive: true })
+  atomicWriteFileSync(path, JSON.stringify(access, null, 2))
+  logger.info({ channelId: CHANNEL_CHAT_ID }, 'discord-group-bootstrap: added channel to access.groups')
+}


### PR DESCRIPTION
Follow-up to #163.

PR #163 added the Discord provider plumbing, but spawning a channels
session with `--channels plugin:discord@claude-plugins-official` makes
the plugin's MCP server fail at start (footer shows "1 MCP server
failed"), because `discord@claude-plugins-official` is not on Claude
Code's org-approved plugins allowlist. Even past that, the plugin's
outbound `reply` tool gates server-channel sends on
`access.groups[channelId]`, so a fresh install with `DISCORD_CHANNEL_ID`
set still gets "channel `<id>` is not allowlisted -- add via
`/discord:access`" until the operator runs the slash command manually.

This PR closes both gaps with two small commits:

## Commits

**`fix(channels): Discord plugin needs tagged dev-channels flag + warning auto-accept`**

The bypass flag exists, but with two non-obvious requirements:

1. The flag REQUIRES a tagged entry. Bare `--dangerously-load-development-channels` exits 1 with `entries must be tagged: plugin:<name>@<marketplace>` (verified on `claude 2.1.150`). The correct form is `--dangerously-load-development-channels plugin:<id>` and runs ALONGSIDE `--channels plugin:<id>`, not instead.
2. The flag triggers an interactive "Loading development channels" warning dialog ("I am using this for local development / Exit") before the plugin loads. Without auto-accept the session sits at the dialog forever.

Applied on both POSIX channels-session spawn paths:
- `scripts/channels.sh`: `DEVCHANNELS_FLAG="--dangerously-load-development-channels plugin:${PLUGIN_ID}"` when `CHANNEL_PROVIDER=discord`, injected into the tmux `new-session` command. Auto-accept case added to the 12-iteration dialog loop alongside trust + bypass + welcome.
- `src/web/channel-monitor.ts::resumeMarveenSession`: same tagged flag inlined into `claudeCmd` when `provider.type === 'discord'`.

Telegram + Slack unaffected -- their plugin IDs are on the default allowlist and don't trigger the warning, so `DEVCHANNELS_FLAG` stays empty for them.

**`feat(channels-discord): auto-add DISCORD_CHANNEL_ID to access.groups on boot`**

When `DISCORD_CHANNEL_ID` is set in the project `.env` (the canonical signal that the operator picked a target channel) the dashboard can add the channel-group entry itself on boot. `ensureDiscordChannelGroup` reads `~/.claude/channels/discord/access.json`, inserts the entry if missing (`requireMention: false, allowFrom: []`), and writes back. No-op when the entry is already present, when `CHANNEL_PROVIDER !== 'discord'`, when `DISCORD_CHANNEL_ID` is unset, or when `access.json` is corrupt (safer to leave alone than overwrite).

Wired into `src/index.ts` boot right before `startInviteMonitor`, so the entry is present before the first inbound Discord message can fire the plugin's gate.

## Out of scope / known gaps

- Operator-issued first-pair for DMs still goes through `/discord:access pair <code>` (unchanged behaviour).
- Dashboard web UI has no input for `DISCORD_CHANNEL_ID` yet -- it has to be edited into the project `.env` manually before the bootstrap helper can act.

🤖 Generated with [Claude Code](https://claude.com/claude-code)