### PR TITLE
feat(dashboard): per-agent auth-mode selection

### DIFF
--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -208,6 +208,30 @@ export function writeAgentChannelProvider(name: string, provider: string): void 
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
+export type AuthMode = 'shared' | 'own_team' | 'api'
+
+const VALID_AUTH_MODES = new Set<AuthMode>(['shared', 'own_team', 'api'])
+
+export function readAgentAuthMode(name: string): AuthMode {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  try {
+    const config = JSON.parse(readFileOr(configPath, '{}'))
+    if (typeof config.authMode === 'string' && VALID_AUTH_MODES.has(config.authMode as AuthMode)) {
+      return config.authMode as AuthMode
+    }
+  } catch { /* fall through */ }
+  return 'shared'
+}
+
+export function writeAgentAuthMode(name: string, mode: AuthMode): void {
+  if (!VALID_AUTH_MODES.has(mode)) return
+  const configPath = join(agentDir(name), 'agent-config.json')
+  let config: Record<string, unknown> = {}
+  try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
+  config.authMode = mode
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
 export function writeAgentSecurityProfile(name: string, profileId: string): void {
   const configPath = join(agentDir(name), 'agent-config.json')
   let config: Record<string, unknown> = {}

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -10,7 +10,7 @@ import {
   decideSubmitFollowup,
   shouldClearTruncatedPreamble,
 } from '../pane-state.js'
-import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir, readAgentChannelProvider } from './agent-config.js'
+import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode } from './agent-config.js'
 import { parseTelegramToken } from './telegram.js'
 import { getProvider, getProviderType, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import { CHANNEL_PROVIDER } from '../config.js'
@@ -67,19 +67,24 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     } catch { /* ok */ }
 
     const model = readAgentModel(name)
+    const authMode = readAgentAuthMode(name)
     const isClaude = model.startsWith('claude-')
     const isDeepseek = model.startsWith('deepseek-')
     const isOllama = !isClaude && !isDeepseek
     const ollamaEnv = isOllama ? `export ANTHROPIC_AUTH_TOKEN=ollama && export ANTHROPIC_BASE_URL=${OLLAMA_URL} && ` : ''
-    // DeepSeek's /anthropic base URL accepts the literal Anthropic SDK
-    // request format, so Claude Code talks to it as if it were Anthropic.
-    // We pull the API key from the encrypted vault (entry id: DEEPSEEK_API_KEY)
-    // rather than process.env so operators can rotate it from the dashboard
-    // without restarting. We do NOT fail-fast on missing key here -- a 401
-    // from the upstream gives a clearer signal in the agent's tmux pane
-    // than a pre-flight error string the operator would have to dig out of logs.
     const deepseekKey = isDeepseek ? (getSecret('DEEPSEEK_API_KEY') ?? '') : ''
     const deepseekEnv = isDeepseek ? `export ANTHROPIC_AUTH_TOKEN="${deepseekKey}" && export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic && ` : ''
+    // When authMode is 'api', the agent uses its own ANTHROPIC_API_KEY from
+    // the vault instead of the host's OAuth. The vault entry ID follows the
+    // convention `agent-{name}-api-key`. We inject it as an env var so Claude
+    // Code picks it up without needing OAuth credentials at all.
+    let apiKeyEnv = ''
+    if (isClaude && authMode === 'api') {
+      const agentApiKey = getSecret(`agent-${name}-api-key`) ?? ''
+      if (agentApiKey) {
+        apiKeyEnv = `export ANTHROPIC_API_KEY="${agentApiKey}" && `
+      }
+    }
     // Apply security profile: write allow/deny list into settings.json, and
     // skip the dangerously-skip-permissions flag for strict profiles so
     // Claude Code enforces the list rather than bypassing it.
@@ -109,7 +114,7 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     // Slack plugin is third-party; its "not on approved allowlist" check is
     // bypassed via `allowedChannelPlugins` in /Library/Application Support/ClaudeCode/managed-settings.json.
     const auditLogEnv = agentProvider === 'slack' ? ` && export SLACK_AUDIT_LOG="${agentChannelDir}/audit.jsonl"` : ''
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}"${auditLogEnv} && ${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}"${auditLogEnv} && ${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -6,7 +6,7 @@ import { logger } from '../../logger.js'
 import { MAIN_AGENT_ID, BOT_NAME } from '../../config.js'
 import { createAgentMessage, listPendingChannelRequests, updateChannelRequestStatus } from '../../db.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
-import { getSecret } from '../vault.js'
+import { getSecret, setSecret, deleteSecret, listSecrets } from '../vault.js'
 import {
   agentDir,
   agentConfigRoot,
@@ -25,6 +25,9 @@ import {
   isKnownAgent,
   readAgentChannelProvider,
   writeAgentChannelProvider,
+  readAgentAuthMode,
+  writeAgentAuthMode,
+  type AuthMode,
 } from '../agent-config.js'
 import {
   readAgentTeam,
@@ -183,6 +186,7 @@ interface AgentSummary {
   displayName: string
   description: string
   model: string
+  authMode: AuthMode
   securityProfile: string
   team: TeamConfig
   hasTelegram: boolean
@@ -199,6 +203,7 @@ interface AgentDetail extends AgentSummary {
   mcpJson: string
   skills: { name: string; hasSkillMd: boolean }[]
   hasAvatar: boolean
+  hasApiKey: boolean
 }
 
 function getAgentSummary(name: string): AgentSummary {
@@ -217,6 +222,7 @@ function getAgentSummary(name: string): AgentSummary {
     displayName: readAgentDisplayName(name),
     description: extractDescriptionFromClaudeMd(claudeMd),
     model: readAgentModel(name),
+    authMode: readAgentAuthMode(name),
     securityProfile: readAgentSecurityProfile(name),
     team: readAgentTeam(name),
     hasTelegram: tg.hasTelegram,
@@ -256,6 +262,7 @@ function getAgentDetail(name: string): AgentDetail {
     mcpJson,
     skills,
     hasAvatar: findAvatarForAgent(name) !== null,
+    hasApiKey: getSecret(`agent-${name}-api-key`) !== null,
   }
 }
 
@@ -983,11 +990,23 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (!isKnownAgent(name)) { json(res, { error: 'Agent not found' }, 404); return true }
     const body = await readBody(req)
     const configRoot = agentConfigRoot(name)
-    const data = JSON.parse(body.toString()) as { claudeMd?: string; soulMd?: string; mcpJson?: string; model?: string }
+    const data = JSON.parse(body.toString()) as {
+      claudeMd?: string; soulMd?: string; mcpJson?: string; model?: string
+      authMode?: AuthMode; apiKey?: string
+    }
     if (data.claudeMd !== undefined) atomicWriteFileSync(join(configRoot, 'CLAUDE.md'), data.claudeMd)
     if (data.soulMd !== undefined) atomicWriteFileSync(join(agentDir(name), 'SOUL.md'), data.soulMd)
     if (data.mcpJson !== undefined) atomicWriteFileSync(join(agentDir(name), '.mcp.json'), data.mcpJson)
     if (data.model !== undefined) writeAgentModel(name, data.model)
+    if (data.authMode !== undefined) {
+      writeAgentAuthMode(name, data.authMode)
+      if (data.authMode === 'api' && typeof data.apiKey === 'string' && data.apiKey.trim()) {
+        setSecret(`agent-${name}-api-key`, `API key for agent ${name}`, data.apiKey.trim())
+      }
+      if (data.authMode !== 'api') {
+        deleteSecret(`agent-${name}-api-key`)
+      }
+    }
     json(res, { ok: true })
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -1021,7 +1021,7 @@ async function openMarveenDetail() {
 
 function applyMarveenReadonlyMode(readOnly) {
   const textareaIds = ['editClaudeMd', 'editSoulMd', 'editMcpJson']
-  const saveButtonIds = ['saveClaudeMdBtn', 'saveSoulMdBtn', 'saveMcpJsonBtn', 'saveModelBtn']
+  const saveButtonIds = ['saveClaudeMdBtn', 'saveSoulMdBtn', 'saveMcpJsonBtn', 'saveModelBtn', 'saveAuthModeBtn']
   for (const id of textareaIds) {
     const el = document.getElementById(id)
     if (!el) continue
@@ -1034,6 +1034,8 @@ function applyMarveenReadonlyMode(readOnly) {
     const btn = document.getElementById(id)
     if (btn) btn.hidden = readOnly
   }
+  const authModeGroup = document.getElementById('authModeGroup')
+  if (authModeGroup) authModeGroup.hidden = readOnly
   const note = document.getElementById('marveenReadonlyNote')
   if (note) note.hidden = !readOnly
 }
@@ -1154,6 +1156,7 @@ async function openAgentDetail(agentName) {
     currentAgent.securityProfile || 'default',
   )
   renderTeamEditor(currentAgent, agents)
+  updateAuthModeUI(currentAgent.authMode || 'shared', currentAgent.hasApiKey || false)
   document.getElementById('editClaudeMd').value = currentAgent.claudeMd || currentAgent.content || ''
   document.getElementById('editSoulMd').value = currentAgent.soulMd || ''
   document.getElementById('editMcpJson').value = currentAgent.mcpJson || ''
@@ -1541,6 +1544,55 @@ document.getElementById('saveProfileBtn').addEventListener('click', async () => 
     showToast(body.requiresRestart ? 'Profil mentve (újraindítás szükséges)' : 'Profil mentve')
     loadAgents()
   } catch { showToast('Hiba a profil mentésekor') }
+})
+
+// === Auth Mode ===
+function updateAuthModeUI(mode, hasApiKey) {
+  document.querySelectorAll('input[name="authMode"]').forEach(r => { r.checked = r.value === mode })
+  document.getElementById('authModeApiKeySection').hidden = mode !== 'api'
+  document.getElementById('authModeOwnTeamHint').hidden = mode !== 'own_team'
+  const statusEl = document.getElementById('authModeApiKeyStatus')
+  const keyInput = document.getElementById('editAgentApiKey')
+  keyInput.value = ''
+  if (mode === 'api') {
+    statusEl.textContent = hasApiKey ? 'API kulcs konfigurálva a vault-ban' : 'Nincs API kulcs beállítva'
+    statusEl.style.color = hasApiKey ? 'var(--success)' : 'var(--warning)'
+  }
+}
+
+document.querySelectorAll('input[name="authMode"]').forEach(radio => {
+  radio.addEventListener('change', (e) => {
+    const mode = e.target.value
+    document.getElementById('authModeApiKeySection').hidden = mode !== 'api'
+    document.getElementById('authModeOwnTeamHint').hidden = mode !== 'own_team'
+  })
+})
+
+document.getElementById('saveAuthModeBtn').addEventListener('click', async () => {
+  if (!currentAgent || currentAgent.role === 'main') return
+  const mode = document.querySelector('input[name="authMode"]:checked')?.value || 'shared'
+  const payload = { authMode: mode }
+  if (mode === 'api') {
+    const key = document.getElementById('editAgentApiKey').value.trim()
+    if (key) payload.apiKey = key
+  }
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (!res.ok) throw new Error()
+    showToast('Hitelesítési mód mentve (újraindítás szükséges)')
+    loadAgents()
+    // Refresh detail to update hasApiKey status
+    const detailRes = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}`)
+    if (detailRes.ok) {
+      const updated = await detailRes.json()
+      currentAgent = updated
+      updateAuthModeUI(updated.authMode || 'shared', updated.hasApiKey || false)
+    }
+  } catch { showToast('Hiba a mentés során') }
 })
 
 document.getElementById('saveClaudeMdBtn').addEventListener('click', async () => {

--- a/web/index.html
+++ b/web/index.html
@@ -1241,6 +1241,31 @@
               DeepSeek-V4-Pro nincs konfigurálva. <a href="#" id="deepseekConfigLink">API kulcs hozzáadása</a> a Vault oldalon.
             </small>
           </div>
+          <div class="form-group" id="authModeGroup">
+            <label>Hitelesítési mód</label>
+            <div class="auth-mode-radios" style="display:flex;gap:12px;margin:8px 0">
+              <label class="radio-label" style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px">
+                <input type="radio" name="authMode" value="shared" checked> Megosztott (host OAuth)
+              </label>
+              <label class="radio-label" style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px">
+                <input type="radio" name="authMode" value="own_team"> Saját Team login
+              </label>
+              <label class="radio-label" style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px">
+                <input type="radio" name="authMode" value="api"> API kulcs
+              </label>
+            </div>
+            <div id="authModeApiKeySection" hidden style="margin-top:8px">
+              <input type="password" id="editAgentApiKey" placeholder="sk-ant-..." style="width:100%;padding:8px 10px;border-radius:var(--radius);border:1px solid var(--border);background:var(--bg-input);color:var(--text);font-family:monospace;font-size:13px">
+              <small id="authModeApiKeyStatus" style="display:block;margin-top:4px;color:var(--text-muted);font-size:12px"></small>
+            </div>
+            <div id="authModeOwnTeamHint" hidden style="margin-top:8px">
+              <small style="color:var(--text-muted);font-size:12px;line-height:1.4">
+                Az agent saját Claude Code config könyvtárat használ (claudeConfigDir az agent-config.json-ban).
+                Állítsd be a <code>claudeConfigDir</code> mezőt, majd indítsd újra az agentet, hogy a saját login-ját használja.
+              </small>
+            </div>
+            <button class="btn-secondary btn-compact agent-save-section" id="saveAuthModeBtn">Mentés</button>
+          </div>
           <div class="form-group">
             <label for="editAgentProfile">Biztonsági profil</label>
             <select id="editAgentProfile"></select>


### PR DESCRIPTION
## Summary
- Adds per-agent authentication mode selection (shared / own_team / api) to the dashboard Settings tab
- When `api` mode is selected, the agent's ANTHROPIC_API_KEY is stored in the encrypted vault and injected at tmux launch
- When `own_team` is selected, the agent uses its own claudeConfigDir for separate OAuth login
- Backend: new `authMode` field in agent-config.json, auth-mode-aware credential resolution in agent-process.ts, vault-backed API key storage
- Frontend: radio buttons with conditional API key input and vault status indicator

## Test plan
- [ ] Open dashboard, click any sub-agent, go to Settings tab
- [ ] Verify "Hitelesitesi mod" radio buttons appear (shared selected by default)
- [ ] Select "API kulcs", verify password input appears with vault status
- [ ] Enter a test API key, click Mentes, verify toast "Hitelesitesi mod mentve"
- [ ] Re-open agent detail, verify "API kulcs" is selected and "API kulcs konfigurálva a vault-ban" status shows
- [ ] Switch to "Megosztott", save, verify vault key is cleaned up
- [ ] Verify Marveen detail hides the auth-mode section (read-only mode)
- [ ] Restart an agent with api mode + valid key, verify it picks up ANTHROPIC_API_KEY from env

Generated with [Claude Code](https://claude.com/claude-code)