### PR TITLE
feat(dashboard): auth-mode UI v2 — radio-card + action buttons (3 modes)

### DIFF
--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -70,6 +70,9 @@ import {
   startAgentProcess,
   stopAgentProcess,
   getAgentProcessInfo,
+  agentSessionName,
+  sendPromptToSession,
+  capturePane,
 } from '../agent-process.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
 import { getChannelHealth } from '../channel-health-monitor.js'
@@ -955,6 +958,42 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       json(res, { ok: true })
     } else {
       json(res, { error: 'Request not found or already resolved' }, 404)
+    }
+    return true
+  }
+
+  // POST /api/agents/:name/auth/init -- trigger /login in the agent's tmux,
+  // wait a few seconds for the auth URL to appear, then scrape it back.
+  const authInitMatch = path.match(/^\/api\/agents\/([^/]+)\/auth\/init$/)
+  if (authInitMatch && method === 'POST') {
+    const name = decodeURIComponent(authInitMatch[1])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (!isAgentRunning(name)) { json(res, { error: 'Agent is not running' }, 400); return true }
+    const session = agentSessionName(name)
+    try {
+      sendPromptToSession(session, '/login')
+      // Wait for Claude Code to render the auth URL (typically 3-6s)
+      let authUrl: string | null = null
+      for (let i = 0; i < 12; i++) {
+        execSync('sleep 1', { timeout: 3000 })
+        const pane = capturePane(session)
+        if (!pane) continue
+        const urlMatch = pane.match(/https:\/\/console\.anthropic\.com\/[^\s"']+/)
+          || pane.match(/https:\/\/auth\.anthropic\.com\/[^\s"']+/)
+          || pane.match(/https:\/\/claude\.ai\/[^\s"']+login[^\s"']*/)
+        if (urlMatch) {
+          authUrl = urlMatch[0]
+          break
+        }
+      }
+      if (authUrl) {
+        json(res, { ok: true, authUrl })
+      } else {
+        json(res, { ok: false, error: 'Auth URL nem jelent meg 12 masodpercen belul. Probald ujra, vagy nezd a tmux session-t.' })
+      }
+    } catch (err) {
+      logger.error({ err, name }, 'Auth init failed')
+      json(res, { error: 'Auth flow inditasa sikertelen' }, 500)
     }
     return true
   }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -993,7 +993,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       }
     } catch (err) {
       logger.error({ err, name }, 'Auth init failed')
-      json(res, { error: 'Auth flow inditasa sikertelen' }, 500)
+      json(res, { error: 'Auth flow indítása sikertelen' }, 500)
     }
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -1604,12 +1604,12 @@ document.getElementById('authSharedApplyBtn').addEventListener('click', async ()
       const startRes = await fetch(`${base}/start`, { method: 'POST' })
       const startData = await startRes.json()
       if (!startRes.ok) {
-        errorDiv.textContent = startData.error || 'Agent ujrainditasa sikertelen'
+        errorDiv.textContent = startData.error || 'Agent újraindítása sikertelen'
         errorDiv.hidden = false
         return
       }
     }
-    showToast('Agent ujrainditva host OAuth-tal')
+    showToast('Agent újraindítva host OAuth-tal')
     loadAgents()
     const detailRes = await fetch(base)
     if (detailRes.ok) {
@@ -1618,7 +1618,7 @@ document.getElementById('authSharedApplyBtn').addEventListener('click', async ()
       updateProcessControl(currentAgent)
     }
   } catch {
-    errorDiv.textContent = 'Hiba az alkalmazas soran'
+    errorDiv.textContent = 'Hiba az alkalmazás során'
     errorDiv.hidden = false
   } finally {
     btnText.hidden = false
@@ -1655,7 +1655,7 @@ document.getElementById('authFlowInitBtn').addEventListener('click', async () =>
       errorDiv.hidden = false
     }
   } catch {
-    errorDiv.textContent = 'Halozati hiba az auth-flow inditasakor'
+    errorDiv.textContent = 'Hálózati hiba az auth-flow indításakor'
     errorDiv.hidden = false
   } finally {
     btnText.hidden = false
@@ -1684,7 +1684,7 @@ document.getElementById('saveAuthModeBtn').addEventListener('click', async () =>
       body: JSON.stringify(payload),
     })
     if (!res.ok) throw new Error()
-    showToast('Hitelesitesi mod mentve (ujrainditás szukseges)')
+    showToast('Hitelesítési mód mentve (ujrainditás szukseges)')
     loadAgents()
     const detailRes = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}`)
     if (detailRes.ok) {

--- a/web/app.js
+++ b/web/app.js
@@ -1555,10 +1555,12 @@ function selectAuthModeCard(mode) {
     c.classList.toggle('selected', isSelected)
     c.querySelector('input[type="radio"]').checked = isSelected
   })
+  document.getElementById('authModeSharedSection').hidden = mode !== 'shared'
   document.getElementById('authModeApiKeySection').hidden = mode !== 'api'
   document.getElementById('authModeOwnTeamSection').hidden = mode !== 'own_team'
   document.getElementById('authFlowResult').hidden = true
   document.getElementById('authFlowError').hidden = true
+  document.getElementById('authSharedError').hidden = true
 }
 
 function updateAuthModeUI(mode, hasApiKey) {
@@ -1576,6 +1578,53 @@ document.querySelectorAll('.auth-mode-card').forEach(card => {
   card.addEventListener('click', () => {
     selectAuthModeCard(card.dataset.mode)
   })
+})
+
+document.getElementById('authSharedApplyBtn').addEventListener('click', async () => {
+  if (!currentAgent) return
+  const btn = document.getElementById('authSharedApplyBtn')
+  const btnText = btn.querySelector('.btn-text')
+  const btnLoading = btn.querySelector('.btn-loading')
+  const errorDiv = document.getElementById('authSharedError')
+  errorDiv.hidden = true
+  btnText.hidden = true
+  btnLoading.hidden = false
+  btn.disabled = true
+  try {
+    const base = `/api/agents/${encodeURIComponent(currentAgent.name)}`
+    const saveRes = await fetch(base, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ authMode: 'shared' }),
+    })
+    if (!saveRes.ok) throw new Error('Save failed')
+    if (currentAgent.running) {
+      await fetch(`${base}/stop`, { method: 'POST' })
+      await new Promise(r => setTimeout(r, 2000))
+      const startRes = await fetch(`${base}/start`, { method: 'POST' })
+      const startData = await startRes.json()
+      if (!startRes.ok) {
+        errorDiv.textContent = startData.error || 'Agent ujrainditasa sikertelen'
+        errorDiv.hidden = false
+        return
+      }
+    }
+    showToast('Agent ujrainditva host OAuth-tal')
+    loadAgents()
+    const detailRes = await fetch(base)
+    if (detailRes.ok) {
+      currentAgent = await detailRes.json()
+      updateAuthModeUI(currentAgent.authMode || 'shared', currentAgent.hasApiKey || false)
+      updateProcessControl(currentAgent)
+    }
+  } catch {
+    errorDiv.textContent = 'Hiba az alkalmazas soran'
+    errorDiv.hidden = false
+  } finally {
+    btnText.hidden = false
+    btnLoading.hidden = true
+    btn.disabled = false
+  }
 })
 
 document.getElementById('authFlowInitBtn').addEventListener('click', async () => {

--- a/web/app.js
+++ b/web/app.js
@@ -1549,25 +1549,75 @@ document.getElementById('saveProfileBtn').addEventListener('click', async () => 
 })
 
 // === Auth Mode ===
-function updateAuthModeUI(mode, hasApiKey) {
-  document.querySelectorAll('input[name="authMode"]').forEach(r => { r.checked = r.value === mode })
+function selectAuthModeCard(mode) {
+  document.querySelectorAll('.auth-mode-card').forEach(c => {
+    const isSelected = c.dataset.mode === mode
+    c.classList.toggle('selected', isSelected)
+    c.querySelector('input[type="radio"]').checked = isSelected
+  })
   document.getElementById('authModeApiKeySection').hidden = mode !== 'api'
-  document.getElementById('authModeOwnTeamHint').hidden = mode !== 'own_team'
-  const statusEl = document.getElementById('authModeApiKeyStatus')
+  document.getElementById('authModeOwnTeamSection').hidden = mode !== 'own_team'
+  document.getElementById('authFlowResult').hidden = true
+  document.getElementById('authFlowError').hidden = true
+}
+
+function updateAuthModeUI(mode, hasApiKey) {
+  selectAuthModeCard(mode)
   const keyInput = document.getElementById('editAgentApiKey')
   keyInput.value = ''
   if (mode === 'api') {
+    const statusEl = document.getElementById('authModeApiKeyStatus')
     statusEl.textContent = hasApiKey ? 'API kulcs konfigurálva a vault-ban' : 'Nincs API kulcs beállítva'
     statusEl.style.color = hasApiKey ? 'var(--success)' : 'var(--warning)'
   }
 }
 
-document.querySelectorAll('input[name="authMode"]').forEach(radio => {
-  radio.addEventListener('change', (e) => {
-    const mode = e.target.value
-    document.getElementById('authModeApiKeySection').hidden = mode !== 'api'
-    document.getElementById('authModeOwnTeamHint').hidden = mode !== 'own_team'
+document.querySelectorAll('.auth-mode-card').forEach(card => {
+  card.addEventListener('click', () => {
+    selectAuthModeCard(card.dataset.mode)
   })
+})
+
+document.getElementById('authFlowInitBtn').addEventListener('click', async () => {
+  if (!currentAgent) return
+  const btn = document.getElementById('authFlowInitBtn')
+  const btnText = btn.querySelector('.btn-text')
+  const btnLoading = btn.querySelector('.btn-loading')
+  const resultDiv = document.getElementById('authFlowResult')
+  const errorDiv = document.getElementById('authFlowError')
+  resultDiv.hidden = true
+  errorDiv.hidden = true
+  btnText.hidden = true
+  btnLoading.hidden = false
+  btn.disabled = true
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/auth/init`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const data = await res.json()
+    if (data.ok && data.authUrl) {
+      const urlEl = document.getElementById('authFlowUrl')
+      urlEl.href = data.authUrl
+      urlEl.textContent = data.authUrl
+      resultDiv.hidden = false
+    } else {
+      errorDiv.textContent = data.error || 'Auth URL nem talalhato'
+      errorDiv.hidden = false
+    }
+  } catch {
+    errorDiv.textContent = 'Halozati hiba az auth-flow inditasakor'
+    errorDiv.hidden = false
+  } finally {
+    btnText.hidden = false
+    btnLoading.hidden = true
+    btn.disabled = false
+  }
+})
+
+document.getElementById('authFlowCopyBtn').addEventListener('click', () => {
+  const url = document.getElementById('authFlowUrl').textContent
+  navigator.clipboard.writeText(url).then(() => showToast('URL masolva'))
 })
 
 document.getElementById('saveAuthModeBtn').addEventListener('click', async () => {
@@ -1585,16 +1635,15 @@ document.getElementById('saveAuthModeBtn').addEventListener('click', async () =>
       body: JSON.stringify(payload),
     })
     if (!res.ok) throw new Error()
-    showToast('Hitelesítési mód mentve (újraindítás szükséges)')
+    showToast('Hitelesitesi mod mentve (ujrainditás szukseges)')
     loadAgents()
-    // Refresh detail to update hasApiKey status
     const detailRes = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}`)
     if (detailRes.ok) {
       const updated = await detailRes.json()
       currentAgent = updated
       updateAuthModeUI(updated.authMode || 'shared', updated.hasApiKey || false)
     }
-  } catch { showToast('Hiba a mentés során') }
+  } catch { showToast('Hiba a mentes soran') }
 })
 
 document.getElementById('saveClaudeMdBtn').addEventListener('click', async () => {

--- a/web/index.html
+++ b/web/index.html
@@ -1306,7 +1306,7 @@
             </small>
           </div>
           <div class="form-group" id="authModeGroup">
-            <label>Hitelesitesi mod</label>
+            <label>Hitelesítési mód</label>
             <div class="auth-mode-cards">
               <label class="auth-mode-card selected" data-mode="shared">
                 <input type="radio" name="authMode" value="shared" checked>
@@ -1315,7 +1315,7 @@
                 </div>
                 <div class="auth-mode-card-body">
                   <div class="auth-mode-card-title">Megosztott</div>
-                  <div class="auth-mode-card-desc">A host OAuth hitelesiteset hasznalja (alapertelmezett)</div>
+                  <div class="auth-mode-card-desc">A host OAuth hitelesiteset használja (alapértelmezett)</div>
                 </div>
               </label>
               <label class="auth-mode-card" data-mode="own_team">
@@ -1324,8 +1324,8 @@
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
                 </div>
                 <div class="auth-mode-card-body">
-                  <div class="auth-mode-card-title">Sajat Team login</div>
-                  <div class="auth-mode-card-desc">Kulon Anthropic Team login sajat OAuth-tal</div>
+                  <div class="auth-mode-card-title">Saját Team login</div>
+                  <div class="auth-mode-card-desc">Külön Anthropic Team login saját OAuth-tal</div>
                 </div>
               </label>
               <label class="auth-mode-card" data-mode="api">
@@ -1342,11 +1342,11 @@
             <div id="authModeSharedSection" hidden style="margin-top:12px;padding:12px 14px;background:var(--bg-input);border-radius:var(--radius-sm)">
               <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
                 <div>
-                  <div style="font-size:13px;font-weight:500;color:var(--text)">Host OAuth alkalmazasa</div>
-                  <small style="color:var(--text-muted);font-size:12px">Ujrainditja az agentet a host hitelesitesevel. Nincs kulon bejelentkezes.</small>
+                  <div style="font-size:13px;font-weight:500;color:var(--text)">Host OAuth alkalmazása</div>
+                  <small style="color:var(--text-muted);font-size:12px">Újraindítja az agentet a host hitelesítésével. Nincs külön bejelentkezés.</small>
                 </div>
                 <button class="btn-primary btn-compact" id="authSharedApplyBtn">
-                  <span class="btn-text">Alkalmazas</span>
+                  <span class="btn-text">Alkalmazás</span>
                   <span class="btn-loading" hidden><span class="spinner"></span></span>
                 </button>
               </div>
@@ -1355,11 +1355,11 @@
             <div id="authModeOwnTeamSection" hidden style="margin-top:12px;padding:12px 14px;background:var(--bg-input);border-radius:var(--radius-sm)">
               <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
                 <div>
-                  <div style="font-size:13px;font-weight:500;color:var(--text)">Auth-flow inditasa</div>
-                  <small style="color:var(--text-muted);font-size:12px">Az agent tmux session-jeben elinditja a <code>/login</code> parancsot es visszaadja az auth URL-t.</small>
+                  <div style="font-size:13px;font-weight:500;color:var(--text)">Auth-flow indítása</div>
+                  <small style="color:var(--text-muted);font-size:12px">Az agent tmux session-jében elindítja a <code>/login</code> parancsot és visszaadja az auth URL-t.</small>
                 </div>
                 <button class="btn-primary btn-compact" id="authFlowInitBtn">
-                  <span class="btn-text">Bejelentkezes</span>
+                  <span class="btn-text">Bejelentkezés</span>
                   <span class="btn-loading" hidden><span class="spinner"></span></span>
                 </button>
               </div>

--- a/web/index.html
+++ b/web/index.html
@@ -1339,6 +1339,19 @@
                 </div>
               </label>
             </div>
+            <div id="authModeSharedSection" hidden style="margin-top:12px;padding:12px 14px;background:var(--bg-input);border-radius:var(--radius-sm)">
+              <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+                <div>
+                  <div style="font-size:13px;font-weight:500;color:var(--text)">Host OAuth alkalmazasa</div>
+                  <small style="color:var(--text-muted);font-size:12px">Ujrainditja az agentet a host hitelesitesevel. Nincs kulon bejelentkezes.</small>
+                </div>
+                <button class="btn-primary btn-compact" id="authSharedApplyBtn">
+                  <span class="btn-text">Alkalmazas</span>
+                  <span class="btn-loading" hidden><span class="spinner"></span></span>
+                </button>
+              </div>
+              <div id="authSharedError" hidden style="margin-top:10px;font-size:12px;color:var(--danger)"></div>
+            </div>
             <div id="authModeOwnTeamSection" hidden style="margin-top:12px;padding:12px 14px;background:var(--bg-input);border-radius:var(--radius-sm)">
               <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
                 <div>

--- a/web/index.html
+++ b/web/index.html
@@ -1306,29 +1306,65 @@
             </small>
           </div>
           <div class="form-group" id="authModeGroup">
-            <label>Hitelesítési mód</label>
-            <div class="auth-mode-radios" style="display:flex;gap:12px;margin:8px 0">
-              <label class="radio-label" style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px">
-                <input type="radio" name="authMode" value="shared" checked> Megosztott (host OAuth)
+            <label>Hitelesitesi mod</label>
+            <div class="auth-mode-cards">
+              <label class="auth-mode-card selected" data-mode="shared">
+                <input type="radio" name="authMode" value="shared" checked>
+                <div class="auth-mode-card-icon">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+                </div>
+                <div class="auth-mode-card-body">
+                  <div class="auth-mode-card-title">Megosztott</div>
+                  <div class="auth-mode-card-desc">A host OAuth hitelesiteset hasznalja (alapertelmezett)</div>
+                </div>
               </label>
-              <label class="radio-label" style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px">
-                <input type="radio" name="authMode" value="own_team"> Saját Team login
+              <label class="auth-mode-card" data-mode="own_team">
+                <input type="radio" name="authMode" value="own_team">
+                <div class="auth-mode-card-icon">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+                </div>
+                <div class="auth-mode-card-body">
+                  <div class="auth-mode-card-title">Sajat Team login</div>
+                  <div class="auth-mode-card-desc">Kulon Anthropic Team login sajat OAuth-tal</div>
+                </div>
               </label>
-              <label class="radio-label" style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px">
-                <input type="radio" name="authMode" value="api"> API kulcs
+              <label class="auth-mode-card" data-mode="api">
+                <input type="radio" name="authMode" value="api">
+                <div class="auth-mode-card-icon">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 11-7.778 7.778 5.5 5.5 0 017.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+                </div>
+                <div class="auth-mode-card-body">
+                  <div class="auth-mode-card-title">API kulcs</div>
+                  <div class="auth-mode-card-desc">ANTHROPIC_API_KEY a vault-bol</div>
+                </div>
               </label>
             </div>
-            <div id="authModeApiKeySection" hidden style="margin-top:8px">
-              <input type="password" id="editAgentApiKey" placeholder="sk-ant-..." style="width:100%;padding:8px 10px;border-radius:var(--radius);border:1px solid var(--border);background:var(--bg-input);color:var(--text);font-family:monospace;font-size:13px">
-              <small id="authModeApiKeyStatus" style="display:block;margin-top:4px;color:var(--text-muted);font-size:12px"></small>
+            <div id="authModeOwnTeamSection" hidden style="margin-top:12px;padding:12px 14px;background:var(--bg-input);border-radius:var(--radius-sm)">
+              <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+                <div>
+                  <div style="font-size:13px;font-weight:500;color:var(--text)">Auth-flow inditasa</div>
+                  <small style="color:var(--text-muted);font-size:12px">Az agent tmux session-jeben elinditja a <code>/login</code> parancsot es visszaadja az auth URL-t.</small>
+                </div>
+                <button class="btn-primary btn-compact" id="authFlowInitBtn">
+                  <span class="btn-text">Bejelentkezes</span>
+                  <span class="btn-loading" hidden><span class="spinner"></span></span>
+                </button>
+              </div>
+              <div id="authFlowResult" hidden style="margin-top:10px;padding:10px 12px;background:var(--bg-card);border-radius:var(--radius-sm);border:1px solid var(--border)">
+                <div style="font-size:12px;color:var(--text-muted);margin-bottom:4px">Nyisd meg a bongeszodben:</div>
+                <div style="display:flex;align-items:center;gap:8px">
+                  <a id="authFlowUrl" href="#" target="_blank" style="font-size:13px;color:var(--accent);word-break:break-all;flex:1"></a>
+                  <button class="btn-secondary btn-compact" id="authFlowCopyBtn" style="flex-shrink:0">Masolas</button>
+                </div>
+              </div>
+              <div id="authFlowError" hidden style="margin-top:10px;font-size:12px;color:var(--danger)"></div>
             </div>
-            <div id="authModeOwnTeamHint" hidden style="margin-top:8px">
-              <small style="color:var(--text-muted);font-size:12px;line-height:1.4">
-                Az agent saját Claude Code config könyvtárat használ (claudeConfigDir az agent-config.json-ban).
-                Állítsd be a <code>claudeConfigDir</code> mezőt, majd indítsd újra az agentet, hogy a saját login-ját használja.
-              </small>
+            <div id="authModeApiKeySection" hidden style="margin-top:12px;padding:12px 14px;background:var(--bg-input);border-radius:var(--radius-sm)">
+              <div style="font-size:13px;font-weight:500;color:var(--text);margin-bottom:8px">API kulcs</div>
+              <input type="password" id="editAgentApiKey" placeholder="sk-ant-..." style="width:100%;padding:8px 10px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-card);color:var(--text);font-family:monospace;font-size:13px">
+              <small id="authModeApiKeyStatus" style="display:block;margin-top:6px;font-size:12px"></small>
             </div>
-            <button class="btn-secondary btn-compact agent-save-section" id="saveAuthModeBtn">Mentés</button>
+            <button class="btn-secondary btn-compact agent-save-section" id="saveAuthModeBtn" style="margin-top:12px">Mentes</button>
           </div>
           <div class="form-group">
             <label for="editAgentProfile">Biztonsági profil</label>

--- a/web/style.css
+++ b/web/style.css
@@ -4798,3 +4798,65 @@ main {
   .cxhu-banner-close { position: absolute; top: 10px; right: 10px; }
   .cxhu-banner { position: relative; }
 }
+
+/* Auth Mode Cards */
+.auth-mode-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+.auth-mode-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  background: var(--bg-card);
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: border-color var(--transition), background var(--transition);
+}
+.auth-mode-card:hover {
+  border-color: var(--accent);
+  background: var(--bg-card-hover);
+}
+.auth-mode-card.selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.auth-mode-card input[type="radio"] {
+  display: none;
+}
+.auth-mode-card-icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--bg-input);
+  color: var(--text-muted);
+  transition: color var(--transition), background var(--transition);
+}
+.auth-mode-card.selected .auth-mode-card-icon {
+  background: var(--accent);
+  color: #fff;
+}
+.auth-mode-card-body { flex: 1; min-width: 0; }
+.auth-mode-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+.auth-mode-card-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+@media (max-width: 600px) {
+  .auth-mode-cards { gap: 6px; }
+  .auth-mode-card { padding: 10px 12px; gap: 10px; }
+}


### PR DESCRIPTION
## Summary
PR #171 follow-up — Szabi screenshot-visszajelzése alapján UI v2:

- **Radio-card stílus**: 3 választás külön kártyán (border + hover + selected state), SVG ikonokkal, NEM inline radio
- **shared mode**: "Alkalmazás (host auth)" gomb — restart agent host-credential-state-tel
- **own_team mode**: "Bejelentkezés" gomb — POST /api/agents/:name/auth/init → tmux send-keys /login → 12s URL scrape → clickable link + copy gomb
- **api mode**: javított kulcs-input panel vault-status kijelzéssel

Minden 3 mode-nak van saját action button — sehol nem hagyjuk a usert "módosíts kézzel" instrukcióval.

## Test plan
- [x] TypeScript build OK
- [ ] UI vizuális ellenőrzés: 3 kártya jól látszik, hover/selected state
- [ ] shared: "Alkalmazás" → agent restart sikeres, host-OAuth-val működik
- [ ] own_team: "Bejelentkezés" → tmux pane-ben /login parancs lefut, URL megjelenik a UI-on
- [ ] api: vault-status (kulcs van/nincs) helyesen mutatva

Closes kanban CDB937A8

🤖 Generated with [Claude Code](https://claude.com/claude-code)