### PR TITLE
fix(dashboard): ékezetek a maradék UI-szövegekben (Mentés, Mégse, Összekapcsolás)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1684,7 +1684,7 @@ document.getElementById('saveAuthModeBtn').addEventListener('click', async () =>
       body: JSON.stringify(payload),
     })
     if (!res.ok) throw new Error()
-    showToast('Hitelesítési mód mentve (ujrainditás szukseges)')
+    showToast('Hitelesítési mód mentve (újraindítás szukseges)')
     loadAgents()
     const detailRes = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}`)
     if (detailRes.ok) {
@@ -5207,7 +5207,7 @@ function renderVaultGrid(secrets) {
       if (!data.value) return
       const form = document.createElement('div')
       form.className = 'vault-card-edit-form'
-      form.innerHTML = `<input type="password" class="input vault-edit-value" value="${escapeHtml(data.value)}" style="font-size:13px;margin-bottom:6px"><button class="btn-primary btn-compact vault-edit-save">Mentes</button> <button class="btn-secondary btn-compact vault-edit-cancel">Megse</button>`
+      form.innerHTML = `<input type="password" class="input vault-edit-value" value="${escapeHtml(data.value)}" style="font-size:13px;margin-bottom:6px"><button class="btn-primary btn-compact vault-edit-save">Mentés</button> <button class="btn-secondary btn-compact vault-edit-cancel">Mégse</button>`
       card.appendChild(form)
       const input = form.querySelector('.vault-edit-value')
       input.focus()
@@ -5362,7 +5362,7 @@ function renderVaultGrid(secrets) {
     }
 
     saveBtn.disabled = true
-    saveBtn.textContent = 'Mentes...'
+    saveBtn.textContent = 'Mentés...'
     try {
       const res = await fetch('/api/vault/bindings', {
         method: 'POST',

--- a/web/index.html
+++ b/web/index.html
@@ -564,7 +564,7 @@
             <div class="connector-external-add">
               <input type="text" id="vaultIdInput" class="input" placeholder="Kulcs nev (pl. OPENAI_API_KEY)" style="flex:1">
               <input type="password" id="vaultValueInput" class="input" placeholder="Ertek" style="flex:1">
-              <button class="btn-secondary btn-compact" id="vaultAddBtn">Mentes</button>
+              <button class="btn-secondary btn-compact" id="vaultAddBtn">Mentés</button>
             </div>
           </div>
         </div>
@@ -592,12 +592,12 @@
             <button class="modal-close" id="envVarModalClose">&times;</button>
           </div>
           <div class="modal-body">
-            <p class="modal-desc">Ez az MCP szerver az alabbi env valtozokat igenyeli. Az ertekek titkositva a Vault-ba kerulnek.</p>
+            <p class="modal-desc">Ez az MCP szerver az alabbi env változókat igenyeli. Az ertekek titkositva a Vault-ba kerulnek.</p>
             <div id="envVarFields"></div>
           </div>
           <div class="modal-footer">
             <button class="btn-secondary" id="envVarSkipBtn">Kihagyas</button>
-            <button class="btn-primary" id="envVarSaveBtn">Mentes es telepites</button>
+            <button class="btn-primary" id="envVarSaveBtn">Mentés és telepítés</button>
           </div>
         </div>
       </div>
@@ -840,7 +840,7 @@
         <div class="vault-add-actions">
           <button class="btn-primary" id="vaultPageAddBtn">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-            Mentes a Vault-ba
+            Mentés a Vault-ba
           </button>
         </div>
       </div>
@@ -878,7 +878,7 @@
               <select id="vaultBindServer" class="input"></select>
             </div>
             <div class="form-group">
-              <label for="vaultBindEnvVar">Kornyezeti valtozo neve</label>
+              <label for="vaultBindEnvVar">Kornyezeti változó neve</label>
               <input type="text" id="vaultBindEnvVar" class="input" placeholder="pl. API_KEY">
             </div>
             <div id="vaultBindStatus" hidden class="vault-bind-status"></div>
@@ -1315,7 +1315,7 @@
                 </div>
                 <div class="auth-mode-card-body">
                   <div class="auth-mode-card-title">Megosztott</div>
-                  <div class="auth-mode-card-desc">A host OAuth hitelesiteset használja (alapértelmezett)</div>
+                  <div class="auth-mode-card-desc">A host OAuth hitelesítését használja (alapértelmezett)</div>
                 </div>
               </label>
               <label class="auth-mode-card" data-mode="own_team">
@@ -1377,7 +1377,7 @@
               <input type="password" id="editAgentApiKey" placeholder="sk-ant-..." style="width:100%;padding:8px 10px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-card);color:var(--text);font-family:monospace;font-size:13px">
               <small id="authModeApiKeyStatus" style="display:block;margin-top:6px;font-size:12px"></small>
             </div>
-            <button class="btn-secondary btn-compact agent-save-section" id="saveAuthModeBtn" style="margin-top:12px">Mentes</button>
+            <button class="btn-secondary btn-compact agent-save-section" id="saveAuthModeBtn" style="margin-top:12px">Mentés</button>
           </div>
           <div class="form-group">
             <label for="editAgentProfile">Biztonsági profil</label>
@@ -1438,7 +1438,7 @@
               <input type="text" id="chSlackAppToken" placeholder="xapp-1-...">
             </div>
             <button class="btn-primary" id="chConnectBtn">
-              <span class="btn-text">Osszekapcsolas</span>
+              <span class="btn-text">Összekapcsolás</span>
               <span class="btn-loading" hidden><span class="spinner"></span> Csatlakozas...</span>
             </button>
           </div>
@@ -1761,7 +1761,7 @@
           <input type="text" id="memKeywords" placeholder="pl. marketing, kampany, ROI">
         </div>
         <input type="hidden" id="memEditId">
-        <button class="btn-primary" id="saveMemBtn">Mentes</button>
+        <button class="btn-primary" id="saveMemBtn">Mentés</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
PR #172 v3 ékezet-fix follow-up. A gomb-feliratok és pár vault/env form-szöveg ékezet nélkül maradt:

- "Mentes" → "Mentés" (saveAuthModeBtn + vaultAddBtn + envVarSaveBtn + saveMemBtn + vault-edit-save)
- "Megse" → "Mégse"
- "Osszekapcsolas" → "Összekapcsolás"
- "valtozokat" → "változókat", "hitelesiteset" → "hitelesítését"
- "ujrainditás" → "újraindítás"

## Test plan
- [x] Markdown render OK
- [ ] Dashboard agent Settings tabban a "Mentés" gomb ékezetesen jelenik meg
- [ ] Vault add/edit panel "Mentés" + "Mégse" ékezetesen
- [ ] Egyéb formok (memory, env-var) ékezetesek

🤖 Generated with [Claude Code](https://claude.com/claude-code)