### PR TITLE
fix(dashboard): toast z-index above modal overlay

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -1789,7 +1789,7 @@ main {
   font-weight: 500;
   box-shadow: var(--shadow-lg);
   transition: transform 0.3s ease;
-  z-index: 300;
+  z-index: 1100;
   white-space: nowrap;
 }
 .toast.visible { transform: translateX(-50%) translateY(0); }


### PR DESCRIPTION
## Summary
- Toast notification had `z-index: 300` while agent-detail modal overlay uses `z-index: 1000`, causing toast to render behind the modal blur
- Bumped toast z-index to `1100` so it always appears above all overlays

Closes #174

## Test plan
- [ ] Open agent detail modal, trigger a toast action (e.g. save settings) — toast should appear above the modal

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>