### PR TITLE
feat(heartbeat): pluggable calendar provider via CALENDAR_PROVIDER env

### DIFF
--- a/src/calendar-provider.ts
+++ b/src/calendar-provider.ts
@@ -1,0 +1,16 @@
+import { CALENDAR_PROVIDER } from './config.js'
+import { getCalendarEvents, type CalendarEvent } from './google-api.js'
+import { getM365CalendarEvents } from './m365-api.js'
+
+export type { CalendarEvent }
+
+export async function getCalendarEventsForHeartbeat(
+  calendarId: string,
+  timeMin: Date,
+  timeMax: Date
+): Promise<CalendarEvent[]> {
+  if (CALENDAR_PROVIDER === 'm365') {
+    return getM365CalendarEvents(calendarId, timeMin, timeMax)
+  }
+  return getCalendarEvents(calendarId, timeMin, timeMax)
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,3 +42,8 @@ export const HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
 export const HEARTBEAT_START_HOUR = 9
 export const HEARTBEAT_END_HOUR = 23
 export const HEARTBEAT_CALENDAR_ID = env['HEARTBEAT_CALENDAR_ID'] ?? ''
+
+// Calendar provider: 'google' (default, backward-compat) or 'm365'
+const rawCalendarProvider = env['CALENDAR_PROVIDER'] ?? 'google'
+export const CALENDAR_PROVIDER: 'google' | 'm365' =
+  rawCalendarProvider === 'm365' ? 'm365' : 'google'

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -8,7 +8,7 @@ import {
   DB_FILENAME,
 } from './config.js'
 import { getHeartbeatKanbanSummary, getActiveScheduledTaskCount } from './db.js'
-import { getCalendarEvents, type CalendarEvent } from './google-api.js'
+import { getCalendarEventsForHeartbeat, type CalendarEvent } from './calendar-provider.js'
 import { runAgent } from './agent.js'
 import { notifyTelegram } from './notify.js'
 import { logger } from './logger.js'
@@ -35,7 +35,7 @@ async function collectCalendar(): Promise<CalendarEvent[]> {
   try {
     const now = new Date()
     const twoHoursLater = new Date(now.getTime() + 2 * 60 * 60 * 1000)
-    return await getCalendarEvents(HEARTBEAT_CALENDAR_ID, now, twoHoursLater)
+    return await getCalendarEventsForHeartbeat(HEARTBEAT_CALENDAR_ID, now, twoHoursLater)
   } catch (err) {
     logger.error({ err }, 'Heartbeat: calendar fetch failed')
     return []

--- a/src/m365-api.ts
+++ b/src/m365-api.ts
@@ -1,0 +1,222 @@
+import https from 'node:https'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { logger } from './logger.js'
+import type { CalendarEvent } from './google-api.js'
+
+const MSAL_CACHE_PATH = join(homedir(), '.m365-mcp', 'msal-cache.json')
+const GRAPH_BASE = 'https://graph.microsoft.com/v1.0'
+
+interface MsalCache {
+  AccessToken?: Record<string, MsalAccessToken>
+  RefreshToken?: Record<string, MsalRefreshToken>
+}
+
+interface MsalAccessToken {
+  client_id: string
+  secret: string
+  realm: string
+  expires_on: string
+  cached_at: string
+}
+
+interface MsalRefreshToken {
+  client_id: string
+  secret: string
+}
+
+// Microsoft Graph calendar event shape (subset we use)
+interface GraphEvent {
+  id: string
+  subject?: string
+  start?: { dateTime: string; timeZone: string }
+  end?: { dateTime: string; timeZone: string }
+  location?: { displayName?: string }
+  isAllDay?: boolean
+  attendees?: Array<{
+    emailAddress?: { address?: string; name?: string }
+    type?: string
+  }>
+  bodyPreview?: string
+  isCancelled?: boolean
+}
+
+interface GraphCalendarViewResponse {
+  value?: GraphEvent[]
+}
+
+function loadMsalCache(): MsalCache {
+  return JSON.parse(readFileSync(MSAL_CACHE_PATH, 'utf-8')) as MsalCache
+}
+
+function saveMsalCache(cache: MsalCache): void {
+  writeFileSync(MSAL_CACHE_PATH, JSON.stringify(cache, null, 2))
+}
+
+function findAccessToken(cache: MsalCache): MsalAccessToken | null {
+  const entries = Object.values(cache.AccessToken ?? {})
+  return entries[0] ?? null
+}
+
+function findRefreshToken(cache: MsalCache): MsalRefreshToken | null {
+  const entries = Object.values(cache.RefreshToken ?? {})
+  return entries[0] ?? null
+}
+
+function httpsRequest(url: string, options: https.RequestOptions, body?: string): Promise<{ status: number; data: string }> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, options, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (chunk: Buffer) => chunks.push(chunk))
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, data: Buffer.concat(chunks).toString('utf-8') }))
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    if (body) req.write(body)
+    req.end()
+  })
+}
+
+async function refreshAccessToken(cache: MsalCache): Promise<string> {
+  const atEntry = findAccessToken(cache)
+  const rtEntry = findRefreshToken(cache)
+  if (!atEntry || !rtEntry) throw new Error('M365: no token entries in MSAL cache')
+
+  const clientId = atEntry.client_id
+  const tenantId = atEntry.realm
+  const tokenEndpoint = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    grant_type: 'refresh_token',
+    refresh_token: rtEntry.secret,
+    scope: 'https://graph.microsoft.com/Calendars.Read offline_access',
+  })
+
+  const { status, data } = await httpsRequest(
+    tokenEndpoint,
+    { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+    params.toString()
+  )
+
+  if (status !== 200) {
+    logger.error({ status, body: data }, 'M365 token refresh failed')
+    throw new Error(`M365 token refresh failed: ${status}`)
+  }
+
+  const refreshed = JSON.parse(data)
+  const now = Math.floor(Date.now() / 1000)
+
+  // Update access token entry in cache
+  const cacheKey = Object.keys(cache.AccessToken ?? {})[0]
+  if (cacheKey && cache.AccessToken) {
+    cache.AccessToken[cacheKey] = {
+      ...cache.AccessToken[cacheKey],
+      secret: refreshed.access_token as string,
+      cached_at: String(now),
+      expires_on: String(now + (refreshed.expires_in as number)),
+    }
+  }
+
+  // Update refresh token if rotated
+  if (refreshed.refresh_token) {
+    const rtKey = Object.keys(cache.RefreshToken ?? {})[0]
+    if (rtKey && cache.RefreshToken) {
+      cache.RefreshToken[rtKey] = {
+        ...cache.RefreshToken[rtKey],
+        secret: refreshed.refresh_token as string,
+      }
+    }
+  }
+
+  saveMsalCache(cache)
+  logger.info('M365 access token refreshed')
+  return refreshed.access_token as string
+}
+
+async function getValidAccessToken(): Promise<string> {
+  const cache = loadMsalCache()
+  const atEntry = findAccessToken(cache)
+  if (!atEntry) throw new Error('M365: no access token in MSAL cache')
+
+  const expiresOn = parseInt(atEntry.expires_on, 10)
+  const nowSec = Math.floor(Date.now() / 1000)
+
+  if (nowSec > expiresOn - 300) {
+    return refreshAccessToken(cache)
+  }
+
+  return atEntry.secret
+}
+
+function toIsoWithoutTz(dt: string): string {
+  // Graph returns UTC datetime strings like "2026-05-26T10:00:00.0000000"
+  // Append Z if no timezone indicator present
+  return dt.endsWith('Z') || dt.includes('+') ? dt : dt + 'Z'
+}
+
+function mapGraphEvent(ev: GraphEvent): CalendarEvent {
+  return {
+    id: ev.id,
+    summary: ev.subject,
+    start: ev.isAllDay
+      ? { date: ev.start?.dateTime?.split('T')[0] }
+      : { dateTime: ev.start ? toIsoWithoutTz(ev.start.dateTime) : undefined },
+    end: ev.isAllDay
+      ? { date: ev.end?.dateTime?.split('T')[0] }
+      : { dateTime: ev.end ? toIsoWithoutTz(ev.end.dateTime) : undefined },
+    status: ev.isCancelled ? 'cancelled' : 'confirmed',
+    location: ev.location?.displayName,
+    attendees: ev.attendees?.map((a) => ({
+      email: a.emailAddress?.address ?? '',
+      displayName: a.emailAddress?.name,
+    })),
+  }
+}
+
+export async function getM365CalendarEvents(
+  _calendarId: string,
+  timeMin: Date,
+  timeMax: Date
+): Promise<CalendarEvent[]> {
+  const token = await getValidAccessToken()
+
+  const params = new URLSearchParams({
+    startDateTime: timeMin.toISOString(),
+    endDateTime: timeMax.toISOString(),
+    $select: 'id,subject,start,end,location,attendees,isAllDay,isCancelled',
+    $orderby: 'start/dateTime',
+    $top: '20',
+  })
+
+  const url = `${GRAPH_BASE}/me/calendarView?${params}`
+
+  const { status, data } = await httpsRequest(url, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  if (status === 401) {
+    const cache = loadMsalCache()
+    const newToken = await refreshAccessToken(cache)
+    const retry = await httpsRequest(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${newToken}` },
+    })
+    if (retry.status !== 200) {
+      logger.error({ status: retry.status, body: retry.data }, 'M365 Graph API error after refresh')
+      return []
+    }
+    const parsed: GraphCalendarViewResponse = JSON.parse(retry.data)
+    return (parsed.value ?? []).map(mapGraphEvent)
+  }
+
+  if (status !== 200) {
+    logger.error({ status, body: data }, 'M365 Graph API error')
+    return []
+  }
+
+  const parsed: GraphCalendarViewResponse = JSON.parse(data)
+  return (parsed.value ?? []).map(mapGraphEvent)
+}


### PR DESCRIPTION
## Summary

- Adds a Microsoft Graph (M365) calendar backend alongside the existing Google Calendar one
- New `CALENDAR_PROVIDER` env var controls which backend is used at runtime
- Default is `google` — no breaking change for existing deployments
- M365 token handling reads from `~/.m365-mcp/msal-cache.json` (MSAL public-client token cache) and refreshes automatically

## Details

**New files:**
- `src/m365-api.ts` — fetches events via `/me/calendarView`, handles MSAL access-token refresh using the refresh token (no client secret needed — public client flow)
- `src/calendar-provider.ts` — thin router: delegates to Google or M365 based on `CALENDAR_PROVIDER`

**Modified:**
- `src/config.ts` — exports `CALENDAR_PROVIDER: 'google' | 'm365'`
- `src/heartbeat.ts` — uses `getCalendarEventsForHeartbeat` from `calendar-provider` instead of importing `google-api` directly

## Usage

```env
# .env
CALENDAR_PROVIDER=m365   # switch to Microsoft Graph
# CALENDAR_PROVIDER=google  # default
```

M365 requires `~/.m365-mcp/msal-cache.json` with a valid MSAL token cache (Calendars.Read scope).

## Test plan

- [ ] `npm run typecheck` passes (verified locally)
- [ ] Pre-existing test suite passes (1 unrelated failure in managed-settings pre-dates this PR)
- [ ] `CALENDAR_PROVIDER=google` (default) behaves identically to before
- [ ] `CALENDAR_PROVIDER=m365` fetches events via Graph API with token auto-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)