### PR TITLE
fix(kanban): replace hardcoded 'Marveen' with BOT_NAME

### DIFF
--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -5,7 +5,7 @@ import {
   getKanbanComments, addKanbanComment, listKanbanProjects,
   getKanbanCard, getChildCards, getDb,
 } from '../../db.js'
-import { OWNER_NAME } from '../../config.js'
+import { OWNER_NAME, BOT_NAME } from '../../config.js'
 import { listAgentNames } from '../agent-config.js'
 import { generateBreakdown } from '../llm-breakdown.js'
 import { logger } from '../../logger.js'
@@ -29,7 +29,7 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
     const agents = listAgentNames().map((name) => ({ name, type: 'agent' }))
     json(res, [
       { name: OWNER_NAME, type: 'owner' },
-      { name: 'Marveen', type: 'bot' },
+      { name: BOT_NAME, type: 'bot' },
       ...agents,
     ])
     return true
@@ -140,7 +140,7 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
         })
         ids.push(id)
       }
-      addKanbanComment(parentId, 'Marveen', `Auto-breakdown: ${ids.length} subtask létrehozva (${ids.join(', ')})`)
+      addKanbanComment(parentId, BOT_NAME, `Auto-breakdown: ${ids.length} subtask létrehozva (${ids.join(', ')})`)
       return ids
     })()
     json(res, { ok: true, created })


### PR DESCRIPTION
## Summary
- Two spots in `src/web/routes/kanban.ts` referenced the literal string `'Marveen'` instead of `BOT_NAME` from `src/config.ts`.
- Forks that customize `BOT_NAME` (e.g. `Jarvis`) still saw `Marveen` in the kanban assignees dropdown and as the author of auto-breakdown comments.
- Now imports `BOT_NAME` alongside `OWNER_NAME` and uses it in both spots.

## Test plan
- [ ] Set `BOT_NAME=Jarvis` in `.env`
- [ ] `npm run build && launchctl kickstart -k gui/$(id -u)/com.jarvis.dashboard`
- [ ] `curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" http://localhost:3420/api/kanban/assignees` → bot row shows `Jarvis`, not `Marveen`
- [ ] Trigger auto-breakdown on a kanban card → comment author = `Jarvis`

🤖 Generated with [Claude Code](https://claude.com/claude-code)