### PR TITLE
refactor(channels): remove dev-channels flag, document managed-settings.json gate

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -43,14 +43,18 @@ case "$CHANNEL_PROVIDER" in
   *)        PLUGIN_ID="telegram@claude-plugins-official" ;;
 esac
 
-# Discord plugin is not on Claude Code's org-approved channels list, so
-# `--channels plugin:discord@...` makes the plugin's MCP server fail at
-# start ("1 MCP server failed" in the pane footer). The dev-channels flag
-# bypasses the allowlist, but REQUIRES a tagged entry -- bare flag exits 1
-# with "entries must be tagged". Telegram + Slack are on the default
-# allowlist and don't need this.
-DEVCHANNELS_FLAG=""
-[ "$CHANNEL_PROVIDER" = "discord" ] && DEVCHANNELS_FLAG="--dangerously-load-development-channels plugin:${PLUGIN_ID}"
+# ROOT-CAUSE NOTE (kali-linux WSL, claude-code 2.1.152, 2026-05-27):
+# Inbound MCP notifications from the `--channels` plugin go through a SECOND
+# gate beyond --dangerously-skip-permissions / --dangerously-load-development-
+# channels: claude-code checks `/etc/claude-code/managed-settings.json`
+# allowedChannelPlugins and SILENTLY DROPS notifications from any plugin not
+# in that list. The plugin still sends the MCP notification successfully
+# (confirmed by debug-logging the plugin), but the session never ingests it.
+# Symptom: bot online, plugin debug shows "MCP notification SENT successfully",
+# but claude pane shows no <channel source="..."> inbound and the bot never
+# replies. Fix is to add the plugin to managed-settings.json (requires sudo).
+# Once that's done, the dev-channels flag is unnecessary -- this is why
+# the earlier DEVCHANNELS_FLAG block was removed.
 
 # Extra safety net for existing installs whose tmux server already has a
 # polluted global env -- scrub channel tokens so new child sessions don't
@@ -78,7 +82,7 @@ $TMUX kill-session -t "$SESSION" 2>/dev/null
 # resuming one of those loses the --channels activation state, causing
 # "Channel notifications skipped: server not in --channels list" errors.
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "$CLAUDE --dangerously-skip-permissions $DEVCHANNELS_FLAG --channels plugin:${PLUGIN_ID}"
+  "$CLAUDE --dangerously-skip-permissions --channels plugin:${PLUGIN_ID}"
 
 # Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
 # kulonben a headless session orokre parkolna a prompton es a Telegram plugin
@@ -92,11 +96,6 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
   sleep 1
   pane=$($TMUX capture-pane -t "$SESSION" -p 2>/dev/null || true)
   case "$pane" in
-    *"Loading development channels"*"I am using this for local development"*)
-      $TMUX send-keys -t "$SESSION" "1" Enter
-      sleep 1
-      continue
-      ;;
     *"Bypass Permissions mode"*"Yes, I accept"*)
       $TMUX send-keys -t "$SESSION" "2" Enter
       sleep 1

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -197,10 +197,14 @@ function resumeMarveenSession(): boolean {
     const claudeCmd = [
       'export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"',
       '&&', CLAUDE, '--continue', '--dangerously-skip-permissions',
-      // Discord plugin is not on the org-approved channels allowlist.
-      // Flag REQUIRES a tagged entry -- bare flag exits 1 with
-      // "entries must be tagged". Telegram + Slack don't need this.
-      ...(provider.type === 'discord' ? [`--dangerously-load-development-channels plugin:${provider.pluginId}`] : []),
+      // NOTE: inbound from `--channels` goes through a separate
+      // allowlist at /etc/claude-code/managed-settings.json
+      // (allowedChannelPlugins). If the plugin isn't listed there,
+      // claude-code 2.1.152+ silently drops MCP notifications even
+      // with --dangerously-skip-permissions. The dev-channels flag
+      // does NOT bypass this -- you must edit managed-settings.json
+      // (root) to add the plugin. See scripts/channels.sh for the
+      // full root-cause note.
       `--channels plugin:${provider.pluginId}`,
     ].join(' ')
     execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })


### PR DESCRIPTION
## Summary

The job-level `if:` in `.github/workflows/claude.yml` uses `contains(..., '@claude')`, which is a literal substring check. Comments that reference any plugin marketplace whose name begins with `@claude-` (e.g. `@claude-plugins-official`, `@claude-code-slack-channel`) match this filter even though no `@claude` mention is intended.

When that happens, the workflow starts, the action correctly emits `No trigger was met for @claude`, but has already requested an OIDC token. For comments from users without write access, the subsequent OIDC → app-token exchange returns 401 and the run ends in `failure`.

## Observed

Six such failures today, triggered by comments that mentioned `@claude-plugins-official` on #36431 / #36837 — example run [#26360938809](https://github.com/anthropics/claude-code/actions/runs/26360938809):

```
No trigger was met for @claude
Auto-detected mode: agent for event: issue_comment
Requesting OIDC token...
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
```

## Fix

Add a small shell step that performs a Perl-regex word-boundary check (`@claude(?![a-zA-Z0-9_-])`) over the relevant body/title fields, passed via env vars (no inline interpolation, no script-injection surface). The two downstream steps (`Checkout`, `Run Claude Code`) gate on `steps.trigger_check.outputs.matched == 'true'`.

Real `@claude` mentions still match; only substring false positives no longer produce misleading failures in the Actions UI.

## Why a step-level shell check instead of refining `if:` directly

GitHub Actions expression language has no regex; an expression-only fix would need an OR-chain over `@claude `, end-of-string, and punctuation forms × 4 event types × multiple body fields — visually noisy and brittle. A single shell step with proper `\b` semantics is shorter and more maintainable.

## Local verification

Ran the regex against 10 cases (GNU grep `-P`, `LC_ALL=C.UTF-8`):

| Case | Input | Expected | Actual |
|------|-------|----------|--------|
| 1 | `@claude please review` | match | match |
| 2 | `look at @claude-plugins-official` | nomatch | nomatch |
| 3 | `see @claude-code-slack-channel for community` | nomatch | nomatch |
| 4 | `ping @claude.bot` | match | match |
| 5 | `EOL: @claude` | match | match |
| 6 | `punct: @claude!` | match | match |
| 7 | `underscore: @claude_bot` | nomatch | nomatch |
| 8 | multiline body containing `@claude` | match | match |
| A | full Comment-A body (`@claude-plugins-official…`) | nomatch | nomatch |
| B | full Comment-B body (`@claude — this IS…`) | match | match |

End-to-end Actions integration was not exercised on my fork (billing-locked account; jobs do not start), so the test plan below is for a reviewer with running CI.

## Test plan

- [ ] Comment containing `@claude please review` triggers a full run as before.
- [ ] Comment containing only `@claude-plugins-official` (or similar `@claude-…`) starts the workflow, the `trigger_check` step emits the notice, and the job exits cleanly without attempting OIDC exchange.
- [ ] Same for `pull_request_review_comment`, `pull_request_review`, and `issues` event types — covered by the `BODY: || ||` env fallback.