### PR TITLE
refactor(channels): remove dev-channels flag, document managed-settings.json gate

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -43,14 +43,18 @@ case "$CHANNEL_PROVIDER" in
   *)        PLUGIN_ID="telegram@claude-plugins-official" ;;
 esac
 
-# Discord plugin is not on Claude Code's org-approved channels list, so
-# `--channels plugin:discord@...` makes the plugin's MCP server fail at
-# start ("1 MCP server failed" in the pane footer). The dev-channels flag
-# bypasses the allowlist, but REQUIRES a tagged entry -- bare flag exits 1
-# with "entries must be tagged". Telegram + Slack are on the default
-# allowlist and don't need this.
-DEVCHANNELS_FLAG=""
-[ "$CHANNEL_PROVIDER" = "discord" ] && DEVCHANNELS_FLAG="--dangerously-load-development-channels plugin:${PLUGIN_ID}"
+# ROOT-CAUSE NOTE (kali-linux WSL, claude-code 2.1.152, 2026-05-27):
+# Inbound MCP notifications from the `--channels` plugin go through a SECOND
+# gate beyond --dangerously-skip-permissions / --dangerously-load-development-
+# channels: claude-code checks `/etc/claude-code/managed-settings.json`
+# allowedChannelPlugins and SILENTLY DROPS notifications from any plugin not
+# in that list. The plugin still sends the MCP notification successfully
+# (confirmed by debug-logging the plugin), but the session never ingests it.
+# Symptom: bot online, plugin debug shows "MCP notification SENT successfully",
+# but claude pane shows no <channel source="..."> inbound and the bot never
+# replies. Fix is to add the plugin to managed-settings.json (requires sudo).
+# Once that's done, the dev-channels flag is unnecessary -- this is why
+# the earlier DEVCHANNELS_FLAG block was removed.
 
 # Extra safety net for existing installs whose tmux server already has a
 # polluted global env -- scrub channel tokens so new child sessions don't
@@ -78,7 +82,7 @@ $TMUX kill-session -t "$SESSION" 2>/dev/null
 # resuming one of those loses the --channels activation state, causing
 # "Channel notifications skipped: server not in --channels list" errors.
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "$CLAUDE --dangerously-skip-permissions $DEVCHANNELS_FLAG --channels plugin:${PLUGIN_ID}"
+  "$CLAUDE --dangerously-skip-permissions --channels plugin:${PLUGIN_ID}"
 
 # Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
 # kulonben a headless session orokre parkolna a prompton es a Telegram plugin
@@ -92,11 +96,6 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
   sleep 1
   pane=$($TMUX capture-pane -t "$SESSION" -p 2>/dev/null || true)
   case "$pane" in
-    *"Loading development channels"*"I am using this for local development"*)
-      $TMUX send-keys -t "$SESSION" "1" Enter
-      sleep 1
-      continue
-      ;;
     *"Bypass Permissions mode"*"Yes, I accept"*)
       $TMUX send-keys -t "$SESSION" "2" Enter
       sleep 1

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -197,10 +197,14 @@ function resumeMarveenSession(): boolean {
     const claudeCmd = [
       'export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"',
       '&&', CLAUDE, '--continue', '--dangerously-skip-permissions',
-      // Discord plugin is not on the org-approved channels allowlist.
-      // Flag REQUIRES a tagged entry -- bare flag exits 1 with
-      // "entries must be tagged". Telegram + Slack don't need this.
-      ...(provider.type === 'discord' ? [`--dangerously-load-development-channels plugin:${provider.pluginId}`] : []),
+      // NOTE: inbound from `--channels` goes through a separate
+      // allowlist at /etc/claude-code/managed-settings.json
+      // (allowedChannelPlugins). If the plugin isn't listed there,
+      // claude-code 2.1.152+ silently drops MCP notifications even
+      // with --dangerously-skip-permissions. The dev-channels flag
+      // does NOT bypass this -- you must edit managed-settings.json
+      // (root) to add the plugin. See scripts/channels.sh for the
+      // full root-cause note.
       `--channels plugin:${provider.pluginId}`,
     ].join(' ')
     execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })


### PR DESCRIPTION
## Summary
- Remove `--dangerously-load-development-channels` flag + paired `"Loading development channels"` auto-accept (`scripts/channels.sh`, `src/web/channel-monitor.ts`)
- claude-code 2.1.152+ silently drops inbound MCP notifications from plugins not in `/etc/claude-code/managed-settings.json` `allowedChannelPlugins` — the flag does **not** bypass this. Real fix is one-line addition to managed-settings.
- Adds `ROOT-CAUSE NOTE` comment in `channels.sh` documenting the gate + symptoms for future maintainers.

Follow-up to #163.

## Test plan
Tested on **kali-linux (WSL2)** with claude-code 2.1.152 — Discord works for me end-to-end. Not tested on macOS.

- [x] `tsc --noEmit` passes
- [x] Discord bot inbound text message → claude session ingests + replies
- [x] Discord bot outbound text reply visible in channel
- [x] Photo / image attachment send to Discord channel
- [x] File / attachment upload to Discord channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)