### PR TITLE
fix(wsl): systemd fallback + channel token isolation + restart safety

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -18,7 +18,16 @@ if [ "$OS" = "Darwin" ]; then
   launchctl load "$HOME/Library/LaunchAgents/com.${SLUG}.dashboard.plist" 2>/dev/null || true
   launchctl load "$HOME/Library/LaunchAgents/com.${SLUG}.channels.plist" 2>/dev/null || true
 elif [ "$OS" = "Linux" ]; then
-  systemctl --user start "${SLUG}-dashboard" "${SLUG}-channels"
+  if pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
+    systemctl --user start "${SLUG}-dashboard" "${SLUG}-channels"
+  else
+    echo "systemd not available (WSL or container), using direct launch..."
+    mkdir -p "$INSTALL_DIR/store"
+    nohup bun "$INSTALL_DIR/src/web/serve.ts" > "$INSTALL_DIR/store/dashboard.log" 2>&1 &
+    echo $! > "$INSTALL_DIR/store/dashboard.pid"
+    nohup bash "$INSTALL_DIR/scripts/channels.sh" > "$INSTALL_DIR/store/channels.log" 2>&1 &
+    echo $! > "$INSTALL_DIR/store/channels.pid"
+  fi
 fi
 
 echo "✓ Dashboard: http://localhost:3420"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -15,7 +15,18 @@ if [ "$OS" = "Darwin" ]; then
   launchctl unload "$HOME/Library/LaunchAgents/com.${SLUG}.dashboard.plist" 2>/dev/null
   launchctl unload "$HOME/Library/LaunchAgents/com.${SLUG}.channels.plist" 2>/dev/null
 elif [ "$OS" = "Linux" ]; then
-  systemctl --user stop "${SLUG}-dashboard" "${SLUG}-channels" 2>/dev/null || true
+  if pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
+    systemctl --user stop "${SLUG}-dashboard" "${SLUG}-channels" 2>/dev/null || true
+  else
+    for svc in dashboard channels; do
+      pidfile="$INSTALL_DIR/store/${svc}.pid"
+      if [ -f "$pidfile" ]; then
+        pid=$(cat "$pidfile")
+        kill "$pid" 2>/dev/null || true
+        rm -f "$pidfile"
+      fi
+    done
+  fi
 fi
 
 # Stop the main channels tmux session. Do NOT kill sub-agent sessions --

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -15,7 +15,7 @@ import {
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
-import { getProvider, channelStateDir, type ChannelProviderType } from '../channel-provider.js'
+import { getProvider, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import { attemptChannelMcpReconnect } from './channel-mcp-reconnect.js'
 
 const TMUX = resolveFromPath('tmux')
@@ -376,6 +376,13 @@ export function startChannelPluginMonitor(): NodeJS.Timeout {
         if (shouldEscalateMarveenDown()) handleMarveenDown()
       } else {
         if (!agentDownSince.has(t.session)) agentDownSince.set(t.session, Date.now())
+        const agentProvider = resolveAgentProvider(t.agentName!)
+        const stateDir = channelStateDir(agentProvider, agentDir(t.agentName!))
+        const agentToken = readChannelToken(agentProvider, join(stateDir, '.env'))
+        if (!agentToken) {
+          logger.warn({ agent: t.agentName, provider: agentProvider }, 'Agent has no channel token in state dir -- skipping restart to avoid token conflict')
+          continue
+        }
         logger.warn({ agent: t.agentName, provider: t.provider }, 'Agent channel plugin down -- auto-restarting')
         try {
           stopAgentProcess(t.agentName!)

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -160,15 +160,13 @@ export function setAgentEnabledPlugins(name: string, provider: ChannelProviderTy
     try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
   }
   const plugins = (existing.enabledPlugins ?? {}) as Record<string, boolean>
-  if (provider === 'discord') {
-    plugins['telegram@claude-plugins-official'] = false
-    plugins['slack-channel@marveen-marketplace'] = false
-  } else if (provider === 'slack') {
-    plugins['telegram@claude-plugins-official'] = false
-    plugins['discord@claude-plugins-official'] = false
-  } else {
-    plugins['slack-channel@marveen-marketplace'] = false
-    plugins['discord@claude-plugins-official'] = false
+  const allPlugins: Record<ChannelProviderType, string> = {
+    telegram: 'telegram@claude-plugins-official',
+    slack: 'slack-channel@marveen-marketplace',
+    discord: 'discord@claude-plugins-official',
+  }
+  for (const [p, pluginKey] of Object.entries(allPlugins)) {
+    plugins[pluginKey] = p === provider
   }
   existing.enabledPlugins = plugins
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))


### PR DESCRIPTION
## Summary
- **Bug 1 (WSL systemd)**: `start.sh` and `stop.sh` now detect systemd availability before calling `systemctl --user`. On WSL2/containers without systemd, falls back to `nohup` with PID files for clean stop.
- **Bug 3 (Token isolation)**: `setAgentEnabledPlugins` now explicitly enables the agent's own provider plugin (previously only disabled others). This ensures the project-level settings.json is unambiguous.
- **Bug 4 (Restart safety)**: `channel-monitor.ts` auto-restart now pre-checks that the agent has its own channel token in its state dir before restarting with `--channels`. Skips restart if no token found, preventing 409 Conflict from global token fallback.

Bug 2 (duplicate token detection) was already fixed in #183.

Reported via Skool community WSL2/Ubuntu bug report (4 issues).

## Test plan
- [ ] WSL2 without systemd: `bash scripts/start.sh` launches dashboard + channels via nohup
- [ ] WSL2: `bash scripts/stop.sh` kills PID-tracked processes
- [ ] Native Linux with systemd: existing `systemctl --user` path unchanged
- [ ] macOS: launchctl path unchanged
- [ ] Agent without own token: channel-monitor skips restart (check logs)
- [ ] Agent with own token: channel-monitor restarts normally
- [ ] `tsc --noEmit` passes