### PR TITLE
fix(kanban-ui): inline-edit assignee on detail view + clarify comment-author dropdown

### DIFF
--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -5,7 +5,7 @@ import {
   getKanbanComments, addKanbanComment, listKanbanProjects,
   getKanbanCard, getChildCards, getDb,
 } from '../../db.js'
-import { OWNER_NAME } from '../../config.js'
+import { OWNER_NAME, BOT_NAME } from '../../config.js'
 import { listAgentNames } from '../agent-config.js'
 import { generateBreakdown } from '../llm-breakdown.js'
 import { logger } from '../../logger.js'
@@ -29,7 +29,7 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
     const agents = listAgentNames().map((name) => ({ name, type: 'agent' }))
     json(res, [
       { name: OWNER_NAME, type: 'owner' },
-      { name: 'Marveen', type: 'bot' },
+      { name: BOT_NAME, type: 'bot' },
       ...agents,
     ])
     return true
@@ -140,7 +140,7 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
         })
         ids.push(id)
       }
-      addKanbanComment(parentId, 'Marveen', `Auto-breakdown: ${ids.length} subtask létrehozva (${ids.join(', ')})`)
+      addKanbanComment(parentId, BOT_NAME, `Auto-breakdown: ${ids.length} subtask létrehozva (${ids.join(', ')})`)
       return ids
     })()
     json(res, { ok: true, created })

--- a/web/app.js
+++ b/web/app.js
@@ -425,7 +425,7 @@ async function showCardDetail(card) {
     </div>
     <div class="meta-item">
       <span class="meta-label">Felelős</span>
-      <span class="meta-value">${assignee ? escapeHtml(assignee.name) : '-- nincs --'}</span>
+      <span class="meta-value meta-value-editable" id="metaAssigneeValue" data-card-id="${card.id}" title="Kattints a módosításhoz">${assignee ? escapeHtml(assignee.name) : '-- nincs --'}</span>
     </div>
     <div class="meta-item">
       <span class="meta-label">Prioritás</span>
@@ -440,6 +440,54 @@ async function showCardDetail(card) {
       <span class="meta-value">${card.due_date ? new Date(card.due_date * 1000).toLocaleDateString('hu-HU') : '-- nincs --'}</span>
     </div>
   `
+
+  // Inline edit for assignee on detail view
+  const assigneeValueEl = document.getElementById('metaAssigneeValue')
+  assigneeValueEl.addEventListener('click', () => {
+    if (assigneeValueEl.querySelector('select')) return
+    const current = card.assignee || ''
+    const sel = document.createElement('select')
+    sel.style.cssText = 'padding:2px 6px; border-radius:4px; border:1px solid var(--border); background:var(--bg-card); color:var(--text); font-size:inherit'
+    sel.innerHTML = '<option value="">-- Nincs --</option>'
+    for (const a of kanbanAssignees) {
+      const opt = document.createElement('option')
+      opt.value = a.name
+      opt.textContent = a.name
+      if (a.name === current) opt.selected = true
+      sel.appendChild(opt)
+    }
+    assigneeValueEl.innerHTML = ''
+    assigneeValueEl.appendChild(sel)
+    sel.focus()
+    const save = async () => {
+      const newVal = sel.value || null
+      if (newVal === current || (newVal === null && !current)) {
+        assigneeValueEl.textContent = current ? current : '-- nincs --'
+        return
+      }
+      try {
+        const r = await fetch(`/api/kanban/${encodeURIComponent(card.id)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...card, assignee: newVal }),
+        })
+        if (!r.ok) throw new Error('PUT failed')
+        card.assignee = newVal
+        assigneeValueEl.textContent = newVal ? newVal : '-- nincs --'
+        showToast('Felelős frissítve')
+        loadKanban && loadKanban()
+      } catch {
+        assigneeValueEl.textContent = current ? current : '-- nincs --'
+        showToast('Hiba a mentésnél')
+      }
+    }
+    sel.addEventListener('change', save)
+    sel.addEventListener('blur', () => {
+      if (assigneeValueEl.querySelector('select')) {
+        assigneeValueEl.textContent = card.assignee ? card.assignee : '-- nincs --'
+      }
+    })
+  })
 
   document.getElementById('cardDetailDesc').textContent = card.description || ''
 

--- a/web/index.html
+++ b/web/index.html
@@ -1073,7 +1073,8 @@
               </div>
             </div>
             <div class="form-row" style="gap:8px; align-items:center">
-              <select id="commentAuthor" class="comment-author-select"></select>
+              <label for="commentAuthor" style="font-size:0.85em; color:var(--text-muted)">Komment szerzője:</label>
+              <select id="commentAuthor" class="comment-author-select" title="A komment szerzője. A kártya felelőse fent, a Felelős mezőre kattintva állítható."></select>
               <button class="btn-primary btn-compact" id="addCommentBtn">Küldés</button>
             </div>
           </div>

--- a/web/style.css
+++ b/web/style.css
@@ -1934,6 +1934,13 @@ main {
   font-size: 13px;
   color: var(--text-secondary);
 }
+.meta-value-editable {
+  cursor: pointer;
+  border-bottom: 1px dashed var(--border);
+}
+.meta-value-editable:hover {
+  color: var(--text);
+}
 
 .task-detail-result {
   margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- Inline-edit Felelős (assignee) directly on the card detail meta — click → dropdown → auto-save → board refresh.
- Comment-author select beside Küldés now has explicit label and tooltip pointing to the inline Felelős edit. Previously users could mistake it for the card-level assignee, press Küldés, and only post a comment.

## Test plan
- [ ] Open any kanban card detail.
- [ ] Click the "Felelős" value → dropdown appears with all assignees → pick one → toast "Felelős frissítve" + card updates.
- [ ] Verify the comment form now shows "Komment szerzője:" before its select; hover shows tooltip about the inline edit.
- [ ] Edge: click "Felelős" then click elsewhere → reverts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)