### PR TITLE
pane-state: detect wedged thinking-block API error, stop injecting + alert

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import {
   detectPaneState,
+  detectsThinkingBlockError,
   isReadyForPrompt,
   shouldRetrySubmit,
   shouldClearTruncatedPreamble,
   decideSubmitFollowup,
+  decidePaneErrorAlert,
 } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
@@ -175,6 +177,130 @@ const IDLE_BACKGROUND_ONE_SHELL_HIDDEN = [
   '  ⏵⏵ bypass permissions on · 1 shell · ↓ to manage',
 ].join('\n')
 
+// Wedged thinking-block API error. An assistant turn ended with the
+// 400 about thinking blocks that "cannot be modified"; the pane shows
+// the tool-output chrome (`⎿  API Error: ...`), a past-tense thinking
+// stamp, an empty input box and the idle footer. The U+23BF result
+// glyph and the full phrase are reproduced exactly so the regex sees
+// the same bytes it would in prod. Sanitised: no internal names/paths.
+const ERROR_THINKING_BLOCK = [
+  '  ⎿  API Error: 400 messages.55.content.19: `thinking` or `redacted_thinking` blocks in the latest assistant message',
+  '      cannot be modified. These blocks must remain as they were in the original response.',
+  '',
+  '✻ Sauteed for 1s',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A message body that QUOTES "API Error 400" in prose (an instruction
+// to report if the error recurs). No `⎿  API Error: <num>` chrome and
+// no "cannot be modified" phrase -- must NOT be read as a wedged error.
+const ERROR_ECHO_IN_MESSAGE = [
+  '  HA a session-history korrupt es ismet API Error 400 jon a feldolgozas',
+  '  elejen, AZONNAL jelezd vissza inter-agent uzenetben.',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A reply that quotes the FULL phrase ("thinking ... cannot be
+// modified") in prose, e.g. a bug analysis, but WITHOUT the
+// `⎿  API Error: <num>` chrome glyph. The chrome guard must keep this
+// out of the 'error' class.
+const ERROR_FULL_PHRASE_PROSE = [
+  '  A hiba lenyege: a thinking vagy redacted_thinking blocks cannot be',
+  '  modified ket API-hivas kozott. Ezt most csak elemzem, nem elo hiba.',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// An old error far up in scrollback (above the live tail), with a fresh
+// idle turn below it. The position scope must ignore the stale error so
+// a recovered session is not stuck classified as 'error'.
+const ERROR_DEEP_SCROLLBACK = [
+  '  ⎿  API Error: 400 messages.55.content.19: `thinking` blocks cannot be modified.',
+  ...Array(24).fill('  (normal output line after the session recovered)'),
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Error chrome present BUT a live spinner is also rendered: the turn is
+// running again, not wedged. The busy guard must win so we do not stop
+// injecting into a session that is actually working.
+const ERROR_DURING_BUSY = [
+  '  ⎿  API Error: 400 messages.55.content.19: `thinking` blocks cannot be modified.',
+  '✻ Combobulating… (12s · ↓ 480 tokens)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+].join('\n')
+
+// A BENIGN chrome error (429) on one line AND an unrelated "thinking ...
+// cannot be modified" prose several lines below it (outside the chrome
+// block). The guards are required WITHIN one chrome block, so this must
+// NOT be flagged -- otherwise a healthy session that hits a rate limit
+// and elsewhere mentions the phrase would be wrongly reset.
+const ERROR_DECOUPLED_BENIGN = [
+  '  ⎿  API Error: 429 overloaded_error: server busy, retrying',
+  '  retry succeeded, continuing the task',
+  '  finished that step',
+  '',
+  '  Note: the thinking-block error is when a block cannot be modified.',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A real wedged error with a STRAY footer-looking line ("? for
+// shortcuts") quoted higher up in scrollback. The footer must be found
+// from the bottom, otherwise the scope locks onto the stray line and the
+// real error below it is missed (false negative).
+const ERROR_WITH_STRAY_FOOTER_ABOVE = [
+  '  Use the ? for shortcuts hint mentioned in the docs',
+  '  (a scrollback message that quotes help text)',
+  '  ⎿  API Error: 400 messages.55.content.19: `thinking` or `redacted_thinking` blocks in the latest assistant message',
+  '      cannot be modified. These blocks must remain as they were in the original response.',
+  '✻ Sauteed for 1s',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Narrow terminal: the long error message wraps so "cannot be modified"
+// lands on the 4th line of the chrome block (chrome + 3 continuations).
+// A 3-line window would miss it (false negative); the 4-line block
+// catches it. The thinking kind is on the chrome line, redacted_thinking
+// on the 2nd, the phrase on the 4th.
+const ERROR_NARROW_WRAP = [
+  '  ⎿  API Error: 400 messages.55.content.19: `thinking`',
+  '      or `redacted_thinking` blocks in the latest assistant',
+  '      message. These response',
+  '      blocks cannot be modified and must remain unchanged.',
+  '✻ Sauteed for 1s',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
 describe('detectPaneState', () => {
   it('returns unknown for empty input', () => {
     expect(detectPaneState('')).toBe('unknown')
@@ -261,6 +387,64 @@ describe('detectPaneState', () => {
 
   it('detects busy when a tool-use summary is paired with a live spinner', () => {
     expect(detectPaneState(BUSY_TOOL_USE_ACTIVE)).toBe('busy')
+  })
+
+  it('detects error when wedged on the thinking-block 400', () => {
+    // The wedged state: idle footer (turn finished) + past-tense
+    // thinking stamp, no live busy signal, but the live tail shows the
+    // `⎿  API Error: ... thinking ... cannot be modified` output. Old
+    // detector said 'idle' here, so the scheduler kept injecting doomed
+    // prompts. Must now be 'error' so isReadyForPrompt() returns false.
+    expect(detectPaneState(ERROR_THINKING_BLOCK)).toBe('error')
+  })
+
+  it('does NOT classify a prose "API Error 400" mention as error', () => {
+    // A message body quoting "API Error 400" (an instruction to report
+    // recurrence) has no `⎿  API Error: <num>` chrome and no
+    // "cannot be modified" phrase. Must stay idle.
+    expect(detectPaneState(ERROR_ECHO_IN_MESSAGE)).toBe('idle')
+  })
+
+  it('does NOT classify the full phrase in prose (no chrome) as error', () => {
+    // A bug-analysis reply quoting "thinking ... cannot be modified" in
+    // prose, without the tool-output chrome glyph, must not trip the
+    // detector. The chrome guard is what discriminates a real wedged
+    // turn from a quote.
+    expect(detectPaneState(ERROR_FULL_PHRASE_PROSE)).toBe('idle')
+  })
+
+  it('does NOT classify a stale error in deep scrollback as error', () => {
+    // Once a session recovers, its old error scrolls up out of the live
+    // tail. The position scope must ignore it so a healthy session is
+    // not stuck flagged. Below the stale error the pane is plainly idle.
+    expect(detectPaneState(ERROR_DEEP_SCROLLBACK)).toBe('idle')
+  })
+
+  it('prefers busy over error when a live spinner is rendered', () => {
+    // Error chrome on screen but the turn is running again (spinner +
+    // token tail). The busy guard precedes the error guard so we do not
+    // stop injecting into a session that is actually working.
+    expect(detectPaneState(ERROR_DURING_BUSY)).toBe('busy')
+  })
+
+  it('does NOT flag a benign chrome + decoupled phrase as error', () => {
+    // A 429 chrome on one line and an unrelated "cannot be modified"
+    // prose several lines below (outside the chrome block) must not
+    // AND-combine into a false positive. This is the per-block guard.
+    expect(detectPaneState(ERROR_DECOUPLED_BENIGN)).toBe('idle')
+  })
+
+  it('detects error even when a stray footer line sits in scrollback', () => {
+    // The footer is found from the bottom, so a "? for shortcuts" string
+    // quoted higher up does not steal the scope from the real wedged
+    // error sitting just above the live footer.
+    expect(detectPaneState(ERROR_WITH_STRAY_FOOTER_ABOVE)).toBe('error')
+  })
+
+  it('detects error when a narrow terminal wraps the message onto 4 lines', () => {
+    // The phrase "cannot be modified" wraps to the 4th line of the
+    // chrome block. The 4-line block window must still catch it.
+    expect(detectPaneState(ERROR_NARROW_WRAP)).toBe('error')
   })
 
   it('does NOT classify idle-with-stale-tool-use-scrollback as busy', () => {
@@ -408,6 +592,71 @@ describe('isReadyForPrompt', () => {
     expect(isReadyForPrompt(PENDING_PASTE)).toBe(false)
     expect(isReadyForPrompt(NON_CLAUDE)).toBe(false)
     expect(isReadyForPrompt('')).toBe(false)
+    // A wedged thinking-block error is not idle, so it is not ready --
+    // this is what stops the router/scheduler injecting doomed prompts.
+    expect(isReadyForPrompt(ERROR_THINKING_BLOCK)).toBe(false)
+  })
+})
+
+describe('detectsThinkingBlockError', () => {
+  it('is true on the wedged thinking-block 400 pane', () => {
+    expect(detectsThinkingBlockError(ERROR_THINKING_BLOCK)).toBe(true)
+  })
+
+  it('is false on a healthy idle pane', () => {
+    expect(detectsThinkingBlockError(IDLE_BYPASS)).toBe(false)
+    expect(detectsThinkingBlockError(IDLE_BACKGROUND_SHELLS)).toBe(false)
+  })
+
+  it('is false when only the chrome is present without the thinking phrase', () => {
+    // A different turn-level API error (rate limit, overloaded) renders
+    // the same `⎿  API Error:` chrome but is NOT the thinking-block
+    // class. Those recover on their own / via the rate-limit watchdog,
+    // so they must not be flagged as the wedged state.
+    const rateLimit = [
+      '  ⎿  API Error: 429 rate_limit_error: too many requests',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectsThinkingBlockError(rateLimit)).toBe(false)
+  })
+
+  it('is false when the phrase appears without the chrome glyph', () => {
+    expect(detectsThinkingBlockError(ERROR_FULL_PHRASE_PROSE)).toBe(false)
+  })
+
+  it('is false when there is no idle footer (no live region to scope)', () => {
+    // Without an idle footer the pane is busy or not a Claude surface;
+    // there is no settled live tail to inspect, so we never flag error.
+    const noFooter = [
+      '  ⎿  API Error: 400 messages.55.content.19: `thinking` blocks cannot be modified.',
+      '✻ Combobulating… (12s · ↓ 480 tokens · esc to interrupt)',
+    ].join('\n')
+    expect(detectsThinkingBlockError(noFooter)).toBe(false)
+  })
+
+  it('is false on a stale error above the live tail', () => {
+    expect(detectsThinkingBlockError(ERROR_DEEP_SCROLLBACK)).toBe(false)
+  })
+
+  it('is false when chrome and phrase are in different blocks', () => {
+    // Benign 429 chrome + decoupled phrase prose below it: the phrase
+    // and kind must co-occur within ONE chrome block, not anywhere in
+    // the tail, so this stays false.
+    expect(detectsThinkingBlockError(ERROR_DECOUPLED_BENIGN)).toBe(false)
+  })
+
+  it('is true with a stray footer line above the real footer', () => {
+    // Footer found from the bottom: the stray "? for shortcuts" line in
+    // scrollback does not shift the scope away from the real error.
+    expect(detectsThinkingBlockError(ERROR_WITH_STRAY_FOOTER_ABOVE)).toBe(true)
+  })
+
+  it('is false on empty input', () => {
+    expect(detectsThinkingBlockError('')).toBe(false)
   })
 })
 
@@ -777,5 +1026,107 @@ describe('decideSubmitFollowup', () => {
     // Done-state on a maxAttempts=0 pane still returns done -- there
     // is nothing to retry.
     expect(decideSubmitFollowup(IDLE_BYPASS, PAYLOAD_HINT, 0, 0)).toBe('done')
+  })
+})
+
+describe('decidePaneErrorAlert', () => {
+  const TH = { confirmMs: 120_000, dedupMs: 1_800_000, clearMs: 300_000 }
+  const NONE = { firstSeenAt: null, lastAlertAt: null, lastErrorAt: null }
+
+  it('does nothing when not in error and no active spell', () => {
+    const d = decidePaneErrorAlert(false, NONE, 5000, TH)
+    expect(d.alert).toBe(false)
+    expect(d.next).toEqual(NONE)
+  })
+
+  it('records first sighting without alerting (confirm window)', () => {
+    const d = decidePaneErrorAlert(true, NONE, 10_000, TH)
+    expect(d.alert).toBe(false)
+    expect(d.next.firstSeenAt).toBe(10_000)
+    expect(d.next.lastAlertAt).toBe(null)
+    expect(d.next.lastErrorAt).toBe(10_000)
+  })
+
+  it('does not alert while still inside the confirm window', () => {
+    // First seen at t=0, now t=60s, confirm window 120s -> not yet.
+    const d = decidePaneErrorAlert(true, { firstSeenAt: 0, lastAlertAt: null, lastErrorAt: 0 }, 60_000, TH)
+    expect(d.alert).toBe(false)
+    expect(d.next.firstSeenAt).toBe(0)
+  })
+
+  it('alerts once the confirm window elapses (first alert)', () => {
+    const d = decidePaneErrorAlert(true, { firstSeenAt: 0, lastAlertAt: null, lastErrorAt: 60_000 }, 120_000, TH)
+    expect(d.alert).toBe(true)
+    expect(d.next.firstSeenAt).toBe(0)
+    expect(d.next.lastAlertAt).toBe(120_000)
+  })
+
+  it('suppresses repeat alerts inside the dedup window', () => {
+    // Sustained error, last alert 10 min ago, dedup 30 min -> quiet.
+    const d = decidePaneErrorAlert(true, { firstSeenAt: 0, lastAlertAt: 120_000, lastErrorAt: 660_000 }, 720_000, TH)
+    expect(d.alert).toBe(false)
+    expect(d.next.lastAlertAt).toBe(120_000)
+  })
+
+  it('re-alerts once the dedup window elapses', () => {
+    // Last alert at t=120s, now t=120s+30min -> dedup elapsed.
+    const now = 120_000 + 1_800_000
+    const d = decidePaneErrorAlert(true, { firstSeenAt: 0, lastAlertAt: 120_000, lastErrorAt: now - 60_000 }, now, TH)
+    expect(d.alert).toBe(true)
+    expect(d.next.lastAlertAt).toBe(now)
+  })
+
+  it('clears the spell after a sustained error-free gap', () => {
+    // error stops, last error 6 min ago (> clearMs 5 min) -> clear.
+    const d = decidePaneErrorAlert(false, { firstSeenAt: 0, lastAlertAt: 120_000, lastErrorAt: 60_000 }, 420_000, TH)
+    expect(d.alert).toBe(false)
+    expect(d.next).toEqual(NONE)
+  })
+
+  it('starts a fresh spell after the cleared recovery', () => {
+    // error -> sustained recovery (cleared) -> error again times its own
+    // confirm window from the new sighting.
+    const recovered = decidePaneErrorAlert(false, { firstSeenAt: 0, lastAlertAt: 120_000, lastErrorAt: 60_000 }, 420_000, TH)
+    expect(recovered.next).toEqual(NONE)
+    const reappeared = decidePaneErrorAlert(true, recovered.next, 500_000, TH)
+    expect(reappeared.alert).toBe(false)
+    expect(reappeared.next.firstSeenAt).toBe(500_000)
+  })
+
+  it('holds the spell across a brief non-error blip (flapping capture)', () => {
+    // A genuinely wedged but flapping session: error, then one non-error
+    // tick (null capture / mid-flight busy) only 60s after the last
+    // error (< clearMs). The spell must NOT reset, otherwise the confirm
+    // window never elapses and the wedged session never alerts.
+    const held = decidePaneErrorAlert(false, { firstSeenAt: 0, lastAlertAt: null, lastErrorAt: 60_000 }, 120_000, TH)
+    expect(held.alert).toBe(false)
+    expect(held.next.firstSeenAt).toBe(0) // spell preserved
+    // The next error tick is sustained from the original firstSeenAt and
+    // alerts (confirm window elapsed), proving the flap did not starve it.
+    const back = decidePaneErrorAlert(true, held.next, 180_000, TH)
+    expect(back.alert).toBe(true)
+  })
+
+  it('never alerts on the first sighting even when confirmMs is 0', () => {
+    // The first-sighting guard means an error must be observed on at
+    // least two ticks before any alert, independent of confirmMs. A
+    // single transient one-tick error never fires an alert.
+    const zeroTh = { confirmMs: 0, dedupMs: 1_800_000, clearMs: 300_000 }
+    const first = decidePaneErrorAlert(true, NONE, 1000, zeroTh)
+    expect(first.alert).toBe(false)
+    expect(first.next.firstSeenAt).toBe(1000)
+    // Second tick with confirmMs=0 now alerts (sustained from tick 1).
+    const second = decidePaneErrorAlert(true, first.next, 1001, zeroTh)
+    expect(second.alert).toBe(true)
+  })
+
+  it('does not stall on backwards clock skew (future timestamp)', () => {
+    // now jumps backwards (NTP correction): a stored firstSeenAt in the
+    // future would drive the delta negative and stall. Instead restart
+    // the spell from now rather than getting stuck never-alerting.
+    const skewed = decidePaneErrorAlert(true, { firstSeenAt: 1_000_000, lastAlertAt: 1_000_000, lastErrorAt: 1_000_000 }, 500_000, TH)
+    expect(skewed.alert).toBe(false)
+    expect(skewed.next.firstSeenAt).toBe(500_000)
+    expect(skewed.next.lastAlertAt).toBe(null)
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -19,7 +19,7 @@
 // captured pane fixtures. The I/O (capture-pane + double-sample) lives
 // in src/web.ts alongside the rest of the scheduler.
 
-export type PaneState = 'idle' | 'busy' | 'typing' | 'unknown'
+export type PaneState = 'idle' | 'busy' | 'typing' | 'unknown' | 'error'
 
 // Claude Code shows the footer in one of two modes: the default "bypass"
 // permissions mode (permissive) and the "strict" mode. Both are "idle"
@@ -101,6 +101,88 @@ const BOX_SEP_RX = /^─{10,}/
 // ([ \t] not \s) to avoid crossing into the next line.
 const PARKED_INPUT_RX = /❯[ \t]+\S/
 
+// Persistent Anthropic thinking-block API error. When an assistant turn
+// ends with a 400 about thinking/redacted_thinking blocks that "cannot
+// be modified", the session is wedged: every subsequent prompt re-sends
+// the same context and yields the identical 400. The pane shows the idle
+// footer (turn "finished") plus a past-tense thinking stamp but NO live
+// busy indicator, so detectPaneState would otherwise classify it 'idle'
+// and the scheduler/router would keep injecting -- each injection
+// another doomed 400. Surfacing this as a distinct 'error' state makes
+// isReadyForPrompt() return false so injection stops, and lets the
+// channel monitor alert that a manual reset is needed.
+//
+// Three guards, ALL required, to avoid flagging a healthy session that
+// merely quotes the error text (a bug-report message, a log analysis):
+//
+//   (a) Position scope: only the "live tail" (the lines just above the
+//       idle footer) is inspected, never deep scrollback. A long-ago
+//       turn's error echo above the live region is ignored. The footer
+//       is found from the BOTTOM (the live footer is always the last
+//       line of the pane) so a footer-looking string quoted higher up
+//       in scrollback does not shift the scope.
+//   (b) Chrome glyph: the error must render as a tool-output line
+//       `⎿  API Error: <code>` -- the U+23BF result glyph Claude Code
+//       prints before a turn-level error. Prose that quotes "API Error
+//       400" in a message body has no leading `⎿  API Error: <num>`.
+//   (c) Specific phrase: the thinking-block signature `cannot be
+//       modified` together with `thinking` or `redacted_thinking`. A
+//       generic API error (rate limit, overloaded) is NOT this class.
+//
+// (b) and (c) are required WITHIN ONE CHROME BLOCK (the chrome line plus
+// its wrapped continuation), not anywhere in the joined tail. Otherwise
+// a benign `⎿ API Error: 429` on one line plus an unrelated "thinking
+// ... cannot be modified" prose on another line would AND-combine into
+// a false positive on a healthy session.
+const ERROR_CHROME_RX = /⎿\s*API Error:\s*\d+/
+const ERROR_THINKING_PHRASE_RX = /cannot be modified/
+const ERROR_THINKING_KIND_RX = /\b(?:redacted_thinking|thinking)\b/
+
+// How many lines above the idle footer count as the "live tail". The
+// error output (the `⎿` line + its wrapped continuation), the thinking
+// stamp, and the input box together span well under 20 lines; 20 gives
+// margin for terminal re-flow without reaching deep scrollback.
+const ERROR_LIVE_TAIL_LINES = 20
+
+// How many lines a single API-error render spans: the `⎿` chrome line
+// plus its wrapped continuation. The thinking-block message is long and
+// the terminal wraps it; at ~80 cols "cannot be modified" lands on the
+// 2nd line, at ~60 cols on the 3rd-4th. 4 covers narrow panes while
+// staying short enough that an adjacent unrelated chrome block does not
+// bleed in (the decoupled-benign test pins this boundary).
+const ERROR_BLOCK_LINES = 4
+
+/**
+ * True when the pane is wedged in the persistent thinking-block API
+ * error described above. Scoped to the live tail above the idle footer
+ * so a quoted error string in scrollback or a message body does not
+ * trigger a false positive. Returns false when there is no idle footer
+ * (the pane is busy or not a recognised Claude Code surface).
+ */
+export function detectsThinkingBlockError(pane: string): boolean {
+  if (!pane) return false
+  const lines = pane.split('\n')
+  // Find the footer from the bottom: the live footer is the last line of
+  // the pane, so a footer-looking line quoted in scrollback must not win.
+  let footerIdx = -1
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (IDLE_FOOTER_RX.test(lines[i])) { footerIdx = i; break }
+  }
+  if (footerIdx < 0) return false
+  const start = Math.max(0, footerIdx - ERROR_LIVE_TAIL_LINES)
+  const tail = lines.slice(start, footerIdx)
+  // The chrome glyph and the thinking-block phrase+kind must co-occur
+  // within ONE chrome block, not be scattered across the tail.
+  for (let i = 0; i < tail.length; i++) {
+    if (!ERROR_CHROME_RX.test(tail[i])) continue
+    const block = tail.slice(i, i + ERROR_BLOCK_LINES).join('\n')
+    if (ERROR_THINKING_PHRASE_RX.test(block) && ERROR_THINKING_KIND_RX.test(block)) {
+      return true
+    }
+  }
+  return false
+}
+
 export interface DetectPaneStateOptions {
   /** If true, the 'typing' state (text parked in input box) is
    * merged into 'busy'. Default false -- callers that care about
@@ -117,9 +199,13 @@ export interface DetectPaneStateOptions {
  *      wider spinner/token-count fallbacks that catch the frame-level
  *      footer gap.
  *   3. No idle footer visible -> 'unknown' (pane is not Claude Code).
- *   4. Pending paste placeholder -> 'busy'.
- *   5. Text parked inside the bottom input box -> 'typing'.
- *   6. Otherwise -> 'idle'.
+ *   4. Wedged thinking-block API error in the live tail -> 'error'.
+ *      Checked after the busy guard (a live turn is never 'error') and
+ *      after the footer guard (an 'error' surface still shows the
+ *      footer) so the scheduler/router stop injecting doomed prompts.
+ *   5. Pending paste placeholder -> 'busy'.
+ *   6. Text parked inside the bottom input box -> 'typing'.
+ *   7. Otherwise -> 'idle'.
  */
 export function detectPaneState(
   pane: string,
@@ -132,6 +218,8 @@ export function detectPaneState(
   }
 
   if (!IDLE_FOOTER_RX.test(pane)) return 'unknown'
+
+  if (detectsThinkingBlockError(pane)) return 'error'
 
   if (PENDING_PASTE_RX.test(pane)) return 'busy'
 
@@ -384,4 +472,101 @@ export function decideSubmitFollowup(
   if (!shouldRetrySubmit(pane, payloadHint)) return 'done'
   if (attempt >= maxAttempts) return 'give-up'
   return 'retry-enter'
+}
+
+export interface PaneErrorAlertState {
+  /** When the session was first observed in the error state during the
+   * current spell, or null when there is no active spell. */
+  firstSeenAt: number | null
+  /** When the last alert was sent for this session, or null if never. */
+  lastAlertAt: number | null
+  /** When the session was last observed in the error state. Used to
+   * keep a spell alive across brief non-error blips (a flapping
+   * capture, or a busy spinner mid-flight) so the confirm window is
+   * not reset to zero by a single non-error tick. */
+  lastErrorAt: number | null
+}
+
+export interface PaneErrorAlertThresholds {
+  /** How long the session must stay in error before the first alert, so
+   * a transient one-tick error that clears on its own is not reported. */
+  confirmMs: number
+  /** Minimum gap between repeated alerts within one unbroken error
+   * spell, so a wedged session does not alert on every monitor tick. */
+  dedupMs: number
+  /** How long the session must be continuously error-free before an
+   * active spell is cleared. A single non-error tick (null capture, a
+   * mid-flight busy spinner) must NOT reset the spell, otherwise a
+   * genuinely wedged but flapping session never reaches the confirm
+   * window and never alerts. */
+  clearMs: number
+}
+
+export interface PaneErrorAlertDecision {
+  alert: boolean
+  next: PaneErrorAlertState
+}
+
+/**
+ * Pure state machine for "should the monitor alert that this session is
+ * wedged in the thinking-block error". Dependency-free so it is
+ * unit-testable without tmux or timers: feed the current error
+ * observation, the previous persisted state and a clock, get back the
+ * alert decision plus the next state to persist.
+ *
+ * Deliberately ALERT-only -- it never decides to reset or restart a
+ * session. Auto-reset destroys the agent's in-context working memory,
+ * and while the deep trigger is not fully understood a false positive
+ * must not nuke a healthy agent. A human (or the hub agent) acts on the
+ * alert. Guards that keep it quiet: the first sighting only records
+ * (never alerts, so an error must be seen on at least two ticks even
+ * when confirmMs is 0), a confirm window (the error must persist), and a
+ * dedup window (one alert per spell, not per tick). A non-error tick
+ * does NOT immediately end a spell -- it ends only after clearMs of
+ * continuous error-free time, so a flapping capture (null / mid-flight
+ * busy between error frames) cannot starve the confirm window. A
+ * future-dated stored timestamp (wall-clock skew, NTP correction)
+ * restarts the spell instead of stalling the deltas negative.
+ */
+export function decidePaneErrorAlert(
+  isError: boolean,
+  prev: PaneErrorAlertState,
+  now: number,
+  thresholds: PaneErrorAlertThresholds,
+): PaneErrorAlertDecision {
+  if (!isError) {
+    // No active spell: nothing to track.
+    if (prev.firstSeenAt === null) {
+      return { alert: false, next: { firstSeenAt: null, lastAlertAt: null, lastErrorAt: null } }
+    }
+    // Active spell: clear only after a sustained error-free gap, so a
+    // single flapping non-error tick does not reset the confirm window.
+    // A future-dated lastErrorAt (clock skew) counts as "clear now".
+    const errorFreeFor = prev.lastErrorAt === null ? Infinity : now - prev.lastErrorAt
+    if (errorFreeFor >= thresholds.clearMs || errorFreeFor < 0) {
+      return { alert: false, next: { firstSeenAt: null, lastAlertAt: null, lastErrorAt: null } }
+    }
+    // Hold the spell unchanged.
+    return { alert: false, next: { ...prev } }
+  }
+  // First sighting in this spell: record only, never alert. Guarantees
+  // at least two observations before any alert, independent of confirmMs.
+  if (prev.firstSeenAt === null) {
+    return { alert: false, next: { firstSeenAt: now, lastAlertAt: prev.lastAlertAt, lastErrorAt: now } }
+  }
+  // Clock skew: a stored timestamp in the future relative to now would
+  // drive the deltas negative and stall the machine silently. Restart
+  // the spell from now and drop the stale alert time.
+  if (now < prev.firstSeenAt || (prev.lastAlertAt !== null && now < prev.lastAlertAt)) {
+    return { alert: false, next: { firstSeenAt: now, lastAlertAt: null, lastErrorAt: now } }
+  }
+  const sustained = now - prev.firstSeenAt >= thresholds.confirmMs
+  if (!sustained) {
+    return { alert: false, next: { firstSeenAt: prev.firstSeenAt, lastAlertAt: prev.lastAlertAt, lastErrorAt: now } }
+  }
+  const dedupElapsed = prev.lastAlertAt === null || now - prev.lastAlertAt >= thresholds.dedupMs
+  if (dedupElapsed) {
+    return { alert: true, next: { firstSeenAt: prev.firstSeenAt, lastAlertAt: now, lastErrorAt: now } }
+  }
+  return { alert: false, next: { firstSeenAt: prev.firstSeenAt, lastAlertAt: prev.lastAlertAt, lastErrorAt: now } }
 }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -13,6 +13,7 @@ import {
   startAgentProcess,
   stopAgentProcess,
 } from './agent-process.js'
+import { detectPaneState, decidePaneErrorAlert, type PaneErrorAlertState } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
 import { getProvider, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
@@ -151,6 +152,22 @@ const agentDownSince: Map<string, number> = new Map()
 const agentLastRestart: Map<string, number> = new Map()
 const AGENT_RESTART_GRACE_MS = 90_000
 const PLUGIN_ALERT_DEDUP_MS = 30 * 60 * 1000
+
+// Per-session tracking for the wedged thinking-block error (a Claude
+// session stuck returning `400 ... thinking blocks cannot be modified`
+// on every prompt). detectPaneState() classifies such a pane as
+// 'error'; the monitor alerts so the operator can reset it. Alert-only
+// by design -- auto-reset would destroy the agent's working memory and a
+// false positive must not nuke a healthy session.
+const paneErrorState: Map<string, PaneErrorAlertState> = new Map()
+// Must persist for at least two monitor ticks (60s interval) before the
+// first alert, so a one-tick transient never reports. 30 min dedup
+// matches the channel-plugin alert cadence. clearMs (5 min) keeps a
+// spell alive across brief non-error blips (null capture, mid-flight
+// busy) so a flapping but genuinely wedged session still alerts.
+const PANE_ERROR_CONFIRM_MS = 120_000
+const PANE_ERROR_DEDUP_MS = 30 * 60 * 1000
+const PANE_ERROR_CLEAR_MS = 5 * 60 * 1000
 
 type MarveenRecoveryStage = 'soft' | 'save' | 'resume' | 'hard' | 'gave_up'
 interface MarveenDownState {
@@ -346,6 +363,32 @@ export function startChannelPluginMonitor(): NodeJS.Timeout {
         })
       }
     }
+
+    // Pane-level thinking-block error detection. Independent of channel
+    // plugin liveness: a session can keep a live plugin yet be wedged on
+    // the API error, every injected prompt yielding another 400. Detect
+    // it via the pane state and alert (never auto-reset).
+    for (const t of targets) {
+      const pane = capturePane(t.session)
+      const isError = pane != null && detectPaneState(pane) === 'error'
+      const prev = paneErrorState.get(t.session) ?? { firstSeenAt: null, lastAlertAt: null, lastErrorAt: null }
+      const decision = decidePaneErrorAlert(isError, prev, Date.now(), {
+        confirmMs: PANE_ERROR_CONFIRM_MS,
+        dedupMs: PANE_ERROR_DEDUP_MS,
+        clearMs: PANE_ERROR_CLEAR_MS,
+      })
+      if (decision.next.firstSeenAt === null) {
+        paneErrorState.delete(t.session)
+      } else {
+        paneErrorState.set(t.session, decision.next)
+      }
+      if (decision.alert) {
+        const label = t.isMarveen ? BOT_NAME : (t.agentName ?? t.session)
+        logger.error({ session: t.session, agent: label }, 'Agent wedged on thinking-block API error -- manual reset needed')
+        sendAlert(`🚨 A(z) ${label} agens elakadt egy thinking-block API hibaban (a session-history korrupt, minden uj prompt ugyanazt a 400-at adja). Kezi reset kell: allitsd le es inditsd ujra, friss session indul. Reszletek: tmux attach -t ${t.session}`)
+      }
+    }
+
     for (const t of targets) {
       const claudePid = getClaudePidForSession(t.session)
       if (!claudePid) {


### PR DESCRIPTION
## Why this matters

A Claude Code agent session can wedge on a 400 from the API:
`thinking or redacted_thinking blocks in the latest assistant message cannot be modified`.
Once wedged, every subsequent prompt re-sends the same context and yields
the identical 400; the session is dead until a manual reset.

The wedged pane is the trap: it shows the idle footer plus a past-tense
thinking stamp (e.g. `Sauteed for 1s`) but no live busy indicator, so
`detectPaneState()` classified it `idle`. `isSessionReadyForPrompt()`
then returned true and the message router and scheduler kept delivering
prompts into the dead session, each one another doomed 400. Observed in
production: three queued messages reported "delivered" into a session
that could not process any of them.

## Change

- `src/pane-state.ts`: new `'error'` PaneState. `detectsThinkingBlockError()`
  inspects only the live tail above the idle footer (footer found from
  the bottom, so a quoted footer string in scrollback cannot shift the
  scope) and requires three signals to co-occur within one chrome block:
  the tool-output chrome glyph `API Error: <code>`, the phrase
  `cannot be modified`, and `thinking`/`redacted_thinking`. This keeps a
  healthy session that merely quotes the error text from being flagged.
  `detectPaneState()` checks `'error'` after the busy guard (a live turn
  is never `'error'`) and after the idle-footer guard.
- `src/web/channel-monitor.ts`: the 60s health monitor now also detects a
  sustained `'error'` pane and alerts that a manual reset is needed. The
  decision is a pure state machine `decidePaneErrorAlert()` with confirm
  (must persist across ticks), dedup (one alert per spell), and
  clear-grace (a flapping capture does not reset the spell) windows. It
  deliberately never auto-resets: auto-reset would destroy the agent's
  in-context working memory, and a false positive must not nuke a healthy
  agent.

## Scope / compatibility

- `isSessionReadyForPrompt()` is unchanged; it already requires
  `=== 'idle'`, so the new `'error'` state automatically makes the router
  (`message-router.ts`) and scheduler (`schedule-runner.ts`) stop
  injecting.
- No change to the idle/busy/typing/unknown classification. Only the
  previously-misclassified wedged pane moves from `idle` to `error`.
- All existing PaneState consumers were checked: none use a `switch`; all
  compare against `'idle'`, which handles the new variant correctly.

## Test plan

- `npm run typecheck`: clean.
- Package tests: `pane-state.test.ts` 104 tests pass, covering the
  detector and the alert state machine, including the false-positive
  guards (decoupled benign chrome, stray footer in scrollback,
  narrow-terminal wrap, busy-wins-over-error, deep-scrollback stale
  error) and the confirm/dedup/clear-grace/clock-skew paths.
- Live reproduction on a real captured wedged pane: the old detector
  returned `idle`, the new one returns `error` and not-ready; a recovered
  pane returns `idle` (no false positive).

## Known limitations

- This stops the amplification (no more injecting into a wedged session)
  and surfaces an alert, but it does not fix the deeper trigger, which is
  a client/API-side thinking-block serialization issue, not in this repo.
  Recovery is still a manual reset (start a fresh session); auto-reset is
  intentionally out of scope.
- The wedge has been observed independently of client version and
  session size, so the detector keys on the pane signature rather than
  any version or size heuristic.