### PR TITLE
feat(models): add Opus 4.8 to the model picker

### DIFF
--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -11,7 +11,7 @@ export const DEFAULT_MODEL = 'claude-sonnet-4-6'
 
 // Map short model names to full Claude model IDs (backwards compat with old configs)
 export const MODEL_ALIASES: Record<string, string> = {
-  'opus': 'claude-opus-4-6',
+  'opus': 'claude-opus-4-8',
   'sonnet': 'claude-sonnet-4-6',
   'haiku': 'claude-haiku-4-5-20251001',
   'inherit': DEFAULT_MODEL,

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -334,7 +334,8 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const hasDeepseek = getSecret('DEEPSEEK_API_KEY') !== null
     json(res, {
       claude: [
-        { id: 'claude-opus-4-7', label: 'Opus 4.7 (legújabb, legjobb)' },
+        { id: 'claude-opus-4-8', label: 'Opus 4.8 (legújabb)' },
+        { id: 'claude-opus-4-7', label: 'Opus 4.7' },
         { id: 'claude-opus-4-6', label: 'Opus 4.6' },
         { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6 (alapértelmezett)' },
         { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5 (leggyorsabb)' },

--- a/web/index.html
+++ b/web/index.html
@@ -1144,7 +1144,8 @@
             <select id="agentModel">
               <option value="inherit">Öröklött (alapértelmezett)</option>
               <optgroup label="☁️ Claude (felhő)">
-                <option value="claude-opus-4-7">Opus 4.7 (legújabb, legjobb)</option>
+                <option value="claude-opus-4-8">Opus 4.8 (legújabb)</option>
+                <option value="claude-opus-4-7">Opus 4.7</option>
                 <option value="claude-opus-4-6">Opus 4.6</option>
                 <option value="claude-sonnet-4-6">Sonnet 4.6 (gyors és okos)</option>
                 <option value="claude-haiku-4-5-20251001">Haiku 4.5 (leggyorsabb)</option>
@@ -1291,7 +1292,8 @@
             <label for="editAgentModel">Modell</label>
             <select id="editAgentModel">
               <optgroup label="☁️ Claude (felhő)">
-                <option value="claude-opus-4-7">Opus 4.7 (legújabb, legjobb)</option>
+                <option value="claude-opus-4-8">Opus 4.8 (legújabb)</option>
+                <option value="claude-opus-4-7">Opus 4.7</option>
                 <option value="claude-opus-4-6">Opus 4.6</option>
                 <option value="claude-sonnet-4-6">Sonnet 4.6 (alapértelmezett)</option>
                 <option value="claude-haiku-4-5-20251001">Haiku 4.5 (leggyorsabb)</option>


### PR DESCRIPTION
Szabi via Marveen (kanban 35066DAC, part 1/2): surface Anthropic's newest Opus build in the agent model dropdowns.

## Changes

- **`src/web/routes/agents.ts`** `/api/models/available`: new entry `claude-opus-4-8` at the top of the Claude list as "Opus 4.8 (legújabb)". 4.7 loses the "legjobb" tail, sits plainly underneath. 4.6 unchanged.
- **`web/index.html`** lines 1147 and 1295: same change in both `<select>` dropdowns (create-agent wizard and edit-agent panel).
- **`src/web/agent-config.ts`** MODEL_ALIASES: short alias `'opus'` now resolves to `claude-opus-4-8` (was 4.6). Marveen's note flagged this as optional but it keeps the alias pointing at "current Opus".

## Verification

```
$ npx tsc --noEmit
# clean exit
```

## Part 2 (separate PR)

The 'dynamic workflow-k' (ultracode) toggle from the same kanban card is in discovery — a 4-agent triage workflow is mapping the agent-config write path, the post-launch keystroke mechanism, and verifying the `/effort → ultracode` keystroke sequence. Plan goes to Marveen for sign-off before any code lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)