### PR TITLE
feat(models): add Opus 4.8 + default opus alias points to 4.8

### DIFF
--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -11,7 +11,7 @@ export const DEFAULT_MODEL = 'claude-sonnet-4-6'
 
 // Map short model names to full Claude model IDs (backwards compat with old configs)
 export const MODEL_ALIASES: Record<string, string> = {
-  'opus': 'claude-opus-4-6',
+  'opus': 'claude-opus-4-8',
   'sonnet': 'claude-sonnet-4-6',
   'haiku': 'claude-haiku-4-5-20251001',
   'inherit': DEFAULT_MODEL,

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -336,7 +336,8 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const hasDeepseek = getSecret('DEEPSEEK_API_KEY') !== null
     json(res, {
       claude: [
-        { id: 'claude-opus-4-7', label: 'Opus 4.7 (legújabb, legjobb)' },
+        { id: 'claude-opus-4-8', label: 'Opus 4.8 (legújabb, legjobb)' },
+        { id: 'claude-opus-4-7', label: 'Opus 4.7' },
         { id: 'claude-opus-4-6', label: 'Opus 4.6' },
         { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6 (alapértelmezett)' },
         { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5 (leggyorsabb)' },

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -25,7 +25,7 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
     json(res, {
       name: BOT_NAME,
       description,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-8',
       running: true,
       hasTelegram: tg.hasTelegram,
       telegramBotUsername: tg.botUsername,

--- a/web/app.js
+++ b/web/app.js
@@ -973,7 +973,7 @@ async function openMarveenDetail() {
   avatar.innerHTML = `<img src="/api/marveen/avatar?t=${Date.now()}" alt="${escapeHtml(displayName)}">`
   document.getElementById('agentDetailName').textContent = displayName
   document.getElementById('agentDetailDesc').textContent = m.description || ''
-  document.getElementById('agentDetailModel').textContent = 'claude-opus-4-6'
+  document.getElementById('agentDetailModel').textContent = m.model || 'claude-opus-4-8'
   document.getElementById('agentDetailChStatus').innerHTML = '<span class="tg-status"><span class="tg-dot connected"></span>Csatlakozva</span>'
   document.getElementById('agentDetailSkillCount').textContent = '-'
 

--- a/web/index.html
+++ b/web/index.html
@@ -1143,7 +1143,8 @@
             <select id="agentModel">
               <option value="inherit">Öröklött (alapértelmezett)</option>
               <optgroup label="☁️ Claude (felhő)">
-                <option value="claude-opus-4-7">Opus 4.7 (legújabb, legjobb)</option>
+                <option value="claude-opus-4-8">Opus 4.8 (legújabb, legjobb)</option>
+                <option value="claude-opus-4-7">Opus 4.7</option>
                 <option value="claude-opus-4-6">Opus 4.6</option>
                 <option value="claude-sonnet-4-6">Sonnet 4.6 (gyors és okos)</option>
                 <option value="claude-haiku-4-5-20251001">Haiku 4.5 (leggyorsabb)</option>
@@ -1290,7 +1291,8 @@
             <label for="editAgentModel">Modell</label>
             <select id="editAgentModel">
               <optgroup label="☁️ Claude (felhő)">
-                <option value="claude-opus-4-7">Opus 4.7 (legújabb, legjobb)</option>
+                <option value="claude-opus-4-8">Opus 4.8 (legújabb, legjobb)</option>
+                <option value="claude-opus-4-7">Opus 4.7</option>
                 <option value="claude-opus-4-6">Opus 4.6</option>
                 <option value="claude-sonnet-4-6">Sonnet 4.6 (alapértelmezett)</option>
                 <option value="claude-haiku-4-5-20251001">Haiku 4.5 (leggyorsabb)</option>


### PR DESCRIPTION
## Summary

- Adds Claude Opus 4.8 to the agent model dropdown (now labeled "legújabb, legjobb")
- Updates the `opus` alias in MODEL_ALIASES to point to 4.8 (was 4.6)
- Bumps the main marveen agent model field to 4.8
- Agent detail panel in the UI now reads `m.model` from the API instead of hardcoded 4-6

## Files touched

- `src/web/routes/agents.ts` — `/api/models/available` dropdown
- `src/web/agent-config.ts` — `MODEL_ALIASES.opus`
- `src/web/routes/marveen.ts` — main agent model field
- `web/index.html` — agent create + edit dropdowns
- `web/app.js` — detail panel now reads `m.model` with 4-8 fallback

## Test plan

- [x] `npm run build` clean
- [x] Restart dashboard, `/api/models/available` returns Opus 4.8 at the top
- [x] `/api/marveen` returns `"model":"claude-opus-4-8"`
- [ ] Manual: open dashboard, create/edit agent → Opus 4.8 selectable
- [ ] Existing fixtures in `__tests__/claude-config-dir.test.ts` left untouched (historical model IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)