### PR TITLE
feat(agents): allow channel-less agents to start (inter-agent only)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "enabledPlugins": {
-    "slack-channel@marveen-marketplace": false
+    "slack-channel@marveen-marketplace": false,
+    "telegram@claude-plugins-official": true
   }
 }

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -24,6 +24,7 @@ INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 if [ -f "$INSTALL_DIR/.env" ]; then
   MAIN_AGENT_ID="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
   CHANNEL_PROVIDER="$(grep -E '^CHANNEL_PROVIDER=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
+  BOT_NAME="$(grep -E '^BOT_NAME=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
   # Claude Code auth: pass API key or OAuth token so the tmux-spawned
   # claude process can authenticate. These are safe to export -- unlike
   # TELEGRAM_BOT_TOKEN they don't cause cross-session conflicts.
@@ -116,6 +117,14 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
       ;;
   esac
 done
+
+# Set agent name and remote-control identifier once the session is ready.
+_bot_name="${BOT_NAME:-${MAIN_AGENT_ID:-marveen}}"
+sleep 1
+$TMUX send-keys -t "$SESSION" "/name ${_bot_name}" Enter
+sleep 1
+$TMUX send-keys -t "$SESSION" "/remote-control ${_bot_name}" Enter
+unset _bot_name
 
 # Bot menu setup (Telegram only; Slack uses App Manifest)
 if [ "$CHANNEL_PROVIDER" = "telegram" ]; then

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -51,11 +51,11 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
   const agentChannelDir = channelStateDir(agentProvider, dir)
   const token = readChannelToken(agentProvider, join(agentChannelDir, '.env'))
   // Backward compat: try legacy Telegram token if provider-aware lookup misses
+  let hasChannel = !!token
   if (!token && agentProvider === 'telegram') {
     const legacyToken = parseTelegramToken(name)
-    if (!legacyToken) return { ok: false, error: 'Channel not configured for this agent' }
-  } else if (!token) {
-    return { ok: false, error: `${provider.type} channel not configured for this agent` }
+    hasChannel = !!legacyToken
+    // Channel-less agents (inter-agent only, no direct Telegram/Slack) are allowed to start
   }
 
   const session = agentSessionName(name)
@@ -114,7 +114,11 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     // Slack plugin is third-party; its "not on approved allowlist" check is
     // bypassed via `allowedChannelPlugins` in /Library/Application Support/ClaudeCode/managed-settings.json.
     const auditLogEnv = agentProvider === 'slack' ? ` && export SLACK_AUDIT_LOG="${agentChannelDir}/audit.jsonl"` : ''
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && export ${stateEnvVar}="${agentChannelDir}"${auditLogEnv} && ${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} --channels plugin:${provider.pluginId}`
+    const channelSetup = hasChannel
+      ? `export ${stateEnvVar}="${agentChannelDir}"${auditLogEnv} && `
+      : ''
+    const channelFlag = hasChannel ? `--channels plugin:${provider.pluginId}` : ''
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${channelSetup}${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} ${channelFlag}`.trimEnd()
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -40,6 +40,16 @@ export function isAgentRunning(name: string): boolean {
   }
 }
 
+export function agentHasChannel(name: string): boolean {
+  const agentProvider = resolveAgentProvider(name)
+  const dir = agentDir(name)
+  const agentChannelDir = channelStateDir(agentProvider, dir)
+  const token = readChannelToken(agentProvider, join(agentChannelDir, '.env'))
+  if (token) return true
+  if (agentProvider === 'telegram') return !!parseTelegramToken(name)
+  return false
+}
+
 export function startAgentProcess(name: string): { ok: boolean; pid?: number; error?: string } {
   if (isAgentRunning(name)) return { ok: false, error: 'Agent is already running' }
 

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync, execFileSync } from 'node:child_process'
@@ -10,7 +10,7 @@ import {
   decideSubmitFollowup,
   shouldClearTruncatedPreamble,
 } from '../pane-state.js'
-import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode } from './agent-config.js'
+import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName } from './agent-config.js'
 import { parseTelegramToken } from './telegram.js'
 import { getProvider, getProviderType, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import { CHANNEL_PROVIDER } from '../config.js'
@@ -100,6 +100,25 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
     // Claude Code enforces the list rather than bypassing it.
     const profile = loadProfileTemplate(readAgentSecurityProfile(name))
     writeAgentSettingsFromProfile(name, profile)
+    // Channel-less agents must not load the global channel plugins from
+    // enabledPlugins. Without this, they fall back to the main agent's
+    // token and two instances fight over the same getUpdates slot (409
+    // Conflict / orphan watchdog loop causing recurring MCP disconnects).
+    if (!hasChannel) {
+      const settingsPath = join(agentDir(name), '.claude', 'settings.json')
+      try {
+        const s = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>
+        s.enabledPlugins = {
+          ...(s.enabledPlugins as Record<string, boolean> | undefined ?? {}),
+          'telegram@claude-plugins-official': false,
+          'slack-channel@marveen-marketplace': false,
+          'discord@claude-plugins-official': false,
+        }
+        writeFileSync(settingsPath, JSON.stringify(s, null, 2))
+      } catch (err) {
+        logger.warn({ err, name }, 'Could not disable channel plugins for channel-less agent')
+      }
+    }
     const skipFlag = profile.permissionMode === 'strict' ? '' : '--dangerously-skip-permissions '
     // Optional per-agent CLAUDE_CONFIG_DIR (alternate Claude Code config dir,
     // e.g. for routing this agent to a separate Anthropic login). When the
@@ -157,6 +176,18 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
       } catch (err) {
         logger.warn({ err, name, session }, 'Post-restart modal dismiss failed')
       }
+      // Set /name and /remote-control so the agent is identifiable.
+      setTimeout(() => {
+        try {
+          const displayName = readAgentDisplayName(name)
+          execFileSync(TMUX, ['send-keys', '-t', session, `/name ${displayName}`, 'Enter'], { timeout: 5000 })
+          execFileSync('/bin/sleep', ['1'], { timeout: 2000 })
+          execFileSync(TMUX, ['send-keys', '-t', session, `/remote-control ${displayName}`, 'Enter'], { timeout: 5000 })
+          logger.info({ name, session, displayName }, 'Set agent /name and /remote-control')
+        } catch (err) {
+          logger.warn({ err, name, session }, 'Failed to set agent /name or /remote-control')
+        }
+      }, 5000)
     }, 8000)
 
     return { ok: true }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -6,6 +6,7 @@ import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER } from '../config.js'
 import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
 import {
+  agentHasChannel,
   agentSessionName,
   capturePane,
   isAgentRunning,
@@ -354,7 +355,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout {
     type Target = { session: string; isMarveen: boolean; agentName?: string; provider: ChannelProviderType }
     const targets: Target[] = [{ session: MAIN_CHANNELS_SESSION, isMarveen: true, provider: mainProvider }]
     for (const a of listAgentNames()) {
-      if (isAgentRunning(a)) {
+      if (isAgentRunning(a) && agentHasChannel(a)) {
         targets.push({
           session: agentSessionName(a),
           isMarveen: false,


### PR DESCRIPTION
Agents without a configured channel currently fail to start. This PR enables channel-less agents so they can participate in inter-agent communication without requiring a Telegram/Slack/Discord setup.

## Changes

- Allow agents to start without a channel provider configured
- Disable channel plugins (telegram, slack, discord) for channel-less agents to prevent getUpdates 409 Conflicts when multiple agents share the same bot token
- Skip channel-less agents in the channel plugin health monitor
- Auto-send `/name` and `/remote-control` on session start for agent identity