### PR TITLE
feat(marveen): main agent default model 4.8 + detail panel reads from API

### DIFF
--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -25,7 +25,7 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
     json(res, {
       name: BOT_NAME,
       description,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-8',
       running: true,
       hasTelegram: tg.hasTelegram,
       telegramBotUsername: tg.botUsername,

--- a/web/app.js
+++ b/web/app.js
@@ -1021,7 +1021,7 @@ async function openMarveenDetail() {
   avatar.innerHTML = `<img src="/api/marveen/avatar?t=${Date.now()}" alt="${escapeHtml(displayName)}">`
   document.getElementById('agentDetailName').textContent = displayName
   document.getElementById('agentDetailDesc').textContent = m.description || ''
-  document.getElementById('agentDetailModel').textContent = 'claude-opus-4-6'
+  document.getElementById('agentDetailModel').textContent = m.model || 'claude-opus-4-8'
   document.getElementById('agentDetailChStatus').innerHTML = '<span class="tg-status"><span class="tg-dot connected"></span>Csatlakozva</span>'
   document.getElementById('agentDetailSkillCount').textContent = '-'
 


### PR DESCRIPTION
Follow-up to the merged PR #193 (which exposed Opus 4.8 in the model picker) — cherry-picks the two unique improvements from #194 that did not duplicate #193:

- **`src/web/routes/marveen.ts:28`**: `GET /api/marveen` now returns `model: 'claude-opus-4-8'` so the dashboard shows the actual model in use.
- **`web/app.js:1024`**: agent detail panel was hardcoded to print `'claude-opus-4-6'`. Now reads `m.model` from the API response (with 4.8 fallback) so the panel actually reflects whichever model the API is serving (longstanding stale-display bug).

Both spots were originally caught by @theisszsolt in PR #194; cherry-picked here so the rest of #194 (which conflicted with #193 on `agent-config.ts`, `agents.ts`, `web/index.html`) can close as superseded.

## Verification

```
$ npx tsc --noEmit
# clean exit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)