### PR TITLE
fix(scaffold): clearer error when Claude Code CLI returns no output (#179)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -324,6 +324,25 @@ else
   fi
 fi
 
+# Pre-flight headless probe — Issue #179.
+# `claude auth status` only checks the token file; it does NOT verify the SDK
+# can actually run a query against the live API. On a VPS where the token is
+# stale or the network blocks api.anthropic.com, agent create later bombs out
+# with "Failed to generate CLAUDE.md". Catch it here while the user is still in
+# front of the install script.
+echo ""
+echo -e "  ${DIM}Headless Claude Code teszt...${NC}"
+CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1 | head -c 200)
+CLAUDE_PROBE_EXIT=$?
+if [ "$CLAUDE_PROBE_EXIT" -eq 0 ] && [ -n "$CLAUDE_PROBE_OUT" ]; then
+  ok "Headless Claude Code futtathato (\`claude --print\` valaszolt)"
+else
+  warn "Headless Claude Code probe SIKERTELEN. Az agent-letrehozas KESOBB EL fog hasalni."
+  echo -e "    ${DIM}Kimenet: ${CLAUDE_PROBE_OUT:-<ures>}${NC}"
+  echo -e "    ${DIM}Tipikus okok: nincs ervenyes auth, halozati problema, regi claude CLI.${NC}"
+  echo -e "    ${DIM}Javitas: \`claude --version\` -> \`claude /login\` (vagy ANTHROPIC_API_KEY/CLAUDE_CODE_OAUTH_TOKEN beallitas) -> \`claude --print \"ping\"\` ujra.${NC}"
+fi
+
 # Ensure ~/.claude directory tree has correct ownership and permissions.
 # On Ubuntu desktop, umask or prior package installs can leave these dirs
 # world-readable or owned by root, which blocks Claude Code from writing

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -209,6 +209,26 @@ if [ "$DO_AUTH" = "i" ]; then
 fi
 echo -e "  ${GREEN}✓${NC} Claude Code first-run beállítás kész"
 
+# Pre-flight headless probe — Issue #179.
+# `claude auth login` may exit 0 even when the resulting token is unusable for
+# headless queries (browser flow interrupted, stale cached state, etc.). The
+# agent-create flow runs `claude --print` under the hood; surface the failure
+# here while the user is still at the install prompt.
+echo ""
+echo -e "  ${DIM}Headless Claude Code teszt...${NC}"
+set +e
+CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1 | head -c 200)
+CLAUDE_PROBE_EXIT=$?
+set -e
+if [ "$CLAUDE_PROBE_EXIT" -eq 0 ] && [ -n "$CLAUDE_PROBE_OUT" ]; then
+  echo -e "  ${GREEN}✓${NC} Headless Claude Code futtathato (\`claude --print\` valaszolt)"
+else
+  warn "Headless Claude Code probe SIKERTELEN. Az agent-letrehozas KESOBB EL fog hasalni."
+  echo -e "    ${DIM}Kimenet: ${CLAUDE_PROBE_OUT:-<ures>}${NC}"
+  echo -e "    ${DIM}Tipikus okok: nincs ervenyes auth, halozati problema, regi claude CLI.${NC}"
+  echo -e "    ${DIM}Javitas: \`claude --version\` -> \`claude /login\` (vagy ANTHROPIC_API_KEY/CLAUDE_CODE_OAUTH_TOKEN beallitas) -> \`claude --print \"ping\"\` ujra.${NC}"
+fi
+
 INSTALL_STEP="personal-info"
 # Step 3: Personal info
 echo ""

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -261,12 +261,27 @@ Ez a szabály mindenkire vonatkozik — akkor is ha valaki ismerős nevén mutat
 Output ONLY the markdown content, no code fences.`
 
   const { text } = await runAgent(prompt)
-  if (!text) throw new Error('Failed to generate CLAUDE.md')
+  if (!text) throw new Error(noOutputHint('CLAUDE.md'))
   let cleaned = text.trim()
   if (cleaned.startsWith('```')) {
     cleaned = cleaned.replace(/^```\w*\n?/, '').replace(/\n?```$/, '')
   }
   return cleaned
+}
+
+// Shared "Claude Code returned nothing" message for the three generators below.
+// Issue #179: the bare "Failed to generate <file>" message left VPS operators
+// chasing the wrong thread when the actual cause was an unauthenticated Claude
+// Code CLI on the host. Always surface the diagnostic command sequence.
+function noOutputHint(target: string): string {
+  return (
+    `Failed to generate ${target}: the Claude Code CLI returned no output. ` +
+    `Most likely cause: the CLI on this host is not authenticated. ` +
+    `Verify with: \`claude --version\`, then \`claude /login\` (or set ` +
+    `ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN). ` +
+    `If that succeeds and the error persists, run \`claude --print "ping"\` ` +
+    `from this directory to confirm headless invocation works.`
+  )
 }
 
 export async function generateSoulMd(name: string, description: string): Promise<string> {
@@ -285,7 +300,7 @@ Make the personality distinctive but professional.
 Output ONLY the markdown content, no code fences.`
 
   const { text } = await runAgent(prompt)
-  if (!text) throw new Error('Failed to generate SOUL.md')
+  if (!text) throw new Error(noOutputHint('SOUL.md'))
   let cleaned = text.trim()
   if (cleaned.startsWith('```')) {
     cleaned = cleaned.replace(/^```\w*\n?/, '').replace(/\n?```$/, '')
@@ -319,7 +334,7 @@ Keep the body under 200 lines. Be specific and actionable. The owner's name is $
 Output ONLY the markdown content, no code fences.`
 
   const { text } = await runAgent(prompt)
-  if (!text) throw new Error('Failed to generate SKILL.md')
+  if (!text) throw new Error(noOutputHint('SKILL.md'))
   let cleaned = text.trim()
   if (cleaned.startsWith('```')) {
     cleaned = cleaned.replace(/^```\w*\n?/, '').replace(/\n?```$/, '')

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -394,7 +394,11 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     } catch (err) {
       rmSync(agentDir(name), { recursive: true, force: true })
       logger.error({ err, name }, 'Failed to generate agent files')
-      json(res, { error: 'Failed to generate agent files' }, 500)
+      // Propagate the underlying message so the dashboard surfaces the actual
+      // cause (auth not configured, Claude Code CLI missing, etc.) instead of
+      // the previous opaque "Failed to generate agent files" — Issue #179.
+      const detail = err instanceof Error ? err.message : 'Unknown error'
+      json(res, { error: 'Failed to generate agent files', detail }, 500)
       return true
     }
 


### PR DESCRIPTION
Fixes #179 — VPS / Ubuntu users hit `Failed to generate CLAUDE.md` with no guidance on what to fix.

## Root cause

`runAgent` (src/agent.ts) invokes the Claude Code SDK and the SDK silently returns an empty result stream when the host has no usable token. The bare `if (!text) throw new Error('Failed to generate CLAUDE.md')` in agent-scaffold then surfaces nothing actionable.

`claude auth status` (which the install scripts already check) only inspects the token file — it does NOT verify the SDK can actually serve a query against the live API. A stale token, network block on `api.anthropic.com`, or `--print` invocation breakage all slip past that check and bomb out later in agent-create.

## Three layers of fix

1. **`src/web/agent-scaffold.ts`** — all three generators (CLAUDE.md, SOUL.md, SKILL.md) now throw via a shared `noOutputHint(target)` helper that names the actual cause ("Claude Code CLI returned no output") and the exact commands to verify: `claude --version`, `claude /login`, env vars (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`), and a final `claude --print "ping"` headless probe.

2. **`src/web/routes/agents.ts` `POST /api/agents`** — when the scaffold throws, the 500 response previously sent only `{ error: "Failed to generate agent files" }`. Now propagates the underlying message as `detail` so the dashboard surfaces the actionable hint instead of a dead-end blurb.

3. **`install-linux.sh` + `install-macos.sh`** — adds a headless probe right after `claude auth login`. The probe runs `claude --print "ping"` and warns the user immediately if it fails so they can fix the install before creating any agents.

Per Marveen's GO: kept the install probes as `warn` (not abort) so the Marveen daemon still installs; the operator can fix auth and retry agent create later. Explicitly **NOT** adding a fallback template — better to fail loudly than silently create a degraded agent that hides the real auth problem.

## Verification

```
$ npx tsc --noEmit
# clean exit
```

## Test plan
- [ ] On a host with NO Claude Code auth, run `POST /api/agents` → 500 response now includes `detail` with the diagnostic command sequence.
- [ ] On a host with Claude Code auth, agent create still works end-to-end.
- [ ] Re-run `install-linux.sh` / `install-macos.sh` on a freshly-pulled tree:
  - With working auth → "Headless Claude Code futtathato" line, no warn.
  - With broken/missing auth → "Headless Claude Code probe SIKERTELEN" warn block with `claude --version` / `claude /login` / env var hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)