### PR TITLE
fix(tmux): unset $TMUX in channels.sh + clearer manual-attach hint (#189)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -66,6 +66,15 @@ command -v tmux >/dev/null 2>&1 && tmux set-environment -g -u SLACK_BOT_TOKEN 2>
 command -v tmux >/dev/null 2>&1 && tmux set-environment -g -u DISCORD_BOT_TOKEN 2>/dev/null || true
 unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN
 
+# Issue #189: when this script runs from inside an existing tmux session (the
+# user's own work session, for example), the inherited TMUX env var points at
+# the parent client's socket. Any `tmux new-session` we spawn then tries to
+# attach to that socket and fails with "Permission denied" (different uid,
+# different socket dir, or just the new-session-from-inside-tmux block). The
+# child marveen-channels session must live on a fresh tmux client context, so
+# scrub the env var before any tmux command runs.
+unset TMUX
+
 export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
 
 CLAUDE="$(command -v claude)"

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -316,7 +316,10 @@ function handleMarveenDown(): void {
     const serviceCmd = process.platform === 'linux'
       ? `\`systemctl --user status ${MAIN_AGENT_ID}-channels\``
       : `\`launchctl list | grep ${MAIN_AGENT_ID}\``
-    sendAlert(`🚨 Hard restart SEM segitett. Kezzel kell megnezni: \`tmux attach -t ${MAIN_CHANNELS_SESSION}\` es ${serviceCmd}.`)
+    // Issue #189: a plain `tmux attach -t ...` may itself fail with "Permission
+    // denied" when the operator is running it from another tmux session. Prefix
+    // with `unset TMUX` so the hint works in both nested and non-nested cases.
+    sendAlert(`🚨 Hard restart SEM segitett. Kezzel kell megnezni: \`unset TMUX && tmux attach -t ${MAIN_CHANNELS_SESSION}\` es ${serviceCmd}.`)
     return
   }
   if (now - marveenDownState.lastAlertAt > PLUGIN_ALERT_DEDUP_MS) {


### PR DESCRIPTION
Fixes #189 — when scripts/channels.sh runs from inside an existing tmux session, the inherited `$TMUX` env var points at the parent client's socket; the `tmux new-session -d -s marveen-channels` call then tries to attach to that socket and fails with "Permission denied" on Linux, blocking the channel bridge from ever coming up. Reported by @blackPantherOS with the exact fix suggestion.

## Changes

- **`scripts/channels.sh`** — `unset TMUX` right after the env-token scrub block, before any tmux command runs. The internal `TMUX="$(command -v tmux)"` later in the script is a non-exported bash binding, so child processes get a fresh tmux client context.
- **`src/web/channel-monitor.ts:319`** — the "Hard restart SEM segitett" alert previously suggested `tmux attach -t marveen-channels`, which suffers the same nested-tmux trap. Now suggests `unset TMUX && tmux attach -t marveen-channels` so the hint works in both nested and non-nested cases.

## Verification (manual, per Marveen's required test)

```
=== TEST 1: NEM-NESTED (no TMUX env) ===
SESSION RUNS OK

=== TEST 2: NESTED simulation (TMUX env set, then unset) ===
BEFORE unset TMUX: /tmp/fake-socket,99999,0
AFTER unset TMUX: <empty>
SESSION RUNS OK (unset TMUX works for nested case)
```

So the fix does not wedge the normal launchd / systemd-user startup path (TEST 1) and correctly defuses the nested-tmux Permission denied case (TEST 2).

`npx tsc --noEmit` clean.

## Per Marveen's GO (explicit scope)

- ✅ `unset TMUX` in channels.sh (this PR).
- ✅ channel-monitor alert hint (this PR).
- ❌ `-L marveen` explicit socket isolation — deferred. Only revisit if simple unset is not enough.
- ❌ `tmux move-window` ergonomics from the issue body — out of scope (nice-to-have).

## Test plan
- [ ] Deploy to a Linux/Ubuntu box where the operator routinely works inside tmux. Restart marveen-channels (systemd-user) and confirm it comes up without Permission denied in the logs.
- [ ] Operator opens a fresh tmux session, then runs `unset TMUX && tmux attach -t marveen-channels` — must attach.
- [ ] Non-tmux operator (regular shell) starts the daemon — still works (no regression).

Refs: Issue #189
Reported-by: blackPantherOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)