### PR TITLE
feat(dashboard): live agent model + tmux session name, restart-on-model-change

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "claude-opus-4-8",
   "enabledPlugins": {
     "slack-channel@marveen-marketplace": false,
     "telegram@claude-plugins-official": true

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ reports/
 
 # Test artifacts
 test-results/
+.playwright-mcp/
 
 # macOS
 .DS_Store

--- a/mcp-catalog.json
+++ b/mcp-catalog.json
@@ -173,5 +173,51 @@
     "authType": "oauth",
     "authNote": "Első használatkor OAuth bejelentkezés (Google/Microsoft fiók) a böngészőben",
     "infoUrl": "https://fireflies.ai/blog/fireflies-mcp-server/"
+  },
+  {
+    "id": "billingo-netmask",
+    "name": "Billingo (Netmask Interactive Kft.)",
+    "description": "Magyar online számlázó (Netmask partner-fiók): számlák, partnerek, termékek a Billingo API v3-on",
+    "type": "local",
+    "category": "productivity",
+    "icon": "🧾",
+    "command": "node",
+    "args": ["/Users/boo/marveen-vendor/billingo-mcp/dist/cli.js"],
+    "env": {"BILLINGO_API_KEY": ""},
+    "authType": "apikey",
+    "authNote": "Kulcs forrás: /Users/boo/marveen/store/secrets.json -> .billingo.netmask (NEM commit-olható, gitignored)",
+    "secretRef": "billingo.netmask",
+    "infoUrl": "https://github.com/Szotasz/billingo-mcp",
+    "partner_id": "netmask"
+  },
+  {
+    "id": "billingo-habana",
+    "name": "Billingo (Habana Kft.)",
+    "description": "Magyar online számlázó (Habana partner-fiók): számlák, partnerek, termékek a Billingo API v3-on",
+    "type": "local",
+    "category": "productivity",
+    "icon": "🧾",
+    "command": "node",
+    "args": ["/Users/boo/marveen-vendor/billingo-mcp/dist/cli.js"],
+    "env": {"BILLINGO_API_KEY": ""},
+    "authType": "apikey",
+    "authNote": "Kulcs forrás: /Users/boo/marveen/store/secrets.json -> .billingo.habana (NEM commit-olható, gitignored)",
+    "secretRef": "billingo.habana",
+    "infoUrl": "https://github.com/Szotasz/billingo-mcp",
+    "partner_id": "habana"
+  },
+  {
+    "id": "playwright",
+    "name": "Playwright (böngészővezérlés)",
+    "description": "Chromium/Firefox/WebKit böngésző automatizáció: navigate, click, fill, screenshot, JavaScript futtatás. Headless (default) és headed (--headed flag) is.",
+    "type": "local",
+    "category": "automation",
+    "icon": "🌐",
+    "command": "npx",
+    "args": ["-y", "@playwright/mcp@latest"],
+    "env": {},
+    "authType": "none",
+    "authNote": "Nincs auth. Headed mode-hoz adjuk hozzá az --headed flag-et az args-hoz.",
+    "infoUrl": "https://github.com/microsoft/playwright-mcp"
   }
 ]

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -82,6 +82,17 @@ TMUX="$(command -v tmux)"
 [ -z "$CLAUDE" ] && echo "ERROR: claude not found on PATH" >&2 && exit 1
 [ -z "$TMUX" ]   && echo "ERROR: tmux not found on PATH" >&2 && exit 1
 
+# Read the main agent's default model from .claude/settings.json so we can
+# pass --model explicitly. Without --model claude-code falls back to its
+# built-in default, which can drift across versions. Passing the flag makes
+# the choice deterministic and visible in `ps`.
+MAIN_MODEL=""
+if [ -f "$INSTALL_DIR/.claude/settings.json" ] && command -v jq >/dev/null 2>&1; then
+  MAIN_MODEL="$(jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null)"
+fi
+MODEL_FLAG=""
+[ -n "$MAIN_MODEL" ] && MODEL_FLAG="--model $MAIN_MODEL "
+
 # Régi session takarítás
 $TMUX kill-session -t "$SESSION" 2>/dev/null
 
@@ -92,7 +103,7 @@ $TMUX kill-session -t "$SESSION" 2>/dev/null
 # resuming one of those loses the --channels activation state, causing
 # "Channel notifications skipped: server not in --channels list" errors.
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "$CLAUDE --dangerously-skip-permissions --channels plugin:${PLUGIN_ID}"
+  "$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
 
 # Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
 # kulonben a headless session orokre parkolna a prompton es a Telegram plugin

--- a/src/web/active-model.ts
+++ b/src/web/active-model.ts
@@ -1,0 +1,64 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+
+// Claude Code writes one .jsonl session log per session under
+// ~/.claude/projects/<encoded-working-dir>/. Every assistant turn carries the
+// model id that answered it. We use that to surface the *live* running model
+// (vs. the configured value in agent-config.json), so the dashboard can show
+// what the running process is actually using, including across restarts.
+//
+// When an agent is launched with --continue, Claude Code appends to the same
+// session jsonl across restarts, so the latest "model" field may reflect a
+// pre-restart turn rather than the freshly-spawned process. Callers that know
+// when the current session started should pass sinceUnixSec; we then ignore
+// any line whose own timestamp predates that, leaving the caller to fall back
+// to the configured model until the new session writes its first turn.
+const cache = new Map<string, { value: string | null; expiresAt: number }>()
+const TTL_MS = 3000
+
+export function readActiveModelFromProjectDir(workingDir: string, sinceUnixSec?: number): string | null {
+  const now = Date.now()
+  const cacheKey = `${workingDir}:${sinceUnixSec ?? ''}`
+  const cached = cache.get(cacheKey)
+  if (cached && cached.expiresAt > now) return cached.value
+  let value: string | null = null
+  try {
+    const encoded = workingDir.replace(/[/.]/g, '-')
+    const dir = join(homedir(), '.claude', 'projects', encoded)
+    if (!existsSync(dir)) {
+      cache.set(cacheKey, { value: null, expiresAt: now + TTL_MS })
+      return null
+    }
+    const jsonls = readdirSync(dir)
+      .filter(f => f.endsWith('.jsonl'))
+      .map(f => ({ f, mtime: statSync(join(dir, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime)
+    if (jsonls.length === 0) {
+      cache.set(cacheKey, { value: null, expiresAt: now + TTL_MS })
+      return null
+    }
+    const content = readFileSync(join(dir, jsonls[0].f), 'utf-8')
+    const lines = content.split('\n')
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim()
+      if (!line) continue
+      try {
+        const entry = JSON.parse(line)
+        const msg = entry?.message
+        const model = msg?.model
+        if (typeof model !== 'string' || model.startsWith('<')) continue
+        if (sinceUnixSec !== undefined) {
+          const ts = entry?.timestamp
+          if (typeof ts !== 'string') continue
+          const lineUnix = Math.floor(new Date(ts).getTime() / 1000)
+          if (!Number.isFinite(lineUnix) || lineUnix < sinceUnixSec) continue
+        }
+        value = model
+        break
+      } catch { /* skip malformed JSON line */ }
+    }
+  } catch { /* fall through */ }
+  cache.set(cacheKey, { value, expiresAt: now + TTL_MS })
+  return value
+}

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -40,6 +40,20 @@ export function isAgentRunning(name: string): boolean {
   }
 }
 
+export function getAgentRunningSince(name: string): number | null {
+  try {
+    const out = execFileSync(
+      TMUX,
+      ['display-message', '-p', '-t', agentSessionName(name), '#{session_created}'],
+      { timeout: 3000, encoding: 'utf-8' },
+    ).trim()
+    const ts = parseInt(out, 10)
+    return Number.isFinite(ts) ? ts : null
+  } catch {
+    return null
+  }
+}
+
 export function agentHasChannel(name: string): boolean {
   const agentProvider = resolveAgentProvider(name)
   const dir = agentDir(name)
@@ -236,6 +250,14 @@ export function getAgentProcessInfo(name: string): { running: boolean; session?:
     running: true,
     session: agentSessionName(name),
   }
+}
+
+export function restartAgentProcess(name: string): { ok: boolean; pid?: number; error?: string } {
+  if (isAgentRunning(name)) {
+    const stopResult = stopAgentProcess(name)
+    if (!stopResult.ok) return { ok: false, error: stopResult.error || 'Failed to stop running agent before restart' }
+  }
+  return startAgentProcess(name)
 }
 
 // Claude Code occasionally pops a "How is Claude doing this session? (optional)"

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { execSync, execFileSync } from 'node:child_process'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
-import { MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER } from '../config.js'
+import { MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT } from '../config.js'
 import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
 import {
   agentHasChannel,
@@ -209,12 +209,30 @@ function triggerMarveenMemorySave(): void {
   }
 }
 
+// Read the main agent's configured model from .claude/settings.json so a
+// soft resume passes --model explicitly, mirroring scripts/channels.sh. Without
+// it the respawned session falls back to claude-code's built-in default and
+// silently drifts off the model the user picked. Returns '' when unset.
+function readConfiguredMainModel(): string {
+  try {
+    const settingsPath = join(PROJECT_ROOT, '.claude', 'settings.json')
+    if (!existsSync(settingsPath)) return ''
+    const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    const model = parsed?.model
+    return typeof model === 'string' ? model.trim() : ''
+  } catch {
+    return ''
+  }
+}
+
 function resumeMarveenSession(): boolean {
   const provider = getProvider(getMainAgentProvider())
   try {
+    const model = readConfiguredMainModel()
     const claudeCmd = [
       'export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"',
       '&&', CLAUDE, '--continue', '--dangerously-skip-permissions',
+      ...(model ? ['--model', model] : []),
       // NOTE: inbound from `--channels` goes through a separate
       // allowlist at /etc/claude-code/managed-settings.json
       // (allowedChannelPlugins). If the plugin isn't listed there,

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -69,11 +69,14 @@ import {
   isAgentRunning,
   startAgentProcess,
   stopAgentProcess,
+  restartAgentProcess,
+  getAgentRunningSince,
   getAgentProcessInfo,
   agentSessionName,
   sendPromptToSession,
   capturePane,
 } from '../agent-process.js'
+import { readActiveModelFromProjectDir } from '../active-model.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
 import { getChannelHealth } from '../channel-health-monitor.js'
 import {
@@ -234,6 +237,8 @@ interface AgentSummary {
   displayName: string
   description: string
   model: string
+  activeModel: string | null
+  runningSince: number | null
   authMode: AuthMode
   securityProfile: string
   team: TeamConfig
@@ -266,12 +271,15 @@ function getAgentSummary(name: string): AgentSummary {
   const hasSoulMd = soulMd.trim().length > 0
 
   const proc = getAgentProcessInfo(name)
+  const runningSince = proc.running ? getAgentRunningSince(name) : null
 
   return {
     name,
     displayName: readAgentDisplayName(name),
     description: extractDescriptionFromClaudeMd(claudeMd),
     model: readAgentModel(name),
+    activeModel: proc.running ? readActiveModelFromProjectDir(dir, runningSince ?? undefined) : null,
+    runningSince,
     authMode: readAgentAuthMode(name),
     securityProfile: readAgentSecurityProfile(name),
     team: readAgentTeam(name),
@@ -1062,6 +1070,16 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   if (stopMatch && method === 'POST') {
     const name = decodeURIComponent(stopMatch[1])
     const result = stopAgentProcess(name)
+    if (result.ok) { json(res, { ok: true }); return true }
+    json(res, { error: result.error }, 400)
+    return true
+  }
+
+  const restartMatch = path.match(/^\/api\/agents\/([^/]+)\/restart$/)
+  if (restartMatch && method === 'POST') {
+    const name = decodeURIComponent(restartMatch[1])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    const result = restartAgentProcess(name)
     if (result.ok) { json(res, { ok: true }); return true }
     json(res, { error: result.error }, 400)
     return true

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -6,7 +6,13 @@ import { hardRestartMarveenChannels } from '../channel-monitor.js'
 import { readFileOr } from '../agent-config.js'
 import { parseMultipart } from '../multipart.js'
 import { readBody, json, serveFile } from '../http-helpers.js'
+import { MAIN_CHANNELS_SESSION } from '../main-agent.js'
+import { readActiveModelFromProjectDir } from '../active-model.js'
 import type { RouteContext } from './types.js'
+
+function getActiveMarveenModel(): string {
+  return readActiveModelFromProjectDir(PROJECT_ROOT) ?? 'unknown'
+}
 
 export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promise<boolean> {
   const { req, res, path, method } = ctx
@@ -25,7 +31,8 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
     json(res, {
       name: BOT_NAME,
       description,
-      model: 'claude-opus-4-8',
+      model: getActiveMarveenModel(),
+      tmuxSession: MAIN_CHANNELS_SESSION,
       running: true,
       hasTelegram: tg.hasTelegram,
       telegramBotUsername: tg.botUsername,

--- a/web/app.js
+++ b/web/app.js
@@ -1021,16 +1021,20 @@ async function openMarveenDetail() {
   avatar.innerHTML = `<img src="/api/marveen/avatar?t=${Date.now()}" alt="${escapeHtml(displayName)}">`
   document.getElementById('agentDetailName').textContent = displayName
   document.getElementById('agentDetailDesc').textContent = m.description || ''
-  document.getElementById('agentDetailModel').textContent = m.model || 'claude-opus-4-8'
+  document.getElementById('agentDetailModel').textContent = m.model || '-'
   document.getElementById('agentDetailChStatus').innerHTML = '<span class="tg-status"><span class="tg-dot connected"></span>Csatlakozva</span>'
   document.getElementById('agentDetailSkillCount').textContent = '-'
 
   // Process control for Marveen - always running, no start/stop
   document.getElementById('processDot').className = 'process-dot running'
   document.getElementById('processLabel').textContent = 'Fut'
-  document.getElementById('processUptime').textContent = 'tmux: marveen-channels'
+  document.getElementById('processUptime').textContent = `tmux: ${m.tmuxSession || '-'}`
   document.getElementById('agentStartBtn').hidden = true
   document.getElementById('agentStopBtn').hidden = true
+  // Sync the settings tab model select with Marveen's actual model so it
+  // doesn't carry over the previously opened sub-agent's selection.
+  const marveenModelSelect = document.getElementById('editAgentModel')
+  if (marveenModelSelect) marveenModelSelect.value = m.activeModel || m.model || ''
   // Surface the "channels restart" button -- destructive, but mobile-safe
   // when the Telegram plugin wedges and you're away from a terminal.
   document.getElementById('marveenRestartBtn').hidden = false
@@ -1071,7 +1075,12 @@ async function openMarveenDetail() {
 
 function applyMarveenReadonlyMode(readOnly) {
   const textareaIds = ['editClaudeMd', 'editSoulMd', 'editMcpJson']
-  const saveButtonIds = ['saveClaudeMdBtn', 'saveSoulMdBtn', 'saveMcpJsonBtn', 'saveModelBtn', 'saveAuthModeBtn']
+  // saveModelBtn stays VISIBLE but disabled for Marveen, so the settings tab
+  // doesn't look like the row is missing -- the other save buttons (tied to
+  // readonly textareas) are hidden because the textareas are also hidden by
+  // the readonly note flow.
+  const hideButtonIds = ['saveClaudeMdBtn', 'saveSoulMdBtn', 'saveMcpJsonBtn', 'saveAuthModeBtn']
+  const disableButtonIds = ['saveModelBtn']
   for (const id of textareaIds) {
     const el = document.getElementById(id)
     if (!el) continue
@@ -1080,9 +1089,13 @@ function applyMarveenReadonlyMode(readOnly) {
   }
   const modelSelect = document.getElementById('editAgentModel')
   if (modelSelect) modelSelect.disabled = readOnly
-  for (const id of saveButtonIds) {
+  for (const id of hideButtonIds) {
     const btn = document.getElementById(id)
     if (btn) btn.hidden = readOnly
+  }
+  for (const id of disableButtonIds) {
+    const btn = document.getElementById(id)
+    if (btn) { btn.hidden = false; btn.disabled = readOnly }
   }
   const authModeGroup = document.getElementById('authModeGroup')
   if (authModeGroup) authModeGroup.hidden = readOnly
@@ -1190,7 +1203,8 @@ async function openAgentDetail(agentName) {
     : initial
   document.getElementById('agentDetailName').textContent = detailLabel
   document.getElementById('agentDetailDesc').textContent = currentAgent.description || ''
-  document.getElementById('agentDetailModel').textContent = currentAgent.model || 'inherit'
+  document.getElementById('agentDetailModel').textContent = currentAgent.activeModel || currentAgent.model || 'inherit'
+  document.getElementById('agentDetailModelRestarting').hidden = true
 
   const chConnected = currentAgent.hasTelegram || false
   document.getElementById('agentDetailChStatus').innerHTML = `<span class="tg-status"><span class="tg-dot ${chConnected ? 'connected' : 'disconnected'}"></span>${chConnected ? 'Csatlakozva' : 'Nincs bekötve'}</span>`
@@ -1198,7 +1212,7 @@ async function openAgentDetail(agentName) {
   // Settings tab - load Ollama + DeepSeek models then set value
   loadAvailableModels()
   loadOllamaModels().then(() => {
-    document.getElementById('editAgentModel').value = currentAgent.model || 'claude-sonnet-4-6'
+    document.getElementById('editAgentModel').value = currentAgent.activeModel || currentAgent.model || 'claude-sonnet-4-6'
   })
   populateProfileSelect(
     document.getElementById('editAgentProfile'),
@@ -1566,17 +1580,93 @@ async function loadAvailableModels() {
   } catch { /* dashboard not available */ }
 }
 
+let modelRestartPollTimer = null
+let modelRestartPollName = null
+
+function stopModelRestartPolling() {
+  if (modelRestartPollTimer) { clearInterval(modelRestartPollTimer); modelRestartPollTimer = null }
+  modelRestartPollName = null
+}
+
+function startModelRestartPolling(name, expectedModel, triggeredAt) {
+  stopModelRestartPolling()
+  modelRestartPollName = name
+  const badge = document.getElementById('agentDetailModelRestarting')
+  const display = document.getElementById('agentDetailModel')
+  const processLabel = document.getElementById('processLabel')
+  const processDot = document.getElementById('processDot')
+  const deadline = Date.now() + 60000
+  modelRestartPollTimer = setInterval(async () => {
+    if (modelRestartPollName !== name || !currentAgent || currentAgent.name !== name) {
+      stopModelRestartPolling(); return
+    }
+    if (Date.now() > deadline) {
+      stopModelRestartPolling()
+      badge.hidden = true
+      if (currentAgent) updateProcessControl(currentAgent)
+      showToast('Az újraindítás állapotát nem tudtam visszaolvasni, ellenőrizd a sessiont')
+      return
+    }
+    try {
+      const r = await fetch(`/api/agents/${encodeURIComponent(name)}`)
+      if (!r.ok) return
+      const data = await r.json()
+      // The new tmux session's creation timestamp is the reliable "restart
+      // complete" signal. Claude Code writes the "model" field into the
+      // session jsonl only when it answers a message, so activeModel may
+      // stay null/old until the agent receives its first prompt -- waiting
+      // for that match would time out on idle agents. The configured model
+      // is what the agent was just started with via --model.
+      const restarted = data.runningSince && data.runningSince >= triggeredAt
+      if (restarted) {
+        const displayModel = data.activeModel || data.model
+        if (currentAgent && currentAgent.name === name) {
+          currentAgent.activeModel = data.activeModel
+          currentAgent.runningSince = data.runningSince
+          currentAgent.model = data.model
+          currentAgent.running = !!data.running
+          currentAgent.session = data.session
+          display.textContent = displayModel
+        }
+        badge.hidden = true
+        processDot.className = 'process-dot running'
+        processLabel.textContent = 'Fut'
+        stopModelRestartPolling()
+        const liveMatched = data.activeModel === expectedModel
+        showToast(liveMatched
+          ? `Új modell aktív: ${displayModel}`
+          : `Újraindítva: ${displayModel}`)
+      }
+    } catch { /* network blip, keep polling */ }
+  }, 2000)
+}
+
 document.getElementById('saveModelBtn').addEventListener('click', async () => {
   if (!currentAgent || currentAgent.role === 'main') return
+  const newModel = document.getElementById('editAgentModel').value
+  const name = currentAgent.name
   try {
-    const res = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}`, {
+    const res = await fetch(`/api/agents/${encodeURIComponent(name)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model: document.getElementById('editAgentModel').value }),
+      body: JSON.stringify({ model: newModel }),
     })
     if (!res.ok) throw new Error()
-    showToast('Modell mentve (újraindítás szükséges)')
+    currentAgent.model = newModel
+    const triggeredAt = Math.floor(Date.now() / 1000)
+    document.getElementById('agentDetailModelRestarting').hidden = false
+    document.getElementById('processLabel').textContent = 'Újraindítás'
+    document.getElementById('processDot').className = 'process-dot restarting'
+    showToast('Modell mentve, agent újraindítása...')
     loadAgents()
+    const restartRes = await fetch(`/api/agents/${encodeURIComponent(name)}/restart`, { method: 'POST' })
+    if (!restartRes.ok) {
+      document.getElementById('agentDetailModelRestarting').hidden = true
+      if (currentAgent) updateProcessControl(currentAgent)
+      showToast('Az újraindítás indítása sikertelen')
+      return
+    }
+    startModelRestartPolling(name, newModel, triggeredAt)
   } catch { showToast('Hiba a mentés során') }
 })
 

--- a/web/index.html
+++ b/web/index.html
@@ -1248,7 +1248,10 @@
           <div class="agent-overview-grid">
             <div class="agent-overview-item">
               <span class="meta-label">Modell</span>
-              <span class="meta-value" id="agentDetailModel"></span>
+              <div class="meta-value-row">
+                <span class="meta-value" id="agentDetailModel"></span>
+                <span class="meta-badge" id="agentDetailModelRestarting" hidden>újraindítás alatt</span>
+              </div>
             </div>
             <div class="agent-overview-item">
               <span class="meta-label">Csatorna</span>

--- a/web/style.css
+++ b/web/style.css
@@ -911,6 +911,11 @@ main {
   animation: pulse-dot 2s ease-in-out infinite;
 }
 .process-dot.stopped { background: var(--text-muted); }
+.process-dot.restarting {
+  background: var(--warning, #d4a52c);
+  box-shadow: 0 0 6px rgba(212, 165, 44, 0.6);
+  animation: pulse-dot 1s ease-in-out infinite;
+}
 
 @keyframes pulse-dot {
   0%, 100% { opacity: 1; }
@@ -1679,7 +1684,12 @@ main {
   cursor: pointer;
   transition: all var(--transition);
 }
-.btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+.btn-secondary:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.btn-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  color: var(--text-muted);
+}
 
 .btn-danger {
   padding: 10px 20px;
@@ -1941,6 +1951,23 @@ main {
 .meta-value-editable:hover {
   color: var(--text);
 }
+.meta-value-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.meta-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--bg-elevated, rgba(255, 165, 0, 0.15));
+  border: 1px solid var(--border, rgba(255, 165, 0, 0.4));
+  border-radius: 4px;
+}
+.meta-badge[hidden] { display: none; }
 
 .task-detail-result {
   margin-bottom: 20px;


### PR DESCRIPTION
## Mit és miért

A dashboard eddig **hardcode-olt modellnevet** mutatott az agenteknél, és modellváltáskor nem módosultak az infomációk s kézzel kellett a sessiont újraindítani. Ez a PR end-to-end megoldja, plusz pár kapcsolódó apróságot.

### 1. Élő ("active") modell megjelenítés
- Új `src/web/active-model.ts`: kiolvassa a Claude Code session jsonl-jéből (`~/.claude/projects/<dir>/`) hogy a **futó** process ténylegesen melyik modellt használja, nem a configban beállított értéket. 3 mp-es cache, és `sinceUnixSec` paraméterrel kiszűri a restart előtti turn-öket (`--continue` ugyanabba a jsonl-be ír).
- Az agent- és Marveen-summary API mostantól `activeModel` + `runningSince` mezőt is ad vissza. A Marveen detail panel a hardcode `claude-opus-4-8` helyett az élő modellt mutatja.

### 2. Modellváltás = automatikus újraindítás
- Új `POST /api/agents/:name/restart` végpont (`restartAgentProcess`: stop ha fut, majd start).
- Új `getAgentRunningSince` (tmux `session_created`) — ez a megbízható "újraindult" jel.
- A dashboardon a modell mentése után az agent automatikusan újraindul: "újraindítás alatt" badge + sárga pulzáló process-dot, majd a frontend pollozza a `runningSince`-t és visszaolvassa az új modellt.

### 3. `--model` flag végigvezetve
- `scripts/channels.sh` és a `channel-monitor.ts` soft-resume mostantól a `.claude/settings.json`-ből olvassa a fő agent modelljét és explicit `--model`-lel indít, hogy ne driftelődjön el a claude-code beépített defaultjára. `.claude/settings.json`: `"model": "claude-opus-4-8"`. A main agent a Claude default modellel indult de opus4.8-at irt a  modell választóban. felvéve a default modell a settings.json-ba így force azzal indul a modell. Akkor is ha valakinek nincs default.

### Egyéb
- CSS: `meta-badge`, `process-dot.restarting`, disabled secondary-button állapot.

## Teszt
- [ ] Sub-agent modell váltása a dashboardon -> automatikus restart + új modell megjelenik
- [ ] Marveen detail panel az élő modellt mutatja
- [ ] `scripts/channels.sh` `--model`-lel indítja a fő sessiont

🤖 Generated with [Claude Code](https://claude.com/claude-code)