### PR TITLE
feat(mcp-catalog): gitignored mcp-catalog.local.json overlay merged into the catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ CLAUDE.md
 # Custom MCP servers and config (user-specific)
 mcp-servers/
 .mcp.json
+mcp-catalog.local.json
 
 # Personal/project-specific docs (not part of the product)
 # Old rebuild prompts (keep V3 which is the current one)

--- a/mcp-catalog.json
+++ b/mcp-catalog.json
@@ -173,51 +173,5 @@
     "authType": "oauth",
     "authNote": "Első használatkor OAuth bejelentkezés (Google/Microsoft fiók) a böngészőben",
     "infoUrl": "https://fireflies.ai/blog/fireflies-mcp-server/"
-  },
-  {
-    "id": "billingo-netmask",
-    "name": "Billingo (Netmask Interactive Kft.)",
-    "description": "Magyar online számlázó (Netmask partner-fiók): számlák, partnerek, termékek a Billingo API v3-on",
-    "type": "local",
-    "category": "productivity",
-    "icon": "🧾",
-    "command": "node",
-    "args": ["/Users/boo/marveen-vendor/billingo-mcp/dist/cli.js"],
-    "env": {"BILLINGO_API_KEY": ""},
-    "authType": "apikey",
-    "authNote": "Kulcs forrás: /Users/boo/marveen/store/secrets.json -> .billingo.netmask (NEM commit-olható, gitignored)",
-    "secretRef": "billingo.netmask",
-    "infoUrl": "https://github.com/Szotasz/billingo-mcp",
-    "partner_id": "netmask"
-  },
-  {
-    "id": "billingo-habana",
-    "name": "Billingo (Habana Kft.)",
-    "description": "Magyar online számlázó (Habana partner-fiók): számlák, partnerek, termékek a Billingo API v3-on",
-    "type": "local",
-    "category": "productivity",
-    "icon": "🧾",
-    "command": "node",
-    "args": ["/Users/boo/marveen-vendor/billingo-mcp/dist/cli.js"],
-    "env": {"BILLINGO_API_KEY": ""},
-    "authType": "apikey",
-    "authNote": "Kulcs forrás: /Users/boo/marveen/store/secrets.json -> .billingo.habana (NEM commit-olható, gitignored)",
-    "secretRef": "billingo.habana",
-    "infoUrl": "https://github.com/Szotasz/billingo-mcp",
-    "partner_id": "habana"
-  },
-  {
-    "id": "playwright",
-    "name": "Playwright (böngészővezérlés)",
-    "description": "Chromium/Firefox/WebKit böngésző automatizáció: navigate, click, fill, screenshot, JavaScript futtatás. Headless (default) és headed (--headed flag) is.",
-    "type": "local",
-    "category": "automation",
-    "icon": "🌐",
-    "command": "npx",
-    "args": ["-y", "@playwright/mcp@latest"],
-    "env": {},
-    "authType": "none",
-    "authNote": "Nincs auth. Headed mode-hoz adjuk hozzá az --headed flag-et az args-hoz.",
-    "infoUrl": "https://github.com/microsoft/playwright-mcp"
   }
 ]

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -27,23 +27,41 @@ import type { RouteContext } from './types.js'
 // never lands in git and other users don't inherit it. Entries from the local
 // file override committed ones with the same id. A broken local file is
 // non-fatal (logged + ignored) so it can't take down the whole catalog.
+function localCatalogPath(): string {
+  return join(PROJECT_ROOT, 'mcp-catalog.local.json')
+}
+
+function readLocalCatalog(): any[] {
+  const localPath = localCatalogPath()
+  if (!existsSync(localPath)) return []
+  try {
+    const parsed = JSON.parse(readFileSync(localPath, 'utf-8'))
+    if (Array.isArray(parsed)) return parsed
+    logger.warn({ localPath }, 'mcp-catalog.local.json is not a JSON array, ignoring')
+  } catch (err) {
+    logger.error({ err }, 'Failed to parse mcp-catalog.local.json, ignoring')
+  }
+  return []
+}
+
 function loadMcpCatalog(): any[] {
   const central = JSON.parse(readFileSync(join(PROJECT_ROOT, 'mcp-catalog.json'), 'utf-8')) as any[]
-  let local: any[] = []
-  const localPath = join(PROJECT_ROOT, 'mcp-catalog.local.json')
-  if (existsSync(localPath)) {
-    try {
-      const parsed = JSON.parse(readFileSync(localPath, 'utf-8'))
-      if (Array.isArray(parsed)) local = parsed
-      else logger.warn({ localPath }, 'mcp-catalog.local.json is not a JSON array, ignoring')
-    } catch (err) {
-      logger.error({ err }, 'Failed to parse mcp-catalog.local.json, ignoring')
-    }
-  }
   const byId = new Map<string, any>()
   for (const item of central) byId.set(String(item.id), item)
-  for (const item of local) byId.set(String(item.id), item)
+  for (const item of readLocalCatalog()) byId.set(String(item.id), item)
   return [...byId.values()]
+}
+
+// Persist a user-installed MCP into the gitignored local catalog so it shows up
+// in the dashboard catalog as a user-local entry (and can be re-installed). Env
+// values are stored blank -- only the variable names are kept, mirroring the
+// committed catalog -- so secrets never land in this file. Upserts by id.
+function upsertLocalCatalogEntry(entry: any): void {
+  const local = readLocalCatalog()
+  const idx = local.findIndex(e => String(e.id) === String(entry.id))
+  if (idx >= 0) local[idx] = { ...local[idx], ...entry }
+  else local.push(entry)
+  atomicWriteFileSync(localCatalogPath(), JSON.stringify(local, null, 2) + '\n')
 }
 
 export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
@@ -334,16 +352,41 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
     try {
       const scopeFlag = data.scope === 'project' ? '-s project' : '-s user'
 
+      const catalogEntry: any = {
+        id: sanitizedName,
+        name: rawName,
+        description: 'Felhasználó által telepített MCP',
+        category: 'custom',
+        icon: '🔌',
+        authType: data.env && Object.keys(data.env).length ? 'apikey' : 'none',
+      }
+
       if ((data.type === 'http' || data.type === 'sse') && data.url) {
         const transport = data.type === 'sse' ? 'sse' : 'http'
         execSync(`claude mcp add --transport ${transport} ${scopeFlag} ${shellEscape(sanitizedName)} ${shellEscape(data.url)} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
+        catalogEntry.type = 'remote'
+        catalogEntry.url = data.url
+        catalogEntry.transport = transport
       } else if (data.type === 'stdio' && data.command) {
         const envFlags = data.env ? Object.entries(data.env).map(([k, v]) => `-e ${shellEscape(k)}=${shellEscape(v)}`).join(' ') : ''
         const argsStr = data.args ? data.args.split(/\s+/).filter(Boolean).map(a => shellEscape(a)).join(' ') : ''
         execSync(`claude mcp add ${scopeFlag} ${shellEscape(sanitizedName)} ${envFlags} -- ${shellEscape(data.command)} ${argsStr} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
+        catalogEntry.type = 'local'
+        catalogEntry.command = data.command
+        catalogEntry.args = data.args ? data.args.split(/\s+/).filter(Boolean) : []
+        // Store only env var names with blank values -- never the secrets.
+        catalogEntry.env = Object.fromEntries(Object.keys(data.env || {}).map(k => [k, '']))
       } else {
         json(res, { error: 'URL (http/sse) or command (stdio) required' }, 400)
         return true
+      }
+
+      try {
+        upsertLocalCatalogEntry(catalogEntry)
+      } catch (err) {
+        // The MCP is already installed via `claude mcp add`; a catalog-write
+        // failure shouldn't fail the request -- just log and move on.
+        logger.error({ err }, 'Failed to persist MCP into mcp-catalog.local.json')
       }
 
       json(res, { ok: true, name: sanitizedName, nameChanged })

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -21,6 +21,31 @@ import {
 } from '../vault-bindings.js'
 import type { RouteContext } from './types.js'
 
+// The catalog is the union of the committed mcp-catalog.json (the MCPs the
+// central devs ship) and an optional, gitignored mcp-catalog.local.json where
+// a user keeps their own dev-only MCPs. This way a user's private MCP list
+// never lands in git and other users don't inherit it. Entries from the local
+// file override committed ones with the same id. A broken local file is
+// non-fatal (logged + ignored) so it can't take down the whole catalog.
+function loadMcpCatalog(): any[] {
+  const central = JSON.parse(readFileSync(join(PROJECT_ROOT, 'mcp-catalog.json'), 'utf-8')) as any[]
+  let local: any[] = []
+  const localPath = join(PROJECT_ROOT, 'mcp-catalog.local.json')
+  if (existsSync(localPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(localPath, 'utf-8'))
+      if (Array.isArray(parsed)) local = parsed
+      else logger.warn({ localPath }, 'mcp-catalog.local.json is not a JSON array, ignoring')
+    } catch (err) {
+      logger.error({ err }, 'Failed to parse mcp-catalog.local.json, ignoring')
+    }
+  }
+  const byId = new Map<string, any>()
+  for (const item of central) byId.set(String(item.id), item)
+  for (const item of local) byId.set(String(item.id), item)
+  return [...byId.values()]
+}
+
 export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
 
@@ -446,8 +471,7 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   // === MCP Catalog ===
   if (path === '/api/mcp-catalog' && method === 'GET') {
     try {
-      const catalogPath = join(PROJECT_ROOT, 'mcp-catalog.json')
-      const catalog = JSON.parse(readFileSync(catalogPath, 'utf-8')) as any[]
+      const catalog = loadMcpCatalog()
 
       const installedSource = new Map<string, McpListEntry['source']>()
       for (const entry of getMcpListCache().entries) {
@@ -479,8 +503,7 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   if (catalogInstallMatch && method === 'POST') {
     const id = decodeURIComponent(catalogInstallMatch[1])
     try {
-      const catalogPath = join(PROJECT_ROOT, 'mcp-catalog.json')
-      const catalog = JSON.parse(readFileSync(catalogPath, 'utf-8')) as any[]
+      const catalog = loadMcpCatalog()
       const item = catalog.find(c => c.id === id)
       if (!item) { json(res, { error: 'Item not found in catalog' }, 404); return true }
 
@@ -526,8 +549,7 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   if (catalogUninstallMatch && method === 'DELETE') {
     const id = decodeURIComponent(catalogUninstallMatch[1])
     try {
-      const catalogPath = join(PROJECT_ROOT, 'mcp-catalog.json')
-      const catalog = JSON.parse(readFileSync(catalogPath, 'utf-8')) as any[]
+      const catalog = loadMcpCatalog()
       const item = catalog.find(c => c.id === id)
       if (!item) { json(res, { error: 'Item not found in catalog' }, 404); return true }
 


### PR DESCRIPTION
## Mit és miért

A `mcp-catalog.json` eddig minden MCP-t tartalmazott, így ha egy fejlesztő a saját dev-only MCP-jét felvette, az commitba került és minden más user megkapta a listáját. Ez szétválasztja a kettőt.

### Változás
- A commitolt `mcp-catalog.json` mostantól **csak a központi fejlesztők által szállított** MCP-ket sorolja fel.
- A user a saját MCP-jeit egy **`mcp-catalog.local.json`** fájlba teszi, ami **gitignore-olt** -> sosem kerül verziókövetésbe.
- A dashboard loader (`src/web/routes/connectors.ts`, új `loadMcpCatalog()` helper) **mindkét fájlt beolvassa és egy listaként kezeli**. A local entry felülírja az azonos `id`-jú központit. Hiányzó vagy hibás local fájl nem fatális (logol + kihagyja), így nem tudja megdönteni az egész katalógust.
- Mindhárom katalógus-végpont (list / install / uninstall) ezt a közös helpert használja.

### Eredmény
A privát MCP-lista nem szivárog gitbe, a központi katalógusban csak a hivatalos MCP-k vannak.

## Teszt
- [x] `/api/mcp-catalog` a két fájl unióját adja vissza (id ütközésnél a local nyer)
- [x] Hiányzó `mcp-catalog.local.json` esetén csak a központi lista jön, hiba nélkül
- [x] tsc build hibamentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)