### PR TITLE
fix(model): Opus 4.8 → 1M-context variant (claude-opus-4-8[1m]) + shell-quote everywhere

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-8",
+  "model": "claude-opus-4-8[1m]",
   "enabledPlugins": {
     "slack-channel@marveen-marketplace": false,
     "telegram@claude-plugins-official": true

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -91,7 +91,9 @@ if [ -f "$INSTALL_DIR/.claude/settings.json" ] && command -v jq >/dev/null 2>&1;
   MAIN_MODEL="$(jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null)"
 fi
 MODEL_FLAG=""
-[ -n "$MAIN_MODEL" ] && MODEL_FLAG="--model $MAIN_MODEL "
+# Single-quote the model id so values like `claude-opus-4-8[1m]` survive the
+# tmux command-string round-trip without the inner shell glob-expanding `[1m]`.
+[ -n "$MAIN_MODEL" ] && MODEL_FLAG="--model '$MAIN_MODEL' "
 
 # Régi session takarítás
 $TMUX kill-session -t "$SESSION" 2>/dev/null

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -11,7 +11,7 @@ export const DEFAULT_MODEL = 'claude-sonnet-4-6'
 
 // Map short model names to full Claude model IDs (backwards compat with old configs)
 export const MODEL_ALIASES: Record<string, string> = {
-  'opus': 'claude-opus-4-8',
+  'opus': 'claude-opus-4-8[1m]',
   'sonnet': 'claude-sonnet-4-6',
   'haiku': 'claude-haiku-4-5-20251001',
   'inherit': DEFAULT_MODEL,

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -161,7 +161,9 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
       ? `export ${stateEnvVar}="${agentChannelDir}"${auditLogEnv} && `
       : ''
     const channelFlag = hasChannel ? `--channels plugin:${provider.pluginId}` : ''
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${channelSetup}${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model ${model} ${channelFlag}`.trimEnd()
+    // Single-quote `${model}` so values like `claude-opus-4-8[1m]` (1M-context
+    // suffix) are not glob-expanded by the shell that tmux spawns the command in.
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${channelSetup}${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
     execSync(
       `${TMUX} new-session -d -s ${session} "${cmd}"`,
       { timeout: 10000 }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -232,7 +232,9 @@ function resumeMarveenSession(): boolean {
     const claudeCmd = [
       'export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"',
       '&&', CLAUDE, '--continue', '--dangerously-skip-permissions',
-      ...(model ? ['--model', model] : []),
+      // Single-quote the model id so a value like `claude-opus-4-8[1m]` is not
+      // glob-expanded by the shell that tmux respawn-pane spawns the command in.
+      ...(model ? ['--model', `'${model}'`] : []),
       // NOTE: inbound from `--channels` goes through a separate
       // allowlist at /etc/claude-code/managed-settings.json
       // (allowedChannelPlugins). If the plugin isn't listed there,

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -342,7 +342,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const hasDeepseek = getSecret('DEEPSEEK_API_KEY') !== null
     json(res, {
       claude: [
-        { id: 'claude-opus-4-8', label: 'Opus 4.8 (legújabb)' },
+        { id: 'claude-opus-4-8[1m]', label: 'Opus 4.8 (1M kontextus)' },
         { id: 'claude-opus-4-7', label: 'Opus 4.7' },
         { id: 'claude-opus-4-6', label: 'Opus 4.6' },
         { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6 (alapértelmezett)' },

--- a/web/index.html
+++ b/web/index.html
@@ -1144,7 +1144,7 @@
             <select id="agentModel">
               <option value="inherit">Öröklött (alapértelmezett)</option>
               <optgroup label="☁️ Claude (felhő)">
-                <option value="claude-opus-4-8">Opus 4.8 (legújabb)</option>
+                <option value="claude-opus-4-8[1m]">Opus 4.8 (1M kontextus)</option>
                 <option value="claude-opus-4-7">Opus 4.7</option>
                 <option value="claude-opus-4-6">Opus 4.6</option>
                 <option value="claude-sonnet-4-6">Sonnet 4.6 (gyors és okos)</option>
@@ -1295,7 +1295,7 @@
             <label for="editAgentModel">Modell</label>
             <select id="editAgentModel">
               <optgroup label="☁️ Claude (felhő)">
-                <option value="claude-opus-4-8">Opus 4.8 (legújabb)</option>
+                <option value="claude-opus-4-8[1m]">Opus 4.8 (1M kontextus)</option>
                 <option value="claude-opus-4-7">Opus 4.7</option>
                 <option value="claude-opus-4-6">Opus 4.6</option>
                 <option value="claude-sonnet-4-6">Sonnet 4.6 (alapértelmezett)</option>


### PR DESCRIPTION
External report (via Szabi/Marveen): the dashboard's Opus 4.8 setting routes the running session to the 200K context window, not the 1M one. The flotta UI testing / large-context work needs the 1M variant.

## Root cause

The model id everywhere was the plain `claude-opus-4-8` string → Claude Code defaults that to the 200K window. The CLI accepts a suffixed variant `claude-opus-4-8[1m]` that picks the 1M window.

**Live confirmation** on the running marveen-channels session jsonl:
```
$ grep -oE "claude-opus-4-8\[1m\]" ~/.claude/projects/<dir>/<latest>.jsonl
claude-opus-4-8[1m]
claude-opus-4-8[1m]
claude-opus-4-8[1m]
$ grep -oE "context-1m" ...
context-1m
```
The 200K variant has neither marker. So Claude Code accepts the suffix syntax and routes the request to the 1M window.

## Changes — model id swap (4 surfaces)

- `src/web/agent-config.ts` `MODEL_ALIASES.opus`
- `src/web/routes/agents.ts` `/api/models/available` picker entry (label: "Opus 4.8 (1M kontextus)")
- `web/index.html` both `<option>` dropdowns (create + edit wizard)
- `.claude/settings.json` main agent default

## Changes — shell-quote caveat (critical)

The `[1m]` suffix contains square brackets which are bash glob characters. The launch paths that build `--model <id>` as a shell-string for tmux to execute must single-quote the value:
- `scripts/channels.sh` `MODEL_FLAG` → `--model '$MAIN_MODEL'`
- `src/web/channel-monitor.ts` `resumeMarveenSession` claudeCmd → `'--model', \`'${model}'\``
- `src/web/agent-process.ts` `startAgentProcess` cmd-string → `--model '${model}'`

Round-trip test:
```
$ MAIN_MODEL="claude-opus-4-8[1m]"; MODEL_FLAG="--model '$MAIN_MODEL'"; echo $MODEL_FLAG
--model 'claude-opus-4-8[1m]'
```
Brackets intact, no glob expansion.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] Shell glob round-trip test (above)
- [x] Live jsonl confirmation that Claude Code uses + emits the `[1m]` syntax + `context-1m` beta flag
- [ ] After deploy: dashboard "Restart" an agent set to Opus 4.8; check the agent's own jsonl for `claude-opus-4-8[1m]` + `context-1m`. Confirmed working at the Marveen level already; the rebuild propagates the quoting fix to all per-agent launches.

## Per Marveen's call

- Kept a single "Opus 4.8 (1M kontextus)" option in the picker; no separate 200K entry. The 1M default is enough for the flotta given the Max plan flat fee (cf. memory `feedback_tokenkoltseg_irrelevans`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)