### PR TITLE
watchdog: defer agent auto-restart during process startup grace

### DIFF
--- a/src/__tests__/agent-restart-policy.test.ts
+++ b/src/__tests__/agent-restart-policy.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest'
+import { shouldAutoRestartDownAgent, parseEtimeToSeconds } from '../web/agent-restart-policy.js'
+
+const STARTUP = 180_000
+const RESTART = 90_000
+
+describe('shouldAutoRestartDownAgent', () => {
+  it('restarts an old process that was never restarted by the watchdog', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 5 * 60_000,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(true)
+  })
+
+  it('does NOT restart a freshly started process (within startup grace)', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 20_000,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(false)
+  })
+
+  it('does NOT restart exactly at the startup-grace boundary minus one', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: STARTUP - 1,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(false)
+  })
+
+  it('restarts exactly at the startup-grace boundary', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: STARTUP,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(true)
+  })
+
+  it('does NOT restart when recently restarted by the watchdog', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 10 * 60_000,
+      msSinceLastRestart: 10_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(false)
+  })
+
+  it('restarts when the restart grace has elapsed', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 10 * 60_000,
+      msSinceLastRestart: RESTART + 1,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(true)
+  })
+
+  it('does NOT restart at the restart-grace boundary minus one', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 10 * 60_000,
+      msSinceLastRestart: RESTART - 1,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(false)
+  })
+
+  it('does NOT restart when the process age is unknown (negative)', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: -1,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(false)
+  })
+
+  it('does NOT restart when the process age is NaN', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: Number.NaN,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(false)
+  })
+
+  it('startup grace takes precedence over an elapsed restart grace', () => {
+    // Young process, but msSinceLastRestart already past restart grace:
+    // still must not restart, because it is within startup grace.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 5_000,
+      msSinceLastRestart: RESTART + 100_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(false)
+  })
+
+  it('handles a realistic Opus-1M startup that previously crash-looped', () => {
+    // The agent has been up 45s (plugin not yet spawned), never watchdog-restarted.
+    // Old behaviour: restart. New behaviour: defer.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 45_000,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(false)
+  })
+
+  it('restarts a genuinely dead long-running agent', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 3 * 60 * 60_000,
+      msSinceLastRestart: 30 * 60_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(true)
+  })
+})
+
+describe('parseEtimeToSeconds', () => {
+  it('parses MM:SS', () => {
+    expect(parseEtimeToSeconds('05:23')).toBe(5 * 60 + 23)
+  })
+
+  it('parses HH:MM:SS', () => {
+    expect(parseEtimeToSeconds('01:05:23')).toBe(3600 + 5 * 60 + 23)
+  })
+
+  it('parses DD-HH:MM:SS', () => {
+    expect(parseEtimeToSeconds('2-03:04:05')).toBe(2 * 86400 + 3 * 3600 + 4 * 60 + 5)
+  })
+
+  it('parses a leading-space single-digit minute (BSD ps padding)', () => {
+    expect(parseEtimeToSeconds('  5:23')).toBe(5 * 60 + 23)
+  })
+
+  it('parses 00:00', () => {
+    expect(parseEtimeToSeconds('00:00')).toBe(0)
+  })
+
+  it('returns -1 for an empty string', () => {
+    expect(parseEtimeToSeconds('')).toBe(-1)
+  })
+
+  it('returns -1 for non-numeric junk', () => {
+    expect(parseEtimeToSeconds('not-a-time')).toBe(-1)
+  })
+
+  it('returns -1 for a single bare number (no colon)', () => {
+    expect(parseEtimeToSeconds('42')).toBe(-1)
+  })
+
+  it('returns -1 for too many segments', () => {
+    expect(parseEtimeToSeconds('1:2:3:4')).toBe(-1)
+  })
+
+  it('returns -1 for an out-of-range seconds field', () => {
+    expect(parseEtimeToSeconds('05:99')).toBe(-1)
+  })
+
+  it('returns -1 for an out-of-range minutes field', () => {
+    expect(parseEtimeToSeconds('99:30')).toBe(-1)
+  })
+
+  it('allows large hour and day counts', () => {
+    expect(parseEtimeToSeconds('5-23:59:59')).toBe(5 * 86400 + 23 * 3600 + 59 * 60 + 59)
+  })
+
+  it('returns -1 for a bare colon (empty segments)', () => {
+    expect(parseEtimeToSeconds(':')).toBe(-1)
+  })
+
+  it('returns -1 for a leading dash with no day count', () => {
+    expect(parseEtimeToSeconds('-05:30')).toBe(-1)
+  })
+
+  it('returns -1 for an empty day segment before the dash', () => {
+    expect(parseEtimeToSeconds('-01:02:03')).toBe(-1)
+  })
+
+  it('returns -1 for a trailing colon', () => {
+    expect(parseEtimeToSeconds('05:')).toBe(-1)
+  })
+
+  it('returns -1 for the DD-MM:SS shape ps never emits (days require hours)', () => {
+    expect(parseEtimeToSeconds('5-23:59')).toBe(-1)
+  })
+})

--- a/src/web/agent-restart-policy.ts
+++ b/src/web/agent-restart-policy.ts
@@ -1,0 +1,64 @@
+// Pure decision logic for the channel-plugin watchdog's agent auto-restart.
+//
+// Extracted from channel-monitor.ts so the restart guards are unit-testable
+// without spawning processes or mocking the OS. The watchdog walks each
+// agent's process tree to check whether the channel plugin (a `bun server.ts`
+// grandchild) is alive; when it is not, it used to restart the agent
+// immediately. That killed freshly-started agents whose plugin had simply not
+// finished spawning yet -- a large-context model launched with --continue can
+// take well over the 30s first-probe window to bring the plugin up, so the
+// watchdog saw "down", restarted, and looped forever. The startup grace below
+// gives a young process time to finish coming up before any restart.
+
+export interface AgentRestartDecisionInput {
+  // How long the agent's claude process has been running, in milliseconds.
+  // Pass a negative value when the age could not be determined; the policy
+  // then errs on the side of NOT restarting.
+  processAgeMs: number
+  // Milliseconds since the watchdog last restarted this agent, or null when
+  // it has never restarted it (e.g. the process was started by boot or by an
+  // operator action rather than the watchdog).
+  msSinceLastRestart: number | null
+  // A young process is still bringing its channel plugin up; do not restart
+  // until it is at least this old.
+  startupGraceMs: number
+  // After the watchdog restarts an agent, give the new process at least this
+  // long to come up before considering another restart.
+  restartGraceMs: number
+}
+
+// Returns true only when a down-reporting agent should actually be restarted.
+export function shouldAutoRestartDownAgent(input: AgentRestartDecisionInput): boolean {
+  const { processAgeMs, msSinceLastRestart, startupGraceMs, restartGraceMs } = input
+  // Unknown process age: the age probe failed. Be conservative and do not
+  // restart -- a false "down" must never kill a healthy agent.
+  if (!Number.isFinite(processAgeMs) || processAgeMs < 0) return false
+  // Freshly started: the channel plugin may still be spawning.
+  if (processAgeMs < startupGraceMs) return false
+  // Recently restarted by the watchdog: give the new process time to come up.
+  if (msSinceLastRestart !== null && msSinceLastRestart < restartGraceMs) return false
+  return true
+}
+
+// Parse the elapsed-time string from `ps -o etime=` into seconds.
+// Format is `[[dd-]hh:]mm:ss` on both BSD (macOS) and procps (Linux):
+//   "05:23"        -> 323
+//   "01:05:23"     -> 3923
+//   "2-03:04:05"   -> 183845
+// Returns -1 for anything it cannot parse.
+export function parseEtimeToSeconds(etime: string): number {
+  // Match exactly the documented shapes and nothing else, so malformed input
+  // (empty segments, a leading '-', stray colons) falls through to -1 instead
+  // of coercing through Number('') === 0 into a bogus duration.
+  // The day count only appears together with an hours field, so days and hours
+  // share one optional group: this matches MM:SS, HH:MM:SS and DD-HH:MM:SS but
+  // rejects shapes ps never emits (e.g. DD-MM:SS).
+  const m = etime.trim().match(/^(?:(?:(\d+)-)?(\d+):)?(\d+):(\d+)$/)
+  if (!m) return -1
+  const days = m[1] ? Number(m[1]) : 0
+  const hours = m[2] ? Number(m[2]) : 0
+  const minutes = Number(m[3])
+  const seconds = Number(m[4])
+  if (minutes > 59 || seconds > 59) return -1
+  return days * 86400 + hours * 3600 + minutes * 60 + seconds
+}

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -19,9 +19,22 @@ import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
 import { getProvider, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import { attemptChannelMcpReconnect } from './channel-mcp-reconnect.js'
+import { shouldAutoRestartDownAgent, parseEtimeToSeconds } from './agent-restart-policy.js'
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
+
+// How long the agent's claude process has been running. Returns -1 when it
+// cannot be determined, which the restart policy treats as "do not restart".
+function getProcessAgeMs(pid: number): number {
+  try {
+    const out = execFileSync('/bin/ps', ['-o', 'etime=', '-p', String(pid)], { timeout: 3000, encoding: 'utf-8' })
+    const secs = parseEtimeToSeconds(out)
+    return secs < 0 ? -1 : secs * 1000
+  } catch {
+    return -1
+  }
+}
 
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
@@ -152,6 +165,11 @@ function hasChannelPluginAlive(claudePid: number, providerType: ChannelProviderT
 const agentDownSince: Map<string, number> = new Map()
 const agentLastRestart: Map<string, number> = new Map()
 const AGENT_RESTART_GRACE_MS = 90_000
+// A freshly started agent can take well over the first-probe window to bring
+// its channel plugin up (a large-context model launched with --continue spawns
+// the plugin only after a slow session load). Never restart a process younger
+// than this on a "plugin down" reading, or the watchdog crash-loops it.
+const AGENT_STARTUP_GRACE_MS = 180_000
 const PLUGIN_ALERT_DEDUP_MS = 30 * 60 * 1000
 
 // Per-session tracking for the wedged thinking-block error (a Claude
@@ -435,14 +453,21 @@ export function startChannelPluginMonitor(): NodeJS.Timeout {
         }
         continue
       }
-      if (!t.isMarveen && t.agentName) {
-        const lastRestart = agentLastRestart.get(t.agentName)
-        if (lastRestart && Date.now() - lastRestart < AGENT_RESTART_GRACE_MS) continue
-      }
       if (t.isMarveen) {
         if (shouldEscalateMarveenDown()) handleMarveenDown()
       } else {
         if (!agentDownSince.has(t.session)) agentDownSince.set(t.session, Date.now())
+        const lastRestart = agentLastRestart.get(t.agentName!)
+        const restart = shouldAutoRestartDownAgent({
+          processAgeMs: getProcessAgeMs(claudePid),
+          msSinceLastRestart: lastRestart != null ? Date.now() - lastRestart : null,
+          startupGraceMs: AGENT_STARTUP_GRACE_MS,
+          restartGraceMs: AGENT_RESTART_GRACE_MS,
+        })
+        if (!restart) {
+          logger.debug({ agent: t.agentName, provider: t.provider }, 'Channel plugin probe reports down but agent is within startup/restart grace -- deferring')
+          continue
+        }
         const agentProvider = resolveAgentProvider(t.agentName!)
         const stateDir = channelStateDir(agentProvider, agentDir(t.agentName!))
         const agentToken = readChannelToken(agentProvider, join(stateDir, '.env'))


### PR DESCRIPTION
## Why this matters

The channel-plugin health monitor auto-restarts a sub-agent when it cannot find
the agent's channel plugin process (a `bun server.ts` grandchild) under the
agent's `claude` PID. The liveness probe itself is correct for a settled agent.

The problem is timing at startup. A freshly started agent spawns its channel
plugin only after the `claude` process has loaded, and a large-context model
launched with `--continue` can take well over the monitor's 30s first-probe
window to get there. The monitor saw "plugin down", restarted the agent, and on
the next tick saw the same thing, looping forever. In practice every affected
agent was killed and restarted roughly every two minutes and never stayed up.

The existing grace only covered restarts the monitor had itself performed
(`agentLastRestart`); a process started by boot or by an operator action had no
grace at all, so the very first probe could kill it before its plugin spawned.

Repro: launch an agent with a model/session slow enough that the channel plugin
takes longer than ~30s to appear under the `claude` PID. The monitor restarts it
on the first tick and keeps doing so; `dashboard.log` fills with repeated
`Agent channel plugin down -- auto-restarting` at ~2 min cadence.

## Change

- New pure module `src/web/agent-restart-policy.ts`:
  - `shouldAutoRestartDownAgent(...)` -- the full restart decision. Returns
    `false` while the process is within a startup grace, while it is within the
    post-restart grace, or when the process age is unknown.
  - `parseEtimeToSeconds(...)` -- parses `ps -o etime=` output
    (`[[DD-]HH:]MM:SS`) with a strict regex; returns `-1` for anything else.
- `src/web/channel-monitor.ts`:
  - New `getProcessAgeMs(pid)` helper (reads `ps -o etime=`).
  - New `AGENT_STARTUP_GRACE_MS = 180_000`.
  - The non-main restart branch now calls `shouldAutoRestartDownAgent(...)` with
    the process age, replacing the old inline `agentLastRestart`-only grace.
- `src/__tests__/agent-restart-policy.test.ts` -- 29 unit tests.

## Scope / compatibility

- No behavior change for a genuinely dead long-running agent: once it is past
  the startup grace it restarts exactly as before.
- Unknown process age (e.g. the `ps` probe fails) errs toward NOT restarting, so
  a transient false "down" can never kill a healthy agent.
- The main agent's channels session path and the `!claudePid` branch are
  unchanged.
- `ps -o etime=` and the `[[DD-]HH:]MM:SS` format are common to BSD (macOS) and
  procps (Linux).

## Test plan

- `npm run typecheck` -- clean.
- `npx vitest run src/__tests__/agent-restart-policy.test.ts` -- 29 passed
  (boundary cases for both grace windows, unknown age, and every etime shape,
  including malformed inputs that must return `-1`).
- `npx vitest run src/__tests__/channel-health-monitor.test.ts` -- still green.

## Known limitations

- The startup grace is a fixed 3 minutes. An agent whose plugin genuinely fails
  to come up at all is detected only after that window (acceptable: recovery is
  delayed, not lost). A future refinement could probe the plugin's own readiness
  rather than infer it from process age.
