### PR TITLE
dashboard: read live agent model from the agent's own config dir

### DIFF
--- a/src/__tests__/active-model.test.ts
+++ b/src/__tests__/active-model.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { join } from 'node:path'
+import { projectsDirFor } from '../web/active-model.js'
+
+describe('projectsDirFor', () => {
+  it('uses <home>/.claude/projects when no config dir is given', () => {
+    const result = projectsDirFor('/home/u/work', undefined, '/home/u')
+    expect(result).toBe(join('/home/u', '.claude', 'projects', '-home-u-work'))
+  })
+
+  it('uses the supplied config dir instead of the default home location', () => {
+    const result = projectsDirFor('/home/u/work', '/home/u/.claude-coding', '/home/u')
+    expect(result).toBe(join('/home/u/.claude-coding', 'projects', '-home-u-work'))
+  })
+
+  it('does not fall back to the home dir when a config dir is supplied', () => {
+    const result = projectsDirFor('/home/u/work', '/var/lib/claude-coding', '/home/u')
+    expect(result.startsWith('/var/lib/claude-coding')).toBe(true)
+    expect(result).not.toContain('/home/u/.claude')
+  })
+
+  it('encodes slashes and dots in the working dir to dashes', () => {
+    const result = projectsDirFor('/home/u/some.dir/app', '/cfg', '/home/u')
+    expect(result).toBe(join('/cfg', 'projects', '-home-u-some-dir-app'))
+  })
+
+  it('produces distinct project dirs for the same working dir on different config roots', () => {
+    const a = projectsDirFor('/w', '/home/u/.claude', '/home/u')
+    const b = projectsDirFor('/w', '/home/u/.claude-coding', '/home/u')
+    expect(a).not.toBe(b)
+  })
+})

--- a/src/web/active-model.ts
+++ b/src/web/active-model.ts
@@ -17,15 +17,25 @@ import { homedir } from 'node:os'
 const cache = new Map<string, { value: string | null; expiresAt: number }>()
 const TTL_MS = 3000
 
-export function readActiveModelFromProjectDir(workingDir: string, sinceUnixSec?: number): string | null {
+// Resolve the session-log directory Claude Code writes for a working dir.
+// Logs live under <config-root>/projects/<encoded-working-dir>/, where the
+// config root is ~/.claude by default but an alternate one when the agent was
+// launched with CLAUDE_CONFIG_DIR. Pass that absolute config root as configDir
+// so we read the right project dir for agents on a non-default config.
+export function projectsDirFor(workingDir: string, configDir?: string, homeDirOverride?: string): string {
+  const base = configDir ?? join(homeDirOverride ?? homedir(), '.claude')
+  const encoded = workingDir.replace(/[/.]/g, '-')
+  return join(base, 'projects', encoded)
+}
+
+export function readActiveModelFromProjectDir(workingDir: string, sinceUnixSec?: number, configDir?: string): string | null {
   const now = Date.now()
-  const cacheKey = `${workingDir}:${sinceUnixSec ?? ''}`
+  const cacheKey = `${workingDir}:${sinceUnixSec ?? ''}:${configDir ?? ''}`
   const cached = cache.get(cacheKey)
   if (cached && cached.expiresAt > now) return cached.value
   let value: string | null = null
   try {
-    const encoded = workingDir.replace(/[/.]/g, '-')
-    const dir = join(homedir(), '.claude', 'projects', encoded)
+    const dir = projectsDirFor(workingDir, configDir)
     if (!existsSync(dir)) {
       cache.set(cacheKey, { value: null, expiresAt: now + TTL_MS })
       return null

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -27,6 +27,7 @@ import {
   writeAgentChannelProvider,
   readAgentAuthMode,
   writeAgentAuthMode,
+  readAgentClaudeConfigDir,
   type AuthMode,
 } from '../agent-config.js'
 import {
@@ -278,7 +279,7 @@ function getAgentSummary(name: string): AgentSummary {
     displayName: readAgentDisplayName(name),
     description: extractDescriptionFromClaudeMd(claudeMd),
     model: readAgentModel(name),
-    activeModel: proc.running ? readActiveModelFromProjectDir(dir, runningSince ?? undefined) : null,
+    activeModel: proc.running ? readActiveModelFromProjectDir(dir, runningSince ?? undefined, readAgentClaudeConfigDir(name) ?? undefined) : null,
     runningSince,
     authMode: readAgentAuthMode(name),
     securityProfile: readAgentSecurityProfile(name),


### PR DESCRIPTION
## Why this matters

The dashboard shows each agent's live running model by reading the latest Claude
Code session jsonl under `<config-root>/projects/<encoded-working-dir>/`. The
config root was hard-coded to `~/.claude`.

An agent launched with `CLAUDE_CONFIG_DIR` set (an alternate Claude Code config,
e.g. a separate login for coding agents) writes its session logs under that
alternate root, not `~/.claude`. The probe looked in the wrong place and found
nothing, so every such agent's live model rendered as null/unknown in the
dashboard even while running normally.

## Change

- `src/web/active-model.ts`:
  - New exported pure helper `projectsDirFor(workingDir, configDir?, homeDirOverride?)`
    that builds the session-log directory, using the supplied config root when
    present and falling back to `~/.claude` otherwise.
  - `readActiveModelFromProjectDir` takes an optional third arg `configDir` and
    includes it in the cache key.
- `src/web/routes/agents.ts`: the activeModel lookup now passes the agent's
  resolved config dir via `readAgentClaudeConfigDir(name)` (already used by the
  launcher to inject `CLAUDE_CONFIG_DIR`), so reader and launcher agree on the
  path.
- `src/__tests__/active-model.test.ts`: unit tests for `projectsDirFor`.

## Scope / compatibility

- No change for agents on the default config: a null/absent config dir resolves
  to `~/.claude/projects` exactly as before.
- `readAgentClaudeConfigDir` already returns an absolute, validated config root
  (the same value the launcher uses), so no new path handling is introduced.
- The working-dir encoding (`replace(/[/.]/g, '-')`) is unchanged.

## Test plan

- `npm run typecheck` -- clean.
- `npx vitest run src/__tests__/active-model.test.ts` -- 5 passed (default root,
  alternate root, no-home-fallback when a config dir is supplied, slash/dot
  encoding, per-config-root distinctness).

## Known limitations

- The main agent's model lookup (`routes/marveen.ts`) still reads from the
  default config root. The main agent currently runs on the default config, so
  this is correct today; wiring a config-dir override for the main agent is out
  of scope here.
