### PR TITLE
chore(mcp-catalog): restore Playwright entry in committed catalog (#201 follow-up)

### DIFF
--- a/mcp-catalog.json
+++ b/mcp-catalog.json
@@ -173,5 +173,19 @@
     "authType": "oauth",
     "authNote": "Első használatkor OAuth bejelentkezés (Google/Microsoft fiók) a böngészőben",
     "infoUrl": "https://fireflies.ai/blog/fireflies-mcp-server/"
+  },
+  {
+    "id": "playwright",
+    "name": "Playwright (böngészővezérlés)",
+    "description": "Chromium/Firefox/WebKit böngésző automatizáció: navigate, click, fill, screenshot, JavaScript futtatás. Headless (default) és headed (--headed flag) is.",
+    "type": "local",
+    "category": "automation",
+    "icon": "🌐",
+    "command": "npx",
+    "args": ["-y", "@playwright/mcp@latest"],
+    "env": {},
+    "authType": "none",
+    "authNote": "Nincs auth. Headed mode-hoz adjuk hozzá az --headed flag-et az args-hoz.",
+    "infoUrl": "https://github.com/microsoft/playwright-mcp"
   }
 ]


### PR DESCRIPTION
Follow-up to #201 (NoirHun) — restores the Playwright catalog entry that was inadvertently moved into the local overlay. Playwright is npx-based (`npx @playwright/mcp@latest`) and runs on every machine, so it belongs in the committed catalog (the user-specific Billingo entries correctly stay in the overlay, as designed by #201). The flotta uses the Playwright MCP for the UI-test workflow; leaving it out would break the one-click install on every fresh deploy.

## Verification

- `python3 -c "import json; json.load(open('mcp-catalog.json'))"` parses cleanly.
- `grep -c playwright mcp-catalog.json` → 3 (≥ 1).
- `npx tsc --noEmit` clean.

## Test plan

- [x] JSON validity + playwright count + tsc (above)
- [ ] After deploy: the dashboard catalog lists Playwright as installable; the user-specific Billingo entries remain only via the local overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)