### PR TITLE
fix(channel-setup): validate Discord channelId before hardRestartMarveenChannels (#202 fast-follow)

### DIFF
--- a/src/__tests__/validate-discord-channel-id.test.ts
+++ b/src/__tests__/validate-discord-channel-id.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { validateDiscordChannelId } from '../web/routes/agents.js'
+
+describe('validateDiscordChannelId', () => {
+  it('accepts a 17-digit snowflake', () => {
+    expect(validateDiscordChannelId('12345678901234567').ok).toBe(true)
+  })
+  it('accepts an 18-digit snowflake (most common today)', () => {
+    expect(validateDiscordChannelId('123456789012345678').ok).toBe(true)
+  })
+  it('accepts a 20-digit snowflake (upper bound)', () => {
+    expect(validateDiscordChannelId('12345678901234567890').ok).toBe(true)
+  })
+  it('trims leading and trailing whitespace before validating', () => {
+    expect(validateDiscordChannelId('  123456789012345678  ').ok).toBe(true)
+  })
+  it('rejects undefined', () => {
+    const r = validateDiscordChannelId(undefined)
+    expect(r.ok).toBe(false)
+    expect(r.error).toMatch(/required.*snowflake/)
+  })
+  it('rejects an empty string', () => {
+    expect(validateDiscordChannelId('').ok).toBe(false)
+  })
+  it('rejects a whitespace-only string', () => {
+    expect(validateDiscordChannelId('   ').ok).toBe(false)
+  })
+  it('rejects an alphanumeric channel name (e.g. #general)', () => {
+    expect(validateDiscordChannelId('general').ok).toBe(false)
+    expect(validateDiscordChannelId('#general').ok).toBe(false)
+  })
+  it('rejects a value with non-digit characters mixed in', () => {
+    expect(validateDiscordChannelId('1234567890123456a').ok).toBe(false)
+    expect(validateDiscordChannelId('12345-67890-12345').ok).toBe(false)
+  })
+  it('rejects a value too short (16 digits)', () => {
+    expect(validateDiscordChannelId('1234567890123456').ok).toBe(false)
+  })
+  it('rejects a value too long (21 digits)', () => {
+    expect(validateDiscordChannelId('123456789012345678901').ok).toBe(false)
+  })
+  it('rejects a signed numeric value', () => {
+    expect(validateDiscordChannelId('-123456789012345678').ok).toBe(false)
+    expect(validateDiscordChannelId('+123456789012345678').ok).toBe(false)
+  })
+})

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -92,6 +92,19 @@ import type { RouteContext } from './types.js'
 
 const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord'])
 
+// Discord channel ids are snowflakes — base-10 numeric ids, 17 to 20 digits
+// long in practice (current Discord scheme is 64-bit, with the leading bit
+// always 0). Rejects empty, whitespace-only, non-numeric, or wrong-length
+// values before any state write so a typo in the dashboard cannot bounce the
+// live Marveen session through hardRestartMarveenChannels().
+export function validateDiscordChannelId(cid: string | undefined): { ok: boolean; error?: string } {
+  const trimmed = cid?.trim()
+  if (!trimmed || !/^[0-9]{17,20}$/.test(trimmed)) {
+    return { ok: false, error: 'Discord channelId is required and must be a numeric snowflake (17-20 digits).' }
+  }
+  return { ok: true }
+}
+
 function parseChannelProvider(raw: string): ChannelProviderType | null {
   if (VALID_PROVIDERS.has(raw as ChannelProviderType)) return raw as ChannelProviderType
   return null
@@ -560,6 +573,16 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const body = await readBody(req)
     const { botToken, appToken, channelId } = JSON.parse(body.toString()) as { botToken: string; appToken?: string; channelId?: string }
     if (!botToken?.trim()) { json(res, { error: 'botToken is required' }, 400); return true }
+
+    // Discord-specific channelId guard: the dashboard ships the channel where
+    // the bot will post by default; without it the plugin spins up but cannot
+    // resolve a default channel, and on the main Marveen agent the missing
+    // value would still trigger hardRestartMarveenChannels and bounce the
+    // live session for no useful reason. Reject before any state write.
+    if (provider === 'discord') {
+      const cidCheck = validateDiscordChannelId(channelId)
+      if (!cidCheck.ok) { json(res, { error: cidCheck.error }, 400); return true }
+    }
 
     const channelProvider = getProvider(provider)
     const validation = await channelProvider.validateToken(botToken.trim())


### PR DESCRIPTION
Fast-follow to #202 — validates the Discord channelId before any state write or restart, so a typo or missing value in the dashboard cannot bounce the live Marveen session on top of an unusable channel-state file.

## What changes

- New `validateDiscordChannelId()` helper in `src/web/routes/agents.ts` — exported so it's unit-testable. Rejects undefined, empty, whitespace-only, alphanumeric, dashed, signed, too-short (<17), and too-long (>20) values. Accepts base-10 snowflakes of 17-20 digits with surrounding whitespace trimmed.
- POST `/api/agents/<name>/channels/discord`: the new helper runs **before** `channelProvider.validateToken` and the subsequent `hardRestartMarveenChannels()`, so a bad channelId 400s without ever touching disk or restarting the daemon.
- 12 unit tests in `src/__tests__/validate-discord-channel-id.test.ts` covering accept and reject paths.

The botToken side was already validated via `channelProvider.validateToken` in #202; this PR is the missing half on the input.

## Verification

```
$ npx tsc --noEmit       # clean
$ npm test -- src/__tests__/validate-discord-channel-id.test.ts
Test Files  1 passed (1)
     Tests  12 passed (12)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)