### PR TITLE
fix(telegram): prevent sub-agents from stealing the Telegram poller + heartbeat answers direct messages

### DIFF
--- a/scheduled-tasks/memoria-heartbeat/SKILL.md
+++ b/scheduled-tasks/memoria-heartbeat/SKILL.md
@@ -3,6 +3,12 @@ name: memoria-heartbeat
 description: 30 percenként átnézi a beszélgetést, menti a fontosat, és skill-eket generál ha volt komplex munka
 ---
 
+## 0. ELŐSZÖR: Van-e várakozó Telegram üzenet?
+
+**Mielőtt bármit csinálnál**, nézd meg a session inputját: ha van `← telegram ·` prefixű üzenet a kontextusban (azaz Gábor küldött valamit Telegramon), **azonnal válaszolj rá** -- a heartbeat logika (A/B/C, csendben maradás) NEM vonatkozik a közvetlen felhasználói üzenetekre. Válasz után folytasd a heartbeat-et.
+
+---
+
 Nézd át az utolsó 30 perc beszélgetéseidet. Két dolgot csinálj:
 
 ## 1. Memória mentés
@@ -63,7 +69,9 @@ Lépések:
 
 ## 3. Csendben maradás
 
-Ha NINCS komplex feladat / hiba / korrekció (A=B=C=NEM), és nincs új információ a 30 percben:
+**KIVÉTEL: Ha Gábor Telegram üzenetet küldött (← telegram · prefix), arra mindig válaszolj -- a csendes heartbeat szabály NEM vonatkozik rá.**
+
+Ha NINCS komplex feladat / hiba / korrekció (A=B=C=NEM), ÉS nincs várakozó Telegram üzenet, ÉS nincs új információ a 30 percben:
 - Ne ments memóriát feleslegesen
 - Ne generálj skill-t
 - Ne küldj üzenetet a csatornára

--- a/scheduled-tasks/memoria-heartbeat/SKILL.md
+++ b/scheduled-tasks/memoria-heartbeat/SKILL.md
@@ -5,7 +5,7 @@ description: 30 percenként átnézi a beszélgetést, menti a fontosat, és ski
 
 ## 0. ELŐSZÖR: Van-e várakozó Telegram üzenet?
 
-**Mielőtt bármit csinálnál**, nézd meg a session inputját: ha van `← telegram ·` prefixű üzenet a kontextusban (azaz Gábor küldött valamit Telegramon), **azonnal válaszolj rá** -- a heartbeat logika (A/B/C, csendben maradás) NEM vonatkozik a közvetlen felhasználói üzenetekre. Válasz után folytasd a heartbeat-et.
+**Mielőtt bármit csinálnál**, nézd meg a session inputját: ha van `<channel source=` kezdetű blokk a kontextusban (azaz a felhasználó küldött valamit egy csatornán -- Telegram, Slack, stb.), **azonnal válaszolj rá** -- a heartbeat logika (A/B/C, csendben maradás) NEM vonatkozik a közvetlen felhasználói üzenetekre. Válasz után folytasd a heartbeat-et.
 
 ---
 
@@ -69,7 +69,7 @@ Lépések:
 
 ## 3. Csendben maradás
 
-**KIVÉTEL: Ha Gábor Telegram üzenetet küldött (← telegram · prefix), arra mindig válaszolj -- a csendes heartbeat szabály NEM vonatkozik rá.**
+**KIVÉTEL: Ha a felhasználó üzenetet küldött egy csatornán (`<channel source=` kezdetű blokk a kontextusban), arra mindig válaszolj -- a csendes heartbeat szabály NEM vonatkozik rá.**
 
 Ha NINCS komplex feladat / hiba / korrekció (A=B=C=NEM), ÉS nincs várakozó Telegram üzenet, ÉS nincs új információ a 30 percben:
 - Ne ments memóriát feleslegesen


### PR DESCRIPTION
## What

Two fleet-level Telegram fixes for multi-agent setups sharing the official Telegram plugin.

### 1. Prevent sentinel (and any sub-agent) from stealing the Telegram poller
A sub-agent loading the Telegram plugin via the global `enabledPlugins` opens a second `getUpdates` long-poll on the **same bot token** as the main channels session. Two pollers on one token means inbound updates get split between them and roughly half the messages silently vanish.

Fix: enable the Telegram plugin only in the dedicated channels session's `.claude/settings.json`, not globally.

### 2. Heartbeat must always answer direct Telegram messages
The `memoria-heartbeat` skill's "stay silent" logic (skip output when there is no complex task) was also swallowing **direct user messages**. A user could write on Telegram and get no reply.

Fix: add an explicit exception in `scheduled-tasks/memoria-heartbeat/SKILL.md` — if a `← telegram ·` prefixed message is in context, always respond; the silent-heartbeat rule does not apply to direct user messages.

## Why it helps others
Anyone running more than one agent with the official Telegram plugin hits the duplicate-poller problem (lost inbound messages) and the heartbeat-swallow problem. Both are generic, not specific to one deployment.

## Files
- `scheduled-tasks/memoria-heartbeat/SKILL.md`

## Testing
Verified live: after scoping the plugin to the channels session only, the duplicate `getUpdates` poller disappeared and inbound delivery became reliable. The heartbeat now replies to direct Telegram messages instead of staying silent.
