### PR TITLE
feat(dashboard): live agent activity panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "claudeclaw",
+  "name": "marveen",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claudeclaw",
+      "name": "marveen",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",
         "better-sqlite3": "^11.7.0",

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -79,6 +79,8 @@ import {
   capturePane,
 } from '../agent-process.js'
 import { readActiveModelFromProjectDir } from '../active-model.js'
+import { detectPaneState } from '../../pane-state.js'
+import { MAIN_CHANNELS_SESSION } from '../main-agent.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
 import { getChannelHealth } from '../channel-health-monitor.js'
 import {
@@ -376,6 +378,56 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
 
   if (path === '/api/agents' && method === 'GET') {
     json(res, listAgentSummaries())
+    return true
+  }
+
+  // Live activity panel: per-agent "what is it doing right now". Read-only.
+  // Reads each agent's tmux pane (capturePane), classifies it with the same
+  // detector the scheduler uses (detectPaneState), and returns the last few
+  // non-empty lines as a "live tail". Polled by the dashboard every few sec
+  // (no SSE infra in this codebase). Includes the main agent's channels
+  // session so the operator sees the whole fleet, not just sub-agents.
+  if (path === '/api/agents/activity' && method === 'GET') {
+    // PaneState -> coarse label the UI renders as a colored badge.
+    const label = (running: boolean, pane: string | null): string => {
+      if (!running) return 'stopped'
+      if (pane === null) return 'unknown'
+      const s = detectPaneState(pane)
+      if (s === 'busy' || s === 'typing') return 'working'
+      if (s === 'idle') return 'idle'
+      return s // 'unknown' | 'error'
+    }
+    const tailOf = (pane: string | null): string[] =>
+      pane === null
+        ? []
+        : pane
+            .split('\n')
+            .map(l => l.replace(/\s+$/, ''))
+            .filter(l => l.trim().length > 0)
+            .slice(-8)
+
+    const entries: Array<{ name: string; isMain: boolean; running: boolean; state: string; tail: string[] }> = []
+
+    // Main agent (runs in the --channels session, not agent-<name>).
+    {
+      const mainPane = capturePane(MAIN_CHANNELS_SESSION)
+      const running = mainPane !== null
+      entries.push({
+        name: MAIN_AGENT_ID,
+        isMain: true,
+        running,
+        state: label(running, mainPane),
+        tail: tailOf(mainPane),
+      })
+    }
+
+    for (const name of listAgentNames()) {
+      const running = isAgentRunning(name)
+      const pane = running ? capturePane(agentSessionName(name)) : null
+      entries.push({ name, isMain: false, running, state: label(running, pane), tail: tailOf(pane) })
+    }
+
+    json(res, entries)
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -69,6 +69,9 @@ const pages = document.querySelectorAll('.page')
 function switchPage(pageId) {
   pages.forEach((p) => (p.hidden = p.id !== pageId + 'Page'))
   navLinks.forEach((l) => l.classList.toggle('active', l.dataset.page === pageId))
+  // Activity page runs a live poll; stop it whenever we navigate away.
+  if (pageId !== 'activity') stopActivityPoll()
+  if (pageId === 'activity') startActivityPoll()
   if (pageId === 'overview') loadOverview()
   if (pageId === 'kanban') loadKanban()
   if (pageId === 'tasks') loadSchedules()
@@ -93,6 +96,73 @@ navLinks.forEach((link) => {
     switchPage(link.dataset.page)
   })
 })
+
+
+// ============================================================
+// === Activity (live agent status) ===
+// ============================================================
+
+let activityTimer = null
+
+const ACTIVITY_STATE_META = {
+  working: { label: 'dolgozik', cls: 'act-working' },
+  idle: { label: 'várakozik', cls: 'act-idle' },
+  unknown: { label: 'ismeretlen', cls: 'act-unknown' },
+  error: { label: 'hiba', cls: 'act-error' },
+  stopped: { label: 'leállt', cls: 'act-stopped' },
+}
+
+function startActivityPoll() {
+  loadActivity()
+  if (activityTimer) clearInterval(activityTimer)
+  activityTimer = setInterval(loadActivity, 3000)
+}
+
+function stopActivityPoll() {
+  if (activityTimer) {
+    clearInterval(activityTimer)
+    activityTimer = null
+  }
+}
+
+async function loadActivity() {
+  try {
+    const res = await fetch('/api/agents/activity')
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const entries = await res.json()
+    renderActivity(entries)
+    const upd = document.getElementById('activityUpdated')
+    if (upd) upd.textContent = 'Frissítve: ' + new Date().toLocaleTimeString('hu-HU')
+  } catch (e) {
+    const list = document.getElementById('activityList')
+    if (list) list.innerHTML = '<p class="activity-empty">Nem sikerült lekérni az aktivitást: ' + escapeHtml(String(e.message || e)) + '</p>'
+  }
+}
+
+function renderActivity(entries) {
+  const list = document.getElementById('activityList')
+  if (!list) return
+  if (!Array.isArray(entries) || entries.length === 0) {
+    list.innerHTML = '<p class="activity-empty">Nincs ügynök.</p>'
+    return
+  }
+  list.innerHTML = entries.map((a) => {
+    const meta = ACTIVITY_STATE_META[a.state] || ACTIVITY_STATE_META.unknown
+    const tail = (a.tail || []).map((l) => escapeHtml(l)).join('\n')
+    const mainBadge = a.isMain ? '<span class="act-main-badge">fő</span>' : ''
+    return (
+      '<div class="activity-card ' + meta.cls + '">' +
+        '<div class="activity-card-head">' +
+          '<span class="activity-name">' + escapeHtml(a.name) + mainBadge + '</span>' +
+          '<span class="activity-badge ' + meta.cls + '">' + meta.label + '</span>' +
+        '</div>' +
+        (tail
+          ? '<pre class="activity-tail">' + tail + '</pre>'
+          : '<p class="activity-tail-empty">' + (a.running ? 'nincs friss kimenet' : 'a session nem fut') + '</p>') +
+      '</div>'
+    )
+  }).join('')
+}
 
 
 // ============================================================

--- a/web/index.html
+++ b/web/index.html
@@ -28,6 +28,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
         <span class="sb-label">Ügynökök</span>
       </a>
+      <a href="#" class="sb-link" data-page="activity">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14"/></svg>
+        <span class="sb-label">Aktivitás</span>
+      </a>
       <a href="#" class="sb-link" data-page="team">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="3"/><path d="M12 8v4"/><circle cx="5" cy="18" r="3"/><circle cx="19" cy="18" r="3"/><path d="M12 12l-7 6M12 12l7 6"/></svg>
         <span class="sb-label">Csapat</span>
@@ -198,6 +202,22 @@
           </div>
           <span>Új ügynök</span>
         </button>
+      </div>
+    </div>
+
+    <!-- === Activity (live agent status) Page === -->
+    <div class="page" id="activityPage" hidden>
+      <div class="page-header">
+        <div class="page-header-row">
+          <div>
+            <h1>Aktivitás</h1>
+            <p class="subtitle">Mit csinál épp minden ügynök — élő nézet, 3 mp-enként frissül</p>
+          </div>
+          <div class="activity-meta"><span id="activityUpdated" class="activity-updated"></span></div>
+        </div>
+      </div>
+      <div class="activity-list" id="activityList">
+        <p class="activity-empty">Betöltés…</p>
       </div>
     </div>
 

--- a/web/style.css
+++ b/web/style.css
@@ -4894,3 +4894,40 @@ main {
   .auth-mode-cards { gap: 6px; }
   .auth-mode-card { padding: 10px 12px; gap: 10px; }
 }
+
+/* === Activity (live agent status) === */
+.activity-meta { display: flex; align-items: center; }
+.activity-updated { font-size: 12px; color: var(--text-muted); }
+.activity-list { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; }
+.activity-empty { color: var(--text-muted); font-size: 14px; }
+.activity-card {
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+  padding: 14px 16px;
+}
+.activity-card.act-working { border-left-color: #22c55e; }
+.activity-card.act-idle    { border-left-color: #9ca3af; }
+.activity-card.act-error   { border-left-color: #ef4444; }
+.activity-card.act-unknown { border-left-color: #eab308; }
+.activity-card.act-stopped { border-left-color: #6b7280; opacity: 0.7; }
+.activity-card-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.activity-name { font-weight: 600; font-size: 15px; display: flex; align-items: center; gap: 8px; }
+.act-main-badge {
+  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  background: var(--border); color: var(--text-muted); border-radius: 4px; padding: 1px 6px;
+}
+.activity-badge { font-size: 12px; font-weight: 600; border-radius: 999px; padding: 2px 10px; }
+.activity-badge.act-working { background: rgba(34,197,94,0.15); color: #16a34a; }
+.activity-badge.act-idle    { background: rgba(156,163,175,0.18); color: #6b7280; }
+.activity-badge.act-error   { background: rgba(239,68,68,0.15); color: #dc2626; }
+.activity-badge.act-unknown { background: rgba(234,179,8,0.18); color: #ca8a04; }
+.activity-badge.act-stopped { background: rgba(107,114,128,0.15); color: #6b7280; }
+.activity-tail {
+  margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px;
+  line-height: 1.45; color: var(--text-muted); white-space: pre-wrap; word-break: break-word;
+  max-height: 160px; overflow: auto; background: var(--bg-subtle, rgba(127,127,127,0.06));
+  border-radius: 6px; padding: 8px 10px;
+}
+.activity-tail-empty { margin: 0; font-size: 12px; color: var(--text-muted); font-style: italic; }


### PR DESCRIPTION
Read-only live view of fleet activity — what each agent is doing right now (working/idle/waiting) + last lines of its Claude pane. Zsolt-requested MVP.

## What
- New endpoint `GET /api/agents/activity`: for the main agent + each sub-agent, reads the tmux pane (capturePane) and classifies it with detectPaneState (busy/typing->working, idle->idle, unknown/error), returns last ~8 non-empty tail lines.
- New dashboard page 'Aktivitás' (nav link + page): polls the endpoint every 3s, renders per-agent cards with a colored state badge + live pane tail. Poll stops on navigation away.
- CSS for the activity cards/badges/tail.

## Notes
- Read-only monitor (no control), additive (new route + new UI page), no schema changes.
- tsc clean. Live-verified: endpoint returns correct shape, shows jarvis/devy/disy states + tails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)