### PR TITLE
fix(install-windows): UTF-8 BOM + CRLF for PowerShell 5.1 compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Force PowerShell scripts to keep CRLF line endings + UTF-8 BOM on checkout.
+# Windows PowerShell 5.1 fails to parse here-strings (@"..."@) and Hungarian
+# UTF-8 characters in .ps1 files that have LF-only line endings or no BOM.
+*.ps1 text eol=crlf working-tree-encoding=UTF-8
+
+# Other shell scripts stay LF — they run on bash.
+*.sh   text eol=lf
+*.bash text eol=lf

--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -1,4 +1,4 @@
-# Marveen - Windows telepítő (WSL alapú)
+﻿# Marveen - Windows telepítő (WSL alapú)
 # Futtatás: PowerShell-ben: .\install-windows.ps1
 
 Write-Host ""


### PR DESCRIPTION
## Summary

Fixes the first half of #212 — `install-windows.ps1` does not run on a stock Windows 11 + PowerShell 5.1 setup. The script silently exits with parse errors that point at bash tokens (`&&`, `<<`, `VAR=value`) inside the `wsl bash -c @"..."@` here-strings.

## Root cause

The file was checked in as UTF-8 **without** a BOM and with **LF-only** line endings. Windows PowerShell 5.1:

1. **Encoding** — without a BOM, Windows PS 5.1 reads `.ps1` files using the system ANSI code page (cp1250 / cp1252 on a Hungarian host). The Hungarian characters in our comments (`telepítő`, `függőségek`, ô, í, etc.) become garbled multi-byte sequences in the lexer.
2. **Line endings** — Windows PS 5.1 expects CRLF for here-string boundary detection. With LF-only files the parser does not see `"@` at the start of a new line, so the here-string body is parsed as PowerShell code and the embedded bash tokens fail.

PowerShell 7+ accepts UTF-8-no-BOM and LF, which is why the script works for developers on PS 7 but not for users on a fresh Windows 11 install (PS 5.1 is what `powershell.exe` still resolves to).

## What changes

- `install-windows.ps1` — UTF-8 BOM prepended; line endings converted to CRLF. No logic changes; the bash inside the `@"..."@` blocks is unchanged byte-for-byte (after re-encoding).
- New `.gitattributes` — locks `*.ps1` to CRLF + UTF-8 on every checkout regardless of `core.autocrlf`, and locks `*.sh` / `*.bash` to LF so the existing bash scripts are untouched.

## Test plan

- [ ] On Windows 11 + PowerShell 5.1: `.\install-windows.ps1` should now parse and reach the first `Read-Host` prompt instead of dying silently
- [ ] On Windows 11 + PowerShell 7: still works (PS 7 already handled both encodings)
- [ ] On macOS / Linux: `bash install.sh` and `./install-linux.sh` untouched (`.gitattributes` keeps them LF)

## Refs

Refs #212 (PowerShell parse error half). The Telegram-poller half (`getUpdates` not running, pending_update_count rising) is a separate fix-PR coming next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)