### PR TITLE
feat(hooks): channel-reply-guard — catch missing channel replies

### DIFF
--- a/docs/channel-reply-guard.md
+++ b/docs/channel-reply-guard.md
@@ -1,0 +1,61 @@
+# channel-reply-guard — Stop hook
+
+## Problem
+
+A Marveen agent that talks to a user over a channel (Telegram / Slack / Discord)
+sometimes *generates* its reply as plain text but forgets to call the channel
+send-tool. When that happens the answer only lands in the CLI transcript and
+**never reaches the user** — the user is left waiting, with no idea whether the
+agent is working or stuck.
+
+## What the hook does
+
+`scripts/channel-reply-guard.sh` runs on the `Stop` event. At the end of every
+turn it checks:
+
+1. Did the **last user message come from a channel**? (It looks for the
+   `<channel source="plugin:telegram...">` / `← telegram` markers.)
+2. If so, was there a **channel send-tool call** after that message?
+   (Any tool whose name contains `telegram`, `reply`, `slack`, or `discord`.)
+
+If the message was from a channel but **no send-tool was called**, the hook
+returns `{"decision":"block"}` with a reminder, so the model sends the reply
+before the turn ends.
+
+Heartbeat / scheduled-task prompts (where staying silent is correct) are
+explicitly skipped — they may end without a send.
+
+## How to enable it
+
+Add it to the `Stop` hooks in your `.claude/settings.json` (alongside any
+existing Stop hooks):
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/channel-reply-guard.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+(Use an absolute path if `${CLAUDE_PROJECT_DIR}` is not available in your setup.)
+
+After editing `settings.json`, open the `/hooks` menu once (or restart the
+session) so the hook is picked up.
+
+## Relation to #210
+
+PR #210 stops sub-agents from stealing the Telegram poller and lets heartbeats
+answer direct messages — it protects the *inbound* path. This hook protects the
+*outbound* path: it guarantees the agent's reply actually leaves through the
+channel. The two are complementary.

--- a/scripts/channel-reply-guard.sh
+++ b/scripts/channel-reply-guard.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# channel-reply-guard — Stop hook
+#
+# When the last user message came from a channel (Telegram/Slack/Discord) but the
+# turn ended WITHOUT a channel send-tool call, this hook blocks the stop and asks
+# the model to actually send the reply — instead of only generating it as text
+# into the CLI transcript, where the user never sees it.
+#
+# Reads the Stop event's stdin JSON for transcript_path, inspects the last user
+# message and the assistant tool calls produced after it.
+
+INPUT=$(cat)
+
+python3 - "$INPUT" << 'PYEOF'
+import json, sys, os
+
+try:
+    data = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(0)  # unparseable input -> do not block
+
+transcript = data.get("transcript_path", "")
+if not transcript or not os.path.exists(transcript):
+    sys.exit(0)
+
+# Tool-name fragments that mean an actual channel send
+SEND_TOOLS = ("telegram", "reply", "slack", "discord")
+
+try:
+    lines = open(transcript, encoding="utf-8").read().splitlines()
+except Exception:
+    sys.exit(0)
+
+# Walk events; remember the index of the last user message.
+events = []
+last_user_idx = None
+for ln in lines:
+    if not ln.strip():
+        continue
+    try:
+        ev = json.loads(ln)
+    except Exception:
+        continue
+    events.append(ev)
+    role = ev.get("message", {}).get("role") or ev.get("role")
+    if role == "user":
+        last_user_idx = len(events) - 1
+
+if last_user_idx is None:
+    sys.exit(0)
+
+def text_of(ev):
+    msg = ev.get("message", ev)
+    c = msg.get("content", "")
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        return " ".join(p.get("text", "") if isinstance(p, dict) else str(p) for p in c)
+    return str(c)
+
+user_text = text_of(events[last_user_idx])
+is_channel = (
+    'source="plugin:telegram' in user_text
+    or '<channel source=' in user_text
+    or '← telegram' in user_text  # "← telegram"
+)
+if not is_channel:
+    sys.exit(0)  # not a channel message -> nothing to enforce
+
+# Heartbeat / scheduled-task prompts may legitimately stay silent.
+if (
+    'scheduled-task:' in user_text
+    or '[Heartbeat:' in user_text
+    or 'untrusted source="scheduled-task' in user_text
+):
+    sys.exit(0)
+
+# Was there a channel send-tool call after the last user message?
+sent = False
+for ev in events[last_user_idx + 1:]:
+    msg = ev.get("message", ev)
+    content = msg.get("content", [])
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "tool_use":
+                name = (part.get("name") or "").lower()
+                if any(t in name for t in SEND_TOOLS):
+                    sent = True
+                    break
+    if sent:
+        break
+
+if sent:
+    sys.exit(0)
+
+# No channel send -> block and remind the model.
+print(json.dumps({
+    "decision": "block",
+    "reason": (
+        "The user's last message arrived from a channel (Telegram/Slack/Discord), "
+        "but this turn did NOT call the channel send-tool (e.g. the telegram reply "
+        "tool). Your text answer only went into the CLI transcript and never reached "
+        "the user. Send the reply NOW via the channel send-tool (use the chat_id from "
+        "the inbound <channel> tag)."
+    )
+}))
+sys.exit(0)
+PYEOF


### PR DESCRIPTION
## Problem

A Marveen agent that talks to a user over a channel (Telegram/Slack/Discord) sometimes *generates* its reply as plain text but forgets to call the channel send-tool. When that happens the answer only lands in the CLI transcript and **never reaches the user** — the user waits with no idea whether the agent is working or stuck.

## What this adds

`scripts/channel-reply-guard.sh` — a `Stop` hook that, at the end of every turn:
1. Checks whether the **last user message came from a channel** (`<channel source="plugin:telegram...">` / `← telegram` markers).
2. If so, checks whether a **channel send-tool was called** afterwards (any tool whose name contains `telegram`, `reply`, `slack`, `discord`).

If the message was from a channel but no send-tool fired, the hook returns `{"decision":"block"}` with a reminder, so the model sends the reply before the turn ends. Heartbeat / scheduled-task prompts (where silence is correct) are skipped.

`docs/channel-reply-guard.md` documents the problem and how to wire it into `.claude/settings.json`.

## Relation to #210

#210 protects the **inbound** path (sub-agents stealing the poller, heartbeats answering DMs). This protects the **outbound** path — guaranteeing the reply actually leaves through the channel. Complementary.

## Testing

Verified on three synthetic transcripts: channel message without send → blocks; channel message with send → passes; heartbeat/scheduled-task prompt → passes (stays silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)