### PR TITLE
fix(dashboard): show agent display names instead of internal ids in kanban assignee UI

### DIFF
--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -6,7 +6,7 @@ import {
   getKanbanCard, getChildCards, getDb,
 } from '../../db.js'
 import { OWNER_NAME, BOT_NAME } from '../../config.js'
-import { listAgentNames } from '../agent-config.js'
+import { listAgentNames, readAgentDisplayName } from '../agent-config.js'
 import { generateBreakdown } from '../llm-breakdown.js'
 import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
@@ -26,7 +26,7 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   }
 
   if (path === '/api/kanban/assignees' && method === 'GET') {
-    const agents = listAgentNames().map((name) => ({ name, type: 'agent' }))
+    const agents = listAgentNames().map((name) => ({ name, type: 'agent', displayName: readAgentDisplayName(name) || name }))
     json(res, [
       { name: OWNER_NAME, type: 'owner' },
       { name: BOT_NAME, type: 'bot' },

--- a/web/app.js
+++ b/web/app.js
@@ -231,7 +231,7 @@ function createCardEl(card) {
 
   const assignee = card.assignee ? kanbanAssignees.find((a) => a.name === card.assignee) : null
   const assigneeHtml = assignee
-    ? `<span class="kanban-card-assignee"><span class="assignee-dot ${assignee.type}">${assignee.name[0]}</span>${escapeHtml(assignee.name)}</span>`
+    ? `<span class="kanban-card-assignee"><span class="assignee-dot ${assignee.type}">${(assignee.displayName || assignee.name)[0]}</span>${escapeHtml(assignee.displayName || assignee.name)}</span>`
     : ''
 
   let dueHtml = ''
@@ -361,7 +361,7 @@ function populateAssigneeSelect(selectId, selected) {
   for (const a of kanbanAssignees) {
     const opt = document.createElement('option')
     opt.value = a.name
-    opt.textContent = a.name
+    opt.textContent = a.displayName || a.name
     if (selected && a.name === selected) opt.selected = true
     sel.appendChild(opt)
   }
@@ -425,7 +425,7 @@ async function showCardDetail(card) {
     </div>
     <div class="meta-item">
       <span class="meta-label">Felelős</span>
-      <span class="meta-value meta-value-editable" id="metaAssigneeValue" data-card-id="${card.id}" title="Kattints a módosításhoz">${assignee ? escapeHtml(assignee.name) : '-- nincs --'}</span>
+      <span class="meta-value meta-value-editable" id="metaAssigneeValue" data-card-id="${card.id}" title="Kattints a módosításhoz">${assignee ? escapeHtml(assignee.displayName || assignee.name) : '-- nincs --'}</span>
     </div>
     <div class="meta-item">
       <span class="meta-label">Prioritás</span>
@@ -452,7 +452,7 @@ async function showCardDetail(card) {
     for (const a of kanbanAssignees) {
       const opt = document.createElement('option')
       opt.value = a.name
-      opt.textContent = a.name
+      opt.textContent = a.displayName || a.name
       if (a.name === current) opt.selected = true
       sel.appendChild(opt)
     }
@@ -644,7 +644,7 @@ function showBreakdownModal(subtasks, parentCard) {
 
   const priorityLabels = { low: 'Alacsony', normal: 'Normál', high: 'Magas', urgent: 'Sürgős' }
   const assigneeOptions = kanbanAssignees
-    .map((a) => `<option value="${escapeHtml(a.name)}">${escapeHtml(a.name)}</option>`)
+    .map((a) => `<option value="${escapeHtml(a.name)}">${escapeHtml(a.displayName || a.name)}</option>`)
     .join('')
 
   subtasks.forEach((st, i) => {


### PR DESCRIPTION
## Context

The dashboard agent cards already render each agent's persona `displayName`, but the kanban assignee UI (card labels, the create/edit assignee dropdowns, and the AI-breakdown subtask options) rendered the raw sanitized agent id (e.g. `virgil`, `borbas`, `domotor`) instead. The naming was therefore inconsistent across the dashboard.

Root cause: `/api/kanban/assignees` returned only `{ name, type }` per agent, so `displayName` was never available to the frontend in those views.

## Changes

- `src/web/routes/kanban.ts`: include `displayName` (via `readAgentDisplayName(name) || name`) in the `/api/kanban/assignees` agent entries.
- `web/app.js`: render `displayName || name` in the kanban assignee card label, both assignee `<select>` dropdowns, the inline meta editor, and the breakdown subtask options.

The stored value/key remains the agent id, so existing card assignments and lookups (`a.name === card.assignee`) are unaffected.

## Testing

- `tsc --noEmit` passes.
- Owner/bot entries (no `displayName`) fall back to `name` via `displayName || name`.
- No data migration needed: `card.assignee` still stores and matches by agent id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)