### PR TITLE
fix: channel-path Enter auto-recovery + robust scheduler pending-retry alert

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -7,6 +7,8 @@ import {
   shouldClearTruncatedPreamble,
   decideSubmitFollowup,
   decidePaneErrorAlert,
+  stuckInputSignature,
+  decideStuckInputRecovery,
 } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
@@ -1128,5 +1130,111 @@ describe('decidePaneErrorAlert', () => {
     expect(skewed.alert).toBe(false)
     expect(skewed.next.firstSeenAt).toBe(500_000)
     expect(skewed.next.lastAlertAt).toBe(null)
+  })
+})
+
+describe('stuckInputSignature', () => {
+  it('returns a normalised signature for parked input', () => {
+    const sig = stuckInputSignature(TYPING_PARKED)
+    expect(sig).not.toBeNull()
+    expect(sig).toContain('Valami amit a felhasznalo elkezdett geppelni')
+    // Whitespace collapsed so a re-flow / cursor blink does not look new.
+    expect(sig).not.toMatch(/\s{2,}/)
+  })
+
+  it('is null for an idle empty input box', () => {
+    expect(stuckInputSignature(IDLE_BYPASS)).toBeNull()
+  })
+
+  it('is null for a busy pane', () => {
+    expect(stuckInputSignature(BUSY_FULL_FOOTER)).toBeNull()
+  })
+
+  it('is null for a paste placeholder (treated as busy, not parked text)', () => {
+    expect(stuckInputSignature(PENDING_PASTE)).toBeNull()
+  })
+
+  it('ignores a ❯ caret left in scrollback', () => {
+    expect(stuckInputSignature(IDLE_WITH_SCROLLBACK_CARET)).toBeNull()
+  })
+})
+
+describe('decideStuckInputRecovery', () => {
+  const TH = { confirmMs: 10_000, dedupMs: 12_000, maxAttempts: 3 }
+  const NONE = { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
+
+  it('does nothing when nothing is parked and no spell is active', () => {
+    const d = decideStuckInputRecovery(null, NONE, 5_000, TH)
+    expect(d.recover).toBe(false)
+    expect(d.next).toEqual(NONE)
+  })
+
+  it('records the first sighting without recovering (confirm window)', () => {
+    const d = decideStuckInputRecovery('msg-A', NONE, 10_000, TH)
+    expect(d.recover).toBe(false)
+    expect(d.next).toEqual({ parkedSig: 'msg-A', firstSeenAt: 10_000, lastRecoverAt: null, attempts: 0 })
+  })
+
+  it('does not recover while still inside the confirm window', () => {
+    const prev = { parkedSig: 'msg-A', firstSeenAt: 0, lastRecoverAt: null, attempts: 0 }
+    const d = decideStuckInputRecovery('msg-A', prev, 9_000, TH)
+    expect(d.recover).toBe(false)
+    expect(d.next.firstSeenAt).toBe(0)
+  })
+
+  it('recovers once the same text persists past the confirm window', () => {
+    const prev = { parkedSig: 'msg-A', firstSeenAt: 0, lastRecoverAt: null, attempts: 0 }
+    const d = decideStuckInputRecovery('msg-A', prev, 10_000, TH)
+    expect(d.recover).toBe(true)
+    expect(d.next.attempts).toBe(1)
+    expect(d.next.lastRecoverAt).toBe(10_000)
+    expect(d.next.firstSeenAt).toBe(0)
+  })
+
+  it('restarts the confirm window when the parked text changes', () => {
+    // A new/different message arriving (or text still being composed)
+    // must not inherit the prior spell's elapsed time.
+    const prev = { parkedSig: 'msg-A', firstSeenAt: 0, lastRecoverAt: null, attempts: 0 }
+    const d = decideStuckInputRecovery('msg-B', prev, 9_000, TH)
+    expect(d.recover).toBe(false)
+    expect(d.next).toEqual({ parkedSig: 'msg-B', firstSeenAt: 9_000, lastRecoverAt: null, attempts: 0 })
+  })
+
+  it('suppresses a repeat recovery inside the dedup window', () => {
+    const prev = { parkedSig: 'msg-A', firstSeenAt: 0, lastRecoverAt: 10_000, attempts: 1 }
+    const d = decideStuckInputRecovery('msg-A', prev, 18_000, TH) // 8s < 12s dedup
+    expect(d.recover).toBe(false)
+    expect(d.next.attempts).toBe(1)
+  })
+
+  it('recovers again once the dedup window elapses', () => {
+    const prev = { parkedSig: 'msg-A', firstSeenAt: 0, lastRecoverAt: 10_000, attempts: 1 }
+    const d = decideStuckInputRecovery('msg-A', prev, 22_000, TH) // 12s >= dedup
+    expect(d.recover).toBe(true)
+    expect(d.next.attempts).toBe(2)
+    expect(d.next.lastRecoverAt).toBe(22_000)
+  })
+
+  it('gives up after maxAttempts without further recoveries', () => {
+    const prev = { parkedSig: 'msg-A', firstSeenAt: 0, lastRecoverAt: 40_000, attempts: 3 }
+    const d = decideStuckInputRecovery('msg-A', prev, 60_000, TH)
+    expect(d.recover).toBe(false)
+    expect(d.next.attempts).toBe(3)
+  })
+
+  it('clears the spell when the input box empties', () => {
+    const prev = { parkedSig: 'msg-A', firstSeenAt: 0, lastRecoverAt: 10_000, attempts: 1 }
+    const d = decideStuckInputRecovery(null, prev, 30_000, TH)
+    expect(d.recover).toBe(false)
+    expect(d.next).toEqual(NONE)
+  })
+
+  it('does not stall on backwards clock skew (future timestamp)', () => {
+    const prev = { parkedSig: 'msg-A', firstSeenAt: 1_000_000, lastRecoverAt: 1_000_000, attempts: 1 }
+    const d = decideStuckInputRecovery('msg-A', prev, 500_000, TH)
+    expect(d.recover).toBe(false)
+    expect(d.next.firstSeenAt).toBe(500_000)
+    expect(d.next.lastRecoverAt).toBe(null)
+    expect(d.next.attempts).toBe(0)
   })
 })

--- a/src/__tests__/pending-retries.test.ts
+++ b/src/__tests__/pending-retries.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   shouldSendAlert,
   toPendingRetryView,
+  classifyTelegramSendError,
   ALERT_THRESHOLD_MS,
 } from '../pending-retries.js'
 
@@ -101,5 +102,31 @@ describe('toPendingRetryView', () => {
     expect(view.alertDue).toBe(true)
     const viewUnder = toPendingRetryView(baseRow, 1_000_100, 200)
     expect(viewUnder.alertDue).toBe(false)
+  })
+})
+
+describe('classifyTelegramSendError', () => {
+  it('treats a bare network error (no HTTP status) as transient', () => {
+    expect(classifyTelegramSendError('fetch failed')).toBe('transient')
+    expect(classifyTelegramSendError('TypeError: fetch failed')).toBe('transient')
+  })
+
+  it('treats 429 (rate limited) as transient', () => {
+    expect(classifyTelegramSendError('Telegram API 429: Too Many Requests')).toBe('transient')
+  })
+
+  it('treats 5xx as transient', () => {
+    expect(classifyTelegramSendError('Telegram API 500: Internal Server Error')).toBe('transient')
+    expect(classifyTelegramSendError('Telegram API 502: Bad Gateway')).toBe('transient')
+  })
+
+  it('treats 400 (bad chat_id) as permanent', () => {
+    expect(classifyTelegramSendError('Telegram API 400: Bad Request: chat not found')).toBe('permanent')
+  })
+
+  it('treats 401/403/404 (bad or blocked token) as permanent', () => {
+    expect(classifyTelegramSendError('Telegram API 401: Unauthorized')).toBe('permanent')
+    expect(classifyTelegramSendError('Telegram API 403: Forbidden: bot was blocked by the user')).toBe('permanent')
+    expect(classifyTelegramSendError('Telegram API 404: Not Found')).toBe('permanent')
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -570,3 +570,127 @@ export function decidePaneErrorAlert(
   }
   return { alert: false, next: { firstSeenAt: prev.firstSeenAt, lastAlertAt: prev.lastAlertAt, lastErrorAt: now } }
 }
+
+// A stable signature of the text parked in the live input box, or null
+// when the pane is not in the 'typing' (parked-input) state.
+//
+// Used by the stuck-input watcher to decide whether a swallowed Enter on
+// the channel-notification path left a message stranded in the prompt
+// box. Whitespace is collapsed so a cursor blink or a terminal re-flow at
+// a different width does not read as "new text" and reset the recovery
+// confirm window. Returns null (not an empty string) when there is no
+// parked text so callers can branch on "is anything parked at all".
+export function stuckInputSignature(pane: string): string | null {
+  if (detectPaneState(pane) !== 'typing') return null
+  const box = liveInputBox(pane)
+  if (box == null) return null
+  const sig = box.replace(/\s+/g, ' ').trim()
+  return sig.length > 0 ? sig : null
+}
+
+// Per-session bookkeeping for the stuck-input recovery watcher. A "spell"
+// is one continuous stretch of the SAME text parked in the input box.
+export interface StuckInputState {
+  /** Signature of the parked text for the active spell, or null when no
+   * spell is active (the box is empty / the pane is busy). */
+  parkedSig: string | null
+  /** When the active spell was first observed. */
+  firstSeenAt: number | null
+  /** When the last recovery Enter was sent in this spell, or null. */
+  lastRecoverAt: number | null
+  /** How many recovery Enters have been sent in the active spell. */
+  attempts: number
+}
+
+export interface StuckInputThresholds {
+  /** How long the SAME text must stay parked before the first recovery
+   * Enter, so a turn that is about to submit on its own (frame race) is
+   * not pre-empted and a human mid-typing is left alone. */
+  confirmMs: number
+  /** Minimum gap between recovery Enters within one spell, so a pane
+   * that ignores the Enter is not hammered every tick. */
+  dedupMs: number
+  /** Max recovery Enters per spell before giving up (caller logs). A
+   * pane still stuck after this is not the swallowed-Enter case the
+   * watcher targets; further Enters would not help. */
+  maxAttempts: number
+}
+
+export interface StuckInputDecision {
+  recover: boolean
+  next: StuckInputState
+}
+
+const NO_STUCK_INPUT: StuckInputState = {
+  parkedSig: null,
+  firstSeenAt: null,
+  lastRecoverAt: null,
+  attempts: 0,
+}
+
+/**
+ * Pure decision for "should the watcher send a recovery Enter to this
+ * session". Dependency-free so it is unit-testable without tmux or
+ * timers: feed the current parked-input signature (from
+ * stuckInputSignature), the previous persisted state and a clock, get
+ * back whether to send Enter plus the next state to persist.
+ *
+ * The channel-notification path (inbound Telegram/Slack delivered by the
+ * plugin) does not go through sendPromptToSession, so its post-send
+ * Enter-retry budget cannot cover a swallowed Enter there. This watcher
+ * is the backstop: it detects the symptom (text stranded in the prompt
+ * box) and re-submits.
+ *
+ * Guards that keep it from firing on healthy panes:
+ *   - A new or CHANGED parked signature restarts the confirm window
+ *     (record-only), so text that is still arriving / being edited and a
+ *     turn that submits on its own are never pre-empted. With confirmMs
+ *     > 0 this also guarantees at least two observations before any Enter.
+ *   - A confirm window: the same text must persist for confirmMs.
+ *   - A dedup window between Enters, and a maxAttempts cap per spell.
+ *   - Backwards clock skew (a future stored timestamp) restarts the
+ *     spell instead of stalling the deltas negative.
+ *
+ * @param parkedSig   Signature of the parked input now, or null when the
+ *                    pane is not in the parked-input state.
+ * @param prev        Previously persisted state for this session.
+ * @param now         Current clock (ms).
+ * @param thresholds  Confirm / dedup / maxAttempts knobs.
+ */
+export function decideStuckInputRecovery(
+  parkedSig: string | null,
+  prev: StuckInputState,
+  now: number,
+  thresholds: StuckInputThresholds,
+): StuckInputDecision {
+  // Nothing parked: end any active spell.
+  if (parkedSig === null) {
+    return { recover: false, next: { ...NO_STUCK_INPUT } }
+  }
+  // New spell, or the parked text changed (still arriving / edited /
+  // a different message): restart the confirm window, record only.
+  if (prev.parkedSig !== parkedSig || prev.firstSeenAt === null) {
+    return { recover: false, next: { parkedSig, firstSeenAt: now, lastRecoverAt: null, attempts: 0 } }
+  }
+  // Backwards clock skew: a stored timestamp in the future relative to
+  // now would drive the deltas negative and stall. Restart the spell.
+  if (now < prev.firstSeenAt || (prev.lastRecoverAt !== null && now < prev.lastRecoverAt)) {
+    return { recover: false, next: { parkedSig, firstSeenAt: now, lastRecoverAt: null, attempts: 0 } }
+  }
+  // Retry budget spent: hold without acting.
+  if (prev.attempts >= thresholds.maxAttempts) {
+    return { recover: false, next: { ...prev } }
+  }
+  // Confirm window not yet elapsed.
+  if (now - prev.firstSeenAt < thresholds.confirmMs) {
+    return { recover: false, next: { ...prev } }
+  }
+  // Dedup gap between recovery Enters.
+  if (prev.lastRecoverAt !== null && now - prev.lastRecoverAt < thresholds.dedupMs) {
+    return { recover: false, next: { ...prev } }
+  }
+  return {
+    recover: true,
+    next: { parkedSig, firstSeenAt: prev.firstSeenAt, lastRecoverAt: now, attempts: prev.attempts + 1 },
+  }
+}

--- a/src/pending-retries.ts
+++ b/src/pending-retries.ts
@@ -54,6 +54,33 @@ export function shouldSendAlert(
 }
 
 /**
+ * Classify a Telegram send failure as transient (worth retrying) or
+ * permanent (a config / client error that will fail identically every
+ * tick). sendTelegramMessage throws `Error("Telegram API <status>: ...")`
+ * on a non-2xx response and a bare network error (TypeError "fetch
+ * failed") when the request never reaches Telegram.
+ *
+ *   - transient: network failure (no status), HTTP 429 (rate limited),
+ *     or any 5xx. The next 60s tick should retry, so the caller clears
+ *     the per-attempt stamp.
+ *   - permanent: HTTP 4xx other than 429 (400 bad chat_id, 401/404 bad
+ *     token, 403 blocked). Retrying every tick just spams the log with
+ *     the identical failure, so the caller KEEPS the stamp to stop the
+ *     alert from re-firing until the underlying config is fixed.
+ *
+ * Pure (takes the error message string) so it is unit-testable without a
+ * live Telegram endpoint.
+ */
+export function classifyTelegramSendError(errMessage: string): 'transient' | 'permanent' {
+  const m = /Telegram API (\d{3})\b/.exec(errMessage)
+  if (!m) return 'transient' // no HTTP status -> network-level failure
+  const status = Number(m[1])
+  if (status === 429 || status >= 500) return 'transient'
+  if (status >= 400) return 'permanent'
+  return 'transient'
+}
+
+/**
  * Shape of a pending retry used by the UI + the alert layer. A small
  * subset of the DB row, decoupled from the DB type so tests don't need
  * better-sqlite3.

--- a/src/web.ts
+++ b/src/web.ts
@@ -14,6 +14,7 @@ import { startMcpListChecker } from './web/mcp-list.js'
 import { startScheduleRunner } from './web/schedule-runner.js'
 import { startChannelPluginMonitor } from './web/channel-monitor.js'
 import { startChannelHealthMonitor } from './web/channel-health-monitor.js'
+import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
@@ -219,6 +220,9 @@ export function startWebServer(port = 3420): http.Server {
   const channelHealthInterval = startChannelHealthMonitor()
   logger.info('Channel MCP health monitor started (60s poll, 45s offset)')
 
+  const stuckInputInterval = startStuckInputWatcher()
+  logger.info('Stuck-input watcher started (15s poll, 20s offset)')
+
   const updateCheckerInterval = startUpdateChecker()
   logger.info('Update checker started (15min poll)')
 
@@ -265,6 +269,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(scheduleInterval)
     clearInterval(pluginMonitorInterval)
     clearInterval(channelHealthInterval)
+    clearInterval(stuckInputInterval)
     clearInterval(updateCheckerInterval)
     return origClose(cb)
   }

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -429,6 +429,21 @@ export function sendPromptToSession(session: string, text: string): void {
 // spinner lands; a quarter-second settle window is well past that.
 const PANE_READY_CONFIRM_DELAY_S = '0.25'
 
+// Send a bare Enter to a session. Used by the stuck-input watcher to
+// re-submit a prompt whose trailing Enter was swallowed on the channel-
+// notification path (where the plugin, not sendPromptToSession, delivered
+// the text, so the post-send retry budget never ran). Best-effort: a
+// tmux failure is logged and swallowed so the watcher loop keeps going.
+export function sendEnterToSession(session: string): boolean {
+  try {
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+    return true
+  } catch (err) {
+    logger.warn({ err, session }, 'sendEnterToSession: failed to send recovery Enter')
+    return false
+  }
+}
+
 // Capture a pane snapshot with an execSync timeout. Null on any error so
 // the caller can treat "capture failed" as "not ready".
 export function capturePane(session: string): string | null {

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -16,7 +16,7 @@ import {
   markPendingTaskRetryAlert,
   clearPendingTaskRetryAlert,
 } from '../db.js'
-import { toPendingRetryView, type PendingRetryView } from '../pending-retries.js'
+import { toPendingRetryView, classifyTelegramSendError, type PendingRetryView } from '../pending-retries.js'
 import {
   UNTRUSTED_PREAMBLE,
   wrapUntrusted,
@@ -158,6 +158,28 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   const claimed = markPendingTaskRetryAlert(view.taskName, view.agentName, nowMs)
   if (!claimed) return
 
+  // Validate the delivery config BEFORE building/sending. A missing token
+  // or chat_id is a permanent configuration problem -- it will fail
+  // identically on every 60s tick. Earlier this path (token only) cleared
+  // the stamp on failure, so the alert re-fired every minute forever and
+  // spammed the log; and chat_id was never validated at all, so an empty
+  // ALLOWED_CHAT_ID guaranteed a 400 from Telegram on every attempt. Leave
+  // the stamp in place (it acts as the throttle) and log once so the
+  // operator sees the config gap without the spin. The scheduled task
+  // itself keeps retrying regardless -- only this alert is suppressed.
+  const envPath = join(PROJECT_ROOT, '.env')
+  const envContent = readFileOr(envPath, '')
+  const tokenMatch = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)
+  const token = tokenMatch?.[1]?.trim()
+  if (!token) {
+    logger.warn({ task: view.taskName, agent: view.agentName }, 'Pending-retry alert suppressed: no TELEGRAM_BOT_TOKEN (config error, stamp kept to avoid 60s spin)')
+    return
+  }
+  if (!ALLOWED_CHAT_ID.trim()) {
+    logger.warn({ task: view.taskName, agent: view.agentName }, 'Pending-retry alert suppressed: empty ALLOWED_CHAT_ID (config error, stamp kept to avoid 60s spin)')
+    return
+  }
+
   const ageMinutes = Math.floor(view.ageMs / 60000)
   const firstAttempt = new Date(view.firstAttempt).toLocaleString('hu-HU')
   const text = [
@@ -167,23 +189,21 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   ].join('\n')
   ;(async () => {
     try {
-      const envPath = join(PROJECT_ROOT, '.env')
-      const envContent = readFileOr(envPath, '')
-      const tokenMatch = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)
-      const token = tokenMatch?.[1]?.trim()
-      if (!token) {
-        logger.warn({ task: view.taskName, agent: view.agentName }, 'Pending-retry alert skipped: no TELEGRAM_BOT_TOKEN, clearing stamp for retry')
-        clearPendingTaskRetryAlert(view.taskName, view.agentName)
-        return
-      }
       await sendTelegramMessage(token, ALLOWED_CHAT_ID, text)
       logger.info({ task: view.taskName, agent: view.agentName, ageMinutes }, 'Pending-retry Telegram alert sent')
     } catch (err) {
-      // Real send failure (network error, 4xx from Telegram). Clear the
-      // per-attempt stamp so the next tick can legitimately retry --
-      // otherwise a bad token silently wedges the alerting forever.
-      logger.warn({ err, task: view.taskName, agent: view.agentName }, 'Pending-retry alert delivery failed, clearing stamp for retry')
-      clearPendingTaskRetryAlert(view.taskName, view.agentName)
+      // Distinguish a transient failure (network blip, 429, 5xx) from a
+      // permanent one (4xx: bad chat_id / revoked token). Transient ->
+      // clear the per-attempt stamp so the next tick retries. Permanent
+      // -> KEEP the stamp; retrying every 60s would just repeat the same
+      // rejection and spam the log until the config is fixed.
+      const kind = classifyTelegramSendError(err instanceof Error ? err.message : String(err))
+      if (kind === 'transient') {
+        logger.warn({ err, task: view.taskName, agent: view.agentName }, 'Pending-retry alert delivery failed (transient), clearing stamp for retry')
+        clearPendingTaskRetryAlert(view.taskName, view.agentName)
+      } else {
+        logger.warn({ err, task: view.taskName, agent: view.agentName }, 'Pending-retry alert delivery failed (permanent), stamp kept to avoid 60s spin')
+      }
     }
   })()
 }

--- a/src/web/stuck-input-watcher.ts
+++ b/src/web/stuck-input-watcher.ts
@@ -1,0 +1,109 @@
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID } from '../config.js'
+import { listAgentNames } from './agent-config.js'
+import { isAgentRunning, capturePane, sendEnterToSession } from './agent-process.js'
+import { resolveAgentSession } from './channel-mcp-reconnect.js'
+import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import {
+  stuckInputSignature,
+  decideStuckInputRecovery,
+  type StuckInputState,
+  type StuckInputThresholds,
+} from '../pane-state.js'
+
+// Backstop recovery for a swallowed Enter on the channel-notification
+// path. Inbound Telegram/Slack messages are delivered into the session by
+// the channel plugin, NOT by sendPromptToSession, so the post-send
+// Enter-retry budget there cannot cover them. After a long thinking turn
+// the closing Enter is occasionally dropped and the user's message is
+// left parked in the prompt box with no submit. This watcher captures
+// each running agent's pane on a timer, and when the SAME text has been
+// parked past the confirm window it re-sends Enter to submit it.
+//
+// All the decision logic is the pure decideStuckInputRecovery() in
+// pane-state.ts (unit-tested); this module is only the I/O + per-session
+// state map, mirroring channel-health-monitor.ts.
+
+const THRESHOLDS: StuckInputThresholds = {
+  // The same text must stay parked this long before the first recovery
+  // Enter. A real turn transitions typing -> busy within a second or two
+  // of submit, so 10s comfortably clears the frame race while still
+  // recovering a genuinely swallowed Enter quickly.
+  confirmMs: 10_000,
+  // Gap between recovery Enters within one spell.
+  dedupMs: 12_000,
+  // A pane still parked after this many Enters is not the swallowed-Enter
+  // case (e.g. a paste placeholder, which detectPaneState already treats
+  // as busy and so never reaches here anyway); stop and log.
+  maxAttempts: 3,
+}
+
+// Initial delay before the first sweep, and the sweep interval. Offset
+// from channel-monitor (30s) and channel-health-monitor (45s) so the
+// three watchers do not pile their capture-pane calls onto one tick.
+const INITIAL_DELAY_MS = 20_000
+const INTERVAL_MS = 15_000
+
+const NO_STATE: StuckInputState = { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
+
+const watchState = new Map<string, StuckInputState>()
+
+function checkSession(label: string, session: string): void {
+  const pane = capturePane(session)
+  // A failed capture is treated as "nothing parked" -- it ends any active
+  // spell rather than holding stale state across a transient tmux miss.
+  const sig = pane == null ? null : stuckInputSignature(pane)
+
+  const prev = watchState.get(session) ?? NO_STATE
+  const { recover, next } = decideStuckInputRecovery(sig, prev, Date.now(), THRESHOLDS)
+
+  if (next.parkedSig === null) {
+    watchState.delete(session)
+  } else {
+    watchState.set(session, next)
+  }
+
+  if (recover) {
+    logger.info(
+      { label, session, attempt: next.attempts },
+      'stuck-input-watcher: parked input persisted past confirm window, sending recovery Enter',
+    )
+    sendEnterToSession(session)
+  } else if (next.parkedSig !== null && next.attempts >= THRESHOLDS.maxAttempts) {
+    // Logged at most once per spell: the give-up is recorded on the tick
+    // that spent the last attempt (attempts hits maxAttempts there), not
+    // every subsequent tick, because once at the cap recover stays false
+    // and attempts no longer increments.
+    if (prev.attempts < THRESHOLDS.maxAttempts) {
+      logger.warn({ label, session }, 'stuck-input-watcher: input still parked after max recovery Enters, giving up for this spell')
+    }
+  }
+}
+
+export function startStuckInputWatcher(): NodeJS.Timeout {
+  function sweep() {
+    // The main agent's channels session is named `<id>-channels`, not
+    // `agent-<id>`, so isAgentRunning (which checks the agent- prefix)
+    // does not apply. Check it directly; capturePane returns null when it
+    // is not up, which ends any spell without acting.
+    try {
+      checkSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION)
+    } catch (err) {
+      logger.debug({ err }, 'stuck-input-watcher: main agent check error')
+    }
+    for (const name of listAgentNames()) {
+      if (!isAgentRunning(name)) {
+        watchState.delete(resolveAgentSession(name))
+        continue
+      }
+      try {
+        checkSession(name, resolveAgentSession(name))
+      } catch (err) {
+        logger.debug({ err, agent: name }, 'stuck-input-watcher: agent check error')
+      }
+    }
+  }
+
+  setTimeout(sweep, INITIAL_DELAY_MS)
+  return setInterval(sweep, INTERVAL_MS)
+}


### PR DESCRIPTION
Two independent, general-purpose robustness fixes for multi-agent / scheduler setups. Both ship with pure, unit-tested decision logic.

## 1. Auto-recover a swallowed Enter on the channel-notification path
Inbound channel messages (Telegram/Slack) are delivered into the agent's session by the plugin's MCP notification — **not** by `sendPromptToSession` — so the existing post-send Enter-retry budget cannot cover them. After a long thinking turn the closing Enter is occasionally dropped, leaving the user's message parked in the prompt box with no submit; the agent then sits silent.

A new backstop watcher (`stuck-input-watcher.ts`, modelled on `channel-health-monitor.ts`) captures each running agent's pane on a timer and, when the **same** text has stayed parked past a confirm window, re-sends Enter. The decision is a pure function `decideStuckInputRecovery` + `stuckInputSignature` in `pane-state.ts`.

Guards (no firing on healthy panes): a new/changed parked signature restarts the confirm window (text still arriving or a turn about to submit is never pre-empted), a dedup window between Enters, a per-spell attempt cap, and a clock-skew guard.

## 2. Robust pending-retry Telegram alert
`sendPendingRetryAlert` cleared the per-attempt alert stamp on **any** send failure, so a permanent problem (empty `ALLOWED_CHAT_ID`, revoked token, bad chat_id) made the alert re-fire every 60s forever and spam the log, never succeeding. And `ALLOWED_CHAT_ID` was never validated (only the token was), so an empty chat_id guaranteed a 400 on every tick.

- Validate `ALLOWED_CHAT_ID` up front; on a missing token/chat_id, suppress the alert and **keep** the stamp (no spin), logging once. The scheduled task itself keeps retrying regardless.
- On a real send failure, classify it: transient (network / 429 / 5xx) clears the stamp to retry; permanent (4xx) keeps the stamp to stop the spin. `classifyTelegramSendError` is pure + unit-tested.

## Tests
`npm test`: 119 pane-state cases (15 new) + 19 pending-retries cases (6 new) green. `npm run build` + `tsc --noEmit` clean.
