### PR TITLE
feat(backup): cover skills/scheduled-tasks/channel token/launchd + migration runbook

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,183 @@
+# Migration runbook — moving the fleet to a new machine
+
+Goal: move the whole ClaudeClaw / Marveen fleet to a stronger host with **zero
+data loss** and minimal downtime. Read this end to end before starting.
+
+The single most important rule: **ONE BOT = ONE POLLER.** A Telegram/Slack bot
+token may only be long-polled by one running session. Do **not** run the old
+and new machine against the same token at once — the second poller gets HTTP
+409 Conflict and inbound messages are split/lost. Cut over (old off → new on),
+never overlap.
+
+---
+
+## 1. What moves (inventory)
+
+Three independent stores. The tarball (`scripts/backup.sh`) covers (1) and (2);
+the Docker volumes (3) are **separate** and must be moved on their own.
+
+**(1) Repo-relative — under the project root (`repo/` group in the archive)**
+- `store/claudeclaw.db` (+ `-shm`/`-wal`) — kanban, memory, messages, schedules DB
+- `store/.dashboard-token` — dashboard bearer token
+- `.env` — project secrets
+- `scheduled-tasks.json` — legacy, if present
+- `assets/meetings/**` — meeting transcripts/memos
+- `agents/*/CLAUDE.md`, `SOUL.md`, `.mcp.json` — per-agent identity
+- `agents/*/.claude/channels/*/.env`, `access.json` — sub-agent channel tokens + pairing
+
+**(2) Home-relative — under `$HOME` (`home/` group in the archive)**
+- `~/.claude/skills/**` — the self-built skill library
+- `~/.claude/scheduled-tasks/**` — file-based scheduled tasks (SKILL.md + task-config.json)
+- `~/.claude/channels/*/.env` — MAIN orchestrator channel token
+- `~/.claude/channels/*/access.json`, `invites.json`, `approved/**` — pairing allowlist + approvals
+- `~/Library/LaunchAgents/com.gorcsevivan.*.plist` — launchd jobs
+
+**(3) Docker volumes — NOT in the tarball, migrate separately**
+- `stack_influxdb-data`, `stack_influxdb-config` — InfluxDB 2.7 time-series (Loxone history)
+- `stack_grafana-data` — Grafana dashboards/datasources
+- Source: `projects/loxonTSDB/` (compose stack). Volumes are docker-managed and
+  do **not** live in the repo, so a `git clone` + tar restore does NOT bring
+  them. Forgetting this silently loses all historical metrics.
+
+**Not migrated (rebuilt natively, see pitfalls):** `.venv-whisperx`, `.venv-diar`
+(Python venvs with Apple-Silicon-native wheels), `node_modules/`, `dist/`.
+
+---
+
+## 2. On the OLD machine (prepare)
+
+1. Record versions so the new host matches:
+   - `node -v` (currently v22.x), `claude --version` (pinned; auto-update OFF),
+     `docker --version`, `tailscale version`.
+2. Run a fresh backup and verify it:
+   ```bash
+   cd <repo> && bash scripts/backup.sh
+   tar -tzf backups/claudeclaw-*.tar.gz | sed -E 's,(^[^/]+/[^/]+/).*,\1...,' | sort -u
+   ```
+   Confirm both `repo/...` and `home/...` groups and the `MANIFEST.txt` are present.
+3. Export the Docker volumes (time-series + dashboards):
+   ```bash
+   cd <repo>/projects/loxonTSDB && docker compose down   # quiesce writers first
+   for v in stack_influxdb-data stack_influxdb-config stack_grafana-data; do
+     docker run --rm -v "$v":/from -v "$PWD":/to alpine \
+       tar -czf "/to/${v}.tar.gz" -C /from .
+   done
+   ```
+   (Or `influx backup` for InfluxDB specifically — but the volume tar is the
+   simplest complete capture of both Influx and Grafana.)
+4. Copy the backup archive + the three `stack_*.tar.gz` to the new machine over
+   a trusted channel (USB / `scp` / Tailscale file copy). **Never** put the
+   token-bearing archive in iCloud/Dropbox/Drive.
+5. **Do not stop the live fleet yet** — keep it serving until the new host is
+   verified and you are ready to cut over (step 4 below).
+
+---
+
+## 3. On the NEW machine (restore)
+
+1. **Prereqs** (Apple Silicon native): Homebrew, `node` (match the old major
+   version), Docker Desktop, Tailscale, `git`, `sqlite3`, `tmux`, `ffmpeg`,
+   `python3`. The repo ships `install-macos.sh` — use it for the baseline, then
+   pin `claude` to the same version and keep auto-update OFF
+   (`DISABLE_AUTOUPDATER=1`) to avoid the binary-churn PATH failure.
+2. **Clone the repo** to the same absolute path if possible
+   (`/Users/<user>/marveen`). A different path means every launchd plist and
+   any absolute reference must be updated (see pitfalls).
+3. **Restore the tarball**, preserving modes (the token files are `0600`):
+   ```bash
+   mkdir -p /tmp/restore && tar -xpzf claudeclaw-YYYYmmdd-HHMMSS.tar.gz -C /tmp/restore
+   # inspect /tmp/restore/MANIFEST.txt, then:
+   rsync -a /tmp/restore/repo/  <repo>/         # repo group -> project root
+   rsync -a /tmp/restore/home/  "$HOME/"        # home group -> $HOME
+   ```
+   Verify perms: `ls -l <repo>/store/.dashboard-token ~/.claude/channels/*/.env`
+   should show `-rw-------`.
+4. **Build the app** (do NOT copy `dist/` or `node_modules/` from the old box):
+   ```bash
+   cd <repo> && npm install && npm run build
+   ```
+5. **Restore the Docker volumes**, then bring the stack up:
+   ```bash
+   for v in stack_influxdb-data stack_influxdb-config stack_grafana-data; do
+     docker volume create "$v"
+     docker run --rm -v "$v":/to -v "$PWD":/from alpine \
+       sh -c "cd /to && tar -xzf /from/${v}.tar.gz"
+   done
+   cd <repo>/projects/loxonTSDB && docker compose up -d
+   ```
+6. **Rebuild the Python venvs natively** (do NOT copy them — see pitfalls):
+   recreate `.venv-whisperx` and `.venv-diar` with `python3 -m venv` and reinstall
+   their packages so the torch/whisper wheels are arm64, not the old Intel x86_64.
+7. **Fix + install the launchd jobs:**
+   - If the user/home/repo path changed, edit each
+     `~/Library/LaunchAgents/com.gorcsevivan.*.plist` (`ProgramArguments`,
+     `WorkingDirectory`, `StandardOutPath`, env `HOME`/`PATH`) to the new paths.
+   - Load them: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.gorcsevivan.<job>.plist`
+     (jobs: `channels`, `dashboard`, `channels-nightly-restart`, `hosttemp`,
+     `poller-watchdog`, `session-limit-watchdog`).
+8. **Grant macOS permissions (TCC):** the first time the new processes need
+   Full Disk Access / Automation / Accessibility, macOS silently blocks them
+   until granted in System Settings → Privacy & Security. Grant Full Disk
+   Access to the terminal/`node`/`tmux` that run the fleet, or launchd jobs will
+   fail to read protected paths with no obvious error.
+
+---
+
+## 4. Cutover (the irreversible step — do last)
+
+1. On the OLD machine: stop everything that polls a bot token, in this order:
+   `launchctl bootout gui/$(id -u)/com.gorcsevivan.channels` (and the dashboard,
+   watchdogs), then confirm no `bun server.ts` / poller is left
+   (`pgrep -fl "claude .*--channels"`). Leaving the old poller alive = 409 on the new one.
+2. On the NEW machine: start `com.gorcsevivan.channels` (and dashboard). Confirm
+   a fresh poller: `pgrep -P <channels_pid>` shows a `bun` child, `bot.pid`
+   appears, `getWebhookInfo` `pending_update_count` drains to 0.
+3. Send a test Telegram message → it must reach the new fleet and get a reply.
+
+---
+
+## 5. Pitfalls (read before cutover)
+
+- **ONE BOT = ONE POLLER.** Repeated for emphasis: stop the old poller before
+  starting the new one, or inbound 409s and messages vanish. (See also
+  `telegram-inbound-dead-poller` skill.)
+- **macOS Full Disk Access / TCC.** New processes are blocked from protected
+  paths until explicitly granted; the failure is silent. Grant FDA to the
+  fleet's terminal/node/tmux up front.
+- **launchd plist paths are absolute.** `ProgramArguments`
+  (`/usr/local/bin/node`, `<repo>/dist/index.js`), `WorkingDirectory`, log
+  paths, and `EnvironmentVariables` (`HOME`, `PATH`, `DISABLE_AUTOUPDATER`) all
+  hard-code paths. If the username/home/node location differs, fix every plist
+  or the jobs fail to launch.
+- **Python venvs are not portable.** `.venv-whisperx` / `.venv-diar` hold
+  compiled torch/whisper wheels built for the old CPU arch (Intel x86_64). On
+  Apple Silicon they must be **rebuilt** (`python3 -m venv` + reinstall), never
+  copied — a copied venv crashes with arch/dyld errors.
+- **Docker volumes are not in the tarball.** InfluxDB history + Grafana
+  dashboards live in `stack_*` docker volumes; export/import them separately
+  (section 2.3 / 3.5). `git clone` + tar restore does NOT bring them.
+- **Tailscale.** The dashboard's external reach (`WEB_HOST`, `DASHBOARD_PUBLIC_URL`)
+  depends on the host's Tailscale identity. Install/log in Tailscale on the new
+  host; the machine gets a new tailnet name/IP, so update any URL that pinned
+  the old hostname. (See `marveen-dashboard-kulso-eleres` skill.)
+- **claude auto-update.** Keep `DISABLE_AUTOUPDATER=1`; the global-install
+  auto-updater rewrites the native binary and the `/usr/local/bin/claude`
+  symlink can vanish mid-swap → "claude not found on PATH" rapid-fail loops.
+- **dist vs src.** Always `npm run build` on the new host; never trust a copied
+  `dist/`. The dashboard launchd job runs `node dist/index.js` directly.
+
+---
+
+## 6. Post-migration verification checklist
+
+- [ ] Dashboard reachable at `http://localhost:3420` (and via Tailscale if used).
+- [ ] `sqlite3 store/claudeclaw.db 'PRAGMA integrity_check;'` → `ok`.
+- [ ] Kanban, memory, schedules visible in the dashboard (DB restored).
+- [ ] Skills present: `ls ~/.claude/skills` matches the old count.
+- [ ] Scheduled tasks present: `ls ~/.claude/scheduled-tasks` matches.
+- [ ] Telegram inbound + outbound works (test message round-trip).
+- [ ] Pairing intact: previously-approved chats still allowed (no re-pairing).
+- [ ] InfluxDB has the history: a Flux `count()` over the Loxone measurement
+      matches the old machine; Grafana dashboards render.
+- [ ] All six launchd jobs are loaded: `launchctl list | grep gorcsevivan`.
+- [ ] Old machine's pollers are fully stopped (no 409).

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,16 +1,32 @@
 #!/usr/bin/env bash
 # ClaudeClaw backup.
 #
-# What we snapshot:
-#   - store/claudeclaw.db (SQLite; WAL-checkpointed before copy)
-#   - store/.dashboard-token
-#   - agents/*/CLAUDE.md, SOUL.md, .mcp.json
-#   - agents/*/.claude/channels/{telegram,slack}/.env, access.json
-#   - .env (project root)
-#   - scheduled-tasks.json (if present)
+# The archive has two top-level groups so a restore is unambiguous about
+# where each file belongs (see docs/MIGRATION.md):
+#
+#   repo/   -> extract under the project root (this repo)
+#     store/claudeclaw.db (+ -shm/-wal; WAL-checkpointed before copy)
+#     store/.dashboard-token   (dashboard bearer)
+#     .env                     (project root secrets)
+#     scheduled-tasks.json     (legacy, if present)
+#     assets/meetings/**       (meeting transcripts/memos)
+#     agents/*/CLAUDE.md, SOUL.md, .mcp.json
+#     agents/*/.claude/channels/{telegram,slack,discord}/.env, access.json
+#
+#   home/   -> extract under $HOME
+#     .claude/skills/**            (the self-built skill library)
+#     .claude/scheduled-tasks/**   (file-based scheduled tasks: SKILL.md + config)
+#     .claude/channels/*/.env      (MAIN orchestrator channel token)
+#     .claude/channels/*/access.json, invites.json, approved/**  (pairing state)
+#     Library/LaunchAgents/com.gorcsevivan.*.plist (launchd jobs)
 #
 # Output: backups/claudeclaw-YYYYmmdd-HHMMSS.tar.gz
 # Retention: keeps the most recent 14 archives, prunes the rest.
+#
+# Restore (preserve modes so the 0600 token files stay private):
+#   tar -xpzf <archive> -C /tmp/restore        # inspect first
+#   then copy repo/* into the project root and home/* into $HOME.
+# Full runbook: docs/MIGRATION.md.
 
 set -euo pipefail
 
@@ -21,7 +37,6 @@ ARCHIVE="${BACKUP_DIR}/claudeclaw-${STAMP}.tar.gz"
 KEEP=14
 
 mkdir -p "${BACKUP_DIR}"
-
 cd "${REPO_ROOT}"
 
 # Checkpoint WAL into the main DB file so the snapshot is self-contained.
@@ -30,49 +45,107 @@ if [[ -f store/claudeclaw.db ]] && command -v sqlite3 >/dev/null 2>&1; then
   sqlite3 store/claudeclaw.db 'PRAGMA wal_checkpoint(TRUNCATE);' >/dev/null || true
 fi
 
-# Collect relative paths that actually exist. tar refuses missing entries
-# otherwise and the whole backup fails on a fresh machine where, e.g., no
-# agents have been created yet.
-TMPLIST="$(mktemp -t claudeclaw-backup.XXXXXX)"
-trap 'rm -f "${TMPLIST}"' EXIT
+# --- Build the two path lists (each relative to its own base). -------------
+# tar refuses missing entries, which would fail the whole backup on a fresh
+# machine (no agents yet) -- so we only list paths that actually exist.
+REPOLIST="$(mktemp -t claudeclaw-repo.XXXXXX)"
+HOMELIST="$(mktemp -t claudeclaw-home.XXXXXX)"
+MANIFEST="$(mktemp -t claudeclaw-manifest.XXXXXX)"
+STAGE="$(mktemp -d -t claudeclaw-stage.XXXXXX)"
+trap 'rm -f "${REPOLIST}" "${HOMELIST}" "${MANIFEST}"; rm -rf "${STAGE}"' EXIT
 
-maybe_add() {
-  local path="$1"
-  if [[ -e "${path}" ]]; then echo "${path}" >> "${TMPLIST}"; fi
+# add_if <listfile> <base> <relpath>  -- append relpath when <base>/<relpath> exists.
+add_if() {
+  local list="$1" base="$2" rel="$3"
+  if [[ -e "${base}/${rel}" ]]; then echo "${rel}" >> "${list}"; fi
 }
 
-maybe_add store/claudeclaw.db
-maybe_add store/claudeclaw.db-shm
-maybe_add store/claudeclaw.db-wal
-maybe_add store/.dashboard-token
-maybe_add .env
-maybe_add scheduled-tasks.json
-
-# Glob across all agents. Using find so a missing dir isn't an error.
+# repo/ group (relative to REPO_ROOT)
+add_if "${REPOLIST}" "${REPO_ROOT}" store/claudeclaw.db
+add_if "${REPOLIST}" "${REPO_ROOT}" store/claudeclaw.db-shm
+add_if "${REPOLIST}" "${REPO_ROOT}" store/claudeclaw.db-wal
+add_if "${REPOLIST}" "${REPO_ROOT}" store/.dashboard-token
+add_if "${REPOLIST}" "${REPO_ROOT}" .env
+add_if "${REPOLIST}" "${REPO_ROOT}" scheduled-tasks.json
+add_if "${REPOLIST}" "${REPO_ROOT}" assets/meetings
+# Per-agent identity + channel secrets (glob; missing dir is not an error).
 if [[ -d agents ]]; then
   find agents -type f \
     \( -name 'CLAUDE.md' -o -name 'SOUL.md' -o -name '.mcp.json' \
        -o -name 'access.json' -o -name '.env' \) \
-    -print >> "${TMPLIST}"
+    -print >> "${REPOLIST}"
 fi
 
-if [[ ! -s "${TMPLIST}" ]]; then
+# home/ group (relative to $HOME)
+add_if "${HOMELIST}" "${HOME}" .claude/skills
+add_if "${HOMELIST}" "${HOME}" .claude/scheduled-tasks
+# MAIN orchestrator channel tokens + pairing state, per provider. bot.pid and
+# inbox/ are runtime/transient and intentionally excluded.
+if [[ -d "${HOME}/.claude/channels" ]]; then
+  ( cd "${HOME}" && find .claude/channels -maxdepth 2 \
+      \( -name '.env' -o -name 'access.json' -o -name 'invites.json' \) \
+      -print ) >> "${HOMELIST}"
+  ( cd "${HOME}" && find .claude/channels -maxdepth 2 -type d -name 'approved' -print ) >> "${HOMELIST}"
+fi
+# launchd jobs for this fleet.
+if [[ -d "${HOME}/Library/LaunchAgents" ]]; then
+  ( cd "${HOME}" && find Library/LaunchAgents -maxdepth 1 -name 'com.gorcsevivan.*.plist' -print ) >> "${HOMELIST}"
+fi
+
+if [[ ! -s "${REPOLIST}" && ! -s "${HOMELIST}" ]]; then
   echo "backup: nothing to archive" >&2
   exit 0
 fi
 
-tar -czf "${ARCHIVE}" -T "${TMPLIST}"
+# --- Manifest (stored at the archive root for self-description). -----------
+{
+  echo "ClaudeClaw backup ${STAMP}"
+  echo "host: $(hostname 2>/dev/null || echo '?')   user: ${USER:-?}   home: ${HOME}"
+  echo "repo root: ${REPO_ROOT}"
+  echo "Restore: tar -xpzf <archive> -C <tmp>; copy repo/* -> project root, home/* -> \$HOME."
+  echo "See docs/MIGRATION.md for the full runbook (TCC, launchd paths, one-bot-one-poller, venv rebuild)."
+  echo "--- repo/ ---"; sed 's,^,repo/,' "${REPOLIST}" 2>/dev/null || true
+  echo "--- home/ ---"; sed 's,^,home/,' "${HOMELIST}" 2>/dev/null || true
+} > "${MANIFEST}"
+
+# --- Assemble the archive via a staging dir, then one plain tar. -----------
+# The repo/ and home/ groups are produced by copying into a staging tree, NOT
+# by tar name-substitution: bsdtar's `-s` and GNU tar's `--transform` are
+# mutually incompatible (on GNU tar, `-s` is `--same-order` and takes no
+# argument), so a substitution-based build is not portable. Staging + a single
+# `tar -czf -C "${STAGE}" .` works identically on macOS (bsdtar) and Linux
+# (GNU tar). Everything backed up is small (a few MB), so the copy is cheap;
+# `cp -pR` preserves modes so the 0600 token files stay private.
+cp "${MANIFEST}" "${STAGE}/MANIFEST.txt"
+
+stage_group() {  # stage_group <listfile> <base> <group>
+  local list="$1" base="$2" group="$3" rel parent
+  [[ -s "${list}" ]] || return 0
+  while IFS= read -r rel; do
+    [[ -z "${rel}" ]] && continue
+    parent="$(dirname "${rel}")"
+    mkdir -p "${STAGE}/${group}/${parent}"
+    cp -pR "${base}/${rel}" "${STAGE}/${group}/${parent}/"
+  done < "${list}"
+}
+
+stage_group "${REPOLIST}" "${REPO_ROOT}" repo
+stage_group "${HOMELIST}" "${HOME}" home
+
+# Archive only the top-level entries that exist (a group dir is absent when
+# its list was empty), so tar never errors on a missing entry and the names
+# stay clean (no leading "./").
+( cd "${STAGE}" && tar -czf "${ARCHIVE}" MANIFEST.txt \
+    $( [[ -d repo ]] && echo repo ) $( [[ -d home ]] && echo home ) )
 echo "backup: wrote ${ARCHIVE} ($(wc -c < "${ARCHIVE}" | awk '{print $1}') bytes)"
 
-# The archive contains sensitive tokens (dashboard bearer, Telegram bot
-# tokens, project .env secrets). Do not auto-sync ${BACKUP_DIR} to iCloud,
-# Dropbox, Google Drive, or any other cloud-backup folder. Keep it local
-# (Time Machine is fine because it stays on your encrypted-volume backup).
+# The archive contains sensitive tokens (dashboard bearer, channel bot tokens,
+# project .env secrets). Do not auto-sync ${BACKUP_DIR} to iCloud, Dropbox,
+# Google Drive, or any other cloud-backup folder. Keep it local.
 echo "backup: WARNING -- archive contains sensitive tokens; keep ${BACKUP_DIR} out of cloud-sync folders (iCloud / Dropbox / Google Drive)." >&2
 
-# Keep the newest ${KEEP} archives, drop the rest.
-# Use a while-read loop instead of mapfile so this works on macOS's default
-# bash 3.2 (mapfile is a bash-4 builtin).
+# Keep the newest ${KEEP} archives, drop the rest. while-read (not mapfile)
+# for macOS bash 3.2 compatibility.
 ls -1t "${BACKUP_DIR}"/claudeclaw-*.tar.gz 2>/dev/null | tail -n +$((KEEP + 1)) | while IFS= read -r f; do
   [[ -z "${f}" ]] && continue
   rm -f "${f}"


### PR DESCRIPTION
Makes the backup cover everything a host migration needs, and adds a migration runbook. Portable across macOS (bsdtar) and Linux (GNU tar).

## scripts/backup.sh
Previously snapshotted only the DB, project/agent secrets and agent channel tokens. It missed several things that live under `$HOME` (outside the repo), so a restore from the old archive would silently lose them.

- The archive is grouped: **`repo/`** (project-root-relative) and **`home/`** (`$HOME`-relative), so a restore is unambiguous about where each file goes.
- Built **portably** via a temp staging dir + a single `tar -czf`, *not* tar name-substitution: bsdtar's `-s` and GNU tar's `--transform` are mutually incompatible (on GNU tar `-s` is `--same-order` and takes no argument), so staging is the only cross-platform approach. `cp -pR` preserves the `0600` modes so token files stay private on restore.
- `home/` now also captures: `~/.claude/skills`, `~/.claude/scheduled-tasks`, `~/.claude/channels/*/{.env,access.json,invites.json,approved}`, `~/Library/LaunchAgents/com.gorcsevivan.*.plist`. `repo/` adds `assets/meetings`.
- Runtime/transient files (`bot.pid`, channels `inbox/`) are excluded. A `MANIFEST.txt` at the archive root lists contents + a restore hint.

## docs/MIGRATION.md
Full runbook for moving the fleet to a new machine: inventory (**including the Docker volumes that are NOT in the tarball** — InfluxDB/Grafana time-series — and must be migrated separately), restore steps, and the pitfalls (one-bot-one-poller / 409, macOS Full Disk Access/TCC, absolute launchd plist paths, non-portable Apple-Silicon venvs, Docker volume migration, Tailscale, claude auto-update), plus a verification checklist.

## Testing
Ran `scripts/backup.sh` on macOS (bsdtar 3.5.3): archive contains all expected items (DB, tokens, 57 skills, 21 scheduled-task files, pairing state, 6 launchd plists), runtime files excluded. Restore dry-run: clean extract, `0600` modes preserved, `PRAGMA integrity_check` → ok. `bash -n` clean.
