### PR TITLE
feat(auto-restart): per-agent scheduled session restart + live context size

### DIFF
--- a/src/__tests__/auto-restart.test.ts
+++ b/src/__tests__/auto-restart.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseHHMM,
+  normalizeAutoRestartConfig,
+  restartDue,
+  dailyDueAtMs,
+  DEFAULT_AUTO_RESTART,
+} from '../auto-restart.js'
+
+describe('parseHHMM', () => {
+  it('parses valid times to minutes since midnight', () => {
+    expect(parseHHMM('00:00')).toBe(0)
+    expect(parseHHMM('03:00')).toBe(180)
+    expect(parseHHMM('23:59')).toBe(23 * 60 + 59)
+    expect(parseHHMM('9:30')).toBe(570)
+  })
+  it('rejects malformed or out-of-range values', () => {
+    for (const bad of ['', '3', '24:00', '12:60', '-1:00', 'aa:bb', '12:5', 12 as unknown, null]) {
+      expect(parseHHMM(bad as unknown)).toBeNull()
+    }
+  })
+})
+
+describe('normalizeAutoRestartConfig', () => {
+  it('returns safe defaults for junk input', () => {
+    expect(normalizeAutoRestartConfig(null)).toEqual(DEFAULT_AUTO_RESTART)
+    expect(normalizeAutoRestartConfig('nope')).toEqual(DEFAULT_AUTO_RESTART)
+    expect(normalizeAutoRestartConfig({})).toEqual(DEFAULT_AUTO_RESTART)
+  })
+  it('keeps a valid daily config and clears interval (daily wins)', () => {
+    const c = normalizeAutoRestartConfig({ enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: 6, handoff: true })
+    expect(c).toEqual({ enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: null, handoff: true })
+  })
+  it('keeps a valid interval config when no daily time', () => {
+    const c = normalizeAutoRestartConfig({ enabled: true, mode: 'continue', intervalHours: 8 })
+    expect(c).toEqual({ enabled: true, mode: 'continue', dailyTime: null, intervalHours: 8, handoff: false })
+  })
+  it('drops an invalid dailyTime and non-positive interval', () => {
+    const c = normalizeAutoRestartConfig({ enabled: true, dailyTime: '99:99', intervalHours: 0 })
+    expect(c.dailyTime).toBeNull()
+    expect(c.intervalHours).toBeNull()
+  })
+  it('defaults mode to continue for an unknown mode', () => {
+    expect(normalizeAutoRestartConfig({ mode: 'wild' }).mode).toBe('continue')
+  })
+})
+
+describe('restartDue', () => {
+  const DUE = 1_000_000
+
+  it('is not due before the scheduled time', () => {
+    expect(restartDue(null, DUE - 1, DUE)).toBe(false)
+  })
+  it('is due at/after the scheduled time when never restarted', () => {
+    expect(restartDue(null, DUE, DUE)).toBe(true)
+    expect(restartDue(null, DUE + 5_000, DUE)).toBe(true)
+  })
+  it('does not re-fire once restarted at/after the due point', () => {
+    expect(restartDue(DUE, DUE + 5_000, DUE)).toBe(false)
+    expect(restartDue(DUE + 1, DUE + 5_000, DUE)).toBe(false)
+  })
+  it('fires again for a later due point even if restarted at an earlier one', () => {
+    const earlier = DUE - 86_400_000 // yesterday's restart
+    expect(restartDue(earlier, DUE + 1, DUE)).toBe(true)
+  })
+  it('is never due for a non-finite dueAt', () => {
+    expect(restartDue(null, DUE, Number.NaN)).toBe(false)
+    expect(restartDue(null, DUE, Number.POSITIVE_INFINITY)).toBe(false)
+  })
+})
+
+describe('dailyDueAtMs', () => {
+  it('adds the minutes-since-midnight offset to local midnight', () => {
+    const midnight = 1_700_000_000_000
+    expect(dailyDueAtMs(midnight, 0)).toBe(midnight)
+    expect(dailyDueAtMs(midnight, 180)).toBe(midnight + 180 * 60_000) // 03:00
+  })
+})

--- a/src/auto-restart.ts
+++ b/src/auto-restart.ts
@@ -1,0 +1,107 @@
+// Pure logic for the per-agent auto-restart feature.
+//
+// A long-lived Claude Code session accumulates context: every turn re-reads the
+// whole transcript, so a big context is slower and costlier and hits the
+// per-session limit sooner. Restarting periodically (by default after the
+// nightly dream consolidation -- "the brain sleeps, tidies up, wakes fresh")
+// keeps sessions lean. Two modes:
+//   - 'fresh':    drop the conversation (start without --continue) -- the speed-up.
+//   - 'continue': keep the conversation (--continue) but re-spawn the process,
+//                 so a tier/limit-budget refresh takes effect without losing context.
+//
+// This module is dependency-free so the due-decision is unit-testable without a
+// clock, tmux, or the filesystem. The I/O (reading the config store, checking the
+// pane is idle, performing the restart) lives in src/web/auto-restart-runner.ts.
+
+export type AutoRestartMode = 'fresh' | 'continue'
+
+export interface AutoRestartConfig {
+  /** Master toggle. When false the agent is never auto-restarted. */
+  enabled: boolean
+  /** What kind of restart to perform. */
+  mode: AutoRestartMode
+  /** Daily restart wall-clock time, 'HH:MM' in local time, or null. */
+  dailyTime: string | null
+  /** Restart every N hours, or null. Exactly one of dailyTime/intervalHours is
+   *  meaningful; dailyTime wins if both are somehow set. */
+  intervalHours: number | null
+  /** Phase 2: run the handoff skill to persist context before a fresh restart. */
+  handoff: boolean
+}
+
+export const DEFAULT_AUTO_RESTART: AutoRestartConfig = {
+  enabled: false,
+  mode: 'continue',
+  dailyTime: null,
+  intervalHours: null,
+  handoff: false,
+}
+
+/** Parse 'HH:MM' (24h) into minutes since local midnight, or null if invalid. */
+export function parseHHMM(s: unknown): number | null {
+  if (typeof s !== 'string') return null
+  const m = /^(\d{1,2}):(\d{2})$/.exec(s.trim())
+  if (!m) return null
+  const h = Number(m[1])
+  const min = Number(m[2])
+  if (!Number.isInteger(h) || !Number.isInteger(min)) return null
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null
+  return h * 60 + min
+}
+
+/**
+ * Coerce arbitrary parsed JSON into a safe, fully-populated config. Unknown /
+ * malformed fields fall back to defaults, so a hand-edited or older store can
+ * never crash the runner or yield a half-set config.
+ */
+export function normalizeAutoRestartConfig(raw: unknown): AutoRestartConfig {
+  const o = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const mode: AutoRestartMode = o.mode === 'fresh' ? 'fresh' : 'continue'
+  const dailyTime = parseHHMM(o.dailyTime) !== null ? (o.dailyTime as string).trim() : null
+  let intervalHours: number | null = null
+  if (typeof o.intervalHours === 'number' && Number.isFinite(o.intervalHours) && o.intervalHours > 0) {
+    intervalHours = o.intervalHours
+  }
+  // dailyTime takes precedence: never keep both, so the schedule is unambiguous.
+  if (dailyTime !== null) intervalHours = null
+  return {
+    enabled: o.enabled === true,
+    mode,
+    dailyTime,
+    intervalHours,
+    handoff: o.handoff === true,
+  }
+}
+
+/**
+ * Pure decision: is a restart due *now*?
+ *
+ * `dueAtMs` is the timestamp the caller computed for the next scheduled restart
+ * (today's HH:MM for the daily schedule, or lastRestart + interval for the
+ * interval schedule). A restart is due when now has reached it AND we have not
+ * already restarted at or after it (so it fires once per scheduled point, not
+ * every tick in the window).
+ *
+ * @param lastRestartAtMs  When this agent was last auto-restarted, or null if never.
+ * @param nowMs            Current clock (ms).
+ * @param dueAtMs          The scheduled restart timestamp to compare against.
+ */
+export function restartDue(lastRestartAtMs: number | null, nowMs: number, dueAtMs: number): boolean {
+  if (!Number.isFinite(dueAtMs)) return false
+  if (nowMs < dueAtMs) return false
+  if (lastRestartAtMs !== null && lastRestartAtMs >= dueAtMs) return false
+  return true
+}
+
+/**
+ * Start-of-local-day timestamp for the day containing `nowMs`, given the
+ * environment's local-midnight offset already applied by the caller. Kept here
+ * as a pure helper that takes the local Y/M/D components so it is testable
+ * without a timezone: the runner passes `new Date(nowMs)` getFullYear/Month/Date.
+ */
+export function dailyDueAtMs(
+  localMidnightMs: number,
+  minutesSinceMidnight: number,
+): number {
+  return localMidnightMs + minutesSinceMidnight * 60_000
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -17,6 +17,7 @@ import { startInboundProber } from './web/inbound-probe.js'
 import { startChannelHealthMonitor } from './web/channel-health-monitor.js'
 import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
 import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
+import { startAutoRestartRunner } from './web/auto-restart-runner.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
@@ -235,6 +236,9 @@ export function startWebServer(port = 3420): http.Server {
   const stuckToolCallInterval = startStuckToolCallWatcher()
   logger.info('Stuck-tool-call watcher started (30s poll, 35s offset)')
 
+  const autoRestartInterval = startAutoRestartRunner()
+  logger.info('Auto-restart runner started (60s poll, 40s offset)')
+
   const updateCheckerInterval = startUpdateChecker()
   logger.info('Update checker started (15min poll)')
 
@@ -283,6 +287,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(channelHealthInterval)
     clearInterval(stuckInputInterval)
     clearInterval(stuckToolCallInterval)
+    clearInterval(autoRestartInterval)
     clearInterval(updateCheckerInterval)
     return origClose(cb)
   }

--- a/src/web/active-model.ts
+++ b/src/web/active-model.ts
@@ -72,3 +72,50 @@ export function readActiveModelFromProjectDir(workingDir: string, sinceUnixSec?:
   cache.set(cacheKey, { value, expiresAt: now + TTL_MS })
   return value
 }
+
+const ctxCache = new Map<string, { value: number | null; expiresAt: number }>()
+
+// Current context size of the live session, in tokens. Claude Code records a
+// `usage` object on each assistant turn; the context that gets re-read every
+// turn is input_tokens + cache_read_input_tokens + cache_creation_input_tokens
+// (output_tokens is the new reply, not context). We scan the newest transcript
+// from the end for the last turn carrying a usage and sum those three. Returns
+// null when there is no transcript / no usage yet (fresh session). This is what
+// the dashboard surfaces so the operator can see a session growing heavy and
+// decide to restart it.
+export function readContextTokensFromProjectDir(workingDir: string, configDir?: string): number | null {
+  const now = Date.now()
+  const cacheKey = `${workingDir}:${configDir ?? ''}`
+  const cached = ctxCache.get(cacheKey)
+  if (cached && cached.expiresAt > now) return cached.value
+  let value: number | null = null
+  try {
+    const dir = projectsDirFor(workingDir, configDir)
+    if (existsSync(dir)) {
+      const jsonls = readdirSync(dir)
+        .filter(f => f.endsWith('.jsonl'))
+        .map(f => ({ f, mtime: statSync(join(dir, f)).mtimeMs }))
+        .sort((a, b) => b.mtime - a.mtime)
+      if (jsonls.length > 0) {
+        const content = readFileSync(join(dir, jsonls[0].f), 'utf-8')
+        const lines = content.split('\n')
+        for (let i = lines.length - 1; i >= 0; i--) {
+          const line = lines[i].trim()
+          if (!line) continue
+          try {
+            const u = JSON.parse(line)?.message?.usage
+            if (u && typeof u === 'object') {
+              const inp = Number(u.input_tokens) || 0
+              const cr = Number(u.cache_read_input_tokens) || 0
+              const cc = Number(u.cache_creation_input_tokens) || 0
+              const total = inp + cr + cc
+              if (total > 0) { value = total; break }
+            }
+          } catch { /* skip malformed JSON line */ }
+        }
+      }
+    }
+  } catch { /* fall through */ }
+  ctxCache.set(cacheKey, { value, expiresAt: now + TTL_MS })
+  return value
+}

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -66,7 +66,7 @@ export function agentHasChannel(name: string): boolean {
   return false
 }
 
-export function startAgentProcess(name: string): { ok: boolean; pid?: number; error?: string } {
+export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}): { ok: boolean; pid?: number; error?: string } {
   if (isAgentRunning(name)) return { ok: false, error: 'Agent is already running' }
 
   const dir = agentDir(name)
@@ -167,7 +167,10 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
       : join(homedir(), '.claude', 'projects')
     const encodedProject = dir.replace(/\//g, '-')
     const hasPriorSession = existsSync(join(projectsRoot, encodedProject))
-    const continueFlag = hasPriorSession ? '--continue ' : ''
+    // opts.fresh forces a brand-new conversation (auto-restart 'fresh' mode):
+    // omit --continue so the heavy accumulated context is dropped. Without it
+    // we resume the prior session (the 'continue' mode / normal restart).
+    const continueFlag = (hasPriorSession && !opts.fresh) ? '--continue ' : ''
     const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : 'TELEGRAM_STATE_DIR'
     const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN'
     // Slack plugin is third-party; its "not on approved allowlist" check is
@@ -244,12 +247,12 @@ export function getAgentProcessInfo(name: string): { running: boolean; session?:
   }
 }
 
-export function restartAgentProcess(name: string): { ok: boolean; pid?: number; error?: string } {
+export function restartAgentProcess(name: string, opts: { fresh?: boolean } = {}): { ok: boolean; pid?: number; error?: string } {
   if (isAgentRunning(name)) {
     const stopResult = stopAgentProcess(name)
     if (!stopResult.ok) return { ok: false, error: stopResult.error || 'Failed to stop running agent before restart' }
   }
-  return startAgentProcess(name)
+  return startAgentProcess(name, opts)
 }
 
 // Claude Code occasionally pops a "How is Claude doing this session? (optional)"

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from 'node:child_process'
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID } from '../config.js'
+import { listAgentNames } from './agent-config.js'
+import {
+  isAgentRunning,
+  agentSessionName,
+  restartAgentProcess,
+  capturePane,
+} from './agent-process.js'
+import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { detectPaneState } from '../pane-state.js'
+import { readAutoRestartConfig } from './auto-restart-store.js'
+import { restartDue, dailyDueAtMs, parseHHMM, type AutoRestartConfig } from '../auto-restart.js'
+
+// Drives per-agent scheduled restarts (see src/auto-restart.ts for the why and
+// the pure due-logic). Mirrors the other watcher loops: a 60s sweep, started
+// after the others to avoid piling tmux calls onto one tick.
+//
+// Two hard safety rules:
+//   - IDLE-GUARD: never restart a session mid-turn (a busy pane), including the
+//     main channels session -- that would cut off a live conversation. We defer
+//     to the next tick until the pane is idle.
+//   - SEED-ON-FIRST-SIGHT: on the first sweep we record "last restart = now" for
+//     each enabled agent without acting, so a daily time that already passed
+//     before the dashboard started does not trigger a spurious restart on boot.
+
+const INITIAL_DELAY_MS = 40_000
+const INTERVAL_MS = 60_000
+
+// agent name -> last auto-restart time (ms). Also seeded on first sight (no
+// restart) so a past-due daily slot does not fire at startup. In-memory: a
+// dashboard restart re-seeds, at worst skipping one slot -- never double-fires.
+const lastRestart = new Map<string, number>()
+
+function localMidnightMs(nowMs: number): number {
+  const d = new Date(nowMs)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+function computeDueAt(cfg: AutoRestartConfig, name: string, nowMs: number): number | null {
+  if (cfg.dailyTime) {
+    const mins = parseHHMM(cfg.dailyTime)
+    if (mins === null) return null
+    return dailyDueAtMs(localMidnightMs(nowMs), mins)
+  }
+  if (cfg.intervalHours) {
+    const base = lastRestart.get(name) ?? nowMs
+    return base + cfg.intervalHours * 3_600_000
+  }
+  return null
+}
+
+function sessionFor(name: string): string {
+  return name === MAIN_AGENT_ID ? MAIN_CHANNELS_SESSION : agentSessionName(name)
+}
+
+function paneIsIdle(session: string): boolean {
+  const pane = capturePane(session)
+  if (pane == null) return false
+  return detectPaneState(pane) === 'idle'
+}
+
+function performRestart(name: string, cfg: AutoRestartConfig): void {
+  if (name === MAIN_AGENT_ID) {
+    // The main channels session is launchd-managed and channels.sh always
+    // starts a fresh conversation, so 'continue' is not applicable here -- a
+    // kickstart is always a fresh restart. KeepAlive brings it straight back.
+    const uid = typeof process.getuid === 'function' ? process.getuid() : ''
+    execFileSync('/bin/launchctl', ['kickstart', '-k', `gui/${uid}/com.${MAIN_AGENT_ID}.channels`], { timeout: 10_000 })
+  } else {
+    restartAgentProcess(name, { fresh: cfg.mode === 'fresh' })
+  }
+}
+
+function checkAgent(name: string, nowMs: number): void {
+  const cfg = readAutoRestartConfig(name)
+  if (!cfg.enabled) {
+    lastRestart.delete(name) // re-seed cleanly if re-enabled later
+    return
+  }
+  // Sub-agents must be up to be restarted; the main session is launchd-managed
+  // (always considered present).
+  if (name !== MAIN_AGENT_ID && !isAgentRunning(name)) return
+
+  // Seed on first sight so a daily slot that already elapsed before boot does
+  // not fire now.
+  if (!lastRestart.has(name)) {
+    lastRestart.set(name, nowMs)
+    return
+  }
+
+  const dueAt = computeDueAt(cfg, name, nowMs)
+  if (dueAt === null) return
+  if (!restartDue(lastRestart.get(name) ?? null, nowMs, dueAt)) return
+
+  const session = sessionFor(name)
+  if (!paneIsIdle(session)) {
+    logger.info({ name, session }, 'auto-restart: due but pane is busy, deferring to next tick')
+    return
+  }
+
+  try {
+    performRestart(name, cfg)
+    lastRestart.set(name, nowMs)
+    logger.info({ name, mode: name === MAIN_AGENT_ID ? 'fresh(main)' : cfg.mode }, 'auto-restart: restarted session')
+  } catch (err) {
+    logger.warn({ err, name }, 'auto-restart: restart failed')
+  }
+}
+
+export function startAutoRestartRunner(): NodeJS.Timeout {
+  function sweep() {
+    const now = Date.now()
+    try { checkAgent(MAIN_AGENT_ID, now) } catch (err) { logger.debug({ err }, 'auto-restart: main check error') }
+    for (const name of listAgentNames()) {
+      try { checkAgent(name, now) } catch (err) { logger.debug({ err, agent: name }, 'auto-restart: agent check error') }
+    }
+  }
+  setTimeout(sweep, INITIAL_DELAY_MS)
+  return setInterval(sweep, INTERVAL_MS)
+}

--- a/src/web/auto-restart-store.ts
+++ b/src/web/auto-restart-store.ts
@@ -1,0 +1,49 @@
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { PROJECT_ROOT } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+import {
+  normalizeAutoRestartConfig,
+  DEFAULT_AUTO_RESTART,
+  type AutoRestartConfig,
+} from '../auto-restart.js'
+
+// Per-agent auto-restart config lives in one JSON map keyed by agent name
+// (the main orchestrator included, under its agent id). A single file keeps the
+// main session and sub-agents uniform and sidesteps the per-agent-dir vs
+// PROJECT_ROOT config-path split.
+const STORE_PATH = join(PROJECT_ROOT, 'store', 'auto-restart.json')
+
+function readRaw(): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(readFileSync(STORE_PATH, 'utf-8'))
+    return (parsed && typeof parsed === 'object') ? parsed as Record<string, unknown> : {}
+  } catch {
+    return {}
+  }
+}
+
+/** All configured agents, normalized. Agents with no entry are simply absent. */
+export function readAllAutoRestartConfigs(): Record<string, AutoRestartConfig> {
+  const raw = readRaw()
+  const out: Record<string, AutoRestartConfig> = {}
+  for (const [name, cfg] of Object.entries(raw)) {
+    out[name] = normalizeAutoRestartConfig(cfg)
+  }
+  return out
+}
+
+/** One agent's config, normalized; the disabled default when unset. */
+export function readAutoRestartConfig(name: string): AutoRestartConfig {
+  const raw = readRaw()
+  return name in raw ? normalizeAutoRestartConfig(raw[name]) : { ...DEFAULT_AUTO_RESTART }
+}
+
+/** Persist one agent's config (normalized first so the store stays clean). */
+export function writeAutoRestartConfig(name: string, cfg: unknown): AutoRestartConfig {
+  const normalized = normalizeAutoRestartConfig(cfg)
+  const raw = readRaw()
+  raw[name] = normalized
+  atomicWriteFileSync(STORE_PATH, JSON.stringify(raw, null, 2))
+  return normalized
+}

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -79,8 +79,10 @@ import {
   sendPromptToSession,
   capturePane,
 } from '../agent-process.js'
-import { readActiveModelFromProjectDir } from '../active-model.js'
+import { readActiveModelFromProjectDir, readContextTokensFromProjectDir } from '../active-model.js'
 import { detectPaneState } from '../../pane-state.js'
+import { readAutoRestartConfig, writeAutoRestartConfig } from '../auto-restart-store.js'
+import type { AutoRestartConfig } from '../../auto-restart.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
 import { getChannelHealth } from '../channel-health-monitor.js'
 import {
@@ -266,6 +268,10 @@ interface AgentSummary {
   running: boolean
   session?: string
   hasAvatar: boolean
+  autoRestart: AutoRestartConfig
+  /** Live context size in tokens (input+cache_read+cache_creation of the last
+   *  turn), or null when not running / no transcript yet. */
+  contextTokens: number | null
 }
 
 interface AgentDetail extends AgentSummary {
@@ -307,6 +313,8 @@ function getAgentSummary(name: string): AgentSummary {
     running: proc.running,
     session: proc.session,
     hasAvatar: findAvatarForAgent(name) !== null,
+    autoRestart: readAutoRestartConfig(name),
+    contextTokens: proc.running ? readContextTokensFromProjectDir(dir, readAgentClaudeConfigDir(name) ?? undefined) : null,
   }
 }
 
@@ -752,6 +760,22 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     writeAgentSecurityProfile(name, requested)
     writeAgentSettingsFromProfile(name, profile)
     json(res, { ok: true, requiresRestart: isAgentRunning(name) })
+    return true
+  }
+
+  // PUT /api/agents/:name/auto-restart -- set the per-agent auto-restart config.
+  // Accepts the main orchestrator id too (auto-restart applies to it as well).
+  // The body is normalized server-side, so a partial/garbled payload is coerced
+  // to a safe config rather than rejected.
+  const autoRestartMatch = path.match(/^\/api\/agents\/([^/]+)\/auto-restart$/)
+  if (autoRestartMatch && method === 'PUT') {
+    const name = decodeURIComponent(autoRestartMatch[1])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    const body = await readBody(req)
+    let data: unknown
+    try { data = JSON.parse(body.toString()) } catch { json(res, { error: 'invalid JSON' }, 400); return true }
+    const saved = writeAutoRestartConfig(name, data)
+    json(res, { ok: true, autoRestart: saved })
     return true
   }
 

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -7,7 +7,8 @@ import { readFileOr } from '../agent-config.js'
 import { parseMultipart } from '../multipart.js'
 import { readBody, json, serveFile } from '../http-helpers.js'
 import { MAIN_CHANNELS_SESSION } from '../main-agent.js'
-import { readActiveModelFromProjectDir } from '../active-model.js'
+import { readActiveModelFromProjectDir, readContextTokensFromProjectDir } from '../active-model.js'
+import { readAutoRestartConfig } from '../auto-restart-store.js'
 import type { RouteContext } from './types.js'
 
 function getActiveMarveenModel(): string {
@@ -40,6 +41,11 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
       model: getActiveMarveenModel(),
       tmuxSession: MAIN_CHANNELS_SESSION,
       running: true,
+      // Auto-restart applies to the main channels session too; key it by the
+      // orchestrator id (autoRestartId) so the UI PUTs to the right store entry.
+      autoRestart: readAutoRestartConfig(MAIN_AGENT_ID),
+      autoRestartId: MAIN_AGENT_ID,
+      contextTokens: readContextTokensFromProjectDir(PROJECT_ROOT),
       hasTelegram: tg.hasTelegram,
       hasDiscord: dc.hasDiscord,
       hasSlack: sl.hasSlack,

--- a/web/app.js
+++ b/web/app.js
@@ -1252,12 +1252,59 @@ async function loadAgents() {
   }
 }
 
+// Format a context-token count for display (e.g. 699884 -> "≈700k token").
+function formatContextTokens(n) {
+  if (typeof n !== 'number' || !isFinite(n) || n <= 0) return '-'
+  if (n < 1000) return `${n} token`
+  const k = n / 1000
+  return `≈${k < 10 ? k.toFixed(1) : Math.round(k)}k token`
+}
+
+// Populate the auto-restart controls + context display from an agent payload.
+// Works for sub-agents (agent.name) and the main session (agent.autoRestartId).
+function setupAutoRestartUI(agent) {
+  const ctxEl = document.getElementById('agentDetailContext')
+  if (ctxEl) ctxEl.textContent = formatContextTokens(agent && agent.contextTokens)
+
+  const ar = (agent && agent.autoRestart) || { enabled: false, mode: 'continue', dailyTime: null, intervalHours: null }
+  const enabled = document.getElementById('arEnabled')
+  const mode = document.getElementById('arMode')
+  const schedKind = document.getElementById('arSchedKind')
+  const dailyWrap = document.getElementById('arDailyWrap')
+  const dailyTime = document.getElementById('arDailyTime')
+  const intervalWrap = document.getElementById('arIntervalWrap')
+  const intervalHours = document.getElementById('arIntervalHours')
+  if (!enabled || !mode || !schedKind) return
+
+  enabled.checked = ar.enabled === true
+  mode.value = ar.mode === 'fresh' ? 'fresh' : 'continue'
+  if (ar.intervalHours) {
+    schedKind.value = 'interval'
+    intervalHours.value = ar.intervalHours
+  } else {
+    schedKind.value = 'daily'
+    if (ar.dailyTime) dailyTime.value = ar.dailyTime
+  }
+  const syncSched = () => {
+    const isInterval = schedKind.value === 'interval'
+    intervalWrap.hidden = !isInterval
+    dailyWrap.hidden = isInterval
+  }
+  syncSched()
+  // Attach the show/hide listener once.
+  if (schedKind.dataset.wired !== '1') {
+    schedKind.addEventListener('change', syncSched)
+    schedKind.dataset.wired = '1'
+  }
+}
+
 async function openMarveenDetail() {
   const m = window._marveen
   if (!m) return
 
   // Reuse the agent detail modal for Marveen
   currentAgent = { ...m, name: 'marveen', claudeMd: '', soulMd: '', mcpJson: '', skills: [] }
+  setupAutoRestartUI(currentAgent)
 
   const displayName = m.name || 'Marveen'
   document.getElementById('agentDetailTitle').textContent = displayName
@@ -1475,6 +1522,9 @@ async function openAgentDetail(agentName) {
   document.getElementById('editClaudeMd').value = currentAgent.claudeMd || currentAgent.content || ''
   document.getElementById('editSoulMd').value = currentAgent.soulMd || ''
   document.getElementById('editMcpJson').value = currentAgent.mcpJson || ''
+
+  // Auto-restart settings + live context size
+  setupAutoRestartUI(currentAgent)
 
   // Telegram tab
   updateChannelTab(currentAgent)
@@ -1933,6 +1983,33 @@ document.getElementById('saveModelBtn').addEventListener('click', async () => {
       return
     }
     startModelRestartPolling(name, newModel, triggeredAt)
+  } catch { showToast('Hiba a mentés során') }
+})
+
+document.getElementById('saveAutoRestartBtn').addEventListener('click', async () => {
+  if (!currentAgent) return
+  // Auto-restart applies to the main session too, so (unlike model/profile) we
+  // do NOT skip role === 'main'. The store key is autoRestartId for the main
+  // session, the sanitized name for sub-agents.
+  const id = currentAgent.autoRestartId || currentAgent.name
+  const schedKind = document.getElementById('arSchedKind').value
+  const cfg = {
+    enabled: document.getElementById('arEnabled').checked,
+    mode: document.getElementById('arMode').value === 'fresh' ? 'fresh' : 'continue',
+    dailyTime: schedKind === 'daily' ? document.getElementById('arDailyTime').value : null,
+    intervalHours: schedKind === 'interval' ? Number(document.getElementById('arIntervalHours').value) : null,
+    handoff: false,
+  }
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(id)}/auto-restart`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(cfg),
+    })
+    if (!res.ok) throw new Error()
+    const body = await res.json()
+    if (currentAgent) currentAgent.autoRestart = body.autoRestart
+    showToast('Auto-restart beállítás mentve')
   } catch { showToast('Hiba a mentés során') }
 })
 

--- a/web/index.html
+++ b/web/index.html
@@ -1308,6 +1308,10 @@
               <span class="meta-label">Skillek</span>
               <span class="meta-value" id="agentDetailSkillCount">0</span>
             </div>
+            <div class="agent-overview-item">
+              <span class="meta-label">Kontextus</span>
+              <span class="meta-value" id="agentDetailContext">-</span>
+            </div>
           </div>
           <div class="agent-process-control" id="agentProcessControl">
             <div class="process-status" id="processStatus">
@@ -1357,6 +1361,47 @@
             <small id="deepseekHint" style="display:none;margin-top:6px;color:var(--text-muted);font-size:12px;line-height:1.4">
               DeepSeek-V4-Pro nincs konfigurálva. <a href="#" id="deepseekConfigLink">API kulcs hozzáadása</a> a Vault oldalon.
             </small>
+          </div>
+          <div class="form-group" id="autoRestartGroup">
+            <label>Automatikus újraindítás</label>
+            <p style="margin:4px 0 10px;font-size:12.5px;line-height:1.5;color:var(--text-muted)">
+              A hosszú sessionök lelassulnak: a teljes kontextust minden válasznál újra fel kell dolgozni,
+              ezért a nagyobb kontextus lassabb és drágább, és hamarabb eléri a limitet. Érdemes időnként
+              újraindítani, hogy a session friss és lendületes maradjon. Alapértelmezetten az éjszakai
+              konszolidáció (DREAM) után fut, mint az alvás: az agy éjjel rendet rak, és reggel frissen ébredsz.
+            </p>
+            <label style="display:flex;align-items:center;gap:8px;font-size:13px;margin-bottom:10px;cursor:pointer">
+              <input type="checkbox" id="arEnabled"> Bekapcsolva
+            </label>
+            <div class="form-row" style="gap:10px;flex-wrap:wrap;align-items:flex-end">
+              <div class="form-group" style="flex:1;min-width:200px;margin-bottom:0">
+                <label for="arMode" style="font-size:12px;color:var(--text-muted)">Mód</label>
+                <select id="arMode">
+                  <option value="continue">Folytatás — kontextus megmarad, tier/limit frissül</option>
+                  <option value="fresh">Friss — kontextus eldobása (ez gyorsít)</option>
+                </select>
+              </div>
+              <div class="form-group" style="margin-bottom:0">
+                <label for="arSchedKind" style="font-size:12px;color:var(--text-muted)">Ütemezés</label>
+                <select id="arSchedKind">
+                  <option value="daily">Napi időpont</option>
+                  <option value="interval">Óránként</option>
+                </select>
+              </div>
+              <div class="form-group" id="arDailyWrap" style="margin-bottom:0">
+                <label for="arDailyTime" style="font-size:12px;color:var(--text-muted)">Időpont</label>
+                <input type="time" id="arDailyTime" value="03:00">
+              </div>
+              <div class="form-group" id="arIntervalWrap" hidden style="margin-bottom:0">
+                <label for="arIntervalHours" style="font-size:12px;color:var(--text-muted)">Óránként</label>
+                <input type="number" id="arIntervalHours" min="1" max="168" value="12" style="width:80px">
+              </div>
+            </div>
+            <small style="display:block;margin-top:8px;color:var(--text-muted);font-size:12px;line-height:1.5">
+              A fő channels-session mindig friss indul (a Folytatás mód rá nem vonatkozik).
+              Soha nem szakít meg futó munkát: csak üresjáratban (idle) indít újra, különben a következő körre halaszt.
+            </small>
+            <button class="btn-secondary btn-compact agent-save-section" id="saveAutoRestartBtn" style="margin-top:10px">Mentés</button>
           </div>
           <div class="form-group" id="authModeGroup">
             <label>Hitelesítési mód</label>


### PR DESCRIPTION
Per-agent scheduled session restart, to keep long-lived sessions lean. A long session accumulates context — every turn re-reads the whole transcript, so a big context is slower, costlier, and hits the per-session limit sooner. Restarting periodically (by default after the nightly dream consolidation — "the brain sleeps, tidies up, wakes fresh") keeps sessions fast.

## Modes
- **fresh** — drop the conversation (start without `--continue`); the speed-up.
- **continue** — keep the conversation (`--continue`) but re-spawn the process, so a tier / limit-budget refresh takes effect without losing context.

The main channels session is launchd-managed and always starts fresh (per `channels.sh`), so it restarts via `launchctl kickstart` (fresh-only); sub-agents use `restartAgentProcess({fresh})`.

## Safety
- **Idle-guard** — never restart a busy pane (mid-turn), including the **main channels session**, so a live conversation is never cut off; it defers to the next tick. Uses `detectPaneState`.
- **Seed-on-first-sight** — on the first sweep it only records "last restart = now" without acting, so a daily slot that already passed before the dashboard started does not trigger a spurious restart on boot. In-memory, so a restart at worst skips one slot — never double-fires.

## Pieces
- `src/auto-restart.ts` — pure config type + `normalizeAutoRestartConfig` + `restartDue` + `parseHHMM` (dependency-free, unit-tested: 13 cases).
- `src/web/auto-restart-store.ts` — `store/auto-restart.json` (one map keyed by agent, main orchestrator included).
- `src/web/active-model.ts` — `readContextTokensFromProjectDir`: live context size (input + cache_read + cache_creation of the last turn).
- `src/web/agent-process.ts` — `start`/`restartAgentProcess` gain `{fresh}` (omit `--continue`).
- `src/web/auto-restart-runner.ts` — 60s sweep with the guards above.
- `routes/agents.ts` + `routes/marveen.ts` — agent payload gains `autoRestart` + `contextTokens`; `PUT /api/agents/:id/auto-restart`.
- Dashboard UI (`web/index.html`, `web/app.js`) — Settings controls (toggle, mode, daily-time / every-N-hours) + a live context-size readout + **inline** explanatory text (not a tooltip): why smaller context is better, that it never interrupts a busy session, and the sleep analogy for the default DREAM timing. Generic, no per-deployment hard-coding.

## Deploy note
Once enabled for the main session, this supersedes a launchd nightly-restart-of-the-channels-session quick-version some deployments run (e.g. a 03:00 cron job) — disable that to avoid a double restart.

## Tests
`npm test`: 13 new pure-logic cases green. `tsc --noEmit` + `npm run build` clean.
