### PR TITLE
feat(dashboard): mobile-responsive shell — off-canvas sidebar + hamburger (<=768px)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -90,10 +90,25 @@ function switchPage(pageId) {
   if (pageId === 'tokenUsage') loadTokenUsage()
 }
 
+// Mobile off-canvas sidebar toggle. No-op visual effect on desktop (the
+// hamburger/backdrop are display:none there); on narrow screens it slides the
+// sidebar in over a backdrop.
+const sidebarEl = document.querySelector('.sidebar')
+const sidebarBackdrop = document.getElementById('sidebarBackdrop')
+const mobileMenuBtn = document.getElementById('mobileMenuBtn')
+function setSidebarOpen(open) {
+  if (sidebarEl) sidebarEl.classList.toggle('open', open)
+  if (sidebarBackdrop) sidebarBackdrop.classList.toggle('open', open)
+  if (mobileMenuBtn) mobileMenuBtn.setAttribute('aria-expanded', open ? 'true' : 'false')
+}
+if (mobileMenuBtn) mobileMenuBtn.addEventListener('click', () => setSidebarOpen(!sidebarEl.classList.contains('open')))
+if (sidebarBackdrop) sidebarBackdrop.addEventListener('click', () => setSidebarOpen(false))
+
 navLinks.forEach((link) => {
   link.addEventListener('click', (e) => {
     e.preventDefault()
     switchPage(link.dataset.page)
+    setSidebarOpen(false) // close the drawer after navigating on mobile
   })
 })
 

--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,13 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
+  <div class="mobile-topbar">
+    <button class="mobile-menu-btn" id="mobileMenuBtn" aria-label="Menü" aria-expanded="false">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <span class="mobile-topbar-title">Marveen</span>
+  </div>
+  <div class="sidebar-backdrop" id="sidebarBackdrop"></div>
   <aside class="sidebar">
     <div class="sidebar-brand">
       <div class="sidebar-brand-mark" id="sidebarBrandMark">M</div>

--- a/web/style.css
+++ b/web/style.css
@@ -73,6 +73,66 @@ body {
   padding: 20px 14px;
   z-index: 90;
 }
+
+/* === Mobile shell (hamburger + off-canvas sidebar) === */
+/* On desktop the top bar and backdrop are hidden; the sidebar lives in the
+ * body grid. On narrow screens the body collapses to one column, the sidebar
+ * slides in off-canvas over a backdrop, and a fixed top bar carries the
+ * hamburger -- without this the fixed 220px sidebar column pushed the content
+ * off the right edge of a phone viewport. */
+.mobile-topbar { display: none; }
+.sidebar-backdrop { display: none; }
+@media (max-width: 768px) {
+  body { grid-template-columns: 1fr; }
+  .mobile-topbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    position: sticky;
+    top: 0;
+    z-index: 80;
+    height: 52px;
+    padding: 0 14px;
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+  }
+  .mobile-topbar-title { font-weight: 600; font-size: 15px; }
+  .mobile-menu-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg);
+    color: var(--text);
+    cursor: pointer;
+  }
+  .sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 240px;
+    max-width: 82vw;
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    box-shadow: var(--shadow-lg);
+  }
+  .sidebar.open { transform: translateX(0); }
+  .sidebar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 85;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+  }
+  .sidebar-backdrop.open { opacity: 1; pointer-events: auto; }
+  main { max-width: 100%; padding: 16px 14px 48px; overflow-x: hidden; }
+}
 .sidebar-brand {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Makes the dashboard usable from a phone. The app became reachable remotely, but the UI never collapsed for small screens — the cards ran off the right edge of the viewport.

## ⚠️ Needs on-device approval before merge
The responsive `@media` could **not** be visually validated in this environment (headless Chrome crashes here, and the Quick Look fallback doesn't set a real viewport width). The CSS is standard and the desktop layout is provably untouched (see below), but **please verify on an actual phone before merging** — the reporter has the before screenshots and can confirm the fix.

## What changed (`<=768px` only)
- `body` collapses from the fixed `220px 1fr` grid to a single column — this was the actual overflow cause (the sidebar column kept its 220px and pushed content off-screen).
- The sidebar becomes a fixed **off-canvas drawer** that slides in over a backdrop, toggled by a **hamburger** in a new sticky top bar.
- `main` goes full-width with `overflow-x` guarded.
- Tapping a nav item or the backdrop closes the drawer.

## Desktop is untouched (low risk)
The hamburger top bar and backdrop are `display:none` by default and only appear inside the `@media (max-width: 768px)` block; the sidebar keeps its existing in-grid sticky layout above the breakpoint. So nothing changes for desktop users.

## Scope
Frontend only: `web/style.css` (+60), `web/index.html` (+7), `web/app.js` (+15). No backend/build changes. The pre-existing per-component responsive rules (kanban/agents grids → one column, modals → 95% width) are unchanged and keep working.
