### PR TITLE
fix(channel-reconnect): target Reconnect/Enable instead of blind Down+Enter

### DIFF
--- a/src/__tests__/channel-mcp-reconnect.test.ts
+++ b/src/__tests__/channel-mcp-reconnect.test.ts
@@ -55,7 +55,33 @@ import {
   attemptChannelMcpReconnect,
   resolveAgentSession,
   resolveAgentProviderType,
+  selectedSubmenuLine,
+  chooseSubmenuTarget,
 } from '../web/channel-mcp-reconnect.js'
+
+// Submenu panes Claude Code renders for each plugin state. The `❯` marks the
+// row the cursor sits on when the submenu first opens (top row).
+const SUBMENU_CONNECTED_TOP = [
+  'plugin:telegram:telegram',
+  '❯ View tools',
+  '  Reconnect',
+  '  Disable',
+].join('\n')
+const SUBMENU_CONNECTED_ON_RECONNECT = [
+  'plugin:telegram:telegram',
+  '  View tools',
+  '❯ Reconnect',
+  '  Disable',
+].join('\n')
+const SUBMENU_FAILED_TOP = [
+  'plugin:telegram:telegram',
+  '❯ Reconnect',
+  '  Disable',
+].join('\n')
+const SUBMENU_DISABLED_TOP = [
+  'plugin:telegram:telegram',
+  '❯ Enable',
+].join('\n')
 
 describe('resolveAgentSession', () => {
   it('returns main channels session for main agent', () => {
@@ -78,33 +104,117 @@ describe('resolveAgentProviderType', () => {
   })
 })
 
+describe('selectedSubmenuLine', () => {
+  it('returns the row marked with the cursor', () => {
+    expect(selectedSubmenuLine(SUBMENU_CONNECTED_TOP)).toBe('❯ View tools')
+    expect(selectedSubmenuLine(SUBMENU_FAILED_TOP)).toBe('❯ Reconnect')
+  })
+
+  it('returns null when no cursor is present', () => {
+    expect(selectedSubmenuLine('  View tools\n  Reconnect')).toBeNull()
+  })
+})
+
+describe('chooseSubmenuTarget', () => {
+  it('prefers Reconnect when present', () => {
+    expect(chooseSubmenuTarget(SUBMENU_CONNECTED_TOP)?.source).toBe('reconnect')
+    expect(chooseSubmenuTarget(SUBMENU_FAILED_TOP)?.source).toBe('reconnect')
+  })
+
+  it('falls back to Enable in the disabled state', () => {
+    const t = chooseSubmenuTarget(SUBMENU_DISABLED_TOP)
+    expect(t?.test('❯ Enable')).toBe(true)
+    expect(t?.source).not.toBe('reconnect')
+  })
+
+  it('never targets Disable when no Reconnect/Enable exists', () => {
+    expect(chooseSubmenuTarget('plugin:x\n❯ View tools\n  Disable')).toBeNull()
+  })
+
+  it('does not mistake "Disable" for an Enable target', () => {
+    // \benable\b must not match the "Disable" row.
+    expect(chooseSubmenuTarget('plugin:x\n❯ View tools\n  Disable')).toBeNull()
+  })
+})
+
 describe('attemptChannelMcpReconnect', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('returns ok:true when plugin submenu is found on first Up', () => {
+  it('connected state: steps Down onto Reconnect, then activates it', () => {
     mockCapturePane
-      .mockReturnValueOnce('/mcp menu content')
-      .mockReturnValueOnce('some content with plugin:telegram:telegram listed')
+      .mockReturnValueOnce('/mcp menu content')            // after /mcp
+      .mockReturnValueOnce('plugin:telegram:telegram')     // first loop: matched on Up x1
+      .mockReturnValueOnce(SUBMENU_CONNECTED_TOP)          // submenu capture: cursor on View tools
+      .mockReturnValueOnce(SUBMENU_CONNECTED_ON_RECONNECT) // after one Down: cursor on Reconnect
 
     const result = attemptChannelMcpReconnect('marveen')
 
     expect(result.ok).toBe(true)
+    expect(result.message).toContain('Reconnect')
     expect(result.message).toContain('Up x1')
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      '/usr/local/bin/tmux',
-      ['send-keys', '-t', 'marveen-channels', '/mcp', 'Enter'],
-      expect.any(Object),
+    // Exactly one Enter is sent inside the submenu (the activation).
+    const submenuEnters = mockExecFileSync.mock.calls.filter(
+      (c) => Array.isArray(c[1]) && c[1].includes('Enter') && !c[1].includes('/mcp'),
     )
+    expect(submenuEnters.length).toBeGreaterThanOrEqual(2) // open submenu + activate
   })
 
-  it('returns ok:true when plugin found on third Up', () => {
+  it('failed state: Reconnect is already selected, activates WITHOUT pressing Down', () => {
+    mockCapturePane
+      .mockReturnValueOnce('/mcp menu')
+      .mockReturnValueOnce('plugin:telegram:telegram')
+      .mockReturnValueOnce(SUBMENU_FAILED_TOP) // cursor already on Reconnect
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('Reconnect')
+    // Regression guard: the old code blindly pressed Down here and landed on
+    // "Disable", killing the plugin. No Down may be sent in the submenu.
+    const downCalls = mockExecFileSync.mock.calls.filter(
+      (c) => Array.isArray(c[1]) && c[1].includes('Down'),
+    )
+    expect(downCalls.length).toBe(0)
+  })
+
+  it('disabled state: activates Enable', () => {
+    mockCapturePane
+      .mockReturnValueOnce('/mcp menu')
+      .mockReturnValueOnce('plugin:telegram:telegram')
+      .mockReturnValueOnce(SUBMENU_DISABLED_TOP)
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('Enable')
+  })
+
+  it('never activates when only unsafe options exist (no Reconnect/Enable)', () => {
+    mockCapturePane
+      .mockReturnValueOnce('/mcp menu')
+      .mockReturnValueOnce('plugin:telegram:telegram')
+      .mockReturnValueOnce('plugin:telegram:telegram\n❯ View tools\n  Disable')
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('No Reconnect/Enable')
+    // No Enter is pressed inside the submenu -> Disable can never be triggered.
+    const downCalls = mockExecFileSync.mock.calls.filter(
+      (c) => Array.isArray(c[1]) && c[1].includes('Down'),
+    )
+    expect(downCalls.length).toBe(0)
+  })
+
+  it('finds the plugin on the third Up before opening the submenu', () => {
     mockCapturePane
       .mockReturnValueOnce('/mcp menu')
       .mockReturnValueOnce('no match')
       .mockReturnValueOnce('no match')
-      .mockReturnValueOnce('plugin:telegram:telegram here')
+      .mockReturnValueOnce('plugin:telegram:telegram here') // matched on Up x3
+      .mockReturnValueOnce(SUBMENU_FAILED_TOP)              // submenu: Reconnect selected
 
     const result = attemptChannelMcpReconnect('marveen')
 
@@ -137,6 +247,7 @@ describe('attemptChannelMcpReconnect', () => {
     mockCapturePane
       .mockReturnValueOnce('/mcp')
       .mockReturnValueOnce('plugin:slack-channel:marveen-marketplace found')
+      .mockReturnValueOnce('plugin:slack-channel:marveen-marketplace\n❯ Reconnect\n  Disable')
 
     attemptChannelMcpReconnect('slacker')
 

--- a/src/web/channel-mcp-reconnect.ts
+++ b/src/web/channel-mcp-reconnect.ts
@@ -32,13 +32,58 @@ function getPluginPattern(providerType: ChannelProviderType): RegExp {
   return new RegExp(escaped, 'i')
 }
 
+// Max Down presses we'll spend trying to land the cursor on the target
+// option inside the plugin submenu.
+const SUBMENU_MAX_STEPS = 6
+const RECONNECT_RX = /reconnect/i
+// Word-anchored so it never matches the "Disable" option (which we must
+// never activate). "Disable" contains no "enable" substring anyway, but the
+// boundary keeps intent explicit.
+const ENABLE_RX = /\benable\b/i
+// Claude Code's TUI marks the selected list row with a `❯` cursor (same glyph
+// the input prompt uses -- see pane-state.ts). capture-pane -p strips colour,
+// so this textual marker is our only selection signal.
+const POINTER_RX = /❯/
+
+/** The submenu row currently marked with the `❯` cursor, or null. */
+export function selectedSubmenuLine(pane: string): string | null {
+  for (const raw of pane.split('\n')) {
+    if (POINTER_RX.test(raw)) return raw
+  }
+  return null
+}
+
+/**
+ * Pick which action to drive in the plugin submenu based on what the pane
+ * offers. Prefer "Reconnect"; if the plugin sits in the disabled state only
+ * "Enable" is available. Returns null when neither is present -- in that case
+ * we must NOT press anything, because the remaining option could be "Disable".
+ */
+export function chooseSubmenuTarget(pane: string): RegExp | null {
+  if (RECONNECT_RX.test(pane)) return RECONNECT_RX
+  if (ENABLE_RX.test(pane)) return ENABLE_RX
+  return null
+}
+
 /**
  * Attempt to reconnect a channel MCP plugin by navigating the /mcp
  * menu in the agent's tmux session. Generalises the existing
  * softReconnectMarveen() logic to any agent.
  *
  * Sequence: Escape → /mcp Enter → Up×N until plugin found → Enter →
- * Down (Reconnect) → Enter → Escape.
+ * step the `❯` cursor onto "Reconnect" (or "Enable" when disabled),
+ * verifying after each step → Enter → Escape.
+ *
+ * The submenu option order is STATE-DEPENDENT in Claude Code 2.1.x:
+ *   connected: 1.View tools  2.Reconnect  3.Disable
+ *   failed:    1.Reconnect   ...
+ *   disabled:  1.Enable
+ * The previous logic blindly pressed Down+Enter, assuming "Reconnect" was
+ * always one row down -- true only while connected. In the failed state that
+ * landed on "Disable" and DISABLED the plugin, which then offered only
+ * "Enable" and broke every subsequent retry ("submenu not found"). We now
+ * read the menu and only press Enter once the cursor is confirmed on a safe
+ * target.
  */
 export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
   const session = resolveAgentSession(agentName)
@@ -84,14 +129,51 @@ export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
       return { ok: false, message: `Plugin not found within ${MAX_UP_ATTEMPTS} Up attempts` }
     }
 
-    execFileSync(TMUX, ['send-keys', '-t', session, 'Down'], { timeout: 3000 })
-    execFileSync('/bin/sleep', ['0.3'], { timeout: 1000 })
+    // Inside the plugin submenu now. Drive the cursor onto a safe action
+    // ("Reconnect", or "Enable" when disabled) and only press Enter once it
+    // is confirmed there -- never blindly, which previously hit "Disable".
+    let submenu = capturePane(session)
+    if (!submenu) {
+      logger.warn({ agentName, session }, 'channel-mcp-reconnect: capture failed in submenu')
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
+      return { ok: false, message: 'Failed to capture submenu pane' }
+    }
+
+    const target = chooseSubmenuTarget(submenu)
+    if (!target) {
+      logger.warn({ agentName, session }, 'channel-mcp-reconnect: no Reconnect/Enable option in submenu')
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
+      return { ok: false, message: 'No Reconnect/Enable option in submenu' }
+    }
+
+    let onTarget = false
+    for (let step = 0; step <= SUBMENU_MAX_STEPS; step++) {
+      const sel = selectedSubmenuLine(submenu)
+      if (sel && target.test(sel)) {
+        onTarget = true
+        break
+      }
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Down'], { timeout: 3000 })
+      execFileSync('/bin/sleep', ['0.3'], { timeout: 1000 })
+      submenu = capturePane(session) ?? ''
+    }
+
+    if (!onTarget) {
+      logger.warn(
+        { agentName, session, target: target.source, maxSteps: SUBMENU_MAX_STEPS },
+        'channel-mcp-reconnect: could not place cursor on target option',
+      )
+      execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
+      return { ok: false, message: `Could not select ${target.source} within ${SUBMENU_MAX_STEPS} steps` }
+    }
+
     execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 3000 })
     execFileSync('/bin/sleep', ['2'], { timeout: 4000 })
-
     execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
-    logger.info({ agentName, session, matchedAt, provider: providerType }, 'channel-mcp-reconnect: completed')
-    return { ok: true, message: `Reconnected via /mcp (Up x${matchedAt})` }
+
+    const action = target === RECONNECT_RX ? 'Reconnect' : 'Enable'
+    logger.info({ agentName, session, matchedAt, action, provider: providerType }, 'channel-mcp-reconnect: completed')
+    return { ok: true, message: `Activated ${action} via /mcp (Up x${matchedAt})` }
   } catch (err) {
     logger.warn({ err, agentName, session }, 'channel-mcp-reconnect failed')
     try { execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 }) } catch { /* best effort */ }


### PR DESCRIPTION
## Mi a baj

Az auto-recovery a `/mcp` plugin-submenüt vakon navigálta: belépés után egy `Down` + `Enter`, abban a feltevésben hogy a "Reconnect" mindig egy sorral a top alatt van. Ez csak **connected** állapotban igaz:

| állapot | submenü sorrend | `Down`+`Enter` eredménye |
|---|---|---|
| connected | 1.View tools · 2.Reconnect · 3.Disable | Reconnect ✅ |
| failed | 1.Reconnect · … | a Reconnect ALATTI sor ❌ |
| disabled | 1.Enable | — |

**failed** állapotban (pont amikor a recovery fut) a `Down`+`Enter` a Reconnect alatti pontra esett és **letiltotta** a plugint. A letiltott plugin már csak "Enable"-t kínál, így minden további próbálkozás `submenu not found`-dal elhasalt, és a csatorna halott maradt a hard restartig.

## A fix

A kód most beolvassa a submenüt, kiválaszt egy biztonságos célt ("Reconnect", vagy letiltott állapotban "Enable"), a `❯` kurzort lépésenként ráviszi (minden lépés után ellenőrizve), és CSAK akkor nyom `Enter`-t, ha a kurzor igazoltan a célon áll. A "Disable" sosem kerül kiválasztásra. Sorrend-független, így túléli a Claude Code menü-átrendezéseit.

## Teszt

- connected / failed / disabled submenü-layout
- regressziós őr: failed állapotban NEM nyom `Down`-t (ez tiltotta le korábban a plugint)
- biztonsági ág: ha nincs Reconnect/Enable, semmit nem aktivál (a Disable kizárva)

`vitest`: 19/19 zöld, `tsc --noEmit` tiszta.

> Élesedéshez build + dashboard-restart kell; a futó dashboard még a régi kódot futtatja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)