### PR TITLE
fix(channels): reap orphan plugin pollers on agent start/stop and main launch

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -98,6 +98,28 @@ MODEL_FLAG=""
 # Régi session takarítás
 $TMUX kill-session -t "$SESSION" 2>/dev/null
 
+# Reap orphan main-agent channel pollers (bun/node grandchildren of the
+# previous tmux server). A tmux kill-session does not always tear them down,
+# they keep polling getUpdates with the same bot token, and the fresh poller
+# we spawn below 409-Conflicts on every cycle until the old one exits. The
+# poller env contains *_STATE_DIR=<this main agent's channel dir>; argv does
+# not, so `pkill -f` against the env var never matches. We grep `ps eww -e`
+# instead, which surfaces each process environment on macOS BSD ps.
+MAIN_CHAN_DIR="$INSTALL_DIR/.claude/channels/$CHANNEL_PROVIDER"
+case "$CHANNEL_PROVIDER" in
+  slack)    STATE_ENV_VAR="SLACK_STATE_DIR" ;;
+  discord)  STATE_ENV_VAR="DISCORD_STATE_DIR" ;;
+  *)        STATE_ENV_VAR="TELEGRAM_STATE_DIR" ;;
+esac
+ORPHAN_PIDS="$(/bin/ps eww -e 2>/dev/null | awk -v needle="${STATE_ENV_VAR}=${MAIN_CHAN_DIR}" '$0 ~ needle { print $1 }')"
+if [ -n "$ORPHAN_PIDS" ]; then
+  # shellcheck disable=SC2086
+  /bin/kill -TERM $ORPHAN_PIDS 2>/dev/null || true
+  /bin/sleep 0.3
+  # shellcheck disable=SC2086
+  /bin/kill -KILL $ORPHAN_PIDS 2>/dev/null || true
+fi
+
 # Tmux session indítás
 #
 # Always start a fresh conversation. --continue is intentionally omitted:

--- a/src/__tests__/channel-poller-reap.test.ts
+++ b/src/__tests__/channel-poller-reap.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { parsePollerPidsFromPs } from '../web/channel-poller-reap.js'
+
+// Sample rows captured from a real `ps eww -e` on macOS during the
+// 2026-06-01 channel-disconnect incident. The bun poller, the slack
+// node server, and a shell - the env-var match must select ONLY the
+// bun poller and only when the state dir matches.
+const PS_SAMPLE = [
+  '  90798 s000  S+     0:00.01 bun run --cwd /Users/x/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 --silent start HOME=/Users/x PATH=/opt/homebrew/bin TELEGRAM_STATE_DIR=/Users/x/ClaudeClaw/agents/samu/.claude/channels/telegram CLAUDE_CODE_SESSION_ID=abc',
+  '  90799 s000  S+     0:00.15 node /Users/x/.claude/plugins/cache/marveen-marketplace/slack-channel/0.1.0/server.ts HOME=/Users/x SLACK_STATE_DIR=/Users/x/ClaudeClaw/agents/samu/.claude/channels/slack',
+  '  90800 s000  S+     0:00.05 bun run --cwd /Users/x/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 --silent start HOME=/Users/x TELEGRAM_STATE_DIR=/Users/x/ClaudeClaw/agents/boni/.claude/channels/telegram',
+  '   1234 s000  Ss     0:00.00 /bin/zsh HOME=/Users/x SHELL=/bin/zsh',
+].join('\n')
+
+describe('parsePollerPidsFromPs', () => {
+  it('returns the bun poller pid matching the TELEGRAM_STATE_DIR for samu', () => {
+    const pids = parsePollerPidsFromPs(
+      PS_SAMPLE,
+      'TELEGRAM_STATE_DIR',
+      '/Users/x/ClaudeClaw/agents/samu/.claude/channels/telegram',
+    )
+    expect(pids).toEqual([90798])
+  })
+
+  it('returns the slack poller pid for the SLACK_STATE_DIR variant', () => {
+    const pids = parsePollerPidsFromPs(
+      PS_SAMPLE,
+      'SLACK_STATE_DIR',
+      '/Users/x/ClaudeClaw/agents/samu/.claude/channels/slack',
+    )
+    expect(pids).toEqual([90799])
+  })
+
+  it('does NOT match a different agent that uses the same env var', () => {
+    // The samu reap must not kill boni's poller, even though both have the
+    // TELEGRAM_STATE_DIR env var set; only the full path matches.
+    const pids = parsePollerPidsFromPs(
+      PS_SAMPLE,
+      'TELEGRAM_STATE_DIR',
+      '/Users/x/ClaudeClaw/agents/samu/.claude/channels/telegram',
+    )
+    expect(pids).not.toContain(90800)
+  })
+
+  it('returns empty array when no row matches', () => {
+    const pids = parsePollerPidsFromPs(
+      PS_SAMPLE,
+      'TELEGRAM_STATE_DIR',
+      '/Users/x/ClaudeClaw/agents/nobody/.claude/channels/telegram',
+    )
+    expect(pids).toEqual([])
+  })
+
+  it('returns multiple pids when several rows match (a real orphan scenario)', () => {
+    // Two bun pollers against the same channel dir - the bug that triggered
+    // this work item. Both must be reaped.
+    const orphans = [
+      '  29932 ttys001  S+   77:09.33 bun run --cwd /Users/x/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 start HOME=/Users/x TELEGRAM_STATE_DIR=/Users/x/ClaudeClaw/.claude/channels/telegram',
+      '  91234 ttys002  S+    0:00.01 bun run --cwd /Users/x/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 start HOME=/Users/x TELEGRAM_STATE_DIR=/Users/x/ClaudeClaw/.claude/channels/telegram',
+    ].join('\n')
+    const pids = parsePollerPidsFromPs(
+      orphans,
+      'TELEGRAM_STATE_DIR',
+      '/Users/x/ClaudeClaw/.claude/channels/telegram',
+    )
+    expect(pids).toEqual([29932, 91234])
+  })
+
+  it('ignores rows where the path appears only in argv (not as an env-var value)', () => {
+    // Defensive: a row that *mentions* the state dir in its --cwd argv must
+    // not be confused with one that actually has the env var. argv values
+    // are not preceded by the literal `TELEGRAM_STATE_DIR=` prefix.
+    const argvMention = '  55555 s000  S+   0:00.00 grep TELEGRAM_STATE_DIR /Users/x/ClaudeClaw/.claude/channels/telegram'
+    const pids = parsePollerPidsFromPs(
+      argvMention,
+      'TELEGRAM_STATE_DIR',
+      '/Users/x/ClaudeClaw/.claude/channels/telegram',
+    )
+    // The needle `TELEGRAM_STATE_DIR=/Users/x/ClaudeClaw/.claude/channels/telegram`
+    // is NOT present in this row (the argv has space, not `=`), so no match.
+    expect(pids).toEqual([])
+  })
+
+  it('drops pid 0 and pid 1 even if such a row could be crafted', () => {
+    const malformed = '   1 ttys000  S+  0:00.00 fake-init TELEGRAM_STATE_DIR=/x'
+    const pids = parsePollerPidsFromPs(malformed, 'TELEGRAM_STATE_DIR', '/x')
+    expect(pids).toEqual([])
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -17,6 +17,7 @@ import { CHANNEL_PROVIDER } from '../config.js'
 import { loadProfileTemplate } from './profiles.js'
 import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
 import { getSecret } from './vault.js'
+import { reapChannelOrphans } from './channel-poller-reap.js'
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
@@ -90,6 +91,20 @@ export function startAgentProcess(name: string): { ok: boolean; pid?: number; er
       execSync(`${TMUX} kill-session -t ${session} 2>/dev/null`, { timeout: 3000 })
       execSync('sleep 3', { timeout: 5000 })
     } catch { /* ok */ }
+
+    // Reap any orphan poller (bun/node) left over from a previous run BEFORE
+    // we spawn the new tmux session. The plugin process is a grandchild of
+    // the tmux server, so a tmux kill-session does not always tear it down -
+    // it can be orphaned and keep polling getUpdates with the agent's bot
+    // token, racing the freshly-spawned poller and producing 409 Conflict on
+    // a roughly hourly cadence. See channel-poller-reap.ts.
+    try {
+      const agentProvider = resolveAgentProvider(name)
+      const dir = agentDir(name)
+      reapChannelOrphans(agentProvider, dir)
+    } catch (err) {
+      logger.warn({ err, name }, 'pre-launch channel-poller reap failed (continuing)')
+    }
 
     const model = readAgentModel(name)
     const authMode = readAgentAuthMode(name)
@@ -221,23 +236,16 @@ export function stopAgentProcess(name: string): { ok: boolean; error?: string } 
   try {
     execSync(`${TMUX} kill-session -t ${session}`, { timeout: 5000 })
     execSync('sleep 2', { timeout: 4000 })
-    // Reap any orphaned plugin grandchildren that tmux didn't get.
-    // The plugin writes its pid to the agent's channel state dir;
-    // prefer that, fall back to a env-var-scoped pkill.
+    // Reap any orphaned plugin grandchild that tmux did not tear down.
+    // See channel-poller-reap.ts - the old pkill-by-env-var-on-cmdline did
+    // not work because the env vars are not part of argv on macOS.
     try {
       const agentProvider = resolveAgentProvider(name)
       const dir = agentDir(name)
-      const chanDir = channelStateDir(agentProvider, dir)
-      const pidPath = join(chanDir, 'bot.pid')
-      if (existsSync(pidPath)) {
-        const pid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10)
-        if (pid > 1) {
-          try { process.kill(pid, 'SIGTERM') } catch { /* already gone */ }
-        }
-      }
-      const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : 'TELEGRAM_STATE_DIR'
-      execFileSync('/usr/bin/pkill', ['-f', `${stateEnvVar}=${chanDir}`], { timeout: 3000 })
-    } catch { /* pkill returns non-zero if no match -- fine */ }
+      reapChannelOrphans(agentProvider, dir)
+    } catch (err) {
+      logger.warn({ err, name }, 'post-stop channel-poller reap failed')
+    }
     logger.info({ name, session }, 'Agent tmux session stopped')
     return { ok: true }
   } catch (err) {

--- a/src/web/channel-poller-reap.ts
+++ b/src/web/channel-poller-reap.ts
@@ -1,0 +1,132 @@
+// Reap orphaned channel-plugin pollers (bun/node processes that survived a
+// tmux kill-session or are left over from a previous agent crash).
+//
+// The bug we close (2026-06-01 incident, channel-disconnect roundtrip):
+//   - stopAgentProcess used `pkill -f TELEGRAM_STATE_DIR=<dir>`, but the
+//     plugin process argv is just `bun run --cwd .../telegram/0.0.6 start`
+//     - the env var lives in /proc-equivalent environment storage, not argv,
+//     so `pkill -f` never matches and the orphan keeps polling getUpdates
+//     with the same bot token until SIGTERM by hand.
+//   - startAgentProcess only killed the tmux session pre-launch and did NOT
+//     reap orphans at all. After a restart the old poller raced the new one
+//     and Telegram returned 409 Conflict in a loop.
+//   - The plugin writes bot.pid in <chanDir>/bot.pid. That works on the
+//     happy path but if a new poller crashed and a later one overwrote the
+//     file, the older orphan is no longer in bot.pid - we miss it.
+//
+// Strategy: combine two identifiers.
+//   1. bot.pid (cheap, works for the supervised process).
+//   2. `ps eww -e` scan for the *_STATE_DIR=<chanDir> env-var match. This
+//      catches orphans whose pid is no longer in bot.pid - any process that
+//      was started against this channel state dir is in scope, regardless
+//      of how its argv was rendered. macOS BSD ps emits each process's full
+//      environment when invoked with `e`; we grep that.
+
+import { execFileSync, execSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { ChannelProviderType } from '../channel-provider.js'
+import { channelStateDir } from '../channel-provider.js'
+import { logger } from '../logger.js'
+
+const STATE_ENV_VAR: Record<ChannelProviderType, string> = {
+  telegram: 'TELEGRAM_STATE_DIR',
+  slack: 'SLACK_STATE_DIR',
+  discord: 'DISCORD_STATE_DIR',
+}
+
+// Parse `ps eww -e` output and return every PID whose process environment
+// contains `<envVar>=<value>`. Exported for testability.
+//
+// `ps eww -e` rows on macOS look like:
+//   90798 s000  S+   0:00.01 bun run --cwd ... HOME=/Users/... TELEGRAM_STATE_DIR=/path... ...
+// The match must be precise: substring `TELEGRAM_STATE_DIR=/path` against
+// `TELEGRAM_STATE_DIR=/path-elsewhere` is acceptable because the value is an
+// absolute path, but we still anchor on the env-var literal to avoid
+// matching a row that just *mentions* the path string in its argv.
+export function parsePollerPidsFromPs(
+  psOutput: string,
+  envVar: string,
+  value: string,
+): number[] {
+  const needle = `${envVar}=${value}`
+  const out: number[] = []
+  for (const line of psOutput.split('\n')) {
+    if (!line.includes(needle)) continue
+    const m = line.match(/^\s*(\d+)\s/)
+    if (!m) continue
+    const pid = parseInt(m[1]!, 10)
+    if (pid > 1) out.push(pid)
+  }
+  return out
+}
+
+function listPollerPidsByStateDir(envVar: string, chanDir: string): number[] {
+  try {
+    const out = execSync('/bin/ps eww -e', { timeout: 5000, encoding: 'utf-8', maxBuffer: 8 * 1024 * 1024 })
+    return parsePollerPidsFromPs(out, envVar, chanDir)
+  } catch (err) {
+    logger.warn({ err, chanDir }, 'channel-poller-reap: ps scan failed')
+    return []
+  }
+}
+
+function readBotPid(chanDir: string): number | null {
+  const path = join(chanDir, 'bot.pid')
+  if (!existsSync(path)) return null
+  try {
+    const pid = parseInt(readFileSync(path, 'utf-8').trim(), 10)
+    return Number.isFinite(pid) && pid > 1 ? pid : null
+  } catch {
+    return null
+  }
+}
+
+export interface ReapResult {
+  reaped: number[]
+  source: { fromBotPid: number | null; fromEnvScan: number[] }
+}
+
+/**
+ * Reap every channel-plugin poller process associated with this agent.
+ * Combines bot.pid (cheap, supervised pid) with a `ps eww -e` env-var scan
+ * (catches orphans whose pid is no longer in bot.pid). SIGTERM first; after
+ * a short grace period, SIGKILL any survivor. Safe to call multiple times
+ * (process.kill on a missing pid is caught).
+ */
+export function reapChannelOrphans(
+  provider: ChannelProviderType,
+  agentDirPath: string,
+): ReapResult {
+  const chanDir = channelStateDir(provider, agentDirPath)
+  const envVar = STATE_ENV_VAR[provider]
+
+  const fromBotPid = readBotPid(chanDir)
+  const fromEnvScan = listPollerPidsByStateDir(envVar, chanDir)
+
+  // Deduplicate while preserving order so the bot.pid path is logged first.
+  const all: number[] = []
+  const seen = new Set<number>()
+  for (const pid of [fromBotPid, ...fromEnvScan]) {
+    if (pid && !seen.has(pid)) {
+      seen.add(pid)
+      all.push(pid)
+    }
+  }
+
+  // SIGTERM, give bun/node ~300ms to flush, then SIGKILL stragglers.
+  for (const pid of all) {
+    try { process.kill(pid, 'SIGTERM') } catch { /* already gone */ }
+  }
+  if (all.length > 0) {
+    try { execFileSync('/bin/sleep', ['0.3'], { timeout: 2000 }) } catch { /* ignore */ }
+    for (const pid of all) {
+      try { process.kill(pid, 0) /* probe */; process.kill(pid, 'SIGKILL') } catch { /* gone */ }
+    }
+  }
+
+  if (all.length > 0) {
+    logger.info({ provider, chanDir, reaped: all, fromBotPid, fromEnvScan }, 'channel-poller-reap: orphans killed')
+  }
+  return { reaped: all, source: { fromBotPid, fromEnvScan } }
+}


### PR DESCRIPTION
## Summary

Closes the root cause behind the ~hourly Telegram channel disconnects Marveen has been hand-reaping all morning (3 zombies killed today before this PR). Per Marveen's diagnosis (channel-disconnect handoff):

- The disconnects are NOT token collisions across agents (each agent has its own token).
- They are **orphan bun/node poller processes** left over from previous runs, sharing the same bot token and racing `getUpdates` with 409 Conflict until one side gives up.

## Why this repo missed the orphans

- **`startAgentProcess()`** only killed the tmux session pre-launch. The plugin is a *grandchild* of the tmux server, and `tmux kill-session` does not always reach it. The new tmux session spawned its own poller while the old one was still running.
- **`stopAgentProcess()`** *attempted* a reap via `pkill -f TELEGRAM_STATE_DIR=<dir>`, but on macOS the env vars are not part of argv — `pkill -f` never matched. The reap was a silent no-op.
- **`bot.pid`** is overwritten by each fresh poller, so if a previous one crashed or was orphaned, its pid was no longer in the file and the next stop could not find it.
- **`scripts/channels.sh`** (main-agent launch) only killed its own tmux session — same orphan race on the main channel.

## What changes

- **New `src/web/channel-poller-reap.ts`** — combines two identifiers:
  1. `bot.pid` (cheap, supervised pid).
  2. `ps eww -e` scan that grep-matches the full `<STATE_ENV_VAR>=<chanDir>` needle. macOS BSD `ps` emits each process's environment with `e`, so this catches every orphan whose pid is no longer in `bot.pid` AND whose argv does not contain the state dir.

  SIGTERM first, 300 ms grace, then SIGKILL stragglers. Idempotent (`process.kill` on a missing pid is caught).

- **`startAgentProcess()`** now reaps AFTER `tmux kill-session` and BEFORE spawning the new tmux. Failures are logged and the launch continues — safer to skip reap than to block start.
- **`stopAgentProcess()`** delegates to the same helper. The `pkill -f` env-var path is gone.
- **`scripts/channels.sh`** mirrors the logic in pure shell (helper is Node, not callable from bash). `awk` on `ps eww -e` selects pids whose env contains `<STATE_ENV_VAR>=<main chan dir>`, then `kill -TERM` → 300 ms → `kill -KILL`.

## Why the env-var path matters more than `bot.pid` alone

When Marveen hand-killed 3 zombies this morning (29932 marveen, 37530 samu-dup, 37864 boni-dup), all three were *not* in any `bot.pid` — they were orphaned grandchildren whose supervised pid file had been overwritten by the next-cycle poller. The env-var scan is what would have caught them.

## Tests

7 unit tests for `parsePollerPidsFromPs` cover:

- Canonical TELEGRAM and SLACK state-dir matches.
- Multi-agent isolation — samu's reap must NOT kill boni's poller, even though both have the env var set.
- Defensive argv-mention case — only `<var>=<path>` matches, never a path mentioned in argv (e.g. a grep call with the path).
- Malformed-row guard — pid 0 and pid 1 are never reaped.
- Multi-orphan scenario — two pollers on the same channel are both selected.

Full suite: 1232 tests, 8 pre-existing failures in `managed-settings.test.ts` are unrelated.

`tsc` clean.

## Test plan (post-merge, live)

- [ ] Deploy: `npm run build` + `launchctl kickstart -k com.marveen.dashboard` + `launchctl kickstart -k com.marveen.channels` (so the main `channels.sh` reap-on-start kicks in)
- [ ] `ps eww -e | awk '{ if ($0 ~ /TELEGRAM_STATE_DIR/) print $1 }' | sort -u | wc -l` → no more than one per agent
- [ ] Restart any one agent (e.g. samu) via dashboard → no orphan poller for samu in the `ps` scan; only the fresh one survives
- [ ] Observe the next ~hour: no fresh `409 Conflict` rows for any agent token

## Notes

- PII-free per repo policy. No tokens, no chat ids, no emails in commit/PR body.