### PR TITLE
fix(channel-monitor): reap orphans + dismiss resume-modal + bump grace in stage-3

### DIFF
--- a/src/__tests__/channel-monitor-resume-recovery.test.ts
+++ b/src/__tests__/channel-monitor-resume-recovery.test.ts
@@ -1,0 +1,80 @@
+// Regression tests for the 2026-06-01 channel-recovery stage-3 fix.
+//
+// Background: every Telegram channel disconnect on 2026-06-01 13:09 / 13:51 /
+// 15:03 escalated stage1 -> stage4 (hard restart, context lost), because the
+// stage-3 path (`resumeMarveenSession`) called `tmux respawn-pane -k` but
+// never reaped the orphan bun poller grandchild. The freshly-respawned
+// --continue session raced the still-alive poller for the same bot token,
+// the plugin never reached an inbound-ready state, the recovery timed out
+// after 90s and fell through to the kontextus-losing stage 4.
+//
+// We can't drive a real tmux/launchd interaction from a unit test, so the
+// asserts here are static (read the source) and lock in the structural
+// invariants that the 2026-06-01 fix introduced:
+//   1. reapChannelOrphans is imported and called BEFORE respawn-pane -k.
+//   2. dismissResumeSummaryModalIfPresent is called AFTER respawn-pane -k.
+//   3. RESUME_GRACE_MS is at least 150 seconds (was 90; the 60s
+//      channel-monitor poll plus plugin re-handshake needs the headroom).
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MONITOR_PATH = join(__dirname, '..', 'web', 'channel-monitor.ts')
+
+describe('channel-monitor: stage-3 resumeMarveenSession recovery hardening', () => {
+  const src = readFileSync(MONITOR_PATH, 'utf-8')
+
+  // Slice out the resumeMarveenSession body so unrelated mentions
+  // elsewhere in the file (e.g. comments, sendAlert text) cannot
+  // satisfy these checks by accident.
+  const fnStart = src.indexOf('function resumeMarveenSession')
+  expect(fnStart, 'resumeMarveenSession not found').toBeGreaterThan(0)
+  const fnEnd = src.indexOf('\n}\n', fnStart)
+  expect(fnEnd, 'resumeMarveenSession closing brace not found').toBeGreaterThan(fnStart)
+  const fnBody = src.slice(fnStart, fnEnd)
+
+  it('reapChannelOrphans is imported in channel-monitor', () => {
+    // Cheap guard: a future refactor that drops the symbol from the
+    // import list would leave the function as a TS reference error,
+    // but this assertion surfaces it explicitly with a clearer message.
+    expect(src).toMatch(/import\s*{\s*reapChannelOrphans\s*}\s*from\s*'\.\/channel-poller-reap\.js'/)
+  })
+
+  it('dismissResumeSummaryModalIfPresent is imported from agent-process', () => {
+    expect(src).toMatch(/dismissResumeSummaryModalIfPresent[\s\S]*?from\s*'\.\/agent-process\.js'/)
+  })
+
+  it('reapChannelOrphans is called inside resumeMarveenSession BEFORE the tmux respawn', () => {
+    const reapIdx = fnBody.indexOf('reapChannelOrphans(')
+    const respawnIdx = fnBody.indexOf("'respawn-pane'")
+    expect(reapIdx, 'reapChannelOrphans call missing from resumeMarveenSession').toBeGreaterThan(0)
+    expect(respawnIdx, 'respawn-pane call missing from resumeMarveenSession').toBeGreaterThan(0)
+    // Order matters: the reap must happen first to clear the orphan
+    // before the fresh poller is spawned by the respawn.
+    expect(reapIdx).toBeLessThan(respawnIdx)
+  })
+
+  it('dismissResumeSummaryModalIfPresent is called inside resumeMarveenSession AFTER the tmux respawn', () => {
+    const dismissIdx = fnBody.indexOf('dismissResumeSummaryModalIfPresent(')
+    const respawnIdx = fnBody.indexOf("'respawn-pane'")
+    expect(dismissIdx, 'modal dismiss call missing from resumeMarveenSession').toBeGreaterThan(0)
+    expect(respawnIdx, 'respawn-pane call missing from resumeMarveenSession').toBeGreaterThan(0)
+    // Order matters: dismiss can only run on the fresh TUI that the
+    // respawn just produced. Calling it before respawn would target
+    // the dying parent's pane state.
+    expect(respawnIdx).toBeLessThan(dismissIdx)
+  })
+
+  it('RESUME_GRACE_MS is at least 150 seconds (post-2026-06-01 budget)', () => {
+    // 90s was the pre-fix budget; the new path needs more headroom to
+    // cover the plugin re-handshake. We pin >=150000 to catch a
+    // future refactor that drops it back down to 90s.
+    const m = src.match(/const\s+RESUME_GRACE_MS\s*=\s*([\d_]+)/)
+    expect(m, 'RESUME_GRACE_MS constant not found').not.toBeNull()
+    const value = parseInt((m![1] as string).replace(/_/g, ''), 10)
+    expect(value).toBeGreaterThanOrEqual(150_000)
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -302,7 +302,7 @@ function dismissSurveyModalIfPresent(session: string): void {
 // pick option 1 (Resume from summary, recommended) and Enter to confirm.
 const RESUME_SUMMARY_MODAL_RX = /Resume from summary/
 
-function dismissResumeSummaryModalIfPresent(session: string): void {
+export function dismissResumeSummaryModalIfPresent(session: string): void {
   try {
     const pane = execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
     if (!RESUME_SUMMARY_MODAL_RX.test(pane)) return

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -9,11 +9,13 @@ import {
   agentHasChannel,
   agentSessionName,
   capturePane,
+  dismissResumeSummaryModalIfPresent,
   isAgentRunning,
   sendPromptToSession,
   startAgentProcess,
   stopAgentProcess,
 } from './agent-process.js'
+import { reapChannelOrphans } from './channel-poller-reap.js'
 import { detectPaneState, decidePaneErrorAlert, type PaneErrorAlertState } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
@@ -246,6 +248,21 @@ function readConfiguredMainModel(): string {
 function resumeMarveenSession(): boolean {
   const provider = getProvider(getMainAgentProvider())
   try {
+    // Reap any orphan bun/node poller BEFORE we respawn. `tmux respawn-pane -k`
+    // kills the parent claude process but leaves grandchild pollers running -
+    // see channel-poller-reap.ts for the full background. Without this, the
+    // freshly-respawned --continue session would race a still-alive poller for
+    // the same bot token (409 Conflict on getUpdates) and stage 3 would fail
+    // exactly the way it did 2026-06-01 13:09 / 13:51 / 15:03, forcing the
+    // recovery to fall through to stage 4 hard restart and lose conversation
+    // context. The reap is best-effort: any failure logs and the respawn
+    // continues, because a stale orphan is better than no respawn at all.
+    try {
+      reapChannelOrphans(provider.type, PROJECT_ROOT)
+    } catch (err) {
+      logger.warn({ err }, 'resumeMarveenSession: pre-respawn reap failed (continuing)')
+    }
+
     const model = readConfiguredMainModel()
     const claudeCmd = [
       'export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"',
@@ -264,6 +281,20 @@ function resumeMarveenSession(): boolean {
       `--channels plugin:${provider.pluginId}`,
     ].join(' ')
     execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
+
+    // --continue replays the last conversation. When the prior session is
+    // large (>200k tokens) Claude Code opens with a "Resume from summary"
+    // modal that parks the prompt - the plugin never reaches the inbound-
+    // ready state, detectPaneState stays 'unknown', and stage 3 silently
+    // times out into stage 4. The agent-process startup path already dismisses
+    // this modal; we do the same here so the resume path matches.
+    try {
+      execFileSync('/bin/sleep', ['2'], { timeout: 4000 })
+      dismissResumeSummaryModalIfPresent(MAIN_CHANNELS_SESSION)
+    } catch (err) {
+      logger.warn({ err }, 'resumeMarveenSession: post-respawn modal dismiss failed (continuing)')
+    }
+
     logger.warn({ provider: provider.type }, 'Marveen session respawned with --continue')
     return true
   } catch (err) {
@@ -272,7 +303,13 @@ function resumeMarveenSession(): boolean {
   }
 }
 
-const RESUME_GRACE_MS = 90_000
+// Bumped 90s -> 150s 2026-06-01: --continue + plugin re-init on a
+// large-context session can take past 90s, and the channel-monitor poll only
+// re-evaluates every 60s, so the previous window left ~30s of safety margin
+// before stage 4 fired. With the new reap+modal-dismiss path the resume
+// itself should succeed more often, but the budget still has to cover plugin
+// re-handshake + first getUpdates round-trip on the upstream provider.
+const RESUME_GRACE_MS = 150_000
 let marveenLastHardRestart = 0
 const MARVEEN_HARD_RESTART_GRACE_MS = 120_000
 


### PR DESCRIPTION
## Summary

Closes the 2026-06-01 channel-recovery context-loss thread. Every Telegram disconnect (13:09 / 13:51 / 15:03) escalated stage1 -> stage4, losing conversation context every time, because stage 3 (`resumeMarveenSession`) never reaped the orphan bun poller that survived the `tmux respawn-pane -k`.

Per Marveen's diagnosis-request thread (msg 1523) and her go-ahead with the explicit ask for the modal-dismiss kicker; deploy held for her OK.

## What was wrong

```
stage 1 (soft /mcp reconnect)      → tehetetlen 409-re; the MCP pipe is fine,
                                      the poller-Telegram conn is the problem
stage 2 (memory save)              → cosmetic; just prompts the agent to flush
stage 3 (--continue session resume) → `tmux respawn-pane -k` killed the parent
                                      claude but NOT the orphan bun poller; the
                                      respawned --continue session raced the
                                      orphan for the bot token → 409 Conflict →
                                      plugin never came up → 90s grace elapsed
stage 4 (launchctl hard restart)   → channels.sh now reaps (PR #225) so this
                                      path WORKS, but channels.sh:103 omits
                                      --continue on purpose → context lost
```

The fix closes stage 3 so the recovery does not need to fall through to stage 4 on a typical orphan-induced flap.

## Changes

- **`reapChannelOrphans(provider.type, PROJECT_ROOT)`** runs **before** the `tmux respawn-pane -k` in `resumeMarveenSession`. Uses the existing helper from PR #225 (bot.pid + `ps eww -e` env-var scan + SIGTERM/300ms/SIGKILL).
- **`dismissResumeSummaryModalIfPresent(MAIN_CHANNELS_SESSION)`** runs **after** the respawn. Marveen's session is >200k tokens, so `--continue` opens with a *Resume from summary* modal that parks the prompt; the agent-process startup path already dismisses this and the resume path now mirrors it. `dismissResumeSummaryModalIfPresent` is exported from `agent-process.ts` for this reuse.
- **`RESUME_GRACE_MS`** 90s → 150s. The 60s channel-monitor poll plus the plugin re-handshake on a large context borders on the old budget; the new headroom covers the first-getUpdates round-trip on the upstream provider.

## Tests

New `src/__tests__/channel-monitor-resume-recovery.test.ts` (5 cases), static asserts against the source:

- `reapChannelOrphans` imported from `./channel-poller-reap.js`.
- `dismissResumeSummaryModalIfPresent` imported from `./agent-process.js`.
- **Reap called BEFORE respawn** (ordering: orphan must die first or the 409 race repeats).
- **Modal dismiss called AFTER respawn** (only works on the fresh TUI; pre-respawn it would target the dying parent).
- `RESUME_GRACE_MS >= 150_000`.

1232 existing tests still pass. `tsc` clean.

## Deploy plan (HOLD for Marveen's OK)

The deploy is itself a hard restart of the dashboard (which now serves the new code), so the marveen-channels session keeps running its current channels.sh — the new stage-3 path only fires on the NEXT disconnect. No immediate context loss from the deploy itself. Sequence I'd run, once Marveen says go:

1. `npm run build`
2. `launchctl kickstart -k gui/501/com.marveen.dashboard` (~5s downtime for /api/* )
3. On the next channel flap, verify in `store/dashboard.log`: stage 3 should now log the reap and stay below stage 4.

## Out of scope (PRIO 3, not now)

`channels.sh` `--continue` or a stage 3.5 retry. Marveen and I agreed to wait and see whether the reap + modal dismiss + extended grace are enough to keep recovery off stage 4 in production before reaching for PRIO 3.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/__tests__/channel-monitor-resume-recovery.test.ts` 5/5 pass
- [ ] After deploy + first natural flap: `store/dashboard.log` shows `channel-poller-reap: orphans killed` followed by `Marveen session respawned with --continue` and `Marveen channel plugin recovered` WITHOUT `stage 4 (hard restart)` firing