### PR TITLE
fix(channel-monitor): log Telegram 409 Conflict explicitly on down-detect (Szabi req)

### DIFF
--- a/src/__tests__/channel-conflict-probe.test.ts
+++ b/src/__tests__/channel-conflict-probe.test.ts
@@ -1,0 +1,85 @@
+// Unit tests for the Telegram 409-Conflict diagnostic probe added per Szabi's
+// 2026-06-01 request. The probe runs ONCE per down-cycle and writes the
+// upstream cause to dashboard.log so an operator can distinguish the orphan
+// poller race from a real network/hardware failure.
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { probeTelegramConflict } from '../web/channel-conflict-probe.js'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function mockJsonResponse(status: number, body: unknown): typeof fetch {
+  return (async () => new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })) as unknown as typeof fetch
+}
+
+describe('probeTelegramConflict', () => {
+  it('returns conflicted=true with the description when Telegram answers 409', async () => {
+    // Real Telegram body for this case, verbatim.
+    globalThis.fetch = mockJsonResponse(409, {
+      ok: false,
+      error_code: 409,
+      description: 'Conflict: terminated by other getUpdates request; make sure that only one bot instance is running',
+    })
+    const r = await probeTelegramConflict('test-token')
+    expect(r.conflicted).toBe(true)
+    expect(r.status).toBe(409)
+    expect(r.description).toMatch(/Conflict.*other getUpdates request/)
+  })
+
+  it('returns conflicted=false on 200 OK (normal poll succeeded)', async () => {
+    globalThis.fetch = mockJsonResponse(200, { ok: true, result: [] })
+    const r = await probeTelegramConflict('test-token')
+    expect(r.conflicted).toBe(false)
+    expect(r.status).toBe(200)
+  })
+
+  it('returns conflicted=false on 401 unauthorized (rotated/revoked token, NOT orphan)', async () => {
+    // Distinguish a 401 from a 409 so the operator does not chase the orphan
+    // path when the actual issue is a bad token.
+    globalThis.fetch = mockJsonResponse(401, {
+      ok: false, error_code: 401, description: 'Unauthorized',
+    })
+    const r = await probeTelegramConflict('bad-token')
+    expect(r.conflicted).toBe(false)
+    expect(r.status).toBe(401)
+    expect(r.description).toBe('Unauthorized')
+  })
+
+  it('returns conflicted=false on network failure without throwing', async () => {
+    // The probe runs on the dashboard's sync check loop. A network exception
+    // must not propagate.
+    globalThis.fetch = (async () => { throw new Error('network unreachable') }) as unknown as typeof fetch
+    const r = await probeTelegramConflict('test-token')
+    expect(r.conflicted).toBe(false)
+    expect(r.status).toBe(0)
+    expect(r.description).toBeNull()
+  })
+
+  it('returns conflicted=false on empty token (cheap guard, no HTTP call)', async () => {
+    let called = false
+    globalThis.fetch = (async () => { called = true; return new Response('', { status: 200 }) }) as unknown as typeof fetch
+    const r = await probeTelegramConflict('')
+    expect(r.conflicted).toBe(false)
+    expect(called).toBe(false)
+  })
+
+  it('tolerates a non-JSON 409 body (proxy/CDN interposition)', async () => {
+    // Defensive: still classifies as conflicted on status alone even if the
+    // body cannot be parsed as JSON.
+    globalThis.fetch = (async () => new Response('<html>cf error</html>', {
+      status: 409,
+      headers: { 'Content-Type': 'text/html' },
+    })) as unknown as typeof fetch
+    const r = await probeTelegramConflict('test-token')
+    expect(r.conflicted).toBe(true)
+    expect(r.status).toBe(409)
+    // description may be null because body was not JSON - that's fine
+  })
+})

--- a/src/web/channel-conflict-probe.ts
+++ b/src/web/channel-conflict-probe.ts
@@ -1,0 +1,69 @@
+// Telegram 409 Conflict probe. Used by channel-monitor to confirm and LOG the
+// real cause of a channel disconnect, instead of inferring it from a pane-grep.
+//
+// Background (2026-06-01, Szabi explicit request): the existing health monitor
+// flags the plugin as "down" based on pane scanning - it does not record what
+// the upstream provider actually returned. When the cause is the orphan-poller
+// race fixed by PR #225 (and now stage-3 in the same PR), Telegram returns
+//
+//   409 Conflict
+//   { "ok": false, "error_code": 409,
+//     "description": "Conflict: terminated by other getUpdates request;
+//       make sure that only one bot instance is running" }
+//
+// on every getUpdates call. Without that log line in dashboard.log, an
+// operator (Szabi) cannot distinguish a real network/hardware issue from the
+// orphan-poller bug. This module probes the upstream HTTP API directly with
+// a short-timeout getUpdates call when the monitor first sees a down state,
+// so the dashboard.log carries explicit evidence of the 409.
+
+import { logger } from '../logger.js'
+
+export interface TelegramConflictResult {
+  conflicted: boolean
+  status: number
+  description: string | null
+}
+
+// Short timeout: this runs on the dashboard monitor's poll path. A network-
+// hung Telegram API must NOT delay the next iteration of the check loop.
+const PROBE_TIMEOUT_MS = 4_000
+
+/**
+ * Issues a single bounded getUpdates call against Telegram and reports
+ * whether the upstream signalled a 409 Conflict. Used ONLY for diagnostics:
+ * the result is logged, the channel state is not modified here. Returns
+ * `conflicted: false` for any non-conflict outcome (success, network error,
+ * other 4xx/5xx) so the caller can pick its own escalation.
+ */
+export async function probeTelegramConflict(token: string): Promise<TelegramConflictResult> {
+  if (!token) return { conflicted: false, status: 0, description: null }
+
+  // offset=-1 + timeout=0 = fetch the most recent update without long-poll.
+  // This is the cheapest call that still triggers the 409 if another poller
+  // holds the slot.
+  const url = `https://api.telegram.org/bot${token}/getUpdates?offset=-1&timeout=0`
+
+  const controller = new AbortController()
+  const timeoutHandle = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    const status = res.status
+    let description: string | null = null
+    try {
+      const body = await res.json() as { description?: string; error_code?: number }
+      description = body.description ?? null
+    } catch {
+      // Telegram is consistent about returning JSON even on errors, but a
+      // proxy/CDN interposition could yield non-JSON. Ignore and continue
+      // with status alone.
+    }
+    return { conflicted: status === 409, status, description }
+  } catch (err) {
+    logger.warn({ err }, 'probeTelegramConflict: HTTP probe failed (network/timeout)')
+    return { conflicted: false, status: 0, description: null }
+  } finally {
+    clearTimeout(timeoutHandle)
+  }
+}

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -16,6 +16,7 @@ import {
   stopAgentProcess,
 } from './agent-process.js'
 import { reapChannelOrphans } from './channel-poller-reap.js'
+import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { detectPaneState, decidePaneErrorAlert, type PaneErrorAlertState } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
@@ -197,6 +198,9 @@ interface MarveenDownState {
   lastAlertAt: number
   softAttempts: number
   stageStartedAt?: number
+  // Set once we've issued the diagnostic getUpdates probe for this down-cycle,
+  // so we don't spam the upstream API every poll while recovery is running.
+  conflictProbed?: boolean
 }
 
 const SAVE_WINDOW_MS = 60_000
@@ -346,6 +350,35 @@ function handleMarveenDown(): void {
   if (!marveenDownState) {
     marveenDownState = { downSince: now, stage: 'soft', lastAlertAt: now, softAttempts: 0 }
     logger.warn({ provider: providerLabel }, 'Marveen channel plugin down -- stage 1 (soft /mcp reconnect, silent)')
+    // Diagnostic 409 probe (Telegram only). Fire-and-forget so the sync
+    // check-loop is not blocked on a network call. Logs explicitly when the
+    // upstream returns the orphan-poller's "terminated by other getUpdates
+    // request" message, so dashboard.log carries hard evidence of the real
+    // cause instead of leaving the operator to infer it from a pane scan.
+    if (providerLabel === 'telegram' && !marveenDownState.conflictProbed) {
+      marveenDownState.conflictProbed = true
+      const tokenPath = join(channelStateDir(providerLabel, PROJECT_ROOT), '.env')
+      const tok = readChannelToken(providerLabel, tokenPath)
+      if (tok) {
+        probeTelegramConflict(tok)
+          .then(r => {
+            if (r.conflicted) {
+              logger.warn(
+                { status: r.status, description: r.description },
+                'Telegram getUpdates 409 Conflict confirmed -- orphan poller is contending for the bot token. Recovery will reap and respawn.',
+              )
+            } else if (r.status > 0) {
+              logger.info(
+                { status: r.status, description: r.description },
+                'Telegram getUpdates returned non-409 status on diagnostic probe -- the down state has a different cause than orphan poller contention',
+              )
+            }
+          })
+          .catch(err => {
+            logger.warn({ err }, 'Telegram conflict probe failed to complete')
+          })
+      }
+    }
     if (softReconnectMarveen()) marveenDownState.softAttempts += 1
     return
   }


### PR DESCRIPTION
## Summary

Companion to **#228** (already merged): stage-3 reap + modal-dismiss + grace bump landed without the 409-log piece, because the 409-log commit was pushed AFTER the squash-merge to the same branch. This PR re-lands just the 409-log on top of the freshly-merged main, so the diff is small and reviewable.

Szabi's explicit ask: stronger logging that surfaces the upstream cause of a channel disconnect, so `dashboard.log` carries hard evidence of the orphan poller race instead of leaving the operator to infer it from a pane scan and (incorrectly) suspect hardware.

## What's in the diff

- **New `src/web/channel-conflict-probe.ts`** — `probeTelegramConflict(token)` issues a single timeout-bounded `/getUpdates?offset=-1&timeout=0` call. On 409 Conflict returns the upstream description (`Conflict: terminated by other getUpdates request`). Returns `conflicted=false` for 200 / 401 / network / timeout so callers can distinguish the orphan race from a bad token or a real network failure.
- **`channel-monitor.ts` `handleMarveenDown()` first-entry**: fire-and-forget probe (sync check-loop stays unblocked). New `MarveenDownState.conflictProbed` bit prevents re-firing every poll while recovery runs. Telegram-only.

## Expected output on the next flap

```
WARN: Marveen channel plugin down -- stage 1 (soft /mcp reconnect, silent)
WARN: Telegram getUpdates 409 Conflict confirmed -- orphan poller is
      contending for the bot token. Recovery will reap and respawn.
      description: "Conflict: terminated by other getUpdates request..."
[stage 3 reap fires here -- from #228]
INFO: Marveen session respawned with --continue
INFO: Marveen channel plugin recovered  (no stage 4 hard restart)
```

## Tests (6 new, all pass)

`channel-conflict-probe.test.ts`:
- 409 happy path with description.
- 200 OK classified as not-conflicted.
- 401 unauthorized distinguished from 409 (avoid chasing the orphan path on a bad token).
- Network error caught without throw (probe is sync-loop-safe).
- Empty token short-circuits without HTTP call.
- Non-JSON 409 body still classifies as conflicted on status alone.

`tsc` clean.

## Deploy plan (HOLD; Marveen merges then signals)

Per Marveen's instruction: hold the dashboard restart until this PR is merged so both halves land in the same kickstart. After merge: `git checkout main && git pull && npm run build && launchctl kickstart -k gui/501/com.marveen.dashboard`.