### PR TITLE
fix(channel-monitor): bump RESUME_GRACE_MS 150s -> 240s for large-context resume

### DIFF
--- a/src/__tests__/channel-monitor-resume-recovery.test.ts
+++ b/src/__tests__/channel-monitor-resume-recovery.test.ts
@@ -68,13 +68,15 @@ describe('channel-monitor: stage-3 resumeMarveenSession recovery hardening', () 
     expect(respawnIdx).toBeLessThan(dismissIdx)
   })
 
-  it('RESUME_GRACE_MS is at least 150 seconds (post-2026-06-01 budget)', () => {
-    // 90s was the pre-fix budget; the new path needs more headroom to
-    // cover the plugin re-handshake. We pin >=150000 to catch a
-    // future refactor that drops it back down to 90s.
+  it('RESUME_GRACE_MS is at least 240 seconds (post-2026-06-01-16:31 budget)', () => {
+    // 90s -> 150s -> 240s. The 150s window was empirically insufficient on
+    // a >200k-token --continue session (2026-06-01 16:31 incident); the
+    // resume respawned cleanly but the plugin re-handshake did not finish
+    // inside the window and stage 4 fired. Pin >=240000 to catch a future
+    // refactor that drops the budget back below the observed worst case.
     const m = src.match(/const\s+RESUME_GRACE_MS\s*=\s*([\d_]+)/)
     expect(m, 'RESUME_GRACE_MS constant not found').not.toBeNull()
     const value = parseInt((m![1] as string).replace(/_/g, ''), 10)
-    expect(value).toBeGreaterThanOrEqual(150_000)
+    expect(value).toBeGreaterThanOrEqual(240_000)
   })
 })

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -307,13 +307,15 @@ function resumeMarveenSession(): boolean {
   }
 }
 
-// Bumped 90s -> 150s 2026-06-01: --continue + plugin re-init on a
-// large-context session can take past 90s, and the channel-monitor poll only
-// re-evaluates every 60s, so the previous window left ~30s of safety margin
-// before stage 4 fired. With the new reap+modal-dismiss path the resume
-// itself should succeed more often, but the budget still has to cover plugin
-// re-handshake + first getUpdates round-trip on the upstream provider.
-const RESUME_GRACE_MS = 150_000
+// Grace history: 90s -> 150s -> 240s.
+// 2026-06-01 16:31 incident: with the reap+modal-dismiss path landed,
+// resumeMarveenSession respawned cleanly, but a >200k-token --continue
+// session-load + plugin re-handshake exceeded the 150s window and stage 4
+// fired anyway (context lost). Bumped to 240s so the slowest realistic
+// large-context resume completes inside the window. The monitor polls every
+// 60s, so the effective resolution rounds up to the next poll - 240s gives
+// 3-4 polls' worth of slack before the hard restart escalates.
+const RESUME_GRACE_MS = 240_000
 let marveenLastHardRestart = 0
 const MARVEEN_HARD_RESTART_GRACE_MS = 120_000
 


### PR DESCRIPTION
## Summary

Empirical follow-up to the 2026-06-01 16:31 incident. The reap + modal-dismiss path (#228) landed and ran cleanly — `resumeMarveenSession` respawned with `--continue` at 16:28:51, no orphan was present so the reap was a no-op, no *Resume from summary* modal so the dismiss was a no-op. But the >200k-token session-load + plugin re-handshake did not finish inside the 150s window and stage 4 (launchctl hard restart, context lost) fired anyway at 16:31:48.

Szabi's voice msg 411: *Ez így nem lesz jó, nem elég tartós megoldás* — exactly this. The 240s bump is the short-term safety net; the long-term fix is **PR #226** (kovesdan, *durable Telegram-channel stability*) which addresses the upstream cause by NOT respawning in the first place when a busy session keeps the keep-alive fresh. #226 is being rebased onto the channel-stack PRs that have landed since.

## What changes

- `src/web/channel-monitor.ts`: `RESUME_GRACE_MS = 150_000` → `240_000`. Comment updated with the incident date and the reasoning (monitor poll every 60s, so 240s rounds to 3-4 polls of slack).
- `src/__tests__/channel-monitor-resume-recovery.test.ts`: floor assertion bumped 150_000 → 240_000 so a future "tune this down" refactor flags the regression.

## Why 240s and not 180s or 300s

- **Observed**: 16:28:51 respawn → 16:31:48 stage-4 fire = 177s, and the plugin still wasn't alive when the check fired. So 180s is the lower bound for this hardware + this session size.
- **240s** gives one extra poll boundary of slack (60s × 4 = 240s) without making the recovery feel unresponsive if a *genuinely* dead resume needs to escalate.
- **300s+** would over-correct: a real deafness case would sit five minutes before any escalation.

## Tests

`channel-monitor-resume-recovery.test.ts` (5 cases) still passes with the bumped floor; `tsc` clean.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/__tests__/channel-monitor-resume-recovery.test.ts` 5/5 pass
- [ ] After deploy: next large-context flap should resolve at stage 3 (no stage-4 line in dashboard.log) within ~3 minutes of respawn