### PR TITLE
fix(channels): post-init /mcp unlock for Claude Code 2.1.159 plugin race

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -186,6 +186,38 @@ sleep 1
 $TMUX send-keys -t "$SESSION" "/name ${_bot_name}" Enter
 unset _bot_name
 
+# POST-INIT PLUGIN UNLOCK (2026-06-01 Szabi 15:24 incident workaround):
+# Claude Code 2.1.159 + telegram-plugin 0.0.6: the `--channels` parameter
+# announces "Listening for channel messages from: plugin:telegram@..." in the
+# TUI, but the plugin server itself is NOT always spawned on fresh-session
+# init - it lands in /mcp's Failed state with no bun-poller child. Manually
+# opening /mcp, moving the cursor up to the failed plugin row, and pressing
+# Enter twice (enter submenu, press Reconnect) brings the plugin live -
+# Szabi's empirical sequence that fixed the 16:31 hard-restart aftermath.
+#
+# We replicate that sequence here in the background, idempotently: wait ~15s
+# for Claude Code to settle, then check whether a bun poller scoped to
+# $MAIN_CHAN_DIR is running. If none, fire the unlock keystrokes. The
+# subshell is detached so the main script keeps moving to the wait-loop.
+(
+  sleep 15
+  POST_POLLERS=$(/bin/ps eww -e 2>/dev/null | awk -v needle="${STATE_ENV_VAR}=${MAIN_CHAN_DIR}" '$0 ~ needle { print $1 }' | head -1)
+  if [ -z "$POST_POLLERS" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh post-init: no ${STATE_ENV_VAR} poller for ${MAIN_CHAN_DIR} after 15s, firing /mcp+Up+Enter+Enter unlock" >> "$INSTALL_DIR/store/channels-failures.log"
+    $TMUX send-keys -t "$SESSION" Escape
+    sleep 1
+    $TMUX send-keys -t "$SESSION" "/mcp" Enter
+    sleep 3
+    $TMUX send-keys -t "$SESSION" Up
+    sleep 1
+    $TMUX send-keys -t "$SESSION" Enter
+    sleep 2
+    $TMUX send-keys -t "$SESSION" Enter
+    sleep 4
+    $TMUX send-keys -t "$SESSION" Escape
+  fi
+) &
+
 # Bot menu setup (Telegram only; Slack uses App Manifest)
 if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   "$INSTALL_DIR/scripts/set-bot-menu.sh" &


### PR DESCRIPTION
## Summary

Workaround for the 2026-06-01 16:31 + 17:24 incident. After a launchctl reload of `com.marveen.channels`, the fresh claude session announces *Listening for channel messages from: plugin:telegram@claude-plugins-official* but does NOT spawn the bun-telegram poller as a child. The plugin sits in `/mcp`'s **Failed** state with no inbound path — `reply` tool gone, Marveen unreachable. The other six MCP servers (Gmail, Calendar, Drive, Filesystem, gitnexus, aiam-blog) load normally; only the `--channels`-supplied plugin misses its handshake on Claude Code 2.1.159 + plugin 0.0.6.

Szabi msg 422 sequence (empirical, fixed the live session today): `Esc` → `/mcp Enter` → `Up` → `Enter` → `Enter`. Lands the cursor on the failed plugin row, enters the submenu (default highlight is *Reconnect*), confirms, plugin spawns, getUpdates resumes.

Szabi go (msg 424): *Tedd egyelőre scriptbe, de a legjobb lenne ha le se szakadna.* This is the script half; the *le se szakadna* part is upstream Claude Code 2.1.159 init race that we cannot fix locally.

## What changes

`scripts/channels.sh` gains a backgrounded subshell after `/name`:

```bash
(
  sleep 15
  POST_POLLERS=$(/bin/ps eww -e 2>/dev/null | awk ... STATE_ENV_VAR=MAIN_CHAN_DIR ...)
  if [ -z "$POST_POLLERS" ]; then
    # log + Esc + /mcp Enter + Up + Enter + Enter + Esc
  fi
) &
```

- **Idempotent**: `ps eww -e` env-scan looks for `${STATE_ENV_VAR}=${MAIN_CHAN_DIR}` (the same needle PR #225 introduced for orphan reaping). If the plugin DID spawn cleanly, no keystrokes fire.
- **Bounded**: 15s sleep lets the TUI settle; the keystroke sequence itself is ~10s. The subshell is detached with `&` so the main script's wait-loop keeps running.
- **Audited**: every fire writes a timestamped row to `store/channels-failures.log` so we can see in production how often the workaround is needed.

## Test plan

- [ ] After deploy: next `launchctl kickstart -k com.marveen.channels` should self-heal the plugin within ~30s without manual `/mcp` interaction. Verify `pgrep -fl 'bun.*telegram.*start'` lists a poller scoped to the marveen chan dir; verify `dashboard.log` shows no `Marveen channel plugin down` cascade.
- [ ] If the upstream race ever stops happening, the `if [ -z "$POST_POLLERS" ]` guard makes the block a no-op and `store/channels-failures.log` stops growing.

## Long-term

The Claude Code init race is the real bug. Worth filing an issue against anthropics/claude-code with the reproduction steps. This commit can be reverted once the upstream is fixed.