### PR TITLE
fix(channels): reset keep-alive watchdog baseline on session init

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -186,6 +186,22 @@ sleep 1
 $TMUX send-keys -t "$SESSION" "/name ${_bot_name}" Enter
 unset _bot_name
 
+# Reset the keep-alive watchdog baseline so a session that was just restarted
+# is not immediately judged stale by the dashboard's checkMainKeepaliveStaleness
+# (channel-monitor.ts, ~18min threshold). The dashboard's hardRestartMarveenChannels
+# path writes both files when it triggers the restart, but a manual
+# `launchctl kickstart -k com.marveen.channels` (or the launchd KeepAlive's own
+# restart after a crash) bypasses the dashboard - those code paths never touched
+# the watchdog baseline, and the old mtimes survived into the fresh session,
+# triggering a false-positive respawn loop within minutes (2026-06-01 18:26).
+#
+# touch + epoch-write happens unconditionally here so every channels.sh launch
+# (manual or dashboard-driven) leaves a consistent baseline. The scheduled
+# edit_message keep-alive (every ~6min) takes over from there.
+mkdir -p "$INSTALL_DIR/store"
+touch "$INSTALL_DIR/store/.channel-keepalive"
+date +%s > "$INSTALL_DIR/store/.channel-last-respawn"
+
 # POST-INIT PLUGIN UNLOCK (2026-06-01 Szabi 15:24 incident workaround):
 # Claude Code 2.1.159 + telegram-plugin 0.0.6: the `--channels` parameter
 # announces "Listening for channel messages from: plugin:telegram@..." in the


### PR DESCRIPTION
## Summary

2026-06-01 18:26 incident: 3 minutes after the `launchctl kickstart -k com.marveen.channels` deploy (Szabi msg 430), the dashboard's keep-alive watchdog (`checkMainKeepaliveStaleness`, #226) sent the Telegram alert

> ⚠️ A fő channel keep-alive 26 perce nem frissült -- respawn-pane a marveen-channels session-on (a beszelgetes elveszik, memoria marad).

The freshly restarted session was healthy (bun PID 74298 running, plugin up), but `store/.channel-keepalive` still carried the previous session's last mtime (`Jun 1 18:00:03`). Now=18:26, age=26min, threshold=18min → false-positive respawn-pane would have followed within minutes, losing the just-restarted conversation again.

## Cause

The dashboard's own `hardRestartMarveenChannels` writes `RESPAWN_STAMP_FILE` when *it* triggers a restart, so the dashboard-driven path was always covered. The bypass paths were:

- Manual `launchctl kickstart -k com.marveen.channels` (operator command)
- launchd KeepAlive auto-restart after a process crash

Both spawn a fresh `channels.sh` without going through `hardRestartMarveenChannels`, and never touched the watchdog files. The next dashboard poll sees the stale mtimes from the prior session and fires.

## Fix

`scripts/channels.sh` now touches both files (`.channel-keepalive` mtime and `.channel-last-respawn` epoch) unconditionally after `/name` has been sent. The scheduled `edit_message` keep-alive (~6min cadence) takes over from there during normal operation.

```bash
mkdir -p "$INSTALL_DIR/store"
touch "$INSTALL_DIR/store/.channel-keepalive"
date +%s > "$INSTALL_DIR/store/.channel-last-respawn"
```

Side effect: a launchd back-to-back crash loop also touches the files each time, but the existing rapid-failure counter in `channels-failures.log` + the back-off (60s/300s) kick in before keep-alive maintenance matters.

## Verified

- `bash -n scripts/channels.sh` clean
- Lokálisan az "EMERGENCY" touch (msg 433) megnyugtatta a watchdogot; ez a PR ugyanazt csinálja a session-init-en, automatikusan

## Test plan

- [ ] After deploy: `launchctl kickstart -k com.marveen.channels` does NOT produce the *keep-alive 26 perce nem frissült* alert within the first 18min of the restart
- [ ] `stat store/.channel-keepalive` shows a fresh mtime after each channels.sh launch
- [ ] `cat store/.channel-last-respawn` shows an epoch within seconds of the launch