### PR TITLE
fix(channels): in-process plugin-unlock probe for JS respawn paths

### DIFF
--- a/src/__tests__/channel-plugin-unlock.test.ts
+++ b/src/__tests__/channel-plugin-unlock.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for the in-process post-respawn channel-plugin unlock helper.
+//
+// The unlock keystrokes (/mcp + Up + Enter + Enter) are only safe to deliver
+// when (a) the bun poller is provably ABSENT under the new claude pid and
+// (b) the pane is at the idle bypass-permissions footer. The 2026-06-01 18:55
+// channel-disconnect incident was caused precisely by an unlock-while-already-
+// running cycle that toggled the plugin to `◯ disabled`. These tests pin the
+// safety gates so a future refactor cannot quietly drop them.
+
+const REPO_ROOT = join(__dirname, '../..')
+const HELPER_PATH = join(REPO_ROOT, 'src/web/channel-plugin-unlock.ts')
+const MONITOR_PATH = join(REPO_ROOT, 'src/web/channel-monitor.ts')
+
+const helper = readFileSync(HELPER_PATH, 'utf-8')
+const monitor = readFileSync(MONITOR_PATH, 'utf-8')
+
+describe('channel-plugin-unlock helper contract', () => {
+  it('exports schedulePluginUnlockAfterRespawn for the channel-monitor respawn paths', () => {
+    expect(helper).toMatch(/export\s+function\s+schedulePluginUnlockAfterRespawn\b/)
+  })
+
+  it('gates the keystrokes on the absence of a bun child under the claude pid', () => {
+    // The bun-child probe is the single most important safety check: if a
+    // bun poller is alive, the plugin is running and Up+Enter+Enter would
+    // navigate to "Disable", killing a healthy channel.
+    expect(helper).toMatch(/pgrep/)
+    expect(helper).toMatch(/hasBunChild/)
+    // The unlock keystrokes path must be reachable ONLY when hasBunChild is
+    // false - assert by checking the early-return branch precedes the
+    // keystroke call inside runUnlockProbe.
+    const probeStart = helper.indexOf('function runUnlockProbe')
+    expect(probeStart, 'runUnlockProbe not found').toBeGreaterThan(0)
+    const probeEnd = helper.indexOf('\n}\n', probeStart)
+    const probeBody = helper.slice(probeStart, probeEnd > probeStart ? probeEnd : undefined)
+    const bunIdx = probeBody.indexOf('hasBunChild(')
+    const sendIdx = probeBody.indexOf('sendUnlockKeystrokes(')
+    expect(bunIdx).toBeGreaterThan(0)
+    expect(sendIdx).toBeGreaterThan(bunIdx)
+    // Ensure the hasBunChild branch returns before sendUnlockKeystrokes.
+    const between = probeBody.slice(bunIdx, sendIdx)
+    expect(between).toMatch(/return\b/)
+  })
+
+  it('refuses to send keystrokes if the pane shows a modal or non-idle state', () => {
+    // isSessionReadyForUnlock must reject "Resume from summary" and the
+    // macOS permissions dialog - those signatures mean the keystrokes
+    // would land in the wrong context.
+    expect(helper).toMatch(/Resume from summary/)
+    expect(helper).toMatch(/Open System Settings/)
+    // Idle footer requirement: bypass-permissions string must be present.
+    expect(helper).toMatch(/bypass permissions on/)
+  })
+
+  it('delivers exactly /mcp, Up, Enter, Enter as the unlock sequence', () => {
+    // Pinning the exact 4-key sequence: anything else would either fail
+    // to revive the plugin or risk an unintended menu action.
+    const sendStart = helper.indexOf('function sendUnlockKeystrokes')
+    expect(sendStart, 'sendUnlockKeystrokes not found').toBeGreaterThan(0)
+    const sendEnd = helper.indexOf('\n}\n', sendStart)
+    const sendBody = helper.slice(sendStart, sendEnd > sendStart ? sendEnd : undefined)
+    expect(sendBody).toMatch(/'\/mcp',\s*'Enter'/)
+    // Two stand-alone Enters after Up (open menu, activate first action).
+    const upIdx = sendBody.indexOf("'Up'")
+    expect(upIdx, "'Up' keystroke missing").toBeGreaterThan(0)
+    const afterUp = sendBody.slice(upIdx)
+    // Count standalone Enter keystrokes after Up: must be exactly two.
+    const enterMatches = afterUp.match(/send-keys[^]*?'Enter'\]/g) ?? []
+    expect(enterMatches.length).toBe(2)
+  })
+
+  it('schedules the probe with a cold-start delay >= 25 seconds', () => {
+    // The plugin handshake needs time to complete on cold start; firing
+    // the probe too early would always see no bun and trigger a needless
+    // unlock cycle. Stay >= 25s to comfortably cover the 8s modal +
+    // 5s /name + plugin spawn window observed in channels.sh.
+    const m = helper.match(/const\s+UNLOCK_PROBE_DELAY_MS\s*=\s*([\d_]+)/)
+    expect(m, 'UNLOCK_PROBE_DELAY_MS constant not found').not.toBeNull()
+    const value = parseInt((m![1] as string).replace(/_/g, ''), 10)
+    expect(value).toBeGreaterThanOrEqual(25_000)
+  })
+})
+
+describe('channel-monitor wires the unlock probe into both in-process respawn paths', () => {
+  // The 2026-06-01 18:55 root cause was that channels.sh's post-init unlock
+  // probe (#231/#232) only runs on the launchd start path - the JS respawn
+  // paths (resumeMarveenSession and respawnMarveenSessionFresh) call tmux
+  // respawn-pane directly and skipped channels.sh entirely. Both JS paths
+  // must now call schedulePluginUnlockAfterRespawn after scheduleIdentitySetup
+  // or a Failed/disabled plugin will stay offline indefinitely.
+
+  it('imports schedulePluginUnlockAfterRespawn from channel-plugin-unlock', () => {
+    expect(monitor).toMatch(/from\s+'\.\/channel-plugin-unlock\.js'/)
+    expect(monitor).toMatch(/schedulePluginUnlockAfterRespawn/)
+  })
+
+  function bodyOf(fnName: string): string {
+    const start = monitor.indexOf(`function ${fnName}`)
+    expect(start, `${fnName} not found`).toBeGreaterThan(0)
+    const end = monitor.indexOf('\nfunction ', start + 1)
+    return monitor.slice(start, end > start ? end : undefined)
+  }
+
+  it('resumeMarveenSession schedules the unlock probe after the respawn', () => {
+    const body = bodyOf('resumeMarveenSession')
+    expect(body).toMatch(/schedulePluginUnlockAfterRespawn\(MAIN_CHANNELS_SESSION/)
+  })
+
+  it('respawnMarveenSessionFresh schedules the unlock probe after the respawn', () => {
+    const body = bodyOf('respawnMarveenSessionFresh')
+    expect(body).toMatch(/schedulePluginUnlockAfterRespawn\(MAIN_CHANNELS_SESSION/)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -18,6 +18,7 @@ import {
 } from './agent-process.js'
 import { reapChannelOrphans } from './channel-poller-reap.js'
 import { probeTelegramConflict } from './channel-conflict-probe.js'
+import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import { detectPaneState, decidePaneErrorAlert, type PaneErrorAlertState, type PaneState } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
@@ -331,6 +332,12 @@ function resumeMarveenSession(): boolean {
     // identity is gone after respawn-pane; channels.sh sets it on a normal
     // start). /remote-control was dropped (the operator no longer uses it).
     scheduleIdentitySetup(MAIN_CHANNELS_SESSION, BOT_NAME)
+    // channels.sh runs an /mcp+Up+Enter+Enter unlock probe after launching
+    // the main session to revive a Failed/disabled channel plugin (#231/#232),
+    // but THIS code path skips channels.sh entirely - tmux respawn-pane is
+    // direct. Schedule the same probe in-process so the plugin doesn't get
+    // stuck in `◯ disabled` after an in-process respawn (2026-06-01 18:55).
+    schedulePluginUnlockAfterRespawn(MAIN_CHANNELS_SESSION, provider.type)
     return true
   } catch (err) {
     logger.error({ err }, 'Marveen session respawn failed')
@@ -400,6 +407,12 @@ function respawnMarveenSessionFresh(): boolean {
     logger.warn({ provider: provider.type }, 'Hard restart: marveen session respawned fresh (no --continue)')
     // Re-establish /name on the fresh process (see note in resumeMarveenSession).
     scheduleIdentitySetup(MAIN_CHANNELS_SESSION, BOT_NAME)
+    // Same channels.sh-bypass concern as in resumeMarveenSession: this respawn
+    // path does NOT invoke channels.sh, so the post-init plugin unlock probe
+    // (#231/#232) never runs. Wire it in-process so the keep-alive-watchdog
+    // fresh-respawn path also revives a Failed/disabled plugin instead of
+    // leaving the channel offline until manual intervention.
+    schedulePluginUnlockAfterRespawn(MAIN_CHANNELS_SESSION, provider.type)
     writeRespawnStamp() // coordinate with the systemd-timer watchdog (covers the keepalive path too)
     return true
   } catch (err) {

--- a/src/web/channel-plugin-unlock.ts
+++ b/src/web/channel-plugin-unlock.ts
@@ -1,0 +1,213 @@
+// Post-respawn channel-plugin unlock for in-process tmux respawn-pane paths.
+//
+// scripts/channels.sh already runs an unlock probe after launching the main
+// session (see PR #231 / #232): wait for the bun-poller, and if it never
+// appears, the plugin is stuck in a Failed/disabled state and a manual
+// /mcp + Up + Enter + Enter sequence is the only known revive. That helper
+// covers cold launches (launchd start, manual `launchctl kickstart`).
+//
+// What it does NOT cover: the in-process respawn-pane recovery paths in
+// channel-monitor.ts (resumeMarveenSession and respawnMarveenSessionFresh).
+// Those call `tmux respawn-pane` directly with the claude command, completely
+// bypassing channels.sh - so the post-init unlock never runs. The
+// 2026-06-01 18:55 incident demonstrated this end-to-end: the keep-alive
+// staleness watchdog fired respawnMarveenSessionFresh at 18:55:09, the new
+// session came up cleanly, but the Telegram plugin landed in `◯ disabled`
+// (likely a side-effect of a prior unlock-while-already-running cycle
+// disabling it) and stayed there because no unlock probe was scheduled.
+// The channel was offline for ~6 minutes until manually rescued via /mcp.
+//
+// This module is the in-process equivalent of the channels.sh probe.
+// schedulePluginUnlockAfterRespawn() is fire-and-forget from the JS respawn
+// paths; it waits past the cold-start window, gates on `pgrep -P <claude_pid>
+// bun` (no bun = plugin is not running), and if it needs to act, sends the
+// same /mcp + Up + Enter + Enter sequence. The Up wraps to the bottom of the
+// MCP server list (where plugin:<provider>:<provider> lives), the first Enter
+// opens its action menu, and the second Enter selects whichever first action
+// is offered - "Enable" for disabled, "Reconnect" for failed. Both revive
+// the plugin; the only failure mode (selecting "View tools" or "Disable" on
+// a healthy plugin) is precluded by the bun-absence gate.
+//
+// Same caveat as channels.sh: while the keystrokes are being delivered the
+// session cannot accept other input, but the helper runs in a setTimeout off
+// the recovery thread and only fires once per respawn, so the cost is bounded.
+
+import { execFileSync } from 'node:child_process'
+import { resolveFromPath } from '../platform.js'
+import { logger } from '../logger.js'
+import type { ChannelProviderType } from '../channel-provider.js'
+
+const TMUX = resolveFromPath('tmux')
+
+// Mirror of scripts/channels.sh post-init grace. The plugin handshake
+// (bun spawn + Telegram getMe + sendMessage) usually completes within 15s
+// of the claude TUI being interactive. After scheduleIdentitySetup's
+// 8s modal-dismiss + 5s /name + a ~1s safety buffer, the prompt is ready
+// around T+15s. We wait another 20s on top of that so a healthy plugin
+// has time to write its bot.pid and spawn the bun child before we read.
+// Total: T+35s post-respawn.
+const UNLOCK_PROBE_DELAY_MS = 35_000
+
+// If the bun child still hasn't appeared the first time we look, give it
+// one more grace window before we conclude the plugin is wedged. Some
+// installs see the bun process appear only after the first inbound poll,
+// which can be delayed if Telegram's long-poll happens to be quiet.
+const UNLOCK_PROBE_RETRY_DELAY_MS = 15_000
+const UNLOCK_PROBE_MAX_RETRIES = 2
+
+// Per-keystroke settling delays. Match the channels.sh script: opening /mcp
+// renders the server list (~3s), Up scrolls to the bottom of the list (~1s),
+// the first Enter opens the menu (~2s), the second Enter activates it (~3s).
+const MCP_OPEN_SETTLE_MS = 3000
+const KEYSTROKE_SETTLE_MS = 1500
+
+function getSessionClaudePid(session: string): number | null {
+  try {
+    const raw = execFileSync(TMUX, ['list-panes', '-t', session, '-F', '#{pane_pid}'], {
+      timeout: 3000,
+      encoding: 'utf-8',
+    }).trim().split('\n')[0]
+    const pid = parseInt(raw ?? '', 10)
+    return Number.isFinite(pid) && pid > 1 ? pid : null
+  } catch (err) {
+    logger.warn({ err, session }, 'channel-plugin-unlock: failed to read session claude pid')
+    return null
+  }
+}
+
+// True iff at least one `bun` child is reparented under the claude pid -
+// the plugin spawns its poller as a direct subprocess of the claude main
+// loop, so bun's presence under the claude pid is the most reliable
+// liveness signal we have. Matches the channels.sh `pgrep -P <claude_pid>
+// bun` check so the two paths agree on what "plugin running" means.
+function hasBunChild(claudePid: number): boolean {
+  try {
+    const out = execFileSync('/usr/bin/pgrep', ['-P', String(claudePid), 'bun'], {
+      timeout: 3000,
+      encoding: 'utf-8',
+    }).trim()
+    return out.length > 0
+  } catch {
+    // pgrep exits 1 when there are no matches; treat as "no bun child"
+    return false
+  }
+}
+
+// Captured pane lines we use to refuse the keystrokes. Two safety gates:
+// (a) the session must be at the bypass-permissions footer (the TUI's idle
+// state). If we still see the modal/dialog prompt or the Resume-from-summary
+// screen, the unlock keystrokes would land in the wrong context. (b) we
+// never send keystrokes if `bun` *is* running - that would risk toggling
+// the plugin into Disable, exactly the 2026-06-01 18:55 root cause.
+function isSessionReadyForUnlock(session: string): boolean {
+  try {
+    const pane = execFileSync(TMUX, ['capture-pane', '-t', session, '-p'], {
+      timeout: 3000,
+      encoding: 'utf-8',
+    })
+    // Idle footer: claude renders this footer line once the TUI is ready
+    // for input. Matches the empirical signature used by detectPaneState
+    // for the 'idle' state.
+    if (!/bypass permissions on/.test(pane)) return false
+    // Refuse if any modal is visible.
+    if (/Resume from summary/.test(pane)) return false
+    if (/Open System Settings/.test(pane)) return false
+    return true
+  } catch (err) {
+    logger.warn({ err, session }, 'channel-plugin-unlock: capture-pane failed')
+    return false
+  }
+}
+
+function sendUnlockKeystrokes(session: string): void {
+  try {
+    // Open the MCP dialog. Claude renders the server list within ~2s; the
+    // 3s settle ensures the cursor is on the first item before we move.
+    execFileSync(TMUX, ['send-keys', '-t', session, '/mcp', 'Enter'], { timeout: 5000 })
+    execFileSync('/bin/sleep', [String(MCP_OPEN_SETTLE_MS / 1000)], { timeout: MCP_OPEN_SETTLE_MS + 2000 })
+    // Up wraps to the bottom of the list, where the plugin servers live
+    // (claude lists them last). Built-in MCPs are above Plugin MCPs in the
+    // sort order, so the bottommost entry is the channel plugin we want.
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Up'], { timeout: 5000 })
+    execFileSync('/bin/sleep', [String(KEYSTROKE_SETTLE_MS / 1000)], { timeout: KEYSTROKE_SETTLE_MS + 2000 })
+    // First Enter opens the action menu for the selected MCP server.
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+    execFileSync('/bin/sleep', [String(KEYSTROKE_SETTLE_MS / 1000)], { timeout: KEYSTROKE_SETTLE_MS + 2000 })
+    // Second Enter activates the first action - "Enable" for disabled,
+    // "Reconnect" for failed. Both revive the plugin.
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+    logger.warn({ session }, 'channel-plugin-unlock: sent /mcp+Up+Enter+Enter unlock sequence')
+  } catch (err) {
+    logger.error({ err, session }, 'channel-plugin-unlock: failed to deliver unlock keystrokes')
+  }
+}
+
+interface UnlockProbeState {
+  session: string
+  provider: ChannelProviderType
+  retriesLeft: number
+}
+
+function runUnlockProbe(state: UnlockProbeState): void {
+  const claudePid = getSessionClaudePid(state.session)
+  if (!claudePid) {
+    logger.warn({ session: state.session }, 'channel-plugin-unlock: no claude pid; skipping unlock probe')
+    return
+  }
+
+  if (hasBunChild(claudePid)) {
+    logger.info(
+      { session: state.session, claudePid, provider: state.provider },
+      'channel-plugin-unlock: bun child present, plugin healthy - no unlock needed',
+    )
+    return
+  }
+
+  if (!isSessionReadyForUnlock(state.session)) {
+    if (state.retriesLeft > 0) {
+      logger.info(
+        { session: state.session, retriesLeft: state.retriesLeft },
+        'channel-plugin-unlock: pane not idle yet, retrying',
+      )
+      setTimeout(() => runUnlockProbe({ ...state, retriesLeft: state.retriesLeft - 1 }), UNLOCK_PROBE_RETRY_DELAY_MS)
+      return
+    }
+    logger.warn({ session: state.session }, 'channel-plugin-unlock: pane never reached idle state, abandoning')
+    return
+  }
+
+  logger.warn(
+    { session: state.session, claudePid, provider: state.provider },
+    'channel-plugin-unlock: bun child absent after cold-start window, firing /mcp unlock sequence',
+  )
+  sendUnlockKeystrokes(state.session)
+}
+
+/**
+ * Schedule a post-respawn unlock probe for the main channels session.
+ *
+ * Call this fire-and-forget right after `tmux respawn-pane` in any in-process
+ * recovery path (resumeMarveenSession, respawnMarveenSessionFresh, etc.).
+ * The probe waits for the new claude session to finish cold-starting, then
+ * checks `pgrep -P <claude_pid> bun`:
+ *   - bun child present: plugin healthy, do nothing.
+ *   - bun child absent + idle pane: send /mcp + Up + Enter + Enter to
+ *     enable or reconnect whichever channel plugin is at the bottom of
+ *     the MCP list.
+ *   - bun child absent + non-idle pane: retry up to UNLOCK_PROBE_MAX_RETRIES
+ *     times every UNLOCK_PROBE_RETRY_DELAY_MS before giving up.
+ *
+ * Idempotent across multiple respawns - each call schedules its own setTimeout
+ * and the unlock-keystrokes path is itself gated on bun absence, so a stale
+ * probe from a previous respawn cannot toggle a healthy plugin to Disable.
+ */
+export function schedulePluginUnlockAfterRespawn(session: string, provider: ChannelProviderType): void {
+  setTimeout(
+    () => runUnlockProbe({ session, provider, retriesLeft: UNLOCK_PROBE_MAX_RETRIES }),
+    UNLOCK_PROBE_DELAY_MS,
+  )
+  logger.info(
+    { session, provider, delayMs: UNLOCK_PROBE_DELAY_MS },
+    'channel-plugin-unlock: probe scheduled after respawn',
+  )
+}


### PR DESCRIPTION
## Summary

2026-06-01 18:55 incident: the keep-alive staleness watchdog (#226) fired `respawnMarveenSessionFresh()` cleanly, but the Telegram plugin landed in `◯ disabled` and stayed offline for ~6 min until I manually opened the /mcp menu and re-enabled it. Root cause was an unlock-coverage gap — `scripts/channels.sh` runs the post-init /mcp unlock probe added in #231/#232 to revive a Failed/disabled plugin, but the JS respawn paths in `channel-monitor.ts` (`resumeMarveenSession`, `respawnMarveenSessionFresh`) call `tmux respawn-pane` directly and skip `channels.sh` entirely. No probe → plugin stays wedged.

## Fix

New helper `src/web/channel-plugin-unlock.ts` mirrors the `channels.sh` logic in-process:

- `schedulePluginUnlockAfterRespawn(session, provider)` fires 35s post-respawn (covers the 8s modal-dismiss + 5s `/name` + plugin spawn window).
- Gates STRICTLY on `pgrep -P <claude_pid> bun` (no bun child → plugin is not running) PLUS pane idle on `bypass permissions on` footer. Same dual-gate as #232 — we cannot accidentally toggle a healthy plugin to Disable.
- Refuses if the pane shows `Resume from summary` or `Open System Settings` modal signatures (keystrokes would land in the wrong context).
- Up wraps to the bottom of the MCP list where `plugin:<provider>:<provider>` lives; first Enter opens its action menu; second Enter activates whichever first action is offered — `Enable` for disabled, `Reconnect` for failed. Both revive the plugin.

Wired into both `resumeMarveenSession` and `respawnMarveenSessionFresh` right after `scheduleIdentitySetup`. `hardRestartMarveenChannels` on macOS uses `launchctl unload/load` which DOES go through `channels.sh`, so it inherits the existing probe and needs no change.

## Verified

- 8 new contract tests pass (pin: helper exports, bun-gate ordering, modal-blocker signatures, exact 4-key sequence, ≥25s delay constant, both JS respawn paths wire the probe).
- `npx tsc --noEmit` clean.
- During the 18:55 incident I ran the same /mcp+Up+Enter+Enter sequence by hand — the bun child appeared (PID 84347), Telegram channel restored. Helper implements the same flow with safety gates.

## Test plan

- [ ] After deploy: provoke a keep-alive fresh-respawn (touch `store/.channel-keepalive` back ~20min, dashboard fires `respawnMarveenSessionFresh`) → confirm in `dashboard.log` that the probe scheduled, then either logged `bun child present, plugin healthy` (~35s) OR `firing /mcp unlock sequence` followed by the bun-poller appearing.
- [ ] No false-positive Disable on a healthy session — verify after a normal launchd restart that the probe logs `bun child present` instead of sending keystrokes.

## Related

- #226 (kovesdan keep-alive staleness watchdog — fires the respawn this PR now finishes recovering from)
- #231 / #232 (channels.sh post-init unlock probe — this PR mirrors that into the JS respawn paths)
- #233 (touch keep-alive baseline on channels.sh init — complementary; addresses a different bypass path)