### PR TITLE
fix(channels): widen post-respawn cold-start grace + gate on any-respawn

### DIFF
--- a/src/__tests__/channel-monitor-resume-recovery.test.ts
+++ b/src/__tests__/channel-monitor-resume-recovery.test.ts
@@ -80,3 +80,44 @@ describe('channel-monitor: stage-3 resumeMarveenSession recovery hardening', () 
     expect(value).toBeGreaterThanOrEqual(240_000)
   })
 })
+
+describe('channel-monitor: post-respawn cold-start guard (2026-06-01 480s outage)', () => {
+  // Background: a keepalive fresh-respawn at 17:59:20 was followed by a
+  // down-detect at 18:03 because the post-respawn grace was only 120s -- it
+  // expired while the new large-context session was still booting, so the
+  // recovery cascade (soft->save->resume->hard) stacked THREE restarts onto a
+  // session that was merely cold-starting. downedFor was 480s. The fix widens
+  // the grace and gates the cascade on lastMainRespawnAt() (which folds in the
+  // keepalive-respawn timestamp, not just the hard-restart one).
+  const src = readFileSync(MONITOR_PATH, 'utf-8')
+
+  const fnStart = src.indexOf('function handleMarveenDown')
+  expect(fnStart, 'handleMarveenDown not found').toBeGreaterThan(0)
+  const fnEnd = src.indexOf('\nfunction ', fnStart + 1)
+  const fnBody = src.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined)
+
+  it('post-respawn grace is at least 300 seconds (covers a large-context cold start)', () => {
+    const m = src.match(/const\s+MARVEEN_POST_RESPAWN_GRACE_MS\s*=\s*([\d_]+)/)
+    expect(m, 'MARVEEN_POST_RESPAWN_GRACE_MS constant not found').not.toBeNull()
+    const value = parseInt((m![1] as string).replace(/_/g, ''), 10)
+    expect(value).toBeGreaterThanOrEqual(300_000)
+  })
+
+  it('handleMarveenDown gates on lastMainRespawnAt() so a keepalive respawn also suppresses escalation', () => {
+    // The earlier code gated only on marveenLastHardRestart, which a keepalive
+    // fresh-respawn updated but a future refactor might not. lastMainRespawnAt()
+    // is the single source of truth for "we respawned recently, give it time".
+    expect(fnBody).toMatch(/lastMainRespawnAt\(\)/)
+    expect(fnBody).toMatch(/MARVEEN_POST_RESPAWN_GRACE_MS/)
+  })
+
+  it('the cold-start guard returns BEFORE the cascade creates a down state', () => {
+    // The grace check must short-circuit before the `if (!marveenDownState)`
+    // branch, otherwise a still-booting session would begin stage 1 and stack.
+    const guardIdx = fnBody.indexOf('MARVEEN_POST_RESPAWN_GRACE_MS')
+    const downStateIdx = fnBody.indexOf('if (!marveenDownState)')
+    expect(guardIdx, 'grace guard missing from handleMarveenDown').toBeGreaterThan(0)
+    expect(downStateIdx, 'down-state init missing from handleMarveenDown').toBeGreaterThan(0)
+    expect(guardIdx).toBeLessThan(downStateIdx)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -348,7 +348,17 @@ function resumeMarveenSession(): boolean {
 // 3-4 polls' worth of slack before the hard restart escalates.
 const RESUME_GRACE_MS = 240_000
 let marveenLastHardRestart = 0
-const MARVEEN_HARD_RESTART_GRACE_MS = 120_000
+// Post-respawn cold-start grace. After ANY main-session respawn (keepalive
+// fresh-respawn, stage-3 resume, or stage-4 hard restart) the new claude needs
+// minutes to load its large context and complete the channel-plugin handshake.
+// The 2026-06-01 480s outage was self-inflicted churn: a keepalive fresh-respawn
+// at 17:59:20 was followed by a down-detect at 18:03 because this grace was only
+// 120s -- it expired mid cold-start, so soft->save->resume->hard piled THREE
+// restarts onto a session that was merely still booting. 6 min comfortably
+// covers the slowest realistic cold start while staying under the 18-min
+// keepalive-staleness net, so a session that is genuinely dead after a respawn
+// is still caught by another path.
+const MARVEEN_POST_RESPAWN_GRACE_MS = 360_000
 
 /**
  * B2 fix: shared cross-path grace accessor.
@@ -581,7 +591,15 @@ function sendAlert(text: string): void {
 function handleMarveenDown(): void {
   const now = Date.now()
   const providerLabel = getMainAgentProvider()
-  if (marveenLastHardRestart && now - marveenLastHardRestart < MARVEEN_HARD_RESTART_GRACE_MS) {
+  // Cold-start guard: defer the ENTIRE down cascade while a recent respawn
+  // (from any recovery path -- keepalive fresh-respawn, stage-3 resume, stage-4
+  // hard restart, or the external watchdog's file stamp) is still inside its
+  // boot window. lastMainRespawnAt() folds all three timestamps together, so a
+  // keepalive respawn that did NOT touch marveenLastHardRestart still suppresses
+  // escalation. This is what stops the restart-on-restart stacking that caused
+  // the 2026-06-01 480s outage (see MARVEEN_POST_RESPAWN_GRACE_MS).
+  const lastRespawn = lastMainRespawnAt()
+  if (lastRespawn && now - lastRespawn < MARVEEN_POST_RESPAWN_GRACE_MS) {
     return
   }
   if (!marveenDownState) {


### PR DESCRIPTION
## Summary

2026-06-01 18:03 outage post-mortem. A keep-alive fresh-respawn at 17:59:20 was followed by a down-detect at 18:03:00 — the 120-second `MARVEEN_HARD_RESTART_GRACE_MS` expired mid cold-start of a large-context session, so the recovery cascade (soft → save → resume → hard) ran on a session that was merely still booting. Three restarts piled onto each other; channel down for 480s.

## Fix

1. Grace widened to **6 minutes** (`MARVEEN_POST_RESPAWN_GRACE_MS = 360_000`). Covers the slowest realistic `--continue` cold start while staying under the 18-min keep-alive-staleness net, so a session that is genuinely dead after a respawn is still caught by another path.

2. `handleMarveenDown()` now gates on `lastMainRespawnAt()` instead of just `marveenLastHardRestart`. The keep-alive fresh-respawn updates the in-process counter, but `lastMainRespawnAt()` is the single source of truth that folds in the file-stamp watchdog signal too — so an external respawn (e.g. systemd-timer hard restart) also suppresses the cascade.

3 new contract tests pin the grace value (≥ 300s), the `lastMainRespawnAt()` gate, and the ordering (grace check returns BEFORE the down-state cascade initializes).

## Test plan

- [ ] After deploy: provoke a keep-alive fresh-respawn (touch `store/.channel-keepalive` back ~20min) — confirm in `dashboard.log` that subsequent down-detects within 6 min log "post-respawn grace" suppression instead of starting stage 1.
- [ ] No false-negative: after 6+ min the cascade still fires normally if the session is actually dead.

## Related

- #226 (keep-alive staleness watchdog — the fresh-respawn path that exposed this)
- #234 (in-process plugin unlock — same incident, different recovery gap)
- #233 (touch keep-alive baseline — complementary)