### PR TITLE
fix(channels): Esc+Esc after unlock so pane returns to idle prompt

### DIFF
--- a/src/__tests__/channel-plugin-unlock.test.ts
+++ b/src/__tests__/channel-plugin-unlock.test.ts
@@ -55,21 +55,32 @@ describe('channel-plugin-unlock helper contract', () => {
     expect(helper).toMatch(/bypass permissions on/)
   })
 
-  it('delivers exactly /mcp, Up, Enter, Enter as the unlock sequence', () => {
-    // Pinning the exact 4-key sequence: anything else would either fail
-    // to revive the plugin or risk an unintended menu action.
+  it('delivers /mcp, Up, Enter, Enter then Esc, Esc to back the pane out to idle', () => {
+    // Pinning the full 6-key sequence:
+    //   /mcp + Up + Enter + Enter   -> revive plugin (Enable / Reconnect)
+    //   Esc + Esc                   -> back out of menu so pane returns idle
+    // Both Escapes are required: one for the action menu, one for the
+    // server list. Without them, detectPaneState stays non-idle and every
+    // scheduled task + inter-agent msg piles up "session busy"
+    // (2026-06-01 19:25 incident -- 13 min of dropped traffic).
     const sendStart = helper.indexOf('function sendUnlockKeystrokes')
     expect(sendStart, 'sendUnlockKeystrokes not found').toBeGreaterThan(0)
     const sendEnd = helper.indexOf('\n}\n', sendStart)
     const sendBody = helper.slice(sendStart, sendEnd > sendStart ? sendEnd : undefined)
     expect(sendBody).toMatch(/'\/mcp',\s*'Enter'/)
-    // Two stand-alone Enters after Up (open menu, activate first action).
     const upIdx = sendBody.indexOf("'Up'")
     expect(upIdx, "'Up' keystroke missing").toBeGreaterThan(0)
     const afterUp = sendBody.slice(upIdx)
-    // Count standalone Enter keystrokes after Up: must be exactly two.
+    // Exactly two Enters after Up.
     const enterMatches = afterUp.match(/send-keys[^]*?'Enter'\]/g) ?? []
     expect(enterMatches.length).toBe(2)
+    // Exactly two Escapes after the second Enter.
+    const escapeMatches = afterUp.match(/send-keys[^]*?'Escape'\]/g) ?? []
+    expect(escapeMatches.length).toBe(2)
+    // Order: both Escapes must come AFTER the last Enter.
+    const lastEnterIdx = afterUp.lastIndexOf("'Enter'")
+    const firstEscapeIdx = afterUp.indexOf("'Escape'")
+    expect(firstEscapeIdx).toBeGreaterThan(lastEnterIdx)
   })
 
   it('schedules the probe with a cold-start delay >= 25 seconds', () => {

--- a/src/web/channel-plugin-unlock.ts
+++ b/src/web/channel-plugin-unlock.ts
@@ -60,6 +60,12 @@ const UNLOCK_PROBE_MAX_RETRIES = 2
 // the first Enter opens the menu (~2s), the second Enter activates it (~3s).
 const MCP_OPEN_SETTLE_MS = 3000
 const KEYSTROKE_SETTLE_MS = 1500
+// After the second Enter activates Enable/Reconnect, the plugin handshake
+// takes a moment and Claude Code renders an action confirmation toast.
+// Wait long enough for the toast to settle before Escape, otherwise the
+// first Escape can be swallowed by the toast dismiss instead of backing
+// out of the action menu.
+const POST_UNLOCK_SETTLE_MS = 3000
 
 function getSessionClaudePid(session: string): number | null {
   try {
@@ -136,7 +142,21 @@ function sendUnlockKeystrokes(session: string): void {
     // Second Enter activates the first action - "Enable" for disabled,
     // "Reconnect" for failed. Both revive the plugin.
     execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
-    logger.warn({ session }, 'channel-plugin-unlock: sent /mcp+Up+Enter+Enter unlock sequence')
+    // After activation, the pane stays in the MCP server list (Claude Code
+    // does NOT auto-dismiss to the prompt). detectPaneState reads that as
+    // non-idle, every scheduled tick + inter-agent msg piles up with
+    // "Schedule target session busy" until someone manually presses Esc.
+    // 2026-06-01 19:25 incident: the unlock probe recovered the plugin at
+    // 19:27:16, but the pane stayed wedged in the MCP list until manual
+    // Escape at 19:40 -- 13 minutes of dropped traffic. Escape twice to
+    // back out of both menu levels (action menu -> server list -> idle
+    // prompt), with a settle between so the first Escape lands before
+    // the second arrives.
+    execFileSync('/bin/sleep', [String(POST_UNLOCK_SETTLE_MS / 1000)], { timeout: POST_UNLOCK_SETTLE_MS + 2000 })
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 5000 })
+    execFileSync('/bin/sleep', [String(KEYSTROKE_SETTLE_MS / 1000)], { timeout: KEYSTROKE_SETTLE_MS + 2000 })
+    execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 5000 })
+    logger.warn({ session }, 'channel-plugin-unlock: sent /mcp+Up+Enter+Enter+Esc+Esc unlock sequence')
   } catch (err) {
     logger.error({ err, session }, 'channel-plugin-unlock: failed to deliver unlock keystrokes')
   }


### PR DESCRIPTION
## Summary

2026-06-01 19:25 incident, follow-up to #234. The in-process unlock probe correctly recovered the Telegram plugin at 19:27:16 (`Marveen channel plugin recovered` in dashboard.log) — but the pane stayed wedged in the MCP server list. Claude Code does NOT auto-dismiss the /mcp dialog after Enable/Reconnect: the cursor stays on the server list view, which `detectPaneState` reads as non-idle. Every scheduled tick and inter-agent message logged `Schedule target session busy or has pending input` for the next 13 minutes; one msg even hit `Agent message abandoned: target never ready within window` at 19:32. Manual Escape at 19:40 unblocked it.

## Fix

After the second Enter activates Enable/Reconnect, wait 3s for the action toast to settle, then send **two Escape keystrokes** spaced 1.5s apart. The first backs out of the action menu, the second backs out of the server list, returning the pane to the idle `bypass permissions on` prompt. `detectPaneState` then transitions back to idle on the next read.

Sequence now: `/mcp + Up + Enter + Enter + Esc + Esc`.

## Verified

- 8 tests pass; contract test pins the full 6-key sequence and that both Escapes come AFTER the last Enter.
- `tsc --noEmit` clean.
- Lokálisan a 19:40 kézi Escape ugyanazt csinálta — a pane visszament idle-be, a `Schedule busy` warnings azonnal megszűntek, a backlog feloldódott. Ez a PR ugyanazt automatizálja a probe végén.

## Test plan

- [ ] Provoke another keep-alive fresh-respawn → probe fires unlock → confirm in `dashboard.log` that no `Schedule target session busy` warnings appear after `sent /mcp+Up+Enter+Enter+Esc+Esc unlock sequence`.

## Related

- #234 (in-process plugin unlock — this PR completes its sequence)
- #226 (kovesdan keep-alive watchdog — the fresh-respawn path)