### PR TITLE
fix(channels): stage-1 reconnect picks Enable when plugin status is disabled

### DIFF
--- a/src/__tests__/channel-mcp-reconnect.test.ts
+++ b/src/__tests__/channel-mcp-reconnect.test.ts
@@ -135,7 +135,47 @@ describe('chooseSubmenuTarget', () => {
     // \benable\b must not match the "Disable" row.
     expect(chooseSubmenuTarget('plugin:x\n❯ View tools\n  Disable')).toBeNull()
   })
+
+  it('uses status header as ground truth: disabled status -> Enable even if pane contains the word "reconnect"', () => {
+    // 2026-06-01 20:02 incident: stage 1 logged
+    //   "could not place cursor on target option ... target: reconnect"
+    // while the plugin was actually `◯ disabled`. Cause was a stray
+    // "reconnect" substring elsewhere in the pane (Claude Code's own
+    // footer / scrollback). Status header is now authoritative.
+    const paneWithDisabledStatusAndFooterText = [
+      'Plugin:telegram:telegram MCP Server',
+      '',
+      'Status:           ◯ disabled',
+      '',
+      '❯ 1. Enable',
+      '',
+      '↑/↓ to navigate · Enter to select · Esc to back',
+      '※ Run claude --debug to see error logs / use /mcp to reconnect',
+    ].join('\n')
+    const t = chooseSubmenuTarget(paneWithDisabledStatusAndFooterText)
+    expect(t?.test('Enable')).toBe(true)
+    expect(t?.source).not.toBe('reconnect')
+  })
+
+  it('uses status header: failed status -> Reconnect', () => {
+    const failedPane = [
+      'Plugin:telegram:telegram MCP Server',
+      'Status:           ✗ failed',
+      '❯ 1. Reconnect',
+    ].join('\n')
+    expect(chooseSubmenuTarget(failedPane)?.source).toBe('reconnect')
+  })
+
+  it('handles the ◯/○ glyph variants Claude Code has shipped', () => {
+    const withHollow = 'Status: ○ disabled\n❯ Enable'
+    const withCircled = 'Status: ◯ disabled\n❯ Enable'
+    expect(chooseSubmenuTarget(withHollow)?.source).toBe(ENABLE_RX.source)
+    expect(chooseSubmenuTarget(withCircled)?.source).toBe(ENABLE_RX.source)
+  })
 })
+
+// Re-export the regex for the glyph-variant test (defined in helper file)
+const ENABLE_RX = /\benable\b/i
 
 describe('attemptChannelMcpReconnect', () => {
   beforeEach(() => {

--- a/src/web/channel-mcp-reconnect.ts
+++ b/src/web/channel-mcp-reconnect.ts
@@ -40,6 +40,19 @@ const RECONNECT_RX = /reconnect/i
 // never activate). "Disable" contains no "enable" substring anyway, but the
 // boundary keeps intent explicit.
 const ENABLE_RX = /\benable\b/i
+// Plugin-state markers Claude Code renders in the submenu header line
+// `Status: <glyph> <word>`. We use the STATUS as authoritative when present,
+// because scanning the whole pane for "reconnect"/"enable" is fragile in two
+// ways: (a) Claude Code's own footer line ("Use /mcp to reconnect") triggers
+// a false RECONNECT match even for disabled plugins; (b) action labels can
+// change order across CC versions. Status text is rendered once, plugin-
+// header-line, and is the ground truth for what action menu is offered.
+//   ✔ connected -> View tools / Reconnect / Disable
+//   ✗ failed    -> Reconnect / ...
+//   ◯ disabled  -> Enable
+// The ◯ vs ○ ambiguity is real (Claude Code has shipped both); match either.
+const DISABLED_STATUS_RX = /Status:\s*[◯○]\s*disabled/i
+const FAILED_STATUS_RX = /Status:\s*[✗x×]\s*failed/i
 // Claude Code's TUI marks the selected list row with a `❯` cursor (same glyph
 // the input prompt uses -- see pane-state.ts). capture-pane -p strips colour,
 // so this textual marker is our only selection signal.
@@ -55,11 +68,29 @@ export function selectedSubmenuLine(pane: string): string | null {
 
 /**
  * Pick which action to drive in the plugin submenu based on what the pane
- * offers. Prefer "Reconnect"; if the plugin sits in the disabled state only
- * "Enable" is available. Returns null when neither is present -- in that case
- * we must NOT press anything, because the remaining option could be "Disable".
+ * offers. Authoritative source is the `Status: <glyph> <word>` header that
+ * Claude Code renders for every plugin in the submenu -- because scanning
+ * for the option labels themselves false-positives on CC's own footer text
+ * ("Use /mcp to reconnect", etc.) and pulled stage-1 onto Reconnect even
+ * for disabled plugins (2026-06-01 20:02 incident: "could not place cursor
+ * on target option ... target: reconnect" while the plugin was actually
+ * `◯ disabled` and only an Enable row existed).
+ *
+ *   ◯ disabled -> Enable
+ *   ✗ failed   -> Reconnect
+ *   ✔ connected -> Reconnect (View tools is safe, Disable is forbidden)
+ *
+ * Returns null when neither status nor option label is found -- in that
+ * case we must NOT press anything, because the remaining option could be
+ * "Disable".
  */
 export function chooseSubmenuTarget(pane: string): RegExp | null {
+  // Status-first: ground truth, immune to footer false-positives.
+  if (DISABLED_STATUS_RX.test(pane)) return ENABLE_RX
+  if (FAILED_STATUS_RX.test(pane)) return RECONNECT_RX
+  // Fallback: status header absent (older CC versions or partial captures).
+  // Prefer Reconnect -- if the plugin were truly disabled it would not
+  // expose a Reconnect row, so seeing one means we are NOT disabled.
   if (RECONNECT_RX.test(pane)) return RECONNECT_RX
   if (ENABLE_RX.test(pane)) return ENABLE_RX
   return null


### PR DESCRIPTION
## Summary

Szabi: *"a soft-nál annyit lehetne javítani hogy amennyiben nem failed a plugin hanem disabled akkor ne reconnectet hanem enable-t keressen"*. Yep — the 2026-06-01 20:02 incident proved exactly that bug live.

After the heartbeat sub-agent crashed the live Marveen bun-poller via 409 Conflict, recovery stage 1 (`attemptChannelMcpReconnect`) opened the plugin submenu. Plugin was `◯ disabled` so only `Enable` was offered. But `chooseSubmenuTarget` returned `RECONNECT_RX` — not because a Reconnect row existed but because the literal word "reconnect" showed up elsewhere in the capture-pane content (Claude Code's footer text or scrollback). Stage 1 logged

> `could not place cursor on target option ... target: reconnect`

and recovery fell through to stages 2-4. Stage 2/3 worked (thanks to #234), but the cascade took 2+ minutes when stage 1 alone should have unblocked it in seconds.

## Fix

`chooseSubmenuTarget` now reads the plugin's `Status: <glyph> <word>` header as authoritative:

| Status | Target |
|---|---|
| `◯/○ disabled` | `ENABLE_RX` |
| `✗/×/x failed` | `RECONNECT_RX` |
| `✔ connected` (no status text matched) | `RECONNECT_RX` (fallback by option-label scan) |

Whole-pane scanning stays as fallback for older CC versions that may not render the status line.

## Verified

- 22 reconnect tests pass (4 new):
  - disabled status forces Enable even with "reconnect" footer text present
  - failed status forces Reconnect
  - both `◯` and `○` glyph variants recognised
  - existing "Disable is never targeted" invariants preserved
- `tsc --noEmit` clean.

## Test plan

- [ ] Provoke a Marveen plugin disabled state, watch `dashboard.log` confirm stage 1 logs `Activated Enable via /mcp` instead of falling through to stage 2.
- [ ] No regression on the failed/connected paths.

## Related

- #234 / #236 (in-process unlock + Esc+Esc) — the stage-3 fallback that masked this bug
- #237 (heartbeat isolation) — removes the upstream cause of disabled-state events