### PR TITLE
fix(channels): skip keepalive respawn when channel plugin is alive

### DIFF
--- a/src/__tests__/channel-monitor-keepalive-shortcircuit.test.ts
+++ b/src/__tests__/channel-monitor-keepalive-shortcircuit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const MONITOR_PATH = join(__dirname, '../web/channel-monitor.ts')
+const src = readFileSync(MONITOR_PATH, 'utf-8')
+
+describe('checkMainKeepaliveStaleness: bun-alive short-circuit (2026-06-01 21:18 incident)', () => {
+  // Szabi reported: "óra :18 és :48 kor folyton" stale-keepalive alerts during
+  // quiet conversation periods. Each alert triggered a respawn-pane that
+  // killed the running --continue context for nothing -- the plugin was
+  // perfectly alive, the file just hadn't been touched in 18+ min because
+  // there was no organic inbound traffic. The fix: if the channel plugin's
+  // bun poller is alive under the claude pid, return early; a stale file
+  // with a live poller is a QUIET channel, not a deaf one.
+
+  const fnStart = src.indexOf('function checkMainKeepaliveStaleness')
+  expect(fnStart, 'checkMainKeepaliveStaleness not found').toBeGreaterThan(0)
+  const fnEnd = src.indexOf('\nfunction ', fnStart + 1)
+  const fnBody = src.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined)
+
+  it('probes hasChannelPluginAlive before measuring file staleness', () => {
+    const aliveIdx = fnBody.indexOf('hasChannelPluginAlive(')
+    const ageIdx = fnBody.indexOf('keepaliveAgeMs')
+    expect(aliveIdx, 'hasChannelPluginAlive call missing').toBeGreaterThan(0)
+    expect(ageIdx, 'age calculation missing').toBeGreaterThan(0)
+    expect(aliveIdx).toBeLessThan(ageIdx)
+  })
+
+  it('returns early when the plugin is alive (no respawn for quiet channels)', () => {
+    const aliveIdx = fnBody.indexOf('hasChannelPluginAlive(')
+    // The early-return must come BEFORE shouldRespawnForStaleKeepalive() is consulted.
+    const decisionIdx = fnBody.indexOf('shouldRespawnForStaleKeepalive(')
+    expect(decisionIdx).toBeGreaterThan(aliveIdx)
+    // And there must be a `return` between alive-probe and decision.
+    const between = fnBody.slice(aliveIdx, decisionIdx)
+    expect(between).toMatch(/return\b/)
+  })
+
+  it('fails OPEN (falls through to existing logic) if the liveness probe throws', () => {
+    // A try/catch around the shortcut so a broken pgrep / missing tmux session
+    // never blocks recovery of a genuinely dead session.
+    const aliveIdx = fnBody.indexOf('hasChannelPluginAlive(')
+    const tryIdx = fnBody.lastIndexOf('try {', aliveIdx)
+    expect(tryIdx).toBeGreaterThan(0)
+    // The try-block must end before shouldRespawnForStaleKeepalive
+    const catchIdx = fnBody.indexOf('catch', tryIdx)
+    expect(catchIdx).toBeGreaterThan(0)
+    expect(catchIdx).toBeLessThan(fnBody.indexOf('shouldRespawnForStaleKeepalive('))
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -559,6 +559,31 @@ function checkMainKeepaliveStaleness(): void {
   // SAFETY NET first: let any fresh inbound traffic warm the file before we
   // judge staleness, so a busy-but-alive session is never seen as stale-deaf.
   refreshKeepaliveFromInbound()
+
+  // GROUND-TRUTH SHORTCUT (2026-06-01 21:18 incident): if the channel
+  // plugin's bun poller is ALIVE under Marveen's claude pid, the channel
+  // is healthy by definition -- Telegram traffic CAN reach us. A stale
+  // keepalive file with a live poller is just a quiet conversation, NOT
+  // deafness. Respawning here would kill the session for nothing (Szabi
+  // got "channel keep-alive 18 perce nem frissült" alerts every 30 min
+  // during idle periods, each one losing the running --continue context).
+  // The bun-child check is the same liveness signal channel-plugin-unlock
+  // already uses; reuse it here so the two paths agree on "alive".
+  try {
+    const claudePid = getClaudePidForSession(MAIN_CHANNELS_SESSION)
+    if (claudePid != null) {
+      const provider = getProvider(getMainAgentProvider())
+      if (hasChannelPluginAlive(claudePid, provider.type)) {
+        logger.debug({ claudePid, provider: provider.type }, 'Keepalive stale but channel plugin is alive -- skipping respawn')
+        return
+      }
+    }
+  } catch (err) {
+    // Fail-open: if we couldn't probe liveness, fall through to the
+    // existing staleness path so a genuinely dead session still recovers.
+    logger.debug({ err }, 'Keepalive liveness shortcut probe failed, falling through')
+  }
+
   let ageMs: number | null = null
   try {
     ageMs = Date.now() - statSync(KEEPALIVE_FILE).mtimeMs


### PR DESCRIPTION
## Summary

Szabi: *"Illetve folyton ez jön: ⚠️ A fő channel keep-alive 18 perce nem frissült -- respawn-pane a marveen-channels session-on. Óra 18-kor, óra 48-kor."*

The keep-alive staleness watchdog (#226) is firing twice an hour during **quiet** periods, killing Marveen's `--continue` context for nothing. The plugin is alive, traffic can reach us, the file just hasn't been touched because there's no organic inbound for 18+ min.

`KEEPALIVE_STALE_MS = 18 min` assumes the 6-min scheduled `edit_message` keep-alive is the dominant refresher. But that task is `skipIfBusy: false` for the file-update path and the conversation is genuinely busy when active, so the file ages purely from clock time during quiet stretches. `refreshKeepaliveFromInbound()` warms from inbound, but during organic silence (Szabi away, no other agent pings) there is no inbound to warm with.

## Fix

Before measuring file age, probe `hasChannelPluginAlive()` under the Marveen claude pid. If the bun poller is alive, the channel is healthy by definition — Telegram traffic CAN reach us, so a stale file is just a quiet conversation, not a deaf one. Return early, no respawn.

The bun-child check is the same liveness signal `channel-plugin-unlock` already uses, so the two paths now agree on "alive". Fail-OPEN on probe error: a genuinely dead session still falls through to the existing staleness logic and recovers normally.

## Verified

- 3 contract tests pass: liveness probe order, early-return on alive, try/catch fail-open
- `tsc --noEmit` clean

## Test plan

- [ ] After deploy: idle Marveen for 30+ min → no `keep-alive ... nem frissült` alert (where there used to be one at :18 and :48)
- [ ] Genuine plugin death (kill bun child) → fall-through still respawns

## Related

- #226 (kovesdan watchdog — this completes the busy-skip exemption with a liveness ground truth)
- #234 / #236 (in-process unlock uses the same `pgrep -P bun` liveness signal)