### PR TITLE
fix(dashboard): wire per-agent skills, MCP catalog install-state + 4 more UI controls to backend reality

### DIFF
--- a/src/__tests__/mcp-list-parser.test.ts
+++ b/src/__tests__/mcp-list-parser.test.ts
@@ -4,6 +4,7 @@ import {
   parseMcpList,
   applyRefreshOutcome,
   scrubPaths,
+  catalogMatchesConfigured,
   type McpListEntry,
 } from '../mcp-list-parser.js'
 
@@ -27,6 +28,35 @@ describe('parseMcpListLine -- guard rails', () => {
 
   it('returns null when the status separator is missing', () => {
     expect(parseMcpListLine('name: endpoint only')).toBeNull()
+  })
+})
+
+describe('catalogMatchesConfigured -- catalog vs .mcp.json server names', () => {
+  it('matches a catalog id against an exact configured slug', () => {
+    expect(catalogMatchesConfigured('slack', 'slack', ['slack'])).toBe(true)
+  })
+
+  it('matches the "<id>-<variant>" convention (gmail -> gmail-egov / gmail-personal)', () => {
+    const configured = ['gmail-egov', 'gmail-personal']
+    expect(catalogMatchesConfigured('gmail', 'gmail', configured)).toBe(true)
+  })
+
+  it('matches on the name slug when the id slug differs', () => {
+    expect(catalogMatchesConfigured('gdrive', 'google-drive', ['google-drive-work'])).toBe(true)
+  })
+
+  it('does not match an unrelated server that merely shares a prefix without the hyphen', () => {
+    // "githubby" must not satisfy catalog id "github" -- only "github" or
+    // "github-..." counts.
+    expect(catalogMatchesConfigured('github', 'github', ['githubby'])).toBe(false)
+  })
+
+  it('returns false when nothing is configured', () => {
+    expect(catalogMatchesConfigured('gmail', 'gmail', [])).toBe(false)
+  })
+
+  it('ignores empty id/name slugs so a blank catalog field cannot match everything', () => {
+    expect(catalogMatchesConfigured('', '', ['anything', 'else'])).toBe(false)
   })
 })
 

--- a/src/mcp-list-parser.ts
+++ b/src/mcp-list-parser.ts
@@ -56,6 +56,27 @@ export function slugify(raw: string): string {
     .replace(/^-+|-+$/g, '')
 }
 
+// Decide whether an MCP catalog entry (identified by its slug id and/or slug
+// name) is satisfied by one of the MCP server names actually configured in the
+// fleet's .mcp.json files. A user installs the catalog's "gmail" entry but
+// names the servers "gmail-egov" / "gmail-personal"; the exact-id check the
+// catalog used to do never matched those, so a working connector showed as
+// "telepítésre vár". Match rule: exact slug equality, or the "<id>-<variant>"
+// convention. The hyphen guard keeps "github" from matching a configured
+// "github-actions-runner" only when intended -- a bare "<id>" prefix without
+// the trailing hyphen (e.g. "githubby") never matches.
+export function catalogMatchesConfigured(
+  idSlug: string,
+  nameSlug: string,
+  configuredSlugs: Iterable<string>,
+): boolean {
+  for (const s of configuredSlugs) {
+    if (idSlug && (s === idSlug || s.startsWith(idSlug + '-'))) return true
+    if (nameSlug && (s === nameSlug || s.startsWith(nameSlug + '-'))) return true
+  }
+  return false
+}
+
 function classifyName(raw: string): { source: McpListSource; normalizedId: string } {
   const trimmed = raw.trim()
   // "plugin:<package>:<name>" -- the trailing segment is the actual

--- a/src/web/routes/agents-skills.ts
+++ b/src/web/routes/agents-skills.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, mkdirSync, writeFileSync, unlinkSync, rmSync, statSync, lstatSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, unlinkSync, rmSync, statSync, lstatSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { randomUUID } from 'node:crypto'
@@ -24,6 +24,45 @@ function skillsRootFor(name: string): string {
 }
 function agentExistsFor(name: string): boolean {
   return name === MAIN_AGENT_ID || existsSync(agentDir(name))
+}
+
+// Pull the `description:` field out of a skill's SKILL.md YAML frontmatter so
+// the dashboard can show what each skill does. Best-effort: single-line value,
+// quotes trimmed, capped so a malformed file can't bloat the response.
+function readSkillDescription(skillDir: string): string {
+  try {
+    const md = readFileSync(join(skillDir, 'SKILL.md'), 'utf-8')
+    const fm = md.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+    const block = fm ? fm[1] : md.slice(0, 600)
+    const m = block.match(/^description:\s*(.+)$/m)
+    if (!m) return ''
+    return m[1].trim().replace(/^["']|["']$/g, '').slice(0, 300)
+  } catch {
+    return ''
+  }
+}
+
+type AgentSkill = {
+  name: string
+  hasSkillMd: boolean
+  description: string
+  source: 'agent' | 'global'
+  deletable: boolean
+}
+
+// List the skill directories under `dir`, tagging each with where it came from
+// and whether it can be deleted from this agent's view.
+function scanSkillDir(dir: string, source: 'agent' | 'global', deletable: boolean): AgentSkill[] {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir)
+    .filter((f) => { try { return statSync(join(dir, f)).isDirectory() } catch { return false } })
+    .map((f) => ({
+      name: f,
+      hasSkillMd: existsSync(join(dir, f, 'SKILL.md')),
+      description: readSkillDescription(join(dir, f)),
+      source,
+      deletable,
+    }))
 }
 
 export async function tryHandleAgentsSkills(ctx: RouteContext): Promise<boolean> {
@@ -138,12 +177,23 @@ export async function tryHandleAgentsSkills(ctx: RouteContext): Promise<boolean>
   if (skillsMatch && method === 'GET') {
     const name = decodeURIComponent(skillsMatch[1])
     if (!agentExistsFor(name)) { json(res, { error: 'Agent not found' }, 404); return true }
-    const skillsDir = skillsRootFor(name)
-    let skills: { name: string; hasSkillMd: boolean }[] = []
-    if (existsSync(skillsDir)) {
-      skills = readdirSync(skillsDir)
-        .filter((f) => { try { return statSync(join(skillsDir, f)).isDirectory() } catch { return false } })
-        .map((f) => ({ name: f, hasSkillMd: existsSync(join(skillsDir, f, 'SKILL.md')) }))
+    const globalRoot = join(homedir(), '.claude', 'skills')
+    let skills: AgentSkill[]
+    if (name === MAIN_AGENT_ID) {
+      // The main agent's skill root IS the global ~/.claude/skills dir; these
+      // skills physically live there and are deletable from this view.
+      skills = scanSkillDir(skillsRootFor(name), 'global', true)
+    } else {
+      // Sub-agents own a small agents/<name>/.claude/skills set (deletable) but
+      // at runtime ALSO inherit every global ~/.claude/skills entry. The old
+      // endpoint only scanned the agent-local dir, so the tab looked empty even
+      // though the agent had ~36 inherited skills available. List both; the
+      // inherited ones are not deletable from a single agent's view (they are
+      // shared) and a local skill shadows a global one of the same name.
+      const local = scanSkillDir(skillsRootFor(name), 'agent', true)
+      const localNames = new Set(local.map((s) => s.name))
+      const inherited = scanSkillDir(globalRoot, 'global', false).filter((s) => !localNames.has(s.name))
+      skills = [...local, ...inherited]
     }
     json(res, skills)
     return true

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -6,6 +6,7 @@ import { PROJECT_ROOT, OLLAMA_URL } from '../../config.js'
 import { logger } from '../../logger.js'
 import {
   slugify as slugifyMcp,
+  catalogMatchesConfigured,
   type McpListEntry,
 } from '../../mcp-list-parser.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
@@ -50,6 +51,37 @@ function loadMcpCatalog(): any[] {
   for (const item of central) byId.set(String(item.id), item)
   for (const item of readLocalCatalog()) byId.set(String(item.id), item)
   return [...byId.values()]
+}
+
+// Slugs of every MCP server declared in a .mcp.json / .claude.json the fleet
+// can see. The mcp-list cache (`claude mcp list`) only reflects servers Claude
+// Code has actually spawned this run, and a catalog id ("gmail") rarely equals
+// the server name a user chose ("gmail-egov", "gmail-personal"). Collecting the
+// configured names lets the catalog mark an entry installed by exact id or the
+// "<id>-<variant>" naming convention, so a working, configured connector stops
+// showing as "telepítésre vár".
+function collectConfiguredServerSlugs(): Set<string> {
+  const slugs = new Set<string>()
+  const files = [
+    join(PROJECT_ROOT, '.mcp.json'),
+    join(homedir(), '.claude.json'),
+  ]
+  for (const agentName of listAgentNames()) {
+    files.push(join(AGENTS_BASE_DIR, agentName, '.mcp.json'))
+  }
+  for (const extPath of getExternalProjectPaths()) {
+    files.push(join(extPath, '.mcp.json'))
+  }
+  for (const f of files) {
+    try {
+      const parsed = JSON.parse(readFileOr(f, '{}'))
+      for (const name of Object.keys(parsed.mcpServers || {})) {
+        const s = slugifyMcp(name)
+        if (s) slugs.add(s)
+      }
+    } catch { /* ignore unreadable / malformed config */ }
+  }
+  return slugs
 }
 
 // Persist a user-installed MCP into the gitignored local catalog so it shows up
@@ -522,15 +554,29 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
           installedSource.set(entry.normalizedId, entry.source)
         }
       }
+      // Servers configured in .mcp.json files count as installed too, even when
+      // the mcp-list cache misses them or names them differently from the
+      // catalog id (e.g. "gmail-egov" / "gmail-personal" for catalog id "gmail").
+      const configuredSlugs = collectConfiguredServerSlugs()
 
       const result = catalog.map(item => {
         const itemId = slugifyMcp(String(item.id ?? ''))
         const itemNameSlug = slugifyMcp(String(item.name ?? ''))
-        const source = installedSource.get(itemId) || installedSource.get(itemNameSlug)
+        let source = installedSource.get(itemId) || installedSource.get(itemNameSlug)
+        // configMatch flags entries detected only via .mcp.json. They are
+        // installed under a custom server name, so the catalog's generic-id
+        // uninstall (`claude mcp remove <id>`) would not target them -- the
+        // frontend hides the uninstall link and points at the Connectors list.
+        let configMatch = false
+        if (source === undefined && catalogMatchesConfigured(itemId, itemNameSlug, configuredSlugs)) {
+          source = 'local'
+          configMatch = true
+        }
         return {
           ...item,
           installed: source !== undefined,
           installedSource: source,
+          configMatch,
         }
       })
 

--- a/web/app.js
+++ b/web/app.js
@@ -2805,25 +2805,36 @@ async function loadSkills(agentName) {
     for (const skill of skills) {
       const item = document.createElement('div')
       item.className = 'skill-item'
+      // Inherited global skills (~/.claude/skills) are shared across every
+      // agent, so they get a badge and no per-agent delete button -- only the
+      // agent's own local skills are deletable from this view.
+      const isGlobal = skill.source === 'global'
+      const badge = isGlobal
+        ? '<span class="skill-item-badge" title="Globális skill, minden agent örökli">globális</span>'
+        : ''
+      const deletable = skill.deletable !== false
       item.innerHTML = `
         <div class="skill-item-info">
-          <div class="skill-item-name">${escapeHtml(skill.name)}</div>
+          <div class="skill-item-name">${escapeHtml(skill.name)}${badge}</div>
           ${skill.description ? `<div class="skill-item-desc">${escapeHtml(skill.description)}</div>` : ''}
         </div>
         <div class="skill-item-actions">
-          <button class="btn-icon btn-icon-danger" title="Törlés">${trashIcon()}</button>
+          ${deletable ? `<button class="btn-icon btn-icon-danger" title="Törlés">${trashIcon()}</button>` : ''}
         </div>
       `
-      item.querySelector('.btn-icon-danger').addEventListener('click', async () => {
-        if (!confirm(`Skill törlése: ${skill.name}?`)) return
-        try {
-          await fetch(`/api/agents/${encodeURIComponent(agentName)}/skills/${encodeURIComponent(skill.name)}`, { method: 'DELETE' })
-          showToast('Skill törölve')
-          loadSkills(agentName)
-        } catch {
-          showToast('Hiba a törlés során')
-        }
-      })
+      const delBtn = item.querySelector('.btn-icon-danger')
+      if (delBtn) {
+        delBtn.addEventListener('click', async () => {
+          if (!confirm(`Skill törlése: ${skill.name}?`)) return
+          try {
+            await fetch(`/api/agents/${encodeURIComponent(agentName)}/skills/${encodeURIComponent(skill.name)}`, { method: 'DELETE' })
+            showToast('Skill törölve')
+            loadSkills(agentName)
+          } catch {
+            showToast('Hiba a törlés során')
+          }
+        })
+      }
       listEl.appendChild(item)
     }
   } catch {
@@ -4979,7 +4990,7 @@ function renderCatalog() {
       </div>
       <div class="catalog-card-footer">
         ${item.installed
-          ? `<span class="catalog-install-btn installed" title="Forrás: ${escapeHtml(item.installedSource || 'ismeretlen')}">Telepítve &#10003;${item.installedSource === 'claude.ai' ? ' (claude.ai)' : item.installedSource === 'plugin' ? ' (plugin)' : ''}</span>${item.installedSource === 'claude.ai' ? '' : `<a class="catalog-uninstall-link" data-id="${item.id}">Eltávolítás</a>`}`
+          ? `<span class="catalog-install-btn installed" title="${item.configMatch ? 'Bekötve a .mcp.json-ban (a Connectors listán kezelhető)' : 'Forrás: ' + escapeHtml(item.installedSource || 'ismeretlen')}">Telepítve &#10003;${item.configMatch ? ' (.mcp.json)' : item.installedSource === 'claude.ai' ? ' (claude.ai)' : item.installedSource === 'plugin' ? ' (plugin)' : ''}</span>${(item.installedSource === 'claude.ai' || item.configMatch) ? '' : `<a class="catalog-uninstall-link" data-id="${item.id}">Eltávolítás</a>`}`
           : `<button class="catalog-install-btn install" data-id="${item.id}">Telepítés</button>${authHint}`
         }
       </div>

--- a/web/app.js
+++ b/web/app.js
@@ -720,11 +720,16 @@ async function showCardDetail(card) {
     }
   } catch { /* ignore */ }
 
-  // Author select for new comment. Default to the human owner "Gábor" -- a
-  // value that actually exists in the assignee list, so the select never falls
-  // back to the empty "-- Nincs --" option (which silently produced author=""
-  // -> server 400 -> a lost comment).
-  populateAssigneeSelect('commentAuthor', 'Gábor')
+  // Author select for new comment. Default to the bot assignee resolved by
+  // type (never a hard-coded display name -- BOT_NAME differs per deployment),
+  // falling back to the first assignee. The old literal 'Marveen' never matched
+  // on non-Marveen installs, so the select stayed on "-- Nincs --" and the
+  // comment submit silently no-opped (addCommentBtn returns when !author).
+  // (Resolution of the #254/#241 overlap: keep #241's type-resolved default
+  // over #254's hard-coded "Gábor" -- same deployment-agnostic reasoning.)
+  const defaultCommentAuthor =
+    (kanbanAssignees.find((a) => a.type === 'bot') || kanbanAssignees[0] || {}).name || ''
+  populateAssigneeSelect('commentAuthor', defaultCommentAuthor)
 
   // Add comment
   document.getElementById('addCommentBtn').onclick = async () => {
@@ -7578,6 +7583,9 @@ async function loadRecallPage() {
     document.getElementById('recallBtn').addEventListener('click', doRecall)
     document.getElementById('recallExpr').addEventListener('keydown', e => { if (e.key === 'Enter') doRecall() })
     document.getElementById('recallSearch').addEventListener('keydown', e => { if (e.key === 'Enter') doRecall() })
+    // Re-fetch per-agent log dates when the agent filter changes; without this
+    // the date hint stayed stuck on the agent active at first page load.
+    document.getElementById('recallAgent').addEventListener('change', loadRecallDates)
 
     loadRecallDates()
   }
@@ -7714,14 +7722,17 @@ async function loadBgTasksPage() {
   if (!bgInitialized) {
     bgInitialized = true
     try {
-      const res = await fetch('/api/agents')
+      // Use /api/schedules/agents (not /api/agents) so the main agent is a
+      // selectable background-task target too -- /api/agents lists sub-agents
+      // only, while the backend (spawnBackgroundTask) accepts any agent_id.
+      const res = await fetch('/api/schedules/agents')
       if (res.ok) {
         const agents = await res.json()
         const sel = document.getElementById('bgAgent')
         agents.forEach(a => {
           const opt = document.createElement('option')
           opt.value = a.name
-          opt.textContent = a.name
+          opt.textContent = a.label || a.name
           sel.appendChild(opt)
         })
         if (agents.length === 1) sel.value = agents[0].name

--- a/web/index.html
+++ b/web/index.html
@@ -532,6 +532,10 @@
               <span class="cxhu-state-label">Telepítés folyamatban...</span>
             </div>
             <div class="cxhu-state cxhu-state--token" id="cxhuStateToken" hidden>
+              <span class="cxhu-done-badge">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                CLI telepítve
+              </span>
               <input class="cxhu-token-input" id="cxhuTokenInput" type="password" placeholder="connectors.hu token (dashboardról)" autocomplete="off" spellcheck="false">
               <button class="cxhu-banner-cta" id="cxhuConfigureBtn">Mentés és szinkron</button>
             </div>

--- a/web/style.css
+++ b/web/style.css
@@ -1403,6 +1403,19 @@ main {
   font-size: 14px;
   font-weight: 500;
 }
+.skill-item-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  vertical-align: middle;
+  background: var(--info-soft);
+  color: var(--info);
+}
 .skill-item-desc {
   font-size: 12px;
   color: var(--text-muted);


### PR DESCRIPTION
## What

Fixes a batch of dashboard bugs where the backend already produced the right
data but the UI did not read it, showed the wrong state, or offered a control
wired to the wrong endpoint. These came out of a full dashboard UI-audit
(backend routes vs frontend wiring).

### The two headline bugs (commit 1)

- **Per-agent Skills tab was empty for sub-agents.** `GET /api/agents/:name/skills`
  only scanned `agents/<name>/.claude/skills` (near-empty), ignoring the global
  `~/.claude/skills` that every agent inherits at runtime — so an agent with ~37
  inherited skills showed `0`. It now returns the union, tagging inherited skills
  `global` (not deletable from a single agent's view) and parsing each
  `SKILL.md` description (the response previously had no `description` field at
  all, so that render was dead even for the main agent).
- **MCP catalog showed configured, working connectors as "telepítésre vár".**
  The catalog matched its id only against the `claude mcp list` cache by exact
  slug, and that cache is run from a temp dir so project `.mcp.json` servers
  never appear. Catalog id `gmail` also never matched servers named
  `gmail-egov` / `gmail-personal`. The catalog now also treats `.mcp.json`-configured
  servers as installed via a pure `catalogMatchesConfigured()` helper (exact
  match or the `<id>-<variant>` convention), flagged `configMatch` so the UI
  hides the generic-id uninstall link (which would not target the custom-named
  servers) and points at the Connectors list instead.

### Four more wiring fixes (commit 2)

- **kanban:** the new-comment author defaulted to the hard-coded literal
  `'Marveen'`, which never matches `BOT_NAME` on other installs, so the author
  select stayed empty and the comment submit silently no-opped. Now resolved by
  assignee `type === 'bot'`, falling back to the first assignee.
- **bgTasks:** the agent-target dropdown fetched `/api/agents` (sub-agents
  only), so the main agent could not be picked even though the backend accepts
  any `agent_id`. Switched to `/api/schedules/agents`, which includes the main
  agent.
- **recall:** the per-agent log-date hint never refreshed when the agent filter
  changed (no `change` listener). Re-fetches now.
- **connectors.hu:** the installed-but-unconfigured state showed a bare token
  prompt with no acknowledgement the CLI was already installed. Added a
  "CLI telepítve" badge to the token state.

## Test

- `tsc --noEmit` clean; `node --check web/app.js` clean.
- 59/59 `mcp-list-parser` unit tests pass (6 new for `catalogMatchesConfigured`,
  incl. the gmail → gmail-egov case and prefix-collision guards).
- Runtime-verified against the real config on disk: the Gmail catalog entry now
  resolves `installed=true` while all 13 other catalog entries stay `false`
  (no false positives); the global skills dir yields the inherited set every
  sub-agent runs with.

All changes are display/read/wiring side; no schema changes, no behavioural
change to scheduling/agent-runtime. Desktop layout untouched.
