### PR TITLE
fix(dashboard): restore GET /api/agents/activity route (regressed by #226)

### DIFF
--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -53,7 +53,7 @@ import {
   agentChannelDir,
 } from '../channel-invites.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
-import { isMainChannelsAgent } from '../main-agent.js'
+import { isMainChannelsAgent, MAIN_CHANNELS_SESSION } from '../main-agent.js'
 import {
   getProvider,
   channelStateDir,
@@ -80,6 +80,7 @@ import {
   capturePane,
 } from '../agent-process.js'
 import { readActiveModelFromProjectDir } from '../active-model.js'
+import { detectPaneState } from '../../pane-state.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
 import { getChannelHealth } from '../channel-health-monitor.js'
 import {
@@ -377,6 +378,55 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
 
   if (path === '/api/agents' && method === 'GET') {
     json(res, listAgentSummaries())
+    return true
+  }
+
+  // Live activity panel: per-agent "what is it doing right now". Read-only,
+  // polled by the dashboard every 3s; uses the same pane-state detector as the
+  // scheduler (detectPaneState) and returns the last few output lines as a tail.
+  // Includes the main agent's channels session so the operator sees the whole
+  // fleet, not just sub-agents. Restored after #226 dropped this route while the
+  // frontend kept calling /api/agents/activity (which then 404'd the panel).
+  if (path === '/api/agents/activity' && method === 'GET') {
+    const label = (running: boolean, pane: string | null): string => {
+      if (!running) return 'stopped'
+      if (pane === null) return 'unknown'
+      const s = detectPaneState(pane)
+      if (s === 'busy' || s === 'typing') return 'working'
+      if (s === 'idle') return 'idle'
+      return s // 'unknown' | 'error'
+    }
+    const tailOf = (pane: string | null): string[] =>
+      pane === null
+        ? []
+        : pane
+            .split('\n')
+            .map(l => l.replace(/\s+$/, ''))
+            .filter(l => l.trim().length > 0)
+            .slice(-8)
+
+    const entries: Array<{ name: string; isMain: boolean; running: boolean; state: string; tail: string[] }> = []
+
+    // Main agent runs in the --channels session, not agent-<name>.
+    {
+      const mainPane = capturePane(MAIN_CHANNELS_SESSION)
+      const running = mainPane !== null
+      entries.push({
+        name: MAIN_AGENT_ID,
+        isMain: true,
+        running,
+        state: label(running, mainPane),
+        tail: tailOf(mainPane),
+      })
+    }
+
+    for (const name of listAgentNames()) {
+      const running = isAgentRunning(name)
+      const pane = running ? capturePane(agentSessionName(name)) : null
+      entries.push({ name, isMain: false, running, state: label(running, pane), tail: tailOf(pane) })
+    }
+
+    json(res, entries)
     return true
   }
 


### PR DESCRIPTION
## What

Restores `GET /api/agents/activity`, which **#226** (durable channel-stability
hardening) removed from `src/web/routes/agents.ts` (−56 lines) along with its
`detectPaneState` import. The dashboard frontend (`loadActivity`, added in
**#211**) still polls that endpoint every 3s, so after #226 the Activity panel
shows:

> Nem sikerült lekérni az aktivitást: HTTP 404

This is a regression — the route worked before #226 and the frontend was never
changed to stop calling it.

## Fix

Re-add the read-only handler (and the `detectPaneState` + `MAIN_CHANNELS_SESSION`
imports it needs). It returns one entry per agent — the main `--channels`
session plus every sub-agent — each with:

- `state`: `detectPaneState` mapped to the UI's coarse label
  (`busy`/`typing` → `working`, `idle` → `idle`, else `unknown`/`error`, and
  `stopped` when the session isn't running),
- `tail`: the last 8 non-blank output lines of the pane,
- `isMain` / `running` flags the frontend already renders.

The implementation is identical to the pre-#226 version (recovered from the
git history at the commit before the regression). No frontend change needed —
`renderActivity` already consumes exactly this shape.

## Test

- `tsc --noEmit` clean.
- Full `vitest run`: 747 passed; the only failures are the 4 pre-existing
  `managed-settings.test.ts` cases (the test's own python-parse regex, unrelated
  and present on `main` before this change).
- The change is purely additive (one route + two imports); no existing behavior
  is touched.
