### PR TITLE
feat(dashboard): inter-agent message log + compose on the Team page (b5)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -86,7 +86,7 @@ function switchPage(pageId) {
   if (pageId === 'vault') loadVaultPage()
   if (pageId === 'autonomy') loadAutonomy()
   if (pageId === 'updates') loadUpdates()
-  if (pageId === 'team') loadTeamGraph()
+  if (pageId === 'team') { loadTeamGraph(); loadTeamMessages(); populateMsgComposeTargets() }
   if (pageId === 'tokenUsage') loadTokenUsage()
 }
 
@@ -6907,6 +6907,109 @@ function renderTeamGraph(container, data) {
 
 const refreshTeamBtn = document.getElementById('refreshTeamBtn')
 if (refreshTeamBtn) refreshTeamBtn.addEventListener('click', loadTeamGraph)
+
+// === Team: inter-agent message log + compose ===
+// View the /api/messages queue and let the operator send a message to an agent
+// from the dashboard. Targets come from /api/schedules/agents (the same allowed
+// agent list the scheduler uses) -- never a free-text target. The sender is the
+// owner (resolved by type from /api/kanban/assignees), so the receiving agent
+// sees a message from Gábor, not a spoofable string. /api/messages sits behind
+// the dashboard bearer token + Cloudflare Access.
+const MSG_STATUS_META = {
+  pending: { label: 'függőben', cls: 'badge-warm' },
+  delivered: { label: 'kézbesítve', cls: 'badge-active' },
+  done: { label: 'kész', cls: 'badge-active' },
+  failed: { label: 'hibás', cls: 'badge-paused' },
+}
+let msgComposeReady = false
+
+async function loadTeamMessages() {
+  const list = document.getElementById('teamMessageList')
+  if (!list) return
+  const filter = document.getElementById('msgFilter')?.value || ''
+  try {
+    const q = filter ? `?status=${encodeURIComponent(filter)}&limit=50` : '?limit=50'
+    const res = await fetch('/api/messages' + q)
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const msgs = await res.json()
+    if (!Array.isArray(msgs) || msgs.length === 0) {
+      list.innerHTML = '<p class="activity-empty">Nincs üzenet.</p>'
+      return
+    }
+    list.innerHTML = msgs.map(m => {
+      const meta = MSG_STATUS_META[m.status] || { label: m.status || '-', cls: 'badge' }
+      const when = m.created_at ? new Date(m.created_at * 1000).toLocaleString('hu-HU') : ''
+      return `<div class="team-message">
+        <div class="team-message-head">
+          <span class="team-message-route">${escapeHtml(m.from_agent)} &rarr; ${escapeHtml(m.to_agent)}</span>
+          <span class="badge ${meta.cls}">${escapeHtml(meta.label)}</span>
+        </div>
+        <div class="team-message-body">${escapeHtml(m.content)}</div>
+        <div class="team-message-time">${escapeHtml(when)}</div>
+      </div>`
+    }).join('')
+  } catch (e) {
+    list.innerHTML = '<p class="activity-empty">Nem sikerült betölteni az üzeneteket: ' + escapeHtml(String(e.message || e)) + '</p>'
+  }
+}
+
+async function populateMsgComposeTargets() {
+  const sel = document.getElementById('msgComposeTo')
+  if (!sel || msgComposeReady) return
+  try {
+    const res = await fetch('/api/schedules/agents')
+    if (!res.ok) return
+    const agents = await res.json()
+    sel.innerHTML = ''
+    for (const a of agents) {
+      const opt = document.createElement('option')
+      opt.value = a.name
+      opt.textContent = a.label || a.name
+      sel.appendChild(opt)
+    }
+    msgComposeReady = true
+  } catch { /* leave empty; send will warn */ }
+}
+
+async function resolveOwnerName() {
+  try {
+    const res = await fetch('/api/kanban/assignees')
+    if (res.ok) {
+      const list = await res.json()
+      const owner = Array.isArray(list) ? list.find(a => a.type === 'owner') : null
+      if (owner && owner.name) return owner.name
+    }
+  } catch { /* fall through */ }
+  return 'owner'
+}
+
+async function sendComposeMessage() {
+  const to = document.getElementById('msgComposeTo').value
+  const content = document.getElementById('msgComposeContent').value.trim()
+  if (!to) { showToast('Válassz címzett ügynököt'); return }
+  if (!content) { document.getElementById('msgComposeContent').focus(); return }
+  const btn = document.getElementById('msgComposeSend')
+  btn.disabled = true
+  try {
+    const from = await resolveOwnerName()
+    const res = await fetch('/api/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from, to, content }),
+    })
+    if (!res.ok) { const err = await res.json(); throw new Error(err.error || 'Hiba') }
+    document.getElementById('msgComposeContent').value = ''
+    showToast('Üzenet elküldve')
+    loadTeamMessages()
+  } catch (e) {
+    showToast('Hiba: ' + (e.message || e))
+  } finally {
+    btn.disabled = false
+  }
+}
+
+document.getElementById('msgFilter')?.addEventListener('change', loadTeamMessages)
+document.getElementById('msgComposeSend')?.addEventListener('click', sendComposeMessage)
 
 function renderTeamEditor(agent, allAgents) {
   const team = agent.team || { role: 'member', reportsTo: null, delegatesTo: [], autoDelegation: false, trustFrom: [] }

--- a/web/index.html
+++ b/web/index.html
@@ -746,6 +746,30 @@
       <p style="color:var(--text-muted);font-size:12px;margin-top:16px">
         A szerep és a beosztott/vezető kapcsolatok az ügynök részletek &gt; Csapat fülén szerkeszthetők.
       </p>
+
+      <div class="team-messages">
+        <div class="page-header-row" style="margin-bottom:14px">
+          <h2 style="font-size:18px;margin:0">Üzenetek</h2>
+          <select id="msgFilter">
+            <option value="">Összes</option>
+            <option value="pending">Függőben</option>
+            <option value="done">Kész</option>
+            <option value="failed">Hibás</option>
+          </select>
+        </div>
+        <div id="teamMessageList" class="team-message-list"></div>
+        <div class="team-compose">
+          <div class="form-group">
+            <label for="msgComposeTo">Címzett ügynök</label>
+            <select id="msgComposeTo"></select>
+          </div>
+          <div class="form-group">
+            <label for="msgComposeContent">Üzenet</label>
+            <textarea id="msgComposeContent" rows="2" placeholder="Üzenet egy ügynöknek (a dashboardról küldve)"></textarea>
+          </div>
+          <button class="btn-primary btn-compact" id="msgComposeSend">Küldés</button>
+        </div>
+      </div>
     </div>
 
     <!-- === Autonomy Page === -->

--- a/web/style.css
+++ b/web/style.css
@@ -4932,3 +4932,14 @@ main {
   border-radius: 6px; padding: 8px 10px;
 }
 .activity-tail-empty { margin: 0; font-size: 12px; color: var(--text-muted); font-style: italic; }
+
+/* Team page: inter-agent message log + compose */
+.team-messages { margin-top: 28px; }
+.team-message-list { display: flex; flex-direction: column; gap: 10px; margin-bottom: 18px; max-height: 420px; overflow-y: auto; }
+.team-message { border: 1px solid var(--border); border-radius: 10px; background: var(--bg-card); padding: 10px 14px; }
+.team-message-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
+.team-message-route { font-weight: 600; font-size: 13px; }
+.team-message-body { font-size: 13px; white-space: pre-wrap; word-break: break-word; }
+.team-message-time { font-size: 11px; color: var(--text-muted); margin-top: 4px; }
+.team-compose { border-top: 1px solid var(--border); padding-top: 16px; }
+.team-compose textarea { width: 100%; resize: vertical; }


### PR DESCRIPTION
## What

Surfaces the inter-agent message queue on the **Team** page, with a compose box
(b5 from the dashboard UI-audit; Gábor-approved).

The `/api/messages` family (GET list with `agent`/`status`/`limit`, POST create,
PUT done/failed) was fully implemented and live, but **no dashboard page
consumed it** — the Team page only drew the static org-chart graph.

## Adds

- **Message log**: recent messages rendered as `from → to`, content, a status
  badge (pending / delivered / done / failed) and timestamp, with a status
  filter dropdown. Loads on the Team page and refreshes after a send.
- **Compose box**: the operator can send a message to an agent straight from the
  dashboard (`POST /api/messages`).

## Security

- The compose **target** comes from `/api/schedules/agents` (the same allowed
  agent list the scheduler uses) — a dropdown, **never a free-text target**.
- The **sender** is resolved to the owner *by type* from
  `/api/kanban/assignees` (not a spoofable free-text string), so the receiving
  agent sees a message from the owner.
- `/api/messages` already sits behind the dashboard bearer token + Cloudflare
  Access, so the compose surface inherits that gating.

## Test

- `tsc --noEmit` clean; `node --check web/app.js` clean.
- Verified the live `GET /api/messages` shape matches what the renderer consumes
  (`from_agent`, `to_agent`, `content`, `status`, `created_at`).
- Full `vitest run`: 747 passed; only the 4 pre-existing `managed-settings.test.ts`
  failures remain (unrelated, present on `main` before this).

Pure frontend (markup + `app.js` + CSS); backend untouched.
