### PR TITLE
fix(channels): stuck-tool-call watchdog for the Worked-for-Ns TUI freeze

### DIFF
--- a/src/__tests__/stuck-tool-call.test.ts
+++ b/src/__tests__/stuck-tool-call.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+import {
+  stuckToolCallSignature,
+  decideStuckToolCallRecovery,
+  type StuckToolCallState,
+  type StuckToolCallThresholds,
+} from '../pane-state.js'
+
+// Thresholds matching the production defaults in stuck-tool-call-watcher.ts.
+// Repeated here so the tests pin the contract independently of the wrapper
+// module (Marveen 2026-06-02 review: every threshold change should require
+// an intentional test edit, not silently relax).
+const THRESHOLDS: StuckToolCallThresholds = {
+  freezeSeconds: 180,
+  stagnantPolls: 2,
+}
+
+const NO_STATE: StuckToolCallState = {
+  tag: null,
+  spellStartSeconds: null,
+  firstSeenAt: null,
+  lastSeconds: null,
+  stagnantPolls: 0,
+  attempts: 0,
+}
+
+describe('stuckToolCallSignature', () => {
+  it('parses "Worked for 31s" -- the 2026-06-02 incident shape', () => {
+    const pane = [
+      '  hírlevél-welcome-ot...',
+      '',
+      '✻ Worked for 31s',
+      '',
+      '❯ Maradjon, jó így.',
+    ].join('\n')
+    expect(stuckToolCallSignature(pane)).toEqual({ tag: 'worked', seconds: 31 })
+  })
+
+  it('parses all known verbs Claude Code has shipped', () => {
+    expect(stuckToolCallSignature('Brewed for 42s')).toEqual({ tag: 'brewed', seconds: 42 })
+    expect(stuckToolCallSignature('Baked for 7s')).toEqual({ tag: 'baked', seconds: 7 })
+    expect(stuckToolCallSignature('Cooking for 12s')).toEqual({ tag: 'cooking', seconds: 12 })
+    expect(stuckToolCallSignature('Simmered for 99s')).toEqual({ tag: 'simmered', seconds: 99 })
+    expect(stuckToolCallSignature('Sauteed for 21s')).toEqual({ tag: 'sauteed', seconds: 21 })
+  })
+
+  it('handles the ✻ glyph prefix', () => {
+    expect(stuckToolCallSignature('✻ Worked for 31s')).toEqual({ tag: 'worked', seconds: 31 })
+  })
+
+  it('returns null when no progress line is present', () => {
+    expect(stuckToolCallSignature('❯ idle prompt\nbypass permissions on')).toBeNull()
+    expect(stuckToolCallSignature('')).toBeNull()
+  })
+})
+
+describe('decideStuckToolCallRecovery', () => {
+  it('starts a fresh spell on first observation, no recovery', () => {
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, NO_STATE, 1_000_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next.tag).toBe('worked')
+    expect(r.next.spellStartSeconds).toBe(31)
+    expect(r.next.stagnantPolls).toBe(0)
+  })
+
+  it('null pane ends any spell', () => {
+    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 200, stagnantPolls: 2, attempts: 0 }
+    const r = decideStuckToolCallRecovery(null, prev, 1_000_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next).toEqual(NO_STATE)
+  })
+
+  it('tag change resets the spell (verb change = real progress)', () => {
+    const prev: StuckToolCallState = { tag: 'brewed', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 200, stagnantPolls: 2, attempts: 0 }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 5 }, prev, 1_000_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next.tag).toBe('worked')
+    expect(r.next.spellStartSeconds).toBe(5)
+    expect(r.next.stagnantPolls).toBe(0)
+  })
+
+  it('counter increment resets stagnantPolls (real tool-call progress)', () => {
+    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 195, stagnantPolls: 1, attempts: 0 }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 220 }, prev, 1_000_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next.lastSeconds).toBe(220)
+    expect(r.next.stagnantPolls).toBe(0)
+  })
+
+  it('seconds<freezeSeconds + stagnant: tick counter, do NOT recover (still below threshold)', () => {
+    // The 2026-06-02 incident sat at 31s -- well below 180. Even if it
+    // stagnates forever there, we don't act (a legitimate user might pause
+    // a tool-call briefly). Only freeze AT >= freezeSeconds matters.
+    let state = NO_STATE
+    for (let i = 0; i < 5; i++) {
+      const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, state, 1_000_000 + i * 30_000, THRESHOLDS)
+      expect(r.recover).toBe(false)
+      state = r.next
+    }
+  })
+
+  it('seconds>=freezeSeconds + 1 stagnant poll: tick, do NOT recover yet', () => {
+    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200, stagnantPolls: 0, attempts: 0 }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 200 }, prev, 1_030_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next.stagnantPolls).toBe(1)
+  })
+
+  it('seconds>=freezeSeconds + 2 stagnant polls: RECOVER', () => {
+    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200, stagnantPolls: 1, attempts: 0 }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 200 }, prev, 1_060_000, THRESHOLDS)
+    expect(r.recover).toBe(true)
+    expect(r.next.attempts).toBe(1)
+  })
+
+  it('one-shot: once recovered, hold even if still stagnant (next sweep reads fresh pane)', () => {
+    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200, stagnantPolls: 2, attempts: 1 }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 200 }, prev, 1_090_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next.attempts).toBe(1)
+  })
+
+  it('clock skew backwards: restart spell rather than stall', () => {
+    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 2_000_000, lastSeconds: 200, stagnantPolls: 1, attempts: 0 }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 200 }, prev, 1_500_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next.firstSeenAt).toBe(1_500_000)
+    expect(r.next.stagnantPolls).toBe(0)
+  })
+
+  it('legitimate long tool-call: counter increments every poll, NEVER recovers', () => {
+    // 5-minute slow Anthropic call. Counter goes 30s -> 60s -> 90s -> ... -> 300s.
+    // Each poll observes an increment, so stagnantPolls stays 0, recover stays false.
+    let state = NO_STATE
+    for (let n = 30; n <= 300; n += 30) {
+      const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: n }, state, 1_000_000 + n * 1000, THRESHOLDS)
+      expect(r.recover).toBe(false)
+      state = r.next
+    }
+    expect(state.stagnantPolls).toBe(0)
+  })
+
+  it('rolled-back counter: treated as stagnant (a counter that goes backwards is unhealthy)', () => {
+    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200, stagnantPolls: 1, attempts: 0 }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 199 }, prev, 1_060_000, THRESHOLDS)
+    expect(r.recover).toBe(true)
+    expect(r.next.attempts).toBe(1)
+  })
+})
+
+describe('stuck-tool-call-watcher wiring contract', () => {
+  // Pin the production thresholds and the boot-time wiring so a future
+  // refactor cannot silently disable the watchdog or relax the gates that
+  // protect against false-positive respawns during legitimate long work.
+  const watcherSrc = require('node:fs').readFileSync(
+    require('node:path').join(__dirname, '../web/stuck-tool-call-watcher.ts'),
+    'utf-8',
+  ) as string
+  const webSrc = require('node:fs').readFileSync(
+    require('node:path').join(__dirname, '../web.ts'),
+    'utf-8',
+  ) as string
+
+  it('production freezeSeconds is >= 180', () => {
+    const m = watcherSrc.match(/freezeSeconds:\s*(\d+)/)
+    expect(m, 'freezeSeconds constant missing').not.toBeNull()
+    expect(parseInt(m![1]!, 10)).toBeGreaterThanOrEqual(180)
+  })
+
+  it('production stagnantPolls is >= 2', () => {
+    const m = watcherSrc.match(/stagnantPolls:\s*(\d+)/)
+    expect(m, 'stagnantPolls constant missing').not.toBeNull()
+    expect(parseInt(m![1]!, 10)).toBeGreaterThanOrEqual(2)
+  })
+
+  it('the watcher hard-restarts only via hardRestartMarveenChannels', () => {
+    expect(watcherSrc).toMatch(/hardRestartMarveenChannels\(\)/)
+    // Defensive: must NOT call respawn-pane directly or kill processes.
+    expect(watcherSrc).not.toMatch(/respawn-pane/)
+    expect(watcherSrc).not.toMatch(/kill\(/)
+  })
+
+  it('the watcher logs an audit line when it acts', () => {
+    expect(watcherSrc).toMatch(/stuck-tool-call-watcher:/)
+    expect(watcherSrc).toMatch(/logger\.warn/)
+  })
+
+  it('web.ts boots the watcher', () => {
+    expect(webSrc).toMatch(/startStuckToolCallWatcher\(\)/)
+    expect(webSrc).toMatch(/Stuck-tool-call watcher started/)
+  })
+})

--- a/src/__tests__/stuck-tool-call.test.ts
+++ b/src/__tests__/stuck-tool-call.test.ts
@@ -21,6 +21,7 @@ const NO_STATE: StuckToolCallState = {
   firstSeenAt: null,
   lastSeconds: null,
   stagnantPolls: 0,
+  stagnantSince: null,
   attempts: 0,
 }
 
@@ -61,90 +62,169 @@ describe('decideStuckToolCallRecovery', () => {
     expect(r.next.tag).toBe('worked')
     expect(r.next.spellStartSeconds).toBe(31)
     expect(r.next.stagnantPolls).toBe(0)
+    expect(r.next.stagnantSince).toBeNull()
   })
 
   it('null pane ends any spell', () => {
-    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 200, stagnantPolls: 2, attempts: 0 }
+    const prev: StuckToolCallState = {
+      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 31,
+      stagnantPolls: 2, stagnantSince: 1, attempts: 0,
+    }
     const r = decideStuckToolCallRecovery(null, prev, 1_000_000, THRESHOLDS)
     expect(r.recover).toBe(false)
     expect(r.next).toEqual(NO_STATE)
   })
 
   it('tag change resets the spell (verb change = real progress)', () => {
-    const prev: StuckToolCallState = { tag: 'brewed', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 200, stagnantPolls: 2, attempts: 0 }
+    const prev: StuckToolCallState = {
+      tag: 'brewed', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 200,
+      stagnantPolls: 2, stagnantSince: 1, attempts: 0,
+    }
     const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 5 }, prev, 1_000_000, THRESHOLDS)
     expect(r.recover).toBe(false)
     expect(r.next.tag).toBe('worked')
     expect(r.next.spellStartSeconds).toBe(5)
     expect(r.next.stagnantPolls).toBe(0)
+    expect(r.next.stagnantSince).toBeNull()
   })
 
-  it('counter increment resets stagnantPolls (real tool-call progress)', () => {
-    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 195, stagnantPolls: 1, attempts: 0 }
-    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 220 }, prev, 1_000_000, THRESHOLDS)
+  it('counter increment resets stagnantPolls AND stagnantSince (real tool-call progress)', () => {
+    const prev: StuckToolCallState = {
+      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 195,
+      stagnantPolls: 1, stagnantSince: 1_000_000, attempts: 0,
+    }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 220 }, prev, 1_030_000, THRESHOLDS)
     expect(r.recover).toBe(false)
     expect(r.next.lastSeconds).toBe(220)
     expect(r.next.stagnantPolls).toBe(0)
+    expect(r.next.stagnantSince).toBeNull()
   })
 
-  it('seconds<freezeSeconds + stagnant: tick counter, do NOT recover (still below threshold)', () => {
-    // The 2026-06-02 incident sat at 31s -- well below 180. Even if it
-    // stagnates forever there, we don't act (a legitimate user might pause
-    // a tool-call briefly). Only freeze AT >= freezeSeconds matters.
-    let state = NO_STATE
-    for (let i = 0; i < 5; i++) {
-      const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, state, 1_000_000 + i * 30_000, THRESHOLDS)
+  it('first stagnant poll stamps stagnantSince but does NOT recover (anti-fluke gate)', () => {
+    const prev: StuckToolCallState = {
+      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 31,
+      stagnantPolls: 0, stagnantSince: null, attempts: 0,
+    }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, prev, 1_030_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next.stagnantPolls).toBe(1)
+    expect(r.next.stagnantSince).toBe(1_030_000)
+  })
+
+  it('FROZEN at 31s recovers after 180s WALL-CLOCK stagnation (the 2026-06-02 incident)', () => {
+    // PR #246 review fix: a wedged TUI keeps displaying the same seconds
+    // forever. Recovery must be triggered by elapsed wall-clock time since
+    // the counter stopped advancing, NOT by the displayed value reaching
+    // a threshold. This was the precise vacuum in the original PR.
+    const t0 = 1_000_000
+    let state: StuckToolCallState = NO_STATE
+
+    // Poll 1: first observation. spellStart.
+    let r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, state, t0, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    state = r.next
+    expect(state.stagnantSince).toBeNull() // not stagnant yet -- just spell-start
+
+    // Poll 2 (30s later): same 31, first stagnant observation.
+    r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, state, t0 + 30_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    state = r.next
+    expect(state.stagnantPolls).toBe(1)
+    expect(state.stagnantSince).toBe(t0 + 30_000)
+
+    // Poll 3-6 (90s, 120s, 150s, 180s later): still 31, accumulating wall-clock.
+    //   90 -> stagnantPolls=2 but stagnant for 60s -> still below freezeSeconds
+    //  180 -> stagnant for 150s -> still below
+    for (const dt of [60_000, 90_000, 120_000, 150_000]) {
+      r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, state, t0 + 30_000 + dt, THRESHOLDS)
       expect(r.recover).toBe(false)
       state = r.next
     }
-  })
 
-  it('seconds>=freezeSeconds + 1 stagnant poll: tick, do NOT recover yet', () => {
-    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200, stagnantPolls: 0, attempts: 0 }
-    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 200 }, prev, 1_030_000, THRESHOLDS)
-    expect(r.recover).toBe(false)
-    expect(r.next.stagnantPolls).toBe(1)
-  })
-
-  it('seconds>=freezeSeconds + 2 stagnant polls: RECOVER', () => {
-    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200, stagnantPolls: 1, attempts: 0 }
-    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 200 }, prev, 1_060_000, THRESHOLDS)
+    // Poll 7 (30s + 180s later from t0): stagnant for exactly 180_000 ms.
+    // Wall-clock gate hits, stagnantPolls already > 2, RECOVER.
+    r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, state, t0 + 30_000 + 180_000, THRESHOLDS)
     expect(r.recover).toBe(true)
     expect(r.next.attempts).toBe(1)
   })
 
   it('one-shot: once recovered, hold even if still stagnant (next sweep reads fresh pane)', () => {
-    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200, stagnantPolls: 2, attempts: 1 }
-    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 200 }, prev, 1_090_000, THRESHOLDS)
+    const prev: StuckToolCallState = {
+      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 31,
+      stagnantPolls: 8, stagnantSince: 1_000_000, attempts: 1,
+    }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, prev, 2_000_000, THRESHOLDS)
     expect(r.recover).toBe(false)
     expect(r.next.attempts).toBe(1)
   })
 
   it('clock skew backwards: restart spell rather than stall', () => {
-    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 2_000_000, lastSeconds: 200, stagnantPolls: 1, attempts: 0 }
-    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 200 }, prev, 1_500_000, THRESHOLDS)
+    const prev: StuckToolCallState = {
+      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 2_000_000, lastSeconds: 31,
+      stagnantPolls: 1, stagnantSince: 2_000_000, attempts: 0,
+    }
+    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, prev, 1_500_000, THRESHOLDS)
     expect(r.recover).toBe(false)
     expect(r.next.firstSeenAt).toBe(1_500_000)
+    expect(r.next.stagnantSince).toBeNull()
     expect(r.next.stagnantPolls).toBe(0)
   })
 
-  it('legitimate long tool-call: counter increments every poll, NEVER recovers', () => {
-    // 5-minute slow Anthropic call. Counter goes 30s -> 60s -> 90s -> ... -> 300s.
-    // Each poll observes an increment, so stagnantPolls stays 0, recover stays false.
-    let state = NO_STATE
+  it('LEGITIMATE long tool-call invariant: counter increments every poll, NEVER recovers', () => {
+    // 5-minute slow Anthropic call. Counter goes 30 -> 60 -> 90 -> ... -> 300s.
+    // Each poll sees an increment, so stagnantSince keeps resetting to null
+    // and the wall-clock duration never accumulates. Crucial invariant
+    // preserved by the PR #246 review fix.
+    let state: StuckToolCallState = NO_STATE
     for (let n = 30; n <= 300; n += 30) {
-      const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: n }, state, 1_000_000 + n * 1000, THRESHOLDS)
+      const r = decideStuckToolCallRecovery(
+        { tag: 'worked', seconds: n },
+        state,
+        1_000_000 + n * 1000,
+        THRESHOLDS,
+      )
       expect(r.recover).toBe(false)
       state = r.next
     }
+    expect(state.stagnantSince).toBeNull()
     expect(state.stagnantPolls).toBe(0)
   })
 
-  it('rolled-back counter: treated as stagnant (a counter that goes backwards is unhealthy)', () => {
-    const prev: StuckToolCallState = { tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200, stagnantPolls: 1, attempts: 0 }
-    const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 199 }, prev, 1_060_000, THRESHOLDS)
+  it('rolled-back counter: treated as stagnant -- recovers after wall-clock window', () => {
+    // 199 < 200 is an unhealthy regression. We treat it as stagnant. Two
+    // polls of 199, plus enough wall-clock to clear freezeSeconds, recovers.
+    const prev: StuckToolCallState = {
+      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200,
+      stagnantPolls: 0, stagnantSince: null, attempts: 0,
+    }
+    // First stagnant poll just stamps the wall-clock start.
+    let r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 199 }, prev, 1_030_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    // ~3 min later, still 199 (or any value <= 200): wall-clock hit.
+    r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 199 }, r.next, 1_030_000 + 180_000, THRESHOLDS)
     expect(r.recover).toBe(true)
-    expect(r.next.attempts).toBe(1)
+  })
+
+  it('partial freeze, recovers, then re-freezes -- accumulates fresh wall-clock', () => {
+    // Counter goes 50 -> 50 (stagnant for 60s) -> 51 (progress, reset) ->
+    // freeze at 51 for the full 180s wall clock. The first freeze didn't
+    // qualify (only 60s stagnant), the second does. stagnantSince must have
+    // been reset by the progress observation.
+    let state: StuckToolCallState = NO_STATE
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 50 }, state, 1_000_000, THRESHOLDS).next
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 50 }, state, 1_030_000, THRESHOLDS).next
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 50 }, state, 1_060_000, THRESHOLDS).next
+    // Progress: stagnantSince should reset.
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 51 }, state, 1_090_000, THRESHOLDS).next
+    expect(state.stagnantSince).toBeNull()
+    // Now refreeze. First stagnant poll stamps, second poll qualifies polls,
+    // wall-clock takes a while to accumulate -- recover only after 180s.
+    let r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 51 }, state, 1_120_000, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next.stagnantSince).toBe(1_120_000)
+    state = r.next
+    r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 51 }, state, 1_120_000 + 180_000, THRESHOLDS)
+    expect(r.recover).toBe(true)
   })
 })
 

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -739,29 +739,42 @@ export function stuckToolCallSignature(pane: string): ToolCallProgressSignature 
 export interface StuckToolCallState {
   /** Current tool-call tag we are watching (e.g. "worked"), or null if no spell active. */
   tag: string | null
-  /** The seconds value observed when the spell started -- so we can detect
-   * non-progression by comparing to the current seconds. */
+  /** The seconds value observed when the spell started -- preserved for the
+   * audit log so an operator can tell at what counter value the freeze happened. */
   spellStartSeconds: number | null
   /** When the spell was first observed (ms). */
   firstSeenAt: number | null
-  /** Last observed seconds value, to detect stagnation across polls. */
+  /** Last observed seconds value, used to detect stagnation across polls. */
   lastSeconds: number | null
   /** Consecutive polls in which the seconds value did NOT increase. */
   stagnantPolls: number
+  /** Wall-clock timestamp (ms) at which the counter first stopped advancing
+   * in this spell, or null if the counter is currently progressing. This is
+   * the load-bearing measurement for the freeze decision: a wedged TUI keeps
+   * displaying the same `<verb> for Ns` regardless of real time, so we
+   * measure freeze duration in WALL CLOCK from stagnantSince, NOT from the
+   * displayed counter value. (PR #246 review fix, 2026-06-02: the prior
+   * version gated on sig.seconds >= freezeSeconds and so could never fire on
+   * a counter frozen at <180s -- exactly the 2026-06-02 06:41 incident shape
+   * where it sat at 31s.) */
+  stagnantSince: number | null
   /** Recoveries fired in this spell (cap at 1 -- a respawn is the only
    * action, and the next sweep observes the new pane fresh). */
   attempts: number
 }
 
 export interface StuckToolCallThresholds {
-  /** A tool-call may legitimately run for a long time (a slow Anthropic
-   * inference, a multi-stage research agent). Only flag as frozen once
-   * the displayed seconds value reaches this -- below it, just record. */
+  /** How long the TUI counter must remain stagnant in WALL-CLOCK terms
+   * before we conclude the render loop is wedged. A healthy long-running
+   * tool-call increments the counter every TUI redraw (~once per second),
+   * so a counter that holds the same value for >= this many ms is wedged
+   * regardless of what value it holds. The previous "displayed-value
+   * threshold" reading was the PR #246 review bug. */
   freezeSeconds: number
   /** How many consecutive polls of NON-INCREASING seconds count as
-   * "the TUI render loop is wedged". A real tool-call increments the
-   * counter every TUI redraw (~once per second), so a stagnant counter
-   * across multiple poll intervals is conclusive. */
+   * "the TUI render loop is wedged" (anti-fluke). A real tool-call
+   * increments every TUI redraw, so multi-poll stagnation is conclusive.
+   * Composed WITH the wall-clock freezeSeconds check -- BOTH must hold. */
   stagnantPolls: number
 }
 
@@ -776,24 +789,33 @@ const NO_STUCK_TOOL_CALL: StuckToolCallState = {
   firstSeenAt: null,
   lastSeconds: null,
   stagnantPolls: 0,
+  stagnantSince: null,
   attempts: 0,
 }
 
 /**
- * Pure decision: should the watcher respawn this session because the
- * tool-call line has been frozen at the same value past the threshold?
+ * Pure decision: should the watcher respawn this session because the TUI
+ * tool-call counter has stopped advancing for too long?
+ *
+ * Load-bearing measurement is WALL-CLOCK stagnation duration, NOT the
+ * displayed counter value. A wedged TUI keeps showing the same
+ * `<verb> for Ns` regardless of real time; gating on `sig.seconds >=
+ * freezeSeconds` (PR #246 review bug, 2026-06-02) would miss exactly the
+ * incident shape the watchdog is built for (counter frozen at 31s, never
+ * reaches 180s, never recovers).
  *
  * Guards against false positives on legitimate long tool-calls:
- *   - The counter must have REACHED freezeSeconds (180s default). Below
- *     that, we just record.
- *   - The counter must have been STAGNANT for stagnantPolls (2 default)
- *     consecutive polls. A real tool-call increments every TUI redraw,
- *     so a non-incrementing counter across 30s+ of wall clock is the
- *     wedge signature -- not normal long-running behaviour.
+ *   - Wall-clock stagnation `(now - stagnantSince) >= freezeSeconds`. A
+ *     healthy long-running call increments the counter every TUI redraw,
+ *     so stagnantSince keeps resetting to null and the duration never
+ *     accumulates. A wedged TUI lets it accumulate.
+ *   - Anti-fluke: stagnantPolls >= thresholds.stagnantPolls (two
+ *     consecutive non-incrementing observations), composed AND with the
+ *     wall-clock check.
  *   - Recovery is one-shot per spell (attempts cap at 1). The next sweep
  *     reads a fresh pane after the respawn.
- *   - A tag change (e.g. Brewed -> Worked) resets the spell -- the
- *     tool-call moved to a new phase, that IS progress.
+ *   - A tag change (e.g. Brewed -> Worked) or counter increment resets
+ *     the spell -- both are genuine progress.
  */
 export function decideStuckToolCallRecovery(
   sig: ToolCallProgressSignature | null,
@@ -815,12 +837,13 @@ export function decideStuckToolCallRecovery(
         firstSeenAt: now,
         lastSeconds: sig.seconds,
         stagnantPolls: 0,
+        stagnantSince: null,
         attempts: 0,
       },
     }
   }
   // Backwards clock skew: restart the spell rather than stall.
-  if (now < prev.firstSeenAt) {
+  if (now < prev.firstSeenAt || (prev.stagnantSince !== null && now < prev.stagnantSince)) {
     return {
       recover: false,
       next: {
@@ -829,33 +852,49 @@ export function decideStuckToolCallRecovery(
         firstSeenAt: now,
         lastSeconds: sig.seconds,
         stagnantPolls: 0,
+        stagnantSince: null,
         attempts: 0,
       },
     }
   }
-  // Counter advanced: real progress, reset the stagnant counter. We keep
-  // the spell open (tag is the same) so that if it freezes LATER we don't
-  // have to wait through another freezeSeconds runup.
+  // Counter advanced: real progress. Reset both the stagnant-poll counter
+  // and the stagnantSince timestamp -- the TUI is alive. Keep the spell
+  // open with the same tag so a LATER freeze is detected without re-running
+  // the full freezeSeconds window from scratch (the wall-clock measurement
+  // restarts from the next stagnation onward, which is the right thing).
   if (prev.lastSeconds !== null && sig.seconds > prev.lastSeconds) {
     return {
       recover: false,
-      next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: 0 },
+      next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: 0, stagnantSince: null },
     }
   }
-  // Counter stagnant (same or rolled-back). Tick the stagnant counter.
+  // Counter stagnant (same or rolled-back). Tick the stagnant counter and
+  // stamp stagnantSince on the FIRST stagnant observation in this stretch.
+  // Subsequent stagnant polls preserve the original stagnantSince so the
+  // wall-clock duration accumulates correctly.
   const nextStagnant = prev.stagnantPolls + 1
+  const nextStagnantSince = prev.stagnantSince ?? now
   // Recovery already fired in this spell: hold.
   if (prev.attempts >= 1) {
-    return { recover: false, next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant } }
+    return {
+      recover: false,
+      next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant, stagnantSince: nextStagnantSince },
+    }
   }
-  // Not yet at the freeze threshold -- a tool-call can pause briefly mid-
-  // run without being wedged. Only fire once the counter sits at >=
-  // freezeSeconds AND has held there for stagnantPolls consecutive polls.
-  if (sig.seconds < thresholds.freezeSeconds || nextStagnant < thresholds.stagnantPolls) {
-    return { recover: false, next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant } }
+  // Recover only when BOTH gates hold: wall-clock freeze duration AND
+  // anti-fluke poll count. A 5-minute genuine tool-call resets
+  // stagnantSince on every redraw, so even though the call is long this
+  // duration never accumulates.
+  const stagnantMs = now - nextStagnantSince
+  const freezeMs = thresholds.freezeSeconds * 1000
+  if (stagnantMs < freezeMs || nextStagnant < thresholds.stagnantPolls) {
+    return {
+      recover: false,
+      next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant, stagnantSince: nextStagnantSince },
+    }
   }
   return {
     recover: true,
-    next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant, attempts: 1 },
+    next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant, stagnantSince: nextStagnantSince, attempts: 1 },
   }
 }

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -694,3 +694,168 @@ export function decideStuckInputRecovery(
     next: { parkedSig, firstSeenAt: prev.firstSeenAt, lastRecoverAt: now, attempts: prev.attempts + 1 },
   }
 }
+
+// =============================================================================
+// Stuck tool-call watcher (2026-06-02 incident, Worked-for >Ns freeze)
+// =============================================================================
+//
+// Symptom: Marveen's TUI shows "Worked for 31s" (or "Brewed for", "Baked for")
+// indefinitely. The claude process is at 0.3% CPU (IO-wait, no progress), bun
+// poller is alive, hasChannelPluginAlive() returns true -- so the recovery
+// cascade gated on bun absence (#240) never fires. Real cause: the Telegram
+// reply tool-call hung server-side without a client-side timeout, taking the
+// TUI render loop with it.
+//
+// Detection: parse the `Worked for Ns` line. If the SAME tag+seconds is
+// observed across `confirmPolls` consecutive polls AND `seconds >= freezeSeconds`,
+// the tool-call is frozen and the session needs a hard restart. The tag must
+// stay the same too (different verb / restart of the counter means progress).
+
+/**
+ * Parse the TUI's "Worked / Brewed / Baked / Cooking / Simmered for Ns"
+ * footer if present. Returns null when the pane is not in a tool-call
+ * waiting state (no tool-call line, or it just changed verb).
+ *
+ * The verb is part of the signature so that a TUI transition from "Brewed"
+ * to "Worked" -- which actually IS progress, the tool-call moved to a new
+ * phase -- resets the stuck-spell.
+ */
+export interface ToolCallProgressSignature {
+  tag: string
+  seconds: number
+}
+
+const TOOL_CALL_PROGRESS_RX = /(?:✻\s*)?(Worked|Brewed|Baked|Cooking|Simmered|Sauteed|Sauted)\s+for\s+(\d+)s/i
+
+export function stuckToolCallSignature(pane: string): ToolCallProgressSignature | null {
+  const m = pane.match(TOOL_CALL_PROGRESS_RX)
+  if (!m) return null
+  const tag = m[1]!.toLowerCase()
+  const seconds = parseInt(m[2]!, 10)
+  if (!Number.isFinite(seconds) || seconds < 0) return null
+  return { tag, seconds }
+}
+
+export interface StuckToolCallState {
+  /** Current tool-call tag we are watching (e.g. "worked"), or null if no spell active. */
+  tag: string | null
+  /** The seconds value observed when the spell started -- so we can detect
+   * non-progression by comparing to the current seconds. */
+  spellStartSeconds: number | null
+  /** When the spell was first observed (ms). */
+  firstSeenAt: number | null
+  /** Last observed seconds value, to detect stagnation across polls. */
+  lastSeconds: number | null
+  /** Consecutive polls in which the seconds value did NOT increase. */
+  stagnantPolls: number
+  /** Recoveries fired in this spell (cap at 1 -- a respawn is the only
+   * action, and the next sweep observes the new pane fresh). */
+  attempts: number
+}
+
+export interface StuckToolCallThresholds {
+  /** A tool-call may legitimately run for a long time (a slow Anthropic
+   * inference, a multi-stage research agent). Only flag as frozen once
+   * the displayed seconds value reaches this -- below it, just record. */
+  freezeSeconds: number
+  /** How many consecutive polls of NON-INCREASING seconds count as
+   * "the TUI render loop is wedged". A real tool-call increments the
+   * counter every TUI redraw (~once per second), so a stagnant counter
+   * across multiple poll intervals is conclusive. */
+  stagnantPolls: number
+}
+
+export interface StuckToolCallDecision {
+  recover: boolean
+  next: StuckToolCallState
+}
+
+const NO_STUCK_TOOL_CALL: StuckToolCallState = {
+  tag: null,
+  spellStartSeconds: null,
+  firstSeenAt: null,
+  lastSeconds: null,
+  stagnantPolls: 0,
+  attempts: 0,
+}
+
+/**
+ * Pure decision: should the watcher respawn this session because the
+ * tool-call line has been frozen at the same value past the threshold?
+ *
+ * Guards against false positives on legitimate long tool-calls:
+ *   - The counter must have REACHED freezeSeconds (180s default). Below
+ *     that, we just record.
+ *   - The counter must have been STAGNANT for stagnantPolls (2 default)
+ *     consecutive polls. A real tool-call increments every TUI redraw,
+ *     so a non-incrementing counter across 30s+ of wall clock is the
+ *     wedge signature -- not normal long-running behaviour.
+ *   - Recovery is one-shot per spell (attempts cap at 1). The next sweep
+ *     reads a fresh pane after the respawn.
+ *   - A tag change (e.g. Brewed -> Worked) resets the spell -- the
+ *     tool-call moved to a new phase, that IS progress.
+ */
+export function decideStuckToolCallRecovery(
+  sig: ToolCallProgressSignature | null,
+  prev: StuckToolCallState,
+  now: number,
+  thresholds: StuckToolCallThresholds,
+): StuckToolCallDecision {
+  // No tool-call line: end any spell.
+  if (sig === null) {
+    return { recover: false, next: { ...NO_STUCK_TOOL_CALL } }
+  }
+  // Spell start, OR tag changed (a verb change is genuine progress).
+  if (prev.tag !== sig.tag || prev.firstSeenAt === null) {
+    return {
+      recover: false,
+      next: {
+        tag: sig.tag,
+        spellStartSeconds: sig.seconds,
+        firstSeenAt: now,
+        lastSeconds: sig.seconds,
+        stagnantPolls: 0,
+        attempts: 0,
+      },
+    }
+  }
+  // Backwards clock skew: restart the spell rather than stall.
+  if (now < prev.firstSeenAt) {
+    return {
+      recover: false,
+      next: {
+        tag: sig.tag,
+        spellStartSeconds: sig.seconds,
+        firstSeenAt: now,
+        lastSeconds: sig.seconds,
+        stagnantPolls: 0,
+        attempts: 0,
+      },
+    }
+  }
+  // Counter advanced: real progress, reset the stagnant counter. We keep
+  // the spell open (tag is the same) so that if it freezes LATER we don't
+  // have to wait through another freezeSeconds runup.
+  if (prev.lastSeconds !== null && sig.seconds > prev.lastSeconds) {
+    return {
+      recover: false,
+      next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: 0 },
+    }
+  }
+  // Counter stagnant (same or rolled-back). Tick the stagnant counter.
+  const nextStagnant = prev.stagnantPolls + 1
+  // Recovery already fired in this spell: hold.
+  if (prev.attempts >= 1) {
+    return { recover: false, next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant } }
+  }
+  // Not yet at the freeze threshold -- a tool-call can pause briefly mid-
+  // run without being wedged. Only fire once the counter sits at >=
+  // freezeSeconds AND has held there for stagnantPolls consecutive polls.
+  if (sig.seconds < thresholds.freezeSeconds || nextStagnant < thresholds.stagnantPolls) {
+    return { recover: false, next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant } }
+  }
+  return {
+    recover: true,
+    next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant, attempts: 1 },
+  }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -16,6 +16,7 @@ import { startChannelPluginMonitor } from './web/channel-monitor.js'
 import { startInboundProber } from './web/inbound-probe.js'
 import { startChannelHealthMonitor } from './web/channel-health-monitor.js'
 import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
+import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
@@ -233,6 +234,9 @@ export function startWebServer(port = 3420): http.Server {
   const stuckInputInterval = startStuckInputWatcher()
   logger.info('Stuck-input watcher started (15s poll, 20s offset)')
 
+  const stuckToolCallInterval = startStuckToolCallWatcher()
+  logger.info('Stuck-tool-call watcher started (30s poll, 35s offset)')
+
   const updateCheckerInterval = startUpdateChecker()
   logger.info('Update checker started (15min poll)')
 
@@ -280,6 +284,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(pluginMonitorInterval)
     clearInterval(channelHealthInterval)
     clearInterval(stuckInputInterval)
+    clearInterval(stuckToolCallInterval)
     clearInterval(updateCheckerInterval)
     return origClose(cb)
   }

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -1,0 +1,125 @@
+// Stuck tool-call watchdog for the main channels session (2026-06-02 incident).
+//
+// Symptom & root cause (from cold-memory entry `marveen,deafness,Worked for`):
+//   Marveen's TUI gets stuck at "Worked for 31s" indefinitely. The Telegram
+//   reply tool-call hung server-side (no client-side timeout), and the
+//   claude TUI render loop blocks on its stdio pipe. CPU drops to 0.3%,
+//   IO-wait. The bun channel-plugin poller is still alive, so #240's
+//   bun-alive short-circuit hides the freeze from the main recovery cascade --
+//   stage 1-4 never fires. Inbound traffic is read by bun and delivered into
+//   the prompt buffer, but the TUI can never act on it: Szabi sees "Marveen
+//   válaszol, de a válasz nem jön meg Telegramra".
+//
+// Detection: parse the TUI's "<verb> for Ns" progress line; if the same
+// tag+seconds is observed across multiple polls AND the seconds value has
+// reached freezeSeconds, the tool-call is wedged. Recovery is a fresh
+// respawn (hardRestartMarveenChannels), which goes through channels.sh and
+// hence picks up all the existing safety nets (#231, #232, #234, #236).
+//
+// Critical guard (Marveen 2026-06-02 review): a legitimate long-running
+// tool-call (slow Anthropic inference, multi-stage research agent) MUST
+// NOT trigger this. Two layers of false-positive protection:
+//   1. seconds >= freezeSeconds (180s default) -- below that, just record.
+//   2. The counter must be STAGNANT for stagnantPolls (2 default) consecutive
+//      polls. A real tool-call increments the seconds every TUI redraw
+//      (~once per second). A non-incrementing counter across two 30s poll
+//      intervals (60s wall clock at least) is the wedge signature.
+// A real wedge satisfies BOTH. A real slow-but-progressing tool-call fails
+// the second (counter keeps incrementing) so we never act.
+//
+// Scope: MAIN channels session only. Sub-agents are managed by Marveen
+// inter-agent; their tool-call freezes are not user-facing in the same way
+// and the respawn path (stopAgentProcess + startAgentProcess) is different.
+// Extend if a sub-agent case ever materialises.
+
+import { logger } from '../logger.js'
+import { capturePane } from './agent-process.js'
+import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { hardRestartMarveenChannels } from './channel-monitor.js'
+import {
+  stuckToolCallSignature,
+  decideStuckToolCallRecovery,
+  type StuckToolCallState,
+  type StuckToolCallThresholds,
+} from '../pane-state.js'
+
+// Defaults chosen against the 2026-06-02 incident profile.
+//   - freezeSeconds = 180: long enough that a real slow Anthropic call
+//     (multi-thousand-token thinking + tool result) doesn't trip it. The
+//     observed wedge sat at 31s, but the seconds value when the freeze
+//     actually started is irrelevant -- a wedged 31s sits at 31s forever
+//     until we hit freezeSeconds when stagnation IS the signal.
+//   - stagnantPolls = 2: with INTERVAL_MS=30s, two consecutive non-
+//     incrementing polls means ~60s+ of wall clock without a single TUI
+//     redraw advancing the counter. A healthy long-running tool-call
+//     redraws every second.
+const THRESHOLDS: StuckToolCallThresholds = {
+  freezeSeconds: 180,
+  stagnantPolls: 2,
+}
+
+// Poll cadence. Offset 35s so the three pane-readers (channel-monitor 30s,
+// channel-health 45s, stuck-input 15s+20s, this one) don't all hit
+// capture-pane on the same tick.
+const INITIAL_DELAY_MS = 35_000
+const INTERVAL_MS = 30_000
+
+const NO_STATE: StuckToolCallState = {
+  tag: null,
+  spellStartSeconds: null,
+  firstSeenAt: null,
+  lastSeconds: null,
+  stagnantPolls: 0,
+  attempts: 0,
+}
+
+// Session-keyed state map. Only the main session ever has an entry today,
+// but the map shape leaves room for sub-agents without an API change.
+const watchState = new Map<string, StuckToolCallState>()
+
+function checkSession(label: string, session: string): void {
+  const pane = capturePane(session)
+  const sig = pane == null ? null : stuckToolCallSignature(pane)
+
+  const prev = watchState.get(session) ?? NO_STATE
+  const { recover, next } = decideStuckToolCallRecovery(sig, prev, Date.now(), THRESHOLDS)
+
+  if (next.tag === null) {
+    watchState.delete(session)
+  } else {
+    watchState.set(session, next)
+  }
+
+  if (recover) {
+    // Audit log requested by Marveen 2026-06-02: every respawn this watcher
+    // decides on must record the input that led to it, so a regression
+    // (spurious respawn during legitimate long work) is easy to spot.
+    logger.warn(
+      {
+        label,
+        session,
+        tag: next.tag,
+        seconds: next.lastSeconds,
+        stagnantPolls: next.stagnantPolls,
+        thresholds: THRESHOLDS,
+      },
+      'stuck-tool-call-watcher: TUI counter stagnant past freeze threshold, hard-restarting main channels session',
+    )
+    const result = hardRestartMarveenChannels()
+    if (!result.ok) {
+      logger.error({ label, session, error: result.error }, 'stuck-tool-call-watcher: hard restart failed')
+    }
+  }
+}
+
+export function startStuckToolCallWatcher(): NodeJS.Timeout {
+  function sweep() {
+    try {
+      checkSession('main', MAIN_CHANNELS_SESSION)
+    } catch (err) {
+      logger.debug({ err }, 'stuck-tool-call-watcher: main session check error')
+    }
+  }
+  setTimeout(sweep, INITIAL_DELAY_MS)
+  return setInterval(sweep, INTERVAL_MS)
+}

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -70,6 +70,7 @@ const NO_STATE: StuckToolCallState = {
   firstSeenAt: null,
   lastSeconds: null,
   stagnantPolls: 0,
+  stagnantSince: null,
   attempts: 0,
 }
 


### PR DESCRIPTION
## Summary (HIGH priority — reliability blocker)

2026-06-02 06:41 incident. Marveen's TUI sat at `Worked for 31s` with the channel-plugin's bun poller perfectly alive (9h14m etime). The Telegram reply tool-call hung server-side without a client-side timeout and the claude TUI render loop blocked on its stdio pipe. CPU 0.3%, IO-wait. Szabi's view: *"Mintha válaszolna de a válasza nem jön meg Telegramra"*.

The existing recovery cascade missed it because `hasChannelPluginAlive()` returned true (bun was up), so the #240 bun-alive short-circuit — which fixed the genuine 18-min false-positive at quiet idle — now also hides this kind of wedge. `stuck-input-watcher` only looks for typing-state parked text. launchctl/respawn paths trigger only on bun death or keepalive file aging out.

## Detection

Parse the TUI's `<verb> for Ns` line (Worked / Brewed / Baked / Cooking / Simmered / Sauteed). If the same `tag+seconds` is observed across `stagnantPolls` (default **2**) consecutive polls AND the counter has reached `freezeSeconds` (default **180s**), the TUI render loop is wedged.

## Recovery

`hardRestartMarveenChannels()` (existing path): `launchctl reload → channels.sh → #231/#232 unlock probe → #234 in-process unlock if needed`. `channels.sh --continue` keeps the session context.

## False-positive guards (Marveen 2026-06-02 review)

1. `seconds >= 180s`. Below that, just record. A real slow tool-call can pause briefly mid-run.
2. Counter must be **stagnant** across 2 polls. A healthy long-running tool-call increments the counter every TUI redraw (~once per second); a non-incrementing counter across 60s of wall clock is conclusive.
3. **One-shot per spell** — after a recovery we hold and let the next sweep read a fresh pane.
4. Tag changes (Brewed → Worked) and counter increments reset the spell, so legitimate verb transitions / progress never trip it.

**Audit log on every recovery** (Marveen-required): logs the tag, seconds, stagnantPolls and thresholds — a spurious respawn will be immediately greppable in `dashboard.log` for `stuck-tool-call-watcher:`.

## Scope

MAIN channels session only. Sub-agents are managed by Marveen inter-agent; their tool-call freezes are not user-facing in the same way and the respawn path is different. Extend if a sub-agent case ever materialises.

## Verified

- **20 tests pass**: parser, freeze threshold, stagnation gate, one-shot guard, **legitimate-long-call invariant** (counter goes 30→60→…→300s, never recovers), clock skew, boot-wiring assertions.
- `tsc --noEmit` clean.

## Test plan

- [ ] After deploy: `grep stuck-tool-call-watcher ~/ClaudeClaw/store/dashboard.log` shows the boot line and only shows recovery logs for actual freezes.
- [ ] Provoke a freeze (e.g. `kill -STOP <bun-pid>` then send a reply tool-call): expect recovery within ~60-90s; the audit log records `seconds`, `stagnantPolls`, thresholds.
- [ ] No spurious respawn during a long deep-research tool-call (counter increments → never acts).

## Out of scope (intentionally)

Timeout-wrap on the Telegram-plugin MCP tool-call is the complementary defense layer Marveen flagged as stretch. Separate PR if/when needed — not blocking this watchdog.

## Related

- #234 / #236 / #240 (channel-monitor recovery stack — this watchdog closes a gap they leave)
- #226 (kovesdan keep-alive — first version of "watch the pane mtime"; this is the natural extension to the tool-call line)