### PR TITLE
fix(heartbeat): disable channel plugins at project scope (#237 follow-up)

### DIFF
--- a/src/__tests__/heartbeat-worker-isolation.test.ts
+++ b/src/__tests__/heartbeat-worker-isolation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for the 2026-06-02 09:00-incident fix: the heartbeat
+// sub-agent must NOT load the Telegram / Slack / Discord channel plugins,
+// because doing so spawns a duplicate bun poller against Marveen's bot
+// token and crashes the live Marveen channel via 409 Conflict.
+//
+// The #237 fix scoped only project-level MCPs (empty .mcp.json), but
+// `enabledPlugins` lives at the USER scope in ~/.claude/settings.json and
+// is global to every Claude Code spawn unless a project-scope settings.json
+// overrides it. This PR adds that override.
+
+const SRC = readFileSync(join(__dirname, '../heartbeat.ts'), 'utf-8')
+
+describe('heartbeat worker cwd isolation (2026-06-02 09:00 incident)', () => {
+  it('declares the disabled-plugins list explicitly', () => {
+    expect(SRC).toMatch(/HEARTBEAT_DISABLED_PLUGINS/)
+    expect(SRC).toMatch(/telegram@claude-plugins-official/)
+    expect(SRC).toMatch(/slack-channel@marveen-marketplace/)
+  })
+
+  it('writes a project-scope .claude/settings.json with enabledPlugins:false', () => {
+    expect(SRC).toMatch(/\.claude/)
+    expect(SRC).toMatch(/enabledPlugins/)
+    // The write path must call writeFileSync with a settings.json target.
+    expect(SRC).toMatch(/settingsPath/)
+    expect(SRC).toMatch(/writeFileSync\(settingsPath/)
+  })
+
+  it('MERGES with existing settings.json (preserves hooks/etc., does not clobber)', () => {
+    // The Claude Code TUI auto-generates a settings.json with a PreCompact
+    // hooks section. The ensureHeartbeatWorkerCwd must NOT overwrite that
+    // (Marveen audit memoria-mentes hook relies on it). Re-read, parse,
+    // merge enabledPlugins only.
+    expect(SRC).toMatch(/readFileSync\(settingsPath/)
+    expect(SRC).toMatch(/JSON\.parse/)
+    expect(SRC).toMatch(/\.\.\.current/)
+  })
+
+  it('idempotent: a no-op tick must NOT rewrite the file (dirty flag)', () => {
+    // Repeated writes would tick the mtime every minute and add noise to
+    // any file watcher / SCM diff. Only write when the enabledPlugins map
+    // actually changes.
+    expect(SRC).toMatch(/dirty/)
+    expect(SRC).toMatch(/dirty\s*\|\|/)
+  })
+
+  it('keeps the empty .mcp.json -- defense in depth for project-scope MCPs', () => {
+    expect(SRC).toMatch(/mcpServers/)
+    expect(SRC).toMatch(/"mcpServers":\{\}/)
+  })
+
+  it('runs in the same ensureHeartbeatWorkerCwd that heartbeat.ts already calls', () => {
+    expect(SRC).toMatch(/function ensureHeartbeatWorkerCwd/)
+    expect(SRC).toMatch(/ensureHeartbeatWorkerCwd\(\)/)
+  })
+})

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,4 +1,4 @@
-import { statSync, mkdirSync, writeFileSync, existsSync } from 'node:fs'
+import { statSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   HEARTBEAT_START_HOUR,
@@ -30,14 +30,72 @@ import { wrapUntrusted, UNTRUSTED_PREAMBLE } from './prompt-safety.js'
 // call -- safe to delete by hand, will be recreated next tick.
 const HEARTBEAT_AGENT_CWD = join(PROJECT_ROOT, 'agents', 'heartbeat-worker')
 
+// Plugins that MUST be disabled at the project-scope settings.json for the
+// heartbeat sub-agent. The user-scope ~/.claude/settings.json keeps these
+// enabled for Marveen / sub-agents that legitimately need them; the
+// project-scope override is just for this isolated cwd. 2026-06-02 09:00
+// incident: the original #237 fix only emptied `.mcp.json` (project-scope
+// MCPs), but the user-scope `enabledPlugins` is GLOBAL and was still
+// loading the Telegram plugin in the sub-agent. The sub-agent then spawned
+// its own bun poller against the same bot token -> 409 Conflict -> Marveen
+// channel down by 09:02:45. Project-scope `enabledPlugins: false` overrides
+// the user-scope `true` per Claude Code settings precedence.
+const HEARTBEAT_DISABLED_PLUGINS = [
+  'telegram@claude-plugins-official',
+  'slack-channel@marveen-marketplace',
+  'discord@claude-plugins-official',
+] as const
+
+interface ClaudeSettings {
+  enabledPlugins?: Record<string, boolean>
+  hooks?: unknown
+  [key: string]: unknown
+}
+
 function ensureHeartbeatWorkerCwd(): void {
   try {
     if (!existsSync(HEARTBEAT_AGENT_CWD)) {
       mkdirSync(HEARTBEAT_AGENT_CWD, { recursive: true })
     }
+    // Project-scope empty MCP list (defense in depth -- the load-bearing
+    // gate is the enabledPlugins override below).
     const mcpPath = join(HEARTBEAT_AGENT_CWD, '.mcp.json')
     if (!existsSync(mcpPath)) {
       writeFileSync(mcpPath, '{"mcpServers":{}}\n')
+    }
+
+    // Project-scope settings.json with enabledPlugins override. MERGE with
+    // anything Claude Code (or a prior tick) may have written -- a stale
+    // hooks: section or other field must survive. We only force-write the
+    // enabledPlugins map.
+    const settingsDir = join(HEARTBEAT_AGENT_CWD, '.claude')
+    const settingsPath = join(settingsDir, 'settings.json')
+    if (!existsSync(settingsDir)) {
+      mkdirSync(settingsDir, { recursive: true })
+    }
+    let current: ClaudeSettings = {}
+    if (existsSync(settingsPath)) {
+      try {
+        const raw = readFileSync(settingsPath, 'utf-8')
+        const parsed = JSON.parse(raw)
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          current = parsed as ClaudeSettings
+        }
+      } catch (err) {
+        logger.warn({ err, path: settingsPath }, 'Heartbeat: failed to parse worker settings.json, rewriting')
+      }
+    }
+    const enabledPlugins: Record<string, boolean> = { ...(current.enabledPlugins ?? {}) }
+    let dirty = false
+    for (const plugin of HEARTBEAT_DISABLED_PLUGINS) {
+      if (enabledPlugins[plugin] !== false) {
+        enabledPlugins[plugin] = false
+        dirty = true
+      }
+    }
+    if (dirty || current.enabledPlugins == null) {
+      const next: ClaudeSettings = { ...current, enabledPlugins }
+      writeFileSync(settingsPath, JSON.stringify(next, null, 2) + '\n')
     }
   } catch (err) {
     logger.warn({ err, cwd: HEARTBEAT_AGENT_CWD }, 'Heartbeat: failed to ensure isolated worker cwd, falling back to PROJECT_ROOT')


### PR DESCRIPTION
## Summary (HIGH priority — reliability blocker, 10:00 heartbeat is next test window)

2026-06-02 09:00 incident exposed that #237 was incomplete. Symptom: at 09:00:00 the heartbeat sub-agent ran, by 09:02:45 Marveen's channel plugin was down — the exact 65%-cluster correlation #237 was meant to close.

## Root cause

#237 emptied the project-scope `.mcp.json`, which only prevents project-level MCPs from loading. But the channel plugin lives in the **USER-scope** `enabledPlugins` map at `~/.claude/settings.json`, global to every Claude Code spawn:

```json
"enabledPlugins": {
  "telegram@claude-plugins-official": true,
  "slack-channel@marveen-marketplace": true,
  ...
}
```

The SDK-spawned heartbeat sub-agent inherited that user-scope map, loaded the Telegram plugin, and the plugin's bun poller raced Marveen's poller for the same bot token → 409 Conflict → Marveen channel down.

## Fix

`ensureHeartbeatWorkerCwd` now also writes/merges a project-scope `.claude/settings.json` with `enabledPlugins.<plugin>: false` for telegram / slack-channel / discord. Per Claude Code's settings precedence (project overrides user per-key), the sub-agent now sees those plugins as disabled regardless of the user map.

## Merge semantics

The Claude Code TUI auto-generates `settings.json` with a PreCompact `hooks` section. The write path reads, parses, merges only the `enabledPlugins` map, writes back — never clobbers `hooks` or any other key. **Dirty-flag** guards against pointless rewrites (a no-op tick must not touch mtime).

## Verified

- 6 new contract tests pass (explicit plugin list, project-scope write path, merge semantics, idempotency, `.mcp.json` defense-in-depth, function-wiring)
- `tsc --noEmit` clean

## Test plan

- [ ] Deploy before 10:00 (next heartbeat window)
- [ ] 10:00:00: heartbeat sub-agent runs, `cat agents/heartbeat-worker/.claude/settings.json` shows `enabledPlugins.telegram@claude-plugins-official: false`
- [ ] By 10:10: NO `Marveen channel plugin down -- stage 1` in dashboard.log for the heartbeat window
- [ ] Marveen claude PID + bun unchanged across the heartbeat run

## Related

- #237 (project-scope `.mcp.json` empty — necessary but not sufficient; this completes the fix)
- #246 (stuck-tool-call watchdog — already deployed, catches the symptom; this PR removes the cause)