### PR TITLE
fix(heartbeat): isolate sub-agent via CLAUDE_CONFIG_DIR (#247 failed in prod)

### DIFF
--- a/src/__tests__/heartbeat-worker-isolation.test.ts
+++ b/src/__tests__/heartbeat-worker-isolation.test.ts
@@ -2,58 +2,69 @@ import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-// Contract tests for the 2026-06-02 09:00-incident fix: the heartbeat
-// sub-agent must NOT load the Telegram / Slack / Discord channel plugins,
-// because doing so spawns a duplicate bun poller against Marveen's bot
-// token and crashes the live Marveen channel via 409 Conflict.
+// Contract tests for the 2026-06-02 channel-disconnect chain.
 //
-// The #237 fix scoped only project-level MCPs (empty .mcp.json), but
-// `enabledPlugins` lives at the USER scope in ~/.claude/settings.json and
-// is global to every Claude Code spawn unless a project-scope settings.json
-// overrides it. This PR adds that override.
+// - #237: project-scope .mcp.json={} -- necessary but not sufficient
+// - #247: project-scope .claude/settings.json enabledPlugins:false --
+//         DID NOT WORK in production (9/10/11/12 hb all spawned the
+//         Telegram plugin and crashed Marveen via 409 Conflict). The
+//         claude-agent-sdk reads ~/.claude/settings.json directly and
+//         ignores the project-scope override.
+// - THIS PR: CLAUDE_CONFIG_DIR repointing -- the SDK-documented way to
+//         override the entire ~/.claude/ root for an SDK-spawned claude.
+//         Combined with a symlinked passthrough of auth + projects, the
+//         heartbeat sub-agent now operates with enabledPlugins:{} and
+//         cannot load any channel plugin.
 
 const SRC = readFileSync(join(__dirname, '../heartbeat.ts'), 'utf-8')
 
-describe('heartbeat worker cwd isolation (2026-06-02 09:00 incident)', () => {
-  it('declares the disabled-plugins list explicitly', () => {
+describe('heartbeat worker cwd + CLAUDE_CONFIG_DIR isolation (2026-06-02 incident chain)', () => {
+  it('uses CLAUDE_CONFIG_DIR as the load-bearing override -- not just project-scope settings.json', () => {
+    expect(SRC).toMatch(/CLAUDE_CONFIG_DIR/)
+    expect(SRC).toMatch(/HEARTBEAT_CONFIG_DIR/)
+  })
+
+  it('passes CLAUDE_CONFIG_DIR to runAgent via the env override', () => {
+    // runAgent's 6th positional arg is env: Record<string, string | undefined>.
+    // CLAUDE_CONFIG_DIR must travel through that channel to actually reach the
+    // SDK-spawned claude.
+    expect(SRC).toMatch(/runAgent\([^)]+CLAUDE_CONFIG_DIR/)
+  })
+
+  it('symlinks ~/.claude/ entries INTO the isolated config dir (preserve auth + projects)', () => {
+    // An empty CLAUDE_CONFIG_DIR would lose the OAuth tokens needed for the
+    // sub-agent to call the Anthropic API. We symlink everything except
+    // settings.json (which we replace) and noise files.
+    expect(SRC).toMatch(/symlinkSync/)
+    expect(SRC).toMatch(/homedir\(\)/)
+    expect(SRC).toMatch(/readdirSync/)
+    expect(SRC).toMatch(/HEARTBEAT_CONFIG_SKIP/)
+  })
+
+  it('explicitly skips settings.json from the symlink set (it is the WHOLE POINT to replace it)', () => {
+    expect(SRC).toMatch(/HEARTBEAT_CONFIG_SKIP[^)]*settings\.json/s)
+  })
+
+  it('writes a fresh settings.json with enabledPlugins:false for telegram/slack/discord', () => {
     expect(SRC).toMatch(/HEARTBEAT_DISABLED_PLUGINS/)
     expect(SRC).toMatch(/telegram@claude-plugins-official/)
     expect(SRC).toMatch(/slack-channel@marveen-marketplace/)
+    expect(SRC).toMatch(/discord@claude-plugins-official/)
   })
 
-  it('writes a project-scope .claude/settings.json with enabledPlugins:false', () => {
-    expect(SRC).toMatch(/\.claude/)
-    expect(SRC).toMatch(/enabledPlugins/)
-    // The write path must call writeFileSync with a settings.json target.
-    expect(SRC).toMatch(/settingsPath/)
-    expect(SRC).toMatch(/writeFileSync\(settingsPath/)
+  it('refuses to read through a settings.json symlink (would import user-scope enabledPlugins)', () => {
+    // If a prior tick's HEARTBEAT_CONFIG_SKIP didn't contain settings.json
+    // and it got symlinked, we must unlink it and write our own file --
+    // never inherit the user-scope content silently.
+    expect(SRC).toMatch(/isSymbolicLink/)
+    expect(SRC).toMatch(/rmSync\(settingsPath/)
   })
 
-  it('MERGES with existing settings.json (preserves hooks/etc., does not clobber)', () => {
-    // The Claude Code TUI auto-generates a settings.json with a PreCompact
-    // hooks section. The ensureHeartbeatWorkerCwd must NOT overwrite that
-    // (Marveen audit memoria-mentes hook relies on it). Re-read, parse,
-    // merge enabledPlugins only.
-    expect(SRC).toMatch(/readFileSync\(settingsPath/)
-    expect(SRC).toMatch(/JSON\.parse/)
-    expect(SRC).toMatch(/\.\.\.current/)
-  })
-
-  it('idempotent: a no-op tick must NOT rewrite the file (dirty flag)', () => {
-    // Repeated writes would tick the mtime every minute and add noise to
-    // any file watcher / SCM diff. Only write when the enabledPlugins map
-    // actually changes.
-    expect(SRC).toMatch(/dirty/)
-    expect(SRC).toMatch(/dirty\s*\|\|/)
-  })
-
-  it('keeps the empty .mcp.json -- defense in depth for project-scope MCPs', () => {
-    expect(SRC).toMatch(/mcpServers/)
+  it('keeps the empty .mcp.json -- defense in depth', () => {
     expect(SRC).toMatch(/"mcpServers":\{\}/)
   })
 
-  it('runs in the same ensureHeartbeatWorkerCwd that heartbeat.ts already calls', () => {
-    expect(SRC).toMatch(/function ensureHeartbeatWorkerCwd/)
-    expect(SRC).toMatch(/ensureHeartbeatWorkerCwd\(\)/)
+  it('idempotent: stale non-symlinks under the config dir get rebuilt, not appended', () => {
+    expect(SRC).toMatch(/rmSync\(linkPath/)
   })
 })

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,5 +1,6 @@
-import { statSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
+import { statSync, mkdirSync, writeFileSync, existsSync, readFileSync, symlinkSync, readdirSync, lstatSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
+import { homedir } from 'node:os'
 import {
   HEARTBEAT_START_HOUR,
   HEARTBEAT_END_HOUR,
@@ -30,6 +31,22 @@ import { wrapUntrusted, UNTRUSTED_PREAMBLE } from './prompt-safety.js'
 // call -- safe to delete by hand, will be recreated next tick.
 const HEARTBEAT_AGENT_CWD = join(PROJECT_ROOT, 'agents', 'heartbeat-worker')
 
+// Isolated CLAUDE_CONFIG_DIR for the heartbeat sub-agent. The claude-agent-sdk
+// recognises the CLAUDE_CONFIG_DIR env var and reads ALL Claude Code config
+// (settings.json, projects/, plugins/, marketplaces/, OAuth tokens) from this
+// path instead of ~/.claude/. We construct this dir as a SET OF SYMLINKS to
+// the real ~/.claude/ -- preserving auth, project transcripts and plugin
+// marketplaces -- but REPLACE settings.json with an explicit
+// enabledPlugins:{} (all-false) override.
+//
+// Why: 2026-06-02 10:00 incident proved that the project-scope settings.json
+// (#247) does NOT override the user-scope enabledPlugins map inside the
+// claude-agent-sdk spawn path. The SDK reads ~/.claude/settings.json
+// directly. Repointing CLAUDE_CONFIG_DIR is the documented way the SDK
+// supports an isolated config root (sdk.d.ts: "set CLAUDE_CONFIG_DIR=/tmp
+// for ephemeral local copy").
+const HEARTBEAT_CONFIG_DIR = join(HEARTBEAT_AGENT_CWD, '.claude-config')
+
 // Plugins that MUST be disabled at the project-scope settings.json for the
 // heartbeat sub-agent. The user-scope ~/.claude/settings.json keeps these
 // enabled for Marveen / sub-agents that legitimately need them; the
@@ -52,29 +69,69 @@ interface ClaudeSettings {
   [key: string]: unknown
 }
 
+// Items under ~/.claude/ that must NOT be symlinked into the isolated
+// config dir. settings.json is the WHOLE POINT -- it gets replaced with
+// our enabledPlugins:{} override. .DS_Store / lock files are just noise.
+const HEARTBEAT_CONFIG_SKIP = new Set(['settings.json', '.DS_Store', '.lock'])
+
 function ensureHeartbeatWorkerCwd(): void {
   try {
     if (!existsSync(HEARTBEAT_AGENT_CWD)) {
       mkdirSync(HEARTBEAT_AGENT_CWD, { recursive: true })
     }
     // Project-scope empty MCP list (defense in depth -- the load-bearing
-    // gate is the enabledPlugins override below).
+    // gates are the enabledPlugins override + CLAUDE_CONFIG_DIR).
     const mcpPath = join(HEARTBEAT_AGENT_CWD, '.mcp.json')
     if (!existsSync(mcpPath)) {
       writeFileSync(mcpPath, '{"mcpServers":{}}\n')
     }
 
-    // Project-scope settings.json with enabledPlugins override. MERGE with
-    // anything Claude Code (or a prior tick) may have written -- a stale
-    // hooks: section or other field must survive. We only force-write the
-    // enabledPlugins map.
-    const settingsDir = join(HEARTBEAT_AGENT_CWD, '.claude')
-    const settingsPath = join(settingsDir, 'settings.json')
-    if (!existsSync(settingsDir)) {
-      mkdirSync(settingsDir, { recursive: true })
+    // Build the isolated CLAUDE_CONFIG_DIR. Symlink every top-level entry
+    // from ~/.claude/ EXCEPT settings.json (which we replace) and noise
+    // files. Symlinks let auth tokens / project transcripts / plugin
+    // marketplaces remain shared, while settings.json -- the only file
+    // whose enabledPlugins map matters here -- is private to this dir.
+    if (!existsSync(HEARTBEAT_CONFIG_DIR)) {
+      mkdirSync(HEARTBEAT_CONFIG_DIR, { recursive: true })
     }
+    const realClaude = join(homedir(), '.claude')
+    if (existsSync(realClaude)) {
+      for (const entry of readdirSync(realClaude)) {
+        if (HEARTBEAT_CONFIG_SKIP.has(entry)) continue
+        const linkPath = join(HEARTBEAT_CONFIG_DIR, entry)
+        const target = join(realClaude, entry)
+        // Already a correct symlink? Skip. Anything else (stale file,
+        // wrong target) gets unlinked and re-created so a manual edit
+        // doesn't permanently break the isolation.
+        let needsLink = true
+        if (existsSync(linkPath) || lstatSyncSafe(linkPath)) {
+          try {
+            const st = lstatSync(linkPath)
+            if (st.isSymbolicLink()) {
+              needsLink = false
+            } else {
+              rmSync(linkPath, { recursive: true, force: true })
+            }
+          } catch { /* will recreate */ }
+        }
+        if (needsLink) {
+          try {
+            symlinkSync(target, linkPath)
+          } catch (err) {
+            logger.warn({ err, target, linkPath }, 'Heartbeat: failed to symlink config entry, sub-agent may degrade')
+          }
+        }
+      }
+    }
+
+    // The actual override: a fresh settings.json with enabledPlugins:{}
+    // (every channel plugin explicitly false). MERGE with anything
+    // Claude Code may have written in a prior tick so hook configs etc.
+    // survive -- but if a real ~/.claude/settings.json exists, we DO NOT
+    // copy its content (only the enabledPlugins flip is intended).
+    const settingsPath = join(HEARTBEAT_CONFIG_DIR, 'settings.json')
     let current: ClaudeSettings = {}
-    if (existsSync(settingsPath)) {
+    if (existsSync(settingsPath) && !lstatSync(settingsPath).isSymbolicLink()) {
       try {
         const raw = readFileSync(settingsPath, 'utf-8')
         const parsed = JSON.parse(raw)
@@ -84,6 +141,11 @@ function ensureHeartbeatWorkerCwd(): void {
       } catch (err) {
         logger.warn({ err, path: settingsPath }, 'Heartbeat: failed to parse worker settings.json, rewriting')
       }
+    } else if (lstatSyncSafe(settingsPath)?.isSymbolicLink()) {
+      // Symlink to real settings.json from a prior tick or HEARTBEAT_CONFIG_SKIP
+      // change -- remove it so we own the file. Reading through the symlink
+      // would import the user-scope enabledPlugins, defeating the override.
+      rmSync(settingsPath, { force: true })
     }
     const enabledPlugins: Record<string, boolean> = { ...(current.enabledPlugins ?? {}) }
     let dirty = false
@@ -93,13 +155,17 @@ function ensureHeartbeatWorkerCwd(): void {
         dirty = true
       }
     }
-    if (dirty || current.enabledPlugins == null) {
+    if (dirty || current.enabledPlugins == null || !existsSync(settingsPath)) {
       const next: ClaudeSettings = { ...current, enabledPlugins }
       writeFileSync(settingsPath, JSON.stringify(next, null, 2) + '\n')
     }
   } catch (err) {
     logger.warn({ err, cwd: HEARTBEAT_AGENT_CWD }, 'Heartbeat: failed to ensure isolated worker cwd, falling back to PROJECT_ROOT')
   }
+}
+
+function lstatSyncSafe(p: string): ReturnType<typeof lstatSync> | null {
+  try { return lstatSync(p) } catch { return null }
 }
 
 // --- Data types ---
@@ -317,7 +383,14 @@ async function executeHeartbeat(): Promise<void> {
     // heartbeat fire. The agents/heartbeat-worker dir has an empty
     // .mcp.json and no agent-config, so claude finds no channel plugin
     // to activate.
-    const { text } = await runAgent(prompt, undefined, undefined, false, HEARTBEAT_AGENT_CWD)
+    // CLAUDE_CONFIG_DIR repoints the SDK-spawned claude to the isolated
+    // config root we just built. That's the gate that actually prevents
+    // the user-scope enabledPlugins:{telegram:true} from leaking in --
+    // the project-scope override in #247 did NOT (verified: 09/10/11/12
+    // hb all loaded the plugin and crashed Marveen via 409 Conflict).
+    const { text } = await runAgent(prompt, undefined, undefined, false, HEARTBEAT_AGENT_CWD, {
+      CLAUDE_CONFIG_DIR: HEARTBEAT_CONFIG_DIR,
+    })
     if (text) {
       await notifyTelegram(text)
       logger.info('Heartbeat ertesites elkuldve')


### PR DESCRIPTION
## Summary (HIGH priority — production-verified blocker)

2026-06-02 9/10/11/12:00 heartbeat fires ALL crashed Marveen's channel plugin via the same 409-Conflict path, despite #247 having deployed. The `.claude/settings.json` is written correctly at every tick, but **the claude-agent-sdk-spawned headless claude reads `~/.claude/settings.json` directly and ignores the project-scope override**. The user-scope `telegram@…: true` wins every time.

The #246 stuck-tool-call watchdog hid the symptom (~2 min recovery on every fire), but the underlying cause stayed live: ~65 % of Marveen restarts today clustered into the 0-10 min window after each heartbeat fire, just like 2026-06-01.

## Fix

`CLAUDE_CONFIG_DIR` env var — the SDK-documented way to repoint the entire Claude Code config root for a single sub-agent spawn (`sdk.d.ts`: *"set CLAUDE_CONFIG_DIR=/tmp for ephemeral local copy"*).

The heartbeat-worker now constructs an isolated config dir at `agents/heartbeat-worker/.claude-config/` that:

- **Symlinks every entry under `~/.claude/` EXCEPT `settings.json`** — OAuth tokens, `projects/`, `plugins/cache/`, `marketplaces/` remain shared, sub-agent can still authenticate and use installed skills
- **Writes its OWN `settings.json`** with `enabledPlugins:{telegram:false, slack-channel:false, discord:false}`
- **Refuses to read a settings.json symlink** (a prior tick that symlinked it would silently inherit user-scope `enabledPlugins`)

`runAgent` call now passes `env: { CLAUDE_CONFIG_DIR: HEARTBEAT_CONFIG_DIR }` so the SDK spawn picks up the override.

## Verified

- 8 contract tests pass (`CLAUDE_CONFIG_DIR` present, env-passing to `runAgent`, symlink construction, settings.json skip invariant, explicit plugin disable list, symlink-rejection, `.mcp.json` defense in depth, idempotent rebuild)
- `tsc --noEmit` clean

## Test plan

- [ ] Deploy ASAP (next hb at 13:00)
- [ ] 13:00:00: heartbeat fires; `ls -la agents/heartbeat-worker/.claude-config/` shows symlinks for `projects` / `plugins` / oauth files, AND a regular file `settings.json` with `enabledPlugins:false`
- [ ] No `Marveen channel plugin down -- stage 1` event in the 13:00-13:10 window of `dashboard.log`
- [ ] Sub-agent's heartbeat notification still goes out (Resend / Telegram Bot API direct, not via the channel plugin)

## Related

- #237 (project `.mcp.json={}` — necessary, kept as defense in depth)
- #247 (project `.claude/settings.json enabledPlugins:false` — failed in prod, kept for the CLI-bin code path that may yet honour it)
- #246 (stuck-tool-call watchdog — backstop, still in force for unrelated freezes)