### PR TITLE
fix(heartbeat): copy ~/.claude.json + dashboard-hide sentinel (#252 regression)

### DIFF
--- a/src/__tests__/heartbeat-claude-json-bridge.test.ts
+++ b/src/__tests__/heartbeat-claude-json-bridge.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for the 2026-06-02 14:27 hb-fire regression (#252 follow-up):
+//   - Sub-agent ran without 'Not logged in' (Claude API auth fine), but
+//     Gmail OAuth was gone and Calendar fell back to the wrong default
+//     account because user-level project-scope MCPs live in ~/.claude.json
+//     under projects[<cwd>], which the symlink loop missed (HOME root, one
+//     level UP from ~/.claude/).
+//   - Fix: copy ~/.claude.json into the isolated config dir and duplicate
+//     projects[PROJECT_ROOT] under projects[HEARTBEAT_AGENT_CWD].
+//   - Plus: dashboard-hide sentinel so the heartbeat-worker dir doesn't
+//     pollute the agent list (Szabi 14:31 ask).
+
+const HB_SRC = readFileSync(join(__dirname, '../heartbeat.ts'), 'utf-8')
+const CFG_SRC = readFileSync(join(__dirname, '../web/agent-config.ts'), 'utf-8')
+
+describe('heartbeat ~/.claude.json bridge (2026-06-02 14:27 regression fix)', () => {
+  it('reads the real ~/.claude.json from HOME (not from CLAUDE_CONFIG_DIR)', () => {
+    expect(HB_SRC).toMatch(/homedir\(\),\s*'\.claude\.json'/)
+  })
+
+  it('writes the parsed JSON into HEARTBEAT_CONFIG_DIR/.claude.json with mode 0600', () => {
+    expect(HB_SRC).toMatch(/HEARTBEAT_CONFIG_DIR.*\.claude\.json/s)
+    // The auth-equivalent file must have the same 0600 mode as
+    // .credentials.json -- a world-readable .claude.json with the
+    // oauthAccount key would leak the user id.
+    const start = HB_SRC.indexOf('heartbeatClaudeJsonPath')
+    expect(start).toBeGreaterThan(0)
+    // The next writeFileSync that targets heartbeatClaudeJsonPath must
+    // pass mode 0o600. Slice from the first `writeFileSync(heartbeatClaudeJsonPath`
+    // to the end of that call and look for 0o600 anywhere inside.
+    const writeIdx = HB_SRC.indexOf('writeFileSync(heartbeatClaudeJsonPath', start)
+    expect(writeIdx).toBeGreaterThan(0)
+    const callEnd = HB_SRC.indexOf('})', writeIdx)
+    expect(callEnd).toBeGreaterThan(writeIdx)
+    const callBody = HB_SRC.slice(writeIdx, callEnd + 2)
+    expect(callBody).toMatch(/0o600/)
+  })
+
+  it('duplicates projects[PROJECT_ROOT] into projects[HEARTBEAT_AGENT_CWD]', () => {
+    // The Claude Code TUI keys project-scope MCPs by absolute cwd. The
+    // heartbeat sub-agent runs in agents/heartbeat-worker, so an empty
+    // entry there means no MCPs visible. Duplicating the PROJECT_ROOT
+    // entry under the new key lets the sub-agent inherit Marveen's
+    // Gmail + Calendar MCPs without any other change.
+    expect(HB_SRC).toMatch(/projects\[PROJECT_ROOT\]/)
+    expect(HB_SRC).toMatch(/projects\[HEARTBEAT_AGENT_CWD\]/)
+  })
+
+  it('refuses to clobber an existing projects[HEARTBEAT_AGENT_CWD] entry', () => {
+    // If a prior tick wrote a curated entry we should not stomp it.
+    // Guard with `!projects[HEARTBEAT_AGENT_CWD]` (only set when absent).
+    expect(HB_SRC).toMatch(/!\s*projects\[HEARTBEAT_AGENT_CWD\]/)
+  })
+
+  it('failure to copy ~/.claude.json is non-fatal (warn, do not abort)', () => {
+    // The auth path is still good (CLAUDE_CONFIG_DIR + .credentials.json),
+    // so a parse error on ~/.claude.json must not break the heartbeat.
+    // Warn and continue.
+    const idx = HB_SRC.indexOf('failed to materialise .claude.json')
+    expect(idx).toBeGreaterThan(0)
+    const window = HB_SRC.slice(Math.max(0, idx - 200), idx)
+    expect(window).toMatch(/catch/)
+  })
+})
+
+describe('dashboard-hide sentinel (Szabi 2026-06-02 14:31 ask)', () => {
+  it('agent-config exports HIDDEN_AGENT_SENTINEL', () => {
+    expect(CFG_SRC).toMatch(/export const HIDDEN_AGENT_SENTINEL = '\.hidden-from-dashboard'/)
+  })
+
+  it('listAgentNames filters out directories containing the sentinel', () => {
+    expect(CFG_SRC).toMatch(/HIDDEN_AGENT_SENTINEL/)
+    expect(CFG_SRC).toMatch(/existsSync\(join\(AGENTS_BASE_DIR,\s*f,\s*HIDDEN_AGENT_SENTINEL\)\)/)
+  })
+
+  it('heartbeat ensures the sentinel exists in agents/heartbeat-worker/', () => {
+    expect(HB_SRC).toMatch(/sentinelPath\s*=\s*join\(HEARTBEAT_AGENT_CWD,\s*'\.hidden-from-dashboard'\)/)
+    expect(HB_SRC).toMatch(/writeFileSync\(sentinelPath/)
+  })
+
+  it('sentinel write is idempotent (skip if already present)', () => {
+    const idx = HB_SRC.indexOf('sentinelPath')
+    expect(idx).toBeGreaterThan(0)
+    const window = HB_SRC.slice(idx, idx + 400)
+    expect(window).toMatch(/!existsSync\(sentinelPath\)/)
+  })
+})

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -175,6 +175,47 @@ function ensureHeartbeatWorkerCwd(): void {
       const credPath = join(HEARTBEAT_CONFIG_DIR, '.credentials.json')
       writeFileSync(credPath, credentialsJson, { mode: 0o600 })
     }
+
+    // MCP-server bridge: Claude Code stores PROJECT-scoped MCP server
+    // configs in ~/.claude.json under the `projects[<cwd>]` map. The
+    // 2026-06-02 14:00 hb-fire ran with an empty .claude.json (Claude
+    // Code generated a fresh one in CLAUDE_CONFIG_DIR), so the sub-agent
+    // saw zero user-level MCPs -- Gmail OAuth lost, Calendar fell back to
+    // the wrong default account (Szabi 14:27 report).
+    //
+    // Copy the real ~/.claude.json into the isolated config dir AND
+    // duplicate the `projects[PROJECT_ROOT]` entry under
+    // `projects[HEARTBEAT_AGENT_CWD]` so the sub-agent inherits Marveen's
+    // server-gmail-autoauth-mcp + server-google-calendar-mcp config from
+    // its own cwd key. Channel-plugin isolation stays in force because
+    // enabledPlugins is governed by the CLAUDE_CONFIG_DIR settings.json
+    // (which we still write with all channel plugins = false), NOT by
+    // .claude.json.
+    try {
+      const homeClaudeJsonPath = join(homedir(), '.claude.json')
+      if (existsSync(homeClaudeJsonPath)) {
+        const raw = readFileSync(homeClaudeJsonPath, 'utf-8')
+        const parsed = JSON.parse(raw) as Record<string, unknown>
+        if (parsed && typeof parsed === 'object') {
+          const projects = (parsed as { projects?: Record<string, unknown> }).projects
+          if (projects && typeof projects === 'object' && projects[PROJECT_ROOT] && !projects[HEARTBEAT_AGENT_CWD]) {
+            projects[HEARTBEAT_AGENT_CWD] = projects[PROJECT_ROOT]
+          }
+          const heartbeatClaudeJsonPath = join(HEARTBEAT_CONFIG_DIR, '.claude.json')
+          writeFileSync(heartbeatClaudeJsonPath, JSON.stringify(parsed, null, 2) + '\n', { mode: 0o600 })
+        }
+      }
+    } catch (err) {
+      logger.warn({ err }, 'Heartbeat: failed to materialise .claude.json into isolated config dir (sub-agent will lack project MCPs)')
+    }
+
+    // Dashboard-hide sentinel: Szabi 2026-06-02 asked that this technical
+    // worker NOT show up as a real agent on the dashboard. listAgentNames()
+    // filters out any subdir of agents/ that contains this sentinel file.
+    const sentinelPath = join(HEARTBEAT_AGENT_CWD, '.hidden-from-dashboard')
+    if (!existsSync(sentinelPath)) {
+      writeFileSync(sentinelPath, '')
+    }
   } catch (err) {
     logger.warn({ err, cwd: HEARTBEAT_AGENT_CWD }, 'Heartbeat: failed to ensure isolated worker cwd, falling back to PROJECT_ROOT')
   }

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -240,10 +240,27 @@ export function writeAgentSecurityProfile(name: string, profileId: string): void
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
+// Sentinel filename. A subdirectory under agents/ that contains this empty
+// file is treated as a TECHNICAL worker, not a first-class agent: it stays
+// out of listAgentNames() (so it never appears on the dashboard, in the
+// schedule runner, in inter-agent message routing, etc.), but is still a
+// real directory on disk for whatever workflow needs it. Used today by
+// agents/heartbeat-worker/, the sentinel cwd for the SDK-spawned hourly
+// heartbeat sub-agent (Szabi 2026-06-02: "ez a technikai agent meg se
+// jelenjen a dashboardon").
+export const HIDDEN_AGENT_SENTINEL = '.hidden-from-dashboard'
+
 export function listAgentNames(): string[] {
   if (!existsSync(AGENTS_BASE_DIR)) return []
   return readdirSync(AGENTS_BASE_DIR).filter((f) => {
-    try { return statSync(join(AGENTS_BASE_DIR, f)).isDirectory() } catch { return false }
+    try {
+      if (!statSync(join(AGENTS_BASE_DIR, f)).isDirectory()) return false
+      // Hide technical workers explicitly opted out via the sentinel
+      // file. Cheap fs stat -- one extra existsSync per agent dir per
+      // tick; the agent list is small (~6 today).
+      if (existsSync(join(AGENTS_BASE_DIR, f, HIDDEN_AGENT_SENTINEL))) return false
+      return true
+    } catch { return false }
   })
 }
 


### PR DESCRIPTION
## Summary (HIGH priority — 7:30 reggeli napindító Gmail/Calendar fél)

2026-06-02 14:27 Szabi report: the 14:00 hb fired without crashing Marveen and without "Not logged in", BUT the sub-agent ran with **Gmail OAuth missing** and Calendar fell back to the **wrong default account** (not `szota.szabolcs@gmail.com`). The 7:30 reggeli napindító — which actually USES Gmail + Calendar — would be useless without this.

#250+#252 fixed the channel-crash + Claude API auth but missed the project-scope MCP server config that lives in `~/.claude.json` (HOME root, one level UP from `~/.claude/`).

## Root cause

The #250 symlink loop iterates `~/.claude/` entries, but `~/.claude.json` sits ONE LEVEL UP in HOME. Claude Code stores project-scope MCP configs there under `projects[<absolute-cwd>]`:

```json
"projects": {
  "/Users/marvin/ClaudeClaw": {
    "mcpServers": { "server-gmail-autoauth-mcp": {...},
                    "server-google-calendar-mcp": {...} }
  }
}
```

The heartbeat sub-agent runs in `cwd = agents/heartbeat-worker`, which has no entry in `projects[...]`. Result: zero user-level MCPs visible. Gmail/Calendar gone.

## Fix

In `ensureHeartbeatWorkerCwd`, copy `~/.claude.json` into the isolated `CLAUDE_CONFIG_DIR` and inject `projects[HEARTBEAT_AGENT_CWD] = projects[PROJECT_ROOT]`. The sub-agent now inherits Marveen's Gmail + Calendar MCP config from its own cwd key, without us having to inventory or duplicate the server list itself. `enabledPlugins` isolation stays in force (governed by `CLAUDE_CONFIG_DIR/settings.json`, not by `.claude.json`). Mode 0600 — same as credentials.

Guards:
- Only set `projects[HEARTBEAT_AGENT_CWD]` when ABSENT (no clobbering a curated entry)
- Copy is in try/catch — parse error on `~/.claude.json` must not break the heartbeat (auth via `.credentials.json` is independent)

## Plus: dashboard-hide sentinel

Szabi 14:31: *"ez a technikai agent meg se jelenjen a dashboardon mint agent? Mert most látszik, pedig nem kellene."*

New `HIDDEN_AGENT_SENTINEL = '.hidden-from-dashboard'` exported from `agent-config.ts`. `listAgentNames()` filters out any subdir of `agents/` containing the sentinel. `heartbeat.ts` writes the sentinel idempotently. The heartbeat-worker dir disappears from the dashboard agent list, schedule runner, inter-agent routing — everything that calls `listAgentNames` — without changing its on-disk role.

## Verified

- 9 new contract tests pass (home-root `.claude.json` read, 0o600 mode, `projects` duplication, no-clobber guard, non-fatal copy failure, sentinel exported + wired in `listAgentNames`, sentinel write location, idempotent write)
- `tsc --noEmit` clean

## Test plan

- [ ] Deploy ASAP (15:00 hb tests the path live; 7:30 reggeli napindító is the production deadline)
- [ ] 15:00 hb: sub-agent uses Gmail/Calendar MCP, calendar reads `szota.szabolcs@gmail.com`, no "Not logged in"
- [ ] Marveen channel still NOT crashed
- [ ] Dashboard `/api/agents` does NOT include `heartbeat-worker`

## Related

- #250 (CLAUDE_CONFIG_DIR isolation)
- #252 (Keychain JSON → `.credentials.json`)