### PR TITLE
fix(kanban): save comments reliably + show running card number

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -882,6 +882,9 @@ export function updateTask(id: string, prompt: string, schedule: string, nextRun
 
 export interface KanbanCard {
   id: string
+  // Stable running number derived from the SQLite rowid (insertion order, never
+  // reused) -- a human-friendly "#N" shown next to the 8-char hex id.
+  seq?: number
   title: string
   description: string | null
   status: 'planned' | 'in_progress' | 'waiting' | 'done'
@@ -911,7 +914,7 @@ export function listKanbanCards(): KanbanCard[] {
     "UPDATE kanban_cards SET archived_at = ? WHERE status = 'done' AND archived_at IS NULL AND updated_at < ?"
   ).run(Math.floor(Date.now() / 1000), thirtyDaysAgo)
   return db
-    .prepare('SELECT * FROM kanban_cards WHERE archived_at IS NULL ORDER BY sort_order ASC')
+    .prepare('SELECT rowid AS seq, * FROM kanban_cards WHERE archived_at IS NULL ORDER BY sort_order ASC')
     .all() as KanbanCard[]
 }
 
@@ -922,7 +925,7 @@ export function listKanbanCardsSummary(): { status: string; title: string; assig
 }
 
 export function getKanbanCard(id: string): KanbanCard | undefined {
-  return db.prepare('SELECT * FROM kanban_cards WHERE id = ?').get(id) as KanbanCard | undefined
+  return db.prepare('SELECT rowid AS seq, * FROM kanban_cards WHERE id = ?').get(id) as KanbanCard | undefined
 }
 
 export function createKanbanCard(card: {

--- a/web/app.js
+++ b/web/app.js
@@ -426,9 +426,13 @@ function createCardEl(card) {
     ? `<span class="kanban-card-project">${escapeHtml(card.project)}</span>`
     : ''
 
+  const seqHtml = card.seq != null
+    ? `<span class="kanban-card-seq" style="font-family:monospace;font-size:11px;color:var(--muted);margin-right:5px">#${card.seq}</span>`
+    : ''
+
   el.innerHTML = `
     ${projectHtml}
-    <div class="kanban-card-title">${escapeHtml(card.title)}</div>
+    <div class="kanban-card-title">${seqHtml}${escapeHtml(card.title)}</div>
     <div class="kanban-card-footer">${assigneeHtml}${dueHtml}</div>
     <div class="kanban-card-actions">
       <button class="card-breakdown-btn" title="AI szétbont" aria-label="AI szétbont">⚡</button>
@@ -590,7 +594,9 @@ document.getElementById('saveCardBtn').addEventListener('click', async () => {
 
 // === Card detail ===
 async function showCardDetail(card) {
-  document.getElementById('cardDetailTitle').textContent = card.title
+  // Running number (#N) in the title bar, plus the stable hex id in the meta.
+  const seqPrefix = card.seq != null ? `#${card.seq} ` : ''
+  document.getElementById('cardDetailTitle').textContent = `${seqPrefix}${card.title}`
 
   // Case-insensitive match; fall back to the raw stored name so a casing
   // mismatch (or an unregistered assignee) shows the actual name, not "nincs".
@@ -603,7 +609,12 @@ async function showCardDetail(card) {
   const statusLabels = { planned: 'Tervezett', in_progress: 'Folyamatban', waiting: 'Várakozik', done: 'Kész' }
 
   const meta = document.getElementById('cardDetailMeta')
+  const idLabel = (card.seq != null ? `#${card.seq} · ` : '') + card.id
   meta.innerHTML = `
+    <div class="meta-item">
+      <span class="meta-label">Azonosító</span>
+      <span class="meta-value" style="font-family:monospace" title="Futó sorszám · hex azonosító">${escapeHtml(idLabel)}</span>
+    </div>
     <div class="meta-item">
       <span class="meta-label">Állapot</span>
       <span class="meta-value">${statusLabels[card.status] || card.status}</span>
@@ -694,20 +705,32 @@ async function showCardDetail(card) {
     }
   } catch { /* ignore */ }
 
-  // Author select for new comment
-  populateAssigneeSelect('commentAuthor', 'Marveen')
+  // Author select for new comment. Default to the human owner "Gábor" -- a
+  // value that actually exists in the assignee list, so the select never falls
+  // back to the empty "-- Nincs --" option (which silently produced author=""
+  // -> server 400 -> a lost comment).
+  populateAssigneeSelect('commentAuthor', 'Gábor')
 
   // Add comment
   document.getElementById('addCommentBtn').onclick = async () => {
     const content = document.getElementById('commentContent').value.trim()
     const author = document.getElementById('commentAuthor').value
-    if (!content || !author) return
+    if (!content) { document.getElementById('commentContent').focus(); return }
+    if (!author) { showToast('Válassz szerzőt a megjegyzéshez'); return }
     try {
-      await fetch(`/api/kanban/${encodeURIComponent(card.id)}/comments`, {
+      const res = await fetch(`/api/kanban/${encodeURIComponent(card.id)}/comments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ author, content }),
       })
+      // Without this check an HTTP error (e.g. 400) still cleared the textarea
+      // and "refreshed", so the comment looked sent but was never saved.
+      if (!res.ok) {
+        let msg = `HTTP ${res.status}`
+        try { msg = (await res.json()).error || msg } catch {}
+        showToast('Megjegyzés nem mentődött: ' + msg)
+        return
+      }
       document.getElementById('commentContent').value = ''
       showCardDetail(card) // refresh
     } catch {


### PR DESCRIPTION
Two dashboard kanban fixes reported by Gábor.

## 1. Lost comments (data loss)
Adding a comment from the card-detail view could silently drop it.

Root cause: the new-comment author `<select>` defaulted to `"Marveen"`, a name that is **not** in the assignee list, so the select fell back to the empty `-- Nincs --` option → `author=""` → the POST returned `400 {"error":"Szerző és tartalom kötelező"}`. The handler did not check `res.ok`, so it still cleared the textarea and re-rendered: the comment **looked** sent but was never saved.

Fix:
- Default the author to the real owner `"Gábor"` (present in `/api/kanban/assignees`).
- Check `res.ok`; on failure show the server error via toast and keep the text (no more silent loss). Empty author now shows a hint instead of a silent no-op.

## 2. Running card number
Cards only had an 8-char hex id, not visible on the board. Expose the SQLite `rowid` as a stable `seq` from `listKanbanCards` / `getKanbanCard` and render it as `#N`:
- on each board card title,
- in the card-detail title bar + a new "Azonosító" meta row (`#N · hex`).

`rowid` is monotonic and never reused, so numbers stay stable across deletes (gaps are expected, by design).

## Test
- `tsc` clean; full suite: kanban/db tests pass. (Pre-existing unrelated failures in `managed-settings.test.ts` only.)
- Verified live: `/api/kanban` now returns `seq`; comment POST with empty author surfaces the error instead of dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)