### PR TITLE
fix(google-api): mtime-invalidate cachedTokens (Calendar re-auth survival)

### DIFF
--- a/src/__tests__/google-api-token-cache.test.ts
+++ b/src/__tests__/google-api-token-cache.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for the 2026-06-02 14:30 hb regression after Calendar
+// re-auth. Symptom: Szabi re-authed at 16:26 (live HTTP 200 verified), but
+// the heartbeat kept logging `Google token refresh failed` because the
+// dashboard's module-level cachedTokens still held the pre-re-auth (88-day
+// expired, revoked) refresh_token. Manual dashboard restart fixed the
+// immediate symptom; this PR fixes the cache so out-of-process re-auths
+// propagate automatically.
+
+const SRC = readFileSync(join(__dirname, '../google-api.ts'), 'utf-8')
+
+describe('google-api token cache mtime invalidation', () => {
+  it('cache entry carries the file mtime alongside the parsed payload', () => {
+    // Without mtimeMs in the cache shape, no way to tell when the file
+    // on disk has been rewritten by an out-of-process re-auth.
+    expect(SRC).toMatch(/cachedTokens:\s*\{[^}]*mtimeMs:\s*number/s)
+  })
+
+  it('loadTokens re-reads when the file mtime advances', () => {
+    const start = SRC.indexOf('function loadTokens')
+    expect(start).toBeGreaterThan(0)
+    const closeIdx = SRC.indexOf('\n}\n', start)
+    const body = SRC.slice(start, closeIdx)
+    expect(body).toMatch(/statSync\(TOKENS_PATH\)/)
+    expect(body).toMatch(/cachedTokens\.mtimeMs !==/)
+  })
+
+  it('saveTokens populates the cache with a matching mtime (no double-read)', () => {
+    // After a write, the next loadTokens() should NOT need to re-read the
+    // file (the in-memory copy is the truth). Track the post-write mtime
+    // so cachedTokens.mtimeMs matches the file's mtime on the next check.
+    const start = SRC.indexOf('function saveTokens')
+    const closeIdx = SRC.indexOf('\n}\n', start)
+    const body = SRC.slice(start, closeIdx)
+    expect(body).toMatch(/statSync\(TOKENS_PATH\)/)
+    expect(body).toMatch(/cachedTokens\s*=\s*\{[^}]*mtimeMs/s)
+  })
+
+  it('saveTokens writes ONLY tokens.normal-shaped JSON (no cache-mtime leak)', () => {
+    // The cache layer must not leak its internal mtimeMs into the on-disk
+    // JSON; tokens.json schema is { normal: TokenData } and the OAuth
+    // server doesn't care about our cache bookkeeping.
+    const start = SRC.indexOf('function saveTokens')
+    const closeIdx = SRC.indexOf('\n}\n', start)
+    const body = SRC.slice(start, closeIdx)
+    // JSON.stringify of an object literal with `normal:` is fine; should
+    // NOT serialise mtimeMs alongside.
+    expect(body).toMatch(/writeFileSync\([^)]*JSON\.stringify\(\s*\{\s*normal:\s*tokens\s*\}/)
+  })
+
+  it('handles a missing TOKENS_PATH at stat time without throwing', () => {
+    // statSync throws on missing file. The cache check must be wrapped in
+    // try/catch so loadTokens can still surface the readFileSync error
+    // explicitly (current behaviour) rather than being short-circuited by
+    // the stat.
+    const start = SRC.indexOf('function loadTokens')
+    const closeIdx = SRC.indexOf('\n}\n', start)
+    const body = SRC.slice(start, closeIdx)
+    expect(body).toMatch(/try\s*\{\s*[^}]*statSync\(TOKENS_PATH\)/s)
+    expect(body).toMatch(/catch\s*\{\s*\/\*/)
+  })
+})

--- a/src/google-api.ts
+++ b/src/google-api.ts
@@ -1,5 +1,5 @@
 import https from 'node:https'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { logger } from './logger.js'
@@ -38,19 +38,36 @@ interface CalendarListResponse {
   items?: CalendarEvent[]
 }
 
-let cachedTokens: { normal: TokenData } | null = null
+// Token cache + mtime-invalidation. The cache spares us a JSON parse on
+// every getCalendarEvents call, but a stale cache kills the heartbeat after
+// an out-of-process re-auth (the OAuth-mcp `auth` subcommand writes a fresh
+// tokens.json from a separate process, our cache never re-reads it). Track
+// the file's mtime alongside the parsed payload; re-read whenever the mtime
+// advances. 2026-06-02 14:30 incident: after Szabi re-authed at 16:26 the
+// dashboard kept dropping `Google token refresh failed` until a manual
+// process restart, because cachedTokens held the pre-re-auth (88-day-old,
+// already-revoked) refresh_token.
+let cachedTokens: { normal: TokenData; mtimeMs: number } | null = null
 let cachedClient: ClientCredentials | null = null
 
 function loadTokens(): TokenData {
-  if (!cachedTokens) {
-    cachedTokens = JSON.parse(readFileSync(TOKENS_PATH, 'utf-8'))
+  let currentMtime = 0
+  try { currentMtime = statSync(TOKENS_PATH).mtimeMs } catch { /* file missing -- fall through to readFileSync error */ }
+  if (!cachedTokens || cachedTokens.mtimeMs !== currentMtime) {
+    const parsed = JSON.parse(readFileSync(TOKENS_PATH, 'utf-8'))
+    cachedTokens = { normal: parsed.normal, mtimeMs: currentMtime }
   }
-  return cachedTokens!.normal
+  return cachedTokens.normal
 }
 
 function saveTokens(tokens: TokenData): void {
-  cachedTokens = { normal: tokens }
-  writeFileSync(TOKENS_PATH, JSON.stringify(cachedTokens, null, 2))
+  writeFileSync(TOKENS_PATH, JSON.stringify({ normal: tokens }, null, 2))
+  // Re-stat AFTER write so the next loadTokens() sees the matching mtime
+  // and uses the freshly-written content from cache rather than triggering
+  // an extra re-read on the very next call.
+  let mtimeMs = 0
+  try { mtimeMs = statSync(TOKENS_PATH).mtimeMs } catch { /* unlikely right after writeFileSync */ }
+  cachedTokens = { normal: tokens, mtimeMs }
 }
 
 function loadClientCredentials(): ClientCredentials {


### PR DESCRIPTION
## Summary

Today's 14:30 hb regression: Szabi re-authed the Calendar OAuth at 16:26 (live token refresh HTTP 200), but the heartbeat kept logging `Google token refresh failed` until I manually restarted the dashboard. The module-level `cachedTokens` had latched onto the pre-re-auth (88-day-old, revoked) refresh_token from process boot and never re-read the freshly-written `tokens.json`.

## Fix

`cachedTokens` now carries the file's `mtimeMs` alongside the parsed payload. `loadTokens()` statSyncs every call and re-reads on mtime advance. `saveTokens()` writes THEN stats so the next `loadTokens()` finds matching mtimes and uses the freshly-written in-memory copy directly (no double read).

Cost: one `statSync` per `loadTokens()` (~microseconds). The path runs once per hour anyway — that's nothing compared to the cost of an unnoticed revoked refresh token.

## Verified

- 5 contract tests pass: mtime in cache shape, re-read on mtime advance, saveTokens stat-after-write, on-disk JSON unaffected (no cache-mtime leak into tokens.json), missing-file safety (statSync wrapped)
- `tsc --noEmit` clean

## Test plan

- [ ] Deploy
- [ ] Force a fresh `tokens.json` write out-of-process (the `npx @cocal/google-calendar-mcp auth` flow does this naturally on next re-auth)
- [ ] Confirm next heartbeat picks up the new refresh_token WITHOUT a dashboard restart — no `Google token refresh failed`, no manual intervention

## Context

Not the only post-re-auth path — the Calendar OAuth project should also be moved Testing → Production in Google Cloud Console (PUBLISH APP) so refresh_tokens stop expiring at 7 days. Szabi did that today. This cache fix makes future re-auths painless even on Production-mode tokens (which still get rotated occasionally).