### PR TITLE
feat(kanban): wake the assigned agent when a card moves to in_progress

### DIFF
--- a/src/__tests__/kanban-dispatch.test.ts
+++ b/src/__tests__/kanban-dispatch.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { resolveKanbanDispatchTarget } from '../kanban-dispatch.js'
+
+const base = {
+  ownerName: 'Gábor',
+  botName: 'GorcsevIvan',
+  mainAgentId: 'gorcsevivan',
+  agentNames: ['tuskohopkins', 'sentinel'],
+  isRunning: (n: string) => n === 'tuskohopkins', // only tuskohopkins is "running"
+}
+
+describe('resolveKanbanDispatchTarget', () => {
+  it('returns null for empty / null / undefined / whitespace assignee', () => {
+    expect(resolveKanbanDispatchTarget(null, base)).toBeNull()
+    expect(resolveKanbanDispatchTarget(undefined, base)).toBeNull()
+    expect(resolveKanbanDispatchTarget('', base)).toBeNull()
+    expect(resolveKanbanDispatchTarget('   ', base)).toBeNull()
+  })
+
+  it('never dispatches to the human owner', () => {
+    expect(resolveKanbanDispatchTarget('Gábor', base)).toBeNull()
+  })
+
+  it('maps the bot display name to the main agent id', () => {
+    expect(resolveKanbanDispatchTarget('GorcsevIvan', base)).toBe('gorcsevivan')
+  })
+
+  it('maps the canonical main agent id to itself', () => {
+    expect(resolveKanbanDispatchTarget('gorcsevivan', base)).toBe('gorcsevivan')
+  })
+
+  it('matches the bot/main case-insensitively', () => {
+    expect(resolveKanbanDispatchTarget('gorcsevIVAN', base)).toBe('gorcsevivan')
+    expect(resolveKanbanDispatchTarget('GORCSEVIVAN', base)).toBe('gorcsevivan')
+  })
+
+  it('dispatches to a sub-agent only when its session is running', () => {
+    expect(resolveKanbanDispatchTarget('tuskohopkins', base)).toBe('tuskohopkins')
+    expect(resolveKanbanDispatchTarget('sentinel', base)).toBeNull() // not running -> silent no-op
+  })
+
+  it('matches sub-agent names case-insensitively', () => {
+    expect(resolveKanbanDispatchTarget('TuskoHopkins', base)).toBe('tuskohopkins')
+  })
+
+  it('returns null for an unknown assignee name', () => {
+    expect(resolveKanbanDispatchTarget('SomebodyElse', base)).toBeNull()
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -160,6 +160,13 @@ export function initDatabase(): void {
     // column already exists
   }
   db.exec('CREATE INDEX IF NOT EXISTS idx_kanban_parent ON kanban_cards(parent_id)')
+  // Migration: add dispatched_at to kanban_cards (kanban -> agent dispatch
+  // once-only guard). Older installs created the table without it.
+  try {
+    db.exec('ALTER TABLE kanban_cards ADD COLUMN dispatched_at INTEGER')
+  } catch {
+    // column already exists
+  }
   // Migration: add agent_id, category, auto_generated columns to memories
   try {
     db.exec("ALTER TABLE memories ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'marveen'")
@@ -894,6 +901,10 @@ export interface KanbanCard {
   created_at: number
   updated_at: number
   archived_at: number | null
+  // Set the first time the card is moved to in_progress and the assigned agent
+  // is woken (kanban -> agent dispatch). NULL = never dispatched; the once-only
+  // guard so re-dragging a card does not re-prompt the agent.
+  dispatched_at: number | null
 }
 
 export interface KanbanComment {
@@ -973,6 +984,13 @@ export function moveKanbanCard(id: string, status: KanbanCard['status'], sortOrd
   return db.prepare(
     'UPDATE kanban_cards SET status=?, sort_order=?, updated_at=? WHERE id=?'
   ).run(status, sortOrder, now, id).changes > 0
+}
+
+// Stamp the once-only kanban -> agent dispatch guard. Returns false if the
+// card id does not exist.
+export function markKanbanCardDispatched(id: string): boolean {
+  const now = Math.floor(Date.now() / 1000)
+  return db.prepare('UPDATE kanban_cards SET dispatched_at=? WHERE id=?').run(now, id).changes > 0
 }
 
 export function archiveKanbanCard(id: string): boolean {

--- a/src/kanban-dispatch.ts
+++ b/src/kanban-dispatch.ts
@@ -1,0 +1,46 @@
+// Pure decision logic for the kanban -> agent dispatch (option D).
+//
+// When a kanban card is moved to `in_progress`, the dashboard wakes the
+// assigned agent by enqueuing an inter-agent message (createAgentMessage ->
+// the existing message-router, which gives us retry / dedup / trust-wrapping /
+// busy-receiver handling for free). This module decides WHO, if anyone, should
+// be woken. Kept pure so the decision tree is unit-tested without tmux/db.
+//
+// Rules (mirroring the assignee semantics from PR #251):
+//   - empty / unknown assignee        -> null  (no dispatch)
+//   - the human owner (OWNER_NAME)     -> null  (humans never get a prompt)
+//   - the bot / main agent             -> MAIN_AGENT_ID (main channels session)
+//   - a sub-agent, ONLY if its session is running -> that agent's id
+//     (a non-running sub-agent is a silent no-op; the card just stays in
+//      in_progress rather than queuing a message for a session that isn't up)
+
+export interface DispatchResolveOpts {
+  ownerName: string
+  botName: string
+  mainAgentId: string
+  agentNames: string[]
+  isRunning: (name: string) => boolean
+}
+
+export function resolveKanbanDispatchTarget(
+  assignee: string | null | undefined,
+  opts: DispatchResolveOpts,
+): string | null {
+  const a = (assignee ?? '').trim()
+  if (!a) return null
+  const lower = a.toLowerCase()
+
+  // Human owner never triggers an agent.
+  if (a === opts.ownerName) return null
+
+  // Bot / main agent (matched by display name or canonical id) -> main session.
+  if (lower === opts.botName.toLowerCase() || lower === opts.mainAgentId.toLowerCase()) {
+    return opts.mainAgentId
+  }
+
+  // Sub-agent: case-insensitive name match, dispatched only if it is running.
+  const match = opts.agentNames.find((n) => n.toLowerCase() === lower)
+  if (match && opts.isRunning(match)) return match
+
+  return null
+}

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -4,13 +4,42 @@ import {
   deleteKanbanCard, moveKanbanCard, archiveKanbanCard,
   getKanbanComments, addKanbanComment, listKanbanProjects,
   getKanbanCard, getChildCards, getDb,
+  createAgentMessage, markKanbanCardDispatched,
 } from '../../db.js'
-import { OWNER_NAME, BOT_NAME } from '../../config.js'
+import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID } from '../../config.js'
 import { listAgentNames, readAgentDisplayName } from '../agent-config.js'
+import { isAgentRunning } from '../agent-process.js'
+import { resolveKanbanDispatchTarget } from '../../kanban-dispatch.js'
 import { generateBreakdown } from '../llm-breakdown.js'
 import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
+
+// Option D: kanban -> agent dispatch. When a card moves to in_progress, wake the
+// assigned agent once via the inter-agent message router (createAgentMessage),
+// which gives retry / dedup / trust-wrapping / busy-receiver handling for free.
+// dispatched_at is the once-only guard; errors never block the card move.
+function fireKanbanDispatch(id: string): void {
+  try {
+    const card = getKanbanCard(id)
+    if (!card || card.dispatched_at) return
+    const target = resolveKanbanDispatchTarget(card.assignee, {
+      ownerName: OWNER_NAME,
+      botName: BOT_NAME,
+      mainAgentId: MAIN_AGENT_ID,
+      agentNames: listAgentNames(),
+      isRunning: isAgentRunning,
+    })
+    if (!target) return
+    const desc = (card.description ?? '').trim()
+    const content = `[Kanban feladat #${id}]: ${card.title}${desc ? ' — ' + desc : ''}\n\nA kártyát in_progress-re húzták. Ha kész vagy, húzd "done"-ra.`
+    createAgentMessage(MAIN_AGENT_ID, target, content)
+    markKanbanCardDispatched(id)
+    logger.info({ id, target, assignee: card.assignee }, 'Kanban in_progress dispatch fired')
+  } catch (err) {
+    logger.warn({ err, id }, 'Kanban dispatch failed (card move still succeeded)')
+  }
+}
 
 export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
@@ -66,7 +95,12 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
     const id = decodeURIComponent(kanbanMoveMatch[1])
     const body = await readBody(req)
     const { status, sort_order } = JSON.parse(body.toString())
-    if (moveKanbanCard(id, status, sort_order ?? 0)) { json(res, { ok: true }); return true }
+    if (moveKanbanCard(id, status, sort_order ?? 0)) {
+      // Wake the assigned agent once when the card enters in_progress.
+      if (status === 'in_progress') fireKanbanDispatch(id)
+      json(res, { ok: true })
+      return true
+    }
     json(res, { error: 'Kártya nem található' }, 404)
     return true
   }


### PR DESCRIPTION
## What

Wakes the assigned agent when a kanban card is moved to **in_progress** — the
"option D" design for kanban → agent automation (own minimal trigger, built on
our existing inter-agent message infrastructure rather than a direct tmux
inject).

## How

- **Trigger**: in the existing `POST /api/kanban/:id/move` handler, after a
  successful move, if `status === 'in_progress'`, fire the dispatch.
- **Transport**: `createAgentMessage(...)` → the existing message-router
  delivers it, so we inherit retry, the abandon-window, trust-wrapping and
  busy-receiver handling for free (vs. a raw `sendPromptToSession` that bypasses
  all of that).
- **Dedup**: a new `kanban_cards.dispatched_at` column (migration + once-only
  guard) — re-dragging a card never re-prompts.
- **Assignee resolution** (pure + unit-tested, `src/kanban-dispatch.ts`):
  - human owner (`OWNER_NAME`) → no dispatch
  - bot / main agent → the main channels session (`MAIN_AGENT_ID`)
  - sub-agent → only if its session is running, else a silent no-op
- Best-effort: any dispatch error is logged and swallowed so the card move
  always succeeds.

Deliberately minimal: the live activity panel stays the existing
`GET /api/agents/activity`; none of the bundled extras from the other proposal
(workflow recorder, idea box, a second activity monitor) are included.

## Test

- `tsc --noEmit` clean.
- New `src/__tests__/kanban-dispatch.test.ts`: 8 cases covering the resolver
  (owner no-op, bot/main mapping, case-insensitivity, running vs non-running
  sub-agent, unknown/empty).
- Full `vitest run`: 807 passed; only the 4 pre-existing `managed-settings.test.ts`
  failures remain (unrelated, present on `main` before this).

## Files

- `src/kanban-dispatch.ts` (new, pure resolver)
- `src/__tests__/kanban-dispatch.test.ts` (new)
- `src/db.ts` (dispatched_at column + migration + `markKanbanCardDispatched`)
- `src/web/routes/kanban.ts` (the trigger in the move handler)
