### PR TITLE
feat(heartbeat): dedicated channel-less heartbeat agent (Szabi 2026-06-02)

### DIFF
--- a/src/__tests__/schedule-runner-heartbeat-prefix.test.ts
+++ b/src/__tests__/schedule-runner-heartbeat-prefix.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for Marveen's PR #257 review-block: the
+// schedule-runner's heartbeat prefix had a Marveen-specific
+// Telegram-keepalive directive hardcoded. Funnelling the new
+// channel-less `heartbeat` agent through the same prefix would have:
+//   1. Contradicted the agent's own CLAUDE.md contract ("NEVER call
+//      Telegram tools, always inter-agent to Marveen").
+//   2. If the channel-plugin disable ever leaked through user-scope
+//      settings (the fleet's recurring failure mode), instructed the
+//      agent to call chat_id ALLOWED_CHAT_ID directly -- reproducing
+//      the self-poll problem this whole PR is meant to solve.
+//
+// Fix: branch the heartbeat-prefix by agentName. Channel-less
+// `heartbeat` agent gets a minimal tag; Marveen still gets the
+// historical Telegram-keepalive scaffolding.
+
+const SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+
+describe('schedule-runner heartbeat prefix branches by agentName', () => {
+  it('keeps the [Heartbeat: ${task.name}] tag (resubmit-marker matches)', () => {
+    // The marker downstream is `[Heartbeat: ${task.name}]`. Both
+    // branches of the new conditional MUST emit it -- otherwise the
+    // resubmit-retry code at the bottom of the function stops working.
+    expect(SRC).toMatch(/\[Heartbeat: \$\{task\.name\}\]/)
+  })
+
+  it('routes agentName === heartbeat to the minimal prefix (no Telegram directive)', () => {
+    // The outer heartbeat-vs-utemezett-feladat block ends where the
+    // `[Utemezett feladat:` prefix appears. Slice from "task.type ===
+    // 'heartbeat'" up to that marker -- everything between is the
+    // heartbeat branch, including BOTH inner sub-branches.
+    const heartbeatBlockStart = SRC.indexOf("if (task.type === 'heartbeat')")
+    expect(heartbeatBlockStart).toBeGreaterThan(0)
+    const outerElseMarker = SRC.indexOf('[Utemezett feladat:', heartbeatBlockStart)
+    expect(outerElseMarker).toBeGreaterThan(heartbeatBlockStart)
+    const heartbeatBlock = SRC.slice(heartbeatBlockStart, outerElseMarker)
+    expect(heartbeatBlock).toMatch(/agentName === 'heartbeat'/)
+
+    // Identify the channel-less sub-branch: from the inner-if to the
+    // inner-else. Both are inside heartbeatBlock now.
+    const innerIfIdx = heartbeatBlock.indexOf("agentName === 'heartbeat'")
+    const innerElseIdx = heartbeatBlock.indexOf('} else {', innerIfIdx)
+    expect(innerElseIdx).toBeGreaterThan(innerIfIdx)
+    const channelLessBranch = heartbeatBlock.slice(innerIfIdx, innerElseIdx)
+
+    // Channel-less branch MUST NOT have Telegram instruction strings.
+    expect(channelLessBranch).not.toMatch(/NE Telegram-tool-t/)
+    expect(channelLessBranch).not.toMatch(/CSAK AKKOR irj Telegramon/)
+    expect(channelLessBranch).not.toMatch(/ALLOWED_CHAT_ID/)
+    expect(channelLessBranch).not.toMatch(/Telegram-bun MCP-stdio-pipe/)
+  })
+
+  it('Marveen branch still carries the historical keep-alive scaffolding', () => {
+    // Don't break the Marveen-targeted heartbeat (e.g. the existing
+    // memoria-heartbeat task) when fixing the channel-less one.
+    expect(SRC).toMatch(/KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ/)
+    expect(SRC).toMatch(/Telegram-bun MCP-stdio-pipe keep-alive/)
+  })
+
+  it('comments the rationale for the branch (why, not just what)', () => {
+    // PR #257 review-block specifically called out the
+    // contract-contradiction risk. Future readers should find that
+    // reasoning at the branch, not buried in git log.
+    expect(SRC).toMatch(/contract|contradiction|channel-plugin disable/i)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { STORE_DIR, PID_FILENAME, WEB_PORT, ALLOWED_CHAT_ID, MAIN_AGENT_ID } fro
 import { initDatabase } from './db.js'
 import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
+import { ensureHeartbeatAgent, HEARTBEAT_AGENT_NAME } from './web/heartbeat-agent-scaffold.js'
+import { startAgentProcess } from './web/agent-process.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
 import { startInviteMonitor, stopInviteMonitor } from './web/channel-invites.js'
@@ -429,10 +431,24 @@ async function main(): Promise<void> {
   }
   scheduleDailyDigest()
 
-  // Heartbeat
-  initHeartbeat()
-  heartbeatStarted = true
-  logger.info('Heartbeat utemezo elindult')
+  // Heartbeat -- 2026-06-02 architecture switch: the dedicated channel-less
+  // `heartbeat` sub-agent now handles the hourly summary via the scheduled-
+  // task runner. The legacy native scheduler (initHeartbeat) was the source
+  // of the Marveen self-poll loop that caused channel-disconnect every fire
+  // (see commit history #237/#250/#252/#253/#255 for the abandoned
+  // isolation-chain attempt). We keep the native module imported so other
+  // code paths that reference its exports still compile, but we do NOT
+  // start its scheduler.
+  ensureHeartbeatAgent()
+  logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent scaffold ensured (channel-less, dashboard-hidden)')
+  const heartbeatStart = startAgentProcess(HEARTBEAT_AGENT_NAME)
+  if (heartbeatStart.ok) {
+    logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent started')
+  } else if (heartbeatStart.error === 'Agent is already running') {
+    logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent already running')
+  } else {
+    logger.warn({ error: heartbeatStart.error }, 'Heartbeat agent failed to start (legacy native heartbeat is NOT a fallback any more)')
+  }
 
   // Discord-only: ensure the operator-configured DISCORD_CHANNEL_ID is
   // in access.groups so the plugin's outbound `reply` tool can send to

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -1,0 +1,238 @@
+// Bootstrap helper for the dedicated `heartbeat` channel-less sub-agent.
+//
+// Background (Szabi 2026-06-02 14:09): the historical heartbeat path
+// (src/heartbeat.ts -- the natív hourly module that called the
+// claude-agent-sdk's runAgent() and notifyTelegram()) routinely crashed
+// Marveen's channel plugin within 2-3 minutes of every fire. After a
+// long isolation-chain attempt (#237 / #250 / #252 / #253 / #255) the
+// remaining failure mode was a TUI-level freeze in Marveen, suspected
+// to be caused by Marveen's own poller picking up the heartbeat's
+// `notifyTelegram` sendMessage as a regular inbound and entering a
+// tool-call loop on it.
+//
+// Architectural fix: stop calling the SDK from inside the dashboard
+// process. Run the heartbeat in a SEPARATE channel-less tmux agent
+// (named "heartbeat"), driven by the existing scheduled-task system,
+// and have IT send the formatted summary to Marveen via inter-agent
+// message rather than directly to Telegram. Marveen then decides if
+// it relays to Szabi -- so the heartbeat output never spawns a
+// Marveen-token sendMessage, never produces a self-inbound event, and
+// the channel plugin stays untouched.
+//
+// This module is responsible for materialising the agent's directory
+// (gitignored under agents/) at dashboard boot time. The dir mirrors
+// the layout of the other channel-less agents:
+//   agents/heartbeat/
+//     ├── CLAUDE.md                       -- role/scope/output format
+//     ├── agent-config.json               -- model, profile, auth-mode
+//     ├── .claude/settings.json           -- channel plugins explicitly disabled
+//     └── .hidden-from-dashboard          -- listAgentNames() filter (#253)
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+import { logger } from '../logger.js'
+
+const HEARTBEAT_AGENT_NAME = 'heartbeat'
+const HEARTBEAT_AGENT_DIR = join(PROJECT_ROOT, 'agents', HEARTBEAT_AGENT_NAME)
+
+// Channel plugins MUST be explicitly disabled in the agent's
+// project-scope .claude/settings.json. Without this they leak through
+// from the user-scope ~/.claude/settings.json (every channel plugin
+// the operator has enabled globally would otherwise activate here,
+// open its own poller against the OPERATOR's bot token, and race the
+// main agent's poller for the same getUpdates slot -- see
+// agent-process.ts:137 for the same disable baked into startup).
+const CHANNEL_PLUGIN_DISABLES = {
+  'telegram@claude-plugins-official': false,
+  'slack-channel@marveen-marketplace': false,
+  'discord@claude-plugins-official': false,
+}
+
+// Haiku-class model: the heartbeat job is data-formatting (Calendar
+// events + kanban counts + memory + tasks list -> a short structured
+// message). Opus is wildly overpowered, and the previous hourly Opus
+// spawns burned tokens with no upside. Haiku finishes in seconds and
+// costs effectively nothing.
+//
+// authMode 'oauth' uses the host's Claude Code OAuth from the
+// Keychain -- the same auth Marveen and every other channel-less
+// sub-agent runs under. NO per-agent API key needed.
+const HEARTBEAT_AGENT_CONFIG = {
+  model: 'claude-haiku-4-5',
+  authMode: 'oauth' as const,
+  securityProfile: 'standard',
+}
+
+// The CLAUDE.md prose. Single source of truth for the agent's behaviour
+// at every scheduled fire. Critical contract:
+//   - NEVER call the Telegram reply tool. The whole point is to keep
+//     the heartbeat output OUT of any bot-API call from this process,
+//     so Marveen's poller never sees a self-generated inbound.
+//   - The output goes to Marveen via inter-agent message. Marveen
+//     decides whether to relay it to Szabi on Telegram, in HER own
+//     session, with HER own context.
+//   - Structured-text format so Marveen can either parse or relay-
+//     verbatim depending on signal-to-noise.
+function renderClaudeMd(): string {
+  return `# Heartbeat agent
+
+You are the **heartbeat agent** — a dedicated, headless worker that
+runs on the hourly schedule and produces a structured summary of
+what is happening across Szabolcs' systems right now. You ALWAYS
+hand the result to Marveen via inter-agent message; you NEVER
+contact Szabi directly.
+
+## Why this agent exists (Szabi 2026-06-02 14:09)
+
+The previous heartbeat ran from inside the dashboard process and
+called the Telegram Bot API directly. Every fire caused Marveen's
+channel plugin to fall over 2-3 minutes later -- the bot's outbound
+sendMessage was being read back as an inbound by Marveen's own
+poller and triggered a tool-call freeze. Splitting the heartbeat
+into its own channel-less agent (this one), wired to Marveen only
+through inter-agent message, removes the self-poll loop entirely.
+
+## What to do on every fire
+
+When you receive the heartbeat prompt:
+
+1. **Collect** the four data sources:
+   - **Calendar (next 2 hours)** — use the
+     \`mcp__server-google-calendar-mcp__list-events\` tool against
+     \`szota.szabolcs@gmail.com\`, timeMin=now, timeMax=now+2h.
+     If the call fails (token revoked / 401), record the failure
+     reason rather than the events; Marveen can act on the failure.
+   - **Kanban** — read the SQLite DB at
+     \`/Users/marvin/ClaudeClaw/store/claudeclaw.db\`:
+     \`sqlite3 store/claudeclaw.db "SELECT status, COUNT(*) FROM
+     kanban_cards WHERE archived_at IS NULL GROUP BY status"\` for
+     counts, and grab the titles of cards where
+     \`priority='urgent'\` or \`status='waiting'\`.
+   - **Scheduled tasks** — count active rows in
+     \`scheduled_tasks\` table; record \`next_run_at\` for the
+     earliest upcoming one.
+   - **Memory + system** — DB file size, any \`category='hot'\`
+     memories newer than 1 hour, plus presence of any
+     \`status='warning'\` entries in the memory log.
+
+2. **Format** the result as a single inter-agent message:
+
+   \`\`\`
+   ## Heartbeat YYYY-MM-DD HH:MM (Europe/Budapest)
+
+   ### Calendar (next 2h)
+   - HH:MM — <summary> (<attendees>)
+   - <or: "no upcoming events">
+   - <or: "calendar fetch failed: <reason>">
+
+   ### Kanban
+   - urgent: <N> (<short titles, comma-separated>)
+   - in_progress: <N>
+   - waiting: <N> (<short titles>)
+   - planned: <N>
+
+   ### Tasks
+   - active: <N>
+   - next: <task name @ YYYY-MM-DD HH:MM>
+
+   ### Memory / system
+   - DB size: <X> MB
+   - new hot memories (1h): <N>
+   - warnings: <none | comma-separated>
+   \`\`\`
+
+3. **Send** that string to Marveen via the dashboard API:
+
+   \`\`\`bash
+   TOKEN=$(cat /Users/marvin/ClaudeClaw/store/.dashboard-token)
+   curl -s -X POST http://localhost:3420/api/messages \\
+     -H "Content-Type: application/json" \\
+     -H "Authorization: Bearer $TOKEN" \\
+     -d '{"from":"heartbeat","to":"marveen","content":"<the formatted text>"}'
+   \`\`\`
+
+4. **Stop.** Do not Telegram-reply, do not Slack, do not message
+   anyone else. The handoff to Marveen is the entire job. Marveen
+   handles the human-facing relay decision.
+
+## Hard rules (never break)
+
+- **NEVER** call \`reply\` / Telegram / Slack tools.
+- **NEVER** contact a chat_id directly.
+- **NEVER** include API tokens, OAuth state, or any Bearer key in the
+  message body. The dashboard token in the example above goes in the
+  Authorization header only.
+- **NEVER** keep the output longer than ~30 lines. If something does
+  not fit, write "<N> more …" and let Marveen ask for the long
+  form. Heartbeat is a status pulse, not a transcript.
+- If a data source raises, record the failure reason in that
+  section's body and CONTINUE — partial output is fine, silence is
+  not.
+
+## You are headless
+
+You do not own a Telegram channel and the operator never reaches you
+directly. The only inputs you ever process are heartbeat prompts
+from the scheduler. If you receive anything else, hand it off to
+Marveen with a brief "received off-pattern input, please advise"
+note and stop.
+`
+}
+
+function renderAgentConfigJson(): string {
+  return JSON.stringify(HEARTBEAT_AGENT_CONFIG, null, 2) + '\n'
+}
+
+function renderClaudeSettingsJson(): string {
+  return JSON.stringify({ enabledPlugins: CHANNEL_PLUGIN_DISABLES }, null, 2) + '\n'
+}
+
+// Files we ALWAYS rewrite. Settings + agent-config are recreated to
+// keep them in sync with the constants in this file; if the operator
+// hand-edited the on-disk copy, our boot rewrite wins. CLAUDE.md is
+// re-rendered every boot for the same reason: the canonical source of
+// truth for the agent's instructions lives here, not on disk.
+const ALWAYS_WRITE: ReadonlyArray<readonly [string, () => string]> = [
+  ['CLAUDE.md', renderClaudeMd],
+  ['agent-config.json', renderAgentConfigJson],
+  [join('.claude', 'settings.json'), renderClaudeSettingsJson],
+] as const
+
+// Files we write only when missing. The sentinel is a marker, not a
+// payload -- once it exists we leave it alone.
+const SENTINEL_FILES: ReadonlyArray<readonly [string, string]> = [
+  ['.hidden-from-dashboard', ''],
+] as const
+
+/**
+ * Build the heartbeat agent's directory tree if it is missing, and
+ * (re)write the canonical CLAUDE.md / agent-config.json /
+ * .claude/settings.json on every call. Sentinel files are created
+ * idempotently. Call this once at dashboard boot, before
+ * startAgentProcess('heartbeat') -- the scheduled-task runner will
+ * pick it up from there.
+ */
+export function ensureHeartbeatAgent(): void {
+  try {
+    if (!existsSync(HEARTBEAT_AGENT_DIR)) {
+      mkdirSync(HEARTBEAT_AGENT_DIR, { recursive: true })
+    }
+    const claudeDir = join(HEARTBEAT_AGENT_DIR, '.claude')
+    if (!existsSync(claudeDir)) {
+      mkdirSync(claudeDir, { recursive: true })
+    }
+    for (const [relPath, render] of ALWAYS_WRITE) {
+      writeFileSync(join(HEARTBEAT_AGENT_DIR, relPath), render())
+    }
+    for (const [relPath, body] of SENTINEL_FILES) {
+      const p = join(HEARTBEAT_AGENT_DIR, relPath)
+      if (!existsSync(p)) writeFileSync(p, body)
+    }
+    logger.info({ dir: HEARTBEAT_AGENT_DIR }, 'Heartbeat agent scaffold ensured')
+  } catch (err) {
+    logger.error({ err, dir: HEARTBEAT_AGENT_DIR }, 'Failed to scaffold heartbeat agent')
+  }
+}
+
+export { HEARTBEAT_AGENT_NAME, HEARTBEAT_AGENT_DIR }

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -121,7 +121,25 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
   try {
     let prefix: string
     if (task.type === 'heartbeat') {
-      prefix = `[Heartbeat: ${task.name}] *** KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ: hivj meg pontosan EGY local-only tool-t (peldaul Bash 'echo keepalive >> /tmp/marveen-keepalive.log' VAGY Read tool egy meglevo fajlra mint ${join(PROJECT_ROOT, 'HEARTBEAT.md')}). NE Telegram-tool-t -- az zajt eredmenyezne. Ezt a Telegram-bun MCP-stdio-pipe keep-alive-ehez kell, ha kihagyod, a Telegram-conn 30 percen belul disconnect-el. *** Aztan: ez egy csendes ellenorzes. CSAK AKKOR irj Telegramon (chat_id: ${ALLOWED_CHAT_ID}), ha tenyleg fontos/surgos dolgot talalsz. Ha minden rendben, NE kuldj Telegram uzenetet -- a kotelezo no-op tool-call mar megfelelo aktivitas. Egy rovid 'csendes heartbeat' sor a transzkriptbe + a tool-call elég. `
+      // Channel-less heartbeat agents (today: only `heartbeat`) MUST NOT
+      // receive the Telegram-keepalive directive -- their CLAUDE.md is
+      // explicit that all output goes to Marveen via inter-agent message
+      // (Marveen 2026-06-02 PR #257 review block). The historical prefix
+      // was Marveen-specific scaffolding ("keep the bun-poller stdio
+      // alive, only Telegram-reply if urgent") and would create a direct
+      // contradiction with the agent's own contract; worse, if the
+      // channel-plugin disable ever leaks through from the user-scope
+      // settings (which it has done before in this fleet -- the very
+      // motivation for this whole rearchitecture), the leftover Telegram
+      // tool would receive an explicit instruction to use chat_id
+      // ALLOWED_CHAT_ID. So: emit a minimal heartbeat tag for the
+      // resubmit-marker code below to match, and let the agent's own
+      // CLAUDE.md + SKILL.md drive behaviour.
+      if (agentName === 'heartbeat') {
+        prefix = `[Heartbeat: ${task.name}] `
+      } else {
+        prefix = `[Heartbeat: ${task.name}] *** KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ: hivj meg pontosan EGY local-only tool-t (peldaul Bash 'echo keepalive >> /tmp/marveen-keepalive.log' VAGY Read tool egy meglevo fajlra mint ${join(PROJECT_ROOT, 'HEARTBEAT.md')}). NE Telegram-tool-t -- az zajt eredmenyezne. Ezt a Telegram-bun MCP-stdio-pipe keep-alive-ehez kell, ha kihagyod, a Telegram-conn 30 percen belul disconnect-el. *** Aztan: ez egy csendes ellenorzes. CSAK AKKOR irj Telegramon (chat_id: ${ALLOWED_CHAT_ID}), ha tenyleg fontos/surgos dolgot talalsz. Ha minden rendben, NE kuldj Telegram uzenetet -- a kotelezo no-op tool-call mar megfelelo aktivitas. Egy rovid 'csendes heartbeat' sor a transzkriptbe + a tool-call elég. `
+      }
     } else {
       prefix = `[Utemezett feladat: ${task.name}] Az eredmenyt kuldd el Telegramon (chat_id: ${ALLOWED_CHAT_ID}, reply tool). `
     }


### PR DESCRIPTION
## Summary (HIGH priority — architecture-level fix for the recurring Marveen channel-disconnect)

Szabi 2026-06-02 14:09: the previous native heartbeat ran from inside the dashboard process and called Bot-API `sendMessage` directly with Marveen's token. Every fire produced a self-inbound event in Marveen's own poller and triggered a tool-call freeze 2-3 minutes later. The #237/#250/#252/#253/#255 isolation-chain attempts mitigated symptoms but never closed the root cause.

**Directive**: stop calling the SDK / Bot-API from inside the dashboard. Run the heartbeat in its OWN channel-less tmux agent, hand the formatted output to Marveen via inter-agent message, let Marveen decide whether to relay to Szabi on Telegram.

## What's in this PR

1. **New scaffold**: `agents/heartbeat/` (gitignored), materialised by `ensureHeartbeatAgent()` at dashboard boot:
   - `CLAUDE.md` — behaviour contract (single source of truth)
   - `agent-config.json` — `claude-haiku-4-5`, oauth, standard profile
   - `.claude/settings.json` — channel plugins explicitly disabled
   - `.hidden-from-dashboard` — `listAgentNames()` filter (#253)

2. **Boot integration** in `index.ts`: `ensureHeartbeatAgent()` then `startAgentProcess('heartbeat')`. The native `initHeartbeat()` call is REMOVED — the module stays imported (so other consumers of its exports compile) but its scheduler no longer runs.

3. **New scheduled task** `hourly-heartbeat` (`0 9-22 * * *` Europe/Budapest, `agent=heartbeat`). Schedule-runner injects the `type=heartbeat` prefix and SKILL.md prompt; the agent's CLAUDE.md handles the actual work and inter-agent send to Marveen.

## Hard contract in CLAUDE.md

- NEVER call Telegram/Slack reply tools
- NEVER include API tokens / Bearer keys in message bodies
- Output capped at ~30 lines; partial output is fine, silence is not
- Only inputs processed are heartbeat-prompts from the scheduler; off-pattern inputs handed to Marveen with "received off-pattern" note

## Test plan

- [ ] Deploy. `agents/heartbeat/` scaffold appears with all 4 files. `agent-heartbeat` tmux session running.
- [ ] **19:00 hb-fire**: hourly-heartbeat task fires into agent-heartbeat. Agent assembles summary. Inter-agent message arrives at Marveen.
- [ ] **Marveen channel plugin DOES NOT lose its bun-poller** in the 19:00-19:10 window. This is the single most important verification — the whole point of this rearchitecture.
- [ ] No Bot-API sendMessage call from the dashboard process during the fire.

## Follow-up (not in this PR — keep diff small + reversible)

- Delete `src/heartbeat.ts` entirely
- Strip `notifyTelegram` direct callsites from the dashboard
- Consider migrating the daily-digest scheduler to the same agent-driven pattern

## Related

- #237/#250/#252/#253/#255 — symptom mitigations from the SDK-spawn isolation chain. They stay in force as defense in depth but are no longer load-bearing for heartbeat.
- #246 / #236 — stuck-tool-call + Esc+Esc unlock. Backstop for any unrelated TUI freeze; unaffected by this PR.