### PR TITLE
feat(dashboard): status tooltips + breathing working badge

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -105,11 +105,11 @@ navLinks.forEach((link) => {
 let activityTimer = null
 
 const ACTIVITY_STATE_META = {
-  working: { label: 'dolgozik', cls: 'act-working' },
-  idle: { label: 'várakozik', cls: 'act-idle' },
-  unknown: { label: 'ismeretlen', cls: 'act-unknown' },
-  error: { label: 'hiba', cls: 'act-error' },
-  stopped: { label: 'leállt', cls: 'act-stopped' },
+  working: { label: 'dolgozik', cls: 'act-working', tip: 'Élő állapot (a tmux pane tartalmából, 3 másodpercenként): éppen dolgozik / gondolkodik.' },
+  idle: { label: 'várakozik', cls: 'act-idle', tip: 'Élő állapot (3 másodpercenként): fut, de épp nem csinál semmit.' },
+  unknown: { label: 'ismeretlen', cls: 'act-unknown', tip: 'Élő állapot: nem sikerült megállapítani a session pane tartalmából.' },
+  error: { label: 'hiba', cls: 'act-error', tip: 'Élő állapot: hiba látszik az ágens session paneljén.' },
+  stopped: { label: 'leállt', cls: 'act-stopped', tip: 'Élő állapot: az ágens session nem fut.' },
 }
 
 function startActivityPoll() {
@@ -154,7 +154,7 @@ function renderActivity(entries) {
       '<div class="activity-card ' + meta.cls + '">' +
         '<div class="activity-card-head">' +
           '<span class="activity-name">' + escapeHtml(a.name) + mainBadge + '</span>' +
-          '<span class="activity-badge ' + meta.cls + '">' + meta.label + '</span>' +
+          '<span class="activity-badge ' + meta.cls + '" title="' + escapeHtml(meta.tip || '') + '">' + meta.label + '</span>' +
         '</div>' +
         (tail
           ? '<pre class="activity-tail">' + tail + '</pre>'
@@ -1306,6 +1306,20 @@ function getAvatarGradient(name) {
   return 'gradient-' + ((hash % 3) + 1)
 }
 
+// Tooltip text for the "Fut" / "Leállva" footer indicator (process state).
+function processTip(isRunning) {
+  return isRunning
+    ? 'Fut: él az ágens tmux session-je (a Claude Code folyamat fut). Forrás: tmux list-sessions.'
+    : 'Leállva: nincs élő tmux session az ágensnek. Forrás: tmux list-sessions.'
+}
+
+// Tooltip text for the "Online" / "Offline" footer indicator (channel state).
+function channelTip(isConnected) {
+  return isConnected
+    ? 'Online: van bekonfigurált csatorna-token (saját bot). Figyelem: ez nem élő kapcsolat, csak a token meglétét jelzi.'
+    : 'Offline: nincs csatorna bekötve (channel-less, csak inter-agent ágens).'
+}
+
 function renderAgents() {
   agentsGrid.querySelectorAll('.agent-card:not(.add-card)').forEach((el) => el.remove())
 
@@ -1325,8 +1339,8 @@ function renderAgents() {
       </div>
       <div class="agent-card-footer">
         <span class="agent-model-badge opus">opus</span>
-        <span class="process-indicator"><span class="process-dot running"></span>Fut</span>
-        <span class="tg-status"><span class="tg-dot connected"></span>Online</span>
+        <span class="process-indicator" title="Fut: a fő asszisztens mindig a --channels session-ben fut. Ez a kártya fixen Fut állapotot mutat, nincs per-ágens tmux-ellenőrzés."><span class="process-dot running"></span>Fut</span>
+        <span class="tg-status" title="Online: a fő asszisztens csatornáját a --channels session kezeli, ezért fixen online (nincs külön token-ellenőrzés)."><span class="tg-dot connected"></span>Online</span>
       </div>
     `
     mCard.addEventListener('click', () => openMarveenDetail())
@@ -1365,8 +1379,8 @@ function renderAgents() {
       </div>
       <div class="agent-card-footer">
         <span class="agent-model-badge ${escapeHtml(modelClass)}">${escapeHtml(modelLabel)}</span>
-        <span class="process-indicator"><span class="process-dot ${runDotClass}"></span>${runLabel}</span>
-        <span class="tg-status"><span class="tg-dot ${chDotClass}"></span>${chLabel}</span>
+        <span class="process-indicator" title="${escapeHtml(processTip(isRunning))}"><span class="process-dot ${runDotClass}"></span>${runLabel}</span>
+        <span class="tg-status" title="${escapeHtml(channelTip(chConnected))}"><span class="tg-dot ${chDotClass}"></span>${chLabel}</span>
       </div>
     `
     card.addEventListener('click', () => openAgentDetail(agent.name))

--- a/web/style.css
+++ b/web/style.css
@@ -4920,11 +4920,23 @@ main {
   background: var(--border); color: var(--text-muted); border-radius: 4px; padding: 1px 6px;
 }
 .activity-badge { font-size: 12px; font-weight: 600; border-radius: 999px; padding: 2px 10px; }
-.activity-badge.act-working { background: rgba(34,197,94,0.15); color: #16a34a; }
+.activity-badge.act-working {
+  background: rgba(34,197,94,0.15); color: #16a34a;
+  /* "Breathing" pulse so the live "dolgozik" badge reads as active, mirroring
+     the .process-dot.running pulse (same 2s ease-in-out cadence). */
+  animation: badge-breathe 2s ease-in-out infinite;
+}
 .activity-badge.act-idle    { background: rgba(156,163,175,0.18); color: #6b7280; }
 .activity-badge.act-error   { background: rgba(239,68,68,0.15); color: #dc2626; }
 .activity-badge.act-unknown { background: rgba(234,179,8,0.18); color: #ca8a04; }
 .activity-badge.act-stopped { background: rgba(107,114,128,0.15); color: #6b7280; }
+
+/* Green "breathing" glow for the working badge: saturates the pill and pulses a
+   soft halo at peak, then settles. */
+@keyframes badge-breathe {
+  0%, 100% { background: rgba(34,197,94,0.12); box-shadow: 0 0 0 0 rgba(34,197,94,0); }
+  50%      { background: rgba(34,197,94,0.32); box-shadow: 0 0 8px 1px rgba(34,197,94,0.40); }
+}
 .activity-tail {
   margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px;
   line-height: 1.45; color: var(--text-muted); white-space: pre-wrap; word-break: break-word;


### PR DESCRIPTION
Two small, additive UX improvements to the agents / activity views.

## What

**1. Hover tooltips on the status indicators**, explaining what each means and where its data comes from:
- **Fut / Leállva** (process): live tmux session presence (`isAgentRunning` -> `tmux list-sessions`).
- **Online / Offline** (channel): channel **token** presence, *not* a live connection. Clarified because the label otherwise implies an active link.
- **activity badge** (dolgozik / várakozik / ...): live tmux pane state, polled ~3s.

The main-agent card's hardcoded Fut/Online also get tooltips noting they are fixed for the channels session.

**2. Breathing working badge** — the live "dolgozik" (working) activity badge now breathes with a green glow pulse, mirroring the existing `.process-dot.running` pulse (2s ease-in-out), so active work reads at a glance.

## Scope
- Frontend-only: `web/app.js` + `web/style.css`.
- Purely additive: `title` attributes + one CSS keyframe/animation. Nothing is overwritten or restructured.
- Builds on existing anchors (`ACTIVITY_STATE_META`, `.activity-badge`, `.process-indicator`, `.tg-status`, the `.process-dot.running` pulse), so it should apply cleanly.
- Tooltip strings are Hungarian to match the existing UI language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
