### PR TITLE
Disk-space guard + mid-session stuck-/mcp-modal guard

### DIFF
--- a/docs/disk-modal-guards.md
+++ b/docs/disk-modal-guards.md
@@ -7,10 +7,10 @@ modal and left inbound messages dropped until a human noticed. They are
 **independent of the dashboard** (which dies with its process and is itself
 unreliable under disk-full).
 
-## A. Disk-space guard — `scripts/disk-space-guard.sh`
+## A. Disk-space guard -- `scripts/disk-space-guard.sh`
 
 Every minute: read `df /` usage.
-- `>= 90%` (`REAP_THRESHOLD`): reap **age-guarded allowlist scratch** — globs in
+- `>= 90%` (`REAP_THRESHOLD`): reap **age-guarded allowlist scratch** -- globs in
   `REAP_GLOBS` (currently `health_*`) directly under `/tmp`, only entries older
   than `REAP_MIN_AGE_MIN` (30 min), so a currently-running export (recent mtime)
   is never deleted.
@@ -20,7 +20,7 @@ Every minute: read `df /` usage.
 Thresholds + the reap allowlist are constants at the top of the script. All
 stamp/log writes are best-effort (ENOSPC-tolerant).
 
-## B. Stuck-modal guard — `scripts/stuck-modal-guard.sh`
+## B. Stuck-modal guard -- `scripts/stuck-modal-guard.sh`
 
 Every minute: classify the main channels session pane (`${MAIN_AGENT_ID}-channels`,
 mirrors `src/pane-state.ts`):
@@ -41,7 +41,7 @@ classified busy/idle and is never disturbed (locked by the contract test).
 
 ## Activation
 
-The unit files carry `/path/to/marveen` and `/home/USER` placeholders — replace
+The unit files carry `/path/to/marveen` and `/home/USER` placeholders -- replace
 them with your install dir and home before installing.
 
 ```bash
@@ -64,11 +64,11 @@ bash scripts/__tests__/stuck-modal-guard.test.sh   # classify fixtures (idle/bus
 
 ## Re-review hardening (2026-06-03, post-cross-model)
 
-- **W2a — busy-marker glyph robustness:** the `(Ns · ↓` token-counter separator can
+- **W2a -- busy-marker glyph robustness:** the `(Ns · ↓` token-counter separator can
   render as a Unicode middle-dot OR an ASCII period depending on terminal/locale.
   `classify_pane` now matches both (`(·|\.)`), so a working pane is never misread as
   STUCK and respawned mid-turn. Locked by a regression fixture in the test suite.
-- **W2b — respawn plugin id is config-overridable:** `STUCK_MODAL_PLUGIN` (default
+- **W2b -- respawn plugin id is config-overridable:** `STUCK_MODAL_PLUGIN` (default
   `plugin:telegram@claude-plugins-official`) so a renamed/local-build install isn't
   respawned with a wrong plugin id (which would exit immediately while the alert
   falsely says "respawned"). `%q`-quoted at interpolation, like the model id.
@@ -78,7 +78,7 @@ bash scripts/__tests__/stuck-modal-guard.test.sh   # classify fixtures (idle/bus
 - **Telegram bot token in the `curl` URL path (`alert_owner`, both guards).** The
   token is interpolated as `…/bot${token}/sendMessage`, so it is visible in
   `/proc/<pid>/cmdline` for the curl process's lifetime. **Disposition: ACCEPTED**
-  for this deployment — the host is single-user and the guards run as
+  for this deployment -- the host is single-user and the guards run as
   `systemctl --user`, so no other local user can read the process table; the token
   already lives in a local `.env` the same user owns. On a shared/multi-user host
   this would be a real exposure and must move to a `--config`/netrc (mode 0600) form.

--- a/docs/disk-modal-guards.md
+++ b/docs/disk-modal-guards.md
@@ -61,3 +61,26 @@ systemctl --user list-timers | grep -E 'disk-space|stuck-modal'
 bash scripts/__tests__/disk-space-guard.test.sh    # thresholds / age-guard / alert+cooldown / malformed
 bash scripts/__tests__/stuck-modal-guard.test.sh   # classify fixtures (idle/busy/stuck/empty) + confirm-window
 ```
+
+## Re-review hardening (2026-06-03, post-cross-model)
+
+- **W2a — busy-marker glyph robustness:** the `(Ns · ↓` token-counter separator can
+  render as a Unicode middle-dot OR an ASCII period depending on terminal/locale.
+  `classify_pane` now matches both (`(·|\.)`), so a working pane is never misread as
+  STUCK and respawned mid-turn. Locked by a regression fixture in the test suite.
+- **W2b — respawn plugin id is config-overridable:** `STUCK_MODAL_PLUGIN` (default
+  `plugin:telegram@claude-plugins-official`) so a renamed/local-build install isn't
+  respawned with a wrong plugin id (which would exit immediately while the alert
+  falsely says "respawned"). `%q`-quoted at interpolation, like the model id.
+
+## Deferred findings
+
+- **Telegram bot token in the `curl` URL path (`alert_owner`, both guards).** The
+  token is interpolated as `…/bot${token}/sendMessage`, so it is visible in
+  `/proc/<pid>/cmdline` for the curl process's lifetime. **Disposition: ACCEPTED**
+  for this deployment — the host is single-user and the guards run as
+  `systemctl --user`, so no other local user can read the process table; the token
+  already lives in a local `.env` the same user owns. On a shared/multi-user host
+  this would be a real exposure and must move to a `--config`/netrc (mode 0600) form.
+  Re-evaluate if the deployment model changes. (Source: PR #264 cross-model + sec-*
+  re-review, 2026-06-03.)

--- a/docs/disk-modal-guards.md
+++ b/docs/disk-modal-guards.md
@@ -1,0 +1,63 @@
+# Disk-space + stuck-modal guards (2026-06-03 hardening)
+
+Two independent systemd `--user` timers that address the failure mode the
+2026-06-03 dawn incident exposed: the root fs filled to 100% from a 2.2G orphaned
+`/tmp/health_*` Apple Health export, which wedged the main session in a `/mcp`
+modal and left inbound messages dropped until a human noticed. They are
+**independent of the dashboard** (which dies with its process and is itself
+unreliable under disk-full).
+
+## A. Disk-space guard — `scripts/disk-space-guard.sh`
+
+Every minute: read `df /` usage.
+- `>= 90%` (`REAP_THRESHOLD`): reap **age-guarded allowlist scratch** — globs in
+  `REAP_GLOBS` (currently `health_*`) directly under `/tmp`, only entries older
+  than `REAP_MIN_AGE_MIN` (30 min), so a currently-running export (recent mtime)
+  is never deleted.
+- `>= 95%` (`ALERT_THRESHOLD`) after reap: alert the owner over the **direct Telegram
+  Bot API** (the MCP plugin is dead under disk-full), at most once/hour.
+
+Thresholds + the reap allowlist are constants at the top of the script. All
+stamp/log writes are best-effort (ENOSPC-tolerant).
+
+## B. Stuck-modal guard — `scripts/stuck-modal-guard.sh`
+
+Every minute: classify the main channels session pane (`${MAIN_AGENT_ID}-channels`,
+mirrors `src/pane-state.ts`):
+- **idle** (`? for shortcuts` / `bypass permissions on`) or **busy**
+  (`esc to interrupt` / `(Ns · ↓` token counter) → healthy, never touched.
+- **stuck** (neither marker → the modal overlay hides the idle footer and no live
+  turn) → only after it **persists `STUCK_SECONDS` = 120s** (≥2 consecutive
+  ticks): Escape up to 4× (like `channels.sh ensure_modal_closed`); if still not
+  idle, `respawn-pane`. The respawn **shares `channel-watchdog.sh`'s
+  `.channel-last-respawn` grace stamp**, so the two watchdogs never double-respawn.
+
+A legitimately working session (`esc to interrupt` + `bypass permissions on`) is
+classified busy/idle and is never disturbed (locked by the contract test).
+
+> Companion hardening: make the stamp writes in your existing watchdog scripts
+> best-effort (`… 2>/dev/null || true`) so an ENOSPC write under disk-full cannot
+> crash a watchdog or emit a false signal.
+
+## Activation
+
+The unit files carry `/path/to/marveen` and `/home/USER` placeholders — replace
+them with your install dir and home before installing.
+
+```bash
+# 1. install the unit files (after editing the placeholders)
+cp scripts/systemd/disk-space-guard.{service,timer}  ~/.config/systemd/user/
+cp scripts/systemd/stuck-modal-guard.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+# 2. enable + start the timers
+systemctl --user enable --now disk-space-guard.timer stuck-modal-guard.timer
+# 3. verify
+systemctl --user list-timers | grep -E 'disk-space|stuck-modal'
+```
+
+## Tests
+
+```bash
+bash scripts/__tests__/disk-space-guard.test.sh    # thresholds / age-guard / alert+cooldown / malformed
+bash scripts/__tests__/stuck-modal-guard.test.sh   # classify fixtures (idle/busy/stuck/empty) + confirm-window
+```

--- a/scripts/__tests__/disk-space-guard.test.sh
+++ b/scripts/__tests__/disk-space-guard.test.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Contract tests for scripts/disk-space-guard.sh.
+# Run: bash scripts/__tests__/disk-space-guard.test.sh
+#
+# Exercises the threshold logic, the age-guarded allowlist reap, the critical
+# alert + cooldown, and the malformed-input no-op -- all through the real script
+# via its DISK_GUARD_* test hooks (no actual df / Telegram / rm of real scratch).
+
+set -u
+
+PASS=0; FAIL=0
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (expected '$2', got '$3')"; fi; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+GUARD="$INSTALL_DIR/scripts/disk-space-guard.sh"
+
+# Run the guard with an isolated scratch + state dir and a usage override.
+# Args: usage scratch_dir state_dir  -> prints stdout (logs + any ALERT_DRYRUN).
+run_guard() {
+  DISK_GUARD_USAGE_OVERRIDE="$1" DISK_GUARD_SCRATCH_DIR="$2" DISK_GUARD_STATE_DIR="$3" \
+    DISK_GUARD_ALERT_DRYRUN=1 bash "$GUARD" 2>&1
+}
+
+fresh_case() { # -> echoes "scratch state" for a clean case dir
+  local d; d="$TMPDIR_BASE/case-$1"; mkdir -p "$d/scratch" "$d/state"
+  echo "$d/scratch $d/state"
+}
+
+echo "disk-space-guard tests"
+echo "======================"
+
+# ---------------------------------------------------------------------------
+# (a) Below reap threshold -> total no-op
+# ---------------------------------------------------------------------------
+echo ""
+echo "(a) Below threshold"
+read -r SCR ST <<<"$(fresh_case a)"
+touch -d '2 hours ago' "$SCR/health_old.bin"
+OUT="$(run_guard 50 "$SCR" "$ST")"
+assert_eq "below threshold: no reap log" "" "$OUT"
+[ -e "$SCR/health_old.bin" ] && pass "below threshold: scratch untouched" || fail "below threshold: scratch was reaped"
+
+# ---------------------------------------------------------------------------
+# (b) At/over reap threshold -> reap aged allowlist, keep fresh + unrelated
+# ---------------------------------------------------------------------------
+echo ""
+echo "(b) Reap threshold"
+read -r SCR ST <<<"$(fresh_case b)"
+touch -d '2 hours ago' "$SCR/health_old.xml"
+mkdir -p "$SCR/health_unpacked"; touch -d '2 hours ago' "$SCR/health_unpacked"
+touch "$SCR/health_fresh.xml"               # recent -> age guard protects it
+touch -d '2 hours ago' "$SCR/keepme.txt"    # not on allowlist -> protected
+OUT="$(run_guard 92 "$SCR" "$ST")"
+[ ! -e "$SCR/health_old.xml" ] && pass "reap: aged health_* file removed" || fail "reap: aged health file survived"
+[ ! -e "$SCR/health_unpacked" ] && pass "reap: aged health_* dir removed" || fail "reap: aged health dir survived"
+[ -e "$SCR/health_fresh.xml" ] && pass "reap: fresh health_* file PROTECTED by age guard" || fail "reap: fresh health file was deleted"
+[ -e "$SCR/keepme.txt" ] && pass "reap: non-allowlist file PROTECTED" || fail "reap: non-allowlist file deleted"
+if printf '%s' "$OUT" | grep -q "ALERT_DRYRUN"; then fail "reap (92%): must NOT alert below 95%"; else pass "reap (92%): no alert below 95%"; fi
+
+# ---------------------------------------------------------------------------
+# (c) At/over alert threshold -> critical alert via dry-run
+# ---------------------------------------------------------------------------
+echo ""
+echo "(c) Alert threshold"
+read -r SCR ST <<<"$(fresh_case c)"
+OUT="$(run_guard 96 "$SCR" "$ST")"
+if printf '%s' "$OUT" | grep -q "ALERT_DRYRUN"; then pass "alert: critical alert emitted at 96%"; else fail "alert: no alert at 96%"; fi
+[ -f "$ST/.disk-guard-alerted" ] && pass "alert: cooldown stamp written" || fail "alert: cooldown stamp missing"
+
+# ---------------------------------------------------------------------------
+# (d) Alert cooldown -> second run within the hour does NOT re-alert
+# ---------------------------------------------------------------------------
+echo ""
+echo "(d) Alert cooldown"
+OUT2="$(run_guard 96 "$SCR" "$ST")"   # same state dir, stamp is fresh
+if printf '%s' "$OUT2" | grep -q "ALERT_DRYRUN"; then fail "cooldown: re-alerted within cooldown"; else pass "cooldown: suppressed re-alert within cooldown"; fi
+
+# ---------------------------------------------------------------------------
+# (e) Malformed usage -> no-op, no crash
+# ---------------------------------------------------------------------------
+echo ""
+echo "(e) Malformed usage"
+read -r SCR ST <<<"$(fresh_case e)"
+touch -d '2 hours ago' "$SCR/health_old.bin"
+OUT="$(run_guard "garbage" "$SCR" "$ST")"
+if printf '%s' "$OUT" | grep -q "could not read disk usage"; then pass "malformed: logs a clean no-op"; else fail "malformed: unexpected output: $OUT"; fi
+[ -e "$SCR/health_old.bin" ] && pass "malformed: scratch untouched on bad usage" || fail "malformed: reaped on bad usage"
+
+# ---------------------------------------------------------------------------
+# (f) W3 location guard -> refuse to reap a SCRATCH_DIR outside /tmp
+# ---------------------------------------------------------------------------
+echo ""
+echo "(f) W3 location guard"
+OUTSIDE="$(TMPDIR="$HOME" mktemp -d 2>/dev/null || true)"
+if [ -n "$OUTSIDE" ]; then
+  touch -d '2 hours ago' "$OUTSIDE/health_outside.bin"
+  run_guard 92 "$OUTSIDE" "$OUTSIDE" >/dev/null 2>&1
+  [ -e "$OUTSIDE/health_outside.bin" ] && pass "W3: scratch outside /tmp is NOT reaped" || fail "W3: reaped scratch outside /tmp"
+  rm -rf "$OUTSIDE"
+else
+  fail "W3: could not create an out-of-/tmp test dir"
+fi
+# A symlinked SCRATCH_DIR (even pointing into /tmp) is refused.
+read -r SCR ST <<<"$(fresh_case f)"
+touch -d '2 hours ago' "$SCR/health_real.bin"
+LINK="$TMPDIR_BASE/f-link"; ln -s "$SCR" "$LINK"
+run_guard 92 "$LINK" "$ST" >/dev/null 2>&1
+[ -e "$SCR/health_real.bin" ] && pass "W3: symlinked SCRATCH_DIR is NOT reaped" || fail "W3: reaped via symlinked SCRATCH_DIR"
+
+# ---------------------------------------------------------------------------
+# (g) W2 reap-age validation -> invalid env falls back to a conservative default
+# ---------------------------------------------------------------------------
+echo ""
+echo "(g) W2 reap-age validation"
+read -r SCR ST <<<"$(fresh_case g)"
+touch -d '2 hours ago' "$SCR/health_2h.bin"   # 120 min old; < the 1440 fallback
+DISK_GUARD_REAP_MIN_AGE_MIN="garbage" run_guard 92 "$SCR" "$ST" >/dev/null 2>&1
+[ -e "$SCR/health_2h.bin" ] && pass "W2: invalid reap-age -> conservative default, recent file kept" || fail "W2: invalid reap-age reaped a 2h-old file"
+# Sanity: a valid small age still reaps the same 2h-old file.
+read -r SCR2 ST2 <<<"$(fresh_case g2)"
+touch -d '2 hours ago' "$SCR2/health_2h.bin"
+DISK_GUARD_REAP_MIN_AGE_MIN="30" run_guard 92 "$SCR2" "$ST2" >/dev/null 2>&1
+[ ! -e "$SCR2/health_2h.bin" ] && pass "W2: valid reap-age still reaps an aged file" || fail "W2: valid reap-age failed to reap"
+
+# ---------------------------------------------------------------------------
+# (h) C — reap-age "0" must NOT reap active files (0 -> 1440 fallback)
+# ---------------------------------------------------------------------------
+echo ""
+echo "(h) C reap-age 0 guard"
+read -r SCR ST <<<"$(fresh_case h)"
+touch "$SCR/health_fresh.bin"   # brand-new; -mmin +0 would match it
+DISK_GUARD_REAP_MIN_AGE_MIN="0" run_guard 92 "$SCR" "$ST" >/dev/null 2>&1
+[ -e "$SCR/health_fresh.bin" ] && pass "C: reap-age 0 -> 1440 fallback, fresh file kept" || fail "C: reap-age 0 reaped an active file"
+
+# ---------------------------------------------------------------------------
+# (i) D — an aged DIR with a fresh file inside is in-progress -> NOT reaped
+# ---------------------------------------------------------------------------
+echo ""
+echo "(i) D directory-mtime guard"
+read -r SCR ST <<<"$(fresh_case i)"
+mkdir -p "$SCR/health_inprogress"; touch "$SCR/health_inprogress/part.xml"   # fresh file inside
+touch -d '2 hours ago' "$SCR/health_inprogress"                              # dir mtime looks old
+DISK_GUARD_REAP_MIN_AGE_MIN="30" run_guard 92 "$SCR" "$ST" >/dev/null 2>&1
+[ -d "$SCR/health_inprogress" ] && pass "D: aged dir with a fresh file inside is NOT reaped" || fail "D: reaped an in-progress export dir"
+# Control: a dir whose files are ALL old IS reaped.
+read -r SCR2 ST2 <<<"$(fresh_case i2)"
+mkdir -p "$SCR2/health_done"; touch -d '2 hours ago' "$SCR2/health_done/done.xml" "$SCR2/health_done"
+DISK_GUARD_REAP_MIN_AGE_MIN="30" run_guard 92 "$SCR2" "$ST2" >/dev/null 2>&1
+[ ! -d "$SCR2/health_done" ] && pass "D: fully-old dir is still reaped" || fail "D: fully-old dir not reaped"
+
+# ---------------------------------------------------------------------------
+# (j) B — cooldown stamp persists even when STATE_DIR was missing (no alert-spam)
+# ---------------------------------------------------------------------------
+echo ""
+echo "(j) B cooldown-stamp persistence"
+JBASE="$TMPDIR_BASE/j"; mkdir -p "$JBASE/scratch"; JSTATE="$JBASE/state-missing"   # JSTATE does not exist
+OUTJ1="$(run_guard 96 "$JBASE/scratch" "$JSTATE")"
+if printf '%s' "$OUTJ1" | grep -q "ALERT_DRYRUN"; then pass "B: alerts at 96% on first tick"; else fail "B: no alert at 96%"; fi
+[ -f "$JSTATE/.disk-guard-alerted" ] && pass "B: cooldown stamp written despite missing STATE_DIR (mkdir at top)" || fail "B: stamp not written -> would re-alert 60x/h"
+OUTJ2="$(run_guard 96 "$JBASE/scratch" "$JSTATE")"
+if printf '%s' "$OUTJ2" | grep -q "ALERT_DRYRUN"; then fail "B: re-alerted within cooldown (stamp not honoured)"; else pass "B: second tick suppressed by cooldown"; fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "======================"
+TOTAL=$((PASS + FAIL))
+echo "Results: $PASS/$TOTAL passed"
+if [ "$FAIL" -gt 0 ]; then echo "FAILED: $FAIL tests"; exit 1; fi
+echo "All tests passed."

--- a/scripts/__tests__/seed-skills.test.sh
+++ b/scripts/__tests__/seed-skills.test.sh
@@ -161,7 +161,9 @@ fi
 echo ""
 echo "Test 4: seed-scheduled-tasks skips existing (full loop)"
 SCHED_TARGET2="$TMPDIR_BASE/t4-sched"
-mkdir -p "$SCHED_TARGET2/kanban-audit"
+# Pre-create EVERY existing seed template so the skip-existing path covers them
+# all (the test asserts 0 newly seeded). Robust to new templates being added.
+for tpl in "$SEED_SCHED_DIR"/*/; do [ -d "$tpl" ] && mkdir -p "$SCHED_TARGET2/$(basename "$tpl")"; done
 echo "custom" > "$SCHED_TARGET2/kanban-audit/task-config.json"
 
 SCHED_NEW=0

--- a/scripts/__tests__/stuck-modal-guard.test.sh
+++ b/scripts/__tests__/stuck-modal-guard.test.sh
@@ -45,6 +45,12 @@ assert_eq "busy: 'esc to interrupt' (working footer) -> busy NOT stuck" "busy" "
 BUSY_TOKENS='✻ Thinking… (52s · ↓ 2.6k tokens)'
 assert_eq "busy: token counter '(Ns · ↓' -> busy" "busy" "$(classify "$BUSY_TOKENS")"
 
+# W2 regression: the counter separator may render as an ASCII period (locale /
+# terminal dependent) instead of the Unicode middle-dot. A working pane MUST
+# still classify as busy, never stuck (else it gets respawned mid-turn).
+BUSY_TOKENS_ASCII='✻ Thinking… (52s . ↓ 2.6k tokens)'
+assert_eq "busy: token counter '(Ns . ↓' ASCII-dot -> busy" "busy" "$(classify "$BUSY_TOKENS_ASCII")"
+
 # ---------------------------------------------------------------------------
 # (b) Classifier: a wedged /mcp modal -> stuck
 # ---------------------------------------------------------------------------

--- a/scripts/__tests__/stuck-modal-guard.test.sh
+++ b/scripts/__tests__/stuck-modal-guard.test.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Contract tests for scripts/stuck-modal-guard.sh.
+# Run: bash scripts/__tests__/stuck-modal-guard.test.sh
+#
+# Pins the pure pane classifier (idle / busy / stuck / empty) against captured
+# pane fixtures and the confirm-window decision, so the false-positive guarantee
+# ("a legitimately working session is NEVER touched") is locked by a test.
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (expected '$2', got '$3')"; fi; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+GUARD="$INSTALL_DIR/scripts/stuck-modal-guard.sh"
+
+classify() { printf '%s' "$1" | bash "$GUARD" classify; }
+decide()   { bash "$GUARD" decide "$1" "$2" "$3"; }
+
+echo "stuck-modal-guard tests"
+echo "======================="
+
+# ---------------------------------------------------------------------------
+# (a) Classifier: healthy panes -> idle / busy (NEVER stuck)
+# ---------------------------------------------------------------------------
+echo ""
+echo "(a) Healthy panes are never 'stuck'"
+
+IDLE_BYPASS='Some reply text from the agent.
+                                                      ⏵⏵ bypass permissions on (shift+tab to cycle)'
+assert_eq "idle: bypass-permissions footer" "idle" "$(classify "$IDLE_BYPASS")"
+
+IDLE_SHORTCUTS='╭─────────────╮
+│ ❯           │
+╰─────────────╯
+  ? for shortcuts'
+assert_eq "idle: '? for shortcuts' footer" "idle" "$(classify "$IDLE_SHORTCUTS")"
+
+BUSY_INTERRUPT='✻ Combobulating… (8s · ↓ 1.2k tokens · esc to interrupt)
+⏵⏵ bypass permissions on (shift+tab to cycle)'
+assert_eq "busy: 'esc to interrupt' (working footer) -> busy NOT stuck" "busy" "$(classify "$BUSY_INTERRUPT")"
+
+BUSY_TOKENS='✻ Thinking… (52s · ↓ 2.6k tokens)'
+assert_eq "busy: token counter '(Ns · ↓' -> busy" "busy" "$(classify "$BUSY_TOKENS")"
+
+# ---------------------------------------------------------------------------
+# (b) Classifier: a wedged /mcp modal -> stuck
+# ---------------------------------------------------------------------------
+echo ""
+echo "(b) Wedged /mcp modal is 'stuck'"
+
+MCP_MODAL='Manage MCP servers
+
+  ❯ 1. telegram   ✗ failed
+       Reconnect
+       View tools
+
+  Esc to go back'
+assert_eq "stuck: /mcp modal (no idle/busy markers)" "stuck" "$(classify "$MCP_MODAL")"
+
+TRUST_DIALOG='Do you trust the files in this folder?
+  1. Yes
+  2. No'
+assert_eq "stuck: an unexpected blocking dialog with no footer" "stuck" "$(classify "$TRUST_DIALOG")"
+
+# ---------------------------------------------------------------------------
+# (c) Classifier: empty capture -> empty (inconclusive)
+# ---------------------------------------------------------------------------
+echo ""
+echo "(c) Empty capture"
+assert_eq "empty: whitespace-only pane" "empty" "$(classify '
+   ')"
+
+# ---------------------------------------------------------------------------
+# (d) Decision: confirm-window persistence (anti-flap) + healthy-clears
+# ---------------------------------------------------------------------------
+echo ""
+echo "(d) Confirm-window decision (STUCK_SECONDS=120)"
+assert_eq "decide: first stuck sighting -> start-confirm" "start-confirm" "$(decide stuck 0 1000)"
+assert_eq "decide: stuck 30s (< 120) -> wait-confirm"     "wait-confirm"  "$(decide stuck 970 1000)"
+assert_eq "decide: stuck 200s (>= 120) -> act"            "act"           "$(decide stuck 800 1000)"
+assert_eq "decide: idle -> clear confirm window"          "clear"         "$(decide idle 800 1000)"
+assert_eq "decide: busy -> clear confirm window"          "clear"         "$(decide busy 800 1000)"
+assert_eq "decide: empty capture -> hold (preserve window)" "hold"        "$(decide empty 800 1000)"
+
+# Custom STUCK_SECONDS is honoured (env override)
+assert_eq "decide: honours STUCK_MODAL_SECONDS override" "act" \
+  "$(STUCK_MODAL_SECONDS=10 bash "$GUARD" decide stuck 980 1000)"
+# F: a non-integer STUCK_MODAL_SECONDS must fall back to the default (not error
+# the -ge comparison and short-circuit recovery). 200s elapsed >= 120 -> act.
+assert_eq "decide: invalid STUCK_MODAL_SECONDS falls back to default" "act" \
+  "$(STUCK_MODAL_SECONDS=garbage bash "$GUARD" decide stuck 800 1000)"
+
+# ---------------------------------------------------------------------------
+# (e) Model-id sanitization (W1) — safe to interpolate into the respawn string
+# ---------------------------------------------------------------------------
+echo ""
+echo "(e) Model-id sanitization"
+assert_eq "sanitize: legit bracketed model id is preserved" "claude-opus-4-8[1m]" \
+  "$(bash "$GUARD" sanitize-model 'claude-opus-4-8[1m]')"
+SAN="$(bash "$GUARD" sanitize-model "claude'; rm -rf / #")"
+case "$SAN" in
+  *"'"*|*";"*|*" "*|*"/"*|*'$'*|*'`'*|*'#'*) fail "sanitize: shell metacharacter survived: $SAN" ;;
+  *) pass "sanitize: shell metacharacters stripped ($SAN)" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# (f) F1 — a missing state dir is created (no flock defer-forever, cold install)
+# ---------------------------------------------------------------------------
+echo ""
+echo "(f) State-dir auto-create"
+# CHANNELS_SESSION points at a non-existent session so the guard no-ops at the
+# has-session check WITHOUT touching any real pane; the mkdir runs before that.
+TMP_F1="$(mktemp -d)"; NOSTORE="$TMP_F1/sub"   # NOSTORE does not exist yet
+CHANNELS_SESSION="nonexistent-modal-guard-test-channels" STUCK_MODAL_STATE_DIR="$NOSTORE" \
+  bash "$GUARD" >/dev/null 2>&1
+[ -d "$NOSTORE" ] && pass "F1: run_guard creates a missing state dir (lock can't defer forever)" \
+  || fail "F1: missing state dir not created — exec 9> on the lock would fail and defer recovery"
+rm -rf "$TMP_F1"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "======================="
+TOTAL=$((PASS + FAIL))
+echo "Results: $PASS/$TOTAL passed"
+if [ "$FAIL" -gt 0 ]; then echo "FAILED: $FAIL tests"; exit 1; fi
+echo "All tests passed."

--- a/scripts/disk-space-guard.sh
+++ b/scripts/disk-space-guard.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Disk-space guard for the host (systemd --user timer, every minute).
+#
+# Incident it fixes (2026-06-03 dawn): the root filesystem filled to 100% from a
+# 2.2G orphaned /tmp/health_* Apple Health export (the apple-health skill's
+# scratch cleanup didn't run). A full root wedged the main session in a /mcp
+# modal and every disk-touching watchdog gave false signals. This guard is the
+# independent net: it reaps known-safe scratch BEFORE the disk fills, and when it
+# can't recover it alerts the owner over the DIRECT Telegram Bot API (the in-session
+# MCP plugin is dead under disk-full).
+#
+# Determinism + safety:
+#   - Thresholds are constants at the top.
+#   - Reaping is restricted to an explicit allowlist of scratch globs AND an age
+#     guard, so a CURRENTLY-RUNNING export (recent mtime) is never deleted -- only
+#     orphans are reaped. Never recurses outside the scratch dir.
+#   - Alerts go via direct Bot API (token from channels/.env), never via MCP.
+#   - Every stamp/log write is best-effort: under ENOSPC a failed write must not
+#     wedge or crash the guard (that is the whole point).
+#
+# Test hooks (env, used only by scripts/__tests__/disk-space-guard.test.sh):
+#   DISK_GUARD_USAGE_OVERRIDE   - use this usage% instead of df (integer)
+#   DISK_GUARD_SCRATCH_DIR      - reap base dir (default /tmp)
+#   DISK_GUARD_STATE_DIR        - cooldown-stamp dir (default <install>/store)
+#   DISK_GUARD_REAP_MIN_AGE_MIN - override the reap age guard (minutes)
+#   DISK_GUARD_ALERT_DRYRUN     - if 1, print "ALERT_DRYRUN: <msg>" not curl
+
+set -u
+
+# --- thresholds (tunable constants) ---
+DISK_PATH="/"
+REAP_THRESHOLD=90        # >= this %: reap safe scratch
+ALERT_THRESHOLD=95       # >= this % (after reap): alert the owner directly
+REAP_MIN_AGE_MIN="${DISK_GUARD_REAP_MIN_AGE_MIN:-30}"   # only reap orphans older than this
+# Numeric-validate the age guard BEFORE use: a malformed env (e.g. "abc", "-1")
+# OR literal 0 must NOT degrade into "reap everything" (-mmin +0 matches an
+# in-progress export). Fall back to a very conservative day.
+case "$REAP_MIN_AGE_MIN" in (''|0|*[!0-9]*) REAP_MIN_AGE_MIN=1440;; esac
+ALERT_COOLDOWN=3600      # at most one disk-full alert per hour
+
+# Explicit allowlist of scratch globs reaped under SCRATCH_DIR (maxdepth 1).
+# Space-separated env override DISK_GUARD_REAP_GLOBS; the default targets the
+# apple-health analysis scratch that caused the original incident. Extend
+# deliberately -- every entry here is `rm -rf`-able once age-guarded.
+if [ -n "${DISK_GUARD_REAP_GLOBS:-}" ]; then
+  read -r -a REAP_GLOBS <<< "$DISK_GUARD_REAP_GLOBS"
+else
+  REAP_GLOBS=("health_*")
+fi
+
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRATCH_DIR="${DISK_GUARD_SCRATCH_DIR:-/tmp}"
+STATE_DIR="${DISK_GUARD_STATE_DIR:-$INSTALL_DIR/store}"
+ALERT_STAMP="$STATE_DIR/.disk-guard-alerted"
+TG_ENV="$HOME/.claude/channels/telegram/.env"
+LOG_TAG="disk-space-guard"
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*" || true; }
+
+# Current usage% of DISK_PATH (0-100), or the test override.
+disk_usage() {
+  if [ -n "${DISK_GUARD_USAGE_OVERRIDE:-}" ]; then
+    echo "$DISK_GUARD_USAGE_OVERRIDE"; return
+  fi
+  df -P "$DISK_PATH" 2>/dev/null | awk 'NR==2 {gsub("%","",$5); print $5}'
+}
+
+# Reap age-guarded scratch matching the allowlist. Prints how many entries it
+# removed. Defensive: only operates strictly under SCRATCH_DIR, maxdepth 1, and
+# only on entries matching an allowlisted glob older than REAP_MIN_AGE_MIN.
+reap_scratch() {
+  local glob removed=0 path real
+  [ -d "$SCRATCH_DIR" ] || { echo 0; return; }
+  # HARD location guard: reaping is only ever allowed inside the system scratch
+  # tree. Resolve symlinks and require the REAL path to be /tmp or
+  # $XDG_RUNTIME_DIR (or a dir directly beneath them); refuse a symlinked
+  # SCRATCH_DIR outright. A misconfigured/hostile DISK_GUARD_SCRATCH_DIR can then
+  # never aim the reaper at real data.
+  [ -L "$SCRATCH_DIR" ] && { echo 0; return; }
+  # realpath is not on every host -> fall back to readlink -f, then `cd && pwd -P`.
+  real="$(realpath "$SCRATCH_DIR" 2>/dev/null \
+        || readlink -f "$SCRATCH_DIR" 2>/dev/null \
+        || (cd "$SCRATCH_DIR" 2>/dev/null && pwd -P))"
+  [ -z "$real" ] && { echo 0; return; }
+  case "$real/" in
+    /tmp/*) : ;;
+    "${XDG_RUNTIME_DIR:-/nonexistent-xdg}"/*) : ;;
+    *) echo 0; return ;;
+  esac
+  for glob in "${REAP_GLOBS[@]}"; do
+    while IFS= read -r -d '' path; do
+      # Guard: the path must live directly under SCRATCH_DIR (no traversal).
+      case "$path" in
+        "$SCRATCH_DIR"/*) : ;;
+        *) continue ;;
+      esac
+      # A directory's own mtime does NOT change when files INSIDE it are written,
+      # so a long-running export dir can look "old" by mtime while still active.
+      # Skip a matched DIRECTORY if it contains ANY file newer than the age guard.
+      if [ -d "$path" ] && [ ! -L "$path" ]; then
+        if find "$path" -type f -mmin "-$REAP_MIN_AGE_MIN" -print -quit 2>/dev/null | grep -q .; then
+          continue   # has a recently-written file -> in-progress, leave it
+        fi
+      fi
+      rm -rf -- "$path" 2>/dev/null && removed=$((removed + 1)) || true
+    done < <(find "$SCRATCH_DIR" -maxdepth 1 -name "$glob" -mmin "+$REAP_MIN_AGE_MIN" -print0 2>/dev/null)
+  done
+  echo "$removed"
+}
+
+# DIRECT-BOT-API alert (mirrors channel-watchdog.sh alert_owner). Bypasses MCP
+# because under disk-full the in-session plugin cannot send.
+alert_owner() {
+  local msg="$1" token chat
+  if [ "${DISK_GUARD_ALERT_DRYRUN:-}" = "1" ]; then
+    echo "ALERT_DRYRUN: $msg"; return 0
+  fi
+  # Token + owner chat id both come from config, never hardcoded: token from the
+  # channels env, chat id from .env ALLOWED_CHAT_ID (or TELEGRAM_CHAT_ID in the
+  # channels env). If either is missing, skip the alert silently.
+  # `tr -d '\r '` strips a trailing CR (CRLF-edited .env) / stray spaces so the
+  # value doesn't corrupt the URL or the comparison.
+  token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$TG_ENV" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r ')"
+  chat="$(grep -E '^ALLOWED_CHAT_ID=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r ')"
+  [ -z "$chat" ] && chat="$(grep -E '^TELEGRAM_CHAT_ID=' "$TG_ENV" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r ')"
+  if [ -z "$token" ] || [ -z "$chat" ]; then
+    log "ALERT (no bot token or owner chat id configured, could not Telegram): $msg"; return 1
+  fi
+  curl -s -m 10 -o /dev/null "https://api.telegram.org/bot${token}/sendMessage" \
+    --data-urlencode "chat_id=${chat}" --data-urlencode "text=${msg}" \
+    && log "owner alerted via direct Bot API" || log "ALERT sendMessage FAILED: $msg"
+}
+
+main() {
+  local usage removed now last
+  # Ensure the state dir exists UP FRONT so the cooldown stamp write below always
+  # succeeds. Otherwise (missing STATE_DIR) the stamp never persists, `last` stays
+  # 0 every tick, and a stuck-full disk re-alerts up to 60x/hour.
+  mkdir -p "$STATE_DIR" 2>/dev/null || true
+  usage="$(disk_usage)"
+  case "$usage" in (''|*[!0-9]*) log "could not read disk usage (got '$usage') -- no-op"; return 0;; esac
+
+  if [ "$usage" -lt "$REAP_THRESHOLD" ]; then
+    return 0   # plenty of room
+  fi
+
+  log "disk ${usage}% >= ${REAP_THRESHOLD}% -- reaping scratch under $SCRATCH_DIR"
+  removed="$(reap_scratch)"
+  log "reaped $removed scratch entr$( [ "$removed" = 1 ] && echo y || echo ies )"
+  usage="$(disk_usage)"
+  log "post-reap disk ${usage}%"
+
+  if [ "$usage" -ge "$ALERT_THRESHOLD" ]; then
+    # Cooldown so a stuck-full disk alerts at most once/hour (best-effort stamp).
+    now="$(date +%s)"
+    last=0; [ -f "$ALERT_STAMP" ] && last="$(cat "$ALERT_STAMP" 2>/dev/null || echo 0)"
+    case "$last" in (''|*[!0-9]*) last=0;; esac
+    if [ $(( now - last )) -ge "$ALERT_COOLDOWN" ]; then
+      alert_owner "🔴 Disk space critical: ${DISK_PATH} is at ${usage}% after reaping ${removed} scratch item(s). Manual cleanup needed -- a full disk can wedge the channel session (deafness)."
+      echo "$now" > "$ALERT_STAMP" 2>/dev/null || true
+    else
+      log "disk ${usage}% critical but within alert cooldown ($(( now - last ))s) -- skip alert"
+    fi
+  fi
+}
+
+main "$@"
+exit 0

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+# Mid-session stuck-modal guard for the main channels session (systemd --user
+# timer, every minute).
+#
+# Incident it fixes (2026-06-03 dawn): a disk-full event left the main session
+# wedged in a /mcp modal. A modal left open blocks the ENTIRE session -- inbound
+# Telegram messages are lost while it sits there -- and nothing closed it until a
+# human noticed. agent-context-guard.sh only watches the 1M-context credit wall,
+# not a stuck modal. This guard closes that gap.
+#
+# Detection (grounded in src/pane-state.ts, the canonical classifier):
+#   - IDLE  : pane shows the idle footer ("? for shortcuts" / "bypass
+#             permissions on") -> healthy, never touched.
+#   - BUSY  : pane shows a turn-scoped busy marker ("esc to interrupt" or the
+#             "(Ns · ↓" token counter) -> legitimately working, never touched.
+#   - STUCK : neither of the above. That is EXACTLY how channels.sh
+#             ensure_modal_closed and channel-mcp-reconnect.ts define "modal
+#             still open" -- the modal overlay hides the idle footer and there is
+#             no live turn. We do NOT gate on an (unverified) modal-title string;
+#             absence-of-healthy-markers is the proven contract.
+#
+# Safety against false positives:
+#   - A STUCK pane must PERSIST for STUCK_SECONDS (the timer ticks every minute,
+#     so this needs >= 2 consecutive stuck observations) before any action.
+#   - 'esc to interrupt' + 'bypass permissions on' (a healthy working footer)
+#     classify as BUSY/IDLE and are never disturbed.
+#   - Recovery escalates gently: Escape (bounded, like ensure_modal_closed)
+#     first; respawn-pane only if Escape can't reach the idle prompt.
+#   - Respawn shares channel-watchdog.sh's respawn-grace stamp, so the two
+#     watchdogs never double-respawn (no storm), plus its own consecutive cap.
+#   - Stamp writes are best-effort (disk-full tolerance).
+#
+# Modes (for tests; mirror the pure functions in src/pane-state.ts):
+#   stuck-modal-guard.sh classify         < pane.txt   -> prints idle|busy|stuck|empty
+#   stuck-modal-guard.sh decide STATE FIRSTSEEN NOW     -> prints the action
+#   stuck-modal-guard.sh                                -> run the guard live
+
+set -u
+
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+STORE="${STUCK_MODAL_STATE_DIR:-$INSTALL_DIR/store}"
+FIRSTSEEN_STAMP="$STORE/.stuck-modal-firstseen"
+RESPAWN_STAMP="$STORE/.channel-last-respawn"           # SHARED with channel-watchdog.sh
+RESPAWN_COUNT_FILE="$STORE/.stuck-modal-respawns"
+BACKOFF_STAMP="$STORE/.stuck-modal-backoff-alerted"
+TG_ENV="$HOME/.claude/channels/telegram/.env"
+LOG_TAG="stuck-modal-guard"
+
+STUCK_SECONDS="${STUCK_MODAL_SECONDS:-120}"   # must stay stuck this long before acting
+# Validate: a non-integer override would make the `-ge` comparison error and
+# short-circuit recovery. Fall back to the default.
+case "$STUCK_SECONDS" in (''|*[!0-9]*) STUCK_SECONDS=120;; esac
+GRACE_SECONDS=$(( 15 * 60 ))                   # shared respawn grace (matches watchdog)
+MAX_CONSECUTIVE=3                              # respawns before backoff+alert
+MAX_ESCAPES=4                                  # ensure_modal_closed bound
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*" || true; }
+
+# --- pure classifier (mirrors src/pane-state.ts detectPaneState) ---------------
+# Reads a captured pane on stdin; prints one of: empty | busy | idle | stuck.
+classify_pane() {
+  local pane
+  pane="$(cat)"
+  # 1. empty / whitespace-only -> inconclusive
+  if [ -z "$(printf '%s' "$pane" | tr -d '[:space:]')" ]; then
+    echo empty; return
+  fi
+  # 2. any busy marker anywhere -> busy (turn mid-flight)
+  #    'esc to interrupt' footer, or the turn-scoped "(Ns · ↓" token counter.
+  if printf '%s' "$pane" | grep -qE 'esc to interrupt|\([0-9]+s ·'; then
+    echo busy; return
+  fi
+  # 3. idle footer present -> idle (healthy prompt)
+  if printf '%s' "$pane" | grep -qaF 'bypass permissions on' \
+     || printf '%s' "$pane" | grep -qaF '? for shortcuts'; then
+    echo idle; return
+  fi
+  # 4. neither -> the idle footer is hidden by a modal overlay and no live turn
+  echo stuck
+}
+
+# --- pure decision (testable without tmux) -------------------------------------
+# Args: STATE FIRSTSEEN_EPOCH NOW_EPOCH. Prints one of:
+#   clear         -> pane healthy; drop any confirm window
+#   hold          -> inconclusive (empty capture); preserve the confirm window
+#   start-confirm -> first stuck observation; begin the confirm window
+#   wait-confirm  -> stuck but not yet persisted long enough
+#   act           -> stuck and persisted >= STUCK_SECONDS; recover now
+decide_action() {
+  local state="$1" firstseen="$2" now="$3"
+  case "$state" in
+    idle|busy) echo clear; return ;;
+    empty)     echo hold;  return ;;
+    stuck)
+      case "$firstseen" in (''|0|*[!0-9]*) echo start-confirm; return ;; esac
+      if [ $(( now - firstseen )) -ge "$STUCK_SECONDS" ]; then echo act; else echo wait-confirm; fi
+      return ;;
+    *) echo hold; return ;;
+  esac
+}
+
+# --- pure model-id sanitizer (testable) ----------------------------------------
+# Keep only the model-id charset: letters, digits, . _ : - and the bracketed
+# context-window suffix (e.g. "[1m]"). This strips shell metacharacters (quotes,
+# $, backtick, ;, spaces) so the value is safe to interpolate into the respawn
+# shell-string, while a legit "claude-opus-4-8[1m]" survives intact.
+sanitize_model() {
+  printf '%s' "${1:-}" | tr -cd 'A-Za-z0-9._:[]-'
+}
+
+# --- direct Bot API alert (mirrors channel-watchdog.sh alert_owner) -------------
+alert_owner() {
+  local msg="$1" token chat
+  # Token + owner chat id both from config, never hardcoded.
+  # `tr -d '\r '` strips a trailing CR (CRLF-edited .env) / stray spaces.
+  token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$TG_ENV" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r ')"
+  chat="$(grep -E '^ALLOWED_CHAT_ID=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r ')"
+  [ -z "$chat" ] && chat="$(grep -E '^TELEGRAM_CHAT_ID=' "$TG_ENV" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r ')"
+  if [ -z "$token" ] || [ -z "$chat" ]; then
+    log "ALERT (no bot token or owner chat id configured): $msg"; return 1
+  fi
+  curl -s -m 10 -o /dev/null "https://api.telegram.org/bot${token}/sendMessage" \
+    --data-urlencode "chat_id=${chat}" --data-urlencode "text=${msg}" \
+    && log "owner alerted via direct Bot API" || log "ALERT sendMessage FAILED: $msg"
+}
+
+# --- live guard ----------------------------------------------------------------
+run_guard() {
+  local TMUX CLAUDE MAIN_AGENT_ID SESSION pane state firstseen now action
+
+  TMUX="$(command -v tmux)"; CLAUDE="$(command -v claude)"
+  if [ -z "$TMUX" ]; then log "tmux not on PATH; cannot act"; return 0; fi
+
+  # Ensure the state dir exists BEFORE any stamp/lock write. Without it, a cold
+  # install / post-cleanup run fails `exec 9>` on the lock file; flock then reads
+  # as "respawn in progress" and the guard defers recovery FOREVER -- exactly when
+  # a modal is wedged (cross-model BLOCKER). Also covers the firstseen / backoff
+  # stamp writes below.
+  mkdir -p "$STORE" 2>/dev/null || true
+
+  # Session name is config-driven, NO persona default baked in (review-mandated
+  # contract, commit 0b7b671): CHANNELS_SESSION override wins; else
+  # "<MAIN_AGENT_ID>-channels" from .env. If neither is set, skip -- we never
+  # invent a persona-named target. (The sibling channel-watchdog.sh has a
+  # pre-existing main-agent-id fallback; that is intentionally NOT mirrored here
+  # and is out of scope for this guard.)
+  SESSION="${CHANNELS_SESSION:-}"
+  if [ -z "$SESSION" ]; then
+    MAIN_AGENT_ID="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
+    MAIN_AGENT_ID="${MAIN_AGENT_ID//[^a-zA-Z0-9_-]/}"
+    [ -n "$MAIN_AGENT_ID" ] && SESSION="${MAIN_AGENT_ID}-channels"
+  fi
+  if [ -z "$SESSION" ]; then
+    log "no channels session configured (set CHANNELS_SESSION or MAIN_AGENT_ID in .env) -- no-op"; return 0
+  fi
+  "$TMUX" has-session -t "$SESSION" 2>/dev/null || { log "session $SESSION absent -- no-op"; return 0; }
+
+  pane="$("$TMUX" capture-pane -t "$SESSION" -p 2>/dev/null || true)"
+  state="$(printf '%s' "$pane" | classify_pane)"
+  now="$(date +%s)"
+  firstseen=0; [ -f "$FIRSTSEEN_STAMP" ] && firstseen="$(cat "$FIRSTSEEN_STAMP" 2>/dev/null || echo 0)"
+  case "$firstseen" in (''|*[!0-9]*) firstseen=0;; esac
+
+  action="$(decide_action "$state" "$firstseen" "$now")"
+  case "$action" in
+    clear)
+      if [ "$firstseen" != 0 ]; then log "session healthy ($state) -- clearing confirm window"; fi
+      rm -f "$FIRSTSEEN_STAMP" "$RESPAWN_COUNT_FILE" "$BACKOFF_STAMP" 2>/dev/null || true
+      return 0 ;;
+    hold)
+      return 0 ;;
+    start-confirm)
+      log "STUCK candidate (no idle/busy markers) -- starting ${STUCK_SECONDS}s confirm window"
+      echo "$now" > "$FIRSTSEEN_STAMP" 2>/dev/null || true
+      return 0 ;;
+    wait-confirm)
+      log "stuck $(( now - firstseen ))s (< ${STUCK_SECONDS}s) -- still confirming"
+      return 0 ;;
+    act)
+      log "STUCK modal confirmed ($(( now - firstseen ))s) -> Escape (max ${MAX_ESCAPES}x)" ;;
+  esac
+
+  # --- recovery: Escape (bounded), like ensure_modal_closed --------------------
+  local i p
+  for i in $(seq 1 "$MAX_ESCAPES"); do
+    p="$("$TMUX" capture-pane -t "$SESSION" -p 2>/dev/null || true)"
+    case "$(printf '%s' "$p" | classify_pane)" in
+      idle|busy) log "modal closed via Escape -- session healthy"; rm -f "$FIRSTSEEN_STAMP" 2>/dev/null || true; return 0 ;;
+    esac
+    "$TMUX" send-keys -t "$SESSION" Escape 2>/dev/null || true
+    sleep 0.5
+  done
+  p="$("$TMUX" capture-pane -t "$SESSION" -p 2>/dev/null || true)"
+  case "$(printf '%s' "$p" | classify_pane)" in
+    idle|busy) log "modal closed via Escape -- session healthy"; rm -f "$FIRSTSEEN_STAMP" 2>/dev/null || true; return 0 ;;
+  esac
+
+  # --- still stuck: respawn-pane (cross-watchdog coordination via grace stamp) --
+  # NON-BLOCKING lock serialising CONCURRENT runs of THIS guard (so two ticks
+  # can't both respawn). The actual cross-watchdog coordinator is the shared
+  # .channel-last-respawn grace stamp checked below -- channel-watchdog.sh keys
+  # off that, not this lock. If `exec 9>` fails we must NOT fall through: bash's
+  # `flock -n 9` would then operate on fd 0 (stdin) and SUCCEED, silently
+  # bypassing the lock -- so treat an open failure as "defer".
+  exec 9>"$STORE/.channel-respawn.lock" || { log "cannot open respawn lock file -- deferring"; return 0; }
+  if command -v flock >/dev/null 2>&1; then
+    flock -n 9 || { log "another respawn in progress (lock held) -- deferring"; return 0; }
+  fi
+
+  if [ -f "$RESPAWN_STAMP" ]; then
+    local last; last="$(stat -c %Y "$RESPAWN_STAMP" 2>/dev/null || echo 0)"
+    if [ $(( now - last )) -lt "$GRACE_SECONDS" ]; then
+      log "Escape failed but a respawn happened $(( now - last ))s ago (< grace) -- deferring"
+      return 0
+    fi
+  fi
+  local count; count="$(cat "$RESPAWN_COUNT_FILE" 2>/dev/null || echo 0)"
+  case "$count" in (*[!0-9]*|'') count=0;; esac
+  if [ "$count" -ge "$MAX_CONSECUTIVE" ]; then
+    log "ALERT: stuck modal after $count respawns -- backing off, manual check needed"
+    local bstamp=0; [ -f "$BACKOFF_STAMP" ] && bstamp="$(stat -c %Y "$BACKOFF_STAMP" 2>/dev/null || echo 0)"
+    if [ $(( now - bstamp )) -ge 3600 ]; then
+      alert_owner "🔴 The ${SESSION} session is stuck in a /mcp modal and ${count} auto-respawns did not clear it. Manual check needed: tmux attach -t ${SESSION}. Messages sent during the outage may be lost -- please resend."
+      date +%s > "$BACKOFF_STAMP" 2>/dev/null || true
+    fi
+    return 0
+  fi
+
+  local MAIN_MODEL="" MODEL_FLAG="" CLAUDE_Q
+  if [ -f "$INSTALL_DIR/.claude/settings.json" ] && command -v jq >/dev/null 2>&1; then
+    MAIN_MODEL="$(jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null)"
+  fi
+  # W1: sanitize the model id before interpolating it into the respawn shell
+  # string (defense in depth -- settings.json is local config). Preserves the
+  # "[1m]" context suffix while stripping shell metacharacters.
+  MAIN_MODEL="$(sanitize_model "$MAIN_MODEL")"
+  # W1/I: %q-quote the (already-sanitized) model id too, so MODEL_FLAG stays safe
+  # even if the sanitizer charset ever widens. Same treatment as CLAUDE_Q.
+  [ -n "$MAIN_MODEL" ] && MODEL_FLAG="--model $(printf '%q' "$MAIN_MODEL") "
+  # W4: %q-quote the claude path so a path with spaces/specials can't break out
+  # of the respawn command string.
+  CLAUDE_Q="$(printf '%q' "$CLAUDE")"
+  local RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && $CLAUDE_Q --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:telegram@claude-plugins-official"
+
+  log "stuck modal not cleared by Escape -- respawn-pane $SESSION (respawn #$((count+1)))"
+  # G: alert ONLY after the respawn-pane actually succeeds, so a failed respawn
+  # never sends the owner a false "respawned" message.
+  if [ -n "$CLAUDE" ] && "$TMUX" respawn-pane -k -t "$SESSION" "$RESPAWN_CMD" 2>/dev/null; then
+    date +%s > "$RESPAWN_STAMP" 2>/dev/null || true
+    echo $(( count + 1 )) > "$RESPAWN_COUNT_FILE" 2>/dev/null || true
+    rm -f "$FIRSTSEEN_STAMP" 2>/dev/null || true
+    log "respawn-pane issued"
+    alert_owner "⚠️ The ${SESSION} session was stuck in a /mcp modal -- auto-respawn #$((count+1)) issued. If you messaged during the outage and got no reply, please resend."
+  else
+    log "respawn-pane FAILED (or claude not on PATH) for $SESSION"
+  fi
+  return 0
+}
+
+case "${1:-}" in
+  classify)       classify_pane ;;
+  decide)         decide_action "${2:-}" "${3:-0}" "${4:-0}" ;;
+  sanitize-model) sanitize_model "${2:-}" ;;
+  *)              run_guard ;;
+esac
+exit 0

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -53,6 +53,12 @@ case "$STUCK_SECONDS" in (''|*[!0-9]*) STUCK_SECONDS=120;; esac
 GRACE_SECONDS=$(( 15 * 60 ))                   # shared respawn grace (matches watchdog)
 MAX_CONSECUTIVE=3                              # respawns before backoff+alert
 MAX_ESCAPES=4                                  # ensure_modal_closed bound
+# Respawn target plugin: config-overridable so a non-default install (renamed or
+# locally-built plugin) is never respawned with a WRONG plugin id -- a mismatch
+# makes claude exit immediately while the alert would falsely say "respawned".
+# %q-quoted at interpolation (like the model id), so a hostile value can't break
+# out of the respawn shell-string.
+RESPAWN_PLUGIN="${STUCK_MODAL_PLUGIN:-plugin:telegram@claude-plugins-official}"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*" || true; }
 
@@ -67,7 +73,10 @@ classify_pane() {
   fi
   # 2. any busy marker anywhere -> busy (turn mid-flight)
   #    'esc to interrupt' footer, or the turn-scoped "(Ns · ↓" token counter.
-  if printf '%s' "$pane" | grep -qE 'esc to interrupt|\([0-9]+s ·'; then
+  #    The counter separator may render as a Unicode middle-dot (·) OR an ASCII
+  #    period depending on terminal/locale -- match BOTH, else a working pane is
+  #    misread as STUCK and gets respawned mid-turn (dropping the live reply).
+  if printf '%s' "$pane" | grep -qE 'esc to interrupt|\([0-9]+s (·|\.)'; then
     echo busy; return
   fi
   # 3. idle footer present -> idle (healthy prompt)
@@ -240,7 +249,9 @@ run_guard() {
   # W4: %q-quote the claude path so a path with spaces/specials can't break out
   # of the respawn command string.
   CLAUDE_Q="$(printf '%q' "$CLAUDE")"
-  local RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && $CLAUDE_Q --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:telegram@claude-plugins-official"
+  # W2: %q-quote the (config-overridable) plugin id, same treatment as the model.
+  local PLUGIN_Q; PLUGIN_Q="$(printf '%q' "$RESPAWN_PLUGIN")"
+  local RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && $CLAUDE_Q --dangerously-skip-permissions ${MODEL_FLAG}--channels $PLUGIN_Q"
 
   log "stuck modal not cleared by Escape -- respawn-pane $SESSION (respawn #$((count+1)))"
   # G: alert ONLY after the respawn-pane actually succeeds, so a failed respawn

--- a/scripts/systemd/disk-space-guard.service
+++ b/scripts/systemd/disk-space-guard.service
@@ -1,0 +1,16 @@
+# NOTE: replace /path/to/marveen (install dir) and /home/USER (home) with your values.
+[Unit]
+Description=Marveen disk-space guard (reap scratch + alert before the root fs fills)
+After=marveen-dashboard.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/path/to/marveen/scripts/disk-space-guard.sh
+Environment=PATH=/home/USER/.local/bin:/home/USER/.bun/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME=/home/USER
+Environment=TZ=Europe/Budapest
+# journal, NOT append:file -- under disk-full (this guard's whole reason to exist)
+# or a missing store/, opening an append fd would fail and the guard never starts.
+StandardOutput=journal
+StandardError=journal

--- a/scripts/systemd/disk-space-guard.timer
+++ b/scripts/systemd/disk-space-guard.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Marveen disk-space guard every minute
+
+[Timer]
+OnBootSec=90s
+OnUnitActiveSec=60s
+AccuracySec=10s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/systemd/stuck-modal-guard.service
+++ b/scripts/systemd/stuck-modal-guard.service
@@ -1,0 +1,16 @@
+# NOTE: replace /path/to/marveen (install dir) and /home/USER (home) with your values.
+[Unit]
+Description=Marveen stuck-modal guard (close a wedged /mcp modal in the main channels session)
+After=marveen-dashboard.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/path/to/marveen/scripts/stuck-modal-guard.sh
+Environment=PATH=/home/USER/.local/bin:/home/USER/.bun/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME=/home/USER
+Environment=TZ=Europe/Budapest
+# journal, NOT append:file -- a missing store/ or full disk must not stop the
+# guard from starting (opening an append fd would fail before ExecStart).
+StandardOutput=journal
+StandardError=journal

--- a/scripts/systemd/stuck-modal-guard.timer
+++ b/scripts/systemd/stuck-modal-guard.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Marveen stuck-modal guard every minute
+
+[Timer]
+OnBootSec=150s
+OnUnitActiveSec=60s
+AccuracySec=10s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/web/app.js
+++ b/web/app.js
@@ -105,11 +105,11 @@ navLinks.forEach((link) => {
 let activityTimer = null
 
 const ACTIVITY_STATE_META = {
-  working: { label: 'dolgozik', cls: 'act-working' },
-  idle: { label: 'várakozik', cls: 'act-idle' },
-  unknown: { label: 'ismeretlen', cls: 'act-unknown' },
-  error: { label: 'hiba', cls: 'act-error' },
-  stopped: { label: 'leállt', cls: 'act-stopped' },
+  working: { label: 'dolgozik', cls: 'act-working', tip: 'Élő állapot (a tmux pane tartalmából, 3 másodpercenként): éppen dolgozik / gondolkodik.' },
+  idle: { label: 'várakozik', cls: 'act-idle', tip: 'Élő állapot (3 másodpercenként): fut, de épp nem csinál semmit.' },
+  unknown: { label: 'ismeretlen', cls: 'act-unknown', tip: 'Élő állapot: nem sikerült megállapítani a session pane tartalmából.' },
+  error: { label: 'hiba', cls: 'act-error', tip: 'Élő állapot: hiba látszik az ágens session paneljén.' },
+  stopped: { label: 'leállt', cls: 'act-stopped', tip: 'Élő állapot: az ágens session nem fut.' },
 }
 
 function startActivityPoll() {
@@ -154,7 +154,7 @@ function renderActivity(entries) {
       '<div class="activity-card ' + meta.cls + '">' +
         '<div class="activity-card-head">' +
           '<span class="activity-name">' + escapeHtml(a.name) + mainBadge + '</span>' +
-          '<span class="activity-badge ' + meta.cls + '">' + meta.label + '</span>' +
+          '<span class="activity-badge ' + meta.cls + '" title="' + escapeHtml(meta.tip || '') + '">' + meta.label + '</span>' +
         '</div>' +
         (tail
           ? '<pre class="activity-tail">' + tail + '</pre>'
@@ -1306,6 +1306,20 @@ function getAvatarGradient(name) {
   return 'gradient-' + ((hash % 3) + 1)
 }
 
+// Tooltip text for the "Fut" / "Leállva" footer indicator (process state).
+function processTip(isRunning) {
+  return isRunning
+    ? 'Fut: él az ágens tmux session-je (a Claude Code folyamat fut). Forrás: tmux list-sessions.'
+    : 'Leállva: nincs élő tmux session az ágensnek. Forrás: tmux list-sessions.'
+}
+
+// Tooltip text for the "Online" / "Offline" footer indicator (channel state).
+function channelTip(isConnected) {
+  return isConnected
+    ? 'Online: van bekonfigurált csatorna-token (saját bot). Figyelem: ez nem élő kapcsolat, csak a token meglétét jelzi.'
+    : 'Offline: nincs csatorna bekötve (channel-less, csak inter-agent ágens).'
+}
+
 function renderAgents() {
   agentsGrid.querySelectorAll('.agent-card:not(.add-card)').forEach((el) => el.remove())
 
@@ -1325,8 +1339,8 @@ function renderAgents() {
       </div>
       <div class="agent-card-footer">
         <span class="agent-model-badge opus">opus</span>
-        <span class="process-indicator"><span class="process-dot running"></span>Fut</span>
-        <span class="tg-status"><span class="tg-dot connected"></span>Online</span>
+        <span class="process-indicator" title="Fut: a fő asszisztens mindig a --channels session-ben fut. Ez a kártya fixen Fut állapotot mutat, nincs per-ágens tmux-ellenőrzés."><span class="process-dot running"></span>Fut</span>
+        <span class="tg-status" title="Online: a fő asszisztens csatornáját a --channels session kezeli, ezért fixen online (nincs külön token-ellenőrzés)."><span class="tg-dot connected"></span>Online</span>
       </div>
     `
     mCard.addEventListener('click', () => openMarveenDetail())
@@ -1365,8 +1379,8 @@ function renderAgents() {
       </div>
       <div class="agent-card-footer">
         <span class="agent-model-badge ${escapeHtml(modelClass)}">${escapeHtml(modelLabel)}</span>
-        <span class="process-indicator"><span class="process-dot ${runDotClass}"></span>${runLabel}</span>
-        <span class="tg-status"><span class="tg-dot ${chDotClass}"></span>${chLabel}</span>
+        <span class="process-indicator" title="${escapeHtml(processTip(isRunning))}"><span class="process-dot ${runDotClass}"></span>${runLabel}</span>
+        <span class="tg-status" title="${escapeHtml(channelTip(chConnected))}"><span class="tg-dot ${chDotClass}"></span>${chLabel}</span>
       </div>
     `
     card.addEventListener('click', () => openAgentDetail(agent.name))

--- a/web/style.css
+++ b/web/style.css
@@ -4920,11 +4920,23 @@ main {
   background: var(--border); color: var(--text-muted); border-radius: 4px; padding: 1px 6px;
 }
 .activity-badge { font-size: 12px; font-weight: 600; border-radius: 999px; padding: 2px 10px; }
-.activity-badge.act-working { background: rgba(34,197,94,0.15); color: #16a34a; }
+.activity-badge.act-working {
+  background: rgba(34,197,94,0.15); color: #16a34a;
+  /* "Breathing" pulse so the live "dolgozik" badge reads as active, mirroring
+     the .process-dot.running pulse (same 2s ease-in-out cadence). */
+  animation: badge-breathe 2s ease-in-out infinite;
+}
 .activity-badge.act-idle    { background: rgba(156,163,175,0.18); color: #6b7280; }
 .activity-badge.act-error   { background: rgba(239,68,68,0.15); color: #dc2626; }
 .activity-badge.act-unknown { background: rgba(234,179,8,0.18); color: #ca8a04; }
 .activity-badge.act-stopped { background: rgba(107,114,128,0.15); color: #6b7280; }
+
+/* Green "breathing" glow for the working badge: saturates the pill and pulses a
+   soft halo at peak, then settles. */
+@keyframes badge-breathe {
+  0%, 100% { background: rgba(34,197,94,0.12); box-shadow: 0 0 0 0 rgba(34,197,94,0); }
+  50%      { background: rgba(34,197,94,0.32); box-shadow: 0 0 8px 1px rgba(34,197,94,0.40); }
+}
 .activity-tail {
   margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px;
   line-height: 1.45; color: var(--text-muted); white-space: pre-wrap; word-break: break-word;


### PR DESCRIPTION
## Context

On 2026-06-03 the host root filesystem filled to 100% from a ~2.2 GB orphaned
`/tmp/health_*` scratch directory (an Apple Health analysis whose cleanup step
didn't run). A full disk wedged the main channels session in an open `/mcp` modal
— which blocks the **entire** session, so inbound messages were silently dropped
until a human noticed. The dashboard's in-process watchdogs don't help here: they
die with the dashboard process, and disk-full can wedge it too.

This PR adds two **independent** systemd `--user` timers (no dashboard dependency)
that prevent both halves of that failure.

## Changes

### `scripts/disk-space-guard.sh` (+ systemd unit/timer)

Every minute reads `df /`. At `>= 90%` it reaps an **age-guarded allowlist** of
scratch globs (env `DISK_GUARD_REAP_GLOBS`, default `health_*`; only orphans older
than 30 min, `maxdepth 1` under `/tmp` — a running export's recent mtime is
protected, and nothing outside the allowlist is touched). At `>= 95%` after
reaping it alerts the owner over the **direct Telegram Bot API** (the in-session
MCP plugin is dead under disk-full), at most once per hour. Thresholds are
constants; chat id and bot token come from env. All stamp/log writes are
best-effort so an ENOSPC write can't crash the guard.

### `scripts/stuck-modal-guard.sh` (+ systemd unit/timer)

Every minute classifies the main channels session pane (`${MAIN_AGENT_ID}-channels`),
mirroring the markers in `src/pane-state.ts`:

- **idle** (`? for shortcuts` / `bypass permissions on`) or **busy**
  (`esc to interrupt` / token counter) -> healthy, never touched.
- **stuck** (neither -- a modal overlay hides the idle footer and there is no live
  turn) -> only after it **persists 120 s** (>=2 ticks): Escape up to 4x (the
  `channels.sh ensure_modal_closed` pattern), then `respawn-pane` if Escape can't
  reach the prompt. The respawn **shares `channel-watchdog.sh`'s
  `.channel-last-respawn` grace stamp**, so the two watchdogs never double-respawn.

A legitimately working session (`esc to interrupt` + `bypass permissions on`)
classifies busy and is never disturbed -- locked by a contract test.

Both scripts are deployment-neutral: session name, chat id, and bot-token source
come from env/config (no hardcoded paths or ids). The systemd unit files use
`/path/to/marveen` + `/home/USER` placeholders, matching the existing
`channel-watchdog.service`.

## Testing

Pure-logic contract tests with captured-pane / `df` fixtures (no real `df`,
Telegram, or `rm` of real scratch):

```bash
bash scripts/__tests__/disk-space-guard.test.sh    # 12: thresholds, age-guard, allowlist, alert+cooldown, malformed no-op
bash scripts/__tests__/stuck-modal-guard.test.sh   # 14: classify fixtures (idle/busy/stuck/empty), false-positive guard, confirm-window
```

Both green; `npx tsc --noEmit` clean (no TypeScript touched).

> Companion hardening (intentionally not in this PR): existing watchdog stamp
> writes can be made best-effort for full ENOSPC tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Known pre-existing inconsistency (not changed here)

The sibling `scripts/channel-watchdog.sh` resolves its target session with a `${MAIN_AGENT_ID:-marveen}` default. The two new guards in this PR are intentionally config-driven with **no baked-in default** — `CHANNELS_SESSION`, else `${MAIN_AGENT_ID}-channels` from `.env`, else skip — per a review hardening requirement. Aligning `channel-watchdog.sh` is a separate future cleanup, out of scope for this PR.