### PR TITLE
Fő channels session önhelyreállítása ha teljesen eltűnt

### DIFF
--- a/src/__tests__/channel-monitor-session-recreate.test.ts
+++ b/src/__tests__/channel-monitor-session-recreate.test.ts
@@ -1,0 +1,91 @@
+// Regression tests for the self-healing main-session fix.
+//
+// Background: the channel-monitor down-cascade (handleMarveenDown) recovers a
+// main session by replacing the claude process in the EXISTING tmux pane via
+// `tmux respawn-pane`. respawn-pane needs a live pane -- it cannot recreate a
+// session that has vanished entirely (crash, self-update mid-restart, OOM,
+// reboot). On installs where nothing supervises the session (the channels
+// systemd unit disabled, or any pure-tmux deploy) the session then stays gone,
+// and the scheduler silently skips every main-agent task whose target tmux
+// session is missing. This fix teaches check() to detect a fully-absent
+// session and recreate it from scratch via scripts/channels.sh instead of
+// running a respawn-pane cascade that can only fail.
+//
+// As with the sibling channel-monitor tests, we cannot drive a real tmux
+// interaction from a unit test, so the asserts read the source and lock in the
+// structural invariants the fix introduced.
+
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MONITOR_PATH = join(__dirname, "..", "web", "channel-monitor.ts")
+const src = readFileSync(MONITOR_PATH, "utf-8")
+
+function sliceFn(name: string): string {
+  const start = src.indexOf("function " + name)
+  expect(start, name + " not found").toBeGreaterThan(0)
+  const end = src.indexOf("\n}\n", start)
+  expect(end, name + " closing brace not found").toBeGreaterThan(start)
+  return src.slice(start, end)
+}
+
+describe("channel-monitor: self-healing vanished main session", () => {
+  it("imports spawn from node:child_process", () => {
+    expect(src).toMatch(/import\s*{[^}]*\bspawn\b[^}]*}\s*from\s*["']node:child_process["']/)
+  })
+
+  it("mainChannelsSessionExists probes via tmux has-session", () => {
+    const fn = sliceFn("mainChannelsSessionExists")
+    expect(fn).toContain("has-session")
+    expect(fn).toContain("MAIN_CHANNELS_SESSION")
+  })
+
+  it("createMainChannelsSession launches channels.sh detached and unref'd", () => {
+    const fn = sliceFn("createMainChannelsSession")
+    expect(fn).toContain("CHANNELS_SCRIPT")
+    expect(fn).toContain("spawn(")
+    expect(fn).toContain("detached: true")
+    expect(fn).toContain(".unref()")
+  })
+
+  it("createMainChannelsSession is throttled by a multi-minute grace", () => {
+    const fn = sliceFn("createMainChannelsSession")
+    expect(fn).toContain("MAIN_SESSION_CREATE_GRACE_MS")
+    const m = src.match(/const\s+MAIN_SESSION_CREATE_GRACE_MS\s*=\s*([\d_]+)/)
+    expect(m, "MAIN_SESSION_CREATE_GRACE_MS constant not found").not.toBeNull()
+    const value = parseInt((m![1] as string).replace(/_/g, ""), 10)
+    expect(value).toBeGreaterThanOrEqual(120_000)
+  })
+
+  it("createMainChannelsSession writes the shared respawn stamp for cold-start grace", () => {
+    const fn = sliceFn("createMainChannelsSession")
+    expect(fn).toContain("writeRespawnStamp()")
+  })
+
+  it("CHANNELS_SCRIPT resolves to scripts/channels.sh under PROJECT_ROOT", () => {
+    expect(src).toMatch(/const\s+CHANNELS_SCRIPT\s*=\s*join\(PROJECT_ROOT,\s*["']scripts["'],\s*["']channels\.sh["']\)/)
+  })
+
+  it("check() recreates an absent session instead of running the respawn-pane cascade", () => {
+    // The monitor loop must consult mainChannelsSessionExists() and route a
+    // vanished session to createMainChannelsSession(), only falling through to
+    // handleMarveenDown() when the session still exists (dead/wedged claude in
+    // a live pane -- the case respawn-pane can actually fix).
+    const fnStart = src.indexOf("export function startChannelPluginMonitor")
+    expect(fnStart, "startChannelPluginMonitor not found").toBeGreaterThan(0)
+    const loop = src.slice(fnStart)
+    const existsIdx = loop.indexOf("!mainChannelsSessionExists()")
+    const createIdx = loop.indexOf("createMainChannelsSession()")
+    const downIdx = loop.indexOf("handleMarveenDown()")
+    expect(existsIdx, "absent-session guard missing from monitor loop").toBeGreaterThan(0)
+    expect(createIdx, "createMainChannelsSession call missing from monitor loop").toBeGreaterThan(0)
+    expect(downIdx, "handleMarveenDown fall-through missing from monitor loop").toBeGreaterThan(0)
+    // The absent-session check and its recreate must come before the
+    // handleMarveenDown fall-through in the same branch.
+    expect(existsIdx).toBeLessThan(createIdx)
+    expect(createIdx).toBeLessThan(downIdx)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, statSync, writeFileSync, utimesSync } from 'node:fs'
 import { join } from 'node:path'
-import { execSync, execFileSync } from 'node:child_process'
+import { execSync, execFileSync, spawn } from 'node:child_process'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT } from '../config.js'
@@ -397,6 +397,72 @@ function writeRespawnStamp(): void {
   try {
     writeFileSync(RESPAWN_STAMP_FILE, String(Math.floor(Date.now() / 1000)))
   } catch { /* best effort */ }
+}
+
+// --- Vanished-session recovery (self-healing main session) ---
+//
+// The down-cascade (handleMarveenDown) recovers a main session whose claude
+// process is alive but whose channel plugin died, by replacing the claude
+// process in the EXISTING pane via `tmux respawn-pane`. respawn-pane needs a
+// live pane: it cannot bring back a session that has disappeared entirely
+// (crash, self-update mid-restart, OOM kill, host reboot). On a deployment
+// where nothing supervises the session -- marveen-channels.service disabled,
+// or any pure-tmux install -- a vanished session stays gone, and because the
+// scheduler skips every task whose target tmux session is missing
+// (schedule-runner !sessionExists branch), ALL main-agent scheduled jobs
+// (morning briefing, daily-log, dream-engine, audits, heartbeats) silently
+// stop firing with no error surfaced anywhere. This closes that gap by
+// recreating the session from scratch via the canonical scripts/channels.sh --
+// the same path the service uses -- so recovery is channel-independent and
+// works even with the service disabled.
+const CHANNELS_SCRIPT = join(PROJECT_ROOT, 'scripts', 'channels.sh')
+// channels.sh creates the session, runs the first-run dialog auto-accept, sets
+// /name, and brings up the channel plugin -- a cold start that takes minutes.
+// Throttle relaunches so a session that is still booting is not torn down and
+// recreated on the next 60s poll.
+const MAIN_SESSION_CREATE_GRACE_MS = 360_000
+let marveenLastSessionCreate = 0
+
+export function mainChannelsSessionExists(): boolean {
+  try {
+    execFileSync(TMUX, ['has-session', '-t', MAIN_CHANNELS_SESSION], { timeout: 3000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function createMainChannelsSession(): boolean {
+  const now = Date.now()
+  if (marveenLastSessionCreate && now - marveenLastSessionCreate < MAIN_SESSION_CREATE_GRACE_MS) {
+    return false
+  }
+  if (!existsSync(CHANNELS_SCRIPT)) {
+    logger.error({ script: CHANNELS_SCRIPT }, 'Cannot recreate main channels session: channels.sh missing')
+    return false
+  }
+  try {
+    // Detached + unref'd: channels.sh is a long-lived supervisor (it tails the
+    // session in a wait loop), so it must outlive this check() tick without
+    // keeping the dashboard event loop alive. stdio ignored -- channels.sh does
+    // its own logging to store/channels-failures.log.
+    const child = spawn('/bin/bash', [CHANNELS_SCRIPT], {
+      detached: true,
+      stdio: 'ignore',
+      cwd: PROJECT_ROOT,
+    })
+    child.unref()
+    marveenLastSessionCreate = now
+    // Fold into the shared cold-start grace so the down-cascade defers to this
+    // boot instead of stacking a respawn on a session that is still coming up.
+    writeRespawnStamp()
+    logger.warn({ session: MAIN_CHANNELS_SESSION }, 'Main channels session absent -- recreating via channels.sh')
+    sendAlert(`♻️ A ${MAIN_CHANNELS_SESSION} session eltunt -- ujrainditom (channels.sh). Enelkul minden utemezett feladat csendben kimaradna.`)
+    return true
+  } catch (err) {
+    logger.error({ err }, 'Failed to recreate main channels session via channels.sh')
+    return false
+  }
 }
 
 // Hard-restart fallback when there is no systemd unit to bounce: respawn the
@@ -802,7 +868,22 @@ export function startChannelPluginMonitor(): NodeJS.Timeout {
           if (lastRestart && Date.now() - lastRestart < AGENT_RESTART_GRACE_MS) continue
         }
         if (t.isMarveen) {
-          if (shouldEscalateMarveenDown()) handleMarveenDown()
+          // The claude pid is gone. WHY decides recovery: a session that no
+          // longer exists at all must be recreated from scratch (respawn-pane,
+          // the only tool the down-cascade has on Linux, cannot resurrect a
+          // vanished session); a session that still exists with a dead/wedged
+          // claude is the down-cascade's job. Without this split a crashed,
+          // self-updated or rebooted main session never returns on installs
+          // with no supervising service, and every scheduled main-agent task
+          // silently skips (scheduler !sessionExists branch).
+          if (!mainChannelsSessionExists()) {
+            if (shouldEscalateMarveenDown() && createMainChannelsSession()) {
+              marveenDownState = null
+              marveenSuspectFirstSeen = null
+            }
+          } else if (shouldEscalateMarveenDown()) {
+            handleMarveenDown()
+          }
         }
         continue
       }


### PR DESCRIPTION
## Mit old meg

A fő (`MAIN_CHANNELS_SESSION`, pl. `marveen-channels`) tmux session **csendben eltűnhet** crash, mid-restart self-update, OOM-kill vagy host-reboot miatt. Amikor ez megtörténik, a `channel-monitor` jelenlegi helyreállító kaszkádja **nem tudja visszahozni**, és emiatt a scheduler **minden fő-agent ütemezett feladatot némán kihagy** — hiba nélkül, sehol nem jelez.

### Miért nem kapja el a meglévő recovery

A `handleMarveenDown()` 4 lépcsős kaszkádja (soft `/mcp` reconnect → memória-mentés → `--continue` resume → hard restart) mindegyik lépése `tmux respawn-pane`-t használ a **létező** pane-en. A `respawn-pane` csak egy élő pane claude-folyamatát tudja kicserélni — **nem tud újra létrehozni egy teljesen megszűnt sessiont**. Linux-on a hard restart is szándékosan csak `respawn-pane` (sosem `systemctl restart`, mert a channels unit `KillMode=control-group`-ja megölné a megosztott tmux-szervert és vele az összes agent sessiont).

Tehát a tényleges kétféle eset:

- **A claude-folyamat halott/beragadt, de a session/pane él** → a `respawn-pane` kaszkád meg tudja javítani. *(változatlan)*
- **A session teljesen eltűnt** → a `respawn-pane`-nek nincs mihez nyúlnia → a kaszkád minden lépése elbukik, a session örökre lent marad.

A következmény az utóbbi esetben: a scheduler `!sessionExists` ágon **némán kihagy** minden fő-agent feladatot (reggeli napindító, daily-log, dream-engine, auditok, heartbeatek). Az operátor csak annyit lát, hogy „valamiért nem jött a reggeli".

Ez **nem deployment-specifikus**: bármely telepítést érint, ahol a sessiont semmi nem felügyeli — letiltott channels systemd unit, vagy bármilyen tiszta-tmux telepítés —, illetve ahol a session crash/reboot miatt eltűnik.

## A javítás

A `check()` ciklus most megkülönbözteti a két esetet. Amikor a fő-agent claude-pidje eltűnt:

- **`mainChannelsSessionExists()`** (`tmux has-session`) megnézi, hogy a session *egyáltalán létezik-e még*.
- Ha **igen** (élő pane, halott/beragadt claude) → marad a változatlan `handleMarveenDown()` kaszkád.
- Ha **nem** (eltűnt session) → **`createMainChannelsSession()`** a kanonikus `scripts/channels.sh`-val nulláról újra létrehozza — ugyanaz az út, amit a service is használ, így channel-független és service nélkül is működik.

Biztonsági korlátok:

- **Throttle** (`MAIN_SESSION_CREATE_GRACE_MS = 6 perc`): a `channels.sh` cold startja (first-run dialógus auto-accept, `/name`, plugin-handshake) percekig tart; a throttle megakadályozza, hogy egy még éppen bootoló sessiont a következő 60 mp-es poll letépje és újraindítson.
- **Közös cold-start grace**: a create kiírja a `RESPAWN_STAMP_FILE`-t (`writeRespawnStamp()`), így a `handleMarveenDown` kaszkád a `lastMainRespawnAt()`-en keresztül defer-el a friss boot alatt — nem rakódik respawn egy épp felálló sessionre.
- **Detached + `unref()`**: a `channels.sh` hosszú életű supervisor (a session wait-loopját tailezi), ezért túl kell élnie a `check()` tickjét, és nem foghatja meg a dashboard event-loopját. A saját logolása a `store/channels-failures.log`-ba megy.
- Nincs új cgroup-probléma: a `channels.sh` `unset TMUX` után a **meglévő** tmux-szerverhez csatlakozik (`new-session`), nem unit-restartot végez — pont ezért biztonságos a self-heal, szemben egy service-restarttal.

A `mainChannelsSessionExists` / `createMainChannelsSession` `export`-ált (a `buildMainSessionRespawnCmd` „exported for the contract test" mintáját követve), hogy a viselkedés tesztelhető/verifikálható legyen.

## Tesztelés

**Regressziós tesztek** — `src/__tests__/channel-monitor-session-recreate.test.ts` (7 teszt, a repo bevett statikus-forrás mintája szerint, mert valódi tmux/launchd interakciót unit-tesztből nem lehet hajtani). Lockolja: `spawn` import; `has-session` próba; detached+`unref()` spawn; throttle-konstans; közös respawn-stamp kiírása; a `CHANNELS_SCRIPT` útvonal; és hogy a `check()` az eltűnt sessiont a `createMainChannelsSession`-höz routolja, és csak létező session esetén esik a `handleMarveenDown`-ra (sorrend-ellenőrzés). `typecheck` + `build` tiszta; a meglévő channel-monitor tesztek továbbra is zöldek.

**Élő funkcionális verifikáció (nem mock)** — egy ténylegesen hiányzó fő-session ellen, a lefordított valódi függvényt hívva:

- `mainChannelsSessionExists()` → `false` (helyes detektálás)
- `createMainChannelsSession()` → `true`, logol: `Main channels session absent -- recreating via channels.sh`
- a `marveen-channels` session 5 mp alatt felállt: claude + a channel-plugin (bun poller) + MCP szerverek benne, a keepalive baseline kiírva (nincs false-positive staleness respawn)
- a többi futó agent session (sub-agentek) **érintetlen** maradt — nincs tmux-szerver / cgroup mellékhatás

## Megjegyzés a reviewerek számára

A `channel-monitor.ts` diffjében szereplő `handleMarveenDown` környékbeli sorok érintetlenek — a Telegram-markdown code-formázáshoz használt escape-elt backtickek (`` \` ``) változatlanok. A diff valódi tartalma: a két új helper + a `check()` elágazás + a `spawn` import.
