### PR TITLE
fix(stuck-tool-call-watcher): post-respawn grace before hard-restart

### DIFF
--- a/src/__tests__/stuck-tool-call.test.ts
+++ b/src/__tests__/stuck-tool-call.test.ts
@@ -5,6 +5,7 @@ import {
   type StuckToolCallState,
   type StuckToolCallThresholds,
 } from '../pane-state.js'
+import { shouldDeferForRecentRespawn } from '../web/stuck-tool-call-watcher.js'
 
 // Thresholds matching the production defaults in stuck-tool-call-watcher.ts.
 // Repeated here so the tests pin the contract independently of the wrapper
@@ -268,5 +269,39 @@ describe('stuck-tool-call-watcher wiring contract', () => {
   it('web.ts boots the watcher', () => {
     expect(webSrc).toMatch(/startStuckToolCallWatcher\(\)/)
     expect(webSrc).toMatch(/Stuck-tool-call watcher started/)
+  })
+})
+
+// Post-respawn grace: the watcher must NOT hard-restart a session that was just
+// respawned (by any source: itself, channel-monitor, channel-watchdog.sh, or
+// the #264 stuck-modal-guard on Linux) -- avoids boot-churn + double-respawn.
+describe('shouldDeferForRecentRespawn', () => {
+  const GRACE = 360_000
+  const now = 1_000_000_000
+
+  it('no respawn recorded (0) -> do not defer', () => {
+    expect(shouldDeferForRecentRespawn(0, now)).toBe(false)
+  })
+
+  it('respawn just now -> defer', () => {
+    expect(shouldDeferForRecentRespawn(now, now)).toBe(true)
+  })
+
+  it('respawn 5 min ago (< 6 min grace) -> defer', () => {
+    expect(shouldDeferForRecentRespawn(now - 5 * 60_000, now)).toBe(true)
+  })
+
+  it('respawn exactly at the grace boundary -> do not defer (>= grace fires)', () => {
+    expect(shouldDeferForRecentRespawn(now - GRACE, now)).toBe(false)
+  })
+
+  it('respawn 10 min ago (> grace) -> do not defer (a genuine re-wedge is caught)', () => {
+    expect(shouldDeferForRecentRespawn(now - 10 * 60_000, now)).toBe(false)
+  })
+
+  it('default grace matches the shared MARVEEN_POST_RESPAWN_GRACE_MS (360s)', () => {
+    // 359s defers, 361s does not, with the default arg.
+    expect(shouldDeferForRecentRespawn(now - 359_000, now)).toBe(true)
+    expect(shouldDeferForRecentRespawn(now - 361_000, now)).toBe(false)
   })
 })

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -253,8 +253,9 @@ let marveenLastHardRestart = 0
 // restarts onto a session that was merely still booting. 6 min comfortably
 // covers the slowest realistic cold start while staying under the 18-min
 // keepalive-staleness net, so a session that is genuinely dead after a respawn
-// is still caught by another path.
-const MARVEEN_POST_RESPAWN_GRACE_MS = 360_000
+// is still caught by another path. Exported so the stuck-tool-call-watcher
+// shares the same post-respawn grace (single source of truth).
+export const MARVEEN_POST_RESPAWN_GRACE_MS = 360_000
 
 /**
  * B2 fix: shared cross-path grace accessor.

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -35,7 +35,7 @@
 import { logger } from '../logger.js'
 import { capturePane } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-import { hardRestartMarveenChannels } from './channel-monitor.js'
+import { hardRestartMarveenChannels, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS } from './channel-monitor.js'
 import {
   stuckToolCallSignature,
   decideStuckToolCallRecovery,
@@ -78,6 +78,18 @@ const NO_STATE: StuckToolCallState = {
 // but the map shape leaves room for sub-agents without an API change.
 const watchState = new Map<string, StuckToolCallState>()
 
+// Pure: should a hard-restart be deferred because a respawn (any source --
+// this watcher, channel-monitor's cascade, channel-watchdog.sh, or the #264
+// stuck-modal-guard) happened within the post-respawn grace? lastRespawnMs is
+// lastMainRespawnAt()'s epoch-ms (0 when none recorded).
+export function shouldDeferForRecentRespawn(
+  lastRespawnMs: number,
+  nowMs: number,
+  graceMs = MARVEEN_POST_RESPAWN_GRACE_MS,
+): boolean {
+  return lastRespawnMs > 0 && nowMs - lastRespawnMs < graceMs
+}
+
 function checkSession(label: string, session: string): void {
   const pane = capturePane(session)
   const sig = pane == null ? null : stuckToolCallSignature(pane)
@@ -92,6 +104,24 @@ function checkSession(label: string, session: string): void {
   }
 
   if (recover) {
+    // Post-respawn grace: defer if a respawn (this watcher, channel-monitor's
+    // cascade, channel-watchdog.sh, or the #264 stuck-modal-guard on Linux)
+    // happened within the grace window. Two reasons: (1) a freshly respawned
+    // session's TUI counter can read as a fresh "spell" while it is still
+    // booting -- re-restarting it would churn; (2) it symmetrizes coordination
+    // with every other respawner via the shared lastMainRespawnAt() stamp, so a
+    // recent external respawn can't be double-acted here (bounded the worst
+    // case to a single overlap; this closes it). A genuine re-wedge is still
+    // caught: the stagnation detection (freeze threshold + 2 stagnant polls)
+    // restarts the clock, so it fires again once the grace has elapsed.
+    const lastRespawn = lastMainRespawnAt()
+    if (shouldDeferForRecentRespawn(lastRespawn, Date.now())) {
+      logger.info(
+        { label, session, sinceRespawnMs: lastRespawn ? Date.now() - lastRespawn : null, graceMs: MARVEEN_POST_RESPAWN_GRACE_MS },
+        'stuck-tool-call-watcher: recent respawn within grace, deferring hard-restart (avoid double-respawn / boot churn)',
+      )
+      return
+    }
     // Audit log requested by Marveen 2026-06-02: every respawn this watcher
     // decides on must record the input that led to it, so a regression
     // (spurious respawn during legitimate long work) is easy to spot.


### PR DESCRIPTION
## Háttér

A #264 review-ból eredő szimmetria-hardening (Marveen-jóváhagyott follow-up #2). A `stuck-tool-call-watcher` eddig grace-check NÉLKÜL hívta a `hardRestartMarveenChannels`-t.

Két probléma:
1. Egy frissen respawnolt session TUI-countere új stuck "spell"-ként olvasódhat amíg még bootol → a watcher újraindíthatott egy egészséges bootot (churn).
2. Ez volt az egyetlen aszimmetria a respawn-koordinációban: minden MÁS respawner (channel-monitor cascade, channel-watchdog.sh, a #264 stuck-modal-guard Linux-on) defer-el a megosztott `lastMainRespawnAt()` stampen keresztül, de ez a watcher nem → bounded dupla-respawn ablak.

## Mit csinál

`shouldDeferForRecentRespawn(lastRespawnMs, now, grace)` — pure guard — a hard-restart ELŐTT: ha a `lastMainRespawnAt()` a `MARVEEN_POST_RESPAWN_GRACE_MS`-en (most exportált a channel-monitor-ból, single source of truth) belül van, defer + log. Egy valódi re-wedge továbbra is elkapott: a stagnation-detektálás újraindítja a saját óráját, így a grace lejárta után újra tüzel.

## Tesztek

6 új teszt (no-respawn / just-now / within-grace / boundary / past-grace / default-arg). 26 stuck-tool-call teszt összesen, build tiszta, nincs új regresszió.

Megjegyzés: ezzel a respawn-koordináció TELJESEN szimmetrikus a #264 stuck-modal-guarddal (Linux), és a futó rendszerünkön (macOS, #264 nem fut) is megszünteti a freshly-respawned-session re-restart churn-t.

🤖 Generated with [Claude Code](https://claude.com/claude-code)