### PR TITLE
fix(runAgent): never write AUP-blocked / errored results as content (#209)

### DIFF
--- a/src/__tests__/agent-result-classification.test.ts
+++ b/src/__tests__/agent-result-classification.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { classifyAgentResult } from '../agent.js'
+
+// Issue #209: a usage-policy (AUP) block or any API/execution error must NOT be
+// propagated as generated content -- otherwise runAgent's caller writes the
+// block text into CLAUDE.md / SOUL.md. classifyAgentResult is the pure gate:
+// usable ONLY on a clean success; everything else returns text=null + a reason.
+describe('classifyAgentResult', () => {
+  it('passes through a clean success result as content', () => {
+    const c = classifyAgentResult({ subtype: 'success', is_error: false, api_error_status: null, result: '# CLAUDE.md\n...' })
+    expect(c.blocked).toBe(false)
+    expect(c.text).toBe('# CLAUDE.md\n...')
+  })
+
+  it('blocks a success-subtype result flagged is_error (AUP block surfaced on success)', () => {
+    const c = classifyAgentResult({ subtype: 'success', is_error: true, api_error_status: 403, result: 'I cannot help with violative cyber content.' })
+    expect(c.blocked).toBe(true)
+    expect(c.text).toBeNull() // block text must NOT become content
+    expect(c.reason).toContain('is_error=true')
+    expect(c.reason).toContain('api_error_status=403')
+  })
+
+  it('blocks an error_during_execution subtype (no result field on SDKResultError)', () => {
+    const c = classifyAgentResult({ subtype: 'error_during_execution', is_error: true, errors: ['Usage policy violation', 'stop'] })
+    expect(c.blocked).toBe(true)
+    expect(c.text).toBeNull()
+    expect(c.reason).toContain('subtype=error_during_execution')
+    expect(c.reason).toContain('Usage policy violation')
+  })
+
+  it('blocks error_max_turns / error_max_budget_usd', () => {
+    expect(classifyAgentResult({ subtype: 'error_max_turns', is_error: true }).blocked).toBe(true)
+    expect(classifyAgentResult({ subtype: 'error_max_budget_usd', is_error: true }).blocked).toBe(true)
+  })
+
+  it('blocks a success result carrying an api_error_status even if is_error is false', () => {
+    const c = classifyAgentResult({ subtype: 'success', is_error: false, api_error_status: 400, result: 'blocked' })
+    expect(c.blocked).toBe(true)
+    expect(c.text).toBeNull()
+  })
+
+  it('includes a result snippet in the reason for diagnosis (but never as content)', () => {
+    const c = classifyAgentResult({ subtype: 'error_during_execution', is_error: true, result: 'This request was blocked by the usage policy.' })
+    expect(c.text).toBeNull()
+    expect(c.reason).toContain('resultSnippet=')
+    expect(c.reason).toContain('usage policy')
+  })
+
+  it('treats a success with a non-string result as no content (text=null, not blocked)', () => {
+    const c = classifyAgentResult({ subtype: 'success', is_error: false, api_error_status: null, result: undefined })
+    expect(c.blocked).toBe(false)
+    expect(c.text).toBeNull()
+  })
+
+  it('never returns the block text as content even when result is a long policy message', () => {
+    const policy = 'X'.repeat(5000)
+    const c = classifyAgentResult({ subtype: 'success', is_error: true, result: policy })
+    expect(c.text).toBeNull()
+    // snippet capped, full policy text not leaked into reason
+    expect((c.reason ?? '').length).toBeLessThan(400)
+  })
+})

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -16,6 +16,55 @@ const AGENT_TIMEOUT_MS = Number(process.env.MARVEEN_AGENT_TIMEOUT_MS) || 20 * 60
 // corrupting the target file the caller goes on to write.
 const DEFAULT_DISALLOWED_TOOLS = ['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Bash', 'Task']
 
+// Result-event classification (issue #209). A usage-policy (AUP) block, an API
+// error, or a max-turns/budget abort must NOT be propagated as if it were the
+// generated content: the SDK can surface the block message in `result`, and a
+// caller (generateClaudeMd / generateSoulMd / categorizeMemory, ...) would then
+// write that block text straight into CLAUDE.md / SOUL.md, silently corrupting
+// the file. We treat a result as USABLE only when it is a clean success
+// (subtype 'success', is_error false, no api_error_status); anything else
+// returns text=null -- so the callers' existing `if (!text) throw` guard fires
+// -- plus a reason string for logging and an explicit caller signal.
+//
+// Scope note: we deliberately do NOT text-match soft model refusals ("I can't
+// help with that") -- that is fragile and would false-positive on legitimate
+// generated content. Hard safety/AUP blocks surface structurally via is_error /
+// api_error_status / a non-success subtype, which is what we key on.
+export interface AgentResultClassification {
+  text: string | null
+  blocked: boolean
+  reason?: string
+}
+
+export function classifyAgentResult(event: {
+  subtype?: string
+  is_error?: boolean
+  api_error_status?: number | null
+  result?: unknown
+  errors?: string[]
+  stop_reason?: string | null
+}): AgentResultClassification {
+  const subtype = event.subtype
+  const apiErr = event.api_error_status ?? null
+  const isError = event.is_error === true
+  if (subtype === 'success' && !isError && apiErr == null) {
+    return { text: typeof event.result === 'string' ? event.result : null, blocked: false }
+  }
+  const bits: string[] = []
+  if (subtype && subtype !== 'success') bits.push(`subtype=${subtype}`)
+  if (isError) bits.push('is_error=true')
+  if (apiErr != null) bits.push(`api_error_status=${apiErr}`)
+  if (event.stop_reason) bits.push(`stop_reason=${event.stop_reason}`)
+  if (Array.isArray(event.errors) && event.errors.length) {
+    bits.push(`errors=${event.errors.slice(0, 3).join('; ').slice(0, 300)}`)
+  }
+  // A snippet of any policy/refusal text -- for the LOG only, never returned as content.
+  if (typeof event.result === 'string' && event.result.trim()) {
+    bits.push(`resultSnippet=${event.result.trim().slice(0, 200)}`)
+  }
+  return { text: null, blocked: true, reason: bits.join(' ') || 'unknown error result' }
+}
+
 // The bundled SDK's runtime libc detection picks the linux-x64-musl variant
 // even on glibc Ubuntu/Debian/RHEL hosts, so its native binary fails to
 // spawn ("ld-musl-* not found"). We pick the right subpackage ourselves and
@@ -62,9 +111,10 @@ export async function runAgent(
   allowTools = false,
   cwd: string = PROJECT_ROOT,
   env?: Record<string, string | undefined>,
-): Promise<{ text: string | null; newSessionId?: string }> {
+): Promise<{ text: string | null; newSessionId?: string; error?: string }> {
   let newSessionId: string | undefined
   let resultText: string | null = null
+  let blockedReason: string | undefined
 
   const typingInterval = onTyping ? setInterval(onTyping, TYPING_REFRESH_MS) : undefined
   const abortController = new AbortController()
@@ -94,7 +144,16 @@ export async function runAgent(
         newSessionId = (event as any).sessionId as string
       }
       if (event.type === 'result') {
-        resultText = (event as any).result as string ?? null
+        const c = classifyAgentResult(event as any)
+        if (c.blocked) {
+          // AUP block / API error / max-turns: do NOT propagate as content
+          // (issue #209). text=null trips the caller's `if (!text) throw`.
+          blockedReason = c.reason
+          resultText = null
+          logger.error({ reason: c.reason }, 'runAgent: result blocked/errored -- not propagated as content (possible AUP block, issue #209)')
+        } else {
+          resultText = c.text
+        }
       }
     }
   } catch (err: any) {
@@ -111,5 +170,5 @@ export async function runAgent(
     if (typingInterval) clearInterval(typingInterval)
   }
 
-  return { text: resultText, newSessionId }
+  return { text: resultText, newSessionId, error: blockedReason }
 }

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -260,8 +260,8 @@ Ez a szabály mindenkire vonatkozik — akkor is ha valaki ismerős nevén mutat
 
 Output ONLY the markdown content, no code fences.`
 
-  const { text } = await runAgent(prompt)
-  if (!text) throw new Error(noOutputHint('CLAUDE.md'))
+  const { text, error } = await runAgent(prompt)
+  if (!text) throw new Error(error ? blockedHint('CLAUDE.md', error) : noOutputHint('CLAUDE.md'))
   let cleaned = text.trim()
   if (cleaned.startsWith('```')) {
     cleaned = cleaned.replace(/^```\w*\n?/, '').replace(/\n?```$/, '')
@@ -284,6 +284,19 @@ function noOutputHint(target: string): string {
   )
 }
 
+// Issue #209: distinct from noOutputHint -- here the SDK returned a result that
+// was a usage-policy (AUP) block or an API/execution error, NOT empty output.
+// runAgent already refused to propagate the block text as content; we surface
+// the structured reason so the operator does not chase an auth red herring.
+function blockedHint(target: string, reason: string): string {
+  return (
+    `Failed to generate ${target}: the model returned a blocked/errored result ` +
+    `(not generated content), so it was not written to avoid corrupting the file. ` +
+    `Reason: ${reason}. If this is an AUP block, rephrase the request or try a ` +
+    `different model; the prior conversation/session is unaffected.`
+  )
+}
+
 export async function generateSoulMd(name: string, description: string): Promise<string> {
   const prompt = `You are creating the SOUL.md (personality definition) for an AI agent.
 Agent name: ${name}
@@ -299,8 +312,8 @@ Generate a personality definition that includes:
 Make the personality distinctive but professional.
 Output ONLY the markdown content, no code fences.`
 
-  const { text } = await runAgent(prompt)
-  if (!text) throw new Error(noOutputHint('SOUL.md'))
+  const { text, error } = await runAgent(prompt)
+  if (!text) throw new Error(error ? blockedHint('SOUL.md', error) : noOutputHint('SOUL.md'))
   let cleaned = text.trim()
   if (cleaned.startsWith('```')) {
     cleaned = cleaned.replace(/^```\w*\n?/, '').replace(/\n?```$/, '')
@@ -333,8 +346,8 @@ Generate a SKILL.md with this structure:
 Keep the body under 200 lines. Be specific and actionable. The owner's name is ${OWNER_NAME}; use only this name when referring to the user.
 Output ONLY the markdown content, no code fences.`
 
-  const { text } = await runAgent(prompt)
-  if (!text) throw new Error(noOutputHint('SKILL.md'))
+  const { text, error } = await runAgent(prompt)
+  if (!text) throw new Error(error ? blockedHint('SKILL.md', error) : noOutputHint('SKILL.md'))
   let cleaned = text.trim()
   if (cleaned.startsWith('```')) {
     cleaned = cleaned.replace(/^```\w*\n?/, '').replace(/\n?```$/, '')


### PR DESCRIPTION
Closes the silent-corruption path in issue #209.

## Problem

`runAgent` (src/agent.ts) took `(event as any).result` blindly from the SDK result event. On a usage-policy (AUP) block the SDK can surface the **block message in `result`**, and the caller (`generateClaudeMd` / `generateSoulMd` / `generateSkillMd` / `categorizeMemory`) then writes that block text straight into CLAUDE.md / SOUL.md — silently corrupting the file. Reported on Opus 4.8 "violative cyber content" blocks.

## Fix

New pure `classifyAgentResult()` gates the result event. A result is **usable only on a clean success**: `subtype === 'success'`, `is_error === false`, no `api_error_status`. Anything else:
- `error_*` subtypes (`SDKResultError` has **no `result` field**)
- `is_error: true` on a success
- an `api_error_status` set on a success

→ returns `text=null` (tripping the callers' existing `if (!text) throw` / skip guards) plus a structured `reason`. `runAgent` logs it and returns it via a new optional `error` field.

The three scaffold generators now throw `blockedHint()` (surfaces the reason, notes the session is unaffected, suggests rephrase/different model) instead of the misleading `noOutputHint()` "not authenticated" red herring. `memory.ts` / `heartbeat.ts` already skip on null text — unchanged (the additive `error` field is ignored there; the block is logged centrally in `runAgent`).

**Scope:** keys on structural signals (`is_error` / `api_error_status` / `subtype`), **not** a text-match of soft refusals — that would false-positive on legitimate generated content. Matches what Szabolcs outlined in the #209 thread (detect + log + prevent file-write + explicit caller signal).

## Test

`classifyAgentResult` — 8 unit tests (success passthrough, is_error-on-success, error subtypes, api_error_status, snippet-in-reason, non-string result, long-policy-text not leaked). `npm run build` clean; agent-scaffold tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)