### PR TITLE
fix(install-linux): KillMode=process on the dashboard unit

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -891,6 +891,13 @@ After=network.target
 
 [Service]
 Type=simple
+# KillMode=process: the dashboard spawns sub-agent tmux sessions (claude
+# processes) that live in this unit's cgroup. With the default
+# control-group kill mode, every dashboard restart/deploy would SIGKILL
+# the whole cgroup and take all running agents down with it (only the
+# main agent survives via its own channels unit). process mode kills only
+# the node main process on stop/restart, leaving the agents running.
+KillMode=process
 WorkingDirectory=$INSTALL_DIR
 ExecStart=$NODE_PATH $INSTALL_DIR/dist/index.js
 Restart=on-failure


### PR DESCRIPTION
## Problem

The dashboard spawns sub-agent tmux sessions (the `claude` processes) into its own systemd cgroup. The generated `*-dashboard.service` unit uses the default `KillMode=control-group`, so **every dashboard restart/deploy SIGKILLs the entire cgroup** — taking down all running sub-agents with it. The main agent survives because it has its own separate channels unit; the sub-agents stay dead.

On a production fleet this shows up as the recurring "after a restart, only the main agent is running" failure.

## Fix

Add `KillMode=process` to the dashboard unit template in `install-linux.sh`. systemd then sends the stop signal only to the node main process and leaves the spawned agents running across dashboard restarts/redeploys.

The channels unit deliberately keeps `control-group` (it relies on a full-cgroup kill for hard restarts), so it is left unchanged.

## Notes

- One-line unit change, no runtime code touched.
- Existing installs can apply it manually: add `KillMode=process` under `[Service]` in `~/.config/systemd/user/<bot>-dashboard.service` (or the system unit) and `systemctl daemon-reload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)