### PR TITLE
feat(channels): gate respawn/keep-alive to a single host

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { hostname } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { readEnvFile } from './env.js'
@@ -37,6 +38,27 @@ export const OLLAMA_URL = env['OLLAMA_URL'] ?? 'http://localhost:11434'
 export const CHANNEL_PROVIDER: ChannelProviderType = getProviderType(env['CHANNEL_PROVIDER'])
 export const CHANNEL_TOKEN = getChannelToken(CHANNEL_PROVIDER, env)
 export const CHANNEL_CHAT_ID = getChannelChatId(CHANNEL_PROVIDER, env)
+
+// Respawn / keep-alive gate.
+// The in-process channel-plugin monitor (main-agent respawn + sub-agent
+// auto-restart) must run on exactly ONE machine. When the same checkout runs
+// on more than one host (e.g. a dev box alongside the production host), each
+// would independently respawn agents and the two would fight over the same bot
+// tokens / getUpdates slot. Gate it so only the intended host keeps agents alive.
+//   RESPAWN_ENABLED -- "1"/"true" forces on, "0"/"false" forces off
+//   RESPAWN_HOST    -- optional substring matched against the OS hostname; when
+//                      set, respawn is enabled only on a host whose name matches
+// Default (neither set): enabled, so a single-host install needs no config.
+const RESPAWN_HOST = (env['RESPAWN_HOST'] ?? '').toLowerCase()
+const RESPAWN_OVERRIDE = (env['RESPAWN_ENABLED'] ?? '').toLowerCase()
+export const RESPAWN_ENABLED =
+  RESPAWN_OVERRIDE === '1' || RESPAWN_OVERRIDE === 'true'
+    ? true
+    : RESPAWN_OVERRIDE === '0' || RESPAWN_OVERRIDE === 'false'
+      ? false
+      : RESPAWN_HOST
+        ? hostname().toLowerCase().includes(RESPAWN_HOST)
+        : true
 
 // Heartbeat
 export const HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000 // 1 hour

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
 import { join } from 'node:path'
 import { execFileSync, execSync } from 'node:child_process'
 import type { Server as HttpServer } from 'node:http'
-import { STORE_DIR, PID_FILENAME, WEB_PORT, ALLOWED_CHAT_ID, MAIN_AGENT_ID } from './config.js'
+import { STORE_DIR, PID_FILENAME, WEB_PORT, ALLOWED_CHAT_ID, MAIN_AGENT_ID, RESPAWN_ENABLED } from './config.js'
 import { initDatabase } from './db.js'
 import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
@@ -439,15 +439,22 @@ async function main(): Promise<void> {
   // isolation-chain attempt). We keep the native module imported so other
   // code paths that reference its exports still compile, but we do NOT
   // start its scheduler.
-  ensureHeartbeatAgent()
-  logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent scaffold ensured (channel-less, dashboard-hidden)')
-  const heartbeatStart = startAgentProcess(HEARTBEAT_AGENT_NAME)
-  if (heartbeatStart.ok) {
-    logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent started')
-  } else if (heartbeatStart.error === 'Agent is already running') {
-    logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent already running')
+  // Only the respawn host runs the heartbeat sub-agent. On a gated-off machine
+  // (e.g. a dev box) we must not spawn it -- otherwise it would fight the
+  // production host over the channel, exactly what RESPAWN_ENABLED prevents.
+  if (RESPAWN_ENABLED) {
+    ensureHeartbeatAgent()
+    logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent scaffold ensured (channel-less, dashboard-hidden)')
+    const heartbeatStart = startAgentProcess(HEARTBEAT_AGENT_NAME)
+    if (heartbeatStart.ok) {
+      logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent started')
+    } else if (heartbeatStart.error === 'Agent is already running') {
+      logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent already running')
+    } else {
+      logger.warn({ error: heartbeatStart.error }, 'Heartbeat agent failed to start (legacy native heartbeat is NOT a fallback any more)')
+    }
   } else {
-    logger.warn({ error: heartbeatStart.error }, 'Heartbeat agent failed to start (legacy native heartbeat is NOT a fallback any more)')
+    logger.info('Heartbeat agent boot-start skipped (respawn disabled on this host)')
   }
 
   // Discord-only: ensure the operator-configured DISCORD_CHANNEL_ID is

--- a/src/web.ts
+++ b/src/web.ts
@@ -281,7 +281,7 @@ export function startWebServer(port = 3420): http.Server {
   server.close = (cb?: (err?: Error) => void) => {
     clearInterval(routerInterval)
     clearInterval(scheduleInterval)
-    clearInterval(pluginMonitorInterval)
+    if (pluginMonitorInterval) clearInterval(pluginMonitorInterval)
     clearInterval(channelHealthInterval)
     clearInterval(stuckInputInterval)
     clearInterval(stuckToolCallInterval)

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1,9 +1,10 @@
 import { existsSync, readFileSync, statSync, writeFileSync, utimesSync } from 'node:fs'
+import { hostname } from 'node:os'
 import { join } from 'node:path'
 import { execSync, execFileSync } from 'node:child_process'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
-import { MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT } from '../config.js'
+import { MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT, RESPAWN_ENABLED } from '../config.js'
 import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
 import {
   agentHasChannel,
@@ -752,7 +753,16 @@ function shouldEscalateMarveenDown(): boolean {
   return now - marveenSuspectFirstSeen >= MARVEEN_DOWN_CONFIRM_MS
 }
 
-export function startChannelPluginMonitor(): NodeJS.Timeout {
+export function startChannelPluginMonitor(): NodeJS.Timeout | null {
+  // Respawn/keep-alive is production-only. On any non-production host (e.g. a
+  // local dev checkout) we never respawn the main agent or auto-restart
+  // sub-agents -- otherwise two machines would fight over the same bot tokens.
+  // Applies to ALL agents because the whole monitor loop is skipped here.
+  if (!RESPAWN_ENABLED) {
+    logger.info({ host: hostname() }, 'Channel plugin monitor disabled (respawn is production-only)')
+    return null
+  }
+
   const mainProvider = getMainAgentProvider()
 
   function check() {


### PR DESCRIPTION
## Problem

When the same checkout runs on more than one machine (e.g. a developer's laptop *and* the production host), each machine independently respawns the main agent, auto-restarts sub-agents, and boots the heartbeat sub-agent. The two boxes then fight over the same bot tokens / `getUpdates` slot (409 Conflict loops), and a dev machine can clobber the live fleet.

## Fix

Gate the respawn/keep-alive machinery behind `RESPAWN_ENABLED`:

- `RESPAWN_ENABLED` — `1`/`true` forces on, `0`/`false` forces off.
- `RESPAWN_HOST` — optional substring matched against `os.hostname()`; when set, respawn is enabled only on a host whose name matches.
- Default (neither set) — **enabled**, so a single-host install needs no configuration and upstream behaviour is unchanged.

When disabled:
- `startChannelPluginMonitor()` logs once and returns `null` (the whole monitor loop is skipped); the shutdown path guards `clearInterval` for the nullable return.
- the boot-time heartbeat sub-agent start is skipped (it would otherwise fight the production host over the channel).

Multi-host operators set `RESPAWN_ENABLED=0` on the dev box (or `RESPAWN_HOST=<prod-hostname>` everywhere) via their `.env` — no host-specific values in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)