### PR TITLE
feat(channel-monitor): desired-state auto-recovery for sub-agents

### DIFF
--- a/src/web/agent-desired-state.ts
+++ b/src/web/agent-desired-state.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { STORE_DIR } from '../config.js'
+import { logger } from '../logger.js'
+
+// Desired run-state for sub-agents.
+//
+// The agents run on a tmux server shared with the main channels session, which
+// gets `systemctl restart`ed several times a day (bun-watchdog, stuck-tool-call
+// watchdog, hard-restart). Because that unit is KillMode=control-group, every
+// such restart kills the whole tmux server and takes ALL sub-agents down with
+// it -- and the channel monitor only auto-restarts agents whose *session still
+// exists* with a dead plugin, not agents whose session vanished entirely.
+//
+// This file records which agents the operator wants running, so the monitor can
+// reconcile reality back to that desired state (after a nuke, a dashboard
+// restart, or a machine reboot). Explicit start adds; explicit stop removes --
+// so a deliberately stopped agent is not resurrected.
+const DESIRED_FILE = join(STORE_DIR, 'agents-desired.json')
+
+export function getDesiredAgents(): Set<string> {
+  try {
+    if (!existsSync(DESIRED_FILE)) return new Set()
+    const parsed = JSON.parse(readFileSync(DESIRED_FILE, 'utf-8'))
+    if (Array.isArray(parsed)) return new Set(parsed.filter((x): x is string => typeof x === 'string'))
+    return new Set()
+  } catch (err) {
+    logger.warn({ err }, 'Could not read agents-desired.json; treating as empty')
+    return new Set()
+  }
+}
+
+function writeDesired(set: Set<string>): void {
+  try {
+    writeFileSync(DESIRED_FILE, JSON.stringify([...set].sort(), null, 2))
+  } catch (err) {
+    logger.error({ err }, 'Failed to persist agents-desired.json')
+  }
+}
+
+export function addDesiredAgent(name: string): void {
+  const set = getDesiredAgents()
+  if (set.has(name)) return
+  set.add(name)
+  writeDesired(set)
+  logger.info({ agent: name }, 'Agent added to desired run-state')
+}
+
+export function removeDesiredAgent(name: string): void {
+  const set = getDesiredAgents()
+  if (!set.delete(name)) return
+  writeDesired(set)
+  logger.info({ agent: name }, 'Agent removed from desired run-state')
+}

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -26,6 +26,7 @@ import { getProvider, channelStateDir, readChannelToken, type ChannelProviderTyp
 import { attemptChannelMcpReconnect } from './channel-mcp-reconnect.js'
 import { readLastIngestionTimestamp, TRANSCRIPT_DIR } from './inbound-probe.js'
 import { shouldAutoRestartDownAgent, parseEtimeToSeconds } from './agent-restart-policy.js'
+import { getDesiredAgents } from './agent-desired-state.js'
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
@@ -853,9 +854,52 @@ export function startChannelPluginMonitor(): NodeJS.Timeout {
         }
       }
     }
+
+    // Desired-state reconciliation: bring back agents the operator wants
+    // running but whose tmux session vanished entirely (shared tmux server
+    // killed by a channels-unit restart, or a machine reboot). The per-target
+    // loop above only handles sessions that still exist with a dead plugin.
+    // Staggered to avoid the simultaneous-start race that kills agents.
+    void reconcileDesiredAgents()
   }
   setTimeout(check, 30000)
   return setInterval(check, 60000)
+}
+
+// Start desired-but-missing agents one at a time (~15s apart). The stagger is
+// mandatory: starting several channel agents at once makes them all die in the
+// resume-from-summary modal race. A single in-flight burst at a time.
+let reconcileBurstInProgress = false
+const AGENT_RECONCILE_STAGGER_MS = 15000
+function delay(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)) }
+
+async function reconcileDesiredAgents(): Promise<void> {
+  if (reconcileBurstInProgress) return
+  const desired = getDesiredAgents()
+  if (desired.size === 0) return
+  const down = [...desired].filter((name) => !isAgentRunning(name))
+  if (down.length === 0) return
+  reconcileBurstInProgress = true
+  try {
+    for (const name of down) {
+      if (isAgentRunning(name)) continue
+      const last = agentLastRestart.get(name)
+      if (last != null && Date.now() - last < AGENT_RESTART_GRACE_MS) continue
+      logger.warn({ agent: name }, 'Desired agent not running -- auto-starting (reconcile)')
+      try {
+        const r = startAgentProcess(name)
+        agentLastRestart.set(name, Date.now())
+        if (!r.ok && r.error !== 'Agent is already running') {
+          logger.error({ agent: name, error: r.error }, 'Reconcile start failed')
+        }
+      } catch (err) {
+        logger.error({ err, agent: name }, 'Reconcile start threw')
+      }
+      await delay(AGENT_RECONCILE_STAGGER_MS)
+    }
+  } finally {
+    reconcileBurstInProgress = false
+  }
 }
 
 // Backward-compatible alias

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -79,6 +79,7 @@ import {
   sendPromptToSession,
   capturePane,
 } from '../agent-process.js'
+import { addDesiredAgent, removeDesiredAgent } from '../agent-desired-state.js'
 import { readActiveModelFromProjectDir } from '../active-model.js'
 import { detectPaneState } from '../../pane-state.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
@@ -1157,6 +1158,9 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const name = decodeURIComponent(startMatch[1])
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
     const result = startAgentProcess(name)
+    // Record operator intent so the monitor keeps this agent up across shared
+    // tmux-server restarts / reboots (see agent-desired-state.ts).
+    if (result.ok || result.error === 'Agent is already running') addDesiredAgent(name)
     if (result.ok) { json(res, { ok: true }); return true }
     json(res, { error: result.error }, 400)
     return true
@@ -1166,6 +1170,8 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   if (stopMatch && method === 'POST') {
     const name = decodeURIComponent(stopMatch[1])
     const result = stopAgentProcess(name)
+    // Explicit stop clears intent so the monitor will not resurrect it.
+    removeDesiredAgent(name)
     if (result.ok) { json(res, { ok: true }); return true }
     json(res, { error: result.error }, 400)
     return true


### PR DESCRIPTION
## Problem

Sub-agents run on a tmux server **shared** with the main channels session. That unit gets `systemctl restart`ed several times a day (a bun-watchdog restarts it when the main agent's telegram bun child dies; the stuck-tool-call watchdog / hard restart also do). Because the channels unit is `KillMode=control-group`, each restart kills the whole shared tmux server and takes **every sub-agent** down at once.

The monitor previously only auto-restarted agents whose session still existed with a dead plugin — agents whose session vanished entirely stayed down until a manual start. Net effect on a fleet: several times a day everything except the main agent silently dies and never comes back.

## Fix

Track operator intent and reconcile it:

- `store/agents-desired.json` — written by the `/start` (add) and `/stop` (remove) routes, so a deliberately stopped agent is **not** resurrected.
- The channel monitor reconciles each tick: any desired-but-missing agent is restarted, **staggered ~15s apart** (starting several channel agents simultaneously makes them all die in the resume-from-summary modal race), one in-flight burst at a time.

This also covers machine reboot — the first monitor tick brings the fleet back.

## Verification

On a production host, after a `*-channels` restart nuke (0/5 agents), the fleet auto-recovered to 5/5 in ~85s and stayed up; deliberately stopped agents were not restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)