### PR TITLE
feat(dashboard): messages chat subpage with threads + pagination

### DIFF
--- a/src/__tests__/agent-conversation.test.ts
+++ b/src/__tests__/agent-conversation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import {
+  initDatabase,
+  createAgentMessage,
+  getAgentConversation,
+  getAgentConversationThreads,
+} from '../db.js'
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test'
+  initDatabase()
+})
+
+// Dashboard messages bug (2026-06-03): the old GET /api/messages?agent=X path
+// fetched the GLOBAL last-N then JS-filtered, so a rarely-active agent's thread
+// looked empty. These cover the SQL-filtered replacement + threads aggregation.
+describe('getAgentConversation', () => {
+  it('returns ONLY this agent\'s messages, newest-first', () => {
+    const a = 'tconv-alpha'
+    createAgentMessage(a, 'marveen', 'a1')
+    createAgentMessage('marveen', a, 'a2')
+    createAgentMessage('someone-else', 'third', 'noise') // must not leak in
+    const conv = getAgentConversation(a, 50)
+    expect(conv.length).toBe(2)
+    expect(conv.every(m => m.from_agent === a || m.to_agent === a)).toBe(true)
+    // newest-first: a2 (later id) before a1
+    expect(conv[0].content).toBe('a2')
+    expect(conv[1].content).toBe('a1')
+  })
+
+  it('respects the limit', () => {
+    const a = 'tconv-limit'
+    for (let i = 0; i < 5; i++) createAgentMessage(a, 'marveen', `m${i}`)
+    expect(getAgentConversation(a, 3).length).toBe(3)
+  })
+
+  it('caps the limit at 200 and floors it at 1', () => {
+    const a = 'tconv-cap'
+    createAgentMessage(a, 'marveen', 'x')
+    expect(getAgentConversation(a, 99999).length).toBeLessThanOrEqual(200)
+    expect(getAgentConversation(a, 0).length).toBe(1) // floored to >=1, one row exists
+  })
+
+  it('paginates older with beforeId (scroll-up)', () => {
+    const a = 'tconv-page'
+    const ids: number[] = []
+    for (let i = 0; i < 6; i++) ids.push(createAgentMessage(a, 'marveen', `p${i}`).id)
+    // newest-first page of 3 -> the 3 highest ids
+    const page1 = getAgentConversation(a, 3)
+    expect(page1.map(m => m.id)).toEqual([ids[5], ids[4], ids[3]])
+    // next older page: before the oldest id we have (ids[3])
+    const page2 = getAgentConversation(a, 3, ids[3])
+    expect(page2.map(m => m.id)).toEqual([ids[2], ids[1], ids[0]])
+    // no overlap between pages
+    expect(page2.every(m => m.id < ids[3])).toBe(true)
+  })
+})
+
+describe('getAgentConversationThreads', () => {
+  it('lists a peer with its count + most-recent message', () => {
+    const a = 'tthread-peer'
+    createAgentMessage(a, 'marveen', 't1')
+    createAgentMessage('marveen', a, 't2')
+    const last = createAgentMessage(a, 'marveen', 't3-last')
+    const threads = getAgentConversationThreads()
+    const row = threads.find(t => t.agent === a)
+    expect(row).toBeDefined()
+    expect(row!.count).toBe(3)
+    expect(row!.lastMessage?.id).toBe(last.id)
+    expect(row!.lastMessage?.content).toBe('t3-last')
+  })
+
+  it('excludes CHAT_SYSTEM_AGENTS as thread rows but still counts their messages for the peer', () => {
+    const a = 'tthread-withsys'
+    createAgentMessage('heartbeat', a, 'hb-to-peer')
+    createAgentMessage(a, 'channel-coordinator', 'peer-to-coord')
+    const threads = getAgentConversationThreads()
+    const agents = threads.map(t => t.agent)
+    // system agents never appear as their own thread row
+    expect(agents).not.toContain('heartbeat')
+    expect(agents).not.toContain('channel-coordinator')
+    expect(agents).not.toContain('telegram-coordinator')
+    expect(agents).not.toContain('system')
+    // but the peer's count includes the messages exchanged with system agents
+    const row = threads.find(t => t.agent === a)
+    expect(row?.count).toBe(2)
+  })
+
+  it('is sorted newest-first by last message', () => {
+    const older = 'tthread-older'
+    const newer = 'tthread-newer'
+    createAgentMessage(older, 'marveen', 'old')
+    createAgentMessage(newer, 'marveen', 'new')
+    const threads = getAgentConversationThreads()
+    const iOlder = threads.findIndex(t => t.agent === older)
+    const iNewer = threads.findIndex(t => t.agent === newer)
+    expect(iNewer).toBeGreaterThanOrEqual(0)
+    expect(iOlder).toBeGreaterThan(iNewer) // newer peer appears before older
+  })
+})

--- a/src/__tests__/agent-conversation.test.ts
+++ b/src/__tests__/agent-conversation.test.ts
@@ -8,7 +8,8 @@ import {
 
 beforeAll(() => {
   process.env.NODE_ENV = 'test'
-  initDatabase()
+  // In-memory DB so the test is idempotent and never touches store/claudeclaw.db.
+  initDatabase(':memory:')
 })
 
 // Dashboard messages bug (2026-06-03): the old GET /api/messages?agent=X path

--- a/src/db.ts
+++ b/src/db.ts
@@ -1159,6 +1159,74 @@ export function listAgentMessages(limit = 50): AgentMessage[] {
   return db.prepare('SELECT * FROM agent_messages ORDER BY created_at DESC LIMIT ?').all(limit) as AgentMessage[]
 }
 
+// System/automation participants that are not real conversation peers. They are
+// excluded as THREAD rows in the dashboard sidebar (you don't chat with the
+// heartbeat or the coordinator), but messages involving them still count toward
+// the human/agent peer they are paired with (so a thread's count matches what
+// getAgentConversation returns when you open it).
+export const CHAT_SYSTEM_AGENTS = ['heartbeat', 'telegram-coordinator', 'channel-coordinator', 'system'] as const
+
+const AGENT_MESSAGE_LIMIT_CAP = 200
+
+// The actual last-N messages for ONE agent, filtered in SQL (NOT global-last-N
+// then JS-filter -- that starved rarely-active agents' threads, dashboard bug
+// 2026-06-03). `beforeId` pages older: pass the oldest id you already have to
+// fetch the next-older batch (scroll-up pagination). Newest-first.
+export function getAgentConversation(agent: string, limit = 50, beforeId?: number): AgentMessage[] {
+  const cap = Math.min(Math.max(1, Math.floor(limit) || 1), AGENT_MESSAGE_LIMIT_CAP)
+  if (beforeId !== undefined && Number.isFinite(beforeId)) {
+    return db.prepare(
+      'SELECT * FROM agent_messages WHERE (from_agent = ? OR to_agent = ?) AND id < ? ORDER BY created_at DESC, id DESC LIMIT ?'
+    ).all(agent, agent, beforeId, cap) as AgentMessage[]
+  }
+  return db.prepare(
+    'SELECT * FROM agent_messages WHERE (from_agent = ? OR to_agent = ?) ORDER BY created_at DESC, id DESC LIMIT ?'
+  ).all(agent, agent, cap) as AgentMessage[]
+}
+
+export interface AgentThread {
+  agent: string
+  count: number
+  lastMessage: AgentMessage | null
+}
+
+// One row per distinct conversation peer (from_agent OR to_agent), excluding
+// CHAT_SYSTEM_AGENTS, each with its total message count and its most-recent
+// message. Drives the dashboard sidebar. Recency is computed per-peer (max
+// created_at) so a rarely-active peer's last message is never hidden behind the
+// global recency window (the bug the JS-filter path had). Sorted newest-first.
+export function getAgentConversationThreads(): AgentThread[] {
+  const parties = db.prepare(`
+    WITH parties AS (
+      SELECT from_agent AS agent FROM agent_messages
+      UNION
+      SELECT to_agent AS agent FROM agent_messages
+    )
+    SELECT p.agent AS agent,
+      (SELECT COUNT(*) FROM agent_messages m WHERE m.from_agent = p.agent OR m.to_agent = p.agent) AS count
+    FROM parties p
+  `).all() as { agent: string; count: number }[]
+
+  const lastStmt = db.prepare(
+    'SELECT * FROM agent_messages WHERE from_agent = ? OR to_agent = ? ORDER BY created_at DESC, id DESC LIMIT 1'
+  )
+
+  const system = new Set<string>(CHAT_SYSTEM_AGENTS)
+  const threads: AgentThread[] = []
+  for (const p of parties) {
+    if (!p.agent || system.has(p.agent)) continue
+    const lastMessage = (lastStmt.get(p.agent, p.agent) as AgentMessage | undefined) ?? null
+    threads.push({ agent: p.agent, count: p.count, lastMessage })
+  }
+  threads.sort((a, b) => {
+    const ca = a.lastMessage?.created_at ?? 0
+    const cb = b.lastMessage?.created_at ?? 0
+    if (cb !== ca) return cb - ca
+    return (b.lastMessage?.id ?? 0) - (a.lastMessage?.id ?? 0) // tiebreak: newest id first
+  })
+  return threads
+}
+
 // --- Task Run History ---
 
 export interface TaskRunEntry { name: string; agent: string; ts: number }

--- a/src/db.ts
+++ b/src/db.ts
@@ -29,20 +29,26 @@ function tightenDbPermissions(dbPath: string): void {
   }
 }
 
-export function initDatabase(): void {
-  mkdirSync(STORE_DIR, { recursive: true })
+// dbPathOverride is for tests: pass ':memory:' (or a temp path) to open an
+// isolated database instead of the real store/claudeclaw.db. The file-precreate
+// (openSync 'wx') and tightenDbPermissions steps are SKIPPED for an override --
+// they only make sense for a real on-disk store file, and ':memory:' has no path
+// to chmod. This keeps tests idempotent and stops them polluting the prod DB.
+export function initDatabase(dbPathOverride?: string): void {
+  const useOverride = dbPathOverride !== undefined
+  if (!useOverride) mkdirSync(STORE_DIR, { recursive: true })
   // Idempotent re-init: close a previous handle before opening a new one
   // so repeated calls (tests, hot-reload, recovery paths) do not leak
   // the old better-sqlite3 fd.
   if (db) {
     try { db.close() } catch { /* already closed */ }
   }
-  const dbPath = join(STORE_DIR, DB_FILENAME)
+  const dbPath = useOverride ? dbPathOverride! : join(STORE_DIR, DB_FILENAME)
   // Step 1: close the TOCTOU window on fresh installs. openSync with 'wx'
   // + 0o600 creates the file ONLY if it doesn't exist and sets the strict
   // mode atomically. better-sqlite3 then opens the existing file rather
-  // than creating one at the default umask.
-  if (!existsSync(dbPath)) {
+  // than creating one at the default umask. Skipped for a test override.
+  if (!useOverride && !existsSync(dbPath)) {
     try {
       closeSync(openSync(dbPath, 'wx', 0o600))
     } catch (err) {
@@ -56,7 +62,7 @@ export function initDatabase(): void {
   }
   db = new Database(dbPath)
   db.pragma('journal_mode = WAL')
-  tightenDbPermissions(dbPath)
+  if (!useOverride) tightenDbPermissions(dbPath)
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS sessions (

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -1,5 +1,6 @@
 import {
   createAgentMessage, getPendingMessages, listAgentMessages,
+  getAgentConversation, getAgentConversationThreads,
   markMessageDone, markMessageFailed,
   type AgentMessage,
 } from '../../db.js'
@@ -45,22 +46,31 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
     return true
   }
 
+  // Sidebar threads: one row per conversation peer (system agents excluded),
+  // each with its count + most-recent message, recency computed per-peer.
+  if (path === '/api/messages/threads' && method === 'GET') {
+    json(res, getAgentConversationThreads())
+    return true
+  }
+
   if (path === '/api/messages' && method === 'GET') {
     const agent = url.searchParams.get('agent') || ''
     const status = url.searchParams.get('status') || ''
     const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200)
+    const beforeRaw = url.searchParams.get('before')
+    const before = beforeRaw !== null ? parseInt(beforeRaw, 10) : undefined
 
     let messages: AgentMessage[]
     if (status === 'pending' && agent) {
       messages = getPendingMessages(agent)
     } else if (status === 'pending') {
       messages = getPendingMessages()
+    } else if (agent) {
+      // SQL-filtered to THIS agent's last N (+ before-cursor pagination), not
+      // global-last-N-then-JS-filter which starved rarely-active threads.
+      messages = getAgentConversation(agent, limit, Number.isFinite(before as number) ? before : undefined)
     } else {
       messages = listAgentMessages(limit)
-    }
-
-    if (agent && status !== 'pending') {
-      messages = messages.filter(m => m.from_agent === agent || m.to_agent === agent)
     }
 
     json(res, messages)

--- a/web/app.js
+++ b/web/app.js
@@ -7144,22 +7144,35 @@ async function resolveOwnerName() {
 const chatAgentHasAvatar = new Map() // name -> true|false
 let chatSelectedAgent = null
 
-function chatMonogram(agentName, size) {
+function chatMonogramEl(agentName, size) {
   const letter = agentName.charAt(0).toUpperCase()
   const colors = ['#d97757','#00C2A8','#818cf8','#22c55e','#f59e0b','#ec4899']
   const color = colors[agentName.split('').reduce((a,c)=>a+c.charCodeAt(0),0) % colors.length]
   return `<div class="chat-avatar chat-avatar-mono" style="width:${size}px;height:${size}px;background:${color};font-size:${Math.round(size*0.4)}px">${letter}</div>`
 }
 
+// Global onerror handler — avoids HTML-in-attribute escaping issues
+window.chatImgError = function(img) {
+  const name = img.getAttribute('data-agent-name') || img.alt || '?'
+  const size = parseInt(img.width) || 32
+  const letter = name.charAt(0).toUpperCase()
+  const colors = ['#d97757','#00C2A8','#818cf8','#22c55e','#f59e0b','#ec4899']
+  const color = colors[name.split('').reduce((a,c)=>a+c.charCodeAt(0),0) % colors.length]
+  const div = document.createElement('div')
+  div.className = 'chat-avatar chat-avatar-mono'
+  div.style.cssText = `width:${size}px;height:${size}px;background:${color};font-size:${Math.round(size*0.4)}px`
+  div.textContent = letter
+  img.replaceWith(div)
+}
+
 function chatAvatarHtml(agentName, size = 32) {
   const lower = agentName.toLowerCase()
   const hasAvatar = chatAgentHasAvatar.get(lower)
-  if (!hasAvatar) return chatMonogram(agentName, size)
+  if (!hasAvatar) return chatMonogramEl(agentName, size)
   const src = lower === 'marveen'
     ? `/api/marveen/avatar?t=${Date.now()}`
     : `/api/agents/${encodeURIComponent(lower)}/avatar?t=${Date.now()}`
-  const mono = chatMonogram(agentName, size).replace(/`/g, '\`').replace(/\$/g, '\$')
-  return `<img class="chat-avatar" src="${src}" width="${size}" height="${size}" alt="${escapeHtml(agentName)}" onerror="this.outerHTML=\`${mono}\`">`
+  return `<img class="chat-avatar" src="${src}" width="${size}" height="${size}" alt="${escapeHtml(agentName)}" data-agent-name="${escapeHtml(agentName)}" onerror="chatImgError(this)">`
 }
 
 async function loadMessagesPage() {
@@ -7172,49 +7185,56 @@ async function loadChatAgentList() {
   const sidebar = document.getElementById('chatAgentList')
   if (!sidebar) return
   try {
-    // Load fleet agents from API + marveen (main agent)
-    const [agentsRes, msgsRes] = await Promise.all([
+    // Load fleet agents + threads in parallel
+    const [agentsRes, threadsRes] = await Promise.all([
       fetch('/api/agents'),
-      fetch('/api/messages?limit=200'),
+      fetch('/api/messages/threads'),
     ])
     const agentsRaw = agentsRes.ok ? await agentsRes.json() : []
-    const msgs = msgsRes.ok ? await msgsRes.json() : []
+    const threads = threadsRes.ok ? await threadsRes.json() : []
 
     // Build fleet list: API agents + marveen, minus system agents
     const fleetNames = ['marveen', ...agentsRaw.map(a => a.name || a)]
       .filter(n => !CHAT_SYSTEM_AGENTS.has(n))
       .filter((n, i, arr) => arr.indexOf(n) === i)
 
-    // Populate avatar map from API data (hasAvatar field)
+    // Populate avatar map from API data
     chatAgentHasAvatar.clear()
-    chatAgentHasAvatar.set('marveen', true) // main agent always has avatar endpoint
+    chatAgentHasAvatar.set('marveen', true)
     for (const a of agentsRaw) {
       if (a.name) chatAgentHasAvatar.set(a.name, !!a.hasAvatar)
     }
 
-    // Build message index: agentName -> {lastMsg, count}
-    const msgIndex = new Map()
-    for (const m of msgs) {
-      for (const party of [m.from_agent, m.to_agent]) {
-        if (CHAT_SYSTEM_AGENTS.has(party)) continue
-        if (!msgIndex.has(party)) msgIndex.set(party, { lastMsg: m, count: 0 })
-        msgIndex.get(party).count++
+    // Build index from /api/messages/threads (per-agent, no global-window bug)
+    const threadIndex = new Map() // agentName -> {lastMessage, count}
+    for (const t of threads) {
+      if (t.agent) threadIndex.set(t.agent, { lastMsg: t.lastMessage, count: t.count || 0 })
+    }
+    // Also include thread agents not in fleet (e.g. Szabolcs/owner direct msgs)
+    for (const t of threads) {
+      if (t.agent && !fleetNames.includes(t.agent) && !CHAT_SYSTEM_AGENTS.has(t.agent)) {
+        fleetNames.push(t.agent)
       }
     }
 
     // Sort: agents with messages first (by recency), rest alphabetical
-    const sorted = fleetNames.sort((a, b) => {
-      const aHas = msgIndex.has(a), bHas = msgIndex.has(b)
+    const sorted = [...fleetNames].sort((a, b) => {
+      const aHas = threadIndex.has(a), bHas = threadIndex.has(b)
       if (aHas && !bHas) return -1
       if (!aHas && bHas) return 1
-      if (aHas && bHas) return (msgIndex.get(b).lastMsg.created_at || 0) - (msgIndex.get(a).lastMsg.created_at || 0)
+      if (aHas && bHas) {
+        const aTime = threadIndex.get(a).lastMsg?.created_at || 0
+        const bTime = threadIndex.get(b).lastMsg?.created_at || 0
+        return bTime - aTime
+      }
       return a.localeCompare(b)
     })
 
     sidebar.innerHTML = sorted.map(name => {
-      const info = msgIndex.get(name)
-      const when = info ? new Date(info.lastMsg.created_at * 1000).toLocaleTimeString('hu-HU', {hour:'2-digit',minute:'2-digit'}) : ''
-      const preview = info ? (info.lastMsg.content || '').replace(/\n/g,' ').slice(0, 60) : 'Nincs üzenet'
+      const info = threadIndex.get(name)
+      const lm = info?.lastMsg
+      const when = lm?.created_at ? new Date(lm.created_at * 1000).toLocaleTimeString('hu-HU', {hour:'2-digit',minute:'2-digit'}) : ''
+      const preview = lm ? (lm.content || '').replace(/\n/g,' ').slice(0, 60) : 'Nincs üzenet'
       const isSelected = name === chatSelectedAgent ? ' selected' : ''
       const dimmed = info ? '' : ' style="opacity:0.5"'
       return `<div class="chat-agent-item${isSelected}" data-agent="${escapeHtml(name)}"${dimmed}>

--- a/web/app.js
+++ b/web/app.js
@@ -7140,20 +7140,26 @@ async function resolveOwnerName() {
 }
 
 // === Messages page ===
-const KNOWN_AGENT_AVATARS = new Set(['boni','deeper','iris','marveen','samu','zara'])
+// chatAgentHasAvatar: populated from /api/agents during loadChatAgentList
+const chatAgentHasAvatar = new Map() // name -> true|false
 let chatSelectedAgent = null
 
-function chatAvatarHtml(agentName, size = 32) {
-  const lower = agentName.toLowerCase()
-  const hasAvatar = KNOWN_AGENT_AVATARS.has(lower)
-  if (hasAvatar) {
-    return `<img class="chat-avatar" src="/avatars/${lower}-ref.png" width="${size}" height="${size}" alt="${escapeHtml(agentName)}" onerror="this.style.display='none'">`
-  }
-  // Monogram fallback
+function chatMonogram(agentName, size) {
   const letter = agentName.charAt(0).toUpperCase()
   const colors = ['#d97757','#00C2A8','#818cf8','#22c55e','#f59e0b','#ec4899']
   const color = colors[agentName.split('').reduce((a,c)=>a+c.charCodeAt(0),0) % colors.length]
   return `<div class="chat-avatar chat-avatar-mono" style="width:${size}px;height:${size}px;background:${color};font-size:${Math.round(size*0.4)}px">${letter}</div>`
+}
+
+function chatAvatarHtml(agentName, size = 32) {
+  const lower = agentName.toLowerCase()
+  const hasAvatar = chatAgentHasAvatar.get(lower)
+  if (!hasAvatar) return chatMonogram(agentName, size)
+  const src = lower === 'marveen'
+    ? `/api/marveen/avatar?t=${Date.now()}`
+    : `/api/agents/${encodeURIComponent(lower)}/avatar?t=${Date.now()}`
+  const mono = chatMonogram(agentName, size).replace(/`/g, '\`').replace(/\$/g, '\$')
+  return `<img class="chat-avatar" src="${src}" width="${size}" height="${size}" alt="${escapeHtml(agentName)}" onerror="this.outerHTML=\`${mono}\`">`
 }
 
 async function loadMessagesPage() {
@@ -7178,6 +7184,13 @@ async function loadChatAgentList() {
     const fleetNames = ['marveen', ...agentsRaw.map(a => a.name || a)]
       .filter(n => !CHAT_SYSTEM_AGENTS.has(n))
       .filter((n, i, arr) => arr.indexOf(n) === i)
+
+    // Populate avatar map from API data (hasAvatar field)
+    chatAgentHasAvatar.clear()
+    chatAgentHasAvatar.set('marveen', true) // main agent always has avatar endpoint
+    for (const a of agentsRaw) {
+      if (a.name) chatAgentHasAvatar.set(a.name, !!a.hasAvatar)
+    }
 
     // Build message index: agentName -> {lastMsg, count}
     const msgIndex = new Map()

--- a/web/app.js
+++ b/web/app.js
@@ -7160,34 +7160,51 @@ async function loadMessagesPage() {
   await loadChatAgentList()
 }
 
+const CHAT_SYSTEM_AGENTS = new Set(['heartbeat','telegram-coordinator','channel-coordinator'])
+
 async function loadChatAgentList() {
   const sidebar = document.getElementById('chatAgentList')
   if (!sidebar) return
   try {
-    // Get all messages (limit 200) and group by other-party
-    const res = await fetch('/api/messages?limit=200')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    const msgs = await res.json()
+    // Load fleet agents from API + marveen (main agent)
+    const [agentsRes, msgsRes] = await Promise.all([
+      fetch('/api/agents'),
+      fetch('/api/messages?limit=200'),
+    ])
+    const agentsRaw = agentsRes.ok ? await agentsRes.json() : []
+    const msgs = msgsRes.ok ? await msgsRes.json() : []
 
-    // Group: for each message, the "other party" from marveen's perspective
-    const threads = new Map() // agentName -> {lastMsg, count, unread}
+    // Build fleet list: API agents + marveen, minus system agents
+    const fleetNames = ['marveen', ...agentsRaw.map(a => a.name || a)]
+      .filter(n => !CHAT_SYSTEM_AGENTS.has(n))
+      .filter((n, i, arr) => arr.indexOf(n) === i)
+
+    // Build message index: agentName -> {lastMsg, count}
+    const msgIndex = new Map()
     for (const m of msgs) {
-      const other = m.from_agent === 'marveen' ? m.to_agent : m.from_agent
-      if (!threads.has(other)) threads.set(other, { lastMsg: m, count: 0 })
-      threads.get(other).count++
+      for (const party of [m.from_agent, m.to_agent]) {
+        if (CHAT_SYSTEM_AGENTS.has(party)) continue
+        if (!msgIndex.has(party)) msgIndex.set(party, { lastMsg: m, count: 0 })
+        msgIndex.get(party).count++
+      }
     }
 
-    if (threads.size === 0) {
-      sidebar.innerHTML = '<div class="chat-sidebar-empty">Nincs üzenet.</div>'
-      return
-    }
+    // Sort: agents with messages first (by recency), rest alphabetical
+    const sorted = fleetNames.sort((a, b) => {
+      const aHas = msgIndex.has(a), bHas = msgIndex.has(b)
+      if (aHas && !bHas) return -1
+      if (!aHas && bHas) return 1
+      if (aHas && bHas) return (msgIndex.get(b).lastMsg.created_at || 0) - (msgIndex.get(a).lastMsg.created_at || 0)
+      return a.localeCompare(b)
+    })
 
-    sidebar.innerHTML = Array.from(threads.entries()).map(([name, info]) => {
-      const m = info.lastMsg
-      const when = m.created_at ? new Date(m.created_at * 1000).toLocaleTimeString('hu-HU', {hour:'2-digit',minute:'2-digit'}) : ''
-      const preview = (m.content || '').replace(/\n/g,' ').slice(0, 60)
+    sidebar.innerHTML = sorted.map(name => {
+      const info = msgIndex.get(name)
+      const when = info ? new Date(info.lastMsg.created_at * 1000).toLocaleTimeString('hu-HU', {hour:'2-digit',minute:'2-digit'}) : ''
+      const preview = info ? (info.lastMsg.content || '').replace(/\n/g,' ').slice(0, 60) : 'Nincs üzenet'
       const isSelected = name === chatSelectedAgent ? ' selected' : ''
-      return `<div class="chat-agent-item${isSelected}" data-agent="${escapeHtml(name)}">
+      const dimmed = info ? '' : ' style="opacity:0.5"'
+      return `<div class="chat-agent-item${isSelected}" data-agent="${escapeHtml(name)}"${dimmed}>
         <div class="chat-agent-avatar">${chatAvatarHtml(name, 40)}</div>
         <div class="chat-agent-info">
           <div class="chat-agent-name">${escapeHtml(name)}</div>
@@ -7197,7 +7214,6 @@ async function loadChatAgentList() {
       </div>`
     }).join('')
 
-    // Bind clicks
     sidebar.querySelectorAll('.chat-agent-item').forEach(el => {
       el.addEventListener('click', () => {
         sidebar.querySelectorAll('.chat-agent-item').forEach(x => x.classList.remove('selected'))
@@ -7207,7 +7223,6 @@ async function loadChatAgentList() {
       })
     })
 
-    // Auto-select first if none
     if (!chatSelectedAgent) {
       const first = sidebar.querySelector('.chat-agent-item')
       if (first) first.click()
@@ -7233,7 +7248,7 @@ async function loadChatThread(agentName) {
     <div class="chat-compose">
       <div class="chat-compose-row">
         <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="Üzenet ${escapeHtml(agentName)}-nek..."></textarea>
-        <button class="btn-primary chat-send-btn" id="chatSendBtn">Küldés</button>
+        <button class="btn-primary btn-compact chat-send-btn" id="chatSendBtn">Küldés</button>
       </div>
     </div>
   `

--- a/web/app.js
+++ b/web/app.js
@@ -86,7 +86,8 @@ function switchPage(pageId) {
   if (pageId === 'vault') loadVaultPage()
   if (pageId === 'autonomy') loadAutonomy()
   if (pageId === 'updates') loadUpdates()
-  if (pageId === 'team') { loadTeamGraph(); loadTeamMessages(); populateMsgComposeTargets() }
+  if (pageId === 'team') { loadTeamGraph() }
+  if (pageId === 'messages') loadMessagesPage()
   if (pageId === 'tokenUsage') loadTokenUsage()
   if (pageId === 'ideas') loadIdeasPage()
 }
@@ -7126,56 +7127,6 @@ const MSG_STATUS_META = {
   done: { label: 'kész', cls: 'badge-active' },
   failed: { label: 'hibás', cls: 'badge-paused' },
 }
-let msgComposeReady = false
-
-async function loadTeamMessages() {
-  const list = document.getElementById('teamMessageList')
-  if (!list) return
-  const filter = document.getElementById('msgFilter')?.value || ''
-  try {
-    const q = filter ? `?status=${encodeURIComponent(filter)}&limit=50` : '?limit=50'
-    const res = await fetch('/api/messages' + q)
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    const msgs = await res.json()
-    if (!Array.isArray(msgs) || msgs.length === 0) {
-      list.innerHTML = '<p class="activity-empty">Nincs üzenet.</p>'
-      return
-    }
-    list.innerHTML = msgs.map(m => {
-      const meta = MSG_STATUS_META[m.status] || { label: m.status || '-', cls: 'badge' }
-      const when = m.created_at ? new Date(m.created_at * 1000).toLocaleString('hu-HU') : ''
-      return `<div class="team-message">
-        <div class="team-message-head">
-          <span class="team-message-route">${escapeHtml(m.from_agent)} &rarr; ${escapeHtml(m.to_agent)}</span>
-          <span class="badge ${meta.cls}">${escapeHtml(meta.label)}</span>
-        </div>
-        <div class="team-message-body">${escapeHtml(m.content)}</div>
-        <div class="team-message-time">${escapeHtml(when)}</div>
-      </div>`
-    }).join('')
-  } catch (e) {
-    list.innerHTML = '<p class="activity-empty">Nem sikerült betölteni az üzeneteket: ' + escapeHtml(String(e.message || e)) + '</p>'
-  }
-}
-
-async function populateMsgComposeTargets() {
-  const sel = document.getElementById('msgComposeTo')
-  if (!sel || msgComposeReady) return
-  try {
-    const res = await fetch('/api/schedules/agents')
-    if (!res.ok) return
-    const agents = await res.json()
-    sel.innerHTML = ''
-    for (const a of agents) {
-      const opt = document.createElement('option')
-      opt.value = a.name
-      opt.textContent = a.label || a.name
-      sel.appendChild(opt)
-    }
-    msgComposeReady = true
-  } catch { /* leave empty; send will warn */ }
-}
-
 async function resolveOwnerName() {
   try {
     const res = await fetch('/api/kanban/assignees')
@@ -7188,33 +7139,187 @@ async function resolveOwnerName() {
   return 'owner'
 }
 
-async function sendComposeMessage() {
-  const to = document.getElementById('msgComposeTo').value
-  const content = document.getElementById('msgComposeContent').value.trim()
-  if (!to) { showToast('Válassz címzett ügynököt'); return }
-  if (!content) { document.getElementById('msgComposeContent').focus(); return }
-  const btn = document.getElementById('msgComposeSend')
-  btn.disabled = true
+// === Messages page ===
+const KNOWN_AGENT_AVATARS = new Set(['boni','deeper','iris','marveen','samu','zara'])
+let chatSelectedAgent = null
+
+function chatAvatarHtml(agentName, size = 32) {
+  const lower = agentName.toLowerCase()
+  const hasAvatar = KNOWN_AGENT_AVATARS.has(lower)
+  if (hasAvatar) {
+    return `<img class="chat-avatar" src="/avatars/${lower}-ref.png" width="${size}" height="${size}" alt="${escapeHtml(agentName)}" onerror="this.style.display='none'">`
+  }
+  // Monogram fallback
+  const letter = agentName.charAt(0).toUpperCase()
+  const colors = ['#d97757','#00C2A8','#818cf8','#22c55e','#f59e0b','#ec4899']
+  const color = colors[agentName.split('').reduce((a,c)=>a+c.charCodeAt(0),0) % colors.length]
+  return `<div class="chat-avatar chat-avatar-mono" style="width:${size}px;height:${size}px;background:${color};font-size:${Math.round(size*0.4)}px">${letter}</div>`
+}
+
+async function loadMessagesPage() {
+  await loadChatAgentList()
+}
+
+async function loadChatAgentList() {
+  const sidebar = document.getElementById('chatAgentList')
+  if (!sidebar) return
+  try {
+    // Get all messages (limit 200) and group by other-party
+    const res = await fetch('/api/messages?limit=200')
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const msgs = await res.json()
+
+    // Group: for each message, the "other party" from marveen's perspective
+    const threads = new Map() // agentName -> {lastMsg, count, unread}
+    for (const m of msgs) {
+      const other = m.from_agent === 'marveen' ? m.to_agent : m.from_agent
+      if (!threads.has(other)) threads.set(other, { lastMsg: m, count: 0 })
+      threads.get(other).count++
+    }
+
+    if (threads.size === 0) {
+      sidebar.innerHTML = '<div class="chat-sidebar-empty">Nincs üzenet.</div>'
+      return
+    }
+
+    sidebar.innerHTML = Array.from(threads.entries()).map(([name, info]) => {
+      const m = info.lastMsg
+      const when = m.created_at ? new Date(m.created_at * 1000).toLocaleTimeString('hu-HU', {hour:'2-digit',minute:'2-digit'}) : ''
+      const preview = (m.content || '').replace(/\n/g,' ').slice(0, 60)
+      const isSelected = name === chatSelectedAgent ? ' selected' : ''
+      return `<div class="chat-agent-item${isSelected}" data-agent="${escapeHtml(name)}">
+        <div class="chat-agent-avatar">${chatAvatarHtml(name, 40)}</div>
+        <div class="chat-agent-info">
+          <div class="chat-agent-name">${escapeHtml(name)}</div>
+          <div class="chat-agent-preview">${escapeHtml(preview)}</div>
+        </div>
+        <div class="chat-agent-time">${when}</div>
+      </div>`
+    }).join('')
+
+    // Bind clicks
+    sidebar.querySelectorAll('.chat-agent-item').forEach(el => {
+      el.addEventListener('click', () => {
+        sidebar.querySelectorAll('.chat-agent-item').forEach(x => x.classList.remove('selected'))
+        el.classList.add('selected')
+        chatSelectedAgent = el.dataset.agent
+        loadChatThread(chatSelectedAgent)
+      })
+    })
+
+    // Auto-select first if none
+    if (!chatSelectedAgent) {
+      const first = sidebar.querySelector('.chat-agent-item')
+      if (first) first.click()
+    }
+  } catch (e) {
+    sidebar.innerHTML = `<div class="chat-sidebar-empty">Hiba: ${escapeHtml(String(e.message||e))}</div>`
+  }
+}
+
+async function loadChatThread(agentName) {
+  const panel = document.getElementById('chatThreadPanel')
+  if (!panel) return
+
+  panel.innerHTML = `
+    <div class="chat-thread-header">
+      ${chatAvatarHtml(agentName, 32)}
+      <span class="chat-thread-title">${escapeHtml(agentName)}</span>
+      <button class="btn-secondary btn-compact" style="margin-left:auto" onclick="loadChatThread('${escapeHtml(agentName)}')">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+      </button>
+    </div>
+    <div class="chat-bubbles" id="chatBubbles">Betöltés...</div>
+    <div class="chat-compose">
+      <div class="chat-compose-row">
+        <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="Üzenet ${escapeHtml(agentName)}-nek..."></textarea>
+        <button class="btn-primary chat-send-btn" id="chatSendBtn">Küldés</button>
+      </div>
+    </div>
+  `
+
+  document.getElementById('chatSendBtn')?.addEventListener('click', () => sendChatMessage(agentName))
+  document.getElementById('chatComposeText')?.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); sendChatMessage(agentName) }
+  })
+
+  try {
+    const res = await fetch(`/api/messages?agent=${encodeURIComponent(agentName)}&limit=50`)
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const msgs = await res.json()
+    renderChatBubbles(msgs, agentName)
+  } catch (e) {
+    const bubbles = document.getElementById('chatBubbles')
+    if (bubbles) bubbles.innerHTML = `<p class="activity-empty">Hiba: ${escapeHtml(String(e.message||e))}</p>`
+  }
+}
+
+function renderChatBubbles(msgs, agentName) {
+  const container = document.getElementById('chatBubbles')
+  if (!container) return
+
+  if (!msgs || msgs.length === 0) {
+    container.innerHTML = '<p class="activity-empty">Nincs üzenet ebben a szálban.</p>'
+    return
+  }
+
+  // Sort oldest first
+  const sorted = [...msgs].sort((a,b) => (a.created_at||0) - (b.created_at||0))
+
+  container.innerHTML = sorted.map(m => {
+    const isOutgoing = m.from_agent === 'marveen'
+    const senderName = isOutgoing ? 'marveen' : m.from_agent
+    const when = m.created_at ? new Date(m.created_at * 1000).toLocaleString('hu-HU', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : ''
+    const statusMeta = MSG_STATUS_META[m.status] || { label: m.status || '', cls: 'badge' }
+
+    return `<div class="chat-bubble-row ${isOutgoing ? 'outgoing' : 'incoming'}">
+      ${!isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml(senderName, 28)}</div>` : ''}
+      <div class="chat-bubble ${isOutgoing ? 'bubble-out' : 'bubble-in'}">
+        <div class="bubble-meta">
+          ${!isOutgoing ? `<span class="bubble-sender">${escapeHtml(senderName)}</span>` : ''}
+          <span class="bubble-id-chip">#${m.id}</span>
+          <span class="badge ${statusMeta.cls}" style="font-size:10px">${escapeHtml(statusMeta.label)}</span>
+        </div>
+        <div class="bubble-text">${escapeHtml(m.content || '')}</div>
+        <div class="bubble-time">${when}</div>
+      </div>
+      ${isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml('marveen', 28)}</div>` : ''}
+    </div>`
+  }).join('')
+
+  // Scroll to bottom
+  container.scrollTop = container.scrollHeight
+}
+
+async function sendChatMessage(toAgent) {
+  const textarea = document.getElementById('chatComposeText')
+  const btn = document.getElementById('chatSendBtn')
+  const content = textarea?.value?.trim()
+  if (!content) { textarea?.focus(); return }
+  if (btn) btn.disabled = true
   try {
     const from = await resolveOwnerName()
     const res = await fetch('/api/messages', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ from, to, content }),
+      body: JSON.stringify({ from, to: toAgent, content }),
     })
     if (!res.ok) { const err = await res.json(); throw new Error(err.error || 'Hiba') }
-    document.getElementById('msgComposeContent').value = ''
+    if (textarea) textarea.value = ''
     showToast('Üzenet elküldve')
-    loadTeamMessages()
+    await loadChatThread(toAgent)
+    await loadChatAgentList()
   } catch (e) {
     showToast('Hiba: ' + (e.message || e))
   } finally {
-    btn.disabled = false
+    if (btn) btn.disabled = false
   }
 }
 
-document.getElementById('msgFilter')?.addEventListener('change', loadTeamMessages)
-document.getElementById('msgComposeSend')?.addEventListener('click', sendComposeMessage)
+document.getElementById('chatRefreshBtn')?.addEventListener('click', () => {
+  loadChatAgentList()
+  if (chatSelectedAgent) loadChatThread(chatSelectedAgent)
+})
 
 function renderTeamEditor(agent, allAgents) {
   const team = agent.team || { role: 'member', reportsTo: null, delegatesTo: [], autoDelegation: false, trustFrom: [] }

--- a/web/app.js
+++ b/web/app.js
@@ -7245,9 +7245,19 @@ async function loadChatAgentList() {
   }
 }
 
+// Pagination state for the open thread
+const chatThreadState = { agent: null, minLoadedId: null, hasMore: true, loading: false }
+const CHAT_PAGE_SIZE = 10
+const CHAT_LOAD_MORE = 20
+
 async function loadChatThread(agentName) {
   const panel = document.getElementById('chatThreadPanel')
   if (!panel) return
+
+  chatThreadState.agent = agentName
+  chatThreadState.minLoadedId = null
+  chatThreadState.hasMore = true
+  chatThreadState.loading = false
 
   panel.innerHTML = `
     <div class="chat-thread-header">
@@ -7257,7 +7267,7 @@ async function loadChatThread(agentName) {
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
       </button>
     </div>
-    <div class="chat-bubbles" id="chatBubbles">Betöltés...</div>
+    <div class="chat-bubbles" id="chatBubbles"><div class="chat-loading-indicator" id="chatLoadingTop" style="display:none;text-align:center;padding:8px;font-size:11px;color:var(--text-muted)">Betöltés...</div></div>
     <div class="chat-compose">
       <div class="chat-compose-row">
         <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="Üzenet ${escapeHtml(agentName)}-nek..."></textarea>
@@ -7271,51 +7281,106 @@ async function loadChatThread(agentName) {
     if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); sendChatMessage(agentName) }
   })
 
+  // Initial load
+  await fetchChatPage(agentName, null, CHAT_PAGE_SIZE, 'replace')
+
+  // Scroll-up pagination handler
+  const bubbles = document.getElementById('chatBubbles')
+  if (bubbles) {
+    bubbles.addEventListener('scroll', () => {
+      if (bubbles.scrollTop < 80 && chatThreadState.hasMore && !chatThreadState.loading
+          && chatThreadState.agent === agentName) {
+        fetchChatPage(agentName, chatThreadState.minLoadedId, CHAT_LOAD_MORE, 'prepend')
+      }
+    })
+  }
+}
+
+function buildBubbleHtml(m) {
+  const isOutgoing = m.from_agent === 'marveen'
+  const senderName = isOutgoing ? 'marveen' : m.from_agent
+  const when = m.created_at ? new Date(m.created_at * 1000).toLocaleString('hu-HU', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : ''
+  const statusMeta = MSG_STATUS_META[m.status] || { label: m.status || '', cls: 'badge' }
+  return `<div class="chat-bubble-row ${isOutgoing ? 'outgoing' : 'incoming'}" data-msg-id="${m.id}">
+    ${!isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml(senderName, 28)}</div>` : ''}
+    <div class="chat-bubble ${isOutgoing ? 'bubble-out' : 'bubble-in'}">
+      <div class="bubble-meta">
+        ${!isOutgoing ? `<span class="bubble-sender">${escapeHtml(senderName)}</span>` : ''}
+        <span class="bubble-id-chip">#${m.id}</span>
+        <span class="badge ${statusMeta.cls}" style="font-size:10px">${escapeHtml(statusMeta.label)}</span>
+      </div>
+      <div class="bubble-text">${escapeHtml(m.content || '')}</div>
+      <div class="bubble-time">${when}</div>
+    </div>
+    ${isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml('marveen', 28)}</div>` : ''}
+  </div>`
+}
+
+async function fetchChatPage(agentName, beforeId, limit, mode) {
+  if (chatThreadState.loading) return
+  chatThreadState.loading = true
+  const container = document.getElementById('chatBubbles')
+  const loadingIndicator = document.getElementById('chatLoadingTop')
+  if (!container) { chatThreadState.loading = false; return }
+  if (loadingIndicator && mode === 'prepend') loadingIndicator.style.display = 'block'
   try {
-    const res = await fetch(`/api/messages?agent=${encodeURIComponent(agentName)}&limit=50`)
+    let url = `/api/messages?agent=${encodeURIComponent(agentName)}&limit=${limit}`
+    if (beforeId) url += `&before=${beforeId}`
+    const res = await fetch(url)
     if (!res.ok) throw new Error('HTTP ' + res.status)
     const msgs = await res.json()
-    renderChatBubbles(msgs, agentName)
+    const sorted = Array.isArray(msgs) ? [...msgs].sort((a, b) => (a.created_at || 0) - (b.created_at || 0)) : []
+
+    if (mode === 'replace') {
+      if (sorted.length === 0) {
+        container.innerHTML = '<p class="activity-empty">Nincs üzenet ebben a szálban.</p>'
+      } else {
+        container.innerHTML = '<div class="chat-loading-indicator" id="chatLoadingTop" style="display:none;text-align:center;padding:8px;font-size:11px;color:var(--text-muted)">Betöltés...</div>'
+        container.insertAdjacentHTML('beforeend', sorted.map(buildBubbleHtml).join(''))
+        container.scrollTop = container.scrollHeight
+      }
+      if (sorted.length < limit) chatThreadState.hasMore = false
+    } else { // prepend
+      if (loadingIndicator) loadingIndicator.style.display = 'none'
+      if (!sorted.length) { chatThreadState.hasMore = false; chatThreadState.loading = false; return }
+      if (sorted.length < limit) chatThreadState.hasMore = false
+      const prevHeight = container.scrollHeight
+      const indicator = document.getElementById('chatLoadingTop')
+      const html = sorted.map(buildBubbleHtml).join('')
+      if (indicator) {
+        indicator.insertAdjacentHTML('afterend', html)
+      } else {
+        container.insertAdjacentHTML('afterbegin', html)
+      }
+      // Restore scroll position so view doesn't jump
+      container.scrollTop = container.scrollHeight - prevHeight
+    }
+
+    if (sorted.length > 0) {
+      const minId = Math.min(...sorted.map(m => m.id))
+      if (chatThreadState.minLoadedId === null || minId < chatThreadState.minLoadedId) {
+        chatThreadState.minLoadedId = minId
+      }
+    }
   } catch (e) {
-    const bubbles = document.getElementById('chatBubbles')
-    if (bubbles) bubbles.innerHTML = `<p class="activity-empty">Hiba: ${escapeHtml(String(e.message||e))}</p>`
+    if (loadingIndicator) loadingIndicator.style.display = 'none'
+    if (mode === 'replace') {
+      container.innerHTML = `<p class="activity-empty">Hiba: ${escapeHtml(String(e.message||e))}</p>`
+    }
+  } finally {
+    chatThreadState.loading = false
   }
 }
 
 function renderChatBubbles(msgs, agentName) {
   const container = document.getElementById('chatBubbles')
   if (!container) return
-
   if (!msgs || msgs.length === 0) {
     container.innerHTML = '<p class="activity-empty">Nincs üzenet ebben a szálban.</p>'
     return
   }
-
-  // Sort oldest first
   const sorted = [...msgs].sort((a,b) => (a.created_at||0) - (b.created_at||0))
-
-  container.innerHTML = sorted.map(m => {
-    const isOutgoing = m.from_agent === 'marveen'
-    const senderName = isOutgoing ? 'marveen' : m.from_agent
-    const when = m.created_at ? new Date(m.created_at * 1000).toLocaleString('hu-HU', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : ''
-    const statusMeta = MSG_STATUS_META[m.status] || { label: m.status || '', cls: 'badge' }
-
-    return `<div class="chat-bubble-row ${isOutgoing ? 'outgoing' : 'incoming'}">
-      ${!isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml(senderName, 28)}</div>` : ''}
-      <div class="chat-bubble ${isOutgoing ? 'bubble-out' : 'bubble-in'}">
-        <div class="bubble-meta">
-          ${!isOutgoing ? `<span class="bubble-sender">${escapeHtml(senderName)}</span>` : ''}
-          <span class="bubble-id-chip">#${m.id}</span>
-          <span class="badge ${statusMeta.cls}" style="font-size:10px">${escapeHtml(statusMeta.label)}</span>
-        </div>
-        <div class="bubble-text">${escapeHtml(m.content || '')}</div>
-        <div class="bubble-time">${when}</div>
-      </div>
-      ${isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml('marveen', 28)}</div>` : ''}
-    </div>`
-  }).join('')
-
-  // Scroll to bottom
+  container.innerHTML = sorted.map(buildBubbleHtml).join('')
   container.scrollTop = container.scrollHeight
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -43,6 +43,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="3"/><path d="M12 8v4"/><circle cx="5" cy="18" r="3"/><circle cx="19" cy="18" r="3"/><path d="M12 12l-7 6M12 12l7 6"/></svg>
         <span class="sb-label">Csapat</span>
       </a>
+      <a href="#" class="sb-link" data-page="messages">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+        <span class="sb-label">Üzenetek</span>
+      </a>
       <a href="#" class="sb-link" data-page="tasks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
         <span class="sb-label">Ütemezések</span>
@@ -761,27 +765,31 @@
         A szerep és a beosztott/vezető kapcsolatok az ügynök részletek &gt; Csapat fülén szerkeszthetők.
       </p>
 
-      <div class="team-messages">
-        <div class="page-header-row" style="margin-bottom:14px">
-          <h2 style="font-size:18px;margin:0">Üzenetek</h2>
-          <select id="msgFilter">
-            <option value="">Összes</option>
-            <option value="pending">Függőben</option>
-            <option value="done">Kész</option>
-            <option value="failed">Hibás</option>
-          </select>
+    </div>
+
+    <!-- === Messages Page === -->
+    <div class="page" id="messagesPage" hidden>
+      <div class="page-header" style="margin-bottom:0">
+        <div class="page-header-row">
+          <div>
+            <h1>Üzenetek</h1>
+            <p class="subtitle">Inter-agent kommunikáció</p>
+          </div>
+          <button class="btn-secondary btn-compact" id="chatRefreshBtn">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+            Frissítés
+          </button>
         </div>
-        <div id="teamMessageList" class="team-message-list"></div>
-        <div class="team-compose">
-          <div class="form-group">
-            <label for="msgComposeTo">Címzett ügynök</label>
-            <select id="msgComposeTo"></select>
+      </div>
+      <div class="chat-layout">
+        <div class="chat-sidebar" id="chatAgentList">
+          <div class="chat-sidebar-loading">Betöltés...</div>
+        </div>
+        <div class="chat-thread-panel" id="chatThreadPanel">
+          <div class="chat-thread-empty">
+            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="opacity:0.3"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+            <p>Válassz ügynököt</p>
           </div>
-          <div class="form-group">
-            <label for="msgComposeContent">Üzenet</label>
-            <textarea id="msgComposeContent" rows="2" placeholder="Üzenet egy ügynöknek (a dashboardról küldve)"></textarea>
-          </div>
-          <button class="btn-primary btn-compact" id="msgComposeSend">Küldés</button>
         </div>
       </div>
     </div>

--- a/web/style.css
+++ b/web/style.css
@@ -5154,7 +5154,7 @@ main {
   padding: 8px 12px;
   border-radius: 8px;
   border: 1px solid var(--border);
-  background: var(--bg-main, #1a1a1a);
+  background: var(--bg-input);
   color: var(--text);
   font-size: 13px;
   font-family: inherit;

--- a/web/style.css
+++ b/web/style.css
@@ -5142,7 +5142,7 @@ main {
 .bubble-out .bubble-text { color: #fff; }
 .bubble-time { font-size: 10px; opacity: 0.55; text-align: right; margin-top: 2px; }
 .chat-compose {
-  padding: 12px 16px;
+  padding: 10px 14px;
   border-top: 1px solid var(--border);
   background: var(--bg-card);
   flex-shrink: 0;
@@ -5154,12 +5154,26 @@ main {
   padding: 8px 12px;
   border-radius: 8px;
   border: 1px solid var(--border);
-  background: var(--bg-main);
+  background: var(--bg-main, #1a1a1a);
   color: var(--text);
   font-size: 13px;
   font-family: inherit;
-  min-height: 38px;
+  min-height: 62px;
+  max-height: 120px;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
 }
 .chat-compose-input:focus { outline: none; border-color: var(--accent); }
-.chat-send-btn { height: 38px; white-space: nowrap; padding: 0 16px; flex-shrink: 0; }
+.chat-send-btn {
+  height: 38px !important;
+  width: auto !important;
+  min-width: 72px;
+  max-width: 90px;
+  white-space: nowrap;
+  padding: 0 14px !important;
+  flex-shrink: 0;
+  font-size: 13px !important;
+  align-self: flex-end;
+}
 

--- a/web/style.css
+++ b/web/style.css
@@ -5019,13 +5019,147 @@ main {
 }
 .activity-tail-empty { margin: 0; font-size: 12px; color: var(--text-muted); font-style: italic; }
 
-/* Team page: inter-agent message log + compose */
-.team-messages { margin-top: 28px; }
-.team-message-list { display: flex; flex-direction: column; gap: 10px; margin-bottom: 18px; max-height: 420px; overflow-y: auto; }
-.team-message { border: 1px solid var(--border); border-radius: 10px; background: var(--bg-card); padding: 10px 14px; }
-.team-message-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
-.team-message-route { font-weight: 600; font-size: 13px; }
-.team-message-body { font-size: 13px; white-space: pre-wrap; word-break: break-word; }
-.team-message-time { font-size: 11px; color: var(--text-muted); margin-top: 4px; }
-.team-compose { border-top: 1px solid var(--border); padding-top: 16px; }
-.team-compose textarea { width: 100%; resize: vertical; }
+/* === Messages / Chat page === */
+.chat-layout {
+  display: flex;
+  gap: 0;
+  flex: 1;
+  min-height: 0;
+  height: calc(100vh - 160px);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  margin-top: 16px;
+}
+.chat-sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  background: var(--bg-card);
+  display: flex;
+  flex-direction: column;
+}
+.chat-sidebar-loading, .chat-sidebar-empty {
+  padding: 20px 16px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.chat-agent-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.15s;
+}
+.chat-agent-item:hover { background: var(--bg-hover); }
+.chat-agent-item.selected { background: color-mix(in srgb, var(--accent) 12%, transparent); border-left: 3px solid var(--accent); }
+.chat-agent-avatar { flex-shrink: 0; }
+.chat-avatar { border-radius: 50%; display: block; object-fit: cover; }
+.chat-avatar-mono { border-radius: 50%; display: flex; align-items: center; justify-content: center; font-weight: 700; color: #fff; flex-shrink: 0; }
+.chat-agent-info { flex: 1; min-width: 0; }
+.chat-agent-name { font-size: 13px; font-weight: 600; }
+.chat-agent-preview { font-size: 11px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-top: 2px; }
+.chat-agent-time { font-size: 10px; color: var(--text-muted); flex-shrink: 0; }
+.chat-thread-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg-main);
+}
+.chat-thread-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+.chat-thread-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card);
+  flex-shrink: 0;
+}
+.chat-thread-title { font-size: 15px; font-weight: 700; }
+.chat-bubbles {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.chat-bubble-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+.chat-bubble-row.outgoing { flex-direction: row-reverse; }
+.chat-bubble-avatar { flex-shrink: 0; }
+.chat-bubble { max-width: 72%; display: flex; flex-direction: column; gap: 4px; }
+.bubble-out {
+  background: var(--accent);
+  color: #fff;
+  border-radius: 16px 4px 16px 16px;
+  padding: 10px 14px;
+  align-self: flex-end;
+}
+.bubble-in {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 4px 16px 16px 16px;
+  padding: 10px 14px;
+  align-self: flex-start;
+}
+.bubble-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+  flex-wrap: wrap;
+}
+.bubble-sender { font-size: 11px; font-weight: 600; opacity: 0.7; }
+.bubble-id-chip {
+  font-size: 10px;
+  font-weight: 700;
+  background: rgba(255,255,255,0.2);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-family: monospace;
+}
+.bubble-out .bubble-id-chip { background: rgba(255,255,255,0.25); color: #fff; }
+.bubble-in .bubble-id-chip { background: var(--bg-hover); color: var(--text-muted); }
+.bubble-text { font-size: 13px; line-height: 1.55; white-space: pre-wrap; word-break: break-word; }
+.bubble-out .bubble-text { color: #fff; }
+.bubble-time { font-size: 10px; opacity: 0.55; text-align: right; margin-top: 2px; }
+.chat-compose {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-card);
+  flex-shrink: 0;
+}
+.chat-compose-row { display: flex; gap: 8px; align-items: flex-end; }
+.chat-compose-input {
+  flex: 1;
+  resize: none;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-main);
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  min-height: 38px;
+}
+.chat-compose-input:focus { outline: none; border-color: var(--accent); }
+.chat-send-btn { height: 38px; white-space: nowrap; padding: 0 16px; flex-shrink: 0; }
+


### PR DESCRIPTION
Splits inter-agent messages out of the Team page into a dedicated **Üzenetek** subpage with a chat-app layout (sidebar of agents + threaded conversation panel).

## What changed
- **New Messages subpage**: own nav entry + page, removed from the bottom of the Team page.
- **Chat-app layout**: left sidebar lists every fleet agent (avatar + last-message preview), right panel shows the selected thread as chat bubbles with sender avatar, message-id chip, and status badge.
- **Sidebar via `/api/messages/threads`**: one row per conversation peer with per-peer recency, fixing the bug where rarely-active agents (boni, deeper, iris) showed "no message" because the old path only scanned the global last 200.
- **Thread pagination**: loads the last 10 messages, then loads older packs (+20) on scroll-up with scroll-position preservation. Backed by a new `before=<id>` cursor on `GET /api/messages?agent=`.
- **Backend**: `getAgentConversation()` SQL-filters per agent (was global-last-N then JS-filter, which starved low-traffic threads) with before-cursor pagination; `getAgentConversationThreads()` aggregates the sidebar. Auth forge-guard and the <=200 cap unchanged.
- **Avatars**: use the canonical `/api/marveen/avatar` and `/api/agents/{name}/avatar` endpoints with a monogram fallback; no static file set.
- **Test isolation**: `initDatabase(dbPathOverride?)` accepts `:memory:` for tests so they no longer write to the production DB.

## Verification
- tsc clean; agent-conversation + db tests green, idempotent across repeated runs, prod DB untouched.
- Live endpoint smoke test: threads return real peers only, before-cursor pages older messages without overlap.
- Browser test: sidebar shows boni/deeper with their messages, thread renders 10 bubbles with id-chips, 0 broken avatar images. The one pre-existing slacker avatar 404 originates from the overview/team render, not this feature (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)