### PR TITLE
feat(dashboard): agent reauth badge + one-click /login + live terminal backend

### DIFF
--- a/src/__tests__/reauth-detect.test.ts
+++ b/src/__tests__/reauth-detect.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { detectReauthNeeded } from '../web/reauth-detect.js'
+
+// Dashboard reauth badge (Szabi 2026-06-03). Must fire on the distinctive
+// Claude Code auth-failure strings, and NOT on ordinary chat that merely
+// mentions "/login".
+describe('detectReauthNeeded', () => {
+  it('null/empty pane -> no reauth', () => {
+    expect(detectReauthNeeded(null).needsReauth).toBe(false)
+    expect(detectReauthNeeded('').needsReauth).toBe(false)
+    expect(detectReauthNeeded(undefined).needsReauth).toBe(false)
+  })
+
+  it('detects "Please run /login"', () => {
+    const r = detectReauthNeeded('Some output\n  Please run /login\n')
+    expect(r.needsReauth).toBe(true)
+    expect(r.reason).toMatch(/login/i)
+  })
+
+  it('detects the 401 invalid-credentials string', () => {
+    const r = detectReauthNeeded('API Error: 401 Invalid authentication credentials')
+    expect(r.needsReauth).toBe(true)
+    expect(r.reason).toMatch(/401|credential/i)
+  })
+
+  it('detects "Not logged in"', () => {
+    expect(detectReauthNeeded('Not logged in - Please run /login').needsReauth).toBe(true)
+  })
+
+  it('detects bare API Error: 401', () => {
+    expect(detectReauthNeeded('request failed: API Error: 401').needsReauth).toBe(true)
+  })
+
+  it('detects OAuth token expired', () => {
+    expect(detectReauthNeeded('Your OAuth token has expired.').needsReauth).toBe(true)
+  })
+
+  it('does NOT fire on a chat message mentioning /login as a topic', () => {
+    const pane = '❯ hogyan működik a /login parancs?\n  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+    expect(detectReauthNeeded(pane).needsReauth).toBe(false)
+  })
+
+  it('does NOT fire on a normal idle pane', () => {
+    const pane = '✻ Sautéed for 1m\n❯\n  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt'
+    expect(detectReauthNeeded(pane).needsReauth).toBe(false)
+  })
+})

--- a/src/__tests__/reauth-detect.test.ts
+++ b/src/__tests__/reauth-detect.test.ts
@@ -44,4 +44,26 @@ describe('detectReauthNeeded', () => {
     const pane = '✻ Sautéed for 1m\n❯\n  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt'
     expect(detectReauthNeeded(pane).needsReauth).toBe(false)
   })
+
+  it('does NOT fire when the marker is in scrollback ABOVE the tail (review false-positive)', () => {
+    // Reproduces the review case: an agent reading reauth-detect.ts has the
+    // markers high in scrollback, but its live tail is a normal idle prompt.
+    const scrollback = [
+      'reviewing: detects "Invalid authentication credentials"',
+      'and "Please run /login" and "API Error: 401"',
+      ...Array.from({ length: 20 }, (_, i) => `... work line ${i} ...`),
+      '❯',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+    ].join('\n')
+    expect(detectReauthNeeded(scrollback).needsReauth).toBe(false)
+  })
+
+  it('DOES fire when the marker is in the live tail', () => {
+    const pane = [
+      ...Array.from({ length: 20 }, (_, i) => `... work line ${i} ...`),
+      'API Error: 401 Invalid authentication credentials',
+      'Please run /login',
+    ].join('\n')
+    expect(detectReauthNeeded(pane).needsReauth).toBe(true)
+  })
 })

--- a/src/__tests__/tmux-keys.test.ts
+++ b/src/__tests__/tmux-keys.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { resolveSpecialKey, literalKeyArgs, specialKeyArgs, loginSequence } from '../web/tmux-keys.js'
+
+// Web-terminal keystroke mapping (Szabi 2026-06-03). The allow-list is the
+// security boundary: only recognised special keys may be injected.
+describe('resolveSpecialKey', () => {
+  it('maps known keys', () => {
+    expect(resolveSpecialKey('Enter')).toEqual(['Enter'])
+    expect(resolveSpecialKey('Escape')).toEqual(['Escape'])
+    expect(resolveSpecialKey('C-c')).toEqual(['C-c'])
+    expect(resolveSpecialKey('S-Tab')).toEqual(['BTab'])
+    expect(resolveSpecialKey('Backspace')).toEqual(['BSpace'])
+  })
+
+  it('returns null for an unknown / non-allow-listed key', () => {
+    expect(resolveSpecialKey('C-x')).toBeNull()
+    expect(resolveSpecialKey('rm -rf')).toBeNull()
+    expect(resolveSpecialKey('')).toBeNull()
+  })
+})
+
+describe('literalKeyArgs', () => {
+  it('builds a literal send-keys with -l and the -- terminator', () => {
+    expect(literalKeyArgs('agent-samu', 'hello')).toEqual(['send-keys', '-t', 'agent-samu', '-l', '--', 'hello'])
+  })
+
+  it('passes leading-dash text literally (after --)', () => {
+    // The -- terminator means even "-Enter" is taken as text, not a flag.
+    expect(literalKeyArgs('agent-x', '-Enter')).toEqual(['send-keys', '-t', 'agent-x', '-l', '--', '-Enter'])
+  })
+
+  it('returns null for empty text', () => {
+    expect(literalKeyArgs('agent-x', '')).toBeNull()
+  })
+})
+
+describe('specialKeyArgs', () => {
+  it('builds send-keys for an allow-listed key', () => {
+    expect(specialKeyArgs('agent-x', 'Enter')).toEqual(['send-keys', '-t', 'agent-x', 'Enter'])
+  })
+  it('returns null for a non-allow-listed key', () => {
+    expect(specialKeyArgs('agent-x', 'C-x')).toBeNull()
+  })
+})
+
+describe('loginSequence', () => {
+  it('start phase: types /login, submits, accepts the highlighted subscription option', () => {
+    const steps = loginSequence('start')
+    expect(steps[0]).toMatchObject({ kind: 'literal', text: '/login' })
+    expect(steps.filter(s => s.kind === 'special' && s.key === 'Enter').length).toBe(2)
+    // every step carries a non-negative settle delay
+    expect(steps.every(s => s.delayMs >= 0)).toBe(true)
+  })
+
+  it('confirm phase: sends the two trailing Enters', () => {
+    const steps = loginSequence('confirm')
+    expect(steps.length).toBe(2)
+    expect(steps.every(s => s.kind === 'special' && s.key === 'Enter')).toBe(true)
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -21,6 +21,7 @@ import { startAutoRestartRunner } from './web/auto-restart-runner.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
+import { tryHandleAgentTerminal } from './web/routes/agent-terminal.js'
 import { tryHandleDailyLog } from './web/routes/daily-log.js'
 import { tryHandleMemories } from './web/routes/memories.js'
 import { tryHandleMigrate } from './web/routes/migrate.js'
@@ -103,8 +104,15 @@ export function startWebServer(port = 3420): http.Server {
       const ok = checkBearerToken(req.headers.authorization, DASHBOARD_TOKEN)
       return json(res, { authenticated: ok })
     }
+    // The live pane SSE stream is consumed via EventSource, which cannot set an
+    // Authorization header -- accept the token via ?token= for this one GET
+    // path, validated with the same constant-time check. Everything else stays
+    // header-only.
+    const isSseStream = method === 'GET' && /^\/api\/agents\/[^/]+\/pane\/stream$/.test(path)
     if (path.startsWith('/api/') && !isPublicApi) {
-      if (!checkBearerToken(req.headers.authorization, DASHBOARD_TOKEN)) {
+      const headerOk = checkBearerToken(req.headers.authorization, DASHBOARD_TOKEN)
+      const queryOk = isSseStream && checkBearerToken(`Bearer ${url.searchParams.get('token') ?? ''}`, DASHBOARD_TOKEN)
+      if (!headerOk && !queryOk) {
         res.writeHead(401, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ error: 'Unauthorized' }))
         return
@@ -125,6 +133,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleConnectors(routeCtx)) return
       if (await tryHandleAgentsSkills(routeCtx)) return
       if (await tryHandleSkills(routeCtx)) return
+      if (await tryHandleAgentTerminal(routeCtx)) return
       if (await tryHandleAgents(routeCtx, WEB_DIR)) return
       if (await tryHandleMarveen(routeCtx, WEB_DIR)) return
       if (await tryHandleBackgroundTasks(routeCtx)) return

--- a/src/web/reauth-detect.ts
+++ b/src/web/reauth-detect.ts
@@ -1,0 +1,40 @@
+// Detect whether a Claude Code agent session needs re-authentication (/login).
+//
+// Szabi 2026-06-03: surface a "reauth needed" badge on the dashboard agent
+// card so an expired login (which silently stops the agent from working) is
+// visible at a glance, with a one-click /login button next to it.
+//
+// We key ONLY on distinctive multi-word strings that Claude Code itself prints
+// on an auth failure -- NOT a bare "/login" token, which could appear in a
+// user's chat message or an assistant reply and cause a false badge. Pure +
+// exported for unit testing against captured pane fixtures.
+
+export interface ReauthState {
+  needsReauth: boolean
+  reason?: string
+}
+
+// Each entry: a distinctive marker Claude Code renders on an auth failure, and
+// the short reason surfaced to the UI. Ordered most-specific first.
+const REAUTH_MARKERS: { rx: RegExp; reason: string }[] = [
+  { rx: /Invalid authentication credentials/i, reason: 'Invalid authentication credentials (401)' },
+  { rx: /Please run\s+\/login/i, reason: 'Please run /login' },
+  { rx: /Not logged in/i, reason: 'Not logged in' },
+  { rx: /\bAPI Error:\s*401\b/i, reason: 'API Error: 401' },
+  { rx: /OAuth token (?:has )?expired/i, reason: 'OAuth token expired' },
+  { rx: /Invalid API key/i, reason: 'Invalid API key' },
+  { rx: /session has expired.*\/login/i, reason: 'Session expired' },
+]
+
+/**
+ * Inspect a captured pane and decide whether the session needs re-auth.
+ * Returns { needsReauth:false } for a null/empty pane (capture failed / not
+ * running) -- absence of evidence is not evidence of an auth problem.
+ */
+export function detectReauthNeeded(pane: string | null | undefined): ReauthState {
+  if (!pane) return { needsReauth: false }
+  for (const m of REAUTH_MARKERS) {
+    if (m.rx.test(pane)) return { needsReauth: true, reason: m.reason }
+  }
+  return { needsReauth: false }
+}

--- a/src/web/reauth-detect.ts
+++ b/src/web/reauth-detect.ts
@@ -26,15 +26,31 @@ const REAUTH_MARKERS: { rx: RegExp; reason: string }[] = [
   { rx: /session has expired.*\/login/i, reason: 'Session expired' },
 ]
 
+// Only scan the live tail of the pane, not the whole scrollback. A real auth
+// failure shows in the active error/prompt region at the bottom; scanning the
+// full capture would false-positive whenever an agent merely *discusses* these
+// strings higher up -- e.g. an agent reviewing THIS code, or a chat about a 401.
+// (Caught in review 2026-06-03: the reviewer's own pane was full of these
+// markers from reading reauth-detect.ts and would have falsely badged.)
+const TAIL_LINES = 15
+
+function tailOf(pane: string, n: number): string {
+  const lines = pane.split('\n')
+  return lines.slice(Math.max(0, lines.length - n)).join('\n')
+}
+
 /**
  * Inspect a captured pane and decide whether the session needs re-auth.
  * Returns { needsReauth:false } for a null/empty pane (capture failed / not
- * running) -- absence of evidence is not evidence of an auth problem.
+ * running) -- absence of evidence is not evidence of an auth problem. Only the
+ * last TAIL_LINES are scanned so scrollback that merely mentions the markers
+ * does not trigger a false badge.
  */
 export function detectReauthNeeded(pane: string | null | undefined): ReauthState {
   if (!pane) return { needsReauth: false }
+  const tail = tailOf(pane, TAIL_LINES)
   for (const m of REAUTH_MARKERS) {
-    if (m.rx.test(pane)) return { needsReauth: true, reason: m.reason }
+    if (m.rx.test(tail)) return { needsReauth: true, reason: m.reason }
   }
   return { needsReauth: false }
 }

--- a/src/web/routes/agent-terminal.ts
+++ b/src/web/routes/agent-terminal.ts
@@ -1,0 +1,142 @@
+import { execFile, execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { resolveFromPath } from '../../platform.js'
+import { logger } from '../../logger.js'
+import { readBody, json } from '../http-helpers.js'
+import { agentDir } from '../agent-config.js'
+import { agentSessionName, isAgentRunning, capturePane } from '../agent-process.js'
+import { literalKeyArgs, specialKeyArgs, loginSequence, type LoginStep } from '../tmux-keys.js'
+import type { RouteContext } from './types.js'
+
+const TMUX = resolveFromPath('tmux')
+
+// Per-agent dashboard terminal: live pane stream (SSE), keystroke injection,
+// and the scripted /login flow. All gated by the dashboard token (the SSE
+// endpoint accepts the token via ?token= because EventSource cannot set
+// headers -- see the auth gate in web.ts). Szabi 2026-06-03.
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// Run a single `tmux <args>` invocation. Rejects on non-zero exit so the
+// caller can surface a 500 rather than silently swallowing a tmux failure.
+function tmux(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(TMUX, args, { timeout: 5000 }, (err) => {
+      if (err) reject(err)
+      else resolve()
+    })
+  })
+}
+
+async function runLoginSteps(session: string, steps: LoginStep[]): Promise<void> {
+  for (const step of steps) {
+    const args = step.kind === 'literal'
+      ? literalKeyArgs(session, step.text)
+      : specialKeyArgs(session, step.key)
+    if (args) await tmux(args)
+    if (step.delayMs > 0) await sleep(step.delayMs)
+  }
+}
+
+export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method, url } = ctx
+
+  // --- live pane stream (SSE) ------------------------------------------
+  const streamMatch = path.match(/^\/api\/agents\/([^/]+)\/pane\/stream$/)
+  if (streamMatch && method === 'GET') {
+    const name = decodeURIComponent(streamMatch[1])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    const session = agentSessionName(name)
+
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    })
+
+    let closed = false
+    const tick = (): void => {
+      if (closed) return
+      // -e keeps ANSI colour/escapes so xterm renders the screen faithfully;
+      // -p prints to stdout; -J joins wrapped lines. The frontend repaints
+      // (clear+home) before writing each frame since this is a full snapshot.
+      let pane: string | null = null
+      try {
+        pane = execSync(`${TMUX} capture-pane -t ${session} -e -p`, { timeout: 3000, encoding: 'utf-8' })
+      } catch {
+        pane = null
+      }
+      const running = isAgentRunning(name)
+      try {
+        res.write(`data: ${JSON.stringify({ pane: pane ?? '', running })}\n\n`)
+      } catch {
+        closed = true
+      }
+    }
+
+    tick()
+    const interval = setInterval(tick, 700)
+    const stop = (): void => { closed = true; clearInterval(interval) }
+    ctx.req.on('close', stop)
+    ctx.req.on('error', stop)
+    return true
+  }
+
+  // --- keystroke injection ---------------------------------------------
+  const keysMatch = path.match(/^\/api\/agents\/([^/]+)\/keys$/)
+  if (keysMatch && method === 'POST') {
+    const name = decodeURIComponent(keysMatch[1])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (!isAgentRunning(name)) { json(res, { error: 'Agent is not running' }, 400); return true }
+    const session = agentSessionName(name)
+    const body = await readBody(ctx.req)
+    let parsed: { keys?: string; special?: string }
+    try { parsed = JSON.parse(body.toString()) } catch { json(res, { error: 'Invalid JSON' }, 400); return true }
+
+    const args = parsed.special
+      ? specialKeyArgs(session, parsed.special)
+      : (typeof parsed.keys === 'string' ? literalKeyArgs(session, parsed.keys) : null)
+    if (!args) {
+      json(res, { error: 'Provide {keys:string} or an allow-listed {special}' }, 400)
+      return true
+    }
+    try {
+      await tmux(args)
+      json(res, { ok: true })
+    } catch (err) {
+      logger.warn({ err, name }, 'agent-terminal: send-keys failed')
+      json(res, { error: 'send-keys failed' }, 500)
+    }
+    return true
+  }
+
+  // --- scripted /login flow --------------------------------------------
+  const loginMatch = path.match(/^\/api\/agents\/([^/]+)\/login$/)
+  if (loginMatch && method === 'POST') {
+    const name = decodeURIComponent(loginMatch[1])
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (!isAgentRunning(name)) { json(res, { error: 'Agent is not running' }, 400); return true }
+    const session = agentSessionName(name)
+    const body = await readBody(ctx.req)
+    let phase: string | undefined
+    try { phase = (JSON.parse(body.toString()) as { phase?: string }).phase } catch { /* default below */ }
+    if (phase !== 'start' && phase !== 'confirm') {
+      json(res, { error: "phase must be 'start' or 'confirm'" }, 400)
+      return true
+    }
+    try {
+      await runLoginSteps(session, loginSequence(phase))
+      logger.info({ name, phase }, 'agent-terminal: /login sequence sent')
+      json(res, { ok: true, phase })
+    } catch (err) {
+      logger.warn({ err, name, phase }, 'agent-terminal: /login sequence failed')
+      json(res, { error: 'login sequence failed' }, 500)
+    }
+    return true
+  }
+
+  return false
+}

--- a/src/web/routes/agent-terminal.ts
+++ b/src/web/routes/agent-terminal.ts
@@ -1,4 +1,4 @@
-import { execFile, execSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { resolveFromPath } from '../../platform.js'
 import { logger } from '../../logger.js'
@@ -58,23 +58,25 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
     })
 
     let closed = false
+    let inFlight = false
     const tick = (): void => {
-      if (closed) return
-      // -e keeps ANSI colour/escapes so xterm renders the screen faithfully;
-      // -p prints to stdout; -J joins wrapped lines. The frontend repaints
-      // (clear+home) before writing each frame since this is a full snapshot.
-      let pane: string | null = null
-      try {
-        pane = execSync(`${TMUX} capture-pane -t ${session} -e -p`, { timeout: 3000, encoding: 'utf-8' })
-      } catch {
-        pane = null
-      }
-      const running = isAgentRunning(name)
-      try {
-        res.write(`data: ${JSON.stringify({ pane: pane ?? '', running })}\n\n`)
-      } catch {
-        closed = true
-      }
+      if (closed || inFlight) return // skip if a slow capture is still running
+      inFlight = true
+      // ASYNC execFile (arg array) -- NOT execSync: a setInterval execSync would
+      // block the WHOLE dashboard event loop for up to the tmux timeout on every
+      // tick, freezing all other HTTP requests. The arg array also avoids shell
+      // interpolation of `session`. -e keeps ANSI so xterm renders faithfully;
+      // -p prints; the frontend repaints (clear+home) each frame (full snapshot).
+      execFile(TMUX, ['capture-pane', '-t', session, '-e', '-p'], { timeout: 3000, encoding: 'utf-8', maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
+        inFlight = false
+        if (closed) return
+        const pane = err ? '' : (stdout ?? '')
+        try {
+          res.write(`data: ${JSON.stringify({ pane, running: isAgentRunning(name) })}\n\n`)
+        } catch {
+          closed = true
+        }
+      })
     }
 
     tick()

--- a/src/web/routes/agent-terminal.ts
+++ b/src/web/routes/agent-terminal.ts
@@ -1,10 +1,11 @@
-import { execFile } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { resolveFromPath } from '../../platform.js'
 import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
 import { agentDir } from '../agent-config.js'
-import { agentSessionName, isAgentRunning, capturePane } from '../agent-process.js'
+import { agentSessionName, isAgentRunning } from '../agent-process.js'
+import { isMainChannelsAgent, MAIN_CHANNELS_SESSION } from '../main-agent.js'
 import { literalKeyArgs, specialKeyArgs, loginSequence, type LoginStep } from '../tmux-keys.js'
 import type { RouteContext } from './types.js'
 
@@ -17,6 +18,27 @@ const TMUX = resolveFromPath('tmux')
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isTmuxSessionAlive(session: string): boolean {
+  try {
+    execFileSync(TMUX, ['has-session', '-t', session], { timeout: 3000, stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Resolve a terminal target for both sub-agents and the MAIN agent (Marveen).
+// The main agent has no agents/<name> dir and runs in `<id>-channels`, not
+// `agent-<name>` -- so the sub-agent assumptions (existsSync(agentDir) +
+// agentSessionName) 404 it (Zara hit this, 871005b). Branch on the main agent.
+interface SessionTarget { exists: boolean; running: boolean; session: string }
+function resolveTarget(name: string): SessionTarget {
+  if (isMainChannelsAgent(name)) {
+    return { exists: true, running: isTmuxSessionAlive(MAIN_CHANNELS_SESSION), session: MAIN_CHANNELS_SESSION }
+  }
+  return { exists: existsSync(agentDir(name)), running: isAgentRunning(name), session: agentSessionName(name) }
 }
 
 // Run a single `tmux <args>` invocation. Rejects on non-zero exit so the
@@ -47,8 +69,9 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
   const streamMatch = path.match(/^\/api\/agents\/([^/]+)\/pane\/stream$/)
   if (streamMatch && method === 'GET') {
     const name = decodeURIComponent(streamMatch[1])
-    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
-    const session = agentSessionName(name)
+    const target = resolveTarget(name)
+    if (!target.exists) { json(res, { error: 'Agent not found' }, 404); return true }
+    const session = target.session
 
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
@@ -71,8 +94,11 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
         inFlight = false
         if (closed) return
         const pane = err ? '' : (stdout ?? '')
+        // A successful capture proves the session is alive; only re-probe on
+        // capture failure (cheap, and avoids a has-session call every tick).
+        const running = err ? isTmuxSessionAlive(session) : true
         try {
-          res.write(`data: ${JSON.stringify({ pane, running: isAgentRunning(name) })}\n\n`)
+          res.write(`data: ${JSON.stringify({ pane, running })}\n\n`)
         } catch {
           closed = true
         }
@@ -91,9 +117,10 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
   const keysMatch = path.match(/^\/api\/agents\/([^/]+)\/keys$/)
   if (keysMatch && method === 'POST') {
     const name = decodeURIComponent(keysMatch[1])
-    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
-    if (!isAgentRunning(name)) { json(res, { error: 'Agent is not running' }, 400); return true }
-    const session = agentSessionName(name)
+    const target = resolveTarget(name)
+    if (!target.exists) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (!target.running) { json(res, { error: 'Agent is not running' }, 400); return true }
+    const session = target.session
     const body = await readBody(ctx.req)
     let parsed: { keys?: string; special?: string }
     try { parsed = JSON.parse(body.toString()) } catch { json(res, { error: 'Invalid JSON' }, 400); return true }
@@ -119,9 +146,10 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
   const loginMatch = path.match(/^\/api\/agents\/([^/]+)\/login$/)
   if (loginMatch && method === 'POST') {
     const name = decodeURIComponent(loginMatch[1])
-    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
-    if (!isAgentRunning(name)) { json(res, { error: 'Agent is not running' }, 400); return true }
-    const session = agentSessionName(name)
+    const target = resolveTarget(name)
+    if (!target.exists) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (!target.running) { json(res, { error: 'Agent is not running' }, 400); return true }
+    const session = target.session
     const body = await readBody(ctx.req)
     let phase: string | undefined
     try { phase = (JSON.parse(body.toString()) as { phase?: string }).phase } catch { /* default below */ }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -81,6 +81,7 @@ import {
 } from '../agent-process.js'
 import { readActiveModelFromProjectDir, readContextTokensFromProjectDir } from '../active-model.js'
 import { detectPaneState } from '../../pane-state.js'
+import { detectReauthNeeded } from '../reauth-detect.js'
 import { readAutoRestartConfig, writeAutoRestartConfig } from '../auto-restart-store.js'
 import type { AutoRestartConfig } from '../../auto-restart.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
@@ -272,6 +273,10 @@ interface AgentSummary {
   /** Live context size in tokens (input+cache_read+cache_creation of the last
    *  turn), or null when not running / no transcript yet. */
   contextTokens: number | null
+  /** True when the running session's pane shows a login/401 auth failure --
+   *  drives the dashboard "reauth needed" badge + one-click /login button. */
+  needsReauth: boolean
+  reauthReason?: string
 }
 
 interface AgentDetail extends AgentSummary {
@@ -296,6 +301,10 @@ function getAgentSummary(name: string): AgentSummary {
   const proc = getAgentProcessInfo(name)
   const runningSince = proc.running ? getAgentRunningSince(name) : null
 
+  // Reauth badge: only meaningful for a running session (a stopped agent has
+  // no pane to inspect). One capture-pane per running agent on the list poll.
+  const reauth = proc.running ? detectReauthNeeded(capturePane(agentSessionName(name))) : { needsReauth: false }
+
   return {
     name,
     displayName: readAgentDisplayName(name),
@@ -315,6 +324,8 @@ function getAgentSummary(name: string): AgentSummary {
     hasAvatar: findAvatarForAgent(name) !== null,
     autoRestart: readAutoRestartConfig(name),
     contextTokens: proc.running ? readContextTokensFromProjectDir(dir, readAgentClaudeConfigDir(name) ?? undefined) : null,
+    needsReauth: reauth.needsReauth,
+    reauthReason: reauth.reason,
   }
 }
 

--- a/src/web/tmux-keys.ts
+++ b/src/web/tmux-keys.ts
@@ -1,0 +1,92 @@
+// Pure mapping of dashboard keyboard input -> `tmux send-keys` arguments, and
+// the scripted /login keystroke sequence. Kept dependency-free + exported so
+// the mapping (the part most likely to drift) is unit-testable without spawning
+// tmux. The actual execFile lives in routes/agent-terminal.ts.
+
+// Named special keys the web terminal may send (xterm captures these and posts
+// {special}). tmux understands these key names directly in send-keys.
+const SPECIAL_KEYS: Record<string, string[]> = {
+  Enter: ['Enter'],
+  Escape: ['Escape'],
+  Tab: ['Tab'],
+  BSpace: ['BSpace'],
+  Backspace: ['BSpace'],
+  Up: ['Up'],
+  Down: ['Down'],
+  Left: ['Left'],
+  Right: ['Right'],
+  Home: ['Home'],
+  End: ['End'],
+  PageUp: ['PageUp'],
+  PageDown: ['PageDown'],
+  Space: ['Space'],
+  'S-Tab': ['BTab'],
+  'C-c': ['C-c'],
+  'C-d': ['C-d'],
+  'C-u': ['C-u'],
+  'C-l': ['C-l'],
+  'C-r': ['C-r'],
+  'C-a': ['C-a'],
+  'C-e': ['C-e'],
+}
+
+/**
+ * Resolve a {special} key name to the tmux send-keys argument list, or null if
+ * the name is not allow-listed. The allow-list is the security boundary: the
+ * web terminal can only inject keys we recognise, not arbitrary control args.
+ */
+export function resolveSpecialKey(name: string): string[] | null {
+  return SPECIAL_KEYS[name] ?? null
+}
+
+/**
+ * Build send-keys args for a literal text chunk. tmux send-keys treats a string
+ * that begins with `-` as a flag; the leading `--` terminator forces it to be
+ * taken literally. We always pass the text after `--`. Returns null for empty.
+ */
+export function literalKeyArgs(session: string, text: string): string[] | null {
+  if (!text) return null
+  // `-l` sends the keys literally (no key-name interpretation), so text like
+  // "Enter" or "C-c" typed by the user is inserted as characters, not actions.
+  return ['send-keys', '-t', session, '-l', '--', text]
+}
+
+/**
+ * Build send-keys args for a named special key. Returns null if not allow-listed.
+ */
+export function specialKeyArgs(session: string, name: string): string[] | null {
+  const keys = resolveSpecialKey(name)
+  if (!keys) return null
+  return ['send-keys', '-t', session, ...keys]
+}
+
+// The scripted /login flow, split into the two phases Szabi described
+// (2026-06-03): 'start' opens the login picker and selects the subscription
+// option (which triggers the browser OAuth window / prints the URL); the user
+// then authorises in the browser; 'confirm' sends the trailing Enters that
+// finalise the session after the browser round-trip.
+//
+// Each phase is a list of steps: a special key, or a literal string, plus a
+// post-step delay (ms) so the TUI has time to render the next surface before
+// the next key lands. The executor runs these sequentially.
+export type LoginStep =
+  | { kind: 'literal'; text: string; delayMs: number }
+  | { kind: 'special'; key: string; delayMs: number }
+
+export function loginSequence(phase: 'start' | 'confirm'): LoginStep[] {
+  if (phase === 'start') {
+    return [
+      // Type the slash command and submit it.
+      { kind: 'literal', text: '/login', delayMs: 400 },
+      { kind: 'special', key: 'Enter', delayMs: 1500 },
+      // The login picker appears with the subscription option highlighted
+      // first; Enter accepts it and launches the browser OAuth.
+      { kind: 'special', key: 'Enter', delayMs: 300 },
+    ]
+  }
+  // confirm: the two trailing Enters after the user authorised in the browser.
+  return [
+    { kind: 'special', key: 'Enter', delayMs: 500 },
+    { kind: 'special', key: 'Enter', delayMs: 100 },
+  ]
+}

--- a/web/app.js
+++ b/web/app.js
@@ -9369,6 +9369,8 @@ function openTerminalModal(agentName) {
     cursorBlink: false,
     disableStdin: false,
     scrollback: 500,
+    convertEol: true,
+    allowProposedApi: true,
   })
   const fitAddon = new window.FitAddon.FitAddon()
   term.loadAddon(fitAddon)
@@ -9385,7 +9387,11 @@ function openTerminalModal(agentName) {
   sse.onmessage = (e) => {
     try {
       const msg = JSON.parse(e.data)
-      if (msg.pane !== undefined) term.write('\x1b[2J\x1b[H' + msg.pane)
+      if (msg.pane !== undefined) {
+        // Strip OSC-8 hyperlinks (not supported by xterm, cause visual noise)
+        const clean = msg.pane.replace(/\x1b]8;[^\x1b]*\x1b\\/g, '')
+        term.write('\x1b[2J\x1b[H' + clean)
+      }
     } catch {}
   }
   sse.onerror = () => term.write('\r\n[stream hiba vagy leállva]\r\n')

--- a/web/app.js
+++ b/web/app.js
@@ -9380,6 +9380,7 @@ function openTerminalModal(agentName) {
   terminalFit = fitAddon
 
   openModal(overlay)
+  setTimeout(() => term.focus(), 50)
 
   // SSE pane stream
   const token = localStorage.getItem('marveen-dashboard-token') || ''

--- a/web/app.js
+++ b/web/app.js
@@ -1470,7 +1470,16 @@ function renderAgents() {
         <span class="process-indicator" title="Fut: a fő asszisztens mindig a --channels session-ben fut. Ez a kártya fixen Fut állapotot mutat, nincs per-ágens tmux-ellenőrzés."><span class="process-dot running"></span>Fut</span>
         <span class="tg-status" title="Online: a fő asszisztens csatornáját a --channels session kezeli, ezért fixen online (nincs külön token-ellenőrzés)."><span class="tg-dot connected"></span>Online</span>
       </div>
+      <div class="agent-card-actions">
+        <button class="btn-secondary btn-compact agent-terminal-btn" title="Terminal">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+          Terminal
+        </button>
+      </div>
     `
+    mCard.querySelector('.agent-terminal-btn')?.addEventListener('click', (e) => {
+      e.stopPropagation(); openTerminalModal('marveen')
+    })
     mCard.addEventListener('click', () => openMarveenDetail())
     agentsGrid.insertBefore(mCard, addBtn)
   }

--- a/web/app.js
+++ b/web/app.js
@@ -1510,7 +1510,26 @@ function renderAgents() {
         <span class="process-indicator" title="${escapeHtml(processTip(isRunning))}"><span class="process-dot ${runDotClass}"></span>${runLabel}</span>
         <span class="tg-status" title="${escapeHtml(channelTip(chConnected))}"><span class="tg-dot ${chDotClass}"></span>${chLabel}</span>
       </div>
+      ${agent.needsReauth ? `
+        <div class="agent-reauth-banner">
+          <span class="agent-reauth-reason">${escapeHtml(agent.reauthReason || 'Újrabejelentkezés szükséges')}</span>
+          <button class="btn-danger btn-compact agent-login-btn" data-phase="start">Bejelentkezés</button>
+        </div>` : ''}
+      <div class="agent-card-actions">
+        <button class="btn-secondary btn-compact agent-terminal-btn" title="Terminal">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+          Terminal
+        </button>
+      </div>
     `
+    // Login button handler (start → confirm flow)
+    card.querySelectorAll('.agent-login-btn').forEach(btn => {
+      btn.addEventListener('click', (e) => { e.stopPropagation(); handleAgentLogin(agent.name, btn) })
+    })
+    // Terminal button
+    card.querySelector('.agent-terminal-btn')?.addEventListener('click', (e) => {
+      e.stopPropagation(); openTerminalModal(agent.name)
+    })
     card.addEventListener('click', () => openAgentDetail(agent.name))
     agentsGrid.insertBefore(card, addBtn)
   }
@@ -9292,6 +9311,128 @@ document.getElementById('ideaPromotePlan')?.addEventListener('click', () => prom
 document.getElementById('ideaStatusFilter')?.addEventListener('change', loadIdeasPage)
 document.getElementById('ideaCategoryFilter')?.addEventListener('change', loadIdeasPage)
 
+
+// === Agent reauth login flow ===
+async function handleAgentLogin(agentName, btn) {
+  const phase = btn.dataset.phase || 'start'
+  btn.disabled = true
+  const origText = btn.textContent
+  btn.textContent = phase === 'start' ? 'Indítás...' : 'Megerősítés...'
+  try {
+    const res = await fetch(`/api/agents/${encodeURIComponent(agentName)}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phase }),
+    })
+    if (!res.ok) { const err = await res.json().catch(() => ({})); throw new Error(err.error || 'HTTP ' + res.status) }
+    if (phase === 'start') {
+      btn.dataset.phase = 'confirm'
+      btn.textContent = 'Auth kész → Megerősít'
+      btn.disabled = false
+      showToast('Auth folyamat elindítva — engedélyezd a böngészőben, majd kattints Megerősít')
+    } else {
+      btn.textContent = 'Bejelentkezve'
+      showToast('Bejelentkezés sikeres')
+      setTimeout(() => loadAgents(), 1500)
+    }
+  } catch (e) {
+    showToast('Hiba: ' + (e.message || e))
+    btn.textContent = origText
+    btn.dataset.phase = 'start'
+    btn.disabled = false
+  }
+}
+
+// === Agent terminal modal (xterm.js) ===
+let terminalInstance = null
+let terminalSSE = null
+let terminalFit = null
+
+function openTerminalModal(agentName) {
+  const overlay = document.getElementById('terminalOverlay')
+  const container = document.getElementById('terminalContainer')
+  const title = document.getElementById('terminalModalTitle')
+  if (!overlay || !container) return
+
+  title.textContent = agentName + ' — Terminal'
+
+  // Cleanup previous
+  if (terminalSSE) { terminalSSE.close(); terminalSSE = null }
+  if (terminalInstance) { terminalInstance.dispose(); terminalInstance = null }
+  container.innerHTML = ''
+
+  // Init xterm
+  const term = new window.Terminal({
+    theme: { background: '#1a1a1a', foreground: '#e8e4da' },
+    fontFamily: 'JetBrains Mono, Menlo, monospace',
+    fontSize: 13,
+    cursorBlink: false,
+    disableStdin: false,
+    scrollback: 500,
+  })
+  const fitAddon = new window.FitAddon.FitAddon()
+  term.loadAddon(fitAddon)
+  term.open(container)
+  fitAddon.fit()
+  terminalInstance = term
+  terminalFit = fitAddon
+
+  openModal(overlay)
+
+  // SSE pane stream
+  const token = localStorage.getItem('marveen-dashboard-token') || ''
+  const sse = new EventSource(`/api/agents/${encodeURIComponent(agentName)}/pane/stream?token=${encodeURIComponent(token)}`)
+  sse.onmessage = (e) => {
+    try {
+      const msg = JSON.parse(e.data)
+      if (msg.pane !== undefined) term.write('\x1b[2J\x1b[H' + msg.pane)
+    } catch {}
+  }
+  sse.onerror = () => term.write('\r\n[stream hiba vagy leállva]\r\n')
+  terminalSSE = sse
+
+  // Input: regular chars
+  term.onData(data => {
+    fetch(`/api/agents/${encodeURIComponent(agentName)}/keys`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ keys: data }),
+    }).catch(() => {})
+  })
+
+  // Input: special keys
+  term.onKey(({ domEvent }) => {
+    const specialMap = {
+      'Enter': 'Enter', 'Escape': 'Escape',
+      'ArrowUp': 'Up', 'ArrowDown': 'Down', 'ArrowLeft': 'Left', 'ArrowRight': 'Right',
+      'Tab': domEvent.shiftKey ? 'S-Tab' : 'Tab',
+      'Backspace': 'BSpace',
+      'PageUp': 'PageUp', 'PageDown': 'PageDown',
+    }
+    let special = specialMap[domEvent.key]
+    if (!special && domEvent.ctrlKey) {
+      const ctrlMap = { c: 'C-c', d: 'C-d', u: 'C-u', l: 'C-l' }
+      special = ctrlMap[domEvent.key.toLowerCase()]
+    }
+    if (special) {
+      domEvent.preventDefault()
+      fetch(`/api/agents/${encodeURIComponent(agentName)}/keys`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ special }),
+      }).catch(() => {})
+    }
+  })
+
+  // Resize fit on modal resize
+  const ro = new ResizeObserver(() => { try { fitAddon.fit() } catch {} })
+  ro.observe(container)
+}
+
+document.getElementById('terminalClose')?.addEventListener('click', () => {
+  const overlay = document.getElementById('terminalOverlay')
+  if (overlay) closeModal(overlay)
+  if (terminalSSE) { terminalSSE.close(); terminalSSE = null }
+  if (terminalInstance) { terminalInstance.dispose(); terminalInstance = null }
+})
 ;(() => {
   function routeFromHash() {
     let pageId = decodeURIComponent((location.hash || '').replace(/^#/, ''))

--- a/web/app.js
+++ b/web/app.js
@@ -1470,16 +1470,7 @@ function renderAgents() {
         <span class="process-indicator" title="Fut: a fő asszisztens mindig a --channels session-ben fut. Ez a kártya fixen Fut állapotot mutat, nincs per-ágens tmux-ellenőrzés."><span class="process-dot running"></span>Fut</span>
         <span class="tg-status" title="Online: a fő asszisztens csatornáját a --channels session kezeli, ezért fixen online (nincs külön token-ellenőrzés)."><span class="tg-dot connected"></span>Online</span>
       </div>
-      <div class="agent-card-actions">
-        <button class="btn-secondary btn-compact agent-terminal-btn" title="Terminal">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
-          Terminal
-        </button>
-      </div>
     `
-    mCard.querySelector('.agent-terminal-btn')?.addEventListener('click', (e) => {
-      e.stopPropagation(); openTerminalModal('marveen')
-    })
     mCard.addEventListener('click', () => openMarveenDetail())
     agentsGrid.insertBefore(mCard, addBtn)
   }

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ClaudeClaw</title>
   <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/css/xterm.css">
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/lib/xterm.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10/lib/addon-fit.js"></script>
 </head>
 <body>
   <div class="mobile-topbar">
@@ -2170,6 +2173,16 @@
 
   <div class="toast" id="toast"></div>
 
+  <!-- Terminal modal -->
+  <div class="modal-overlay" id="terminalOverlay">
+    <div class="modal terminal-modal">
+      <div class="modal-header">
+        <h2 id="terminalModalTitle">Terminal</h2>
+        <button class="modal-close" id="terminalClose">&times;</button>
+      </div>
+      <div id="terminalContainer" style="background:#1a1a1a;padding:8px;border-radius:0 0 8px 8px;flex:1;min-height:360px;"></div>
+    </div>
+  </div>
   <script src="/app.js"></script>
 </body>
 </html>

--- a/web/style.css
+++ b/web/style.css
@@ -5190,3 +5190,50 @@ main {
   flex-shrink: 0;
 }
 .unread-preview { font-weight: 600; color: var(--text) !important; }
+
+/* === Agent reauth + terminal === */
+.agent-reauth-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+  border: 1px solid #ef4444;
+  border-radius: 6px;
+  padding: 6px 10px;
+  margin: 8px 0 0;
+}
+.agent-reauth-reason { font-size: 11px; color: #ef4444; font-weight: 600; flex: 1; }
+.btn-danger {
+  background: #ef4444;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.btn-danger:hover { background: #dc2626; }
+.btn-danger:disabled { opacity: 0.6; cursor: not-allowed; }
+.agent-card-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+.agent-terminal-btn { font-size: 11px; display: flex; align-items: center; gap: 4px; }
+
+/* Terminal modal */
+.terminal-modal {
+  max-width: 860px;
+  width: 96vw;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}
+.terminal-modal .modal-header { flex-shrink: 0; }
+#terminalContainer { flex: 1; min-height: 360px; }
+.xterm { height: 100% !important; }


### PR DESCRIPTION
Backend for the dashboard-ops feature Szabi requested on 2026-06-03 (kanban cd36ebf3). Frontend (badge, buttons, xterm.js modal) is a separate Zara change in `web/app.js`.

## Endpoints / contract (for the frontend)

- **`GET /api/agents`** — each agent now carries `needsReauth: boolean` (+ `reauthReason`). Running agents only.
- **`GET /api/agents/:name/pane/stream`** — SSE. Emits `data: {"pane": "<ansi>", "running": bool}` every 700ms (full-screen `capture-pane -e -p` snapshot; repaint per frame: `term.write('\x1b[2J\x1b[H' + pane)`). Token via `?token=` (EventSource can't set headers).
- **`POST /api/agents/:name/keys`** — `{keys:"..."}` (literal) or `{special:"Enter|Escape|Up|Down|C-c|..."}` (allow-list). 
- **`POST /api/agents/:name/login`** — `{phase:"start"}` types `/login` + accepts the subscription option (opens browser OAuth); after the user authorises in-browser, `{phase:"confirm"}` sends the trailing Enters.

## Design notes

- **No new dependencies.** SSE + `send-keys` over the existing http server instead of `node-pty` — a native build would add fleet install fragility (cf. #212). Trade-off: the terminal is a live screen *mirror* (perfect for Claude Code's full-screen TUI), not scrollback-streaming.
- **Security:** all gated by the dashboard token (SSE via a narrow constant-time `?token=` exception, SSE-GET only). `send-keys` special keys are an allow-list; literal text goes via `-l --` so leading-dash input can't be parsed as a flag.
- **No false badges:** `detectReauthNeeded` keys only on distinctive Claude Code auth-failure strings, never a bare `/login` mention.

## Test

`reauth-detect` (8) + `tmux-keys` (9) unit tests green; `tsc` clean. tmux send-keys (`-l --`, leading-dash-as-text, Enter) + `capture-pane -e -p` verified end-to-end on a throwaway session. Not deployed (prod dashboard restart is bundled into the promote window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)