### PR TITLE
feat(recovery): autonomous re-auth healer (detect + best-effort /login + escalate)

### DIFF
--- a/src/__tests__/reauth-healer.test.ts
+++ b/src/__tests__/reauth-healer.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { decideReauthAction, NO_REAUTH_STATE, type ReauthHealerState } from '../web/reauth-healer.js'
+
+const T = { threshold: 3, cooldownMs: 30 * 60 * 1000 }
+const base = (over: Partial<Parameters<typeof decideReauthAction>[0]> = {}) => ({
+  isDeadToken: true,
+  sessionAlive: true,
+  isMain: false,
+  prev: NO_REAUTH_STATE,
+  nowMs: 1_000_000,
+  ...over,
+})
+
+// Autonomous re-auth healer decision (Adam stability-fix #1). Conservative:
+// false-positive avoidance is the priority since the action injects /login.
+describe('decideReauthAction', () => {
+  it('clean token resets the spell, no action', () => {
+    const d = decideReauthAction(base({ isDeadToken: false, prev: { consecutiveDead: 2, lastActionAtMs: 5 } }), T)
+    expect(d.sendKeys).toBe(false)
+    expect(d.escalate).toBe(false)
+    expect(d.next).toEqual(NO_REAUTH_STATE)
+  })
+
+  it('dead session-gone resets the spell (capture-null treated as not-applicable)', () => {
+    const d = decideReauthAction(base({ sessionAlive: false, prev: { consecutiveDead: 2, lastActionAtMs: null } }), T)
+    expect(d.escalate).toBe(false)
+    expect(d.next.consecutiveDead).toBe(0)
+  })
+
+  it('debounces: 1st and 2nd dead probes do not act', () => {
+    const p1 = decideReauthAction(base({ prev: NO_REAUTH_STATE }), T)
+    expect(p1.escalate).toBe(false)
+    expect(p1.next.consecutiveDead).toBe(1)
+    const p2 = decideReauthAction(base({ prev: p1.next }), T)
+    expect(p2.escalate).toBe(false)
+    expect(p2.next.consecutiveDead).toBe(2)
+  })
+
+  it('3rd consecutive dead probe escalates + send-keys (sub-agent)', () => {
+    const d = decideReauthAction(base({ prev: { consecutiveDead: 2, lastActionAtMs: null }, nowMs: 2_000_000 }), T)
+    expect(d.escalate).toBe(true)
+    expect(d.sendKeys).toBe(true)
+    expect(d.next.lastActionAtMs).toBe(2_000_000)
+    expect(d.next.consecutiveDead).toBe(3)
+  })
+
+  it('main agent at threshold escalates but does NOT send-keys', () => {
+    const d = decideReauthAction(base({ isMain: true, prev: { consecutiveDead: 2, lastActionAtMs: null } }), T)
+    expect(d.escalate).toBe(true)
+    expect(d.sendKeys).toBe(false)
+  })
+
+  it('cooldown: still-dead within 30min does not re-fire', () => {
+    const lastActionAtMs = 1_000_000
+    const d = decideReauthAction(base({
+      prev: { consecutiveDead: 5, lastActionAtMs },
+      nowMs: lastActionAtMs + 10 * 60 * 1000, // 10 min later
+    }), T)
+    expect(d.escalate).toBe(false)
+    expect(d.sendKeys).toBe(false)
+    expect(d.next.lastActionAtMs).toBe(lastActionAtMs) // unchanged
+    expect(d.next.consecutiveDead).toBe(6) // keeps counting
+  })
+
+  it('cooldown: re-fires after 30min if still dead (does not forget)', () => {
+    const lastActionAtMs = 1_000_000
+    const d = decideReauthAction(base({
+      prev: { consecutiveDead: 12, lastActionAtMs },
+      nowMs: lastActionAtMs + 31 * 60 * 1000,
+    }), T)
+    expect(d.escalate).toBe(true)
+    expect(d.next.lastActionAtMs).toBe(lastActionAtMs + 31 * 60 * 1000)
+  })
+
+  it('a heal between dead spells lets the next spell alert immediately', () => {
+    // dead x3 -> alert
+    const a = decideReauthAction(base({ prev: { consecutiveDead: 2, lastActionAtMs: null } }), T)
+    expect(a.escalate).toBe(true)
+    // healed -> reset
+    const b = decideReauthAction(base({ isDeadToken: false, prev: a.next }), T)
+    expect(b.next).toEqual(NO_REAUTH_STATE)
+    // dead again x3 from fresh -> alerts again (lastActionAtMs was reset)
+    let s: ReauthHealerState = b.next
+    let last = { escalate: false } as { escalate: boolean }
+    for (let i = 0; i < 3; i++) { const r = decideReauthAction(base({ prev: s, nowMs: 9_000_000 }), T); s = r.next; last = r }
+    expect(last.escalate).toBe(true)
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -17,6 +17,7 @@ import { startInboundProber } from './web/inbound-probe.js'
 import { startChannelHealthMonitor } from './web/channel-health-monitor.js'
 import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
 import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
+import { startReauthHealer } from './web/reauth-healer.js'
 import { startAutoRestartRunner } from './web/auto-restart-runner.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
@@ -249,6 +250,9 @@ export function startWebServer(port = 3420): http.Server {
   const stuckToolCallInterval = startStuckToolCallWatcher()
   logger.info('Stuck-tool-call watcher started (30s poll, 35s offset)')
 
+  const reauthHealerInterval = startReauthHealer()
+  if (reauthHealerInterval) logger.info('Reauth healer started (3min poll, 90s offset)')
+
   const autoRestartInterval = startAutoRestartRunner()
   logger.info('Auto-restart runner started (60s poll, 40s offset)')
 
@@ -300,6 +304,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(channelHealthInterval)
     clearInterval(stuckInputInterval)
     clearInterval(stuckToolCallInterval)
+    if (reauthHealerInterval) clearInterval(reauthHealerInterval)
     clearInterval(autoRestartInterval)
     clearInterval(updateCheckerInterval)
     return origClose(cb)

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -1,0 +1,179 @@
+import { execFile } from 'node:child_process'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID, PROJECT_ROOT, RESPAWN_ENABLED } from '../config.js'
+import { resolveFromPath } from '../platform.js'
+import { listAgentNames } from './agent-config.js'
+import { isAgentRunning, capturePane } from './agent-process.js'
+import { resolveAgentSession } from './channel-mcp-reconnect.js'
+import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { detectReauthNeeded } from './reauth-detect.js'
+import { loginSequence, literalKeyArgs, specialKeyArgs } from './tmux-keys.js'
+
+// Autonomous re-auth healer (Adam stability-fix #1, scoped 2026-06-03).
+//
+// The watchdog only restarts MISSING sessions; the reauth badge only surfaces
+// the dead-token state in the dashboard. Neither acts on a session that is
+// ALIVE but whose OAuth token is dead (401) -- it silently stops working.
+//
+// There is NO magic full-heal for an expired OAuth: the /login flow needs a
+// human browser authorize step, and a restart yields another unauthenticated
+// session (cf. issue #248). So this loop is, honestly: autonomous DETECTION +
+// best-effort /login (which recovers only the rare transient/refreshable case)
+// + LOUD escalation to the owner via notify.sh (plugin-independent Bot API, so
+// it reaches the owner even when the channel plugin is also wedged).
+//
+// Scope (Marveen-approved): sub-agents get best-effort /login send-keys +
+// escalate; the MAIN agent (always-on channels session) is escalate-ONLY -- we
+// do not inject /login into a live conversation autonomously. Production-host
+// only (RESPAWN_ENABLED), like the other recovery loops.
+
+const TMUX = resolveFromPath('tmux')
+const NOTIFY_SCRIPT = join(PROJECT_ROOT, 'scripts', 'notify.sh')
+
+const PROBE_INTERVAL_MS = 3 * 60 * 1000 // 3 min
+const INITIAL_DELAY_MS = 90_000         // after boot-grace, offset from other watchers
+const DEAD_PROBE_THRESHOLD = 3          // ~9 min of consecutive dead-token probes before acting
+const ESCALATION_COOLDOWN_MS = 30 * 60 * 1000 // 1 alert / agent / 30 min (re-alerts if still dead)
+
+export interface ReauthHealerState {
+  consecutiveDead: number
+  lastActionAtMs: number | null
+}
+
+export interface ReauthHealerInput {
+  isDeadToken: boolean
+  sessionAlive: boolean
+  isMain: boolean
+  prev: ReauthHealerState
+  nowMs: number
+}
+
+export interface ReauthHealerThresholds {
+  threshold: number
+  cooldownMs: number
+}
+
+export interface ReauthHealerDecision {
+  sendKeys: boolean   // best-effort autonomous /login (sub-agents only)
+  escalate: boolean   // notify.sh alert to the owner
+  next: ReauthHealerState
+}
+
+export const NO_REAUTH_STATE: ReauthHealerState = { consecutiveDead: 0, lastActionAtMs: null }
+
+/**
+ * Pure decision for the healer. A clean probe (token healed, or session gone)
+ * resets the spell. A confirmed dead-token-but-alive session escalates once the
+ * consecutive count reaches `threshold`, then re-fires no more than once per
+ * `cooldownMs`. send-keys is gated to the same cadence (so /login is not spammed
+ * into the session every tick) and never fires for the main agent.
+ */
+export function decideReauthAction(input: ReauthHealerInput, t: ReauthHealerThresholds): ReauthHealerDecision {
+  const { isDeadToken, sessionAlive, isMain, prev, nowMs } = input
+
+  // Clean / not-applicable: end the spell, allow a fresh alert next time.
+  if (!isDeadToken || !sessionAlive) {
+    return { sendKeys: false, escalate: false, next: NO_REAUTH_STATE }
+  }
+
+  const consecutiveDead = prev.consecutiveDead + 1
+  const atThreshold = consecutiveDead >= t.threshold
+  const cooldownElapsed = prev.lastActionAtMs == null || (nowMs - prev.lastActionAtMs) >= t.cooldownMs
+  const fireNow = atThreshold && cooldownElapsed
+
+  return {
+    sendKeys: fireNow && !isMain,
+    escalate: fireNow,
+    next: {
+      consecutiveDead,
+      lastActionAtMs: fireNow ? nowMs : prev.lastActionAtMs,
+    },
+  }
+}
+
+const watchState = new Map<string, ReauthHealerState>()
+
+function sleep(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)) }
+
+// Fire-and-forget best-effort /login into a sub-agent session. Reuses the same
+// scripted sequence as the dashboard button (loginSequence('start')).
+async function sendBestEffortLogin(session: string): Promise<void> {
+  for (const step of loginSequence('start')) {
+    const args = step.kind === 'literal' ? literalKeyArgs(session, step.text) : specialKeyArgs(session, step.key)
+    if (args) {
+      await new Promise<void>((resolve) => {
+        execFile(TMUX, args, { timeout: 5000 }, () => resolve())
+      })
+    }
+    if (step.delayMs > 0) await sleep(step.delayMs)
+  }
+}
+
+function escalate(label: string, reason: string): void {
+  const msg = `🔐 A(z) ${label} ágens halott OAuth tokent jelez (${reason}) ~9 perce. Manuális browser /login kell a dashboardon (az ügynök kártyáján a "Bejelentkezés" gomb), automatikusan nem gyógyítható.`
+  execFile('/bin/bash', [NOTIFY_SCRIPT, msg], { timeout: 10_000 }, (err) => {
+    if (err) logger.warn({ err, label }, 'reauth-healer: notify.sh escalation failed')
+  })
+}
+
+function checkSession(label: string, session: string, isMain: boolean): void {
+  const pane = capturePane(session)
+  const sessionAlive = pane != null
+  const reauth = detectReauthNeeded(pane)
+  const prev = watchState.get(session) ?? NO_REAUTH_STATE
+
+  const decision = decideReauthAction(
+    { isDeadToken: reauth.needsReauth, sessionAlive, isMain, prev, nowMs: Date.now() },
+    { threshold: DEAD_PROBE_THRESHOLD, cooldownMs: ESCALATION_COOLDOWN_MS },
+  )
+
+  if (decision.next.consecutiveDead === 0) {
+    watchState.delete(session)
+  } else {
+    watchState.set(session, decision.next)
+  }
+
+  if (decision.sendKeys) {
+    logger.warn({ label, session }, 'reauth-healer: confirmed dead token on live sub-agent -- best-effort /login send-keys')
+    void sendBestEffortLogin(session)
+  }
+  if (decision.escalate) {
+    logger.error({ label, session, reason: reauth.reason }, 'reauth-healer: dead OAuth token on live session -- escalating to owner')
+    escalate(label, reauth.reason ?? 'auth failure')
+  }
+}
+
+export function startReauthHealer(): NodeJS.Timeout | null {
+  // Production-host only, like the other recovery loops: sending /login keys on
+  // a dev box would fight the production host (and there is nothing to heal).
+  if (!RESPAWN_ENABLED) {
+    logger.info('reauth-healer disabled (respawn is production-only)')
+    return null
+  }
+
+  function sweep(): void {
+    // Main agent: escalate-only (no autonomous /login into a live always-on
+    // conversation). capturePane returns null when it is down -> spell ends.
+    try {
+      checkSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, true)
+    } catch (err) {
+      logger.debug({ err }, 'reauth-healer: main agent check error')
+    }
+    for (const name of listAgentNames()) {
+      const session = resolveAgentSession(name)
+      if (!isAgentRunning(name)) {
+        watchState.delete(session)
+        continue
+      }
+      try {
+        checkSession(name, session, false)
+      } catch (err) {
+        logger.debug({ err, agent: name }, 'reauth-healer: agent check error')
+      }
+    }
+  }
+
+  setTimeout(sweep, INITIAL_DELAY_MS)
+  return setInterval(sweep, PROBE_INTERVAL_MS)
+}

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -110,8 +110,12 @@ async function sendBestEffortLogin(session: string): Promise<void> {
   }
 }
 
-function escalate(label: string, reason: string): void {
-  const msg = `🔐 A(z) ${label} ágens halott OAuth tokent jelez (${reason}) ~9 perce. Manuális browser /login kell a dashboardon (az ügynök kártyáján a "Bejelentkezés" gomb), automatikusan nem gyógyítható.`
+function escalate(label: string, reason: string, consecutiveDead: number): void {
+  // Dynamic duration: consecutiveDead probes at PROBE_INTERVAL_MS each. On a
+  // re-alert (after the 30min cooldown, still dead) this grows past the initial
+  // ~9min, so a hardcoded value would lie -- compute it from the probe count.
+  const approxMin = Math.round((consecutiveDead * PROBE_INTERVAL_MS) / 60_000)
+  const msg = `🔐 A(z) ${label} ágens halott OAuth tokent jelez (${reason}) több mint ~${approxMin} perce. Manuális browser /login kell a dashboardon (az ügynök kártyáján a "Bejelentkezés" gomb), automatikusan nem gyógyítható.`
   execFile('/bin/bash', [NOTIFY_SCRIPT, msg], { timeout: 10_000 }, (err) => {
     if (err) logger.warn({ err, label }, 'reauth-healer: notify.sh escalation failed')
   })
@@ -140,7 +144,7 @@ function checkSession(label: string, session: string, isMain: boolean): void {
   }
   if (decision.escalate) {
     logger.error({ label, session, reason: reauth.reason }, 'reauth-healer: dead OAuth token on live session -- escalating to owner')
-    escalate(label, reauth.reason ?? 'auth failure')
+    escalate(label, reauth.reason ?? 'auth failure', decision.next.consecutiveDead)
   }
 }
 


### PR DESCRIPTION
Adam stability-fix **#1** (scoped + approved by Marveen). Closes the gap between the watchdog (restarts only MISSING sessions) and the reauth badge (dashboard-only): a session that is **alive but whose OAuth token is dead (401)** silently stops working — nothing acted on it.

## Honest scope

There is **no magic full-heal** for an expired OAuth: `/login` needs a human browser authorize step, and a restart just yields another unauthenticated session (cf. #248). So this is: autonomous **detection** + **best-effort** `/login` (recovers only the rare transient/refreshable case) + **loud escalation** to the owner via `notify.sh` (plugin-independent Bot API → reaches the owner even when the channel plugin is also wedged).

## Behavior (Marveen-approved)

- Periodic 3-min `detectReauthNeeded` sweep over all sessions, **RESPAWN_ENABLED-gated** like the other recovery loops.
- Conservative: acts only after **3 consecutive dead-token probes** (~9 min) — false-positive avoidance is the priority since the action injects `/login`.
- **Sub-agents:** best-effort `/login` send-keys + escalate. **Main agent** (always-on channels session): **escalate-only** — no autonomous `/login` into a live conversation.
- Escalation cooldown: 1 alert / agent / 30 min (re-alerts if still dead; doesn't forget).
- A clean probe (token healed / session gone) resets the spell, so the next dead-spell can alert immediately.

## Design

- Pure `decideReauthAction()` holds all the logic (unit-tested without tmux). The module is I/O + a per-session state map, mirroring `stuck-input-watcher.ts`.
- Reuses `detectReauthNeeded` (tail-scan, no false-badge) and `loginSequence` (same scripted flow as the dashboard button).

## Test

`decideReauthAction` — 8 unit tests (debounce, threshold, main=escalate-only, cooldown floor + re-alert, heal-resets-spell). `tsc` clean.

Note: not deployed (activates on dashboard-restart, the existing gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)