### PR TITLE
heartbeat: make the dedicated heartbeat agent opt-in and config-driven

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import {
+  renderHeartbeatClaudeMd,
+  shouldBootHeartbeatAgent,
+  type HeartbeatIdentity,
+} from '../web/heartbeat-agent-scaffold.js'
+
+// A fully generic identity -- no real deployment values. The renderer is
+// pure, so every operator-specific string in its output must trace back to
+// one of these fields.
+const ID: HeartbeatIdentity = {
+  ownerName: 'Nina',
+  botName: 'Helios',
+  mainAgentId: 'helios',
+  storeDir: '/srv/app/store',
+  dashboardOrigin: 'http://localhost:3420',
+  calendarAccount: 'nina@example.com',
+}
+
+describe('renderHeartbeatClaudeMd', () => {
+  it('threads the owner name into the role + hard rules', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain("across Nina's systems")
+    expect(out).toContain('you NEVER contact Nina directly')
+  })
+
+  it('names the main agent as the relay target by display name', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('hand the result to the main agent (Helios)')
+  })
+
+  it('routes the inter-agent message to the main agent id', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('"to":"helios"')
+    // The sender is always the fixed heartbeat agent id.
+    expect(out).toContain('"from":"heartbeat"')
+  })
+
+  it('uses the supplied store dir (absolute) for the DB and token paths', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('/srv/app/store/claudeclaw.db')
+    expect(out).toContain('cat /srv/app/store/.dashboard-token')
+  })
+
+  it('uses the supplied dashboard origin for the messages API', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('http://localhost:3420/api/messages')
+  })
+
+  it('targets the configured calendar account when one is set', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('against `nina@example.com`')
+  })
+
+  it('falls back to the MCP primary calendar when no account is set', () => {
+    const out = renderHeartbeatClaudeMd({ ...ID, calendarAccount: '' })
+    expect(out).toContain('your primary calendar')
+    // No dangling "against `<empty>`" -- the empty case must not emit a
+    // backtick-quoted account at all.
+    expect(out).not.toContain('against `')
+    // The empty account is the shipped default, so the rendered file must
+    // then carry no email address whatsoever.
+    expect(out.match(/[\w.+-]+@[\w.-]+/g) ?? []).toEqual([])
+  })
+
+  it('emits no email beyond the configured calendar account', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // The configured account is the ONLY address allowed in the output;
+    // a previously hardcoded personal address would add a second one.
+    const emails = out.match(/[\w.+-]+@[\w.-]+/g) ?? []
+    expect(emails).toEqual(['nina@example.com'])
+  })
+
+  it('emits no absolute path outside the supplied store dir', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // The generic identity uses /srv/app/store; any leftover home-dir
+    // hardcode would surface as a /Users/ or /home/ path.
+    expect(out).not.toMatch(/\/Users\//)
+    expect(out).not.toMatch(/\/home\//)
+  })
+
+  it('carries no upstream default identity beyond the params', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // With a non-default owner/bot, the upstream default names must not
+    // leak through from any hardcoded string.
+    expect(out).not.toMatch(/Szabolcs|Szabi|Marveen/)
+  })
+
+  it('contains no em-dash (project style rule)', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // Build the em-dash (U+2014) via fromCharCode so this source file
+    // itself stays em-dash-free.
+    expect(out).not.toContain(String.fromCharCode(0x2014))
+  })
+
+  it('preserves the no-outbound-channel hard contract', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('**NEVER** call `reply` / Telegram / Slack tools.')
+    expect(out).toContain('You are headless')
+  })
+
+  it('is fully driven by the identity -- distinct configs render distinctly', () => {
+    const a = renderHeartbeatClaudeMd(ID)
+    const b = renderHeartbeatClaudeMd({
+      ownerName: 'Omar',
+      botName: 'Atlas',
+      mainAgentId: 'atlas',
+      storeDir: '/data/store',
+      dashboardOrigin: 'http://localhost:9000',
+      calendarAccount: '',
+    })
+    expect(a).not.toBe(b)
+    expect(b).toContain("across Omar's systems")
+    expect(b).toContain('"to":"atlas"')
+    expect(b).toContain('/data/store/claudeclaw.db')
+    expect(b).toContain('http://localhost:9000/api/messages')
+  })
+})
+
+describe('shouldBootHeartbeatAgent', () => {
+  it('boots only when respawn-enabled AND agent-enabled', () => {
+    expect(shouldBootHeartbeatAgent({ respawnEnabled: true, agentEnabled: true })).toBe(true)
+  })
+
+  it('does not boot when the agent is not opted in (default off)', () => {
+    expect(shouldBootHeartbeatAgent({ respawnEnabled: true, agentEnabled: false })).toBe(false)
+  })
+
+  it('does not boot on a respawn-gated-off host even if opted in', () => {
+    expect(shouldBootHeartbeatAgent({ respawnEnabled: false, agentEnabled: true })).toBe(false)
+  })
+
+  it('does not boot when both gates are off', () => {
+    expect(shouldBootHeartbeatAgent({ respawnEnabled: false, agentEnabled: false })).toBe(false)
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,5 +63,19 @@ export const RESPAWN_ENABLED =
 // Heartbeat
 export const HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
 export const HEARTBEAT_START_HOUR = 9
+
+// Dedicated channel-less `heartbeat` sub-agent (hourly summary worker).
+// OFF by default: a fresh or upgrading install must NOT silently spawn a
+// sub-agent that reads the operator's calendar and database. Opt in with
+// HEARTBEAT_AGENT_ENABLED=1 (it additionally requires the respawn gate
+// above, since the heartbeat has to run on exactly one host).
+export const HEARTBEAT_AGENT_ENABLED =
+  ['1', 'true', 'yes', 'on'].includes((env['HEARTBEAT_AGENT_ENABLED'] ?? '').trim().toLowerCase())
+
+// Google Calendar account the heartbeat summarises (next 2h). Empty (the
+// default) means the agent uses whatever calendar its MCP server is
+// authenticated as, so no personal address is baked into the shipped
+// scaffold.
+export const HEARTBEAT_CALENDAR_ACCOUNT = (env['HEARTBEAT_CALENDAR_ACCOUNT'] ?? '').trim()
 export const HEARTBEAT_END_HOUR = 23
 export const HEARTBEAT_CALENDAR_ID = env['HEARTBEAT_CALENDAR_ID'] ?? ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,11 @@ import {
 import { join } from 'node:path'
 import { execFileSync, execSync } from 'node:child_process'
 import type { Server as HttpServer } from 'node:http'
-import { STORE_DIR, PID_FILENAME, WEB_PORT, ALLOWED_CHAT_ID, MAIN_AGENT_ID, RESPAWN_ENABLED } from './config.js'
+import { STORE_DIR, PID_FILENAME, WEB_PORT, ALLOWED_CHAT_ID, MAIN_AGENT_ID, RESPAWN_ENABLED, HEARTBEAT_AGENT_ENABLED } from './config.js'
 import { initDatabase } from './db.js'
 import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
-import { ensureHeartbeatAgent, HEARTBEAT_AGENT_NAME } from './web/heartbeat-agent-scaffold.js'
+import { ensureHeartbeatAgent, shouldBootHeartbeatAgent, HEARTBEAT_AGENT_NAME } from './web/heartbeat-agent-scaffold.js'
 import { startAgentProcess } from './web/agent-process.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
@@ -439,10 +439,13 @@ async function main(): Promise<void> {
   // isolation-chain attempt). We keep the native module imported so other
   // code paths that reference its exports still compile, but we do NOT
   // start its scheduler.
-  // Only the respawn host runs the heartbeat sub-agent. On a gated-off machine
-  // (e.g. a dev box) we must not spawn it -- otherwise it would fight the
-  // production host over the channel, exactly what RESPAWN_ENABLED prevents.
-  if (RESPAWN_ENABLED) {
+  // The heartbeat sub-agent is OFF by default. It auto-starts only when it
+  // is explicitly opted in (HEARTBEAT_AGENT_ENABLED) AND this host owns the
+  // respawn gate -- a fresh or upgrading install must not silently spawn a
+  // sub-agent that reads the operator's calendar and DB, and a gated-off
+  // machine (e.g. a dev box) must not fight the production host over the
+  // channel.
+  if (shouldBootHeartbeatAgent({ respawnEnabled: RESPAWN_ENABLED, agentEnabled: HEARTBEAT_AGENT_ENABLED })) {
     ensureHeartbeatAgent()
     logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent scaffold ensured (channel-less, dashboard-hidden)')
     const heartbeatStart = startAgentProcess(HEARTBEAT_AGENT_NAME)
@@ -454,7 +457,7 @@ async function main(): Promise<void> {
       logger.warn({ error: heartbeatStart.error }, 'Heartbeat agent failed to start (legacy native heartbeat is NOT a fallback any more)')
     }
   } else {
-    logger.info('Heartbeat agent boot-start skipped (respawn disabled on this host)')
+    logger.info('Heartbeat agent boot-start skipped (set HEARTBEAT_AGENT_ENABLED=1 on the respawn host to enable)')
   }
 
   // Discord-only: ensure the operator-configured DISCORD_CHANNEL_ID is

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -1,36 +1,49 @@
 // Bootstrap helper for the dedicated `heartbeat` channel-less sub-agent.
 //
-// Background (Szabi 2026-06-02 14:09): the historical heartbeat path
-// (src/heartbeat.ts -- the natív hourly module that called the
-// claude-agent-sdk's runAgent() and notifyTelegram()) routinely crashed
-// Marveen's channel plugin within 2-3 minutes of every fire. After a
-// long isolation-chain attempt (#237 / #250 / #252 / #253 / #255) the
-// remaining failure mode was a TUI-level freeze in Marveen, suspected
-// to be caused by Marveen's own poller picking up the heartbeat's
+// Background (2026-06-02): the historical heartbeat path (src/heartbeat.ts
+// -- the native hourly module that called the claude-agent-sdk's
+// runAgent() and notifyTelegram()) routinely crashed the main agent's
+// channel plugin within 2-3 minutes of every fire. After a long
+// isolation-chain attempt (#237 / #250 / #252 / #253 / #255) the
+// remaining failure mode was a TUI-level freeze, suspected to be caused
+// by the main agent's own poller picking up the heartbeat's
 // `notifyTelegram` sendMessage as a regular inbound and entering a
 // tool-call loop on it.
 //
 // Architectural fix: stop calling the SDK from inside the dashboard
 // process. Run the heartbeat in a SEPARATE channel-less tmux agent
 // (named "heartbeat"), driven by the existing scheduled-task system,
-// and have IT send the formatted summary to Marveen via inter-agent
-// message rather than directly to Telegram. Marveen then decides if
-// it relays to Szabi -- so the heartbeat output never spawns a
-// Marveen-token sendMessage, never produces a self-inbound event, and
-// the channel plugin stays untouched.
+// and have IT send the formatted summary to the main agent via
+// inter-agent message rather than directly to Telegram. The main agent
+// then decides if it relays to the operator -- so the heartbeat output
+// never spawns a main-agent-token sendMessage, never produces a
+// self-inbound event, and the channel plugin stays untouched.
 //
-// This module is responsible for materialising the agent's directory
-// (gitignored under agents/) at dashboard boot time. The dir mirrors
-// the layout of the other channel-less agents:
+// This module materialises the agent's directory (gitignored under
+// agents/) when the heartbeat is enabled. The dir mirrors the layout of
+// the other channel-less agents:
 //   agents/heartbeat/
 //     ├── CLAUDE.md                       -- role/scope/output format
 //     ├── agent-config.json               -- model, profile, auth-mode
 //     ├── .claude/settings.json           -- channel plugins explicitly disabled
 //     └── .hidden-from-dashboard          -- listAgentNames() filter (#253)
+//
+// Nothing operator-specific is hardcoded here: the boot-time auto-start
+// is gated on HEARTBEAT_AGENT_ENABLED, and every identity baked into the
+// CLAUDE.md (owner, main-agent name, store path, calendar account) comes
+// from config via currentHeartbeatIdentity().
 
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { PROJECT_ROOT } from '../config.js'
+import {
+  PROJECT_ROOT,
+  STORE_DIR,
+  OWNER_NAME,
+  BOT_NAME,
+  MAIN_AGENT_ID,
+  WEB_PORT,
+  HEARTBEAT_CALENDAR_ACCOUNT,
+} from '../config.js'
 import { logger } from '../logger.js'
 
 const HEARTBEAT_AGENT_NAME = 'heartbeat'
@@ -56,7 +69,7 @@ const CHANNEL_PLUGIN_DISABLES = {
 // costs effectively nothing.
 //
 // authMode 'oauth' uses the host's Claude Code OAuth from the
-// Keychain -- the same auth Marveen and every other channel-less
+// Keychain -- the same auth the main agent and every other channel-less
 // sub-agent runs under. NO per-agent API key needed.
 const HEARTBEAT_AGENT_CONFIG = {
   model: 'claude-haiku-4-5',
@@ -64,55 +77,103 @@ const HEARTBEAT_AGENT_CONFIG = {
   securityProfile: 'standard',
 }
 
-// The CLAUDE.md prose. Single source of truth for the agent's behaviour
-// at every scheduled fire. Critical contract:
-//   - NEVER call the Telegram reply tool. The whole point is to keep
-//     the heartbeat output OUT of any bot-API call from this process,
-//     so Marveen's poller never sees a self-generated inbound.
-//   - The output goes to Marveen via inter-agent message. Marveen
-//     decides whether to relay it to Szabi on Telegram, in HER own
-//     session, with HER own context.
-//   - Structured-text format so Marveen can either parse or relay-
-//     verbatim depending on signal-to-noise.
-function renderClaudeMd(): string {
+// Per-deployment identity threaded into the rendered CLAUDE.md. Pulled
+// from config (see currentHeartbeatIdentity) so the shipped scaffold
+// carries no operator-specific calendar address, owner name, store path
+// or main-agent name.
+export interface HeartbeatIdentity {
+  // Whose systems the heartbeat summarises (OWNER_NAME).
+  ownerName: string
+  // The main agent's display name -- the relay target (BOT_NAME).
+  botName: string
+  // The main agent's id for inter-agent routing (MAIN_AGENT_ID).
+  mainAgentId: string
+  // Absolute path to store/ (holds the DB and the dashboard token).
+  storeDir: string
+  // Dashboard origin for the inter-agent message POST, e.g.
+  // http://localhost:3420.
+  dashboardOrigin: string
+  // Google Calendar account to summarise, or '' to let the calendar MCP
+  // server use whatever account it is authenticated as.
+  calendarAccount: string
+}
+
+// Build the identity from the live config. Kept separate from the pure
+// renderer so the renderer stays unit-testable without importing config.
+export function currentHeartbeatIdentity(): HeartbeatIdentity {
+  return {
+    ownerName: OWNER_NAME,
+    botName: BOT_NAME,
+    mainAgentId: MAIN_AGENT_ID,
+    storeDir: STORE_DIR,
+    dashboardOrigin: `http://localhost:${WEB_PORT}`,
+    calendarAccount: HEARTBEAT_CALENDAR_ACCOUNT,
+  }
+}
+
+// Pure boot gate. The heartbeat sub-agent must run on exactly one host
+// (the respawn gate) AND be explicitly opted in (HEARTBEAT_AGENT_ENABLED,
+// off by default) -- both are required before the dashboard scaffolds and
+// spawns it at boot.
+export function shouldBootHeartbeatAgent(opts: { respawnEnabled: boolean; agentEnabled: boolean }): boolean {
+  return opts.respawnEnabled && opts.agentEnabled
+}
+
+// The CLAUDE.md prose. Pure: every operator-specific value comes from the
+// supplied identity, so the same renderer produces a correct file on any
+// deployment and the unit tests can assert the output without fs or
+// config. Critical contract:
+//   - NEVER call the Telegram reply tool. The whole point is to keep the
+//     heartbeat output OUT of any bot-API call from this process, so the
+//     main agent's poller never sees a self-generated inbound.
+//   - The output goes to the main agent via inter-agent message; the main
+//     agent decides whether to relay it to the operator.
+//   - Structured-text format so the main agent can parse or relay verbatim
+//     depending on signal-to-noise.
+export function renderHeartbeatClaudeMd(id: HeartbeatIdentity): string {
+  const calendarTarget = id.calendarAccount
+    ? `against \`${id.calendarAccount}\``
+    : 'against your primary calendar (whatever account the calendar MCP server is authenticated as)'
   return `# Heartbeat agent
 
-You are the **heartbeat agent** — a dedicated, headless worker that
+You are the **heartbeat agent** -- a dedicated, headless worker that
 runs on the hourly schedule and produces a structured summary of
-what is happening across Szabolcs' systems right now. You ALWAYS
-hand the result to Marveen via inter-agent message; you NEVER
-contact Szabi directly.
+what is happening across ${id.ownerName}'s systems right now. You
+ALWAYS hand the result to the main agent (${id.botName}) via
+inter-agent message; you NEVER contact ${id.ownerName} directly.
 
-## Why this agent exists (Szabi 2026-06-02 14:09)
+## Why this agent exists
 
 The previous heartbeat ran from inside the dashboard process and
-called the Telegram Bot API directly. Every fire caused Marveen's
-channel plugin to fall over 2-3 minutes later -- the bot's outbound
-sendMessage was being read back as an inbound by Marveen's own
-poller and triggered a tool-call freeze. Splitting the heartbeat
-into its own channel-less agent (this one), wired to Marveen only
-through inter-agent message, removes the self-poll loop entirely.
+called the Telegram Bot API directly. Every fire caused the main
+agent's channel plugin to fall over 2-3 minutes later -- the bot's
+outbound sendMessage was being read back as an inbound by the main
+agent's own poller and triggered a tool-call freeze. Splitting the
+heartbeat into its own channel-less agent (this one), wired to the
+main agent only through inter-agent message, removes the self-poll
+loop entirely.
 
 ## What to do on every fire
 
 When you receive the heartbeat prompt:
 
 1. **Collect** the four data sources:
-   - **Calendar (next 2 hours)** — use the
-     \`mcp__server-google-calendar-mcp__list-events\` tool against
-     \`szota.szabolcs@gmail.com\`, timeMin=now, timeMax=now+2h.
+   - **Calendar (next 2 hours)** -- use the
+     \`mcp__server-google-calendar-mcp__list-events\` tool
+     ${calendarTarget}, timeMin=now, timeMax=now+2h.
      If the call fails (token revoked / 401), record the failure
-     reason rather than the events; Marveen can act on the failure.
-   - **Kanban** — read the SQLite DB at
-     \`/Users/marvin/ClaudeClaw/store/claudeclaw.db\`:
-     \`sqlite3 store/claudeclaw.db "SELECT status, COUNT(*) FROM
-     kanban_cards WHERE archived_at IS NULL GROUP BY status"\` for
-     counts, and grab the titles of cards where
+     reason rather than the events; the main agent can act on the
+     failure.
+   - **Kanban** -- read the SQLite DB at
+     \`${id.storeDir}/claudeclaw.db\`:
+     \`sqlite3 ${id.storeDir}/claudeclaw.db "SELECT status, COUNT(*)
+     FROM kanban_cards WHERE archived_at IS NULL GROUP BY status"\`
+     for counts, and grab the titles of cards where
      \`priority='urgent'\` or \`status='waiting'\`.
-   - **Scheduled tasks** — count active rows in
+   - **Scheduled tasks** -- count active rows in
      \`scheduled_tasks\` table; record \`next_run_at\` for the
      earliest upcoming one.
-   - **Memory + system** — DB file size, any \`category='hot'\`
+   - **Memory + system** -- DB file size, any \`category='hot'\`
      memories newer than 1 hour, plus presence of any
      \`status='warning'\` entries in the memory log.
 
@@ -122,7 +183,7 @@ When you receive the heartbeat prompt:
    ## Heartbeat YYYY-MM-DD HH:MM (Europe/Budapest)
 
    ### Calendar (next 2h)
-   - HH:MM — <summary> (<attendees>)
+   - HH:MM -- <summary> (<attendees>)
    - <or: "no upcoming events">
    - <or: "calendar fetch failed: <reason>">
 
@@ -142,19 +203,19 @@ When you receive the heartbeat prompt:
    - warnings: <none | comma-separated>
    \`\`\`
 
-3. **Send** that string to Marveen via the dashboard API:
+3. **Send** that string to the main agent via the dashboard API:
 
    \`\`\`bash
-   TOKEN=$(cat /Users/marvin/ClaudeClaw/store/.dashboard-token)
-   curl -s -X POST http://localhost:3420/api/messages \\
+   TOKEN=$(cat ${id.storeDir}/.dashboard-token)
+   curl -s -X POST ${id.dashboardOrigin}/api/messages \\
      -H "Content-Type: application/json" \\
      -H "Authorization: Bearer $TOKEN" \\
-     -d '{"from":"heartbeat","to":"marveen","content":"<the formatted text>"}'
+     -d '{"from":"heartbeat","to":"${id.mainAgentId}","content":"<the formatted text>"}'
    \`\`\`
 
 4. **Stop.** Do not Telegram-reply, do not Slack, do not message
-   anyone else. The handoff to Marveen is the entire job. Marveen
-   handles the human-facing relay decision.
+   anyone else. The handoff to the main agent is the entire job. The
+   main agent handles the human-facing relay decision.
 
 ## Hard rules (never break)
 
@@ -164,18 +225,18 @@ When you receive the heartbeat prompt:
   message body. The dashboard token in the example above goes in the
   Authorization header only.
 - **NEVER** keep the output longer than ~30 lines. If something does
-  not fit, write "<N> more …" and let Marveen ask for the long
-  form. Heartbeat is a status pulse, not a transcript.
+  not fit, write "<N> more ..." and let the main agent ask for the
+  long form. Heartbeat is a status pulse, not a transcript.
 - If a data source raises, record the failure reason in that
-  section's body and CONTINUE — partial output is fine, silence is
+  section's body and CONTINUE -- partial output is fine, silence is
   not.
 
 ## You are headless
 
 You do not own a Telegram channel and the operator never reaches you
 directly. The only inputs you ever process are heartbeat prompts
-from the scheduler. If you receive anything else, hand it off to
-Marveen with a brief "received off-pattern input, please advise"
+from the scheduler. If you receive anything else, hand it off to the
+main agent with a brief "received off-pattern input, please advise"
 note and stop.
 `
 }
@@ -194,7 +255,7 @@ function renderClaudeSettingsJson(): string {
 // re-rendered every boot for the same reason: the canonical source of
 // truth for the agent's instructions lives here, not on disk.
 const ALWAYS_WRITE: ReadonlyArray<readonly [string, () => string]> = [
-  ['CLAUDE.md', renderClaudeMd],
+  ['CLAUDE.md', () => renderHeartbeatClaudeMd(currentHeartbeatIdentity())],
   ['agent-config.json', renderAgentConfigJson],
   [join('.claude', 'settings.json'), renderClaudeSettingsJson],
 ] as const


### PR DESCRIPTION
## Why this matters

The dedicated channel-less `heartbeat` sub-agent auto-starts on every dashboard boot whenever the respawn gate is on (the single-host default). Two consequences fall out of that:

1. A fresh or upgrading install silently spawns a sub-agent that reads the operator's calendar and database, with no opt-in.
2. The scaffolded `agents/heartbeat/CLAUDE.md` bakes in one deployment's identity: a personal Google Calendar address, an absolute `/Users/<name>/...` store path, and hardcoded owner / main-agent names. Every other install then inherits those values on disk and re-renders them on each boot, so the agent points at someone else's calendar and a non-existent absolute path.

## Change

- New `HEARTBEAT_AGENT_ENABLED` env, **default off**. The boot block in `src/index.ts` now starts the heartbeat only when `shouldBootHeartbeatAgent({ respawnEnabled, agentEnabled })` is true, i.e. the host owns the respawn gate AND the heartbeat is explicitly enabled. The gate is a small pure, unit-tested function.
- `renderHeartbeatClaudeMd(id)` is now a pure function fed by `currentHeartbeatIdentity()`, which pulls the owner name (`OWNER_NAME`), the main-agent name/id (`BOT_NAME` / `MAIN_AGENT_ID`), the absolute store dir (`STORE_DIR`), the dashboard origin (`WEB_PORT`) and an optional `HEARTBEAT_CALENDAR_ACCOUNT` from config. No personal address, home-dir path or hardcoded name remains in the shipped scaffold; an empty calendar account renders "your primary calendar" with no address at all.

Files: `src/config.ts`, `src/index.ts`, `src/web/heartbeat-agent-scaffold.ts`, `src/__tests__/heartbeat-agent-scaffold.test.ts`.

## Scope / compatibility

- **Behaviour change for installs that relied on the auto-started heartbeat:** with the new default-off gate they set `HEARTBEAT_AGENT_ENABLED=1` on the respawn host to keep it (and `HEARTBEAT_CALENDAR_ACCOUNT=<account>` to pin the calendar).
- The heartbeat's runtime contract is unchanged: it still never calls a channel send tool, still hands its summary to the main agent over inter-agent message, and stays headless.
- Side fix: the Kanban instruction now uses the absolute store path in both the prose and the `sqlite3` command. The command was previously relative (`sqlite3 store/claudeclaw.db`) and would not have resolved from the agent's working dir.

## Test plan

- `npx tsc --noEmit` clean.
- New `src/__tests__/heartbeat-agent-scaffold.test.ts` (17 tests) covers:
  - the `shouldBootHeartbeatAgent` truth table (boots only when both gates are on; default-off holds);
  - identity threading (owner name, main-agent id in the routed message, absolute store paths, dashboard origin);
  - the set vs empty calendar-account branches;
  - regression guards that the rendered output carries no email beyond the configured account (and none at all for the empty default), no `/Users/` or `/home/` path, no leftover default identity name, and no em-dash;
  - that the hard behavioural contract (never reply/Telegram/Slack, headless) survives the rewrite.
- Full `src/` vitest suite green, except one pre-existing `managed-settings` failure that is unrelated to this change and also fails on `main`.

## Known limitations

- `HEARTBEAT_CALENDAR_ACCOUNT` is a single account; multi-calendar aggregation is out of scope.
- The dashboard origin is rendered as `http://localhost:<WEB_PORT>`. A `WEB_HOST` bound to a non-loopback address would make that wrong for a remote caller, but the heartbeat sub-agent always runs locally on the same host, so localhost is correct here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
