### PR TITLE
backup: derive the launchd-jobs glob from MAIN_AGENT_ID, not a hardcoded label

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -30,7 +30,7 @@ the Docker volumes (3) are **separate** and must be moved on their own.
 - `~/.claude/scheduled-tasks/**` — file-based scheduled tasks (SKILL.md + task-config.json)
 - `~/.claude/channels/*/.env` — MAIN orchestrator channel token
 - `~/.claude/channels/*/access.json`, `invites.json`, `approved/**` — pairing allowlist + approvals
-- `~/Library/LaunchAgents/com.gorcsevivan.*.plist` — launchd jobs
+- `~/Library/LaunchAgents/com.<MAIN_AGENT_ID>.*.plist` -- launchd jobs (the prefix is your `MAIN_AGENT_ID`, `marveen` by default)
 
 **(3) Docker volumes — NOT in the tarball, migrate separately**
 - `stack_influxdb-data`, `stack_influxdb-config` — InfluxDB 2.7 time-series (Loxone history)
@@ -110,11 +110,12 @@ the Docker volumes (3) are **separate** and must be moved on their own.
    their packages so the torch/whisper wheels are arm64, not the old Intel x86_64.
 7. **Fix + install the launchd jobs:**
    - If the user/home/repo path changed, edit each
-     `~/Library/LaunchAgents/com.gorcsevivan.*.plist` (`ProgramArguments`,
+     `~/Library/LaunchAgents/com.<MAIN_AGENT_ID>.*.plist` (`ProgramArguments`,
      `WorkingDirectory`, `StandardOutPath`, env `HOME`/`PATH`) to the new paths.
-   - Load them: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.gorcsevivan.<job>.plist`
-     (jobs: `channels`, `dashboard`, `channels-nightly-restart`, `hosttemp`,
-     `poller-watchdog`, `session-limit-watchdog`).
+     The label prefix is your `MAIN_AGENT_ID` (`marveen` by default).
+   - Load them: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.<MAIN_AGENT_ID>.<job>.plist`
+     (the core jobs are `channels` and `dashboard`; load any other
+     `com.<MAIN_AGENT_ID>.*` jobs you run too).
 8. **Grant macOS permissions (TCC):** the first time the new processes need
    Full Disk Access / Automation / Accessibility, macOS silently blocks them
    until granted in System Settings → Privacy & Security. Grant Full Disk
@@ -126,10 +127,10 @@ the Docker volumes (3) are **separate** and must be moved on their own.
 ## 4. Cutover (the irreversible step — do last)
 
 1. On the OLD machine: stop everything that polls a bot token, in this order:
-   `launchctl bootout gui/$(id -u)/com.gorcsevivan.channels` (and the dashboard,
+   `launchctl bootout gui/$(id -u)/com.<MAIN_AGENT_ID>.channels` (and the dashboard,
    watchdogs), then confirm no `bun server.ts` / poller is left
    (`pgrep -fl "claude .*--channels"`). Leaving the old poller alive = 409 on the new one.
-2. On the NEW machine: start `com.gorcsevivan.channels` (and dashboard). Confirm
+2. On the NEW machine: start `com.<MAIN_AGENT_ID>.channels` (and dashboard). Confirm
    a fresh poller: `pgrep -P <channels_pid>` shows a `bun` child, `bot.pid`
    appears, `getWebhookInfo` `pending_update_count` drains to 0.
 3. Send a test Telegram message → it must reach the new fleet and get a reply.
@@ -179,5 +180,5 @@ the Docker volumes (3) are **separate** and must be moved on their own.
 - [ ] Pairing intact: previously-approved chats still allowed (no re-pairing).
 - [ ] InfluxDB has the history: a Flux `count()` over the Loxone measurement
       matches the old machine; Grafana dashboards render.
-- [ ] All six launchd jobs are loaded: `launchctl list | grep gorcsevivan`.
+- [ ] All your launchd jobs are loaded: `launchctl list | grep com.<MAIN_AGENT_ID>`.
 - [ ] Old machine's pollers are fully stopped (no 409).

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -18,7 +18,7 @@
 #     .claude/scheduled-tasks/**   (file-based scheduled tasks: SKILL.md + config)
 #     .claude/channels/*/.env      (MAIN orchestrator channel token)
 #     .claude/channels/*/access.json, invites.json, approved/**  (pairing state)
-#     Library/LaunchAgents/com.gorcsevivan.*.plist (launchd jobs)
+#     Library/LaunchAgents/com.<MAIN_AGENT_ID>.*.plist (launchd jobs)
 #
 # Output: backups/claudeclaw-YYYYmmdd-HHMMSS.tar.gz
 # Retention: keeps the most recent 14 archives, prunes the rest.
@@ -87,9 +87,22 @@ if [[ -d "${HOME}/.claude/channels" ]]; then
       -print ) >> "${HOMELIST}"
   ( cd "${HOME}" && find .claude/channels -maxdepth 2 -type d -name 'approved' -print ) >> "${HOMELIST}"
 fi
-# launchd jobs for this fleet.
+# launchd jobs for this fleet. The job labels are com.<MAIN_AGENT_ID>.<service>
+# (see src/web/main-agent.ts), so resolve MAIN_AGENT_ID the way the app does
+# (src/env.ts: read from .env, default "marveen" when unset) instead of
+# hardcoding one deployment's prefix. Parsing mirrors env.ts: last definition
+# wins, surrounding matching quotes stripped.
+MAIN_AGENT_ID="marveen"
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+  # `|| true`: with `set -o pipefail`, a no-match grep would otherwise fail the
+  # whole substitution (and, under `set -e`, abort the backup) on any install
+  # that leaves MAIN_AGENT_ID unset and relies on the "marveen" default.
+  _mid="$(grep -E '^[[:space:]]*MAIN_AGENT_ID[[:space:]]*=' "${REPO_ROOT}/.env" | tail -1 \
+    | sed -E 's/^[^=]*=[[:space:]]*//; s/[[:space:]]*$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/' || true)"
+  [[ -n "${_mid}" ]] && MAIN_AGENT_ID="${_mid}"
+fi
 if [[ -d "${HOME}/Library/LaunchAgents" ]]; then
-  ( cd "${HOME}" && find Library/LaunchAgents -maxdepth 1 -name 'com.gorcsevivan.*.plist' -print ) >> "${HOMELIST}"
+  ( cd "${HOME}" && find Library/LaunchAgents -maxdepth 1 -name "com.${MAIN_AGENT_ID}.*.plist" -print ) >> "${HOMELIST}"
 fi
 
 if [[ ! -s "${REPOLIST}" && ! -s "${HOMELIST}" ]]; then


### PR DESCRIPTION
## Why this matters

`scripts/backup.sh` hardcoded the launchd-jobs backup glob to one deployment's launchd label (`com.<that-deployment>.*.plist`). On every other install that glob matches **zero** files, so the fleet's launchd jobs (`com.<MAIN_AGENT_ID>.channels`, `com.<MAIN_AGENT_ID>.dashboard`, and any others) are silently dropped from the archive. That is exactly the silent-loss failure the backup is meant to prevent: a restore from such an archive comes up with no launchd jobs and no obvious sign anything is missing.

## Change

- Resolve `MAIN_AGENT_ID` from `.env` the way the app already does (`src/env.ts`: last definition wins, surrounding matching quotes stripped; default `marveen` when unset), and glob `com.${MAIN_AGENT_ID}.*.plist`. That matches how `src/web/main-agent.ts` constructs the job labels (`com.<MAIN_AGENT_ID>.<service>.plist`).
- The `.env` read is guarded with `|| true` so that a no-match lookup cannot abort the backup under `set -euo pipefail` on an install that leaves `MAIN_AGENT_ID` at its default.
- `docs/MIGRATION.md` is updated to use the `com.<MAIN_AGENT_ID>` placeholder in the same spots (inventory, launchd install, cutover, verification checklist).

Files: `scripts/backup.sh`, `docs/MIGRATION.md`.

## Scope / compatibility

- **No behaviour change** for an install whose `MAIN_AGENT_ID` already resolves to the previously hardcoded value: it still globs the same plists.
- Installs that left `MAIN_AGENT_ID` unset fall back to `com.marveen.*.plist`, consistent with the app default.
- macOS (bsdtar / BSD userland) and Linux (GNU) both supported: the new commands use the portable `grep -E` / `sed -E` spellings and the POSIX `[[:space:]]` class.

## Test plan

- `bash -n scripts/backup.sh` clean.
- On a box whose `MAIN_AGENT_ID` is not the hardcoded one, the old glob matched **0** launchd plists while the new glob matches the real `com.<MAIN_AGENT_ID>.channels` / `.dashboard` plists; a full `backup.sh` run was confirmed to place both under `home/Library/LaunchAgents/` in the archive (and in `MANIFEST.txt`).
- `MAIN_AGENT_ID` resolution checked for the unset (-> `marveen`), set, and quoted cases, all under `set -euo pipefail` (no abort on a no-match read).
- `docs/MIGRATION.md` has no remaining hardcoded label and no em-dash on changed lines.

## Known limitations

- The shell-side `.env` parse diverges from `src/env.ts` only on pathological values (a trailing inline `#` comment after the value, inner-space-padded quotes, or an explicitly empty `MAIN_AGENT_ID=`). None of those are valid agent slugs (the installer derives the id as NFKD / ASCII / lowercase-dash), so none affect real glob matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
