### PR TITLE
fix(ledger-replay): derive owner name from OWNER_NAME, not hardcoded "Gyula"

### DIFF
--- a/scripts/hooks/ledger-replay.py
+++ b/scripts/hooks/ledger-replay.py
@@ -54,9 +54,11 @@ def main():
     if not rows and not open_q:
         sys.exit(0)  # nothing to replay
 
+    owner = ledger_lib.owner_name()
+
     transcript = []
     for direction, chat_id, text, ts in rows:
-        who = "Gyula" if direction == "in" else "Te"
+        who = owner if direction == "in" else "Te"
         snippet = (text or "").strip().replace("\n", " ")
         transcript.append(f'  [{ts}] {who}: "{snippet}"')
 
@@ -78,7 +80,7 @@ def main():
         chat_id, message_id, text, ts = open_q
         snippet = (text or "").strip().replace("\n", " ")
         parts.append(
-            f'NYITOTT KÉRDÉS (még NEM válaszoltad meg): Gyula utolsó üzenete '
+            f'NYITOTT KÉRDÉS (még NEM válaszoltad meg): {owner} utolsó üzenete '
             f'(chat {chat_id}, message_id {message_id}): "{snippet}". Válaszolj rá '
             f'MOST a telegram reply tool (mcp__plugin_telegram_telegram__reply) '
             f'meghívásával a megfelelő chat_id-re, a fenti kontextusból folytatva.'

--- a/scripts/hooks/ledger_lib.py
+++ b/scripts/hooks/ledger_lib.py
@@ -67,6 +67,29 @@ def main_agent_id():
     return "marveen"
 
 
+def owner_name():
+    """The human owner's display name, used to label inbound turns in the
+    replayed conversation context. Same resolution order as main_agent_id():
+    OWNER_NAME env var first, then the install-dir .env (channels.sh does NOT
+    export OWNER_NAME into the hook environment, so the .env file is the path
+    that actually fires at runtime), finally a neutral default. Never hardcode
+    a specific person -- every install configures its own OWNER_NAME, so a
+    baked-in name (e.g. "Gyula") leaks the wrong name into every user's agent."""
+    v = os.environ.get("OWNER_NAME")
+    if v and v.strip():
+        return v.strip()
+    try:
+        with open(os.path.join(_install_dir(), ".env")) as f:
+            for line in f:
+                if line.startswith("OWNER_NAME="):
+                    name = line.split("=", 1)[1].strip()
+                    if name:
+                        return name
+    except Exception:
+        pass
+    return "A felhasználó"
+
+
 def agent_id_from_cwd(cwd):
     """Which channel agent is this session? Derived from cwd so the hooks are
     generic across all three agents and never cross-contaminate:


### PR DESCRIPTION
Fixes #282.

## Probléma
A `scripts/hooks/ledger-replay.py` SessionStart hook minden bejövő beszélgetés-fordulót (és a kiemelt OPEN QUESTION sort) egy bedrótozott `"Gyula"` névvel címkézte. A script **commitolva** szállítódik (nem template), így minden telepítés ezt a literál nevet injektálta a saját agentje kontextusába, a beállított owner-névtől függetlenül. Egy `Béla` nevű felhasználó a saját agentje replay-kontextusában `"Gyula utolsó üzenete..."`-t látott (#282, reporter: @v8tom).

## Fix
Új `ledger_lib.owner_name()` helper, ugyanazzal a feloldási sorrenddel mint a meglévő `main_agent_id()`:
1. `OWNER_NAME` env var
2. install-dir `.env` (`OWNER_NAME=` sor)
3. neutrális `"A felhasználó"` default

A `channels.sh` szándékosan **nem** exportálja az `OWNER_NAME`-et a hook környezetébe (hogy ne szivárogjon secret a `.env`-ből), ezért futásidőben a `.env`-olvasás az a path ami ténylegesen érvényesül — pontosan úgy mint a `MAIN_AGENT_ID`-nél. A transcript speaker-label ÉS az OPEN QUESTION mondat is a feloldott nevet használja.

## Teszt
- `OWNER_NAME` override → a label a megadott név
- env unset → `.env` fallback (`OWNER_NAME=Szabolcs`) → `Szabolcs`
- mindkettő hiányzik → `A felhasználó`
- end-to-end seed-elt ledgerrel: bejövő fordulók + OPEN QUESTION a konfigurált nevet kapják, **0 db `Gyula`** marad a kimenetben
- hibás DB → no-op, exit 0 (nem töri a session-startot)

## Nem érint
Csak a két hook-fájl (`ledger_lib.py`, `ledger-replay.py`). Nincs séma-/viselkedésváltozás a no-op és token-guard utakon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)