### PR TITLE
fix(channels): in-session plugin-liveness watchdog (dashboard-independent backstop)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 node_modules/
 dist/
 
+# Python bytecode cache (e.g. scripts/hooks/__pycache__/*.pyc)
+__pycache__/
+*.pyc
+
 # Secrets & personal data
 .env
 store/

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -298,9 +298,67 @@ fi
 # instead of tight-looping and burning API tokens.
 START_TS=$(date +%s)
 
+# Plugin liveness watchdog (main channels session only) -- a last-resort
+# backstop UNDER the dashboard channel-monitor, not a replacement. The monitor
+# is the primary recovery, but its down-state lives in dashboard process
+# memory: a plugin that dies WHILE THE DASHBOARD ITSELF IS RESTARTING is missed
+# (the in-memory state machine resets and never re-detects it). This in-session
+# shell watchdog is independent of the dashboard. If the channel bot process
+# (tracked via the plugin's bot.pid) never comes up, OR comes up and then stays
+# dead, we exit so the service manager (launchd/systemd) restarts us with a
+# fresh Claude + plugin.
+#
+# Thresholds are deliberately COARSER than the dashboard monitor's (~60-120s)
+# so in normal operation the dashboard acts FIRST and this only fires when the
+# dashboard couldn't -- avoids double-restart races. bot.pid lives at the
+# main-agent channelStateDir(): ~/.claude/channels/<provider>/bot.pid (HOME-,
+# not INSTALL_DIR-relative; see src/channel-provider.ts channelStateDir()).
+MAIN_BOT_PID_FILE="$HOME/.claude/channels/$CHANNEL_PROVIDER/bot.pid"
+# Never-started budget: generous so a slow cold-start (WSL first-run, MCP
+# handshake + /mcp unlock retries) is never killed prematurely. The plugin
+# normally writes bot.pid within ~1-2 min; 10 min is a safe ceiling.
+PLUGIN_NEVER_STARTED_DEADLINE=$((START_TS + 600))
+# Died-after-up budget: once we have seen the plugin alive, a continuous
+# disappearance this long means it crashed and is not self-recovering.
+PLUGIN_DEAD_GRACE=180
+PLUGIN_SEEN_ONCE=false
+PLUGIN_DEAD_SINCE=0
+
 # Várakozás amíg a session él
 while $TMUX has-session -t "$SESSION" 2>/dev/null; do
   sleep 5
+
+  NOW=$(date +%s)
+  _plugin_alive=false
+  if [ -f "$MAIN_BOT_PID_FILE" ]; then
+    _bot_pid=$(cat "$MAIN_BOT_PID_FILE" 2>/dev/null | tr -d '[:space:]')
+    if [ -n "$_bot_pid" ] && [ "$_bot_pid" -gt 1 ] 2>/dev/null && kill -0 "$_bot_pid" 2>/dev/null; then
+      _plugin_alive=true
+    fi
+  fi
+  unset _bot_pid
+
+  if [ "$_plugin_alive" = "true" ]; then
+    PLUGIN_SEEN_ONCE=true
+    PLUGIN_DEAD_SINCE=0
+  elif [ "$PLUGIN_SEEN_ONCE" = "true" ]; then
+    # Was up, now gone -- start/continue the dead-grace timer (a transient
+    # gap that recovers resets it, so only a sustained death triggers exit).
+    if [ "$PLUGIN_DEAD_SINCE" -eq 0 ]; then
+      PLUGIN_DEAD_SINCE=$NOW
+      echo "WARN: $CHANNEL_PROVIDER plugin (bot.pid) disappeared -- ${PLUGIN_DEAD_GRACE}s grace before restart" >&2
+    elif [ "$((NOW - PLUGIN_DEAD_SINCE))" -ge "$PLUGIN_DEAD_GRACE" ]; then
+      echo "WARN: $CHANNEL_PROVIDER plugin dead for $((NOW - PLUGIN_DEAD_SINCE))s -- exiting for service-manager restart" >&2
+      break
+    fi
+  else
+    # Never came up at all (e.g. a Claude Code build that silently disables
+    # --channels). Give it the full cold-start budget, then restart.
+    if [ "$NOW" -ge "$PLUGIN_NEVER_STARTED_DEADLINE" ]; then
+      echo "WARN: $CHANNEL_PROVIDER plugin never started within $((PLUGIN_NEVER_STARTED_DEADLINE - START_TS))s -- exiting for service-manager restart" >&2
+      break
+    fi
+  fi
 done
 
 ELAPSED=$(( $(date +%s) - START_TS ))


### PR DESCRIPTION
Cherry-picked **Piece B** value from the #289 fork PR — clean reimplementation, channels.sh only, **without** the fork-state dump (no package-lock churn, no persona/email/zoho/slack files, no committed .pyc).

## Mit csinál
A dashboard `channel-monitor` az elsődleges channel-plugin recovery, DE a down-state a dashboard process memóriájában él: egy plugin ami **a dashboard saját újraindulása ALATT** hal meg, kimarad (a memóriabeli state-machine resetel, és többé nem detektálja). Ez egy **dashboard-független** in-session shell watchdog a `channels.sh` wait-loopban.

A main-agent `bot.pid`-et figyeli (`~/.claude/channels/<provider>/bot.pid` — a homedir-alapú `channelStateDir()`, egyezik a `src/channel-provider.ts`-szel és a `verify-channels-health.sh`-val). Kilép (→ launchd/systemd friss Claude+plugin restart), ha:
- a plugin **600s-ig el sem indul** (elkapja a Claude Code buildeket amik némán letiltják a `--channels`-t). A budget szándékosan bőkezű, hogy egy lassú **WSL first-run cold-start** soha ne haljon meg idő előtt.
- a plugin **elindult, majd 180s-ig folyamatosan halott** (egy tranziens, magától helyreálló rés reseteli a timert, így csak tartós halál vált ki kilépést).

## Miért biztonságos (nincs double-restart race)
A küszöbök **szándékosan durvábbak** mint a dashboard monitoré (~60-120s): normál működésben a dashboard cselekszik ELŐSZÖR, így ez csak akkor sül el ha a dashboard nem tudott. A `break` után `ELAPSED >> 30`, tehát a normál `exit 0` ágra fut (nem számít rapid-failure-nek, nincs backoff-akkumuláció).

## WSL-safe deadline (Marveen kérése)
A fork eredeti 300s never-started deadline-ja túl szoros volt lassú cold-startra → **600s**-re emeltem. Died-after-up grace **180s**.

## Teszt
- Standalone harness mindhárom ágra: `alive` → nincs kilépés; `never-started` → kilépés a deadline-nél; `alive-then-dead` → kilépés a grace után.
- `bash -n scripts/channels.sh` tiszta.

## Scope
Csak `scripts/channels.sh` (+ `.gitignore`: `__pycache__/` + `*.pyc`, hogy a `scripts/hooks/` bytecode-cache ne kerülhessen be véletlenül — ez a #289 commitolt `.pyc` gyökeroka). Semmi más fájl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)