### PR TITLE
fix(channel-monitor): recover a channel message stranded at the prompt (stuck-input watchdog)

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -9,6 +9,7 @@ import {
   decidePaneErrorAlert,
   stuckInputSignature,
   decideStuckInputRecovery,
+  parkedChannelInput,
 } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
@@ -1236,5 +1237,66 @@ describe('decideStuckInputRecovery', () => {
     expect(d.next.firstSeenAt).toBe(500_000)
     expect(d.next.lastRecoverAt).toBe(null)
     expect(d.next.attempts).toBe(0)
+  })
+})
+
+describe('parkedChannelInput (stuck channel-block gate + truncation guard)', () => {
+  const SEP = '─'.repeat(80)
+  const wrap = (boxLines: string[]) =>
+    ['', SEP, ...boxLines, SEP, '  ⏵⏵ bypass permissions on (shift+tab to cycle)'].join('\n')
+
+  it('returns null when the pane is idle (nothing parked)', () => {
+    expect(parkedChannelInput(wrap(['❯ ']))).toBeNull()
+  })
+
+  it('returns null for a HUMAN hand-typed draft (no <channel> marker) -- never touched', () => {
+    expect(parkedChannelInput(wrap(['❯ Valami amit a felhasznalo elkezdett geppelni']))).toBeNull()
+  })
+
+  it('extracts a COMPLETE single-line parked channel block with chat_id', () => {
+    const pane = wrap(['❯ <channel source="plugin:telegram:telegram" chat_id="1268077055" message_id="999" ts="2026-06-05T10:00:00Z">Szia, mi a helyzet?</channel>'])
+    const r = parkedChannelInput(pane)
+    expect(r).not.toBeNull()
+    expect(r!.complete).toBe(true)
+    expect(r!.chatId).toBe('1268077055')
+    expect(r!.block).toContain('</channel>')
+    expect(r!.block).toContain('chat_id="1268077055"')
+  })
+
+  it('reconstructs a wrapped multi-line block when chat_id stays intact', () => {
+    // Terminal wrap splits message_id but NOT chat_id -> still recoverable.
+    const pane = wrap([
+      '❯ <channel source="plugin:telegram:telegram" chat_id="1268077055" mess',
+      'age_id="999" ts="2026-06-05T10:00:00Z">Hosszu uzenet ami tobb sorba',
+      'tordelodott a terminal szelessegen.</channel>',
+    ])
+    const r = parkedChannelInput(pane)
+    expect(r).not.toBeNull()
+    expect(r!.complete).toBe(true)
+    expect(r!.chatId).toBe('1268077055')
+  })
+
+  it('flags complete:false when the closing </channel> scrolled off (truncated)', () => {
+    const pane = wrap(['❯ <channel source="plugin:telegram:telegram" chat_id="1268077055" ts="2026-06-05T10:00:00Z">Az uzenet vege lescrollozott es nincs zaro tag'])
+    const r = parkedChannelInput(pane)
+    expect(r).not.toBeNull()
+    expect(r!.complete).toBe(false)
+    expect(r!.chatId).toBeNull()
+  })
+
+  it('flags complete:false when a wrap corrupts chat_id with embedded whitespace', () => {
+    // Wrap landed INSIDE the chat_id value -> "126 8077055" after collapse.
+    const pane = wrap([
+      '❯ <channel source="plugin:telegram:telegram" chat_id="126',
+      '8077055" message_id="999">Test</channel>',
+    ])
+    const r = parkedChannelInput(pane)
+    expect(r).not.toBeNull()
+    expect(r!.complete).toBe(false) // refuse re-inject; caller stays on Enter
+    expect(r!.chatId).toBeNull()
+  })
+
+  it('returns null for a non-plugin channel marker (defensive)', () => {
+    expect(parkedChannelInput(wrap(['❯ <channel source="other:thing" chat_id="1">x</channel>']))).toBeNull()
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -588,6 +588,49 @@ export function stuckInputSignature(pane: string): string | null {
   return sig.length > 0 ? sig : null
 }
 
+export interface ParkedChannelInput {
+  /** True only when the parked block is captured intact -- opening
+   * <channel source="plugin:..."> tag WITH a chat_id AND a closing
+   * </channel>. False when the box holds a channel block whose header has
+   * scrolled/truncated out of the capture (chat_id unrecoverable), so a
+   * caller must NOT verbatim re-inject it (a partial re-inject could answer
+   * the wrong chat_id -- worse than a delayed submit). */
+  complete: boolean
+  /** The complete <channel>...</channel> block, whitespace-collapsed, when
+   * complete; null when truncated. Safe to re-inject verbatim. */
+  block: string | null
+  /** The recovered chat_id when complete; null otherwise. */
+  chatId: string | null
+}
+
+// Classify the live input box as a stranded CHANNEL notification, or null
+// when it is not ours to touch. Returns null when the pane is not parked
+// ('typing'), the box is empty, OR the parked text is a HUMAN's own
+// hand-typed draft (no <channel source="plugin:..."> marker) -- the
+// stuck-input watcher must leave a human draft alone. When a channel block
+// IS parked, the `complete` flag is the truncation-guard: only a complete
+// capture (header + chat_id + closing tag present) is safe to re-inject.
+//
+// The captured box is whitespace-collapsed first because liveInputBox()
+// preserves the terminal-wrap newlines, which would otherwise split the
+// <channel> tag attributes across lines and defeat the match.
+export function parkedChannelInput(pane: string): ParkedChannelInput | null {
+  if (detectPaneState(pane) !== 'typing') return null
+  const box = liveInputBox(pane)
+  if (box == null) return null
+  const flat = box.replace(/\s+/g, ' ').trim()
+  if (!/<channel\s+source="plugin:/.test(flat)) return null // human draft -> not ours
+  const m = flat.match(/<channel\s+source="plugin:[^"]*"[^>]*>.*?<\/channel>/)
+  if (!m) return { complete: false, block: null, chatId: null } // opening tag only -> truncated
+  const block = m[0]
+  const cm = block.match(/\bchat_id="([^"]+)"/)
+  // A terminal wrap can land INSIDE chat_id="..."; whitespace-collapse then
+  // yields a corrupted id with an embedded space. Reject it (stay on Enter)
+  // rather than re-inject to a wrong chat_id.
+  if (!cm || /\s/.test(cm[1])) return { complete: false, block, chatId: null }
+  return { complete: true, block, chatId: cm[1] }
+}
+
 // Per-session bookkeeping for the stuck-input recovery watcher. A "spell"
 // is one continuous stretch of the SAME text parked in the input box.
 export interface StuckInputState {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -374,7 +374,7 @@ const SUBMIT_RETRY_POLL_MS = '0.3'
 // Buffer-clear (Ctrl-U) used pre-flight when shouldClearTruncatedPreamble
 // flags a stale preamble. Sent as a single key name (no `-l` literal
 // flag) so tmux interprets it as the control sequence.
-function clearInputBuffer(session: string): void {
+export function clearInputBuffer(session: string): void {
   try {
     execFileSync(TMUX, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
     // Settle briefly so the next send-keys lands in the freshly cleared

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -10,6 +10,7 @@ import {
   agentHasChannel,
   agentSessionName,
   capturePane,
+  clearInputBuffer,
   dismissResumeSummaryModalIfPresent,
   isAgentRunning,
   sendPromptToSession,
@@ -20,7 +21,11 @@ import {
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
 import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
-import { detectPaneState, decidePaneErrorAlert, type PaneErrorAlertState, type PaneState } from '../pane-state.js'
+import {
+  detectPaneState, decidePaneErrorAlert, type PaneErrorAlertState, type PaneState,
+  stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
+  type StuckInputState, type StuckInputThresholds,
+} from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
 import { getProvider, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
@@ -68,6 +73,28 @@ const AGENT_RESTART_GRACE_MS = 90_000
 // than this on a "plugin down" reading, or the watchdog crash-loops it.
 const AGENT_STARTUP_GRACE_MS = 180_000
 const PLUGIN_ALERT_DEDUP_MS = 30 * 60 * 1000
+
+// Stuck channel-input recovery (MAIN session only). A channel notification
+// delivered while Boss is busy can be parked as plain text at the ❯ prompt
+// without being submitted ('typing' state) -- it wedges the session because
+// skipIfBusy heartbeats read 'typing' as not-idle and Boss never processes
+// the message. The parked text already carries the full
+// <channel ... chat_id=...> block, so recovery only needs to get it SUBMITTED.
+let mainStuckInput: StuckInputState = { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
+// Raw Enters tried before escalating to clear+re-inject. Enter is faithful
+// (it submits the REAL buffer, no capture-truncation risk); re-inject is the
+// fallback for a TUI that swallows the Enter in raw-mode.
+const MAIN_STUCK_ENTER_ATTEMPTS = 2
+const MAIN_STUCK_THRESHOLDS: StuckInputThresholds = {
+  // Same text must stay parked this long before the first recovery action so a
+  // turn about to submit on its own is not pre-empted (>=2 observations at the
+  // 60s tick).
+  confirmMs: 90_000,
+  // One recovery action per ~tick.
+  dedupMs: 45_000,
+  // 2 Enters + up to 2 re-injects, then hold (logged).
+  maxAttempts: 4,
+}
 
 // Per-session tracking for the wedged thinking-block error (a Claude
 // session stuck returning `400 ... thinking blocks cannot be modified`
@@ -706,6 +733,44 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         const label = t.isMarveen ? BOT_NAME : (t.agentName ?? t.session)
         logger.error({ session: t.session, agent: label }, 'Agent wedged on thinking-block API error -- manual reset needed')
         sendAlert(`🚨 A(z) ${label} agens elakadt egy thinking-block API hibaban (a session-history korrupt, minden uj prompt ugyanazt a 400-at adja). Kezi reset kell: allitsd le es inditsd ujra, friss session indul. Reszletek: tmux attach -t ${t.session}`)
+      }
+    }
+
+    // Stuck channel-input recovery (MAIN session only). Recover a channel
+    // notification stranded at the ❯ prompt by getting it SUBMITTED. The gate
+    // (parkedChannelInput != null) fires ONLY for a parked <channel> block, so
+    // a human's own hand-typed draft is never touched. Enter-first (faithful);
+    // escalate to clear+re-inject only after MAIN_STUCK_ENTER_ATTEMPTS, and
+    // only when the captured block looks COMPLETE -- a truncated capture stays
+    // on Enter rather than risk a partial re-inject to the wrong chat_id.
+    {
+      const mainPane = capturePane(MAIN_CHANNELS_SESSION)
+      const parked = mainPane != null ? parkedChannelInput(mainPane) : null
+      const sig = parked != null && mainPane != null ? stuckInputSignature(mainPane) : null
+      const decision = decideStuckInputRecovery(sig, mainStuckInput, Date.now(), MAIN_STUCK_THRESHOLDS)
+      mainStuckInput = decision.next
+      if (decision.recover && parked != null) {
+        const attempt = decision.next.attempts
+        const reinject = attempt > MAIN_STUCK_ENTER_ATTEMPTS && parked.complete && parked.block != null
+        if (reinject) {
+          logger.warn({ session: MAIN_CHANNELS_SESSION, chatId: parked.chatId, attempt }, 'Stuck channel input -- escalating to clear + verbatim re-inject')
+          try {
+            clearInputBuffer(MAIN_CHANNELS_SESSION)
+            sendPromptToSession(MAIN_CHANNELS_SESSION, parked.block!)
+          } catch (err) {
+            logger.warn({ err, session: MAIN_CHANNELS_SESSION }, 'Stuck-input re-inject failed')
+          }
+        } else {
+          // Enter-first, and the truncation-guard fallback: if escalation was
+          // due but the block looks incomplete, hold on Enter instead.
+          const heldForTruncation = attempt > MAIN_STUCK_ENTER_ATTEMPTS && !parked.complete
+          logger.warn({ session: MAIN_CHANNELS_SESSION, attempt, heldForTruncation }, 'Stuck channel input -- recovery Enter')
+          try {
+            execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Enter'], { timeout: 5000 })
+          } catch (err) {
+            logger.warn({ err, session: MAIN_CHANNELS_SESSION }, 'Stuck-input recovery Enter failed')
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Piece C a #289-ből, a **korrigált** design szerint (a jóváhagyott ledger-alapú megközelítés helyett — l. lentebb miért).

## A probléma
Egy channel-értesítés, ami akkor érkezik amikor Boss BUSY, beragadhat plain textként a ❯ promptnál anélkül hogy submitálódna (`typing` state). Ez beékeli a MAIN sessiont: a `skipIfBusy` heartbeatek a `typing`-ot not-idle-nek látják → felgyűlnek, és Boss SOSEM dolgozza fel a beragadt üzenetet.

## Miért nem a ledger (a jóváhagyott design korrekciója)
A `conversation_log` inbound sorát a `ledger-capture.py` **`UserPromptSubmit` hook** írja — tehát egy beragadt, NEM-submitált üzenet SOSINCS benne. A `telegram_history` writer (`saveTelegramMessage`) holt kód (0 hívó). Vagyis semmilyen DB-forrás nincs a parked üzenetre. **De** a parked text MAGA tartalmazza a teljes `<channel ... chat_id=...>` blokkot, így a chat_id ott van — nem kell rekonstruálni, csak SUBMIT-álni.

## Design — Enter-first, majd escalate (mindkét esetre véd)
Nincs verifikált ground-truth arról hogy a TUI lenyeli-e a nyers Entert, és az élő prod sessionön nem kísérletezünk. Ezért a kaszkád mindkettőre véd:
- **Kapu:** `parkedChannelInput()` csak akkor ad nem-null-t, ha egy `<channel source="plugin:...">` blokk van parkolva. Humán kézi draftnak nincs ilyen markere → SOHA nem nyúlunk hozzá.
- **1..N akció:** nyers Enter. Hű — a VALÓDI buffert submitálja, nulla capture-csonkolás-rizikó.
- **Escalate (N után):** `clearInputBuffer` + a befogott blokk VERBATIM re-injectje — de CSAK ha a capture TELJESNEK tűnik. **Csonkolás-guard:** ha a záró `</channel>` kiscrollozott, vagy egy terminal-wrap whitespace-szel rontotta el a `chat_id`-t, a `parkedChannelInput` `complete:false`-t ad → maradunk Enternél. Rossz chat_id-re válaszolni rosszabb mint a késleltetett submit.
- **Idempotencia:** a meglévő `decideStuckInputRecovery` per-spell confirm-ablaka (≥2 megfigyelés), dedup gap és `maxAttempts` cap; a spell resetel typing-exitkor vagy szöveg-változáskor.

## Scope
`channel-monitor.ts` (csak MAIN session) + új pure `parkedChannelInput()` a `pane-state.ts`-ben (a meglévő `stuckInputSignature`/`decideStuckInputRecovery` helperekre építve, nem duplikálva) + `clearInputBuffer` export. **Nulla DB-változás.**

## Teszt
Build tiszta, 126 pane-state teszt zöld (6 új): humán-draft kapu, teljes single-line + wrapped extrakció, és MINDKÉT csonkolás-eset (hiányzó záró tag, whitespace-rontott chat_id → `complete:false`). A teljes suite 4 failje (`managed-settings.test.ts`) **pre-existing** az `origin/develop`-on, az enyémhez nincs köze (verifikáltam clean baseline-en).

## Küszöbök (review-tunolható)
`confirmMs=90s` (≥2 megfigyelés a 60s tick mellett), `dedupMs=45s`, `MAIN_STUCK_ENTER_ATTEMPTS=2`, `maxAttempts=4` (2 Enter + max 2 re-inject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)