### PR TITLE
fix(dashboard): route load-bearing 'marveen' literals through window._marveen.agentId

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -3,6 +3,16 @@
 // On first visit we pluck the token out of the URL, store it in localStorage,
 // strip it from the visible URL, and then inject it into every /api/* fetch
 // as a Bearer header so the server lets us through.
+
+// The main (channels) agent's real id. The backend /api/marveen route returns
+// the configured MAIN_AGENT_ID (NOT the literal "marveen") in window._marveen;
+// use this everywhere an agent id is sent to /api/agents/... or compared to a
+// fleet name, so the dashboard works on non-"marveen" installs. Falls back to
+// "marveen" only before /api/marveen has resolved (or on a legacy backend).
+function mainAgentId() {
+  return window._marveen?.agentId || 'marveen'
+}
+
 (() => {
   const TOKEN_KEY = 'marveen-dashboard-token'
   const urlParams = new URLSearchParams(window.location.search)
@@ -1344,7 +1354,7 @@ async function openMarveenDetail() {
   if (!m) return
 
   // Reuse the agent detail modal for Marveen
-  currentAgent = { ...m, name: 'marveen', claudeMd: '', soulMd: '', mcpJson: '', skills: [] }
+  currentAgent = { ...m, name: mainAgentId(), claudeMd: '', soulMd: '', mcpJson: '', skills: [] }
   setupAutoRestartUI(currentAgent)
 
   const displayName = m.name || 'Marveen'
@@ -1396,7 +1406,7 @@ async function openMarveenDetail() {
   // Telegram tab -- without this the tab stays in the default "not connected"
   // view even though the bot is running and receiving messages.
   updateChannelTab({
-    name: 'marveen',
+    name: mainAgentId(),
     hasTelegram: mFull.hasTelegram !== undefined ? mFull.hasTelegram : true,
     hasDiscord: mFull.hasDiscord,
     hasSlack: mFull.hasSlack,
@@ -1492,7 +1502,7 @@ function renderAgents() {
       </div>
     `
     mCard.querySelector('.agent-terminal-btn')?.addEventListener('click', (e) => {
-      e.stopPropagation(); openTerminalModal('marveen')
+      e.stopPropagation(); openTerminalModal(mainAgentId())
     })
     mCard.addEventListener('click', () => openMarveenDetail())
     agentsGrid.insertBefore(mCard, addBtn)
@@ -3551,7 +3561,7 @@ function renderScheduleList(tasks) {
   for (const task of tasks) {
     const row = document.createElement('div')
     row.className = 'schedule-row'
-    const agent = scheduleAgents.find(a => a.name === task.agent) || { name: task.agent || 'marveen', avatar: '/api/marveen/avatar', label: task.agent || 'marveen' }
+    const agent = scheduleAgents.find(a => a.name === task.agent) || { name: task.agent || mainAgentId(), avatar: '/api/marveen/avatar', label: task.agent || mainAgentId() }
 
     row.innerHTML = `
       <div class="schedule-agent-avatar">
@@ -3626,7 +3636,7 @@ function renderTimeline(tasks) {
   // Group tasks by agent
   const agentTasks = {}
   for (const task of tasks) {
-    const agentName = task.agent || 'marveen'
+    const agentName = task.agent || mainAgentId()
     if (!agentTasks[agentName]) agentTasks[agentName] = []
     agentTasks[agentName].push(task)
   }
@@ -3781,7 +3791,7 @@ function renderWeekView(data) {
       const count = tasks.length
 
       tasks.forEach((task, idx) => {
-        const agent = scheduleAgents.find(a => a.name === task.agent) || { name: task.agent || 'marveen', avatar: '/api/marveen/avatar' }
+        const agent = scheduleAgents.find(a => a.name === task.agent) || { name: task.agent || mainAgentId(), avatar: '/api/marveen/avatar' }
 
         const card = document.createElement('div')
         card.className = 'week-task-card'
@@ -4213,7 +4223,7 @@ function renderMemories(memories) {
     const tierBadge = tierLabels[tier] || tier
     const badgeClass = 'badge-' + tier
     const shortContent = mem.content.length > 120 ? mem.content.slice(0, 120) + '...' : mem.content
-    const agentLabel = mem.agent_id || 'marveen'
+    const agentLabel = mem.agent_id || mainAgentId()
 
     // Build keywords HTML
     let keywordsHtml = ''
@@ -4389,7 +4399,7 @@ function buildGraph(memories) {
       connectionCount: 0,
       label: label,
       tier: mem.tier || mem.category || 'warm',
-      agent: mem.agent_id || 'marveen',
+      agent: mem.agent_id || mainAgentId(),
       keywords: keywords,
       mem: mem,
       searchMatch: true,
@@ -4836,7 +4846,7 @@ function hideGraphPanel() {
 
 function openEditMemory(mem) {
   document.getElementById('memModalTitle').textContent = 'Emlék szerkesztése'
-  document.getElementById('memAgent').value = mem.agent_id || 'marveen'
+  document.getElementById('memAgent').value = mem.agent_id || mainAgentId()
   document.getElementById('memTier').value = mem.tier || mem.category || 'warm'
   document.getElementById('memContent').value = mem.content || ''
   document.getElementById('memKeywords').value = mem.keywords || ''
@@ -6384,8 +6394,8 @@ async function openConnectorDetail(connector) {
         assignedAgents.add(c.scope.replace('agent:', ''))
       }
     }
-    const mainAgent = allAgents.find(a => a.name === 'marveen')
-    const subAgents = allAgents.filter(a => a.name !== 'marveen')
+    const mainAgent = allAgents.find(a => a.name === mainAgentId())
+    const subAgents = allAgents.filter(a => a.name !== mainAgentId())
 
     const listEl = document.getElementById('connectorAgentList')
     listEl.innerHTML = ''
@@ -6775,7 +6785,7 @@ memImportSaveBtn.addEventListener('click', async () => {
 
     memImportStatus.textContent = `${allChunks.length} chunk kategorizálása és importálása...`
 
-    const agentId = document.getElementById('memImportAgent').value || 'marveen'
+    const agentId = document.getElementById('memImportAgent').value || mainAgentId()
     const resp = await fetch('/api/memories/import', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -7274,7 +7284,7 @@ function chatAvatarHtml(agentName, size = 32) {
   const lower = agentName.toLowerCase()
   const hasAvatar = chatAgentHasAvatar.get(lower)
   if (!hasAvatar) return chatMonogramEl(agentName, size)
-  const src = lower === 'marveen'
+  const src = lower === mainAgentId().toLowerCase()
     ? `/api/marveen/avatar?t=${Date.now()}`
     : `/api/agents/${encodeURIComponent(lower)}/avatar?t=${Date.now()}`
   return `<img class="chat-avatar" src="${src}" width="${size}" height="${size}" alt="${escapeHtml(agentName)}" data-agent-name="${escapeHtml(agentName)}" onerror="chatImgError(this)">`
@@ -7311,13 +7321,13 @@ async function loadChatAgentList() {
     const threads = threadsRes.ok ? await threadsRes.json() : []
 
     // Build fleet list: API agents + marveen, minus system agents
-    const fleetNames = ['marveen', ...agentsRaw.map(a => a.name || a)]
+    const fleetNames = [mainAgentId(), ...agentsRaw.map(a => a.name || a)]
       .filter(n => !CHAT_SYSTEM_AGENTS.has(n))
       .filter((n, i, arr) => arr.indexOf(n) === i)
 
     // Populate avatar map from API data
     chatAgentHasAvatar.clear()
-    chatAgentHasAvatar.set('marveen', true)
+    chatAgentHasAvatar.set(mainAgentId(), true)
     for (const a of agentsRaw) {
       if (a.name) chatAgentHasAvatar.set(a.name, !!a.hasAvatar)
     }
@@ -7452,8 +7462,8 @@ async function loadChatThread(agentName) {
 }
 
 function buildBubbleHtml(m) {
-  const isOutgoing = m.from_agent === 'marveen'
-  const senderName = isOutgoing ? 'marveen' : m.from_agent
+  const isOutgoing = m.from_agent === mainAgentId()
+  const senderName = isOutgoing ? mainAgentId() : m.from_agent
   const when = m.created_at ? new Date(m.created_at * 1000).toLocaleString('hu-HU', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : ''
   const statusMeta = MSG_STATUS_META[m.status] || { label: m.status || '', cls: 'badge' }
   return `<div class="chat-bubble-row ${isOutgoing ? 'outgoing' : 'incoming'}" data-msg-id="${m.id}">
@@ -7467,7 +7477,7 @@ function buildBubbleHtml(m) {
       <div class="bubble-text">${escapeHtml(m.content || '')}</div>
       <div class="bubble-time">${when}</div>
     </div>
-    ${isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml('marveen', 28)}</div>` : ''}
+    ${isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml(mainAgentId(), 28)}</div>` : ''}
   </div>`
 }
 


### PR DESCRIPTION
Több friss telepítésnél a dashboard ügynökök-oldala hardcoded `marveen` literálokkal tört a nem-marveen installokon (terminal-gomb, channel/main-detektálás, inter-agent feladó). Backend RENDBEN — a `/api/marveen` (fix API-útnév) a valódi `agentId=MAIN_AGENT_ID`, `role:main`, `tmuxSession=<id>-channels` értékeket adja `window._marveen`-be; a bug a frontend volt.

## Megoldás
Új `mainAgentId()` helper (`window._marveen?.agentId || marveen`), és minden **load-bearing** használat ezen át:
- **terminal**: `openTerminalModal(mainAgentId())` (1505) → `/api/agents/<valódi id>/pane/stream`
- `currentAgent.name` (1357, 1409)
- **fő-ügynök detektálás**: `allAgents.find/filter(a.name === mainAgentId())` (6397/6398)
- **fleet + avatar regisztráció**: `fleetNames=[mainAgentId(), ...]` (7324), `chatAgentHasAvatar.set(mainAgentId(), true)` (7330)
- **inter-agent feladó**: `m.from_agent === mainAgentId()` + `senderName` (7465/7466), outgoing buborék avatar (7480)
- **avatar-forrás switch**: `lower === mainAgentId().toLowerCase()` (7287)
- **kozmetikai fallbackek**: `task.agent || mainAgentId()` / `mem.agent_id || mainAgentId()` (3564, 3639, 3794, 4226, 4402, 4849, 6788)

## Backend: NEM kell változtatás
Az `agent-terminal.ts` `resolveTarget()` MÁR ágazik `isMainChannelsAgent(name)` (`name === MAIN_AGENT_ID`) → `MAIN_CHANNELS_SESSION`-re. Tehát amint a frontend a valódi id-t küldi, a `pane/stream` route helyesen oldja fel a fő ügynököt. (Verifikáltam: `isMainChannelsAgent` az env-vezérelt `MAIN_AGENT_ID`-t használja, nem a literált.)

## Szándékosan HAGYVA (instance-szintű, nem agent-függő)
`marveen-dashboard-token` localStorage kulcs, `/api/marveen*` route-ok, `/api/marveen/avatar`, `marveenRestartBtn`/`marveenReadonlyNote` element-id-k, a legacy szín-map objektum-kulcs (`marveen: #6366f1` — computed-property korai eval-t kockáztatna `window._marveen` betöltése előtt).

## Teszt (böngészőben, KÖTELEZŐ)
Playwright, az **élő** dashboard ellen az ehhez tartozó `app.js`-t injektálva (**prod working tree érintetlen**, izolált git worktree-ből), restart-gomb NEM kattintva (nem indítom újra az élő fő sessiont):
- `window._marveen` populál (`role:main`, `tmuxSession=marveen-channels`); `mainAgentId()` a **valódi** backend agentId-t adja (nem fallback).
- Szimulált nem-marveen identitás (`jarvis`) → `mainAgentId()=jarvis` → `/api/agents/jarvis/pane/stream` ✓.
- Ezen (marveen) installon a valódi terminal-open → `/api/agents/marveen/pane/stream` ✓.
- Nincs ÚJ JS-hiba (az egyetlen 404 az eredeti app.js-en is megvan → pre-existing).
- `node --check` tiszta.

Csak `web/app.js`. index.html + src/web átnézve, nincs más load-bearing literál.

🤖 Generated with [Claude Code](https://claude.com/claude-code)