### PR TITLE
feat(activity): click card to open terminal modal

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -181,11 +181,18 @@ function renderActivity(entries) {
     const meta = ACTIVITY_STATE_META[a.state] || ACTIVITY_STATE_META.unknown
     const tail = (a.tail || []).map((l) => escapeHtml(l)).join('\n')
     const mainBadge = a.isMain ? '<span class="act-main-badge">fő</span>' : ''
+    const canOpen = !!a.running
+    const termIcon = canOpen
+      ? '<svg class="act-term-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" title="Terminal megnyitása"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>'
+      : ''
     return (
-      '<div class="activity-card ' + meta.cls + '">' +
+      '<div class="activity-card ' + meta.cls + (canOpen ? ' act-clickable' : '') + '" data-agent="' + escapeHtml(a.name) + '">' +
         '<div class="activity-card-head">' +
           '<span class="activity-name">' + escapeHtml(a.name) + mainBadge + '</span>' +
-          '<span class="activity-badge ' + meta.cls + '" title="' + escapeHtml(meta.tip || '') + '">' + meta.label + '</span>' +
+          '<span style="display:flex;align-items:center;gap:8px">' +
+            termIcon +
+            '<span class="activity-badge ' + meta.cls + '" title="' + escapeHtml(meta.tip || '') + '">' + meta.label + '</span>' +
+          '</span>' +
         '</div>' +
         (tail
           ? '<pre class="activity-tail">' + tail + '</pre>'
@@ -194,6 +201,17 @@ function renderActivity(entries) {
     )
   }).join('')
 }
+
+// Event delegation: clicking a running activity-card opens the terminal modal
+;(() => {
+  const actList = document.getElementById('activityList')
+  if (actList) {
+    actList.addEventListener('click', (e) => {
+      const card = e.target.closest('.activity-card.act-clickable[data-agent]')
+      if (card) openTerminalModal(card.dataset.agent)
+    })
+  }
+})()
 
 
 // ============================================================

--- a/web/style.css
+++ b/web/style.css
@@ -4994,6 +4994,10 @@ main {
 .activity-card.act-error   { border-left-color: #ef4444; }
 .activity-card.act-unknown { border-left-color: #eab308; }
 .activity-card.act-stopped { border-left-color: #6b7280; opacity: 0.7; }
+.activity-card.act-clickable { cursor: pointer; transition: background 0.15s, box-shadow 0.15s; }
+.activity-card.act-clickable:hover { background: var(--bg-card-hover, var(--bg-card)); box-shadow: 0 0 0 2px var(--accent); }
+.act-term-icon { color: var(--text-muted); flex-shrink: 0; opacity: 0.6; }
+.activity-card.act-clickable:hover .act-term-icon { opacity: 1; color: var(--accent); }
 .activity-card-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
 .activity-name { font-weight: 600; font-size: 15px; display: flex; align-items: center; gap: 8px; }
 .act-main-badge {


### PR DESCRIPTION
## Summary

- Running agent cards in the Activity view are now clickable — opens the full xterm.js terminal modal (same component as the Agents page Terminal button)
- Stopped sessions get no click affordance (`.running === false` → no `.act-clickable` class)
- Small terminal icon (`>_`) in card header signals interactivity; highlights on hover
- Event delegation on `#activityList` handles clicks since cards are built via innerHTML

## Test plan
- [x] 7 clickable cards detected (all running agents)
- [x] Click opens terminal modal with correct agent name in header
- [x] xterm.js renders live pane output
- [x] 0 JS errors

**Before / After screenshots in commit.**

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)