### PR TITLE
fix(stuck-tool-call-watcher): recover via respawn-pane (no client-kick) + reap + CPU guard (#248)

### DIFF
--- a/src/__tests__/stuck-tool-call.test.ts
+++ b/src/__tests__/stuck-tool-call.test.ts
@@ -5,7 +5,7 @@ import {
   type StuckToolCallState,
   type StuckToolCallThresholds,
 } from '../pane-state.js'
-import { shouldDeferForRecentRespawn } from '../web/stuck-tool-call-watcher.js'
+import { shouldDeferForRecentRespawn, confirmsWedgeProfile } from '../web/stuck-tool-call-watcher.js'
 
 // Thresholds matching the production defaults in stuck-tool-call-watcher.ts.
 // Repeated here so the tests pin the contract independently of the wrapper
@@ -254,11 +254,19 @@ describe('stuck-tool-call-watcher wiring contract', () => {
     expect(parseInt(m![1]!, 10)).toBeGreaterThanOrEqual(2)
   })
 
-  it('the watcher hard-restarts only via hardRestartMarveenChannels', () => {
-    expect(watcherSrc).toMatch(/hardRestartMarveenChannels\(\)/)
-    // Defensive: must NOT call respawn-pane directly or kill processes.
-    expect(watcherSrc).not.toMatch(/respawn-pane/)
-    expect(watcherSrc).not.toMatch(/kill\(/)
+  it('recovers via the respawn-pane path (resumeMarveenSession), NOT the launchctl hard-restart (#248)', () => {
+    // #248: the launchctl hard-restart -> channels.sh -> `tmux kill-session`
+    // kicked the attached client ([exited]). Recovery now delegates to
+    // resumeMarveenSession (respawn-pane -k + pane-attribution reap), which
+    // replaces only the pane's claude and never kills the session.
+    expect(watcherSrc).toMatch(/resumeMarveenSession\(\)/)
+    // Import-level (comment-proof): the launchctl hard-restart is no longer
+    // wired into the watcher, so it cannot kick an attached client.
+    expect(watcherSrc).not.toMatch(/import[^\n]*hardRestartMarveenChannels/)
+  })
+
+  it('confirms the idle wedge profile before recovering (CPU-load false-positive guard, #248)', () => {
+    expect(watcherSrc).toMatch(/confirmsWedgeProfile\(/)
   })
 
   it('the watcher logs an audit line when it acts', () => {
@@ -303,5 +311,24 @@ describe('shouldDeferForRecentRespawn', () => {
     // 359s defers, 361s does not, with the default arg.
     expect(shouldDeferForRecentRespawn(now - 359_000, now)).toBe(true)
     expect(shouldDeferForRecentRespawn(now - 361_000, now)).toBe(false)
+  })
+})
+
+describe('confirmsWedgeProfile (#248 CPU-profile guard)', () => {
+  const MAX = 30
+
+  it('confirms the idle stdio-wedge profile (CPU ~0.3%, IO-wait)', () => {
+    expect(confirmsWedgeProfile(0.3, MAX)).toBe(true)
+    expect(confirmsWedgeProfile(0, MAX)).toBe(true)
+    expect(confirmsWedgeProfile(MAX, MAX)).toBe(true) // boundary inclusive
+  })
+
+  it('does NOT confirm when the process is still burning CPU (heavy work / starvation, not a wedge)', () => {
+    expect(confirmsWedgeProfile(31, MAX)).toBe(false)
+    expect(confirmsWedgeProfile(95.5, MAX)).toBe(false)
+  })
+
+  it('fails OPEN on a null sample (ps failed) -- never blocks recovery on a missing reading', () => {
+    expect(confirmsWedgeProfile(null, MAX)).toBe(true)
   })
 })

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -198,7 +198,14 @@ export function buildMainSessionRespawnCmd(opts: {
   ].join(' ')
 }
 
-function resumeMarveenSession(): boolean {
+// Exported so the stuck-tool-call-watcher recovers a wedged main session via
+// this respawn-pane path (reap + `tmux respawn-pane -k --continue`) INSTEAD of
+// the launchctl hard-restart. respawn-pane replaces only the claude process in
+// the pane: it does NOT `tmux kill-session`, so an attached client is never
+// kicked ([exited]) -- the #248 user-visible crash. It also runs the
+// pane-attribution detached-claude reap first, breaking the orphan->409->freeze
+// doom-loop that the launchctl path (channels.sh env-grep reap) never cleaned.
+export function resumeMarveenSession(): boolean {
   const provider = getProvider(getMainAgentProvider())
   try {
     // Reap any orphan bun/node poller BEFORE we respawn. tmux respawn-pane -k

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -12,9 +12,14 @@
 //
 // Detection: parse the TUI's "<verb> for Ns" progress line; if the same
 // tag+seconds is observed across multiple polls AND the seconds value has
-// reached freezeSeconds, the tool-call is wedged. Recovery is a fresh
-// respawn (hardRestartMarveenChannels), which goes through channels.sh and
-// hence picks up all the existing safety nets (#231, #232, #234, #236).
+// reached freezeSeconds, the tool-call is wedged. Recovery (#248 fix) is the
+// respawn-pane path resumeMarveenSession() -- NOT the launchctl hard-restart.
+// `tmux respawn-pane -k` replaces only the pane's claude process: it does NOT
+// `tmux kill-session`, so an attached client is never kicked ([exited], the
+// #248 user-visible crash), and it runs the pane-attribution detached-claude
+// reap first (breaking the orphan->409->freeze doom-loop the env-grep reap on
+// the launchctl/channels.sh path never cleaned). A CPU-profile guard skips the
+// recovery unless the process matches the idle stdio-wedge profile.
 //
 // Critical guard (Marveen 2026-06-02 review): a legitimate long-running
 // tool-call (slow Anthropic inference, multi-stage research agent) MUST
@@ -32,16 +37,53 @@
 // and the respawn path (stopAgentProcess + startAgentProcess) is different.
 // Extend if a sub-agent case ever materialises.
 
+import { execFileSync } from 'node:child_process'
 import { logger } from '../logger.js'
+import { resolveFromPath } from '../platform.js'
 import { capturePane } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-import { hardRestartMarveenChannels, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS } from './channel-monitor.js'
+import { resumeMarveenSession, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS } from './channel-monitor.js'
 import {
   stuckToolCallSignature,
   decideStuckToolCallRecovery,
   type StuckToolCallState,
   type StuckToolCallThresholds,
 } from '../pane-state.js'
+
+const TMUX = resolveFromPath('tmux')
+
+// CPU-profile guard (#248): the genuine wedge is a render loop blocked on stdio
+// -- CPU collapses to ~0.3% (IO-wait). A frozen "Worked for Ns" counter on a
+// process that is STILL BURNING CPU is not that wedge: it is a session doing
+// heavy synchronous work that just hasn't yielded to a TUI redraw. Only recover
+// when the process matches the idle wedge profile (CPU <= maxCpuPercent).
+// Fail-open: a null sample (ps failed) does NOT block recovery -- the
+// counter-stagnation signal stands on its own.
+const WEDGE_MAX_CPU_PERCENT = 30
+
+// Pure: does the sampled CPU% match the idle stdio-wedge profile? null (sample
+// failed) -> true (fail-open; do not block recovery on a missing sample).
+export function confirmsWedgeProfile(cpuPercent: number | null, maxCpuPercent: number): boolean {
+  if (cpuPercent === null) return true
+  return cpuPercent <= maxCpuPercent
+}
+
+// Recent CPU% of the main session's pane-leader claude (claudePid == panePid for
+// the main channels session). null on any failure (fail-open). `ps -o %cpu=` is
+// a recent decaying average on macOS/Linux -- enough to tell a 0.3% IO-wait
+// wedge from a process actively burning CPU.
+function sampleMainClaudeCpuPercent(session: string): number | null {
+  try {
+    const panePid = execFileSync(TMUX, ['list-panes', '-t', session, '-F', '#{pane_pid}'], { timeout: 3000, encoding: 'utf-8' })
+      .split('\n')[0]?.trim()
+    if (!panePid || !/^\d+$/.test(panePid)) return null
+    const out = execFileSync('/bin/ps', ['-o', '%cpu=', '-p', panePid], { timeout: 3000, encoding: 'utf-8' }).trim()
+    const cpu = parseFloat(out)
+    return Number.isFinite(cpu) ? cpu : null
+  } catch {
+    return null
+  }
+}
 
 // Defaults chosen against the 2026-06-02 incident profile.
 //   - freezeSeconds = 180: long enough that a real slow Anthropic call
@@ -118,7 +160,20 @@ function checkSession(label: string, session: string): void {
     if (shouldDeferForRecentRespawn(lastRespawn, Date.now())) {
       logger.info(
         { label, session, sinceRespawnMs: lastRespawn ? Date.now() - lastRespawn : null, graceMs: MARVEEN_POST_RESPAWN_GRACE_MS },
-        'stuck-tool-call-watcher: recent respawn within grace, deferring hard-restart (avoid double-respawn / boot churn)',
+        'stuck-tool-call-watcher: recent respawn within grace, deferring recovery (avoid double-respawn / boot churn)',
+      )
+      return
+    }
+    // CPU-profile guard (#248): the genuine wedge is a render loop blocked on
+    // stdio (CPU ~0.3%, IO-wait). A counter that froze while the claude is still
+    // burning CPU is heavy synchronous work / render starvation, not the wedge
+    // -- respawning it is churn. Skip unless the process matches the idle
+    // profile. Fail-open on a null sample.
+    const cpuPercent = sampleMainClaudeCpuPercent(session)
+    if (!confirmsWedgeProfile(cpuPercent, WEDGE_MAX_CPU_PERCENT)) {
+      logger.info(
+        { label, session, cpuPercent, maxCpuPercent: WEDGE_MAX_CPU_PERCENT, seconds: next.lastSeconds },
+        'stuck-tool-call-watcher: counter stagnant but claude is CPU-active (not the idle wedge profile) -- deferring recovery',
       )
       return
     }
@@ -132,13 +187,21 @@ function checkSession(label: string, session: string): void {
         tag: next.tag,
         seconds: next.lastSeconds,
         stagnantPolls: next.stagnantPolls,
+        cpuPercent,
         thresholds: THRESHOLDS,
       },
-      'stuck-tool-call-watcher: TUI counter stagnant past freeze threshold, hard-restarting main channels session',
+      'stuck-tool-call-watcher: TUI counter stagnant past freeze threshold + idle wedge profile -- recovering main channels session (respawn-pane, no client-kick)',
     )
-    const result = hardRestartMarveenChannels()
-    if (!result.ok) {
-      logger.error({ label, session, error: result.error }, 'stuck-tool-call-watcher: hard restart failed')
+    // Recover via the respawn-pane path (resumeMarveenSession), NOT the launchctl
+    // hard-restart. respawn-pane -k replaces only the pane's claude process: no
+    // `tmux kill-session`, so an attached client is never kicked ([exited], the
+    // #248 user-visible crash). resumeMarveenSession also runs the
+    // pane-attribution detached-claude reap FIRST, breaking the
+    // orphan->409->freeze doom-loop that the launchctl/channels.sh env-grep reap
+    // never cleaned (the loop's launchctl path never reaped the main orphans).
+    const ok = resumeMarveenSession()
+    if (!ok) {
+      logger.error({ label, session }, 'stuck-tool-call-watcher: respawn-pane recovery failed')
     }
   }
 }


### PR DESCRIPTION
Fixes #248 (main session random `[exited]` crash). Load-bearing recovery code -- kérlek teljes diff-review + a deploy a te Szabi-gated egyben-deployoddal.

## Gyökér (élesben verifikált)
A stuck-tool-call-watcher egy wedged main sessiont a `hardRestartMarveenChannels()` → **launchctl reload → channels.sh → `tmux kill-session`** úton állított helyre. A kill-session megöli a sessiont az **attachelt klienssel együtt** → `[exited]` (a #248 crash). Ráadásul a channels.sh reap-je `TELEGRAM_STATE_DIR` env-re grepel, amit a Claude Code a main poller-be SOHA nem injektál (channels.sh:231 dokumentálja) → ez az út SOHA nem reapelte a detached orphan claude-okat. Halmozódtak (élő ps: ~5 orphan + 6 poller egy tokenen → 409 → tool-call pipe-stall → a watcher újra üt): önerősítő doom-loop, **118 hard-restart** a logban.

## Fix (a)+(b)+(c) -- a megbeszélt irány
- **(a) respawn-pane, nem launchctl:** a recovery mostantól `resumeMarveenSession()` (ugyanaz a respawn-pane út, amit a channel-monitor down-cascade-je használ). `tmux respawn-pane -k` csak a pane claude-ját cseréli → **nincs kill-session → nincs `[exited]` kirúgás.**
- **(b) reap a recovery ELŐTT:** a `resumeMarveenSession` lefuttatja a pane-attribúciós `reapDetachedChannelClaudes`-t (az EGYETLEN reap ami látja a main orphanokat: egy claude akkor orphan, ha se a pid-je, se egy ős-pid-je nem live tmux pane). **Megtöri a doom-loopot.**
- **(c) CPU-profil false-positive guard:** a valódi wedge IO-wait ~0.3% CPU. Ha a counter befagyott DE a claude még CPU-t éget → nehéz szinkron munka / render-starvation, nem wedge → `confirmsWedgeProfile` (≤30% CPU; null ps-mintára fail-open) kihagyja a recovery-t. Ez a CPU-load false-positive vektor (#258-cal egybevág).

## Scope / biztonság
- `hardRestartMarveenChannels()` (launchctl) **változatlan**, a többi hívója (inbound-probe, manuális `/api/marveen/restart`, agent-route-ok) használja tovább. CSAK a stuck-watcher recovery-je lett átirányítva.
- A `resumeMarveenSession` exportált lett (eddig privát volt).

## Teszt
- `confirmsWedgeProfile`: idle confirms / CPU-active defers / null fail-open.
- wiring-contract frissítve: a recovery `resumeMarveenSession()`-ön megy, NINCS launchctl-import (comment-proof import-szintű assert).
- `tsc` OK, **1013 pass** (a 4 managed-settings failure pre-existing a develop-on).

## Külön track (NEM ebben a PR-ben)
Az azonnali tűzoltás (a ~5 meglévő live orphan reapelése) külön, Szabi explicit GO-jára megy -- előkészítve, HOLD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)