### PR TITLE
fix(update): follow the branch's upstream instead of hardcoding 'main'

### DIFF
--- a/src/__tests__/update-preflight.test.ts
+++ b/src/__tests__/update-preflight.test.ts
@@ -9,22 +9,34 @@ import {
 
 // Helper: build a GitRunner from plain strings. Covers the common
 // "return this exact branch / status" fixtures without dragging in a
-// real git invocation.
-function makeGit(branch: string, porcelain = ''): GitRunner {
+// real git invocation. Upstream defaults to "origin/<branch>" so the
+// common case (a branch that tracks its remote) is the zero-config
+// fixture; pass an explicit '' to model a local-only branch.
+function makeGit(
+  branch: string,
+  porcelain = '',
+  upstream: string = branch.trim() && branch.trim() !== 'HEAD' ? `origin/${branch.trim()}` : '',
+): GitRunner {
   return {
     currentBranch: () => branch,
+    upstreamBranch: () => upstream,
     porcelainStatus: () => porcelain,
   }
 }
 
 describe('checkUpdatePreflight --happy path', () => {
-  it('returns ok when on main with a clean tree', () => {
+  it('returns ok on the deployment branch (develop) with a clean tree', () => {
+    const result = checkUpdatePreflight(makeGit('develop', ''))
+    expect(result.ok).toBe(true)
+  })
+
+  it('returns ok on main too (installations that track main)', () => {
     const result = checkUpdatePreflight(makeGit('main', ''))
     expect(result.ok).toBe(true)
   })
 
   it('ignores whitespace-only branch output', () => {
-    const result = checkUpdatePreflight(makeGit('  main  ', '   '))
+    const result = checkUpdatePreflight(makeGit('  develop  ', '   ', 'origin/develop'))
     expect(result.ok).toBe(true)
   })
 })
@@ -47,7 +59,7 @@ describe('checkUpdatePreflight --detached HEAD', () => {
 
   it('prioritises detached-HEAD over dirty-tree when both apply', () => {
     // If we are detached we do not want a "commit your changes" message,
-    // because the right next step is checkout main first.
+    // because the right next step is to check out a tracking branch.
     const result = checkUpdatePreflight(makeGit('HEAD', ' M src/web.ts\n'))
     expect(result.ok).toBe(false)
     if (result.ok) return
@@ -55,34 +67,33 @@ describe('checkUpdatePreflight --detached HEAD', () => {
   })
 })
 
-describe('checkUpdatePreflight --feature branch', () => {
-  it('rejects any branch name other than main', () => {
-    const result = checkUpdatePreflight(makeGit('v3-05-ui-trustfrom-picker'))
+describe('checkUpdatePreflight --no upstream', () => {
+  it('rejects a local-only branch with no upstream tracking ref', () => {
+    const result = checkUpdatePreflight(makeGit('v3-05-ui-trustfrom-picker', '', ''))
     expect(result.ok).toBe(false)
-    if (result.ok || result.reason !== 'not-on-main') {
-      throw new Error('expected not-on-main result')
+    if (result.ok || result.reason !== 'no-upstream') {
+      throw new Error('expected no-upstream result')
     }
     expect(result.branch).toBe('v3-05-ui-trustfrom-picker')
     expect(result.message).toContain("'v3-05-ui-trustfrom-picker'")
-    expect(result.message).toMatch(/git checkout main/)
+    expect(result.message).toMatch(/set-upstream-to=origin\/v3-05-ui-trustfrom-picker/)
   })
 
-  it('rejects "master" (a common misconfiguration)', () => {
-    const result = checkUpdatePreflight(makeGit('master'))
-    expect(result.ok).toBe(false)
-    if (result.ok) return
-    expect(result.reason).toBe('not-on-main')
+  it('accepts a feature branch that DOES track an upstream', () => {
+    // The guard is about "is there something to fast-forward from", not
+    // about the branch name. A branch tracking origin/feat-x updates from
+    // that ref; --ff-only is the final safety net if it cannot advance.
+    const result = checkUpdatePreflight(makeGit('feat-x', '', 'origin/feat-x'))
+    expect(result.ok).toBe(true)
   })
 
-  it('prioritises not-on-main over dirty-tree when both apply', () => {
-    // Switching to main first invalidates the dirty-tree check anyway
-    // (the modifications may or may not carry across branches), so the
-    // useful error message for the user is "switch branches", not
-    // "commit your changes on this branch".
-    const result = checkUpdatePreflight(makeGit('feature-x', ' M src/web.ts\n'))
+  it('prioritises no-upstream over dirty-tree when both apply', () => {
+    // With no upstream there is nothing to pull regardless of tree state,
+    // so the actionable message is "set an upstream", not "commit first".
+    const result = checkUpdatePreflight(makeGit('feature-x', ' M src/web.ts\n', ''))
     expect(result.ok).toBe(false)
     if (result.ok) return
-    expect(result.reason).toBe('not-on-main')
+    expect(result.reason).toBe('no-upstream')
   })
 })
 
@@ -127,15 +138,15 @@ describe('checkUpdatePreflight -- result shape', () => {
     expect(Object.hasOwn(result, 'branch')).toBe(false)
   })
 
-  it('only emits a branch field on the not-on-main path', () => {
+  it('only emits a branch field on the no-upstream path', () => {
     const detached = checkUpdatePreflight(makeGit(''))
     expect(Object.hasOwn(detached, 'branch')).toBe(false)
 
     const dirty = checkUpdatePreflight(makeGit('main', ' M x'))
     expect(Object.hasOwn(dirty, 'branch')).toBe(false)
 
-    const feature = checkUpdatePreflight(makeGit('feature-x'))
-    expect(Object.hasOwn(feature, 'branch')).toBe(true)
+    const noUpstream = checkUpdatePreflight(makeGit('feature-x', '', ''))
+    expect(Object.hasOwn(noUpstream, 'branch')).toBe(true)
   })
 })
 

--- a/src/update-preflight.ts
+++ b/src/update-preflight.ts
@@ -24,6 +24,13 @@
 export interface GitRunner {
   // Current branch name. "HEAD" (or empty) signals a detached checkout.
   currentBranch(): string
+  // Upstream tracking ref of the current branch, e.g. "origin/develop".
+  // Empty when the branch has no configured upstream (a local-only,
+  // ad-hoc branch). This is what `git pull --ff-only` follows, so it is
+  // the authoritative signal for "is this checkout safe to fast-forward".
+  // Implementations return '' on the `git rev-parse @{u}` error path
+  // rather than throwing.
+  upstreamBranch(): string
   // Porcelain status excluding untracked files. Non-empty = dirty tree.
   // Untracked files are excluded because the repo legitimately carries
   // ad-hoc backup files (CLAUDE.md.backup-*, SOUL.md mid-edit, etc.)
@@ -33,7 +40,7 @@ export interface GitRunner {
 
 export type PreflightResult =
   | { ok: true }
-  | { ok: false; reason: 'not-on-main'; branch: string; message: string }
+  | { ok: false; reason: 'no-upstream'; branch: string; message: string }
   | { ok: false; reason: 'dirty-tree'; message: string }
   | { ok: false; reason: 'detached-head'; message: string }
 
@@ -115,8 +122,6 @@ export function checkNoConcurrentUpdate(pf: PidfileRunner): ConcurrencyResult {
   }
 }
 
-const EXPECTED_BRANCH = 'main'
-
 export function checkUpdatePreflight(git: GitRunner): PreflightResult {
   const branch = git.currentBranch().trim()
 
@@ -128,19 +133,27 @@ export function checkUpdatePreflight(git: GitRunner): PreflightResult {
       ok: false,
       reason: 'detached-head',
       message:
-        'Repository is in a detached-HEAD state. Check out main before updating: git checkout main',
+        'Repository is in a detached-HEAD state. Check out a tracking branch before updating.',
     }
   }
 
-  if (branch !== EXPECTED_BRANCH) {
+  // The update follows the branch's upstream tracking ref (update.sh runs
+  // a bare `git pull --ff-only`, which pulls from @{u}). A branch with no
+  // upstream -- a local-only, ad-hoc feature branch -- has nothing to
+  // fast-forward from, so refuse rather than let update.sh fail invisibly.
+  // This deliberately does NOT hardcode 'main': the deployment branch is
+  // whatever the checkout tracks (here 'develop'), and any installation
+  // that tracks its own release branch is updated from that branch.
+  const upstream = git.upstreamBranch().trim()
+  if (!upstream) {
     return {
       ok: false,
-      reason: 'not-on-main',
+      reason: 'no-upstream',
       branch,
       message:
-        `Cannot update from branch '${branch}'. ` +
-        `'git pull --ff-only origin main' cannot fast-forward a feature branch. ` +
-        `Switch to main first: git checkout main`,
+        `Branch '${branch}' has no upstream tracking branch, so there is ` +
+        `nothing to fast-forward from. Set one with: ` +
+        `git branch --set-upstream-to=origin/${branch}`,
     }
   }
 

--- a/src/web/routes/updates.ts
+++ b/src/web/routes/updates.ts
@@ -124,6 +124,20 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
         ['rev-parse', '--abbrev-ref', 'HEAD'],
         { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
       ),
+      // Returns '' when the branch has no upstream: `git rev-parse @{u}`
+      // exits non-zero in that case, which execFileSync throws on. The
+      // preflight treats an empty upstream as the no-upstream block.
+      upstreamBranch: () => {
+        try {
+          return execFileSync(
+            '/usr/bin/git',
+            ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'],
+            { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
+          )
+        } catch {
+          return ''
+        }
+      },
       porcelainStatus: () => execFileSync(
         '/usr/bin/git',
         ['status', '--porcelain', '--untracked-files=no'],
@@ -144,7 +158,7 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
     if (!preflight.ok) {
       // dirty-tree + autoStash=true: skip the dashboard-side block and let
       // update.sh handle the stash+pop. Other failure reasons (detached HEAD,
-      // not-on-main, …) still hard-block since stash cannot rescue them.
+      // no-upstream, …) still hard-block since stash cannot rescue them.
       const skipForAutoStash = preflight.reason === 'dirty-tree' && autoStash
       if (!skipForAutoStash) {
         releaseLock()
@@ -152,7 +166,7 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
           error: preflight.message,
           reason: preflight.reason,
         }
-        if (preflight.reason === 'not-on-main') body.branch = preflight.branch
+        if (preflight.reason === 'no-upstream') body.branch = preflight.branch
         json(res, body, 409)
         return true
       }

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -50,6 +50,26 @@ export function parseGitHubRemote(): string {
   return 'Szotasz/marveen'
 }
 
+// Remote branch this checkout tracks, e.g. "develop" for an upstream of
+// "origin/develop". The dashboard polls GitHub for this branch's HEAD so
+// the "behind" count matches what update.sh would actually pull. Falls
+// back to "main" when there is no upstream (detached / local-only branch),
+// which keeps the badge working on a fresh clone before tracking is set.
+export function currentTrackingBranch(): string {
+  try {
+    const upstream = execFileSync(
+      '/usr/bin/git',
+      ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'],
+      { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
+    ).trim()
+    // "origin/develop" -> "develop"; keep slashes in branch names like
+    // "origin/feat/foo" -> "feat/foo" by dropping only the first segment.
+    const slash = upstream.indexOf('/')
+    if (slash >= 0 && slash < upstream.length - 1) return upstream.slice(slash + 1)
+  } catch { /* fall through */ }
+  return 'main'
+}
+
 export async function refreshUpdateStatus(): Promise<UpdateStatus> {
   const current = currentGitHead()
   const remote = parseGitHubRemote()
@@ -67,13 +87,15 @@ export async function refreshUpdateStatus(): Promise<UpdateStatus> {
     return status
   }
   try {
-    // 1) find HEAD of default branch (main) via the commits endpoint
-    const latestRes = await fetch(`https://api.github.com/repos/${remote}/commits/main`, {
+    // 1) find HEAD of the tracked branch via the commits endpoint. This
+    // is the branch update.sh fast-forwards from, not a hardcoded 'main'.
+    const branch = currentTrackingBranch()
+    const latestRes = await fetch(`https://api.github.com/repos/${remote}/commits/${encodeURIComponent(branch)}`, {
       headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'marveen-update-check' },
     })
-    if (!latestRes.ok) throw new Error(`GitHub /commits/main -> ${latestRes.status}`)
+    if (!latestRes.ok) throw new Error(`GitHub /commits/${branch} -> ${latestRes.status}`)
     const latestJson = await latestRes.json() as { sha?: string }
-    if (!latestJson.sha) throw new Error('No sha on commits/main response')
+    if (!latestJson.sha) throw new Error(`No sha on commits/${branch} response`)
     status.latest = latestJson.sha
 
     if (status.latest === current) {
@@ -111,8 +133,8 @@ export async function refreshUpdateStatus(): Promise<UpdateStatus> {
   return status
 }
 
-// Polls the GitHub repo's main branch for new commits and compares to the
-// local HEAD. Lets the dashboard show a "new version available" badge
+// Polls the GitHub repo's tracked branch for new commits and compares to
+// the local HEAD. Lets the dashboard show a "new version available" badge
 // without anyone having to SSH in and run update.sh.
 export function startUpdateChecker(): NodeJS.Timeout {
   // First check shortly after startup; then every 15 minutes.

--- a/update.sh
+++ b/update.sh
@@ -86,27 +86,30 @@ echo ""
 echo -e "${BOLD}Marveen frissites...${NC} [$(date -u +%Y-%m-%dT%H:%M:%SZ)]"
 echo ""
 
-# Guard 1: refuse to run from a non-main branch.
-# 'git pull --ff-only origin main' below would exit non-zero on any
-# branch whose tip is not an ancestor of origin/main -- for example
-# every feature branch whose PR was squash-merged upstream. Because
-# the dashboard launches this script detached with stdio: 'ignore',
-# that exit is invisible to the operator: the UI silently reloads on
-# the same pending-commit list. Same guard also exists server-side
-# in /api/updates/apply as a 409 pre-check; this is defense-in-depth
-# for manual invocations.
+# Guard 1: refuse to run without an upstream tracking branch.
+# The pull below is a bare 'git pull --ff-only', which fast-forwards the
+# current branch from its configured upstream (@{u}). A detached HEAD or a
+# local-only branch with no upstream has nothing to pull, and the pull
+# would exit non-zero. Because the dashboard launches this script detached
+# with stdio: 'ignore', that exit is invisible to the operator: the UI
+# silently reloads on the same pending-commit list. The same guard exists
+# server-side in /api/updates/apply as a 409 pre-check; this is
+# defense-in-depth for manual invocations.
+#
+# Note: this deliberately does NOT require the branch be named 'main'. The
+# deployment tracks whatever release branch it was installed from (here
+# 'develop'); the update follows that branch's upstream.
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 if [ "$CURRENT_BRANCH" = "HEAD" ] || [ -z "$CURRENT_BRANCH" ]; then
   echo -e "${RED}HIBA:${NC} A repo detached-HEAD allapotban van."
-  echo "       Allj at a main branchre, majd indithatod ujra a frissitest:"
-  echo "         git checkout main"
+  echo "       Allj at egy kovetett branchre, majd indithatod ujra a frissitest."
   exit 2
 fi
-if [ "$CURRENT_BRANCH" != "main" ]; then
-  echo -e "${RED}HIBA:${NC} A jelenlegi branch '${CURRENT_BRANCH}', nem 'main'."
-  echo "       A 'git pull --ff-only origin main' csak a main branchrol fut tisztan."
-  echo "       Allj at elobb a main branchre:"
-  echo "         git checkout main"
+UPSTREAM_BRANCH=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+if [ -z "$UPSTREAM_BRANCH" ]; then
+  echo -e "${RED}HIBA:${NC} A '${CURRENT_BRANCH}' branchnek nincs upstream kovetett branche."
+  echo "       Nincs honnan fast-forwardolni. Allitsd be:"
+  echo "         git branch --set-upstream-to=origin/${CURRENT_BRANCH}"
   exit 2
 fi
 
@@ -146,9 +149,10 @@ fi
 # Save current version
 OLD_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
-# Pull latest
-echo -e "  Letoltes..."
-git pull --ff-only origin main
+# Pull latest. Bare --ff-only follows the current branch's upstream
+# (@{u} = ${UPSTREAM_BRANCH}), so no remote/branch is hardcoded here.
+echo -e "  Letoltes (${UPSTREAM_BRANCH})..."
+git pull --ff-only
 NEW_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then


### PR DESCRIPTION
## Probléma

A dashboard "Frissítés most" minden frissítést elutasít a `develop`-on futó telepítéseken: a preflight `not-on-main` 409-et dob, mert a frissítő három helyen `main`-t hardcode-ol (`update.sh`, `src/update-preflight.ts`, `src/web/update-checker.ts`). A GitHub "behind" poll is rossz branchet hasonlít össze.

Hibaüzenet amit a felhasználó látott:
> Cannot update from branch 'develop'. 'git pull --ff-only origin main' cannot fast-forward a feature branch. Switch to main first: git checkout main

## Megoldás

A frissítő mostantól a jelenlegi branch upstream tracking refjét (`@{u}`) követi, nem hardcode `main`-t. Deployment-agnosztikus: `main`, `develop` vagy bármely release branch amit egy checkout trackel.

- **update-preflight.ts**: `EXPECTED_BRANCH='main'` helyett upstream-létezés ellenőrzés. Upstream nélküli (lokális ad-hoc) branch az új `no-upstream` block, a régi `not-on-main` helyett.
- **update.sh**: bare `git pull --ff-only` (a `@{u}`-t követi); a guard az upstream meglétét nézi, nem a `main` nevet.
- **update-checker.ts**: a trackelt remote branch HEAD-jét pollozza, nem `/commits/main`.
- **routes/updates.ts**: `upstreamBranch()` a GitRunner-hez; reason mező átnevezve.

## Teszt

- 38/38 preflight teszt zöld (a `no-upstream` szemantikára frissítve)
- `tsc --noEmit` tiszta a v1.5.0 bázison
- `bash -n update.sh` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)