### PR TITLE
fix: continuity-ledger follow-ups — verified inter-agent submit + credit-wall defer; watchdog probes never open questions (implements #279)

### DIFF
--- a/scripts/__tests__/conversation-ledger.test.sh
+++ b/scripts/__tests__/conversation-ledger.test.sh
@@ -33,7 +33,9 @@ run_hook() {
     local hook="$1"
     local db="$2"
     shift 2
-    LEDGER_DB_PATH="$db" LEDGER_OWNER_CHAT="8517922966" MAIN_AGENT_ID="marveen" \
+    # OWNER_NAME set explicitly: upstream #291 derives the transcript prefix
+    # from env (no hardcoded name); the prefix assertions below rely on it.
+    LEDGER_DB_PATH="$db" LEDGER_OWNER_CHAT="8517922966" MAIN_AGENT_ID="marveen" OWNER_NAME="Gyula" \
         python3 "$HOOKS_DIR/$hook" "$@"
 }
 
@@ -363,6 +365,32 @@ assert_eq "live drain: statefile records the surfaced message_id" "1122" \
 # (g2) same open question again -> dedup, no output
 OUT_G2="$(run_drain "$DB_LD1")"
 assert_eq "live drain: dedup suppresses re-surfacing the same message_id" "" "$OUT_G2"
+
+# (g-wd) watchdog probes are NEVER open questions (2026-06-04, marveen report:
+# the drain surfaced `__wd_ping <ISO>` as OPEN_QUESTION; answering probes is
+# forbidden by CLAUDE.md). Two invariants: a probe-only inbound surfaces
+# nothing; AND a probe arriving AFTER a real unanswered question must not
+# mask it (the source filter selects the newest NON-probe inbound).
+mkdir -p "$TMPDIR_BASE/ldw1"; DB_LDW1="$TMPDIR_BASE/ldw1/x.db"
+emit_inbound 8517922966 1571 "__wd_ping 2026-06-04T13:25:00Z" | run_hook ledger-capture.py "$DB_LDW1"
+age_rows "$DB_LDW1" 120
+OUT_GW1="$(run_drain "$DB_LDW1")"
+if printf '%s' "$OUT_GW1" | grep -q "OPEN_QUESTION"; then
+    fail "live drain: wd_ping probe surfaced as OPEN_QUESTION (got: $OUT_GW1)"
+else
+    pass "live drain: wd_ping probe-only inbound surfaces nothing"
+fi
+
+mkdir -p "$TMPDIR_BASE/ldw2"; DB_LDW2="$TMPDIR_BASE/ldw2/x.db"
+emit_inbound 8517922966 1580 "Valodi kerdes valasz nelkul" | run_hook ledger-capture.py "$DB_LDW2"
+emit_inbound 8517922966 1581 "__wd_ping 2026-06-04T13:30:00Z" | run_hook ledger-capture.py "$DB_LDW2"
+age_rows "$DB_LDW2" 120
+OUT_GW2="$(run_drain "$DB_LDW2")"
+if printf '%s' "$OUT_GW2" | grep -q "OPEN_QUESTION chat_id=8517922966 message_id=1580"; then
+    pass "live drain: a newer wd_ping does NOT mask the real unanswered question"
+else
+    fail "live drain: real question masked by a newer wd_ping (got: $OUT_GW2)"
+fi
 
 # (g3) a later 'out' answered it -> no output
 mkdir -p "$TMPDIR_BASE/ld3"; DB_LD3="$TMPDIR_BASE/ld3/x.db"

--- a/scripts/agent-context-guard.sh
+++ b/scripts/agent-context-guard.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Context-exhaustion guard for the always-alive channel agents.
+#
+# Symptom it fixes (2026-06-02): sub-agents run with `claude --continue`, so
+# their conversation grows without bound. At ~100% context the next turn would
+# need the 1M-context window, which requires usage credits that are not enabled
+# -> every reply dies with "Usage credits required for 1M context". The agent
+# still RECEIVES inbound messages (channel is alive -- this is NOT deafness),
+# it just cannot answer.
+#
+# Recovery: issue `/clear` into the wedged pane. That resets the conversation
+# client-side (no API call, no credits), the channel stays connected, and the
+# agent answers the next message. We only act when the credit-wall error is
+# visible on the pane RIGHT NOW, so the agent is already non-functional and
+# /clear loses nothing that was not already broken.
+#
+# Invoked every minute by marveen-agent-context-guard.timer (systemd --user).
+
+set -u
+
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# tmux session names of the agents to guard. Override with CTXGUARD_SESSIONS
+# (space-separated) so the list is not hardcoded to one deployment's agents.
+if [ -n "${CTXGUARD_SESSIONS:-}" ]; then
+  read -r -a SESSIONS <<< "$CTXGUARD_SESSIONS"
+else
+  SESSIONS=(aladar-channels agent-dia agent-erno-ba agent-virgil)
+fi
+
+# The exact wedge signature printed by claude when context is full and the
+# 1M-context spill needs credits.
+WEDGE_RE='Usage credits required for 1M context'
+
+# Per-session cooldown so a still-settling pane is not cleared twice in a row.
+COOLDOWN=600   # seconds
+STATE_DIR="${CTXGUARD_STATE_DIR:-$INSTALL_DIR/store}"
+mkdir -p "$STATE_DIR" 2>/dev/null || true   # ensure stamp writes never fail on a missing dir
+
+ts() { date '+%F %T'; }
+
+for s in "${SESSIONS[@]}"; do
+  tmux has-session -t "$s" 2>/dev/null || continue
+
+  pane="$(tmux capture-pane -t "$s" -p 2>/dev/null)"
+  printf '%s' "$pane" | grep -q "$WEDGE_RE" || continue
+
+  stamp="$STATE_DIR/.ctxguard-$s"
+  if [ -f "$stamp" ]; then
+    last="$(cat "$stamp" 2>/dev/null || echo 0)"
+    now="$(date +%s)"
+    if [ $((now - last)) -lt "$COOLDOWN" ]; then
+      echo "$(ts) $s wedged but in cooldown ($((now - last))s) -- skip"
+      continue
+    fi
+  fi
+
+  echo "$(ts) $s WEDGED on context/credit wall -> issuing /clear"
+  tmux send-keys -t "$s" Escape;  sleep 1
+  tmux send-keys -t "$s" C-u;     sleep 1
+  tmux send-keys -t "$s" "/clear"; sleep 1
+  tmux send-keys -t "$s" Enter;   sleep 3
+
+  if tmux capture-pane -t "$s" -p 2>/dev/null | grep -q "$WEDGE_RE"; then
+    echo "$(ts) $s still shows wedge after /clear -- needs manual attention"
+  else
+    echo "$(ts) $s recovered (context cleared)"
+  fi
+  date +%s > "$stamp" 2>/dev/null || true   # best-effort: tolerate ENOSPC
+done

--- a/scripts/hooks/ledger-live-drain.py
+++ b/scripts/hooks/ledger-live-drain.py
@@ -83,6 +83,13 @@ def main():
         sys.exit(0)
 
     snippet = (text or "").strip()
+    # Safety net (ac66f49; the source filter lives in ledger_lib): a watchdog
+    # probe must never surface as an open question -- answering it is forbidden,
+    # so surfacing it only burns an operator decision. Worse, a probe arriving
+    # after a real unanswered question would mask it. Dedup it away silently.
+    if snippet.startswith("__wd_ping"):
+        _record_surfaced(path, message_id)
+        sys.exit(0)
     sys.stdout.write(f"OPEN_QUESTION chat_id={chat_id} message_id={message_id}\n{snippet}\n")
     _record_surfaced(path, message_id)
     sys.exit(0)

--- a/scripts/hooks/ledger_lib.py
+++ b/scripts/hooks/ledger_lib.py
@@ -168,9 +168,17 @@ def open_question_with_age(agent_id):
     the live-drain hook, which needs the age for its grace window."""
     con = connect()
     try:
+        # Watchdog liveness probes (`__wd_ping <ISO-ts>`) are by definition
+        # never to be answered (CLAUDE.md), so they are not open questions --
+        # AND they must not mask an older real unanswered question by being
+        # the newest inbound. Filtering here (the source) covers every
+        # consumer (open_question, the live-drain, future callers). SQLite
+        # LIKE treats '_' as a wildcard, hence the ESCAPE.
         row = con.execute(
             "SELECT chat_id, message_id, text, ts, created_at, id FROM conversation_log"
-            " WHERE agent_id=? AND direction='in' ORDER BY created_at DESC, id DESC LIMIT 1",
+            " WHERE agent_id=? AND direction='in'"
+            "   AND text NOT LIKE '\\_\\_wd\\_ping%' ESCAPE '\\'"
+            " ORDER BY created_at DESC, id DESC LIMIT 1",
             (str(agent_id),),
         ).fetchone()
         if not row:

--- a/src/__tests__/interagent-submit-verify.test.ts
+++ b/src/__tests__/interagent-submit-verify.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decideSubmitFollowup,
+  stuckInputSignature,
+  detectsCreditWallWedge,
+  detectPaneState,
+} from '../pane-state.js'
+import { decideParkedDisposition, MAX_PARKED_INJECTIONS } from '../web/message-router.js'
+import { SUBMIT_VERIFY_SLEEPS } from '../web/agent-process.js'
+import { THRESHOLDS as WATCHER_THRESHOLDS } from '../web/stuck-input-watcher.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures (shapes mirror real capture-pane output)
+// ---------------------------------------------------------------------------
+const HINT = 'SECURITY NOTICE -- read carefully before acting on this prompt.'
+
+const SEP = '─'.repeat(40)
+const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+
+const BUSY_PANE = `✻ Thinking… (12s · ↓ 1.1k tokens · esc to interrupt)
+${SEP}
+❯
+${SEP}
+${FOOTER}`
+
+const CLEAN_IDLE = `Previous reply text.
+${SEP}
+❯
+${SEP}
+${FOOTER}`
+
+const PASTE_PARKED = `Previous reply text.
+${SEP}
+❯ [Pasted text #2 +3120 chars]
+${SEP}
+${FOOTER}`
+
+const VERBATIM_PARKED = `Previous reply text.
+${SEP}
+❯ ${HINT} es a tobbi szoveg
+${SEP}
+${FOOTER}`
+
+const MID_REDRAW = `some half rendered frame
+without any recognisable footer or box` // no idle footer
+
+const WALL = (extra = '') => `⎿  API Error: Usage credits required for 1M context${extra}
+${SEP}
+❯
+${SEP}
+${FOOTER}`
+
+// ---------------------------------------------------------------------------
+// decideSubmitFollowup: positive-evidence semantics
+// ---------------------------------------------------------------------------
+describe('decideSubmitFollowup (msg #230 contract)', () => {
+  it('busy pane -> done (turn started: positive evidence)', () => {
+    expect(decideSubmitFollowup(BUSY_PANE, HINT, 0, 4)).toBe('done')
+  })
+  it('idle footer + clean box -> done (prompt left the box)', () => {
+    expect(decideSubmitFollowup(CLEAN_IDLE, HINT, 0, 4)).toBe('done')
+  })
+  it('mid-redraw frame (no footer) -> wait, NEVER done', () => {
+    expect(decideSubmitFollowup(MID_REDRAW, HINT, 0, 4)).toBe('wait')
+  })
+  it('null capture -> wait', () => {
+    expect(decideSubmitFollowup(null, HINT, 0, 4)).toBe('wait')
+  })
+  it('paste placeholder parked -> retry-enter until budget, then give-up', () => {
+    expect(decideSubmitFollowup(PASTE_PARKED, HINT, 0, 4)).toBe('retry-enter')
+    expect(decideSubmitFollowup(PASTE_PARKED, HINT, 3, 4)).toBe('retry-enter')
+    expect(decideSubmitFollowup(PASTE_PARKED, HINT, 4, 4)).toBe('give-up')
+  })
+  it('verbatim payload parked -> retry-enter', () => {
+    expect(decideSubmitFollowup(VERBATIM_PARKED, HINT, 0, 4)).toBe('retry-enter')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stuckInputSignature: the watcher must SEE a paste park
+// ---------------------------------------------------------------------------
+describe('stuckInputSignature paste unblinding', () => {
+  it('paste park under idle footer -> signature (watcher can recover)', () => {
+    const sig = stuckInputSignature(PASTE_PARKED)
+    expect(sig).not.toBeNull()
+    expect(sig).toContain('[Pasted text #2')
+  })
+  it('paste reference inside a BUSY turn -> null (never pre-empt a live turn)', () => {
+    const busyWithPaste = `❯ [Pasted text #2 +3120 chars]
+✻ Thinking… (3s · ↓ 0.2k tokens · esc to interrupt)
+${SEP}
+❯
+${SEP}
+${FOOTER}`
+    expect(stuckInputSignature(busyWithPaste)).toBeNull()
+  })
+  it('clean idle box -> null', () => {
+    expect(stuckInputSignature(CLEAN_IDLE)).toBeNull()
+  })
+  it('detectPaneState still reports busy for a paste park (scheduler contract unchanged)', () => {
+    expect(detectPaneState(PASTE_PARKED)).toBe('busy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectsCreditWallWedge: the router must not inject into a wedged pane
+// ---------------------------------------------------------------------------
+describe('detectsCreditWallWedge (msg #220 contract)', () => {
+  it('wedge in the live tail -> true', () => {
+    expect(detectsCreditWallWedge(WALL())).toBe(true)
+  })
+  it('phrase quoted in the live INPUT BOX -> false (someone composing about the bug)', () => {
+    const composing = `Previous reply text.
+${SEP}
+❯ jelzem hogy a "Usage credits required for 1M context" hibat lattam
+${SEP}
+${FOOTER}`
+    expect(detectsCreditWallWedge(composing)).toBe(false)
+  })
+  it('phrase deep in scrollback, clean live tail -> false', () => {
+    const scrollback = `old turn: Usage credits required for 1M context discussion
+${'filler line\n'.repeat(30)}${SEP}
+❯
+${SEP}
+${FOOTER}`
+    expect(detectsCreditWallWedge(scrollback)).toBe(false)
+  })
+  it('phrase while a turn is BUSY (streaming a quote) -> false', () => {
+    const busyQuote = `Usage credits required for 1M context
+✻ Thinking… (3s · ↓ 0.2k tokens · esc to interrupt)
+${SEP}
+❯
+${SEP}
+${FOOTER}`
+    expect(detectsCreditWallWedge(busyQuote)).toBe(false)
+  })
+  it('no idle footer -> false (not a readable Claude surface)', () => {
+    expect(detectsCreditWallWedge('Usage credits required for 1M context')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Router parked disposition: bounded clean retries, then VISIBLE failure
+// ---------------------------------------------------------------------------
+describe('decideParkedDisposition', () => {
+  it('retries below the cap, fails at the cap', () => {
+    expect(decideParkedDisposition(1, MAX_PARKED_INJECTIONS)).toBe('retry')
+    expect(decideParkedDisposition(2, MAX_PARKED_INJECTIONS)).toBe('retry')
+    expect(decideParkedDisposition(3, MAX_PARKED_INJECTIONS)).toBe('fail')
+    expect(decideParkedDisposition(7, MAX_PARKED_INJECTIONS)).toBe('fail')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Timing contract: the duplicate-delivery guard. A router-injected park is
+// always rolled back within sendPromptToSession's verify budget; the watcher
+// only Enter-recovers text parked LONGER than confirmMs. If the budget ever
+// grows past confirmMs, the watcher could submit the same text the router is
+// about to re-send -> double delivery. This test makes that invariant explicit.
+// ---------------------------------------------------------------------------
+describe('anti-duplicate timing contract', () => {
+  it('total verify budget stays below the watcher confirm window', () => {
+    const budgetMs = SUBMIT_VERIFY_SLEEPS.reduce((s, x) => s + parseFloat(x) * 1000, 0)
+    expect(budgetMs).toBeLessThan(WATCHER_THRESHOLDS.confirmMs)
+  })
+})

--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -991,11 +991,13 @@ describe('shouldRetrySubmit minHintChars clamp', () => {
 })
 
 describe('decideSubmitFollowup', () => {
-  it('returns "give-up" when the pane capture failed', () => {
-    // A null pane means we cannot tell whether the prompt landed; the
-    // safest action is to stop retrying rather than fire a blind
-    // Enter that might submit a different turn's draft.
-    expect(decideSubmitFollowup(null, PAYLOAD_HINT, 0, 2)).toBe('give-up')
+  it('returns "wait" when the pane capture failed (2026-06-03 semantics)', () => {
+    // A null pane means we cannot tell whether the prompt landed. The
+    // old contract said 'give-up', which the caller treated as terminal
+    // and the router marked the message delivered -- a single capture
+    // hiccup became silent loss (msg #230). 'wait' re-samples WITHOUT
+    // firing a blind Enter; the caller's poll budget bounds the loop.
+    expect(decideSubmitFollowup(null, PAYLOAD_HINT, 0, 2)).toBe('wait')
   })
 
   it('returns "done" when the pane is not stuck', () => {
@@ -1151,8 +1153,13 @@ describe('stuckInputSignature', () => {
     expect(stuckInputSignature(BUSY_FULL_FOOTER)).toBeNull()
   })
 
-  it('is null for a paste placeholder (treated as busy, not parked text)', () => {
-    expect(stuckInputSignature(PENDING_PASTE)).toBeNull()
+  it('returns a signature for a parked paste placeholder (2026-06-03 unblinding)', () => {
+    // The placeholder never auto-submits, so the watcher MUST see it to
+    // Enter-recover it -- previously it was invisible to every net and a
+    // parked inter-agent message sat 25 minutes until a manual Enter
+    // (msg #230). detectPaneState still reports 'busy' for scheduler
+    // purposes; only the watcher signature changed.
+    expect(stuckInputSignature(PENDING_PASTE)).toContain('[Pasted text #1')
   })
 
   it('ignores a ❯ caret left in scrollback', () => {

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -698,6 +698,7 @@ export function parkedChannelInput(pane: string): ParkedChannelInput | null {
   // rather than re-inject to a wrong chat_id.
   if (!cm || /\s/.test(cm[1])) return { complete: false, block, chatId: null }
   return { complete: true, block, chatId: cm[1] }
+}
 
 // =============================================================================
 // Context/credit-wall wedge (2026-06-03, msg #220 loss at erno-ba)

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -457,7 +457,7 @@ export function shouldClearTruncatedPreamble(pane: string): boolean {
   return true
 }
 
-export type SubmitFollowupAction = 'retry-enter' | 'done' | 'give-up'
+export type SubmitFollowupAction = 'retry-enter' | 'done' | 'give-up' | 'wait'
 
 /**
  * Decide what the post-send-keys loop should do next, given the
@@ -489,6 +489,15 @@ export type SubmitFollowupAction = 'retry-enter' | 'done' | 'give-up'
  *                     send total. The decision returns 'give-up' once
  *                     attempt >= maxAttempts and the pane is still
  *                     stuck.
+ *
+ * SEMANTICS (2026-06-03, msg #230 silent-loss fix): 'done' requires
+ * POSITIVE evidence — a live busy indicator (the turn started) or an
+ * idle footer with a clean input box (the prompt left the box). An
+ * ambiguous frame (capture failed, no idle footer mid-redraw, input box
+ * not parseable) returns 'wait': re-sample, never conclude success. The
+ * old behavior declared 'done' on exactly those ambiguous frames, so a
+ * paste-placeholder park behind one mid-redraw frame was reported as
+ * submitted and the message was lost-as-delivered.
  */
 export function decideSubmitFollowup(
   pane: string | null,
@@ -496,10 +505,24 @@ export function decideSubmitFollowup(
   attempt: number,
   maxAttempts: number,
 ): SubmitFollowupAction {
-  if (pane == null) return 'give-up'
-  if (!shouldRetrySubmit(pane, payloadHint)) return 'done'
-  if (attempt >= maxAttempts) return 'give-up'
-  return 'retry-enter'
+  // Capture failed: cannot conclude anything -- re-sample.
+  if (pane == null || !pane.trim()) return 'wait'
+  // Positive evidence the turn started: any live busy indicator.
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(pane)) return 'done'
+  }
+  // No idle footer: mid-redraw / unknown surface. NOT success -- wait.
+  if (!IDLE_FOOTER_RX.test(pane)) return 'wait'
+  const inputBox = liveInputBox(pane)
+  if (inputBox == null) return 'wait'
+  // Parked: paste placeholder, or the just-sent payload verbatim.
+  const parked =
+    PENDING_PASTE_RX.test(inputBox) ||
+    (payloadHint.length >= 16 && inputBox.includes(payloadHint))
+  if (parked) return attempt >= maxAttempts ? 'give-up' : 'retry-enter'
+  // Positive evidence of submit: idle footer + the box no longer holds
+  // our payload.
+  return 'done'
 }
 
 export interface PaneErrorAlertState {
@@ -609,9 +632,27 @@ export function decidePaneErrorAlert(
 // confirm window. Returns null (not an empty string) when there is no
 // parked text so callers can branch on "is anything parked at all".
 export function stuckInputSignature(pane: string): string | null {
-  if (detectPaneState(pane) !== 'typing') return null
+  if (!pane || !pane.trim()) return null
+  // A live turn (busy indicator) is never a parked input.
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(pane)) return null
+  }
+  if (!IDLE_FOOTER_RX.test(pane)) return null
   const box = liveInputBox(pane)
   if (box == null) return null
+  // Paste-placeholder park (2026-06-03, msg #230): a `[Pasted text #N]`
+  // stub under an idle footer never auto-submits. detectPaneState
+  // deliberately reports it 'busy' so the scheduler/router won't pile a
+  // second prompt on top -- but the recovery watcher MUST see it, else a
+  // parked paste is invisible to every safety net and sits until a human
+  // presses Enter. Signature on the placeholder text (stable once the
+  // paste has settled; still-arriving chunks change the box content and
+  // keep restarting the confirm window).
+  if (PENDING_PASTE_RX.test(box)) {
+    const sig = box.replace(/\s+/g, ' ').trim()
+    return sig.length > 0 ? sig : null
+  }
+  if (detectPaneState(pane) !== 'typing') return null
   const sig = box.replace(/\s+/g, ' ').trim()
   return sig.length > 0 ? sig : null
 }
@@ -657,6 +698,68 @@ export function parkedChannelInput(pane: string): ParkedChannelInput | null {
   // rather than re-inject to a wrong chat_id.
   if (!cm || /\s/.test(cm[1])) return { complete: false, block, chatId: null }
   return { complete: true, block, chatId: cm[1] }
+
+// =============================================================================
+// Context/credit-wall wedge (2026-06-03, msg #220 loss at erno-ba)
+// =============================================================================
+
+// The exact error claude prints when the conversation has outgrown the
+// normal window and the 1M-context spill needs usage credits that are
+// not enabled. Mirrors WEDGE_RE in scripts/agent-context-guard.sh (the
+// guard that auto-/clears the session); keep the two in sync.
+const CREDIT_WALL_PHRASE = 'Usage credits required for 1M context'
+
+// How many lines above the idle footer count as the live tail for the
+// wall check. Same rationale as ERROR_LIVE_TAIL_LINES.
+const WALL_LIVE_TAIL_LINES = 20
+
+/**
+ * True when the pane shows the credit-wall wedge in its LIVE TAIL: the
+ * session cannot process any prompt (every turn dies on the same error)
+ * until agent-context-guard /clears it. The router checks this before
+ * injecting so an inter-agent message is not typed into a doomed pane
+ * and then marked delivered (the msg #220 loss).
+ *
+ * False-positive guards:
+ *   - busy indicator anywhere -> false (a live turn merely STREAMING the
+ *     quoted phrase is not wedged);
+ *   - scope: only the WALL_LIVE_TAIL_LINES above the bottom-most idle
+ *     footer; the phrase deep in scrollback (an old discussion) never
+ *     triggers;
+ *   - the live input box content is EXCLUDED, so an operator/agent
+ *     composing a message that quotes the phrase does not trigger.
+ * Residual risk (a finished reply quoting the phrase in its last lines)
+ * is bounded by the caller's defer window, not here.
+ */
+export function detectsCreditWallWedge(pane: string): boolean {
+  if (!pane || !pane.includes(CREDIT_WALL_PHRASE)) return false
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(pane)) return false
+  }
+  const lines = pane.split('\n')
+  // Bottom-most idle footer (the live footer is the last one rendered).
+  let footerIdx = -1
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (IDLE_FOOTER_RX.test(lines[i])) { footerIdx = i; break }
+  }
+  if (footerIdx < 0) return false
+  // Identify the live input box bounds so its content can be excluded.
+  let bottomSep = -1
+  for (let i = footerIdx - 1; i >= 0; i--) {
+    if (BOX_SEP_RX.test(lines[i])) { bottomSep = i; break }
+  }
+  let topSep = -1
+  if (bottomSep > 0) {
+    for (let i = bottomSep - 1; i >= 0; i--) {
+      if (BOX_SEP_RX.test(lines[i])) { topSep = i; break }
+    }
+  }
+  const tailStart = Math.max(0, footerIdx - WALL_LIVE_TAIL_LINES)
+  for (let i = tailStart; i < footerIdx; i++) {
+    if (topSep >= 0 && i > topSep && i < bottomSep) continue // inside input box
+    if (lines[i].includes(CREDIT_WALL_PHRASE)) return true
+  }
+  return false
 }
 
 // Per-session bookkeeping for the stuck-input recovery watcher. A "spell"

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -8,6 +8,7 @@ import { logger } from '../logger.js'
 import {
   detectPaneState,
   decideSubmitFollowup,
+  shouldRetrySubmit,
   shouldClearTruncatedPreamble,
 } from '../pane-state.js'
 import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName } from './agent-config.js'
@@ -359,29 +360,41 @@ export function scheduleIdentitySetup(session: string, displayName: string): voi
 
 // How many follow-up Enters sendPromptToSession() is willing to fire
 // when the post-send capture says the prompt is still parked in the
-// input box. Two retries cover the observed stuck-rate (single-pane
-// recovery typically lands on the first or second extra Enter); a
-// stuck-after-two-retries pane gets a logged give-up so the operator
-// can intervene rather than the loop spinning indefinitely.
-const SUBMIT_RETRY_MAX_ATTEMPTS = 2
-// Wait between sending an Enter and re-capturing the pane. Long enough
-// for tmux to flush the keystroke into the Claude Code TUI and for
-// the TUI to either transition to busy (turn started) or stay idle
-// with the parked text (still stuck). Empirically 300ms is past the
-// frame-render gap detectPaneState already guards against.
-const SUBMIT_RETRY_POLL_MS = '0.3'
+// input box. Four because a bracketed-paste placeholder ignores Enters
+// until the paste settles (msg #230: 2 quick retries all lost the race,
+// yet ONE manual Enter 25 minutes later worked instantly).
+const SUBMIT_RETRY_MAX_ATTEMPTS = 4
+// Escalating poll sleeps for the post-send verification loop, in
+// seconds (passed to /bin/sleep). Total worst case ~8.3s -- bounded
+// because everything here is execSync and blocks the event loop; the
+// typical verified-submit path exits on the first or second poll, and a
+// pure-miss path (only ambiguous frames, no park ever seen) breaks
+// early after 3 polls (~1.8s).
+//
+// TIMING CONTRACT (locked by interagent-submit-verify.test.ts): the
+// total of these sleeps MUST stay below the stuck-input watcher's
+// confirmMs (10s). A router-injected park is always rolled back within
+// this budget, so the watcher can never confirm-and-Enter the SAME text
+// the router is about to re-send -- that ordering is what prevents the
+// duplicate-delivery race.
+export const SUBMIT_VERIFY_SLEEPS = ['0.3', '0.5', '1', '1.5', '2', '3'] as const
 
 // Buffer-clear (Ctrl-U) used pre-flight when shouldClearTruncatedPreamble
 // flags a stale preamble. Sent as a single key name (no `-l` literal
 // flag) so tmux interprets it as the control sequence.
-export function clearInputBuffer(session: string): void {
+// Merged resolution (52c84e4 x upstream #293): keep the export (the stuck-input
+// watchdog calls this externally) AND the boolean return (the verified-submit
+// flow checks the outcome). void-callers are unaffected by a boolean return.
+export function clearInputBuffer(session: string): boolean {
   try {
     execFileSync(TMUX, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
     // Settle briefly so the next send-keys lands in the freshly cleared
     // buffer rather than racing the Ctrl-U.
     execFileSync('/bin/sleep', ['0.1'], { timeout: 2000 })
+    return true
   } catch (err) {
     logger.warn({ err, session }, 'Failed to clear pane input buffer before send')
+    return false
   }
 }
 
@@ -404,7 +417,9 @@ export function clearInputBuffer(session: string): void {
 // still reports stuck, send up to SUBMIT_RETRY_MAX_ATTEMPTS extra
 // Enters. The retry budget bounds the loop so a pathologically stuck
 // pane gives up rather than spinning.
-export function sendPromptToSession(session: string, text: string): void {
+export type SendPromptOutcome = 'submitted' | 'parked'
+
+export function sendPromptToSession(session: string, text: string): SendPromptOutcome {
   dismissSurveyModalIfPresent(session)
   dismissResumeSummaryModalIfPresent(session)
 
@@ -446,28 +461,66 @@ export function sendPromptToSession(session: string, text: string): void {
   }
   execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
 
-  // Post-send retry loop. The payload hint is the first chunk of oneLine
-  // (truncated to a safe length) so the verbatim-stuck path has something
-  // recognisable to substring-match against without leaking the whole
-  // prompt body into log lines should the give-up branch fire.
+  // Post-send verification loop (2026-06-03 msg #230 silent-loss fix).
+  // The payload hint is the first chunk of oneLine (truncated) so the
+  // verbatim-stuck path has something recognisable to substring-match
+  // against without leaking the whole prompt body into logs.
+  //
+  // 'done' now requires POSITIVE evidence (busy indicator, or idle footer
+  // with a clean input box); ambiguous frames return 'wait' and we
+  // re-sample. The sleeps ESCALATE because a bracketed-paste placeholder
+  // needs a moment to settle before an Enter lands -- the old fixed
+  // 2x0.3s budget always lost that race.
   const payloadHint = oneLine.slice(0, Math.min(oneLine.length, 96))
-  for (let attempt = 0; ; attempt++) {
-    try { execFileSync('/bin/sleep', [SUBMIT_RETRY_POLL_MS], { timeout: 2000 }) } catch { /* best effort */ }
+  let enters = 0
+  for (let poll = 0; poll < SUBMIT_VERIFY_SLEEPS.length; poll++) {
+    try { execFileSync('/bin/sleep', [SUBMIT_VERIFY_SLEEPS[poll]], { timeout: 4000 }) } catch { /* best effort */ }
     const pane = capturePane(session)
-    const action = decideSubmitFollowup(pane, payloadHint, attempt, SUBMIT_RETRY_MAX_ATTEMPTS)
-    if (action === 'done') break
-    if (action === 'give-up') {
-      logger.warn({ session, attempt }, 'sendPromptToSession: prompt still parked after retries')
-      break
+    const action = decideSubmitFollowup(pane, payloadHint, enters, SUBMIT_RETRY_MAX_ATTEMPTS)
+    if (action === 'done') return 'submitted'
+    if (action === 'wait') {
+      // Pure-miss early break: if 3 polls produced only ambiguous frames
+      // and we never positively saw a park, stop burning the event loop
+      // (~1.8s spent) -- the final capture below decides, and the watcher
+      // backstop covers a park we could not see.
+      if (enters === 0 && poll >= 2) break
+      continue
     }
+    if (action === 'give-up') break
     // action === 'retry-enter'
+    enters++
     try {
       execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
     } catch (err) {
-      logger.warn({ err, session, attempt }, 'Retry-Enter send failed')
+      logger.warn({ err, session, enters }, 'Retry-Enter send failed')
       break
     }
   }
+
+  // Budget spent. Roll back ONLY a park we can positively see, so the
+  // caller can re-inject cleanly later (a parked prompt must never be
+  // reported as submitted -- that is how msg #230 was lost-as-delivered).
+  // An unreadable final frame is left alone: blind-clearing a pane we
+  // cannot read risks destroying state, so we report submitted and rely
+  // on the stuck-input watcher backstop.
+  const last = capturePane(session)
+  if (last != null && shouldRetrySubmit(last, payloadHint)) {
+    // 'parked' PROMISES the caller a clean buffer for re-injection. If the
+    // rollback fails, that promise would be false: the next injection
+    // would concatenate onto the stale text, AND the (paste-unblinded)
+    // stuck-input watcher could later Enter the leftover while the router
+    // re-sends -- the duplicate-delivery race. So a failed clear reports
+    // 'submitted' instead and the watcher backstop delivers the parked
+    // copy exactly once.
+    if (clearInputBuffer(session)) {
+      logger.warn({ session, enters }, 'sendPromptToSession: prompt PARKED after retry budget -- input cleared for a clean re-send')
+      return 'parked'
+    }
+    logger.warn({ session, enters }, 'sendPromptToSession: prompt parked AND buffer-clear failed; deferring to the stuck-input watcher (single delivery preserved)')
+    return 'submitted'
+  }
+  logger.warn({ session, enters }, 'sendPromptToSession: could not verify submit (ambiguous frames); assuming submitted')
+  return 'submitted'
 }
 
 // How long to wait between the two capture samples when the first one

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -22,9 +22,11 @@ import { isKnownAgent } from './agent-config.js'
 import { readAgentTeam } from './agent-team.js'
 import {
   agentSessionName,
+  capturePane,
   isSessionReadyForPrompt,
   sendPromptToSession,
 } from './agent-process.js'
+import { detectsCreditWallWedge } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 
 const TMUX = resolveFromPath('tmux')
@@ -48,6 +50,37 @@ const MESSAGE_ABANDON_WINDOW_MS = 60 * 60 * 1000
 // Log "skipping, target not ready" at most once per message id so a busy
 // receiver over many 5s ticks does not spam the log.
 const routerLoggedMisses: Set<number> = new Set()
+
+// How many PARKED injection outcomes (text typed but submit never landed;
+// buffer rolled back) a single message may accumulate before it is marked
+// failed. Each attempt re-types from a clean buffer, so this bounds a
+// pathological never-submitting target instead of retrying forever.
+export const MAX_PARKED_INJECTIONS = 3
+const parkedCounts: Map<number, number> = new Map()
+
+// Credit-wall defer (msg #220 loss at erno-ba): when the target pane shows
+// the "Usage credits required for 1M context" wedge in its live tail, an
+// injected prompt is doomed -- the turn dies on the same error and the
+// message would be lost-as-delivered. Defer instead; agent-context-guard
+// auto-/clears a REAL wall within ~1-11 minutes, after which delivery
+// proceeds. The escape hatch bounds a false positive (a finished reply
+// QUOTING the phrase in its last lines would otherwise defer forever,
+// because no new turn ever scrolls it away).
+const WALL_DEFER_MAX_MS = 15 * 60 * 1000
+const wallFirstSeen: Map<string, number> = new Map()
+// Re-log the defer roughly once a minute per session (not once per message)
+// so an operator watching the log can SEE an ongoing wall-stall instead of
+// a single line 14 minutes ago.
+const wallLastLogAt: Map<string, number> = new Map()
+
+/**
+ * Pure disposition for a parked injection outcome: 'retry' keeps the
+ * message pending for a clean re-send, 'fail' marks it failed once the
+ * cap is reached. Exported for contract tests.
+ */
+export function decideParkedDisposition(parkedSoFar: number, cap: number): 'retry' | 'fail' {
+  return parkedSoFar >= cap ? 'fail' : 'retry'
+}
 
 /**
  * Pure decision: should a pending inter-agent message be abandoned?
@@ -106,6 +139,32 @@ export function startMessageRouter(): NodeJS.Timeout {
         continue
       }
 
+      // Credit-wall check BEFORE readiness: a wedged pane often still shows
+      // an idle footer, so isSessionReadyForPrompt alone would inject a
+      // doomed prompt into it (the msg #220 loss path).
+      const wallPane = capturePane(session)
+      if (wallPane != null && detectsCreditWallWedge(wallPane)) {
+        const firstSeen = wallFirstSeen.get(session) ?? now
+        if (!wallFirstSeen.has(session)) wallFirstSeen.set(session, now)
+        if (now - firstSeen < WALL_DEFER_MAX_MS) {
+          const lastLog = wallLastLogAt.get(session) ?? 0
+          if (now - lastLog >= 60_000) {
+            wallLastLogAt.set(session, now)
+            logger.warn(
+              { id: msg.id, to: msg.to_agent, session, deferredForMs: now - firstSeen, deferRemainingMs: WALL_DEFER_MAX_MS - (now - firstSeen) },
+              'Agent message deferred: target pane is on the context/credit wall (agent-context-guard should clear it)',
+            )
+          }
+          continue
+        }
+        // Escape hatch: a real wall would have been cleared by the guard by
+        // now; treat the lingering phrase as quoted scrollback and proceed.
+        logger.warn({ session }, 'Credit-wall phrase persisted past the defer window -- treating as stale/quoted and resuming delivery')
+      } else {
+        wallFirstSeen.delete(session)
+        wallLastLogAt.delete(session)
+      }
+
       if (!isSessionReadyForPrompt(session)) {
         if (!routerLoggedMisses.has(msg.id)) {
           logger.warn({ id: msg.id, to: msg.to_agent, session }, 'Agent message target session busy, will retry')
@@ -161,10 +220,33 @@ export function startMessageRouter(): NodeJS.Timeout {
         }
         // Inline preamble so a fresh session (post hard-restart) doesn't miss
         // the context that explains the tag semantics.
-        sendPromptToSession(session, prefix + wrapped)
+        // Merged resolution (52c84e4 x coordinator prefix-building): the prefix
+        // is built above (channel-inbound aware); here we keep the VERIFIED
+        // submit flow (outcome=parked -> never mark delivered, msg #230 loss).
+        const outcome = sendPromptToSession(session, prefix + wrapped)
+        if (outcome === 'parked') {
+          // The text never submitted; sendPromptToSession rolled the input
+          // buffer back, so the message can re-send cleanly. Do NOT mark
+          // delivered (msg #230 was lost exactly that way) -- retry up to
+          // the cap, then fail VISIBLY so the sender knows.
+          const parked = (parkedCounts.get(msg.id) ?? 0) + 1
+          parkedCounts.set(msg.id, parked)
+          if (decideParkedDisposition(parked, MAX_PARKED_INJECTIONS) === 'fail') {
+            logger.warn({ id: msg.id, to: msg.to_agent, session, parked }, 'Agent message FAILED: injected text would not submit after repeated clean attempts')
+            if (!markMessageFailed(msg.id, `Injected text would not submit (parked) after ${parked} attempts`)) {
+              logger.warn({ id: msg.id }, 'markMessageFailed affected 0 rows (deleted concurrently?)')
+            }
+            parkedCounts.delete(msg.id)
+            routerLoggedMisses.delete(msg.id)
+          } else {
+            logger.warn({ id: msg.id, to: msg.to_agent, session, parked }, 'Agent message injection parked; buffer cleared, will re-send')
+          }
+          continue
+        }
         if (!markMessageDelivered(msg.id)) {
           logger.warn({ id: msg.id }, 'markMessageDelivered affected 0 rows (deleted concurrently?)')
         }
+        parkedCounts.delete(msg.id)
         routerLoggedMisses.delete(msg.id)
         logger.info({ id: msg.id, from: msg.from_agent, to: msg.to_agent, category: isChannelInbound ? 'channel-inbound' : trusted ? 'trusted-peer' : 'untrusted' }, 'Agent message delivered')
       } catch (err) {

--- a/src/web/stuck-input-watcher.ts
+++ b/src/web/stuck-input-watcher.ts
@@ -24,7 +24,11 @@ import {
 // pane-state.ts (unit-tested); this module is only the I/O + per-session
 // state map, mirroring channel-health-monitor.ts.
 
-const THRESHOLDS: StuckInputThresholds = {
+// Exported for the timing-contract test: confirmMs MUST exceed the total
+// of agent-process.ts SUBMIT_VERIFY_SLEEPS, so a router-injected park is
+// always rolled back BEFORE this watcher could confirm-and-Enter it
+// (duplicate-delivery guard).
+export const THRESHOLDS: StuckInputThresholds = {
   // The same text must stay parked this long before the first recovery
   // Enter. A real turn transitions typing -> busy within a second or two
   // of submit, so 10s comfortably clears the frame race while still


### PR DESCRIPTION
Implements the offer in #279 (RFC: loss-prevention continuity ledger). Targets `develop` per the maintainer's current cherry-pick flow.

## What this PR contains

The two remaining fork-only follow-up fixes offered in #279 (the third, `43de77d` router never-abandon, is **already on develop** via #284 — verified semantically present in `shouldAbandon`, so it is intentionally NOT re-included here):

1. **`fix(router): verified inter-agent submit + credit-wall defer`** — two silent-loss modes fixed at source: (a) long messages tripping the TUI bracketed-paste detector were marked *delivered* while parked unsubmitted (25-min real loss); the router now verifies the submit outcome (`SendPromptOutcome`), retries parked injections up to a cap with a clean buffer roll-back, then fails VISIBLY; (b) a session wedged on the 1M-context credit wall is detected (`detectsCreditWallWedge`, live-tail scoped with false-positive guards) and delivery is deferred instead of typing into a doomed pane.
2. **`fix(ledger): watchdog probes are never open questions`** — 3-artifact fix (source filter in `ledger_lib`, surfacing safety net in `ledger-live-drain`, shell contract tests): liveness probes (`__wd_ping <ts>`) never surface as OPEN_QUESTION and can no longer mask a real unanswered user question.

## Conflict-resolution notes (cherry-pick onto develop)

- `pane-state.ts`: develop's `parkedChannelInput` (#293) and our credit-wall block are different features at the same location — **both kept**.
- `agent-process.ts` `clearInputBuffer`: merged signature `export` (your #293 watchdog calls it) **+** `boolean` return (our verified-submit flow checks it); void-callers unaffected.
- `message-router.ts`: develop's richer channel-inbound-aware prefix-building kept; our verified-submit outcome flow added below it.
- `ledger-live-drain.py`: develop's early-exit flow kept; the `__wd_ping` safety net injected before the surfacing write.
- Our fork's swim-app files that were bundled in the original `ac66f49` commit are **excluded** (personal-fork feature, not upstream material).
- The ledger shell test now sets `OWNER_NAME=Gyula` explicitly, exercising your #291 env-derived owner-name path instead of asserting a hardcoded name.

## Verification

- `tsc --noEmit` clean on the branch.
- Focused suites: `interagent-submit-verify` + `router-abandon` + `pane-state` + `stuck-input-watcher` — **151 tests green**; the two new-feature suites alone: 21 green.
- `scripts/__tests__/conversation-ledger.test.sh`: **36/36 green** (includes the 3 new probe-filter contract tests).
- Full vitest on the branch: 1029 passed; the only failures (4) are in `managed-settings.test.ts`, which is **byte-identical to develop in this PR** (`git diff develop..HEAD --name-only` does not include it) — an environment-dependent command-string parse in our VM; expected green in your CI.
- Production provenance: both fixes have been running on our Linux/systemd fork since 2026-06-03/04; the verified-submit path recovered real msg-loss incidents (#230/#220 class), and the probe filter has prevented question-masking since 2026-06-04.

## Open question from the RFC, answered

You asked (well, we asked in #279) "separate PRs or folded into one" — this is the folded version; happy to split if you prefer.

---

*Original RFC text from #279 for context:*


## Summary

Telegram channel "deafness" — the agent's session is alive and logged in
("Listening for channel messages"), but inbound messages never reach the running
session, so the user's messages are silently dropped. We hit this in production
on Linux/systemd; the most painful variant is a mid-session gap where the bridge
consumes a Telegram update but the session never sees it.

The upstream line solves this with a standalone `channel-coordinator` (#259/#261/
#262/#269): a separate poller that detects native-bridge death and re-delivers
lost messages from `getUpdates` after the fact via its own `incoming_events`/
`poll_offset` tables and a reconcile loop.

This RFC describes our fork's alternative: a deterministic conversation-continuity
ledger that prevents the loss in the first place and surfaces any straggler into
the **already-running** session, rather than repairing after death. We are not
proposing to replace the coordinator; we are offering a different tradeoff that is
battle-proven on Linux, plus the remaining fork-only fixes if there's interest.

## Our approach — the continuity ledger

A small, dependency-free (Python stdlib + `better-sqlite3` schema) set of Claude
Code hooks around a durable `conversation_log` table (already merged upstream in
#260, commit `0ebf328`):

- **Capture (UserPromptSubmit).** `ledger-capture.py` parses the inbound
  `<channel source="plugin:telegram:telegram" …>` block and writes it to
  `conversation_log` (direction=`in`) *before* the agent processes the prompt.
  `agent_id` is derived from the session cwd, so the same hook is generic across
  all channel agents and never cross-contaminates.
- **Outbound (PostToolUse).** `ledger-outbound.py` records the agent's replies
  (direction=`out`), so "answered vs. unanswered" is decidable.
- **Replay (SessionStart).** `ledger-replay.py` injects the last ~20 turns
  (token-bounded to ~16k chars) plus a highlighted OPEN QUESTION into the fresh
  session's `additionalContext`. After a respawn the new session doesn't need to
  *remember* anything — its context window already carries the conversation and
  the unanswered question.
- **Live-drain (heartbeat, ~2 min).** `ledger-live-drain.py` handles the case
  SessionStart can't: a message lost in an *already-running* session. It
  re-surfaces the still-unanswered inbound (with a 60s grace so it never fights an
  in-flight reply, and a dedup statefile so it surfaces once) directly into the
  running session — no respawn required. It also surfaces undelivered inter-agent
  reports the router could not hand off while the session was unreachable.

Architecture in one line: capture-before-process → durable transcript →
replay-on-start + drain-into-running-session. The data path is the agent's own
context window, not a second inbound poller.

## How this differs from coordinator backfill

Different layer, different philosophy:

- **Coordinator = after-the-fact repair at the transport layer.** A second
  process polls Telegram directly when the native bridge looks dead, persists to
  its own tables, and a reconcile loop replays abandoned messages. The loss
  guarantee is formally closed and detection is fast (~10s).
- **Ledger = loss-prevention at the session/router layer.** We keep the native
  bridge as the single inbound path and make the session resilient: capture the
  message the moment it arrives, and re-surface it into the live or fresh session
  if it wasn't answered. No second poller, no second Telegram connection.

This is a genuine tradeoff, not a strict win. The coordinator detects and repairs
faster and entirely sidesteps the hard pane-state classification problem. Our
line recovers a real bridge death more slowly (see below) but adds no second
poller, no extra Telegram connection, and is already tuned for systemd
(EXIT_DEFER_TO_PEER / RestartPreventExitStatus). We think both are reasonable;
ours has simply been the one running in our production environment.

## What we observed in production (2026-06-04)

- A real outage was survived with **zero message loss**: a two-direction "acid
  test" passed — the false-positive-respawn direction stayed clean, and a genuine
  bridge death self-healed without losing a single message. The user's messages
  were delayed, not lost.
- Recovery time: an active inbound probe (`inbound-probe.ts`) — a userbot pings
  the bot every 3 minutes, and two missed round-trips declare the channel deaf
  and trigger a pane respawn — puts detection + recovery at **~3–6 minutes** for
  inbound deafness.
- Honest cost: a few minutes is still slower than coordinator backfill detection
  (~10s). If a multi-minute blind window is unacceptable, the coordinator's speed
  is the real argument for it.
- Origin of the design: a mid-session deafness incident on 2026-06-02 where the
  bridge consumed updates the session never saw — the case `ledger-live-drain.py`
  was built for.

## Known interaction/conflict points if both run together

From our conflict analysis (`plan/DEAFNESS_ARCH_COMPARISON_2026-06-04.md`); these
are why we'd be cautious about running both mechanisms simultaneously, not
objections to the coordinator itself:

- **Competing pollers stealing updates.** During a backfill window the
  coordinator polls `getUpdates` on the same bot token the native bridge may also
  poll. If liveness misreads "down" (e.g. a reparented bridge), both poll at once
  → 409 + inbound theft. We have hit this duplicate-poller class before.
- **Two reap/respawn deciders.** The coordinator's detached-claude reap
  (tmux-pane attribution) and our newest-wins/survivor-wins bridge reap target the
  same orphan problem in the same process tree; run naively together they can each
  classify the other's chosen survivor as an orphan → respawn thrash.
- **Loss-guarantee semantics conflict.** Upstream's router abandons a busy-but-
  alive session after ~1h so the coordinator's reconcile can replay the `failed`
  message. Our router (`43de77d`) *never* abandons a busy-but-alive session.
  Combined naively: keep our fix and the coordinator never finds a `failed`
  message to replay; revert to the abandon semantics and the coordinator
  re-delivers a message the router still held → double delivery.
- **Opposite reaction to a 409.** The coordinator treats a 409 as authoritative
  "native is alive" and suppresses backfill for ~90s; our recovery treats the same
  409 as a reap+respawn trigger. Same signal, opposite action.

The cleanest combination we found is selective: adopt upstream's
`wrapChannelInbound` / inbound preamble / forged-coordinator-id 403-guard
(`prompt-safety.ts`, conflict-free for us) regardless, and keep the two
loss-guarantee mechanisms from overlapping by gating one of them off.

## What we offer

All on the `kovesdan/marveen` fork:

- The full continuity ledger is already upstream as **#260** (`0ebf328`).
- Three fork-only follow-up fixes not yet PR'd, on branch `feat/swim-dashboard`
  (pushed as `origin/feat/swim-dashboard`):
  - `43de77d` fix(router): never silently drop inter-agent reports to a busy main
    session
  - `52c84e4` fix(router): verified inter-agent submit + credit-wall defer
  - `ac66f49` fix(ledger): watchdog probes are never open questions (3-artifact
    fix: downstream filter + upstream contract + contract test)
- We're happy to open these as focused PRs (they're generic, not personal-fork
  logic) and to contribute the conflict map above if you want to evaluate a hybrid.
- Besides this issue thread, you can also reach us by email at
  gyula.kovesdan.assistant@linistry.com if that's more convenient.

## Open questions

- Is a multi-minute blind window during a genuine bridge death acceptable for the
  upstream default, or is the coordinator's faster detection a hard requirement?
- If a hybrid is desired, which single loss-guarantee owner should win — router
  never-abandon (ours) or coordinator reconcile (upstream)? They cannot both be
  authoritative without double-delivery or a guarantee gap.
- Would you want the three follow-up fixes as separate PRs, or folded into one?