### PR TITLE
fix(update-checker): refresh cache immediately on startup

### DIFF
--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -115,7 +115,8 @@ export async function refreshUpdateStatus(): Promise<UpdateStatus> {
 // local HEAD. Lets the dashboard show a "new version available" badge
 // without anyone having to SSH in and run update.sh.
 export function startUpdateChecker(): NodeJS.Timeout {
-  // First check shortly after startup; then every 15 minutes.
-  setTimeout(() => { refreshUpdateStatus().catch(() => {}) }, 10_000)
+  // Refresh immediately on startup to avoid stale cache in the dashboard
+  refreshUpdateStatus().catch(() => {})
+  // Then check every 15 minutes
   return setInterval(() => { refreshUpdateStatus().catch(() => {}) }, 15 * 60_000)
 }


### PR DESCRIPTION
Avoids showing stale commit counts on dashboard initialization. Previously the update-checker waited 10s before the first refresh, causing dashboards that loaded quickly to display outdated version info. 

Now refreshes immediately then polls every 15 minutes. This ensures users always see the correct 'up-to-date' or 'X commits behind' status on first load rather than stale cache values.