### PR TITLE
feat: fleet-helper skill (deterministic heartbeat gate + MarkdownV2 + mail-triage)

### DIFF
--- a/seed-skills/fleet-helper/SKILL.md
+++ b/seed-skills/fleet-helper/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: fleet-helper
+description: Shared, dependency-free Python helpers for the agent fleet - dashboard API (memory, messages, kanban), Telegram MarkdownV2 escaping, and rule-based Mail.app triage. Use to do deterministic work (fetch/filter/SQL/format/escape) in Python instead of burning model tokens doing it in the LLM turn. The dashboard token is read from store/.dashboard-token at call time, never hardcoded.
+---
+
+# fleet-helper
+
+Move deterministic work (fetch / filter / SQL / format / escape) out of the model
+and into Python, so heartbeats and scheduled tasks stop spending tokens
+re-deriving the same plumbing each cycle. Python 3 stdlib only, no pip deps.
+
+No secrets or personal data are baked in: the dashboard token is read from
+`store/.dashboard-token` at call time, the project root comes from `CLAW_DIR`
+(or is auto-detected), and any personal sender/keyword lists live in a gitignored
+`mail_rules.json` (see `scripts/mail_rules.example.json`).
+
+## When to use
+- Saving/searching memory, posting daily-log, sending inter-agent messages.
+- Reading kanban (due today / stuck / by status) without writing SQL by hand.
+- Escaping text for a Telegram MarkdownV2 message.
+- An email heartbeat: pre-filter unread mail to a compact JSON before the model
+  reasons about it.
+- Building a token-cheap heartbeat gate (see "The heartbeat gate pattern" below).
+
+## Scripts
+- `scripts/fleet.py` - dashboard API + kanban read helpers + MarkdownV2 escaper
+  (CLI and importable module).
+- `scripts/mail_triage.py` - rule-based unread Mail.app filter (macOS), JSON out,
+  never sends and never marks read.
+- `scripts/gate_example.py` - reference heartbeat gate; its shell invocation IS
+  the mandatory keep-alive tool call (the LLM turn is not skipped, just cheap).
+- `scripts/mail_rules.example.json` - copy to `mail_rules.json` (gitignored) with
+  your real senders/keywords.
+- `scripts/README.md` - full usage and the heartbeat gate pattern write-up.
+
+## Quick start
+```bash
+P=seed-skills/fleet-helper/scripts
+python3 $P/fleet.py mdv2 "Tomorrow (8:00) - report!"   # escaped MarkdownV2
+python3 $P/fleet.py kanban-due
+python3 $P/mail_triage.py 90                            # unread <= 90 min -> JSON
+```
+
+## The heartbeat gate pattern (the high-value idea)
+Frequent heartbeats often wake the model just to run deterministic checks and
+then stay silent - wasted tokens. Naively skipping the turn can be unsafe if your
+channel transport (e.g. a Telegram MCP over a stdio pipe) relies on a periodic
+local tool call to stay connected. The safe pattern: keep the turn but make it
+cheap - the heartbeat's first action runs a `gate.py` via the shell (that one
+Bash call IS the keep-alive), the gate does the deterministic checks and prints a
+`has_signal` flag; on `false` the model writes one line and stops, on `true` it
+only does the judgment + notification. Zero scheduler/runner changes. See
+`scripts/README.md` for the full rationale and two hard-won scheduling lessons
+(avoid cron collisions with other heartbeats; `skipIfBusy` trade-off).
+
+## Safety
+- Token is read from `store/.dashboard-token` at call time; never printed or committed.
+- Kanban helpers are READ-ONLY; mutations stay in your own audited flows.
+- `mail_rules.json` (your real senders) is gitignored.

--- a/seed-skills/fleet-helper/scripts/.gitignore
+++ b/seed-skills/fleet-helper/scripts/.gitignore
@@ -1,0 +1,7 @@
+# Local secrets / personal data - never commit
+mail_rules.json
+.dashboard-token
+
+# Python
+__pycache__/
+*.pyc

--- a/seed-skills/fleet-helper/scripts/README.md
+++ b/seed-skills/fleet-helper/scripts/README.md
@@ -1,0 +1,91 @@
+# fleet-helper
+
+Shared, dependency-free Python helpers for a ClaudeClaw-style agent fleet. The
+goal: do deterministic work (fetch / filter / SQL / format / escape) in Python
+instead of burning model tokens doing it inside the LLM turn. Python 3 stdlib
+only.
+
+No secrets or personal data are baked in: the dashboard token is read from
+`store/.dashboard-token` at call time, paths come from `CLAW_DIR` (or are
+auto-detected), and any personal sender/keyword lists live in a gitignored
+`mail_rules.json` (see `mail_rules.example.json`).
+
+## fleet.py - dashboard API + kanban + MarkdownV2
+CLI (fewer tokens than a curl block) or import as a module:
+
+```bash
+python3 fleet.py mdv2 "Tomorrow (8:00) - report!"   # escaped MarkdownV2
+python3 fleet.py mem-save  <agent> "text" warm "k1, k2"
+python3 fleet.py mem-search <agent> "query" warm
+python3 fleet.py msg <from> <to> "message"
+python3 fleet.py agents
+python3 fleet.py kanban-due | kanban-stuck <sec> | kanban-status <status>
+```
+
+MarkdownV2: `escape_mdv2()` escapes literal text. Escape the dynamic text first,
+then add your own `*...*` bold markers around the escaped pieces.
+
+## mail_triage.py - rule-based unread-mail filter (macOS Mail.app)
+Auth-free (osascript), returns JSON, never sends and never marks read. Buckets:
+`important` / `review` / `dropped`. Real senders/keywords go in `mail_rules.json`.
+
+## The heartbeat gate pattern (the interesting part)
+
+Frequent agent "heartbeats" (periodic checks every N minutes) often wake the LLM
+just to run deterministic checks (read mail, query a DB, scan a calendar) and
+then decide there's nothing to report. That is mostly wasted tokens.
+
+The naive fix - "skip the LLM turn when nothing changed" - can be unsafe: if your
+channel transport (e.g. a Telegram MCP server over a stdio pipe) relies on the
+agent making a periodic local tool call to stay connected, skipping the turn
+entirely lets the pipe go idle and disconnect (losing inbound messages).
+
+The pattern that captures the savings WITHOUT that risk:
+
+1. Keep the heartbeat turn, but make it cheap. The heartbeat's mandatory first
+   action is to run a single `gate.py` via the shell. **That one Bash call IS the
+   keep-alive local tool call** - the transport stays warm.
+2. `gate.py` does all the deterministic checks (mail filter, kanban SQL, calendar
+   scan) outside the model and prints a compact JSON with a `has_signal` flag.
+3. If `has_signal == false`: the model writes one short line and stops. No
+   external message, and crucially no in-model AppleScript / SQL / filtering.
+4. If `has_signal == true`: the model only does the judgment (is this worth
+   surfacing? phrase it) and sends the notification.
+
+The token saving does not come from skipping the turn (the keep-alive call was
+already mandatory) - it comes from replacing "LLM reasons through
+AppleScript+SQL+filtering each cycle" with "LLM runs one gate + reads a tiny
+JSON". Zero changes to the scheduler/runner core are required: it is purely a
+heartbeat-prompt rewrite plus the gate script.
+
+Scheduling caveats (learned the hard way in a live test):
+
+1. **Avoid cron collisions with other heartbeats.** If two heartbeats land in the
+   same minute in the same session, one consistently loses (gets absorbed by the
+   other's turn) and its cycle silently never runs. A `*/30` task (:00,:30)
+   always collides with a `*/15` task (:00,:15,:30,:45). Do NOT schedule a gated
+   heartbeat on :00/:15/:30/:45 (or any minute another heartbeat uses) - pick
+   offset minutes, e.g. `7,23,37,53 * * * *`. This was the actual reason our
+   first three live cycles never fired - not `skipIfBusy`.
+2. **`skipIfBusy`:** a gated heartbeat still needs its turn to run for the
+   keep-alive to fire. With `skipIfBusy:true`, a busy session can drop the cycle
+   entirely. Where the keep-alive matters, prefer `skipIfBusy:false` (queue the
+   prompt); the per-cycle work is cheap by design, so queuing is harmless.
+
+`gate_example.py` is a reference gate (mail + kanban + calendar) you can adapt.
+
+## Layout
+```
+fleet.py                 # shared lib + CLI
+mail_triage.py           # unread-mail filter
+gate_example.py          # reference heartbeat gate (keep-alive == the gate call)
+mail_rules.example.json  # copy to mail_rules.json (gitignored) with real values
+```
+
+## Safety notes
+- Token is read from `store/.dashboard-token` at call time. Never print or commit it.
+- Kanban helpers are READ-ONLY; mutations stay in your own audited flows.
+- `mail_rules.json` (your real senders) must be gitignored (see `.gitignore`).
+
+## License
+MIT, consistent with the parent project (ClaudeClaw / marveen).

--- a/seed-skills/fleet-helper/scripts/fleet.py
+++ b/seed-skills/fleet-helper/scripts/fleet.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+ClaudeClaw fleet helper - shared, deterministic plumbing so agents don't burn
+tokens hand-rolling curl/SQL/escaping in the model.
+
+Covers: dashboard API auth (token always read from store/.dashboard-token, never
+hardcoded), memory save/search, daily log, inter-agent messages, agent list,
+kanban read helpers, and Telegram MarkdownV2 escaping.
+
+Importable as a module or used from the CLI. See README.md for usage.
+
+Config (no hardcoded paths or secrets):
+  CLAW_DIR  - project root (the dir containing `store/`). If unset, the project
+              root is auto-detected by walking up from the current directory
+              until a `store/.dashboard-token` is found.
+  CLAW_BASE - dashboard base url (default http://localhost:3420).
+"""
+import json
+import os
+import sys
+import sqlite3
+import urllib.request
+import urllib.error
+
+
+def project_dir():
+    env = os.environ.get("CLAW_DIR")
+    if env and os.path.isdir(os.path.join(env, "store")):
+        return env
+    d = os.getcwd()
+    while True:
+        if os.path.isfile(os.path.join(d, "store", ".dashboard-token")):
+            return d
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    raise RuntimeError("project root not found (set CLAW_DIR to the dir containing store/)")
+
+
+def base_url():
+    return os.environ.get("CLAW_BASE", "http://localhost:3420").rstrip("/")
+
+
+def token():
+    with open(os.path.join(project_dir(), "store", ".dashboard-token")) as f:
+        return f.read().strip()
+
+
+def db_path():
+    return os.path.join(project_dir(), "store", "claudeclaw.db")
+
+
+def api(method, path, payload=None, timeout=20):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(base_url() + path, data=data, method=method)
+    req.add_header("Authorization", "Bearer " + token())
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            body = r.read().decode()
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"API {method} {path} -> {e.code}: {e.read().decode()[:200]}")
+    try:
+        return json.loads(body)
+    except ValueError:
+        return body
+
+
+def save_memory(agent, content, category="warm", keywords=""):
+    return api("POST", "/api/memories", {"agent_id": agent, "content": content,
+                                         "category": category, "keywords": keywords})
+
+
+def search_memory(agent, q, category=None):
+    from urllib.parse import quote
+    path = f"/api/memories?agent={quote(agent)}&q={quote(q)}"
+    if category:
+        path += f"&category={quote(category)}"
+    return api("GET", path)
+
+
+def daily_log(agent, content):
+    return api("POST", "/api/daily-log", {"agent_id": agent, "content": content})
+
+
+def send_message(from_agent, to_agent, content):
+    return api("POST", "/api/messages", {"from": from_agent, "to": to_agent, "content": content})
+
+
+def list_agents():
+    return api("GET", "/api/agents")
+
+
+def _kanban(where, params=()):
+    con = sqlite3.connect(db_path())
+    con.row_factory = sqlite3.Row
+    try:
+        rows = con.execute(
+            "SELECT id, title, status, assignee, priority, project, due_date, "
+            "updated_at FROM kanban_cards WHERE archived_at IS NULL AND " + where,
+            params).fetchall()
+    finally:
+        con.close()
+    return [dict(r) for r in rows]
+
+
+def kanban_due_today():
+    return _kanban(
+        "due_date IS NOT NULL AND status != 'done' "
+        "AND date(due_date,'unixepoch','localtime') <= date('now','localtime') "
+        "ORDER BY due_date")
+
+
+def kanban_stuck(idle_seconds=14400):
+    return _kanban("status = 'in_progress' AND updated_at < strftime('%s','now') - ? "
+                   "ORDER BY updated_at", (idle_seconds,))
+
+
+def kanban_by_status(status):
+    return _kanban("status = ? ORDER BY priority DESC, updated_at DESC", (status,))
+
+
+_MDV2_SPECIAL = r"_*[]()~`>#+-=|{}.!\\"
+
+
+def escape_mdv2(text):
+    """Escape literal text for Telegram MarkdownV2. Escape your dynamic text with
+    this, THEN wrap intended formatting (e.g. '*'+escape_mdv2(label)+'*' for bold)."""
+    return "".join("\\" + ch if ch in _MDV2_SPECIAL else ch for ch in str(text))
+
+
+def _out(v):
+    print(json.dumps(v, ensure_ascii=False, indent=2) if isinstance(v, (dict, list)) else v)
+
+
+def main(argv):
+    if not argv:
+        print(__doc__)
+        return 0
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "mdv2":
+        print(escape_mdv2(rest[0] if rest else sys.stdin.read()))
+    elif cmd == "mem-save":
+        _out(save_memory(rest[0], rest[1], rest[2] if len(rest) > 2 else "warm",
+                         rest[3] if len(rest) > 3 else ""))
+    elif cmd == "mem-search":
+        _out(search_memory(rest[0], rest[1], rest[2] if len(rest) > 2 else None))
+    elif cmd == "daily-log":
+        _out(daily_log(rest[0], rest[1]))
+    elif cmd == "msg":
+        _out(send_message(rest[0], rest[1], rest[2]))
+    elif cmd == "agents":
+        _out([{"name": a.get("name"), "running": a.get("running"),
+               "model": a.get("model")} for a in list_agents()])
+    elif cmd == "kanban-due":
+        _out(kanban_due_today())
+    elif cmd == "kanban-stuck":
+        _out(kanban_stuck(int(rest[0]) if rest else 14400))
+    elif cmd == "kanban-status":
+        _out(kanban_by_status(rest[0]))
+    else:
+        sys.stderr.write(f"unknown command: {cmd}\n")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/seed-skills/fleet-helper/scripts/gate_example.py
+++ b/seed-skills/fleet-helper/scripts/gate_example.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Reference heartbeat gate (see README - "The heartbeat gate pattern").
+
+The shell invocation of THIS script is the mandatory local-only keep-alive tool
+call: the heartbeat LLM-turn is not skipped, it just becomes cheap. The script
+does the deterministic checks outside the model and prints a compact JSON with
+`has_signal`.
+
+Heartbeat contract (in the task prompt):
+  has_signal == false -> write one short line and STOP (no external message).
+  has_signal == true  -> the model judges and notifies.
+
+Checks: urgent unread mail (last ~70 min), kanban cards due today, calendar
+events starting within the next 60 min (macOS Calendar.app). Adapt to taste.
+"""
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import fleet          # noqa: E402
+import mail_triage    # noqa: E402
+
+# Same file the transport's keep-alive directive appends to; the Bash call that
+# runs this script is itself the keep-alive, this line just makes it auditable.
+KEEPALIVE_LOG = os.environ.get("KEEPALIVE_LOG", "/tmp/agent-keepalive.log")
+
+
+def keepalive_touch():
+    ts = datetime.now().isoformat(timespec="seconds")
+    try:
+        with open(KEEPALIVE_LOG, "a") as f:
+            f.write(f"{ts} keepalive gate\n")
+    except OSError:
+        pass
+    return ts
+
+
+def calendar_soon(minutes=60):
+    us, rs = chr(31), chr(30)
+    script = f'''
+    set US to (ASCII character 31)
+    set RS to (ASCII character 30)
+    set d0 to (current date)
+    set d1 to d0 + ({minutes} * minutes)
+    set outp to ""
+    tell application "Calendar"
+        repeat with c in calendars
+            try
+                set evs to (every event of c whose start date is greater than or equal to d0 and start date is less than d1)
+                repeat with e in evs
+                    set sd to start date of e
+                    set hh to (hours of sd) as string
+                    set mm to text -2 thru -1 of ("0" & ((minutes of sd) as string))
+                    set outp to outp & (summary of e) & US & hh & ":" & mm & US & (name of c) & RS
+                end repeat
+            end try
+        end repeat
+    end tell
+    return outp
+    '''
+    try:
+        p = subprocess.run(["osascript", "-e", script], capture_output=True,
+                           text=True, timeout=45)
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        return {"events": [], "error": f"osascript: {e}"}
+    if p.returncode != 0:
+        return {"events": [], "error": (p.stderr or "failed").strip()[:200]}
+    events, seen = [], set()
+    for rec in p.stdout.split(rs):
+        parts = rec.strip().split(us)
+        if len(parts) < 3:
+            continue
+        key = (parts[0].strip(), parts[1].strip())
+        if key in seen:
+            continue
+        seen.add(key)
+        events.append({"summary": parts[0].strip(), "start": parts[1].strip(),
+                       "calendar": parts[2].strip()})
+    events.sort(key=lambda e: e["start"])
+    return {"events": events, "error": None}
+
+
+def main():
+    keepalive_ts = keepalive_touch()
+    mail = mail_triage.triage(70)
+    try:
+        kanban_due = fleet.kanban_due_today()
+        kanban_err = None
+    except Exception as e:
+        kanban_due, kanban_err = [], str(e)
+    cal = calendar_soon(60)
+    has_signal = bool(mail["important"] or kanban_due or cal["events"])
+    print(json.dumps({
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "keepalive_ran": True,
+        "keepalive_ts": keepalive_ts,
+        "checks": {
+            "mail_important": mail["important"],
+            "mail_review_count": len(mail["review"]),
+            "kanban_due": kanban_due,
+            "kanban_error": kanban_err,
+            "calendar_next_60min": cal["events"],
+            "calendar_error": cal["error"],
+        },
+        "has_signal": has_signal,
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/seed-skills/fleet-helper/scripts/mail_rules.example.json
+++ b/seed-skills/fleet-helper/scripts/mail_rules.example.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Copy to mail_rules.json (keep it OUT of version control) and fill with YOUR real values. All matching is case-insensitive substring (senders/important) or word-boundary (spam).",
+  "important_senders": [
+    "boss@work.example",
+    "school@kids.example",
+    "billing@bank.example"
+  ],
+  "important_keywords": [
+    "invoice", "deadline", "payment", "tax", "school", "appointment"
+  ],
+  "spam_keywords": [
+    "newsletter", "unsubscribe", "promo", "sale", "discount", "marketing"
+  ]
+}

--- a/seed-skills/fleet-helper/scripts/mail_triage.py
+++ b/seed-skills/fleet-helper/scripts/mail_triage.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Deterministic Mail.app triage for an hourly email heartbeat (macOS).
+
+Reads UNREAD inbox messages via osascript (auth-free), applies rule-based
+filtering, prints JSON. Does NOT send anything and does NOT mark mail read - the
+final nuanced judgment stays with the agent, which reads this compact JSON
+instead of raw mail, saving tokens.
+
+Buckets: important (known senders or important keywords), review (ambiguous),
+dropped (clear spam/promo - count only).
+
+PRIVACY: DEFAULTS ship with EMPTY important_senders and only generic keywords.
+Put your real senders/keywords in `mail_rules.json` next to this file (keep that
+file OUT of version control). See mail_rules.example.json.
+
+Usage: mail_triage.py [max_age_min]   # default 90; 0 = all unread
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime
+
+RULES_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mail_rules.json")
+
+# Generic, non-personal defaults. Real senders go in the gitignored override.
+DEFAULTS = {
+    "important_senders": [],          # e.g. ["boss@work.example"] - via mail_rules.json
+    "important_keywords": [
+        "invoice", "szamla", "számla", "deadline", "hatarid", "határid",
+        "fizet", "payment", "urgent", "surgos", "sürgős", "tax", "nav",
+        "contract", "szerzod", "szerződ",
+    ],
+    "spam_keywords": [
+        "newsletter", "hirlevel", "hírlevél", "unsubscribe", "leiratkoz",
+        "promo", "promó", "sale", "akcio", "akció", "discount", "kedvezmeny",
+        "kedvezmény", "marketing", "webshop",
+    ],
+}
+
+
+def load_rules():
+    rules = {k: list(v) for k, v in DEFAULTS.items()}
+    if os.path.isfile(RULES_FILE):
+        try:
+            override = json.load(open(RULES_FILE))
+            for k in rules:
+                if isinstance(override.get(k), list):
+                    rules[k] = override[k]
+        except (ValueError, OSError):
+            pass
+    return {k: [s.lower() for s in v] for k, v in rules.items()}
+
+
+def read_unread():
+    us, rs = chr(31), chr(30)
+    script = '''
+    set US to (ASCII character 31)
+    set RS to (ASCII character 30)
+    set outp to ""
+    tell application "Mail"
+        set msgs to (messages of inbox whose read status is false)
+        repeat with m in msgs
+            try
+                set outp to outp & (sender of m) & US & (subject of m) & US & (((current date) - (date received of m)) as string) & RS
+            end try
+        end repeat
+    end tell
+    return outp
+    '''
+    try:
+        raw = subprocess.run(["osascript", "-e", script], capture_output=True,
+                             text=True, timeout=60).stdout
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        sys.stderr.write(f"osascript failed: {e}\n")
+        return []
+    out = []
+    for rec in raw.split(rs):
+        parts = rec.strip().split(us)
+        if len(parts) < 3:
+            continue
+        try:
+            age = int(float(parts[2]))
+        except ValueError:
+            age = 0
+        out.append((parts[0].strip(), parts[1].strip(), age))
+    return out
+
+
+def _kw_substring(keywords, hay):
+    # Substring for IMPORTANT keywords - agglutinative languages (e.g. Hungarian)
+    # need 'szamla' to match inside 'villanyszamla'. Over-surfacing is acceptable.
+    for kw in keywords:
+        if kw in hay:
+            return kw
+    return None
+
+
+def _kw_boundary(keywords, hay):
+    # Leading word boundary for SPAM keywords so 'akcio' != 'reakcio'.
+    for kw in keywords:
+        if re.search(r"\b" + re.escape(kw), hay):
+            return kw
+    return None
+
+
+def classify(sender, subject, rules):
+    hay = (sender + " " + subject).lower()
+    for s in rules["important_senders"]:
+        if s in hay:
+            return "important", f"known sender ({s})"
+    kw = _kw_substring(rules["important_keywords"], hay)
+    if kw:
+        return "important", f"keyword:{kw}"
+    kw = _kw_boundary(rules["spam_keywords"], hay)
+    if kw:
+        return "dropped", f"spam:{kw}"
+    return "review", "ambiguous"
+
+
+def triage(max_age_min=90):
+    rules = load_rules()
+    important, review, dropped = [], [], 0
+    for sender, subject, age_s in read_unread():
+        if max_age_min and age_s > max_age_min * 60:
+            continue
+        bucket, reason = classify(sender, subject, rules)
+        item = {"sender": sender, "subject": subject,
+                "age_min": round(age_s / 60), "reason": reason}
+        if bucket == "important":
+            important.append(item)
+        elif bucket == "review":
+            review.append(item)
+        else:
+            dropped += 1
+    return {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "max_age_min": max_age_min,
+        "important": important, "review": review, "dropped": dropped,
+        "has_signal": bool(important or review),
+    }
+
+
+if __name__ == "__main__":
+    age = int(sys.argv[1]) if len(sys.argv) > 1 else 90
+    print(json.dumps(triage(age), ensure_ascii=False, indent=2))


### PR DESCRIPTION
## What

Adds `seed-skills/fleet-helper`: a small, dependency-free (Python 3 stdlib) skill
that lets fleet agents do deterministic work in scripts instead of in the model,
to cut token usage on heartbeats and scheduled tasks.

- `fleet.py` - dashboard API helpers (memory, messages), kanban read helpers, and
  a Telegram MarkdownV2 escaper (CLI + importable).
- `mail_triage.py` - rule-based unread Mail.app filter (macOS), JSON out; never
  sends, never marks read.
- `gate_example.py` - reference **heartbeat gate**: the gate's shell call doubles
  as the mandatory keep-alive tool call, so a gated heartbeat stays cheap without
  dropping the channel transport (e.g. a Telegram MCP stdio pipe).
- `mail_rules.example.json` + `README.md` (full usage + the gate-pattern write-up).

## Why

Frequent heartbeats often wake the model just to run deterministic checks and then
stay silent. Moving that work into a gate script keeps the (already mandatory)
keep-alive tool call but removes the in-model AppleScript/SQL/filtering. See the
README for the rationale and two scheduling lessons learned in a live test:
avoid cron collisions with other heartbeats (don't use `:00/:15/:30/:45`), and the
`skipIfBusy` trade-off.

## Safety / privacy

- Opt-in: nothing runs unless a task/skill invokes it.
- No secrets or PII baked in: the dashboard token is read from
  `store/.dashboard-token` at call time; project root via `CLAW_DIR` (or
  auto-detected); personal sender/keyword lists live in a gitignored
  `mail_rules.json` (an `.example.json` is shipped). Kanban helpers are read-only.
- MIT, consistent with the repo.

Proposal only - reviewed and opened as a suggestion; merge at your discretion.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
