### PR TITLE
fix(token-usage): match main agent by encoded project path

### DIFF
--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -5,9 +5,17 @@ import { createReadStream } from 'node:fs'
 import { createInterface } from 'node:readline'
 import { getDb } from '../db.js'
 import { logger } from '../logger.js'
-import { MAIN_AGENT_ID } from '../config.js'
+import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
 
 const PROJECTS_DIR = join(homedir(), '.claude', 'projects')
+
+// Claude Code encodes a project's absolute path into a directory name by
+// replacing every non-alphanumeric/non-dash character with `-`. The main
+// agent's transcripts live under that exact directory, regardless of what
+// the agent calls itself.
+function encodeProjectPath(p: string): string {
+  return p.replace(/[^a-zA-Z0-9-]/g, '-')
+}
 
 interface AgentTranscriptSource {
   agent: string
@@ -17,6 +25,7 @@ interface AgentTranscriptSource {
 function discoverAgentSources(): AgentTranscriptSource[] {
   const sources: AgentTranscriptSource[] = []
   if (!existsSync(PROJECTS_DIR)) return sources
+  const mainDirName = encodeProjectPath(PROJECT_ROOT)
   for (const entry of readdirSync(PROJECTS_DIR)) {
     const full = join(PROJECTS_DIR, entry)
     let stat
@@ -26,7 +35,7 @@ function discoverAgentSources(): AgentTranscriptSource[] {
     const agentMatch = entry.match(/-agents-([a-z]+)$/)
     if (agentMatch) {
       sources.push({ agent: agentMatch[1], projectDir: full })
-    } else if (entry.includes(`-${MAIN_AGENT_ID}`) && !entry.includes('-agents-')) {
+    } else if (entry === mainDirName) {
       sources.push({ agent: MAIN_AGENT_ID, projectDir: full })
     }
   }


### PR DESCRIPTION
## Summary

`discoverAgentSources` matched the main agent's transcripts via `entry.includes(\`-${MAIN_AGENT_ID}\`)`, but the transcript directory name is encoded from the working tree path, not the agent id. After a `marveen -> cuzcoo` rename only sub-agent transcripts (matched by `/-agents-([a-z]+)$/`) showed up in the dashboard's token monitor, while the main agent's own transcripts dropped out.

## Change

Match the encoded `PROJECT_ROOT` directly instead, so the discovery is independent of what the agent calls itself.

## Test plan

- [x] `npm run typecheck` clean.
- [x] Local verification: after `MAIN_AGENT_ID=cuzcoo` rename, main agent's token usage appears in `/api/tokens/usage` again.

## Severity

Medium — silent data drop in the token monitor whenever the install is renamed away from "marveen".

🤖 Generated with [Claude Code](https://claude.com/claude-code)