### PR TITLE
fix(agent-process,start): execFile tmux launch + optional google-sheets MCP

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -9,6 +9,8 @@ INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 if [ -f "$INSTALL_DIR/.env" ]; then
   SLUG="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
   BOT_NAME="$(grep -E '^BOT_NAME=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
+  GOOGLE_CLIENT_ID="$(grep -E '^GOOGLE_CLIENT_ID=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
+  GOOGLE_CLIENT_SECRET="$(grep -E '^GOOGLE_CLIENT_SECRET=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
 fi
 SLUG="${SLUG:-marveen}"
 
@@ -48,8 +50,15 @@ elif [ "$OS" = "Linux" ]; then
     echo $! > "$INSTALL_DIR/store/dashboard.pid"
     nohup bash "$INSTALL_DIR/scripts/channels.sh" > "$INSTALL_DIR/store/channels.log" 2>&1 &
     echo $! > "$INSTALL_DIR/store/channels.pid"
+    if [ -n "$GOOGLE_CLIENT_ID" ] && [ -n "$GOOGLE_CLIENT_SECRET" ]; then
+      GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
+        MCP_TRANSPORT=http nohup /home/jocoo/.npm-global/bin/google-sheets-mcp \
+        > "$INSTALL_DIR/store/gsheets-mcp.log" 2>&1 &
+      echo $! > "$INSTALL_DIR/store/gsheets-mcp.pid"
+    fi
   fi
 fi
 
 echo "✓ Dashboard: http://localhost:3420"
 echo "✓ Csatorna inditva"
+[ -n "$GOOGLE_CLIENT_ID" ] && echo "✓ Google Sheets MCP: http://localhost:3000/mcp"

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -195,8 +195,8 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // Single-quote `${model}` so values like `claude-opus-4-8[1m]` (1M-context
     // suffix) are not glob-expanded by the shell that tmux spawns the command in.
     const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${channelSetup}${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
-    execSync(
-      `${TMUX} new-session -d -s ${session} "${cmd}"`,
+    execFileSync(
+      TMUX, ['new-session', '-d', '-s', session, cmd],
       { timeout: 10000 }
     )
 


### PR DESCRIPTION
## Summary

Two small fixes bundled because both touch the agent startup path:

1. `agent-process.ts`: replace shell-formatted `execSync` for `tmux new-session` with `execFileSync`. Shell glob/escape pitfalls bite whenever the assembled command string contains characters the shell would interpret (spaces, quotes in agent names). `execFileSync` passes the argv array directly to tmux and sidesteps the shell entirely.

2. `start.sh`: optional Google Sheets MCP server launch, gated on `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` being present in `.env`. Default-off so existing installs are unaffected.

## Test plan

- [x] `npm run typecheck` clean.
- [x] Local: agent restart via `scripts/stop.sh && scripts/start.sh` succeeds; tmux session spawns without shell-interpretation errors.
- [x] With Google MCP creds absent, start.sh skips silently.

## Severity

Low–medium — the tmux escape issue is a latent footgun that surfaces only with certain agent names; the MCP add is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)