### PR TITLE
feat(gitnexus): opt-in per-repo post-commit auto-rebuild hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ claudeclaw.log
 
 # Local backup archives from scripts/backup.sh
 backups/
+
+# GitNexus knowledge-graph index (local, per-clone; auto-rebuilt by the post-commit hook)
+.gitnexus/

--- a/scripts/gitnexus/README.md
+++ b/scripts/gitnexus/README.md
@@ -1,0 +1,46 @@
+# GitNexus auto-rebuild hook
+
+Opt-in, per-repo git **post-commit** hook that keeps the GitNexus knowledge graph
+fresh automatically — closing the one gap vs Graphify (commit-triggered
+self-updating graph) without giving up GitNexus's deeper query/impact layer or
+the fleet's existing MCP + skills + hooks integration.
+
+## What it does
+After each commit it runs an **incremental** `gitnexus analyze --skip-agents-md`
+(NOT `--force`) so:
+- the re-index is fast (skip-if-up-to-date; only changed symbols are reprocessed),
+- it runs in the **background** → the commit returns instantly,
+- a **single-flight lock** (`.gitnexus/.autorebuild.lock`) prevents rapid commits
+  from piling up (if a rebuild is running, the commit is skipped and the next
+  incremental pass catches up),
+- `--skip-agents-md` keeps the working tree clean (only the gitignored
+  `.gitnexus/` graph changes; `AGENTS.md` / `CLAUDE.md` are not touched).
+
+Determinism/cost unchanged: GitNexus's default build is embedding-free
+(`--embeddings` is opt-in), so the rebuild has zero API cost.
+
+## Install (per repo)
+```bash
+# from inside the target repo (must already be `gitnexus analyze`-d once):
+/Users/marvin/ClaudeClaw/scripts/gitnexus/install-autorebuild.sh
+# or for another repo:
+/Users/marvin/ClaudeClaw/scripts/gitnexus/install-autorebuild.sh /path/to/repo
+```
+Idempotent: re-running updates the managed block in place and preserves any
+pre-existing `post-commit` hook content.
+
+## New-repo onboarding flow
+```bash
+cd /path/to/new/repo
+gitnexus analyze                       # initial index + AGENTS.md/CLAUDE.md + skills
+/Users/marvin/ClaudeClaw/scripts/gitnexus/install-autorebuild.sh
+# from now on every commit refreshes the graph in the background
+```
+
+## Uninstall
+Remove the block between `# >>> gitnexus-autorebuild >>>` and
+`# <<< gitnexus-autorebuild <<<` from `.git/hooks/post-commit` (delete the file
+if that block was its only content).
+
+## Log
+`.gitnexus/autorebuild.log` in the target repo.

--- a/scripts/gitnexus/README.md
+++ b/scripts/gitnexus/README.md
@@ -12,7 +12,8 @@ After each commit it runs an **incremental** `gitnexus analyze --skip-agents-md`
 - it runs in the **background** → the commit returns instantly,
 - a **single-flight lock** (`.gitnexus/.autorebuild.lock`) prevents rapid commits
   from piling up (if a rebuild is running, the commit is skipped and the next
-  incremental pass catches up),
+  incremental pass catches up); a **stale-lock guard** reclaims the lock if it is
+  older than 15 min, so a `kill -9` mid-rebuild can't permanently disable rebuilds,
 - `--skip-agents-md` keeps the working tree clean (only the gitignored
   `.gitnexus/` graph changes; `AGENTS.md` / `CLAUDE.md` are not touched).
 

--- a/scripts/gitnexus/install-autorebuild.sh
+++ b/scripts/gitnexus/install-autorebuild.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Install an opt-in, per-repo GitNexus auto-rebuild post-commit hook.
+#
+# After each commit the hook runs an INCREMENTAL `gitnexus analyze`
+# (skip-if-up-to-date, NOT --force) in the BACKGROUND so the commit returns
+# instantly, with a single-flight lock so rapid commits don't pile up. It uses
+# --skip-agents-md so the working tree is never dirtied post-commit (only the
+# gitignored .gitnexus/ graph is refreshed).
+#
+# This closes the one gap vs Graphify (commit-triggered self-updating graph)
+# while keeping GitNexus's deeper query/impact layer + the fleet's existing
+# integration. Idempotent: re-running updates the managed block in place and
+# preserves any pre-existing post-commit hook content.
+#
+# Usage: install-autorebuild.sh [repo-path]   (default: current git repo)
+set -euo pipefail
+
+REPO="${1:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+if [ -z "$REPO" ] || [ ! -d "$REPO/.git" ]; then
+  echo "error: not a git repository (pass a repo path)." >&2
+  exit 1
+fi
+if ! command -v gitnexus >/dev/null 2>&1; then
+  echo "error: gitnexus not found on PATH. Install it first (npm i -g gitnexus)." >&2
+  exit 1
+fi
+
+HOOK="$REPO/.git/hooks/post-commit"
+BEGIN="# >>> gitnexus-autorebuild >>>"
+END="# <<< gitnexus-autorebuild <<<"
+
+BLOCK="$BEGIN
+# Managed by scripts/gitnexus/install-autorebuild.sh -- do not edit between markers.
+(
+  command -v gitnexus >/dev/null 2>&1 || {
+    PATH=\"/opt/homebrew/bin:\$HOME/.local/bin:/usr/local/bin:\$PATH\"
+    export PATH
+  }
+  command -v gitnexus >/dev/null 2>&1 || exit 0
+  ROOT=\$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+  mkdir -p \"\$ROOT/.gitnexus\" 2>/dev/null || exit 0
+  LOCK=\"\$ROOT/.gitnexus/.autorebuild.lock\"
+  LOG=\"\$ROOT/.gitnexus/autorebuild.log\"
+  # Single-flight: if a rebuild is already running, skip -- the next commit's
+  # incremental pass catches up. mkdir is atomic across processes.
+  mkdir \"\$LOCK\" 2>/dev/null || exit 0
+  trap 'rmdir \"\$LOCK\" 2>/dev/null' EXIT
+  cd \"\$ROOT\" || exit 0
+  echo \"[\$(date -u +%FT%TZ)] incremental analyze after \$(git rev-parse --short HEAD 2>/dev/null)\" >>\"\$LOG\" 2>&1
+  # Incremental (no --force) + --skip-agents-md so tracked files stay clean.
+  gitnexus analyze --skip-agents-md >>\"\$LOG\" 2>&1
+) >/dev/null 2>&1 &
+$END"
+
+mkdir -p "$REPO/.git/hooks"
+
+if [ -f "$HOOK" ] && grep -qF "$BEGIN" "$HOOK"; then
+  # Replace the existing managed block in place (preserve surrounding content).
+  tmp="$(mktemp)"
+  awk -v b="$BEGIN" -v e="$END" -v repl="$BLOCK" '
+    $0==b {print repl; skip=1; next}
+    $0==e {skip=0; next}
+    skip!=1 {print}
+  ' "$HOOK" >"$tmp"
+  mv "$tmp" "$HOOK"
+  echo "Updated gitnexus-autorebuild block in $HOOK"
+elif [ -f "$HOOK" ]; then
+  # Append our block, preserving the existing hook.
+  printf '\n%s\n' "$BLOCK" >>"$HOOK"
+  echo "Appended gitnexus-autorebuild block to existing $HOOK"
+else
+  printf '#!/usr/bin/env bash\n\n%s\nexit 0\n' "$BLOCK" >"$HOOK"
+  echo "Created $HOOK"
+fi
+chmod +x "$HOOK"
+echo "Done. Commits in $REPO now trigger a background incremental GitNexus re-index."
+echo "Log: $REPO/.gitnexus/autorebuild.log"

--- a/scripts/gitnexus/install-autorebuild.sh
+++ b/scripts/gitnexus/install-autorebuild.sh
@@ -41,6 +41,11 @@ BLOCK="$BEGIN
   mkdir -p \"\$ROOT/.gitnexus\" 2>/dev/null || exit 0
   LOCK=\"\$ROOT/.gitnexus/.autorebuild.lock\"
   LOG=\"\$ROOT/.gitnexus/autorebuild.log\"
+  # Stale-lock guard: a kill -9 mid-rebuild can orphan the lock dir, which would
+  # then skip every future rebuild. If the lock is older than 15 min, reclaim it.
+  if [ -d \"\$LOCK\" ] && [ -n \"\$(find \"\$LOCK\" -maxdepth 0 -mmin +15 2>/dev/null)\" ]; then
+    rmdir \"\$LOCK\" 2>/dev/null || true
+  fi
   # Single-flight: if a rebuild is already running, skip -- the next commit's
   # incremental pass catches up. mkdir is atomic across processes.
   mkdir \"\$LOCK\" 2>/dev/null || exit 0


### PR DESCRIPTION
## Cél
A Graphify-vs-GitNexus eval (Szabi új-projekt-onboarding use-case) egyetlen valódi gap-jét zárja: a **commit-utáni önfrissülő gráf**. Maradunk GitNexuson (mély flotta-integráció + erősebb impact/query réteg), és pótoljuk ezt az egy feature-t.

## Mit csinál
Opt-in, per-repo git **post-commit** hook: minden commit után **háttérben**, **single-flight** lockkal, **inkrementálisan** futtat `gitnexus analyze --skip-agents-md`-t.
- Háttér + skip-if-up-to-date → a commit instant marad (**tesztelve: 0.30s**).
- Single-flight lock (`.gitnexus/.autorebuild.lock`) → gyors commitok nem torlódnak.
- `--skip-agents-md` → a working tree tiszta marad (csak a gitignored `.gitnexus/` gráf változik; AGENTS.md/CLAUDE.md érintetlen).
- Embedding-mentes default build → **nulla API-költség**.
- Az installer idempotens + megőrzi a meglévő post-commit hookot.

## Teszt (e2e, throwaway repo)
init → `gitnexus analyze` → hook install → új függvény + commit → a háttér-inkrementális rebuild lefut → az új `beta()` függvény megjelenik a gráfban; lock feltakarítva; tree tiszta; commit 0.30s.

## Használat
```bash
cd /path/to/new/repo && gitnexus analyze
scripts/gitnexus/install-autorebuild.sh
```

Forrás-jelölt eval Marveennél; ez az ajánlott "GitNexust bővítsük" opció implementációja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)