### PR TITLE
fix(gitnexus): BSD/macOS-safe in-place block update in autorebuild installer

### DIFF
--- a/scripts/gitnexus/install-autorebuild.sh
+++ b/scripts/gitnexus/install-autorebuild.sh
@@ -59,14 +59,30 @@ $END"
 
 mkdir -p "$REPO/.git/hooks"
 
+# Pure-shell in-place replace of the managed block (no awk -- BSD/macOS awk
+# rejects a multi-line value passed via -v). Emits the fresh BLOCK at the old
+# block's position and preserves everything outside the markers.
+replace_managed_block() {  # reads $HOOK on stdin -> stdout
+  in_block=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ "$line" = "$BEGIN" ]; then
+      printf '%s\n' "$BLOCK"
+      in_block=1
+      continue
+    fi
+    if [ "$line" = "$END" ]; then
+      in_block=0
+      continue
+    fi
+    [ "$in_block" = 1 ] && continue
+    printf '%s\n' "$line"
+  done
+}
+
 if [ -f "$HOOK" ] && grep -qF "$BEGIN" "$HOOK"; then
   # Replace the existing managed block in place (preserve surrounding content).
   tmp="$(mktemp)"
-  awk -v b="$BEGIN" -v e="$END" -v repl="$BLOCK" '
-    $0==b {print repl; skip=1; next}
-    $0==e {skip=0; next}
-    skip!=1 {print}
-  ' "$HOOK" >"$tmp"
+  replace_managed_block < "$HOOK" >"$tmp"
   mv "$tmp" "$HOOK"
   echo "Updated gitnexus-autorebuild block in $HOOK"
 elif [ -f "$HOOK" ]; then


### PR DESCRIPTION
Follow-up to #309. The installer's idempotent **update path** used `awk -v repl="$BLOCK"` with a multi-line value -> BSD/macOS awk errors ("newline in string"), so re-running the installer to refresh the managed block failed on macOS (the whole fleet). Fresh install was fine; only the re-run/update broke.

Fix: pure-shell in-place block replace (no awk) -- emits the fresh block at the old position, preserves surrounding content, no duplication, stays before any trailing `exit 0`.

Tested on macOS: fresh install + 2nd-install update both clean (1 marker, TTL guard present, syntax OK, block before exit 0). 🤖 Generated with [Claude Code](https://claude.com/claude-code)