### PR TITLE
chore(gitignore): ignore local one-off artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ backups/
 DREAM.md
 .external-ops-last-run
 REBUILD_PROMPT_V3.1.md
+
+# Python bytecode cache
+__pycache__/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,9 @@ backups/
 
 # GitNexus knowledge-graph index (local, per-clone; auto-rebuilt by the post-commit hook)
 .gitnexus/
+
+# Local one-off artifacts (brainstorm docs, runtime state, rebuild prompts) --
+# never committed; ignored to prevent accidental `git add -A` bloat.
+DREAM.md
+.external-ops-last-run
+REBUILD_PROMPT_V3.1.md


### PR DESCRIPTION
Megelőzi az újabb `git add -A` bedagadást (a #311 +9000-soros near-miss ezekből a untracked lokálokból jött). Ignorálva: `DREAM.md`, `.external-ops-last-run`, `REBUILD_PROMPT_V3.1.md`. 

NB: `REBUILD_PROMPT_V3.md` MÁR trackelt -> a gitignore nem untrackeli; érintetlen hagytam (eltávolítása külön döntés, ha kell). 🤖 Generated with [Claude Code](https://claude.com/claude-code)