### PR TITLE
feat(support-mail): support@ mailbox CLI tooling (secret/PII-scanned)

### DIFF
--- a/scripts/support-mail/check-inbox.py
+++ b/scripts/support-mail/check-inbox.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""List recent messages in the support@aiamindennapokban.hu INBOX (read-only).
+
+Usage: python3 check-inbox.py [N]   (default N=10 most recent)
+Prints: index, date, from, subject, unread-flag. Bodies are NOT fetched here.
+"""
+import sys, ssl, imaplib, email
+from email.header import decode_header
+sys.path.insert(0, "/Users/marvin/ClaudeClaw/scripts/support-mail")
+import lib
+
+
+def _dec(v):
+    if not v:
+        return ""
+    out = []
+    for part, enc in decode_header(v):
+        out.append(part.decode(enc or "utf-8", "replace") if isinstance(part, bytes) else part)
+    return "".join(out)
+
+
+def main():
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 10
+    M = imaplib.IMAP4_SSL(lib.IMAP_HOST, lib.IMAP_PORT, ssl_context=ssl.create_default_context())
+    M.login(lib.EMAIL, lib.password())
+    M.select("INBOX", readonly=True)
+    typ, data = M.search(None, "ALL")
+    ids = data[0].split()
+    unseen = set(M.search(None, "UNSEEN")[1][0].split())
+    recent = ids[-n:][::-1]
+    print(f"INBOX: {len(ids)} total, {len(unseen)} unread. Last {len(recent)}:")
+    for i in recent:
+        typ, msg_data = M.fetch(i, "(BODY.PEEK[HEADER.FIELDS (FROM SUBJECT DATE)])")
+        hdr = email.message_from_bytes(msg_data[0][1])
+        flag = "●UNREAD" if i in unseen else "       "
+        print(f"  [{i.decode()}] {flag} {_dec(hdr.get('Date',''))[:31]:31} | {_dec(hdr.get('From',''))[:34]:34} | {_dec(hdr.get('Subject',''))[:50]}")
+    M.logout()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/support-mail/lib.py
+++ b/scripts/support-mail/lib.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Shared config + secret-safe credential loader for the support@aiamindennapokban.hu mailbox.
+
+Hostinger IMAP/SMTP. The password lives ONLY in the Marveen vault
+(key: support@aiamindennapokba.hu_pw -- note the owner's typo in the key name)
+and is fetched at runtime via the dashboard vault API. It is never written to
+disk or printed.
+"""
+import json, os, urllib.request
+
+EMAIL = "support@aiamindennapokban.hu"
+IMAP_HOST, IMAP_PORT = "imap.hostinger.com", 993
+SMTP_HOST, SMTP_PORT = "smtp.hostinger.com", 465  # implicit TLS/SSL
+VAULT_KEY = "support@aiamindennapokba.hu_pw"  # owner's typo in the key, kept as-is
+_ROOT = "/Users/marvin/ClaudeClaw"
+
+
+def password() -> str:
+    tok = open(os.path.join(_ROOT, "store/.dashboard-token")).read().strip()
+    req = urllib.request.Request(
+        f"http://localhost:3420/api/vault/{VAULT_KEY}",
+        headers={"Authorization": "Bearer " + tok},
+    )
+    pw = json.load(urllib.request.urlopen(req, timeout=10)).get("value", "")
+    if not pw:
+        raise RuntimeError("support mailbox password not found in vault")
+    return pw

--- a/scripts/support-mail/no-support-reply.html
+++ b/scripts/support-mail/no-support-reply.html
@@ -1,0 +1,22 @@
+<!-- No-valid-support auto-reply sablon (support@-ról, send.py --html). Akkor megy, ha a feladonak NINCS ervenyes support-entitlementje. Szabi 2026-06-06: biztonsagos false-negative eseten is (a "ellenorizd a cimet" miatt), ezert auto-kuldheto. -->
+<!DOCTYPE html>
+<html lang="hu"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background-color:#f0ede5;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f0ede5;"><tr><td align="center" style="padding:32px 16px;">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:12px;overflow:hidden;">
+  <tr><td style="background:#141413;padding:24px 36px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:18px;font-weight:700;color:#fff;">marveen <span style="font-weight:400;color:#73726c;font-size:13px;">&middot; support</span></td></tr>
+  <tr><td style="padding:32px 36px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:1.7;color:#141413;">
+    <p style="margin:0 0 18px;">Szia,</p>
+    <p style="margin:0 0 18px;">Köszönöm, hogy írtál. A rendszerünkben jelenleg <strong>nem látunk érvényes Marveen support-előfizetést</strong> ehhez az email-címhez.</p>
+    <p style="margin:0 0 12px;">Két dolgot érdemes megnézni:</p>
+    <p style="margin:0 0 12px;">1. <strong>Ha van előfizetésed</strong> (telepítéshez járó support, vagy Standard/Premium): kérlek ellenőrizd, hogy arról az email-címről írtál-e, amivel előfizettél. Ha esetleg másik címről, írj onnan, vagy jelezd, és összenézzük.</p>
+    <p style="margin:0 0 24px;">2. <strong>Ha még nincs előfizetésed</strong>, itt tudsz választani csomagot:</p>
+    <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px;"><tr><td style="background:#d97757;border-radius:8px;"><a href="https://aiamindennapokban.hu/marveen" style="display:inline-block;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:15px;font-weight:700;color:#fff;text-decoration:none;padding:13px 26px;">Előfizetés &rarr;</a></td></tr></table>
+    <p style="margin:0 0 4px;">Üdv,</p>
+    <p style="margin:0;font-weight:600;">Szota Szabolcs</p>
+    <p style="margin:2px 0 0;font-size:14px;color:#73726c;">AI a mindennapokban</p>
+  </td></tr>
+  <tr><td style="background:#141413;padding:16px 36px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:11px;color:#73726c;text-align:center;">Szota Szabolcs e.v. &middot; support@aiamindennapokban.hu &middot; aiamindennapokban.hu</td></tr>
+</table>
+</td></tr></table>
+</body></html>

--- a/scripts/support-mail/read.py
+++ b/scripts/support-mail/read.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Read the body of a specific support@ inbox message (read-only, no \\Seen flag set).
+
+Usage: python3 read.py <imap_id>
+Prints: From, Subject, Date, then the plain-text body (HTML stripped to text if needed).
+Does NOT mark the message as read (uses BODY.PEEK).
+"""
+import sys, ssl, imaplib, email, re
+from email.header import decode_header
+sys.path.insert(0, "/Users/marvin/ClaudeClaw/scripts/support-mail")
+import lib
+
+
+def _dec(v):
+    if not v:
+        return ""
+    return "".join(p.decode(e or "utf-8", "replace") if isinstance(p, bytes) else p
+                   for p, e in decode_header(v))
+
+
+def _body(msg):
+    if msg.is_multipart():
+        # prefer text/plain
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain" and "attachment" not in str(part.get("Content-Disposition", "")):
+                return part.get_payload(decode=True).decode(part.get_content_charset() or "utf-8", "replace")
+        for part in msg.walk():
+            if part.get_content_type() == "text/html":
+                html = part.get_payload(decode=True).decode(part.get_content_charset() or "utf-8", "replace")
+                return re.sub(r"<[^>]+>", " ", html)
+        return ""
+    payload = msg.get_payload(decode=True)
+    if not payload:
+        return ""
+    text = payload.decode(msg.get_content_charset() or "utf-8", "replace")
+    if msg.get_content_type() == "text/html":
+        text = re.sub(r"<[^>]+>", " ", text)
+    return text
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: read.py <imap_id>"); sys.exit(1)
+    mid = sys.argv[1]
+    M = imaplib.IMAP4_SSL(lib.IMAP_HOST, lib.IMAP_PORT, ssl_context=ssl.create_default_context())
+    M.login(lib.EMAIL, lib.password())
+    M.select("INBOX", readonly=True)
+    typ, data = M.fetch(mid, "(BODY.PEEK[])")
+    if typ != "OK" or not data or not data[0]:
+        print("not found"); M.logout(); sys.exit(2)
+    msg = email.message_from_bytes(data[0][1])
+    print("From:", _dec(msg.get("From")))
+    print("Subject:", _dec(msg.get("Subject")))
+    print("Date:", _dec(msg.get("Date")))
+    print("---")
+    print(_body(msg).strip()[:4000])
+    M.logout()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/support-mail/send.py
+++ b/scripts/support-mail/send.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Send an email FROM support@aiamindennapokban.hu via Hostinger SMTP (implicit TLS:465).
+
+Usage:
+  python3 send.py --to a@b.hu --subject "..." --body "..." [--cc you@example.com] [--html]
+Body can also be piped on stdin if --body is omitted.
+Password is pulled from the vault at runtime (never stored/printed).
+"""
+import sys, ssl, smtplib, argparse
+from email.message import EmailMessage
+sys.path.insert(0, "/Users/marvin/ClaudeClaw/scripts/support-mail")
+import lib
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--to", required=True)
+    ap.add_argument("--subject", required=True)
+    ap.add_argument("--body", default=None)
+    ap.add_argument("--cc", default=None)
+    ap.add_argument("--html", action="store_true")
+    a = ap.parse_args()
+    body = a.body if a.body is not None else sys.stdin.read()
+
+    msg = EmailMessage()
+    msg["From"] = f"AI a mindennapokban support <{lib.EMAIL}>"
+    msg["To"] = a.to
+    if a.cc:
+        msg["Cc"] = a.cc
+    msg["Subject"] = a.subject
+    if a.html:
+        msg.set_content("A levél HTML formátumú; nézd HTML-képes kliensben.")
+        msg.add_alternative(body, subtype="html")
+    else:
+        msg.set_content(body)
+
+    rcpts = [a.to] + ([a.cc] if a.cc else [])
+    # FQDN EHLO name is REQUIRED: Hostinger SMTP rejects EHLO with a private/bare IP
+    # ([192.168.x.x]) -> "421 4.4.2 timeout exceeded". local_hostname forces a proper FQDN.
+    with smtplib.SMTP_SSL(lib.SMTP_HOST, lib.SMTP_PORT,
+                          local_hostname="aiamindennapokban.hu",
+                          context=ssl.create_default_context(), timeout=45) as s:
+        s.login(lib.EMAIL, lib.password())
+        s.send_message(msg, to_addrs=rcpts)
+    print(f"SENT from {lib.EMAIL} to {a.to}" + (f" cc {a.cc}" if a.cc else ""))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hostinger IMAP/SMTP helper a support@aiamindennapokban.hu mailboxhoz: `read.py`/`check-inbox.py` (inbox), `send.py` (küldés + opcionális CC/HTML), `no-support-reply.html` sablon, `lib.py` közös config.

## Secret/PII-scan (commit ELŐTT, flotta-policy)
- **NINCS hardcoded secret**: a `lib.py` a mailbox-jelszót RUNTIME-ban a Marveen vaultból tölti (dashboard vault API, kulcs `support@...pw`); sosem lemezen/forrásban.
- **NINCS customer PII**: az egyetlen személyes email (owner gmail egy `send.py` usage-példában) `you@example.com`-ra scrubbolva. A maradék email a service-cím + placeholderek.
- `__pycache__/` nincs benne (explicit fájl-add; a #312 amúgy is ignorálja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)