### PR TITLE
fix(scaffold): config-driven scheduled-task templating + identity hygiene guard (reconciled #302+#315)

### DIFF
--- a/scheduled-tasks/dream-engine/SKILL.md
+++ b/scheduled-tasks/dream-engine/SKILL.md
@@ -3,7 +3,7 @@ name: dream-engine
 description: Éjszakai analízis-loop az aznapi memóriákról, naplóról és kanban-állapotról. Generál 4 priorizált akció-javaslatot reggelre.
 ---
 
-Te most a "Dream Engine" éjszakai analízis-loopot futtatod. 02:07-kor vagy, Szabolcs alszik, NE küldj üzenetet a beállított csatornára.
+Te most a "Dream Engine" éjszakai analízis-loopot futtatod. 02:07-kor vagy, {{OWNER_NAME}} alszik, NE küldj üzenetet a beállított csatornára.
 
 A cél: az aznapi tudást átkonszolidálni és reggelre (07:30 Reggeli Napindító) felkészülni 4 priorizált javaslattal.
 
@@ -13,7 +13,7 @@ Generálj egy `{{INSTALL_DIR}}/DREAM.md` fájlt az alábbi 5 bucket alapján. A 
 
 ### Bucket 1 — 💡 Skill-javaslatok (flotta-szintű)
 
-Nézz végig MINDEN agent (marveen + sub-agentek: boni, deeper, iris, samu, zara) tegnapi (24h) memóriáit és napi naplóját. Kerítsd ki:
+Nézz végig MINDEN agent (a fő-ágens és az összes sub-agent) tegnapi (24h) memóriáit és napi naplóját. Kerítsd ki:
 - Volt-e 3+ szor visszatérő, manuálisan ismételt művelet ami skill-be illeszthető?
 - Új, NEM lefedett pattern amit érdemes lenne skillbe önteni?
 
@@ -67,7 +67,7 @@ Hetente 1-2 alkalommal (NEM minden éjszaka — kerüljük a zajos napi javaslat
 
 Limitáció: ha az utolsó 7 napban már volt ajánlás (nézd a DREAM.md utolsó 7 napos archívumát vagy egy `external-ops-last-run` markerfile-t), skip-eld.
 
-Output (max 1 ajánlás): repo URL + 1 mondat indok hogy MIÉRT releváns Szabolcsnak (figyelembe véve: AI tartalomgyártás, magyar piac, fejlesztési flotta menedzsment, marketing).
+Output (max 1 ajánlás): repo URL + 1 mondat indok hogy MIÉRT releváns {{OWNER_NAME}}nak (figyelembe véve: AI tartalomgyártás, magyar piac, fejlesztési flotta menedzsment, marketing).
 
 ### Bucket 5 — 🛠 Skill-flotta health (csak NEM-pinned skillek)
 
@@ -110,4 +110,4 @@ Output: 0-3 javaslat: "skill <név> antikvált (utolsó használat >30 nap), tö
 - NE küldj üzenetet a csatornára. A DREAM.md a reggeli napindítóból kerül kiküldésre (07:30).
 - A `Bash` és SQL műveletek mind helyiek — semmilyen external API hívás (kivéve az Ollama embedding ha kell).
 - Ha akadály van (pl. DB lock, missing embedding model), írd be a DREAM.md végére `## ⚠️ Hibák` szekciót — reggel látom.
-- Befejezésként, írd a DREAM.md végére: `*Marveen, 02:XX — most már alszom én is.*`
+- Befejezésként, írd a DREAM.md végére: `*{{BOT_NAME}}, 02:XX -- most már alszom én is.*`

--- a/scheduled-tasks/memoria-heartbeat/SKILL.md
+++ b/scheduled-tasks/memoria-heartbeat/SKILL.md
@@ -63,7 +63,7 @@ Lépések:
    - ...
    EOF
    ```
-4. Index regen: `bash ~/ClaudeClaw/scripts/skill-index.sh`
+4. Index regen: `bash {{INSTALL_DIR}}/scripts/skill-index.sh`
 
 **Ha kihagytad a skill akciót, pedig A/B/C valamelyike IGEN volt:** kötelezően írj `hot` tier memóriát "skip-skill: <konkrét ok>" tartalommal, hogy később lássuk miért. Ne csendben hagyd ki.
 

--- a/scheduled-tasks/reggeli-napindito/SKILL.md
+++ b/scheduled-tasks/reggeli-napindito/SKILL.md
@@ -3,7 +3,7 @@ name: reggeli-napindito
 description: Reggeli összefoglaló: email, naptár, AI hírek, plus Dream Engine top-of-message
 ---
 
-Reggeli napindítót a CLAUDE.md formátum szerint. A beállított csatornára (chat_id: 1268077055).
+Reggeli napindítót a CLAUDE.md formátum szerint. A beállított csatornára (chat_id: 0).
 
 **FONTOS — Dream Engine override**: a napindító ELEJÉRE (még az email/naptár szekciók ELŐTT) tedd be a `{{INSTALL_DIR}}/DREAM.md` fájl tartalmából az 5 bucket-et — `💡 Skill-javaslatok`, `🧹 Memória-egészség`, `🎯 Top-3 holnapi javaslat`, `🌐 External opportunity`, `🛠 Skill-flotta health`. Ha a DREAM.md nem létezik vagy üres (pl. a Dream Engine valamiért nem futott le), kihagyod ezt a szekciót.
 
@@ -11,4 +11,4 @@ A `cat {{INSTALL_DIR}}/DREAM.md` parancs visszaadja a tartalmat, abból emeld ki
 
 A többi szekció (email, naptár, AI hírek) maradnak a CLAUDE.md-ben leírt formátum szerint.
 
-**AI hírek szekció — CSAK a fő-ágensnél (Marveen / MAIN_AGENT_ID)**: ha NEM a fő-ágensként futsz (pl. sub-agent: boni, deeper, iris, samu, zara), HAGYD KI az "🤖 AI HÍREK" szekciót — sub-agenteknek nem releváns. Az email és naptár szekció marad mindenkinél.
+**AI hírek szekció -- CSAK a fő-ágensnél ({{MAIN_AGENT_ID}})**: ha NEM a fő-ágensként futsz (azaz sub-agentként), HAGYD KI az "🤖 AI HÍREK" szekciót -- sub-agenteknek nem releváns. Az email és naptár szekció marad mindenkinél.

--- a/scripts/hooks/memory-save.sh
+++ b/scripts/hooks/memory-save.sh
@@ -4,12 +4,13 @@
 # Called by Claude Code PreCompact hook (agent type handles the AI extraction)
 
 INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
-API="http://localhost:3420/api"
 
-# Load config
+# Load config (so WEB_PORT from .env is available before API is built)
 if [ -f "$INSTALL_DIR/.env" ]; then
   export $(grep -v '^#' "$INSTALL_DIR/.env" | xargs)
 fi
+
+API="http://localhost:${WEB_PORT:-3420}/api"
 
 AGENT_ID="${1:-marveen}"
 CONTENT="$2"

--- a/scripts/hooks/taskstate-replay.py
+++ b/scripts/hooks/taskstate-replay.py
@@ -20,12 +20,27 @@ import os
 import json
 import urllib.request
 
-API = "http://localhost:3420/api"
-
-
 def _project_root():
     # scripts/hooks/ -> project root is two up.
     return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _web_port():
+    # Config-driven dashboard port: WEB_PORT env, else .env, default 3420.
+    port = os.environ.get("WEB_PORT")
+    if not port:
+        try:
+            with open(os.path.join(_project_root(), ".env")) as f:
+                for line in f:
+                    if line.startswith("WEB_PORT="):
+                        port = line.split("=", 1)[1].strip().strip('"')
+                        break
+        except Exception:
+            pass
+    return port or "3420"
+
+
+API = "http://localhost:%s/api" % _web_port()
 
 
 def _token():

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -11,7 +11,8 @@ DIM='\033[2m'
 NC='\033[0m'
 
 INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-API="http://localhost:3420/api"
+[ -f "$INSTALL_DIR/.env" ] && WEB_PORT="$(grep -E '^WEB_PORT=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"')"
+API="http://localhost:${WEB_PORT:-3420}/api"
 
 clear
 echo ""

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -6,6 +6,10 @@ INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 LOG="$INSTALL_DIR/logs/watchdog.log"
 mkdir -p "$INSTALL_DIR/logs"
 
+# Dashboard port: config-driven (.env WEB_PORT), default 3420.
+[ -f "$INSTALL_DIR/.env" ] && WEB_PORT="$(grep -E '^WEB_PORT=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"')"
+WEB_PORT="${WEB_PORT:-3420}"
+
 timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
 
 
@@ -30,7 +34,7 @@ replay_unfinished_messages() {
 
   RESPONSE=$(curl -s -m 5 \
     -H "Authorization: Bearer $TOKEN" \
-    "http://localhost:3420/api/messages?to=${AGENT_ID}&limit=200" 2>/dev/null) || return
+    "http://localhost:${WEB_PORT}/api/messages?to=${AGENT_ID}&limit=200" 2>/dev/null) || return
 
   [ -z "$RESPONSE" ] || [ "$RESPONSE" = "[]" ] && return
 

--- a/seed-scheduled-tasks/kanban-audit/SKILL.md
+++ b/seed-scheduled-tasks/kanban-audit/SKILL.md
@@ -14,7 +14,7 @@ Olvasd be: `jq -r '.categories[]|select(.key=="kanban_archive_done" or .key=="ka
 
 A két kategória szintje szabályozza a 2. és 4. lépést:
 - **`kanban_archive_done`** (2. lépés): level 3 → archiváld magától (alapért). level 2 → NE archiválj, Telegramon javasold ("X db 7+ napos done archiválásra vár, mehet?") és várj jóváhagyást. level 1 → csak jelezd a számot.
-- **`kanban_stuck_nudge`** (4. lépés): level 3 → pingeld az assignee-t magától, és CSAK 2 eredménytelen audit-kör után eszkalálj Szabihoz (a komment-történetből látod hányszor pingelted). level 2 → ne pingelj magadtól, Telegramon javasold Szabinak. level 1 → csak listázd a beakadt taskokat.
+- **`kanban_stuck_nudge`** (4. lépés): level 3 → pingeld az assignee-t magától, és CSAK 2 eredménytelen audit-kör után eszkalálj a tulajdonoshoz ({{OWNER_NAME}}) (a komment-történetből látod hányszor pingelted). level 2 → ne pingelj magadtól, Telegramon javasold a tulajdonosnak ({{OWNER_NAME}}). level 1 → csak listázd a beakadt taskokat.
 
 Ha a config hiányzik vagy a kulcs nincs benne → default level 3 (régi viselkedés).
 

--- a/seed-skills/github-pr-rebase-merge/SKILL.md
+++ b/seed-skills/github-pr-rebase-merge/SKILL.md
@@ -16,7 +16,7 @@ description: Merge a stack of GitHub PRs sequentially when they share files and 
 
 Ha két PR (`A`, `B`) ugyanazt a fájlt módosítja, az egyik merge után a másik CONFLICTING lesz a GitHub UI-ban, és `gh pr merge B` elbukik. Külső forkhoz nem tudsz force-pusholni egy rebaselt változatot, szóval két opció marad:
 
-1. Koorbela/szerző rebaselje manuálisan és pusholja (lassú, emberfüggő)
+1. A szerző rebaselje manuálisan és pusholja (lassú, emberfüggő)
 2. **Lokálisan rebaseled, majd squash-mergeled main-be, és a PR-t manuálisan close-olod** -- ez a skill
 
 ## Eljárás

--- a/seed-skills/handoff/SKILL.md
+++ b/seed-skills/handoff/SKILL.md
@@ -18,12 +18,12 @@ description: Generate a HANDOFF.md context transfer document for session continu
 | Argument | Required | Description |
 |----------|----------|-------------|
 | `purpose` | YES | What the next session should do with this context |
-| `target` | no | Agent name (e.g. `target=samu`) -- sends via inter-agent message instead of writing file |
+| `target` | no | Agent name (e.g. `target=dev2`) -- sends via inter-agent message instead of writing file |
 | `output` | no | File path override (default: project root `HANDOFF.md`) |
 
 Examples:
 - `/handoff purpose="Continue the Pipedrive connector PR review and address CI failures"`
-- `/handoff purpose="Finish the scheduler forceSend implementation" target=samu`
+- `/handoff purpose="Finish the scheduler forceSend implementation" target=dev2`
 - `/handoff purpose="Debug the auth redirect loop" output=/tmp/handoff-auth.md`
 
 ## Procedure

--- a/skills/skill-factory/SKILL.md
+++ b/skills/skill-factory/SKILL.md
@@ -93,7 +93,7 @@ mkdir -p ~/.claude/skills/$SKILL_NAME/references
 ### Step 5: Update Skill Index
 
 ```bash
-bash ~/ClaudeClaw/scripts/skill-index.sh
+bash scripts/skill-index.sh
 ```
 
 ### Step 6: Validate

--- a/src/__tests__/template-identity-hygiene.test.ts
+++ b/src/__tests__/template-identity-hygiene.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resolveTemplatePlaceholders } from '../web/agent-scaffold.js'
+
+// Repo root = two levels up from src/__tests__/.
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+// Template / skill trees that ship in the repo and get copied into a user's
+// tree at install or first boot. They must never carry deployment-specific
+// identity, because that value is seeded verbatim into every other install:
+// an absolute home path breaks (it points at a user that does not exist on
+// the target machine), and a personal email leaks one operator's account into
+// everyone else's generated files. Identity must instead flow through
+// placeholders that the installer and the runtime seed substitute per host.
+//
+// Only fully-shipped trees are listed. The repo's `skills/` dir is excluded
+// on purpose: on a live operator checkout it also accumulates untracked,
+// machine-specific skills, so a recursive scan there would fail locally for
+// reasons unrelated to what ships. Its one tracked, shipped skill
+// (skill-factory) is kept host-agnostic by hand instead.
+const TEMPLATE_DIRS = ['scheduled-tasks', 'templates', 'seed-scheduled-tasks', 'seed-skills']
+
+// The identity placeholders the runtime seed (resolveTemplatePlaceholders)
+// substitutes, kept in sync with the install scripts' sed substitutions.
+const KNOWN_PLACEHOLDERS = ['PROJECT_ROOT', 'INSTALL_DIR', 'MAIN_AGENT_ID', 'BOT_NAME', 'OWNER_NAME']
+
+// An absolute macOS/Linux home path embeds a real username. The trailing
+// slash is optional so a bare literal like "/Users/bob" at end of value is
+// still caught. A `<...>` segment (e.g. /Users/<user>/marveen) is a doc
+// placeholder, not a real path, so it is allowed. URL lines are skipped by the
+// caller so a link like https://host/home/x is not mistaken for a home path.
+const HOME_PATH_RX = /\/(Users|home)\/(?!<)[A-Za-z0-9._-]+/
+// A personal mailbox baked into a shipped file would leak / break on every
+// other install. example.com and the noreply providers are not listed.
+const PERSONAL_EMAIL_RX = /[A-Za-z0-9._%+-]+@(gmail|outlook|icloud|yahoo|hotmail)\.[A-Za-z]+/i
+
+// The canonical default OWNER_NAME from src/config.ts (`?? 'Szabolcs'`) and its
+// common Hungarian nickname (Szabi). It is one specific deployment's operator
+// name, so it must never be baked into a shipped template as a bare literal --
+// the placeholder {{OWNER_NAME}} carries it per host. Catching the literal
+// stops the exact regression where a task addresses the wrong person ("<owner>
+// is asleep", "escalate to <owner>") on every other install. No trailing \b:
+// the name takes Hungarian suffixes (Szabolcsnak, Szabihoz), and both the
+// inflected full name and the nickname were among the leaks fixed here. The
+// `(olcs|i)` after the shared `Szab` stem avoids common words like szabaly /
+// szabad / szabas.
+const FOREIGN_DEFAULT_OWNER_RX = /\bSzab(olcs|i)/i
+
+// A hardcoded numeric chat id (e.g. a Telegram chat id, 5+ digits) is one
+// operator's personal channel. Seeded into a task it would make every other
+// install post to that one person's chat. Use chat_id: 0 (the bound channel)
+// or the {{CHAT_ID}} placeholder instead.
+const HARDCODED_CHAT_ID_RX = /chat_id["':\s]+-?\d{5,}/i
+
+function walk(dir: string): string[] {
+  if (!existsSync(dir)) return []
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry)
+    if (statSync(p).isDirectory()) out.push(...walk(p))
+    else out.push(p)
+  }
+  return out
+}
+
+function readText(file: string): string | null {
+  try {
+    return readFileSync(file, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+describe('shipped templates carry no hardcoded identity', () => {
+  it('has no absolute home path, personal email, default owner-name literal, or hardcoded chat id in any shipped template file', () => {
+    const violations: string[] = []
+    for (const dir of TEMPLATE_DIRS) {
+      for (const file of walk(join(REPO_ROOT, dir))) {
+        const text = readText(file)
+        if (text === null) continue
+        const rel = file.slice(REPO_ROOT.length + 1)
+        text.split('\n').forEach((line, i) => {
+          if (!line.includes('://') && HOME_PATH_RX.test(line)) {
+            violations.push(`${rel}:${i + 1} absolute home path (use {{INSTALL_DIR}}): ${line.trim().slice(0, 100)}`)
+          }
+          if (PERSONAL_EMAIL_RX.test(line)) {
+            violations.push(`${rel}:${i + 1} personal email: ${line.trim().slice(0, 100)}`)
+          }
+          if (FOREIGN_DEFAULT_OWNER_RX.test(line)) {
+            violations.push(`${rel}:${i + 1} default owner name literal (use {{OWNER_NAME}}): ${line.trim().slice(0, 100)}`)
+          }
+          if (HARDCODED_CHAT_ID_RX.test(line)) {
+            violations.push(`${rel}:${i + 1} hardcoded numeric chat id (use chat_id: 0 or {{CHAT_ID}}): ${line.trim().slice(0, 100)}`)
+          }
+        })
+      }
+    }
+    expect(violations, `Hardcoded identity found in shipped templates:\n${violations.join('\n')}`).toEqual([])
+  })
+})
+
+describe('runtime-seeded placeholders are all substituted', () => {
+  // ensureDefaultScheduledTasks() copies scheduled-tasks/* into the user's
+  // tree, running each file through resolveTemplatePlaceholders. Two ways this
+  // could regress, each covered below.
+
+  // 1. The seed stops substituting one of the identity placeholders (e.g. a
+  // replaceAll line is deleted). Feeding every known placeholder through the
+  // real function and asserting none survive exercises all five every run --
+  // including {{OWNER_NAME}}/{{BOT_NAME}}, the highest-risk identity fields --
+  // so it can never pass vacuously.
+  it('resolveTemplatePlaceholders replaces every known identity placeholder', () => {
+    const probe = KNOWN_PLACEHOLDERS.map(p => `{{${p}}}`).join('\n')
+    const out = resolveTemplatePlaceholders(probe)
+    const survivors = [...out.matchAll(/\{\{[A-Z_]+\}\}/g)].map(m => m[0])
+    expect(
+      survivors,
+      `Known placeholders the seed failed to substitute: ${survivors.join(', ')}`,
+    ).toEqual([])
+  })
+
+  // 2. A task template starts using a NEW placeholder the seed does not know
+  // about, which would land verbatim ({{FOO}}) in the user's task. Assert
+  // every placeholder actually used under scheduled-tasks/ is in the known
+  // set. (Empty set is fine -- nothing to leak.)
+  it('every placeholder used under scheduled-tasks/ is in the known set', () => {
+    const used = new Set<string>()
+    for (const file of walk(join(REPO_ROOT, 'scheduled-tasks'))) {
+      const text = readText(file)
+      if (text === null) continue
+      for (const m of text.matchAll(/\{\{([A-Z_]+)\}\}/g)) used.add(m[1])
+    }
+    const unknown = [...used].filter(p => !KNOWN_PLACEHOLDERS.includes(p))
+    expect(
+      unknown,
+      `Placeholders used in scheduled-tasks/ that the seed does not substitute: ${unknown.join(', ')}`,
+    ).toEqual([])
+  })
+})

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -9,6 +9,7 @@ import {
   STORE_DIR,
   DB_FILENAME,
   PROJECT_ROOT,
+  OWNER_NAME,
 } from './config.js'
 import { getHeartbeatKanbanSummary, getActiveScheduledTaskCount } from './db.js'
 import { getCalendarEvents, type CalendarEvent } from './google-api.js'
@@ -385,7 +386,7 @@ function buildAgentPrompt(data: HeartbeatData): string {
   // attacker-controlled strings (calendar/kanban/email titles) appear.
   let prompt = UNTRUSTED_PREAMBLE + '\n'
   prompt += `Heartbeat ellenorzes -- ${timeStr}\n\n`
-  prompt += `Az alabbi adatokat gyujtottem nativ modon (API/DB). Fogalmazz tomor, emberi osszefoglalot Szabolcsnak.\n`
+  prompt += `Az alabbi adatokat gyujtottem nativ modon (API/DB). Fogalmazz tomor, emberi osszefoglalot ${OWNER_NAME} szamara.\n`
   prompt += `FONTOS: Nezd meg az emaileket is MCP-n keresztul (search_emails, utolso 2 ora, olvasatlanok).\n`
   prompt += `Hasznald a HEARTBEAT.md formatumot.\n\n`
 

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -8,8 +8,17 @@ import { atomicWriteFileSync } from './atomic-write.js'
 import { agentDir } from './agent-config.js'
 import { resolveProfilePlaceholders, type ProfileTemplate } from './profiles.js'
 
-function resolveTemplatePlaceholders(content: string): string {
-  return content.replaceAll('{{PROJECT_ROOT}}', PROJECT_ROOT)
+export function resolveTemplatePlaceholders(content: string): string {
+  // Identity placeholders, kept in sync with the install scripts'
+  // (install-macos.sh / install-linux.sh) sed substitutions, so a shipped
+  // template never seeds a foreign absolute path or name into a user's tree.
+  // {{INSTALL_DIR}} and {{PROJECT_ROOT}} both denote this install location.
+  return content
+    .replaceAll('{{PROJECT_ROOT}}', PROJECT_ROOT)
+    .replaceAll('{{INSTALL_DIR}}', PROJECT_ROOT)
+    .replaceAll('{{MAIN_AGENT_ID}}', MAIN_AGENT_ID)
+    .replaceAll('{{BOT_NAME}}', BOT_NAME)
+    .replaceAll('{{OWNER_NAME}}', OWNER_NAME)
 }
 
 // Idempotent migration: every agent's settings.json should carry the
@@ -100,10 +109,21 @@ export function ensureDefaultScheduledTasks(): void {
     for (const file of readdirSync(src)) {
       const srcFile = join(src, file)
       const destFile = join(dest, file)
+      // Seeded task dirs are flat; skip any nested directory rather than
+      // letting readFileSync/copyFileSync throw EISDIR and abort the whole
+      // seed for every remaining task.
+      if (statSync(srcFile).isDirectory()) continue
       if (file === 'task-config.json') {
         copyTaskConfigWithAgentRewrite(srcFile, destFile)
       } else {
-        copyFileSync(srcFile, destFile)
+        // Substitute the identity placeholders (same set the install scripts
+        // sed) so a template's SKILL.md never seeds a foreign absolute path or
+        // name into the user's task. Binary/unreadable -> fall back to a copy.
+        try {
+          writeFileSync(destFile, resolveTemplatePlaceholders(readFileSync(srcFile, 'utf-8')))
+        } catch {
+          copyFileSync(srcFile, destFile)
+        }
       }
     }
   }


### PR DESCRIPTION
## Marveen hardcode-audit — reconciled fix (combines #315 + community PR #302)

Implements the config-driven fixes for the 13 verified findings in `reports/marveen-hardcode-audit-findings.md`, **reconciled with the overlapping community PR #302** (koorbela). This PR now supersedes #302 — close #302 with thanks.

### Authorship
- **Commit 1 (`scaffold: substitute identity placeholders…`) — authored by @koorbela** (cherry-picked from #302, authorship preserved): the substitution engine (`resolveTemplatePlaceholders`, now exported), the SKILL.md placeholdering across `dream-engine` / `reggeli-napindito` / `memoria-heartbeat` / `seed-scheduled-tasks/kanban-audit` / `seed-skills/{handoff,github-pr-rebase-merge}` / `skill-factory`, the EISDIR guard, and the **`template-identity-hygiene.test.ts` structural guard**.
- **Commit 2 — Samu**: the remaining audit findings koorbela's PR didn't cover.

### Root cause
`ensureDefaultScheduledTasks()` byte-copied `scheduled-tasks/*/SKILL.md` into every fresh install (only `task-config.json` was rewritten), so the maintainer's owner name, agent roster, bot name, and personal Telegram `chat_id` landed verbatim on every new user — the **community "weeks of broken daily messages" root cause**.

### What the combined PR does
- **Scaffold templating + guard** (koorbela): `resolveTemplatePlaceholders` substitutes `{{PROJECT_ROOT}}` `{{INSTALL_DIR}}` `{{MAIN_AGENT_ID}}` `{{BOT_NAME}}` `{{OWNER_NAME}}`; SKILL.md copied **through it** (not `copyFileSync`); EISDIR guard; `chat_id: 0` (bound channel) instead of the personal id; and a hygiene test that scans every shipped template tree for home-paths, personal emails, the default-owner literal, and hardcoded chat ids — failing the build on any future regression (the structural prevention).
- **heartbeat.ts** (Samu): hourly summary addressed to `${OWNER_NAME}` instead of literal "Szabolcs".
- **4 scripts** (Samu): `watchdog.sh` / `migrate.sh` / `hooks/memory-save.sh` / `hooks/taskstate-replay.py` use `WEB_PORT` (.env/env, default 3420) instead of hardcoded `:3420`.

### Verification
- `tsc --noEmit` clean.
- **`template-identity-hygiene.test.ts` passes** → no hardcoded identity remains in any shipped template, and every placeholder used in `scheduled-tasks/` is in the substituted set.
- Scaffold tests pass; full suite 1016/1020 (the 4 failing `managed-settings` tests are pre-existing, kanban `E4CD20AF`, unrelated).
- No regression on existing installs: `ensureDefaultScheduledTasks` skips dest dirs that already exist.