### PR TITLE
chore(gitignore): ignore operator's local support auto-reply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,11 @@ DREAM.md
 .external-ops-last-run
 REBUILD_PROMPT_V3.1.md
 
+# Operator's branded support auto-reply. The shipped support-mail tooling is a
+# generic IMAP/SMTP CLI (no operator data); each operator keeps their own
+# branded auto-reply here locally. Ignored so it never ships to other installs.
+scripts/support-mail/no-support-reply.html
+
 # Python bytecode cache
 __pycache__/
 *.pyc


### PR DESCRIPTION
Per Szabi support-function-preservation: the shipped `scripts/support-mail` tooling is a generic IMAP/SMTP CLI (de-identified in #316), but each operator keeps their own **branded** `no-support-reply.html` locally so their support@ auto-reply keeps working. This adds the gitignore rule so that local template never ships to another install and a `git add -A` can't re-commit it.

The HTML file itself is **not** committed (local-only, operator-specific). One-line ignore rule; promotes with the next release.

Verified on this instance: full support@ workflow intact — `check-inbox`/`read` work (config from .env), and `send.py --html no-support-reply.html` builds a valid branded message (the restored original HTML has no placeholders, so the bare `send.py` sends it raw — no missing `render()` dependency).