### PR TITLE
feat(terminal): interactive PTY-backed agent terminal over WebSocket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,32 @@
 {
   "name": "marveen",
-  "version": "1.0.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marveen",
-      "version": "1.0.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",
         "better-sqlite3": "^11.7.0",
         "cron-parser": "^5.0.0",
+        "node-pty": "^1.1.0",
         "pino": "^9.6.0",
-        "pino-pretty": "^13.0.0"
+        "pino-pretty": "^13.0.0",
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.10.0",
+        "@types/ws": "^8.18.1",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
         "vitest": "^2.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20 <24"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -1067,6 +1070,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2352,6 +2365,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/object-assign": {
@@ -3937,6 +3966,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.116",
     "better-sqlite3": "^11.7.0",
     "cron-parser": "^5.0.0",
+    "node-pty": "^1.1.0",
     "pino": "^9.6.0",
-    "pino-pretty": "^13.0.0"
+    "pino-pretty": "^13.0.0",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.0",
+    "@types/ws": "^8.18.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"

--- a/src/__tests__/agent-pty-bridge-remote.test.ts
+++ b/src/__tests__/agent-pty-bridge-remote.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { ptyAttachCommand, tmuxControlCommand } from '../web/agent-pty-bridge.js'
+
+// The team-view live terminal failed for remote agents (Cassie on the jannoti
+// laptop) with "can't find session: agent-cassie" -- the bridge spawned a LOCAL
+// `tmux attach`, but the session lives on the remote host. These pure builders
+// route the attach + control commands over ssh when the agent is remote.
+
+describe('ptyAttachCommand', () => {
+  it('attaches locally for a local agent (host = null)', () => {
+    expect(ptyAttachCommand(null, 'agent-prof')).toEqual({
+      file: 'tmux',
+      args: ['attach-session', '-t', 'agent-prof'],
+    })
+  })
+
+  it('attaches over ssh with a forced PTY for a remote agent', () => {
+    expect(ptyAttachCommand('jannoti', 'agent-cassie')).toEqual({
+      file: 'ssh',
+      args: ['-tt', 'jannoti', 'tmux', 'attach-session', '-t', 'agent-cassie'],
+    })
+  })
+})
+
+describe('tmuxControlCommand', () => {
+  it('runs control commands locally for a local agent', () => {
+    expect(tmuxControlCommand(null, ['resize-window', '-t', 'agent-prof', '-x', '80', '-y', '24'])).toEqual({
+      file: 'tmux',
+      args: ['resize-window', '-t', 'agent-prof', '-x', '80', '-y', '24'],
+    })
+  })
+
+  it('wraps control commands in ssh for a remote agent (window-pin on the remote host)', () => {
+    expect(tmuxControlCommand('jannoti', ['set-window-option', '-t', 'agent-cassie', '-u', 'window-size'])).toEqual({
+      file: 'ssh',
+      args: ['jannoti', 'tmux', 'set-window-option', '-t', 'agent-cassie', '-u', 'window-size'],
+    })
+  })
+})

--- a/src/__tests__/agent-pty-bridge.test.ts
+++ b/src/__tests__/agent-pty-bridge.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import http from 'node:http'
+import { WebSocket } from 'ws'
+import { execSync } from 'node:child_process'
+import { issueTicket, consumeTicket } from '../web/pty-ticket.js'
+import { attachWsUpgradeHandler } from '../web/agent-pty-bridge.js'
+
+const UID = Date.now()
+const TEST_AGENT = `bridge-${UID}`
+const TEST_SESSION = `agent-${TEST_AGENT}`
+let server: http.Server
+let port: number
+
+const sessionNameFn = (name: string) => `agent-${name}`
+
+beforeAll(async () => {
+  execSync(`tmux new-session -d -s '${TEST_SESSION}' 'cat'`, { stdio: 'ignore' })
+  server = http.createServer((_, res) => { res.writeHead(404); res.end() })
+  attachWsUpgradeHandler(server, consumeTicket, sessionNameFn, {
+    pingIntervalMs: 200,
+    pongTimeoutMs: 300,
+  })
+  await new Promise<void>(r => server.listen(0, '127.0.0.1', r))
+  port = (server.address() as any).port
+}, 30000)
+
+afterAll(async () => {
+  await new Promise<void>(r => server.close(() => r()))
+  try { execSync(`tmux kill-session -t '${TEST_SESSION}'`, { stdio: 'ignore' }) } catch {}
+})
+
+function wsCloseCode(path: string): Promise<number> {
+  return new Promise((resolve) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${path}`)
+    ws.on('close', (code) => resolve(code))
+    ws.on('error', () => resolve(-1))
+    setTimeout(() => { ws.terminate(); resolve(-2) }, 4000)
+  })
+}
+
+async function connectWs(path: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${path}`)
+    ws.once('open', () => resolve(ws))
+    ws.once('error', reject)
+  })
+}
+
+function closeAndWait(ws: WebSocket): Promise<void> {
+  return new Promise(r => {
+    if (ws.readyState === WebSocket.CLOSED) return r()
+    ws.once('close', () => r())
+    ws.close()
+  })
+}
+
+describe('agent-pty-bridge', () => {
+  it('invalid/short ticket returns close 4401', async () => {
+    const code = await wsCloseCode('/ws/agent-pty?ticket=badticket')
+    expect(code).toBe(4401)
+  })
+
+  it('valid ticket for non-existent session returns 4404', async () => {
+    const deadAgent = `ghost-${UID}`
+    const ticket = issueTicket(deadAgent, Math.floor(Date.now() / 1000))
+    const code = await wsCloseCode(`/ws/agent-pty?ticket=${ticket}`)
+    expect(code).toBe(4404)
+  })
+
+  it('connects successfully with valid ticket and real tmux session', async () => {
+    const ticket = issueTicket(TEST_AGENT, Math.floor(Date.now() / 1000))
+    const ws = await connectWs(`/ws/agent-pty?ticket=${ticket}&cols=80&rows=24`)
+    expect(ws.readyState).toBe(WebSocket.OPEN)
+    await closeAndWait(ws)
+  }, 5000)
+
+  it('resize message is forwarded without error', async () => {
+    const ticket = issueTicket(TEST_AGENT, Math.floor(Date.now() / 1000))
+    const ws = await connectWs(`/ws/agent-pty?ticket=${ticket}`)
+    ws.send(JSON.stringify({ type: 'resize', cols: 100, rows: 40 }))
+    await new Promise(r => setTimeout(r, 300))
+    expect(ws.readyState).toBe(WebSocket.OPEN)
+    await closeAndWait(ws)
+  }, 3000)
+
+  it('reuses same ticket on second connect returns 4401 (single-use)', async () => {
+    const ticket = issueTicket(TEST_AGENT, Math.floor(Date.now() / 1000))
+    const ws1 = await connectWs(`/ws/agent-pty?ticket=${ticket}`)
+    await closeAndWait(ws1)
+    const code = await wsCloseCode(`/ws/agent-pty?ticket=${ticket}`)
+    expect(code).toBe(4401)
+  }, 5000)
+
+  it('URL agent param is ignored — session comes only from the consumed ticket', async () => {
+    const ticket = issueTicket(TEST_AGENT, Math.floor(Date.now() / 1000))
+    const ws = await connectWs(`/ws/agent-pty?ticket=${ticket}&agent=ghost-${UID}-attacker`)
+    expect(ws.readyState).toBe(WebSocket.OPEN)
+    await closeAndWait(ws)
+  }, 5000)
+
+  it('a 4th concurrent viewer on the same session is rejected with 4429; slot frees after disconnect', async () => {
+    const nowS = Math.floor(Date.now() / 1000)
+    const t1 = issueTicket(TEST_AGENT, nowS)
+    const t2 = issueTicket(TEST_AGENT, nowS)
+    const t3 = issueTicket(TEST_AGENT, nowS)
+    const t4 = issueTicket(TEST_AGENT, nowS)
+    const ws1 = await connectWs(`/ws/agent-pty?ticket=${t1}`)
+    const ws2 = await connectWs(`/ws/agent-pty?ticket=${t2}`)
+    const ws3 = await connectWs(`/ws/agent-pty?ticket=${t3}`)
+    expect(ws1.readyState).toBe(WebSocket.OPEN)
+    expect(ws2.readyState).toBe(WebSocket.OPEN)
+    expect(ws3.readyState).toBe(WebSocket.OPEN)
+
+    const code = await wsCloseCode(`/ws/agent-pty?ticket=${t4}`)
+    expect(code).toBe(4429)
+
+    await closeAndWait(ws1)
+    await new Promise(r => setTimeout(r, 150))
+    const t5 = issueTicket(TEST_AGENT, Math.floor(Date.now() / 1000))
+    const ws5 = await connectWs(`/ws/agent-pty?ticket=${t5}`)
+    expect(ws5.readyState).toBe(WebSocket.OPEN)
+
+    await closeAndWait(ws2)
+    await closeAndWait(ws3)
+    await closeAndWait(ws5)
+  }, 10000)
+
+  it('keepalive: a dead connection (no pong) is torn down and its viewer slot is freed', async () => {
+    const nowS = Math.floor(Date.now() / 1000)
+    const t1 = issueTicket(TEST_AGENT, nowS)
+    // Connect with autoPong:false and override the 'ping' listener so the
+    // client never replies. This simulates a dead-but-alive TCP connection
+    // from the server's perspective (no pong arrives → pong-timeout fires).
+    const ws = await new Promise<WebSocket>((resolve, reject) => {
+      const w = new WebSocket(`ws://127.0.0.1:${port}/ws/agent-pty?ticket=${t1}`, {
+        autoPong: false,
+      } as any)
+      w.once('open', () => resolve(w))
+      w.once('error', reject)
+    })
+    expect(ws.readyState).toBe(WebSocket.OPEN)
+
+    const closed: number = await new Promise((resolve) => {
+      ws.once('close', (code: number) => resolve(code))
+      setTimeout(() => resolve(-1), 3000)
+    })
+    // After ~500ms (200ms ping + 300ms pong-timeout) the server should close
+    // with a deliberate code (1011 in this implementation). -1 means we never
+    // saw a close event within 3s — that would be the bug we are guarding against.
+    expect(closed).not.toBe(-1)
+
+    // Slot should now be free: open 3 fresh tickets and verify all succeed.
+    await new Promise(r => setTimeout(r, 100))
+    const tt = [
+      issueTicket(TEST_AGENT, Math.floor(Date.now() / 1000)),
+      issueTicket(TEST_AGENT, Math.floor(Date.now() / 1000)),
+      issueTicket(TEST_AGENT, Math.floor(Date.now() / 1000)),
+    ]
+    const wss: WebSocket[] = []
+    for (const t of tt) {
+      const w = await connectWs(`/ws/agent-pty?ticket=${t}`)
+      expect(w.readyState).toBe(WebSocket.OPEN)
+      wss.push(w)
+    }
+    for (const w of wss) await closeAndWait(w)
+  }, 8000)
+})

--- a/src/__tests__/pty-render-utils.test.ts
+++ b/src/__tests__/pty-render-utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { buildPtyWsUrl, buildResizeMsg, ptyCloseCodeMsg } from '../pty-render-utils.js'
+
+describe('buildPtyWsUrl', () => {
+  it('uses ws: for http protocol', () => {
+    const url = buildPtyWsUrl('http:', 'localhost:8080', 'abc123ticket', 120, 30)
+    expect(url).toBe('ws://localhost:8080/ws/agent-pty?ticket=abc123ticket&cols=120&rows=30')
+  })
+
+  it('uses wss: for https protocol', () => {
+    const url = buildPtyWsUrl('https:', 'example.com:443', 'xyz', 80, 24)
+    expect(url).toBe('wss://example.com:443/ws/agent-pty?ticket=xyz&cols=80&rows=24')
+  })
+
+  it('encodes ticket in query string', () => {
+    const url = buildPtyWsUrl('http:', 'host:3000', 'tick et+val', 80, 24)
+    expect(url).toContain('ticket=tick%20et%2Bval')
+  })
+
+  it('accepts location.host-style combined hostPort', () => {
+    const url = buildPtyWsUrl('http:', '127.0.0.1:3420', 't', 120, 30)
+    expect(url).toContain('//127.0.0.1:3420/')
+  })
+})
+
+describe('buildResizeMsg', () => {
+  it('returns JSON with type resize and given cols/rows', () => {
+    const msg = buildResizeMsg(120, 40)
+    const parsed = JSON.parse(msg)
+    expect(parsed).toEqual({ type: 'resize', cols: 120, rows: 40 })
+  })
+
+  it('round-trips through JSON.parse', () => {
+    const msg = buildResizeMsg(80, 24)
+    expect(typeof msg).toBe('string')
+    expect(JSON.parse(msg).type).toBe('resize')
+  })
+})
+
+describe('ptyCloseCodeMsg', () => {
+  it('returns friendly message for 4401', () => {
+    expect(ptyCloseCodeMsg(4401)).toContain('invalid ticket')
+  })
+
+  it('returns friendly message for 4404', () => {
+    expect(ptyCloseCodeMsg(4404)).toContain('not running')
+  })
+
+  it('returns friendly message for 4429', () => {
+    expect(ptyCloseCodeMsg(4429)).toContain('concurrent viewers')
+  })
+
+  it('returns generic message for unknown codes', () => {
+    const msg = ptyCloseCodeMsg(1006)
+    expect(msg).toContain('1006')
+  })
+})

--- a/src/__tests__/pty-ticket.test.ts
+++ b/src/__tests__/pty-ticket.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+
+// These functions don't exist yet → RED
+import { issueTicket, consumeTicket, checkRateLimit } from '../web/pty-ticket.js'
+
+describe('issueTicket', () => {
+  it('returns a 64-char hex string', () => {
+    const t = issueTicket('cody', 1000)
+    expect(t).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('returns unique tickets per call', () => {
+    const t1 = issueTicket('cody', 1000)
+    const t2 = issueTicket('cody', 1000)
+    expect(t1).not.toBe(t2)
+  })
+})
+
+describe('consumeTicket', () => {
+  it('happy path: fresh unused ticket', () => {
+    const t = issueTicket('cody', 1000)
+    const result = consumeTicket(t, 1010)
+    expect(result).toEqual({ ok: true, agentName: 'cody' })
+  })
+
+  it('expired TTL (30s) returns { ok: false, reason: "expired" }', () => {
+    const t = issueTicket('cody', 1000)
+    const result = consumeTicket(t, 1031) // 31s later
+    expect(result).toEqual({ ok: false, reason: 'expired' })
+  })
+
+  it('exactly at 30s boundary is expired', () => {
+    const t = issueTicket('cody', 1000)
+    const result = consumeTicket(t, 1030) // exactly 30s
+    expect(result).toEqual({ ok: false, reason: 'expired' })
+  })
+
+  it('within 30s is valid', () => {
+    const t = issueTicket('cody', 1000)
+    const result = consumeTicket(t, 1029) // 29s
+    expect(result.ok).toBe(true)
+  })
+
+  it('second consume of same ticket returns already_used', () => {
+    const t = issueTicket('cody', 1000)
+    consumeTicket(t, 1010)
+    const result = consumeTicket(t, 1010)
+    expect(result).toEqual({ ok: false, reason: 'already_used' })
+  })
+
+  it('unknown ticket returns not_found', () => {
+    const result = consumeTicket('a'.repeat(64), 1000)
+    expect(result).toEqual({ ok: false, reason: 'not_found' })
+  })
+})
+
+describe('checkRateLimit', () => {
+  it('first 10 requests from same IP are ok', () => {
+    const ip = `ip-test-${Date.now()}` // unique IP to avoid cross-test interference
+    const now = 1000000
+    for (let i = 0; i < 10; i++) {
+      expect(checkRateLimit(ip, now + i)).toEqual({ ok: true })
+    }
+  })
+
+  it('11th request within 60s window returns not-ok with retry_after_s', () => {
+    const ip = `ip-rate-${Date.now()}`
+    const now = 2000000
+    for (let i = 0; i < 10; i++) checkRateLimit(ip, now)
+    const result = checkRateLimit(ip, now + 5)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.retry_after_s).toBeGreaterThan(0)
+      expect(result.retry_after_s).toBeLessThanOrEqual(60)
+    }
+  })
+
+  it('resets after 60s window elapses', () => {
+    const ip = `ip-reset-${Date.now()}`
+    const now = 3000000
+    for (let i = 0; i < 10; i++) checkRateLimit(ip, now)
+    // 61s later, new window
+    const result = checkRateLimit(ip, now + 61)
+    expect(result).toEqual({ ok: true })
+  })
+})

--- a/src/pty-render-utils.ts
+++ b/src/pty-render-utils.ts
@@ -1,0 +1,25 @@
+// Pure helpers mirroring the inline implementations in web/app.js's openAgentPty.
+// Signatures match how the browser code constructs values: location.host already
+// combines hostname:port, so we accept a single hostPort string.
+
+export function buildPtyWsUrl(
+  protocol: string,
+  hostPort: string,
+  ticket: string,
+  cols: number,
+  rows: number,
+): string {
+  const wsScheme = protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${wsScheme}//${hostPort}/ws/agent-pty?ticket=${encodeURIComponent(ticket)}&cols=${cols}&rows=${rows}`
+}
+
+export function buildResizeMsg(cols: number, rows: number): string {
+  return JSON.stringify({ type: 'resize', cols, rows })
+}
+
+export function ptyCloseCodeMsg(code: number): string {
+  if (code === 4401) return '\u274C Expired or invalid ticket'
+  if (code === 4404) return '\u274C Agent is not running'
+  if (code === 4429) return '\u274C Too many concurrent viewers'
+  return `\u274C Connection closed (code: ${code})`
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -22,6 +22,9 @@ import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
 import { tryHandleAgentTerminal } from './web/routes/agent-terminal.js'
+import { attachWsUpgradeHandler } from './web/agent-pty-bridge.js'
+import { consumeTicket } from './web/pty-ticket.js'
+import { agentSessionName } from './web/agent-process.js'
 import { tryHandleAgentTaskState } from './web/routes/agent-taskstate.js'
 import { sweepOrphanTaskStates } from './web/agent-taskstate.js'
 import { tryHandleDailyLog } from './web/routes/daily-log.js'
@@ -212,6 +215,10 @@ export function startWebServer(port = 3420): http.Server {
       logger.error({ err }, 'Web szerver hiba')
     }
   })
+
+  // Interactive PTY terminal: attach the WebSocket upgrade handler before
+  // listen so /ws/agent-pty is served. resolveHost defaults to local-only.
+  attachWsUpgradeHandler(server, consumeTicket, agentSessionName, { allowedOrigins })
 
   server.listen(port, WEB_HOST, () => {
     logger.info({ port }, `Web dashboard: http://localhost:${port}`)

--- a/src/web/agent-pty-bridge.ts
+++ b/src/web/agent-pty-bridge.ts
@@ -1,0 +1,229 @@
+import type http from 'node:http'
+import { execFile } from 'node:child_process'
+import { WebSocketServer, WebSocket } from 'ws'
+import * as pty from 'node-pty'
+import type { ConsumeResult } from './pty-ticket.js'
+import { logger } from '../logger.js'
+
+// Pure command builders (host-aware). A remote agent's tmux session lives on
+// its host (e.g. the laptop), reached over ssh; a local agent talks to local
+// tmux. Kept pure so the local/remote routing is unit-testable without tmux/ssh.
+export function ptyAttachCommand(host: string | null, session: string): { file: string; args: string[] } {
+  // -tt forces remote PTY allocation so the remote `tmux attach` gets a terminal.
+  return host
+    ? { file: 'ssh', args: ['-tt', host, 'tmux', 'attach-session', '-t', session] }
+    : { file: 'tmux', args: ['attach-session', '-t', session] }
+}
+
+export function tmuxControlCommand(host: string | null, args: string[]): { file: string; args: string[] } {
+  return host
+    ? { file: 'ssh', args: [host, 'tmux', ...args] }
+    : { file: 'tmux', args }
+}
+
+// Fire-and-forget tmux control command (window pinning), host-aware. Failures
+// are logged but never block the viewer -- a missed pin only degrades to the
+// old resize jitter.
+function tmuxControl(host: string | null, args: string[]): void {
+  const cmd = tmuxControlCommand(host, args)
+  execFile(cmd.file, cmd.args, { env: process.env as NodeJS.ProcessEnv }, (err) => {
+    if (err) logger.warn({ err, host, args }, 'tmux control command failed')
+  })
+}
+
+const MAX_VIEWERS = 3
+const MAX_WS_PAYLOAD = 64 * 1024
+const DEFAULT_PING_INTERVAL_MS = 30_000
+const DEFAULT_PONG_TIMEOUT_MS = 10_000
+
+type ConsumeFn = (ticket: string, nowS: number) => ConsumeResult
+type SessionNameFn = (agentName: string) => string
+
+interface BridgeOptions {
+  allowedOrigins?: Set<string>
+  pingIntervalMs?: number
+  pongTimeoutMs?: number
+  // Resolve an agent's remote ssh host (null = local). Injected so the bridge
+  // attaches to a remote agent's tmux session over ssh instead of looking for
+  // it on the dashboard host. Defaults to local-only.
+  resolveHost?: (agentName: string) => string | null
+}
+
+const viewerCount = new Map<string, number>()
+
+export function attachWsUpgradeHandler(
+  server: http.Server,
+  consumeTicketFn: ConsumeFn,
+  sessionNameFn: SessionNameFn,
+  options: BridgeOptions = {},
+): void {
+  const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_WS_PAYLOAD })
+  const allowedOrigins = options.allowedOrigins
+  const pingIntervalMs = options.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS
+  const pongTimeoutMs = options.pongTimeoutMs ?? DEFAULT_PONG_TIMEOUT_MS
+  const resolveHost = options.resolveHost ?? (() => null)
+
+  server.on('upgrade', (req, socket, head) => {
+    const url = new URL(req.url ?? '/', 'ws://localhost')
+    if (url.pathname !== '/ws/agent-pty') {
+      socket.destroy()
+      return
+    }
+    // CSRF defense-in-depth: WS upgrade Origin must match dashboard allowlist
+    // when one is configured. The ticket is primary auth; this is belt+braces.
+    const origin = (req.headers.origin as string | undefined) ?? ''
+    if (allowedOrigins && origin && !allowedOrigins.has(origin)) {
+      socket.destroy()
+      return
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      handleConnection(ws, url, consumeTicketFn, sessionNameFn, resolveHost, pingIntervalMs, pongTimeoutMs)
+    })
+  })
+}
+
+function handleConnection(
+  ws: WebSocket,
+  url: URL,
+  consumeTicketFn: ConsumeFn,
+  sessionNameFn: SessionNameFn,
+  resolveHost: (agentName: string) => string | null,
+  pingIntervalMs: number,
+  pongTimeoutMs: number,
+): void {
+  const ticket = url.searchParams.get('ticket') ?? ''
+  const cols = Math.max(1, parseInt(url.searchParams.get('cols') ?? '120', 10))
+  const rows = Math.max(1, parseInt(url.searchParams.get('rows') ?? '30', 10))
+
+  const result = consumeTicketFn(ticket, Math.floor(Date.now() / 1000))
+  if (!result.ok) {
+    ws.close(4401, 'invalid or expired ticket')
+    return
+  }
+
+  // The agent name comes ONLY from the ticket — never from URL params.
+  const agentName = result.agentName
+  const session = sessionNameFn(agentName)
+  // Remote agents (e.g. on the laptop) run their tmux session on another host;
+  // attach over ssh instead of looking for the session on the dashboard host.
+  const host = resolveHost(agentName)
+
+  const current = viewerCount.get(session) ?? 0
+  if (current >= MAX_VIEWERS) {
+    ws.close(4429, 'too many viewers')
+    return
+  }
+
+  let ptyProc: pty.IPty
+  try {
+    const cmd = ptyAttachCommand(host, session)
+    ptyProc = pty.spawn(cmd.file, cmd.args, {
+      cols,
+      rows,
+      name: 'xterm-256color',
+      env: process.env as Record<string, string>,
+      cwd: process.env.HOME ?? '/tmp',
+    })
+  } catch {
+    ws.close(4404, 'agent session not running')
+    return
+  }
+
+  viewerCount.set(session, (viewerCount.get(session) ?? 0) + 1)
+  logger.info({ agentName, session }, 'PTY viewer connected')
+
+  // Pin the agent window to this viewer's size. Default 'window-size latest'
+  // makes tmux flap the shared window to whichever client most recently changed
+  // size, so a browser viewer and the operator's console fight over the size and
+  // the agent TUI repaints fully on every flip -- the jitter seen in BOTH the
+  // browser and the console. resize-window pins the window (implicitly sets
+  // window-size=manual); cleanup() releases it for the last viewer.
+  tmuxControl(host, ['resize-window', '-t', session, '-x', String(cols), '-y', String(rows)])
+
+  // Keepalive: send ping every pingIntervalMs; if no pong arrives within
+  // pongTimeoutMs the connection is treated as dead and cleaned up.
+  // Worst-case dead-detect ≈ pingIntervalMs + pongTimeoutMs (e.g., 40s).
+  let pongTimer: NodeJS.Timeout | undefined
+  const pingTimer: NodeJS.Timeout = setInterval(() => {
+    if (ws.readyState !== WebSocket.OPEN) return
+    ws.ping()
+    pongTimer = setTimeout(() => {
+      logger.warn({ session }, 'PTY viewer pong timeout, cleaning up')
+      // Close with a distinct code so the client sees a deliberate teardown
+      // (1011 = server error). cleanup() will be invoked again via the
+      // 'close' handler and is idempotent.
+      try { ws.close(1011, 'pong timeout') } catch {}
+      cleanup()
+    }, pongTimeoutMs)
+    pongTimer.unref?.()
+  }, pingIntervalMs)
+  pingTimer.unref?.()
+  ws.on('pong', () => {
+    if (pongTimer) { clearTimeout(pongTimer); pongTimer = undefined }
+  })
+
+  // pty output → WS
+  ptyProc.onData((data) => {
+    if (ws.readyState === WebSocket.OPEN) ws.send(data)
+  })
+
+  // WS input → pty
+  ws.on('message', (msg: Buffer | string) => {
+    const str = Buffer.isBuffer(msg) ? msg.toString('utf8') : msg
+    try {
+      const obj = JSON.parse(str)
+      if (obj.type === 'resize' && Number.isFinite(obj.cols) && Number.isFinite(obj.rows)) {
+        const c = Math.max(1, obj.cols), r = Math.max(1, obj.rows)
+        try {
+          ptyProc.resize(c, r)
+          // Keep the manual pin in step with deliberate browser resizes so the
+          // window follows the viewer's container instead of flapping.
+          tmuxControl(host, ['resize-window', '-t', session, '-x', String(c), '-y', String(r)])
+        } catch (err) {
+          logger.warn({ err, session }, 'pty.resize after exit')
+          cleanup()
+        }
+        return
+      }
+    } catch { /* not JSON — forward as raw input */ }
+    try {
+      ptyProc.write(str)
+    } catch (err) {
+      logger.warn({ err, session }, 'pty.write after exit')
+      cleanup()
+    }
+  })
+
+  let cleaned = false
+  let killTimer: NodeJS.Timeout | undefined
+  function cleanup() {
+    if (cleaned) return
+    cleaned = true
+    clearInterval(pingTimer)
+    if (pongTimer) { clearTimeout(pongTimer); pongTimer = undefined }
+    try { ptyProc.kill('SIGTERM') } catch {}
+    killTimer = setTimeout(() => { try { ptyProc.kill('SIGKILL') } catch {} }, 2000)
+    killTimer.unref?.()
+    const n = Math.max(0, (viewerCount.get(session) ?? 1) - 1)
+    if (n === 0) {
+      viewerCount.delete(session)
+      // Last viewer gone -- release the manual pin (unset at both window and
+      // session scope) so the window-size reverts to the inherited 'latest' and
+      // the operator's console reclaims its own size.
+      tmuxControl(host, ['set-window-option', '-t', session, '-u', 'window-size'])
+      tmuxControl(host, ['set-option', '-t', session, '-u', 'window-size'])
+    } else {
+      viewerCount.set(session, n)
+    }
+    logger.info({ session }, 'PTY viewer disconnected')
+  }
+
+  ws.on('close', cleanup)
+  ws.on('error', cleanup)
+  ptyProc.onExit(() => {
+    // Clean exit — cancel pending SIGKILL escalation.
+    if (killTimer) { clearTimeout(killTimer); killTimer = undefined }
+    cleanup()
+    if (ws.readyState === WebSocket.OPEN) ws.close(4404, 'session ended')
+  })
+}

--- a/src/web/pty-ticket.ts
+++ b/src/web/pty-ticket.ts
@@ -1,0 +1,76 @@
+import { randomBytes } from 'node:crypto'
+
+const TICKET_TTL_S = 30
+const RATE_LIMIT_MAX = 10
+const RATE_LIMIT_WINDOW_S = 60
+
+interface TicketEntry {
+  agentName: string
+  expiresAt: number  // epoch seconds
+  used: boolean
+}
+
+interface RateLimitEntry {
+  count: number
+  windowStart: number  // epoch seconds
+}
+
+const tickets = new Map<string, TicketEntry>()
+const rateLimits = new Map<string, RateLimitEntry>()
+
+function cleanupExpired(nowS: number): void {
+  for (const [k, v] of tickets) {
+    if (nowS >= v.expiresAt) tickets.delete(k)
+  }
+}
+
+function cleanupExpiredRateLimits(nowS: number): void {
+  // Drop entries older than 2× the window — they could not be hit again.
+  for (const [k, v] of rateLimits) {
+    if (nowS - v.windowStart >= RATE_LIMIT_WINDOW_S * 2) rateLimits.delete(k)
+  }
+}
+
+export function issueTicket(agentName: string, nowS: number): string {
+  cleanupExpired(nowS)
+  const ticket = randomBytes(32).toString('hex')
+  tickets.set(ticket, { agentName, expiresAt: nowS + TICKET_TTL_S, used: false })
+  return ticket
+}
+
+export type ConsumeResult =
+  | { ok: true; agentName: string }
+  | { ok: false; reason: 'not_found' | 'expired' | 'already_used' }
+
+export function consumeTicket(ticket: string, nowS: number): ConsumeResult {
+  // Check the specific ticket BEFORE global cleanup, so we can distinguish
+  // 'expired' (was valid, now stale) from 'not_found' (never existed).
+  const entry = tickets.get(ticket)
+  if (!entry) return { ok: false, reason: 'not_found' }
+  if (nowS >= entry.expiresAt) return { ok: false, reason: 'expired' }
+  if (entry.used) return { ok: false, reason: 'already_used' }
+  entry.used = true
+  cleanupExpired(nowS)
+  return { ok: true, agentName: entry.agentName }
+}
+
+type RateLimitResult =
+  | { ok: true }
+  | { ok: false; retry_after_s: number }
+
+export function checkRateLimit(ip: string, nowS: number): RateLimitResult {
+  cleanupExpiredRateLimits(nowS)
+  const entry = rateLimits.get(ip)
+  if (!entry || nowS - entry.windowStart >= RATE_LIMIT_WINDOW_S) {
+    rateLimits.set(ip, { count: 1, windowStart: nowS })
+    return { ok: true }
+  }
+  if (entry.count < RATE_LIMIT_MAX) {
+    entry.count++
+    return { ok: true }
+  }
+  const retry = Math.ceil(RATE_LIMIT_WINDOW_S - (nowS - entry.windowStart))
+  return { ok: false, retry_after_s: retry }
+}
+
+export { TICKET_TTL_S }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -94,6 +94,7 @@ import {
 import { sanitizeAgentName } from '../sanitize.js'
 import { parseMultipart } from '../multipart.js'
 import { readBody, json, serveFile } from '../http-helpers.js'
+import { issueTicket, checkRateLimit, TICKET_TTL_S } from '../pty-ticket.js'
 import type { RouteContext } from './types.js'
 
 const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord'])
@@ -1282,6 +1283,25 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     rmSync(dir, { recursive: true, force: true })
     cleanupTeamReferences(name)
     json(res, { ok: true })
+    return true
+  }
+
+  const agentPtyTicketMatch = path.match(/^\/api\/agents\/([^/]+)\/pty-ticket$/)
+  if (agentPtyTicketMatch && method === 'POST') {
+    const name = decodeURIComponent(agentPtyTicketMatch[1])
+    // The dashboard binds to 127.0.0.1, so the socket address is the real
+    // client. X-Forwarded-For is intentionally NOT trusted here: without a
+    // configured reverse proxy a browser could spoof it to bypass the limit.
+    const ip = req.socket.remoteAddress ?? 'unknown'
+    const rl = checkRateLimit(ip, Math.floor(Date.now() / 1000))
+    if (!rl.ok) {
+      json(res, { error: 'rate limited', retry_after_s: rl.retry_after_s }, 429)
+      return true
+    }
+    if (!isKnownAgent(name)) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (!isAgentRunning(name)) { json(res, { error: 'agent not running' }, 409); return true }
+    const ticket = issueTicket(name, Math.floor(Date.now() / 1000))
+    json(res, { ticket, ttl_s: TICKET_TTL_S })
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -9462,90 +9462,135 @@ let terminalInstance = null
 let terminalSSE = null
 let terminalFit = null
 
+// Interactive PTY-backed terminal. Streams the agent's real tmux session over
+// a WebSocket (xterm.js <-> node-pty), so keystrokes, scrollback and redraws
+// are bidirectional and char-by-char in real time. A short-lived, single-use
+// ticket (POST /pty-ticket) authorizes the WS upgrade.
+function openAgentPty(agentName, mountEl) {
+  var DEFAULT_COLS = 120, DEFAULT_ROWS = 30
+  var term = new window.Terminal({
+    cols: DEFAULT_COLS, rows: DEFAULT_ROWS,
+    fontSize: 12, scrollback: 3000,
+    fontFamily: 'JetBrains Mono, Menlo, monospace',
+    theme: { background: '#1a1a1a', foreground: '#e8e4da' },
+    allowProposedApi: true,
+  })
+  var fitAddon = new window.FitAddon.FitAddon()
+  term.loadAddon(fitAddon)
+  term.open(mountEl)
+  // Fit safely: the container only has its final width on the next layout
+  // frame (it was just un-hidden), so fitting synchronously here keeps the
+  // terminal at DEFAULT_COLS and clips on the right. Defer to rAF.
+  function safeFit() { try { fitAddon.fit() } catch (e) { /* not laid out yet */ } }
+  var wsScheme = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  var result = { close: function() { if (ws) ws.close() } }
+  var ws
+
+  // OS-level dictation / paste tools copy to the clipboard and send a plain
+  // Ctrl+V. xterm treats Ctrl+V as a literal ^V and only pastes on
+  // Ctrl+Shift+V, so dictated/pasted text never reaches the PTY. Make plain
+  // Ctrl+V paste too, via the bracketed-paste-aware term.paste.
+  term.attachCustomKeyEventHandler(function(e) {
+    if (e.type === 'keydown' && (e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey
+        && (e.key === 'v' || e.key === 'V')) {
+      e.preventDefault()
+      if (ws && ws.readyState === WebSocket.OPEN
+          && navigator.clipboard && navigator.clipboard.readText) {
+        navigator.clipboard.readText().then(function(t) {
+          if (t) term.paste(t)
+        }).catch(function() { /* clipboard read denied -- skip */ })
+      }
+      return false
+    }
+    return true
+  })
+
+  // Coalesce resize bursts into one fit per frame and only notify the PTY when
+  // the grid actually changes. Without the dimension guard the ResizeObserver
+  // re-fires on every fit() (fit changes layout -> observer -> fit ...), a
+  // feedback loop that makes tmux redraw constantly = visible vibration.
+  var lastCols = 0, lastRows = 0, fitScheduled = false
+  function applyFit() {
+    fitScheduled = false
+    safeFit()
+    if (term.cols === lastCols && term.rows === lastRows) return
+    lastCols = term.cols; lastRows = term.rows
+    if (ws && ws.readyState === WebSocket.OPEN)
+      ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }))
+  }
+  function scheduleFit() {
+    if (fitScheduled) return
+    fitScheduled = true
+    requestAnimationFrame(applyFit)
+  }
+
+  fetch('/api/agents/' + encodeURIComponent(agentName) + '/pty-ticket', { method: 'POST' })
+    .then(function(r) { return r.json() })
+    .then(function(data) {
+      if (!data.ticket) { term.write('\r\n\x1b[31m\u274C Could not obtain a ticket\x1b[0m\r\n'); return }
+      // Fit against the now-laid-out container before reading cols/rows so the
+      // initial PTY size matches what the user actually sees.
+      requestAnimationFrame(function() { requestAnimationFrame(function() {
+        safeFit()
+        lastCols = term.cols; lastRows = term.rows
+        var cols = term.cols, rows = term.rows
+        var wsUrl = wsScheme + '//' + location.host + '/ws/agent-pty?ticket='
+          + encodeURIComponent(data.ticket) + '&cols=' + cols + '&rows=' + rows
+        ws = new WebSocket(wsUrl)
+        ws.binaryType = 'arraybuffer'
+        result.close = function() { ws.close() }
+
+        ws.onopen = function() {
+          term.write('\r\n\x1b[32m\u2713 Connected\x1b[0m\r\n')
+          scheduleFit()
+          try { term.focus() } catch (e) { /* not laid out */ }
+          var resizeObs = new ResizeObserver(function() { scheduleFit() })
+          resizeObs.observe(mountEl)
+          ws._resizeObs = resizeObs
+        }
+        ws.onmessage = function(e) {
+          if (e.data instanceof ArrayBuffer) term.write(new Uint8Array(e.data))
+          else term.write(e.data)
+        }
+        ws.onclose = function(e) {
+          var msgs = { 4401: '\u274C Expired or invalid ticket',
+                       4404: '\u274C Agent is not running',
+                       4429: '\u274C Too many concurrent viewers' }
+          var msg = msgs[e.code] || ('\u274C Connection closed (code: ' + e.code + ')')
+          term.write('\r\n\x1b[31m' + msg + '\x1b[0m\r\n')
+          if (ws._resizeObs) ws._resizeObs.disconnect()
+        }
+        term.onData(function(d) { if (ws.readyState === WebSocket.OPEN) ws.send(d) })
+      }) })
+    })
+    .catch(function() { term.write('\r\n\x1b[31m\u274C Network error\x1b[0m\r\n') })
+
+  return result
+}
+
+let modalPty = null
 function openTerminalModal(agentName) {
   const overlay = document.getElementById('terminalOverlay')
   const container = document.getElementById('terminalContainer')
   const title = document.getElementById('terminalModalTitle')
   if (!overlay || !container) return
 
-  title.textContent = agentName + ' — Terminal'
+  title.textContent = agentName + ' \u2014 Terminal'
 
-  // Cleanup previous
-  if (terminalSSE) { terminalSSE.close(); terminalSSE = null }
-  if (terminalInstance) { terminalInstance.dispose(); terminalInstance = null }
-  container.innerHTML = ''
-
-  // Init xterm — fontSize 12 + wider modal fits ~140 chars of tmux output
-  const term = new window.Terminal({
-    theme: { background: '#1a1a1a', foreground: '#e8e4da' },
-    fontFamily: 'JetBrains Mono, Menlo, monospace',
-    fontSize: 12,
-    cursorBlink: false,
-    disableStdin: false,
-    scrollback: 500,
-    convertEol: true,
-    allowProposedApi: true,
-  })
-  const fitAddon = new window.FitAddon.FitAddon()
-  term.loadAddon(fitAddon)
-  term.open(container)
-  fitAddon.fit()
-  terminalInstance = term
-  terminalFit = fitAddon
+  // Tear down any previous session before opening a new one.
+  if (modalPty) { modalPty.close(); modalPty = null }
+  container.textContent = ''
 
   openModal(overlay)
-  setTimeout(() => term.focus(), 50)
-
-  // SSE pane stream
-  const token = localStorage.getItem('marveen-dashboard-token') || ''
-  const sse = new EventSource(`/api/agents/${encodeURIComponent(agentName)}/pane/stream?token=${encodeURIComponent(token)}`)
-  sse.onmessage = (e) => {
-    try {
-      const msg = JSON.parse(e.data)
-      if (msg.pane !== undefined) {
-        const clean = msg.pane.replace(/\x1b]8;[^\x1b]*\x1b\\/g, '')
-        term.write('\x1b[2J\x1b[H' + clean)
-      }
-    } catch {}
-  }
-  sse.onerror = () => term.write('\r\n[stream hiba vagy leállva]\r\n')
-  terminalSSE = sse
-
-  // Single onData handler — maps escape sequences to {special}, plain chars to {keys}
-  // Using onData only (no onKey) avoids double-firing on arrow/Enter keys
-  const ESC_TO_SPECIAL = {
-    '\r': 'Enter', '\x1b': 'Escape',
-    '\x1b[A': 'Up', '\x1b[B': 'Down', '\x1b[C': 'Right', '\x1b[D': 'Left',
-    '\x7f': 'BSpace', '\t': 'Tab', '\x1b[Z': 'S-Tab',
-    '\x03': 'C-c', '\x04': 'C-d', '\x15': 'C-u', '\x0c': 'C-l',
-    '\x1b[5~': 'PageUp', '\x1b[6~': 'PageDown',
-  }
-  term.onData(data => {
-    const special = ESC_TO_SPECIAL[data]
-    const body = special ? { special } : { keys: data }
-    fetch(`/api/agents/${encodeURIComponent(agentName)}/keys`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }).catch(() => {})
-  })
-
-  // Resize fit on modal resize — observe the modal wrapper (not the xterm container
-  // itself) to avoid a ResizeObserver->fit->resize->ResizeObserver infinite loop
-  let fitTimer = null
-  const ro = new ResizeObserver(() => {
-    clearTimeout(fitTimer)
-    fitTimer = setTimeout(() => { try { fitAddon.fit() } catch {} }, 50)
-  })
-  const modalEl = container.closest('.terminal-modal') || container.parentElement
-  if (modalEl) ro.observe(modalEl)
+  modalPty = openAgentPty(agentName, container)
 }
 
-document.getElementById('terminalClose')?.addEventListener('click', () => {
+function closeTerminalModal() {
   const overlay = document.getElementById('terminalOverlay')
   if (overlay) closeModal(overlay)
-  if (terminalSSE) { terminalSSE.close(); terminalSSE = null }
-  if (terminalInstance) { terminalInstance.dispose(); terminalInstance = null }
-})
+  if (modalPty) { modalPty.close(); modalPty = null }
+}
+document.getElementById('terminalClose')?.addEventListener('click', closeTerminalModal)
 ;(() => {
   function routeFromHash() {
     let pageId = decodeURIComponent((location.hash || '').replace(/^#/, ''))


### PR DESCRIPTION
## Summary

Adds an **interactive, PTY-backed terminal** to the agent dashboard. Each running agent gets a real TTY attached to its `tmux` session, streamed bidirectionally over a WebSocket. This is **purely additive** — the existing SSE pane-mirror terminal (`agent-terminal.ts`, `/keys`, `/login`) is untouched, so nothing regresses.

## Why

The current terminal mirrors the tmux pane over Server-Sent Events and injects keystrokes via a separate `/keys` POST. That works for read-mostly viewing, but it is not a true terminal: no proper TTY semantics, awkward input, no resize, no paste. This PR adds a real interactive terminal that feels like attaching to the session directly, while leaving the existing viewer in place for anyone who prefers it.

## Design

**Auth flow (defence in depth):**
- `POST /api/agents/:name/pty-ticket` — token-gated (behind the existing bearer gate), per-IP rate-limited, returns a single-use ticket with a 30s TTL.
- `GET /ws/agent-pty` (WebSocket upgrade) — authorized by the single-use ticket, plus an Origin allow-list check. The WS upgrade deliberately bypasses the bearer header gate (browsers cannot set headers on WS handshakes), so the short-lived ticket *is* its credential.

**Backend (new files):**
- `src/web/pty-ticket.ts` — ticket issue/consume + per-IP rate limiter. Self-contained, no shared state with the rest of the app.
- `src/web/agent-pty-bridge.ts` — `WebSocketServer` on `/ws/agent-pty`. `attachWsUpgradeHandler(server, consumeTicketFn, sessionNameFn, opts)` consumes the ticket, checks Origin, then spawns `tmux attach-session` via `node-pty` and pipes bytes both ways. Ping/pong keepalive. Host-aware command builders (`ptyAttachCommand`, `tmuxControlCommand`) take an injectable `resolveHost` that **defaults to local-only** — no remote attach unless a host resolver is wired in.

**Frontend (`web/app.js`):**
- `openAgentPty(agentName, mountEl)` mounts xterm.js (CDN globals), fit addon, a `ResizeObserver` that coalesces one `fit()` per animation frame (with a dimension guard to avoid feedback loops), and a `Ctrl+V` bracketed-paste handler. The modal opens, requests a ticket, connects the WS, and tears everything down cleanly on close.

**Deps:** `node-pty`, `ws`, `@types/ws`.

## Tests

- Unit: ticket lifecycle, single-use enforcement, TTL expiry, per-IP rate limiting, and WS close-code render helpers.
- Integration: a real test that boots an http server + ws client and attaches to a live `tmux` session via `node-pty`, asserting the byte round-trip.

## Verification

- `npm run build` clean; full suite green.
- Runtime E2E on an isolated build: ticket issuance authed -> 200, unauthed -> 401, WS round-trip echoes the tmux output, reused ticket rejected with close code 4401.
- Browser smoke test: the modal renders xterm with a live, streaming tmux pane.

## Note on pre-existing test failures

`develop` currently has 4 failing tests in `managed-settings.test.ts` (a non-dotall regex that cannot match the multiline command `getManagedSettingsSudoCommand` produces). These are **unrelated to this PR** — they fail identically on a pristine `develop` checkout, and this change does not touch managed-settings. Happy to send a separate PR for that fix if useful.
