### PR TITLE
fix(managed-settings): cross-platform support + platform-independent tests

### DIFF
--- a/src/__tests__/managed-settings.test.ts
+++ b/src/__tests__/managed-settings.test.ts
@@ -75,10 +75,10 @@ describe('getManagedSettingsSudoCommand merge logic', () => {
     const pipeIdx = cmd.indexOf('|')
     const echoAndPayload = cmd.slice(0, pipeIdx).trim()
     const pythonPart = cmd.slice(pipeIdx + 1).trim()
-    const innerMatch = pythonPart.match(/python3 -c '(.+?)' \|/)
+    const innerMatch = pythonPart.match(/python3 -c '([\s\S]+?)' \|/)
     if (!innerMatch) throw new Error('Could not parse python script from command')
     const script = innerMatch[1]
-      .replace(new RegExp('/Library/Application Support/ClaudeCode/managed-settings\\.json', 'g'), targetPath)
+      .replace(new RegExp('/Library/Application Support/ClaudeCode/managed-settings\\.json|/etc/claude-code/managed-settings\\.json', 'g'), targetPath)
       .replace(/; /g, '\n')
 
     if (existingContent !== null) writeFileSync(targetPath, existingContent)

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync, renameSync } from 'node:fs'
-import { join, extname } from 'node:path'
+import { join, extname, dirname } from 'node:path'
 import { homedir, platform } from 'node:os'
 import { execSync } from 'node:child_process'
 import { logger } from '../../logger.js'
@@ -131,9 +131,17 @@ function matchChannelRoute(path: string, suffix: string): [string, ChannelProvid
   return null
 }
 
-const MANAGED_SETTINGS_PATH = platform() === 'darwin'
-  ? '/Library/Application Support/ClaudeCode/managed-settings.json'
-  : '/etc/claude-code/managed-settings.json'
+function managedSettingsPath(): string {
+  switch (platform()) {
+    case 'darwin':
+      return '/Library/Application Support/ClaudeCode/managed-settings.json'
+    case 'win32':
+      return join(process.env.ProgramData || 'C:\\ProgramData', 'ClaudeCode', 'managed-settings.json')
+    default:
+      return '/etc/claude-code/managed-settings.json'
+  }
+}
+const MANAGED_SETTINGS_PATH = managedSettingsPath()
 const SLACK_ALLOWLIST_ENTRY = { plugin: 'slack-channel', marketplace: 'marveen-marketplace' }
 
 export function isManagedSettingsReady(): boolean {
@@ -157,7 +165,7 @@ export function getManagedSettingsSudoCommand(): string {
   const mergeScript = [
     'import json, sys',
     'new_data = json.loads(sys.stdin.read())',
-    'try:\n  with open("' + MANAGED_SETTINGS_PATH + '") as f: data = json.load(f)',
+    'try:\n  with open(' + JSON.stringify(MANAGED_SETTINGS_PATH) + ') as f: data = json.load(f)',
     'except:\n  data = {}',
     'data["channelsEnabled"] = True',
     'existing = data.get("allowedChannelPlugins", [])',
@@ -171,6 +179,10 @@ export function getManagedSettingsSudoCommand(): string {
       { plugin: 'telegram', marketplace: 'claude-plugins-official' },
     ],
   })
+  if (platform() === 'win32') {
+    const dir = dirname(MANAGED_SETTINGS_PATH)
+    return `New-Item -ItemType Directory -Force -Path '${dir}' | Out-Null; '${payload}' | python -c '${mergeScript}' | Set-Content -LiteralPath '${MANAGED_SETTINGS_PATH}' -Encoding utf8`
+  }
   const escapedScript = mergeScript.replace(/'/g, "'\\''")
   return `echo '${payload}' | sudo python3 -c '${escapedScript}' | sudo tee "${MANAGED_SETTINGS_PATH}" > /dev/null`
 }


### PR DESCRIPTION
## Summary

Makes the managed-settings helpers work on **Windows** (in addition to macOS/Linux) and makes the test suite pass on **any host**.

This also resolves the 4 pre-existing `managed-settings.test.ts` failures noted in #318 — they fail on `develop` on every non-macOS host.

## Production code (src/web/routes/agents.ts)

- `managedSettingsPath()` resolves the path per-OS; Windows -> `%ProgramData%\ClaudeCode\managed-settings.json` (the standard Claude Code location). macOS/Linux unchanged.
- `getManagedSettingsSudoCommand()` returns a PowerShell pipeline (`New-Item` + `python -c` + `Set-Content`) on Windows; the POSIX `sudo ... | sudo tee` path is unchanged.
- The embedded Python builds the target path with `JSON.stringify()` so Windows backslashes escape correctly inside the script literal. No-op on POSIX.

## Tests (src/__tests__/managed-settings.test.ts)

- Script-extraction regex `(.+?)` -> `([\s\S]+?)`: `.` cannot span newlines, so the old regex failed to parse the multiline command and threw on every non-macOS host. **This is the direct cause of the 4 failures.**
- Path substitution now rewrites the Linux path as well as the macOS one, so the merge tests use the temp file on Linux instead of the real /etc path.

## Verification

- Full suite green on Linux: **1020 passed** (previously 4 failing on `develop`).

## Caveat

The Windows path is the documented Claude Code location, but the Windows *command* (elevated PowerShell, `python` on PATH) has not been exercised on a native Windows host yet. It is strictly better than the current behaviour, which emits a broken `sudo` command on Windows. Happy to adjust if a maintainer can verify on Windows.
