### PR TITLE
feat(schedule): auto-start a stopped agent on cron + manual Run now

### DIFF
--- a/src/__tests__/schedule-run-now.test.ts
+++ b/src/__tests__/schedule-run-now.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for the "Run now" feature: an operator can fire a scheduled
+// task immediately from the dashboard, instead of waiting for its cron (or
+// hand-editing the cron to the next minute). It reuses the runner's fire path
+// (attemptFireTask), so a stopped agent is auto-started and the prompt is
+// queued for delivery just like a real cron fire.
+
+const RUNNER = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+const ROUTE = readFileSync(join(__dirname, '../web/routes/schedules.ts'), 'utf-8')
+const APP = readFileSync(join(__dirname, '../../web/app.js'), 'utf-8')
+
+describe('Run now: runner exports an immediate-fire entry point', () => {
+  it('schedule-runner exports runScheduledTaskNow', () => {
+    expect(RUNNER).toMatch(/export function runScheduledTaskNow\(/)
+  })
+
+  it('a manual run delivers regardless of skipIfBusy (always enqueues on starting/busy)', () => {
+    const fn = RUNNER.slice(RUNNER.indexOf('export function runScheduledTaskNow('))
+    const body = fn.slice(0, fn.indexOf('\n}\n') + 3)
+    // Reuses the real fire path...
+    expect(body).toMatch(/attemptFireTask\(/)
+    // ...and queues delivery for both an auto-started ('starting') and a busy
+    // session, WITHOUT consulting task.skipIfBusy (that's a cron-cadence knob).
+    expect(body).toMatch(/insertPendingTaskRetryIfNew/)
+    expect(body).not.toMatch(/task\.skipIfBusy/)
+  })
+})
+
+describe('Run now: REST route', () => {
+  it('schedules route handles POST /api/schedules/{name}/run', () => {
+    // The route matcher ends in `/run$/` and delegates to the runner.
+    expect(ROUTE).toMatch(/\/run\$\//)
+    expect(ROUTE).toMatch(/runScheduledTaskNow/)
+  })
+})
+
+describe('Run now: dashboard button', () => {
+  it('schedule row has a run action wired to the run endpoint', () => {
+    expect(APP).toMatch(/data-action="run"/)
+    expect(APP).toMatch(/\/api\/schedules\/\$\{encodeURIComponent\(task\.name\)\}\/run/)
+  })
+})

--- a/src/__tests__/schedule-runner-autostart.test.ts
+++ b/src/__tests__/schedule-runner-autostart.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for the daily-batch-agent "never runs" fix.
+//
+// Root cause: a daily batch agent has no 24/7 tmux session. When its cron
+// fired (e.g. a `0 2 * * *` digest), attemptFireTask found the target session
+// missing and returned 'missing' -- a silent skip. The task was enabled and
+// scheduled but could never fire.
+//
+// Fix: when the session is missing, START the agent and return a new 'starting'
+// state. The caller enqueues a retry that delivers the prompt on a later tick
+// once Claude has booted. Crucially this retry must bypass skipIfBusy -- the
+// whole point was to wake the agent for its scheduled run, so a skipIfBusy=true
+// task must NOT drop the delivery.
+
+const SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+
+describe('schedule-runner auto-starts a stopped agent for its scheduled task', () => {
+  it('attemptFireTask can return a distinct "starting" state', () => {
+    // The return union must carry 'starting' so the caller can tell an
+    // auto-start apart from a genuine busy session.
+    const sig = SRC.slice(SRC.indexOf('function attemptFireTask'))
+    expect(sig.slice(0, 200)).toMatch(/'starting'/)
+  })
+
+  it('the missing-session branch auto-starts the agent instead of skipping', () => {
+    // Locate the sessionExists guard and assert it now launches the agent.
+    const guardIdx = SRC.indexOf('if (!sessionExists)')
+    expect(guardIdx).toBeGreaterThan(0)
+    // Window covering the missing-session block (comment + code, before the
+    // real busy-check). Must launch the agent and return the 'starting' state.
+    const missingBlock = SRC.slice(guardIdx, guardIdx + 1400)
+    expect(missingBlock).toMatch(/startAgentProcess\(agentName\)/)
+    expect(missingBlock).toMatch(/return 'starting'/)
+  })
+
+  it('the cron loop enqueues a retry for "starting" WITHOUT the skipIfBusy gate', () => {
+    // Find where the cron loop handles a 'starting' result. That branch must
+    // insert a pending retry, and must NOT be guarded by task.skipIfBusy
+    // (otherwise a skipIfBusy=true daily digest would auto-start the agent and
+    // then drop the delivery -- the original bug). Target the cron-loop's
+    // standalone branch specifically (runScheduledTaskNow also references
+    // 'starting', but in an `|| result === 'busy'` form).
+    const startingIdx = SRC.indexOf("if (result === 'starting') {")
+    expect(startingIdx).toBeGreaterThan(0)
+    // Slice the starting-branch up to the next else-if / busy handling.
+    const busyHandlingIdx = SRC.indexOf("result === 'busy'", startingIdx)
+    expect(busyHandlingIdx).toBeGreaterThan(startingIdx)
+    const startingBranch = SRC.slice(startingIdx, busyHandlingIdx)
+    expect(startingBranch).toMatch(/insertPendingTaskRetryIfNew/)
+    // Not gated by the skipIfBusy flag (the code form `task.skipIfBusy`); a
+    // mention in an explanatory comment is fine.
+    expect(startingBranch).not.toMatch(/task\.skipIfBusy/)
+  })
+
+  it('documents WHY (daily batch agent), not just what', () => {
+    const guardIdx = SRC.indexOf('if (!sessionExists)')
+    const rationale = SRC.slice(guardIdx, guardIdx + 900)
+    expect(rationale).toMatch(/auto-start|batch agent|digest/i)
+    expect(rationale).toMatch(/skipIfBusy/i)
+  })
+})

--- a/src/web/routes/schedules.ts
+++ b/src/web/routes/schedules.ts
@@ -17,6 +17,7 @@ import {
   SCHEDULED_TASKS_DIR, MAX_SCHEDULED_TASK_PROMPT_LEN,
   listScheduledTasks, writeScheduledTask,
 } from '../scheduled-tasks-io.js'
+import { runScheduledTaskNow } from '../schedule-runner.js'
 import type { RouteContext } from './types.js'
 
 export async function tryHandleSchedules(ctx: RouteContext): Promise<boolean> {
@@ -202,6 +203,18 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
     atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
     logger.info({ name, enabled: newEnabled }, 'Scheduled task toggled')
     json(res, { ok: true, enabled: newEnabled })
+    return true
+  }
+
+  const scheduleRunMatch = path.match(/^\/api\/schedules\/([^/]+)\/run$/)
+  if (scheduleRunMatch && method === 'POST') {
+    const name = decodeURIComponent(scheduleRunMatch[1])
+    const dir = join(SCHEDULED_TASKS_DIR, name)
+    if (!existsSync(dir)) { json(res, { error: 'Schedule not found' }, 404); return true }
+    const result = runScheduledTaskNow(name)
+    if (!result.ok) { json(res, { error: result.error }, 400); return true }
+    logger.info({ name, result: result.result }, 'Scheduled task run-now fired')
+    json(res, { ok: true, result: result.result })
     return true
   }
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -34,6 +34,7 @@ import {
   isAgentRunning,
   isSessionReadyForPrompt,
   sendPromptToSession,
+  startAgentProcess,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
@@ -85,7 +86,7 @@ function persistScheduleLastRun(): void {
 // Try to fire a task at a single target agent. Returns the outcome so the
 // caller can decide whether to queue a retry. Splitting this out means the
 // pendingTaskRetries loop and the normal cron loop share one code path.
-function attemptFireTask(task: ScheduledTask, agentName: string, now: number): 'fired' | 'busy' | 'missing' | 'error' {
+function attemptFireTask(task: ScheduledTask, agentName: string, now: number): 'fired' | 'busy' | 'missing' | 'starting' | 'error' {
   const isMainAgent = agentName === MAIN_AGENT_ID
   // Allow per-task session override via targetSession config field.
   // Falls back to the standard agent session name derivation.
@@ -100,8 +101,24 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
   } catch { /* no tmux */ }
 
   if (!sessionExists) {
-    logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session not running, skipping')
-    return 'missing'
+    // Auto-start the agent, then deliver on a later tick. A daily batch agent
+    // (e.g. a `0 2 * * *` digest) has no 24/7 session, so a cron fire used to
+    // just skip here -- the task never ran. Launch the session now and return
+    // 'starting'; the caller enqueues a retry that bypasses skipIfBusy (waking
+    // the agent for its scheduled run is the whole point, so a skipIfBusy=true
+    // task must NOT drop the delivery). The next tick finds the session up and
+    // sends once Claude has booted (isSessionReadyForPrompt).
+    const start = startAgentProcess(agentName)
+    if (!start.ok) {
+      // "already running" means it raced up between the check and here -- treat
+      // as busy so the normal retry path delivers. Any other failure (config
+      // error, launch failure) is a real miss: log and skip this tick.
+      if (/already running/i.test(start.error ?? '')) return 'busy'
+      logger.warn({ task: task.name, agent: agentName, session, error: start.error }, 'Schedule target session missing, auto-start failed')
+      return 'missing'
+    }
+    logger.info({ task: task.name, agent: agentName, session }, 'Schedule target session missing, auto-started agent; will deliver on retry')
+    return 'starting'
   }
 
   // When forceSend is true, skip the busy-state check entirely and inject
@@ -187,6 +204,36 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
     logger.warn({ err, task: task.name }, 'Failed to fire scheduled task')
     return 'error'
   }
+}
+
+// Manual "Run now": fire a scheduled task immediately, bypassing the cron
+// match + lastRun catch-up + skipIfBusy guards (the operator explicitly asked
+// for it). Reuses attemptFireTask, so a stopped agent is auto-started and the
+// prompt is queued for delivery exactly like a real cron fire. Returns a
+// per-target summary string for the API/UI.
+export function runScheduledTaskNow(taskName: string): { ok: boolean; result?: string; error?: string } {
+  const task = listScheduledTasks().find(t => t.name === taskName)
+  if (!task) return { ok: false, error: 'Schedule not found' }
+  if (!task.enabled) return { ok: false, error: 'Schedule is disabled' }
+
+  const now = Date.now()
+  const targets = task.agent === 'all'
+    ? [MAIN_AGENT_ID, ...listAgentNames().filter(a => isAgentRunning(a))]
+    : [task.agent || MAIN_AGENT_ID]
+
+  const summary: string[] = []
+  for (const agentName of targets) {
+    const result = attemptFireTask(task, agentName, now)
+    // A manual run ALWAYS wants delivery: an auto-started ('starting') or a
+    // busy session both get a queued retry that lands once the session is
+    // ready. We deliberately do NOT consult skipIfBusy here -- that flag trims
+    // redundant cron ticks, but an explicit run-now must not be dropped.
+    if (result === 'starting' || result === 'busy') {
+      insertPendingTaskRetryIfNew(task.name, agentName, now, result)
+    }
+    summary.push(`${agentName}: ${result}`)
+  }
+  return { ok: true, result: summary.join(', ') }
 }
 
 // Fire a Telegram alert when a pending retry has been stuck past the
@@ -335,7 +382,14 @@ export function startScheduleRunner(): NodeJS.Timeout {
         // the retry handler -- don't re-queue or double-fire.
         if (pendingKeys.has(key)) continue
         const result = attemptFireTask(task, agentName, now)
-        if (result === 'busy') {
+        if (result === 'starting') {
+          // Agent was auto-started this tick. ALWAYS enqueue the retry that
+          // delivers the prompt once the session is ready -- skipIfBusy must
+          // NOT drop it (that flag is for genuinely-busy short-cadence tasks;
+          // here we deliberately woke the agent for its scheduled run). The
+          // pending-retry loop then sends as soon as Claude has booted.
+          insertPendingTaskRetryIfNew(task.name, agentName, now, 'starting')
+        } else if (result === 'busy') {
           if (task.skipIfBusy) {
             // Opt-in skip for short-cadence tasks (e.g. 30-min heartbeats):
             // a single missed tick is harmless because the next one is

--- a/web/app.js
+++ b/web/app.js
@@ -3598,6 +3598,9 @@ function renderScheduleList(tasks) {
         </div>
       </div>
       <div class="schedule-actions">
+        <button class="btn-icon" data-action="run" title="Futtatás most">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        </button>
         <button class="btn-icon" data-action="toggle" title="${task.enabled ? 'Szüneteltetés' : 'Folytatás'}">
           ${task.enabled ? pauseIcon() : playIcon()}
         </button>
@@ -3614,6 +3617,17 @@ function renderScheduleList(tasks) {
     })
 
     // Action buttons
+    row.querySelector('[data-action="run"]').addEventListener('click', async (e) => {
+      e.stopPropagation()
+      try {
+        const r = await fetch(`/api/schedules/${encodeURIComponent(task.name)}/run`, { method: 'POST' })
+        const data = await r.json().catch(() => ({}))
+        if (r.ok) showToast('Feladat elindítva' + (data.result ? ': ' + data.result : ''))
+        else showToast('Hiba: ' + (data.error || r.status))
+        loadSchedules()
+      } catch { showToast('Hiba a futtatáskor') }
+    })
+
     row.querySelector('[data-action="toggle"]').addEventListener('click', async (e) => {
       e.stopPropagation()
       try {


### PR DESCRIPTION
## Summary

Two related scheduling improvements that make scheduled tasks reliable for agents that are **not** running 24/7, plus an operator convenience.

### 1. Auto-start a stopped agent for its scheduled task

A daily/weekly batch agent typically has **no always-on tmux session**. When its cron fired (e.g. a `0 2 * * *` digest), `attemptFireTask` found the target session missing and returned `'missing'` — a silent skip. The task was enabled and scheduled but **could never run**.

Now the missing-session branch starts the agent (`startAgentProcess`) and returns a new `'starting'` state. The cron loop enqueues a pending retry that delivers the prompt on a later tick, once Claude has booted (`isSessionReadyForPrompt`).

This retry deliberately **bypasses `skipIfBusy`**: that flag trims redundant short-cadence ticks, but here we intentionally woke the agent for its scheduled run, so a `skipIfBusy=true` daily task must not have its single delivery dropped. An "already running" race (the session came up between the check and the launch) is treated as `'busy'` so the normal retry path still delivers; any other launch failure logs and skips the tick.

### 2. Manual "Run now"

New `runScheduledTaskNow(taskName)` fires a task immediately, bypassing the cron match + last-run catch-up + `skipIfBusy` guards (the operator explicitly asked for it). It reuses `attemptFireTask`, so a stopped agent is auto-started and the prompt is queued for delivery exactly like a real cron fire.

- New bearer-gated route: `POST /api/schedules/{name}/run`
- New per-row "run" button in the dashboard schedule list

## Tests

- `schedule-runner-autostart.test.ts` — the `'starting'` state, the missing-session auto-start branch, and the cron loop's ungated retry.
- `schedule-run-now.test.ts` — the exported entry point, the REST route, and the dashboard button wiring.

All new tests pass and `tsc` is clean. (The 4 pre-existing `managed-settings` test failures on `develop` are unrelated to this change.)

## Notes

New UI strings follow this branch's existing Hungarian UI convention.
