### PR TITLE
feat(schedule): command-type scheduled tasks (raw shell on cron)

### DIFF
--- a/src/__tests__/command-task-eval.test.ts
+++ b/src/__tests__/command-task-eval.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateCommandResult, type CommandHealth } from '../web/command-task.js'
+
+// Unit tests for the command-task failure/recovery policy. This is the
+// decision core behind type='command' scheduled tasks (raw shell health
+// checks). The rules under test:
+//   - a success zeroes the consecutive-failure streak
+//   - an alert fires exactly ONCE, when the streak first hits failThreshold
+//   - while still failing past the threshold, no repeat alerts
+//   - a recover fires exactly ONCE, when a previously-alerted task succeeds
+const T = 1_000
+
+describe('evaluateCommandResult', () => {
+  it('returns no action on the first failure below threshold', () => {
+    const { next, action } = evaluateCommandResult(undefined, false, 2, T)
+    expect(action).toBe('none')
+    expect(next.fails).toBe(1)
+    expect(next.alerted).toBe(false)
+    expect(next.lastStatus).toBe('fail')
+  })
+
+  it('alerts exactly when the streak first reaches the threshold', () => {
+    const prev: CommandHealth = { fails: 1, alerted: false, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, false, 2, T)
+    expect(action).toBe('alert')
+    expect(next.fails).toBe(2)
+    expect(next.alerted).toBe(true)
+  })
+
+  it('does not re-alert while already alerted and still failing', () => {
+    const prev: CommandHealth = { fails: 2, alerted: true, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, false, 2, T)
+    expect(action).toBe('none')
+    expect(next.fails).toBe(3)
+    expect(next.alerted).toBe(true)
+  })
+
+  it('recovers exactly once when a previously-alerted task succeeds', () => {
+    const prev: CommandHealth = { fails: 3, alerted: true, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, true, 2, T)
+    expect(action).toBe('recover')
+    expect(next.fails).toBe(0)
+    expect(next.alerted).toBe(false)
+    expect(next.lastStatus).toBe('ok')
+  })
+
+  it('stays silent on success when not previously alerted', () => {
+    const prev: CommandHealth = { fails: 1, alerted: false, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, true, 2, T)
+    expect(action).toBe('none')
+    expect(next.fails).toBe(0)
+  })
+
+  it('respects a custom failThreshold greater than 2', () => {
+    let prev: CommandHealth | undefined
+    const actions: string[] = []
+    for (let i = 0; i < 3; i++) {
+      const r = evaluateCommandResult(prev, false, 3, T)
+      prev = r.next
+      actions.push(r.action)
+    }
+    expect(actions).toEqual(['none', 'none', 'alert'])
+  })
+})

--- a/src/web/command-task.ts
+++ b/src/web/command-task.ts
@@ -1,0 +1,108 @@
+import { spawnSync } from "node:child_process"
+import { join } from "node:path"
+import { readFileSync } from "node:fs"
+import { STORE_DIR, TELEGRAM_BOT_TOKEN, ALLOWED_CHAT_ID } from "../config.js"
+import { atomicWriteFileSync } from "./atomic-write.js"
+import { logger } from "../logger.js"
+import { sendTelegramMessage } from "./telegram.js"
+import { appendTaskRun } from "../db.js"
+import type { ScheduledTask } from "./scheduled-tasks-io.js"
+
+// command-type scheduled tasks run a raw shell command directly (no LLM
+// agent, no tmux session) and alert on Telegram after N consecutive
+// failures. This keeps infra heartbeats inside the one system that gets
+// backed up (the Marveen store) instead of a separate crontab.
+
+const HEALTH_PATH = join(STORE_DIR, "command-task-health.json")
+
+export interface CommandHealth {
+  fails: number
+  alerted: boolean
+  lastStatus: "ok" | "fail" | "unknown"
+  lastRun: number
+}
+type HealthMap = Record<string, CommandHealth>
+
+let healthMap: HealthMap | null = null
+function load(): HealthMap {
+  if (healthMap) return healthMap
+  try { healthMap = JSON.parse(readFileSync(HEALTH_PATH, "utf-8")) as HealthMap }
+  catch { healthMap = {} }
+  return healthMap
+}
+function persist(): void {
+  try { atomicWriteFileSync(HEALTH_PATH, JSON.stringify(healthMap ?? {}, null, 2)) }
+  catch (err) { logger.warn({ err }, "command-task: failed to persist health map") }
+}
+
+export type CommandAction = "none" | "alert" | "recover"
+
+// Pure decision function so the failure/recovery policy is unit-testable
+// without spawning processes. success=true zeroes the streak; an alert
+// fires exactly once when the streak first reaches failThreshold; a
+// recover fires once when a previously-alerted task succeeds again.
+export function evaluateCommandResult(
+  prev: CommandHealth | undefined,
+  success: boolean,
+  failThreshold: number,
+  now: number,
+): { next: CommandHealth; action: CommandAction } {
+  const wasAlerted = prev?.alerted ?? false
+  const fails = success ? 0 : (prev?.fails ?? 0) + 1
+  let action: CommandAction = "none"
+  let alerted = wasAlerted
+  if (success) {
+    if (wasAlerted) { action = "recover"; alerted = false }
+  } else if (fails >= failThreshold && !wasAlerted) {
+    action = "alert"; alerted = true
+  }
+  return {
+    next: { fails, alerted, lastStatus: success ? "ok" : "fail", lastRun: now },
+    action,
+  }
+}
+
+function runCommand(cmd: string, timeoutMs: number): { ok: boolean; detail: string } {
+  try {
+    const r = spawnSync("bash", ["-lc", cmd], { timeout: timeoutMs, encoding: "utf-8" })
+    if (r.error) {
+      const code = (r.error as NodeJS.ErrnoException).code
+      if (code === "ETIMEDOUT") return { ok: false, detail: `timeout ${timeoutMs}ms` }
+      return { ok: false, detail: r.error.message }
+    }
+    if (r.status === 0) return { ok: true, detail: "exit 0" }
+    const err = (r.stderr || "").trim().slice(0, 200)
+    return { ok: false, detail: `exit ${r.status}${err ? ": " + err : ""}` }
+  } catch (err) {
+    return { ok: false, detail: (err as Error).message }
+  }
+}
+
+export function runCommandTask(task: ScheduledTask, now: number): void {
+  if (!task.command) {
+    logger.warn({ task: task.name }, "command task has no command, skipping")
+    return
+  }
+  const timeoutMs = task.timeoutMs && task.timeoutMs > 0 ? task.timeoutMs : 10_000
+  const failThreshold = task.failThreshold && task.failThreshold > 0 ? task.failThreshold : 2
+  const map = load()
+  const { ok, detail } = runCommand(task.command, timeoutMs)
+  const { next, action } = evaluateCommandResult(map[task.name], ok, failThreshold, now)
+  map[task.name] = next
+  persist()
+  try { appendTaskRun(task.name, task.agent || "system") } catch { /* non-fatal */ }
+  logger.info({ task: task.name, ok, detail, fails: next.fails, action }, "command task ran")
+
+  if (action === "none") return
+  if (!TELEGRAM_BOT_TOKEN || !ALLOWED_CHAT_ID) {
+    logger.warn({ task: task.name }, "command task alert suppressed: missing token/chat_id")
+    return
+  }
+  const label = task.description || task.name
+  const text = action === "alert"
+    ? `\u{1F534} Hiba: ${label} nem v\u00e1laszol (${next.fails}. egym\u00e1s ut\u00e1ni hiba). R\u00e9szlet: ${detail}`
+    : `\u{1F7E2} Helyre\u00e1llt: ${label} ism\u00e9t OK.`
+  sendTelegramMessage(TELEGRAM_BOT_TOKEN, ALLOWED_CHAT_ID, text)
+    .then(() => logger.info({ task: task.name, action }, "command task alert sent"))
+    .catch((err) => logger.warn({ err, task: task.name }, "command task alert send failed"))
+}

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -37,6 +37,7 @@ import {
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
+import { runCommandTask } from './command-task.js'
 
 const TMUX = resolveFromPath('tmux')
 
@@ -318,6 +319,17 @@ export function startScheduleRunner(): NodeJS.Timeout {
       // Prevent double-firing: skip if already ran within the catch-up window
       const lastRun = scheduleLastRun.get(task.name) || 0
       if (now - lastRun < catchUp) continue
+
+      // type='command' tasks run a raw shell command directly -- no LLM, no
+      // tmux, no target agent. They self-manage failure streaks + Telegram
+      // alerts. Record the run time like a fired task so the catch-up window
+      // does not double-run them on a dashboard restart.
+      if (task.type === 'command') {
+        runCommandTask(task, now)
+        scheduleLastRun.set(task.name, now)
+        persistScheduleLastRun()
+        continue
+      }
 
       let targetAgents: string[]
 

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -21,7 +21,7 @@ export interface ScheduledTask {
   agent: string
   enabled: boolean
   createdAt: number
-  type?: 'task' | 'heartbeat'  // heartbeat = silent unless important
+  type?: 'task' | 'heartbeat' | 'command'  // heartbeat = silent unless important; command = raw shell, no LLM
   // When true, a tick whose target session is busy is dropped silently
   // instead of queued. Use ONLY for cron schedules that fire often enough
   // (every 30-60 min) that losing a single tick is harmless because the
@@ -40,6 +40,12 @@ export interface ScheduledTask {
   // `agent-<name>` or MAIN_CHANNELS_SESSION. Enables dedicated
   // scheduler-only sessions in the future.
   targetSession?: string
+  // type='command' only: raw shell command run via `bash -lc`, no LLM/tmux.
+  command?: string
+  // type='command' only: command timeout in ms (default 10000).
+  timeoutMs?: number
+  // type='command' only: consecutive failures before a Telegram alert (default 2).
+  failThreshold?: number
 }
 
 function readFileOr(path: string, fallback: string): string {
@@ -64,28 +70,34 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   const skillPath = join(dir, 'SKILL.md')
   const configPath = join(dir, 'task-config.json')
-  if (!existsSync(skillPath)) return null
+  const hasSkill = existsSync(skillPath)
+  // command-type tasks have no SKILL.md; they are defined entirely by
+  // task-config.json. Only bail if neither file exists.
+  if (!hasSkill && !existsSync(configPath)) return null
 
-  const skillContent = readFileOr(skillPath, '')
+  const skillContent = hasSkill ? readFileOr(skillPath, '') : ''
   const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
 
   return {
     name: name || taskName,
-    description: description || '',
+    description: description || config.description || '',
     prompt: body,
     schedule: config.schedule || '0 9 * * *',
     agent: config.agent || MAIN_AGENT_ID,
     enabled: config.enabled !== false,
     createdAt: config.createdAt || 0,
-    type: (config.type as 'task' | 'heartbeat') || 'task',
+    type: (config.type as 'task' | 'heartbeat' | 'command') || 'task',
     skipIfBusy: config.skipIfBusy === true,
     forceSend: config.forceSend === true,
     targetSession: config.targetSession || undefined,
+    command: config.command,
+    timeoutMs: config.timeoutMs,
+    failThreshold: config.failThreshold,
   }
 }
 
@@ -104,7 +116,7 @@ export function listScheduledTasks(): ScheduledTask[] {
 
 export function writeScheduledTask(
   taskName: string,
-  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string },
+  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number },
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
@@ -131,6 +143,10 @@ export function writeScheduledTask(
   if (data.skipIfBusy !== undefined) config.skipIfBusy = data.skipIfBusy
   if (data.forceSend !== undefined) config.forceSend = data.forceSend
   if (data.targetSession !== undefined) config.targetSession = data.targetSession
+  if (data.command !== undefined) config.command = data.command
+  if (data.timeoutMs !== undefined) config.timeoutMs = data.timeoutMs
+  if (data.failThreshold !== undefined) config.failThreshold = data.failThreshold
+  if (data.description !== undefined) config.description = data.description
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }


### PR DESCRIPTION
## Summary

Add a **`command`** scheduled-task type that runs a raw shell command on a cron schedule — no LLM, no agent, no tmux session. This lets infra heartbeats and other deterministic checks live inside the one system that already gets backed up (the scheduled-tasks store) instead of a separate, easily-forgotten crontab.

## Behavior

- Command runs via `bash -lc` with a configurable timeout (`timeoutMs`, default `10000`).
- Consecutive failures are tracked in a small persisted health map:
  - a Telegram **alert fires exactly once** when the failure streak first reaches `failThreshold` (default `2`);
  - a **recovery message fires once** when a previously-alerted task succeeds again.
  - This avoids both alert spam and silent flapping.
- The run time is stamped like a fired task, so the catch-up window does not double-run the command after a dashboard restart.

## Config

`scheduled-tasks-io` gains `type: 'command'` plus `command`, `timeoutMs` and `failThreshold` fields. A command task can be defined entirely by `task-config.json` (command tasks have no `SKILL.md`):

```json
{
  "schedule": "*/10 * * * *",
  "type": "command",
  "enabled": true,
  "command": "curl -sf https://example.internal/health",
  "timeoutMs": 30000,
  "failThreshold": 2,
  "description": "internal health probe"
}
```

## Design

The failure/recovery policy is a **pure function** (`evaluateCommandResult`) so it is unit-testable without spawning processes: success zeroes the streak, an alert fires once at the threshold, a recover fires once on return to health, then re-arms.

## Tests

`command-task-eval.test.ts` covers the streak/alert/recover state machine (no alert below threshold, alert once at threshold, recover once, re-arm after recovery).

All new tests pass and `tsc` is clean. (The 4 pre-existing `managed-settings` failures on `develop` are unrelated.)
