### PR TITLE
fix(tests): use in-memory DB so unit tests never write to the live store

### DIFF
--- a/src/__tests__/channel-request.test.ts
+++ b/src/__tests__/channel-request.test.ts
@@ -9,8 +9,9 @@ import {
 } from '../db.js'
 
 beforeAll(() => {
+  // In-memory DB so the test never writes to the real store/claudeclaw.db.
   process.env.NODE_ENV = 'test'
-  initDatabase()
+  initDatabase(':memory:')
 })
 
 beforeEach(() => {

--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -25,9 +25,11 @@ import {
 import { STORE_DIR, DB_FILENAME } from '../config.js'
 
 beforeAll(() => {
-  // Teszt adatbázis inicializálás
+  // Teszt adatbázis inicializálás -- in-memory, hogy a teszt SOHA ne irjon a
+  // valodi store/claudeclaw.db-be (kulonben a sessions/memories/pending-task
+  // insertek -- pl. "Szeretem a kavet" -- prod junk-memoriakent landolnak).
   process.env.NODE_ENV = 'test'
-  initDatabase()
+  initDatabase(':memory:')
 })
 
 describe('sessions', () => {

--- a/src/__tests__/token-usage.test.ts
+++ b/src/__tests__/token-usage.test.ts
@@ -54,8 +54,10 @@ function makeToolCallLine(toolName: string, ts: string): string {
 }
 
 beforeAll(() => {
+  // In-memory DB so the test never writes to the real store/claudeclaw.db
+  // (previously test rows leaked into the live token_usage table).
   process.env.NODE_ENV = 'test'
-  initDatabase()
+  initDatabase(':memory:')
 
   // Clean previous test data
   const db = getDb()


### PR DESCRIPTION
> AI-generated by Marveen dev agent (forge, Claude Opus 4.8).

## Problem

Three unit test files opened the **real** database instead of an isolated one:

- `src/__tests__/db.test.ts`
- `src/__tests__/channel-request.test.ts`
- `src/__tests__/token-usage.test.ts`

Each called `initDatabase()` with no `dbPathOverride`, so `beforeAll` opened `store/claudeclaw.db` (the live store) and the test bodies wrote into it on every `npm run test` run:

- `db.test.ts` inserted junk memories (`"Szeretem a kavet"`, `"Mai megbeszeles eredmenye"`) and test sessions/pending-task rows. These surfaced as real agent memories in production and had to be cleaned up by hand / by the nightly compaction job.
- `token-usage.test.ts` wrote test rows into the live `token_usage` / `token_usage_cursors` tables (it even carried a `DELETE ... WHERE agent LIKE 'test-%'` cleanup hack to paper over the leak).
- `channel-request.test.ts` wrote into `pending_channel_requests`.

`initDatabase()` already supports `':memory:'` for exactly this purpose, and the newer tests (`kanban-delete-fk`, `agent-conversation`) already use it. These three were never migrated.

## Fix

Pass `':memory:'` to `initDatabase()` in the `beforeAll` of all three files, matching the existing isolated-test pattern.

- The `database file permissions` describe block in `db.test.ts` intentionally keeps the on-disk `initDatabase()` call, since it asserts real file modes (`0o600`) and `':memory:'` has no file. Left unchanged.
- The now-redundant cleanup `DELETE`s in `token-usage.test.ts` are harmless against an empty in-memory DB and were left in place to keep the diff minimal.

## Verification

- Affected files: `npm run test src/__tests__/db.test.ts src/__tests__/channel-request.test.ts src/__tests__/token-usage.test.ts` -> 63/63 pass.
- After running the suite, a direct `better-sqlite3` read of the live `store/claudeclaw.db` `memories` table shows zero new junk rows (previously 2 per string per run).
- `npx tsc --noEmit` -> clean.
