### PR TITLE
feat(kanban): auto session-lifecycle cards on the agent-sessions board

### DIFF
--- a/src/__tests__/agent-session-card.test.ts
+++ b/src/__tests__/agent-session-card.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { sessionStartCardFields } from '../web/agent-session-card.js'
+
+describe('sessionStartCardFields', () => {
+  it('builds an in_progress, low-priority card on the agent-sessions board', () => {
+    const f = sessionStartCardFields('cody', 'Cody', null)
+    expect(f.status).toBe('in_progress')
+    expect(f.priority).toBe('low')
+    expect(f.project).toBe('agent-sessions')
+    expect(f.assignee).toBe('cody')
+    expect(f.title).toContain('Cody')
+  })
+
+  it('marks a local session as "local" in the description', () => {
+    const f = sessionStartCardFields('cody', 'Cody', null)
+    expect(f.description).toContain('local')
+    expect(f.description).not.toContain('remote')
+  })
+
+  it('marks a remote session with its host in the description', () => {
+    const f = sessionStartCardFields('cassie', 'Cassie', 'devbox')
+    expect(f.description).toContain('remote: devbox')
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -18,6 +18,7 @@ import { loadProfileTemplate } from './profiles.js'
 import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
 import { getSecret } from './vault.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
+import { recordSessionStartCard, closeSessionStartCard } from './agent-session-card.js'
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
@@ -218,6 +219,8 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // -- the outbound pre-flight remains the safety net if this misses.
     scheduleIdentitySetup(session, readAgentDisplayName(name))
 
+    recordSessionStartCard(name, null)
+
     return { ok: true }
   } catch (err) {
     logger.error({ err, name }, 'Failed to start agent tmux session')
@@ -243,6 +246,7 @@ export function stopAgentProcess(name: string): { ok: boolean; error?: string } 
       logger.warn({ err, name }, 'post-stop channel-poller reap failed')
     }
     logger.info({ name, session }, 'Agent tmux session stopped')
+    closeSessionStartCard(name)
     return { ok: true }
   } catch (err) {
     logger.error({ err, name, session }, 'Failed to stop agent tmux session')

--- a/src/web/agent-session-card.ts
+++ b/src/web/agent-session-card.ts
@@ -1,0 +1,68 @@
+import { randomBytes } from 'node:crypto'
+import { createKanbanCard, listKanbanCards, moveKanbanCard, type KanbanCard } from '../db.js'
+import { logger } from '../logger.js'
+
+// Auto-managed kanban cards that mirror an agent's tmux-session lifecycle: a
+// card is opened on the "agent-sessions" board when a session starts and moved
+// to "done" when it stops. This gives an at-a-glance, persisted view of which
+// agents are currently up without polling tmux. All errors are swallowed and
+// logged -- session lifecycle must never fail because of a bookkeeping card.
+
+const SESSION_PROJECT = 'agent-sessions'
+
+export interface SessionStartCardFields {
+  title: string
+  description: string
+  status: 'in_progress'
+  assignee: string
+  priority: 'low'
+  project: string
+}
+
+function isOpenSessionCard(card: KanbanCard, name: string): boolean {
+  return (
+    card.project === SESSION_PROJECT &&
+    (card.assignee ?? '') === name &&
+    card.archived_at == null &&
+    card.status !== 'done'
+  )
+}
+
+export function sessionStartCardFields(
+  name: string,
+  displayName: string,
+  host: string | null
+): SessionStartCardFields {
+  const where = host ? `remote: ${host}` : 'local'
+  return {
+    title: `${displayName} session elindult`,
+    description: `Auto-kártya: a(z) "${name}" agent tmux session-je elindult (${where}).`,
+    status: 'in_progress',
+    assignee: name,
+    priority: 'low',
+    project: SESSION_PROJECT,
+  }
+}
+
+export function recordSessionStartCard(name: string, host: string | null): void {
+  try {
+    const existing = listKanbanCards().find((c) => isOpenSessionCard(c, name))
+    if (existing) return
+    const displayName = name.charAt(0).toUpperCase() + name.slice(1)
+    const fields = sessionStartCardFields(name, displayName, host)
+    createKanbanCard({ id: randomBytes(4).toString('hex'), ...fields })
+  } catch (err) {
+    logger.warn({ err, name }, 'failed to record session-start kanban card')
+  }
+}
+
+export function closeSessionStartCard(name: string): void {
+  try {
+    const open = listKanbanCards().filter((c) => isOpenSessionCard(c, name))
+    for (const card of open) {
+      moveKanbanCard(card.id, 'done', card.sort_order)
+    }
+  } catch (err) {
+    logger.warn({ err, name }, 'failed to close session-start kanban card')
+  }
+}


### PR DESCRIPTION
## Summary

Mirror each agent's **tmux-session lifecycle onto the kanban board**: a card is opened on a dedicated `agent-sessions` board when a session starts, and moved to **done** when it stops. This gives an at-a-glance, persisted view of which agents are currently up — without polling tmux — plus a historical trail of start/stop events.

## Behavior

- **On `startAgentProcess` success** — an `in_progress`, `low`-priority card is created on the `agent-sessions` board, assigned to the agent. Idempotent: if an open card already exists for that agent, the call is a no-op (no duplicate cards across restarts).
- **On `stopAgentProcess` success** — any open card for the agent is moved to `done`.
- All bookkeeping errors are **swallowed and logged**. The card is pure side-bookkeeping; it must never break session start/stop.

## Design

The card-field builder `sessionStartCardFields(name, displayName, host)` is a **pure function**, so the card shape is unit-testable without touching the DB. It takes an optional `host`, labelling the card `local` or `remote: <host>` — so the same path works whether the session is local or on a remote host.

New file `src/web/agent-session-card.ts` (~70 lines); two one-line hooks in `src/web/agent-process.ts` (one in `startAgentProcess`, one in `stopAgentProcess`). It only uses the existing `createKanbanCard` / `listKanbanCards` / `moveKanbanCard` DB API — no schema changes.

## Tests

`agent-session-card.test.ts` covers the pure field builder: status/priority/board, and local vs. remote labelling.

All new tests pass and `tsc` is clean. (The 4 pre-existing `managed-settings` failures on `develop` are unrelated.)
