### PR TITLE
feat(dashboard/terminal): full-viewport agent terminal with a larger, readable font

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -9475,11 +9475,11 @@ function openTerminalModal(agentName) {
   if (terminalInstance) { terminalInstance.dispose(); terminalInstance = null }
   container.innerHTML = ''
 
-  // Init xterm — fontSize 12 + wider modal fits ~140 chars of tmux output
+  // Init xterm — fontSize 14 + wider modal fits ~140 chars of tmux output
   const term = new window.Terminal({
     theme: { background: '#1a1a1a', foreground: '#e8e4da' },
     fontFamily: 'JetBrains Mono, Menlo, monospace',
-    fontSize: 12,
+    fontSize: 14,
     cursorBlink: false,
     disableStdin: false,
     scrollback: 500,

--- a/web/style.css
+++ b/web/style.css
@@ -5247,11 +5247,13 @@ main {
 
 /* Terminal modal */
 .terminal-modal {
-  max-width: 1100px;
-  width: 98vw;
+  max-width: none;
+  width: 100vw;
+  height: 100vh;
+  max-height: 100vh;
+  border-radius: 0;
   display: flex;
   flex-direction: column;
-  max-height: 90vh;
 }
 .terminal-modal .modal-header { flex-shrink: 0; }
 #terminalContainer { flex: 1; min-height: 360px; }


### PR DESCRIPTION
The PTY-backed agent terminal modal (`openTerminalModal`) opened in a bounded box (max 1100px / 90vh) with a small 12px font, which made it hard to read on larger screens.

This opens the terminal modal at the **full browser viewport** and bumps the font **12px -> 14px** for readability. The xterm grid auto-fits to the larger area via the existing `ResizeObserver`, so no manual fit call is needed.

### Changes
- `web/style.css` — `.terminal-modal` now fills the viewport (`100vw x 100vh`, no `max-width`/`max-height`, no `border-radius`); `#terminalContainer` keeps `flex: 1` to fill below the header.
- `web/app.js` — Terminal `fontSize` 12 -> 14.

No behavioural change beyond sizing/readability; the close (X) button still dismisses the modal.