### PR TITLE
feat(dashboard/terminal): deep-linkable terminal in the URL (per-tab, reload-restorable)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -9461,12 +9461,28 @@ async function handleAgentLogin(agentName, btn) {
 let terminalInstance = null
 let terminalSSE = null
 let terminalFit = null
+let currentTerminalAgent = null
 
-function openTerminalModal(agentName) {
+// Parse the location hash into a page id + optional terminal deep-link.
+// Format: "#<page>" or "#<page>/term/<agent>" -- the open terminal lives in the
+// URL, so a terminal can be opened per browser tab and survives a reload.
+function parseHashRoute() {
+  const raw = decodeURIComponent((location.hash || '').replace(/^#/, ''))
+  const parts = raw.split('/')
+  const page = parts[0] || ''
+  const termAgent = (parts[1] === 'term' && parts[2]) ? parts[2] : null
+  return { page, termAgent }
+}
+
+function openTerminalModal(agentName, fromRoute) {
   const overlay = document.getElementById('terminalOverlay')
   const container = document.getElementById('terminalContainer')
   const title = document.getElementById('terminalModalTitle')
   if (!overlay || !container) return
+
+  // Already showing this agent's terminal? Avoid a reconnect loop on re-entry
+  // from the hash router.
+  if (currentTerminalAgent === agentName && terminalInstance) return
 
   title.textContent = agentName + ' — Terminal'
 
@@ -9494,6 +9510,7 @@ function openTerminalModal(agentName) {
   terminalFit = fitAddon
 
   openModal(overlay)
+  currentTerminalAgent = agentName
   setTimeout(() => term.focus(), 50)
 
   // SSE pane stream
@@ -9538,19 +9555,38 @@ function openTerminalModal(agentName) {
   })
   const modalEl = container.closest('.terminal-modal') || container.parentElement
   if (modalEl) ro.observe(modalEl)
+
+  // Reflect the open terminal in the URL so it is deep-linkable and survives a
+  // reload. Skip when we got here *from* the router (hash already matches).
+  if (!fromRoute) {
+    const page = parseHashRoute().page || 'agents'
+    location.hash = page + '/term/' + encodeURIComponent(agentName)
+  }
 }
 
-document.getElementById('terminalClose')?.addEventListener('click', () => {
+function closeTerminalModal(fromRoute) {
   const overlay = document.getElementById('terminalOverlay')
   if (overlay) closeModal(overlay)
   if (terminalSSE) { terminalSSE.close(); terminalSSE = null }
   if (terminalInstance) { terminalInstance.dispose(); terminalInstance = null }
-})
+  currentTerminalAgent = null
+  // Drop the /term/<agent> part of the hash (keep the page).
+  if (!fromRoute) {
+    const page = parseHashRoute().page || 'agents'
+    location.hash = page
+  }
+}
+document.getElementById('terminalClose')?.addEventListener('click', () => closeTerminalModal())
 ;(() => {
   function routeFromHash() {
-    let pageId = decodeURIComponent((location.hash || '').replace(/^#/, ''))
+    const { page, termAgent } = parseHashRoute()
+    let pageId = page
     if (!pageId) pageId = new URLSearchParams(window.location.search).get('page') || ''
     if (pageId && document.getElementById(pageId + 'Page')) switchPage(pageId)
+    // Sync the terminal to the URL: open the deep-linked one, or close it if the
+    // hash no longer carries a terminal (e.g. navigated to another page).
+    if (termAgent) openTerminalModal(termAgent, true)
+    else if (currentTerminalAgent) closeTerminalModal(true)
   }
   window.addEventListener('hashchange', routeFromHash)
   routeFromHash()


### PR DESCRIPTION
The agent terminal modal was modal-only state: opening it left the URL on `#<page>`, so a reload lost the open terminal and you could not have a different terminal per browser tab.

This encodes the open terminal in the location hash as `#<page>/term/<agent>`, making the terminal **deep-linkable**:
- Open a terminal -> the URL becomes `#agents/term/<agent>`.
- **Reload** restores that terminal (the hash router reopens it).
- A **second browser tab** pointed at `#agents/term/<other-agent>` shows that agent's terminal -> one terminal per tab.
- Closing the terminal (X) or navigating to another page drops the `/term/<agent>` part.

### Changes (web/app.js)
- `parseHashRoute()` splits the hash into `{ page, termAgent }`.
- `openTerminalModal(agentName, fromRoute)` tracks `currentTerminalAgent`, guards against a reconnect loop on router re-entry, and writes the hash (unless invoked *from* the router).
- The inline `terminalClose` handler became a named `closeTerminalModal(fromRoute)` that clears state and resets the hash.
- `routeFromHash()` opens/closes the terminal to match the URL on load and on every `hashchange`.

No change to the terminal transport (SSE pane stream) -- this is purely URL/open-close state.