### PR TITLE
fix(dream-engine): correct memory-backfill endpoint path (was 404 reembed) + {{WEB_PORT}} scaffold

### DIFF
--- a/scheduled-tasks/dream-engine/SKILL.md
+++ b/scheduled-tasks/dream-engine/SKILL.md
@@ -29,7 +29,8 @@ Output: 0-2 konkrét skill-javaslat. Mindegyikhez: cím + 1 mondat indoklás + "
 ```bash
 # Vektorizálás ellenőrzés
 sqlite3 {{INSTALL_DIR}}/store/claudeclaw.db "SELECT COUNT(*) as total, COUNT(embedding) as with_emb FROM memories"
-# Ha NEM 100%, hívd meg a /api/memories/reembed endpoint-ot vagy futtass embedding-job-ot a missing ID-kra
+# Ha NEM 100%, hívd meg a backfill endpoint-ot (Ollamaval embeddeli a hianyzo ID-kat):
+curl -s -X POST http://localhost:{{WEB_PORT}}/api/memories/backfill -H "Authorization: Bearer $(cat {{INSTALL_DIR}}/store/.dashboard-token)"
 
 # Antikvált hot-tier (>7 napos hot, nem hivatkozott a memories_fts-en az elmúlt 24h-ban)
 sqlite3 {{INSTALL_DIR}}/store/claudeclaw.db "SELECT id, content, accessed_at FROM memories WHERE category='hot' AND accessed_at < strftime('%s', 'now', '-7 days')"

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER } from '../config.js'
+import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT } from '../config.js'
 import { channelStateDir } from '../channel-provider.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
@@ -19,6 +19,7 @@ export function resolveTemplatePlaceholders(content: string): string {
     .replaceAll('{{MAIN_AGENT_ID}}', MAIN_AGENT_ID)
     .replaceAll('{{BOT_NAME}}', BOT_NAME)
     .replaceAll('{{OWNER_NAME}}', OWNER_NAME)
+    .replaceAll('{{WEB_PORT}}', String(WEB_PORT))
 }
 
 // Idempotent migration: every agent's settings.json should carry the


### PR DESCRIPTION
## Mi a baj
A dream-engine nightly memória-health check a `/api/memories/reembed` endpointot hívta, ami NEM létezik (404). A valódi backfill endpoint: `POST /api/memories/backfill`. Emiatt a vektorizálatlan emlékek sosem ágyazódtak be utólag → felhalmozódtak (124 stuck NULL embedding, krónikus, ~2+ napja stagnált).

## Gyökér
Az embedding helyi Ollamával fut (nomic-embed-text). Az infra végig egészséges volt (Ollama fut, modell megvan, teszt 768-dim OK), és az ÚJ emlékek kaptak vektort. CSAK a backfill-trigger path volt rossz a SKILL.md-ben.

## Fix
- `scheduled-tasks/dream-engine/SKILL.md`: a helyes `/api/memories/backfill` endpoint hívása, config-vezérelt placeholderekkel (`{{WEB_PORT}}` + `{{INSTALL_DIR}}`), nincs hardcode host/path.
- `agent-scaffold.ts`: `{{WEB_PORT}}` helyettesítés a shipped template-ekben (config WEB_PORT, default 3420), hogy friss install feloldja.

## Verifikáció
- A 124 stuck emlék backfillje MÁR lefutott kézzel → 888/888 vektorizált, 0 NULL.
- `tsc --noEmit` exit 0.
- A javított nightly dream-engine mostantól önjavít (ha bármi NULL marad, a helyes endpointot hívja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)