### PR TITLE
feat(scheduler): command task type for LLM-free shell schedules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,5 +22,6 @@ Minden lap két szemszögből mutatja be a funkciót:
 | [Vault & titkosítás](vault.md) | Titkosított titok-tár (AES-256-GCM) OS-kulcstárral |
 | [Dream-engine](dream-engine.md) | Éjszakai tudás-konszolidáció + reggeli prioritás-javaslatok |
 | [Háttér-feladatok](background-tasks.md) | Leválasztott, hosszú feladatok futtatása + értesítés |
+| [Command-feladatok](command-tasks.md) | Shell-ütemezés LLM nélkül: health-check / karbantartó-szkript + hiba-riasztás |
 
 *A dokumentáció él; javításokat/bővítéseket szívesen fogadunk.*

--- a/docs/command-tasks.md
+++ b/docs/command-tasks.md
@@ -1,0 +1,51 @@
+# Command-feladatok (shell-ütemezés LLM nélkül)
+
+> Nem minden ütemezett munkához kell egy nyelvi modell. Egy HTTP-health-check vagy egy karbantartó-szkript csak fusson le, és szóljon ha elromlott.
+
+---
+
+## 🎯 Mit tud / miért érdekes
+
+Az ütemezett feladatok alapból egy LLM-ügynököt ébresztenek a SKILL.md promptjával (`task` / `heartbeat` típus). Sok háttérmunkához viszont nincs szükség modellre: egy webhely elérhetőség-ellenőrzése, egy backup-integritás-próba, egy log-rotáció. Ezekre való a **`command`** típus: nyers shell-parancsot futtat (LLM és tmux nélkül), és Telegramon riaszt, ha N egymás utáni futás elhasal.
+
+A nyereség: ezek a könnyű infra-ellenőrzések **ugyanabban a rendszerben** élnek, amit a dashboard kezel és a Marveen store ment, nem egy külön, felügyelet nélküli crontabban.
+
+---
+
+## 🛠 Hogyan működik
+
+### Definíció
+
+A `command` feladatnak **nincs SKILL.md-je** — kizárólag a `task-config.json` írja le:
+
+```json
+{
+  "type": "command",
+  "schedule": "*/5 * * * *",
+  "command": "curl -fsS https://example.com/health",
+  "timeoutMs": 10000,
+  "failThreshold": 2,
+  "description": "example.com health"
+}
+```
+
+| Mező | Jelentés |
+|------|----------|
+| `command` | A `bash -lc`-en futtatott parancs. |
+| `timeoutMs` | Kemény timeout ms-ban (default 10000). A timeout hibának számít. |
+| `failThreshold` | Hány egymás utáni hiba után menjen riasztás (default 2). |
+
+### Riasztás-logika
+
+A hiba/helyreállás döntés **él-vezérelt** (`evaluateCommandResult`, tisztán unit-tesztelt):
+
+- egy sikeres futás nullázza a hiba-sorozatot,
+- **egy** riasztás megy, amikor a sorozat először eléri a `failThreshold`-ot,
+- amíg hibás marad, nincs ismételt riasztás,
+- **egy** helyreállás-üzenet megy, amikor egy korábban riasztott feladat újra sikeres.
+
+Így egy hosszú kiesés vagy egy flapping szolgáltatás is pontosan egy riasztást + egy helyreállást ad, nem futásonkénti spamet. Az állapot a `store/command-task-health.json`-ban perzisztált, így egy dashboard-restart nem nullázza a sorozatot és nem riaszt újra egy már ismert kiesésre.
+
+### Mikor érdemes
+
+`command` típus: nyelvi modellt nem igénylő, gyakran futó, gép-ellenőrizhető munka (HTTP/SMTP-próba, integritás-check, szkript). Ha a feladat ítéletet, szöveg-értelmezést vagy cselekvést igényel, a `task` / `heartbeat` (LLM) típus való rá.

--- a/src/__tests__/command-task-eval.test.ts
+++ b/src/__tests__/command-task-eval.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateCommandResult, type CommandHealth } from '../web/command-task.js'
+
+// Unit tests for the command-task failure/recovery policy. This is the
+// decision core behind type='command' scheduled tasks (raw shell health
+// checks). The rules under test:
+//   - a success zeroes the consecutive-failure streak
+//   - an alert fires exactly ONCE, when the streak first hits failThreshold
+//   - while still failing past the threshold, no repeat alerts
+//   - a recover fires exactly ONCE, when a previously-alerted task succeeds
+const T = 1_000
+
+describe('evaluateCommandResult', () => {
+  it('returns no action on the first failure below threshold', () => {
+    const { next, action } = evaluateCommandResult(undefined, false, 2, T)
+    expect(action).toBe('none')
+    expect(next.fails).toBe(1)
+    expect(next.alerted).toBe(false)
+    expect(next.lastStatus).toBe('fail')
+  })
+
+  it('alerts exactly when the streak first reaches the threshold', () => {
+    const prev: CommandHealth = { fails: 1, alerted: false, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, false, 2, T)
+    expect(action).toBe('alert')
+    expect(next.fails).toBe(2)
+    expect(next.alerted).toBe(true)
+  })
+
+  it('does not re-alert while already alerted and still failing', () => {
+    const prev: CommandHealth = { fails: 2, alerted: true, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, false, 2, T)
+    expect(action).toBe('none')
+    expect(next.fails).toBe(3)
+    expect(next.alerted).toBe(true)
+  })
+
+  it('recovers exactly once when a previously-alerted task succeeds', () => {
+    const prev: CommandHealth = { fails: 3, alerted: true, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, true, 2, T)
+    expect(action).toBe('recover')
+    expect(next.fails).toBe(0)
+    expect(next.alerted).toBe(false)
+    expect(next.lastStatus).toBe('ok')
+  })
+
+  it('stays silent on success when not previously alerted', () => {
+    const prev: CommandHealth = { fails: 1, alerted: false, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, true, 2, T)
+    expect(action).toBe('none')
+    expect(next.fails).toBe(0)
+  })
+
+  it('respects a custom failThreshold greater than 2', () => {
+    let prev: CommandHealth | undefined
+    const actions: string[] = []
+    for (let i = 0; i < 3; i++) {
+      const r = evaluateCommandResult(prev, false, 3, T)
+      prev = r.next
+      actions.push(r.action)
+    }
+    expect(actions).toEqual(['none', 'none', 'alert'])
+  })
+})

--- a/src/web/command-task.ts
+++ b/src/web/command-task.ts
@@ -1,0 +1,122 @@
+import { spawnSync } from "node:child_process"
+import { join } from "node:path"
+import { readFileSync } from "node:fs"
+import { STORE_DIR, TELEGRAM_BOT_TOKEN, ALLOWED_CHAT_ID } from "../config.js"
+import { atomicWriteFileSync } from "./atomic-write.js"
+import { logger } from "../logger.js"
+import { sendTelegramMessage } from "./telegram.js"
+import { appendTaskRun } from "../db.js"
+import type { ScheduledTask } from "./scheduled-tasks-io.js"
+
+// `command`-type scheduled tasks run a raw shell command directly (no LLM
+// agent, no tmux session) and alert on Telegram after N consecutive failures.
+// This keeps lightweight infra checks (HTTP probes, SMTP reachability, custom
+// scripts) inside the one system that already gets scheduled + backed up (the
+// Marveen store) instead of a separate, unmonitored crontab.
+//
+// A `command` task is defined entirely by its task-config.json -- it needs no
+// SKILL.md, because there is no prompt and no agent. Minimal config:
+//   { "type": "command", "schedule": "*/5 * * * *",
+//     "command": "curl -fsS https://example.com/health",
+//     "timeoutMs": 10000, "failThreshold": 2 }
+
+const HEALTH_PATH = join(STORE_DIR, "command-task-health.json")
+
+export interface CommandHealth {
+  fails: number          // consecutive-failure streak (0 when healthy)
+  alerted: boolean       // a failure alert is currently outstanding
+  lastStatus: "ok" | "fail" | "unknown"
+  lastRun: number
+}
+type HealthMap = Record<string, CommandHealth>
+
+// Health is persisted (not just in-memory) so a dashboard restart does not
+// reset failure streaks and re-alert on an already-known outage.
+let healthMap: HealthMap | null = null
+function load(): HealthMap {
+  if (healthMap) return healthMap
+  try { healthMap = JSON.parse(readFileSync(HEALTH_PATH, "utf-8")) as HealthMap }
+  catch { healthMap = {} }
+  return healthMap
+}
+function persist(): void {
+  try { atomicWriteFileSync(HEALTH_PATH, JSON.stringify(healthMap ?? {}, null, 2)) }
+  catch (err) { logger.warn({ err }, "command-task: failed to persist health map") }
+}
+
+export type CommandAction = "none" | "alert" | "recover"
+
+// Pure decision function so the failure/recovery policy is unit-testable
+// without spawning processes. success=true zeroes the streak; an alert fires
+// exactly once when the streak first reaches failThreshold; a recover fires
+// once when a previously-alerted task succeeds again. This "edge-triggered"
+// design means a flapping or long outage produces one alert + one recovery,
+// never a per-tick stream.
+export function evaluateCommandResult(
+  prev: CommandHealth | undefined,
+  success: boolean,
+  failThreshold: number,
+  now: number,
+): { next: CommandHealth; action: CommandAction } {
+  const wasAlerted = prev?.alerted ?? false
+  const fails = success ? 0 : (prev?.fails ?? 0) + 1
+  let action: CommandAction = "none"
+  let alerted = wasAlerted
+  if (success) {
+    if (wasAlerted) { action = "recover"; alerted = false }
+  } else if (fails >= failThreshold && !wasAlerted) {
+    action = "alert"; alerted = true
+  }
+  return {
+    next: { fails, alerted, lastStatus: success ? "ok" : "fail", lastRun: now },
+    action,
+  }
+}
+
+// Run the command through `bash -lc` with a hard timeout. A non-zero exit, a
+// spawn error, or a timeout all count as a failure; the first 200 chars of
+// stderr are surfaced into the alert detail.
+function runCommand(cmd: string, timeoutMs: number): { ok: boolean; detail: string } {
+  try {
+    const r = spawnSync("bash", ["-lc", cmd], { timeout: timeoutMs, encoding: "utf-8" })
+    if (r.error) {
+      const code = (r.error as NodeJS.ErrnoException).code
+      if (code === "ETIMEDOUT") return { ok: false, detail: `timeout ${timeoutMs}ms` }
+      return { ok: false, detail: r.error.message }
+    }
+    if (r.status === 0) return { ok: true, detail: "exit 0" }
+    const err = (r.stderr || "").trim().slice(0, 200)
+    return { ok: false, detail: `exit ${r.status}${err ? ": " + err : ""}` }
+  } catch (err) {
+    return { ok: false, detail: (err as Error).message }
+  }
+}
+
+export function runCommandTask(task: ScheduledTask, now: number): void {
+  if (!task.command) {
+    logger.warn({ task: task.name }, "command task has no command, skipping")
+    return
+  }
+  const timeoutMs = task.timeoutMs && task.timeoutMs > 0 ? task.timeoutMs : 10_000
+  const failThreshold = task.failThreshold && task.failThreshold > 0 ? task.failThreshold : 2
+  const map = load()
+  const { ok, detail } = runCommand(task.command, timeoutMs)
+  const { next, action } = evaluateCommandResult(map[task.name], ok, failThreshold, now)
+  map[task.name] = next
+  persist()
+  try { appendTaskRun(task.name, task.agent || "system") } catch { /* non-fatal */ }
+  logger.info({ task: task.name, ok, detail, fails: next.fails, action }, "command task ran")
+
+  if (action === "none") return
+  if (!TELEGRAM_BOT_TOKEN || !ALLOWED_CHAT_ID) {
+    logger.warn({ task: task.name }, "command task alert suppressed: missing token/chat_id")
+    return
+  }
+  const label = task.description || task.name
+  const text = action === "alert"
+    ? `[Marveen scheduler] Hiba: ${label} nem valaszol (${next.fails}. egymas utani hiba). Reszlet: ${detail}`
+    : `[Marveen scheduler] Helyreallt: ${label} ismet OK.`
+  sendTelegramMessage(TELEGRAM_BOT_TOKEN, ALLOWED_CHAT_ID, text)
+    .then(() => logger.info({ task: task.name, action }, "command task alert sent"))
+    .catch((err) => logger.warn({ err, task: task.name }, "command task alert send failed"))
+}

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -4,6 +4,7 @@ import { execSync, execFileSync } from 'node:child_process'
 import { resolveFromPath } from '../platform.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { logger } from '../logger.js'
+import { runCommandTask } from './command-task.js'
 import {
   PROJECT_ROOT,
   MAIN_AGENT_ID,
@@ -318,6 +319,17 @@ export function startScheduleRunner(): NodeJS.Timeout {
       // Prevent double-firing: skip if already ran within the catch-up window
       const lastRun = scheduleLastRun.get(task.name) || 0
       if (now - lastRun < catchUp) continue
+
+      // type='command' tasks run a raw shell command directly -- no LLM, no
+      // tmux, no target agent. They self-manage failure streaks + Telegram
+      // alerts (see command-task.ts). Record the run time like a fired task so
+      // the catch-up window does not double-run them on a dashboard restart.
+      if (task.type === 'command') {
+        runCommandTask(task, now)
+        scheduleLastRun.set(task.name, now)
+        persistScheduleLastRun()
+        continue
+      }
 
       let targetAgents: string[]
 

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -21,7 +21,11 @@ export interface ScheduledTask {
   agent: string
   enabled: boolean
   createdAt: number
-  type?: 'task' | 'heartbeat'  // heartbeat = silent unless important
+  // task = wake an LLM agent with the SKILL.md prompt; heartbeat = same but
+  // silent unless important; command = run a raw shell command, no LLM/tmux
+  // (see command-task.ts). A `command` task is defined entirely by the
+  // command/timeoutMs/failThreshold fields below -- it has no SKILL.md.
+  type?: 'task' | 'heartbeat' | 'command'
   // When true, a tick whose target session is busy is dropped silently
   // instead of queued. Use ONLY for cron schedules that fire often enough
   // (every 30-60 min) that losing a single tick is harmless because the
@@ -40,6 +44,15 @@ export interface ScheduledTask {
   // `agent-<name>` or MAIN_CHANNELS_SESSION. Enables dedicated
   // scheduler-only sessions in the future.
   targetSession?: string
+  // command-type only: the raw shell command, run via `bash -lc`. No LLM,
+  // no tmux, no target agent.
+  command?: string
+  // command-type only: hard timeout in ms (default 10000). A timeout counts
+  // as a failure.
+  timeoutMs?: number
+  // command-type only: consecutive failures before a Telegram alert fires
+  // (default 2). One alert per outage, one recovery when it clears.
+  failThreshold?: number
 }
 
 function readFileOr(path: string, fallback: string): string {
@@ -64,15 +77,17 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   const skillPath = join(dir, 'SKILL.md')
   const configPath = join(dir, 'task-config.json')
-  if (!existsSync(skillPath)) return null
-
-  const skillContent = readFileOr(skillPath, '')
-  const { name, description, body } = parseSkillMdFrontmatter(skillContent)
-
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
+
+  // command-type tasks are defined entirely by task-config.json (no prompt,
+  // no agent) and therefore have no SKILL.md. Every other type requires one.
+  if (!existsSync(skillPath) && config.type !== 'command') return null
+
+  const skillContent = readFileOr(skillPath, '')
+  const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
   return {
     name: name || taskName,
@@ -82,10 +97,13 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
     agent: config.agent || MAIN_AGENT_ID,
     enabled: config.enabled !== false,
     createdAt: config.createdAt || 0,
-    type: (config.type as 'task' | 'heartbeat') || 'task',
+    type: (config.type as 'task' | 'heartbeat' | 'command') || 'task',
     skipIfBusy: config.skipIfBusy === true,
     forceSend: config.forceSend === true,
     targetSession: config.targetSession || undefined,
+    command: config.command,
+    timeoutMs: config.timeoutMs,
+    failThreshold: config.failThreshold,
   }
 }
 
@@ -104,7 +122,7 @@ export function listScheduledTasks(): ScheduledTask[] {
 
 export function writeScheduledTask(
   taskName: string,
-  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string },
+  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number },
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
@@ -114,12 +132,16 @@ export function writeScheduledTask(
 
   // Read existing if updating
   const existing = readScheduledTask(taskName)
+  const type = data.type ?? existing?.type ?? 'task'
 
-  // Write SKILL.md
-  const desc = data.description ?? existing?.description ?? ''
-  const prompt = data.prompt ?? existing?.prompt ?? ''
-  const skillContent = `---\nname: ${taskName}\ndescription: ${desc}\n---\n\n${prompt}\n`
-  atomicWriteFileSync(skillPath, skillContent)
+  // Write SKILL.md -- but command-type tasks have no prompt/agent, so they get
+  // no SKILL.md (they are defined entirely by task-config.json).
+  if (type !== 'command') {
+    const desc = data.description ?? existing?.description ?? ''
+    const prompt = data.prompt ?? existing?.prompt ?? ''
+    const skillContent = `---\nname: ${taskName}\ndescription: ${desc}\n---\n\n${prompt}\n`
+    atomicWriteFileSync(skillPath, skillContent)
+  }
 
   // Write/update config
   let config: Record<string, unknown> = {}
@@ -131,6 +153,9 @@ export function writeScheduledTask(
   if (data.skipIfBusy !== undefined) config.skipIfBusy = data.skipIfBusy
   if (data.forceSend !== undefined) config.forceSend = data.forceSend
   if (data.targetSession !== undefined) config.targetSession = data.targetSession
+  if (data.command !== undefined) config.command = data.command
+  if (data.timeoutMs !== undefined) config.timeoutMs = data.timeoutMs
+  if (data.failThreshold !== undefined) config.failThreshold = data.failThreshold
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }


### PR DESCRIPTION
## Mit

Új `command` scheduled-task típus: nyers shell-parancsot futtat a cron-ütemezésén (LLM-ügynök és tmux nélkül), és Telegramon riaszt N egymás utáni hiba után, egyszer helyreáll amikor elmúlik. HTTP/SMTP health-checkekhez, karbantartó-szkriptekhez, amikhez nem kell modell. Kizárólag a `task-config.json` írja le (nincs SKILL.md).

## Hogyan

- `src/web/command-task.ts`: a futtatás + él-vezérelt hiba/helyreállás policy (tiszta, unit-tesztelt `evaluateCommandResult`). Az állapot a `store/command-task-health.json`-ban perzisztált, így restart nem riaszt újra egy ismert kiesésre.
- `scheduled-tasks-io.ts`: `type: 'command'` + `command` / `timeoutMs` / `failThreshold` mezők; a command-task SKILL.md nélkül is betöltődik.
- `schedule-runner.ts`: a cron-loop a command-taskot inline futtatja, target-agent nélkül.

## Teszt
6 unit-teszt a hiba/recovery döntésre (egy alert/kiesés, egy recovery, custom threshold). `docs/command-tasks.md` hozzáadva.

Példa config:
```json
{ "type": "command", "schedule": "*/5 * * * *",
  "command": "curl -fsS https://example.com/health",
  "timeoutMs": 10000, "failThreshold": 2 }
```