### PR TITLE
feat(email): privacy-first address-based inbox digest + AI review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,5 +22,6 @@ Minden lap két szemszögből mutatja be a funkciót:
 | [Vault & titkosítás](vault.md) | Titkosított titok-tár (AES-256-GCM) OS-kulcstárral |
 | [Dream-engine](dream-engine.md) | Éjszakai tudás-konszolidáció + reggeli prioritás-javaslatok |
 | [Háttér-feladatok](background-tasks.md) | Leválasztott, hosszú feladatok futtatása + értesítés |
+| [Command-feladatok](command-tasks.md) | Shell-ütemezés LLM nélkül: health-check / karbantartó-szkript + hiba-riasztás |
 
 *A dokumentáció él; javításokat/bővítéseket szívesen fogadunk.*

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,5 +23,6 @@ Minden lap két szemszögből mutatja be a funkciót:
 | [Dream-engine](dream-engine.md) | Éjszakai tudás-konszolidáció + reggeli prioritás-javaslatok |
 | [Háttér-feladatok](background-tasks.md) | Leválasztott, hosszú feladatok futtatása + értesítés |
 | [Command-feladatok](command-tasks.md) | Shell-ütemezés LLM nélkül: health-check / karbantartó-szkript + hiba-riasztás |
+| [Email-digest](email-digest.md) | Cím-alapú postafiók-triage: archív/fontos/AI-review, privacy-first |
 
 *A dokumentáció él; javításokat/bővítéseket szívesen fogadunk.*

--- a/docs/command-tasks.md
+++ b/docs/command-tasks.md
@@ -1,0 +1,51 @@
+# Command-feladatok (shell-ütemezés LLM nélkül)
+
+> Nem minden ütemezett munkához kell egy nyelvi modell. Egy HTTP-health-check vagy egy karbantartó-szkript csak fusson le, és szóljon ha elromlott.
+
+---
+
+## 🎯 Mit tud / miért érdekes
+
+Az ütemezett feladatok alapból egy LLM-ügynököt ébresztenek a SKILL.md promptjával (`task` / `heartbeat` típus). Sok háttérmunkához viszont nincs szükség modellre: egy webhely elérhetőség-ellenőrzése, egy backup-integritás-próba, egy log-rotáció. Ezekre való a **`command`** típus: nyers shell-parancsot futtat (LLM és tmux nélkül), és Telegramon riaszt, ha N egymás utáni futás elhasal.
+
+A nyereség: ezek a könnyű infra-ellenőrzések **ugyanabban a rendszerben** élnek, amit a dashboard kezel és a Marveen store ment, nem egy külön, felügyelet nélküli crontabban.
+
+---
+
+## 🛠 Hogyan működik
+
+### Definíció
+
+A `command` feladatnak **nincs SKILL.md-je** — kizárólag a `task-config.json` írja le:
+
+```json
+{
+  "type": "command",
+  "schedule": "*/5 * * * *",
+  "command": "curl -fsS https://example.com/health",
+  "timeoutMs": 10000,
+  "failThreshold": 2,
+  "description": "example.com health"
+}
+```
+
+| Mező | Jelentés |
+|------|----------|
+| `command` | A `bash -lc`-en futtatott parancs. |
+| `timeoutMs` | Kemény timeout ms-ban (default 10000). A timeout hibának számít. |
+| `failThreshold` | Hány egymás utáni hiba után menjen riasztás (default 2). |
+
+### Riasztás-logika
+
+A hiba/helyreállás döntés **él-vezérelt** (`evaluateCommandResult`, tisztán unit-tesztelt):
+
+- egy sikeres futás nullázza a hiba-sorozatot,
+- **egy** riasztás megy, amikor a sorozat először eléri a `failThreshold`-ot,
+- amíg hibás marad, nincs ismételt riasztás,
+- **egy** helyreállás-üzenet megy, amikor egy korábban riasztott feladat újra sikeres.
+
+Így egy hosszú kiesés vagy egy flapping szolgáltatás is pontosan egy riasztást + egy helyreállást ad, nem futásonkénti spamet. Az állapot a `store/command-task-health.json`-ban perzisztált, így egy dashboard-restart nem nullázza a sorozatot és nem riaszt újra egy már ismert kiesésre.
+
+### Mikor érdemes
+
+`command` típus: nyelvi modellt nem igénylő, gyakran futó, gép-ellenőrizhető munka (HTTP/SMTP-próba, integritás-check, szkript). Ha a feladat ítéletet, szöveg-értelmezést vagy cselekvést igényel, a `task` / `heartbeat` (LLM) típus való rá.

--- a/docs/email-digest.md
+++ b/docs/email-digest.md
@@ -1,0 +1,61 @@
+# Email-digest (cím-alapú postafiók-triage)
+
+> A postafiók magától rendet tart: a szemét az Archive-ba kerül, a fontosak Telegramra pingelnek, és csak azt olvassa el egy modell, amit te kifejezetten engedélyezel.
+
+---
+
+## 🎯 Mit tud / miért érdekes
+
+Egy IMAP-postafiókot rendez a **feladó címe** alapján, három viselkedéssel:
+
+- **important** → minden új olvasatlan egyszer pingel Telegramon (feladó + tárgy + dátum), és bent marad az inboxban.
+- **archive** → az ilyen feladók levelei az Archive mappába kerülnek (mozgatás, sosem törlés), és bekerülnek a napi számszerű jelentésbe.
+- **ai_analysis** → cím-alapon nem eldönthető (monitoring-riasztás, rendszer-riport): ezeket egy LLM-task elolvassa és összefoglalja, mi történt.
+
+**A fő érv a privacy-modell.** A szűrés tisztán a feladó CÍME alapján történik -- a levél törzse és tárgya SOHA nem hagyja el a postafiókot egy LLM/felhő felé. Az **egyetlen** kivétel az `ai_analysis` allowlist, ahova te magad teszel be feladókat, kifejezetten azért, hogy a tartalmukat AI elemezze. Az IMAP-jelszó kizárólag a **vaultban** él, futásidőben kérdezi le a szkript -- nincs a repóban.
+
+---
+
+## 🛠 Hogyan működik
+
+### Szabályok (`store/email-rules.json`)
+
+A `store/` gitignore-olt, így a valódi listáid privátok maradnak. Egy lista-elem:
+
+- `@domain.com` → az egész domain ÉS az aldomainjei (`@shop.com` fogja a `news.shop.com`-ot is)
+- `valaki@ceg.com` → pontos feladó
+
+**Specificitás:** a pontos cím mindig erősebb a domainnél, bármelyik listában is van. Így egy domain mehet archívba, miközben pár cím belőle fontos marad (pl. `@social.example` archív, de `messages-noreply@social.example` fontos).
+
+**Carve-out-ok:**
+- A `\Flagged` (IMAP "fontos"/csillag) levelet SOSEM mozgatja -- bent marad az inboxban.
+- Az `ai_analysis` feladókat a watch békén hagyja (az AI-task kezeli).
+
+**Routes** (opcionális): feladó + tárgy-kulcsszó → tetszőleges mappa (+ping). Pl. egy webshop "order/shipped/tracking" tárgyú levele az `Orders` mappába. A tárgy CSAK lokálisan matchel, semmi nem megy ki.
+
+Indulj a mintából: másold a `scripts/email-digest/email-rules.example.json`-t `store/email-rules.json`-ba és írd át.
+
+### A három ütemezett feladat
+
+| Feladat | Típus | Ütemezés | Mit csinál |
+|---|---|---|---|
+| `email-watch` | command | `* * * * *` | Archivál/route-ol, pingeli az új fontosakat, triggereli az AI-review-t |
+| `email-daily-digest` | command | `0 8 * * *` | Napi számszerű archív-összesítő domainenként |
+| `email-ai-review` | task (LLM) | trigger-only | Elolvassa + összefoglalja az `ai_analysis` leveleket, archivál |
+
+A `watch` és a `daily` **command**-típusú (LLM nélküli) feladat -- olcsó, percenként futhat. Az `ai-review` egy LLM-task, amit a watch a **run-now** endpointon triggerel, amikor új `ai_analysis` levél jön (Message-ID dedup, 30 perc utáni újrapróba). Nincs órás időzítése (a febr-30 cron sosem fut).
+
+> Ez a feature a `command` task-típusra és a run-now endpointra épül -- mindkettő külön is dokumentált (lásd [Command-feladatok](command-tasks.md)).
+
+### Adatvédelmi határ
+
+A `--mode ai-dump` szkript-mód **kódból** a config `ai_analysis` listájára van korlátozva: csak ezektől a feladóktól olvas tartalmat. Minden más levélnél csak a fejléc (From/Subject/Date) kerül feldolgozásra, lokálisan.
+
+### Beüzemelés
+
+1. Tedd a postafiók IMAP-jelszavát a vaultba a `vault_key` alatt (alapból az email-cím).
+2. Másold a példa-configot `store/email-rules.json`-ba, töltsd fel a listáidat.
+3. A `.env`-ben legyen `TELEGRAM_BOT_TOKEN` és `ALLOWED_CHAT_ID` (ide mennek a pingek).
+4. Engedélyezd mind a három `email-*` ütemezett feladatot (alapból `enabled: false`).
+
+> A `command` parancsok a repo gyökeréből futnak (`python3 scripts/email-digest/digest.py ...`). Ha a dashboard nem onnan indul, írj abszolút útvonalat a `command` mezőbe.

--- a/scripts/email-digest/digest.py
+++ b/scripts/email-digest/digest.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Address-based email digest for any IMAP account in store/email-rules.json.
+
+Privacy-first: matches purely on the sender ADDRESS. No body or subject ever
+leaves the mailbox to an LLM/cloud -- the ONE exception is the `ai_analysis`
+allowlist (see below), whose content you explicitly opt into AI review for.
+Rules live in store/email-rules.json (`@domain.com` = whole domain incl.
+subdomains, `someone@company.com` = exact sender). The IMAP password lives
+ONLY in the vault, fetched at runtime via the dashboard API -- never stored
+in this repo. The Telegram chat is read from ALLOWED_CHAT_ID in .env.
+
+Run modes (each wired to a separate scheduled task):
+  --mode watch       (e.g. every minute): archive `archive`-rule mail into the
+                     Archive folder (move, never delete), route `routes` mail to
+                     custom folders, and Telegram-ping each NEW `important`
+                     unread ONCE (deduped by Message-ID). Also triggers the AI
+                     review (run-now) when a new `ai_analysis` mail arrives.
+  --mode daily       (e.g. 08:00): send the day's numeric archive summary (how
+                     many per domain) to Telegram and reset the tally.
+  --mode ai-dump     print the `ai_analysis` mail for the AI task to read.
+  --mode ai-archive  move the reviewed `ai_analysis` mail into Archive.
+
+Matching respects two carve-outs:
+  - \\Flagged (the IMAP "important"/star flag) -> never moved, stays in inbox.
+  - `ai_analysis` senders -> left for the AI review task, not address-filtered.
+"""
+import imaplib, json, email, email.utils, email.header, urllib.request, urllib.parse, pathlib, sys, time
+from collections import Counter
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CONFIG = ROOT / "store" / "email-rules.json"
+STATE = ROOT / "store" / "email-digest-state.json"      # notified important Message-IDs
+TALLY = ROOT / "store" / "email-archive-tally.json"     # archived-per-domain since last daily
+MAX_NOTIFIED = 3000    # cap the dedup ring so it cannot grow unbounded
+AI_TASK = "email-ai-review"   # scheduled task the watch triggers per new ai_analysis mail
+AI_RETRIGGER_SEC = 1800       # re-fire if a mail is still unread after 30 min (crash recovery)
+
+
+def _env(key, default=""):
+    envf = ROOT / ".env"
+    if envf.exists():
+        for line in envf.read_text().splitlines():
+            line = line.strip()
+            if line.startswith(key + "="):
+                return line[len(key) + 1:].strip().strip('"').strip("'")
+    return default
+
+
+def vault_password(vault_key):
+    tok = (ROOT / "store" / ".dashboard-token").read_text().strip()
+    port = _env("WEB_PORT", "3420")
+    url = f"http://localhost:{port}/api/vault/" + urllib.parse.quote(vault_key, safe="")
+    req = urllib.request.Request(url, headers={"Authorization": "Bearer " + tok})
+    return json.load(urllib.request.urlopen(req, timeout=10)).get("value", "")
+
+
+def telegram(text):
+    token = _env("TELEGRAM_BOT_TOKEN")
+    chat_id = _env("ALLOWED_CHAT_ID")
+    if not token or not chat_id:
+        print("no TELEGRAM_BOT_TOKEN / ALLOWED_CHAT_ID -- skip send"); return
+    data = urllib.parse.urlencode({"chat_id": chat_id, "text": text}).encode()
+    req = urllib.request.Request(f"https://api.telegram.org/bot{token}/sendMessage", data=data)
+    urllib.request.urlopen(req, timeout=15)
+
+
+def trigger_ai_task():
+    """Fire the AI-analysis scheduled task via run-now (delivers its SKILL prompt
+    to the agent, auto-starting it if down). Returns True on success."""
+    tok = (ROOT / "store" / ".dashboard-token").read_text().strip()
+    port = _env("WEB_PORT", "3420")
+    url = f"http://localhost:{port}/api/schedules/{AI_TASK}/run"
+    req = urllib.request.Request(url, data=b"{}", method="POST",
+                                 headers={"Authorization": "Bearer " + tok, "Content-Type": "application/json"})
+    try:
+        urllib.request.urlopen(req, timeout=20)
+        return True
+    except Exception as e:
+        print(f"AI-trigger HIBA: {e}", file=sys.stderr)
+        return False
+
+
+def _load_json(path, default):
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return default
+
+
+def matches(addr, rules):
+    addr = (addr or "").lower()
+    dom = addr.split("@")[-1] if "@" in addr else ""
+    for r in rules:
+        r = r.strip().lower()
+        if not r:
+            continue
+        if r.startswith("@"):
+            base = r[1:]
+            # Domain rule covers the domain itself AND its subdomains
+            # (@example.com -> info.example.com, mail.example.com, ...).
+            if dom == base or dom.endswith("." + base):
+                return True
+        elif r == addr:
+            return True
+    return False
+
+
+def _hdr(msg, name, default=""):
+    raw = msg.get(name, default)
+    try:
+        return str(email.header.make_header(email.header.decode_header(raw)))
+    except Exception:
+        return raw
+
+
+def _match_kind(addr, rules):
+    """How `addr` matches `rules`: 'exact' (full address) > 'domain' > None."""
+    addr = (addr or "").lower()
+    dom = addr.split("@")[-1] if "@" in addr else ""
+    best = None
+    for r in rules:
+        r = r.strip().lower()
+        if not r:
+            continue
+        if r.startswith("@"):
+            base = r[1:]
+            if dom == base or dom.endswith("." + base):
+                best = best or "domain"
+        elif r == addr:
+            return "exact"  # most specific -- can't be beaten
+    return best
+
+
+def classify(addr, important, archive):
+    """'important' / 'archive' / None by specificity: an exact-address rule beats
+    a domain rule in the other list (e.g. messages-noreply@social.example stays
+    important even though @social.example is archived). On a tie, important wins."""
+    rank = {"exact": 2, "domain": 1, None: 0}
+    ik, ak = _match_kind(addr, important), _match_kind(addr, archive)
+    if rank[ik] > rank[ak]:
+        return "important"
+    if rank[ak] > rank[ik]:
+        return "archive"
+    return "important" if ik else None
+
+
+def match_route(addr, subject, routes):
+    """First route whose sender matches and (if given) whose subject contains a
+    keyword. Subject is matched LOCALLY only (never sent anywhere)."""
+    subj = (subject or "").lower()
+    for rt in routes:
+        if not matches(addr, [rt.get("from", "")]):
+            continue
+        kws = rt.get("subject_contains") or []
+        if not kws or any(k.lower() in subj for k in kws):
+            return rt
+    return None
+
+
+def process_account(acct, important, archive, ai_rules, routes, notified):
+    """Returns (new_important, arch_counts). Mutates `notified` with seen Message-IDs."""
+    from collections import defaultdict
+    pw = vault_password(acct["vault_key"])
+    if not pw:
+        print(f"[{acct['email']}] no vault password -- skip"); return [], Counter()
+    M = imaplib.IMAP4_SSL(acct["imap_host"], int(acct.get("imap_port", 993)))
+    M.login(acct["email"], pw)
+    M.select("INBOX")  # read-write: we may move mail to Archive / route folders
+    # Candidates: all UNSEEN (for the important-ping + new mail) PLUS every mail
+    # (read or unread) from archive / route / ai senders, so already-READ junk
+    # and read alerts get handled too. The important-ping itself stays unseen-only.
+    typ, data = M.search(None, "UNSEEN")
+    unseen = set(data[0].split() if data and data[0] else [])
+    sender_terms = set()
+    for r in archive:
+        sender_terms.add((r[1:] if r.startswith("@") else r).strip().lower())
+    for rt in routes:
+        f = rt.get("from", "")
+        sender_terms.add((f[1:] if f.startswith("@") else f).strip().lower())
+    for r in ai_rules:
+        sender_terms.add((r[1:] if r.startswith("@") else r).strip().lower())
+    cand = set(unseen)
+    for term in sender_terms:
+        if not term:
+            continue
+        typ, d = M.search(None, "FROM", term)
+        if typ == "OK" and d and d[0]:
+            cand.update(d[0].split())
+    archive_folder = acct.get("archive_folder", "Archive")
+    new_important, moves, arch_counts, ai_unread = [], defaultdict(list), Counter(), []
+    for mid in cand:
+        # FLAGS + headers only. BODY.PEEK so the unread flag is NOT cleared.
+        typ, parts = M.fetch(mid, "(FLAGS BODY.PEEK[HEADER.FIELDS (FROM SUBJECT DATE MESSAGE-ID)])")
+        if typ != "OK" or not parts or not parts[0]:
+            continue
+        meta = parts[0][0] or b""
+        flagged = b"\\Flagged" in meta  # Thunderbird "important"/star
+        msg = email.message_from_bytes(parts[0][1])
+        addr = email.utils.parseaddr(msg.get("From", ""))[1]
+        dom = addr.split("@")[-1].lower() if "@" in addr else ""
+        subj = _hdr(msg, "Subject", "(nincs targy)")
+        date = msg.get("Date", "")[:25]
+        if matches(addr, ai_rules):
+            # Left in the inbox for the AI task; record its Message-ID so the
+            # watch can trigger a per-email analysis (deduped) for new ones.
+            msgid = (msg.get("Message-ID") or msg.get("Message-Id") or "").strip() or f"{addr}|{date}"
+            ai_unread.append(msgid)
+            continue
+        if flagged:
+            continue  # Thunderbird-important stays in the inbox, untouched
+        rt = match_route(addr, subj, routes)
+        if rt:
+            moves[rt.get("folder", archive_folder)].append(mid)
+            if rt.get("notify") and mid in unseen:  # ping only new (unread) ones
+                new_important.append({"from": addr, "subject": subj[:80], "date": date,
+                                      "folder": rt.get("folder")})
+            continue
+        kind = classify(addr, important, archive)
+        if kind == "archive":
+            moves[archive_folder].append(mid)
+            arch_counts[dom] += 1
+        elif kind == "important" and mid in unseen:
+            # Only ping unread important; a read one (e.g. surfaced by the sender
+            # search) stays in the inbox untouched.
+            msgid = (msg.get("Message-ID") or msg.get("Message-Id") or "").strip()
+            key = msgid or f"{addr}|{subj}|{date}"
+            if key in notified:
+                continue
+            notified.add(key)
+            new_important.append({"from": addr, "subject": subj[:80], "date": date})
+    for folder, mids in moves.items():
+        ids_str = b",".join(mids).decode()
+        M.copy(ids_str, folder)
+        M.store(ids_str, "+FLAGS", "\\Deleted")
+    if moves:
+        M.expunge()
+    M.logout()
+    moved = sum(len(v) for v in moves.values())
+    print(f"[{acct['email']}] {len(new_important)} uj fontos, {moved} mozgatva ({sum(arch_counts.values())} archiv)")
+    return new_important, arch_counts, ai_unread
+
+
+def run_watch(cfg):
+    important = cfg.get("important", [])
+    archive = cfg.get("archive", [])
+    ai_rules = cfg.get("ai_analysis", [])
+    routes = cfg.get("routes", [])
+    state = _load_json(STATE, {})
+    notified = set(state.get("notified", []))
+    ai_triggered = dict(state.get("ai_triggered", {}))  # Message-ID -> epoch last triggered
+    tally = Counter(_load_json(TALLY, {}))
+    all_new, ai_seen = [], []
+    for acct in cfg.get("accounts", []):
+        try:
+            new_imp, counts, ai_unread = process_account(acct, important, archive, ai_rules, routes, notified)
+            all_new += [(acct["email"], f) for f in new_imp]
+            tally += counts
+            ai_seen += ai_unread
+        except Exception as e:
+            print(f"[{acct.get('email')}] HIBA: {e}", file=sys.stderr)
+    # Per-email AI trigger: fire for any alert not triggered recently (new, or
+    # still unread 30 min after a trigger that apparently did not finish).
+    now = time.time()
+    due = [m for m in ai_seen if now - ai_triggered.get(m, 0) > AI_RETRIGGER_SEC]
+    if due:
+        if trigger_ai_task():
+            for m in ai_seen:
+                ai_triggered[m] = now
+            print(f"AI-review triggerelve ({len(due)} uj/lejart level)")
+    # Drop trigger records for alerts no longer unread (analyzed + archived).
+    ai_triggered = {m: t for m, t in ai_triggered.items() if m in ai_seen}
+    # Persist dedup ring (trimmed) + AI trigger state + running archive tally.
+    STATE.write_text(json.dumps({"notified": list(notified)[-MAX_NOTIFIED:], "ai_triggered": ai_triggered}))
+    TALLY.write_text(json.dumps(dict(tally)))
+    if all_new:
+        lines = [f"Fontos olvasatlan ({len(all_new)}):", ""]
+        for _box, f in all_new:
+            tag = f"  [-> {f['folder']}]" if f.get("folder") else ""
+            lines.append(f"- {f['from']}\n  {f['subject']}\n  {f['date']}{tag}")
+        telegram("\n".join(lines))
+        print("Fontos-ping elkuldve")
+    else:
+        print("nincs uj fontos -- nincs Telegram")
+
+
+def run_daily(cfg):
+    tally = Counter(_load_json(TALLY, {}))
+    if not tally:
+        telegram("Email napi osszesito: az elmult 24 oraban nem volt archivalando level.")
+        print("ures tally -- 'semmi' uzenet"); return
+    lines = [f"Email napi osszesito -- archivalva ({sum(tally.values())}):", ""]
+    for dom, n in sorted(tally.items(), key=lambda x: -x[1]):
+        lines.append(f"- {dom}: {n}")
+    telegram("\n".join(lines))
+    TALLY.write_text(json.dumps({}))  # reset for the next day
+    print("Napi osszesito elkuldve + tally reset")
+
+
+def _body_text(msg, limit=4000):
+    """Plain-text body (fallback: HTML stripped). Used ONLY by the AI-analysis
+    dump, which is restricted to ai_analysis senders -- no other mail's content
+    is ever read out."""
+    import re as _re
+    def dec(part):
+        try:
+            return (part.get_payload(decode=True) or b"").decode(part.get_content_charset() or "utf-8", "replace")
+        except Exception:
+            return ""
+    text = ""
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                text += dec(part) + "\n"
+        if not text.strip():
+            for part in msg.walk():
+                if part.get_content_type() == "text/html":
+                    text += _re.sub("<[^>]+>", " ", dec(part)) + "\n"
+    else:
+        text = dec(msg)
+    text = _re.sub(r"[ \t]+", " ", text)
+    return text.strip()[:limit]
+
+
+def _ai_candidate_uids(M, ai_rules):
+    """All mail (READ or unread) from ai_analysis senders in the selected box --
+    AI review is needed regardless of read status."""
+    cand = set()
+    for r in ai_rules:
+        term = (r[1:] if r.startswith("@") else r).strip()
+        if not term:
+            continue
+        typ, d = M.search(None, "FROM", term)
+        if typ == "OK" and d and d[0]:
+            cand.update(d[0].split())
+    return sorted(cand, key=lambda b: int(b))
+
+
+def run_ai_dump(cfg):
+    """Print the ai_analysis mail (From/Date/Subject/Body) for the LLM task to
+    analyze. Hard-restricted to the ai_analysis senders -- nothing else is ever
+    dumped. BODY.PEEK keeps the unread flag so a failed run loses nothing."""
+    ai_rules = cfg.get("ai_analysis", [])
+    if not ai_rules:
+        print("nincs ai_analysis szabaly a configban"); return
+    total = 0
+    for acct in cfg.get("accounts", []):
+        pw = vault_password(acct["vault_key"])
+        if not pw:
+            continue
+        M = imaplib.IMAP4_SSL(acct["imap_host"], int(acct.get("imap_port", 993)))
+        M.login(acct["email"], pw); M.select("INBOX")
+        for mid in _ai_candidate_uids(M, ai_rules):
+            typ, p = M.fetch(mid, "(BODY.PEEK[])")
+            if typ != "OK" or not p or not p[0]:
+                continue
+            msg = email.message_from_bytes(p[0][1])
+            addr = email.utils.parseaddr(msg.get("From", ""))[1]
+            if not matches(addr, ai_rules):
+                continue  # safety: only ever read ai_analysis senders
+            total += 1
+            print(f"=== AI-REVIEW #{total} ===")
+            print(f"From: {addr}")
+            print(f"Date: {msg.get('Date', '')}")
+            print(f"Subject: {_hdr(msg, 'Subject')}")
+            print("Body:")
+            print(_body_text(msg))
+            print()
+        M.logout()
+    if total == 0:
+        print("NINCS olvasatlan ai_analysis level")
+
+
+def run_ai_archive(cfg):
+    """Move the UNREAD ai_analysis mail to Archive (call after analysis)."""
+    ai_rules = cfg.get("ai_analysis", [])
+    moved = 0
+    for acct in cfg.get("accounts", []):
+        pw = vault_password(acct["vault_key"])
+        if not pw:
+            continue
+        M = imaplib.IMAP4_SSL(acct["imap_host"], int(acct.get("imap_port", 993)))
+        M.login(acct["email"], pw); M.select("INBOX")
+        to_move = []
+        for mid in _ai_candidate_uids(M, ai_rules):
+            typ, p = M.fetch(mid, "(BODY.PEEK[HEADER.FIELDS (FROM)])")
+            if typ != "OK" or not p or not p[0]:
+                continue
+            addr = email.utils.parseaddr(email.message_from_bytes(p[0][1]).get("From", ""))[1]
+            if matches(addr, ai_rules):  # safety: FROM search is substring, re-verify
+                to_move.append(mid)
+        if to_move:
+            af = acct.get("archive_folder", "Archive")
+            ids_str = b",".join(to_move).decode()
+            M.copy(ids_str, af); M.store(ids_str, "+FLAGS", "\\Deleted"); M.expunge()
+            moved += len(to_move)
+        M.logout()
+    print(f"{moved} ai_analysis level archivalva")
+
+
+def main():
+    mode = "watch"
+    if "--mode" in sys.argv:
+        mode = sys.argv[sys.argv.index("--mode") + 1]
+    cfg = json.loads(CONFIG.read_text())
+    if mode == "daily":
+        run_daily(cfg)
+    elif mode == "ai-dump":
+        run_ai_dump(cfg)
+    elif mode == "ai-archive":
+        run_ai_archive(cfg)
+    else:
+        run_watch(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/email-digest/email-rules.example.json
+++ b/scripts/email-digest/email-rules.example.json
@@ -1,0 +1,32 @@
+{
+  "_format": "Copy this file to store/email-rules.json and edit it (store/ is gitignored, so your real sender lists stay private). A list entry is either '@domain.com' (the whole domain AND its subdomains) or 'someone@company.com' (exact sender). SPECIFICITY: an exact address always beats a domain rule, in either list -- so a domain can go to archive while a few addresses from it stay important. important -> Telegram ping (once per mail, deduped) + stays in inbox. archive -> moved to the Archive folder (never deleted) + counted in the daily numeric report. ai_analysis -> left for the AI review task (the watch triggers it via run-now); this is the ONLY content that reaches an LLM. routes -> sender (+ optional subject_contains keyword) moves the mail to a custom folder, and pings if notify=true; the subject is matched LOCALLY, nothing is sent anywhere. A mail flagged '\\Flagged' (the IMAP important/star flag) is NEVER moved -- it stays in the inbox. The IMAP password is NOT here: store it in the vault under vault_key and the script fetches it at runtime.",
+  "accounts": [
+    {
+      "email": "you@example.com",
+      "vault_key": "you@example.com",
+      "imap_host": "mail.example.com",
+      "imap_port": 993,
+      "archive_folder": "Archive"
+    }
+  ],
+  "important": [
+    "@bank.example",
+    "boss@work.example"
+  ],
+  "archive": [
+    "@newsletter.example",
+    "@promo.example",
+    "notifications-noreply@social.example"
+  ],
+  "ai_analysis": [
+    "alerts@monitoring.example"
+  ],
+  "routes": [
+    {
+      "from": "@shop.example",
+      "subject_contains": ["order", "shipped", "tracking", "delivery"],
+      "folder": "Orders",
+      "notify": true
+    }
+  ]
+}

--- a/scripts/email-digest/test_digest.py
+++ b/scripts/email-digest/test_digest.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Dependency-free tests for the email-digest pure matching logic.
+
+Run: python3 scripts/email-digest/test_digest.py  (exit 0 = all passed)
+Covers the rules that decide where a mail goes, WITHOUT touching IMAP/network:
+  - domain rules cover subdomains
+  - an exact-address rule beats a domain rule in the OTHER list (specificity)
+  - routes match on sender + optional local subject keyword
+"""
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import digest  # noqa: E402
+
+failures = []
+def check(name, cond):
+    print(f"{'ok  ' if cond else 'FAIL'}  {name}")
+    if not cond:
+        failures.append(name)
+
+
+# --- matches(): domain covers subdomains; exact is exact -----------------
+check("domain rule matches the domain itself",
+      digest.matches("a@shop.com", ["@shop.com"]))
+check("domain rule matches a subdomain",
+      digest.matches("a@news.shop.com", ["@shop.com"]))
+check("domain rule does NOT match a lookalike suffix",
+      not digest.matches("a@notshop.com", ["@shop.com"]))
+check("exact rule matches only that address",
+      digest.matches("boss@work.com", ["boss@work.com"])
+      and not digest.matches("other@work.com", ["boss@work.com"]))
+
+# --- classify(): specificity (exact beats domain across lists) -----------
+important = ["messages@social.com"]
+archive = ["@social.com"]
+check("exact important beats domain archive",
+      digest.classify("messages@social.com", important, archive) == "important")
+check("domain archive still applies to other senders",
+      digest.classify("ads@social.com", important, archive) == "archive")
+check("unmatched address classifies as None",
+      digest.classify("nobody@elsewhere.com", important, archive) is None)
+check("on a tie (both domain) important wins",
+      digest.classify("x@dual.com", ["@dual.com"], ["@dual.com"]) == "important")
+
+# --- match_route(): sender + optional local subject keyword --------------
+routes = [{"from": "@shop.com",
+           "subject_contains": ["order", "shipped"],
+           "folder": "Orders", "notify": True}]
+check("route matches sender + subject keyword",
+      digest.match_route("x@shop.com", "Your order shipped", routes) is not None)
+check("route does NOT match when subject keyword absent",
+      digest.match_route("x@shop.com", "Weekend sale!", routes) is None)
+check("route does NOT match a different sender",
+      digest.match_route("x@other.com", "Your order shipped", routes) is None)
+route_no_kw = [{"from": "@shop.com", "folder": "Orders"}]
+check("route with no subject_contains matches any subject",
+      digest.match_route("x@shop.com", "anything", route_no_kw) is not None)
+
+print()
+if failures:
+    print(f"{len(failures)} FAILED: {failures}")
+    sys.exit(1)
+print("all passed")

--- a/seed-scheduled-tasks/email-ai-review/SKILL.md
+++ b/seed-scheduled-tasks/email-ai-review/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: email-ai-review
+description: Per-email AI review of the `ai_analysis` senders in store/email-rules.json. Triggered by the email-watch task (via run-now) when a new such mail arrives -- not on a clock. Reads the mail, summarizes WHAT happened (benign vs needs-attention), sends it to Telegram, then archives it.
+---
+
+# Email AI review (ai_analysis senders)
+
+## When / purpose
+Event-driven: the per-minute `email-watch` task fires this one through the
+run-now endpoint as soon as a new unread mail from an `ai_analysis` sender
+arrives (deduped by Message-ID, re-fired after 30 min if still unread). The
+`ai_analysis` list is for senders whose mail cannot be triaged by address
+alone -- monitoring alerts, system reports, anything you need to actually read.
+This task is the ONLY place email CONTENT reaches the LLM, and only for these
+explicitly-listed senders (the dump script is hard-restricted to the config's
+`ai_analysis` list).
+
+## Procedure
+
+1. **Read the mail** (dumps only the `ai_analysis` unread, BODY.PEEK -- does not
+   mark them read):
+```bash
+python3 scripts/email-digest/digest.py --mode ai-dump
+```
+
+2. **Analyze.**
+   - If the output is `NINCS olvasatlan ai_analysis level`, reply with one short
+     line ("AI review: nothing new") and skip to step 4 (ai-archive will move 0).
+   - Otherwise, give a short per-mail summary: WHAT happened, and your verdict --
+     **benign** (routine / no action) or **NEEDS ATTENTION** (a real problem).
+     Make anything genuinely concerning stand out. Be terse and factual; do not
+     paste the full body, just the essence.
+
+3. **The summary is your reply** -- it goes to Telegram (this is a `task`-type
+   scheduled task). Keep it short.
+
+## Pitfalls
+- The dump uses BODY.PEEK: if the run is interrupted, the mail stays unread and
+  is not lost.
+- Only `ai_analysis` senders are ever dumped -- never widen this to other mail.
+
+## Verify / close
+4. **Archive** the reviewed mail (moves only `ai_analysis` senders into the
+   Archive folder, never deletes):
+```bash
+python3 scripts/email-digest/digest.py --mode ai-archive
+```
+Run this only AFTER the analysis. If step 2 found nothing, it moves 0 -- fine.

--- a/seed-scheduled-tasks/email-ai-review/task-config.json
+++ b/seed-scheduled-tasks/email-ai-review/task-config.json
@@ -1,0 +1,8 @@
+{
+  "schedule": "0 0 30 2 *",
+  "enabled": false,
+  "type": "task",
+  "skipIfBusy": false,
+  "createdAt": 0,
+  "_comment": "Trigger-only AI review. Fired by the email-watch task via run-now (POST /api/schedules/email-ai-review/run) when a new ai_analysis mail arrives -- not on a clock. The Feb-30 cron never matches, so there is no time-based run. `agent` is omitted, so it targets the main agent; set it to a specific agent if you prefer. Note: enabled must be true for run-now to deliver, so flip this to true when you opt into the email feature."
+}

--- a/seed-scheduled-tasks/email-daily-digest/task-config.json
+++ b/seed-scheduled-tasks/email-daily-digest/task-config.json
@@ -1,0 +1,10 @@
+{
+  "schedule": "0 8 * * *",
+  "agent": "system",
+  "type": "command",
+  "enabled": false,
+  "command": "python3 scripts/email-digest/digest.py --mode daily",
+  "timeoutMs": 120000,
+  "failThreshold": 3,
+  "description": "Daily email digest: numeric archive summary per domain to Telegram, then reset the tally. Address-based, store/email-rules.json."
+}

--- a/seed-scheduled-tasks/email-watch/task-config.json
+++ b/seed-scheduled-tasks/email-watch/task-config.json
@@ -1,0 +1,10 @@
+{
+  "schedule": "* * * * *",
+  "agent": "system",
+  "type": "command",
+  "enabled": false,
+  "command": "python3 scripts/email-digest/digest.py --mode watch",
+  "timeoutMs": 60000,
+  "failThreshold": 5,
+  "description": "Email watch: move archive/route-rule senders out of the inbox, ping each new important unread once, and trigger the AI review per new ai_analysis mail. Address-based, store/email-rules.json. Disabled until you create the rules + vault password; then enable all three email tasks."
+}

--- a/src/__tests__/command-task-eval.test.ts
+++ b/src/__tests__/command-task-eval.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateCommandResult, type CommandHealth } from '../web/command-task.js'
+
+// Unit tests for the command-task failure/recovery policy. This is the
+// decision core behind type='command' scheduled tasks (raw shell health
+// checks). The rules under test:
+//   - a success zeroes the consecutive-failure streak
+//   - an alert fires exactly ONCE, when the streak first hits failThreshold
+//   - while still failing past the threshold, no repeat alerts
+//   - a recover fires exactly ONCE, when a previously-alerted task succeeds
+const T = 1_000
+
+describe('evaluateCommandResult', () => {
+  it('returns no action on the first failure below threshold', () => {
+    const { next, action } = evaluateCommandResult(undefined, false, 2, T)
+    expect(action).toBe('none')
+    expect(next.fails).toBe(1)
+    expect(next.alerted).toBe(false)
+    expect(next.lastStatus).toBe('fail')
+  })
+
+  it('alerts exactly when the streak first reaches the threshold', () => {
+    const prev: CommandHealth = { fails: 1, alerted: false, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, false, 2, T)
+    expect(action).toBe('alert')
+    expect(next.fails).toBe(2)
+    expect(next.alerted).toBe(true)
+  })
+
+  it('does not re-alert while already alerted and still failing', () => {
+    const prev: CommandHealth = { fails: 2, alerted: true, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, false, 2, T)
+    expect(action).toBe('none')
+    expect(next.fails).toBe(3)
+    expect(next.alerted).toBe(true)
+  })
+
+  it('recovers exactly once when a previously-alerted task succeeds', () => {
+    const prev: CommandHealth = { fails: 3, alerted: true, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, true, 2, T)
+    expect(action).toBe('recover')
+    expect(next.fails).toBe(0)
+    expect(next.alerted).toBe(false)
+    expect(next.lastStatus).toBe('ok')
+  })
+
+  it('stays silent on success when not previously alerted', () => {
+    const prev: CommandHealth = { fails: 1, alerted: false, lastStatus: 'fail', lastRun: 0 }
+    const { next, action } = evaluateCommandResult(prev, true, 2, T)
+    expect(action).toBe('none')
+    expect(next.fails).toBe(0)
+  })
+
+  it('respects a custom failThreshold greater than 2', () => {
+    let prev: CommandHealth | undefined
+    const actions: string[] = []
+    for (let i = 0; i < 3; i++) {
+      const r = evaluateCommandResult(prev, false, 3, T)
+      prev = r.next
+      actions.push(r.action)
+    }
+    expect(actions).toEqual(['none', 'none', 'alert'])
+  })
+})

--- a/src/__tests__/schedule-run-now.test.ts
+++ b/src/__tests__/schedule-run-now.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for the "Run now" feature: an operator can fire a scheduled
+// task immediately from the dashboard, instead of waiting for its cron (or
+// hand-editing the cron to the next minute). It reuses the runner's fire path
+// (attemptFireTask), so a stopped agent is auto-started and the prompt is
+// queued for delivery just like a real cron fire.
+
+const RUNNER = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+const ROUTE = readFileSync(join(__dirname, '../web/routes/schedules.ts'), 'utf-8')
+const APP = readFileSync(join(__dirname, '../../web/app.js'), 'utf-8')
+
+describe('Run now: runner exports an immediate-fire entry point', () => {
+  it('schedule-runner exports runScheduledTaskNow', () => {
+    expect(RUNNER).toMatch(/export function runScheduledTaskNow\(/)
+  })
+
+  it('a manual run delivers regardless of skipIfBusy (always enqueues on starting/busy)', () => {
+    const fn = RUNNER.slice(RUNNER.indexOf('export function runScheduledTaskNow('))
+    const body = fn.slice(0, fn.indexOf('\n}\n') + 3)
+    // Reuses the real fire path...
+    expect(body).toMatch(/attemptFireTask\(/)
+    // ...and queues delivery for both an auto-started ('starting') and a busy
+    // session, WITHOUT consulting task.skipIfBusy (that's a cron-cadence knob).
+    expect(body).toMatch(/insertPendingTaskRetryIfNew/)
+    expect(body).not.toMatch(/task\.skipIfBusy/)
+  })
+})
+
+describe('Run now: REST route', () => {
+  it('schedules route handles POST /api/schedules/{name}/run', () => {
+    // The route matcher ends in `/run$/` and delegates to the runner.
+    expect(ROUTE).toMatch(/\/run\$\//)
+    expect(ROUTE).toMatch(/runScheduledTaskNow/)
+  })
+})
+
+describe('Run now: dashboard button', () => {
+  it('schedule row has a run action wired to the run endpoint', () => {
+    expect(APP).toMatch(/data-action="run"/)
+    expect(APP).toMatch(/\/api\/schedules\/\$\{encodeURIComponent\(task\.name\)\}\/run/)
+  })
+})

--- a/src/__tests__/schedule-runner-autostart.test.ts
+++ b/src/__tests__/schedule-runner-autostart.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for auto-starting a stopped agent for its scheduled task.
+//
+// Without this, a daily/intermittent agent that has no 24/7 tmux session can
+// never run a scheduled task: when its cron fired, attemptFireTask found the
+// session missing and returned 'missing' -- a silent skip. The task was
+// enabled and scheduled but could never fire.
+//
+// Fix: when the session is missing, START the agent and return a distinct
+// 'starting' state. The caller enqueues a retry that delivers the prompt on a
+// later tick once the session is ready. That retry must bypass skipIfBusy (we
+// deliberately woke the agent for its run), and a global cap bounds runaway
+// relaunches of a task that never reaches a ready state.
+
+const SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+
+describe('schedule-runner auto-starts a stopped agent for its scheduled task', () => {
+  it('attemptFireTask can return a distinct "starting" state', () => {
+    // The return union must carry 'starting' so the caller can tell an
+    // auto-start apart from a genuine busy session.
+    const sig = SRC.slice(SRC.indexOf('function attemptFireTask'))
+    expect(sig.slice(0, 400)).toMatch(/'starting'/)
+  })
+
+  it('the missing-session branch auto-starts the agent instead of skipping', () => {
+    // Locate the sessionExists guard and assert it now launches the agent.
+    const guardIdx = SRC.indexOf('if (!sessionExists) {')
+    expect(guardIdx).toBeGreaterThan(0)
+    const missingBlock = SRC.slice(guardIdx, guardIdx + 1200)
+    expect(missingBlock).toMatch(/startAgentProcess\(agentName\)/)
+    expect(missingBlock).toMatch(/return 'starting'/)
+    // A failed start must fall back to 'missing' (skip this tick), not throw.
+    expect(missingBlock).toMatch(/return 'missing'/)
+  })
+
+  it('the cron loop enqueues a retry for "starting" WITHOUT the skipIfBusy gate', () => {
+    // The cron-loop branch that handles a 'starting' result must insert a
+    // pending retry, and must NOT be guarded by task.skipIfBusy (otherwise a
+    // skipIfBusy=true task would auto-start the agent and then drop the
+    // delivery -- defeating the whole point). runScheduledTaskNow also
+    // references 'starting', but in an `|| result === 'busy'` form, so target
+    // the standalone cron branch specifically.
+    const startingIdx = SRC.indexOf("if (result === 'starting') {")
+    expect(startingIdx).toBeGreaterThan(0)
+    const busyHandlingIdx = SRC.indexOf("result === 'busy'", startingIdx)
+    expect(busyHandlingIdx).toBeGreaterThan(startingIdx)
+    const startingBranch = SRC.slice(startingIdx, busyHandlingIdx)
+    expect(startingBranch).toMatch(/insertPendingTaskRetryIfNew/)
+    // No `task.skipIfBusy` code form in this branch (a comment mention is ok).
+    expect(startingBranch).not.toMatch(/task\.skipIfBusy/)
+  })
+
+  it('bounds runaway retries so a stuck task cannot perpetually relaunch its agent', () => {
+    // A retry that never resolves used to relaunch the agent forever. The
+    // pending-retry loop must abandon after a fixed cap.
+    expect(SRC).toMatch(/MAX_RETRY_ATTEMPTS\s*=\s*\d+/)
+    expect(SRC).toMatch(/attempt_count\s*>=\s*MAX_RETRY_ATTEMPTS/)
+  })
+})

--- a/src/web/command-task.ts
+++ b/src/web/command-task.ts
@@ -1,0 +1,122 @@
+import { spawnSync } from "node:child_process"
+import { join } from "node:path"
+import { readFileSync } from "node:fs"
+import { STORE_DIR, TELEGRAM_BOT_TOKEN, ALLOWED_CHAT_ID } from "../config.js"
+import { atomicWriteFileSync } from "./atomic-write.js"
+import { logger } from "../logger.js"
+import { sendTelegramMessage } from "./telegram.js"
+import { appendTaskRun } from "../db.js"
+import type { ScheduledTask } from "./scheduled-tasks-io.js"
+
+// `command`-type scheduled tasks run a raw shell command directly (no LLM
+// agent, no tmux session) and alert on Telegram after N consecutive failures.
+// This keeps lightweight infra checks (HTTP probes, SMTP reachability, custom
+// scripts) inside the one system that already gets scheduled + backed up (the
+// Marveen store) instead of a separate, unmonitored crontab.
+//
+// A `command` task is defined entirely by its task-config.json -- it needs no
+// SKILL.md, because there is no prompt and no agent. Minimal config:
+//   { "type": "command", "schedule": "*/5 * * * *",
+//     "command": "curl -fsS https://example.com/health",
+//     "timeoutMs": 10000, "failThreshold": 2 }
+
+const HEALTH_PATH = join(STORE_DIR, "command-task-health.json")
+
+export interface CommandHealth {
+  fails: number          // consecutive-failure streak (0 when healthy)
+  alerted: boolean       // a failure alert is currently outstanding
+  lastStatus: "ok" | "fail" | "unknown"
+  lastRun: number
+}
+type HealthMap = Record<string, CommandHealth>
+
+// Health is persisted (not just in-memory) so a dashboard restart does not
+// reset failure streaks and re-alert on an already-known outage.
+let healthMap: HealthMap | null = null
+function load(): HealthMap {
+  if (healthMap) return healthMap
+  try { healthMap = JSON.parse(readFileSync(HEALTH_PATH, "utf-8")) as HealthMap }
+  catch { healthMap = {} }
+  return healthMap
+}
+function persist(): void {
+  try { atomicWriteFileSync(HEALTH_PATH, JSON.stringify(healthMap ?? {}, null, 2)) }
+  catch (err) { logger.warn({ err }, "command-task: failed to persist health map") }
+}
+
+export type CommandAction = "none" | "alert" | "recover"
+
+// Pure decision function so the failure/recovery policy is unit-testable
+// without spawning processes. success=true zeroes the streak; an alert fires
+// exactly once when the streak first reaches failThreshold; a recover fires
+// once when a previously-alerted task succeeds again. This "edge-triggered"
+// design means a flapping or long outage produces one alert + one recovery,
+// never a per-tick stream.
+export function evaluateCommandResult(
+  prev: CommandHealth | undefined,
+  success: boolean,
+  failThreshold: number,
+  now: number,
+): { next: CommandHealth; action: CommandAction } {
+  const wasAlerted = prev?.alerted ?? false
+  const fails = success ? 0 : (prev?.fails ?? 0) + 1
+  let action: CommandAction = "none"
+  let alerted = wasAlerted
+  if (success) {
+    if (wasAlerted) { action = "recover"; alerted = false }
+  } else if (fails >= failThreshold && !wasAlerted) {
+    action = "alert"; alerted = true
+  }
+  return {
+    next: { fails, alerted, lastStatus: success ? "ok" : "fail", lastRun: now },
+    action,
+  }
+}
+
+// Run the command through `bash -lc` with a hard timeout. A non-zero exit, a
+// spawn error, or a timeout all count as a failure; the first 200 chars of
+// stderr are surfaced into the alert detail.
+function runCommand(cmd: string, timeoutMs: number): { ok: boolean; detail: string } {
+  try {
+    const r = spawnSync("bash", ["-lc", cmd], { timeout: timeoutMs, encoding: "utf-8" })
+    if (r.error) {
+      const code = (r.error as NodeJS.ErrnoException).code
+      if (code === "ETIMEDOUT") return { ok: false, detail: `timeout ${timeoutMs}ms` }
+      return { ok: false, detail: r.error.message }
+    }
+    if (r.status === 0) return { ok: true, detail: "exit 0" }
+    const err = (r.stderr || "").trim().slice(0, 200)
+    return { ok: false, detail: `exit ${r.status}${err ? ": " + err : ""}` }
+  } catch (err) {
+    return { ok: false, detail: (err as Error).message }
+  }
+}
+
+export function runCommandTask(task: ScheduledTask, now: number): void {
+  if (!task.command) {
+    logger.warn({ task: task.name }, "command task has no command, skipping")
+    return
+  }
+  const timeoutMs = task.timeoutMs && task.timeoutMs > 0 ? task.timeoutMs : 10_000
+  const failThreshold = task.failThreshold && task.failThreshold > 0 ? task.failThreshold : 2
+  const map = load()
+  const { ok, detail } = runCommand(task.command, timeoutMs)
+  const { next, action } = evaluateCommandResult(map[task.name], ok, failThreshold, now)
+  map[task.name] = next
+  persist()
+  try { appendTaskRun(task.name, task.agent || "system") } catch { /* non-fatal */ }
+  logger.info({ task: task.name, ok, detail, fails: next.fails, action }, "command task ran")
+
+  if (action === "none") return
+  if (!TELEGRAM_BOT_TOKEN || !ALLOWED_CHAT_ID) {
+    logger.warn({ task: task.name }, "command task alert suppressed: missing token/chat_id")
+    return
+  }
+  const label = task.description || task.name
+  const text = action === "alert"
+    ? `[Marveen scheduler] Hiba: ${label} nem valaszol (${next.fails}. egymas utani hiba). Reszlet: ${detail}`
+    : `[Marveen scheduler] Helyreallt: ${label} ismet OK.`
+  sendTelegramMessage(TELEGRAM_BOT_TOKEN, ALLOWED_CHAT_ID, text)
+    .then(() => logger.info({ task: task.name, action }, "command task alert sent"))
+    .catch((err) => logger.warn({ err, task: task.name }, "command task alert send failed"))
+}

--- a/src/web/routes/schedules.ts
+++ b/src/web/routes/schedules.ts
@@ -17,6 +17,7 @@ import {
   SCHEDULED_TASKS_DIR, MAX_SCHEDULED_TASK_PROMPT_LEN,
   listScheduledTasks, writeScheduledTask,
 } from '../scheduled-tasks-io.js'
+import { runScheduledTaskNow } from '../schedule-runner.js'
 import type { RouteContext } from './types.js'
 
 export async function tryHandleSchedules(ctx: RouteContext): Promise<boolean> {
@@ -202,6 +203,20 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
     atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
     logger.info({ name, enabled: newEnabled }, 'Scheduled task toggled')
     json(res, { ok: true, enabled: newEnabled })
+    return true
+  }
+
+  // Fire a scheduled task immediately, regardless of its cron schedule. The
+  // runner auto-starts the target agent if it is down and queues delivery.
+  const scheduleRunMatch = path.match(/^\/api\/schedules\/([^/]+)\/run$/)
+  if (scheduleRunMatch && method === 'POST') {
+    const name = decodeURIComponent(scheduleRunMatch[1])
+    const dir = join(SCHEDULED_TASKS_DIR, name)
+    if (!existsSync(dir)) { json(res, { error: 'Schedule not found' }, 404); return true }
+    const result = runScheduledTaskNow(name)
+    if (!result.ok) { json(res, { error: result.error }, 400); return true }
+    logger.info({ name, result: result.result }, 'Scheduled task run-now fired')
+    json(res, { ok: true, result: result.result })
     return true
   }
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -35,6 +35,7 @@ import {
   isAgentRunning,
   isSessionReadyForPrompt,
   sendPromptToSession,
+  startAgentProcess,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
@@ -83,10 +84,20 @@ function persistScheduleLastRun(): void {
   }
 }
 
+// Bound runaway retries so a permanently-busy task -- or one whose agent is
+// auto-started but never reaches a ready state -- cannot spin (and relaunch
+// its agent) forever. After this many attempts the pending retry is dropped.
+const MAX_RETRY_ATTEMPTS = 15
+
 // Try to fire a task at a single target agent. Returns the outcome so the
 // caller can decide whether to queue a retry. Splitting this out means the
 // pendingTaskRetries loop and the normal cron loop share one code path.
-function attemptFireTask(task: ScheduledTask, agentName: string, now: number): 'fired' | 'busy' | 'missing' | 'error' {
+//   fired    -> prompt delivered
+//   busy     -> session up but not ready; retry later
+//   starting -> session was down, agent auto-started; deliver on a later retry
+//   missing  -> session down and auto-start failed; skip this tick
+//   error    -> unexpected failure
+function attemptFireTask(task: ScheduledTask, agentName: string, now: number): 'fired' | 'busy' | 'missing' | 'starting' | 'error' {
   const isMainAgent = agentName === MAIN_AGENT_ID
   // Allow per-task session override via targetSession config field.
   // Falls back to the standard agent session name derivation.
@@ -101,8 +112,20 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
   } catch { /* no tmux */ }
 
   if (!sessionExists) {
-    logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session not running, skipping')
-    return 'missing'
+    // Auto-start the agent so a scheduled run is not silently skipped just
+    // because the agent happened to be down. The tmux session is created
+    // synchronously, but the LLM inside needs a few seconds to boot -- so we
+    // return 'starting' and the caller queues a pending retry that delivers
+    // the prompt once the session is ready. startAgentProcess no-ops when the
+    // agent is already running, so retries cannot double-launch it. A failed
+    // start falls back to 'missing' (skip this tick).
+    logger.info({ task: task.name, agent: agentName, session }, 'Schedule target session not running, auto-starting agent')
+    const start = startAgentProcess(agentName)
+    if (!start.ok) {
+      logger.warn({ task: task.name, agent: agentName, session, error: start.error }, 'Schedule auto-start failed, skipping tick')
+      return 'missing'
+    }
+    return 'starting'
   }
 
   // When forceSend is true, skip the busy-state check entirely and inject
@@ -255,6 +278,46 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   })()
 }
 
+// Fire a scheduled task immediately, ignoring its cron schedule -- the engine
+// behind the dashboard "Run now" button and POST /api/schedules/:name/run.
+// command tasks run inline; LLM tasks go through attemptFireTask, so a stopped
+// agent is auto-started and the delivery is queued as a pending retry. Unlike
+// the cron loop, a manual run ALWAYS wants delivery, so we do NOT consult
+// skipIfBusy here -- an explicit run must not be silently dropped.
+export function runScheduledTaskNow(taskName: string): { ok: boolean; result?: string; error?: string } {
+  const task = listScheduledTasks().find(t => t.name === taskName)
+  if (!task) return { ok: false, error: 'Schedule not found' }
+  if (!task.enabled) return { ok: false, error: 'Schedule is disabled' }
+
+  const now = Date.now()
+  if (task.type === 'command') {
+    try {
+      runCommandTask(task, now)
+      scheduleLastRun.set(task.name, now)
+      persistScheduleLastRun()
+      return { ok: true, result: 'command task executed' }
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  const targets = task.agent === 'all'
+    ? [MAIN_AGENT_ID, ...listAgentNames().filter(a => isAgentRunning(a))]
+    : [task.agent || MAIN_AGENT_ID]
+
+  const summary: string[] = []
+  for (const agentName of targets) {
+    const result = attemptFireTask(task, agentName, now)
+    // An auto-started ('starting') or busy session both get a queued retry
+    // that lands once the session is ready.
+    if (result === 'starting' || result === 'busy') {
+      insertPendingTaskRetryIfNew(task.name, agentName, now, result)
+    }
+    summary.push(`${agentName}: ${result}`)
+  }
+  return { ok: true, result: summary.join(', ') }
+}
+
 export function startScheduleRunner(): NodeJS.Timeout {
   // Reload the persisted last-run times so a restart inside a task's catch-up
   // window does not re-fire an already-run task.
@@ -288,6 +351,13 @@ export function startScheduleRunner(): NodeJS.Timeout {
       // while the retry sat in the queue, drop the retry so a long-stuck
       // task doesn't surprise-fire the moment the session frees up.
       if (!taskDef.enabled) {
+        deletePendingTaskRetry(row.task_name, row.agent_name)
+        continue
+      }
+      // Bound runaway retries so a permanently-busy task cannot spin forever
+      // (nor, via the 'starting' auto-start, perpetually relaunch its agent).
+      if (row.attempt_count >= MAX_RETRY_ATTEMPTS) {
+        logger.warn({ task: row.task_name, agent: row.agent_name, attempts: row.attempt_count }, 'Scheduled task retry gave up after max attempts')
         deletePendingTaskRetry(row.task_name, row.agent_name)
         continue
       }
@@ -347,7 +417,13 @@ export function startScheduleRunner(): NodeJS.Timeout {
         // the retry handler -- don't re-queue or double-fire.
         if (pendingKeys.has(key)) continue
         const result = attemptFireTask(task, agentName, now)
-        if (result === 'busy') {
+        if (result === 'starting') {
+          // Agent was auto-started this tick. ALWAYS enqueue the retry that
+          // delivers the prompt once the session is ready -- skipIfBusy must
+          // NOT drop it (that flag is for genuinely-busy short-cadence tasks;
+          // here we deliberately woke the agent for its scheduled run).
+          insertPendingTaskRetryIfNew(task.name, agentName, now, 'starting')
+        } else if (result === 'busy') {
           if (task.skipIfBusy) {
             // Opt-in skip for short-cadence tasks (e.g. 30-min heartbeats):
             // a single missed tick is harmless because the next one is

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -4,6 +4,7 @@ import { execSync, execFileSync } from 'node:child_process'
 import { resolveFromPath } from '../platform.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { logger } from '../logger.js'
+import { runCommandTask } from './command-task.js'
 import {
   PROJECT_ROOT,
   MAIN_AGENT_ID,
@@ -318,6 +319,17 @@ export function startScheduleRunner(): NodeJS.Timeout {
       // Prevent double-firing: skip if already ran within the catch-up window
       const lastRun = scheduleLastRun.get(task.name) || 0
       if (now - lastRun < catchUp) continue
+
+      // type='command' tasks run a raw shell command directly -- no LLM, no
+      // tmux, no target agent. They self-manage failure streaks + Telegram
+      // alerts (see command-task.ts). Record the run time like a fired task so
+      // the catch-up window does not double-run them on a dashboard restart.
+      if (task.type === 'command') {
+        runCommandTask(task, now)
+        scheduleLastRun.set(task.name, now)
+        persistScheduleLastRun()
+        continue
+      }
 
       let targetAgents: string[]
 

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -21,7 +21,11 @@ export interface ScheduledTask {
   agent: string
   enabled: boolean
   createdAt: number
-  type?: 'task' | 'heartbeat'  // heartbeat = silent unless important
+  // task = wake an LLM agent with the SKILL.md prompt; heartbeat = same but
+  // silent unless important; command = run a raw shell command, no LLM/tmux
+  // (see command-task.ts). A `command` task is defined entirely by the
+  // command/timeoutMs/failThreshold fields below -- it has no SKILL.md.
+  type?: 'task' | 'heartbeat' | 'command'
   // When true, a tick whose target session is busy is dropped silently
   // instead of queued. Use ONLY for cron schedules that fire often enough
   // (every 30-60 min) that losing a single tick is harmless because the
@@ -40,6 +44,15 @@ export interface ScheduledTask {
   // `agent-<name>` or MAIN_CHANNELS_SESSION. Enables dedicated
   // scheduler-only sessions in the future.
   targetSession?: string
+  // command-type only: the raw shell command, run via `bash -lc`. No LLM,
+  // no tmux, no target agent.
+  command?: string
+  // command-type only: hard timeout in ms (default 10000). A timeout counts
+  // as a failure.
+  timeoutMs?: number
+  // command-type only: consecutive failures before a Telegram alert fires
+  // (default 2). One alert per outage, one recovery when it clears.
+  failThreshold?: number
 }
 
 function readFileOr(path: string, fallback: string): string {
@@ -64,15 +77,17 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   const skillPath = join(dir, 'SKILL.md')
   const configPath = join(dir, 'task-config.json')
-  if (!existsSync(skillPath)) return null
-
-  const skillContent = readFileOr(skillPath, '')
-  const { name, description, body } = parseSkillMdFrontmatter(skillContent)
-
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
+
+  // command-type tasks are defined entirely by task-config.json (no prompt,
+  // no agent) and therefore have no SKILL.md. Every other type requires one.
+  if (!existsSync(skillPath) && config.type !== 'command') return null
+
+  const skillContent = readFileOr(skillPath, '')
+  const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
   return {
     name: name || taskName,
@@ -82,10 +97,13 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
     agent: config.agent || MAIN_AGENT_ID,
     enabled: config.enabled !== false,
     createdAt: config.createdAt || 0,
-    type: (config.type as 'task' | 'heartbeat') || 'task',
+    type: (config.type as 'task' | 'heartbeat' | 'command') || 'task',
     skipIfBusy: config.skipIfBusy === true,
     forceSend: config.forceSend === true,
     targetSession: config.targetSession || undefined,
+    command: config.command,
+    timeoutMs: config.timeoutMs,
+    failThreshold: config.failThreshold,
   }
 }
 
@@ -104,7 +122,7 @@ export function listScheduledTasks(): ScheduledTask[] {
 
 export function writeScheduledTask(
   taskName: string,
-  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string },
+  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number },
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
@@ -114,12 +132,16 @@ export function writeScheduledTask(
 
   // Read existing if updating
   const existing = readScheduledTask(taskName)
+  const type = data.type ?? existing?.type ?? 'task'
 
-  // Write SKILL.md
-  const desc = data.description ?? existing?.description ?? ''
-  const prompt = data.prompt ?? existing?.prompt ?? ''
-  const skillContent = `---\nname: ${taskName}\ndescription: ${desc}\n---\n\n${prompt}\n`
-  atomicWriteFileSync(skillPath, skillContent)
+  // Write SKILL.md -- but command-type tasks have no prompt/agent, so they get
+  // no SKILL.md (they are defined entirely by task-config.json).
+  if (type !== 'command') {
+    const desc = data.description ?? existing?.description ?? ''
+    const prompt = data.prompt ?? existing?.prompt ?? ''
+    const skillContent = `---\nname: ${taskName}\ndescription: ${desc}\n---\n\n${prompt}\n`
+    atomicWriteFileSync(skillPath, skillContent)
+  }
 
   // Write/update config
   let config: Record<string, unknown> = {}
@@ -131,6 +153,9 @@ export function writeScheduledTask(
   if (data.skipIfBusy !== undefined) config.skipIfBusy = data.skipIfBusy
   if (data.forceSend !== undefined) config.forceSend = data.forceSend
   if (data.targetSession !== undefined) config.targetSession = data.targetSession
+  if (data.command !== undefined) config.command = data.command
+  if (data.timeoutMs !== undefined) config.timeoutMs = data.timeoutMs
+  if (data.failThreshold !== undefined) config.failThreshold = data.failThreshold
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }

--- a/web/app.js
+++ b/web/app.js
@@ -3598,6 +3598,9 @@ function renderScheduleList(tasks) {
         </div>
       </div>
       <div class="schedule-actions">
+        <button class="btn-icon" data-action="run" title="Futtatás most">
+          ${playIcon()}
+        </button>
         <button class="btn-icon" data-action="toggle" title="${task.enabled ? 'Szüneteltetés' : 'Folytatás'}">
           ${task.enabled ? pauseIcon() : playIcon()}
         </button>
@@ -3614,6 +3617,15 @@ function renderScheduleList(tasks) {
     })
 
     // Action buttons
+    // Run now: fire the task immediately regardless of its cron schedule.
+    row.querySelector('[data-action="run"]').addEventListener('click', async (e) => {
+      e.stopPropagation()
+      try {
+        const res = await fetch(`/api/schedules/${encodeURIComponent(task.name)}/run`, { method: 'POST' })
+        showToast(res.ok ? 'Feladat elindítva' : 'Nem sikerült elindítani')
+      } catch { showToast('Hiba történt') }
+    })
+
     row.querySelector('[data-action="toggle"]').addEventListener('click', async (e) => {
       e.stopPropagation()
       try {


### PR DESCRIPTION
## Mit

Egy IMAP-postafiók rendezése a feladó CÍME alapján: a fontos feladók pingelnek Telegramon, az archiválandók az Archive mappába kerülnek (mozgatás, sosem törlés), a routes szabályok egyedi mappákba sorolnak feladó + lokális tárgy-kulcsszó alapján.

## Privacy

A levél TARTALMA nem hagyja el a postafiókot LLM/felhő felé. Az egyetlen kivétel egy explicit `ai_analysis` allowlist, aminek a leveleit egy LLM-task elemzi (érkezésenként triggerelve a run-now-val). A szkript `ai-dump` módja kódból erre a listára van korlátozva. Az IMAP-jelszó csak a vaultban él.

## Hogyan

- `scripts/email-digest/digest.py`: cím-alapú matching specificitással (pontos cím veri a domaint), aldomain-lefedés, `\\Flagged` carve-out, dedup-os fontos-ping, napi számszerű archív-jelentés, routes, és a per-email AI-review trigger (run-now).
- 3 opt-in seed-task (`email-watch` + `email-daily-digest` command-típus, `email-ai-review` LLM-task) + `email-rules.example.json` + `docs/email-digest.md`.
- A valódi szabályok a gitignore-olt `store/email-rules.json`-ban élnek (privát).

## Teszt
12 függőség-mentes logikai teszt (matches/classify/match_route: aldomain, specificitás, route subject-keyword).

## Megjegyzés
A stack teteje: #329 (command type) -> #330 (run-now) -> ez. A `command` típusra és a run-now endpointra épül. A diff a stack alsó commitjait is tartalmazza; az `ebd63f4` az email net-új rész. Review/merge #330 után.