### PR TITLE
feat(agents): run agents on remote hosts over SSH + tmux (#320, rebased+fixed)

### DIFF
--- a/docs/agent-fleet.md
+++ b/docs/agent-fleet.md
@@ -30,7 +30,7 @@ POST /api/messages   { "from": "<agent>", "to": "<agent>", "content": "..." }
 GET  /api/messages?agent=<agent>      # státusz
 ```
 
-A rendszer az üzenetet a célpont ügynök tmux-session-jébe juttatja (`[Uzenet @<felado>-tol]: ...` formátumban), aki feldolgozza és a saját csatornáján válaszol. Csak futó (tmux-session-nel rendelkező) ügynöknek lehet üzenni.
+A rendszer az üzenetet a célpont ügynök tmux-session-jébe juttatja (`[Uzenet @<felado>-tol]: ...` formátumban), aki feldolgozza és a saját csatornáján válaszol. Csak futó (tmux-session-nel rendelkező) ügynöknek lehet üzenni. Távoli ügynöknél ez azt jelenti, hogy az ssh-kapcsolat és a laptop tmux-szervere elérhető kell legyen a delivery-loop ciklusában; ha nem az, az üzenet a sorban marad és visszakapcsoláskor kézbesül (lásd [Távoli ügynökök](#-távoli-remote-ügynökök)).
 
 ### Életciklus
 
@@ -42,6 +42,69 @@ GET  /api/agents                # flotta-lista
 ```
 
 Az indítás kezeli a Claude Code "resume summary" modal automatikus elutasítását, hogy a friss session ne ragadjon be.
+
+A teljes életciklus (start/stop/status/lista) és az inter-agent üzenetküldés **távoli ügynöknél is működik**, ssh-n keresztül (lásd lentebb) -- a helyi ügynökök viselkedése változatlan.
+
+---
+
+## 🌐 Távoli (remote) ügynökök
+
+Marveen egy always-on orchestrator gépen fut. Egy ügynök beállítható úgy, hogy a **tmux-session-je egy távoli gépen** (pl. egy fejlesztői gépen) fusson egy ott megadott munkakönyvtárban, miközben Marveen az orchestratorról indítja, állítja le, kérdezi le és üzen neki -- mindezt ssh-n keresztül.
+
+### ⭐ Alapelv: az ügynök élete független az ssh-kapcsolattól
+
+A távoli ügynök egy **detached tmux-session**-ben fut a távoli gép saját tmux-szerverén (`tmux new-session -d`), így a `claude` process a tmux-szerver gyereke, NEM az ssh-é. Következmények:
+
+- Egy ssh-szakadás SOHA nem állítja le a távoli ügynököt. A távoli gépen tovább fut és dolgozik; csak Marveen üzenés/megfigyelés képessége szünetel, és visszakapcsoláskor folytatódik.
+- A sorban álló inter-agent üzenetek és ütemezett feladatok kivárják a szakadást, és visszakapcsoláskor kézbesülnek (a router 1 óra után dob el egy üzenetet, ha addig nem elérhető).
+- A dashboard `unreachable` állapotot mutat (nem `stopped`), és az auto-restart NEM indítja újra az elérhetetlen ügynököt.
+- Leállás CSAK explicit `POST /stop`-ra történik.
+
+### Beállítás
+
+```
+PUT /api/agents/<name>/remote   { "host": "devbox", "workdir": "/home/user/projekt" }
+PUT /api/agents/<name>/remote   { "host": "", "workdir": "" }   # törlés -> újra helyi
+```
+
+- `host`: ssh-destination -- alias a `~/.ssh/config`-ból (ajánlott) vagy `user@host`. **NINCS `:port`** a host-stringben; a portot a `~/.ssh/config` `Port` direktívájába tedd. Shell-metakarakter nem engedett.
+- `workdir`: **abszolút** elérési út a távoli gépen (relatív/tilde nem engedett, hogy a `--continue` projekt-kódolás determinisztikus legyen).
+- Csak ha MINDKETTŐ érvényes, lesz az ügynök távoli; félig konfigurált ügynök helyi marad. A fő ügynök (`marveen`) mindig helyi.
+- A `GET /api/agents` válaszban megjelenik a `remoteHost`, `remoteWorkdir` és a `runState` (`running` | `stopped` | `unreachable`).
+
+### ssh-config előfeltétel (orchestrator oldal)
+
+A kód minden ControlMaster/keepalive/ConnectTimeout/BatchMode opciót `-o` flag-gel ad át, így egy minimális stanza elég:
+
+```
+Host devbox
+  HostName <tavoli-ip-vagy-host>
+  User <username>
+  # Port 22   # ha nem a default
+```
+
+Kell még: jelszó nélküli ssh-kulcs az orchestratortól a távoli gépig (a `BatchMode=yes` miatt soha nem blokkol promptra). A kód `ControlMaster`-multiplexinget használ egy privát socket-könyvtárban (`$XDG_RUNTIME_DIR/marveen-ssh`, mode 0700), hogy az 5mp-es delivery-loop és a watcherek egy kapcsolatot újrahasználjanak.
+
+### Indítás / auth előfeltétel a távoli gépen
+
+- `tmux` és `claude` legyen PATH-on a távoli gépen, és a `claude` legyen bejelentkezve.
+- **Ellenőrizd nem-interaktív ssh-kontextusban** (a macOS Keychain nem feltétlenül elérhető ssh-spawnolt processznek):
+
+  ```
+  ssh devbox 'which claude && claude --version'
+  ```
+
+  Ennek sikerülnie kell. Ha az OAuth-credential nem elérhető nem-interaktívan, állítsd a távoli `claude`-ot API-kulcsos loginra. A `start` egyébként eleve elutasítja az indítást, ha a `which claude` elbukik.
+
+### Működési modell: launch-only, channel-less
+
+A távoli ügynök a távoli gép SAJÁT `~/.claude` loginját és a távoli munkakönyvtár `CLAUDE.md`-jét használja. Nem visz át channel-tokent/vault-titkot/settings.json-t -- inter-agent only (Marveen delegál, az ügynök inter-agent üzenetben jelez vissza).
+
+### Scaffolding-szinkron
+
+Az `agents/<name>/` mappa **gitignore-olt**, így a távoli ügynök viselkedését a távoli munkakönyvtár `CLAUDE.md`-je + a távoli gép `~/.claude` loginja adja -- az orchestrator-oldali persona-fájlok (CLAUDE.md/SOUL.md/skillek) nem szinkronizálódnak automatikusan a távoli gépre.
+
+Ha azt akarod, hogy a távoli ügynök a flotta personáját vigye, tedd azokat a fájlokat a távoli munkakönyvtárba (annak saját git/sync-csatornáján át), vagy vedd fel az `agents/<name>/`-t egy szinkronizált útvonalra. Ez üzemeltetői (infra) döntés, nem repo-változtatás.
 
 ### Delegálási elv
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/marvin/ClaudeClaw/node_modules

--- a/src/__tests__/remote-api.test.ts
+++ b/src/__tests__/remote-api.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { writeAgentRemoteConfig, readAgentRemoteConfig, agentDir } from '../web/agent-config.js'
+
+// Exercises the persistence layer that backs `PUT /api/agents/:name/remote`.
+// The HTTP handler itself imports db.js (better-sqlite3, ABI-mismatched in this
+// runtime) so it cannot be loaded here, but writeAgentRemoteConfig is the whole
+// of its validate-and-persist logic.
+
+const TEST_AGENT = 'zz-remote-api-test-tmp'
+
+describe('writeAgentRemoteConfig (PUT /remote backing logic)', () => {
+  beforeEach(() => {
+    mkdirSync(agentDir(TEST_AGENT), { recursive: true })
+    // Seed an existing config to prove the remote write MERGES, not clobbers.
+    writeFileSync(
+      join(agentDir(TEST_AGENT), 'agent-config.json'),
+      JSON.stringify({ model: 'claude-sonnet-4-6', displayName: 'Tmp' }, null, 2),
+    )
+  })
+  afterEach(() => {
+    rmSync(agentDir(TEST_AGENT), { recursive: true, force: true })
+  })
+
+  it('persists a valid host + workdir and preserves other config keys', () => {
+    const res = writeAgentRemoteConfig(TEST_AGENT, 'devbox', '/home/user/proj')
+    expect(res.ok).toBe(true)
+    expect(readAgentRemoteConfig(TEST_AGENT)).toEqual({ host: 'devbox', workdir: '/home/user/proj' })
+    const cfg = JSON.parse(readFileSync(join(agentDir(TEST_AGENT), 'agent-config.json'), 'utf-8'))
+    expect(cfg.model).toBe('claude-sonnet-4-6')
+    expect(cfg.displayName).toBe('Tmp')
+  })
+
+  it('rejects an invalid host (shell metachars) and does NOT persist', () => {
+    const res = writeAgentRemoteConfig(TEST_AGENT, 'bad host;rm', '/x')
+    expect(res.ok).toBe(false)
+    expect(readAgentRemoteConfig(TEST_AGENT)).toEqual({ host: null, workdir: null })
+  })
+
+  it('rejects a host with a colon/port', () => {
+    const res = writeAgentRemoteConfig(TEST_AGENT, 'devbox:22', '/x')
+    expect(res.ok).toBe(false)
+    expect(readAgentRemoteConfig(TEST_AGENT)).toEqual({ host: null, workdir: null })
+  })
+
+  it('rejects a relative/tilde workdir', () => {
+    expect(writeAgentRemoteConfig(TEST_AGENT, 'devbox', '~/proj').ok).toBe(false)
+    expect(writeAgentRemoteConfig(TEST_AGENT, 'devbox', 'rel/dir').ok).toBe(false)
+  })
+
+  it('clears the fields (revert to local) on empty input', () => {
+    writeAgentRemoteConfig(TEST_AGENT, 'devbox', '/home/user/proj')
+    const res = writeAgentRemoteConfig(TEST_AGENT, '', '')
+    expect(res.ok).toBe(true)
+    expect(readAgentRemoteConfig(TEST_AGENT)).toEqual({ host: null, workdir: null })
+    // Other keys survive the clear.
+    const cfg = JSON.parse(readFileSync(join(agentDir(TEST_AGENT), 'agent-config.json'), 'utf-8'))
+    expect(cfg.model).toBe('claude-sonnet-4-6')
+    expect('remoteHost' in cfg).toBe(false)
+  })
+
+  it('rejects a half-configured write (host without workdir)', () => {
+    expect(writeAgentRemoteConfig(TEST_AGENT, 'devbox', '').ok).toBe(false)
+    expect(readAgentRemoteConfig(TEST_AGENT)).toEqual({ host: null, workdir: null })
+  })
+})

--- a/src/__tests__/remote-config.test.ts
+++ b/src/__tests__/remote-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { resolveRemoteConfig } from '../web/agent-config.js'
+
+describe('resolveRemoteConfig', () => {
+  it('returns both null for empty / no-remote config (agent is local)', () => {
+    expect(resolveRemoteConfig('{}')).toEqual({ host: null, workdir: null })
+  })
+
+  it('returns both null for unparseable JSON', () => {
+    expect(resolveRemoteConfig('not json')).toEqual({ host: null, workdir: null })
+    expect(resolveRemoteConfig('')).toEqual({ host: null, workdir: null })
+  })
+
+  it('resolves a valid alias host + absolute workdir', () => {
+    expect(resolveRemoteConfig('{"remoteHost":"devbox","remoteWorkdir":"/home/user/proj"}'))
+      .toEqual({ host: 'devbox', workdir: '/home/user/proj' })
+  })
+
+  it('accepts a user@host form', () => {
+    expect(resolveRemoteConfig('{"remoteHost":"user@laptop","remoteWorkdir":"/x/y"}'))
+      .toEqual({ host: 'user@laptop', workdir: '/x/y' })
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(resolveRemoteConfig('{"remoteHost":"  devbox  ","remoteWorkdir":"  /p  "}'))
+      .toEqual({ host: 'devbox', workdir: '/p' })
+  })
+
+  it('rejects a host with a colon/port (port belongs in ~/.ssh/config)', () => {
+    expect(resolveRemoteConfig('{"remoteHost":"devbox:22","remoteWorkdir":"/x"}'))
+      .toEqual({ host: null, workdir: null })
+  })
+
+  it('rejects a host with shell metacharacters', () => {
+    expect(resolveRemoteConfig('{"remoteHost":"a b; rm -rf","remoteWorkdir":"/x"}'))
+      .toEqual({ host: null, workdir: null })
+  })
+
+  it('rejects a relative or tilde workdir (encoding must be deterministic)', () => {
+    expect(resolveRemoteConfig('{"remoteHost":"devbox","remoteWorkdir":"~/proj"}'))
+      .toEqual({ host: null, workdir: null })
+    expect(resolveRemoteConfig('{"remoteHost":"devbox","remoteWorkdir":"relative/dir"}'))
+      .toEqual({ host: null, workdir: null })
+  })
+
+  it('rejects a workdir with a parent-traversal segment', () => {
+    expect(resolveRemoteConfig('{"remoteHost":"devbox","remoteWorkdir":"/a/../b"}'))
+      .toEqual({ host: null, workdir: null })
+  })
+
+  it('treats a half-configured agent (host only / workdir only) as local', () => {
+    expect(resolveRemoteConfig('{"remoteHost":"devbox"}')).toEqual({ host: null, workdir: null })
+    expect(resolveRemoteConfig('{"remoteWorkdir":"/x"}')).toEqual({ host: null, workdir: null })
+    // host valid but workdir invalid => both null
+    expect(resolveRemoteConfig('{"remoteHost":"devbox","remoteWorkdir":"bad dir"}'))
+      .toEqual({ host: null, workdir: null })
+  })
+})

--- a/src/__tests__/remote-launch-command.test.ts
+++ b/src/__tests__/remote-launch-command.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { buildRemoteLaunchCommand, classifyRunState, classifyRunStateFromExit, buildContinueProbeCommand } from '../web/ssh-tmux.js'
+
+describe('classifyRunStateFromExit (failed list-sessions probe)', () => {
+  it('remote ssh transport failure (exit 255) is unreachable', () => {
+    expect(classifyRunStateFromExit(255, true)).toBe('unreachable')
+  })
+
+  it('remote reachable but tmux has no server/session (exit 1) is stopped, NOT unreachable', () => {
+    // The crux: a reachable laptop with no tmux server yet must be startable.
+    expect(classifyRunStateFromExit(1, true)).toBe('stopped')
+  })
+
+  it('remote killed/timeout (no numeric status) is unreachable', () => {
+    expect(classifyRunStateFromExit(null, true)).toBe('unreachable')
+    expect(classifyRunStateFromExit(undefined, true)).toBe('unreachable')
+  })
+
+  it('local failures are always stopped (no tmux server)', () => {
+    expect(classifyRunStateFromExit(1, false)).toBe('stopped')
+    expect(classifyRunStateFromExit(255, false)).toBe('stopped')
+    expect(classifyRunStateFromExit(null, false)).toBe('stopped')
+  })
+})
+
+describe('buildContinueProbeCommand', () => {
+  it('keeps $HOME OUTSIDE the single-quoted region so the remote shell expands it', () => {
+    const cmd = buildContinueProbeCommand('/var/www/casino-common')
+    // $HOME must be in a double-quoted (expandable) region, NOT single-quoted.
+    expect(cmd).toContain('"$HOME/.claude/projects/"')
+    expect(cmd).not.toContain("'$HOME")
+    // The encoded (leading-dash) segment is single-quoted and concatenated, so
+    // it forms one path word and is not parsed as a `test` flag.
+    expect(cmd).toContain("'-var-www-casino-common'")
+    expect(cmd.startsWith('test -d ')).toBe(true)
+  })
+
+  it('encodes an absolute workdir with the leading-dash scheme', () => {
+    expect(buildContinueProbeCommand('/home/user/p')).toContain("'-home-user-p'")
+  })
+})
+
+describe('buildRemoteLaunchCommand', () => {
+  it('builds a channel-less launch with cd, --continue and a quoted model', () => {
+    const cmd = buildRemoteLaunchCommand({ workdir: '/home/user/p', model: 'claude-opus-4-8[1m]', continue: true })
+    expect(cmd).toContain("cd '/home/user/p'")
+    expect(cmd).toContain('--continue')
+    expect(cmd).toContain("--model 'claude-opus-4-8[1m]'")
+    expect(cmd).toContain('--dangerously-skip-permissions')
+  })
+
+  it('exports a PATH covering both macOS and Linux binary locations', () => {
+    const cmd = buildRemoteLaunchCommand({ workdir: '/p', model: 'm', continue: false })
+    expect(cmd).toContain('export PATH=')
+    expect(cmd).toContain('$HOME/.bun/bin')
+    expect(cmd).toContain('$HOME/.local/bin')
+  })
+
+  it('omits --continue when continue is false', () => {
+    const cmd = buildRemoteLaunchCommand({ workdir: '/p', model: 'm', continue: false })
+    expect(cmd).not.toContain('--continue')
+  })
+
+  it('never carries channel/token scaffolding (launch-only, channel-less)', () => {
+    const cmd = buildRemoteLaunchCommand({ workdir: '/p', model: 'm', continue: true })
+    expect(cmd).not.toContain('--channels')
+    expect(cmd).not.toContain('ANTHROPIC_API_KEY')
+    expect(cmd).not.toContain('TELEGRAM')
+  })
+})
+
+describe('classifyRunState', () => {
+  it('running when the session is present in the list output', () => {
+    expect(classifyRunState('agent-a\nagent-x\n', 'agent-x', true)).toBe('running')
+    expect(classifyRunState('agent-a\nagent-x\n', 'agent-x', false)).toBe('running')
+  })
+
+  it('stopped when the session is absent but the list query succeeded', () => {
+    expect(classifyRunState('agent-a\n', 'agent-x', true)).toBe('stopped')
+    expect(classifyRunState('agent-a\n', 'agent-x', false)).toBe('stopped')
+  })
+
+  it('unreachable for a remote agent when the query itself failed (null)', () => {
+    expect(classifyRunState(null, 'agent-x', true)).toBe('unreachable')
+  })
+
+  it('stopped (not unreachable) for a local agent when the query failed (no tmux)', () => {
+    expect(classifyRunState(null, 'agent-x', false)).toBe('stopped')
+  })
+})

--- a/src/__tests__/remote-routing.test.ts
+++ b/src/__tests__/remote-routing.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { resolveRemoteConfig } from '../web/agent-config.js'
+import { buildTmuxInvocation, sessionInList, SSH_OPTS } from '../web/ssh-tmux.js'
+
+// The message-router / schedule-runner wiring resolves a host from the agent's
+// config and routes its tmux calls through buildTmuxInvocation. These tests
+// lock the END-TO-END transport decision using the real functions (no db, no
+// tmux): a remote-configured agent must drive an `ssh` invocation, a local one
+// must stay on the bare tmux binary. (The loops themselves import db.js, whose
+// native better-sqlite3 binding is ABI-mismatched in this test runtime, so they
+// cannot be imported here -- but every primitive they call is covered.)
+
+const TMUX = '/usr/bin/tmux'
+
+function transportFor(agentConfigJson: string, session: string) {
+  const host = resolveRemoteConfig(agentConfigJson).host
+  return buildTmuxInvocation(host, TMUX, ['list-sessions', '-F', '#{session_name}'])
+    && { host, inv: buildTmuxInvocation(host, TMUX, ['send-keys', '-t', session, '-l', 'hi']) }
+}
+
+describe('delivery transport selection', () => {
+  it('a remote-configured agent routes its tmux send over ssh', () => {
+    const { host, inv } = transportFor(
+      '{"remoteHost":"devbox","remoteWorkdir":"/home/user/proj"}',
+      'agent-dev',
+    )
+    expect(host).toBe('devbox')
+    expect(inv.file).toBe('ssh')
+    expect(inv.args.slice(0, SSH_OPTS.length)).toEqual([...SSH_OPTS])
+    expect(inv.args).toContain('devbox')
+  })
+
+  it('a local agent stays on the bare tmux binary (no ssh) -- local behavior preserved', () => {
+    const { host, inv } = transportFor('{}', 'agent-dev')
+    expect(host).toBeNull()
+    expect(inv.file).toBe(TMUX)
+    expect(inv.args).toEqual(['send-keys', '-t', 'agent-dev', '-l', 'hi'])
+    expect(inv.args).not.toContain('ssh')
+  })
+
+  it('a half-configured (invalid) remote agent falls back to local transport', () => {
+    const { host, inv } = transportFor(
+      '{"remoteHost":"devbox","remoteWorkdir":"~/bad"}',
+      'agent-dev',
+    )
+    expect(host).toBeNull()
+    expect(inv.file).toBe(TMUX)
+  })
+})
+
+describe('sessionInList existence check (shared by router + scheduler)', () => {
+  it('finds the exact remote/local session name in list-sessions output', () => {
+    const listOutput = 'agent-other\nagent-dev\nmarveen-channels\n'
+    expect(sessionInList(listOutput, 'agent-dev')).toBe(true)
+    expect(sessionInList(listOutput, 'agent-missing')).toBe(false)
+  })
+})

--- a/src/__tests__/remote-status-cache.test.ts
+++ b/src/__tests__/remote-status-cache.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { RemoteStatusCache } from '../web/remote-status-cache.js'
+
+describe('RemoteStatusCache', () => {
+  it('calls the fetcher on a cold miss and caches the value', () => {
+    const cache = new RemoteStatusCache<string>(3000)
+    const fetch = vi.fn(() => 'running')
+    expect(cache.getOrRefresh('a', 1000, fetch)).toBe('running')
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the cached value WITHOUT calling the fetcher again within the TTL', () => {
+    const cache = new RemoteStatusCache<string>(3000)
+    const fetch = vi.fn(() => 'running')
+    cache.getOrRefresh('a', 1000, fetch)
+    // 2.9s later -> still fresh -> no second ssh call (dashboard never blocks)
+    expect(cache.getOrRefresh('a', 3900, fetch)).toBe('running')
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes once the TTL has elapsed', () => {
+    const cache = new RemoteStatusCache<string>(3000)
+    let n = 0
+    const fetch = vi.fn(() => `v${++n}`)
+    expect(cache.getOrRefresh('a', 1000, fetch)).toBe('v1')
+    expect(cache.getOrRefresh('a', 4001, fetch)).toBe('v2') // 3.001s later -> stale
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('keys are independent', () => {
+    const cache = new RemoteStatusCache<string>(3000)
+    const fetch = vi.fn((k: string) => k)
+    expect(cache.getOrRefresh('a', 1000, () => fetch('a'))).toBe('a')
+    expect(cache.getOrRefresh('b', 1000, () => fetch('b'))).toBe('b')
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let a fetcher throw escape -- returns last-known on error, or the fallback when cold', () => {
+    const cache = new RemoteStatusCache<string>(3000)
+    // cold + throwing fetch -> fallback
+    const boom = () => { throw new Error('ssh down') }
+    expect(cache.getOrRefresh('a', 1000, boom, 'unreachable')).toBe('unreachable')
+    // warm it, then a later throwing refresh returns the last-known value
+    cache.getOrRefresh('a', 5000, () => 'running')
+    expect(cache.getOrRefresh('a', 9001, boom, 'unreachable')).toBe('running')
+  })
+})

--- a/src/__tests__/schedule-runner-autostart.test.ts
+++ b/src/__tests__/schedule-runner-autostart.test.ts
@@ -26,12 +26,12 @@ describe('schedule-runner auto-starts a stopped agent for its scheduled task', (
   })
 
   it('the missing-session branch auto-starts the agent instead of skipping', () => {
-    // Locate the sessionExists guard and assert it now launches the agent.
-    const guardIdx = SRC.indexOf('if (!sessionExists)')
+    // Locate the (host-aware) missing-session guard and assert it now launches the agent.
+    const guardIdx = SRC.indexOf('if (!sessionExistsOnHost(')
     expect(guardIdx).toBeGreaterThan(0)
     // Window covering the missing-session block (comment + code, before the
     // real busy-check). Must launch the agent and return the 'starting' state.
-    const missingBlock = SRC.slice(guardIdx, guardIdx + 1400)
+    const missingBlock = SRC.slice(guardIdx, guardIdx + 1800)
     expect(missingBlock).toMatch(/startAgentProcess\(agentName\)/)
     expect(missingBlock).toMatch(/return 'starting'/)
   })
@@ -56,7 +56,7 @@ describe('schedule-runner auto-starts a stopped agent for its scheduled task', (
   })
 
   it('documents WHY (daily batch agent), not just what', () => {
-    const guardIdx = SRC.indexOf('if (!sessionExists)')
+    const guardIdx = SRC.indexOf('if (!sessionExistsOnHost(')
     const rationale = SRC.slice(guardIdx, guardIdx + 900)
     expect(rationale).toMatch(/auto-start|batch agent|digest/i)
     expect(rationale).toMatch(/skipIfBusy/i)

--- a/src/__tests__/ssh-tmux.test.ts
+++ b/src/__tests__/ssh-tmux.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import {
+  shQuote,
+  buildTmuxInvocation,
+  buildSshExec,
+  sessionInList,
+  SSH_OPTS,
+  controlDir,
+} from '../web/ssh-tmux.js'
+
+describe('shQuote', () => {
+  it('wraps a plain string in single quotes', () => {
+    expect(shQuote('hello')).toBe("'hello'")
+  })
+
+  it('escapes an embedded single quote with the POSIX dance', () => {
+    expect(shQuote("a'b")).toBe("'a'\\''b'")
+  })
+
+  it('keeps glob/bracket characters literal (inside single quotes)', () => {
+    expect(shQuote('claude-opus-4-8[1m]')).toBe("'claude-opus-4-8[1m]'")
+  })
+
+  it('keeps shell metacharacters literal', () => {
+    expect(shQuote('a; rm -rf / && echo $HOME')).toBe("'a; rm -rf / && echo $HOME'")
+  })
+})
+
+describe('buildTmuxInvocation', () => {
+  it('host=null returns the bare local binary + args (byte-identical to a direct local call)', () => {
+    expect(buildTmuxInvocation(null, '/usr/bin/tmux', ['list-sessions'])).toEqual({
+      file: '/usr/bin/tmux',
+      args: ['list-sessions'],
+    })
+  })
+
+  it('host set wraps every tmux arg in one shell-quoted ssh command string', () => {
+    const inv = buildTmuxInvocation('devbox', '/usr/bin/tmux', ['send-keys', '-t', 'agent-x', '-l', "a'b c"])
+    expect(inv.file).toBe('ssh')
+    // SSH_OPTS, then the host, then exactly ONE remote command string.
+    expect(inv.args.length).toBe(SSH_OPTS.length + 2)
+    expect(inv.args.slice(0, SSH_OPTS.length)).toEqual([...SSH_OPTS])
+    expect(inv.args[SSH_OPTS.length]).toBe('devbox')
+    expect(inv.args[SSH_OPTS.length + 1]).toBe(
+      "tmux 'send-keys' '-t' 'agent-x' '-l' 'a'\\''b c'",
+    )
+  })
+
+  it('a full new-session launch command rides as a SINGLE argv element with brackets kept literal', () => {
+    const cmd = "cd '/home/user/p' && claude --continue --model 'claude-opus-4-8[1m]'"
+    const inv = buildTmuxInvocation('devbox', '/usr/bin/tmux', ['new-session', '-d', '-s', 'agent-x', cmd])
+    expect(inv.file).toBe('ssh')
+    // host + ONE command string => no splitting of cmd across argv elements.
+    expect(inv.args.length).toBe(SSH_OPTS.length + 2)
+    const remote = inv.args[SSH_OPTS.length + 1]
+    expect(remote.startsWith("tmux 'new-session' '-d' '-s' 'agent-x' ")).toBe(true)
+    // The bracketed model token survives intact inside the quoting.
+    expect(remote).toContain('claude-opus-4-8[1m]')
+  })
+
+  it('preserves a slid leading-dash chunk (Hungarian suffix) verbatim', () => {
+    const inv = buildTmuxInvocation('devbox', '/usr/bin/tmux', ['send-keys', '-t', 'agent-x', '-l', ' -szal'])
+    const remote = inv.args[SSH_OPTS.length + 1]
+    expect(remote.endsWith("' -szal'")).toBe(true)
+  })
+})
+
+describe('buildSshExec', () => {
+  it('builds an ssh invocation with SSH_OPTS + host + the raw remote command', () => {
+    const inv = buildSshExec('devbox', 'which claude')
+    expect(inv.file).toBe('ssh')
+    expect(inv.args).toEqual([...SSH_OPTS, 'devbox', 'which claude'])
+  })
+})
+
+describe('SSH_OPTS', () => {
+  it('bounds an alive-but-unresponsive remote (ServerAlive), not just TCP connect', () => {
+    expect(SSH_OPTS).toContain('ServerAliveInterval=2')
+    expect(SSH_OPTS).toContain('ServerAliveCountMax=2')
+    expect(SSH_OPTS).toContain('ConnectTimeout=5')
+    expect(SSH_OPTS).toContain('BatchMode=yes')
+  })
+
+  it('uses a private ControlMaster socket dir, not a bare world-writable /tmp path', () => {
+    const cpIdx = SSH_OPTS.indexOf('ControlMaster=auto')
+    expect(cpIdx).toBeGreaterThanOrEqual(0)
+    const controlPathOpt = SSH_OPTS.find(o => o.startsWith('ControlPath='))
+    expect(controlPathOpt).toBeDefined()
+    expect(controlPathOpt).toContain(controlDir())
+    expect(controlDir()).toMatch(/marveen-ssh/)
+    // Not the bare `/tmp/<file>` form flagged as world-writable.
+    expect(controlPathOpt).not.toMatch(/ControlPath=\/tmp\/[^/]+%/)
+  })
+})
+
+describe('sessionInList', () => {
+  it('matches an exact session line', () => {
+    expect(sessionInList('agent-a\nagent-b\n', 'agent-b')).toBe(true)
+  })
+
+  it('is false when the session is absent', () => {
+    expect(sessionInList('agent-a\n', 'agent-x')).toBe(false)
+  })
+
+  it('does not match on a substring of a longer session name', () => {
+    expect(sessionInList('agent-bbb\n', 'agent-b')).toBe(false)
+  })
+})

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -189,6 +189,101 @@ export function readAgentClaudeConfigDir(name: string): string | null {
   return resolveClaudeConfigDir(readFileOr(configPath, '{}'), homedir())
 }
 
+// --- Remote agent config (remoteHost + remoteWorkdir) ---
+//
+// When BOTH a valid host and a valid absolute workdir are present, the agent's
+// tmux session runs on a remote machine over ssh instead of locally. Validation
+// mirrors resolveClaudeConfigDir's whitelist-not-blacklist philosophy: the host
+// is passed as a raw ssh-destination argv element (never shell-interpolated), so
+// the charset is defense-in-depth, but the workdir IS inlined into the remote
+// launch command (shQuoted), so it is validated strictly too.
+
+// ssh alias or user@host. NO ':' -- `ssh host:port` is not valid syntax; the
+// port belongs in the ~/.ssh/config `Port` directive.
+const REMOTE_HOST_ALLOWED = /^[A-Za-z0-9_.@-]+$/
+// Absolute path only. Tilde is rejected: a `~/proj` workdir would encode to
+// `~-proj` for the --continue probe but Claude Code stores the tilde-EXPANDED
+// path as `-home-user-proj`, so the probe would never match and --continue would
+// be silently dropped. Requiring an absolute path makes the encoding
+// deterministic.
+const REMOTE_WORKDIR_ALLOWED = /^\/[A-Za-z0-9_./@+-]*$/
+
+export interface RemoteAgentConfig {
+  host: string | null
+  workdir: string | null
+}
+
+// Pure resolver: takes the raw agent-config.json text and returns the remote
+// {host, workdir}. An agent is "remote" only when BOTH validate; a
+// half-configured agent (host set but workdir invalid, or vice-versa) is
+// treated as local (both null) so it never launches into an undefined dir.
+export function resolveRemoteConfig(rawConfigJson: string): RemoteAgentConfig {
+  const NONE: RemoteAgentConfig = { host: null, workdir: null }
+  let config: unknown
+  try { config = JSON.parse(rawConfigJson) } catch { return NONE }
+  if (!config || typeof config !== 'object') return NONE
+  const rawHost = (config as Record<string, unknown>).remoteHost
+  const rawWorkdir = (config as Record<string, unknown>).remoteWorkdir
+  if (typeof rawHost !== 'string' || typeof rawWorkdir !== 'string') return NONE
+  const host = rawHost.trim()
+  const workdir = rawWorkdir.trim()
+  if (!host || !workdir) return NONE
+  if (!REMOTE_HOST_ALLOWED.test(host)) return NONE
+  if (!REMOTE_WORKDIR_ALLOWED.test(workdir)) return NONE
+  if (hasParentTraversal(workdir)) return NONE
+  return { host, workdir }
+}
+
+export function readAgentRemoteConfig(name: string): RemoteAgentConfig {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  return resolveRemoteConfig(readFileOr(configPath, '{}'))
+}
+
+// Convenience for the many callers that only need the host to decide whether a
+// session is remote. Returns null for local agents.
+export function readAgentRemoteHost(name: string): string | null {
+  return readAgentRemoteConfig(name).host
+}
+
+// Validate-and-persist the remote config. Empty strings clear the fields
+// (revert the agent to local). Returns the resolved config on success, or an
+// error string when a non-empty value fails validation.
+export function writeAgentRemoteConfig(
+  name: string,
+  host: string,
+  workdir: string,
+): { ok: true; remote: RemoteAgentConfig } | { ok: false; error: string } {
+  const h = host.trim()
+  const w = workdir.trim()
+  const configPath = join(agentDir(name), 'agent-config.json')
+  let config: Record<string, unknown> = {}
+  try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
+
+  // Clearing: both empty -> remove the fields, agent becomes local.
+  if (!h && !w) {
+    delete config.remoteHost
+    delete config.remoteWorkdir
+    atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+    return { ok: true, remote: { host: null, workdir: null } }
+  }
+
+  // Setting: both required and both must validate together.
+  if (!h || !w) {
+    return { ok: false, error: 'Both remoteHost and remoteWorkdir are required (or both empty to clear).' }
+  }
+  const probe = resolveRemoteConfig(JSON.stringify({ remoteHost: h, remoteWorkdir: w }))
+  if (!probe.host || !probe.workdir) {
+    return {
+      ok: false,
+      error: 'Invalid remoteHost (alias or user@host, no port/metachars) or remoteWorkdir (must be an absolute path without `..`).',
+    }
+  }
+  config.remoteHost = probe.host
+  config.remoteWorkdir = probe.workdir
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+  return { ok: true, remote: probe }
+}
+
 export function readAgentChannelProvider(name: string): string | null {
   const configPath = join(agentDir(name), 'agent-config.json')
   try {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -10,7 +10,19 @@ import {
   decideSubmitFollowup,
   shouldClearTruncatedPreamble,
 } from '../pane-state.js'
-import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName } from './agent-config.js'
+import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost } from './agent-config.js'
+import {
+  buildTmuxInvocation,
+  buildSshExec,
+  buildRemoteLaunchCommand,
+  buildContinueProbeCommand,
+  classifyRunState,
+  classifyRunStateFromExit,
+  sessionInList,
+  ensureControlDir,
+  cleanStaleSshSockets,
+  type AgentRunState,
+} from './ssh-tmux.js'
 import { parseTelegramToken } from './telegram.js'
 import { getProvider, getProviderType, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import { CHANNEL_PROVIDER } from '../config.js'
@@ -32,10 +44,58 @@ export function agentSessionName(name: string): string {
   return `agent-${name}`
 }
 
-export function isAgentRunning(name: string): boolean {
+// All tmux operations route through these two wrappers so the local-vs-remote
+// (ssh) decision and the quoting live in ONE place (ssh-tmux.ts). host=null is
+// byte-identical to the prior direct local tmux call. Remote calls get a larger
+// default timeout because an ssh round-trip (handshake + remote exec) is slower
+// than a local fork; ServerAlive/ConnectTimeout in SSH_OPTS bound a dead host.
+function runTmux(host: string | null, tmuxArgs: string[], opts: { timeout?: number } = {}): void {
+  // Ensure the private ControlMaster socket dir exists before ANY remote ssh
+  // call (idempotent, ~free). Without this a watcher-first remote call after a
+  // marveen restart would lose connection multiplexing and re-handshake each tick.
+  if (host) ensureControlDir()
+  const inv = buildTmuxInvocation(host, TMUX, tmuxArgs)
+  execFileSync(inv.file, inv.args, { timeout: opts.timeout ?? (host ? 8000 : 3000) })
+}
+
+function captureTmux(host: string | null, tmuxArgs: string[], opts: { timeout?: number } = {}): string {
+  if (host) ensureControlDir()
+  const inv = buildTmuxInvocation(host, TMUX, tmuxArgs)
+  return execFileSync(inv.file, inv.args, { timeout: opts.timeout ?? (host ? 8000 : 3000), encoding: 'utf-8' })
+}
+
+// Tri-state run state. For a remote agent a failed list-sessions query is
+// 'unreachable' (the session is almost certainly still alive on the laptop --
+// an SSH drop must never read as 'stopped', which would trigger a wrong
+// auto-restart or a duplicate start). See classifyRunState.
+export function agentRunState(name: string): AgentRunState {
+  const host = readAgentRemoteHost(name)
   try {
-    const output = execSync(`${TMUX} list-sessions -F "#{session_name}"`, { timeout: 3000, encoding: 'utf-8' })
-    return output.split('\n').some(line => line.trim() === agentSessionName(name))
+    const out = captureTmux(host, ['list-sessions', '-F', '#{session_name}'])
+    return classifyRunState(out, agentSessionName(name), host != null)
+  } catch (err) {
+    // tmux list-sessions exits non-zero ("no server running") when there are
+    // zero sessions -- on a REACHABLE remote that means 'stopped', not
+    // 'unreachable'. Only a true ssh transport failure (exit 255 / killed)
+    // is unreachable. The exit status carries that distinction.
+    const status = (err && typeof err === 'object' && 'status' in err)
+      ? (err as { status?: number | null }).status
+      : undefined
+    return classifyRunStateFromExit(status, host != null)
+  }
+}
+
+export function isAgentRunning(name: string): boolean {
+  return agentRunState(name) === 'running'
+}
+
+// Host-aware "does this tmux session exist" check, shared by the message router
+// and schedule runner. For a remote agent the list-sessions query runs on the
+// laptop over ssh; an ssh failure returns false (the loop retries next tick),
+// matching the local "session not found" semantics.
+export function sessionExistsOnHost(host: string | null, session: string): boolean {
+  try {
+    return sessionInList(captureTmux(host, ['list-sessions', '-F', '#{session_name}']), session)
   } catch {
     return false
   }
@@ -43,11 +103,8 @@ export function isAgentRunning(name: string): boolean {
 
 export function getAgentRunningSince(name: string): number | null {
   try {
-    const out = execFileSync(
-      TMUX,
-      ['display-message', '-p', '-t', agentSessionName(name), '#{session_created}'],
-      { timeout: 3000, encoding: 'utf-8' },
-    ).trim()
+    const host = readAgentRemoteHost(name)
+    const out = captureTmux(host, ['display-message', '-p', '-t', agentSessionName(name), '#{session_created}']).trim()
     const ts = parseInt(out, 10)
     return Number.isFinite(ts) ? ts : null
   } catch {
@@ -66,11 +123,80 @@ export function agentHasChannel(name: string): boolean {
   return false
 }
 
-export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}): { ok: boolean; pid?: number; error?: string } {
-  if (isAgentRunning(name)) return { ok: false, error: 'Agent is already running' }
+// Remote agent launch (ssh). Starts a DETACHED tmux session on the laptop so
+// the claude process is a child of the laptop's tmux server -- NOT of sshd --
+// and therefore survives any ssh disconnect; an outage only pauses the orchestrator's
+// ability to message/observe it. Launch-only + channel-less: the laptop's own
+// ~/.claude login and the remote workdir's CLAUDE.md drive behaviour, so none of
+// the local channel/token/vault/settings scaffolding applies. Has its own
+// tri-state start guard: it refuses on 'unreachable' so a brief outage never
+// spawns a duplicate session.
+function startRemoteAgentProcess(
+  name: string,
+  host: string,
+  workdir: string,
+  opts: { fresh?: boolean },
+): { ok: boolean; error?: string } {
+  const state = agentRunState(name)
+  if (state === 'running') return { ok: false, error: 'Agent is already running' }
+  if (state === 'unreachable') {
+    return { ok: false, error: `Remote host '${host}' unreachable -- refusing to start (cannot confirm state)` }
+  }
 
+  ensureControlDir()
+  cleanStaleSshSockets(host)
+
+  const session = agentSessionName(name)
+
+  // Pre-flight: claude must be on PATH on the laptop, else the session starts
+  // and instantly dies with a silent "command not found".
+  try {
+    const probe = buildSshExec(host, 'which claude')
+    execFileSync(probe.file, probe.args, { timeout: 8000, stdio: 'ignore' })
+  } catch {
+    return { ok: false, error: `claude not found on PATH on '${host}' (or host unreachable)` }
+  }
+
+  // --continue only when the remote session dir already exists. workdir is an
+  // absolute path (validated), so the `/`->`-` encoding matches Claude Code's
+  // own leading-'-' scheme. A probe failure defaults to a fresh launch (safe).
+  let hasPriorSession = false
+  if (!opts.fresh) {
+    try {
+      const probe = buildSshExec(host, buildContinueProbeCommand(workdir))
+      execFileSync(probe.file, probe.args, { timeout: 8000, stdio: 'ignore' })
+      hasPriorSession = true
+    } catch {
+      hasPriorSession = false
+    }
+  }
+
+  const model = readAgentModel(name)
+  const cmd = buildRemoteLaunchCommand({ workdir, model, continue: hasPriorSession })
+
+  try {
+    runTmux(host, ['new-session', '-d', '-s', session, cmd], { timeout: 10000 })
+    logger.info({ name, session, host, workdir }, 'Remote agent tmux session started')
+    scheduleIdentitySetup(session, readAgentDisplayName(name), host)
+    return { ok: true }
+  } catch (err) {
+    logger.error({ err, name, host }, 'Failed to start remote agent tmux session')
+    return { ok: false, error: 'Failed to start remote tmux session' }
+  }
+}
+
+export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}): { ok: boolean; pid?: number; error?: string } {
   const dir = agentDir(name)
   if (!existsSync(dir)) return { ok: false, error: 'Agent not found' }
+
+  // Remote agents are handled entirely by the ssh path above (with its own
+  // start guard), before any local already-running check / scaffolding.
+  const remote = readAgentRemoteConfig(name)
+  if (remote.host && remote.workdir) {
+    return startRemoteAgentProcess(name, remote.host, remote.workdir, opts)
+  }
+
+  if (isAgentRunning(name)) return { ok: false, error: 'Agent is already running' }
 
   const agentProvider = resolveAgentProvider(name)
   const provider = getProvider(agentProvider)
@@ -88,7 +214,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
 
   try {
     try {
-      execSync(`${TMUX} kill-session -t ${session} 2>/dev/null`, { timeout: 3000 })
+      runTmux(null, ['kill-session', '-t', session])
       execSync('sleep 3', { timeout: 5000 })
     } catch { /* ok */ }
 
@@ -195,10 +321,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // Single-quote `${model}` so values like `claude-opus-4-8[1m]` (1M-context
     // suffix) are not glob-expanded by the shell that tmux spawns the command in.
     const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${channelSetup}${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
-    execSync(
-      `${TMUX} new-session -d -s ${session} "${cmd}"`,
-      { timeout: 10000 }
-    )
+    runTmux(null, ['new-session', '-d', '-s', session, cmd], { timeout: 10000 })
 
     logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')
 
@@ -229,23 +352,28 @@ export function stopAgentProcess(name: string): { ok: boolean; error?: string } 
   const session = agentSessionName(name)
   if (!isAgentRunning(name)) return { ok: false, error: 'Agent is not running' }
 
+  const host = readAgentRemoteHost(name)
+
   try {
-    execSync(`${TMUX} kill-session -t ${session}`, { timeout: 5000 })
+    runTmux(host, ['kill-session', '-t', session], { timeout: 5000 })
     execSync('sleep 2', { timeout: 4000 })
-    // Reap any orphaned plugin grandchild that tmux did not tear down.
-    // See channel-poller-reap.ts - the old pkill-by-env-var-on-cmdline did
-    // not work because the env vars are not part of argv on macOS.
-    try {
-      const agentProvider = resolveAgentProvider(name)
-      const dir = agentDir(name)
-      reapChannelOrphans(agentProvider, dir)
-    } catch (err) {
-      logger.warn({ err, name }, 'post-stop channel-poller reap failed')
+    // Reap any orphaned plugin grandchild that tmux did not tear down. This is
+    // a LOCAL pkill against this host's process table, so it only makes sense
+    // for local agents; a remote agent is channel-less and its processes live
+    // on the laptop, so skip it.
+    if (!host) {
+      try {
+        const agentProvider = resolveAgentProvider(name)
+        const dir = agentDir(name)
+        reapChannelOrphans(agentProvider, dir)
+      } catch (err) {
+        logger.warn({ err, name }, 'post-stop channel-poller reap failed')
+      }
     }
-    logger.info({ name, session }, 'Agent tmux session stopped')
+    logger.info({ name, session, host }, 'Agent tmux session stopped')
     return { ok: true }
   } catch (err) {
-    logger.error({ err, name, session }, 'Failed to stop agent tmux session')
+    logger.error({ err, name, session, host }, 'Failed to stop agent tmux session')
     return { ok: false, error: 'Failed to stop tmux session' }
   }
 }
@@ -276,11 +404,11 @@ export function restartAgentProcess(name: string, opts: { fresh?: boolean } = {}
 // caller writing a prompt has a clear input field.
 const SURVEY_MODAL_RX = /How is Claude doing this session/
 
-function dismissSurveyModalIfPresent(session: string): void {
+function dismissSurveyModalIfPresent(session: string, host: string | null = null): void {
   try {
-    const pane = execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
+    const pane = captureTmux(host, ['capture-pane', '-t', session, '-p'])
     if (!SURVEY_MODAL_RX.test(pane)) return
-    execFileSync(TMUX, ['send-keys', '-t', session, '0'], { timeout: 5000 })
+    runTmux(host, ['send-keys', '-t', session, '0'], { timeout: 5000 })
     // Modal close is one frame; settle window so the next send-keys lands in
     // the prompt input, not the now-stale modal handler.
     execFileSync('/bin/sleep', ['0.3'], { timeout: 2000 })
@@ -298,13 +426,13 @@ function dismissSurveyModalIfPresent(session: string): void {
 // pick option 1 (Resume from summary, recommended) and Enter to confirm.
 const RESUME_SUMMARY_MODAL_RX = /Resume from summary/
 
-export function dismissResumeSummaryModalIfPresent(session: string): void {
+export function dismissResumeSummaryModalIfPresent(session: string, host: string | null = null): void {
   try {
-    const pane = execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
+    const pane = captureTmux(host, ['capture-pane', '-t', session, '-p'])
     if (!RESUME_SUMMARY_MODAL_RX.test(pane)) return
-    execFileSync(TMUX, ['send-keys', '-t', session, '1'], { timeout: 5000 })
+    runTmux(host, ['send-keys', '-t', session, '1'], { timeout: 5000 })
     execFileSync('/bin/sleep', ['0.1'], { timeout: 2000 })
-    execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+    runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
     // /compact starts immediately and can run for minutes; we only need to
     // unblock the modal so detectPaneState can transition off 'unknown'.
     execFileSync('/bin/sleep', ['0.3'], { timeout: 2000 })
@@ -335,18 +463,18 @@ const IDENTITY_SEND_DELAY_MS = 5000
 // (resumeMarveenSession / respawnMarveenSessionFresh), which previously left the
 // main session without its identity after auto-recovery. Fire-and-forget; all
 // errors are swallowed/logged so a missed setup never tears down the caller.
-export function scheduleIdentitySetup(session: string, displayName: string): void {
+export function scheduleIdentitySetup(session: string, displayName: string, host: string | null = null): void {
   setTimeout(() => {
     try {
-      dismissSurveyModalIfPresent(session)
-      dismissResumeSummaryModalIfPresent(session)
+      dismissSurveyModalIfPresent(session, host)
+      dismissResumeSummaryModalIfPresent(session, host)
     } catch (err) {
       logger.warn({ err, session }, 'Post-restart modal dismiss failed')
     }
     setTimeout(() => {
       try {
         for (const cmd of identitySlashCommands(displayName)) {
-          execFileSync(TMUX, ['send-keys', '-t', session, cmd, 'Enter'], { timeout: 5000 })
+          runTmux(host, ['send-keys', '-t', session, cmd, 'Enter'], { timeout: 5000 })
           execFileSync('/bin/sleep', ['1'], { timeout: 2000 })
         }
         logger.info({ session, displayName }, 'Set session /name')
@@ -374,9 +502,9 @@ const SUBMIT_RETRY_POLL_MS = '0.3'
 // Buffer-clear (Ctrl-U) used pre-flight when shouldClearTruncatedPreamble
 // flags a stale preamble. Sent as a single key name (no `-l` literal
 // flag) so tmux interprets it as the control sequence.
-export function clearInputBuffer(session: string): void {
+export function clearInputBuffer(session: string, host: string | null = null): void {
   try {
-    execFileSync(TMUX, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
+    runTmux(host, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
     // Settle briefly so the next send-keys lands in the freshly cleared
     // buffer rather than racing the Ctrl-U.
     execFileSync('/bin/sleep', ['0.1'], { timeout: 2000 })
@@ -404,19 +532,19 @@ export function clearInputBuffer(session: string): void {
 // still reports stuck, send up to SUBMIT_RETRY_MAX_ATTEMPTS extra
 // Enters. The retry budget bounds the loop so a pathologically stuck
 // pane gives up rather than spinning.
-export function sendPromptToSession(session: string, text: string): void {
-  dismissSurveyModalIfPresent(session)
-  dismissResumeSummaryModalIfPresent(session)
+export function sendPromptToSession(session: string, text: string, host: string | null = null): void {
+  dismissSurveyModalIfPresent(session, host)
+  dismissResumeSummaryModalIfPresent(session, host)
 
   // Pre-flight buffer-clear when a stale preamble is detected. Reading
   // the pane is best-effort: a capture failure here means we cannot
   // prove the buffer is clean, but proceeding without the clear is no
   // worse than the pre-fix status quo.
   try {
-    const preCapture = execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
+    const preCapture = captureTmux(host, ['capture-pane', '-t', session, '-p'])
     if (shouldClearTruncatedPreamble(preCapture)) {
       logger.info({ session }, 'Cleared stale preamble from input buffer before sending prompt')
-      clearInputBuffer(session)
+      clearInputBuffer(session, host)
     }
   } catch (err) {
     logger.warn({ err, session }, 'Pre-send capture-pane failed; skipping truncated-preamble check')
@@ -440,11 +568,11 @@ export function sendPromptToSession(session: string, text: string): void {
     }
     let chunk = oneLine.slice(i, end)
     if (chunk.startsWith('-')) chunk = ' ' + chunk
-    execFileSync(TMUX, ['send-keys', '-t', session, '-l', chunk], { timeout: 5000 })
+    runTmux(host, ['send-keys', '-t', session, '-l', chunk], { timeout: 5000 })
     i = end
     if (i < oneLine.length) execFileSync('/bin/sleep', ['0.03'], { timeout: 1000 })
   }
-  execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+  runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
 
   // Post-send retry loop. The payload hint is the first chunk of oneLine
   // (truncated to a safe length) so the verbatim-stuck path has something
@@ -453,7 +581,7 @@ export function sendPromptToSession(session: string, text: string): void {
   const payloadHint = oneLine.slice(0, Math.min(oneLine.length, 96))
   for (let attempt = 0; ; attempt++) {
     try { execFileSync('/bin/sleep', [SUBMIT_RETRY_POLL_MS], { timeout: 2000 }) } catch { /* best effort */ }
-    const pane = capturePane(session)
+    const pane = capturePane(session, host)
     const action = decideSubmitFollowup(pane, payloadHint, attempt, SUBMIT_RETRY_MAX_ATTEMPTS)
     if (action === 'done') break
     if (action === 'give-up') {
@@ -462,7 +590,7 @@ export function sendPromptToSession(session: string, text: string): void {
     }
     // action === 'retry-enter'
     try {
-      execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+      runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
     } catch (err) {
       logger.warn({ err, session, attempt }, 'Retry-Enter send failed')
       break
@@ -481,9 +609,9 @@ const PANE_READY_CONFIRM_DELAY_S = '0.25'
 // notification path (where the plugin, not sendPromptToSession, delivered
 // the text, so the post-send retry budget never ran). Best-effort: a
 // tmux failure is logged and swallowed so the watcher loop keeps going.
-export function sendEnterToSession(session: string): boolean {
+export function sendEnterToSession(session: string, host: string | null = null): boolean {
   try {
-    execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+    runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
     return true
   } catch (err) {
     logger.warn({ err, session }, 'sendEnterToSession: failed to send recovery Enter')
@@ -493,9 +621,9 @@ export function sendEnterToSession(session: string): boolean {
 
 // Capture a pane snapshot with an execSync timeout. Null on any error so
 // the caller can treat "capture failed" as "not ready".
-export function capturePane(session: string): string | null {
+export function capturePane(session: string, host: string | null = null): string | null {
   try {
-    return execSync(`${TMUX} capture-pane -t ${session} -p`, { timeout: 3000, encoding: 'utf-8' })
+    return captureTmux(host, ['capture-pane', '-t', session, '-p'])
   } catch {
     return null
   }
@@ -519,14 +647,14 @@ export function capturePane(session: string): string | null {
 //      returns true. Cost on the ready path: ~250ms sleep plus a second
 //      tmux capture-pane round-trip (typically tens of ms). Busy pass
 //      through layer 1 and return immediately without the delay.
-export function isSessionReadyForPrompt(session: string): boolean {
-  const first = capturePane(session)
+export function isSessionReadyForPrompt(session: string, host: string | null = null): boolean {
+  const first = capturePane(session, host)
   if (first == null) return false
   if (detectPaneState(first) !== 'idle') return false
 
   try { execFileSync('/bin/sleep', [PANE_READY_CONFIRM_DELAY_S], { timeout: 2000 }) } catch { /* best effort */ }
 
-  const second = capturePane(session)
+  const second = capturePane(session, host)
   if (second == null) return false
   return detectPaneState(second) === 'idle'
 }

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -1,9 +1,9 @@
 import { execFileSync } from 'node:child_process'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID } from '../config.js'
-import { listAgentNames } from './agent-config.js'
+import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
 import {
-  isAgentRunning,
+  agentRunState,
   agentSessionName,
   restartAgentProcess,
   capturePane,
@@ -56,8 +56,8 @@ function sessionFor(name: string): string {
   return name === MAIN_AGENT_ID ? MAIN_CHANNELS_SESSION : agentSessionName(name)
 }
 
-function paneIsIdle(session: string): boolean {
-  const pane = capturePane(session)
+function paneIsIdle(session: string, host: string | null): boolean {
+  const pane = capturePane(session, host)
   if (pane == null) return false
   return detectPaneState(pane) === 'idle'
 }
@@ -81,8 +81,14 @@ function checkAgent(name: string, nowMs: number): void {
     return
   }
   // Sub-agents must be up to be restarted; the main session is launchd-managed
-  // (always considered present).
-  if (name !== MAIN_AGENT_ID && !isAgentRunning(name)) return
+  // (always considered present). Branch explicitly on the tri-state run state:
+  // ONLY 'running' is eligible. 'unreachable' (remote laptop briefly out of
+  // reach) is never auto-restarted -- the agent is almost certainly still alive
+  // on the laptop, and restarting would be wrong AND risk a duplicate session
+  // (the core SSH-independence invariant). 'stopped' is also left alone (auto-
+  // restart cycles running sessions on a schedule; it does not resurrect dead
+  // ones, matching the prior local behavior).
+  if (name !== MAIN_AGENT_ID && agentRunState(name) !== 'running') return
 
   // Seed on first sight so a daily slot that already elapsed before boot does
   // not fire now.
@@ -96,7 +102,8 @@ function checkAgent(name: string, nowMs: number): void {
   if (!restartDue(lastRestart.get(name) ?? null, nowMs, dueAt)) return
 
   const session = sessionFor(name)
-  if (!paneIsIdle(session)) {
+  const host = name === MAIN_AGENT_ID ? null : readAgentRemoteHost(name)
+  if (!paneIsIdle(session, host)) {
     logger.info({ name, session }, 'auto-restart: due but pane is busy, deferring to next tick')
     return
   }

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -1,5 +1,3 @@
-import { execSync } from 'node:child_process'
-import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID } from '../config.js'
 import {
@@ -18,16 +16,15 @@ import {
 } from '../prompt-safety.js'
 import { isTrustedPeer } from '../team-trust.js'
 import { COORDINATOR_AGENT_ID } from '../channel-coordinator/ingest.js'
-import { isKnownAgent } from './agent-config.js'
+import { isKnownAgent, readAgentRemoteHost } from './agent-config.js'
 import { readAgentTeam } from './agent-team.js'
 import {
   agentSessionName,
   isSessionReadyForPrompt,
   sendPromptToSession,
+  sessionExistsOnHost,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-
-const TMUX = resolveFromPath('tmux')
 
 // Channel-coordinator sources whose messages are real inbound user messages
 // (relayed during a native-channel disconnect window), NOT inter-agent data.
@@ -82,12 +79,12 @@ export function startMessageRouter(): NodeJS.Timeout {
       // message as pending forever. Mirror the scheduler's session resolution.
       const isMainAgent = msg.to_agent === MAIN_AGENT_ID
       const session = isMainAgent ? MAIN_CHANNELS_SESSION : agentSessionName(msg.to_agent)
+      // Remote sub-agents run their tmux session on the laptop; resolve the host
+      // so the existence/readiness checks and the send all cross the ssh
+      // boundary. Local agents (and the main channels agent) stay host=null.
+      const host = isMainAgent ? null : readAgentRemoteHost(msg.to_agent)
 
-      let sessionExists = false
-      try {
-        const sessions = execSync(`${TMUX} list-sessions -F "#{session_name}"`, { timeout: 3000, encoding: 'utf-8' })
-        sessionExists = sessions.split('\n').some(s => s.trim() === session)
-      } catch { /* no tmux */ }
+      const sessionExists = sessionExistsOnHost(host, session)
 
       if (shouldAbandon(sessionExists, ageMs, MESSAGE_ABANDON_WINDOW_MS)) {
         logger.warn({ id: msg.id, from: msg.from_agent, to: msg.to_agent, ageMs }, 'Agent message abandoned: target session absent for full retry window')
@@ -106,7 +103,7 @@ export function startMessageRouter(): NodeJS.Timeout {
         continue
       }
 
-      if (!isSessionReadyForPrompt(session)) {
+      if (!isSessionReadyForPrompt(session, host)) {
         if (!routerLoggedMisses.has(msg.id)) {
           logger.warn({ id: msg.id, to: msg.to_agent, session }, 'Agent message target session busy, will retry')
           routerLoggedMisses.add(msg.id)
@@ -161,7 +158,7 @@ export function startMessageRouter(): NodeJS.Timeout {
         }
         // Inline preamble so a fresh session (post hard-restart) doesn't miss
         // the context that explains the tag semantics.
-        sendPromptToSession(session, prefix + wrapped)
+        sendPromptToSession(session, prefix + wrapped, host)
         if (!markMessageDelivered(msg.id)) {
           logger.warn({ id: msg.id }, 'markMessageDelivered affected 0 rows (deleted concurrently?)')
         }

--- a/src/web/remote-status-cache.ts
+++ b/src/web/remote-status-cache.ts
@@ -1,0 +1,46 @@
+// Short-TTL cache for remote-agent status so the synchronous dashboard
+// endpoints (`/api/agents`, polled on load; `/api/agents/activity`, polled every
+// 3s) do not issue a fresh blocking ssh call on every request. A remote ssh
+// round-trip against a sleeping laptop can take up to the ConnectTimeout/
+// ServerAlive bound (~5s), and Node's event loop is single-threaded, so an
+// uncached call would freeze the dashboard for ALL agents (local included).
+//
+// With a few-second TTL each remote agent is probed at most once per window;
+// every other poll reads the cache and returns instantly. NOTE: the miss path
+// fetches SYNCHRONOUSLY -- a cold miss against a sleeping laptop blocks that one
+// request for the full ssh timeout (~5-8s). The TTL bounds this to once per
+// window per agent (the dominant fix), so the dashboard is not frozen on every
+// poll, but it is not non-blocking. A throwing fetch (host unreachable) never
+// escapes: the last-known value is returned if we have one, otherwise the
+// caller-supplied fallback. Local agents are never cached -- their tmux calls
+// are sub-millisecond, so they always fetch fresh.
+//
+// (Fully async/non-blocking refresh via child_process.spawn is a deferred idea.)
+export class RemoteStatusCache<T> {
+  private store = new Map<string, { value: T; at: number }>()
+
+  constructor(private readonly ttlMs: number) {}
+
+  /**
+   * Return a fresh-enough cached value, or call `fetch()` once, cache, and
+   * return it. If `fetch` throws, return the last-known value when present, else
+   * `fallback` (when provided) -- the error never propagates to the HTTP layer.
+   */
+  getOrRefresh(key: string, nowMs: number, fetch: () => T, fallback?: T): T {
+    const entry = this.store.get(key)
+    if (entry && nowMs - entry.at < this.ttlMs) return entry.value
+    try {
+      const value = fetch()
+      this.store.set(key, { value, at: nowMs })
+      return value
+    } catch {
+      if (entry) return entry.value
+      return fallback as T
+    }
+  }
+
+  /** Drop a key (e.g. when an agent is deleted or its remote config cleared). */
+  invalidate(key: string): void {
+    this.store.delete(key)
+  }
+}

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -28,6 +28,9 @@ import {
   readAgentAuthMode,
   writeAgentAuthMode,
   readAgentClaudeConfigDir,
+  readAgentRemoteConfig,
+  readAgentRemoteHost,
+  writeAgentRemoteConfig,
   type AuthMode,
 } from '../agent-config.js'
 import {
@@ -70,6 +73,7 @@ import {
 } from '../agent-scaffold.js'
 import {
   isAgentRunning,
+  agentRunState,
   startAgentProcess,
   stopAgentProcess,
   restartAgentProcess,
@@ -80,6 +84,8 @@ import {
   capturePane,
 } from '../agent-process.js'
 import { addDesiredAgent, removeDesiredAgent } from '../agent-desired-state.js'
+import { RemoteStatusCache } from '../remote-status-cache.js'
+import type { AgentRunState } from '../ssh-tmux.js'
 import { readActiveModelFromProjectDir, readContextTokensFromProjectDir } from '../active-model.js'
 import { detectPaneState } from '../../pane-state.js'
 import { detectReauthNeeded } from '../reauth-detect.js'
@@ -97,6 +103,20 @@ import { readBody, json, serveFile } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
 
 const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord'])
+
+// Short-TTL caches so the synchronous, frequently-polled status endpoints
+// (`/api/agents` on load, `/api/agents/activity` every 3s) don't issue a fresh
+// blocking ssh call per remote agent per request. Only remote agents are cached;
+// local agents fetch fresh (sub-ms tmux). See remote-status-cache.ts.
+const remoteRunStateCache = new RemoteStatusCache<AgentRunState>(5000)
+const remotePaneCache = new RemoteStatusCache<string | null>(3000)
+
+// Resolve an agent's run state, cached for remote agents to avoid blocking on
+// ssh. `isRemote` is passed by the caller (it already read the remote config).
+function agentRunStateCached(name: string, isRemote: boolean): AgentRunState {
+  if (!isRemote) return agentRunState(name)
+  return remoteRunStateCache.getOrRefresh(name, Date.now(), () => agentRunState(name), 'unreachable')
+}
 
 // Discord channel ids are snowflakes — base-10 numeric ids, 17 to 20 digits
 // long in practice (current Discord scheme is 64-bit, with the leading bit
@@ -280,6 +300,11 @@ interface AgentSummary {
   hasDiscord: boolean
   status: 'configured' | 'draft'
   running: boolean
+  /** Tri-state: 'running' | 'stopped' | 'unreachable' (remote ssh failure). */
+  runState: AgentRunState
+  /** Remote ssh destination + workdir, or null for a local agent. */
+  remoteHost: string | null
+  remoteWorkdir: string | null
   session?: string
   hasAvatar: boolean
   autoRestart: AutoRestartConfig
@@ -311,19 +336,26 @@ function getAgentSummary(name: string): AgentSummary {
   const hasClaudeMd = claudeMd.trim().length > 0
   const hasSoulMd = soulMd.trim().length > 0
 
-  const proc = getAgentProcessInfo(name)
-  const runningSince = proc.running ? getAgentRunningSince(name) : null
+  // Resolve run state through the cache (remote agents) so listing the fleet
+  // never blocks on a sleeping laptop's ssh timeout. `running` is derived from
+  // it; `unreachable` reads as not-running but is surfaced distinctly so the UI
+  // does not show a still-alive remote agent as "stopped".
+  const remote = readAgentRemoteConfig(name)
+  const runState = agentRunStateCached(name, remote.host != null)
+  const running = runState === 'running'
+  const session = running ? agentSessionName(name) : undefined
+  const runningSince = running ? getAgentRunningSince(name) : null
 
   // Reauth badge: only meaningful for a running session (a stopped agent has
   // no pane to inspect). One capture-pane per running agent on the list poll.
-  const reauth = proc.running ? detectReauthNeeded(capturePane(agentSessionName(name))) : { needsReauth: false }
+  const reauth = running ? detectReauthNeeded(capturePane(agentSessionName(name))) : { needsReauth: false }
 
   return {
     name,
     displayName: readAgentDisplayName(name),
     description: extractDescriptionFromClaudeMd(claudeMd),
     model: readAgentModel(name),
-    activeModel: proc.running ? readActiveModelFromProjectDir(dir, runningSince ?? undefined, readAgentClaudeConfigDir(name) ?? undefined) : null,
+    activeModel: running ? readActiveModelFromProjectDir(dir, runningSince ?? undefined, readAgentClaudeConfigDir(name) ?? undefined) : null,
     runningSince,
     authMode: readAgentAuthMode(name),
     securityProfile: readAgentSecurityProfile(name),
@@ -332,11 +364,14 @@ function getAgentSummary(name: string): AgentSummary {
     telegramBotUsername: tg.botUsername,
     hasDiscord: dc.hasDiscord,
     status: hasClaudeMd && hasSoulMd ? 'configured' : 'draft',
-    running: proc.running,
-    session: proc.session,
+    running,
+    runState,
+    remoteHost: remote.host,
+    remoteWorkdir: remote.workdir,
+    session,
     hasAvatar: findAvatarForAgent(name) !== null,
     autoRestart: readAutoRestartConfig(name),
-    contextTokens: proc.running ? readContextTokensFromProjectDir(dir, readAgentClaudeConfigDir(name) ?? undefined) : null,
+    contextTokens: running ? readContextTokensFromProjectDir(dir, readAgentClaudeConfigDir(name) ?? undefined) : null,
     needsReauth: reauth.needsReauth,
     reauthReason: reauth.reason,
   }
@@ -453,9 +488,19 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     }
 
     for (const name of listAgentNames()) {
-      const running = isAgentRunning(name)
-      const pane = running ? capturePane(agentSessionName(name)) : null
-      entries.push({ name, isMain: false, running, state: label(running, pane), tail: tailOf(pane) })
+      // Remote agents: resolve run state + pane through the short-TTL caches so
+      // this 3s-polled endpoint never blocks the event loop on an ssh timeout.
+      const host = readAgentRemoteHost(name)
+      const runState = agentRunStateCached(name, host != null)
+      const running = runState === 'running'
+      let pane: string | null = null
+      if (running) {
+        pane = host
+          ? remotePaneCache.getOrRefresh(name, Date.now(), () => capturePane(agentSessionName(name), host), null)
+          : capturePane(agentSessionName(name))
+      }
+      const state = runState === 'unreachable' ? 'unreachable' : label(running, pane)
+      entries.push({ name, isMain: false, running, state, tail: tailOf(pane) })
     }
 
     json(res, entries)
@@ -800,6 +845,26 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     try { data = JSON.parse(body.toString()) } catch { json(res, { error: 'invalid JSON' }, 400); return true }
     const saved = writeAutoRestartConfig(name, data)
     json(res, { ok: true, autoRestart: saved })
+    return true
+  }
+
+  // PUT /api/agents/:name/remote -- set or clear the remote host + workdir that
+  // makes this agent's tmux session run on another machine over ssh. Empty
+  // strings clear the fields (revert to local). The main agent is always local.
+  const remoteCfgMatch = path.match(/^\/api\/agents\/([^/]+)\/remote$/)
+  if (remoteCfgMatch && method === 'PUT') {
+    const name = decodeURIComponent(remoteCfgMatch[1])
+    if (name === MAIN_AGENT_ID) { json(res, { error: 'Main agent is always local' }, 400); return true }
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    const body = await readBody(req)
+    let data: { host?: string; workdir?: string }
+    try { data = JSON.parse(body.toString() || '{}') } catch { json(res, { error: 'invalid JSON' }, 400); return true }
+    const result = writeAgentRemoteConfig(name, data.host ?? '', data.workdir ?? '')
+    if (!result.ok) { json(res, { error: result.error }, 400); return true }
+    // Config changed -> drop any cached status so the next poll reflects it.
+    remoteRunStateCache.invalidate(name)
+    remotePaneCache.invalidate(name)
+    json(res, { ok: true, remoteHost: result.remote.host, remoteWorkdir: result.remote.workdir })
     return true
   }
 
@@ -1172,13 +1237,14 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
     if (!isAgentRunning(name)) { json(res, { error: 'Agent is not running' }, 400); return true }
     const session = agentSessionName(name)
+    const host = readAgentRemoteHost(name)
     try {
-      sendPromptToSession(session, '/login')
+      sendPromptToSession(session, '/login', host)
       // Wait for Claude Code to render the auth URL (typically 3-6s)
       let authUrl: string | null = null
       for (let i = 0; i < 12; i++) {
         execSync('sleep 1', { timeout: 3000 })
-        const pane = capturePane(session)
+        const pane = capturePane(session, host)
         if (!pane) continue
         const urlMatch = pane.match(/https:\/\/console\.anthropic\.com\/[^\s"']+/)
           || pane.match(/https:\/\/auth\.anthropic\.com\/[^\s"']+/)

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -1,7 +1,5 @@
 import { join } from 'node:path'
 import { readFileSync } from 'node:fs'
-import { execSync, execFileSync } from 'node:child_process'
-import { resolveFromPath } from '../platform.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { logger } from '../logger.js'
 import {
@@ -28,19 +26,20 @@ import {
   listScheduledTasks,
   type ScheduledTask,
 } from './scheduled-tasks-io.js'
-import { listAgentNames, readFileOr } from './agent-config.js'
+import { listAgentNames, readFileOr, readAgentRemoteHost } from './agent-config.js'
 import {
   agentSessionName,
   isAgentRunning,
   isSessionReadyForPrompt,
   sendPromptToSession,
   startAgentProcess,
+  sessionExistsOnHost,
+  capturePane,
+  sendEnterToSession,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
 import { runCommandTask } from './command-task.js'
-
-const TMUX = resolveFromPath('tmux')
 
 // --- Schedule Runner ---
 // Checks every minute if any scheduled task is due and injects the prompt
@@ -95,20 +94,21 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
     ? task.targetSession
     : isMainAgent ? MAIN_CHANNELS_SESSION : agentSessionName(agentName)
 
-  let sessionExists = false
-  try {
-    const sessions = execSync(`${TMUX} list-sessions -F "#{session_name}"`, { timeout: 3000, encoding: 'utf-8' })
-    sessionExists = sessions.split('\n').some(s => s.trim() === session)
-  } catch { /* no tmux */ }
+  // A remote sub-agent's session lives on the laptop -- resolve its host so the
+  // existence/readiness checks and the send cross the ssh boundary. A custom
+  // targetSession override and the main channels agent stay local (host=null).
+  const host = (task.targetSession || isMainAgent) ? null : readAgentRemoteHost(agentName)
 
-  if (!sessionExists) {
+  if (!sessionExistsOnHost(host, session)) {
     // Auto-start the agent, then deliver on a later tick. A daily batch agent
     // (e.g. a `0 2 * * *` digest) has no 24/7 session, so a cron fire used to
     // just skip here -- the task never ran. Launch the session now and return
     // 'starting'; the caller enqueues a retry that bypasses skipIfBusy (waking
     // the agent for its scheduled run is the whole point, so a skipIfBusy=true
     // task must NOT drop the delivery). The next tick finds the session up and
-    // sends once Claude has booted (isSessionReadyForPrompt).
+    // sends once Claude has booted (isSessionReadyForPrompt). host-aware:
+    // startAgentProcess is itself remote-aware and launches over ssh when the
+    // target agent is remote, so a missing remote session is auto-started too.
     const start = startAgentProcess(agentName)
     if (!start.ok) {
       // "already running" means it raced up between the check and here -- treat
@@ -127,7 +127,7 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
   // will process it at the next idle slot. This prevents the infinite
   // retry loop observed when the target session stays busy for hours
   // (275 retries overnight in production).
-  if (!task.forceSend && !isSessionReadyForPrompt(session)) {
+  if (!task.forceSend && !isSessionReadyForPrompt(session, host)) {
     logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session busy or has pending input, will retry')
     return 'busy'
   }
@@ -169,7 +169,7 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
       UNTRUSTED_PREAMBLE + '\n' +
       prefix.trimEnd() + '\n\n' +
       wrapUntrusted(`scheduled-task:${task.name}`, task.prompt)
-    sendPromptToSession(session, fullPrompt)
+    sendPromptToSession(session, fullPrompt, host)
     scheduleLastRun.set(task.name, now)
     persistScheduleLastRun()
     appendTaskRun(task.name, agentName)
@@ -186,14 +186,16 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
       : `[Utemezett feladat: ${task.name}]`
     const resubmit = (attempt: number) => {
       try {
-        const pane = execFileSync(TMUX, ['capture-pane', '-t', session, '-p'], { timeout: 3000, encoding: 'utf-8' })
-        const stuck = /❯\s+\S/.test(pane) && pane.includes(marker)
+        // Host-aware so a remote agent's post-send stuck-check + recovery Enter
+        // hit the laptop session, not a (nonexistent) local one.
+        const pane = capturePane(session, host)
+        const stuck = pane != null && /❯\s+\S/.test(pane) && pane.includes(marker)
         if (!stuck) return
         if (attempt >= 5) {
           logger.warn({ task: task.name, session }, 'Scheduled prompt still stuck after 5 Enter retries -- giving up')
           return
         }
-        execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 3000 })
+        sendEnterToSession(session, host)
         setTimeout(() => resubmit(attempt + 1), 3000)
       } catch (err) {
         logger.warn({ err, task: task.name }, 'Post-send resubmit failed')

--- a/src/web/ssh-tmux.ts
+++ b/src/web/ssh-tmux.ts
@@ -1,0 +1,196 @@
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { userInfo } from 'node:os'
+import { execFileSync } from 'node:child_process'
+
+// SSH + tmux transport primitives.
+//
+// Every tmux operation against a remote agent is routed through here so the
+// quoting and connection-option logic lives in ONE airtight, unit-tested place.
+// When `host` is null these helpers reduce to a bare local tmux call (the exact
+// pre-remote behavior); when `host` is set the tmux command is shell-quoted and
+// wrapped in `ssh <opts> <host> '<quoted tmux cmd>'`.
+//
+// SECURITY: shQuote is the injection boundary. Remote tmux args include
+// arbitrary inter-agent message content (via `send-keys -l <chunk>`), so a
+// quoting flaw here is a remote command injection. POSIX single-quoting is the
+// canonical airtight escape: wrap in single quotes, and replace every embedded
+// single quote with the four-char sequence '\'' (close-quote, escaped-quote,
+// open-quote). Inside single quotes EVERYTHING else (spaces, $, ;, &, globs,
+// brackets) is literal.
+
+/** POSIX single-quote a string so it survives re-parsing by a remote shell. */
+export function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+// Private ControlMaster socket directory. `/tmp/<file>` is world-writable on
+// Linux (sticky-bit 1777) which permits a pre-creation socket-hijack race;
+// XDG_RUNTIME_DIR (mode 0700, per-user) avoids it. Falls back to a per-uid
+// /tmp subdir that we create mode 0700 ourselves.
+export function controlDir(): string {
+  const xdg = process.env.XDG_RUNTIME_DIR
+  if (xdg && xdg.trim()) return join(xdg.trim(), 'marveen-ssh')
+  // No XDG_RUNTIME_DIR (rare on the Linux target): a per-user private /tmp dir.
+  // getuid is always present on Linux; the no-getuid fallback (non-POSIX) uses
+  // the username so distinct users never collide on the same /tmp path.
+  let id: string
+  if (typeof process.getuid === 'function') id = String(process.getuid())
+  else { try { id = userInfo().username } catch { id = 'default' } }
+  return `/tmp/marveen-ssh-${id}`
+}
+
+/** ControlMaster socket path template (ssh expands %r/%h/%p itself). */
+export const CONTROL_PATH: string = join(controlDir(), 'cm-%r@%h:%p')
+
+// Shared ssh options for every remote call.
+//  - BatchMode=yes        : never block on an interactive auth prompt.
+//  - ConnectTimeout=5     : bound the TCP handshake when the host is offline.
+//  - ServerAliveInterval/CountMax: detect an alive-but-unresponsive remote in
+//    ~4s (ConnectTimeout alone does NOT bound a hung post-connect command).
+//  - ControlMaster=auto + ControlPersist=60 : multiplex one connection so the
+//    5s delivery loop / watchers reuse it instead of re-handshaking each tick.
+export const SSH_OPTS: readonly string[] = [
+  '-o', 'BatchMode=yes',
+  '-o', 'ConnectTimeout=5',
+  '-o', 'ServerAliveInterval=2',
+  '-o', 'ServerAliveCountMax=2',
+  '-o', 'ControlMaster=auto',
+  '-o', `ControlPath=${CONTROL_PATH}`,
+  '-o', 'ControlPersist=60',
+]
+
+export interface TmuxInvocation {
+  file: string
+  args: string[]
+}
+
+/**
+ * Build the {file, args} to run `tmux <tmuxArgs>` locally (host null) or on a
+ * remote host over ssh. The remote command rides as ONE shell-quoted string so
+ * the remote shell re-parses it back into the same argv.
+ */
+export function buildTmuxInvocation(
+  host: string | null,
+  localTmuxBin: string,
+  tmuxArgs: string[],
+  remoteTmuxBin = 'tmux',
+): TmuxInvocation {
+  if (host == null) return { file: localTmuxBin, args: tmuxArgs }
+  // remoteTmuxBin is a trusted constant ('tmux'); only the args carry data, so
+  // only the args are quoted. The whole thing is a single argv element for ssh.
+  const remoteCmd = [remoteTmuxBin, ...tmuxArgs.map(shQuote)].join(' ')
+  return { file: 'ssh', args: [...SSH_OPTS, host, remoteCmd] }
+}
+
+/**
+ * Build an ssh invocation for a raw remote command (e.g. `which claude`, or a
+ * `test -d <shQuoted path>` probe). The caller is responsible for shQuoting any
+ * data embedded in `remoteCmd`.
+ */
+export function buildSshExec(host: string, remoteCmd: string): TmuxInvocation {
+  return { file: 'ssh', args: [...SSH_OPTS, host, remoteCmd] }
+}
+
+/** True when `session` appears as an exact line in `tmux list-sessions` output. */
+export function sessionInList(listOutput: string, session: string): boolean {
+  return listOutput.split('\n').some(line => line.trim() === session)
+}
+
+export type AgentRunState = 'running' | 'stopped' | 'unreachable'
+
+/**
+ * Classify an agent's run state from a `tmux list-sessions` result. `listOutput`
+ * is null when the query itself failed (exec threw / ssh error). For a remote
+ * agent a failed query means "unreachable" (the session is almost certainly
+ * still alive on the laptop, we just cannot see it) -- NOT "stopped", so callers
+ * never auto-restart or double-start it. For a local agent a failed query means
+ * there is no tmux server, i.e. stopped.
+ */
+export function classifyRunState(
+  listOutput: string | null,
+  session: string,
+  isRemote: boolean,
+): AgentRunState {
+  if (listOutput == null) return isRemote ? 'unreachable' : 'stopped'
+  return sessionInList(listOutput, session) ? 'running' : 'stopped'
+}
+
+/**
+ * Classify run state when the `tmux list-sessions` probe FAILED (threw), from
+ * the exec exit status. The key distinction for a remote agent: `tmux
+ * list-sessions` exits non-zero ("no server running", typically 1) on a
+ * perfectly REACHABLE laptop that simply has no tmux server/session yet -- that
+ * is 'stopped' (and must be startable), NOT 'unreachable'. Only a real ssh
+ * transport failure (exit 255) or a killed/timed-out connection (no numeric
+ * status) is 'unreachable'. Local failures are always 'stopped' (no tmux server).
+ */
+export function classifyRunStateFromExit(
+  exitStatus: number | null | undefined,
+  isRemote: boolean,
+): AgentRunState {
+  if (!isRemote) return 'stopped'
+  if (typeof exitStatus === 'number' && exitStatus !== 255) return 'stopped'
+  return 'unreachable'
+}
+
+/**
+ * Build the channel-less remote launch command run inside `tmux new-session -d`.
+ * Uses the laptop's own `~/.claude` login (no token/vault/CLAUDE_CONFIG_DIR env,
+ * no --channels). PATH covers both macOS (/opt/homebrew) and Linux ($HOME/.local)
+ * binary locations. The model is shell-quoted so a `[1m]` suffix is not globbed.
+ */
+export function buildRemoteLaunchCommand(opts: {
+  workdir: string
+  model: string
+  continue: boolean
+}): string {
+  const path = 'export PATH="$HOME/.bun/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"'
+  const cont = opts.continue ? '--continue ' : ''
+  return `${path} && cd ${shQuote(opts.workdir)} && claude ${cont}--dangerously-skip-permissions --model ${shQuote(opts.model)}`
+}
+
+/**
+ * Build the remote `test -d` command that probes whether a prior Claude Code
+ * session dir exists for an absolute workdir (so the launcher knows whether to
+ * pass --continue). $HOME MUST stay outside the single-quoted region so the
+ * remote shell expands it; only the validated, leading-dash-encoded segment is
+ * single-quoted. The two adjacent quotings concatenate into one path word, so
+ * the leading '-' is never parsed as a `test` flag. (shQuoting the whole path --
+ * including $HOME -- would test a directory literally named "$HOME", which never
+ * exists, silently dropping --continue on every remote launch.)
+ */
+export function buildContinueProbeCommand(absWorkdir: string): string {
+  const encoded = absWorkdir.replace(/\//g, '-')
+  return 'test -d "$HOME/.claude/projects/"' + shQuote(encoded)
+}
+
+let controlDirEnsured = false
+
+/** Create the private ControlMaster socket dir (mode 0700) once, best-effort. */
+export function ensureControlDir(): void {
+  if (controlDirEnsured) return
+  try {
+    mkdirSync(controlDir(), { recursive: true, mode: 0o700 })
+    controlDirEnsured = true
+  } catch {
+    /* best effort: a missing dir only costs us connection multiplexing */
+  }
+}
+
+/**
+ * Drop a dead/stale ControlMaster master for `host` before a fresh connection.
+ * After a marveen restart the previous run's socket can linger; with
+ * BatchMode=yes a dead socket may fail fast instead of falling back, so we
+ * proactively tell ssh to exit any existing master. No master => harmless error.
+ */
+export function cleanStaleSshSockets(host: string): void {
+  try {
+    execFileSync('ssh', ['-O', 'exit', '-o', `ControlPath=${CONTROL_PATH}`, host], {
+      timeout: 3000,
+      stdio: 'ignore',
+    })
+  } catch {
+    /* no live master to drop -- expected on the common path */
+  }
+}

--- a/src/web/stuck-input-watcher.ts
+++ b/src/web/stuck-input-watcher.ts
@@ -1,6 +1,6 @@
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID } from '../config.js'
-import { listAgentNames } from './agent-config.js'
+import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
 import { isAgentRunning, capturePane, sendEnterToSession } from './agent-process.js'
 import { resolveAgentSession } from './channel-mcp-reconnect.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
@@ -48,8 +48,8 @@ const NO_STATE: StuckInputState = { parkedSig: null, firstSeenAt: null, lastReco
 
 const watchState = new Map<string, StuckInputState>()
 
-function checkSession(label: string, session: string): void {
-  const pane = capturePane(session)
+function checkSession(label: string, session: string, host: string | null = null): void {
+  const pane = capturePane(session, host)
   // A failed capture is treated as "nothing parked" -- it ends any active
   // spell rather than holding stale state across a transient tmux miss.
   const sig = pane == null ? null : stuckInputSignature(pane)
@@ -68,7 +68,7 @@ function checkSession(label: string, session: string): void {
       { label, session, attempt: next.attempts },
       'stuck-input-watcher: parked input persisted past confirm window, sending recovery Enter',
     )
-    sendEnterToSession(session)
+    sendEnterToSession(session, host)
   } else if (next.parkedSig !== null && next.attempts >= THRESHOLDS.maxAttempts) {
     // Logged at most once per spell: the give-up is recorded on the tick
     // that spent the last attempt (attempts hits maxAttempts there), not
@@ -97,7 +97,7 @@ export function startStuckInputWatcher(): NodeJS.Timeout {
         continue
       }
       try {
-        checkSession(name, resolveAgentSession(name))
+        checkSession(name, resolveAgentSession(name), readAgentRemoteHost(name))
       } catch (err) {
         logger.debug({ err, agent: name }, 'stuck-input-watcher: agent check error')
       }

--- a/web/app.js
+++ b/web/app.js
@@ -1490,6 +1490,42 @@ function channelTip(isConnected) {
     : 'Offline: nincs csatorna bekötve (channel-less, csak inter-agent ágens).'
 }
 
+// Build the copy-paste tmux attach command for an agent live session. A local
+// agent session runs on the orchestrator host (a direct `tmux attach`); a remote
+// agent session runs on its configured remoteHost, reached over ssh. Only
+// meaningful for running agents.
+function tmuxAttachCommand(agent) {
+  const session = agent.session || ('agent-' + agent.name)
+  const direct = 'tmux attach -t ' + session
+  const remoteHost = agent.remoteHost || null
+  return remoteHost ? 'ssh ' + remoteHost + " -t '" + direct + "'" : direct
+}
+
+// Append a single "copy tmux attach command" button to a running agent card.
+// Clicks copy to clipboard and never bubble to the card open-detail handler.
+function attachTmuxCopyButtons(card, agent) {
+  const cmd = tmuxAttachCommand(agent)
+  const row = document.createElement('div')
+  row.className = 'agent-tmux-cmds'
+  const btn = document.createElement('button')
+  btn.type = 'button'
+  btn.className = 'tmux-copy-btn'
+  btn.setAttribute('aria-label', 'tmux attach parancs masolasa')
+  btn.title = cmd
+  btn.innerHTML = '<span class="tmux-copy-ico">⧉</span>tmux'
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation()
+    navigator.clipboard.writeText(cmd).then(() => {
+      const orig = btn.innerHTML
+      btn.classList.add('copied')
+      btn.innerHTML = '<span class="tmux-copy-ico">✓</span>masolva'
+      setTimeout(() => { btn.innerHTML = orig; btn.classList.remove('copied') }, 1400)
+    }).catch(() => showToast('Masolas sikertelen'))
+  })
+  row.appendChild(btn)
+  card.appendChild(row)
+}
+
 function renderAgents() {
   agentsGrid.querySelectorAll('.agent-card:not(.add-card)').forEach((el) => el.remove())
 
@@ -1582,6 +1618,9 @@ function renderAgents() {
       e.stopPropagation(); openTerminalModal(agent.name)
     })
     card.addEventListener('click', () => openAgentDetail(agent.name))
+    // Only running agents have a live session to look at, so only they get the
+    // copy-the-tmux-command buttons.
+    if (isRunning) attachTmuxCopyButtons(card, agent)
     agentsGrid.insertBefore(card, addBtn)
   }
 }

--- a/web/style.css
+++ b/web/style.css
@@ -924,6 +924,44 @@ main {
 .agent-model-badge.sonnet { background: var(--info-soft); color: var(--info); }
 .agent-model-badge.haiku { background: var(--success-soft); color: var(--success); }
 
+/* === Per-agent tmux attach copy buttons (running agents only) === */
+.agent-tmux-cmds {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+.tmux-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--text-muted);
+  background: var(--bg-input);
+  border: 1px solid var(--border, rgba(255,255,255,0.08));
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.tmux-copy-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.tmux-copy-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.tmux-copy-btn.copied {
+  color: var(--success);
+  border-color: var(--success);
+}
+.tmux-copy-ico {
+  font-size: 12px;
+  line-height: 1;
+}
+
 .marveen-card { border-left: 3px solid var(--accent); }
 .marveen-badge {
   font-size: 10px;


### PR DESCRIPTION
Integration of #320 onto current develop (Option B: we caused the conflict via same-day #321/#322, so we rebased + fixed the trivial `proc.running`→`running` instead of bouncing it back to @Janokapapa).

- Conflict in `schedule-runner.ts` resolved keeping BOTH the #320 host-aware routing and #321 auto-start.
- Compile error fixed (`proc.running`→`running`, agents.ts).
- #321 contract-test locators updated to the host-aware guard.

Verified: `tsc --noEmit` clean; full suite 1087/1088 (the 1 failure is the pre-existing #328 `{{WEB_PORT}}` seed issue, unrelated).

Co-authored-by: Janokapapa <7418240+Janokapapa@users.noreply.github.com>