### PR TITLE
fix(seed): substitute {{WEB_PORT}} in install scripts + hygiene known-set

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -676,6 +676,7 @@ if [ -d "$SCHED_TPL_DIR" ]; then
           -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
           -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
           -e "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" \
+          -e "s/{{WEB_PORT}}/${WEB_PORT:-3420}/g" \
           "$f" > "$target/$(basename "$f")"
     done
     ok "Utemezett feladat scaffoldolva: $task_name"
@@ -706,6 +707,7 @@ if [ -d "$SEED_SCHED_DIR" ]; then
           -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
           -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
           -e "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" \
+          -e "s/{{WEB_PORT}}/${WEB_PORT:-3420}/g" \
           "$f" > "$target/$(basename "$f")"
     done
     SCHED_NEW=$((SCHED_NEW + 1))

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -440,6 +440,7 @@ if [ -d "$SCHED_TPL_DIR" ]; then
           -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
           -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
           -e "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" \
+          -e "s/{{WEB_PORT}}/${WEB_PORT:-3420}/g" \
           "$f" > "$target/$(basename "$f")"
     done
     echo -e "  ${GREEN}✓${NC} Utemezett feladat scaffoldolva: $task_name"
@@ -575,6 +576,7 @@ if [ -d "$SEED_SCHED_DIR" ]; then
           -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
           -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
           -e "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" \
+          -e "s/{{WEB_PORT}}/${WEB_PORT:-3420}/g" \
           "$f" > "$target/$(basename "$f")"
     done
     SCHED_NEW=$((SCHED_NEW + 1))

--- a/src/__tests__/template-identity-hygiene.test.ts
+++ b/src/__tests__/template-identity-hygiene.test.ts
@@ -24,7 +24,7 @@ const TEMPLATE_DIRS = ['scheduled-tasks', 'templates', 'seed-scheduled-tasks', '
 
 // The identity placeholders the runtime seed (resolveTemplatePlaceholders)
 // substitutes, kept in sync with the install scripts' sed substitutions.
-const KNOWN_PLACEHOLDERS = ['PROJECT_ROOT', 'INSTALL_DIR', 'MAIN_AGENT_ID', 'BOT_NAME', 'OWNER_NAME']
+const KNOWN_PLACEHOLDERS = ['PROJECT_ROOT', 'INSTALL_DIR', 'MAIN_AGENT_ID', 'BOT_NAME', 'OWNER_NAME', 'WEB_PORT']
 
 // An absolute macOS/Linux home path embeds a real username. The trailing
 // slash is optional so a bare literal like "/Users/bob" at end of value is


### PR DESCRIPTION
## Mi a baj
A #328 hozzáadta a `{{WEB_PORT}}`-ot a dream-engine SKILL.md-hez + a runtime seedhez (agent-scaffold.ts), DE két helyen kimaradt -> develop PIROS + valós distribution-rés:
- A `template-identity-hygiene.test.ts` KNOWN_PLACEHOLDERS-éből hiányzott a WEB_PORT -> az 'every placeholder used under scheduled-tasks/ is in the known set' teszt bukott.
- Az install-macos.sh / install-linux.sh scheduled-task sed-blokkjai NEM substituálták a `{{WEB_PORT}}`-ot -> friss install a script-úton literális `{{WEB_PORT}}`-ot seedelne a dream-engine SKILL.md curl-URL-jébe (eltört volna).

## Fix
- WEB_PORT a teszt known-set-jébe (a runtime seed már substituálja, a teszt #1 validálja).
- `-e s/{{WEB_PORT}}/${WEB_PORT:-3420}/g` mindkét install-script scheduled-task sed-jébe (default 3420, .env WEB_PORT felülírja).

## Verify
- template-identity-hygiene: 4/4 zöld.
- tsc --noEmit: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)