### PR TITLE
feat(agent): interactive-tmux worker backend for runAgent (jun.15 subscription migration)

### DIFF
--- a/src/__tests__/agent-worker.test.ts
+++ b/src/__tests__/agent-worker.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { buildWorkerPrompt, decidePoll } from '../web/agent-worker.js'
+
+// Pure-logic tests for the interactive-tmux worker that backs runAgent on the
+// subscription (jun.15 migration). The live-session orchestration is exercised
+// by the heartbeat-path integration check; these cover the decision core.
+
+describe('buildWorkerPrompt', () => {
+  const out = '/w/scratch/abc.out'
+  const done = '/w/scratch/abc.done'
+
+  it('keeps the caller prompt verbatim and first (only content instruction)', () => {
+    const caller = 'Summarize today in 5 sentences. Magyarul.'
+    const p = buildWorkerPrompt(caller, out, done)
+    expect(p.startsWith(caller)).toBe(true)
+  })
+
+  it('directs the answer to the .out file and a done marker to the .done file', () => {
+    const p = buildWorkerPrompt('x', out, done)
+    expect(p).toContain(out)
+    expect(p).toContain(done)
+    expect(p).toMatch(/Write tool/)
+    expect(p).toMatch(/do not print the response|Do not print the response/i)
+  })
+
+  it('does not inject any persona / project voice', () => {
+    const p = buildWorkerPrompt('TASK', out, done)
+    expect(p).not.toMatch(/Marveen|Szabolcs|asszisztens/i)
+  })
+})
+
+describe('decidePoll', () => {
+  const base = { doneExists: false, sessionAlive: true, elapsedMs: 0, timeoutMs: 1000 }
+
+  it('returns ready as soon as the done sentinel exists', () => {
+    expect(decidePoll({ ...base, doneExists: true })).toBe('ready')
+  })
+
+  it('done takes priority even if the deadline passed and the session died', () => {
+    // A request that completed in the same tick the session died must still
+    // return its result, not be reported dead/timeout.
+    expect(decidePoll({ doneExists: true, sessionAlive: false, elapsedMs: 9999, timeoutMs: 1000 })).toBe('ready')
+  })
+
+  it('times out once past the deadline (no done yet)', () => {
+    expect(decidePoll({ ...base, elapsedMs: 1000 })).toBe('timeout')
+    expect(decidePoll({ ...base, elapsedMs: 1500 })).toBe('timeout')
+  })
+
+  it('fails fast (dead) when the session vanishes mid-run, before the deadline', () => {
+    expect(decidePoll({ ...base, sessionAlive: false, elapsedMs: 10 })).toBe('dead')
+  })
+
+  it('keeps waiting while alive, before the deadline, with no done yet', () => {
+    expect(decidePoll({ ...base, elapsedMs: 500 })).toBe('wait')
+  })
+})

--- a/src/__tests__/kanban-breakdown.test.ts
+++ b/src/__tests__/kanban-breakdown.test.ts
@@ -7,6 +7,11 @@ vi.mock('node:child_process', () => ({
   execSync: vi.fn(() => '/usr/local/bin/claude'),
 }))
 
+// generateBreakdown now routes through runAgent (the interactive worker), not
+// `claude -p`. Mock the agent module so the breakdown tests exercise the
+// parse/validate path without a live session.
+vi.mock('../agent.js', () => ({ runAgent: vi.fn() }))
+
 describe('kanban parent_id schema and subtask queries', () => {
   let db: ReturnType<typeof Database>
 
@@ -188,25 +193,21 @@ describe('validateSubtasks (from llm-breakdown)', () => {
   })
 })
 
-describe('generateBreakdown with claude -p', () => {
-  let mockedExecFile: ReturnType<typeof vi.fn>
+describe('generateBreakdown via worker (runAgent)', () => {
+  let mockedRunAgent: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    vi.resetModules()
-    const cp = await import('node:child_process')
-    mockedExecFile = vi.mocked(cp.execFile)
+    const agent = await import('../agent.js')
+    mockedRunAgent = vi.mocked(agent.runAgent)
   })
 
-  it('parses claude -p JSON result output', async () => {
+  it('parses the worker JSON array output', async () => {
     const subtasks = [
       { title: 'Step 1', description: 'Do first thing', assignee: null, priority: 'normal' },
       { title: 'Step 2', description: 'Do second thing', assignee: null, priority: 'high' },
     ]
-    mockedExecFile.mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
-      cb(null, JSON.stringify({ result: JSON.stringify(subtasks) }), '')
-      return { stdin: { write: () => {}, end: () => {} } } as any
-    })
+    mockedRunAgent.mockResolvedValue({ text: JSON.stringify(subtasks) })
 
     const { generateBreakdown } = await import('../web/llm-breakdown.js')
     const result = await generateBreakdown('Test card', 'Some description')
@@ -215,46 +216,38 @@ describe('generateBreakdown with claude -p', () => {
     expect(result.subtasks[1].priority).toBe('high')
   })
 
-  it('handles timeout error', async () => {
-    mockedExecFile.mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
-      const err = new Error('timed out') as any
-      err.killed = true
-      cb(err, '', '')
-      return { stdin: { write: () => {}, end: () => {} } } as any
-    })
+  it('strips a ```json fence the model may add despite instructions', async () => {
+    const subtasks = [{ title: 'T', description: 'D', assignee: null, priority: 'normal' }]
+    mockedRunAgent.mockResolvedValue({ text: '```json\n' + JSON.stringify(subtasks) + '\n```' })
 
     const { generateBreakdown } = await import('../web/llm-breakdown.js')
-    await expect(generateBreakdown('Test', null)).rejects.toThrow('timed out after 60s')
+    const result = await generateBreakdown('T', null)
+    expect(result.subtasks).toHaveLength(1)
   })
 
-  it('handles non-JSON output', async () => {
-    mockedExecFile.mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
-      cb(null, 'This is not JSON at all', '')
-      return { stdin: { write: () => {}, end: () => {} } } as any
-    })
+  it('throws when the worker returns no content (timeout / blocked)', async () => {
+    mockedRunAgent.mockResolvedValue({ text: null, error: 'worker timeout after 1200s' })
+
+    const { generateBreakdown } = await import('../web/llm-breakdown.js')
+    await expect(generateBreakdown('Test', null)).rejects.toThrow('no content')
+  })
+
+  it('throws on non-JSON output', async () => {
+    mockedRunAgent.mockResolvedValue({ text: 'This is not JSON at all' })
 
     const { generateBreakdown } = await import('../web/llm-breakdown.js')
     await expect(generateBreakdown('Test', null)).rejects.toThrow('parse')
   })
 
-  it('passes prompt via stdin (not in args)', async () => {
+  it('passes the full system+card prompt to runAgent', async () => {
     const subtasks = [{ title: 'T', description: 'D', assignee: null, priority: 'normal' }]
-    let stdinData = ''
-    mockedExecFile.mockImplementation((_cmd: any, args: any, _opts: any, cb: any) => {
-      expect(args).not.toContain(expect.stringContaining('card_title'))
-      cb(null, JSON.stringify({ result: JSON.stringify(subtasks) }), '')
-      return {
-        stdin: {
-          write: (data: string) => { stdinData = data },
-          end: () => {},
-        },
-      } as any
-    })
+    mockedRunAgent.mockResolvedValue({ text: JSON.stringify(subtasks) })
 
     const { generateBreakdown } = await import('../web/llm-breakdown.js')
     await generateBreakdown('My card', 'Description')
-    expect(stdinData).toContain('card_title')
-    expect(stdinData).toContain('My card')
+    const promptArg = mockedRunAgent.mock.calls[0][0] as string
+    expect(promptArg).toContain('card_title')
+    expect(promptArg).toContain('My card')
   })
 })
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -104,6 +104,14 @@ function resolveClaudeCodeBin(): string | undefined {
   return cachedClaudeCodeBin
 }
 
+// Backend selector (jun.15 subscription migration). 'worker' (default) routes
+// to a persistent INTERACTIVE Claude Code session in tmux (subscription login);
+// 'sdk' keeps the legacy Agent SDK `query` path (API billing) as an emergency
+// rollback via MARVEEN_AGENT_BACKEND=sdk.
+function agentBackend(): 'worker' | 'sdk' {
+  return (process.env.MARVEEN_AGENT_BACKEND || 'worker').toLowerCase() === 'sdk' ? 'sdk' : 'worker'
+}
+
 export async function runAgent(
   message: string,
   sessionId?: string,
@@ -112,6 +120,19 @@ export async function runAgent(
   cwd: string = PROJECT_ROOT,
   env?: Record<string, string | undefined>,
 ): Promise<{ text: string | null; newSessionId?: string; error?: string }> {
+  if (agentBackend() === 'worker') {
+    // The interactive worker is a single shared session with its own fixed,
+    // isolated, NEUTRAL cwd/config -- so the SDK-era per-call cwd/env isolation
+    // hacks (CLAUDE_CONFIG_DIR to dodge the telegram-plugin 409) are subsumed
+    // and intentionally ignored here. resume/sessionId is unsupported (no caller
+    // uses it). Dynamic import keeps the SDK module off the worker-path hot path
+    // and avoids any load-order coupling.
+    if (sessionId) logger.warn('runAgent(worker): resume/sessionId not supported on worker backend, ignoring')
+    const { runViaWorker } = await import('./web/agent-worker.js')
+    const { text, error } = await runViaWorker(message, AGENT_TIMEOUT_MS)
+    return { text, error }
+  }
+  // --- legacy SDK path (rollback: MARVEEN_AGENT_BACKEND=sdk; API billing) ---
   let newSessionId: string | undefined
   let resultText: string | null = null
   let blockedReason: string | undefined

--- a/src/web.ts
+++ b/src/web.ts
@@ -231,6 +231,16 @@ export function startWebServer(port = 3420): http.Server {
   const scheduleInterval = startScheduleRunner()
   logger.info('Schedule runner started (60s poll)')
 
+  // Pre-start the interactive agent worker (subscription backend) so the first
+  // heartbeat / scheduled generation after boot does not pay the cold-boot
+  // latency. runViaWorker still lazy-starts + restarts it on demand, so this is
+  // a warm-up, not a hard dependency. Skipped on the SDK rollback backend.
+  if ((process.env.MARVEEN_AGENT_BACKEND || 'worker').toLowerCase() !== 'sdk') {
+    import('./web/agent-worker.js')
+      .then(m => { m.startWorkerSession(); logger.info('Interactive agent worker pre-started') })
+      .catch(err => logger.warn({ err }, 'Failed to pre-start agent worker (will lazy-start on first use)'))
+  }
+
   const pluginMonitorInterval = startChannelPluginMonitor()
   logger.info('Channel plugin health monitor started (60s poll)')
 

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync, lstatSync, symlinkSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync, lstatSync, symlinkSync, realpathSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { resolveFromPath } from '../platform.js'
@@ -181,7 +181,10 @@ export function ensureWorkerCwd(): void {
   }
   const enabledPlugins: Record<string, boolean> = { ...(current.enabledPlugins ?? {}) }
   for (const p of WORKER_DISABLED_PLUGINS) enabledPlugins[p] = false
-  writeFileSync(settingsPath, JSON.stringify({ ...current, enabledPlugins }, null, 2) + '\n')
+  // skipDangerousModePermissionPrompt: suppress the "Bypass Permissions mode"
+  // first-run warning so the headless worker (launched with
+  // --dangerously-skip-permissions) reaches its prompt without a blocking modal.
+  writeFileSync(settingsPath, JSON.stringify({ ...current, enabledPlugins, skipDangerousModePermissionPrompt: true }, null, 2) + '\n')
 
   // Subscription auth: materialise the host login JSON as .credentials.json.
   const credentialsJson = readClaudeCodeOauthJson()
@@ -189,19 +192,29 @@ export function ensureWorkerCwd(): void {
     writeFileSync(join(WORKER_CONFIG_DIR, '.credentials.json'), credentialsJson, { mode: 0o600 })
   }
 
-  // Inherit project-scoped MCP servers under the worker's own cwd key.
+  // Inherit project-scoped MCP servers under the worker's own cwd key, AND
+  // pre-accept the first-run dialogs so the headless interactive session never
+  // parks on a modal (Trust folder / project onboarding). hasCompletedOnboarding
+  // (global) suppresses the theme picker + login onboarding. We stamp the trust
+  // flags on BOTH WORKER_HOME and its realpath (macOS /var, symlinked $HOME
+  // edge-cases) since Claude Code keys trust by the resolved workspace path.
   try {
     const homeClaudeJson = join(homedir(), '.claude.json')
-    if (existsSync(homeClaudeJson)) {
-      const parsed = JSON.parse(readFileSync(homeClaudeJson, 'utf-8')) as { projects?: Record<string, unknown> }
-      const projects = parsed.projects
-      if (projects && typeof projects === 'object' && projects[PROJECT_ROOT] && !projects[WORKER_HOME]) {
-        projects[WORKER_HOME] = projects[PROJECT_ROOT]
-      }
-      writeFileSync(join(WORKER_CONFIG_DIR, '.claude.json'), JSON.stringify(parsed, null, 2) + '\n', { mode: 0o600 })
-    }
+    const parsed: { projects?: Record<string, unknown>; hasCompletedOnboarding?: boolean; [k: string]: unknown } =
+      existsSync(homeClaudeJson) ? JSON.parse(readFileSync(homeClaudeJson, 'utf-8')) : {}
+    parsed.hasCompletedOnboarding = true
+    const projects: Record<string, unknown> = (parsed.projects && typeof parsed.projects === 'object') ? parsed.projects : {}
+    const base = (projects[PROJECT_ROOT] && typeof projects[PROJECT_ROOT] === 'object')
+      ? projects[PROJECT_ROOT] as Record<string, unknown>
+      : {}
+    const trusted = { ...base, hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true, projectOnboardingSeenCount: 1 }
+    const keys = new Set<string>([WORKER_HOME])
+    try { keys.add(realpathSync(WORKER_HOME)) } catch { /* dir may not resolve yet */ }
+    for (const k of keys) projects[k] = { ...trusted }
+    parsed.projects = projects
+    writeFileSync(join(WORKER_CONFIG_DIR, '.claude.json'), JSON.stringify(parsed, null, 2) + '\n', { mode: 0o600 })
   } catch (err) {
-    logger.warn({ err }, 'worker: failed to materialise .claude.json (worker will lack project MCPs)')
+    logger.warn({ err }, 'worker: failed to materialise .claude.json (worker may park on a first-run modal)')
   }
 }
 

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -1,0 +1,322 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync, lstatSync, symlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { resolveFromPath } from '../platform.js'
+import { logger } from '../logger.js'
+import { PROJECT_ROOT } from '../config.js'
+import {
+  capturePane,
+  isSessionReadyForPrompt,
+  sendPromptToSession,
+  sessionExistsOnHost,
+} from './agent-process.js'
+import { readClaudeCodeOauthJson } from './claude-credentials.js'
+
+// =============================================================================
+// Interactive-tmux agent worker (jun.15 subscription migration).
+//
+// runAgent() used to spawn the Claude Agent SDK (`query`), which bills on the
+// API (the jun.15 change). This drives a SINGLE always-on INTERACTIVE Claude
+// Code session in tmux instead -- which runs on the host's own ~/.claude
+// SUBSCRIPTION login, exactly like the fleet agents. The 4 runAgent callers
+// (heartbeat, memory digest, schedules, scaffold) and llm-breakdown all route
+// through here unchanged.
+//
+// Reliability bonus (beyond billing): the worker is launched WITHOUT any
+// channel plugin (isolated CLAUDE_CONFIG_DIR with enabledPlugins:{}), so it can
+// never open a second Telegram getUpdates long-poll -- which is what caused the
+// 409 Conflict that killed the live bot and clustered ~65% of restarts right
+// after every hourly heartbeat.
+//
+// Output capture is via a TEMP-FILE sentinel, NOT pane-scrape: the callers need
+// clean multi-line markdown (full CLAUDE.md / SOUL.md) and JSON, which terminal
+// wrapping + ANSI + scrollback would corrupt. The worker is told to Write its
+// answer to <reqid>.out and signal with <reqid>.done; runAgent polls the files.
+// =============================================================================
+
+const TMUX = resolveFromPath('tmux')
+
+const WORKER_SESSION = process.env.MARVEEN_WORKER_SESSION || 'marveen-worker'
+// MUST be OUTSIDE PROJECT_ROOT so Claude Code's upward CLAUDE.md discovery never
+// finds Marveen's persona CLAUDE.md -- one-shot generations (scaffold CLAUDE.md/
+// SOUL.md for a NEW agent, memory digests) must be UNTINTED. The caller prompt
+// is the only instruction. (Refinement #1.)
+const WORKER_HOME = process.env.MARVEEN_WORKER_DIR || join(homedir(), '.marveen-worker')
+const WORKER_CONFIG_DIR = join(WORKER_HOME, '.claude-config')
+const SCRATCH_DIR = join(WORKER_HOME, 'scratch')
+const WORKER_MODEL = process.env.MARVEEN_WORKER_MODEL || 'claude-opus-4-8[1m]'
+
+// How long to wait for a freshly launched worker to reach an idle prompt.
+const WORKER_BOOT_TIMEOUT_MS = 90_000
+// Poll cadence while waiting for the <reqid>.done sentinel.
+const CAPTURE_POLL_MS = 1_500
+// Channel plugins to force-disable in the worker's isolated settings.json.
+const WORKER_DISABLED_PLUGINS = ['telegram', 'slack-channel']
+// ~/.claude entries NOT symlinked into the isolated config dir:
+//  - settings.json: we own it (enabledPlugins:{} override).
+//  - CLAUDE.md: skipped so global user memory never tints one-shot gens (refinement #1).
+const WORKER_CONFIG_SKIP = new Set(['settings.json', 'CLAUDE.md', '.DS_Store', '.lock'])
+
+// --- pure, unit-testable logic -------------------------------------------------
+
+/**
+ * Build the per-request prompt: the caller's prompt verbatim, plus a transport
+ * directive telling the worker to Write its answer to a scratch file (capture
+ * mechanism) instead of printing it. The directive is transport, NOT content --
+ * the caller prompt remains the only *content* instruction.
+ */
+export function buildWorkerPrompt(callerPrompt: string, outPath: string, donePath: string): string {
+  return [
+    callerPrompt,
+    '',
+    '---',
+    'OUTPUT INSTRUCTIONS (delivery mechanism, not part of the task):',
+    `1. Write your COMPLETE response -- and nothing else, no commentary, no code fences around it unless the task itself asks -- to this exact file using the Write tool:`,
+    `   ${outPath}`,
+    `2. Then write the single word done to:`,
+    `   ${donePath}`,
+    'Do not print the response in the chat. Those two files are your only output.',
+  ].join('\n')
+}
+
+export type PollDecision = 'ready' | 'timeout' | 'dead' | 'wait'
+
+/**
+ * Decide the next poll action from observable state. Pure so the
+ * done/timeout/liveness policy is testable without a live session.
+ *  - done sentinel present            -> 'ready'
+ *  - past the deadline                -> 'timeout'
+ *  - worker session vanished mid-run  -> 'dead' (fail-fast, don't wait out the
+ *                                        full timeout; refinement #2)
+ *  - otherwise                        -> 'wait'
+ * `done` is checked FIRST so a request that completed in the same tick the
+ * session died still returns its result.
+ */
+export function decidePoll(opts: {
+  doneExists: boolean
+  sessionAlive: boolean
+  elapsedMs: number
+  timeoutMs: number
+}): PollDecision {
+  if (opts.doneExists) return 'ready'
+  if (opts.elapsedMs >= opts.timeoutMs) return 'timeout'
+  if (!opts.sessionAlive) return 'dead'
+  return 'wait'
+}
+
+// --- single-worker mutex -------------------------------------------------------
+
+// The worker is one interactive session -> one prompt at a time. Serialize all
+// runViaWorker calls through a promise chain so an hourly heartbeat and an
+// ad-hoc scheduled task never interleave on the same pane.
+let workerChain: Promise<unknown> = Promise.resolve()
+function withWorkerLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = workerChain.then(fn, fn)
+  // Keep the chain alive regardless of this call's outcome.
+  workerChain = run.then(() => undefined, () => undefined)
+  return run
+}
+
+// --- isolated worker cwd / config ---------------------------------------------
+
+function lstatSyncSafe(p: string): ReturnType<typeof lstatSync> | null {
+  try { return lstatSync(p) } catch { return null }
+}
+
+interface WorkerSettings { enabledPlugins?: Record<string, boolean>; [k: string]: unknown }
+
+/**
+ * Build (idempotently) the worker's isolated cwd + CLAUDE_CONFIG_DIR:
+ *  - empty project .mcp.json (defense in depth);
+ *  - config dir symlinks every ~/.claude entry EXCEPT settings.json + CLAUDE.md
+ *    (so auth/transcripts/marketplaces stay shared, persona memory does not);
+ *  - settings.json with every channel plugin disabled (no 409);
+ *  - .credentials.json seeded from the host login (subscription auth);
+ *  - .claude.json with projects[WORKER_HOME] mirroring projects[PROJECT_ROOT]
+ *    so the worker inherits Marveen's project-scoped MCP servers.
+ * No CLAUDE.md is written here: the cwd is outside PROJECT_ROOT, so the worker
+ * boots with a neutral context.
+ */
+export function ensureWorkerCwd(): void {
+  if (!existsSync(WORKER_HOME)) mkdirSync(WORKER_HOME, { recursive: true })
+  if (!existsSync(SCRATCH_DIR)) mkdirSync(SCRATCH_DIR, { recursive: true })
+
+  const mcpPath = join(WORKER_HOME, '.mcp.json')
+  if (!existsSync(mcpPath)) writeFileSync(mcpPath, '{"mcpServers":{}}\n')
+
+  if (!existsSync(WORKER_CONFIG_DIR)) mkdirSync(WORKER_CONFIG_DIR, { recursive: true })
+
+  const realClaude = join(homedir(), '.claude')
+  if (existsSync(realClaude)) {
+    for (const entry of readdirSync(realClaude)) {
+      if (WORKER_CONFIG_SKIP.has(entry)) continue
+      const linkPath = join(WORKER_CONFIG_DIR, entry)
+      const target = join(realClaude, entry)
+      let needsLink = true
+      const st = lstatSyncSafe(linkPath)
+      if (st) {
+        if (st.isSymbolicLink()) needsLink = false
+        else rmSync(linkPath, { recursive: true, force: true })
+      }
+      if (needsLink) {
+        try { symlinkSync(target, linkPath) }
+        catch (err) { logger.warn({ err, target, linkPath }, 'worker: failed to symlink config entry') }
+      }
+    }
+  }
+
+  // settings.json: own it; force all channel plugins off (merge-preserve any
+  // hook config Claude Code wrote in a prior run).
+  const settingsPath = join(WORKER_CONFIG_DIR, 'settings.json')
+  let current: WorkerSettings = {}
+  const sst = lstatSyncSafe(settingsPath)
+  if (sst?.isSymbolicLink()) {
+    rmSync(settingsPath, { force: true })
+  } else if (existsSync(settingsPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) current = parsed as WorkerSettings
+    } catch { /* rewrite */ }
+  }
+  const enabledPlugins: Record<string, boolean> = { ...(current.enabledPlugins ?? {}) }
+  for (const p of WORKER_DISABLED_PLUGINS) enabledPlugins[p] = false
+  writeFileSync(settingsPath, JSON.stringify({ ...current, enabledPlugins }, null, 2) + '\n')
+
+  // Subscription auth: materialise the host login JSON as .credentials.json.
+  const credentialsJson = readClaudeCodeOauthJson()
+  if (credentialsJson) {
+    writeFileSync(join(WORKER_CONFIG_DIR, '.credentials.json'), credentialsJson, { mode: 0o600 })
+  }
+
+  // Inherit project-scoped MCP servers under the worker's own cwd key.
+  try {
+    const homeClaudeJson = join(homedir(), '.claude.json')
+    if (existsSync(homeClaudeJson)) {
+      const parsed = JSON.parse(readFileSync(homeClaudeJson, 'utf-8')) as { projects?: Record<string, unknown> }
+      const projects = parsed.projects
+      if (projects && typeof projects === 'object' && projects[PROJECT_ROOT] && !projects[WORKER_HOME]) {
+        projects[WORKER_HOME] = projects[PROJECT_ROOT]
+      }
+      writeFileSync(join(WORKER_CONFIG_DIR, '.claude.json'), JSON.stringify(parsed, null, 2) + '\n', { mode: 0o600 })
+    }
+  } catch (err) {
+    logger.warn({ err }, 'worker: failed to materialise .claude.json (worker will lack project MCPs)')
+  }
+}
+
+// --- session lifecycle ---------------------------------------------------------
+
+function workerSessionExists(): boolean {
+  return sessionExistsOnHost(null, WORKER_SESSION)
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms))
+}
+
+/**
+ * Launch the interactive worker session if it is not already up. Subscription
+ * login via the isolated CLAUDE_CONFIG_DIR; no --channels, bypassPermissions so
+ * the Write-to-scratch capture works. Idempotent.
+ */
+export function startWorkerSession(): void {
+  if (workerSessionExists()) return
+  ensureWorkerCwd()
+  // Detached session; launch claude via a login shell so PATH + the config-dir
+  // env are set. The model suffix ([1m]) is single-quoted so it is not globbed.
+  const launch =
+    `export CLAUDE_CONFIG_DIR=${shArg(WORKER_CONFIG_DIR)}; ` +
+    `cd ${shArg(WORKER_HOME)} && ` +
+    `claude --dangerously-skip-permissions --model ${shArg(WORKER_MODEL)}`
+  execFileSync(TMUX, ['new-session', '-d', '-s', WORKER_SESSION, '-c', WORKER_HOME, 'bash', '-lc', launch], { timeout: 8000 })
+  logger.info({ session: WORKER_SESSION, cwd: WORKER_HOME }, 'agent-worker: launched interactive worker session')
+}
+
+function shArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+async function ensureWorkerReady(): Promise<boolean> {
+  startWorkerSession()
+  const deadline = Date.now() + WORKER_BOOT_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    if (isSessionReadyForPrompt(WORKER_SESSION)) return true
+    await sleepMs(2000)
+  }
+  return false
+}
+
+function restartWorkerSession(): void {
+  try { execFileSync(TMUX, ['kill-session', '-t', WORKER_SESSION], { timeout: 5000 }) } catch { /* not running */ }
+  try { startWorkerSession() } catch (err) { logger.warn({ err }, 'agent-worker: restart failed') }
+}
+
+// Reset context between requests so unrelated one-shots never share/grow context.
+function clearWorkerContext(): void {
+  try {
+    execFileSync(TMUX, ['send-keys', '-t', WORKER_SESSION, '-l', '/clear'], { timeout: 5000 })
+    execFileSync('/bin/sleep', ['0.2'], { timeout: 2000 })
+    execFileSync(TMUX, ['send-keys', '-t', WORKER_SESSION, 'Enter'], { timeout: 5000 })
+    execFileSync('/bin/sleep', ['0.5'], { timeout: 2000 })
+  } catch (err) {
+    logger.warn({ err }, 'agent-worker: /clear failed (continuing)')
+  }
+}
+
+let reqCounter = 0
+function nextReqId(): string {
+  reqCounter = (reqCounter + 1) % 1_000_000
+  return `${Date.now().toString(36)}-${reqCounter}`
+}
+
+/**
+ * Run one prompt through the interactive worker and return its text output.
+ * Serialized via the worker mutex. Returns text=null + error on timeout, a
+ * mid-flight worker death (fail-fast + restart), or a non-ready worker.
+ */
+export async function runViaWorker(message: string, timeoutMs: number): Promise<{ text: string | null; error?: string }> {
+  return withWorkerLock(async () => {
+    const ready = await ensureWorkerReady()
+    if (!ready) {
+      logger.warn('agent-worker: worker not ready, failing request (text=null)')
+      return { text: null, error: 'worker session not ready' }
+    }
+
+    const reqId = nextReqId()
+    const outPath = join(SCRATCH_DIR, `${reqId}.out`)
+    const donePath = join(SCRATCH_DIR, `${reqId}.done`)
+    for (const p of [outPath, donePath]) { try { rmSync(p, { force: true }) } catch { /* none */ } }
+
+    clearWorkerContext()
+    sendPromptToSession(WORKER_SESSION, buildWorkerPrompt(message, outPath, donePath))
+
+    const start = Date.now()
+    try {
+      while (true) {
+        await sleepMs(CAPTURE_POLL_MS)
+        const decision = decidePoll({
+          doneExists: existsSync(donePath),
+          sessionAlive: workerSessionExists(),
+          elapsedMs: Date.now() - start,
+          timeoutMs,
+        })
+        if (decision === 'ready') {
+          const text = existsSync(outPath) ? readFileSync(outPath, 'utf-8') : null
+          return { text: text && text.trim() ? text : null, error: text && text.trim() ? undefined : 'worker produced empty output' }
+        }
+        if (decision === 'timeout') {
+          logger.warn({ reqId, timeoutMs }, 'agent-worker: request timed out')
+          return { text: null, error: `worker timeout after ${Math.round(timeoutMs / 1000)}s` }
+        }
+        if (decision === 'dead') {
+          logger.warn({ reqId }, 'agent-worker: session died mid-request, restarting (fail-fast)')
+          restartWorkerSession()
+          return { text: null, error: 'worker session died mid-request' }
+        }
+      }
+    } finally {
+      for (const p of [outPath, donePath]) { try { rmSync(p, { force: true }) } catch { /* best effort */ } }
+    }
+  })
+}

--- a/src/web/claude-credentials.ts
+++ b/src/web/claude-credentials.ts
@@ -1,0 +1,26 @@
+import { execFileSync } from 'node:child_process'
+import { userInfo } from 'node:os'
+import { logger } from '../logger.js'
+
+// Read the host's Claude Code SUBSCRIPTION login JSON from the macOS Keychain,
+// to materialise as <CLAUDE_CONFIG_DIR>/.credentials.json for an isolated
+// sub-agent / worker config dir. Mirrors heartbeat.ts's readClaudeCodeOauthJson
+// (kept as a standalone copy here to avoid an agent <-> heartbeat import cycle;
+// consolidate when heartbeat itself migrates onto the worker). Returns null off
+// macOS or on any lookup failure (the worker then runs logged-out and its
+// requests fail closed to text=null).
+export function readClaudeCodeOauthJson(): string | null {
+  if (process.platform !== 'darwin') return null
+  try {
+    const out = execFileSync(
+      '/usr/bin/security',
+      ['find-generic-password', '-s', 'Claude Code-credentials', '-a', userInfo().username, '-w'],
+      { timeout: 3000, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim()
+    return out || null
+  } catch {
+    // Not logging err: some macOS auth errors echo a fragment of the lookup key.
+    logger.warn('worker: failed to read Claude Code credentials from Keychain (worker will run logged-out)')
+    return null
+  }
+}

--- a/src/web/llm-breakdown.ts
+++ b/src/web/llm-breakdown.ts
@@ -1,7 +1,6 @@
-import { execFile } from 'node:child_process'
 import { logger } from '../logger.js'
 import { listAgentNames } from './agent-config.js'
-import { resolveFromPath } from '../platform.js'
+import { runAgent } from '../agent.js'
 
 export interface SubtaskSuggestion {
   title: string
@@ -13,8 +12,6 @@ export interface SubtaskSuggestion {
 export interface BreakdownResult {
   subtasks: SubtaskSuggestion[]
 }
-
-const TIMEOUT_MS = 60_000
 
 const SYSTEM_PROMPT = `You are a project management assistant that breaks down kanban cards into actionable subtasks.
 
@@ -52,41 +49,31 @@ function getValidAssignees(): Set<string> {
   return new Set(['Szabolcs', 'Marveen', ...agents])
 }
 
-function resolveClaudeBinary(): string {
-  return resolveFromPath('claude')
+// Strip a leading/trailing ```json ... ``` fence if the model added one despite
+// the "no markdown fences" instruction.
+function stripCodeFences(s: string): string {
+  const m = s.trim().match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/)
+  return m ? m[1].trim() : s.trim()
 }
 
-async function callClaudeP(userPrompt: string): Promise<SubtaskSuggestion[]> {
-  const claude = resolveClaudeBinary()
+// Generate the subtask JSON via runAgent -> the interactive worker (subscription
+// login, no `claude -p` / SDK -- jun.15 billing migration). The worker writes
+// its response (the JSON array, per SYSTEM_PROMPT) to a scratch file that
+// runAgent returns as `text`.
+async function callBreakdownAgent(userPrompt: string): Promise<SubtaskSuggestion[]> {
   const fullPrompt = `${SYSTEM_PROMPT}\n\n${userPrompt}`
-
-  return new Promise((resolve, reject) => {
-    const child = execFile(
-      claude,
-      ['-p', '--model', 'claude-sonnet-4-6', '--output-format', 'json'],
-      { timeout: TIMEOUT_MS, maxBuffer: 1024 * 1024 },
-      (err, stdout, stderr) => {
-        if (err) {
-          if ((err as any).killed || err.message.includes('TIMEOUT') || err.message.includes('timed out')) {
-            return reject(new Error('claude -p timed out after 60s'))
-          }
-          logger.warn({ err, stderr: stderr?.slice(0, 300) }, 'claude -p failed')
-          return reject(new Error(`claude -p failed: ${err.message}`))
-        }
-        try {
-          const parsed = JSON.parse(stdout)
-          const text = parsed?.result ?? stdout
-          const subtasks = typeof text === 'string' ? JSON.parse(text) : text
-          resolve(Array.isArray(subtasks) ? subtasks : [])
-        } catch (parseErr) {
-          logger.warn({ stdout: stdout?.slice(0, 500) }, 'claude -p output parse failed')
-          reject(new Error('Failed to parse claude -p output as JSON'))
-        }
-      },
-    )
-    child.stdin?.write(fullPrompt)
-    child.stdin?.end()
-  })
+  const { text, error } = await runAgent(fullPrompt)
+  if (!text || !text.trim()) {
+    throw new Error(`breakdown agent returned no content${error ? `: ${error}` : ''}`)
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stripCodeFences(text))
+  } catch {
+    logger.warn({ output: text.slice(0, 500) }, 'breakdown agent output parse failed')
+    throw new Error('Failed to parse breakdown output as JSON')
+  }
+  return Array.isArray(parsed) ? (parsed as SubtaskSuggestion[]) : []
 }
 
 export function validateSubtasks(raw: unknown, validAssignees?: Set<string>): SubtaskSuggestion[] {
@@ -112,14 +99,6 @@ export async function generateBreakdown(title: string, description: string | nul
   const agents = [...validAssignees]
   const userPrompt = buildUserPrompt(title, description, agents)
 
-  try {
-    const raw = await callClaudeP(userPrompt)
-    return { subtasks: validateSubtasks(raw, validAssignees) }
-  } catch (err) {
-    const msg = (err as Error).message
-    if (msg.includes('not found on PATH')) {
-      throw new Error('claude CLI not available on this system')
-    }
-    throw err
-  }
+  const raw = await callBreakdownAgent(userPrompt)
+  return { subtasks: validateSubtasks(raw, validAssignees) }
 }


### PR DESCRIPTION
Migrates runAgent off the Agent SDK `query` (API billing -- the jun.15 change) onto a persistent INTERACTIVE Claude Code session in tmux (subscription login). All 4 callers unchanged; llm-breakdown moved off `claude -p`. MARVEEN_AGENT_BACKEND=sdk rollback.

Reliability bonus: worker has no channel plugin -> no second getUpdates 409 (the post-heartbeat restart cause).

Approved by review. Verified: tsc 0, worker+breakdown 33/33, full suite 1097/1097. Live heartbeat-path parity green (subscription, no Telegram side-effect). Refinements in: neutral CLAUDE.md (cwd outside PROJECT_ROOT + symlink-skip), mid-flight liveness fail-fast. First-run dialogs pre-accepted.

NOTE: develop-merge only -- main-promote/deploy is separately Szabi-timed (core change touches fleet comms/heartbeat).