### PR TITLE
fix(channels): respawn-stamp on resumeMarveenSession + spell-peak discriminator (kill self-respawn loop)

### DIFF
--- a/src/__tests__/channel-monitor-session-recreate.test.ts
+++ b/src/__tests__/channel-monitor-session-recreate.test.ts
@@ -65,6 +65,28 @@ describe("channel-monitor: self-healing vanished main session", () => {
     expect(fn).toContain("writeRespawnStamp()")
   })
 
+  it("resumeMarveenSession writes the shared respawn stamp (2026-06-08 self-defer fix)", () => {
+    // Without this stamp the stuck-tool-call-watcher cannot defer its own
+    // self-respawn during the post-respawn grace, because lastMainRespawnAt()
+    // only sees the keepalive and launchctl timestamps -- not a stage-3 /
+    // watcher-triggered resume. The 2026-06-08 false-positive loop respawned
+    // the session 13 times in 8h because every fresh respawn left a residual
+    // TUI footer the watcher then re-classified as a wedge.
+    const start = src.indexOf("export function resumeMarveenSession")
+    expect(start, "resumeMarveenSession not found").toBeGreaterThan(0)
+    // Slice generously to the next top-level export so the assertion catches
+    // a stamp call anywhere inside the function, not just before the next "\n}\n".
+    const end = src.indexOf("\nexport ", start + 1)
+    const fn = end > start ? src.slice(start, end) : src.slice(start)
+    expect(fn).toContain("writeRespawnStamp()")
+    // It must appear before the successful return so a failed respawn does
+    // not falsely suppress later recovery paths.
+    const stampIdx = fn.indexOf("writeRespawnStamp()")
+    const returnTrueIdx = fn.indexOf("return true")
+    expect(stampIdx, "writeRespawnStamp must precede the success return").toBeGreaterThan(0)
+    expect(stampIdx).toBeLessThan(returnTrueIdx)
+  })
+
   it("CHANNELS_SCRIPT resolves to scripts/channels.sh under PROJECT_ROOT", () => {
     expect(src).toMatch(/const\s+CHANNELS_SCRIPT\s*=\s*join\(PROJECT_ROOT,\s*["']scripts["'],\s*["']channels\.sh["']\)/)
   })

--- a/src/__tests__/stuck-tool-call.test.ts
+++ b/src/__tests__/stuck-tool-call.test.ts
@@ -14,11 +14,13 @@ import { shouldDeferForRecentRespawn, confirmsWedgeProfile } from '../web/stuck-
 const THRESHOLDS: StuckToolCallThresholds = {
   freezeSeconds: 180,
   stagnantPolls: 2,
+  minPeakSeconds: 20,
 }
 
 const NO_STATE: StuckToolCallState = {
   tag: null,
   spellStartSeconds: null,
+  spellPeakSeconds: null,
   firstSeenAt: null,
   lastSeconds: null,
   stagnantPolls: 0,
@@ -68,7 +70,7 @@ describe('decideStuckToolCallRecovery', () => {
 
   it('null pane ends any spell', () => {
     const prev: StuckToolCallState = {
-      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 31,
+      tag: 'worked', spellStartSeconds: 30, spellPeakSeconds: 31, firstSeenAt: 1, lastSeconds: 31,
       stagnantPolls: 2, stagnantSince: 1, attempts: 0,
     }
     const r = decideStuckToolCallRecovery(null, prev, 1_000_000, THRESHOLDS)
@@ -78,7 +80,7 @@ describe('decideStuckToolCallRecovery', () => {
 
   it('tag change resets the spell (verb change = real progress)', () => {
     const prev: StuckToolCallState = {
-      tag: 'brewed', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 200,
+      tag: 'brewed', spellStartSeconds: 30, spellPeakSeconds: 200, firstSeenAt: 1, lastSeconds: 200,
       stagnantPolls: 2, stagnantSince: 1, attempts: 0,
     }
     const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 5 }, prev, 1_000_000, THRESHOLDS)
@@ -91,7 +93,7 @@ describe('decideStuckToolCallRecovery', () => {
 
   it('counter increment resets stagnantPolls AND stagnantSince (real tool-call progress)', () => {
     const prev: StuckToolCallState = {
-      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1, lastSeconds: 195,
+      tag: 'worked', spellStartSeconds: 30, spellPeakSeconds: 195, firstSeenAt: 1, lastSeconds: 195,
       stagnantPolls: 1, stagnantSince: 1_000_000, attempts: 0,
     }
     const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 220 }, prev, 1_030_000, THRESHOLDS)
@@ -103,7 +105,7 @@ describe('decideStuckToolCallRecovery', () => {
 
   it('first stagnant poll stamps stagnantSince but does NOT recover (anti-fluke gate)', () => {
     const prev: StuckToolCallState = {
-      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 31,
+      tag: 'worked', spellStartSeconds: 30, spellPeakSeconds: 31, firstSeenAt: 1_000_000, lastSeconds: 31,
       stagnantPolls: 0, stagnantSince: null, attempts: 0,
     }
     const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, prev, 1_030_000, THRESHOLDS)
@@ -151,7 +153,7 @@ describe('decideStuckToolCallRecovery', () => {
 
   it('one-shot: once recovered, hold even if still stagnant (next sweep reads fresh pane)', () => {
     const prev: StuckToolCallState = {
-      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 31,
+      tag: 'worked', spellStartSeconds: 30, spellPeakSeconds: 31, firstSeenAt: 1_000_000, lastSeconds: 31,
       stagnantPolls: 8, stagnantSince: 1_000_000, attempts: 1,
     }
     const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, prev, 2_000_000, THRESHOLDS)
@@ -161,7 +163,7 @@ describe('decideStuckToolCallRecovery', () => {
 
   it('clock skew backwards: restart spell rather than stall', () => {
     const prev: StuckToolCallState = {
-      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 2_000_000, lastSeconds: 31,
+      tag: 'worked', spellStartSeconds: 30, spellPeakSeconds: 31, firstSeenAt: 2_000_000, lastSeconds: 31,
       stagnantPolls: 1, stagnantSince: 2_000_000, attempts: 0,
     }
     const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, prev, 1_500_000, THRESHOLDS)
@@ -195,7 +197,7 @@ describe('decideStuckToolCallRecovery', () => {
     // 199 < 200 is an unhealthy regression. We treat it as stagnant. Two
     // polls of 199, plus enough wall-clock to clear freezeSeconds, recovers.
     const prev: StuckToolCallState = {
-      tag: 'worked', spellStartSeconds: 30, firstSeenAt: 1_000_000, lastSeconds: 200,
+      tag: 'worked', spellStartSeconds: 30, spellPeakSeconds: 200, firstSeenAt: 1_000_000, lastSeconds: 200,
       stagnantPolls: 0, stagnantSince: null, attempts: 0,
     }
     // First stagnant poll just stamps the wall-clock start.
@@ -204,6 +206,83 @@ describe('decideStuckToolCallRecovery', () => {
     // ~3 min later, still 199 (or any value <= 200): wall-clock hit.
     r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 199 }, r.next, 1_030_000 + 180_000, THRESHOLDS)
     expect(r.recover).toBe(true)
+  })
+
+  // Spell-peak discriminator (2026-06-08 fix): a residual TUI footer left over
+  // after a prior respawn sits at 3-4s forever -- the counter never advances
+  // because the new claude is not running that tool-call, the TUI just kept the
+  // stale string. Before the fix this looked exactly like a wedge (counter
+  // never increments) and triggered 13 self-respawns in 8h. The discriminator:
+  // a real wedge climbed to a meaningful seconds value (31s in the 2026-06-02
+  // incident); a residual never does.
+  it('residual TUI counter (3-4s never climbing) does NOT recover even after full freeze window', () => {
+    const t0 = 1_000_000
+    let state: StuckToolCallState = NO_STATE
+    // Poll 1: residual sits at 4s -- this is the spell-start observation.
+    let r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 4 }, state, t0, THRESHOLDS)
+    expect(r.recover).toBe(false)
+    expect(r.next.spellPeakSeconds).toBe(4)
+    state = r.next
+    // Pile on many stagnant polls past the wall-clock freeze window.
+    // spellPeak stays at 4, well below minPeakSeconds=20, so recovery is
+    // blocked despite the wall-clock+anti-fluke gates being fully satisfied.
+    for (let dt = 30_000; dt <= 30 * 60_000; dt += 30_000) {
+      r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 4 }, state, t0 + dt, THRESHOLDS)
+      expect(r.recover).toBe(false)
+      state = r.next
+    }
+    expect(state.spellPeakSeconds).toBe(4)
+    expect(state.attempts).toBe(0)
+  })
+
+  it('residual that flickers 3 -> 4 -> 3 -> 4 still does NOT recover (peak stays at 4)', () => {
+    // Mirrors the kanban diagnosis "seconds=3-4" -- the residual jiggles
+    // by one across polls. The 3 -> 4 step is technically a counter advance
+    // (resets stagnantSince once) but the peak only climbs to 4, still well
+    // under minPeakSeconds, so the discriminator continues to block.
+    const t0 = 1_000_000
+    let state: StuckToolCallState = NO_STATE
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 3 }, state, t0, THRESHOLDS).next
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 4 }, state, t0 + 30_000, THRESHOLDS).next
+    expect(state.spellPeakSeconds).toBe(4)
+    for (let dt = 60_000; dt <= 20 * 60_000; dt += 30_000) {
+      const r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 4 }, state, t0 + dt, THRESHOLDS)
+      expect(r.recover).toBe(false)
+      state = r.next
+    }
+    expect(state.spellPeakSeconds).toBe(4)
+  })
+
+  it('counter that climbed above minPeakSeconds before freezing DOES recover (real wedge shape)', () => {
+    // 2026-06-02 incident shape: counter climbed to 31s, then the render loop
+    // wedged. spellPeak reaches 31, clears the discriminator gate, and the
+    // wall-clock + anti-fluke gates fire as before.
+    const t0 = 1_000_000
+    let state: StuckToolCallState = NO_STATE
+    // Counter climbs 5 -> 18 -> 31 across three polls.
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 5 }, state, t0, THRESHOLDS).next
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 18 }, state, t0 + 30_000, THRESHOLDS).next
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, state, t0 + 60_000, THRESHOLDS).next
+    expect(state.spellPeakSeconds).toBe(31)
+    // Then it wedges. Drive enough stagnant polls + wall-clock to clear all gates.
+    let r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, state, t0 + 90_000, THRESHOLDS)
+    expect(r.recover).toBe(false) // first stagnant poll
+    state = r.next
+    r = decideStuckToolCallRecovery({ tag: 'worked', seconds: 31 }, state, t0 + 60_000 + 30_000 + 180_000, THRESHOLDS)
+    expect(r.recover).toBe(true)
+    expect(r.next.spellPeakSeconds).toBe(31) // preserved across stagnation
+  })
+
+  it('spellPeakSeconds is preserved when counter goes stagnant after a climb', () => {
+    // Peak rises with each advance; later stagnation must not erase it.
+    const t0 = 1_000_000
+    let state: StuckToolCallState = NO_STATE
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 10 }, state, t0, THRESHOLDS).next
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 25 }, state, t0 + 30_000, THRESHOLDS).next
+    expect(state.spellPeakSeconds).toBe(25)
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 25 }, state, t0 + 60_000, THRESHOLDS).next
+    state = decideStuckToolCallRecovery({ tag: 'worked', seconds: 25 }, state, t0 + 90_000, THRESHOLDS).next
+    expect(state.spellPeakSeconds).toBe(25)
   })
 
   it('partial freeze, recovers, then re-freezes -- accumulates fresh wall-clock', () => {
@@ -252,6 +331,18 @@ describe('stuck-tool-call-watcher wiring contract', () => {
     const m = watcherSrc.match(/stagnantPolls:\s*(\d+)/)
     expect(m, 'stagnantPolls constant missing').not.toBeNull()
     expect(parseInt(m![1]!, 10)).toBeGreaterThanOrEqual(2)
+  })
+
+  it('production minPeakSeconds blocks the residual band (2026-06-08 fix)', () => {
+    // Spell-peak discriminator must sit above the residual TUI band (3-4s
+    // observed in the 2026-06-08 false-positive loop) and below the real
+    // wedge floor (31s from the 2026-06-02 incident). Anywhere in (4, 31)
+    // is safe; the production default lives at 20s.
+    const m = watcherSrc.match(/minPeakSeconds:\s*(\d+)/)
+    expect(m, 'minPeakSeconds constant missing').not.toBeNull()
+    const v = parseInt(m![1]!, 10)
+    expect(v).toBeGreaterThan(4)
+    expect(v).toBeLessThan(31)
   })
 
   it('recovers via the respawn-pane path (resumeMarveenSession), NOT the launchctl hard-restart (#248)', () => {

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -813,6 +813,14 @@ export interface StuckToolCallState {
   /** The seconds value observed when the spell started -- preserved for the
    * audit log so an operator can tell at what counter value the freeze happened. */
   spellStartSeconds: number | null
+  /** Highest seconds value observed in this spell. Load-bearing for the
+   * spell-peak discriminator: a residual TUI footer left over from a prior
+   * respawn never climbs (stays at 3-4s across every observation), while a
+   * legitimately running tool-call that wedges climbed to a meaningful value
+   * before stalling. Recovery is gated on spellPeakSeconds >= minPeakSeconds
+   * so the residual band does not look like a wedge (2026-06-08 false-positive
+   * loop: 13 self-respawns in 8h triggered by 3-4s residuals every poll). */
+  spellPeakSeconds: number | null
   /** When the spell was first observed (ms). */
   firstSeenAt: number | null
   /** Last observed seconds value, used to detect stagnation across polls. */
@@ -847,6 +855,14 @@ export interface StuckToolCallThresholds {
    * increments every TUI redraw, so multi-poll stagnation is conclusive.
    * Composed WITH the wall-clock freezeSeconds check -- BOTH must hold. */
   stagnantPolls: number
+  /** Spell-peak discriminator (2026-06-08 fix): the highest seconds value the
+   * counter has reached in this spell must be at LEAST this many seconds for
+   * the spell to qualify as a wedge. A residual TUI footer left over after a
+   * prior respawn never climbs (stays at 3-4s every poll); a legitimately
+   * wedged tool-call climbed to a meaningful value before freezing (the
+   * 2026-06-02 incident sat at 31s). Composed AND with the wall-clock and
+   * anti-fluke gates -- all three must hold. */
+  minPeakSeconds: number
 }
 
 export interface StuckToolCallDecision {
@@ -857,6 +873,7 @@ export interface StuckToolCallDecision {
 const NO_STUCK_TOOL_CALL: StuckToolCallState = {
   tag: null,
   spellStartSeconds: null,
+  spellPeakSeconds: null,
   firstSeenAt: null,
   lastSeconds: null,
   stagnantPolls: 0,
@@ -905,6 +922,7 @@ export function decideStuckToolCallRecovery(
       next: {
         tag: sig.tag,
         spellStartSeconds: sig.seconds,
+        spellPeakSeconds: sig.seconds,
         firstSeenAt: now,
         lastSeconds: sig.seconds,
         stagnantPolls: 0,
@@ -920,6 +938,7 @@ export function decideStuckToolCallRecovery(
       next: {
         tag: sig.tag,
         spellStartSeconds: sig.seconds,
+        spellPeakSeconds: sig.seconds,
         firstSeenAt: now,
         lastSeconds: sig.seconds,
         stagnantPolls: 0,
@@ -933,10 +952,13 @@ export function decideStuckToolCallRecovery(
   // open with the same tag so a LATER freeze is detected without re-running
   // the full freezeSeconds window from scratch (the wall-clock measurement
   // restarts from the next stagnation onward, which is the right thing).
+  // Also raise spellPeakSeconds -- the discriminator that separates a real
+  // wedge (climbed before freezing) from a leftover residual footer.
   if (prev.lastSeconds !== null && sig.seconds > prev.lastSeconds) {
+    const peak = Math.max(prev.spellPeakSeconds ?? sig.seconds, sig.seconds)
     return {
       recover: false,
-      next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: 0, stagnantSince: null },
+      next: { ...prev, spellPeakSeconds: peak, lastSeconds: sig.seconds, stagnantPolls: 0, stagnantSince: null },
     }
   }
   // Counter stagnant (same or rolled-back). Tick the stagnant counter and
@@ -952,13 +974,20 @@ export function decideStuckToolCallRecovery(
       next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant, stagnantSince: nextStagnantSince },
     }
   }
-  // Recover only when BOTH gates hold: wall-clock freeze duration AND
-  // anti-fluke poll count. A 5-minute genuine tool-call resets
-  // stagnantSince on every redraw, so even though the call is long this
-  // duration never accumulates.
+  // Recover only when ALL THREE gates hold: wall-clock freeze duration,
+  // anti-fluke poll count, AND spell-peak discriminator. A 5-minute genuine
+  // tool-call resets stagnantSince on every redraw, so even though the call
+  // is long the duration never accumulates. A residual TUI footer left over
+  // from a prior respawn never climbs past minPeakSeconds, so the peak gate
+  // blocks the 2026-06-08 false-positive shape (3-4s residual every poll).
   const stagnantMs = now - nextStagnantSince
   const freezeMs = thresholds.freezeSeconds * 1000
-  if (stagnantMs < freezeMs || nextStagnant < thresholds.stagnantPolls) {
+  const peak = prev.spellPeakSeconds ?? sig.seconds
+  if (
+    stagnantMs < freezeMs ||
+    nextStagnant < thresholds.stagnantPolls ||
+    peak < thresholds.minPeakSeconds
+  ) {
     return {
       recover: false,
       next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant, stagnantSince: nextStagnantSince },

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -277,6 +277,13 @@ export function resumeMarveenSession(): boolean {
     // direct. Schedule the same probe in-process so the plugin doesn't get
     // stuck in `◯ disabled` after an in-process respawn (2026-06-01 18:55).
     schedulePluginUnlockAfterRespawn(MAIN_CHANNELS_SESSION, provider.type)
+    // Stamp the shared respawn timestamp so lastMainRespawnAt() sees this
+    // respawn from any caller (down-cascade stage 3, stuck-tool-call-watcher,
+    // external systemd-timer watchdog). Without it the watcher cannot defer
+    // its own self-respawn-and-recheck within the post-respawn grace, which
+    // produced the 2026-06-08 false-positive loop (13 respawns in 8h on
+    // residual 3-4s counters left over from the prior respawn's TUI redraw).
+    writeRespawnStamp()
     return true
   } catch (err) {
     logger.error({ err }, 'Marveen session respawn failed')

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -95,9 +95,16 @@ function sampleMainClaudeCpuPercent(session: string): number | null {
 //     incrementing polls means ~60s+ of wall clock without a single TUI
 //     redraw advancing the counter. A healthy long-running tool-call
 //     redraws every second.
+// minPeakSeconds (2026-06-08 fix): the spell's highest observed counter value
+// must reach >= this many seconds before recovery can fire. The 2026-06-08
+// false-positive loop respawned the session 13 times in 8h on residual TUI
+// footers (3-4s every poll, never advancing) left behind by a prior respawn.
+// The real 2026-06-02 wedge had climbed to 31s before stalling. 20s sits
+// comfortably between the residual band and the real wedge floor.
 const THRESHOLDS: StuckToolCallThresholds = {
   freezeSeconds: 180,
   stagnantPolls: 2,
+  minPeakSeconds: 20,
 }
 
 // Poll cadence. Offset 35s so the three pane-readers (channel-monitor 30s,
@@ -109,6 +116,7 @@ const INTERVAL_MS = 30_000
 const NO_STATE: StuckToolCallState = {
   tag: null,
   spellStartSeconds: null,
+  spellPeakSeconds: null,
   firstSeenAt: null,
   lastSeconds: null,
   stagnantPolls: 0,
@@ -186,6 +194,7 @@ function checkSession(label: string, session: string): void {
         session,
         tag: next.tag,
         seconds: next.lastSeconds,
+        spellPeakSeconds: next.spellPeakSeconds,
         stagnantPolls: next.stagnantPolls,
         cpuPercent,
         thresholds: THRESHOLDS,


### PR DESCRIPTION
> AI-generated by Marveen dev agent (dev, Claude Opus 4.7).

## Problem

The channel-monitor cascaded a self-respawn loop on Marveen's main session for
~8 hours on 2026-06-08: 13 `respawn-pane -k --continue` cycles, all triggered
by the `stuck-tool-call-watcher`, all on a tag=`worked`/`brewed`/`baked`
counter sitting at 3-4s with stagnantPolls=7 and CPU 1.2-3.0% (idle wedge
profile by `confirmsWedgeProfile`). The 2026-06-02 incident this watcher was
built for sat at 31s; the 2026-06-08 shape was very different.

Two compounding root causes:

1. `resumeMarveenSession()` (the recovery path used by both the down-cascade
   stage 3 and the stuck-tool-call-watcher itself) did NOT write the shared
   respawn timestamp. `lastMainRespawnAt()` only saw `marveenLastHardRestart`,
   `marveenLastKeepaliveRespawn`, and the external watchdog's file stamp -- a
   watcher-triggered or stage-3 resume was invisible to the post-respawn
   grace, and the watcher could re-fire ~4 minutes after its own respawn.

2. The stuck-tool-call detector had no way to distinguish a real wedge (counter
   climbed to a meaningful value before stalling) from a residual TUI footer
   left behind by a prior respawn (counter never moves past the boot band,
   3-4s in the observed shape). Both look identical to the existing
   wall-clock + anti-fluke gates.

## Fix

**A1: respawn-stamp on `resumeMarveenSession`** (`src/web/channel-monitor.ts`).
Add `writeRespawnStamp()` before the success `return true`, after the existing
`schedulePluginUnlockAfterRespawn`. Every successful resume is now visible to
`lastMainRespawnAt()`, so the watcher's `shouldDeferForRecentRespawn` gate
covers its own respawns and the cascade's stage-3 resume alike.

**A2: spell-peak discriminator** (`src/pane-state.ts`,
`src/web/stuck-tool-call-watcher.ts`).

- New `StuckToolCallState.spellPeakSeconds: number | null` -- highest seconds
  value the counter has reached in the current spell.
- New `StuckToolCallThresholds.minPeakSeconds: number` -- gate threshold.
- `decideStuckToolCallRecovery` initializes peak on spell-start / tag-change /
  clock-skew, raises it on counter-advance, preserves it across stagnation.
- Recovery is now gated on three ANDed predicates: wall-clock stagnation
  >= `freezeSeconds`, anti-fluke `stagnantPolls`, AND `spellPeakSeconds >=
  minPeakSeconds`.
- Production `minPeakSeconds = 20`. The 2026-06-08 residual band sits at 3-4s;
  the 2026-06-02 real wedge sat at 31s. 20 is comfortably between the two.

## Known limitation / follow-up

The spell-peak gate **does not** catch the case where a session does
legitimate long work that climbs the counter well above `minPeakSeconds`, then
goes idle while the TUI footer stays frozen at the final high value (one such
isolated respawn was observed at 2026-06-09 02:24 right after a long
heavy-compute run). A2 successfully suppresses the dominant false-positive
loop, but this residual class needs a different signal -- e.g. "did the
counter advance at all in the last N polls of this spell," recorded as an
extra state field so the gate becomes "peak >= minPeak AND counter actually
moved during the spell." Out of scope for this PR; would land as a follow-up
that builds on the same `spellPeakSeconds` plumbing.

## Verification

- `npm run typecheck` -- clean
- `npx vitest run src/__tests__/stuck-tool-call.test.ts
  src/__tests__/channel-monitor-session-recreate.test.ts` -- 43 / 43 pass
- Full `npx vitest run` -- 1021 pass / 5 fail / 1 skip; the 5 failures match
  the pre-change baseline (4 macOS `managed-settings` + 1 unrelated
  `channel-plugin-unlock` drift), no new regressions introduced by this
  change.

6 new test cases plus 6 existing prev-state fixtures extended with
`spellPeakSeconds`:
- `resumeMarveenSession` writes the shared respawn stamp before returning
- residual 3-4s counter never recovers across the full freeze window
- residual that flickers 3 <-> 4 still does not recover (peak stays at 4)
- 5 -> 18 -> 31 climbed-then-stalled real-wedge shape DOES recover
- `spellPeakSeconds` is preserved when the counter goes stagnant after a climb
- production `minPeakSeconds` wiring contract: > 4, < 31



## Related

- Refs #258 -- umbrella issue ("Telegram channel keeps dropping under load").
  This PR addresses the residual TUI footer / watcher self-respawn-loop slice
  of that pattern: the cascade can no longer churn the session on a counter
  that never actually advanced.