### PR TITLE
fix(channels): provider-specific poller matching in coordinator/liveness (close masking gap)

### DIFF
--- a/src/__tests__/liveness-masking.test.ts
+++ b/src/__tests__/liveness-masking.test.ts
@@ -1,0 +1,190 @@
+// Integration test for `decideHasPluginAlive` -- the pure decider extracted
+// from `hasChannelPluginAlive`. The masking-prevention guarantee at the
+// matcher layer is already proven by provider-poller-match.test.ts; this file
+// verifies the decider wires the matcher into the tree-walk + bot.pid +
+// cross-tree fallbacks correctly, and replays the 2026-06-09 multi-plugin
+// masking scenario end-to-end.
+
+import { describe, it, expect } from 'vitest'
+import { decideHasPluginAlive } from '../channel-coordinator/liveness.js'
+
+// Synthetic `ps -axo pid,ppid,command` snapshots. First line is the header
+// `ps` always emits; the decider skips it via .slice(1) just like the live
+// path does, so the header is required for fidelity.
+const PS_HEADER = '  PID  PPID COMMAND'
+
+function ps(rows: Array<{ pid: number; ppid: number; command: string }>): string {
+  const body = rows.map(r => `${String(r.pid).padStart(5)} ${String(r.ppid).padStart(5)} ${r.command}`).join('\n')
+  return PS_HEADER + '\n' + body
+}
+
+const CLAUDE_PID = 1000
+const TELEGRAM_BUN_PID = 2000
+const SYNOLOGY_BUN_PID = 3000
+
+const TELEGRAM_CMD =
+  'bun run --cwd /home/user/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 --shell=bun --silent start'
+const SYNOLOGY_CMD =
+  'bun run --cwd /home/user/.claude/plugins/efi-src/synology-chat --shell=bun --silent start'
+
+const ALL_PIDS_ALIVE = () => true
+const NO_PIDS_ALIVE = () => false
+
+describe('decideHasPluginAlive -- 2026-06-09 multi-plugin masking regression', () => {
+  it('telegram down + synology up under claude pid -> NOT alive (the masking bug pre-fix)', () => {
+    // Only the synology poller is a child of claude. The decider must NOT
+    // report "telegram alive" merely because some bun process happens to be
+    // a child of the claude. Pre-fix this reported true via the generic
+    // `bun + server.ts` clause if the cmdline ever contained server.ts; we
+    // also regression-lock against any future broadening of the matcher
+    // that could match the synology cmdline.
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude --channels plugin:telegram@claude-plugins-official' },
+      { pid: SYNOLOGY_BUN_PID, ppid: CLAUDE_PID, command: SYNOLOGY_CMD },
+    ])
+    const alive = decideHasPluginAlive({
+      psOutput: out,
+      claudePid: CLAUDE_PID,
+      providerType: 'telegram',
+      botPid: null,
+      isPidAlive: ALL_PIDS_ALIVE,
+    })
+    expect(alive).toBe(false)
+  })
+
+  it('telegram up + synology up under claude pid -> alive', () => {
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude --channels plugin:telegram@claude-plugins-official' },
+      { pid: TELEGRAM_BUN_PID, ppid: CLAUDE_PID, command: TELEGRAM_CMD },
+      { pid: SYNOLOGY_BUN_PID, ppid: CLAUDE_PID, command: SYNOLOGY_CMD },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'telegram',
+      botPid: null, isPidAlive: ALL_PIDS_ALIVE,
+    })).toBe(true)
+  })
+
+  it('telegram pid gone + synology still up -> NOT alive (the original 2026-06-09 scenario)', () => {
+    // Telegram bun row dropped from ps (process died); synology bun row still
+    // present. This is what happens when the real telegram poller crashes
+    // mid-flight while the SynoChat worker keeps running. Without the fix
+    // the channel-monitor stays at "alive" -- the user-visible deafness Szabi
+    // reported. With the fix, the matcher refuses to credit synology to
+    // telegram, the monitor sees "down", and the recovery cascade can act.
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude --channels plugin:telegram@claude-plugins-official' },
+      { pid: SYNOLOGY_BUN_PID, ppid: CLAUDE_PID, command: SYNOLOGY_CMD },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'telegram',
+      botPid: null, isPidAlive: ALL_PIDS_ALIVE,
+    })).toBe(false)
+  })
+
+  it('telegram bun is a grandchild (not direct child) of claude -> alive (tree-walk descends)', () => {
+    // claude spawns a `bun` wrapper which spawns the real poller. The
+    // tree-walk must descend through the wrapper to find the poller.
+    const WRAPPER = 1500
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude --channels plugin:telegram@claude-plugins-official' },
+      { pid: WRAPPER, ppid: CLAUDE_PID, command: 'bun' },
+      { pid: TELEGRAM_BUN_PID, ppid: WRAPPER, command: TELEGRAM_CMD },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'telegram',
+      botPid: null, isPidAlive: ALL_PIDS_ALIVE,
+    })).toBe(true)
+  })
+
+  it('claude pid absent from ps -> NOT alive', () => {
+    const out = ps([
+      { pid: SYNOLOGY_BUN_PID, ppid: 1, command: SYNOLOGY_CMD },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'telegram',
+      botPid: null, isPidAlive: ALL_PIDS_ALIVE,
+    })).toBe(false)
+  })
+})
+
+describe('decideHasPluginAlive -- bot.pid fallback (reparented orphan)', () => {
+  it('telegram orphan reparented away from claude tree but bot.pid points to it -> alive', () => {
+    const ORPHAN = 4000
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude --channels plugin:telegram@claude-plugins-official' },
+      // reparented (ppid != claude); will not be found via tree-walk
+      { pid: ORPHAN, ppid: 1, command: TELEGRAM_CMD },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'telegram',
+      botPid: ORPHAN, isPidAlive: ALL_PIDS_ALIVE,
+    })).toBe(true)
+  })
+
+  it('bot.pid points to a dead pid -> ignore, do NOT report alive', () => {
+    const DEAD = 4001
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude' },
+      // The pid is in ps with telegram cmdline but isPidAlive says it's gone.
+      { pid: DEAD, ppid: 1, command: TELEGRAM_CMD },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'telegram',
+      botPid: DEAD, isPidAlive: NO_PIDS_ALIVE,
+    })).toBe(false)
+  })
+
+  it('bot.pid points to a pid whose cmdline is the WRONG provider -> NOT alive', () => {
+    // The bot.pid file contains a stale pid that has been recycled by an
+    // unrelated process (or the SynoChat worker by coincidence). Without the
+    // matcher gate this would falsely report telegram alive.
+    const RECYCLED = 4002
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude' },
+      { pid: RECYCLED, ppid: 1, command: SYNOLOGY_CMD },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'telegram',
+      botPid: RECYCLED, isPidAlive: ALL_PIDS_ALIVE,
+    })).toBe(false)
+  })
+})
+
+describe('decideHasPluginAlive -- slack/discord cross-tree scan', () => {
+  it('slack poller alive but NOT a descendant of claude -> alive via cross-tree scan', () => {
+    const SLACK_NODE = 5000
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude --channels plugin:slack-channel@marveen-marketplace' },
+      // Slack node process owned by something else (e.g. an MCP server boot)
+      // but matching the slack-channel plugin path.
+      { pid: SLACK_NODE, ppid: 1, command: 'node /home/user/.claude/plugins/marketplaces/marveen-marketplace/slack-channel/0.1.0/server.js' },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'slack',
+      botPid: null, isPidAlive: ALL_PIDS_ALIVE,
+    })).toBe(true)
+  })
+
+  it('discord poller alive but NOT a descendant -> alive via cross-tree scan', () => {
+    const DISCORD = 6000
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude --channels plugin:discord@claude-plugins-official' },
+      { pid: DISCORD, ppid: 1, command: 'bun run --cwd /home/user/.claude/plugins/cache/claude-plugins-official/discord/0.0.4 --silent start' },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'discord',
+      botPid: null, isPidAlive: ALL_PIDS_ALIVE,
+    })).toBe(true)
+  })
+
+  it('cross-tree scan respects the matcher: synology process does NOT count as slack', () => {
+    const out = ps([
+      { pid: CLAUDE_PID, ppid: 1, command: 'claude --channels plugin:slack-channel@marveen-marketplace' },
+      { pid: SYNOLOGY_BUN_PID, ppid: 1, command: SYNOLOGY_CMD },
+    ])
+    expect(decideHasPluginAlive({
+      psOutput: out, claudePid: CLAUDE_PID, providerType: 'slack',
+      botPid: null, isPidAlive: ALL_PIDS_ALIVE,
+    })).toBe(false)
+  })
+})

--- a/src/__tests__/provider-poller-match.test.ts
+++ b/src/__tests__/provider-poller-match.test.ts
@@ -1,0 +1,164 @@
+// Standalone matcher tests. The masking-prevention guarantee is proven here
+// at the matcher layer, independent of the higher-level integration test for
+// `decideHasPluginAlive` -- so a future refactor cannot silently re-introduce
+// the broad substring matching even if the integration path moves.
+//
+// All POSITIVE cmdlines are taken VERBATIM from a live `ps -axo pid,command`
+// snapshot captured on the EFi production host on 2026-06-09 (two plugins
+// resident: the upstream telegram plugin + an EFi-local synology-chat worker).
+
+import { describe, it, expect } from 'vitest'
+import { matchesProviderPollerCmd } from '../channel-coordinator/provider-poller-match.js'
+
+// Live cmdlines from `ps -axo pid,command` (2026-06-09 production snapshot).
+const TELEGRAM_CACHE_CMD =
+  'bun run --cwd /home/user/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 --shell=bun --silent start'
+const TELEGRAM_MARKETPLACE_CMD =
+  'bun run --cwd /home/user/.claude/plugins/marketplaces/claude-plugins-official/external_plugins/telegram --shell=bun --silent start'
+const SYNOLOGY_CHAT_CMD =
+  'bun run --cwd /home/user/.claude/plugins/efi-src/synology-chat --shell=bun --silent start'
+// Slack live snapshot was not available on the EFi host (telegram is the
+// production provider). The cmdline below mirrors the marveen-marketplace
+// `slack-channel@marveen-marketplace` plugin layout documented in
+// scripts/channels.sh (PLUGIN_ID) -- adjust if the upstream slack plugin
+// ever ships under a different directory name.
+const SLACK_CHANNEL_CMD =
+  'node /home/user/.claude/plugins/marketplaces/marveen-marketplace/slack-channel/0.1.0/server.js'
+const SLACK_BUN_CMD =
+  'bun run --cwd /home/user/.claude/plugins/cache/marveen-marketplace/slack-channel/0.1.0 --silent start'
+const DISCORD_CACHE_CMD =
+  'bun run --cwd /home/user/.claude/plugins/cache/claude-plugins-official/discord/0.0.4 --shell=bun --silent start'
+
+describe('matchesProviderPollerCmd', () => {
+  describe('telegram', () => {
+    it('matches the live cache-path telegram poller', () => {
+      expect(matchesProviderPollerCmd(TELEGRAM_CACHE_CMD, 'telegram')).toBe(true)
+    })
+    it('matches the live marketplace-path telegram poller', () => {
+      // Behavior IMPROVEMENT over the pre-fix substring `cmd.includes('/telegram/')`,
+      // which missed this row (no trailing `/` after telegram in the marketplace
+      // path). The path-boundary regex now accepts either `/telegram/` or
+      // `/telegram<whitespace|EOS>`.
+      expect(matchesProviderPollerCmd(TELEGRAM_MARKETPLACE_CMD, 'telegram')).toBe(true)
+    })
+  })
+
+  describe('slack', () => {
+    it('matches a slack-channel node poller (documented plugin path)', () => {
+      expect(matchesProviderPollerCmd(SLACK_CHANNEL_CMD, 'slack')).toBe(true)
+    })
+    it('matches a slack-channel bun poller', () => {
+      expect(matchesProviderPollerCmd(SLACK_BUN_CMD, 'slack')).toBe(true)
+    })
+    it('matches a slack poller whose cmdline carries the socket-mode signal but no /slack/ path-slug', () => {
+      // Behavior-preserving for the pre-fix cross-tree scan which accepted
+      // `socket-mode` as a Slack liveness signal regardless of plugin path.
+      // Covers slack pollers whose cwd does not reflect the plugin install
+      // dir (reparented orphan, unusual upstream layout). EFiveen 2026-06-09
+      // review catch: the original fix narrowed slack matching to the path
+      // slug only and dropped this signal.
+      const cmd = 'node /opt/some-other-layout/bolt-app --mode socket-mode'
+      expect(matchesProviderPollerCmd(cmd, 'slack')).toBe(true)
+    })
+  })
+
+  describe('discord', () => {
+    it('matches a discord cache-path bun poller', () => {
+      expect(matchesProviderPollerCmd(DISCORD_CACHE_CMD, 'discord')).toBe(true)
+    })
+  })
+
+  describe('masking-prevention (2026-06-09 fix, the load-bearing guarantee)', () => {
+    it('synology-chat poller is NOT misidentified as telegram alive', () => {
+      // Before this fix, the generic `bun + server.ts` clause could match an
+      // unrelated plugin's poller (any future bun process whose argv
+      // mentioned server.ts) -- a real telegram outage would be masked while
+      // the SynoChat worker kept the channel-monitor at "telegram alive."
+      // The path-boundary regex requires `/telegram` in the cmdline.
+      expect(matchesProviderPollerCmd(SYNOLOGY_CHAT_CMD, 'telegram')).toBe(false)
+    })
+    it('synology-chat poller is NOT misidentified as slack alive', () => {
+      expect(matchesProviderPollerCmd(SYNOLOGY_CHAT_CMD, 'slack')).toBe(false)
+    })
+    it('synology-chat poller is NOT misidentified as discord alive', () => {
+      expect(matchesProviderPollerCmd(SYNOLOGY_CHAT_CMD, 'discord')).toBe(false)
+    })
+    it('a hypothetical bun + server.ts cmdline without /telegram/ does NOT match telegram', () => {
+      // Regression-lock on the removed generic clause: any `bun ... server.ts`
+      // command without the provider slug must be rejected.
+      const cmd = 'bun run /home/user/some-other-plugin/server.ts'
+      expect(matchesProviderPollerCmd(cmd, 'telegram')).toBe(false)
+    })
+    it('a node process whose argv mentions "slack" but not as a plugin path does NOT match slack', () => {
+      // Regression-lock on the removed `cmd.includes('slack') && cmd.includes('node')`
+      // pair: the word slack must appear as a plugin-path slug, not free-text.
+      const cmd = 'node /home/user/tools/notify.js --webhook slack'
+      expect(matchesProviderPollerCmd(cmd, 'slack')).toBe(false)
+    })
+    it('a node process whose argv mentions "discord" but not as a plugin path does NOT match discord', () => {
+      const cmd = 'node /home/user/tools/notify.js --service discord'
+      expect(matchesProviderPollerCmd(cmd, 'discord')).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('empty cmd -> false for all providers', () => {
+      expect(matchesProviderPollerCmd('', 'telegram')).toBe(false)
+      expect(matchesProviderPollerCmd('', 'slack')).toBe(false)
+      expect(matchesProviderPollerCmd('', 'discord')).toBe(false)
+    })
+    it('plugin path present but no bun/node runtime -> false', () => {
+      // A grep / cat / ls happening to print the plugin path. Without bun
+      // or node tokens, this is not a poller process.
+      const cmd = '/bin/cat /home/user/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6/README.md'
+      expect(matchesProviderPollerCmd(cmd, 'telegram')).toBe(false)
+    })
+    it('bun substring inside a word -> false (\\bbun\\b token requirement)', () => {
+      // `embun` is not bun. The runtime-token check uses `\b` so a partial
+      // substring inside a larger word does not count.
+      const cmd = 'embuncher --cwd /home/user/.claude/plugins/.../telegram/0.0.6'
+      expect(matchesProviderPollerCmd(cmd, 'telegram')).toBe(false)
+    })
+    it('telegram slug at end-of-string -> true', () => {
+      const cmd = 'bun --cwd /home/user/.claude/plugins/marketplaces/.../telegram'
+      expect(matchesProviderPollerCmd(cmd, 'telegram')).toBe(true)
+    })
+  })
+
+  describe('socket-mode signal is slack-scoped (no cross-provider leak)', () => {
+    it('socket-mode in a node cmdline does NOT match telegram', () => {
+      const cmd = 'node /opt/something --mode socket-mode'
+      expect(matchesProviderPollerCmd(cmd, 'telegram')).toBe(false)
+    })
+    it('socket-mode in a bun cmdline does NOT match discord', () => {
+      const cmd = 'bun run /opt/something --mode socket-mode'
+      expect(matchesProviderPollerCmd(cmd, 'discord')).toBe(false)
+    })
+    it('socket-mode WITHOUT bun/node runtime token does NOT match slack', () => {
+      // The runtime-token gate stays in effect: socket-mode alone is not
+      // enough; the process must look like a JS runtime.
+      const cmd = '/bin/cat /var/log/socket-mode.log'
+      expect(matchesProviderPollerCmd(cmd, 'slack')).toBe(false)
+    })
+    it('"socket-modemax" (substring inside a word) does NOT match slack', () => {
+      // Whole-word anchor on socket-mode to avoid partial-substring drift.
+      const cmd = 'node /opt/socket-modemax/server.js'
+      expect(matchesProviderPollerCmd(cmd, 'slack')).toBe(false)
+    })
+  })
+
+  describe('cross-provider non-confusion', () => {
+    it('telegram cmdline does NOT match slack or discord', () => {
+      expect(matchesProviderPollerCmd(TELEGRAM_CACHE_CMD, 'slack')).toBe(false)
+      expect(matchesProviderPollerCmd(TELEGRAM_CACHE_CMD, 'discord')).toBe(false)
+    })
+    it('slack cmdline does NOT match telegram or discord', () => {
+      expect(matchesProviderPollerCmd(SLACK_CHANNEL_CMD, 'telegram')).toBe(false)
+      expect(matchesProviderPollerCmd(SLACK_CHANNEL_CMD, 'discord')).toBe(false)
+    })
+    it('discord cmdline does NOT match telegram or slack', () => {
+      expect(matchesProviderPollerCmd(DISCORD_CACHE_CMD, 'telegram')).toBe(false)
+      expect(matchesProviderPollerCmd(DISCORD_CACHE_CMD, 'slack')).toBe(false)
+    })
+  })
+})

--- a/src/channel-coordinator/liveness.ts
+++ b/src/channel-coordinator/liveness.ts
@@ -15,6 +15,7 @@ import { logger } from '../logger.js'
 import { PROJECT_ROOT } from '../config.js'
 import { channelStateDir, type ChannelProviderType } from '../channel-provider.js'
 import { agentDir } from '../web/agent-config.js'
+import { matchesProviderPollerCmd } from './provider-poller-match.js'
 
 const TMUX = resolveFromPath('tmux')
 
@@ -47,92 +48,110 @@ export function getClaudePidForSession(session: string): number | null {
   }
 }
 
+/**
+ * Pure decision: does the parsed `ps` snapshot + bot.pid + alive-predicate
+ * prove that the `providerType` channel plugin is alive under `claudePid`?
+ *
+ * Extracted 1:1 from `hasChannelPluginAlive` for testability (matches the
+ * `decideStuckToolCallRecovery` pure-decider pattern used elsewhere). The
+ * branching, ordering, and bot.pid + cross-tree fallbacks are preserved
+ * verbatim; only the per-provider command-line matching delegates to
+ * `matchesProviderPollerCmd` (the path-boundary matcher that closes the
+ * multi-plugin masking gap).
+ */
+export interface PluginAliveContext {
+  psOutput: string
+  claudePid: number
+  providerType: ChannelProviderType
+  botPid: number | null
+  isPidAlive: (pid: number) => boolean
+  agentName?: string
+  debugLog?: (event: string, fields: Record<string, unknown>) => void
+}
+
+export function decideHasPluginAlive(ctx: PluginAliveContext): boolean {
+  const { psOutput, claudePid, providerType, botPid, isPidAlive, agentName, debugLog } = ctx
+  const lines = psOutput.split('\n').slice(1)
+  const childrenOf = new Map<number, number[]>()
+  const cmdOf = new Map<number, string>()
+  for (const line of lines) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/)
+    if (!m) continue
+    const pid = parseInt(m[1], 10)
+    const ppid = parseInt(m[2], 10)
+    cmdOf.set(pid, m[3])
+    const arr = childrenOf.get(ppid) || []
+    arr.push(pid)
+    childrenOf.set(ppid, arr)
+  }
+
+  const stack = [claudePid]
+  const seen = new Set<number>()
+  while (stack.length) {
+    const p = stack.pop()!
+    if (seen.has(p)) continue
+    seen.add(p)
+    const cmd = cmdOf.get(p) || ''
+    if (matchesProviderPollerCmd(cmd, providerType)) return true
+    for (const k of (childrenOf.get(p) || [])) stack.push(k)
+  }
+
+  if (botPid !== null && botPid > 1) {
+    if (isPidAlive(botPid)) {
+      const cmd = cmdOf.get(botPid) || ''
+      if (matchesProviderPollerCmd(cmd, providerType)) {
+        debugLog?.('plugin alive via bot.pid (reparented)', { claudePid, orphanPid: botPid, agentName, providerType })
+        return true
+      }
+    }
+  }
+
+  if (providerType === 'slack') {
+    for (const [pid, cmd] of cmdOf) {
+      if (seen.has(pid)) continue
+      if (matchesProviderPollerCmd(cmd, providerType) && isPidAlive(pid)) {
+        debugLog?.('slack plugin alive via process scan', { claudePid, slackPid: pid, agentName })
+        return true
+      }
+    }
+  }
+
+  if (providerType === 'discord') {
+    for (const [pid, cmd] of cmdOf) {
+      if (seen.has(pid)) continue
+      if (matchesProviderPollerCmd(cmd, providerType) && isPidAlive(pid)) {
+        debugLog?.('discord plugin alive via process scan', { claudePid, discordPid: pid, agentName })
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
 export function hasChannelPluginAlive(claudePid: number, providerType: ChannelProviderType, agentName?: string): boolean {
   try {
-    const ps = execFileSync('/bin/ps', ['-axo', 'pid,ppid,command'], { timeout: 3000, encoding: 'utf-8' })
-    const lines = ps.split('\n').slice(1)
-    const childrenOf = new Map<number, number[]>()
-    const cmdOf = new Map<number, string>()
-    for (const line of lines) {
-      const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/)
-      if (!m) continue
-      const pid = parseInt(m[1], 10)
-      const ppid = parseInt(m[2], 10)
-      cmdOf.set(pid, m[3])
-      const arr = childrenOf.get(ppid) || []
-      arr.push(pid)
-      childrenOf.set(ppid, arr)
-    }
-
-    const stack = [claudePid]
-    const seen = new Set<number>()
-    while (stack.length) {
-      const p = stack.pop()!
-      if (seen.has(p)) continue
-      seen.add(p)
-      const cmd = cmdOf.get(p) || ''
-      if (providerType === 'telegram') {
-        if (cmd.includes('/telegram/') && cmd.includes('bun')) return true
-        if (/\bbun\b/.test(cmd) && cmd.includes('server.ts')) return true
-      } else if (providerType === 'discord') {
-        if (cmd.includes('discord') && (cmd.includes('node') || cmd.includes('bun'))) return true
-      } else {
-        if (cmd.includes('slack') && cmd.includes('node')) return true
-        if (cmd.includes('slack-channel') && (cmd.includes('bun') || cmd.includes('node'))) return true
-      }
-      for (const k of (childrenOf.get(p) || [])) stack.push(k)
-    }
-
+    const psOutput = execFileSync('/bin/ps', ['-axo', 'pid,ppid,command'], { timeout: 3000, encoding: 'utf-8' })
     const stateDir = agentName
       ? channelStateDir(providerType, agentDir(agentName))
       : channelStateDir(providerType)
     const pidPath = join(stateDir, 'bot.pid')
+    let botPid: number | null = null
     if (existsSync(pidPath)) {
-      const pid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10)
-      if (pid > 1) {
-        try {
-          process.kill(pid, 0)
-          const cmd = cmdOf.get(pid) || ''
-          const isRelevant = providerType === 'telegram'
-            ? (cmd.includes('bun') || cmd.includes('server.ts') || cmd.includes('telegram'))
-            : providerType === 'discord'
-              ? (cmd.includes('discord') && (cmd.includes('node') || cmd.includes('bun')))
-              : (cmd.includes('node') || cmd.includes('slack'))
-          if (isRelevant) {
-            logger.debug({ claudePid, orphanPid: pid, agentName, providerType }, 'Channel plugin alive via bot.pid (reparented)')
-            return true
-          }
-        } catch { /* process gone */ }
-      }
+      const parsed = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10)
+      if (Number.isFinite(parsed)) botPid = parsed
     }
-
-    if (providerType === 'slack') {
-      for (const [pid, cmd] of cmdOf) {
-        if (seen.has(pid)) continue
-        if ((cmd.includes('slack') || cmd.includes('socket-mode')) && (cmd.includes('node') || cmd.includes('bun'))) {
-          try {
-            process.kill(pid, 0)
-            logger.debug({ claudePid, slackPid: pid, agentName }, 'Slack plugin alive via process scan')
-            return true
-          } catch { /* gone */ }
-        }
-      }
-    }
-
-    if (providerType === 'discord') {
-      for (const [pid, cmd] of cmdOf) {
-        if (seen.has(pid)) continue
-        if (cmd.includes('discord') && (cmd.includes('node') || cmd.includes('bun'))) {
-          try {
-            process.kill(pid, 0)
-            logger.debug({ claudePid, discordPid: pid, agentName }, 'Discord plugin alive via process scan')
-            return true
-          } catch { /* gone */ }
-        }
-      }
-    }
-
-    return false
+    return decideHasPluginAlive({
+      psOutput,
+      claudePid,
+      providerType,
+      botPid,
+      agentName,
+      isPidAlive: (pid) => {
+        try { process.kill(pid, 0); return true } catch { return false }
+      },
+      debugLog: (event, fields) => logger.debug(fields, event),
+    })
   } catch {
     return false
   }

--- a/src/channel-coordinator/provider-poller-match.ts
+++ b/src/channel-coordinator/provider-poller-match.ts
@@ -1,0 +1,89 @@
+// Provider-specific poller cmdline matcher.
+//
+// `hasChannelPluginAlive` walks the process tree under a marveen-channels claude
+// looking for the plugin's bun/node poller. Before this module, the per-provider
+// check was a loose substring search: `cmd.includes('/telegram/') && ...` or a
+// generic `bun + server.ts` fallback. In a multi-plugin setup -- e.g. Marveen
+// running both the upstream Telegram plugin AND a SynoChat worker (both spawned
+// as `bun run --cwd <plugin-dir>` children of the same claude pid) -- the
+// generic fallback can MATCH the unrelated SynoChat process and report
+// "telegram alive" while the real telegram poller is dead (masking). The fix:
+// match against the plugin's own directory slug bounded by path separators, so
+// each provider only matches its own poller. The masking gap is closed at the
+// matcher layer regardless of whether the consumer is the tree-walk, the
+// bot.pid fallback, or the slack/discord cross-tree scan.
+
+import type { ChannelProviderType } from '../channel-provider.js'
+
+// Runtime token: bun OR node. A poller is always one of these two. Bare
+// substring `bun` would match a process whose argv merely mentions bun
+// (a help line, an unrelated tool); `\bbun\b` anchors on token boundaries.
+const RUNTIME_TOKEN_RX = /\b(bun|node)\b/
+
+// Per-provider plugin-directory slug, anchored on path-boundary so a substring
+// inside an unrelated argv (e.g. the literal word "discord" in someone's MCP
+// description) is not enough -- the slug must look like a real plugin path
+// segment, with a path separator (or end-of-token whitespace, or end-of-string)
+// on at least one side.
+//
+// Slug derivation:
+//   - telegram: 'telegram' -- the @claude-plugins-official cache layout puts
+//     pollers under `.../cache/claude-plugins-official/telegram/<ver>/` AND
+//     the marketplace layout puts them under
+//     `.../marketplaces/claude-plugins-official/external_plugins/telegram`,
+//     so both `/telegram/<ver>` and `/telegram` (token-end) shapes are covered
+//     by the same path-boundary pattern.
+//   - discord: 'discord' -- same dual layout, same pattern.
+//   - slack: 'slack(-channel)?' -- the marveen `slack-channel@marveen-marketplace`
+//     plugin checks in under a `slack-channel` directory, while any upstream
+//     `slack@...` plugin would land at `/slack`. Both are accepted. NOTE: if
+//     upstream ever ships the slack plugin under a different directory name
+//     (e.g. `slack-mcp` or similar), this slug needs an update; today it is
+//     derived from the marveen-marketplace plugin-id and the conventional
+//     upstream layout, both documented in scripts/channels.sh (PLUGIN_ID).
+//
+// The `(?:\/|\s|$)` trailing anchor accepts:
+//   - `/telegram/0.0.6/server.ts ...`  → trailing `/`
+//   - `/telegram --shell=bun ...`      → trailing whitespace
+//   - `... /telegram`                  → end-of-string
+const SLUG_RX: Record<ChannelProviderType, RegExp> = {
+  telegram: /\/telegram(?:\/|\s|$)/,
+  slack: /\/slack(?:-channel)?(?:\/|\s|$)/,
+  discord: /\/discord(?:\/|\s|$)/,
+}
+
+// Slack-specific behavior-preserving fallback. The pre-fix cross-tree scan
+// accepted `socket-mode` as a valid liveness signal:
+//   (cmd.includes('slack') || cmd.includes('socket-mode')) && (node|bun)
+// `socket-mode` is the Slack Bolt SDK / `@slack/socket-mode` connection mode.
+// A live slack poller process whose ps row does NOT carry a `/slack` or
+// `/slack-channel` path segment (e.g. an unusual plugin layout, a reparented
+// orphan whose cwd no longer reflects the install dir, or a different upstream
+// distribution layout we cannot test against from here) would still be caught
+// by this signal. Preserving it as an OR-branch avoids a regression for any
+// slack user whose poller cmdline differs from the marveen-marketplace shape
+// we tested against. Whole-word anchored (`\b`) so a substring inside an
+// unrelated argv does not match. ONLY applies to provider='slack' -- the
+// telegram/discord branches stay strict.
+const SLACK_SOCKET_MODE_RX = /\bsocket-mode\b/
+
+/**
+ * Pure: does this process command line look like a channel poller for `provider`?
+ *
+ * Match requires BOTH:
+ *  - bun OR node runtime token (whole-word, not substring)
+ *  - provider-specific plugin-directory slug bounded by path separators
+ *
+ * Reject everything else, including the historical `bun + server.ts` generic
+ * fallback that masked a co-resident plugin's poller as "the provider's alive."
+ */
+export function matchesProviderPollerCmd(
+  cmd: string,
+  provider: ChannelProviderType,
+): boolean {
+  if (!cmd) return false
+  if (!RUNTIME_TOKEN_RX.test(cmd)) return false
+  if (SLUG_RX[provider].test(cmd)) return true
+  if (provider === 'slack' && SLACK_SOCKET_MODE_RX.test(cmd)) return true
+  return false
+}


### PR DESCRIPTION
> AI-generated by Marveen dev agent (dev, Claude Opus 4.7).

## Problem

`hasChannelPluginAlive` in `src/channel-coordinator/liveness.ts` -- the
plugin-poller probe shared by the dashboard's channel-monitor and the
standalone channel-coordinator -- checks for the provider's poller via loose
substring matching:

```ts
// telegram branch
if (cmd.includes('/telegram/') && cmd.includes('bun')) return true
if (/\bbun\b/.test(cmd) && cmd.includes('server.ts')) return true   // generic fallback
// slack branch
if (cmd.includes('slack') && cmd.includes('node')) return true
if (cmd.includes('slack-channel') && (cmd.includes('bun') || cmd.includes('node'))) return true
// discord branch
if (cmd.includes('discord') && (cmd.includes('node') || cmd.includes('bun'))) return true
```

The same shape is repeated for the bot.pid reparented-orphan fallback and for
the slack/discord cross-tree scans.

In a multi-plugin setup -- e.g. Marveen running both the upstream Telegram
plugin AND a co-resident bun-based plugin -- the generic
`/\bbun\b/.test(cmd) && cmd.includes('server.ts')` clause can credit the
unrelated plugin's poller to the wrong provider. The channel-monitor then
reports "telegram alive" while the real telegram poller is dead, the
recovery cascade never fires, and inbound traffic silently stalls.

The same masking shape applies to `discord` (`cmd.includes('discord')` is
satisfied by any cmdline mentioning that word in argv) and to a lesser
extent `slack`.

## Fix

**1. New pure helper `src/channel-coordinator/provider-poller-match.ts`.**
A single exported function:

```ts
export function matchesProviderPollerCmd(cmd: string, provider: ChannelProviderType): boolean
```

Match requires BOTH:
- A bun OR node runtime token, whole-word anchored (`\b(bun|node)\b`).
- A provider-specific plugin-directory slug bounded by path separators:
  - `telegram` -> `/telegram(?:\/|\s|$)`
  - `slack` -> `/slack(?:-channel)?(?:\/|\s|$)`
  - `discord` -> `/discord(?:\/|\s|$)`

The historical `cmd.includes('server.ts')` generic fallback is removed.

**2. Mechanical decider extraction.** `hasChannelPluginAlive` is split into
two functions:

- `decideHasPluginAlive(ctx)` -- pure decision over a parsed ps snapshot, a
  pre-resolved bot.pid, and an `isPidAlive(pid)` predicate. The branching,
  ordering, and bot.pid + cross-tree fallbacks are preserved verbatim from
  the prior implementation. Only the per-provider command-line check
  delegates to the new helper.
- `hasChannelPluginAlive(claudePid, provider, agentName?)` -- the I/O
  wrapper. Reads `ps -axo pid,ppid,command`, reads bot.pid from disk,
  supplies the `process.kill(pid, 0)` predicate, calls the decider.

Same pattern as `decideStuckToolCallRecovery` / `decidePaneErrorAlert`
elsewhere in the repo: pure decision layer with a side-effecting wrapper.
This makes the masking-prevention guarantee unit-testable without process
mocking.

## Known scope narrowing (intentional)

The pre-fix slack cross-tree scan accepted EITHER `cmd.includes('slack')` OR
`cmd.includes('socket-mode')` as a slack liveness signal. The path-slug
matcher would have dropped the socket-mode signal. To avoid a false-negative
regression for any slack user whose poller cmdline does not carry the
`/slack(-channel)?` path segment (reparented orphan, alternative plugin
layout, anything we cannot test against from here), `matchesProviderPollerCmd`
preserves the socket-mode signal as an OR-branch scoped to
`provider === 'slack'`:

```ts
if (provider === 'slack' && /\bsocket-mode\b/.test(cmd)) return true
```

This is the only behavior the new matcher inherits from the old broad
matching. The other broad matches (`cmd.includes('slack')` free-text, the
generic telegram `server.ts` clause, the broad discord substring) are NOT
preserved -- regression-locked by tests.

## Verification

Live `ps -axo pid,command` snapshot captured on the production host on
2026-06-09 with two plugins resident (the upstream telegram plugin and a
co-resident bun-based plugin):

| Cmdline shape | Old matcher | New matcher |
|---|---|---|
| telegram cache path (`/telegram/0.0.6 ...`) | alive | alive |
| telegram marketplace path (`/external_plugins/telegram ...`) | NOT detected via tree-walk (substring `cmd.includes('/telegram/')` did not match -- relied on bot.pid fallback) | alive (path-boundary regex accepts `/telegram<whitespace|EOS>`) |
| co-resident bun plugin (no `/telegram` in cwd) | would be credited via `bun + server.ts` if that substring ever appeared in its argv | NOT credited to telegram |

- `npm run typecheck` -- clean
- `npx vitest run src/__tests__/provider-poller-match.test.ts
  src/__tests__/liveness-masking.test.ts` -- 34 / 34 pass
- Full `npx vitest run` -- 1045 pass / 4 fail / 1 skip; the 4 failures are
  pre-existing macOS `managed-settings` shape mismatches unrelated to this
  change.

**Tests added:**

- `src/__tests__/provider-poller-match.test.ts` (23 tests) -- the load-bearing
  guarantee. Positive: cache-path + marketplace-path telegram, slack-channel
  bun/node, discord cache, slack socket-mode. Masking-prevention: the
  co-resident plugin's cmdline returns false for telegram, slack, and discord.
  Regression-locks for the deleted clauses: a hypothetical `bun + server.ts`
  cmdline without `/telegram/` returns false; a `node ... slack` free-text
  cmdline without `/slack/` returns false; a `node ... discord` free-text
  cmdline without `/discord/` returns false. socket-mode is slack-scoped and
  does not leak to other providers; the substring `socket-modemax` does not
  match (whole-word anchor).

- `src/__tests__/liveness-masking.test.ts` (11 tests) -- integration over
  `decideHasPluginAlive`. The 2026-06-09 multi-plugin scenario end-to-end:
  only the co-resident plugin's bun process is a child of claude under
  `providerType='telegram'` -> false. Real telegram poller alone -> true.
  Both running -> true. Real telegram pid gone, co-resident still up -> false
  (the post-fix recovery path). Tree-walk descends through bun wrappers.
  bot.pid reparented orphan -> alive. bot.pid pointing to a recycled pid of
  the WRONG provider -> not alive. Cross-tree scan for slack/discord respects
  the matcher.

## Related

- Refs #258 -- umbrella issue ("Telegram channel keeps dropping under load").
  This change closes one of the remaining false-down detection holes
  (cross-plugin liveness masking) that the umbrella tracks.
- Related: #292 -- in-session plugin-liveness watchdog. Same area of the
  liveness probe; this change tightens the per-provider match the watchdog
  ultimately relies on.
- Related: #297 -- stuck-tool-call respawn / recovery cascade. Independent
  fix path; both PRs harden the same overall "is the channel actually alive"
  decision the channel-monitor makes every tick.
