### PR TITLE
fix(dashboard): scrollback + stable paging in agent terminal widget

### DIFF
--- a/src/web/routes/agent-terminal.ts
+++ b/src/web/routes/agent-terminal.ts
@@ -89,8 +89,11 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
       // block the WHOLE dashboard event loop for up to the tmux timeout on every
       // tick, freezing all other HTTP requests. The arg array also avoids shell
       // interpolation of `session`. -e keeps ANSI so xterm renders faithfully;
-      // -p prints; the frontend repaints (clear+home) each frame (full snapshot).
-      execFile(TMUX, ['capture-pane', '-t', session, '-e', '-p'], { timeout: 3000, encoding: 'utf-8', maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
+      // -p prints. `-S -2000` includes 2000 lines of scrollback history (not just
+      // the visible pane) so the frontend can offer scroll-back; the frontend
+      // repaints the full snapshot (clear-scrollback + clear + home) each changed
+      // frame and only when the user is at the bottom, so scrolling up is stable.
+      execFile(TMUX, ['capture-pane', '-t', session, '-S', '-2000', '-e', '-p'], { timeout: 3000, encoding: 'utf-8', maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
         inFlight = false
         if (closed) return
         const pane = err ? '' : (stdout ?? '')

--- a/web/app.js
+++ b/web/app.js
@@ -9561,7 +9561,7 @@ function openTerminalModal(agentName) {
     fontSize: 12,
     cursorBlink: false,
     disableStdin: false,
-    scrollback: 500,
+    scrollback: 4000,
     convertEol: true,
     allowProposedApi: true,
   })
@@ -9575,31 +9575,55 @@ function openTerminalModal(agentName) {
   openModal(overlay)
   setTimeout(() => term.focus(), 50)
 
-  // SSE pane stream
+  // SSE pane stream.
+  // The pane snapshot now includes scrollback history (server uses
+  // `capture-pane -S -2000`), so the user can scroll back. To keep scrolling
+  // stable we (a) only repaint when the snapshot actually changed, and (b) only
+  // repaint while the viewport is at the bottom — if the user has scrolled up we
+  // freeze their view and resume painting when they return to the bottom (the
+  // onScroll handler below). The repaint clears the scrollback (CSI 3 J) before
+  // rewriting the full snapshot so frames don't accumulate duplicate history.
+  let latestPane = null
+  let paintedPane = null
+  const isAtBottom = () => {
+    const buf = term.buffer.active
+    return buf.viewportY >= buf.baseY
+  }
+  const repaint = () => {
+    if (latestPane === null || latestPane === paintedPane) return
+    if (!isAtBottom()) return // user scrolled up — keep their view put
+    paintedPane = latestPane
+    term.write('\x1b[3J\x1b[2J\x1b[H' + latestPane)
+  }
   const token = localStorage.getItem('marveen-dashboard-token') || ''
   const sse = new EventSource(`/api/agents/${encodeURIComponent(agentName)}/pane/stream?token=${encodeURIComponent(token)}`)
   sse.onmessage = (e) => {
     try {
       const msg = JSON.parse(e.data)
       if (msg.pane !== undefined) {
-        const clean = msg.pane.replace(/\x1b]8;[^\x1b]*\x1b\\/g, '')
-        term.write('\x1b[2J\x1b[H' + clean)
+        latestPane = msg.pane.replace(/\x1b]8;[^\x1b]*\x1b\\/g, '')
+        repaint()
       }
     } catch {}
   }
   sse.onerror = () => term.write('\r\n[stream hiba vagy leállva]\r\n')
   terminalSSE = sse
+  // When the user scrolls back down to the bottom, resume live repainting.
+  term.onScroll(() => { if (isAtBottom()) repaint() })
 
   // Single onData handler — maps escape sequences to {special}, plain chars to {keys}
-  // Using onData only (no onKey) avoids double-firing on arrow/Enter keys
+  // Using onData only (no onKey) avoids double-firing on arrow/Enter keys.
+  // PageUp/PageDown are intentionally NOT forwarded: they scroll the xterm
+  // scrollback locally (history viewing) instead of going to the agent.
   const ESC_TO_SPECIAL = {
     '\r': 'Enter', '\x1b': 'Escape',
     '\x1b[A': 'Up', '\x1b[B': 'Down', '\x1b[C': 'Right', '\x1b[D': 'Left',
     '\x7f': 'BSpace', '\t': 'Tab', '\x1b[Z': 'S-Tab',
     '\x03': 'C-c', '\x04': 'C-d', '\x15': 'C-u', '\x0c': 'C-l',
-    '\x1b[5~': 'PageUp', '\x1b[6~': 'PageDown',
   }
   term.onData(data => {
+    if (data === '\x1b[5~') { term.scrollPages(-1); return } // PageUp -> scroll history up
+    if (data === '\x1b[6~') { term.scrollPages(1); return }  // PageDown -> scroll history down
     const special = ESC_TO_SPECIAL[data]
     const body = special ? { special } : { keys: data }
     fetch(`/api/agents/${encodeURIComponent(agentName)}/keys`, {


### PR DESCRIPTION
The per-agent terminal only captured the visible tmux pane and repainted with a full clear+home every 700ms, so xterm had no history to scroll into and PageUp/PageDown were forwarded to the agent instead of scrolling.

- backend: capture-pane now includes 2000 lines of scrollback (-S -2000)
- frontend: repaint only when the snapshot changed AND the viewport is at the bottom (freeze the view while the user scrolls up; resume on return), clearing scrollback (CSI 3J) per frame so history doesn't duplicate
- frontend: PageUp/PageDown scroll the xterm scrollback locally instead of being sent to the agent; xterm scrollback raised 500 -> 4000