### PR TITLE
feat(dashboard): read-only Docs viewer for the project docs/ folder

### DIFF
--- a/docs/onboarding-uj-asszisztens.md
+++ b/docs/onboarding-uj-asszisztens.md
@@ -1,0 +1,97 @@
+# Új asszisztens onboarding (Marveen flotta)
+
+Ez a leírás végigvezet egy új kolléga-asszisztens beüzemelésén: saját Telegram bot
+és saját Google (Gmail/Drive/Naptár) hozzáférés. Példa: "Dia Marveenja".
+
+Két dolgot kell beállítani: **Telegram** (hogy a kolléga beszélni tudjon az
+asszisztensével) és **Google** (hogy az asszisztens lássa a kolléga levelét,
+naptárát, fájljait). A kettő független, bármelyikkel kezdheted.
+
+---
+
+## Alapelvek
+
+- **Minden asszisztens = saját Telegram bot.** Egy bot tokent nem lehet két
+  asszisztensen megosztani (a Telegram botonként csak egy kapcsolatot enged, és a
+  dashboard is tiltja a duplikációt).
+- **A személyes Google a kolléga saját asszisztensébe kerül**, nem a Főnökbe
+  (iS Marveen Főnök / marveen-is). A Főnök a flottát kezeli, nem olvassa senki
+  postáját.
+- **A titkokat (bot token, OAuth) soha ne küldd Telegram-chatbe.** A bot token a
+  dashboard mezőjébe megy, a Google belépés pedig egy egyszeri böngészős lépés.
+
+---
+
+## 1. Telegram bot létrehozása és bekötése
+
+1. **Bot létrehozása (Telegramban, @BotFather):**
+   - Nyisd meg a @BotFather-t, parancs: `/newbot`
+   - Név: pl. `Dia Marveenja`
+   - Username: pl. `dia_marveen_bot` (egyedinek kell lennie, `_bot`-ra végződik)
+   - A BotFather ad egy API tokent. Ezt másold ki.
+   - Tipp: a botot te (admin) hozd létre, így céges kézben marad. A kolléga a
+     tokent soha nem látja.
+
+2. **Asszisztens létrehozása a dashboardon** (https://marveen.isolutions.hu):
+   - "Felvétel", ahogy a korábbi asszisztenseknél.
+
+3. **Token bekötése:**
+   - Az asszisztens csatorna-beállításánál illeszd be a bot tokent.
+   - A rendszer ellenőrzi, bekötí, és küld egy üdvözlő üzenetet a boton.
+
+4. **A kolléga hozzáférése (párosítás):**
+   - A kolléga megnyitja a botot (`t.me/dia_marveen_bot`), és ír neki egy üzenetet.
+   - Alapból csak engedélyezett felhasználó tud írni (allowlist policy).
+   - Te a dashboardon jóváhagyod a kolléga párosítását. Ettől kezdve beszélhet az
+     asszisztensével.
+
+---
+
+## 2. Google (Gmail / Drive / Naptár) bekötése
+
+Egyszeri céges előfeltétel (már megvan, csak referencia):
+- Google Cloud projekt, engedélyezve a Gmail + Drive + Calendar API.
+- OAuth consent screen: Internal (csak céges fiókok).
+- Egy "Desktop" OAuth kliens, a titka a szerveren zárolva.
+
+A kolléga bekötése:
+1. A Főnök (iS Marveen Főnök) előkészíti az asszisztens Google-konfigját és
+   generál egy belépési linket.
+2. A kolléga a **saját gépén** megnyitja a linket, belép a **saját céges Google
+   fiókjával**, és engedélyezi a hozzáférést.
+3. A böngésző a végén egy `localhost:...` címre ugrik és hibát mutat. Ez normális.
+   A kolléga a böngésző címsorából kimásolja a teljes URL-t, és visszaküldi a
+   Főnöknek.
+4. A Főnök a szerveren lezárja a belépést. Ezután az asszisztens újraindul, és
+   látja a Gmailt/Drive-ot/Naptárt. Újra belépni nem kell.
+
+A kolléga a tokent és a technikai részleteket nem látja, csak egyszer belép a
+saját Google fiókjával.
+
+---
+
+## Ki mit csinál (gyors összefoglaló)
+
+| Lépés | Ki csinálja |
+|-------|-------------|
+| Bot létrehozása (@BotFather) | Admin (te) |
+| Asszisztens felvétele a dashboardon | Admin (te) |
+| Bot token bekötése | Admin (te) |
+| Párosítás jóváhagyása | Admin (te) |
+| Google belépés (egyszeri) | A kolléga (saját fiókkal) |
+| Google konfig + lezárás a szerveren | iS Marveen Főnök |
+
+---
+
+## Hibakeresés
+
+- **A kolléga ír a botnak, de nincs válasz:** valószínűleg nincs még jóváhagyva a
+  párosítás. Nézd meg a dashboardon a függő (pending) párosításokat.
+- **Eltűnő üzenetek / kapcsolat-hibák:** majdnem biztos, hogy ugyanazt a bot
+  tokent két asszisztensre tették. Minden asszisztensnek külön bot kell.
+- **A Google belépés "origin not allowed" vagy hasonló hibát ad:** szólj a
+  Főnöknek, ez OAuth-konfig kérdés, nem a kolléga hibája.
+
+---
+
+*Készítette: iS Marveen Főnök. A flotta a marveen.isolutions.hu címen érhető el.*

--- a/src/web.ts
+++ b/src/web.ts
@@ -30,6 +30,7 @@ import { tryHandleMigrate } from './web/routes/migrate.js'
 import { tryHandleKanban } from './web/routes/kanban.js'
 import { tryHandleSchedules } from './web/routes/schedules.js'
 import { tryHandleConnectors } from './web/routes/connectors.js'
+import { tryHandleDocs } from './web/routes/docs.js'
 import { tryHandleConnectorsHu } from './web/routes/connectors-hu.js'
 import { tryHandleAgentsSkills } from './web/routes/agents-skills.js'
 import { tryHandleSkills } from './web/routes/skills.js'
@@ -133,6 +134,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleSchedules(routeCtx)) return
       if (await tryHandleConnectorsHu(routeCtx)) return
       if (await tryHandleConnectors(routeCtx)) return
+      if (await tryHandleDocs(routeCtx)) return
       if (await tryHandleAgentsSkills(routeCtx)) return
       if (await tryHandleSkills(routeCtx)) return
       if (await tryHandleAgentTerminal(routeCtx)) return

--- a/src/web/routes/docs.ts
+++ b/src/web/routes/docs.ts
@@ -1,0 +1,71 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, basename } from 'node:path'
+import { PROJECT_ROOT } from '../../config.js'
+import { json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+// Read-only viewer for the project's docs/ folder. Both endpoints sit under
+// /api/* so the dashboard's bearer-token gate already protects them -- no extra
+// auth wiring here. Nothing is writable; this only ever reads .md files that
+// already live in the repo.
+const DOCS_DIR = join(PROJECT_ROOT, 'docs')
+// Allowlist: a bare markdown filename. Combined with the basename() check below
+// this blocks path traversal (../, absolute paths, nested segments).
+const NAME_RE = /^[A-Za-z0-9._-]+\.md$/
+
+function titleOf(content: string, fallback: string): string {
+  const m = content.match(/^#\s+(.+)$/m)
+  return m ? m[1].trim() : fallback
+}
+
+export async function tryHandleDocs(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method } = ctx
+
+  if (path === '/api/docs' && method === 'GET') {
+    let files: string[] = []
+    try {
+      files = readdirSync(DOCS_DIR).filter(
+        f => NAME_RE.test(f) && statSync(join(DOCS_DIR, f)).isFile(),
+      )
+    } catch {
+      files = []
+    }
+    const docs = files.sort().map(name => {
+      let title = name
+      let created: string | null = null
+      try {
+        const file = join(DOCS_DIR, name)
+        title = titleOf(readFileSync(file, 'utf-8'), name)
+        const s = statSync(file)
+        // birthtime is the file's creation time; on filesystems that don't track
+        // it (returns 0) fall back to the last-modified time.
+        const ms = s.birthtimeMs && s.birthtimeMs > 0 ? s.birthtimeMs : s.mtimeMs
+        created = new Date(ms).toISOString().slice(0, 10)
+      } catch {
+        /* keep filename as title, created stays null */
+      }
+      return { name, title, created }
+    })
+    json(res, docs)
+    return true
+  }
+
+  const match = path.match(/^\/api\/docs\/([^/]+)$/)
+  if (match && method === 'GET') {
+    const name = decodeURIComponent(match[1])
+    if (!NAME_RE.test(name) || basename(name) !== name) {
+      json(res, { error: 'Invalid doc name' }, 400)
+      return true
+    }
+    const file = join(DOCS_DIR, name)
+    if (!existsSync(file) || !statSync(file).isFile()) {
+      json(res, { error: 'Not found' }, 404)
+      return true
+    }
+    const content = readFileSync(file, 'utf-8')
+    json(res, { name, title: titleOf(content, name), content })
+    return true
+  }
+
+  return false
+}

--- a/web/app.js
+++ b/web/app.js
@@ -90,6 +90,7 @@ function switchPage(pageId) {
   if (pageId === 'skills') loadGlobalSkills()
   if (pageId === 'connectors') loadConnectors()
   if (pageId === 'migrate') loadMigrateAgents()
+  if (pageId === 'docs') loadDocs()
   if (pageId === 'status') loadStatus()
   if (pageId === 'recall') loadRecallPage()
   if (pageId === 'bgTasks') loadBgTasksPage()
@@ -9634,3 +9635,138 @@ document.getElementById('terminalClose')?.addEventListener('click', () => {
   window.addEventListener('hashchange', routeFromHash)
   routeFromHash()
 })()
+
+// ============================================================
+// === Docs (read-only viewer for the project's docs/ folder) ===
+// ============================================================
+
+function escapeAttr(s) {
+  return escapeHtml(String(s)).replace(/"/g, '&quot;')
+}
+
+// Minimal, dependency-free Markdown -> HTML renderer. Inputs come from the
+// repo's own docs/ folder (trusted), but we HTML-escape everything anyway and
+// only emit a fixed set of tags. Covers the constructs our docs use: fenced
+// code, headings, hr, tables, ordered/unordered lists, blockquotes, paragraphs,
+// and inline code/bold/italic/links.
+function mdInline(text) {
+  let s = escapeHtml(text)
+  s = s.replace(/`([^`]+)`/g, (m, c) => '<code>' + c + '</code>')
+  s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+  s = s.replace(/\*([^*]+)\*/g, '<em>$1</em>')
+  s = s.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (m, txt, url) =>
+    '<a href="' + escapeAttr(url) + '" target="_blank" rel="noopener noreferrer">' + txt + '</a>')
+  return s
+}
+
+function renderMarkdown(md) {
+  const lines = String(md).replace(/\r\n/g, '\n').split('\n')
+  const out = []
+  let i = 0
+  const isBlockStart = (l) =>
+    /^```/.test(l) || /^(#{1,6})\s/.test(l) || /^\s*[-*]\s+/.test(l) ||
+    /^\s*\d+\.\s+/.test(l) || /^\s*\|.*\|\s*$/.test(l) || /^\s*>\s?/.test(l) ||
+    /^\s*([-*_])\1{2,}\s*$/.test(l) || /^\s*$/.test(l)
+  while (i < lines.length) {
+    const line = lines[i]
+    const fence = line.match(/^```(\w*)\s*$/)
+    if (fence) {
+      const code = []
+      i++
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) { code.push(lines[i]); i++ }
+      i++
+      out.push('<pre><code>' + escapeHtml(code.join('\n')) + '</code></pre>')
+      continue
+    }
+    const h = line.match(/^(#{1,6})\s+(.*)$/)
+    if (h) { const lvl = h[1].length; out.push('<h' + lvl + '>' + mdInline(h[2].trim()) + '</h' + lvl + '>'); i++; continue }
+    if (/^\s*([-*_])\1{2,}\s*$/.test(line)) { out.push('<hr>'); i++; continue }
+    if (/^\s*\|.*\|\s*$/.test(line) && i + 1 < lines.length &&
+        /^\s*\|?[\s:|-]+\|?\s*$/.test(lines[i + 1]) && lines[i + 1].includes('-')) {
+      const parseRow = (r) => r.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map(c => c.trim())
+      const headers = parseRow(line)
+      i += 2
+      const rows = []
+      while (i < lines.length && /^\s*\|.*\|\s*$/.test(lines[i])) { rows.push(parseRow(lines[i])); i++ }
+      let t = '<table><thead><tr>' + headers.map(c => '<th>' + mdInline(c) + '</th>').join('') + '</tr></thead><tbody>'
+      for (const r of rows) t += '<tr>' + r.map(c => '<td>' + mdInline(c) + '</td>').join('') + '</tr>'
+      t += '</tbody></table>'
+      out.push(t)
+      continue
+    }
+    if (/^\s*[-*]\s+/.test(line)) {
+      const items = []
+      while (i < lines.length && /^\s*[-*]\s+/.test(lines[i])) { items.push(lines[i].replace(/^\s*[-*]\s+/, '')); i++ }
+      out.push('<ul>' + items.map(it => '<li>' + mdInline(it) + '</li>').join('') + '</ul>')
+      continue
+    }
+    if (/^\s*\d+\.\s+/.test(line)) {
+      const items = []
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) { items.push(lines[i].replace(/^\s*\d+\.\s+/, '')); i++ }
+      out.push('<ol>' + items.map(it => '<li>' + mdInline(it) + '</li>').join('') + '</ol>')
+      continue
+    }
+    if (/^\s*>\s?/.test(line)) {
+      const q = []
+      while (i < lines.length && /^\s*>\s?/.test(lines[i])) { q.push(lines[i].replace(/^\s*>\s?/, '')); i++ }
+      out.push('<blockquote>' + q.map(mdInline).join('<br>') + '</blockquote>')
+      continue
+    }
+    if (/^\s*$/.test(line)) { i++; continue }
+    const para = []
+    while (i < lines.length && !isBlockStart(lines[i])) { para.push(lines[i]); i++ }
+    if (para.length) out.push('<p>' + para.map(mdInline).join('<br>') + '</p>')
+  }
+  return out.join('\n')
+}
+
+async function loadDocs() {
+  const listEl = document.getElementById('docsList')
+  const contentEl = document.getElementById('docsContent')
+  if (!listEl) return
+  listEl.innerHTML = '<p class="muted">Betöltés...</p>'
+  let docs = []
+  try {
+    const res = await fetch('/api/docs')
+    docs = await res.json()
+    if (!Array.isArray(docs)) docs = []
+  } catch (e) {
+    listEl.innerHTML = '<p class="muted">Nem sikerült betölteni a listát: ' + escapeHtml(String(e.message || e)) + '</p>'
+    return
+  }
+  if (!docs.length) {
+    listEl.innerHTML = '<p class="muted">Nincs dokumentum a docs/ mappában.</p>'
+    if (contentEl) contentEl.innerHTML = '<p class="muted">Nincs megjeleníthető dokumentum.</p>'
+    return
+  }
+  listEl.innerHTML = docs.map(d =>
+    '<a href="#" class="docs-list-item" data-doc="' + escapeAttr(d.name) + '">' +
+      '<span class="docs-list-title">' + escapeHtml(d.title || d.name) + '</span>' +
+      (d.created ? '<span class="docs-list-date">' + escapeHtml(d.created) + '</span>' : '') +
+    '</a>'
+  ).join('')
+  listEl.querySelectorAll('.docs-list-item').forEach(a => {
+    a.addEventListener('click', (e) => {
+      e.preventDefault()
+      listEl.querySelectorAll('.docs-list-item').forEach(x => x.classList.remove('active'))
+      a.classList.add('active')
+      openDoc(a.dataset.doc)
+    })
+  })
+  const first = listEl.querySelector('.docs-list-item')
+  if (first) { first.classList.add('active'); openDoc(first.dataset.doc) }
+}
+
+async function openDoc(name) {
+  const contentEl = document.getElementById('docsContent')
+  if (!contentEl) return
+  contentEl.innerHTML = '<p class="muted">Betöltés...</p>'
+  try {
+    const res = await fetch('/api/docs/' + encodeURIComponent(name))
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const doc = await res.json()
+    contentEl.innerHTML = renderMarkdown(doc.content || '')
+  } catch (e) {
+    contentEl.innerHTML = '<p class="muted">Nem sikerült megnyitni: ' + escapeHtml(String(e.message || e)) + '</p>'
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -80,6 +80,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/><polyline points="7 10 12 5 17 10"/><line x1="12" y1="5" x2="12" y2="17"/></svg>
         <span class="sb-label">Költöztetés</span>
       </a>
+      <a href="#" class="sb-link" data-page="docs">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+        <span class="sb-label">Dokumentáció</span>
+      </a>
       <a href="#" class="sb-link" data-page="status">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
         <span class="sb-label">Státusz</span>
@@ -715,6 +719,22 @@
           <div class="migrate-result" id="migrateResult"></div>
           <button class="btn-secondary btn-compact" id="migrateNewBtn" style="margin-top:16px">Új költöztetés</button>
         </div>
+      </div>
+    </div>
+
+    <!-- === Docs Page === -->
+    <div class="page" id="docsPage" hidden>
+      <div class="page-header">
+        <h1>Dokumentáció</h1>
+        <p class="subtitle">A projekt docs/ mappája, olvasható formában</p>
+      </div>
+      <div class="docs-layout">
+        <aside class="docs-list" id="docsList">
+          <p class="muted">Betöltés...</p>
+        </aside>
+        <article class="docs-content markdown-body" id="docsContent">
+          <p class="muted">Válassz egy dokumentumot a bal oldali listából.</p>
+        </article>
       </div>
     </div>
 

--- a/web/style.css
+++ b/web/style.css
@@ -5308,3 +5308,90 @@ main {
 .terminal-modal .modal-header { flex-shrink: 0; }
 #terminalContainer { flex: 1; min-height: 360px; }
 .xterm { height: 100% !important; }
+
+/* === Docs viewer === */
+.docs-layout {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+.docs-list {
+  flex: 0 0 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  position: sticky;
+  top: 16px;
+}
+.docs-list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  color: var(--text, #222);
+  text-decoration: none;
+  font-size: 14px;
+  border: 1px solid transparent;
+}
+.docs-list-title { line-height: 1.3; }
+.docs-list-date {
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  font-variant-numeric: tabular-nums;
+}
+.docs-list-item:hover { background: var(--surface-2, rgba(127,127,127,0.08)); }
+.docs-list-item.active {
+  background: var(--surface-2, rgba(127,127,127,0.12));
+  border-color: var(--border, rgba(127,127,127,0.25));
+  font-weight: 600;
+}
+.docs-content {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 8px 4px 40px;
+  line-height: 1.65;
+}
+.markdown-body h1 { font-size: 1.7em; margin: 0.2em 0 0.6em; }
+.markdown-body h2 { font-size: 1.35em; margin: 1.4em 0 0.5em; border-bottom: 1px solid var(--border, rgba(127,127,127,0.2)); padding-bottom: 0.2em; }
+.markdown-body h3 { font-size: 1.12em; margin: 1.2em 0 0.4em; }
+.markdown-body p { margin: 0.6em 0; }
+.markdown-body ul, .markdown-body ol { margin: 0.5em 0; padding-left: 1.6em; }
+.markdown-body li { margin: 0.25em 0; }
+.markdown-body code {
+  background: var(--surface-2, rgba(127,127,127,0.12));
+  padding: 0.12em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.markdown-body pre {
+  background: var(--surface-2, rgba(127,127,127,0.12));
+  padding: 12px 14px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+.markdown-body pre code { background: none; padding: 0; }
+.markdown-body table {
+  border-collapse: collapse;
+  margin: 0.8em 0;
+  width: 100%;
+}
+.markdown-body th, .markdown-body td {
+  border: 1px solid var(--border, rgba(127,127,127,0.3));
+  padding: 7px 11px;
+  text-align: left;
+}
+.markdown-body th { background: var(--surface-2, rgba(127,127,127,0.1)); }
+.markdown-body blockquote {
+  margin: 0.8em 0;
+  padding: 0.4em 1em;
+  border-left: 3px solid var(--border, rgba(127,127,127,0.4));
+  color: var(--text-muted, #666);
+}
+.markdown-body hr { border: none; border-top: 1px solid var(--border, rgba(127,127,127,0.25)); margin: 1.4em 0; }
+.markdown-body a { color: var(--accent, #3b82f6); }
+@media (max-width: 760px) {
+  .docs-layout { flex-direction: column; }
+  .docs-list { flex-basis: auto; width: 100%; position: static; }
+}


### PR DESCRIPTION
Adds a 'Dokumentáció' page to the dashboard that lists and renders the markdown files under docs/. New read-only API endpoints (GET /api/docs, GET /api/docs/:name) sit behind the existing bearer-token gate; the :name route is allowlisted to a bare *.md filename and basename-checked to block path traversal. Frontend renders markdown with a small dependency-free renderer (no external CDN). Also ships the new-assistant onboarding doc.