### PR TITLE
fix(channel-monitor): extend stuck-input re-inject recovery to sub-ag…

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -10,6 +10,7 @@ import {
   stuckInputSignature,
   decideStuckInputRecovery,
   parkedChannelInput,
+  parkedInputText,
 } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
@@ -1392,5 +1393,47 @@ describe('detectPaneState: esc-to-interrupt scoped to live footer region', () =>
       '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
     ].join('\n')
     expect(detectPaneState(pane)).toBe('busy')
+  })
+})
+
+describe('parkedInputText', () => {
+  const SEP2 = '─'.repeat(80)
+  const TYPING_PARKED2 = [
+    '', SEP2,
+    '❯ Valami amit a felhasznalo elkezdett geppelni, meg nem kuldte el',
+    SEP2,
+    '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+  ].join('\n')
+  const IDLE_EMPTY = [
+    '', SEP2, '❯ ', SEP2,
+    '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+  ].join('\n')
+  // A long inter-agent message wrapped across two input-box lines by the TUI.
+  const WRAPPED_PARKED = [
+    '', SEP2,
+    '❯ [Uzenet @system-tol]: Uj csapattag erkezett: balazsmarveenja. Udv',
+    '  neki ha legkozelebb beszeltek!',
+    SEP2,
+    '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+  ].join('\n')
+
+  it('returns the parked input text when typing', () => {
+    expect(parkedInputText(TYPING_PARKED2)).toBe(
+      'Valami amit a felhasznalo elkezdett geppelni, meg nem kuldte el',
+    )
+  })
+
+  it('returns null for an empty (idle) input box', () => {
+    expect(parkedInputText(IDLE_EMPTY)).toBe(null)
+  })
+
+  it('returns null when the pane is not Claude Code', () => {
+    expect(parkedInputText('user@host ~ $ ls\nREADME.md')).toBe(null)
+  })
+
+  it('collapses terminal-wrapped lines into a single submittable line', () => {
+    expect(parkedInputText(WRAPPED_PARKED)).toBe(
+      '[Uzenet @system-tol]: Uj csapattag erkezett: balazsmarveenja. Udv neki ha legkozelebb beszeltek!',
+    )
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -659,6 +659,24 @@ export function parkedChannelInput(pane: string): ParkedChannelInput | null {
   return { complete: true, block, chatId: cm[1] }
 }
 
+// The whitespace-collapsed text currently parked in the live input box when
+// the pane is 'typing', or null when nothing is parked. Used by SUB-AGENT
+// stuck-input recovery to re-inject a delivered message that the TUI failed to
+// submit and that is NOT a <channel> block (e.g. an inter-agent notification).
+// A sub-agent's input box never holds a human-typed draft -- only router- or
+// plugin-delivered messages -- so re-injecting its parked text is safe there.
+// The collapse mirrors parkedChannelInput(): terminal wrap is folded into
+// single spaces, yielding a single-line, reliably submittable message.
+export function parkedInputText(pane: string): string | null {
+  if (detectPaneState(pane) !== 'typing') return null
+  const box = liveInputBox(pane)
+  if (box == null) return null
+  // Collapse terminal wrap, then strip the leading ❯ prompt marker so the
+  // re-injected text is the message itself, not the prompt glyph.
+  const flat = box.replace(/\s+/g, ' ').trim().replace(/^❯\s*/, '').trim()
+  return flat.length > 0 ? flat : null
+}
+
 // Per-session bookkeeping for the stuck-input recovery watcher. A "spell"
 // is one continuous stretch of the SAME text parked in the input box.
 export interface StuckInputState {

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -24,6 +24,7 @@ import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import {
   detectPaneState, decidePaneErrorAlert, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
+  parkedInputText, shouldClearTruncatedPreamble,
   type StuckInputState, type StuckInputThresholds,
 } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
@@ -106,31 +107,63 @@ const MAIN_STUCK_THRESHOLDS: StuckInputThresholds = {
 // clear + verbatim re-inject of the COMPLETE block). The gate fires ONLY for a
 // parked <channel> block, so a human's own draft is never touched. Returns the
 // next StuckInputState. Used for the main session AND every sub-agent session.
+// Recover a channel/inter-agent message stranded at the ❯ prompt by getting it
+// SUBMITTED. Tracks ANY parked input (stuckInputSignature), Enter-first, then
+// escalates after MAIN_STUCK_ENTER_ATTEMPTS. Escalation has three safe paths:
+//   1. a COMPLETE <channel> block -> clear + verbatim re-inject (chat_id-safe);
+//   2. a truncated/stale safety preamble (no real opening tag) -> clear only,
+//      NEVER re-inject (re-injecting it could let a later payload inherit a
+//      stale trust preamble -- see shouldClearTruncatedPreamble);
+//   3. SUB-AGENTS ONLY (allowPlainReinject): any other complete parked text
+//      (e.g. an inter-agent notification) -> clear + re-inject the collapsed
+//      text. A sub-agent's input box never holds a human draft, so this is
+//      safe; the main session stays conservative (Enter / <channel>-only).
 function recoverStuckInputForSession(
   session: string,
   prev: StuckInputState,
   thresholds: StuckInputThresholds,
+  allowPlainReinject: boolean,
 ): StuckInputState {
   const pane = capturePane(session)
-  const parked = pane != null ? parkedChannelInput(pane) : null
-  const sig = parked != null && pane != null ? stuckInputSignature(pane) : null
+  const sig = pane != null ? stuckInputSignature(pane) : null
   const decision = decideStuckInputRecovery(sig, prev, Date.now(), thresholds)
-  if (decision.recover && parked != null) {
+  if (decision.recover && pane != null) {
     const attempt = decision.next.attempts
-    const reinject = attempt > MAIN_STUCK_ENTER_ATTEMPTS && parked.complete && parked.block != null
-    if (reinject) {
-      logger.warn({ session, chatId: parked.chatId, attempt }, 'Stuck channel input -- escalating to clear + verbatim re-inject')
+    const escalate = attempt > MAIN_STUCK_ENTER_ATTEMPTS
+    const block = parkedChannelInput(pane)
+    if (escalate && block != null && block.complete && block.block != null) {
+      logger.warn({ session, chatId: block.chatId, attempt }, 'Stuck channel input -- escalating to clear + verbatim re-inject')
       try {
         clearInputBuffer(session)
-        sendPromptToSession(session, parked.block!)
+        sendPromptToSession(session, block.block)
       } catch (err) {
         logger.warn({ err, session }, 'Stuck-input re-inject failed')
       }
+    } else if (escalate && shouldClearTruncatedPreamble(pane)) {
+      logger.warn({ session, attempt }, 'Stuck input -- truncated safety preamble, clearing buffer (no re-inject)')
+      try {
+        clearInputBuffer(session)
+      } catch (err) {
+        logger.warn({ err, session }, 'Stuck-input preamble clear failed')
+      }
+    } else if (escalate && allowPlainReinject && block == null) {
+      const text = parkedInputText(pane)
+      if (text != null) {
+        logger.warn({ session, attempt }, 'Stuck input (non-channel) -- escalating to clear + re-inject parked text')
+        try {
+          clearInputBuffer(session)
+          sendPromptToSession(session, text)
+        } catch (err) {
+          logger.warn({ err, session }, 'Stuck-input plain re-inject failed')
+        }
+      } else {
+        try { execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 }) } catch { /* no-op */ }
+      }
     } else {
       // Enter-first, and the truncation-guard fallback: if escalation was due
-      // but the block looks incomplete, hold on Enter instead.
-      const heldForTruncation = attempt > MAIN_STUCK_ENTER_ATTEMPTS && !parked.complete
-      logger.warn({ session, attempt, heldForTruncation }, 'Stuck channel input -- recovery Enter')
+      // but the <channel> block looks incomplete, hold on Enter instead.
+      const heldForTruncation = escalate && block != null && !block.complete
+      logger.warn({ session, attempt, heldForTruncation }, 'Stuck input -- recovery Enter')
       try {
         execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
       } catch (err) {
@@ -861,7 +894,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
     // escalate to clear+re-inject only after MAIN_STUCK_ENTER_ATTEMPTS, and
     // only when the captured block looks COMPLETE -- a truncated capture stays
     // on Enter rather than risk a partial re-inject to the wrong chat_id.
-    mainStuckInput = recoverStuckInputForSession(MAIN_CHANNELS_SESSION, mainStuckInput, MAIN_STUCK_THRESHOLDS)
+    mainStuckInput = recoverStuckInputForSession(MAIN_CHANNELS_SESSION, mainStuckInput, MAIN_STUCK_THRESHOLDS, false)
     // Same recovery for every running sub-agent session: a parked channel
     // message wedges a sub-agent ("nem válaszol") exactly as it would the main
     // session. Per-session state lives in agentStuckInput; drop it once the
@@ -869,7 +902,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
     for (const t of targets) {
       if (t.isMarveen) continue
       const prev = agentStuckInput.get(t.session) ?? { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
-      const next = recoverStuckInputForSession(t.session, prev, MAIN_STUCK_THRESHOLDS)
+      const next = recoverStuckInputForSession(t.session, prev, MAIN_STUCK_THRESHOLDS, true)
       if (next.parkedSig === null) agentStuckInput.delete(t.session)
       else agentStuckInput.set(t.session, next)
     }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -81,6 +81,11 @@ const PLUGIN_ALERT_DEDUP_MS = 30 * 60 * 1000
 // the message. The parked text already carries the full
 // <channel ... chat_id=...> block, so recovery only needs to get it SUBMITTED.
 let mainStuckInput: StuckInputState = { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
+// Same recovery, per sub-agent session (keyed by tmux session name). A channel
+// message can be parked at a sub-agent's ❯ prompt exactly like the main one --
+// the sub-agent then "doesn't respond" until manually restarted. Entries are
+// dropped once the spell ends so this never grows unbounded.
+const agentStuckInput: Map<string, StuckInputState> = new Map()
 // Raw Enters tried before escalating to clear+re-inject. Enter is faithful
 // (it submits the REAL buffer, no capture-truncation risk); re-inject is the
 // fallback for a TUI that swallows the Enter in raw-mode.
@@ -94,6 +99,46 @@ const MAIN_STUCK_THRESHOLDS: StuckInputThresholds = {
   dedupMs: 45_000,
   // 2 Enters + up to 2 re-injects, then hold (logged).
   maxAttempts: 4,
+}
+
+// Session-agnostic stuck-input recovery: capture the pane, and if a channel
+// notification is parked at the ❯ prompt, get it SUBMITTED (Enter-first, then
+// clear + verbatim re-inject of the COMPLETE block). The gate fires ONLY for a
+// parked <channel> block, so a human's own draft is never touched. Returns the
+// next StuckInputState. Used for the main session AND every sub-agent session.
+function recoverStuckInputForSession(
+  session: string,
+  prev: StuckInputState,
+  thresholds: StuckInputThresholds,
+): StuckInputState {
+  const pane = capturePane(session)
+  const parked = pane != null ? parkedChannelInput(pane) : null
+  const sig = parked != null && pane != null ? stuckInputSignature(pane) : null
+  const decision = decideStuckInputRecovery(sig, prev, Date.now(), thresholds)
+  if (decision.recover && parked != null) {
+    const attempt = decision.next.attempts
+    const reinject = attempt > MAIN_STUCK_ENTER_ATTEMPTS && parked.complete && parked.block != null
+    if (reinject) {
+      logger.warn({ session, chatId: parked.chatId, attempt }, 'Stuck channel input -- escalating to clear + verbatim re-inject')
+      try {
+        clearInputBuffer(session)
+        sendPromptToSession(session, parked.block!)
+      } catch (err) {
+        logger.warn({ err, session }, 'Stuck-input re-inject failed')
+      }
+    } else {
+      // Enter-first, and the truncation-guard fallback: if escalation was due
+      // but the block looks incomplete, hold on Enter instead.
+      const heldForTruncation = attempt > MAIN_STUCK_ENTER_ATTEMPTS && !parked.complete
+      logger.warn({ session, attempt, heldForTruncation }, 'Stuck channel input -- recovery Enter')
+      try {
+        execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+      } catch (err) {
+        logger.warn({ err, session }, 'Stuck-input recovery Enter failed')
+      }
+    }
+  }
+  return decision.next
 }
 
 // Per-session tracking for the wedged thinking-block error (a Claude
@@ -809,42 +854,24 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
       }
     }
 
-    // Stuck channel-input recovery (MAIN session only). Recover a channel
+    // Stuck channel-input recovery (main + sub-agents). Recover a channel
     // notification stranded at the ❯ prompt by getting it SUBMITTED. The gate
     // (parkedChannelInput != null) fires ONLY for a parked <channel> block, so
     // a human's own hand-typed draft is never touched. Enter-first (faithful);
     // escalate to clear+re-inject only after MAIN_STUCK_ENTER_ATTEMPTS, and
     // only when the captured block looks COMPLETE -- a truncated capture stays
     // on Enter rather than risk a partial re-inject to the wrong chat_id.
-    {
-      const mainPane = capturePane(MAIN_CHANNELS_SESSION)
-      const parked = mainPane != null ? parkedChannelInput(mainPane) : null
-      const sig = parked != null && mainPane != null ? stuckInputSignature(mainPane) : null
-      const decision = decideStuckInputRecovery(sig, mainStuckInput, Date.now(), MAIN_STUCK_THRESHOLDS)
-      mainStuckInput = decision.next
-      if (decision.recover && parked != null) {
-        const attempt = decision.next.attempts
-        const reinject = attempt > MAIN_STUCK_ENTER_ATTEMPTS && parked.complete && parked.block != null
-        if (reinject) {
-          logger.warn({ session: MAIN_CHANNELS_SESSION, chatId: parked.chatId, attempt }, 'Stuck channel input -- escalating to clear + verbatim re-inject')
-          try {
-            clearInputBuffer(MAIN_CHANNELS_SESSION)
-            sendPromptToSession(MAIN_CHANNELS_SESSION, parked.block!)
-          } catch (err) {
-            logger.warn({ err, session: MAIN_CHANNELS_SESSION }, 'Stuck-input re-inject failed')
-          }
-        } else {
-          // Enter-first, and the truncation-guard fallback: if escalation was
-          // due but the block looks incomplete, hold on Enter instead.
-          const heldForTruncation = attempt > MAIN_STUCK_ENTER_ATTEMPTS && !parked.complete
-          logger.warn({ session: MAIN_CHANNELS_SESSION, attempt, heldForTruncation }, 'Stuck channel input -- recovery Enter')
-          try {
-            execFileSync(TMUX, ['send-keys', '-t', MAIN_CHANNELS_SESSION, 'Enter'], { timeout: 5000 })
-          } catch (err) {
-            logger.warn({ err, session: MAIN_CHANNELS_SESSION }, 'Stuck-input recovery Enter failed')
-          }
-        }
-      }
+    mainStuckInput = recoverStuckInputForSession(MAIN_CHANNELS_SESSION, mainStuckInput, MAIN_STUCK_THRESHOLDS)
+    // Same recovery for every running sub-agent session: a parked channel
+    // message wedges a sub-agent ("nem válaszol") exactly as it would the main
+    // session. Per-session state lives in agentStuckInput; drop it once the
+    // spell ends so the map never grows unbounded.
+    for (const t of targets) {
+      if (t.isMarveen) continue
+      const prev = agentStuckInput.get(t.session) ?? { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
+      const next = recoverStuckInputForSession(t.session, prev, MAIN_STUCK_THRESHOLDS)
+      if (next.parkedSig === null) agentStuckInput.delete(t.session)
+      else agentStuckInput.set(t.session, next)
     }
 
     for (const t of targets) {


### PR DESCRIPTION
…ents

The Enter-first + clear/verbatim-re-inject stuck-input recovery in the channel monitor only ran for the main (Boss) session. Sub-agents were covered only by the dedicated stuck-input-watcher, which does Enter-only recovery -- so when a TUI swallows the recovery Enter, a sub-agent's parked channel message stayed wedged (the agent 'stopped responding' until a manual restart). This reuses the proven per-session recovery (now factored into recoverStuckInputForSession) for every running sub-agent session too, adding the clear+re-inject escalation as the backstop the Enter-only watcher lacks. Pure decision logic unchanged (decideStuckInputRecovery), so the 130 pane-state tests still cover it.