### PR TITLE
fix(updater): make self-update branch-agnostic instead of hardcoding …

### DIFF
--- a/src/__tests__/update-preflight.test.ts
+++ b/src/__tests__/update-preflight.test.ts
@@ -55,34 +55,31 @@ describe('checkUpdatePreflight --detached HEAD', () => {
   })
 })
 
-describe('checkUpdatePreflight --feature branch', () => {
-  it('rejects any branch name other than main', () => {
-    const result = checkUpdatePreflight(makeGit('v3-05-ui-trustfrom-picker'))
-    expect(result.ok).toBe(false)
-    if (result.ok || result.reason !== 'not-on-main') {
-      throw new Error('expected not-on-main result')
-    }
-    expect(result.branch).toBe('v3-05-ui-trustfrom-picker')
-    expect(result.message).toContain("'v3-05-ui-trustfrom-picker'")
-    expect(result.message).toMatch(/git checkout main/)
+describe('checkUpdatePreflight --branch agnostic', () => {
+  it('accepts a non-main release branch on a clean tree', () => {
+    // The update is branch-agnostic: update.sh pulls origin/<this-branch>.
+    // An install that tracks "develop" must be allowed to self-update.
+    const result = checkUpdatePreflight(makeGit('develop', ''))
+    expect(result.ok).toBe(true)
   })
 
-  it('rejects "master" (a common misconfiguration)', () => {
-    const result = checkUpdatePreflight(makeGit('master'))
-    expect(result.ok).toBe(false)
-    if (result.ok) return
-    expect(result.reason).toBe('not-on-main')
+  it('accepts an arbitrary feature branch on a clean tree', () => {
+    const result = checkUpdatePreflight(makeGit('v3-05-ui-trustfrom-picker', ''))
+    expect(result.ok).toBe(true)
   })
 
-  it('prioritises not-on-main over dirty-tree when both apply', () => {
-    // Switching to main first invalidates the dirty-tree check anyway
-    // (the modifications may or may not carry across branches), so the
-    // useful error message for the user is "switch branches", not
-    // "commit your changes on this branch".
-    const result = checkUpdatePreflight(makeGit('feature-x', ' M src/web.ts\n'))
+  it('accepts "master" on a clean tree', () => {
+    const result = checkUpdatePreflight(makeGit('master', ''))
+    expect(result.ok).toBe(true)
+  })
+
+  it('still blocks a dirty tree regardless of branch name', () => {
+    // The branch is fine, but uncommitted changes would break the
+    // fast-forward pull, so dirty-tree is the reported reason.
+    const result = checkUpdatePreflight(makeGit('develop', ' M src/web.ts\n'))
     expect(result.ok).toBe(false)
     if (result.ok) return
-    expect(result.reason).toBe('not-on-main')
+    expect(result.reason).toBe('dirty-tree')
   })
 })
 
@@ -121,13 +118,12 @@ describe('checkUpdatePreflight --dirty working tree', () => {
 })
 
 describe('checkUpdatePreflight -- result shape', () => {
-  it('never emits a branch field on the ok path', () => {
-    const result = checkUpdatePreflight(makeGit('main'))
-    // TypeScript alone does not enforce this at runtime, so assert it.
-    expect(Object.hasOwn(result, 'branch')).toBe(false)
-  })
+  it('never emits a branch field on any path', () => {
+    // No result carries a branch field anymore; the update is
+    // branch-agnostic, so the branch name is never part of a rejection.
+    const ok = checkUpdatePreflight(makeGit('main'))
+    expect(Object.hasOwn(ok, 'branch')).toBe(false)
 
-  it('only emits a branch field on the not-on-main path', () => {
     const detached = checkUpdatePreflight(makeGit(''))
     expect(Object.hasOwn(detached, 'branch')).toBe(false)
 
@@ -135,7 +131,7 @@ describe('checkUpdatePreflight -- result shape', () => {
     expect(Object.hasOwn(dirty, 'branch')).toBe(false)
 
     const feature = checkUpdatePreflight(makeGit('feature-x'))
-    expect(Object.hasOwn(feature, 'branch')).toBe(true)
+    expect(Object.hasOwn(feature, 'branch')).toBe(false)
   })
 })
 

--- a/src/update-preflight.ts
+++ b/src/update-preflight.ts
@@ -7,10 +7,16 @@
 //   4. after 30s the page reloads and shows the same pending commits
 //
 // The silent failure mode is update.sh hitting `git pull --ff-only origin
-// main` while the local checkout is on a feature branch (or has local
-// modifications that would make a fast-forward impossible). set -e in
+// <branch>` while the local checkout is detached, or has local
+// modifications that would make a fast-forward impossible. set -e in
 // update.sh makes it exit before the stop.sh / start.sh step, but the
 // frontend has no way to know because it only watched spawn() success.
+//
+// The update is branch-agnostic: update.sh derives the branch from the
+// current checkout and pulls origin/<that-branch>, so an install that
+// tracks any release branch (main, develop, …) self-updates. The only
+// branch state this preflight rejects is a detached HEAD, which has no
+// branch to pull.
 //
 // Running the preflight checks server-side means the apply endpoint can
 // refuse with a 409 and a readable reason, the user sees an actionable
@@ -33,7 +39,6 @@ export interface GitRunner {
 
 export type PreflightResult =
   | { ok: true }
-  | { ok: false; reason: 'not-on-main'; branch: string; message: string }
   | { ok: false; reason: 'dirty-tree'; message: string }
   | { ok: false; reason: 'detached-head'; message: string }
 
@@ -115,32 +120,20 @@ export function checkNoConcurrentUpdate(pf: PidfileRunner): ConcurrencyResult {
   }
 }
 
-const EXPECTED_BRANCH = 'main'
-
 export function checkUpdatePreflight(git: GitRunner): PreflightResult {
   const branch = git.currentBranch().trim()
 
   // `git rev-parse --abbrev-ref HEAD` prints "HEAD" on a detached
-  // checkout. Treat that separately so the error message can explain
-  // it instead of claiming the branch is called "HEAD".
+  // checkout. A detached HEAD has no branch to pull from, so it is the
+  // one branch state the update cannot proceed from. Any named branch
+  // is fine: update.sh pulls origin/<that-branch>.
   if (!branch || branch === 'HEAD') {
     return {
       ok: false,
       reason: 'detached-head',
       message:
-        'Repository is in a detached-HEAD state. Check out main before updating: git checkout main',
-    }
-  }
-
-  if (branch !== EXPECTED_BRANCH) {
-    return {
-      ok: false,
-      reason: 'not-on-main',
-      branch,
-      message:
-        `Cannot update from branch '${branch}'. ` +
-        `'git pull --ff-only origin main' cannot fast-forward a feature branch. ` +
-        `Switch to main first: git checkout main`,
+        'Repository is in a detached-HEAD state. ' +
+        'Check out a release branch before updating, e.g.: git checkout main',
     }
   }
 

--- a/src/web/routes/updates.ts
+++ b/src/web/routes/updates.ts
@@ -143,8 +143,8 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
     }
     if (!preflight.ok) {
       // dirty-tree + autoStash=true: skip the dashboard-side block and let
-      // update.sh handle the stash+pop. Other failure reasons (detached HEAD,
-      // not-on-main, …) still hard-block since stash cannot rescue them.
+      // update.sh handle the stash+pop. The other failure reason (detached
+      // HEAD) still hard-blocks since stash cannot rescue it.
       const skipForAutoStash = preflight.reason === 'dirty-tree' && autoStash
       if (!skipForAutoStash) {
         releaseLock()
@@ -152,7 +152,6 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
           error: preflight.message,
           reason: preflight.reason,
         }
-        if (preflight.reason === 'not-on-main') body.branch = preflight.branch
         json(res, body, 409)
         return true
       }

--- a/update.sh
+++ b/update.sh
@@ -86,26 +86,30 @@ echo ""
 echo -e "${BOLD}Marveen frissites...${NC} [$(date -u +%Y-%m-%dT%H:%M:%SZ)]"
 echo ""
 
-# Guard 1: refuse to run from a non-main branch.
-# 'git pull --ff-only origin main' below would exit non-zero on any
-# branch whose tip is not an ancestor of origin/main -- for example
-# every feature branch whose PR was squash-merged upstream. Because
-# the dashboard launches this script detached with stdio: 'ignore',
-# that exit is invisible to the operator: the UI silently reloads on
-# the same pending-commit list. Same guard also exists server-side
-# in /api/updates/apply as a 409 pre-check; this is defense-in-depth
-# for manual invocations.
+# Guard 1: derive the release branch from the current checkout and refuse
+# only a detached HEAD. The pull below targets origin/<CURRENT_BRANCH>, so
+# an install tracking any release branch (main, develop, ...) self-updates
+# instead of being hardcoded to main. A detached HEAD is the one state with
+# no branch to pull, so it is still rejected. Because the dashboard launches
+# this script detached with stdio: 'ignore', a silent non-zero exit would be
+# invisible to the operator (the UI just reloads on the same pending-commit
+# list), so the guards exit with a readable message. The same detached-HEAD
+# pre-check also exists server-side in /api/updates/apply as a 409;
+# this is defense-in-depth for manual invocations.
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 if [ "$CURRENT_BRANCH" = "HEAD" ] || [ -z "$CURRENT_BRANCH" ]; then
   echo -e "${RED}HIBA:${NC} A repo detached-HEAD allapotban van."
-  echo "       Allj at a main branchre, majd indithatod ujra a frissitest:"
+  echo "       Allj at egy release branchre, majd indithatod ujra a frissitest, pl.:"
   echo "         git checkout main"
   exit 2
 fi
-if [ "$CURRENT_BRANCH" != "main" ]; then
-  echo -e "${RED}HIBA:${NC} A jelenlegi branch '${CURRENT_BRANCH}', nem 'main'."
-  echo "       A 'git pull --ff-only origin main' csak a main branchrol fut tisztan."
-  echo "       Allj at elobb a main branchre:"
+# The branch must exist on origin, otherwise 'git pull' below cannot find a
+# ref to fast-forward to (e.g. a local-only feature branch). Fail early with
+# a clear message instead of letting set -e abort mid-run.
+if ! git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" >/dev/null 2>&1; then
+  echo -e "${RED}HIBA:${NC} A '${CURRENT_BRANCH}' branch nem letezik az origin-on."
+  echo "       Csak az origin-on is meglevo (kovetett) branchrol lehet frissiteni."
+  echo "       Allj at egy release branchre, pl.:"
   echo "         git checkout main"
   exit 2
 fi
@@ -146,9 +150,9 @@ fi
 # Save current version
 OLD_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
-# Pull latest
-echo -e "  Letoltes..."
-git pull --ff-only origin main
+# Pull latest from the current branch's origin counterpart.
+echo -e "  Letoltes (origin/${CURRENT_BRANCH})..."
+git pull --ff-only origin "$CURRENT_BRANCH"
 NEW_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then


### PR DESCRIPTION
## Purpose

The in-dashboard "Update now" flow and `update.sh` hardcoded the release branch as `main`. `update.sh` ran `git pull --ff-only origin main`, and the server-side preflight (`update-preflight.ts`) refused any non-`main` checkout with a `not-on-main` 409. An install that intentionally tracks a different release branch (e.g. `develop`, the repo default) could therefore never self-update: the preflight returned `not-on-main` and the script exited 2 before the stop/start step. Because the dashboard spawns `update.sh` detached with stdio ignored, that failure was silent.

## Change

Derive the branch from the current checkout instead of hardcoding it:

- `update.sh` pulls `origin/<CURRENT_BRANCH>` and adds an early `git ls-remote` guard, so a local-only branch fails with a readable message rather than aborting mid-run under `set -e`.
- `update-preflight.ts` drops `EXPECTED_BRANCH` and the `not-on-main` result. Only a detached HEAD (no branch to pull) and a dirty working tree still block.
- `updates.ts` drops the now-dead `not-on-main` branch field.
- Tests updated: `develop`/feature/`master` branches now pass preflight; detached-HEAD and dirty-tree guards unchanged.

## Testing

Full suite green: 74 files, 1141 tests. `tsc --noEmit` clean, `bash -n update.sh` clean.

## AI assistance disclosure

This change was authored with AI assistance: written by the project's own Jarvis agent running Claude Opus 4.8 (1M context), and reviewed by the maintainer (@cett) before submission.