### PR TITLE
feat(dashboard): Napló (recall) page -- main-agent filter option, default newest-first order, sort toggle

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -8138,6 +8138,7 @@ document.getElementById('chSlackManifestBtn').addEventListener('click', async ()
 // ============================================================
 
 let recallInitialized = false
+let recallSortDesc = true
 
 async function loadRecallPage() {
   if (!recallInitialized) {
@@ -8146,14 +8147,15 @@ async function loadRecallPage() {
     document.getElementById('recallDate').value = today
 
     try {
-      const res = await fetch('/api/agents')
+      // /api/schedules/agents includes the main agent (jarvis); /api/agents lists sub-agents only
+      const res = await fetch('/api/schedules/agents')
       if (res.ok) {
         const agents = await res.json()
         const sel = document.getElementById('recallAgent')
         agents.forEach(a => {
           const opt = document.createElement('option')
           opt.value = a.name
-          opt.textContent = a.name
+          opt.textContent = a.label || a.name
           sel.appendChild(opt)
         })
       }
@@ -8165,6 +8167,14 @@ async function loadRecallPage() {
     // Re-fetch per-agent log dates when the agent filter changes; without this
     // the date hint stayed stuck on the agent active at first page load.
     document.getElementById('recallAgent').addEventListener('change', loadRecallDates)
+    // #53: sort order toggle
+    document.getElementById('recallSortToggle').addEventListener('click', () => {
+      recallSortDesc = !recallSortDesc
+      const btn = document.getElementById('recallSortToggle')
+      btn.textContent = recallSortDesc ? '↓' : '↑'
+      btn.title = recallSortDesc ? 'Csökkenő sorrend (legújabb elöl)' : 'Növekvő sorrend (legrégebbi elöl)'
+      doRecall()
+    })
 
     loadRecallDates()
   }
@@ -8245,7 +8255,8 @@ function renderRecallTimeline(el, data) {
   const items = []
   logs.forEach(l => items.push({ type: 'log', ts: l.created_at, agent: l.agent_id, date: l.date, content: l.content, label: l.created_label }))
   memories.forEach(m => items.push({ type: 'memory', ts: m.created_at, agent: m.agent_id, category: m.category, content: m.content, keywords: m.keywords, label: m.created_label }))
-  items.sort((a, b) => a.ts - b.ts)
+  // #52/#53: apply sort order (desc = newest first, default)
+  items.sort((a, b) => recallSortDesc ? b.ts - a.ts : a.ts - b.ts)
 
   let currentDate = ''
   let html = ''

--- a/web/index.html
+++ b/web/index.html
@@ -460,6 +460,7 @@
         <select id="recallAgent" class="recall-agent-filter">
           <option value="">Minden ágens</option>
         </select>
+        <button class="btn-icon" id="recallSortToggle" title="Csökkeno sorrend (legujabb elol)">&#8595;</button>
         <button class="btn-primary btn-compact" id="recallBtn">Keresés</button>
       </div>
       <div class="recall-summary" id="recallSummary"></div>


### PR DESCRIPTION
## Megvalósított funkció

Három UX-javítás a dashboard Napló (recall) oldalán:
1. A fő agent külön opcióként választható az agent-szűrőben (eddig csak "Minden ágens" + a sub-agentek voltak, a fő agent hiányzott).
2. A timeline bejegyzések alapból csökkenő sorrendben (legújabb elöl).
3. Sorrend-váltó gomb a legújabb-elöl és legrégebbi-elöl között.

## A megvalósítás módja

- web/app.js loadRecallPage(): a recallAgent dropdown mostantól a /api/schedules/agents végpontból töltődik (ez tartalmazza a fő agentet) a /api/agents (csak sub-agentek) helyett, és a.label || a.name jelenik meg.
- web/app.js renderRecallTimeline(): az items.sort() egy új recallSortDesc flag szerint rendez (alap: true => b.ts - a.ts, legújabb elöl).
- web/index.html + app.js: egy recallSortToggle gomb a recall toolbar-ban (az agent-szűrő és a Keresés gomb között) átváltja a recallSortDesc-et, frissíti a ↓/↑ ikont, és újrafuttatja a doRecall()-t.

## AI-közreműködés

Ezt a kódváltoztatást AI generálta (a projekt Zack ágense, a Jarvis ágens koordinálásával, Claude Opus 4.8 / 1M context). A beküldés előtt emberi felülvizsgálat és kifejezett jóváhagyás történt (a karbantartó részéről).

Co-Authored-By: Claude Opus 4.8 (1M context)