### PR TITLE
feat(dashboard): kanban auto-refresh via Visibility API + 30s polling

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -82,8 +82,10 @@ function switchPage(pageId) {
   // Activity page runs a live poll; stop it whenever we navigate away.
   if (pageId !== 'activity') stopActivityPoll()
   if (pageId === 'activity') startActivityPoll()
+  // Kanban auto-refresh: start on enter, stop on leave.
+  if (pageId !== 'kanban') stopKanbanRefresh()
   if (pageId === 'overview') loadOverview()
-  if (pageId === 'kanban') loadKanban()
+  if (pageId === 'kanban') { loadKanban(); startKanbanRefresh() }
   if (pageId === 'tasks') loadSchedules()
   if (pageId === 'agents') loadAgents()
   if (pageId === 'memories') { loadMemAgents(); loadMemStats(); loadMemories() }
@@ -143,6 +145,30 @@ const ACTIVITY_STATE_META = {
   error: { label: 'hiba', cls: 'act-error', tip: 'Élő állapot: hiba látszik az ágens session paneljén.' },
   stopped: { label: 'leállt', cls: 'act-stopped', tip: 'Élő állapot: az ágens session nem fut.' },
 }
+
+// === Kanban auto-refresh ===
+let kanbanRefreshTimer = null
+
+function startKanbanRefresh() {
+  if (kanbanRefreshTimer) clearInterval(kanbanRefreshTimer)
+  kanbanRefreshTimer = setInterval(loadKanban, 30000)
+}
+
+function stopKanbanRefresh() {
+  if (kanbanRefreshTimer) {
+    clearInterval(kanbanRefreshTimer)
+    kanbanRefreshTimer = null
+  }
+}
+
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    stopKanbanRefresh()
+  } else if (!document.getElementById('kanbanPage').hidden) {
+    loadKanban()
+    startKanbanRefresh()
+  }
+})
 
 function startActivityPoll() {
   loadActivity()


### PR DESCRIPTION
A kanban tábla eddig csak manuális navigációkor (oldalra lépéskor) frissült; az ügynökök által végrehajtott kanban-változások csak akkor jelentek meg, ha a felhasználó elhagyta majd visszanavigált az oldalra.

## Megvalósítás

Nulla backend változás. Csak web/app.js:
- startKanbanRefresh() / stopKanbanRefresh(): setInterval(loadKanban, 30000) az activity-poll mintáját követve, dupla-timer guard clearInterval-lal
- switchPage(): kanban oldalra lépéskor startKanbanRefresh(), más oldalra lépéskor stopKanbanRefresh()
- document.visibilitychange listener: tab hidden -> stopKanbanRefresh(); tab visible + kanbanPage aktív -> azonnali loadKanban() + startKanbanRefresh()

A kódot AI generálta @cett felügyelete mellett.