### PR TITLE
feat(telegram): plugin-independent "working…" progress indicator + watchdog (closes #314)

### DIFF
--- a/docs/telegram-progress-indicator.md
+++ b/docs/telegram-progress-indicator.md
@@ -1,0 +1,84 @@
+# Telegram "working…" progress indicator
+
+A lightweight, plugin-independent "the agent is working…" indicator for the
+Telegram channel, plus a watchdog (sentry) that turns a stuck turn into a clear
+error. Built entirely with Claude Code hooks + a standalone watchdog, so it
+needs **no changes to the official telegram plugin** and survives plugin
+updates.
+
+## Why
+
+When you message a Telegram-bridged agent there is no reliable signal about what
+is happening: did the bot receive the message, is it thinking, or is it
+stuck/offline? The plugin fires a one-shot `sendChatAction('typing')`, but
+Telegram clears that after ~5s and the model usually thinks longer, so the
+indicator vanishes and the user is left guessing.
+
+A `typing…` action was rejected on purpose: it is dishonest (the model is
+thinking, not typing) and it expires. This gives honest, unambiguous status:
+
+1. Message received -> a visible `✍️ Dolgozom rajta…` placeholder appears.
+2. Answer sent -> the placeholder disappears and the real reply lands as a
+   fresh, notifying message.
+3. Turn never completes (agent crashed / wedged / unreachable) -> the
+   placeholder is rewritten into a clear error, so the user always gets
+   **either an answer or an explicit failure**.
+
+## How it works
+
+Four small stdlib-Python pieces. Token + state dir are resolved exactly like the
+plugin (honor `TELEGRAM_STATE_DIR`, else `~/.claude/channels/telegram`), so each
+piece stays correct per-agent even with different bots.
+
+| Piece | Trigger | Job |
+|-------|---------|-----|
+| `telegram_progress.py` | `UserPromptSubmit` hook | If the prompt contains a Telegram `<channel … chat_id … message_id>` block, post the placeholder and record its message id in a per-session state file. |
+| `telegram_progress_reply_clear.py` | `PostToolUse` hook (matcher `telegram.*reply`) | Delete the placeholder(s) for the replied chat the instant a reply is sent. **Primary clear path.** |
+| `telegram_progress_clear.py` | `Stop` hook | Delete any placeholder still recorded at turn end (fallback for turns that finish without replying). |
+| `telegram_progress_watchdog.py` | launchd / systemd, ~60s | Scan every agent's per-agent state dir; for an orphan (the agent's `agent-<name>` tmux session is gone + older than a short grace, OR older than a generous "wedged" threshold) rewrite the placeholder via `editMessageText` into the error text. The only layer that can speak when the agent itself is down. |
+
+### Why both PostToolUse and Stop
+
+Originally the placeholder was cleared **only** at `Stop`. That breaks on a long,
+multi-reply turn: if the agent emits several replies before the turn ends, the
+original `Dolgozom rajta…` lingers for the whole (possibly very long) turn even
+though the user already has an answer — it *looks* stuck. Clearing on the
+`reply` tool (PostToolUse) makes the placeholder vanish exactly when the answer
+appears; `Stop` is kept as a fallback and the watchdog as the crash backstop.
+
+### Hardening
+
+- **Dedup guard**: an atomic `O_EXCL` marker keyed by the inbound message id, so
+  even if the hook is registered at two scopes (global + project, which Claude
+  Code merges additively) it can never post a double placeholder.
+- **Fleet-wide**: the hooks live in the global `~/.claude/settings.json`, so
+  every existing and future agent gets it automatically; the watchdog scans all
+  agents under `$MARVEEN_ROOT` (default `~/marveen`).
+
+## Install
+
+```bash
+bash ~/ClaudeClaw/scripts/install-telegram-progress-hook.sh
+```
+
+It is idempotent and is auto-run by `scripts/sync-hooks.sh` on every update. It:
+
+1. Copies the four hook scripts to `~/.claude/hooks/`.
+2. Patches `~/.claude/settings.json` (UserPromptSubmit / PostToolUse / Stop).
+3. Installs the watchdog as a **launchd** agent (macOS) or **systemd** user
+   service+timer (Linux), running every ~60s.
+
+## Tuning
+
+- `telegram_progress_watchdog.py`: `DOWN_GRACE_SEC` (default 120s — agent down +
+  placeholder older than this -> error) and `WEDGED_SEC` (default 15m — agent up
+  but placeholder this old -> error).
+- `MARVEEN_ROOT` env var overrides the fleet root the watchdog scans.
+
+## Remove
+
+Delete the four `~/.claude/hooks/telegram_progress*.py` files and their entries
+in `~/.claude/settings.json`, then unload the watchdog
+(`launchctl unload ~/Library/LaunchAgents/com.marveen.telegram-progress-watchdog.plist`
+on macOS, or `systemctl --user disable --now marveen-telegram-progress-watchdog.timer`
+on Linux).

--- a/docs/telegram-progress-indicator.md
+++ b/docs/telegram-progress-indicator.md
@@ -34,7 +34,7 @@ piece stays correct per-agent even with different bots.
 |-------|---------|-----|
 | `telegram_progress.py` | `UserPromptSubmit` hook | If the prompt contains a Telegram `<channel … chat_id … message_id>` block, post the placeholder and record its message id in a per-session state file. |
 | `telegram_progress_reply_clear.py` | `PostToolUse` hook (matcher `telegram.*reply`) | Delete the placeholder(s) for the replied chat the instant a reply is sent. **Primary clear path.** |
-| `telegram_progress_clear.py` | `Stop` hook | Delete any placeholder still recorded at turn end (fallback for turns that finish without replying). |
+| `telegram_progress_clear.py` | `Stop` hook | Delete any placeholder still recorded at turn end, **and enforce delivery** (see below). |
 | `telegram_progress_watchdog.py` | launchd / systemd, ~60s | Scan every agent's per-agent state dir; for an orphan (the agent's `agent-<name>` tmux session is gone + older than a short grace, OR older than a generous "wedged" threshold) rewrite the placeholder via `editMessageText` into the error text. The only layer that can speak when the agent itself is down. |
 
 ### Why both PostToolUse and Stop
@@ -45,6 +45,26 @@ original `Dolgozom rajta…` lingers for the whole (possibly very long) turn eve
 though the user already has an answer — it *looks* stuck. Clearing on the
 `reply` tool (PostToolUse) makes the placeholder vanish exactly when the answer
 appears; `Stop` is kept as a fallback and the watchdog as the crash backstop.
+
+### Reply enforcement (the "answered only in the CLI" bug)
+
+Goal #3 above — *the user always gets either an answer or an explicit failure* —
+has one more failure mode the watchdog can't catch: the agent finishes normally
+(so `Stop` fires) but never actually called the `reply` tool, so its answer lives
+only in the CLI/transcript and the Telegram user sees nothing. The `Stop` hook
+closes this: if a placeholder is still pending at turn end (= a Telegram turn
+with no reply sent to that chat) it
+
+1. **blocks the stop once** and instructs the agent to send its answer via the
+   `reply` tool (the agent re-enters and replies properly, with its own
+   formatting), and
+2. if it *still* didn't reply after that single nudge, **delivers the agent's
+   final answer** (last assistant message from the transcript) to the chat as a
+   guaranteed fallback.
+
+Loop-safe: a per-session `enforce-<sid>.marker` guarantees at most one block, and
+`stop_hook_active` is honored. Turns that never had a Telegram placeholder
+(plain CLI sessions, silent heartbeats) are untouched.
 
 ### Hardening
 

--- a/scripts/hooks/telegram_progress.py
+++ b/scripts/hooks/telegram_progress.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook — Telegram "processing" indicator.
+
+When an inbound Telegram channel message is delivered to the agent, this:
+  1) reacts with ✍️ on the user's message (a persistent "received" marker), and
+  2) posts a "✍️ Dolgozom rajta…" placeholder message,
+then records the placeholder id so the Stop hook can delete it when the turn
+ends. This is the honest alternative to a "typing…" action (which only lasts
+~5s and lies, since the model is thinking, not typing).
+
+MUST stay silent on stdout — stdout from UserPromptSubmit is injected into the
+model prompt. All diagnostics go to a debug log file under the state dir.
+
+Token/state dir resolution mirrors the telegram plugin: honor TELEGRAM_STATE_DIR
+(set per-agent), else default to ~/.claude/channels/telegram. This keeps the
+hook correct even if installed globally across agents with different bots.
+"""
+import sys, os, json, re, urllib.request
+
+PLACEHOLDER = "✍️ Dolgozom rajta…"   # ✍️ Dolgozom rajta…
+REACTION = "✍️"                            # ✍️
+
+
+def state_dir():
+    d = os.environ.get("TELEGRAM_STATE_DIR")
+    if d:
+        return d
+    return os.path.expanduser("~/.claude/channels/telegram")
+
+
+def log(sd, msg):
+    try:
+        os.makedirs(os.path.join(sd, "progress"), exist_ok=True)
+        with open(os.path.join(sd, "progress", "debug.log"), "a", encoding="utf-8") as f:
+            f.write(msg + "\n")
+    except Exception:
+        pass
+
+
+def token(sd):
+    try:
+        for line in open(os.path.join(sd, ".env"), encoding="utf-8"):
+            line = line.strip()
+            if line.startswith("TELEGRAM_BOT_TOKEN="):
+                return line.split("=", 1)[1].strip()
+    except Exception:
+        return None
+    return None
+
+
+def api(tok, method, payload):
+    url = f"https://api.telegram.org/bot{tok}/{method}"
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=8) as r:
+        return json.loads(r.read().decode())
+
+
+def claim(progress_dir, sid, src_mid):
+    """Atomic per-inbound-message guard. Returns True if THIS invocation claimed
+    the message (proceed), False if another already did (skip). Prevents double
+    placeholders if the hook is ever registered at two scopes (global + project)
+    that both fire for the same prompt. O_EXCL makes the claim race-safe."""
+    if not src_mid:
+        return True
+    try:
+        os.makedirs(progress_dir, exist_ok=True)
+        marker = os.path.join(progress_dir, f"seen-{sid}-{src_mid}.marker")
+        fd = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.close(fd)
+        return True
+    except FileExistsError:
+        return False
+    except Exception:
+        return True  # never let the guard block the indicator
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        ev = json.loads(raw)
+    except Exception:
+        return
+    prompt = ev.get("prompt") or ""
+    sid = ev.get("session_id") or "default"
+    sd = state_dir()
+
+    blocks = re.findall(r'<channel\b[^>]*\bsource="[^"]*telegram[^"]*"[^>]*>', prompt)
+    if not blocks:
+        return  # not a telegram turn — stay silent
+    log(sd, f"[submit] sid={sid} blocks={len(blocks)} state_dir={sd}")
+
+    tok = token(sd)
+    if not tok:
+        log(sd, "[submit] no token found")
+        return
+
+    pending = []
+    for b in blocks:
+        cid = re.search(r'\bchat_id="([^"]+)"', b)
+        mid = re.search(r'\bmessage_id="([^"]+)"', b)
+        if not cid:
+            continue
+        chat_id = cid.group(1)
+        src_mid = mid.group(1) if mid else None
+        # Dedup: skip if a sibling invocation already handled this inbound msg.
+        if not claim(os.path.join(sd, "progress"), sid, src_mid):
+            log(sd, f"[submit] dedup skip src={src_mid}")
+            continue
+        # Note: no reaction on the user's message — the "Dolgozom rajta…"
+        # placeholder already signals receipt, so a reaction would be redundant
+        # (per user preference 2026-06-07).
+        try:
+            resp = api(tok, "sendMessage", {"chat_id": chat_id, "text": PLACEHOLDER})
+            pmid = resp.get("result", {}).get("message_id")
+            if pmid:
+                pending.append({"chat_id": chat_id, "message_id": pmid})
+        except Exception as e:
+            log(sd, f"[submit] placeholder failed: {e}")
+
+    if pending:
+        path = os.path.join(sd, "progress", f"{sid}.json")
+        old = []
+        try:
+            old = json.load(open(path))
+        except Exception:
+            old = []
+        try:
+            json.dump(old + pending, open(path, "w"))
+            log(sd, f"[submit] stored {len(pending)} placeholder(s)")
+        except Exception as e:
+            log(sd, f"[submit] store failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/telegram_progress_clear.py
+++ b/scripts/hooks/telegram_progress_clear.py
@@ -1,15 +1,40 @@
 #!/usr/bin/env python3
 """
-Stop hook — removes the Telegram "✍️ Dolgozom rajta…" placeholder(s) that the
-UserPromptSubmit hook (telegram_progress.py) posted for this session, once the
-turn finishes. Every turn ends with Stop, so the placeholder can never get
-stuck under normal operation; a crashed/wedged turn (no Stop) is the only orphan
-case, which the separate watchdog cleans up.
+Stop hook — two jobs, in one place so there is a single owner of the per-session
+progress state at turn end (no racing Stop hooks):
 
-Silent on stdout. Token/state dir resolution mirrors the plugin (TELEGRAM_STATE_DIR
-else default).
+  1) CLEAR: remove the "✍️ Dolgozom rajta…" placeholder(s) that the
+     UserPromptSubmit hook (telegram_progress.py) posted for this session. Under
+     normal operation the PostToolUse reply hook already cleared them the moment
+     the agent replied, so usually there is nothing left to do.
+
+  2) ENFORCE DELIVERY: if the turn was triggered by an inbound Telegram message
+     but the agent ended the turn WITHOUT ever sending a reply to that chat
+     (i.e. a placeholder is still pending), the answer only exists in the CLI /
+     transcript — which the Telegram user never sees ("the agent looks frozen").
+     This hook then:
+       - on the first Stop: BLOCKS the stop and instructs the agent to send its
+         answer via the Telegram `reply` tool (the agent re-enters and replies
+         properly, with its own formatting);
+       - if it STILL did not reply after that one nudge: delivers the agent's
+         final answer (last assistant message from the transcript) to the chat
+         as a guaranteed fallback, then removes the placeholder.
+     So a Telegram turn always ends with the user getting the answer here.
+
+Loop safety: a per-session `enforce-<sid>.marker` guarantees we block at most
+once; `stop_hook_active` is also honored. Silent on stdout EXCEPT the single
+decision JSON when blocking. Token/state dir resolution mirrors the plugin
+(TELEGRAM_STATE_DIR else default).
 """
 import sys, os, json, glob, urllib.request
+
+INSTRUCTION = (
+    "KÖTELEZŐ: erre a Telegram-üzenetre még NEM küldtél választ a Telegram "
+    "`reply` tool-lal (chat_id=%s). A CLI/transzkript szöveget a felhasználó a "
+    "Telegramon NEM látja — onnan nézve csak befagytál. Küldd el a válaszodat "
+    "MOST a `reply` tool-lal a megfelelő chat_id-vel. Ha tényleg nincs érdemi "
+    "válasz, akkor is küldj egy rövid visszaigazolást."
+)
 
 
 def state_dir():
@@ -48,6 +73,40 @@ def api(tok, method, payload):
         return json.loads(r.read().decode())
 
 
+def last_assistant_text(transcript_path):
+    """Return the last non-empty assistant text message from the JSONL transcript
+    (the agent's final user-facing answer). Empty string if none / unreadable."""
+    text = ""
+    if not transcript_path:
+        return text
+    try:
+        for line in open(transcript_path, encoding="utf-8"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except Exception:
+                continue
+            msg = ev.get("message") or {}
+            role = msg.get("role") or ev.get("role")
+            if ev.get("type") == "assistant" or role == "assistant":
+                content = msg.get("content", ev.get("content"))
+                parts = []
+                if isinstance(content, list):
+                    for c in content:
+                        if isinstance(c, dict) and c.get("type") == "text":
+                            parts.append(c.get("text", ""))
+                elif isinstance(content, str):
+                    parts.append(content)
+                t = "\n".join(p for p in parts if p).strip()
+                if t:
+                    text = t  # keep the LAST non-empty one
+    except Exception:
+        pass
+    return text
+
+
 def main():
     raw = sys.stdin.read()
     try:
@@ -55,31 +114,72 @@ def main():
     except Exception:
         ev = {}
     sid = ev.get("session_id") or "default"
+    transcript = ev.get("transcript_path")
+    stop_active = bool(ev.get("stop_hook_active"))
     sd = state_dir()
+    pdir = os.path.join(sd, "progress")
+    guard = os.path.join(pdir, f"enforce-{sid}.marker")
+
     # Clean up this session's dedup markers (created by telegram_progress.py).
-    for m in glob.glob(os.path.join(sd, "progress", f"seen-{sid}-*.marker")):
+    for m in glob.glob(os.path.join(pdir, f"seen-{sid}-*.marker")):
         try:
             os.remove(m)
         except Exception:
             pass
-    path = os.path.join(sd, "progress", f"{sid}.json")
+
+    path = os.path.join(pdir, f"{sid}.json")
     try:
         pend = json.load(open(path))
     except Exception:
-        return  # nothing pending
+        pend = None
+
+    if not pend:
+        # Nothing pending: either not a Telegram turn, or the reply was already
+        # sent (PostToolUse cleared it). Drop any stale enforce marker and exit.
+        try:
+            os.remove(guard)
+        except Exception:
+            pass
+        return
+
+    # A Telegram turn whose reply was NOT sent for the listed chat(s).
+    blocked_before = os.path.exists(guard)
+    if not stop_active and not blocked_before:
+        # First Stop with an un-replied Telegram turn -> nudge the agent to reply
+        # properly via its own tool. Keep the placeholder so the re-entry path
+        # (PostToolUse) clears it when the reply finally goes out.
+        try:
+            open(guard, "w").close()
+        except Exception:
+            pass
+        chats = ", ".join(sorted({str(p.get("chat_id")) for p in pend}))
+        log(sd, f"[enforce] blocking stop, no reply sent sid={sid} chats={chats}")
+        print(json.dumps({"decision": "block", "reason": INSTRUCTION % chats}))
+        return
+
+    # Already nudged once (or loop guard tripped) and STILL no reply -> guaranteed
+    # fallback: deliver the agent's final answer to the chat, then clear.
+    answer = last_assistant_text(transcript)
     tok = token(sd)
     if tok:
         for p in pend:
+            cid, mid = p.get("chat_id"), p.get("message_id")
+            if answer:
+                try:
+                    api(tok, "sendMessage", {"chat_id": cid, "text": answer[:4000]})
+                except Exception as e:
+                    log(sd, f"[enforce] fallback send failed: {e}")
             try:
-                api(tok, "deleteMessage",
-                    {"chat_id": p["chat_id"], "message_id": p["message_id"]})
+                api(tok, "deleteMessage", {"chat_id": cid, "message_id": mid})
             except Exception as e:
                 log(sd, f"[stop] delete failed: {e}")
-    try:
-        os.remove(path)
-        log(sd, f"[stop] cleared {len(pend)} placeholder(s) sid={sid}")
-    except Exception:
-        pass
+    for f in (path, guard):
+        try:
+            os.remove(f)
+        except Exception:
+            pass
+    log(sd, f"[enforce] fallback-delivered={bool(answer)} cleared {len(pend)} "
+            f"placeholder(s) sid={sid}")
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/telegram_progress_clear.py
+++ b/scripts/hooks/telegram_progress_clear.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Stop hook — removes the Telegram "✍️ Dolgozom rajta…" placeholder(s) that the
+UserPromptSubmit hook (telegram_progress.py) posted for this session, once the
+turn finishes. Every turn ends with Stop, so the placeholder can never get
+stuck under normal operation; a crashed/wedged turn (no Stop) is the only orphan
+case, which the separate watchdog cleans up.
+
+Silent on stdout. Token/state dir resolution mirrors the plugin (TELEGRAM_STATE_DIR
+else default).
+"""
+import sys, os, json, glob, urllib.request
+
+
+def state_dir():
+    d = os.environ.get("TELEGRAM_STATE_DIR")
+    if d:
+        return d
+    return os.path.expanduser("~/.claude/channels/telegram")
+
+
+def log(sd, msg):
+    try:
+        os.makedirs(os.path.join(sd, "progress"), exist_ok=True)
+        with open(os.path.join(sd, "progress", "debug.log"), "a", encoding="utf-8") as f:
+            f.write(msg + "\n")
+    except Exception:
+        pass
+
+
+def token(sd):
+    try:
+        for line in open(os.path.join(sd, ".env"), encoding="utf-8"):
+            line = line.strip()
+            if line.startswith("TELEGRAM_BOT_TOKEN="):
+                return line.split("=", 1)[1].strip()
+    except Exception:
+        return None
+    return None
+
+
+def api(tok, method, payload):
+    url = f"https://api.telegram.org/bot{tok}/{method}"
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=8) as r:
+        return json.loads(r.read().decode())
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        ev = json.loads(raw)
+    except Exception:
+        ev = {}
+    sid = ev.get("session_id") or "default"
+    sd = state_dir()
+    # Clean up this session's dedup markers (created by telegram_progress.py).
+    for m in glob.glob(os.path.join(sd, "progress", f"seen-{sid}-*.marker")):
+        try:
+            os.remove(m)
+        except Exception:
+            pass
+    path = os.path.join(sd, "progress", f"{sid}.json")
+    try:
+        pend = json.load(open(path))
+    except Exception:
+        return  # nothing pending
+    tok = token(sd)
+    if tok:
+        for p in pend:
+            try:
+                api(tok, "deleteMessage",
+                    {"chat_id": p["chat_id"], "message_id": p["message_id"]})
+            except Exception as e:
+                log(sd, f"[stop] delete failed: {e}")
+    try:
+        os.remove(path)
+        log(sd, f"[stop] cleared {len(pend)} placeholder(s) sid={sid}")
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/telegram_progress_reply_clear.py
+++ b/scripts/hooks/telegram_progress_reply_clear.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+PostToolUse hook — clears the "✍️ Dolgozom rajta…" placeholder as soon as the
+agent actually SENDS a reply, instead of waiting for the turn to end (Stop).
+
+Why: a single long turn can pull a bigger task forward and emit several replies
+before it finishes. With Stop-only cleanup the placeholder visibly lingers for
+the whole (possibly very long) turn even though the user already got an answer.
+Clearing on the reply tool makes the placeholder disappear exactly when the
+answer appears — matching the user's mental model.
+
+Fires after the Telegram `reply` tool. Deletes any pending placeholder(s) for
+the replied chat_id in this session. The Stop hook + watchdog remain as
+backstops for turns that end without a reply, or true crashes.
+
+Silent on stdout. Honors TELEGRAM_STATE_DIR (per-agent token) like the others.
+"""
+import sys, os, json, urllib.request
+
+
+def state_dir():
+    return os.environ.get("TELEGRAM_STATE_DIR") or os.path.expanduser("~/.claude/channels/telegram")
+
+
+def token(sd):
+    try:
+        for line in open(os.path.join(sd, ".env"), encoding="utf-8"):
+            line = line.strip()
+            if line.startswith("TELEGRAM_BOT_TOKEN="):
+                return line.split("=", 1)[1].strip()
+    except Exception:
+        return None
+    return None
+
+
+def api(tok, method, payload):
+    url = f"https://api.telegram.org/bot{tok}/{method}"
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=8) as r:
+        return json.loads(r.read().decode())
+
+
+def main():
+    try:
+        ev = json.loads(sys.stdin.read())
+    except Exception:
+        return
+    tool = ev.get("tool_name") or ev.get("toolName") or ""
+    if "telegram" not in tool or "reply" not in tool:
+        return
+    ti = ev.get("tool_input") or ev.get("toolInput") or {}
+    chat_id = ti.get("chat_id")
+    if chat_id is None:
+        return
+    chat_id = str(chat_id)
+    sid = ev.get("session_id") or "default"
+    sd = state_dir()
+    path = os.path.join(sd, "progress", f"{sid}.json")
+    try:
+        pend = json.load(open(path))
+    except Exception:
+        return
+    keep, drop = [], []
+    for p in pend:
+        (drop if str(p.get("chat_id")) == chat_id else keep).append(p)
+    if not drop:
+        return
+    tok = token(sd)
+    if tok:
+        for p in drop:
+            try:
+                api(tok, "deleteMessage", {"chat_id": p["chat_id"], "message_id": p["message_id"]})
+            except Exception:
+                pass
+    try:
+        if keep:
+            json.dump(keep, open(path, "w"))
+        else:
+            os.remove(path)
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/telegram_progress_watchdog.py
+++ b/scripts/hooks/telegram_progress_watchdog.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+telegram_progress_watchdog.py — the "őrszem" (sentry) for the Telegram progress
+indicator. Runs independently of the agent sessions (via launchd), so it can
+speak even when an agent is wedged or down.
+
+Problem it solves: the UserPromptSubmit hook posts a "✍️ Dolgozom rajta…"
+placeholder; the Stop hook deletes it when the turn ends. If a turn never ends
+(agent crashed, session killed, wedged), the placeholder would sit there
+forever and the user is left wondering "is it working or broken?". This watchdog
+detects those orphans and rewrites the placeholder into a CLEAR error message,
+so the user always gets an unambiguous signal.
+
+Detection (per pending placeholder, identified by its session state file):
+  - agent process DOWN (its tmux `agent-<name>` session is gone) and the
+    placeholder is older than DOWN_GRACE_SEC  -> error (covers crash / not
+    reachable, with a short grace so a fleet restart isn't flagged), or
+  - agent UP but the placeholder is older than WEDGED_SEC -> error (covers a
+    genuinely stuck turn; generous so long legit tasks aren't killed).
+
+On error it edits the existing placeholder message (editMessageText) into the
+error text and removes the state file so it fires once.
+
+Standalone: scans every agent's per-agent telegram state dir. No marveen src
+dependency; only Python stdlib + the `tmux` binary.
+"""
+import os, glob, json, time, subprocess, urllib.request
+
+# State dirs to scan: per-agent dirs under the fleet, plus the default dir.
+# No hardcoded user paths — derive from $HOME (override with MARVEEN_ROOT).
+FLEET_ROOT = os.environ.get("MARVEEN_ROOT") or os.path.expanduser("~/marveen")
+SCAN_GLOBS = [
+    os.path.join(FLEET_ROOT, "agents", "*", ".claude", "channels", "telegram", "progress"),
+    os.path.expanduser("~/.claude/channels/telegram/progress"),
+]
+DOWN_GRACE_SEC = 120        # agent down + placeholder older than this -> error
+WEDGED_SEC = 15 * 60        # agent up but placeholder this old -> error
+ERROR_TEXT = ("⚠️ Valami elakadt, és erre nem érkezett válasz. "
+              "Lehet, hogy újra kell indítani az ügynököt, vagy próbáld újra kicsit később.")
+
+
+def token(state_dir):
+    try:
+        for line in open(os.path.join(state_dir, ".env"), encoding="utf-8"):
+            line = line.strip()
+            if line.startswith("TELEGRAM_BOT_TOKEN="):
+                return line.split("=", 1)[1].strip()
+    except Exception:
+        return None
+    return None
+
+
+def api(tok, method, payload):
+    url = f"https://api.telegram.org/bot{tok}/{method}"
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=8) as r:
+        return json.loads(r.read().decode())
+
+
+def agent_name_from(progress_dir):
+    # .../agents/<name>/.claude/channels/telegram/progress  -> <name>
+    parts = progress_dir.split(os.sep)
+    if "agents" in parts:
+        i = parts.index("agents")
+        if i + 1 < len(parts):
+            return parts[i + 1]
+    return None
+
+
+def tmux_session_alive(session):
+    try:
+        return subprocess.run(["tmux", "has-session", "-t", session],
+                              capture_output=True, timeout=5).returncode == 0
+    except Exception:
+        return True  # if tmux probe fails, assume alive (don't false-alarm)
+
+
+def log(progress_dir, msg):
+    try:
+        with open(os.path.join(progress_dir, "debug.log"), "a", encoding="utf-8") as f:
+            f.write(f"[watchdog {time.strftime('%H:%M:%S')}] {msg}\n")
+    except Exception:
+        pass
+
+
+def handle_dir(progress_dir):
+    state_dir = os.path.dirname(progress_dir)           # .../telegram
+    name = agent_name_from(progress_dir)
+    agent_up = tmux_session_alive(f"agent-{name}") if name else True
+    now = time.time()
+    # Sweep orphan dedup markers (normally removed by the Stop hook).
+    for m in glob.glob(os.path.join(progress_dir, "seen-*.marker")):
+        try:
+            if now - os.path.getmtime(m) > 3600:
+                os.remove(m)
+        except Exception:
+            pass
+    tok = None
+    for path in glob.glob(os.path.join(progress_dir, "*.json")):
+        try:
+            age = now - os.path.getmtime(path)
+        except Exception:
+            continue
+        # Decide if this is an orphan needing an error.
+        orphan = (not agent_up and age > DOWN_GRACE_SEC) or (age > WEDGED_SEC)
+        if not orphan:
+            continue
+        try:
+            pend = json.load(open(path))
+        except Exception:
+            pend = []
+        if tok is None:
+            tok = token(state_dir)
+        for p in pend:
+            if not tok:
+                break
+            try:
+                api(tok, "editMessageText", {
+                    "chat_id": p["chat_id"], "message_id": p["message_id"],
+                    "text": ERROR_TEXT,
+                })
+            except Exception as e:
+                log(progress_dir, f"edit failed (mid={p.get('message_id')}): {e}")
+        try:
+            os.remove(path)
+            log(progress_dir, f"orphan handled: {os.path.basename(path)} "
+                              f"agent_up={agent_up} age={int(age)}s")
+        except Exception:
+            pass
+
+
+def main():
+    dirs = []
+    for g in SCAN_GLOBS:
+        dirs.extend(glob.glob(g))
+    for d in dirs:
+        if os.path.isdir(d):
+            handle_dir(d)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install-telegram-progress-hook.sh
+++ b/scripts/install-telegram-progress-hook.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# Install the Telegram "working…" progress indicator: hooks + a standalone
+# watchdog (sentry). Plugin-independent — needs no changes to the official
+# telegram plugin, so it survives plugin updates.
+#
+# What you get:
+#   - inbound Telegram message  -> a "✍️ Dolgozom rajta…" placeholder appears
+#   - the agent sends a reply   -> the placeholder is deleted the instant the
+#                                  answer goes out (PostToolUse), Stop as fallback
+#   - the turn never finishes    -> a watchdog rewrites the placeholder into a
+#     (crash/wedged/agent down)    clear error, so the user always gets either an
+#                                  answer or an explicit failure
+#
+# What it does:
+#   1. Copies the 4 hook scripts to ~/.claude/hooks/
+#   2. Patches ~/.claude/settings.json idempotently:
+#        UserPromptSubmit -> telegram_progress.py
+#        PostToolUse(telegram.*reply) -> telegram_progress_reply_clear.py
+#        Stop -> telegram_progress_clear.py
+#   3. Installs the watchdog as a launchd agent (macOS) or systemd
+#      service+timer (Linux), running ~every 60s.
+#
+# Idempotent: safe to re-run (e.g. from sync-hooks.sh on every update).
+#
+# Usage:
+#   bash ~/ClaudeClaw/scripts/install-telegram-progress-hook.sh
+
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "$0")" && pwd)/hooks"
+DEST_DIR="$HOME/.claude/hooks"
+SETTINGS="$HOME/.claude/settings.json"
+
+SUBMIT_HOOK="$DEST_DIR/telegram_progress.py"
+STOP_HOOK="$DEST_DIR/telegram_progress_clear.py"
+REPLY_HOOK="$DEST_DIR/telegram_progress_reply_clear.py"
+WATCHDOG="$DEST_DIR/telegram_progress_watchdog.py"
+
+for f in telegram_progress.py telegram_progress_clear.py \
+         telegram_progress_reply_clear.py telegram_progress_watchdog.py; do
+  if [ ! -f "$SRC_DIR/$f" ]; then
+    echo "❌ Source hook not found: $SRC_DIR/$f" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$DEST_DIR"
+cp "$SRC_DIR/telegram_progress.py"             "$SUBMIT_HOOK"
+cp "$SRC_DIR/telegram_progress_clear.py"       "$STOP_HOOK"
+cp "$SRC_DIR/telegram_progress_reply_clear.py" "$REPLY_HOOK"
+cp "$SRC_DIR/telegram_progress_watchdog.py"    "$WATCHDOG"
+chmod +x "$SUBMIT_HOOK" "$STOP_HOOK" "$REPLY_HOOK" "$WATCHDOG"
+echo "✓ Hooks installed in $DEST_DIR"
+
+if [ ! -f "$SETTINGS" ]; then
+  echo '{"hooks":{}}' > "$SETTINGS"
+fi
+
+# Resolve an absolute python3 for both the hooks and the daemon unit.
+PY="$(command -v python3 || true)"
+if [ -z "$PY" ]; then
+  echo "❌ python3 not found in PATH" >&2
+  exit 1
+fi
+
+# --- Patch settings.json idempotently --------------------------------------
+"$PY" - "$SETTINGS" "$PY" "$SUBMIT_HOOK" "$STOP_HOOK" "$REPLY_HOOK" <<'PYEOF'
+import json, sys
+
+settings_path, py, submit_hook, stop_hook, reply_hook = sys.argv[1:6]
+with open(settings_path) as f:
+    cfg = json.load(f)
+hooks = cfg.setdefault('hooks', {})
+
+def cmd(path):
+    return f"{py} {path}"
+
+def has_command(group_list, command, matcher=None):
+    for g in group_list:
+        if matcher is not None and g.get('matcher') != matcher:
+            continue
+        for h in g.get('hooks', []):
+            if h.get('command') == command:
+                return True
+    return False
+
+def find_group(group_list, matcher):
+    for g in group_list:
+        if g.get('matcher') == matcher:
+            return g
+    return None
+
+changed = False
+
+# UserPromptSubmit (no matcher) -> placeholder
+ups = hooks.setdefault('UserPromptSubmit', [])
+if not has_command(ups, cmd(submit_hook)):
+    grp = next((g for g in ups if 'matcher' not in g), None)
+    if grp is None:
+        grp = {'hooks': []}
+        ups.append(grp)
+    grp.setdefault('hooks', []).append(
+        {'type': 'command', 'command': cmd(submit_hook), 'timeout': 15})
+    changed = True
+
+# Stop (no matcher) -> clear fallback
+stop = hooks.setdefault('Stop', [])
+if not has_command(stop, cmd(stop_hook)):
+    grp = next((g for g in stop if 'matcher' not in g), None)
+    if grp is None:
+        grp = {'hooks': []}
+        stop.append(grp)
+    grp.setdefault('hooks', []).append(
+        {'type': 'command', 'command': cmd(stop_hook), 'timeout': 15})
+    changed = True
+
+# PostToolUse(matcher="telegram.*reply") -> clear on reply
+post = hooks.setdefault('PostToolUse', [])
+if not has_command(post, cmd(reply_hook), matcher='telegram.*reply'):
+    grp = find_group(post, 'telegram.*reply')
+    if grp is None:
+        grp = {'matcher': 'telegram.*reply', 'hooks': []}
+        post.append(grp)
+    grp.setdefault('hooks', []).append(
+        {'type': 'command', 'command': cmd(reply_hook), 'timeout': 15})
+    changed = True
+
+if changed:
+    with open(settings_path, 'w') as f:
+        json.dump(cfg, f, indent=2, ensure_ascii=False)
+    print("✓ settings.json hooks patched (UserPromptSubmit / PostToolUse / Stop)")
+else:
+    print("⊙ settings.json already has the progress hooks — skipping")
+PYEOF
+
+# --- Install the watchdog daemon -------------------------------------------
+OS="$(uname -s)"
+if [ "$OS" = "Darwin" ]; then
+  PLIST_DIR="$HOME/Library/LaunchAgents"
+  LABEL="com.marveen.telegram-progress-watchdog"
+  PLIST="$PLIST_DIR/$LABEL.plist"
+  LOG="$HOME/.claude/channels/telegram-progress-watchdog.log"
+  mkdir -p "$PLIST_DIR" "$HOME/.claude/channels"
+  cat > "$PLIST" <<PLISTEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$PY</string>
+        <string>$WATCHDOG</string>
+    </array>
+    <!-- launchd's default PATH is minimal; the watchdog shells out to tmux. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>StartInterval</key>
+    <integer>60</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$LOG</string>
+    <key>StandardErrorPath</key>
+    <string>$LOG</string>
+</dict>
+</plist>
+PLISTEOF
+  launchctl unload "$PLIST" 2>/dev/null || true
+  launchctl load "$PLIST" 2>/dev/null || true
+  echo "✓ Watchdog installed (launchd: $LABEL, every 60s)"
+else
+  # Linux: systemd user service + timer
+  UNIT_DIR="$HOME/.config/systemd/user"
+  SVC="marveen-telegram-progress-watchdog"
+  mkdir -p "$UNIT_DIR"
+  cat > "$UNIT_DIR/$SVC.service" <<UNITEOF
+[Unit]
+Description=Marveen Telegram progress-indicator watchdog (sentry)
+
+[Service]
+Type=oneshot
+ExecStart=$PY $WATCHDOG
+UNITEOF
+  cat > "$UNIT_DIR/$SVC.timer" <<TIMEREOF
+[Unit]
+Description=Run the Telegram progress watchdog every 60s
+Requires=$SVC.service
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target
+TIMEREOF
+  if pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
+    systemctl --user daemon-reload
+    systemctl --user enable --now "$SVC.timer" 2>/dev/null || true
+    echo "✓ Watchdog installed (systemd timer: $SVC.timer, every 60s)"
+  else
+    echo "⚠ systemd --user not available — units written to $UNIT_DIR"
+    echo "  Enable later: systemctl --user enable --now $SVC.timer"
+  fi
+fi
+
+echo ""
+echo "Done. Telegram turns now show a 'Dolgozom rajta…' placeholder that clears"
+echo "on reply, and a watchdog turns any stuck turn into a clear error."


### PR DESCRIPTION
Implements RFC #314. As offered in that issue, here is the upstreamable package.

## What it is
A lightweight, **plugin-independent** "the agent is working…" indicator for the Telegram channel, plus a watchdog (sentry) that turns a stuck turn into a clear error. Built entirely with Claude Code hooks + a standalone watchdog, so it needs **no changes to the official telegram plugin** and survives plugin updates.

## Behavior
- inbound Telegram message -> a `✍️ Dolgozom rajta…` placeholder appears
- agent sends a reply -> the placeholder is deleted **the instant the answer goes out** (PostToolUse), `Stop` as fallback
- turn never finishes (crash / wedged / agent down) -> the watchdog rewrites the placeholder into a clear error, so the user always gets **either an answer or an explicit failure**

A `typing…` action was rejected on purpose: it is dishonest (the model is thinking, not typing) and it expires after ~5s.

## Pieces
All stdlib Python. Token + state dir resolved exactly like the plugin (`TELEGRAM_STATE_DIR`, else `~/.claude/channels/telegram`), so each piece stays correct per-agent even with different bots.

| File | Trigger | Job |
|------|---------|-----|
| `scripts/hooks/telegram_progress.py` | `UserPromptSubmit` | post placeholder, record id |
| `scripts/hooks/telegram_progress_reply_clear.py` | `PostToolUse` (`telegram.*reply`) | delete placeholder the moment a reply is sent (primary) |
| `scripts/hooks/telegram_progress_clear.py` | `Stop` | delete leftover placeholder at turn end (fallback) |
| `scripts/hooks/telegram_progress_watchdog.py` | launchd / systemd (~60s) | rewrite orphaned placeholders into an error (the only layer that can speak when the agent is down) |

### Why both PostToolUse and Stop
Stop-only cleanup leaves the placeholder lingering through a long, multi-reply turn even after the user already has an answer (it *looks* stuck). Clearing on the `reply` tool makes it vanish exactly when the answer appears; `Stop` stays as a fallback and the watchdog as the crash backstop.

### Hardening
- **Dedup guard**: atomic `O_EXCL` marker keyed by inbound message id, so a hook registered at two scopes (global + project, which Claude Code merges additively) can never post a double placeholder.
- **Fleet-wide**: hooks in global `~/.claude/settings.json`; watchdog scans all agents under `$MARVEEN_ROOT` (default `~/marveen`).

## Install
`scripts/install-telegram-progress-hook.sh` — idempotent, auto-run by `scripts/sync-hooks.sh` on every update (matches the existing `install-*-hook.sh` pattern). It copies the hooks, patches `settings.json` idempotently, and installs the watchdog as a **launchd** agent (macOS) or **systemd** user service+timer (Linux). Docs: `docs/telegram-progress-indicator.md`.

## Testing
- `bash -n` + `py_compile` clean on all five scripts.
- settings.json patcher verified idempotent (re-run = no-op) and non-destructive (coexists with an existing `telegram.*reply` matcher and other hooks).
- Running live on macOS across a 6-agent fleet.

Closes #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)