### PR TITLE
fix(dashboard): stop terminal-modal vibration and modal content overflow

### DIFF
--- a/src/__tests__/dashboard-modal-css-contract.test.ts
+++ b/src/__tests__/dashboard-modal-css-contract.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// Contract test for two dashboard modal CSS regressions reported 2026-06-11:
+//   1. "Vibrating terminal modal": `.terminal-modal` had only `max-height: 90vh`
+//      (no fixed height), so its height was content-driven. The xterm FitAddon
+//      grows the modal as the live pane repaints, which re-runs fit() and makes
+//      the modal oscillate (grow to the cap, snap back, grow again -- a loop).
+//      Fix: a fixed `height` on `.terminal-modal` so the flex container is stable
+//      and xterm scrolls internally instead of resizing the modal.
+//   2. "Content sticking out of the modal" (agent-detail "Csapat" tab): the
+//      generic `.form-group input { width: 100% }` (meant for text fields) also
+//      stretched the auto-delegation checkbox inside its flex label to full
+//      width, shoving the adjacent label text past the modal's right edge.
+//      Fix: checkbox/radio inputs keep their native size.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const cssPath = join(__dirname, '..', '..', 'web', 'style.css')
+// Strip /* ... */ comments so an explanatory comment that *mentions* a property
+// is never mistaken for a real declaration.
+const css = readFileSync(cssPath, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '')
+
+/** Return the body of the first `selector { ... }` rule, or null. */
+function ruleBody(selector: string): string | null {
+  const idx = css.indexOf(selector)
+  if (idx < 0) return null
+  const open = css.indexOf('{', idx)
+  const close = css.indexOf('}', open)
+  if (open < 0 || close < 0) return null
+  return css.slice(open + 1, close)
+}
+
+describe('dashboard modal CSS contract', () => {
+  it('the .terminal-modal must have a fixed height, not just max-height (vibration loop guard)', () => {
+    const body = ruleBody('.terminal-modal {')
+    expect(body, '.terminal-modal rule not found in web/style.css').not.toBeNull()
+    // A bare `max-height` lets the xterm FitAddon resize the modal in a loop;
+    // a real `height:` declaration pins it.
+    expect(body!).toMatch(/(^|[;{\s])height\s*:/)
+  })
+
+  it('checkbox/radio inputs in a form-group override the text-field width:100% (overflow guard)', () => {
+    const body = ruleBody('.form-group input[type="checkbox"]')
+    expect(
+      body,
+      'missing `.form-group input[type="checkbox"]` width override in web/style.css',
+    ).not.toBeNull()
+    expect(body!).toMatch(/width\s*:\s*auto/i)
+  })
+})

--- a/web/style.css
+++ b/web/style.css
@@ -1767,6 +1767,17 @@ main {
   transition: all var(--transition);
   outline: none;
 }
+/* Checkbox/radio inputs must not inherit the width:100% + padding meant for
+   text fields -- inside a flex label that stretches the box to full width and
+   shoves the adjacent label text out past the modal's right edge ("content
+   sticking out of the modal" bug, e.g. the agent-detail Csapat tab). */
+.form-group input[type="checkbox"],
+.form-group input[type="radio"] {
+  width: auto;
+  flex: 0 0 auto;
+  padding: 0;
+  margin: 0;
+}
 .form-group input:focus,
 .form-group textarea:focus,
 .form-group select:focus {
@@ -5303,10 +5314,17 @@ main {
   width: 98vw;
   display: flex;
   flex-direction: column;
-  max-height: 90vh;
+  /* Fixed height (not max-height): with a content-driven height the xterm
+     FitAddon grows the modal as the pane repaints, which re-runs fit() and
+     makes the modal oscillate ("vibrating terminal"). A fixed height gives the
+     flex:1 container a stable size, so fit() settles and xterm scrolls
+     internally instead of resizing the modal. */
+  height: 90vh;
 }
 .terminal-modal .modal-header { flex-shrink: 0; }
-#terminalContainer { flex: 1; min-height: 360px; }
+/* min-height:0 lets the flex child actually shrink to the container; overflow
+   hidden stops the xterm screen from pushing the modal taller. */
+#terminalContainer { flex: 1; min-height: 0; overflow: hidden; }
 .xterm { height: 100% !important; }
 
 /* === Docs viewer === */


### PR DESCRIPTION
Two visual bugs reported on the web dashboard (localhost:3420).

## 1. Vibrating terminal modal (agents view)
`.terminal-modal` had only `max-height: 90vh` with no fixed height, so its height was content-driven. The xterm FitAddon grows the modal as the live tmux pane repaints; that re-runs `fit()`, which grows it again -- the modal swells to the cap, snaps back, and loops (visible vibration).

**Fix:** pin the modal to a fixed `height: 90vh`, and `min-height: 0; overflow: hidden` on `#terminalContainer`, so the flex container is stable and xterm scrolls internally instead of resizing the modal.

Verified headless (Playwright): modal height oscillation over ~2s dropped from **125px to 0px**.

## 2. Content sticking out of the modal (agent-detail "Csapat" tab)
The generic `.form-group input { width: 100% }` (meant for text fields) also stretched the auto-delegation checkbox inside its flex label to full width, shoving the adjacent label text past the modal's right edge.

**Fix:** checkbox/radio inputs keep their native size (`width: auto`).

Verified headless: checkbox 13px, label within the modal, nothing overflows.

## Tests
Both fixes guarded by a contract test that reads the real `web/style.css` (`src/__tests__/dashboard-modal-css-contract.test.ts`). `npm run typecheck` and the contract test are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)