### PR TITLE
channels: scope the second orphan-poller reap to the main agent

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -131,9 +131,21 @@ fi
 # env (e.g. telegram@0.0.1). Those pollers carry CLAUDE_PLUGIN_ROOT=.../<provider>
 # instead, so the STATE_DIR grep above never matches and orphans accumulate
 # across restarts -> multiple getUpdates long-polls -> 409 Conflict -> the bot
-# goes silent/flaky. This runs BEFORE the fresh session is spawned, so every
-# matching poller is by definition a stale orphan and safe to kill.
-ORPHAN_PIDS2="$(/bin/ps eww -e 2>/dev/null | awk -v needle="CLAUDE_PLUGIN_ROOT=" -v prov="/${CHANNEL_PROVIDER}" '$0 ~ needle && $0 ~ prov { print $1 }')"
+# goes silent/flaky.
+#
+# Scope to THIS (main) agent only. The tmux server is SHARED across the fleet,
+# and every sub-agent runs its OWN provider poller out of
+# $INSTALL_DIR/agents/<name>/. Those processes carry that agent dir in their
+# environment; the main agent's pollers do not. CLAUDE_PLUGIN_ROOT points at the
+# shared user-level plugin cache for every agent, so it cannot tell main from
+# sub on its own -- without the agents/ exclusion this pass SIGKILLs every live
+# sub-agent poller on a main restart (they would only recover on each
+# sub-agent's own next restart). A main orphan from an old build has no agent
+# dir, so it is still reaped. index() is a literal (non-regex) substring test so
+# an install path with regex metacharacters can't break the exclusion. The var
+# is named `subdir` (not `sub`) because `sub` is a reserved awk function name and
+# BSD/macOS awk syntax-errors on it.
+ORPHAN_PIDS2="$(/bin/ps eww -e 2>/dev/null | awk -v needle="CLAUDE_PLUGIN_ROOT=" -v prov="/${CHANNEL_PROVIDER}" -v subdir="${INSTALL_DIR}/agents/" '$0 ~ needle && $0 ~ prov && index($0, subdir) == 0 { print $1 }')"
 if [ -n "$ORPHAN_PIDS2" ]; then
   # shellcheck disable=SC2086
   /bin/kill -TERM $ORPHAN_PIDS2 2>/dev/null || true

--- a/src/__tests__/channels-reap-scope.test.ts
+++ b/src/__tests__/channels-reap-scope.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const channelsSh = readFileSync(join(REPO_ROOT, 'scripts', 'channels.sh'), 'utf-8')
+
+// The second reap pass in channels.sh kills orphan provider pollers from older
+// plugin builds that carry CLAUDE_PLUGIN_ROOT but no *_STATE_DIR. CLAUDE_PLUGIN_ROOT
+// resolves to the SHARED user-level plugin cache for every agent, so it cannot
+// distinguish the main agent from a sub-agent. The fix scopes the pass to the
+// main agent by excluding any process whose environment references
+// $INSTALL_DIR/agents/<name>/ (where every sub-agent's poller runs). These tests
+// pull the REAL awk program out of channels.sh and run it against fixture
+// `ps eww -e` lines, so a regression to the unscoped form fails here.
+
+const INSTALL_DIR = '/test/install'
+const PROVIDER = 'telegram'
+
+function extractReapAwkProgram(): string {
+  const line = channelsSh.split('\n').find(l => l.includes('ORPHAN_PIDS2=') && l.includes('awk'))
+  if (!line) throw new Error('ORPHAN_PIDS2 awk line not found in channels.sh')
+  const m = line.match(/awk .*?'([^']*)'/)
+  if (!m) throw new Error('could not extract awk program from the ORPHAN_PIDS2 line')
+  return m[1]
+}
+
+function runReapMatcher(psLines: string[]): string[] {
+  const program = extractReapAwkProgram()
+  const out = execSync(
+    `awk -v needle='CLAUDE_PLUGIN_ROOT=' -v prov='/${PROVIDER}' -v subdir='${INSTALL_DIR}/agents/' '${program}'`,
+    { input: psLines.join('\n') + '\n', encoding: 'utf-8' },
+  )
+  return out.split('\n').map(s => s.trim()).filter(Boolean)
+}
+
+// CLAUDE_PLUGIN_ROOT is the shared cache path for main and sub alike. A main
+// orphan carries no agent dir; a sub-agent poller carries $INSTALL_DIR/agents/<name>/.
+const MAIN_ORPHAN_A = '67149 ?? S 0:01 node CLAUDE_PLUGIN_ROOT=/Users/u/.claude/plugins/marketplaces/claude-plugins-official/external_plugins/telegram BOT=x'
+const MAIN_ORPHAN_B = '67154 ?? S 0:01 node CLAUDE_PLUGIN_ROOT=/Users/u/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 BOT=x'
+const SUB_DEV2 = `14513 ?? S 0:01 node CLAUDE_PLUGIN_ROOT=/Users/u/.claude/plugins/marketplaces/claude-plugins-official/external_plugins/telegram TELEGRAM_STATE_DIR=${INSTALL_DIR}/agents/dev2/.claude/channels/telegram`
+const SUB_DEV3 = `28358 ?? S 0:01 node CLAUDE_PLUGIN_ROOT=/Users/u/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 CLAUDE_CONFIG_DIR=${INSTALL_DIR}/agents/dev3/.claude`
+const OTHER_PROVIDER = '99999 ?? S 0:01 node CLAUDE_PLUGIN_ROOT=/Users/u/.claude/plugins/marketplaces/claude-plugins-official/external_plugins/slack'
+const UNRELATED = '88888 ?? S 0:01 node some-other-process --flag'
+
+describe('channels.sh second-pass orphan reap is scoped to the main agent', () => {
+  it('reaps the main agent old-build orphans (no agent dir in env)', () => {
+    expect(runReapMatcher([MAIN_ORPHAN_A, MAIN_ORPHAN_B]).sort()).toEqual(['67149', '67154'])
+  })
+
+  it('never reaps a live sub-agent poller (env carries $INSTALL_DIR/agents/<name>/)', () => {
+    expect(runReapMatcher([SUB_DEV2, SUB_DEV3])).toEqual([])
+  })
+
+  it('selects only the main orphans out of a mixed fleet snapshot', () => {
+    const selected = runReapMatcher([
+      MAIN_ORPHAN_A, SUB_DEV2, SUB_DEV3, MAIN_ORPHAN_B, OTHER_PROVIDER, UNRELATED,
+    ])
+    expect(selected.sort()).toEqual(['67149', '67154'])
+  })
+
+  it('ignores a different provider and non-poller processes', () => {
+    expect(runReapMatcher([OTHER_PROVIDER, UNRELATED])).toEqual([])
+  })
+
+  it('keeps the sub-agent exclusion guard so it cannot revert to the unscoped form', () => {
+    expect(channelsSh).toContain('subdir="${INSTALL_DIR}/agents/"')
+    expect(extractReapAwkProgram()).toContain('index($0, subdir) == 0')
+  })
+})


### PR DESCRIPTION
## Why this matters

`scripts/channels.sh` runs on a main-agent channel restart. Its second orphan-reap pass kills stale provider pollers left by older plugin builds that carry `CLAUDE_PLUGIN_ROOT` but no `*_STATE_DIR`. It matched any process whose environment contained `CLAUDE_PLUGIN_ROOT=` plus the provider slug (e.g. `/telegram`).

The problem: `CLAUDE_PLUGIN_ROOT` resolves to the **shared user-level plugin cache** (`~/.claude/plugins/...`), which is identical for every agent. On a fleet that shares one tmux server, that match hit not only the main agent's own stale orphans but **every live sub-agent poller**. So a single main-channel restart SIGKILLed all of them, and each sub-agent's channel went dark until that sub-agent's own next restart.

This bites the multi-agent + per-agent-channel configuration (a first-class supported setup). A single-agent install is unaffected; an install whose sub-agents have their own provider channels loses all of them on a main restart.

## Change

Scope the second reap pass to the main agent by excluding any process whose environment references `$INSTALL_DIR/agents/<name>/` -- the directory every sub-agent's poller runs from (carried via its `*_STATE_DIR` and the project dir Claude Code sets from the launcher's `cd "${dir}"`). A main-agent orphan from an old build has no agent dir, so it is still reaped.

The exclusion uses a literal `index($0, subdir) == 0` test (not a regex), so an install path containing regex metacharacters cannot break it. The awk variable is named `subdir` rather than `sub` because `sub` is a reserved awk function name that BSD/macOS awk syntax-errors on.

## Scope / compatibility

Single-agent installs are unaffected (no `$INSTALL_DIR/agents/` processes exist, so nothing new is excluded). The fix strictly shrinks the kill set, so it cannot introduce a new false-positive. The first reap pass (STATE_DIR-scoped) and the reap timing (before the new session spawns) are unchanged.

## Test plan

- New test `src/__tests__/channels-reap-scope.test.ts` extracts the real awk program from `channels.sh` and runs it via `execSync` against fixture `ps eww -e` lines, asserting: main orphans are reaped, sub-agent pollers (matched via state dir and config dir) are spared, a different provider and non-poller processes are ignored, plus a regression lock on the scoping guard.
- `npm run typecheck` clean; full `vitest run` green.
- Verified against a live multi-agent fleet: the scoped matcher selects only the main-agent orphans and spares every live sub-agent poller, where the previous unscoped form matched all of them.

## Known limitations

The pre-existing `prov` provider match is a plain substring (`$0 ~ "/telegram"`), so it would also substring-match a hypothetical `/telegramx` elsewhere on an env line. This behavior is unchanged by this PR and is not exploitable in practice (the provider is only ever `telegram`/`slack`/`discord`, none a prefix of another). Anchoring the slug to the `CLAUDE_PLUGIN_ROOT` value is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
