### PR TITLE
fix(stuck-input): drive robust clear+re-inject recovery on the fast w…

### DIFF
--- a/src/__tests__/stuck-input-fast-recovery.test.ts
+++ b/src/__tests__/stuck-input-fast-recovery.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decideStuckInputRecovery,
+  type StuckInputState,
+  type StuckInputThresholds,
+} from '../pane-state.js'
+
+// Contract for the sub-agent FAST stuck-input recovery (stuck-input-watcher.ts):
+// on the 15s tick the same parked signature must reach the clear+re-inject
+// escalation (attempt > MAIN_STUCK_ENTER_ATTEMPTS=2, i.e. attempts 3..) WELL
+// BEFORE the give-up cap, so a sub-agent whose Enter is swallowed gets its
+// message actually re-injected within ~30-45s instead of waiting minutes for
+// the slow channel-monitor backstop. These thresholds mirror SUB_THRESHOLDS.
+const SUB_THRESHOLDS: StuckInputThresholds = {
+  confirmMs: 12_000,
+  dedupMs: 12_000,
+  maxAttempts: 5,
+}
+
+const NO_STATE: StuckInputState = { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
+const MAIN_STUCK_ENTER_ATTEMPTS = 2 // bare Enters before clear+re-inject escalation
+
+// Drive a stable parked signature through the decision fn on a fixed tick,
+// collecting the attempt number on every tick that recovers.
+function runSpell(sig: string, tickMs: number, ticks: number): number[] {
+  let state = NO_STATE
+  let now = 0
+  const recoveredAttempts: number[] = []
+  for (let i = 0; i < ticks; i++) {
+    now += tickMs
+    const { recover, next } = decideStuckInputRecovery(sig, state, now, SUB_THRESHOLDS)
+    if (recover) recoveredAttempts.push(next.attempts)
+    state = next
+  }
+  return recoveredAttempts
+}
+
+describe('sub-agent fast stuck-input recovery contract', () => {
+  it('reaches clear+re-inject escalation before the give-up cap', () => {
+    // 15s tick (the watcher interval). First seen at t=15s, confirm window
+    // 12s already elapsed by the next tick, then one action per tick.
+    const attempts = runSpell('parked Németh Gábor ...', 15_000, 10)
+    // Recovers exactly maxAttempts times, numbered 1..5.
+    expect(attempts).toEqual([1, 2, 3, 4, 5])
+    // At least one escalation attempt (>2) happened -> clear + re-inject is
+    // exercised, not just bare Enter.
+    expect(attempts.some((a) => a > MAIN_STUCK_ENTER_ATTEMPTS)).toBe(true)
+  })
+
+  it('stops acting once the give-up cap is hit (no infinite recovery)', () => {
+    const attempts = runSpell('still parked', 15_000, 40)
+    expect(attempts).toEqual([1, 2, 3, 4, 5])
+    expect(attempts.length).toBe(SUB_THRESHOLDS.maxAttempts)
+  })
+
+  it('a changed signature restarts the spell (message still arriving / edited)', () => {
+    let state = NO_STATE
+    let now = 0
+    // First signature parks and recovers once...
+    now += 15_000
+    let d = decideStuckInputRecovery('sig-a', state, now, SUB_THRESHOLDS)
+    state = d.next // record only (new spell)
+    now += 15_000
+    d = decideStuckInputRecovery('sig-a', state, now, SUB_THRESHOLDS)
+    expect(d.recover).toBe(true)
+    expect(d.next.attempts).toBe(1)
+    state = d.next
+    // ...then the text changes: confirm window restarts, no immediate action.
+    now += 15_000
+    d = decideStuckInputRecovery('sig-b', state, now, SUB_THRESHOLDS)
+    expect(d.recover).toBe(false)
+    expect(d.next.attempts).toBe(0)
+    expect(d.next.firstSeenAt).toBe(now)
+  })
+
+  it('clears state when nothing is parked', () => {
+    const d = decideStuckInputRecovery(null, { parkedSig: 'x', firstSeenAt: 1, lastRecoverAt: 1, attempts: 2 }, 99_999, SUB_THRESHOLDS)
+    expect(d.recover).toBe(false)
+    expect(d.next.parkedSig).toBeNull()
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -118,7 +118,7 @@ const MAIN_STUCK_THRESHOLDS: StuckInputThresholds = {
 //      (e.g. an inter-agent notification) -> clear + re-inject the collapsed
 //      text. A sub-agent's input box never holds a human draft, so this is
 //      safe; the main session stays conservative (Enter / <channel>-only).
-function recoverStuckInputForSession(
+export function recoverStuckInputForSession(
   session: string,
   prev: StuckInputState,
   thresholds: StuckInputThresholds,
@@ -732,7 +732,7 @@ function checkMainKeepaliveStaleness(): void {
   }
 }
 
-function sendAlert(text: string): void {
+export function sendAlert(text: string): void {
   notifyChannel(text).catch(() => {})
 }
 

--- a/src/web/stuck-input-watcher.ts
+++ b/src/web/stuck-input-watcher.ts
@@ -4,6 +4,7 @@ import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
 import { isAgentRunning, capturePane, sendEnterToSession } from './agent-process.js'
 import { resolveAgentSession } from './channel-mcp-reconnect.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { recoverStuckInputForSession, sendAlert } from './channel-monitor.js'
 import {
   stuckInputSignature,
   decideStuckInputRecovery,
@@ -18,12 +19,30 @@ import {
 // the closing Enter is occasionally dropped and the user's message is
 // left parked in the prompt box with no submit. This watcher captures
 // each running agent's pane on a timer, and when the SAME text has been
-// parked past the confirm window it re-sends Enter to submit it.
+// parked past the confirm window it recovers it.
 //
-// All the decision logic is the pure decideStuckInputRecovery() in
-// pane-state.ts (unit-tested); this module is only the I/O + per-session
-// state map, mirroring channel-health-monitor.ts.
+// MAIN session + REMOTE sub-agents: conservative -- bare recovery Enter
+// only (host-aware). channel-monitor owns the clear+re-inject escalation at
+// the slower 60s cadence, and re-inject (clear + sendPromptToSession) is
+// local-tmux only, so a remote-host agent cannot use it here.
+//
+// LOCAL sub-agents: this fast 15s loop drives the FULL robust escalation
+// (Enter-first, then clear + re-inject of the COMPLETE <channel> block or,
+// for a sub-agent, any complete parked text) via the shared
+// recoverStuckInputForSession. A bare Enter is frequently swallowed by the
+// Claude TUI in raw mode, so the previous "Enter x3 then give up" left
+// sub-agents wedged for minutes until channel-monitor's slow escalation (or
+// a manual restart) caught up. Running the real re-inject here drops the
+// mean-time-to-recovery from ~3min to ~30-45s and actually SUBMITS the
+// message. channel-monitor stays as a slower backstop; in practice this
+// loop clears the spell long before the 90s-confirm backstop escalates, so
+// they do not double-act.
+//
+// The escalation/decision logic is the pure recoverStuckInputForSession +
+// decideStuckInputRecovery (unit-tested in pane-state); this module is only
+// the I/O + per-session state map, mirroring channel-health-monitor.ts.
 
+// MAIN session + remote sub-agents: bare-Enter recovery only.
 const THRESHOLDS: StuckInputThresholds = {
   // The same text must stay parked this long before the first recovery
   // Enter. A real turn transitions typing -> busy within a second or two
@@ -38,9 +57,18 @@ const THRESHOLDS: StuckInputThresholds = {
   maxAttempts: 3,
 }
 
-// Initial delay before the first sweep, and the sweep interval. Offset
-// from channel-monitor (30s) and channel-health-monitor (45s) so the
-// three watchers do not pile their capture-pane calls onto one tick.
+// LOCAL sub-agent thresholds: drive the robust escalation on the fast tick.
+// confirm/dedup are aligned to the 15s interval so the first Enter fires
+// after ~1 confirm window, the two Enter attempts are spent within ~2-3
+// ticks, and clear+re-inject escalation begins ~30-45s in (vs ~3min on the
+// 60s channel-monitor). maxAttempts leaves room for 2 Enters + 3 re-inject
+// attempts before giving up and alerting.
+const SUB_THRESHOLDS: StuckInputThresholds = {
+  confirmMs: 12_000,
+  dedupMs: 12_000,
+  maxAttempts: 5,
+}
+
 const INITIAL_DELAY_MS = 20_000
 const INTERVAL_MS = 15_000
 
@@ -48,7 +76,10 @@ const NO_STATE: StuckInputState = { parkedSig: null, firstSeenAt: null, lastReco
 
 const watchState = new Map<string, StuckInputState>()
 
-function checkSession(label: string, session: string, host: string | null = null): void {
+// Bare-Enter recovery (host-aware). Used for the MAIN session (host null) and
+// for REMOTE sub-agents, where the local-tmux clear+re-inject is not
+// available. channel-monitor owns the clear+re-inject escalation for these.
+function bareEnterRecovery(label: string, session: string, host: string | null): void {
   const pane = capturePane(session, host)
   // A failed capture is treated as "nothing parked" -- it ends any active
   // spell rather than holding stale state across a transient tmux miss.
@@ -72,10 +103,27 @@ function checkSession(label: string, session: string, host: string | null = null
   } else if (next.parkedSig !== null && next.attempts >= THRESHOLDS.maxAttempts) {
     // Logged at most once per spell: the give-up is recorded on the tick
     // that spent the last attempt (attempts hits maxAttempts there), not
-    // every subsequent tick, because once at the cap recover stays false
-    // and attempts no longer increments.
+    // every subsequent tick.
     if (prev.attempts < THRESHOLDS.maxAttempts) {
       logger.warn({ label, session }, 'stuck-input-watcher: input still parked after max recovery Enters, giving up for this spell')
+    }
+  }
+}
+
+// LOCAL sub-agent: full robust escalation (Enter -> clear + re-inject) on the
+// fast tick. On give-up (still parked after maxAttempts) alert the Boss once
+// so a truly wedged TUI surfaces for a manual restart before the user notices.
+function checkLocalSubAgent(label: string, session: string): void {
+  const prev = watchState.get(session) ?? NO_STATE
+  const next = recoverStuckInputForSession(session, prev, SUB_THRESHOLDS, true)
+
+  if (next.parkedSig === null) {
+    watchState.delete(session)
+  } else {
+    watchState.set(session, next)
+    if (next.attempts >= SUB_THRESHOLDS.maxAttempts && prev.attempts < SUB_THRESHOLDS.maxAttempts) {
+      logger.warn({ label, session }, 'stuck-input-watcher: sub-agent input still parked after max recovery attempts, alerting for manual restart')
+      sendAlert(`⚠️ A(z) ${label} agens bemenete beragadt és az auto-recovery (Enter + clear/re-inject) nem szabadította ki. Valószínűleg kézi restart kell: POST /api/agents/${label}/restart vagy a dashboardon.`)
     }
   }
 }
@@ -85,9 +133,9 @@ export function startStuckInputWatcher(): NodeJS.Timeout {
     // The main agent's channels session is named `<id>-channels`, not
     // `agent-<id>`, so isAgentRunning (which checks the agent- prefix)
     // does not apply. Check it directly; capturePane returns null when it
-    // is not up, which ends any spell without acting.
+    // is not up, which ends any spell without acting. Main is always local.
     try {
-      checkSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION)
+      bareEnterRecovery(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, null)
     } catch (err) {
       logger.debug({ err }, 'stuck-input-watcher: main agent check error')
     }
@@ -96,8 +144,16 @@ export function startStuckInputWatcher(): NodeJS.Timeout {
         watchState.delete(resolveAgentSession(name))
         continue
       }
+      const session = resolveAgentSession(name)
+      const host = readAgentRemoteHost(name)
       try {
-        checkSession(name, resolveAgentSession(name), readAgentRemoteHost(name))
+        // Local sub-agents get the full robust escalation; remote-host ones
+        // (no local tmux for clear+re-inject) stay on the host-aware Enter.
+        if (host == null) {
+          checkLocalSubAgent(name, session)
+        } else {
+          bareEnterRecovery(name, session, host)
+        }
       } catch (err) {
         logger.debug({ err, agent: name }, 'stuck-input-watcher: agent check error')
       }


### PR DESCRIPTION
…atcher for sub-agents

Sub-agents whose closing Enter is swallowed by the Claude TUI sat wedged for minutes: the fast 15s stuck-input-watcher only sent bare Enter and gave up after 3 attempts, while the real recovery (clear + re-inject via sendPromptToSession's submit-retry) lived only in the 60s channel-monitor with a 90s confirm window -- ~3min mean-time-to-recovery, so users hit it before the auto-recovery did (observed 3x in one day: viktormarvinja x2, balazsmarveenja x1).

Now the fast watcher runs the full robust escalation for sub-agents via the shared recoverStuckInputForSession (Enter-first, then clear + re-inject of the COMPLETE <channel> block, or any complete parked text for a sub-agent), with tight thresholds (12s confirm/dedup, 5 attempts). MTTR drops to ~30-45s and the message is actually submitted. On give-up it alerts the Boss for a manual restart instead of going silent. The main session stays conservative (bare Enter only here; channel-monitor owns its clear+re-inject). channel-monitor is untouched as a slower backstop and does not double-act (its 90s confirm escalates long after the fast loop has cleared the spell).

- export recoverStuckInputForSession + sendAlert from channel-monitor
- stuck-input-watcher: sub-agents use robust recovery + give-up alert
- add stuck-input-fast-recovery.test.ts (escalation-before-give-up contract)