### PR TITLE
feat(dashboard): readable per-agent conversation view from transcript

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -22,6 +22,7 @@ import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
 import { tryHandleAgentTerminal } from './web/routes/agent-terminal.js'
+import { tryHandleAgentConversation } from './web/routes/agent-conversation.js'
 import { tryHandleAgentTaskState } from './web/routes/agent-taskstate.js'
 import { sweepOrphanTaskStates } from './web/agent-taskstate.js'
 import { tryHandleDailyLog } from './web/routes/daily-log.js'
@@ -138,6 +139,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleAgentsSkills(routeCtx)) return
       if (await tryHandleSkills(routeCtx)) return
       if (await tryHandleAgentTerminal(routeCtx)) return
+      if (await tryHandleAgentConversation(routeCtx)) return
       if (await tryHandleAgentTaskState(routeCtx)) return
       if (await tryHandleAgents(routeCtx, WEB_DIR)) return
       if (await tryHandleMarveen(routeCtx, WEB_DIR)) return

--- a/src/web/routes/agent-conversation.ts
+++ b/src/web/routes/agent-conversation.ts
@@ -1,0 +1,155 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { json } from '../http-helpers.js'
+import { agentDir, readAgentClaudeConfigDir } from '../agent-config.js'
+import { projectsDirFor } from '../active-model.js'
+import { isMainChannelsAgent } from '../main-agent.js'
+import { PROJECT_ROOT } from '../../config.js'
+import type { RouteContext } from './types.js'
+
+// Read-only, human-readable conversation view for an agent. The dashboard
+// terminal only mirrors the live tmux pane (no history, and it does not show
+// the full Telegram traffic cleanly). The complete conversation lives in the
+// Claude Code transcript (.jsonl): every inbound channel message, every
+// outbound reply, and every action. We parse the newest session transcript
+// into a chat-style timeline so an operator can actually review what happened
+// -- and, for customer-hosted Marveens, support them. Read-only.
+
+interface Entry {
+  ts: string | null
+  // in  = inbound channel (e.g. Telegram) message from the user
+  // out = outbound message the agent sent back (reply/react/edit)
+  // note = the agent's own narration text for that turn
+  // action = a tool the agent ran (Bash, search, draft, ...)
+  kind: 'in' | 'out' | 'note' | 'action'
+  text: string
+  label?: string
+}
+
+const MAX_TEXT = 6000
+const DEFAULT_LIMIT = 400
+
+function workingDirFor(name: string): string {
+  return isMainChannelsAgent(name) ? PROJECT_ROOT : agentDir(name)
+}
+
+function newestTranscript(name: string): string | null {
+  const configDir = isMainChannelsAgent(name) ? undefined : (readAgentClaudeConfigDir(name) ?? undefined)
+  const dir = projectsDirFor(workingDirFor(name), configDir)
+  try {
+    if (!existsSync(dir)) return null
+    const files = readdirSync(dir)
+      .filter(f => f.endsWith('.jsonl'))
+      .map(f => ({ f, m: statSync(join(dir, f)).mtimeMs }))
+      .sort((a, b) => b.m - a.m)
+    return files.length ? join(dir, files[0].f) : null
+  } catch {
+    return null
+  }
+}
+
+const CHANNEL_RE = /<channel\b[^>]*>([\s\S]*?)<\/channel>/g
+
+function clip(s: string): string {
+  return s.length > MAX_TEXT ? s.slice(0, MAX_TEXT) + ' …' : s
+}
+
+// One-line human label for a non-messaging tool call.
+function actionLabel(name: string, input: Record<string, unknown>): string {
+  const base = name.includes('__') ? name.split('__').pop()! : name
+  const pick = (k: string): string => (typeof input[k] === 'string' ? (input[k] as string) : '')
+  if (name === 'Bash') return `Bash: ${pick('description') || pick('command').slice(0, 80)}`
+  if (name === 'Read') return `Read: ${pick('file_path')}`
+  if (name === 'Write') return `Write: ${pick('file_path')}`
+  if (name === 'Edit') return `Edit: ${pick('file_path')}`
+  if (base.includes('search_gmail')) return `Gmail keresés: ${pick('query')}`
+  if (base.includes('draft_gmail')) return `Gmail draft: ${pick('subject')}`
+  if (base.includes('send_gmail')) return `Email küldés: ${pick('subject')}`
+  if (base.includes('import_to_google_doc')) return `Google Doc: ${pick('file_name')}`
+  if (base.includes('import_to_google_slides')) return `Google Slides: ${pick('file_name')}`
+  if (base === 'WebSearch') return `Web keresés: ${pick('query')}`
+  if (base === 'WebFetch') return `Web lekérés: ${pick('url')}`
+  if (base.includes('download_attachment')) return 'Csatolmány letöltés'
+  return base
+}
+
+// Turn the newest transcript into a flat, chronological, readable timeline.
+function buildTimeline(file: string, limit: number): Entry[] {
+  const entries: Entry[] = []
+  const raw = readFileSync(file, 'utf-8').split('\n')
+  for (const line of raw) {
+    const t = line.trim()
+    if (!t) continue
+    let d: Record<string, unknown>
+    try { d = JSON.parse(t) } catch { continue }
+    const type = d['type']
+    const ts = typeof d['timestamp'] === 'string' ? (d['timestamp'] as string) : null
+    const msg = d['message'] as Record<string, unknown> | undefined
+    if (!msg) continue
+
+    if (type === 'user') {
+      const content = msg['content']
+      const asText = typeof content === 'string' ? content : ''
+      // Only surface real inbound channel messages; skip tool results,
+      // system-reminders and slash-command echoes.
+      if (asText.includes('<channel')) {
+        let m: RegExpExecArray | null
+        CHANNEL_RE.lastIndex = 0
+        while ((m = CHANNEL_RE.exec(asText)) !== null) {
+          const inner = m[1].trim()
+          if (inner) entries.push({ ts, kind: 'in', text: clip(inner) })
+        }
+      }
+      continue
+    }
+
+    if (type === 'assistant') {
+      const content = msg['content']
+      if (!Array.isArray(content)) continue
+      for (const block of content as Array<Record<string, unknown>>) {
+        const bt = block['type']
+        if (bt === 'text') {
+          const txt = typeof block['text'] === 'string' ? (block['text'] as string).trim() : ''
+          if (txt) entries.push({ ts, kind: 'note', text: clip(txt) })
+        } else if (bt === 'tool_use') {
+          const name = typeof block['name'] === 'string' ? (block['name'] as string) : ''
+          const input = (block['input'] as Record<string, unknown>) ?? {}
+          if (name.endsWith('telegram__reply') || name.endsWith('__reply')) {
+            const txt = typeof input['text'] === 'string' ? (input['text'] as string) : ''
+            if (txt) entries.push({ ts, kind: 'out', text: clip(txt), label: 'válasz' })
+          } else if (name.endsWith('telegram__react') || name.endsWith('__react')) {
+            const emoji = typeof input['emoji'] === 'string' ? (input['emoji'] as string) : '?'
+            entries.push({ ts, kind: 'out', text: emoji, label: 'reakció' })
+          } else if (name.endsWith('telegram__edit_message') || name.endsWith('__edit_message')) {
+            const txt = typeof input['text'] === 'string' ? (input['text'] as string) : ''
+            entries.push({ ts, kind: 'out', text: clip(txt), label: 'szerkesztés' })
+          } else {
+            entries.push({ ts, kind: 'action', text: actionLabel(name, input) })
+          }
+        }
+      }
+      continue
+    }
+  }
+  // Keep the most recent `limit` entries, oldest-first.
+  return entries.length > limit ? entries.slice(entries.length - limit) : entries
+}
+
+export async function tryHandleAgentConversation(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method, url } = ctx
+  const match = path.match(/^\/api\/agents\/([^/]+)\/conversation$/)
+  if (!match || method !== 'GET') return false
+  const name = decodeURIComponent(match[1])
+  const limitRaw = Number(url.searchParams.get('limit'))
+  const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 2000) : DEFAULT_LIMIT
+
+  const file = newestTranscript(name)
+  if (!file) { json(res, { agent: name, entries: [], note: 'Nincs még beszélgetés-előzmény ehhez az agenthez.' }); return true }
+  try {
+    const entries = buildTimeline(file, limit)
+    json(res, { agent: name, sessionId: file.split('/').pop()?.replace('.jsonl', '') ?? null, count: entries.length, entries })
+  } catch {
+    json(res, { error: 'A beszélgetés feldolgozása nem sikerült' }, 500)
+  }
+  return true
+}

--- a/web/app.js
+++ b/web/app.js
@@ -1576,6 +1576,10 @@ function renderAgents() {
         <span class="tg-status" title="Online: a fő asszisztens csatornáját a --channels session kezeli, ezért fixen online (nincs külön token-ellenőrzés)."><span class="tg-dot connected"></span>Online</span>
       </div>
       <div class="agent-card-actions">
+        <button class="btn-secondary btn-compact agent-conversation-btn" title="Beszélgetés">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          Beszélgetés
+        </button>
         <button class="btn-secondary btn-compact agent-terminal-btn" title="Terminal">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
           Terminal
@@ -1584,6 +1588,9 @@ function renderAgents() {
     `
     mCard.querySelector('.agent-terminal-btn')?.addEventListener('click', (e) => {
       e.stopPropagation(); openTerminalModal(mainAgentId())
+    })
+    mCard.querySelector('.agent-conversation-btn')?.addEventListener('click', (e) => {
+      e.stopPropagation(); openConversationModal(mainAgentId(), 'Marveen Főnök')
     })
     mCard.addEventListener('click', () => openMarveenDetail())
     agentsGrid.insertBefore(mCard, addBtn)
@@ -1630,6 +1637,10 @@ function renderAgents() {
           <button class="btn-danger btn-compact agent-login-btn" data-phase="start">Bejelentkezés</button>
         </div>` : ''}
       <div class="agent-card-actions">
+        <button class="btn-secondary btn-compact agent-conversation-btn" title="Beszélgetés">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          Beszélgetés
+        </button>
         <button class="btn-secondary btn-compact agent-terminal-btn" title="Terminal">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
           Terminal
@@ -1643,6 +1654,10 @@ function renderAgents() {
     // Terminal button
     card.querySelector('.agent-terminal-btn')?.addEventListener('click', (e) => {
       e.stopPropagation(); openTerminalModal(agent.name)
+    })
+    // Conversation (readable transcript) button
+    card.querySelector('.agent-conversation-btn')?.addEventListener('click', (e) => {
+      e.stopPropagation(); openConversationModal(agent.name, label)
     })
     card.addEventListener('click', () => openAgentDetail(agent.name))
     // Only running agents have a live session to look at, so only they get the
@@ -9687,6 +9702,85 @@ document.getElementById('terminalClose')?.addEventListener('click', () => {
   if (terminalSSE) { terminalSSE.close(); terminalSSE = null }
   if (terminalInstance) { terminalInstance.dispose(); terminalInstance = null }
 })
+
+// === Agent conversation (readable transcript) modal ===
+// Renders the agent's Claude Code transcript as a chat-style timeline: inbound
+// Telegram messages, the agent's replies, and (optionally) its notes/actions.
+// Solves what the raw terminal can't: a readable, searchable review of what
+// actually happened -- also the support view for customer-hosted Marveens.
+let conversationEntries = []
+let conversationAgentName = null
+
+async function openConversationModal(agentName, displayName) {
+  const overlay = document.getElementById('conversationOverlay')
+  const container = document.getElementById('conversationContainer')
+  const title = document.getElementById('conversationModalTitle')
+  if (!overlay || !container) return
+  conversationAgentName = agentName
+  title.textContent = (displayName || agentName) + ' — Beszélgetés'
+  container.innerHTML = '<div class="conversation-empty">Betöltés…</div>'
+  openModal(overlay)
+  await loadConversation()
+}
+
+async function loadConversation() {
+  const container = document.getElementById('conversationContainer')
+  const token = localStorage.getItem('marveen-dashboard-token') || ''
+  try {
+    const r = await fetch(`/api/agents/${encodeURIComponent(conversationAgentName)}/conversation?limit=600`, {
+      headers: { 'Authorization': 'Bearer ' + token },
+    })
+    const d = await r.json()
+    conversationEntries = Array.isArray(d.entries) ? d.entries : []
+    renderConversation()
+  } catch {
+    if (container) container.innerHTML = '<div class="conversation-empty">Nem sikerült betölteni a beszélgetést.</div>'
+  }
+}
+
+function fmtConvTs(ts) {
+  if (!ts) return ''
+  try {
+    return new Date(ts).toLocaleString('hu-HU', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
+  } catch { return '' }
+}
+
+function renderConversation() {
+  const container = document.getElementById('conversationContainer')
+  if (!container) return
+  const q = (document.getElementById('conversationSearch')?.value || '').toLowerCase().trim()
+  const showActions = document.getElementById('conversationShowActions')?.checked
+  let list = conversationEntries
+  if (!showActions) list = list.filter(e => e.kind === 'in' || e.kind === 'out')
+  if (q) list = list.filter(e => (e.text || '').toLowerCase().includes(q))
+  if (!list.length) { container.innerHTML = '<div class="conversation-empty">Nincs megjeleníthető üzenet.</div>'; return }
+  container.innerHTML = list.map(renderConvEntry).join('')
+  container.scrollTop = container.scrollHeight
+}
+
+function renderConvEntry(e) {
+  const ts = fmtConvTs(e.ts)
+  const txt = escapeHtml(e.text || '').replace(/\n/g, '<br>')
+  if (e.kind === 'in') {
+    return `<div class="conv-row conv-in"><div class="conv-bubble"><div class="conv-meta">Telegram be · ${ts}</div><div class="conv-text">${txt}</div></div></div>`
+  }
+  if (e.kind === 'out') {
+    const lbl = escapeHtml(e.label || 'válasz')
+    return `<div class="conv-row conv-out"><div class="conv-bubble"><div class="conv-meta">${lbl} · ${ts}</div><div class="conv-text">${txt}</div></div></div>`
+  }
+  if (e.kind === 'note') {
+    return `<div class="conv-row conv-note"><div class="conv-note-text">📝 ${txt}</div></div>`
+  }
+  return `<div class="conv-row conv-action"><div class="conv-action-text">⚙ ${txt}<span class="conv-action-ts">${ts}</span></div></div>`
+}
+
+document.getElementById('conversationClose')?.addEventListener('click', () => {
+  const overlay = document.getElementById('conversationOverlay')
+  if (overlay) closeModal(overlay)
+})
+document.getElementById('conversationSearch')?.addEventListener('input', () => renderConversation())
+document.getElementById('conversationShowActions')?.addEventListener('change', () => renderConversation())
+document.getElementById('conversationRefresh')?.addEventListener('click', () => loadConversation())
 ;(() => {
   function routeFromHash() {
     let pageId = decodeURIComponent((location.hash || '').replace(/^#/, ''))

--- a/web/index.html
+++ b/web/index.html
@@ -2216,6 +2216,22 @@
       <div id="terminalContainer" style="background:#1a1a1a;padding:8px;border-radius:0 0 8px 8px;flex:1;min-height:360px;"></div>
     </div>
   </div>
+
+  <!-- Conversation (readable transcript) modal -->
+  <div class="modal-overlay" id="conversationOverlay">
+    <div class="modal conversation-modal">
+      <div class="modal-header">
+        <h2 id="conversationModalTitle">Beszélgetés</h2>
+        <button class="modal-close" id="conversationClose">&times;</button>
+      </div>
+      <div class="conversation-toolbar">
+        <input type="text" id="conversationSearch" placeholder="Keresés a beszélgetésben…" autocomplete="off">
+        <label class="conversation-filter"><input type="checkbox" id="conversationShowActions"> Műveletek/jegyzetek mutatása</label>
+        <button class="btn-secondary btn-compact" id="conversationRefresh">Frissítés</button>
+      </div>
+      <div id="conversationContainer" class="conversation-container"></div>
+    </div>
+  </div>
   <script src="/app.js"></script>
 </body>
 </html>

--- a/web/style.css
+++ b/web/style.css
@@ -5413,3 +5413,24 @@ main {
   .docs-layout { flex-direction: column; }
   .docs-list { flex-basis: auto; width: 100%; position: static; }
 }
+
+/* === Agent conversation (readable transcript) modal === */
+.conversation-modal { width: min(820px, 94vw); max-height: 88vh; display: flex; flex-direction: column; }
+.conversation-toolbar { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-bottom: 1px solid var(--border, #2a2a2a); flex-wrap: wrap; }
+.conversation-toolbar #conversationSearch { flex: 1; min-width: 160px; padding: 7px 10px; border-radius: 6px; border: 1px solid var(--border, #333); background: var(--bg-input, #1c1c1c); color: inherit; }
+.conversation-filter { display: flex; align-items: center; gap: 5px; font-size: 12px; opacity: .85; white-space: nowrap; }
+.conversation-container { flex: 1; overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 8px; background: #141414; border-radius: 0 0 8px 8px; min-height: 320px; }
+.conversation-empty { opacity: .6; text-align: center; padding: 30px; }
+.conv-row { display: flex; }
+.conv-row.conv-in { justify-content: flex-start; }
+.conv-row.conv-out { justify-content: flex-end; }
+.conv-bubble { max-width: 78%; padding: 8px 12px; border-radius: 12px; font-size: 13.5px; line-height: 1.45; }
+.conv-in .conv-bubble { background: #26323d; border-bottom-left-radius: 3px; }
+.conv-out .conv-bubble { background: #1f4030; border-bottom-right-radius: 3px; }
+.conv-meta { font-size: 10.5px; opacity: .6; margin-bottom: 3px; }
+.conv-text { white-space: normal; word-break: break-word; }
+.conv-row.conv-note { justify-content: center; }
+.conv-note-text { font-size: 12px; opacity: .55; font-style: italic; max-width: 88%; }
+.conv-row.conv-action { justify-content: flex-start; }
+.conv-action-text { font-size: 11.5px; opacity: .5; font-family: 'JetBrains Mono', monospace; display: flex; gap: 8px; align-items: baseline; }
+.conv-action-ts { opacity: .6; font-size: 10px; }


### PR DESCRIPTION
The per-agent terminal only mirrors the live tmux pane: no history, and it does not show the full Telegram traffic cleanly, so it is hard to review what an agent actually did. This adds a 'Beszélgetés' view that parses the agent's Claude Code transcript (.jsonl) into a chat-style timeline.

- backend: GET /api/agents/<name>/conversation parses the newest session transcript into inbound channel messages, outbound replies/reactions/edits, the agent's notes, and tool actions (read-only); works for sub-agents and the main channels agent
- frontend: a 'Beszélgetés' button + modal per agent card, chat-style render (Telegram in/out as bubbles, notes/actions togglable), with text search

This is also the support view for customer-hosted Marveens: an operator can read back what happened without deciphering the raw terminal.