### PR TITLE
feat(agents): persona-model fit analysis with runtime signals

### DIFF
--- a/docs/agent-fleet.md
+++ b/docs/agent-fleet.md
@@ -109,3 +109,68 @@ Ha azt akarod, hogy a távoli ügynök a flotta personáját vigye, tedd azokat 
 ### Delegálási elv
 
 Egyértelmű szerep-feladatnál az orchestrator magától delegál (nem kérdez minden lépésnél). A feladat kanban-kártyán fut (lásd [kanban](kanban.md)), az `assignee` a felelős ügynök. Az asset-előállító ügynökök (pl. videó) a végeredményt közvetlenül a felhasználó csatornájára küldik.
+
+---
+
+## 🔍 Persona-modell megfelelőség elemzés
+
+> Minden ügynökhöz hozzárendelt modell **elemzésre és optimalizálásra alkalmas** a tényleges terhelési jelek alapján.
+
+### Mi ez?
+
+Az Ügynökök képernyőn elérhető **"Model javaslat"** gomb kiértékeli, hogy az egyes agensekhez rendelt Claude-modell összhangban van-e a persona szerepével és a mért terhelési mutatókkal. Az elemzés eredménye:
+
+- Megerősítés ("a jelenlegi modell megfelelő"), vagy
+- Modellváltási javaslat indoklással (pl. "ez az ágens egyszerű, rövid feladatokat végez -- Haiku elegendő és olcsóbb")
+
+Ha van olyan ágens, amelynél váltás javasolt, a rendszer rákérdez: kerüljön-e kanban-kártya a változtatáshoz.
+
+### Mikor érdemes futtatni?
+
+- Új ágens létrehozásakor (az alapértelmezett modell általános, nem persona-specifikus)
+- A flotta bővítése vagy átszervezése után
+- Ha a token-fogyasztás (lásd [Token Usage](token-usage.md)) meglepően magas egy ágenseknél
+
+### Mért jelek (AgentSignals)
+
+Az elemzés öt TIER-1 jelzőből dolgozik -- ezeket a rendszer az ügynök tényleges tevékenységéből gyűjti:
+
+| Mező | Leírás |
+|------|--------|
+| `tokenAvgInputPerCall` | Átlagos bemeneti token/hívás |
+| `kanbanOpenCount` | Nyitott kanban-kártyák száma |
+| `kanbanUrgentCount` | Urgent prioritású kártyák száma |
+| `scheduledFreqPerDay` | Ütemezett feladatok napi gyakorisága |
+| `mcpServerCount` | Bekötött MCP-szerverek száma |
+
+### Küszöbök és hatásuk
+
+| Feltétel | Hatás |
+|----------|-------|
+| `tokenAvgInputPerCall > 10 000` | +1 pont Opus irányba (nagy kontextus-igény) |
+| `mcpServerCount >= 4` | +1 pont Opus irányba (mély integráció) |
+| `kanbanUrgentCount >= 2` | +1 pont Opus irányba (magas terhelés, üzleti kritikus) |
+| `scheduledFreqPerDay >= 10` | +1 pont Haiku irányba (ismétlődő, egyszerű feladatok) |
+
+### Javaslat-szöveg struktúrája
+
+Minden ágenshez generált szöveg hat szekcióból áll:
+
+1. **Jelenlegi modell** -- az aktuálisan beállított modell neve
+2. **Megfigyelt használat** -- token-fogyasztás, kanban-terhelés, ütemezési frekvencia, integráció-mélység
+3. **Szempont-értékelés** -- ✅ / ⚠️ / ❌ jelölésekkel az egyes jelek értékelése
+4. **Ajánlás** -- javasolt modell + a két legmeghatározóbb szempont kiemelve
+5. **Becsült költséghatás** -- a modellváltás várható token-költség-változása
+6. **Bizonytalanság** -- adathiány vagy alacsony mintaszám esetén jelzés
+
+### API
+
+```
+POST /api/agents/model-suggest     # összes agensre lefuttatja az elemzést
+```
+
+Válasz: ágensenként `{ agent, currentModel, suggestedModel, reason, changeAdvised }`.
+
+### Kanban integráció
+
+Ha `changeAdvised: true` bármely agensnél, és a felhasználó megerősíti, a rendszer automatikusan kanban-kártyát hoz létre az érintett ügynökhöz (`assignee: marveen`, státusz: `planned`).

--- a/src/__tests__/model-suggest.test.ts
+++ b/src/__tests__/model-suggest.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+import { classifyPersona, suggestForAgent } from '../web/model-suggest.js'
+
+describe('classifyPersona', () => {
+  it('suggests Opus for an architect persona', () => {
+    const text = 'Te vagy a fleet IT rendszerarchitektje. Elosztott rendszerek, mikroszolgáltatás-architektúrák, komplex döntések.'
+    const result = classifyPersona(text)
+    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+  })
+
+  it('suggests Haiku for a fitness coach persona', () => {
+    const text = 'A neved Peter. Te vagy a fleet sportedzője. Edzés, fitness, futás, kerékpár, úszás -- rövid válaszok.'
+    const result = classifyPersona(text)
+    expect(result.suggestedModel).toBe('claude-haiku-4-5-20251001')
+  })
+
+  it('suggests Haiku for an accounting persona', () => {
+    const text = 'Pénzügyi szakember vagy. Számvitel, könyvelés, könyvelő feladatok, adminisztráció.'
+    const result = classifyPersona(text)
+    expect(result.suggestedModel).toBe('claude-haiku-4-5-20251001')
+  })
+
+  it('suggests Sonnet as default for a general backend dev', () => {
+    const text = 'Senior backend fejlesztő vagy. REST API, adatbázis, integrációk, tesztelés.'
+    const result = classifyPersona(text)
+    expect(result.suggestedModel).toBe('claude-sonnet-4-6')
+  })
+
+  it('overrides to Opus when contextTokens > 150k regardless of persona', () => {
+    const text = 'Egyszerű feladatok, rövid válaszok, sport, edzés.'
+    const result = classifyPersona(text, 160_000)
+    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.reason).toMatch(/kontextus/)
+  })
+
+  it('does not suggest Haiku when fewer than 2 keyword hits', () => {
+    const text = 'Általános asszisztens. Edzés az egyik feladat.'
+    const result = classifyPersona(text)
+    // Only 1 haiku keyword hit -- should fall back to Sonnet
+    expect(result.suggestedModel).toBe('claude-sonnet-4-6')
+  })
+})
+
+describe('suggestForAgent -- base (no signals)', () => {
+  it('sets changeAdvised=false when current model matches suggestion', () => {
+    const text = 'Senior backend fejlesztő, REST API, adatbázis.'
+    const result = suggestForAgent('zack', 'claude-sonnet-4-6', text)
+    expect(result.changeAdvised).toBe(false)
+    expect(result.agent).toBe('zack')
+  })
+
+  it('sets changeAdvised=true when models differ', () => {
+    const text = 'IT architekt. Komplex elosztott rendszerterv, mikroszolgáltatás, stratégiai döntések.'
+    const result = suggestForAgent('rick', 'claude-sonnet-4-6', text)
+    expect(result.changeAdvised).toBe(true)
+    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+  })
+
+  it('normalises [1m] suffix for comparison', () => {
+    const text = 'IT architekt. Komplex elosztott rendszerterv, mikroszolgáltatás, stratégiai döntések.'
+    const result = suggestForAgent('rick', 'claude-opus-4-8[1m]', text)
+    expect(result.changeAdvised).toBe(false)
+  })
+})
+
+describe('suggestForAgent -- AgentSignals thresholds', () => {
+  const neutralPersona = 'Általános asszisztens vagy.'
+
+  it('tokenAvgInputPerCall > 10K alone adds 1 opus signal point (below threshold without persona hits)', () => {
+    // 1 signal hit alone is not enough to push to Opus (need >=2 total)
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', neutralPersona, 0, {
+      tokenAvgInputPerCall: 15_000,
+    })
+    expect(result.suggestedModel).toBe('claude-sonnet-4-6')
+  })
+
+  it('tokenAvgInputPerCall > 10K + mcpServerCount >= 4 pushes to Opus (2 signal hits)', () => {
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', neutralPersona, 0, {
+      tokenAvgInputPerCall: 15_000,
+      mcpServerCount: 5,
+    })
+    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.changeAdvised).toBe(true)
+  })
+
+  it('mcpServerCount >= 4 + kanbanUrgentCount >= 2 pushes to Opus (2 signal hits)', () => {
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', neutralPersona, 0, {
+      mcpServerCount: 4,
+      kanbanUrgentCount: 3,
+    })
+    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+  })
+
+  it('scheduledFreqPerDay >= 10 alone adds 1 haiku signal point (not enough without persona)', () => {
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', neutralPersona, 0, {
+      scheduledFreqPerDay: 96,
+    })
+    expect(result.suggestedModel).toBe('claude-sonnet-4-6')
+  })
+
+  it('scheduledFreqPerDay >= 10 + haiku persona keywords pushes to Haiku', () => {
+    const haikuPersona = 'Sport, edzés, futás, kerékpár, tréner.'
+    const result = suggestForAgent('peter', 'claude-sonnet-4-6', haikuPersona, 0, {
+      scheduledFreqPerDay: 48,
+    })
+    expect(result.suggestedModel).toBe('claude-haiku-4-5-20251001')
+  })
+
+  it('opus signal hits block Haiku even with >= 2 haiku keyword hits', () => {
+    // haiku persona + 1 haiku signal + 2 opus signals -> Opus wins
+    const haikuPersona = 'Sport, edzés, fitness, edző -- rövid feladatok.'
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', haikuPersona, 0, {
+      scheduledFreqPerDay: 48,   // +1 haiku signal
+      mcpServerCount: 5,          // +1 opus signal
+      kanbanUrgentCount: 2,       // +1 opus signal
+    })
+    // totalOpus=2 (signals) > 0, so Haiku condition fails; totalOpus>=2 -> Opus
+    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+  })
+
+  it('context override (>150K) wins over all signals', () => {
+    const result = suggestForAgent('x', 'claude-haiku-4-5-20251001', neutralPersona, 200_000, {
+      scheduledFreqPerDay: 200,
+      kanbanOpenCount: 0,
+    })
+    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.changeAdvised).toBe(true)
+  })
+
+  it('mcpServerCount below threshold (3) does not add opus signal point', () => {
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', neutralPersona, 0, {
+      mcpServerCount: 3,
+    })
+    expect(result.suggestedModel).toBe('claude-sonnet-4-6')
+  })
+
+  it('kanbanUrgentCount below threshold (1) does not add opus signal point', () => {
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', neutralPersona, 0, {
+      kanbanUrgentCount: 1,
+    })
+    expect(result.suggestedModel).toBe('claude-sonnet-4-6')
+  })
+
+  it('tokenAvgInputPerCall at threshold boundary (exactly 10K) does not trigger', () => {
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', neutralPersona, 0, {
+      tokenAvgInputPerCall: 10_000,
+    })
+    expect(result.suggestedModel).toBe('claude-sonnet-4-6')
+  })
+})
+
+describe('suggestForAgent -- reason structure (6 sections)', () => {
+  it('reason contains all 6 sections when signals provided', () => {
+    const text = 'IT architekt. Komplex elosztott rendszerterv, mikroszolgáltatás, stratégiai döntések.'
+    const result = suggestForAgent('rick', 'claude-sonnet-4-6', text, 0, {
+      tokenAvgInputPerCall: 12_000,
+      kanbanOpenCount: 3,
+      kanbanUrgentCount: 2,
+      scheduledFreqPerDay: 2,
+      mcpServerCount: 6,
+    })
+    expect(result.reason).toMatch(/Jelenlegi modell/)
+    expect(result.reason).toMatch(/Megfigyelt használat/)
+    expect(result.reason).toMatch(/Szempont-értékelés/)
+    expect(result.reason).toMatch(/Ajánlás/)
+    expect(result.reason).toMatch(/Becsült költséghatás/)
+    expect(result.reason).toMatch(/Bizonytalanság/)
+  })
+
+  it('reason section 6 lists missing signals as uncertainty', () => {
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', 'Általános.', 0, {})
+    expect(result.reason).toMatch(/token-adat hiányzik/)
+    expect(result.reason).toMatch(/kanban-adat hiányzik/)
+    expect(result.reason).toMatch(/ütemezési adat hiányzik/)
+    expect(result.reason).toMatch(/MCP-konfig hiányzik/)
+  })
+
+  it('reason section 6 confirms full coverage when all signals present', () => {
+    const result = suggestForAgent('x', 'claude-sonnet-4-6', 'Általános.', 0, {
+      tokenAvgInputPerCall: 5_000,
+      kanbanOpenCount: 1,
+      kanbanUrgentCount: 0,
+      scheduledFreqPerDay: 3,
+      mcpServerCount: 2,
+    })
+    expect(result.reason).toMatch(/minden szempont adattal alátámasztott/)
+  })
+
+  it('cost section shows cheaper direction when switching to Haiku', () => {
+    const haikuPersona = 'Sport, edzés, futás, kerékpár, úszás, tréner.'
+    const result = suggestForAgent('peter', 'claude-opus-4-8[1m]', haikuPersona, 0, {
+      scheduledFreqPerDay: 48,
+      kanbanOpenCount: 0,
+      kanbanUrgentCount: 0,
+      mcpServerCount: 1,
+      tokenAvgInputPerCall: 500,
+    })
+    expect(result.suggestedModel).toBe('claude-haiku-4-5-20251001')
+    expect(result.reason).toMatch(/olcsóbb/)
+  })
+})

--- a/src/web/model-suggest.ts
+++ b/src/web/model-suggest.ts
@@ -1,0 +1,332 @@
+// Pure, side-effect-free persona→model classifier. Imported by the route and
+// by unit tests. No fs, no network, no db -- all I/O happens in the caller.
+
+export type ModelId =
+  | 'claude-haiku-4-5-20251001'
+  | 'claude-sonnet-4-6'
+  | 'claude-opus-4-8[1m]'
+  | 'claude-fable-5'
+  | string
+
+export interface ModelSuggestion {
+  suggestedModel: ModelId
+  reason: string
+  changeAdvised: boolean
+}
+
+export interface AgentSuggestionResult {
+  agent: string
+  currentModel: ModelId
+  suggestedModel: ModelId
+  reason: string
+  changeAdvised: boolean
+}
+
+/**
+ * Runtime signals collected by the route layer (I/O-free here).
+ * Every field is optional so the classifier degrades gracefully when
+ * an agent has no history yet.
+ */
+export interface AgentSignals {
+  /** token_usage, last 30 days: totalInput / totalCalls */
+  tokenAvgInputPerCall?: number
+  /** kanban_cards WHERE assignee=name AND archived_at IS NULL */
+  kanbanOpenCount?: number
+  /** subset of kanbanOpenCount where priority IN ('urgent','high') */
+  kanbanUrgentCount?: number
+  /** estimated scheduled-task executions per day (cron-derived) */
+  scheduledFreqPerDay?: number
+  /** .mcp.json mcpServers key count */
+  mcpServerCount?: number
+}
+
+// Keyword sets keyed by suggested model tier.
+// Match against lowercased persona text (CLAUDE.md + SOUL.md concatenated).
+const OPUS_KEYWORDS = [
+  'architekt', 'architecture', 'architect',
+  'rendszerterv', 'system design', 'elosztott', 'distributed',
+  'mikroszolgáltatás', 'microservice',
+  'komplex', 'complex', 'összetett',
+  'koordinál', 'orchestrat', 'stratégi',
+  'dönt', 'decision', 'vezető', 'leader',
+  'multi.step', 'agentic', 'multi-agent',
+  'senior',
+]
+
+const HAIKU_KEYWORDS = [
+  'sport', 'edzés', 'edző', 'fitness', 'tréner', 'trainer',
+  'futás', 'kerékpár', 'úszás', 'atlétika', 'zwift', 'garmin',
+  'számvitel', 'könyvelés', 'könyvelő', 'pénzügyi adminisztráció',
+  'accounting', 'bookkeeping',
+  'rövid válasz', 'tömör', 'egyszerű feladat',
+]
+
+// Approximate input-token cost in USD per 1M tokens (mid-2026 pricing).
+const MODEL_COST_PER_M: Record<string, number> = {
+  'claude-opus-4-8': 15,
+  'claude-fable-5': 15,
+  'claude-sonnet-4-6': 3,
+  'claude-haiku-4-5': 0.80,
+}
+
+function countKeywordHits(text: string, keywords: string[]): number {
+  const lower = text.toLowerCase()
+  return keywords.filter(kw => {
+    // Support simple regex-like dot wildcard used in OPUS_KEYWORDS
+    const pattern = kw.replace('.', '.')
+    return lower.includes(pattern) || new RegExp(pattern).test(lower)
+  }).length
+}
+
+function modelCostPerM(model: string): number {
+  const base = model.replace(/\[.*\]$/, '').trim()
+  for (const [prefix, cost] of Object.entries(MODEL_COST_PER_M)) {
+    if (base.startsWith(prefix)) return cost
+  }
+  return 3
+}
+
+function normalize(m: string): string {
+  return m.replace(/\[.*\]$/, '').trim()
+}
+
+function buildReason(
+  currentModel: string,
+  suggestedModel: string,
+  contextTokens: number,
+  opusKeyHits: number,
+  haikuKeyHits: number,
+  opusSignalHits: number,
+  haikuSignalHits: number,
+  signals: AgentSignals | undefined,
+  changeAdvised: boolean,
+  contextOverride: boolean,
+): string {
+  const s = signals ?? {}
+  const lines: string[] = []
+
+  // Section 1: Jelenlegi állapot
+  const verdict = changeAdvised ? 'váltás javasolt' : 'megfelelő'
+  lines.push(`Jelenlegi modell: ${currentModel} | Javaslat: ${suggestedModel} (${verdict})`)
+  lines.push('')
+
+  // Section 2: Megfigyelt használat
+  lines.push('Megfigyelt használat:')
+  const tokenStr = s.tokenAvgInputPerCall !== undefined
+    ? `${(s.tokenAvgInputPerCall / 1000).toFixed(1)}K token/hívás (30 nap átlag)`
+    : 'nincs adat'
+  const kanbanStr = s.kanbanOpenCount !== undefined
+    ? `${s.kanbanOpenCount} aktív kártya${s.kanbanUrgentCount ? `, ebből ${s.kanbanUrgentCount} sürgős/magas` : ''}`
+    : 'nincs adat'
+  const schedStr = s.scheduledFreqPerDay !== undefined
+    ? `~${Math.round(s.scheduledFreqPerDay)}x/nap`
+    : 'nincs adat'
+  const mcpStr = s.mcpServerCount !== undefined
+    ? `${s.mcpServerCount} MCP szerver`
+    : 'nincs adat'
+  lines.push(`  Token-fogyasztás: ${tokenStr}`)
+  lines.push(`  Kanban-terhelés: ${kanbanStr}`)
+  lines.push(`  Ütemezési frekvencia: ${schedStr}`)
+  lines.push(`  Integráció-mélység: ${mcpStr}`)
+  lines.push('')
+
+  // Section 3: Szempont-értékelés
+  lines.push('Szempont-értékelés:')
+
+  const personaIcon = opusKeyHits >= 2 ? '❌' : haikuKeyHits >= 2 ? '✅' : '⚠️'
+  const personaDesc = opusKeyHits >= 2
+    ? `Opus-jellegű (${opusKeyHits} opus-jelző, ${haikuKeyHits} haiku-jelző)`
+    : haikuKeyHits >= 2
+      ? `Haiku-elegendő (${haikuKeyHits} haiku-jelző, ${opusKeyHits} opus-jelző)`
+      : `Általános (${opusKeyHits} opus-jelző, ${haikuKeyHits} haiku-jelző)`
+  lines.push(`  Persona komplexitás: ${personaIcon} ${personaDesc}`)
+
+  const tokenIcon = s.tokenAvgInputPerCall === undefined ? '⚠️'
+    : s.tokenAvgInputPerCall > 10_000 ? '❌'
+    : s.tokenAvgInputPerCall > 3_000 ? '⚠️'
+    : '✅'
+  const tokenDesc = s.tokenAvgInputPerCall === undefined ? 'nincs adat'
+    : s.tokenAvgInputPerCall > 10_000 ? 'magas -- komplex, hosszú kontextus'
+    : s.tokenAvgInputPerCall > 3_000 ? 'közepes'
+    : 'alacsony'
+  lines.push(`  Token-fogyasztás: ${tokenIcon} ${tokenDesc}`)
+
+  const kanbanIcon = s.kanbanUrgentCount === undefined ? '⚠️'
+    : s.kanbanUrgentCount >= 2 ? '❌'
+    : (s.kanbanOpenCount ?? 0) === 0 ? '✅'
+    : '⚠️'
+  const kanbanDesc = s.kanbanUrgentCount === undefined ? 'nincs adat'
+    : s.kanbanUrgentCount >= 2 ? `${s.kanbanUrgentCount} sürgős/magas prioritású feladat`
+    : (s.kanbanOpenCount ?? 0) === 0 ? 'nincs aktív feladat'
+    : 'normál terhelés'
+  lines.push(`  Kanban-terhelés: ${kanbanIcon} ${kanbanDesc}`)
+
+  const schedIcon = s.scheduledFreqPerDay === undefined ? '⚠️'
+    : s.scheduledFreqPerDay >= 10 ? '✅'
+    : '⚠️'
+  const schedDesc = s.scheduledFreqPerDay === undefined ? 'nincs adat'
+    : s.scheduledFreqPerDay >= 10 ? `sűrű heartbeat (${Math.round(s.scheduledFreqPerDay)}x/nap) -- Haiku elegendő`
+    : `ritka/közepes (${Math.round(s.scheduledFreqPerDay ?? 0)}x/nap)`
+  lines.push(`  Ütemezési frekvencia: ${schedIcon} ${schedDesc}`)
+
+  const mcpIcon = s.mcpServerCount === undefined ? '⚠️'
+    : s.mcpServerCount >= 4 ? '❌'
+    : s.mcpServerCount >= 2 ? '⚠️'
+    : '✅'
+  const mcpDesc = s.mcpServerCount === undefined ? 'nincs adat'
+    : s.mcpServerCount >= 4 ? `${s.mcpServerCount} MCP szerver -- gazdag tool-chain`
+    : s.mcpServerCount >= 2 ? `${s.mcpServerCount} MCP szerver`
+    : `${s.mcpServerCount ?? 0} MCP szerver -- minimális integráció`
+  lines.push(`  Integráció-mélység: ${mcpIcon} ${mcpDesc}`)
+  lines.push('')
+
+  // Section 4: Ajánlás + 2 fő szempont
+  const topReasons: string[] = []
+  if (contextOverride) {
+    topReasons.push(`nagy session-kontextus (${Math.round(contextTokens / 1000)}K token)`)
+  } else {
+    if (opusKeyHits >= 2) topReasons.push(`persona ${opusKeyHits} opus-jelzőt tartalmaz`)
+    if ((s.tokenAvgInputPerCall ?? 0) > 10_000) topReasons.push(`magas token-fogyasztás (${(s.tokenAvgInputPerCall! / 1000).toFixed(1)}K/hívás)`)
+    if ((s.mcpServerCount ?? 0) >= 4) topReasons.push(`${s.mcpServerCount} MCP integráció`)
+    if ((s.kanbanUrgentCount ?? 0) >= 2) topReasons.push(`${s.kanbanUrgentCount} sürgős/magas feladat`)
+    if (haikuKeyHits >= 2) topReasons.push(`persona ${haikuKeyHits} haiku-jelzőt tartalmaz`)
+    if ((s.scheduledFreqPerDay ?? 0) >= 10) topReasons.push(`sűrű heartbeat (${Math.round(s.scheduledFreqPerDay!)}x/nap)`)
+  }
+  const reasonText = topReasons.slice(0, 2).join('; ') || 'általános szempont alapján'
+  lines.push(`Ajánlás: ${suggestedModel} -- ${reasonText}.`)
+  lines.push('')
+
+  // Section 5: Becsült költséghatás
+  const currentCost = modelCostPerM(currentModel)
+  const suggestedCost = modelCostPerM(suggestedModel)
+  if (currentCost !== suggestedCost) {
+    const pct = Math.round((suggestedCost / currentCost - 1) * 100)
+    const dir = pct > 0 ? `+${pct}% drágább` : `${Math.abs(pct)}% olcsóbb`
+    lines.push(`Becsült költséghatás: $${currentCost}/M → $${suggestedCost}/M input token (${dir}).`)
+  } else {
+    lines.push(`Becsült költséghatás: azonos árszint ($${currentCost}/M input token).`)
+  }
+  lines.push('')
+
+  // Section 6: Bizonytalanság
+  const unknowns: string[] = []
+  if (s.tokenAvgInputPerCall === undefined) unknowns.push('token-adat hiányzik')
+  if (s.kanbanOpenCount === undefined) unknowns.push('kanban-adat hiányzik')
+  if (s.scheduledFreqPerDay === undefined) unknowns.push('ütemezési adat hiányzik')
+  if (s.mcpServerCount === undefined) unknowns.push('MCP-konfig hiányzik')
+  lines.push(unknowns.length > 0
+    ? `Bizonytalanság: ${unknowns.join('; ')}.`
+    : 'Bizonytalanság: minden szempont adattal alátámasztott.')
+
+  return lines.join('\n')
+}
+
+/**
+ * Classify a persona into a model tier based on the persona text and
+ * optional context-window usage. Deterministic and side-effect-free.
+ *
+ * @param personaText  Concatenated CLAUDE.md + SOUL.md content (or either)
+ * @param contextTokens  Current session context size (0 = unknown / not running)
+ */
+export function classifyPersona(
+  personaText: string,
+  contextTokens = 0,
+): ModelSuggestion {
+  const opusHits = countKeywordHits(personaText, OPUS_KEYWORDS)
+  const haikuHits = countKeywordHits(personaText, HAIKU_KEYWORDS)
+
+  // Context-window override: very large sessions always need Opus
+  if (contextTokens > 150_000) {
+    return {
+      suggestedModel: 'claude-opus-4-8[1m]',
+      reason: `Nagy session-kontextus (${Math.round(contextTokens / 1000)}K token) -- Opus 4.8 ajánlott a hosszú memóriakezeléshez.`,
+      changeAdvised: true,
+    }
+  }
+
+  if (opusHits >= 2) {
+    return {
+      suggestedModel: 'claude-opus-4-8[1m]',
+      reason: `A persona architektúra/koordináció/komplex feladatokra utal (${opusHits} egyező jelző) -- Opus 4.8 ajánlott.`,
+      changeAdvised: true,
+    }
+  }
+
+  if (haikuHits >= 2 && opusHits === 0) {
+    return {
+      suggestedModel: 'claude-haiku-4-5-20251001',
+      reason: `A persona rövid, ismétlődő vagy fizikai/adminisztratív feladatokra utal (${haikuHits} egyező jelző) -- Haiku 4.5 elegendő és olcsóbb.`,
+      changeAdvised: true,
+    }
+  }
+
+  // Default: Sonnet is the balanced general-purpose choice
+  return {
+    suggestedModel: 'claude-sonnet-4-6',
+    reason: 'Általános célú ágens -- Sonnet 4.6 ajánlott (egyensúly minőség és sebesség között).',
+    changeAdvised: true, // caller compares to currentModel to decide final changeAdvised
+  }
+}
+
+/**
+ * Full multi-signal suggestion for a single agent.
+ * classifyPersona handles persona keywords; signals add runtime observations.
+ * All I/O (token queries, DB, filesystem) happens in the caller -- this stays pure.
+ */
+export function suggestForAgent(
+  agentName: string,
+  currentModel: ModelId,
+  personaText: string,
+  contextTokens = 0,
+  signals?: AgentSignals,
+): AgentSuggestionResult {
+  const s = signals ?? {}
+
+  // Context-window override takes priority over everything
+  const contextOverride = contextTokens > 150_000
+  if (contextOverride) {
+    const suggestedModel = 'claude-opus-4-8[1m]'
+    const changeAdvised = normalize(suggestedModel) !== normalize(currentModel)
+    return {
+      agent: agentName,
+      currentModel,
+      suggestedModel,
+      reason: buildReason(currentModel, suggestedModel, contextTokens, 0, 0, 0, 0, s, changeAdvised, true),
+      changeAdvised,
+    }
+  }
+
+  // Keyword scoring (persona-based)
+  const opusKeyHits = countKeywordHits(personaText, OPUS_KEYWORDS)
+  const haikuKeyHits = countKeywordHits(personaText, HAIKU_KEYWORDS)
+
+  // Signal scoring (runtime observations)
+  let opusSignalHits = 0
+  let haikuSignalHits = 0
+  if ((s.tokenAvgInputPerCall ?? 0) > 10_000) opusSignalHits++
+  if ((s.mcpServerCount ?? 0) >= 4) opusSignalHits++
+  if ((s.kanbanUrgentCount ?? 0) >= 2) opusSignalHits++
+  if ((s.scheduledFreqPerDay ?? 0) >= 10) haikuSignalHits++
+
+  const totalOpus = opusKeyHits + opusSignalHits
+  const totalHaiku = haikuKeyHits + haikuSignalHits
+
+  let suggestedModel: ModelId
+  if (totalOpus >= 2) suggestedModel = 'claude-opus-4-8[1m]'
+  else if (totalHaiku >= 2 && totalOpus === 0) suggestedModel = 'claude-haiku-4-5-20251001'
+  else suggestedModel = 'claude-sonnet-4-6'
+
+  const changeAdvised = normalize(suggestedModel) !== normalize(currentModel)
+
+  return {
+    agent: agentName,
+    currentModel,
+    suggestedModel,
+    reason: buildReason(
+      currentModel, suggestedModel, contextTokens,
+      opusKeyHits, haikuKeyHits, opusSignalHits, haikuSignalHits,
+      s, changeAdvised, false,
+    ),
+    changeAdvised,
+  }
+}

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -3,8 +3,8 @@ import { join, extname, dirname } from 'node:path'
 import { homedir, platform } from 'node:os'
 import { execSync } from 'node:child_process'
 import { logger } from '../../logger.js'
-import { MAIN_AGENT_ID, BOT_NAME } from '../../config.js'
-import { createAgentMessage, listPendingChannelRequests, updateChannelRequestStatus } from '../../db.js'
+import { MAIN_AGENT_ID, BOT_NAME, PROJECT_ROOT } from '../../config.js'
+import { createAgentMessage, listPendingChannelRequests, updateChannelRequestStatus, getDb } from '../../db.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { getSecret, setSecret, deleteSecret, listSecrets } from '../vault.js'
 import {
@@ -101,6 +101,9 @@ import { sanitizeAgentName } from '../sanitize.js'
 import { parseMultipart } from '../multipart.js'
 import { readBody, json, serveFile } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
+import { suggestForAgent, type AgentSignals } from '../model-suggest.js'
+import { getTokenSummary } from '../token-usage.js'
+import { listScheduledTasks } from '../scheduled-tasks-io.js'
 
 const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord'])
 
@@ -503,6 +506,95 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     }
 
     json(res, entries)
+    return true
+  }
+
+  if (path === '/api/agents/model-suggest' && method === 'POST') {
+    // Collect runtime signals once, then classify per agent.
+    // I/O is centralised here; the classifier (model-suggest.ts) stays pure.
+
+    // Token usage: per-agent average input tokens/call over the last 30 days
+    const thirtyDaysAgo = Math.floor(Date.now() / 1000) - 30 * 24 * 3600
+    const tokenSummaries = getTokenSummary(thirtyDaysAgo)
+    const tokenMap = new Map(
+      tokenSummaries.map(s => [s.agent, s.totalCalls > 0 ? s.totalInput / s.totalCalls : 0])
+    )
+
+    // Kanban: open and urgent/high card counts per assignee
+    const db = getDb()
+    type KanbanRow = { assignee: string | null; priority: string; cnt: number }
+    const kanbanRows = db.prepare(
+      `SELECT assignee, priority, COUNT(*) as cnt
+       FROM kanban_cards
+       WHERE archived_at IS NULL AND assignee IS NOT NULL
+       GROUP BY assignee, priority`
+    ).all() as KanbanRow[]
+    const kanbanMap = new Map<string, { open: number; urgent: number }>()
+    for (const row of kanbanRows) {
+      if (!row.assignee) continue
+      const cur = kanbanMap.get(row.assignee) ?? { open: 0, urgent: 0 }
+      cur.open += row.cnt
+      if (row.priority === 'urgent' || row.priority === 'high') cur.urgent += row.cnt
+      kanbanMap.set(row.assignee, cur)
+    }
+
+    // Scheduled-task frequency: total estimated runs/day per agent (cron-derived)
+    function cronFreqPerDay(cron: string): number {
+      const parts = cron.trim().split(/\s+/)
+      if (parts.length < 5) return 1
+      const [min, hour] = parts
+      if (min.startsWith('*/')) {
+        const n = parseInt(min.slice(2), 10)
+        if (!isNaN(n) && n > 0) return Math.round((60 / n) * 24)
+      }
+      if (hour === '*') return 24
+      if (hour.startsWith('*/')) {
+        const n = parseInt(hour.slice(2), 10)
+        if (!isNaN(n) && n > 0) return Math.round(24 / n)
+      }
+      return 1
+    }
+    const schedFreqMap = new Map<string, number>()
+    try {
+      for (const task of listScheduledTasks()) {
+        if (!task.enabled) continue
+        const freq = cronFreqPerDay(task.schedule)
+        schedFreqMap.set(task.agent, (schedFreqMap.get(task.agent) ?? 0) + freq)
+      }
+    } catch { /* scheduled-tasks dir may not exist yet */ }
+
+    // MCP server count: read agents/<name>/.mcp.json
+    function mcpServerCount(agentName: string): number {
+      const mcpPath = join(agentDir(agentName), '.mcp.json')
+      if (!existsSync(mcpPath)) return 0
+      try {
+        const cfg = JSON.parse(readFileSync(mcpPath, 'utf-8')) as { mcpServers?: Record<string, unknown> }
+        return Object.keys(cfg.mcpServers ?? {}).length
+      } catch { return 0 }
+    }
+
+    const names = listAgentNames()
+    const results = [MAIN_AGENT_ID, ...names].map(name => {
+      const dir = agentDir(name)
+      const claudeMd = readFileOr(join(dir, 'CLAUDE.md'), '')
+      const personaPath = join(PROJECT_ROOT, 'personas', `${name}.md`)
+      const personaMd = existsSync(personaPath) ? readFileSync(personaPath, 'utf-8') : ''
+      const personaText = [claudeMd, personaMd].filter(Boolean).join('\n')
+      const currentModel = readAgentModel(name)
+      const contextTokens = readContextTokensFromProjectDir(dir) ?? 0
+
+      const kanban = kanbanMap.get(name)
+      const signals: AgentSignals = {
+        tokenAvgInputPerCall: tokenMap.has(name) ? tokenMap.get(name) : undefined,
+        kanbanOpenCount: kanban?.open,
+        kanbanUrgentCount: kanban?.urgent,
+        scheduledFreqPerDay: schedFreqMap.has(name) ? schedFreqMap.get(name) : undefined,
+        mcpServerCount: mcpServerCount(name),
+      }
+
+      return suggestForAgent(name, currentModel, personaText, contextTokens, signals)
+    })
+    json(res, { results })
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -2226,6 +2226,89 @@ document.getElementById('saveModelBtn').addEventListener('click', async () => {
   } catch { showToast('Hiba a mentés során') }
 })
 
+document.getElementById('modelSuggestBtn').addEventListener('click', async () => {
+  if (!currentAgent) return
+  const resultDiv = document.getElementById('modelSuggestionResult')
+  resultDiv.style.display = 'block'
+  resultDiv.textContent = 'Elemzés...'
+  try {
+    const res = await fetch('/api/agents/model-suggest', { method: 'POST' })
+    if (!res.ok) throw new Error()
+    const { results } = await res.json()
+    const entry = results.find(r => r.agent === currentAgent.name)
+    if (!entry) {
+      resultDiv.textContent = 'Nincs adat ehhez az ágenshez.'
+      return
+    }
+    resultDiv.style.color = entry.changeAdvised ? 'var(--warning, #e6a817)' : 'var(--success)'
+    resultDiv.style.whiteSpace = 'pre-wrap'
+    resultDiv.style.fontFamily = 'monospace'
+    resultDiv.style.fontSize = '12px'
+    resultDiv.textContent = entry.reason
+  } catch { resultDiv.textContent = 'Hiba az elemzés során.' }
+})
+
+document.getElementById('analyzeAllModelsBtn').addEventListener('click', async () => {
+  const panel = document.getElementById('agentsModelAnalysis')
+  panel.style.display = 'block'
+  panel.innerHTML = '<p style="color:var(--text-muted);font-size:13px">Elemzés folyamatban...</p>'
+  try {
+    const res = await fetch('/api/agents/model-suggest', { method: 'POST' })
+    if (!res.ok) throw new Error()
+    const { results } = await res.json()
+    const changes = results.filter(r => r.changeAdvised)
+    const ok = results.filter(r => !r.changeAdvised)
+    let html = '<div style="font-size:13px;padding:12px 14px;background:var(--surface-hover);border-radius:8px;border:1px solid var(--border)">'
+    html += `<p style="margin:0 0 8px;font-weight:600">Modell elemzés -- ${results.length} ágens</p>`
+    if (changes.length === 0) {
+      html += '<p style="color:var(--success);margin:0">Minden ágenshez megfelelő modell van beállítva.</p>'
+    } else {
+      html += `<p style="color:var(--warning, #e6a817);margin:0 0 8px">${changes.length} változtatás javasolt:</p>`
+      html += '<ul style="margin:0 0 10px;padding-left:18px">'
+      for (const r of changes) {
+        const safeReason = r.reason.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+        html += `<li style="margin-bottom:6px"><strong>${r.agent}</strong>: ${r.currentModel} &rarr; ${r.suggestedModel}`
+        html += ` <details style="display:inline-block;vertical-align:top;margin-left:4px"><summary style="cursor:pointer;font-size:11px;color:var(--text-muted)">részletek</summary>`
+        html += `<pre style="white-space:pre-wrap;font-size:11px;margin:4px 0 0;background:var(--surface);padding:6px 8px;border-radius:4px;color:var(--text-muted)">${safeReason}</pre></details></li>`
+      }
+      html += '</ul>'
+      if (ok.length > 0) {
+        html += `<p style="color:var(--text-muted);margin:0;font-size:12px">Megfelelő: ${ok.map(r => r.agent).join(', ')}</p>`
+      }
+      html += `<button class="btn-secondary btn-compact" id="createModelChangeCardsBtn" style="margin-top:10px">Kanban kártyák létrehozása</button>`
+    }
+    html += '</div>'
+    panel.innerHTML = html
+    const createBtn = document.getElementById('createModelChangeCardsBtn')
+    if (createBtn) {
+      createBtn.addEventListener('click', async () => {
+        if (!confirm(`${changes.length} kanban kártya létrehozása a modell-változtatásokhoz?`)) return
+        createBtn.disabled = true
+        createBtn.textContent = 'Létrehozás...'
+        let created = 0
+        for (const r of changes) {
+          try {
+            await fetch('/api/kanban', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                title: `Modell-váltás: ${r.agent}`,
+                description: `Jelenlegi: ${r.currentModel}\nJavasolt: ${r.suggestedModel}\n\nIndoklás: ${r.reason}`,
+                assignee: 'marveen',
+                priority: 'normal',
+                status: 'planned',
+              }),
+            })
+            created++
+          } catch { /* skip failed card */ }
+        }
+        showToast(`${created} kanban kártya létrehozva.`)
+        createBtn.textContent = `${created} kártya létrehozva`
+      })
+    }
+  } catch { panel.innerHTML = '<p style="color:var(--error);font-size:13px">Hiba az elemzés során.</p>' }
+})
+
 document.getElementById('saveAutoRestartBtn').addEventListener('click', async () => {
   if (!currentAgent) return
   // Auto-restart applies to the main session too, so (unlike model/profile) we

--- a/web/index.html
+++ b/web/index.html
@@ -222,8 +222,12 @@
             <h1>Csapat</h1>
             <p class="subtitle">AI csapattagok kezelése</p>
           </div>
+          <div class="header-actions">
+            <button class="btn-secondary btn-compact" id="analyzeAllModelsBtn">Modell elemzés</button>
+          </div>
         </div>
       </div>
+      <div id="agentsModelAnalysis" style="display:none;margin:0 0 16px"></div>
       <div class="agents-grid" id="agentsGrid">
         <button class="agent-card add-card" id="addAgentBtn">
           <div class="add-icon">
@@ -1474,9 +1478,11 @@
               </optgroup>
             </select>
             <button class="btn-secondary btn-compact agent-save-section" id="saveModelBtn">Mentés</button>
+            <button class="btn-secondary btn-compact" id="modelSuggestBtn" style="margin-left:6px">Javaslat</button>
             <small id="deepseekHint" style="display:none;margin-top:6px;color:var(--text-muted);font-size:12px;line-height:1.4">
               DeepSeek-V4-Pro nincs konfigurálva. <a href="#" id="deepseekConfigLink">API kulcs hozzáadása</a> a Vault oldalon.
             </small>
+            <div id="modelSuggestionResult" style="display:none;margin-top:8px;font-size:12.5px;padding:8px 10px;border-radius:6px;background:var(--surface-hover);color:var(--text-muted)"></div>
           </div>
           <div class="form-group" id="autoRestartGroup">
             <label>Automatikus újraindítás</label>


### PR DESCRIPTION
Adds a POST /api/agents/model-suggest endpoint that evaluates whether each agent's current Claude model matches its persona role and observed usage.

Classifier (src/web/model-suggest.ts):
- Pure, side-effect-free; all I/O happens in the caller (route layer)
- AgentSignals interface: tokenAvgInputPerCall, kanbanOpenCount, kanbanUrgentCount, scheduledFreqPerDay, mcpServerCount
- Signal thresholds: avgInput>10K +1 opus, mcpCount>=4 +1 opus, kanbanUrgent>=2 +1 opus, scheduledFreq>=10 +1 haiku
- Combined with existing persona keyword scoring (opusHits + haikuHits)
- 6-section reason text: current state / observed usage / per-dimension assessment (✅⚠️❌) / recommendation + top 2 reasons / cost impact / uncertainty note
- classifyPersona() unchanged (all existing tests pass)

Route (src/web/routes/agents.ts):
- Collects signals once per request: token_usage (getTokenSummary, 30d), kanban SQL GROUP BY assignee+priority, listScheduledTasks + cron→freq/day, .mcp.json mcpServers key count
- Returns { results: AgentSuggestionResult[] } for all agents incl. main

Frontend (web/app.js + web/index.html):
- "Modell elemzés" button on Agents page: fleet-wide analysis panel with collapsible per-agent detail (<details>/<summary>) and optional kanban card creation for advised changes
- "Javaslat" button in per-agent Settings tab: inline pre-wrap reason display

Tests (src/__tests__/model-suggest.test.ts):
- 23 tests total; covers all signal threshold combinations, boundary cases, Opus-blocks-Haiku guard, context override, all 6 reason sections

This change was authored with AI assistance (Zack agent, fleet senior backend developer), reviewed by @cett before submission.