### PR TITLE
fix(dashboard): mobile-login QR uses server LAN IP, not localhost origin

### DIFF
--- a/src/__tests__/network-info.test.ts
+++ b/src/__tests__/network-info.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { pickLanIp, isPrivateIpv4 } from '../web/network-info.js'
+
+// Minimal shape matching os.NetworkInterfaceInfo for the fields pickLanIp reads.
+function v4(address: string, internal = false) {
+  return { address, family: 'IPv4', internal, netmask: '255.255.255.0', mac: '00:00:00:00:00:00', cidr: null } as any
+}
+function v6(address: string, internal = false) {
+  return { address, family: 'IPv6', internal, netmask: '', mac: '00:00:00:00:00:00', cidr: null, scopeid: 0 } as any
+}
+
+describe('isPrivateIpv4', () => {
+  it('accepts the three private ranges', () => {
+    expect(isPrivateIpv4('10.0.0.5')).toBe(true)
+    expect(isPrivateIpv4('192.168.1.50')).toBe(true)
+    expect(isPrivateIpv4('172.16.4.4')).toBe(true)
+    expect(isPrivateIpv4('172.31.255.1')).toBe(true)
+  })
+  it('rejects public, link-local, and 172.x outside 16-31', () => {
+    expect(isPrivateIpv4('8.8.8.8')).toBe(false)
+    expect(isPrivateIpv4('169.254.1.2')).toBe(false) // link-local
+    expect(isPrivateIpv4('172.15.0.1')).toBe(false)
+    expect(isPrivateIpv4('172.32.0.1')).toBe(false)
+  })
+})
+
+describe('pickLanIp', () => {
+  it('picks the WiFi private IP on a typical macOS host (skips loopback/VPN/awdl)', () => {
+    const ifaces = {
+      lo0: [v4('127.0.0.1', true), v6('::1', true)],
+      en0: [v4('192.168.1.50'), v6('fe80::1')],
+      utun3: [v4('10.99.0.2')], // VPN tunnel -- must be skipped despite private range
+      awdl0: [v6('fe80::2')],
+    }
+    expect(pickLanIp(ifaces)).toBe('192.168.1.50')
+  })
+
+  it('picks the eth0 private IP on Linux and skips the docker bridge', () => {
+    const ifaces = {
+      lo: [v4('127.0.0.1', true)],
+      eth0: [v4('10.0.0.5')],
+      docker0: [v4('172.17.0.1')], // skipped by name
+    }
+    expect(pickLanIp(ifaces)).toBe('10.0.0.5')
+  })
+
+  it('prefers en0 over en1 when both qualify', () => {
+    const ifaces = {
+      en1: [v4('192.168.1.99')],
+      en0: [v4('192.168.1.50')],
+    }
+    expect(pickLanIp(ifaces)).toBe('192.168.1.50')
+  })
+
+  it('returns null when only loopback exists (localhost-only / no LAN)', () => {
+    expect(pickLanIp({ lo0: [v4('127.0.0.1', true)] })).toBeNull()
+  })
+
+  it('returns null when the only non-internal IPv4 is public (no private LAN addr)', () => {
+    expect(pickLanIp({ en0: [v4('203.0.113.7')] })).toBeNull()
+  })
+
+  it('ignores IPv6 and internal addresses', () => {
+    const ifaces = {
+      en0: [v6('2001:db8::1'), v4('192.168.0.10')],
+      lo0: [v4('127.0.0.1', true)],
+    }
+    expect(pickLanIp(ifaces)).toBe('192.168.0.10')
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -5,6 +5,7 @@ import { execSync, execFileSync } from 'node:child_process'
 import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL } from './config.js'
 import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-auth.js'
 import { json } from './web/http-helpers.js'
+import { detectLanIp } from './web/network-info.js'
 import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
 import { ensureAgentHooks, ensureDefaultScheduledTasks } from './web/agent-scaffold.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
@@ -121,6 +122,15 @@ export function startWebServer(port = 3420): http.Server {
         res.end(JSON.stringify({ error: 'Unauthorized' }))
         return
       }
+    }
+
+    // The mobile-login QR needs a URL the phone can actually reach. When the
+    // desktop opens the dashboard on localhost, window.location.origin is
+    // useless (the phone would hit its OWN localhost), so the client asks the
+    // server for its LAN IP and builds the QR from that. Auth is already
+    // enforced by the /api/* gate above.
+    if (path === '/api/network-info' && method === 'GET') {
+      return json(res, { lan_ip: detectLanIp(), port })
     }
 
     try {

--- a/src/web/network-info.ts
+++ b/src/web/network-info.ts
@@ -1,0 +1,52 @@
+import os from 'node:os'
+
+// Pick the best LAN IPv4 address for reaching this host from another device on
+// the same network (e.g. a phone scanning the mobile-login QR). The desktop
+// usually opens the dashboard on localhost/127.0.0.1, so window.location.origin
+// is useless for the QR -- the phone would hit its OWN localhost. The server
+// resolves its real LAN IP here instead.
+//
+// Heuristics: skip loopback, VPN/tunnel (utun/tun/tap), and virtualization
+// (docker/bridge/vmnet/awdl) interfaces; keep only private-range IPv4 (the
+// address a phone on the same WiFi can route to); prefer the common physical
+// interface names. Returns null when nothing qualifies, so the caller can tell
+// the user to open the dashboard on the LAN IP directly rather than show a
+// broken QR.
+
+const SKIP_IFACE = /^(lo|utun|tun|tap|bridge|docker|vmnet|vnic|llw|awdl|gif|stf|ap\d)/i
+const PREFERRED = ['en0', 'en1', 'eth0', 'eth1', 'wlan0', 'wlan1']
+
+export function isPrivateIpv4(ip: string): boolean {
+  return (
+    /^10\./.test(ip) ||
+    /^192\.168\./.test(ip) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(ip)
+  )
+}
+
+function rank(name: string): number {
+  const i = PREFERRED.indexOf(name)
+  return i === -1 ? 99 : i
+}
+
+export function pickLanIp(ifaces: NodeJS.Dict<os.NetworkInterfaceInfo[]>): string | null {
+  const candidates: Array<{ name: string; addr: string }> = []
+  for (const [name, addrs] of Object.entries(ifaces)) {
+    if (!addrs || SKIP_IFACE.test(name)) continue
+    for (const a of addrs) {
+      // Node 20 reports family as the string 'IPv4'; accept the numeric 4 too
+      // for forward-compatibility.
+      const isV4 = a.family === 'IPv4' || (a.family as unknown) === 4
+      if (isV4 && !a.internal && isPrivateIpv4(a.address)) {
+        candidates.push({ name, addr: a.address })
+      }
+    }
+  }
+  if (candidates.length === 0) return null
+  candidates.sort((a, b) => rank(a.name) - rank(b.name))
+  return candidates[0].addr
+}
+
+export function detectLanIp(): string | null {
+  return pickLanIp(os.networkInterfaces())
+}

--- a/web/app.js
+++ b/web/app.js
@@ -9937,17 +9937,41 @@ async function openDoc(name) {
   const qrBox = document.getElementById('mobileLoginQr')
   const closeBtn = document.getElementById('mobileLoginClose')
 
-  function render() {
+  async function render() {
     const token = localStorage.getItem('marveen-dashboard-token')
     if (!token) {
-      qrBox.innerHTML = '<p class="muted">Nincs eltárolt token ebben a böngészőben — előbb itt lépj be.</p>'
+      qrBox.innerHTML = '<p class="muted">Nincs eltárolt token ebben a böngészőben, előbb itt lépj be.</p>'
       return
     }
-    const url = window.location.origin + '/?token=' + token
     if (typeof qrcode !== 'function') {
       qrBox.innerHTML = '<p class="muted">A QR-generátor nem töltött be (CDN). Hálózat?</p>'
       return
     }
+    // The QR must encode a URL the phone can reach. If the desktop opened the
+    // dashboard on localhost/127.0.0.1, window.location.origin would put
+    // "localhost" in the QR and the phone would hit its OWN localhost. In that
+    // case ask the server for its LAN IP and build the QR from that. If the
+    // dashboard is already open on a LAN IP or a tunnel host, the origin works
+    // as-is.
+    let base = window.location.origin
+    const host = window.location.hostname
+    if (host === 'localhost' || host === '127.0.0.1') {
+      qrBox.innerHTML = '<p class="muted">QR készítése…</p>'
+      try {
+        const r = await fetch('/api/network-info', { headers: { 'Authorization': 'Bearer ' + token } })
+        const info = r.ok ? await r.json() : {}
+        if (info.lan_ip) {
+          base = 'http://' + info.lan_ip + ':' + (info.port || window.location.port || '3420')
+        } else {
+          qrBox.innerHTML = '<p class="mobile-login-warn">A mobil-belépés a géped helyi hálózati (LAN) IP-jén működik. Most localhoston nyitottad meg a dashboardot, és nem találtam használható LAN-címet. Nyisd meg a dashboardot a géped LAN-IP-jén (pl. http://192.168.x.x:3420), és onnan próbáld a mobil-belépést.</p>'
+          return
+        }
+      } catch (e) {
+        qrBox.innerHTML = '<p class="mobile-login-warn">Nem sikerült lekérdezni a gép LAN-IP-jét a mobil-belépéshez. Nyisd meg a dashboardot a géped helyi (LAN) IP-jén, és onnan próbáld.</p>'
+        return
+      }
+    }
+    const url = base + '/?token=' + token
     try {
       const qr = qrcode(0, 'M') // typeNumber 0 = auto-fit, ECC level M
       qr.addData(url)


### PR DESCRIPTION
Fixes the #358 mobile-login QR localhost bug (Szabi's report, card e273a12e).

## Problem
The QR encoded `window.location.origin`. When the desktop opens the dashboard on `localhost:3420` / `127.0.0.1`, the QR contained `localhost` → the scanning phone hit its **own** localhost → mobile login never worked. It only worked if the dashboard happened to be open on the Mac's LAN IP.

## Fix (option a, with b fallback)
- **New token-gated `GET /api/network-info`** returns the server's detected LAN IPv4 (`os.networkInterfaces()`, skipping loopback/VPN/virtual interfaces, private ranges only, preferring `en0`/`eth0`). The pure `pickLanIp()` is unit-tested (8 tests).
- **QR render** asks for the LAN IP only when the origin is `localhost`/`127.0.0.1`. If the dashboard is already open on a LAN IP or a tunnel host, the origin is used as-is. If no LAN IP is found, the modal explains to open the dashboard on the machine's LAN IP instead of showing a broken QR.

## Verification
- `detectLanIp()` returns `192.168.0.246` on this host → the QR encodes a URL the phone can actually reach on the same WiFi.
- `tsc --noEmit` green; `network-info.test.ts` 8/8 green (macOS/Linux interface sets, VPN/docker skip, en0-preference, no-LAN → null, IPv6/internal ignored).
- Scope: +159/-3, 4 files (new module + test, web.ts route, app.js render). Also dropped one stray em-dash in the edited mobile-login string.

Needs to land before the v1.7.4 promote so a broken feature doesn't ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)