### PR TITLE
fix(channel-monitor): exponential back-off for repeated failed plugin-restarts

### DIFF
--- a/src/__tests__/agent-restart-policy.test.ts
+++ b/src/__tests__/agent-restart-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { shouldAutoRestartDownAgent, parseEtimeToSeconds } from '../web/agent-restart-policy.js'
+import { shouldAutoRestartDownAgent, effectiveRestartGraceMs, parseEtimeToSeconds } from '../web/agent-restart-policy.js'
 
 const STARTUP = 180_000
 const RESTART = 90_000
@@ -185,5 +185,85 @@ describe('parseEtimeToSeconds', () => {
 
   it('returns -1 for the DD-MM:SS shape ps never emits (days require hours)', () => {
     expect(parseEtimeToSeconds('5-23:59')).toBe(-1)
+  })
+})
+
+describe('effectiveRestartGraceMs (exponential back-off)', () => {
+  it('returns the base grace with zero failures', () => {
+    expect(effectiveRestartGraceMs(RESTART, 0)).toBe(RESTART)
+  })
+
+  it('doubles per consecutive failure', () => {
+    expect(effectiveRestartGraceMs(RESTART, 1)).toBe(RESTART * 2)
+    expect(effectiveRestartGraceMs(RESTART, 2)).toBe(RESTART * 4)
+    expect(effectiveRestartGraceMs(RESTART, 3)).toBe(RESTART * 8)
+  })
+
+  it('caps at maxRestartGraceMs once the back-off would exceed it', () => {
+    const cap = 60 * 60 * 1000 // 1h
+    // RESTART(90s) * 2^5 = 48min < cap; * 2^6 = 96min -> capped to 1h
+    expect(effectiveRestartGraceMs(RESTART, 6, cap)).toBe(cap)
+    expect(effectiveRestartGraceMs(RESTART, 20, cap)).toBe(cap)
+  })
+
+  it('treats negative / non-finite failure counts as zero', () => {
+    expect(effectiveRestartGraceMs(RESTART, -3)).toBe(RESTART)
+    expect(effectiveRestartGraceMs(RESTART, Number.NaN)).toBe(RESTART)
+  })
+})
+
+describe('shouldAutoRestartDownAgent with back-off', () => {
+  it('defers a restart that would fire under base grace but not under the backed-off grace', () => {
+    // 100s since last restart: past the 90s base grace, but with 1 prior
+    // failure the grace is 180s -> still deferred.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 10 * 60_000,
+      msSinceLastRestart: 100_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      consecutiveFailures: 1,
+    })).toBe(false)
+  })
+
+  it('restarts once the backed-off grace has elapsed', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 10 * 60_000,
+      msSinceLastRestart: RESTART * 2 + 1, // past the 1-failure (180s) grace
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      consecutiveFailures: 1,
+    })).toBe(true)
+  })
+
+  it('a perpetually-failing plugin is retried at most at the cap, not the base grace', () => {
+    const cap = 60 * 60 * 1000
+    // 10 failures would be 90s*2^10 ~ 25h without a cap; capped to 1h.
+    // 50min since last restart -> still within the 1h cap -> deferred.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 30 * 60_000,
+      msSinceLastRestart: 50 * 60_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      consecutiveFailures: 10,
+      maxRestartGraceMs: cap,
+    })).toBe(false)
+    // 61min since last restart -> past the cap -> retried.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 30 * 60_000,
+      msSinceLastRestart: 61 * 60_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      consecutiveFailures: 10,
+      maxRestartGraceMs: cap,
+    })).toBe(true)
+  })
+
+  it('preserves the original behaviour when consecutiveFailures is omitted', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 10 * 60_000,
+      msSinceLastRestart: RESTART + 1,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+    })).toBe(true)
   })
 })

--- a/src/web/agent-restart-policy.ts
+++ b/src/web/agent-restart-policy.ts
@@ -25,6 +25,39 @@ export interface AgentRestartDecisionInput {
   // After the watchdog restarts an agent, give the new process at least this
   // long to come up before considering another restart.
   restartGraceMs: number
+  // Consecutive watchdog restarts that did NOT bring the plugin back up. Each
+  // failure doubles the effective restart grace (exponential back-off), so a
+  // perpetually-failing plugin (e.g. a broken third-party channel plugin that
+  // crashes on every launch) is retried ever less often instead of churning at
+  // the fixed grace forever -- which restarts the WHOLE agent every few minutes
+  // and renders it unusable. Reset to 0 by the caller once the plugin recovers.
+  // 0 / omitted preserves the original fixed-grace behaviour.
+  consecutiveFailures?: number
+  // Upper bound on the backed-off restart grace, so the watchdog still retries a
+  // long-down plugin occasionally (it may recover after an external fix) rather
+  // than backing off unboundedly. Omitted = no cap beyond the exponent.
+  maxRestartGraceMs?: number
+}
+
+// The restart grace after applying exponential back-off for repeated failed
+// restarts. Each consecutive failure doubles the base grace, capped (when a cap
+// is given) so retries continue at a bounded floor frequency. Exported for unit
+// tests and so the caller can log the effective interval.
+export function effectiveRestartGraceMs(
+  restartGraceMs: number,
+  consecutiveFailures: number,
+  maxRestartGraceMs?: number,
+): number {
+  const failures = Number.isFinite(consecutiveFailures) && consecutiveFailures > 0
+    ? Math.floor(consecutiveFailures)
+    : 0
+  // Cap the exponent well below the point where 2^n overflows Number range.
+  const exp = Math.min(failures, 30)
+  let grace = restartGraceMs * 2 ** exp
+  if (maxRestartGraceMs != null && Number.isFinite(maxRestartGraceMs)) {
+    grace = Math.min(grace, maxRestartGraceMs)
+  }
+  return grace
 }
 
 // Returns true only when a down-reporting agent should actually be restarted.
@@ -35,8 +68,11 @@ export function shouldAutoRestartDownAgent(input: AgentRestartDecisionInput): bo
   if (!Number.isFinite(processAgeMs) || processAgeMs < 0) return false
   // Freshly started: the channel plugin may still be spawning.
   if (processAgeMs < startupGraceMs) return false
-  // Recently restarted by the watchdog: give the new process time to come up.
-  if (msSinceLastRestart !== null && msSinceLastRestart < restartGraceMs) return false
+  // Recently restarted by the watchdog: give the new process time to come up,
+  // backed off exponentially for repeated failed restarts so a plugin that can
+  // never come up is not restarted on a fixed short cadence forever.
+  const grace = effectiveRestartGraceMs(restartGraceMs, input.consecutiveFailures ?? 0, input.maxRestartGraceMs)
+  if (msSinceLastRestart !== null && msSinceLastRestart < grace) return false
   return true
 }
 

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -67,7 +67,16 @@ function resolveAgentProvider(name: string): ChannelProviderType {
 
 const agentDownSince: Map<string, number> = new Map()
 const agentLastRestart: Map<string, number> = new Map()
+// Consecutive watchdog restarts (keyed by agent name) that did NOT bring the
+// plugin back up. Drives exponential back-off so a plugin that crashes on every
+// launch (e.g. a broken third-party channel plugin) is not restarted on a fixed
+// short cadence forever -- which restarts the WHOLE agent every few minutes and
+// renders it unusable. Reset to 0 the moment the plugin is seen alive again.
+const agentRestartFailures: Map<string, number> = new Map()
 const AGENT_RESTART_GRACE_MS = 90_000
+// Floor frequency for the backed-off restart: even a long-down plugin is still
+// retried at least this often, in case an external fix brings it back.
+const AGENT_MAX_RESTART_GRACE_MS = 60 * 60 * 1000 // 1h
 // A freshly started agent can take well over the first-probe window to bring
 // its channel plugin up (a large-context model launched with --continue spawns
 // the plugin only after a slow session load). Never restart a process younger
@@ -967,9 +976,14 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // Process-alive does NOT prove the inbound MCP pipe is healthy (the
           // deafness blind spot). Cross-check the keep-alive freshness.
           checkMainKeepaliveStaleness()
-        } else if (agentDownSince.has(t.session)) {
-          logger.info({ session: t.session, provider: t.provider }, 'Agent channel plugin recovered')
-          agentDownSince.delete(t.session)
+        } else {
+          if (agentDownSince.has(t.session)) {
+            logger.info({ session: t.session, provider: t.provider }, 'Agent channel plugin recovered')
+            agentDownSince.delete(t.session)
+          }
+          // Healthy observation clears the exponential back-off so the next
+          // down-spell starts again at the base grace.
+          agentRestartFailures.delete(t.agentName!)
         }
         continue
       }
@@ -978,14 +992,17 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
       } else {
         if (!agentDownSince.has(t.session)) agentDownSince.set(t.session, Date.now())
         const lastRestart = agentLastRestart.get(t.agentName!)
+        const failures = agentRestartFailures.get(t.agentName!) ?? 0
         const restart = shouldAutoRestartDownAgent({
           processAgeMs: getProcessAgeMs(claudePid),
           msSinceLastRestart: lastRestart != null ? Date.now() - lastRestart : null,
           startupGraceMs: AGENT_STARTUP_GRACE_MS,
           restartGraceMs: AGENT_RESTART_GRACE_MS,
+          consecutiveFailures: failures,
+          maxRestartGraceMs: AGENT_MAX_RESTART_GRACE_MS,
         })
         if (!restart) {
-          logger.debug({ agent: t.agentName, provider: t.provider }, 'Channel plugin probe reports down but agent is within startup/restart grace -- deferring')
+          logger.debug({ agent: t.agentName, provider: t.provider, failures }, 'Channel plugin probe reports down but agent is within startup/restart back-off -- deferring')
           continue
         }
         const agentProvider = resolveAgentProvider(t.agentName!)
@@ -995,13 +1012,17 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           logger.warn({ agent: t.agentName, provider: agentProvider }, 'Agent has no channel token in state dir -- skipping restart to avoid token conflict')
           continue
         }
-        logger.warn({ agent: t.agentName, provider: t.provider }, 'Agent channel plugin down -- auto-restarting')
+        logger.warn({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down -- auto-restarting')
         try {
           stopAgentProcess(t.agentName!)
           execSync('sleep 2', { timeout: 4000 })
           startAgentProcess(t.agentName!)
           agentLastRestart.set(t.agentName!, Date.now())
           agentDownSince.delete(t.session)
+          // Count this restart as failed until a later sweep sees the plugin
+          // alive (which resets the counter). Repeated failures back off the
+          // next restart exponentially instead of churning every base-grace.
+          agentRestartFailures.set(t.agentName!, failures + 1)
         } catch (err) {
           logger.error({ err, agent: t.agentName }, 'Failed to auto-restart agent after channel plugin down')
         }


### PR DESCRIPTION
Hardening from the slacker diagnosis (card c1decf31). General protection against any perpetually-failing channel plugin.

## Problem
A channel plugin that crashes on every launch (the WIP `slack-channel` plugin whose `SessionSupervisor.shutdown()` throws `not yet implemented (ccsc-xa3.14)`) was restarted by the watchdog at the **fixed 90s restart grace forever** — which restarts the **whole agent** every few minutes (observed: **~1685 slacker restarts/day**) and renders it unusable.

## Fix
The restart decision now backs off **exponentially** per consecutive failed restart: each failure doubles the effective grace (90s → 180s → 360s → …), **capped at 1h** so a long-down plugin is still retried occasionally (in case an external fix lands). A **healthy probe resets the counter**, so a transient blip is unaffected.

- `agent-restart-policy.ts`: new `effectiveRestartGraceMs()` + optional `consecutiveFailures` / `maxRestartGraceMs` inputs. Omitting them preserves the exact prior behaviour (backward-compatible).
- `channel-monitor.ts`: per-agent `agentRestartFailures` map — pass the count to the policy, increment on each restart, reset on a healthy probe. The **main-agent (marveen) recovery path is untouched** (this is the non-marveen branch only).
- Tests: `effectiveRestartGraceMs` (doubling, cap, negative/NaN guards) + backed-off `shouldAutoRestartDownAgent` deferral/retry/back-compat.

## Verification
- `tsc --noEmit` green.
- `agent-restart-policy.test.ts` 37 tests (incl. new back-off) + adjacent restart suites green; all 20 channel/recovery suites green (391 tests).
- Scope: +145/-8, 3 files (policy + monitor + test).

Note: this stops the *churn*; the actual slack-plugin fix (pin a stable version / implement `shutdown()`) is a separate question for Szabi (deferred until after GWS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)