### PR TITLE
feat(dashboard): docs viewer — newest-first sort + raw .md download

### DIFF
--- a/src/web/routes/docs.ts
+++ b/src/web/routes/docs.ts
@@ -30,22 +30,28 @@ export async function tryHandleDocs(ctx: RouteContext): Promise<boolean> {
     } catch {
       files = []
     }
-    const docs = files.sort().map(name => {
-      let title = name
-      let created: string | null = null
-      try {
-        const file = join(DOCS_DIR, name)
-        title = titleOf(readFileSync(file, 'utf-8'), name)
-        const s = statSync(file)
-        // birthtime is the file's creation time; on filesystems that don't track
-        // it (returns 0) fall back to the last-modified time.
-        const ms = s.birthtimeMs && s.birthtimeMs > 0 ? s.birthtimeMs : s.mtimeMs
-        created = new Date(ms).toISOString().slice(0, 10)
-      } catch {
-        /* keep filename as title, created stays null */
-      }
-      return { name, title, created }
-    })
+    const docs = files
+      .map(name => {
+        let title = name
+        let created: string | null = null
+        let ms = 0
+        try {
+          const file = join(DOCS_DIR, name)
+          title = titleOf(readFileSync(file, 'utf-8'), name)
+          const s = statSync(file)
+          // birthtime is the file's creation time; on filesystems that don't track
+          // it (returns 0) fall back to the last-modified time.
+          ms = s.birthtimeMs && s.birthtimeMs > 0 ? s.birthtimeMs : s.mtimeMs
+          created = new Date(ms).toISOString().slice(0, 10)
+        } catch {
+          /* keep filename as title, created stays null */
+        }
+        return { name, title, created, ms }
+      })
+      // Newest first: sort by the file's creation/modification time descending,
+      // tie-break by name. The `ms` field is internal -- strip it before sending.
+      .sort((a, b) => (b.ms - a.ms) || a.name.localeCompare(b.name))
+      .map(({ name, title, created }) => ({ name, title, created }))
     json(res, docs)
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -10003,9 +10003,34 @@ async function openDoc(name) {
     const res = await fetch('/api/docs/' + encodeURIComponent(name))
     if (!res.ok) throw new Error('HTTP ' + res.status)
     const doc = await res.json()
-    contentEl.innerHTML = renderMarkdown(doc.content || '')
+    const content = doc.content || ''
+    // Toolbar with a raw-.md download, then the rendered markdown.
+    contentEl.innerHTML =
+      '<div class="docs-content-toolbar">' +
+        '<button class="btn-secondary btn-compact" id="docsDownloadBtn">⬇ .md letöltés</button>' +
+      '</div>' +
+      '<div class="docs-rendered markdown-body">' + renderMarkdown(content) + '</div>'
+    const dl = document.getElementById('docsDownloadBtn')
+    if (dl) dl.addEventListener('click', () => downloadMarkdown(name, content))
   } catch (e) {
     contentEl.innerHTML = '<p class="muted">Nem sikerült megnyitni: ' + escapeHtml(String(e.message || e)) + '</p>'
+  }
+}
+
+// Download a doc's raw markdown as a .md file (client-side Blob, no server).
+function downloadMarkdown(name, content) {
+  try {
+    const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = /\.md$/.test(name) ? name : (name + '.md')
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+  } catch (e) {
+    showToast('Nem sikerült a letöltés: ' + String(e && e.message || e))
   }
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -5455,3 +5455,7 @@ main {
   margin: 0;
   line-height: 1.4;
 }
+
+/* === Docs viewer: content toolbar (.md download) === */
+.docs-content-toolbar { display: flex; justify-content: flex-end; margin: 0 0 12px; }
+.docs-content-toolbar .btn-compact { font-size: 12px; }


### PR DESCRIPTION
Two small Docs-viewer improvements requested by the owner:

- List order: sort docs by file creation/modification time DESC (newest on top), tie-broken by name, instead of plain alphabetical. The internal `ms` sort key is stripped before the JSON response.
- Raw .md download: the opened doc gets a "⬇ .md letöltés" button that downloads the raw markdown as a Blob client-side (filename = the doc's .md name). No server route, no extra load.

Frontend-only for the download (web/app.js + style.css); the sort is in the docs route (src/web/routes/docs.ts).