### PR TITLE
feat(monitor): auto-recover sessions stuck in a blocking interactive …

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   detectPaneState,
   detectsThinkingBlockError,
+  detectsBlockingMenu,
   isReadyForPrompt,
   shouldRetrySubmit,
   shouldClearTruncatedPreamble,
@@ -1435,5 +1436,66 @@ describe('parkedInputText', () => {
     expect(parkedInputText(WRAPPED_PARKED)).toBe(
       '[Uzenet @system-tol]: Uj csapattag erkezett: balazsmarveenja. Udv neki ha legkozelebb beszeltek!',
     )
+  })
+})
+
+describe('detectsBlockingMenu', () => {
+  // The real /mcp "Manage MCP servers" modal that wedged the main channels
+  // session for ~6h (2026-06-12). The input box is gone; the footer shows the
+  // navigate/confirm/cancel hints instead of the permission footer.
+  const MCP_MENU = [
+    '   Manage MCP servers',
+    '   5 servers',
+    '',
+    '     claude.ai',
+    '   ❯ claude.ai Canva · ✔ connected · 39 tools',
+    '     claude.ai Google Calendar · ✔ connected · 8 tools',
+    '     claude.ai MailerLite · △ needs authentication',
+    '',
+    '   https://code.claude.com/docs/en/mcp for help',
+    '   ↑/↓ to navigate · Enter to confirm · Esc to cancel',
+  ].join('\n')
+
+  // A single-screen modal that only offers Esc to exit (no navigation row).
+  const ESC_ONLY_MODAL = [
+    '   Some dialog title',
+    '   body text here',
+    '',
+    '   Press Esc to exit',
+  ].join('\n')
+
+  it('detects the /mcp server-manager modal', () => {
+    expect(detectsBlockingMenu(MCP_MENU)).toBe(true)
+  })
+
+  it('detects an esc-only modal with no navigation row', () => {
+    expect(detectsBlockingMenu(ESC_ONLY_MODAL)).toBe(true)
+  })
+
+  it('is false for a normal idle prompt (bypass/strict)', () => {
+    expect(detectsBlockingMenu(IDLE_BYPASS)).toBe(false)
+    expect(detectsBlockingMenu(IDLE_STRICT)).toBe(false)
+  })
+
+  it('is false for a busy turn even if it renders esc-to-interrupt', () => {
+    expect(detectsBlockingMenu(BUSY_FULL_FOOTER)).toBe(false)
+    expect(detectsBlockingMenu(BUSY_TOKENS_ONLY)).toBe(false)
+  })
+
+  it('is false for an empty pane', () => {
+    expect(detectsBlockingMenu('')).toBe(false)
+    expect(detectsBlockingMenu('   \n  ')).toBe(false)
+  })
+
+  it('does not trigger on a reply that merely quotes menu chrome above a live prompt', () => {
+    const quoted = [
+      '  Tipp: a /mcp menuben az "Esc to cancel" sorral lepsz ki.',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectsBlockingMenu(quoted)).toBe(false)
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -199,6 +199,54 @@ export function detectsThinkingBlockError(pane: string): boolean {
   return false
 }
 
+// Claude Code modal/overlay surfaces -- the /mcp server manager, the model/
+// config/theme pickers, and permission dialogs -- replace the input box with a
+// navigable list whose footer reads e.g.
+//   "↑/↓ to navigate · Enter to confirm · Esc to cancel".
+// A headless service session (the main --channels session, a sub-agent) parked
+// in such a modal silently stops processing inbound work: it is not 'busy' (no
+// spinner / token counter) and not 'idle' (the input box is gone), so
+// detectPaneState classifies it 'unknown' and the scheduler/router just skip
+// it. Observed 2026-06-12: the main channels session sat in /mcp for ~6h, deaf
+// on Telegram, with nothing alerting. detectsBlockingMenu recognises the modal
+// so the monitor can pop back to the prompt with a single Escape.
+//
+// Guards against a healthy session that merely quotes menu chrome in a reply
+// or a log line:
+//   (a) Not busy: a live turn (spinner / token counter / esc-to-interrupt) is
+//       never a parked menu.
+//   (b) No idle footer: a real modal hides the permission/shortcuts footer.
+//       capturePane uses `capture-pane -p` (visible screen only, no
+//       scrollback), so a quoted footer cannot linger from a past turn -- an
+//       idle footer present means the normal prompt is live, not a menu.
+//   (c) The dismiss/navigation hint must sit in the live footer region (the
+//       bottom few lines), not anywhere in the pane, so a message body that
+//       quotes "Esc to cancel" does not trigger it.
+// `esc to interrupt` (the busy footer) is deliberately excluded from
+// MENU_ESC_RX, and guard (a) rejects it anyway.
+const MENU_NAV_RX = /(?:↑\/↓|↑↓)\s+to\s+(?:navigate|select|choose)/
+const MENU_ESC_RX = /\besc to (?:cancel|exit|close|go back|quit)\b/i
+const MENU_FOOTER_REGION_LINES = 8
+
+/**
+ * True when the pane is parked in a blocking Claude Code interactive menu /
+ * modal (not busy, not at the idle prompt). Pure + dependency-free for unit
+ * testing. The monitor uses this to send a recovery Escape; detectPaneState
+ * intentionally still returns 'unknown' for these panes so the hot-path
+ * scheduler/router behaviour is unchanged.
+ */
+export function detectsBlockingMenu(pane: string): boolean {
+  if (!pane || !pane.trim()) return false
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(pane)) return false
+  }
+  const lines = pane.split('\n')
+  const footerRegion = lines.slice(-MENU_FOOTER_REGION_LINES).join('\n')
+  if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
+  if (IDLE_FOOTER_RX.test(pane)) return false
+  return MENU_NAV_RX.test(footerRegion) || MENU_ESC_RX.test(footerRegion)
+}
+
 export interface DetectPaneStateOptions {
   /** If true, the 'typing' state (text parked in input box) is
    * merged into 'busy'. Default false -- callers that care about

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -22,7 +22,7 @@ import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller
 import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import {
-  detectPaneState, decidePaneErrorAlert, type PaneErrorAlertState, type PaneState,
+  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
   parkedInputText, shouldClearTruncatedPreamble,
   type StuckInputState, type StuckInputThresholds,
@@ -208,6 +208,19 @@ const paneErrorState: Map<string, PaneErrorAlertState> = new Map()
 const PANE_ERROR_CONFIRM_MS = 120_000
 const PANE_ERROR_DEDUP_MS = 30 * 60 * 1000
 const PANE_ERROR_CLEAR_MS = 5 * 60 * 1000
+
+// Per-session tracking for a session parked in a blocking interactive menu
+// (the /mcp manager, a model/config picker, a permission dialog). Unlike the
+// thinking-block error this IS auto-recovered: a single Escape pops the modal
+// without touching the conversation, so it is non-destructive. Reuses the
+// decidePaneErrorAlert state machine (treat its `alert` as "recover now") so a
+// one-tick transient never fires and the Escape is not re-sent every tick.
+// confirmMs keeps it to ~2 ticks (~1-2 min) before recovering; dedupMs throttles
+// retries if the Escape did not take; clearMs survives brief capture blips.
+const paneMenuState: Map<string, PaneErrorAlertState> = new Map()
+const MENU_RECOVER_CONFIRM_MS = 45_000
+const MENU_RECOVER_DEDUP_MS = 5 * 60 * 1000
+const MENU_RECOVER_CLEAR_MS = 2 * 60 * 1000
 
 type MarveenRecoveryStage = 'soft' | 'save' | 'resume' | 'hard' | 'gave_up'
 interface MarveenDownState {
@@ -910,6 +923,41 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         const label = t.isMarveen ? BOT_NAME : (t.agentName ?? t.session)
         logger.error({ session: t.session, agent: label }, 'Agent wedged on thinking-block API error -- manual reset needed')
         sendAlert(`🚨 A(z) ${label} agens elakadt egy thinking-block API hibaban (a session-history korrupt, minden uj prompt ugyanazt a 400-at adja). Kezi reset kell: allitsd le es inditsd ujra, friss session indul. Reszletek: tmux attach -t ${t.session}`)
+      }
+    }
+
+    // Blocking-menu recovery (main + sub-agents). A session parked in an
+    // interactive modal (/mcp manager, model/config picker, permission dialog)
+    // is neither busy nor idle, so detectPaneState reads 'unknown' and the
+    // scheduler/router silently skip it -- the session goes deaf with nothing
+    // alerting (observed: main session sat in /mcp ~6h). A single Escape pops
+    // the modal back to the prompt without touching the conversation, so unlike
+    // the thinking-block error this is safe to auto-recover. Same debounce
+    // machine as the error pass (alert == "recover now") so a one-tick frame
+    // never fires and the Escape is not re-sent every tick.
+    for (const t of targets) {
+      const pane = capturePane(t.session)
+      const inMenu = pane != null && detectsBlockingMenu(pane)
+      const prev = paneMenuState.get(t.session) ?? { firstSeenAt: null, lastAlertAt: null, lastErrorAt: null }
+      const decision = decidePaneErrorAlert(inMenu, prev, Date.now(), {
+        confirmMs: MENU_RECOVER_CONFIRM_MS,
+        dedupMs: MENU_RECOVER_DEDUP_MS,
+        clearMs: MENU_RECOVER_CLEAR_MS,
+      })
+      if (decision.next.firstSeenAt === null) {
+        paneMenuState.delete(t.session)
+      } else {
+        paneMenuState.set(t.session, decision.next)
+      }
+      if (decision.alert) {
+        const label = t.isMarveen ? BOT_NAME : (t.agentName ?? t.session)
+        logger.warn({ session: t.session, agent: label }, 'Session parked in a blocking interactive menu -- sending Escape to recover')
+        try {
+          execFileSync(TMUX, ['send-keys', '-t', t.session, 'Escape'], { timeout: 5000 })
+        } catch (err) {
+          logger.warn({ err, session: t.session }, 'Menu-recovery Escape failed')
+        }
+        sendAlert(`⌨️ A(z) ${label} session beragadt egy interaktiv menube (pl. /mcp) es nem dolgozott fel uzeneteket. Kikuldtem egy Escape-et, visszateritettem a prompthoz. Ha ismetlodik: tmux attach -t ${t.session}`)
       }
     }
 


### PR DESCRIPTION
…menu

A headless session (the main --channels session or a sub-agent) parked in a Claude Code modal -- the /mcp manager, a model/config picker, a permission dialog -- is neither 'busy' nor 'idle', so detectPaneState reads 'unknown' and the scheduler/router silently skip it. The session goes deaf with nothing alerting: the main channels session was observed sitting in /mcp for ~6h, unresponsive on Telegram.

- Add detectsBlockingMenu() to pane-state: pure, dependency-free, recognises the modal by its navigate/dismiss footer while guarding against busy turns, the normal idle prompt, and reply text that merely quotes menu chrome.
- channel-monitor: per-session recovery pass reusing the decidePaneErrorAlert debounce machine. After ~2 ticks of a confirmed menu it sends a single Escape (non-destructive -- pops the modal, conversation intact) and alerts. Dedup throttles retries; clearMs survives capture blips.
- Unit tests for the real /mcp fixture, esc-only modals, and the negatives (idle footers, busy panes, quoted chrome, empty panes).

detectPaneState still returns 'unknown' for these panes, so the hot-path scheduler/router behaviour is unchanged.