### PR TITLE
feat(chat-app): Google Workspace login + per-user cookie sessions (/chat-api/auth)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,13 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # OLLAMA_URL=http://localhost:11434
 # MARVEEN_ENV=linux-server  # platform override: macos | linux-server | linux-gui
 # GOOGLE_API_KEY=your_google_api_key
+#
+# Chat app (per-user web chat, Google Workspace login) — opcionális:
+# CHAT_APP_ENABLED=1
+# CHAT_GOOGLE_CLIENT_ID=your_oauth_web_client_id.apps.googleusercontent.com
+# CHAT_GOOGLE_CLIENT_SECRET=your_oauth_web_client_secret
+# CHAT_ALLOWED_DOMAIN=example.com            # csak ennek a Workspace domainnek a fiókjai léphetnek be
+# CHAT_PUBLIC_URL=https://chat.example.com   # a böngésző felőli origin (OAuth redirect URI + Secure cookie)
+# CHAT_SESSION_TTL_HOURS=24
+# A belépő email -> agent leképezés a store/chat-users.json fájlban él
+# (lásd chat-users.example.json), restart nélkül újraolvasódik.

--- a/chat-users.example.json
+++ b/chat-users.example.json
@@ -1,0 +1,4 @@
+{
+  "alice@example.com": "alice",
+  "bob@example.com": "bob"
+}

--- a/src/__tests__/chat-auth.test.ts
+++ b/src/__tests__/chat-auth.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  decodeIdTokenClaims, validateIdClaims, validateWorkspaceUser, buildGoogleAuthUrl,
+  type GoogleIdClaims,
+} from '../web/chat/google-oauth.js'
+import { resolveAgentForEmail, resetChatUsersCache } from '../web/chat/chat-users.js'
+import { parseCookies, buildSessionCookie, createSession, getChatUser, destroySession } from '../web/chat/chat-session.js'
+import { initDatabase, createChatWebSession, getChatWebSession, pruneExpiredChatWebSessions } from '../db.js'
+import type http from 'node:http'
+
+const CLIENT_ID = 'test-client.apps.googleusercontent.com'
+
+function makeClaims(overrides: Partial<GoogleIdClaims> = {}): GoogleIdClaims {
+  return {
+    iss: 'https://accounts.google.com',
+    aud: CLIENT_ID,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    nonce: 'nonce-1',
+    email: 'alice@example.com',
+    email_verified: true,
+    hd: 'example.com',
+    ...overrides,
+  }
+}
+
+describe('validateIdClaims', () => {
+  const expected = { clientId: CLIENT_ID, nonce: 'nonce-1' }
+
+  it('accepts a valid claim set', () => {
+    expect(validateIdClaims(makeClaims(), expected)).toEqual({ ok: true })
+  })
+
+  it('rejects a foreign issuer', () => {
+    const r = validateIdClaims(makeClaims({ iss: 'https://evil.example' }), expected)
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects an audience mismatch (token minted for another client)', () => {
+    const r = validateIdClaims(makeClaims({ aud: 'other-client' }), expected)
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects an expired token', () => {
+    const r = validateIdClaims(makeClaims({ exp: Math.floor(Date.now() / 1000) - 10 }), expected)
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects a nonce mismatch (replayed token from another login flow)', () => {
+    const r = validateIdClaims(makeClaims({ nonce: 'other-nonce' }), expected)
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects an unverified email', () => {
+    const r = validateIdClaims(makeClaims({ email_verified: false }), expected)
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('validateWorkspaceUser (server-side domain gate)', () => {
+  it('accepts a workspace account of the allowed domain', () => {
+    expect(validateWorkspaceUser(makeClaims(), 'example.com')).toEqual({ ok: true, email: 'alice@example.com' })
+  })
+
+  it('lowercases the returned email', () => {
+    const r = validateWorkspaceUser(makeClaims({ email: 'Alice@Example.com' }), 'example.com')
+    expect(r).toEqual({ ok: true, email: 'alice@example.com' })
+  })
+
+  it('rejects when hd is missing (consumer Gmail account)', () => {
+    const r = validateWorkspaceUser(makeClaims({ hd: undefined }), 'example.com')
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects a foreign workspace domain even with a matching email suffix', () => {
+    const r = validateWorkspaceUser(makeClaims({ hd: 'other.com' }), 'example.com')
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects an email outside the domain even when hd matches', () => {
+    const r = validateWorkspaceUser(makeClaims({ email: 'alice@other.com' }), 'example.com')
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects everything when no domain is configured', () => {
+    const r = validateWorkspaceUser(makeClaims(), '')
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('decodeIdTokenClaims', () => {
+  it('decodes the payload of an unsigned-format JWT', () => {
+    const payload = Buffer.from(JSON.stringify(makeClaims()), 'utf-8').toString('base64url')
+    const token = `eyJhbGciOiJSUzI1NiJ9.${payload}.sig`
+    expect(decodeIdTokenClaims(token).email).toBe('alice@example.com')
+  })
+
+  it('throws on a malformed token', () => {
+    expect(() => decodeIdTokenClaims('not-a-jwt')).toThrow()
+  })
+})
+
+describe('buildGoogleAuthUrl', () => {
+  it('carries state, nonce and the domain hint', () => {
+    const url = new URL(buildGoogleAuthUrl({ clientId: CLIENT_ID, redirectUri: 'https://chat.example.com/chat-api/auth/callback' }, 's1', 'n1', 'example.com'))
+    expect(url.searchParams.get('state')).toBe('s1')
+    expect(url.searchParams.get('nonce')).toBe('n1')
+    expect(url.searchParams.get('hd')).toBe('example.com')
+    expect(url.searchParams.get('redirect_uri')).toBe('https://chat.example.com/chat-api/auth/callback')
+    expect(url.searchParams.get('scope')).toBe('openid email')
+  })
+})
+
+describe('chat-users mapping', () => {
+  let dir: string
+  let path: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chat-users-'))
+    path = join(dir, 'chat-users.json')
+    resetChatUsersCache()
+  })
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('resolves a mapped email case-insensitively', () => {
+    writeFileSync(path, JSON.stringify({ 'Alice@Example.com': 'alice-agent' }))
+    expect(resolveAgentForEmail('alice@EXAMPLE.com', path)).toBe('alice-agent')
+  })
+
+  it('returns null for an unmapped email (mapping doubles as allowlist)', () => {
+    writeFileSync(path, JSON.stringify({ 'alice@example.com': 'alice-agent' }))
+    expect(resolveAgentForEmail('mallory@example.com', path)).toBeNull()
+  })
+
+  it('returns null when the mapping file does not exist', () => {
+    expect(resolveAgentForEmail('alice@example.com', join(dir, 'missing.json'))).toBeNull()
+  })
+
+  it('skips invalid entries instead of failing the whole file', () => {
+    writeFileSync(path, JSON.stringify({ 'not-an-email': 'x', 'bob@example.com': 'bob-agent', 'carol@example.com': 42 }))
+    expect(resolveAgentForEmail('bob@example.com', path)).toBe('bob-agent')
+    expect(resolveAgentForEmail('carol@example.com', path)).toBeNull()
+  })
+})
+
+describe('chat web sessions', () => {
+  beforeEach(() => initDatabase(':memory:'))
+
+  function fakeReq(cookie?: string): http.IncomingMessage {
+    return { headers: cookie ? { cookie } : {} } as http.IncomingMessage
+  }
+
+  it('round-trips a session through the cookie', () => {
+    const { sid } = createSession('alice@example.com', 'alice-agent')
+    const user = getChatUser(fakeReq(`marveen_chat_sid=${sid}`))
+    expect(user).toEqual({ email: 'alice@example.com', agentId: 'alice-agent' })
+  })
+
+  it('stores only a hash: the raw sid never appears in the DB', () => {
+    const { sid } = createSession('alice@example.com', 'alice-agent')
+    expect(getChatWebSession(sid)).toBeUndefined()
+  })
+
+  it('rejects a forged / malformed sid', () => {
+    createSession('alice@example.com', 'alice-agent')
+    expect(getChatUser(fakeReq('marveen_chat_sid=deadbeef'))).toBeNull()
+    expect(getChatUser(fakeReq(`marveen_chat_sid=${'0'.repeat(64)}`))).toBeNull()
+    expect(getChatUser(fakeReq())).toBeNull()
+  })
+
+  it('expires sessions and prunes them', () => {
+    createChatWebSession('h1', 'a@example.com', 'a', -1000) // already expired
+    expect(getChatWebSession('h1')).toBeUndefined()
+    createChatWebSession('h2', 'b@example.com', 'b', -1000)
+    expect(pruneExpiredChatWebSessions()).toBeGreaterThanOrEqual(1)
+  })
+
+  it('logout destroys the session server-side', () => {
+    const { sid } = createSession('alice@example.com', 'alice-agent')
+    destroySession(fakeReq(`marveen_chat_sid=${sid}`))
+    expect(getChatUser(fakeReq(`marveen_chat_sid=${sid}`))).toBeNull()
+  })
+
+  it('session cookie is HttpOnly + SameSite=Lax', () => {
+    const cookie = buildSessionCookie('abc', 60)
+    expect(cookie).toContain('HttpOnly')
+    expect(cookie).toContain('SameSite=Lax')
+    expect(cookie).toContain('Max-Age=60')
+  })
+})
+
+describe('parseCookies', () => {
+  it('parses multiple cookies and ignores malformed parts', () => {
+    expect(parseCookies('a=1; b=2; malformed; c=%20x')).toEqual({ a: '1', b: '2', c: ' x' })
+  })
+  it('handles a missing header', () => {
+    expect(parseCookies(undefined)).toEqual({})
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,20 @@ export const RESPAWN_ENABLED =
         ? hostname().toLowerCase().includes(RESPAWN_HOST)
         : true
 
+// Chat app (per-user web chat, Google Workspace login). OFF by default: the
+// feature exposes a cookie-authenticated API namespace (/chat-api/*) next to
+// the bearer-gated admin /api/*, so an install must opt in explicitly and
+// provide its own OAuth client. CHAT_PUBLIC_URL is the browser-facing origin
+// (behind the reverse proxy) used for the OAuth redirect URI and the cookie
+// Secure flag.
+export const CHAT_APP_ENABLED =
+  ['1', 'true', 'yes', 'on'].includes((env['CHAT_APP_ENABLED'] ?? '').trim().toLowerCase())
+export const CHAT_GOOGLE_CLIENT_ID = (env['CHAT_GOOGLE_CLIENT_ID'] ?? '').trim()
+export const CHAT_GOOGLE_CLIENT_SECRET = (env['CHAT_GOOGLE_CLIENT_SECRET'] ?? '').trim()
+export const CHAT_ALLOWED_DOMAIN = (env['CHAT_ALLOWED_DOMAIN'] ?? '').trim().toLowerCase()
+export const CHAT_PUBLIC_URL = (env['CHAT_PUBLIC_URL'] ?? '').trim().replace(/\/$/, '')
+export const CHAT_SESSION_TTL_HOURS = parseInt(env['CHAT_SESSION_TTL_HOURS'] ?? '24', 10)
+
 // Heartbeat
 export const HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
 export const HEARTBEAT_START_HOUR = 9

--- a/src/db.ts
+++ b/src/db.ts
@@ -484,6 +484,20 @@ export function initDatabase(dbPathOverride?: string): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_session ON tool_call_log(session_id, created_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_ts ON tool_call_log(created_at)`)
 
+  // --- Chat app web sessions (per-user Google login) ---
+  // Only the SHA-256 hash of the session id is stored: a leaked DB file (or a
+  // sub-agent reading store/) must not yield usable login cookies.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chat_web_sessions (
+      sid_hash TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_chat_web_sessions_expiry ON chat_web_sessions(expires_at)`)
+
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
   // re-importing. Wrapped in a transaction so a crash mid-import is safe.
@@ -1681,3 +1695,38 @@ export function pruneToolCallLog(olderThanSecs = 86400): void {
   db.prepare('DELETE FROM tool_call_log WHERE created_at < ?').run(cutoff)
 }
 
+
+// --- Chat app web sessions ---
+
+export interface ChatWebSession {
+  email: string
+  agentId: string
+  expiresAt: number
+}
+
+export function createChatWebSession(sidHash: string, email: string, agentId: string, ttlMs: number): void {
+  const now = Date.now()
+  db.prepare(
+    'INSERT INTO chat_web_sessions (sid_hash, email, agent_id, created_at, expires_at) VALUES (?, ?, ?, ?, ?)',
+  ).run(sidHash, email, agentId, now, now + ttlMs)
+}
+
+export function getChatWebSession(sidHash: string): ChatWebSession | undefined {
+  const row = db.prepare(
+    'SELECT email, agent_id, expires_at FROM chat_web_sessions WHERE sid_hash = ?',
+  ).get(sidHash) as { email: string; agent_id: string; expires_at: number } | undefined
+  if (!row) return undefined
+  if (row.expires_at <= Date.now()) {
+    db.prepare('DELETE FROM chat_web_sessions WHERE sid_hash = ?').run(sidHash)
+    return undefined
+  }
+  return { email: row.email, agentId: row.agent_id, expiresAt: row.expires_at }
+}
+
+export function deleteChatWebSession(sidHash: string): void {
+  db.prepare('DELETE FROM chat_web_sessions WHERE sid_hash = ?').run(sidHash)
+}
+
+export function pruneExpiredChatWebSessions(): number {
+  return db.prepare('DELETE FROM chat_web_sessions WHERE expires_at <= ?').run(Date.now()).changes
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,7 +2,7 @@ import http from 'node:http'
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { execSync, execFileSync } from 'node:child_process'
-import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL } from './config.js'
+import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL, CHAT_APP_ENABLED, CHAT_PUBLIC_URL } from './config.js'
 import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-auth.js'
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
@@ -48,6 +48,8 @@ import { tryHandleTokenUsage } from './web/routes/token-usage.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleStatic } from './web/routes/static.js'
+import { tryHandleChatAuth } from './web/routes/chat-auth.js'
+import { pruneExpiredChatWebSessions } from './db.js'
 import type { RouteContext } from './web/routes/types.js'
 
 const WEB_DIR = join(PROJECT_ROOT, 'web')
@@ -68,6 +70,7 @@ export function startWebServer(port = 3420): http.Server {
     `http://127.0.0.1:${port}`,
     ...( WEB_HOST !== 'localhost' && WEB_HOST !== '127.0.0.1' ? [`http://${WEB_HOST}:${port}`] : []),
     ...(DASHBOARD_PUBLIC_URL ? [DASHBOARD_PUBLIC_URL.replace(/\/$/, '')] : []),
+    ...(CHAT_APP_ENABLED && CHAT_PUBLIC_URL ? [CHAT_PUBLIC_URL] : []),
   ])
   const isSafeMethod = (m: string) => m === 'GET' || m === 'HEAD' || m === 'OPTIONS'
 
@@ -135,6 +138,11 @@ export function startWebServer(port = 3420): http.Server {
 
     try {
       const routeCtx: RouteContext = { req, res, path, method, url }
+
+      // Chat app namespace (/chat-api/*): cookie-session auth, fully separate
+      // from the /api/* bearer gate above. The handler self-gates on
+      // CHAT_APP_ENABLED (404 when off).
+      if (await tryHandleChatAuth(routeCtx)) return
 
       if (await tryHandleProfiles(routeCtx)) return
       if (await tryHandleMessages(routeCtx)) return
@@ -285,6 +293,16 @@ export function startWebServer(port = 3420): http.Server {
   const updateCheckerInterval = startUpdateChecker()
   logger.info('Update checker started (15min poll)')
 
+  // Expired chat sessions are also dropped lazily on lookup; this sweep just
+  // keeps the table from accumulating rows for users who never come back.
+  let chatSessionPruneInterval: NodeJS.Timeout | null = null
+  if (CHAT_APP_ENABLED) {
+    chatSessionPruneInterval = setInterval(() => {
+      try { pruneExpiredChatWebSessions() } catch { /* table missing only before initDatabase */ }
+    }, 60 * 60 * 1000)
+    logger.info('Chat app enabled: /chat-api namespace active, session prune started (1h)')
+  }
+
   // NOTE: startMcpListChecker() is intentionally NOT called here.
   //
   // Root cause: calling `claude mcp list` at boot time (30s delay) spawns the
@@ -349,6 +367,7 @@ export function startWebServer(port = 3420): http.Server {
     if (reauthHealerInterval) clearInterval(reauthHealerInterval)
     clearInterval(autoRestartInterval)
     clearInterval(updateCheckerInterval)
+    if (chatSessionPruneInterval) clearInterval(chatSessionPruneInterval)
     return origClose(cb)
   }
 

--- a/src/web/chat/chat-session.ts
+++ b/src/web/chat/chat-session.ts
@@ -1,0 +1,85 @@
+// Cookie-backed server-side sessions for the chat app. Deliberately separate
+// from the dashboard bearer token: a chat login must never grant /api/* admin
+// access, and the admin token must never reach a chat user's browser. The
+// cookie carries a random 256-bit id; only its SHA-256 hash is persisted
+// (chat_web_sessions table), so neither the DB file nor a backup yields a
+// usable cookie.
+import type http from 'node:http'
+import { createHash, randomBytes } from 'node:crypto'
+import {
+  createChatWebSession, getChatWebSession, deleteChatWebSession,
+} from '../../db.js'
+import { CHAT_PUBLIC_URL, CHAT_SESSION_TTL_HOURS } from '../../config.js'
+
+export const CHAT_SESSION_COOKIE = 'marveen_chat_sid'
+
+function hashSid(sid: string): string {
+  return createHash('sha256').update(sid).digest('hex')
+}
+
+export function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!header) return out
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    const name = part.slice(0, eq).trim()
+    const value = part.slice(eq + 1).trim()
+    if (name) out[name] = decodeURIComponent(value)
+  }
+  return out
+}
+
+function cookieIsSecure(): boolean {
+  // Behind the public reverse proxy the browser-facing origin is https; on a
+  // bare localhost dev setup it is http, where a Secure cookie would never be
+  // sent back.
+  return CHAT_PUBLIC_URL.startsWith('https://')
+}
+
+export function buildSessionCookie(sid: string, maxAgeSeconds: number): string {
+  const attrs = [
+    `${CHAT_SESSION_COOKIE}=${sid}`,
+    'HttpOnly',
+    'Path=/',
+    'SameSite=Lax',
+    `Max-Age=${maxAgeSeconds}`,
+  ]
+  if (cookieIsSecure()) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+export function buildClearedSessionCookie(): string {
+  const attrs = [`${CHAT_SESSION_COOKIE}=`, 'HttpOnly', 'Path=/', 'SameSite=Lax', 'Max-Age=0']
+  if (cookieIsSecure()) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+export interface ChatUser {
+  email: string
+  agentId: string
+}
+
+export function createSession(email: string, agentId: string): { sid: string; maxAgeSeconds: number } {
+  const sid = randomBytes(32).toString('hex')
+  const ttlMs = CHAT_SESSION_TTL_HOURS * 60 * 60 * 1000
+  createChatWebSession(hashSid(sid), email, agentId, ttlMs)
+  return { sid, maxAgeSeconds: Math.floor(ttlMs / 1000) }
+}
+
+// The per-request authorization boundary for /chat-api/*: returns the logged-
+// in user (email + their own agent) or null. Every chat endpoint must scope
+// strictly to the returned agentId -- never to an agent name taken from the
+// request.
+export function getChatUser(req: http.IncomingMessage): ChatUser | null {
+  const sid = parseCookies(req.headers.cookie)[CHAT_SESSION_COOKIE]
+  if (!sid || !/^[0-9a-f]{64}$/.test(sid)) return null
+  const session = getChatWebSession(hashSid(sid))
+  if (!session) return null
+  return { email: session.email, agentId: session.agentId }
+}
+
+export function destroySession(req: http.IncomingMessage): void {
+  const sid = parseCookies(req.headers.cookie)[CHAT_SESSION_COOKIE]
+  if (sid) deleteChatWebSession(hashSid(sid))
+}

--- a/src/web/chat/chat-users.ts
+++ b/src/web/chat/chat-users.ts
@@ -1,0 +1,57 @@
+// Email -> agent mapping for the chat app. Operators maintain a plain JSON
+// file at store/chat-users.json:
+//
+//   { "alice@example.com": "alice", "bob@example.com": "bob" }
+//
+// The file is re-read when its mtime changes, so entries can be added or
+// removed without restarting the server. An email that is missing here gets a
+// 403 at login even with a valid Workspace account -- the mapping doubles as
+// the allowlist.
+import { readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../../config.js'
+import { logger } from '../../logger.js'
+
+export const CHAT_USERS_PATH = join(PROJECT_ROOT, 'store', 'chat-users.json')
+
+let cache: { mtimeMs: number; map: Map<string, string> } | null = null
+
+function loadMap(path: string): Map<string, string> {
+  const raw = JSON.parse(readFileSync(path, 'utf-8')) as unknown
+  const map = new Map<string, string>()
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('chat-users.json must be a JSON object of "email": "agent" pairs')
+  }
+  for (const [email, agent] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof agent !== 'string' || !agent.trim() || !email.includes('@')) {
+      logger.warn({ email }, 'chat-users.json: skipping invalid entry')
+      continue
+    }
+    map.set(email.trim().toLowerCase(), agent.trim())
+  }
+  return map
+}
+
+export function resolveAgentForEmail(email: string, path = CHAT_USERS_PATH): string | null {
+  let mtimeMs: number
+  try {
+    mtimeMs = statSync(path).mtimeMs
+  } catch {
+    return null // no mapping file -> nobody can log in
+  }
+  if (!cache || cache.mtimeMs !== mtimeMs) {
+    try {
+      cache = { mtimeMs, map: loadMap(path) }
+    } catch (err) {
+      logger.error({ err, path }, 'chat-users.json unreadable; keeping previous mapping')
+      if (!cache) return null
+    }
+  }
+  return cache.map.get(email.trim().toLowerCase()) ?? null
+}
+
+// Test hook: drop the mtime cache so a rewritten temp file is re-read even
+// when the filesystem mtime granularity would hide the change.
+export function resetChatUsersCache(): void {
+  cache = null
+}

--- a/src/web/chat/google-oauth.ts
+++ b/src/web/chat/google-oauth.ts
@@ -1,0 +1,110 @@
+// Google OAuth (authorization code flow) for the chat app login.
+//
+// Trust model: the id_token is obtained server-side, directly from Google's
+// token endpoint over TLS, so its JWT signature is NOT re-verified here --
+// the TLS channel to oauth2.googleapis.com authenticates the issuer (this is
+// the standard "token endpoint response" trust case from OIDC Core 3.1.3.7).
+// What MUST still be validated server-side, because the values themselves can
+// be wrong for our purposes even in a genuine Google token: iss, aud, exp,
+// nonce, email_verified, and the Workspace domain (hd + email suffix -- the
+// `hd` REQUEST parameter is a client-side hint only and is spoofable, so the
+// domain decision is made exclusively on the returned claims).
+
+export interface GoogleIdClaims {
+  iss?: string
+  aud?: string
+  exp?: number
+  nonce?: string
+  email?: string
+  email_verified?: boolean
+  hd?: string
+}
+
+export interface OAuthClientConfig {
+  clientId: string
+  clientSecret: string
+  redirectUri: string
+}
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const GOOGLE_ISSUERS = new Set(['https://accounts.google.com', 'accounts.google.com'])
+
+export function buildGoogleAuthUrl(
+  cfg: { clientId: string; redirectUri: string },
+  state: string,
+  nonce: string,
+  domainHint?: string,
+): string {
+  const params = new URLSearchParams({
+    client_id: cfg.clientId,
+    redirect_uri: cfg.redirectUri,
+    response_type: 'code',
+    scope: 'openid email',
+    state,
+    nonce,
+    prompt: 'select_account',
+  })
+  // UX hint only (pre-filters the account chooser); the real domain check
+  // happens on the returned claims in validateWorkspaceUser.
+  if (domainHint) params.set('hd', domainHint)
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`
+}
+
+export async function exchangeCodeForIdToken(code: string, cfg: OAuthClientConfig): Promise<string> {
+  const res = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: cfg.clientId,
+      client_secret: cfg.clientSecret,
+      redirect_uri: cfg.redirectUri,
+      grant_type: 'authorization_code',
+    }).toString(),
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Google token endpoint returned ${res.status}: ${body.slice(0, 200)}`)
+  }
+  const data = (await res.json()) as { id_token?: string }
+  if (!data.id_token) throw new Error('Google token response missing id_token')
+  return data.id_token
+}
+
+export function decodeIdTokenClaims(idToken: string): GoogleIdClaims {
+  const parts = idToken.split('.')
+  if (parts.length !== 3) throw new Error('Malformed id_token')
+  const payload = Buffer.from(parts[1], 'base64url').toString('utf-8')
+  return JSON.parse(payload) as GoogleIdClaims
+}
+
+export function validateIdClaims(
+  claims: GoogleIdClaims,
+  expected: { clientId: string; nonce: string },
+  nowMs = Date.now(),
+): { ok: true } | { ok: false; reason: string } {
+  if (!claims.iss || !GOOGLE_ISSUERS.has(claims.iss)) return { ok: false, reason: 'bad issuer' }
+  if (claims.aud !== expected.clientId) return { ok: false, reason: 'audience mismatch' }
+  if (typeof claims.exp !== 'number' || claims.exp * 1000 <= nowMs) return { ok: false, reason: 'token expired' }
+  if (!claims.nonce || claims.nonce !== expected.nonce) return { ok: false, reason: 'nonce mismatch' }
+  if (claims.email_verified !== true) return { ok: false, reason: 'email not verified' }
+  if (!claims.email) return { ok: false, reason: 'missing email' }
+  return { ok: true }
+}
+
+// The Workspace gate. Both conditions are required: `hd` proves the account
+// belongs to the Workspace org (a gmail.com account named like the domain has
+// no hd), and the email suffix pins the primary address to the same domain.
+export function validateWorkspaceUser(
+  claims: GoogleIdClaims,
+  allowedDomain: string,
+): { ok: true; email: string } | { ok: false; reason: string } {
+  const domain = allowedDomain.trim().toLowerCase()
+  if (!domain) return { ok: false, reason: 'no allowed domain configured' }
+  const email = (claims.email ?? '').trim().toLowerCase()
+  if (!email) return { ok: false, reason: 'missing email' }
+  if ((claims.hd ?? '').toLowerCase() !== domain) return { ok: false, reason: 'not a workspace account of the allowed domain' }
+  if (!email.endsWith(`@${domain}`)) return { ok: false, reason: 'email domain mismatch' }
+  return { ok: true, email }
+}

--- a/src/web/routes/chat-auth.ts
+++ b/src/web/routes/chat-auth.ts
@@ -1,0 +1,182 @@
+// Chat app login endpoints (/chat-api/auth/*). Google Workspace OAuth ->
+// HttpOnly cookie session. This namespace is intentionally OUTSIDE /api/*:
+// the dashboard bearer gate does not apply here, and the chat session cookie
+// grants nothing under /api/*.
+import { randomBytes } from 'node:crypto'
+import {
+  CHAT_APP_ENABLED, CHAT_GOOGLE_CLIENT_ID, CHAT_GOOGLE_CLIENT_SECRET,
+  CHAT_ALLOWED_DOMAIN, CHAT_PUBLIC_URL, WEB_PORT,
+} from '../../config.js'
+import { logger } from '../../logger.js'
+import { json } from '../http-helpers.js'
+import {
+  buildGoogleAuthUrl, exchangeCodeForIdToken, decodeIdTokenClaims,
+  validateIdClaims, validateWorkspaceUser,
+} from '../chat/google-oauth.js'
+import { resolveAgentForEmail, CHAT_USERS_PATH } from '../chat/chat-users.js'
+import {
+  createSession, destroySession, getChatUser,
+  buildSessionCookie, buildClearedSessionCookie, parseCookies,
+} from '../chat/chat-session.js'
+import type { RouteContext } from './types.js'
+
+// Short-lived cookie carrying the OAuth state+nonce pair between /login and
+// /callback. Cookie-bound (not a server-side map) so it survives a server
+// restart mid-login and needs no cleanup.
+const OAUTH_FLOW_COOKIE = 'marveen_chat_oauth'
+const OAUTH_FLOW_TTL_SECONDS = 10 * 60
+
+function publicBaseUrl(): string {
+  return CHAT_PUBLIC_URL || `http://localhost:${WEB_PORT}`
+}
+
+function redirectUri(): string {
+  return `${publicBaseUrl()}/chat-api/auth/callback`
+}
+
+function oauthConfigured(): boolean {
+  return Boolean(CHAT_GOOGLE_CLIENT_ID && CHAT_GOOGLE_CLIENT_SECRET && CHAT_ALLOWED_DOMAIN)
+}
+
+function flowCookie(state: string, nonce: string): string {
+  const attrs = [
+    `${OAUTH_FLOW_COOKIE}=${state}.${nonce}`,
+    'HttpOnly',
+    'Path=/chat-api/auth',
+    'SameSite=Lax',
+    `Max-Age=${OAUTH_FLOW_TTL_SECONDS}`,
+  ]
+  if (publicBaseUrl().startsWith('https://')) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+function clearedFlowCookie(): string {
+  const attrs = [`${OAUTH_FLOW_COOKIE}=`, 'HttpOnly', 'Path=/chat-api/auth', 'SameSite=Lax', 'Max-Age=0']
+  if (publicBaseUrl().startsWith('https://')) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+// Login failures redirect back to the app root with a machine-readable code
+// (the future chat UI shows the message); they carry no session cookie.
+function failRedirect(res: RouteContext['res'], code: string): void {
+  res.writeHead(302, {
+    Location: `${publicBaseUrl()}/?login_error=${encodeURIComponent(code)}`,
+    'Set-Cookie': clearedFlowCookie(),
+    'Cache-Control': 'private, no-store',
+  })
+  res.end()
+}
+
+export async function tryHandleChatAuth(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method, url } = ctx
+  if (!path.startsWith('/chat-api/auth/')) return false
+
+  if (!CHAT_APP_ENABLED) {
+    json(res, { error: 'Chat app is not enabled' }, 404)
+    return true
+  }
+
+  if (path === '/chat-api/auth/login' && method === 'GET') {
+    if (!oauthConfigured()) {
+      logger.error('Chat app login attempted without CHAT_GOOGLE_CLIENT_ID/SECRET/CHAT_ALLOWED_DOMAIN configured')
+      json(res, { error: 'Chat login is not configured on this server' }, 503)
+      return true
+    }
+    const state = randomBytes(16).toString('hex')
+    const nonce = randomBytes(16).toString('hex')
+    const authUrl = buildGoogleAuthUrl(
+      { clientId: CHAT_GOOGLE_CLIENT_ID, redirectUri: redirectUri() },
+      state, nonce, CHAT_ALLOWED_DOMAIN,
+    )
+    res.writeHead(302, {
+      Location: authUrl,
+      'Set-Cookie': flowCookie(state, nonce),
+      'Cache-Control': 'private, no-store',
+    })
+    res.end()
+    return true
+  }
+
+  if (path === '/chat-api/auth/callback' && method === 'GET') {
+    const flowRaw = parseCookies(req.headers.cookie)[OAUTH_FLOW_COOKIE] ?? ''
+    const [cookieState, cookieNonce] = flowRaw.split('.')
+    const queryState = url.searchParams.get('state') ?? ''
+    const code = url.searchParams.get('code') ?? ''
+    if (!cookieState || !cookieNonce || !queryState || queryState !== cookieState) {
+      failRedirect(res, 'state_mismatch')
+      return true
+    }
+    if (!code) {
+      // User cancelled at Google (error=access_denied) or malformed callback.
+      failRedirect(res, 'cancelled')
+      return true
+    }
+    let email: string
+    try {
+      const idToken = await exchangeCodeForIdToken(code, {
+        clientId: CHAT_GOOGLE_CLIENT_ID,
+        clientSecret: CHAT_GOOGLE_CLIENT_SECRET,
+        redirectUri: redirectUri(),
+      })
+      const claims = decodeIdTokenClaims(idToken)
+      const claimCheck = validateIdClaims(claims, { clientId: CHAT_GOOGLE_CLIENT_ID, nonce: cookieNonce })
+      if (!claimCheck.ok) {
+        logger.warn({ reason: claimCheck.reason }, 'Chat login rejected: invalid id_token claims')
+        failRedirect(res, 'invalid_token')
+        return true
+      }
+      const domainCheck = validateWorkspaceUser(claims, CHAT_ALLOWED_DOMAIN)
+      if (!domainCheck.ok) {
+        logger.warn({ reason: domainCheck.reason }, 'Chat login rejected: domain check failed')
+        failRedirect(res, 'forbidden_domain')
+        return true
+      }
+      email = domainCheck.email
+    } catch (err) {
+      logger.error({ err }, 'Chat login: code exchange failed')
+      failRedirect(res, 'exchange_failed')
+      return true
+    }
+
+    const agentId = resolveAgentForEmail(email)
+    if (!agentId) {
+      logger.warn({ email }, `Chat login rejected: no agent mapping (add the user to ${CHAT_USERS_PATH})`)
+      failRedirect(res, 'no_agent')
+      return true
+    }
+
+    const { sid, maxAgeSeconds } = createSession(email, agentId)
+    logger.info({ email, agentId }, 'Chat login successful')
+    res.writeHead(302, {
+      Location: `${publicBaseUrl()}/`,
+      'Set-Cookie': [buildSessionCookie(sid, maxAgeSeconds), clearedFlowCookie()],
+      'Cache-Control': 'private, no-store',
+    })
+    res.end()
+    return true
+  }
+
+  if (path === '/chat-api/auth/me' && method === 'GET') {
+    const user = getChatUser(req)
+    if (!user) {
+      json(res, { authenticated: false }, 401)
+      return true
+    }
+    json(res, { authenticated: true, email: user.email, agent: user.agentId })
+    return true
+  }
+
+  if (path === '/chat-api/auth/logout' && method === 'POST') {
+    destroySession(req)
+    res.writeHead(200, {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Set-Cookie': buildClearedSessionCookie(),
+      'Cache-Control': 'private, no-store',
+    })
+    res.end(JSON.stringify({ ok: true }))
+    return true
+  }
+
+  json(res, { error: 'Not found' }, 404)
+  return true
+}


### PR DESCRIPTION
First PR of the chat app track (multi-thread, per-user web chat next to the admin dashboard — plan agreed 2026-06-12). This adds the authentication foundation only; chat endpoints and the UI come in follow-up PRs.

## What

- **Google OAuth login** (`GET /chat-api/auth/login` → Google → `GET /chat-api/auth/callback`): authorization-code flow with state+nonce carried in a short-lived HttpOnly cookie. The id_token is obtained server-side directly from Google's token endpoint over TLS; `iss`/`aud`/`exp`/`nonce`/`email_verified` are validated server-side.
- **Workspace domain gate**: BOTH the `hd` claim and the email suffix must match `CHAT_ALLOWED_DOMAIN`. The `hd` *request* parameter is treated as a UX hint only — the decision is made exclusively on the returned claims, since the request param is client-side spoofable.
- **Email → agent mapping as allowlist**: `store/chat-users.json` (see `chat-users.example.json`), mtime-cached so it's editable without a restart. An unmapped email gets a login error even with a valid Workspace account.
- **Server-side sessions**: new `chat_web_sessions` table; the cookie carries a random 256-bit id, only its SHA-256 hash is persisted (a leaked DB/backup yields no usable cookie). HttpOnly + SameSite=Lax (+ Secure when `CHAT_PUBLIC_URL` is https), TTL configurable (`CHAT_SESSION_TTL_HOURS`, default 24h), lazy expiry on lookup + hourly prune sweep.
- **`/chat-api/auth/me`** (session probe) and **`POST /chat-api/auth/logout`** (server-side destroy + cookie clear).

## Isolation guarantees

- The `/chat-api/*` namespace is fully separate from the bearer-gated admin `/api/*`: a chat session cookie grants **nothing** under `/api/*`, and the dashboard token never reaches a chat user's browser.
- Every future chat endpoint scopes to the agent id stored in the session row — never to an agent name taken from the request (`getChatUser()` is the per-request boundary).
- Everything is behind `CHAT_APP_ENABLED` (default **off**). An existing install is byte-for-byte unaffected until it opts in and brings its own OAuth web client (`.env.example` documents the new vars).

## Tests

27 new tests (`src/__tests__/chat-auth.test.ts`): id_token claim validation (issuer/audience/expiry/nonce/unverified-email rejections), the hd+email domain gate (consumer-Gmail and foreign-workspace rejections), mapping allowlist behaviour, session round-trip/forged-sid/expiry/logout, cookie attributes. Full suite: 1224 passed.

Next PRs in the track: session-machinery generalisation (N sessions per agent), the `/chat-api/threads` API, then the chat frontend built on the #356 transcript renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)