### PR TITLE
feat(chat-app): per-user thread API (/chat-api/threads) — CRUD, messages, transcript timeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,5 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # CHAT_SESSION_TTL_HOURS=24
 # A belépő email -> agent leképezés a store/chat-users.json fájlban él
 # (lásd chat-users.example.json), restart nélkül újraolvasódik.
+# CHAT_THREAD_IDLE_MINUTES=45                # idle szál auto-felfüggesztés (backstop)
+# CHAT_MAX_OPEN_THREADS_PER_AGENT=10         # laza felső határ a nyitott szálakra

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,13 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # OLLAMA_URL=http://localhost:11434
 # MARVEEN_ENV=linux-server  # platform override: macos | linux-server | linux-gui
 # GOOGLE_API_KEY=your_google_api_key
+#
+# Chat app (per-user web chat, Google Workspace login) — opcionális:
+# CHAT_APP_ENABLED=1
+# CHAT_GOOGLE_CLIENT_ID=your_oauth_web_client_id.apps.googleusercontent.com
+# CHAT_GOOGLE_CLIENT_SECRET=your_oauth_web_client_secret
+# CHAT_ALLOWED_DOMAIN=example.com            # csak ennek a Workspace domainnek a fiókjai léphetnek be
+# CHAT_PUBLIC_URL=https://chat.example.com   # a böngésző felőli origin (OAuth redirect URI + Secure cookie)
+# CHAT_SESSION_TTL_HOURS=24
+# A belépő email -> agent leképezés a store/chat-users.json fájlban él
+# (lásd chat-users.example.json), restart nélkül újraolvasódik.

--- a/chat-users.example.json
+++ b/chat-users.example.json
@@ -1,0 +1,4 @@
+{
+  "alice@example.com": "alice",
+  "bob@example.com": "bob"
+}

--- a/src/__tests__/chat-auth.test.ts
+++ b/src/__tests__/chat-auth.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  decodeIdTokenClaims, validateIdClaims, validateWorkspaceUser, buildGoogleAuthUrl,
+  type GoogleIdClaims,
+} from '../web/chat/google-oauth.js'
+import { resolveAgentForEmail, resetChatUsersCache } from '../web/chat/chat-users.js'
+import { parseCookies, buildSessionCookie, createSession, getChatUser, destroySession } from '../web/chat/chat-session.js'
+import { initDatabase, createChatWebSession, getChatWebSession, pruneExpiredChatWebSessions } from '../db.js'
+import type http from 'node:http'
+
+const CLIENT_ID = 'test-client.apps.googleusercontent.com'
+
+function makeClaims(overrides: Partial<GoogleIdClaims> = {}): GoogleIdClaims {
+  return {
+    iss: 'https://accounts.google.com',
+    aud: CLIENT_ID,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    nonce: 'nonce-1',
+    email: 'alice@example.com',
+    email_verified: true,
+    hd: 'example.com',
+    ...overrides,
+  }
+}
+
+describe('validateIdClaims', () => {
+  const expected = { clientId: CLIENT_ID, nonce: 'nonce-1' }
+
+  it('accepts a valid claim set', () => {
+    expect(validateIdClaims(makeClaims(), expected)).toEqual({ ok: true })
+  })
+
+  it('rejects a foreign issuer', () => {
+    const r = validateIdClaims(makeClaims({ iss: 'https://evil.example' }), expected)
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects an audience mismatch (token minted for another client)', () => {
+    const r = validateIdClaims(makeClaims({ aud: 'other-client' }), expected)
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects an expired token', () => {
+    const r = validateIdClaims(makeClaims({ exp: Math.floor(Date.now() / 1000) - 10 }), expected)
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects a nonce mismatch (replayed token from another login flow)', () => {
+    const r = validateIdClaims(makeClaims({ nonce: 'other-nonce' }), expected)
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects an unverified email', () => {
+    const r = validateIdClaims(makeClaims({ email_verified: false }), expected)
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('validateWorkspaceUser (server-side domain gate)', () => {
+  it('accepts a workspace account of the allowed domain', () => {
+    expect(validateWorkspaceUser(makeClaims(), 'example.com')).toEqual({ ok: true, email: 'alice@example.com' })
+  })
+
+  it('lowercases the returned email', () => {
+    const r = validateWorkspaceUser(makeClaims({ email: 'Alice@Example.com' }), 'example.com')
+    expect(r).toEqual({ ok: true, email: 'alice@example.com' })
+  })
+
+  it('rejects when hd is missing (consumer Gmail account)', () => {
+    const r = validateWorkspaceUser(makeClaims({ hd: undefined }), 'example.com')
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects a foreign workspace domain even with a matching email suffix', () => {
+    const r = validateWorkspaceUser(makeClaims({ hd: 'other.com' }), 'example.com')
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects an email outside the domain even when hd matches', () => {
+    const r = validateWorkspaceUser(makeClaims({ email: 'alice@other.com' }), 'example.com')
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects everything when no domain is configured', () => {
+    const r = validateWorkspaceUser(makeClaims(), '')
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('decodeIdTokenClaims', () => {
+  it('decodes the payload of an unsigned-format JWT', () => {
+    const payload = Buffer.from(JSON.stringify(makeClaims()), 'utf-8').toString('base64url')
+    const token = `eyJhbGciOiJSUzI1NiJ9.${payload}.sig`
+    expect(decodeIdTokenClaims(token).email).toBe('alice@example.com')
+  })
+
+  it('throws on a malformed token', () => {
+    expect(() => decodeIdTokenClaims('not-a-jwt')).toThrow()
+  })
+})
+
+describe('buildGoogleAuthUrl', () => {
+  it('carries state, nonce and the domain hint', () => {
+    const url = new URL(buildGoogleAuthUrl({ clientId: CLIENT_ID, redirectUri: 'https://chat.example.com/chat-api/auth/callback' }, 's1', 'n1', 'example.com'))
+    expect(url.searchParams.get('state')).toBe('s1')
+    expect(url.searchParams.get('nonce')).toBe('n1')
+    expect(url.searchParams.get('hd')).toBe('example.com')
+    expect(url.searchParams.get('redirect_uri')).toBe('https://chat.example.com/chat-api/auth/callback')
+    expect(url.searchParams.get('scope')).toBe('openid email')
+  })
+})
+
+describe('chat-users mapping', () => {
+  let dir: string
+  let path: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chat-users-'))
+    path = join(dir, 'chat-users.json')
+    resetChatUsersCache()
+  })
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('resolves a mapped email case-insensitively', () => {
+    writeFileSync(path, JSON.stringify({ 'Alice@Example.com': 'alice-agent' }))
+    expect(resolveAgentForEmail('alice@EXAMPLE.com', path)).toBe('alice-agent')
+  })
+
+  it('returns null for an unmapped email (mapping doubles as allowlist)', () => {
+    writeFileSync(path, JSON.stringify({ 'alice@example.com': 'alice-agent' }))
+    expect(resolveAgentForEmail('mallory@example.com', path)).toBeNull()
+  })
+
+  it('returns null when the mapping file does not exist', () => {
+    expect(resolveAgentForEmail('alice@example.com', join(dir, 'missing.json'))).toBeNull()
+  })
+
+  it('skips invalid entries instead of failing the whole file', () => {
+    writeFileSync(path, JSON.stringify({ 'not-an-email': 'x', 'bob@example.com': 'bob-agent', 'carol@example.com': 42 }))
+    expect(resolveAgentForEmail('bob@example.com', path)).toBe('bob-agent')
+    expect(resolveAgentForEmail('carol@example.com', path)).toBeNull()
+  })
+})
+
+describe('chat web sessions', () => {
+  beforeEach(() => initDatabase(':memory:'))
+
+  function fakeReq(cookie?: string): http.IncomingMessage {
+    return { headers: cookie ? { cookie } : {} } as http.IncomingMessage
+  }
+
+  it('round-trips a session through the cookie', () => {
+    const { sid } = createSession('alice@example.com', 'alice-agent')
+    const user = getChatUser(fakeReq(`marveen_chat_sid=${sid}`))
+    expect(user).toEqual({ email: 'alice@example.com', agentId: 'alice-agent' })
+  })
+
+  it('stores only a hash: the raw sid never appears in the DB', () => {
+    const { sid } = createSession('alice@example.com', 'alice-agent')
+    expect(getChatWebSession(sid)).toBeUndefined()
+  })
+
+  it('rejects a forged / malformed sid', () => {
+    createSession('alice@example.com', 'alice-agent')
+    expect(getChatUser(fakeReq('marveen_chat_sid=deadbeef'))).toBeNull()
+    expect(getChatUser(fakeReq(`marveen_chat_sid=${'0'.repeat(64)}`))).toBeNull()
+    expect(getChatUser(fakeReq())).toBeNull()
+  })
+
+  it('expires sessions and prunes them', () => {
+    createChatWebSession('h1', 'a@example.com', 'a', -1000) // already expired
+    expect(getChatWebSession('h1')).toBeUndefined()
+    createChatWebSession('h2', 'b@example.com', 'b', -1000)
+    expect(pruneExpiredChatWebSessions()).toBeGreaterThanOrEqual(1)
+  })
+
+  it('logout destroys the session server-side', () => {
+    const { sid } = createSession('alice@example.com', 'alice-agent')
+    destroySession(fakeReq(`marveen_chat_sid=${sid}`))
+    expect(getChatUser(fakeReq(`marveen_chat_sid=${sid}`))).toBeNull()
+  })
+
+  it('session cookie is HttpOnly + SameSite=Lax', () => {
+    const cookie = buildSessionCookie('abc', 60)
+    expect(cookie).toContain('HttpOnly')
+    expect(cookie).toContain('SameSite=Lax')
+    expect(cookie).toContain('Max-Age=60')
+  })
+})
+
+describe('parseCookies', () => {
+  it('parses multiple cookies and ignores malformed parts', () => {
+    expect(parseCookies('a=1; b=2; malformed; c=%20x')).toEqual({ a: '1', b: '2', c: ' x' })
+  })
+  it('handles a missing header', () => {
+    expect(parseCookies(undefined)).toEqual({})
+  })
+})

--- a/src/__tests__/chat-thread-transcript.test.ts
+++ b/src/__tests__/chat-thread-transcript.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { parseThreadTimeline, deriveThreadTitle } from '../web/chat/thread-transcript.js'
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj)
+}
+
+function userLine(content: unknown, ts = '2026-06-12T10:00:00Z'): string {
+  return line({ type: 'user', timestamp: ts, message: { role: 'user', content } })
+}
+
+function assistantLine(blocks: unknown[], ts = '2026-06-12T10:00:05Z'): string {
+  return line({ type: 'assistant', timestamp: ts, message: { role: 'assistant', content: blocks } })
+}
+
+describe('parseThreadTimeline', () => {
+  it('renders plain user prompts and assistant text as a chat timeline', () => {
+    const jsonl = [
+      userLine('Szia, mi a heti terv?'),
+      assistantLine([{ type: 'text', text: 'Szia! Itt a heti terv: ...' }]),
+    ].join('\n')
+    const entries = parseThreadTimeline(jsonl)
+    expect(entries).toEqual([
+      { ts: '2026-06-12T10:00:00Z', kind: 'user', text: 'Szia, mi a heti terv?' },
+      { ts: '2026-06-12T10:00:05Z', kind: 'assistant', text: 'Szia! Itt a heti terv: ...' },
+    ])
+  })
+
+  it('skips tool_result user lines (array content is not a human message)', () => {
+    const jsonl = [
+      userLine('kérdés'),
+      userLine([{ type: 'tool_result', tool_use_id: 'x', content: 'file contents...' }]),
+    ].join('\n')
+    expect(parseThreadTimeline(jsonl)).toHaveLength(1)
+  })
+
+  it('strips system-reminder and slash-command blocks; drops lines with nothing left', () => {
+    const jsonl = [
+      userLine('<system-reminder>belső utasítás</system-reminder>valódi üzenet'),
+      userLine('<system-reminder>csak harness-zaj</system-reminder>'),
+      userLine('<command-name>/compact</command-name><command-message>compact</command-message>'),
+    ].join('\n')
+    const entries = parseThreadTimeline(jsonl)
+    expect(entries).toEqual([
+      expect.objectContaining({ kind: 'user', text: 'valódi üzenet' }),
+    ])
+  })
+
+  it('renders tool_use blocks as collapsed action labels', () => {
+    const jsonl = assistantLine([
+      { type: 'tool_use', name: 'Bash', input: { description: 'List files' } },
+      { type: 'tool_use', name: 'mcp__iss__iss_query_tickets', input: {} },
+      { type: 'text', text: 'Kész.' },
+    ])
+    const entries = parseThreadTimeline(jsonl)
+    expect(entries).toEqual([
+      expect.objectContaining({ kind: 'action', text: 'Bash: List files' }),
+      expect.objectContaining({ kind: 'action', text: 'iss_query_tickets' }),
+      expect.objectContaining({ kind: 'assistant', text: 'Kész.' }),
+    ])
+  })
+
+  it('tolerates malformed lines and applies the limit keeping the newest entries', () => {
+    const lines = ['not-json', '{"type":"user"}']
+    for (let i = 0; i < 10; i++) lines.push(userLine(`üzenet ${i}`))
+    const entries = parseThreadTimeline(lines.join('\n'), 3)
+    expect(entries.map(e => e.text)).toEqual(['üzenet 7', 'üzenet 8', 'üzenet 9'])
+  })
+})
+
+describe('deriveThreadTitle', () => {
+  it('uses the whole message when short', () => {
+    expect(deriveThreadTitle('Heti riport összeállítása')).toBe('Heti riport összeállítása')
+  })
+
+  it('collapses whitespace and cuts long messages at a word boundary with ellipsis', () => {
+    const title = deriveThreadTitle('Kérlek nézd át a   teljes\n szerződés-állományt és készíts részletes összefoglalót a lejáratokról ügyfelenként')
+    expect(title.length).toBeLessThanOrEqual(61)
+    expect(title.endsWith('…')).toBe(true)
+    expect(title).not.toContain('\n')
+  })
+})

--- a/src/__tests__/chat-threads.test.ts
+++ b/src/__tests__/chat-threads.test.ts
@@ -153,3 +153,11 @@ describe('pickIdleThreads (idle backstop decision)', () => {
     expect(pickIdleThreads([t], NOW, IDLE)).toHaveLength(1)
   })
 })
+
+describe('projectsDirFor encoding (transcript lookup)', () => {
+  it('encodes every non-alphanumeric char as dash, matching Claude Code', async () => {
+    const { projectsDirFor } = await import('../web/active-model.js')
+    const dir = projectsDirFor('/Users/x/code/is_backend_system/agents/demo.v2', undefined, '/home/u')
+    expect(dir).toBe('/home/u/.claude/projects/-Users-x-code-is-backend-system-agents-demo-v2')
+  })
+})

--- a/src/__tests__/chat-threads.test.ts
+++ b/src/__tests__/chat-threads.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  initDatabase, createChatThread, getChatThread, listChatThreads, listOpenChatThreads,
+  countOpenChatThreads, setChatThreadStatus, renameChatThread, touchChatThread,
+  type ChatThread,
+} from '../db.js'
+import {
+  threadSessionName, buildThreadLaunchCommand, pickIdleThreads,
+} from '../web/chat/thread-process.js'
+
+describe('chat_threads CRUD', () => {
+  beforeEach(() => initDatabase(':memory:'))
+
+  it('creates a thread with a deterministic claude session id and lists it', () => {
+    const t = createChatThread('alice', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', 'Első feladat')
+    expect(t.status).toBe('open')
+    expect(getChatThread(t.id)?.claude_session_id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+    expect(listChatThreads('alice')).toHaveLength(1)
+    expect(listChatThreads('bob')).toHaveLength(0)
+  })
+
+  it('closed threads drop out of the default list but stay queryable', () => {
+    const t = createChatThread('alice', 's1')
+    setChatThreadStatus(t.id, 'closed')
+    expect(listChatThreads('alice')).toHaveLength(0)
+    expect(listChatThreads('alice', { includeClosed: true })).toHaveLength(1)
+  })
+
+  it('counts only open threads (the per-agent cap input)', () => {
+    const a = createChatThread('alice', 's1')
+    createChatThread('alice', 's2')
+    createChatThread('bob', 's3')
+    setChatThreadStatus(a.id, 'suspended')
+    expect(countOpenChatThreads('alice')).toBe(1)
+    expect(countOpenChatThreads('bob')).toBe(1)
+  })
+
+  it('lists open threads across agents for the idle sweep', () => {
+    createChatThread('alice', 's1')
+    const b = createChatThread('bob', 's2')
+    setChatThreadStatus(b.id, 'suspended')
+    expect(listOpenChatThreads().map(t => t.agent_id)).toEqual(['alice'])
+  })
+
+  it('renames and touches a thread', () => {
+    const t = createChatThread('alice', 's1')
+    expect(renameChatThread(t.id, 'Új cím')).toBe(true)
+    touchChatThread(t.id)
+    const fresh = getChatThread(t.id)!
+    expect(fresh.title).toBe('Új cím')
+    expect(fresh.last_activity_at).toBeGreaterThanOrEqual(t.last_activity_at)
+  })
+
+  it('rejects an invalid status at the DB layer', () => {
+    const t = createChatThread('alice', 's1')
+    expect(() => setChatThreadStatus(t.id, 'bogus' as ChatThread['status'])).toThrow()
+  })
+})
+
+describe('threadSessionName', () => {
+  it('is namespaced under the agent and never collides with the main session', () => {
+    const name = threadSessionName('alice', 'thread-1')
+    expect(name).toBe('agent-alice-thread-thread-1')
+    expect(name).not.toBe('agent-alice')
+  })
+})
+
+describe('buildThreadLaunchCommand', () => {
+  const base = {
+    claudePath: '/usr/local/bin/claude',
+    dir: '/home/m/agents/alice',
+    model: 'claude-opus-4-8[1m]',
+    sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    skipPermissions: true,
+    threadStateDir: '/home/m/agents/alice/.claude/chat-thread-state',
+  }
+
+  it('fresh thread pins the session id with --session-id', () => {
+    const cmd = buildThreadLaunchCommand({ ...base, resume: false })
+    expect(cmd).toContain(`--session-id ${base.sessionId}`)
+    expect(cmd).not.toContain('--resume')
+    expect(cmd).not.toContain('--continue')
+  })
+
+  it('reopen uses --resume with the same id', () => {
+    const cmd = buildThreadLaunchCommand({ ...base, resume: true })
+    expect(cmd).toContain(`--resume ${base.sessionId}`)
+    expect(cmd).not.toContain('--session-id')
+  })
+
+  it('is always channel-less: no --channels, tokens unset, state dirs pointed at the inert thread dir', () => {
+    const cmd = buildThreadLaunchCommand({ ...base, resume: false })
+    expect(cmd).not.toContain('--channels')
+    expect(cmd).toContain('unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN')
+    expect(cmd).toContain(`TELEGRAM_STATE_DIR="${base.threadStateDir}"`)
+    expect(cmd).toContain(`SLACK_STATE_DIR="${base.threadStateDir}"`)
+    expect(cmd).toContain(`DISCORD_STATE_DIR="${base.threadStateDir}"`)
+  })
+
+  it('single-quotes the model so [1m] suffixes do not glob-expand', () => {
+    const cmd = buildThreadLaunchCommand({ ...base, resume: false })
+    expect(cmd).toContain("--model 'claude-opus-4-8[1m]'")
+  })
+
+  it('strict profile drops the dangerously-skip-permissions flag', () => {
+    const cmd = buildThreadLaunchCommand({ ...base, resume: false, skipPermissions: false })
+    expect(cmd).not.toContain('--dangerously-skip-permissions')
+  })
+
+  it('api authMode injects the per-agent key; oauth mode does not', () => {
+    const withKey = buildThreadLaunchCommand({ ...base, resume: false, apiKey: 'sk-ant-xxx' })
+    expect(withKey).toContain('export ANTHROPIC_API_KEY="sk-ant-xxx"')
+    const withoutKey = buildThreadLaunchCommand({ ...base, resume: false })
+    expect(withoutKey).not.toContain('ANTHROPIC_API_KEY')
+  })
+
+  it('per-agent CLAUDE_CONFIG_DIR is exported when configured', () => {
+    const cmd = buildThreadLaunchCommand({ ...base, resume: false, claudeConfigDir: '/home/m/.claude-alt' })
+    expect(cmd).toContain('export CLAUDE_CONFIG_DIR="/home/m/.claude-alt"')
+  })
+
+  it('ollama models get the local base url instead of an api key', () => {
+    const cmd = buildThreadLaunchCommand({ ...base, resume: false, model: 'llama3', ollamaUrl: 'http://localhost:11434' })
+    expect(cmd).toContain('ANTHROPIC_BASE_URL=http://localhost:11434')
+    expect(cmd).toContain('ANTHROPIC_AUTH_TOKEN=ollama')
+  })
+})
+
+describe('pickIdleThreads (idle backstop decision)', () => {
+  const NOW = 1_000_000_000
+  const IDLE = 45 * 60 * 1000
+
+  function thread(overrides: Partial<ChatThread>): ChatThread {
+    return {
+      id: 't', agent_id: 'alice', title: '', status: 'open',
+      claude_session_id: 's', created_at: 0, last_activity_at: NOW,
+      ...overrides,
+    }
+  }
+
+  it('suspends only open threads past the idle threshold', () => {
+    const threads = [
+      thread({ id: 'fresh', last_activity_at: NOW - IDLE + 1000 }),
+      thread({ id: 'stale', last_activity_at: NOW - IDLE - 1000 }),
+      thread({ id: 'already-suspended', status: 'suspended', last_activity_at: NOW - 10 * IDLE }),
+      thread({ id: 'closed', status: 'closed', last_activity_at: NOW - 10 * IDLE }),
+    ]
+    expect(pickIdleThreads(threads, NOW, IDLE).map(t => t.id)).toEqual(['stale'])
+  })
+
+  it('boundary: exactly at the threshold counts as idle', () => {
+    const t = thread({ id: 'edge', last_activity_at: NOW - IDLE })
+    expect(pickIdleThreads([t], NOW, IDLE)).toHaveLength(1)
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,20 @@ export const RESPAWN_ENABLED =
         ? hostname().toLowerCase().includes(RESPAWN_HOST)
         : true
 
+// Chat app (per-user web chat, Google Workspace login). OFF by default: the
+// feature exposes a cookie-authenticated API namespace (/chat-api/*) next to
+// the bearer-gated admin /api/*, so an install must opt in explicitly and
+// provide its own OAuth client. CHAT_PUBLIC_URL is the browser-facing origin
+// (behind the reverse proxy) used for the OAuth redirect URI and the cookie
+// Secure flag.
+export const CHAT_APP_ENABLED =
+  ['1', 'true', 'yes', 'on'].includes((env['CHAT_APP_ENABLED'] ?? '').trim().toLowerCase())
+export const CHAT_GOOGLE_CLIENT_ID = (env['CHAT_GOOGLE_CLIENT_ID'] ?? '').trim()
+export const CHAT_GOOGLE_CLIENT_SECRET = (env['CHAT_GOOGLE_CLIENT_SECRET'] ?? '').trim()
+export const CHAT_ALLOWED_DOMAIN = (env['CHAT_ALLOWED_DOMAIN'] ?? '').trim().toLowerCase()
+export const CHAT_PUBLIC_URL = (env['CHAT_PUBLIC_URL'] ?? '').trim().replace(/\/$/, '')
+export const CHAT_SESSION_TTL_HOURS = parseInt(env['CHAT_SESSION_TTL_HOURS'] ?? '24', 10)
+
 // Heartbeat
 export const HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
 export const HEARTBEAT_START_HOUR = 9

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,13 @@ export const CHAT_GOOGLE_CLIENT_SECRET = (env['CHAT_GOOGLE_CLIENT_SECRET'] ?? ''
 export const CHAT_ALLOWED_DOMAIN = (env['CHAT_ALLOWED_DOMAIN'] ?? '').trim().toLowerCase()
 export const CHAT_PUBLIC_URL = (env['CHAT_PUBLIC_URL'] ?? '').trim().replace(/\/$/, '')
 export const CHAT_SESSION_TTL_HOURS = parseInt(env['CHAT_SESSION_TTL_HOURS'] ?? '24', 10)
+// Thread lifecycle. Users open/close threads themselves (ChatGPT-style); the
+// idle auto-suspend is a backstop against forgotten threads, not the primary
+// mechanism, and a suspended thread reopens losslessly via --resume. The
+// open-thread cap is a soft server guard: every open thread is a live
+// tmux+claude process (~hundreds of MB RSS each).
+export const CHAT_THREAD_IDLE_MINUTES = parseInt(env['CHAT_THREAD_IDLE_MINUTES'] ?? '45', 10)
+export const CHAT_MAX_OPEN_THREADS_PER_AGENT = parseInt(env['CHAT_MAX_OPEN_THREADS_PER_AGENT'] ?? '10', 10)
 
 // Heartbeat
 export const HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000 // 1 hour

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3'
+import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 import { existsSync, mkdirSync, readFileSync, renameSync, chmodSync, openSync, closeSync } from 'node:fs'
 import { STORE_DIR, DB_FILENAME, ALLOWED_CHAT_ID, OLLAMA_URL } from './config.js'
@@ -497,6 +498,25 @@ export function initDatabase(dbPathOverride?: string): void {
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_chat_web_sessions_expiry ON chat_web_sessions(expires_at)`)
+
+  // --- Chat app threads (one thread = one Claude Code session per agent) ---
+  // claude_session_id is assigned at creation (claude --session-id) so the
+  // thread <-> transcript mapping is deterministic: the transcript file is
+  // <claude_session_id>.jsonl in the agent's projects dir, and a suspended
+  // thread reopens with --resume <claude_session_id>. The main agent session
+  // (agent-<name>) is NOT tracked here -- it stays untouched.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chat_threads (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open','suspended','closed')),
+      claude_session_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      last_activity_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_chat_threads_agent ON chat_threads(agent_id, status)`)
 
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
@@ -1729,4 +1749,60 @@ export function deleteChatWebSession(sidHash: string): void {
 
 export function pruneExpiredChatWebSessions(): number {
   return db.prepare('DELETE FROM chat_web_sessions WHERE expires_at <= ?').run(Date.now()).changes
+}
+
+// --- Chat app threads ---
+
+export interface ChatThread {
+  id: string
+  agent_id: string
+  title: string
+  status: 'open' | 'suspended' | 'closed'
+  claude_session_id: string
+  created_at: number
+  last_activity_at: number
+}
+
+export function createChatThread(agentId: string, claudeSessionId: string, title = ''): ChatThread {
+  const id = randomUUID()
+  const now = Date.now()
+  db.prepare(
+    `INSERT INTO chat_threads (id, agent_id, title, status, claude_session_id, created_at, last_activity_at)
+     VALUES (?, ?, ?, 'open', ?, ?, ?)`,
+  ).run(id, agentId, title, claudeSessionId, now, now)
+  return { id, agent_id: agentId, title, status: 'open', claude_session_id: claudeSessionId, created_at: now, last_activity_at: now }
+}
+
+export function getChatThread(id: string): ChatThread | undefined {
+  return db.prepare('SELECT * FROM chat_threads WHERE id = ?').get(id) as ChatThread | undefined
+}
+
+// Closed threads stay listed (reopenable history) unless the caller filters.
+export function listChatThreads(agentId: string, opts: { includeClosed?: boolean } = {}): ChatThread[] {
+  const where = opts.includeClosed ? '' : " AND status != 'closed'"
+  return db.prepare(
+    `SELECT * FROM chat_threads WHERE agent_id = ?${where} ORDER BY last_activity_at DESC`,
+  ).all(agentId) as ChatThread[]
+}
+
+export function listOpenChatThreads(): ChatThread[] {
+  return db.prepare("SELECT * FROM chat_threads WHERE status = 'open'").all() as ChatThread[]
+}
+
+export function countOpenChatThreads(agentId: string): number {
+  return (db.prepare("SELECT COUNT(*) AS c FROM chat_threads WHERE agent_id = ? AND status = 'open'")
+    .get(agentId) as { c: number }).c
+}
+
+export function setChatThreadStatus(id: string, status: ChatThread['status']): boolean {
+  return db.prepare('UPDATE chat_threads SET status = ?, last_activity_at = ? WHERE id = ?')
+    .run(status, Date.now(), id).changes > 0
+}
+
+export function renameChatThread(id: string, title: string): boolean {
+  return db.prepare('UPDATE chat_threads SET title = ? WHERE id = ?').run(title, id).changes > 0
+}
+
+export function touchChatThread(id: string): void {
+  db.prepare('UPDATE chat_threads SET last_activity_at = ? WHERE id = ?').run(Date.now(), id)
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -484,6 +484,20 @@ export function initDatabase(dbPathOverride?: string): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_session ON tool_call_log(session_id, created_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_ts ON tool_call_log(created_at)`)
 
+  // --- Chat app web sessions (per-user Google login) ---
+  // Only the SHA-256 hash of the session id is stored: a leaked DB file (or a
+  // sub-agent reading store/) must not yield usable login cookies.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chat_web_sessions (
+      sid_hash TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_chat_web_sessions_expiry ON chat_web_sessions(expires_at)`)
+
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
   // re-importing. Wrapped in a transaction so a crash mid-import is safe.
@@ -1681,3 +1695,38 @@ export function pruneToolCallLog(olderThanSecs = 86400): void {
   db.prepare('DELETE FROM tool_call_log WHERE created_at < ?').run(cutoff)
 }
 
+
+// --- Chat app web sessions ---
+
+export interface ChatWebSession {
+  email: string
+  agentId: string
+  expiresAt: number
+}
+
+export function createChatWebSession(sidHash: string, email: string, agentId: string, ttlMs: number): void {
+  const now = Date.now()
+  db.prepare(
+    'INSERT INTO chat_web_sessions (sid_hash, email, agent_id, created_at, expires_at) VALUES (?, ?, ?, ?, ?)',
+  ).run(sidHash, email, agentId, now, now + ttlMs)
+}
+
+export function getChatWebSession(sidHash: string): ChatWebSession | undefined {
+  const row = db.prepare(
+    'SELECT email, agent_id, expires_at FROM chat_web_sessions WHERE sid_hash = ?',
+  ).get(sidHash) as { email: string; agent_id: string; expires_at: number } | undefined
+  if (!row) return undefined
+  if (row.expires_at <= Date.now()) {
+    db.prepare('DELETE FROM chat_web_sessions WHERE sid_hash = ?').run(sidHash)
+    return undefined
+  }
+  return { email: row.email, agentId: row.agent_id, expiresAt: row.expires_at }
+}
+
+export function deleteChatWebSession(sidHash: string): void {
+  db.prepare('DELETE FROM chat_web_sessions WHERE sid_hash = ?').run(sidHash)
+}
+
+export function pruneExpiredChatWebSessions(): number {
+  return db.prepare('DELETE FROM chat_web_sessions WHERE expires_at <= ?').run(Date.now()).changes
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -50,6 +50,8 @@ import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import { tryHandleChatAuth } from './web/routes/chat-auth.js'
 import { pruneExpiredChatWebSessions } from './db.js'
+import { sweepIdleThreads } from './web/chat/thread-process.js'
+import { CHAT_THREAD_IDLE_MINUTES } from './config.js'
 import type { RouteContext } from './web/routes/types.js'
 
 const WEB_DIR = join(PROJECT_ROOT, 'web')
@@ -296,11 +298,18 @@ export function startWebServer(port = 3420): http.Server {
   // Expired chat sessions are also dropped lazily on lookup; this sweep just
   // keeps the table from accumulating rows for users who never come back.
   let chatSessionPruneInterval: NodeJS.Timeout | null = null
+  let threadIdleSweepInterval: NodeJS.Timeout | null = null
   if (CHAT_APP_ENABLED) {
     chatSessionPruneInterval = setInterval(() => {
       try { pruneExpiredChatWebSessions() } catch { /* table missing only before initDatabase */ }
     }, 60 * 60 * 1000)
-    logger.info('Chat app enabled: /chat-api namespace active, session prune started (1h)')
+    // Idle backstop for forgotten threads. 5-min cadence is plenty: the idle
+    // threshold is tens of minutes, and a sweep only costs a DB query when
+    // nothing qualifies.
+    threadIdleSweepInterval = setInterval(() => {
+      try { sweepIdleThreads(CHAT_THREAD_IDLE_MINUTES) } catch (err) { logger.warn({ err }, 'Thread idle sweep failed') }
+    }, 5 * 60 * 1000)
+    logger.info({ idleMinutes: CHAT_THREAD_IDLE_MINUTES }, 'Chat app enabled: /chat-api namespace active, session prune (1h) + thread idle sweep (5min) started')
   }
 
   // NOTE: startMcpListChecker() is intentionally NOT called here.
@@ -368,6 +377,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(autoRestartInterval)
     clearInterval(updateCheckerInterval)
     if (chatSessionPruneInterval) clearInterval(chatSessionPruneInterval)
+    if (threadIdleSweepInterval) clearInterval(threadIdleSweepInterval)
     return origClose(cb)
   }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,7 +2,7 @@ import http from 'node:http'
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { execSync, execFileSync } from 'node:child_process'
-import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL } from './config.js'
+import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL, CHAT_APP_ENABLED, CHAT_PUBLIC_URL } from './config.js'
 import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-auth.js'
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
@@ -48,6 +48,8 @@ import { tryHandleTokenUsage } from './web/routes/token-usage.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleStatic } from './web/routes/static.js'
+import { tryHandleChatAuth } from './web/routes/chat-auth.js'
+import { pruneExpiredChatWebSessions } from './db.js'
 import type { RouteContext } from './web/routes/types.js'
 
 const WEB_DIR = join(PROJECT_ROOT, 'web')
@@ -68,6 +70,7 @@ export function startWebServer(port = 3420): http.Server {
     `http://127.0.0.1:${port}`,
     ...( WEB_HOST !== 'localhost' && WEB_HOST !== '127.0.0.1' ? [`http://${WEB_HOST}:${port}`] : []),
     ...(DASHBOARD_PUBLIC_URL ? [DASHBOARD_PUBLIC_URL.replace(/\/$/, '')] : []),
+    ...(CHAT_APP_ENABLED && CHAT_PUBLIC_URL ? [CHAT_PUBLIC_URL] : []),
   ])
   const isSafeMethod = (m: string) => m === 'GET' || m === 'HEAD' || m === 'OPTIONS'
 
@@ -135,6 +138,11 @@ export function startWebServer(port = 3420): http.Server {
 
     try {
       const routeCtx: RouteContext = { req, res, path, method, url }
+
+      // Chat app namespace (/chat-api/*): cookie-session auth, fully separate
+      // from the /api/* bearer gate above. The handler self-gates on
+      // CHAT_APP_ENABLED (404 when off).
+      if (await tryHandleChatAuth(routeCtx)) return
 
       if (await tryHandleProfiles(routeCtx)) return
       if (await tryHandleMessages(routeCtx)) return
@@ -285,6 +293,16 @@ export function startWebServer(port = 3420): http.Server {
   const updateCheckerInterval = startUpdateChecker()
   logger.info('Update checker started (15min poll)')
 
+  // Expired chat sessions are also dropped lazily on lookup; this sweep just
+  // keeps the table from accumulating rows for users who never come back.
+  let chatSessionPruneInterval: NodeJS.Timeout | null = null
+  if (CHAT_APP_ENABLED) {
+    chatSessionPruneInterval = setInterval(() => {
+      try { pruneExpiredChatWebSessions() } catch { /* table missing only before initDatabase */ }
+    }, 60 * 60 * 1000)
+    logger.info('Chat app enabled: /chat-api namespace active, session prune started (1h)')
+  }
+
   // NOTE: startMcpListChecker() is intentionally NOT called here.
   //
   // Root cause: calling `claude mcp list` at boot time (30s delay) spawns the
@@ -349,6 +367,7 @@ export function startWebServer(port = 3420): http.Server {
     if (reauthHealerInterval) clearInterval(reauthHealerInterval)
     clearInterval(autoRestartInterval)
     clearInterval(updateCheckerInterval)
+    if (chatSessionPruneInterval) clearInterval(chatSessionPruneInterval)
     return origClose(cb)
   }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -49,6 +49,7 @@ import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import { tryHandleChatAuth } from './web/routes/chat-auth.js'
+import { tryHandleChatApi } from './web/routes/chat-api.js'
 import { pruneExpiredChatWebSessions } from './db.js'
 import { sweepIdleThreads } from './web/chat/thread-process.js'
 import { CHAT_THREAD_IDLE_MINUTES } from './config.js'
@@ -145,6 +146,7 @@ export function startWebServer(port = 3420): http.Server {
       // from the /api/* bearer gate above. The handler self-gates on
       // CHAT_APP_ENABLED (404 when off).
       if (await tryHandleChatAuth(routeCtx)) return
+      if (await tryHandleChatApi(routeCtx)) return
 
       if (await tryHandleProfiles(routeCtx)) return
       if (await tryHandleMessages(routeCtx)) return

--- a/src/web/active-model.ts
+++ b/src/web/active-model.ts
@@ -24,7 +24,13 @@ const TTL_MS = 3000
 // so we read the right project dir for agents on a non-default config.
 export function projectsDirFor(workingDir: string, configDir?: string, homeDirOverride?: string): string {
   const base = configDir ?? join(homeDirOverride ?? homedir(), '.claude')
-  const encoded = workingDir.replace(/[/.]/g, '-')
+  // Claude Code's own encoding replaces EVERY non-alphanumeric character with
+  // '-', not just '/' and '.' (verified against real ~/.claude/projects dirs:
+  // /Users/x/code/is_backend_system -> -Users-x-code-is-backend-system). The
+  // previous [/.]-only variant silently missed the project dir for any
+  // working dir containing '_' or other specials, so the model/context/
+  // conversation readers came back empty there.
+  const encoded = workingDir.replace(/[^a-zA-Z0-9]/g, '-')
   return join(base, 'projects', encoded)
 }
 

--- a/src/web/chat/chat-session.ts
+++ b/src/web/chat/chat-session.ts
@@ -1,0 +1,85 @@
+// Cookie-backed server-side sessions for the chat app. Deliberately separate
+// from the dashboard bearer token: a chat login must never grant /api/* admin
+// access, and the admin token must never reach a chat user's browser. The
+// cookie carries a random 256-bit id; only its SHA-256 hash is persisted
+// (chat_web_sessions table), so neither the DB file nor a backup yields a
+// usable cookie.
+import type http from 'node:http'
+import { createHash, randomBytes } from 'node:crypto'
+import {
+  createChatWebSession, getChatWebSession, deleteChatWebSession,
+} from '../../db.js'
+import { CHAT_PUBLIC_URL, CHAT_SESSION_TTL_HOURS } from '../../config.js'
+
+export const CHAT_SESSION_COOKIE = 'marveen_chat_sid'
+
+function hashSid(sid: string): string {
+  return createHash('sha256').update(sid).digest('hex')
+}
+
+export function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!header) return out
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    const name = part.slice(0, eq).trim()
+    const value = part.slice(eq + 1).trim()
+    if (name) out[name] = decodeURIComponent(value)
+  }
+  return out
+}
+
+function cookieIsSecure(): boolean {
+  // Behind the public reverse proxy the browser-facing origin is https; on a
+  // bare localhost dev setup it is http, where a Secure cookie would never be
+  // sent back.
+  return CHAT_PUBLIC_URL.startsWith('https://')
+}
+
+export function buildSessionCookie(sid: string, maxAgeSeconds: number): string {
+  const attrs = [
+    `${CHAT_SESSION_COOKIE}=${sid}`,
+    'HttpOnly',
+    'Path=/',
+    'SameSite=Lax',
+    `Max-Age=${maxAgeSeconds}`,
+  ]
+  if (cookieIsSecure()) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+export function buildClearedSessionCookie(): string {
+  const attrs = [`${CHAT_SESSION_COOKIE}=`, 'HttpOnly', 'Path=/', 'SameSite=Lax', 'Max-Age=0']
+  if (cookieIsSecure()) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+export interface ChatUser {
+  email: string
+  agentId: string
+}
+
+export function createSession(email: string, agentId: string): { sid: string; maxAgeSeconds: number } {
+  const sid = randomBytes(32).toString('hex')
+  const ttlMs = CHAT_SESSION_TTL_HOURS * 60 * 60 * 1000
+  createChatWebSession(hashSid(sid), email, agentId, ttlMs)
+  return { sid, maxAgeSeconds: Math.floor(ttlMs / 1000) }
+}
+
+// The per-request authorization boundary for /chat-api/*: returns the logged-
+// in user (email + their own agent) or null. Every chat endpoint must scope
+// strictly to the returned agentId -- never to an agent name taken from the
+// request.
+export function getChatUser(req: http.IncomingMessage): ChatUser | null {
+  const sid = parseCookies(req.headers.cookie)[CHAT_SESSION_COOKIE]
+  if (!sid || !/^[0-9a-f]{64}$/.test(sid)) return null
+  const session = getChatWebSession(hashSid(sid))
+  if (!session) return null
+  return { email: session.email, agentId: session.agentId }
+}
+
+export function destroySession(req: http.IncomingMessage): void {
+  const sid = parseCookies(req.headers.cookie)[CHAT_SESSION_COOKIE]
+  if (sid) deleteChatWebSession(hashSid(sid))
+}

--- a/src/web/chat/chat-users.ts
+++ b/src/web/chat/chat-users.ts
@@ -1,0 +1,57 @@
+// Email -> agent mapping for the chat app. Operators maintain a plain JSON
+// file at store/chat-users.json:
+//
+//   { "alice@example.com": "alice", "bob@example.com": "bob" }
+//
+// The file is re-read when its mtime changes, so entries can be added or
+// removed without restarting the server. An email that is missing here gets a
+// 403 at login even with a valid Workspace account -- the mapping doubles as
+// the allowlist.
+import { readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../../config.js'
+import { logger } from '../../logger.js'
+
+export const CHAT_USERS_PATH = join(PROJECT_ROOT, 'store', 'chat-users.json')
+
+let cache: { mtimeMs: number; map: Map<string, string> } | null = null
+
+function loadMap(path: string): Map<string, string> {
+  const raw = JSON.parse(readFileSync(path, 'utf-8')) as unknown
+  const map = new Map<string, string>()
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('chat-users.json must be a JSON object of "email": "agent" pairs')
+  }
+  for (const [email, agent] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof agent !== 'string' || !agent.trim() || !email.includes('@')) {
+      logger.warn({ email }, 'chat-users.json: skipping invalid entry')
+      continue
+    }
+    map.set(email.trim().toLowerCase(), agent.trim())
+  }
+  return map
+}
+
+export function resolveAgentForEmail(email: string, path = CHAT_USERS_PATH): string | null {
+  let mtimeMs: number
+  try {
+    mtimeMs = statSync(path).mtimeMs
+  } catch {
+    return null // no mapping file -> nobody can log in
+  }
+  if (!cache || cache.mtimeMs !== mtimeMs) {
+    try {
+      cache = { mtimeMs, map: loadMap(path) }
+    } catch (err) {
+      logger.error({ err, path }, 'chat-users.json unreadable; keeping previous mapping')
+      if (!cache) return null
+    }
+  }
+  return cache.map.get(email.trim().toLowerCase()) ?? null
+}
+
+// Test hook: drop the mtime cache so a rewritten temp file is re-read even
+// when the filesystem mtime granularity would hide the change.
+export function resetChatUsersCache(): void {
+  cache = null
+}

--- a/src/web/chat/google-oauth.ts
+++ b/src/web/chat/google-oauth.ts
@@ -1,0 +1,110 @@
+// Google OAuth (authorization code flow) for the chat app login.
+//
+// Trust model: the id_token is obtained server-side, directly from Google's
+// token endpoint over TLS, so its JWT signature is NOT re-verified here --
+// the TLS channel to oauth2.googleapis.com authenticates the issuer (this is
+// the standard "token endpoint response" trust case from OIDC Core 3.1.3.7).
+// What MUST still be validated server-side, because the values themselves can
+// be wrong for our purposes even in a genuine Google token: iss, aud, exp,
+// nonce, email_verified, and the Workspace domain (hd + email suffix -- the
+// `hd` REQUEST parameter is a client-side hint only and is spoofable, so the
+// domain decision is made exclusively on the returned claims).
+
+export interface GoogleIdClaims {
+  iss?: string
+  aud?: string
+  exp?: number
+  nonce?: string
+  email?: string
+  email_verified?: boolean
+  hd?: string
+}
+
+export interface OAuthClientConfig {
+  clientId: string
+  clientSecret: string
+  redirectUri: string
+}
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const GOOGLE_ISSUERS = new Set(['https://accounts.google.com', 'accounts.google.com'])
+
+export function buildGoogleAuthUrl(
+  cfg: { clientId: string; redirectUri: string },
+  state: string,
+  nonce: string,
+  domainHint?: string,
+): string {
+  const params = new URLSearchParams({
+    client_id: cfg.clientId,
+    redirect_uri: cfg.redirectUri,
+    response_type: 'code',
+    scope: 'openid email',
+    state,
+    nonce,
+    prompt: 'select_account',
+  })
+  // UX hint only (pre-filters the account chooser); the real domain check
+  // happens on the returned claims in validateWorkspaceUser.
+  if (domainHint) params.set('hd', domainHint)
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`
+}
+
+export async function exchangeCodeForIdToken(code: string, cfg: OAuthClientConfig): Promise<string> {
+  const res = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: cfg.clientId,
+      client_secret: cfg.clientSecret,
+      redirect_uri: cfg.redirectUri,
+      grant_type: 'authorization_code',
+    }).toString(),
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Google token endpoint returned ${res.status}: ${body.slice(0, 200)}`)
+  }
+  const data = (await res.json()) as { id_token?: string }
+  if (!data.id_token) throw new Error('Google token response missing id_token')
+  return data.id_token
+}
+
+export function decodeIdTokenClaims(idToken: string): GoogleIdClaims {
+  const parts = idToken.split('.')
+  if (parts.length !== 3) throw new Error('Malformed id_token')
+  const payload = Buffer.from(parts[1], 'base64url').toString('utf-8')
+  return JSON.parse(payload) as GoogleIdClaims
+}
+
+export function validateIdClaims(
+  claims: GoogleIdClaims,
+  expected: { clientId: string; nonce: string },
+  nowMs = Date.now(),
+): { ok: true } | { ok: false; reason: string } {
+  if (!claims.iss || !GOOGLE_ISSUERS.has(claims.iss)) return { ok: false, reason: 'bad issuer' }
+  if (claims.aud !== expected.clientId) return { ok: false, reason: 'audience mismatch' }
+  if (typeof claims.exp !== 'number' || claims.exp * 1000 <= nowMs) return { ok: false, reason: 'token expired' }
+  if (!claims.nonce || claims.nonce !== expected.nonce) return { ok: false, reason: 'nonce mismatch' }
+  if (claims.email_verified !== true) return { ok: false, reason: 'email not verified' }
+  if (!claims.email) return { ok: false, reason: 'missing email' }
+  return { ok: true }
+}
+
+// The Workspace gate. Both conditions are required: `hd` proves the account
+// belongs to the Workspace org (a gmail.com account named like the domain has
+// no hd), and the email suffix pins the primary address to the same domain.
+export function validateWorkspaceUser(
+  claims: GoogleIdClaims,
+  allowedDomain: string,
+): { ok: true; email: string } | { ok: false; reason: string } {
+  const domain = allowedDomain.trim().toLowerCase()
+  if (!domain) return { ok: false, reason: 'no allowed domain configured' }
+  const email = (claims.email ?? '').trim().toLowerCase()
+  if (!email) return { ok: false, reason: 'missing email' }
+  if ((claims.hd ?? '').toLowerCase() !== domain) return { ok: false, reason: 'not a workspace account of the allowed domain' }
+  if (!email.endsWith(`@${domain}`)) return { ok: false, reason: 'email domain mismatch' }
+  return { ok: true, email }
+}

--- a/src/web/chat/thread-process.ts
+++ b/src/web/chat/thread-process.ts
@@ -30,7 +30,7 @@ import {
 } from '../agent-config.js'
 import { loadProfileTemplate } from '../profiles.js'
 import { getSecret } from '../vault.js'
-import { sessionExistsOnHost, sendPromptToSession, isSessionReadyForPrompt } from '../agent-process.js'
+import { sessionExistsOnHost, sendPromptToSession, isSessionReadyForPrompt, scheduleIdentitySetup } from '../agent-process.js'
 import { projectsDirFor } from '../active-model.js'
 import { buildTmuxInvocation } from '../ssh-tmux.js'
 import {
@@ -133,6 +133,11 @@ export function startThreadSession(agentName: string, thread: ChatThread): { ok:
   try {
     runLocalTmux(['new-session', '-d', '-s', session, cmd])
     setChatThreadStatus(thread.id, 'open')
+    // Same post-spawn care as startAgentProcess: dismiss first-run/resume
+    // modals once the TUI has rendered and set the session /name -- without
+    // this a resumed thread can sit behind a "Resume from summary" modal and
+    // every message bounces with "Thread is busy".
+    scheduleIdentitySetup(session, thread.title || 'Chat szál')
     logger.info({ agentName, threadId: thread.id, session, resume }, 'Chat thread session started')
     return { ok: true }
   } catch (err) {

--- a/src/web/chat/thread-process.ts
+++ b/src/web/chat/thread-process.ts
@@ -1,0 +1,202 @@
+// Thread session lifecycle for the chat app: N extra Claude Code sessions per
+// agent, one per conversation thread, next to the untouched main session
+// (agent-<name>). Deliberately narrower than startAgentProcess:
+//
+//   - local only (no remote/ssh agents -- a chat thread runs where the
+//     orchestrator runs)
+//   - channel-less ALWAYS: no --channels flag, channel state-dir env vars
+//     pointed at an empty per-thread dir and token vars unset, so the channel
+//     plugin in the shared agent workdir has nothing to poll with (the same
+//     mechanism startAgentProcess uses for channel-less agents -- a second
+//     poller on the agent's bot token would 409-war the main session)
+//   - deterministic session id: spawned with `claude --session-id <uuid>`
+//     (the uuid is minted at thread creation and stored on the chat_threads
+//     row), so the transcript file is <uuid>.jsonl and suspend/reopen is
+//     `--resume <uuid>` with zero "newest file" guessing
+//
+// The thread runs in the agent's own workdir, so it shares CLAUDE.md and the
+// memory tiers with the main session -- only the conversation context is
+// separate. That is the whole point of the feature.
+import { existsSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { execFileSync } from 'node:child_process'
+import { resolveFromPath } from '../../platform.js'
+import { logger } from '../../logger.js'
+import { OLLAMA_URL } from '../../config.js'
+import {
+  agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir,
+  readAgentAuthMode, readAgentRemoteConfig,
+} from '../agent-config.js'
+import { loadProfileTemplate } from '../profiles.js'
+import { getSecret } from '../vault.js'
+import { sessionExistsOnHost, sendPromptToSession, isSessionReadyForPrompt } from '../agent-process.js'
+import { projectsDirFor } from '../active-model.js'
+import { buildTmuxInvocation } from '../ssh-tmux.js'
+import {
+  type ChatThread, getChatThread, listOpenChatThreads, setChatThreadStatus,
+} from '../../db.js'
+
+const TMUX = resolveFromPath('tmux')
+const CLAUDE = resolveFromPath('claude')
+
+export function threadSessionName(agentName: string, threadId: string): string {
+  return `agent-${agentName}-thread-${threadId}`
+}
+
+export function isThreadRunning(agentName: string, threadId: string): boolean {
+  return sessionExistsOnHost(null, threadSessionName(agentName, threadId))
+}
+
+// Pure command builder, unit-tested. Mirrors the relevant parts of
+// startAgentProcess's launch line (PATH, model providers, per-agent api key /
+// config dir, security-profile skip flag) minus everything channel-related.
+export function buildThreadLaunchCommand(opts: {
+  claudePath: string
+  dir: string
+  model: string
+  resume: boolean
+  sessionId: string
+  skipPermissions: boolean
+  claudeConfigDir?: string | null
+  apiKey?: string | null
+  ollamaUrl?: string
+  deepseekKey?: string | null
+  threadStateDir: string
+}): string {
+  const isClaude = opts.model.startsWith('claude-')
+  const isDeepseek = opts.model.startsWith('deepseek-')
+  const isOllama = !isClaude && !isDeepseek
+  const ollamaEnv = isOllama ? `export ANTHROPIC_AUTH_TOKEN=ollama && export ANTHROPIC_BASE_URL=${opts.ollamaUrl ?? OLLAMA_URL} && ` : ''
+  const deepseekEnv = isDeepseek ? `export ANTHROPIC_AUTH_TOKEN="${opts.deepseekKey ?? ''}" && export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic && ` : ''
+  const apiKeyEnv = isClaude && opts.apiKey ? `export ANTHROPIC_API_KEY="${opts.apiKey}" && ` : ''
+  const claudeConfigEnv = opts.claudeConfigDir ? `export CLAUDE_CONFIG_DIR="${opts.claudeConfigDir}" && ` : ''
+  // Channel neutralisation: empty state dir + no tokens => the plugin (auto-
+  // loaded from the shared workdir's enabledPlugins) has no credentials and
+  // stays inert in this session.
+  const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN'
+  const stateEnv = `export TELEGRAM_STATE_DIR="${opts.threadStateDir}" && export SLACK_STATE_DIR="${opts.threadStateDir}" && export DISCORD_STATE_DIR="${opts.threadStateDir}" && `
+  const sessionFlag = opts.resume ? `--resume ${opts.sessionId} ` : `--session-id ${opts.sessionId} `
+  const skipFlag = opts.skipPermissions ? '--dangerously-skip-permissions ' : ''
+  // Single-quote the model for the same reason as startAgentProcess: ids like
+  // `claude-opus-4-8[1m]` must not glob-expand.
+  return `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${stateEnv}${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${opts.dir}" && ${opts.claudePath} ${sessionFlag}${skipFlag}--model '${opts.model}'`.trimEnd()
+}
+
+function runLocalTmux(args: string[]): void {
+  const inv = buildTmuxInvocation(null, TMUX, args)
+  execFileSync(inv.file, inv.args, { timeout: 10000 })
+}
+
+export function transcriptPathForThread(agentName: string, claudeSessionId: string): string {
+  const dir = agentDir(agentName)
+  const configDir = readAgentClaudeConfigDir(agentName) ?? undefined
+  return join(projectsDirFor(dir, configDir), `${claudeSessionId}.jsonl`)
+}
+
+// Start (or reopen) a thread session. Fresh threads get --session-id; a
+// suspended thread whose transcript already exists resumes it. A thread that
+// was suspended before its first message has no transcript yet -- --resume
+// would die instantly -- so it starts fresh under the SAME session id.
+export function startThreadSession(agentName: string, thread: ChatThread): { ok: boolean; error?: string } {
+  const dir = agentDir(agentName)
+  if (!existsSync(dir)) return { ok: false, error: 'Agent not found' }
+  if (readAgentRemoteConfig(agentName).host) {
+    return { ok: false, error: 'Chat threads are not supported for remote agents' }
+  }
+  const session = threadSessionName(agentName, thread.id)
+  if (sessionExistsOnHost(null, session)) return { ok: false, error: 'Thread session already running' }
+
+  const threadStateDir = join(dir, '.claude', 'chat-thread-state')
+  try { mkdirSync(threadStateDir, { recursive: true }) } catch { /* exists */ }
+
+  const model = readAgentModel(agentName)
+  const profile = loadProfileTemplate(readAgentSecurityProfile(agentName))
+  const apiKey = readAgentAuthMode(agentName) === 'api' ? (getSecret(`agent-${agentName}-api-key`) ?? null) : null
+  const deepseekKey = model.startsWith('deepseek-') ? (getSecret('DEEPSEEK_API_KEY') ?? null) : null
+  const claudeConfigDir = readAgentClaudeConfigDir(agentName)
+  const resume = existsSync(transcriptPathForThread(agentName, thread.claude_session_id))
+
+  const cmd = buildThreadLaunchCommand({
+    claudePath: CLAUDE,
+    dir,
+    model,
+    resume,
+    sessionId: thread.claude_session_id,
+    skipPermissions: profile.permissionMode !== 'strict',
+    claudeConfigDir,
+    apiKey,
+    deepseekKey,
+    threadStateDir,
+  })
+
+  try {
+    runLocalTmux(['new-session', '-d', '-s', session, cmd])
+    setChatThreadStatus(thread.id, 'open')
+    logger.info({ agentName, threadId: thread.id, session, resume }, 'Chat thread session started')
+    return { ok: true }
+  } catch (err) {
+    logger.error({ err, agentName, threadId: thread.id }, 'Failed to start chat thread session')
+    return { ok: false, error: 'Failed to start thread tmux session' }
+  }
+}
+
+function killThreadSession(agentName: string, threadId: string): void {
+  const session = threadSessionName(agentName, threadId)
+  if (!sessionExistsOnHost(null, session)) return
+  try {
+    runLocalTmux(['kill-session', '-t', session])
+  } catch (err) {
+    logger.warn({ err, session }, 'Failed to kill thread tmux session')
+  }
+}
+
+// Suspend = stop the process, keep the conversation reopenable (--resume).
+export function suspendThread(agentName: string, threadId: string): boolean {
+  killThreadSession(agentName, threadId)
+  return setChatThreadStatus(threadId, 'suspended')
+}
+
+// Close = user says the task is done. Same teardown; only the status differs
+// (closed threads drop out of the default thread list but stay reopenable).
+export function closeThread(agentName: string, threadId: string): boolean {
+  killThreadSession(agentName, threadId)
+  return setChatThreadStatus(threadId, 'closed')
+}
+
+export function sendPromptToThread(agentName: string, threadId: string, text: string): { ok: boolean; error?: string } {
+  const thread = getChatThread(threadId)
+  if (!thread || thread.agent_id !== agentName) return { ok: false, error: 'Thread not found' }
+  const session = threadSessionName(agentName, threadId)
+  if (!sessionExistsOnHost(null, session)) {
+    // Unlike the message-router's queue-and-retry (built for the always-on
+    // main session), a chat message to a dead thread fails synchronously: the
+    // caller reopens the thread explicitly. No silent 1-hour abandon window.
+    return { ok: false, error: 'Thread session is not running' }
+  }
+  if (!isSessionReadyForPrompt(session)) return { ok: false, error: 'Thread is busy' }
+  sendPromptToSession(session, text)
+  return { ok: true }
+}
+
+// Pure idle-sweep decision, unit-tested separately from the tmux side effects.
+export function pickIdleThreads(threads: ChatThread[], nowMs: number, idleMs: number): ChatThread[] {
+  return threads.filter(t => t.status === 'open' && nowMs - t.last_activity_at >= idleMs)
+}
+
+// Backstop sweep for forgotten threads (user-driven close is the primary
+// mechanism). Suspended threads cost nothing and reopen losslessly.
+export function sweepIdleThreads(idleMinutes: number): number {
+  const idleMs = idleMinutes * 60 * 1000
+  let suspended = 0
+  for (const t of pickIdleThreads(listOpenChatThreads(), Date.now(), idleMs)) {
+    try {
+      suspendThread(t.agent_id, t.id)
+      suspended++
+      logger.info({ agentId: t.agent_id, threadId: t.id }, 'Idle chat thread auto-suspended')
+    } catch (err) {
+      logger.warn({ err, threadId: t.id }, 'Idle thread suspend failed')
+    }
+  }
+  return suspended
+}

--- a/src/web/chat/thread-transcript.ts
+++ b/src/web/chat/thread-transcript.ts
@@ -1,0 +1,107 @@
+// Chat-style timeline for a THREAD transcript. Differs from the #356
+// agent-conversation parser on the inbound side: a thread session has no
+// channel plugin, so the user's messages arrive as plain prompts (typed into
+// the session by sendPromptToSession), not inside <channel> wrappers. Tool
+// results, system-reminders and slash-command echoes also land as type=user
+// lines and must be filtered out, otherwise they would render as fake user
+// bubbles.
+import { readFileSync } from 'node:fs'
+
+export interface ThreadEntry {
+  ts: string | null
+  // user = the colleague's message; assistant = the agent's visible reply;
+  // action = a tool the agent ran (rendered collapsed in the UI)
+  kind: 'user' | 'assistant' | 'action'
+  text: string
+}
+
+const MAX_TEXT = 6000
+export const DEFAULT_TIMELINE_LIMIT = 400
+
+function clip(s: string): string {
+  return s.length > MAX_TEXT ? s.slice(0, MAX_TEXT) + ' …' : s
+}
+
+// Strip harness-injected blocks from a user prompt; if nothing user-authored
+// remains, the line is not a real message.
+function cleanUserText(raw: string): string {
+  return raw
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '')
+    .replace(/<command-name>[\s\S]*?<\/command-name>/g, '')
+    .replace(/<command-message>[\s\S]*?<\/command-message>/g, '')
+    .replace(/<command-args>[\s\S]*?<\/command-args>/g, '')
+    .replace(/<local-command-stdout>[\s\S]*?<\/local-command-stdout>/g, '')
+    .trim()
+}
+
+function actionLabel(name: string, input: Record<string, unknown>): string {
+  const base = name.includes('__') ? name.split('__').pop()! : name
+  const pick = (k: string): string => (typeof input[k] === 'string' ? (input[k] as string) : '')
+  if (name === 'Bash') return `Bash: ${pick('description') || pick('command').slice(0, 80)}`
+  if (name === 'Read') return `Read: ${pick('file_path')}`
+  if (name === 'Write') return `Write: ${pick('file_path')}`
+  if (name === 'Edit') return `Edit: ${pick('file_path')}`
+  if (base === 'WebSearch') return `Web keresés: ${pick('query')}`
+  if (base === 'WebFetch') return `Web lekérés: ${pick('url')}`
+  return base
+}
+
+export function parseThreadTimeline(jsonl: string, limit = DEFAULT_TIMELINE_LIMIT): ThreadEntry[] {
+  const entries: ThreadEntry[] = []
+  for (const line of jsonl.split('\n')) {
+    const t = line.trim()
+    if (!t) continue
+    let d: Record<string, unknown>
+    try { d = JSON.parse(t) } catch { continue }
+    const type = d['type']
+    const ts = typeof d['timestamp'] === 'string' ? (d['timestamp'] as string) : null
+    const msg = d['message'] as Record<string, unknown> | undefined
+    if (!msg) continue
+
+    if (type === 'user') {
+      const content = msg['content']
+      // tool_result feedback comes back as type=user with an array content --
+      // not a human message. String content is the typed prompt.
+      if (typeof content !== 'string') continue
+      const text = cleanUserText(content)
+      if (text) entries.push({ ts, kind: 'user', text: clip(text) })
+      continue
+    }
+
+    if (type === 'assistant') {
+      const content = msg['content']
+      if (!Array.isArray(content)) continue
+      for (const block of content as Array<Record<string, unknown>>) {
+        if (block['type'] === 'text') {
+          const txt = typeof block['text'] === 'string' ? (block['text'] as string).trim() : ''
+          if (txt) entries.push({ ts, kind: 'assistant', text: clip(txt) })
+        } else if (block['type'] === 'tool_use') {
+          const name = typeof block['name'] === 'string' ? (block['name'] as string) : ''
+          const input = (block['input'] as Record<string, unknown>) ?? {}
+          entries.push({ ts, kind: 'action', text: actionLabel(name, input) })
+        }
+      }
+    }
+  }
+  return entries.length > limit ? entries.slice(entries.length - limit) : entries
+}
+
+export function readThreadTimeline(transcriptPath: string, limit = DEFAULT_TIMELINE_LIMIT): ThreadEntry[] {
+  let raw: string
+  try {
+    raw = readFileSync(transcriptPath, 'utf-8')
+  } catch {
+    return [] // no transcript yet: thread exists but has no first message
+  }
+  return parseThreadTimeline(raw, limit)
+}
+
+// Auto-title for a fresh thread from its first message, ChatGPT-style. Pure;
+// the route applies it only while the stored title is empty.
+export function deriveThreadTitle(firstMessage: string, maxLen = 60): string {
+  const oneLine = firstMessage.replace(/\s+/g, ' ').trim()
+  if (oneLine.length <= maxLen) return oneLine
+  const cut = oneLine.slice(0, maxLen)
+  const lastSpace = cut.lastIndexOf(' ')
+  return (lastSpace > maxLen / 2 ? cut.slice(0, lastSpace) : cut) + '…'
+}

--- a/src/web/routes/chat-api.ts
+++ b/src/web/routes/chat-api.ts
@@ -1,0 +1,215 @@
+// Per-user chat API (/chat-api/threads*). Cookie-session auth (PR: chat-auth),
+// thread machinery (PR: chat-threads). THE authorization invariant of the
+// whole chat app lives here: every endpoint resolves the agent EXCLUSIVELY
+// from the logged-in user's session row (getChatUser), never from the request
+// path or body, and a thread belonging to another agent 404s without
+// existence leakage. The admin /api/* surface is unreachable with a chat
+// cookie by construction (separate namespace, separate auth).
+import { randomUUID } from 'node:crypto'
+import {
+  CHAT_APP_ENABLED, CHAT_MAX_OPEN_THREADS_PER_AGENT,
+} from '../../config.js'
+import { logger } from '../../logger.js'
+import { json, readBody } from '../http-helpers.js'
+import { getChatUser, type ChatUser } from '../chat/chat-session.js'
+import {
+  createChatThread, getChatThread, listChatThreads, countOpenChatThreads,
+  renameChatThread, touchChatThread, type ChatThread,
+} from '../../db.js'
+import {
+  startThreadSession, suspendThread, closeThread, sendPromptToThread,
+  isThreadRunning, transcriptPathForThread,
+} from '../chat/thread-process.js'
+import { readThreadTimeline, deriveThreadTitle, DEFAULT_TIMELINE_LIMIT } from '../chat/thread-transcript.js'
+import type { RouteContext } from './types.js'
+
+const MAX_BODY_BYTES = 256 * 1024
+const MAX_TITLE_LEN = 120
+const MAX_MESSAGE_LEN = 64 * 1024
+
+function threadView(t: ChatThread, agentName: string): Record<string, unknown> {
+  return {
+    id: t.id,
+    title: t.title,
+    status: t.status,
+    running: t.status === 'open' && isThreadRunning(agentName, t.id),
+    created_at: t.created_at,
+    last_activity_at: t.last_activity_at,
+  }
+}
+
+// Scope guard: a thread id from the URL is only visible when it belongs to
+// the session user's own agent. Foreign and nonexistent ids are the same 404.
+function ownedThread(user: ChatUser, threadId: string): ChatThread | null {
+  const t = getChatThread(threadId)
+  if (!t || t.agent_id !== user.agentId) return null
+  return t
+}
+
+export async function tryHandleChatApi(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method, url } = ctx
+  if (!path.startsWith('/chat-api/threads')) return false
+
+  if (!CHAT_APP_ENABLED) {
+    json(res, { error: 'Chat app is not enabled' }, 404)
+    return true
+  }
+
+  const user = getChatUser(req)
+  if (!user) {
+    json(res, { error: 'Unauthorized' }, 401)
+    return true
+  }
+
+  if (path === '/chat-api/threads' && method === 'GET') {
+    const includeClosed = url.searchParams.get('include_closed') === '1'
+    const threads = listChatThreads(user.agentId, { includeClosed })
+    json(res, {
+      agent: user.agentId,
+      open_count: countOpenChatThreads(user.agentId),
+      max_open: CHAT_MAX_OPEN_THREADS_PER_AGENT,
+      threads: threads.map(t => threadView(t, user.agentId)),
+    })
+    return true
+  }
+
+  if (path === '/chat-api/threads' && method === 'POST') {
+    if (countOpenChatThreads(user.agentId) >= CHAT_MAX_OPEN_THREADS_PER_AGENT) {
+      json(res, { error: `Elérted a nyitott szálak felső határát (${CHAT_MAX_OPEN_THREADS_PER_AGENT}). Zárj le egyet, mielőtt újat nyitsz.` }, 409)
+      return true
+    }
+    let title = ''
+    try {
+      const body = await readBody(req, { maxBytes: MAX_BODY_BYTES })
+      if (body.length) {
+        const parsed = JSON.parse(body.toString()) as { title?: string }
+        if (typeof parsed.title === 'string') title = parsed.title.trim().slice(0, MAX_TITLE_LEN)
+      }
+    } catch { /* empty/invalid body -> untitled thread */ }
+
+    const thread = createChatThread(user.agentId, randomUUID(), title)
+    const started = startThreadSession(user.agentId, thread)
+    if (!started.ok) {
+      // Keep the row reopenable instead of vanishing the user's thread.
+      suspendThread(user.agentId, thread.id)
+      logger.error({ agent: user.agentId, threadId: thread.id, error: started.error }, 'Thread spawn failed at creation')
+      json(res, { error: started.error ?? 'A szál indítása nem sikerült', thread: threadView(getChatThread(thread.id)!, user.agentId) }, 502)
+      return true
+    }
+    logger.info({ email: user.email, agent: user.agentId, threadId: thread.id }, 'Chat thread created')
+    json(res, { thread: threadView(getChatThread(thread.id)!, user.agentId) }, 201)
+    return true
+  }
+
+  const threadMatch = path.match(/^\/chat-api\/threads\/([0-9a-f-]{36})(\/messages|\/reopen)?$/)
+  if (!threadMatch) {
+    json(res, { error: 'Not found' }, 404)
+    return true
+  }
+  const thread = ownedThread(user, threadMatch[1])
+  if (!thread) {
+    json(res, { error: 'Not found' }, 404)
+    return true
+  }
+  const sub = threadMatch[2] ?? ''
+
+  if (sub === '' && method === 'PATCH') {
+    try {
+      const body = JSON.parse((await readBody(req, { maxBytes: MAX_BODY_BYTES })).toString()) as { title?: string }
+      const title = typeof body.title === 'string' ? body.title.trim().slice(0, MAX_TITLE_LEN) : ''
+      if (!title) {
+        json(res, { error: 'title is required' }, 400)
+        return true
+      }
+      renameChatThread(thread.id, title)
+      json(res, { thread: threadView(getChatThread(thread.id)!, user.agentId) })
+    } catch {
+      json(res, { error: 'Invalid JSON body' }, 400)
+    }
+    return true
+  }
+
+  if (sub === '' && method === 'DELETE') {
+    closeThread(user.agentId, thread.id)
+    logger.info({ email: user.email, threadId: thread.id }, 'Chat thread closed')
+    json(res, { ok: true })
+    return true
+  }
+
+  if (sub === '/reopen' && method === 'POST') {
+    if (thread.status === 'open' && isThreadRunning(user.agentId, thread.id)) {
+      json(res, { thread: threadView(thread, user.agentId) })
+      return true
+    }
+    if (countOpenChatThreads(user.agentId) >= CHAT_MAX_OPEN_THREADS_PER_AGENT && thread.status !== 'open') {
+      json(res, { error: `Elérted a nyitott szálak felső határát (${CHAT_MAX_OPEN_THREADS_PER_AGENT}).` }, 409)
+      return true
+    }
+    const started = startThreadSession(user.agentId, thread)
+    if (!started.ok) {
+      json(res, { error: started.error ?? 'A szál újranyitása nem sikerült' }, 502)
+      return true
+    }
+    json(res, { thread: threadView(getChatThread(thread.id)!, user.agentId) })
+    return true
+  }
+
+  if (sub === '/messages' && method === 'GET') {
+    const limitRaw = Number(url.searchParams.get('limit'))
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 2000) : DEFAULT_TIMELINE_LIMIT
+    const entries = readThreadTimeline(transcriptPathForThread(user.agentId, thread.claude_session_id), limit)
+    json(res, {
+      thread: threadView(thread, user.agentId),
+      count: entries.length,
+      entries,
+    })
+    return true
+  }
+
+  if (sub === '/messages' && method === 'POST') {
+    let text = ''
+    try {
+      const body = JSON.parse((await readBody(req, { maxBytes: MAX_BODY_BYTES })).toString()) as { text?: string }
+      text = typeof body.text === 'string' ? body.text.trim() : ''
+    } catch { /* handled below */ }
+    if (!text) {
+      json(res, { error: 'text is required' }, 400)
+      return true
+    }
+    if (text.length > MAX_MESSAGE_LEN) {
+      json(res, { error: `Az üzenet túl hosszú (max ${MAX_MESSAGE_LEN} karakter)` }, 413)
+      return true
+    }
+
+    // Suspended/closed thread: auto-reopen and tell the client to retry. The
+    // session needs seconds to boot, so delivering in the same request would
+    // hold the connection hostage; 202 + retry keeps the API snappy.
+    if (!isThreadRunning(user.agentId, thread.id)) {
+      if (countOpenChatThreads(user.agentId) >= CHAT_MAX_OPEN_THREADS_PER_AGENT && thread.status !== 'open') {
+        json(res, { error: `Elérted a nyitott szálak felső határát (${CHAT_MAX_OPEN_THREADS_PER_AGENT}).` }, 409)
+        return true
+      }
+      const started = startThreadSession(user.agentId, thread)
+      if (!started.ok) {
+        json(res, { error: started.error ?? 'A szál indítása nem sikerült' }, 502)
+        return true
+      }
+      json(res, { status: 'starting', retry_after_ms: 5000 }, 202)
+      return true
+    }
+
+    const sent = sendPromptToThread(user.agentId, thread.id, text)
+    if (!sent.ok) {
+      const busy = sent.error === 'Thread is busy'
+      json(res, { error: busy ? 'A szál még az előző üzeneten dolgozik' : (sent.error ?? 'Küldés sikertelen'), retry_after_ms: busy ? 2000 : undefined }, busy ? 409 : 502)
+      return true
+    }
+    touchChatThread(thread.id)
+    if (!thread.title) renameChatThread(thread.id, deriveThreadTitle(text))
+    json(res, { ok: true, thread: threadView(getChatThread(thread.id)!, user.agentId) })
+    return true
+  }
+
+  json(res, { error: 'Not found' }, 404)
+  return true
+}

--- a/src/web/routes/chat-auth.ts
+++ b/src/web/routes/chat-auth.ts
@@ -1,0 +1,182 @@
+// Chat app login endpoints (/chat-api/auth/*). Google Workspace OAuth ->
+// HttpOnly cookie session. This namespace is intentionally OUTSIDE /api/*:
+// the dashboard bearer gate does not apply here, and the chat session cookie
+// grants nothing under /api/*.
+import { randomBytes } from 'node:crypto'
+import {
+  CHAT_APP_ENABLED, CHAT_GOOGLE_CLIENT_ID, CHAT_GOOGLE_CLIENT_SECRET,
+  CHAT_ALLOWED_DOMAIN, CHAT_PUBLIC_URL, WEB_PORT,
+} from '../../config.js'
+import { logger } from '../../logger.js'
+import { json } from '../http-helpers.js'
+import {
+  buildGoogleAuthUrl, exchangeCodeForIdToken, decodeIdTokenClaims,
+  validateIdClaims, validateWorkspaceUser,
+} from '../chat/google-oauth.js'
+import { resolveAgentForEmail, CHAT_USERS_PATH } from '../chat/chat-users.js'
+import {
+  createSession, destroySession, getChatUser,
+  buildSessionCookie, buildClearedSessionCookie, parseCookies,
+} from '../chat/chat-session.js'
+import type { RouteContext } from './types.js'
+
+// Short-lived cookie carrying the OAuth state+nonce pair between /login and
+// /callback. Cookie-bound (not a server-side map) so it survives a server
+// restart mid-login and needs no cleanup.
+const OAUTH_FLOW_COOKIE = 'marveen_chat_oauth'
+const OAUTH_FLOW_TTL_SECONDS = 10 * 60
+
+function publicBaseUrl(): string {
+  return CHAT_PUBLIC_URL || `http://localhost:${WEB_PORT}`
+}
+
+function redirectUri(): string {
+  return `${publicBaseUrl()}/chat-api/auth/callback`
+}
+
+function oauthConfigured(): boolean {
+  return Boolean(CHAT_GOOGLE_CLIENT_ID && CHAT_GOOGLE_CLIENT_SECRET && CHAT_ALLOWED_DOMAIN)
+}
+
+function flowCookie(state: string, nonce: string): string {
+  const attrs = [
+    `${OAUTH_FLOW_COOKIE}=${state}.${nonce}`,
+    'HttpOnly',
+    'Path=/chat-api/auth',
+    'SameSite=Lax',
+    `Max-Age=${OAUTH_FLOW_TTL_SECONDS}`,
+  ]
+  if (publicBaseUrl().startsWith('https://')) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+function clearedFlowCookie(): string {
+  const attrs = [`${OAUTH_FLOW_COOKIE}=`, 'HttpOnly', 'Path=/chat-api/auth', 'SameSite=Lax', 'Max-Age=0']
+  if (publicBaseUrl().startsWith('https://')) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+// Login failures redirect back to the app root with a machine-readable code
+// (the future chat UI shows the message); they carry no session cookie.
+function failRedirect(res: RouteContext['res'], code: string): void {
+  res.writeHead(302, {
+    Location: `${publicBaseUrl()}/?login_error=${encodeURIComponent(code)}`,
+    'Set-Cookie': clearedFlowCookie(),
+    'Cache-Control': 'private, no-store',
+  })
+  res.end()
+}
+
+export async function tryHandleChatAuth(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method, url } = ctx
+  if (!path.startsWith('/chat-api/auth/')) return false
+
+  if (!CHAT_APP_ENABLED) {
+    json(res, { error: 'Chat app is not enabled' }, 404)
+    return true
+  }
+
+  if (path === '/chat-api/auth/login' && method === 'GET') {
+    if (!oauthConfigured()) {
+      logger.error('Chat app login attempted without CHAT_GOOGLE_CLIENT_ID/SECRET/CHAT_ALLOWED_DOMAIN configured')
+      json(res, { error: 'Chat login is not configured on this server' }, 503)
+      return true
+    }
+    const state = randomBytes(16).toString('hex')
+    const nonce = randomBytes(16).toString('hex')
+    const authUrl = buildGoogleAuthUrl(
+      { clientId: CHAT_GOOGLE_CLIENT_ID, redirectUri: redirectUri() },
+      state, nonce, CHAT_ALLOWED_DOMAIN,
+    )
+    res.writeHead(302, {
+      Location: authUrl,
+      'Set-Cookie': flowCookie(state, nonce),
+      'Cache-Control': 'private, no-store',
+    })
+    res.end()
+    return true
+  }
+
+  if (path === '/chat-api/auth/callback' && method === 'GET') {
+    const flowRaw = parseCookies(req.headers.cookie)[OAUTH_FLOW_COOKIE] ?? ''
+    const [cookieState, cookieNonce] = flowRaw.split('.')
+    const queryState = url.searchParams.get('state') ?? ''
+    const code = url.searchParams.get('code') ?? ''
+    if (!cookieState || !cookieNonce || !queryState || queryState !== cookieState) {
+      failRedirect(res, 'state_mismatch')
+      return true
+    }
+    if (!code) {
+      // User cancelled at Google (error=access_denied) or malformed callback.
+      failRedirect(res, 'cancelled')
+      return true
+    }
+    let email: string
+    try {
+      const idToken = await exchangeCodeForIdToken(code, {
+        clientId: CHAT_GOOGLE_CLIENT_ID,
+        clientSecret: CHAT_GOOGLE_CLIENT_SECRET,
+        redirectUri: redirectUri(),
+      })
+      const claims = decodeIdTokenClaims(idToken)
+      const claimCheck = validateIdClaims(claims, { clientId: CHAT_GOOGLE_CLIENT_ID, nonce: cookieNonce })
+      if (!claimCheck.ok) {
+        logger.warn({ reason: claimCheck.reason }, 'Chat login rejected: invalid id_token claims')
+        failRedirect(res, 'invalid_token')
+        return true
+      }
+      const domainCheck = validateWorkspaceUser(claims, CHAT_ALLOWED_DOMAIN)
+      if (!domainCheck.ok) {
+        logger.warn({ reason: domainCheck.reason }, 'Chat login rejected: domain check failed')
+        failRedirect(res, 'forbidden_domain')
+        return true
+      }
+      email = domainCheck.email
+    } catch (err) {
+      logger.error({ err }, 'Chat login: code exchange failed')
+      failRedirect(res, 'exchange_failed')
+      return true
+    }
+
+    const agentId = resolveAgentForEmail(email)
+    if (!agentId) {
+      logger.warn({ email }, `Chat login rejected: no agent mapping (add the user to ${CHAT_USERS_PATH})`)
+      failRedirect(res, 'no_agent')
+      return true
+    }
+
+    const { sid, maxAgeSeconds } = createSession(email, agentId)
+    logger.info({ email, agentId }, 'Chat login successful')
+    res.writeHead(302, {
+      Location: `${publicBaseUrl()}/`,
+      'Set-Cookie': [buildSessionCookie(sid, maxAgeSeconds), clearedFlowCookie()],
+      'Cache-Control': 'private, no-store',
+    })
+    res.end()
+    return true
+  }
+
+  if (path === '/chat-api/auth/me' && method === 'GET') {
+    const user = getChatUser(req)
+    if (!user) {
+      json(res, { authenticated: false }, 401)
+      return true
+    }
+    json(res, { authenticated: true, email: user.email, agent: user.agentId })
+    return true
+  }
+
+  if (path === '/chat-api/auth/logout' && method === 'POST') {
+    destroySession(req)
+    res.writeHead(200, {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Set-Cookie': buildClearedSessionCookie(),
+      'Cache-Control': 'private, no-store',
+    })
+    res.end(JSON.stringify({ ok: true }))
+    return true
+  }
+
+  json(res, { error: 'Not found' }, 404)
+  return true
+}


### PR DESCRIPTION
Third PR of the chat app track. **Stacked on #365** (and transitively #364) — their commits are included; a rebase after they merge shrinks this to its own diff.

## Endpoints (plan §7, cookie-session auth)

| Method | Path | Behaviour |
|---|---|---|
| GET | `/chat-api/threads` | the user's own threads (+ `open_count`/`max_open` for the UI) |
| POST | `/chat-api/threads` | new thread; 409 over the per-agent cap; spawn failure keeps the row suspended (reopenable) instead of vanishing it |
| PATCH | `/chat-api/threads/:id` | rename |
| DELETE | `/chat-api/threads/:id` | close (drops from default list, stays reopenable) |
| POST | `/chat-api/threads/:id/reopen` | `--resume` the session |
| GET | `/chat-api/threads/:id/messages` | chat timeline from the deterministic transcript `<claude_session_id>.jsonl` |
| POST | `/chat-api/threads/:id/messages` | send prompt; **202 + retry_after** while a suspended thread boots; **409 + retry_after** while the previous turn runs; first message auto-titles the thread |

## Authorization invariant

Every endpoint resolves the agent **exclusively** from the logged-in user's session row (`getChatUser`) — never from the path or body. A thread id owned by another agent 404s indistinguishably from a nonexistent id. The admin `/api/*` surface remains unreachable with a chat cookie by construction.

## Timeline parser

Thread-specific (`thread-transcript.ts`), not the #356 agent-conversation parser: thread sessions have no channel plugin, so the colleague's messages are plain typed prompts rather than `<channel>` wrappers. `tool_result` user-lines, `<system-reminder>`s and slash-command echoes are filtered out so they don't render as fake user bubbles; `tool_use` blocks become collapsed action labels.

## Tests

7 new (`chat-thread-transcript.test.ts`): user/assistant rendering, tool_result and harness-noise filtering, action labels, malformed-line tolerance + limit semantics, auto-title derivation. Full suite: 1248 passed.

Next (last) PR: the chat frontend (thread list + chat UI, mobile-friendly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)