### PR TITLE
fix(channels): recover paste-placeholder stuck input + wait-for-idle send gate

### DIFF
--- a/src/__tests__/pane-looks-idle.test.ts
+++ b/src/__tests__/pane-looks-idle.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest'
+import { paneLooksIdle, isReadyForPrompt } from '../pane-state.js'
+
+// Unit tests for paneLooksIdle -- the pure idle predicate extracted as the
+// SINGLE source of truth for "is this pane idle / safe to send a prompt into".
+// It backs three call sites: the readiness check (isReadyForPrompt), the
+// auto-restart idle-guard (auto-restart-runner.paneIsIdle), and the
+// sendPromptToSession pre-flight wait-until-idle gate (waitForPaneIdle).
+//
+// These assertions are on DETERMINISTIC string->bool output only; no LLM
+// behaviour, no tmux, no timers. Fixtures reproduce real `tmux capture-pane -p`
+// bytes (U+2500 ─ box separators, U+276F ❯ prompt, U+23F5 ⏵ footer chevrons,
+// U+00B7 · footer dot). Sanitised: no internal names/paths.
+
+const SEP = '─'.repeat(80)
+
+// --- Idle surfaces (predicate must be TRUE) ---
+
+// Default bypass-permissions footer with the shift+tab-cycle hint, empty box.
+const IDLE_BYPASS = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Strict-mode footer ("? for shortcuts"), empty box -- also idle.
+const IDLE_STRICT = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ? for shortcuts',
+].join('\n')
+
+// Background-shells footer variant. A session with a BashTool background shell
+// rewrites the footer to "· N shells · ... · ↓ to manage" but is still idle and
+// MUST accept a prompt, else its scheduled tasks / inbox pile up forever.
+const IDLE_BACKGROUND_SHELLS = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on · 3 shells · ctrl+t to hide tasks · ↓ to manage',
+].join('\n')
+
+// Post-tool-use idle: a "Searched / Listed" summary persists in scrollback
+// after the turn ended, but no spinner / tokens / esc-to-interrupt. Idle.
+const IDLE_AFTER_TOOL_USE = [
+  '  Searched for 3 patterns, listed 4 directories (ctrl+o to expand)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Multibyte / non-ASCII content sitting in scrollback above an empty, idle
+// input box. The idle classification must not be perturbed by wide glyphs,
+// accented Latin, CJK or emoji in the reply text above.
+const IDLE_MULTIBYTE_SCROLLBACK = [
+  '⏺ Kész: az árvíztűrő tükörfúrógép működik. 完了しました 🚀 -- ✅',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// --- Busy surfaces (predicate must be FALSE) ---
+
+// Full busy footer: spinner + token counter + `esc to interrupt`.
+const BUSY_FULL_FOOTER = [
+  '✢ Combobulating… (52s · ↓ 2.6k tokens · thinking some more)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+].join('\n')
+
+// The frame-gap: spinner rendered but the footer is momentarily still in its
+// idle shape (no `· esc to interrupt` yet). The token/spinner signal must keep
+// this classified busy -- this is the exact false-positive the predicate
+// closes (a tick here previously sent a prompt into a mid-turn pane).
+const BUSY_FOOTER_FRAME_GAP = [
+  '✢ Combobulating… (52s · ↓ 2.6k tokens · thinking some more)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Only the `esc to interrupt` footer marker present (no visible spinner line).
+const BUSY_ESC_ONLY = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+].join('\n')
+
+// --- Not-ready non-idle surfaces (predicate must be FALSE) ---
+
+// Text parked in the live input box (user composing, or a swallowed send) ->
+// 'typing', not idle: a new prompt would concatenate onto it.
+const TYPING_PARKED = [
+  '',
+  SEP,
+  '❯ egy felig begepelt sor amit meg nem kuldtek el',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// `[Pasted text #N]` placeholder in the input box -- the bracketed-paste stub
+// that does not auto-submit; classified busy (not idle) so nothing piles on.
+const PENDING_PASTE = [
+  '',
+  SEP,
+  '❯ [Pasted text #1 +234 chars]',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A blocking interactive menu / modal (e.g. the /mcp manager or a picker):
+// the input box is replaced by a nav list with "↑/↓ to navigate · Esc to
+// cancel". No idle footer -> not idle.
+const MODAL_BLOCKING_MENU = [
+  '  Select an MCP server to manage:',
+  '   1. alpha',
+  '   2. bravo',
+  '',
+  '  ↑/↓ to navigate · Enter to confirm · Esc to cancel',
+].join('\n')
+
+// Resume-from-summary modal shown near the context limit: numbered options +
+// "Enter to confirm", no bypass/strict footer -> not idle.
+const MODAL_RESUME_SUMMARY = [
+  '  Resume from summary',
+  '   1. Resume from summary (recommended)',
+  '   2. Start fresh',
+  '',
+  '  Enter to confirm',
+].join('\n')
+
+// Empty / whitespace-only capture (capture race, blank pane) -> not idle.
+const EMPTY_CAPTURE = ''
+const WHITESPACE_CAPTURE = '   \n  \n\t\n'
+
+// A plain shell pane (not Claude Code at all) -> 'unknown', not idle.
+const NON_CLAUDE = [
+  'user@host project $ ls',
+  'README.md  src  test',
+  'user@host project $ ',
+].join('\n')
+
+describe('paneLooksIdle', () => {
+  describe('idle surfaces -> true', () => {
+    it('default bypass footer (shift+tab to cycle), empty box', () => {
+      expect(paneLooksIdle(IDLE_BYPASS)).toBe(true)
+    })
+    it('strict-mode footer (? for shortcuts)', () => {
+      expect(paneLooksIdle(IDLE_STRICT)).toBe(true)
+    })
+    it('background-shells footer variant', () => {
+      expect(paneLooksIdle(IDLE_BACKGROUND_SHELLS)).toBe(true)
+    })
+    it('post-tool-use idle (summary in scrollback, no live busy signal)', () => {
+      expect(paneLooksIdle(IDLE_AFTER_TOOL_USE)).toBe(true)
+    })
+    it('multibyte / emoji content in scrollback above an empty idle box', () => {
+      expect(paneLooksIdle(IDLE_MULTIBYTE_SCROLLBACK)).toBe(true)
+    })
+  })
+
+  describe('busy surfaces -> false', () => {
+    it('full busy footer (spinner + tokens + esc to interrupt)', () => {
+      expect(paneLooksIdle(BUSY_FULL_FOOTER)).toBe(false)
+    })
+    it('frame-gap: spinner present, footer momentarily idle-shaped', () => {
+      expect(paneLooksIdle(BUSY_FOOTER_FRAME_GAP)).toBe(false)
+    })
+    it('esc to interrupt footer marker alone', () => {
+      expect(paneLooksIdle(BUSY_ESC_ONLY)).toBe(false)
+    })
+  })
+
+  describe('non-idle / not-ready surfaces -> false', () => {
+    it('text parked in the live input box (typing)', () => {
+      expect(paneLooksIdle(TYPING_PARKED)).toBe(false)
+    })
+    it('[Pasted text #N] placeholder in the input box', () => {
+      expect(paneLooksIdle(PENDING_PASTE)).toBe(false)
+    })
+    it('blocking interactive menu / modal', () => {
+      expect(paneLooksIdle(MODAL_BLOCKING_MENU)).toBe(false)
+    })
+    it('resume-from-summary modal', () => {
+      expect(paneLooksIdle(MODAL_RESUME_SUMMARY)).toBe(false)
+    })
+    it('empty capture', () => {
+      expect(paneLooksIdle(EMPTY_CAPTURE)).toBe(false)
+    })
+    it('whitespace-only capture', () => {
+      expect(paneLooksIdle(WHITESPACE_CAPTURE)).toBe(false)
+    })
+    it('non-Claude shell pane', () => {
+      expect(paneLooksIdle(NON_CLAUDE)).toBe(false)
+    })
+  })
+
+  describe('isReadyForPrompt is a thin alias over paneLooksIdle', () => {
+    const cases: Array<[string, string]> = [
+      ['IDLE_BYPASS', IDLE_BYPASS],
+      ['BUSY_FULL_FOOTER', BUSY_FULL_FOOTER],
+      ['BUSY_FOOTER_FRAME_GAP', BUSY_FOOTER_FRAME_GAP],
+      ['TYPING_PARKED', TYPING_PARKED],
+      ['PENDING_PASTE', PENDING_PASTE],
+      ['MODAL_BLOCKING_MENU', MODAL_BLOCKING_MENU],
+      ['EMPTY_CAPTURE', EMPTY_CAPTURE],
+      ['NON_CLAUDE', NON_CLAUDE],
+    ]
+    for (const [name, fixture] of cases) {
+      it(`agrees with isReadyForPrompt on ${name}`, () => {
+        expect(isReadyForPrompt(fixture)).toBe(paneLooksIdle(fixture))
+      })
+    }
+  })
+})

--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -3,6 +3,7 @@ import {
   detectPaneState,
   detectsThinkingBlockError,
   detectsBlockingMenu,
+  detectsPastePlaceholder,
   isReadyForPrompt,
   shouldRetrySubmit,
   shouldClearTruncatedPreamble,
@@ -107,6 +108,24 @@ const PENDING_PASTE = [
   '❯ [Pasted text #1 +234 chars]',
   SEP,
   '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// REALISTIC placeholder render, captured from a live Claude Code v2.1.x build:
+// a single large send-keys write trips the bracketed-paste detector, which
+// REPLACES the idle footer (`bypass permissions on ...`) with the
+// `paste again to expand` hint. The pane therefore does NOT satisfy
+// IDLE_FOOTER_RX, which is exactly why the placeholder previously slipped
+// through every guard (detectPaneState -> 'unknown', shouldRetrySubmit ->
+// false). The `[Pasted text #N]` stub here has no `+X chars` suffix, the
+// other shape the same build emits.
+const PENDING_PASTE_REALISTIC = [
+  '',
+  SEP,
+  '❯ [Pasted text #38]the quick brown fox jumps over the lazy dog the quick brown',
+  '  brown fox jumps over the lazy dog the quick brown fox jumps over the lazy dog',
+  '  the lazy dog the quick brown fox jumps over the lazy dog',
+  SEP,
+  '  paste again to expand',
 ].join('\n')
 
 // Historical ❯ above the separators (scrollback). Must NOT count as
@@ -472,6 +491,14 @@ describe('detectPaneState', () => {
     expect(detectPaneState(PENDING_PASTE)).toBe('busy')
   })
 
+  it('treats the REALISTIC placeholder (no idle footer) as busy, not unknown', () => {
+    // Regression for the root-cause gap: the real placeholder render replaces
+    // the idle footer with `paste again to expand`, so it failed IDLE_FOOTER_RX
+    // and was mis-classified 'unknown' (slipping past the readiness/retry
+    // guards). The paste check now runs BEFORE the idle-footer gate.
+    expect(detectPaneState(PENDING_PASTE_REALISTIC)).toBe('busy')
+  })
+
   it('does NOT confuse a historical ❯ in scrollback for a parked input', () => {
     expect(detectPaneState(IDLE_WITH_SCROLLBACK_CARET)).toBe('idle')
   })
@@ -768,6 +795,14 @@ describe('shouldRetrySubmit', () => {
     expect(shouldRetrySubmit(STUCK_MULTI_PLACEHOLDER_MIX, PAYLOAD_HINT)).toBe(true)
   })
 
+  it('detects the REALISTIC placeholder (no idle footer) as stuck', () => {
+    // Regression: the real placeholder render has the `paste again to expand`
+    // footer, not the idle footer, so the old footer-gate ordering returned
+    // false here. The placeholder check now precedes the idle-footer gate.
+    expect(shouldRetrySubmit(PENDING_PASTE_REALISTIC, '')).toBe(true)
+    expect(shouldRetrySubmit(PENDING_PASTE_REALISTIC, PAYLOAD_HINT)).toBe(true)
+  })
+
   it('detects verbatim parked payload (footer idle, no spinner) as stuck', () => {
     // The payload substring sits in the live input box and the footer
     // shows bypass idle without any busy markers. Classic Incidens 2/5
@@ -1009,10 +1044,19 @@ describe('decideSubmitFollowup', () => {
     expect(decideSubmitFollowup(TYPING_PARKED, PAYLOAD_HINT, 0, 2)).toBe('done')
   })
 
-  it('returns "retry-enter" while attempts are below the cap', () => {
+  it('returns "retry-enter" for VERBATIM stuck text while below the cap', () => {
+    // Verbatim parked text (trailing Enter swallowed) submits on a plain
+    // Enter, so the verbatim path still routes to retry-enter.
     expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 0, 2)).toBe('retry-enter')
     expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 1, 2)).toBe('retry-enter')
-    expect(decideSubmitFollowup(PENDING_PASTE, '', 0, 2)).toBe('retry-enter')
+  })
+
+  it('returns "clear-and-resend" for a paste placeholder while below the cap', () => {
+    // A `[Pasted text #N]` placeholder is PROVEN not to submit on a plain
+    // Enter (Enter only expands it to still-parked verbatim text), so it must
+    // route to the clear-and-resend recovery, NOT retry-enter.
+    expect(decideSubmitFollowup(PENDING_PASTE, '', 0, 2)).toBe('clear-and-resend')
+    expect(decideSubmitFollowup(PENDING_PASTE_REALISTIC, '', 0, 2)).toBe('clear-and-resend')
   })
 
   it('returns "give-up" once attempts reach the cap', () => {
@@ -1021,6 +1065,13 @@ describe('decideSubmitFollowup', () => {
     // burning more retries on a pane that refuses to flush.
     expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 2, 2)).toBe('give-up')
     expect(decideSubmitFollowup(STUCK_VERBATIM, PAYLOAD_HINT, 5, 2)).toBe('give-up')
+  })
+
+  it('returns "give-up" for a placeholder once attempts reach the cap', () => {
+    // A placeholder that survived the clear-and-resend budget must bail too,
+    // not loop forever clearing and re-sending.
+    expect(decideSubmitFollowup(PENDING_PASTE_REALISTIC, '', 4, 4)).toBe('give-up')
+    expect(decideSubmitFollowup(PENDING_PASTE, '', 2, 2)).toBe('give-up')
   })
 
   it('treats maxAttempts === 0 as "give-up on first stuck observation"', () => {
@@ -1497,5 +1548,66 @@ describe('detectsBlockingMenu', () => {
       '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
     ].join('\n')
     expect(detectsBlockingMenu(quoted)).toBe(false)
+  })
+})
+
+describe('detectsPastePlaceholder', () => {
+  it('detects the `[Pasted text #N +X chars]` stub', () => {
+    expect(detectsPastePlaceholder(PENDING_PASTE)).toBe(true)
+  })
+
+  it('detects the bare `[Pasted text #N]` stub (no +X chars suffix)', () => {
+    // The live v2.1.x build emits the bare shape; both must match.
+    expect(detectsPastePlaceholder(PENDING_PASTE_REALISTIC)).toBe(true)
+  })
+
+  it('detects a multi-stub mixed buffer', () => {
+    expect(detectsPastePlaceholder(STUCK_MULTI_PLACEHOLDER_MIX)).toBe(true)
+  })
+
+  it('is false on a clean idle pane', () => {
+    expect(detectsPastePlaceholder(IDLE_BYPASS)).toBe(false)
+    expect(detectsPastePlaceholder(IDLE_STRICT)).toBe(false)
+  })
+
+  it('is false on a busy pane', () => {
+    expect(detectsPastePlaceholder(BUSY_FULL_FOOTER)).toBe(false)
+    expect(detectsPastePlaceholder(BUSY_TOKENS_ONLY)).toBe(false)
+  })
+
+  it('is false on verbatim parked text (no stub)', () => {
+    expect(detectsPastePlaceholder(STUCK_VERBATIM)).toBe(false)
+    expect(detectsPastePlaceholder(TYPING_PARKED)).toBe(false)
+  })
+
+  it('is false on an empty / whitespace pane', () => {
+    expect(detectsPastePlaceholder('')).toBe(false)
+    expect(detectsPastePlaceholder('   \n  ')).toBe(false)
+  })
+
+  it('does NOT key on the `paste again to expand` hint alone', () => {
+    // The hint LINGERS for a frame after the message submits (box already
+    // empty, stub gone). Keying on it would false-positive a freshly-
+    // submitted pane as still stuck. Only the `[Pasted text #N]` stub counts.
+    const submittedButHintLingers = [
+      '  ⏺ Done.',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  paste again to expand',
+    ].join('\n')
+    expect(detectsPastePlaceholder(submittedButHintLingers)).toBe(false)
+  })
+
+  it('matches the stub anywhere in the visible pane', () => {
+    const wrappedStub = [
+      'some preceding line',
+      SEP,
+      '❯ leading text [Pasted text #7] trailing text',
+      SEP,
+      '  paste again to expand',
+    ].join('\n')
+    expect(detectsPastePlaceholder(wrappedStub)).toBe(true)
   })
 })

--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -110,14 +110,14 @@ const PENDING_PASTE = [
   '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
 ].join('\n')
 
-// REALISTIC placeholder render, captured from a live Claude Code v2.1.x build:
-// a single large send-keys write trips the bracketed-paste detector, which
-// REPLACES the idle footer (`bypass permissions on ...`) with the
-// `paste again to expand` hint. The pane therefore does NOT satisfy
-// IDLE_FOOTER_RX, which is exactly why the placeholder previously slipped
-// through every guard (detectPaneState -> 'unknown', shouldRetrySubmit ->
-// false). The `[Pasted text #N]` stub here has no `+X chars` suffix, the
-// other shape the same build emits.
+// Placeholder render from an OLDER Claude Code build: the bracketed-paste
+// detector REPLACES the idle footer (`bypass permissions on ...`) with a
+// `paste again to expand` hint, so the pane does NOT satisfy IDLE_FOOTER_RX.
+// The detector must NOT depend on this footer being present or absent -- the
+// footer shape is version-dependent. Kept as a regression case so the
+// box-scoped, footer-independent detector still classifies this shape.
+// The `[Pasted text #N]` stub here has no `+X chars` suffix, the other shape
+// the same build emits. The stub sits on the FIRST line of the live input box.
 const PENDING_PASTE_REALISTIC = [
   '',
   SEP,
@@ -126,6 +126,55 @@ const PENDING_PASTE_REALISTIC = [
   '  the lazy dog the quick brown fox jumps over the lazy dog',
   SEP,
   '  paste again to expand',
+].join('\n')
+
+// SANITIZED reproduction of the REAL production render shape (derived from the
+// 6 captured incident panes, NOT copied verbatim -- the captures contain agent
+// names / real messages). Ground truth from the captures:
+//   - The long input WRAPS, so the stub straddles a line break: `...[Pasted
+//     text` at the end of one line and `  #N]...` at the start of the next.
+//     The single-space regex `[Pasted text #\d` MISSED this (false negative on
+//     2 of 3 real incidents).
+//   - The stub sits inside the LIVE INPUT BOX (the wrapped `❯` prompt line).
+//   - The footer is the NORMAL `bypass permissions on (shift+tab to cycle)`
+//     idle footer -- there is NO `paste again to expand` line. The detector
+//     must therefore not rely on that hint.
+// Benign filler stands in for the real (sensitive) message body.
+const PENDING_PASTE_WRAPPED_REAL_SHAPE = [
+  '',
+  SEP,
+  '❯ TEAM MEMBER NOTICE filler filler filler filler filler filler filler b[Pasted text',
+  '  #3]filler continuation of the wrapped message body in the live input box here',
+  '  more benign filler text continuing inside the same wrapped input box region',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Same wrapped-stub real shape but with the DIGITS themselves straddling the
+// break: `#` at the end of one line, the digit at the start of the next. The
+// `\s*` between `#` and the digit must tolerate this too.
+const PENDING_PASTE_WRAPPED_DIGIT_SPLIT = [
+  '',
+  SEP,
+  '❯ filler filler filler filler filler filler filler filler filler [Pasted text #',
+  '  12]filler continuation of the parked message body inside the live input box',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// FALSE-POSITIVE guard: a `[Pasted text #N +X chars]` literal sits ONLY in an
+// upper reply line (these agents routinely quote tmux captures and discuss this
+// very bug), while the live input box at the bottom is EMPTY. A whole-pane
+// match would fire a destructive Ctrl-C + resend on a healthy, idle agent. The
+// box-scoped detector must return false here.
+const PASTE_ECHO_IN_SCROLLBACK_ONLY = [
+  '  Quoting a capture in a reply: [Pasted text #1 +900 chars] -- discussed in',
+  '  the stuck-input bug thread, just prose about the placeholder behaviour',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
 ].join('\n')
 
 // Historical ❯ above the separators (scrollback). Must NOT count as
@@ -491,12 +540,26 @@ describe('detectPaneState', () => {
     expect(detectPaneState(PENDING_PASTE)).toBe('busy')
   })
 
-  it('treats the REALISTIC placeholder (no idle footer) as busy, not unknown', () => {
-    // Regression for the root-cause gap: the real placeholder render replaces
+  it('treats the older-build placeholder (paste-again footer) as busy, not unknown', () => {
+    // Regression for the root-cause gap: the older placeholder render replaces
     // the idle footer with `paste again to expand`, so it failed IDLE_FOOTER_RX
     // and was mis-classified 'unknown' (slipping past the readiness/retry
     // guards). The paste check now runs BEFORE the idle-footer gate.
     expect(detectPaneState(PENDING_PASTE_REALISTIC)).toBe('busy')
+  })
+
+  it('treats the WRAPPED real-shape placeholder (normal idle footer) as busy', () => {
+    // The primary real-incident shape: wrapped stub inside the input box with
+    // the NORMAL idle footer below it. Must read 'busy' so the scheduler/router
+    // defer rather than pile a second prompt onto the parked placeholder.
+    expect(detectPaneState(PENDING_PASTE_WRAPPED_REAL_SHAPE)).toBe('busy')
+    expect(detectPaneState(PENDING_PASTE_WRAPPED_DIGIT_SPLIT)).toBe('busy')
+  })
+
+  it('stays idle when a stub is only quoted in scrollback and the box is empty', () => {
+    // False-positive guard: a `[Pasted text #N]` quoted in a reply line must
+    // not flip an idle, empty-box pane to 'busy'.
+    expect(detectPaneState(PASTE_ECHO_IN_SCROLLBACK_ONLY)).toBe('idle')
   })
 
   it('does NOT confuse a historical ❯ in scrollback for a parked input', () => {
@@ -795,12 +858,27 @@ describe('shouldRetrySubmit', () => {
     expect(shouldRetrySubmit(STUCK_MULTI_PLACEHOLDER_MIX, PAYLOAD_HINT)).toBe(true)
   })
 
-  it('detects the REALISTIC placeholder (no idle footer) as stuck', () => {
-    // Regression: the real placeholder render has the `paste again to expand`
+  it('detects the older-build placeholder (paste-again footer) as stuck', () => {
+    // Regression: the older placeholder render has the `paste again to expand`
     // footer, not the idle footer, so the old footer-gate ordering returned
     // false here. The placeholder check now precedes the idle-footer gate.
     expect(shouldRetrySubmit(PENDING_PASTE_REALISTIC, '')).toBe(true)
     expect(shouldRetrySubmit(PENDING_PASTE_REALISTIC, PAYLOAD_HINT)).toBe(true)
+  })
+
+  it('detects the WRAPPED real-shape placeholder (normal idle footer) as stuck', () => {
+    // The primary real-incident shape: wrapped stub + normal idle footer. The
+    // single-space regex missed the wrap; the wrap-tolerant box-scoped check
+    // now catches it so the recovery fires.
+    expect(shouldRetrySubmit(PENDING_PASTE_WRAPPED_REAL_SHAPE, '')).toBe(true)
+    expect(shouldRetrySubmit(PENDING_PASTE_WRAPPED_DIGIT_SPLIT, '')).toBe(true)
+  })
+
+  it('returns false when a stub is only quoted in scrollback (empty box)', () => {
+    // False-positive guard: must not fire a clear-and-resend when the stub is
+    // merely quoted above an empty input box.
+    expect(shouldRetrySubmit(PASTE_ECHO_IN_SCROLLBACK_ONLY, PAYLOAD_HINT)).toBe(false)
+    expect(shouldRetrySubmit(PASTE_ECHO_IN_SCROLLBACK_ONLY, '')).toBe(false)
   })
 
   it('detects verbatim parked payload (footer idle, no spinner) as stuck', () => {
@@ -1054,9 +1132,17 @@ describe('decideSubmitFollowup', () => {
   it('returns "clear-and-resend" for a paste placeholder while below the cap', () => {
     // A `[Pasted text #N]` placeholder is PROVEN not to submit on a plain
     // Enter (Enter only expands it to still-parked verbatim text), so it must
-    // route to the clear-and-resend recovery, NOT retry-enter.
+    // route to the clear-and-resend recovery, NOT retry-enter. Covers the
+    // single-line, older-build, and wrapped real-shape placeholders.
     expect(decideSubmitFollowup(PENDING_PASTE, '', 0, 2)).toBe('clear-and-resend')
     expect(decideSubmitFollowup(PENDING_PASTE_REALISTIC, '', 0, 2)).toBe('clear-and-resend')
+    expect(decideSubmitFollowup(PENDING_PASTE_WRAPPED_REAL_SHAPE, '', 0, 2)).toBe('clear-and-resend')
+  })
+
+  it('returns "done" when a stub is only quoted in scrollback (empty box)', () => {
+    // False-positive guard at the decision layer: a quoted stub above an empty
+    // box is not stuck, so no follow-up action fires.
+    expect(decideSubmitFollowup(PASTE_ECHO_IN_SCROLLBACK_ONLY, PAYLOAD_HINT, 0, 2)).toBe('done')
   })
 
   it('returns "give-up" once attempts reach the cap', () => {
@@ -1557,8 +1643,28 @@ describe('detectsPastePlaceholder', () => {
   })
 
   it('detects the bare `[Pasted text #N]` stub (no +X chars suffix)', () => {
-    // The live v2.1.x build emits the bare shape; both must match.
+    // The older build emits the bare shape (with `paste again to expand`
+    // footer); both stub shapes must match regardless of the footer.
     expect(detectsPastePlaceholder(PENDING_PASTE_REALISTIC)).toBe(true)
+  })
+
+  it('detects the WRAPPED stub (real shape: line break between `[Pasted text` and `#N`)', () => {
+    // The primary real-incident case: a long input wraps so the stub straddles
+    // a line break, and the footer is the NORMAL idle footer (no `paste again
+    // to expand`). The single-space regex missed this on 2 of 3 real incidents.
+    expect(detectsPastePlaceholder(PENDING_PASTE_WRAPPED_REAL_SHAPE)).toBe(true)
+  })
+
+  it('detects the wrapped stub when the DIGITS straddle the line break', () => {
+    // `#` at the end of one line, the digit at the start of the next.
+    expect(detectsPastePlaceholder(PENDING_PASTE_WRAPPED_DIGIT_SPLIT)).toBe(true)
+  })
+
+  it('is false when a stub appears ONLY in an upper reply line (scoped to the box)', () => {
+    // False-positive guard (the confirmed bug): a `[Pasted text #N]` quoted in
+    // scrollback / a reply while the live input box is empty must NOT trigger a
+    // destructive clear-and-resend on a healthy idle agent.
+    expect(detectsPastePlaceholder(PASTE_ECHO_IN_SCROLLBACK_ONLY)).toBe(false)
   })
 
   it('detects a multi-stub mixed buffer', () => {
@@ -1600,14 +1706,17 @@ describe('detectsPastePlaceholder', () => {
     expect(detectsPastePlaceholder(submittedButHintLingers)).toBe(false)
   })
 
-  it('matches the stub anywhere in the visible pane', () => {
-    const wrappedStub = [
+  it('matches the stub when it sits inside the live input box', () => {
+    // Scoped to the box: a stub on the prompt line (between the separators) is
+    // a genuine parked placeholder and must match, regardless of whether the
+    // footer is the normal idle footer or `paste again to expand`.
+    const stubInBox = [
       'some preceding line',
       SEP,
       '❯ leading text [Pasted text #7] trailing text',
       SEP,
       '  paste again to expand',
     ].join('\n')
-    expect(detectsPastePlaceholder(wrappedStub)).toBe(true)
+    expect(detectsPastePlaceholder(stubInBox)).toBe(true)
   })
 })

--- a/src/__tests__/send-prompt-force-send-gate.test.ts
+++ b/src/__tests__/send-prompt-force-send-gate.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Contract tests for Finding 4: forceSend must skip the pre-flight
+// wait-until-idle gate inside sendPromptToSession.
+//
+// Root cause: the wait-until-idle gate (added to fix the busy-stuck class) was
+// made unconditional in sendPromptToSession. But a scheduled task with
+// forceSend=true is documented to BYPASS the busy-state check so it does not
+// pile up retries against a session that stays busy for hours (the overnight
+// 275-retry loop). An unconditional 12s idle wait silently re-introduces that
+// per-tick block. The fix threads an optional waitForIdle flag (default true,
+// gate ON for every other caller) and the forceSend path opts out.
+
+const AGENT_PROCESS = readFileSync(join(__dirname, '../web/agent-process.ts'), 'utf-8')
+const SCHEDULE_RUNNER = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+
+describe('sendPromptToSession waitForIdle gate', () => {
+  it('sendPromptToSession accepts a waitForIdle option', () => {
+    const sigIdx = AGENT_PROCESS.indexOf('export function sendPromptToSession(')
+    expect(sigIdx).toBeGreaterThan(0)
+    const sig = AGENT_PROCESS.slice(sigIdx, sigIdx + 260)
+    expect(sig).toMatch(/opts:\s*\{\s*waitForIdle\?:\s*boolean\s*\}/)
+  })
+
+  it('the gate defaults ON (waitForIdle !== false) so all other callers keep it', () => {
+    // The default must be ON: only an explicit waitForIdle:false opts out.
+    expect(AGENT_PROCESS).toMatch(/const waitForIdle = opts\.waitForIdle !== false/)
+    // And the wait is guarded by that flag, not called unconditionally.
+    expect(AGENT_PROCESS).toMatch(/if \(waitForIdle && !waitForPaneIdle\(session, host\)\)/)
+    // No unconditional `if (!waitForPaneIdle(` remains.
+    expect(AGENT_PROCESS).not.toMatch(/^\s*if \(!waitForPaneIdle\(session, host\)\) \{/m)
+  })
+
+  it('the forceSend scheduled-task path opts out of the idle wait', () => {
+    const callIdx = SCHEDULE_RUNNER.indexOf('sendPromptToSession(session, fullPrompt, host')
+    expect(callIdx).toBeGreaterThan(0)
+    const call = SCHEDULE_RUNNER.slice(callIdx, callIdx + 120)
+    // waitForIdle is the negation of forceSend: ON for normal tasks, OFF for
+    // forceSend so a long-busy session is not blocked on the 12s gate.
+    expect(call).toMatch(/\{\s*waitForIdle:\s*!task\.forceSend\s*\}/)
+  })
+
+  it('documents WHY forceSend skips the gate', () => {
+    const callIdx = SCHEDULE_RUNNER.indexOf('sendPromptToSession(session, fullPrompt, host')
+    const rationale = SCHEDULE_RUNNER.slice(Math.max(0, callIdx - 500), callIdx)
+    expect(rationale).toMatch(/forceSend/)
+    expect(rationale).toMatch(/idle|busy|queue/i)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -101,11 +101,30 @@ const BUSY_INDICATORS: RegExp[] = [
 const BUSY_ESC_TO_INTERRUPT_RX = /\besc to interrupt\b/
 const LIVE_FOOTER_REGION_LINES = 5
 
-// Pasted-text placeholder. Claude Code lifts bursts of input keys into
-// `[Pasted text #N +X chars]` stubs, which sit in the input buffer and
-// never auto-submit on Enter. Treat as busy so the scheduler doesn't pile
-// a second prompt on top.
+// Pasted-text placeholder. Claude Code lifts a single large input write
+// (empirically a tmux send-keys -l of more than ~700 chars) into a
+// `[Pasted text #N]` / `[Pasted text #N +X chars]` stub that sits in the
+// input buffer and never auto-submits. Treat as busy so the scheduler
+// doesn't pile a second prompt on top. The version-stable opening
+// `[Pasted text #<digits>` covers both the bare and the `+X chars` shapes.
 const PENDING_PASTE_RX = /\[Pasted text #\d+/
+
+// A placeholder pane is identified SOLELY by the `[Pasted text #N]` stub.
+// The accompanying `paste again to expand` footer hint is deliberately NOT
+// used: empirically it LINGERS for a beat after the message submits (the box
+// is already empty, the stub gone, yet the hint line is still rendered), so
+// keying on it would false-positive a freshly-submitted pane as still stuck
+// and trigger a needless clear-and-resend. The stub itself appears iff a real
+// placeholder is parked (verified: present in every placeholder render, absent
+// the instant it submits). Pure + dependency-free so callers (detectPaneState,
+// shouldRetrySubmit, the recovery decision) share ONE definition instead of
+// re-inlining the regex. capturePane uses `capture-pane -p` (visible screen
+// only, no scrollback), so a `[Pasted text` echo from a past turn cannot
+// linger here.
+export function detectsPastePlaceholder(pane: string): boolean {
+  if (!pane) return false
+  return PENDING_PASTE_RX.test(pane)
+}
 
 // Input-box separator lines are made of U+2500 BOX DRAWINGS LIGHT
 // HORIZONTAL. At least 10 in a run to ignore stray `-` glyphs.
@@ -289,11 +308,18 @@ export function detectPaneState(
   const footerRegion = paneLines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return 'busy'
 
+  // Pending-paste placeholder check runs BEFORE the idle-footer gate: a
+  // placeholder pane REPLACES the idle footer with `paste again to expand`,
+  // so it does not satisfy IDLE_FOOTER_RX and was previously mis-classified
+  // 'unknown' (and the old line-296 paste check below was unreachable). A
+  // placeholder must read 'busy' so the scheduler/router/keepalive defer
+  // rather than pile a second prompt on, exactly as the (now corrected)
+  // comment on PENDING_PASTE_RX intends.
+  if (detectsPastePlaceholder(pane)) return 'busy'
+
   if (!IDLE_FOOTER_RX.test(pane)) return 'unknown'
 
   if (detectsThinkingBlockError(pane)) return 'error'
-
-  if (PENDING_PASTE_RX.test(pane)) return 'busy'
 
   // Find the input box: two BOX_SEP_RX lines framing the current prompt.
   // Scan UPWARDS from the footer so we stay inside the live box and
@@ -453,15 +479,22 @@ export function shouldRetrySubmit(
   const retryPaneLines = pane.split('\n')
   const retryFooterRegion = retryPaneLines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
   if (BUSY_ESC_TO_INTERRUPT_RX.test(retryFooterRegion)) return false
+
+  // Path 1: placeholder is unambiguous, retry regardless of hint -- and it is
+  // checked BEFORE the idle-footer gate below. A placeholder pane replaces the
+  // idle footer with `paste again to expand`, so it fails IDLE_FOOTER_RX; the
+  // old ordering (footer gate first, then a placeholder check scoped to the
+  // input box) therefore returned false on the very state the recovery exists
+  // to catch. The whole-pane check is safe because capture-pane -p shows only
+  // the visible screen (no scrollback echo of a past `[Pasted text]`).
+  if (detectsPastePlaceholder(pane)) return true
+
   // Without an idle footer the pane is either not Claude Code or in an
   // unknown render state. Be conservative and skip.
   if (!IDLE_FOOTER_RX.test(pane)) return false
 
   const inputBox = liveInputBox(pane)
   if (inputBox == null) return false
-
-  // Path 1: placeholder is unambiguous, retry regardless of hint.
-  if (PENDING_PASTE_RX.test(inputBox)) return true
 
   // Path 2: verbatim payload parked in the input box.
   // Clamp the minimum hint length to >= 1. minHintChars=0 paired with
@@ -520,7 +553,7 @@ export function shouldClearTruncatedPreamble(pane: string): boolean {
   return true
 }
 
-export type SubmitFollowupAction = 'retry-enter' | 'done' | 'give-up'
+export type SubmitFollowupAction = 'retry-enter' | 'clear-and-resend' | 'done' | 'give-up'
 
 /**
  * Decide what the post-send-keys loop should do next, given the
@@ -528,13 +561,20 @@ export type SubmitFollowupAction = 'retry-enter' | 'done' | 'give-up'
  * been made. Returns one of three discrete actions so the caller can
  * branch without re-running the detection logic itself.
  *
- *   - 'done'        -- the prompt landed (or the pane is busy
- *                      processing); no further action.
- *   - 'retry-enter' -- the pane shows a stuck send; send another Enter
- *                      and re-sample.
- *   - 'give-up'     -- the retry budget is spent, or the capture failed
- *                      and we cannot tell whether retry would help.
- *                      Caller should log a warning and move on.
+ *   - 'done'             -- the prompt landed (or the pane is busy
+ *                           processing); no further action.
+ *   - 'retry-enter'      -- the pane shows a VERBATIM stuck send; send
+ *                           another Enter and re-sample. (A plain Enter
+ *                           submits verbatim parked text.)
+ *   - 'clear-and-resend' -- the pane shows a `[Pasted text #N]`
+ *                           placeholder. A plain Enter is PROVEN not to
+ *                           submit it (it merely expands the stub to
+ *                           parked verbatim text, still unsubmitted), so
+ *                           the caller must clear the buffer and re-send
+ *                           the payload defensively instead.
+ *   - 'give-up'          -- the retry budget is spent, or the capture
+ *                           failed and we cannot tell whether retry would
+ *                           help. Caller should log a warning and move on.
  *
  * Splitting the decision out as pure logic keeps the I/O-bound loop in
  * src/web/agent-process.ts trivially testable without mocking tmux or
@@ -562,6 +602,10 @@ export function decideSubmitFollowup(
   if (pane == null) return 'give-up'
   if (!shouldRetrySubmit(pane, payloadHint)) return 'done'
   if (attempt >= maxAttempts) return 'give-up'
+  // A placeholder will NOT submit on a plain Enter (proven empirically: Enter
+  // only expands the stub to still-parked verbatim text). Route it to the
+  // clear-and-resend recovery instead of wasting a retry-Enter on it.
+  if (detectsPastePlaceholder(pane)) return 'clear-and-resend'
   return 'retry-enter'
 }
 

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -104,26 +104,70 @@ const LIVE_FOOTER_REGION_LINES = 5
 // Pasted-text placeholder. Claude Code lifts a single large input write
 // (empirically a tmux send-keys -l of more than ~700 chars) into a
 // `[Pasted text #N]` / `[Pasted text #N +X chars]` stub that sits in the
-// input buffer and never auto-submits. Treat as busy so the scheduler
-// doesn't pile a second prompt on top. The version-stable opening
-// `[Pasted text #<digits>` covers both the bare and the `+X chars` shapes.
-const PENDING_PASTE_RX = /\[Pasted text #\d+/
+// LIVE INPUT BOX and never auto-submits. Treat as busy so the scheduler
+// doesn't pile a second prompt on top.
+//
+// Wrap tolerance (real-capture finding): when the input is long the stub
+// renders wrapped across a terminal line break -- `...[Pasted text` at the
+// end of one line and `  #3]...` at the start of the next (the digits
+// themselves can also straddle the break). The opening token, the `#`, and
+// the digit are therefore separated by `\s*` (which includes newlines and
+// the leading indent of the wrapped continuation) rather than a single
+// literal space. This still matches the unwrapped `[Pasted text #N` and
+// `[Pasted text #N +X chars]` shapes.
+const PENDING_PASTE_RX = /\[Pasted text\s*#\s*\d/
 
-// A placeholder pane is identified SOLELY by the `[Pasted text #N]` stub.
-// The accompanying `paste again to expand` footer hint is deliberately NOT
-// used: empirically it LINGERS for a beat after the message submits (the box
-// is already empty, the stub gone, yet the hint line is still rendered), so
-// keying on it would false-positive a freshly-submitted pane as still stuck
-// and trigger a needless clear-and-resend. The stub itself appears iff a real
-// placeholder is parked (verified: present in every placeholder render, absent
-// the instant it submits). Pure + dependency-free so callers (detectPaneState,
-// shouldRetrySubmit, the recovery decision) share ONE definition instead of
-// re-inlining the regex. capturePane uses `capture-pane -p` (visible screen
-// only, no scrollback), so a `[Pasted text` echo from a past turn cannot
-// linger here.
+// How many trailing lines to inspect for the stub when no input-box
+// separators are visible (a malformed / partial capture, or the older
+// `paste again to expand` render with separators scrolled off). Kept tight
+// so a stub quoted higher up in scrollback cannot reach the bottom region.
+const PASTE_REGION_FALLBACK_LINES = 8
+
+// Scope the placeholder match to the live input box, not the whole pane.
+// The box is the region between the two most recent U+2500 separators found
+// from the BOTTOM of the pane -- footer-INDEPENDENT, because the placeholder
+// render is version-dependent: the current build keeps the normal
+// `bypass permissions ...` idle footer below the box, while an older build
+// replaced it with a `paste again to expand` hint. Anchoring on the
+// separators (always present around the box) covers both. When two
+// separators are not found we fall back to the last few lines.
+//
+// Whole-pane matching was a confirmed false-POSITIVE source: these agents
+// routinely quote tmux captures and discuss this very bug, so a literal
+// `[Pasted text #N` in a reply line or deep scrollback would trigger a
+// destructive Ctrl-C + resend on a perfectly healthy session. Scoping to
+// the box (same discipline as BUSY_ESC_TO_INTERRUPT_RX / the footer checks)
+// confines the match to where a genuine parked stub actually lives.
+function pastePlaceholderRegion(pane: string): string {
+  const lines = pane.split('\n')
+  let bottomSep = -1
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (BOX_SEP_RX.test(lines[i])) { bottomSep = i; break }
+  }
+  if (bottomSep > 0) {
+    let topSep = -1
+    for (let i = bottomSep - 1; i >= 0; i--) {
+      if (BOX_SEP_RX.test(lines[i])) { topSep = i; break }
+    }
+    if (topSep >= 0) return lines.slice(topSep + 1, bottomSep).join('\n')
+  }
+  return lines.slice(-PASTE_REGION_FALLBACK_LINES).join('\n')
+}
+
+// A placeholder pane is identified by the `[Pasted text #N]` stub IN THE LIVE
+// INPUT BOX. The accompanying `paste again to expand` footer hint is
+// deliberately NOT used: it is version-dependent (the current build keeps the
+// normal idle footer instead) AND it empirically LINGERS for a beat after the
+// message submits (the box is already empty, the stub gone, yet the hint line
+// is still rendered), so keying on it would false-positive a freshly-submitted
+// pane as still stuck and trigger a needless clear-and-resend. The stub itself
+// appears iff a real placeholder is parked (verified across real captures:
+// present in every placeholder render, absent the instant it submits). Pure +
+// dependency-free so callers (detectPaneState, shouldRetrySubmit, the recovery
+// decision) share ONE definition instead of re-inlining the regex.
 export function detectsPastePlaceholder(pane: string): boolean {
   if (!pane) return false
-  return PENDING_PASTE_RX.test(pane)
+  return PENDING_PASTE_RX.test(pastePlaceholderRegion(pane))
 }
 
 // Input-box separator lines are made of U+2500 BOX DRAWINGS LIGHT
@@ -308,13 +352,15 @@ export function detectPaneState(
   const footerRegion = paneLines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return 'busy'
 
-  // Pending-paste placeholder check runs BEFORE the idle-footer gate: a
-  // placeholder pane REPLACES the idle footer with `paste again to expand`,
-  // so it does not satisfy IDLE_FOOTER_RX and was previously mis-classified
-  // 'unknown' (and the old line-296 paste check below was unreachable). A
-  // placeholder must read 'busy' so the scheduler/router/keepalive defer
-  // rather than pile a second prompt on, exactly as the (now corrected)
-  // comment on PENDING_PASTE_RX intends.
+  // Pending-paste placeholder check runs BEFORE the idle-footer gate. The
+  // stub sits in the live input box; the footer below it is version-dependent
+  // (the current build keeps the normal `bypass permissions ...` idle footer,
+  // an older build showed `paste again to expand` instead and so failed
+  // IDLE_FOOTER_RX). Running the box-scoped placeholder check first classifies
+  // BOTH shapes as 'busy' -- and on the older `paste again to expand` shape it
+  // also rescues the pane from being mis-read 'unknown' at the idle-footer gate
+  // below. A placeholder must read 'busy' so the scheduler/router/keepalive
+  // defer rather than pile a second prompt on.
   if (detectsPastePlaceholder(pane)) return 'busy'
 
   if (!IDLE_FOOTER_RX.test(pane)) return 'unknown'
@@ -481,12 +527,13 @@ export function shouldRetrySubmit(
   if (BUSY_ESC_TO_INTERRUPT_RX.test(retryFooterRegion)) return false
 
   // Path 1: placeholder is unambiguous, retry regardless of hint -- and it is
-  // checked BEFORE the idle-footer gate below. A placeholder pane replaces the
-  // idle footer with `paste again to expand`, so it fails IDLE_FOOTER_RX; the
-  // old ordering (footer gate first, then a placeholder check scoped to the
-  // input box) therefore returned false on the very state the recovery exists
-  // to catch. The whole-pane check is safe because capture-pane -p shows only
-  // the visible screen (no scrollback echo of a past `[Pasted text]`).
+  // checked BEFORE the idle-footer gate below. The footer beneath a placeholder
+  // is version-dependent: the current build keeps the normal idle footer, an
+  // older build showed `paste again to expand` (failing IDLE_FOOTER_RX). The
+  // old ordering (footer gate first) therefore returned false on the older
+  // shape -- the very state the recovery exists to catch. detectsPastePlaceholder
+  // scopes the match to the live input box, so a `[Pasted text #N]` quoted in a
+  // reply line or scrollback cannot trigger a spurious clear-and-resend.
   if (detectsPastePlaceholder(pane)) return true
 
   // Without an idle footer the pane is either not Claude Code or in an

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -323,12 +323,27 @@ export function detectPaneState(
 }
 
 /**
+ * Canonical pure idle predicate: true iff the capture classifies as the
+ * 'idle' pane state (input box live and empty, not busy / typing / menu /
+ * error / unknown). This is the SINGLE place the "is this pane idle" rule
+ * lives, so every caller -- the readiness check (isReadyForPrompt), the
+ * auto-restart idle-guard (auto-restart-runner.paneIsIdle) and the
+ * sendPromptToSession pre-flight wait-until-idle gate -- shares one
+ * definition rather than re-inlining `detectPaneState(...) === 'idle'`
+ * (and, worse, the busy regex) in several files.
+ */
+export function paneLooksIdle(capture: string): boolean {
+  return detectPaneState(capture) === 'idle'
+}
+
+/**
  * True when the pane is in the specific "accepting a new prompt" state.
  * 'typing' counts as not-ready because the user has unsubmitted text
- * in the input box and a new prompt would concatenate into it.
+ * in the input box and a new prompt would concatenate into it. Thin alias
+ * over paneLooksIdle kept for its existing call sites / tests.
  */
 export function isReadyForPrompt(pane: string): boolean {
-  return detectPaneState(pane) === 'idle'
+  return paneLooksIdle(pane)
 }
 
 // Locate the live Claude Code input box and return its inner content as

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -9,6 +9,7 @@ import {
   paneLooksIdle,
   decideSubmitFollowup,
   shouldClearTruncatedPreamble,
+  detectsPastePlaceholder,
 } from '../pane-state.js'
 import { agentDir, readAgentModel, readAgentSecurityProfile, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost } from './agent-config.js'
 import {
@@ -485,13 +486,17 @@ export function scheduleIdentitySetup(session: string, displayName: string, host
   }, MODAL_DISMISS_DELAY_MS)
 }
 
-// How many follow-up Enters sendPromptToSession() is willing to fire
-// when the post-send capture says the prompt is still parked in the
-// input box. Two retries cover the observed stuck-rate (single-pane
-// recovery typically lands on the first or second extra Enter); a
-// stuck-after-two-retries pane gets a logged give-up so the operator
-// can intervene rather than the loop spinning indefinitely.
-const SUBMIT_RETRY_MAX_ATTEMPTS = 2
+// How many follow-up actions (retry-Enter OR clear-and-resend)
+// sendPromptToSession() is willing to fire when the post-send capture says
+// the prompt is still parked in the input box. The verbatim path lands on the
+// first or second extra Enter; the placeholder clear-and-resend path needs a
+// little more headroom because a resend can itself occasionally park (the
+// observed convergence was placeholder -> resend -> verbatim/placeholder ->
+// resend -> submitted, i.e. up to ~3 cycles). Four bounds the loop well past
+// the empirical worst case (which converged within 5 in a 12/12 proof) while
+// still giving a logged give-up so a pathologically stuck pane does not spin
+// indefinitely.
+const SUBMIT_RETRY_MAX_ATTEMPTS = 4
 // Wait between sending an Enter and re-capturing the pane. Long enough
 // for tmux to flush the keystroke into the Claude Code TUI and for
 // the TUI to either transition to busy (turn started) or stay idle
@@ -560,6 +565,44 @@ export function clearInputBuffer(session: string, host: string | null = null): v
   }
 }
 
+// How many Ctrl-C presses the placeholder-discard will attempt before giving
+// up. Empirically a single Ctrl-C discards a `[Pasted text #N]` stub (and
+// expanded verbatim text) and returns to the empty prompt; the extra presses
+// cover a frame race where the first one was eaten mid-render.
+const PLACEHOLDER_DISCARD_MAX = 3
+// Settle window after a Ctrl-C so the next capture reflects the cleared box.
+const PLACEHOLDER_DISCARD_SETTLE_S = '0.45'
+
+// Discard a `[Pasted text #N]` placeholder (or the verbatim text it expands
+// into) from the input box with Ctrl-C, then confirm the box no longer holds
+// the placeholder. Ctrl-U is deliberately NOT used: it is proven NOT to clear
+// a paste placeholder, and on a multi-row verbatim buffer it only clears the
+// row the cursor sits on. Ctrl-C is the only key that reliably empties the box.
+//
+// SAFETY: Ctrl-C on an EMPTY Claude Code box quits the TUI, and on a BUSY pane
+// it interrupts the live turn. This helper must therefore only ever be called
+// when a placeholder is CONFIRMED present (box non-empty, not busy) -- which
+// detectsPastePlaceholder guarantees at the call site. We re-check before each
+// press and stop the instant the placeholder is gone, so we never press Ctrl-C
+// into an already-empty box. Returns true if the placeholder was cleared.
+function discardPlaceholderBuffer(session: string, host: string | null = null): boolean {
+  for (let i = 0; i < PLACEHOLDER_DISCARD_MAX; i++) {
+    const pane = capturePane(session, host)
+    // Stop pressing once the stub is gone -- a further Ctrl-C on an empty box
+    // would quit the TUI.
+    if (pane != null && !detectsPastePlaceholder(pane)) return true
+    try {
+      runTmux(host, ['send-keys', '-t', session, 'C-c'], { timeout: 5000 })
+    } catch (err) {
+      logger.warn({ err, session }, 'discardPlaceholderBuffer: Ctrl-C send failed')
+      return false
+    }
+    try { execFileSync('/bin/sleep', [PLACEHOLDER_DISCARD_SETTLE_S], { timeout: 2000 }) } catch { /* best effort */ }
+  }
+  const finalPane = capturePane(session, host)
+  return finalPane != null && !detectsPastePlaceholder(finalPane)
+}
+
 // Send text to a tmux session as if typed at the prompt.
 // Uses execFileSync so callers can pass raw text -- tmux send-keys -l treats
 // the argument as literal characters, bypassing shell quoting entirely.
@@ -611,6 +654,11 @@ export function sendPromptToSession(session: string, text: string, host: string 
 
   const oneLine = text.replace(/\r?\n/g, ' ')
   const CHUNK = 80
+  // Stream oneLine into the pane as CHUNK-sized literal send-keys writes,
+  // followed by a submitting Enter. Extracted as a closure so the
+  // clear-and-resend recovery path below can replay the EXACT same byte
+  // stream after a Ctrl-C, rather than duplicating the dash-slide logic.
+  //
   // tmux send-keys doesn't support `--` option-terminator, so a chunk that
   // starts with '-' parses as a flag ("command send-keys: unknown flag -s"
   // on Hungarian suffixes like -szal/-vel/-ban). Slide the boundary up to a
@@ -618,25 +666,42 @@ export function sendPromptToSession(session: string, text: string, host: string 
   // so a long run of dashes doesn't inflate one chunk past the paste-detector
   // threshold; if the cap is reached, prepend a space to the chunk instead.
   const MAX_SLIDE = 8
-  let i = 0
-  while (i < oneLine.length) {
-    let end = Math.min(i + CHUNK, oneLine.length)
-    let slide = 0
-    while (end < oneLine.length && oneLine[end] === '-' && slide < MAX_SLIDE) {
-      end++; slide++
+  const sendChunks = (): void => {
+    let i = 0
+    while (i < oneLine.length) {
+      let end = Math.min(i + CHUNK, oneLine.length)
+      let slide = 0
+      while (end < oneLine.length && oneLine[end] === '-' && slide < MAX_SLIDE) {
+        end++; slide++
+      }
+      let chunk = oneLine.slice(i, end)
+      if (chunk.startsWith('-')) chunk = ' ' + chunk
+      runTmux(host, ['send-keys', '-t', session, '-l', chunk], { timeout: 5000 })
+      i = end
+      if (i < oneLine.length) execFileSync('/bin/sleep', ['0.03'], { timeout: 1000 })
     }
-    let chunk = oneLine.slice(i, end)
-    if (chunk.startsWith('-')) chunk = ' ' + chunk
-    runTmux(host, ['send-keys', '-t', session, '-l', chunk], { timeout: 5000 })
-    i = end
-    if (i < oneLine.length) execFileSync('/bin/sleep', ['0.03'], { timeout: 1000 })
+    runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
   }
-  runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+  sendChunks()
 
   // Post-send retry loop. The payload hint is the first chunk of oneLine
   // (truncated to a safe length) so the verbatim-stuck path has something
   // recognisable to substring-match against without leaking the whole
   // prompt body into log lines should the give-up branch fire.
+  //
+  // Two stuck modes, two recoveries (see decideSubmitFollowup):
+  //   - VERBATIM text parked under an idle footer -> a plain Enter submits it
+  //     ('retry-enter').
+  //   - A `[Pasted text #N]` placeholder -> a plain Enter does NOT submit it
+  //     (proven: Enter only expands the stub to still-parked verbatim text,
+  //     and once the text spans multiple visual rows a plain Enter inserts a
+  //     newline rather than submitting). The placeholder forms when several
+  //     chunks coalesce into one >~700-char PTY read under tmux-server
+  //     contention, tripping the TUI's bracketed-paste detector. The only
+  //     reliable fix is to Ctrl-C the buffer empty and re-send the chunks
+  //     ('clear-and-resend'). The same Ctrl-C path also clears an expanded
+  //     multi-row verbatim buffer that a plain Enter cannot submit, so a
+  //     resend that itself parks is re-cleared and retried until it lands.
   const payloadHint = oneLine.slice(0, Math.min(oneLine.length, 96))
   for (let attempt = 0; ; attempt++) {
     try { execFileSync('/bin/sleep', [SUBMIT_RETRY_POLL_MS], { timeout: 2000 }) } catch { /* best effort */ }
@@ -646,6 +711,23 @@ export function sendPromptToSession(session: string, text: string, host: string 
     if (action === 'give-up') {
       logger.warn({ session, attempt }, 'sendPromptToSession: prompt still parked after retries')
       break
+    }
+    if (action === 'clear-and-resend') {
+      // Placeholder confirmed in the pane (box non-empty, not busy), so the
+      // Ctrl-C in discardPlaceholderBuffer is safe. Clear it, then replay the
+      // chunk stream. The loop re-samples on the next iteration and will keep
+      // recovering (or give up at the budget) if the resend itself parks.
+      logger.info({ session, attempt }, 'sendPromptToSession: paste placeholder detected; clearing and re-sending')
+      if (!discardPlaceholderBuffer(session, host)) {
+        logger.warn({ session, attempt }, 'sendPromptToSession: failed to clear paste placeholder before resend')
+      }
+      try {
+        sendChunks()
+      } catch (err) {
+        logger.warn({ err, session, attempt }, 'Clear-and-resend chunk replay failed')
+        break
+      }
+      continue
     }
     // action === 'retry-enter'
     try {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -6,7 +6,7 @@ import { OLLAMA_URL } from '../config.js'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
 import {
-  detectPaneState,
+  paneLooksIdle,
   decideSubmitFollowup,
   shouldClearTruncatedPreamble,
 } from '../pane-state.js'
@@ -499,6 +499,53 @@ const SUBMIT_RETRY_MAX_ATTEMPTS = 2
 // frame-render gap detectPaneState already guards against.
 const SUBMIT_RETRY_POLL_MS = '0.3'
 
+// Pre-flight wait-until-idle gate (root-cause fix for the busy-stuck class).
+// Before streaming chunks we poll the pane and wait for it to return to the
+// 'idle' state. Sending while the target is mid-turn (footer `esc to
+// interrupt`) is the condition the stuck-input incidents correlated with: the
+// typed text + trailing Enter can be parked in the input box (verbatim or as a
+// `[Pasted text #N]` stub) and only "land" much later, so a delegated prompt
+// sits unsubmitted until a human presses Enter. Waiting for idle removes that
+// condition for EVERY caller of sendPromptToSession (router, scheduler,
+// channel-monitor, /login, worker) rather than relying on each caller to gate
+// itself -- and it closes the check->send TOCTOU gap where a caller's own
+// readiness check passed but the agent started a turn before the bytes landed.
+//
+// Budget: poll every PANE_IDLE_POLL_MS up to PANE_IDLE_WAIT_TIMEOUT_MS total.
+// The timeout is generous on purpose -- it must NOT truncate a legitimately
+// long turn into a premature "give up and send anyway". 12s comfortably spans
+// the inter-turn gaps and short tool-calls we observe between a turn's visible
+// completion and the input box settling, while still bounding the wait so a
+// genuinely long-running turn does not block the 5s router / 60s scheduler tick
+// indefinitely. On timeout we proceed best-effort: the existing post-send
+// retry loop (decideSubmitFollowup) remains the backstop, and a hard-busy
+// session that never idles must still receive its prompt eventually.
+const PANE_IDLE_WAIT_TIMEOUT_MS = 12_000
+const PANE_IDLE_POLL_MS = 300
+// String form for /bin/sleep (seconds), kept in sync with PANE_IDLE_POLL_MS.
+const PANE_IDLE_POLL_S = (PANE_IDLE_POLL_MS / 1000).toFixed(3)
+
+// Block until the session's pane looks idle, or the budget elapses. Returns
+// true if idle was observed, false on timeout-still-busy (caller proceeds
+// best-effort). Reuses the shared paneLooksIdle predicate -- the SAME rule the
+// readiness check and the auto-restart idle-guard use -- so the busy regex is
+// never re-inlined here. A capture failure is treated as "not yet idle" and we
+// keep polling within the budget (a transient tmux hiccup should not be read as
+// idle and let us blast a prompt into a busy pane).
+export function waitForPaneIdle(
+  session: string,
+  host: string | null = null,
+  timeoutMs: number = PANE_IDLE_WAIT_TIMEOUT_MS,
+): boolean {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const pane = capturePane(session, host)
+    if (pane != null && paneLooksIdle(pane)) return true
+    if (Date.now() >= deadline) return false
+    try { execFileSync('/bin/sleep', [PANE_IDLE_POLL_S], { timeout: 2000 }) } catch { /* best effort */ }
+  }
+}
+
 // Buffer-clear (Ctrl-U) used pre-flight when shouldClearTruncatedPreamble
 // flags a stale preamble. Sent as a single key name (no `-l` literal
 // flag) so tmux interprets it as the control sequence.
@@ -535,6 +582,18 @@ export function clearInputBuffer(session: string, host: string | null = null): v
 export function sendPromptToSession(session: string, text: string, host: string | null = null): void {
   dismissSurveyModalIfPresent(session, host)
   dismissResumeSummaryModalIfPresent(session, host)
+
+  // Pre-flight wait-until-idle (root-cause gate). Placed here -- inside
+  // sendPromptToSession, AFTER the modal dismissals (a modal keeps the pane
+  // non-idle, so we must clear it first or the wait would always time out) and
+  // BEFORE the truncated-preamble check + chunk-send -- so EVERY caller is
+  // protected and the live input box we inspect/clear below reflects a settled,
+  // idle pane. On timeout we fall through and send anyway: a session that never
+  // idles must still receive its prompt, and the post-send retry loop is the
+  // backstop. host is threaded so a remote agent's pane is polled over ssh.
+  if (!waitForPaneIdle(session, host)) {
+    logger.warn({ session }, 'sendPromptToSession: pane still busy after wait-until-idle budget; sending best-effort')
+  }
 
   // Pre-flight buffer-clear when a stale preamble is detected. Reading
   // the pane is best-effort: a capture failure here means we cannot
@@ -650,12 +709,12 @@ export function capturePane(session: string, host: string | null = null): string
 export function isSessionReadyForPrompt(session: string, host: string | null = null): boolean {
   const first = capturePane(session, host)
   if (first == null) return false
-  if (detectPaneState(first) !== 'idle') return false
+  if (!paneLooksIdle(first)) return false
 
   try { execFileSync('/bin/sleep', [PANE_READY_CONFIRM_DELAY_S], { timeout: 2000 }) } catch { /* best effort */ }
 
   const second = capturePane(session, host)
   if (second == null) return false
-  return detectPaneState(second) === 'idle'
+  return paneLooksIdle(second)
 }
 

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -622,7 +622,12 @@ function discardPlaceholderBuffer(session: string, host: string | null = null): 
 // still reports stuck, send up to SUBMIT_RETRY_MAX_ATTEMPTS extra
 // Enters. The retry budget bounds the loop so a pathologically stuck
 // pane gives up rather than spinning.
-export function sendPromptToSession(session: string, text: string, host: string | null = null): void {
+export function sendPromptToSession(
+  session: string,
+  text: string,
+  host: string | null = null,
+  opts: { waitForIdle?: boolean } = {},
+): void {
   dismissSurveyModalIfPresent(session, host)
   dismissResumeSummaryModalIfPresent(session, host)
 
@@ -630,11 +635,20 @@ export function sendPromptToSession(session: string, text: string, host: string 
   // sendPromptToSession, AFTER the modal dismissals (a modal keeps the pane
   // non-idle, so we must clear it first or the wait would always time out) and
   // BEFORE the truncated-preamble check + chunk-send -- so EVERY caller is
-  // protected and the live input box we inspect/clear below reflects a settled,
-  // idle pane. On timeout we fall through and send anyway: a session that never
-  // idles must still receive its prompt, and the post-send retry loop is the
-  // backstop. host is threaded so a remote agent's pane is polled over ssh.
-  if (!waitForPaneIdle(session, host)) {
+  // protected by default and the live input box we inspect/clear below reflects
+  // a settled, idle pane. On timeout we fall through and send anyway: a session
+  // that never idles must still receive its prompt, and the post-send retry
+  // loop is the backstop. host is threaded so a remote agent's pane is polled
+  // over ssh.
+  //
+  // opts.waitForIdle defaults to true (the gate is ON for every caller). The
+  // forceSend scheduled-task path opts OUT (waitForIdle:false): forceSend is
+  // documented to skip the busy-state check so a task does NOT pile up retries
+  // against a session that stays busy for hours (the overnight 275-retry loop).
+  // Eating the 12s idle wait here would defeat that contract -- the whole point
+  // of forceSend is to inject regardless and let Claude Code queue it.
+  const waitForIdle = opts.waitForIdle !== false
+  if (waitForIdle && !waitForPaneIdle(session, host)) {
     logger.warn({ session }, 'sendPromptToSession: pane still busy after wait-until-idle budget; sending best-effort')
   }
 

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -9,7 +9,7 @@ import {
   capturePane,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-import { detectPaneState } from '../pane-state.js'
+import { paneLooksIdle } from '../pane-state.js'
 import { readAutoRestartConfig } from './auto-restart-store.js'
 import { restartDue, dailyDueAtMs, parseHHMM, type AutoRestartConfig } from '../auto-restart.js'
 
@@ -59,7 +59,7 @@ function sessionFor(name: string): string {
 function paneIsIdle(session: string, host: string | null): boolean {
   const pane = capturePane(session, host)
   if (pane == null) return false
-  return detectPaneState(pane) === 'idle'
+  return paneLooksIdle(pane)
 }
 
 function performRestart(name: string, cfg: AutoRestartConfig): void {

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -169,7 +169,12 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
       UNTRUSTED_PREAMBLE + '\n' +
       prefix.trimEnd() + '\n\n' +
       wrapUntrusted(`scheduled-task:${task.name}`, task.prompt)
-    sendPromptToSession(session, fullPrompt, host)
+    // forceSend skips the busy-state check above; it must also skip the
+    // pre-flight wait-until-idle gate inside sendPromptToSession, otherwise a
+    // task aimed at a long-busy session would block on the 12s idle wait every
+    // tick -- defeating the very purpose of forceSend (inject regardless, let
+    // Claude Code queue it). All non-forceSend tasks keep the gate ON.
+    sendPromptToSession(session, fullPrompt, host, { waitForIdle: !task.forceSend })
     scheduleLastRun.set(task.name, now)
     persistScheduleLastRun()
     appendTaskRun(task.name, agentName)


### PR DESCRIPTION
## Why this matters

Messages delivered to a Claude Code agent session (via the inter-agent router, the scheduler, and the worker) are typed into the pane with `tmux send-keys`. Two failure modes leave a fully written prompt parked in the input box, never submitted, until a human presses a key:

1. **Paste-placeholder (primary).** When a long message arrives as a burst (which happens under tmux-server contention during multi-session broadcasts), the TUI bracketed-paste detector turns it into a `[Pasted text #N]` placeholder. No Enter submits a placeholder, so the existing retry loop sent plain Enters that did nothing. Worse, the placeholder render is mis-read by the prior stuck-detectors (which keyed on the idle footer), so the pane was classified as not-stuck and none of the existing watchdogs fired. A documented stuck-rate of roughly 60% on 5-way broadcasts traced to this.
2. **Busy-send.** The sender wrote into a pane that was mid-turn; the text plus Enter did not submit, and the prompt parked once the turn ended.

## Change

- **`pane-state.ts`**: new `detectsPastePlaceholder()` is checked BEFORE the idle-footer gate in `detectPaneState` / `shouldRetrySubmit`, and is SCOPED to the live input-box region (the bottom box between the separators) so a `[Pasted text` string quoted in scrollback or reply text does not trigger a false positive. The regex tolerates the stub wrapping across a line break (`[Pasted text` newline `#N]`), which is how it actually renders for long inputs. `decideSubmitFollowup` returns a new `clear-and-resend` action for placeholders.
- **`agent-process.ts`**: `discardPlaceholderBuffer()` clears a confirmed placeholder with Ctrl-C (empirically the only key that clears it; Enter, Ctrl-U, and Escape do not), guarded to fire only while a placeholder is confirmed in the scoped region, so it never hits an empty box. `waitForPaneIdle()` is a bounded (12s) pre-flight gate that waits for the pane to be idle before sending, so messages are not typed into a busy turn. The post-send retry loop now routes placeholders to clear-and-resend instead of wasting Enters.
- **`schedule-runner.ts`**: `forceSend` tasks opt out of the idle gate (`waitForIdle: false`) to preserve their existing skip-the-busy-check behavior.
- **`auto-restart-runner.ts`**: refactored to the shared `paneLooksIdle` predicate (no behavior change).

## Scope / compatibility

- No change to the chunked send mechanism itself (it measured robust into idle panes; alternatives were worse).
- Idle-pane happy path: one extra capture, immediate return, no added latency.
- All non-forceSend callers keep the idle gate on by default.
- Ctrl-C only ever fires when a placeholder is confirmed present in the input-box region.

## Test plan

- `npm run typecheck` -> 0 errors.
- `npx vitest run` -> 1251 / 1251 passing (81 files; the change adds new cases).
- New tests assert deterministic predicate output (not model behavior), including synthetic panes that reproduce the real wrapped-stub render shape and a scrollback-echo false-positive guard.
- Verified directly against captured panes from real incidents: genuinely stuck panes detect as placeholder / clear-and-resend; healthy panes detect as idle / done.
- End-to-end: 10 / 10 pre-formed placeholders recovered through the real compiled send path.

## Known limitations

- The placeholder-to-stuck causal chain under real production multi-session contention could not be reproduced in an isolated harness; the fix is mechanism-agnostic (it recovers any placeholder however it formed), so this does not weaken it.
- A separate, pre-existing issue (not addressed here): `PARKED_INPUT_RX` does not account for a non-breaking-space prompt glyph, which can make the background stuck-input watcher mis-classify a verbatim-parked pane. Tracked separately; it does not affect this PR placeholder path.
