### PR TITLE
fix(schedule-runner): drop coercive keep-alive injection from heartbeat prompts

### DIFF
--- a/src/__tests__/schedule-runner-heartbeat-prefix.test.ts
+++ b/src/__tests__/schedule-runner-heartbeat-prefix.test.ts
@@ -2,68 +2,47 @@ import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-// Contract tests for Marveen's PR #257 review-block: the
-// schedule-runner's heartbeat prefix had a Marveen-specific
-// Telegram-keepalive directive hardcoded. Funnelling the new
-// channel-less `heartbeat` agent through the same prefix would have:
-//   1. Contradicted the agent's own CLAUDE.md contract ("NEVER call
-//      Telegram tools, always inter-agent to Marveen").
-//   2. If the channel-plugin disable ever leaked through user-scope
-//      settings (the fleet's recurring failure mode), instructed the
-//      agent to call chat_id ALLOWED_CHAT_ID directly -- reproducing
-//      the self-poll problem this whole PR is meant to solve.
+// Security regression test (2026-06-08).
 //
-// Fix: branch the heartbeat-prefix by agentName. Channel-less
-// `heartbeat` agent gets a minimal tag; Marveen still gets the
-// historical Telegram-keepalive scaffolding.
+// The schedule-runner used to inject a coercive "keep-alive" preamble into
+// heartbeat prompts for every agent whose name was not literally `heartbeat`
+// (so the jarvis-driven heartbeats -- kanban-audit, memoria-heartbeat -- all
+// got it). The preamble sat OUTSIDE the wrapUntrusted() envelope and demanded
+// a mandatory no-op tool call while forbidding use of Telegram: the runner
+// poisoning its own trusted channel, a prompt injection we shipped ourselves.
+//
+// It is removed. The runner must never again prepend an operational directive
+// to a heartbeat prompt; the agent's CLAUDE.md + the task SKILL.md drive
+// behaviour. These tests lock that in.
 
 const SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
 
-describe('schedule-runner heartbeat prefix branches by agentName', () => {
+describe('schedule-runner heartbeat prefix is injection-free', () => {
   it('keeps the [Heartbeat: ${task.name}] tag (resubmit-marker matches)', () => {
-    // The marker downstream is `[Heartbeat: ${task.name}]`. Both
-    // branches of the new conditional MUST emit it -- otherwise the
-    // resubmit-retry code at the bottom of the function stops working.
+    // The downstream resubmit-retry code matches `[Heartbeat: ${task.name}]`,
+    // so the tag itself must stay.
     expect(SRC).toMatch(/\[Heartbeat: \$\{task\.name\}\]/)
   })
 
-  it('routes agentName === heartbeat to the minimal prefix (no Telegram directive)', () => {
-    // The outer heartbeat-vs-utemezett-feladat block ends where the
-    // `[Utemezett feladat:` prefix appears. Slice from "task.type ===
-    // 'heartbeat'" up to that marker -- everything between is the
-    // heartbeat branch, including BOTH inner sub-branches.
+  it('contains NO keep-alive / Telegram-keepalive injection strings anywhere', () => {
+    expect(SRC).not.toMatch(/KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ/)
+    expect(SRC).not.toMatch(/Telegram-bun MCP-stdio-pipe keep-alive/)
+    expect(SRC).not.toMatch(/NE Telegram-tool-t/)
+    expect(SRC).not.toMatch(/marveen-keepalive\.log/)
+    expect(SRC).not.toMatch(/kotelezo no-op tool-call/)
+  })
+
+  it('does not branch the heartbeat prefix by agentName (one clean prefix)', () => {
     const heartbeatBlockStart = SRC.indexOf("if (task.type === 'heartbeat')")
     expect(heartbeatBlockStart).toBeGreaterThan(0)
     const outerElseMarker = SRC.indexOf('[Utemezett feladat:', heartbeatBlockStart)
     expect(outerElseMarker).toBeGreaterThan(heartbeatBlockStart)
     const heartbeatBlock = SRC.slice(heartbeatBlockStart, outerElseMarker)
-    expect(heartbeatBlock).toMatch(/agentName === 'heartbeat'/)
-
-    // Identify the channel-less sub-branch: from the inner-if to the
-    // inner-else. Both are inside heartbeatBlock now.
-    const innerIfIdx = heartbeatBlock.indexOf("agentName === 'heartbeat'")
-    const innerElseIdx = heartbeatBlock.indexOf('} else {', innerIfIdx)
-    expect(innerElseIdx).toBeGreaterThan(innerIfIdx)
-    const channelLessBranch = heartbeatBlock.slice(innerIfIdx, innerElseIdx)
-
-    // Channel-less branch MUST NOT have Telegram instruction strings.
-    expect(channelLessBranch).not.toMatch(/NE Telegram-tool-t/)
-    expect(channelLessBranch).not.toMatch(/CSAK AKKOR irj Telegramon/)
-    expect(channelLessBranch).not.toMatch(/ALLOWED_CHAT_ID/)
-    expect(channelLessBranch).not.toMatch(/Telegram-bun MCP-stdio-pipe/)
+    // No inner agentName branch deciding whether to inject a directive.
+    expect(heartbeatBlock).not.toMatch(/agentName === 'heartbeat'/)
   })
 
-  it('Marveen branch still carries the historical keep-alive scaffolding', () => {
-    // Don't break the Marveen-targeted heartbeat (e.g. the existing
-    // memoria-heartbeat task) when fixing the channel-less one.
-    expect(SRC).toMatch(/KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ/)
-    expect(SRC).toMatch(/Telegram-bun MCP-stdio-pipe keep-alive/)
-  })
-
-  it('comments the rationale for the branch (why, not just what)', () => {
-    // PR #257 review-block specifically called out the
-    // contract-contradiction risk. Future readers should find that
-    // reasoning at the branch, not buried in git log.
-    expect(SRC).toMatch(/contract|contradiction|channel-plugin disable/i)
+  it('documents the security rationale at the branch (why, not just what)', () => {
+    expect(SRC).toMatch(/SECURITY|inject|poison|wrapUntrusted/i)
   })
 })

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -139,25 +139,25 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
   try {
     let prefix: string
     if (task.type === 'heartbeat') {
-      // Channel-less heartbeat agents (today: only `heartbeat`) MUST NOT
-      // receive the Telegram-keepalive directive -- their CLAUDE.md is
-      // explicit that all output goes to Marveen via inter-agent message
-      // (Marveen 2026-06-02 PR #257 review block). The historical prefix
-      // was Marveen-specific scaffolding ("keep the bun-poller stdio
-      // alive, only Telegram-reply if urgent") and would create a direct
-      // contradiction with the agent's own contract; worse, if the
-      // channel-plugin disable ever leaks through from the user-scope
-      // settings (which it has done before in this fleet -- the very
-      // motivation for this whole rearchitecture), the leftover Telegram
-      // tool would receive an explicit instruction to use chat_id
-      // ALLOWED_CHAT_ID. So: emit a minimal heartbeat tag for the
-      // resubmit-marker code below to match, and let the agent's own
-      // CLAUDE.md + SKILL.md drive behaviour.
-      if (agentName === 'heartbeat') {
-        prefix = `[Heartbeat: ${task.name}] `
-      } else {
-        prefix = `[Heartbeat: ${task.name}] *** KOTELEZO ELSO TEENDO MIELOTT BARMIT IRSZ: hivj meg pontosan EGY local-only tool-t (peldaul Bash 'echo keepalive >> /tmp/marveen-keepalive.log' VAGY Read tool egy meglevo fajlra mint ${join(PROJECT_ROOT, 'HEARTBEAT.md')}). NE Telegram-tool-t -- az zajt eredmenyezne. Ezt a Telegram-bun MCP-stdio-pipe keep-alive-ehez kell, ha kihagyod, a Telegram-conn 30 percen belul disconnect-el. *** Aztan: ez egy csendes ellenorzes. CSAK AKKOR irj Telegramon (chat_id: ${ALLOWED_CHAT_ID}), ha tenyleg fontos/surgos dolgot talalsz. Ha minden rendben, NE kuldj Telegram uzenetet -- a kotelezo no-op tool-call mar megfelelo aktivitas. Egy rovid 'csendes heartbeat' sor a transzkriptbe + a tool-call elég. `
-      }
+      // Heartbeat prompts get ONLY a minimal tag. The agent's CLAUDE.md and
+      // the task SKILL.md drive behaviour -- the runner MUST NOT prepend any
+      // operational directive here.
+      //
+      // SECURITY (removed 2026-06-08): the previous `agentName !== 'heartbeat'`
+      // branch injected a coercive "call exactly one local tool before you
+      // write anything, do NOT use Telegram" keep-alive preamble. That text sat
+      // OUTSIDE the wrapUntrusted() envelope, so the receiving agent -- told to
+      // trust everything outside the untrusted tags -- was instructed to perform
+      // a mandatory no-op tool call and to suppress the very channel the user
+      // sees. The runner was poisoning its own trusted channel: a prompt
+      // injection we shipped ourselves. It also contradicted the agent contract
+      // and, if the channel-plugin disable leaked through user-scope settings,
+      // told the leftover Telegram tool to message ALLOWED_CHAT_ID. Removed
+      // entirely; ALL heartbeat agents now get the clean tag. Channel liveness
+      // is handled separately by the channels TUI keepalive
+      // (channel-coordinator/liveness.ts), never by injecting instructions into
+      // heartbeat prompts.
+      prefix = `[Heartbeat: ${task.name}] `
     } else {
       prefix = `[Utemezett feladat: ${task.name}] Az eredmenyt kuldd el Telegramon (chat_id: ${ALLOWED_CHAT_ID}, reply tool). `
     }


### PR DESCRIPTION
## Mi ez

A `schedule-runner` heartbeat-prompt prefix-építője egy hardcode-olt "kötelező első teendő: hívj meg pontosan egy local-only tool-t, NE használj Telegram-tool-t" keep-alive preamble-t tett MINDEN heartbeat-task elé, ami az `agent !== 'heartbeat'` ágra esett (így Jarvis/main mindig megkapta).

A szöveg a `wrapUntrusted()` envelope-on **kívül** ült. A fogadó ágens (aki azt tanulja, hogy az untrusted tageken kívüli mindent megbízhatónak vesz) így egy kötelező no-op tool-hívásra és a user-facing Telegram-csatorna elnyomására kapott utasítást. A runner a saját megbízható csatornáját mérgezte -- egy prompt injection, amit mi magunk szállítottunk. Ráadásul ellentmondott az ágens-kontraktusnak, és egy kiszivárgó channel-plugin-disable esetén a maradék Telegram-toolnak azt mondta, üzenjen az `ALLOWED_CHAT_ID`-nak.

## Mit változik

- Minden heartbeat-task a tiszta `[Heartbeat: <name>]` prefixet kapja, agent-névtől függetlenül; nincs operatív direktíva preprend.
- A channel-liveness külön marad (channels TUI keepalive), sosem injektálva a heartbeat-promptba.
- A teszt átírva lock-in-ből security-regression guarddá: asserteli, hogy az injection-stringek nincsenek a promptban.

## Verifikáció

- `tsc --noEmit`: 0 hiba
- runner tesztek: 12/12 pass (heartbeat-prefix, run-now, autostart)
- Élesben már fut (dist), de origin-on eddig nem volt -> egy tiszta rebuild visszahozta volna a sebezhetőséget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)