### PR TITLE
fix(agents): scope channel plugins per sub-agent at spawn (kill dup telegram pollers)

### DIFF
--- a/src/__tests__/scope-channel-plugins.test.ts
+++ b/src/__tests__/scope-channel-plugins.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { scopeChannelPlugins, CHANNEL_PLUGIN_IDS } from '../web/agent-process.js'
+
+const TG = CHANNEL_PLUGIN_IDS.telegram     // telegram@claude-plugins-official
+const SL = CHANNEL_PLUGIN_IDS.slack        // slack-channel@marveen-marketplace
+const DI = CHANNEL_PLUGIN_IDS.discord      // discord@claude-plugins-official
+
+// scopeChannelPlugins keys on the EXPLICIT per-agent channelProvider (null when
+// unset). This is the crux: a channel-less sub-agent (boni/deeper/iris/zara/samu)
+// has channelProvider=null even though resolveAgentProvider would default it to
+// telegram -- so it MUST disable telegram. Only an agent that declares its
+// channel (e.g. slacker=slack) keeps its own plugin.
+describe('scopeChannelPlugins', () => {
+  it('channel-less sub-agent (explicit provider null) disables ALL three -- the dup-poller fix', () => {
+    const out = scopeChannelPlugins(null)
+    expect(out[TG]).toBe(false)
+    expect(out[SL]).toBe(false)
+    expect(out[DI]).toBe(false)
+  })
+
+  it('a channel-less agent that still carried a stale telegram:true gets it forced OFF', () => {
+    // The exact respawn regression: a leaked/defaulted telegram:true must not
+    // survive for an agent whose explicit provider is null.
+    const out = scopeChannelPlugins(null, { [TG]: true })
+    expect(out[TG]).toBe(false)
+  })
+
+  it('a slack agent (explicit slack) enables ONLY slack, disables telegram + discord', () => {
+    const out = scopeChannelPlugins('slack', { [TG]: true })
+    expect(out[SL]).toBe(true)
+    expect(out[TG]).toBe(false)
+    expect(out[DI]).toBe(false)
+  })
+
+  it('a telegram agent (explicit telegram) enables ONLY telegram', () => {
+    const out = scopeChannelPlugins('telegram')
+    expect(out[TG]).toBe(true)
+    expect(out[SL]).toBe(false)
+    expect(out[DI]).toBe(false)
+  })
+
+  it('preserves unrelated (non-channel) plugins untouched', () => {
+    const out = scopeChannelPlugins(null, {
+      'frontend-design@claude-plugins-official': true,
+      [TG]: true,
+    })
+    expect(out['frontend-design@claude-plugins-official']).toBe(true)
+    expect(out[TG]).toBe(false)
+  })
+
+  it('an unknown explicit provider disables all (no own plugin to enable)', () => {
+    const out = scopeChannelPlugins('mystery')
+    expect(out[TG]).toBe(false)
+    expect(out[SL]).toBe(false)
+    expect(out[DI]).toBe(false)
+  })
+
+  it('does not mutate the passed-in object', () => {
+    const existing = { [TG]: true }
+    scopeChannelPlugins('slack', existing)
+    expect(existing[TG]).toBe(true) // unchanged
+  })
+})
+
+// CATASTROPHE-BRANCH regression guard: the spawn-time plugin scoping must NEVER
+// run for the MAIN agent, or scopeChannelPlugins(null) would disable the owner's
+// telegram channel (Szabi's primary line). marveen is structurally outside this
+// path (not in agents/, launched via channels.sh), but this locks the explicit
+// guard so a future refactor cannot regress it.
+describe('main-agent telegram channel is protected from spawn-time scoping', () => {
+  const SRC = readFileSync(join(__dirname, '../web/agent-process.ts'), 'utf-8')
+
+  it('the spawn-time scoping block is guarded by name !== MAIN_AGENT_ID', () => {
+    // The scopeChannelPlugins call must sit inside an `if (name !== MAIN_AGENT_ID)`.
+    const callIdx = SRC.indexOf('s.enabledPlugins = scopeChannelPlugins(')
+    expect(callIdx).toBeGreaterThan(0)
+    const before = SRC.slice(Math.max(0, callIdx - 700), callIdx)
+    expect(before).toMatch(/if \(name !== MAIN_AGENT_ID\) \{/)
+  })
+
+  it('an explicit telegram provider KEEPS telegram enabled (so a telegram main/agent is never disabled)', () => {
+    const out = scopeChannelPlugins('telegram')
+    expect(out[TG]).toBe(true)
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -26,7 +26,7 @@ import {
 } from './ssh-tmux.js'
 import { parseTelegramToken } from './telegram.js'
 import { getProvider, getProviderType, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
-import { CHANNEL_PROVIDER } from '../config.js'
+import { CHANNEL_PROVIDER, MAIN_AGENT_ID } from '../config.js'
 import { loadProfileTemplate } from './profiles.js'
 import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
 import { getSecret } from './vault.js'
@@ -34,6 +34,41 @@ import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
+
+// The fleet's channel plugins keyed by provider. A sub-agent must enable ONLY
+// its own provider's plugin; the others are forced off so it cannot spawn a
+// competing poller against the main agent's bot token (the dup-poller / 409
+// Conflict class). Keep in sync with the user-scope enabledPlugins ids.
+export const CHANNEL_PLUGIN_IDS: Record<string, string> = {
+  telegram: 'telegram@claude-plugins-official',
+  slack: 'slack-channel@marveen-marketplace',
+  discord: 'discord@claude-plugins-official',
+}
+
+// Pure: compute the enabledPlugins map for a sub-agent so that exactly its own
+// channel plugin is enabled and every other channel plugin is disabled.
+// Non-channel plugins in `existing` are preserved untouched.
+//
+// `explicitProvider` MUST be the agent's EXPLICIT per-agent channelProvider
+// (readAgentChannelProvider), or null when unset -- NOT the resolved provider.
+// resolveAgentProvider() defaults an agent with no channelProvider to the global
+// CHANNEL_PROVIDER (telegram), and a legacy-token fallback then marks it
+// hasChannel -- so EVERY channel-less sub-agent (boni/deeper/iris/zara/samu) is
+// launched with --channels plugin:telegram and would keep the dup poller. Keying
+// on the EXPLICIT provider means a channel-less agent (null) disables all three;
+// only an agent that genuinely declares its channel (e.g. slacker=slack) keeps
+// its own plugin.
+export function scopeChannelPlugins(
+  explicitProvider: string | null,
+  existing?: Record<string, boolean>,
+): Record<string, boolean> {
+  const out: Record<string, boolean> = { ...(existing ?? {}) }
+  const ownPlugin = explicitProvider ? CHANNEL_PLUGIN_IDS[explicitProvider] : undefined
+  for (const pid of Object.values(CHANNEL_PLUGIN_IDS)) {
+    out[pid] = pid === ownPlugin
+  }
+  return out
+}
 
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
@@ -269,23 +304,39 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // Claude Code enforces the list rather than bypassing it.
     const profile = loadProfileTemplate(readAgentSecurityProfile(name))
     writeAgentSettingsFromProfile(name, profile)
-    // Channel-less agents must not load the global channel plugins from
-    // enabledPlugins. Without this, they fall back to the main agent's
-    // token and two instances fight over the same getUpdates slot (409
-    // Conflict / orphan watchdog loop causing recurring MCP disconnects).
-    if (!hasChannel) {
+    // A sub-agent must load ONLY its own channel plugin. The user-scope
+    // enabledPlugins would otherwise make EVERY sub-agent spawn a telegram
+    // (and slack/discord) poller that falls back to the main agent's bot
+    // token and fights it over the same getUpdates slot (409 Conflict /
+    // orphan-poller churn / recurring MCP disconnects). Scope the agent's
+    // settings.json so exactly its configured provider stays enabled and the
+    // other channel plugins are forced off; a channel-less agent disables all
+    // three. Applies to channel-HAVING sub-agents too (e.g. a slack agent must
+    // not also run a telegram poller). Re-applied on EVERY spawn because
+    // writeAgentSettingsFromProfile() above regenerates settings.json from the
+    // profile template -- so this survives respawns, unlike a one-off manual
+    // per-agent override (which a respawn silently wiped). The main agent runs
+    // via channels.sh, not this path, so it remains the sole telegram poller.
+    //
+    // CATASTROPHE GUARD: never scope the MAIN agent's plugins here. marveen is
+    // not in agents/ (so listAgentNames never spawns it through this path) and
+    // its channel comes up via channels.sh -- but if a future caller ever passed
+    // MAIN_AGENT_ID in, scopeChannelPlugins(null) would DISABLE the owner's
+    // telegram channel (Szabi's primary line). Refuse outright.
+    if (name !== MAIN_AGENT_ID) {
       const settingsPath = join(agentDir(name), '.claude', 'settings.json')
       try {
         const s = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>
-        s.enabledPlugins = {
-          ...(s.enabledPlugins as Record<string, boolean> | undefined ?? {}),
-          'telegram@claude-plugins-official': false,
-          'slack-channel@marveen-marketplace': false,
-          'discord@claude-plugins-official': false,
-        }
+        // Key on the EXPLICIT per-agent channelProvider (null when unset), NOT
+        // the resolved/defaulted agentProvider -- a channel-less sub-agent must
+        // disable telegram even though resolveAgentProvider defaulted it to it.
+        s.enabledPlugins = scopeChannelPlugins(
+          readAgentChannelProvider(name),
+          s.enabledPlugins as Record<string, boolean> | undefined,
+        )
         writeFileSync(settingsPath, JSON.stringify(s, null, 2))
       } catch (err) {
-        logger.warn({ err, name }, 'Could not disable channel plugins for channel-less agent')
+        logger.warn({ err, name }, 'Could not scope channel plugins for sub-agent')
       }
     }
     const skipFlag = profile.permissionMode === 'strict' ? '' : '--dangerously-skip-permissions '


### PR DESCRIPTION
Persistent fix for the dup-poller / 409-churn (card 30040663). GO'd by Marveen.

## Root cause (why yesterday's `telegram=false` didn't stick + why ALL channel-less sub-agents run a telegram poller)
1. `startAgentProcess` calls `writeAgentSettingsFromProfile()` which **regenerates `settings.json` from the profile template on every spawn**, wiping any manual `enabledPlugins` override → the per-agent override is lost on respawn.
2. `resolveAgentProvider` **defaults** a channel-less agent (no per-agent `channelProvider`) to the global `CHANNEL_PROVIDER` (telegram), and a legacy-token fallback marks it `hasChannel` → **every** channel-less sub-agent (boni/deeper/iris/zara/samu) is launched with `--channels plugin:telegram` and spawns a poller fighting the main agent's bot token (409 Conflict / orphan-poller churn / recurring MCP disconnects). *(Found via the suspicious deepseek-v4-pro poller — that's the `deeper` agent.)*

## Fix
A pure `scopeChannelPlugins(explicitProvider, existing)` keyed on the **explicit** per-agent `channelProvider` (`readAgentChannelProvider`, **null** when unset) — NOT the defaulted provider. A channel-less agent (null) disables all three channel plugins; an agent that declares its channel (e.g. `slacker`=slack) keeps only its own. `startAgentProcess` applies it to **all** sub-agents on every spawn (after the profile regen), so it **survives respawns**. `enabledPlugins:false` suppresses the poller even though the `--channels` flag is still passed — verified empirically in the boni single-agent test. The main agent runs via `channels.sh` (not this path) and stays the sole telegram poller.

## Verification
- `tsc --noEmit` green.
- `scope-channel-plugins.test.ts` 7 cases (channel-less null→all off incl. stale `telegram:true`; slack→only slack; telegram→only telegram; non-channel plugins preserved; unknown provider→all off; no mutation) + channel/agent suites green.

## Deploy note
Takes effect at the **v1.7.4 deploy** — the live dashboard spawns agents from compiled `dist/`, so the fix is dormant until deployed (consistent with the dup-poller returning on the current live build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)