### PR TITLE
feat(schedules): run history log with token estimates and auto-collection

### DIFF
--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -236,8 +236,29 @@ Az ütemezett feladatok vizuálisan is kezelhetők a dashboardon: http://localho
 - Feladatok listája (név, ágens, cron, típus, enabled állapot)
 - Enable/disable toggle
 - Run Now gomb (azonnali futtatás teszteléshez)
+- **Futtatási előzmények (ℹ gomb)**: az utolsó 10 futtatás adatai -- pontos időpont, állapot, és közelítő tokenfogyasztás
 - Új feladat varázsló: rövid leírásból AI-val kibővített promptot generál, interaktív cron-szerkesztővel
 - Pending retries panel: a retry queue-ban várakozó feladatok, manuális törlési lehetőséggel
+
+### Futtatási állapotok
+
+| Állapot | Jelentés |
+|---------|----------|
+| `fired` / Rendben | A prompt sikeresen kézbesült az ágens session-jébe |
+| `error` / Hiba | Kivétel keletkezett a kézbesítés során |
+| `skipped` / Kihagyva | `skipIfBusy=true` és a session foglalt volt -- a tick szándékosan kihagyva |
+
+Az előzmények az utolsó 30 napot tartalmazzák; régebbi sorok automatikusan törlődnek.
+
+Az állapotok lekérdezhetők az API-n is:
+
+```bash
+TOKEN=$(cat store/.dashboard-token)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:3420/api/schedules/reggeli-napindito/runs" | jq .
+```
+
+A tokenszám közelítő: az ágens teljes tokenforgalmát összesíti a futtatás pillanatától a következő futtatás kezdetéig (max. 1 óra). Ha az ágens ebben az ablakban más feladatot is végzett, az is beleszámít.
 
 ---
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1269,6 +1269,7 @@ export function listTaskRunHistory(name: string, limit: number): TaskRunHistoryE
     'SELECT ts, status, agent FROM task_runs WHERE name = ? ORDER BY ts DESC LIMIT ?'
   ).all(name, limit) as { ts: number; status: string; agent: string }[]
 
+  // token_usage.timestamp is in seconds; task_runs.ts is in ms -- divide by 1000
   const tokenStmt = db.prepare(
     `SELECT COALESCE(SUM(input_tokens + output_tokens + cache_read_tokens), 0) as total
      FROM token_usage WHERE agent = ? AND timestamp >= ? AND timestamp < ?`
@@ -1279,7 +1280,7 @@ export function listTaskRunHistory(name: string, limit: number): TaskRunHistoryE
   return rows.map((row, i) => {
     const newerTs = i > 0 ? rows[i - 1].ts : undefined
     const windowEnd = newerTs !== undefined ? Math.min(row.ts + 3600000, newerTs) : row.ts + 3600000
-    const tokenRow = tokenStmt.get(row.agent, row.ts, windowEnd) as { total: number }
+    const tokenRow = tokenStmt.get(row.agent, Math.floor(row.ts / 1000), Math.floor(windowEnd / 1000)) as { total: number }
     return { ts: row.ts, status: row.status, tokens_est: tokenRow.total > 0 ? tokenRow.total : null }
   })
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -371,6 +371,8 @@ export function initDatabase(dbPathOverride?: string): void {
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_task_runs_ts ON task_runs(ts)`)
+  // Migration: add status column to task_runs (introduced 2026-06-13)
+  try { db.exec(`ALTER TABLE task_runs ADD COLUMN status TEXT NOT NULL DEFAULT 'fired'`) } catch { /* already present */ }
 
   // --- Pending Scheduled Task Retries ---
   // Busy-skipped scheduled tasks used to live in an in-memory Map. On a
@@ -1249,15 +1251,37 @@ export function getAgentConversationThreads(): AgentThread[] {
 
 // --- Task Run History ---
 
-export interface TaskRunEntry { name: string; agent: string; ts: number }
+export interface TaskRunEntry { name: string; agent: string; ts: number; status: string }
+
+export interface TaskRunHistoryEntry { ts: number; status: string; tokens_est: number | null }
 
 const TASK_RUN_TTL_MS = 30 * 24 * 60 * 60 * 1000
 
-export function appendTaskRun(name: string, agent: string): void {
+export function appendTaskRun(name: string, agent: string, status = 'fired'): void {
   const now = Date.now()
-  db.prepare('INSERT INTO task_runs (name, agent, ts) VALUES (?, ?, ?)').run(name, agent, now)
+  db.prepare('INSERT INTO task_runs (name, agent, ts, status) VALUES (?, ?, ?, ?)').run(name, agent, now, status)
   // Opportunistic TTL prune: cheap indexed DELETE, keeps the table bounded.
   db.prepare('DELETE FROM task_runs WHERE ts < ?').run(now - TASK_RUN_TTL_MS)
+}
+
+export function listTaskRunHistory(name: string, limit: number): TaskRunHistoryEntry[] {
+  const rows = db.prepare(
+    'SELECT ts, status, agent FROM task_runs WHERE name = ? ORDER BY ts DESC LIMIT ?'
+  ).all(name, limit) as { ts: number; status: string; agent: string }[]
+
+  const tokenStmt = db.prepare(
+    `SELECT COALESCE(SUM(input_tokens + output_tokens + cache_read_tokens), 0) as total
+     FROM token_usage WHERE agent = ? AND timestamp >= ? AND timestamp < ?`
+  )
+
+  // Rows are DESC (newest first). For each run, approximate token usage as
+  // the sum for that agent in the window [ts, next_newer_ts) capped at 1 hour.
+  return rows.map((row, i) => {
+    const newerTs = i > 0 ? rows[i - 1].ts : undefined
+    const windowEnd = newerTs !== undefined ? Math.min(row.ts + 3600000, newerTs) : row.ts + 3600000
+    const tokenRow = tokenStmt.get(row.agent, row.ts, windowEnd) as { total: number }
+    return { ts: row.ts, status: row.status, tokens_est: tokenRow.total > 0 ? tokenRow.total : null }
+  })
 }
 
 export function countTaskRunsBetween(fromTs: number, toTs?: number): number {

--- a/src/web.ts
+++ b/src/web.ts
@@ -19,6 +19,7 @@ import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
 import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
 import { startReauthHealer } from './web/reauth-healer.js'
 import { startAutoRestartRunner } from './web/auto-restart-runner.js'
+import { collectTokenUsage } from './web/token-usage.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
@@ -285,6 +286,14 @@ export function startWebServer(port = 3420): http.Server {
   const updateCheckerInterval = startUpdateChecker()
   logger.info('Update checker started (15min poll)')
 
+  // Collect token usage from JSONL transcripts every hour so the run-history
+  // token estimates stay fresh without requiring a manual dashboard visit.
+  const tokenCollectInterval = setInterval(() => {
+    collectTokenUsage().catch(err => logger.warn({ err }, 'Periodic token usage collection failed'))
+  }, 60 * 60 * 1000)
+  collectTokenUsage().catch(err => logger.warn({ err }, 'Startup token usage collection failed'))
+  logger.info('Token usage auto-collect started (1h poll + startup)')
+
   // NOTE: startMcpListChecker() is intentionally NOT called here.
   //
   // Root cause: calling `claude mcp list` at boot time (30s delay) spawns the
@@ -349,6 +358,7 @@ export function startWebServer(port = 3420): http.Server {
     if (reauthHealerInterval) clearInterval(reauthHealerInterval)
     clearInterval(autoRestartInterval)
     clearInterval(updateCheckerInterval)
+    clearInterval(tokenCollectInterval)
     return origClose(cb)
   }
 

--- a/src/web/routes/schedules.ts
+++ b/src/web/routes/schedules.ts
@@ -1,7 +1,7 @@
 import { existsSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import {
-  listPendingTaskRetries, deletePendingTaskRetryById,
+  listPendingTaskRetries, deletePendingTaskRetryById, listTaskRunHistory,
 } from '../../db.js'
 import { MAIN_AGENT_ID, BOT_NAME } from '../../config.js'
 import { runAgent } from '../../agent.js'
@@ -222,6 +222,16 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
     const now = Date.now()
     const rows = listPendingTaskRetries().map(r => toPendingRetryView(r, now))
     json(res, rows)
+    return true
+  }
+
+  const scheduleRunsMatch = path.match(/^\/api\/schedules\/([^/]+)\/runs$/)
+  if (scheduleRunsMatch && method === 'GET') {
+    const name = decodeURIComponent(scheduleRunsMatch[1])
+    const dir = join(SCHEDULED_TASKS_DIR, name)
+    if (!existsSync(dir)) { json(res, { error: 'Schedule not found' }, 404); return true }
+    const runs = listTaskRunHistory(name, 10)
+    json(res, runs)
     return true
   }
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -177,7 +177,7 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
     sendPromptToSession(session, fullPrompt, host, { waitForIdle: !task.forceSend })
     scheduleLastRun.set(task.name, now)
     persistScheduleLastRun()
-    appendTaskRun(task.name, agentName)
+    appendTaskRun(task.name, agentName, 'fired')
     logger.info({ task: task.name, agent: agentName, session }, 'Scheduled task fired')
 
     // Post-send verify: if the agent started a new turn during our chunk
@@ -210,6 +210,7 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
     return 'fired'
   } catch (err) {
     logger.warn({ err, task: task.name }, 'Failed to fire scheduled task')
+    appendTaskRun(task.name, agentName, 'error')
     return 'error'
   }
 }
@@ -418,6 +419,7 @@ export function startScheduleRunner(): NodeJS.Timeout {
             // Daily/weekly schedules keep skipIfBusy=false so the queue
             // + alert path catches a long-running busy state.
             logger.info({ task: task.name, agent: agentName }, 'Schedule busy, skipIfBusy=true: dropping tick silently')
+            appendTaskRun(task.name, agentName, 'skipped')
             continue
           }
           // First encounter -- insert a new pending row. If somehow a

--- a/web/app.js
+++ b/web/app.js
@@ -3768,6 +3768,9 @@ function renderScheduleList(tasks) {
         <button class="btn-icon" data-action="toggle" title="${task.enabled ? 'Szüneteltetés' : 'Folytatás'}">
           ${task.enabled ? pauseIcon() : playIcon()}
         </button>
+        <button class="btn-icon" data-action="history" title="Futtatási előzmények">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        </button>
         <button class="btn-icon btn-icon-danger" data-action="delete" title="Törlés">
           ${trashIcon()}
         </button>
@@ -3811,8 +3814,67 @@ function renderScheduleList(tasks) {
       } catch { showToast('Hiba a törlés során') }
     })
 
+    row.querySelector('[data-action="history"]').addEventListener('click', async (e) => {
+      e.stopPropagation()
+      openScheduleRunHistory(task.name)
+    })
+
     scheduleList.appendChild(row)
   }
+}
+
+const scheduleRunHistoryOverlay = document.getElementById('scheduleRunHistoryOverlay')
+document.getElementById('scheduleRunHistoryClose').addEventListener('click', () => closeModal(scheduleRunHistoryOverlay))
+scheduleRunHistoryOverlay.addEventListener('click', (e) => { if (e.target === scheduleRunHistoryOverlay) closeModal(scheduleRunHistoryOverlay) })
+
+const RUN_STATUS_LABEL = {
+  fired: 'Rendben',
+  error: 'Hiba',
+  skipped: 'Kihagyva',
+}
+const RUN_STATUS_CLASS = {
+  fired: 'badge-active',
+  error: 'badge-danger',
+  skipped: 'badge-paused',
+}
+
+async function openScheduleRunHistory(taskName) {
+  document.getElementById('scheduleRunHistoryTitle').textContent = `Előzmények: ${taskName}`
+  const body = document.getElementById('scheduleRunHistoryBody')
+  body.innerHTML = '<p>Betöltés...</p>'
+  openModal(scheduleRunHistoryOverlay)
+  try {
+    const r = await fetch(`/api/schedules/${encodeURIComponent(taskName)}/runs`)
+    const runs = await r.json()
+    if (!Array.isArray(runs) || runs.length === 0) {
+      body.innerHTML = '<p class="hint">Még nincs rögzített futtatás.</p>'
+      return
+    }
+    const rows = runs.map(run => {
+      const d = new Date(run.ts)
+      const date = d.toLocaleDateString('hu-HU', { month: 'short', day: 'numeric' })
+      const time = d.toLocaleTimeString('hu-HU', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+      const label = RUN_STATUS_LABEL[run.status] || run.status
+      const cls = RUN_STATUS_CLASS[run.status] || 'badge-paused'
+      const tokens = run.tokens_est !== null ? `~${run.tokens_est.toLocaleString()}` : '-'
+      return `<tr>
+        <td style="white-space:nowrap">${date} ${time}</td>
+        <td><span class="badge ${cls}">${escapeHtml(label)}</span></td>
+        <td style="text-align:right;font-variant-numeric:tabular-nums">${tokens}</td>
+      </tr>`
+    }).join('')
+    body.innerHTML = `<table style="width:100%;border-collapse:collapse">
+      <thead><tr>
+        <th style="text-align:left;padding:4px 8px;border-bottom:1px solid var(--border)">Időpont</th>
+        <th style="text-align:left;padding:4px 8px;border-bottom:1px solid var(--border)">Állapot</th>
+        <th style="text-align:right;padding:4px 8px;border-bottom:1px solid var(--border)">Token (kb.)</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`
+    body.querySelectorAll('tbody tr').forEach(tr => {
+      tr.querySelectorAll('td').forEach(td => { td.style.padding = '5px 8px'; td.style.borderBottom = '1px solid var(--border-light, #eee)' })
+    })
+  } catch { body.innerHTML = '<p class="hint">Hiba az előzmények betöltésekor.</p>' }
 }
 
 function renderTimeline(tasks) {

--- a/web/index.html
+++ b/web/index.html
@@ -1873,6 +1873,20 @@
     </div>
   </div>
 
+  <!-- Modal: Schedule Run History -->
+  <div class="modal-overlay" id="scheduleRunHistoryOverlay" hidden>
+    <div class="modal">
+      <div class="modal-header">
+        <h2 id="scheduleRunHistoryTitle">Futtatási előzmények</h2>
+        <button class="modal-close" id="scheduleRunHistoryClose">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p class="hint" style="margin-bottom:0.75rem">Utolsó 10 futtatás. Tokenszám becslés: az ágens tokenforgalma a futtatás utáni 1 órában (közelítő érték).</p>
+        <div id="scheduleRunHistoryBody"></div>
+      </div>
+    </div>
+  </div>
+
   <!-- Modal: New/Edit Schedule -->
   <div class="modal-overlay" id="scheduleModalOverlay">
     <div class="modal modal-wide">

--- a/web/index.html
+++ b/web/index.html
@@ -1874,7 +1874,7 @@
   </div>
 
   <!-- Modal: Schedule Run History -->
-  <div class="modal-overlay" id="scheduleRunHistoryOverlay" hidden>
+  <div class="modal-overlay" id="scheduleRunHistoryOverlay">
     <div class="modal">
       <div class="modal-header">
         <h2 id="scheduleRunHistoryTitle">Futtatási előzmények</h2>


### PR DESCRIPTION
## Summary

- Add run-history info button on each scheduled task card showing last 10 runs (timestamp, status, estimated token count)
- Fix timestamp unit mismatch in token estimation: `task_runs.ts` is milliseconds, `token_usage.timestamp` is seconds
- Fix invisible run-history modal: `hidden` HTML attribute kept overlay invisible after `openModal()` call
- Add automatic token usage collection on startup and every hour

## AI authorship

Authored with AI assistance (claude-sonnet-4-6) under human review by @cett.

## Test plan

- [ ] Schedules page → ⓘ gomb → modal opens with last 10 runs
- [ ] Token column shows estimated counts (not all dashes)
- [ ] Empty state: "Még nincs rögzített futtatás."
- [ ] Server log shows "Token usage auto-collect started" on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)