### PR TITLE
Make the product brand fully configurable (complete the BOT_NAME branding)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,24 @@ TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 ALLOWED_CHAT_ID=your_telegram_chat_id
 OWNER_NAME=Your Name
 HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
+
+# Branding (optional). The installer writes these for you; defaults below keep
+# the product named "Marveen". They are INDEPENDENT:
+#   BOT_NAME    -- the main agent's display name (e.g. "MyAssistant")
+#   BRAND_NAME  -- the product / system name shown in the dashboard chrome
+#                  (browser tab, sidebar, topbar). Defaults to BOT_NAME.
+# Set BRAND_NAME only if you want the product called something different from
+# the agent. Example: BOT_NAME="MyAssistant", BRAND_NAME="AcmeAI".
+# BOT_NAME=Marveen
+# BRAND_NAME=AcmeAI
+# MAIN_AGENT_ID and SERVICE_ID are derived by the installer (ASCII slugs of
+# BOT_NAME / BRAND_NAME) and rarely need manual editing. MAIN_AGENT_ID is the
+# internal agent id (tmux session, DB, API routing); SERVICE_ID names the OS
+# service units (launchd com.<id>.* / systemd <id>-*) and defaults to
+# MAIN_AGENT_ID.
+# MAIN_AGENT_ID=marveen
+# SERVICE_ID=marveen
+
 # Opcionális:
 # WEB_PORT=3420
 # WEB_HOST=127.0.0.1       # FONTOS: 0.0.0.0-val a dashboard elérhető a hálózatról. Használj DASHBOARD_TOKEN-t!

--- a/README.md
+++ b/README.md
@@ -93,8 +93,36 @@ A telepítő végigvezet a beállításokon:
 1. Függőségek ellenőrzése és telepítése
 2. Claude Code bejelentkezés
 3. Telegram bot létrehozása
-4. Személyes beállítások
+4. Személyes beállítások (a bot neve és a termék/márka neve)
 5. Szolgáltatások indítása
+
+### Branding (saját márkanév)
+
+A platform szabadon márkázható telepítéskor. Két, egymástól **független** beállítás:
+
+| Beállítás | Mi ez | Default |
+|-----------|-------|---------|
+| `BOT_NAME` | A fő ágens megjelenített neve (pl. `MyAssistant`) | `Marveen` |
+| `BRAND_NAME` | A termék / rendszer neve a dashboard fejlécében (böngésző-cím, oldalsáv, mobil topbar) | `BOT_NAME` |
+
+A telepítő mindkettőt megkérdezi. Ha csak Entert nyomsz, minden marad `Marveen` (a viselkedés változatlan a meglévő telepítésekhez képest). Ha külön márkanevet adsz meg, a teljes felület és az OS szolgáltatás-azonosítók is azzal jönnek létre:
+
+```bash
+# Példa: az ágens neve "MyAssistant", a terméké "AcmeAI"
+#   Mi legyen a botod neve? [Marveen]: MyAssistant
+#   Mi a termék/márka neve? [MyAssistant]: AcmeAI
+```
+
+A `.env`-ben ezek a kulcsok jelennek meg (lásd `.env.example`):
+
+```env
+BOT_NAME=MyAssistant
+BRAND_NAME=AcmeAI
+MAIN_AGENT_ID=myassistant   # belső ágens-azonosító (a BOT_NAME ASCII slug-ja)
+SERVICE_ID=acmeai           # OS szolgáltatás-azonosító (a BRAND_NAME ASCII slug-ja)
+```
+
+A `MAIN_AGENT_ID` és `SERVICE_ID` értékeket a telepítő automatikusan származtatja; ritkán kell kézzel szerkeszteni. Ha a `BRAND_NAME` megegyezik a `BOT_NAME`-mel (a default), a `SERVICE_ID` megegyezik a `MAIN_AGENT_ID`-vel, így a launchd/systemd unit-nevek byte-azonosak a márkázatlan telepítéssel: a helyben történő frissítés nem törik el.
 
 ## Használat
 

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -573,6 +573,36 @@ if [ "$MAIN_AGENT_ID" != "marveen" ]; then
   echo -e "  ${DIM}Ügynök belső azonosító: ${MAIN_AGENT_ID}${NC}"
 fi
 
+# Product / system brand. Separate from BOT_NAME (the main agent's display
+# name): an operator may want the product called one thing and the agent
+# another. Defaults to BOT_NAME, so an operator who just presses Enter gets
+# today's behaviour with no brand divergence.
+read -p "  Mi a termék/márka neve? [${BOT_NAME}]: " BRAND_NAME
+BRAND_NAME=${BRAND_NAME:-"$BOT_NAME"}
+
+# Slug for service labels (systemd units) derived from BRAND_NAME with the SAME
+# NFKD rule as MAIN_AGENT_ID. DEFAULT-SAFE: when BRAND_NAME equals BOT_NAME (the
+# default), this slug equals MAIN_AGENT_ID, so the systemd unit names below are
+# byte-identical to a brand-unaware install. Only an operator who types a
+# DIFFERENT brand gets brand-based unit names -- in-place upgrades that keep the
+# default are untouched.
+BRAND_SLUG=$(python3 - "$BRAND_NAME" <<'PYEOF'
+import sys, unicodedata, re
+s = sys.argv[1].strip()
+s = unicodedata.normalize('NFKD', s).encode('ASCII', 'ignore').decode()
+s = re.sub(r'[^a-zA-Z0-9]+', '-', s).strip('-').lower()
+print(s or 'marveen')
+PYEOF
+)
+# The id used for systemd unit names: brand slug when the operator chose a brand
+# distinct from the agent id, otherwise the agent id (unchanged default).
+if [ "$BRAND_SLUG" != "$MAIN_AGENT_ID" ]; then
+  SERVICE_ID="$BRAND_SLUG"
+  echo -e "  ${DIM}Szolgáltatás-azonosító (systemd): ${SERVICE_ID}${NC}"
+else
+  SERVICE_ID="$MAIN_AGENT_ID"
+fi
+
 INSTALL_STEP="npm-install"
 # ─────────────────────────────────────────────
 # [5/7] Fuggosegek telepitese + konfiguracic
@@ -609,7 +639,9 @@ echo -e "${BOLD}  Konfiguracio letrehozasa...${NC}"
 CHANNEL_PROVIDER=${CHANNEL_PROVIDER}
 OWNER_NAME=${OWNER_NAME}
 BOT_NAME=${BOT_NAME}
+BRAND_NAME=${BRAND_NAME}
 MAIN_AGENT_ID=${MAIN_AGENT_ID}
+SERVICE_ID=${SERVICE_ID}
 ENVEOF
 )
 if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
@@ -956,9 +988,14 @@ SYSTEMD_DIR="$HOME/.config/systemd/user"
 mkdir -p "$SYSTEMD_DIR"
 
 NODE_PATH="$(which node)"
-DASH_UNIT="${MAIN_AGENT_ID}-dashboard"
-CHAN_UNIT="${MAIN_AGENT_ID}-channels"
-MORN_UNIT="${MAIN_AGENT_ID}-morning"
+# Unit names key off SERVICE_ID. SERVICE_ID == MAIN_AGENT_ID for a brand-unaware
+# (default) install, so these unit names are unchanged unless the operator chose
+# a distinct brand above. The channels unit still runs channels.sh, which names
+# its tmux session ${MAIN_AGENT_ID}-channels (the session id the backend uses);
+# the unit name and the session name are independent.
+DASH_UNIT="${SERVICE_ID}-dashboard"
+CHAN_UNIT="${SERVICE_ID}-channels"
+MORN_UNIT="${SERVICE_ID}-morning"
 
 # Detect the host timezone so the scheduled-task runner (which reads
 # cron expressions in Node's local TZ) fires at the operator's wall

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -345,6 +345,36 @@ if [ "$MAIN_AGENT_ID" != "marveen" ]; then
   echo -e "  ${DIM}Ügynök belső azonosító: ${MAIN_AGENT_ID}${NC}"
 fi
 
+# Product / system brand. Separate from BOT_NAME (the main agent's display
+# name): an operator may want the product called one thing and the agent
+# another. Defaults to BOT_NAME, so an operator who just presses Enter gets
+# today's behaviour with no brand divergence.
+read -p "  Mi a termék/márka neve? [${BOT_NAME}]: " BRAND_NAME
+BRAND_NAME=${BRAND_NAME:-"$BOT_NAME"}
+
+# Slug for service labels (launchd) derived from BRAND_NAME with the SAME NFKD
+# rule as MAIN_AGENT_ID. DEFAULT-SAFE: when BRAND_NAME equals BOT_NAME (the
+# default), this slug equals MAIN_AGENT_ID, so the launchd labels below are
+# byte-identical to a brand-unaware install. Only an operator who types a
+# DIFFERENT brand gets brand-based labels -- in-place upgrades that keep the
+# default are untouched.
+BRAND_SLUG=$(python3 - "$BRAND_NAME" <<'PYEOF'
+import sys, unicodedata, re
+s = sys.argv[1].strip()
+s = unicodedata.normalize('NFKD', s).encode('ASCII', 'ignore').decode()
+s = re.sub(r'[^a-zA-Z0-9]+', '-', s).strip('-').lower()
+print(s or 'marveen')
+PYEOF
+)
+# The id used for launchd service labels: brand slug when the operator chose a
+# brand distinct from the agent id, otherwise the agent id (unchanged default).
+if [ "$BRAND_SLUG" != "$MAIN_AGENT_ID" ]; then
+  SERVICE_ID="$BRAND_SLUG"
+  echo -e "  ${DIM}Szolgáltatás-azonosító (launchd): ${SERVICE_ID}${NC}"
+else
+  SERVICE_ID="$MAIN_AGENT_ID"
+fi
+
 # Step 5: Install dependencies
 INSTALL_STEP="npm-install"
 echo ""
@@ -374,7 +404,9 @@ echo -e "${BOLD}[6/7] Konfiguráció létrehozása...${NC}"
 CHANNEL_PROVIDER=${CHANNEL_PROVIDER}
 OWNER_NAME=${OWNER_NAME}
 BOT_NAME=${BOT_NAME}
+BRAND_NAME=${BRAND_NAME}
 MAIN_AGENT_ID=${MAIN_AGENT_ID}
+SERVICE_ID=${SERVICE_ID}
 ENVEOF
 )
 # Append provider-specific tokens
@@ -679,8 +711,11 @@ PLIST_DIR="$HOME/Library/LaunchAgents"
 mkdir -p "$PLIST_DIR"
 
 NODE_PATH="$(which node)"
-DASHBOARD_PLIST="com.${MAIN_AGENT_ID}.dashboard"
-CHANNELS_PLIST="com.${MAIN_AGENT_ID}.channels"
+# Launchd labels key off SERVICE_ID. SERVICE_ID == MAIN_AGENT_ID for a
+# brand-unaware (default) install, so these labels are unchanged unless the
+# operator picked a distinct brand above.
+DASHBOARD_PLIST="com.${SERVICE_ID}.dashboard"
+CHANNELS_PLIST="com.${SERVICE_ID}.channels"
 
 # Dashboard service
 cat > "$PLIST_DIR/${DASHBOARD_PLIST}.plist" << PLISTEOF

--- a/src/__tests__/configurable-brand.test.ts
+++ b/src/__tests__/configurable-brand.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest'
+import { resolveBrandName, resolveServiceId, brandSlug } from '../config.js'
+import {
+  substituteTemplatePlaceholders,
+  type TemplateIdentity,
+} from '../web/agent-scaffold.js'
+import {
+  channelsSessionName,
+  channelsLaunchdLabel,
+  channelsPlistPath,
+} from '../web/main-agent.js'
+import { buildMarveenIdentityCore } from '../web/routes/marveen.js'
+
+// This suite proves the configurable-brand feature works under a NON-"marveen"
+// identity: it sets BRAND_NAME / BOT_NAME / MAIN_AGENT_ID / OWNER_NAME to
+// generic placeholder values and asserts that the identity payload, template
+// substitution, main-agent detection, launchd label derivation, and the
+// brand-population fallback all resolve from those values with NO literal
+// "marveen"/"Marveen" leaking through. The DEFAULT (Marveen) is asserted
+// separately so the feature is also confirmed zero-change for existing installs.
+//
+// Generic, non-sensitive placeholders only.
+const BRAND = 'AcmeAI'
+const AGENT_DISPLAY = 'MyAssistant'
+const AGENT_ID = 'myassistant'
+const OWNER = 'Operator'
+
+// Anything that still hardcodes the product brand would surface as one of these
+// literals in a value derived from a non-marveen identity.
+const MARVEEN_RX = /marveen/i
+
+function assertNoMarveen(value: string, label: string): void {
+  expect(value, `${label} leaked a literal brand: ${value}`).not.toMatch(MARVEEN_RX)
+}
+
+describe('BRAND_NAME / BOT_NAME separation', () => {
+  it('defaults BRAND_NAME to BOT_NAME when the env var is unset/empty (default-safe)', () => {
+    expect(resolveBrandName(undefined, 'Marveen')).toBe('Marveen')
+    expect(resolveBrandName('', 'Marveen')).toBe('Marveen')
+    expect(resolveBrandName('   ', 'Marveen')).toBe('Marveen')
+    // The product brand can differ from the agent display name.
+    expect(resolveBrandName(undefined, AGENT_DISPLAY)).toBe(AGENT_DISPLAY)
+  })
+
+  it('uses an explicit BRAND_NAME independently of BOT_NAME', () => {
+    expect(resolveBrandName(BRAND, AGENT_DISPLAY)).toBe(BRAND)
+    expect(resolveBrandName(BRAND, AGENT_DISPLAY)).not.toBe(AGENT_DISPLAY)
+  })
+})
+
+describe('brandSlug derivation (mirrors the installer NFKD rule)', () => {
+  it('slugs the default brand back to "marveen" so labels are unchanged by default', () => {
+    expect(brandSlug('Marveen')).toBe('marveen')
+  })
+
+  it('derives an ASCII slug for a non-marveen brand', () => {
+    expect(brandSlug(BRAND)).toBe('acmeai')
+    expect(brandSlug(AGENT_DISPLAY)).toBe('myassistant')
+    expect(brandSlug('My Assistant')).toBe('my-assistant')
+    expect(brandSlug('Acme-AI v2!')).toBe('acme-ai-v2')
+  })
+
+  it('folds accented brands to ASCII (no non-marveen unicode leak)', () => {
+    // Generic accented example -- exercises the NFKD path without a real name.
+    expect(brandSlug('Éxãmple Brand')).toBe('example-brand')
+  })
+
+  it('falls back to "marveen" for an empty/blank brand', () => {
+    expect(brandSlug('')).toBe('marveen')
+    expect(brandSlug('   ')).toBe('marveen')
+    expect(brandSlug('!!!')).toBe('marveen')
+  })
+})
+
+describe('resolveServiceId (launchd/systemd service id)', () => {
+  it('equals MAIN_AGENT_ID for the default brand (default-safe labels)', () => {
+    // Default brand slug == agent id -> same service id -> identical labels.
+    expect(resolveServiceId('marveen', 'marveen')).toBe('marveen')
+  })
+
+  it('uses the brand slug for a distinct non-marveen brand', () => {
+    expect(resolveServiceId('acmeai', AGENT_ID)).toBe('acmeai')
+    expect(resolveServiceId('acmeai', AGENT_ID)).not.toBe(AGENT_ID)
+  })
+
+  it('falls back to the agent id when no distinct brand slug is given', () => {
+    expect(resolveServiceId('', AGENT_ID)).toBe(AGENT_ID)
+    expect(resolveServiceId(AGENT_ID, AGENT_ID)).toBe(AGENT_ID)
+  })
+})
+
+describe('launchd / channels label derivation for a non-marveen identity', () => {
+  it('builds the tmux channels session from the agent id', () => {
+    expect(channelsSessionName(AGENT_ID)).toBe('myassistant-channels')
+    assertNoMarveen(channelsSessionName(AGENT_ID), 'channelsSessionName')
+  })
+
+  it('builds the launchd label + plist path from the service id', () => {
+    const serviceId = resolveServiceId(brandSlug(BRAND), AGENT_ID)
+    expect(serviceId).toBe('acmeai')
+    expect(channelsLaunchdLabel(serviceId)).toBe('com.acmeai.channels')
+    expect(channelsPlistPath(serviceId)).toMatch(/\/com\.acmeai\.channels\.plist$/)
+    assertNoMarveen(channelsLaunchdLabel(serviceId), 'channelsLaunchdLabel')
+    assertNoMarveen(channelsPlistPath(serviceId), 'channelsPlistPath')
+  })
+
+  it('keeps the default label as com.marveen.channels (zero change for existing installs)', () => {
+    const serviceId = resolveServiceId(brandSlug('Marveen'), 'marveen')
+    expect(channelsLaunchdLabel(serviceId)).toBe('com.marveen.channels')
+  })
+})
+
+describe('identity payload core resolves from config, not the literal', () => {
+  it('maps display name / brand / canonical id for a non-marveen identity', () => {
+    const brandName = resolveBrandName(BRAND, AGENT_DISPLAY)
+    const core = buildMarveenIdentityCore(AGENT_DISPLAY, brandName, AGENT_ID)
+    expect(core).toEqual({
+      name: AGENT_DISPLAY,
+      brandName: BRAND,
+      agentId: AGENT_ID,
+      autoRestartId: AGENT_ID,
+      role: 'main',
+    })
+    for (const [k, v] of Object.entries(core)) assertNoMarveen(String(v), `identity.${k}`)
+  })
+
+  it('falls brandName back to the display name when no separate brand is set', () => {
+    const brandName = resolveBrandName(undefined, AGENT_DISPLAY)
+    const core = buildMarveenIdentityCore(AGENT_DISPLAY, brandName, AGENT_ID)
+    expect(core.brandName).toBe(AGENT_DISPLAY)
+  })
+})
+
+describe('template substitution for a non-marveen identity', () => {
+  const identity: TemplateIdentity = {
+    projectRoot: '/opt/myassistant',
+    mainAgentId: AGENT_ID,
+    botName: AGENT_DISPLAY,
+    ownerName: OWNER,
+    webPort: 3420,
+  }
+
+  it('substitutes every identity placeholder with the non-marveen values', () => {
+    const tpl = [
+      'root={{PROJECT_ROOT}}',
+      'install={{INSTALL_DIR}}',
+      'agent={{MAIN_AGENT_ID}}',
+      'bot={{BOT_NAME}}',
+      'owner={{OWNER_NAME}}',
+      'port={{WEB_PORT}}',
+    ].join('\n')
+    const out = substituteTemplatePlaceholders(tpl, identity)
+    // No placeholder survives.
+    expect([...out.matchAll(/\{\{[A-Z_]+\}\}/g)].map(m => m[0])).toEqual([])
+    // Values are the injected non-marveen identity.
+    expect(out).toContain('agent=myassistant')
+    expect(out).toContain('bot=MyAssistant')
+    expect(out).toContain('owner=Operator')
+    expect(out).toContain('root=/opt/myassistant')
+    // No literal brand leaked through the substitution.
+    assertNoMarveen(out, 'substituteTemplatePlaceholders output')
+  })
+
+  it('does not invent a marveen value when the template has no brand reference', () => {
+    expect(substituteTemplatePlaceholders('hello {{OWNER_NAME}}', identity)).toBe('hello Operator')
+  })
+})
+
+describe('brand-population fallback contract (initSidebarBrand)', () => {
+  // The client picks `brandName` and only falls back to `name` (and finally the
+  // HTML default) when the backend omits it. Replicating the exact rule guards
+  // against a regression where the chrome stops honoring brandName.
+  const pickBrand = (m: { brandName?: string; name?: string }) => m.brandName || m.name
+
+  it('prefers brandName when present (non-marveen)', () => {
+    expect(pickBrand({ brandName: BRAND, name: AGENT_DISPLAY })).toBe(BRAND)
+  })
+
+  it('falls back to name when brandName is absent', () => {
+    expect(pickBrand({ name: AGENT_DISPLAY })).toBe(AGENT_DISPLAY)
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,11 +23,62 @@ export const SLACK_CHANNEL_ID = env['SLACK_CHANNEL_ID'] ?? ''
 export const OWNER_NAME = env['OWNER_NAME'] ?? 'Szabolcs'
 export const BOT_NAME = env['BOT_NAME'] ?? 'Marveen'
 
+// Product / system brand shown in the dashboard chrome (browser tab title,
+// mobile topbar, sidebar, updates page). Kept SEPARATE from BOT_NAME so an
+// operator can name the product one thing (BRAND_NAME) and the main agent
+// another (BOT_NAME, the agent's display name). Defaults to BOT_NAME -- which
+// itself defaults to 'Marveen' -- so an install that sets neither, or only
+// BOT_NAME, behaves exactly as before.
+export const BRAND_NAME = env['BRAND_NAME'] ?? BOT_NAME
+
+// Pure resolution rule for BRAND_NAME, so the default (brandEnv unset =>
+// botName) is provable without a live .env. brandEnv is the raw env value
+// (undefined / empty when unset). Mirrors the `env['BRAND_NAME'] ?? BOT_NAME`
+// above plus an empty-string guard (an empty .env line should not blank the
+// brand).
+export function resolveBrandName(brandEnv: string | undefined, botName: string): string {
+  const b = (brandEnv ?? '').trim()
+  return b || botName
+}
+
+// Pure derivation of the OS service id from a brand slug and the agent id:
+// the brand slug names the service units when it differs from the agent id,
+// otherwise the agent id is used. Mirrors the installer's SERVICE_ID choice so
+// the default (brandSlug == mainAgentId) is provably label-identical.
+export function resolveServiceId(brandSlug: string, mainAgentId: string): string {
+  const s = (brandSlug ?? '').trim()
+  return s && s !== mainAgentId ? s : mainAgentId
+}
+
+// ASCII slug used for agent/service ids, mirroring the install scripts'
+// Python NFKD rule: NFKD-normalize, drop non-ASCII, collapse runs of non-
+// alphanumerics to a single dash, trim dashes, lowercase, and fall back to
+// 'marveen' when the result is empty. Exported so the launchd/systemd label
+// derivation is provable for any brand string in one place.
+export function brandSlug(raw: string): string {
+  const ascii = (raw ?? '')
+    .normalize('NFKD')
+    // strip combining marks left by NFKD, then any remaining non-ASCII
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^\x00-\x7f]/g, '')
+  const slug = ascii.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-+|-+$/g, '').toLowerCase()
+  return slug || 'marveen'
+}
+
 // Canonical identifier for the main agent in the DB, tmux sessions, plist
 // labels, API routing, etc. The installer derives this from BOT_NAME
 // (NFKD + ASCII + lowercase dashes). Older installs without this env var
 // fall back to "marveen" so nothing breaks when upgrading in place.
 export const MAIN_AGENT_ID = env['MAIN_AGENT_ID'] ?? 'marveen'
+
+// Identifier the OS service manager uses for the main agent's units (launchd
+// label com.<id>.channels / com.<id>.dashboard, systemd <id>-channels, etc.).
+// The installer derives this from BRAND_NAME when the operator picks a brand
+// distinct from the agent id; otherwise it equals MAIN_AGENT_ID. Defaults to
+// MAIN_AGENT_ID here, so an install without SERVICE_ID in its .env (every
+// existing install) keeps byte-identical service labels and the recovery path
+// (launchctl unload/load, kickstart) still targets the right unit.
+export const SERVICE_ID = env['SERVICE_ID'] ?? MAIN_AGENT_ID
 
 export const WEB_PORT = parseInt(env['WEB_PORT'] ?? '3420', 10)
 

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -8,18 +8,41 @@ import { atomicWriteFileSync } from './atomic-write.js'
 import { agentDir } from './agent-config.js'
 import { resolveProfilePlaceholders, type ProfileTemplate } from './profiles.js'
 
-export function resolveTemplatePlaceholders(content: string): string {
-  // Identity placeholders, kept in sync with the install scripts'
-  // (install-macos.sh / install-linux.sh) sed substitutions, so a shipped
-  // template never seeds a foreign absolute path or name into a user's tree.
-  // {{INSTALL_DIR}} and {{PROJECT_ROOT}} both denote this install location.
+// Identity values the template substitution injects. Pulled out so the
+// substitution is a pure, parameterizable function (the runtime binds these to
+// config; tests can prove a non-default identity substitutes with no literal
+// brand leak).
+export interface TemplateIdentity {
+  projectRoot: string
+  mainAgentId: string
+  botName: string
+  ownerName: string
+  webPort: number | string
+}
+
+// Pure substitution of the identity placeholders into a template body. Kept in
+// sync with the install scripts' (install-macos.sh / install-linux.sh) sed
+// substitutions, so a shipped template never seeds a foreign absolute path or
+// name into a user's tree. {{INSTALL_DIR}} and {{PROJECT_ROOT}} both denote the
+// install location.
+export function substituteTemplatePlaceholders(content: string, id: TemplateIdentity): string {
   return content
-    .replaceAll('{{PROJECT_ROOT}}', PROJECT_ROOT)
-    .replaceAll('{{INSTALL_DIR}}', PROJECT_ROOT)
-    .replaceAll('{{MAIN_AGENT_ID}}', MAIN_AGENT_ID)
-    .replaceAll('{{BOT_NAME}}', BOT_NAME)
-    .replaceAll('{{OWNER_NAME}}', OWNER_NAME)
-    .replaceAll('{{WEB_PORT}}', String(WEB_PORT))
+    .replaceAll('{{PROJECT_ROOT}}', id.projectRoot)
+    .replaceAll('{{INSTALL_DIR}}', id.projectRoot)
+    .replaceAll('{{MAIN_AGENT_ID}}', id.mainAgentId)
+    .replaceAll('{{BOT_NAME}}', id.botName)
+    .replaceAll('{{OWNER_NAME}}', id.ownerName)
+    .replaceAll('{{WEB_PORT}}', String(id.webPort))
+}
+
+export function resolveTemplatePlaceholders(content: string): string {
+  return substituteTemplatePlaceholders(content, {
+    projectRoot: PROJECT_ROOT,
+    mainAgentId: MAIN_AGENT_ID,
+    botName: BOT_NAME,
+    ownerName: OWNER_NAME,
+    webPort: WEB_PORT,
+  })
 }
 
 // Idempotent migration: every agent's settings.json should carry the

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import { logger } from '../logger.js'
-import { MAIN_AGENT_ID } from '../config.js'
+import { MAIN_AGENT_ID, SERVICE_ID } from '../config.js'
 import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
 import {
   agentRunState,
@@ -68,7 +68,9 @@ function performRestart(name: string, cfg: AutoRestartConfig): void {
     // starts a fresh conversation, so 'continue' is not applicable here -- a
     // kickstart is always a fresh restart. KeepAlive brings it straight back.
     const uid = typeof process.getuid === 'function' ? process.getuid() : ''
-    execFileSync('/bin/launchctl', ['kickstart', '-k', `gui/${uid}/com.${MAIN_AGENT_ID}.channels`], { timeout: 10_000 })
+    // Label keys off SERVICE_ID (defaults to MAIN_AGENT_ID) so it matches the
+    // launchd label the installer wrote.
+    execFileSync('/bin/launchctl', ['kickstart', '-k', `gui/${uid}/com.${SERVICE_ID}.channels`], { timeout: 10_000 })
   } else {
     restartAgentProcess(name, { fresh: cfg.mode === 'fresh' })
   }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { execSync, execFileSync, spawn } from 'node:child_process'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
-import { MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT, RESPAWN_ENABLED } from '../config.js'
+import { MAIN_AGENT_ID, SERVICE_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT, RESPAWN_ENABLED } from '../config.js'
 import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
 import {
   agentHasChannel,
@@ -570,7 +570,7 @@ export function hardRestartMarveenChannels(): { ok: boolean; error?: string } {
       execFileSync('/bin/launchctl', ['unload', MAIN_CHANNELS_PLIST], { timeout: 5000 })
       execFileSync('/bin/sleep', ['2'], { timeout: 4000 })
       execFileSync('/bin/launchctl', ['load', MAIN_CHANNELS_PLIST], { timeout: 5000 })
-      logger.warn(`Hard restart: launchctl reload of com.${MAIN_AGENT_ID}.channels`)
+      logger.warn(`Hard restart: launchctl reload of com.${SERVICE_ID}.channels`)
       marveenLastHardRestart = Date.now()
       writeRespawnStamp() // coordinate with the systemd-timer watchdog
       return { ok: true }
@@ -847,8 +847,8 @@ function handleMarveenDown(): void {
     marveenDownState.lastAlertAt = now
     logger.error({ provider: providerLabel }, 'Marveen channel plugin still down after hard restart -- giving up auto-recovery')
     const serviceCmd = process.platform === 'linux'
-      ? `\`systemctl --user status ${MAIN_AGENT_ID}-channels\``
-      : `\`launchctl list | grep ${MAIN_AGENT_ID}\``
+      ? `\`systemctl --user status ${SERVICE_ID}-channels\``
+      : `\`launchctl list | grep ${SERVICE_ID}\``
     // Issue #189: a plain `tmux attach -t ...` may itself fail with "Permission
     // denied" when the operator is running it from another tmux session. Prefix
     // with `unset TMUX` so the hint works in both nested and non-nested cases.

--- a/src/web/llm-breakdown.ts
+++ b/src/web/llm-breakdown.ts
@@ -1,6 +1,7 @@
 import { logger } from '../logger.js'
 import { listAgentNames } from './agent-config.js'
 import { runAgent } from '../agent.js'
+import { OWNER_NAME, BOT_NAME } from '../config.js'
 
 export interface SubtaskSuggestion {
   title: string
@@ -46,7 +47,10 @@ function buildUserPrompt(title: string, description: string | null, agents: stri
 
 function getValidAssignees(): Set<string> {
   const agents = listAgentNames()
-  return new Set(['Szabolcs', 'Marveen', ...agents])
+  // OWNER_NAME (the operator) and BOT_NAME (the main agent display name) are
+  // valid assignees alongside the sub-agents. Derive both from config so a
+  // non-default install does not drop its own owner / main agent from the set.
+  return new Set([OWNER_NAME, BOT_NAME, ...agents])
 }
 
 // Strip a leading/trailing ```json ... ``` fence if the model added one despite

--- a/src/web/main-agent.ts
+++ b/src/web/main-agent.ts
@@ -1,22 +1,41 @@
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { MAIN_AGENT_ID } from '../config.js'
+import { MAIN_AGENT_ID, SERVICE_ID } from '../config.js'
+
+// The channels tmux session name for a given main-agent id. The main agent
+// runs in a long-lived `${id}-channels` tmux session (managed by launchd /
+// systemd via channels.sh), not the `agent-${name}` template that sub-agents
+// use. Pure + parameterized so the derivation is provable for any id, not just
+// the default.
+export function channelsSessionName(mainAgentId: string): string {
+  return `${mainAgentId}-channels`
+}
+
+// The launchd label (`com.<serviceId>.channels`) and plist path for the
+// channels job. The OS service id is SEPARATE from the agent id: SERVICE_ID
+// (derived by the installer from BRAND_NAME) names the service units, while
+// MAIN_AGENT_ID names the tmux session inside. Pure + parameterized so the
+// label derivation is testable for any brand.
+export function channelsLaunchdLabel(serviceId: string): string {
+  return `com.${serviceId}.channels`
+}
+export function channelsPlistPath(serviceId: string): string {
+  return join(homedir(), 'Library', 'LaunchAgents', `${channelsLaunchdLabel(serviceId)}.plist`)
+}
 
 // The main agent (Marveen) runs in a long-lived `${id}-channels` tmux
 // session managed by launchd, not the `agent-${name}` template that
 // sub-agents use. Anything that needs to address it has to use this name
 // rather than agentSessionName().
-export const MAIN_CHANNELS_SESSION = `${MAIN_AGENT_ID}-channels`
+export const MAIN_CHANNELS_SESSION = channelsSessionName(MAIN_AGENT_ID)
 
 // The launchd plist that owns MAIN_CHANNELS_SESSION. Used by the recovery
 // path (telegram plugin monitor) to bounce the channels session via
-// launchctl when softer reconnect attempts fail.
-export const MAIN_CHANNELS_PLIST = join(
-  homedir(),
-  'Library',
-  'LaunchAgents',
-  `com.${MAIN_AGENT_ID}.channels.plist`
-)
+// launchctl when softer reconnect attempts fail. The label keys off SERVICE_ID
+// (the value the installer wrote into the plist filename), which defaults to
+// MAIN_AGENT_ID, so an install without SERVICE_ID in its .env targets the same
+// plist as before.
+export const MAIN_CHANNELS_PLIST = channelsPlistPath(SERVICE_ID)
 
 // Whether an agent's process lifecycle (start/restart) must go through the
 // channels-session helper (systemd/launchd via hardRestartMarveenChannels)

--- a/src/web/routes/ideas.ts
+++ b/src/web/routes/ideas.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { MAIN_AGENT_ID } from '../../config.js'
 import { listIdeas, createIdea, updateIdea, deleteIdea, listIdeaCategories, createKanbanCard, getDb } from '../../db.js'
 import { generateBreakdown } from '../llm-breakdown.js'
 import { logger } from '../../logger.js'
@@ -89,7 +90,7 @@ export async function tryHandleIdeas(ctx: RouteContext): Promise<boolean> {
       description: idea.description ?? '',
       status,
       priority: 'normal',
-      assignee: 'marveen',
+      assignee: MAIN_AGENT_ID,
       project: 'Fejlesztési ötletek',
     })
     updateIdea(ideaId, { status: 'kanban', kanban_id: cardId })
@@ -136,7 +137,7 @@ export async function tryHandleIdeas(ctx: RouteContext): Promise<boolean> {
       description: idea.description ?? '',
       status: 'planned',
       priority: 'normal',
-      assignee: 'marveen',
+      assignee: MAIN_AGENT_ID,
       project: 'Fejlesztési ötletek',
     })
     const childIds: string[] = []
@@ -149,7 +150,7 @@ export async function tryHandleIdeas(ctx: RouteContext): Promise<boolean> {
         description: (st.description ?? '').slice(0, 500),
         status: 'planned',
         priority: (st.priority && VALID_PRIORITIES.has(st.priority) ? st.priority : 'normal') as 'low' | 'normal' | 'high' | 'urgent',
-        assignee: st.assignee || 'marveen',
+        assignee: st.assignee || MAIN_AGENT_ID,
         project: 'Fejlesztési ötletek',
         parent_id: parentId,
       })

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -1,6 +1,6 @@
 import { existsSync, unlinkSync, copyFileSync, writeFileSync } from 'node:fs'
 import { join, extname } from 'node:path'
-import { PROJECT_ROOT, OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, CHANNEL_PROVIDER } from '../../config.js'
+import { PROJECT_ROOT, OWNER_NAME, BOT_NAME, BRAND_NAME, MAIN_AGENT_ID, CHANNEL_PROVIDER } from '../../config.js'
 import { readMarveenTelegramConfig, readMarveenDiscordConfig, readMarveenSlackConfig, sendMarveenAvatarChange } from '../telegram.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
 import { readFileOr } from '../agent-config.js'
@@ -13,6 +13,31 @@ import type { RouteContext } from './types.js'
 
 function getActiveMarveenModel(): string {
   return readActiveModelFromProjectDir(PROJECT_ROOT) ?? 'unknown'
+}
+
+// Pure identity-core of the /api/marveen payload: the brand-relevant fields the
+// dashboard chrome + agent routing depend on. Extracted so the mapping (display
+// name -> name, product brand -> brandName, canonical id -> agentId) is provable
+// for any non-default identity, independent of the route's file I/O.
+export interface MarveenIdentityCore {
+  name: string
+  brandName: string
+  agentId: string
+  autoRestartId: string
+  role: 'main'
+}
+export function buildMarveenIdentityCore(
+  botName: string,
+  brandName: string,
+  mainAgentId: string,
+): MarveenIdentityCore {
+  return {
+    name: botName,
+    brandName,
+    agentId: mainAgentId,
+    autoRestartId: mainAgentId,
+    role: 'main',
+  }
 }
 
 export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promise<boolean> {
@@ -31,26 +56,27 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
     const tg = readMarveenTelegramConfig()
     const dc = readMarveenDiscordConfig()
     const sl = readMarveenSlackConfig()
+    // Brand-relevant identity core. `name` = main agent display name (BOT_NAME),
+    // `brandName` = product brand for the dashboard chrome (defaults to BOT_NAME;
+    // the client falls back to its own HTML default "Marveen" if absent on a
+    // legacy backend), `agentId` = canonical MAIN_AGENT_ID so the dashboard can
+    // hit /api/agents/<id>/skills for the main agent.
+    const idCore = buildMarveenIdentityCore(BOT_NAME, BRAND_NAME, MAIN_AGENT_ID)
     json(res, {
-      name: BOT_NAME,
-      // Canonical agent id (MAIN_AGENT_ID, e.g. "gorcsevivan") so the dashboard
-      // can hit /api/agents/<id>/skills for the main agent -- the display name
-      // (BOT_NAME) is not a valid agent-dir id.
-      agentId: MAIN_AGENT_ID,
+      ...idCore,
       description,
       model: getActiveMarveenModel(),
       tmuxSession: MAIN_CHANNELS_SESSION,
       running: true,
       // Auto-restart applies to the main channels session too; key it by the
-      // orchestrator id (autoRestartId) so the UI PUTs to the right store entry.
+      // orchestrator id (autoRestartId, part of idCore) so the UI PUTs to the
+      // right store entry.
       autoRestart: readAutoRestartConfig(MAIN_AGENT_ID),
-      autoRestartId: MAIN_AGENT_ID,
       contextTokens: readContextTokensFromProjectDir(PROJECT_ROOT),
       hasTelegram: tg.hasTelegram,
       hasDiscord: dc.hasDiscord,
       hasSlack: sl.hasSlack,
       telegramBotUsername: tg.botUsername,
-      role: 'main',
       personality: soulSection,
       claudeMd,
       soulMd,

--- a/web/app.js
+++ b/web/app.js
@@ -8027,7 +8027,12 @@ async function loadOverview() {
   }
 }
 
-// Brand mark: use main agent's avatar if available
+// Brand mark + product-brand chrome: pull the configured brand from
+// /api/marveen and apply it to the dashboard chrome (tab title, mobile topbar,
+// sidebar name, updates subtitle). brandName is the product/system name and is
+// distinct from the main agent's display name; the backend defaults brandName to
+// BOT_NAME, so a brand-unaware install keeps showing the agent name. If the
+// field is absent (legacy backend) the existing HTML default text is kept.
 async function initSidebarBrand() {
   try {
     const img = document.createElement('img')
@@ -8039,8 +8044,16 @@ async function initSidebarBrand() {
     const res = await fetch('/api/marveen')
     if (res.ok) {
       const m = await res.json()
-      const name = document.getElementById('sidebarBrandName')
-      if (name && m.name) name.textContent = m.name
+      const brand = m.brandName || m.name
+      if (brand) {
+        document.title = brand
+        const topbar = document.getElementById('mobileTopbarTitle')
+        if (topbar) topbar.textContent = brand
+        const name = document.getElementById('sidebarBrandName')
+        if (name) name.textContent = brand
+        const subtitle = document.getElementById('updatesSubtitle')
+        if (subtitle) subtitle.textContent = `${brand} verzió ellenőrzés`
+      }
     }
   } catch {}
 }

--- a/web/index.html
+++ b/web/index.html
@@ -20,7 +20,7 @@
     <button class="mobile-menu-btn" id="mobileMenuBtn" aria-label="Menü" aria-expanded="false">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
     </button>
-    <span class="mobile-topbar-title">Marveen</span>
+    <span class="mobile-topbar-title" id="mobileTopbarTitle">Marveen</span>
   </div>
   <div class="sidebar-backdrop" id="sidebarBackdrop"></div>
   <aside class="sidebar">


### PR DESCRIPTION
## Why this matters

The product brand is already partly configurable at runtime: `BOT_NAME` / `MAIN_AGENT_ID` and the sidebar name flow from config through `/api/marveen` into the dashboard, and the installers derive service labels from the agent id. But a few things still bypass this and hardcode "Marveen", so a personalized self-host install still shows "Marveen" in places. This PR finishes that existing branding path so the product name is fully configurable, without changing anything for existing installs.

## What changes

- **`BRAND_NAME`** (new, optional; defaults to `BOT_NAME`) -- the product/system name (browser title, mobile topbar, sidebar, updates subtitle).
- **`SERVICE_ID`** (new, optional; defaults to `MAIN_AGENT_ID`) -- the launchd/systemd service id. A shared helper makes the installer and the runtime recovery path derive the exact same label, so they can never desync.
- `/api/marveen` now also returns `brandName`; `initSidebarBrand()` populates the 4 static UI strings from it (HTML keeps "Marveen" as the pre-JS fallback).
- Installers (macOS + Linux) accept an optional brand at setup and name units accordingly; README + `.env.example` document the new keys with generic placeholders.
- Two latent bugs fixed along the way: an ideas->kanban promotion and the valid-assignee set both hardcoded the default agent/owner literals instead of reading config, so they dropped the real configured names. Now they resolve from `MAIN_AGENT_ID` / `OWNER_NAME` / `BOT_NAME`.

## Scope / compatibility

- **Default behavior is byte-identical.** With no new env vars set, `BRAND_NAME` resolves to `BOT_NAME` (default "Marveen") and `SERVICE_ID` to `MAIN_AGENT_ID` (default "marveen"), producing the same labels, API payload, templates and UI as before. In-place upgrades are unaffected.
- `/api/marveen` is additive (only a new `brandName` field); `initSidebarBrand()` degrades gracefully against an older backend (`brandName || name`, falls back to the HTML default).
- No new required config; internal identifiers (route paths, keychain entry, worker session/dirs, marketplace id) are intentionally left untouched.

## Who benefits

- Self-hosters who want their own name instead of "Marveen" in the browser tab and chrome.
- Teams / multi-environment setups that run several installs under distinct names.
- Maintainer + project: people who currently fork just to rebrand can configure instead, so fewer divergent forks and less drift from upstream.

## Test plan

- New `src/__tests__/configurable-brand.test.ts` (18 tests): sets BRAND_NAME / BOT_NAME / MAIN_AGENT_ID / OWNER_NAME to non-default generic values and asserts the identity payload, template substitution, main-agent + service-label derivation, and brand population all resolve correctly with no hardcoded-literal leak; also asserts the default maps back to the current "marveen" labels. The slug rule is verified byte-for-byte against the installers' derivation.
- `npm run typecheck`: 0 errors. `npx vitest run`: full suite green (+18 new).
