### PR TITLE
feat(token-monitor): valós claude.ai usage-sávok (session + heti) CDP scraperrel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,8 @@ scripts/support-mail/no-support-reply.html
 # Python bytecode cache
 __pycache__/
 *.pyc
+
+# claude.ai usage scraper: persistent browser profile and usage cache
+# These contain session cookies and real-time usage data — never commit.
+store/claude-usage.json
+claude-usage-profile/

--- a/docs/en/token-usage.md
+++ b/docs/en/token-usage.md
@@ -91,11 +91,43 @@ CREATE TABLE token_usage_cursors (
 
 ---
 
+## claude.ai usage scraper
+
+The dashboard fetches **real usage percentages** from claude.ai/settings/usage via a Playwright-based headless scraper (`src/web/claude-usage-scraper.ts`). This shows the same session and weekly percentages you see on the claude.ai settings page — not local token estimates.
+
+### Setup (one-time)
+
+1. Install the Playwright Chromium browser binary (not included in the npm package):
+   ```bash
+   npx playwright install chromium
+   ```
+
+2. On first use, run a headed scrape so you can log in to claude.ai:
+   ```bash
+   CLAUDE_USAGE_HEADED=1 node -e "import('./dist/web/claude-usage-scraper.js').then(m => m.scrapeClaudeUsage(true))"
+   ```
+   A browser window opens. Sign in to claude.ai. The session is saved to `~/.claude/claude-usage-profile/` (gitignored) and all future scrapes run headless.
+
+### How it works
+
+- The scraper runs **every 15 minutes** as a background poller inside `src/web.ts` and on startup (10-second delay).
+- Results are cached in `store/claude-usage.json` (gitignored, 14-min TTL).
+- The dashboard `/api/claude-usage` endpoint serves the cached data; `/api/claude-usage/refresh` triggers a one-off background rescrape.
+- If not logged in (headless), the scraper returns `null` and the dashboard shows "data not available."
+
+### Security
+
+- No credentials, cookies, or session tokens are written to code, logs, or git.
+- The persistent Playwright profile lives at `~/.claude/claude-usage-profile/` (outside the project root, gitignored by pattern).
+- `store/claude-usage.json` is also gitignored.
+
+---
+
 ## Dashboard UI (`web/app.js` + `web/index.html`)
 
 - **Summary cards**: per-agent total consumption (input/output/cache), call count, last activity
 - **Timeline chart**: Canvas-based bar chart with dynamic bucket size (1h period = 5-min buckets, otherwise 1-hour)
-- **Usage limit progress bars**: below the Timeline, two progress bars — "Current session" (tokens in the last 5-hour window / configured limit) and "Weekly limit / all models" (7-day total / configured limit). Top-right shows a countdown to when the current 5h window resets. Limits are user-configurable by clicking the value; stored in `localStorage` (`tu_limit_5h`, `tu_limit_weekly`). Defaults: 5 M / 100 M tokens.
+- **Usage limit progress bars**: below the Timeline, two progress bars showing **real claude.ai percentages** — "Current session" and "Weekly / all models". Countdowns show when each resets. Data comes from the claude.ai scraper above; if unavailable, the card shows an "adat nem elérhető" state with setup instructions.
 - **Sidebar widget**: the same progress bar pair in compact form at the bottom of the navigation sidebar (appears once data is loaded), with a countdown refreshed every 10 seconds.
 - **Detail table**: individual API calls, time, agent, tool, token breakdown, content preview
 - **Filters**: time period (1h/24h/7d/30d), agent card click

--- a/docs/en/token-usage.md
+++ b/docs/en/token-usage.md
@@ -97,15 +97,16 @@ The dashboard fetches **real usage percentages** from claude.ai/settings/usage b
 
 ### Setup (one-time)
 
-Start Chrome with the remote debugging port enabled. The easiest way on macOS:
+Start Chrome with a **dedicated profile** and the remote debugging port. Chrome 149+ ignores `--remote-debugging-port` on the default profile (security restriction), so a separate `--user-data-dir` is required.
 
 ```bash
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
   --remote-debugging-port=9222 \
-  --profile-directory="Default"
+  --user-data-dir="$HOME/.claude/chrome-cdp-profile" \
+  --no-first-run
 ```
 
-You can leave this running as a background instance. Chrome must be open and logged in to claude.ai for the scraper to work.
+Sign in to claude.ai in the window that opens. The session is stored in `~/.claude/chrome-cdp-profile/` and reused on every subsequent scrape. You can leave this Chrome instance running in the background.
 
 Optional: override the default endpoint with `CLAUDE_USAGE_CDP_URL` (default: `http://127.0.0.1:9222`).
 

--- a/docs/en/token-usage.md
+++ b/docs/en/token-usage.md
@@ -93,33 +93,35 @@ CREATE TABLE token_usage_cursors (
 
 ## claude.ai usage scraper
 
-The dashboard fetches **real usage percentages** from claude.ai/settings/usage via a Playwright-based headless scraper (`src/web/claude-usage-scraper.ts`). This shows the same session and weekly percentages you see on the claude.ai settings page — not local token estimates.
+The dashboard fetches **real usage percentages** from claude.ai/settings/usage by connecting to an already-running Chrome instance via the Chrome DevTools Protocol (CDP). This bypasses bot-detection because we drive the user's own Chrome (already logged in) rather than launching a separate browser.
 
 ### Setup (one-time)
 
-1. Install the Playwright Chromium browser binary (not included in the npm package):
-   ```bash
-   npx playwright install chromium
-   ```
+Start Chrome with the remote debugging port enabled. The easiest way on macOS:
 
-2. On first use, run a headed scrape so you can log in to claude.ai:
-   ```bash
-   CLAUDE_USAGE_HEADED=1 node -e "import('./dist/web/claude-usage-scraper.js').then(m => m.scrapeClaudeUsage(true))"
-   ```
-   A browser window opens. Sign in to claude.ai. The session is saved to `~/.claude/claude-usage-profile/` (gitignored) and all future scrapes run headless.
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --profile-directory="Default"
+```
+
+You can leave this running as a background instance. Chrome must be open and logged in to claude.ai for the scraper to work.
+
+Optional: override the default endpoint with `CLAUDE_USAGE_CDP_URL` (default: `http://127.0.0.1:9222`).
 
 ### How it works
 
-- The scraper runs **every 15 minutes** as a background poller inside `src/web.ts` and on startup (10-second delay).
-- Results are cached in `store/claude-usage.json` (gitignored, 14-min TTL).
-- The dashboard `/api/claude-usage` endpoint serves the cached data; `/api/claude-usage/refresh` triggers a one-off background rescrape.
-- If not logged in (headless), the scraper returns `null` and the dashboard shows "data not available."
+- The scraper connects to Chrome via CDP, finds or opens a tab at `/settings/usage`, waits for the `[role="progressbar"]` elements (this also covers any Cloudflare challenge that may run first), then extracts the two percentages and reset times.
+- It runs **every 15 minutes** as a background poller in `src/web.ts`, plus once at startup (10-second delay).
+- Results are cached in `store/claude-usage.json` (gitignored, 14-min TTL) so a dashboard restart does not trigger an immediate rescrape.
+- `/api/claude-usage` serves cached data; `/api/claude-usage/refresh` triggers a one-off rescrape.
+- If Chrome is not reachable at the CDP endpoint, the scraper logs an info message and returns null — no crash, no error shown to users.
 
 ### Security
 
 - No credentials, cookies, or session tokens are written to code, logs, or git.
-- The persistent Playwright profile lives at `~/.claude/claude-usage-profile/` (outside the project root, gitignored by pattern).
-- `store/claude-usage.json` is also gitignored.
+- The scraper only reads the usage page; it never modifies Chrome's profile.
+- `store/claude-usage.json` is gitignored.
 
 ---
 

--- a/docs/en/token-usage.md
+++ b/docs/en/token-usage.md
@@ -1,0 +1,112 @@
+# Token Usage Monitor
+
+> Raw token consumption tracking per agent, per session, per time period.
+
+---
+
+## What it does / why it matters
+
+Records every Claude Code API call's token usage: input, output, cache read, cache creation. Data is collected from Claude Code JSONL transcripts, stored in SQLite, and visualised on the dashboard as a timeline + detailed table.
+
+Helps understand:
+- Which agent consumes how much
+- When peak periods occur
+- Which tasks are most expensive (kanban correlation)
+- Cache efficiency (cache read vs. creation ratio)
+
+---
+
+## Architecture
+
+### Data collection (`src/web/token-usage.ts`)
+
+1. **Agent discovery**: identifies agents from the `~/.claude/projects/` directory based on directory names (`-agents-NAME` pattern for sub-agents, `-MAIN_AGENT_ID` for the main agent).
+
+2. **JSONL parsing**: recursively traverses project directories (including `subagents/` subdirs) and processes `.jsonl` files. Only considers `assistant` type messages that have a `usage` field.
+
+3. **Cursor tracking**: stores the last processed line and file size per file (`token_usage_cursors` table). Unchanged files are skipped; modified files are continued from the last position.
+
+4. **Deduplication**: `UNIQUE INDEX` on `(agent, session_id, timestamp, input_tokens, output_tokens)` + `INSERT OR IGNORE`. The same record is never stored twice.
+
+### API endpoints (`src/web/routes/token-usage.ts`)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/token-usage/collect` | POST | Collect new token data from JSONL files |
+| `/api/token-usage/summary` | GET | Per-agent aggregated summary |
+| `/api/token-usage/timeline` | GET | Timeline buckets (for charts) |
+| `/api/token-usage` | GET | Detailed records (for table) |
+
+### Query parameters
+
+**Summary** (`/api/token-usage/summary`):
+- `from` / `to`: Unix timestamp (epoch seconds)
+
+**Timeline** (`/api/token-usage/timeline`):
+- `bucket`: Bucket size in minutes (default: 60)
+- `from` / `to`: Unix timestamp
+- `agent`: Filter to one agent
+
+**Details** (`/api/token-usage`):
+- `agent`: Agent filter
+- `from` / `to`: Unix timestamp
+- `limit`: Max rows (default: 100, max: 500)
+- `offset`: For pagination
+- `min_tokens`: Minimum input token filter
+- `q`: Free-text search (agent, tool_name, content_preview, task_title)
+
+### Kanban correlation
+
+The `correlateWithKanban()` function matches token usage to tasks using the `kanban_cards` table. It pairs by assignee and time interval, so the dashboard shows how many tokens each agent spent per task.
+
+---
+
+## DB schema
+
+```sql
+CREATE TABLE token_usage (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,
+  input_tokens INTEGER DEFAULT 0,
+  output_tokens INTEGER DEFAULT 0,
+  cache_read_tokens INTEGER DEFAULT 0,
+  cache_creation_tokens INTEGER DEFAULT 0,
+  content_preview TEXT,
+  tool_name TEXT,
+  task_title TEXT,
+  project TEXT
+);
+
+CREATE UNIQUE INDEX idx_token_usage_dedup
+  ON token_usage(agent, session_id, timestamp, input_tokens, output_tokens);
+
+CREATE TABLE token_usage_cursors (
+  file_path TEXT PRIMARY KEY,
+  last_line INTEGER DEFAULT 0,
+  last_size INTEGER DEFAULT 0
+);
+```
+
+---
+
+## Dashboard UI (`web/app.js` + `web/index.html`)
+
+- **Summary cards**: per-agent total consumption (input/output/cache), call count, last activity
+- **Timeline chart**: Canvas-based bar chart with dynamic bucket size (1h period = 5-min buckets, otherwise 1-hour)
+- **Usage limit progress bars**: below the Timeline, two progress bars — "Current session" (tokens in the last 5-hour window / configured limit) and "Weekly limit / all models" (7-day total / configured limit). Top-right shows a countdown to when the current 5h window resets. Limits are user-configurable by clicking the value; stored in `localStorage` (`tu_limit_5h`, `tu_limit_weekly`). Defaults: 5 M / 100 M tokens.
+- **Sidebar widget**: the same progress bar pair in compact form at the bottom of the navigation sidebar (appears once data is loaded), with a countdown refreshed every 10 seconds.
+- **Detail table**: individual API calls, time, agent, tool, token breakdown, content preview
+- **Filters**: time period (1h/24h/7d/30d), agent card click
+- **Collect button**: manual data collection trigger
+
+All user-originated data (agent name, tool name, preview) passes through `escapeHtml()` for XSS protection.
+
+---
+
+## Limitations
+
+- JSONL files live on the current machine; if Claude Code runs elsewhere those transcripts are not visible.
+- Cursor tracking is file-size based: if a file gets shorter (truncated), the cursor resets and reprocessing starts — dedup prevents duplicates.
+- Kanban correlation is heuristic: pairs by task time window, not exact session-to-task mapping.

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -97,15 +97,16 @@ A dashboard **valós fogyasztási százalékokat** kér le a claude.ai/settings/
 
 ### Beállítás (egyszeri)
 
-Indítsd el a Chrome-ot remote debugging porttal. macOS-en a legegyszerűbb módja:
+Indítsd el a Chrome-ot **dedikált profillal** és remote debugging porttal. A Chrome 149+ biztonsági okokból figyelmen kívül hagyja a `--remote-debugging-port` flag-et az alapértelmezett profilon, ezért külön `--user-data-dir` szükséges.
 
 ```bash
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
   --remote-debugging-port=9222 \
-  --profile-directory="Default"
+  --user-data-dir="$HOME/.claude/chrome-cdp-profile" \
+  --no-first-run
 ```
 
-Ezt háttérben futva hagyhatod. A Chrome-nak nyitva kell lennie és be kell lenni jelentkezve a claude.ai-ra.
+Jelentkezz be a claude.ai-ra a megnyíló ablakban. A session a `~/.claude/chrome-cdp-profile/` mappában tárolódik és minden következő scrape felhasználja. Ezt a Chrome példányt háttérben futva hagyhatod.
 
 Opcionális: az alapértelmezett végpont (`http://127.0.0.1:9222`) felülírható a `CLAUDE_USAGE_CDP_URL` env változóval.
 

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -95,6 +95,8 @@ CREATE TABLE token_usage_cursors (
 
 - **Summary cards**: Ágensenként teljes fogyasztás (input/output/cache), hívásszám, utolsó aktivitás
 - **Timeline chart**: Canvas-alapú oszlopdiagram, dinamikus bucket mérettel (1h period = 5 perces bucketek, egyébként 1 órás)
+- **Fogyasztási korlátok (progressbar blokk)**: Az Idővonal alatt 2 progressbar: "Aktuális session" (az elmúlt 5 órás ablak tokenszáma / beállított korlát) és "Heti limit / összes modell" (7 napos összesítés / beállított korlát). Jobb felső sarokban visszaszámláló: mikor áll vissza az aktuális 5h ablak. A korlátokat a felhasználó szabja be (kattintás az értékre): `localStorage`-ban tárolódnak (`tu_limit_5h`, `tu_limit_weekly`). Alapértelmezés: 5M / 100M token.
+- **Sidebar widget**: Ugyanez a progressbar-pár kompakt formában a navigációs sáv alján jelenik meg (amint van adat), 10 másodpercenként frissülő visszaszámlálóval.
 - **Detail table**: Egyedi API-hívások listája, idő, ágens, tool, token breakdown, content preview
 - **Szűrők**: Időszak (1h/24h/7d/30d), ágens kártya kattintás
 - **Collect gomb**: Kézi adatgyűjtés indítása

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -91,11 +91,43 @@ CREATE TABLE token_usage_cursors (
 
 ---
 
+## claude.ai fogyasztás-scraper
+
+A dashboard **valós fogyasztási százalékokat** kér le a claude.ai/settings/usage oldalról egy Playwright alapú headless scraper segítségével (`src/web/claude-usage-scraper.ts`). Ugyanazokat a session és heti százalékokat mutatja, amelyek a claude.ai beállítások oldalán is láthatók - nem lokális tokenszámlálást.
+
+### Beállítás (egyszeri)
+
+1. Telepítsd a Playwright Chromium böngészőt (az npm csomag nem tartalmazza):
+   ```bash
+   npx playwright install chromium
+   ```
+
+2. Az első használatkor futtasd headed módban, hogy be tudj jelentkezni a claude.ai-ba:
+   ```bash
+   CLAUDE_USAGE_HEADED=1 node -e "import('./dist/web/claude-usage-scraper.js').then(m => m.scrapeClaudeUsage(true))"
+   ```
+   Megnyílik egy böngésző ablak. Jelentkezz be a claude.ai-ra. A session elmentődik a `~/.claude/claude-usage-profile/` mappába (gitignored), és ezután minden scrape headless módban fut.
+
+### Működés
+
+- A scraper **15 percenként** fut háttér pollerként a `src/web.ts`-ben, és indításkor is (10 másodperces késleltetéssel).
+- Az eredmény cache-elve van a `store/claude-usage.json` fájlban (gitignored, 14 perces TTL).
+- A `/api/claude-usage` végpont a cache-elt adatot adja vissza; a `/api/claude-usage/refresh` egyszeri háttér újralekérést indít.
+- Ha nincs bejelentkezve (headless), a scraper `null`-t ad vissza, a dashboard "adat nem elérhető" állapotot mutat.
+
+### Biztonság
+
+- Hitelesítő adatok, sütik és session tokenek nem kerülnek kódba, logba vagy gitbe.
+- A Playwright profil a `~/.claude/claude-usage-profile/` mappában él (a projekt mappáján kívül, gitignored).
+- A `store/claude-usage.json` szintén gitignored.
+
+---
+
 ## Dashboard UI (`web/app.js` + `web/index.html`)
 
 - **Summary cards**: Ágensenként teljes fogyasztás (input/output/cache), hívásszám, utolsó aktivitás
 - **Timeline chart**: Canvas-alapú oszlopdiagram, dinamikus bucket mérettel (1h period = 5 perces bucketek, egyébként 1 órás)
-- **Fogyasztási korlátok (progressbar blokk)**: Az Idővonal alatt 2 progressbar: "Aktuális session" (az elmúlt 5 órás ablak tokenszáma / beállított korlát) és "Heti limit / összes modell" (7 napos összesítés / beállított korlát). Jobb felső sarokban visszaszámláló: mikor áll vissza az aktuális 5h ablak. A korlátokat a felhasználó szabja be (kattintás az értékre): `localStorage`-ban tárolódnak (`tu_limit_5h`, `tu_limit_weekly`). Alapértelmezés: 5M / 100M token.
+- **Fogyasztási korlátok (progressbar blokk)**: Az Idővonal alatt 2 progressbar a **valós claude.ai százalékokkal** -- "Aktuális session" és "Heti / összes modell". Visszaszámlálók mutatják mikor áll vissza mindkettő. Az adat a fenti claude.ai scrapertől jön; ha nem elérhető, a kártya "adat nem elérhető" állapotot mutat beállítási útmutatóval.
 - **Sidebar widget**: Ugyanez a progressbar-pár kompakt formában a navigációs sáv alján jelenik meg (amint van adat), 10 másodpercenként frissülő visszaszámlálóval.
 - **Detail table**: Egyedi API-hívások listája, idő, ágens, tool, token breakdown, content preview
 - **Szűrők**: Időszak (1h/24h/7d/30d), ágens kártya kattintás

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -93,33 +93,35 @@ CREATE TABLE token_usage_cursors (
 
 ## claude.ai fogyasztás-scraper
 
-A dashboard **valós fogyasztási százalékokat** kér le a claude.ai/settings/usage oldalról egy Playwright alapú headless scraper segítségével (`src/web/claude-usage-scraper.ts`). Ugyanazokat a session és heti százalékokat mutatja, amelyek a claude.ai beállítások oldalán is láthatók - nem lokális tokenszámlálást.
+A dashboard **valós fogyasztási százalékokat** kér le a claude.ai/settings/usage oldalról a Chrome DevTools Protocol (CDP) segítségével, egy már futó Chrome példányhoz csatlakozva. Ez megkerüli a bot-védelmet, mivel a felhasználó saját, már bejelentkezett Chrome-ját vezérli ahelyett, hogy külön böngészőt indítana.
 
 ### Beállítás (egyszeri)
 
-1. Telepítsd a Playwright Chromium böngészőt (az npm csomag nem tartalmazza):
-   ```bash
-   npx playwright install chromium
-   ```
+Indítsd el a Chrome-ot remote debugging porttal. macOS-en a legegyszerűbb módja:
 
-2. Az első használatkor futtasd headed módban, hogy be tudj jelentkezni a claude.ai-ba:
-   ```bash
-   CLAUDE_USAGE_HEADED=1 node -e "import('./dist/web/claude-usage-scraper.js').then(m => m.scrapeClaudeUsage(true))"
-   ```
-   Megnyílik egy böngésző ablak. Jelentkezz be a claude.ai-ra. A session elmentődik a `~/.claude/claude-usage-profile/` mappába (gitignored), és ezután minden scrape headless módban fut.
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --profile-directory="Default"
+```
+
+Ezt háttérben futva hagyhatod. A Chrome-nak nyitva kell lennie és be kell lenni jelentkezve a claude.ai-ra.
+
+Opcionális: az alapértelmezett végpont (`http://127.0.0.1:9222`) felülírható a `CLAUDE_USAGE_CDP_URL` env változóval.
 
 ### Működés
 
-- A scraper **15 percenként** fut háttér pollerként a `src/web.ts`-ben, és indításkor is (10 másodperces késleltetéssel).
-- Az eredmény cache-elve van a `store/claude-usage.json` fájlban (gitignored, 14 perces TTL).
+- A scraper CDP-vel csatlakozik a Chrome-hoz, megkeresi vagy megnyitja a `/settings/usage` tabot, megvárja a `[role="progressbar"]` elemeket (ez a Cloudflare challenge-t is lefedi), majd kinyeri a két százalékot és a visszaállítási időket.
+- **15 percenként** fut háttér pollerként a `src/web.ts`-ben, indításkor is (10 másodperces késleltetéssel).
+- Az eredmény cache-elve van a `store/claude-usage.json` fájlban (gitignored, 14 perces TTL), így egy dashboard újraindítás nem vált ki azonnali újralekérést.
 - A `/api/claude-usage` végpont a cache-elt adatot adja vissza; a `/api/claude-usage/refresh` egyszeri háttér újralekérést indít.
-- Ha nincs bejelentkezve (headless), a scraper `null`-t ad vissza, a dashboard "adat nem elérhető" állapotot mutat.
+- Ha a Chrome nem érhető el a CDP végponton, a scraper info üzenetet logol és null-t ad vissza -- nem crashel, a felhasználónak nem jelez hibát.
 
 ### Biztonság
 
 - Hitelesítő adatok, sütik és session tokenek nem kerülnek kódba, logba vagy gitbe.
-- A Playwright profil a `~/.claude/claude-usage-profile/` mappában él (a projekt mappáján kívül, gitignored).
-- A `store/claude-usage.json` szintén gitignored.
+- A scraper csak olvas a usage oldalról, a Chrome profilját soha nem módosítja.
+- A `store/claude-usage.json` gitignored.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.116",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^11.7.0",
     "cron-parser": "^5.0.0",
     "pino": "^9.6.0",
-    "pino-pretty": "^13.0.0"
+    "pino-pretty": "^13.0.0",
+    "playwright": "^1.60.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",

--- a/scripts/claude-usage-mcp.ts
+++ b/scripts/claude-usage-mcp.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * claude-usage MCP server (stdio transport)
+ *
+ * Exposes one tool: get_usage
+ *   Returns: { sessionPct, weeklyPct, sessionResetAt, weeklyResetAt, fetchedAt }
+ *   scraped from claude.ai/settings/usage using a persistent Playwright profile.
+ *
+ * Register in an agent's .mcp.json:
+ *   "claude-usage": {
+ *     "command": "node",
+ *     "args": ["/abs/path/to/marveen/dist/scripts/claude-usage-mcp.js"],
+ *     "env": { "CLAUDE_USAGE_PROFILE_DIR": "/abs/path/to/profile" }
+ *   }
+ *
+ * First-time login: run with CLAUDE_USAGE_HEADED=1 to open a visible browser,
+ * sign in once, then subsequent calls run headless.
+ *
+ * SECURITY: no credentials, tokens or cookies are written to this file or
+ * to any log output. The profile directory is gitignored.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js'
+import { scrapeClaudeUsage, readUsageCache } from '../src/web/claude-usage-scraper.js'
+
+const server = new Server(
+  { name: 'claude-usage', version: '1.0.0' },
+  { capabilities: { tools: {} } },
+)
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'get_usage',
+      description: 'Fetch current claude.ai session and weekly usage percentages and reset times.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          force_refresh: {
+            type: 'boolean',
+            description: 'Skip cache and scrape fresh data even if cache is valid.',
+          },
+        },
+      },
+    },
+  ],
+}))
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name !== 'get_usage') {
+    return { content: [{ type: 'text', text: JSON.stringify({ error: 'Unknown tool' }) }] }
+  }
+
+  const forceRefresh = (req.params.arguments as Record<string, unknown>)?.force_refresh === true
+  const headed = process.env.CLAUDE_USAGE_HEADED === '1'
+
+  let data = forceRefresh ? null : readUsageCache()
+  if (!data) {
+    data = await scrapeClaudeUsage(headed)
+  }
+
+  if (!data) {
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({ error: 'not_available', message: 'claude.ai usage data unavailable — run with CLAUDE_USAGE_HEADED=1 to sign in' }),
+      }],
+    }
+  }
+
+  return { content: [{ type: 'text', text: JSON.stringify(data) }] }
+})
+
+const transport = new StdioServerTransport()
+await server.connect(transport)

--- a/scripts/claude-usage-mcp.ts
+++ b/scripts/claude-usage-mcp.ts
@@ -4,20 +4,20 @@
  *
  * Exposes one tool: get_usage
  *   Returns: { sessionPct, weeklyPct, sessionResetAt, weeklyResetAt, fetchedAt }
- *   scraped from claude.ai/settings/usage using a persistent Playwright profile.
+ *   scraped from claude.ai/settings/usage via CDP (Chrome DevTools Protocol).
  *
  * Register in an agent's .mcp.json:
  *   "claude-usage": {
  *     "command": "node",
  *     "args": ["/abs/path/to/marveen/dist/scripts/claude-usage-mcp.js"],
- *     "env": { "CLAUDE_USAGE_PROFILE_DIR": "/abs/path/to/profile" }
+ *     "env": { "CLAUDE_USAGE_CDP_URL": "http://127.0.0.1:9222" }
  *   }
  *
- * First-time login: run with CLAUDE_USAGE_HEADED=1 to open a visible browser,
- * sign in once, then subsequent calls run headless.
+ * Prerequisites: Chrome must be running with --remote-debugging-port=9222.
+ * See docs/token-usage.md for setup instructions.
  *
  * SECURITY: no credentials, tokens or cookies are written to this file or
- * to any log output. The profile directory is gitignored.
+ * to any log output. The user's Chrome profile is never written to.
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
@@ -57,18 +57,20 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   }
 
   const forceRefresh = (req.params.arguments as Record<string, unknown>)?.force_refresh === true
-  const headed = process.env.CLAUDE_USAGE_HEADED === '1'
 
   let data = forceRefresh ? null : readUsageCache()
   if (!data) {
-    data = await scrapeClaudeUsage(headed)
+    data = await scrapeClaudeUsage()
   }
 
   if (!data) {
     return {
       content: [{
         type: 'text',
-        text: JSON.stringify({ error: 'not_available', message: 'claude.ai usage data unavailable — run with CLAUDE_USAGE_HEADED=1 to sign in' }),
+        text: JSON.stringify({
+          error: 'not_available',
+          message: 'claude.ai usage data unavailable — start Chrome with --remote-debugging-port=9222 (see docs/token-usage.md)',
+        }),
       }],
     }
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -303,15 +303,15 @@ export function startWebServer(port = 3420): http.Server {
   collectTokenUsage().catch(err => logger.warn({ err }, 'Startup token usage collection failed'))
   logger.info('Token usage auto-collect started (1h poll + startup)')
 
-  // Poll claude.ai/settings/usage every 15 minutes for real-time usage %.
-  // headless=false would require an interactive session; we always run headless
-  // here. If not logged in the scraper returns null and the cache stays empty.
+  // Poll claude.ai/settings/usage every 15 minutes via CDP.
+  // If Chrome isn't running with --remote-debugging-port=9222 the scraper
+  // returns null silently and the cache stays empty.
   setInterval(() => {
-    scrapeClaudeUsage(false).catch(err => logger.warn({ err }, 'claude-usage poll failed'))
+    scrapeClaudeUsage().catch(err => logger.warn({ err }, 'claude-usage poll failed'))
   }, 15 * 60 * 1000)
-  // Stagger startup scrape by 10s so the server is fully up before Playwright launches.
+  // Stagger startup scrape by 10s so the server is fully up before connecting.
   setTimeout(() => {
-    scrapeClaudeUsage(false).catch(err => logger.warn({ err }, 'claude-usage startup scrape failed'))
+    scrapeClaudeUsage().catch(err => logger.warn({ err }, 'claude-usage startup scrape failed'))
   }, 10000)
 
   // NOTE: startMcpListChecker() is intentionally NOT called here.

--- a/src/web.ts
+++ b/src/web.ts
@@ -21,6 +21,7 @@ import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
 import { startReauthHealer } from './web/reauth-healer.js'
 import { startAutoRestartRunner } from './web/auto-restart-runner.js'
 import { collectTokenUsage } from './web/token-usage.js'
+import { scrapeClaudeUsage } from './web/claude-usage-scraper.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
@@ -51,6 +52,7 @@ import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleSettings } from './web/routes/settings.js'
 import { tryHandleAuditLog } from './web/routes/audit-log.js'
+import { tryHandleClaudeUsage } from './web/routes/claude-usage.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import type { RouteContext } from './web/routes/types.js'
 
@@ -165,6 +167,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleStatus(routeCtx)) return
       if (await tryHandleAutonomy(routeCtx)) return
       if (await tryHandleTokenUsage(routeCtx)) return
+      if (await tryHandleClaudeUsage(routeCtx)) return
       if (await tryHandleIdeas(routeCtx)) return
       if (await tryHandleToolLog(routeCtx)) return
       if (await tryHandleSettings(routeCtx)) return
@@ -299,6 +302,17 @@ export function startWebServer(port = 3420): http.Server {
   }, 60 * 60 * 1000)
   collectTokenUsage().catch(err => logger.warn({ err }, 'Startup token usage collection failed'))
   logger.info('Token usage auto-collect started (1h poll + startup)')
+
+  // Poll claude.ai/settings/usage every 15 minutes for real-time usage %.
+  // headless=false would require an interactive session; we always run headless
+  // here. If not logged in the scraper returns null and the cache stays empty.
+  setInterval(() => {
+    scrapeClaudeUsage(false).catch(err => logger.warn({ err }, 'claude-usage poll failed'))
+  }, 15 * 60 * 1000)
+  // Stagger startup scrape by 10s so the server is fully up before Playwright launches.
+  setTimeout(() => {
+    scrapeClaudeUsage(false).catch(err => logger.warn({ err }, 'claude-usage startup scrape failed'))
+  }, 10000)
 
   // NOTE: startMcpListChecker() is intentionally NOT called here.
   //

--- a/src/web/claude-usage-scraper.ts
+++ b/src/web/claude-usage-scraper.ts
@@ -7,9 +7,14 @@
  * Chrome profile.
  *
  * Prerequisites:
- *   1. npx playwright install chromium   (only needed for other Playwright use;
- *      the CDP path uses the user's real Chrome, not Playwright's Chromium)
- *   2. Start Chrome with --remote-debugging-port=9222
+ *   Start Chrome with a dedicated profile and the remote debugging port:
+ *     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+ *       --remote-debugging-port=9222 \
+ *       --user-data-dir=$HOME/.claude/chrome-cdp-profile \
+ *       --no-first-run
+ *   Sign in to claude.ai in that window once; subsequent scrapes reuse the session.
+ *   Note: Chrome 149+ ignores --remote-debugging-port on the default profile.
+ *         A dedicated --user-data-dir is required.
  *
  * SECURITY: no credentials, cookies, or session tokens are written to this
  * file or to any log. The user's Chrome profile is never touched by this code.
@@ -114,7 +119,7 @@ export async function scrapeClaudeUsage(): Promise<ClaudeUsageData | null> {
     // interstitial that runs before the real page content renders.
     await page.waitForSelector('[role="progressbar"]', { timeout: 30000 })
 
-    // --- Strategy 1: aria progressbar values ---
+    // --- Extract percentages and reset times from the usage page ---
     const result = await page.evaluate(() => {
       function pctFromBar(bar: Element): number | null {
         const now = bar.getAttribute('aria-valuenow')
@@ -123,54 +128,50 @@ export async function scrapeClaudeUsage(): Promise<ClaudeUsageData | null> {
         return Math.round((parseFloat(now) / parseFloat(max)) * 100)
       }
 
-      function nearbyText(el: Element): string {
-        const parent = el.closest('[class]') ?? el.parentElement
-        return parent?.textContent ?? ''
+      // Walk up from a progressbar to find the section container that includes
+      // reset-time text. Scoping to each section's subtree is essential to avoid
+      // both sections matching the same "in Xh Ym" text from the body.
+      function getSectionText(el: Element): string {
+        let cur: Element | null = el
+        for (let i = 0; i < 8; i++) {
+          cur = cur?.parentElement ?? null
+          if (!cur) break
+          const txt = cur.textContent ?? ''
+          if (txt.length > 80 && /reset|session|week/i.test(txt)) return txt
+        }
+        return el.closest('[class]')?.textContent ?? document.body.innerText
       }
 
-      const bars = Array.from(document.querySelectorAll('[role="progressbar"]'))
-      let sessionPct: number | null = null
-      let weeklyPct: number | null = null
-
-      for (const bar of bars) {
-        const ctx = nearbyText(bar).toLowerCase()
-        const pct = pctFromBar(bar)
-        if (pct == null) continue
-        if (ctx.includes('session') && sessionPct == null) sessionPct = pct
-        else if ((ctx.includes('week') || ctx.includes('all models')) && weeklyPct == null) weeklyPct = pct
-        else if (sessionPct == null) sessionPct = pct
-        else if (weeklyPct == null) weeklyPct = pct
-      }
-
-      // --- Strategy 2: text extraction fallback ---
-      if (sessionPct == null || weeklyPct == null) {
-        const body = document.body.innerText
-        const sessionM = body.match(/current session[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
-          ?? body.match(/(\d+(?:\.\d+)?)\s*%[^]*?current session/i)
-        const weeklyM = body.match(/weekly[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
-          ?? body.match(/all models[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
-          ?? body.match(/(\d+(?:\.\d+)?)\s*%[^]*?weekly/i)
-
-        if (sessionPct == null && sessionM) sessionPct = parseFloat(sessionM[1])
-        if (weeklyPct == null && weeklyM) weeklyPct = parseFloat(weeklyM[1])
-      }
-
-      // --- Reset times: parse countdown / "resets at HH:MM" text ---
-      function parseResetMs(keyword: string): number {
-        const body = document.body.innerText
-        const re = new RegExp(keyword + '[^\\n]{0,120}reset[s]?[^\\n]{0,80}', 'i')
-        const m = re.exec(body)
-        const ctx = m ? m[0] : body
-
-        // "in Xh Ym"
-        const inM = ctx.match(/in\s+(\d+)\s*h(?:ours?)?\s*(?:(\d+)\s*m(?:in)?)?/i)
+      // Parse a reset timestamp from a section's text.
+      // Session format: "Resets in 2h 15m"
+      // Weekly format:  "Resets Tue 3:59 PM"
+      function parseResetMs(text: string): number {
+        // "in Xh Ym" — relative countdown (session)
+        const inM = text.match(/in\s+(\d+)\s*h(?:ours?)?\s*(?:(\d+)\s*m(?:in)?)?/i)
         if (inM) {
           const h = parseInt(inM[1] || '0')
           const min = parseInt(inM[2] || '0')
           return Date.now() + (h * 3600 + min * 60) * 1000
         }
-        // "at HH:MM" today/tomorrow
-        const atM = ctx.match(/at\s+(\d{1,2}):(\d{2})\s*(AM|PM)?/i)
+        // "Resets Mon 3:59 PM" — day-of-week + time (weekly)
+        const dayNames = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
+        const dayM = text.match(/resets?\s+(sun|mon|tue|wed|thu|fri|sat)\w*\s+(\d{1,2}):(\d{2})\s*(AM|PM)?/i)
+        if (dayM) {
+          const targetDay = dayNames.indexOf(dayM[1].toLowerCase().slice(0, 3))
+          let h = parseInt(dayM[2])
+          const min = parseInt(dayM[3])
+          if (dayM[4]?.toUpperCase() === 'PM' && h < 12) h += 12
+          if (dayM[4]?.toUpperCase() === 'AM' && h === 12) h = 0
+          const now = new Date()
+          const t = new Date(now)
+          t.setHours(h, min, 0, 0)
+          let daysUntil = (targetDay - now.getDay() + 7) % 7
+          if (daysUntil === 0 && t.getTime() <= now.getTime()) daysUntil = 7
+          t.setDate(t.getDate() + daysUntil)
+          return t.getTime()
+        }
+        // "at HH:MM" fallback (today/tomorrow)
+        const atM = text.match(/at\s+(\d{1,2}):(\d{2})\s*(AM|PM)?/i)
         if (atM) {
           const now = new Date()
           let h = parseInt(atM[1])
@@ -178,14 +179,47 @@ export async function scrapeClaudeUsage(): Promise<ClaudeUsageData | null> {
           if (atM[3]?.toUpperCase() === 'PM' && h < 12) h += 12
           if (atM[3]?.toUpperCase() === 'AM' && h === 12) h = 0
           const t = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, min)
-          if (t.getTime() < Date.now()) t.setDate(t.getDate() + 1)
+          if (t.getTime() < now.getTime()) t.setDate(t.getDate() + 1)
           return t.getTime()
         }
         return 0
       }
 
-      const sessionResetAt = parseResetMs('session') || (Date.now() + 5 * 3600 * 1000)
-      const weeklyResetAt = parseResetMs('week') || (Date.now() + 7 * 24 * 3600 * 1000)
+      const bars = Array.from(document.querySelectorAll('[role="progressbar"]'))
+      let sessionPct: number | null = null
+      let weeklyPct: number | null = null
+      let sessionBar: Element | null = null
+      let weeklyBar: Element | null = null
+
+      for (const bar of bars) {
+        const ctx = (bar.closest('[class]')?.textContent ?? '').toLowerCase()
+        const pct = pctFromBar(bar)
+        if (pct == null) continue
+        if (ctx.includes('session') && sessionBar == null) { sessionPct = pct; sessionBar = bar }
+        else if ((ctx.includes('week') || ctx.includes('all models')) && weeklyBar == null) { weeklyPct = pct; weeklyBar = bar }
+        else if (sessionBar == null) { sessionPct = pct; sessionBar = bar }
+        else if (weeklyBar == null) { weeklyPct = pct; weeklyBar = bar }
+      }
+
+      // Text extraction fallback for percentages
+      if (sessionPct == null || weeklyPct == null) {
+        const body = document.body.innerText
+        const sessionM = body.match(/current session[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
+          ?? body.match(/(\d+(?:\.\d+)?)\s*%[^]*?current session/i)
+        const weeklyM = body.match(/weekly[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
+          ?? body.match(/all models[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
+          ?? body.match(/(\d+(?:\.\d+)?)\s*%[^]*?weekly/i)
+        if (sessionPct == null && sessionM) sessionPct = parseFloat(sessionM[1])
+        if (weeklyPct == null && weeklyM) weeklyPct = parseFloat(weeklyM[1])
+      }
+
+      // Parse reset times from each section's own DOM subtree, NOT from the
+      // full body, to prevent the session "in Xh Ym" from bleeding into the
+      // weekly parse (which uses a different format: "Resets Tue 3:59 PM").
+      const sessionText = sessionBar ? getSectionText(sessionBar) : document.body.innerText
+      const weeklyText = weeklyBar ? getSectionText(weeklyBar) : document.body.innerText
+      const sessionResetAt = parseResetMs(sessionText) || (Date.now() + 5 * 3600 * 1000)
+      const weeklyResetAt = parseResetMs(weeklyText) || (Date.now() + 7 * 24 * 3600 * 1000)
 
       return { sessionPct, weeklyPct, sessionResetAt, weeklyResetAt }
     })

--- a/src/web/claude-usage-scraper.ts
+++ b/src/web/claude-usage-scraper.ts
@@ -82,14 +82,28 @@ export async function scrapeClaudeUsage(headed = false): Promise<ClaudeUsageData
     const page = browser.pages()[0] ?? await browser.newPage()
 
     await page.goto(USAGE_URL, { waitUntil: 'domcontentloaded', timeout: 30000 })
-    // Allow JS to render the usage data
-    await page.waitForTimeout(3000)
 
-    // Redirect to login page → not authenticated
-    if (page.url().includes('/login') || page.url().includes('/auth')) {
-      logger.info('claude-usage: not logged in, headed=%s', headed)
-      return null
+    const onLoginPage = () => page.url().includes('/login') || page.url().includes('/auth')
+
+    if (onLoginPage()) {
+      if (!headed) {
+        // Headless: no user present to log in — bail immediately.
+        logger.info('claude-usage: not logged in (headless), skipping')
+        return null
+      }
+      // Headed: wait up to 5 minutes for the user to complete login and land
+      // on the usage page. The browser window stays open so they can sign in.
+      logger.info('claude-usage: not logged in — waiting for user to sign in (headed, up to 5 min)')
+      try {
+        await page.waitForURL('**/settings/usage**', { timeout: 5 * 60 * 1000 })
+      } catch {
+        logger.warn('claude-usage: login wait timed out after 5 minutes')
+        return null
+      }
     }
+
+    // Allow JS to render the usage data after navigation settles
+    await page.waitForTimeout(3000)
 
     // --- Strategy 1: aria progressbar values ---
     const result = await page.evaluate(() => {

--- a/src/web/claude-usage-scraper.ts
+++ b/src/web/claude-usage-scraper.ts
@@ -1,0 +1,194 @@
+/**
+ * Headless Playwright scraper for claude.ai/settings/usage.
+ *
+ * Uses a persistent browser profile so the user only has to sign in once
+ * (headed mode). Subsequent calls run headless against the stored session.
+ *
+ * SECURITY: no credentials, cookies, or session tokens are written to this
+ * file or to any log. The persistent profile directory is gitignored and
+ * lives outside the project root.
+ */
+
+import { chromium } from 'playwright'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { STORE_DIR } from '../config.js'
+import { logger } from '../logger.js'
+
+const USAGE_URL = 'https://claude.ai/settings/usage'
+
+// Profile dir: env override or ~/.claude/claude-usage-profile (gitignored)
+function profileDir(): string {
+  return process.env.CLAUDE_USAGE_PROFILE_DIR ?? join(homedir(), '.claude', 'claude-usage-profile')
+}
+
+const CACHE_PATH = join(STORE_DIR, 'claude-usage.json')
+const CACHE_TTL_MS = 14 * 60 * 1000  // 14 minutes — just under the 15-min poll interval
+
+export interface ClaudeUsageData {
+  sessionPct: number       // 0–100
+  weeklyPct: number        // 0–100
+  sessionResetAt: number   // epoch ms
+  weeklyResetAt: number    // epoch ms
+  fetchedAt: number        // epoch ms
+}
+
+export function readUsageCache(): ClaudeUsageData | null {
+  try {
+    if (!existsSync(CACHE_PATH)) return null
+    const raw = readFileSync(CACHE_PATH, 'utf-8')
+    const data = JSON.parse(raw) as ClaudeUsageData
+    if (Date.now() - data.fetchedAt > CACHE_TTL_MS) return null
+    return data
+  } catch {
+    return null
+  }
+}
+
+function writeUsageCache(data: ClaudeUsageData): void {
+  try {
+    writeFileSync(CACHE_PATH, JSON.stringify(data))
+  } catch (err) {
+    logger.warn({ err }, 'claude-usage: failed to write cache')
+  }
+}
+
+/** Parse a percentage string like "35%" → 35. Returns null if unparseable. */
+function parsePct(s: string | null | undefined): number | null {
+  if (!s) return null
+  const m = s.match(/(\d+(?:\.\d+)?)/)
+  if (!m) return null
+  const v = parseFloat(m[1])
+  return isNaN(v) ? null : Math.min(100, Math.max(0, v))
+}
+
+/**
+ * Scrape usage percentages and reset times from claude.ai/settings/usage.
+ * Returns null if not logged in or page structure has changed.
+ *
+ * headed=true opens a visible browser window (for first-time login).
+ */
+export async function scrapeClaudeUsage(headed = false): Promise<ClaudeUsageData | null> {
+  const dir = profileDir()
+  mkdirSync(dir, { recursive: true })
+
+  const browser = await chromium.launchPersistentContext(dir, {
+    headless: !headed,
+    args: ['--no-sandbox', '--disable-blink-features=AutomationControlled'],
+  })
+
+  try {
+    const page = browser.pages()[0] ?? await browser.newPage()
+
+    await page.goto(USAGE_URL, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    // Allow JS to render the usage data
+    await page.waitForTimeout(3000)
+
+    // Redirect to login page → not authenticated
+    if (page.url().includes('/login') || page.url().includes('/auth')) {
+      logger.info('claude-usage: not logged in, headed=%s', headed)
+      return null
+    }
+
+    // --- Strategy 1: aria progressbar values ---
+    const result = await page.evaluate(() => {
+      function pctFromBar(bar: Element): number | null {
+        const now = bar.getAttribute('aria-valuenow')
+        const max = bar.getAttribute('aria-valuemax') ?? '100'
+        if (now == null) return null
+        return Math.round((parseFloat(now) / parseFloat(max)) * 100)
+      }
+
+      function nearbyText(el: Element, radius = 200): string {
+        const parent = el.closest('[class]') ?? el.parentElement
+        return parent?.textContent ?? ''
+      }
+
+      const bars = Array.from(document.querySelectorAll('[role="progressbar"]'))
+      let sessionPct: number | null = null
+      let weeklyPct: number | null = null
+
+      for (const bar of bars) {
+        const ctx = nearbyText(bar).toLowerCase()
+        const pct = pctFromBar(bar)
+        if (pct == null) continue
+        if (ctx.includes('session') && sessionPct == null) sessionPct = pct
+        else if ((ctx.includes('week') || ctx.includes('all models')) && weeklyPct == null) weeklyPct = pct
+        else if (sessionPct == null) sessionPct = pct
+        else if (weeklyPct == null) weeklyPct = pct
+      }
+
+      // --- Strategy 2: text extraction ---
+      if (sessionPct == null || weeklyPct == null) {
+        const body = document.body.innerText
+        // Look for "X% used" or "X%" near section headings
+        const sessionM = body.match(/current session[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
+          ?? body.match(/(\d+(?:\.\d+)?)\s*%[^]*?current session/i)
+        const weeklyM = body.match(/weekly[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
+          ?? body.match(/all models[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
+          ?? body.match(/(\d+(?:\.\d+)?)\s*%[^]*?weekly/i)
+
+        if (sessionPct == null && sessionM) sessionPct = parseFloat(sessionM[1])
+        if (weeklyPct == null && weeklyM) weeklyPct = parseFloat(weeklyM[1])
+      }
+
+      // --- Reset times: look for countdown/reset text ---
+      function parseResetMs(keyword: string): number {
+        const body = document.body.innerText
+        // "Resets in 2h 15m" / "resets at HH:MM" / ISO date strings
+        const re = new RegExp(keyword + '[^\\n]{0,120}reset[s]?[^\\n]{0,80}', 'i')
+        const m = re.exec(body)
+        const ctx = m ? m[0] : body
+
+        // "in Xh Ym"
+        const inM = ctx.match(/in\s+(\d+)\s*h(?:ours?)?\s*(?:(\d+)\s*m(?:in)?)?/i)
+        if (inM) {
+          const h = parseInt(inM[1] || '0')
+          const min = parseInt(inM[2] || '0')
+          return Date.now() + (h * 3600 + min * 60) * 1000
+        }
+        // "at HH:MM" today/tomorrow
+        const atM = ctx.match(/at\s+(\d{1,2}):(\d{2})\s*(AM|PM)?/i)
+        if (atM) {
+          const now = new Date()
+          let h = parseInt(atM[1])
+          const min = parseInt(atM[2])
+          if (atM[3]?.toUpperCase() === 'PM' && h < 12) h += 12
+          if (atM[3]?.toUpperCase() === 'AM' && h === 12) h = 0
+          const t = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, min)
+          if (t.getTime() < Date.now()) t.setDate(t.getDate() + 1)
+          return t.getTime()
+        }
+        return 0
+      }
+
+      const sessionResetAt = parseResetMs('session') || (Date.now() + 5 * 3600 * 1000)
+      const weeklyResetAt = parseResetMs('week') || (Date.now() + 7 * 24 * 3600 * 1000)
+
+      return { sessionPct, weeklyPct, sessionResetAt, weeklyResetAt }
+    })
+
+    if (result.sessionPct == null && result.weeklyPct == null) {
+      logger.warn('claude-usage: could not extract usage data from page')
+      return null
+    }
+
+    const data: ClaudeUsageData = {
+      sessionPct: result.sessionPct ?? 0,
+      weeklyPct: result.weeklyPct ?? 0,
+      sessionResetAt: result.sessionResetAt,
+      weeklyResetAt: result.weeklyResetAt,
+      fetchedAt: Date.now(),
+    }
+    writeUsageCache(data)
+    logger.info({ data }, 'claude-usage: scraped successfully')
+    return data
+
+  } catch (err) {
+    logger.warn({ err }, 'claude-usage: scrape failed')
+    return null
+  } finally {
+    await browser.close()
+  }
+}

--- a/src/web/claude-usage-scraper.ts
+++ b/src/web/claude-usage-scraper.ts
@@ -128,61 +128,36 @@ export async function scrapeClaudeUsage(): Promise<ClaudeUsageData | null> {
         return Math.round((parseFloat(now) / parseFloat(max)) * 100)
       }
 
-      // Walk up from a progressbar to find the section container that includes
-      // reset-time text. Scoping to each section's subtree is essential to avoid
-      // both sections matching the same "in Xh Ym" text from the body.
-      function getSectionText(el: Element): string {
-        let cur: Element | null = el
-        for (let i = 0; i < 8; i++) {
-          cur = cur?.parentElement ?? null
-          if (!cur) break
-          const txt = cur.textContent ?? ''
-          if (txt.length > 80 && /reset|session|week/i.test(txt)) return txt
-        }
-        return el.closest('[class]')?.textContent ?? document.body.innerText
+      // The reset-time strings live in a separate DOM branch from the
+      // progressbars (the section headers), so per-bar subtree walking is
+      // unreliable. Instead parse the two DISTINCT formats from the full body
+      // and assign by format type — they are mutually exclusive:
+      //   session: "Resets in 4 hr 41 min" (relative countdown)
+      //   weekly:  "Resets Tue 3:59 PM"   (weekday + clock time)
+      function parseSessionReset(text: string): number {
+        // tolerate h / hr / hour(s) and m / min / minute(s)
+        const m = text.match(/in\s+(\d+)\s*(?:h|hr|hours?)\b\s*(?:(\d+)\s*(?:m|min|minutes?)\b)?/i)
+        if (!m) return 0
+        const h = parseInt(m[1] || '0')
+        const min = parseInt(m[2] || '0')
+        return Date.now() + (h * 3600 + min * 60) * 1000
       }
-
-      // Parse a reset timestamp from a section's text.
-      // Session format: "Resets in 2h 15m"
-      // Weekly format:  "Resets Tue 3:59 PM"
-      function parseResetMs(text: string): number {
-        // "in Xh Ym" — relative countdown (session)
-        const inM = text.match(/in\s+(\d+)\s*h(?:ours?)?\s*(?:(\d+)\s*m(?:in)?)?/i)
-        if (inM) {
-          const h = parseInt(inM[1] || '0')
-          const min = parseInt(inM[2] || '0')
-          return Date.now() + (h * 3600 + min * 60) * 1000
-        }
-        // "Resets Mon 3:59 PM" — day-of-week + time (weekly)
+      function parseWeeklyReset(text: string): number {
         const dayNames = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
-        const dayM = text.match(/resets?\s+(sun|mon|tue|wed|thu|fri|sat)\w*\s+(\d{1,2}):(\d{2})\s*(AM|PM)?/i)
-        if (dayM) {
-          const targetDay = dayNames.indexOf(dayM[1].toLowerCase().slice(0, 3))
-          let h = parseInt(dayM[2])
-          const min = parseInt(dayM[3])
-          if (dayM[4]?.toUpperCase() === 'PM' && h < 12) h += 12
-          if (dayM[4]?.toUpperCase() === 'AM' && h === 12) h = 0
-          const now = new Date()
-          const t = new Date(now)
-          t.setHours(h, min, 0, 0)
-          let daysUntil = (targetDay - now.getDay() + 7) % 7
-          if (daysUntil === 0 && t.getTime() <= now.getTime()) daysUntil = 7
-          t.setDate(t.getDate() + daysUntil)
-          return t.getTime()
-        }
-        // "at HH:MM" fallback (today/tomorrow)
-        const atM = text.match(/at\s+(\d{1,2}):(\d{2})\s*(AM|PM)?/i)
-        if (atM) {
-          const now = new Date()
-          let h = parseInt(atM[1])
-          const min = parseInt(atM[2])
-          if (atM[3]?.toUpperCase() === 'PM' && h < 12) h += 12
-          if (atM[3]?.toUpperCase() === 'AM' && h === 12) h = 0
-          const t = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, min)
-          if (t.getTime() < now.getTime()) t.setDate(t.getDate() + 1)
-          return t.getTime()
-        }
-        return 0
+        const m = text.match(/resets?\s+(sun|mon|tue|wed|thu|fri|sat)\w*\s+(\d{1,2}):(\d{2})\s*(am|pm)?/i)
+        if (!m) return 0
+        const targetDay = dayNames.indexOf(m[1].toLowerCase().slice(0, 3))
+        let h = parseInt(m[2])
+        const min = parseInt(m[3])
+        if (m[4]?.toUpperCase() === 'PM' && h < 12) h += 12
+        if (m[4]?.toUpperCase() === 'AM' && h === 12) h = 0
+        const now = new Date()
+        const t = new Date(now)
+        t.setHours(h, min, 0, 0)
+        let daysUntil = (targetDay - now.getDay() + 7) % 7
+        if (daysUntil === 0 && t.getTime() <= now.getTime()) daysUntil = 7
+        t.setDate(t.getDate() + daysUntil)
+        return t.getTime()
       }
 
       const bars = Array.from(document.querySelectorAll('[role="progressbar"]'))
@@ -213,13 +188,12 @@ export async function scrapeClaudeUsage(): Promise<ClaudeUsageData | null> {
         if (weeklyPct == null && weeklyM) weeklyPct = parseFloat(weeklyM[1])
       }
 
-      // Parse reset times from each section's own DOM subtree, NOT from the
-      // full body, to prevent the session "in Xh Ym" from bleeding into the
-      // weekly parse (which uses a different format: "Resets Tue 3:59 PM").
-      const sessionText = sessionBar ? getSectionText(sessionBar) : document.body.innerText
-      const weeklyText = weeklyBar ? getSectionText(weeklyBar) : document.body.innerText
-      const sessionResetAt = parseResetMs(sessionText) || (Date.now() + 5 * 3600 * 1000)
-      const weeklyResetAt = parseResetMs(weeklyText) || (Date.now() + 7 * 24 * 3600 * 1000)
+      // Reset times: parse each distinct format from the full body. The
+      // formats don't collide, so no DOM scoping is needed (and the reset
+      // text isn't inside the progressbar's subtree anyway).
+      const body2 = document.body.innerText
+      const sessionResetAt = parseSessionReset(body2) || (Date.now() + 5 * 3600 * 1000)
+      const weeklyResetAt = parseWeeklyReset(body2) || (Date.now() + 7 * 24 * 3600 * 1000)
 
       return { sessionPct, weeklyPct, sessionResetAt, weeklyResetAt }
     })

--- a/src/web/claude-usage-scraper.ts
+++ b/src/web/claude-usage-scraper.ts
@@ -1,27 +1,31 @@
 /**
- * Headless Playwright scraper for claude.ai/settings/usage.
+ * CDP-based scraper for claude.ai/settings/usage.
  *
- * Uses a persistent browser profile so the user only has to sign in once
- * (headed mode). Subsequent calls run headless against the stored session.
+ * Connects to an already-running Chrome instance via the Chrome DevTools
+ * Protocol (CDP) instead of launching a separate browser. This bypasses
+ * Cloudflare bot-detection because we drive the user's own, already-logged-in
+ * Chrome profile.
+ *
+ * Prerequisites:
+ *   1. npx playwright install chromium   (only needed for other Playwright use;
+ *      the CDP path uses the user's real Chrome, not Playwright's Chromium)
+ *   2. Start Chrome with --remote-debugging-port=9222
  *
  * SECURITY: no credentials, cookies, or session tokens are written to this
- * file or to any log. The persistent profile directory is gitignored and
- * lives outside the project root.
+ * file or to any log. The user's Chrome profile is never touched by this code.
  */
 
 import { chromium } from 'playwright'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import type { Page } from 'playwright'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 import { STORE_DIR } from '../config.js'
 import { logger } from '../logger.js'
 
 const USAGE_URL = 'https://claude.ai/settings/usage'
 
-// Profile dir: env override or ~/.claude/claude-usage-profile (gitignored)
-function profileDir(): string {
-  return process.env.CLAUDE_USAGE_PROFILE_DIR ?? join(homedir(), '.claude', 'claude-usage-profile')
-}
+// CDP endpoint: env override or default debug port
+const cdpUrl = (): string => process.env.CLAUDE_USAGE_CDP_URL ?? 'http://127.0.0.1:9222'
 
 const CACHE_PATH = join(STORE_DIR, 'claude-usage.json')
 const CACHE_TTL_MS = 14 * 60 * 1000  // 14 minutes — just under the 15-min poll interval
@@ -54,56 +58,61 @@ function writeUsageCache(data: ClaudeUsageData): void {
   }
 }
 
-/** Parse a percentage string like "35%" → 35. Returns null if unparseable. */
-function parsePct(s: string | null | undefined): number | null {
-  if (!s) return null
-  const m = s.match(/(\d+(?:\.\d+)?)/)
-  if (!m) return null
-  const v = parseFloat(m[1])
-  return isNaN(v) ? null : Math.min(100, Math.max(0, v))
-}
-
 /**
- * Scrape usage percentages and reset times from claude.ai/settings/usage.
- * Returns null if not logged in or page structure has changed.
+ * Scrape usage percentages and reset times from claude.ai/settings/usage
+ * by connecting to an already-running Chrome via CDP.
  *
- * headed=true opens a visible browser window (for first-time login).
+ * Returns null if Chrome is not running on the debug port, if the page
+ * structure has changed, or if any other error occurs.
  */
-export async function scrapeClaudeUsage(headed = false): Promise<ClaudeUsageData | null> {
-  const dir = profileDir()
-  mkdirSync(dir, { recursive: true })
+export async function scrapeClaudeUsage(): Promise<ClaudeUsageData | null> {
+  const endpoint = cdpUrl()
 
-  const browser = await chromium.launchPersistentContext(dir, {
-    headless: !headed,
-    args: ['--no-sandbox', '--disable-blink-features=AutomationControlled'],
-  })
+  // Try to connect — fail gracefully if Chrome isn't running with --remote-debugging-port
+  let browser: Awaited<ReturnType<typeof chromium.connectOverCDP>>
+  try {
+    browser = await chromium.connectOverCDP(endpoint)
+  } catch {
+    logger.info(
+      `claude-usage: Chrome not reachable at ${endpoint} — ` +
+      'start Chrome with --remote-debugging-port=9222 (or set CLAUDE_USAGE_CDP_URL)',
+    )
+    return null
+  }
+
+  let ownedPage = false
+  let page: Page | null = null
 
   try {
-    const page = browser.pages()[0] ?? await browser.newPage()
+    const contexts = browser.contexts()
+    if (!contexts.length) {
+      logger.warn('claude-usage: no browser context available via CDP')
+      return null
+    }
+    const ctx = contexts[0]
 
-    await page.goto(USAGE_URL, { waitUntil: 'domcontentloaded', timeout: 30000 })
-
-    const onLoginPage = () => page.url().includes('/login') || page.url().includes('/auth')
-
-    if (onLoginPage()) {
-      if (!headed) {
-        // Headless: no user present to log in — bail immediately.
-        logger.info('claude-usage: not logged in (headless), skipping')
-        return null
-      }
-      // Headed: wait up to 5 minutes for the user to complete login and land
-      // on the usage page. The browser window stays open so they can sign in.
-      logger.info('claude-usage: not logged in — waiting for user to sign in (headed, up to 5 min)')
-      try {
-        await page.waitForURL('**/settings/usage**', { timeout: 5 * 60 * 1000 })
-      } catch {
-        logger.warn('claude-usage: login wait timed out after 5 minutes')
-        return null
+    // Reuse an existing /settings/usage tab if one is already open
+    for (const p of ctx.pages()) {
+      if (p.url().includes('/settings/usage')) {
+        page = p
+        break
       }
     }
 
-    // Allow JS to render the usage data after navigation settles
-    await page.waitForTimeout(3000)
+    // Otherwise open a new tab in the user's existing context
+    if (!page) {
+      page = await ctx.newPage()
+      ownedPage = true
+    }
+
+    // Navigate to usage page if not already there
+    if (!page.url().includes('/settings/usage')) {
+      await page.goto(USAGE_URL, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    }
+
+    // Wait for the progress bars — this also covers any transient Cloudflare
+    // interstitial that runs before the real page content renders.
+    await page.waitForSelector('[role="progressbar"]', { timeout: 30000 })
 
     // --- Strategy 1: aria progressbar values ---
     const result = await page.evaluate(() => {
@@ -114,7 +123,7 @@ export async function scrapeClaudeUsage(headed = false): Promise<ClaudeUsageData
         return Math.round((parseFloat(now) / parseFloat(max)) * 100)
       }
 
-      function nearbyText(el: Element, radius = 200): string {
+      function nearbyText(el: Element): string {
         const parent = el.closest('[class]') ?? el.parentElement
         return parent?.textContent ?? ''
       }
@@ -133,10 +142,9 @@ export async function scrapeClaudeUsage(headed = false): Promise<ClaudeUsageData
         else if (weeklyPct == null) weeklyPct = pct
       }
 
-      // --- Strategy 2: text extraction ---
+      // --- Strategy 2: text extraction fallback ---
       if (sessionPct == null || weeklyPct == null) {
         const body = document.body.innerText
-        // Look for "X% used" or "X%" near section headings
         const sessionM = body.match(/current session[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
           ?? body.match(/(\d+(?:\.\d+)?)\s*%[^]*?current session/i)
         const weeklyM = body.match(/weekly[^0-9]*(\d+(?:\.\d+)?)\s*%/i)
@@ -147,10 +155,9 @@ export async function scrapeClaudeUsage(headed = false): Promise<ClaudeUsageData
         if (weeklyPct == null && weeklyM) weeklyPct = parseFloat(weeklyM[1])
       }
 
-      // --- Reset times: look for countdown/reset text ---
+      // --- Reset times: parse countdown / "resets at HH:MM" text ---
       function parseResetMs(keyword: string): number {
         const body = document.body.innerText
-        // "Resets in 2h 15m" / "resets at HH:MM" / ISO date strings
         const re = new RegExp(keyword + '[^\\n]{0,120}reset[s]?[^\\n]{0,80}', 'i')
         const m = re.exec(body)
         const ctx = m ? m[0] : body
@@ -203,6 +210,10 @@ export async function scrapeClaudeUsage(headed = false): Promise<ClaudeUsageData
     logger.warn({ err }, 'claude-usage: scrape failed')
     return null
   } finally {
+    // Close only the page we opened; never close the user's browser.
+    if (page && ownedPage) await page.close().catch(() => {})
+    // On CDP connections Playwright's browser.close() only disconnects the
+    // session — it does NOT shut down the user's Chrome process.
     await browser.close()
   }
 }

--- a/src/web/routes/claude-usage.ts
+++ b/src/web/routes/claude-usage.ts
@@ -19,7 +19,7 @@ export async function tryHandleClaudeUsage(ctx: RouteContext): Promise<boolean> 
   if (path === '/api/claude-usage/refresh' && method === 'POST') {
     // Trigger a background scrape; respond immediately so the caller isn't blocked
     // on a 10+ second Playwright launch.
-    scrapeClaudeUsage(false).catch(err => logger.warn({ err }, 'claude-usage refresh failed'))
+    scrapeClaudeUsage().catch(err => logger.warn({ err }, 'claude-usage refresh failed'))
     json(res, { ok: true, message: 'refresh triggered' })
     return true
   }

--- a/src/web/routes/claude-usage.ts
+++ b/src/web/routes/claude-usage.ts
@@ -1,0 +1,28 @@
+import { readUsageCache, scrapeClaudeUsage } from '../claude-usage-scraper.js'
+import { json } from '../http-helpers.js'
+import { logger } from '../../logger.js'
+import type { RouteContext } from './types.js'
+
+export async function tryHandleClaudeUsage(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method } = ctx
+
+  if (path === '/api/claude-usage' && method === 'GET') {
+    const data = readUsageCache()
+    if (!data) {
+      json(res, { available: false })
+    } else {
+      json(res, { available: true, ...data })
+    }
+    return true
+  }
+
+  if (path === '/api/claude-usage/refresh' && method === 'POST') {
+    // Trigger a background scrape; respond immediately so the caller isn't blocked
+    // on a 10+ second Playwright launch.
+    scrapeClaudeUsage(false).catch(err => logger.warn({ err }, 'claude-usage refresh failed'))
+    json(res, { ok: true, message: 'refresh triggered' })
+    return true
+  }
+
+  return false
+}

--- a/web/app.js
+++ b/web/app.js
@@ -9852,6 +9852,7 @@ async function loadTokenUsage() {
   const timeline = await tlRes.json()
   renderTuTimeline(timeline, agent)
   renderTuBudgetCards()
+  renderTuLimitBars()
 
   tuDetailSearch = ''
   const searchEl = document.getElementById('tuSearchInput')
@@ -10325,6 +10326,128 @@ function renderTuBudgetCards() {
     })
   })
 }
+
+// --- Token limit progress bars (shared component: #tuLimitBarsInner + #sidebarTokenWidget) ---
+// Limits are persisted in localStorage so the user can tune them to match their subscription.
+const TU_LIMIT_5H_DEFAULT = 5_000_000
+const TU_LIMIT_WEEKLY_DEFAULT = 100_000_000
+
+function tuGetLimits() {
+  return {
+    limit5h: parseInt(localStorage.getItem('tu_limit_5h') || '') || TU_LIMIT_5H_DEFAULT,
+    limitWeekly: parseInt(localStorage.getItem('tu_limit_weekly') || '') || TU_LIMIT_WEEKLY_DEFAULT,
+  }
+}
+
+function tuFormat5hCountdown() {
+  const now = Date.now()
+  const windowMs = 5 * 3600 * 1000
+  const windowEnd = Math.ceil(now / windowMs) * windowMs
+  const msLeft = windowEnd - now
+  const h = Math.floor(msLeft / 3600000)
+  const m = Math.floor((msLeft % 3600000) / 60000)
+  const s = Math.floor((msLeft % 60000) / 1000)
+  return h > 0 ? `${h} ó ${m.toString().padStart(2,'0')} p` : `${m} p ${s.toString().padStart(2,'0')} mp`
+}
+
+// Renders the content of a token-limit bar block into `innerEl`.
+// compact=true → sidebar mini version; compact=false → full card version.
+function renderTokenLimitBarsInto(innerEl, compact) {
+  const cur5h = tuChartState?.win5h?.length
+    ? tuChartState.win5h[tuChartState.win5h.length - 1].cumulative : 0
+  const curWeekly = tuChartState?.winWeekly?.length
+    ? tuChartState.winWeekly[tuChartState.winWeekly.length - 1].cumulative : 0
+  const { limit5h, limitWeekly } = tuGetLimits()
+  const pct5h = Math.min(100, limit5h > 0 ? Math.round(cur5h / limit5h * 100) : 0)
+  const pctWeekly = Math.min(100, limitWeekly > 0 ? Math.round(curWeekly / limitWeekly * 100) : 0)
+  const countdown = tuFormat5hCountdown()
+  const color5h = pct5h >= 90 ? '#ef4444' : pct5h >= 70 ? '#f59e0b' : '#06b6d4'
+  const colorW = pctWeekly >= 90 ? '#ef4444' : pctWeekly >= 70 ? '#f59e0b' : '#8b5cf6'
+
+  if (compact) {
+    innerEl.innerHTML = `
+      <div style="font-size:11px;color:var(--text-secondary);margin-bottom:6px;display:flex;justify-content:space-between">
+        <span>Token korlátok</span>
+        <span style="color:${color5h}">↻ ${countdown}</span>
+      </div>
+      <div style="margin-bottom:5px">
+        <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px">
+          <span style="color:var(--text-secondary)">Aktuális session</span>
+          <span style="color:${color5h};font-weight:600">${pct5h}%</span>
+        </div>
+        <div style="height:5px;border-radius:3px;background:var(--border);overflow:hidden">
+          <div style="height:100%;width:${pct5h}%;background:${color5h};border-radius:3px;transition:width .3s"></div>
+        </div>
+        <div style="font-size:10px;color:var(--text-secondary);margin-top:1px">${tuFormatTokens(cur5h)} / ${tuFormatTokens(limit5h)}</div>
+      </div>
+      <div>
+        <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px">
+          <span style="color:var(--text-secondary)">Heti limit / összes modell</span>
+          <span style="color:${colorW};font-weight:600">${pctWeekly}%</span>
+        </div>
+        <div style="height:5px;border-radius:3px;background:var(--border);overflow:hidden">
+          <div style="height:100%;width:${pctWeekly}%;background:${colorW};border-radius:3px;transition:width .3s"></div>
+        </div>
+        <div style="font-size:10px;color:var(--text-secondary);margin-top:1px">${tuFormatTokens(curWeekly)} / ${tuFormatTokens(limitWeekly)}</div>
+      </div>`
+  } else {
+    innerEl.innerHTML = `
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;flex-wrap:wrap;gap:8px">
+        <h3 style="margin:0">Fogyasztási korlátok</h3>
+        <span style="font-size:13px;color:var(--text-secondary)">5h ablak visszaáll: <strong style="color:${color5h}">${countdown}</strong></span>
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+        <div>
+          <div style="display:flex;justify-content:space-between;margin-bottom:4px">
+            <span style="font-size:13px;font-weight:600">Aktuális session</span>
+            <span style="font-size:13px;color:${color5h};font-weight:700">${pct5h}%</span>
+          </div>
+          <div style="height:10px;border-radius:5px;background:var(--border);overflow:hidden;margin-bottom:4px">
+            <div style="height:100%;width:${pct5h}%;background:${color5h};border-radius:5px;transition:width .4s ease"></div>
+          </div>
+          <div style="font-size:12px;color:var(--text-secondary)">${tuFormatTokens(cur5h)} / <button class="btn-link tu-edit-limit" data-key="tu_limit_5h" data-cur="${limit5h}" title="Korlát szerkesztése" style="font-size:12px">${tuFormatTokens(limit5h)}</button></div>
+        </div>
+        <div>
+          <div style="display:flex;justify-content:space-between;margin-bottom:4px">
+            <span style="font-size:13px;font-weight:600">Heti limit / összes modell</span>
+            <span style="font-size:13px;color:${colorW};font-weight:700">${pctWeekly}%</span>
+          </div>
+          <div style="height:10px;border-radius:5px;background:var(--border);overflow:hidden;margin-bottom:4px">
+            <div style="height:100%;width:${pctWeekly}%;background:${colorW};border-radius:5px;transition:width .4s ease"></div>
+          </div>
+          <div style="font-size:12px;color:var(--text-secondary)">${tuFormatTokens(curWeekly)} / <button class="btn-link tu-edit-limit" data-key="tu_limit_weekly" data-cur="${limitWeekly}" title="Korlát szerkesztése" style="font-size:12px">${tuFormatTokens(limitWeekly)}</button></div>
+        </div>
+      </div>`
+
+    innerEl.querySelectorAll('.tu-edit-limit').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const raw = prompt('Új korlát (tokenek száma):', btn.dataset.cur)
+        if (!raw) return
+        const v = parseInt(raw.replace(/[^0-9]/g, ''))
+        if (!Number.isFinite(v) || v <= 0) { showToast('Érvénytelen érték'); return }
+        localStorage.setItem(btn.dataset.key, String(v))
+        renderTuLimitBars()
+      })
+    })
+  }
+}
+
+function renderTuLimitBars() {
+  const cardInner = document.getElementById('tuLimitBarsInner')
+  if (cardInner) renderTokenLimitBarsInto(cardInner, false)
+
+  const sidebarEl = document.getElementById('sidebarTokenWidget')
+  if (sidebarEl) {
+    if (!tuChartState) { sidebarEl.style.display = 'none'; return }
+    sidebarEl.style.display = 'block'
+    renderTokenLimitBarsInto(sidebarEl, true)
+  }
+}
+
+// Refresh the countdown every 10 seconds while the page is visible.
+setInterval(() => {
+  if (tuChartState) renderTuLimitBars()
+}, 10000)
 
 let tuDetailData = []
 let tuDetailSort = { col: 'timestamp', dir: 'desc' }

--- a/web/app.js
+++ b/web/app.js
@@ -9852,7 +9852,7 @@ async function loadTokenUsage() {
   const timeline = await tlRes.json()
   renderTuTimeline(timeline, agent)
   renderTuBudgetCards()
-  renderTuLimitBars()
+  renderTuLimitBars()  // async, non-blocking
 
   tuDetailSearch = ''
   const searchEl = document.getElementById('tuSearchInput')
@@ -10328,125 +10328,153 @@ function renderTuBudgetCards() {
 }
 
 // --- Token limit progress bars (shared component: #tuLimitBarsInner + #sidebarTokenWidget) ---
-// Limits are persisted in localStorage so the user can tune them to match their subscription.
-const TU_LIMIT_5H_DEFAULT = 5_000_000
-const TU_LIMIT_WEEKLY_DEFAULT = 100_000_000
+// Real usage data comes from /api/claude-usage (scrapes claude.ai/settings/usage via Playwright).
+// If data is unavailable (not logged in / scrape failed) we show an explicit "not available" state
+// instead of a potentially misleading local estimate.
 
-function tuGetLimits() {
-  return {
-    limit5h: parseInt(localStorage.getItem('tu_limit_5h') || '') || TU_LIMIT_5H_DEFAULT,
-    limitWeekly: parseInt(localStorage.getItem('tu_limit_weekly') || '') || TU_LIMIT_WEEKLY_DEFAULT,
-  }
+let tuUsageData = null  // { sessionPct, weeklyPct, sessionResetAt, weeklyResetAt } or null
+
+async function tuFetchUsageData() {
+  try {
+    const r = await fetch('/api/claude-usage')
+    if (!r.ok) return
+    const d = await r.json()
+    tuUsageData = d.available ? d : null
+  } catch { /* ignore */ }
 }
 
-function tuFormat5hCountdown() {
-  const now = Date.now()
-  const windowMs = 5 * 3600 * 1000
-  const windowEnd = Math.ceil(now / windowMs) * windowMs
-  const msLeft = windowEnd - now
+function tuFormatCountdown(resetAtMs) {
+  if (!resetAtMs) return '--'
+  const msLeft = Math.max(0, resetAtMs - Date.now())
   const h = Math.floor(msLeft / 3600000)
   const m = Math.floor((msLeft % 3600000) / 60000)
-  const s = Math.floor((msLeft % 60000) / 1000)
-  return h > 0 ? `${h} ó ${m.toString().padStart(2,'0')} p` : `${m} p ${s.toString().padStart(2,'0')} mp`
+  return h > 0 ? `${h} ó ${m.toString().padStart(2, '0')} p` : `${m} p`
 }
 
 // Renders the content of a token-limit bar block into `innerEl`.
 // compact=true → sidebar mini version; compact=false → full card version.
 function renderTokenLimitBarsInto(innerEl, compact) {
-  const cur5h = tuChartState?.win5h?.length
-    ? tuChartState.win5h[tuChartState.win5h.length - 1].cumulative : 0
-  const curWeekly = tuChartState?.winWeekly?.length
-    ? tuChartState.winWeekly[tuChartState.winWeekly.length - 1].cumulative : 0
-  const { limit5h, limitWeekly } = tuGetLimits()
-  const pct5h = Math.min(100, limit5h > 0 ? Math.round(cur5h / limit5h * 100) : 0)
-  const pctWeekly = Math.min(100, limitWeekly > 0 ? Math.round(curWeekly / limitWeekly * 100) : 0)
-  const countdown = tuFormat5hCountdown()
-  const color5h = pct5h >= 90 ? '#ef4444' : pct5h >= 70 ? '#f59e0b' : '#06b6d4'
-  const colorW = pctWeekly >= 90 ? '#ef4444' : pctWeekly >= 70 ? '#f59e0b' : '#8b5cf6'
+  if (!tuUsageData) {
+    if (compact) {
+      innerEl.innerHTML = `<div style="font-size:11px;color:var(--text-secondary);text-align:center;padding:4px 0">
+        Token limit adat nem elérhető.<br>
+        <button class="btn-link" id="tuUsageLoginBtn" style="font-size:11px">Bejelentkezés →</button>
+      </div>`
+      innerEl.querySelector('#tuUsageLoginBtn')?.addEventListener('click', triggerUsageLogin)
+    } else {
+      innerEl.innerHTML = `
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
+          <h3 style="margin:0">Fogyasztási korlátok</h3>
+        </div>
+        <div style="color:var(--text-secondary);font-size:13px;display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+          <span>Adat nem elérhető — a claude.ai session nincs bejelentkezve.</span>
+          <button class="btn-secondary btn-compact" id="tuUsageLoginBtnFull">Bejelentkezés (headed)</button>
+        </div>`
+      innerEl.querySelector('#tuUsageLoginBtnFull')?.addEventListener('click', triggerUsageLogin)
+    }
+    return
+  }
+
+  const { sessionPct, weeklyPct, sessionResetAt, weeklyResetAt } = tuUsageData
+  const sessionCountdown = tuFormatCountdown(sessionResetAt)
+  const weeklyCountdown = tuFormatCountdown(weeklyResetAt)
+  const color5h = sessionPct >= 90 ? '#ef4444' : sessionPct >= 70 ? '#f59e0b' : '#06b6d4'
+  const colorW = weeklyPct >= 90 ? '#ef4444' : weeklyPct >= 70 ? '#f59e0b' : '#8b5cf6'
 
   if (compact) {
     innerEl.innerHTML = `
       <div style="font-size:11px;color:var(--text-secondary);margin-bottom:6px;display:flex;justify-content:space-between">
-        <span>Token korlátok</span>
-        <span style="color:${color5h}">↻ ${countdown}</span>
+        <span>claude.ai korlátok</span>
+        <span style="color:${color5h}">↻ ${sessionCountdown}</span>
       </div>
       <div style="margin-bottom:5px">
         <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px">
           <span style="color:var(--text-secondary)">Aktuális session</span>
-          <span style="color:${color5h};font-weight:600">${pct5h}%</span>
+          <span style="color:${color5h};font-weight:600">${sessionPct}%</span>
         </div>
         <div style="height:5px;border-radius:3px;background:var(--border);overflow:hidden">
-          <div style="height:100%;width:${pct5h}%;background:${color5h};border-radius:3px;transition:width .3s"></div>
+          <div style="height:100%;width:${Math.min(100,sessionPct)}%;background:${color5h};border-radius:3px;transition:width .3s"></div>
         </div>
-        <div style="font-size:10px;color:var(--text-secondary);margin-top:1px">${tuFormatTokens(cur5h)} / ${tuFormatTokens(limit5h)}</div>
       </div>
       <div>
         <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px">
-          <span style="color:var(--text-secondary)">Heti limit / összes modell</span>
-          <span style="color:${colorW};font-weight:600">${pctWeekly}%</span>
+          <span style="color:var(--text-secondary)">Heti / összes modell</span>
+          <span style="color:${colorW};font-weight:600">${weeklyPct}%</span>
         </div>
         <div style="height:5px;border-radius:3px;background:var(--border);overflow:hidden">
-          <div style="height:100%;width:${pctWeekly}%;background:${colorW};border-radius:3px;transition:width .3s"></div>
+          <div style="height:100%;width:${Math.min(100,weeklyPct)}%;background:${colorW};border-radius:3px;transition:width .3s"></div>
         </div>
-        <div style="font-size:10px;color:var(--text-secondary);margin-top:1px">${tuFormatTokens(curWeekly)} / ${tuFormatTokens(limitWeekly)}</div>
       </div>`
   } else {
     innerEl.innerHTML = `
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;flex-wrap:wrap;gap:8px">
         <h3 style="margin:0">Fogyasztási korlátok</h3>
-        <span style="font-size:13px;color:var(--text-secondary)">5h ablak visszaáll: <strong style="color:${color5h}">${countdown}</strong></span>
+        <button class="btn-secondary btn-compact" id="tuUsageRefreshBtn">↻ Frissítés</button>
       </div>
       <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
         <div>
           <div style="display:flex;justify-content:space-between;margin-bottom:4px">
             <span style="font-size:13px;font-weight:600">Aktuális session</span>
-            <span style="font-size:13px;color:${color5h};font-weight:700">${pct5h}%</span>
+            <span style="font-size:13px;color:${color5h};font-weight:700">${sessionPct}%</span>
           </div>
           <div style="height:10px;border-radius:5px;background:var(--border);overflow:hidden;margin-bottom:4px">
-            <div style="height:100%;width:${pct5h}%;background:${color5h};border-radius:5px;transition:width .4s ease"></div>
+            <div style="height:100%;width:${Math.min(100,sessionPct)}%;background:${color5h};border-radius:5px;transition:width .4s ease"></div>
           </div>
-          <div style="font-size:12px;color:var(--text-secondary)">${tuFormatTokens(cur5h)} / <button class="btn-link tu-edit-limit" data-key="tu_limit_5h" data-cur="${limit5h}" title="Korlát szerkesztése" style="font-size:12px">${tuFormatTokens(limit5h)}</button></div>
+          <div style="font-size:12px;color:var(--text-secondary)">Visszaáll: ${sessionCountdown}</div>
         </div>
         <div>
           <div style="display:flex;justify-content:space-between;margin-bottom:4px">
             <span style="font-size:13px;font-weight:600">Heti limit / összes modell</span>
-            <span style="font-size:13px;color:${colorW};font-weight:700">${pctWeekly}%</span>
+            <span style="font-size:13px;color:${colorW};font-weight:700">${weeklyPct}%</span>
           </div>
           <div style="height:10px;border-radius:5px;background:var(--border);overflow:hidden;margin-bottom:4px">
-            <div style="height:100%;width:${pctWeekly}%;background:${colorW};border-radius:5px;transition:width .4s ease"></div>
+            <div style="height:100%;width:${Math.min(100,weeklyPct)}%;background:${colorW};border-radius:5px;transition:width .4s ease"></div>
           </div>
-          <div style="font-size:12px;color:var(--text-secondary)">${tuFormatTokens(curWeekly)} / <button class="btn-link tu-edit-limit" data-key="tu_limit_weekly" data-cur="${limitWeekly}" title="Korlát szerkesztése" style="font-size:12px">${tuFormatTokens(limitWeekly)}</button></div>
+          <div style="font-size:12px;color:var(--text-secondary)">Visszaáll: ${weeklyCountdown}</div>
         </div>
       </div>`
 
-    innerEl.querySelectorAll('.tu-edit-limit').forEach(btn => {
-      btn.addEventListener('click', () => {
-        const raw = prompt('Új korlát (tokenek száma):', btn.dataset.cur)
-        if (!raw) return
-        const v = parseInt(raw.replace(/[^0-9]/g, ''))
-        if (!Number.isFinite(v) || v <= 0) { showToast('Érvénytelen érték'); return }
-        localStorage.setItem(btn.dataset.key, String(v))
-        renderTuLimitBars()
-      })
+    innerEl.querySelector('#tuUsageRefreshBtn')?.addEventListener('click', async () => {
+      const btn = innerEl.querySelector('#tuUsageRefreshBtn')
+      if (btn) btn.textContent = '...'
+      await fetch('/api/claude-usage/refresh', { method: 'POST' })
+      await new Promise(r => setTimeout(r, 12000))  // wait for Playwright scrape
+      await tuFetchUsageData()
+      renderTuLimitBars()
     })
   }
 }
 
-function renderTuLimitBars() {
+async function triggerUsageLogin() {
+  const ok = confirm('Headless bejelentkezéshez nyiss egy terminált és futtasd:\n\nCLAUDE_USAGE_HEADED=1 node dist/scripts/claude-usage-mcp.js\n\nEz megnyitja a böngészőt, ahol bejelentkezhetsz.')
+  if (!ok) return
+  showToast('Futtasd a terminálban: CLAUDE_USAGE_HEADED=1 node dist/scripts/claude-usage-mcp.js')
+}
+
+async function renderTuLimitBars() {
+  await tuFetchUsageData()
+
   const cardInner = document.getElementById('tuLimitBarsInner')
   if (cardInner) renderTokenLimitBarsInto(cardInner, false)
 
   const sidebarEl = document.getElementById('sidebarTokenWidget')
   if (sidebarEl) {
-    if (!tuChartState) { sidebarEl.style.display = 'none'; return }
     sidebarEl.style.display = 'block'
     renderTokenLimitBarsInto(sidebarEl, true)
   }
 }
 
-// Refresh the countdown every 10 seconds while the page is visible.
-setInterval(() => {
-  if (tuChartState) renderTuLimitBars()
+// Refresh countdown text every 10 seconds; re-fetch data every 5 minutes.
+let tuLimitTickCount = 0
+setInterval(async () => {
+  tuLimitTickCount++
+  if (tuLimitTickCount % 30 === 0) await tuFetchUsageData()  // full fetch every 5 min
+  const cardInner = document.getElementById('tuLimitBarsInner')
+  if (cardInner && document.getElementById('tokenUsagePage') && !document.getElementById('tokenUsagePage').hidden) {
+    renderTokenLimitBarsInto(cardInner, false)
+  }
+  const sidebarEl = document.getElementById('sidebarTokenWidget')
+  if (sidebarEl && sidebarEl.style.display !== 'none') renderTokenLimitBarsInto(sidebarEl, true)
 }, 10000)
 
 let tuDetailData = []

--- a/web/app.js
+++ b/web/app.js
@@ -8905,6 +8905,7 @@ populateAvatarGrid()
 loadMemAgents()
 loadOverview()
 loadAvailableModels()
+renderTuLimitBars()  // populate the sidebar token widget on startup (not only after visiting Token Monitor)
 
 // "DeepSeek API kulcs hozzáadása" link az agent edit panel-en --
 // a Vault page-re visz, ahol a felhasználó egy DEEPSEEK_API_KEY

--- a/web/app.js
+++ b/web/app.js
@@ -10383,9 +10383,8 @@ function renderTokenLimitBarsInto(innerEl, compact) {
 
   if (compact) {
     innerEl.innerHTML = `
-      <div style="font-size:11px;color:var(--text-secondary);margin-bottom:6px;display:flex;justify-content:space-between">
+      <div style="font-size:11px;color:var(--text-secondary);margin-bottom:6px">
         <span>claude.ai korlátok</span>
-        <span style="color:${color5h}">↻ ${sessionCountdown}</span>
       </div>
       <div style="margin-bottom:5px">
         <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px">
@@ -10395,6 +10394,7 @@ function renderTokenLimitBarsInto(innerEl, compact) {
         <div style="height:5px;border-radius:3px;background:var(--border);overflow:hidden">
           <div style="height:100%;width:${Math.min(100,sessionPct)}%;background:${color5h};border-radius:3px;transition:width .3s"></div>
         </div>
+        <div style="font-size:10px;color:var(--text-secondary);margin-top:1px">↻ ${sessionCountdown}</div>
       </div>
       <div>
         <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px">
@@ -10404,6 +10404,7 @@ function renderTokenLimitBarsInto(innerEl, compact) {
         <div style="height:5px;border-radius:3px;background:var(--border);overflow:hidden">
           <div style="height:100%;width:${Math.min(100,weeklyPct)}%;background:${colorW};border-radius:3px;transition:width .3s"></div>
         </div>
+        <div style="font-size:10px;color:var(--text-secondary);margin-top:1px">↻ ${weeklyCountdown}</div>
       </div>`
   } else {
     innerEl.innerHTML = `

--- a/web/index.html
+++ b/web/index.html
@@ -134,6 +134,7 @@
         <span class="updates-badge sb-badge" id="updatesBadge" hidden></span>
       </a>
     </nav>
+    <div id="sidebarTokenWidget" style="padding:10px 12px 4px;border-top:1px solid var(--border);display:none"></div>
     <div class="sidebar-footer">
       <button class="theme-toggle" id="mobileLoginBtn" title="Mobil belépés (QR)">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><line x1="14" y1="14" x2="14" y2="14.01"/><line x1="21" y1="14" x2="21" y2="21"/><line x1="14" y1="21" x2="17" y2="21"/></svg>
@@ -1269,6 +1270,10 @@
         <div id="tuTimelineChart" style="height:370px;position:relative;overflow:hidden">
           <canvas id="tuCanvas"></canvas>
         </div>
+      </div>
+
+      <div class="overview-card" style="margin-bottom:16px" id="tuLimitBarsCard">
+        <div id="tuLimitBarsInner"></div>
       </div>
 
       <div class="overview-card">


### PR DESCRIPTION
## Summary

Real claude.ai usage limits on the Token Monitor screen and as a sidebar widget — two progress bars (current session + weekly/all-models) with percentage, color thresholds (70%/90%), and reset countdowns, mirroring claude.ai/settings/usage.

- Data source: a small Playwright scraper reads the live claude.ai usage page over the Chrome DevTools Protocol (connectOverCDP) against the user's real, logged-in Chrome — this passes Cloudflare and uses the real subscription session (no official API exists for these numbers).
- Backend: GET /api/claude-usage (cached) + POST /api/claude-usage/refresh, with a 15-min poll. Falls back to an explicit "not available" state instead of a misleading local estimate.
- MCP server (scripts/claude-usage-mcp.ts) exposing get_usage.
- Docs in HU + EN, including the setup (dedicated Chrome profile + --remote-debugging-port; Chrome 149+ blocks the debug port on the default profile).
- No credentials, cookies, or session tokens are written to code, logs, or git; the browser profile dir and usage cache are gitignored.

## Setup note

The scraper connects to a user-launched Chrome started with --remote-debugging-port using a dedicated --user-data-dir (see docs/token-usage.md). If Chrome isn't running on the port, the feature degrades gracefully to "not available".

## AI authorship

Authored with AI assistance by the project's own Zack and Jarvis agents (Claude), under human review by @cett before submission.

## Test plan

- [ ] Start Chrome with the dedicated profile + debug port, log into claude.ai
- [ ] Token Monitor → bars show real session/weekly % with correct, differing reset times
- [ ] Sidebar widget shows both bars + both countdowns on any page from first load
- [ ] Chrome not on the port → "not available" state, no crash