### PR TITLE
fix(install): drop the interactive brand prompt -- always brand as the agent

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -573,35 +573,14 @@ if [ "$MAIN_AGENT_ID" != "marveen" ]; then
   echo -e "  ${DIM}Ügynök belső azonosító: ${MAIN_AGENT_ID}${NC}"
 fi
 
-# Product / system brand. Separate from BOT_NAME (the main agent's display
-# name): an operator may want the product called one thing and the agent
-# another. Defaults to BOT_NAME, so an operator who just presses Enter gets
-# today's behaviour with no brand divergence.
-read -p "  Mi a termék/márka neve? [${BOT_NAME}]: " BRAND_NAME
-BRAND_NAME=${BRAND_NAME:-"$BOT_NAME"}
-
-# Slug for service labels (systemd units) derived from BRAND_NAME with the SAME
-# NFKD rule as MAIN_AGENT_ID. DEFAULT-SAFE: when BRAND_NAME equals BOT_NAME (the
-# default), this slug equals MAIN_AGENT_ID, so the systemd unit names below are
-# byte-identical to a brand-unaware install. Only an operator who types a
-# DIFFERENT brand gets brand-based unit names -- in-place upgrades that keep the
-# default are untouched.
-BRAND_SLUG=$(python3 - "$BRAND_NAME" <<'PYEOF'
-import sys, unicodedata, re
-s = sys.argv[1].strip()
-s = unicodedata.normalize('NFKD', s).encode('ASCII', 'ignore').decode()
-s = re.sub(r'[^a-zA-Z0-9]+', '-', s).strip('-').lower()
-print(s or 'marveen')
-PYEOF
-)
-# The id used for systemd unit names: brand slug when the operator chose a brand
-# distinct from the agent id, otherwise the agent id (unchanged default).
-if [ "$BRAND_SLUG" != "$MAIN_AGENT_ID" ]; then
-  SERVICE_ID="$BRAND_SLUG"
-  echo -e "  ${DIM}Szolgáltatás-azonosító (systemd): ${SERVICE_ID}${NC}"
-else
-  SERVICE_ID="$MAIN_AGENT_ID"
-fi
+# Product / system brand. Per Szabi's decision the installer does NOT prompt for
+# a brand -- the product is always named after the main agent. BRAND_NAME and
+# SERVICE_ID remain as fields (config.ts keeps the env support as a dormant
+# capability, default = the agent name), but the install flow hardcodes them to
+# the defaults, so the systemd unit names below stay byte-identical to a
+# brand-unaware install.
+BRAND_NAME="$BOT_NAME"
+SERVICE_ID="$MAIN_AGENT_ID"
 
 INSTALL_STEP="npm-install"
 # ─────────────────────────────────────────────

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -345,35 +345,14 @@ if [ "$MAIN_AGENT_ID" != "marveen" ]; then
   echo -e "  ${DIM}Ügynök belső azonosító: ${MAIN_AGENT_ID}${NC}"
 fi
 
-# Product / system brand. Separate from BOT_NAME (the main agent's display
-# name): an operator may want the product called one thing and the agent
-# another. Defaults to BOT_NAME, so an operator who just presses Enter gets
-# today's behaviour with no brand divergence.
-read -p "  Mi a termék/márka neve? [${BOT_NAME}]: " BRAND_NAME
-BRAND_NAME=${BRAND_NAME:-"$BOT_NAME"}
-
-# Slug for service labels (launchd) derived from BRAND_NAME with the SAME NFKD
-# rule as MAIN_AGENT_ID. DEFAULT-SAFE: when BRAND_NAME equals BOT_NAME (the
-# default), this slug equals MAIN_AGENT_ID, so the launchd labels below are
-# byte-identical to a brand-unaware install. Only an operator who types a
-# DIFFERENT brand gets brand-based labels -- in-place upgrades that keep the
-# default are untouched.
-BRAND_SLUG=$(python3 - "$BRAND_NAME" <<'PYEOF'
-import sys, unicodedata, re
-s = sys.argv[1].strip()
-s = unicodedata.normalize('NFKD', s).encode('ASCII', 'ignore').decode()
-s = re.sub(r'[^a-zA-Z0-9]+', '-', s).strip('-').lower()
-print(s or 'marveen')
-PYEOF
-)
-# The id used for launchd service labels: brand slug when the operator chose a
-# brand distinct from the agent id, otherwise the agent id (unchanged default).
-if [ "$BRAND_SLUG" != "$MAIN_AGENT_ID" ]; then
-  SERVICE_ID="$BRAND_SLUG"
-  echo -e "  ${DIM}Szolgáltatás-azonosító (launchd): ${SERVICE_ID}${NC}"
-else
-  SERVICE_ID="$MAIN_AGENT_ID"
-fi
+# Product / system brand. Per Szabi's decision the installer does NOT prompt for
+# a brand -- the product is always named after the main agent. BRAND_NAME and
+# SERVICE_ID remain as fields (config.ts keeps the env support as a dormant
+# capability, default = the agent name), but the install flow hardcodes them to
+# the defaults, so the launchd labels below stay byte-identical to a
+# brand-unaware install.
+BRAND_NAME="$BOT_NAME"
+SERVICE_ID="$MAIN_AGENT_ID"
 
 # Step 5: Install dependencies
 INSTALL_STEP="npm-install"


### PR DESCRIPTION
## Kontextus

Szabi döntése: a telepítő **ne kérdezzen** termék/márka nevet. A #379 brand-promptját kivesszük a flow-ból; a config.ts BRAND_NAME/SERVICE_ID env-támogatás **marad** mint szunnyadó képesség (default = az agent neve), csak a telepítő nem exponálja.

## Mit csinál

Mindkét scriptből (`install-macos.sh` + `install-linux.sh`) törölve:
- a `read -p "Mi a termék/márka neve?"` prompt,
- a `BRAND_SLUG` NFKD-derivation,
- a `SERVICE_ID` elágazás.

Helyette hardcode a defaultokra:
```sh
BRAND_NAME="$BOT_NAME"
SERVICE_ID="$MAIN_AGENT_ID"
```

A service-labelek továbbra is `SERVICE_ID`-ből épülnek, ami most mindig `MAIN_AGENT_ID` → a launchd labelek (`com.<id>.channels`/`.dashboard`) és systemd unit-nevek **byte-azonosak a #379 előtti** brand-unaware állapottal.

## Verify

- `bash -n` tiszta mindkét scriptre.
- Nincs maradék brand-prompt / `BRAND_SLUG` referencia.
- Szimuláció: `BOT_NAME=Marveen` → `SERVICE_ID=marveen` → `com.marveen.channels` (= pre-#379).
- A telepítő nem áll meg brand-inputra (prompt eltávolítva).

🤖 Generated with [Claude Code](https://claude.com/claude-code)