### PR TITLE
Feat/Kanban detail/editor improvements

### DIFF
--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -1,0 +1,63 @@
+# Kanban + automatic task breakdown
+
+> Every task lives on a card. Drop in a big goal and the assistant breaks it down into subtasks on its own.
+
+---
+
+## 🎯 What it does / why it matters
+
+You don't need to micro-manage the fleet — that's the point of this kanban system. Throw in a large, vague goal ("let's get X done") and the agent automatically breaks it into a subtask hierarchy, assigns the right owner, and tracks progress. You see the result and milestones, not the internal steps.
+
+Two things make it special:
+
+1. **Automatic breakdown:** the LLM turns a task into a card hierarchy (linked with `parent_id`), which you can approve or refine — no need to hold the full to-do list in your head.
+2. **Self-driving audit:** every 4 hours the system reviews the board itself — archives old closed cards and follows up with the responsible agent on stalled tasks. You don't need to knock and ask "how's that thing going?"
+
+**Highlight:** card statuses are automatically included in every agent's context. Nobody needs a separate briefing on "where we are" — everyone sees the full picture and picks up where the other left off.
+
+---
+
+## 🛠 How it works
+
+### Storage
+
+SQLite (`store/`): `kanban_cards` (id, title, status, project, priority, assignee, sort_order, archived_at, timestamps) + `kanban_comments` (card-level log).
+
+- **Statuses:** `planned`, `in_progress`, `waiting`, `done`
+- **Priorities:** `low`, `normal`, `high`, `urgent`
+
+### Automatic breakdown
+
+For a new large task, a single LLM call (headless `claude -p` via the existing subscription, no external API key) proposes a subtask hierarchy as cards linked with `parent_id`. The user/orchestrator approves, refines, or rejects.
+
+### 4-hour audit
+
+Scheduled task (at 8/12/16/20) relying on a state file (`last_audit_at`):
+1. Archive cards closed 7+ days ago.
+2. Stalled task = `in_progress` that hasn't moved since the previous audit (`updated_at < last_audit_at`) → message to the responsible agent.
+3. Behaviour governed by [progressive autonomy](heartbeat-autonomy.md) level (3: acts; 2: suggests; 1: only notifies).
+
+### Kanban-first workflow
+
+Every project task runs on a card: the orchestrator records it as a card, delegates to the responsible agent (`assignee`), who updates status and comments back. Meta-tasks (like the audit itself) don't get cards.
+
+### Access
+
+Direct SQLite, or the dashboard kanban interface. Card status is automatically included in every agent's context.
+
+### Dashboard kanban interface
+
+Key behaviours in the card editor on the web dashboard (`http://localhost:3420`):
+
+- **Comment author default:** the primary human assignee (`owner` type) is pre-selected as the comment author for new comments, not the bot.
+- **Add subtask:** parent cards (not subtasks themselves) show a "New subtask" form. The new subtask inherits the parent's current status. Adding a subtask to a `done` parent is not allowed.
+- **Delete subtask:** each subtask row shows a Delete button with a confirmation dialog. The button is hidden when the parent is `done`.
+- **Parent assignment editing:** in the subtask detail view (`planned` and `waiting` status only), a dropdown lets you change or detach the parent task. It appears in the card properties row, full-width.
+
+---
+
+## Related documents
+
+- [Ideas (Idea box)](ideas.md) — from ideas to kanban cards (with AI breakdown)
+- [Agent fleet](agent-fleet.md) — assignee agents, delegation
+- [Heartbeat autonomy](heartbeat-autonomy.md) — kanban audit autonomy level

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -44,3 +44,12 @@ Minden projekt-feladat kártyán fut: az orchestrator kártyaként rögzíti, on
 ### Hozzáférés
 
 Közvetlen SQLite, vagy a dashboard kanban-felülete. A kártya-állapot minden ügynök kontextusába automatikusan bekerül.
+
+### Dashboard kanban felület
+
+A webes dashboard (`http://localhost:3420`) kártyaszerkesztőjének főbb viselkedései:
+
+- **Komment-szerző default:** az új komment szerzőjeként az elsődleges humán felelős jelenik meg előre kiválasztva (az `owner` típusú assignee), nem a bot.
+- **Alfeladat hozzáadás:** szülő-kártyánál (nem alfeladatnál) „Új alfeladat" form jelenik meg. Az új alfeladat a szülő aktuális státuszát örökli. `done` státuszú szülőhöz nem lehet alfeladatot hozzáadni.
+- **Alfeladat törlés:** alfeladatok soránál Törlés gomb jelenik meg, megerősítő párbeszéddel. `done` státuszú szülőnél a gomb nem jelenik meg.
+- **Szülő-feladat szerkesztése:** alfeladat részletező nézetében (`planned` és `waiting` státusznál) legördülő menüből a szülő-hozzárendelés módosítható vagy leválasztható. A menü a szülőt a kártya-tulajdonságok sorában mutatja, teljes szélességben.

--- a/web/app.js
+++ b/web/app.js
@@ -957,8 +957,8 @@ async function showCardDetail(card) {
     const addSubtaskSection = document.getElementById('cardAddSubtaskSection')
     const isTask = !card.parent_id
 
-    // #113: Show add-subtask form only for top-level tasks (not for subtasks themselves)
-    if (isTask) {
+    // #113: Show add-subtask form only for top-level tasks that are not done
+    if (isTask && card.status !== 'done') {
       addSubtaskSection.style.display = ''
       const titleInput = document.getElementById('newSubtaskTitle')
       titleInput.value = ''
@@ -968,7 +968,7 @@ async function showCardDetail(card) {
         try {
           const r = await fetch('/api/kanban', {
             method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ title, parent_id: card.id, status: 'planned', priority: card.priority, project: card.project || null, assignee: null }),
+            body: JSON.stringify({ title, parent_id: card.id, status: card.status, priority: card.priority, project: card.project || null, assignee: null }),
           })
           if (!r.ok) { showToast('Hiba az alfeladat létrehozásakor'); return }
           showToast('Alfeladat létrehozva')

--- a/web/app.js
+++ b/web/app.js
@@ -828,11 +828,16 @@ async function showCardDetail(card) {
     if (canModifyParent) {
       // Build the parent-select dropdown: null option + all top-level tasks
       parentSelect.innerHTML = '<option value="">Üres (nincs szülő)</option>'
-      const availableParents = kanbanCards.filter(c => !c.parent_id && c.id !== card.id && !c.archived_at)
+      const availableParents = kanbanCards.filter(c =>
+        !c.parent_id && c.id !== card.id && !c.archived_at &&
+        (c.status === 'planned' || c.status === 'in_progress' || c.status === 'waiting')
+      )
       for (const p of availableParents) {
         const opt = document.createElement('option')
         opt.value = p.id
-        opt.textContent = (p.seq != null ? `#${p.seq} ` : '') + p.title
+        const fullLabel = (p.seq != null ? `#${p.seq} ` : '') + p.title
+        opt.title = fullLabel
+        opt.textContent = fullLabel.length > 33 ? fullLabel.slice(0, 32) + '…' : fullLabel
         if (p.id === card.parent_id) opt.selected = true
         parentSelect.appendChild(opt)
       }

--- a/web/app.js
+++ b/web/app.js
@@ -814,50 +814,39 @@ async function showCardDetail(card) {
 
   document.getElementById('cardDetailDesc').textContent = card.description || ''
 
-  // #115: Parent section — shown for subtasks; dropdown to reparent/detach only in planned/waiting
-  const parentSection = document.getElementById('cardParentSection')
-  const parentInfoEl = document.getElementById('cardParentInfo')
+  // #115: Parent meta row — dropdown replaces the old read-only display; shown only when editable
+  const parentMetaItem = document.getElementById('parentMetaItem')
   const parentSelect = document.getElementById('parentSelect')
   const canModifyParent = card.status === 'planned' || card.status === 'waiting'
-  if (card.parent_id) {
-    const parentCard = kanbanCards.find(c => c.id === card.parent_id)
-    const parentSeq = parentCard?.seq != null ? `#${parentCard.seq} ` : ''
-    parentInfoEl.innerHTML = `<span>${parentSeq}${escapeHtml(parentCard?.title || card.parent_id)}</span>`
-    parentInfoEl.onclick = () => { if (parentCard) { closeModal(cardDetailOverlay); showCardDetail(parentCard) } }
-    parentSection.style.display = ''
-    if (canModifyParent) {
-      // Build the parent-select dropdown: null option + all top-level tasks
-      parentSelect.innerHTML = '<option value="">Üres (nincs szülő)</option>'
-      const availableParents = kanbanCards.filter(c =>
-        !c.parent_id && c.id !== card.id && !c.archived_at &&
-        (c.status === 'planned' || c.status === 'in_progress' || c.status === 'waiting')
-      )
-      for (const p of availableParents) {
-        const opt = document.createElement('option')
-        opt.value = p.id
-        const fullLabel = (p.seq != null ? `#${p.seq} ` : '') + p.title
-        opt.title = fullLabel
-        opt.textContent = fullLabel.length > 33 ? fullLabel.slice(0, 32) + '…' : fullLabel
-        if (p.id === card.parent_id) opt.selected = true
-        parentSelect.appendChild(opt)
-      }
-      parentSelect.style.display = ''
-      parentSelect.onchange = async () => {
-        const newParentId = parentSelect.value || null
-        const label = newParentId ? 'Szülő módosítva' : 'Szülő leválasztva'
-        const r = await fetch(`/api/kanban/${encodeURIComponent(card.id)}`, {
-          method: 'PUT', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ...card, parent_id: newParentId }),
-        })
-        if (r.ok) { card.parent_id = newParentId; showToast(label); loadKanban(); showCardDetail(card) }
-        else showToast('Hiba a mentésnél')
-      }
-    } else {
-      parentSelect.style.display = 'none'
+  if (card.parent_id && canModifyParent) {
+    // Build the parent-select dropdown: null option + all top-level non-done tasks
+    parentSelect.innerHTML = '<option value="">Üres (nincs szülő)</option>'
+    const availableParents = kanbanCards.filter(c =>
+      !c.parent_id && c.id !== card.id && !c.archived_at &&
+      (c.status === 'planned' || c.status === 'in_progress' || c.status === 'waiting')
+    )
+    for (const p of availableParents) {
+      const opt = document.createElement('option')
+      opt.value = p.id
+      const fullLabel = (p.seq != null ? `#${p.seq} ` : '') + p.title
+      opt.title = fullLabel
+      opt.textContent = fullLabel.length > 33 ? fullLabel.slice(0, 32) + '…' : fullLabel
+      if (p.id === card.parent_id) opt.selected = true
+      parentSelect.appendChild(opt)
     }
+    parentSelect.onchange = async () => {
+      const newParentId = parentSelect.value || null
+      const label = newParentId ? 'Szülő módosítva' : 'Szülő leválasztva'
+      const r = await fetch(`/api/kanban/${encodeURIComponent(card.id)}`, {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...card, parent_id: newParentId }),
+      })
+      if (r.ok) { card.parent_id = newParentId; showToast(label); loadKanban(); showCardDetail(card) }
+      else showToast('Hiba a mentésnél')
+    }
+    parentMetaItem.style.display = ''
   } else {
-    parentSection.style.display = 'none'
-    parentSelect.style.display = 'none'
+    parentMetaItem.style.display = 'none'
   }
 
   // Load comments

--- a/web/app.js
+++ b/web/app.js
@@ -814,6 +814,71 @@ async function showCardDetail(card) {
 
   document.getElementById('cardDetailDesc').textContent = card.description || ''
 
+  // #115: Parent section — shown for subtasks; modify/remove only in planned/waiting state
+  const parentSection = document.getElementById('cardParentSection')
+  const parentInfoEl = document.getElementById('cardParentInfo')
+  const removeParentBtn = document.getElementById('removeParentBtn')
+  const changeParentBtn = document.getElementById('changeParentBtn')
+  const canModifyParent = card.status === 'planned' || card.status === 'waiting'
+  if (card.parent_id) {
+    const parentCard = kanbanCards.find(c => c.id === card.parent_id)
+    const parentSeq = parentCard?.seq != null ? `#${parentCard.seq} ` : ''
+    parentInfoEl.innerHTML = `<span>${parentSeq}${escapeHtml(parentCard?.title || card.parent_id)}</span>`
+    parentInfoEl.onclick = () => { if (parentCard) { closeModal(cardDetailOverlay); showCardDetail(parentCard) } }
+    parentSection.style.display = ''
+    if (canModifyParent) {
+      removeParentBtn.style.display = ''
+      removeParentBtn.onclick = async () => {
+        if (!confirm('Leválasztod az alfeladatot a szülőjéről? (Önálló feladattá válik)')) return
+        const r = await fetch(`/api/kanban/${encodeURIComponent(card.id)}`, {
+          method: 'PUT', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...card, parent_id: null }),
+        })
+        if (r.ok) { card.parent_id = null; showToast('Szülő leválasztva'); loadKanban(); showCardDetail(card) }
+        else showToast('Hiba a mentésnél')
+      }
+      changeParentBtn.style.display = ''
+      changeParentBtn.onclick = () => {
+        const availableParents = kanbanCards.filter(c => !c.parent_id && c.id !== card.id && !c.archived_at)
+        if (!availableParents.length) { showToast('Nincs elérhető szülő feladat'); return }
+        const sel = document.createElement('select')
+        sel.style.cssText = 'padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:13px;margin-left:8px'
+        sel.innerHTML = '<option value="">-- Válassz szülőt --</option>'
+        for (const p of availableParents) {
+          const opt = document.createElement('option')
+          opt.value = p.id
+          opt.textContent = (p.seq != null ? `#${p.seq} ` : '') + p.title
+          if (p.id === card.parent_id) opt.selected = true
+          sel.appendChild(opt)
+        }
+        const confirmBtn = document.createElement('button')
+        confirmBtn.className = 'btn-primary btn-compact'
+        confirmBtn.style.marginLeft = '6px'
+        confirmBtn.textContent = 'Mentés'
+        parentInfoEl.appendChild(sel)
+        parentInfoEl.appendChild(confirmBtn)
+        changeParentBtn.style.display = 'none'
+        confirmBtn.onclick = async () => {
+          const newParentId = sel.value
+          if (!newParentId) return
+          const r = await fetch(`/api/kanban/${encodeURIComponent(card.id)}`, {
+            method: 'PUT', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ...card, parent_id: newParentId }),
+          })
+          if (r.ok) { card.parent_id = newParentId; showToast('Szülő módosítva'); loadKanban(); showCardDetail(card) }
+          else showToast('Hiba a mentésnél')
+        }
+      }
+    } else {
+      removeParentBtn.style.display = 'none'
+      changeParentBtn.style.display = 'none'
+    }
+  } else {
+    parentSection.style.display = 'none'
+    removeParentBtn.style.display = 'none'
+    changeParentBtn.style.display = 'none'
+  }
+
   // Load comments
   try {
     const res = await fetch(`/api/kanban/${encodeURIComponent(card.id)}/comments`)
@@ -840,7 +905,7 @@ async function showCardDetail(card) {
   // (Resolution of the #254/#241 overlap: keep #241's type-resolved default
   // over #254's hard-coded "Gábor" -- same deployment-agnostic reasoning.)
   const defaultCommentAuthor =
-    (kanbanAssignees.find((a) => a.type === 'bot') || kanbanAssignees[0] || {}).name || ''
+    (kanbanAssignees.find((a) => a.type === 'owner') || kanbanAssignees[0] || {}).name || ''
   populateAssigneeSelect('commentAuthor', defaultCommentAuthor)
 
   // Add comment
@@ -913,29 +978,81 @@ async function showCardDetail(card) {
     }
   }
 
-  // Load children (subtasks)
+  // Load children (subtasks) — only top-level tasks have children (no subtask of subtask)
   try {
     const childRes = await fetch(`/api/kanban/${encodeURIComponent(card.id)}/children`)
     const children = await childRes.json()
     const section = document.getElementById('cardChildrenSection')
     const list = document.getElementById('cardChildrenList')
-    if (children.length > 0) {
+    const addSubtaskSection = document.getElementById('cardAddSubtaskSection')
+    const isTask = !card.parent_id
+
+    // #113: Show add-subtask form only for top-level tasks (not for subtasks themselves)
+    if (isTask) {
+      addSubtaskSection.style.display = ''
+      const titleInput = document.getElementById('newSubtaskTitle')
+      titleInput.value = ''
+      document.getElementById('addSubtaskBtn').onclick = async () => {
+        const title = titleInput.value.trim()
+        if (!title) { titleInput.focus(); return }
+        try {
+          const r = await fetch('/api/kanban', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ title, parent_id: card.id, status: 'planned', priority: card.priority, project: card.project || null, assignee: null }),
+          })
+          if (!r.ok) { showToast('Hiba az alfeladat létrehozásakor'); return }
+          showToast('Alfeladat létrehozva')
+          loadKanban()
+          showCardDetail(card)
+        } catch { showToast('Hiba az alfeladat létrehozásakor') }
+      }
+    } else {
+      addSubtaskSection.style.display = 'none'
+    }
+
+    const statusLabelsShort = { planned: 'Tervezett', in_progress: 'Folyamatban', waiting: 'Vár', done: 'Kész' }
+    if (children.length > 0 || isTask) {
       section.style.display = ''
       list.innerHTML = ''
-      const statusLabelsShort = { planned: 'Tervezett', in_progress: 'Folyamatban', waiting: 'Vár', done: 'Kész' }
+      // #114: Delete button per subtask — only shown when the parent card is not done
+      const canDeleteChild = card.status !== 'done'
       for (const ch of children) {
         const div = document.createElement('div')
         div.className = 'comment-item'
-        div.style.cursor = 'pointer'
-        div.innerHTML = `<div><strong>${escapeHtml(ch.title)}</strong> <span style="color:var(--text-muted)">[${statusLabelsShort[ch.status] || ch.status}]</span></div>
-          <div style="font-size:0.85em; color:var(--text-muted)">${ch.assignee ? escapeHtml(ch.assignee) : ''} ${ch.description ? '-- ' + escapeHtml(ch.description).slice(0, 80) : ''}</div>`
-        div.onclick = () => { closeModal(cardDetailOverlay); showCardDetail(ch) }
+        div.style.cssText = 'cursor:pointer; display:flex; justify-content:space-between; align-items:center; gap:8px'
+        const info = document.createElement('div')
+        info.style.flex = '1'
+        info.innerHTML = `<div><strong>${escapeHtml(ch.title)}</strong> <span style="color:var(--text-muted)">[${statusLabelsShort[ch.status] || ch.status}]</span></div>
+          <div style="font-size:0.85em;color:var(--text-muted)">${ch.assignee ? escapeHtml(ch.assignee) : ''}${ch.description ? ' -- ' + escapeHtml(ch.description).slice(0, 80) : ''}</div>`
+        info.onclick = () => { closeModal(cardDetailOverlay); showCardDetail(ch) }
+        div.appendChild(info)
+        if (canDeleteChild) {
+          const delBtn = document.createElement('button')
+          delBtn.className = 'btn-danger btn-compact'
+          delBtn.style.flexShrink = '0'
+          delBtn.textContent = 'Törlés'
+          delBtn.onclick = async (e) => {
+            e.stopPropagation()
+            if (!confirm(`Biztosan törlöd az alfeladatot: "${ch.title}"?`)) return
+            try {
+              const r = await fetch(`/api/kanban/${encodeURIComponent(ch.id)}`, { method: 'DELETE' })
+              if (!r.ok) { showToast('Hiba a törlés során'); return }
+              showToast('Alfeladat törölve')
+              loadKanban()
+              showCardDetail(card)
+            } catch { showToast('Hiba a törlés során') }
+          }
+          div.appendChild(delBtn)
+        }
         list.appendChild(div)
       }
     } else {
       section.style.display = 'none'
     }
-  } catch { document.getElementById('cardChildrenSection').style.display = 'none' }
+  } catch {
+    document.getElementById('cardChildrenSection').style.display = 'none'
+    document.getElementById('cardAddSubtaskSection').style.display = 'none'
+  }
 
   // Breakdown button
   document.getElementById('cardBreakdownBtn').onclick = async () => {

--- a/web/app.js
+++ b/web/app.js
@@ -814,11 +814,10 @@ async function showCardDetail(card) {
 
   document.getElementById('cardDetailDesc').textContent = card.description || ''
 
-  // #115: Parent section — shown for subtasks; modify/remove only in planned/waiting state
+  // #115: Parent section — shown for subtasks; dropdown to reparent/detach only in planned/waiting
   const parentSection = document.getElementById('cardParentSection')
   const parentInfoEl = document.getElementById('cardParentInfo')
-  const removeParentBtn = document.getElementById('removeParentBtn')
-  const changeParentBtn = document.getElementById('changeParentBtn')
+  const parentSelect = document.getElementById('parentSelect')
   const canModifyParent = card.status === 'planned' || card.status === 'waiting'
   if (card.parent_id) {
     const parentCard = kanbanCards.find(c => c.id === card.parent_id)
@@ -827,56 +826,33 @@ async function showCardDetail(card) {
     parentInfoEl.onclick = () => { if (parentCard) { closeModal(cardDetailOverlay); showCardDetail(parentCard) } }
     parentSection.style.display = ''
     if (canModifyParent) {
-      removeParentBtn.style.display = ''
-      removeParentBtn.onclick = async () => {
-        if (!confirm('Leválasztod az alfeladatot a szülőjéről? (Önálló feladattá válik)')) return
+      // Build the parent-select dropdown: null option + all top-level tasks
+      parentSelect.innerHTML = '<option value="">Üres (nincs szülő)</option>'
+      const availableParents = kanbanCards.filter(c => !c.parent_id && c.id !== card.id && !c.archived_at)
+      for (const p of availableParents) {
+        const opt = document.createElement('option')
+        opt.value = p.id
+        opt.textContent = (p.seq != null ? `#${p.seq} ` : '') + p.title
+        if (p.id === card.parent_id) opt.selected = true
+        parentSelect.appendChild(opt)
+      }
+      parentSelect.style.display = ''
+      parentSelect.onchange = async () => {
+        const newParentId = parentSelect.value || null
+        const label = newParentId ? 'Szülő módosítva' : 'Szülő leválasztva'
         const r = await fetch(`/api/kanban/${encodeURIComponent(card.id)}`, {
           method: 'PUT', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ...card, parent_id: null }),
+          body: JSON.stringify({ ...card, parent_id: newParentId }),
         })
-        if (r.ok) { card.parent_id = null; showToast('Szülő leválasztva'); loadKanban(); showCardDetail(card) }
+        if (r.ok) { card.parent_id = newParentId; showToast(label); loadKanban(); showCardDetail(card) }
         else showToast('Hiba a mentésnél')
       }
-      changeParentBtn.style.display = ''
-      changeParentBtn.onclick = () => {
-        const availableParents = kanbanCards.filter(c => !c.parent_id && c.id !== card.id && !c.archived_at)
-        if (!availableParents.length) { showToast('Nincs elérhető szülő feladat'); return }
-        const sel = document.createElement('select')
-        sel.style.cssText = 'padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:13px;margin-left:8px'
-        sel.innerHTML = '<option value="">-- Válassz szülőt --</option>'
-        for (const p of availableParents) {
-          const opt = document.createElement('option')
-          opt.value = p.id
-          opt.textContent = (p.seq != null ? `#${p.seq} ` : '') + p.title
-          if (p.id === card.parent_id) opt.selected = true
-          sel.appendChild(opt)
-        }
-        const confirmBtn = document.createElement('button')
-        confirmBtn.className = 'btn-primary btn-compact'
-        confirmBtn.style.marginLeft = '6px'
-        confirmBtn.textContent = 'Mentés'
-        parentInfoEl.appendChild(sel)
-        parentInfoEl.appendChild(confirmBtn)
-        changeParentBtn.style.display = 'none'
-        confirmBtn.onclick = async () => {
-          const newParentId = sel.value
-          if (!newParentId) return
-          const r = await fetch(`/api/kanban/${encodeURIComponent(card.id)}`, {
-            method: 'PUT', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ ...card, parent_id: newParentId }),
-          })
-          if (r.ok) { card.parent_id = newParentId; showToast('Szülő módosítva'); loadKanban(); showCardDetail(card) }
-          else showToast('Hiba a mentésnél')
-        }
-      }
     } else {
-      removeParentBtn.style.display = 'none'
-      changeParentBtn.style.display = 'none'
+      parentSelect.style.display = 'none'
     }
   } else {
     parentSection.style.display = 'none'
-    removeParentBtn.style.display = 'none'
-    changeParentBtn.style.display = 'none'
+    parentSelect.style.display = 'none'
   }
 
   // Load comments

--- a/web/index.html
+++ b/web/index.html
@@ -1243,15 +1243,27 @@
             </div>
           </div>
         </div>
+        <div id="cardParentSection" style="display:none; margin-top:12px">
+          <h4>Szülő feladat</h4>
+          <div id="cardParentInfo" class="comment-item" style="cursor:pointer"></div>
+        </div>
         <div id="cardChildrenSection" style="display:none; margin-top:12px">
           <h4>Subtask-ok</h4>
           <div id="cardChildrenList" class="comments-list"></div>
+          <div id="cardAddSubtaskSection" style="display:none; margin-top:8px">
+            <div class="form-row" style="gap:8px; align-items:center">
+              <input type="text" id="newSubtaskTitle" placeholder="Új alfeladat neve..." style="flex:1; padding:6px 10px; border-radius:6px; border:1px solid var(--border); background:var(--bg); color:var(--text); font-size:13px">
+              <button class="btn-primary btn-compact" id="addSubtaskBtn">Hozzáadás</button>
+            </div>
+          </div>
         </div>
         <div class="detail-actions" style="gap:8px">
           <button class="btn-secondary" id="cardBreakdownBtn">⚡ AI szétbont</button>
           <button class="btn-secondary" id="cardEditBtn">Szerkesztés</button>
           <button class="btn-secondary" id="cardArchiveBtn">Archiválás</button>
           <button class="btn-danger" id="cardDeleteBtn">Törlés</button>
+          <button class="btn-secondary" id="removeParentBtn" style="display:none">Szülő leválasztása</button>
+          <button class="btn-secondary" id="changeParentBtn" style="display:none">Szülő módosítása</button>
         </div>
       </div>
     </div>

--- a/web/index.html
+++ b/web/index.html
@@ -1262,8 +1262,7 @@
           <button class="btn-secondary" id="cardEditBtn">Szerkesztés</button>
           <button class="btn-secondary" id="cardArchiveBtn">Archiválás</button>
           <button class="btn-danger" id="cardDeleteBtn">Törlés</button>
-          <button class="btn-secondary" id="removeParentBtn" style="display:none">Szülő leválasztása</button>
-          <button class="btn-secondary" id="changeParentBtn" style="display:none">Szülő módosítása</button>
+          <select id="parentSelect" style="display:none; padding:5px 8px; border-radius:6px; border:1px solid var(--border); background:var(--bg); color:var(--text); font-size:13px" title="Szülő feladat módosítása"></select>
         </div>
       </div>
     </div>

--- a/web/index.html
+++ b/web/index.html
@@ -1226,6 +1226,10 @@
       </div>
       <div class="modal-body">
         <div class="card-detail-meta" id="cardDetailMeta"></div>
+        <div class="meta-item" id="parentMetaItem" style="display:none">
+          <span class="meta-label">Szülő</span>
+          <select id="parentSelect" style="flex:1; width:100%; padding:5px 8px; border-radius:6px; border:1px solid var(--border); background:var(--bg); color:var(--text); font-size:13px" title="Szülő feladat módosítása"></select>
+        </div>
         <div class="card-detail-desc" id="cardDetailDesc"></div>
         <div class="card-detail-comments">
           <h4>Megjegyzések</h4>
@@ -1243,10 +1247,7 @@
             </div>
           </div>
         </div>
-        <div id="cardParentSection" style="display:none; margin-top:12px">
-          <h4>Szülő feladat</h4>
-          <div id="cardParentInfo" class="comment-item" style="cursor:pointer"></div>
-        </div>
+
         <div id="cardChildrenSection" style="display:none; margin-top:12px">
           <h4>Subtask-ok</h4>
           <div id="cardChildrenList" class="comments-list"></div>
@@ -1262,7 +1263,6 @@
           <button class="btn-secondary" id="cardEditBtn">Szerkesztés</button>
           <button class="btn-secondary" id="cardArchiveBtn">Archiválás</button>
           <button class="btn-danger" id="cardDeleteBtn">Törlés</button>
-          <select id="parentSelect" style="display:none; padding:5px 8px; border-radius:6px; border:1px solid var(--border); background:var(--bg); color:var(--text); font-size:13px" title="Szülő feladat módosítása"></select>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- the comment composer defaults to the primary human (owner) instead of the main agent.
- "New subtask" form on a top-level task's detail view; the new subtask inherits the parent's current status. Hidden on subtasks and on done parents.
- per-subtask Delete button with a confirm() dialog; hidden when the parent is done.
- in a subtask's editor, a single full-width parent dropdown (replacing the read-only parent row + two buttons): "Üres (nincs szülő)" detaches it (becomes a task), or pick another parent to reassign. Titles truncated to 33 chars (full title in tooltip); only planned/in_progress/waiting tasks are offered. Shown only when the subtask is planned/waiting.
- #116: HU + EN docs (docs/kanban.md, docs/en/kanban.md) updated with these behaviours.

Frontend-only (web/app.js, web/index.html) + docs — no backend or build changes. Uses the existing /api/kanban POST/PUT/DELETE endpoints (parent_id changes via PUT merge — no data loss).

## AI authorship

Authored with AI assistance, under human review by @cett before submission.

## Test plan

- [ ] Comment composer default = primary human
- [ ] New subtask appears on a task, inherits parent status; no add/delete form on a done parent
- [ ] Delete subtask asks for confirmation
- [ ] Subtask editor parent dropdown: detach + reassign, narrow width, only first-three-column tasks listed
- [ ] Docs reflect the new behaviours