### PR TITLE
fix(ideas): AI-submitted kanban cards use the agent display name, not…

### DIFF
--- a/src/web/routes/ideas.ts
+++ b/src/web/routes/ideas.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { MAIN_AGENT_ID } from '../../config.js'
+import { MAIN_AGENT_ID, BOT_NAME } from '../../config.js'
 import { listIdeas, createIdea, updateIdea, deleteIdea, listIdeaCategories, createKanbanCard, getDb } from '../../db.js'
 import { generateBreakdown } from '../llm-breakdown.js'
 import { logger } from '../../logger.js'
@@ -90,7 +90,7 @@ export async function tryHandleIdeas(ctx: RouteContext): Promise<boolean> {
       description: idea.description ?? '',
       status,
       priority: 'normal',
-      assignee: MAIN_AGENT_ID,
+      assignee: BOT_NAME,
       project: 'Fejlesztési ötletek',
     })
     updateIdea(ideaId, { status: 'kanban', kanban_id: cardId })
@@ -137,7 +137,7 @@ export async function tryHandleIdeas(ctx: RouteContext): Promise<boolean> {
       description: idea.description ?? '',
       status: 'planned',
       priority: 'normal',
-      assignee: MAIN_AGENT_ID,
+      assignee: BOT_NAME,
       project: 'Fejlesztési ötletek',
     })
     const childIds: string[] = []
@@ -150,7 +150,7 @@ export async function tryHandleIdeas(ctx: RouteContext): Promise<boolean> {
         description: (st.description ?? '').slice(0, 500),
         status: 'planned',
         priority: (st.priority && VALID_PRIORITIES.has(st.priority) ? st.priority : 'normal') as 'low' | 'normal' | 'high' | 'urgent',
-        assignee: st.assignee || MAIN_AGENT_ID,
+        assignee: st.assignee || BOT_NAME,
         project: 'Fejlesztési ötletek',
         parent_id: parentId,
       })


### PR DESCRIPTION
## Summary

Fix the assignee of cards/subtasks created from the idea box's "Kanbanra (AI)" flow.

The idea-box handlers set the kanban assignee to MAIN_AGENT_ID — the internal lowercase agent id, which defaults to "marveen" — instead of the agent's display name. The board therefore showed a hardcoded "marveen" rather than the real agent name. Use BOT_NAME (the display name) for all three assignee defaults in src/web/routes/ideas.ts: the direct "Kanbanra" card, the AI-breakdown parent, and each generated subtask's fallback.

Backend-only (src/web/routes/ideas.ts), one commit. Pre-existing cards keep their stored assignee.

## AI authorship

Authored with AI assistance, under human review by @cett before submission.

## Test plan

- [ ] Idea box → "Kanbanra (AI)" → generated card/subtasks show the agent display name (not "marveen"/the lowercase id)
- [ ] LLM-suggested valid assignees are preserved; only the empty fallback uses the display name

