### PR TITLE
agents: scope a sub-agent's channel plugin from its own token, not the (null) explicit provider field

### DIFF
--- a/src/__tests__/scope-channel-plugins.test.ts
+++ b/src/__tests__/scope-channel-plugins.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { scopeChannelPlugins, CHANNEL_PLUGIN_IDS } from '../web/agent-process.js'
+import { scopeChannelPlugins, ownChannelProviderForScope, CHANNEL_PLUGIN_IDS } from '../web/agent-process.js'
 
 const TG = CHANNEL_PLUGIN_IDS.telegram     // telegram@claude-plugins-official
 const SL = CHANNEL_PLUGIN_IDS.slack        // slack-channel@marveen-marketplace
@@ -76,12 +76,82 @@ describe('main-agent telegram channel is protected from spawn-time scoping', () 
     // The scopeChannelPlugins call must sit inside an `if (name !== MAIN_AGENT_ID)`.
     const callIdx = SRC.indexOf('s.enabledPlugins = scopeChannelPlugins(')
     expect(callIdx).toBeGreaterThan(0)
-    const before = SRC.slice(Math.max(0, callIdx - 700), callIdx)
+    // Window spans the guard-open `if`, the settings read, and the explanatory
+    // comment block that precedes the call (~600 chars), so keep it generous.
+    const before = SRC.slice(Math.max(0, callIdx - 1500), callIdx)
     expect(before).toMatch(/if \(name !== MAIN_AGENT_ID\) \{/)
   })
 
   it('an explicit telegram provider KEEPS telegram enabled (so a telegram main/agent is never disabled)', () => {
     const out = scopeChannelPlugins('telegram')
     expect(out[TG]).toBe(true)
+  })
+})
+
+// The spawn-time enable decision must match the --channels launch gate: the
+// presence of a REAL own bot token in the agent's own channel .env -- NOT the
+// explicit channelProvider config field (null for every sub-agent). This fixes
+// the regression that left a legitimately-channelled sub-agent's plugin "truly
+// unreachable" (loaded by --channels but disabled in settings -> no bun poller,
+// no bot.pid) after any respawn.
+describe('ownChannelProviderForScope', () => {
+  it('own token + telegram provider -> telegram (plugin stays enabled)', () => {
+    expect(ownChannelProviderForScope(true, 'telegram')).toBe('telegram')
+  })
+
+  it('own token + slack provider -> slack', () => {
+    expect(ownChannelProviderForScope(true, 'slack')).toBe('slack')
+  })
+
+  it('NO own token (channel-less / legacy-fallback only) + telegram -> null', () => {
+    // A channel-less agent is defaulted to telegram and a legacy token marks
+    // hasChannel, but it has no OWN token -> must stay channel-less (dup-poller fix).
+    expect(ownChannelProviderForScope(false, 'telegram')).toBeNull()
+  })
+
+  it('no own token + null provider -> null', () => {
+    expect(ownChannelProviderForScope(false, null)).toBeNull()
+  })
+
+  it('own token but null resolved provider -> null (nothing to enable)', () => {
+    expect(ownChannelProviderForScope(true, null)).toBeNull()
+  })
+})
+
+// End-to-end of the spawn-time decision: the own-token gate feeds scopeChannelPlugins.
+describe('spawn-time enable decision (ownChannelProviderForScope + scopeChannelPlugins)', () => {
+  it('own-token telegram sub-agent KEEPS its plugin enabled (regression fix)', () => {
+    const out = scopeChannelPlugins(ownChannelProviderForScope(true, 'telegram'), { [TG]: true })
+    expect(out[TG]).toBe(true)
+    expect(out[SL]).toBe(false)
+    expect(out[DI]).toBe(false)
+  })
+
+  it('a stale telegram:true on a token-less agent is still forced OFF', () => {
+    const out = scopeChannelPlugins(ownChannelProviderForScope(false, 'telegram'), { [TG]: true })
+    expect(out[TG]).toBe(false)
+  })
+
+  it('own-token slack sub-agent enables ONLY slack', () => {
+    const out = scopeChannelPlugins(ownChannelProviderForScope(true, 'slack'), { [TG]: true })
+    expect(out[SL]).toBe(true)
+    expect(out[TG]).toBe(false)
+    expect(out[DI]).toBe(false)
+  })
+})
+
+// REGRESSION LOCK: the spawn-time scoping must feed scopeChannelPlugins from the
+// own-token gate (ownChannelProviderForScope), NOT from readAgentChannelProvider
+// (the explicit channelProvider field, null for every sub-agent), which disabled
+// the plugin for legitimately-channelled sub-agents.
+describe('spawn-time scoping is gated on the own token, not the explicit provider field', () => {
+  const SRC = readFileSync(join(__dirname, '../web/agent-process.ts'), 'utf-8')
+
+  it('the scopeChannelPlugins call argument is ownChannelProviderForScope(...)', () => {
+    const callIdx = SRC.indexOf('s.enabledPlugins = scopeChannelPlugins(')
+    expect(callIdx).toBeGreaterThan(0)
+    const arg = SRC.slice(callIdx, callIdx + 120)
+    expect(arg).toMatch(/ownChannelProviderForScope\(/)
+    expect(arg).not.toMatch(/readAgentChannelProvider\(/)
   })
 })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -70,6 +70,25 @@ export function scopeChannelPlugins(
   return out
 }
 
+// Pure: which channel provider a sub-agent should ENABLE the plugin for at spawn.
+// The enable decision MUST match the --channels launch gate, which is the
+// presence of a REAL own bot token in the agent's own channel .env (hasOwnToken).
+// Spawn-time scoping originally keyed enabledPlugins on the EXPLICIT channelProvider
+// config field, but that field is null for every sub-agent (none set it) -- so a
+// sub-agent with a genuine own token still got its plugin forced off: --channels
+// loaded it, yet enabledPlugins:false made Claude Code refuse to register it (no
+// MCP entry, no bun poller, no bot.pid -> dead bot after any respawn). Gating on
+// the own token keeps the dup-poller intent: a channel-less agent (no own token,
+// only the legacy/global-token fallback that still marks hasChannel) returns null,
+// so scopeChannelPlugins(null) disables all three and it never fights the main
+// agent over the shared getUpdates slot.
+export function ownChannelProviderForScope(
+  hasOwnToken: boolean,
+  resolvedProvider: string | null,
+): string | null {
+  return hasOwnToken && resolvedProvider ? resolvedProvider : null
+}
+
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
   if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord') return perAgent
@@ -327,11 +346,17 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
       const settingsPath = join(agentDir(name), '.claude', 'settings.json')
       try {
         const s = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>
-        // Key on the EXPLICIT per-agent channelProvider (null when unset), NOT
-        // the resolved/defaulted agentProvider -- a channel-less sub-agent must
-        // disable telegram even though resolveAgentProvider defaulted it to it.
+        // Gate the enable decision on the SAME signal as the --channels launch
+        // flag: a real own bot token in this agent's channel .env (token, above).
+        // A genuine own-token agent enables its own provider's plugin; a channel-
+        // less agent (no own token, only the legacy/global fallback that still
+        // marks hasChannel) yields null -> all three disabled, so it never fights
+        // the main agent over the shared getUpdates slot. Keying on the explicit
+        // channelProvider config field instead (always null for sub-agents) was
+        // the regression that disabled the plugin for every legitimately-channelled
+        // sub-agent after a respawn (truly-unreachable plugin, no bun poller).
         s.enabledPlugins = scopeChannelPlugins(
-          readAgentChannelProvider(name),
+          ownChannelProviderForScope(!!token, agentProvider),
           s.enabledPlugins as Record<string, boolean> | undefined,
         )
         writeFileSync(settingsPath, JSON.stringify(s, null, 2))


### PR DESCRIPTION
## Why this matters

A sub-agent that owns a real channel bot token (its own `TELEGRAM_BOT_TOKEN` in `agents/<name>/.claude/channels/telegram/.env`) loses its channel after **any** respawn. The bot goes silent: no MCP entry for the plugin, no `bun` poller child, no `bot.pid`. The plugin is "truly unreachable" -- it does not even appear in `/mcp`, so the existing `/mcp` reconnect recovery cannot revive it.

Reproduction:
1. A sub-agent with its own channel `.env` token is running with a live channel plugin.
2. It is respawned (host restart, or the channel-monitor's auto-restart on a transient down).
3. `startAgentProcess` regenerates the agent's `settings.json` and the bot never comes back. A manual restart does not help, because every respawn re-applies the same disabling write.

A host restart that respawns several such sub-agents at once leaves all of them silent on their channels.

## Root cause

`#373` added spawn-time plugin scoping: `startAgentProcess` rewrites each sub-agent's `enabledPlugins` so only its own channel plugin stays enabled (killing duplicate pollers that fight the main bot token). The scoping keys on `readAgentChannelProvider(name)` -- the **explicit** `channelProvider` config field. That field is unset (`null`) for a sub-agent that declares its channel only via an `.env` token, so `scopeChannelPlugins(null)` forces **all** channel plugins to `false`.

Meanwhile the `--channels plugin:<provider>` launch flag is gated on a **different** signal: `hasChannel`, the presence of a real own token. The two diverge: the launch flag loads the plugin, but `enabledPlugins: false` makes Claude Code refuse to register it. Result: a loaded-but-disabled plugin with no poller -> dead bot after the next respawn.

## Change

`src/web/agent-process.ts`:
- New pure helper `ownChannelProviderForScope(hasOwnToken, resolvedProvider)` returning `hasOwnToken && resolvedProvider ? resolvedProvider : null`.
- The spawn-time scoping call now gates on the **same signal as the `--channels` flag** -- the agent's own `.env` token -- instead of the always-null explicit `channelProvider` field:

```ts
scopeChannelPlugins(ownChannelProviderForScope(!!token, agentProvider), s.enabledPlugins)
```

`scopeChannelPlugins` itself is unchanged.

## Scope / compatibility

- **Channel-less agents are unaffected.** An agent with no own token (only the legacy/global-token fallback that still marks `hasChannel`) yields `null` -> all three channel plugins disabled, exactly as `#373` intended. The duplicate-poller protection is intact.
- **Main agent is untouched.** The scoping block stays guarded by `name !== MAIN_AGENT_ID` (locked by an existing source-grep test).
- No behavior change for an agent that already declared an explicit `channelProvider`.

## Test plan

- `tsc --noEmit`: clean.
- `src/__tests__/scope-channel-plugins.test.ts`: 18/18 pass. New cases: the own-token gate (own token -> provider; no own token -> `null`; `null` provider -> `null`), end-to-end `ownChannelProviderForScope` + `scopeChannelPlugins` (own-token telegram keeps plugin enabled; token-less stale `telegram:true` forced off; own-token slack enables only slack), and a regression-lock asserting the call argument is `ownChannelProviderForScope(...)`, not `readAgentChannelProvider(...)`.
- Full core suite: 1292/1292 pass.

## Note on deployment

The fix is source-only. A running install must be rebuilt (`tsc`) and the service restarted for it to take effect; after that, a respawn of an affected sub-agent writes `enabledPlugins: { <provider>: true }`, the `--channels` flag registers the plugin, and the poller comes back.
