### PR TITLE
Feat/kanban card aging vizuális jelzés (aging-csík + napszámláló)

### DIFF
--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -53,6 +53,25 @@ Key behaviours in the card editor on the web dashboard (`http://localhost:3420`)
 - **Add subtask:** parent cards (not subtasks themselves) show a "New subtask" form. The new subtask inherits the parent's current status. Adding a subtask to a `done` parent is not allowed.
 - **Delete subtask:** each subtask row shows a Delete button with a confirmation dialog. The button is hidden when the parent is `done`.
 - **Parent assignment editing:** in the subtask detail view (`planned` and `waiting` status only), a dropdown lets you change or detach the parent task. It appears in the card properties row, full-width.
+
+### Stuck cards -- visual indicators
+
+Every non-done card automatically shows a visual warning when it hasn't moved for a while:
+
+**Left-side coloured stripe** -- visible at a glance:
+
+| Colour | What it means |
+|--------|--------------|
+| Yellow | Unchanged for 1 day -- worth keeping an eye on |
+| Orange | Unchanged for 3 days -- will soon need attention |
+| Red (pulsing) | Unchanged for 1 week -- stuck, needs immediate attention |
+
+**Hourglass + day counter** (top-right corner) -- e.g. `⏳ 4d` = hasn't moved in 4 days. Hover to see the exact timestamp of the last change.
+
+Cards in `done` status show no indicators -- only active tasks age.
+
+**What to watch for:** if you see many red or orange cards on the board, check them in order: either the task is stuck (the agent didn't receive it or got blocked), or it should be closed or deleted.
+
 ### Card aging -- technical details
 
 The dashboard computes an aging level for every non-done card based on the `updated_at` unix timestamp.

--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -53,6 +53,36 @@ Key behaviours in the card editor on the web dashboard (`http://localhost:3420`)
 - **Add subtask:** parent cards (not subtasks themselves) show a "New subtask" form. The new subtask inherits the parent's current status. Adding a subtask to a `done` parent is not allowed.
 - **Delete subtask:** each subtask row shows a Delete button with a confirmation dialog. The button is hidden when the parent is `done`.
 - **Parent assignment editing:** in the subtask detail view (`planned` and `waiting` status only), a dropdown lets you change or detach the parent task. It appears in the card properties row, full-width.
+### Card aging -- technical details
+
+The dashboard computes an aging level for every non-done card based on the `updated_at` unix timestamp.
+
+**Three tiers, both indicators shown simultaneously:**
+
+| Tier | Default threshold | Left stripe + badge |
+|------|------------------|---------------------|
+| `warn` | 24 h | yellow |
+| `caution` | 72 h | orange |
+| `critical` | 168 h (7 days) | red, pulsing |
+
+**Display:**
+- Left 3px stripe (`border-left`) — overrides the priority border, uses `--card-aging-color` CSS custom property.
+- Top-right `⏳ Xd` / `⏳ Xh` badge — hover tooltip shows the exact last-modified timestamp.
+- At critical tier, a subtle CSS `animation: aging-pulse` plays on the badge.
+- `done` cards show no indicator.
+
+**Configuration (`.env`):**
+
+```
+KANBAN_AGING_WARN_H=24
+KANBAN_AGING_CAUTION_H=72
+KANBAN_AGING_CRITICAL_H=168
+KANBAN_AGING_WARN_COLOR=#c9a000
+KANBAN_AGING_CAUTION_COLOR=#d46b00
+KANBAN_AGING_CRITICAL_COLOR=#c53030
+```
+
+Config flow: `src/config.ts` → `/api/marveen` (`kanbanAging` key) → `window._marveen.kanbanAging` (frontend). The frontend is static (`web/app.js`, no build step) — a server HUP is sufficient to pick up threshold changes.
 
 ---
 

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -53,3 +53,33 @@ A webes dashboard (`http://localhost:3420`) kártyaszerkesztőjének főbb visel
 - **Alfeladat hozzáadás:** szülő-kártyánál (nem alfeladatnál) „Új alfeladat" form jelenik meg. Az új alfeladat a szülő aktuális státuszát örökli. `done` státuszú szülőhöz nem lehet alfeladatot hozzáadni.
 - **Alfeladat törlés:** alfeladatok soránál Törlés gomb jelenik meg, megerősítő párbeszéddel. `done` státuszú szülőnél a gomb nem jelenik meg.
 - **Szülő-feladat szerkesztése:** alfeladat részletező nézetében (`planned` és `waiting` státusznál) legördülő menüből a szülő-hozzárendelés módosítható vagy leválasztható. A menü a szülőt a kártya-tulajdonságok sorában mutatja, teljes szélességben.
+### Kártya-öregedés -- technikai részletek
+
+A dashboard minden nem-lezárt (`done` kivételével) kártyán kiszámítja az öregedési szintet a `updated_at` unix timestamp alapján.
+
+**Három szint, mindkettő egyszerre jelenik meg:**
+
+| Szint | Default küszöb | Bal csík + jelvény |
+|-------|---------------|-------------------|
+| `warn` | 24 h | sárga |
+| `caution` | 72 h | narancs |
+| `critical` | 168 h (7 nap) | piros, pulzál |
+
+**Megjelenítés:**
+- Bal 3px csík (`border-left`) -- felülírja a prioritás-csíkot, `--card-aging-color` CSS custom property-vel.
+- Jobb felső `⏳ Xd` / `⏳ Xh` jelvény -- hover tooltip pontosan mikor módosult.
+- Kritikus szintnél enyhe CSS `animation: aging-pulse` a jelvényen.
+- `done` kártyákon nem jelenik meg semmilyen jelző.
+
+**Konfiguráció (`.env`):**
+
+```
+KANBAN_AGING_WARN_H=24
+KANBAN_AGING_CAUTION_H=72
+KANBAN_AGING_CRITICAL_H=168
+KANBAN_AGING_WARN_COLOR=#c9a000
+KANBAN_AGING_CAUTION_COLOR=#d46b00
+KANBAN_AGING_CRITICAL_COLOR=#c53030
+```
+
+Értékek forrása: `src/config.ts` → `/api/marveen` (`kanbanAging` kulcs) → `window._marveen.kanbanAging` (frontend). A frontend statikus (`web/app.js`), nincs build lépés a küszöb-értékek frissítésekor -- szerver HUP elegendő.

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -53,6 +53,25 @@ A webes dashboard (`http://localhost:3420`) kártyaszerkesztőjének főbb visel
 - **Alfeladat hozzáadás:** szülő-kártyánál (nem alfeladatnál) „Új alfeladat" form jelenik meg. Az új alfeladat a szülő aktuális státuszát örökli. `done` státuszú szülőhöz nem lehet alfeladatot hozzáadni.
 - **Alfeladat törlés:** alfeladatok soránál Törlés gomb jelenik meg, megerősítő párbeszéddel. `done` státuszú szülőnél a gomb nem jelenik meg.
 - **Szülő-feladat szerkesztése:** alfeladat részletező nézetében (`planned` és `waiting` státusznál) legördülő menüből a szülő-hozzárendelés módosítható vagy leválasztható. A menü a szülőt a kártya-tulajdonságok sorában mutatja, teljes szélességben.
+
+### Beakadt kártyák vizuális jelzése
+
+Minden nem lezárt kártyán automatikusan megjelenik, ha a kártya régóta nem mozdult:
+
+**Bal oldali színes csík** -- az első ránézésre feltűnik:
+
+| Szín | Mit jelent |
+|------|-----------|
+| Sárga | 1 napja nem változott -- érdemes szemmel tartani |
+| Narancs | 3 napja nem változott -- hamarosan beavatkozást igényel |
+| Piros (villog) | 1 hete nem változott -- beakadt, azonnali figyelem kell |
+
+**Homokóra + napszámláló** (jobb felső sarok) -- pl. `⏳ 4d` = 4 napja nem mozdult. Hover-re megjelenik a pontos időpont, amikor utoljára változott.
+
+A `done` státuszú kártyákon nem jelenik meg semmilyen jelzés -- csak az aktív feladatok öregszenek.
+
+**Mire figyelj?** Ha a kanban táblán sok piros vagy narancs kártyát látsz, azokat érdemes sorban megnézni: vagy beakadt a feladat (az ügynök nem kapta meg, vagy elakadt), vagy le kell zárni, vagy törölni.
+
 ### Kártya-öregedés -- technikai részletek
 
 A dashboard minden nem-lezárt (`done` kivételével) kártyán kiszámítja az öregedési szintet a `updated_at` unix timestamp alapján.

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,15 @@ export const SERVICE_ID = env['SERVICE_ID'] ?? MAIN_AGENT_ID
 export const WEB_PORT = parseInt(env['WEB_PORT'] ?? '3420', 10)
 
 export const WEB_HOST = env['WEB_HOST'] ?? '127.0.0.1'
+
+// Kanban card aging visual thresholds (hours since last update) and colours.
+// Override per-install via .env; defaults match the design spec (24/72/168h).
+export const KANBAN_AGING_WARN_H = parseInt(env['KANBAN_AGING_WARN_H'] ?? '24', 10)
+export const KANBAN_AGING_CAUTION_H = parseInt(env['KANBAN_AGING_CAUTION_H'] ?? '72', 10)
+export const KANBAN_AGING_CRITICAL_H = parseInt(env['KANBAN_AGING_CRITICAL_H'] ?? '168', 10)
+export const KANBAN_AGING_WARN_COLOR = env['KANBAN_AGING_WARN_COLOR'] ?? '#c9a000'
+export const KANBAN_AGING_CAUTION_COLOR = env['KANBAN_AGING_CAUTION_COLOR'] ?? '#d46b00'
+export const KANBAN_AGING_CRITICAL_COLOR = env['KANBAN_AGING_CRITICAL_COLOR'] ?? '#c53030'
 export const DASHBOARD_PUBLIC_URL = env['DASHBOARD_PUBLIC_URL'] ?? ''
 export const OLLAMA_URL = env['OLLAMA_URL'] ?? 'http://localhost:11434'
 

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -1,6 +1,10 @@
 import { existsSync, unlinkSync, copyFileSync, writeFileSync } from 'node:fs'
 import { join, extname } from 'node:path'
-import { PROJECT_ROOT, OWNER_NAME, BOT_NAME, BRAND_NAME, MAIN_AGENT_ID, CHANNEL_PROVIDER } from '../../config.js'
+import {
+  PROJECT_ROOT, OWNER_NAME, BOT_NAME, BRAND_NAME, MAIN_AGENT_ID, CHANNEL_PROVIDER,
+  KANBAN_AGING_WARN_H, KANBAN_AGING_CAUTION_H, KANBAN_AGING_CRITICAL_H,
+  KANBAN_AGING_WARN_COLOR, KANBAN_AGING_CAUTION_COLOR, KANBAN_AGING_CRITICAL_COLOR,
+} from '../../config.js'
 import { readMarveenTelegramConfig, readMarveenDiscordConfig, readMarveenSlackConfig, sendMarveenAvatarChange } from '../telegram.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
 import { readFileOr } from '../agent-config.js'
@@ -86,6 +90,14 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
       // CHANNEL_PROVIDER env-jébe pinneljük, hogy a UI ne hardcode-olt
       // 'telegram'-mal induljon.
       channelProvider: CHANNEL_PROVIDER,
+      kanbanAging: {
+        warnH: KANBAN_AGING_WARN_H,
+        cautionH: KANBAN_AGING_CAUTION_H,
+        criticalH: KANBAN_AGING_CRITICAL_H,
+        warnColor: KANBAN_AGING_WARN_COLOR,
+        cautionColor: KANBAN_AGING_CAUTION_COLOR,
+        criticalColor: KANBAN_AGING_CRITICAL_COLOR,
+      },
     })
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -280,6 +280,14 @@ document.querySelectorAll('.kanban-add-btn').forEach((btn) => {
 
 async function loadKanban() {
   try {
+    // Ensure the card-aging config (window._marveen.kanbanAging) is loaded even
+    // if the user opens the Kanban page first, before the Agents page populated it.
+    if (!window._marveen?.kanbanAging) {
+      try {
+        const mr = await fetch('/api/marveen')
+        if (mr.ok) window._marveen = { ...(window._marveen || {}), ...(await mr.json()) }
+      } catch { /* ignore -- aging just won't render until _marveen loads */ }
+    }
     const [cardsRes, assigneesRes, projectsRes] = await Promise.all([
       fetch('/api/kanban'),
       fetch('/api/kanban/assignees'),

--- a/web/app.js
+++ b/web/app.js
@@ -530,6 +530,31 @@ function createCardEl(card, embeddedChildren = []) {
     ? `<span class="kanban-card-seq" style="font-family:monospace;font-size:11px;color:var(--muted);margin-right:5px">#${card.seq}</span>`
     : ''
 
+  // Card aging: left stripe + top-right badge based on hours since last update.
+  // Skipped for done cards. Config thresholds and colours come from window._marveen.kanbanAging.
+  let agingBadgeHtml = ''
+  const agingCfg = window._marveen?.kanbanAging
+  if (agingCfg && card.updated_at && card.status !== 'done') {
+    const hoursOld = (Date.now() / 1000 - card.updated_at) / 3600
+    let agingLevel = null
+    let agingColor = null
+    if (hoursOld >= agingCfg.criticalH) {
+      agingLevel = 'critical'; agingColor = agingCfg.criticalColor
+    } else if (hoursOld >= agingCfg.cautionH) {
+      agingLevel = 'caution'; agingColor = agingCfg.cautionColor
+    } else if (hoursOld >= agingCfg.warnH) {
+      agingLevel = 'warn'; agingColor = agingCfg.warnColor
+    }
+    if (agingLevel) {
+      const days = Math.floor(hoursOld / 24)
+      const ageLabel = days >= 1 ? `${days}d` : `${Math.floor(hoursOld)}h`
+      const exact = new Date(card.updated_at * 1000).toLocaleString('hu-HU')
+      agingBadgeHtml = `<span class="kanban-card-aging-badge kanban-card-aging-${agingLevel}" style="color:${agingColor}" title="Utoljára módosítva: ${exact}">⏳ ${ageLabel}</span>`
+      el.dataset.aging = agingLevel
+      el.style.setProperty('--card-aging-color', agingColor)
+    }
+  }
+
   // Embedded subtasks: rendered as mini-cards below a divider when the subtask
   // shares the same column as this parent card.
   let embeddedHtml = ''
@@ -552,6 +577,7 @@ function createCardEl(card, embeddedChildren = []) {
     <div class="kanban-card-actions">
       <button class="card-breakdown-btn" title="AI szétbont" aria-label="AI szétbont">⚡</button>
     </div>
+    ${agingBadgeHtml}
     <div class="kanban-subtask-badge" style="display:none"></div>
     ${embeddedHtml}
   `

--- a/web/style.css
+++ b/web/style.css
@@ -772,6 +772,30 @@ main {
 .kanban-card[data-priority="normal"] { border-left: 3px solid transparent; }
 .kanban-card[data-priority="low"] { border-left: 3px solid var(--border); }
 
+/* Card aging: left stripe overrides priority border when card is stale.
+   Colour is set as --card-aging-color via inline style by JS. */
+.kanban-card[data-aging] { border-left: 3px solid var(--card-aging-color); }
+
+/* Aging badge: hourglass + day/hour counter, top-right (left of the ⚡ action) */
+.kanban-card-aging-badge {
+  position: absolute;
+  top: 6px;
+  right: 28px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+@keyframes aging-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+.kanban-card-aging-badge.kanban-card-aging-critical {
+  animation: aging-pulse 2.2s ease-in-out infinite;
+}
+
 /* === Card detail === */
 .card-detail-meta {
   display: flex;


### PR DESCRIPTION
## Summary

Card aging visual indicator on the kanban board. Stale cards (no movement for a configurable time) get two coherent, non-conflicting markers:
- a 3px left-edge stripe whose colour escalates by age, and
- a small hourglass + day-counter badge in the top-right corner (with an exact "last modified" tooltip).

Skipped for done cards. Thresholds and colours are configurable via env (KANBAN_AGING_WARN_H/CAUTION_H/CRITICAL_H = 24/72/168h defaults; KANBAN_AGING_*_COLOR), exposed to the frontend through /api/marveen (window._marveen.kanbanAging). The card-aging config is also loaded by the Kanban page itself so the markers show even when opening that page first.

Files: web/app.js, web/style.css (frontend), src/config.ts + src/web/routes/marveen.ts (config), docs/kanban.md + docs/en/kanban.md (technical + user-facing sections, HU+EN).

## AI authorship

Authored with AI assistance, under human review by @cett before submission.

## Test plan

- [ ] A card not moved for >24h shows a yellow left stripe + "Nd" badge; >72h orange; >168h red (subtle pulse)
- [ ] Done cards show no aging marker
- [ ] Thresholds/colours overridable via the KANBAN_AGING_* env vars
- [ ] Stripe/badge don't collide with priority border, assignee, or subtask elements