### PR TITLE
feat(dashboard): group scheduled tasks by cron cadence

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -4110,11 +4110,21 @@ function renderPendingRetries(container, rows) {
   })
 }
 
-function renderScheduleList(tasks) {
-  scheduleList.innerHTML = ''
-  scheduleEmpty.hidden = tasks.length > 0
+// Classify a cron expression into a cadence bucket for grouping the list.
+function cronCadence(cron) {
+  const p = (cron || '').trim().split(/\s+/)
+  if (p.length < 5) return { order: 5, label: 'Egyéb / egyedi' }
+  const [min, hour, , mon, dow] = p
+  const dom = p[2]
+  if (mon !== '*' || dom !== '*') return { order: 3, label: 'Havonta vagy ritkábban' }
+  if (dow !== '*' && dow !== '1-5') return { order: 2, label: 'Hetente' }
+  const multiDaily = /[\/,\-]/.test(min) || /[\/,\-]/.test(hour)
+  if (multiDaily) return { order: 0, label: 'Óránként vagy sűrűbben' }
+  return { order: 1, label: 'Naponta' }
+}
+const CADENCE_ICON = { 0: '⚡', 1: '☀️', 2: '📅', 3: '🗓️', 5: '•' }
 
-  for (const task of tasks) {
+function makeScheduleRow(task) {
     const row = document.createElement('div')
     row.className = 'schedule-row'
     const agent = scheduleAgents.find(a => a.name === task.agent) || { name: task.agent || mainAgentId(), avatar: '/api/marveen/avatar', label: task.agent || mainAgentId() }
@@ -4193,7 +4203,26 @@ function renderScheduleList(tasks) {
       openScheduleRunHistory(task.name)
     })
 
-    scheduleList.appendChild(row)
+    return row
+}
+
+function renderScheduleList(tasks) {
+  scheduleList.innerHTML = ''
+  scheduleEmpty.hidden = tasks.length > 0
+  const groups = new Map()
+  for (const task of tasks) {
+    const c = cronCadence(task.schedule)
+    if (!groups.has(c.order)) groups.set(c.order, { label: c.label, tasks: [] })
+    groups.get(c.order).tasks.push(task)
+  }
+  for (const o of [0, 1, 2, 3, 5]) {
+    const g = groups.get(o)
+    if (!g) continue
+    const header = document.createElement('div')
+    header.className = 'schedule-section'
+    header.innerHTML = `<span class="schedule-section-icon">${CADENCE_ICON[o] || ''}</span><span class="schedule-section-label">${escapeHtml(g.label)}</span><span class="schedule-section-count">${g.tasks.length}</span>`
+    scheduleList.appendChild(header)
+    for (const task of g.tasks) scheduleList.appendChild(makeScheduleRow(task))
   }
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -2865,6 +2865,27 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
   flex-wrap: wrap;
 }
 
+.schedule-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 18px 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+}
+.schedule-section:first-child { margin-top: 4px; }
+.schedule-section-icon { font-size: 13px; }
+.schedule-section-count {
+  background: var(--bg-input);
+  color: var(--text-muted);
+  border-radius: 10px;
+  padding: 1px 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
 .schedule-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

Groups the scheduled-task list in the dashboard by **cron cadence** instead of one flat list.

Each task's cron expression is classified into a bucket — *hourly-or-more / daily / weekly / monthly-or-rarer / other* — and the list is rendered under labelled section headers, each with an icon and a count. This makes the run frequency of every job visible at a glance, which gets hard once you have more than a handful of schedules.

## How

- New `cronCadence(cron)` classifier (pure function, parses the 5-field cron expression).
- Row-building extracted from the `renderScheduleList` loop into `makeScheduleRow(task)` — no change to the row markup or its event handlers (run / toggle / history / delete all preserved).
- `renderScheduleList` now bins tasks by cadence and emits a `.schedule-section` header before each group.
- Small CSS block for the section header / count badge, reusing existing theme variables (`--text-secondary`, `--bg-input`, `--text-muted`).

Purely an additional grouping layer over the existing list — no API or behavioural change to the rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)