### PR TITLE
Feat/oszloponkénti WIP-limit badge (kihasználtság-alapú szín-állapotok)

### DIFF
--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -102,6 +102,28 @@ KANBAN_AGING_CRITICAL_COLOR=#c53030
 ```
 
 Config flow: `src/config.ts` → `/api/marveen` (`kanbanAging` key) → `window._marveen.kanbanAging` (frontend). The frontend is static (`web/app.js`, no build step) — a server HUP is sufficient to pick up threshold changes.
+### Column WIP limits
+
+A WIP (Work In Progress) limit tells you when a column is overloaded -- meaning it has more active tasks than it's sensible to handle at once.
+
+**What you see in the column header**
+
+A round badge at the top of each column shows the current state, e.g. `4/5` (4 cards, limit is 5). The badge colour reflects how close you are to the limit:
+
+| Badge | What it means |
+|-------|--------------|
+| Grey | Plenty of room, all good |
+| Yellow | Approaching the limit -- worth keeping an eye on |
+| Orange | One away from the limit -- avoid adding new cards here |
+| Red, pulsing | Limit exceeded -- the column is overloaded, resolve something before adding more |
+
+**What to do**
+
+If a column is flashing a red badge, don't push new work into it. Close or move an existing card first. The limit doesn't block new cards -- it's a warning, not a lock.
+
+**How to configure the limit**
+
+WIP limits are set per column in the `.env` file (see the technical documentation for details). If no limit is configured for a column, the badge doesn't appear.
 
 ---
 

--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -125,6 +125,35 @@ If a column is flashing a red badge, don't push new work into it. Close or move 
 
 WIP limits are set per column in the `.env` file (see the technical documentation for details). If no limit is configured for a column, the badge doesn't appear.
 
+### Column WIP limits -- technical details
+
+Each kanban column accepts an optional card-count ceiling. When set, the existing count badge in the column header switches to `count/limit` format and changes colour based on utilisation:
+
+| State | Condition | Appearance |
+|-------|-----------|------------|
+| ok | < `WARN_PCT`% | dark grey, no animation |
+| warn | >= `WARN_PCT`% (default 80%) | yellow |
+| full | exactly at limit (100%) | orange + mild pulse |
+| over | exceeds limit | red + stronger pulse + 10% scale |
+
+The badge is implemented by updating the existing `kanban-col-count` span -- no additional HTML element is added.
+
+**Configuration keys (`.env`):**
+
+```
+KANBAN_WIP_PLANNED=0        # 0 = unlimited
+KANBAN_WIP_IN_PROGRESS=0
+KANBAN_WIP_WAITING=0
+KANBAN_WIP_DONE=0
+KANBAN_WIP_WARN_PCT=80      # % threshold for yellow tier
+KANBAN_WIP_OK_COLOR=#6b7280
+KANBAN_WIP_WARN_COLOR=#c9a000
+KANBAN_WIP_FULL_COLOR=#d46b00
+KANBAN_WIP_OVER_COLOR=#c53030
+```
+
+Data flow: `src/config.ts` → `/api/marveen` (`kanbanWip` key) → `window._marveen.kanbanWip` (frontend). The frontend is static -- a server HUP is sufficient to apply limit changes.
+
 ---
 
 ## Related documents

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -102,3 +102,26 @@ KANBAN_AGING_CRITICAL_COLOR=#c53030
 ```
 
 Értékek forrása: `src/config.ts` → `/api/marveen` (`kanbanAging` kulcs) → `window._marveen.kanbanAging` (frontend). A frontend statikus (`web/app.js`), nincs build lépés a küszöb-értékek frissítésekor -- szerver HUP elegendő.
+
+### Oszloponkénti WIP-limit
+
+A WIP-limit (Work In Progress limit) megmutatja, ha egy oszlop túlterhelt -- azaz több aktív feladat van benne, mint amennyit célszerű egyszerre kezelni.
+
+**Mit látsz az oszlopfejlécben?**
+
+Minden oszlop tetején egy kerek badge jelzi az aktuális állapotot, pl. `4/5` (4 kártya van, a limit 5). A badge színe a kihasználtság szerint változik:
+
+| Badge | Mit jelent |
+|-------|-----------|
+| Szürke | Bőven van hely, minden rendben |
+| Sárga | Közeledik a limit -- érdemes figyelni |
+| Narancs | Egy lépésre a limittől -- új kártyát ne tegyél ide |
+| Piros, villog | Túllépve -- az oszlop túlterhelt, oldj meg valamit mielőtt újat veszel fel |
+
+**Mire figyelj?**
+
+Ha egy oszlop piros badge-dzsel villog, ne vegyél fel oda új feladatot. Először zárj le vagy helyezz át egy meglévőt. A limit nem tiltja meg az új kártyák felvételét -- figyelmeztetés, nem zár.
+
+**Hogyan állítható a limit?**
+
+A WIP-limit oszloponként konfigurálható a `.env` fájlban (részletek a technikai dokumentációban). Ha az oszlopnak nincs beállított limitje, a badge nem jelenik meg.

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -45,6 +45,35 @@ Minden projekt-feladat kártyán fut: az orchestrator kártyaként rögzíti, on
 
 Közvetlen SQLite, vagy a dashboard kanban-felülete. A kártya-állapot minden ügynök kontextusába automatikusan bekerül.
 
+### WIP-limit (folyamatban lévő kártyák korlátja) -- technikai részletek
+
+Minden kanban-oszlophoz beállítható egy maximális kártyaszám (Work In Progress limit). Ha a limit be van állítva, az oszlopfejlécben lévő kártyaszámláló `count/limit` formátumra vált, és a kihasználtság alapján változtatja a színét:
+
+| Szint | Feltétel | Megjelenés |
+|-------|---------|-----------|
+| ok | < `WARN_PCT`% | sötétszürke, animáció nélkül |
+| warn | >= `WARN_PCT`% (alapért. 80%) | sárga |
+| full | pontosan 100% | narancs + enyhe pulzálás |
+| over | > limit | piros + erős pulzálás + 10% méretnövekedés |
+
+A badge az oszlopfejlécben lévő meglévő kártyaszámlálóba épül bele -- nincs külön HTML-elem.
+
+**Konfigurációs kulcsok (`.env`):**
+
+```
+KANBAN_WIP_PLANNED=0        # 0 = korlát nélkül
+KANBAN_WIP_IN_PROGRESS=0
+KANBAN_WIP_WAITING=0
+KANBAN_WIP_DONE=0
+KANBAN_WIP_WARN_PCT=80      # %-os küszöb a sárga szinthez
+KANBAN_WIP_OK_COLOR=#6b7280
+KANBAN_WIP_WARN_COLOR=#c9a000
+KANBAN_WIP_FULL_COLOR=#d46b00
+KANBAN_WIP_OVER_COLOR=#c53030
+```
+
+Adatfolyam: `src/config.ts` → `/api/marveen` (`kanbanWip` kulcs) → `window._marveen.kanbanWip` (frontend). A frontend statikus, nincs build lépés -- szerver HUP elegendő a limitek megváltoztatásához.
+
 ### Dashboard kanban felület
 
 A webes dashboard (`http://localhost:3420`) kártyaszerkesztőjének főbb viselkedései:

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,18 @@ export const KANBAN_AGING_CRITICAL_H = parseInt(env['KANBAN_AGING_CRITICAL_H'] ?
 export const KANBAN_AGING_WARN_COLOR = env['KANBAN_AGING_WARN_COLOR'] ?? '#c9a000'
 export const KANBAN_AGING_CAUTION_COLOR = env['KANBAN_AGING_CAUTION_COLOR'] ?? '#d46b00'
 export const KANBAN_AGING_CRITICAL_COLOR = env['KANBAN_AGING_CRITICAL_COLOR'] ?? '#c53030'
+// Kanban WIP limits per column (0 = unlimited). Override via .env.
+export const KANBAN_WIP_PLANNED = parseInt(env['KANBAN_WIP_PLANNED'] ?? '0', 10)
+export const KANBAN_WIP_IN_PROGRESS = parseInt(env['KANBAN_WIP_IN_PROGRESS'] ?? '0', 10)
+export const KANBAN_WIP_WAITING = parseInt(env['KANBAN_WIP_WAITING'] ?? '0', 10)
+export const KANBAN_WIP_DONE = parseInt(env['KANBAN_WIP_DONE'] ?? '0', 10)
+// Utilisation % at which the badge turns yellow (default 80)
+export const KANBAN_WIP_WARN_PCT = parseInt(env['KANBAN_WIP_WARN_PCT'] ?? '80', 10)
+// Badge colours for each utilisation tier
+export const KANBAN_WIP_OK_COLOR = env['KANBAN_WIP_OK_COLOR'] ?? '#6b7280'
+export const KANBAN_WIP_WARN_COLOR = env['KANBAN_WIP_WARN_COLOR'] ?? '#c9a000'
+export const KANBAN_WIP_FULL_COLOR = env['KANBAN_WIP_FULL_COLOR'] ?? '#d46b00'
+export const KANBAN_WIP_OVER_COLOR = env['KANBAN_WIP_OVER_COLOR'] ?? '#c53030'
 export const DASHBOARD_PUBLIC_URL = env['DASHBOARD_PUBLIC_URL'] ?? ''
 export const OLLAMA_URL = env['OLLAMA_URL'] ?? 'http://localhost:11434'
 

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -4,6 +4,8 @@ import {
   PROJECT_ROOT, OWNER_NAME, BOT_NAME, BRAND_NAME, MAIN_AGENT_ID, CHANNEL_PROVIDER,
   KANBAN_AGING_WARN_H, KANBAN_AGING_CAUTION_H, KANBAN_AGING_CRITICAL_H,
   KANBAN_AGING_WARN_COLOR, KANBAN_AGING_CAUTION_COLOR, KANBAN_AGING_CRITICAL_COLOR,
+  KANBAN_WIP_PLANNED, KANBAN_WIP_IN_PROGRESS, KANBAN_WIP_WAITING, KANBAN_WIP_DONE,
+  KANBAN_WIP_WARN_PCT, KANBAN_WIP_OK_COLOR, KANBAN_WIP_WARN_COLOR, KANBAN_WIP_FULL_COLOR, KANBAN_WIP_OVER_COLOR,
 } from '../../config.js'
 import { readMarveenTelegramConfig, readMarveenDiscordConfig, readMarveenSlackConfig, sendMarveenAvatarChange } from '../telegram.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
@@ -97,6 +99,19 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
         warnColor: KANBAN_AGING_WARN_COLOR,
         cautionColor: KANBAN_AGING_CAUTION_COLOR,
         criticalColor: KANBAN_AGING_CRITICAL_COLOR,
+      },
+      kanbanWip: {
+        limits: {
+          planned: KANBAN_WIP_PLANNED,
+          in_progress: KANBAN_WIP_IN_PROGRESS,
+          waiting: KANBAN_WIP_WAITING,
+          done: KANBAN_WIP_DONE,
+        },
+        warnPct: KANBAN_WIP_WARN_PCT,
+        okColor: KANBAN_WIP_OK_COLOR,
+        warnColor: KANBAN_WIP_WARN_COLOR,
+        fullColor: KANBAN_WIP_FULL_COLOR,
+        overColor: KANBAN_WIP_OVER_COLOR,
       },
     })
     return true

--- a/web/app.js
+++ b/web/app.js
@@ -280,13 +280,13 @@ document.querySelectorAll('.kanban-add-btn').forEach((btn) => {
 
 async function loadKanban() {
   try {
-    // Ensure the card-aging config (window._marveen.kanbanAging) is loaded even
-    // if the user opens the Kanban page first, before the Agents page populated it.
-    if (!window._marveen?.kanbanAging) {
+    // Ensure the marveen config (kanbanAging + kanbanWip) is loaded even if the
+    // user opens the Kanban page first, before the Agents page populated it.
+    if (!window._marveen?.kanbanAging || !window._marveen?.kanbanWip) {
       try {
         const mr = await fetch('/api/marveen')
         if (mr.ok) window._marveen = { ...(window._marveen || {}), ...(await mr.json()) }
-      } catch { /* ignore -- aging just won't render until _marveen loads */ }
+      } catch { /* ignore -- aging/WIP just won't render until _marveen loads */ }
     }
     const [cardsRes, assigneesRes, projectsRes] = await Promise.all([
       fetch('/api/kanban'),

--- a/web/app.js
+++ b/web/app.js
@@ -474,6 +474,49 @@ function renderKanban() {
 
   // Badge: only count subtasks that are in a different column (not embedded here)
   updateSubtaskBadges(embeddedSubtaskIds)
+
+  // WIP limit badges: update column-header count spans with "count/limit" when configured
+  updateWipBadges(grouped)
+}
+
+// Map column status keys to their count-span IDs
+const WIP_COUNT_IDS = {
+  planned: 'countPlanned',
+  in_progress: 'countInProgress',
+  waiting: 'countWaiting',
+  done: 'countDone',
+}
+
+function updateWipBadges(grouped) {
+  const cfg = window._marveen?.kanbanWip
+  for (const [status, cards] of Object.entries(grouped)) {
+    const el = document.getElementById(WIP_COUNT_IDS[status])
+    if (!el) continue
+    const limit = cfg?.limits?.[status] || 0
+    if (!limit) {
+      // No limit configured: restore plain count and clear WIP styling
+      el.textContent = cards.length
+      delete el.dataset.wip
+      el.style.color = ''
+      el.style.borderColor = ''
+      continue
+    }
+    const count = cards.length
+    el.textContent = `${count}/${limit}`
+    let state, color
+    if (count > limit) {
+      state = 'over'; color = cfg.overColor
+    } else if (count === limit) {
+      state = 'full'; color = cfg.fullColor
+    } else if ((count / limit) * 100 >= cfg.warnPct) {
+      state = 'warn'; color = cfg.warnColor
+    } else {
+      state = 'ok'; color = cfg.okColor
+    }
+    el.dataset.wip = state
+    el.style.color = color
+    el.style.borderColor = color
+  }
 }
 
 function updateSubtaskBadges(embeddedSubtaskIds) {

--- a/web/style.css
+++ b/web/style.css
@@ -565,6 +565,22 @@ main {
   padding: 1px 7px;
   min-width: 20px;
   text-align: center;
+  border: 1px solid transparent;
+  transition: color 0.2s, border-color 0.2s, transform 0.2s;
+}
+
+/* WIP limit badge states — colour applied via inline style from JS */
+.kanban-col-count[data-wip="warn"] { background: color-mix(in oklch, currentColor 10%, var(--bg-card)); }
+.kanban-col-count[data-wip="full"] { background: color-mix(in oklch, currentColor 10%, var(--bg-card)); animation: wip-pulse-mild 2.4s ease-in-out infinite; }
+.kanban-col-count[data-wip="over"] { background: color-mix(in oklch, currentColor 12%, var(--bg-card)); animation: wip-pulse-strong 1.6s ease-in-out infinite; transform: scale(1.1); }
+
+@keyframes wip-pulse-mild {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+@keyframes wip-pulse-strong {
+  0%, 100% { opacity: 1; transform: scale(1.1); }
+  50% { opacity: 0.4; transform: scale(1.1); }
 }
 .kanban-add-btn {
   margin-left: auto;


### PR DESCRIPTION
## Summary

Adds a per-column WIP (work-in-progress) limit badge to the kanban board, Jira-style. Each column header shows a "count/limit" badge whose colour escalates with utilisation:

- below the warn threshold: neutral grey (ok)
- at/above the warn threshold (default 80%): yellow (warn)
- at 100%: orange, with a subtle pulse (full)
- above 100%: red, stronger pulse + slight size bump (over)

Limits default to 0 (unlimited = no badge), so the feature is opt-in and invisible until configured. Goal: surface column/fleet overload early, complementing the kanban stalled-task audit.

## Config (.env)

- KANBAN_WIP_PLANNED / IN_PROGRESS / WAITING / DONE (per-column limit, 0 = unlimited)
- KANBAN_WIP_WARN_PCT (default 80)
- KANBAN_WIP_OK_COLOR / WARN_COLOR / FULL_COLOR / OVER_COLOR

Config flows src/config.ts → /api/marveen (kanbanWip key) → window._marveen → frontend badge render. loadKanban also fetches the config so badges show on direct kanban-page open.

## Files

- web/app.js, web/style.css (badge render + colour states + pulse)
- src/config.ts, src/web/routes/marveen.ts (config + API exposure)
- docs/kanban.md, docs/en/kanban.md (technical + user-facing sections, HU+EN)

This change was authored with AI assistance, reviewed by the user @cett before submission.

## Test plan

- [ ] With a limit set, the column header shows count/limit and the colour matches utilisation (grey/yellow/orange/red)
- [ ] Limit 0 hides the badge (plain count)
- [ ] Badge renders when opening the kanban page directly (not only after visiting Agents)
- [ ] Thresholds/colours overridable via KANBAN_WIP_* env vars