### PR TITLE
Feat/kanban: swimlane nézet (csoportosítás felelős vagy prioritás szerint)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # SERVICE_ID=marveen
 
 # Opcionális:
+# KANBAN_SWIMLANE_DEFAULT_GROUP=assignee   # none (alapért.) | assignee | priority
+# KANBAN_SWIMLANE_SEPARATOR_COLOR=#3d3d3a  # swimlane-ok közti szaggatott elválasztó színe
 # WEB_PORT=3420
 # WEB_HOST=127.0.0.1       # FONTOS: 0.0.0.0-val a dashboard elérhető a hálózatról. Használj DASHBOARD_TOKEN-t!
 # OLLAMA_URL=http://localhost:11434

--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -182,6 +182,43 @@ If a lane isn't relevant right now (e.g. an assignee with everything closed out)
 
 On a large board with lots of cards, the plain column view gets hard to scan. The swimlane view immediately shows the load distribution -- if cards are piling up for one owner (or at one priority level), you see it at a glance, before reading through each one.
 
+### Swimlanes -- technical details
+
+The kanban board can optionally split into horizontal lanes (swimlanes), grouped by one of two fields: assignee or priority. By default (no grouping) the board uses the usual 4-column layout, unchanged.
+
+**Layout in grouped view:**
+
+Each swimlane is a full-width band containing all 4 status columns (planned/in_progress/waiting/done), but only with cards belonging to that group. A 44px header bar precedes each lane:
+
+- **Left side:** a 28px round avatar (assignee-type color + initial, or a priority-color marker with no text), followed by the bold name/priority label.
+- **Right side:** a card-count badge (total cards in the lane across all statuses), followed by a chevron button (▼/▶) to collapse the lane.
+
+The header uses `position: sticky` (both top and left), so it stays in view during both horizontal and vertical scrolling. A 2px dashed separator runs between lanes.
+
+**Grouping key:**
+
+- **By assignee:** based on the card's `assignee` field, matched case-insensitively against the `/api/kanban/assignees` list; unmatched or missing assignees fall into an "Unassigned" catch-all lane.
+- **By priority:** based on the card's `priority` field (`urgent` > `high` > `normal` > `low` order).
+
+Empty (cardless) swimlanes are not rendered.
+
+**Persistence:**
+
+The grouping choice is stored in `localStorage` (key `marveen.kanbanGroupBy`), so the user's last choice survives a page reload in that browser and overrides the `.env`-configured default. Lane-collapse state, by contrast, only lives in the page's in-memory state (cleared on reload), though it survives board refreshes (e.g. card moves, the 30-second auto-refresh).
+
+**Drag and drop:**
+
+The existing card-move logic (status + order) works in swimlane view too, per column -- a card can be dragged into a different status column within its own lane. Dragging into a different lane does not change the card's assignee/priority, only its status.
+
+**Configuration keys (`.env`):**
+
+```
+KANBAN_SWIMLANE_DEFAULT_GROUP=none         # none (default) | assignee | priority
+KANBAN_SWIMLANE_SEPARATOR_COLOR=           # empty = CSS default (var(--border))
+```
+
+Data flow: `src/config.ts` → `/api/marveen` (`kanbanSwimlanes` key) → `window._marveen.kanbanSwimlanes` (frontend). The frontend is static, no build step -- a server restart is enough to pick up config changes.
+
 ---
 
 ## Related documents

--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -153,6 +153,34 @@ KANBAN_WIP_OVER_COLOR=#c53030
 ```
 
 Data flow: `src/config.ts` → `/api/marveen` (`kanbanWip` key) → `window._marveen.kanbanWip` (frontend). The frontend is static -- a server HUP is sufficient to apply limit changes.
+### Swimlane view
+
+The swimlane view splits the board into horizontal lanes, so instead of one big column you immediately see where cards are piling up -- by owner or by priority.
+
+**What you see**
+
+When grouping is turned on, cards are arranged into horizontal lanes instead of (or within) columns. Each lane starts with a sticky header (always visible while scrolling) showing:
+
+- the assignee's avatar and name (when grouping by owner), or the priority label (when grouping by priority),
+- the number of cards in the lane,
+- a small chevron icon to collapse the lane.
+
+**Switching the grouping**
+
+A control above the board lets you choose how cards are split into lanes:
+
+- **By owner** -- one lane per assignee, so you can tell at a glance who has how much in flight.
+- **By priority** -- cards land in `low`/`normal`/`high`/`urgent` lanes, so urgent work doesn't get lost in the crowd.
+
+Your choice is remembered in the browser, so you don't have to re-select it every time you open the board.
+
+**Collapsing a lane**
+
+If a lane isn't relevant right now (e.g. an assignee with everything closed out), click the chevron in its header -- the lane collapses to just the header (with the card count). Click again to reopen it.
+
+**What it's for**
+
+On a large board with lots of cards, the plain column view gets hard to scan. The swimlane view immediately shows the load distribution -- if cards are piling up for one owner (or at one priority level), you see it at a glance, before reading through each one.
 
 ---
 

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -182,3 +182,40 @@ Ha egy sáv jelenleg nem érdekes (pl. egy felelős minden kártyája lezárva),
 **Mire jó?**
 
 Nagy, sok kártyás táblánál a sima oszlopnézet könnyen átláthatatlanná válik. A swimlane nézet azonnal megmutatja a terheléseloszlást -- ha egy felelősnél (vagy egy prioritási szinten) feltorlódnak a kártyák, az első pillantásra látszik, mielőtt bele kellene olvasni mindegyikbe.
+
+### Swimlane-ek -- technikai részletek
+
+A kanban-tábla opcionálisan vízszintes sávokra (swimlane) bontható, két csoportosító mező közül választva: felelős (assignee) vagy prioritás. Alapállapotban (nincs csoportosítás) a tábla a megszokott 4 oszlopos elrendezést használja, változás nélkül.
+
+**Felépítés csoportosított nézetben:**
+
+Minden swimlane egy teljes szélességű sáv, amely a tábla mind a 4 státusz-oszlopát (tervezett/folyamatban/várakozik/kész) tartalmazza, de csak az adott csoportba tartozó kártyákkal. A swimlane előtt egy 44px magas fejléc-sáv jelenik meg:
+
+- **Bal oldal:** 28px kör alakú avatar (a felelős típusa szerinti szín + kezdőbetű, vagy prioritás-szín jelölő, szöveg nélkül), majd a félkövér név/prioritás-címke.
+- **Jobb oldal:** kártyaszám-badge (a swimlane összes kártyájának száma, az összes státuszban összesítve), majd egy chevron gomb (▼/▶) a sáv összecsukásához.
+
+A fejléc `position: sticky` (top és left egyaránt), így vízszintes és függőleges görgetésnél is a látható területen marad. A swimlane-ek között 2px szaggatott elválasztó vonal van.
+
+**Csoportosítás kulcsa:**
+
+- **Felelős szerint:** a kártya `assignee` mezője alapján, a `/api/kanban/assignees` listával egyezés (kis- és nagybetű-érzéketlen), nem egyező vagy hiányzó felelős esetén "Nincs hozzárendelve" gyűjtő-sáv.
+- **Prioritás szerint:** a kártya `priority` mezője alapján (`urgent` > `high` > `normal` > `low` sorrendben).
+
+Az üres (kártya nélküli) swimlane-ek nem jelennek meg.
+
+**Perzisztencia:**
+
+A csoportosítás-választás `localStorage`-ban (`marveen.kanbanGroupBy` kulcs) tárolódik, így a felhasználó utolsó választása böngészőnkénti újratöltés után is megmarad, és felülírja a `.env`-ben konfigurált alapértéket. A sáv-összecsukás állapota viszont csak a böngészőlap memóriájában él (oldal-frissítésnél törlődik), a táblafrissítések (pl. kártya mozgatás, 30 másodperces auto-refresh) azonban nem törlik.
+
+**Drag & drop:**
+
+A meglévő kártyamozgatás logika (státusz + sorrend) swimlane-nézetben is működik, oszloponként -- a kártya az adott swimlane adott státusz-oszlopába húzható. Más swimlane-be húzás nem módosítja a kártya felelősét/prioritását, csak a státuszát.
+
+**Konfigurációs kulcsok (`.env`):**
+
+```
+KANBAN_SWIMLANE_DEFAULT_GROUP=none         # none (alapért.) | assignee | priority
+KANBAN_SWIMLANE_SEPARATOR_COLOR=           # üres = CSS alapszín (var(--border))
+```
+
+Adatfolyam: `src/config.ts` → `/api/marveen` (`kanbanSwimlanes` kulcs) → `window._marveen.kanbanSwimlanes` (frontend). A frontend statikus, nincs build lépés -- szerver HUP elegendő a beállítások megváltoztatásához.

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -154,3 +154,31 @@ Ha egy oszlop piros badge-dzsel villog, ne vegyél fel oda új feladatot. Elősz
 **Hogyan állítható a limit?**
 
 A WIP-limit oszloponként konfigurálható a `.env` fájlban (részletek a technikai dokumentációban). Ha az oszlopnak nincs beállított limitje, a badge nem jelenik meg.
+### Sávos nézet (Swimlane)
+
+A swimlane nézet vízszintes sávokra bontja a táblát, hogy egy nagy oszlop helyett azonnal lásd, kinél vagy milyen prioritású kártyák torlódnak.
+
+**Mit látsz?**
+
+Csoportosítás bekapcsolásakor a kártyák oszlopok helyett (vagy azokon belül) vízszintes sávokba rendeződnek. Minden sáv elején egy "ragadó" (a görgetésnél mindig látható) fejléc áll:
+
+- a felelős avatarja és neve (ha felelős szerint csoportosítasz), vagy a prioritás címkéje (ha prioritás szerint),
+- a sávban lévő kártyák száma,
+- egy kis nyíl (chevron) ikon, amivel a sáv összecsukható.
+
+**Csoportosítás váltása**
+
+A tábla feletti vezérlőben választhatsz, mi szerint bontsa sávokra a rendszer a kártyákat:
+
+- **Felelős szerint** -- minden felelőshöz egy sáv, így egy pillantással látod, kinél mennyi van folyamatban.
+- **Prioritás szerint** -- a kártyák `low`/`normal`/`high`/`urgent` sávokba kerülnek, így a sürgős feladatok nem tűnnek el a tömegben.
+
+A választás a böngésződben megmarad, nem kell minden megnyitásnál újra beállítani.
+
+**Sáv összecsukása**
+
+Ha egy sáv jelenleg nem érdekes (pl. egy felelős minden kártyája lezárva), kattints a fejléc chevronjára -- a sáv összecsukódik, csak a fejléc (létszámmal) marad látható. Ugyanígy nyitható vissza.
+
+**Mire jó?**
+
+Nagy, sok kártyás táblánál a sima oszlopnézet könnyen átláthatatlanná válik. A swimlane nézet azonnal megmutatja a terheléseloszlást -- ha egy felelősnél (vagy egy prioritási szinten) feltorlódnak a kártyák, az első pillantásra látszik, mielőtt bele kellene olvasni mindegyikbe.

--- a/src/config.ts
+++ b/src/config.ts
@@ -107,6 +107,16 @@ export const KANBAN_WIP_OVER_COLOR = env['KANBAN_WIP_OVER_COLOR'] ?? '#c53030'
 export const DASHBOARD_PUBLIC_URL = env['DASHBOARD_PUBLIC_URL'] ?? ''
 export const OLLAMA_URL = env['OLLAMA_URL'] ?? 'http://localhost:11434'
 
+// Kanban swimlanes: which field the board groups by on first load. Invalid
+// values silently fall back to 'none' (flat board) rather than breaking the
+// grouping logic on the frontend.
+const rawKanbanSwimlaneDefaultGroup = env['KANBAN_SWIMLANE_DEFAULT_GROUP'] ?? 'none'
+export const KANBAN_SWIMLANE_DEFAULT_GROUP =
+  rawKanbanSwimlaneDefaultGroup === 'assignee' || rawKanbanSwimlaneDefaultGroup === 'priority'
+    ? rawKanbanSwimlaneDefaultGroup
+    : 'none'
+export const KANBAN_SWIMLANE_SEPARATOR_COLOR = env['KANBAN_SWIMLANE_SEPARATOR_COLOR'] ?? ''
+
 export const CHANNEL_PROVIDER: ChannelProviderType = getProviderType(env['CHANNEL_PROVIDER'])
 export const CHANNEL_TOKEN = getChannelToken(CHANNEL_PROVIDER, env)
 export const CHANNEL_CHAT_ID = getChannelChatId(CHANNEL_PROVIDER, env)

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -6,6 +6,7 @@ import {
   KANBAN_AGING_WARN_COLOR, KANBAN_AGING_CAUTION_COLOR, KANBAN_AGING_CRITICAL_COLOR,
   KANBAN_WIP_PLANNED, KANBAN_WIP_IN_PROGRESS, KANBAN_WIP_WAITING, KANBAN_WIP_DONE,
   KANBAN_WIP_WARN_PCT, KANBAN_WIP_OK_COLOR, KANBAN_WIP_WARN_COLOR, KANBAN_WIP_FULL_COLOR, KANBAN_WIP_OVER_COLOR,
+  KANBAN_SWIMLANE_DEFAULT_GROUP, KANBAN_SWIMLANE_SEPARATOR_COLOR,
 } from '../../config.js'
 import { readMarveenTelegramConfig, readMarveenDiscordConfig, readMarveenSlackConfig, sendMarveenAvatarChange } from '../telegram.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
@@ -112,6 +113,10 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
         warnColor: KANBAN_WIP_WARN_COLOR,
         fullColor: KANBAN_WIP_FULL_COLOR,
         overColor: KANBAN_WIP_OVER_COLOR,
+      },
+      kanbanSwimlanes: {
+        defaultGroup: KANBAN_SWIMLANE_DEFAULT_GROUP,
+        separatorColor: KANBAN_SWIMLANE_SEPARATOR_COLOR || null,
       },
     })
     return true

--- a/web/app.js
+++ b/web/app.js
@@ -256,6 +256,15 @@ let kanbanProjectFilter = ''
 // Matched case-insensitively against card.assignee so a casing mismatch
 // (e.g. card "gorcsevivan" vs list "GorcsevIvan") still filters correctly.
 let kanbanAssigneeFilter = ''
+// Swimlane grouping: 'none' (flat board, default) | 'assignee' | 'priority'.
+// The initial value is pulled from window._marveen.kanbanSwimlanes.defaultGroup
+// the first time loadKanban() runs (see kanbanGroupByInitialized below), then
+// fully user-controlled via the toolbar dropdown.
+let kanbanGroupBy = 'none'
+let kanbanGroupByInitialized = false
+// Which swimlane keys (assignee name or priority value) are collapsed. Lives
+// for the page session only -- intentionally not persisted across reloads.
+const kanbanCollapsedLanes = new Set()
 
 const cardModalOverlay = document.getElementById('cardModalOverlay')
 const cardDetailOverlay = document.getElementById('cardDetailOverlay')
@@ -280,13 +289,30 @@ document.querySelectorAll('.kanban-add-btn').forEach((btn) => {
 
 async function loadKanban() {
   try {
-    // Ensure the marveen config (kanbanAging + kanbanWip) is loaded even if the
-    // user opens the Kanban page first, before the Agents page populated it.
-    if (!window._marveen?.kanbanAging || !window._marveen?.kanbanWip) {
+    // Ensure the marveen config (kanbanAging + kanbanWip + kanbanSwimlanes) is
+    // loaded even if the user opens the Kanban page first, before the Agents
+    // page populated it.
+    if (!window._marveen?.kanbanAging || !window._marveen?.kanbanWip || !window._marveen?.kanbanSwimlanes) {
       try {
         const mr = await fetch('/api/marveen')
         if (mr.ok) window._marveen = { ...(window._marveen || {}), ...(await mr.json()) }
-      } catch { /* ignore -- aging/WIP just won't render until _marveen loads */ }
+      } catch { /* ignore -- aging/WIP/swimlanes just won't render until _marveen loads */ }
+    }
+    if (!kanbanGroupByInitialized) {
+      kanbanGroupByInitialized = true
+      // A user's own past choice (saved to localStorage) wins over the
+      // server-configured default, so switching the grouping sticks across
+      // page reloads instead of resetting every time.
+      const stored = localStorage.getItem('marveen.kanbanGroupBy')
+      const defaultGroup = window._marveen?.kanbanSwimlanes?.defaultGroup
+      const initialGroup = (stored === 'assignee' || stored === 'priority' || stored === 'none')
+        ? stored
+        : (defaultGroup === 'assignee' || defaultGroup === 'priority' ? defaultGroup : 'none')
+      if (initialGroup !== 'none') {
+        kanbanGroupBy = initialGroup
+        const sel = document.getElementById('kanbanGroupBy')
+        if (sel) sel.value = initialGroup
+      }
     }
     const [cardsRes, assigneesRes, projectsRes] = await Promise.all([
       fetch('/api/kanban'),
@@ -304,6 +330,12 @@ async function loadKanban() {
     console.error('Kanban betöltés hiba:', err)
   }
 }
+
+document.getElementById('kanbanGroupBy').addEventListener('change', (e) => {
+  kanbanGroupBy = e.target.value
+  localStorage.setItem('marveen.kanbanGroupBy', kanbanGroupBy)
+  renderKanban()
+})
 
 function populateProjectFilter() {
   const sel = document.getElementById('kanbanProjectFilter')
@@ -453,26 +485,153 @@ function renderKanban() {
     if (grouped[card.status]) grouped[card.status].push(card)
   }
 
-  for (const [status, cards] of Object.entries(grouped)) {
-    const col = document.querySelector(`.kanban-col-body[data-status="${status}"]`)
-    col.innerHTML = ''
-    cards.sort((a, b) => a.sort_order - b.sort_order)
-
-    for (const card of cards) {
-      const embeddedChildren = kanbanCards
-        .filter(c => c.parent_id === card.id && embeddedSubtaskIds.has(c.id))
-        .sort((a, b) => a.sort_order - b.sort_order)
-      col.appendChild(createCardEl(card, embeddedChildren))
-    }
-  }
-
   // Update counts (embedded subtasks don't count as separate cards)
   document.getElementById('countPlanned').textContent = grouped.planned.length
   document.getElementById('countInProgress').textContent = grouped.in_progress.length
   document.getElementById('countWaiting').textContent = grouped.waiting.length
   document.getElementById('countDone').textContent = grouped.done.length
 
-  // Badge: only count subtasks that are in a different column (not embedded here)
+  const flatBoard = document.getElementById('kanbanBoard')
+  const swimlaneBoard = document.getElementById('kanbanSwimlaneBoard')
+
+  if (kanbanGroupBy === 'none') {
+    swimlaneBoard.hidden = true
+    flatBoard.hidden = false
+    for (const [status, cards] of Object.entries(grouped)) {
+      const col = document.querySelector(`#kanbanBoard .kanban-col-body[data-status="${status}"]`)
+      col.innerHTML = ''
+      cards.sort((a, b) => a.sort_order - b.sort_order)
+
+      for (const card of cards) {
+        const embeddedChildren = kanbanCards
+          .filter(c => c.parent_id === card.id && embeddedSubtaskIds.has(c.id))
+          .sort((a, b) => a.sort_order - b.sort_order)
+        col.appendChild(createCardEl(card, embeddedChildren))
+      }
+    }
+    // Badge: only count subtasks that are in a different column (not embedded here)
+    updateSubtaskBadges(embeddedSubtaskIds)
+  } else {
+    flatBoard.hidden = true
+    swimlaneBoard.hidden = false
+    renderSwimlaneBoard(grouped, embeddedSubtaskIds)
+  }
+}
+
+const KANBAN_STATUS_DEFS = [
+  { status: 'planned', title: 'Tervezett' },
+  { status: 'in_progress', title: 'Folyamatban' },
+  { status: 'waiting', title: 'Várakozik' },
+  { status: 'done', title: 'Kész' },
+]
+const KANBAN_PRIORITY_LABELS = { urgent: 'Sürgős', high: 'Magas', normal: 'Normál', low: 'Alacsony' }
+const KANBAN_PRIORITY_ORDER = ['urgent', 'high', 'normal', 'low']
+
+// Which swimlane a card belongs to under the current grouping. Returns a
+// stable string key: the matched assignee's canonical name, '__unassigned__'
+// for cards with no/unmatched assignee, or the priority value.
+function kanbanSwimlaneKeyFor(card) {
+  if (kanbanGroupBy === 'priority') return card.priority || 'normal'
+  const raw = card.assignee ? String(card.assignee).trim() : ''
+  if (!raw) return '__unassigned__'
+  const match = kanbanAssignees.find(a => a.name.toLowerCase() === raw.toLowerCase())
+  return match ? match.name : raw
+}
+
+// Display metadata (label + avatar styling) for a swimlane key.
+function kanbanSwimlaneMeta(key) {
+  if (kanbanGroupBy === 'priority') {
+    const label = KANBAN_PRIORITY_LABELS[key] || key
+    return { label, avatarClass: `priority-${key}`, avatarChar: '' }
+  }
+  if (key === '__unassigned__') return { label: 'Nincs hozzárendelve', avatarClass: 'unknown', avatarChar: '?' }
+  const match = kanbanAssignees.find(a => a.name === key)
+  const label = match ? (match.displayName || match.name) : key
+  return { label, avatarClass: match ? match.type : 'unknown', avatarChar: (label[0] || '?').toUpperCase() }
+}
+
+function renderSwimlaneBoard(grouped, embeddedSubtaskIds) {
+  const board = document.getElementById('kanbanSwimlaneBoard')
+  board.innerHTML = ''
+
+  const presentKeys = new Set()
+  for (const cards of Object.values(grouped)) {
+    for (const c of cards) presentKeys.add(kanbanSwimlaneKeyFor(c))
+  }
+
+  const canonicalOrder = kanbanGroupBy === 'priority'
+    ? KANBAN_PRIORITY_ORDER
+    : [...kanbanAssignees.map(a => a.name), '__unassigned__']
+  const orderedKeys = canonicalOrder.filter(k => presentKeys.has(k))
+  const leftoverKeys = [...presentKeys].filter(k => !orderedKeys.includes(k)).sort((a, b) => a.localeCompare(b))
+  const keys = [...orderedKeys, ...leftoverKeys]
+
+  const separatorColor = window._marveen?.kanbanSwimlanes?.separatorColor
+
+  for (const key of keys) {
+    const meta = kanbanSwimlaneMeta(key)
+    const collapsed = kanbanCollapsedLanes.has(key)
+
+    const laneCardsByStatus = {}
+    let totalCount = 0
+    for (const def of KANBAN_STATUS_DEFS) {
+      const cards = grouped[def.status].filter(c => kanbanSwimlaneKeyFor(c) === key)
+      laneCardsByStatus[def.status] = cards
+      totalCount += cards.length
+    }
+
+    const lane = document.createElement('div')
+    lane.className = 'kanban-swimlane' + (collapsed ? ' collapsed' : '')
+    lane.dataset.group = key
+    if (separatorColor) lane.style.borderBottomColor = separatorColor
+
+    const header = document.createElement('div')
+    header.className = 'kanban-swimlane-header'
+    header.innerHTML = `
+      <span class="kanban-swimlane-avatar ${meta.avatarClass}">${escapeHtml(meta.avatarChar)}</span>
+      <span class="kanban-swimlane-name">${escapeHtml(meta.label)}</span>
+      <span class="kanban-swimlane-count">${totalCount}</span>
+      <button class="kanban-swimlane-toggle" type="button" aria-expanded="${!collapsed}" title="${collapsed ? 'Kibontás' : 'Összecsukás'}">${collapsed ? '▶' : '▼'}</button>
+    `
+    header.querySelector('.kanban-swimlane-toggle').addEventListener('click', (e) => {
+      e.stopPropagation()
+      if (kanbanCollapsedLanes.has(key)) kanbanCollapsedLanes.delete(key)
+      else kanbanCollapsedLanes.add(key)
+      renderKanban()
+    })
+    lane.appendChild(header)
+
+    const body = document.createElement('div')
+    body.className = 'kanban-swimlane-body'
+    for (const def of KANBAN_STATUS_DEFS) {
+      const col = document.createElement('div')
+      col.className = 'kanban-swimlane-col'
+
+      const colHeader = document.createElement('div')
+      colHeader.className = 'kanban-swimlane-col-header'
+      colHeader.textContent = def.title
+
+      const colBody = document.createElement('div')
+      colBody.className = 'kanban-col-body kanban-swimlane-col-body'
+      colBody.dataset.status = def.status
+
+      const cards = laneCardsByStatus[def.status].sort((a, b) => a.sort_order - b.sort_order)
+      for (const card of cards) {
+        const embeddedChildren = kanbanCards
+          .filter(c => c.parent_id === card.id && embeddedSubtaskIds.has(c.id))
+          .sort((a, b) => a.sort_order - b.sort_order)
+        colBody.appendChild(createCardEl(card, embeddedChildren))
+      }
+      wireKanbanColumnDnD(colBody)
+
+      col.appendChild(colHeader)
+      col.appendChild(colBody)
+      body.appendChild(col)
+    }
+    lane.appendChild(body)
+    board.appendChild(lane)
+  }
+
   updateSubtaskBadges(embeddedSubtaskIds)
 
   // WIP limit badges: update column-header count spans with "count/limit" when configured
@@ -663,7 +822,11 @@ function createCardEl(card, embeddedChildren = []) {
 }
 
 // === Drag & Drop ===
-columns.forEach((col) => {
+// Wires the drag/drop handlers for one column-body element. Used for the
+// 4 static flat-board columns at load time, and again for every swimlane
+// column-body created dynamically in renderSwimlaneBoard (those elements
+// don't exist yet when this module first runs).
+function wireKanbanColumnDnD(col) {
   col.addEventListener('dragover', (e) => {
     e.preventDefault()
     e.dataTransfer.dropEffect = 'move'
@@ -706,7 +869,8 @@ columns.forEach((col) => {
       showToast('Hiba az áthelyezés során')
     }
   })
-})
+}
+columns.forEach(wireKanbanColumnDnD)
 
 function getDragAfterElement(col, y) {
   const els = [...col.querySelectorAll('.kanban-card:not(.dragging)')]

--- a/web/index.html
+++ b/web/index.html
@@ -185,6 +185,12 @@
         <select id="kanbanProjectFilter" style="font-size:13px;padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--fg);min-width:140px;">
           <option value="">Mind</option>
         </select>
+        <label for="kanbanGroupBy" style="font-size:13px;color:var(--muted);white-space:nowrap;margin-left:8px;">Csoportosítás:</label>
+        <select id="kanbanGroupBy" style="font-size:13px;padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--fg);min-width:140px;">
+          <option value="none">Nincs</option>
+          <option value="assignee">Felelős szerint</option>
+          <option value="priority">Prioritás szerint</option>
+        </select>
       </div>
       <div class="kanban-board" id="kanbanBoard">
         <div class="kanban-col" data-status="planned">
@@ -219,6 +225,7 @@
           <div class="kanban-col-body" data-status="done"></div>
         </div>
       </div>
+      <div class="kanban-board kanban-swimlane-board" id="kanbanSwimlaneBoard" hidden></div>
     </div>
 
     <!-- === Agents Page === -->

--- a/web/style.css
+++ b/web/style.css
@@ -532,6 +532,11 @@ main {
   gap: 12px;
   min-height: calc(100vh - 160px);
 }
+/* Both the flat board and the swimlane board carry .kanban-board; an
+   explicit [hidden] override is required because the unconditional
+   `display: grid` above otherwise wins the cascade over the UA [hidden]
+   default (equal specificity, later source order). */
+.kanban-board[hidden] { display: none; }
 
 .kanban-col {
   background: var(--bg-input);
@@ -810,6 +815,112 @@ main {
 }
 .kanban-card-aging-badge.kanban-card-aging-critical {
   animation: aging-pulse 2.2s ease-in-out infinite;
+}
+
+/* === Kanban Swimlanes === */
+.kanban-swimlane-board {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.kanban-swimlane {
+  border-bottom: 2px dashed var(--border);
+  padding-bottom: 16px;
+  margin-bottom: 16px;
+}
+.kanban-swimlane:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+  margin-bottom: 0;
+}
+.kanban-swimlane-header {
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 5;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 4px;
+  background: var(--bg);
+}
+.kanban-swimlane-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+.kanban-swimlane-avatar.owner { background: var(--accent); }
+.kanban-swimlane-avatar.bot { background: var(--info); }
+.kanban-swimlane-avatar.agent { background: var(--success); }
+.kanban-swimlane-avatar.unknown { background: var(--text-muted); }
+.kanban-swimlane-avatar.priority-urgent { background: var(--danger); }
+.kanban-swimlane-avatar.priority-high { background: var(--accent); }
+.kanban-swimlane-avatar.priority-normal { background: var(--text-muted); }
+.kanban-swimlane-avatar.priority-low { background: var(--border); }
+.kanban-swimlane-name {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text);
+  margin-right: auto;
+}
+.kanban-swimlane-count {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--bg-card);
+  border-radius: 10px;
+  padding: 1px 7px;
+  min-width: 20px;
+  text-align: center;
+}
+.kanban-swimlane-toggle {
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition);
+}
+.kanban-swimlane-toggle:hover { background: var(--accent-soft); color: var(--accent); }
+.kanban-swimlane-body {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 4px;
+}
+.kanban-swimlane.collapsed .kanban-swimlane-body { display: none; }
+.kanban-swimlane-col {
+  background: var(--bg-input);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  min-height: 60px;
+}
+.kanban-swimlane-col-header {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-muted);
+  padding: 8px 12px 4px;
+}
+.kanban-swimlane-col-body {
+  flex: 1;
+  min-height: 40px;
 }
 
 /* === Card detail === */
@@ -4729,6 +4840,10 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
     gap: 16px;
   }
   .kanban-col { min-height: auto; }
+  .kanban-swimlane-body {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary

Adds a swimlane (horizontal grouping) view to the kanban board. A "Group by" selector in the toolbar lets the board split into horizontal lanes by assignee or by priority (or none = the flat board).

Each lane has a sticky 44px header: an avatar (agent colour / initial), the name (or priority label), a card-count badge, and a chevron to collapse/expand the lane. The header stays sticky during horizontal scroll; a dashed separator divides lanes. The chosen grouping persists in the browser (localStorage).

## Config (.env)

- KANBAN_SWIMLANE_DEFAULT_GROUP (none | assignee | priority; default none)
- KANBAN_SWIMLANE_SEPARATOR_COLOR (optional)

Config flows src/config.ts → /api/marveen (kanbanSwimlanes key) → window._marveen → frontend. loadKanban fetches the config so the view works on direct kanban-page open.

## Files

- web/app.js, web/style.css, web/index.html (group-by selector + swimlane render + sticky header styling)
- src/config.ts, src/web/routes/marveen.ts (config + API exposure)
- docs/kanban.md, docs/en/kanban.md (technical + user-facing sections, HU+EN)

This change was authored with AI assistance, reviewed by @cett before submission.

## Test plan

- [ ] Group by assignee shows one lane per assignee with correct counts; group by priority shows one lane per priority tier
- [ ] "none" returns the flat board
- [ ] Lane headers are sticky on horizontal scroll; collapse/expand works and persists
- [ ] Grouping choice persists across reloads (localStorage)
- [ ] Default grouping / separator colour overridable via the KANBAN_SWIMLANE_* env vars
