### PR TITLE
Feat/kanban labels filters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # Opcionális:
 # KANBAN_SWIMLANE_DEFAULT_GROUP=assignee   # none (alapért.) | assignee | priority
 # KANBAN_SWIMLANE_SEPARATOR_COLOR=#3d3d3a  # swimlane-ok közti szaggatott elválasztó színe
+# KANBAN_LABEL_COLORS=#3b82f6,#0ea5e9,#10b981,#14b8a6,#8b5cf6,#64748b  # kártya-címkék választható színpalettája
 # WEB_PORT=3420
 # WEB_HOST=127.0.0.1       # FONTOS: 0.0.0.0-val a dashboard elérhető a hálózatról. Használj DASHBOARD_TOKEN-t!
 # OLLAMA_URL=http://localhost:11434

--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -245,27 +245,27 @@ The board list endpoint (`GET /api/kanban`) embeds each card's `labels` array us
 
 The card detail view's "Labels" section shows attached labels as removable pills, a dropdown adds an existing label, and an inline form creates a new one (name + palette swatch picker). A newly created label is attached to the open card immediately.
 
-**Priority quick-filter chip row:**
+**Label quick-filter chip row:**
 
-The toolbar above the board, right-aligned next to the project filter, shows 4 pills -- one per priority value (`low`/`normal`/`high`/`urgent`) -- reusing the colour association already established for card priority (urgent=red, high=accent, normal=green, low=grey). Clicking a chip activates it (filled colour + × icon); multiple active chips combine with OR semantics. Each chip also shows a count: how many cards would match that priority under the currently active project/assignee/label filters -- independent of whether the chip itself is active, so the number stays meaningful either way.
+The toolbar above the board, right-aligned next to the project filter, shows one pill per defined label (from `/api/kanban/labels`), tinted in the label's own colour. Clicking a chip activates it (filled colour + × icon); multiple active chips combine with OR semantics -- this is the same `kanbanLabelFilter` set that the card footer pills also drive, just a second entry point into it. Each chip also shows a count: how many cards would match that label under the currently active project/assignee filters -- independent of whether the chip itself is active, so the number stays meaningful either way.
 
 **Label footer pills (on the card):**
 
-Each card's footer shows up to 3 of its attached labels as cold-toned pills (`#label-name`, in the label's own colour), with a non-clickable "+N" badge for the rest. Clicking a pill toggles that label into the active label filter -- selected labels combine with OR semantics (a card matches if it carries ANY of the active labels).
+Each card's footer shows up to 3 of its attached labels as cold-toned pills (`#label-name`, in the label's own colour), with a non-clickable "+N" badge for the rest. Clicking a pill toggles that label into the same active label filter the header chip row uses.
 
 **Filter-combination semantics:**
 
 All filter dimensions combine with AND:
 
 ```
-visible = project filter AND assignee filter AND (priority1 OR priority2 OR ...) AND (label1 OR label2 OR ...)
+visible = project filter AND assignee filter AND (label1 OR label2 OR ...)
 ```
 
-An empty dimension (no active priority or label selected) doesn't narrow anything -- every card matches that dimension. The swimlane grouping renders from the already-filtered card set, so quick filters and the swimlane view work together automatically, with no extra integration code. The "Clear filters" link in the toolbar (shown only when at least one priority or label filter is active) empties both sets at once.
+An empty label filter (no active label selected) doesn't narrow anything -- every card matches that dimension. The swimlane grouping renders from the already-filtered card set, so the quick filter and the swimlane view work together automatically, with no extra integration code. The "Clear filters" link in the toolbar (shown only when at least one label filter is active) empties the set.
 
 **Persistence:**
 
-Both the priority filter and the label filter are stored in `localStorage` (keys `marveen.kanbanPriorityFilter` and `marveen.kanbanLabelFilter`, as JSON arrays), the same way the swimlane grouping choice is -- they survive a page reload in that browser.
+The label filter is stored in `localStorage` (key `marveen.kanbanLabelFilter`, as a JSON array), the same way the swimlane grouping choice is -- it survives a page reload in that browser.
 
 **Configuration keys (`.env`):**
 

--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -219,6 +219,62 @@ KANBAN_SWIMLANE_SEPARATOR_COLOR=           # empty = CSS default (var(--border))
 
 Data flow: `src/config.ts` → `/api/marveen` (`kanbanSwimlanes` key) → `window._marveen.kanbanSwimlanes` (frontend). The frontend is static, no build step -- a server restart is enough to pick up config changes.
 
+### Quick filters and labels -- technical details
+
+**Data model:**
+
+Labels live in their own registry (`labels` table: `id`, `name`, `color`, `created_at`), linked to cards through a join table (`kanban_card_labels`: `card_id`, `label_id`, `created_at`). This lets the same label appear on many cards and be recoloured/renamed in one place. Deleting a card or a label drops the join rows transactionally, so no orphaned associations are left behind.
+
+A label's colour is not free text: it must be one of the entries in the `KANBAN_LABEL_COLORS` configuration palette (validated server-side; an invalid or missing value falls back to the first palette colour). This keeps the colour assignment traceable to a single configurable source instead of a hardcoded mapping in the code.
+
+**API endpoints:**
+
+```
+GET    /api/kanban/labels              -- list all labels
+POST   /api/kanban/labels              -- create a label ({ name, color })
+PUT    /api/kanban/labels/:id          -- rename/recolour a label
+DELETE /api/kanban/labels/:id          -- delete a label (+ all its card associations)
+GET    /api/kanban/:id/labels          -- a card's labels
+POST   /api/kanban/:id/labels          -- attach a label to a card ({ labelId })
+DELETE /api/kanban/:id/labels/:labelId -- detach a label from a card
+```
+
+The board list endpoint (`GET /api/kanban`) embeds each card's `labels` array using a single bulk JOIN query (not an N+1 per-card lookup), so the footer pills get everything they need in one round trip.
+
+**Card editor (CRUD UI):**
+
+The card detail view's "Labels" section shows attached labels as removable pills, a dropdown adds an existing label, and an inline form creates a new one (name + palette swatch picker). A newly created label is attached to the open card immediately.
+
+**Priority quick-filter chip row:**
+
+The toolbar above the board, right-aligned next to the project filter, shows 4 pills -- one per priority value (`low`/`normal`/`high`/`urgent`) -- reusing the colour association already established for card priority (urgent=red, high=accent, normal=green, low=grey). Clicking a chip activates it (filled colour + × icon); multiple active chips combine with OR semantics. Each chip also shows a count: how many cards would match that priority under the currently active project/assignee/label filters -- independent of whether the chip itself is active, so the number stays meaningful either way.
+
+**Label footer pills (on the card):**
+
+Each card's footer shows up to 3 of its attached labels as cold-toned pills (`#label-name`, in the label's own colour), with a non-clickable "+N" badge for the rest. Clicking a pill toggles that label into the active label filter -- selected labels combine with OR semantics (a card matches if it carries ANY of the active labels).
+
+**Filter-combination semantics:**
+
+All filter dimensions combine with AND:
+
+```
+visible = project filter AND assignee filter AND (priority1 OR priority2 OR ...) AND (label1 OR label2 OR ...)
+```
+
+An empty dimension (no active priority or label selected) doesn't narrow anything -- every card matches that dimension. The swimlane grouping renders from the already-filtered card set, so quick filters and the swimlane view work together automatically, with no extra integration code. The "Clear filters" link in the toolbar (shown only when at least one priority or label filter is active) empties both sets at once.
+
+**Persistence:**
+
+Both the priority filter and the label filter are stored in `localStorage` (keys `marveen.kanbanPriorityFilter` and `marveen.kanbanLabelFilter`, as JSON arrays), the same way the swimlane grouping choice is -- they survive a page reload in that browser.
+
+**Configuration keys (`.env`):**
+
+```
+KANBAN_LABEL_COLORS=#3b82f6,#0ea5e9,#10b981,#14b8a6,#8b5cf6,#64748b  # selectable palette (cold tones)
+```
+
+Data flow: `src/config.ts` → `/api/marveen` (`kanbanLabels.colors` key) → `window._marveen.kanbanLabels` (frontend).
+
 ---
 
 ## Related documents

--- a/docs/en/kanban.md
+++ b/docs/en/kanban.md
@@ -219,6 +219,32 @@ KANBAN_SWIMLANE_SEPARATOR_COLOR=           # empty = CSS default (var(--border))
 
 Data flow: `src/config.ts` → `/api/marveen` (`kanbanSwimlanes` key) → `window._marveen.kanbanSwimlanes` (frontend). The frontend is static, no build step -- a server restart is enough to pick up config changes.
 
+### Quick filters and labels
+
+Cards can carry coloured labels, which both visually group the board and let you filter with a single click.
+
+**Adding/removing a label**
+
+Open a card, and in the detail view's "Labels" section:
+
+- pick an existing label from the dropdown to attach it to the card,
+- or create a new label (name + a colour from the offered palette),
+- next to each attached label there's a button to remove it from the card.
+
+**What do the pills at the bottom of a card mean?**
+
+Each card shows up to 3 attached labels at the bottom as cool-toned "pills" (in `#label-name` form, in the label's own colour). If a card has more than 3 labels, the rest are shown as a "+N" badge. Clicking a pill immediately filters by it -- every other card carrying that same label also shows up in the filtered view.
+
+**Filtering with the header chip row**
+
+A chip appears in the toolbar above the board for every existing label, in its own colour, with a count (how many cards match the label given the other currently active filters). Clicking a chip activates it, narrowing the board to cards carrying that label. Multiple chips can be selected at once -- they combine with OR logic (a card matching any of the selected labels shows up). The × icon on an active chip removes that filter; the "Clear filters" button empties all active label filters at once.
+
+**How does it combine with other filters?**
+
+The label filter combines with the project and assignee filters using AND logic: a visible card must match the project filter, the assignee filter, AND at least one active label filter (if any are active). In swimlane view, lanes are built from the already-filtered card set, so the two features work together seamlessly.
+
+Your chosen label filters persist in the browser, so you don't have to re-select them every time you open the board.
+
 ### Quick filters and labels -- technical details
 
 **Data model:**

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -246,27 +246,27 @@ A tábla-listázó `GET /api/kanban` minden kártyához becsomagolja a `labels` 
 
 A kártya-részletező nézet "Címkék" szekciójában a hozzárendelt címkék eltávolítható pillékként jelennek meg, egy legördülő menü meglévő címkét ad hozzá, egy beágyazott form pedig új címkét hoz létre (név + paletta-színválasztó). A létrehozott címke azonnal hozzá is rendelődik a megnyitott kártyához.
 
-**Gyors-szűrő (prioritás) chip-sor:**
+**Gyors-szűrő (címke) chip-sor:**
 
-A tábla feletti vezérlősorban, a projekt-szűrő mellett jobbra igazítva 4 pill jelenik meg, egy a `low`/`normal`/`high`/`urgent` prioritás-értékek mindegyikéhez, a kártya-prioritás már meglévő szín-asszociációját felhasználva (sürgős=piros, magas=accent, normál=zöld, alacsony=szürke). Kattintásra a chip aktívvá válik (kitöltött szín + × ikon), és VAGY-kapcsolatban kombinálódik a többi aktív prioritás-chippel (több is kiválasztható egyszerre). Minden chip mellett egy darabszám látható: hány kártya felelne meg ennek a prioritásnak a JELENLEG aktív egyéb szűrők (projekt, felelős, címke) mellett -- ez a szám független attól, hogy a chip maga aktív-e, így mindig informatív marad.
+A tábla feletti vezérlősorban, a projekt-szűrő mellett jobbra igazítva egy pill jelenik meg minden definiált címkéhez (`/api/kanban/labels` listából), a címke saját színével. Kattintásra a chip aktívvá válik (kitöltött szín + × ikon), és VAGY-kapcsolatban kombinálódik a többi aktív címke-chippel (több is kiválasztható egyszerre) -- ugyanaz a `kanbanLabelFilter` halmaz, amit a kártyák footer-pilljei is vezérelnek, csak két belépési ponttal. Minden chip mellett egy darabszám látható: hány kártya felelne meg ennek a címkének a JELENLEG aktív projekt/felelős szűrők mellett -- ez a szám független attól, hogy a chip maga aktív-e, így mindig informatív marad.
 
 **Címke footer-pillek (kártyán):**
 
-Minden kártya lábsorában megjelenik legfeljebb 3 hozzárendelt címke hideg-tónusú pilleként (`#címke-név` formátumban, a címke saját színével), a maradékot egy "+N" jelvény jelzi (nem kattintható). Egy konkrét pillére kattintás hozzáadja/leveszi az adott címkét az aktív címke-szűrőhöz -- a kiválasztott címkék egymással VAGY-kapcsolatban vannak (a kártya megfelel, ha BÁRMELYIK aktív címkével rendelkezik).
+Minden kártya lábsorában megjelenik legfeljebb 3 hozzárendelt címke hideg-tónusú pilleként (`#címke-név` formátumban, a címke saját színével), a maradékot egy "+N" jelvény jelzi (nem kattintható). Egy konkrét pillére kattintás hozzáadja/leveszi az adott címkét az aktív címke-szűrőhöz -- ugyanazt a halmazt módosítva, amit a fejléc gyors-szűrő chip-sora is használ.
 
 **Szűrő-kombináció szemantikája:**
 
 Az összes szűrési dimenzió ÉS-kapcsolatban kombinálódik:
 
 ```
-látható = projekt-szűrő ÉS felelős-szűrő ÉS (prioritás1 VAGY prioritás2 VAGY ...) ÉS (címke1 VAGY címke2 VAGY ...)
+látható = projekt-szűrő ÉS felelős-szűrő ÉS (címke1 VAGY címke2 VAGY ...)
 ```
 
-Egy dimenzió üres halmaza (nincs aktív prioritás vagy címke) nem szűkít -- minden kártya megfelel arra a dimenzióra. A swimlane-csoportosítás a már megszűrt kártyahalmazból dolgozik, így a gyors-szűrők és a swimlane-nézet automatikusan együttműködnek, külön integrációs kód nélkül. A vezérlősorban megjelenő "Szűrők törlése" gomb (csak akkor látható, ha legalább egy prioritás- vagy címke-szűrő aktív) egyszerre üríti mindkét halmazt.
+Egy üres címke-szűrő (nincs aktív címke kiválasztva) nem szűkít -- minden kártya megfelel ennek a dimenziónak. A swimlane-csoportosítás a már megszűrt kártyahalmazból dolgozik, így a gyors-szűrő és a swimlane-nézet automatikusan együttműködnek, külön integrációs kód nélkül. A vezérlősorban megjelenő "Szűrők törlése" gomb (csak akkor látható, ha legalább egy címke-szűrő aktív) üríti a halmazt.
 
 **Perzisztencia:**
 
-A prioritás-szűrő és a címke-szűrő is `localStorage`-ban tárolódik (`marveen.kanbanPriorityFilter`, `marveen.kanbanLabelFilter` kulcsok, JSON-tömbként), ugyanazzal a mintával mint a swimlane-csoportosítás választása -- böngészőnkénti újratöltés után is megmaradnak.
+A címke-szűrő `localStorage`-ban tárolódik (`marveen.kanbanLabelFilter` kulcs, JSON-tömbként), ugyanazzal a mintával mint a swimlane-csoportosítás választása -- böngészőnkénti újratöltés után is megmarad.
 
 **Konfigurációs kulcsok (`.env`):**
 

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -219,3 +219,59 @@ KANBAN_SWIMLANE_SEPARATOR_COLOR=           # üres = CSS alapszín (var(--border
 ```
 
 Adatfolyam: `src/config.ts` → `/api/marveen` (`kanbanSwimlanes` kulcs) → `window._marveen.kanbanSwimlanes` (frontend). A frontend statikus, nincs build lépés -- szerver HUP elegendő a beállítások megváltoztatásához.
+
+### Gyors-szűrők és címkék -- technikai részletek
+
+**Adatmodell:**
+
+A címkék külön regiszterben élnek (`labels` tábla: `id`, `name`, `color`, `created_at`), és egy join táblán (`kanban_card_labels`: `card_id`, `label_id`, `created_at`) keresztül kapcsolódnak a kártyákhoz. Ez lehetővé teszi, hogy ugyanaz a címke több kártyán is szerepeljen, és egy helyen átszínezhető/átnevezhető legyen. Kártya vagy címke törlésekor a kapcsoló sorok tranzakcióban törlődnek, így nem marad árva join-bejegyzés.
+
+A címke színe nem szabad szöveg: a `KANBAN_LABEL_COLORS` konfigurációs paletta egyik eleme lehet csak (szerver-oldali validáció, érvénytelen vagy hiányzó érték esetén a paletta első színére esik vissza). Ez biztosítja, hogy a szín-hozzárendelés egyetlen konfigurálható forrásból ered, nem egy kódba ágyazott leképezésből.
+
+**API végpontok:**
+
+```
+GET    /api/kanban/labels              -- összes címke
+POST   /api/kanban/labels              -- új címke ({ name, color })
+PUT    /api/kanban/labels/:id          -- címke átnevezése/átszínezése
+DELETE /api/kanban/labels/:id          -- címke törlése (+ minden kártya-kapcsolat)
+GET    /api/kanban/:id/labels          -- egy kártya címkéi
+POST   /api/kanban/:id/labels          -- címke hozzáadása a kártyához ({ labelId })
+DELETE /api/kanban/:id/labels/:labelId -- címke levétele a kártyáról
+```
+
+A tábla-listázó `GET /api/kanban` minden kártyához becsomagolja a `labels` tömböt is, egyetlen bulk JOIN lekérdezéssel (nem N+1 kártyánkénti hívással), így a footer-pillek egyetlen körútból megkapják az adatot.
+
+**Kártya-szerkesztő (CRUD UI):**
+
+A kártya-részletező nézet "Címkék" szekciójában a hozzárendelt címkék eltávolítható pillékként jelennek meg, egy legördülő menü meglévő címkét ad hozzá, egy beágyazott form pedig új címkét hoz létre (név + paletta-színválasztó). A létrehozott címke azonnal hozzá is rendelődik a megnyitott kártyához.
+
+**Gyors-szűrő (prioritás) chip-sor:**
+
+A tábla feletti vezérlősorban, a projekt-szűrő mellett jobbra igazítva 4 pill jelenik meg, egy a `low`/`normal`/`high`/`urgent` prioritás-értékek mindegyikéhez, a kártya-prioritás már meglévő szín-asszociációját felhasználva (sürgős=piros, magas=accent, normál=zöld, alacsony=szürke). Kattintásra a chip aktívvá válik (kitöltött szín + × ikon), és VAGY-kapcsolatban kombinálódik a többi aktív prioritás-chippel (több is kiválasztható egyszerre). Minden chip mellett egy darabszám látható: hány kártya felelne meg ennek a prioritásnak a JELENLEG aktív egyéb szűrők (projekt, felelős, címke) mellett -- ez a szám független attól, hogy a chip maga aktív-e, így mindig informatív marad.
+
+**Címke footer-pillek (kártyán):**
+
+Minden kártya lábsorában megjelenik legfeljebb 3 hozzárendelt címke hideg-tónusú pilleként (`#címke-név` formátumban, a címke saját színével), a maradékot egy "+N" jelvény jelzi (nem kattintható). Egy konkrét pillére kattintás hozzáadja/leveszi az adott címkét az aktív címke-szűrőhöz -- a kiválasztott címkék egymással VAGY-kapcsolatban vannak (a kártya megfelel, ha BÁRMELYIK aktív címkével rendelkezik).
+
+**Szűrő-kombináció szemantikája:**
+
+Az összes szűrési dimenzió ÉS-kapcsolatban kombinálódik:
+
+```
+látható = projekt-szűrő ÉS felelős-szűrő ÉS (prioritás1 VAGY prioritás2 VAGY ...) ÉS (címke1 VAGY címke2 VAGY ...)
+```
+
+Egy dimenzió üres halmaza (nincs aktív prioritás vagy címke) nem szűkít -- minden kártya megfelel arra a dimenzióra. A swimlane-csoportosítás a már megszűrt kártyahalmazból dolgozik, így a gyors-szűrők és a swimlane-nézet automatikusan együttműködnek, külön integrációs kód nélkül. A vezérlősorban megjelenő "Szűrők törlése" gomb (csak akkor látható, ha legalább egy prioritás- vagy címke-szűrő aktív) egyszerre üríti mindkét halmazt.
+
+**Perzisztencia:**
+
+A prioritás-szűrő és a címke-szűrő is `localStorage`-ban tárolódik (`marveen.kanbanPriorityFilter`, `marveen.kanbanLabelFilter` kulcsok, JSON-tömbként), ugyanazzal a mintával mint a swimlane-csoportosítás választása -- böngészőnkénti újratöltés után is megmaradnak.
+
+**Konfigurációs kulcsok (`.env`):**
+
+```
+KANBAN_LABEL_COLORS=#3b82f6,#0ea5e9,#10b981,#14b8a6,#8b5cf6,#64748b  # választható paletta (hideg tónusok)
+```
+
+Adatfolyam: `src/config.ts` → `/api/marveen` (`kanbanLabels.colors` kulcs) → `window._marveen.kanbanLabels` (frontend).

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -220,6 +220,32 @@ KANBAN_SWIMLANE_SEPARATOR_COLOR=           # üres = CSS alapszín (var(--border
 
 Adatfolyam: `src/config.ts` → `/api/marveen` (`kanbanSwimlanes` kulcs) → `window._marveen.kanbanSwimlanes` (frontend). A frontend statikus, nincs build lépés -- szerver HUP elegendő a beállítások megváltoztatásához.
 
+### Gyors-szűrők és címkék
+
+A kártyák elláthatók színes címkékkel, amik egyrészt vizuálisan csoportosítják a táblát, másrészt egy kattintással szűrhetők.
+
+**Címke hozzáadása/levétele**
+
+Nyiss meg egy kártyát, és a részletező nézet "Címkék" szekciójában:
+
+- a legördülő menüből válassz egy meglévő címkét a kártyához rendeléshez,
+- vagy hozz létre új címkét (név + szín a felkínált palettából),
+- a hozzárendelt címkék mellett egy gombbal bármelyik levehető a kártyáról.
+
+**Mit jelentenek a kártyák alján a pillék?**
+
+Minden kártya alján legfeljebb 3 hozzárendelt címke jelenik meg hideg-tónusú "pilleként" (`#cimke-nev` formában, a címke saját színével). Ha egy kártyához 3-nál több címke van rendelve, a maradékot egy "+N" jelvény jelzi. Egy pillére kattintva azonnal rá is szűrhetsz -- a kártya összes többi, ugyanazzal a címkével ellátott kártyája is megjelenik a szűrt nézetben.
+
+**Szűrés a fejléc chip-sorával**
+
+A tábla feletti vezérlősorban minden létező címkéhez megjelenik egy chip, a saját színével és egy darabszámmal (hány kártyára illik a címke a jelenleg aktív többi szűrő mellett). Kattintásra a chip aktívvá válik, és csak az adott címkével ellátott kártyák látszanak. Több chip is kiválasztható egyszerre -- ezek "VAGY" kapcsolatban kombinálódnak (bármelyik kiválasztott címkével ellátott kártya megjelenik). Az × ikon egy aktív chipen levonja az adott szűrést, a "Szűrők törlése" gomb az összes aktív címke-szűrőt egyszerre üríti.
+
+**Hogyan kombinálódik a többi szűrővel?**
+
+A címke-szűrő a projekt- és felelős-szűrővel "ÉS" kapcsolatban van: a látható kártyáknak egyszerre meg kell felelniük a projekt-szűrőnek, a felelős-szűrőnek, ÉS legalább egy aktív címke-szűrőnek (ha van ilyen). Swimlane-nézetben a sávok már a megszűrt kártyahalmazból épülnek fel, így a két funkció zökkenőmentesen együttműködik.
+
+A választott címke-szűrők a böngésződben megmaradnak, nem kell minden megnyitásnál újra beállítani.
+
 ### Gyors-szűrők és címkék -- technikai részletek
 
 **Adatmodell:**

--- a/src/__tests__/kanban-labels.test.ts
+++ b/src/__tests__/kanban-labels.test.ts
@@ -1,0 +1,103 @@
+// Contract tests for the kanban label registry + card<->label join table.
+//
+// These call the real production entry points (db.js) against an in-memory
+// database seeded with the production schema, mirroring the pattern used by
+// kanban-delete-fk.test.ts for deleteKanbanCard.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  initDatabase, createKanbanCard, deleteKanbanCard,
+  listLabels, getLabel, createLabel, updateLabel, deleteLabel,
+  addLabelToCard, removeLabelFromCard, getLabelsForCard, getLabelsForAllCards,
+} from '../db.js'
+
+beforeEach(() => {
+  initDatabase(':memory:')
+})
+
+describe('label registry CRUD', () => {
+  it('creates and lists a label', () => {
+    createLabel({ id: 'lbl-a', name: 'bug', color: '#3b82f6' })
+    expect(listLabels()).toEqual([{ id: 'lbl-a', name: 'bug', color: '#3b82f6', created_at: expect.any(Number) }])
+  })
+
+  it('updates name and colour independently', () => {
+    createLabel({ id: 'lbl-a', name: 'bug', color: '#3b82f6' })
+    expect(updateLabel('lbl-a', { color: '#10b981' })).toBe(true)
+    expect(getLabel('lbl-a')).toMatchObject({ name: 'bug', color: '#10b981' })
+
+    expect(updateLabel('lbl-a', { name: 'defect' })).toBe(true)
+    expect(getLabel('lbl-a')).toMatchObject({ name: 'defect', color: '#10b981' })
+  })
+
+  it('returns false updating a non-existent label', () => {
+    expect(updateLabel('nope', { name: 'x' })).toBe(false)
+  })
+
+  it('deletes a label and its card associations (no dangling join rows)', () => {
+    createKanbanCard({ id: 'card-a', title: 'Card A' })
+    createLabel({ id: 'lbl-a', name: 'bug', color: '#3b82f6' })
+    addLabelToCard('card-a', 'lbl-a')
+    expect(getLabelsForCard('card-a')).toHaveLength(1)
+
+    expect(deleteLabel('lbl-a')).toBe(true)
+    expect(getLabel('lbl-a')).toBeUndefined()
+    expect(getLabelsForCard('card-a')).toHaveLength(0)
+  })
+
+  it('returns false deleting a non-existent label', () => {
+    expect(deleteLabel('nope')).toBe(false)
+  })
+})
+
+describe('card <-> label associations', () => {
+  beforeEach(() => {
+    createKanbanCard({ id: 'card-a', title: 'Card A' })
+    createKanbanCard({ id: 'card-b', title: 'Card B' })
+    createLabel({ id: 'lbl-bug', name: 'bug', color: '#3b82f6' })
+    createLabel({ id: 'lbl-q2', name: 'q2', color: '#10b981' })
+  })
+
+  it('attaches a label to a card and reads it back', () => {
+    addLabelToCard('card-a', 'lbl-bug')
+    expect(getLabelsForCard('card-a')).toEqual([
+      { id: 'lbl-bug', name: 'bug', color: '#3b82f6', created_at: expect.any(Number) },
+    ])
+    expect(getLabelsForCard('card-b')).toHaveLength(0)
+  })
+
+  it('is idempotent -- attaching the same label twice does not duplicate it', () => {
+    addLabelToCard('card-a', 'lbl-bug')
+    addLabelToCard('card-a', 'lbl-bug')
+    expect(getLabelsForCard('card-a')).toHaveLength(1)
+  })
+
+  it('removes a label from a card', () => {
+    addLabelToCard('card-a', 'lbl-bug')
+    expect(removeLabelFromCard('card-a', 'lbl-bug')).toBe(true)
+    expect(getLabelsForCard('card-a')).toHaveLength(0)
+  })
+
+  it('returns false removing an association that does not exist', () => {
+    expect(removeLabelFromCard('card-a', 'lbl-bug')).toBe(false)
+  })
+
+  it('bulk-loads labels for all cards in one map', () => {
+    addLabelToCard('card-a', 'lbl-bug')
+    addLabelToCard('card-a', 'lbl-q2')
+    addLabelToCard('card-b', 'lbl-q2')
+
+    const map = getLabelsForAllCards()
+    expect(map.get('card-a')).toHaveLength(2)
+    expect(map.get('card-b')).toHaveLength(1)
+    expect(map.has('card-c')).toBe(false)
+  })
+
+  it('drops a card label association when the card is deleted', () => {
+    addLabelToCard('card-a', 'lbl-bug')
+    expect(deleteKanbanCard('card-a')).toBe(true)
+    // The label itself must survive -- only the association is gone.
+    expect(getLabel('lbl-bug')).toBeDefined()
+    expect(getLabelsForAllCards().has('card-a')).toBe(false)
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,16 @@ export const KANBAN_SWIMLANE_DEFAULT_GROUP =
     : 'none'
 export const KANBAN_SWIMLANE_SEPARATOR_COLOR = env['KANBAN_SWIMLANE_SEPARATOR_COLOR'] ?? ''
 
+// Kanban label colour palette (cold tones by default). The label CRUD UI
+// offers these as swatches instead of a free-text colour input, so every
+// label's colour traces back to this single configurable list rather than
+// a hardcoded per-label mapping in the frontend.
+const rawKanbanLabelColors = (env['KANBAN_LABEL_COLORS'] ?? '#3b82f6,#0ea5e9,#10b981,#14b8a6,#8b5cf6,#64748b')
+  .split(',')
+  .map((c) => c.trim())
+  .filter(Boolean)
+export const KANBAN_LABEL_COLORS = rawKanbanLabelColors.length > 0 ? rawKanbanLabelColors : ['#64748b']
+
 export const CHANNEL_PROVIDER: ChannelProviderType = getProviderType(env['CHANNEL_PROVIDER'])
 export const CHANNEL_TOKEN = getChannelToken(CHANNEL_PROVIDER, env)
 export const CHANNEL_CHAT_ID = getChannelChatId(CHANNEL_PROVIDER, env)

--- a/src/db.ts
+++ b/src/db.ts
@@ -326,6 +326,29 @@ export function initDatabase(dbPathOverride?: string): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_kanban_comments_card ON kanban_comments(card_id)`)
 
+  // --- Kanban labels (tags) -----------------------------------------------
+  // Labels are a separate registry (not hardcoded per-card strings) so the
+  // same label can be reused across many cards and recolored in one place.
+  // The colour itself is validated against the configured palette
+  // (KANBAN_LABEL_COLORS) at the route layer, not hardcoded here.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS labels (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      color TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS kanban_card_labels (
+      card_id TEXT NOT NULL,
+      label_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (card_id, label_id)
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_card_labels_label ON kanban_card_labels(label_id)`)
+
   // --- Agent Messages ---
   db.exec(`
     CREATE TABLE IF NOT EXISTS agent_messages (
@@ -1075,19 +1098,22 @@ export function listKanbanProjects(): string[] {
 }
 
 export function deleteKanbanCard(id: string): boolean {
-  // Wrapped in a transaction to ensure atomicity: all three mutations
-  // succeed together or none of them do. Steps in FK-safe order:
+  // Wrapped in a transaction to ensure atomicity: all mutations succeed
+  // together or none of them do. Steps in FK-safe order:
   //   1. Delete comments that reference this card (FK: kanban_comments.card_id).
-  //   2. Null-out child cards that reference this card as their parent
+  //   2. Delete this card's label associations (FK: kanban_card_labels.card_id)
+  //      -- the labels themselves stay in the registry, only the link goes.
+  //   3. Null-out child cards that reference this card as their parent
   //      (FK: kanban_cards.parent_id). Setting parent_id = NULL keeps the
   //      children alive as root-level cards rather than leaving them with a
   //      dangling reference. FK enforcement is currently OFF by default
   //      (better-sqlite3 default), but the dangling parent_id is still a
   //      data bug -- orphaned children do not appear under any parent and
   //      are invisible in hierarchy views.
-  //   3. Delete the card itself.
+  //   4. Delete the card itself.
   return db.transaction((cardId: string) => {
     db.prepare('DELETE FROM kanban_comments WHERE card_id = ?').run(cardId)
+    db.prepare('DELETE FROM kanban_card_labels WHERE card_id = ?').run(cardId)
     db.prepare('UPDATE kanban_cards SET parent_id = NULL WHERE parent_id = ?').run(cardId)
     return db.prepare('DELETE FROM kanban_cards WHERE id = ?').run(cardId).changes > 0
   })(id) as boolean
@@ -1104,6 +1130,90 @@ export function addKanbanComment(cardId: string, author: string, content: string
   ).run(cardId, author, content, now)
   db.prepare('UPDATE kanban_cards SET updated_at = ? WHERE id = ?').run(now, cardId)
   return { id: Number(info.lastInsertRowid), card_id: cardId, author, content, created_at: now }
+}
+
+// --- Kanban labels (tags) ---
+
+export interface Label {
+  id: string
+  name: string
+  color: string
+  created_at: number
+}
+
+export function listLabels(): Label[] {
+  return db.prepare('SELECT * FROM labels ORDER BY name ASC').all() as Label[]
+}
+
+export function getLabel(id: string): Label | undefined {
+  return db.prepare('SELECT * FROM labels WHERE id = ?').get(id) as Label | undefined
+}
+
+export function createLabel(label: { id: string; name: string; color: string }): Label {
+  const now = Math.floor(Date.now() / 1000)
+  db.prepare(
+    'INSERT INTO labels (id, name, color, created_at) VALUES (?, ?, ?, ?)'
+  ).run(label.id, label.name, label.color, now)
+  return { ...label, created_at: now }
+}
+
+export function updateLabel(id: string, fields: Partial<Pick<Label, 'name' | 'color'>>): boolean {
+  const label = getLabel(id)
+  if (!label) return false
+  const f = { ...label, ...fields }
+  return db.prepare('UPDATE labels SET name=?, color=? WHERE id=?').run(f.name, f.color, id).changes > 0
+}
+
+export function deleteLabel(id: string): boolean {
+  // Transaction: drop every card<->label link before the label row itself,
+  // otherwise the join table keeps dangling references to a label that no
+  // longer exists (FK enforcement is off by default, but the orphan rows
+  // would still silently resurrect a "deleted" label in card detail views).
+  return db.transaction((labelId: string) => {
+    db.prepare('DELETE FROM kanban_card_labels WHERE label_id = ?').run(labelId)
+    return db.prepare('DELETE FROM labels WHERE id = ?').run(labelId).changes > 0
+  })(id) as boolean
+}
+
+export function addLabelToCard(cardId: string, labelId: string): void {
+  const now = Math.floor(Date.now() / 1000)
+  db.prepare(
+    'INSERT OR IGNORE INTO kanban_card_labels (card_id, label_id, created_at) VALUES (?, ?, ?)'
+  ).run(cardId, labelId, now)
+}
+
+export function removeLabelFromCard(cardId: string, labelId: string): boolean {
+  return db.prepare(
+    'DELETE FROM kanban_card_labels WHERE card_id = ? AND label_id = ?'
+  ).run(cardId, labelId).changes > 0
+}
+
+export function getLabelsForCard(cardId: string): Label[] {
+  return db.prepare(`
+    SELECT l.* FROM labels l
+    JOIN kanban_card_labels cl ON cl.label_id = l.id
+    WHERE cl.card_id = ?
+    ORDER BY l.name ASC
+  `).all(cardId) as Label[]
+}
+
+// Bulk variant for the board list view -- one JOIN query instead of an N+1
+// per-card lookup when rendering footer pills for every card at once.
+export function getLabelsForAllCards(): Map<string, Label[]> {
+  const rows = db.prepare(`
+    SELECT cl.card_id AS card_id, l.id AS id, l.name AS name, l.color AS color, l.created_at AS created_at
+    FROM kanban_card_labels cl
+    JOIN labels l ON l.id = cl.label_id
+    ORDER BY l.name ASC
+  `).all() as Array<Label & { card_id: string }>
+  const map = new Map<string, Label[]>()
+  for (const row of rows) {
+    const { card_id, ...label } = row
+    const list = map.get(card_id)
+    if (list) list.push(label)
+    else map.set(card_id, [label])
+  }
+  return map
 }
 
 // --- Heartbeat helpers ---

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -6,8 +6,10 @@ import {
   getKanbanComments, addKanbanComment, listKanbanProjects,
   getKanbanCard, getChildCards, getDb,
   createAgentMessage, markKanbanCardDispatched,
+  listLabels, getLabel, createLabel, updateLabel, deleteLabel,
+  addLabelToCard, removeLabelFromCard, getLabelsForAllCards, getLabelsForCard,
 } from '../../db.js'
-import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, STORE_DIR, WEB_HOST, WEB_PORT } from '../../config.js'
+import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, STORE_DIR, WEB_HOST, WEB_PORT, KANBAN_LABEL_COLORS } from '../../config.js'
 import { listAgentNames, readAgentDisplayName } from '../agent-config.js'
 import { isAgentRunning } from '../agent-process.js'
 import { resolveKanbanDispatchTarget } from '../../kanban-dispatch.js'
@@ -79,7 +81,81 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
 
   if (path === '/api/kanban' && method === 'GET') {
-    json(res, listKanbanCards())
+    // Embed each card's labels in one extra JOIN query (getLabelsForAllCards)
+    // instead of an N+1 per-card lookup, so the footer-pill UI gets
+    // everything it needs in a single round trip.
+    const labelsByCard = getLabelsForAllCards()
+    const cards = listKanbanCards().map((card) => ({ ...card, labels: labelsByCard.get(card.id) ?? [] }))
+    json(res, cards)
+    return true
+  }
+
+  if (path === '/api/kanban/labels' && method === 'GET') {
+    json(res, listLabels())
+    return true
+  }
+
+  if (path === '/api/kanban/labels' && method === 'POST') {
+    const body = await readBody(req)
+    const { name, color } = JSON.parse(body.toString()) as { name?: string; color?: string }
+    if (!name || !name.trim()) { json(res, { error: 'Címke neve kötelező' }, 400); return true }
+    // Colour is validated against the configured palette (KANBAN_LABEL_COLORS)
+    // rather than accepted as free-text, so every label's colour traces back
+    // to the single configurable source instead of an arbitrary per-request value.
+    const resolvedColor = color && KANBAN_LABEL_COLORS.includes(color) ? color : KANBAN_LABEL_COLORS[0]
+    const id = randomUUID().slice(0, 8)
+    const label = createLabel({ id, name: name.trim(), color: resolvedColor })
+    json(res, label)
+    return true
+  }
+
+  const labelMatch = path.match(/^\/api\/kanban\/labels\/([^/]+)$/)
+  if (labelMatch && method === 'PUT') {
+    const id = decodeURIComponent(labelMatch[1])
+    const body = await readBody(req)
+    const { name, color } = JSON.parse(body.toString()) as { name?: string; color?: string }
+    const fields: { name?: string; color?: string } = {}
+    if (name !== undefined) {
+      if (!name.trim()) { json(res, { error: 'Címke neve kötelező' }, 400); return true }
+      fields.name = name.trim()
+    }
+    if (color !== undefined) {
+      fields.color = KANBAN_LABEL_COLORS.includes(color) ? color : KANBAN_LABEL_COLORS[0]
+    }
+    if (updateLabel(id, fields)) { json(res, { ok: true }); return true }
+    json(res, { error: 'Címke nem található' }, 404)
+    return true
+  }
+  if (labelMatch && method === 'DELETE') {
+    const id = decodeURIComponent(labelMatch[1])
+    if (deleteLabel(id)) { json(res, { ok: true }); return true }
+    json(res, { error: 'Címke nem található' }, 404)
+    return true
+  }
+
+  const cardLabelsMatch = path.match(/^\/api\/kanban\/([^/]+)\/labels$/)
+  if (cardLabelsMatch && method === 'GET') {
+    const cardId = decodeURIComponent(cardLabelsMatch[1])
+    json(res, getLabelsForCard(cardId))
+    return true
+  }
+  if (cardLabelsMatch && method === 'POST') {
+    const cardId = decodeURIComponent(cardLabelsMatch[1])
+    if (!getKanbanCard(cardId)) { json(res, { error: 'Kártya nem található' }, 404); return true }
+    const body = await readBody(req)
+    const { labelId } = JSON.parse(body.toString()) as { labelId?: string }
+    if (!labelId || !getLabel(labelId)) { json(res, { error: 'Címke nem található' }, 404); return true }
+    addLabelToCard(cardId, labelId)
+    json(res, { ok: true })
+    return true
+  }
+
+  const cardLabelDeleteMatch = path.match(/^\/api\/kanban\/([^/]+)\/labels\/([^/]+)$/)
+  if (cardLabelDeleteMatch && method === 'DELETE') {
+    const cardId = decodeURIComponent(cardLabelDeleteMatch[1])
+    const labelId = decodeURIComponent(cardLabelDeleteMatch[2])
+    if (removeLabelFromCard(cardId, labelId)) { json(res, { ok: true }); return true }
+    json(res, { error: 'A kártyán nincs ilyen címke' }, 404)
     return true
   }
 

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -7,6 +7,7 @@ import {
   KANBAN_WIP_PLANNED, KANBAN_WIP_IN_PROGRESS, KANBAN_WIP_WAITING, KANBAN_WIP_DONE,
   KANBAN_WIP_WARN_PCT, KANBAN_WIP_OK_COLOR, KANBAN_WIP_WARN_COLOR, KANBAN_WIP_FULL_COLOR, KANBAN_WIP_OVER_COLOR,
   KANBAN_SWIMLANE_DEFAULT_GROUP, KANBAN_SWIMLANE_SEPARATOR_COLOR,
+  KANBAN_LABEL_COLORS,
 } from '../../config.js'
 import { readMarveenTelegramConfig, readMarveenDiscordConfig, readMarveenSlackConfig, sendMarveenAvatarChange } from '../telegram.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
@@ -117,6 +118,9 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
       kanbanSwimlanes: {
         defaultGroup: KANBAN_SWIMLANE_DEFAULT_GROUP,
         separatorColor: KANBAN_SWIMLANE_SEPARATOR_COLOR || null,
+      },
+      kanbanLabels: {
+        colors: KANBAN_LABEL_COLORS,
       },
     })
     return true

--- a/web/app.js
+++ b/web/app.js
@@ -476,15 +476,81 @@ function setupAssigneeFilter() {
   syncOwnerFilterBtn()
 }
 
+// Project + assignee + label filters, independent of the priority quick-filter
+// dimension -- shared by the board visibility pass and by the quick-filter
+// chip counts (each chip shows how many cards match under every OTHER active
+// filter, so the count stays meaningful whether the chip itself is on or off).
+function kanbanCardMatchesNonPriorityFilters(card) {
+  if (kanbanProjectFilter && (card.project || '') !== kanbanProjectFilter) return false
+  const assigneeFilter = kanbanAssigneeFilter.toLowerCase()
+  if (assigneeFilter && String(card.assignee || '').trim().toLowerCase() !== assigneeFilter) return false
+  if (kanbanLabelFilter.size > 0) {
+    const cardLabelIds = (card.labels || []).map((l) => l.id)
+    if (!cardLabelIds.some((id) => kanbanLabelFilter.has(id))) return false
+  }
+  return true
+}
+
+function toggleKanbanPriorityFilter(priority) {
+  if (kanbanPriorityFilter.has(priority)) kanbanPriorityFilter.delete(priority)
+  else kanbanPriorityFilter.add(priority)
+  persistKanbanFilters()
+  renderKanban()
+}
+
+function toggleKanbanLabelFilter(labelId) {
+  if (kanbanLabelFilter.has(labelId)) kanbanLabelFilter.delete(labelId)
+  else kanbanLabelFilter.add(labelId)
+  persistKanbanFilters()
+  renderKanban()
+}
+
+function clearKanbanQuickFilters() {
+  kanbanPriorityFilter.clear()
+  kanbanLabelFilter.clear()
+  persistKanbanFilters()
+  renderKanban()
+}
+
+function persistKanbanFilters() {
+  localStorage.setItem('marveen.kanbanPriorityFilter', JSON.stringify([...kanbanPriorityFilter]))
+  localStorage.setItem('marveen.kanbanLabelFilter', JSON.stringify([...kanbanLabelFilter]))
+}
+
+function renderKanbanQuickFilters() {
+  const row = document.getElementById('kanbanQuickFilters')
+  if (!row) return
+  row.innerHTML = ''
+  for (const priority of KANBAN_PRIORITY_ORDER) {
+    const count = kanbanCards.filter((c) => c.priority === priority && kanbanCardMatchesNonPriorityFilters(c)).length
+    const active = kanbanPriorityFilter.has(priority)
+    const chip = document.createElement('span')
+    chip.className = 'kanban-quick-filter-chip' + (active ? ' active' : '')
+    chip.dataset.priority = priority
+    chip.style.setProperty('--chip-color', `var(${KANBAN_PRIORITY_CHIP_VAR[priority]})`)
+    chip.innerHTML = `${escapeHtml(KANBAN_PRIORITY_LABELS[priority])} <span class="kanban-quick-filter-count">${count}</span>${active ? '<span class="kanban-quick-filter-clear">&times;</span>' : ''}`
+    chip.addEventListener('click', () => toggleKanbanPriorityFilter(priority))
+    row.appendChild(chip)
+  }
+  if (kanbanPriorityFilter.size > 0 || kanbanLabelFilter.size > 0) {
+    const clearAll = document.createElement('button')
+    clearAll.className = 'kanban-quick-filter-clear-all'
+    clearAll.textContent = 'Szűrők törlése'
+    clearAll.addEventListener('click', clearKanbanQuickFilters)
+    row.appendChild(clearAll)
+  }
+}
+
 function renderKanban() {
   const cardById = new Map(kanbanCards.map(c => [c.id, c]))
-  const assigneeFilter = kanbanAssigneeFilter.toLowerCase()
+
+  renderKanbanQuickFilters()
 
   // Determine which top-level cards are visible under current filters.
   const visibleCardIds = new Set()
   for (const card of kanbanCards) {
-    if (kanbanProjectFilter && (card.project || '') !== kanbanProjectFilter) continue
-    if (assigneeFilter && String(card.assignee || '').trim().toLowerCase() !== assigneeFilter) continue
+    if (!kanbanCardMatchesNonPriorityFilters(card)) continue
+    if (kanbanPriorityFilter.size > 0 && !kanbanPriorityFilter.has(card.priority)) continue
     visibleCardIds.add(card.id)
   }
 
@@ -548,6 +614,10 @@ const KANBAN_STATUS_DEFS = [
 ]
 const KANBAN_PRIORITY_LABELS = { urgent: 'Sürgős', high: 'Magas', normal: 'Normál', low: 'Alacsony' }
 const KANBAN_PRIORITY_ORDER = ['urgent', 'high', 'normal', 'low']
+// Quick-filter chip tone per priority, reusing the existing theme palette
+// (no new colour constants) -- same association a reader already knows from
+// the card priority border.
+const KANBAN_PRIORITY_CHIP_VAR = { urgent: '--danger', high: '--accent', normal: '--success', low: '--text-muted' }
 
 // Which swimlane a card belongs to under the current grouping. Returns a
 // stable string key: the matched assignee's canonical name, '__unassigned__'
@@ -758,6 +828,22 @@ function createCardEl(card, embeddedChildren = []) {
     ? `<span class="kanban-card-project">${escapeHtml(card.project)}</span>`
     : ''
 
+  // Label footer pills: at most 3 shown + a "+N" overflow indicator. Each pill
+  // (except the overflow one) toggles that label into the active label-filter
+  // when clicked, mirroring the priority quick-filter chips above the board.
+  let labelsHtml = ''
+  if (Array.isArray(card.labels) && card.labels.length > 0) {
+    const shown = card.labels.slice(0, 3)
+    const overflow = card.labels.length - shown.length
+    const pills = shown.map((l) =>
+      `<span class="kanban-card-label-pill" data-label-id="${escapeHtml(l.id)}" style="--label-color:${escapeHtml(l.color)}" title="Szűrés: #${escapeHtml(l.name)}">#${escapeHtml(l.name)}</span>`
+    ).join('')
+    const overflowHtml = overflow > 0
+      ? `<span class="kanban-card-label-pill kanban-card-label-overflow" title="${overflow} további címke">+${overflow}</span>`
+      : ''
+    labelsHtml = `<div class="kanban-card-labels">${pills}${overflowHtml}</div>`
+  }
+
   const seqHtml = card.seq != null
     ? `<span class="kanban-card-seq" style="font-family:monospace;font-size:11px;color:var(--muted);margin-right:5px">#${card.seq}</span>`
     : ''
@@ -806,6 +892,7 @@ function createCardEl(card, embeddedChildren = []) {
     ${projectHtml}
     <div class="kanban-card-title">${seqHtml}${escapeHtml(card.title)}</div>
     <div class="kanban-card-footer">${assigneeHtml}${dueHtml}</div>
+    ${labelsHtml}
     <div class="kanban-card-actions">
       <button class="card-breakdown-btn" title="AI szétbont" aria-label="AI szétbont">⚡</button>
     </div>
@@ -818,6 +905,14 @@ function createCardEl(card, embeddedChildren = []) {
   el.querySelector('.card-breakdown-btn').addEventListener('click', (e) => {
     e.stopPropagation()
     triggerBreakdown(card)
+  })
+
+  // Label pills -> toggle that label into the active filter (don't open detail)
+  el.querySelectorAll('.kanban-card-label-pill[data-label-id]').forEach((pillEl) => {
+    pillEl.addEventListener('click', (e) => {
+      e.stopPropagation()
+      toggleKanbanLabelFilter(pillEl.dataset.labelId)
+    })
   })
 
   // Click on embedded subtask -> open that subtask's detail (don't bubble to parent)

--- a/web/app.js
+++ b/web/app.js
@@ -253,11 +253,11 @@ let kanbanProjects = []
 // Label registry (id/name/color), independent of which cards currently carry
 // which labels -- card.labels (embedded by GET /api/kanban) holds that link.
 let kanbanAllLabels = []
-// Active quick-filter (priority) values and active label-filter ids. Both
-// OR-combined within their own dimension, AND-combined across dimensions
-// together with the existing project/assignee filters. Persisted in
+// Active label-filter ids -- the quick-filter chip row AND the per-card
+// footer label pills both toggle this same set (two entry points, one
+// filter dimension). OR-combined within itself (any active label matches),
+// AND-combined with the existing project/assignee filters. Persisted in
 // localStorage alongside the swimlane groupBy choice.
-let kanbanPriorityFilter = new Set()
 let kanbanLabelFilter = new Set()
 let kanbanProjectFilter = ''
 // Assignee filter for the kanban board. '' = show all. Set via the
@@ -322,13 +322,8 @@ async function loadKanban() {
         const sel = document.getElementById('kanbanGroupBy')
         if (sel) sel.value = initialGroup
       }
-      // Active quick-filter (priority) + label-filter selections, restored the
-      // same way as the groupBy choice -- a fresh page load should not lose
-      // the filters the user had set up.
-      try {
-        const storedPriority = JSON.parse(localStorage.getItem('marveen.kanbanPriorityFilter') || '[]')
-        if (Array.isArray(storedPriority)) kanbanPriorityFilter = new Set(storedPriority)
-      } catch { /* ignore malformed storage */ }
+      // Active label-filter selection, restored the same way as the groupBy
+      // choice -- a fresh page load should not lose the filters set up.
       try {
         const storedLabels = JSON.parse(localStorage.getItem('marveen.kanbanLabelFilter') || '[]')
         if (Array.isArray(storedLabels)) kanbanLabelFilter = new Set(storedLabels)
@@ -477,27 +472,28 @@ function setupAssigneeFilter() {
 }
 
 // Project + assignee + label filters, independent of the priority quick-filter
-// dimension -- shared by the board visibility pass and by the quick-filter
-// chip counts (each chip shows how many cards match under every OTHER active
-// filter, so the count stays meaningful whether the chip itself is on or off).
-function kanbanCardMatchesNonPriorityFilters(card) {
+// Project + assignee filters only -- the baseline the label quick-filter
+// chip counts are computed against, independent of which labels are
+// currently active, so a chip's count stays meaningful whether it's the one
+// being toggled or not.
+function kanbanCardMatchesBaseFilters(card) {
   if (kanbanProjectFilter && (card.project || '') !== kanbanProjectFilter) return false
   const assigneeFilter = kanbanAssigneeFilter.toLowerCase()
   if (assigneeFilter && String(card.assignee || '').trim().toLowerCase() !== assigneeFilter) return false
-  if (kanbanLabelFilter.size > 0) {
-    const cardLabelIds = (card.labels || []).map((l) => l.id)
-    if (!cardLabelIds.some((id) => kanbanLabelFilter.has(id))) return false
-  }
   return true
 }
 
-function toggleKanbanPriorityFilter(priority) {
-  if (kanbanPriorityFilter.has(priority)) kanbanPriorityFilter.delete(priority)
-  else kanbanPriorityFilter.add(priority)
-  persistKanbanFilters()
-  renderKanban()
+// The label-filter dimension itself: a card matches when no label filter is
+// active, or when it carries at least one of the active labels (OR within
+// the dimension).
+function kanbanCardMatchesLabelFilter(card) {
+  if (kanbanLabelFilter.size === 0) return true
+  const cardLabelIds = (card.labels || []).map((l) => l.id)
+  return cardLabelIds.some((id) => kanbanLabelFilter.has(id))
 }
 
+// Shared by both the header quick-filter chips and the per-card footer label
+// pills -- one filter dimension, two entry points into the same toggle.
 function toggleKanbanLabelFilter(labelId) {
   if (kanbanLabelFilter.has(labelId)) kanbanLabelFilter.delete(labelId)
   else kanbanLabelFilter.add(labelId)
@@ -506,33 +502,36 @@ function toggleKanbanLabelFilter(labelId) {
 }
 
 function clearKanbanQuickFilters() {
-  kanbanPriorityFilter.clear()
   kanbanLabelFilter.clear()
   persistKanbanFilters()
   renderKanban()
 }
 
 function persistKanbanFilters() {
-  localStorage.setItem('marveen.kanbanPriorityFilter', JSON.stringify([...kanbanPriorityFilter]))
   localStorage.setItem('marveen.kanbanLabelFilter', JSON.stringify([...kanbanLabelFilter]))
 }
 
+// Quick-filter chip row: one chip per defined label (not per priority), tinted
+// with that label's own colour. Clicking toggles the same kanbanLabelFilter
+// set the footer pills use.
 function renderKanbanQuickFilters() {
   const row = document.getElementById('kanbanQuickFilters')
   if (!row) return
   row.innerHTML = ''
-  for (const priority of KANBAN_PRIORITY_ORDER) {
-    const count = kanbanCards.filter((c) => c.priority === priority && kanbanCardMatchesNonPriorityFilters(c)).length
-    const active = kanbanPriorityFilter.has(priority)
+  for (const label of kanbanAllLabels) {
+    const count = kanbanCards.filter((c) =>
+      kanbanCardMatchesBaseFilters(c) && (c.labels || []).some((l) => l.id === label.id)
+    ).length
+    const active = kanbanLabelFilter.has(label.id)
     const chip = document.createElement('span')
     chip.className = 'kanban-quick-filter-chip' + (active ? ' active' : '')
-    chip.dataset.priority = priority
-    chip.style.setProperty('--chip-color', `var(${KANBAN_PRIORITY_CHIP_VAR[priority]})`)
-    chip.innerHTML = `${escapeHtml(KANBAN_PRIORITY_LABELS[priority])} <span class="kanban-quick-filter-count">${count}</span>${active ? '<span class="kanban-quick-filter-clear">&times;</span>' : ''}`
-    chip.addEventListener('click', () => toggleKanbanPriorityFilter(priority))
+    chip.dataset.labelId = label.id
+    chip.style.setProperty('--chip-color', label.color)
+    chip.innerHTML = `#${escapeHtml(label.name)} <span class="kanban-quick-filter-count">${count}</span>${active ? '<span class="kanban-quick-filter-clear">&times;</span>' : ''}`
+    chip.addEventListener('click', () => toggleKanbanLabelFilter(label.id))
     row.appendChild(chip)
   }
-  if (kanbanPriorityFilter.size > 0 || kanbanLabelFilter.size > 0) {
+  if (kanbanLabelFilter.size > 0) {
     const clearAll = document.createElement('button')
     clearAll.className = 'kanban-quick-filter-clear-all'
     clearAll.textContent = 'Szűrők törlése'
@@ -549,8 +548,8 @@ function renderKanban() {
   // Determine which top-level cards are visible under current filters.
   const visibleCardIds = new Set()
   for (const card of kanbanCards) {
-    if (!kanbanCardMatchesNonPriorityFilters(card)) continue
-    if (kanbanPriorityFilter.size > 0 && !kanbanPriorityFilter.has(card.priority)) continue
+    if (!kanbanCardMatchesBaseFilters(card)) continue
+    if (!kanbanCardMatchesLabelFilter(card)) continue
     visibleCardIds.add(card.id)
   }
 
@@ -614,10 +613,6 @@ const KANBAN_STATUS_DEFS = [
 ]
 const KANBAN_PRIORITY_LABELS = { urgent: 'Sürgős', high: 'Magas', normal: 'Normál', low: 'Alacsony' }
 const KANBAN_PRIORITY_ORDER = ['urgent', 'high', 'normal', 'low']
-// Quick-filter chip tone per priority, reusing the existing theme palette
-// (no new colour constants) -- same association a reader already knows from
-// the card priority border.
-const KANBAN_PRIORITY_CHIP_VAR = { urgent: '--danger', high: '--accent', normal: '--success', low: '--text-muted' }
 
 // Which swimlane a card belongs to under the current grouping. Returns a
 // stable string key: the matched assignee's canonical name, '__unassigned__'

--- a/web/app.js
+++ b/web/app.js
@@ -250,6 +250,15 @@ function renderActivity(entries) {
 let kanbanCards = []
 let kanbanAssignees = []
 let kanbanProjects = []
+// Label registry (id/name/color), independent of which cards currently carry
+// which labels -- card.labels (embedded by GET /api/kanban) holds that link.
+let kanbanAllLabels = []
+// Active quick-filter (priority) values and active label-filter ids. Both
+// OR-combined within their own dimension, AND-combined across dimensions
+// together with the existing project/assignee filters. Persisted in
+// localStorage alongside the swimlane groupBy choice.
+let kanbanPriorityFilter = new Set()
+let kanbanLabelFilter = new Set()
 let kanbanProjectFilter = ''
 // Assignee filter for the kanban board. '' = show all. Set via the
 // assignee dropdown / "Csak Gábor" toggle injected by setupAssigneeFilter().
@@ -292,7 +301,7 @@ async function loadKanban() {
     // Ensure the marveen config (kanbanAging + kanbanWip + kanbanSwimlanes) is
     // loaded even if the user opens the Kanban page first, before the Agents
     // page populated it.
-    if (!window._marveen?.kanbanAging || !window._marveen?.kanbanWip || !window._marveen?.kanbanSwimlanes) {
+    if (!window._marveen?.kanbanAging || !window._marveen?.kanbanWip || !window._marveen?.kanbanSwimlanes || !window._marveen?.kanbanLabels) {
       try {
         const mr = await fetch('/api/marveen')
         if (mr.ok) window._marveen = { ...(window._marveen || {}), ...(await mr.json()) }
@@ -313,15 +322,28 @@ async function loadKanban() {
         const sel = document.getElementById('kanbanGroupBy')
         if (sel) sel.value = initialGroup
       }
+      // Active quick-filter (priority) + label-filter selections, restored the
+      // same way as the groupBy choice -- a fresh page load should not lose
+      // the filters the user had set up.
+      try {
+        const storedPriority = JSON.parse(localStorage.getItem('marveen.kanbanPriorityFilter') || '[]')
+        if (Array.isArray(storedPriority)) kanbanPriorityFilter = new Set(storedPriority)
+      } catch { /* ignore malformed storage */ }
+      try {
+        const storedLabels = JSON.parse(localStorage.getItem('marveen.kanbanLabelFilter') || '[]')
+        if (Array.isArray(storedLabels)) kanbanLabelFilter = new Set(storedLabels)
+      } catch { /* ignore malformed storage */ }
     }
-    const [cardsRes, assigneesRes, projectsRes] = await Promise.all([
+    const [cardsRes, assigneesRes, projectsRes, labelsRes] = await Promise.all([
       fetch('/api/kanban'),
       fetch('/api/kanban/assignees'),
       fetch('/api/kanban-projects'),
+      fetch('/api/kanban/labels'),
     ])
     kanbanCards = await cardsRes.json()
     kanbanAssignees = await assigneesRes.json()
     kanbanProjects = await projectsRes.json()
+    kanbanAllLabels = await labelsRes.json()
     populateProjectFilter()
     populateProjectSuggestions()
     setupAssigneeFilter()
@@ -960,6 +982,106 @@ document.getElementById('saveCardBtn').addEventListener('click', async () => {
   }
 })
 
+// === Card labels (in the detail modal) ===
+// Always re-fetches the card's own labels via the dedicated endpoint instead
+// of trusting card.labels -- callers that pass a card object sourced from
+// /api/kanban/:id/children (subtask list) don't have labels embedded, only
+// the bulk board listing (/api/kanban) does.
+async function renderCardLabelsSection(card) {
+  const listEl = document.getElementById('cardLabelList')
+  const addSelect = document.getElementById('cardLabelAdd')
+  const newBtn = document.getElementById('cardLabelNewBtn')
+  const newForm = document.getElementById('cardLabelNewForm')
+  const newNameInput = document.getElementById('cardLabelNewName')
+  const newColorsEl = document.getElementById('cardLabelNewColors')
+  const newSaveBtn = document.getElementById('cardLabelNewSaveBtn')
+
+  let attached = []
+  try {
+    attached = await (await fetch(`/api/kanban/${encodeURIComponent(card.id)}/labels`)).json()
+  } catch { /* leave empty -- pill list just stays blank */ }
+
+  listEl.innerHTML = ''
+  for (const label of attached) {
+    const pill = document.createElement('span')
+    pill.className = 'label-pill'
+    pill.style.setProperty('--label-color', label.color)
+    pill.innerHTML = `#${escapeHtml(label.name)} <button class="label-pill-remove" title="Címke eltávolítása" aria-label="Címke eltávolítása">&times;</button>`
+    pill.querySelector('.label-pill-remove').addEventListener('click', async () => {
+      try {
+        await fetch(`/api/kanban/${encodeURIComponent(card.id)}/labels/${encodeURIComponent(label.id)}`, { method: 'DELETE' })
+        renderCardLabelsSection(card)
+        loadKanban()
+      } catch { showToast('Hiba a címke eltávolításakor') }
+    })
+    listEl.appendChild(pill)
+  }
+
+  const attachedIds = new Set(attached.map((l) => l.id))
+  addSelect.innerHTML = '<option value="">-- Meglévő címke hozzáadása --</option>'
+  for (const label of kanbanAllLabels) {
+    if (attachedIds.has(label.id)) continue
+    const opt = document.createElement('option')
+    opt.value = label.id
+    opt.textContent = label.name
+    addSelect.appendChild(opt)
+  }
+  addSelect.onchange = async () => {
+    const labelId = addSelect.value
+    if (!labelId) return
+    try {
+      await fetch(`/api/kanban/${encodeURIComponent(card.id)}/labels`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ labelId }),
+      })
+      renderCardLabelsSection(card)
+      loadKanban()
+    } catch { showToast('Hiba a címke hozzáadásakor') }
+  }
+
+  newForm.style.display = 'none'
+  newBtn.onclick = () => {
+    newForm.style.display = newForm.style.display === 'none' ? '' : 'none'
+    newNameInput.value = ''
+  }
+
+  const palette = window._marveen?.kanbanLabels?.colors || ['#64748b']
+  newColorsEl.innerHTML = ''
+  let selectedColor = palette[0]
+  palette.forEach((color, i) => {
+    const sw = document.createElement('span')
+    sw.className = 'label-color-swatch' + (i === 0 ? ' selected' : '')
+    sw.style.background = color
+    sw.addEventListener('click', () => {
+      selectedColor = color
+      newColorsEl.querySelectorAll('.label-color-swatch').forEach((s) => s.classList.remove('selected'))
+      sw.classList.add('selected')
+    })
+    newColorsEl.appendChild(sw)
+  })
+
+  newSaveBtn.onclick = async () => {
+    const name = newNameInput.value.trim()
+    if (!name) { newNameInput.focus(); return }
+    try {
+      const r = await fetch('/api/kanban/labels', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, color: selectedColor }),
+      })
+      if (!r.ok) { showToast('Hiba a címke létrehozásakor'); return }
+      const newLabel = await r.json()
+      kanbanAllLabels.push(newLabel)
+      await fetch(`/api/kanban/${encodeURIComponent(card.id)}/labels`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ labelId: newLabel.id }),
+      })
+      newForm.style.display = 'none'
+      renderCardLabelsSection(card)
+      loadKanban()
+    } catch { showToast('Hiba a címke létrehozásakor') }
+  }
+}
+
 // === Card detail ===
 async function showCardDetail(card) {
   // Running number (#N) in the title bar, plus the stable hex id in the meta.
@@ -1054,6 +1176,8 @@ async function showCardDetail(card) {
   })
 
   document.getElementById('cardDetailDesc').textContent = card.description || ''
+
+  renderCardLabelsSection(card)
 
   // #115: Parent meta row — dropdown replaces the old read-only display; shown only when editable
   const parentMetaItem = document.getElementById('parentMetaItem')

--- a/web/index.html
+++ b/web/index.html
@@ -191,6 +191,7 @@
           <option value="assignee">Felelős szerint</option>
           <option value="priority">Prioritás szerint</option>
         </select>
+        <div class="kanban-quick-filters" id="kanbanQuickFilters" style="margin-left:auto; display:flex; gap:6px; flex-wrap:wrap; align-items:center;"></div>
       </div>
       <div class="kanban-board" id="kanbanBoard">
         <div class="kanban-col" data-status="planned">

--- a/web/index.html
+++ b/web/index.html
@@ -1238,6 +1238,21 @@
           <select id="parentSelect" style="flex:1; width:100%; padding:5px 8px; border-radius:6px; border:1px solid var(--border); background:var(--bg); color:var(--text); font-size:13px" title="Szülő feladat módosítása"></select>
         </div>
         <div class="card-detail-desc" id="cardDetailDesc"></div>
+        <div class="card-detail-labels">
+          <h4>Címkék</h4>
+          <div class="label-pill-list" id="cardLabelList"></div>
+          <div class="form-row" style="gap:8px; align-items:center; margin-top:6px">
+            <select id="cardLabelAdd" style="flex:1; padding:5px 8px; border-radius:6px; border:1px solid var(--border); background:var(--bg); color:var(--text); font-size:13px">
+              <option value="">-- Meglévő címke hozzáadása --</option>
+            </select>
+            <button class="btn-secondary btn-compact" id="cardLabelNewBtn">+ Új címke</button>
+          </div>
+          <div class="form-row" id="cardLabelNewForm" style="display:none; gap:8px; align-items:center; margin-top:6px">
+            <input type="text" id="cardLabelNewName" placeholder="Címke neve (pl. bug)" style="flex:1; padding:5px 8px; border-radius:6px; border:1px solid var(--border); background:var(--bg); color:var(--text); font-size:13px">
+            <div class="label-color-swatches" id="cardLabelNewColors"></div>
+            <button class="btn-primary btn-compact" id="cardLabelNewSaveBtn">Mentés</button>
+          </div>
+        </div>
         <div class="card-detail-comments">
           <h4>Megjegyzések</h4>
           <div class="comments-list" id="commentsList"></div>

--- a/web/style.css
+++ b/web/style.css
@@ -939,6 +939,54 @@ main {
 }
 .card-detail-desc:empty { display: none; }
 
+.card-detail-labels { margin-bottom: 20px; }
+.card-detail-labels h4 {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 10px;
+}
+.label-pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 22px;
+}
+.label-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--label-color);
+  background: color-mix(in srgb, var(--label-color) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--label-color) 40%, transparent);
+}
+.label-pill-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  padding: 0;
+  opacity: 0.7;
+}
+.label-pill-remove:hover { opacity: 1; }
+.label-color-swatches { display: flex; gap: 4px; }
+.label-color-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+.label-color-swatch.selected { border-color: var(--text); }
+
 .card-detail-comments { margin-bottom: 20px; }
 .card-detail-comments h4 {
   font-size: 12px;

--- a/web/style.css
+++ b/web/style.css
@@ -776,6 +776,67 @@ main {
 }
 .kanban-card-due.overdue { color: var(--danger); font-weight: 600; }
 
+.kanban-card-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+.kanban-card-label-pill {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 8px;
+  color: var(--label-color);
+  background: color-mix(in srgb, var(--label-color) 16%, transparent);
+  cursor: pointer;
+  line-height: 1.5;
+}
+.kanban-card-label-pill:hover { filter: brightness(1.15); }
+.kanban-card-label-overflow {
+  color: var(--text-muted);
+  background: var(--bg);
+  cursor: default;
+}
+.kanban-card-label-overflow:hover { filter: none; }
+
+.kanban-quick-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  padding: 3px 9px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  background: var(--bg-card);
+  cursor: pointer;
+  user-select: none;
+}
+.kanban-quick-filter-chip:hover { border-color: var(--chip-color); }
+.kanban-quick-filter-chip.active {
+  color: white;
+  background: var(--chip-color);
+  border-color: var(--chip-color);
+}
+.kanban-quick-filter-count {
+  font-size: 10px;
+  opacity: 0.85;
+}
+.kanban-quick-filter-clear {
+  margin-left: 2px;
+  font-weight: 700;
+}
+.kanban-quick-filter-clear-all {
+  font-size: 12px;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
 .priority-bar {
   width: 3px;
   height: 100%;

--- a/web/style.css
+++ b/web/style.css
@@ -807,9 +807,12 @@ main {
   font-size: 12px;
   padding: 3px 9px;
   border-radius: 12px;
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  background: var(--bg-card);
+  /* Inactive chips already carry their label's own colour (border + text +
+     faint tint), so the header filter row visually matches the per-card label
+     pills on the board; the active state below fills solid. */
+  border: 1px solid var(--chip-color);
+  color: var(--chip-color);
+  background: color-mix(in srgb, var(--chip-color) 12%, var(--bg-card));
   cursor: pointer;
   user-select: none;
 }


### PR DESCRIPTION
## Summary

Adds a label/tag system to the kanban board, plus a label-based quick-filter chip row in the header.

Labels: each card can carry labels managed in the card editor. Labels live in their own registry (a labels table) linked to cards via a join table, so the same label can appear on many cards and be renamed/recoloured in one place. A label's colour is restricted to the configurable palette (KANBAN_LABEL_COLORS), validated server-side. On each card, up to 3 cold-toned label pills show in the footer, with "+N" overflow.

Quick-filter: the header shows one chip per defined label, each in its own label colour (so the filter row visually matches the board's pills); the active chip fills solid with × to clear, plus a "clear all". Clicking a label chip filters the board to cards carrying that label. The header chips and the per-card footer pills toggle the same label-filter set (two entry points, one filter dimension). Label filters OR within themselves and AND with the existing project/assignee filters and the swimlane grouping. The active selection persists in localStorage.

## Config (.env)

- KANBAN_LABEL_COLORS (comma-separated palette; labels may only use a colour from it)

## Files

- src/db.ts, src/web/routes/kanban.ts (labels table + join, CRUD + card-label endpoints), src/config.ts, src/web/routes/marveen.ts (palette exposure)
- web/app.js, web/style.css, web/index.html (label pills, header quick-filter chips, filter logic)
- docs/kanban.md, docs/en/kanban.md (technical + user-facing sections, HU+EN)
- src/__tests__/kanban-labels.test.ts (label CRUD tests)

This change was authored with AI assistance, reviewed by @cett  before submission.

## Test plan

- [ ] Create/rename/recolour/delete labels in the card editor; colours restricted to the configured palette
- [ ] A card shows up to 3 footer pills + "+N"; pill colours match the header chips
- [ ] Clicking a header label chip filters to cards with that label; × / clear-all reset it
- [ ] Label filter combines correctly with project/assignee filters and swimlane grouping
- [ ] Filter selection persists across reloads (localStorage)

