### PR TITLE
Feat/dashboard settings: központi Beállítások-felület (config-registry + overrides + /api/settings + UI)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,0 +1,261 @@
+# Konfiguráció-referencia
+
+> Melyik fájl mire jó, hol van, mit tartalmaz. Egy helyen az összes konfigurációs fájl áttekintése.
+
+---
+
+## store/ -- futásidejű állapot
+
+Ezek a fájlok a dashboard által kezelt, futásidőben módosuló konfigurációk. Nem kerülnek be a gitbe (`.gitignore`).
+
+| Fájl | Módosítható | Leírás |
+|------|-------------|--------|
+| `store/.dashboard-token` | nem | Dashboard Bearer token -- minden `/api/*` híváshoz kell |
+| `store/autonomy-config.json` | dashboard UI | Heartbeat autonómia-szintek kategóriánként (1=jelz, 2=javasol, 3=autonóm) |
+| `store/dashboard-settings.json` | dashboard UI | GitHub repo integráció, frissítési beállítások |
+| `store/agents-desired.json` | dashboard UI | Melyik sub-ágenseket kell életben tartani (auto-restart lista) |
+| `store/auto-restart.json` | dashboard UI | Ágensenként auto-restart konfiguráció (enabled, mode, dailyTime) |
+| `store/vault.json` | dashboard UI | Titkosított titkos kulcsok (AES-256-GCM) |
+| `store/.vault-key` | nem | Vault visszafejtési kulcs (OS keychain-be migrált, ha elérhető) |
+| `store/schedule-last-run.json` | automatikus | Ütemezett feladatok utolsó futási időbélyege (crash-safe skip) |
+| `store/kanban-audit-state.json` | automatikus | Kanban audit utolsó futása |
+| `store/claudeclaw.db` | nem direktben | SQLite adatbázis -- memória, kanban, üzenetek, token-log, stb. |
+| `store/config-overrides.json` | dashboard UI | Beállítások-oldal által mentett felülbírálatok (plain értékek, sosem tartalmaz titkokat) |
+| `store/update.pid` | automatikus | Frissítési folyamat PID fájl (concurrency lock) |
+
+### Beállítások rendszer (Settings)
+
+A dashboard Beállítások oldala egy háromrétegű konfigurációs rendszert kezel.
+
+**Feloldási sorrend (priority order, az első találat nyer):**
+1. `store/config-overrides.json` -- a dashboard által mentett felülbírálatok
+2. `.env` -- project szintű értékek (induláskor és minden lekérésnél frissen olvassa)
+3. Registry alapértelmezett érték (`src/config-registry.ts`)
+
+**`store/config-overrides.json` struktúra:**
+
+```json
+{
+  "KANBAN_WIP_PLANNED": 10,
+  "KANBAN_WIP_WARN_PCT": 80,
+  "KANBAN_WIP_OK_COLOR": "#6b7280"
+}
+```
+
+Csak a felülbírált kulcsok jelennek meg; a többi a registry alapértékét kapja. Az írás atomi (tmp fájl + rename), így részleges írás nem fordulhat elő.
+
+**Beállítás-registry (`src/config-registry.ts`):**
+
+Minden dashboard-szerkeszthető beállítás egy bejegyzésként szerepel a registry-ben, az alábbi mezőkkel:
+
+| Mező | Típus | Leírás |
+|------|-------|--------|
+| `key` | string | ENV-kompatibilis kulcs (pl. `KANBAN_WIP_PLANNED`) |
+| `type` | `int` / `color` / `string` | Érték típusa (validáció + UI widget) |
+| `default` | any | Fallback érték, ha nincs override és nincs .env |
+| `description` | string | Felhasználói leírás (UI-ban megjelenik) |
+| `module` | string | Csoportosítás a Beállítások oldalon (pl. `kanban`) |
+| `secret` | boolean | Ha `true`: az API nem adja vissza az értéket, POST sem engedélyezett |
+| `requiresRestart` | boolean | Ha `true`: a badge jelzi, hogy az érték csak újraindítás után lép életbe |
+| `min` / `max` | number? | Int típusnál határértékek |
+| `valueSet` | string[]? | Ha megadott: csak ezek közül lehet választani (select widget) |
+
+**v1 registry (9 kanban WIP kulcs):**
+
+| Kulcs | Típus | Alapérték | Korlát |
+|-------|-------|-----------|--------|
+| `KANBAN_WIP_PLANNED` | int | 0 (korlátlan) | max 100 |
+| `KANBAN_WIP_IN_PROGRESS` | int | 0 | max 100 |
+| `KANBAN_WIP_WAITING` | int | 0 | max 100 |
+| `KANBAN_WIP_DONE` | int | 0 | max 100 |
+| `KANBAN_WIP_WARN_PCT` | int | 80 | min 1, max 100 |
+| `KANBAN_WIP_OK_COLOR` | color | `#6b7280` | #rrggbb |
+| `KANBAN_WIP_WARN_COLOR` | color | `#c9a000` | #rrggbb |
+| `KANBAN_WIP_FULL_COLOR` | color | `#d46b00` | #rrggbb |
+| `KANBAN_WIP_OVER_COLOR` | color | `#c53030` | #rrggbb |
+
+**API végpontok:**
+
+`GET /api/settings` -- összes nem-titkos beállítás lekérése:
+
+```bash
+curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  http://localhost:3420/api/settings
+```
+
+Válasz: `{ "settings": [ { "key", "type", "value", "default", "description", "module", "requiresRestart", "min", "max", "valueSet" }, ... ] }`
+
+`POST /api/settings` -- egy beállítás mentése:
+
+```bash
+curl -s -X POST http://localhost:3420/api/settings \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  -d '{"key": "KANBAN_WIP_WARN_PCT", "value": 75}'
+```
+
+Válasz siker esetén: `{ "ok": true, "key": "KANBAN_WIP_WARN_PCT", "value": 75, "requiresRestart": false }`
+
+Hiba esetén: `{ "error": "..." }` (400 validációs hiba, 403 titkos kulcs, 404 ismeretlen kulcs)
+
+**Hot-reload:** a POST sikeres mentés után a `/api/marveen` `kanbanWip` blokkja azonnal az új értékkel tér vissza (nincs szükség újraindításra, ha `requiresRestart: false`).
+
+**Change-log:** minden sikeres POST audit-sort ír a `config_change_log` SQLite táblába (kulcs, régi érték, új érték, actor, timestamp). Titkos kulcsoknál az érték `null`-ként kerül rögzítésre. UI nincs hozzá; a tábla közvetlenül lekérdezhető.
+
+```sql
+SELECT key, old_value, new_value, actor, datetime(created_at, 'unixepoch', 'localtime')
+FROM config_change_log ORDER BY created_at DESC LIMIT 20;
+```
+
+---
+
+### autonomy-config.json struktúra
+
+```json
+{
+  "version": 1,
+  "categories": [
+    {
+      "key": "kanban_archive_done",
+      "label": "7+ napos done kártya archiválás",
+      "level": 2,
+      "locked": false,
+      "maxLevel": 3
+    }
+  ]
+}
+```
+
+Autonómia szintek: `1` = csak jelez, `2` = javasol + jóváhagyás kell, `3` = autonóm + utólag jelent. `locked: true` esetén max szint 1 (hard safety szabály miatt nem emelhető).
+
+---
+
+## agents/<name>/ -- sub-ágensek konfigurációja
+
+Minden sub-ágens mappája gitignore-olt (`agents/` mappa), így a titkos kulcsok biztonságban maradnak.
+
+| Fájl | Módosítható | Leírás |
+|------|-------------|--------|
+| `agents/<name>/agent-config.json` | dashboard UI | Modell, team hierarchia, permission profil |
+| `agents/<name>/.mcp.json` | kézzel | MCP szerverek listája az ágensnek (gitignore-olt!) |
+| `agents/<name>/.claude/settings.json` | scaffold + kézzel | Claude Code jogosultságok, hook-ok, engedélyezett eszközök |
+| `agents/<name>/CLAUDE.md` | kézzel | Az ágens instrukciói és személyisége |
+| `agents/<name>/SOUL.md` | kézzel | Opcionális mélyebb személyiség-leíró |
+| `agents/<name>/avatar.png` | kézzel | Az ágens Telegram bot profilképe |
+
+### agent-config.json struktúra
+
+```json
+{
+  "model": "claude-sonnet-4-6",
+  "profileId": "developer-senior",
+  "team": {
+    "role": "member",
+    "reportsTo": "marveen",
+    "delegatesTo": [],
+    "autoDelegation": false,
+    "trustFrom": []
+  }
+}
+```
+
+---
+
+## templates/ -- ágens-létrehozási sablonok
+
+Ezek a sablonok az ágens scaffold során töltődnek ki és kerülnek az `agents/<name>/` mappába.
+
+| Fájl / Mappa | Leírás |
+|--------------|--------|
+| `templates/CLAUDE.md.template` | Alapértelmezett CLAUDE.md sablon új ágensekhez |
+| `templates/SOUL.md.template` | Alapértelmezett SOUL.md sablon |
+| `templates/settings.json.template` | Claude Code settings sablon (hook-ok, jogosultságok) |
+| `templates/profiles/` | Permission profil sablonok (JSON fájlok) |
+| `templates/scheduled-tasks/` | Beépített ütemezett feladatok (reggeli napindító, memoria-heartbeat, stb.) |
+
+### Permission profilok (templates/profiles/)
+
+| Profil | permissionMode | Leírás |
+|--------|---------------|--------|
+| `default.json` | permissive | Alapértelmezett fallback, minden engedélyezett |
+| `developer-senior.json` | permissive | SSH/AWS/sudo tiltva, egyébként szabad |
+| `developer-junior.json` | strict | Szigorú sandbox, csak engedélyezett útvonalak |
+| `marketer.json` | strict | Marketing-specifikus hozzáférések |
+| `researcher.json` | strict | Kutató profil, korlátozott írás |
+
+A profil beállítása az ágens `agent-config.json` `profileId` mezőjével történik, és a dashboard "Ágensek" felületén módosítható.
+
+---
+
+## ~/.claude/scheduled-tasks/ -- ütemezett feladatok
+
+Minden feladat egy önálló mappa, benne két fájl. Részletes leírás: [scheduled-tasks.md](scheduled-tasks.md).
+
+| Fájl | Leírás |
+|------|--------|
+| `SKILL.md` | YAML frontmatter (name, description) + a prompt törzse |
+| `task-config.json` | Cron kifejezés, ágens, típus, viselkedési flagek |
+
+---
+
+## ~/.claude/channels/ -- csatorna-hozzáférés
+
+| Fájl | Leírás |
+|------|--------|
+| `~/.claude/channels/telegram/access.json` | Telegram allowFrom lista, párosított senderek |
+| `~/.claude/channels/slack/access.json` | Slack allowFrom lista |
+
+---
+
+## .mcp.json -- MCP szerverek
+
+Az MCP konfigurációk scope-olva vannak: az ágensek `agents/<name>/.mcp.json` fájljaikban csak a számukra releváns szervereket tartalmazzák. A projekt gyökerében lévő `.mcp.json` a főágensre (marveen/Jarvis) vonatkozik.
+
+```json
+{
+  "mcpServers": {
+    "gitlab": {
+      "command": "npx",
+      "args": ["-y", "@zereight/mcp-gitlab"],
+      "env": {
+        "GITLAB_PERSONAL_ACCESS_TOKEN": "...",
+        "GITLAB_API_URL": "https://gitlab.com/api/v4"
+      }
+    },
+    "google-workspace": {
+      "command": "npx",
+      "args": ["-y", "google-workspace-mcp", "serve"]
+    }
+  }
+}
+```
+
+**Fontos:** az `agents/` mappa gitignore-olt, így az `.mcp.json` titkos kulcsai nem kerülnek a repositoryba. A projekt gyökerében lévő `.mcp.json` gitignore-olt (ellenőrizd a `.gitignore`-t!).
+
+---
+
+## Környezeti változók (.env / launchd plist)
+
+A főbb konfigurációs változók a launchd plist-ben (`~/Library/LaunchAgents/com.marveen.dashboard.plist`) vagy a `.env` fájlban élnek.
+
+| Változó | Leírás |
+|---------|--------|
+| `CHANNEL_PROVIDER` | `telegram` vagy `slack` |
+| `TELEGRAM_BOT_TOKEN` | Telegram bot API token |
+| `ALLOWED_CHAT_ID` | Az egyetlen engedélyezett Telegram chat ID |
+| `SLACK_BOT_TOKEN` | Slack bot token (ha Slack provider) |
+| `SLACK_CHANNEL_ID` | Slack csatorna ID |
+| `WEB_PORT` | Dashboard port (alapértelmezett: 3420) |
+| `ANTHROPIC_API_KEY` | Claude API kulcs |
+| `OWNER_NAME` | A tulajdonos neve (pl. "Jónás Gergő") |
+| `BOT_NAME` | A főágens neve (pl. "Jarvis") |
+
+---
+
+## Kapcsolódó dokumentumok
+
+- [Vault és titkosítás](vault.md)
+- [MCP konfiguráció](mcp-config.md)
+- [Ütemezett feladatok](scheduled-tasks.md)
+- [Biztonsági modell](security.md)
+- [Migrálás](MIGRATION.md)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -23,6 +23,29 @@ Ezek a fájlok a dashboard által kezelt, futásidőben módosuló konfiguráci�
 | `store/config-overrides.json` | dashboard UI | Beállítások-oldal által mentett felülbírálatok (plain értékek, sosem tartalmaz titkokat) |
 | `store/update.pid` | automatikus | Frissítési folyamat PID fájl (concurrency lock) |
 
+### Beállítások oldal
+
+A dashboard bal oldali navigációjában a "Beállítások" menüpont megnyitja a konfigurációs felületet, ahol az env-alapú paramétereket közvetlenül a böngészőből lehet megtekinteni és módosítani -- `.env` szerkesztés vagy szerver-hozzáférés nélkül.
+
+**Hogyan módosíts egy értéket?**
+
+A beállítások modul-csoportokba rendezve jelennek meg (pl. "kanban"). Minden sor tartalmaz:
+- a kulcs nevét és leírását,
+- a jelenlegi értéket egy szerkeszthető inputban (egész számoknál beviteli mező az érvényes tartomány jelzésével, színeknél színválasztó az aktuális szín előnézetével),
+- egy "Mentés" gombot.
+
+Kattints a "Mentés" gombra -- a változás azonnal életbe lép, a szerver többi beállítása érintetlen marad. Ha a kanban tábla oldalát ezután megnyitod, már az új értékeket mutatja.
+
+**Mit jelent a validációs hiba?**
+
+Ha érvénytelen értéket adsz meg (pl. 150-et, ahol a maximum 100, vagy nem `#rrggbb` formátumú szín), a hibaüzenet közvetlenül a sor alatt jelenik meg mentés gomb megnyomása után. Más sorok érintetlenek maradnak. Javítsd az értéket és próbáld újra.
+
+**Mikor kell újraindítás?**
+
+Egyes beállítások mellett "Újraindítást igényel" feliratú badge látható -- ha ilyen értéket módosítasz, a változás csak a szerver következő újraindítása után lép életbe. A v1-es kanban beállítások (WIP-limitek és badge-színek) mind azonnal hatnak, újraindítás nélkül.
+
+---
+
 ### Beállítások rendszer (Settings)
 
 A dashboard Beállítások oldala egy háromrétegű konfigurációs rendszert kezel.

--- a/docs/en/MIGRATION.md
+++ b/docs/en/MIGRATION.md
@@ -31,7 +31,7 @@ the Docker volumes (3) are **separate** and must be moved on their own.
 - `~/.claude/scheduled-tasks/**` — file-based scheduled tasks (SKILL.md + task-config.json)
 - `~/.claude/channels/*/.env` — MAIN orchestrator channel token
 - `~/.claude/channels/*/access.json`, `invites.json`, `approved/**` — pairing allowlist + approvals
-- `~/Library/LaunchAgents/com.<MAIN_AGENT_ID>.*.plist` -- launchd jobs (the prefix is your `MAIN_AGENT_ID`, `marveen` by default)
+- `~/Library/LaunchAgents/com.<MAIN_AGENT_ID>.*.plist` — launchd jobs (prefix is your `MAIN_AGENT_ID`, `marveen` by default)
 
 **(3) Docker volumes — NOT in the tarball, migrate separately**
 - `stack_influxdb-data`, `stack_influxdb-config` — InfluxDB 2.7 time-series (Loxone history)

--- a/docs/en/config-reference.md
+++ b/docs/en/config-reference.md
@@ -23,6 +23,29 @@ These files are managed by the dashboard and change at runtime. They are not che
 | `store/config-overrides.json` | dashboard UI | Settings-page overrides (plain values only, never contains secrets) |
 | `store/update.pid` | automatic | Update process PID file (concurrency lock) |
 
+### Settings page
+
+The "Settings" entry in the dashboard's left-hand navigation opens the configuration UI, where env-backed parameters can be viewed and changed directly in the browser -- no `.env` editing or server access required.
+
+**How to change a value**
+
+Settings are grouped by module (e.g. "kanban"). Each row shows:
+- the key name and its description,
+- the current value in an editable input (number fields show the valid range; colour fields show a colour picker with a preview swatch),
+- a "Save" button.
+
+Click "Save" -- the change takes effect immediately, leaving all other settings untouched. The next time you open the Kanban board it will reflect the new values.
+
+**What does a validation error mean?**
+
+If you enter an invalid value (e.g. 150 where the maximum is 100, or a colour that isn't in `#rrggbb` format), an error message appears directly below the row after you press Save. Other rows are unaffected. Fix the value and try again.
+
+**When is a restart required?**
+
+Some rows carry a "Requires restart" badge -- changes to those settings only take effect after the next server restart. The v1 kanban settings (WIP limits and badge colours) all apply immediately, no restart needed.
+
+---
+
 ### Settings System
 
 The dashboard Settings page manages a three-layer configuration system.

--- a/docs/en/config-reference.md
+++ b/docs/en/config-reference.md
@@ -1,0 +1,261 @@
+# Configuration Reference
+
+> Which file does what, where it lives, what it contains. All configuration files in one place.
+
+---
+
+## store/ -- Runtime State
+
+These files are managed by the dashboard and change at runtime. They are not checked into git (`.gitignore`).
+
+| File | Editable | Description |
+|------|----------|-------------|
+| `store/.dashboard-token` | no | Dashboard Bearer token -- required for all `/api/*` calls |
+| `store/autonomy-config.json` | dashboard UI | Heartbeat autonomy levels by category (1=notify, 2=propose, 3=autonomous) |
+| `store/dashboard-settings.json` | dashboard UI | GitHub repo integration, update settings |
+| `store/agents-desired.json` | dashboard UI | Which sub-agents to keep alive (auto-restart list) |
+| `store/auto-restart.json` | dashboard UI | Per-agent auto-restart config (enabled, mode, dailyTime) |
+| `store/vault.json` | dashboard UI | Encrypted secrets (AES-256-GCM) |
+| `store/.vault-key` | no | Vault decryption key (migrated to OS keychain when available) |
+| `store/schedule-last-run.json` | automatic | Last-run timestamps for scheduled tasks (crash-safe skip guard) |
+| `store/kanban-audit-state.json` | automatic | Last kanban audit timestamp |
+| `store/claudeclaw.db` | not directly | SQLite database -- memory, kanban, messages, token log, etc. |
+| `store/config-overrides.json` | dashboard UI | Settings-page overrides (plain values only, never contains secrets) |
+| `store/update.pid` | automatic | Update process PID file (concurrency lock) |
+
+### Settings System
+
+The dashboard Settings page manages a three-layer configuration system.
+
+**Resolution order (first match wins):**
+1. `store/config-overrides.json` -- overrides saved by the dashboard
+2. `.env` -- project-level values (read fresh on every request, not frozen at boot)
+3. Registry default (`src/config-registry.ts`)
+
+**`store/config-overrides.json` structure:**
+
+```json
+{
+  "KANBAN_WIP_PLANNED": 10,
+  "KANBAN_WIP_WARN_PCT": 80,
+  "KANBAN_WIP_OK_COLOR": "#6b7280"
+}
+```
+
+Only overridden keys appear in the file; the rest fall through to the registry default. Writes are atomic (tmp file + rename), so partial writes are impossible.
+
+**Settings registry (`src/config-registry.ts`):**
+
+Every dashboard-editable setting is a registry entry with the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | ENV-compatible key (e.g. `KANBAN_WIP_PLANNED`) |
+| `type` | `int` / `color` / `string` | Value type (drives validation + UI widget) |
+| `default` | any | Fallback when no override and no `.env` entry |
+| `description` | string | Human-readable description shown in the UI |
+| `module` | string | Grouping label on the Settings page (e.g. `kanban`) |
+| `secret` | boolean | If `true`: the API never returns the value; POST is rejected |
+| `requiresRestart` | boolean | If `true`: a badge warns the user that the value takes effect after restart |
+| `min` / `max` | number? | Bounds for `int` type |
+| `valueSet` | string[]? | If set: only these values are accepted (select widget in UI) |
+
+**v1 registry (9 kanban WIP keys):**
+
+| Key | Type | Default | Constraint |
+|-----|------|---------|------------|
+| `KANBAN_WIP_PLANNED` | int | 0 (unlimited) | max 100 |
+| `KANBAN_WIP_IN_PROGRESS` | int | 0 | max 100 |
+| `KANBAN_WIP_WAITING` | int | 0 | max 100 |
+| `KANBAN_WIP_DONE` | int | 0 | max 100 |
+| `KANBAN_WIP_WARN_PCT` | int | 80 | min 1, max 100 |
+| `KANBAN_WIP_OK_COLOR` | color | `#6b7280` | #rrggbb |
+| `KANBAN_WIP_WARN_COLOR` | color | `#c9a000` | #rrggbb |
+| `KANBAN_WIP_FULL_COLOR` | color | `#d46b00` | #rrggbb |
+| `KANBAN_WIP_OVER_COLOR` | color | `#c53030` | #rrggbb |
+
+**API endpoints:**
+
+`GET /api/settings` -- fetch all non-secret settings:
+
+```bash
+curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  http://localhost:3420/api/settings
+```
+
+Response: `{ "settings": [ { "key", "type", "value", "default", "description", "module", "requiresRestart", "min", "max", "valueSet" }, ... ] }`
+
+`POST /api/settings` -- save a single setting:
+
+```bash
+curl -s -X POST http://localhost:3420/api/settings \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  -d '{"key": "KANBAN_WIP_WARN_PCT", "value": 75}'
+```
+
+Success response: `{ "ok": true, "key": "KANBAN_WIP_WARN_PCT", "value": 75, "requiresRestart": false }`
+
+Error response: `{ "error": "..." }` (400 validation error, 403 secret key, 404 unknown key)
+
+**Hot-reload:** after a successful POST, the `/api/marveen` `kanbanWip` block immediately reflects the new value with no restart needed (for keys where `requiresRestart: false`).
+
+**Change log:** every successful POST appends an audit row to the `config_change_log` SQLite table (key, old value, new value, actor, timestamp). For secret keys the value is stored as `null`. There is no UI for this table; query it directly:
+
+```sql
+SELECT key, old_value, new_value, actor, datetime(created_at, 'unixepoch', 'localtime')
+FROM config_change_log ORDER BY created_at DESC LIMIT 20;
+```
+
+---
+
+### autonomy-config.json Structure
+
+```json
+{
+  "version": 1,
+  "categories": [
+    {
+      "key": "kanban_archive_done",
+      "label": "Archive done cards older than 7 days",
+      "level": 2,
+      "locked": false,
+      "maxLevel": 3
+    }
+  ]
+}
+```
+
+Autonomy levels: `1` = notify only, `2` = propose + approval required, `3` = autonomous + reports afterwards. `locked: true` means max level is 1 (cannot be raised due to hard safety rule).
+
+---
+
+## agents/<name>/ -- Sub-agent Configuration
+
+Every sub-agent's directory is gitignored (`agents/` folder), keeping secrets safe.
+
+| File | Editable | Description |
+|------|----------|-------------|
+| `agents/<name>/agent-config.json` | dashboard UI | Model, team hierarchy, permission profile |
+| `agents/<name>/.mcp.json` | manually | MCP servers for this agent (gitignored!) |
+| `agents/<name>/.claude/settings.json` | scaffold + manually | Claude Code permissions, hooks, allowed tools |
+| `agents/<name>/CLAUDE.md` | manually | Agent instructions and persona |
+| `agents/<name>/SOUL.md` | manually | Optional deeper persona descriptor |
+| `agents/<name>/avatar.png` | manually | Agent Telegram bot profile picture |
+
+### agent-config.json Structure
+
+```json
+{
+  "model": "claude-sonnet-4-6",
+  "profileId": "developer-senior",
+  "team": {
+    "role": "member",
+    "reportsTo": "marveen",
+    "delegatesTo": [],
+    "autoDelegation": false,
+    "trustFrom": []
+  }
+}
+```
+
+---
+
+## templates/ -- Agent Creation Templates
+
+These templates are populated during agent scaffolding and placed into `agents/<name>/`.
+
+| File / Folder | Description |
+|---------------|-------------|
+| `templates/CLAUDE.md.template` | Default CLAUDE.md template for new agents |
+| `templates/SOUL.md.template` | Default SOUL.md template |
+| `templates/settings.json.template` | Claude Code settings template (hooks, permissions) |
+| `templates/profiles/` | Permission profile templates (JSON files) |
+| `templates/scheduled-tasks/` | Built-in scheduled tasks (morning briefing, memoria-heartbeat, etc.) |
+
+### Permission Profiles (templates/profiles/)
+
+| Profile | permissionMode | Description |
+|---------|---------------|-------------|
+| `default.json` | permissive | Default fallback, everything allowed |
+| `developer-senior.json` | permissive | SSH/AWS/sudo blocked, otherwise unrestricted |
+| `developer-junior.json` | strict | Strict sandbox, only allowed paths |
+| `marketer.json` | strict | Marketing-specific access |
+| `researcher.json` | strict | Researcher profile, limited writes |
+
+Profile is set via the `profileId` field in `agent-config.json` and configurable from the dashboard "Agents" view.
+
+---
+
+## ~/.claude/scheduled-tasks/ -- Scheduled Tasks
+
+Each task lives in its own folder with two files. Detailed description: [scheduled-tasks.md](scheduled-tasks.md).
+
+| File | Description |
+|------|-------------|
+| `SKILL.md` | YAML frontmatter (name, description) + prompt body |
+| `task-config.json` | Cron expression, agent, type, behaviour flags |
+
+---
+
+## ~/.claude/channels/ -- Channel Access
+
+| File | Description |
+|------|-------------|
+| `~/.claude/channels/telegram/access.json` | Telegram allowFrom list, paired senders |
+| `~/.claude/channels/slack/access.json` | Slack allowFrom list |
+
+---
+
+## .mcp.json -- MCP Servers
+
+MCP configurations are scoped: agent `agents/<name>/.mcp.json` files contain only the servers relevant to that agent. The `.mcp.json` at the project root applies to the main agent (marveen/Jarvis).
+
+```json
+{
+  "mcpServers": {
+    "gitlab": {
+      "command": "npx",
+      "args": ["-y", "@zereight/mcp-gitlab"],
+      "env": {
+        "GITLAB_PERSONAL_ACCESS_TOKEN": "...",
+        "GITLAB_API_URL": "https://gitlab.com/api/v4"
+      }
+    },
+    "google-workspace": {
+      "command": "npx",
+      "args": ["-y", "google-workspace-mcp", "serve"]
+    }
+  }
+}
+```
+
+**Important:** the `agents/` folder is gitignored, so secrets in `.mcp.json` files don't end up in the repository. Verify the project-root `.mcp.json` is also gitignored.
+
+---
+
+## Environment Variables (.env / launchd plist)
+
+Key configuration variables live in the launchd plist (`~/Library/LaunchAgents/com.marveen.dashboard.plist`) or `.env` file.
+
+| Variable | Description |
+|----------|-------------|
+| `CHANNEL_PROVIDER` | `telegram` or `slack` |
+| `TELEGRAM_BOT_TOKEN` | Telegram bot API token |
+| `ALLOWED_CHAT_ID` | The single allowed Telegram chat ID |
+| `SLACK_BOT_TOKEN` | Slack bot token (if Slack provider) |
+| `SLACK_CHANNEL_ID` | Slack channel ID |
+| `WEB_PORT` | Dashboard port (default: 3420) |
+| `ANTHROPIC_API_KEY` | Claude API key |
+| `OWNER_NAME` | Owner name (e.g. "Jónás Gergő") |
+| `BOT_NAME` | Main agent name (e.g. "Jarvis") |
+
+---
+
+## Related Documents
+
+- [Vault and Encryption](vault.md)
+- [MCP Configuration](mcp-config.md)
+- [Scheduled Tasks](scheduled-tasks.md)
+- [Security Model](security.md)
+- [Migration](MIGRATION.md)

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -65,6 +65,7 @@ add_if "${REPOLIST}" "${REPO_ROOT}" store/claudeclaw.db
 add_if "${REPOLIST}" "${REPO_ROOT}" store/claudeclaw.db-shm
 add_if "${REPOLIST}" "${REPO_ROOT}" store/claudeclaw.db-wal
 add_if "${REPOLIST}" "${REPO_ROOT}" store/.dashboard-token
+add_if "${REPOLIST}" "${REPO_ROOT}" store/config-overrides.json
 add_if "${REPOLIST}" "${REPO_ROOT}" .env
 add_if "${REPOLIST}" "${REPO_ROOT}" scheduled-tasks.json
 add_if "${REPOLIST}" "${REPO_ROOT}" assets/meetings

--- a/src/__tests__/config-change-log.test.ts
+++ b/src/__tests__/config-change-log.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { initDatabase, logConfigChange, getRecentConfigChanges } from '../db.js'
+
+// In-memory DB, never touches the real store/claudeclaw.db (same pattern as
+// db.test.ts) -- this table only matters as a background audit trail, no UI
+// reads it yet.
+beforeAll(() => {
+  initDatabase(':memory:')
+})
+
+describe('config change log', () => {
+  it('records an old -> new change with the actor and can read it back newest-first', () => {
+    logConfigChange('KANBAN_WIP_WARN_PCT', 80, 42, 'dashboard')
+    logConfigChange('KANBAN_WIP_OK_COLOR', '#6b7280', '#112233', 'dashboard')
+
+    const rows = getRecentConfigChanges(10)
+    expect(rows.length).toBeGreaterThanOrEqual(2)
+    expect(rows[0].key).toBe('KANBAN_WIP_OK_COLOR')
+    expect(rows[0].old_value).toBe('#6b7280')
+    expect(rows[0].new_value).toBe('#112233')
+    expect(rows[0].actor).toBe('dashboard')
+  })
+
+  it('stores null old/new values as null (for a future secret entry), never a string "null"', () => {
+    logConfigChange('SOME_FUTURE_SECRET', null, null, 'dashboard')
+    const rows = getRecentConfigChanges(1)
+    expect(rows[0].old_value).toBeNull()
+    expect(rows[0].new_value).toBeNull()
+  })
+})

--- a/src/__tests__/config-registry.test.ts
+++ b/src/__tests__/config-registry.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { SETTINGS_REGISTRY, getSettingDefinition, listSettingModules, validateSettingValue } from '../config-registry.js'
+
+describe('config-registry', () => {
+  it('exposes exactly the 9 kanban WIP keys in v1', () => {
+    expect(SETTINGS_REGISTRY).toHaveLength(9)
+    expect(SETTINGS_REGISTRY.every((s) => s.module === 'kanban')).toBe(true)
+    expect(SETTINGS_REGISTRY.every((s) => s.secret === false)).toBe(true)
+    expect(SETTINGS_REGISTRY.every((s) => s.requiresRestart === false)).toBe(true)
+  })
+
+  it('getSettingDefinition finds a known key and returns undefined for unknown', () => {
+    expect(getSettingDefinition('KANBAN_WIP_PLANNED')?.type).toBe('int')
+    expect(getSettingDefinition('NOT_A_REAL_KEY')).toBeUndefined()
+  })
+
+  it('listSettingModules returns the distinct module list', () => {
+    expect(listSettingModules()).toEqual(['kanban'])
+  })
+
+  describe('validateSettingValue', () => {
+    it('accepts a valid int within bounds', () => {
+      const def = getSettingDefinition('KANBAN_WIP_PLANNED')!
+      const result = validateSettingValue(def, '5')
+      expect(result).toEqual({ ok: true, value: 5 })
+    })
+
+    it('rejects a non-integer', () => {
+      const def = getSettingDefinition('KANBAN_WIP_PLANNED')!
+      expect(validateSettingValue(def, 'abc').ok).toBe(false)
+    })
+
+    it('rejects below min', () => {
+      const def = getSettingDefinition('KANBAN_WIP_PLANNED')!
+      expect(validateSettingValue(def, -1).ok).toBe(false)
+    })
+
+    it('rejects 0 for WARN_PCT (min 1, meaningless at 0)', () => {
+      const def = getSettingDefinition('KANBAN_WIP_WARN_PCT')!
+      expect(validateSettingValue(def, 0).ok).toBe(false)
+    })
+
+    it('rejects WARN_PCT above 100', () => {
+      const def = getSettingDefinition('KANBAN_WIP_WARN_PCT')!
+      expect(validateSettingValue(def, 101).ok).toBe(false)
+    })
+
+    it('accepts a valid hex color', () => {
+      const def = getSettingDefinition('KANBAN_WIP_OK_COLOR')!
+      expect(validateSettingValue(def, '#123abc')).toEqual({ ok: true, value: '#123abc' })
+    })
+
+    it('rejects a malformed color', () => {
+      const def = getSettingDefinition('KANBAN_WIP_OK_COLOR')!
+      expect(validateSettingValue(def, 'red').ok).toBe(false)
+      expect(validateSettingValue(def, '#fff').ok).toBe(false)
+    })
+
+    it('enforces an explicit valueSet over type-based validation', () => {
+      const def = { key: 'X', type: 'string' as const, default: 'a', description: '', module: 'm', secret: false, requiresRestart: false, valueSet: ['a', 'b'] }
+      expect(validateSettingValue(def, 'a').ok).toBe(true)
+      expect(validateSettingValue(def, 'c').ok).toBe(false)
+    })
+  })
+})

--- a/src/__tests__/settings-store.test.ts
+++ b/src/__tests__/settings-store.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import {
+  OVERRIDES_PATH,
+  getEffectiveSettingValue,
+  setOverride,
+  getOverrides,
+  reloadOverridesForTest,
+} from '../settings-store.js'
+
+// This worktree's PROJECT_ROOT resolves under /tmp/marveen-dashboard-settings
+// (see config.ts: PROJECT_ROOT = join(__dirname, '..')), so OVERRIDES_PATH
+// here is isolated from any real fleet install -- safe to write/delete.
+describe('settings-store', () => {
+  beforeEach(() => {
+    if (existsSync(OVERRIDES_PATH)) rmSync(OVERRIDES_PATH)
+    reloadOverridesForTest()
+  })
+
+  afterAll(() => {
+    if (existsSync(OVERRIDES_PATH)) rmSync(OVERRIDES_PATH)
+    reloadOverridesForTest()
+  })
+
+  it('falls back to the registry default when no override and no .env value exist', () => {
+    expect(getEffectiveSettingValue('KANBAN_WIP_WARN_PCT')).toBe(80)
+    expect(getEffectiveSettingValue('KANBAN_WIP_OK_COLOR')).toBe('#6b7280')
+  })
+
+  it('throws for a key not in the registry', () => {
+    expect(() => getEffectiveSettingValue('NOT_A_REAL_KEY')).toThrow()
+  })
+
+  it('persists a valid override and resolves it ahead of the default', () => {
+    const result = setOverride('KANBAN_WIP_WARN_PCT', 42)
+    expect(result.ok).toBe(true)
+    expect(getEffectiveSettingValue('KANBAN_WIP_WARN_PCT')).toBe(42)
+  })
+
+  it('writes the overrides file atomically (content matches what was set)', () => {
+    setOverride('KANBAN_WIP_OK_COLOR', '#112233')
+    expect(existsSync(OVERRIDES_PATH)).toBe(true)
+    const onDisk = JSON.parse(readFileSync(OVERRIDES_PATH, 'utf-8'))
+    expect(onDisk.KANBAN_WIP_OK_COLOR).toBe('#112233')
+  })
+
+  it('rejects an invalid value and does not write or change the cache', () => {
+    setOverride('KANBAN_WIP_WARN_PCT', 50) // baseline valid override
+    const result = setOverride('KANBAN_WIP_WARN_PCT', 0) // 0 disallowed (min: 1)
+    expect(result.ok).toBe(false)
+    // rollback: the earlier valid override must still be in effect, not 0
+    // and not silently reset to the registry default either.
+    expect(getEffectiveSettingValue('KANBAN_WIP_WARN_PCT')).toBe(50)
+  })
+
+  it('rejects an unknown key without touching the file', () => {
+    const before = existsSync(OVERRIDES_PATH) ? readFileSync(OVERRIDES_PATH, 'utf-8') : null
+    const result = setOverride('NOT_A_REAL_KEY', 'x')
+    expect(result.ok).toBe(false)
+    const after = existsSync(OVERRIDES_PATH) ? readFileSync(OVERRIDES_PATH, 'utf-8') : null
+    expect(after).toBe(before)
+  })
+
+  it('merges multiple overrides instead of clobbering previously set keys', () => {
+    setOverride('KANBAN_WIP_WARN_PCT', 60)
+    setOverride('KANBAN_WIP_OK_COLOR', '#abcdef')
+    const overrides = getOverrides()
+    expect(overrides.KANBAN_WIP_WARN_PCT).toBe(60)
+    expect(overrides.KANBAN_WIP_OK_COLOR).toBe('#abcdef')
+  })
+})

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -34,7 +34,8 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: 'int',
     default: 0,
     min: 0,
-    description: 'A "planned" oszlop WIP-limitje (max. kartyaszam). 0 = korlatlan.',
+    max: 100,
+    description: 'A "planned" oszlop WIP-limitje (max. kártyaszám). 0 = korlátlan.',
     module: 'kanban',
     secret: false,
     requiresRestart: false,
@@ -44,7 +45,8 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: 'int',
     default: 0,
     min: 0,
-    description: 'Az "in_progress" oszlop WIP-limitje (max. kartyaszam). 0 = korlatlan.',
+    max: 100,
+    description: 'Az "in_progress" oszlop WIP-limitje (max. kártyaszám). 0 = korlátlan.',
     module: 'kanban',
     secret: false,
     requiresRestart: false,
@@ -54,7 +56,8 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: 'int',
     default: 0,
     min: 0,
-    description: 'A "waiting" oszlop WIP-limitje (max. kartyaszam). 0 = korlatlan.',
+    max: 100,
+    description: 'A "waiting" oszlop WIP-limitje (max. kártyaszám). 0 = korlátlan.',
     module: 'kanban',
     secret: false,
     requiresRestart: false,
@@ -64,7 +67,8 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: 'int',
     default: 0,
     min: 0,
-    description: 'A "done" oszlop WIP-limitje (max. kartyaszam). 0 = korlatlan.',
+    max: 100,
+    description: 'A "done" oszlop WIP-limitje (max. kártyaszám). 0 = korlátlan.',
     module: 'kanban',
     secret: false,
     requiresRestart: false,
@@ -75,7 +79,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     default: 80,
     min: 1,
     max: 100,
-    description: 'Kihasznaltsagi szazalek, amely felett a WIP-badge sargara vaalt. 0 nem ertelmes (azonnali figyelmeztetes), ezert tiltott.',
+    description: 'Kihasználtsági százalék, amely felett a WIP-badge sárgára vált. 0 nem értelmes (azonnali figyelmeztetés), ezért tiltott.',
     module: 'kanban',
     secret: false,
     requiresRestart: false,
@@ -84,7 +88,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     key: 'KANBAN_WIP_OK_COLOR',
     type: 'color',
     default: '#6b7280',
-    description: 'A WIP-badge szine, amikor az oszlop kihasznaltsaga a figyelmeztetesi kuszob alatt van.',
+    description: 'A WIP-badge színe, amikor az oszlop kihasználtsága a figyelmeztetési küszöb alatt van.',
     module: 'kanban',
     secret: false,
     requiresRestart: false,
@@ -93,7 +97,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     key: 'KANBAN_WIP_WARN_COLOR',
     type: 'color',
     default: '#c9a000',
-    description: 'A WIP-badge szine a figyelmeztetesi kuszob (WARN_PCT) felett, limit elott.',
+    description: 'A WIP-badge színe a figyelmeztetési küszöb (WARN_PCT) felett, limit előtt.',
     module: 'kanban',
     secret: false,
     requiresRestart: false,
@@ -102,7 +106,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     key: 'KANBAN_WIP_FULL_COLOR',
     type: 'color',
     default: '#d46b00',
-    description: 'A WIP-badge szine, amikor az oszlop pontosan a limiten all.',
+    description: 'A WIP-badge színe, amikor az oszlop pontosan a limiten áll.',
     module: 'kanban',
     secret: false,
     requiresRestart: false,
@@ -111,7 +115,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     key: 'KANBAN_WIP_OVER_COLOR',
     type: 'color',
     default: '#c53030',
-    description: 'A WIP-badge szine, amikor az oszlop tullepte a limitet.',
+    description: 'A WIP-badge színe, amikor az oszlop túllépte a limitet.',
     module: 'kanban',
     secret: false,
     requiresRestart: false,
@@ -139,22 +143,22 @@ export function validateSettingValue(def: SettingDefinition, raw: unknown): Sett
   if (def.valueSet && def.valueSet.length > 0) {
     const str = String(raw)
     if (!def.valueSet.includes(str)) {
-      return { ok: false, error: `Ervenytelen ertek. Megengedett: ${def.valueSet.join(', ')}` }
+      return { ok: false, error: `Érvénytelen érték. Megengedett: ${def.valueSet.join(', ')}` }
     }
     return { ok: true, value: str }
   }
 
   if (def.type === 'int') {
     const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10)
-    if (!Number.isInteger(n)) return { ok: false, error: 'Egesz szam szukseges.' }
-    if (def.min !== undefined && n < def.min) return { ok: false, error: `Az ertek legalabb ${def.min} lehet.` }
-    if (def.max !== undefined && n > def.max) return { ok: false, error: `Az ertek legfeljebb ${def.max} lehet.` }
+    if (!Number.isInteger(n)) return { ok: false, error: 'Egész szám szükséges.' }
+    if (def.min !== undefined && n < def.min) return { ok: false, error: `Az érték legalább ${def.min} lehet.` }
+    if (def.max !== undefined && n > def.max) return { ok: false, error: `Az érték legfeljebb ${def.max} lehet.` }
     return { ok: true, value: n }
   }
 
   if (def.type === 'color') {
     const str = String(raw)
-    if (!HEX_COLOR_RE.test(str)) return { ok: false, error: 'Ervenytelen szin (varhato formatum: #rrggbb).' }
+    if (!HEX_COLOR_RE.test(str)) return { ok: false, error: 'Érvénytelen szín (várható formátum: #rrggbb).' }
     return { ok: true, value: str }
   }
 

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -1,0 +1,163 @@
+// Single source of truth for settings the dashboard's "Beallitasok" page can
+// show and edit. Each entry describes one .env-backed config key: its type
+// (drives the input widget + validation), default, human description, the
+// module it belongs to (drives UI grouping), whether it is secret (drives
+// API redaction), and whether changing it needs a process restart to take
+// effect (drives the UI warning badge).
+//
+// v1 scope is intentionally narrow: the 9 Kanban WIP keys. Extending this
+// array is how a future setting becomes editable from the UI -- no route or
+// frontend change needed beyond what already reads the registry.
+
+export type SettingType = 'int' | 'string' | 'color'
+
+export interface SettingDefinition {
+  key: string
+  type: SettingType
+  default: string | number
+  description: string
+  module: string
+  secret: boolean
+  requiresRestart: boolean
+  /** Optional fixed set of allowed values (enum-style settings). */
+  valueSet?: string[]
+  /** Inclusive bounds, only meaningful for type 'int'. */
+  min?: number
+  max?: number
+}
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/
+
+export const SETTINGS_REGISTRY: SettingDefinition[] = [
+  {
+    key: 'KANBAN_WIP_PLANNED',
+    type: 'int',
+    default: 0,
+    min: 0,
+    description: 'A "planned" oszlop WIP-limitje (max. kartyaszam). 0 = korlatlan.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
+  {
+    key: 'KANBAN_WIP_IN_PROGRESS',
+    type: 'int',
+    default: 0,
+    min: 0,
+    description: 'Az "in_progress" oszlop WIP-limitje (max. kartyaszam). 0 = korlatlan.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
+  {
+    key: 'KANBAN_WIP_WAITING',
+    type: 'int',
+    default: 0,
+    min: 0,
+    description: 'A "waiting" oszlop WIP-limitje (max. kartyaszam). 0 = korlatlan.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
+  {
+    key: 'KANBAN_WIP_DONE',
+    type: 'int',
+    default: 0,
+    min: 0,
+    description: 'A "done" oszlop WIP-limitje (max. kartyaszam). 0 = korlatlan.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
+  {
+    key: 'KANBAN_WIP_WARN_PCT',
+    type: 'int',
+    default: 80,
+    min: 1,
+    max: 100,
+    description: 'Kihasznaltsagi szazalek, amely felett a WIP-badge sargara vaalt. 0 nem ertelmes (azonnali figyelmeztetes), ezert tiltott.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
+  {
+    key: 'KANBAN_WIP_OK_COLOR',
+    type: 'color',
+    default: '#6b7280',
+    description: 'A WIP-badge szine, amikor az oszlop kihasznaltsaga a figyelmeztetesi kuszob alatt van.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
+  {
+    key: 'KANBAN_WIP_WARN_COLOR',
+    type: 'color',
+    default: '#c9a000',
+    description: 'A WIP-badge szine a figyelmeztetesi kuszob (WARN_PCT) felett, limit elott.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
+  {
+    key: 'KANBAN_WIP_FULL_COLOR',
+    type: 'color',
+    default: '#d46b00',
+    description: 'A WIP-badge szine, amikor az oszlop pontosan a limiten all.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
+  {
+    key: 'KANBAN_WIP_OVER_COLOR',
+    type: 'color',
+    default: '#c53030',
+    description: 'A WIP-badge szine, amikor az oszlop tullepte a limitet.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
+]
+
+export function getSettingDefinition(key: string): SettingDefinition | undefined {
+  return SETTINGS_REGISTRY.find((s) => s.key === key)
+}
+
+export function listSettingModules(): string[] {
+  return [...new Set(SETTINGS_REGISTRY.map((s) => s.module))]
+}
+
+export interface SettingValidationResult {
+  ok: boolean
+  error?: string
+  /** Normalised value (e.g. parsed int) to persist when ok === true. */
+  value?: string | number
+}
+
+// Pure validation against a single registry entry. No I/O, no DB -- callers
+// (the /api/settings route, tests) decide what happens with the result.
+export function validateSettingValue(def: SettingDefinition, raw: unknown): SettingValidationResult {
+  if (def.valueSet && def.valueSet.length > 0) {
+    const str = String(raw)
+    if (!def.valueSet.includes(str)) {
+      return { ok: false, error: `Ervenytelen ertek. Megengedett: ${def.valueSet.join(', ')}` }
+    }
+    return { ok: true, value: str }
+  }
+
+  if (def.type === 'int') {
+    const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10)
+    if (!Number.isInteger(n)) return { ok: false, error: 'Egesz szam szukseges.' }
+    if (def.min !== undefined && n < def.min) return { ok: false, error: `Az ertek legalabb ${def.min} lehet.` }
+    if (def.max !== undefined && n > def.max) return { ok: false, error: `Az ertek legfeljebb ${def.max} lehet.` }
+    return { ok: true, value: n }
+  }
+
+  if (def.type === 'color') {
+    const str = String(raw)
+    if (!HEX_COLOR_RE.test(str)) return { ok: false, error: 'Ervenytelen szin (varhato formatum: #rrggbb).' }
+    return { ok: true, value: str }
+  }
+
+  // 'string'
+  return { ok: true, value: String(raw) }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,13 @@ export const KANBAN_AGING_WARN_COLOR = env['KANBAN_AGING_WARN_COLOR'] ?? '#c9a00
 export const KANBAN_AGING_CAUTION_COLOR = env['KANBAN_AGING_CAUTION_COLOR'] ?? '#d46b00'
 export const KANBAN_AGING_CRITICAL_COLOR = env['KANBAN_AGING_CRITICAL_COLOR'] ?? '#c53030'
 // Kanban WIP limits per column (0 = unlimited). Override via .env.
+// NOTE: these constants are frozen at process start (this module reads .env
+// once at import time). The dashboard's Settings page and the /api/marveen
+// kanbanWip payload do NOT read these directly anymore -- they resolve
+// through settings-store.ts (config-overrides.json > .env > registry
+// default) so a value saved in the UI takes effect without a restart. These
+// exports stay as the documented .env-only defaults / for any other code
+// that genuinely wants the boot-time value.
 export const KANBAN_WIP_PLANNED = parseInt(env['KANBAN_WIP_PLANNED'] ?? '0', 10)
 export const KANBAN_WIP_IN_PROGRESS = parseInt(env['KANBAN_WIP_IN_PROGRESS'] ?? '0', 10)
 export const KANBAN_WIP_WAITING = parseInt(env['KANBAN_WIP_WAITING'] ?? '0', 10)

--- a/src/db.ts
+++ b/src/db.ts
@@ -1858,6 +1858,8 @@ export interface ConfigChangeLogRow {
 }
 
 export function getRecentConfigChanges(limit = 200): ConfigChangeLogRow[] {
-  return db.prepare('SELECT * FROM config_change_log ORDER BY created_at DESC LIMIT ?').all(limit) as ConfigChangeLogRow[]
+  // id DESC as a tiebreaker: created_at has 1-second resolution, so two
+  // saves in the same second would otherwise sort arbitrarily.
+  return db.prepare('SELECT * FROM config_change_log ORDER BY created_at DESC, id DESC LIMIT ?').all(limit) as ConfigChangeLogRow[]
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -509,6 +509,22 @@ export function initDatabase(dbPathOverride?: string): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_session ON tool_call_log(session_id, created_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_ts ON tool_call_log(created_at)`)
 
+  // --- Config Change Log (audit trail for /api/settings writes) ---
+  // Background-only: no UI surfaces this table yet (product decision). For
+  // secret settings, callers must pass null for old_value/new_value -- this
+  // table only ever holds plaintext for non-secret registry entries.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS config_change_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      key TEXT NOT NULL,
+      old_value TEXT,
+      new_value TEXT,
+      actor TEXT NOT NULL DEFAULT 'unknown',
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_config_change_log_key ON config_change_log(key, created_at)`)
+
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
   // re-importing. Wrapped in a transaction so a crash mid-import is safe.
@@ -1814,5 +1830,34 @@ export function analyzeWorkflowCandidates(sinceSecs = 3600, minToolCalls = 5, ga
 export function pruneToolCallLog(olderThanSecs = 86400): void {
   const cutoff = Math.floor(Date.now() / 1000) - olderThanSecs
   db.prepare('DELETE FROM tool_call_log WHERE created_at < ?').run(cutoff)
+}
+
+// --- Config Change Log ---
+// Pass null for oldValue/newValue when the registry entry is secret:true --
+// this keeps secret values out of the audit trail entirely rather than
+// relying on a UI to not display them.
+export function logConfigChange(
+  key: string,
+  oldValue: string | number | null,
+  newValue: string | number | null,
+  actor: string,
+): void {
+  const now = Math.floor(Date.now() / 1000)
+  db.prepare(
+    'INSERT INTO config_change_log (key, old_value, new_value, actor, created_at) VALUES (?, ?, ?, ?, ?)',
+  ).run(key, oldValue === null ? null : String(oldValue), newValue === null ? null : String(newValue), actor, now)
+}
+
+export interface ConfigChangeLogRow {
+  id: number
+  key: string
+  old_value: string | null
+  new_value: string | null
+  actor: string
+  created_at: number
+}
+
+export function getRecentConfigChanges(limit = 200): ConfigChangeLogRow[] {
+  return db.prepare('SELECT * FROM config_change_log ORDER BY created_at DESC LIMIT ?').all(limit) as ConfigChangeLogRow[]
 }
 

--- a/src/settings-store.ts
+++ b/src/settings-store.ts
@@ -1,0 +1,103 @@
+import { existsSync, mkdirSync, readFileSync, watch, type FSWatcher } from 'node:fs'
+import { join } from 'node:path'
+import { STORE_DIR } from './config.js'
+import { readEnvFile } from './env.js'
+import { atomicWriteFileSync } from './web/atomic-write.js'
+import { getSettingDefinition, validateSettingValue, type SettingDefinition } from './config-registry.js'
+
+// Writable override layer for registry-backed settings. Resolution order for
+// any registered key is: config-overrides.json > .env > registry default.
+// Writes are atomic (tmp file + rename, via atomicWriteFileSync) so a crash
+// mid-write can never leave a half-written or zero-byte overrides file. A
+// directory watch keeps the in-memory cache in sync if the file is edited
+// outside this process (e.g. by hand over SSH); our own writes update the
+// cache directly without waiting for the watch event.
+export const OVERRIDES_PATH = join(STORE_DIR, 'config-overrides.json')
+
+let cache: Record<string, string | number> = {}
+let watcher: FSWatcher | undefined
+
+function loadFromDisk(): Record<string, string | number> {
+  try {
+    if (!existsSync(OVERRIDES_PATH)) return {}
+    const raw = readFileSync(OVERRIDES_PATH, 'utf-8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed
+    return {}
+  } catch {
+    return {}
+  }
+}
+
+cache = loadFromDisk()
+
+// Lazily start the directory watch on first use rather than at import time,
+// so importing this module in a test (no STORE_DIR yet) does not throw.
+function ensureWatching(): void {
+  if (watcher) return
+  try {
+    mkdirSync(STORE_DIR, { recursive: true })
+    watcher = watch(STORE_DIR, { persistent: false }, (_event, filename) => {
+      if (filename === 'config-overrides.json') cache = loadFromDisk()
+    })
+  } catch {
+    // Best-effort: if the platform/FS doesn't support watching the
+    // directory, the cache simply stays as of the last read/write from this
+    // process -- still correct for the common single-process case.
+  }
+}
+
+export function getOverrides(): Record<string, string | number> {
+  ensureWatching()
+  return { ...cache }
+}
+
+function coerce(def: SettingDefinition, raw: string | number): string | number {
+  if (def.type === 'int') return typeof raw === 'number' ? raw : parseInt(raw, 10)
+  return String(raw)
+}
+
+// Resolves the effective value for a registered key: override > .env >
+// registry default. Reads .env fresh (cheap, scoped to one key) rather than
+// relying on the boot-time config.ts constants, so this resolution stays
+// correct independent of when the process last restarted.
+export function getEffectiveSettingValue(key: string): string | number {
+  ensureWatching()
+  const def = getSettingDefinition(key)
+  if (!def) throw new Error(`Unknown setting key: ${key}`)
+  if (key in cache) return coerce(def, cache[key])
+  const envValue = readEnvFile([key])[key]
+  if (envValue !== undefined) return coerce(def, envValue)
+  return def.default
+}
+
+export interface SetOverrideResult {
+  ok: boolean
+  error?: string
+}
+
+// Validates against the registry, then atomically persists the whole
+// overrides file and updates the in-memory cache. Validation happens before
+// any disk write, so an invalid value never reaches the file -- combined
+// with the atomic write, a failure at any point leaves the previous state
+// fully intact (no partial save).
+export function setOverride(key: string, rawValue: unknown): SetOverrideResult {
+  const def = getSettingDefinition(key)
+  if (!def) return { ok: false, error: `Ismeretlen kulcs: ${key}` }
+
+  const validation = validateSettingValue(def, rawValue)
+  if (!validation.ok) return { ok: false, error: validation.error }
+
+  ensureWatching()
+  mkdirSync(STORE_DIR, { recursive: true })
+  const next = { ...loadFromDisk(), [key]: validation.value! }
+  atomicWriteFileSync(OVERRIDES_PATH, JSON.stringify(next, null, 2))
+  cache = next
+  return { ok: true }
+}
+
+// Test-only escape hatch: forces the in-memory cache back to whatever is
+// currently on disk (or empty if absent), bypassing the watch debounce.
+export function reloadOverridesForTest(): void {
+  cache = loadFromDisk()
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -48,6 +48,7 @@ import { tryHandleAutonomy } from './web/routes/autonomy.js'
 import { tryHandleTokenUsage } from './web/routes/token-usage.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
+import { tryHandleSettings } from './web/routes/settings.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import type { RouteContext } from './web/routes/types.js'
 
@@ -163,6 +164,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleTokenUsage(routeCtx)) return
       if (await tryHandleIdeas(routeCtx)) return
       if (await tryHandleToolLog(routeCtx)) return
+      if (await tryHandleSettings(routeCtx)) return
       if (await tryHandleStatic(routeCtx, WEB_DIR)) return
 
       res.writeHead(404)

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -4,11 +4,10 @@ import {
   PROJECT_ROOT, OWNER_NAME, BOT_NAME, BRAND_NAME, MAIN_AGENT_ID, CHANNEL_PROVIDER,
   KANBAN_AGING_WARN_H, KANBAN_AGING_CAUTION_H, KANBAN_AGING_CRITICAL_H,
   KANBAN_AGING_WARN_COLOR, KANBAN_AGING_CAUTION_COLOR, KANBAN_AGING_CRITICAL_COLOR,
-  KANBAN_WIP_PLANNED, KANBAN_WIP_IN_PROGRESS, KANBAN_WIP_WAITING, KANBAN_WIP_DONE,
-  KANBAN_WIP_WARN_PCT, KANBAN_WIP_OK_COLOR, KANBAN_WIP_WARN_COLOR, KANBAN_WIP_FULL_COLOR, KANBAN_WIP_OVER_COLOR,
   KANBAN_SWIMLANE_DEFAULT_GROUP, KANBAN_SWIMLANE_SEPARATOR_COLOR,
   KANBAN_LABEL_COLORS,
 } from '../../config.js'
+import { getEffectiveSettingValue } from '../../settings-store.js'
 import { readMarveenTelegramConfig, readMarveenDiscordConfig, readMarveenSlackConfig, sendMarveenAvatarChange } from '../telegram.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
 import { readFileOr } from '../agent-config.js'
@@ -102,18 +101,22 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
         cautionColor: KANBAN_AGING_CAUTION_COLOR,
         criticalColor: KANBAN_AGING_CRITICAL_COLOR,
       },
+      // Resolved through the settings overrides layer (override > .env >
+      // registry default) instead of the boot-time config.ts constants, so a
+      // value saved on the Settings page takes effect immediately -- no
+      // process restart needed for these 9 keys.
       kanbanWip: {
         limits: {
-          planned: KANBAN_WIP_PLANNED,
-          in_progress: KANBAN_WIP_IN_PROGRESS,
-          waiting: KANBAN_WIP_WAITING,
-          done: KANBAN_WIP_DONE,
+          planned: getEffectiveSettingValue('KANBAN_WIP_PLANNED'),
+          in_progress: getEffectiveSettingValue('KANBAN_WIP_IN_PROGRESS'),
+          waiting: getEffectiveSettingValue('KANBAN_WIP_WAITING'),
+          done: getEffectiveSettingValue('KANBAN_WIP_DONE'),
         },
-        warnPct: KANBAN_WIP_WARN_PCT,
-        okColor: KANBAN_WIP_OK_COLOR,
-        warnColor: KANBAN_WIP_WARN_COLOR,
-        fullColor: KANBAN_WIP_FULL_COLOR,
-        overColor: KANBAN_WIP_OVER_COLOR,
+        warnPct: getEffectiveSettingValue('KANBAN_WIP_WARN_PCT'),
+        okColor: getEffectiveSettingValue('KANBAN_WIP_OK_COLOR'),
+        warnColor: getEffectiveSettingValue('KANBAN_WIP_WARN_COLOR'),
+        fullColor: getEffectiveSettingValue('KANBAN_WIP_FULL_COLOR'),
+        overColor: getEffectiveSettingValue('KANBAN_WIP_OVER_COLOR'),
       },
       kanbanSwimlanes: {
         defaultGroup: KANBAN_SWIMLANE_DEFAULT_GROUP,

--- a/src/web/routes/settings.ts
+++ b/src/web/routes/settings.ts
@@ -1,0 +1,80 @@
+import { readBody, json } from '../http-helpers.js'
+import { logger } from '../../logger.js'
+import { SETTINGS_REGISTRY, validateSettingValue } from '../../config-registry.js'
+import { getEffectiveSettingValue, setOverride } from '../../settings-store.js'
+import { logConfigChange } from '../../db.js'
+import type { RouteContext } from './types.js'
+
+export async function tryHandleSettings(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  if (path === '/api/settings' && method === 'GET') {
+    // secret:true entries are filtered out entirely -- not just the value,
+    // the whole row -- per spec: a secret's existence is exposed elsewhere
+    // (the vault page), not duplicated here.
+    const settings = SETTINGS_REGISTRY.filter((def) => !def.secret).map((def) => ({
+      key: def.key,
+      type: def.type,
+      value: getEffectiveSettingValue(def.key),
+      default: def.default,
+      description: def.description,
+      module: def.module,
+      requiresRestart: def.requiresRestart,
+      valueSet: def.valueSet,
+      min: def.min,
+      max: def.max,
+    }))
+    json(res, { settings })
+    return true
+  }
+
+  if (path === '/api/settings' && method === 'POST') {
+    try {
+      const body = await readBody(req)
+      const { key, value, actor } = JSON.parse(body.toString())
+
+      if (!key || typeof key !== 'string') {
+        json(res, { error: 'Missing or invalid "key"' }, 400)
+        return true
+      }
+
+      const def = SETTINGS_REGISTRY.find((s) => s.key === key)
+      if (!def) {
+        json(res, { error: `Unknown setting key: ${key}` }, 404)
+        return true
+      }
+      if (def.secret) {
+        // Defensive: v1 has no secret entries, but a future registry entry
+        // marked secret must never be settable through this generic route.
+        json(res, { error: 'Secret settings cannot be changed via this endpoint' }, 403)
+        return true
+      }
+
+      // Validate before touching anything. setOverride re-validates
+      // internally too, but checking here lets us read the "old" value for
+      // the change log without assuming the write will succeed.
+      const validation = validateSettingValue(def, value)
+      if (!validation.ok) {
+        json(res, { error: validation.error }, 400)
+        return true
+      }
+
+      const oldValue = getEffectiveSettingValue(key)
+      const result = setOverride(key, value)
+      if (!result.ok) {
+        json(res, { error: result.error }, 400)
+        return true
+      }
+
+      logConfigChange(key, oldValue, validation.value!, typeof actor === 'string' && actor ? actor : 'dashboard')
+      logger.info({ key, oldValue, newValue: validation.value }, 'Setting updated')
+      json(res, { ok: true, key, value: validation.value, requiresRestart: def.requiresRestart })
+    } catch (err) {
+      logger.error({ err }, 'Failed to update setting')
+      json(res, { error: 'Failed to update setting' }, 500)
+    }
+    return true
+  }
+
+  return false
+}

--- a/web/app.js
+++ b/web/app.js
@@ -100,6 +100,7 @@ function switchPage(pageId) {
   if (pageId === 'bgTasks') loadBgTasksPage()
   if (pageId === 'vault') loadVaultPage()
   if (pageId === 'autonomy') loadAutonomy()
+  if (pageId === 'settings') loadSettings()
   if (pageId === 'updates') loadUpdates()
   if (pageId === 'team') { loadTeamGraph() }
   if (pageId === 'messages') loadMessagesPage()
@@ -9352,6 +9353,166 @@ async function setAutonomyLevel(key, level) {
     loadAutonomy()
   } catch {
     showToast('Hiba a mentésnél')
+  }
+}
+
+// ============================================================
+// === Settings (central config registry) ===
+// ============================================================
+
+document.getElementById('refreshSettingsBtn').addEventListener('click', loadSettings)
+
+// Human label for a registry "module" -- falls back to a capitalised key for
+// any future module the UI doesn't know about yet, so adding a registry
+// entry never requires a frontend change just to render a sane heading.
+const SETTINGS_MODULE_LABELS = { kanban: 'Kanban' }
+function settingsModuleLabel(mod) {
+  return SETTINGS_MODULE_LABELS[mod] || (mod.charAt(0).toUpperCase() + mod.slice(1))
+}
+
+async function loadSettings() {
+  const container = document.getElementById('settingsGroups')
+  container.innerHTML = '<p style="color:var(--text-muted);font-size:13px">Betöltés...</p>'
+
+  try {
+    const res = await fetch('/api/settings')
+    if (!res.ok) throw new Error('fetch failed')
+    const { settings } = await res.json()
+
+    const byModule = new Map()
+    for (const s of settings) {
+      if (!byModule.has(s.module)) byModule.set(s.module, [])
+      byModule.get(s.module).push(s)
+    }
+
+    container.innerHTML = ''
+    if (byModule.size === 0) {
+      container.innerHTML = '<p style="color:var(--text-muted);font-size:13px">Nincs regisztrált beállítás.</p>'
+      return
+    }
+
+    for (const [mod, defs] of byModule) {
+      const group = document.createElement('div')
+      group.className = 'settings-group'
+
+      const heading = document.createElement('h3')
+      heading.className = 'settings-group-title'
+      heading.textContent = settingsModuleLabel(mod)
+      group.appendChild(heading)
+
+      for (const def of defs) {
+        group.appendChild(buildSettingRow(def))
+      }
+      container.appendChild(group)
+    }
+  } catch (err) {
+    container.innerHTML = '<p style="color:var(--danger)">Nem sikerült betölteni a beállításokat.</p>'
+  }
+}
+
+function buildSettingRow(def) {
+  const row = document.createElement('div')
+  row.className = 'settings-row'
+
+  const info = document.createElement('div')
+  info.className = 'settings-row-info'
+
+  const title = document.createElement('div')
+  title.className = 'settings-row-key'
+  title.textContent = def.key
+  if (def.requiresRestart) {
+    const badge = document.createElement('span')
+    badge.className = 'settings-restart-badge'
+    badge.textContent = 'Újraindítást igényel'
+    title.appendChild(badge)
+  }
+  info.appendChild(title)
+
+  const desc = document.createElement('div')
+  desc.className = 'settings-row-desc'
+  desc.textContent = def.description
+  info.appendChild(desc)
+
+  const meta = document.createElement('div')
+  meta.className = 'settings-row-meta'
+  const metaParts = []
+  if (Array.isArray(def.valueSet) && def.valueSet.length) metaParts.push('Lehetséges értékek: ' + def.valueSet.join(', '))
+  if (def.type === 'int' && (def.min !== undefined || def.max !== undefined)) {
+    metaParts.push('Tartomány: ' + (def.min ?? '–') + '–' + (def.max ?? '–'))
+  }
+  if (def.type === 'color') metaParts.push('Formátum: #rrggbb')
+  metaParts.push('Alapérték: ' + def.default)
+  meta.textContent = metaParts.join(' · ')
+  info.appendChild(meta)
+
+  row.appendChild(info)
+
+  const editor = document.createElement('div')
+  editor.className = 'settings-row-editor'
+
+  let valueInput
+  if (Array.isArray(def.valueSet) && def.valueSet.length) {
+    valueInput = document.createElement('select')
+    valueInput.className = 'input'
+    for (const opt of def.valueSet) {
+      const o = document.createElement('option')
+      o.value = opt
+      o.textContent = opt
+      valueInput.appendChild(o)
+    }
+    valueInput.value = String(def.value)
+  } else if (def.type === 'color') {
+    valueInput = document.createElement('input')
+    valueInput.type = 'color'
+    valueInput.className = 'settings-color-input'
+    valueInput.value = def.value
+  } else if (def.type === 'int') {
+    valueInput = document.createElement('input')
+    valueInput.type = 'number'
+    valueInput.className = 'input'
+    if (def.min !== undefined) valueInput.min = def.min
+    if (def.max !== undefined) valueInput.max = def.max
+    valueInput.value = def.value
+  } else {
+    valueInput = document.createElement('input')
+    valueInput.type = 'text'
+    valueInput.className = 'input'
+    valueInput.value = def.value
+  }
+  editor.appendChild(valueInput)
+
+  const saveBtn = document.createElement('button')
+  saveBtn.className = 'btn-primary btn-compact'
+  saveBtn.textContent = 'Mentés'
+  editor.appendChild(saveBtn)
+
+  const errorEl = document.createElement('div')
+  errorEl.className = 'settings-row-error'
+  editor.appendChild(errorEl)
+
+  saveBtn.addEventListener('click', () => saveSetting(def.key, valueInput, errorEl, def.type))
+
+  row.appendChild(editor)
+  return row
+}
+
+async function saveSetting(key, inputEl, errorEl, type) {
+  errorEl.textContent = ''
+  const raw = type === 'int' ? Number(inputEl.value) : inputEl.value
+  try {
+    const res = await fetch('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key, value: raw }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      errorEl.textContent = data.error || 'Hiba a mentésnél'
+      return
+    }
+    showToast(data.requiresRestart ? 'Mentve -- újraindítás szükséges az életbe lépéshez' : 'Mentve')
+  } catch {
+    errorEl.textContent = 'Hiba a mentésnél (kapcsolat)'
   }
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -299,15 +299,16 @@ document.querySelectorAll('.kanban-add-btn').forEach((btn) => {
 
 async function loadKanban() {
   try {
-    // Ensure the marveen config (kanbanAging + kanbanWip + kanbanSwimlanes) is
-    // loaded even if the user opens the Kanban page first, before the Agents
-    // page populated it.
-    if (!window._marveen?.kanbanAging || !window._marveen?.kanbanWip || !window._marveen?.kanbanSwimlanes || !window._marveen?.kanbanLabels) {
-      try {
-        const mr = await fetch('/api/marveen')
-        if (mr.ok) window._marveen = { ...(window._marveen || {}), ...(await mr.json()) }
-      } catch { /* ignore -- aging/WIP/swimlanes just won't render until _marveen loads */ }
-    }
+    // Always refresh the marveen config so values changed on the Settings page
+    // (e.g. WIP limits) show up on the board on the next Kanban open, without a
+    // hard reload. The full /api/marveen payload includes kanbanAging, kanbanWip,
+    // kanbanSwimlanes and kanbanLabels, so the labels (from the labels feature)
+    // stay populated too. Also covers opening the Kanban page first, before the
+    // Agents page populated window._marveen.
+    try {
+      const mr = await fetch('/api/marveen')
+      if (mr.ok) window._marveen = { ...(window._marveen || {}), ...(await mr.json()) }
+    } catch { /* ignore -- aging/WIP/swimlanes/labels just won't render until _marveen loads */ }
     if (!kanbanGroupByInitialized) {
       kanbanGroupByInitialized = true
       // A user's own past choice (saved to localStorage) wins over the

--- a/web/app.js
+++ b/web/app.js
@@ -600,6 +600,10 @@ function renderKanban() {
     }
     // Badge: only count subtasks that are in a different column (not embedded here)
     updateSubtaskBadges(embeddedSubtaskIds)
+    // WIP limit badges (count/limit + colour) on the flat board too -- previously
+    // only the swimlane view updated these, so a configured limit never showed
+    // on the default flat board.
+    updateWipBadges(grouped)
   } else {
     flatBoard.hidden = true
     swimlaneBoard.hidden = false

--- a/web/index.html
+++ b/web/index.html
@@ -96,6 +96,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
         <span class="sb-label">Autonómia</span>
       </a>
+      <a href="#" class="sb-link" data-page="settings">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+        <span class="sb-label">Beállítások</span>
+      </a>
       <a href="#" class="sb-link" data-page="vault">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/><circle cx="12" cy="16" r="1"/></svg>
         <span class="sb-label">Vault</span>
@@ -873,6 +877,26 @@
 
       <div class="autonomy-grid" id="autonomyGrid"></div>
       <p class="autonomy-footer" id="autonomyUpdatedAt"></p>
+    </div>
+
+    <!-- === Settings Page === -->
+    <div class="page" id="settingsPage" hidden>
+      <div class="page-header">
+        <div class="page-header-row">
+          <div>
+            <h1>Beállítások</h1>
+            <p class="subtitle">Központi konfiguráció -- modulonként csoportosítva</p>
+          </div>
+          <button class="btn-secondary btn-compact" id="refreshSettingsBtn">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+            </svg>
+            Frissítés
+          </button>
+        </div>
+      </div>
+
+      <div id="settingsGroups"></div>
     </div>
 
     <!-- === Ötletláda Page === -->

--- a/web/style.css
+++ b/web/style.css
@@ -5143,6 +5143,85 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
   color: var(--text-muted);
 }
 
+/* === Settings page === */
+.settings-group { margin-bottom: 28px; }
+.settings-group:last-child { margin-bottom: 0; }
+.settings-group-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  margin: 0 0 10px;
+}
+.settings-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 8px;
+  transition: border-color var(--transition);
+}
+.settings-row:hover { border-color: var(--accent); }
+.settings-row-info { flex: 1; min-width: 240px; }
+.settings-row-key {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  font-family: var(--font-mono, monospace);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.settings-restart-badge {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--warning, #c9a000);
+  border: 1px solid var(--warning, #c9a000);
+  border-radius: 4px;
+  padding: 1px 6px;
+  white-space: nowrap;
+}
+.settings-row-desc {
+  font-size: 13px;
+  color: var(--text);
+  margin-top: 4px;
+}
+.settings-row-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+.settings-row-editor {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.settings-row-editor .input {
+  width: 140px;
+  font-size: 13px;
+}
+.settings-color-input {
+  width: 44px;
+  height: 32px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-input);
+  cursor: pointer;
+}
+.settings-row-error {
+  font-size: 12px;
+  color: var(--danger);
+  flex-basis: 100%;
+}
+
 /* === connectors.hu cross-promo banner === */
 .cxhu-banner {
   margin-bottom: 16px;

--- a/web/style.css
+++ b/web/style.css
@@ -5200,6 +5200,8 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
 .settings-row-editor {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 8px;
   flex-shrink: 0;
 }
@@ -5208,7 +5210,7 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
   font-size: 13px;
 }
 .settings-color-input {
-  width: 44px;
+  width: 72px;
   height: 32px;
   padding: 2px;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary

Adds a central Settings page to the dashboard for managing the .env-backed configuration through the UI, plus the supporting backend.

A static config registry (config-registry.ts) is the single source of truth for each editable key: type, default, description, module, secret flag, restart-required flag, and value range. The v1 scope is the 9 Kanban WIP keys. A writable overrides layer (config-overrides.json) sits over .env (priority: overrides > .env > default), with atomic writes and hot-reload, so non-process settings take effect without a restart.

The Settings page lists settings grouped by module, each with description, value range, default, an editable field (number with min/max, colour picker, or select), and a per-row Save. Saves are validated against the registry; invalid values are rejected inline and the previous value is kept (rollback). Secrets are never returned by the API. Every successful change is recorded in a background change log (who/when/old to new; secret values masked) without a UI for now. The config-overrides.json is included in the backup/migration package so settings travel to a new machine.

## Config (.env)

The 9 Kanban WIP keys (KANBAN_WIP_PLANNED/IN_PROGRESS/WAITING/DONE, KANBAN_WIP_WARN_PCT, KANBAN_WIP_*_COLOR) are now editable from the page; the registry is how future keys become editable with no route/frontend change.

## Files

- src/config-registry.ts, src/settings-store.ts, src/web/routes/settings.ts, src/web.ts, src/db.ts, src/config.ts, src/web/routes/marveen.ts
- web/app.js, web/index.html, web/style.css
- docs/config-reference.md, docs/en/config-reference.md (technical + user-facing, HU+EN)
- scripts/backup.sh (migration packaging)
- tests: config-registry, settings-store, config-change-log

This change was authored with AI assistance, reviewed by @cett  before submission.

## Test plan

- [ ] Edit a WIP key on the Settings page; value persists and shows on the kanban board on next open
- [ ] Invalid value (out of range / bad colour) is rejected inline, old value kept
- [ ] Each save is recorded in config_change_log (secret values masked)
- [ ] config-overrides.json is part of the backup/migration package
- [ ] Full suite green (1312 tests), tsc clean