### PR TITLE
feat(notify): prefix the sender agent name on non-main notifications

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -13,6 +13,8 @@ fi
 
 TOKEN=$(grep '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" | cut -d= -f2-)
 CHAT_ID=$(grep '^ALLOWED_CHAT_ID=' "$ENV_FILE" | cut -d= -f2-)
+MAIN_AGENT_ID=$(grep '^MAIN_AGENT_ID=' "$ENV_FILE" | head -1 | cut -d= -f2-)
+MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"
 
 if [ -z "$TOKEN" ]; then
   echo "Hiba: TELEGRAM_BOT_TOKEN nincs beallitva"
@@ -28,6 +30,33 @@ MESSAGE="$1"
 if [ -z "$MESSAGE" ]; then
   echo "Hasznalat: $0 \"uzenet\""
   exit 1
+fi
+
+# Sender attribution: notify.sh always uses the main bot token, so without this
+# every notification reads as the main bot. Detect the calling agent from the
+# tmux session name and prefix the message when it is NOT the main agent, so the
+# reader can see who it came from. Distribution-safe: the main agent id is read
+# from .env (default marveen), no hardcoded names.
+SENDER=""
+SESS=$(tmux display-message -p '#S' 2>/dev/null)
+case "$SESS" in
+  agent-*)
+    SENDER="${SESS#agent-}"
+    ;;
+  "${MAIN_AGENT_ID}-channels"|"${MAIN_AGENT_ID}-worker")
+    SENDER="$MAIN_AGENT_ID"
+    ;;
+  *)
+    SENDER=""
+    ;;
+esac
+
+if [ -n "$SENDER" ] && [ "$SENDER" != "$MAIN_AGENT_ID" ]; then
+  # Capitalize the first letter (bash 3.2 portable -- no ${var^}).
+  _first=$(printf '%s' "${SENDER%"${SENDER#?}"}" | tr '[:lower:]' '[:upper:]')
+  SENDER_CAP="${_first}${SENDER#?}"
+  MESSAGE="🤖 ${SENDER_CAP}:
+${MESSAGE}"
 fi
 
 curl -s -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \


### PR DESCRIPTION
`notify.sh` always uses the main bot token, so every notification reads as the main bot (MarveenBot) regardless of which agent actually sent it. This adds sender attribution.

### Behaviour
- Detect the caller from the tmux session name:
  - `agent-<name>` -> `<name>`
  - `<main>-channels` / `<main>-worker` -> the main agent
- If the sender is **not** the main agent, prefix the message with `🤖 <Name>:` (capitalized).
- If the sender **is** the main agent, or the session is undetectable (no tmux), **no prefix** — it is the main bot anyway.

### Distribution-safe (no hardcode)
- Main agent id is read from `.env` `MAIN_AGENT_ID` (default `marveen`); no hardcoded agent names.
- `bash 3.2` portable (no `${var^}`).
- Backward-compatible: arg 1 is still the message; no caller changes, no interface break.

### Verified
- `bash -n` clean.
- Unit-tested the detection + capitalization across `agent-samu/zara/boni` (→ `🤖 Samu:` …), `marveen-channels`, `marveen-worker`, empty, and a random session name — only non-main agents get the prefix.

### Out of scope (flagged separately by Marveen, not this PR)
A few scheduled tasks / napi-szamla-feldolgozas hardcode `chat_id 1268077055`; those should move to a `CHANNEL_CHAT_ID` placeholder per the distribution-hardcode rule, in a later round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)