### PR TITLE
feat(dashboard): lapozás a beszélgetés-nézetben (korábbiak betöltése)

### DIFF
--- a/src/web/routes/agent-conversation.ts
+++ b/src/web/routes/agent-conversation.ts
@@ -74,7 +74,7 @@ function actionLabel(name: string, input: Record<string, unknown>): string {
 }
 
 // Turn the newest transcript into a flat, chronological, readable timeline.
-function buildTimeline(file: string, limit: number): Entry[] {
+function buildTimeline(file: string): Entry[] {
   const entries: Entry[] = []
   const raw = readFileSync(file, 'utf-8').split('\n')
   for (const line of raw) {
@@ -131,8 +131,8 @@ function buildTimeline(file: string, limit: number): Entry[] {
       continue
     }
   }
-  // Keep the most recent `limit` entries, oldest-first.
-  return entries.length > limit ? entries.slice(entries.length - limit) : entries
+  // The full timeline, oldest-first; the route windows it for pagination.
+  return entries
 }
 
 export async function tryHandleAgentConversation(ctx: RouteContext): Promise<boolean> {
@@ -140,14 +140,32 @@ export async function tryHandleAgentConversation(ctx: RouteContext): Promise<boo
   const match = path.match(/^\/api\/agents\/([^/]+)\/conversation$/)
   if (!match || method !== 'GET') return false
   const name = decodeURIComponent(match[1])
+  // Pagination: `limit` is the page size, `offset` is how many of the NEWEST
+  // entries to skip. offset=0 is the latest page; the UI pages further back
+  // (offset += limit) to load older history beyond the on-screen window -- and
+  // beyond the old fixed cap, since the whole transcript is now reachable.
   const limitRaw = Number(url.searchParams.get('limit'))
   const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 2000) : DEFAULT_LIMIT
+  const offsetRaw = Number(url.searchParams.get('offset'))
+  const offset = Number.isFinite(offsetRaw) && offsetRaw > 0 ? Math.floor(offsetRaw) : 0
 
   const file = newestTranscript(name)
-  if (!file) { json(res, { agent: name, entries: [], note: 'Nincs még beszélgetés-előzmény ehhez az agenthez.' }); return true }
+  if (!file) { json(res, { agent: name, entries: [], total: 0, offset: 0, hasOlder: false, note: 'Nincs még beszélgetés-előzmény ehhez az agenthez.' }); return true }
   try {
-    const entries = buildTimeline(file, limit)
-    json(res, { agent: name, sessionId: file.split('/').pop()?.replace('.jsonl', '') ?? null, count: entries.length, entries })
+    const all = buildTimeline(file)
+    const total = all.length
+    const end = Math.max(0, total - offset)
+    const start = Math.max(0, end - limit)
+    const entries = all.slice(start, end)
+    json(res, {
+      agent: name,
+      sessionId: file.split('/').pop()?.replace('.jsonl', '') ?? null,
+      total,
+      offset,
+      hasOlder: start > 0,
+      count: entries.length,
+      entries,
+    })
   } catch {
     json(res, { error: 'A beszélgetés feldolgozása nem sikerült' }, 500)
   }

--- a/web/app.js
+++ b/web/app.js
@@ -10857,8 +10857,11 @@ document.getElementById('terminalClose')?.addEventListener('click', () => {
 // Telegram messages, the agent's replies, and (optionally) its notes/actions.
 // Solves what the raw terminal can't: a readable, searchable review of what
 // actually happened -- also the support view for customer-hosted Marveens.
+const CONVERSATION_PAGE_SIZE = 400
 let conversationEntries = []
 let conversationAgentName = null
+let conversationHasOlder = false
+let conversationLoadingOlder = false
 
 async function openConversationModal(agentName, displayName) {
   const overlay = document.getElementById('conversationOverlay')
@@ -10872,18 +10875,51 @@ async function openConversationModal(agentName, displayName) {
   await loadConversation()
 }
 
+// Latest page (offset=0); resets the loaded window.
 async function loadConversation() {
   const container = document.getElementById('conversationContainer')
   const token = localStorage.getItem('marveen-dashboard-token') || ''
   try {
-    const r = await fetch(`/api/agents/${encodeURIComponent(conversationAgentName)}/conversation?limit=600`, {
+    const r = await fetch(`/api/agents/${encodeURIComponent(conversationAgentName)}/conversation?limit=${CONVERSATION_PAGE_SIZE}&offset=0`, {
       headers: { 'Authorization': 'Bearer ' + token },
     })
     const d = await r.json()
     conversationEntries = Array.isArray(d.entries) ? d.entries : []
+    conversationHasOlder = !!d.hasOlder
     renderConversation()
   } catch {
     if (container) container.innerHTML = '<div class="conversation-empty">Nem sikerült betölteni a beszélgetést.</div>'
+  }
+}
+
+// Page further back: fetch the window of entries immediately before the oldest
+// loaded one and PREPEND it, keeping the scroll position so the view does not
+// jump. Lets the operator read history beyond the on-screen window (and beyond
+// the old fixed cap).
+async function loadOlderConversation() {
+  if (conversationLoadingOlder || !conversationHasOlder) return
+  conversationLoadingOlder = true
+  const btn = document.getElementById('conversationLoadOlder')
+  if (btn) { btn.disabled = true; btn.textContent = 'Betöltés…' }
+  const token = localStorage.getItem('marveen-dashboard-token') || ''
+  try {
+    const offset = conversationEntries.length
+    const r = await fetch(`/api/agents/${encodeURIComponent(conversationAgentName)}/conversation?limit=${CONVERSATION_PAGE_SIZE}&offset=${offset}`, {
+      headers: { 'Authorization': 'Bearer ' + token },
+    })
+    const d = await r.json()
+    const older = Array.isArray(d.entries) ? d.entries : []
+    conversationHasOlder = !!d.hasOlder
+    if (older.length) {
+      conversationEntries = older.concat(conversationEntries)
+      renderConversation({ preserveScroll: true })
+    } else {
+      renderConversation()
+    }
+  } catch {
+    if (btn) { btn.disabled = false; btn.textContent = 'Korábbiak betöltése' }
+  } finally {
+    conversationLoadingOlder = false
   }
 }
 
@@ -10894,17 +10930,33 @@ function fmtConvTs(ts) {
   } catch { return '' }
 }
 
-function renderConversation() {
+function renderConversation(opts = {}) {
   const container = document.getElementById('conversationContainer')
   if (!container) return
+  const prevH = container.scrollHeight
+  const prevTop = container.scrollTop
   const q = (document.getElementById('conversationSearch')?.value || '').toLowerCase().trim()
   const showActions = document.getElementById('conversationShowActions')?.checked
   let list = conversationEntries
   if (!showActions) list = list.filter(e => e.kind === 'in' || e.kind === 'out')
   if (q) list = list.filter(e => (e.text || '').toLowerCase().includes(q))
-  if (!list.length) { container.innerHTML = '<div class="conversation-empty">Nincs megjeleníthető üzenet.</div>'; return }
-  container.innerHTML = list.map(renderConvEntry).join('')
-  container.scrollTop = container.scrollHeight
+  // "Korábbiak betöltése" sits at the top so the operator can page further back;
+  // shown whenever the server still has older entries beyond the loaded window.
+  const olderBtn = conversationHasOlder
+    ? '<button id="conversationLoadOlder" class="conv-load-older">Korábbiak betöltése</button>'
+    : ''
+  if (!list.length) {
+    container.innerHTML = olderBtn || '<div class="conversation-empty">Nincs megjeleníthető üzenet.</div>'
+  } else {
+    container.innerHTML = olderBtn + list.map(renderConvEntry).join('')
+  }
+  document.getElementById('conversationLoadOlder')?.addEventListener('click', loadOlderConversation)
+  if (opts.preserveScroll) {
+    // After prepending older messages, keep the previously-visible ones in place.
+    container.scrollTop = prevTop + (container.scrollHeight - prevH)
+  } else {
+    container.scrollTop = container.scrollHeight
+  }
 }
 
 function renderConvEntry(e) {

--- a/web/style.css
+++ b/web/style.css
@@ -5832,6 +5832,19 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
 .conversation-filter { display: flex; align-items: center; gap: 5px; font-size: 12px; opacity: .85; white-space: nowrap; }
 .conversation-container { flex: 1; overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 8px; background: #141414; border-radius: 0 0 8px 8px; min-height: 320px; }
 .conversation-empty { opacity: .6; text-align: center; padding: 30px; }
+.conv-load-older {
+  display: block;
+  margin: 0 auto 10px;
+  padding: 6px 16px;
+  background: var(--bg);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.conv-load-older:hover:not(:disabled) { color: var(--accent); border-color: var(--accent); }
+.conv-load-older:disabled { opacity: .5; cursor: default; }
 .conv-row { display: flex; }
 .conv-row.conv-in { justify-content: flex-start; }
 .conv-row.conv-out { justify-content: flex-end; }


### PR DESCRIPTION
## Mit old meg

Az ügynök **Beszélgetés**-nézete (`/api/agents/:id/conversation`) eddig csak az utolsó N (max 2000) bejegyzést adta vissza, és nem lehetett tovább lapozni visszafele. Hosszabb beszélgetéseknél a régebbi rész nem volt elérhető a dashboardról.

## Változás

**Backend** (`src/web/routes/agent-conversation.ts`)
- A `buildTimeline` mostantól a **teljes** idővonalat adja vissza (a záró `slice` a route-ba került).
- A route új `offset` query-paramot kap (hány legújabb bejegyzést hagyjon ki), és visszaadja a `total` + `hasOlder` mezőket. `offset=0` a legfrissebb oldal; `offset += limit` lapoz visszafele. A `limit` default 400, max 2000 (változatlan).
- **Backward-kompatibilis:** `offset` nélkül a viselkedés a régivel azonos (legfrissebb oldal).

**Frontend** (`web/app.js`, `web/style.css`)
- A beszélgetés-modal tetején **„Korábbiak betöltése"** gomb, ami a régebbi ablakot **elé fűzi**, a **scroll-pozíció megtartásával** (a nézet nem ugrik).
- A gomb csak akkor látszik, ha a szerver szerint van még régebbi bejegyzés (`hasOlder`).

Így a session **teljes előzménye** elérhető — a korábbi 2000-es plafon fölött is.

## Megjegyzés
- A parse-logika változatlan, csak az ablakozás került a route-ba → alacsony kockázat.
- A **Terminál**-nézet (élő tmux-pane, `capture-pane -S -2000`) nem érintett — az külön mechanizmus.

## Teszt
- `tsc --noEmit` tiszta, `node --check web/app.js` OK.
- Ablakozás-matek ellenőrizve: 1000 bejegyzés → 400 + 400 + 200 (minden elérhető); `< limit` méretű transcript → mind egy oldalon, gomb nélkül.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
