### PR TITLE
Feat/naplo unified Napló (audit log) page -- config change-log, idea status, store files, event log

### DIFF
--- a/docs/en/naplo-audit.md
+++ b/docs/en/naplo-audit.md
@@ -6,16 +6,17 @@ The dashboard "Napló" (Audit Log) page provides a unified, read-only view of sy
 
 ## Using the audit log
 
-Open the page from the "Napló" entry in the left-hand navigation.
+Open the page from the "Napló" entry in the left-hand navigation. This is the single Napló page -- the former separate Recall view has been merged into it.
 
 **Source tabs**
 
-Four tabs at the top of the page filter the event stream:
+Five tabs at the top of the page filter the event stream:
 
 - All -- all sources merged in a single chronological timeline
+- Event log -- general events logged by agents and the system
 - Config -- changes made through the Settings page (e.g. `KANBAN_WIP_IN_PROGRESS` changed from 5 to 8, who changed it, when); secret values are never recorded
 - Ideas -- idea-box status transitions (e.g. `new` -> `kanban` on promotion, or reversal back to `new`); the note field shows the promotion path or reversal reason
-- Store files -- file writes, renames, and deletes inside the `store/` directory; sensitive files (e.g. `vault.json`, `.dashboard-token`) are labelled "sensitív"
+- Store files -- file creation events for files created by agents; Marveen's own system files are excluded; where determinable, the creating agent's name is shown (may be empty for direct tool writes)
 
 Clicking a tab filters the list immediately -- no page reload needed.
 
@@ -137,7 +138,7 @@ Deletion is performed by `pruneAuditLogs()`, called from `runDecaySweep()` which
 
 The "Napló" entry in the left-hand navigation opens the page.
 
-**Source tabs**: Összes (All) / Config / Ötletláda (Ideas) / Store-fájlok (Store Files) -- clicking a tab filters immediately.
+**Source tabs**: All / Event log / Config / Ideas / Store files -- clicking a tab filters immediately.
 
 **Date range**: "From" / "To" date inputs; both optional. When both are empty, all entries up to `limit` are returned.
 

--- a/docs/en/naplo-audit.md
+++ b/docs/en/naplo-audit.md
@@ -1,0 +1,120 @@
+# Audit Log (Napló)
+
+The dashboard "Napló" (Audit Log) page provides a unified, read-only view of system-auditable events: settings changes, idea-box status transitions, and store-directory file events.
+
+---
+
+## Data Sources
+
+### Config change log (`config_change_log`)
+
+Every successful `POST /api/settings` request writes an audit row to this table. For secret settings (`secret: true`), `old_value` and `new_value` are stored as `null` -- the fact of the change is recorded, but the value never is.
+
+Fields: `key`, `old_value`, `new_value`, `actor`, `created_at`
+
+### Idea-box audit (`idea_status_log`)
+
+Every idea status transition (e.g. `new` -> `kanban`, or reversal back to `new`) is recorded. The `promote-breakdown` path also generates a row.
+
+Fields: `idea_id`, `from_status`, `to_status`, `actor`, `note`, `created_at`
+
+### Store file audit (`store_file_audit`)
+
+On startup the server attaches an `fs.watch()` listener to the `store/` directory. Every `change` and `rename` event (file write, rename, delete) is recorded. File content is never stored -- only the path, event type, and file size (if determinable at the time of the event).
+
+Sensitive files (`.dashboard-token`, `vault.json`, `.vault-key`) receive `is_sensitive=1`; the UI labels them "sensitív".
+
+Automatically excluded: atomic-write temp files (`.tmp.<hex>`), `.migrated` and `.bak` suffixed files.
+
+Fields: `rel_path`, `event_type`, `is_sensitive`, `file_size`, `created_at`
+
+---
+
+## API
+
+### `GET /api/audit-log`
+
+Bearer token required.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source` | string | Comma-separated source filter: `config`, `idea`, `store`. Empty = all. |
+| `from` | int | Unix timestamp, inclusive lower bound. |
+| `to` | int | Unix timestamp, inclusive upper bound. |
+| `q` | string | Free-text search (key, path, note, actor, etc.). |
+| `limit` | int | Maximum entries (default: 200, max: `AUDIT_LOG_MAX_ENTRIES`). |
+
+Response:
+```json
+{
+  "entries": [
+    {
+      "id": 1,
+      "source": "config",
+      "created_at": 1718000000,
+      "key": "KANBAN_WIP_IN_PROGRESS",
+      "old_value": "5",
+      "new_value": "8",
+      "actor": "dashboard"
+    },
+    {
+      "id": 2,
+      "source": "idea",
+      "created_at": 1718000100,
+      "idea_id": "abc123",
+      "from_status": "new",
+      "to_status": "kanban",
+      "actor": "jarvis",
+      "note": "promote:planning"
+    },
+    {
+      "id": 3,
+      "source": "store",
+      "created_at": 1718000200,
+      "rel_path": "config-overrides.json",
+      "event_type": "change",
+      "is_sensitive": 0,
+      "file_size": 512
+    }
+  ],
+  "total": 3
+}
+```
+
+Results are sorted `created_at DESC`; the merged order is source-agnostic.
+
+---
+
+## Configuration
+
+The following keys (Settings page, Audit module) control log behaviour:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `AUDIT_LOG_RETENTION_DAYS` | 90 | Entries older than this many days are deleted during the daily sweep. |
+| `AUDIT_LOG_MAX_ENTRIES` | 10 000 | Maximum entries the API returns per request. |
+
+Deletion is performed by `pruneAuditLogs()`, called from `runDecaySweep()` which runs on a 24-hour cycle.
+
+---
+
+## Dashboard UI
+
+The "Napló" entry in the left-hand navigation opens the page.
+
+**Source tabs**: Összes (All) / Config / Ötletláda (Ideas) / Store-fájlok (Store Files) -- clicking a tab filters immediately.
+
+**Date range**: "From" / "To" date inputs; both optional. When both are empty, all entries up to `limit` are returned.
+
+**Search field**: free-text filter mapped to the `q` parameter (key, rel_path, note, actor, etc.).
+
+**Refresh button**: manually re-fetches with the current filter state.
+
+The page is read-only: entries cannot be edited, and are only deleted by the automatic retention sweep.
+
+---
+
+## Related Documents
+
+- [Settings System](config-reference.md#settings-system)
+- [Idea Box](ideabox.md)

--- a/docs/en/naplo-audit.md
+++ b/docs/en/naplo-audit.md
@@ -4,6 +4,41 @@ The dashboard "Napló" (Audit Log) page provides a unified, read-only view of sy
 
 ---
 
+## Using the audit log
+
+Open the page from the "Napló" entry in the left-hand navigation.
+
+**Source tabs**
+
+Four tabs at the top of the page filter the event stream:
+
+- All -- all sources merged in a single chronological timeline
+- Config -- changes made through the Settings page (e.g. `KANBAN_WIP_IN_PROGRESS` changed from 5 to 8, who changed it, when); secret values are never recorded
+- Ideas -- idea-box status transitions (e.g. `new` -> `kanban` on promotion, or reversal back to `new`); the note field shows the promotion path or reversal reason
+- Store files -- file writes, renames, and deletes inside the `store/` directory; sensitive files (e.g. `vault.json`, `.dashboard-token`) are labelled "sensitív"
+
+Clicking a tab filters the list immediately -- no page reload needed.
+
+**Date range**
+
+The "From" and "To" date inputs narrow the time window. Both are optional: leave them empty to see all available entries (up to the retention limit). Filling in only one input applies an open-ended filter in that direction.
+
+**Search**
+
+Text typed in the search field is matched against the key, path, note, and actor fields across all sources at once. For example, search for a specific settings key (`KANBAN_WIP_PLANNED`), an idea identifier, or a file name (`config-overrides.json`).
+
+**Refresh**
+
+The Refresh button re-fetches with the current filter state -- useful when watching live system activity.
+
+**Key things to know**
+
+- The page is read-only: entries cannot be edited or manually deleted
+- Entries are automatically pruned when they exceed the `AUDIT_LOG_RETENTION_DAYS` threshold (default: 90 days) -- adjustable on the Settings page
+- Secret settings (e.g. API tokens) are never written to the log; only the fact that a change occurred is recorded
+
+---
+
 ## Data Sources
 
 ### Config change log (`config_change_log`)

--- a/docs/naplo-audit.md
+++ b/docs/naplo-audit.md
@@ -4,6 +4,41 @@ A dashboard "Napló" oldala egységes, csak-olvasható nézetben jeleníti meg a
 
 ---
 
+## Használat
+
+A bal oldali navigációban a "Napló" menüpont nyitja meg az oldalt.
+
+**Forrás-fülek**
+
+Az oldal tetején négy fül szűri az eseményeket:
+
+- Összes -- minden forrás egységes időrendben
+- Config -- a Beállítások oldalon eszközölt módosítások (pl. `KANBAN_WIP_IN_PROGRESS` 5-ről 8-ra, ki változtatta, mikor)
+- Ötletláda -- ötlet-státuszváltások (pl. `new` -> `kanban` promóció, vagy visszavonás); titkos értékek sosem jelennek meg
+- Store-fájlok -- a `store/` könyvtárban bekövetkező fájlírások, átnevezések, törlések; az érzékeny fájlok (pl. `vault.json`, `.dashboard-token`) "sensitív" felirattal vannak jelölve
+
+A fülre kattintva az oldal azonnal az adott forrás eseményeit mutatja.
+
+**Dátumszűrő**
+
+Az "Ettől" és "Eddig" mezőkkel szűkítheted az időablakot. Mindkettő opcionális: ha üresen hagyod, az összes elérhető bejegyzés megjelenik (a retention-határig). A mezők bármelyikét kitöltve a másik irányban nyitott szűrés érvényesül.
+
+**Keresés**
+
+A keresőmezőbe begépelt szöveg a bejegyzések kulcs-, útvonal-, megjegyzés- és actor-mezőiben keres egyszerre. Például rákereshetsz egy konkrét beállítás-kulcsra (`KANBAN_WIP_PLANNED`), egy ötlet azonosítójára, vagy egy fájlnévre (`config-overrides.json`).
+
+**Frissítés**
+
+A "Frissítés" gombra kattintva az oldal az aktuális szűrési feltételekkel újratölti az adatokat -- hasznos, ha élőben figyeled a rendszer aktivitását.
+
+**Fontos tudnivalók**
+
+- Az oldal csak-olvasható: bejegyzést szerkeszteni vagy manuálisan törölni nem lehet
+- A bejegyzések automatikusan törlődnek az `AUDIT_LOG_RETENTION_DAYS` küszöb (alapértelmezés: 90 nap) elérésekor -- ez a Beállítások oldalon módosítható
+- Titkos beállítások (pl. API tokenek) értéke soha nem kerül a naplóba, csak a módosítás ténye
+
+---
+
 ## Adatforrások
 
 ### Config change-log (`config_change_log`)

--- a/docs/naplo-audit.md
+++ b/docs/naplo-audit.md
@@ -1,0 +1,120 @@
+# Napló - Audit Idővonal
+
+A dashboard "Napló" oldala egységes, csak-olvasható nézetben jeleníti meg a rendszer auditálható eseményeit: beállítás-változások, ötletláda státuszváltások és store-könyvtár fájlesemények.
+
+---
+
+## Adatforrások
+
+### Config change-log (`config_change_log`)
+
+Minden sikeres `POST /api/settings` kérés audit-sort ír ebbe a táblába. Titkos beállítás (`secret: true`) esetén az `old_value` és `new_value` mező `null` -- a tény rögzítve van, de az érték soha nem.
+
+Mezők: `key`, `old_value`, `new_value`, `actor`, `created_at`
+
+### Ötletláda-audit (`idea_status_log`)
+
+Minden ötlet-státuszváltáskor (pl. `new` -> `kanban`, `kanban` -> `new` visszavonáskor) a rendszer beírja a változást. A `promote-breakdown` ágon is keletkezik bejegyzés.
+
+Mezők: `idea_id`, `from_status`, `to_status`, `actor`, `note`, `created_at`
+
+### Store-fájl audit (`store_file_audit`)
+
+Induláskor a szerver `fs.watch()` figyelőt indít a `store/` könyvtárra. Minden `change` és `rename` esemény (fájl írás, átnevezés, törlés) rögzítődik. Tartalom soha nem kerül a táblába -- csak az útvonal, az esemény típusa és a fájlméret (ha meghatározható).
+
+Érzékeny fájlok (`.dashboard-token`, `vault.json`, `.vault-key`) az `is_sensitive=1` jelzőt kapják; a UI "sensitív" felirattal jelzi őket.
+
+Automatikusan kizárt fájlok: atomi írás temp-fájljai (`.tmp.<hex>`), `.migrated` és `.bak` utótagú fájlok.
+
+Mezők: `rel_path`, `event_type`, `is_sensitive`, `file_size`, `created_at`
+
+---
+
+## API
+
+### `GET /api/audit-log`
+
+Bearer tokennel védett.
+
+| Paraméter | Típus | Leírás |
+|-----------|-------|--------|
+| `source` | string | Vesszővel elválasztott forrásszűrő: `config`, `idea`, `store`. Üres = mind. |
+| `from` | int | Unix timestamp, ettől (inclusive). |
+| `to` | int | Unix timestamp, eddig (inclusive). |
+| `q` | string | Szabadszavas keresés (kulcs, útvonal, note stb.). |
+| `limit` | int | Maximum bejegyzésszám (alapérték: 200, max: `AUDIT_LOG_MAX_ENTRIES`). |
+
+Válasz:
+```json
+{
+  "entries": [
+    {
+      "id": 1,
+      "source": "config",
+      "created_at": 1718000000,
+      "key": "KANBAN_WIP_IN_PROGRESS",
+      "old_value": "5",
+      "new_value": "8",
+      "actor": "dashboard"
+    },
+    {
+      "id": 2,
+      "source": "idea",
+      "created_at": 1718000100,
+      "idea_id": "abc123",
+      "from_status": "new",
+      "to_status": "kanban",
+      "actor": "jarvis",
+      "note": "promote:planning"
+    },
+    {
+      "id": 3,
+      "source": "store",
+      "created_at": 1718000200,
+      "rel_path": "config-overrides.json",
+      "event_type": "change",
+      "is_sensitive": 0,
+      "file_size": 512
+    }
+  ],
+  "total": 3
+}
+```
+
+Az eredmények `created_at DESC` sorrendben érkeznek; a mergelt sorrend forrás-független.
+
+---
+
+## Konfiguráció
+
+Az alábbi kulcsok a Settings oldalon (Audit modul) szabályozzák a napló viselkedését:
+
+| Kulcs | Alapérték | Leírás |
+|-------|-----------|--------|
+| `AUDIT_LOG_RETENTION_DAYS` | 90 | Ennyi napnál régebbi bejegyzések törlődnek a napi sweep során. |
+| `AUDIT_LOG_MAX_ENTRIES` | 10 000 | Az API legfeljebb ennyi bejegyzést ad vissza egy kérésenként. |
+
+A törlés a `runDecaySweep()` függvényből hívott `pruneAuditLogs()` függvényen keresztül történik, amely naponta egyszer fut (24 órás ciklus).
+
+---
+
+## Dashboard UI
+
+A bal oldali navigációban a "Napló" menüpont nyitja meg az oldalt.
+
+**Forrás-fülek**: Összes / Config / Ötletláda / Store-fájlok -- a kiválasztott fülre kattintva azonnal szűr.
+
+**Dátumszűrő**: "Ettől" -- "Eddig" dátummező; mindkettő opcionális. Ha mindkettő üres, az összes bejegyzés megjelenik (a `limit` értékéig).
+
+**Keresőmező**: a `q` paraméternek megfelelő szabad szöveges szűrés (key, rel_path, note, actor stb.).
+
+**Frissítés gomb**: manuálisan újratölti az aktuális szűrési feltételekkel.
+
+Az oldal csak-olvasható: szerkeszteni nem lehet, törölni csak az automatikus sweep által.
+
+---
+
+## Kapcsolódó dokumentumok
+
+- [Beállítások rendszer](config-reference.md#beallitasok-rendszer-settings)
+- [Ötletláda](ideabox.md)

--- a/docs/naplo-audit.md
+++ b/docs/naplo-audit.md
@@ -6,16 +6,17 @@ A dashboard "Napló" oldala egységes, csak-olvasható nézetben jeleníti meg a
 
 ## Használat
 
-A bal oldali navigációban a "Napló" menüpont nyitja meg az oldalt.
+A bal oldali navigációban a "Napló" menüpont nyitja meg az oldalt. Ez az egyetlen Napló oldal -- a korábbi különálló Recall nézet beolvadt ide.
 
 **Forrás-fülek**
 
-Az oldal tetején négy fül szűri az eseményeket:
+Az oldal tetején öt fül szűri az eseményeket:
 
 - Összes -- minden forrás egységes időrendben
-- Config -- a Beállítások oldalon eszközölt módosítások (pl. `KANBAN_WIP_IN_PROGRESS` 5-ről 8-ra, ki változtatta, mikor)
-- Ötletláda -- ötlet-státuszváltások (pl. `new` -> `kanban` promóció, vagy visszavonás); titkos értékek sosem jelennek meg
-- Store-fájlok -- a `store/` könyvtárban bekövetkező fájlírások, átnevezések, törlések; az érzékeny fájlok (pl. `vault.json`, `.dashboard-token`) "sensitív" felirattal vannak jelölve
+- Eseménynapló -- az ágensek és a rendszer által naplózott általános események
+- Config -- a Beállítások oldalon eszközölt módosítások (pl. `KANBAN_WIP_IN_PROGRESS` 5-ről 8-ra, ki változtatta, mikor); titkos értékek sosem jelennek meg
+- Ötletláda -- ötlet-státuszváltások (pl. `new` -> `kanban` promóció, vagy visszavonás)
+- Store-fájlok -- az ágensek által létrehozott fájlok létrejöttének eseményei; a Marveen saját rendszerfájljai nem szerepelnek itt; ahol meghatározható, a fájlt létrehozó ágens neve is megjelenik (közvetlen tool-írásnál ez üres lehet)
 
 A fülre kattintva az oldal azonnal az adott forrás eseményeit mutatja.
 
@@ -137,7 +138,7 @@ A törlés a `runDecaySweep()` függvényből hívott `pruneAuditLogs()` függv�
 
 A bal oldali navigációban a "Napló" menüpont nyitja meg az oldalt.
 
-**Forrás-fülek**: Összes / Config / Ötletláda / Store-fájlok -- a kiválasztott fülre kattintva azonnal szűr.
+**Forrás-fülek**: Összes / Eseménynapló / Config / Ötletláda / Store-fájlok -- a kiválasztott fülre kattintva azonnal szűr.
 
 **Dátumszűrő**: "Ettől" -- "Eddig" dátummező; mindkettő opcionális. Ha mindkettő üres, az összes bejegyzés megjelenik (a `limit` értékéig).
 

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -287,6 +287,29 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: false,
     requiresRestart: false,
   },
+  // --- Audit log module ---
+  {
+    key: 'AUDIT_LOG_RETENTION_DAYS',
+    type: 'int',
+    default: 90,
+    min: 1,
+    max: 3650,
+    description: 'Az audit napló (config-változások, ötletláda-audit, store-fájl események) megőrzési ideje napokban. Régebbi bejegyzések a napi sweepkor törlődnek.',
+    module: 'audit',
+    secret: false,
+    requiresRestart: false,
+  },
+  {
+    key: 'AUDIT_LOG_MAX_ENTRIES',
+    type: 'int',
+    default: 10000,
+    min: 100,
+    max: 1000000,
+    description: 'Az audit napló összes forrásra vetített maximális bejegyzésszáma. Az API lekérések ennél soha nem adnak vissza többet (forrásanként egyéni limit: AUDIT_LOG_MAX_ENTRIES / 3).',
+    module: 'audit',
+    secret: false,
+    requiresRestart: false,
+  },
 ]
 
 export function getSettingDefinition(key: string): SettingDefinition | undefined {

--- a/src/db.ts
+++ b/src/db.ts
@@ -2078,11 +2078,12 @@ export function queryAuditLog(opts: {
   }
 
   if (active.includes('store')) {
-    let sql = 'SELECT id, rel_path, event_type, is_sensitive, file_size, created_at FROM store_file_audit WHERE 1=1'
+    let sql = 'SELECT id, rel_path, event_type, is_sensitive, file_size, agent, created_at FROM store_file_audit WHERE 1=1'
     const params: unknown[] = []
     if (from) { sql += ' AND created_at >= ?'; params.push(from) }
     if (to)   { sql += ' AND created_at <= ?'; params.push(to) }
-    if (q)    { sql += ' AND rel_path LIKE ?'; const p = `%${q}%`; params.push(p) }
+    if (agent) { sql += ' AND agent = ?'; params.push(agent) }
+    if (q)    { sql += ' AND (rel_path LIKE ? OR agent LIKE ?)'; const p = `%${q}%`; params.push(p, p) }
     sql += ' ORDER BY created_at DESC, id DESC LIMIT ?'; params.push(limit)
     const rows = db.prepare(sql).all(...params) as StoreFileAuditRow[]
     for (const r of rows) parts.push({ ...r, source: 'store' })

--- a/src/db.ts
+++ b/src/db.ts
@@ -567,10 +567,13 @@ export function initDatabase(dbPathOverride?: string): void {
       event_type TEXT NOT NULL,
       is_sensitive INTEGER NOT NULL DEFAULT 0,
       file_size INTEGER,
+      agent TEXT,
       created_at INTEGER NOT NULL
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_store_file_audit_ts ON store_file_audit(created_at)`)
+  // Migration: add agent column to installs that created the table before this column existed.
+  try { db.exec(`ALTER TABLE store_file_audit ADD COLUMN agent TEXT`) } catch { /* column already exists */ }
 
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
@@ -1986,6 +1989,7 @@ export interface StoreFileAuditRow {
   event_type: string
   is_sensitive: number
   file_size: number | null
+  agent: string | null
   created_at: number
 }
 
@@ -1994,11 +1998,12 @@ export function logStoreFileEvent(
   eventType: string,
   isSensitive: number,
   fileSize: number | null,
+  agent: string | null = null,
 ): void {
   const now = Math.floor(Date.now() / 1000)
   db.prepare(
-    'INSERT INTO store_file_audit (rel_path, event_type, is_sensitive, file_size, created_at) VALUES (?, ?, ?, ?, ?)',
-  ).run(relPath, eventType, isSensitive, fileSize, now)
+    'INSERT INTO store_file_audit (rel_path, event_type, is_sensitive, file_size, agent, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(relPath, eventType, isSensitive, fileSize, agent, now)
 }
 
 export function getRecentStoreFileEvents(limit = 200): StoreFileAuditRow[] {
@@ -2007,7 +2012,7 @@ export function getRecentStoreFileEvents(limit = 200): StoreFileAuditRow[] {
 
 // --- Unified Audit Log Query ---
 
-export type AuditSource = 'config' | 'idea' | 'store'
+export type AuditSource = 'config' | 'idea' | 'store' | 'diary'
 
 export interface AuditLogEntry {
   id: number
@@ -2028,6 +2033,12 @@ export interface AuditLogEntry {
   event_type?: string
   is_sensitive?: number
   file_size?: number | null
+  // diary (daily_logs + memories)
+  agent_id?: string
+  content?: string
+  category?: string
+  keywords?: string
+  entry_type?: 'log' | 'memory'
 }
 
 export function queryAuditLog(opts: {
@@ -2035,10 +2046,11 @@ export function queryAuditLog(opts: {
   from?: number
   to?: number
   q?: string
+  agent?: string
   limit: number
 }): AuditLogEntry[] {
-  const { sources, from, to, q, limit } = opts
-  const all: AuditSource[] = ['config', 'idea', 'store']
+  const { sources, from, to, q, agent, limit } = opts
+  const all: AuditSource[] = ['config', 'idea', 'store', 'diary']
   const active = sources.length > 0 ? sources : all
 
   const parts: AuditLogEntry[] = []
@@ -2074,6 +2086,30 @@ export function queryAuditLog(opts: {
     sql += ' ORDER BY created_at DESC, id DESC LIMIT ?'; params.push(limit)
     const rows = db.prepare(sql).all(...params) as StoreFileAuditRow[]
     for (const r of rows) parts.push({ ...r, source: 'store' })
+  }
+
+  if (active.includes('diary')) {
+    // daily_logs
+    let logSql = 'SELECT id, agent_id, content, created_at FROM daily_logs WHERE 1=1'
+    const logParams: unknown[] = []
+    if (from)  { logSql += ' AND created_at >= ?'; logParams.push(from) }
+    if (to)    { logSql += ' AND created_at <= ?'; logParams.push(to) }
+    if (agent) { logSql += ' AND agent_id = ?'; logParams.push(agent) }
+    if (q)     { logSql += ' AND content LIKE ?'; logParams.push(`%${q}%`) }
+    logSql += ' ORDER BY created_at DESC, id DESC LIMIT ?'; logParams.push(limit)
+    const logRows = db.prepare(logSql).all(...logParams) as Array<{ id: number; agent_id: string; content: string; created_at: number }>
+    for (const r of logRows) parts.push({ id: r.id, source: 'diary', created_at: r.created_at, agent_id: r.agent_id, content: r.content, entry_type: 'log' })
+
+    // memories
+    let memSql = 'SELECT id, agent_id, content, category, keywords, created_at FROM memories WHERE 1=1'
+    const memParams: unknown[] = []
+    if (from)  { memSql += ' AND created_at >= ?'; memParams.push(from) }
+    if (to)    { memSql += ' AND created_at <= ?'; memParams.push(to) }
+    if (agent) { memSql += ' AND agent_id = ?'; memParams.push(agent) }
+    if (q)     { memSql += ' AND (content LIKE ? OR keywords LIKE ?)'; memParams.push(`%${q}%`, `%${q}%`) }
+    memSql += ' ORDER BY created_at DESC, id DESC LIMIT ?'; memParams.push(limit)
+    const memRows = db.prepare(memSql).all(...memParams) as Array<{ id: number; agent_id: string; content: string; category: string; keywords: string | null; created_at: number }>
+    for (const r of memRows) parts.push({ id: r.id, source: 'diary', created_at: r.created_at, agent_id: r.agent_id, content: r.content, category: r.category, keywords: r.keywords ?? undefined, entry_type: 'memory' })
   }
 
   // Merge and sort by created_at DESC, then id DESC as tiebreaker

--- a/src/db.ts
+++ b/src/db.ts
@@ -2081,3 +2081,13 @@ export function queryAuditLog(opts: {
   return parts.slice(0, limit)
 }
 
+// Prune all three audit tables to AUDIT_LOG_RETENTION_DAYS. Called from the
+// daily decay sweep so old entries do not accumulate indefinitely.
+export function pruneAuditLogs(): void {
+  const retentionDays = Number(getEffectiveSettingValue('AUDIT_LOG_RETENTION_DAYS'))
+  const cutoff = Math.floor(Date.now() / 1000) - retentionDays * 86400
+  db.prepare('DELETE FROM config_change_log WHERE created_at < ?').run(cutoff)
+  db.prepare('DELETE FROM idea_status_log WHERE created_at < ?').run(cutoff)
+  db.prepare('DELETE FROM store_file_audit WHERE created_at < ?').run(cutoff)
+}
+

--- a/src/db.ts
+++ b/src/db.ts
@@ -555,6 +555,23 @@ export function initDatabase(dbPathOverride?: string): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_config_change_log_key ON config_change_log(key, created_at)`)
 
+  // --- Store File Audit (fs-watch events on store/) ---
+  // Records every write/rename in the store/ directory. Content is NEVER
+  // stored -- only path, event type and file size. Sensitive files
+  // (.dashboard-token, vault.json, .vault-key) are flagged so the UI can
+  // render them without leaking values.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS store_file_audit (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      rel_path TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      is_sensitive INTEGER NOT NULL DEFAULT 0,
+      file_size INTEGER,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_store_file_audit_ts ON store_file_audit(created_at)`)
+
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
   // re-importing. Wrapped in a transaction so a crash mid-import is safe.
@@ -1959,5 +1976,108 @@ export function getRecentConfigChanges(limit = 200): ConfigChangeLogRow[] {
   // id DESC as a tiebreaker: created_at has 1-second resolution, so two
   // saves in the same second would otherwise sort arbitrarily.
   return db.prepare('SELECT * FROM config_change_log ORDER BY created_at DESC, id DESC LIMIT ?').all(limit) as ConfigChangeLogRow[]
+}
+
+// --- Store File Audit ---
+
+export interface StoreFileAuditRow {
+  id: number
+  rel_path: string
+  event_type: string
+  is_sensitive: number
+  file_size: number | null
+  created_at: number
+}
+
+export function logStoreFileEvent(
+  relPath: string,
+  eventType: string,
+  isSensitive: number,
+  fileSize: number | null,
+): void {
+  const now = Math.floor(Date.now() / 1000)
+  db.prepare(
+    'INSERT INTO store_file_audit (rel_path, event_type, is_sensitive, file_size, created_at) VALUES (?, ?, ?, ?, ?)',
+  ).run(relPath, eventType, isSensitive, fileSize, now)
+}
+
+export function getRecentStoreFileEvents(limit = 200): StoreFileAuditRow[] {
+  return db.prepare('SELECT * FROM store_file_audit ORDER BY created_at DESC, id DESC LIMIT ?').all(limit) as StoreFileAuditRow[]
+}
+
+// --- Unified Audit Log Query ---
+
+export type AuditSource = 'config' | 'idea' | 'store'
+
+export interface AuditLogEntry {
+  id: number
+  source: AuditSource
+  created_at: number
+  actor?: string
+  // config
+  key?: string
+  old_value?: string | null
+  new_value?: string | null
+  // idea
+  idea_id?: string
+  from_status?: string | null
+  to_status?: string
+  note?: string | null
+  // store
+  rel_path?: string
+  event_type?: string
+  is_sensitive?: number
+  file_size?: number | null
+}
+
+export function queryAuditLog(opts: {
+  sources: AuditSource[]
+  from?: number
+  to?: number
+  q?: string
+  limit: number
+}): AuditLogEntry[] {
+  const { sources, from, to, q, limit } = opts
+  const all: AuditSource[] = ['config', 'idea', 'store']
+  const active = sources.length > 0 ? sources : all
+
+  const parts: AuditLogEntry[] = []
+
+  if (active.includes('config')) {
+    let sql = 'SELECT id, key, old_value, new_value, actor, created_at FROM config_change_log WHERE 1=1'
+    const params: unknown[] = []
+    if (from) { sql += ' AND created_at >= ?'; params.push(from) }
+    if (to)   { sql += ' AND created_at <= ?'; params.push(to) }
+    if (q)    { sql += ' AND (key LIKE ? OR old_value LIKE ? OR new_value LIKE ? OR actor LIKE ?)'; const p = `%${q}%`; params.push(p, p, p, p) }
+    sql += ' ORDER BY created_at DESC, id DESC LIMIT ?'; params.push(limit)
+    const rows = db.prepare(sql).all(...params) as ConfigChangeLogRow[]
+    for (const r of rows) parts.push({ ...r, source: 'config' })
+  }
+
+  if (active.includes('idea')) {
+    let sql = 'SELECT id, idea_id, from_status, to_status, actor, note, created_at FROM idea_status_log WHERE 1=1'
+    const params: unknown[] = []
+    if (from) { sql += ' AND created_at >= ?'; params.push(from) }
+    if (to)   { sql += ' AND created_at <= ?'; params.push(to) }
+    if (q)    { sql += ' AND (idea_id LIKE ? OR to_status LIKE ? OR note LIKE ? OR actor LIKE ?)'; const p = `%${q}%`; params.push(p, p, p, p) }
+    sql += ' ORDER BY created_at DESC, id DESC LIMIT ?'; params.push(limit)
+    const rows = db.prepare(sql).all(...params) as Array<{ id: number; idea_id: string; from_status: string | null; to_status: string; actor: string; note: string | null; created_at: number }>
+    for (const r of rows) parts.push({ ...r, source: 'idea' })
+  }
+
+  if (active.includes('store')) {
+    let sql = 'SELECT id, rel_path, event_type, is_sensitive, file_size, created_at FROM store_file_audit WHERE 1=1'
+    const params: unknown[] = []
+    if (from) { sql += ' AND created_at >= ?'; params.push(from) }
+    if (to)   { sql += ' AND created_at <= ?'; params.push(to) }
+    if (q)    { sql += ' AND rel_path LIKE ?'; const p = `%${q}%`; params.push(p) }
+    sql += ' ORDER BY created_at DESC, id DESC LIMIT ?'; params.push(limit)
+    const rows = db.prepare(sql).all(...params) as StoreFileAuditRow[]
+    for (const r of rows) parts.push({ ...r, source: 'store' })
+  }
+
+  // Merge and sort by created_at DESC, then id DESC as tiebreaker
+  parts.sort((a, b) => b.created_at - a.created_at || (b.id ?? 0) - (a.id ?? 0))
+  return parts.slice(0, limit)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { logger } from './logger.js'
 import { startInviteMonitor, stopInviteMonitor } from './web/channel-invites.js'
 import { ensureDiscordChannelGroup } from './web/discord-group-bootstrap.js'
 import { startChannelRequestWatcher, stopChannelRequestWatcher } from './web/channel-request-watcher.js'
+import { startStoreWatcher, stopStoreWatcher } from './store-watcher.js'
 import { AGENTS_BASE_DIR } from './web/agent-config.js'
 import {
   acquirePortLock,
@@ -349,6 +350,7 @@ const shutdown = (): void => {
     }
     try { stopInviteMonitor() } catch (err) { logger.warn({ err }, 'stopInviteMonitor threw during shutdown') }
     try { stopChannelRequestWatcher() } catch (err) { logger.warn({ err }, 'stopChannelRequestWatcher threw during shutdown') }
+    try { stopStoreWatcher() } catch (err) { logger.warn({ err }, 'stopStoreWatcher threw during shutdown') }
     if (decayInterval) clearInterval(decayInterval)
     if (digestTimer) clearTimeout(digestTimer)
     if (digestInterval) clearInterval(digestInterval)
@@ -471,6 +473,9 @@ async function main(): Promise<void> {
 
   // Slack channel request watcher (audit.jsonl -> pending_channel_requests).
   startChannelRequestWatcher()
+
+  // Store file audit watcher
+  startStoreWatcher()
 
   // Web dashboard
   webServer = startWebServer(WEB_PORT)

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -7,6 +7,7 @@ import {
   touchMemory,
   saveMemory,
   decayMemories as dbDecay,
+  pruneAuditLogs,
   getMemoriesForChat,
   listKanbanCardsSummary,
   type Memory,
@@ -152,6 +153,7 @@ export async function saveConversationTurn(
 
 export function runDecaySweep(): void {
   dbDecay()
+  pruneAuditLogs()
   logger.info('Memoria leepulesi sopres vegrehajtva')
 }
 

--- a/src/store-watcher.ts
+++ b/src/store-watcher.ts
@@ -1,31 +1,48 @@
-import { watch, statSync } from 'node:fs'
-import { basename } from 'node:path'
+import { watch, statSync, readdirSync } from 'node:fs'
+import { basename, join } from 'node:path'
 import { STORE_DIR } from './config.js'
 import { logStoreFileEvent } from './db.js'
 import { logger } from './logger.js'
 
-// Files whose presence we record but whose content must never be logged.
-// Even the audit entry for these is flagged is_sensitive=1 so the UI can
-// render a sanitised label rather than showing path components that might
-// hint at secret values.
+// --- System file denylist ---
+// Only files NOT on this list (and not matching SYSTEM_RE) are logged.
+// Everything else = Marveen-managed state that would produce noise.
+// "Agent-created" files are those that remain after filtering.
+const SYSTEM_FILES = new Set([
+  // SQLite database
+  'claudeclaw.db', 'claudeclaw.db-wal', 'claudeclaw.db-shm',
+  // Marveen runtime / scheduler state
+  'schedule-last-run.json', 'external-ops-last-run',
+  'kanban-audit-state.json',
+  // Settings and config overrides written by dashboard routes
+  'config-overrides.json', 'dashboard-settings.json',
+  // Fleet and agent management
+  'agents-desired.json', 'auto-restart.json', 'autonomy-config.json',
+  // Auth and secrets
+  '.dashboard-token', '.vault-key', 'vault.json',
+  // Usage and keepalive
+  'claude-usage.json', '.channel-keepalive', '.channel-last-respawn',
+  // Known Marveen-written log files
+  'channels.log', 'channels.error.log',
+  'dashboard.log', 'dashboard.error.log',
+  'update.log',
+])
+
+// Regex for system-generated filename patterns.
+// Also covers atomic-write temp files (keep in sync with settings-store.ts).
+const SYSTEM_RE = /\.pid$|\.tmp$|\.tmp\.[a-f0-9]+$|\.migrated$|\.bak$|^\.DS_Store$/
+
+// Filenames whose presence is sensitive; the audit row is flagged so the UI
+// can show a sanitised label instead of hinting at secret values.
 const SENSITIVE_NAMES = new Set(['.dashboard-token', 'vault.json', '.vault-key'])
 
-// Atomic-write temp files (our own tmp-file+rename pattern,
-// `<name>.<pid>.<ts>.<hex>.tmp`, see atomic-write.ts) and migration artefacts:
-// ignore them so the audit log doesn't double-count every settings save as
-// both a temp write and a final rename. Ignoring the temp event also matters
-// for attribution: the watch callback consumes the actor slot on the first
-// non-ignored event, so if the temp event were logged it would steal the
-// actor and leave the real (renamed) file with a null agent.
-const IGNORE_RE = /\.tmp$|\.tmp\.[a-f0-9]+$|\.migrated$|\.bak$/
-
 // --- Agent attribution slot ---
-// Node.js is single-threaded; the HTTP request handler sets this before
-// the file write, and the fs.watch callback (which fires in the next
-// event-loop tick) reads and clears it. Because requests are serialised
-// on the event loop, there is no race between two concurrent writes in
-// practice. For writes that originate outside the process (e.g. external
-// tools writing to store/), the slot stays null -> stored as null.
+// Node.js is single-threaded; a route handler sets this before writing,
+// the watch callback reads and clears it in the next event-loop tick.
+// For direct writes (Bash/Write tool from outside the process), this stays
+// null -- stored as null, shown as "ismeretlen" in the UI. There is no
+// OS-level mechanism to identify the writer without a process audit daemon,
+// so null is the honest and correct value.
 let currentWriteActor: string | null = null
 
 export function setStoreWriteActor(actor: string): void {
@@ -36,51 +53,97 @@ export function clearStoreWriteActor(): void {
   currentWriteActor = null
 }
 
-let watcher: ReturnType<typeof watch> | null = null
+// --- Known-files tracking for creation detection ---
+// Populated at watcher startup by scanning store/. A rename event for a path
+// NOT in this set where the file NOW EXISTS means a new file was created.
+let knownFiles = new Set<string>()
 
-// fs.watch fires the same (eventType, filename) several times for a single
-// logical write (especially the rename half of an atomic write), which would
-// otherwise produce duplicate audit rows -- and since the first event consumes
-// the actor slot, the duplicates would be logged with a null agent. Collapse
-// repeats of the same path+event within a short window into one entry.
+function scanStore(dir: string, relBase: string = ''): void {
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const rel = relBase ? `${relBase}/${entry.name}` : entry.name
+      if (entry.isDirectory()) {
+        scanStore(join(dir, entry.name), rel)
+      } else {
+        knownFiles.add(rel)
+      }
+    }
+  } catch { /* non-fatal; store may not exist yet */ }
+}
+
+// --- Dedup ---
+// fs.watch fires the same (eventType, filename) multiple times for a single
+// logical operation. Collapse repeats within a short window.
 const DEDUP_MS = 1000
 const recentEvents = new Map<string, number>()
 
+let watcher: ReturnType<typeof watch> | null = null
+
+function isSystemFile(rel: string): boolean {
+  const name = basename(rel)
+  return SYSTEM_FILES.has(name) || SYSTEM_RE.test(name)
+}
+
 export function startStoreWatcher(): void {
   if (watcher) return
+
+  knownFiles = new Set<string>()
+  scanStore(STORE_DIR)
+
   try {
     watcher = watch(STORE_DIR, { recursive: true }, (eventType, filename) => {
       if (!filename) return
-      if (IGNORE_RE.test(filename)) return
       const rel = filename.replace(/\\/g, '/')
+
+      // Consume (clear) the actor slot for ALL events, including system-file
+      // events, so a slot set before a denylist-ed write cannot leak to the
+      // next unrelated event.
+      const agent = currentWriteActor
+      currentWriteActor = null
+
+      // Only rename events can indicate a new file. change = modification.
+      if (eventType !== 'rename') return
+
+      // Skip system and temp files -- Marveen's own runtime writes.
+      if (isSystemFile(rel)) return
+
+      // If the file no longer exists it was deleted or renamed away -- not a creation.
+      let fileSize: number | null = null
+      try {
+        const st = statSync(`${STORE_DIR}/${rel}`)
+        fileSize = st.size
+      } catch {
+        // File gone: deletion or rename-away. Update knownFiles and skip.
+        knownFiles.delete(rel)
+        return
+      }
+
+      // Already known → not a new creation (could be a rename-to-same or
+      // replace; ignore to avoid false positives).
+      if (knownFiles.has(rel)) return
+
+      // Dedup: fs.watch may fire the rename event several times.
       const now = Date.now()
-      const dedupKey = `${eventType}:${rel}`
+      const dedupKey = rel
       const last = recentEvents.get(dedupKey)
       if (last !== undefined && now - last < DEDUP_MS) return
       recentEvents.set(dedupKey, now)
-      // Prune stale dedup entries so the map cannot grow without bound.
       if (recentEvents.size > 200) {
         for (const [k, t] of recentEvents) if (now - t >= DEDUP_MS) recentEvents.delete(k)
       }
+
+      // New file -- record it and mark as known.
+      knownFiles.add(rel)
       const isSensitive = SENSITIVE_NAMES.has(basename(rel)) ? 1 : 0
-      // Consume the actor slot: the caller set it just before writing.
-      const agent = currentWriteActor
-      currentWriteActor = null
-      let fileSize: number | null = null
-      if (eventType === 'change') {
-        try {
-          fileSize = statSync(`${STORE_DIR}/${rel}`).size
-        } catch { /* file may have been deleted by the time we stat */ }
-      }
+
       try {
-        logStoreFileEvent(rel, eventType, isSensitive, fileSize, agent)
+        logStoreFileEvent(rel, 'create', isSensitive, fileSize, agent)
       } catch (err) {
-        logger.warn({ err, rel }, 'store-watcher: failed to log event')
+        logger.warn({ err, rel }, 'store-watcher: failed to log new file event')
       }
     })
-    logger.info({ dir: STORE_DIR }, 'Store file watcher started')
+    logger.info({ dir: STORE_DIR, knownCount: knownFiles.size }, 'Store file watcher started')
   } catch (err) {
-    // Non-fatal: the rest of the dashboard works fine without store auditing.
     logger.warn({ err }, 'Store file watcher failed to start')
   }
 }

--- a/src/store-watcher.ts
+++ b/src/store-watcher.ts
@@ -1,0 +1,51 @@
+import { watch, statSync } from 'node:fs'
+import { basename } from 'node:path'
+import { STORE_DIR } from './config.js'
+import { logStoreFileEvent } from './db.js'
+import { logger } from './logger.js'
+
+// Files whose presence we record but whose content must never be logged.
+// Even the audit entry for these is flagged is_sensitive=1 so the UI can
+// render a sanitised label rather than showing path components that might
+// hint at secret values.
+const SENSITIVE_NAMES = new Set(['.dashboard-token', 'vault.json', '.vault-key'])
+
+// Atomic-write temp files (our own tmp-file+rename pattern) and migration
+// artefacts: ignore them so the audit log doesn't double-count every settings
+// save as both a `.tmp.<hex>` write and a final rename.
+const IGNORE_RE = /\.tmp\.[a-f0-9]+$|\.migrated$|\.bak$/
+
+let watcher: ReturnType<typeof watch> | null = null
+
+export function startStoreWatcher(): void {
+  if (watcher) return
+  try {
+    watcher = watch(STORE_DIR, { recursive: true }, (eventType, filename) => {
+      if (!filename) return
+      if (IGNORE_RE.test(filename)) return
+      const rel = filename.replace(/\\/g, '/')
+      const isSensitive = SENSITIVE_NAMES.has(basename(rel)) ? 1 : 0
+      let fileSize: number | null = null
+      if (eventType === 'change') {
+        try {
+          fileSize = statSync(`${STORE_DIR}/${rel}`).size
+        } catch { /* file may have been deleted by the time we stat */ }
+      }
+      try {
+        logStoreFileEvent(rel, eventType, isSensitive, fileSize)
+      } catch (err) {
+        logger.warn({ err, rel }, 'store-watcher: failed to log event')
+      }
+    })
+    logger.info({ dir: STORE_DIR }, 'Store file watcher started')
+  } catch (err) {
+    // Non-fatal: the rest of the dashboard works fine without store auditing.
+    logger.warn({ err }, 'Store file watcher failed to start')
+  }
+}
+
+export function stopStoreWatcher(): void {
+  if (!watcher) return
+  try { watcher.close() } catch { /* best-effort */ }
+  watcher = null
+}

--- a/src/store-watcher.ts
+++ b/src/store-watcher.ts
@@ -15,6 +15,23 @@ const SENSITIVE_NAMES = new Set(['.dashboard-token', 'vault.json', '.vault-key']
 // save as both a `.tmp.<hex>` write and a final rename.
 const IGNORE_RE = /\.tmp\.[a-f0-9]+$|\.migrated$|\.bak$/
 
+// --- Agent attribution slot ---
+// Node.js is single-threaded; the HTTP request handler sets this before
+// the file write, and the fs.watch callback (which fires in the next
+// event-loop tick) reads and clears it. Because requests are serialised
+// on the event loop, there is no race between two concurrent writes in
+// practice. For writes that originate outside the process (e.g. external
+// tools writing to store/), the slot stays null -> stored as null.
+let currentWriteActor: string | null = null
+
+export function setStoreWriteActor(actor: string): void {
+  currentWriteActor = actor
+}
+
+export function clearStoreWriteActor(): void {
+  currentWriteActor = null
+}
+
 let watcher: ReturnType<typeof watch> | null = null
 
 export function startStoreWatcher(): void {
@@ -25,6 +42,9 @@ export function startStoreWatcher(): void {
       if (IGNORE_RE.test(filename)) return
       const rel = filename.replace(/\\/g, '/')
       const isSensitive = SENSITIVE_NAMES.has(basename(rel)) ? 1 : 0
+      // Consume the actor slot: the caller set it just before writing.
+      const agent = currentWriteActor
+      currentWriteActor = null
       let fileSize: number | null = null
       if (eventType === 'change') {
         try {
@@ -32,7 +52,7 @@ export function startStoreWatcher(): void {
         } catch { /* file may have been deleted by the time we stat */ }
       }
       try {
-        logStoreFileEvent(rel, eventType, isSensitive, fileSize)
+        logStoreFileEvent(rel, eventType, isSensitive, fileSize, agent)
       } catch (err) {
         logger.warn({ err, rel }, 'store-watcher: failed to log event')
       }

--- a/src/store-watcher.ts
+++ b/src/store-watcher.ts
@@ -10,10 +10,14 @@ import { logger } from './logger.js'
 // hint at secret values.
 const SENSITIVE_NAMES = new Set(['.dashboard-token', 'vault.json', '.vault-key'])
 
-// Atomic-write temp files (our own tmp-file+rename pattern) and migration
-// artefacts: ignore them so the audit log doesn't double-count every settings
-// save as both a `.tmp.<hex>` write and a final rename.
-const IGNORE_RE = /\.tmp\.[a-f0-9]+$|\.migrated$|\.bak$/
+// Atomic-write temp files (our own tmp-file+rename pattern,
+// `<name>.<pid>.<ts>.<hex>.tmp`, see atomic-write.ts) and migration artefacts:
+// ignore them so the audit log doesn't double-count every settings save as
+// both a temp write and a final rename. Ignoring the temp event also matters
+// for attribution: the watch callback consumes the actor slot on the first
+// non-ignored event, so if the temp event were logged it would steal the
+// actor and leave the real (renamed) file with a null agent.
+const IGNORE_RE = /\.tmp$|\.tmp\.[a-f0-9]+$|\.migrated$|\.bak$/
 
 // --- Agent attribution slot ---
 // Node.js is single-threaded; the HTTP request handler sets this before
@@ -34,6 +38,14 @@ export function clearStoreWriteActor(): void {
 
 let watcher: ReturnType<typeof watch> | null = null
 
+// fs.watch fires the same (eventType, filename) several times for a single
+// logical write (especially the rename half of an atomic write), which would
+// otherwise produce duplicate audit rows -- and since the first event consumes
+// the actor slot, the duplicates would be logged with a null agent. Collapse
+// repeats of the same path+event within a short window into one entry.
+const DEDUP_MS = 1000
+const recentEvents = new Map<string, number>()
+
 export function startStoreWatcher(): void {
   if (watcher) return
   try {
@@ -41,6 +53,15 @@ export function startStoreWatcher(): void {
       if (!filename) return
       if (IGNORE_RE.test(filename)) return
       const rel = filename.replace(/\\/g, '/')
+      const now = Date.now()
+      const dedupKey = `${eventType}:${rel}`
+      const last = recentEvents.get(dedupKey)
+      if (last !== undefined && now - last < DEDUP_MS) return
+      recentEvents.set(dedupKey, now)
+      // Prune stale dedup entries so the map cannot grow without bound.
+      if (recentEvents.size > 200) {
+        for (const [k, t] of recentEvents) if (now - t >= DEDUP_MS) recentEvents.delete(k)
+      }
       const isSensitive = SENSITIVE_NAMES.has(basename(rel)) ? 1 : 0
       // Consume the actor slot: the caller set it just before writing.
       const agent = currentWriteActor

--- a/src/web.ts
+++ b/src/web.ts
@@ -49,6 +49,7 @@ import { tryHandleTokenUsage } from './web/routes/token-usage.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleSettings } from './web/routes/settings.js'
+import { tryHandleAuditLog } from './web/routes/audit-log.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import type { RouteContext } from './web/routes/types.js'
 
@@ -166,6 +167,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleIdeas(routeCtx)) return
       if (await tryHandleToolLog(routeCtx)) return
       if (await tryHandleSettings(routeCtx)) return
+      if (await tryHandleAuditLog(routeCtx)) return
       if (await tryHandleStatic(routeCtx, WEB_DIR)) return
 
       res.writeHead(404)

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -91,6 +91,7 @@ import { detectPaneState } from '../../pane-state.js'
 import { detectReauthNeeded } from '../reauth-detect.js'
 import { readAutoRestartConfig, writeAutoRestartConfig } from '../auto-restart-store.js'
 import type { AutoRestartConfig } from '../../auto-restart.js'
+import { setStoreWriteActor } from '../../store-watcher.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
 import { getChannelHealth } from '../channel-health-monitor.js'
 import {
@@ -934,6 +935,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const body = await readBody(req)
     let data: unknown
     try { data = JSON.parse(body.toString()) } catch { json(res, { error: 'invalid JSON' }, 400); return true }
+    setStoreWriteActor('dashboard')
     const saved = writeAutoRestartConfig(name, data)
     json(res, { ok: true, autoRestart: saved })
     return true

--- a/src/web/routes/audit-log.ts
+++ b/src/web/routes/audit-log.ts
@@ -3,7 +3,7 @@ import { queryAuditLog, type AuditSource } from '../../db.js'
 import { getEffectiveSettingValue } from '../../settings-store.js'
 import type { RouteContext } from './types.js'
 
-const VALID_SOURCES = new Set<AuditSource>(['config', 'idea', 'store'])
+const VALID_SOURCES = new Set<AuditSource>(['config', 'idea', 'store', 'diary'])
 
 export async function tryHandleAuditLog(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
@@ -38,6 +38,9 @@ export async function tryHandleAuditLog(ctx: RouteContext): Promise<boolean> {
   // Free-text search.
   const q = (params.get('q') ?? '').trim() || undefined
 
+  // Agent filter (meaningful for diary source; silently ignored for others).
+  const agent = (params.get('agent') ?? '').trim() || undefined
+
   // Per-request limit, capped at registry max.
   const maxEntries = Number(getEffectiveSettingValue('AUDIT_LOG_MAX_ENTRIES'))
   const limitParam = params.get('limit')
@@ -48,7 +51,7 @@ export async function tryHandleAuditLog(ctx: RouteContext): Promise<boolean> {
     return true
   }
 
-  const entries = queryAuditLog({ sources, from, to, q, limit })
+  const entries = queryAuditLog({ sources, from, to, q, agent, limit })
   json(res, { entries, total: entries.length })
   return true
 }

--- a/src/web/routes/audit-log.ts
+++ b/src/web/routes/audit-log.ts
@@ -1,0 +1,54 @@
+import { json } from '../http-helpers.js'
+import { queryAuditLog, type AuditSource } from '../../db.js'
+import { getEffectiveSettingValue } from '../../settings-store.js'
+import type { RouteContext } from './types.js'
+
+const VALID_SOURCES = new Set<AuditSource>(['config', 'idea', 'store'])
+
+export async function tryHandleAuditLog(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  if (path !== '/api/audit-log' || method !== 'GET') return false
+
+  const url = new URL(req.url ?? '/', `http://localhost`)
+  const params = url.searchParams
+
+  // Source filter: comma-separated, defaults to all sources.
+  const sourceParam = params.get('source') ?? ''
+  const sources: AuditSource[] = sourceParam
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s): s is AuditSource => VALID_SOURCES.has(s as AuditSource))
+
+  // Time range (unix seconds).
+  const fromParam = params.get('from')
+  const toParam = params.get('to')
+  const from = fromParam ? parseInt(fromParam, 10) : undefined
+  const to = toParam ? parseInt(toParam, 10) : undefined
+
+  if (from !== undefined && isNaN(from)) {
+    json(res, { error: 'Invalid "from" parameter' }, 400)
+    return true
+  }
+  if (to !== undefined && isNaN(to)) {
+    json(res, { error: 'Invalid "to" parameter' }, 400)
+    return true
+  }
+
+  // Free-text search.
+  const q = (params.get('q') ?? '').trim() || undefined
+
+  // Per-request limit, capped at registry max.
+  const maxEntries = Number(getEffectiveSettingValue('AUDIT_LOG_MAX_ENTRIES'))
+  const limitParam = params.get('limit')
+  const limit = limitParam ? Math.min(parseInt(limitParam, 10), maxEntries) : Math.min(200, maxEntries)
+
+  if (isNaN(limit) || limit < 1) {
+    json(res, { error: 'Invalid "limit" parameter' }, 400)
+    return true
+  }
+
+  const entries = queryAuditLog({ sources, from, to, q, limit })
+  json(res, { entries, total: entries.length })
+  return true
+}

--- a/src/web/routes/autonomy.ts
+++ b/src/web/routes/autonomy.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { PROJECT_ROOT } from '../../config.js'
 import { readBody, json } from '../http-helpers.js'
 import { logger } from '../../logger.js'
+import { setStoreWriteActor } from '../../store-watcher.js'
 import type { RouteContext } from './types.js'
 
 const CONFIG_PATH = join(PROJECT_ROOT, 'store', 'autonomy-config.json')
@@ -76,6 +77,7 @@ export async function tryHandleAutonomy(ctx: RouteContext): Promise<boolean> {
       }
 
       cat.level = level
+      setStoreWriteActor('dashboard')
       saveConfig(config)
       logger.info({ key, level }, 'Autonomy level updated')
       json(res, { ok: true, key, level, updated_at: config.updated_at })

--- a/src/web/routes/settings.ts
+++ b/src/web/routes/settings.ts
@@ -3,6 +3,7 @@ import { logger } from '../../logger.js'
 import { SETTINGS_REGISTRY, validateSettingValue } from '../../config-registry.js'
 import { getEffectiveSettingValue, setOverride } from '../../settings-store.js'
 import { logConfigChange } from '../../db.js'
+import { setStoreWriteActor } from '../../store-watcher.js'
 import type { RouteContext } from './types.js'
 
 export async function tryHandleSettings(ctx: RouteContext): Promise<boolean> {
@@ -59,6 +60,8 @@ export async function tryHandleSettings(ctx: RouteContext): Promise<boolean> {
         return true
       }
 
+      const resolvedActor = typeof actor === 'string' && actor ? actor : 'dashboard'
+      setStoreWriteActor(resolvedActor)
       const oldValue = getEffectiveSettingValue(key)
       const result = setOverride(key, value)
       if (!result.ok) {
@@ -66,7 +69,7 @@ export async function tryHandleSettings(ctx: RouteContext): Promise<boolean> {
         return true
       }
 
-      logConfigChange(key, oldValue, validation.value!, typeof actor === 'string' && actor ? actor : 'dashboard')
+      logConfigChange(key, oldValue, validation.value!, resolvedActor)
       logger.info({ key, oldValue, newValue: validation.value }, 'Setting updated')
       json(res, { ok: true, key, value: validation.value, requiresRestart: def.requiresRestart })
     } catch (err) {

--- a/web/app.js
+++ b/web/app.js
@@ -113,6 +113,7 @@ function switchPage(pageId) {
   if (pageId === 'messages') loadMessagesPage()
   if (pageId === 'tokenUsage') loadTokenUsage()
   if (pageId === 'ideas') loadIdeasPage()
+  if (pageId === 'naplo') loadNaplo()
 }
 
 // Mobile off-canvas sidebar toggle. No-op visual effect on desktop (the
@@ -11159,4 +11160,87 @@ function downloadMarkdown(name, content) {
   btn.addEventListener('click', () => { render(); openModal(overlay) })
   if (closeBtn) closeBtn.addEventListener('click', () => closeModal(overlay))
   overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(overlay) })
+})()
+
+// === Naplo (Audit Timeline) ===
+;(() => {
+  let naploInitialized = false
+  let naploActiveSource = ''
+
+  const SOURCE_LABELS = { config: 'Config', idea: 'Ötletláda', store: 'Store' }
+  const SOURCE_COLORS = { config: '#3b82f6', idea: '#10b981', store: '#f59e0b' }
+
+  function fmtTs(unix) {
+    return new Date(unix * 1000).toLocaleString('hu-HU', { dateStyle: 'short', timeStyle: 'short' })
+  }
+
+  function renderEntry(e) {
+    const badge = `<span class="naplo-badge" style="background:${SOURCE_COLORS[e.source] || '#6b7280'}">${SOURCE_LABELS[e.source] || e.source}</span>`
+    const ts = `<span class="naplo-ts">${fmtTs(e.created_at)}</span>`
+    let detail = ''
+    if (e.source === 'config') {
+      const oldV = e.old_value != null ? `<code>${e.old_value}</code>` : '<em>–</em>'
+      const newV = e.new_value != null ? `<code>${e.new_value}</code>` : '<em>–</em>'
+      detail = `<strong>${e.key}</strong> ${oldV} &rarr; ${newV} <span class="naplo-actor">${e.actor || ''}</span>`
+    } else if (e.source === 'idea') {
+      const from = e.from_status ? `<code>${e.from_status}</code> &rarr; ` : ''
+      detail = `<strong>${e.idea_id}</strong> ${from}<code>${e.to_status}</code>`
+      if (e.note) detail += ` <span class="naplo-note">${e.note}</span>`
+      if (e.actor) detail += ` <span class="naplo-actor">${e.actor}</span>`
+    } else if (e.source === 'store') {
+      const sizeStr = e.file_size != null ? ` (${(e.file_size / 1024).toFixed(1)} KB)` : ''
+      const sens = e.is_sensitive ? ' <span class="naplo-sensitive">sensitív</span>' : ''
+      detail = `<code>${e.rel_path}</code> <span class="naplo-event-type">${e.event_type}</span>${sizeStr}${sens}`
+    }
+    return `<div class="naplo-entry"><div class="naplo-entry-meta">${ts}${badge}</div><div class="naplo-entry-detail">${detail}</div></div>`
+  }
+
+  async function doNaplo() {
+    const timeline = document.getElementById('naplo-timeline')
+    const summary = document.getElementById('naplo-summary')
+    timeline.innerHTML = '<p class="naplo-empty">Betöltés...</p>'
+    summary.textContent = ''
+
+    const params = new URLSearchParams()
+    if (naploActiveSource) params.set('source', naploActiveSource)
+    const from = document.getElementById('naplo-from').value
+    const to = document.getElementById('naplo-to').value
+    const q = document.getElementById('naplo-q').value.trim()
+    if (from) params.set('from', Math.floor(new Date(from).getTime() / 1000))
+    if (to)   params.set('to', Math.floor(new Date(to + 'T23:59:59').getTime() / 1000))
+    if (q)    params.set('q', q)
+    params.set('limit', '200')
+
+    try {
+      const res = await fetch('/api/audit-log?' + params.toString())
+      if (!res.ok) { timeline.innerHTML = `<p class="naplo-empty error">Hiba: ${res.status}</p>`; return }
+      const data = await res.json()
+      const entries = data.entries || []
+      summary.textContent = `${entries.length} bejegyzés`
+      if (entries.length === 0) { timeline.innerHTML = '<p class="naplo-empty">Nincs találat.</p>'; return }
+      timeline.innerHTML = entries.map(renderEntry).join('')
+    } catch (err) {
+      timeline.innerHTML = `<p class="naplo-empty error">Hálózati hiba: ${err.message}</p>`
+    }
+  }
+
+  function loadNaplo() {
+    if (!naploInitialized) {
+      naploInitialized = true
+      document.querySelectorAll('#naplo-source-tabs .naplo-tab').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('#naplo-source-tabs .naplo-tab').forEach((b) => b.classList.remove('active'))
+          btn.classList.add('active')
+          naploActiveSource = btn.dataset.source
+          doNaplo()
+        })
+      })
+      document.getElementById('naplo-search-btn').addEventListener('click', doNaplo)
+      document.getElementById('naplo-q').addEventListener('keydown', (e) => { if (e.key === 'Enter') doNaplo() })
+      document.getElementById('naplo-refresh-btn').addEventListener('click', doNaplo)
+    }
+    doNaplo()
+  }
+
+  window.loadNaplo = loadNaplo
 })()

--- a/web/app.js
+++ b/web/app.js
@@ -11183,8 +11183,8 @@ function downloadMarkdown(name, content) {
     const ts = `<span class="naplo-ts">${fmtTs(e.created_at)}</span>`
     let detail = ''
     if (e.source === 'config') {
-      const oldV = e.old_value != null ? `<code>${esc(e.old_value)}</code>` : '<em>–</em>'
-      const newV = e.new_value != null ? `<code>${esc(e.new_value)}</code>` : '<em>–</em>'
+      const oldV = e.old_value != null ? `<code>${esc(e.old_value)}</code>` : '<em>nincs</em>'
+      const newV = e.new_value != null ? `<code>${esc(e.new_value)}</code>` : '<em>nincs</em>'
       detail = `<strong>${esc(e.key)}</strong> ${oldV} &rarr; ${newV} <span class="naplo-actor">${esc(e.actor || '')}</span>`
     } else if (e.source === 'idea') {
       const from = e.from_status ? `<code>${esc(e.from_status)}</code> &rarr; ` : ''

--- a/web/app.js
+++ b/web/app.js
@@ -11167,30 +11167,45 @@ function downloadMarkdown(name, content) {
   let naploInitialized = false
   let naploActiveSource = ''
 
-  const SOURCE_LABELS = { config: 'Config', idea: 'Ötletláda', store: 'Store' }
-  const SOURCE_COLORS = { config: '#3b82f6', idea: '#10b981', store: '#f59e0b' }
+  const SOURCE_LABELS = { config: 'Config', idea: 'Ötletláda', store: 'Store', diary: 'Eseménynapló' }
+  const SOURCE_COLORS = { config: '#3b82f6', idea: '#10b981', store: '#f59e0b', diary: '#8b5cf6' }
+  const DIARY_ENTRY_LABELS = { log: 'Napló', memory: 'Emlék' }
+  const DIARY_ENTRY_COLORS = { log: '#6b7280', memory: '#a78bfa' }
 
   function fmtTs(unix) {
     return new Date(unix * 1000).toLocaleString('hu-HU', { dateStyle: 'short', timeStyle: 'short' })
   }
 
   function renderEntry(e) {
-    const badge = `<span class="naplo-badge" style="background:${SOURCE_COLORS[e.source] || '#6b7280'}">${SOURCE_LABELS[e.source] || e.source}</span>`
+    const sourceColor = SOURCE_COLORS[e.source] || '#6b7280'
+    const sourceLabel = SOURCE_LABELS[e.source] || e.source
+    const badge = `<span class="naplo-badge" style="background:${sourceColor}">${sourceLabel}</span>`
     const ts = `<span class="naplo-ts">${fmtTs(e.created_at)}</span>`
     let detail = ''
     if (e.source === 'config') {
-      const oldV = e.old_value != null ? `<code>${e.old_value}</code>` : '<em>–</em>'
-      const newV = e.new_value != null ? `<code>${e.new_value}</code>` : '<em>–</em>'
-      detail = `<strong>${e.key}</strong> ${oldV} &rarr; ${newV} <span class="naplo-actor">${e.actor || ''}</span>`
+      const oldV = e.old_value != null ? `<code>${esc(e.old_value)}</code>` : '<em>–</em>'
+      const newV = e.new_value != null ? `<code>${esc(e.new_value)}</code>` : '<em>–</em>'
+      detail = `<strong>${esc(e.key)}</strong> ${oldV} &rarr; ${newV} <span class="naplo-actor">${esc(e.actor || '')}</span>`
     } else if (e.source === 'idea') {
-      const from = e.from_status ? `<code>${e.from_status}</code> &rarr; ` : ''
-      detail = `<strong>${e.idea_id}</strong> ${from}<code>${e.to_status}</code>`
-      if (e.note) detail += ` <span class="naplo-note">${e.note}</span>`
-      if (e.actor) detail += ` <span class="naplo-actor">${e.actor}</span>`
+      const from = e.from_status ? `<code>${esc(e.from_status)}</code> &rarr; ` : ''
+      detail = `<strong>${esc(e.idea_id)}</strong> ${from}<code>${esc(e.to_status)}</code>`
+      if (e.note) detail += ` <span class="naplo-note">${esc(e.note)}</span>`
+      if (e.actor) detail += ` <span class="naplo-actor">${esc(e.actor)}</span>`
     } else if (e.source === 'store') {
       const sizeStr = e.file_size != null ? ` (${(e.file_size / 1024).toFixed(1)} KB)` : ''
+      const agentStr = e.agent ? ` <span class="naplo-actor">${esc(e.agent)}</span>` : ''
       const sens = e.is_sensitive ? ' <span class="naplo-sensitive">sensitív</span>' : ''
-      detail = `<code>${e.rel_path}</code> <span class="naplo-event-type">${e.event_type}</span>${sizeStr}${sens}`
+      detail = `<code>${esc(e.rel_path)}</code> <span class="naplo-event-type">${esc(e.event_type)}</span>${sizeStr}${agentStr}${sens}`
+    } else if (e.source === 'diary') {
+      const entryColor = DIARY_ENTRY_COLORS[e.entry_type] || '#6b7280'
+      const entryLabel = DIARY_ENTRY_LABELS[e.entry_type] || e.entry_type
+      const entryBadge = `<span class="naplo-badge" style="background:${entryColor};font-size:10px">${entryLabel}</span>`
+      const agentStr = e.agent_id ? ` <span class="naplo-actor">${esc(e.agent_id)}</span>` : ''
+      let contentSnippet = esc(e.content || '').replace(/\n/g, ' ').slice(0, 200)
+      if ((e.content || '').length > 200) contentSnippet += '…'
+      const keywordsStr = e.keywords ? `<div class="naplo-note" style="margin-top:2px">Kulcsszavak: ${esc(e.keywords)}</div>` : ''
+      const catStr = e.category ? ` <span class="naplo-event-type">${esc(e.category)}</span>` : ''
+      detail = `${entryBadge}${catStr}${agentStr}<div class="naplo-diary-content">${contentSnippet}</div>${keywordsStr}`
     }
     return `<div class="naplo-entry"><div class="naplo-entry-meta">${ts}${badge}</div><div class="naplo-entry-detail">${detail}</div></div>`
   }
@@ -11206,9 +11221,12 @@ function downloadMarkdown(name, content) {
     const from = document.getElementById('naplo-from').value
     const to = document.getElementById('naplo-to').value
     const q = document.getElementById('naplo-q').value.trim()
+    const agentEl = document.getElementById('naplo-agent')
+    const agentVal = agentEl ? agentEl.value.trim() : ''
     if (from) params.set('from', Math.floor(new Date(from).getTime() / 1000))
     if (to)   params.set('to', Math.floor(new Date(to + 'T23:59:59').getTime() / 1000))
     if (q)    params.set('q', q)
+    if (agentVal) params.set('agent', agentVal)
     params.set('limit', '200')
 
     try {
@@ -11232,6 +11250,8 @@ function downloadMarkdown(name, content) {
           document.querySelectorAll('#naplo-source-tabs .naplo-tab').forEach((b) => b.classList.remove('active'))
           btn.classList.add('active')
           naploActiveSource = btn.dataset.source
+          const agentFilter = document.getElementById('naplo-agent-wrap')
+          if (agentFilter) agentFilter.style.display = naploActiveSource === 'diary' ? '' : 'none'
           doNaplo()
         })
       })

--- a/web/index.html
+++ b/web/index.html
@@ -76,6 +76,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3C7.5 3 4 6.5 4 11v4l-2 3h4v2a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v0a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v-2h4l-2-3v-4c0-4.5-3.5-8-8-8z"/></svg>
         <span class="sb-label">Memória</span>
       </a>
+      <a href="#" class="sb-link" data-page="naplo">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+        <span class="sb-label">Napló</span>
+      </a>
       <a href="#" class="sb-link" data-page="recall">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
         <span class="sb-label">Napló</span>
@@ -1286,6 +1290,45 @@
       <div class="updates-commits">
         <h3>Változások</h3>
         <div id="updatesCommitList" class="updates-commit-list"></div>
+      </div>
+    </div>
+
+    <!-- Naplo page -->
+    <div class="page" id="naploPage" hidden>
+      <div class="page-header">
+        <div class="page-header-row">
+          <div>
+            <h1>Napló</h1>
+            <p class="subtitle">Audit idővonal: konfig-változások, ötletláda-állapotváltások, store-fájl események</p>
+          </div>
+          <button class="btn-secondary btn-compact" id="naplo-refresh-btn">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+            </svg>
+            Frissítés
+          </button>
+        </div>
+      </div>
+
+      <div class="naplo-toolbar">
+        <div class="naplo-source-tabs" id="naplo-source-tabs">
+          <button class="naplo-tab active" data-source="">Összes</button>
+          <button class="naplo-tab" data-source="config">Config</button>
+          <button class="naplo-tab" data-source="idea">Ötletláda</button>
+          <button class="naplo-tab" data-source="store">Store-fájlok</button>
+        </div>
+        <div class="naplo-filters">
+          <input type="date" id="naplo-from" class="naplo-date" title="Ettől">
+          <span class="naplo-date-sep">-</span>
+          <input type="date" id="naplo-to" class="naplo-date" title="Eddig">
+          <input type="text" id="naplo-q" class="naplo-search" placeholder="Keresés...">
+          <button class="btn-primary btn-compact" id="naplo-search-btn">Keresés</button>
+        </div>
+      </div>
+
+      <div class="naplo-summary" id="naplo-summary"></div>
+      <div class="naplo-timeline" id="naplo-timeline">
+        <p class="naplo-empty">Válassz szűrőt és kattints Keresés-re.</p>
       </div>
     </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -80,10 +80,6 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
         <span class="sb-label">Napló</span>
       </a>
-      <a href="#" class="sb-link" data-page="recall">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-        <span class="sb-label">Napló</span>
-      </a>
       <a href="#" class="sb-link" data-page="bgTasks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
         <span class="sb-label">Háttér</span>
@@ -1313,6 +1309,7 @@
       <div class="naplo-toolbar">
         <div class="naplo-source-tabs" id="naplo-source-tabs">
           <button class="naplo-tab active" data-source="">Összes</button>
+          <button class="naplo-tab" data-source="diary">Eseménynapló</button>
           <button class="naplo-tab" data-source="config">Config</button>
           <button class="naplo-tab" data-source="idea">Ötletláda</button>
           <button class="naplo-tab" data-source="store">Store-fájlok</button>
@@ -1322,6 +1319,7 @@
           <span class="naplo-date-sep">-</span>
           <input type="date" id="naplo-to" class="naplo-date" title="Eddig">
           <input type="text" id="naplo-q" class="naplo-search" placeholder="Keresés...">
+          <span id="naplo-agent-wrap" style="display:none"><input type="text" id="naplo-agent" class="naplo-search" placeholder="Ágens (pl. jarvis)" style="width:130px"></span>
           <button class="btn-primary btn-compact" id="naplo-search-btn">Keresés</button>
         </div>
       </div>

--- a/web/style.css
+++ b/web/style.css
@@ -5875,3 +5875,27 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
 .idea-score-chip { font-size: 11px; padding: 2px 6px; border: 1px solid var(--border); border-radius: 4px; color: var(--text-muted); white-space: nowrap; }
 .idea-title-link { color: inherit; text-decoration: none; cursor: pointer; }
 .idea-title-link:hover { text-decoration: underline; }
+
+/* === Naplo (Audit Timeline) === */
+.naplo-toolbar { display: flex; flex-direction: column; gap: 10px; margin-bottom: 16px; }
+.naplo-source-tabs { display: flex; gap: 6px; flex-wrap: wrap; }
+.naplo-tab { padding: 5px 14px; border-radius: 20px; border: 1px solid var(--border); background: var(--bg-card); color: var(--text); cursor: pointer; font-size: 13px; transition: background 0.15s, color 0.15s; }
+.naplo-tab.active { background: var(--accent, #2563eb); color: #fff; border-color: transparent; }
+.naplo-filters { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.naplo-date { padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-card); color: var(--text); font-size: 13px; }
+.naplo-date-sep { color: var(--text-muted); font-size: 13px; }
+.naplo-search { flex: 1; min-width: 160px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-card); color: var(--text); font-size: 13px; }
+.naplo-summary { font-size: 13px; color: var(--text-muted); margin-bottom: 10px; }
+.naplo-empty { color: var(--text-muted); font-size: 14px; text-align: center; margin-top: 40px; }
+.naplo-empty.error { color: var(--danger, #ef4444); }
+.naplo-timeline { display: flex; flex-direction: column; gap: 1px; }
+.naplo-entry { display: flex; flex-direction: column; gap: 4px; padding: 10px 12px; border-radius: 6px; background: var(--bg-card); border: 1px solid var(--border); font-size: 13px; }
+.naplo-entry-meta { display: flex; align-items: center; gap: 8px; }
+.naplo-ts { color: var(--text-muted); font-size: 12px; white-space: nowrap; }
+.naplo-badge { padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; color: #fff; white-space: nowrap; }
+.naplo-entry-detail { color: var(--text); line-height: 1.5; }
+.naplo-entry-detail code { background: var(--bg, #f5f5f5); padding: 1px 5px; border-radius: 3px; font-family: monospace; font-size: 12px; }
+.naplo-actor { color: var(--text-muted); font-size: 12px; }
+.naplo-note { font-style: italic; color: var(--text-muted); }
+.naplo-event-type { font-size: 11px; background: var(--bg); border-radius: 3px; padding: 1px 5px; color: var(--text-muted); }
+.naplo-sensitive { font-size: 11px; color: var(--danger, #ef4444); font-weight: 600; }


### PR DESCRIPTION
## Summary

Adds a single read-only "Napló" (log) page to the dashboard that unifies several audit/event sources into one searchable, filterable timeline, replacing the previous separate recall page.

## What's new

- Unified timeline page with source tabs: All, Event log (daily logs + memories), Config change-log, Idea-box audit, Store files.
- Per-source colour badges, timestamp, free-text search, date-range and source filtering. Read-only.
- New `/api/audit-log` endpoint that merges the sources with shared filtering.
- Store-file auditing: a watcher records files created by agents under `store/`, excluding the app's own runtime/state files (denylist) and recording creation events only. File contents are never logged; sensitive files are flagged and only the path and event are recorded.
- Best-effort agent attribution on store-file events: writes that go through an app code path carry the actor; files created directly by an agent's own tooling are recorded without an attributed agent, because the filesystem watch cannot identify the writing process.
- Retention controls in the settings registry (configurable max entries and retention days) with a daily prune.

## Notes

- The previous separate recall page is removed; its sources (daily logs and memories) are now the "Event log" tab of the unified page.
- `/api/*` is never cached by the service worker, and audit data requires the dashboard bearer token.

## Schema

- New `store_file_audit` table (rel_path, event_type, is_sensitive, file_size, agent, created_at).
- Reads the existing `config_change_log`, `idea_status_log`, `daily_logs`, `memories`.

## Docs

HU and EN documentation (docs/naplo-audit.md, docs/en/naplo-audit.md).

## Testing

Built clean (tsc). Verified on a running dashboard: app state writes (DB, scheduler state, keepalive, atomic temp files) are excluded; an agent-created file under store/ is recorded as a "create" event; settings saves do not generate store entries; the timeline renders all sources with filtering and search; the retention prune runs.

---

This change was authored with AI assistance: written by the project's own development agent, reviewed by @cett before submission.