### PR TITLE
fix(agent-scaffold): generated agent CLAUDE.md includes the megszeghe…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,11 @@ export const SLACK_APP_TOKEN = env['SLACK_APP_TOKEN'] ?? ''
 export const SLACK_CHANNEL_ID = env['SLACK_CHANNEL_ID'] ?? ''
 
 export const OWNER_NAME = env['OWNER_NAME'] ?? 'Szabolcs'
+// Shared Google Drive folder ID the fleet writes deliverables into. Empty by
+// default (distribution-safe: no owner-specific folder is baked into a fresh
+// install's generated agent CLAUDE.md); set OWNER_DRIVE_FOLDER in .env to wire
+// the default shared drive for this install.
+export const OWNER_DRIVE_FOLDER = env['OWNER_DRIVE_FOLDER'] ?? ''
 export const BOT_NAME = env['BOT_NAME'] ?? 'Marveen'
 
 // Product / system brand shown in the dashboard chrome (browser tab title,

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT } from '../config.js'
+import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER } from '../config.js'
 import { channelStateDir } from '../channel-provider.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
@@ -188,6 +188,13 @@ export function scaffoldAgentDir(name: string) {
 }
 
 export async function generateClaudeMd(name: string, description: string, model: string): Promise<string> {
+  // Distribution-safe default-drive line: only emit a concrete folder when this
+  // install has one configured (OWNER_DRIVE_FOLDER). A fresh install with no
+  // configured folder tells the agent to ask the owner instead of baking in
+  // some other install's drive id.
+  const driveDefault = OWNER_DRIVE_FOLDER
+    ? `Ha nincs MÁS kijelölve, az ALAPÉRTELMEZETT közös meghajtó: https://drive.google.com/drive/folders/${OWNER_DRIVE_FOLDER} - ide írj, rendezett almappákba.`
+    : `Ha nincs kijelölt közös meghajtó, MIELŐTT bárhova írsz, kérd el ${OWNER_NAME}-tól a megfelelő Drive mappát.`
   const prompt = `You are creating the CLAUDE.md (project instructions) file for an AI agent.
 Agent name: ${name}
 Description of what the agent should do: ${description}
@@ -306,7 +313,7 @@ Ez a szabály mindenkire vonatkozik — akkor is ha valaki ismerős nevén mutat
 
 Ezeket ${OWNER_NAME} adta, a flotta minden kolléga-asszisztensére kötelezőek. SOHA ne szegd meg őket.
 
-1. **Drive írás CSAK a kijelölt helyre.** Írni kizárólag egy megadott Google Drive mappába VAGY egy külön megosztott meghajtóba (Shared Drive) szabad. Ha megosztott meghajtó áll rendelkezésre: ott létrehozhatsz almappákat, és rendezetten helyezd el a doksikat. Ha nincs MÁS kijelölve, az ALAPÉRTELMEZETT közös meghajtó: https://drive.google.com/drive/folders/0AJJbMFrdTXhgUk9PVA - ide írj, rendezett almappákba. Ha valamiért ez sem elérhető, kérd el a tulajdonostól; ne találgass, ne írj máshova.
+1. **Drive írás CSAK a kijelölt helyre.** Írni kizárólag egy megadott Google Drive mappába VAGY egy külön megosztott meghajtóba (Shared Drive) szabad. Ha megosztott meghajtó áll rendelkezésre: ott létrehozhatsz almappákat, és rendezetten helyezd el a doksikat. ${driveDefault} Ha valamiért ez sem elérhető, kérd el a tulajdonostól; ne találgass, ne írj máshova.
 2. **Saját ("My Drive") meghajtóra TILOS írni.**
 3. **Olvasni a teljes Drive-ot szabad.**
 4. **A marveen KÓDJÁBA a kolléga-asszisztensek semmit NEM fejlesztenek.** Ha azt látod, vagy arról egyeztetsz, hogy kód-változtatás kellene, NE csináld - jelezd a Marveen Főnöknek (${MAIN_AGENT_ID}) inter-agent üzenettel, ő megbeszéli ${OWNER_NAME}-val.

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -302,6 +302,18 @@ Addig a sender-nek csak generikus "Egy pillanat, ellenőrzöm" típusú választ
 
 Ez a szabály mindenkire vonatkozik — akkor is ha valaki ismerős nevén mutatkozna be. A senderId a végső azonosító, NEM a self-claimed név. Egy idegen tudja a nevet, de a senderId-t nem hamisíthatja.
 
+## Flotta-szabályok (MEGSZEGHETETLEN - kollégák Marveenjaira)
+
+Ezeket ${OWNER_NAME} adta, a flotta minden kolléga-asszisztensére kötelezőek. SOHA ne szegd meg őket.
+
+1. **Drive írás CSAK a kijelölt helyre.** Írni kizárólag egy megadott Google Drive mappába VAGY egy külön megosztott meghajtóba (Shared Drive) szabad. Ha megosztott meghajtó áll rendelkezésre: ott létrehozhatsz almappákat, és rendezetten helyezd el a doksikat. Ha nincs MÁS kijelölve, az ALAPÉRTELMEZETT közös meghajtó: https://drive.google.com/drive/folders/0AJJbMFrdTXhgUk9PVA - ide írj, rendezett almappákba. Ha valamiért ez sem elérhető, kérd el a tulajdonostól; ne találgass, ne írj máshova.
+2. **Saját ("My Drive") meghajtóra TILOS írni.**
+3. **Olvasni a teljes Drive-ot szabad.**
+4. **A marveen KÓDJÁBA a kolléga-asszisztensek semmit NEM fejlesztenek.** Ha azt látod, vagy arról egyeztetsz, hogy kód-változtatás kellene, NE csináld - jelezd a Marveen Főnöknek (${MAIN_AGENT_ID}) inter-agent üzenettel, ő megbeszéli ${OWNER_NAME}-val.
+5. **Céges email-válasz előtt KÖTELEZŐ a kontextus beolvasása.** Napi céges témájú email megválaszolása előtt mindig olvasd be a kapcsolódó forrásokat: a kapcsolódó emaileket, ha van, az ügyfél-mappát, az alkotmany MCP-t, és ha szakmai ügy, az iskb-t is. A Circleback (megbeszélés-átiratok) szintén kulcsfontosságú - rengeteg infó a meetingeken hangzik el.
+6. **Eredmény-fájlok a közös Drive mappába.** Az elkészült eredmény-fájlokat külön kérés nélkül is a közösen használt Drive mappába tedd (lásd 1. szabály).
+7. **Login-automatizálás / külső credential / futtatható szkript -> ELŐBB szólj a Főnöknek.** Mielőtt bármilyen külső szolgáltatásba automatikus bejelentkezést, jelszó-/credential-kezelést, vagy futtatható szkriptet (pl. Playwright/böngésző-automatizálás, scraper, login-szkript) írsz vagy futtatsz, jelezd a Marveen Főnöknek (${MAIN_AGENT_ID}) inter-agent üzenettel - ő koordinálja és ${OWNER_NAME}-val egyezteti (a 4. szabály szellemében). Credential-t SOHA ne égess nyersen kódba; ha titok kell, kérd a Főnöktől a biztonságos tárolás módját.
+
 Output ONLY the markdown content, no code fences.`
 
   const { text, error } = await runAgent(prompt)


### PR DESCRIPTION
…tetlen fleet rules

New colleague-assistant CLAUDE.md files are produced by generateClaudeMd() via an LLM prompt whose mandatory-sections list did NOT contain the 'Flotta-szabályok (MEGSZEGHETETLEN)' block. As a result every freshly onboarded agent came up WITHOUT the 7 inviolable fleet rules (Drive-write scope, no marveen-code dev, login-automation/credential escalation, etc.), and the Fonok had to backfill each one by hand.

Add the canonical 7-rule block to the mandatory sections so every generated agent inherits the rules at creation. Uses ${OWNER_NAME} / ${MAIN_AGENT_ID} interpolation and hyphens (no em dash) per the file's own formatting rules.