### PR TITLE
Feat/tips tricks doc

### DIFF
--- a/docs/en/tips-tricks.md
+++ b/docs/en/tips-tricks.md
@@ -68,5 +68,7 @@ Why periodic review pays off:
 - Lower cost and latency where it is sufficient: routine roles run on lighter models
 - The fleet stays current with model progress -- a model that is less capable today may be adequate for a role in six months
 - Deliberate resource management: not every agent needs the heaviest model
+- Documented decisions: record the reason and date for every model change (commit message, daily log) -- context is easily lost over months if the only trace is a changed value in agent-config.json
+- Risk management: for agents in critical roles (architecture design, complex analysis) allow a testing period before making the new model permanent; a faster or cheaper model may seem sufficient until quality degradation shows under real load
 
 **Effect achieved:** optimal quality/cost/speed balance across the fleet; lower bills for routine roles, higher performance where it counts.

--- a/docs/en/tips-tricks.md
+++ b/docs/en/tips-tricks.md
@@ -1,0 +1,27 @@
+# Tips & Tricks
+
+> Proven techniques for working faster and more effectively with the Marveen fleet.
+
+---
+
+## 1. [Tip title]
+
+Brief intro: what problem this technique solves and when to apply it.
+
+**Effect achieved:** ...
+
+---
+
+## 2. [Tip title]
+
+Brief intro: what problem this technique solves and when to apply it.
+
+**Effect achieved:** ...
+
+---
+
+## 3. [Tip title]
+
+Brief intro: what problem this technique solves and when to apply it.
+
+**Effect achieved:** ...

--- a/docs/en/tips-tricks.md
+++ b/docs/en/tips-tricks.md
@@ -72,3 +72,15 @@ Why periodic review pays off:
 - Risk management: for agents in critical roles (architecture design, complex analysis) allow a testing period before making the new model permanent; a faster or cheaper model may seem sufficient until quality degradation shows under real load
 
 **Effect achieved:** optimal quality/cost/speed balance across the fleet; lower bills for routine roles, higher performance where it counts.
+
+---
+
+## 8. Periodic review and rate-reduction of low-yield heartbeat tasks
+
+Scheduled heartbeat tasks accumulate easily, and a run frequency that was justified at setup can become unnecessary over time. Periodically review which tasks typically find nothing (no-op runs) and reduce their schedule. For most notification-type tasks, hourly runs deliver results just as promptly as every-10-minutes -- but with 6x fewer LLM calls.
+
+Concrete example: the eszter-done-ertesito task changed from every 10 minutes (`*/10 * * * *`) to hourly (`0 * * * *`) -- 144 runs per day down to 24, and notifications still arrive within minutes.
+
+Schedules can be adjusted on the dashboard Schedules page or via the API; run history is the best guide for identifying which tasks are candidates for rate reduction.
+
+**Effect achieved:** token and resource savings by eliminating unnecessary no-op LLM runs; reduced noise in the logs.

--- a/docs/en/tips-tricks.md
+++ b/docs/en/tips-tricks.md
@@ -8,6 +8,8 @@
 
 Agent CLAUDE.md descriptors can periodically review themselves: anything procedural and repetitive -- API recipes, step sequences -- should be moved into a skill (recall-on-demand). The behavioural and safety core stays in the descriptor. The process itself is delegable: ask the agent to review its own descriptor and extract what it can into skills.
 
+Example prompt: "Review the agents' CLAUDE.md descriptors: what can be extracted into a shared skill (keeping the behavioural and safety core in place) to reduce descriptor size and token usage?"
+
 **Effect achieved:** Six sub-agent CLAUDE.md files shrank from 103 to 54 lines; the main CLAUDE.md from 292 to 194 lines; duplicated API recipes were consolidated into a single shared skill. Every session now loads fewer tokens -- smaller context, faster responses.
 
 ---

--- a/docs/en/tips-tricks.md
+++ b/docs/en/tips-tricks.md
@@ -4,24 +4,69 @@
 
 ---
 
-## 1. [Tip title]
+## 1. Self-review and skill extraction for agent descriptors
 
-Brief intro: what problem this technique solves and when to apply it.
+Agent CLAUDE.md descriptors can periodically review themselves: anything procedural and repetitive -- API recipes, step sequences -- should be moved into a skill (recall-on-demand). The behavioural and safety core stays in the descriptor. The process itself is delegable: ask the agent to review its own descriptor and extract what it can into skills.
 
-**Effect achieved:** ...
-
----
-
-## 2. [Tip title]
-
-Brief intro: what problem this technique solves and when to apply it.
-
-**Effect achieved:** ...
+**Effect achieved:** Six sub-agent CLAUDE.md files shrank from 103 to 54 lines; the main CLAUDE.md from 292 to 194 lines; duplicated API recipes were consolidated into a single shared skill. Every session now loads fewer tokens -- smaller context, faster responses.
 
 ---
 
-## 3. [Tip title]
+## 2. Label-driven done-state email notification workflow
 
-Brief intro: what problem this technique solves and when to apply it.
+If an agent has email-sending capability (e.g. Google Workspace MCP), a label can drive a workflow that automatically sends an email to the relevant party when a card reaches DONE. The label marks which cards belong to the workflow; a scheduled heartbeat task watches for done+labelled, not-yet-notified cards, sends the email (with correctly encoded subject), then marks the card so it doesn't repeat. For PII-sensitive cases a human approval step can be added.
 
-**Effect achieved:** ...
+Live example: the Eszter label + eszter-done-ertesito scheduled task -- done cards with the Eszter label trigger an email to a given address.
+
+**Effect achieved:** automatic, reliable notification on task completion with no manual step; the label makes the workflow reusable for any project.
+
+---
+
+## 3. Break down larger tasks onto the kanban board with AI
+
+When you hand the agent a larger task, put it on the kanban board and use the "Kanban (AI) breakdown": the agent splits it into meaningful subtasks with priorities and assigned agents. You don't need to plan the whole structure upfront.
+
+**Effect achieved:** faster delegation, clearer progress tracking, less manual planning.
+
+---
+
+## 4. The idea box as a buffer and prioritisation layer
+
+Log not-yet-ripe ideas in the Idea Box with impact/effort scores, and only promote approved ones to the kanban board. The Idea Box is not a to-do list -- it is a filter where ideas mature and get prioritised.
+
+**Effect achieved:** no idea gets lost, but the kanban board stays uncluttered; the scoring helps decide what the best next step is.
+
+---
+
+## 5. Label by topic or project
+
+Tag kanban cards with labels by theme or project. This lets you filter the board instantly, and you can build notification or automation workflows on top of the labels (see Tip 2). The swimlane view can also group by label.
+
+**Effect achieved:** fast overview and filtering; the label doubles as a workflow trigger.
+
+---
+
+## 6. Use your own aliases
+
+Define short personal keywords for repetitive requests that launch an entire complex workflow with a single word. You don't need to spell out every step -- the alias does it for you.
+
+Example: the "napindító" keyword runs the full morning chain (Dream Engine -> Peter workout summary -> email -> calendar) with one word.
+
+**Effect achieved:** faster, consistent daily control; recurring routines start on one keyword and never deviate from the usual order.
+
+---
+
+## 7. Periodic model review for every specialised agent
+
+Regularly review which Claude model each specialised agent uses (the "model" field in `agent-config.json`) and align it with the agent's role and the current model offering.
+
+A demanding, intellectually intensive role -- architecture design, complex code generation, multi-source analysis -- may justify a stronger model where quality is the primary concern. A simpler, routine role -- calendar summaries, email notifications, data formatting -- works just as well with a lighter, faster, and cheaper model. When new models are released, it is worth reassessing the entire fleet.
+
+Why periodic review pays off:
+
+- Better quality where it matters: the hardest tasks get the strongest available model
+- Lower cost and latency where it is sufficient: routine roles run on lighter models
+- The fleet stays current with model progress -- a model that is less capable today may be adequate for a role in six months
+- Deliberate resource management: not every agent needs the heaviest model
+
+**Effect achieved:** optimal quality/cost/speed balance across the fleet; lower bills for routine roles, higher performance where it counts.

--- a/docs/en/tips-tricks.md
+++ b/docs/en/tips-tricks.md
@@ -83,4 +83,8 @@ Concrete example: the eszter-done-ertesito task changed from every 10 minutes (`
 
 Schedules can be adjusted on the dashboard Schedules page or via the API; run history is the best guide for identifying which tasks are candidates for rate reduction.
 
-**Effect achieved:** token and resource savings by eliminating unnecessary no-op LLM runs; reduced noise in the logs.
+Before reducing frequency, assess time-criticality: if a task's result has an immediate impact within minutes -- instant alerting, SLA threshold, business process blocker -- do not reduce its frequency. Rate reduction only makes sense where a delayed result does not reduce the value delivered.
+
+Make the review a recurring habit (e.g. monthly): a task's importance can change, and what was essential two months ago may now be a consistent no-op.
+
+**Effect achieved:** token and resource savings by eliminating unnecessary no-op LLM runs; reduced noise in the logs -- without compromising time-critical monitoring.

--- a/docs/tippek-trukkok.md
+++ b/docs/tippek-trukkok.md
@@ -8,6 +8,8 @@
 
 Az ügynökök CLAUDE.md leírói időszakosan felülvizsgálhatják önmagukat: ami procedurális és ismétlődő (API-receptek, lépéssorok), az kerüljön skillbe (recall-on-demand formában). A viselkedési és biztonsági mag maradjon a leíróban. A folyamat maga is delegálható -- kérd meg az ügynököt, hogy tekintse át saját leíróját, és amit skillbe tud szervezni, azt tegye meg.
 
+Példa prompt: "Vizsgáld meg az ügynökök CLAUDE.md leíróit: mi emelhető át belőlük (a viselkedési és biztonsági magot meghagyva) közös skillbe, hogy csökkenjen a leíró mérete és a tokenhasználat?"
+
 **Elért hatás:** 6 sub-ügynök CLAUDE.md-je 103-ról 54 sorra csökkent; a fő CLAUDE.md 292-ről 194 sorra; a duplikált API-receptek egyetlen közös skillbe kerültek. Minden session indításakor kevesebb token töltődik be -- kisebb kontextus, gyorsabb válasz.
 
 ---

--- a/docs/tippek-trukkok.md
+++ b/docs/tippek-trukkok.md
@@ -4,24 +4,69 @@
 
 ---
 
-## 1. [Tipp neve]
+## 1. Ügynök-leírók önfelülvizsgálata és skill-be szervezése
 
-Rövid bevezető: mit old meg ez a fogás, mikor érdemes alkalmazni.
+Az ügynökök CLAUDE.md leírói időszakosan felülvizsgálhatják önmagukat: ami procedurális és ismétlődő (API-receptek, lépéssorok), az kerüljön skillbe (recall-on-demand formában). A viselkedési és biztonsági mag maradjon a leíróban. A folyamat maga is delegálható -- kérd meg az ügynököt, hogy tekintse át saját leíróját, és amit skillbe tud szervezni, azt tegye meg.
 
-**Elért hatás:** ...
-
----
-
-## 2. [Tipp neve]
-
-Rövid bevezető: mit old meg ez a fogás, mikor érdemes alkalmazni.
-
-**Elért hatás:** ...
+**Elért hatás:** 6 sub-ügynök CLAUDE.md-je 103-ról 54 sorra csökkent; a fő CLAUDE.md 292-ről 194 sorra; a duplikált API-receptek egyetlen közös skillbe kerültek. Minden session indításakor kevesebb token töltődik be -- kisebb kontextus, gyorsabb válasz.
 
 ---
 
-## 3. [Tipp neve]
+## 2. Cimke-vezérelt kész-állapot email-értesítő workflow
 
-Rövid bevezető: mit old meg ez a fogás, mikor érdemes alkalmazni.
+Ha egy ügynöknek van levelküldési lehetősége (pl. Google Workspace MCP), egy cimke segítségével kialakítható olyan workflow, amely egy kártya DONE állapotba kerülésekor automatikusan emailt küld az érintettnek. A cimke jelöli ki, melyik kártyák tartoznak a workflow-ba; egy ütemezett (heartbeat) feladat figyeli a done+cimkés, még nem értesített kártyákat, kiküldi az emailt (ékezetes tárggyal), majd megjelöli a kártyát, hogy ne ismétlődjön. PII-érzékeny esetekben beépíthető humán jóváhagyási lépés.
 
-**Elért hatás:** ...
+Élő példa: az Eszter-cimke + eszter-done-ertesito ütemezett feladat -- a done Eszter-cimkés kártyákról email megy egy megadott címre.
+
+**Elért hatás:** automatikus, megbízható értesítés a kész feladatokról kézi lépés nélkül; a cimke bármely projektre újrahasználható.
+
+---
+
+## 3. Nagyobb feladat kanbanra és AI-bontással
+
+Ha nagyobb feladatot adsz az ügynöknek, tedd kanbanra, majd használd a "Kanbanra (AI)" bontást: az ügynök maga osztja értelmes részfeladatokra, prioritásokkal és felelős ügynökkel. Nem kell előre megtervezned az egész struktúrát.
+
+**Elért hatás:** gyorsabb delegálás, átláthatóbb haladás, kevesebb kézi tervezés.
+
+---
+
+## 4. Ötletláda mint puffer és priorizáló
+
+A még nem érett ötleteket vedd fel az Ötletládába impact/effort pontozással, és csak a jóváhagyottakat promotáld a kanban táblára. Az Ötletláda nem feladatlista -- szűrő, ahol az ötletek érnek és priorizálódnak.
+
+**Elért hatás:** semmi ötlet nem veszik el, de a kanban tábla sem zsúfolódik; a pontozás segít eldönteni, mi a legjobb következő lépés.
+
+---
+
+## 5. Cimkézz témára vagy projektre
+
+Lásd el a kártyákat cimkékkel téma vagy projekt szerint. Így a táblán gyorsan szűrhetsz, és értesítő- vagy automatizált workflow-kat is építhetsz rá (lásd 2. tipp). A swimlane nézet cimkék szerint is csoportosítható.
+
+**Elért hatás:** gyors áttekintés és szűrés; a cimke workflow-kapcsolóként is működik.
+
+---
+
+## 6. Használj saját aliasokat
+
+Definiálj rövid saját kulcsszavakat az ismétlődő kérésekhez, amelyek egyetlen szóra egy egész összetett workflow-t indítanak el. Nem kell minden lépést külön kérned -- az alias elvégzi helyetted.
+
+Példa: a "napindító" kulcsszó a teljes reggeli láncot futtatja (Dream Engine -> Peter edzés-összefoglaló -> email -> naptár) egyetlen szóra.
+
+**Elért hatás:** gyorsabb, konzisztens napi vezérlés; az ismétlődő rutinok egy kulcsszóra indulnak, és nem térnek el a szokásos sorrendtől.
+
+---
+
+## 7. Időszakos modell-elemzés minden specializált ügynökhöz
+
+Rendszeresen vizsgáld felül, melyik Claude-modellt használja minden specializált ügynök (az `agent-config.json` "model" mezőjét), és igazítsd a szerepköréhez és az aktuális modell-kínálathoz.
+
+Egy nehéz, magas szellemi igényű szerepkör -- architektúra-tervezés, komplex kódgenerálás, több forrást egyesítő elemzés -- erősebb modellt indokolhat, ahol a minőség az elsődleges szempont. Egy egyszerűbb, rutinszerűbb szerep -- naptár-összefoglaló, email-értesítő, adatformázás -- könnyebb, gyorsabb és olcsóbb modellel is ugyanolyan jól működik. Új modellek megjelenésekor érdemes az egész flottát újraértékelni.
+
+A rendszeres felülvizsgálat hozadékai:
+
+- Jobb minőség ott, ahol számít: a nehéz feladatokhoz a legerősebb elérhető modell dolgozik
+- Alacsonyabb költség és kisebb késleltetés ott, ahol elegendő: a rutin szerepköröknél a könnyebb modell is teljesít
+- A flotta naprakészen marad a modell-fejlődéssel -- egy ma gyengébb modell fél év múlva már elég lehet egy szerepkörhöz
+- Tudatos erőforrás-gazdálkodás: nem minden ügynök igényli a legsúlyosabb modellt
+
+**Elért hatás:** optimális minőség/költség/sebesség-arány az egész flottában; kisebb számlák a rutin szerepköröknél, nagyobb teljesítmény ott, ahol szükséges.

--- a/docs/tippek-trukkok.md
+++ b/docs/tippek-trukkok.md
@@ -83,4 +83,8 @@ Konkrét példa: az eszter-done-ertesito feladat 10 percenkéntiről (`*/10 * * 
 
 Az ütemezés a dashboard Ütemezés oldalán vagy az API-n keresztül módosítható; a futási előzmények alapján ítélhető meg, hogy melyik feladat érdemes a ritkításra.
 
-**Elért hatás:** token- és erőforrás-megtakarítás a felesleges no-op LLM-futások kiszűrésével; kisebb zajszint a naplókban.
+Ritkítás előtt mérd fel az időkritikusságot: ha egy feladat eredménye perceken belül hatással van valamire (pl. azonnali riasztás, SLA-küszöb, üzleti folyamat blocker), ne ritkítsd -- ott a futási sűrűség indokolt. A ritkítás csak ott előnyös, ahol az eredmény késleltetése semmit sem ront az értéken.
+
+A felülvizsgálatot tedd rendszeressé (pl. havi egyszer): egy feladat fontossága változhat, és ami ma még szükséges volt, két hónap múlva már no-op-nak számít.
+
+**Elért hatás:** token- és erőforrás-megtakarítás a felesleges no-op LLM-futások kiszűrésével; kisebb zajszint a naplókban -- anélkül, hogy az időkritikus figyelések sérülnének.

--- a/docs/tippek-trukkok.md
+++ b/docs/tippek-trukkok.md
@@ -72,3 +72,15 @@ A rendszeres felülvizsgálat hozadékai:
 - Kockázatkezelés: kritikus szerepkörű ügynöknél (architektúra-tervezés, összetett elemzés) legyen tesztelési periódus az új modellel, mielőtt véglegesen átállsz; egy gyorsabb-olcsóbb modell tűnhet elégnek, amíg éles terhelés alatt nem derül ki a minőségromlás
 
 **Elért hatás:** optimális minőség/költség/sebesség-arány az egész flottában; kisebb számlák a rutin szerepköröknél, nagyobb teljesítmény ott, ahol szükséges.
+
+---
+
+## 8. Heartbeat-ek időszakos felülvizsgálata és ütemezésük ritkítása
+
+Az ütemezett heartbeat-feladatok könnyen szaporodnak, és az eredetileg indokolt futási sűrűség idővel feleslegessé válhat. Rendszeresen nézd át, melyek azok, amelyek tipikusan semmit sem találnak (no-op futások), és ritkítsd az ütemezésüket. A legtöbb értesítő-típusú feladatnál az óránkénti futás éppoly időben szállítja az eredményt, mint a 10 percenkénti -- de 6-szor kevesebb LLM-hívással jár.
+
+Konkrét példa: az eszter-done-ertesito feladat 10 percenkéntiről (`*/10 * * * *`) óránkéntire (`0 * * * *`) állítva -- napi 144 helyett 24 futás, az értesítés továbbra is perceken belül megérkezik.
+
+Az ütemezés a dashboard Ütemezés oldalán vagy az API-n keresztül módosítható; a futási előzmények alapján ítélhető meg, hogy melyik feladat érdemes a ritkításra.
+
+**Elért hatás:** token- és erőforrás-megtakarítás a felesleges no-op LLM-futások kiszűrésével; kisebb zajszint a naplókban.

--- a/docs/tippek-trukkok.md
+++ b/docs/tippek-trukkok.md
@@ -1,0 +1,27 @@
+# Tippek, Trükkök
+
+> Bevált fogások, amelyekkel gyorsabban és hatékonyabban dolgozhatsz a Marveen flottával.
+
+---
+
+## 1. [Tipp neve]
+
+Rövid bevezető: mit old meg ez a fogás, mikor érdemes alkalmazni.
+
+**Elért hatás:** ...
+
+---
+
+## 2. [Tipp neve]
+
+Rövid bevezető: mit old meg ez a fogás, mikor érdemes alkalmazni.
+
+**Elért hatás:** ...
+
+---
+
+## 3. [Tipp neve]
+
+Rövid bevezető: mit old meg ez a fogás, mikor érdemes alkalmazni.
+
+**Elért hatás:** ...

--- a/docs/tippek-trukkok.md
+++ b/docs/tippek-trukkok.md
@@ -68,5 +68,7 @@ A rendszeres felülvizsgálat hozadékai:
 - Alacsonyabb költség és kisebb késleltetés ott, ahol elegendő: a rutin szerepköröknél a könnyebb modell is teljesít
 - A flotta naprakészen marad a modell-fejlődéssel -- egy ma gyengébb modell fél év múlva már elég lehet egy szerepkörhöz
 - Tudatos erőforrás-gazdálkodás: nem minden ügynök igényli a legsúlyosabb modellt
+- Dokumentált döntés: minden modellváltást jegyezz fel (commitüzenet, napi napló) -- miért váltottál és mikor; néhány hónap múlva elvész a kontextus, ha csak az agent-config.json-ban van nyoma
+- Kockázatkezelés: kritikus szerepkörű ügynöknél (architektúra-tervezés, összetett elemzés) legyen tesztelési periódus az új modellel, mielőtt véglegesen átállsz; egy gyorsabb-olcsóbb modell tűnhet elégnek, amíg éles terhelés alatt nem derül ki a minőségromlás
 
 **Elért hatás:** optimális minőség/költség/sebesség-arány az egész flottában; kisebb számlák a rutin szerepköröknél, nagyobb teljesítmény ott, ahol szükséges.


### PR DESCRIPTION
## Summary

Adds a new "Tippek, Trükkök" (Tips & Tricks) documentation page in Hungarian and English, collecting practical operational tips for using the dashboard and directing the agent fleet day to day. The page appears automatically in the dashboard's Documentation view.

## Content

Eight numbered tips, each with a title, a description, and an "Elért hatás" (achieved effect) note:
1. Self-review of agent descriptors and moving repeated procedures into shared skills (with an example prompt and the token-reduction effect).
2. Label-driven "done" email-notification workflow.
3. Larger task to kanban board plus AI breakdown.
4. Idea box as a buffer and prioritizer.
5. Labeling by topic / project.
6. Personal command aliases.
7. Periodic per-agent model review (with decision-audit and risk-management notes).
8. Periodic review of deterministic heartbeats and thinning their schedule (with a time-criticality gate and a recurring-review cadence).

## Files

docs/tippek-trukkok.md (HU) and docs/en/tips-tricks.md (EN). The Documentation view auto-discovers the files (readdirSync), so no manual registration is needed.

## Testing

Verified on a running dashboard: the page appears in the Documentation menu in both languages and renders all eight tips with their sections.

---

This change was authored with AI assistance: written by the project's own development agents, reviewed by @cett before submission.