### PR TITLE
feat(channels): Google Chat (Cloud Pub/Sub) channel provider

### DIFF
--- a/src/channel-coordinator/provider-poller-match.ts
+++ b/src/channel-coordinator/provider-poller-match.ts
@@ -50,6 +50,7 @@ const SLUG_RX: Record<ChannelProviderType, RegExp> = {
   telegram: /\/telegram(?:\/|\s|$)/,
   slack: /\/slack(?:-channel)?(?:\/|\s|$)/,
   discord: /\/discord(?:\/|\s|$)/,
+  googlechat: /\/googlechat(?:\/|\s|$)/,
 }
 
 // Slack-specific behavior-preserving fallback. The pre-fix cross-tree scan

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -5,7 +5,7 @@ import { homedir } from 'node:os'
 import { logger } from './logger.js'
 import { formatForTelegram, splitMessage } from './format.js'
 
-export type ChannelProviderType = 'telegram' | 'slack' | 'discord'
+export type ChannelProviderType = 'telegram' | 'slack' | 'discord' | 'googlechat'
 
 export interface ChannelProvider {
   readonly type: ChannelProviderType
@@ -309,6 +309,45 @@ const discordProvider: ChannelProvider = {
   splitMessage: (text) => splitMessage(text, DISCORD_MAX_MESSAGE_LENGTH),
 }
 
+// -- Google Chat implementation --
+//
+// Google Chat (Workspace) has no bot token: the channel plugin authenticates
+// with a service-account key and consumes events over Cloud Pub/Sub. So the
+// token-based dashboard helpers below are minimal -- actual delivery happens
+// through the plugin's MCP tools, not these direct-send methods. "Configured"
+// is detected via GOOGLECHAT_PROJECT_ID in the agent's channel .env (see
+// readChannelToken), which stands in for the token the other providers use.
+
+const GOOGLECHAT_MAX_MESSAGE_LENGTH = 4096
+
+const googlechatProvider: ChannelProvider = {
+  type: 'googlechat',
+  pluginId: 'googlechat@claude-channel-googlechat',
+  pluginPaneId: 'plugin:googlechat:googlechat',
+  envKeys: ['GOOGLE_APPLICATION_CREDENTIALS', 'GOOGLECHAT_PROJECT_ID', 'GOOGLECHAT_SUBSCRIPTION'],
+  stateDir: 'googlechat',
+  chatIdFormat: 'space resource name (e.g. spaces/AAAA)',
+
+  async sendMessage() {
+    // Direct dashboard send is not supported for Google Chat; the agent
+    // delivers via the plugin's reply tool inside its own session.
+    throw new Error('googlechat: direct dashboard send not supported (delivery via plugin MCP tools)')
+  },
+
+  async sendPhoto() {
+    throw new Error('googlechat: direct dashboard send not supported (delivery via plugin MCP tools)')
+  },
+
+  async validateToken() {
+    // No token model; real validation happens in the plugin (service-account
+    // key + Pub/Sub). Report ok so channel-config flows don't false-negative.
+    return { ok: true, botName: 'Google Chat' }
+  },
+
+  formatMessage: (text) => text,
+  splitMessage: (text) => splitMessage(text, GOOGLECHAT_MAX_MESSAGE_LENGTH),
+}
+
 // -- Slack App manifest --
 
 const SLACK_BOT_SCOPES = [
@@ -378,12 +417,14 @@ export function getSlackAppSetupInstructions(): string[] {
 export function getChannelToken(provider: ChannelProviderType, env: Record<string, string>): string {
   if (provider === 'slack') return env['SLACK_BOT_TOKEN'] ?? ''
   if (provider === 'discord') return env['DISCORD_BOT_TOKEN'] ?? ''
+  if (provider === 'googlechat') return env['GOOGLECHAT_PROJECT_ID'] ?? ''
   return env['TELEGRAM_BOT_TOKEN'] ?? ''
 }
 
 export function getChannelChatId(provider: ChannelProviderType, env: Record<string, string>): string {
   if (provider === 'slack') return env['SLACK_CHANNEL_ID'] ?? ''
   if (provider === 'discord') return env['DISCORD_CHANNEL_ID'] ?? ''
+  if (provider === 'googlechat') return env['GOOGLECHAT_SPACE_ID'] ?? ''
   return env['ALLOWED_CHAT_ID'] ?? ''
 }
 
@@ -393,6 +434,7 @@ const providers: Record<ChannelProviderType, ChannelProvider> = {
   telegram: telegramProvider,
   slack: slackProvider,
   discord: discordProvider,
+  googlechat: googlechatProvider,
 }
 
 export function getProvider(type: ChannelProviderType): ChannelProvider {
@@ -402,6 +444,7 @@ export function getProvider(type: ChannelProviderType): ChannelProvider {
 export function getProviderType(envValue: string | undefined): ChannelProviderType {
   if (envValue === 'slack') return 'slack'
   if (envValue === 'discord') return 'discord'
+  if (envValue === 'googlechat') return 'googlechat'
   return 'telegram'
 }
 
@@ -409,7 +452,11 @@ export function channelStateDir(provider: ChannelProviderType, agentDir?: string
   const base = agentDir
     ? join(agentDir, '.claude', 'channels')
     : join(homedir(), '.claude', 'channels')
-  const subdir = provider === 'slack' ? 'slack' : provider === 'discord' ? 'discord' : 'telegram'
+  const subdir =
+    provider === 'slack' ? 'slack'
+    : provider === 'discord' ? 'discord'
+    : provider === 'googlechat' ? 'googlechat'
+    : 'telegram'
   return join(base, subdir)
 }
 
@@ -421,7 +468,13 @@ export function readChannelToken(provider: ChannelProviderType, envFilePath: str
   } catch {
     return null
   }
-  const key = provider === 'slack' ? 'SLACK_BOT_TOKEN' : provider === 'discord' ? 'DISCORD_BOT_TOKEN' : 'TELEGRAM_BOT_TOKEN'
+  // Google Chat has no bot token; GOOGLECHAT_PROJECT_ID standing in the .env
+  // signals the channel is configured (used by agentHasChannel / hasChannel).
+  const key =
+    provider === 'slack' ? 'SLACK_BOT_TOKEN'
+    : provider === 'discord' ? 'DISCORD_BOT_TOKEN'
+    : provider === 'googlechat' ? 'GOOGLECHAT_PROJECT_ID'
+    : 'TELEGRAM_BOT_TOKEN'
   const match = content.match(new RegExp(`${key}=(.+)`))
   return match ? match[1].trim() : null
 }

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -43,6 +43,7 @@ export const CHANNEL_PLUGIN_IDS: Record<string, string> = {
   telegram: 'telegram@claude-plugins-official',
   slack: 'slack-channel@marveen-marketplace',
   discord: 'discord@claude-plugins-official',
+  googlechat: 'googlechat@claude-channel-googlechat',
 }
 
 // Pure: compute the enabledPlugins map for a sub-agent so that exactly its own
@@ -91,7 +92,7 @@ export function ownChannelProviderForScope(
 
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
-  if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord') return perAgent
+  if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord' || perAgent === 'googlechat') return perAgent
   return CHANNEL_PROVIDER
 }
 
@@ -350,11 +351,11 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
         // flag: a real own bot token in this agent's channel .env (token, above).
         // A genuine own-token agent enables its own provider's plugin; a channel-
         // less agent (no own token, only the legacy/global fallback that still
-        // marks hasChannel) yields null -> all three disabled, so it never fights
-        // the main agent over the shared getUpdates slot. Keying on the explicit
-        // channelProvider config field instead (always null for sub-agents) was
-        // the regression that disabled the plugin for every legitimately-channelled
-        // sub-agent after a respawn (truly-unreachable plugin, no bun poller).
+        // marks hasChannel) yields null -> all providers disabled, so it never
+        // fights the main agent over the shared getUpdates slot. Keying on the
+        // explicit channelProvider config field instead (always null for sub-agents)
+        // was the regression that disabled the plugin for every legitimately-
+        // channelled sub-agent after a respawn (truly-unreachable plugin, no poller).
         s.enabledPlugins = scopeChannelPlugins(
           ownChannelProviderForScope(!!token, agentProvider),
           s.enabledPlugins as Record<string, boolean> | undefined,
@@ -386,7 +387,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // omit --continue so the heavy accumulated context is dropped. Without it
     // we resume the prior session (the 'continue' mode / normal restart).
     const continueFlag = (hasPriorSession && !opts.fresh) ? '--continue ' : ''
-    const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : 'TELEGRAM_STATE_DIR'
+    const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : agentProvider === 'googlechat' ? 'GOOGLECHAT_STATE_DIR' : 'TELEGRAM_STATE_DIR'
     const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN'
     // Slack plugin is third-party; its "not on approved allowlist" check is
     // bypassed via `allowedChannelPlugins` in /Library/Application Support/ClaudeCode/managed-settings.json.

--- a/src/web/channel-poller-reap.ts
+++ b/src/web/channel-poller-reap.ts
@@ -33,6 +33,7 @@ const STATE_ENV_VAR: Record<ChannelProviderType, string> = {
   telegram: 'TELEGRAM_STATE_DIR',
   slack: 'SLACK_STATE_DIR',
   discord: 'DISCORD_STATE_DIR',
+  googlechat: 'GOOGLECHAT_STATE_DIR',
 }
 
 // Parse `ps eww -e` output and return every PID whose process environment

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -43,6 +43,7 @@ import {
 import {
   readAgentTelegramConfig,
   readAgentDiscordConfig,
+  readAgentGooglechatConfig,
   readMarveenTelegramConfig,
   sendAvatarChangeMessage,
   sendWelcomeMessage,
@@ -105,7 +106,7 @@ import { suggestForAgent, type AgentSignals } from '../model-suggest.js'
 import { getTokenSummary } from '../token-usage.js'
 import { listScheduledTasks } from '../scheduled-tasks-io.js'
 
-const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord'])
+const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord', 'googlechat'])
 
 // Short-TTL caches so the synchronous, frequently-polled status endpoints
 // (`/api/agents` on load, `/api/agents/activity` every 3s) don't issue a fresh
@@ -142,7 +143,7 @@ function parseChannelProvider(raw: string): ChannelProviderType | null {
 // Match both new /channels/:provider/ and legacy /telegram/ URL patterns.
 // Returns [agentName, provider] or null. Legacy routes always resolve to 'telegram'.
 function matchChannelRoute(path: string, suffix: string): [string, ChannelProviderType] | null {
-  const newPattern = new RegExp(`^/api/agents/([^/]+)/channels/(telegram|slack|discord)${suffix}$`)
+  const newPattern = new RegExp(`^/api/agents/([^/]+)/channels/(telegram|slack|discord|googlechat)${suffix}$`)
   const newMatch = path.match(newPattern)
   if (newMatch) {
     const provider = parseChannelProvider(newMatch[2])
@@ -223,6 +224,7 @@ export function setAgentEnabledPlugins(name: string, provider: ChannelProviderTy
     telegram: 'telegram@claude-plugins-official',
     slack: 'slack-channel@marveen-marketplace',
     discord: 'discord@claude-plugins-official',
+    googlechat: 'googlechat@claude-channel-googlechat',
   }
   for (const [p, pluginKey] of Object.entries(allPlugins)) {
     plugins[pluginKey] = p === provider
@@ -301,6 +303,7 @@ interface AgentSummary {
   hasTelegram: boolean
   telegramBotUsername?: string
   hasDiscord: boolean
+  hasGooglechat: boolean
   status: 'configured' | 'draft'
   running: boolean
   /** Tri-state: 'running' | 'stopped' | 'unreachable' (remote ssh failure). */
@@ -336,6 +339,7 @@ function getAgentSummary(name: string): AgentSummary {
   const soulMd = readFileOr(join(dir, 'SOUL.md'), '')
   const tg = readAgentTelegramConfig(name)
   const dc = readAgentDiscordConfig(name)
+  const gc = readAgentGooglechatConfig(name)
   const hasClaudeMd = claudeMd.trim().length > 0
   const hasSoulMd = soulMd.trim().length > 0
 
@@ -366,6 +370,7 @@ function getAgentSummary(name: string): AgentSummary {
     hasTelegram: tg.hasTelegram,
     telegramBotUsername: tg.botUsername,
     hasDiscord: dc.hasDiscord,
+    hasGooglechat: gc.hasGooglechat,
     status: hasClaudeMd && hasSoulMd ? 'configured' : 'draft',
     running,
     runState,
@@ -790,6 +795,54 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (!isMain && !existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
 
     const body = await readBody(req)
+
+    // Google Chat is creds-based (service-account key + Pub/Sub), not a bot
+    // token. Handle it on its own path: write the channel .env + identity
+    // access.json, enable the plugin, and restart.
+    if (provider === 'googlechat') {
+      const { saKeyPath, projectId, subscription, owner, allowDomain } =
+        JSON.parse(body.toString()) as { saKeyPath?: string; projectId?: string; subscription?: string; owner?: string; allowDomain?: string }
+      if (!saKeyPath?.trim() || !projectId?.trim() || !subscription?.trim() || !owner?.trim()) {
+        json(res, { error: 'Google Chat: saKeyPath, projectId, subscription és owner kötelező' }, 400); return true
+      }
+      const gcDir = isMain ? channelStateDir(provider) : channelStateDir(provider, agentDir(name))
+      mkdirSync(gcDir, { recursive: true })
+      const gcEnv =
+        `GOOGLE_APPLICATION_CREDENTIALS=${saKeyPath.trim()}\n` +
+        `GOOGLECHAT_PROJECT_ID=${projectId.trim()}\n` +
+        `GOOGLECHAT_SUBSCRIPTION=${subscription.trim()}\n`
+      atomicWriteFileSync(join(gcDir, '.env'), gcEnv, { mode: 0o600 })
+      atomicWriteFileSync(join(gcDir, 'access.json'), JSON.stringify({
+        policy: allowDomain?.trim() ? 'domain' : 'allowlist',
+        owner: owner.trim(),
+        allowFrom: [],
+        allowDomains: allowDomain?.trim() ? [allowDomain.trim()] : [],
+        roles: {},
+        spaces: {},
+        flatReplies: true,
+      }, null, 2))
+      let gcRestarted = false
+      let gcWasRunning = false
+      if (isMain) {
+        const r = hardRestartMarveenChannels()
+        gcRestarted = r.ok
+        gcWasRunning = true
+      } else {
+        writeAgentChannelProvider(name, provider)
+        setAgentEnabledPlugins(name, provider)
+        gcWasRunning = isAgentRunning(name)
+        if (gcWasRunning) {
+          const stopRes = stopAgentProcess(name)
+          if (stopRes.ok) {
+            try { execSync('sleep 2', { timeout: 4000 }) } catch {}
+            gcRestarted = startAgentProcess(name).ok
+          }
+        }
+      }
+      json(res, { ok: true, botName: 'Google Chat', restarted: gcRestarted, wasRunning: gcWasRunning })
+      return true
+    }
+
     const { botToken, appToken, channelId } = JSON.parse(body.toString()) as { botToken: string; appToken?: string; channelId?: string }
     if (!botToken?.trim()) { json(res, { error: 'botToken is required' }, 400); return true }
 

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -8,7 +8,7 @@ import {
   KANBAN_LABEL_COLORS,
 } from '../../config.js'
 import { getEffectiveSettingValue } from '../../settings-store.js'
-import { readMarveenTelegramConfig, readMarveenDiscordConfig, readMarveenSlackConfig, sendMarveenAvatarChange } from '../telegram.js'
+import { readMarveenTelegramConfig, readMarveenDiscordConfig, readMarveenSlackConfig, readMarveenGooglechatConfig, sendMarveenAvatarChange } from '../telegram.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
 import { readFileOr } from '../agent-config.js'
 import { parseMultipart } from '../multipart.js'
@@ -63,6 +63,7 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
     const tg = readMarveenTelegramConfig()
     const dc = readMarveenDiscordConfig()
     const sl = readMarveenSlackConfig()
+    const gc = readMarveenGooglechatConfig()
     // Brand-relevant identity core. `name` = main agent display name (BOT_NAME),
     // `brandName` = product brand for the dashboard chrome (defaults to BOT_NAME;
     // the client falls back to its own HTML default "Marveen" if absent on a
@@ -83,6 +84,7 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
       hasTelegram: tg.hasTelegram,
       hasDiscord: dc.hasDiscord,
       hasSlack: sl.hasSlack,
+      hasGooglechat: gc.hasGooglechat,
       telegramBotUsername: tg.botUsername,
       personality: soulSection,
       claudeMd,

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -24,6 +24,15 @@ export function readAgentDiscordConfig(name: string): { hasDiscord: boolean; bot
   return { hasDiscord: true }
 }
 
+// Google Chat is creds-based (no bot token): a configured agent has
+// GOOGLECHAT_PROJECT_ID in its channel .env (see channel-provider readChannelToken).
+export function readAgentGooglechatConfig(name: string): { hasGooglechat: boolean } {
+  const envPath = join(agentDir(name), '.claude', 'channels', 'googlechat', '.env')
+  if (!existsSync(envPath)) return { hasGooglechat: false }
+  const m = readFileOr(envPath, '').match(/GOOGLECHAT_PROJECT_ID=(.+)/)
+  return { hasGooglechat: !!m?.[1]?.trim() }
+}
+
 // Marveen's Telegram channel lives under the global ~/.claude path, not
 // under agents/marveen, because the main agent reuses the system Claude
 // Code channel install. Read it the same way the plugin does.
@@ -47,6 +56,13 @@ export function readMarveenDiscordConfig(): { hasDiscord: boolean } {
   if (!existsSync(envPath)) return { hasDiscord: false }
   const tokenMatch = readFileOr(envPath, '').match(/DISCORD_BOT_TOKEN=(.+)/)
   return { hasDiscord: !!tokenMatch?.[1]?.trim() }
+}
+
+export function readMarveenGooglechatConfig(): { hasGooglechat: boolean } {
+  const envPath = join(homedir(), '.claude', 'channels', 'googlechat', '.env')
+  if (!existsSync(envPath)) return { hasGooglechat: false }
+  const m = readFileOr(envPath, '').match(/GOOGLECHAT_PROJECT_ID=(.+)/)
+  return { hasGooglechat: !!m?.[1]?.trim() }
 }
 
 export function readMarveenSlackConfig(): { hasSlack: boolean } {


### PR DESCRIPTION
## What
Adds a `googlechat` channel provider so a fleet sub-agent can run on **Google Chat** (Workspace), bridged over **Cloud Pub/Sub** by a standalone Claude Code channel plugin, with identity-based (Workspace email) access control.

## Why
Google Chat has no bot-token model (service account + Pub/Sub) and only forwards `@mention` events to apps in spaces. This wires it into the existing provider abstraction so a sub-agent can be `channelProvider: "googlechat"` just like telegram/slack/discord.

## Changes (backend / API layer)
- **channel-provider**: googlechat provider (pluginId, state dir, resolver branches). No token; `GOOGLECHAT_PROJECT_ID` in the channel `.env` signals "configured".
- **agent-process**: per-agent `GOOGLECHAT_STATE_DIR`, plugin scoping via `CHANNEL_PLUGIN_IDS`.
- **channel-poller-reap** + **channel-coordinator/provider-poller-match**: googlechat poller match.
- **routes/agents**: `VALID_PROVIDERS`, channel route, plugin enablement, a creds-based setup branch (`saKeyPath`/`projectId`/`subscription`/`owner`/`allowDomain`), `hasGooglechat`.
- **telegram** + **routes/marveen**: `hasGooglechat` connected-state.

7 files, +140/-13. `npm run build` + `npm test` green on top of latest `main`.

## Companion plugin
The standalone channel plugin (Pub/Sub pull inbound, identity gate, reply/react/edit/download tools, add-on event-envelope parsing) lives in its own repo and is referenced by plugin id `googlechat@<marketplace>`. One-time GCP setup (project, Chat API + Pub/Sub, topic + per-agent subscription, the `gcp-sa-gsuiteaddons` publisher grant, SA key, Chat-app Pub/Sub connection) is documented there.

## Notes
- One GCP project = one Chat app = one bot; each googlechat agent needs its **own** Pub/Sub subscription (subscribers on one subscription load-balance).
- The managed-settings `allowedChannelPlugins` allowlist must include the plugin id.
- Dashboard UI for *selecting* Google Chat is intentionally out of scope here (kept to the provider/API layer); a UI can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
