### PR TITLE
feat(kanban): archived cards dedicated view with restore

### DIFF
--- a/docs/archivalt-kartyak.md
+++ b/docs/archivalt-kartyak.md
@@ -1,0 +1,84 @@
+# Archivált kártyák
+
+> A kanban tábláról eltüntetett, befejezett vagy félretett kártyák dedikált áttekintő nézete, visszaállítással.
+
+---
+
+## Mit tud / miért érdekes
+
+A kanban tábla automatikusan archiválja a `done` állapotú kártyákat, ha azok `KANBAN_ARCHIVE_DONE_DAYS` napnál régebbiek (alapértelmezés: 30 nap). Ezek az "Archivált" nézetben megmaradnak és kereshetők, de nem zsúfolják a táblát.
+
+Az archivált nézet:
+- Teljes szöveges keresés (cím, projekt, felelős).
+- Szűrés projekt, dátumtartomány szerint.
+- Visszaállítás gombbal kártyanként (a kártya visszakerül a táblára).
+
+---
+
+## Konfiguráció
+
+| Kulcs | Leírás | Alapértelmezés |
+|-------|--------|----------------|
+| `KANBAN_ARCHIVE_DONE_DAYS` | Ennyi napnál régebbi "done" kártyák archiválódnak. | 30 |
+| `KANBAN_ARCHIVED_MAX_ROWS` | Az archivált nézetben egyszerre megjelenített kártyák maximuma. | 500 |
+
+Mindkét érték a Beállítások oldalon változtatható, újraindítás nélkül érvényes.
+
+---
+
+## API
+
+### GET /api/kanban/archived
+
+Lekéri az archivált kártyákat. Az eredmény tartalmazza a kártyánkénti cimkéket is.
+
+Query paraméterek (mind opcionális):
+
+| Paraméter | Típus | Leírás |
+|-----------|-------|--------|
+| `q` | string | Szabad szöveges keresés (cím, projekt, felelős). |
+| `project` | string | Projektre szűrés (pontos egyezés). |
+| `label` | string | Cimke nevére szűrés. |
+| `from` | unix timestamp | Archiválás időpontja ettől. |
+| `to` | unix timestamp | Archiválás időpontja eddig. |
+| `limit` | int | Max visszaadott elemszám (legfeljebb 5000; alapértelmezés: `KANBAN_ARCHIVED_MAX_ROWS`). |
+
+Válasz:
+
+```json
+{
+  "cards": [
+    {
+      "id": "AB12CD34",
+      "title": "Kártya neve",
+      "status": "done",
+      "project": "Projekt neve",
+      "priority": "normal",
+      "assignee": "jarvis",
+      "archived_at": 1718000000,
+      "updated_at": 1718000000,
+      "labels": [{ "id": "x1", "name": "AI", "color": "#3b82f6" }]
+    }
+  ],
+  "total": 1,
+  "limit": 500
+}
+```
+
+### POST /api/kanban/:id/unarchive
+
+Visszaállít egy archivált kártyát (`archived_at = NULL`). Csak archivált kártyán működik; aktív kártyán 404-et ad vissza.
+
+```bash
+curl -s -X POST http://localhost:3420/api/kanban/AB12CD34/unarchive \
+  -H "Authorization: Bearer $(cat store/.dashboard-token)"
+```
+
+Válasz: `{ "ok": true }`
+
+---
+
+## Megjegyzések
+
+- Az archivált nézet csak-olvasható -- szerkesztés vagy státuszváltás a visszaállítás után a rendes kanban táblán lehetséges.
+- A `listKanbanCards()` és a heartbeat-szűrők (`archived_at IS NULL`) változatlanok maradnak; az archivált kártyák nem jelennek meg a táblán és nem kerülnek be a heartbeat-összefoglalóba.

--- a/docs/archivalt-kartyak.md
+++ b/docs/archivalt-kartyak.md
@@ -4,14 +4,31 @@
 
 ---
 
-## Mit tud / miért érdekes
+## Használat
 
-A kanban tábla automatikusan archiválja a `done` állapotú kártyákat, ha azok `KANBAN_ARCHIVE_DONE_DAYS` napnál régebbiek (alapértelmezés: 30 nap). Ezek az "Archivált" nézetben megmaradnak és kereshetők, de nem zsúfolják a táblát.
+A bal oldali navigációban a "Archivált" menüpont nyitja meg a nézetet. A kanban tábla automatikusan archiválja a lezárt (`done`) kártyákat, ha azok a megadott napszámnál (alapértelmezés: 30 nap) régebben kerültek done állapotba -- ezek eltűnnek a táblából, de az Archivált nézetben megmaradnak és visszakereshetők.
 
-Az archivált nézet:
-- Teljes szöveges keresés (cím, projekt, felelős).
-- Szűrés projekt, dátumtartomány szerint.
-- Visszaállítás gombbal kártyanként (a kártya visszakerül a táblára).
+**Keresés**
+
+A keresőmezőbe begépelt szöveg a kártya címe, projektje és felelőse között keres egyszerre. A találatok azonnal szűkülnek gépelés közben.
+
+**Szűrés**
+
+A keresőmező mellett három szűrő érhető el:
+
+- Projekt -- legördülő vagy szöveges szűrő a projekt neve alapján (pontos egyezés)
+- Cimke -- egy konkrét cimke szerint szűr
+- Dátumtartomány ("Ettől" / "Eddig") -- az archiválás időpontja alapján szűkíti a listát; mindkét mező opcionális
+
+**Kártya visszaállítása**
+
+Minden kártya sorában egy "Visszaállítás" gomb jelenik meg. Rákattintva a kártya visszakerül a kanban táblára (done státuszban), és ismét megjelenik a szokásos nézeten -- utána szerkeszthető, státusza változtatható.
+
+**Fontos tudnivalók**
+
+- Az archivált nézet csak-olvasható: szerkesztés és státuszváltás visszaállítás után lehetséges a rendes kanban táblán
+- Alapértelmezés szerint legfeljebb 500 kártya jelenik meg egyszerre -- ez a Beállítások oldalon módosítható (`KANBAN_ARCHIVED_MAX_ROWS`)
+- Az archivált kártyák nem szerepelnek a szokásos kanban táblán és nem kerülnek be a heartbeat-összefoglalókba
 
 ---
 

--- a/docs/en/archived-cards.md
+++ b/docs/en/archived-cards.md
@@ -4,14 +4,31 @@
 
 ---
 
-## Overview
+## Using the archive
 
-The kanban board auto-archives `done` cards older than `KANBAN_ARCHIVE_DONE_DAYS` days (default: 30) during the next `listKanbanCards()` call. The Archived view lets you browse and search those cards without cluttering the board, and restore any card back to active status.
+Open the view from the "Archivált" entry in the left-hand navigation. The kanban board automatically archives closed (`done`) cards once they have been in that state longer than the configured threshold (default: 30 days) -- they disappear from the board but remain searchable in the Archived view.
 
-Features:
-- Full-text search (title, project, assignee).
-- Filter by project and date range.
-- Per-card restore button (sets `archived_at = NULL`).
+**Search**
+
+Text typed in the search field matches across card title, project, and assignee simultaneously. Results narrow as you type.
+
+**Filters**
+
+Three filters sit alongside the search field:
+
+- Project -- filter by exact project name
+- Label -- filter by a single label
+- Date range ("From" / "To") -- narrows by the time the card was archived; both inputs are optional
+
+**Restoring a card**
+
+Each row has a Restore button. Clicking it moves the card back to the active kanban board (in `done` status), where it reappears in the normal view and can be edited or moved to a different status.
+
+**Key things to know**
+
+- The archived view is read-only: editing and status changes are only possible after restoring the card to the active board
+- Up to 500 cards are shown at once by default -- adjustable on the Settings page (`KANBAN_ARCHIVED_MAX_ROWS`)
+- Archived cards do not appear on the kanban board and are excluded from heartbeat summaries
 
 ---
 

--- a/docs/en/archived-cards.md
+++ b/docs/en/archived-cards.md
@@ -1,0 +1,84 @@
+# Archived Cards
+
+> A dedicated view for kanban cards removed from the active board, with search and restore.
+
+---
+
+## Overview
+
+The kanban board auto-archives `done` cards older than `KANBAN_ARCHIVE_DONE_DAYS` days (default: 30) during the next `listKanbanCards()` call. The Archived view lets you browse and search those cards without cluttering the board, and restore any card back to active status.
+
+Features:
+- Full-text search (title, project, assignee).
+- Filter by project and date range.
+- Per-card restore button (sets `archived_at = NULL`).
+
+---
+
+## Configuration
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `KANBAN_ARCHIVE_DONE_DAYS` | Days after which `done` cards are auto-archived. | 30 |
+| `KANBAN_ARCHIVED_MAX_ROWS` | Maximum cards returned by the archived view at once. | 500 |
+
+Both settings are hot-reloaded; no restart required.
+
+---
+
+## API
+
+### GET /api/kanban/archived
+
+Returns archived cards with embedded labels per card.
+
+Query parameters (all optional):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `q` | string | Free-text search (title, project, assignee). |
+| `project` | string | Exact project name filter. |
+| `label` | string | Label name filter. |
+| `from` | unix timestamp | Archived-at lower bound. |
+| `to` | unix timestamp | Archived-at upper bound. |
+| `limit` | int | Max rows returned (capped at 5000; defaults to `KANBAN_ARCHIVED_MAX_ROWS`). |
+
+Response:
+
+```json
+{
+  "cards": [
+    {
+      "id": "AB12CD34",
+      "title": "Card title",
+      "status": "done",
+      "project": "Project name",
+      "priority": "normal",
+      "assignee": "jarvis",
+      "archived_at": 1718000000,
+      "updated_at": 1718000000,
+      "labels": [{ "id": "x1", "name": "AI", "color": "#3b82f6" }]
+    }
+  ],
+  "total": 1,
+  "limit": 500
+}
+```
+
+### POST /api/kanban/:id/unarchive
+
+Restores a single archived card (`archived_at = NULL`). Returns 404 if the card is not archived or does not exist.
+
+```bash
+curl -s -X POST http://localhost:3420/api/kanban/AB12CD34/unarchive \
+  -H "Authorization: Bearer $(cat store/.dashboard-token)"
+```
+
+Response: `{ "ok": true }`
+
+---
+
+## Notes
+
+- The archived view is read-only. Editing or moving a card is only possible after restoring it to the active board.
+- `listKanbanCards()`, `listKanbanCardsSummary()`, `getChildCards()`, `listKanbanProjects()` and the heartbeat summary all retain their `archived_at IS NULL` filters unchanged.

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -132,6 +132,17 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: false,
     requiresRestart: false,
   },
+  {
+    key: 'KANBAN_ARCHIVED_MAX_ROWS',
+    type: 'int',
+    default: 500,
+    min: 10,
+    max: 5000,
+    description: 'Az archivált kártya-nézetben egyszerre megjelenített kártyák maximális száma.',
+    module: 'kanban',
+    secret: false,
+    requiresRestart: false,
+  },
   // --- Kanban aging thresholds and colours (hot-reload via settings-store) ---
   {
     key: 'KANBAN_AGING_WARN_H',

--- a/src/db.ts
+++ b/src/db.ts
@@ -1137,6 +1137,57 @@ export function archiveKanbanCard(id: string): boolean {
   return db.prepare('UPDATE kanban_cards SET archived_at=?, updated_at=? WHERE id=?').run(now, now, id).changes > 0
 }
 
+export function unarchiveKanbanCard(id: string): boolean {
+  const now = Math.floor(Date.now() / 1000)
+  return db.prepare('UPDATE kanban_cards SET archived_at=NULL, updated_at=? WHERE id=? AND archived_at IS NOT NULL').run(now, id).changes > 0
+}
+
+export interface ArchivedKanbanCard {
+  id: string
+  title: string
+  status: string
+  project: string | null
+  priority: string
+  assignee: string | null
+  archived_at: number
+  updated_at: number
+}
+
+export function listArchivedKanbanCards(opts: {
+  q?: string
+  project?: string
+  label?: string
+  from?: number
+  to?: number
+  limit: number
+}): ArchivedKanbanCard[] {
+  const { q, project, label, from, to, limit } = opts
+  let sql = `
+    SELECT DISTINCT kc.id, kc.title, kc.status, kc.project, kc.priority, kc.assignee, kc.archived_at, kc.updated_at
+    FROM kanban_cards kc
+  `
+  const params: unknown[] = []
+  if (label) {
+    sql += `
+      JOIN kanban_card_labels kcl ON kcl.card_id = kc.id
+      JOIN labels l ON l.id = kcl.label_id AND l.name = ?
+    `
+    params.push(label)
+  }
+  sql += ' WHERE kc.archived_at IS NOT NULL'
+  if (project) { sql += ' AND kc.project = ?'; params.push(project) }
+  if (from)    { sql += ' AND kc.archived_at >= ?'; params.push(from) }
+  if (to)      { sql += ' AND kc.archived_at <= ?'; params.push(to) }
+  if (q) {
+    sql += ' AND (kc.title LIKE ? OR kc.project LIKE ? OR kc.assignee LIKE ?)'
+    const like = `%${q}%`
+    params.push(like, like, like)
+  }
+  sql += ' ORDER BY kc.archived_at DESC LIMIT ?'
+  params.push(limit)
+  return db.prepare(sql).all(...params) as ArchivedKanbanCard[]
+}
+
 export function listKanbanProjects(): string[] {
   const rows = db.prepare(
     "SELECT DISTINCT project FROM kanban_cards WHERE project IS NOT NULL AND project != '' AND archived_at IS NULL ORDER BY project"

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -2,12 +2,13 @@ import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 import {
   listKanbanCards, createKanbanCard, updateKanbanCard,
-  deleteKanbanCard, moveKanbanCard, archiveKanbanCard,
+  deleteKanbanCard, moveKanbanCard, archiveKanbanCard, unarchiveKanbanCard,
   getKanbanComments, addKanbanComment, listKanbanProjects,
   getKanbanCard, getChildCards, getDb,
   createAgentMessage, markKanbanCardDispatched,
   listLabels, getLabel, createLabel, updateLabel, deleteLabel,
   addLabelToCard, removeLabelFromCard, getLabelsForAllCards, getLabelsForCard,
+  listArchivedKanbanCards,
   revertIdeaFromKanban,
 } from '../../db.js'
 import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, STORE_DIR, WEB_HOST, WEB_PORT, KANBAN_LABEL_COLORS } from '../../config.js'
@@ -17,6 +18,7 @@ import { resolveKanbanDispatchTarget } from '../../kanban-dispatch.js'
 import { generateBreakdown } from '../llm-breakdown.js'
 import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
+import { getEffectiveSettingValue } from '../../settings-store.js'
 import type { RouteContext } from './types.js'
 
 // A headless agent cannot "drag" a card to done, so the dispatch hands it the
@@ -223,6 +225,29 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
     revertIdeaFromKanban(id)
     if (archiveKanbanCard(id)) { json(res, { ok: true }); return true }
     json(res, { error: 'Kártya nem található' }, 404)
+    return true
+  }
+
+  if (path === '/api/kanban/archived' && method === 'GET') {
+    const sp      = ctx.url.searchParams
+    const q       = sp.get('q')?.trim() || undefined
+    const project = sp.get('project')?.trim() || undefined
+    const label   = sp.get('label')?.trim() || undefined
+    const from    = sp.get('from')  ? Number(sp.get('from'))  : undefined
+    const to      = sp.get('to')    ? Number(sp.get('to'))    : undefined
+    const limit   = Math.min(Number(sp.get('limit') ?? 0) || Number(getEffectiveSettingValue('KANBAN_ARCHIVED_MAX_ROWS')), 5000)
+    const labelsByCard = getLabelsForAllCards()
+    const cards = listArchivedKanbanCards({ q, project, label, from, to, limit })
+      .map(card => ({ ...card, labels: labelsByCard.get(card.id) ?? [] }))
+    json(res, { cards, total: cards.length, limit })
+    return true
+  }
+
+  const kanbanUnarchiveMatch = path.match(/^\/api\/kanban\/([^/]+)\/unarchive$/)
+  if (kanbanUnarchiveMatch && method === 'POST') {
+    const id = decodeURIComponent(kanbanUnarchiveMatch[1])
+    if (unarchiveKanbanCard(id)) { json(res, { ok: true }); return true }
+    json(res, { error: 'Kártya nem található vagy nincs archiválva' }, 404)
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -113,6 +113,7 @@ function switchPage(pageId) {
   if (pageId === 'messages') loadMessagesPage()
   if (pageId === 'tokenUsage') loadTokenUsage()
   if (pageId === 'ideas') loadIdeasPage()
+  if (pageId === 'archived') loadArchivedPage()
 }
 
 // Mobile off-canvas sidebar toggle. No-op visual effect on desktop (the
@@ -11159,4 +11160,127 @@ function downloadMarkdown(name, content) {
   btn.addEventListener('click', () => { render(); openModal(overlay) })
   if (closeBtn) closeBtn.addEventListener('click', () => closeModal(overlay))
   overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(overlay) })
+})()
+
+// === Archivalt kartyak ===
+;(() => {
+  let archivedInit = false
+
+  const STATUS_LABELS = { planned: 'Tervezett', in_progress: 'Folyamatban', waiting: 'Várakozik', done: 'Kész' }
+  const STATUS_COLORS = { planned: '#6b7280', in_progress: '#3b82f6', waiting: '#f59e0b', done: '#10b981' }
+  const PRIORITY_LABELS = { low: 'Alacsony', normal: 'Normál', high: 'Magas', urgent: 'Sürgős' }
+  const PRIORITY_COLORS = { low: '#9ca3af', normal: '#6b7280', high: '#f59e0b', urgent: '#ef4444' }
+
+  function fmtDate(unix) {
+    if (!unix) return ''
+    return new Date(unix * 1000).toLocaleString('hu-HU', { dateStyle: 'short', timeStyle: 'short' })
+  }
+
+  function renderArchivedCard(card) {
+    const statusColor = STATUS_COLORS[card.status] || '#6b7280'
+    const statusLabel = STATUS_LABELS[card.status] || card.status
+    const prioColor = PRIORITY_COLORS[card.priority] || '#6b7280'
+    const prioLabel = PRIORITY_LABELS[card.priority] || card.priority
+    const projectBadge = card.project
+      ? `<span class="naplo-badge" style="background:#4b5563;font-size:11px">${esc(card.project)}</span>`
+      : ''
+    const statusBadge = `<span class="naplo-badge" style="background:${statusColor};font-size:11px">${statusLabel}</span>`
+    const prioBadge = `<span class="naplo-badge" style="background:${prioColor};font-size:11px">${prioLabel}</span>`
+    const labelBadges = (card.labels || [])
+      .map(l => `<span class="naplo-badge" style="background:${esc(l.color)};font-size:11px">${esc(l.name)}</span>`)
+      .join(' ')
+    const assigneeStr = card.assignee ? `<span style="font-size:12px;color:var(--muted)">@${esc(card.assignee)}</span>` : ''
+    const archivedStr = `<span style="font-size:12px;color:var(--muted)">Archiválva: ${fmtDate(card.archived_at)}</span>`
+    return `<div class="naplo-entry" style="display:flex;justify-content:space-between;align-items:flex-start;gap:8px;">
+      <div style="flex:1;min-width:0;">
+        <div style="font-weight:500;margin-bottom:4px;">${esc(card.title)}</div>
+        <div style="display:flex;flex-wrap:wrap;gap:4px;align-items:center;">
+          ${statusBadge}${prioBadge}${projectBadge}${labelBadges}${assigneeStr}
+        </div>
+        <div style="margin-top:4px;">${archivedStr}</div>
+      </div>
+      <button class="btn-secondary btn-compact archived-restore-btn" data-id="${esc(card.id)}" title="Visszaállítás a táblára" style="white-space:nowrap;flex-shrink:0;">Visszaállítás</button>
+    </div>`
+  }
+
+  async function populateArchivedProjects() {
+    try {
+      const r = await fetch('/api/kanban-projects')
+      if (!r.ok) return
+      const projects = await r.json()
+      const sel = document.getElementById('archivedProject')
+      const cur = sel.value
+      sel.innerHTML = '<option value="">Minden projekt</option>'
+      for (const p of projects) {
+        const opt = document.createElement('option')
+        opt.value = p
+        opt.textContent = p
+        if (p === cur) opt.selected = true
+        sel.appendChild(opt)
+      }
+    } catch { /* best-effort */ }
+  }
+
+  async function doArchivedSearch() {
+    const list = document.getElementById('archivedList')
+    const summary = document.getElementById('archivedSummary')
+    list.innerHTML = '<p class="naplo-empty">Betöltés...</p>'
+    summary.textContent = ''
+
+    const params = new URLSearchParams()
+    const q = document.getElementById('archivedQ').value.trim()
+    const project = document.getElementById('archivedProject').value
+    const from = document.getElementById('archivedFrom').value
+    const to = document.getElementById('archivedTo').value
+    if (q) params.set('q', q)
+    if (project) params.set('project', project)
+    if (from) params.set('from', Math.floor(new Date(from).getTime() / 1000))
+    if (to) params.set('to', Math.floor(new Date(to + 'T23:59:59').getTime() / 1000))
+
+    try {
+      const r = await fetch('/api/kanban/archived?' + params.toString())
+      if (!r.ok) { list.innerHTML = `<p class="naplo-empty error">Hiba: ${r.status}</p>`; return }
+      const data = await r.json()
+      const cards = data.cards || []
+      summary.textContent = `${cards.length} kártya (max ${data.limit})`
+      if (cards.length === 0) { list.innerHTML = '<p class="naplo-empty">Nincs archivált kártya.</p>'; return }
+      list.innerHTML = cards.map(renderArchivedCard).join('')
+      list.querySelectorAll('.archived-restore-btn').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const id = btn.dataset.id
+          btn.disabled = true
+          btn.textContent = '...'
+          try {
+            const resp = await fetch(`/api/kanban/${id}/unarchive`, { method: 'POST' })
+            if (resp.ok) {
+              btn.closest('.naplo-entry').style.opacity = '0.4'
+              btn.textContent = 'Visszaállítva'
+            } else {
+              btn.disabled = false
+              btn.textContent = 'Visszaállítás'
+              alert('Hiba a visszaállításnál.')
+            }
+          } catch {
+            btn.disabled = false
+            btn.textContent = 'Visszaállítás'
+          }
+        })
+      })
+    } catch (err) {
+      list.innerHTML = `<p class="naplo-empty error">Hálózati hiba: ${err.message}</p>`
+    }
+  }
+
+  function loadArchivedPage() {
+    if (!archivedInit) {
+      archivedInit = true
+      document.getElementById('archivedSearchBtn').addEventListener('click', doArchivedSearch)
+      document.getElementById('archivedRefreshBtn').addEventListener('click', doArchivedSearch)
+      document.getElementById('archivedQ').addEventListener('keydown', e => { if (e.key === 'Enter') doArchivedSearch() })
+    }
+    populateArchivedProjects()
+    doArchivedSearch()
+  }
+
+  window.loadArchivedPage = loadArchivedPage
 })()

--- a/web/app.js
+++ b/web/app.js
@@ -11176,31 +11176,108 @@ function downloadMarkdown(name, content) {
     return new Date(unix * 1000).toLocaleString('hu-HU', { dateStyle: 'short', timeStyle: 'short' })
   }
 
+  // Render an archived card with the same visual language as the live board:
+  // project pill + #seq title + colored rounded priority/label chips, wrapped in
+  // the .kanban-card frame. The whole card opens a read-only detail modal on
+  // click; the restore button stops propagation so it doesn't also open it.
   function renderArchivedCard(card) {
-    const statusColor = STATUS_COLORS[card.status] || '#6b7280'
-    const statusLabel = STATUS_LABELS[card.status] || card.status
     const prioColor = PRIORITY_COLORS[card.priority] || '#6b7280'
     const prioLabel = PRIORITY_LABELS[card.priority] || card.priority
-    const projectBadge = card.project
-      ? `<span class="naplo-badge" style="background:#4b5563;font-size:11px">${esc(card.project)}</span>`
+    const seqHtml = card.seq != null
+      ? `<span class="kanban-card-seq" style="font-family:monospace;font-size:11px;color:var(--text-muted);margin-right:5px">#${card.seq}</span>`
       : ''
-    const statusBadge = `<span class="naplo-badge" style="background:${statusColor};font-size:11px">${statusLabel}</span>`
-    const prioBadge = `<span class="naplo-badge" style="background:${prioColor};font-size:11px">${prioLabel}</span>`
-    const labelBadges = (card.labels || [])
-      .map(l => `<span class="naplo-badge" style="background:${esc(l.color)};font-size:11px">${esc(l.name)}</span>`)
-      .join(' ')
-    const assigneeStr = card.assignee ? `<span style="font-size:12px;color:var(--muted)">@${esc(card.assignee)}</span>` : ''
-    const archivedStr = `<span style="font-size:12px;color:var(--muted)">Archiválva: ${fmtDate(card.archived_at)}</span>`
-    return `<div class="naplo-entry" style="display:flex;justify-content:space-between;align-items:flex-start;gap:8px;">
-      <div style="flex:1;min-width:0;">
-        <div style="font-weight:500;margin-bottom:4px;">${esc(card.title)}</div>
-        <div style="display:flex;flex-wrap:wrap;gap:4px;align-items:center;">
-          ${statusBadge}${prioBadge}${projectBadge}${labelBadges}${assigneeStr}
-        </div>
-        <div style="margin-top:4px;">${archivedStr}</div>
+    const projectHtml = card.project
+      ? `<span class="kanban-card-project">${esc(card.project)}</span>`
+      : ''
+    let labelsHtml = ''
+    if (Array.isArray(card.labels) && card.labels.length > 0) {
+      const pills = card.labels
+        .map(l => `<span class="kanban-card-label-pill" style="--label-color:${esc(l.color)}">#${esc(l.name)}</span>`)
+        .join('')
+      labelsHtml = `<div class="kanban-card-labels">${pills}</div>`
+    }
+    const prioPill = `<span class="archived-prio-pill" style="--prio-color:${prioColor}">${prioLabel}</span>`
+    return `<div class="kanban-card archived-card" data-id="${esc(card.id)}" data-priority="${esc(card.priority)}">
+      ${projectHtml}
+      <div class="kanban-card-title">${seqHtml}${esc(card.title)}</div>
+      <div class="kanban-card-footer">${prioPill}</div>
+      ${labelsHtml}
+      <div class="archived-card-foot">
+        <span class="archived-date">Archiválva: ${fmtDate(card.archived_at)}</span>
+        <button class="btn-secondary btn-compact archived-restore-btn" data-id="${esc(card.id)}" title="Visszaállítás a táblára" style="white-space:nowrap;flex-shrink:0;">Visszaállítás</button>
       </div>
-      <button class="btn-secondary btn-compact archived-restore-btn" data-id="${esc(card.id)}" title="Visszaállítás a táblára" style="white-space:nowrap;flex-shrink:0;">Visszaállítás</button>
     </div>`
+  }
+
+  // Read-only detail modal for an archived card: meta grid, labels, description,
+  // comments -- no editing affordances. Restore button mirrors the card button.
+  async function showArchivedDetail(card) {
+    const seqPrefix = card.seq != null ? `#${card.seq} ` : ''
+    document.getElementById('archivedDetailTitle').textContent = `${seqPrefix}${card.title}`
+    const meta = document.getElementById('archivedDetailMeta')
+    const idLabel = (card.seq != null ? `#${card.seq} · ` : '') + card.id
+    meta.innerHTML = `
+      <div class="meta-item"><span class="meta-label">Azonosító</span><span class="meta-value" style="font-family:monospace">${esc(idLabel)}</span></div>
+      <div class="meta-item"><span class="meta-label">Állapot</span><span class="meta-value">${STATUS_LABELS[card.status] || card.status}</span></div>
+      <div class="meta-item"><span class="meta-label">Felelős</span><span class="meta-value">${card.assignee ? esc(card.assignee) : '-- nincs --'}</span></div>
+      <div class="meta-item"><span class="meta-label">Prioritás</span><span class="meta-value">${PRIORITY_LABELS[card.priority] || card.priority}</span></div>
+      <div class="meta-item"><span class="meta-label">Projekt</span><span class="meta-value">${card.project ? esc(card.project) : '-- nincs --'}</span></div>
+      <div class="meta-item"><span class="meta-label">Archiválva</span><span class="meta-value">${fmtDate(card.archived_at)}</span></div>
+    `
+    const labelsWrap = document.getElementById('archivedDetailLabelsWrap')
+    const labelsBox = document.getElementById('archivedDetailLabels')
+    if (Array.isArray(card.labels) && card.labels.length > 0) {
+      labelsBox.innerHTML = card.labels
+        .map(l => `<span class="kanban-card-label-pill" style="--label-color:${esc(l.color)}">#${esc(l.name)}</span>`)
+        .join('')
+      labelsWrap.style.display = ''
+    } else {
+      labelsWrap.style.display = 'none'
+    }
+    document.getElementById('archivedDetailDesc').textContent = card.description || ''
+
+    const commentsWrap = document.getElementById('archivedDetailCommentsWrap')
+    const commentsBox = document.getElementById('archivedDetailComments')
+    commentsBox.innerHTML = ''
+    try {
+      const res = await fetch(`/api/kanban/${encodeURIComponent(card.id)}/comments`)
+      const comments = res.ok ? await res.json() : []
+      if (Array.isArray(comments) && comments.length > 0) {
+        for (const c of comments) {
+          const date = new Date(c.created_at * 1000).toLocaleString('hu-HU')
+          const div = document.createElement('div')
+          div.className = 'comment-item'
+          div.innerHTML = `<div><span class="comment-author">${esc(c.author)}</span><span class="comment-date">${date}</span></div><div class="comment-body">${esc(c.content)}</div>`
+          commentsBox.appendChild(div)
+        }
+        commentsWrap.style.display = ''
+      } else {
+        commentsWrap.style.display = 'none'
+      }
+    } catch { commentsWrap.style.display = 'none' }
+
+    const restoreBtn = document.getElementById('archivedDetailRestoreBtn')
+    restoreBtn.disabled = false
+    restoreBtn.textContent = 'Visszaállítás a táblára'
+    restoreBtn.onclick = async () => {
+      restoreBtn.disabled = true
+      restoreBtn.textContent = '...'
+      try {
+        const resp = await fetch(`/api/kanban/${encodeURIComponent(card.id)}/unarchive`, { method: 'POST' })
+        if (resp.ok) {
+          closeModal(document.getElementById('archivedDetailOverlay'))
+          doArchivedSearch()
+        } else {
+          restoreBtn.disabled = false
+          restoreBtn.textContent = 'Visszaállítás a táblára'
+          showToast('Hiba a visszaállításnál.')
+        }
+      } catch {
+        restoreBtn.disabled = false
+        restoreBtn.textContent = 'Visszaállítás a táblára'
+      }
+    }
+    openModal(document.getElementById('archivedDetailOverlay'))
   }
 
   async function populateArchivedProjects() {
@@ -11224,6 +11301,7 @@ function downloadMarkdown(name, content) {
   async function doArchivedSearch() {
     const list = document.getElementById('archivedList')
     const summary = document.getElementById('archivedSummary')
+    list.className = ''
     list.innerHTML = '<p class="naplo-empty">Betöltés...</p>'
     summary.textContent = ''
 
@@ -11244,21 +11322,32 @@ function downloadMarkdown(name, content) {
       const cards = data.cards || []
       summary.textContent = `${cards.length} kártya (max ${data.limit})`
       if (cards.length === 0) { list.innerHTML = '<p class="naplo-empty">Nincs archivált kártya.</p>'; return }
+      list.className = 'archived-grid'
       list.innerHTML = cards.map(renderArchivedCard).join('')
+      const byId = new Map(cards.map(c => [c.id, c]))
+      // Whole card opens the read-only detail; restore button acts on its own.
+      list.querySelectorAll('.archived-card').forEach(el => {
+        el.addEventListener('click', () => {
+          const card = byId.get(el.dataset.id)
+          if (card) showArchivedDetail(card)
+        })
+      })
       list.querySelectorAll('.archived-restore-btn').forEach(btn => {
-        btn.addEventListener('click', async () => {
+        btn.addEventListener('click', async (e) => {
+          e.stopPropagation()
           const id = btn.dataset.id
           btn.disabled = true
           btn.textContent = '...'
           try {
             const resp = await fetch(`/api/kanban/${id}/unarchive`, { method: 'POST' })
             if (resp.ok) {
-              btn.closest('.naplo-entry').style.opacity = '0.4'
+              const cardEl = btn.closest('.archived-card')
+              if (cardEl) cardEl.style.opacity = '0.4'
               btn.textContent = 'Visszaállítva'
             } else {
               btn.disabled = false
               btn.textContent = 'Visszaállítás'
-              alert('Hiba a visszaállításnál.')
+              showToast('Hiba a visszaállításnál.')
             }
           } catch {
             btn.disabled = false
@@ -11277,6 +11366,9 @@ function downloadMarkdown(name, content) {
       document.getElementById('archivedSearchBtn').addEventListener('click', doArchivedSearch)
       document.getElementById('archivedRefreshBtn').addEventListener('click', doArchivedSearch)
       document.getElementById('archivedQ').addEventListener('keydown', e => { if (e.key === 'Enter') doArchivedSearch() })
+      const adOverlay = document.getElementById('archivedDetailOverlay')
+      document.getElementById('archivedDetailClose').addEventListener('click', () => closeModal(adOverlay))
+      adOverlay.addEventListener('click', e => { if (e.target === adOverlay) closeModal(adOverlay) })
     }
     populateArchivedProjects()
     doArchivedSearch()

--- a/web/index.html
+++ b/web/index.html
@@ -1433,6 +1433,31 @@
     </div>
   </div>
 
+  <!-- Modal: Archived card detail (read-only) -->
+  <div class="modal-overlay" id="archivedDetailOverlay">
+    <div class="modal modal-wide">
+      <div class="modal-header">
+        <h2 id="archivedDetailTitle">Archivált kártya</h2>
+        <button class="modal-close" id="archivedDetailClose">&times;</button>
+      </div>
+      <div class="modal-body">
+        <div class="card-detail-meta" id="archivedDetailMeta"></div>
+        <div class="card-detail-labels" id="archivedDetailLabelsWrap" style="display:none">
+          <h4>Címkék</h4>
+          <div class="kanban-card-labels" id="archivedDetailLabels"></div>
+        </div>
+        <div class="card-detail-desc" id="archivedDetailDesc"></div>
+        <div class="card-detail-comments" id="archivedDetailCommentsWrap" style="display:none">
+          <h4>Megjegyzések</h4>
+          <div class="comments-list" id="archivedDetailComments"></div>
+        </div>
+        <div class="detail-actions" style="gap:8px">
+          <button class="btn-secondary" id="archivedDetailRestoreBtn">Visszaállítás a táblára</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Modal: Breakdown accept/reject -->
   <div class="modal-overlay" id="breakdownOverlay">
     <div class="modal modal-wide">

--- a/web/index.html
+++ b/web/index.html
@@ -52,6 +52,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="5" height="16" rx="1"/><rect x="10" y="4" width="5" height="10" rx="1"/><rect x="17" y="4" width="4" height="13" rx="1"/></svg>
         <span class="sb-label">Kanban</span>
       </a>
+      <a href="#" class="sb-link" data-page="archived">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5" rx="1"/><line x1="10" y1="12" x2="14" y2="12"/></svg>
+        <span class="sb-label">Archivált</span>
+      </a>
       <a href="#" class="sb-link" data-page="agents">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
         <span class="sb-label">Ügynökök</span>
@@ -243,6 +247,26 @@
         </div>
       </div>
       <div class="kanban-board kanban-swimlane-board" id="kanbanSwimlaneBoard" hidden></div>
+    </div>
+
+    <!-- === Archived Cards Page === -->
+    <div class="page" id="archivedPage" hidden>
+      <div class="page-header" style="margin-bottom:16px;">
+        <h2 style="margin:0;font-size:18px;">Archivált kártyák</h2>
+      </div>
+      <div class="archived-toolbar" style="display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-bottom:12px;">
+        <input type="text" id="archivedQ" class="naplo-search" placeholder="Keresés (cím, projekt, felelős)..." style="min-width:220px;">
+        <select id="archivedProject" style="font-size:13px;padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--fg);min-width:140px;">
+          <option value="">Minden projekt</option>
+        </select>
+        <input type="date" id="archivedFrom" class="naplo-date" title="Archiválástól">
+        <span style="color:var(--muted);font-size:13px;">-</span>
+        <input type="date" id="archivedTo" class="naplo-date" title="Archiválásig">
+        <button class="btn-primary btn-compact" id="archivedSearchBtn">Keresés</button>
+        <button class="btn-secondary btn-compact" id="archivedRefreshBtn">Frissítés</button>
+      </div>
+      <div class="naplo-summary" id="archivedSummary" style="margin-bottom:8px;"></div>
+      <div id="archivedList"></div>
     </div>
 
     <!-- === Agents Page === -->

--- a/web/style.css
+++ b/web/style.css
@@ -800,6 +800,39 @@ main {
 }
 .kanban-card-label-overflow:hover { filter: none; }
 
+/* Archived cards: same card look as the board, laid out in a responsive grid */
+.archived-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+.archived-card {
+  cursor: pointer;
+}
+.archived-card:active { cursor: pointer; }
+.archived-prio-pill {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 8px;
+  border-radius: 8px;
+  color: var(--prio-color);
+  background: color-mix(in srgb, var(--prio-color) 16%, transparent);
+  line-height: 1.5;
+}
+.archived-card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+.archived-date {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
 .kanban-quick-filter-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Archivált kártyák dedikált nézet

A done kártyák bizonyos idő után automatikusan archiválódnak és eltűnnek a tábláról. Eddig nem volt felület a megtekintésükre. Ez a PR egy dedikált "Archivált" oldalt ad a dashboardhoz.

### Backend
- `GET /api/kanban/archived` — archivált kártyák listája, opcionális szűrőkkel: `q` (cím/projekt/felelős), `project`, `label`, `from`/`to` (archiválás időpontja), `limit`. A válasz beágyazza a kártya címkéit.
- `POST /api/kanban/:id/unarchive` — kártya visszaállítása a táblára.
- Új konfigurációs kulcs: `KANBAN_ARCHIVED_MAX_ROWS` (alap 500), a Beállítások felületről állítható.

### Frontend
- Új "Archivált" menüpont a kanban alatt, kereső + projekt/címke/dátum szűrőkkel.
- A kártyák ugyanazzal a vizuális nyelvvel jelennek meg mint a tábla: önálló kártyakeret rácsban, színes lekerekített prioritás/címke/projekt chipek.
- Kattintásra read-only részlet-modal (azonosító, állapot, felelős, prioritás, projekt, archiválás dátuma, címkék, leírás, kommentek) + visszaállítás gomb.
- Soronkénti visszaállítás gomb közvetlenül a kártyán is.

### Dokumentáció
- Felhasználói és technikai leírás magyarul és angolul (docs/archivalt-kartyak.md, docs/en/archived-cards.md).

This change was authored with AI assistance and reviewed by @cett  before submission.