### PR TITLE
feat(scripts): add Google Docs reader/editor helper

### DIFF
--- a/docs/google-docs.md
+++ b/docs/google-docs.md
@@ -1,0 +1,123 @@
+# Google Docs helper
+
+`scripts/gdocs.py` lets an agent **read and edit Google Docs** from the command
+line: read the full text, do targeted find/replace, or replace the whole body
+with formatted content (headings + bullets). It is a thin wrapper over the
+Google Docs API with no extra services to run.
+
+## Install
+
+The helper needs two Google libraries. Install them into a dedicated venv so
+they don't touch the system Python:
+
+```bash
+python3 -m venv .venv-gdocs
+.venv-gdocs/bin/pip install -r scripts/gdocs-requirements.txt
+```
+
+Run the helper with that venv's Python:
+
+```bash
+.venv-gdocs/bin/python scripts/gdocs.py <command> ...
+```
+
+## Authentication
+
+Two methods are supported. The helper picks OAuth if `store/.gdocs-oauth.json`
+exists, otherwise it falls back to the service account.
+
+### A. Service account (recommended, no admin needed)
+
+1. In the [Google Cloud Console](https://console.cloud.google.com/) pick or
+   create a project and **enable the Google Docs API and Google Drive API**.
+2. Create a **service account** (APIs & Services -> Credentials -> Create
+   credentials -> Service account). No roles are required.
+3. On the service account, open **Keys -> Add key -> Create new key -> JSON**
+   and save the downloaded file to `store/.gdocs-sa.json` (override the path
+   with the `GDOCS_SA` environment variable).
+4. Print the service account address and **share the target document** with it
+   as **Editor** (in the document's Share dialog -- do not try to log in as it):
+
+   ```bash
+   .venv-gdocs/bin/python scripts/gdocs.py whoami
+   # -> my-bot@my-project.iam.gserviceaccount.com
+   ```
+
+Edits then appear under the service account's name. To make edits appear under
+a **human user** instead, you need Google Workspace domain-wide delegation
+(Workspace admin required): authorize the service account's client ID for the
+two scopes above in the Admin console, then set `GDOCS_SUBJECT=user@domain`.
+
+### B. OAuth user token (edits appear as a real user)
+
+Use this when you have no Workspace admin but want edits attributed to a person.
+
+1. In the same Cloud project create an **OAuth client ID** of type **Desktop
+   app** and save the downloaded JSON to `store/.gdocs-oauth-client.json`.
+2. Generate the consent URL, open it, sign in, approve, and copy the `code`
+   value from the redirected (localhost) URL:
+
+   ```bash
+   .venv-gdocs/bin/python scripts/gdocs.py auth-url
+   .venv-gdocs/bin/python scripts/gdocs.py auth-exchange "<code>"
+   ```
+
+The refresh token is stored in `store/.gdocs-oauth.json` and reused afterwards.
+
+> Keep all credential files out of version control. The `store/` directory is
+> already gitignored in this project.
+
+## Commands
+
+A document is identified by its ID or full URL.
+
+| Command | What it does |
+| --- | --- |
+| `whoami` | Print the service account email (the address to share docs with). |
+| `read <doc>` | Print the document's plain text to stdout. |
+| `replace <doc> "old" "new"` | Replace every exact (case-sensitive) match of `old` with `new`. |
+| `replace-batch <doc> pairs.json` | Apply many replacements from a JSON array of `{"old","new"}`. |
+| `set-content <doc> source.txt` | Replace the **entire body** from a source file. |
+| `auth-url` / `auth-exchange <code>` | OAuth setup (method B). |
+
+Every `replace*` reports how many occurrences changed per pair, so a `0` flags a
+mismatched `old` string.
+
+### `set-content` markers
+
+`set-content` renders a simple text file into the document with basic styling:
+
+- `# text` -> Heading 1
+- `## text` -> Heading 2
+- `- text` -> bullet list item
+- any other line -> normal paragraph
+- blank lines are ignored (paragraph spacing handles separation)
+
+## Examples
+
+```bash
+PY=".venv-gdocs/bin/python scripts/gdocs.py"
+DOC="https://docs.google.com/document/d/<id>/edit"
+
+# Read it
+$PY read "$DOC"
+
+# One targeted edit
+$PY replace "$DOC" "Q3 2025" "Q4 2025"
+
+# Several edits at once
+echo '[{"old":"draft","new":"final"},{"old":"TODO","new":"Done"}]' > /tmp/pairs.json
+$PY replace-batch "$DOC" /tmp/pairs.json
+
+# Rewrite the whole document
+cat > /tmp/body.txt <<'EOF'
+# Release notes
+
+Summary paragraph.
+
+## Highlights
+- First item
+- Second item
+EOF
+$PY set-content "$DOC" /tmp/body.txt
+```

--- a/scripts/gdocs-requirements.txt
+++ b/scripts/gdocs-requirements.txt
@@ -1,0 +1,6 @@
+# Dependencies for the Google Docs helper (scripts/gdocs.py).
+# Install into a dedicated venv:
+#   python3 -m venv .venv-gdocs
+#   .venv-gdocs/bin/pip install -r scripts/gdocs-requirements.txt
+google-api-python-client==2.197.0
+google-auth==2.55.0

--- a/scripts/gdocs.py
+++ b/scripts/gdocs.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Google Docs reader/editor helper.
+
+Lets an agent read and edit Google Docs from the command line. Authentication
+is service-account based by default; an OAuth user-token path is also supported
+so edits can appear under a human account.
+
+Auth resolution order (first match wins):
+  1. OAuth user token at store/.gdocs-oauth.json (refresh_token + client id/secret)
+     -> edits appear as the authorizing user. No Workspace admin required.
+  2. Service account key at store/.gdocs-sa.json (override with GDOCS_SA).
+     Share the target document with the service account's client_email
+     (Editor) -- the address shown by `whoami`. Edits appear as the service
+     account. Set GDOCS_SUBJECT=<user@domain> to impersonate a user via
+     Google Workspace domain-wide delegation (Workspace admin required).
+
+Usage (run with a venv that has the deps from scripts/gdocs-requirements.txt):
+  gdocs.py whoami                                   # print service-account email
+  gdocs.py read   <doc_id_or_url>
+  gdocs.py replace <doc_id_or_url> "old text" "new text"
+  gdocs.py replace-batch <doc_id_or_url> <pairs.json>   # [{"old":"..","new":".."}, ...]
+  gdocs.py set-content <doc_id_or_url> <source.txt>     # replace the whole body
+  gdocs.py auth-url                                  # OAuth: print consent URL
+  gdocs.py auth-exchange <code>                      # OAuth: store the refresh token
+
+set-content markers: '# ' -> Heading 1, '## ' -> Heading 2, '- ' -> bullet,
+anything else -> normal paragraph. Blank lines are dropped (paragraph spacing
+handles separation).
+
+See docs/google-docs.md for setup.
+"""
+import sys, os, json, re, urllib.parse, urllib.request
+from google.oauth2 import service_account
+from google.oauth2.credentials import Credentials as UserCredentials
+from googleapiclient.discovery import build
+
+SCOPES = ["https://www.googleapis.com/auth/documents",
+          "https://www.googleapis.com/auth/drive"]
+STORE = os.path.join(os.path.dirname(__file__), "..", "store")
+OAUTH_CLIENT = os.path.join(STORE, ".gdocs-oauth-client.json")  # client_id + client_secret
+OAUTH_TOKEN = os.path.join(STORE, ".gdocs-oauth.json")          # + refresh_token
+REDIRECT = "http://localhost"
+TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+def _sa_path():
+    return os.environ.get("GDOCS_SA", os.path.join(STORE, ".gdocs-sa.json"))
+
+def _client_cfg():
+    """Read the OAuth client (Desktop) id+secret; supports Google's downloaded
+    {'installed': {...}} wrapper or a flat {client_id, client_secret} object."""
+    with open(OAUTH_CLIENT) as f:
+        d = json.load(f)
+    d = d.get("installed", d.get("web", d))
+    return d["client_id"], d["client_secret"]
+
+def _svc():
+    # Preferred: OAuth user creds -> edits appear as the authorizing user.
+    if os.path.exists(OAUTH_TOKEN):
+        with open(OAUTH_TOKEN) as f:
+            t = json.load(f)
+        creds = UserCredentials(
+            token=None, refresh_token=t["refresh_token"],
+            client_id=t["client_id"], client_secret=t["client_secret"],
+            token_uri=TOKEN_URI, scopes=SCOPES)
+        return build("docs", "v1", credentials=creds, cache_discovery=False)
+    # Fallback: service account, optionally impersonating via domain-wide delegation.
+    creds = service_account.Credentials.from_service_account_file(_sa_path(), scopes=SCOPES)
+    subject = os.environ.get("GDOCS_SUBJECT", "")
+    if subject:
+        creds = creds.with_subject(subject)
+    return build("docs", "v1", credentials=creds, cache_discovery=False)
+
+def _doc_id(s):
+    m = re.search(r"/document/d/([a-zA-Z0-9_-]+)", s)
+    return m.group(1) if m else s
+
+def _text(doc):
+    out = []
+    for el in doc.get("body", {}).get("content", []):
+        para = el.get("paragraph")
+        if not para:
+            continue
+        out.append("".join(r.get("textRun", {}).get("content", "") for r in para.get("elements", [])))
+    return "".join(out)
+
+def cmd_whoami():
+    with open(_sa_path()) as f:
+        print(json.load(f).get("client_email", "(no client_email in key)"))
+
+def cmd_read(doc_id):
+    sys.stdout.write(_text(_svc().documents().get(documentId=doc_id).execute()))
+
+def cmd_replace(doc_id, old, new):
+    _apply(doc_id, [{"old": old, "new": new}])
+
+def cmd_replace_batch(doc_id, pairs_file):
+    with open(pairs_file) as f:
+        _apply(doc_id, json.load(f))
+
+def _apply(doc_id, pairs):
+    reqs = [{"replaceAllText": {
+        "containsText": {"text": p["old"], "matchCase": True},
+        "replaceText": p["new"]}} for p in pairs]
+    res = _svc().documents().batchUpdate(documentId=doc_id, body={"requests": reqs}).execute()
+    total = 0
+    for p, r in zip(pairs, res.get("replies", [])):
+        n = r.get("replaceAllText", {}).get("occurrencesChanged", 0)
+        total += n
+        flag = "" if n else "  <-- 0 matches, check the 'old' text"
+        print(f"[{n}] {p['old'][:50]!r} -> {p['new'][:50]!r}{flag}")
+    print(f"Total occurrences changed: {total}")
+
+def cmd_set_content(doc_id, src_file):
+    """Replace the entire document body from a source file. Markers:
+    '# ' -> Heading 1, '## ' -> Heading 2, '- ' -> bullet, else normal."""
+    with open(src_file) as f:
+        raw = f.read()
+    lines = []
+    for ln in raw.split("\n"):
+        s = ln.rstrip()
+        if not s.strip():
+            continue
+        if s.startswith("## "):
+            lines.append(("h2", s[3:]))
+        elif s.startswith("# "):
+            lines.append(("h1", s[2:]))
+        elif s.lstrip().startswith("- "):
+            lines.append(("bullet", s.lstrip()[2:]))
+        else:
+            lines.append(("normal", s))
+    text = "\n".join(t for _, t in lines)
+    svc = _svc()
+    doc = svc.documents().get(documentId=doc_id).execute()
+    end = doc["body"]["content"][-1]["endIndex"]
+    reqs = []
+    if end > 2:
+        reqs.append({"deleteContentRange": {"range": {"startIndex": 1, "endIndex": end - 1}}})
+    reqs.append({"insertText": {"location": {"index": 1}, "text": text}})
+    svc.documents().batchUpdate(documentId=doc_id, body={"requests": reqs}).execute()
+    # second pass: paragraph styles + bullets (indices computed on the inserted text)
+    style_reqs, bullets, idx = [], [], 1
+    for kind, t in lines:
+        start, endi = idx, idx + len(t)
+        if kind in ("h1", "h2"):
+            style_reqs.append({"updateParagraphStyle": {
+                "range": {"startIndex": start, "endIndex": endi},
+                "paragraphStyle": {"namedStyleType": "HEADING_1" if kind == "h1" else "HEADING_2"},
+                "fields": "namedStyleType"}})
+        elif kind == "bullet":
+            bullets.append((start, endi))
+        idx = endi + 1
+    spans = []
+    for s, e in bullets:
+        if spans and s == spans[-1][1] + 1:
+            spans[-1][1] = e
+        else:
+            spans.append([s, e])
+    for s, e in spans:
+        style_reqs.append({"createParagraphBullets": {
+            "range": {"startIndex": s, "endIndex": e},
+            "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE"}})
+    if style_reqs:
+        svc.documents().batchUpdate(documentId=doc_id, body={"requests": style_reqs}).execute()
+    print(f"OK: body replaced -- {len(lines)} paragraphs, "
+          f"{sum(1 for k, _ in lines if k in ('h1', 'h2'))} headings, {len(bullets)} bullets.")
+
+def cmd_auth_url():
+    cid, _ = _client_cfg()
+    params = {"client_id": cid, "redirect_uri": REDIRECT, "response_type": "code",
+              "scope": " ".join(SCOPES), "access_type": "offline", "prompt": "consent"}
+    print("Open this URL, sign in, approve, then copy the 'code=' value from the")
+    print("redirected URL (the localhost error page is expected):\n")
+    print("https://accounts.google.com/o/oauth2/v2/auth?" + urllib.parse.urlencode(params))
+
+def cmd_auth_exchange(code):
+    cid, secret = _client_cfg()
+    data = urllib.parse.urlencode({
+        "code": code, "client_id": cid, "client_secret": secret,
+        "redirect_uri": REDIRECT, "grant_type": "authorization_code"}).encode()
+    with urllib.request.urlopen(urllib.request.Request(TOKEN_URI, data=data)) as r:
+        tok = json.load(r)
+    if "refresh_token" not in tok:
+        raise SystemExit(f"No refresh_token in response: {tok}")
+    with open(OAUTH_TOKEN, "w") as f:
+        json.dump({"refresh_token": tok["refresh_token"], "client_id": cid, "client_secret": secret}, f)
+    os.chmod(OAUTH_TOKEN, 0o600)
+    print("OK: refresh token saved ->", OAUTH_TOKEN)
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__); sys.exit(1)
+    cmd = sys.argv[1]
+    if cmd == "whoami":
+        cmd_whoami()
+    elif cmd == "read":
+        cmd_read(_doc_id(sys.argv[2]))
+    elif cmd == "replace":
+        cmd_replace(_doc_id(sys.argv[2]), sys.argv[3], sys.argv[4])
+    elif cmd == "replace-batch":
+        cmd_replace_batch(_doc_id(sys.argv[2]), sys.argv[3])
+    elif cmd == "set-content":
+        cmd_set_content(_doc_id(sys.argv[2]), sys.argv[3])
+    elif cmd == "auth-url":
+        cmd_auth_url()
+    elif cmd == "auth-exchange":
+        cmd_auth_exchange(sys.argv[2])
+    else:
+        print(f"unknown command: {cmd}\n{__doc__}"); sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds an optional CLI helper for reading and editing Google Docs, in the same spirit as the other `scripts/*.py` utilities.

## What
- **scripts/gdocs.py** — wraps the Google Docs API:
  - `read` full text
  - `replace` / `replace-batch` targeted find/replace (reports per-pair match counts)
  - `set-content` whole-body replacement with simple markers (`#`/`##` headings, `-` bullets)
  - `whoami` / `auth-url` / `auth-exchange` helpers
- **scripts/gdocs-requirements.txt** — pinned deps (`google-api-python-client`, `google-auth`), installed into a dedicated venv (same pattern as `scripts/watchdog-requirements.txt`).
- **docs/google-docs.md** — setup for both auth methods, command reference, examples.

## Auth
- Service account by default: share the target doc with the service account email (`whoami`). No Workspace admin needed.
- Optional OAuth user-token path so edits appear under a real user.
- Optional Workspace domain-wide-delegation impersonation (`GDOCS_SUBJECT`).

## Notes
- All credentials are read from gitignored `store/` files; nothing is embedded in the repo.
- No changes to existing files; three new files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)