### PR TITLE
fix(dashboard): stop standalone PWA horizontal drag (sticky-safe clip)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="hu" data-theme="light">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Marveen</title>
   <link rel="stylesheet" href="/style.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/css/xterm.css">

--- a/web/style.css
+++ b/web/style.css
@@ -48,6 +48,15 @@
 
 /* === Reset === */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* Page-level horizontal clip. `overflow-x: clip` (not `hidden`) is deliberate:
+   `hidden` would compute overflow-y to `auto` and make body a scroll container,
+   which breaks the dashboard's many `position: sticky` elements. `clip` clips
+   without establishing a scroll container, so sticky keeps working. This stops
+   an installed (standalone) PWA from being draggable sideways when something
+   overflows by a hair: Safari's rubber-band hides it, standalone does not. */
+html, body { max-width: 100%; overflow-x: clip; }
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
   background: var(--bg);


### PR DESCRIPTION
## Why

On the installed (home-screen) PWA the dashboard can be dragged sideways on iPhone, while the same layout in Safari looks fine. Safari's rubber-band hides a hair of horizontal overflow that **standalone** exposes as a draggable area. There was no **page-level** horizontal clip — only `main` had `overflow-x: hidden`.

## What

- **`html, body { max-width: 100%; overflow-x: clip; }`** — `clip` is deliberate over `hidden`: `hidden` would compute `overflow-y` to `auto` and turn body into a scroll container, which **breaks the dashboard's 7 `position: sticky` elements**. `overflow-x: clip` clips horizontal overflow **without** establishing a scroll container, so sticky keeps working.
- **viewport meta: `viewport-fit=cover`** for standalone safe-area rendering.

## Verify

Tested against the live dashboard (Playwright route-interception, `navigator.standalone` simulated) at 390×844 and 1280×900:
- No horizontal overflow (`scrollWidth <= clientWidth`).
- **The clip holds:** a deliberately injected 3000px-wide child keeps `scrollWidth` clamped to the viewport (proving overflow can no longer create a draggable area).
- **Sticky intact:** `body` computed `overflow-y` stays `visible` (not `auto`), so the sticky elements are unaffected.
- Desktop layout unchanged.
- em/en-dash 0.

Note: the chromium sim can't reproduce iOS standalone's exact rubber-band-absent drag (the 390px layout is already clip-clean in chromium), so this verifies the fix is correct and safe; `overflow-x: clip` guarantees no horizontal scroll regardless of what overflows. Real-device confirmation on the iPhone is the final check.

Goes out with the next dashboard deploy alongside the other mobile refinements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)