### PR TITLE
docs: branch rule in CONTRIBUTING + bilingual PR template (closes #377)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!--
+  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
+  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
+-->
+
+## A változtatás típusa / Type of change
+
+- [ ] Bug fix (hibajavítás / bug fix)
+- [ ] Új funkció (feature / new feature)
+- [ ] Dokumentáció (docs)
+- [ ] Egyéb / Other:
+
+## Rövid leírás / Summary
+
+<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
+     EN: Summarize what problem this PR solves and the technical approach you took. -->
+
+## Kapcsolódó issue / Related issue
+
+Closes #
+
+## Ellenőrzőlista / Checklist
+
+- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
+- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
+- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
+- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,17 @@
 # Hogyan járulhatsz hozzá a Marveen projekthez?
+
 Örülünk, hogy érdeklődsz az AI csapat fejlesztése iránt! A következő lépésekkel tudsz csatlakozni:
-Környezet beállítása: Forkold a repót, majd futtasd a lokális telepítőt (./install.sh). A futtatáshoz szükséged lesz a megfelelő API kulcsokra (pl. Anthropic, Telegram bot token).
-Fejlesztés menete: Készíts egy új branch-et beszédes névvel (pl. feature/uj-mcp-connector vagy fix/telegram-hiba).
-Új Skillek és Integrációk: Ha új képességet adsz az ágenseknek, feltétlenül pótold a működés leírását a docs/ mappában (pl. a skill-factory.md vagy új dokumentum formájában).
-Pull Request beküldése: Nyiss PR-t a develop ág felé, és részletesen írd le a módosításaidat."
+
+- **Környezet beállítása:** Forkold a repót, majd futtasd a lokális telepítőt (`./install.sh`). A futtatáshoz szükséged lesz a megfelelő API kulcsokra (pl. Anthropic, Telegram bot token).
+- **Branch-szabály:** A `develop` (és `main`) ágra KÖZVETLENÜL senki nem pushol. Minden új fejlesztés saját, beszédes nevű branch-en fut (pl. `feature/uj-mcp-connector` vagy `fix/telegram-hiba`), és Pull Requesten keresztül kerül be.
+- **Új Skillek és Integrációk:** Ha új képességet adsz az ágenseknek, feltétlenül pótold a működés leírását a `docs/` mappában (pl. a `skill-factory.md` vagy új dokumentum formájában).
+- **Pull Request beküldése:** Nyiss PR-t a `develop` ág felé. A PR megnyitásakor automatikusan betöltődik a sablon (`.github/pull_request_template.md`); töltsd ki minden szakaszát, hogy a változtatásod egységesen, könnyen áttekinthetően legyen dokumentálva.
 
 # How can you contribute to the Marveen project?
-We are glad that you are interested in developing the AI ​​team! You can join with the following steps:
-Environment setup: Fork the repo, then run the local installer (./install.sh). To run it, you will need the appropriate API keys (e.g. Anthropic, Telegram bot token).
-Development process: Create a new branch with a descriptive name (e.g. feature/uj-mcp-connector or fix/telegram-bug).
-New Skills and Integrations: If you add a new skill to agents, be sure to add a description of how it works in the docs/ folder (e.g. in the form of skill-factory.md or a new document).
-Submit a Pull Request: Open a PR to the develop branch and describe your changes in detail."
+
+We are glad that you are interested in developing the AI team! You can join with the following steps:
+
+- **Environment setup:** Fork the repo, then run the local installer (`./install.sh`). To run it, you will need the appropriate API keys (e.g. Anthropic, Telegram bot token).
+- **Branch rule:** Nobody pushes DIRECTLY to `develop` (or `main`). Every new change runs on its own descriptively named branch (e.g. `feature/uj-mcp-connector` or `fix/telegram-bug`) and lands through a Pull Request.
+- **New Skills and Integrations:** If you add a new skill to the agents, be sure to add a description of how it works in the `docs/` folder (e.g. in the form of `skill-factory.md` or a new document).
+- **Submit a Pull Request:** Open a PR against the `develop` branch. The template (`.github/pull_request_template.md`) loads automatically when you open the PR; fill in every section so your change is documented in a consistent, easy-to-review way.


### PR DESCRIPTION
## What (per #377)
- **CONTRIBUTING.md:** makes the workflow explicit for the growing contributor base — nobody pushes directly to `develop`/`main`; every change runs on its own branch and lands via a PR. Cleaned up the file (removed stray artifacts) and pointed at the new template. Stays bilingual (HU + EN).
- **`.github/pull_request_template.md`:** a HU+EN template that auto-loads when a PR is opened — change type, summary, related issue (`Closes #`), and a checklist (local Telegram/Slack + dashboard test, `docs/` update, no hardcoded secrets, branch-not-develop).

Docs-only. em/en-dash 0.

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)