### PR TITLE
fix(dashboard): runtime owner identity in chat view (#369)

### DIFF
--- a/src/__tests__/template-identity-hygiene.test.ts
+++ b/src/__tests__/template-identity-hygiene.test.ts
@@ -100,6 +100,34 @@ describe('shipped templates carry no hardcoded identity', () => {
     expect(violations, `Hardcoded identity found in shipped templates:\n${violations.join('\n')}`).toEqual([])
   })
 
+  // web/app.js is the dashboard bundle, shipped verbatim to every install. It
+  // must carry no deployment-specific operator identity: the owner display name
+  // flows from the backend (OWNER_NAME -> /api/marveen -> window._marveen.ownerName,
+  // read via chatOwnerName()), never a hardcoded "Szabolcs"/"Szabi" literal, so a
+  // renamed install labels its real owner. This is the exact regression #369
+  // fixed -- the chat sidebar used to pin/label the owner thread off a
+  // `const CHAT_OWNER_AGENT = 'Szabolcs'` literal. The Marveen product brand and
+  // agent role-names are NOT identity and stay allowed (none match these regexes).
+  it('web/app.js carries no absolute home path, personal email, or default owner-name literal', () => {
+    const violations: string[] = []
+    const file = join(REPO_ROOT, 'web', 'app.js')
+    const text = readText(file)
+    if (text !== null) {
+      text.split('\n').forEach((line, i) => {
+        if (!line.includes('://') && HOME_PATH_RX.test(line)) {
+          violations.push(`web/app.js:${i + 1} absolute home path: ${line.trim().slice(0, 100)}`)
+        }
+        if (PERSONAL_EMAIL_RX.test(line)) {
+          violations.push(`web/app.js:${i + 1} personal email: ${line.trim().slice(0, 100)}`)
+        }
+        if (FOREIGN_DEFAULT_OWNER_RX.test(line)) {
+          violations.push(`web/app.js:${i + 1} default owner name literal (read it from window._marveen.ownerName via chatOwnerName()): ${line.trim().slice(0, 100)}`)
+        }
+      })
+    }
+    expect(violations, `Hardcoded operator identity found in web/app.js:\n${violations.join('\n')}`).toEqual([])
+  })
+
   // scripts/support-mail ships operator tooling that talks to a real mailbox.
   // It must carry no operator identity either: the mailbox address, vault key,
   // owner name and branding flow from config (.env) / {{...}} placeholders, so a

--- a/src/web/routes/marveen.ts
+++ b/src/web/routes/marveen.ts
@@ -69,6 +69,10 @@ export async function tryHandleMarveen(ctx: RouteContext, webDir: string): Promi
     const idCore = buildMarveenIdentityCore(BOT_NAME, BRAND_NAME, MAIN_AGENT_ID)
     json(res, {
       ...idCore,
+      // Configured owner display name (OWNER_NAME). The dashboard chat view uses
+      // this to pin/label the owner's own message thread instead of a hardcoded
+      // literal, so a renamed install recognizes its real owner.
+      ownerName: OWNER_NAME,
       description,
       model: getActiveMarveenModel(),
       tmuxSession: MAIN_CHANNELS_SESSION,

--- a/web/app.js
+++ b/web/app.js
@@ -8284,7 +8284,11 @@ async function loadMessagesPage() {
 }
 
 const CHAT_SYSTEM_AGENTS = new Set(['heartbeat','telegram-coordinator','channel-coordinator'])
-const CHAT_OWNER_AGENT = 'Szabolcs' // pinned to top; display label overridden
+// The owner's own message thread is pinned to the top and labelled "<name> (te)".
+// The owner display name comes from the backend (OWNER_NAME via /api/marveen ->
+// window._marveen.ownerName), not a hardcoded literal, so a renamed install
+// recognizes its real owner. Empty until _marveen resolves (no false match).
+function chatOwnerName() { return window._marveen?.ownerName || '' }
 
 function chatLastSeenKey(agentName) { return 'chat_last_seen_' + agentName }
 function chatGetLastSeen(agentName) { return parseInt(localStorage.getItem(chatLastSeenKey(agentName)) || '0', 10) }
@@ -8292,7 +8296,8 @@ function chatMarkSeen(agentName, maxId) {
   if (maxId > chatGetLastSeen(agentName)) localStorage.setItem(chatLastSeenKey(agentName), String(maxId))
 }
 function chatIsUnread(agentName, threadInfo) {
-  if (agentName !== CHAT_OWNER_AGENT) return false
+  const owner = chatOwnerName()
+  if (!owner || agentName !== owner) return false
   if (!threadInfo?.lastMsg) return false
   return threadInfo.lastMsg.id > chatGetLastSeen(agentName)
 }
@@ -8326,7 +8331,7 @@ async function loadChatAgentList() {
     for (const t of threads) {
       if (t.agent) threadIndex.set(t.agent, { lastMsg: t.lastMessage, count: t.count || 0 })
     }
-    // Also include thread agents not in fleet (e.g. Szabolcs/owner direct msgs)
+    // Also include thread agents not in fleet (e.g. the owner's own direct msgs)
     for (const t of threads) {
       if (t.agent && !fleetNames.includes(t.agent) && !CHAT_SYSTEM_AGENTS.has(t.agent)) {
         fleetNames.push(t.agent)
@@ -8334,9 +8339,10 @@ async function loadChatAgentList() {
     }
 
     // Sort: owner pinned first, then agents with messages by recency, rest alphabetical
+    const owner = chatOwnerName()
     const sorted = [...fleetNames].sort((a, b) => {
-      if (a === CHAT_OWNER_AGENT) return -1
-      if (b === CHAT_OWNER_AGENT) return 1
+      if (owner && a === owner) return -1
+      if (owner && b === owner) return 1
       const aHas = threadIndex.has(a), bHas = threadIndex.has(b)
       if (aHas && !bHas) return -1
       if (!aHas && bHas) return 1
@@ -8356,7 +8362,7 @@ async function loadChatAgentList() {
       const isSelected = name === chatSelectedAgent ? ' selected' : ''
       const dimmed = info ? '' : ' style="opacity:0.5"'
       const unread = chatIsUnread(name, info)
-      const displayName = name === CHAT_OWNER_AGENT ? 'Szabolcs (te)' : name
+      const displayName = owner && name === owner ? owner + ' (te)' : name
       return `<div class="chat-agent-item${isSelected}${unread ? ' unread' : ''}" data-agent="${escapeHtml(name)}"${dimmed}>
         <div class="chat-agent-avatar">${chatAvatarHtml(name, 40)}</div>
         <div class="chat-agent-info">
@@ -8399,7 +8405,8 @@ async function loadChatThread(agentName) {
   chatThreadState.hasMore = true
   chatThreadState.loading = false
 
-  const threadDisplayName = agentName === CHAT_OWNER_AGENT ? 'Szabolcs (te)' : agentName
+  const owner = chatOwnerName()
+  const threadDisplayName = owner && agentName === owner ? owner + ' (te)' : agentName
 
   panel.innerHTML = `
     <div class="chat-thread-header">


### PR DESCRIPTION
## What

Resolves #369 — the dashboard chat view recognized the owner off a hardcoded `'Szabolcs'` literal, so a renamed install (different `OWNER_NAME`) never pinned/labelled its real owner's message thread.

## Change

Config-driven, **no new env vars** (reuses the existing `OWNER_NAME`):

- **`src/web/routes/marveen.ts`** — expose `ownerName: OWNER_NAME` on the `/api/marveen` response.
- **`web/app.js`** — replace `const CHAT_OWNER_AGENT = 'Szabolcs'` with `chatOwnerName()` reading `window._marveen.ownerName`. Returns `''` until `_marveen` resolves, so there's no false pin/label before identity loads. Updated all four usages (unread check, sort comparator, sidebar label, thread-header label).
- **`src/__tests__/template-identity-hygiene.test.ts`** — new test scanning `web/app.js` for the banned owner-name literal (home path / personal email too). The Marveen product brand and agent role-names are not identity and stay allowed.

## Verify

- `tsc` clean.
- Full suite **1325/1325** (+1 new app.js hygiene test, baseline 1324).
- Browser-test (Playwright route-interception against the **live** backend): with `ownerName=Szabolcs` the owner thread pins first + labels `Szabolcs (te)` exactly as before; with `ownerName=zara` the pin/label moves to `zara (te)` and **no** `Szabolcs` literal appears anywhere — proving the behavior is fully config-driven.
- Em-dash QA on the diff: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
