### PR TITLE
fix(install-linux): make ollama install step non-fatal

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -898,10 +898,21 @@ if command -v ollama &>/dev/null; then
   ok "ollama mar telepitve"
 else
   echo -e "  Ollama telepitese..."
-  curl -fsSL https://ollama.com/install.sh | sh
-  ok "ollama telepitve"
+  # Az ollama telepitoje sudo-val ir a /usr/local/bin-be es allit be systemd service-t.
+  # Elore gyorsitotarazzuk a sudo hitelesitest, hogy a gyermek-script sudo prompt-ja ne bukjon el.
+  sudo -v 2>/dev/null || true
+  # NEM fatalis: ha az ollama telepitoje hibara fut (pl. sudo, halozat, WSL),
+  # csak figyelmeztetunk es kihagyjuk a szemantikus memoria lepest -- a telepito megy tovabb.
+  if curl -fsSL https://ollama.com/install.sh | sh; then
+    ok "ollama telepitve"
+  else
+    warn "ollama telepitese sikertelen -- a szemantikus memoria kereses kimarad."
+    echo -e "  ${DIM}Kesobb kezzel: sudo -v && curl -fsSL https://ollama.com/install.sh | sh${NC}"
+  fi
 fi
 
+# A service-inditas es modell-letoltes csak akkor fut, ha az ollama tenyleg telepult.
+if command -v ollama &>/dev/null; then
 # A telepito letrehoz egy ollama.service systemd egységet és elindítja.
 # Ha megis nem futna, systemctl-lel indítjuk -- NEM ollama serve &
 if ! curl -s http://localhost:11434/api/version &>/dev/null; then
@@ -938,6 +949,7 @@ ollama_pull() {
 
 # nomic-embed-text (szemantikus memoria, kotelozo)
 ollama_pull "nomic-embed-text" "~274 MB"
+fi  # command -v ollama
 
 # --- Whisper (opcionalis) ---
 echo ""


### PR DESCRIPTION
## Problem

The installer aborted at `install-linux.sh:901` with **"Unexpected error at line 901"**. That line runs:

```bash
curl -fsSL https://ollama.com/install.sh | sh
```

The script uses `set -e` + `trap 'on_error $LINENO' ERR`, so any non-zero exit from ollama's own installer kills the whole Marveen install. The common trigger is a `sudo` auth prompt the ollama installer can't satisfy (e.g. cached sudo credentials expired by the time step 6 runs).

## Fix

- Pre-warm sudo (`sudo -v`) before invoking ollama's installer.
- Wrap `curl … | sh` in an `if`; on failure **warn and continue** instead of aborting. Semantic-memory search is then skipped, not fatal.
- Guard the service-start and model-pull steps behind `command -v ollama` so they don't run uselessly when ollama isn't present.

`bash -n install-linux.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)