### PR TITLE
fix(dashboard): mobil/Tailscale PWA vault-iras (CSRF same-origin)

### DIFF
--- a/src/__tests__/csrf-origin.test.ts
+++ b/src/__tests__/csrf-origin.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { isSafeMethod, originMatchesServedHost, isBlockedCrossOriginWrite } from '../web/csrf-origin.js'
+
+const allow = new Set(['http://localhost:3420', 'http://127.0.0.1:3420'])
+const TS = 'marvins-mac-mini.tail1501e6.ts.net'
+const TS_ORIGIN = `https://${TS}`
+
+describe('isSafeMethod', () => {
+  it('treats GET/HEAD/OPTIONS as safe, others as unsafe', () => {
+    expect(isSafeMethod('GET')).toBe(true)
+    expect(isSafeMethod('HEAD')).toBe(true)
+    expect(isSafeMethod('OPTIONS')).toBe(true)
+    expect(isSafeMethod('POST')).toBe(false)
+    expect(isSafeMethod('DELETE')).toBe(false)
+  })
+})
+
+describe('originMatchesServedHost', () => {
+  it('matches when Origin host equals the Host header (Tailscale preserves Host)', () => {
+    expect(originMatchesServedHost(TS_ORIGIN, TS, undefined)).toBe(true)
+  })
+  it('matches via X-Forwarded-Host when the proxy rewrites Host', () => {
+    expect(originMatchesServedHost(TS_ORIGIN, '127.0.0.1:3420', TS)).toBe(true)
+  })
+  it('uses the first X-Forwarded-Host hop', () => {
+    expect(originMatchesServedHost(TS_ORIGIN, '127.0.0.1:3420', `${TS}, proxy2`)).toBe(true)
+  })
+  it('does NOT match a foreign origin', () => {
+    expect(originMatchesServedHost('https://evil.example.com', TS, TS)).toBe(false)
+  })
+  it('returns false for a malformed origin', () => {
+    expect(originMatchesServedHost('not-a-url', TS, undefined)).toBe(false)
+  })
+})
+
+describe('isBlockedCrossOriginWrite', () => {
+  it('allows safe methods regardless of origin', () => {
+    expect(isBlockedCrossOriginWrite('GET', 'https://evil.example.com', 'x', undefined, allow)).toBe(false)
+  })
+  it('allows writes with no Origin header (same-origin browsers omit it)', () => {
+    expect(isBlockedCrossOriginWrite('POST', undefined, '127.0.0.1:3420', undefined, allow)).toBe(false)
+  })
+  it('allows writes from an allowlisted origin', () => {
+    expect(isBlockedCrossOriginWrite('POST', 'http://localhost:3420', 'localhost:3420', undefined, allow)).toBe(false)
+  })
+  it('allows the Tailscale Serve PWA (same-origin via Host) -- the bug fix', () => {
+    expect(isBlockedCrossOriginWrite('POST', TS_ORIGIN, TS, undefined, allow)).toBe(false)
+  })
+  it('allows the Tailscale Serve PWA (same-origin via X-Forwarded-Host)', () => {
+    expect(isBlockedCrossOriginWrite('POST', TS_ORIGIN, '127.0.0.1:3420', TS, allow)).toBe(false)
+  })
+  it('STILL blocks a genuine cross-site write (CSRF stays defended)', () => {
+    expect(isBlockedCrossOriginWrite('POST', 'https://evil.example.com', TS, TS, allow)).toBe(true)
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { execSync, execFileSync } from 'node:child_process'
 import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL, DASHBOARD_ALLOWED_ORIGINS } from './config.js'
 import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-auth.js'
+import { isBlockedCrossOriginWrite } from './web/csrf-origin.js'
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
 import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
@@ -73,7 +74,6 @@ export function startWebServer(port = 3420): http.Server {
     ...(DASHBOARD_PUBLIC_URL ? [DASHBOARD_PUBLIC_URL.replace(/\/$/, '')] : []),
     ...DASHBOARD_ALLOWED_ORIGINS.split(',').map((o) => o.trim().replace(/\/$/, '')).filter(Boolean),
   ])
-  const isSafeMethod = (m: string) => m === 'GET' || m === 'HEAD' || m === 'OPTIONS'
 
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || '/', `http://localhost:${port}`)
@@ -90,10 +90,11 @@ export function startWebServer(port = 3420): http.Server {
     if (method === 'OPTIONS') { res.writeHead(204); res.end(); return }
 
     // Block state-changing requests from browsers running on foreign origins.
-    // Same-origin fetches from the dashboard don't set Origin on some browsers, so we
-    // accept requests where Origin is absent OR whitelisted. Requests carrying a foreign
-    // Origin are rejected outright (this is the primary CSRF defence).
-    if (!isSafeMethod(method) && origin && !allowedOrigins.has(origin)) {
+    // Same-origin fetches (Origin absent, allowlisted, or matching the host the
+    // server was actually reached on -- e.g. a Tailscale Serve / reverse-proxy
+    // hostname) are accepted; a foreign Origin is rejected (the CSRF defence).
+    if (isBlockedCrossOriginWrite(method, origin, req.headers.host, req.headers['x-forwarded-host'] as string | undefined, allowedOrigins)) {
+      logger.warn({ method, path, origin, host: req.headers.host, xForwardedHost: req.headers['x-forwarded-host'] }, 'CSRF: blocked write from foreign origin')
       res.writeHead(403, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({ error: 'Origin not allowed' }))
       return

--- a/src/web/csrf-origin.ts
+++ b/src/web/csrf-origin.ts
@@ -1,0 +1,54 @@
+// CSRF origin gate for state-changing (non-safe) HTTP requests.
+//
+// The dashboard's primary auth is the bearer token (see dashboard-auth.ts); this
+// origin check is defence-in-depth against a malicious website the user happens
+// to be visiting trying to drive the dashboard via the browser. We block writes
+// whose Origin is foreign.
+//
+// The static allowlist (localhost / 127.0.0.1 / WEB_HOST / DASHBOARD_PUBLIC_URL)
+// can't know every hostname the dashboard is reached by -- in particular a
+// reverse proxy such as Tailscale Serve exposes it on `https://<machine>.<tailnet>.ts.net`.
+// A request from that PWA is genuinely SAME-ORIGIN (the page and the fetch share
+// the ts.net origin), so it is NOT CSRF and must be allowed. We detect that by
+// comparing the Origin's host to the host the server was actually addressed by:
+// the `Host` header, or `X-Forwarded-Host` when behind a proxy. A real
+// cross-site attacker's Origin host matches neither, so it stays blocked.
+
+export function isSafeMethod(method: string): boolean {
+  return method === 'GET' || method === 'HEAD' || method === 'OPTIONS'
+}
+
+// True when the request is same-origin: the Origin's host equals the host the
+// server was reached on (Host, or the first X-Forwarded-Host hop).
+export function originMatchesServedHost(
+  origin: string,
+  host: string | undefined,
+  xForwardedHost: string | undefined,
+): boolean {
+  let originHost: string
+  try { originHost = new URL(origin).host } catch { return false }
+  if (!originHost) return false
+  if (host && originHost === host) return true
+  if (xForwardedHost) {
+    const xf = xForwardedHost.split(',')[0]?.trim()
+    if (xf && originHost === xf) return true
+  }
+  return false
+}
+
+// Decide whether a state-changing request must be rejected as cross-origin.
+// Safe methods, requests without an Origin (many same-origin browsers omit it),
+// allowlisted origins, and same-origin (served-host-matching) requests all pass.
+export function isBlockedCrossOriginWrite(
+  method: string,
+  origin: string | undefined,
+  host: string | undefined,
+  xForwardedHost: string | undefined,
+  allowedOrigins: ReadonlySet<string>,
+): boolean {
+  if (isSafeMethod(method)) return false
+  if (!origin) return false
+  if (allowedOrigins.has(origin)) return false
+  if (originMatchesServedHost(origin, host, xForwardedHost)) return false
+  return true
+}


### PR DESCRIPTION
## Tunet
A mobil/tav dashboardrol (Tailscale Serve PWA, telefonrol) a vault-iras (es minden POST/DELETE) nem persistalt -- pl. Netlify PAT mentese nem latszott a listaban. Asztali (localhost) uton ment. Olvasas (GET) mobilon is mukodott.

## Gyoker-ok (empirikusan igazolva a VALOS Tailscale-uton)
A CSRF origin-gate (`web.ts`) minden nem-safe metodusu kerest 403-zott, ha az Origin nem volt a statikus allowlistban (localhost / 127.0.0.1 / WEB_HOST / DASHBOARD_PUBLIC_URL). A Tailscale Serve a dashboardot `https://<gep>.<tailnet>.ts.net` originen szolgalja ki -- ezt az allowlist nem ismeri.

Bizonyitek (a `marvins-mac-mini.tail1501e6.ts.net`-en at):
- POST a ts.net Originnel -> **403**
- ugyanaz a POST Origin-header NELKUL -> **400** (a body celba er es feldolgozasra kerul) -> kizarolag az Origin-header a blokkolo
- GET (safe metodus) cross-origin -> **200** (ezert mukodott az olvasas)

## Fix
Egy iras same-origin (tehat NEM CSRF), ha az Origin hostja megegyezik azzal a hosttal, amin a szervert tenylegesen elertek: a `Host` header, vagy `X-Forwarded-Host` reverse-proxy mogott. Ezeket most atengedjuk; valodi idegen Origin tovabbra is 403, es a bearer-token marad az elsodleges auth. A logika kiszervezve `web/csrf-origin.ts`-be unit-tesztekkel (Tailscale PWA Host-on es X-Forwarded-Host-on at, allowlist, no-Origin, es a tovabbra is blokkolt cross-site eset). Rejection-log hozzaadva a kesobbi diagnozishoz.

tsc zold, 12/12 uj unit-teszt zold.

## Tesztkeres
Deploy utan Szabi/Marveen probalja ujra a telefonrol egy vault-irast -> persistalnia kell. (A fix Host ES X-Forwarded-Host alapjan is matchel, igy a Tailscale Serve header-viselkedesetol fuggetlenul mukodik.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)