### PR TITLE
feat(ci): frontend smoke-test + syntax-gate (#d62a9557)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "status": "tsx scripts/status.ts",
     "schedule": "tsx src/schedule-cli.ts",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "syntax-check": "node --check web/app.js web/sw.js",
+    "smoke": "playwright test --config=playwright.config.ts"
   },
   "engines": {
     "node": ">=20 <24"
@@ -24,6 +26,7 @@
     "pino-pretty": "^13.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.0",
     "tsx": "^4.19.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/smoke',
+  timeout: 30_000,
+  retries: 0,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.DASHBOARD_URL || 'http://localhost:3420',
+    headless: true,
+    screenshot: 'only-on-failure',
+  },
+})

--- a/tests/smoke/dashboard.spec.ts
+++ b/tests/smoke/dashboard.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Dashboard smoke tests.
+ *
+ * Prerequisites: the dashboard must be running and DASHBOARD_TOKEN must be set.
+ *   DASHBOARD_TOKEN=$(cat store/.dashboard-token) npm run smoke
+ *
+ * What these tests catch: a single JS syntax error or undefined global that
+ * silently breaks the entire dashboard (blank page / stuck UI).
+ * They are NOT a full functional harness -- they verify the minimum viable
+ * page health at the point of merge.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const TOKEN = process.env.DASHBOARD_TOKEN || ''
+
+test.describe('Dashboard smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text())
+    })
+    ;(page as unknown as { _smokeErrors: string[] })._smokeErrors = errors
+  })
+
+  test('loads with token and returns HTTP 200', async ({ page }) => {
+    const response = await page.goto(`/?token=${TOKEN}`)
+    expect(response?.status()).toBe(200)
+  })
+
+  test('navigation sidebar links are visible', async ({ page }) => {
+    await page.goto(`/?token=${TOKEN}`)
+    const navLinks = page.locator('.sb-link[data-page]')
+    await expect(navLinks.first()).toBeVisible()
+    const count = await navLinks.count()
+    expect(count).toBeGreaterThanOrEqual(4)
+  })
+
+  test('switchPage is callable without throwing', async ({ page }) => {
+    await page.goto(`/?token=${TOKEN}`)
+    const errors: string[] = []
+    page.on('pageerror', (e) => errors.push(e.message))
+    await page.evaluate(() => {
+      if (typeof (window as unknown as Record<string, unknown>).switchPage !== 'function') {
+        throw new Error('switchPage is not a function')
+      }
+    })
+    expect(errors).toHaveLength(0)
+  })
+
+  test('no JS errors on page load', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+    await page.goto(`/?token=${TOKEN}`)
+    // brief wait for any deferred init errors
+    await page.waitForTimeout(500)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('kanban page loads without errors', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+    await page.goto(`/?token=${TOKEN}#kanban`)
+    await page.waitForTimeout(500)
+    expect(errors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Adds two quality gates that catch dashboard-breaking JS errors before merge:

1. `npm run syntax-check` -- node --check on web/app.js and web/sw.js (catches silent syntax errors that blank the entire dashboard).

2. `npm run smoke` -- Playwright smoke suite (tests/smoke/dashboard.spec.ts):
   - dashboard loads with ?token= (HTTP 200)
   - sidebar nav links visible (>= 4)
   - switchPage callable without throwing
   - no JS pageerrors on load
   - kanban page loads without errors

Prerequisites for smoke: running dashboard + DASHBOARD_TOKEN env var.
  DASHBOARD_TOKEN=\$(cat store/.dashboard-token) npm run smoke

This change was authored with AI assistance and reviewed by @cett before submission.

