### PR TITLE
fix(channels): auto-fallback to /tmp on EPERM (Claude Code 2.1.183+ regression)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -196,10 +196,26 @@ $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
 #  - "Do you trust the files in this folder?" / "trust" prompts (Y Enter)
 #  - "Welcome to Claude Code" / kezdo vezetes (Enter a folytatashoz)
 # 12 sec timeout ket retry-jal, mert WSL/tmux paint slow lehet first-run-on.
+#
+# EPERM fallback (Claude Code 2.1.183+ regression): launching --channels in a
+# trusted project directory throws EPERM before any dialog appears. Detected
+# below; one auto-restart from /tmp where the trust dialog fires instead.
+_eperm_restarted=0
 for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
   sleep 1
   pane=$($TMUX capture-pane -t "$SESSION" -p 2>/dev/null || true)
   case "$pane" in
+    *"EPERM"*|*"Operation not permitted"*|*"operation not permitted"*)
+      if [ "$_eperm_restarted" = "0" ]; then
+        _eperm_restarted=1
+        $TMUX kill-session -t "$SESSION" 2>/dev/null
+        _CHANNELS_STARTDIR="$(mktemp -d /tmp/marveen-channels-XXXXXX)"
+        $TMUX new-session -d -s "$SESSION" -c "$_CHANNELS_STARTDIR" \
+          "$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
+        unset _CHANNELS_STARTDIR
+      fi
+      continue
+      ;;
     *"Bypass Permissions mode"*"Yes, I accept"*)
       $TMUX send-keys -t "$SESSION" "2" Enter
       sleep 1
@@ -220,6 +236,7 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
       ;;
   esac
 done
+unset _eperm_restarted
 
 # Set agent name once the session is ready. (/remote-control dropped: the operator no
 # longer uses Remote Control.)


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

**HU:** A Claude Code 2.1.183+ verzióban regresszió lépett fel: a `--channels` flag trusted projekt könyvtárból indítva EPERM hibát dob, mielőtt bármilyen dialog megjelenne, és a channels session nem indul el. A channels.sh startup guard eddig a trust dialogot kezelte, de az EPERM előtte jön.

Megoldás: az EPERM automatikus detektálása után a session újraindul egy ideiglenes `/tmp/marveen-channels-XXXXXX` könyvtárból, ahol a trust dialog normálisan jelenik meg és a startup guard elfogadja.

**EN:** Claude Code 2.1.183+ regression: launching `--channels` from a trusted project directory throws EPERM before any dialog appears, preventing the channels session from starting. The existing startup guard handled trust dialogs, but EPERM fires earlier.

Fix: on detecting EPERM, the script kills the failed session and restarts it from a temporary `/tmp/marveen-channels-XXXXXX` directory where the trust dialog fires normally and the startup guard auto-accepts it.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

This change was authored with AI assistance, reviewed by @cett  before submission.