### PR TITLE
feat(db): time-based retention for token_usage (bounds DB growth)

### DIFF
--- a/src/__tests__/token-usage.test.ts
+++ b/src/__tests__/token-usage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
-import { getDb, initDatabase } from '../db.js'
+import { getDb, initDatabase, pruneTokenUsage } from '../db.js'
 
 const TEST_DIR = '/tmp/test-token-usage'
 const PROJECTS_DIR = join(TEST_DIR, '.claude', 'projects')
@@ -101,6 +101,43 @@ afterAll(() => {
   const db = getDb()
   db.exec("DELETE FROM token_usage WHERE agent LIKE 'test-%' OR session_id LIKE 'sess-%'")
   db.exec("DELETE FROM token_usage_cursors WHERE file_path LIKE '/tmp/%'")
+})
+
+describe('pruneTokenUsage', () => {
+  const NOW = Math.floor(Date.now() / 1000)
+  const DAY = 86400
+  function insertRow(sessionId: string, ageDays: number) {
+    getDb().prepare(
+      `INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+       VALUES ('test-prune', ?, ?, 1, 1, 0, 0)`,
+    ).run(sessionId, NOW - ageDays * DAY)
+  }
+
+  beforeEach(() => {
+    getDb().exec("DELETE FROM token_usage WHERE agent = 'test-prune'")
+  })
+
+  it('deletes rows older than the retention window (default 90 days), keeps recent ones', () => {
+    insertRow('sess-old-1', 200)   // well past 90d
+    insertRow('sess-old-2', 91)    // just past 90d
+    insertRow('sess-recent-1', 89) // just inside 90d
+    insertRow('sess-recent-2', 1)  // recent
+
+    const removed = pruneTokenUsage()
+    expect(removed).toBe(2)
+
+    const remaining = getDb()
+      .prepare("SELECT session_id FROM token_usage WHERE agent = 'test-prune' ORDER BY session_id")
+      .all() as Array<{ session_id: string }>
+    expect(remaining.map((r) => r.session_id)).toEqual(['sess-recent-1', 'sess-recent-2'])
+  })
+
+  it('is a no-op when nothing is older than the window', () => {
+    insertRow('sess-fresh', 5)
+    expect(pruneTokenUsage()).toBe(0)
+    const cnt = getDb().prepare("SELECT COUNT(*) c FROM token_usage WHERE agent = 'test-prune'").get() as { c: number }
+    expect(cnt.c).toBe(1)
+  })
 })
 
 describe('collectTokenUsage', () => {

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -321,6 +321,18 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: false,
     requiresRestart: false,
   },
+  // --- Token usage module ---
+  {
+    key: 'TOKEN_USAGE_RETENTION_DAYS',
+    type: 'int',
+    default: 90,
+    min: 7,
+    max: 3650,
+    description: 'A token-használati napló (token_usage tábla) megőrzési ideje napokban. A napi sweep ennél régebbi sorokat törli, így a tábla nem nő korlátlanul. A modell-javaslat csak az utolsó 30 napot nézi, így a 90 nap minden fogyasztónak bőven elég.',
+    module: 'system',
+    secret: false,
+    requiresRestart: false,
+  },
 ]
 
 export function getSettingDefinition(key: string): SettingDefinition | undefined {

--- a/src/db.ts
+++ b/src/db.ts
@@ -2179,3 +2179,14 @@ export function pruneAuditLogs(): void {
   db.prepare('DELETE FROM store_file_audit WHERE created_at < ?').run(cutoff)
 }
 
+// Prune token_usage rows older than TOKEN_USAGE_RETENTION_DAYS. The table is the
+// main DB-growth driver (one row per inbound token-log event); without this it
+// grows unbounded. Called from the daily decay sweep. `timestamp` is unix
+// SECONDS. Returns the number of rows removed (for logging).
+export function pruneTokenUsage(): number {
+  const retentionDays = Number(getEffectiveSettingValue('TOKEN_USAGE_RETENTION_DAYS'))
+  const cutoff = Math.floor(Date.now() / 1000) - retentionDays * 86400
+  const info = db.prepare('DELETE FROM token_usage WHERE timestamp < ?').run(cutoff)
+  return info.changes
+}
+

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -8,6 +8,7 @@ import {
   saveMemory,
   decayMemories as dbDecay,
   pruneAuditLogs,
+  pruneTokenUsage,
   getMemoriesForChat,
   listKanbanCardsSummary,
   type Memory,
@@ -154,7 +155,8 @@ export async function saveConversationTurn(
 export function runDecaySweep(): void {
   dbDecay()
   pruneAuditLogs()
-  logger.info('Memoria leepulesi sopres vegrehajtva')
+  const tokenRowsPruned = pruneTokenUsage()
+  logger.info({ tokenRowsPruned }, 'Memoria leepulesi sopres vegrehajtva')
 }
 
 // --- Daily digest ---


### PR DESCRIPTION
A `token_usage` tábla a fő DB-növekedés-hajtó (egy sor minden bejövő token-log eseményre, ~1600/nap → **105k sor / ~24MB** indexekkel, és NINCS idő-alapú prune — csak egy egyszeri dedup a unique-indexen). Korlátlanul nőtt (a heartbeat egy 31M→44M ugrást jelzett). Kártya: 5d923cf4.

## Mit ad
- **config-registry**: `TOKEN_USAGE_RETENTION_DAYS` (int, default **90**, min 7, max 3650). A 90 nap biztonságos minden fogyasztónak — a modell-javaslat csak az utolsó 30 napot nézi.
- **db**: `pruneTokenUsage()` — törli a sorokat amelyek `timestamp`-je (unix másodperc) régebbi a megőrzési ablaknál; visszaadja a törölt sorok számát.
- **memory**: a `runDecaySweep()` (napi sweep) mostantól hívja a `pruneTokenUsage()`-t a `pruneAuditLogs()` mellett, és logolja a prune-olt sorszámot (az `AUDIT_LOG_RETENTION_DAYS` mintáját tükrözi 1:1).
- **tesztek**: prune törli a >ablak sorokat / megtartja a frisseket / helyes count / no-op ha nincs régi. **23/23 token-usage teszt zöld, tsc tiszta.**

## Megjegyzés
A növekedést bounded-dá teszi (kb. a megőrzési ablaknyi adatra cap-eli). A már lefoglalt lapok visszanyeréséhez egy egyszeri `VACUUM` kéne, de azt SZÁNDÉKOSAN nem futtatom a sweepben (túl nehéz egy napi jobhoz; a felszabadult lapokat az SQLite újrahasználja, így a fájl stabilizálódik). Ha akarjátok, külön egyszeri VACUUM-ot futtathatok élesítéskor.

## Verifikáció
- A `token_usage.timestamp` MÁSODPERC (igazolva: sample 1782032873 → 2026-06-21 09:07), a prune ennek megfelelően számol.
- Aktiválás a következő develop→main promote + dashboard-restart után (a napi decay-sweep hívja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)