### PR TITLE
test(db): run permission test on /tmp temp file, never the prod DB

### DIFF
--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -22,7 +22,7 @@ import {
   markPendingTaskRetryAlert,
   clearPendingTaskRetryAlert,
 } from '../db.js'
-import { STORE_DIR, DB_FILENAME } from '../config.js'
+import { DB_FILENAME } from '../config.js'
 
 beforeAll(() => {
   // Teszt adatbázis inicializálás -- in-memory, hogy a teszt SOHA ne irjon a
@@ -241,45 +241,66 @@ describe('pending task retries', () => {
 })
 
 describe('database file permissions', () => {
-  // Enforcement (not just observation): loosen every sidecar to 0o644
-  // first, then re-run initDatabase() to prove tightenDbPermissions
-  // actually narrows them. Without this, the tests would pass even if
-  // tightenDbPermissions were removed entirely -- the files would
-  // simply retain whatever mode a previous test run left them at.
+  // Run the whole tightening check against a throwaway DB in the OS temp dir,
+  // never the real store/claudeclaw.db. initDatabase() now applies pre-create
+  // + tightenDbPermissions to any on-disk override path (only ':memory:' is
+  // exempt), so a temp file exercises the exact prod tightening logic without
+  // a single touch to the prod store.
+  //
+  // Enforcement (not just observation): loosen every sidecar to 0o644 first,
+  // then re-run initDatabase() to prove tightenDbPermissions actually narrows
+  // them. Without this, the tests would pass even if tightenDbPermissions were
+  // removed entirely -- the files would simply retain whatever mode the
+  // first init left them at.
+  let tmpDir: string
+  let tmpDbPath: string
+
   beforeAll(async () => {
-    const { chmodSync } = await import('node:fs')
-    const dbPath = join(STORE_DIR, DB_FILENAME)
-    for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`, `${dbPath}-journal`]) {
+    const { mkdtempSync, chmodSync } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+    tmpDir = mkdtempSync(join(tmpdir(), 'claudeclaw-perm-'))
+    tmpDbPath = join(tmpDir, DB_FILENAME)
+    // First init creates the file + sidecars (already tightened).
+    initDatabase(tmpDbPath)
+    // Loosen them, then re-init to prove the tightening runs every time.
+    for (const p of [tmpDbPath, `${tmpDbPath}-wal`, `${tmpDbPath}-shm`, `${tmpDbPath}-journal`]) {
       if (existsSync(p)) {
         try { chmodSync(p, 0o644) } catch { /* best effort */ }
       }
     }
-    initDatabase()
+    initDatabase(tmpDbPath)
   })
 
-  it('claudeclaw.db is tightened to owner-only (0o600) by initDatabase', () => {
-    const dbPath = join(STORE_DIR, DB_FILENAME)
-    expect(existsSync(dbPath)).toBe(true)
-    const mode = statSync(dbPath).mode & 0o777
+  afterAll(async () => {
+    const { rmSync } = await import('node:fs')
+    // Restore the in-memory handle so we never leave the suite pointed at the
+    // temp file (which afterAll is about to delete).
+    initDatabase(':memory:')
+    try { rmSync(tmpDir, { recursive: true, force: true }) } catch { /* best effort */ }
+  })
+
+  it('db file is tightened to owner-only (0o600) by initDatabase', () => {
+    expect(existsSync(tmpDbPath)).toBe(true)
+    const mode = statSync(tmpDbPath).mode & 0o777
     expect(mode).toBe(0o600)
   })
 
   it('WAL sidecar (when present) is tightened to 0o600', () => {
-    const walPath = join(STORE_DIR, `${DB_FILENAME}-wal`)
+    const walPath = `${tmpDbPath}-wal`
     if (!existsSync(walPath)) return // WAL may not exist on a freshly-initialised empty DB
     const mode = statSync(walPath).mode & 0o777
     expect(mode).toBe(0o600)
   })
 
   it('SHM sidecar (when present) is tightened to 0o600', () => {
-    const shmPath = join(STORE_DIR, `${DB_FILENAME}-shm`)
+    const shmPath = `${tmpDbPath}-shm`
     if (!existsSync(shmPath)) return
     const mode = statSync(shmPath).mode & 0o777
     expect(mode).toBe(0o600)
   })
 
   it('rollback-journal sidecar (when present) is tightened to 0o600', () => {
-    const journalPath = join(STORE_DIR, `${DB_FILENAME}-journal`)
+    const journalPath = `${tmpDbPath}-journal`
     if (!existsSync(journalPath)) return
     const mode = statSync(journalPath).mode & 0o777
     expect(mode).toBe(0o600)

--- a/src/db.ts
+++ b/src/db.ts
@@ -30,13 +30,16 @@ function tightenDbPermissions(dbPath: string): void {
   }
 }
 
-// dbPathOverride is for tests: pass ':memory:' (or a temp path) to open an
-// isolated database instead of the real store/claudeclaw.db. The file-precreate
-// (openSync 'wx') and tightenDbPermissions steps are SKIPPED for an override --
-// they only make sense for a real on-disk store file, and ':memory:' has no path
-// to chmod. This keeps tests idempotent and stops them polluting the prod DB.
+// dbPathOverride is for tests: pass ':memory:' (or a temp file path) to open an
+// isolated database instead of the real store/claudeclaw.db. ':memory:' has no
+// path to chmod, so the file-precreate (openSync 'wx') and tightenDbPermissions
+// steps are skipped for it. A real on-disk override path (e.g. a /tmp temp file)
+// STILL gets pre-create + tighten -- this lets the permission tests exercise the
+// tightening logic on a throwaway file instead of touching the prod DB. The
+// STORE_DIR mkdir stays prod-only; a temp-file override owns its own directory.
 export function initDatabase(dbPathOverride?: string): void {
   const useOverride = dbPathOverride !== undefined
+  const isMemory = dbPathOverride === ':memory:'
   if (!useOverride) mkdirSync(STORE_DIR, { recursive: true })
   // Idempotent re-init: close a previous handle before opening a new one
   // so repeated calls (tests, hot-reload, recovery paths) do not leak
@@ -48,8 +51,8 @@ export function initDatabase(dbPathOverride?: string): void {
   // Step 1: close the TOCTOU window on fresh installs. openSync with 'wx'
   // + 0o600 creates the file ONLY if it doesn't exist and sets the strict
   // mode atomically. better-sqlite3 then opens the existing file rather
-  // than creating one at the default umask. Skipped for a test override.
-  if (!useOverride && !existsSync(dbPath)) {
+  // than creating one at the default umask. Skipped only for ':memory:'.
+  if (!isMemory && !existsSync(dbPath)) {
     try {
       closeSync(openSync(dbPath, 'wx', 0o600))
     } catch (err) {
@@ -63,7 +66,7 @@ export function initDatabase(dbPathOverride?: string): void {
   }
   db = new Database(dbPath)
   db.pragma('journal_mode = WAL')
-  if (!useOverride) tightenDbPermissions(dbPath)
+  if (!isMemory) tightenDbPermissions(dbPath)
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS sessions (


### PR DESCRIPTION
## Mit

A `database file permissions` teszt-blokk eddig `initDatabase()`-t hívott argumentum nélkül -> a VALÓDI `store/claudeclaw.db`-t nyitotta meg (sidecarokat 0o644-re lazította, majd visszaszorította). Idempotens és ártalmatlan volt, de elvi tisztátalanság: teszt ne nyúljon a prod store-hoz.

## Hogyan

`initDatabase()` korábban MINDEN override-path-re kihagyta a pre-create + `tightenDbPermissions` lépést -> egy temp-fájl override nem tudta gyakorolni a tightening logikát. A skip-et leszűkítettem CSAK `:memory:`-re: egy valódi on-disk override (pl. `/tmp` temp fájl) most ugyanazt a pre-create + tighten utat kapja, mint a prod.

A perm-suite így végig egy eldobható DB-n fut `os.tmpdir()`-ben (`mkdtemp` + `rm` az `afterAll`-ban), és visszaállítja a `:memory:` handle-t, hogy semmi ne maradjon a törölt temp fájlra mutatva.

**A prod út (override nélkül) byte-ról byte-ra változatlan.**

## Verify

- `npx tsc --noEmit` zöld
- 28/28 `db.test.ts` teszt zöld
- prod `store/claudeclaw.db` érintetlen (továbbra is `0o600`), nincs temp-leftover

🤖 Generated with [Claude Code](https://claude.com/claude-code)