### PR TITLE
fix(channels): restore Marveen CLAUDE.md context in the EPERM /tmp fallback

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -210,6 +210,22 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
         _eperm_restarted=1
         $TMUX kill-session -t "$SESSION" 2>/dev/null
         _CHANNELS_STARTDIR="$(mktemp -d /tmp/marveen-channels-XXXXXX)"
+        # Carry the project CLAUDE.md into the fallback cwd so the session keeps
+        # Marveen's instructions/personality instead of running as a generic,
+        # context-less assistant (the biggest degradation of the /tmp fallback).
+        # Best-effort: a symlink failure degrades to the prior behaviour and
+        # never blocks startup. The trust dialog for the fresh /tmp path still
+        # fires and is handled by the guard below; EPERM is keyed on the
+        # registered project path, not on file presence, so seeding CLAUDE.md
+        # does not re-trigger it.
+        #
+        # NOTE: the project-scoped MCP servers (gmail/calendar) are NOT restored
+        # here. Claude Code keys those by project PATH in ~/.claude.json, not in
+        # the project .mcp.json, so a random /tmp path has no entry and symlinking
+        # files cannot bring them back. Restoring them needs a separate, more
+        # invasive change (a stable fallback dir + a seeded ~/.claude.json project
+        # entry); see the PR description / card 7EB18437.
+        [ -e "$INSTALL_DIR/CLAUDE.md" ] && ln -sf "$INSTALL_DIR/CLAUDE.md" "$_CHANNELS_STARTDIR/CLAUDE.md" 2>/dev/null || true
         $TMUX new-session -d -s "$SESSION" -c "$_CHANNELS_STARTDIR" \
           "$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
         unset _CHANNELS_STARTDIR


### PR DESCRIPTION
## Kártya 7EB18437 (follow-up a #425-höz)

Amikor a #425 EPERM-fallback tüzel, a channels session egy üres `mktemp /tmp` dir-ből indul újra, így elveszti a projekt `CLAUDE.md`-t és generikus, kontextus nélküli asszisztensként fut. Ez a PR symlinkeli a `CLAUDE.md`-t a fallback cwd-be (best-effort, sosem blokkolja a startupot), hogy Marveen megtartsa az instrukcióit/személyiségét.

`bash -n` OK, +16 sor (nagyrészt magyarázó komment), em-dash 0.

## Ground-truth finding (FONTOS, scope-szűkítés)

A kártya a projekt-MCP-ket (**gmail/calendar**) is vissza akarta hozni. Ezt symlink **NEM tudja**: a Claude Code a projekt-scoped MCP szervereket a projekt **ÚTVONALA szerint** tárolja a `~/.claude.json`-ban, NEM a `.mcp.json`-ban:

```
~/.claude.json -> projects."/Users/marvin/ClaudeClaw".mcpServers
  = [server-gmail-autoauth-mcp, server-google-calendar-mcp]
```

Egy random `/tmp` útvonalnak nincs ilyen bejegyzése -> a gmail/calendar nem töltődik be. A `.mcp.json`-ban csak `aiam-blog` van, az pedig **nincs engedélyezve** (`enabledMcpjsonServers: []`). Tehát egy `.mcp.json` symlink semmit nem adna, csak egy MCP-trust promptot kockáztatna -> szándékosan kihagyva.

**A gmail/calendar visszahozása külön, invazívabb változtatást igényel** (stabil fallback dir + egy `~/.claude.json` projekt-bejegyzés seedelése a fallback útvonalra). Ez globális user-config mutáció -> design-döntésre váró follow-up, NEM ebbe a PR-be kötve. Opciók ha kell:
1. Fix fallback dir (pl. `~/.claude/tmp/marveen-channels-fallback`) + egyszeri `~/.claude.json` merge a gmail/calendar mcpServers-szel arra az útvonalra (trust + MCP egyszer megadva, nincs /tmp-bloat).
2. Marad a CLAUDE.md-only (ez a PR), a gmail/calendar a degradált-ablakban hiányzik (de a fallback maga ritka + tranziens upstream regresszió).

## Verifikációs korlát (transzparens)

Ez a host Claude Code **2.1.170** (< 2.1.183), így az EPERM-út itt NEM tüzel -> a shell-logikát verifikáltam (`bash -n`; symlink létrejön, feloldódik, olvasható; missing-source graceful exit 0), de élő EPERM-fallback sessiont NEM tudtam meghajtani. A változás biztonságosan degradál (symlink-hiba == korábbi viselkedés).

Recovery-stack terület -> kérlek grep-eld az érintett fallback-utat a review-nál.

🤖 Generated with [Claude Code](https://claude.com/claude-code)