### PR TITLE
feat(installer): auto-install Go and build bumblebee during setup

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1021,13 +1021,18 @@ else
         || echo "go1.25.0")
       _GOTAR="${_GOVERSION}.linux-${_GOARCH}.tar.gz"
       if curl -fsSL "https://go.dev/dl/${_GOTAR}" -o "/tmp/${_GOTAR}" 2>/dev/null; then
-        sudo rm -rf /usr/local/go
-        sudo tar -C /usr/local -xzf "/tmp/${_GOTAR}" 2>/dev/null
+        # set -e + trap ERR van eletben: a kicsomagolas bukasa NE allitsa le a
+        # telepitest, csak hagyja ki bumblebee-t.
+        sudo rm -rf /usr/local/go 2>/dev/null || true
+        if sudo tar -C /usr/local -xzf "/tmp/${_GOTAR}" 2>/dev/null; then
+          export PATH="$PATH:/usr/local/go/bin"
+          ensure_in_rc '/usr/local/go/bin' 'export PATH="$PATH:/usr/local/go/bin"'
+          _GO_INSTALLED=true
+          ok "Go telepitve (/usr/local/go): ${_GOVERSION}"
+        else
+          echo -e "  ${RED}✗${NC} Go tarball kicsomagolas sikertelen."
+        fi
         rm -f "/tmp/${_GOTAR}"
-        export PATH="$PATH:/usr/local/go/bin"
-        ensure_in_rc '/usr/local/go/bin' 'export PATH="$PATH:/usr/local/go/bin"'
-        _GO_INSTALLED=true
-        ok "Go telepitve (/usr/local/go): ${_GOVERSION}"
       else
         echo -e "  ${RED}✗${NC} Go tarball letoltes sikertelen."
       fi
@@ -1048,7 +1053,7 @@ elif _go_version_ok; then
   echo -e "  bumblebee build forrasbol (github.com/perplexityai/bumblebee)..."
   mkdir -p "$HOME/.local/bin"
   _BB_TMP=$(mktemp -d)
-  if git clone -q --depth 1 https://github.com/perplexityai/bumblebee.git "$_BB_TMP" 2>/dev/null; then
+  if git clone -q --depth 1 --branch v0.1.2 https://github.com/perplexityai/bumblebee.git "$_BB_TMP" 2>/dev/null; then
     if (cd "$_BB_TMP" && go build -o "$BUMBLEBEE_BIN" ./cmd/bumblebee 2>/dev/null); then
       chmod +x "$BUMBLEBEE_BIN"
       ok "bumblebee telepitve: $BUMBLEBEE_BIN"

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -975,6 +975,96 @@ else
   fi
 fi
 
+INSTALL_STEP="bumblebee"
+# ─────────────────────────────────────────────
+# Go + bumblebee (supply-chain scanner)
+# ─────────────────────────────────────────────
+echo ""
+echo -e "  Go + bumblebee (supply-chain scanner)..."
+
+_go_version_ok() {
+  command -v go &>/dev/null || return 1
+  local ver major minor
+  ver=$(go version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1)
+  major=$(echo "$ver" | cut -d. -f1)
+  minor=$(echo "$ver" | cut -d. -f2)
+  [ "$major" -gt 1 ] || ( [ "$major" -eq 1 ] && [ "${minor:-0}" -ge 25 ] )
+}
+
+if _go_version_ok; then
+  ok "$(go version | grep -oE 'go[0-9]+\.[0-9.]+')"
+else
+  echo -e "  ${ORANGE}!${NC} Go >= 1.25 szukseges -- telepites..."
+  _GO_INSTALLED=false
+  # 1. snap (Ubuntu/Debian desktop, Fedora, Nobara)
+  if command -v snap &>/dev/null; then
+    echo -e "  snap install go --classic..."
+    if sudo snap install go --classic 2>/dev/null; then
+      export PATH="/snap/bin:$PATH"
+      _GO_INSTALLED=true
+      ok "Go telepitve (snap)"
+    fi
+  fi
+  # 2. Hivatalos tarball fallback (ha snap nem elerheto vagy sikertelen)
+  if [ "$_GO_INSTALLED" = "false" ]; then
+    echo -e "  Hivatalos Go tarball letoltese (go.dev/dl)..."
+    _ARCH=$(uname -m)
+    case "$_ARCH" in
+      x86_64)  _GOARCH="amd64" ;;
+      aarch64) _GOARCH="arm64" ;;
+      armv7l)  _GOARCH="armv6l" ;;
+      *)       _GOARCH="" ;;
+    esac
+    if [ -n "$_GOARCH" ]; then
+      _GOVERSION=$(curl -fsSL "https://go.dev/dl/?mode=json" 2>/dev/null \
+        | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['version'])" 2>/dev/null \
+        || echo "go1.25.0")
+      _GOTAR="${_GOVERSION}.linux-${_GOARCH}.tar.gz"
+      if curl -fsSL "https://go.dev/dl/${_GOTAR}" -o "/tmp/${_GOTAR}" 2>/dev/null; then
+        sudo rm -rf /usr/local/go
+        sudo tar -C /usr/local -xzf "/tmp/${_GOTAR}" 2>/dev/null
+        rm -f "/tmp/${_GOTAR}"
+        export PATH="$PATH:/usr/local/go/bin"
+        ensure_in_rc '/usr/local/go/bin' 'export PATH="$PATH:/usr/local/go/bin"'
+        _GO_INSTALLED=true
+        ok "Go telepitve (/usr/local/go): ${_GOVERSION}"
+      else
+        echo -e "  ${RED}✗${NC} Go tarball letoltes sikertelen."
+      fi
+    else
+      echo -e "  ${RED}✗${NC} Ismeretlen CPU architektura ($_ARCH) -- Go nem telepitheto automatikusan."
+    fi
+  fi
+  if [ "$_GO_INSTALLED" = "false" ]; then
+    echo -e "  ${ORANGE}!${NC} Go telepites sikertelen -- bumblebee kihagyva."
+    echo -e "  ${DIM}  Kezzel: sudo snap install go --classic  VAGY  https://go.dev/dl${NC}"
+  fi
+fi
+
+BUMBLEBEE_BIN="$HOME/.local/bin/bumblebee"
+if [ -x "$BUMBLEBEE_BIN" ]; then
+  ok "bumblebee mar telepitve ($BUMBLEBEE_BIN)"
+elif _go_version_ok; then
+  echo -e "  bumblebee build forrasbol (github.com/perplexityai/bumblebee)..."
+  mkdir -p "$HOME/.local/bin"
+  _BB_TMP=$(mktemp -d)
+  if git clone -q --depth 1 https://github.com/perplexityai/bumblebee.git "$_BB_TMP" 2>/dev/null; then
+    if (cd "$_BB_TMP" && go build -o "$BUMBLEBEE_BIN" ./cmd/bumblebee 2>/dev/null); then
+      chmod +x "$BUMBLEBEE_BIN"
+      ok "bumblebee telepitve: $BUMBLEBEE_BIN"
+    else
+      echo -e "  ${ORANGE}!${NC} bumblebee build sikertelen -- a supply-chain scan kihagyja a binart."
+      echo -e "  ${DIM}  Kezzel: cd /tmp/bb && go build -o ~/.local/bin/bumblebee ./cmd/bumblebee${NC}"
+    fi
+  else
+    echo -e "  ${ORANGE}!${NC} bumblebee clone sikertelen (halozat?) -- kihagyva."
+  fi
+  rm -rf "$_BB_TMP"
+else
+  echo -e "  ${ORANGE}!${NC} Go nem elerheto -- bumblebee kihagyva. A supply-chain scan atlepve."
+  echo -e "  ${DIM}  Kezzel: sudo snap install go --classic && git clone https://github.com/perplexityai/bumblebee /tmp/bb && (cd /tmp/bb && go build -o ~/.local/bin/bumblebee ./cmd/bumblebee)${NC}"
+fi
+
 INSTALL_STEP="systemd"
 # ─────────────────────────────────────────────
 # [7/7] Automatikus inditas (systemd)

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -692,6 +692,58 @@ if ! command -v ffmpeg &>/dev/null; then
 fi
 echo -e "$(_t macos.ffmpeg_done)"
 
+INSTALL_STEP="bumblebee"
+# Go + bumblebee (supply-chain scanner)
+echo ""
+echo -e "  Go + bumblebee (supply-chain scanner)..."
+
+_go_version_ok() {
+  command -v go &>/dev/null || return 1
+  local ver major minor
+  ver=$(go version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1)
+  major=$(echo "$ver" | cut -d. -f1)
+  minor=$(echo "$ver" | cut -d. -f2)
+  [ "$major" -gt 1 ] || ( [ "$major" -eq 1 ] && [ "${minor:-0}" -ge 25 ] )
+}
+
+if _go_version_ok; then
+  echo -e "  ${GREEN}✓${NC} $(go version | grep -oE 'go[0-9]+\.[0-9.]+')"
+else
+  echo -e "  ${ORANGE}!${NC} Go >= 1.25 szukseges -- telepites (brew install go)..."
+  if command -v brew &>/dev/null; then
+    brew install go
+    # Frissitjuk a PATH-ot az uj Go binary-re
+    export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+  else
+    echo -e "  ${RED}✗${NC} Homebrew nem elerheto; bumblebee nem telepitheto automatikusan."
+    echo -e "  ${DIM}  Kezzel: https://go.dev/dl (>= 1.25)${NC}"
+  fi
+fi
+
+BUMBLEBEE_BIN="$HOME/.local/bin/bumblebee"
+if [ -x "$BUMBLEBEE_BIN" ]; then
+  echo -e "  ${GREEN}✓${NC} bumblebee mar telepitve ($BUMBLEBEE_BIN)"
+elif _go_version_ok; then
+  echo -e "  bumblebee build forrasbol (github.com/perplexityai/bumblebee)..."
+  mkdir -p "$HOME/.local/bin"
+  _BB_TMP=$(mktemp -d)
+  if git clone -q --depth 1 https://github.com/perplexityai/bumblebee.git "$_BB_TMP" 2>/dev/null; then
+    if (cd "$_BB_TMP" && go build -o "$BUMBLEBEE_BIN" ./cmd/bumblebee 2>/dev/null); then
+      chmod +x "$BUMBLEBEE_BIN"
+      echo -e "  ${GREEN}✓${NC} bumblebee telepitve: $BUMBLEBEE_BIN"
+    else
+      echo -e "  ${ORANGE}!${NC} bumblebee build sikertelen -- a supply-chain scan kihagyja a binart."
+      echo -e "  ${DIM}  Kezzel: cd /tmp/bb && go build -o ~/.local/bin/bumblebee ./cmd/bumblebee${NC}"
+    fi
+  else
+    echo -e "  ${ORANGE}!${NC} bumblebee clone sikertelen (halozat?) -- kihagyva."
+  fi
+  rm -rf "$_BB_TMP"
+else
+  echo -e "  ${ORANGE}!${NC} Go nem elerheto -- bumblebee kihagyva. A supply-chain scan atlepve."
+  echo -e "  ${DIM}  Kezzel: brew install go && git clone https://github.com/perplexityai/bumblebee /tmp/bb && (cd /tmp/bb && go build -o ~/.local/bin/bumblebee ./cmd/bumblebee)${NC}"
+fi
+
 INSTALL_STEP="launchagent"
 # Step 7: LaunchAgent setup
 echo ""

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -711,9 +711,14 @@ if _go_version_ok; then
 else
   echo -e "  ${ORANGE}!${NC} Go >= 1.25 szukseges -- telepites (brew install go)..."
   if command -v brew &>/dev/null; then
-    brew install go
-    # Frissitjuk a PATH-ot az uj Go binary-re
-    export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+    # set -e + trap ERR van eletben: brew bukasa NE allitsa le a telepitest,
+    # csak hagyja ki bumblebee-t (a _go_version_ok ujra-ellenoriz lentebb).
+    if brew install go; then
+      # Frissitjuk a PATH-ot az uj Go binary-re
+      export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+    else
+      echo -e "  ${ORANGE}!${NC} Go telepites sikertelen -- bumblebee kihagyva."
+    fi
   else
     echo -e "  ${RED}✗${NC} Homebrew nem elerheto; bumblebee nem telepitheto automatikusan."
     echo -e "  ${DIM}  Kezzel: https://go.dev/dl (>= 1.25)${NC}"
@@ -727,7 +732,7 @@ elif _go_version_ok; then
   echo -e "  bumblebee build forrasbol (github.com/perplexityai/bumblebee)..."
   mkdir -p "$HOME/.local/bin"
   _BB_TMP=$(mktemp -d)
-  if git clone -q --depth 1 https://github.com/perplexityai/bumblebee.git "$_BB_TMP" 2>/dev/null; then
+  if git clone -q --depth 1 --branch v0.1.2 https://github.com/perplexityai/bumblebee.git "$_BB_TMP" 2>/dev/null; then
     if (cd "$_BB_TMP" && go build -o "$BUMBLEBEE_BIN" ./cmd/bumblebee 2>/dev/null); then
       chmod +x "$BUMBLEBEE_BIN"
       echo -e "  ${GREEN}✓${NC} bumblebee telepitve: $BUMBLEBEE_BIN"


### PR DESCRIPTION
## Summary

- Both `install-macos.sh` and `install-linux.sh` now detect Go >= 1.25 and the `bumblebee` binary at install time, and build/install them automatically if missing
- **macOS**: `brew install go` if Go is absent or < 1.25; then clones and builds `github.com/perplexityai/bumblebee` into `~/.local/bin/bumblebee`
- **Linux**: tries `snap install go --classic` first; falls back to the official go.dev tarball (auto-detects `amd64`/`arm64`/`armv6l`, queries the go.dev JSON API for the latest version); then clones and builds bumblebee the same way

Both paths are **non-fatal**: if Go or git clone fails, the installer warns and continues — the weekly `bumblebee-hygiene-scan` task already gracefully skips when the binary is missing.

## Closes

Kanban #233

## Test plan

- [ ] macOS: fresh machine without Go — `brew install go` fires, bumblebee builds to `~/.local/bin/bumblebee`
- [ ] macOS: Go already present >= 1.25 — skip install, build bumblebee only if missing
- [ ] macOS: Go already present < 1.25 — upgrade via brew, then build
- [ ] Linux (apt): snap present — `snap install go --classic`, then build
- [ ] Linux: snap absent — tarball download from go.dev, then build
- [ ] Linux: network failure during clone — warn, continue (no crash)
- [ ] Both: `~/.local/bin/bumblebee` already present — skip build entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)