### PR TITLE
fix(stuck-watcher): skip respawn when pane is at the idle prompt

### DIFF
--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -46,6 +46,7 @@ import { resumeMarveenSession, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS 
 import {
   stuckToolCallSignature,
   decideStuckToolCallRecovery,
+  detectPaneState,
   type StuckToolCallState,
   type StuckToolCallThresholds,
 } from '../pane-state.js'
@@ -154,6 +155,27 @@ function checkSession(label: string, session: string): void {
   }
 
   if (recover) {
+    // Idle-prompt guard (2026-06-22 false-positive loop): the signature only
+    // sees a frozen "<verb> for Ns" footer -- it cannot tell an ACTIVELY-wedged
+    // tool-call (the 2026-06-02 incident) from the RESIDUAL footer a COMPLETED
+    // turn leaves on screen while the session sits idle waiting for its next
+    // heartbeat. Both read as a stagnant counter. The discriminator is the input
+    // box: a genuine mid-turn wedge has no ready prompt (detectPaneState != idle,
+    // the box is replaced by the busy/working indicator), whereas a completed
+    // turn's residual sits ABOVE a live `❯` idle prompt. If the pane is idle, the
+    // user can interact -- it is not the user-facing freeze this watcher targets
+    // -- so respawning is pure churn (this is what drove ~150 spurious respawns/
+    // week, each leaving a fresh residual footer that re-armed the loop). Clear
+    // the stale spell so the residual stops re-triggering every poll. Fail-open:
+    // a null pane (capture failed) does NOT block recovery.
+    if (pane != null && detectPaneState(pane) === 'idle') {
+      logger.info(
+        { label, session, tag: next.tag, seconds: next.lastSeconds, spellPeakSeconds: next.spellPeakSeconds },
+        'stuck-tool-call-watcher: counter stagnant but pane is at the idle prompt (residual footer of a completed turn, not a wedge) -- skipping recovery',
+      )
+      watchState.delete(session)
+      return
+    }
     // Post-respawn grace: defer if a respawn (this watcher, channel-monitor's
     // cascade, channel-watchdog.sh, or the #264 stuck-modal-guard on Linux)
     // happened within the grace window. Two reasons: (1) a freshly respawned


### PR DESCRIPTION
The stuck-tool-call-watcher only sees a frozen "<verb> for Ns" footer and cannot distinguish an actively-wedged tool-call (2026-06-02 incident) from the residual footer a COMPLETED turn leaves on screen while the session sits idle awaiting its next heartbeat. Both read as a stagnant counter past the freeze threshold, so the watcher respawned the main session ~150x/week, each respawn leaving a fresh residual that re-armed the loop.

Add an idle-prompt guard before recovery: if detectPaneState(pane) === 'idle' (a live `>` input box is present, so the user can interact), the frozen footer is a completed turn's residual, not the user-facing freeze this watcher targets -- skip the respawn and clear the stale spell. A genuine mid-turn wedge has no ready prompt (busy/unknown state) so recovery still fires; no regression to the 2026-06-02 detection. Fail-open on a null pane capture.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
