### PR TITLE
fix(test): exclude Playwright smoke suite from `vitest run`

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, configDefaults } from 'vitest/config'
+
+// The Playwright smoke suite (tests/smoke/**) is driven by `npm run smoke`
+// (playwright.config.ts), not by `vitest run`. Playwright's test() API throws
+// when collected under vitest, which fails the unit gate. Keep all vitest
+// defaults; only carve out the e2e directory.
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, 'tests/smoke/**'],
+  },
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

HU: A `npm test` (`vitest run`) friss kláznál elbukik, mert a vitest alapból beszedi a Playwright smoke suite-ot (`tests/smoke/dashboard.spec.ts`, #423), és a Playwright `test()`/`describe()` API eldobja magát, ha vitest alatt töltődik be. A smoke suite a `npm run smoke` (playwright.config.ts) úton fut, nem a unit-gate-en. Ez a PR egy minimális `vitest.config.ts`-t ad, ami megtartja az összes vitest alapbeállítást, és csak a `tests/smoke/**` mappát zárja ki a gyűjtésből. Így a unit-suite zöld marad, a Playwright e2e pedig változatlanul a `npm run smoke`-on keresztül fut.

EN: On a fresh checkout `npm test` (`vitest run`) fails because vitest collects the Playwright smoke suite (`tests/smoke/dashboard.spec.ts`, added in #423) by default, and Playwright's `test()`/`describe()` API throws when loaded under vitest. The smoke suite is meant to run via `npm run smoke` (playwright.config.ts), not the unit gate. This PR adds a minimal `vitest.config.ts` that keeps all vitest defaults and only excludes `tests/smoke/**` from collection. The unit suite stays green and the Playwright e2e suite keeps running through `npm run smoke`.

Repro / verification: on a clean `develop` checkout, `npm test` -> 1 failed suite (the smoke spec). With this change, the full unit suite is green (88 files, 1338 passed, 1 skipped). `npm run build` passes.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. (n/a -- test-config only)
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
