### PR TITLE
fix(agent-process): schedule plugin-unlock probe for colleague agents

### DIFF
--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -29,6 +29,7 @@ import { getProvider, getProviderType, channelStateDir, readChannelToken, type C
 import { CHANNEL_PROVIDER, MAIN_AGENT_ID } from '../config.js'
 import { loadProfileTemplate } from './profiles.js'
 import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
+import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import { getSecret } from './vault.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
 
@@ -418,6 +419,21 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // sessions can also be present, so dismiss both. Errors are swallowed
     // -- the outbound pre-flight remains the safety net if this misses.
     scheduleIdentitySetup(session, readAgentDisplayName(name))
+
+    // Colleague auto-unlock (2026-06-22): mirror the main session's
+    // post-respawn unlock probe for channel-having sub-agents. After a restart
+    // the bun channel poller sometimes never attaches during the cold-start
+    // window (observed fleet-wide after a managed restart: the TUI comes up but
+    // bot.pid stays empty, so the agent goes deaf to inbound). The main session
+    // self-heals because channel-monitor schedules schedulePluginUnlockAfterRespawn;
+    // sub-agents had no such probe and stayed stuck until a manual /mcp kick.
+    // Schedule the same probe here. It is gated on bun-absence (a healthy poller
+    // is left untouched) and on an idle pane, so it never disturbs a colleague
+    // mid-turn. Channel-less agents (hasChannel false) get no probe; MAIN never
+    // takes this path (it comes up via channels.sh) but guard defensively.
+    if (hasChannel && name !== MAIN_AGENT_ID) {
+      schedulePluginUnlockAfterRespawn(session, provider.type)
+    }
 
     return { ok: true }
   } catch (err) {


### PR DESCRIPTION
After a managed restart, a channel-having sub-agent's bun poller sometimes never attaches during the cold-start window: the TUI comes up idle but bot.pid stays empty, so the agent goes deaf to inbound (observed fleet-wide after a 05:49 fleet restart -- 5 of 6 colleagues stuck, only a manual /mcp kick or repeated restarts recovered them).

The main channels session already self-heals: channel-monitor schedules schedulePluginUnlockAfterRespawn after its respawn. Sub-agents had no such probe. Schedule the same probe at the end of startAgentProcess for channel- having, non-main agents. The probe is gated on bun-absence (a healthy poller is left untouched) and an idle pane (never disturbs a colleague mid-turn), so it is safe to run on every start. Channel-less agents get no probe.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
