### PR TITLE
pane-state: detect parked input rendered with a non-breaking space after the prompt

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -1576,6 +1576,107 @@ describe('parkedInputText', () => {
   })
 })
 
+describe('parked input rendered with a non-breaking space (U+00A0) after ❯', () => {
+  // Live Claude Code panes render a NON-BREAKING SPACE (U+00A0), not an
+  // ASCII space, between the ❯ prompt glyph and parked (delivered-but-not-
+  // yet-submitted) text. Byte-for-byte the prompt line reads
+  //   e2 9d af (❯)  c2 a0 (NBSP)  <text>
+  // The ASCII-space form only shows up in scrollback for already-submitted
+  // lines. The original PARKED_INPUT_RX `/❯[ \t]+\S/` accepted only ASCII
+  // space or tab after the glyph, so an NBSP-rendered parked box fell
+  // through to 'idle'. And because every stuck-input recovery helper
+  // (stuckInputSignature, parkedChannelInput, parkedInputText) gates on
+  // detectPaneState === 'typing', that single miss took the whole recovery
+  // chain down: the delivered message stranded in the box forever, no
+  // recovery Enter was ever sent. Verified live 2026 on real captured panes.
+  const NBSP = '\u00a0'
+  const NBSP_PARKED = [
+    '', SEP,
+    `❯${NBSP}[Uzenet @dev2-tol]: please re-run the merge once CI is green`,
+    SEP,
+    '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+  ].join('\n')
+  // The same message with an ordinary ASCII space, so the fix is proven to
+  // keep the pre-existing form working rather than swap one gap for another.
+  const ASCII_PARKED = [
+    '', SEP,
+    '❯ [Uzenet @dev2-tol]: please re-run the merge once CI is green',
+    SEP,
+    '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+  ].join('\n')
+
+  it('classifies an NBSP-prompted parked box as typing, not idle', () => {
+    expect(detectPaneState(NBSP_PARKED)).toBe('typing')
+  })
+
+  it('still classifies the ASCII-space parked box as typing (no regression)', () => {
+    expect(detectPaneState(ASCII_PARKED)).toBe('typing')
+  })
+
+  it('merges an NBSP-parked box to busy when mergeTypingAsBusy is set', () => {
+    expect(detectPaneState(NBSP_PARKED, { mergeTypingAsBusy: true })).toBe('busy')
+  })
+
+  it('does not report an NBSP-parked pane as ready for a new prompt', () => {
+    expect(isReadyForPrompt(NBSP_PARKED)).toBe(false)
+  })
+
+  it('revives the stuck-input recovery chain (signature is non-null)', () => {
+    expect(stuckInputSignature(NBSP_PARKED)).not.toBe(null)
+  })
+
+  it('recovers the parked text with the ❯ prompt and NBSP stripped', () => {
+    expect(parkedInputText(NBSP_PARKED)).toBe(
+      '[Uzenet @dev2-tol]: please re-run the merge once CI is green',
+    )
+  })
+
+  // The production-critical stranding path: an inbound plugin notification
+  // (Telegram / inter-agent <channel> block) delivered into the box but not
+  // submitted, rendered with the NBSP gap. This is the exact shape that
+  // strands in the wild, so lock that parkedChannelInput recovers it intact.
+  it('recovers an NBSP-prompted parked CHANNEL block with the correct chat_id', () => {
+    const pane = [
+      '', SEP,
+      `❯${NBSP}<channel source="plugin:telegram:telegram" chat_id="1268077055" message_id="999" ts="2026-06-05T10:00:00Z">message body</channel>`,
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    const r = parkedChannelInput(pane)
+    expect(r).not.toBeNull()
+    expect(r!.complete).toBe(true)
+    expect(r!.chatId).toBe('1268077055')
+  })
+
+  // Real stranded messages are long and the TUI wraps them across input-box
+  // lines. Lock that NBSP + terminal-wrap collapse to one submittable line.
+  it('collapses a terminal-wrapped NBSP-parked message into one submittable line', () => {
+    const pane = [
+      '', SEP,
+      `❯${NBSP}[Uzenet @dev3-tol]: please review the latest changes when you`,
+      '  have a moment and re-run the merge once CI is green',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectPaneState(pane)).toBe('typing')
+    expect(parkedInputText(pane)).toBe(
+      '[Uzenet @dev3-tol]: please review the latest changes when you have a moment and re-run the merge once CI is green',
+    )
+  })
+
+  // The idle footer has two arms (bypass-permissions and the strict
+  // `? for shortcuts`). Lock NBSP detection under the strict arm too.
+  it('classifies an NBSP-parked box as typing under the strict shortcuts footer', () => {
+    const pane = [
+      '', SEP,
+      `❯${NBSP}[Uzenet @dev2-tol]: ping`,
+      SEP,
+      '  ? for shortcuts',
+    ].join('\n')
+    expect(detectPaneState(pane)).toBe('typing')
+  })
+})
+
 describe('detectsBlockingMenu', () => {
   // The real /mcp "Manage MCP servers" modal that wedged the main channels
   // session for ~6h (2026-06-12). The input box is gone; the footer shows the

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -174,11 +174,22 @@ export function detectsPastePlaceholder(pane: string): boolean {
 // HORIZONTAL. At least 10 in a run to ignore stray `-` glyphs.
 const BOX_SEP_RX = /^─{10,}/
 
-// Prompt line inside the input box. `❯` followed by at least one tab/
-// space and then a non-whitespace character means the user (or a
-// send-keys that didn't submit) parked text there. Single-line match
-// ([ \t] not \s) to avoid crossing into the next line.
-const PARKED_INPUT_RX = /❯[ \t]+\S/
+// Prompt line inside the input box. `❯` followed by at least one
+// horizontal whitespace and then a non-whitespace character means the
+// user (or a send-keys that didn't submit) parked text there.
+//
+// The class is `[^\S\r\n]` (any whitespace EXCEPT a line break), not
+// `[ \t]`: a live Claude Code pane renders the gap after the ❯ prompt
+// glyph as a NON-BREAKING SPACE (U+00A0), not an ASCII space, while a
+// message sits parked (delivered but not yet submitted). The ASCII-space
+// form only appears in scrollback for already-submitted lines. `[ \t]`
+// missed that NBSP, so an NBSP-rendered parked box read as 'idle' and the
+// whole stuck-input recovery chain (stuckInputSignature, parkedChannelInput,
+// parkedInputText all gate on detectPaneState === 'typing') never fired --
+// the message stranded forever. Excluding only \r\n keeps the original
+// single-line intent (the match must not cross into the next line) while
+// admitting the NBSP and any other horizontal Unicode space the TUI emits.
+const PARKED_INPUT_RX = /❯[^\S\r\n]+\S/
 
 // Persistent Anthropic thinking-block API error. When an assistant turn
 // ends with a 400 about thinking/redacted_thinking blocks that "cannot


### PR DESCRIPTION
## Why this matters

When the router or a channel plugin delivers a message into an agent's input box, a live Claude Code TUI renders the gap between the `❯` prompt glyph and the parked (delivered-but-not-yet-submitted) text as a NON-BREAKING SPACE (U+00A0), not an ASCII space. Byte-for-byte the prompt line reads `e2 9d af` (❯) `c2 a0` (NBSP) `<text>`. The ASCII-space form only shows up in scrollback for already-submitted lines.

`PARKED_INPUT_RX` was `/❯[ \t]+\S/`, which accepts only ASCII space or tab after the glyph. So an NBSP-rendered parked box classified as `idle` instead of `typing`. Every stuck-input recovery helper (`stuckInputSignature`, `parkedChannelInput`, `parkedInputText`) gates on `detectPaneState(pane) === 'typing'`, so that single miss took the whole recovery chain down: the delivered message stranded in the prompt box, no recovery Enter was ever sent, and the session stalled until a human pressed Enter by hand.

Reproduction (regex level):

- old `/❯[ \t]+\S/` against `❯` + NBSP + text => `false` (the bug)
- new `/❯[^\S\r\n]+\S/` against the same => `true`
- new regex against `❯` + newline => `false` (single-line intent preserved)

## Change

`src/pane-state.ts`: one regex literal, `/❯[ \t]+\S/` -> `/❯[^\S\r\n]+\S/` ("any horizontal whitespace except a line break"), plus an explanatory comment. This admits the NBSP and any other non-newline Unicode space the TUI may emit, while keeping the original single-line constraint (the match must not cross into the next line).

No other code path needed changing. The downstream helpers already whitespace-collapse with `\s+` (which folds NBSP to a plain space), so re-injection, signature dedup and `chat_id` extraction are correct once detection fires. The one other inline gap-regex (`schedule-runner`) already uses `\s`, which matches NBSP.

## Scope / compatibility

- Only the `typing` vs `idle` boundary for a parked box is affected. `busy` / `error` / `menu` / `unknown` detection use independent regexes and are untouched.
- The ASCII-space parked form keeps working (explicit no-regression test).
- An empty live prompt box (`❯` followed by a space or NBSP and no text) still classifies as `idle`, because the trailing `\S` is required.

## Test plan

- `npm run typecheck` -> clean (exit 0)
- `npx vitest run` -> 89 files, 1352 tests pass (9 new)
- The 9 new tests pin the byte sequence and cover: classification as `typing` not `idle`, ASCII-space no-regression, `mergeTypingAsBusy` -> `busy`, `isReadyForPrompt` false, recovery-chain revival (`stuckInputSignature` non-null), NBSP-stripped text recovery, plus regression locks for the parked `<channel>` block (`chat_id` recovery), terminal-wrapped collapse, and the strict shortcuts footer.
- Verified failing-then-passing: with the old regex 8 of the 9 new tests fail; all 9 pass with the fix.

## Known limitations

None. The fix is the minimal change that closes the NBSP gap; the rest of the parked-input and recovery machinery was already NBSP-correct.
