### PR TITLE
fix(agent-process): raise MCP batch size so channel plugin always reg…

### DIFF
--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -402,9 +402,24 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
       ? `export ${stateEnvVar}="${agentChannelDir}"${auditLogEnv} && `
       : ''
     const channelFlag = hasChannel ? `--channels plugin:${provider.pluginId}` : ''
+    // Channel-plugin MCP-registration guard (2026-06-23): the telegram/slack/etc.
+    // channel plugin registers as a stdio MCP server loaded via --channels. Claude
+    // Code connects stdio MCP servers in batches of MCP_SERVER_CONNECTION_BATCH_SIZE
+    // (default 3); when an agent ALSO runs a slow local .mcp.json stdio server
+    // (e.g. google-workspace/workspace-mcp, which spends seconds on OAuth + Google
+    // API init) plus many claude.ai connectors, the channel plugin gets starved
+    // out of the startup batch / hits MCP_TIMEOUT and never registers -- no /mcp
+    // entry, no bun poller, dead bot (observed: balazsmarveenja with workspace-mcp
+    // had NO telegram; removing workspace-mcp restored it). Raise the stdio batch
+    // size and per-server timeout, and force non-blocking startup, so a slow local
+    // MCP can never crowd the channel plugin out of registration. Only set for
+    // channel-having agents (channel-less agents have no plugin to protect).
+    const mcpEnv = hasChannel
+      ? 'export MCP_SERVER_CONNECTION_BATCH_SIZE=10 && export MCP_CONNECTION_NONBLOCKING=1 && export MCP_TIMEOUT=60000 && '
+      : ''
     // Single-quote `${model}` so values like `claude-opus-4-8[1m]` (1M-context
     // suffix) are not glob-expanded by the shell that tmux spawns the command in.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${channelSetup}${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
     runTmux(null, ['new-session', '-d', '-s', session, cmd], { timeout: 10000 })
 
     logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')


### PR DESCRIPTION
…isters

A channel plugin (telegram/slack/etc.) registers as a stdio MCP server loaded via --channels. Claude Code connects stdio MCP servers in batches of MCP_SERVER_CONNECTION_BATCH_SIZE (default 3). When an agent also runs a slow local .mcp.json stdio server -- e.g. google-workspace/workspace-mcp, which spends seconds on OAuth + Google API init -- plus many claude.ai connectors, the channel plugin gets starved out of the startup batch / hits MCP_TIMEOUT and never registers: no /mcp entry, no bun poller, dead bot.

Observed: balazsmarveenja with workspace-mcp in .mcp.json had NO telegram plugin; removing workspace-mcp restored it. With this fix, both load together.

Export MCP_SERVER_CONNECTION_BATCH_SIZE=10, MCP_CONNECTION_NONBLOCKING=1 and MCP_TIMEOUT=60000 for channel-having agents so a slow local MCP can never crowd the channel plugin out of registration. Channel-less agents are unaffected.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
