### PR TITLE
feat(agents): per-agent + whole-fleet export/import bundle

### DIFF
--- a/docs/agent-fleet.md
+++ b/docs/agent-fleet.md
@@ -174,3 +174,56 @@ Válasz: ágensenként `{ agent, currentModel, suggestedModel, reason, changeAdv
 ### Kanban integráció
 
 Ha `changeAdvised: true` bármely agensnél, és a felhasználó megerősíti, a rendszer automatikusan kanban-kártyát hoz létre az érintett ügynökhöz (`assignee: marveen`, státusz: `planned`).
+
+---
+
+## 📦 Ügynök exportálása / importálása (gépek közötti átvitel)
+
+Egy ügynököt át lehet vinni egyik gépről a másikra egy hordozható `.tar.gz`
+bundle-ben, az egész flotta vagy a globális SQLite adatbázis mozgatása nélkül
+(az utóbbi a `scripts/backup.sh` dolga). A bundle az `agents/<név>/` mappa
+hordozható részhalmaza: identitás + viselkedés, opcionálisan a csatorna-titkokkal.
+
+### Mi kerül a bundle-be
+
+| Tartalom | Mindig | Csak `secrets=1` esetén |
+|----------|:------:|:-----------------------:|
+| `agent-config.json` (modell, displayName, profil, authMode) | ✅ | |
+| `CLAUDE.md`, `SOUL.md` (identitás) | ✅ | |
+| `.mcp.json` (MCP eszközök) | ✅ | |
+| `avatar.*` | ✅ | |
+| `.claude/settings.json`, `.claude/skills/`, `.claude/hooks/` | ✅ | |
+| `memory/` (az ügynök saját memóriája) | ✅ | |
+| `.claude/channels/*/.env` (channel bot token) | | ✅ |
+| `.claude/channels/*/access.json`, `invites.json`, `approved/` (párosítás) | | ✅ |
+
+A gép-specifikus mezők (`remoteHost`, `remoteWorkdir`, `claudeConfigDir`) importkor
+**eltávolításra kerülnek**, így az importált ügynök tiszta, helyi ügynökként indul.
+
+### Dashboard
+
+- **Exportálás**: az ügynök részleteinél az *Exportálás* gomb. Rákérdez, hogy a
+  titkokat (channel token, párosítási állapot) belevegyük-e. Titkok nélkül a
+  bundle biztonságosan megosztható; titkokkal CSAK saját gépek közötti átvitelhez.
+- **Importálás**: a Csapat oldalon az *Ügynök importálása* gomb -> válaszd ki a
+  `.tar.gz` fájlt. Névütközéskor felajánlja a felülírást.
+
+### API
+
+```
+GET  /api/agents/<név>/export            # bundle letöltése (titkok nélkül)
+GET  /api/agents/<név>/export?secrets=1  # bundle letöltése titkokkal
+POST /api/agents/import                  # bundle feltöltése (multipart: file=, name=, overwrite=1)
+```
+
+A fő ügynök (`marveen`) nem exportálható így (a PROJECT_ROOT-ban él, nem az
+`agents/` alatt) -- teljes gép-átálláshoz lásd a `scripts/backup.sh`-t és a
+[MIGRATION.md](MIGRATION.md)-t.
+
+### Biztonság
+
+A titkokat tartalmazó bundle channel bot tokeneket hordoz. Ne töltsd fel
+megosztott/publikus helyre, és ne tartsd cloud-sync mappában. Emlékeztető:
+**egy bot = egy poller** -- ha az importált ügynököt egy második gépen is
+elindítod ugyanazzal a tokennel, a Telegram/Slack 409-cel elhasítja a bejövő
+üzeneteket. Régi gép le, új gép fel -- soha ne fusson a kettő egyszerre.

--- a/docs/agent-fleet.md
+++ b/docs/agent-fleet.md
@@ -202,23 +202,35 @@ A gép-specifikus mezők (`remoteHost`, `remoteWorkdir`, `claudeConfigDir`) impo
 
 ### Dashboard
 
-- **Exportálás**: az ügynök részleteinél az *Exportálás* gomb. Rákérdez, hogy a
-  titkokat (channel token, párosítási állapot) belevegyük-e. Titkok nélkül a
-  bundle biztonságosan megosztható; titkokkal CSAK saját gépek közötti átvitelhez.
+- **Exportálás** (egy ügynök): az ügynök részleteinél az *Exportálás* gomb.
+  Rákérdez, hogy a titkokat (channel token, párosítási állapot) belevegyük-e.
+  Titkok nélkül a bundle biztonságosan megosztható; titkokkal CSAK saját gépek
+  közötti átvitelhez.
+- **Összes exportálása** (egész flotta): a Csapat oldal fejlécében az *Összes
+  exportálása* gomb -> egyetlen `.tar.gz` az összes al-ügynökkel. Ugyanúgy
+  rákérdez a titkokra (ekkor MINDEN ügynöké bekerül).
 - **Importálás**: a Csapat oldalon az *Ügynök importálása* gomb -> válaszd ki a
-  `.tar.gz` fájlt. Névütközéskor felajánlja a felülírást.
+  `.tar.gz` fájlt. Ugyanaz a gomb fogad egy-ügynök ÉS flotta-bundle-t is (a
+  backend a manifestből ismeri fel). Névütközéskor felajánlja a felülírást;
+  flotta-importnál csak az ütköző ügynökök íródnak felül, a többi azonnal bejön.
 
 ### API
 
 ```
-GET  /api/agents/<név>/export            # bundle letöltése (titkok nélkül)
-GET  /api/agents/<név>/export?secrets=1  # bundle letöltése titkokkal
+GET  /api/agents/<név>/export            # egy ügynök bundle-je (titkok nélkül)
+GET  /api/agents/<név>/export?secrets=1  # egy ügynök bundle-je titkokkal
+GET  /api/agents/export-all              # az EGÉSZ flotta egy bundle-ben (titkok nélkül)
+GET  /api/agents/export-all?secrets=1    # az egész flotta titkokkal
 POST /api/agents/import                  # bundle feltöltése (multipart: file=, name=, overwrite=1)
+                                         #   -- egy-ügynök ÉS flotta-bundle-t is fogad
 ```
 
-A fő ügynök (`marveen`) nem exportálható így (a PROJECT_ROOT-ban él, nem az
-`agents/` alatt) -- teljes gép-átálláshoz lásd a `scripts/backup.sh`-t és a
-[MIGRATION.md](MIGRATION.md)-t.
+A fő ügynök (`marveen`) egyik módban sem exportálható (a PROJECT_ROOT-ban él,
+nem az `agents/` alatt) -- teljes gép-átálláshoz lásd a `scripts/backup.sh`-t és
+a [MIGRATION.md](MIGRATION.md)-t.
+
+A flotta-bundle elrendezése `manifest.json` (`kind: "fleet"`) + `agents/<név>/`
+ügynökönként; az egy-ügynök bundle `manifest.json` + `agent/`.
 
 ### Biztonság
 

--- a/src/__tests__/agent-bundle.test.ts
+++ b/src/__tests__/agent-bundle.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  stageAgentDirForExport,
+  importAgentBundle,
+  readBundleManifest,
+  sanitizeImportedConfig,
+  bundleFilename,
+  BUNDLE_SCHEMA_VERSION,
+  type BundleManifest,
+} from '../web/agent-bundle.js'
+
+// Hermetic: every test builds its own agent source tree and install target in a
+// temp dir, so nothing touches the real AGENTS_BASE_DIR. The full round-trip
+// tars the staged dir the same way exportAgentBundle does (manifest.json +
+// agent/), then imports via importAgentBundle with an injected resolveDest.
+
+function makeAgent(root: string, files: Record<string, string>): void {
+  for (const [rel, content] of Object.entries(files)) {
+    const p = join(root, rel)
+    mkdirSync(join(p, '..'), { recursive: true })
+    writeFileSync(p, content)
+  }
+}
+
+function packBundle(stageRoot: string, agentName: string, includesSecrets: boolean): Buffer {
+  const manifest: BundleManifest = {
+    schemaVersion: BUNDLE_SCHEMA_VERSION,
+    agentName,
+    includesSecrets,
+  }
+  writeFileSync(join(stageRoot, 'manifest.json'), JSON.stringify(manifest, null, 2))
+  const out = join(stageRoot, '..', 'bundle.tar.gz')
+  execFileSync('tar', ['-czf', out, '-C', stageRoot, 'manifest.json', 'agent'])
+  return readFileSync(out)
+}
+
+describe('agent bundle export/import', () => {
+  let tmp: string
+
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'agent-bundle-test-')) })
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }) })
+
+  it('stages the portable subset and excludes channel secrets by default', () => {
+    const src = join(tmp, 'src')
+    makeAgent(src, {
+      'agent-config.json': '{"model":"claude-sonnet-4-6"}',
+      'CLAUDE.md': '# Agent',
+      'SOUL.md': 'soul',
+      '.mcp.json': '{"mcpServers":{}}',
+      '.claude/settings.json': '{}',
+      '.claude/skills/foo/SKILL.md': 'skill',
+      'memory/MEMORY.md': 'mem',
+      '.claude/channels/telegram/.env': 'TELEGRAM_BOT_TOKEN=secret',
+      '.claude/channels/telegram/access.json': '{"allowed":[]}',
+    })
+    const stage = join(tmp, 'stage')
+    const staged = stageAgentDirForExport(src, stage, false)
+
+    expect(existsSync(join(stage, 'CLAUDE.md'))).toBe(true)
+    expect(existsSync(join(stage, '.claude/skills/foo/SKILL.md'))).toBe(true)
+    expect(existsSync(join(stage, 'memory/MEMORY.md'))).toBe(true)
+    // Secrets excluded.
+    expect(existsSync(join(stage, '.claude/channels/telegram/.env'))).toBe(false)
+    expect(staged).toContain('agent-config.json')
+    expect(staged).not.toContain(join('.claude', 'channels', 'telegram', '.env'))
+  })
+
+  it('includes channel secrets when asked', () => {
+    const src = join(tmp, 'src')
+    makeAgent(src, {
+      'CLAUDE.md': '# Agent',
+      '.claude/channels/slack/.env': 'SLACK_BOT_TOKEN=xoxb',
+    })
+    const stage = join(tmp, 'stage')
+    stageAgentDirForExport(src, stage, true)
+    expect(existsSync(join(stage, '.claude/channels/slack/.env'))).toBe(true)
+    expect(readFileSync(join(stage, '.claude/channels/slack/.env'), 'utf-8')).toContain('xoxb')
+  })
+
+  it('round-trips through tar and installs under a destination base', () => {
+    const src = join(tmp, 'src')
+    makeAgent(src, {
+      'agent-config.json': '{"model":"claude-opus-4-8[1m]","displayName":"Tester"}',
+      'CLAUDE.md': '# Tester agent',
+      'memory/MEMORY.md': 'remembered',
+    })
+    const stageRoot = join(tmp, 'pack')
+    mkdirSync(stageRoot, { recursive: true })
+    stageAgentDirForExport(src, join(stageRoot, 'agent'), false)
+    const bundle = packBundle(stageRoot, 'tester', false)
+
+    const destBase = join(tmp, 'agents')
+    const result = importAgentBundle(bundle, { resolveDest: (n) => join(destBase, n) })
+
+    expect(result.name).toBe('tester')
+    expect(result.overwritten).toBe(false)
+    expect(readFileSync(join(destBase, 'tester', 'CLAUDE.md'), 'utf-8')).toContain('Tester agent')
+    expect(readFileSync(join(destBase, 'tester', 'memory', 'MEMORY.md'), 'utf-8')).toBe('remembered')
+  })
+
+  it('rejects a name collision unless overwrite is set', () => {
+    const src = join(tmp, 'src')
+    makeAgent(src, { 'CLAUDE.md': 'v1' })
+    const stageRoot = join(tmp, 'pack')
+    mkdirSync(stageRoot, { recursive: true })
+    stageAgentDirForExport(src, join(stageRoot, 'agent'), false)
+    const bundle = packBundle(stageRoot, 'dupe', false)
+
+    const destBase = join(tmp, 'agents')
+    const resolveDest = (n: string) => join(destBase, n)
+
+    importAgentBundle(bundle, { resolveDest })
+    expect(() => importAgentBundle(bundle, { resolveDest })).toThrow(/already exists/)
+
+    // overwrite replaces it
+    const r = importAgentBundle(bundle, { resolveDest, overwrite: true })
+    expect(r.overwritten).toBe(true)
+  })
+
+  it('honors overrideName and re-sanitizes it', () => {
+    const src = join(tmp, 'src')
+    makeAgent(src, { 'CLAUDE.md': 'x' })
+    const stageRoot = join(tmp, 'pack')
+    mkdirSync(stageRoot, { recursive: true })
+    stageAgentDirForExport(src, join(stageRoot, 'agent'), false)
+    const bundle = packBundle(stageRoot, 'original', false)
+
+    const destBase = join(tmp, 'agents')
+    // sanitizeAgentName strips accents and any char outside [a-z0-9-]; a space
+    // is removed (not hyphenated), so "Új Név!" decays to "ujnev".
+    const r = importAgentBundle(bundle, {
+      resolveDest: (n) => join(destBase, n),
+      overrideName: 'Új Név!',
+    })
+    expect(r.name).toBe('ujnev')
+    expect(existsSync(join(destBase, 'ujnev', 'CLAUDE.md'))).toBe(true)
+  })
+
+  it('strips machine-specific config fields on import', () => {
+    const stagedAgent = join(tmp, 'agent')
+    mkdirSync(stagedAgent, { recursive: true })
+    writeFileSync(join(stagedAgent, 'agent-config.json'), JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      remoteHost: 'devbox',
+      remoteWorkdir: '/home/user/proj',
+      claudeConfigDir: '/home/user/.claude-alt',
+      displayName: 'Keep me',
+    }))
+    sanitizeImportedConfig(stagedAgent)
+    const cfg = JSON.parse(readFileSync(join(stagedAgent, 'agent-config.json'), 'utf-8'))
+    expect(cfg.remoteHost).toBeUndefined()
+    expect(cfg.remoteWorkdir).toBeUndefined()
+    expect(cfg.claudeConfigDir).toBeUndefined()
+    expect(cfg.model).toBe('claude-sonnet-4-6')
+    expect(cfg.displayName).toBe('Keep me')
+  })
+
+  it('rejects a bundle whose schema is newer than supported', () => {
+    const extractRoot = join(tmp, 'extracted')
+    mkdirSync(extractRoot, { recursive: true })
+    writeFileSync(join(extractRoot, 'manifest.json'), JSON.stringify({
+      schemaVersion: BUNDLE_SCHEMA_VERSION + 1,
+      agentName: 'future',
+    }))
+    expect(() => readBundleManifest(extractRoot)).toThrow(/newer than this install/)
+  })
+
+  it('rejects a bundle with no manifest', () => {
+    const extractRoot = join(tmp, 'extracted')
+    mkdirSync(extractRoot, { recursive: true })
+    expect(() => readBundleManifest(extractRoot)).toThrow(/manifest.json missing/)
+  })
+
+  it('rejects a non-tar buffer with a friendly message', () => {
+    expect(() => importAgentBundle(Buffer.from('not a tar archive'), {
+      resolveDest: (n) => join(tmp, 'agents', n),
+    })).toThrow(/could not extract/)
+  })
+
+  it('builds a safe download filename', () => {
+    expect(bundleFilename('tester')).toBe('marveen-agent-tester.tar.gz')
+    expect(bundleFilename('../../etc/passwd')).toBe('marveen-agent-passwd.tar.gz')
+  })
+})

--- a/src/__tests__/agent-bundle.test.ts
+++ b/src/__tests__/agent-bundle.test.ts
@@ -9,8 +9,13 @@ import {
   readBundleManifest,
   sanitizeImportedConfig,
   bundleFilename,
+  importAllAgentsBundle,
+  peekBundleKind,
+  readFleetManifest,
+  fleetBundleFilename,
   BUNDLE_SCHEMA_VERSION,
   type BundleManifest,
+  type FleetBundleManifest,
 } from '../web/agent-bundle.js'
 
 // Hermetic: every test builds its own agent source tree and install target in a
@@ -184,5 +189,115 @@ describe('agent bundle export/import', () => {
   it('builds a safe download filename', () => {
     expect(bundleFilename('tester')).toBe('marveen-agent-tester.tar.gz')
     expect(bundleFilename('../../etc/passwd')).toBe('marveen-agent-passwd.tar.gz')
+  })
+})
+
+// Pack a fleet bundle (manifest.json kind:'fleet' + agents/<name>/...) the same
+// way exportAllAgentsBundle would, but from arbitrary staged source trees so the
+// importer can be tested off the real AGENTS_BASE_DIR.
+function packFleetBundle(
+  stageRoot: string,
+  agents: Record<string, Record<string, string>>,
+  includesSecrets = false,
+): Buffer {
+  const agentsRoot = join(stageRoot, 'agents')
+  mkdirSync(agentsRoot, { recursive: true })
+  const names: string[] = []
+  for (const [name, files] of Object.entries(agents)) {
+    const src = join(stageRoot, 'src', name)
+    makeAgent(src, files)
+    stageAgentDirForExport(src, join(agentsRoot, name), includesSecrets)
+    names.push(name)
+  }
+  const manifest: FleetBundleManifest = {
+    schemaVersion: BUNDLE_SCHEMA_VERSION,
+    kind: 'fleet',
+    agents: names,
+    includesSecrets,
+  }
+  writeFileSync(join(stageRoot, 'manifest.json'), JSON.stringify(manifest, null, 2))
+  const out = join(stageRoot, 'fleet.tar.gz')
+  execFileSync('tar', ['-czf', out, '-C', stageRoot, 'manifest.json', 'agents'])
+  return readFileSync(out)
+}
+
+describe('fleet bundle export/import', () => {
+  let tmp: string
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'fleet-bundle-test-')) })
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }) })
+
+  it('peekBundleKind tells a fleet bundle from a single-agent bundle', () => {
+    const fleet = packFleetBundle(join(tmp, 'f'), { alpha: { 'CLAUDE.md': 'a' } })
+    expect(peekBundleKind(fleet)).toBe('fleet')
+
+    // Single-agent bundle (manifest.json + agent/).
+    const single = join(tmp, 's')
+    makeAgent(join(single, 'agent'), { 'CLAUDE.md': 'x' })
+    writeFileSync(join(single, 'manifest.json'), JSON.stringify({
+      schemaVersion: BUNDLE_SCHEMA_VERSION, agentName: 'solo', includesSecrets: false,
+    }))
+    const singleOut = join(single, 'b.tar.gz')
+    execFileSync('tar', ['-czf', singleOut, '-C', single, 'manifest.json', 'agent'])
+    expect(peekBundleKind(readFileSync(singleOut))).toBe('agent')
+  })
+
+  it('imports every agent from a fleet bundle', () => {
+    const bundle = packFleetBundle(join(tmp, 'f'), {
+      alpha: { 'CLAUDE.md': '# Alpha', 'memory/MEMORY.md': 'mem-a' },
+      beta: { 'CLAUDE.md': '# Beta', 'agent-config.json': '{"model":"claude-sonnet-4-6"}' },
+    })
+    const destBase = join(tmp, 'agents')
+    const result = importAllAgentsBundle(bundle, { resolveDest: (n) => join(destBase, n) })
+
+    expect(result.imported.map((a) => a.name).sort()).toEqual(['alpha', 'beta'])
+    expect(result.skipped).toHaveLength(0)
+    expect(readFileSync(join(destBase, 'alpha', 'CLAUDE.md'), 'utf-8')).toContain('Alpha')
+    expect(readFileSync(join(destBase, 'beta', 'CLAUDE.md'), 'utf-8')).toContain('Beta')
+  })
+
+  it('skips colliding agents without overwrite, replaces them with it', () => {
+    const bundle = packFleetBundle(join(tmp, 'f'), {
+      alpha: { 'CLAUDE.md': 'v2' },
+      beta: { 'CLAUDE.md': 'fresh' },
+    })
+    const destBase = join(tmp, 'agents')
+    const resolveDest = (n: string) => join(destBase, n)
+    // Pre-existing alpha.
+    makeAgent(join(destBase, 'alpha'), { 'CLAUDE.md': 'v1' })
+
+    const first = importAllAgentsBundle(bundle, { resolveDest })
+    expect(first.imported.map((a) => a.name)).toEqual(['beta'])
+    expect(first.skipped).toEqual([{ name: 'alpha', reason: 'already exists' }])
+    expect(readFileSync(join(destBase, 'alpha', 'CLAUDE.md'), 'utf-8')).toBe('v1')
+
+    const second = importAllAgentsBundle(bundle, { resolveDest, overwrite: true })
+    expect(second.imported.find((a) => a.name === 'alpha')?.overwritten).toBe(true)
+    expect(readFileSync(join(destBase, 'alpha', 'CLAUDE.md'), 'utf-8')).toBe('v2')
+  })
+
+  it('rejects a single-agent bundle fed to the fleet importer', () => {
+    const single = join(tmp, 's')
+    makeAgent(join(single, 'agent'), { 'CLAUDE.md': 'x' })
+    writeFileSync(join(single, 'manifest.json'), JSON.stringify({
+      schemaVersion: BUNDLE_SCHEMA_VERSION, agentName: 'solo',
+    }))
+    const out = join(single, 'b.tar.gz')
+    execFileSync('tar', ['-czf', out, '-C', single, 'manifest.json', 'agent'])
+    expect(() => importAllAgentsBundle(readFileSync(out), {
+      resolveDest: (n) => join(tmp, 'agents', n),
+    })).toThrow(/not a fleet bundle/)
+  })
+
+  it('readFleetManifest rejects a newer schema', () => {
+    const extractRoot = join(tmp, 'extracted')
+    mkdirSync(extractRoot, { recursive: true })
+    writeFileSync(join(extractRoot, 'manifest.json'), JSON.stringify({
+      schemaVersion: BUNDLE_SCHEMA_VERSION + 1, kind: 'fleet', agents: [],
+    }))
+    expect(() => readFleetManifest(extractRoot)).toThrow(/newer than this install/)
+  })
+
+  it('builds a stable fleet download filename', () => {
+    expect(fleetBundleFilename()).toBe('marveen-fleet.tar.gz')
   })
 })

--- a/src/web/agent-bundle.ts
+++ b/src/web/agent-bundle.ts
@@ -1,0 +1,297 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+  cpSync,
+  readdirSync,
+  statSync,
+} from 'node:fs'
+import { join, basename } from 'node:path'
+import { tmpdir } from 'node:os'
+import { execFileSync } from 'node:child_process'
+import { agentDir } from './agent-config.js'
+import { sanitizeAgentName } from './sanitize.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+
+// Portable per-agent export/import bundle.
+//
+// An "agent" on disk is the directory `agents/<name>/`. This module packs that
+// directory into a single self-describing `.tar.gz` so one (or a few) chosen
+// agents can be moved to another machine WITHOUT dragging the whole fleet or
+// the global SQLite DB (that is what scripts/backup.sh is for). The bundle is
+// the unit a user downloads from the dashboard on machine A and uploads on
+// machine B.
+//
+// Two trust levels, selected at export time:
+//   - secrets EXCLUDED (default): identity + behaviour only, safe to share.
+//   - secrets INCLUDED: also the channel bot tokens (.env) + pairing state, for
+//     a confidential move between the operator's own machines.
+//
+// We shell out to the system `tar` (same choice as scripts/backup.sh) rather
+// than add a tar dependency: it is present on every macOS/Linux host the fleet
+// runs on, and a staging dir keeps the archive layout identical across bsdtar
+// and GNU tar (see the staging note in backup.sh).
+
+export const BUNDLE_SCHEMA_VERSION = 1
+
+export interface BundleManifest {
+  schemaVersion: number
+  // The sanitized agent name the bundle was exported as. Import re-sanitizes
+  // and may override this (rename-on-import), but the original is recorded so
+  // the operator can see where it came from.
+  agentName: string
+  // Whether channel tokens / pairing state were included.
+  includesSecrets: boolean
+  // Free-form provenance, never trusted for any logic.
+  exportedBy?: string
+  exportedAt?: string
+}
+
+// Files/dirs that make up a portable agent, RELATIVE to agents/<name>/.
+// Identity + behaviour, no machine-specific runtime state. These are copied
+// regardless of the secrets flag.
+const PORTABLE_ENTRIES = [
+  'agent-config.json',
+  'CLAUDE.md',
+  'SOUL.md',
+  '.mcp.json',
+  'avatar.png',
+  'avatar.jpg',
+  'avatar.jpeg',
+  'avatar.webp',
+  '.claude/settings.json',
+  '.claude/skills',
+  '.claude/hooks',
+  'memory',
+] as const
+
+// Channel secret files, relative to agents/<name>/. Only copied when the
+// operator explicitly opts into a secrets-bearing export. The provider subdir
+// (telegram/slack/discord) is discovered at pack time.
+const CHANNEL_STATE_ROOT = join('.claude', 'channels')
+const CHANNEL_SECRET_FILES = ['.env', 'access.json', 'invites.json'] as const
+const CHANNEL_SECRET_DIRS = ['approved'] as const
+
+// agent-config.json keys that are machine-specific and must NOT survive a move
+// to another host: a remote agent's ssh host/workdir and a per-agent
+// CLAUDE_CONFIG_DIR point at paths/credentials that only exist on the source
+// machine. Stripped on import so an imported agent starts as a clean local
+// agent the operator can re-point if needed.
+const MACHINE_SPECIFIC_CONFIG_KEYS = ['remoteHost', 'remoteWorkdir', 'claudeConfigDir'] as const
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+// Recursively copy a relative entry from <srcRoot> into <dstRoot>, preserving
+// its relative path. No-op when the source does not exist (a fresh agent may
+// lack SOUL.md, an avatar, skills, etc. -- absence is normal, not an error).
+function copyEntryInto(srcRoot: string, dstRoot: string, rel: string): void {
+  const src = join(srcRoot, rel)
+  if (!existsSync(src)) return
+  const dst = join(dstRoot, rel)
+  mkdirSync(join(dst, '..'), { recursive: true })
+  cpSync(src, dst, { recursive: true })
+}
+
+// Stage the portable subset of an agent's source dir into <stageAgentDir>,
+// optionally including channel secrets. Returns the list of relative entries
+// actually staged. Pure-ish: reads <srcRoot>, writes only the staging dir, and
+// never touches AGENTS_BASE_DIR -- so it is hermetically testable against an
+// arbitrary source tree. The agentDir() resolution lives in the thin wrappers.
+export function stageAgentDirForExport(
+  srcRoot: string,
+  stageAgentDir: string,
+  includeSecrets: boolean,
+): string[] {
+  if (!existsSync(srcRoot)) throw new Error(`Agent source not found: ${srcRoot}`)
+  mkdirSync(stageAgentDir, { recursive: true })
+
+  const staged: string[] = []
+  for (const rel of PORTABLE_ENTRIES) {
+    if (existsSync(join(srcRoot, rel))) {
+      copyEntryInto(srcRoot, stageAgentDir, rel)
+      staged.push(rel)
+    }
+  }
+
+  if (includeSecrets) {
+    const channelsRoot = join(srcRoot, CHANNEL_STATE_ROOT)
+    if (existsSync(channelsRoot)) {
+      for (const provider of readdirSync(channelsRoot)) {
+        const providerDir = join(channelsRoot, provider)
+        try { if (!statSync(providerDir).isDirectory()) continue } catch { continue }
+        for (const f of CHANNEL_SECRET_FILES) {
+          const rel = join(CHANNEL_STATE_ROOT, provider, f)
+          if (existsSync(join(srcRoot, rel))) { copyEntryInto(srcRoot, stageAgentDir, rel); staged.push(rel) }
+        }
+        for (const d of CHANNEL_SECRET_DIRS) {
+          const rel = join(CHANNEL_STATE_ROOT, provider, d)
+          if (existsSync(join(srcRoot, rel))) { copyEntryInto(srcRoot, stageAgentDir, rel); staged.push(rel) }
+        }
+      }
+    }
+  }
+
+  return staged
+}
+
+// Thin wrapper: resolve the named agent's dir under AGENTS_BASE_DIR, then stage.
+export function stageAgentForExport(
+  name: string,
+  stageAgentDir: string,
+  includeSecrets: boolean,
+): string[] {
+  return stageAgentDirForExport(agentDir(name), stageAgentDir, includeSecrets)
+}
+
+// Build a .tar.gz bundle of agent <name> at <outPath>. Returns the manifest
+// that was embedded. The archive layout is:
+//   manifest.json
+//   agent/<portable files...>
+export function exportAgentBundle(
+  name: string,
+  outPath: string,
+  opts: { includeSecrets?: boolean; exportedBy?: string; exportedAt?: string } = {},
+): BundleManifest {
+  const includeSecrets = opts.includeSecrets === true
+  const stage = makeTempDir('marveen-agent-export-')
+  try {
+    const stageAgentDir = join(stage, 'agent')
+    stageAgentForExport(name, stageAgentDir, includeSecrets)
+
+    const manifest: BundleManifest = {
+      schemaVersion: BUNDLE_SCHEMA_VERSION,
+      agentName: name,
+      includesSecrets: includeSecrets,
+      ...(opts.exportedBy ? { exportedBy: opts.exportedBy } : {}),
+      ...(opts.exportedAt ? { exportedAt: opts.exportedAt } : {}),
+    }
+    writeFileSync(join(stage, 'manifest.json'), JSON.stringify(manifest, null, 2))
+
+    // Single plain tar over the staging dir -- identical output on bsdtar and
+    // GNU tar (see backup.sh). `-C stage .` keeps names clean (no temp prefix).
+    mkdirSync(join(outPath, '..'), { recursive: true })
+    execFileSync('tar', ['-czf', outPath, '-C', stage, 'manifest.json', 'agent'])
+    return manifest
+  } finally {
+    rmSync(stage, { recursive: true, force: true })
+  }
+}
+
+// Parse + validate a bundle's manifest without unpacking the whole thing.
+// Throws with an operator-facing message on anything malformed.
+export function readBundleManifest(extractedRoot: string): BundleManifest {
+  const manifestPath = join(extractedRoot, 'manifest.json')
+  if (!existsSync(manifestPath)) {
+    throw new Error('Invalid bundle: manifest.json missing (not a Marveen agent bundle?)')
+  }
+  let parsed: unknown
+  try { parsed = JSON.parse(readFileSync(manifestPath, 'utf-8')) } catch {
+    throw new Error('Invalid bundle: manifest.json is not valid JSON')
+  }
+  if (!parsed || typeof parsed !== 'object') throw new Error('Invalid bundle: manifest.json malformed')
+  const m = parsed as Record<string, unknown>
+  const schemaVersion = typeof m.schemaVersion === 'number' ? m.schemaVersion : 0
+  if (schemaVersion > BUNDLE_SCHEMA_VERSION) {
+    throw new Error(
+      `Bundle schema version ${schemaVersion} is newer than this install supports ` +
+      `(max ${BUNDLE_SCHEMA_VERSION}). Update Marveen on this machine first.`,
+    )
+  }
+  const agentName = typeof m.agentName === 'string' ? m.agentName : ''
+  if (!agentName) throw new Error('Invalid bundle: manifest.json has no agentName')
+  return {
+    schemaVersion,
+    agentName,
+    includesSecrets: m.includesSecrets === true,
+    ...(typeof m.exportedBy === 'string' ? { exportedBy: m.exportedBy } : {}),
+    ...(typeof m.exportedAt === 'string' ? { exportedAt: m.exportedAt } : {}),
+  }
+}
+
+// Strip machine-specific fields from a staged agent-config.json in place, so an
+// imported agent never inherits the source host's ssh/remote/config-dir paths.
+export function sanitizeImportedConfig(stagedAgentDir: string): void {
+  const cfgPath = join(stagedAgentDir, 'agent-config.json')
+  if (!existsSync(cfgPath)) return
+  let cfg: Record<string, unknown>
+  try { cfg = JSON.parse(readFileSync(cfgPath, 'utf-8')) } catch { return }
+  let changed = false
+  for (const key of MACHINE_SPECIFIC_CONFIG_KEYS) {
+    if (key in cfg) { delete cfg[key]; changed = true }
+  }
+  if (changed) atomicWriteFileSync(cfgPath, JSON.stringify(cfg, null, 2))
+}
+
+export interface ImportResult {
+  name: string
+  manifest: BundleManifest
+  overwritten: boolean
+}
+
+// Import an agent bundle (a .tar.gz buffer or file) into agents/<name>/.
+//   - overrideName: install under this name instead of the manifest's
+//     (rename-on-import / collision resolution). Re-sanitized.
+//   - overwrite: replace an existing agent dir of the same name; without it a
+//     name collision throws so the caller can surface a 409.
+//   - resolveDest: maps a sanitized name to its install path. Defaults to
+//     agentDir() (the real AGENTS_BASE_DIR); overridden in tests to install
+//     into a temp tree. safeJoin in agentDir() rejects traversal.
+// Returns the final installed name + the bundle manifest.
+export function importAgentBundle(
+  bundle: Buffer,
+  opts: { overrideName?: string; overwrite?: boolean; resolveDest?: (name: string) => string } = {},
+): ImportResult {
+  const resolveDest = opts.resolveDest ?? agentDir
+  const work = makeTempDir('marveen-agent-import-')
+  try {
+    const bundlePath = join(work, 'bundle.tar.gz')
+    writeFileSync(bundlePath, bundle)
+    const extractRoot = join(work, 'extracted')
+    mkdirSync(extractRoot, { recursive: true })
+    // Extract into an isolated dir. tar's own path-traversal guard plus our
+    // staged layout (manifest.json + agent/) mean nothing escapes extractRoot.
+    try {
+      execFileSync('tar', ['-xzf', bundlePath, '-C', extractRoot])
+    } catch {
+      throw new Error('Invalid bundle: could not extract (not a gzip tar archive?)')
+    }
+
+    const manifest = readBundleManifest(extractRoot)
+    const stagedAgentDir = join(extractRoot, 'agent')
+    if (!existsSync(stagedAgentDir) || !statSync(stagedAgentDir).isDirectory()) {
+      throw new Error('Invalid bundle: agent/ directory missing')
+    }
+
+    const rawName = (opts.overrideName ?? manifest.agentName).trim()
+    const name = sanitizeAgentName(rawName)
+    if (!name) throw new Error('Invalid agent name (empty after sanitization)')
+
+    sanitizeImportedConfig(stagedAgentDir)
+
+    const dest = resolveDest(name) // agentDir: safeJoin rejects traversal
+    const exists = existsSync(dest)
+    if (exists && !opts.overwrite) {
+      throw new Error(`Agent "${name}" already exists on this machine`)
+    }
+    if (exists) rmSync(dest, { recursive: true, force: true })
+    mkdirSync(join(dest, '..'), { recursive: true })
+    cpSync(stagedAgentDir, dest, { recursive: true })
+
+    return { name, manifest, overwritten: exists }
+  } finally {
+    rmSync(work, { recursive: true, force: true })
+  }
+}
+
+// Suggested download filename for a bundle. basename() defends against any odd
+// characters in the name (it is already sanitized upstream, but the filename
+// goes into a Content-Disposition header).
+export function bundleFilename(name: string): string {
+  const safe = basename(name).replace(/[^A-Za-z0-9_-]/g, '') || 'agent'
+  return `marveen-agent-${safe}.tar.gz`
+}

--- a/src/web/agent-bundle.ts
+++ b/src/web/agent-bundle.ts
@@ -295,3 +295,189 @@ export function bundleFilename(name: string): string {
   const safe = basename(name).replace(/[^A-Za-z0-9_-]/g, '') || 'agent'
   return `marveen-agent-${safe}.tar.gz`
 }
+
+// ===========================================================================
+// Fleet bundle: ALL sub-agents in one archive.
+//
+// The same portability rules as a single-agent bundle, but for every agent
+// under AGENTS_BASE_DIR at once (the main agent lives at PROJECT_ROOT and is
+// NOT part of this -- use scripts/backup.sh for a whole-host move). Layout:
+//   manifest.json        (kind: 'fleet', agents: [names...])
+//   agents/<name>/<portable files...>
+// The `kind: 'fleet'` discriminator + the plural `agents/` dir distinguish a
+// fleet bundle from a single-agent one (manifest.json + agent/).
+// ===========================================================================
+
+export interface FleetBundleManifest {
+  schemaVersion: number
+  kind: 'fleet'
+  // The sanitized agent names actually staged into the bundle.
+  agents: string[]
+  includesSecrets: boolean
+  exportedBy?: string
+  exportedAt?: string
+}
+
+// Build a .tar.gz bundle of every named agent at <outPath>. Names that resolve
+// to no source dir are silently skipped (a stale registry entry should not fail
+// the whole export). Returns the embedded manifest.
+export function exportAllAgentsBundle(
+  outPath: string,
+  names: string[],
+  opts: { includeSecrets?: boolean; exportedBy?: string; exportedAt?: string } = {},
+): FleetBundleManifest {
+  const includeSecrets = opts.includeSecrets === true
+  const stage = makeTempDir('marveen-fleet-export-')
+  try {
+    const agentsRoot = join(stage, 'agents')
+    mkdirSync(agentsRoot, { recursive: true })
+
+    const staged: string[] = []
+    for (const name of names) {
+      const safe = sanitizeAgentName(name)
+      if (!safe || !existsSync(agentDir(name))) continue
+      stageAgentForExport(name, join(agentsRoot, safe), includeSecrets)
+      staged.push(safe)
+    }
+    if (staged.length === 0) throw new Error('No exportable agents found')
+
+    const manifest: FleetBundleManifest = {
+      schemaVersion: BUNDLE_SCHEMA_VERSION,
+      kind: 'fleet',
+      agents: staged,
+      includesSecrets: includeSecrets,
+      ...(opts.exportedBy ? { exportedBy: opts.exportedBy } : {}),
+      ...(opts.exportedAt ? { exportedAt: opts.exportedAt } : {}),
+    }
+    writeFileSync(join(stage, 'manifest.json'), JSON.stringify(manifest, null, 2))
+
+    mkdirSync(join(outPath, '..'), { recursive: true })
+    execFileSync('tar', ['-czf', outPath, '-C', stage, 'manifest.json', 'agents'])
+    return manifest
+  } finally {
+    rmSync(stage, { recursive: true, force: true })
+  }
+}
+
+// Validate + parse a fleet manifest. Throws with an operator-facing message.
+export function readFleetManifest(extractedRoot: string): FleetBundleManifest {
+  const manifestPath = join(extractedRoot, 'manifest.json')
+  if (!existsSync(manifestPath)) {
+    throw new Error('Invalid bundle: manifest.json missing (not a Marveen bundle?)')
+  }
+  let parsed: unknown
+  try { parsed = JSON.parse(readFileSync(manifestPath, 'utf-8')) } catch {
+    throw new Error('Invalid bundle: manifest.json is not valid JSON')
+  }
+  if (!parsed || typeof parsed !== 'object') throw new Error('Invalid bundle: manifest.json malformed')
+  const m = parsed as Record<string, unknown>
+  const schemaVersion = typeof m.schemaVersion === 'number' ? m.schemaVersion : 0
+  if (schemaVersion > BUNDLE_SCHEMA_VERSION) {
+    throw new Error(
+      `Bundle schema version ${schemaVersion} is newer than this install supports ` +
+      `(max ${BUNDLE_SCHEMA_VERSION}). Update Marveen on this machine first.`,
+    )
+  }
+  if (m.kind !== 'fleet') throw new Error('Invalid bundle: not a fleet bundle')
+  const agents = Array.isArray(m.agents) ? m.agents.filter((a): a is string => typeof a === 'string') : []
+  return {
+    schemaVersion,
+    kind: 'fleet',
+    agents,
+    includesSecrets: m.includesSecrets === true,
+    ...(typeof m.exportedBy === 'string' ? { exportedBy: m.exportedBy } : {}),
+    ...(typeof m.exportedAt === 'string' ? { exportedAt: m.exportedAt } : {}),
+  }
+}
+
+// Cheaply read just manifest.json out of a bundle to tell a single-agent bundle
+// (kind absent/'agent') from a fleet bundle (kind 'fleet'). Lets one import
+// endpoint accept either format. Throws on a non-extractable / manifest-less
+// archive (same operator-facing wording as the full importers).
+export function peekBundleKind(bundle: Buffer): 'agent' | 'fleet' {
+  const work = makeTempDir('marveen-bundle-peek-')
+  try {
+    const bundlePath = join(work, 'bundle.tar.gz')
+    writeFileSync(bundlePath, bundle)
+    try {
+      execFileSync('tar', ['-xzf', bundlePath, '-C', work, 'manifest.json'])
+    } catch {
+      throw new Error('Invalid bundle: could not extract (not a gzip tar archive?)')
+    }
+    const manifestPath = join(work, 'manifest.json')
+    if (!existsSync(manifestPath)) {
+      throw new Error('Invalid bundle: manifest.json missing (not a Marveen bundle?)')
+    }
+    let parsed: unknown
+    try { parsed = JSON.parse(readFileSync(manifestPath, 'utf-8')) } catch {
+      throw new Error('Invalid bundle: manifest.json is not valid JSON')
+    }
+    return parsed && typeof parsed === 'object' && (parsed as Record<string, unknown>).kind === 'fleet'
+      ? 'fleet'
+      : 'agent'
+  } finally {
+    rmSync(work, { recursive: true, force: true })
+  }
+}
+
+export interface FleetImportResult {
+  imported: { name: string; overwritten: boolean }[]
+  skipped: { name: string; reason: string }[]
+  includesSecrets: boolean
+}
+
+// Import every agent from a fleet bundle. Per-agent collisions are NOT fatal:
+//   - overwrite=false -> existing agents are skipped (reason 'already exists'),
+//     fresh ones imported. The caller can re-POST with overwrite=1.
+//   - overwrite=true  -> existing agents are replaced.
+// A malformed bundle (bad archive / wrong kind) throws as a whole.
+export function importAllAgentsBundle(
+  bundle: Buffer,
+  opts: { overwrite?: boolean; resolveDest?: (name: string) => string } = {},
+): FleetImportResult {
+  const resolveDest = opts.resolveDest ?? agentDir
+  const work = makeTempDir('marveen-fleet-import-')
+  try {
+    const bundlePath = join(work, 'bundle.tar.gz')
+    writeFileSync(bundlePath, bundle)
+    const extractRoot = join(work, 'extracted')
+    mkdirSync(extractRoot, { recursive: true })
+    try {
+      execFileSync('tar', ['-xzf', bundlePath, '-C', extractRoot])
+    } catch {
+      throw new Error('Invalid bundle: could not extract (not a gzip tar archive?)')
+    }
+
+    const manifest = readFleetManifest(extractRoot)
+    const agentsRoot = join(extractRoot, 'agents')
+    if (!existsSync(agentsRoot) || !statSync(agentsRoot).isDirectory()) {
+      throw new Error('Invalid bundle: agents/ directory missing')
+    }
+
+    const imported: { name: string; overwritten: boolean }[] = []
+    const skipped: { name: string; reason: string }[] = []
+    for (const entry of readdirSync(agentsRoot)) {
+      const stagedAgentDir = join(agentsRoot, entry)
+      try { if (!statSync(stagedAgentDir).isDirectory()) continue } catch { continue }
+      const name = sanitizeAgentName(entry)
+      if (!name) { skipped.push({ name: entry, reason: 'invalid name' }); continue }
+
+      sanitizeImportedConfig(stagedAgentDir)
+      const dest = resolveDest(name) // agentDir: safeJoin rejects traversal
+      const exists = existsSync(dest)
+      if (exists && !opts.overwrite) { skipped.push({ name, reason: 'already exists' }); continue }
+      if (exists) rmSync(dest, { recursive: true, force: true })
+      mkdirSync(join(dest, '..'), { recursive: true })
+      cpSync(stagedAgentDir, dest, { recursive: true })
+      imported.push({ name, overwritten: exists })
+    }
+
+    return { imported, skipped, includesSecrets: manifest.includesSecrets }
+  } finally {
+    rmSync(work, { recursive: true, force: true })
+  }
+}
+
+export function fleetBundleFilename(): string {
+  return 'marveen-fleet.tar.gz'
+}

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1,6 +1,6 @@
-import { existsSync, readFileSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync, renameSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync, copyFileSync, renameSync } from 'node:fs'
 import { join, extname, dirname } from 'node:path'
-import { homedir, platform } from 'node:os'
+import { homedir, platform, tmpdir } from 'node:os'
 import { execSync } from 'node:child_process'
 import { logger } from '../../logger.js'
 import { MAIN_AGENT_ID, BOT_NAME, PROJECT_ROOT } from '../../config.js'
@@ -102,6 +102,11 @@ import {
 import { sanitizeAgentName } from '../sanitize.js'
 import { parseMultipart } from '../multipart.js'
 import { readBody, json, serveFile } from '../http-helpers.js'
+import {
+  exportAgentBundle,
+  importAgentBundle,
+  bundleFilename,
+} from '../agent-bundle.js'
 import type { RouteContext } from './types.js'
 import { suggestForAgent, type AgentSignals } from '../model-suggest.js'
 import { getTokenSummary } from '../token-usage.js'
@@ -1462,6 +1467,89 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const name = decodeURIComponent(statusMatch[1])
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
     json(res, getAgentProcessInfo(name))
+    return true
+  }
+
+  // --- Per-agent export/import bundle (move an agent to another machine) ---
+  //
+  // GET  /api/agents/:name/export?secrets=1   -> downloads a .tar.gz bundle
+  // POST /api/agents/import                   -> uploads a bundle (multipart)
+  //
+  // The bundle is the portable subset of agents/<name>/ (identity + behaviour),
+  // with channel tokens included only when ?secrets=1 is set explicitly. See
+  // src/web/agent-bundle.ts. The main agent lives at PROJECT_ROOT (not under
+  // agents/) so it is not exportable this way -- use scripts/backup.sh for a
+  // whole-host move.
+  const exportMatch = path.match(/^\/api\/agents\/([^/]+)\/export$/)
+  if (exportMatch && method === 'GET') {
+    const name = decodeURIComponent(exportMatch[1])
+    if (name === MAIN_AGENT_ID) {
+      json(res, { error: 'The main agent cannot be exported as a bundle; use scripts/backup.sh for a whole-host move.' }, 400)
+      return true
+    }
+    if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    const includeSecrets = /[?&]secrets=(1|true)\b/.test(req.url || '')
+    const work = mkdtempSync(join(tmpdir(), 'marveen-agent-dl-'))
+    const outPath = join(work, bundleFilename(name))
+    try {
+      exportAgentBundle(name, outPath, {
+        includeSecrets,
+        exportedBy: MAIN_AGENT_ID,
+        exportedAt: new Date().toISOString(),
+      })
+      const data = readFileSync(outPath)
+      res.writeHead(200, {
+        'Content-Type': 'application/gzip',
+        'Content-Disposition': `attachment; filename="${bundleFilename(name)}"`,
+        'Content-Length': String(data.length),
+        'Cache-Control': 'private, no-store',
+      })
+      res.end(data)
+    } catch (err) {
+      logger.error({ err, name }, 'Agent export failed')
+      json(res, { error: 'Export failed', detail: err instanceof Error ? err.message : String(err) }, 500)
+    } finally {
+      rmSync(work, { recursive: true, force: true })
+    }
+    return true
+  }
+
+  if (path === '/api/agents/import' && method === 'POST') {
+    const body = await readBody(req)
+    const contentType = req.headers['content-type'] || ''
+    let bundle: Buffer | undefined
+    let overrideName = ''
+    let overwrite = false
+    if (contentType.includes('multipart/form-data')) {
+      const { file, fields } = parseMultipart(body, contentType)
+      if (file) bundle = file.data
+      overrideName = (fields.name || '').trim()
+      overwrite = fields.overwrite === '1' || fields.overwrite === 'true'
+    } else {
+      // Raw .tar.gz body; name/overwrite from query string.
+      bundle = body
+      const url = req.url || ''
+      const nameMatch = url.match(/[?&]name=([^&]+)/)
+      if (nameMatch) overrideName = decodeURIComponent(nameMatch[1]).trim()
+      overwrite = /[?&]overwrite=(1|true)\b/.test(url)
+    }
+    if (!bundle || bundle.length === 0) { json(res, { error: 'No bundle uploaded' }, 400); return true }
+    try {
+      const result = importAgentBundle(bundle, { overrideName: overrideName || undefined, overwrite })
+      logger.info({ name: result.name, overwritten: result.overwritten, secrets: result.manifest.includesSecrets }, 'Agent imported from bundle')
+      json(res, {
+        ok: true,
+        name: result.name,
+        overwritten: result.overwritten,
+        includedSecrets: result.manifest.includesSecrets,
+      })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      // A name collision without overwrite is a 409 the UI can offer to resolve;
+      // everything else (malformed bundle, bad name) is a 400.
+      const status = /already exists/.test(msg) ? 409 : 400
+      json(res, { error: msg }, status)
+    }
     return true
   }
 

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -105,7 +105,11 @@ import { readBody, json, serveFile } from '../http-helpers.js'
 import {
   exportAgentBundle,
   importAgentBundle,
+  exportAllAgentsBundle,
+  importAllAgentsBundle,
+  peekBundleKind,
   bundleFilename,
+  fleetBundleFilename,
 } from '../agent-bundle.js'
 import type { RouteContext } from './types.js'
 import { suggestForAgent, type AgentSignals } from '../model-suggest.js'
@@ -1480,6 +1484,39 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   // src/web/agent-bundle.ts. The main agent lives at PROJECT_ROOT (not under
   // agents/) so it is not exportable this way -- use scripts/backup.sh for a
   // whole-host move.
+  // GET /api/agents/export-all?secrets=1 -> a single .tar.gz of EVERY sub-agent
+  // (the main agent lives at PROJECT_ROOT and is excluded). Must be matched
+  // before the generic /api/agents/:name GET further down, or "export-all"
+  // would be read as an agent name.
+  if (path === '/api/agents/export-all' && method === 'GET') {
+    const names = listAgentNames().filter((n) => n !== MAIN_AGENT_ID)
+    if (names.length === 0) { json(res, { error: 'No agents to export' }, 404); return true }
+    const includeSecrets = /[?&]secrets=(1|true)\b/.test(req.url || '')
+    const work = mkdtempSync(join(tmpdir(), 'marveen-fleet-dl-'))
+    const outPath = join(work, fleetBundleFilename())
+    try {
+      exportAllAgentsBundle(outPath, names, {
+        includeSecrets,
+        exportedBy: MAIN_AGENT_ID,
+        exportedAt: new Date().toISOString(),
+      })
+      const data = readFileSync(outPath)
+      res.writeHead(200, {
+        'Content-Type': 'application/gzip',
+        'Content-Disposition': `attachment; filename="${fleetBundleFilename()}"`,
+        'Content-Length': String(data.length),
+        'Cache-Control': 'private, no-store',
+      })
+      res.end(data)
+    } catch (err) {
+      logger.error({ err }, 'Fleet export failed')
+      json(res, { error: 'Export failed', detail: err instanceof Error ? err.message : String(err) }, 500)
+    } finally {
+      rmSync(work, { recursive: true, force: true })
+    }
+    return true
+  }
+
   const exportMatch = path.match(/^\/api\/agents\/([^/]+)\/export$/)
   if (exportMatch && method === 'GET') {
     const name = decodeURIComponent(exportMatch[1])
@@ -1535,10 +1572,33 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     }
     if (!bundle || bundle.length === 0) { json(res, { error: 'No bundle uploaded' }, 400); return true }
     try {
+      // One endpoint accepts either format: peek the manifest, then dispatch to
+      // the single-agent or whole-fleet importer.
+      if (peekBundleKind(bundle) === 'fleet') {
+        const result = importAllAgentsBundle(bundle, { overwrite })
+        logger.info(
+          { imported: result.imported.map((a) => a.name), skipped: result.skipped, secrets: result.includesSecrets },
+          'Fleet imported from bundle',
+        )
+        // Any collision (even with some fresh agents already imported) returns
+        // 409 so the UI can offer to overwrite the rest; re-POSTing with
+        // overwrite=1 is idempotent for the already-imported ones.
+        const hasCollision = result.skipped.some((s) => s.reason === 'already exists')
+        json(res, {
+          ok: true,
+          kind: 'fleet',
+          imported: result.imported,
+          skipped: result.skipped,
+          includedSecrets: result.includesSecrets,
+        }, hasCollision ? 409 : 200)
+        return true
+      }
+
       const result = importAgentBundle(bundle, { overrideName: overrideName || undefined, overwrite })
       logger.info({ name: result.name, overwritten: result.overwritten, secrets: result.manifest.includesSecrets }, 'Agent imported from bundle')
       json(res, {
         ok: true,
+        kind: 'agent',
         name: result.name,
         overwritten: result.overwritten,
         includedSecrets: result.manifest.includesSecrets,

--- a/web/app.js
+++ b/web/app.js
@@ -3304,7 +3304,42 @@ document.getElementById('analyzeAllModelsBtn').addEventListener('click', async (
   } catch { panel.innerHTML = '<p style="color:var(--error);font-size:13px">' + t('agents.model.error') + '</p>' }
 })
 
+// === Export ALL agents (whole fleet) into one .tar.gz bundle ===
+const exportAllAgentsBtn = document.getElementById('exportAllAgentsBtn')
+if (exportAllAgentsBtn) {
+  exportAllAgentsBtn.addEventListener('click', async () => {
+    const withSecrets = confirm(
+      'Belevegyük a titkokat (channel bot tokenek, párosítási állapot) MINDEN ügynöknél?\n\n' +
+      'OK = igen, csak saját gépek közötti átvitelhez.\n' +
+      'Mégse = nem, biztonságosan megosztható (csak identitás + viselkedés).'
+    )
+    const url = `/api/agents/export-all${withSecrets ? '?secrets=1' : ''}`
+    try {
+      const res = await fetch(url)
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        showToast(data.error || 'Hiba az exportálás során')
+        return
+      }
+      const blob = await res.blob()
+      const objectUrl = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = objectUrl
+      a.download = 'marveen-fleet.tar.gz'
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(objectUrl)
+      showToast(`Flotta exportálva${withSecrets ? ' (titkokkal)' : ''}`)
+    } catch {
+      showToast('Hiba az exportálás során')
+    }
+  })
+}
+
 // === Agent import (upload a .tar.gz bundle exported from another machine) ===
+// Accepts both a single-agent bundle and a whole-fleet bundle -- the backend
+// auto-detects the format from the manifest.
 const importAgentBtn = document.getElementById('importAgentBtn')
 const importAgentFile = document.getElementById('importAgentFile')
 if (importAgentBtn && importAgentFile) {
@@ -3324,7 +3359,10 @@ if (importAgentBtn && importAgentFile) {
     try {
       let { res, data } = await upload(false)
       if (res.status === 409) {
-        if (confirm(`Már létezik "${data.name || ''}" nevű ügynök. Felülírjuk?`)) {
+        const prompt = data.kind === 'fleet'
+          ? 'Néhány ügynök már létezik ezen a gépen. Felülírjuk az ütközőket?'
+          : `Már létezik "${data.name || ''}" nevű ügynök. Felülírjuk?`
+        if (confirm(prompt)) {
           ;({ res, data } = await upload(true))
         } else {
           return
@@ -3332,7 +3370,13 @@ if (importAgentBtn && importAgentFile) {
       }
       if (!res.ok) { showToast(data.error || 'Hiba az importálás során'); return }
       const note = data.includedSecrets ? ' (titkokkal)' : ''
-      showToast(`Ügynök importálva: ${data.name}${note}${data.overwritten ? ' (felülírva)' : ''}`)
+      if (data.kind === 'fleet') {
+        const n = (data.imported || []).length
+        const skipped = (data.skipped || []).length
+        showToast(`Flotta importálva: ${n} ügynök${note}${skipped ? ` (${skipped} kihagyva)` : ''}`)
+      } else {
+        showToast(`Ügynök importálva: ${data.name}${note}${data.overwritten ? ' (felülírva)' : ''}`)
+      }
       loadAgents()
     } catch {
       showToast('Hiba az importálás során')

--- a/web/app.js
+++ b/web/app.js
@@ -2690,6 +2690,43 @@ async function openAgentDetail(agentName) {
     }
   }
 
+  // Export button: download a portable .tar.gz bundle of this agent. Offers to
+  // include channel tokens (off by default -- the safe-to-share variant).
+  // The download goes through the auth-wrapped fetch (the global fetch shim
+  // injects the Bearer header) and is turned into a Blob download, rather than
+  // a plain navigation -- a window.location download cannot carry the
+  // Authorization header and the API would 401 it.
+  document.getElementById('exportAgentBtn').onclick = async () => {
+    if (!currentAgent) return
+    const withSecrets = confirm(
+      'Belevegyük a titkokat (channel bot token, párosítási állapot)?\n\n' +
+      'OK = igen, csak saját gépek közötti átvitelhez.\n' +
+      'Mégse = nem, biztonságosan megosztható (csak identitás + viselkedés).'
+    )
+    const name = currentAgent.name
+    const url = `/api/agents/${encodeURIComponent(name)}/export${withSecrets ? '?secrets=1' : ''}`
+    try {
+      const res = await fetch(url)
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        showToast(data.error || 'Hiba az exportálás során')
+        return
+      }
+      const blob = await res.blob()
+      const objectUrl = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = objectUrl
+      a.download = `marveen-agent-${name}.tar.gz`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(objectUrl)
+      showToast(`Ügynök exportálva${withSecrets ? ' (titkokkal)' : ''}`)
+    } catch {
+      showToast('Hiba az exportálás során')
+    }
+  }
+
   // Reset to first tab, hide avatar gallery
   document.getElementById('detailAvatarGallery').hidden = true
   switchAgentTab('overview')
@@ -3266,6 +3303,44 @@ document.getElementById('analyzeAllModelsBtn').addEventListener('click', async (
     }
   } catch { panel.innerHTML = '<p style="color:var(--error);font-size:13px">' + t('agents.model.error') + '</p>' }
 })
+
+// === Agent import (upload a .tar.gz bundle exported from another machine) ===
+const importAgentBtn = document.getElementById('importAgentBtn')
+const importAgentFile = document.getElementById('importAgentFile')
+if (importAgentBtn && importAgentFile) {
+  importAgentBtn.addEventListener('click', () => importAgentFile.click())
+  importAgentFile.addEventListener('change', async () => {
+    const file = importAgentFile.files && importAgentFile.files[0]
+    if (!file) return
+    // Reset the input so picking the same file again re-fires change.
+    const upload = async (overwrite) => {
+      const form = new FormData()
+      form.append('file', file)
+      if (overwrite) form.append('overwrite', '1')
+      const res = await fetch('/api/agents/import', { method: 'POST', body: form })
+      const data = await res.json().catch(() => ({}))
+      return { res, data }
+    }
+    try {
+      let { res, data } = await upload(false)
+      if (res.status === 409) {
+        if (confirm(`Már létezik "${data.name || ''}" nevű ügynök. Felülírjuk?`)) {
+          ;({ res, data } = await upload(true))
+        } else {
+          return
+        }
+      }
+      if (!res.ok) { showToast(data.error || 'Hiba az importálás során'); return }
+      const note = data.includedSecrets ? ' (titkokkal)' : ''
+      showToast(`Ügynök importálva: ${data.name}${note}${data.overwritten ? ' (felülírva)' : ''}`)
+      loadAgents()
+    } catch {
+      showToast('Hiba az importálás során')
+    } finally {
+      importAgentFile.value = ''
+    }
+  })
+}
 
 document.getElementById('saveAutoRestartBtn').addEventListener('click', async () => {
   if (!currentAgent) return

--- a/web/index.html
+++ b/web/index.html
@@ -281,6 +281,8 @@
             <p class="subtitle" data-i18n="agents.page_subtitle">AI csapattagok kezelése</p>
           </div>
           <div class="header-actions">
+            <button class="btn-secondary btn-compact" id="importAgentBtn">Ügynök importálása</button>
+            <input type="file" id="importAgentFile" accept=".gz,.tgz,application/gzip" hidden>
             <button class="btn-secondary btn-compact" id="analyzeAllModelsBtn" data-i18n="agents.page.analyze_btn">Modell elemzés</button>
           </div>
         </div>
@@ -2067,6 +2069,7 @@
 
         <!-- Bottom actions -->
         <div class="detail-actions agent-detail-bottom" id="agentDetailActions">
+          <button class="btn-secondary" id="exportAgentBtn">Exportálás</button>
           <button class="btn-danger" id="deleteAgentBtn" data-i18n="common.btn.delete">Törlés</button>
         </div>
       </div>

--- a/web/index.html
+++ b/web/index.html
@@ -281,6 +281,7 @@
             <p class="subtitle" data-i18n="agents.page_subtitle">AI csapattagok kezelése</p>
           </div>
           <div class="header-actions">
+            <button class="btn-secondary btn-compact" id="exportAllAgentsBtn">Összes exportálása</button>
             <button class="btn-secondary btn-compact" id="importAgentBtn">Ügynök importálása</button>
             <input type="file" id="importAgentFile" accept=".gz,.tgz,application/gzip" hidden>
             <button class="btn-secondary btn-compact" id="analyzeAllModelsBtn" data-i18n="agents.page.analyze_btn">Modell elemzés</button>

--- a/web/style.css
+++ b/web/style.css
@@ -1182,6 +1182,12 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
   gap: 16px;
 }
 
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 /* === Agent Grid === */
 .agents-grid {
   display: grid;


### PR DESCRIPTION
## Type of change

- [x] New feature

## Summary

Adds agent data transfer: move a single agent (or the whole fleet) between
machines in one portable `.tar.gz`, without relocating the entire host and the
global SQLite DB. Previously the only option was `scripts/backup.sh` (full host + DB).

- **`src/web/agent-bundle.ts`** – pack/unpack via system `tar` (like `backup.sh`);
  bundle layout is `manifest.json` + `agent/`.
- **Always transferred (identity + behaviour):** `agent-config.json`, `CLAUDE.md`,
  `SOUL.md`, `.mcp.json`, avatar, `.claude/settings.json|skills|hooks`, `memory/`.
- **Secrets are opt-in per export (default: OFF):** with `?secrets=1` it also
  includes the channel `.env` (bot token), `access.json`, `invites.json`, `approved/`.
  The dashboard prompts on every export.
- On import, machine-specific fields (`remoteHost`, `remoteWorkdir`,
  `claudeConfigDir`) are **stripped** → a clean, local agent on the target machine.
- **Fleet format:** `manifest.json` with `kind:"fleet"` + `agents/<name>/`;
  `peekBundleKind` lets one import endpoint auto-detect single-agent vs. fleet
  bundles. A name collision is non-fatal (`409` → UI offers overwrite; re-import is idempotent).
- API: `GET /api/agents/<name>/export?secrets=0|1`,
  `GET /api/agents/export-all?secrets=0|1`, `POST /api/agents/import` (multipart).
  Dashboard: *Export* / *Export all* / *Import agent* buttons.
- The main agent (`marveen`) cannot be exported (it lives in `PROJECT_ROOT`) – a full
  machine migration is still `scripts/backup.sh`.

**Testing done:** Import tested on Nobara Linux native – the agent started cleanly
from the bundle. Code-level: `typecheck` 0 errors, `vitest` 520 pass / 0 fail
(bundle suite: 16 tests – staging, secret toggle, tar round-trip, collision/overwrite,
fleet round-trip, format detection, malformed-bundle rejection).

## To verify before merge

- [ ] **Export from a Linux host** → import on another machine → agent starts cleanly
      (the bundle is produced by Linux-side `tar`; only the import side was tested on Linux).
- [ ] **`?secrets=1` path with a real channel token** (⚠️ one bot = one poller – the same
      token running on two machines triggers a Telegram/Slack 409; bring the old machine
      down before the new one up).
- [ ] **Fleet import on name collision** → `409` → overwrite flow.

## Related issue

Closes #417

## Checklist

- [x] Tested locally (import on Nobara Linux native; export on Windows-native).
- [x] Updated `docs/` (`docs/agent-fleet.md`).
- [x] No hardcoded secrets (API keys, tokens, personal data).
- [x] Opened from an own, descriptively named branch (`feature/agent-export-import`).
