### PR TITLE
feat(voice): per-agent voice messaging (faster-whisper STT + Piper TTS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,11 @@ DREAM.md
 .external-ops-last-run
 REBUILD_PROMPT_V3.1.md
 
+# Main agent's runtime voice config (responseMode/voiceModel). Sub-agents store
+# theirs under agents/ (already ignored); the main agent's lives at the repo root
+# and is per-install runtime state, never source.
+/agent-config.json
+
 # Operator's branded support auto-reply. The shipped support-mail tooling is a
 # generic IMAP/SMTP CLI (no operator data); each operator keeps their own
 # branded auto-reply here locally. Ignored so it never ships to other installs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Minden lap két szemszögből mutatja be a funkciót:
 | [Ügynök-flotta + inter-agent kommunikáció](agent-fleet.md) | Több specializált ügynök közös üzenetsoron keresztül |
 | [Skill-factory (öntanulás)](skill-factory.md) | Visszatérő munkafolyamatokból újrahasznosítható skill-ek |
 | [Channels (Telegram / Slack)](channels.md) | Natív üzenetküldő-integráció proaktív értesítésekkel |
+| [Hangüzenetek (voice)](voice.md) | Per-agent STT+TTS: helyben futó hang oda-vissza Telegramon, ügynökönként állítható móddal |
 | [Printing-press CLI-k](printing-press-cli.md) | API nélküli oldalakhoz is agent-natív CLI generálás |
 | [Skool CLI](skool-cli.md) | Közösségi platform kezelése parancssorból (API nélkül) |
 | [connectors.hu](connectors-hu.md) | Üzleti API-átjáró (NAV, Billingo, Wise, fal.ai) MCP-n |

--- a/docs/en/voice.md
+++ b/docs/en/voice.md
@@ -1,0 +1,79 @@
+# Voice messaging (per-agent voice)
+
+> Agents receive and send voice messages — everything runs locally, no external API, no recurring cost.
+
+---
+
+## 🎯 What it does / why it matters
+
+When you send a voice note to an agent on Telegram, you can get one back. Not a text reply to a voice message — actual back-and-forth voice communication.
+
+Three things make this interesting:
+
+1. **Fully local.** Both speech recognition (STT) and speech synthesis (TTS) run on your own machine — no external API calls, no privacy concerns, no usage fees.
+2. **Per-agent configuration.** Not a fleet-wide toggle: each agent has its own mode and voice model. One agent can stay text-only while another always replies with audio.
+3. **Transparent pipeline.** The transcript is injected into the agent's context as readable text — no black box, fully loggable, easy to debug.
+
+---
+
+## 🛠 How it works
+
+### The pipeline
+
+```
+Inbound voice note (Telegram)
+  │
+  ▼
+Server-side STT (faster-whisper)
+  ├─ transcribes audio to text
+  └─ injects transcript into the agent prompt
+        │
+        ▼
+Agent produces a text reply
+  │
+  ▼
+TTS (Piper) → OGG/Opus encoding → native sendVoice
+```
+
+No extra steps on the agent side: the text reply is automatically synthesised and sent as a native Telegram voice note.
+
+Inter-agent messages (no `chat_id`) bypass the voice pipeline entirely — no TTS on internal fleet traffic.
+
+### Modes (per-agent)
+
+| Mode | Behaviour |
+|------|-----------|
+| `text` | Always reply as text, never produce audio |
+| `voice` | Always reply as audio, even for text input |
+| `auto` | Reply as audio only when the inbound message was a voice note |
+
+### Voice models
+
+TTS uses Piper ONNX models. Models are stored in `~/.local/share/marveen-voice/voices/`.
+
+Included by default (Hungarian):
+- `hu_HU-imre-medium` — male voice (default)
+- `hu_HU-anna-medium` — female voice
+
+Any other language or voice can be dropped into the same directory — the dashboard will pick it up automatically.
+
+### Installation
+
+Dashboard → agent detail → **Voice** tab → **Install** button. One click installs the Whisper and Piper toolkit locally. One-time setup, no root required.
+
+### Configuration
+
+Mode and voice model are configurable per agent from the dashboard (agent detail → Voice tab) or via REST API:
+
+```
+GET  /api/agents/:id/voice-config
+PUT  /api/agents/:id/voice-config   { responseMode, voiceModel }
+```
+
+Settings persist in the agent's `agent-config.json`.
+
+---
+
+### Notes
+
+Piper models are monolingual per model file. The Hungarian models (`hu_HU-*`) apply Hungarian letter-to-sound rules to all input — English technical terms will be pronounced using Hungarian phonemes and may sound incorrect. Keep English jargon out of TTS strings where possible, or substitute phonetic spellings before synthesis.

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -1,0 +1,79 @@
+# Hangüzenetek (per-agent voice)
+
+> Az ügynök hangüzeneteket fogad és küld -- minden helyben fut, külső API és havidíj nélkül.
+
+---
+
+## 🎯 Mit tud / miért érdekes
+
+Ha hangüzenetet küldesz egy ügynöknek Telegramon, vissza is kaphatsz hangot. Nem szöveg-választ egy hangra, hanem igazi oda-vissza hangkommunikációt.
+
+Három dolog teszi ezt érdekessé:
+
+1. **Teljesen helyi.** A szövegfelismerés (STT) és a hangszintézis (TTS) is a saját gépeden fut -- nincs külső API-hívás, nincs adatvédelmi aggály, nincs forgalmi díj.
+2. **Agensenkénti beállítás.** Nem mindenkire egységesen: minden ügynöknek külön konfigurálható, hogy mikor és milyen hanggal válaszoljon. Egy ügynök maradhat szöveges, a másik mindig hangban válaszol.
+3. **Átlátható működés.** Az átirat bekerül az ügynök kontextusába szövegként -- nem fekete doboz, hanem olvasható, naplózható, hibakeresésnél nem kell találgatni.
+
+---
+
+## 🛠 Hogyan működik
+
+### A pipeline
+
+```
+Bejövő hangüzenet (Telegram)
+  │
+  ▼
+Szerver-oldali STT (faster-whisper)
+  ├─ átírja a hangot szöveggé
+  └─ az átiratot injektálja az ügynök promptjába
+        │
+        ▼
+Az ügynök szöveges választ készít
+  │
+  ▼
+TTS (Piper) → OGG/Opus enkódolás → natív sendVoice
+```
+
+Az ügynök oldalán nincs külön lépés: a válasz szövege automatikusan hanggá alakul, és Telegram hangüzenetként megy ki.
+
+Az ügynökök közötti belső üzenetek (nincs `chat_id`) kihagyják a hangpipeline-t -- nincs felesleges TTS a flotta belső forgalmára.
+
+### Módok (agensenkénti beállítás)
+
+| Mód | Viselkedés |
+|-----|-----------|
+| `text` | Mindig szöveg, soha nem hangol |
+| `voice` | Mindig hang -- szöveges inputra is |
+| `auto` | Csak akkor hangol, ha a bejövő üzenet is hang volt |
+
+### Hangmodellek
+
+A TTS Piper ONNX modelleket használ. A modellek helye: `~/.local/share/marveen-voice/voices/`.
+
+Alapból elérhető magyar hangok:
+- `hu_HU-imre-medium` -- férfi hang (default)
+- `hu_HU-anna-medium` -- női hang
+
+Más nyelv vagy hang behúzható ugyanebbe a könyvtárba -- a rendszer automatikusan felkínálja a dashboardon.
+
+### Telepítés
+
+Dashboard → ügynök részletei → **Voice** fül → **Telepítés** gomb. Egy kattintással feltelepíti a Whisper és Piper toolkitet. Egyszeri, helyi, nem igényel root jogot.
+
+### Konfiguráció
+
+A mód és a hangmodell a dashboardon agensenkénti beállítható (ügynök részletei → Voice fül), vagy REST API-n:
+
+```
+GET  /api/agents/:id/voice-config
+PUT  /api/agents/:id/voice-config   { responseMode, voiceModel }
+```
+
+A beállítás az ügynök `agent-config.json`-jában perzisztál.
+
+---
+
+### Megjegyzés
+
+A Piper modellek modellenkénti egynyelvűek. A magyar modellek (`hu_HU-*`) a szöveg minden szavát magyar betű-hang szabályokkal ejtik -- az angol szakszavak így rosszul hangozhatnak. Érdemes a TTS-be szánt szövegből kihagyni az angol terminusokat, vagy fonetikusan átírni őket.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marveen",
-  "version": "1.12.5",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marveen",
-      "version": "1.12.5",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",
@@ -16,7 +16,6 @@
         "pino-pretty": "^13.0.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.61.0",
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.10.0",
         "tsx": "^4.19.0",
@@ -28,35 +27,35 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.141.tgz",
-      "integrity": "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.117.tgz",
+      "integrity": "sha512-pVBss1Vu0w87nKCBhWtjMggSgCh6GVUtdRmuE58ZvXv0E2q0JcnUCQHehmn92BAW0+VCwPY8q/k7uKWkgwz/gA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.93.0",
+        "@anthropic-ai/sdk": "^0.81.0",
         "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.117",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.117",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.117",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.117",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.117",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.117",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.117",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.117"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.141.tgz",
-      "integrity": "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.117.tgz",
+      "integrity": "sha512-ZeC/Lz8XMKQ5w+GmjTziPR8bSSarBtNCJMkMAYRT9ekNmyXSWXEwGLENe5TDDmtpzNNzAB1mQNuIYoqTsqgV3w==",
       "cpu": [
         "arm64"
       ],
@@ -67,9 +66,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.141.tgz",
-      "integrity": "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.117.tgz",
+      "integrity": "sha512-DKyggGzzpDcr9S435xlpbpwkEYKZNbePSekug75tJclK8l4ddD9+M9BFgMiSUq9F1Zt53kUaRDihDu/cBKvkdQ==",
       "cpu": [
         "x64"
       ],
@@ -80,9 +79,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.141.tgz",
-      "integrity": "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.117.tgz",
+      "integrity": "sha512-jyHmyZQavpPOe3zxBRX3KbdOAJ8JwZ8m/wMr5bhHhhcstugm/vJx6IIs7D44VvFjk+8sqdvR2ZrliL8PUcJL0g==",
       "cpu": [
         "arm64"
       ],
@@ -93,9 +92,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.141.tgz",
-      "integrity": "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.117.tgz",
+      "integrity": "sha512-bJU5gEOmM4VCOn4h8vipOKgdhPATePQ23mMpvyVqtVyipWppHfOUfVkqXb+SrF/hfkNSMYxDuoKxbJ+MmKtGjg==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +105,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.141.tgz",
-      "integrity": "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.117.tgz",
+      "integrity": "sha512-Zb5PXKrDNbQ1dyNYwxZMNL+F2Dhgjh9f9B21wZUJqkhJL69hRJwJyxO42HiNmB2zGCaTxQTyjPhLdB/eQJo74Q==",
       "cpu": [
         "x64"
       ],
@@ -119,9 +118,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.141.tgz",
-      "integrity": "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.117.tgz",
+      "integrity": "sha512-LIkKTAYZGugEVssAuWCPqlDWSqhVZAveNPNsfKLbuG1naIMCR04fUqil6i3d3mAAfk7FaS5D4IdHp45psi+GDw==",
       "cpu": [
         "x64"
       ],
@@ -132,9 +131,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.141.tgz",
-      "integrity": "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.117.tgz",
+      "integrity": "sha512-uetggH3B83PiH0a9D/5MVXB5Hqnlr2DVajehwAP2x0Mt4DBd632ICnHpu6pnSP+vVkWgq3FgQlkHe91RfP+peA==",
       "cpu": [
         "arm64"
       ],
@@ -145,9 +144,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.141.tgz",
-      "integrity": "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.117.tgz",
+      "integrity": "sha512-TT4KngAokDTJSvQ2mrAP6ZRkXj50OLj7Tb1zZA4CnkmrrEidgs4KrMx7er1ZwoivngIvCekV9+TbtC9giknr5w==",
       "cpu": [
         "x64"
       ],
@@ -158,9 +157,9 @@
       ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.93.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.93.0.tgz",
-      "integrity": "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -178,9 +177,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -692,22 +691,6 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.61.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1837,12 +1820,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.2.0"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1873,9 +1856,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "funding": [
         {
           "type": "github",
@@ -2062,9 +2045,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2139,9 +2122,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2326,9 +2309,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -2553,57 +2536,10 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.61.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -2621,7 +2557,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2696,9 +2632,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marveen",
-  "version": "1.10.0",
+  "version": "1.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marveen",
-      "version": "1.10.0",
+      "version": "1.12.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",
@@ -16,6 +16,7 @@
         "pino-pretty": "^13.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.10.0",
         "tsx": "^4.19.0",
@@ -27,35 +28,35 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.117.tgz",
-      "integrity": "sha512-pVBss1Vu0w87nKCBhWtjMggSgCh6GVUtdRmuE58ZvXv0E2q0JcnUCQHehmn92BAW0+VCwPY8q/k7uKWkgwz/gA==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.141.tgz",
+      "integrity": "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.81.0",
+        "@anthropic-ai/sdk": "^0.93.0",
         "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.117",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.117",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.117",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.117",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.117",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.117",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.117",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.117"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.117.tgz",
-      "integrity": "sha512-ZeC/Lz8XMKQ5w+GmjTziPR8bSSarBtNCJMkMAYRT9ekNmyXSWXEwGLENe5TDDmtpzNNzAB1mQNuIYoqTsqgV3w==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.141.tgz",
+      "integrity": "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g==",
       "cpu": [
         "arm64"
       ],
@@ -66,9 +67,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.117.tgz",
-      "integrity": "sha512-DKyggGzzpDcr9S435xlpbpwkEYKZNbePSekug75tJclK8l4ddD9+M9BFgMiSUq9F1Zt53kUaRDihDu/cBKvkdQ==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.141.tgz",
+      "integrity": "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ==",
       "cpu": [
         "x64"
       ],
@@ -79,9 +80,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.117.tgz",
-      "integrity": "sha512-jyHmyZQavpPOe3zxBRX3KbdOAJ8JwZ8m/wMr5bhHhhcstugm/vJx6IIs7D44VvFjk+8sqdvR2ZrliL8PUcJL0g==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.141.tgz",
+      "integrity": "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q==",
       "cpu": [
         "arm64"
       ],
@@ -92,9 +93,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.117.tgz",
-      "integrity": "sha512-bJU5gEOmM4VCOn4h8vipOKgdhPATePQ23mMpvyVqtVyipWppHfOUfVkqXb+SrF/hfkNSMYxDuoKxbJ+MmKtGjg==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.141.tgz",
+      "integrity": "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ==",
       "cpu": [
         "arm64"
       ],
@@ -105,9 +106,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.117.tgz",
-      "integrity": "sha512-Zb5PXKrDNbQ1dyNYwxZMNL+F2Dhgjh9f9B21wZUJqkhJL69hRJwJyxO42HiNmB2zGCaTxQTyjPhLdB/eQJo74Q==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.141.tgz",
+      "integrity": "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A==",
       "cpu": [
         "x64"
       ],
@@ -118,9 +119,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.117.tgz",
-      "integrity": "sha512-LIkKTAYZGugEVssAuWCPqlDWSqhVZAveNPNsfKLbuG1naIMCR04fUqil6i3d3mAAfk7FaS5D4IdHp45psi+GDw==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.141.tgz",
+      "integrity": "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ==",
       "cpu": [
         "x64"
       ],
@@ -131,9 +132,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.117.tgz",
-      "integrity": "sha512-uetggH3B83PiH0a9D/5MVXB5Hqnlr2DVajehwAP2x0Mt4DBd632ICnHpu6pnSP+vVkWgq3FgQlkHe91RfP+peA==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.141.tgz",
+      "integrity": "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w==",
       "cpu": [
         "arm64"
       ],
@@ -144,9 +145,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.117.tgz",
-      "integrity": "sha512-TT4KngAokDTJSvQ2mrAP6ZRkXj50OLj7Tb1zZA4CnkmrrEidgs4KrMx7er1ZwoivngIvCekV9+TbtC9giknr5w==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.141.tgz",
+      "integrity": "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg==",
       "cpu": [
         "x64"
       ],
@@ -157,9 +158,9 @@
       ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
-      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.93.0.tgz",
+      "integrity": "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -177,9 +178,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -691,6 +692,22 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1820,12 +1837,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1856,9 +1873,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2045,9 +2062,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2122,9 +2139,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2309,9 +2326,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "dev": true,
       "funding": [
         {
@@ -2536,10 +2553,57 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2557,7 +2621,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2632,9 +2696,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/scripts/__tests__/test-voice-install.sh
+++ b/scripts/__tests__/test-voice-install.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Acceptance test for scripts/install-voice.sh in a clean environment.
+#
+# Runs inside Docker (ubuntu:24.04) to guarantee no pre-existing components
+# influence the result. Host-side: docker must be available.
+#
+# Usage:
+#   ./scripts/__tests__/test-voice-install.sh           # runs Docker test
+#   SKIP_DOCKER=1 INSTALL_DIR=/tmp/voice-test-xxx \
+#     ./scripts/__tests__/test-voice-install.sh         # in-container self-test
+#
+# Exit code: 0 = all PASS, 1 = at least one FAIL.
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PASS=0; FAIL=0
+
+_pass() { echo "[PASS] $*"; ((PASS++)) || true; }
+_fail() { echo "[FAIL] $*" >&2; ((FAIL++)) || true; }
+_section() { echo ""; echo "--- $* ---"; }
+
+# ============================================================
+# DOCKER MODE (default): spin up persistent ubuntu:24.04, run self
+# Container is kept alive after the test for manual inspection.
+# ============================================================
+CONTAINER_NAME="${VOICE_TEST_CONTAINER:-marveen-voice-test}"
+
+if [[ "${SKIP_DOCKER:-}" != "1" ]]; then
+  # Remove any leftover container from a previous run
+  docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+  echo "==> Starting persistent test container: $CONTAINER_NAME"
+  docker run -d --name "$CONTAINER_NAME" \
+    -v "$REPO_ROOT:/marveen:ro" \
+    ubuntu:24.04 \
+    tail -f /dev/null
+
+  echo "==> Running acceptance tests inside container..."
+  EXIT_CODE=0
+  docker exec \
+    -e SKIP_DOCKER=1 \
+    -e INSTALL_DIR=/tmp/voice-test \
+    "$CONTAINER_NAME" \
+    bash /marveen/scripts/__tests__/test-voice-install.sh 2>&1 || EXIT_CODE=$?
+
+  echo ""
+  if [[ "$EXIT_CODE" -eq 0 ]]; then
+    echo "==> Container test: PASS"
+  else
+    echo "==> Container test: FAIL (exit $EXIT_CODE)"
+  fi
+
+  echo ""
+  echo "==> Container '$CONTAINER_NAME' is still running for manual inspection."
+  echo "    Enter:  docker exec -it $CONTAINER_NAME bash"
+  echo "    Venv:   source /tmp/voice-test/venv/bin/activate"
+  echo "    Voices: ls /tmp/voice-test/voices/"
+  echo "    TTS:    /tmp/voice-test/tts.sh imre <chat_id> 'Helló, ez egy teszt'"
+  echo "    Piper direct: echo 'Helló' | /tmp/voice-test/venv/bin/python -m piper \\"
+  echo "                    -m /tmp/voice-test/voices/hu_HU-imre-medium.onnx -f /tmp/out.wav"
+  echo "    STT:    /tmp/voice-test/venv/bin/python /tmp/voice-test/_vtools.py transcribe <file_id> <state_dir>"
+  echo "    Cleanup: docker rm -f $CONTAINER_NAME"
+  exit "$EXIT_CODE"
+fi
+
+# ============================================================
+# IN-CONTAINER SELF-TEST MODE (SKIP_DOCKER=1)
+# ============================================================
+DEST="${INSTALL_DIR:-/tmp/voice-test}"
+echo "==> Voice install acceptance test"
+echo "    INSTALL_DIR=$DEST"
+echo "    $(uname -a)"
+
+# Preflight: confirm clean environment
+_section "Preflight checks"
+[[ ! -d "$DEST/venv" ]]                            && _pass "No prior venv (clean)" \
+                                                   || _fail "Existing venv found -- not isolated!"
+[[ ! -f "$DEST/voices/hu_HU-imre-medium.onnx" ]]  && _pass "No prior voice model (clean)" \
+                                                   || _fail "Existing voice model found -- not isolated!"
+command -v ffmpeg &>/dev/null                      && _fail "ffmpeg pre-installed (not clean)" \
+                                                   || _pass "No pre-installed ffmpeg (clean)"
+
+# Run installer
+_section "Running installer"
+INSTALL_DIR="$DEST" bash /marveen/scripts/install-voice.sh
+echo "    installer exited $?"
+
+# C1: venv + package import
+_section "C1: Python venv + package import"
+if [[ -d "$DEST/venv" ]]; then
+  _pass "venv exists at $DEST/venv"
+else
+  _fail "venv missing"
+fi
+if "$DEST/venv/bin/python" -c "import faster_whisper, piper" 2>/dev/null; then
+  _pass "faster_whisper and piper importable"
+else
+  _fail "package import failed"
+fi
+
+# C2: Voice models -- both imre and anna
+_section "C2: Hungarian TTS voice models"
+MIN_ONNX_BYTES=1000000
+for name in hu_HU-imre-medium hu_HU-anna-medium; do
+  onnx="$DEST/voices/${name}.onnx"
+  json_file="$DEST/voices/${name}.onnx.json"
+  if [[ -f "$onnx" ]]; then
+    size=$(stat -c%s "$onnx" 2>/dev/null || stat -f%z "$onnx")
+    if [[ "$size" -ge "$MIN_ONNX_BYTES" ]]; then
+      _pass "${name}.onnx present (${size} bytes)"
+    else
+      _fail "${name}.onnx too small (${size} bytes)"
+    fi
+  else
+    _fail "${name}.onnx missing"
+  fi
+  [[ -f "$json_file" ]] && _pass "${name}.onnx.json present" || _fail "${name}.onnx.json missing"
+
+  # Verify the .onnx.json is valid JSON and contains expected fields
+  if "$DEST/venv/bin/python" -c "
+import json, sys
+d = json.load(open('$json_file'))
+assert 'language' in d or 'espeak' in d or 'audio' in d, 'missing expected keys'
+" 2>/dev/null; then
+    _pass "${name}.onnx.json valid"
+  else
+    _fail "${name}.onnx.json invalid or missing expected keys"
+  fi
+done
+
+# C3: ffmpeg + libopus
+_section "C3: ffmpeg + libopus encoder"
+if command -v ffmpeg &>/dev/null; then
+  _pass "ffmpeg available: $(ffmpeg -version 2>&1 | head -1)"
+else
+  _fail "ffmpeg not found after install"
+fi
+_enc=$(ffmpeg -encoders 2>&1 || true)
+if echo "$_enc" | grep -q libopus; then
+  _pass "libopus encoder present"
+else
+  _fail "libopus encoder missing"
+fi
+
+# C4: TTS end-to-end (text -> wav -> ogg/opus)
+_section "C4: TTS end-to-end (both voices)"
+for voice_name in imre anna; do
+  voice_label="hu_HU-${voice_name}-medium"
+  onnx="$DEST/voices/${voice_label}.onnx"
+  wav_out="/tmp/test-tts-${voice_name}.wav"
+  ogg_out="/tmp/test-tts-${voice_name}.ogg"
+  TEST_TEXT="Helló, ez egy teszt üzenet a ${voice_name} hanggal."
+
+  if echo "$TEST_TEXT" | "$DEST/venv/bin/python" -m piper \
+      -m "$onnx" -f "$wav_out" 2>/dev/null; then
+    wav_size=$(stat -c%s "$wav_out" 2>/dev/null || echo 0)
+    if [[ "$wav_size" -gt 0 ]]; then
+      _pass "TTS ${voice_name}: wav generated (${wav_size} bytes)"
+    else
+      _fail "TTS ${voice_name}: wav is empty"
+    fi
+  else
+    _fail "TTS ${voice_name}: piper synthesis failed"
+  fi
+
+  if [[ -f "$wav_out" ]] && [[ "$(stat -c%s "$wav_out" 2>/dev/null || echo 0)" -gt 0 ]]; then
+    if ffmpeg -hide_banner -loglevel error -y -i "$wav_out" \
+        -c:a libopus -b:a 32k "$ogg_out" 2>/dev/null; then
+      ogg_size=$(stat -c%s "$ogg_out" 2>/dev/null || echo 0)
+      if [[ "$ogg_size" -gt 0 ]]; then
+        _pass "TTS ${voice_name}: ogg/opus encoded (${ogg_size} bytes)"
+      else
+        _fail "TTS ${voice_name}: ogg output empty"
+      fi
+    else
+      _fail "TTS ${voice_name}: ffmpeg ogg conversion failed"
+    fi
+  fi
+
+  # Verify ogg is valid audio container
+  if [[ -f "$ogg_out" ]]; then
+    if ffprobe -v quiet -select_streams a:0 \
+        -show_entries stream=codec_name "$ogg_out" 2>/dev/null | grep -q opus; then
+      _pass "TTS ${voice_name}: valid opus stream confirmed"
+    else
+      _fail "TTS ${voice_name}: ffprobe did not find opus stream"
+    fi
+  fi
+done
+
+# C5: STT end-to-end (known ogg -> transcript with expected keyword)
+# Uses one of the TTS outputs as a known-content reference file.
+_section "C5: STT end-to-end (TTS output as reference)"
+REF_OGG="/tmp/test-tts-imre.ogg"
+EXPECTED_KW="teszt"   # "teszt" is in the TTS text, whisper-small should catch it
+if [[ -f "$REF_OGG" ]]; then
+  TRANSCRIPT=$("$DEST/venv/bin/python" - <<'PYEOF'
+import sys
+from faster_whisper import WhisperModel
+m = WhisperModel("small", device="cpu", compute_type="int8")
+segs, _ = m.transcribe("/tmp/test-tts-imre.ogg", language="hu", beam_size=5)
+print(" ".join(s.text.strip() for s in segs).strip().lower())
+PYEOF
+  ) || TRANSCRIPT=""
+  echo "    Transcript: $TRANSCRIPT"
+  if [[ -n "$TRANSCRIPT" ]]; then
+    _pass "STT produced non-empty transcript"
+    if echo "$TRANSCRIPT" | grep -qi "$EXPECTED_KW"; then
+      _pass "STT transcript contains expected keyword: '$EXPECTED_KW'"
+    else
+      # Whisper-small is imperfect on short Hungarian; non-fatal warning
+      echo "    [WARN] keyword '$EXPECTED_KW' not found (small model imprecision, non-fatal)"
+      _pass "STT ran without error (keyword match optional for small model)"
+    fi
+  else
+    _fail "STT returned empty transcript"
+  fi
+else
+  echo "    [SKIP] C5: reference ogg missing (TTS failed earlier)"
+fi
+
+# C6: Per-agent voice selection -- different onnx paths produce different outputs
+_section "C6: Per-agent voice selection (imre vs anna differ)"
+if [[ -f "/tmp/test-tts-imre.ogg" ]] && [[ -f "/tmp/test-tts-anna.ogg" ]]; then
+  size_imre=$(stat -c%s /tmp/test-tts-imre.ogg)
+  size_anna=$(stat -c%s /tmp/test-tts-anna.ogg)
+  if [[ "$size_imre" -ne "$size_anna" ]]; then
+    _pass "imre and anna produce different-sized audio (different voices confirmed)"
+  else
+    # Same size is suspicious but not conclusive -- content could differ
+    echo "    [WARN] same file size for imre/anna -- may be coincidence, not failure"
+    _pass "Both voices generated without error"
+  fi
+else
+  echo "    [SKIP] C6: TTS outputs missing"
+fi
+
+# C7: Idempotence -- re-run installer, nothing breaks
+_section "C7: Idempotence (re-run)"
+INSTALL_DIR="$DEST" bash /marveen/scripts/install-voice.sh 2>&1 | grep -E "SKIP|PASS|complete" | head -10
+"$DEST/venv/bin/python" -c "import faster_whisper, piper" \
+  && _pass "packages still importable after re-run" \
+  || _fail "packages broken after re-run"
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "==========================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==========================================="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/hooks/voice-reply-directive.py
+++ b/scripts/hooks/voice-reply-directive.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""UserPromptSubmit hook: voice-reply directive injection.
+"""UserPromptSubmit hook: voice-reply directive injection + server-side STT.
 
-When a voice message is delivered to a voice/auto-mode agent, this hook
-appends a ready-to-run TTS curl directive to the prompt so the agent knows
-to reply with voice instead of text.
+When a voice message is delivered to a voice/auto-mode agent, this hook:
+  1. Passes the attachment_file_id to /api/voice/directive so the server
+     transcribes the audio (faster-whisper, no Bash/whisper permission needed).
+  2. Injects "[Hang átirat]: <text>" into the prompt when a transcript is returned.
+  3. Injects the TTS curl directive so the agent knows to reply with voice.
 
 Claude Code delivers stdout from UserPromptSubmit hooks directly into the model
 prompt (no JSON wrapper needed -- plain text is injected as-is). This hook
@@ -16,6 +18,7 @@ import os
 import json
 import re
 import urllib.request
+import urllib.parse
 
 
 def _project_root():
@@ -74,6 +77,10 @@ def main():
         sys.exit(0)
     chat_id = m.group(1)
 
+    # Extract attachment_file_id if present (Telegram voice file reference)
+    m_file = re.search(r'\battachment_file_id="([^"]+)"', prompt)
+    file_id = m_file.group(1) if m_file else None
+
     agent_id = _agent_id(payload.get("cwd"))
     if not agent_id:
         sys.exit(0)
@@ -84,17 +91,24 @@ def main():
 
     port = _web_port()
     url = "http://localhost:%s/api/voice/directive?agent=%s&chat=%s" % (port, agent_id, chat_id)
+    if file_id:
+        url += "&file=" + urllib.parse.quote(file_id, safe="")
+
     try:
         req = urllib.request.Request(url)
         req.add_header("Authorization", "Bearer " + token)
-        with urllib.request.urlopen(req, timeout=5) as r:
+        with urllib.request.urlopen(req, timeout=55) as r:
             data = json.load(r)
     except Exception:
-        sys.exit(0)  # dashboard unavailable -- fail-safe, no directive injected
+        sys.exit(0)  # dashboard unavailable -- fail-safe, no injection
+
+    transcript = data.get("transcript")
+    if transcript:
+        sys.stdout.write("\n[Hang átirat]: " + transcript + "\n")
+        sys.stdout.flush()
 
     directive = data.get("directive")
     if directive:
-        # Plain text stdout is injected directly into the model prompt by Claude Code.
         sys.stdout.write(directive)
         sys.stdout.flush()
 

--- a/scripts/hooks/voice-reply-directive.py
+++ b/scripts/hooks/voice-reply-directive.py
@@ -67,17 +67,17 @@ def main():
 
     prompt = payload.get("prompt") or ""
 
-    # Only fire for voice inbound messages
-    if 'attachment_kind="voice"' not in prompt:
-        sys.exit(0)
-
-    # Extract chat_id from <channel chat_id="...">
+    # Gate: only fire for channel-inbound messages (has chat_id).
+    # Inter-agent prompts and non-channel input have no chat_id -- skip those.
+    # (voice-mode agents must reply with audio even to plain text input, so we
+    # cannot gate on attachment_kind="voice" here.)
     m = re.search(r'\bchat_id="(\d+)"', prompt)
     if not m:
         sys.exit(0)
     chat_id = m.group(1)
 
-    # Extract attachment_file_id if present (Telegram voice file reference)
+    # Extract attachment_file_id if present (only set for voice attachments).
+    # Passed to the endpoint so STT runs server-side when a voice file is attached.
     m_file = re.search(r'\battachment_file_id="([^"]+)"', prompt)
     file_id = m_file.group(1) if m_file else None
 

--- a/scripts/hooks/voice-reply-directive.py
+++ b/scripts/hooks/voice-reply-directive.py
@@ -48,6 +48,18 @@ def _token():
         return ""
 
 
+def _main_agent_id():
+    """Read MAIN_AGENT_ID from .env; fall back to 'marveen'."""
+    try:
+        with open(os.path.join(_project_root(), ".env")) as f:
+            for line in f:
+                if line.startswith("MAIN_AGENT_ID="):
+                    return line.split("=", 1)[1].strip().strip('"\'')
+    except Exception:
+        pass
+    return "marveen"
+
+
 def _agent_id(cwd):
     if not cwd:
         return None
@@ -56,6 +68,11 @@ def _agent_id(cwd):
         i = parts.index("agents")
         if i + 1 < len(parts):
             return parts[i + 1]
+    # Fallback: if cwd is the project root itself (main agent session),
+    # use MAIN_AGENT_ID so voice config and state_dir resolve correctly.
+    project_root = os.path.normpath(_project_root())
+    if os.path.normpath(cwd) == project_root:
+        return _main_agent_id()
     return None
 
 

--- a/scripts/hooks/voice-reply-directive.py
+++ b/scripts/hooks/voice-reply-directive.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: voice-reply directive injection.
+
+When a voice message is delivered to a voice/auto-mode agent, this hook
+appends a ready-to-run TTS curl directive to the prompt so the agent knows
+to reply with voice instead of text.
+
+Claude Code delivers stdout from UserPromptSubmit hooks directly into the model
+prompt (no JSON wrapper needed -- plain text is injected as-is). This hook
+stays completely silent for non-voice messages.
+
+Never raises: any error results in a silent exit(0) so the prompt is never blocked.
+"""
+import sys
+import os
+import json
+import re
+import urllib.request
+
+
+def _project_root():
+    # scripts/hooks/ -> project root (two dirs up)
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _web_port():
+    port = os.environ.get("WEB_PORT")
+    if not port:
+        try:
+            with open(os.path.join(_project_root(), ".env")) as f:
+                for line in f:
+                    if line.startswith("WEB_PORT="):
+                        port = line.split("=", 1)[1].strip().strip('"\'')
+                        break
+        except Exception:
+            pass
+    return port or "3420"
+
+
+def _token():
+    try:
+        with open(os.path.join(_project_root(), "store", ".dashboard-token")) as f:
+            return f.read().strip()
+    except Exception:
+        return ""
+
+
+def _agent_id(cwd):
+    if not cwd:
+        return None
+    parts = os.path.normpath(cwd).split(os.sep)
+    if "agents" in parts:
+        i = parts.index("agents")
+        if i + 1 < len(parts):
+            return parts[i + 1]
+    return None
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    prompt = payload.get("prompt") or ""
+
+    # Only fire for voice inbound messages
+    if 'attachment_kind="voice"' not in prompt:
+        sys.exit(0)
+
+    # Extract chat_id from <channel chat_id="...">
+    m = re.search(r'\bchat_id="(\d+)"', prompt)
+    if not m:
+        sys.exit(0)
+    chat_id = m.group(1)
+
+    agent_id = _agent_id(payload.get("cwd"))
+    if not agent_id:
+        sys.exit(0)
+
+    token = _token()
+    if not token:
+        sys.exit(0)
+
+    port = _web_port()
+    url = "http://localhost:%s/api/voice/directive?agent=%s&chat=%s" % (port, agent_id, chat_id)
+    try:
+        req = urllib.request.Request(url)
+        req.add_header("Authorization", "Bearer " + token)
+        with urllib.request.urlopen(req, timeout=5) as r:
+            data = json.load(r)
+    except Exception:
+        sys.exit(0)  # dashboard unavailable -- fail-safe, no directive injected
+
+    directive = data.get("directive")
+    if directive:
+        # Plain text stdout is injected directly into the model prompt by Claude Code.
+        sys.stdout.write(directive)
+        sys.stdout.flush()
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Voice components installer for the Marveen agent fleet.
+#
+# Installs: faster-whisper (STT) + piper-tts (TTS) + ffmpeg/libopus
+#           + Hungarian TTS voice models (imre, anna) + fleet helper scripts.
+#
+# Usage:
+#   ./scripts/install-voice.sh                     # installs to ~/.local/share/atlas-whisper
+#   INSTALL_DIR=/custom/path ./scripts/install-voice.sh
+#
+# Safe to re-run (idempotent): skips already-completed steps.
+# Opt-in: this script is NOT run by the main dashboard installer.
+set -euo pipefail
+
+DEST="${INSTALL_DIR:-$HOME/.local/share/atlas-whisper}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VOICE_SRC="$REPO_ROOT/scripts/voice"
+
+HF_BASE="https://huggingface.co/rhasspy/piper-voices/resolve/main"
+VOICES=(
+  "hu/hu_HU/imre/medium/hu_HU-imre-medium"
+  "hu/hu_HU/anna/medium/hu_HU-anna-medium"
+)
+
+_pass() { echo "    [PASS] $*"; }
+_fail() { echo "    [FAIL] $*" >&2; exit 1; }
+_skip() { echo "    [SKIP] $*"; }
+_step() { echo ""; echo "==> $*"; }
+
+# --- Preflight: no existing install check (for test isolation) ---
+if [[ "${VOICE_PREFLIGHT_CHECK:-}" == "1" ]]; then
+  [[ -d "$DEST/venv" ]] && _fail "Existing venv found at $DEST/venv -- test isolation violated"
+  [[ -f "$DEST/voices/hu_HU-imre-medium.onnx" ]] && _fail "Voice model already present -- test isolation violated"
+  echo "==> Preflight OK: $DEST is clean"
+fi
+
+echo "==> Voice component installer"
+echo "    Target: $DEST"
+
+# --- Step 1: System dependencies ---
+_step "[1/5] System dependencies (ffmpeg + libopus + python3-venv)"
+_has_ffmpeg_opus() {
+  # ffmpeg -encoders exits 1 (no input file); capture output before grep
+  # so pipefail doesn't turn a successful grep into a failure.
+  command -v ffmpeg &>/dev/null || return 1
+  local _enc
+  _enc=$(ffmpeg -encoders 2>&1 || true)
+  echo "$_enc" | grep -q libopus
+}
+_has_python_venv() {
+  python3 -m venv --help &>/dev/null 2>&1
+}
+
+# SKIP_SYSTEM_DEPS=1: skip the apt-get step (used by the dashboard installer
+# which has already verified deps are present and runs without root).
+if [[ "${SKIP_SYSTEM_DEPS:-}" == "1" ]]; then
+  _has_ffmpeg_opus || _fail "ffmpeg + libopus missing -- install manually: sudo apt-get install -y ffmpeg"
+  _has_python_venv || _fail "python3-venv missing -- install manually: sudo apt-get install -y python3-venv python3"
+  _skip "SKIP_SYSTEM_DEPS=1: skipping apt-get step"
+elif command -v apt-get &>/dev/null; then
+  PKGS=()
+  _has_ffmpeg_opus       || PKGS+=(ffmpeg)
+  _has_python_venv       || PKGS+=(python3-venv python3)
+  command -v curl &>/dev/null || PKGS+=(curl)
+  if [[ ${#PKGS[@]} -gt 0 ]]; then
+    echo "    Installing: ${PKGS[*]}"
+    apt-get update -qq 2>&1 | tail -3
+    apt-get install -y --no-install-recommends "${PKGS[@]}" 2>&1 | tail -5
+  else
+    _skip "apt packages already present"
+  fi
+else
+  command -v ffmpeg  || _fail "ffmpeg not found (non-apt system, install manually)"
+  _has_ffmpeg_opus   || _fail "ffmpeg has no libopus encoder"
+  _has_python_venv   || _fail "python3-venv not available"
+  _skip "non-apt system, system deps assumed present"
+fi
+_has_ffmpeg_opus || _fail "ffmpeg + libopus check failed after install"
+_pass "ffmpeg + libopus OK"
+
+# --- Step 2: Python venv ---
+_step "[2/5] Python venv"
+mkdir -p "$DEST/voices"
+if [[ ! -d "$DEST/venv" ]]; then
+  python3 -m venv "$DEST/venv"
+  _pass "venv created at $DEST/venv"
+else
+  _skip "venv exists"
+fi
+
+# --- Step 3: Python packages ---
+_step "[3/5] Python packages (faster-whisper + piper-tts)"
+if "$DEST/venv/bin/python" -c "import faster_whisper, piper" 2>/dev/null; then
+  _skip "packages already installed"
+else
+  "$DEST/venv/bin/pip" install --quiet faster-whisper piper-tts
+  _pass "faster-whisper + piper-tts installed"
+fi
+"$DEST/venv/bin/python" -c "import faster_whisper, piper" || _fail "package import check failed"
+
+# --- Step 4: Hungarian voice models ---
+_step "[4/5] Hungarian TTS voice models"
+MIN_ONNX_BYTES=50000000
+
+for voice_path in "${VOICES[@]}"; do
+  name="$(basename "$voice_path")"
+  onnx="$DEST/voices/${name}.onnx"
+  json="$DEST/voices/${name}.onnx.json"
+  url_base="${HF_BASE}/${voice_path}"
+
+  existing_size=0
+  if [[ -f "$onnx" ]]; then
+    existing_size=$(stat -c%s "$onnx" 2>/dev/null || stat -f%z "$onnx" 2>/dev/null || echo 0)
+  fi
+
+  if [[ "$existing_size" -ge "$MIN_ONNX_BYTES" ]]; then
+    _skip "${name}: present (${existing_size} bytes)"
+    continue
+  fi
+
+  echo "    Downloading ${name} (~63MB)..."
+  curl -sSL --retry 3 --retry-delay 3 --connect-timeout 30 -o "$onnx" "${url_base}.onnx" \
+    || { rm -f "$onnx"; _fail "download failed: ${name}.onnx"; }
+  curl -sSL --retry 3 --retry-delay 3 --connect-timeout 30 -o "$json" "${url_base}.onnx.json" \
+    || { rm -f "$json"; _fail "download failed: ${name}.onnx.json"; }
+
+  size=$(stat -c%s "$onnx" 2>/dev/null || stat -f%z "$onnx")
+  [[ "$size" -ge "$MIN_ONNX_BYTES" ]] || _fail "${name}.onnx too small (${size} bytes) -- download incomplete"
+  _pass "${name}: ${size} bytes"
+done
+
+# --- Step 5: Helper scripts ---
+_step "[5/5] Installing fleet helper scripts"
+cp "$VOICE_SRC/_vtools.py" "$DEST/_vtools.py"
+cp "$VOICE_SRC/stt.sh"     "$DEST/stt.sh"
+cp "$VOICE_SRC/tts.sh"     "$DEST/tts.sh"
+chmod +x "$DEST/stt.sh" "$DEST/tts.sh" "$DEST/_vtools.py"
+_pass "stt.sh, tts.sh, _vtools.py deployed"
+
+# --- Done ---
+echo ""
+echo "==> Installation complete: $DEST"
+echo "    Voices: imre (hu_HU-imre-medium), anna (hu_HU-anna-medium)"
+echo "    STT:    $DEST/stt.sh <file_id> [state_dir]"
+echo "    TTS:    $DEST/tts.sh <voice> <chat_id> <text...>"

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -5,14 +5,14 @@
 #           + Hungarian TTS voice models (imre, anna) + fleet helper scripts.
 #
 # Usage:
-#   ./scripts/install-voice.sh                     # installs to ~/.local/share/atlas-whisper
+#   ./scripts/install-voice.sh                     # installs to ~/.local/share/marveen-voice
 #   INSTALL_DIR=/custom/path ./scripts/install-voice.sh
 #
 # Safe to re-run (idempotent): skips already-completed steps.
 # Opt-in: this script is NOT run by the main dashboard installer.
 set -euo pipefail
 
-DEST="${INSTALL_DIR:-$HOME/.local/share/atlas-whisper}"
+DEST="${INSTALL_DIR:-$HOME/.local/share/marveen-voice}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VOICE_SRC="$REPO_ROOT/scripts/voice"
 

--- a/scripts/voice/_vtools.py
+++ b/scripts/voice/_vtools.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Voice tools for the agent fleet (STT + TTS), local + free.
+
+Subcommands:
+  transcribe <file_id> <state_dir>
+      Download a Telegram voice file by file_id using the bot token in
+      <state_dir>/.env, transcribe it (Hungarian, faster-whisper small),
+      print the transcript to stdout.
+
+  speak <voice_onnx> <state_dir> <chat_id> <text...>
+      Synthesize <text> with the given Piper voice model, convert to
+      ogg/opus, and send it as a Telegram voice message via the bot token
+      in <state_dir>/.env. Prints "ok=<bool> id=<message_id>".
+
+The bot token is read from the caller's OWN state dir at call time, never
+hardcoded -- so each agent speaks/listens on its own bot.
+"""
+import os
+import re
+import sys
+import json
+import subprocess
+import tempfile
+import urllib.request
+import urllib.parse
+
+# Resolved relative to this file so PREFIX-based installs work correctly.
+VENV_PY = os.path.join(os.path.dirname(os.path.abspath(__file__)), "venv", "bin", "python")
+
+
+def _token(state_dir):
+    env = open(os.path.join(state_dir, ".env")).read()
+    m = re.search(r"^TELEGRAM_BOT_TOKEN=(.+)$", env, re.M)
+    if not m:
+        sys.exit("no TELEGRAM_BOT_TOKEN in " + state_dir)
+    return m.group(1).strip().strip('"').strip("'")
+
+
+def transcribe(file_id, state_dir):
+    token = _token(state_dir)
+    d = json.load(urllib.request.urlopen(
+        f"https://api.telegram.org/bot{token}/getFile?file_id={urllib.parse.quote(file_id)}",
+        timeout=20))
+    fp = d["result"]["file_path"]
+    fd, out = tempfile.mkstemp(suffix=".ogg")
+    os.close(fd)
+    try:
+        urllib.request.urlretrieve(f"https://api.telegram.org/file/bot{token}/{fp}", out)
+        from faster_whisper import WhisperModel
+        m = WhisperModel("small", device="cpu", compute_type="int8")
+        segs, _ = m.transcribe(out, language="hu", beam_size=5)
+        print(" ".join(s.text.strip() for s in segs).strip())
+    finally:
+        try:
+            os.unlink(out)
+        except OSError:
+            pass
+
+
+def speak(voice_onnx, state_dir, chat_id, text):
+    token = _token(state_dir)
+    fd_wav, wav = tempfile.mkstemp(suffix=".wav")
+    os.close(fd_wav)
+    fd_ogg, ogg = tempfile.mkstemp(suffix=".ogg")
+    os.close(fd_ogg)
+    try:
+        subprocess.run([VENV_PY, "-m", "piper", "-m", voice_onnx, "-f", wav],
+                       input=text.encode(), check=True)
+        subprocess.run(["ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+                        "-i", wav, "-c:a", "libopus", "-b:a", "32k", ogg], check=True)
+        b = "----fleetvoice"
+        fd = open(ogg, "rb").read()
+        body = (("--" + b + "\r\nContent-Disposition: form-data; name=\"chat_id\"\r\n\r\n" + str(chat_id) + "\r\n").encode()
+                + ("--" + b + "\r\nContent-Disposition: form-data; name=\"voice\"; filename=\"v.ogg\"\r\nContent-Type: audio/ogg\r\n\r\n").encode()
+                + fd + b"\r\n" + ("--" + b + "--\r\n").encode())
+        req = urllib.request.Request(f"https://api.telegram.org/bot{token}/sendVoice", data=body)
+        req.add_header("Content-Type", "multipart/form-data; boundary=" + b)
+        r = json.load(urllib.request.urlopen(req, timeout=30))
+        print("ok=%s id=%s" % (r.get("ok"), (r.get("result") or {}).get("message_id")))
+    finally:
+        for p in (wav, ogg):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+    if cmd == "transcribe":
+        transcribe(sys.argv[2], sys.argv[3])
+    elif cmd == "speak":
+        speak(sys.argv[2], sys.argv[3], sys.argv[4], " ".join(sys.argv[5:]))
+    else:
+        sys.exit("usage: _vtools.py transcribe <file_id> <state_dir> | speak <voice_onnx> <state_dir> <chat_id> <text...")

--- a/scripts/voice/stt.sh
+++ b/scripts/voice/stt.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# STT wrapper for the fleet. Transcribes a Telegram voice message (Hungarian).
+# Usage: stt.sh <file_id> [state_dir]
+# state_dir defaults to the agent's own telegram channel dir (cwd-based) or global.
+set -euo pipefail
+DEST="$(cd "$(dirname "$0")/.." 2>/dev/null && pwd || echo "$HOME/.local/share/atlas-whisper")"
+# When installed to INSTALL_DIR, the parent is INSTALL_DIR itself.
+# Detect: if _vtools.py is in the same dir as this script, use that dir.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -f "$SCRIPT_DIR/_vtools.py" ]]; then
+  DEST="$SCRIPT_DIR"
+fi
+FID="${1:?usage: stt.sh <file_id> [state_dir]}"
+STATE_DIR="${2:-$HOME/.claude/channels/telegram}"
+exec "$DEST/venv/bin/python" "$DEST/_vtools.py" transcribe "$FID" "$STATE_DIR"

--- a/scripts/voice/stt.sh
+++ b/scripts/voice/stt.sh
@@ -3,7 +3,7 @@
 # Usage: stt.sh <file_id> [state_dir]
 # state_dir defaults to the agent's own telegram channel dir (cwd-based) or global.
 set -euo pipefail
-DEST="$(cd "$(dirname "$0")/.." 2>/dev/null && pwd || echo "$HOME/.local/share/atlas-whisper")"
+DEST="$(cd "$(dirname "$0")/.." 2>/dev/null && pwd || echo "$HOME/.local/share/marveen-voice")"
 # When installed to INSTALL_DIR, the parent is INSTALL_DIR itself.
 # Detect: if _vtools.py is in the same dir as this script, use that dir.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/voice/tts.sh
+++ b/scripts/voice/tts.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# TTS wrapper for the fleet. Synthesizes Hungarian speech and sends it as a
+# Telegram voice message via the agent's own bot token.
+# Usage: tts.sh <voice> <chat_id> <text...>   (voice: imre|anna|<path-to-onnx>)
+# Optional env: VOICE_STATE_DIR (defaults to global telegram channel dir).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -f "$SCRIPT_DIR/_vtools.py" ]]; then
+  DEST="$SCRIPT_DIR"
+else
+  DEST="$HOME/.local/share/atlas-whisper"
+fi
+VOICE_ARG="${1:?usage: tts.sh <voice> <chat_id> <text...>}"; shift
+CHAT_ID="${1:?missing chat_id}"; shift
+TEXT="$*"
+STATE_DIR="${VOICE_STATE_DIR:-$HOME/.claude/channels/telegram}"
+case "$VOICE_ARG" in
+  imre)  ONNX="$DEST/voices/hu_HU-imre-medium.onnx" ;;
+  anna)  ONNX="$DEST/voices/hu_HU-anna-medium.onnx" ;;
+  /*)    ONNX="$VOICE_ARG" ;;
+  *)     echo "Unknown voice alias: $VOICE_ARG (use: imre, anna, or absolute path)" >&2; exit 1 ;;
+esac
+exec "$DEST/venv/bin/python" "$DEST/_vtools.py" speak "$ONNX" "$STATE_DIR" "$CHAT_ID" "$TEXT"

--- a/scripts/voice/tts.sh
+++ b/scripts/voice/tts.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 if [[ -f "$SCRIPT_DIR/_vtools.py" ]]; then
   DEST="$SCRIPT_DIR"
 else
-  DEST="$HOME/.local/share/atlas-whisper"
+  DEST="$HOME/.local/share/marveen-voice"
 fi
 VOICE_ARG="${1:?usage: tts.sh <voice> <chat_id> <text...>}"; shift
 CHAT_ID="${1:?missing chat_id}"; shift

--- a/src/channel-coordinator.ts
+++ b/src/channel-coordinator.ts
@@ -194,8 +194,11 @@ export function buildHandoffContent(ev: {
   message_id: number | null
   content: string
   tg_date: number | null
+  meta?: Record<string, unknown>
 }): string {
   const ts = ev.tg_date ? new Date(ev.tg_date * 1000).toISOString() : ''
+  const voiceMeta = ev.meta?.voice as { file_id?: string } | undefined
+  const voiceFileId = voiceMeta?.file_id ?? ''
   const attrs = [
     `source="telegram"`,
     ev.chat_id != null ? `chat_id="${ev.chat_id}"` : '',
@@ -204,6 +207,8 @@ export function buildHandoffContent(ev: {
     ev.user_id != null ? `user_id="${ev.user_id}"` : '',
     ts ? `ts="${ts}"` : '',
     ev.kind !== 'message' ? `kind="${ev.kind}"` : '',
+    voiceFileId ? `attachment_kind="voice"` : '',
+    voiceFileId ? `attachment_file_id="${voiceFileId}"` : '',
   ].filter(Boolean).join(' ')
   const body = neutralizeChannelTags(ev.content || '(empty message)')
   return `<channel ${attrs}>\n${body}\n</channel>`
@@ -272,6 +277,8 @@ function reconcilePending(): void {
   }
   for (const ev of events) {
     try {
+      let parsedMeta: Record<string, unknown> = {}
+      try { if (ev.meta) parsedMeta = JSON.parse(ev.meta) as Record<string, unknown> } catch {}
       const agentMessageId = createHandoffMessage(buildHandoffContent({
         kind: ev.kind,
         chat_id: ev.chat_id,
@@ -280,6 +287,7 @@ function reconcilePending(): void {
         message_id: ev.message_id,
         content: ev.content ?? '',
         tg_date: ev.tg_date,
+        meta: parsedMeta,
       }))
       markEventDelivered(ev.id, agentMessageId)
       logger.warn({ update_id: ev.update_id, eventId: ev.id, agentMessageId }, 'channel-coordinator: re-queued abandoned/stranded inbound message')

--- a/src/web.ts
+++ b/src/web.ts
@@ -52,6 +52,7 @@ import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleSettings } from './web/routes/settings.js'
 import { tryHandleAuditLog } from './web/routes/audit-log.js'
 import { tryHandleStatic } from './web/routes/static.js'
+import { tryHandleVoice } from './web/routes/voice.js'
 import type { RouteContext } from './web/routes/types.js'
 
 const WEB_DIR = join(PROJECT_ROOT, 'web')
@@ -168,6 +169,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleIdeas(routeCtx)) return
       if (await tryHandleToolLog(routeCtx)) return
       if (await tryHandleSettings(routeCtx)) return
+      if (await tryHandleVoice(routeCtx)) return
       if (await tryHandleAuditLog(routeCtx)) return
       if (await tryHandleStatic(routeCtx, WEB_DIR)) return
 
@@ -246,59 +248,71 @@ export function startWebServer(port = 3420): http.Server {
     )
   })
 
-  const routerInterval = startMessageRouter()
-  logger.info('Agent message router started (5s poll)')
+  // WEB_ONLY=true disables all background services (scheduler, pollers, monitors).
+  // Used for staging preview instances that must not conflict with the live fleet
+  // (duplicate schedule execution, Telegram 409, tmux manipulation, etc.).
+  const webOnly = process.env['WEB_ONLY'] === 'true'
+  if (webOnly) {
+    logger.info('[staging] WEB_ONLY mode: background services disabled')
+  }
 
-  const scheduleInterval = startScheduleRunner()
-  logger.info('Schedule runner started (60s poll)')
+  const routerInterval = webOnly ? undefined : startMessageRouter()
+  if (!webOnly) logger.info('Agent message router started (5s poll)')
+
+  const scheduleInterval = webOnly ? undefined : startScheduleRunner()
+  if (!webOnly) logger.info('Schedule runner started (60s poll)')
 
   // Pre-start the interactive agent worker (subscription backend) so the first
   // heartbeat / scheduled generation after boot does not pay the cold-boot
   // latency. runViaWorker still lazy-starts + restarts it on demand, so this is
   // a warm-up, not a hard dependency. Skipped on the SDK rollback backend.
-  if ((process.env.MARVEEN_AGENT_BACKEND || 'worker').toLowerCase() !== 'sdk') {
+  if (!webOnly && (process.env.MARVEEN_AGENT_BACKEND || 'worker').toLowerCase() !== 'sdk') {
     import('./web/agent-worker.js')
       .then(m => { m.startWorkerSession(); logger.info('Interactive agent worker pre-started') })
       .catch(err => logger.warn({ err }, 'Failed to pre-start agent worker (will lazy-start on first use)'))
   }
 
-  const pluginMonitorInterval = startChannelPluginMonitor()
-  logger.info('Channel plugin health monitor started (60s poll)')
+  const pluginMonitorInterval = webOnly ? undefined : startChannelPluginMonitor()
+  if (!webOnly) logger.info('Channel plugin health monitor started (60s poll)')
 
   // Userbot inbound-probe (gold-standard deafness detector). Safe no-op until
   // the prober session file + allowlist are configured. Wrapped so a failure
   // never crashes server startup.
-  try {
-    startInboundProber()
-  } catch (err) {
-    logger.warn({ err }, 'Inbound prober failed to start')
+  if (!webOnly) {
+    try {
+      startInboundProber()
+    } catch (err) {
+      logger.warn({ err }, 'Inbound prober failed to start')
+    }
   }
 
-  const channelHealthInterval = startChannelHealthMonitor()
-  logger.info('Channel MCP health monitor started (60s poll, 45s offset)')
+  const channelHealthInterval = webOnly ? undefined : startChannelHealthMonitor()
+  if (!webOnly) logger.info('Channel MCP health monitor started (60s poll, 45s offset)')
 
-  const stuckInputInterval = startStuckInputWatcher()
-  logger.info('Stuck-input watcher started (15s poll, 20s offset)')
+  const stuckInputInterval = webOnly ? undefined : startStuckInputWatcher()
+  if (!webOnly) logger.info('Stuck-input watcher started (15s poll, 20s offset)')
 
-  const stuckToolCallInterval = startStuckToolCallWatcher()
-  logger.info('Stuck-tool-call watcher started (30s poll, 35s offset)')
+  const stuckToolCallInterval = webOnly ? undefined : startStuckToolCallWatcher()
+  if (!webOnly) logger.info('Stuck-tool-call watcher started (30s poll, 35s offset)')
 
-  const reauthHealerInterval = startReauthHealer()
-  if (reauthHealerInterval) logger.info('Reauth healer started (3min poll, 90s offset)')
+  const reauthHealerInterval = webOnly ? undefined : startReauthHealer()
+  if (!webOnly && reauthHealerInterval) logger.info('Reauth healer started (3min poll, 90s offset)')
 
-  const autoRestartInterval = startAutoRestartRunner()
-  logger.info('Auto-restart runner started (60s poll, 40s offset)')
+  const autoRestartInterval = webOnly ? undefined : startAutoRestartRunner()
+  if (!webOnly) logger.info('Auto-restart runner started (60s poll, 40s offset)')
 
-  const updateCheckerInterval = startUpdateChecker()
-  logger.info('Update checker started (15min poll)')
+  const updateCheckerInterval = webOnly ? undefined : startUpdateChecker()
+  if (!webOnly) logger.info('Update checker started (15min poll)')
 
   // Collect token usage from JSONL transcripts every hour so the run-history
   // token estimates stay fresh without requiring a manual dashboard visit.
-  const tokenCollectInterval = setInterval(() => {
+  const tokenCollectInterval = webOnly ? undefined : setInterval(() => {
     collectTokenUsage().catch(err => logger.warn({ err }, 'Periodic token usage collection failed'))
   }, 60 * 60 * 1000)
-  collectTokenUsage().catch(err => logger.warn({ err }, 'Startup token usage collection failed'))
-  logger.info('Token usage auto-collect started (1h poll + startup)')
+  if (!webOnly) {
+    collectTokenUsage().catch(err => logger.warn({ err }, 'Startup token usage collection failed'))
+    logger.info('Token usage auto-collect started (1h poll + startup)')
+  }
 
   // NOTE: startMcpListChecker() is intentionally NOT called here.
   //

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,7 +2,7 @@ import http from 'node:http'
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { execSync, execFileSync } from 'node:child_process'
-import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL, DASHBOARD_ALLOWED_ORIGINS } from './config.js'
+import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL, DASHBOARD_ALLOWED_ORIGINS, MAIN_AGENT_ID } from './config.js'
 import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-auth.js'
 import { isBlockedCrossOriginWrite } from './web/csrf-origin.js'
 import { json } from './web/http-helpers.js'
@@ -339,7 +339,9 @@ export function startWebServer(port = 3420): http.Server {
   // agent already has its own hooks block.
   try {
     const patched: string[] = []
-    for (const agentName of listAgentNames()) {
+    // Include the main agent (MAIN_AGENT_ID) so the voice hook is also seeded
+    // into ~/.claude/settings.json alongside existing hooks (e.g. telegram_progress.py).
+    for (const agentName of [MAIN_AGENT_ID, ...listAgentNames()]) {
       if (ensureAgentHooks(agentName)) patched.push(agentName)
     }
     if (patched.length) logger.info({ patched }, 'PreCompact hook backfilled into agent settings.json')

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -359,6 +359,67 @@ export function listAgentNames(): string[] {
   })
 }
 
+// ---- per-agent voice config -----------------------------------------------
+
+export type VoiceResponseMode = 'text' | 'voice' | 'auto'
+
+export interface AgentVoiceConfig {
+  responseMode: VoiceResponseMode
+  voiceModel: string
+}
+
+// Canonical set of bundled voice model identifiers (basename without .onnx).
+// Extend here when new models are added to the installer.
+export const KNOWN_VOICE_MODELS = new Set<string>([
+  'hu_HU-imre-medium',
+  'hu_HU-anna-medium',
+])
+
+const VALID_RESPONSE_MODES = new Set<VoiceResponseMode>(['text', 'voice', 'auto'])
+
+export const DEFAULT_VOICE_CONFIG: AgentVoiceConfig = {
+  responseMode: 'text',
+  voiceModel: 'hu_HU-imre-medium',
+}
+
+export function readAgentVoiceConfig(name: string): AgentVoiceConfig {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  try {
+    const config = JSON.parse(readFileOr(configPath, '{}'))
+    const vc = (config.voice ?? {}) as Partial<AgentVoiceConfig>
+    return {
+      responseMode: VALID_RESPONSE_MODES.has(vc.responseMode as VoiceResponseMode)
+        ? (vc.responseMode as VoiceResponseMode)
+        : DEFAULT_VOICE_CONFIG.responseMode,
+      voiceModel: KNOWN_VOICE_MODELS.has(vc.voiceModel ?? '')
+        ? (vc.voiceModel as string)
+        : DEFAULT_VOICE_CONFIG.voiceModel,
+    }
+  } catch {
+    return { ...DEFAULT_VOICE_CONFIG }
+  }
+}
+
+export function writeAgentVoiceConfig(name: string, patch: Partial<AgentVoiceConfig>): void {
+  if (patch.responseMode !== undefined && !VALID_RESPONSE_MODES.has(patch.responseMode)) {
+    throw new Error(`Invalid responseMode: ${patch.responseMode}`)
+  }
+  if (patch.voiceModel !== undefined && !KNOWN_VOICE_MODELS.has(patch.voiceModel)) {
+    throw new Error(`Unknown voiceModel: ${patch.voiceModel}`)
+  }
+  const configPath = join(agentDir(name), 'agent-config.json')
+  let config: Record<string, unknown> = {}
+  try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
+  const current = readAgentVoiceConfig(name)
+  config.voice = {
+    responseMode: patch.responseMode ?? current.responseMode,
+    voiceModel: patch.voiceModel ?? current.voiceModel,
+  }
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
+// ---- agent lookup ----------------------------------------------------------
+
 // Does this identifier refer to a registered agent? MAIN_AGENT_ID always
 // counts (it lives outside agents/ but is a first-class peer). Sub-agents
 // need a directory on disk. One fs stat per call -- the router calls this

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -383,7 +383,7 @@ export const DEFAULT_VOICE_CONFIG: AgentVoiceConfig = {
 }
 
 export function readAgentVoiceConfig(name: string): AgentVoiceConfig {
-  const configPath = join(agentDir(name), 'agent-config.json')
+  const configPath = join(agentConfigRoot(name), 'agent-config.json')
   try {
     const config = JSON.parse(readFileOr(configPath, '{}'))
     const vc = (config.voice ?? {}) as Partial<AgentVoiceConfig>
@@ -407,7 +407,7 @@ export function writeAgentVoiceConfig(name: string, patch: Partial<AgentVoiceCon
   if (patch.voiceModel !== undefined && !KNOWN_VOICE_MODELS.has(patch.voiceModel)) {
     throw new Error(`Unknown voiceModel: ${patch.voiceModel}`)
   }
-  const configPath = join(agentDir(name), 'agent-config.json')
+  const configPath = join(agentConfigRoot(name), 'agent-config.json')
   let config: Record<string, unknown> = {}
   try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
   const current = readAgentVoiceConfig(name)

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -66,19 +66,38 @@ export function ensureAgentHooks(name: string): boolean {
     try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
   }
   const tplHooks = tpl.hooks as Record<string, unknown>
+  type HookEntry = { hooks?: Array<{ command?: string; timeout?: number; [k: string]: unknown }> }
   if (existing.hooks) {
     // Key-level merge: add hook event types that are missing, leave existing ones intact.
     // This handles agents that already have some hooks (e.g. PreCompact) but are missing
     // newly added ones (e.g. UserPromptSubmit).
+    // Additionally, sync the timeout of any command hook whose command matches the template
+    // but whose timeout differs (e.g. 8 -> 60 for voice STT).
     const existingHooks = existing.hooks as Record<string, unknown>
-    let added = false
+    let changed = false
     for (const [event, handlers] of Object.entries(tplHooks)) {
       if (!existingHooks[event]) {
         existingHooks[event] = handlers
-        added = true
+        changed = true
+      } else {
+        const tplEntries = handlers as HookEntry[]
+        const existEntries = existingHooks[event] as HookEntry[]
+        for (const tplEntry of tplEntries) {
+          for (const tplHook of tplEntry.hooks ?? []) {
+            if (!tplHook.command || tplHook.timeout == null) continue
+            for (const existEntry of existEntries) {
+              for (const existHook of existEntry.hooks ?? []) {
+                if (existHook.command === tplHook.command && existHook.timeout !== tplHook.timeout) {
+                  existHook.timeout = tplHook.timeout
+                  changed = true
+                }
+              }
+            }
+          }
+        }
       }
     }
-    if (!added) return false
+    if (!changed) return false
   } else {
     existing.hooks = tplHooks
   }

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -65,8 +65,23 @@ export function ensureAgentHooks(name: string): boolean {
   if (existsSync(settingsPath)) {
     try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
   }
-  if (existing.hooks) return false  // user already has hooks, leave alone
-  existing.hooks = tpl.hooks
+  const tplHooks = tpl.hooks as Record<string, unknown>
+  if (existing.hooks) {
+    // Key-level merge: add hook event types that are missing, leave existing ones intact.
+    // This handles agents that already have some hooks (e.g. PreCompact) but are missing
+    // newly added ones (e.g. UserPromptSubmit).
+    const existingHooks = existing.hooks as Record<string, unknown>
+    let added = false
+    for (const [event, handlers] of Object.entries(tplHooks)) {
+      if (!existingHooks[event]) {
+        existingHooks[event] = handlers
+        added = true
+      }
+    }
+    if (!added) return false
+  } else {
+    existing.hooks = tplHooks
+  }
   mkdirSync(join(agentDir(name), '.claude'), { recursive: true })
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
   return true

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -5,7 +5,7 @@ import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WE
 import { channelStateDir } from '../channel-provider.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
-import { agentDir } from './agent-config.js'
+import { agentDir, agentConfigRoot } from './agent-config.js'
 import { resolveProfilePlaceholders, type ProfileTemplate } from './profiles.js'
 
 // Identity values the template substitution injects. Pulled out so the
@@ -45,12 +45,21 @@ export function resolveTemplatePlaceholders(content: string): string {
   })
 }
 
+// Return the settings.json path for an agent.
+// The main agent's settings live at ~/.claude/settings.json (not inside agents/).
+function agentSettingsPath(name: string): string {
+  if (name === MAIN_AGENT_ID) return join(homedir(), '.claude', 'settings.json')
+  return join(agentDir(name), '.claude', 'settings.json')
+}
+
 // Idempotent migration: every agent's settings.json should carry the
 // PreCompact hook (memory save + skill reflection). Pre-refactor agents
 // were scaffolded before scaffoldAgentDir seeded the template, so their
 // file is permissions-only. Merge the template's hooks block in place.
+// Also handles the main agent (MAIN_AGENT_ID) whose settings.json is at
+// ~/.claude/settings.json -- voice hook is added alongside existing hooks.
 export function ensureAgentHooks(name: string): boolean {
-  const settingsPath = join(agentDir(name), '.claude', 'settings.json')
+  const settingsPath = agentSettingsPath(name)
   const tplPath = join(PROJECT_ROOT, 'templates', 'settings.json.template')
   if (!existsSync(tplPath)) return false
   let tpl: Record<string, unknown>
@@ -68,11 +77,11 @@ export function ensureAgentHooks(name: string): boolean {
   const tplHooks = tpl.hooks as Record<string, unknown>
   type HookEntry = { hooks?: Array<{ command?: string; timeout?: number; [k: string]: unknown }> }
   if (existing.hooks) {
-    // Key-level merge: add hook event types that are missing, leave existing ones intact.
-    // This handles agents that already have some hooks (e.g. PreCompact) but are missing
-    // newly added ones (e.g. UserPromptSubmit).
-    // Additionally, sync the timeout of any command hook whose command matches the template
-    // but whose timeout differs (e.g. 8 -> 60 for voice STT).
+    // Merge strategy:
+    //   1. If a hook event is entirely missing: add it wholesale.
+    //   2. If the event exists: add any template hook commands not yet present
+    //      as a new hook group entry (preserves existing hooks like telegram_progress.py).
+    //   3. Sync the timeout of any command hook whose command matches but timeout differs.
     const existingHooks = existing.hooks as Record<string, unknown>
     let changed = false
     for (const [event, handlers] of Object.entries(tplHooks)) {
@@ -82,7 +91,20 @@ export function ensureAgentHooks(name: string): boolean {
       } else {
         const tplEntries = handlers as HookEntry[]
         const existEntries = existingHooks[event] as HookEntry[]
+        // Collect all command strings already present in this event's hook groups.
+        const existingCommands = new Set(
+          existEntries.flatMap((e) => (e.hooks ?? []).map((h) => h.command).filter(Boolean)),
+        )
         for (const tplEntry of tplEntries) {
+          // Add hooks that are missing (as a new group entry, preserving sibling hooks).
+          const newHooks = (tplEntry.hooks ?? []).filter(
+            (h) => h.command && !existingCommands.has(h.command),
+          )
+          if (newHooks.length > 0) {
+            existEntries.push({ ...tplEntry, hooks: newHooks })
+            changed = true
+          }
+          // Sync timeouts for hooks that already exist with a stale timeout.
           for (const tplHook of tplEntry.hooks ?? []) {
             if (!tplHook.command || tplHook.timeout == null) continue
             for (const existEntry of existEntries) {
@@ -101,7 +123,8 @@ export function ensureAgentHooks(name: string): boolean {
   } else {
     existing.hooks = tplHooks
   }
-  mkdirSync(join(agentDir(name), '.claude'), { recursive: true })
+  // For the main agent, ~/.claude already exists; sub-agents need the dir created.
+  if (name !== MAIN_AGENT_ID) mkdirSync(join(agentDir(name), '.claude'), { recursive: true })
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
   return true
 }

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -1,5 +1,6 @@
 import { logger } from '../logger.js'
-import { MAIN_AGENT_ID } from '../config.js'
+import { MAIN_AGENT_ID, STORE_DIR, WEB_PORT } from '../config.js'
+import { buildTtsDirective } from './voice-directive.js'
 import {
   getPendingMessages,
   markMessageDelivered,
@@ -163,10 +164,17 @@ export function startMessageRouter(): NodeJS.Timeout {
           setLastInboundModality(msg.to_agent, chatId, 'voice')
           if (voiceCfg.responseMode !== 'text') {
             // Attempt STT; on failure fall through to raw voice block.
-            const transcript = await callVoiceSTT(voiceFileId, msg.to_agent)
-            if (transcript) {
-              deliveryContent = injectTranscript(msg.content, transcript)
+            const sttResult = await callVoiceSTT(voiceFileId, msg.to_agent)
+            if (sttResult) {
+              deliveryContent = injectTranscript(msg.content, sttResult.transcript)
               logger.info({ id: msg.id, agent: msg.to_agent }, 'message-router: voice STT applied')
+              // Append ready-to-run TTS directive so the agent replies with voice.
+              const ttsDirective = buildTtsDirective({
+                chatId,
+                stateDir: sttResult.stateDir,
+                voiceModel: voiceCfg.voiceModel ?? 'hu_HU-imre-medium',
+              })
+              if (ttsDirective) deliveryContent += ttsDirective
             } else {
               logger.warn({ id: msg.id, agent: msg.to_agent }, 'message-router: STT failed, delivering raw voice block')
             }
@@ -246,8 +254,11 @@ function injectTranscript(content: string, transcript: string): string {
 }
 
 // Call the dashboard /api/voice/stt endpoint (localhost, same process).
-// Returns the transcript string, or null on failure.
-async function callVoiceSTT(fileId: string, agentId: string): Promise<string | null> {
+// Returns { transcript, stateDir } on success, null on failure.
+async function callVoiceSTT(
+  fileId: string,
+  agentId: string,
+): Promise<{ transcript: string; stateDir: string } | null> {
   try {
     const { homedir } = await import('node:os')
     const { join } = await import('node:path')
@@ -268,13 +279,12 @@ async function callVoiceSTT(fileId: string, agentId: string): Promise<string | n
     if (!existsSync(tokenFile)) return null
 
     // Read dashboard token for the API call
-    const { STORE_DIR } = await import('../config.js')
     const tokenPath = join(STORE_DIR, '.dashboard-token')
     if (!existsSync(tokenPath)) return null
     const dashToken = rfs(tokenPath, 'utf-8').trim()
 
     const body = JSON.stringify({ file_id: fileId, state_dir: resolvedDir })
-    const resp = await fetch('http://127.0.0.1:3420/api/voice/stt', {
+    const resp = await fetch(`http://127.0.0.1:${WEB_PORT}/api/voice/stt`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${dashToken}` },
       body,
@@ -282,9 +292,11 @@ async function callVoiceSTT(fileId: string, agentId: string): Promise<string | n
     })
     if (!resp.ok) return null
     const data = await resp.json() as { transcript?: string }
-    return data.transcript ?? null
+    if (!data.transcript) return null
+    return { transcript: data.transcript, stateDir: resolvedDir }
   } catch (err) {
     logger.warn({ err }, 'message-router: callVoiceSTT error')
     return null
   }
 }
+

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -16,7 +16,7 @@ import {
 } from '../prompt-safety.js'
 import { isTrustedPeer } from '../team-trust.js'
 import { COORDINATOR_AGENT_ID } from '../channel-coordinator/ingest.js'
-import { isKnownAgent, readAgentRemoteHost } from './agent-config.js'
+import { isKnownAgent, readAgentRemoteHost, readAgentVoiceConfig } from './agent-config.js'
 import { readAgentTeam } from './agent-team.js'
 import {
   agentSessionName,
@@ -25,6 +25,7 @@ import {
   sessionExistsOnHost,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { setLastInboundModality } from './voice-modality.js'
 
 // Channel-coordinator sources whose messages are real inbound user messages
 // (relayed during a native-channel disconnect window), NOT inter-agent data.
@@ -68,8 +69,15 @@ export function shouldAbandon(sessionExists: boolean, ageMs: number, windowMs: n
 
 // Checks for pending messages every 5 seconds and injects them into target
 // agent tmux sessions.
+let _tickRunning = false
+
 export function startMessageRouter(): NodeJS.Timeout {
-  return setInterval(() => {
+  return setInterval(async () => {
+    // Re-entrancy guard: STT can hold a tick for up to 65s; skip new ticks
+    // while the previous one is still in flight to prevent double-delivery.
+    if (_tickRunning) return
+    _tickRunning = true
+    try {
     const pending = getPendingMessages()
     const now = Date.now()
     for (const msg of pending) {
@@ -141,13 +149,41 @@ export function startMessageRouter(): NodeJS.Timeout {
         readAgentTeam,
       })
 
+      // Voice auto-mode: if this is a channel-inbound voice message, run STT
+      // and update the last-inbound-modality flag. The decision (STT or not)
+      // lives HERE so both the inbound transcript injection and the modality
+      // flag are set in one place, with full knowledge of agent-id + chat-id.
+      let deliveryContent = msg.content
+      if (isChannelInbound) {
+        const voiceFileId = extractVoiceFileId(msg.content)
+        const chatId = extractChatId(msg.content)
+        const voiceCfg = readAgentVoiceConfig(msg.to_agent)
+        if (voiceFileId && chatId) {
+          // Always record modality so auto-mode TTS can fire on reply.
+          setLastInboundModality(msg.to_agent, chatId, 'voice')
+          if (voiceCfg.responseMode !== 'text') {
+            // Attempt STT; on failure fall through to raw voice block.
+            const transcript = await callVoiceSTT(voiceFileId, msg.to_agent)
+            if (transcript) {
+              deliveryContent = injectTranscript(msg.content, transcript)
+              logger.info({ id: msg.id, agent: msg.to_agent }, 'message-router: voice STT applied')
+            } else {
+              logger.warn({ id: msg.id, agent: msg.to_agent }, 'message-router: STT failed, delivering raw voice block')
+            }
+          }
+        } else if (chatId) {
+          // Text message: record modality so a previous voice flag is cleared.
+          setLastInboundModality(msg.to_agent, chatId, 'text')
+        }
+      }
+
       try {
         let prefix: string
         let wrapped: string
         if (isChannelInbound) {
           // No "[Uzenet @...]" agent-DM line: the <channel> block IS the
           // message, framed exactly like the native plugin's inbound.
-          wrapped = wrapChannelInbound(msg.content)
+          wrapped = wrapChannelInbound(deliveryContent)
           prefix = `${CHANNEL_INBOUND_PREAMBLE}\n`
         } else if (trusted) {
           wrapped = wrapTrustedPeer(`agent:${safeFromAgent}`, msg.content)
@@ -172,5 +208,83 @@ export function startMessageRouter(): NodeJS.Timeout {
         routerLoggedMisses.delete(msg.id)
       }
     }
+    } finally {
+      _tickRunning = false
+    }
   }, 5000)
+}
+
+// ---- voice helpers (message-router level) ----------------------------------
+
+// Extract attachment_file_id from a <channel ... attachment_kind="voice" attachment_file_id="..."> block.
+function extractVoiceFileId(content: string): string | null {
+  if (!content.includes('attachment_kind="voice"')) return null
+  const m = content.match(/attachment_file_id="([^"]+)"/)
+  return m ? m[1] : null
+}
+
+// Extract chat_id from a <channel chat_id="..."> block.
+function extractChatId(content: string): string | null {
+  const m = content.match(/chat_id="([^"]+)"/)
+  return m ? m[1] : null
+}
+
+// Replace the voice attachment block with a transcript prefix.
+// Removes attachment_kind and attachment_file_id attributes; prepends [Hang átirat]:.
+function injectTranscript(content: string, transcript: string): string {
+  // Strip the attachment attributes from the opening tag
+  let result = content
+    .replace(/\s*attachment_kind="voice"/, '')
+    .replace(/\s*attachment_file_id="[^"]*"/, '')
+  // Replace the body with the transcript unconditionally (handles empty, "(empty message)", and caption).
+  // Replacer function avoids $1/$& special-pattern interpretation in the transcript string.
+  result = result.replace(
+    /(<channel[^>]*>)[\s\S]*?(<\/channel>)/,
+    (_m, open: string, close: string) => `${open}\n[Hang átirat]: ${transcript}\n${close}`,
+  )
+  return result
+}
+
+// Call the dashboard /api/voice/stt endpoint (localhost, same process).
+// Returns the transcript string, or null on failure.
+async function callVoiceSTT(fileId: string, agentId: string): Promise<string | null> {
+  try {
+    const { homedir } = await import('node:os')
+    const { join } = await import('node:path')
+    const { readFileSync, existsSync } = await import('node:fs')
+
+    // Resolve the agent's channel state_dir (where its bot .env lives).
+    const stateDir = join(homedir(), '.claude', 'channels', 'telegram')
+    // For sub-agents the channel dir may differ; fall back to the global one.
+    const agentChannelDir = join(homedir(), '.claude', 'channels', 'telegram')
+    const candidateDirs = [
+      join(homedir(), '.claude', 'channels', `telegram-${agentId}`),
+      agentChannelDir,
+    ]
+    const resolvedDir = candidateDirs.find((d) => existsSync(join(d, '.env'))) ?? stateDir
+
+    const { readFileSync: rfs } = await import('node:fs')
+    const tokenFile = join(resolvedDir, '.env')
+    if (!existsSync(tokenFile)) return null
+
+    // Read dashboard token for the API call
+    const { STORE_DIR } = await import('../config.js')
+    const tokenPath = join(STORE_DIR, '.dashboard-token')
+    if (!existsSync(tokenPath)) return null
+    const dashToken = rfs(tokenPath, 'utf-8').trim()
+
+    const body = JSON.stringify({ file_id: fileId, state_dir: resolvedDir })
+    const resp = await fetch('http://127.0.0.1:3420/api/voice/stt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${dashToken}` },
+      body,
+      signal: AbortSignal.timeout(65_000),
+    })
+    if (!resp.ok) return null
+    const data = await resp.json() as { transcript?: string }
+    return data.transcript ?? null
+  } catch (err) {
+    logger.warn({ err }, 'message-router: callVoiceSTT error')
+    return null
+  }
 }

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -1,6 +1,6 @@
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, STORE_DIR, WEB_PORT } from '../config.js'
-import { buildTtsDirective } from './voice-directive.js'
+import { resolveAgentChannelStateDir } from './voice-directive.js'
 import {
   getPendingMessages,
   markMessageDelivered,
@@ -164,17 +164,12 @@ export function startMessageRouter(): NodeJS.Timeout {
           setLastInboundModality(msg.to_agent, chatId, 'voice')
           if (voiceCfg.responseMode !== 'text') {
             // Attempt STT; on failure fall through to raw voice block.
-            const sttResult = await callVoiceSTT(voiceFileId, msg.to_agent)
-            if (sttResult) {
-              deliveryContent = injectTranscript(msg.content, sttResult.transcript)
+            const transcript = await callVoiceSTT(voiceFileId, msg.to_agent)
+            if (transcript) {
+              deliveryContent = injectTranscript(msg.content, transcript)
               logger.info({ id: msg.id, agent: msg.to_agent }, 'message-router: voice STT applied')
-              // Append ready-to-run TTS directive so the agent replies with voice.
-              const ttsDirective = buildTtsDirective({
-                chatId,
-                stateDir: sttResult.stateDir,
-                voiceModel: voiceCfg.voiceModel ?? 'hu_HU-imre-medium',
-              })
-              if (ttsDirective) deliveryContent += ttsDirective
+              // TTS directive is injected by the UserPromptSubmit hook (voice-reply-directive.py)
+              // which fires on every delivery path, not just coordinator-relay.
             } else {
               logger.warn({ id: msg.id, agent: msg.to_agent }, 'message-router: STT failed, delivering raw voice block')
             }
@@ -254,34 +249,21 @@ function injectTranscript(content: string, transcript: string): string {
 }
 
 // Call the dashboard /api/voice/stt endpoint (localhost, same process).
-// Returns { transcript, stateDir } on success, null on failure.
-async function callVoiceSTT(
-  fileId: string,
-  agentId: string,
-): Promise<{ transcript: string; stateDir: string } | null> {
+// Returns the transcript string on success, null on failure.
+async function callVoiceSTT(fileId: string, agentId: string): Promise<string | null> {
   try {
-    const { homedir } = await import('node:os')
-    const { join } = await import('node:path')
     const { readFileSync, existsSync } = await import('node:fs')
+    const { join } = await import('node:path')
 
-    // Resolve the agent's channel state_dir (where its bot .env lives).
-    const stateDir = join(homedir(), '.claude', 'channels', 'telegram')
-    // For sub-agents the channel dir may differ; fall back to the global one.
-    const agentChannelDir = join(homedir(), '.claude', 'channels', 'telegram')
-    const candidateDirs = [
-      join(homedir(), '.claude', 'channels', `telegram-${agentId}`),
-      agentChannelDir,
-    ]
-    const resolvedDir = candidateDirs.find((d) => existsSync(join(d, '.env'))) ?? stateDir
+    // Resolve the agent's channel state_dir using the canonical helper so
+    // sub-agents (whose .env lives under AGENTS_BASE_DIR) are found correctly.
+    const resolvedDir = resolveAgentChannelStateDir(agentId, 'telegram')
 
-    const { readFileSync: rfs } = await import('node:fs')
-    const tokenFile = join(resolvedDir, '.env')
-    if (!existsSync(tokenFile)) return null
+    if (!existsSync(join(resolvedDir, '.env'))) return null
 
-    // Read dashboard token for the API call
     const tokenPath = join(STORE_DIR, '.dashboard-token')
     if (!existsSync(tokenPath)) return null
-    const dashToken = rfs(tokenPath, 'utf-8').trim()
+    const dashToken = readFileSync(tokenPath, 'utf-8').trim()
 
     const body = JSON.stringify({ file_id: fileId, state_dir: resolvedDir })
     const resp = await fetch(`http://127.0.0.1:${WEB_PORT}/api/voice/stt`, {
@@ -292,8 +274,7 @@ async function callVoiceSTT(
     })
     if (!resp.ok) return null
     const data = await resp.json() as { transcript?: string }
-    if (!data.transcript) return null
-    return { transcript: data.transcript, stateDir: resolvedDir }
+    return data.transcript ?? null
   } catch (err) {
     logger.warn({ err }, 'message-router: callVoiceSTT error')
     return null

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -31,6 +31,9 @@ import {
   readAgentRemoteConfig,
   readAgentRemoteHost,
   writeAgentRemoteConfig,
+  readAgentVoiceConfig,
+  writeAgentVoiceConfig,
+  KNOWN_VOICE_MODELS,
   type AuthMode,
 } from '../agent-config.js'
 import {
@@ -1506,6 +1509,36 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     rmSync(dir, { recursive: true, force: true })
     cleanupTeamReferences(name)
     json(res, { ok: true })
+    return true
+  }
+
+  // GET /api/agents/:name/voice-config
+  const voiceConfigMatch = path.match(/^\/api\/agents\/([^/]+)\/voice-config$/)
+  if (voiceConfigMatch && method === 'GET') {
+    const name = decodeURIComponent(voiceConfigMatch[1])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    json(res, { ...readAgentVoiceConfig(name), availableVoices: Array.from(KNOWN_VOICE_MODELS) })
+    return true
+  }
+
+  // PUT /api/agents/:name/voice-config
+  // Body: { responseMode?: 'text'|'voice'|'auto', voiceModel?: string }
+  if (voiceConfigMatch && method === 'PUT') {
+    const name = decodeURIComponent(voiceConfigMatch[1])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    const body = await readBody(req)
+    let data: { responseMode?: string; voiceModel?: string }
+    try { data = JSON.parse(body.toString()) } catch { json(res, { error: 'invalid JSON' }, 400); return true }
+    try {
+      writeAgentVoiceConfig(name, {
+        responseMode: data.responseMode as 'text' | 'voice' | 'auto' | undefined,
+        voiceModel: data.voiceModel,
+      })
+    } catch (err: unknown) {
+      json(res, { error: err instanceof Error ? err.message : 'invalid config' }, 400)
+      return true
+    }
+    json(res, { ok: true, ...readAgentVoiceConfig(name) })
     return true
   }
 

--- a/src/web/routes/static.ts
+++ b/src/web/routes/static.ts
@@ -1,12 +1,51 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { serveFile } from '../http-helpers.js'
+import { MIME } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
+
+// Returns a short version token derived from app.js mtime+size so the
+// script URL changes whenever the file changes, busting browser cache.
+function appJsVersion(webDir: string): string {
+  try {
+    const s = statSync(join(webDir, 'app.js'))
+    return `${s.mtimeMs.toString(36)}-${s.size.toString(36)}`
+  } catch {
+    return '0'
+  }
+}
+
+function serveIndexHtml(ctx: RouteContext, webDir: string): void {
+  const { req, res } = ctx
+  try {
+    const filePath = join(webDir, 'index.html')
+    const s = statSync(filePath)
+    const etag = `"${s.mtimeMs}-${s.size}-${appJsVersion(webDir)}"`
+    const ifNoneMatch = req.headers['if-none-match']
+    if (ifNoneMatch === etag) {
+      res.writeHead(304, { ETag: etag, 'Cache-Control': 'no-cache' })
+      res.end()
+      return
+    }
+    const html = readFileSync(filePath, 'utf-8').replace(
+      /(<script\s+src=")\/app\.js(")/,
+      `$1/app.js?v=${appJsVersion(webDir)}$2`,
+    )
+    res.writeHead(200, {
+      'Content-Type': MIME['.html'],
+      ETag: etag,
+      'Cache-Control': 'no-cache',
+    })
+    res.end(html)
+  } catch {
+    res.writeHead(404); res.end('Not found')
+  }
+}
 
 export async function tryHandleStatic(ctx: RouteContext, webDir: string): Promise<boolean> {
   const { req, res, path } = ctx
 
-  if (path === '/' || path === '/index.html') { serveFile(req, res, join(webDir, 'index.html')); return true }
+  if (path === '/' || path === '/index.html') { serveIndexHtml(ctx, webDir); return true }
   if (path === '/style.css') { serveFile(req, res, join(webDir, 'style.css')); return true }
   if (path === '/app.js') { serveFile(req, res, join(webDir, 'app.js')); return true }
   if (path === '/manifest.json') { serveFile(req, res, join(webDir, 'manifest.json')); return true }

--- a/src/web/routes/voice.ts
+++ b/src/web/routes/voice.ts
@@ -5,6 +5,7 @@
 // TTS: POST /api/voice/tts     -- synthesize text to ogg/opus, send via Telegram sendVoice
 // Config: GET/PUT /api/agents/:id/voice-config  (handled in agents.ts; see there)
 // Modality: GET /api/voice/modality?agent=X&chat=Y
+//           POST /api/voice/modality/set -- set last inbound modality (called by channel plugin)
 //
 // Security:
 //   - voiceModel is whitelisted against KNOWN_VOICE_MODELS (no path traversal)
@@ -18,8 +19,8 @@ import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
-import { KNOWN_VOICE_MODELS } from '../agent-config.js'
-import { getLastInboundModality } from '../voice-modality.js'
+import { KNOWN_VOICE_MODELS, AGENTS_BASE_DIR } from '../agent-config.js'
+import { getLastInboundModality, setLastInboundModality } from '../voice-modality.js'
 import { PROJECT_ROOT } from '../../config.js'
 import type { RouteContext } from './types.js'
 
@@ -34,10 +35,19 @@ const SAFE_FILE_ID_RE = /^[A-Za-z0-9_\-]{10,200}$/
 // The channel plugin stores its .env (bot token) here.
 const CHANNELS_BASE = join(homedir(), '.claude', 'channels')
 
+// Safe paths: ~/.claude/channels/<provider>/  OR  <AGENTS_BASE_DIR>/<name>/.claude/channels/<provider>/
+// Both must contain a .env file. '..' traversal always rejected.
 function isSafeStateDir(dir: string): boolean {
-  // Must be under ~/.claude/channels/ and must contain a .env file.
   const resolved = dir.replace(/\/$/, '')
-  return resolved.startsWith(CHANNELS_BASE) && !resolved.includes('..') && existsSync(join(resolved, '.env'))
+  if (resolved.includes('..')) return false
+  if (!existsSync(join(resolved, '.env'))) return false
+  if (resolved.startsWith(CHANNELS_BASE + '/') || resolved === CHANNELS_BASE) return true
+  if (resolved.startsWith(AGENTS_BASE_DIR + '/')) {
+    // Must match: <AGENTS_BASE_DIR>/<agentName>/.claude/channels/<provider>
+    const rel = resolved.slice(AGENTS_BASE_DIR.length + 1)
+    return /^[a-zA-Z0-9_-]+\/\.claude\/channels\/[a-zA-Z0-9_-]+$/.test(rel)
+  }
+  return false
 }
 
 function voiceOnnxPath(model: string): string | null {
@@ -86,6 +96,25 @@ export async function tryHandleVoice(ctx: RouteContext): Promise<boolean> {
     if (!agentId || !chatId) { json(res, { error: 'agent and chat required' }, 400); return true }
     const modality = getLastInboundModality(agentId, chatId)
     json(res, { modality })
+    return true
+  }
+
+  // POST /api/voice/modality/set
+  // Body: { agent_id: string, chat_id: string, modality: 'voice'|'text' }
+  // TODO: currently unused -- message-router sets modality in-process via setLastInboundModality().
+  // Kept for future use if a channel plugin fork needs to set modality over HTTP.
+  if (path === '/api/voice/modality/set' && method === 'POST') {
+    const body = await readBody(req)
+    let data: { agent_id?: string; chat_id?: string; modality?: string }
+    try { data = JSON.parse(body.toString()) as typeof data } catch { json(res, { error: 'Invalid JSON' }, 400); return true }
+    const agentId = data.agent_id?.trim() ?? ''
+    const chatId = data.chat_id?.trim() ?? ''
+    const modality = data.modality?.trim() ?? ''
+    if (!agentId || !/^[a-zA-Z0-9_-]+$/.test(agentId)) { json(res, { error: 'Invalid agent_id' }, 400); return true }
+    if (!chatId || !/^\d+$/.test(chatId)) { json(res, { error: 'Invalid chat_id' }, 400); return true }
+    if (modality !== 'voice' && modality !== 'text') { json(res, { error: 'modality must be voice or text' }, 400); return true }
+    setLastInboundModality(agentId, chatId, modality as 'voice' | 'text')
+    json(res, { ok: true })
     return true
   }
 

--- a/src/web/routes/voice.ts
+++ b/src/web/routes/voice.ts
@@ -90,20 +90,34 @@ let _installInProgress = false
 export async function tryHandleVoice(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
 
-  // GET /api/voice/directive?agent=X&chat=Y
-  // Returns the pre-filled TTS curl directive string for the UserPromptSubmit hook.
-  // Resolves state_dir (sub-agent aware) and voiceModel from the agent's voice-config.
-  // Returns { directive: string|null } -- null if responseMode===text or token missing.
+  // GET /api/voice/directive?agent=X&chat=Y[&file=FILE_ID]
+  // Returns { directive: string|null, transcript: string|null }.
+  // directive: pre-filled TTS curl string for the UserPromptSubmit hook (null if text mode).
+  // transcript: STT result if `file` (Telegram attachment_file_id) is provided and valid.
+  // fail-safe: STT errors set transcript=null; directive is always attempted independently.
   if (path === '/api/voice/directive' && method === 'GET') {
     const agentId = ctx.url.searchParams.get('agent') ?? ''
     const chatId = ctx.url.searchParams.get('chat') ?? ''
+    const fileParam = ctx.url.searchParams.get('file') ?? ''
     if (!agentId || !/^[a-zA-Z0-9_-]+$/.test(agentId)) { json(res, { error: 'Invalid agent' }, 400); return true }
     if (!chatId || !/^\d+$/.test(chatId)) { json(res, { error: 'Invalid chat_id' }, 400); return true }
     const voiceCfg = readAgentVoiceConfig(agentId)
-    if (voiceCfg.responseMode === 'text') { json(res, { directive: null }); return true }
     const stateDir = resolveAgentChannelStateDir(agentId, 'telegram')
-    const directive = buildTtsDirective({ chatId, stateDir, voiceModel: voiceCfg.voiceModel ?? 'hu_HU-imre-medium' })
-    json(res, { directive })
+    const directive = voiceCfg.responseMode === 'text'
+      ? null
+      : buildTtsDirective({ chatId, stateDir, voiceModel: voiceCfg.voiceModel ?? 'hu_HU-imre-medium' })
+
+    let transcript: string | null = null
+    if (fileParam && SAFE_FILE_ID_RE.test(fileParam) && isVoiceInstalled()) {
+      const sttResult = await runProc(VENV_PY, [VTOOLS_PY, 'transcribe', fileParam, stateDir], { timeoutMs: 60_000 })
+      if (sttResult.code === 0) {
+        transcript = sttResult.stdout.trim() || null
+      } else {
+        logger.warn({ fileParam, stderr: sttResult.stderr }, '/api/voice/directive: STT failed (non-fatal)')
+      }
+    }
+
+    json(res, { directive, transcript })
     return true
   }
 

--- a/src/web/routes/voice.ts
+++ b/src/web/routes/voice.ts
@@ -1,0 +1,229 @@
+// /api/voice/* -- central STT and TTS service for the agent fleet.
+//
+// All endpoints require Bearer auth (enforced by src/web.ts before routing).
+// STT: POST /api/voice/stt     -- transcribe a Telegram voice file_id
+// TTS: POST /api/voice/tts     -- synthesize text to ogg/opus, send via Telegram sendVoice
+// Config: GET/PUT /api/agents/:id/voice-config  (handled in agents.ts; see there)
+// Modality: GET /api/voice/modality?agent=X&chat=Y
+//
+// Security:
+//   - voiceModel is whitelisted against KNOWN_VOICE_MODELS (no path traversal)
+//   - spawn uses arg-array, shell:false (no shell injection)
+//   - file_id validated to Telegram's safe character set before use
+//   - state_dir resolved only to known agent channel dirs, never raw user paths
+
+import { spawn } from 'node:child_process'
+import { join } from 'node:path'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { logger } from '../../logger.js'
+import { readBody, json } from '../http-helpers.js'
+import { KNOWN_VOICE_MODELS } from '../agent-config.js'
+import { getLastInboundModality } from '../voice-modality.js'
+import { PROJECT_ROOT } from '../../config.js'
+import type { RouteContext } from './types.js'
+
+const VOICE_DIR = join(homedir(), '.local', 'share', 'atlas-whisper')
+const VTOOLS_PY = join(VOICE_DIR, '_vtools.py')
+const VENV_PY = join(VOICE_DIR, 'venv', 'bin', 'python')
+
+// Telegram file_ids are base64url + some punctuation; reject anything else.
+const SAFE_FILE_ID_RE = /^[A-Za-z0-9_\-]{10,200}$/
+
+// Known agent channel dirs -- only these are accepted as state_dir.
+// The channel plugin stores its .env (bot token) here.
+const CHANNELS_BASE = join(homedir(), '.claude', 'channels')
+
+function isSafeStateDir(dir: string): boolean {
+  // Must be under ~/.claude/channels/ and must contain a .env file.
+  const resolved = dir.replace(/\/$/, '')
+  return resolved.startsWith(CHANNELS_BASE) && !resolved.includes('..') && existsSync(join(resolved, '.env'))
+}
+
+function voiceOnnxPath(model: string): string | null {
+  if (!KNOWN_VOICE_MODELS.has(model)) return null
+  const p = join(VOICE_DIR, 'voices', `${model}.onnx`)
+  return existsSync(p) ? p : null
+}
+
+function isVoiceInstalled(): boolean {
+  return existsSync(VENV_PY) && existsSync(VTOOLS_PY)
+}
+
+function runProc(
+  cmd: string,
+  args: string[],
+  opts: { stdinData?: string; timeoutMs?: number } = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve) => {
+    const proc = spawn(cmd, args, { shell: false })
+    let stdout = ''
+    let stderr = ''
+    const timer = opts.timeoutMs
+      ? setTimeout(() => { proc.kill('SIGKILL') }, opts.timeoutMs)
+      : null
+    proc.stdout.on('data', (d: Buffer) => { stdout += d.toString() })
+    proc.stderr.on('data', (d: Buffer) => { stderr += d.toString() })
+    if (opts.stdinData != null) { proc.stdin.write(opts.stdinData, 'utf-8'); proc.stdin.end() }
+    proc.on('close', (code) => {
+      if (timer) clearTimeout(timer)
+      resolve({ stdout, stderr, code: code ?? 1 })
+    })
+  })
+}
+
+// Concurrency guard: prevents parallel installs racing on the same venv/DEST.
+let _installInProgress = false
+
+export async function tryHandleVoice(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  // GET /api/voice/modality?agent=X&chat=Y
+  // Returns the last inbound modality for this agent+chat (for the channel plugin).
+  if (path === '/api/voice/modality' && method === 'GET') {
+    const agentId = ctx.url.searchParams.get('agent') ?? ''
+    const chatId = ctx.url.searchParams.get('chat') ?? ''
+    if (!agentId || !chatId) { json(res, { error: 'agent and chat required' }, 400); return true }
+    const modality = getLastInboundModality(agentId, chatId)
+    json(res, { modality })
+    return true
+  }
+
+  // GET /api/voice/status -- is the voice toolkit installed?
+  if (path === '/api/voice/status' && method === 'GET') {
+    const installed = isVoiceInstalled()
+    const voices = installed
+      ? Array.from(KNOWN_VOICE_MODELS).filter((m) => existsSync(join(VOICE_DIR, 'voices', `${m}.onnx`)))
+      : []
+    json(res, { installed, voices, voiceDir: VOICE_DIR })
+    return true
+  }
+
+  // POST /api/voice/stt
+  // Body: { file_id: string, state_dir: string }
+  // Returns: { transcript: string }
+  if (path === '/api/voice/stt' && method === 'POST') {
+    if (!isVoiceInstalled()) { json(res, { error: 'Voice toolkit not installed' }, 503); return true }
+    const body = await readBody(req)
+    let data: { file_id?: string; state_dir?: string }
+    try { data = JSON.parse(body.toString()) as typeof data } catch { json(res, { error: 'Invalid JSON' }, 400); return true }
+    const fileId = data.file_id?.trim() ?? ''
+    const stateDir = data.state_dir?.trim() ?? ''
+    if (!SAFE_FILE_ID_RE.test(fileId)) { json(res, { error: 'Invalid file_id' }, 400); return true }
+    if (!isSafeStateDir(stateDir)) { json(res, { error: 'Invalid state_dir' }, 400); return true }
+
+    const result = await runProc(
+      VENV_PY,
+      [VTOOLS_PY, 'transcribe', fileId, stateDir],
+      { timeoutMs: 60_000 },
+    )
+    if (result.code !== 0) {
+      logger.warn({ fileId, stderr: result.stderr }, '/api/voice/stt: whisper failed')
+      json(res, { error: 'STT failed', detail: result.stderr.slice(0, 200) }, 500)
+      return true
+    }
+    json(res, { transcript: result.stdout.trim() })
+    return true
+  }
+
+  // POST /api/voice/tts
+  // Body: { text: string, voice_model: string, chat_id: string, state_dir: string }
+  // Returns: { ok: boolean, message_id?: number }
+  if (path === '/api/voice/tts' && method === 'POST') {
+    if (!isVoiceInstalled()) { json(res, { error: 'Voice toolkit not installed' }, 503); return true }
+    const body = await readBody(req)
+    let data: { text?: string; voice_model?: string; chat_id?: string | number; state_dir?: string }
+    try { data = JSON.parse(body.toString()) as typeof data } catch { json(res, { error: 'Invalid JSON' }, 400); return true }
+    const text = data.text?.trim() ?? ''
+    const voiceModel = data.voice_model?.trim() ?? 'hu_HU-imre-medium'
+    const chatId = String(data.chat_id ?? '').trim()
+    const stateDir = data.state_dir?.trim() ?? ''
+
+    if (!text) { json(res, { error: 'text required' }, 400); return true }
+    if (!/^\d+$/.test(chatId)) { json(res, { error: 'Invalid chat_id' }, 400); return true }
+    if (!isSafeStateDir(stateDir)) { json(res, { error: 'Invalid state_dir' }, 400); return true }
+
+    const onnxPath = voiceOnnxPath(voiceModel)
+    if (!onnxPath) {
+      json(res, { error: `Unknown or missing voice model: ${voiceModel}` }, 400)
+      return true
+    }
+
+    const result = await runProc(
+      VENV_PY,
+      [VTOOLS_PY, 'speak', onnxPath, stateDir, chatId, text],
+      { timeoutMs: 90_000 },
+    )
+    if (result.code !== 0) {
+      logger.warn({ voiceModel, chatId, stderr: result.stderr }, '/api/voice/tts: piper/sendVoice failed')
+      json(res, { error: 'TTS failed', detail: result.stderr.slice(0, 200) }, 500)
+      return true
+    }
+    // _vtools.py prints "ok=True id=12345" or "ok=False id=None"
+    const okMatch = result.stdout.match(/ok=(\w+)/)
+    const idMatch = result.stdout.match(/id=(\d+)/)
+    json(res, {
+      ok: okMatch?.[1]?.toLowerCase() === 'true',
+      message_id: idMatch ? parseInt(idMatch[1], 10) : null,
+    })
+    return true
+  }
+
+  // POST /api/voice/install
+  // Checks system dependencies (ffmpeg + python3-venv). If missing: returns
+  // { needsSudo: true, sudoCommand } so the user can run it manually. If deps
+  // are present, spawns install-voice.sh with SKIP_SYSTEM_DEPS=1 (no root
+  // needed) and returns immediately; the client polls /api/voice/status.
+  if (path === '/api/voice/install' && method === 'POST') {
+    if (isVoiceInstalled()) {
+      json(res, { ok: true, alreadyInstalled: true })
+      return true
+    }
+
+    // Check system deps without root
+    const depCheck = await runProc('bash', ['-c',
+      'command -v ffmpeg >/dev/null 2>&1' +
+      ' && ffmpeg -encoders 2>&1 | grep -q libopus' +
+      ' && python3 -m venv --help >/dev/null 2>&1' +
+      ' && echo OK || echo MISSING',
+    ], { timeoutMs: 8000 })
+    const depsMissing = !depCheck.stdout.trim().endsWith('OK')
+
+    if (depsMissing) {
+      json(res, {
+        needsSudo: true,
+        sudoCommand: 'sudo apt-get install -y --no-install-recommends ffmpeg python3-venv python3',
+      })
+      return true
+    }
+
+    if (_installInProgress) {
+      json(res, { ok: true, started: true, alreadyRunning: true })
+      return true
+    }
+
+    // Deps present -- fire-and-forget the install (no root needed from here).
+    // detached:true + unref() keeps the child alive even if the dashboard
+    // restarts mid-install (pip + ~126 MB download can take several minutes).
+    _installInProgress = true
+    const scriptPath = join(PROJECT_ROOT, 'scripts', 'install-voice.sh')
+    const child = spawn('bash', [scriptPath], {
+      shell: false,
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env, SKIP_SYSTEM_DEPS: '1' },
+    })
+    child.unref()
+    child.on('error', (err) => { _installInProgress = false; logger.warn({ err }, '/api/voice/install: spawn error') })
+    child.on('close', (code) => {
+      _installInProgress = false
+      if (code !== 0) logger.warn({ code }, '/api/voice/install: install-voice.sh exited non-zero')
+      else logger.info('/api/voice/install: install-voice.sh completed successfully')
+    })
+
+    json(res, { ok: true, started: true })
+    return true
+  }
+
+  return false
+}

--- a/src/web/routes/voice.ts
+++ b/src/web/routes/voice.ts
@@ -92,8 +92,12 @@ export async function tryHandleVoice(ctx: RouteContext): Promise<boolean> {
 
   // GET /api/voice/directive?agent=X&chat=Y[&file=FILE_ID]
   // Returns { directive: string|null, transcript: string|null }.
-  // directive: pre-filled TTS curl string for the UserPromptSubmit hook (null if text mode).
-  // transcript: STT result if `file` (Telegram attachment_file_id) is provided and valid.
+  // directive semantics by responseMode:
+  //   text  -> null (never speaks)
+  //   voice -> always buildTtsDirective (speaks even for plain-text input)
+  //   auto  -> buildTtsDirective only when a voice file_id is present (speaks only if user sent audio)
+  // transcript: STT result when `file` is provided and valid (mode-independent -- even text-mode
+  //   agents can benefit from knowing what a voice message said).
   // fail-safe: STT errors set transcript=null; directive is always attempted independently.
   if (path === '/api/voice/directive' && method === 'GET') {
     const agentId = ctx.url.searchParams.get('agent') ?? ''
@@ -103,9 +107,12 @@ export async function tryHandleVoice(ctx: RouteContext): Promise<boolean> {
     if (!chatId || !/^\d+$/.test(chatId)) { json(res, { error: 'Invalid chat_id' }, 400); return true }
     const voiceCfg = readAgentVoiceConfig(agentId)
     const stateDir = resolveAgentChannelStateDir(agentId, 'telegram')
-    const directive = voiceCfg.responseMode === 'text'
-      ? null
-      : buildTtsDirective({ chatId, stateDir, voiceModel: voiceCfg.voiceModel ?? 'hu_HU-imre-medium' })
+    const fileIsVoice = !!fileParam && SAFE_FILE_ID_RE.test(fileParam)
+    const ttsParams = { chatId, stateDir, voiceModel: voiceCfg.voiceModel ?? 'hu_HU-imre-medium' }
+    const directive = voiceCfg.responseMode === 'text' ? null
+      : voiceCfg.responseMode === 'voice' ? buildTtsDirective(ttsParams)
+      : fileIsVoice ? buildTtsDirective(ttsParams)  // auto: only when inbound was audio
+      : null
 
     let transcript: string | null = null
     if (fileParam && SAFE_FILE_ID_RE.test(fileParam) && isVoiceInstalled()) {

--- a/src/web/routes/voice.ts
+++ b/src/web/routes/voice.ts
@@ -26,7 +26,7 @@ import { buildTtsDirective, resolveAgentChannelStateDir } from '../voice-directi
 import { PROJECT_ROOT } from '../../config.js'
 import type { RouteContext } from './types.js'
 
-const VOICE_DIR = join(homedir(), '.local', 'share', 'atlas-whisper')
+const VOICE_DIR = join(homedir(), '.local', 'share', 'marveen-voice')
 const VTOOLS_PY = join(VOICE_DIR, '_vtools.py')
 const VENV_PY = join(VOICE_DIR, 'venv', 'bin', 'python')
 

--- a/src/web/routes/voice.ts
+++ b/src/web/routes/voice.ts
@@ -5,7 +5,8 @@
 // TTS: POST /api/voice/tts     -- synthesize text to ogg/opus, send via Telegram sendVoice
 // Config: GET/PUT /api/agents/:id/voice-config  (handled in agents.ts; see there)
 // Modality: GET /api/voice/modality?agent=X&chat=Y
-//           POST /api/voice/modality/set -- set last inbound modality (called by channel plugin)
+//           POST /api/voice/modality/set -- set last inbound modality (future plugin hook use)
+// Directive: GET /api/voice/directive?agent=X&chat=Y  -- TTS curl string for UserPromptSubmit hook
 //
 // Security:
 //   - voiceModel is whitelisted against KNOWN_VOICE_MODELS (no path traversal)
@@ -19,8 +20,9 @@ import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
-import { KNOWN_VOICE_MODELS, AGENTS_BASE_DIR } from '../agent-config.js'
+import { KNOWN_VOICE_MODELS, AGENTS_BASE_DIR, readAgentVoiceConfig } from '../agent-config.js'
 import { getLastInboundModality, setLastInboundModality } from '../voice-modality.js'
+import { buildTtsDirective, resolveAgentChannelStateDir } from '../voice-directive.js'
 import { PROJECT_ROOT } from '../../config.js'
 import type { RouteContext } from './types.js'
 
@@ -87,6 +89,23 @@ let _installInProgress = false
 
 export async function tryHandleVoice(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
+
+  // GET /api/voice/directive?agent=X&chat=Y
+  // Returns the pre-filled TTS curl directive string for the UserPromptSubmit hook.
+  // Resolves state_dir (sub-agent aware) and voiceModel from the agent's voice-config.
+  // Returns { directive: string|null } -- null if responseMode===text or token missing.
+  if (path === '/api/voice/directive' && method === 'GET') {
+    const agentId = ctx.url.searchParams.get('agent') ?? ''
+    const chatId = ctx.url.searchParams.get('chat') ?? ''
+    if (!agentId || !/^[a-zA-Z0-9_-]+$/.test(agentId)) { json(res, { error: 'Invalid agent' }, 400); return true }
+    if (!chatId || !/^\d+$/.test(chatId)) { json(res, { error: 'Invalid chat_id' }, 400); return true }
+    const voiceCfg = readAgentVoiceConfig(agentId)
+    if (voiceCfg.responseMode === 'text') { json(res, { directive: null }); return true }
+    const stateDir = resolveAgentChannelStateDir(agentId, 'telegram')
+    const directive = buildTtsDirective({ chatId, stateDir, voiceModel: voiceCfg.voiceModel ?? 'hu_HU-imre-medium' })
+    json(res, { directive })
+    return true
+  }
 
   // GET /api/voice/modality?agent=X&chat=Y
   // Returns the last inbound modality for this agent+chat (for the channel plugin).

--- a/src/web/voice-directive.ts
+++ b/src/web/voice-directive.ts
@@ -1,0 +1,31 @@
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { STORE_DIR, WEB_PORT } from '../config.js'
+
+// Build a ready-to-run TTS directive block injected after the STT transcript.
+// Returns null if the dashboard token cannot be read.
+export function buildTtsDirective(opts: {
+  chatId: string
+  stateDir: string
+  voiceModel: string
+}): string | null {
+  try {
+    const tokenPath = join(STORE_DIR, '.dashboard-token')
+    if (!existsSync(tokenPath)) return null
+    const token = readFileSync(tokenPath, 'utf-8').trim()
+    const { chatId, stateDir, voiceModel } = opts
+    // Escape stateDir for embedding in a jq string argument
+    const escapedStateDir = stateDir.replace(/'/g, "'\\''")
+    return (
+      `\n\n[Hang válasz direktíva]: A fenti hangüzenetre HANGBAN válaszolj. ` +
+      `Amikor megvan a válaszod szövege, futtasd le ezt a parancsot (a szöveget JSON-escape-elve add meg a --arg-ban):\n` +
+      `\`\`\`bash\n` +
+      `jq -n --arg t "A_VÁLASZOD_SZÖVEGE" '{"text":$t,"chat_id":"${chatId}","state_dir":"${escapedStateDir}","voice_model":"${voiceModel}"}' | ` +
+      `curl -s -X POST http://localhost:${WEB_PORT}/api/voice/tts -H "Content-Type: application/json" -H "Authorization: Bearer ${token}" -d @-\n` +
+      `\`\`\`\n` +
+      `Szöveges választ NE küldj -- CSAK a fenti curl-t futtasd le a hangküldéshez.`
+    )
+  } catch {
+    return null
+  }
+}

--- a/src/web/voice-directive.ts
+++ b/src/web/voice-directive.ts
@@ -1,6 +1,22 @@
 import { readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { homedir } from 'node:os'
 import { STORE_DIR, WEB_PORT } from '../config.js'
+import { AGENTS_BASE_DIR } from './agent-config.js'
+
+// Resolve the directory where an agent's channel plugin stores its bot .env.
+// Search order:
+//   1. <AGENTS_BASE_DIR>/<agentId>/.claude/channels/<provider>   (sub-agent own channel)
+//   2. ~/.claude/channels/<provider>-<agentId>                   (alternative naming)
+//   3. ~/.claude/channels/<provider>                             (global fallback / main agent)
+export function resolveAgentChannelStateDir(agentId: string, provider: string): string {
+  const candidates = [
+    join(AGENTS_BASE_DIR, agentId, '.claude', 'channels', provider),
+    join(homedir(), '.claude', 'channels', `${provider}-${agentId}`),
+    join(homedir(), '.claude', 'channels', provider),
+  ]
+  return candidates.find((d) => existsSync(join(d, '.env'))) ?? candidates[candidates.length - 1]
+}
 
 // Build a ready-to-run TTS directive block injected after the STT transcript.
 // Returns null if the dashboard token cannot be read.

--- a/src/web/voice-modality.ts
+++ b/src/web/voice-modality.ts
@@ -1,0 +1,45 @@
+// Transient in-memory store for last-inbound-modality per (agentId, chatId).
+// Used by auto-mode: if the last message to an agent was a voice message,
+// the reply should also be voice. Entries expire after TTL to avoid replying
+// with voice hours after the original request.
+//
+// This is process-local state (intentionally). A restart clears all flags,
+// which is fine: the worst case is a text reply to a stale auto-mode session.
+
+const TTL_MS = 10 * 60 * 1000 // 10 minutes
+
+interface Entry {
+  modality: 'voice' | 'text'
+  ts: number
+}
+
+const store = new Map<string, Entry>()
+
+function key(agentId: string, chatId: string | number): string {
+  return `${agentId}:${chatId}`
+}
+
+export function setLastInboundModality(
+  agentId: string,
+  chatId: string | number,
+  modality: 'voice' | 'text',
+): void {
+  store.set(key(agentId, chatId), { modality, ts: Date.now() })
+}
+
+export function getLastInboundModality(
+  agentId: string,
+  chatId: string | number,
+): 'voice' | 'text' | null {
+  const entry = store.get(key(agentId, chatId))
+  if (!entry) return null
+  if (Date.now() - entry.ts > TTL_MS) {
+    store.delete(key(agentId, chatId))
+    return null
+  }
+  return entry.modality
+}
+
+export function clearLastInboundModality(agentId: string, chatId: string | number): void {
+  store.delete(key(agentId, chatId))
+}

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -34,7 +34,7 @@
           {
             "type": "command",
             "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/voice-reply-directive.py",
-            "timeout": 8
+            "timeout": 60
           }
         ]
       }

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -27,6 +27,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/voice-reply-directive.py",
+            "timeout": 8
+          }
+        ]
+      }
     ]
   }
 }

--- a/web/app.js
+++ b/web/app.js
@@ -2654,6 +2654,7 @@ async function openAgentDetail(agentName) {
   )
   renderTeamEditor(currentAgent, agents)
   updateAuthModeUI(currentAgent.authMode || 'shared', currentAgent.hasApiKey || false)
+  loadVoiceConfig(currentAgent.name)
   document.getElementById('editClaudeMd').value = currentAgent.claudeMd || currentAgent.content || ''
   document.getElementById('editSoulMd').value = currentAgent.soulMd || ''
   document.getElementById('editMcpJson').value = currentAgent.mcpJson || ''
@@ -3292,6 +3293,126 @@ document.getElementById('saveAutoRestartBtn').addEventListener('click', async ()
     if (currentAgent) currentAgent.autoRestart = body.autoRestart
     showToast(t('agents.toast.auto_restart_saved'))
   } catch { showToast(t('common.error_save')) }
+})
+
+// ---- voice config UI -------------------------------------------------------
+
+async function loadVoiceConfig(agentName) {
+  const voiceModelSel = document.getElementById('editAgentVoiceModel')
+  if (!voiceModelSel) return
+  const banner = document.getElementById('voiceNotInstalledBanner')
+  const controls = document.getElementById('voiceInstalledControls')
+  try {
+    // Check toolkit installation first
+    const statusR = await fetch('/api/voice/status')
+    if (!statusR.ok) return
+    const status = await statusR.json()
+
+    if (!status.installed) {
+      if (banner) banner.hidden = false
+      if (controls) controls.hidden = true
+      return
+    }
+    if (banner) banner.hidden = true
+    if (controls) controls.hidden = false
+
+    const r = await fetch(`/api/agents/${encodeURIComponent(agentName)}/voice-config`)
+    if (!r.ok) return
+    const cfg = await r.json()
+    voiceModelSel.innerHTML = (cfg.availableVoices || []).map(v =>
+      `<option value="${v}"${v === cfg.voiceModel ? ' selected' : ''}>${v}</option>`
+    ).join('')
+    const modeInput = document.querySelector(`input[name="voiceResponseMode"][value="${cfg.responseMode || 'text'}"]`)
+    if (modeInput) modeInput.checked = true
+  } catch { /* silent */ }
+}
+
+let _voiceInstallPollTimer = null
+
+document.getElementById('voiceInstallBtn').addEventListener('click', async () => {
+  const btn = document.getElementById('voiceInstallBtn')
+  const sudoHint = document.getElementById('voiceInstallSudoHint')
+  const progress = document.getElementById('voiceInstallProgress')
+
+  if (sudoHint) sudoHint.hidden = true
+  btn.disabled = true
+  btn.textContent = 'Indítás...'
+
+  try {
+    const r = await fetch('/api/voice/install', { method: 'POST' })
+    if (!r.ok) throw new Error(await r.text())
+    const data = await r.json()
+
+    if (data.needsSudo) {
+      // Show sudo command -- user must run it then click again
+      if (sudoHint) {
+        sudoHint.hidden = false
+        sudoHint.innerHTML = 'A rendszercsomagok telepítéséhez futtasd terminálon:<br><code style="display:block;margin-top:4px;word-break:break-all">' + escapeHtml(data.sudoCommand) + '</code><br>Ezután kattints újra a Telepítés gombra.'
+      }
+      btn.disabled = false
+      btn.textContent = 'Telepítés'
+      return
+    }
+
+    if (data.alreadyInstalled) {
+      if (currentAgent) loadVoiceConfig(currentAgent.name)
+      return
+    }
+
+    // Install started -- poll /api/voice/status until installed=true.
+    // Max 4 minutes (80 × 3s); on timeout show a hint and re-enable the button
+    // so the user can retry (the only failure signal from a fire-and-forget spawn).
+    if (progress) progress.hidden = false
+    btn.textContent = 'Telepítés...'
+    clearInterval(_voiceInstallPollTimer)
+    let _voiceInstallPollCount = 0
+    const VOICE_INSTALL_MAX_POLLS = 80 // 80 × 3s = 4 min
+    _voiceInstallPollTimer = setInterval(async () => {
+      _voiceInstallPollCount++
+      try {
+        const sr = await fetch('/api/voice/status')
+        const s = await sr.json()
+        if (s.installed) {
+          clearInterval(_voiceInstallPollTimer)
+          _voiceInstallPollTimer = null
+          if (progress) progress.hidden = true
+          if (currentAgent) loadVoiceConfig(currentAgent.name)
+          return
+        }
+      } catch { /* keep polling */ }
+      if (_voiceInstallPollCount >= VOICE_INSTALL_MAX_POLLS) {
+        clearInterval(_voiceInstallPollTimer)
+        _voiceInstallPollTimer = null
+        if (progress) progress.hidden = true
+        if (sudoHint) {
+          sudoHint.hidden = false
+          sudoHint.textContent = 'A telepítés tovább tart vagy elakadt. Ellenőrizd a dashboard logjait, majd próbáld újra.'
+        }
+        btn.disabled = false
+        btn.textContent = 'Újrapróbálás'
+      }
+    }, 3000)
+  } catch {
+    btn.disabled = false
+    btn.textContent = 'Telepítés'
+    showToast('Hiba a telepítés során')
+  }
+})
+
+document.getElementById('saveVoiceConfigBtn').addEventListener('click', async () => {
+  if (!currentAgent) return
+  const modeEl = document.querySelector('input[name="voiceResponseMode"]:checked')
+  const modelEl = document.getElementById('editAgentVoiceModel')
+  if (!modeEl || !modelEl) return
+  try {
+    const r = await fetch(`/api/agents/${encodeURIComponent(currentAgent.name)}/voice-config`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ responseMode: modeEl.value, voiceModel: modelEl.value }),
+    })
+    if (!r.ok) throw new Error()
+    showToast('Hangbeállítás mentve')
+  } catch { showToast('Hiba a mentés során') }
 })
 
 document.getElementById('saveProfileBtn').addEventListener('click', async () => {

--- a/web/index.html
+++ b/web/index.html
@@ -1855,6 +1855,33 @@
             </div>
             <button class="btn-secondary btn-compact agent-save-section" id="saveAuthModeBtn" style="margin-top:12px" data-i18n="common.btn.save">Mentés</button>
           </div>
+          <div class="form-group" id="voiceConfigGroup">
+            <label>Válaszmód (hang/szöveg)</label>
+            <!-- shown when toolkit is NOT installed -->
+            <div id="voiceNotInstalledBanner" hidden>
+              <p style="margin:8px 0;font-size:13px;color:var(--text-muted);line-height:1.5">A hang funkciók használatához először telepíteni kell a hang-toolkitet, ami a Whisper (beszédfelismerés) és a Piper (beszédszintézis) könyvtárakat tartalmazza.</p>
+              <div id="voiceInstallSudoHint" hidden style="margin:8px 0;padding:8px;background:var(--bg-secondary,#1e1e2e);border-radius:6px;font-size:12px;line-height:1.6"></div>
+              <div id="voiceInstallProgress" hidden style="margin:8px 0;font-size:13px;color:var(--text-muted)"><span class="spinner" style="width:14px;height:14px;display:inline-block;vertical-align:middle;margin-right:6px"></span>Telepítés folyamatban, ez eltarthat pár percig...</div>
+              <button class="btn-secondary btn-compact" id="voiceInstallBtn" style="margin-top:4px">Telepítés</button>
+            </div>
+            <!-- shown when toolkit IS installed -->
+            <div id="voiceInstalledControls" hidden>
+              <div style="display:flex;gap:8px;margin-bottom:10px">
+                <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
+                  <input type="radio" name="voiceResponseMode" value="text"> Szöveg
+                </label>
+                <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
+                  <input type="radio" name="voiceResponseMode" value="voice"> Hang
+                </label>
+                <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
+                  <input type="radio" name="voiceResponseMode" value="auto"> Auto
+                </label>
+              </div>
+              <label for="editAgentVoiceModel" style="font-size:12px;color:var(--text-muted)">Hangmodell</label>
+              <select id="editAgentVoiceModel" style="margin-top:4px"></select>
+              <button class="btn-secondary btn-compact agent-save-section" id="saveVoiceConfigBtn" style="margin-top:10px">Mentés</button>
+            </div>
+          </div>
           <div class="form-group">
             <label for="editAgentProfile" data-i18n="agents.wizard.profile_label">Biztonsági profil</label>
             <select id="editAgentProfile"></select>


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary

**HU:** Végpontok közötti hangüzenetküldést ad a flotta minden ágenséhez. A bejövő Telegram hangüzenetet a szerver oldalon átírja (STT, faster-whisper), és beilleszti az ágens promptjába; az ágens szöveges válaszát natív Telegram hangüzenetté szintetizálja (TTS, Piper), és automatikusan visszaküldi. Minden lokálisan fut, külső API és folyamatos költség nélkül. Részmódok agensenként: `text` / `voice` / `auto`. A fő ágens is teljes jogú voice-citizen.

**EN:** Adds end-to-end voice messaging to every agent in the fleet. Inbound Telegram voice notes are transcribed server-side (STT, faster-whisper) and injected into the agent prompt; the agent's text reply is synthesised into a native Telegram voice note (TTS, Piper) and sent back automatically. Everything runs locally, with no external API and no ongoing cost. Per-agent modes: `text` / `voice` / `auto`. The main agent is a first-class voice citizen too. Full technical detail below.

## Kapcsolódó issue / Related issue

N/A (nincs kapcsolódó upstream issue / no tracked upstream issue).

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram + dashboard); agents communicate without errors. (Plus a clean-room Docker install on Linux, see Testing.)
- [x] Frissítettem a `docs/` mappát. / Updated `docs/`. — Igen. A telepítés a dashboardról egy kattintással megy. / Yes, install is one-click from the dashboard.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (the dashboard token is read from `store/.dashboard-token` at runtime).
- [x] Saját, beszédes nevű branch-ről nyitom (`feat/per-agent-voice`), nem közvetlenül `develop`-ra. / Opened from an own, descriptively named branch (`feat/per-agent-voice`), not directly on `develop`.

---

## Per-agent voice messaging for the marveen fleet

### Summary

Adds end-to-end voice messaging to every agent in the marveen fleet. Inbound Telegram voice messages are transcribed server-side (STT) and injected into the agent prompt; the agent's text reply is synthesised into a native Telegram voice message (TTS) and sent back automatically. Everything runs locally — no external API, no ongoing cost.

---

### Motivation

Agents were text-only. A user sending a voice note got either silence or a text reply, which breaks the conversational UX on mobile. This feature closes that gap while keeping the architecture simple: one hook, one directive endpoint, one TTS endpoint — no per-agent logic required.

---

### What's included

| Commits | Scope |
|---|---|
| Per-agent STT/TTS + installer + dashboard UI | Core infrastructure: `faster-whisper` + `Piper` auto-install, per-agent `voice-config` persistence, dashboard setup page |
| Outbound TTS directive | `voice` and `auto` agents receive a ready-to-run `curl` directive in their prompt; executing it sends a native `sendVoice` to the correct channel |
| Hook-based directive fix | Corrected wrong file path, sub-agent channel resolution, and `voiceModel` propagation in `voice-reply-directive.py` |
| Server-side STT in hook | Transcription now happens inside the hook process, not inside the agent turn — eliminates the Bash/permission prompt that previously interrupted every voice message |
| Correct mode semantics | Pinned the three modes to their intended behaviour: `text` never produces audio, `voice` always does (including for text input), `auto` produces audio only when the inbound message was a voice note |
| Main agent as first-class voice citizen | The main/root agent is now registered in the agent registry with its own voice-config; the hook is wired into the main-session `settings.json`; `agent_id` falls back to the project root when no explicit id is set |

---

### How it works

```
Inbound voice note (Telegram)
  │
  ▼
UserPromptSubmit hook (voice-reply-directive.py)
  ├─ GET /api/voice/directive?agent=<id>&file_id=<...>
  │    ├─ server fetches the OGG from Telegram
  │    ├─ runs faster-whisper → transcript string
  │    └─ returns { transcript, directive_curl }
  ├─ injects "[Hang átirat]: <transcript>" into the prompt
  └─ appends the TTS directive curl to the prompt
        │
        ▼
Agent produces a reply (text)
  │
  ▼
Agent executes directive curl
  └─ POST /api/voice/tts  { text, chat_id, state_dir, voice_model }
       ├─ Piper synthesises WAV → encodes to OGG/Opus (ffmpeg)
       └─ Bot API sendVoice → user receives native voice note
```

Inter-agent messages (no `chat_id`) skip the hook entirely — no TTS is triggered for internal fleet traffic.

---

### Configuration

**Response modes** (per-agent, persistent in `agent-config.json`):

| Mode | Behaviour |
|---|---|
| `text` | Always reply as text, never produce audio |
| `voice` | Always reply as audio, even when the input was text |
| `auto` | Reply as audio only when the inbound message was a voice note |

**Voice model**: any Piper ONNX model installed under `~/.local/share/marveen-voice/voices/`. Defaults to `hu_HU-imre-medium` (male). `hu_HU-anna-medium` (female) is also included. Additional languages/voices can be dropped into the same directory.

**Dashboard**: `http://localhost:3420` → agent detail page → Voice tab. Provides mode selector, model selector, and a test-playback button.

**REST API**:
```
GET  /api/agents/:id/voice-config
PUT  /api/agents/:id/voice-config   { responseMode, voiceModel }
POST /api/voice/tts                 { text, chat_id, state_dir, voice_model }
GET  /api/voice/directive           ?agent=&file_id=  (hook use only)
```

---

### Dashboard UI

The voice settings live on each agent's detail page in the dashboard. The UI is shown in Hungarian (the dashboard's locale); captions below describe each state.

**First run — toolkit not yet installed.** The page explains that voice needs the toolkit (Whisper for STT, Piper for TTS) and offers a one-click install:

![Voice tab before install — install button](https://raw.githubusercontent.com/nortops/marveen/media/voice-ui/docs/voice/voice-config-install.jpg)

**After install — configured.** Response-mode selector (Text / Voice / Auto), voice-model dropdown (here `hu_HU-imre-medium`), and Save:

![Voice tab configured — mode and model selectors](https://raw.githubusercontent.com/nortops/marveen/media/voice-ui/docs/voice/voice-config-configured.jpg)

---

### Testing

Tested end-to-end on a live fleet (two agents, one main session):

- Voice note in → transcript injected, no permission prompt fired
- Agent executes directive → `sendVoice` confirmed (`ok: true`)
- `text` mode: directive curl absent from prompt, no audio sent
- `auto` mode: text input → text reply; voice input → voice reply
- `voice` mode: text input → voice reply
- Inter-agent message → no directive injected, no audio

**Clean-room install (Docker, Linux):** the full voice stack was brought up from scratch in fresh Docker containers on Linux — `faster-whisper` + `Piper` + `ffmpeg` and the Hungarian voice model installed via the setup script on a clean image, across three separate containers, with STT and TTS verified working end-to-end. This confirms the installer provisions the stack reproducibly on a bare Linux environment with no pre-existing dependencies.

---

### Notes and limitations

- **Piper is monolingual per model.** The Hungarian models (`hu_HU-*`) apply Hungarian phoneme rules to all input. English technical terms are pronounced with Hungarian letter-to-sound mapping and will sound incorrect. Mitigation: avoid English jargon in TTS strings, or maintain a phonetic substitution dict pre-synthesis.
- **Voice models are not bundled.** The installer downloads them at setup time; they are not checked into the repository.
- **`faster-whisper` `small` model** is accurate for Hungarian but may drop accents on short utterances. The directive endpoint uses `small`; agents that need higher accuracy can switch to `medium` via the API, at the cost of ~3× transcription time.
- **No streaming.** TTS synthesis blocks until the full WAV is ready before encoding and sending. Long responses (>60 s of speech) may hit Telegram's voice-note size limit.