### PR TITLE
fix(install): stamp dist/.built-commit on fresh install (build-marker self-heal parity)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -610,6 +610,19 @@ if ! npm run build --loglevel warn; then
 fi
 ok "TypeScript leforditva"
 
+# Stamp the build-marker after a successful fresh-install build, mirroring the
+# update.sh self-heal (dist/.built-commit records the commit dist was built
+# from). On a build abort, fail()/the ERR-trap exit 1 BEFORE this line, so the
+# marker is only ever written for a complete dist -- it can never falsely
+# report a stale/partial dist as healthy. Stamping it here also keeps a later
+# update.sh run from a needless first-adoption self-healing rebuild (marker ==
+# HEAD on a fresh install). A failed rev-parse just leaves the marker absent,
+# which the update.sh self-heal then handles exactly as before (no regression).
+if [ -d "$INSTALL_DIR/dist" ]; then
+  _built_commit="$(git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null || true)"
+  [ -n "$_built_commit" ] && printf '%s\n' "$_built_commit" > "$INSTALL_DIR/dist/.built-commit"
+fi
+
 mkdir -p "$INSTALL_DIR/store"
 mkdir -p "$INSTALL_DIR/agents"
 ok "Konyvtarak letrehozva"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -383,6 +383,19 @@ if ! npm run build --loglevel warn; then
 fi
 ok "$(_t macos.ts_built)"
 
+# Stamp the build-marker after a successful fresh-install build, mirroring the
+# update.sh self-heal (dist/.built-commit records the commit dist was built
+# from). On a build abort, fail()/the ERR-trap exit 1 BEFORE this line, so the
+# marker is only ever written for a complete dist -- it can never falsely
+# report a stale/partial dist as healthy. Stamping it here also keeps a later
+# update.sh run from a needless first-adoption self-healing rebuild (marker ==
+# HEAD on a fresh install). A failed rev-parse just leaves the marker absent,
+# which the update.sh self-heal then handles exactly as before (no regression).
+if [ -d "$INSTALL_DIR/dist" ]; then
+  _built_commit="$(git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null || true)"
+  [ -n "$_built_commit" ] && printf '%s\n' "$_built_commit" > "$INSTALL_DIR/dist/.built-commit"
+fi
+
 INSTALL_STEP="configuration"
 # Step 6: Configuration
 echo ""


### PR DESCRIPTION
## Mit

A fresh installerek (`install-macos.sh` / `install-linux.sh`) felépítik a `dist/`-et, de **sosem stampelték** a `dist/.built-commit` markert, amire az update.sh v1.12.5 self-heal (b861d51) épül. Ez a PR ezt a paritást zárja le mindkét installerben.

## Miért (root cause kontextus)

Az i18n "nyers kulcs" tünet (nav.overview a menüben) gyökér-oka **stale dist**: git=NEW / dist=OLD, a régi distből hiányzik a v1.12.3-as `/lang/` route → `/lang/hu.js` 404 → `window._i18n` üres → `t(key)` a nyers kulcsra esik. Az update.sh oldali durable fix (build-marker self-heal) már él. Ez a PR a **fresh-install ágat** fedi le, amit az update.sh fix nem ért el.

Két dolgot zár:

- **Defenzív (fő ok):** a fresh build reálisan abortálhat (pl. #440 lock-strict `npm ci`). Az installer `fail()`/ERR-trap `exit 1` **az új stamp-sor ELŐTT**, így a marker **csak teljes diston** íródik ki, és sosem jelenthet hamisan healthy-t egy hiányos diston. Abort esetén a marker hiányzik → egy későbbi update.sh self-heal-el (`DIST_STALE=1`), pontosan mint eddig. **Nincs regresszió.**
- **Idempotencia:** sikeres fresh install után marker == HEAD, így az első későbbi update.sh futás **nem** indít felesleges first-adoption self-healing rebuildet.

## Konzisztencia

A marker értéke/formátuma az update.sh-t tükrözi (`git rev-parse HEAD`, újsorral; az olvasó `$(cat ...)` levágja). Bukott `rev-parse` egyszerűen marker nélkül hagyja a distet (guarded, sosem bukik installt).

## Teszt

- `bash -n` zöld mindkét installeren.
- Funkcionális teszt mindkét ágon: healthy-build → `DIST_STALE=0` (nincs felesleges rebuild); abort-before-stamp → `DIST_STALE=1` (self-heal aktiválódik).

Kártya: a6fbfbdc. Samu jóváhagyta a scope-ot (dev-scope, reális abort-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)