### PR TITLE
feat(kanban): normalize #<hex8> refs to #<seq> on inter-agent message + comment write

### DIFF
--- a/src/__tests__/kanban-ref-normalize.test.ts
+++ b/src/__tests__/kanban-ref-normalize.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeKanbanRefs, type SeqLookup } from '../web/kanban-ref-normalize.js'
+
+// In-memory map mirrors what getKanbanSeqByIdPrefix does against SQLite: a
+// known 8-char id maps to a seq, anything else returns null. Keeps the test
+// hermetic so the DB doesn't get involved.
+function lookupOf(rows: Record<string, number>): SeqLookup {
+  return (idPrefix) => {
+    const v = rows[idPrefix.toLowerCase()]
+    return v == null ? null : v
+  }
+}
+
+describe('normalizeKanbanRefs', () => {
+  it('rewrites a single matching hex reference to #seq', () => {
+    const lookup = lookupOf({ '2ea7f8d9': 75 })
+    expect(normalizeKanbanRefs('See #2ea7f8d9 for context', lookup))
+      .toBe('See #75 for context')
+  })
+
+  it('rewrites multiple references in the same content', () => {
+    const lookup = lookupOf({ '2ea7f8d9': 75, 'cb5080e5': 31 })
+    expect(normalizeKanbanRefs('Bundling #2ea7f8d9 and #cb5080e5 today', lookup))
+      .toBe('Bundling #75 and #31 today')
+  })
+
+  it('preserves the explicit disambiguation pattern `#seq (hex)`', () => {
+    // The "(cb5080e5)" inside parens has no `#` prefix so the regex never
+    // touches it; the `#31` seq token is digits-only so it also doesn't
+    // match. The whole string round-trips untouched.
+    const lookup = lookupOf({ 'cb5080e5': 31 })
+    const input = 'See #31 (cb5080e5) for the right one'
+    expect(normalizeKanbanRefs(input, lookup)).toBe(input)
+  })
+
+  it('leaves a hex token alone when no kanban card matches', () => {
+    const lookup = lookupOf({}) // empty: no card has this id
+    const input = 'commit deadbeef -> #abcdef12 in the diff'
+    expect(normalizeKanbanRefs(input, lookup)).toBe(input)
+  })
+
+  it('does not touch non-kanban `#` patterns (GitHub PRs, issues)', () => {
+    const lookup = lookupOf({ '2ea7f8d9': 75 })
+    // Mixed: PR #308 and issue #42 are too short to match the 8-hex regex;
+    // the real kanban ref still rewrites.
+    expect(normalizeKanbanRefs('Fix #308 lands #2ea7f8d9 (linked to #42)', lookup))
+      .toBe('Fix #308 lands #75 (linked to #42)')
+  })
+
+  it('case-insensitive: an uppercase hex matches a lowercase card id', () => {
+    const lookup = lookupOf({ '2ea7f8d9': 75 })
+    expect(normalizeKanbanRefs('Mixed-case #2EA7F8D9 should still rewrite', lookup))
+      .toBe('Mixed-case #75 should still rewrite')
+  })
+
+  it('does not match longer hex runs (9+ chars stay intact)', () => {
+    // \b after the 8th hex char fails when the next char is also a word
+    // char, so `#2ea7f8d99` (9 hex) does not get partially rewritten.
+    const lookup = lookupOf({ '2ea7f8d9': 75 })
+    const input = 'Long token #2ea7f8d99 should not change'
+    expect(normalizeKanbanRefs(input, lookup)).toBe(input)
+  })
+
+  it('returns the input untouched when content has no `#` at all', () => {
+    const lookup = lookupOf({ '2ea7f8d9': 75 })
+    const input = 'No references in this line, just text.'
+    expect(normalizeKanbanRefs(input, lookup)).toBe(input)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -1244,6 +1244,20 @@ export function getKanbanComments(cardId: string): KanbanComment[] {
   return db.prepare('SELECT * FROM kanban_comments WHERE card_id = ? ORDER BY created_at ASC').all(cardId) as KanbanComment[]
 }
 
+// Lookup a kanban card's `seq` (its sqlite rowid) by the 8-char hex id stored
+// in `kanban_cards.id`. Used by the kanban-ref normalizer to rewrite hex
+// references to the human-facing `#<seq>` form. Returns null when the prefix
+// matches zero rows OR more than one row (ambiguous → leave the message
+// untouched rather than guess). Case-insensitive: breakdown subtask ids are
+// uppercased while createKanbanCard ids stay lowercase.
+export function getKanbanSeqByIdPrefix(prefix: string): number | null {
+  const rows = db.prepare(
+    'SELECT rowid AS seq FROM kanban_cards WHERE id = ? COLLATE NOCASE LIMIT 2'
+  ).all(prefix) as { seq: number }[]
+  if (rows.length !== 1) return null
+  return rows[0].seq
+}
+
 export function addKanbanComment(cardId: string, author: string, content: string): KanbanComment {
   const now = Math.floor(Date.now() / 1000)
   const info = db.prepare(

--- a/src/web/kanban-ref-normalize.ts
+++ b/src/web/kanban-ref-normalize.ts
@@ -1,0 +1,25 @@
+// Rewrites `#<hex8>` kanban-card references inside inter-agent messages and
+// kanban comments to the human-facing `#<seq>` form before the content is
+// persisted. The CLAUDE.md rule "hivatkozz #seq-vel, ne UUID-vel" is agent
+// guidance; this is the code-side enforcement so the dashboard never shows
+// the hex form even if a sub-agent forgets the convention.
+//
+// The matcher is intentionally narrow: only an 8-char `[a-f0-9]` token
+// directly behind a `#` and on a word boundary, lookup-gated against
+// kanban_cards. A non-match (random hex, GitHub PR `#308`, etc.) passes
+// through untouched. The explicit-disambiguation pattern `#31 (cb5080e5)`
+// keeps the seq intact (`#31` doesn't match the hex regex) and the bare
+// `(cb5080e5)` in parens lacks the `#` prefix so it also passes through.
+
+const HEX8_REF_RE = /#([a-f0-9]{8})\b/gi
+
+export type SeqLookup = (idPrefix: string) => number | null
+
+export function normalizeKanbanRefs(content: string, lookup: SeqLookup): string {
+  if (!content || content.indexOf('#') === -1) return content
+  return content.replace(HEX8_REF_RE, (match, hex: string) => {
+    const seq = lookup(hex.toLowerCase())
+    if (seq == null) return match
+    return `#${seq}`
+  })
+}

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -6,11 +6,13 @@ import {
   getKanbanComments, addKanbanComment, listKanbanProjects,
   getKanbanCard, getChildCards, getDb,
   createAgentMessage, markKanbanCardDispatched,
+  getKanbanSeqByIdPrefix,
   listLabels, getLabel, createLabel, updateLabel, deleteLabel,
   addLabelToCard, removeLabelFromCard, getLabelsForAllCards, getLabelsForCard,
   listArchivedKanbanCards,
   revertIdeaFromKanban,
 } from '../../db.js'
+import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
 import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, STORE_DIR, WEB_HOST, WEB_PORT, KANBAN_LABEL_COLORS } from '../../config.js'
 import { listAgentNames, readAgentDisplayName } from '../agent-config.js'
 import { isAgentRunning } from '../agent-process.js'
@@ -262,7 +264,11 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
     const body = await readBody(req)
     const { author, content } = JSON.parse(body.toString())
     if (!author || !content) { json(res, { error: 'Szerző és tartalom kötelező' }, 400); return true }
-    json(res, addKanbanComment(cardId, author, content))
+    // Code-side kanban-ref enforcement: rewrite `#<hex8>` references that map
+    // to a real card into the human-facing `#<seq>` form before persistence
+    // (#75 Cuzcoo dispatch). Random hex / non-matching tokens pass through.
+    const normalizedContent = normalizeKanbanRefs(content, getKanbanSeqByIdPrefix)
+    json(res, addKanbanComment(cardId, author, normalizedContent))
     return true
   }
 

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -1,6 +1,7 @@
 import {
   createAgentMessage, getPendingMessages, listAgentMessages,
   getAgentConversation, getAgentConversationThreads,
+  getKanbanSeqByIdPrefix,
   markMessageDone, markMessageFailed,
   type AgentMessage,
 } from '../../db.js'
@@ -8,6 +9,7 @@ import { logger } from '../../logger.js'
 import { COORDINATOR_AGENT_ID } from '../../channel-coordinator/ingest.js'
 import { sanitizeAgentIdent } from '../../prompt-safety.js'
 import { readBody, json } from '../http-helpers.js'
+import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
 import type { RouteContext } from './types.js'
 
 export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
@@ -40,7 +42,13 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
       json(res, { error: 'from is reserved for the in-process channel coordinator' }, 403)
       return true
     }
-    const msg = createAgentMessage(from.trim(), to.trim(), content.trim())
+    // Code-side enforcement of the kanban-ref convention: rewrite any
+    // `#<hex8>` token that maps to a real kanban_cards row into its
+    // human-facing `#<seq>` form before persistence, so the dashboard and
+    // every downstream consumer sees the canonical reference even when a
+    // sub-agent forgets the CLAUDE.md rule (#75 Cuzcoo dispatch).
+    const normalizedContent = normalizeKanbanRefs(content.trim(), getKanbanSeqByIdPrefix)
+    const msg = createAgentMessage(from.trim(), to.trim(), normalizedContent)
     logger.info({ id: msg.id, from: msg.from_agent, to: msg.to_agent }, 'Agent message created')
     json(res, msg)
     return true


### PR DESCRIPTION
## Problem

The marveen fleet's convention is to reference kanban cards by their human-facing running number (`#75`), not the 8-char hex `id` (`#2ea7f8d9`) — Jocoo only sees the `#NN` form on the dashboard, so a hex reference in a comment or inter-agent message is opaque to him.

The rule lives in CLAUDE.md as agent guidance, but sub-agents occasionally forget it. The latest incident: an agent referenced a ticket by hex despite the rule being in its system prompt. Asking each agent harder doesn't scale.

## Solution

Code-side enforcement at the persistence boundary: every `#[a-f0-9]{8}` token on a word boundary is rewritten to its `#<seq>` form before the row is written to SQLite — both for `POST /api/messages` (inter-agent) and `POST /api/kanban/{id}/comments`. Anything that doesn't resolve to a real `kanban_cards` row (random hex, GitHub PR-style `#308`, ambiguous prefix) passes through untouched.

The agent-side CLAUDE.md guidance stays — code enforcement complements it, not replaces it. Old persisted rows are left as-is; only new writes go through the normalizer.

### Files

- `src/web/kanban-ref-normalize.ts` — pure helper (~25 lines, no DB dep)
- `src/db.ts` — `getKanbanSeqByIdPrefix(prefix)` lookup, returns null on 0-or-many matches so an ambiguous prefix never gets a wrong-seq rewrite
- `src/web/routes/messages.ts` — normalize before `createAgentMessage`
- `src/web/routes/kanban.ts` — normalize before `addKanbanComment`
- `src/__tests__/kanban-ref-normalize.test.ts` — 8 unit tests (DB-mocked)

### Coverage

- single ref → rewrite
- multiple refs in same content → rewrite both
- explicit disambiguation pattern `#31 (cb5080e5)` → untouched (bare hex has no `#` prefix; seq token is digits-only)
- 8-hex token with no matching card → untouched
- mixed content (GitHub PR `#308`, issue `#42`, real kanban hex) → only the kanban hex rewrites
- case-insensitive match (uppercase hex → lowercase card id)
- 9-char hex run → untouched (`\b` blocks the partial match)
- content with no `#` at all → short-circuit return

### Behaviour trade-off

If a future card id collides with a non-card hex string (`#abcdef12` appears as a commit-SHA fragment, but `abcdef12` is also a card id), the helper will rewrite it. That's the deliberate choice: the convention dictates that 8-hex-after-`#` is a kanban reference, and the cost of a stray rewrite of a SHA fragment is much lower than the cost of an unrewritten card ref staying on the dashboard.

## Test plan

- [x] `npx vitest run src/__tests__/kanban-ref-normalize.test.ts` — 8/8 pass
- [x] `npm run build` — green
- [x] Pre-existing test failures (`heartbeat-agent-scaffold.test.ts`, `tests/smoke/dashboard.spec.ts`) confirmed unrelated by stashing the diff and rerunning
- [ ] Live smoke: POST an inter-agent message with a hex UUID after the dashboard restart, confirm DB row contains `#<seq>` (pending Jocoo's restart-confirm in the marveen fleet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)