### PR TITLE
feat(staleness-guard): warn before acting on a stale/late-delivered c…

### DIFF
--- a/scripts/hooks/staleness-guard.py
+++ b/scripts/hooks/staleness-guard.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: staleness guard.
+
+Inbound channel messages carry the ORIGINAL send time on the <channel ... ts="...">
+envelope. When the channel is healthy the gap between send and processing is a few
+seconds. But when the poller lags or a backfill/watchdog re-delivers an orphaned
+message (e.g. after a session restart), a message written much earlier can be
+processed NOW -- and the agent, lacking that context, may execute a stale
+instruction (the 2026-06-24 incident: a delayed "Küldd is el" triggered a client
+email send via a raw API fallback).
+
+This hook compares each inbound <channel> message's `ts` against the current time.
+If the delivery gap exceeds STALENESS_THRESHOLD_SEC (default 300s = 5 min) it emits
+a context note on stdout asking the agent to re-confirm before any irreversible or
+outward-facing action. It NEVER blocks the prompt (always exit 0) and stays silent
+for normal, fresh messages so it adds no noise.
+
+Coverage note: this covers any channel that stamps `ts` on the <channel> envelope
+(Telegram and the other native channel plugins). The marveenchat web UI does not
+currently stamp inbound text with a timestamp, so web-chat inputs are not covered
+here -- that needs the web layer to emit a send time (tracked separately).
+"""
+import sys
+import os
+import re
+import json
+from datetime import datetime, timezone
+
+# Default 5 minutes; override with STALENESS_THRESHOLD_SEC.
+DEFAULT_THRESHOLD_SEC = 300
+
+# <channel source="..." chat_id="X" message_id="Y" ... ts="2026-06-24T05:40:30.000Z"> ... </channel>
+CHANNEL_RX = re.compile(r'<channel\s+([^>]*)>', re.DOTALL)
+
+
+def _attr(attrs, name):
+    m = re.search(name + r'="([^"]*)"', attrs)
+    return m.group(1) if m else None
+
+
+def _parse_ts(ts):
+    """Parse an ISO-8601 UTC timestamp (trailing Z) to an aware datetime, or None."""
+    if not ts:
+        return None
+    try:
+        # Normalise trailing Z to +00:00 for fromisoformat.
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _threshold():
+    raw = os.environ.get("STALENESS_THRESHOLD_SEC")
+    if raw:
+        try:
+            v = int(float(raw))
+            if v > 0:
+                return v
+        except Exception:
+            pass
+    return DEFAULT_THRESHOLD_SEC
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    prompt = payload.get("prompt") or ""
+    if "<channel" not in prompt:
+        sys.exit(0)
+
+    threshold = _threshold()
+    now = datetime.now(timezone.utc)
+
+    # Find the largest delivery gap across all <channel> blocks in this prompt.
+    worst_gap = -1
+    for m in CHANNEL_RX.finditer(prompt):
+        ts = _parse_ts(_attr(m.group(1), "ts"))
+        if ts is None:
+            continue
+        gap = (now - ts).total_seconds()
+        if gap > worst_gap:
+            worst_gap = gap
+
+    if worst_gap < threshold:
+        sys.exit(0)  # fresh enough -> stay silent
+
+    mins = int(worst_gap // 60)
+    # UserPromptSubmit stdout (exit 0) is injected into the model context.
+    print(
+        f"⚠️ FRISSESSEG-FIGYELMEZTETES (staleness guard): a fenti bejovo "
+        f"uzenet kuldese ota mar legalabb ~{mins} perc telt el (a ts mezo alapjan). "
+        f"Ez azt jelenti, hogy az uzenet KESLELTETVE lett kezbesitve (lagolo poller / "
+        f"backfill / ujrakezbesites), ezert LEHET ELAVULT. Mielott barmilyen "
+        f"visszafordithatatlan vagy kimeno muveletet vegrehajtasz (email-kuldes, fajl "
+        f"torles/feluliras, kulso API hivas, fizetes), eloszor ellenorizd hogy a keres "
+        f"meg aktualis-e, es kerdezz vissza a feladonal ha barmi ketseg van. NE "
+        f"hajtsd vegre vakon a kesve erkezett utasitast."
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__tests__/staleness-guard.test.ts
+++ b/src/__tests__/staleness-guard.test.ts
@@ -1,0 +1,89 @@
+// Staleness guard: the 2026-06-24 incident. A delayed/re-delivered "Küldd is el"
+// (orphaned channel message replayed after a session restart) made a sub-agent
+// send a client email via a raw API fallback. The guard warns the agent when an
+// inbound <channel ts="..."> message was delivered long after it was sent so it
+// re-confirms before irreversible/outward actions.
+//
+// Behavioural tests run the python hook as a subprocess (deterministic, no LLM).
+// Static tests lock the wiring (template + scaffold migration + startup call).
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..', '..')
+const HOOK = join(ROOT, 'scripts', 'hooks', 'staleness-guard.py')
+
+function runHook(prompt: string): string {
+  try {
+    return execFileSync('python3', [HOOK], {
+      input: JSON.stringify({ prompt }),
+      encoding: 'utf-8',
+    })
+  } catch {
+    return ''
+  }
+}
+
+function tsAgoMinutes(min: number): string {
+  const d = new Date(Date.now() - min * 60_000)
+  return d.toISOString().replace(/\.\d+Z$/, 'Z')
+}
+
+function channel(ts: string, body = 'Küldd is el'): string {
+  return `<channel source="plugin:telegram:telegram" chat_id="1" message_id="2" ts="${ts}">${body}</channel>`
+}
+
+describe('staleness-guard hook (behavioural)', () => {
+  it('stays silent for a fresh message (well under threshold)', () => {
+    expect(runHook(channel(tsAgoMinutes(0))).trim()).toBe('')
+  })
+
+  it('warns for a message delivered long after it was sent', () => {
+    const out = runHook(channel(tsAgoMinutes(12)))
+    expect(out).toContain('FRISSESSEG-FIGYELMEZTETES')
+    expect(out.toLowerCase()).toContain('elavult')
+  })
+
+  it('stays silent when there is no channel block at all', () => {
+    expect(runHook('sima belso heartbeat szoveg').trim()).toBe('')
+  })
+
+  it('stays silent (never throws) when the channel block has no ts attribute', () => {
+    expect(runHook('<channel source="x" chat_id="1">hello</channel>').trim()).toBe('')
+  })
+
+  it('honours STALENESS_THRESHOLD_SEC override (90s -> 2min message warns)', () => {
+    const out = execFileSync('python3', [HOOK], {
+      input: JSON.stringify({ prompt: channel(tsAgoMinutes(2)) }),
+      encoding: 'utf-8',
+      env: { ...process.env, STALENESS_THRESHOLD_SEC: '90' },
+    })
+    expect(out).toContain('FRISSESSEG-FIGYELMEZTETES')
+  })
+})
+
+describe('staleness-guard wiring (static)', () => {
+  it('is registered as a UserPromptSubmit hook in the settings template', () => {
+    const tpl = readFileSync(join(ROOT, 'templates', 'settings.json.template'), 'utf-8')
+    const parsed = JSON.parse(tpl.replace(/\{\{PROJECT_ROOT\}\}/g, '/ROOT'))
+    const ups = parsed.hooks?.UserPromptSubmit
+    expect(Array.isArray(ups)).toBe(true)
+    expect(JSON.stringify(ups)).toContain('staleness-guard.py')
+  })
+
+  it('ensureAgentStalenessHook merges idempotently (keyed on the script path)', () => {
+    const src = readFileSync(join(ROOT, 'src', 'web', 'agent-scaffold.ts'), 'utf-8')
+    expect(src).toContain('export function ensureAgentStalenessHook')
+    // idempotency guard + non-clobbering merge into existing hooks
+    expect(src).toContain("includes('staleness-guard.py')")
+    expect(src).toContain('hooks.UserPromptSubmit = ups')
+  })
+
+  it('is backfilled into existing agents on startup', () => {
+    const web = readFileSync(join(ROOT, 'src', 'web.ts'), 'utf-8')
+    expect(web).toContain('ensureAgentStalenessHook')
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -8,7 +8,7 @@ import { isBlockedCrossOriginWrite } from './web/csrf-origin.js'
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
 import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
-import { ensureAgentHooks, ensureDefaultScheduledTasks } from './web/agent-scaffold.js'
+import { ensureAgentHooks, ensureAgentStalenessHook, ensureDefaultScheduledTasks } from './web/agent-scaffold.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
 import { startMessageRouter } from './web/message-router.js'
 import { startUpdateChecker } from './web/update-checker.js'
@@ -325,10 +325,13 @@ export function startWebServer(port = 3420): http.Server {
   // agent already has its own hooks block.
   try {
     const patched: string[] = []
+    const stalePatched: string[] = []
     for (const agentName of listAgentNames()) {
       if (ensureAgentHooks(agentName)) patched.push(agentName)
+      if (ensureAgentStalenessHook(agentName)) stalePatched.push(agentName)
     }
     if (patched.length) logger.info({ patched }, 'PreCompact hook backfilled into agent settings.json')
+    if (stalePatched.length) logger.info({ patched: stalePatched }, 'staleness-guard UserPromptSubmit hook backfilled into agent settings.json')
   } catch (err) {
     logger.warn({ err }, 'Agent hook backfill skipped')
   }

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -72,6 +72,37 @@ export function ensureAgentHooks(name: string): boolean {
   return true
 }
 
+// Idempotent migration: ensure the staleness-guard UserPromptSubmit hook is
+// present. Unlike ensureAgentHooks (which seeds the WHOLE hooks block only for
+// hook-less agents), this MERGES a single UserPromptSubmit entry into an agent
+// that already has other hooks -- so the guard reaches the existing fleet, not
+// just freshly-scaffolded agents. The guard warns the agent when an inbound
+// <channel ts="..."> message was delivered long after it was sent (a lagged /
+// re-delivered message that may be stale), so it re-confirms before irreversible
+// actions. Re-running is a no-op once the entry exists (matched by command path).
+const STALENESS_HOOK_CMD = `python3 ${join(PROJECT_ROOT, 'scripts', 'hooks', 'staleness-guard.py')}`
+
+export function ensureAgentStalenessHook(name: string): boolean {
+  const settingsPath = join(agentDir(name), '.claude', 'settings.json')
+  let settings: Record<string, unknown> = {}
+  if (existsSync(settingsPath)) {
+    try { settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { return false }
+  }
+  const hooks = (settings.hooks && typeof settings.hooks === 'object')
+    ? settings.hooks as Record<string, unknown>
+    : {}
+  const ups = Array.isArray(hooks.UserPromptSubmit) ? hooks.UserPromptSubmit as unknown[] : []
+  // Idempotency: already wired if any command entry references the guard script.
+  const already = JSON.stringify(ups).includes('staleness-guard.py')
+  if (already) return false
+  ups.push({ hooks: [{ type: 'command', command: STALENESS_HOOK_CMD, timeout: 10 }] })
+  hooks.UserPromptSubmit = ups
+  settings.hooks = hooks
+  mkdirSync(join(agentDir(name), '.claude'), { recursive: true })
+  atomicWriteFileSync(settingsPath, JSON.stringify(settings, null, 2))
+  return true
+}
+
 export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemplate): void {
   const agentRoot = agentDir(name)
   const settingsDir = join(agentRoot, '.claude')

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -27,6 +27,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/staleness-guard.py",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
…hannel message

Incident (2026-06-24): a sub-agent sent a client email after a delayed "Küldd is el" -- an orphaned channel message re-delivered by the watchdog after a session restart. The agent, lacking that context, executed the stale instruction (and improvised a raw Gmail-API send when the MCP draft had vanished).

Inbound channel messages already carry the original send time on the <channel ... ts="..."> envelope. This adds a UserPromptSubmit hook (scripts/hooks/staleness-guard.py) that compares each inbound message's ts against now; if the delivery gap exceeds STALENESS_THRESHOLD_SEC (default 300s) it injects a context note asking the agent to re-confirm before any irreversible or outward-facing action. It never blocks the prompt (always exit 0) and stays silent for fresh messages, so it adds no noise on the normal path.

Wiring:
- templates/settings.json.template: UserPromptSubmit -> staleness-guard.py (new agents)
- ensureAgentStalenessHook(): idempotent migration that MERGES the hook into existing agents' settings.json without clobbering their other hooks (the fleet, not just freshly-scaffolded agents), backfilled on dashboard startup.

Coverage note: covers any channel that stamps ts on the <channel> envelope (Telegram + the other native plugins). The marveenchat web UI does not yet stamp inbound text with a send time, so web-chat inputs are not covered here -- that needs the web layer to emit a timestamp (tracked separately).

Tests: behavioural (subprocess: fresh->silent, stale->warns, no-ts->silent, threshold override) + static wiring assertions. Full suite green (1359 tests).

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
