### PR TITLE
fix(heartbeat): silent heartbeat must not park text in the input box

### DIFF
--- a/scheduled-tasks/memoria-heartbeat/SKILL.md
+++ b/scheduled-tasks/memoria-heartbeat/SKILL.md
@@ -75,4 +75,6 @@ Ha NINCS komplex feladat / hiba / korrekció (A=B=C=NEM), ÉS nincs várakozó T
 - Ne ments memóriát feleslegesen
 - Ne generálj skill-t
 - Ne küldj üzenetet a csatornára
-- Maradj csendben (egy rövid "csendes heartbeat" sor a transzkriptbe elég)
+- Maradj csendben: egyszerűen FEJEZD BE a kört, akció nélkül.
+
+**KRITIKUS (felügyelet nélküli stabilitás):** SOHA ne gépelj semmit az input-boxba (a `❯` prompt-sorba) és ne hagyj ott parkolt, el-nem-küldött szöveget -- még a "csendes heartbeat" szót sem. Ha jelezni akarod a csendes kört, az KIZÁRÓLAG a normál válasz-szövegedben (transzkript) lehet, EGYETLEN rövid sorral, majd a köröd azonnal érjen véget. Parkolt input-szöveg blokkolja a következő üzenet kézbesítését (a router `busy`-nak látja a sessiont) -> a csatorna NÉMUL felügyelet nélkül.


### PR DESCRIPTION
**Tünet:** a DGX darwin install csatornája némán bewedge-elt — egy silent-heartbeat után parkolt szöveg ("Csendes heartbeat.") maradt a TUI input-boxában, a `isSessionReadyForPrompt` `busy`-nak látta a sessiont, és minden bejövő Telegram-üzenet `pending`-ben ragadt (auto-recovery nélkül).

**Gyökér (erős jelölt):** a `memoria-heartbeat` silent-szekciója azt mondta *"egy rövid 'csendes heartbeat' sor a transzkriptbe elég"*. Egy gyengébb modell (pl. lokál Qwen) ezt úgy érti, hogy "gépeld be valahova" → az input-boxba stage-eli submit nélkül → parkolt input → wedge.

**Fix:** a kétértelmű "írj egy sort" megfogalmazást egyértelműre cserélem: fejezd be a kört akció nélkül, SOHA ne gépelj/hagyj parkolt szöveget az input-boxban; a következménnyel kiírva, hogy egy gyenge modell is kövesse.

Defense-in-depth (külön, javasolt): stale-parked-input janitor a message-router-ben, ami auto-un-wedge-eli a csatornát NON-main agenteknél. Külön issue/PR.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)