### PR TITLE
feat(router): stale-parked-input janitor to auto-un-wedge silent channels

### DIFF
--- a/src/__tests__/janitor-parked-input.test.ts
+++ b/src/__tests__/janitor-parked-input.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { detectPaneState, parkedInputText } from '../pane-state.js'
+
+// The stale-parked-input janitor (clearStaleParkedInput in agent-process.ts,
+// gated by the message-router) clears a stranded input box ONLY when the pane
+// is in the idle 'typing' state. The actual clear does live tmux I/O, but its
+// SAFETY CONTRACT is decided entirely by detectPaneState, so we pin that here:
+//   - the wedge case (a weak model parked its heartbeat reply) -> 'typing' -> act
+//   - an actively processing session                          -> 'busy'   -> skip
+//   - a clean idle prompt                                      -> 'idle'   -> no-op
+// This is the exact scenario that silenced the DGX darwin channel: a heartbeat
+// left "Csendes heartbeat." in the input box, isSessionReadyForPrompt stayed
+// false, and every inbound message stranded as pending.
+
+const SEP = '─'.repeat(80)
+const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+
+// The real wedge: a heartbeat response typed into the box but never submitted.
+const HEARTBEAT_PARKED = ['', SEP, '❯ Csendes heartbeat.', SEP, FOOTER].join('\n')
+
+// A session actively processing a turn (spinner in the footer region). The
+// janitor MUST NOT touch this -- clearing it would clobber real work.
+const PROCESSING = [
+  '✢ Combobulating… (52s · ↓ 2.6k tokens · thinking some more)',
+  '', SEP, '❯ ', SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+].join('\n')
+
+// A clean idle prompt: empty box, ready to receive -> nothing to clear.
+const IDLE_EMPTY = ['', SEP, '❯ ', SEP, FOOTER].join('\n')
+
+describe('stale-parked-input janitor safety contract', () => {
+  it('treats a parked heartbeat line as typing (janitor acts to un-wedge)', () => {
+    expect(detectPaneState(HEARTBEAT_PARKED)).toBe('typing')
+    expect(parkedInputText(HEARTBEAT_PARKED)).toBe('Csendes heartbeat.')
+  })
+
+  it('treats an actively processing session as busy (janitor must skip)', () => {
+    expect(detectPaneState(PROCESSING)).toBe('busy')
+  })
+
+  it('treats a clean empty prompt as idle (nothing to clear)', () => {
+    expect(detectPaneState(IDLE_EMPTY)).toBe('idle')
+    expect(parkedInputText(IDLE_EMPTY)).toBeNull()
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -10,6 +10,8 @@ import {
   decideSubmitFollowup,
   shouldClearTruncatedPreamble,
   detectsPastePlaceholder,
+  detectPaneState,
+  parkedInputText,
 } from '../pane-state.js'
 import { agentDir, readAgentModel, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost } from './agent-config.js'
 import {
@@ -932,5 +934,41 @@ export function isSessionReadyForPrompt(session: string, host: string | null = n
   const second = capturePane(session, host)
   if (second == null) return false
   return paneLooksIdle(second)
+}
+
+// How long to wait between the two parked-input captures when deciding whether
+// the input box is STUCK (stale) vs being actively typed. Identical parked text
+// across this gap means nobody is typing -> it is a stranded artifact.
+const PARKED_STABLE_CONFIRM_S = '2'
+// Settle after a Ctrl-U so the next capture reflects the cleared box.
+const PARKED_CLEAR_SETTLE_S = '0.3'
+// Bound the Ctrl-U presses for a (possibly multi-line) stale parked input.
+const PARKED_CLEAR_MAX = 3
+
+// Un-wedge a session whose input box holds STALE parked text: a non-submitted
+// line (e.g. a weak local model that typed its heartbeat reply into the box
+// instead of ending the turn). Parked text makes isSessionReadyForPrompt()
+// false forever, so every inbound message strands as pending and the channel
+// goes silent with no recovery. Acts ONLY when the pane is 'typing' (idle WITH
+// parked text -- never 'busy'/processing) AND the text is unchanged across a
+// short settle, so input a human or agent is actively typing is never clobbered.
+// Returns true if it cleared something (caller should retry delivery next tick).
+export function clearStaleParkedInput(session: string, host: string | null = null): boolean {
+  const a = capturePane(session, host)
+  if (a == null || detectPaneState(a) !== 'typing') return false
+  const parked = parkedInputText(a)
+  if (!parked) return false
+  try { execFileSync('/bin/sleep', [PARKED_STABLE_CONFIRM_S], { timeout: 4000 }) } catch { /* best effort */ }
+  const b = capturePane(session, host)
+  // Changed (someone is typing) or already cleared -> leave it alone.
+  if (b == null || detectPaneState(b) !== 'typing' || parkedInputText(b) !== parked) return false
+  for (let i = 0; i < PARKED_CLEAR_MAX; i++) {
+    runTmux(host, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
+    try { execFileSync('/bin/sleep', [PARKED_CLEAR_SETTLE_S], { timeout: 2000 }) } catch { /* best effort */ }
+    const after = capturePane(session, host)
+    if (after == null || detectPaneState(after) !== 'typing') break
+  }
+  logger.warn({ session, parked: parked.slice(0, 60) }, 'message-router: cleared stale parked input (channel un-wedge)')
+  return true
 }
 

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -21,6 +21,7 @@ import { readAgentTeam } from './agent-team.js'
 import {
   agentSessionName,
   isSessionReadyForPrompt,
+  clearStaleParkedInput,
   sendPromptToSession,
   sessionExistsOnHost,
 } from './agent-process.js'
@@ -42,6 +43,11 @@ const CHANNEL_COORDINATOR_AGENTS = new Set<string>([COORDINATOR_AGENT_ID])
 // queue and we stop re-scanning it forever. Matches the scheduled-task retry
 // window so a long turn that ate one also eats the other.
 const MESSAGE_ABANDON_WINDOW_MS = 60 * 60 * 1000
+// How long a message must have waited before the stale-parked-input janitor is
+// allowed to clear the receiver's input box. Long enough that a brief, genuine
+// "agent parked a draft it is about to submit" never gets clobbered; short
+// enough that a wedged channel recovers within ~a minute instead of forever.
+const JANITOR_PARKED_MIN_AGE_MS = 45 * 1000
 // Log "skipping, target not ready" at most once per message id so a busy
 // receiver over many 5s ticks does not spam the log.
 const routerLoggedMisses: Set<number> = new Set()
@@ -104,6 +110,19 @@ export function startMessageRouter(): NodeJS.Timeout {
       }
 
       if (!isSessionReadyForPrompt(session, host)) {
+        // Stale-parked-input janitor: a non-submitted line stuck in the input
+        // box (e.g. a weak local model that typed its heartbeat reply into the
+        // box instead of ending the turn) keeps isSessionReadyForPrompt false
+        // forever, so this message -- and every later one -- strands as pending
+        // and the channel silently wedges. Once a message has waited long enough,
+        // clear a STABLE parked input so delivery resumes next tick. clearStale
+        // ParkedInput only fires on the idle 'typing' state with text unchanged
+        // across a settle, so it never clobbers a session that is actually
+        // processing or input a human/agent is mid-typing.
+        if (ageMs > JANITOR_PARKED_MIN_AGE_MS && clearStaleParkedInput(session, host)) {
+          routerLoggedMisses.delete(msg.id)
+          continue // input cleared; deliver on the next tick
+        }
         if (!routerLoggedMisses.has(msg.id)) {
           logger.warn({ id: msg.id, to: msg.to_agent, session }, 'Agent message target session busy, will retry')
           routerLoggedMisses.add(msg.id)


### PR DESCRIPTION
**Probléma:** ha egy agent TUI input-boxában parkolt (el-nem-küldött) szöveg ragad — pl. egy gyengébb lokál modell (Qwen) a heartbeat-válaszát az input-boxba gépeli submit helyett —, akkor az `isSessionReadyForPrompt()` örökre `false`. A message-router minden bejövő üzenetet `pending`-ben hagy, és a csatorna némán bewedge-el, recovery nélkül. Pontosan ez némította el a DGX darwin csatornát.

**Fix (Fix B, defense-in-depth):** `clearStaleParkedInput(session, host)` — ha egy pending üzenet > `JANITOR_PARKED_MIN_AGE_MS` (45s) várt, ÉS a fogadó pane idle `'typing'` állapotban van (parkolt szöveg, NEM `'busy'`/feldolgozás), ÉS a szöveg változatlan egy rövid settle alatt, akkor törli az input-boxot (bounded Ctrl-U) → a kézbesítés a következő tick-nél folytatódik.

**Biztonság:** a `'typing'`-only guard + a stabilitás-ellenőrzés miatt SOHA nem nyúl egy ténylegesen feldolgozó sessionhöz, sem egy emberi/agent által épp gépelt inputhoz. Az age-gate (45s) megakadályozza, hogy egy rövid, jogos "draft amit mindjárt elküld" parkolást elkapjon.

Párban a silent-heartbeat instrukció-fixszel (#450, a KIVÁLTÓ OKOT szünteti meg); ez a defense-in-depth, ami a parkolt inputból OK-FÜGGETLENÜL helyreáll — ez adja a felügyelet-nélküli stabilitást.

Teszt: a janitor biztonsági-szerződése (typing→act / busy→skip / idle→no-op) a valós "Csendes heartbeat" wedge-fixtúrával. tsc zöld, 672 teszt zöld.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)