### PR TITLE
feat(channel): escalate a wedged main channel to hard restart (respawn-pane)

### DIFF
--- a/src/__tests__/stuck-input-restart.test.ts
+++ b/src/__tests__/stuck-input-restart.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { decideStuckInputRestart } from '../web/channel-monitor.js'
+
+// The reliable backstop: when soft stuck-input recovery (Enter + clear+re-inject)
+// is exhausted but the main channel input is STILL parked, escalate to a hard
+// restart (respawn-pane). decideStuckInputRestart is the pure gate -- rate
+// limited and capped so a wedge a restart cannot clear never loops forever.
+
+const MAX_ATTEMPTS = 4
+const MIN_INTERVAL = 5 * 60 * 1000 // 5 min
+const MAX_CONSEC = 3
+const NOW = 10_000_000
+
+const decide = (over: Partial<{ parked: boolean; attempts: number; last: number; count: number }> = {}) =>
+  decideStuckInputRestart(
+    over.parked ?? true,
+    over.attempts ?? MAX_ATTEMPTS,
+    MAX_ATTEMPTS,
+    NOW,
+    over.last ?? 0,
+    over.count ?? 0,
+    MIN_INTERVAL,
+    MAX_CONSEC,
+  )
+
+describe('decideStuckInputRestart', () => {
+  it('restarts when soft recovery is exhausted and input is still parked', () => {
+    expect(decide()).toBe('restart')
+  })
+
+  it('skips when the input is not parked (nothing wedged)', () => {
+    expect(decide({ parked: false })).toBe('skip')
+  })
+
+  it('skips while soft recovery is still in progress (attempts < max)', () => {
+    expect(decide({ attempts: MAX_ATTEMPTS - 1 })).toBe('skip')
+  })
+
+  it('skips when rate-limited (a restart fired within the interval)', () => {
+    expect(decide({ last: NOW - (MIN_INTERVAL - 1) })).toBe('skip')
+    // ...but allows it once the interval has passed
+    expect(decide({ last: NOW - MIN_INTERVAL })).toBe('restart')
+  })
+
+  it('alerts exactly once when restarts cannot clear the wedge (cap reached)', () => {
+    expect(decide({ count: MAX_CONSEC })).toBe('alert')
+    // already alerted (counter ticked past the cap) -> stop acting
+    expect(decide({ count: MAX_CONSEC + 1 })).toBe('skip')
+  })
+
+  it('keeps restarting up to the cap', () => {
+    expect(decide({ count: 1 })).toBe('restart')
+    expect(decide({ count: MAX_CONSEC - 1 })).toBe('restart')
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -111,6 +111,40 @@ const MAIN_STUCK_THRESHOLDS: StuckInputThresholds = {
   maxAttempts: 4,
 }
 
+// --- Stuck-input hard-restart escalation (reliable backstop) ---
+// When the soft recovery above (Enter + clear+re-inject) is EXHAUSTED but the
+// main channel input is STILL parked, the TUI is hard-wedged: a paste
+// placeholder that Enter only expands (never submits), or a state where
+// keystrokes no longer register. Soft recovery cannot win there; the only fix
+// is a fresh claude process. Escalate to hardRestartMarveenChannels()
+// (respawn-pane on Linux -- replaces ONLY the main pane's claude, the tmux
+// server + every other agent session stay intact). Rate-limited + capped so a
+// wedge a restart cannot clear never becomes a restart loop.
+const STUCK_RESTART_MIN_INTERVAL_MS = 5 * 60 * 1000
+const STUCK_RESTART_MAX_CONSECUTIVE = 3
+let stuckRestartCount = 0
+let lastStuckRestartAt = 0
+
+// Pure decision for the stuck-input restart escalation.
+//   'restart' -> soft recovery exhausted + input still parked + rate-limit ok
+//   'alert'   -> restarts are not clearing the wedge (cap reached) -> surface once
+//   'skip'    -> not wedged past soft recovery, rate-limited, or already alerted
+export function decideStuckInputRestart(
+  parked: boolean,
+  attempts: number,
+  maxAttempts: number,
+  now: number,
+  lastRestartAt: number,
+  restartCount: number,
+  minIntervalMs: number,
+  maxConsecutive: number,
+): 'restart' | 'alert' | 'skip' {
+  if (!parked || attempts < maxAttempts) return 'skip'
+  if (now - lastRestartAt < minIntervalMs) return 'skip'
+  if (restartCount >= maxConsecutive) return restartCount === maxConsecutive ? 'alert' : 'skip'
+  return 'restart'
+}
+
 // Session-agnostic stuck-input recovery: capture the pane, and if a channel
 // notification is parked at the ❯ prompt, get it SUBMITTED (Enter-first, then
 // clear + verbatim re-inject of the COMPLETE block). The gate fires ONLY for a
@@ -593,6 +627,39 @@ export function hardRestartMarveenChannels(): { ok: boolean; error?: string } {
   return { ok: false, error: 'hard restart failed: tmux respawn-pane failed' }
 }
 
+// Escalate a main channel input that survived the full soft recovery to a hard
+// restart (respawn-pane). Driven by the pure decideStuckInputRestart; this
+// wrapper owns the I/O + counters. Called once per monitor tick right after the
+// main stuck-input recovery.
+function maybeRestartWedgedMainChannel(state: StuckInputState): void {
+  const parked = state.parkedSig !== null
+  // A cleared input box ends the spell -> reset the escalation counter so the
+  // next genuine wedge starts fresh (and a successful restart is not penalised).
+  if (!parked) { stuckRestartCount = 0; return }
+  const action = decideStuckInputRestart(
+    parked, state.attempts, MAIN_STUCK_THRESHOLDS.maxAttempts,
+    Date.now(), lastStuckRestartAt, stuckRestartCount,
+    STUCK_RESTART_MIN_INTERVAL_MS, STUCK_RESTART_MAX_CONSECUTIVE,
+  )
+  if (action === 'skip') return
+  if (action === 'alert') {
+    logger.error({ session: MAIN_CHANNELS_SESSION }, 'Stuck main channel input survived max restart escalations -- manual intervention needed')
+    sendAlert(`⛔ A ${MAIN_CHANNELS_SESSION} bemenete beragadt es ${STUCK_RESTART_MAX_CONSECUTIVE} automatikus respawn-pane sem szabaditotta ki. Kezi beavatkozas kell (pl. systemctl --user restart ${SERVICE_ID}-channels).`)
+    stuckRestartCount++ // tick past the cap so the alert fires only once
+    return
+  }
+  logger.warn({ session: MAIN_CHANNELS_SESSION, attempts: state.attempts, restart: stuckRestartCount + 1 }, 'Stuck main channel input survived soft recovery -- escalating to hard restart (respawn-pane)')
+  const r = hardRestartMarveenChannels()
+  lastStuckRestartAt = Date.now()
+  if (r.ok) {
+    stuckRestartCount++
+    // Reset the tracker so the fresh post-restart pane is re-evaluated cleanly.
+    mainStuckInput = { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
+  } else {
+    logger.error({ session: MAIN_CHANNELS_SESSION, err: r.error }, 'Stuck-input hard restart failed')
+  }
+}
+
 // --- Keep-alive staleness watchdog (deafness safety net, decision #3) ---
 //
 // The keep-alive (a scheduled edit_message round-trip from the channels
@@ -978,6 +1045,10 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
     // only when the captured block looks COMPLETE -- a truncated capture stays
     // on Enter rather than risk a partial re-inject to the wrong chat_id.
     mainStuckInput = recoverStuckInputForSession(MAIN_CHANNELS_SESSION, mainStuckInput, MAIN_STUCK_THRESHOLDS, false)
+    // Reliable backstop: if the soft recovery is exhausted and the input is
+    // STILL parked, the TUI is hard-wedged -- escalate to a respawn-pane (the
+    // automated form of the manual `systemctl restart channels`). Rate-limited.
+    maybeRestartWedgedMainChannel(mainStuckInput)
     // Same recovery for every running sub-agent session: a parked channel
     // message wedges a sub-agent ("nem válaszol") exactly as it would the main
     // session. Per-session state lives in agentStuckInput; drop it once the


### PR DESCRIPTION
**Probléma (élesben a DGX darwin Linux-installon):** ha a soft stuck-input recovery (Enter, majd clear+re-inject) KIMERÜL de a main-csatorna inputja MÉG parkolt, a TUI hard-wedge-elt (paste-placeholder, amire az Enter csak expandál nem submitál; vagy állapot ahol a keystroke nem regisztrál). A soft recovery itt nem nyerhet — csak friss claude-processz oldja. A DGX-logok bizonyítják: a stuck-input-watcher 11+ percig pörgette a "recovery Enter"-t hatástalanul; csak kézi `systemctl restart` oldotta, mert a meglévő hard-restart escalation keepalive-staleness/plugin-down/deafness-re van kötve, a parkolt-inputra SOHA.

**Fix:** a stuck-input recovery a soft-recovery kimerülése után escalál a `hardRestartMarveenChannels()`-re. Linuxon ez **respawn-pane** (csak a main-pane claude-ját cseréli; a tmux-szerver + minden más agent-session érintetlen — SOHA nem a cgroup-ölő `systemctl --user restart`). **Rate-limit** (>=5 perc az escalációk közt) + **cap** (3 egymást követő), majd EGY alert kézi beavatkozásra → egy wedge amit a restart nem old, sosem lesz restart-loop.

A pure `decideStuckInputRestart` unit-tesztelt (restart/alert/skip mátrix). tsc zöld; a channel-monitor/stuck-input/pane-state terület 763 teszt zöld (a 2 előzetesen bukó template-identity-hygiene a scripts/support-mail/ operator-lokál mappát scanneli, nem érintett).

Ez a 3. réteg a parked-input wedge ellen: #450 (instrukció, ok-megszüntetés) + #451 (router janitor, delivery-oldal) + EZ (#452, a main-csatorna hard-wedge reliable recovery-je).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)