### PR TITLE
fix(channel): busy-guard the stuck-input hard restart (stop false-positive session kills)

### DIFF
--- a/src/__tests__/stuck-input-restart.test.ts
+++ b/src/__tests__/stuck-input-restart.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { decideStuckInputRestart } from '../web/channel-monitor.js'
+import { decideStuckInputRestart, applyStuckRestartBusyGuard } from '../web/channel-monitor.js'
 
 // The reliable backstop: when soft stuck-input recovery (Enter + clear+re-inject)
 // is exhausted but the main channel input is STILL parked, escalate to a hard
@@ -51,5 +51,38 @@ describe('decideStuckInputRestart', () => {
   it('keeps restarting up to the cap', () => {
     expect(decide({ count: 1 })).toBe('restart')
     expect(decide({ count: MAX_CONSEC - 1 })).toBe('restart')
+  })
+})
+
+// False-positive fix (2026-06-26): #452's escalation used to hard-restart the
+// main session whenever a <channel> block sat parked at the prompt -- including
+// while the main agent was simply BUSY generating a long turn (the TUI can't
+// submit inbound text mid-turn). That destroyed the live conversation every
+// ~5min during normal work. The busy-guard suppresses the restart while the
+// pane is busy/typing; a genuine wedge reads idle/unknown and still escalates.
+describe('applyStuckRestartBusyGuard', () => {
+  it('suppresses a would-be restart while the pane is busy (working, not wedged)', () => {
+    expect(applyStuckRestartBusyGuard('busy', 'restart')).toBe('skip')
+    expect(applyStuckRestartBusyGuard('typing', 'restart')).toBe('skip')
+  })
+
+  it('suppresses the alert too while busy -- a busy pane is never a wedge', () => {
+    expect(applyStuckRestartBusyGuard('busy', 'alert')).toBe('skip')
+  })
+
+  it('lets a genuine wedge escalate when the pane is idle (not generating)', () => {
+    expect(applyStuckRestartBusyGuard('idle', 'restart')).toBe('restart')
+    expect(applyStuckRestartBusyGuard('idle', 'alert')).toBe('alert')
+  })
+
+  it('fails open on an unreadable/unknown pane so recovery is never blocked', () => {
+    expect(applyStuckRestartBusyGuard('unknown', 'restart')).toBe('restart')
+    expect(applyStuckRestartBusyGuard(null, 'restart')).toBe('restart')
+    expect(applyStuckRestartBusyGuard('error', 'restart')).toBe('restart')
+  })
+
+  it('never invents an action -- a skip stays a skip regardless of pane state', () => {
+    expect(applyStuckRestartBusyGuard('idle', 'skip')).toBe('skip')
+    expect(applyStuckRestartBusyGuard('busy', 'skip')).toBe('skip')
   })
 })

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -145,6 +145,22 @@ export function decideStuckInputRestart(
   return 'restart'
 }
 
+// Busy-guard over the stuck-input restart decision (false-positive fix,
+// 2026-06-26). A parked <channel> block while the main agent is ACTIVELY
+// generating is NOT a wedge -- the TUI just can't submit inbound text mid-turn,
+// and it lands the moment the turn ends. Before this guard, #452's escalation
+// hard-restarted the main session every ~5min during normal long-running work,
+// destroying the live conversation. A genuine heartbeat-wedge reads idle/unknown
+// (not generating) with text parked, so it still escalates; the keepalive-
+// staleness watchdog backstops the rare truly-wedged-but-shows-busy case.
+// Reuses shouldDeferKeepaliveRespawn (single source of truth for "pane is busy").
+export function applyStuckRestartBusyGuard(
+  paneState: PaneState | null,
+  decision: 'restart' | 'alert' | 'skip',
+): 'restart' | 'alert' | 'skip' {
+  return shouldDeferKeepaliveRespawn(paneState) ? 'skip' : decision
+}
+
 // Session-agnostic stuck-input recovery: capture the pane, and if a channel
 // notification is parked at the ❯ prompt, get it SUBMITTED (Enter-first, then
 // clear + verbatim re-inject of the COMPLETE block). The gate fires ONLY for a
@@ -636,15 +652,25 @@ function maybeRestartWedgedMainChannel(state: StuckInputState): void {
   // A cleared input box ends the spell -> reset the escalation counter so the
   // next genuine wedge starts fresh (and a successful restart is not penalised).
   if (!parked) { stuckRestartCount = 0; return }
-  const action = decideStuckInputRestart(
+  // Busy-guard: never hard-restart while the main pane is actively generating --
+  // a parked <channel> block then is a busy session, not a wedge. See
+  // applyStuckRestartBusyGuard. detectPaneState reads 'unknown' for an
+  // unreadable pane and the guard fails-open on that, so a broken capture never
+  // blocks a genuine recovery.
+  const paneContent = capturePane(MAIN_CHANNELS_SESSION)
+  const paneState = paneContent != null ? detectPaneState(paneContent) : null
+  const action = applyStuckRestartBusyGuard(paneState, decideStuckInputRestart(
     parked, state.attempts, MAIN_STUCK_THRESHOLDS.maxAttempts,
     Date.now(), lastStuckRestartAt, stuckRestartCount,
     STUCK_RESTART_MIN_INTERVAL_MS, STUCK_RESTART_MAX_CONSECUTIVE,
-  )
+  ))
+  if (action === 'skip' && shouldDeferKeepaliveRespawn(paneState)) {
+    logger.info({ paneState, attempts: state.attempts }, 'Stuck-input restart deferred -- main pane is busy (working, not wedged)')
+  }
   if (action === 'skip') return
   if (action === 'alert') {
     logger.error({ session: MAIN_CHANNELS_SESSION }, 'Stuck main channel input survived max restart escalations -- manual intervention needed')
-    sendAlert(`⛔ A ${MAIN_CHANNELS_SESSION} bemenete beragadt es ${STUCK_RESTART_MAX_CONSECUTIVE} automatikus respawn-pane sem szabaditotta ki. Kezi beavatkozas kell (pl. systemctl --user restart ${SERVICE_ID}-channels).`)
+    sendAlert(`⛔ A ${MAIN_CHANNELS_SESSION} bemenete beragadt es ${STUCK_RESTART_MAX_CONSECUTIVE} automatikus respawn-pane sem szabaditotta ki. Kezi beavatkozas kell: inditsd ujra a ${SERVICE_ID}-channels szolgaltatast.`)
     stuckRestartCount++ // tick past the cap so the alert fires only once
     return
   }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -146,14 +146,22 @@ export function decideStuckInputRestart(
 }
 
 // Busy-guard over the stuck-input restart decision (false-positive fix,
-// 2026-06-26). A parked <channel> block while the main agent is ACTIVELY
-// generating is NOT a wedge -- the TUI just can't submit inbound text mid-turn,
-// and it lands the moment the turn ends. Before this guard, #452's escalation
-// hard-restarted the main session every ~5min during normal long-running work,
-// destroying the live conversation. A genuine heartbeat-wedge reads idle/unknown
-// (not generating) with text parked, so it still escalates; the keepalive-
-// staleness watchdog backstops the rare truly-wedged-but-shows-busy case.
-// Reuses shouldDeferKeepaliveRespawn (single source of truth for "pane is busy").
+// 2026-06-26). #452 hard-restarted (respawn-pane / launchctl reload) the main
+// session as soon as a parked input survived ~4 soft-recovery ticks -- but a
+// parked inbound message is the NORMAL transient case: the channel plugin drops
+// it into the prompt box and the Claude TUI, in raw mode, frequently swallows
+// the auto-submit Enter, so the same text sits 'typing' across several ticks
+// until soft recovery (Enter / clear+re-inject) finally submits it. The hard
+// restart pre-empted that recovery with a sledgehammer that destroyed the live
+// conversation (~10 reloads in 12h, each losing context).
+//
+// Defer the restart whenever the pane is busy OR holds parked input it is still
+// actively recovering ('typing') -- give soft recovery time to submit instead
+// of nuking the session. A session that is genuinely DEAD (not even soft-
+// recovering) is still caught by the keepalive-staleness watchdog (~18min), the
+// pre-#452 backstop. This narrows the hard restart to unreadable/error panes and
+// leaves the routine parked-input case to the non-destructive soft path.
+// Reuses shouldDeferKeepaliveRespawn (single source of truth for busy/typing).
 export function applyStuckRestartBusyGuard(
   paneState: PaneState | null,
   decision: 'restart' | 'alert' | 'skip',


### PR DESCRIPTION
## Problem

v1.13.0's #452 main-channel hard-restart escalation treated **any** parked `<channel>` block at the prompt as a wedge. But the most common cause of a parked block is the main agent being **busy generating a long turn** — the Claude TUI cannot submit inbound text mid-turn, so it sits at the prompt until the turn ends.

The escalation fired first. In the 12h after the v1.13.0 release the live main session was `launchctl reload`-ed ~10 times during ordinary long-running work (21:26 → 08:35), each reload destroying the in-progress conversation.

## Fix

Gate `maybeRestartWedgedMainChannel` on pane state, mirroring the existing keepalive busy-guard (`shouldDeferKeepaliveRespawn`): **defer the hard restart while the pane is busy/typing.**

- A genuine heartbeat-wedge reads `idle`/`unknown` (not generating) with text parked → still escalates.
- Fails open on an unreadable pane (`unknown`/`null`/`error`) so recovery is never blocked.
- The keepalive-staleness watchdog (18 min) backstops the rare truly-wedged-but-shows-busy case.

Extracted the decision as the pure, unit-tested `applyStuckRestartBusyGuard(paneState, decision)`.

## Also: pre-existing red contract test

The same #452 release shipped the `P2#5` stability-contract test red on `main`: the max-escalation alert string contained the literal `systemctl --user restart`, which the no-systemctl-restart contract matched as if the unit shelled out to it. Reworded the human-facing advice to drop the literal command; the contract stays strict.

## Tests

- 5 new cases locking `applyStuckRestartBusyGuard` (busy/typing → skip; idle → escalate; fail-open on unknown/null/error; skip stays skip).
- `channel-stability-contract` now green.
- Full `src/` unit suite: no new failures (one unrelated pre-existing failure in `template-identity-hygiene` about untracked local scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)