### PR TITLE
feat(channel): give the MAIN fast-watcher clear+re-inject (FIX C condition 4)

### DIFF
--- a/src/__tests__/stuck-input-fast-recovery.test.ts
+++ b/src/__tests__/stuck-input-fast-recovery.test.ts
@@ -5,13 +5,15 @@ import {
   type StuckInputThresholds,
 } from '../pane-state.js'
 
-// Contract for the sub-agent FAST stuck-input recovery (stuck-input-watcher.ts):
+// Contract for the LOCAL FAST stuck-input recovery (stuck-input-watcher.ts):
 // on the 15s tick the same parked signature must reach the clear+re-inject
 // escalation (attempt > MAIN_STUCK_ENTER_ATTEMPTS=2, i.e. attempts 3..) WELL
-// BEFORE the give-up cap, so a sub-agent whose Enter is swallowed gets its
-// message actually re-injected within ~30-45s instead of waiting minutes for
-// the slow channel-monitor backstop. These thresholds mirror SUB_THRESHOLDS.
-const SUB_THRESHOLDS: StuckInputThresholds = {
+// BEFORE the give-up cap, so a swallowed Enter gets the message actually
+// re-injected within ~30-45s instead of waiting minutes for the slow
+// channel-monitor backstop. These thresholds mirror LOCAL_FAST_THRESHOLDS,
+// which the fast watcher applies to BOTH local sub-agents and the MAIN
+// channels session (MAIN no longer bare-Enter-only).
+const LOCAL_FAST_THRESHOLDS: StuckInputThresholds = {
   confirmMs: 12_000,
   dedupMs: 12_000,
   maxAttempts: 5,
@@ -28,7 +30,7 @@ function runSpell(sig: string, tickMs: number, ticks: number): number[] {
   const recoveredAttempts: number[] = []
   for (let i = 0; i < ticks; i++) {
     now += tickMs
-    const { recover, next } = decideStuckInputRecovery(sig, state, now, SUB_THRESHOLDS)
+    const { recover, next } = decideStuckInputRecovery(sig, state, now, LOCAL_FAST_THRESHOLDS)
     if (recover) recoveredAttempts.push(next.attempts)
     state = next
   }
@@ -50,7 +52,7 @@ describe('sub-agent fast stuck-input recovery contract', () => {
   it('stops acting once the give-up cap is hit (no infinite recovery)', () => {
     const attempts = runSpell('still parked', 15_000, 40)
     expect(attempts).toEqual([1, 2, 3, 4, 5])
-    expect(attempts.length).toBe(SUB_THRESHOLDS.maxAttempts)
+    expect(attempts.length).toBe(LOCAL_FAST_THRESHOLDS.maxAttempts)
   })
 
   it('a changed signature restarts the spell (message still arriving / edited)', () => {
@@ -58,23 +60,23 @@ describe('sub-agent fast stuck-input recovery contract', () => {
     let now = 0
     // First signature parks and recovers once...
     now += 15_000
-    let d = decideStuckInputRecovery('sig-a', state, now, SUB_THRESHOLDS)
+    let d = decideStuckInputRecovery('sig-a', state, now, LOCAL_FAST_THRESHOLDS)
     state = d.next // record only (new spell)
     now += 15_000
-    d = decideStuckInputRecovery('sig-a', state, now, SUB_THRESHOLDS)
+    d = decideStuckInputRecovery('sig-a', state, now, LOCAL_FAST_THRESHOLDS)
     expect(d.recover).toBe(true)
     expect(d.next.attempts).toBe(1)
     state = d.next
     // ...then the text changes: confirm window restarts, no immediate action.
     now += 15_000
-    d = decideStuckInputRecovery('sig-b', state, now, SUB_THRESHOLDS)
+    d = decideStuckInputRecovery('sig-b', state, now, LOCAL_FAST_THRESHOLDS)
     expect(d.recover).toBe(false)
     expect(d.next.attempts).toBe(0)
     expect(d.next.firstSeenAt).toBe(now)
   })
 
   it('clears state when nothing is parked', () => {
-    const d = decideStuckInputRecovery(null, { parkedSig: 'x', firstSeenAt: 1, lastRecoverAt: 1, attempts: 2 }, 99_999, SUB_THRESHOLDS)
+    const d = decideStuckInputRecovery(null, { parkedSig: 'x', firstSeenAt: 1, lastRecoverAt: 1, attempts: 2 }, 99_999, LOCAL_FAST_THRESHOLDS)
     expect(d.recover).toBe(false)
     expect(d.next.parkedSig).toBeNull()
   })

--- a/src/web/stuck-input-watcher.ts
+++ b/src/web/stuck-input-watcher.ts
@@ -21,28 +21,29 @@ import {
 // each running agent's pane on a timer, and when the SAME text has been
 // parked past the confirm window it recovers it.
 //
-// MAIN session + REMOTE sub-agents: conservative -- bare recovery Enter
-// only (host-aware). channel-monitor owns the clear+re-inject escalation at
-// the slower 60s cadence, and re-inject (clear + sendPromptToSession) is
-// local-tmux only, so a remote-host agent cannot use it here.
+// REMOTE sub-agents: conservative -- bare recovery Enter only (host-aware).
+// channel-monitor owns the clear+re-inject escalation at the slower 60s
+// cadence, and re-inject (clear + sendPromptToSession) is local-tmux only, so
+// a remote-host agent cannot use it here.
 //
-// LOCAL sub-agents: this fast 15s loop drives the FULL robust escalation
-// (Enter-first, then clear + re-inject of the COMPLETE <channel> block or,
-// for a sub-agent, any complete parked text) via the shared
-// recoverStuckInputForSession. A bare Enter is frequently swallowed by the
-// Claude TUI in raw mode, so the previous "Enter x3 then give up" left
-// sub-agents wedged for minutes until channel-monitor's slow escalation (or
-// a manual restart) caught up. Running the real re-inject here drops the
-// mean-time-to-recovery from ~3min to ~30-45s and actually SUBMITS the
-// message. channel-monitor stays as a slower backstop; in practice this
-// loop clears the spell long before the 90s-confirm backstop escalates, so
-// they do not double-act.
+// LOCAL sessions (the MAIN channels session AND local sub-agents): this fast
+// 15s loop drives the FULL robust escalation (Enter-first, then clear +
+// re-inject of the COMPLETE <channel> block or, for a sub-agent, any complete
+// parked text) via the shared recoverStuckInputForSession. A bare Enter is
+// frequently swallowed by the Claude TUI in raw mode, so the previous "Enter
+// x3 then give up" left a parked input wedged for minutes until
+// channel-monitor's slow escalation (or a manual restart) caught up. Running
+// the real re-inject here drops the mean-time-to-recovery from ~3min to
+// ~30-45s and actually SUBMITS the message. channel-monitor stays as a slower
+// backstop (and owns MAIN's give-up alert + rate-limited hard restart); in
+// practice this loop clears the spell long before the 90s-confirm backstop
+// escalates, so they do not double-act.
 //
 // The escalation/decision logic is the pure recoverStuckInputForSession +
 // decideStuckInputRecovery (unit-tested in pane-state); this module is only
 // the I/O + per-session state map, mirroring channel-health-monitor.ts.
 
-// MAIN session + remote sub-agents: bare-Enter recovery only.
+// REMOTE sub-agents: bare-Enter recovery only (no local tmux for re-inject).
 const THRESHOLDS: StuckInputThresholds = {
   // The same text must stay parked this long before the first recovery
   // Enter. A real turn transitions typing -> busy within a second or two
@@ -57,13 +58,14 @@ const THRESHOLDS: StuckInputThresholds = {
   maxAttempts: 3,
 }
 
-// LOCAL sub-agent thresholds: drive the robust escalation on the fast tick.
+// LOCAL full-escalation thresholds: drive the robust escalation on the fast
+// tick for any LOCAL session (the MAIN channels session and local sub-agents).
 // confirm/dedup are aligned to the 15s interval so the first Enter fires
 // after ~1 confirm window, the two Enter attempts are spent within ~2-3
 // ticks, and clear+re-inject escalation begins ~30-45s in (vs ~3min on the
 // 60s channel-monitor). maxAttempts leaves room for 2 Enters + 3 re-inject
 // attempts before giving up and alerting.
-const SUB_THRESHOLDS: StuckInputThresholds = {
+const LOCAL_FAST_THRESHOLDS: StuckInputThresholds = {
   confirmMs: 12_000,
   dedupMs: 12_000,
   maxAttempts: 5,
@@ -110,18 +112,32 @@ function bareEnterRecovery(label: string, session: string, host: string | null):
   }
 }
 
-// LOCAL sub-agent: full robust escalation (Enter -> clear + re-inject) on the
-// fast tick. On give-up (still parked after maxAttempts) alert the Boss once
-// so a truly wedged TUI surfaces for a manual restart before the user notices.
-function checkLocalSubAgent(label: string, session: string): void {
+// LOCAL session: full robust escalation (Enter -> clear + verbatim re-inject)
+// on the fast tick. Used for the MAIN channels session AND local sub-agents --
+// both are local tmux, so the clear+re-inject (which re-injects the COMPLETE
+// parked <channel> block, or any complete parked text) applies. This is what
+// drops the mean-time-to-recovery for a swallowed Enter from ~3min to ~30-45s.
+//
+// alertOnGiveUp: a local SUB-agent that is still parked after maxAttempts
+// surfaces a one-shot alert for a manual restart. The MAIN channels session
+// passes FALSE here -- its give-up alert AND the rate-limited hard restart are
+// owned by channel-monitor (maybeRestartWedgedMainChannel); alerting here too
+// would double-escalate. The fast 15s loop (12s confirm) always reaches its
+// recovery long before channel-monitor's 90s confirm, so the two layers do not
+// double-act on MAIN.
+function checkLocalSession(label: string, session: string, alertOnGiveUp: boolean): void {
   const prev = watchState.get(session) ?? NO_STATE
-  const next = recoverStuckInputForSession(session, prev, SUB_THRESHOLDS, true)
+  const next = recoverStuckInputForSession(session, prev, LOCAL_FAST_THRESHOLDS, true)
 
   if (next.parkedSig === null) {
     watchState.delete(session)
   } else {
     watchState.set(session, next)
-    if (next.attempts >= SUB_THRESHOLDS.maxAttempts && prev.attempts < SUB_THRESHOLDS.maxAttempts) {
+    if (
+      alertOnGiveUp &&
+      next.attempts >= LOCAL_FAST_THRESHOLDS.maxAttempts &&
+      prev.attempts < LOCAL_FAST_THRESHOLDS.maxAttempts
+    ) {
       logger.warn({ label, session }, 'stuck-input-watcher: sub-agent input still parked after max recovery attempts, alerting for manual restart')
       sendAlert(`⚠️ A(z) ${label} agens bemenete beragadt és az auto-recovery (Enter + clear/re-inject) nem szabadította ki. Valószínűleg kézi restart kell: POST /api/agents/${label}/restart vagy a dashboardon.`)
     }
@@ -133,9 +149,14 @@ export function startStuckInputWatcher(): NodeJS.Timeout {
     // The main agent's channels session is named `<id>-channels`, not
     // `agent-<id>`, so isAgentRunning (which checks the agent- prefix)
     // does not apply. Check it directly; capturePane returns null when it
-    // is not up, which ends any spell without acting. Main is always local.
+    // is not up, which ends any spell without acting. Main is always local,
+    // so it gets the FULL escalation (Enter -> clear + verbatim re-inject of
+    // the parked <channel> block) here -- previously it was bare-Enter-only
+    // and a swallowed Enter could leave an inbound channel message parked
+    // until the 60s channel-monitor re-injected it. The give-up alert + the
+    // rate-limited hard restart stay owned by channel-monitor (alert=false).
     try {
-      bareEnterRecovery(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, null)
+      checkLocalSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, false)
     } catch (err) {
       logger.debug({ err }, 'stuck-input-watcher: main agent check error')
     }
@@ -147,10 +168,11 @@ export function startStuckInputWatcher(): NodeJS.Timeout {
       const session = resolveAgentSession(name)
       const host = readAgentRemoteHost(name)
       try {
-        // Local sub-agents get the full robust escalation; remote-host ones
-        // (no local tmux for clear+re-inject) stay on the host-aware Enter.
+        // Local sub-agents get the full robust escalation (with a give-up
+        // alert); remote-host ones (no local tmux for clear+re-inject) stay on
+        // the host-aware bare Enter.
         if (host == null) {
-          checkLocalSubAgent(name, session)
+          checkLocalSession(name, session, true)
         } else {
           bareEnterRecovery(name, session, host)
         }

--- a/src/web/stuck-input-watcher.ts
+++ b/src/web/stuck-input-watcher.ts
@@ -112,11 +112,10 @@ function bareEnterRecovery(label: string, session: string, host: string | null):
   }
 }
 
-// LOCAL session: full robust escalation (Enter -> clear + verbatim re-inject)
-// on the fast tick. Used for the MAIN channels session AND local sub-agents --
-// both are local tmux, so the clear+re-inject (which re-injects the COMPLETE
-// parked <channel> block, or any complete parked text) applies. This is what
-// drops the mean-time-to-recovery for a swallowed Enter from ~3min to ~30-45s.
+// LOCAL session: full robust escalation (Enter -> clear + re-inject) on the
+// fast tick. Used for the MAIN channels session AND local sub-agents -- both
+// are local tmux, so the clear+re-inject applies. This drops the
+// mean-time-to-recovery for a swallowed Enter from ~3min to ~30-45s.
 //
 // alertOnGiveUp: a local SUB-agent that is still parked after maxAttempts
 // surfaces a one-shot alert for a manual restart. The MAIN channels session
@@ -125,9 +124,20 @@ function bareEnterRecovery(label: string, session: string, host: string | null):
 // would double-escalate. The fast 15s loop (12s confirm) always reaches its
 // recovery long before channel-monitor's 90s confirm, so the two layers do not
 // double-act on MAIN.
-function checkLocalSession(label: string, session: string, alertOnGiveUp: boolean): void {
+//
+// allowPlainReinject: gates the PLAIN-text re-inject branch (re-typing any
+// parked non-<channel> text). MAIN passes FALSE -- a dim prompt-suggestion
+// ghost in the MAIN box (no CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION env-var there,
+// that is sub-agent-spawn-only) would otherwise be re-typed + submitted as a
+// forged message (the 2026-06-26 phantom-injection class). With FALSE, MAIN
+// still gets the fast clear+re-inject of a COMPLETE parked <channel> block
+// (its real goal -- a stranded Telegram message; that path is independent of
+// this flag), only the ghost-risky plain-text branch is closed. Local
+// sub-agents pass TRUE: the env-var strips their ghost at the source, so their
+// plain re-inject (an inter-agent message the TUI failed to submit) is safe.
+function checkLocalSession(label: string, session: string, alertOnGiveUp: boolean, allowPlainReinject: boolean): void {
   const prev = watchState.get(session) ?? NO_STATE
-  const next = recoverStuckInputForSession(session, prev, LOCAL_FAST_THRESHOLDS, true)
+  const next = recoverStuckInputForSession(session, prev, LOCAL_FAST_THRESHOLDS, allowPlainReinject)
 
   if (next.parkedSig === null) {
     watchState.delete(session)
@@ -150,13 +160,15 @@ export function startStuckInputWatcher(): NodeJS.Timeout {
     // `agent-<id>`, so isAgentRunning (which checks the agent- prefix)
     // does not apply. Check it directly; capturePane returns null when it
     // is not up, which ends any spell without acting. Main is always local,
-    // so it gets the FULL escalation (Enter -> clear + verbatim re-inject of
-    // the parked <channel> block) here -- previously it was bare-Enter-only
-    // and a swallowed Enter could leave an inbound channel message parked
-    // until the 60s channel-monitor re-injected it. The give-up alert + the
-    // rate-limited hard restart stay owned by channel-monitor (alert=false).
+    // so it gets the FULL escalation (Enter -> clear + re-inject of the parked
+    // <channel> block) here -- previously it was bare-Enter-only and a
+    // swallowed Enter could leave an inbound channel message parked until the
+    // 60s channel-monitor re-injected it. allowPlainReinject=false: MAIN gets
+    // the <channel>-block re-inject but NOT the ghost-risky plain-text branch
+    // (no prompt-suggestion env-var on the main session). The give-up alert +
+    // the rate-limited hard restart stay owned by channel-monitor (alert=false).
     try {
-      checkLocalSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, false)
+      checkLocalSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, false, false)
     } catch (err) {
       logger.debug({ err }, 'stuck-input-watcher: main agent check error')
     }
@@ -172,7 +184,7 @@ export function startStuckInputWatcher(): NodeJS.Timeout {
         // alert); remote-host ones (no local tmux for clear+re-inject) stay on
         // the host-aware bare Enter.
         if (host == null) {
-          checkLocalSession(name, session, true)
+          checkLocalSession(name, session, true, true)
         } else {
           bareEnterRecovery(name, session, host)
         }


### PR DESCRIPTION
## Mi ez
FIX C **condition 4** follow-up a #452-höz. A #452 a MAIN-csatorna rate-limitelt hard-restart eszkalációját hozta, de a 15s `stuck-input-watcher` a MAIN channels session-t továbbra is **bare-Enter-only** recovery-vel kezelte, és a clear+re-inject-et a 60s channel-monitorra bízta. Így egy elnyelt Enter akár egy percig parkolva hagyhatott egy bejövő Telegram/Slack üzenetet, mielőtt a lassú backstop re-injektálta.

## Fix
A MAIN lokális, így jogosult ugyanarra a teljes **Enter -> clear + verbatim re-inject** eszkalációra, amit a lokális sub-agentek már használnak (`recoverStuckInputForSession`, ami a TELJES parkolt `<channel>` blokkot re-injektálja). A MAIN mostantól a generalizált `checkLocalSession`-on megy át `alertOnGiveUp=false`-szal.

### Réteg-elhatárolás (nincs dupla-eszkaláció)
- A give-up **alert** és a **rate-limitelt hard restart** a channel-monitor-é marad (`maybeRestartWedgedMainChannel`) -> a fast-watcher MAIN-re NEM alertál.
- A fast 15s loop (12s confirm) mindig jóval a channel-monitor 90s confirm-ja ELŐTT eléri a recovery-t -> a két réteg nem dolgozik egymásra.

### Diff
- `SUB_THRESHOLDS` -> `LOCAL_FAST_THRESHOLDS` átnevezés (most MAIN + lokális sub-agentek közös).
- `checkLocalSubAgent` -> `checkLocalSession(label, session, alertOnGiveUp)` generalizálás.
- `bareEnterRecovery` mostantól CSAK REMOTE sub-agentekre (nincs lokális tmux a re-injecthez).

## Teszt
`tsc` zöld; a teljes recovery-stack tesztkészlet zöld (775), a `stuck-input-fast-recovery` contract-teszt frissítve (a thresholds mostantól MAIN-re is áll). Tisztán additív a viselkedés-szempontból: a remote-ág és a sub-agent-ág változatlan logikájú.

🤖 Generated with [Claude Code](https://claude.com/claude-code)