### PR TITLE
fix(pane-state): footer-less welcome-screen stuck-input detection + parkedInputRowCount/submitLanded predicates

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -13,6 +13,8 @@ import {
   decideStuckInputRecovery,
   parkedChannelInput,
   parkedInputText,
+  parkedInputRowCount,
+  submitLanded,
 } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
@@ -1819,5 +1821,65 @@ describe('detectsPastePlaceholder', () => {
       '  paste again to expand',
     ].join('\n')
     expect(detectsPastePlaceholder(stubInBox)).toBe(true)
+  })
+})
+
+describe('parkedInputRowCount', () => {
+  it('returns 0 for an empty input box (bare prompt)', () => {
+    expect(parkedInputRowCount(IDLE_BYPASS)).toBe(0)
+    expect(parkedInputRowCount(BUSY_FULL_FOOTER)).toBe(0)
+  })
+
+  it('returns 0 when there is no input box at all', () => {
+    expect(parkedInputRowCount('just scrollback text\nno separators here')).toBe(0)
+  })
+
+  it('returns 1 for a single-row parked input', () => {
+    expect(parkedInputRowCount(TYPING_PARKED)).toBe(1)
+    expect(parkedInputRowCount(PENDING_PASTE)).toBe(1)
+  })
+
+  it('counts every visual row of a wrapped multi-row parked input', () => {
+    // A wrapped message occupying 3 box-interior rows; a bare Enter here would
+    // insert a newline instead of submitting.
+    const multiRow = [
+      '',
+      SEP,
+      '❯ first line of a long parked message that wraps across',
+      '  several visual rows inside the input box and would not',
+      '  submit on a bare Enter',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(parkedInputRowCount(multiRow)).toBe(3)
+  })
+})
+
+describe('submitLanded', () => {
+  // The exact text parked before the submit attempt.
+  const parkedSig = stuckInputSignature(TYPING_PARKED) as string
+
+  it('captures a non-empty signature from the parked fixture', () => {
+    expect(parkedSig).toBeTruthy()
+  })
+
+  it('is false when the identical signature is still parked', () => {
+    expect(submitLanded(parkedSig, TYPING_PARKED)).toBe(false)
+  })
+
+  it('is true when the box cleared (pane went idle)', () => {
+    expect(submitLanded(parkedSig, IDLE_BYPASS)).toBe(true)
+  })
+
+  it('is true when the agent started processing (pane went busy)', () => {
+    expect(submitLanded(parkedSig, BUSY_FULL_FOOTER)).toBe(true)
+  })
+
+  it('is true when different text is now parked', () => {
+    expect(submitLanded(parkedSig, PENDING_PASTE)).toBe(true)
+  })
+
+  it('is false when there is no after-capture (null)', () => {
+    expect(submitLanded(parkedSig, null)).toBe(false)
   })
 })

--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -1883,3 +1883,57 @@ describe('submitLanded', () => {
     expect(submitLanded(parkedSig, null)).toBe(false)
   })
 })
+
+// Fresh-session / welcome-screen layout (Claude Code logo + model line + cwd,
+// the input box framed by two ──── rules, ❯ prefix, NO footer). Modelled on a
+// real captured stuck pane (store/qwen-welcome-stuck-fixture.txt) where a
+// delivered multi-row message parked before any footer rendered, and the whole
+// recovery stack went blind (liveInputBox null -> detectPaneState 'unknown').
+const WELCOME_STUCK = [
+  '',
+  ' ▐▛███▜▌   Claude Code v2.1.170',
+  '▝▜█████▛▘  qwen3.6:27b-192k with high effort · API Usage Billing',
+  '  ▘▘ ▝▝    ~/ClaudeClaw/agents/qwen',
+  '',
+  '',
+  SEP,
+  '❯ kepet: /Users/marvin/workspace/aahe486-screenshot.png',
+  '  Olvasd be a Read tool-lal a kepfajlt, majd mondd meg: (1) mi ez az',
+  '  alkalmazas, (2) a tablazat konkret ertekei. Roviden a vegeredmenyt.',
+  '  </trusted-peer>',
+  SEP,
+  '',
+].join('\n')
+
+describe('footer-less welcome-screen parked input', () => {
+  it('classifies the parked box as typing (not unknown)', () => {
+    expect(detectPaneState(WELCOME_STUCK)).toBe('typing')
+  })
+
+  it('mergeTypingAsBusy folds the footer-less parked box into busy', () => {
+    expect(detectPaneState(WELCOME_STUCK, { mergeTypingAsBusy: true })).toBe('busy')
+  })
+
+  it('stuckInputSignature recovers a non-null signature', () => {
+    const sig = stuckInputSignature(WELCOME_STUCK)
+    expect(sig).not.toBeNull()
+    expect(sig).toContain('kepet')
+  })
+
+  it('parkedInputText returns the collapsed multi-row message (not empty)', () => {
+    const t = parkedInputText(WELCOME_STUCK)
+    expect(t).not.toBeNull()
+    expect(t).not.toBe('')
+    expect(t).toContain('Olvasd be')
+  })
+
+  it('parkedInputRowCount counts every wrapped row', () => {
+    expect(parkedInputRowCount(WELCOME_STUCK)).toBe(4)
+  })
+
+  it('does NOT mistake a scrollback ──── pair without a ❯ box for input', () => {
+    const noBox = ['some scrollback line', SEP, 'plain text, no prompt glyph', SEP, ''].join('\n')
+    expect(detectPaneState(noBox)).toBe('unknown')
+    expect(parkedInputRowCount(noBox)).toBe(0)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -842,6 +842,41 @@ export function parkedInputText(pane: string): string | null {
   return flat.length > 0 ? flat : null
 }
 
+// How many VISUAL rows the live input box content occupies, ignoring the
+// bare prompt glyph and blank padding. The caller uses this to choose the
+// right submit keystroke: a MULTI-row parked input must NOT be submitted with
+// a bare Enter, because in the Claude TUI a plain Enter on a wrapped /
+// multi-line buffer inserts a newline instead of submitting (see
+// agent-process.ts:833) -- a single-row buffer submits on Enter.
+//
+// Counts the non-empty rows of liveInputBox() after stripping the leading `❯`
+// prompt marker; an empty box (`❯ ` only) or no box at all -> 0. Pure: no
+// tmux, only the captured text.
+export function parkedInputRowCount(pane: string): number {
+  const box = liveInputBox(pane)
+  if (box == null) return 0
+  return box
+    .split('\n')
+    .map((row) => row.replace(/^\s*❯/, '').trim())
+    .filter((row) => row.length > 0).length
+}
+
+// Post-submit verification: did the parked input actually leave the box?
+//
+// `prevSig` is stuckInputSignature(pane) captured BEFORE the submit attempt
+// (the exact text that was parked). `paneAfter` is a fresh capture taken
+// AFTER the submit. Returns true when the submit LANDED -- the same parked
+// signature is no longer 'typing' in the box: it cleared (pane went idle),
+// the agent started processing it (pane went busy), or different text is now
+// parked. Returns false when the IDENTICAL signature is still parked (the
+// Enter was swallowed -> the caller should retry / escalate), or when
+// paneAfter is null (no capture -> cannot confirm, treat as not-landed).
+// Pure: builds on stuckInputSignature() (which gates on detectPaneState).
+export function submitLanded(prevSig: string, paneAfter: string | null): boolean {
+  if (paneAfter == null) return false
+  return stuckInputSignature(paneAfter) !== prevSig
+}
+
 // Per-session bookkeeping for the stuck-input recovery watcher. A "spell"
 // is one continuous stretch of the SAME text parked in the input box.
 export interface StuckInputState {

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -374,7 +374,18 @@ export function detectPaneState(
   // defer rather than pile a second prompt on.
   if (detectsPastePlaceholder(pane)) return 'busy'
 
-  if (!IDLE_FOOTER_RX.test(pane)) return 'unknown'
+  if (!IDLE_FOOTER_RX.test(pane)) {
+    // Footer-less fresh-session / welcome-screen: a PARKED \u276F input box still
+    // means the agent has a delivered message waiting to submit. Classify it
+    // 'typing' (not 'unknown') so the stuck-input recovery stack can see and
+    // resubmit it. An empty box / no box stays 'unknown' -- without a footer
+    // there is nothing to confirm a genuine idle state.
+    const box = liveInputBox(pane)
+    if (box != null && box.split('\n').some(l => PARKED_INPUT_RX.test(l))) {
+      return opts.mergeTypingAsBusy ? 'busy' : 'typing'
+    }
+    return 'unknown'
+  }
 
   if (detectsThinkingBlockError(pane)) return 'error'
 
@@ -437,10 +448,31 @@ export function isReadyForPrompt(pane: string): boolean {
 // Returns null when the pane does not have a live input box (no idle
 // footer, only one separator, etc.) -- callers should treat null as
 // "not enough signal to act, do nothing".
+// Fallback for the fresh-session / welcome-screen layout (Claude Code logo +
+// model line + cwd, NO idle footer): a delivered message can sit parked in the
+// input box before the footer is ever rendered, and the footer-anchored path
+// would miss it entirely (return null -> the whole recovery stack goes blind).
+// Anchor on the LAST TWO box separators (/^\u2500{10,}/) and treat the span
+// between them as the input box ONLY when its first non-empty row starts with
+// the \u276F prompt -- otherwise a pair of scrollback rules would be mis-read.
+function liveInputBoxFooterless(lines: string[]): string | null {
+  const seps: number[] = []
+  for (let i = 0; i < lines.length; i++) {
+    if (BOX_SEP_RX.test(lines[i])) seps.push(i)
+  }
+  if (seps.length < 2) return null
+  const topSep = seps[seps.length - 2]
+  const bottomSep = seps[seps.length - 1]
+  const inner = lines.slice(topSep + 1, bottomSep)
+  const firstNonEmpty = inner.find(l => l.trim().length > 0)
+  if (firstNonEmpty == null || !/^\s*\u276F/.test(firstNonEmpty)) return null
+  return inner.join('\n')
+}
+
 function liveInputBox(pane: string): string | null {
   const lines = pane.split('\n')
   const footerIdx = lines.findIndex(l => IDLE_FOOTER_RX.test(l))
-  if (footerIdx < 0) return null
+  if (footerIdx < 0) return liveInputBoxFooterless(lines)
   let bottomSep = -1
   for (let i = footerIdx - 1; i >= 0; i--) {
     if (BOX_SEP_RX.test(lines[i])) { bottomSep = i; break }


### PR DESCRIPTION
## Mit

Delivery-reliability deep-fix, **pane-state.ts pure része** (umbrella BA56A500, card CDAA75B5). Két, tmux/IO nélküli string-analízis darab Dani I/O recovery-laddere alá.

### P1 (kritikus út) -- footer-less detekció
Fresh session / welcome screen (Claude Code logo + model + cwd, **nincs** `? for shortcuts` / `bypass permissions on` footer) esetén egy kézbesített üzenet beragadhat az input-boxba, mielőtt bármilyen footer renderelődne. A `liveInputBox` az `IDLE_FOOTER_RX`-re horgonyzott és footer híján `null`-t adott -> az egész stuck-input recovery stack vakon maradt, az agent örökre wedge-elt (valós eset: qwen welcome-screen).

- új `liveInputBoxFooterless`: footer hiányában az utolsó két box-separator közti sávot csak akkor veszi input-boxnak, ha az első nem-üres sor a prompt-glyph-fel kezdődik (scrollback `────` pár ellen védve)
- `detectPaneState` az ilyen parkolt footer-less boxot `typing`-nak osztályozza (parkolt szöveg, nem busy); üres / box-nélküli pane marad `unknown`

### P2 -- 2 pure export
- `parkedInputRowCount(pane): number` -- a parkolt box vizuális sorai, null/üres -> 0
- `submitLanded(prevSig, paneAfter): boolean` -- igaz ha a submit landolt (a pane már nem `typing` ugyanazzal a sig-gel); `paneAfter==null -> false`

Meglévő export-szignatúrát nem változtat.

## Teszt
`tsc --noEmit` 0 non-test hiba; `vitest run pane-state` **186/186 zöld**. P1+P2 fixtúrák: multi-row, single-row, placeholder, busy, cleared, scrollback-guard. A welcome-fixtúra a valós qwen wedge capture (inline bake-elve, provenance: store/qwen-welcome-stuck-fixture.txt).

## Határ
Csak `src/pane-state.ts` + tesztjei (PURE). Az I/O recovery-ladder (channel-monitor/agent-process) Danié, az integráció+keystroke Samué -- ez a PR azokat nem érinti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)