### PR TITLE
fix(channel-monitor): verify-and-escalate stuck-input recovery; never bare-Enter multi-row (BA56A500)

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -13,6 +13,8 @@ import {
   decideStuckInputRecovery,
   parkedChannelInput,
   parkedInputText,
+  parkedInputRowCount,
+  submitLanded,
 } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
@@ -1819,5 +1821,65 @@ describe('detectsPastePlaceholder', () => {
       '  paste again to expand',
     ].join('\n')
     expect(detectsPastePlaceholder(stubInBox)).toBe(true)
+  })
+})
+
+describe('parkedInputRowCount', () => {
+  it('returns 0 for an empty input box (bare prompt)', () => {
+    expect(parkedInputRowCount(IDLE_BYPASS)).toBe(0)
+    expect(parkedInputRowCount(BUSY_FULL_FOOTER)).toBe(0)
+  })
+
+  it('returns 0 when there is no input box at all', () => {
+    expect(parkedInputRowCount('just scrollback text\nno separators here')).toBe(0)
+  })
+
+  it('returns 1 for a single-row parked input', () => {
+    expect(parkedInputRowCount(TYPING_PARKED)).toBe(1)
+    expect(parkedInputRowCount(PENDING_PASTE)).toBe(1)
+  })
+
+  it('counts every visual row of a wrapped multi-row parked input', () => {
+    // A wrapped message occupying 3 box-interior rows; a bare Enter here would
+    // insert a newline instead of submitting.
+    const multiRow = [
+      '',
+      SEP,
+      '❯ first line of a long parked message that wraps across',
+      '  several visual rows inside the input box and would not',
+      '  submit on a bare Enter',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(parkedInputRowCount(multiRow)).toBe(3)
+  })
+})
+
+describe('submitLanded', () => {
+  // The exact text parked before the submit attempt.
+  const parkedSig = stuckInputSignature(TYPING_PARKED) as string
+
+  it('captures a non-empty signature from the parked fixture', () => {
+    expect(parkedSig).toBeTruthy()
+  })
+
+  it('is false when the identical signature is still parked', () => {
+    expect(submitLanded(parkedSig, TYPING_PARKED)).toBe(false)
+  })
+
+  it('is true when the box cleared (pane went idle)', () => {
+    expect(submitLanded(parkedSig, IDLE_BYPASS)).toBe(true)
+  })
+
+  it('is true when the agent started processing (pane went busy)', () => {
+    expect(submitLanded(parkedSig, BUSY_FULL_FOOTER)).toBe(true)
+  })
+
+  it('is true when different text is now parked', () => {
+    expect(submitLanded(parkedSig, PENDING_PASTE)).toBe(true)
+  })
+
+  it('is false when there is no after-capture (null)', () => {
+    expect(submitLanded(parkedSig, null)).toBe(false)
   })
 })

--- a/src/__tests__/stuck-input-action.test.ts
+++ b/src/__tests__/stuck-input-action.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decideStuckInputAction,
+  submitLanded,
+  parkedInputRowCount,
+  stuckInputSignature,
+  type StuckInputActionFacts,
+} from '../pane-state.js'
+
+// Delivery-reliability deep-fix (BA56A500): the I/O submit-escalation + post-
+// submit verification path. These cover the pure decision (decideStuckInputAction)
+// and the two submit predicates (parkedInputRowCount, submitLanded). The pre-
+// existing recovery-stack tests (decideStuckInputRecovery et al.) are untouched.
+
+// Realistic `tmux capture-pane -p` fixtures (same box-drawing bytes as
+// pane-state.test.ts: U+2500 ─, U+276F ❯).
+const SEP = '─'.repeat(80)
+const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+
+// A single-row parked <channel> block (complete: header + chat_id + close tag).
+const PARKED_CHANNEL_SINGLEROW = [
+  '',
+  SEP,
+  '❯ <channel source="plugin:telegram" chat_id="123">rovid uzenet</channel>',
+  SEP,
+  FOOTER,
+].join('\n')
+
+// The same block wrapped across 3 visual rows of the live input box.
+const PARKED_CHANNEL_MULTIROW = [
+  '',
+  SEP,
+  '❯ <channel source="plugin:telegram" chat_id="123">Szia, ez egy jó',
+  '  hosszú üzenet ami több sorba tördelődött a terminál szélén és',
+  '  több vizuális sort foglal el a beviteli dobozban</channel>',
+  SEP,
+  FOOTER,
+].join('\n')
+
+// An idle pane: empty input box, nothing parked.
+const IDLE = ['', SEP, '❯ ', SEP, FOOTER].join('\n')
+
+function facts(over: Partial<StuckInputActionFacts>): StuckInputActionFacts {
+  return {
+    escalate: false,
+    rowCount: 1,
+    blockComplete: false,
+    blockTruncated: false,
+    truncatedPreamble: false,
+    allowPlainReinject: false,
+    hasPlainText: false,
+    ...over,
+  }
+}
+
+describe('decideStuckInputAction (recovery-decision unit)', () => {
+  it('NEVER bare-Enters a multi-row box: complete block -> re-inject, not enter', () => {
+    // The core of the fix: a plain Enter on a multi-row parked message inserts a
+    // newline (corrupt). Multi-row escalates straight to the chat_id-safe
+    // re-inject even before the Enter-first budget is spent.
+    const a = decideStuckInputAction(facts({ rowCount: 3, blockComplete: true, escalate: false }))
+    expect(a).toBe('reinject-block')
+    expect(a).not.toBe('enter')
+  })
+
+  it('multi-row truncated <channel> block -> hold (no Enter, no wrong-chat_id re-inject)', () => {
+    const a = decideStuckInputAction(facts({ rowCount: 2, blockTruncated: true, escalate: true }))
+    expect(a).toBe('hold')
+  })
+
+  it('multi-row sub-agent plain text -> re-inject plain, never enter', () => {
+    const a = decideStuckInputAction(
+      facts({ rowCount: 2, allowPlainReinject: true, hasPlainText: true }),
+    )
+    expect(a).toBe('reinject-plain')
+  })
+
+  it('multi-row with nothing safely re-injectable -> hold (never corrupt via Enter)', () => {
+    const a = decideStuckInputAction(facts({ rowCount: 4 }))
+    expect(a).toBe('hold')
+  })
+
+  it('single-row complete block, pre-escalation -> bare Enter (may submit on its own)', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, blockComplete: true, escalate: false }))).toBe('enter')
+  })
+
+  it('single-row complete block, escalated -> clear + verbatim re-inject', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, blockComplete: true, escalate: true }))).toBe('reinject-block')
+  })
+
+  it('truncation-guard preserved: escalated truncated preamble -> clear only', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, truncatedPreamble: true, escalate: true }))).toBe('clear-preamble')
+  })
+
+  it('single-row truncated block keeps the harmless legacy Enter', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, blockTruncated: true, escalate: true }))).toBe('enter')
+  })
+
+  it('single-row default (swallowed Enter) -> bare Enter', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, escalate: true }))).toBe('enter')
+  })
+})
+
+describe('submitLanded (post-submit verification)', () => {
+  it('verified-landed -> stop: the parked signature cleared after submit', () => {
+    const prev = stuckInputSignature(PARKED_CHANNEL_SINGLEROW)
+    expect(prev).not.toBeNull()
+    expect(submitLanded(prev!, IDLE)).toBe(true)
+  })
+
+  it('not-landed -> escalate: the same text is still parked after the attempt', () => {
+    const prev = stuckInputSignature(PARKED_CHANNEL_SINGLEROW)
+    expect(submitLanded(prev!, PARKED_CHANNEL_SINGLEROW)).toBe(false)
+  })
+
+  it('null capture after submit -> not landed (cannot confirm -> escalate)', () => {
+    const prev = stuckInputSignature(PARKED_CHANNEL_SINGLEROW)
+    expect(submitLanded(prev!, null)).toBe(false)
+  })
+})
+
+describe('parkedInputRowCount', () => {
+  it('single-row parked input -> 1', () => {
+    expect(parkedInputRowCount(PARKED_CHANNEL_SINGLEROW)).toBe(1)
+  })
+
+  it('wrapped multi-row parked input -> >1', () => {
+    expect(parkedInputRowCount(PARKED_CHANNEL_MULTIROW)).toBe(3)
+  })
+
+  it('idle / empty box -> 0', () => {
+    expect(parkedInputRowCount(IDLE)).toBe(0)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -842,6 +842,41 @@ export function parkedInputText(pane: string): string | null {
   return flat.length > 0 ? flat : null
 }
 
+// How many VISUAL rows the live input box content occupies, ignoring the
+// bare prompt glyph and blank padding. The caller uses this to choose the
+// right submit keystroke: a MULTI-row parked input must NOT be submitted with
+// a bare Enter, because in the Claude TUI a plain Enter on a wrapped /
+// multi-line buffer inserts a newline instead of submitting (see
+// agent-process.ts:833) -- a single-row buffer submits on Enter.
+//
+// Counts the non-empty rows of liveInputBox() after stripping the leading `❯`
+// prompt marker; an empty box (`❯ ` only) or no box at all -> 0. Pure: no
+// tmux, only the captured text.
+export function parkedInputRowCount(pane: string): number {
+  const box = liveInputBox(pane)
+  if (box == null) return 0
+  return box
+    .split('\n')
+    .map((row) => row.replace(/^\s*❯/, '').trim())
+    .filter((row) => row.length > 0).length
+}
+
+// Post-submit verification: did the parked input actually leave the box?
+//
+// `prevSig` is stuckInputSignature(pane) captured BEFORE the submit attempt
+// (the exact text that was parked). `paneAfter` is a fresh capture taken
+// AFTER the submit. Returns true when the submit LANDED -- the same parked
+// signature is no longer 'typing' in the box: it cleared (pane went idle),
+// the agent started processing it (pane went busy), or different text is now
+// parked. Returns false when the IDENTICAL signature is still parked (the
+// Enter was swallowed -> the caller should retry / escalate), or when
+// paneAfter is null (no capture -> cannot confirm, treat as not-landed).
+// Pure: builds on stuckInputSignature() (which gates on detectPaneState).
+export function submitLanded(prevSig: string, paneAfter: string | null): boolean {
+  if (paneAfter == null) return false
+  return stuckInputSignature(paneAfter) !== prevSig
+}
+
 // Per-session bookkeeping for the stuck-input recovery watcher. A "spell"
 // is one continuous stretch of the SAME text parked in the input box.
 export interface StuckInputState {

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -985,6 +985,79 @@ export function decideStuckInputRecovery(
 }
 
 // =============================================================================
+// Submit-action decision (delivery-reliability, BA56A500)
+// =============================================================================
+//
+// Turns the parked-input facts -- built from parkedInputRowCount() and
+// parkedChannelInput() above -- into a recovery MOVE. The decision is the heart
+// of the fix: a plain recovery Enter on a MULTI-ROW parked message inserts a
+// newline rather than submitting (corrupt), so multi-row must never bare-Enter;
+// and the chat_id truncation-guard (no verbatim re-inject of an incomplete
+// <channel> block) is preserved. The caller verifies the move landed with
+// submitLanded() and escalates within the attempts budget if it did not.
+
+/** A concrete recovery move for the stuck-input watcher. */
+export type StuckInputAction =
+  | 'reinject-block'   // clear + verbatim re-inject the COMPLETE <channel> block (chat_id-safe)
+  | 'reinject-plain'   // clear + re-inject collapsed parked text (sub-agents only)
+  | 'clear-preamble'   // clear a truncated/stale safety preamble, never re-inject
+  | 'enter'            // a single bare Enter -- ONLY safe at rowCount <= 1
+  | 'hold'             // do nothing this tick (multi-row truncated / truncation-guard)
+
+export interface StuckInputActionFacts {
+  /** attempt > MAIN_STUCK_ENTER_ATTEMPTS -- past the Enter-first budget. */
+  escalate: boolean
+  /** parkedInputRowCount(pane) -- >1 forbids a bare Enter. */
+  rowCount: number
+  /** A complete <channel> block is parked: chat_id-safe verbatim re-inject. */
+  blockComplete: boolean
+  /** A <channel> block is parked but truncated: chat_id unrecoverable, MUST
+   * NOT re-inject (wrong chat_id) and MUST NOT corrupt via a multi-row Enter. */
+  blockTruncated: boolean
+  /** shouldClearTruncatedPreamble(pane): a stale safety preamble to clear. */
+  truncatedPreamble: boolean
+  /** Sub-agent session: re-injecting collapsed parked text is safe (no human draft). */
+  allowPlainReinject: boolean
+  /** parkedInputText(pane) != null -- there is collapsed text to re-inject. */
+  hasPlainText: boolean
+}
+
+/**
+ * Pure decision: given the parked-input facts, what recovery move to make.
+ * Dependency-free so it is unit-testable without tmux.
+ *
+ * Invariants (the fix):
+ *   - NEVER bare-Enter a multi-row box (rowCount > 1) -- it inserts a newline
+ *     and corrupts the message. Multi-row escalates straight to a re-inject
+ *     (when one is safe) or holds.
+ *   - A complete <channel> block is the safest move (chat_id-safe re-inject);
+ *     prefer it as soon as we escalate, and immediately when multi-row.
+ *   - A TRUNCATED <channel> block (chat_id unrecoverable) must not be
+ *     re-injected; multi-row truncated holds (awaiting the keystroke fix),
+ *     single-row keeps the harmless legacy Enter.
+ *   - Otherwise a bare Enter is the swallowed-Enter remedy, but only single-row.
+ */
+export function decideStuckInputAction(f: StuckInputActionFacts): StuckInputAction {
+  const multiRow = f.rowCount > 1
+  // Complete channel block: chat_id-safe verbatim re-inject. Multi-row is itself
+  // a reason to escalate now (a plain Enter would corrupt it).
+  if (f.blockComplete) {
+    return f.escalate || multiRow ? 'reinject-block' : 'enter'
+  }
+  // Sub-agent non-channel parked text: clear + re-inject is safe (no human draft).
+  if (f.allowPlainReinject && f.hasPlainText && !f.blockTruncated) {
+    return f.escalate || multiRow ? 'reinject-plain' : 'enter'
+  }
+  // Truncated safety preamble: clear only (never re-inject a stale preamble).
+  if (f.truncatedPreamble && f.escalate) return 'clear-preamble'
+  // Truncated <channel> block: hold a multi-row (Enter would corrupt; re-inject
+  // would answer the wrong chat_id), keep the harmless legacy Enter single-row.
+  if (f.blockTruncated) return multiRow ? 'hold' : 'enter'
+  // Default swallowed-Enter remedy -- never on multi-row.
+  return multiRow ? 'hold' : 'enter'
+}
+
+// =============================================================================
 // Stuck tool-call watcher (2026-06-02 incident, Worked-for >Ns freeze)
 // =============================================================================
 //

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -25,7 +25,9 @@ import {
   detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
   parkedInputText, shouldClearTruncatedPreamble,
-  type StuckInputState, type StuckInputThresholds,
+  parkedInputRowCount, submitLanded, decideStuckInputAction,
+  type StuckInputState, type StuckInputThresholds, type StuckInputAction,
+  type StuckInputActionFacts,
 } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
@@ -196,49 +198,90 @@ export function recoverStuckInputForSession(
   const decision = decideStuckInputRecovery(sig, prev, Date.now(), thresholds)
   if (decision.recover && pane != null) {
     const attempt = decision.next.attempts
-    const escalate = attempt > MAIN_STUCK_ENTER_ATTEMPTS
     const block = parkedChannelInput(pane)
-    if (escalate && block != null && block.complete && block.block != null) {
-      logger.warn({ session, chatId: block.chatId, attempt }, 'Stuck channel input -- escalating to clear + verbatim re-inject')
-      try {
-        clearInputBuffer(session)
-        sendPromptToSession(session, block.block)
-      } catch (err) {
-        logger.warn({ err, session }, 'Stuck-input re-inject failed')
-      }
-    } else if (escalate && shouldClearTruncatedPreamble(pane)) {
-      logger.warn({ session, attempt }, 'Stuck input -- truncated safety preamble, clearing buffer (no re-inject)')
-      try {
-        clearInputBuffer(session)
-      } catch (err) {
-        logger.warn({ err, session }, 'Stuck-input preamble clear failed')
-      }
-    } else if (escalate && allowPlainReinject && block == null) {
-      const text = parkedInputText(pane)
-      if (text != null) {
-        logger.warn({ session, attempt }, 'Stuck input (non-channel) -- escalating to clear + re-inject parked text')
-        try {
-          clearInputBuffer(session)
-          sendPromptToSession(session, text)
-        } catch (err) {
-          logger.warn({ err, session }, 'Stuck-input plain re-inject failed')
-        }
-      } else {
-        try { execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 }) } catch { /* no-op */ }
-      }
-    } else {
-      // Enter-first, and the truncation-guard fallback: if escalation was due
-      // but the <channel> block looks incomplete, hold on Enter instead.
-      const heldForTruncation = escalate && block != null && !block.complete
-      logger.warn({ session, attempt, heldForTruncation }, 'Stuck input -- recovery Enter')
-      try {
-        execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
-      } catch (err) {
-        logger.warn({ err, session }, 'Stuck-input recovery Enter failed')
-      }
+    // Gather the parked-input facts and let the pure decision choose the move.
+    // The decision NEVER bare-Enters a multi-row box (that inserts a newline
+    // and corrupts the message) and prefers a chat_id-safe re-inject; the
+    // truncation-guard (no verbatim re-inject of an incomplete <channel> block)
+    // is preserved via blockTruncated.
+    const facts: StuckInputActionFacts = {
+      escalate: attempt > MAIN_STUCK_ENTER_ATTEMPTS,
+      rowCount: parkedInputRowCount(pane),
+      blockComplete: block != null && block.complete && block.block != null,
+      blockTruncated: block != null && !block.complete,
+      truncatedPreamble: shouldClearTruncatedPreamble(pane),
+      allowPlainReinject,
+      hasPlainText: allowPlainReinject && parkedInputText(pane) != null,
     }
+    const action = decideStuckInputAction(facts)
+    performStuckInputAction(session, action, pane, block, sig, attempt)
   }
   return decision.next
+}
+
+// Execute a stuck-input recovery action and verify it landed. The action is
+// chosen by the pure decideStuckInputAction(); this does only the tmux side-
+// effect plus POST-SUBMIT VERIFICATION (re-capture + submitLanded), so a move
+// that did NOT clear the parked text is logged and the next tick escalates
+// within the attempts budget (decideStuckInputRecovery caps it). 'hold' and
+// 'clear-preamble' submit nothing, so there is nothing to verify there.
+function performStuckInputAction(
+  session: string,
+  action: StuckInputAction,
+  paneBefore: string,
+  block: ReturnType<typeof parkedChannelInput>,
+  prevSig: string | null,
+  attempt: number,
+): void {
+  let submitted = false
+  try {
+    switch (action) {
+      case 'reinject-block':
+        logger.warn({ session, chatId: block?.chatId, attempt }, 'Stuck channel input -- clear + verbatim re-inject')
+        clearInputBuffer(session)
+        sendPromptToSession(session, block!.block!)
+        submitted = true
+        break
+      case 'reinject-plain': {
+        const text = parkedInputText(paneBefore)
+        if (text != null) {
+          logger.warn({ session, attempt }, 'Stuck input (non-channel) -- clear + re-inject parked text')
+          clearInputBuffer(session)
+          sendPromptToSession(session, text)
+        } else {
+          execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+        }
+        submitted = true
+        break
+      }
+      case 'clear-preamble':
+        logger.warn({ session, attempt }, 'Stuck input -- truncated safety preamble, clearing buffer (no re-inject)')
+        clearInputBuffer(session)
+        break
+      case 'enter':
+        execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+        submitted = true
+        break
+      case 'hold':
+        logger.warn({ session, attempt }, 'Stuck input -- multi-row/truncated, holding (no bare-Enter; awaiting keystroke fix)')
+        break
+    }
+  } catch (err) {
+    logger.warn({ err, session, action }, 'Stuck-input recovery action failed')
+    return
+  }
+  if (submitted) {
+    // submitLanded() handles a null capture internally (-> not landed). prevSig
+    // is non-null here in practice (recover only fires on a parked signature),
+    // but guard the type narrowing explicitly.
+    const landed = prevSig != null ? submitLanded(prevSig, capturePane(session)) : false
+    logger.warn(
+      { session, action, attempt, landed },
+      landed
+        ? 'Stuck input -- recovery action landed'
+        : 'Stuck input -- recovery action did NOT land (escalating next tick within budget)',
+    )
+  }
 }
 
 // Periodic detached-channel-claude reap (CB6CF755 durable fix). The pane-


### PR DESCRIPTION
## Mit

Delivery-reliability mélyfix (BA56A500) -- az **I/O submit-escalation + verifikáció** fele. A kézbesített üzenet beragadt a Claude TUI input-boxába és a recovery watcher nem submittálta megbízhatóan.

Két gyökérok a channel-kézbesítési úton:
- Plain recovery Enter egy **multi-row** parkolt üzeneten **újsort** szúr be submit helyett -> korrupt üzenet.
- A recovery vakon tüzelt: nincs post-submit ellenőrzés, így egy elnyelt Enter ugyanúgy nézett ki mint egy sikeres submit -> a watcher feladta/loopolt.

## Tartalom (2 commit)

1. `a3f9b37` **parkedInputRowCount + submitLanded** pure predikátumok (**Geri**, co-authored). *Lásd lent a koordinációt -- Geri commitja a közös working tree miatt ide landolt; stub helyett a valódi predikátumokra építek (nincs stub-adósság).*
2. `e81d0f5` **decideStuckInputAction** (pure, pane-state.ts) + **recoverStuckInputForSession** átírás + **post-submit verifikáció** (channel-monitor.ts).

`decideStuckInputAction`:
- **SOHA nem bare-Enter-el multi-row boxot** -> chat_id-safe verbatim re-inject (complete `<channel>` blokk), sub-agent plain re-inject, vagy **hold**.
- **chat_id truncation-guard megtartva**: incomplete `<channel>` blokkot SOHA nem re-injektál; multi-row truncated -> hold.
- v1.13.1 busy-guard és single-row Enter-first viselkedés **változatlan**.

`recoverStuckInputForSession` -> `performStuckInputAction`: tmux side-effect + **post-submit verify** (re-capture + `submitLanded`). Nem-landolt move logolva, a következő tick eszkalál az attempts budgetig.

## Teszt
- `stuck-input-action.test.ts` (15): multi-row->ne-Enter / landed->stop / not-landed->escalate / truncation-guard / predikátum-fixtúrák.
- Teljes recovery-stack suite **zöld, nincs regresszió**. tsc zöld.
- Megj: a `template-identity-hygiene` (scripts/support-mail) teszt-bukás **pre-existing** (a support-mail azonos a developdel, üres diff), NEM ez a PR.

## Koordináció (Samu integrálja)
- A `liveInputBoxFooterless` fresh-session refaktor **külön** `geri-footerless-fix.patch`-ben (NEM ebbe a PR-be, Geri/Samu külön kezeli).
- Geri predikátum-commitja `geri/pane-state-predicates` ref alatt is biztosítva.
- Ez a hard-restart/keystroke-szekvencia (truncated dead-end) ágat NEM tartalmazza -- az Samu koordinációjára vár.

Kártya: BA56A500.