### PR TITLE
fix(channel): reliable parked-message recovery — welcome-screen detection + submit-verify ladder

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -1883,3 +1883,68 @@ describe('submitLanded', () => {
     expect(submitLanded(parkedSig, null)).toBe(false)
   })
 })
+
+// Fresh-session / welcome-screen layout (Claude Code logo + model line + cwd,
+// the input box framed by two ──── rules, ❯ prefix, NO footer). Modelled on a
+// real captured stuck pane (store/qwen-welcome-stuck-fixture.txt) where a
+// delivered multi-row message parked before any footer rendered, and the whole
+// recovery stack went blind (liveInputBox null -> detectPaneState 'unknown').
+const WELCOME_STUCK = [
+  '',
+  ' ▐▛███▜▌   Claude Code v2.1.170',
+  '▝▜█████▛▘  qwen3.6:27b-192k with high effort · API Usage Billing',
+  '  ▘▘ ▝▝    ~/ClaudeClaw/agents/qwen',
+  '',
+  '',
+  SEP,
+  '❯ kepet: /Users/marvin/workspace/aahe486-screenshot.png',
+  '  Olvasd be a Read tool-lal a kepfajlt, majd mondd meg: (1) mi ez az',
+  '  alkalmazas, (2) a tablazat konkret ertekei. Roviden a vegeredmenyt.',
+  '  </trusted-peer>',
+  SEP,
+  '',
+].join('\n')
+
+describe('footer-less welcome-screen parked input', () => {
+  it('classifies the parked box as typing (not unknown)', () => {
+    expect(detectPaneState(WELCOME_STUCK)).toBe('typing')
+  })
+
+  it('mergeTypingAsBusy folds the footer-less parked box into busy', () => {
+    expect(detectPaneState(WELCOME_STUCK, { mergeTypingAsBusy: true })).toBe('busy')
+  })
+
+  it('stuckInputSignature recovers a non-null signature', () => {
+    const sig = stuckInputSignature(WELCOME_STUCK)
+    expect(sig).not.toBeNull()
+    expect(sig).toContain('kepet')
+  })
+
+  it('parkedInputText returns the collapsed multi-row message (not empty)', () => {
+    const t = parkedInputText(WELCOME_STUCK)
+    expect(t).not.toBeNull()
+    expect(t).not.toBe('')
+    expect(t).toContain('Olvasd be')
+  })
+
+  it('parkedInputRowCount counts every wrapped row (> 1 on a real wedge)', () => {
+    expect(parkedInputRowCount(WELCOME_STUCK)).toBe(4)
+    expect(parkedInputRowCount(WELCOME_STUCK)).toBeGreaterThan(1)
+  })
+
+  it('submitLanded fires once the welcome wedge clears to an idle pane', () => {
+    // Full P1 -> P2 chain on the real wedge: detection sees the footer-less
+    // parked box (sig != null), and after the message submits the pane is no
+    // longer that signature -> submitLanded true. This is what tells the
+    // recovery ladder the resubmit actually landed.
+    const sig = stuckInputSignature(WELCOME_STUCK)
+    expect(sig).not.toBeNull()
+    expect(submitLanded(sig as string, IDLE_BYPASS)).toBe(true)
+  })
+
+  it('does NOT mistake a scrollback ──── pair without a ❯ box for input', () => {
+    const noBox = ['some scrollback line', SEP, 'plain text, no prompt glyph', SEP, ''].join('\n')
+    expect(detectPaneState(noBox)).toBe('unknown')
+    expect(parkedInputRowCount(noBox)).toBe(0)
+  })
+})

--- a/src/__tests__/welcome-screen-recovery.test.ts
+++ b/src/__tests__/welcome-screen-recovery.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import {
+  detectPaneState,
+  stuckInputSignature,
+  parkedInputRowCount,
+  parkedInputText,
+  decideStuckInputAction,
+} from '../pane-state.js'
+
+// End-to-end regression guard for the REAL production wedge (2026-06-26):
+// a delivered multi-row inter-agent message parked in a Claude Code v2.1.170
+// fresh-session WELCOME screen (logo + model + cwd, box between two rule lines,
+// no idle footer). Before the P1 fix, liveInputBox anchored on the idle footer,
+// so detectPaneState returned 'unknown' and the whole recovery stack was blind
+// -> the agent stayed wedged until a manual restart. This fixture is the actual
+// captured qwen pane. Live validation confirmed a single Enter submits it once
+// detected; the ladder uses the more robust reinject-plain for a sub-agent.
+const QWEN_WELCOME_WEDGE = `
+ ▐▛███▜▌   Claude Code v2.1.170
+▝▜█████▛▘  qwen3.6:27b-192k with high effort · API Usage Billing
+  ▘▘ ▝▝    ~/ClaudeClaw/agents/qwen
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+❯ kepet: /Users/marvin/ClaudeClaw/workspace/mbh-issue/aahe486-screenshot.png
+  Olvasd be a Read tool-lal a kepfajlt, majd mondd meg: (1) mi ez az
+  alkalmazas/oldal, (2) a tablazat konkret ertekei -- rendszam, tipus,
+  letrehozas+modositas datumok, hany sor. Roviden a vegeredmenyt (ne
+  gondolkodj sokat). Ez egy kepesseg-teszt rolad (qwen3.6 lokal modell),
+  szoval csak old meg ahogy tudod, es a valaszod visszajelzem Szabinak.
+  </trusted-peer>
+────────────────────────────────────────────────────────────────────────────────
+
+`
+
+describe('welcome-screen wedge: detection -> recovery decision (real fixture)', () => {
+  it('P1 detection sees the footer-less welcome-screen parked input', () => {
+    expect(detectPaneState(QWEN_WELCOME_WEDGE)).toBe('typing')
+    expect(stuckInputSignature(QWEN_WELCOME_WEDGE)).not.toBeNull()
+    expect(parkedInputText(QWEN_WELCOME_WEDGE)).not.toBeNull()
+    expect(parkedInputRowCount(QWEN_WELCOME_WEDGE)).toBeGreaterThan(1)
+  })
+
+  it('recovery decides reinject-plain for the multi-row sub-agent message (not hold/bare-Enter)', () => {
+    const action = decideStuckInputAction({
+      escalate: false,
+      rowCount: parkedInputRowCount(QWEN_WELCOME_WEDGE),
+      blockComplete: false,
+      blockTruncated: false,
+      truncatedPreamble: false,
+      allowPlainReinject: true, // sub-agent box: no human draft
+      hasPlainText: parkedInputText(QWEN_WELCOME_WEDGE) != null,
+    })
+    expect(action).toBe('reinject-plain')
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -374,7 +374,18 @@ export function detectPaneState(
   // defer rather than pile a second prompt on.
   if (detectsPastePlaceholder(pane)) return 'busy'
 
-  if (!IDLE_FOOTER_RX.test(pane)) return 'unknown'
+  if (!IDLE_FOOTER_RX.test(pane)) {
+    // Footer-less fresh-session / welcome-screen: a PARKED \u276F input box still
+    // means the agent has a delivered message waiting to submit. Classify it
+    // 'typing' (not 'unknown') so the stuck-input recovery stack can see and
+    // resubmit it. An empty box / no box stays 'unknown' -- without a footer
+    // there is nothing to confirm a genuine idle state.
+    const box = liveInputBox(pane)
+    if (box != null && box.split('\n').some(l => PARKED_INPUT_RX.test(l))) {
+      return opts.mergeTypingAsBusy ? 'busy' : 'typing'
+    }
+    return 'unknown'
+  }
 
   if (detectsThinkingBlockError(pane)) return 'error'
 
@@ -437,10 +448,31 @@ export function isReadyForPrompt(pane: string): boolean {
 // Returns null when the pane does not have a live input box (no idle
 // footer, only one separator, etc.) -- callers should treat null as
 // "not enough signal to act, do nothing".
+// Fallback for the fresh-session / welcome-screen layout (Claude Code logo +
+// model line + cwd, NO idle footer): a delivered message can sit parked in the
+// input box before the footer is ever rendered, and the footer-anchored path
+// would miss it entirely (return null -> the whole recovery stack goes blind).
+// Anchor on the LAST TWO box separators (/^\u2500{10,}/) and treat the span
+// between them as the input box ONLY when its first non-empty row starts with
+// the \u276F prompt -- otherwise a pair of scrollback rules would be mis-read.
+function liveInputBoxFooterless(lines: string[]): string | null {
+  const seps: number[] = []
+  for (let i = 0; i < lines.length; i++) {
+    if (BOX_SEP_RX.test(lines[i])) seps.push(i)
+  }
+  if (seps.length < 2) return null
+  const topSep = seps[seps.length - 2]
+  const bottomSep = seps[seps.length - 1]
+  const inner = lines.slice(topSep + 1, bottomSep)
+  const firstNonEmpty = inner.find(l => l.trim().length > 0)
+  if (firstNonEmpty == null || !/^\s*\u276F/.test(firstNonEmpty)) return null
+  return inner.join('\n')
+}
+
 function liveInputBox(pane: string): string | null {
   const lines = pane.split('\n')
   const footerIdx = lines.findIndex(l => IDLE_FOOTER_RX.test(l))
-  if (footerIdx < 0) return null
+  if (footerIdx < 0) return liveInputBoxFooterless(lines)
   let bottomSep = -1
   for (let i = footerIdx - 1; i >= 0; i--) {
     if (BOX_SEP_RX.test(lines[i])) { bottomSep = i; break }


### PR DESCRIPTION
## Probléma
Kézbesített üzenet beragad a Claude TUI input-boxába (raw-mode Enter-swallow), a soft-recovery néha nem küldte be -> sub-agentek wedge-elnek + "kézi restart kell" alert (Pataki Gábor customer-installján is). v1.13.1 (#454) busy-guardja a FŐ-session öngyilkos restartját állította meg, de a gyökér megmaradt.

## Gyökérok (élő qwen-reprodukcióval megtalálva)
A `detectPaneState`/`liveInputBox` az **idle-footerre** (`? for shortcuts` / `bypass permissions on`) horgonyzott. A Claude Code v2.1.170 **fresh-session / welcome-screen** layouton (logo + model + cwd, a box két `────` rule közt, `❯` prompt, **NINCS footer**) nincs ilyen footer -> `liveInputBox` `null` -> `detectPaneState` `unknown` -> **a teljes recovery-stack VAK volt a parkolt üzenetre** -> permanent wedge -> alert. A valós qwen-pane-en mértem: minden classifier `null`/`unknown` egy nyilvánvalóan parkolt 7-soros üzenetre.

## Megoldás (3 réteg)
1. **Detekció (P1, @geri)** — `liveInputBoxFooterless`: ha nincs idle-footer, a két `────` rule + `❯` prompt alapján nyeri ki a box-ot. Ez teszi LÁTHATÓVÁ a welcome-screen wedge-et. + 2 pure predikátum: `parkedInputRowCount`, `submitLanded`.
2. **Submit-verify ladder (@dani)** — `recoverStuckInputForSession` átírva a pure `decideStuckInputAction`-re + **POST-SUBMIT VERIFIKÁCIÓ** (re-capture + `submitLanded` minden beküldés után, escalate-next-tick a budgetig). SOHA nem bare-Enter-el multi-row boxot (a plain Enter újsort szúrna). Döntés-mátrix: complete `<channel>` blokk -> `reinject-block` (chat_id-safe); sub-agent plain text -> `reinject-plain`; single-row -> `enter`; truncated `<channel>` multi-row -> `hold`.
3. **Integráció + élő validáció (@samu)** — egy ágba fésülve, és **élesben validálva**: un-wedge-eltem a wedge-elt qwen-t (Marveen GO-val). A P1-detekció után 1 Enter HIBÁTLANUL beküldte a 7-soros parkolt üzenetet -> qwen processing. MEGERŐSÍTVE: a welcome-screen wedge gyökere PUSZTÁN DETEKCIÓ volt.

## Korlátok megtartva
- v1.13.1 busy-guard NEM regresszál.
- chat_id truncation-guard megmarad: incomplete `<channel>` blokkot SOHA nem injektálunk újra (rossz chat_id veszély).
- Pure döntés-fv-k (unit-tesztelhetők tmux nélkül).

## Ismert maradék (követés)
A **truncated `<channel>` blokk + multi-row** eset `hold` marad (chat_id nem reconstruálható ÉS a multi-row Enter korrumpálná). Az élő validáció szerint a welcome-screen Enter-submit megbízható, így ehhez egy verified-Enter in-place beküldés egy jövőbeli finomítás lehet — de a guard-biztos `hold` most a helyes konzervatív választás.

## Teszt
- 220 recovery-stack teszt zöld (pane-state 187, action 15, restart 11, janitor 3, fast-recovery).
- Új `welcome-screen-recovery.test.ts`: end-to-end regresszió-guard a VALÓS qwen-fixturán (detekció `typing` + döntés `reinject-plain`).
- `tsc --noEmit` zöld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)