### PR TITLE
fix(agents): per-agent isolated CLAUDE_CONFIG_DIR so channel plugins …

### DIFF
--- a/src/__tests__/isolated-channel-config.test.ts
+++ b/src/__tests__/isolated-channel-config.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  mkdtempSync, mkdirSync, writeFileSync, rmSync, lstatSync, readlinkSync, readFileSync, existsSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Redirect homedir() (used inside ensureIsolatedChannelConfigDir to find the
+// shared ~/.claude) and agentDir() (used to find the agent cwd) at the temp
+// sandbox built per test. tmpdir() stays real so we can create the sandbox.
+let SANDBOX = ''
+vi.mock('node:os', async (orig) => {
+  const actual = await orig<typeof import('node:os')>()
+  return { ...actual, homedir: () => join(SANDBOX, 'home') }
+})
+vi.mock('../web/agent-config.js', async (orig) => {
+  const actual = await orig<typeof import('../web/agent-config.js')>()
+  return { ...actual, agentDir: (name: string) => join(SANDBOX, 'agents', name) }
+})
+
+// Imported AFTER the mocks are registered.
+const { ensureIsolatedChannelConfigDir, CHANNEL_PLUGIN_IDS } = await import('../web/agent-process.js')
+const TG = CHANNEL_PLUGIN_IDS.telegram
+const SL = CHANNEL_PLUGIN_IDS.slack
+const DI = CHANNEL_PLUGIN_IDS.discord
+
+function seedSharedClaude(home: string) {
+  const claude = join(home, '.claude')
+  mkdirSync(claude, { recursive: true })
+  // shared top-level entries that must end up symlinked (auth, transcripts)
+  writeFileSync(join(claude, '.credentials.json'), '{"claudeAiOauth":{}}')
+  mkdirSync(join(claude, 'projects'), { recursive: true })
+  // settings.json must be OWNED (copied), not symlinked
+  writeFileSync(join(claude, 'settings.json'), JSON.stringify({ hooks: { Stop: [] }, enabledPlugins: { [TG]: true } }))
+  // plugins/: cache+marketplaces+data symlinked, install state owned
+  const plugins = join(claude, 'plugins')
+  mkdirSync(join(plugins, 'cache'), { recursive: true })
+  mkdirSync(join(plugins, 'marketplaces'), { recursive: true })
+  mkdirSync(join(plugins, 'data'), { recursive: true })
+  writeFileSync(join(plugins, 'known_marketplaces.json'), '{"claude-plugins-official":{}}')
+  writeFileSync(join(plugins, 'installed_plugins.json'), JSON.stringify({
+    plugins: {
+      [TG]: [{ scope: 'project', projectPath: '/some/other/agent', installPath: '/x', version: '0.0.6' }],
+    },
+  }))
+}
+
+beforeEach(() => {
+  SANDBOX = mkdtempSync(join(tmpdir(), 'isocfg-'))
+  seedSharedClaude(join(SANDBOX, 'home'))
+  mkdirSync(join(SANDBOX, 'agents', 'testagent'), { recursive: true })
+})
+afterEach(() => {
+  rmSync(SANDBOX, { recursive: true, force: true })
+})
+
+describe('ensureIsolatedChannelConfigDir', () => {
+  it('returns the per-agent .claude-config path', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'telegram')
+    expect(cfg).toBe(join(SANDBOX, 'agents', 'testagent', '.claude-config'))
+  })
+
+  it('symlinks shared auth/transcripts so --continue + login stay shared', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'telegram')!
+    expect(lstatSync(join(cfg, '.credentials.json')).isSymbolicLink()).toBe(true)
+    expect(lstatSync(join(cfg, 'projects')).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(join(cfg, '.credentials.json'))).toBe(join(SANDBOX, 'home', '.claude', '.credentials.json'))
+  })
+
+  it('OWNS settings.json (real file) with only the agent provider plugin enabled', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'telegram')!
+    const sp = join(cfg, 'settings.json')
+    expect(lstatSync(sp).isSymbolicLink()).toBe(false)
+    const s = JSON.parse(readFileSync(sp, 'utf-8'))
+    expect(s.enabledPlugins[TG]).toBe(true)
+    expect(s.enabledPlugins[SL]).toBe(false)
+    expect(s.enabledPlugins[DI]).toBe(false)
+    expect(s.hooks).toEqual({ Stop: [] }) // shared non-plugin settings preserved
+  })
+
+  it('a slack agent enables ONLY slack in its isolated settings', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'slack')!
+    const s = JSON.parse(readFileSync(join(cfg, 'settings.json'), 'utf-8'))
+    expect(s.enabledPlugins[SL]).toBe(true)
+    expect(s.enabledPlugins[TG]).toBe(false)
+  })
+
+  it('OWNS plugins/installed_plugins.json re-pointed at this agent cwd, symlinks the cache', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'telegram')!
+    expect(lstatSync(join(cfg, 'plugins', 'cache')).isSymbolicLink()).toBe(true)
+    const ip = join(cfg, 'plugins', 'installed_plugins.json')
+    expect(lstatSync(ip).isSymbolicLink()).toBe(false)
+    const inst = JSON.parse(readFileSync(ip, 'utf-8'))
+    expect(inst.plugins[TG][0].projectPath).toBe(join(SANDBOX, 'agents', 'testagent'))
+  })
+
+  it('is idempotent: a second call leaves a valid isolated dir', () => {
+    const first = ensureIsolatedChannelConfigDir('testagent', 'telegram')
+    const second = ensureIsolatedChannelConfigDir('testagent', 'telegram')
+    expect(second).toBe(first)
+    expect(existsSync(join(second!, 'settings.json'))).toBe(true)
+    expect(lstatSync(join(second!, 'plugins', 'cache')).isSymbolicLink()).toBe(true)
+  })
+
+  it('returns null (degraded, not fatal) when the shared ~/.claude is absent', () => {
+    rmSync(join(SANDBOX, 'home', '.claude'), { recursive: true, force: true })
+    expect(ensureIsolatedChannelConfigDir('testagent', 'telegram')).toBeNull()
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, lstatSync, symlinkSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync, execFileSync } from 'node:child_process'
@@ -92,6 +92,127 @@ export function ownChannelProviderForScope(
   resolvedProvider: string | null,
 ): string | null {
   return hasOwnToken && resolvedProvider ? resolvedProvider : null
+}
+
+// Per-agent isolated CLAUDE_CONFIG_DIR provisioning (2026-06-26 fleet outage).
+//
+// Claude Code records a plugin's PROJECT-scoped install in a single shared
+// file -- ~/.claude/plugins/installed_plugins.json -- keyed by one projectPath
+// per plugin id. Every sub-agent ran out of the SAME ~/.claude, so each agent
+// launch (claude --channels plugin:telegram@...) rewrote that single slot to
+// its OWN project, evicting whichever agent registered before it. Net effect:
+// only ONE agent's channel plugin could be registered (and thus only one bun
+// getUpdates poller / one live bot.pid) at a time fleet-wide; every other agent
+// saw "No MCP servers configured", spawned no poller, and went deaf on its
+// channel. It also produced the /mcp-flap alert storm (agents racing for the
+// slot). Sequentialising restarts did NOT help (the slot is shared state, not a
+// startup-batch race); the only structural fix is to stop the agents sharing
+// one plugin-install file.
+//
+// This gives each channel sub-agent its own CLAUDE_CONFIG_DIR. The pattern
+// mirrors the heartbeat worker's isolation (src/heartbeat.ts): symlink every
+// top-level ~/.claude entry so auth (.credentials.json), project transcripts
+// (--continue) and the plugin marketplaces stay shared, EXCEPT settings.json
+// and plugins/ which become per-agent. The private plugins/ dir symlinks the
+// heavy shared, read-only parts (cache/marketplaces/data) but OWNS
+// installed_plugins.json + known_marketplaces.json, so each agent's
+// project-scoped install lives in its own file and can never evict another's.
+//
+// Idempotent and best-effort: returns the dir on success, or null so the caller
+// falls back to the shared ~/.claude (degraded, but never a launch failure).
+const ISOLATED_CONFIG_SKIP = new Set(['settings.json', 'plugins'])
+
+export function ensureIsolatedChannelConfigDir(
+  name: string,
+  providerType: ChannelProviderType,
+): string | null {
+  try {
+    const cwd = agentDir(name)
+    const cfg = join(cwd, '.claude-config')
+    const realClaude = join(homedir(), '.claude')
+    if (!existsSync(realClaude)) return null
+    mkdirSync(cfg, { recursive: true })
+
+    // 1. Symlink every top-level ~/.claude entry except the two we own.
+    //    A stale non-symlink (e.g. a prior copy) is removed and re-linked so a
+    //    manual edit cannot permanently break the isolation.
+    for (const entry of readdirSync(realClaude)) {
+      if (ISOLATED_CONFIG_SKIP.has(entry)) continue
+      const link = join(cfg, entry)
+      let needsLink = true
+      try {
+        if (lstatSync(link).isSymbolicLink()) needsLink = false
+        else rmSync(link, { recursive: true, force: true })
+      } catch { /* absent -> create */ }
+      if (needsLink) {
+        try { symlinkSync(join(realClaude, entry), link) }
+        catch (err) { logger.warn({ err, entry, name }, 'isolated-config: symlink failed') }
+      }
+    }
+
+    // 2. Own settings.json: copy the shared one (keeps hooks etc.) but force
+    //    enabledPlugins to this agent's own provider only (all other channel
+    //    plugins false), matching the spawn-time scope decision.
+    const sharedSettings = join(realClaude, 'settings.json')
+    let settings: Record<string, unknown> = {}
+    if (existsSync(sharedSettings)) {
+      try { settings = JSON.parse(readFileSync(sharedSettings, 'utf-8')) as Record<string, unknown> }
+      catch { settings = {} }
+    }
+    const ownScopedPlugins = scopeChannelPlugins(
+      providerType,
+      settings.enabledPlugins as Record<string, boolean> | undefined,
+    )
+    settings.enabledPlugins = ownScopedPlugins
+    writeFileSync(join(cfg, 'settings.json'), JSON.stringify(settings, null, 2) + '\n')
+
+    // 3. Own plugins/ dir: symlink the heavy shared parts, own the install state.
+    const pluginsDir = join(cfg, 'plugins')
+    mkdirSync(pluginsDir, { recursive: true })
+    const sharedPlugins = join(realClaude, 'plugins')
+    for (const sub of ['cache', 'marketplaces', 'data']) {
+      const link = join(pluginsDir, sub)
+      const target = join(sharedPlugins, sub)
+      if (!existsSync(target)) continue
+      let needsLink = true
+      try {
+        if (lstatSync(link).isSymbolicLink()) needsLink = false
+        else rmSync(link, { recursive: true, force: true })
+      } catch { /* absent -> create */ }
+      if (needsLink) {
+        try { symlinkSync(target, link) }
+        catch (err) { logger.warn({ err, sub, name }, 'isolated-config: plugin symlink failed') }
+      }
+    }
+    const sharedKnown = join(sharedPlugins, 'known_marketplaces.json')
+    if (existsSync(sharedKnown)) {
+      writeFileSync(join(pluginsDir, 'known_marketplaces.json'), readFileSync(sharedKnown, 'utf-8'))
+    }
+    // Seed installed_plugins.json with every project-scoped install re-pointed
+    // at THIS agent's cwd, so the channel plugin is registered for this project
+    // from first launch (Claude Code keeps maintaining it thereafter).
+    const sharedInstalled = join(sharedPlugins, 'installed_plugins.json')
+    if (existsSync(sharedInstalled)) {
+      try {
+        const inst = JSON.parse(readFileSync(sharedInstalled, 'utf-8')) as {
+          plugins?: Record<string, Array<{ scope?: string; projectPath?: string }>>
+        }
+        for (const entries of Object.values(inst.plugins ?? {})) {
+          for (const e of entries) {
+            if (e.scope === 'project') e.projectPath = cwd
+          }
+        }
+        writeFileSync(join(pluginsDir, 'installed_plugins.json'), JSON.stringify(inst, null, 2) + '\n')
+      } catch (err) {
+        logger.warn({ err, name }, 'isolated-config: failed to seed installed_plugins.json')
+      }
+    }
+
+    return cfg
+  } catch (err) {
+    logger.warn({ err, name }, 'isolated-config: provisioning failed, falling back to shared ~/.claude')
+    return null
+  }
 }
 
 function resolveAgentProvider(name: string): ChannelProviderType {
@@ -385,7 +506,15 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // e.g. for routing this agent to a separate Anthropic login). When the
     // agent-config field is missing or blank, claudeConfigDir is null and we
     // emit no export, preserving the default Claude Code behavior.
-    const claudeConfigDir = readAgentClaudeConfigDir(name)
+    // An explicit per-agent config dir wins. Otherwise, a channel sub-agent
+    // gets an auto-provisioned isolated config dir so its plugin install does
+    // not collide with the rest of the fleet in the shared ~/.claude (see
+    // ensureIsolatedChannelConfigDir). The main agent comes up via channels.sh
+    // and keeps the shared root.
+    let claudeConfigDir = readAgentClaudeConfigDir(name)
+    if (!claudeConfigDir && hasChannel && name !== MAIN_AGENT_ID) {
+      claudeConfigDir = ensureIsolatedChannelConfigDir(name, agentProvider)
+    }
     const claudeConfigEnv = claudeConfigDir ? `export CLAUDE_CONFIG_DIR="${claudeConfigDir}" && ` : ''
     // `--continue` requires an existing session; on a brand-new agent the
     // Claude Code projects directory does not yet exist and `claude` exits


### PR DESCRIPTION
…stop colliding

Claude Code records a plugin's project-scoped install in a single shared file (~/.claude/plugins/installed_plugins.json), keyed by ONE projectPath per plugin id. Every channel sub-agent ran out of the same ~/.claude, so each launch (claude --channels plugin:telegram@...) rewrote that single slot to its own project, evicting whichever agent registered before it. Net effect fleet-wide: only ONE agent's channel plugin could be registered at a time -- one bun getUpdates poller, one live bot.pid -- while every other agent saw "No MCP servers configured", spawned no poller, and went deaf on its channel. It also drove the /mcp blocking-menu alert storm (agents racing for the slot). Sequentialising restarts does NOT help: the slot is shared state, not a startup batch race.

Fix: startAgentProcess now auto-provisions a per-agent isolated CLAUDE_CONFIG_DIR (agents/<name>/.claude-config) for channel sub-agents without an explicit config dir. Mirrors the heartbeat worker isolation: symlink every top-level ~/.claude entry (so auth, --continue transcripts and plugin marketplaces stay shared) except settings.json and plugins/, which become per-agent. The private plugins/ symlinks cache/marketplaces/data but OWNS installed_plugins.json + known_marketplaces.json, so each agent's project-scoped install is independent and can never evict another's. Best-effort + idempotent: returns null (falls back to shared ~/.claude) on any error, never a launch failure.

Verified live: after provisioning, all 7 running fleet agents hold a live telegram poller simultaneously (previously impossible).

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
