### PR TITLE
fix(channel-monitor): never auto-submit human-typed terminal drafts i…

### DIFF
--- a/src/__tests__/looks-like-system-delivery.test.ts
+++ b/src/__tests__/looks-like-system-delivery.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { looksLikeSystemDelivery } from '../pane-state.js'
+
+// Gate for the stuck-input watcher's sub-agent plain re-inject. System
+// deliveries (inter-agent / scheduled / wrapped peer blocks) are safe to
+// auto-submit when parked; raw human-typed terminal text is NOT (the
+// dashboard agent-terminal can leave a half-typed draft in a sub-agent pane).
+describe('looksLikeSystemDelivery', () => {
+  it('true for an inter-agent DM prefix (both ascii and accented forms)', () => {
+    expect(looksLikeSystemDelivery('[Uzenet @balazsmarveenja-tol -- trusted team member]: szia')).toBe(true)
+    expect(looksLikeSystemDelivery('[Üzenet @marveen-is-tól]: csinald meg')).toBe(true)
+  })
+
+  it('true for wrapped peer / untrusted / scheduled blocks', () => {
+    expect(looksLikeSystemDelivery('<trusted-peer source="agent:x">jelzés</trusted-peer>')).toBe(true)
+    expect(looksLikeSystemDelivery('<untrusted>data</untrusted>')).toBe(true)
+    expect(looksLikeSystemDelivery('<scheduled-task source="scheduled-task:foo">do it</scheduled-task>')).toBe(true)
+    expect(looksLikeSystemDelivery('TEAM MEMBER NOTICE -- the next block ...')).toBe(true)
+    expect(looksLikeSystemDelivery('SCHEDULED TASK NOTICE -- one of YOUR OWN tasks')).toBe(true)
+  })
+
+  it('FALSE for raw human-typed terminal text -- the bug class (must not auto-submit)', () => {
+    // The exact 2026-06-26 incident input: a half-typed dashboard-terminal
+    // draft that must NOT be auto-submitted by the watcher.
+    expect(looksLikeSystemDelivery('Szólj Ferencnek a KPI-katalógus Várda-instanciája ügyében')).toBe(false)
+    expect(looksLikeSystemDelivery('küldj egy emailt Tóthnak')).toBe(false)
+    expect(looksLikeSystemDelivery('nézd át az emaileket')).toBe(false)
+  })
+
+  it('false for empty / null / whitespace', () => {
+    expect(looksLikeSystemDelivery('')).toBe(false)
+    expect(looksLikeSystemDelivery(null)).toBe(false)
+    expect(looksLikeSystemDelivery(undefined)).toBe(false)
+    expect(looksLikeSystemDelivery('   ')).toBe(false)
+  })
+
+  it('false for a message that merely mentions the word "uzenet" without the @ prefix', () => {
+    expect(looksLikeSystemDelivery('írj egy uzenetet Ferencnek')).toBe(false)
+  })
+})

--- a/src/__tests__/stuck-input-action.test.ts
+++ b/src/__tests__/stuck-input-action.test.ts
@@ -49,6 +49,7 @@ function facts(over: Partial<StuckInputActionFacts>): StuckInputActionFacts {
     truncatedPreamble: false,
     allowPlainReinject: false,
     hasPlainText: false,
+    plainTextIsSystemDelivery: false,
     ...over,
   }
 }
@@ -68,11 +69,30 @@ describe('decideStuckInputAction (recovery-decision unit)', () => {
     expect(a).toBe('hold')
   })
 
-  it('multi-row sub-agent plain text -> re-inject plain, never enter', () => {
+  it('multi-row sub-agent SYSTEM-delivery plain text -> re-inject plain, never enter', () => {
     const a = decideStuckInputAction(
-      facts({ rowCount: 2, allowPlainReinject: true, hasPlainText: true }),
+      facts({ rowCount: 2, allowPlainReinject: true, hasPlainText: true, plainTextIsSystemDelivery: true }),
     )
     expect(a).toBe('reinject-plain')
+  })
+
+  it('single-row sub-agent SYSTEM-delivery plain text, escalated -> re-inject plain', () => {
+    const a = decideStuckInputAction(
+      facts({ rowCount: 1, allowPlainReinject: true, hasPlainText: true, plainTextIsSystemDelivery: true, escalate: true }),
+    )
+    expect(a).toBe('reinject-plain')
+  })
+
+  it('sub-agent RAW HUMAN draft (not a system delivery) -> hold, NEVER submit (2026-06-26 incident)', () => {
+    // The bug class: a half-typed dashboard-terminal draft parked in a sub-agent
+    // pane must not be auto-submitted -- not via re-inject and not via a bare
+    // Enter. Single-row is the dangerous case (a bare Enter would submit it).
+    expect(
+      decideStuckInputAction(facts({ rowCount: 1, allowPlainReinject: true, hasPlainText: true, plainTextIsSystemDelivery: false, escalate: true })),
+    ).toBe('hold')
+    expect(
+      decideStuckInputAction(facts({ rowCount: 2, allowPlainReinject: true, hasPlainText: true, plainTextIsSystemDelivery: false })),
+    ).toBe('hold')
   })
 
   it('multi-row with nothing safely re-injectable -> hold (never corrupt via Enter)', () => {

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -877,6 +877,34 @@ export function submitLanded(prevSig: string, paneAfter: string | null): boolean
   return stuckInputSignature(paneAfter) !== prevSig
 }
 
+// Markers that identify parked input as a genuine SYSTEM delivery -- an
+// inter-agent message, a scheduled task, or a wrapped channel/peer block --
+// rather than raw human-typed terminal text. The dashboard agent-terminal
+// (POST /api/agents/<n>/keys) injects raw keystrokes straight into a sub-agent
+// pane, so a sub-agent's input box CAN hold a half-typed human draft. The
+// stuck-input watcher must NOT auto-submit that (2026-06-26: a half-typed
+// "Szólj X-nek" terminal draft got submitted and the agent emailed against the
+// principal's wish). Only text bearing one of these system-injected markers is
+// safe to clear + re-submit on the plain (non-<channel>) re-inject path.
+const SYSTEM_DELIVERY_MARKERS = [
+  '[Uzenet @', '[Üzenet @',                 // inter-agent DM prefix (message-router)
+  '<trusted-peer', '</trusted-peer',        // trusted team peer wrapper
+  '<untrusted', '</untrusted',              // untrusted-sender wrapper
+  '<scheduled-task', '</scheduled-task',    // scheduled task wrapper
+  'TEAM MEMBER NOTICE', 'SCHEDULED TASK NOTICE',
+]
+
+/**
+ * True when parked pane text is a system-injected delivery (inter-agent /
+ * scheduled / wrapped peer block) rather than raw human-typed terminal input.
+ * Pure + dependency-free for unit testing; used to gate the sub-agent plain
+ * re-inject in the stuck-input watcher.
+ */
+export function looksLikeSystemDelivery(text: string | null | undefined): boolean {
+  if (!text) return false
+  return SYSTEM_DELIVERY_MARKERS.some((m) => text.includes(m))
+}
+
 // Per-session bookkeeping for the stuck-input recovery watcher. A "spell"
 // is one continuous stretch of the SAME text parked in the input box.
 export interface StuckInputState {
@@ -1020,6 +1048,12 @@ export interface StuckInputActionFacts {
   allowPlainReinject: boolean
   /** parkedInputText(pane) != null -- there is collapsed text to re-inject. */
   hasPlainText: boolean
+  /** The collapsed parked text looks like a system delivery (looksLikeSystemDelivery):
+   * an inter-agent message, scheduled task, or wrapped peer block. Gates the
+   * plain re-inject so a raw human-typed terminal draft -- which the dashboard
+   * agent-terminal can leave parked in a sub-agent pane -- is NEVER auto-submitted
+   * (2026-06-26 incident). When false, a parked plain draft is held, not submitted. */
+  plainTextIsSystemDelivery: boolean
 }
 
 /**
@@ -1044,8 +1078,15 @@ export function decideStuckInputAction(f: StuckInputActionFacts): StuckInputActi
   if (f.blockComplete) {
     return f.escalate || multiRow ? 'reinject-block' : 'enter'
   }
-  // Sub-agent non-channel parked text: clear + re-inject is safe (no human draft).
+  // Sub-agent non-channel parked text. A sub-agent pane CAN hold a raw
+  // human-typed draft (dashboard agent-terminal keystrokes), so re-inject ONLY
+  // a recognised system delivery (inter-agent / scheduled / wrapped peer
+  // block). A non-system draft must NEVER be auto-submitted -- not via
+  // re-inject and not via a bare Enter -- so it holds parked (2026-06-26
+  // incident: a half-typed "Szólj X-nek" draft got submitted and the agent
+  // emailed against the principal's wish).
   if (f.allowPlainReinject && f.hasPlainText && !f.blockTruncated) {
+    if (!f.plainTextIsSystemDelivery) return 'hold'
     return f.escalate || multiRow ? 'reinject-plain' : 'enter'
   }
   // Truncated safety preamble: clear only (never re-inject a stale preamble).

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -24,7 +24,7 @@ import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import {
   detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
-  parkedInputText, shouldClearTruncatedPreamble,
+  parkedInputText, shouldClearTruncatedPreamble, looksLikeSystemDelivery,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
   type StuckInputState, type StuckInputThresholds, type StuckInputAction,
   type StuckInputActionFacts,
@@ -183,10 +183,14 @@ export function applyStuckRestartBusyGuard(
 //   2. a truncated/stale safety preamble (no real opening tag) -> clear only,
 //      NEVER re-inject (re-injecting it could let a later payload inherit a
 //      stale trust preamble -- see shouldClearTruncatedPreamble);
-//   3. SUB-AGENTS ONLY (allowPlainReinject): any other complete parked text
-//      (e.g. an inter-agent notification) -> clear + re-inject the collapsed
-//      text. A sub-agent's input box never holds a human draft, so this is
-//      safe; the main session stays conservative (Enter / <channel>-only).
+//   3. SUB-AGENTS ONLY (allowPlainReinject): other complete parked text that
+//      looks like a system delivery (inter-agent notification / scheduled
+//      task -- looksLikeSystemDelivery) -> clear + re-inject the collapsed
+//      text. NOTE: a sub-agent's input box CAN hold a human-typed draft -- the
+//      dashboard agent-terminal injects raw keystrokes straight into the pane
+//      -- so raw, non-system parked text is left UNTOUCHED rather than
+//      auto-submitted (2026-06-26 incident). The main session stays
+//      conservative (Enter / <channel>-only).
 export function recoverStuckInputForSession(
   session: string,
   prev: StuckInputState,
@@ -204,6 +208,7 @@ export function recoverStuckInputForSession(
     // and corrupts the message) and prefers a chat_id-safe re-inject; the
     // truncation-guard (no verbatim re-inject of an incomplete <channel> block)
     // is preserved via blockTruncated.
+    const plainText = allowPlainReinject ? parkedInputText(pane) : null
     const facts: StuckInputActionFacts = {
       escalate: attempt > MAIN_STUCK_ENTER_ATTEMPTS,
       rowCount: parkedInputRowCount(pane),
@@ -211,7 +216,16 @@ export function recoverStuckInputForSession(
       blockTruncated: block != null && !block.complete,
       truncatedPreamble: shouldClearTruncatedPreamble(pane),
       allowPlainReinject,
-      hasPlainText: allowPlainReinject && parkedInputText(pane) != null,
+      hasPlainText: plainText != null,
+      // 2026-06-26 incident: a sub-agent input box CAN hold a raw human-typed
+      // draft -- the dashboard agent-terminal (POST /api/agents/<n>/keys)
+      // injects keystrokes straight into the pane -- so only a recognised
+      // SYSTEM delivery (inter-agent / scheduled / wrapped peer block) may be
+      // auto-submitted on the plain re-inject path. A non-system draft is held
+      // parked, never re-injected and never bare-Entered (see
+      // decideStuckInputAction). A real channel delivery still goes through the
+      // chat_id-safe <channel> block path (blockComplete).
+      plainTextIsSystemDelivery: plainText != null && looksLikeSystemDelivery(plainText),
     }
     const action = decideStuckInputAction(facts)
     performStuckInputAction(session, action, pane, block, sig, attempt)

--- a/src/web/routes/agent-terminal.ts
+++ b/src/web/routes/agent-terminal.ts
@@ -157,6 +157,17 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
     }
     try {
       await tmux(args)
+      // Audit (2026-06-26): a raw keystroke injection here can become a
+      // SUBMITTED instruction -- the stuck-input watcher may auto-submit text
+      // left parked in the pane -- so a mis-fire (e.g. a half-typed draft that
+      // gets sent) must be traceable. The dashboard token gates this endpoint
+      // but carries no user identity, so the source IP is the best available
+      // attribution. Logged on success only (failures already warn above).
+      const ip = ctx.req.socket?.remoteAddress ?? 'unknown'
+      logger.info(
+        { name, session, ip, keys: parsed.keys?.slice(0, 300), special: parsed.special },
+        'agent-terminal: keystroke injection',
+      )
       json(res, { ok: true })
     } catch (err) {
       logger.warn({ err, name }, 'agent-terminal: send-keys failed')


### PR DESCRIPTION
…n sub-agents

The stuck-input watcher's sub-agent "plain re-inject" path (recoverStuckInputForSession, allowPlainReinject) submitted ANY complete parked text, on the assumption that "a sub-agent's input box never holds a human draft". That assumption is false: the dashboard agent-terminal (POST /api/agents/<n>/keys) injects raw keystrokes straight into a sub-agent pane, so a half-typed human draft CAN sit parked there.

Incident (2026-06-26): someone typed "Szólj Ferencnek ..." into a sub-agent's dashboard terminal without submitting; the watcher auto-submitted the parked text and the agent sent an email against the principal's explicit wish.

Fix: gate the plain re-inject on looksLikeSystemDelivery -- only auto-submit parked text bearing a system-injected marker (inter-agent [Uzenet @...] prefix, <trusted-peer>/<untrusted>/<scheduled-task> wrappers, the NOTICE banners). Otherwise leave the (likely human) draft parked and untouched; a genuine channel delivery is still handled by the <channel> re-inject path above.

Also audit raw keystroke injections (agent-terminal /keys): log agent, session, source IP and a key preview on success, so a future mis-fire is traceable (the endpoint is dashboard-token gated but carries no user identity).

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
