### PR TITLE
fix(channels): fleet-safe restart via KillMode=process + idempotent relaunch

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1152,6 +1152,13 @@ After=network.target
 
 [Service]
 Type=simple
+# KillMode=process: the first tmux new-session from channels.sh starts the
+# SHARED tmux server in this unit's cgroup, and every sub-agent session lives
+# there too. Default control-group mode would SIGKILL the whole fleet on a
+# stop/restart (only the main agent's own unit). process mode kills only
+# channels.sh; the tmux server and all agents survive. channels.sh kill-sessions
+# its own "\$SESSION" before new-session so the surviving session doesn't collide.
+KillMode=process
 WorkingDirectory=$INSTALL_DIR
 ExecStart=$INSTALL_DIR/scripts/channels.sh
 Restart=on-failure

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -12,10 +12,14 @@
 # on success, so a stale file means the session's MCP pipe is no longer doing
 # round-trips (wedged / deaf).
 #
-# Recovery: `tmux respawn-pane` of ONLY the <id>-channels pane. NEVER
-# `systemctl restart` -- the tmux SERVER is shared across every agent and lives
-# in the channels unit's cgroup (KillMode=control-group), so restarting the unit
-# would kill the server and every agent session, not just the main one.
+# Recovery: `tmux respawn-pane` of ONLY the <id>-channels pane -- the precise,
+# fleet-safe restart of just the main channels session. (Historically a
+# `systemctl restart` was outright forbidden here: the shared tmux SERVER lives
+# in the channels unit's cgroup, and under the old KillMode=control-group a
+# restart SIGKILLed the server and every agent session, not just the main one --
+# the 2026-06-26 fleet outage. The unit now runs KillMode=process so a restart is
+# no longer catastrophic, but respawn-pane stays preferred: it recovers only the
+# wedged pane without disturbing any sibling session.)
 #
 # Safety: a respawn-grace stamp prevents storming; a consecutive-respawn cap
 # stops a useless respawn loop when the keepalive is disabled or the problem is

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -185,6 +185,14 @@ fi
 # the cwd-based project dir may contain the user's own CLI sessions, and
 # resuming one of those loses the --channels activation state, causing
 # "Channel notifications skipped: server not in --channels list" errors.
+#
+# Idempotent launch: the service runs KillMode=process so a `systemctl stop`
+# no longer cgroup-kills the SHARED tmux server (which would tear down every
+# sibling agent session on this host -- the 2026-06-26 fleet-wide outage). The
+# trade-off is that a prior "$SESSION" can survive into this relaunch, so kill
+# just THIS session first -- never the server, never another agent's session --
+# otherwise new-session below fails with "duplicate session".
+$TMUX kill-session -t "$SESSION" 2>/dev/null || true
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
   "$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
 

--- a/scripts/systemd/marveen-channels.service
+++ b/scripts/systemd/marveen-channels.service
@@ -9,6 +9,14 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
+# KillMode=process: channels.sh's first `tmux new-session` starts the SHARED
+# tmux server inside this unit's cgroup, and every sub-agent session lives there
+# too. The default control-group mode would SIGKILL the whole fleet on a
+# stop/restart (the 2026-06-26 fleet-wide outage), not just the main agent.
+# process mode kills only channels.sh; the tmux server and all agents survive.
+# channels.sh kill-sessions its own session before new-session, so the surviving
+# session does not collide on relaunch.
+KillMode=process
 WorkingDirectory=/path/to/marveen
 ExecStart=/path/to/marveen/scripts/channels.sh
 # P1 FIX: always (not on-failure). channels.sh exits 0 when the tmux session


### PR DESCRIPTION
## Probléma

A channels systemd unit a default KillMode=control-group alatt futott. A channels.sh első `tmux new-session` hívása a MEGOSZTOTT tmux servert indítja el ennek a unitnak a cgroup-jában, és minden sub-agent session is itt él. Ezért egy `systemctl stop/restart` SIGKILL-elte az egész flottát, nem csak a fő agentet (2026-06-26 flotta-szintű kiesés).

## Változások

- **install-linux.sh + scripts/systemd/marveen-channels.service**: `KillMode=process` a channels unitra, így a stop/restart csak a channels.sh-t öli; a tmux server és minden agent túléli.
- **scripts/channels.sh**: `kill-session` csak a SAJÁT `$SESSION`-re, közvetlenül a `new-session` előtt. Process mód alatt egy korábbi session túlélheti az újraindítást, ami "duplicate session" hibát adna. Scope: csak ez a session, soha nem a server, soha nem másik agent session-je.
- **scripts/channel-watchdog.sh**: recovery-komment frissítés. A `respawn-pane` marad a preferált (csak az akadt panelt gyógyítja), de a unit restart már nem katasztrofális a `KillMode=process` óta.

## Teszt

- `bash -n` mindhárom shell scriptre OK.
- A `kill-session` mindkét `new-session` ág előtt jelen van (fő launch + EPERM fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)