### PR TITLE
security: gate sub-agent self-pace via PreToolUse hook + tool-deny

### DIFF
--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// PreToolUse hard-gate: blocks SELF-PACE for sub-agents.
+//
+// Governance control (2026-06-26, after the autonom-kor incident: a sub-agent
+// scheduled its own wakeups via ScheduleWakeup, fed itself prompts, and acted
+// on a SELF-GENERATED "A) zárjuk le" decision -- dispatching real development
+// -- while the operator slept. Two independent adversarial audits confirmed the
+// root cause is the agent's own self-pace loop, not an external vector).
+//
+// A sub-agent must be INPUT-DRIVEN: it acts on operator / peer messages, never
+// on prompts it scheduled for itself. This gate blocks every self-pace path:
+//   - the Claude Code runtime tools ScheduleWakeup / CronCreate / CronList /
+//     CronDelete / RemoteTrigger (the autonomous-loop machinery), AND
+//   - the Bash escape routes that achieve the same self-injection: writing the
+//     Claude scheduled_tasks.json directly, tmux send-keys into a session, or
+//     POSTing a new schedule to the dashboard.
+//
+// Why a hook and not only a permissions deny-list: permissive profiles launch
+// with --dangerously-skip-permissions. A whole-tool-name deny DOES survive that
+// (deny is checked before the bypass allow), so the scaffold also adds these
+// names to permissions.deny -- but the Bash-command routes can ONLY be caught
+// by a PreToolUse hook, which runs regardless of permission mode. Defense in
+// depth: deny-list for the tool names, this hook for the Bash routes (+ the
+// names again, redundantly fail-closed).
+//
+// Wired into every sub-agent's .claude/settings.json by
+// writeAgentSettingsFromProfile() (agent-scaffold.ts), guarded by
+// name !== MAIN_AGENT_ID, re-applied on every spawn (respawn-safe).
+
+import { readFileSync, realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// Claude Code runtime self-pace / scheduling tools. A sub-agent has no
+// legitimate need to schedule its own future turns -- it is input-driven.
+const SELF_PACE_TOOLS = new Set([
+  'ScheduleWakeup',
+  'CronCreate',
+  'CronDelete',
+  'CronList',
+  'RemoteTrigger',
+])
+
+// Bash command patterns that achieve self-pace by another route. These are
+// tested per COMMAND SEGMENT (see splitSegments), so a token in one part of a
+// compound command never trips a pattern that belongs to another part.
+const SELF_PACE_BASH_PATTERNS = [
+  // tmux pane injection -- every write-subcommand that can push keys/text/commands
+  // into a pane (the actual incident vector), not just send-keys. [\s\S] (not
+  // [^\n]) so an intra-segment newline cannot split the match.
+  /\btmux\b[\s\S]*\b(send-keys|paste-buffer|run-shell|set-buffer)\b/i,
+  // self-backgrounding that relaunches claude (nohup/setsid/disown + claude)
+  /\b(nohup|setsid|disown)\b[\s\S]*\bclaude\b/i,
+  // the loop slash-skill driven from a shell
+  /\bclaude\b[\s\S]*\/loop\b/i,
+]
+
+// OS-level schedulers + delayed exec (cron / launchd / systemd / at / batch): the
+// shell route to the same self-pace the CronCreate tool-deny blocks at the runtime
+// layer. Anchored to command position (segment start), but a leading wrapper is
+// allowed before the binary -- sudo/env/command/nice, a VAR=val environment, and
+// an absolute/relative path -- so `sudo crontab -r`, `/usr/bin/at now`,
+// `PATH=/bin crontab -` are all caught. Trailing \b(?!-) so it never fires on
+// "netstat" / "crontab-helper.sh"; (?!\s*=) so a bare NAME=value assignment
+// (`at=$(...)`) is not mistaken for the `at` binary.
+const SCHED_PREFIX = String.raw`(?:(?:[A-Za-z_]\w*=\S*|sudo|env|command|exec|nice|builtin|time)\s+)*(?:\S*/)?`
+const SCHEDULER_RX = new RegExp(String.raw`(^|[;&|(]\s*)${SCHED_PREFIX}(crontab|launchctl|systemd-run|batch|at)\b(?!-)(?!\s*=)`, 'i')
+// ...but allow a pure READ-listing of one's own schedule (parity with the store /
+// schedule-API read exemptions): crontab -l, launchctl list/print, atq.
+const SCHEDULER_READ_RX = new RegExp(String.raw`(^|[;&|(]\s*)${SCHED_PREFIX}(crontab\s+-l\b|launchctl\s+(?:list|print|dumpstate|blame|examine)\b|atq\b)`, 'i')
+
+// The Claude self-schedule store. Blocked for WRITE on any route (a Bash write,
+// or the native Write/Edit/NotebookEdit tool); a read/grep is legit diagnostics.
+const SCHEDULE_STORE_RX = /scheduled_tasks\.json/i
+// Write-intent shell tokens (redirect / tee / in-place edit / dd / copy-move).
+const WRITE_INTENT_RX = /(>>?|\btee\b|\bsed\b[\s\S]*\s-i|\bdd\b|\bcp\b|\bmv\b)/i
+// Dashboard schedule API. A WRITE method (POST/PUT/PATCH/DELETE) creates/edits a
+// self-paced cron; a GET (list / pending / agents) is legit diagnostics -> allowed.
+const SCHEDULE_API_RX = /\/api\/schedules\b/i
+const HTTP_WRITE_RX = /(-X\s*(POST|PUT|PATCH|DELETE)|--request\s+(POST|PUT|PATCH|DELETE)|(^|\s)(--data\b|--data-\w+\b|-d\b))/i
+
+// Split a compound command into individual simple commands, so a token in one
+// segment cannot trip a check anchored in another (e.g. `cat store && cp a b`).
+// Line-continuations (backslash-newline) are collapsed FIRST so a single command
+// continued across lines stays ONE segment (this is what keeps the
+// tmux\<newline>send-keys vector closed); only real separators split.
+//
+// KNOWN LIMITATIONS (accepted, defense-in-depth -- the runtime tool-deny is the
+// primary guard, this Bash hook is a second layer; a sub-agent is not adversarial
+// to its own gate, it just must not casually self-pace):
+//   - Not quote-aware: a separator INSIDE quotes (e.g. a commit message
+//     `git commit -m "fix; crontab -r"`) splits and could false-deny. Rare
+//     enough (the quoted ; must be immediately followed by a blocked binary at a
+//     segment start) that a full shell-tokenizer is not warranted here.
+//   - Backtick / $(...) substitution that assigns a scheduler result
+//     (`X=$(crontab -)`) can slip; the exotic-route tail is the documented
+//     denylist limit, covered by the ScheduleWakeup/Cron* tool-deny layer.
+export function splitSegments(command) {
+  return String(command ?? '')
+    .replace(/\\\r?\n/g, ' ')
+    .split(/&&|\|\||[;&|]|\r?\n/)
+    // trim so a leading-separator segment (" at now") anchors at ^ correctly
+    .map((s) => s.trim())
+}
+
+// Pure decision: does this tool call set up self-pace / self-injection?
+export function gateDecision(toolName, toolInput) {
+  const name = String(toolName ?? '')
+  if (SELF_PACE_TOOLS.has(name)) return { deny: true }
+  // Native file tools writing the self-schedule store would bypass any Bash regex.
+  if (name === 'Write' || name === 'Edit' || name === 'NotebookEdit') {
+    const fp = String(toolInput?.file_path ?? toolInput?.notebook_path ?? '')
+    if (SCHEDULE_STORE_RX.test(fp)) return { deny: true }
+  }
+  if (name === 'Bash') {
+    // Per-segment so an unrelated token elsewhere in a compound command cannot
+    // turn a legit read (store inspection, schedule-API GET) into a false deny.
+    for (const seg of splitSegments(toolInput?.command)) {
+      if (SELF_PACE_BASH_PATTERNS.some((re) => re.test(seg))) return { deny: true }
+      // scheduler binaries: deny the exec/submit forms, allow pure read-listing
+      if (SCHEDULER_RX.test(seg) && !SCHEDULER_READ_RX.test(seg)) return { deny: true }
+      // self-schedule store: block WRITE only (a read/grep is legit diagnostics)
+      if (SCHEDULE_STORE_RX.test(seg) && WRITE_INTENT_RX.test(seg)) return { deny: true }
+      // dashboard schedule API: block WRITE methods only (GET list/pending is legit)
+      if (SCHEDULE_API_RX.test(seg) && HTTP_WRITE_RX.test(seg)) return { deny: true }
+    }
+  }
+  return { deny: false }
+}
+
+const GATE_MSG =
+  'Self-pace TILTOTT (governance hard-gate). Sub-agentkent NEM utemezhetsz sajat ' +
+  'jovobeli turn-t: se ScheduleWakeup/Cron*/RemoteTrigger, se tmux send-keys, se ' +
+  'scheduled_tasks.json iras, se /api/schedules POST, se /loop self-pace. Input-vezerelt ' +
+  'vagy: csak az operator (channel) vagy egy peer (inter-agent) uzenete inditson. Ha varakozol, ' +
+  'maradj idle a prompt-on -- a beerkezo uzenet majd ujrainditja a turn-t. SOHA ne valaszolj ' +
+  'magadnak es SOHA ne dontsd el az operator helyett egy hozza intezett kerdest.'
+
+function allow() { process.exit(0) }
+
+function deny(reason) {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  }))
+  process.exit(0)
+}
+
+function isInvokedDirectly() {
+  try {
+    const self = realpathSync(fileURLToPath(import.meta.url))
+    const entry = process.argv[1] ? realpathSync(process.argv[1]) : ''
+    return self === entry
+  } catch {
+    return false
+  }
+}
+if (isInvokedDirectly()) {
+  let payload
+  try {
+    payload = JSON.parse(readFileSync(0, 'utf-8'))
+  } catch {
+    allow() // malformed/empty input must never break the agent's tool calls
+  }
+  const { deny: shouldDeny } = gateDecision(payload?.tool_name, payload?.tool_input)
+  if (shouldDeny) deny(GATE_MSG)
+  allow()
+}

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+// @ts-expect-error -- plain .mjs hook script, no types
+import { gateDecision as selfPaceDecision } from '../../scripts/self-pace-gate.mjs'
+import {
+  agentGetsGovernanceGates,
+  injectSelfPaceGate,
+} from '../web/agent-scaffold.js'
+import { MAIN_AGENT_ID } from '../config.js'
+
+// --- self-pace-gate: blocks the agent from scheduling its own future turns ---
+describe('self-pace-gate gateDecision', () => {
+  it('denies the ScheduleWakeup runtime tool', () => {
+    expect(selfPaceDecision('ScheduleWakeup', { prompt: 'x' }).deny).toBe(true)
+  })
+  it('denies CronCreate / CronDelete / CronList / RemoteTrigger', () => {
+    for (const t of ['CronCreate', 'CronDelete', 'CronList', 'RemoteTrigger']) {
+      expect(selfPaceDecision(t, {}).deny).toBe(true)
+    }
+  })
+  it('denies tmux pane injection: send-keys / paste-buffer / run-shell / set-buffer', () => {
+    for (const sub of ['send-keys -t agent-dev2 Enter', 'paste-buffer -t agent-dev2', 'run-shell "claude -p hi"', 'set-buffer "x"']) {
+      expect(selfPaceDecision('Bash', { command: `tmux ${sub}` }).deny).toBe(true)
+    }
+  })
+  it('denies tmux injection split across a newline (no [^newline] escape hatch)', () => {
+    expect(selfPaceDecision('Bash', { command: 'tmux \\\n  send-keys -t agent-dev2 Enter' }).deny).toBe(true)
+  })
+  it('denies OS-level schedulers: crontab / at / launchctl', () => {
+    expect(selfPaceDecision('Bash', { command: '(crontab -l; echo "*/5 * * * * claude -p poll") | crontab -' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'echo "claude -p go" | at now + 5 minutes' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'launchctl submit -l self -- node respawn.mjs' }).deny).toBe(true)
+  })
+  it('denies nohup/setsid self-respawn of claude', () => {
+    expect(selfPaceDecision('Bash', { command: 'nohup claude -p "keep going" &' }).deny).toBe(true)
+  })
+  it('does NOT misfire "at" on a substring (netstat / cat)', () => {
+    expect(selfPaceDecision('Bash', { command: 'cat file.txt && netstat -an' }).deny).toBe(false)
+  })
+  it('denies a WRITE to the self-schedule store (redirect)', () => {
+    expect(selfPaceDecision('Bash', { command: 'echo "{}" > ~/.claude/scheduled_tasks.json' }).deny).toBe(true)
+  })
+  it('ALLOWS a read-only inspection of the self-schedule store (F4)', () => {
+    expect(selfPaceDecision('Bash', { command: 'cat ~/.claude/scheduled_tasks.json' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'grep poll ~/.claude/scheduled_tasks.json' }).deny).toBe(false)
+  })
+  it('denies a WRITE method to the dashboard schedule API', () => {
+    expect(selfPaceDecision('Bash', { command: 'curl -X POST http://localhost:3420/api/schedules -d @x.json' }).deny).toBe(true)
+  })
+  it('ALLOWS a GET read of the schedule API (F2 -- diagnostics, not self-pace)', () => {
+    expect(selfPaceDecision('Bash', { command: 'curl http://localhost:3420/api/schedules' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'curl http://localhost:3420/api/schedules/pending' }).deny).toBe(false)
+  })
+  it('denies writing the schedule store via the native Write/Edit tool (F5)', () => {
+    expect(selfPaceDecision('Write', { file_path: '/home/agent/.claude/scheduled_tasks.json', content: '{}' }).deny).toBe(true)
+    expect(selfPaceDecision('Edit', { file_path: '~/.claude/scheduled_tasks.json' }).deny).toBe(true)
+  })
+  it('denies a shell-driven /loop', () => {
+    expect(selfPaceDecision('Bash', { command: 'claude /loop "keep polling"' }).deny).toBe(true)
+  })
+  it('ALLOWS a normal Bash command', () => {
+    expect(selfPaceDecision('Bash', { command: 'git status && ls -la' }).deny).toBe(false)
+  })
+  it('ALLOWS a legitimate inter-agent message (not self-schedule)', () => {
+    expect(selfPaceDecision('Bash', { command: 'curl -X POST http://localhost:3420/api/messages -d \'{"to":"dev4"}\'' }).deny).toBe(false)
+  })
+  it('ALLOWS read-only tools', () => {
+    expect(selfPaceDecision('Read', {}).deny).toBe(false)
+    expect(selfPaceDecision('Grep', {}).deny).toBe(false)
+  })
+})
+
+// --- compound-command false-positives: a token in one segment must NOT trip a
+// check anchored in another (per-segment matching -- round-2 hardening) ---
+describe('self-pace-gate compound-command false-positives', () => {
+  it('ALLOWS a store read followed by an unrelated cp/mv in another segment', () => {
+    expect(selfPaceDecision('Bash', { command: 'cat ~/.claude/scheduled_tasks.json && cp other.txt backup.txt' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'grep poll scheduled_tasks.json; mv a.log b.log' }).deny).toBe(false)
+  })
+  it('ALLOWS a schedule-API GET with an unrelated -d flag in another segment', () => {
+    expect(selfPaceDecision('Bash', { command: 'curl http://localhost:3420/api/schedules && date -d yesterday' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'curl http://localhost:3420/api/schedules | grep -d' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'ls -d */ && curl http://localhost:3420/api/schedules' }).deny).toBe(false)
+  })
+  it('ALLOWS "batch"/"crontab" as a word in a script name or commit message', () => {
+    expect(selfPaceDecision('Bash', { command: 'npm run batch:migrate' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'git commit -m "add batch endpoint + crontab docs"' }).deny).toBe(false)
+  })
+  it('ALLOWS a legit tmux read with the injected word merely mentioned elsewhere', () => {
+    expect(selfPaceDecision('Bash', { command: 'tmux list-sessions && echo "send-keys docs"' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'tmux ls && grep send-keys notes.md' }).deny).toBe(false)
+  })
+  it('STILL denies the real binary when it IS the command in a segment', () => {
+    expect(selfPaceDecision('Bash', { command: 'echo "claude -p go" | at now + 5 minutes' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'ls; tmux send-keys -t agent-dev2 Enter' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'echo cmd | batch' }).deny).toBe(true)
+  })
+  it('ALLOWS at/batch as a shell variable assignment, not the binary', () => {
+    expect(selfPaceDecision('Bash', { command: 'at=$(git rev-parse HEAD); echo $at' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'start=1; batch=2; end=3' }).deny).toBe(false)
+  })
+  it('ALLOWS read-listing of schedulers (crontab -l / launchctl list / atq)', () => {
+    expect(selfPaceDecision('Bash', { command: 'crontab -l' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'crontab -l | grep claude' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'launchctl list | grep agent' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'atq' }).deny).toBe(false)
+  })
+  it('STILL denies scheduler WRITE forms (crontab - / crontab -r / launchctl submit)', () => {
+    expect(selfPaceDecision('Bash', { command: '(crontab -l; echo job) | crontab -' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'crontab -r' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'launchctl submit -l self -- node x.mjs' }).deny).toBe(true)
+  })
+  it('denies scheduler WRITE behind a sudo/env/PATH/absolute-path wrapper', () => {
+    expect(selfPaceDecision('Bash', { command: 'sudo crontab -r' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: '/usr/bin/at now + 1 minute' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'PATH=/usr/bin crontab cronfile' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'env crontab -' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'sudo launchctl bootstrap gui/501 x.plist' }).deny).toBe(true)
+  })
+  it('ALLOWS a wrapped scheduler READ, and a crontab-prefixed script name', () => {
+    expect(selfPaceDecision('Bash', { command: 'sudo crontab -l' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: './scripts/crontab-helper.sh status' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'at=$(date +%s); echo $at' }).deny).toBe(false)
+  })
+})
+
+// --- scaffold wiring: main-exempt + idempotent ---
+describe('governance gate scaffold wiring', () => {
+  it('applies to sub-agents, exempts the main agent', () => {
+    expect(agentGetsGovernanceGates('dev2')).toBe(true)
+    expect(agentGetsGovernanceGates('dev3')).toBe(true)
+    expect(agentGetsGovernanceGates(MAIN_AGENT_ID)).toBe(false)
+  })
+  it('injectSelfPaceGate is idempotent (no duplicate on respawn)', () => {
+    const s: Record<string, unknown> = {}
+    injectSelfPaceGate(s)
+    injectSelfPaceGate(s)
+    const pre = ((s.hooks as Record<string, unknown>).PreToolUse as unknown[])
+    expect(pre.filter((e) => JSON.stringify(e).includes('self-pace-gate.mjs')).length).toBe(1)
+  })
+  it('the hook MATCHER fires on native file tools too (not just Bash)', () => {
+    // Regression guard: gateDecision blocks a Write/Edit to the schedule store,
+    // but that branch only runs in production if the hook MATCHER covers those
+    // tool names. A Bash-only matcher would leave the native-file route open
+    // while the unit test (which calls gateDecision directly) still passes.
+    const s: Record<string, unknown> = {}
+    injectSelfPaceGate(s)
+    const pre = ((s.hooks as Record<string, unknown>).PreToolUse as Array<{ matcher: string }>)
+    const entry = pre.find((e) => JSON.stringify(e).includes('self-pace-gate.mjs'))
+    const re = new RegExp(`^(?:${entry!.matcher})$`)
+    for (const t of ['Bash', 'Write', 'Edit', 'NotebookEdit', 'ScheduleWakeup', 'CronCreate']) {
+      expect(re.test(t)).toBe(true)
+    }
+    expect(re.test('Read')).toBe(false)
+  })
+  it('self-pace gate survives a respawn re-run, and NO operator-gate is wired', () => {
+    const s: Record<string, unknown> = {}
+    injectSelfPaceGate(s)
+    injectSelfPaceGate(s) // respawn re-run
+    const pre = ((s.hooks as Record<string, unknown>).PreToolUse as unknown[])
+    expect(pre.some((e) => JSON.stringify(e).includes('self-pace-gate.mjs'))).toBe(true)
+    // operator-confirmation-gate is intentionally NOT wired: merge/deploy is
+    // operator-authorized autonomously; the self-decide vector is covered above.
+    expect(pre.some((e) => JSON.stringify(e).includes('operator-confirmation-gate.mjs'))).toBe(false)
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -82,16 +82,27 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
     try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
   }
   const ctx = { HOME: homedir(), AGENT_DIR: agentRoot }
+  const denyList = profile.filesystem.deny.map(p => resolveProfilePlaceholders(p, ctx))
+  // Self-pace tool-name deny: every sub-agent (NOT the main agent) is denied the
+  // Claude Code runtime self-scheduling tools. A whole-tool-name deny IS enforced
+  // even under --dangerously-skip-permissions (deny is checked BEFORE the bypass
+  // allow), so this is a fail-closed layer; the self-pace-gate hook below covers
+  // the Bash escape routes a name-deny cannot reach. (2026-06-26 autonom-kor fix.)
+  if (agentGetsGovernanceGates(name)) denyList.push(...SELF_PACE_TOOL_DENY)
   existing.permissions = {
     allow: profile.filesystem.allow.map(p => resolveProfilePlaceholders(p, ctx)),
-    deny: profile.filesystem.deny.map(p => resolveProfilePlaceholders(p, ctx)),
+    deny: denyList,
   }
-  // Email-send hard-gate: every sub-agent (NOT the main agent) gets a
-  // PreToolUse hook that blocks outbound email-send tools. Re-applied on
-  // every spawn (this function regenerates settings.json), so it survives
-  // respawns. The MAIN_AGENT_ID retains email-send capability -- all outbound
-  // email routes through it for approval.
+  // Governance hard-gates: every sub-agent (NOT the main agent) gets PreToolUse
+  // hooks. Re-applied on every spawn (this function regenerates settings.json),
+  // so they survive respawns. (a) email-send block -- outbound email routes
+  // through the main agent. (b) self-pace block -- no ScheduleWakeup/Cron*/Bash
+  // self-injection. The MAIN_AGENT_ID is exempt from both. Merge/deploy is NOT
+  // gated: the operator authorizes those autonomously (so test/deploy runs are
+  // never blocked); the actual incident vector -- an agent answering its OWN
+  // posed question -- is covered by the self-pace block + the #0 CLAUDE.md doctrine.
   if (agentGetsEmailGate(name)) injectEmailSendGate(existing)
+  if (agentGetsGovernanceGates(name)) injectSelfPaceGate(existing)
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
 }
 
@@ -123,6 +134,40 @@ export function injectEmailSendGate(existing: Record<string, unknown>): void {
   // the hook never accumulates duplicates; other PreToolUse entries are kept.
   hooks.PreToolUse = [
     ...prev.filter((e) => !JSON.stringify(e).includes('email-send-gate.mjs')),
+    entry,
+  ]
+}
+
+// Claude Code runtime self-scheduling tool names denied for sub-agents (fail-
+// closed, enforced even under --dangerously-skip-permissions). The Bash escape
+// routes are covered by the self-pace-gate hook, which a name-deny cannot reach.
+const SELF_PACE_TOOL_DENY = ['ScheduleWakeup', 'CronCreate', 'CronDelete', 'CronList', 'RemoteTrigger']
+
+// Which agents are subject to the self-pace gate: every agent EXCEPT the main
+// agent (same name-agnostic main-exempt rule as the email gate). Pure + exported
+// so the main-exempt guarantee is unit-testable.
+export function agentGetsGovernanceGates(name: string): boolean {
+  return name !== MAIN_AGENT_ID
+}
+
+// Idempotently wire the self-pace-gate PreToolUse hook (blocks ScheduleWakeup /
+// Cron* / RemoteTrigger + the Bash self-injection routes). Same shape + dedupe
+// discipline as injectEmailSendGate.
+export function injectSelfPaceGate(existing: Record<string, unknown>): void {
+  const hooks = (existing.hooks && typeof existing.hooks === 'object'
+    ? existing.hooks
+    : (existing.hooks = {})) as Record<string, unknown>
+  const command = `node ${join(PROJECT_ROOT, 'scripts', 'self-pace-gate.mjs')}`
+  const entry = {
+    // Write|Edit|NotebookEdit are included so the gate actually fires on the
+    // native-file route to the self-schedule store (gateDecision blocks a Write
+    // to scheduled_tasks.json); a Bash-only matcher would leave that route open.
+    matcher: 'ScheduleWakeup|CronCreate|CronDelete|CronList|RemoteTrigger|Bash|Write|Edit|NotebookEdit',
+    hooks: [{ type: 'command', command, timeout: 10 }],
+  }
+  const prev = Array.isArray(hooks.PreToolUse) ? (hooks.PreToolUse as unknown[]) : []
+  hooks.PreToolUse = [
+    ...prev.filter((e) => !JSON.stringify(e).includes('self-pace-gate.mjs')),
     entry,
   ]
 }


### PR DESCRIPTION
## Why this matters

A sub-agent should be **input-driven**: it acts on operator or peer messages, never on a turn it scheduled for itself. Without a guard, a sub-agent can self-pace -- schedule its own future turns and feed itself prompts -- and end up *answering its own posed question* while the operator is away. The self-pace routes are:

- the Claude Code runtime scheduling tools (`ScheduleWakeup`, `CronCreate`/`CronDelete`/`CronList`, `RemoteTrigger`);
- a shell scheduler: `crontab` / `at` / `launchctl` / `batch` / `systemd-run`, including `sudo`/`env`/`PATH=`/absolute-path-wrapped forms;
- `tmux send-keys` / `paste-buffer` / `run-shell` into its own pane;
- writing the self-schedule store (`scheduled_tasks.json`) via a shell redirect **or** the native `Write`/`Edit` tool;
- POSTing a new dashboard schedule, a shell-driven `/loop`, or a `nohup`/`setsid` claude self-respawn.

## Change

A two-layer **self-pace-gate** for every sub-agent (the main agent is exempt -- it legitimately schedules heartbeats):

1. **`permissions.deny`** on the five runtime scheduling tool names. A whole-tool-name deny survives `--dangerously-skip-permissions` (deny is checked before the bypass-allow), so permissive profiles are covered.
2. **A `PreToolUse` hook** (`scripts/self-pace-gate.mjs`) for the Bash and native-file escape routes, since a deny-list cannot reach a Bash command and a hook runs regardless of permission mode.

The hook is **read/write aware**, so it never blocks legit diagnostics or normal work:

- matches **per command-segment** (a token in one part of `cat store && cp a b` does not trip a check anchored in another);
- scheduler **read** (`crontab -l`, `launchctl list`, `atq`) passes; only exec/submit/`crontab -`/`-r` deny;
- a store **read/grep** passes; only a write (redirect / `tee` / `sed -i` / native `Write`) denies;
- a schedule-API **GET** passes; only a write method (`POST`/`PUT`/`-d`) denies.

Wired into each sub-agent's `settings.json` by `writeAgentSettingsFromProfile()` (re-applied on every respawn, idempotent dedupe, name-agnostic main-exempt). Same shape and discipline as the existing email-send gate.

## Scope / compatibility

No behaviour change for the main agent or for normal sub-agent work: **build, test, merge, deploy, feature-branch push, inter-agent messages, file edits, `git status/log/diff`** all pass. Only the self-injection-shaped routes are denied. The gate is keyed on the configured `MAIN_AGENT_ID`, not a hardcoded name, so a customer install gates its own sub-agents and exempts its own owner.

## Test plan

- `npm run build` -- clean (tsc).
- `npx vitest run` -- full suite green (93 files / 1405 tests), including 30 new governance-gate cases.
- New tests cover: each runtime tool + Bash route denied; legit `git` / `npm` / `curl GET` / store-read / scheduler-read / `batch:migrate` / tmux-read / `at=`-assignment allowed; per-segment false-positive guards; the prefix-wrapped (`sudo`/`env`/`PATH=`/abs-path) scheduler caught; and a **matcher-vs-decision regression guard** -- the hook matcher must cover `Write`/`Edit`/`NotebookEdit`, not just `Bash`, or the native-file branch would never fire in production.
- Hardened across several adversarial review rounds (newline + `paste-buffer` bypass, `at`/`cron`/`launchctl` escape, GET false-positive, prefix-wrap bypass, matcher gap -- all fixed).

## Known limitations

Documented inline in `self-pace-gate.mjs`. The Bash hook is a **defense-in-depth second layer**; the runtime tool-deny is the primary guard:

- the segment split is **not quote-aware**, so a separator inside quotes (e.g. a commit message `"fix; crontab -r"`) could rarely false-deny;
- a backtick / `$()` substitution-assignment of a scheduler result, or an option-argument wrapper (`sudo -u user crontab`), is left to the runtime tool-deny layer.
