### PR TITLE
fix(channel): survive the CC 2.1.193 --continue plugin regression

### DIFF
--- a/src/__tests__/channel-deafness-recovery.test.ts
+++ b/src/__tests__/channel-deafness-recovery.test.ts
@@ -5,6 +5,8 @@ import {
   shouldDeferKeepaliveRespawn,
   shouldRefreshKeepaliveFromInbound,
   lastMainRespawnAt,
+  shouldEscalateAfterResume,
+  POST_RESUME_GUARD_DELAY_MS,
 } from '../web/channel-monitor.js'
 
 // CONTRACT: the respawn command MUST carry the .bun/bin PATH export -- without
@@ -38,6 +40,27 @@ describe('buildMainSessionRespawnCmd', () => {
   it('includes --continue only for a resume, not a fresh start', () => {
     expect(buildMainSessionRespawnCmd({ ...base, continueSession: true })).toContain('--continue')
     expect(buildMainSessionRespawnCmd({ ...base, continueSession: false })).not.toContain('--continue')
+  })
+})
+
+// CONTRACT: the post-resume guard (CC 2.1.193) escalates to a fresh respawn iff
+// the --continue resume did NOT bring up the channel plugin. A live pid serving
+// the plugin means context was preserved -- do not escalate.
+describe('shouldEscalateAfterResume', () => {
+  it('does NOT escalate when the resumed claude is alive AND the plugin attached', () => {
+    expect(shouldEscalateAfterResume({ claudePid: 1234, pluginAlive: true })).toBe(false)
+  })
+  it('escalates when the pid is alive but the plugin never loaded (the 2.1.193 regression)', () => {
+    expect(shouldEscalateAfterResume({ claudePid: 1234, pluginAlive: false })).toBe(true)
+  })
+  it('escalates when the resumed claude pid is gone entirely', () => {
+    expect(shouldEscalateAfterResume({ claudePid: null, pluginAlive: false })).toBe(true)
+  })
+  it('guard delay clears the unlock-probe budget (~65s) yet stays under RESUME_GRACE_MS (240s)', () => {
+    // > worst-case unlock-probe completion so a merely-disabled plugin is revived
+    // first, and < the cascade grace so a genuinely-absent plugin escalates sooner.
+    expect(POST_RESUME_GUARD_DELAY_MS).toBeGreaterThan(65_000)
+    expect(POST_RESUME_GUARD_DELAY_MS).toBeLessThan(240_000)
   })
 })
 

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -401,7 +401,15 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // opts.fresh forces a brand-new conversation (auto-restart 'fresh' mode):
     // omit --continue so the heavy accumulated context is dropped. Without it
     // we resume the prior session (the 'continue' mode / normal restart).
-    const continueFlag = (hasPriorSession && !opts.fresh) ? '--continue ' : ''
+    //
+    // CC 2.1.193 REGRESSION: a `--continue` resume does NOT re-initialise the
+    // `--channels` plugin MCP server -- the agent comes up with the plugin
+    // absent from /mcp, no bun poller, no bot.pid -> permanently deaf on its
+    // channel. A FRESH launch loads the plugin correctly. So channel-having
+    // agents are ALWAYS launched fresh: the lost conversation context is the
+    // price of a reachable bot (file/db memory persists either way). Channel-
+    // less agents keep --continue to preserve their accumulated context.
+    const continueFlag = (hasPriorSession && !opts.fresh && !hasChannel) ? '--continue ' : ''
     const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : agentProvider === 'googlechat' ? 'GOOGLECHAT_STATE_DIR' : 'TELEGRAM_STATE_DIR'
     const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN'
     // Slack plugin is third-party; its "not on approved allowlist" check is

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -73,6 +73,13 @@ const agentLastRestart: Map<string, number> = new Map()
 // short cadence forever -- which restarts the WHOLE agent every few minutes and
 // renders it unusable. Reset to 0 the moment the plugin is seen alive again.
 const agentRestartFailures: Map<string, number> = new Map()
+// Global stagger for channel-down restarts. On Claude Code 2.1.193 a sub-agent's
+// --channels plugin only LOADS on a fresh (no --continue) launch, and several
+// such cold-boots at once race on the shared plugin cache so NONE attach a
+// poller. Serialise: at most one channel-down restart per this interval,
+// fleet-wide, so each fresh cold-boot completes in isolation.
+let lastChannelAgentRestartAt = 0
+const CHANNEL_RESTART_STAGGER_MS = 90_000
 const AGENT_RESTART_GRACE_MS = 90_000
 // Floor frequency for the backed-off restart: even a long-down plugin is still
 // retried at least this often, in case an external fix brings it back.
@@ -454,6 +461,14 @@ export function resumeMarveenSession(): boolean {
     // direct. Schedule the same probe in-process so the plugin doesn't get
     // stuck in `◯ disabled` after an in-process respawn (2026-06-01 18:55).
     schedulePluginUnlockAfterRespawn(MAIN_CHANNELS_SESSION, provider.type)
+    // Post-resume guard (CC 2.1.193 regression). A --continue resume can come up
+    // WITHOUT the --channels plugin (absent from /mcp, no poller -> deaf main
+    // channel). The unlock probe above only revives a Failed/disabled plugin --
+    // it cannot help when the plugin never loaded at all. Schedule a liveness
+    // probe; if the plugin is still missing after the settle, escalate straight
+    // to a FRESH respawn instead of burning the full RESUME_GRACE_MS cascade.
+    // Context is dropped only in the bad case; a clean --continue keeps it.
+    schedulePostResumePluginGuard(provider.type)
     // Stamp the shared respawn timestamp so lastMainRespawnAt() sees this
     // respawn from any caller (down-cascade stage 3, stuck-tool-call-watcher,
     // external systemd-timer watchdog). Without it the watcher cannot defer
@@ -619,6 +634,51 @@ function respawnMarveenSessionFresh(): boolean {
     logger.error({ err }, 'Fresh session respawn failed')
     return false
   }
+}
+
+// Post-resume guard delay. Must clear the unlock-probe budget (first probe at
+// ~35s, retries every 15s up to 2x => ~65s worst case) so a plugin that merely
+// loaded `disabled` gets revived BEFORE we declare the resume deaf, yet stay
+// well under RESUME_GRACE_MS (240s) so a genuinely-absent plugin escalates
+// ~150s sooner than the cascade would. 90s leaves a healthy --continue ample
+// time to attach its poller; only a pathologically large (>200k-token) context
+// resume risks a false escalation, which still self-heals (fresh respawn).
+export const POST_RESUME_GUARD_DELAY_MS = 90_000
+
+// PURE decision for the post-resume guard: after a --continue resume, do we have
+// to escalate to a fresh respawn? Yes iff the resumed session is NOT serving the
+// channel plugin -- either the claude pid is gone, or the pid is alive but the
+// plugin never attached (the CC 2.1.193 regression). A live pid WITH the plugin
+// means --continue succeeded and the conversation context is preserved.
+export function shouldEscalateAfterResume(f: { claudePid: number | null; pluginAlive: boolean }): boolean {
+  if (f.claudePid == null) return true
+  return !f.pluginAlive
+}
+
+// Scheduled (non-blocking) check fired after a --continue resume. If the
+// channels plugin attached, the resume succeeded and the conversation context
+// is preserved -- nothing to do. If it did not (CC 2.1.193: --continue does not
+// re-init the plugin MCP server), escalate to a FRESH respawn so the main
+// channel becomes reachable again. respawnMarveenSessionFresh() writes the
+// respawn stamp, so lastMainRespawnAt() suppresses the down-cascade's redundant
+// stage-4 hard restart during the ensuing cold boot.
+function schedulePostResumePluginGuard(provider: ChannelProviderType): void {
+  setTimeout(() => {
+    try {
+      const claudePid = getClaudePidForSession(MAIN_CHANNELS_SESSION)
+      const pluginAlive = claudePid != null && hasChannelPluginAlive(claudePid, provider)
+      if (!shouldEscalateAfterResume({ claudePid, pluginAlive })) {
+        logger.info({ provider }, 'Post-resume guard: channel plugin attached after --continue -- context preserved, no escalation')
+        return
+      }
+      logger.warn({ provider }, 'Post-resume guard: --continue resume came up WITHOUT the channels plugin (CC 2.1.193) -- escalating to fresh respawn (context dropped, memory persists)')
+      sendAlert(`⚠️ A --continue resume suketen jott fel (nincs channel plugin). Fresh respawn most a ${MAIN_CHANNELS_SESSION} session-on (a beszelgetes elveszik, memoria marad).`)
+      respawnMarveenSessionFresh()
+    } catch (err) {
+      logger.warn({ err }, 'Post-resume guard probe failed (leaving recovery to the down-cascade)')
+    }
+  }, POST_RESUME_GUARD_DELAY_MS)
+  logger.info({ delayMs: POST_RESUME_GUARD_DELAY_MS }, 'Post-resume plugin guard scheduled after --continue resume')
 }
 
 export function hardRestartMarveenChannels(): { ok: boolean; error?: string } {
@@ -1165,11 +1225,22 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           logger.warn({ agent: t.agentName, provider: agentProvider }, 'Agent has no channel token in state dir -- skipping restart to avoid token conflict')
           continue
         }
+        // Stagger: only one channel-down restart per CHANNEL_RESTART_STAGGER_MS
+        // fleet-wide, so fresh sub-agent cold-boots serialise instead of racing.
+        if (Date.now() - lastChannelAgentRestartAt < CHANNEL_RESTART_STAGGER_MS) {
+          logger.debug({ agent: t.agentName }, 'Channel-down restart staggered -- deferring to avoid simultaneous cold-boot race')
+          continue
+        }
         logger.warn({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down -- auto-restarting')
         try {
           stopAgentProcess(t.agentName!)
           execSync('sleep 2', { timeout: 4000 })
-          startAgentProcess(t.agentName!)
+          lastChannelAgentRestartAt = Date.now()
+          // FRESH (no --continue): on CC 2.1.193 a --continue resume does NOT load
+          // the --channels plugin MCP server, so the agent comes up with no plugin
+          // and no poller (verified: continue -> "Plugin not found" in /mcp; fresh
+          // -> plugin loads + poller attaches). Context is dropped, memory persists.
+          startAgentProcess(t.agentName!, { fresh: true })
           agentLastRestart.set(t.agentName!, Date.now())
           agentDownSince.delete(t.session)
           // Count this restart as failed until a later sweep sees the plugin

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1416,7 +1416,12 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   if (startMatch && method === 'POST') {
     const name = decodeURIComponent(startMatch[1])
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
-    const result = startAgentProcess(name)
+    // Optional { "fresh": true } body -> no `--continue`. Required for channel
+    // agents on Claude Code 2.1.193, where a `--continue` resume does not load
+    // the --channels plugin MCP server (agent comes up deaf).
+    let startFresh = false
+    try { startFresh = JSON.parse((await readBody(req)).toString() || '{}').fresh === true } catch {}
+    const result = startAgentProcess(name, { fresh: startFresh })
     // Record operator intent so the monitor keeps this agent up across shared
     // tmux-server restarts / reboots (see agent-desired-state.ts).
     if (result.ok || result.error === 'Agent is already running') addDesiredAgent(name)
@@ -1451,7 +1456,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       return true
     }
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
-    const result = restartAgentProcess(name)
+    // Optional { "fresh": true } body -> no `--continue` (see /start note).
+    let restartFresh = false
+    try { restartFresh = JSON.parse((await readBody(req)).toString() || '{}').fresh === true } catch {}
+    const result = restartAgentProcess(name, { fresh: restartFresh })
     if (result.ok) { json(res, { ok: true }); return true }
     json(res, { error: result.error }, 400)
     return true


### PR DESCRIPTION
## Problem

On Claude Code **2.1.193** a `--continue` resume does **not** re-initialise the `--channels` plugin MCP server. The agent comes back up with the plugin absent from `/mcp`, no bun poller and no `bot.pid` -- i.e. **permanently deaf on its channel**. A fresh (no `--continue`) launch loads the plugin correctly.

Verified: `--continue` -> "Plugin not found" in `/mcp`; fresh -> plugin loads + poller attaches.

## Fix

### Sub-agents
- **agent-process.ts**: a channel-having agent is now ALWAYS launched fresh. The lost conversation context is the price of a reachable bot; file/db memory persists either way. Channel-less agents keep `--continue` to preserve their accumulated context.
- **channel-monitor.ts**: the channel-down auto-restart relaunches fresh and is serialised by a 90s fleet-wide stagger, so simultaneous cold-boots don't race on the shared plugin cache (which left NONE of them with a poller).
- **routes/agents.ts**: `/start` and `/restart` accept an optional `{"fresh": true}` body.

### Main channel (post-resume guard)
- stage-3 `resumeMarveenSession` keeps `--continue` (context preserved in the good case) but now schedules a **non-blocking guard 90s later**. If the plugin did not attach, it escalates straight to a fresh respawn instead of burning the full `RESUME_GRACE_MS` (240s) cascade.
- 90s clears the unlock-probe budget (~65s, so a merely-disabled plugin is revived first) yet stays well under the 240s cascade grace, saving ~150s in the bad case while not killing a slow-but-healthy resume.
- The escalation decision is extracted into the pure `shouldEscalateAfterResume()` and locked with contract tests.

## Validation
- `tsc --noEmit` clean
- 1379/1379 tests pass (4 new contract tests for `shouldEscalateAfterResume` + the guard-delay timing invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)