### PR TITLE
fix(channels): set MCP startup-batch env for the main session (parity with sub-agents)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -90,6 +90,24 @@ TMUX="$(command -v tmux)"
 [ -z "$CLAUDE" ] && echo "ERROR: claude not found on PATH" >&2 && exit 1
 [ -z "$TMUX" ]   && echo "ERROR: tmux not found on PATH" >&2 && exit 1
 
+# MCP startup-batch tuning for the MAIN session (2026-06-26).
+#
+# The --channels telegram plugin registers as a stdio MCP server. Claude Code
+# connects stdio MCP servers in batches of MCP_SERVER_CONNECTION_BATCH_SIZE
+# (default 3) and, by default, blocks on each connection. The main session runs
+# the MOST MCP servers of any agent (filesystem + playwright + chrome + the
+# claude.ai Gmail/Calendar/Drive connectors + the channel plugin), so the slow
+# remote connectors starve the telegram plugin out of the startup batch / push
+# it past MCP_TIMEOUT -- it never registers, no poller spawns, and the main bot
+# goes silent (observed 2026-06-26: ~2h outage, auto-recovery exhausted).
+#
+# startAgentProcess already sets these for every sub-agent (which is why their
+# channels come up); channels.sh did NOT, so the main session never got the
+# mitigation. Set them inline on the launch command -- the tmux SERVER predates
+# this script and does not inherit its environment, so exporting here alone
+# would not reach the new claude. Mirrors the sub-agent launch.
+MCP_BATCH_ENV="export MCP_SERVER_CONNECTION_BATCH_SIZE=10 MCP_CONNECTION_NONBLOCKING=1 MCP_TIMEOUT=60000 && "
+
 # Read the main agent's default model from .claude/settings.json so we can
 # pass --model explicitly. Without --model claude-code falls back to its
 # built-in default, which can drift across versions. Passing the flag makes
@@ -186,7 +204,7 @@ fi
 # resuming one of those loses the --channels activation state, causing
 # "Channel notifications skipped: server not in --channels list" errors.
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
+  "${MCP_BATCH_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
 
 # Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
 # kulonben a headless session orokre parkolna a prompton es a Telegram plugin
@@ -227,7 +245,7 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
         # entry); see the PR description / card 7EB18437.
         [ -e "$INSTALL_DIR/CLAUDE.md" ] && ln -sf "$INSTALL_DIR/CLAUDE.md" "$_CHANNELS_STARTDIR/CLAUDE.md" 2>/dev/null || true
         $TMUX new-session -d -s "$SESSION" -c "$_CHANNELS_STARTDIR" \
-          "$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
+          "${MCP_BATCH_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
         unset _CHANNELS_STARTDIR
       fi
       continue

--- a/src/__tests__/channel-deafness-recovery.test.ts
+++ b/src/__tests__/channel-deafness-recovery.test.ts
@@ -30,6 +30,15 @@ describe('buildMainSessionRespawnCmd', () => {
     expect(cmd).toContain("--model 'claude-opus-4-8[1m]'")
   })
 
+  it('tunes the MCP startup batch so the channel plugin is not starved (parity with channels.sh)', () => {
+    const cmd = buildMainSessionRespawnCmd({ ...base, continueSession: false })
+    expect(cmd).toContain('MCP_SERVER_CONNECTION_BATCH_SIZE=10')
+    expect(cmd).toContain('MCP_CONNECTION_NONBLOCKING=1')
+    expect(cmd).toContain('MCP_TIMEOUT=60000')
+    // Must be exported BEFORE the claude binary runs.
+    expect(cmd.indexOf('MCP_SERVER_CONNECTION_BATCH_SIZE')).toBeLessThan(cmd.indexOf('--channels'))
+  })
+
   it('omits --model when no model is configured', () => {
     const cmd = buildMainSessionRespawnCmd({ ...base, model: '', continueSession: false })
     expect(cmd).not.toContain('--model')

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -408,6 +408,15 @@ export function buildMainSessionRespawnCmd(opts: {
 }): string {
   return [
     'export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"',
+    // MCP startup-batch tuning (parity with channels.sh + startAgentProcess):
+    // the --channels plugin is a stdio MCP server; the main session runs the
+    // most MCP servers (filesystem/playwright/chrome + claude.ai connectors +
+    // the plugin), so without these the channel plugin can be starved out of
+    // the default 3-wide blocking startup batch and never register a poller.
+    // This respawn-pane path is the RECOVERY launcher -- it must tune the same
+    // env as the channels.sh boot path, else a recovery respawn comes up
+    // un-tuned and can re-starve under load.
+    '&& export MCP_SERVER_CONNECTION_BATCH_SIZE=10 MCP_CONNECTION_NONBLOCKING=1 MCP_TIMEOUT=60000',
     '&&', opts.claudePath,
     ...(opts.continueSession ? ['--continue'] : []),
     '--dangerously-skip-permissions',


### PR DESCRIPTION
## Mit javit

A `--channels` telegram plugin egy stdio MCP-szerverkent regisztral. A Claude Code a stdio MCP-szervereket `MCP_SERVER_CONNECTION_BATCH_SIZE` (default 3) meretu batchekben, alapertelmezetten blokkolva inditja. A fo session futtatja a legtobb MCP-szervert (filesystem + playwright + chrome + a claude.ai Gmail/Calendar/Drive connectorok + a channel plugin), igy a lassu szerverek kiszorithatjak a telegram plugint a startup-batchbol / MCP_TIMEOUT-ba viszik -> nem regisztral, nincs poller, a fo bot nema marad. Eleskent egy ~2 oras fo-csatorna kieses kapcsan talaltam (2026-06-26).

A `startAgentProcess` mar minden sub-agentnek beallitja ezeket (`MCP_SERVER_CONNECTION_BATCH_SIZE=10`, `MCP_CONNECTION_NONBLOCKING=1`, `MCP_TIMEOUT=60000`) -- ezert jonnek fel a sub-agentek csatornai. A fo session KET launch-utja viszont nem kapta meg:

1. **`channels.sh`** (boot-ag) -- beallitva inline a launch-parancson (primary + EPERM-fallback). A tmux szerver megelozi a scriptet es nem orokli a kornyezetet, ezert inline kell.
2. **`buildMainSessionRespawnCmd`** (`channel-monitor.ts`, respawn-pane recovery-ag) -- ez a recovery-launcher; ha un-tuned jon fel egy respawn, ugyanugy ki tud ehezni terheles alatt. Ugyanaz az env inline, contract-assert a `channel-deafness-recovery.test.ts`-ben.

Igy a fo session MINDKET indulasi utja (boot + recovery) ugyanazt az MCP-batch tuningot kapja, mint a sub-agentek.

## Teszt

- `bash -n scripts/channels.sh`: tiszta.
- `tsc --noEmit`: tiszta.
- `channel-deafness-recovery.test.ts` (uj assert) + `channel-stability-contract` + `agent-restart-policy`: 83 zold.
- Eles: a fo claude ujrainditas utan megkapja a harom env-valtozot (`ps eww`); a fo Jarvis-csatorna helyreallt es stabil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)