### PR TITLE
fix(security): dim ghost-suggestion never auto-submitted by stuck-input recovery

### DIFF
--- a/src/__tests__/ghost-suggestion-strip.test.ts
+++ b/src/__tests__/ghost-suggestion-strip.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import {
+  stripGhostSuggestion,
+  stuckInputSignature,
+  detectPaneState,
+  parkedInputText,
+} from '../pane-state.js'
+
+const ESC = '\x1b'
+const SEP = '─'.repeat(80)
+const FOOTER = `  ⏵⏵ bypass permissions on (shift+tab to cycle) · ↓ to manage`
+
+// A faithful reconstruction of a real `tmux capture-pane -e -p` of a Claude
+// Code pane whose input box is EMPTY but shows the editor's dim (SGR 2)
+// autocomplete "ghost suggestion". This is the exact shape captured live on
+// 2026-06-26 (agent-geri: "Confirm Samu got my last update"). With colour the
+// hint is dim; a plain `-p` capture drops the colour and the box reads as a
+// genuinely parked `❯ <text>` input -> the stuck-input recovery re-typed +
+// Enter-submitted it as a forged message (phantom prompt-injection).
+const GHOST_BOX = [
+  `${ESC}[38;5;37m${SEP}${ESC}[39m`,
+  `${ESC}[39m❯ ${ESC}[2mConfirm Samu got my last update${ESC}[0m`,
+  `${ESC}[38;5;37m${SEP}${ESC}[39m`,
+  FOOTER,
+].join('\n')
+
+// Same layout, but the text after the prompt is REAL typed input rendered at
+// normal intensity (no SGR 2). The strip must PRESERVE this -- over-stripping
+// would re-break legitimate stuck-input recovery.
+const REAL_INPUT_BOX = [
+  `${ESC}[38;5;37m${SEP}${ESC}[39m`,
+  `${ESC}[39m❯ ${ESC}[38;5;253mFinish the migration before lunch${ESC}[39m`,
+  `${ESC}[38;5;37m${SEP}${ESC}[39m`,
+  FOOTER,
+].join('\n')
+
+describe('stripGhostSuggestion', () => {
+  it('drops dim (SGR 2) text and strips all ANSI', () => {
+    const out = stripGhostSuggestion(`${ESC}[2mghost${ESC}[0m real`)
+    expect(out).toBe(' real') // dim "ghost" removed, ANSI gone, "real" kept
+  })
+
+  it('keeps normal-intensity text', () => {
+    expect(stripGhostSuggestion(`${ESC}[38;5;253mhello${ESC}[39m`)).toBe('hello')
+  })
+
+  it('treats SGR 22 and SGR 0 as dim-reset', () => {
+    expect(stripGhostSuggestion(`${ESC}[2mA${ESC}[22mB`)).toBe('B')
+    expect(stripGhostSuggestion(`${ESC}[2mA${ESC}[0mB`)).toBe('B')
+  })
+
+  it('does NOT mistake a 256-colour INDEX of 2 for the dim attribute', () => {
+    // `38;5;2` selects colour index 2 (green); the `2` is a sub-parameter of
+    // the extended-colour selector, not the standalone dim code.
+    expect(stripGhostSuggestion(`${ESC}[38;5;2mvisible${ESC}[39m`)).toBe('visible')
+    // likewise a truecolour green `38;2;0;255;0`
+    expect(stripGhostSuggestion(`${ESC}[38;2;0;255;0mvisible${ESC}[39m`)).toBe('visible')
+  })
+
+  it('collapses a dim-ghost input box to an empty prompt', () => {
+    const stripped = stripGhostSuggestion(GHOST_BOX)
+    expect(stripped).not.toContain('Confirm Samu got my last update')
+    expect(stripped).toContain('❯ ')
+  })
+})
+
+describe('ghost suggestion does not trigger stuck-input recovery', () => {
+  it('a dim-ghost box is NOT classified as parked input', () => {
+    const stripped = stripGhostSuggestion(GHOST_BOX)
+    expect(detectPaneState(stripped)).not.toBe('typing')
+    expect(stuckInputSignature(stripped)).toBeNull()
+    expect(parkedInputText(stripped)).toBeNull()
+  })
+
+  it('a REAL non-dim parked input is preserved (no over-strip)', () => {
+    const stripped = stripGhostSuggestion(REAL_INPUT_BOX)
+    expect(stripped).toContain('Finish the migration before lunch')
+    expect(detectPaneState(stripped)).toBe('typing')
+    expect(stuckInputSignature(stripped)).toBe('❯ Finish the migration before lunch')
+    expect(parkedInputText(stripped)).toBe('Finish the migration before lunch')
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -201,6 +201,61 @@ const BOX_SEP_RX = /^─{10,}/
 // admitting the NBSP and any other horizontal Unicode space the TUI emits.
 const PARKED_INPUT_RX = /❯[^\S\r\n]+\S/
 
+// Strip Claude Code's DIM (SGR 2) "ghost suggestion" autocomplete from a
+// COLOURED pane capture (`tmux capture-pane -e -p`), then remove every
+// remaining ANSI escape, yielding plain text equivalent to `capture-pane -p`
+// MINUS the ghost. Claude Code renders a history/autocomplete hint inside an
+// EMPTY input box at REDUCED intensity (`❯ ` then `ESC[2m<hint>ESC[0m`). A
+// plain (`-p`) capture drops the colour, so the dim hint becomes
+// indistinguishable from a genuinely parked input -- and the stuck-input
+// recovery then re-types + Enter-submits it as if the agent had typed it
+// (the 2026-06-26 phantom prompt-injection: it triggered a real invoice storno
+// and a forged email). The discriminator is intensity: a real parked input is
+// rendered at NORMAL intensity, only the ghost is dim. We track SGR dim state
+// across the stream and DROP any character emitted while dim is active, so a
+// pure-ghost box collapses to `❯ ` (no `\S` after the prompt) and
+// PARKED_INPUT_RX / detectPaneState no longer read it as 'typing'.
+//
+// Pure: a string transform, unit-testable against captured `-e` fixtures.
+// `38`/`48` extended-colour params (`38;5;N`, `38;2;R;G;B`) are consumed as a
+// unit so a colour INDEX of 2 is never mistaken for the dim attribute.
+export function stripGhostSuggestion(coloredPane: string): string {
+  let out = ''
+  let dim = false
+  let i = 0
+  const n = coloredPane.length
+  while (i < n) {
+    const ch = coloredPane[i]
+    if (ch === '\x1b') {
+      if (coloredPane[i + 1] !== '[') { i++; continue } // drop non-CSI ESC
+      let j = i + 2
+      while (j < n && (coloredPane[j] < '@' || coloredPane[j] > '~')) j++
+      const final = coloredPane[j]
+      if (final === 'm') {
+        const params = coloredPane.slice(i + 2, j)
+        const codes = params.length === 0 ? [''] : params.split(';')
+        let k = 0
+        while (k < codes.length) {
+          const c = codes[k]
+          if (c === '38' || c === '48') {
+            const mode = codes[k + 1]
+            k += mode === '5' ? 3 : mode === '2' ? 5 : 1
+            continue
+          }
+          if (c === '2') dim = true
+          else if (c === '0' || c === '22' || c === '') dim = false
+          k++
+        }
+      }
+      i = j < n ? j + 1 : n // skip the whole escape sequence
+      continue
+    }
+    if (!dim) out += ch
+    i++
+  }
+  return out
+}
+
 // Persistent Anthropic thinking-block API error. When an assistant turn
 // ends with a 400 about thinking/redacted_thinking blocks that "cannot
 // be modified", the session is wedged: every subsequent prompt re-sends

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -12,6 +12,7 @@ import {
   detectsPastePlaceholder,
   detectPaneState,
   parkedInputText,
+  stripGhostSuggestion,
 } from '../pane-state.js'
 import { agentDir, readAgentModel, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost } from './agent-config.js'
 import {
@@ -911,6 +912,23 @@ export function sendEnterToSession(session: string, host: string | null = null):
 export function capturePane(session: string, host: string | null = null): string | null {
   try {
     return captureTmux(host, ['capture-pane', '-t', session, '-p'])
+  } catch {
+    return null
+  }
+}
+
+// Capture a pane for STUCK-INPUT detection, with the editor's dim "ghost
+// suggestion" autocomplete removed. Captures WITH colour (`-e`) and strips the
+// SGR-2 (dim) ghost + all ANSI, so a hint shown in an empty input box is never
+// mistaken for a genuinely parked input. Every auto-submitting recovery path
+// (channel-monitor recoverStuckInputForSession, stuck-input-watcher
+// bareEnterRecovery) MUST read the pane through THIS, not plain capturePane --
+// otherwise the dim ghost reads as real text and gets re-typed + Enter-
+// submitted (phantom prompt-injection, 2026-06-26). Returns null on capture
+// failure (treated as "nothing parked"), matching capturePane's contract.
+export function captureParkedInputView(session: string, host: string | null = null): string | null {
+  try {
+    return stripGhostSuggestion(captureTmux(host, ['capture-pane', '-t', session, '-e', '-p']))
   } catch {
     return null
   }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -10,6 +10,7 @@ import {
   agentHasChannel,
   agentSessionName,
   capturePane,
+  captureParkedInputView,
   clearInputBuffer,
   dismissResumeSummaryModalIfPresent,
   isAgentRunning,
@@ -193,7 +194,10 @@ export function recoverStuckInputForSession(
   thresholds: StuckInputThresholds,
   allowPlainReinject: boolean,
 ): StuckInputState {
-  const pane = capturePane(session)
+  // Ghost-stripped capture: a dim autocomplete hint in an empty box must NOT
+  // read as parked input, or the recovery below would re-type + submit it
+  // (phantom prompt-injection). See captureParkedInputView / stripGhostSuggestion.
+  const pane = captureParkedInputView(session)
   const sig = pane != null ? stuckInputSignature(pane) : null
   const decision = decideStuckInputRecovery(sig, prev, Date.now(), thresholds)
   if (decision.recover && pane != null) {
@@ -274,7 +278,7 @@ function performStuckInputAction(
     // submitLanded() handles a null capture internally (-> not landed). prevSig
     // is non-null here in practice (recover only fires on a parked signature),
     // but guard the type narrowing explicitly.
-    const landed = prevSig != null ? submitLanded(prevSig, capturePane(session)) : false
+    const landed = prevSig != null ? submitLanded(prevSig, captureParkedInputView(session)) : false
     logger.warn(
       { session, action, attempt, landed },
       landed

--- a/src/web/stuck-input-watcher.ts
+++ b/src/web/stuck-input-watcher.ts
@@ -1,7 +1,7 @@
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID } from '../config.js'
 import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
-import { isAgentRunning, capturePane, sendEnterToSession } from './agent-process.js'
+import { isAgentRunning, captureParkedInputView, sendEnterToSession } from './agent-process.js'
 import { resolveAgentSession } from './channel-mcp-reconnect.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { recoverStuckInputForSession, sendAlert } from './channel-monitor.js'
@@ -80,7 +80,10 @@ const watchState = new Map<string, StuckInputState>()
 // for REMOTE sub-agents, where the local-tmux clear+re-inject is not
 // available. channel-monitor owns the clear+re-inject escalation for these.
 function bareEnterRecovery(label: string, session: string, host: string | null): void {
-  const pane = capturePane(session, host)
+  // Ghost-stripped capture: a bare recovery Enter submits whatever is parked,
+  // so a dim autocomplete hint read as parked input would be Enter-submitted as
+  // a forged message. captureParkedInputView removes the SGR-2 ghost first.
+  const pane = captureParkedInputView(session, host)
   // A failed capture is treated as "nothing parked" -- it ends any active
   // spell rather than holding stale state across a transient tmux miss.
   const sig = pane == null ? null : stuckInputSignature(pane)


### PR DESCRIPTION
## Focused security fix: dim ghost-suggestion never auto-submitted

**Separate from the #458 deep-fix — immediately shippable.** Affects any install (no manual containment there).

### Root cause (ANSI-proven)
Claude Code renders a **dim (SGR 2)** autocomplete "ghost suggestion" in an *empty* input box (from history / last prompt). The stuck-input recovery captures with `capture-pane -p` (no colour), so the dim marker — the only thing distinguishing a ghost hint from real typed input — is lost. `parkedInputText` / `stuckInputSignature` then read the ghost as a genuinely parked `❯ <text>` input, and the recovery re-types + Enter-submits it as a forged message. On 2026-06-26 this fired a real invoice storno (Boni `[2m]Sztornozd ezt is`) and a forged email (Zara `[2m]Köszi jó éjt`).

### Fix (minimal, surgical)
- `pane-state.ts` — `stripGhostSuggestion()` (pure): tracks SGR dim state, drops dim chars, strips all ANSI. A 256-colour **index** of 2 is not mistaken for the dim **attribute**. A pure-ghost box collapses to `❯ ` → `PARKED_INPUT_RX` no longer matches → not `typing`.
- `agent-process.ts` — `captureParkedInputView()` = `capture-pane -e -p` + strip, used **only** by the parked-input recovery path. The global `capturePane` is **unchanged** (many consumers string-match its plain output).
- `channel-monitor.ts` `recoverStuckInputForSession` + post-submit verify, and `stuck-input-watcher.ts` `bareEnterRecovery` (the second submit-vector: bare Enter on MAIN + remote) now read through it.

Real, non-dim parked input (a stranded `<channel>` block or draft) is **preserved** — legitimate recovery still works; only the ghost is never submitted.

### Tests (mandatory repro included)
- empty box + dim ghost → recovery does **not** submit (regression that this fixes)
- real non-dim parked text → still recovers (preservation, no over-strip)
- 256-colour-index-2 edge, SGR 0/22 dim-reset
- Validated against 3 real captured fixtures (`store/security-forensics/ghost-fixtures`).

**tsc clean, 1407 tests green.** This is the durable replacement for the temporary `allowPlainReinject` containment on our host (keep it until this is verified live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
