### PR TITLE
fix(dashboard): self-heal a silent HTTP bind failure on restart

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -248,21 +248,31 @@ export function startWebServer(port = 3420): http.Server {
     )
   })
 
-  // Self-heal a SILENT bind failure. Under launchd, a `kickstart -k` can race
-  // the dying predecessor's lingering socket: the EADDRINUSE reclaim + re-listen
-  // path can leave this process ALIVE but not actually listening, with no error
-  // (observed 2026-06-27 -- the success log above fired yet nothing was bound,
-  // and the background loops started below kept running, so the dashboard was
-  // deaf for hours until a manual second restart, which bound cleanly). A clean
-  // restart binds reliably, so if the server is not actually listening after a
-  // generous grace window (covers the 1500ms reclaim + retry), exit and let
-  // launchd restart us fresh rather than linger un-servable.
+  // Self-heal a SILENT listener failure. Under launchd, a `kickstart -k` can
+  // race the dying predecessor's lingering socket: the EADDRINUSE reclaim +
+  // re-listen path can leave this process ALIVE but not actually listening, with
+  // no error (observed 2026-06-27 -- the success log above fired yet nothing was
+  // bound, and the background loops started below kept running, so the dashboard
+  // was deaf until a manual restart, which bound cleanly). A clean restart binds
+  // reliably, so if the listener is not up we exit(1) and let launchd restart us
+  // fresh rather than linger un-servable.
+  //
+  // The grace must comfortably exceed a SLOW-but-valid bind: restarting OVER a
+  // wedged predecessor, the EADDRINUSE reclaim retries every ~1500ms until the
+  // old socket finally releases -- observed up to ~5 MINUTES (2026-06-27). An
+  // 8s grace would exit MID-bind and loop, so wait STARTUP_GRACE first. After
+  // that, poll periodically so a mid-life listener drop is caught too, not just
+  // a startup failure.
+  const STARTUP_GRACE_MS = 7 * 60 * 1000
+  const RELISTEN_POLL_MS = 60 * 1000
   setTimeout(() => {
-    if (!server.listening) {
-      logger.error({ port }, 'Web server not listening after startup grace -- exiting(1) for a clean launchd restart')
-      process.exit(1)
-    }
-  }, 8000).unref()
+    setInterval(() => {
+      if (!server.listening) {
+        logger.error({ port }, 'Web server not listening -- exiting(1) for a clean launchd restart')
+        process.exit(1)
+      }
+    }, RELISTEN_POLL_MS).unref()
+  }, STARTUP_GRACE_MS).unref()
 
   const routerInterval = startMessageRouter()
   logger.info('Agent message router started (5s poll)')

--- a/src/web.ts
+++ b/src/web.ts
@@ -220,7 +220,9 @@ export function startWebServer(port = 3420): http.Server {
                 try { process.kill(pid, 'SIGKILL') } catch { /* gone */ }
               } catch { /* gone */ }
             }
-            server.listen(port, WEB_HOST)
+            server.listen(port, WEB_HOST, () => {
+              logger.info({ port }, `Web dashboard: re-listen bound after port reclaim`)
+            })
           }, 1500)
         } else {
           logger.error({ port }, 'Port foglalt de nem talaltunk felszabadithato node processt -- kilepes')
@@ -245,6 +247,22 @@ export function startWebServer(port = 3420): http.Server {
       `\nDashboard access URL (paste into browser, token is stored afterward):\n  ${bootstrapUrl}\n\n`
     )
   })
+
+  // Self-heal a SILENT bind failure. Under launchd, a `kickstart -k` can race
+  // the dying predecessor's lingering socket: the EADDRINUSE reclaim + re-listen
+  // path can leave this process ALIVE but not actually listening, with no error
+  // (observed 2026-06-27 -- the success log above fired yet nothing was bound,
+  // and the background loops started below kept running, so the dashboard was
+  // deaf for hours until a manual second restart, which bound cleanly). A clean
+  // restart binds reliably, so if the server is not actually listening after a
+  // generous grace window (covers the 1500ms reclaim + retry), exit and let
+  // launchd restart us fresh rather than linger un-servable.
+  setTimeout(() => {
+    if (!server.listening) {
+      logger.error({ port }, 'Web server not listening after startup grace -- exiting(1) for a clean launchd restart')
+      process.exit(1)
+    }
+  }, 8000).unref()
 
   const routerInterval = startMessageRouter()
   logger.info('Agent message router started (5s poll)')


### PR DESCRIPTION
## Self-heal a silent HTTP bind failure on dashboard restart

**Incident (2026-06-27, ~07:00):** after a `kickstart -k`, the dashboard process logged `Web dashboard: port 3420` (the listen-success callback fired) but **nothing was bound to 3420**, with no error logged. The background loops (router, scheduler) start right after the `listen()` *call*, so they kept running — the dashboard was **alive but deaf** (web UI + inter-agent POST down) for hours, until a manual *second* restart bound cleanly. Root cause: the kickstart raced the dying predecessor's lingering socket through the EADDRINUSE reclaim + re-listen path (`web.ts`), and the re-listen had no success/failure observability.

**Fix (small, additive):**
- The re-listen after port reclaim (was a bare `server.listen` with no callback) now logs on success → an actual rebind is observable.
- After a generous startup grace window, verify `server.listening`; if false, `exit(1)` so launchd restarts us fresh (a clean restart binds reliably) instead of lingering un-servable. Timer is `.unref()`'d.

No happy-path behaviour change. tsc clean.

**Why it matters now:** this race recurs on *every* deploy restart — including the imminent #458 deploy. With this, a silent bind failure self-heals via launchd instead of taking the fleet's API down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
