### PR TITLE
fix(channel-recovery): drop the unstable /mcp keystroke dance for sub-agents

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -90,6 +90,19 @@ TMUX="$(command -v tmux)"
 [ -z "$CLAUDE" ] && echo "ERROR: claude not found on PATH" >&2 && exit 1
 [ -z "$TMUX" ]   && echo "ERROR: tmux not found on PATH" >&2 && exit 1
 
+# MAIN-session fixes the upstream ghost-text fix (agent-process.ts) only applied
+# to SUB-agents -- the main channels session never got them, so Jarvis kept
+# hitting the ghost-text re-submit bug (stuck /mcp menu -> recovery hard-reset
+# loop) plus MCP startup-batch starvation (most MCP servers of any agent).
+#  - CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false: kill the DIM ghost-text of a
+#    previous prompt that the pane-scraping recovery misreads as parked input
+#    and re-submits (the root of the stuck-/mcp loop).
+#  - MCP_* batch tuning: the --channels plugin is a stdio MCP server; without
+#    these it gets starved out of the default 3-wide blocking startup batch.
+# Inline on the launch command -- the tmux server predates this script and does
+# not inherit its env. Mirrors startAgentProcess (sub-agent launch).
+MAIN_FIX_ENV="export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false MCP_SERVER_CONNECTION_BATCH_SIZE=10 MCP_CONNECTION_NONBLOCKING=1 MCP_TIMEOUT=60000 && "
+
 # Read the main agent's default model from .claude/settings.json so we can
 # pass --model explicitly. Without --model claude-code falls back to its
 # built-in default, which can drift across versions. Passing the flag makes
@@ -186,7 +199,7 @@ fi
 # resuming one of those loses the --channels activation state, causing
 # "Channel notifications skipped: server not in --channels list" errors.
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
+  "${MAIN_FIX_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
 
 # Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
 # kulonben a headless session orokre parkolna a prompton es a Telegram plugin
@@ -227,7 +240,7 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
         # entry); see the PR description / card 7EB18437.
         [ -e "$INSTALL_DIR/CLAUDE.md" ] && ln -sf "$INSTALL_DIR/CLAUDE.md" "$_CHANNELS_STARTDIR/CLAUDE.md" 2>/dev/null || true
         $TMUX new-session -d -s "$SESSION" -c "$_CHANNELS_STARTDIR" \
-          "$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
+          "${MAIN_FIX_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
         unset _CHANNELS_STARTDIR
       fi
       continue

--- a/src/__tests__/agent-restart-policy.test.ts
+++ b/src/__tests__/agent-restart-policy.test.ts
@@ -267,3 +267,158 @@ describe('shouldAutoRestartDownAgent with back-off', () => {
     })).toBe(true)
   })
 })
+
+// 2026-06-27 follow-up: faster first retry on a flaky --channels plugin-load
+// miss. When the pane has SETTLED at the idle prompt the agent finished cold-
+// starting, so a still-absent channel poller is a definitive flaky miss (the
+// bun poller attaches within ~10s when it works) -- not a slow boot. In that
+// state we may relaunch without waiting out the full (5min) startup grace, and
+// the first couple of relaunch failures stay at the base grace instead of
+// doubling, so the common ~2-3 try convergence is not slowed.
+const FAST = 45_000
+describe('shouldAutoRestartDownAgent: settled-pane fast retry', () => {
+  it('restarts a SETTLED young process past the fast grace (definitive flaky miss)', () => {
+    // 60s old: well within the 180s startup grace, but pane is settled and the
+    // 45s fast grace has elapsed -> relaunch now instead of waiting 5 minutes.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 60_000,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      paneSettled: true,
+      fastRetryGraceMs: FAST,
+    })).toBe(true)
+  })
+
+  it('does NOT restart a settled process still within the fast grace', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 30_000,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      paneSettled: true,
+      fastRetryGraceMs: FAST,
+    })).toBe(false)
+  })
+
+  it('does NOT use the fast grace when the pane is NOT settled (still booting)', () => {
+    // Same young age, but the pane has not reached idle -> it may genuinely be
+    // booting (large-context model); keep the conservative startup grace.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 60_000,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      paneSettled: false,
+      fastRetryGraceMs: FAST,
+    })).toBe(false)
+  })
+
+  it('ignores the fast path when fastRetryGraceMs is omitted', () => {
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 60_000,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      paneSettled: true,
+    })).toBe(false)
+  })
+
+  it('never LENGTHENS the grace if fastRetryGraceMs exceeds the startup grace', () => {
+    // min(startup, fast) keeps the smaller; a bogus large fast value is ignored.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: STARTUP - 1,
+      msSinceLastRestart: null,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      paneSettled: true,
+      fastRetryGraceMs: STARTUP + 100_000,
+    })).toBe(false)
+  })
+})
+
+describe('effectiveRestartGraceMs: free fast retries before back-off', () => {
+  it('keeps the base grace for the first freeFastRetries failures', () => {
+    expect(effectiveRestartGraceMs(RESTART, 1, undefined, 2)).toBe(RESTART)
+    expect(effectiveRestartGraceMs(RESTART, 2, undefined, 2)).toBe(RESTART)
+  })
+
+  it('starts doubling only after the free retries are spent', () => {
+    expect(effectiveRestartGraceMs(RESTART, 3, undefined, 2)).toBe(RESTART * 2)
+    expect(effectiveRestartGraceMs(RESTART, 4, undefined, 2)).toBe(RESTART * 4)
+  })
+
+  it('preserves original doubling when freeFastRetries omitted/zero', () => {
+    expect(effectiveRestartGraceMs(RESTART, 1)).toBe(RESTART * 2)
+    expect(effectiveRestartGraceMs(RESTART, 1, undefined, 0)).toBe(RESTART * 2)
+  })
+
+  it('still honours the cap with free retries', () => {
+    const cap = 60 * 60 * 1000
+    expect(effectiveRestartGraceMs(RESTART, 30, cap, 2)).toBe(cap)
+  })
+})
+
+describe('shouldAutoRestartDownAgent: free fast retries end-to-end', () => {
+  it('a settled agent relaunches at base grace for the first failures (no doubling)', () => {
+    // 1 prior failure, 100s since last restart: original behaviour would defer
+    // (180s grace); with 2 free retries the grace stays 90s -> relaunch now.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 60_000,
+      msSinceLastRestart: 100_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      consecutiveFailures: 1,
+      maxRestartGraceMs: 60 * 60 * 1000,
+      paneSettled: true,
+      fastRetryGraceMs: FAST,
+      freeFastRetries: 2,
+    })).toBe(true)
+  })
+
+  it('on a SETTLED pane the relaunch window also shrinks to the fast grace', () => {
+    // 50s since last restart: under the 90s base (would defer without the
+    // settled fast path), but a settled+deaf agent uses the 45s relaunch base.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 50_000,
+      msSinceLastRestart: 50_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      consecutiveFailures: 1,
+      maxRestartGraceMs: 60 * 60 * 1000,
+      paneSettled: true,
+      fastRetryGraceMs: FAST,
+      freeFastRetries: 2,
+    })).toBe(true)
+    // Same timing but NOT settled (still booting): keep the conservative window.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 50_000,
+      msSinceLastRestart: 50_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      consecutiveFailures: 1,
+      maxRestartGraceMs: 60 * 60 * 1000,
+      paneSettled: false,
+      fastRetryGraceMs: FAST,
+      freeFastRetries: 2,
+    })).toBe(false)
+  })
+
+  it('a genuinely-broken settled plugin still backs off after the free retries', () => {
+    // failures past the free window: doubling resumes (from the fast base),
+    // so a plugin that never comes up is not relaunched every 45s forever.
+    // 5 failures, 45s base, 2 free -> 45s * 2^3 = 360s grace; 200s since last
+    // restart is still within it -> defer.
+    expect(shouldAutoRestartDownAgent({
+      processAgeMs: 5 * 60_000,
+      msSinceLastRestart: 200_000,
+      startupGraceMs: STARTUP,
+      restartGraceMs: RESTART,
+      consecutiveFailures: 5,
+      maxRestartGraceMs: 60 * 60 * 1000,
+      paneSettled: true,
+      fastRetryGraceMs: FAST,
+      freeFastRetries: 2,
+    })).toBe(false)
+  })
+})

--- a/src/__tests__/agent-restart-state.test.ts
+++ b/src/__tests__/agent-restart-state.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import {
+  restartStateToJson,
+  parseRestartState,
+  loadRestartState,
+  saveRestartState,
+  emptyRestartState,
+} from '../web/agent-restart-state.js'
+
+describe('agent-restart-state serialisation', () => {
+  it('round-trips failures + lastRestart through JSON', () => {
+    const failures = new Map([['hacker', 3], ['heli', 1]])
+    const lastRestart = new Map([['hacker', 1782490000000], ['heli', 1782490500000]])
+    const parsed = parseRestartState(restartStateToJson(failures, lastRestart))
+    expect(parsed.failures).toEqual({ hacker: 3, heli: 1 })
+    expect(parsed.lastRestart).toEqual({ hacker: 1782490000000, heli: 1782490500000 })
+  })
+
+  it('returns empty state for malformed JSON', () => {
+    expect(parseRestartState('not json {')).toEqual(emptyRestartState())
+    expect(parseRestartState('null')).toEqual(emptyRestartState())
+    expect(parseRestartState('[1,2,3]')).toEqual(emptyRestartState())
+  })
+
+  it('drops corrupt / out-of-range entries instead of trusting them', () => {
+    // negative / NaN failures (would disable back-off) and a zero lastRestart
+    // (min 1, an epoch ms can never be 0) must all be discarded.
+    const raw = JSON.stringify({
+      failures: { hacker: -2, heli: 'x', key: 4, bad: NaN },
+      lastRestart: { hacker: 0, heli: 1782490000000, '': 5 },
+    })
+    const parsed = parseRestartState(raw)
+    expect(parsed.failures).toEqual({ key: 4 })
+    expect(parsed.lastRestart).toEqual({ heli: 1782490000000 })
+  })
+
+  it('floors fractional counters', () => {
+    const parsed = parseRestartState(JSON.stringify({ failures: { hacker: 2.9 }, lastRestart: {} }))
+    expect(parsed.failures).toEqual({ hacker: 2 })
+  })
+})
+
+describe('agent-restart-state file I/O', () => {
+  it('saves and loads from disk', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'restart-state-'))
+    const path = join(dir, 'state.json')
+    try {
+      saveRestartState(path, new Map([['hacker', 2]]), new Map([['hacker', 1782490000000]]))
+      const loaded = loadRestartState(path)
+      expect(loaded.failures).toEqual({ hacker: 2 })
+      expect(loaded.lastRestart).toEqual({ hacker: 1782490000000 })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns empty state when the file is missing', () => {
+    const loaded = loadRestartState(join(tmpdir(), 'definitely-missing-restart-state-xyz.json'))
+    expect(loaded).toEqual(emptyRestartState())
+  })
+
+  it('returns empty state when the file is corrupt', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'restart-state-'))
+    const path = join(dir, 'corrupt.json')
+    try {
+      writeFileSync(path, '{ broken')
+      expect(loadRestartState(path)).toEqual(emptyRestartState())
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/__tests__/channel-mcp-reconnect.test.ts
+++ b/src/__tests__/channel-mcp-reconnect.test.ts
@@ -180,6 +180,30 @@ const ENABLE_RX = /\benable\b/i
 describe('attemptChannelMcpReconnect', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // attemptChannelMcpReconnect now does a preflight capturePane + busy-guard
+    // BEFORE pressing any key (so it never interrupts an actively generating
+    // pane). Queue a non-busy preflight read first; each test's own capture
+    // sequence then flows behind it unchanged. A 'no idle footer' string reads
+    // as 'unknown' (not 'busy'), so the guard lets the reconnect proceed.
+    mockCapturePane.mockReturnValueOnce('preflight-not-busy')
+  })
+
+  it('defers (sends NO keys) when the pane is actively generating', () => {
+    // Reni-reported root cause: the soft /mcp reconnect blindly pressed Escape
+    // into a live session, interrupting work in progress. The busy-guard must
+    // bail before any send-keys when detectPaneState reads 'busy'.
+    mockCapturePane.mockReset()
+    mockCapturePane.mockReturnValueOnce('· Synthesizing… (8s · ↓ 1.2k tokens · esc to interrupt)')
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('busy')
+    // The hard assertion: not a single key was sent into the pane.
+    const sendKeyCalls = mockExecFileSync.mock.calls.filter(
+      (c) => Array.isArray(c[1]) && c[1].includes('send-keys'),
+    )
+    expect(sendKeyCalls.length).toBe(0)
   })
 
   it('connected state: steps Down onto Reconnect, then activates it', () => {

--- a/src/__tests__/channel-monitor-busy-guard.test.ts
+++ b/src/__tests__/channel-monitor-busy-guard.test.ts
@@ -30,20 +30,28 @@ describe('channel-monitor: busy-guard before destructive auto-restart', () => {
     expect(stopIdx, 'stopAgentProcess call not found').toBeGreaterThan(0)
   })
 
-  it('a detectPaneState busy-check defers the restart and sits BEFORE the stop+start', () => {
+  it('a busy-check defers the restart and sits BEFORE the stop+start', () => {
     // The guard slice: window between the per-tick stagger check and the
     // destructive restart. Look just before the auto-restart log line.
     const windowStart = Math.max(0, restartLogIdx - 1200)
     const guardWindow = src.slice(windowStart, restartLogIdx)
 
-    // It must capture the pane and bail on 'busy'.
+    // It must bail on 'busy'. The pane is captured once higher up (downPaneState
+    // = detectPaneState(...)) and reused here, so the busy check reads the
+    // cached state rather than re-capturing.
     expect(guardWindow, 'busy-guard missing before hard restart').toMatch(
-      /detectPaneState\([^)]*\)\s*===\s*'busy'/,
+      /downPaneState\s*===\s*'busy'/,
     )
     expect(guardWindow, 'busy-guard must continue (defer) rather than fall through').toMatch(
       /busy[\s\S]*?continue/i,
     )
     // Ordering: the guard must precede the destructive stopAgentProcess.
     expect(restartLogIdx).toBeLessThan(stopIdx)
+  })
+
+  it('the pane state powering the busy-guard is read via detectPaneState', () => {
+    // The single capture+classify that both the fast-retry decision and the
+    // busy-guard reuse.
+    expect(src).toMatch(/const downPaneState = detectPaneState\(/)
   })
 })

--- a/src/__tests__/channel-monitor-busy-guard.test.ts
+++ b/src/__tests__/channel-monitor-busy-guard.test.ts
@@ -1,0 +1,49 @@
+// Guards the busy-check that protects an actively-generating agent from being
+// hard-restarted (stop+start) when its channel plugin reads "down".
+//
+// Root cause this defends (Reni-reported): the channel-monitor tick would
+// stopAgentProcess + startAgentProcess an agent the moment hasChannelPluginAlive
+// returned false, with no regard for whether the agent was mid-turn. That kills
+// the agent's in-flight work and its --continue context ("restarted me during
+// development"). The fix defers the destructive restart while the pane reads
+// 'busy'. The restart loop is not exported as a unit, so -- matching the
+// existing source-assertion convention in this dir -- we assert the guard's
+// presence AND that it sits BEFORE the destructive stopAgentProcess call.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MONITOR_PATH = join(__dirname, '..', 'web', 'channel-monitor.ts')
+
+describe('channel-monitor: busy-guard before destructive auto-restart', () => {
+  const src = readFileSync(MONITOR_PATH, 'utf-8')
+
+  // Anchor on the auto-restart warning that immediately precedes the hard
+  // restart (the only stop+start in the down-agent path).
+  const restartLogIdx = src.indexOf("'Agent channel plugin down -- auto-restarting'")
+  const stopIdx = src.indexOf('stopAgentProcess(t.agentName!)')
+
+  it('the down-agent hard-restart path still exists', () => {
+    expect(restartLogIdx, 'auto-restart log line not found').toBeGreaterThan(0)
+    expect(stopIdx, 'stopAgentProcess call not found').toBeGreaterThan(0)
+  })
+
+  it('a detectPaneState busy-check defers the restart and sits BEFORE the stop+start', () => {
+    // The guard slice: window between the per-tick stagger check and the
+    // destructive restart. Look just before the auto-restart log line.
+    const windowStart = Math.max(0, restartLogIdx - 1200)
+    const guardWindow = src.slice(windowStart, restartLogIdx)
+
+    // It must capture the pane and bail on 'busy'.
+    expect(guardWindow, 'busy-guard missing before hard restart').toMatch(
+      /detectPaneState\([^)]*\)\s*===\s*'busy'/,
+    )
+    expect(guardWindow, 'busy-guard must continue (defer) rather than fall through').toMatch(
+      /busy[\s\S]*?continue/i,
+    )
+    // Ordering: the guard must precede the destructive stopAgentProcess.
+    expect(restartLogIdx).toBeLessThan(stopIdx)
+  })
+})

--- a/src/__tests__/channel-recovery-no-mcp-dance.test.ts
+++ b/src/__tests__/channel-recovery-no-mcp-dance.test.ts
@@ -1,0 +1,51 @@
+// Locks in the 2026-06-27 recovery change: sub-agent channel-plugin recovery no
+// longer injects /mcp keystrokes. The old recovery drove a fixed
+// /mcp+Up+Enter+Enter navigation (soft reconnect in the monitor, plus a
+// post-respawn "colleague auto-unlock" in agent-process) to re-enable a wedged
+// plugin. That was both pointless (channel sub-agents always launch fresh, so
+// there is no --continue context to preserve) and unstable (the MCP server list
+// order differs per agent, so the hard-coded "one Up == the channel plugin"
+// lands on the wrong server and parks the pane in the /mcp modal -- the
+// Reni-reported deaf-bot / stuck-in-/mcp incident). Recovery is now a verified
+// fresh relaunch retried each tick. The monitor tick + the launch path are not
+// exported as units, so -- matching the source-assertion convention in this dir
+// -- we assert against the source text. The MAIN-session soft /mcp reconnect is
+// intentionally NOT touched by this change and must remain.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MONITOR_PATH = join(__dirname, '..', 'web', 'channel-monitor.ts')
+const PROCESS_PATH = join(__dirname, '..', 'web', 'agent-process.ts')
+
+describe('channel recovery: no /mcp keystroke dance for sub-agents', () => {
+  const monitor = readFileSync(MONITOR_PATH, 'utf-8')
+  const process = readFileSync(PROCESS_PATH, 'utf-8')
+
+  it('the sub-agent down path no longer drives a soft /mcp reconnect', () => {
+    // The per-down-spell soft-reconnect state is gone entirely.
+    expect(monitor).not.toContain('agentSoftReconnectTried')
+    // The sub-agent soft reconnect call (keyed by the per-target agent name)
+    // is gone. The destructive-restart path below it stays the recovery.
+    expect(monitor).not.toContain('attemptChannelMcpReconnect(t.agentName!)')
+  })
+
+  it('still goes straight to the verified fresh relaunch (stop+start) when down', () => {
+    expect(monitor).toContain("'Agent channel plugin down -- auto-restarting'")
+    expect(monitor).toContain('stopAgentProcess(t.agentName!)')
+    expect(monitor).toContain('startAgentProcess(t.agentName!)')
+  })
+
+  it('leaves the MAIN-session soft /mcp reconnect untouched', () => {
+    // The main agent keeps its own soft-first cascade; only the sub-agent path
+    // changed. Guard against an over-broad removal.
+    expect(monitor).toContain('attemptChannelMcpReconnect(MAIN_AGENT_ID)')
+  })
+
+  it('agent-process no longer schedules the /mcp unlock keystrokes on sub-agent launch', () => {
+    // Neither the import nor the call may remain in the launch path.
+    expect(process).not.toContain('schedulePluginUnlockAfterRespawn')
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -32,7 +32,6 @@ import { CHANNEL_PROVIDER, MAIN_AGENT_ID } from '../config.js'
 import { loadProfileTemplate } from './profiles.js'
 import { resolveAgentSecurityProfile } from './agent-team.js'
 import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
-import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import { getSecret } from './vault.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
 
@@ -468,20 +467,21 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // -- the outbound pre-flight remains the safety net if this misses.
     scheduleIdentitySetup(session, readAgentDisplayName(name))
 
-    // Colleague auto-unlock (2026-06-22): mirror the main session's
-    // post-respawn unlock probe for channel-having sub-agents. After a restart
-    // the bun channel poller sometimes never attaches during the cold-start
-    // window (observed fleet-wide after a managed restart: the TUI comes up but
-    // bot.pid stays empty, so the agent goes deaf to inbound). The main session
-    // self-heals because channel-monitor schedules schedulePluginUnlockAfterRespawn;
-    // sub-agents had no such probe and stayed stuck until a manual /mcp kick.
-    // Schedule the same probe here. It is gated on bun-absence (a healthy poller
-    // is left untouched) and on an idle pane, so it never disturbs a colleague
-    // mid-turn. Channel-less agents (hasChannel false) get no probe; MAIN never
-    // takes this path (it comes up via channels.sh) but guard defensively.
-    if (hasChannel && name !== MAIN_AGENT_ID) {
-      schedulePluginUnlockAfterRespawn(session, provider.type)
-    }
+    // Post-respawn channel-plugin recovery for sub-agents is handled by the
+    // channel-monitor's verified fresh-relaunch loop, NOT by /mcp keystroke
+    // injection. The old "colleague auto-unlock" probe drove a fixed
+    // /mcp+Up+Enter+Enter navigation into the pane to re-enable a wedged plugin,
+    // but the MCP server list order differs per agent (e.g. an agent with an
+    // extra project .mcp.json server shifts every row), so the hard-coded
+    // "one Up == the channel plugin at the bottom" assumption lands on the WRONG
+    // server and frequently leaves the agent parked in the /mcp modal -- the
+    // deaf-bot / stuck-in-/mcp failure (2026-06-27 fleet incident, Reni-reported).
+    // Channel sub-agents are ALWAYS launched fresh (no --continue; see continueFlag
+    // above), so there is no conversation context to preserve with a soft in-place
+    // reconnect. When the flaky Claude Code --channels plugin load misses (no bun
+    // poller attaches), the monitor detects it next tick and relaunches fresh
+    // until the poller attaches -- proven to converge in ~2 tries. So we
+    // deliberately inject NO /mcp keys here.
 
     return { ok: true }
   } catch (err) {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -401,7 +401,16 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // opts.fresh forces a brand-new conversation (auto-restart 'fresh' mode):
     // omit --continue so the heavy accumulated context is dropped. Without it
     // we resume the prior session (the 'continue' mode / normal restart).
-    const continueFlag = (hasPriorSession && !opts.fresh) ? '--continue ' : ''
+    //
+    // CC --continue plugin regression (PR #464): a `--continue` resume does NOT
+    // re-initialise the `--channels` plugin MCP server -- the agent comes up with
+    // the plugin absent from /mcp, no bun poller, no bot.pid -> permanently deaf
+    // on its channel. A FRESH launch loads the plugin correctly (confirmed: the
+    // monitor's --continue restarts stayed deaf all night while fleet.sh fresh
+    // restarts attached). So channel-having agents are ALWAYS launched fresh --
+    // the lost conversation context is the price of a reachable bot (file/db
+    // memory persists either way). Channel-less agents keep --continue.
+    const continueFlag = (hasPriorSession && !opts.fresh && !hasChannel) ? '--continue ' : ''
     const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : agentProvider === 'googlechat' ? 'GOOGLECHAT_STATE_DIR' : 'TELEGRAM_STATE_DIR'
     const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN'
     // Slack plugin is third-party; its "not on approved allowlist" check is

--- a/src/web/agent-restart-policy.ts
+++ b/src/web/agent-restart-policy.ts
@@ -37,6 +37,23 @@ export interface AgentRestartDecisionInput {
   // long-down plugin occasionally (it may recover after an external fix) rather
   // than backing off unboundedly. Omitted = no cap beyond the exponent.
   maxRestartGraceMs?: number
+  // True when the agent's TUI has SETTLED at the idle prompt -- i.e. it finished
+  // cold-starting. A still-absent channel poller on a settled pane is a
+  // definitive flaky-load miss (the bun poller attaches within ~10s when it
+  // works), NOT a slow boot, so it is safe to relaunch without waiting out the
+  // full startup grace. Omitted/false keeps the conservative startupGraceMs.
+  paneSettled?: boolean
+  // Shorter startup grace to apply when paneSettled is true. Must still exceed
+  // the healthy plugin-attach window (~10s) so we never relaunch an agent that
+  // was about to come up. Only ever SHORTENS the grace (min with startupGraceMs);
+  // a value above startupGraceMs is ignored. Omitted = no fast path.
+  fastRetryGraceMs?: number
+  // Number of early failures that retry at the BASE restart grace before the
+  // exponential back-off kicks in. The common flaky-load case converges in ~2-3
+  // fresh relaunches, so doubling from the first failure needlessly slows it.
+  // Omitted/0 = original behaviour (double from the first failure). The cap and
+  // unbounded back-off for a genuinely-broken plugin are unchanged.
+  freeFastRetries?: number
 }
 
 // The restart grace after applying exponential back-off for repeated failed
@@ -47,12 +64,18 @@ export function effectiveRestartGraceMs(
   restartGraceMs: number,
   consecutiveFailures: number,
   maxRestartGraceMs?: number,
+  freeFastRetries?: number,
 ): number {
   const failures = Number.isFinite(consecutiveFailures) && consecutiveFailures > 0
     ? Math.floor(consecutiveFailures)
     : 0
-  // Cap the exponent well below the point where 2^n overflows Number range.
-  const exp = Math.min(failures, 30)
+  const free = Number.isFinite(freeFastRetries) && (freeFastRetries as number) > 0
+    ? Math.floor(freeFastRetries as number)
+    : 0
+  // The first `free` failures retry at the base grace (no doubling); the
+  // exponent only grows once those are spent. Cap it well below the point
+  // where 2^n overflows Number range.
+  const exp = Math.min(Math.max(failures - free, 0), 30)
   let grace = restartGraceMs * 2 ** exp
   if (maxRestartGraceMs != null && Number.isFinite(maxRestartGraceMs)) {
     grace = Math.min(grace, maxRestartGraceMs)
@@ -66,12 +89,35 @@ export function shouldAutoRestartDownAgent(input: AgentRestartDecisionInput): bo
   // Unknown process age: the age probe failed. Be conservative and do not
   // restart -- a false "down" must never kill a healthy agent.
   if (!Number.isFinite(processAgeMs) || processAgeMs < 0) return false
-  // Freshly started: the channel plugin may still be spawning.
-  if (processAgeMs < startupGraceMs) return false
+  // Freshly started: the channel plugin may still be spawning. A SETTLED pane
+  // (idle prompt reached) proves the cold-start finished, so a still-absent
+  // poller is a definitive flaky-load miss, not a slow boot -- use the shorter
+  // fast-retry grace there instead of waiting out the full startup grace. The
+  // fast grace can only SHORTEN the window (min), never lengthen it.
+  const fastEligible =
+    input.paneSettled === true && Number.isFinite(input.fastRetryGraceMs) && (input.fastRetryGraceMs as number) >= 0
+  const effectiveStartupGrace = fastEligible
+    ? Math.min(startupGraceMs, input.fastRetryGraceMs as number)
+    : startupGraceMs
+  if (processAgeMs < effectiveStartupGrace) return false
   // Recently restarted by the watchdog: give the new process time to come up,
   // backed off exponentially for repeated failed restarts so a plugin that can
-  // never come up is not restarted on a fixed short cadence forever.
-  const grace = effectiveRestartGraceMs(restartGraceMs, input.consecutiveFailures ?? 0, input.maxRestartGraceMs)
+  // never come up is not restarted on a fixed short cadence forever. The first
+  // `freeFastRetries` failures stay at the base grace so the common flaky-load
+  // case (converges in ~2-3 relaunches) is not slowed by doubling. On a SETTLED
+  // pane the relaunch window itself shrinks to the fast grace too -- a booted,
+  // deaf agent has already missed, so there is nothing to wait for between
+  // relaunches either. The exponential back-off (and its cap) still apply once
+  // the free retries are spent, so a genuinely-broken plugin cannot churn.
+  const restartBase = fastEligible
+    ? Math.min(restartGraceMs, input.fastRetryGraceMs as number)
+    : restartGraceMs
+  const grace = effectiveRestartGraceMs(
+    restartBase,
+    input.consecutiveFailures ?? 0,
+    input.maxRestartGraceMs,
+    input.freeFastRetries,
+  )
   if (msSinceLastRestart !== null && msSinceLastRestart < grace) return false
   return true
 }

--- a/src/web/agent-restart-state.ts
+++ b/src/web/agent-restart-state.ts
@@ -1,0 +1,101 @@
+// Persistence for the channel watchdog's per-agent restart back-off counters.
+//
+// WHY: channel-monitor.ts keeps the auto-restart back-off entirely in memory
+// (agentRestartFailures + agentLastRestart Maps). The dashboard process itself
+// restarts frequently (self-update, crashes, launchd/systemd bounce -- 14
+// distinct dashboard PIDs were observed in a single night). Every dashboard
+// restart wiped those Maps, so the exponential back-off that is supposed to
+// SPACE OUT retries for an agent whose channel plugin never comes up reset to
+// zero -- and the watchdog dropped straight back to the aggressive base-grace
+// (~5 min) restart cadence. The result was a down agent (e.g. hacker, whose
+// telegram poller was slow to register) being stop+start churned all night,
+// each restart destroying the agent's --continue context.
+//
+// This module gives the counters a tiny on-disk home so they survive a
+// dashboard restart. It is best-effort: any I/O or parse failure degrades to
+// the previous in-memory-only behaviour (empty state), never throwing into the
+// monitor tick. The serialize/deserialize halves are pure so they can be unit
+// tested without touching the filesystem.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { logger } from '../logger.js'
+
+export interface PersistedRestartState {
+  // Consecutive failed watchdog restarts, keyed by agent NAME. Mirrors
+  // agentRestartFailures in channel-monitor.ts.
+  failures: Record<string, number>
+  // Wall-clock time (epoch ms) of the last watchdog restart, keyed by agent
+  // NAME. Mirrors agentLastRestart. Persisted alongside failures because the
+  // back-off grace check (shouldAutoRestartDownAgent) needs BOTH: losing
+  // lastRestart makes msSinceLastRestart null, which skips the restart-grace
+  // gate entirely and re-enables immediate churn.
+  lastRestart: Record<string, number>
+}
+
+export function emptyRestartState(): PersistedRestartState {
+  return { failures: {}, lastRestart: {} }
+}
+
+// Pure: turn the two in-memory Maps into the serialisable shape.
+export function restartStateToJson(
+  failures: Map<string, number>,
+  lastRestart: Map<string, number>,
+): string {
+  const state: PersistedRestartState = {
+    failures: Object.fromEntries(failures),
+    lastRestart: Object.fromEntries(lastRestart),
+  }
+  return JSON.stringify(state)
+}
+
+// Pure: parse persisted JSON back into a normalised state. Any malformed or
+// out-of-range entry is dropped rather than trusted, so a corrupt file can
+// never inject a bogus counter (e.g. a negative grace or a NaN that disables
+// back-off). Returns empty state on any failure.
+export function parseRestartState(raw: string): PersistedRestartState {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed == null || typeof parsed !== 'object') return emptyRestartState()
+    const obj = parsed as Record<string, unknown>
+    return {
+      failures: normaliseCounterMap(obj.failures, { min: 0 }),
+      lastRestart: normaliseCounterMap(obj.lastRestart, { min: 1 }),
+    }
+  } catch {
+    return emptyRestartState()
+  }
+}
+
+function normaliseCounterMap(value: unknown, opts: { min: number }): Record<string, number> {
+  const out: Record<string, number> = {}
+  if (value == null || typeof value !== 'object') return out
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof k !== 'string' || k.length === 0) continue
+    if (typeof v !== 'number' || !Number.isFinite(v) || v < opts.min) continue
+    out[k] = Math.floor(v)
+  }
+  return out
+}
+
+// Best-effort load. Missing file / parse error -> empty state.
+export function loadRestartState(path: string): PersistedRestartState {
+  try {
+    return parseRestartState(readFileSync(path, 'utf-8'))
+  } catch {
+    return emptyRestartState()
+  }
+}
+
+// Best-effort save. Never throws (logs at debug on failure) so a read-only or
+// full disk can never break the monitor tick.
+export function saveRestartState(
+  path: string,
+  failures: Map<string, number>,
+  lastRestart: Map<string, number>,
+): void {
+  try {
+    writeFileSync(path, restartStateToJson(failures, lastRestart))
+  } catch (err) {
+    logger.debug({ err, path }, 'saveRestartState failed (non-fatal)')
+  }
+}

--- a/src/web/channel-mcp-reconnect.ts
+++ b/src/web/channel-mcp-reconnect.ts
@@ -6,7 +6,7 @@ import { readAgentChannelProvider } from './agent-config.js'
 import { agentSessionName, capturePane } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { getProvider, type ChannelProviderType } from '../channel-provider.js'
-import { paneLooksIdle } from '../pane-state.js'
+import { paneLooksIdle, detectPaneState } from '../pane-state.js'
 
 const TMUX = resolveFromPath('tmux')
 const MAX_UP_ATTEMPTS = 8
@@ -161,6 +161,20 @@ export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
   const session = resolveAgentSession(agentName)
   const providerType = resolveAgentProviderType(agentName)
   const pluginPattern = getPluginPattern(providerType)
+
+  // Idle-guard: NEVER drive the /mcp menu (which starts by pressing Escape and
+  // then navigates Up/Enter/Down) into a pane that is actively generating. The
+  // Escape would interrupt the agent's in-flight turn and the navigation keys
+  // would inject stray input into a live session -- i.e. it kills work in
+  // progress. A 'busy' read means an Escape lands as an interrupt, so we defer
+  // and let the caller retry on a later tick when the pane is back at the idle
+  // prompt. (detectPaneState reads the live footer / busy indicators; scrollback
+  // mentions of "esc to interrupt" are footer-scoped so they don't false-trip.)
+  const preflight = capturePane(session) ?? ''
+  if (detectPaneState(preflight) === 'busy') {
+    logger.info({ agentName, session }, 'channel-mcp-reconnect: pane busy -- deferring reconnect to avoid interrupting active work')
+    return { ok: false, message: 'Pane busy -- reconnect deferred to avoid interrupting active work' }
+  }
 
   try {
     execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -35,6 +35,7 @@ import { getProvider, channelStateDir, readChannelToken, type ChannelProviderTyp
 import { attemptChannelMcpReconnect } from './channel-mcp-reconnect.js'
 import { readLastIngestionTimestamp, TRANSCRIPT_DIR } from './inbound-probe.js'
 import { shouldAutoRestartDownAgent, parseEtimeToSeconds } from './agent-restart-policy.js'
+import { loadRestartState, saveRestartState } from './agent-restart-state.js'
 // getClaudePidForSession + hasChannelPluginAlive live in the shared liveness
 // module so the standalone channel-coordinator reuses the exact same probe.
 import { getClaudePidForSession, hasChannelPluginAlive } from '../channel-coordinator/liveness.js'
@@ -75,6 +76,31 @@ const agentLastRestart: Map<string, number> = new Map()
 // short cadence forever -- which restarts the WHOLE agent every few minutes and
 // renders it unusable. Reset to 0 the moment the plugin is seen alive again.
 const agentRestartFailures: Map<string, number> = new Map()
+// Sub-agent sessions for which we have already tried a NON-destructive soft
+// /mcp reconnect during the CURRENT down-spell (keyed by tmux session). The
+// watchdog tries one soft reconnect before escalating to a context-destroying
+// stop+start, mirroring the main session's soft-first cascade; cleared when the
+// agent's plugin is seen alive again so the next down-spell gets a fresh try.
+const agentSoftReconnectTried: Set<string> = new Set()
+
+// --- Back-off persistence (survive dashboard restarts) ---
+// agentRestartFailures + agentLastRestart drive the exponential back-off that
+// keeps a perpetually-down agent from being restart-churned. Both were memory-
+// only, so every dashboard restart (frequent: self-update, crash, service
+// bounce) wiped them and dropped the watchdog back to the aggressive base-grace
+// cadence. Persist them so the back-off survives a dashboard restart. Best-
+// effort: load on module init, flush after each mutation.
+const RESTART_STATE_FILE = join(PROJECT_ROOT, 'store', '.agent-restart-state.json')
+function hydrateRestartState(): void {
+  const state = loadRestartState(RESTART_STATE_FILE)
+  for (const [k, v] of Object.entries(state.failures)) agentRestartFailures.set(k, v)
+  for (const [k, v] of Object.entries(state.lastRestart)) agentLastRestart.set(k, v)
+}
+function persistRestartState(): void {
+  saveRestartState(RESTART_STATE_FILE, agentRestartFailures, agentLastRestart)
+}
+hydrateRestartState()
+
 const AGENT_RESTART_GRACE_MS = 90_000
 // Floor frequency for the backed-off restart: even a long-down plugin is still
 // retried at least this often, in case an external fix brings it back.
@@ -83,7 +109,14 @@ const AGENT_MAX_RESTART_GRACE_MS = 60 * 60 * 1000 // 1h
 // its channel plugin up (a large-context model launched with --continue spawns
 // the plugin only after a slow session load). Never restart a process younger
 // than this on a "plugin down" reading, or the watchdog crash-loops it.
-const AGENT_STARTUP_GRACE_MS = 180_000
+// Raised 180s -> 300s (2026-06-27): in a busy startup window the telegram
+// channel-plugin bun poller routinely registers only after ~4-5 min (MCP
+// batch-starvation among many stdio servers), even WITH MCP_CONNECTION_NONBLOCKING
+// set. At 180s the watchdog killed the agent right before the poller came up,
+// and the fresh process hit the same slow window -> an all-night stop+start loop
+// (observed on hacker, 23:49->07:22). 300s lets the slow-but-healthy poller land
+// before any restart, while staying well under the genuinely-dead escalation.
+const AGENT_STARTUP_GRACE_MS = 300_000
 const PLUGIN_ALERT_DEDUP_MS = 30 * 60 * 1000
 
 // Stuck channel-input recovery (MAIN session only). A channel notification
@@ -1187,7 +1220,9 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           }
           // Healthy observation clears the exponential back-off so the next
           // down-spell starts again at the base grace.
-          agentRestartFailures.delete(t.agentName!)
+          if (agentRestartFailures.delete(t.agentName!)) persistRestartState()
+          // End of the down-spell: allow a fresh soft reconnect next time.
+          agentSoftReconnectTried.delete(t.session)
         }
         continue
       }
@@ -1216,6 +1251,27 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           logger.warn({ agent: t.agentName, provider: agentProvider }, 'Agent has no channel token in state dir -- skipping restart to avoid token conflict')
           continue
         }
+        // Soft-first escalation (mirrors the main session's soft /mcp reconnect
+        // before any hard restart). Before stop+start -- which destroys the
+        // agent's --continue context -- try ONE non-destructive /mcp reconnect
+        // per down-spell: it re-handshakes a plugin that registered late or got
+        // wedged WITHOUT killing the conversation. Many "down" reads are exactly
+        // a slow/wedged MCP, not a dead process, so this avoids the context loss
+        // entirely in the common case. Counts toward the per-tick heavy-action
+        // budget (stagger) and re-evaluates next tick; if the plugin is still
+        // down then, the destructive restart below takes over.
+        if (!agentSoftReconnectTried.has(t.session) && !agentRestartedThisTick) {
+          agentSoftReconnectTried.add(t.session)
+          agentRestartedThisTick = true
+          logger.warn({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down -- trying soft /mcp reconnect before hard restart')
+          try {
+            const r = attemptChannelMcpReconnect(t.agentName!)
+            logger.info({ agent: t.agentName, ok: r.ok, message: r.message }, 'Soft channel reconnect attempted -- re-checking next tick before escalating')
+          } catch (err) {
+            logger.warn({ err, agent: t.agentName }, 'Soft channel reconnect threw -- will escalate to hard restart next tick')
+          }
+          continue
+        }
         if (agentRestartedThisTick) {
           logger.info({ agent: t.agentName, provider: t.provider }, 'Channel plugin down, but another agent was already restarted this tick -- deferring to next tick (stagger; avoids the reboot/cascade overload)')
           continue
@@ -1232,6 +1288,9 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // alive (which resets the counter). Repeated failures back off the
           // next restart exponentially instead of churning every base-grace.
           agentRestartFailures.set(t.agentName!, failures + 1)
+          // Persist the back-off counters so a dashboard restart cannot reset
+          // them and re-enable aggressive churn (see agent-restart-state.ts).
+          persistRestartState()
         } catch (err) {
           logger.error({ err, agent: t.agentName }, 'Failed to auto-restart agent after channel plugin down')
         }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1276,6 +1276,20 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           logger.info({ agent: t.agentName, provider: t.provider }, 'Channel plugin down, but another agent was already restarted this tick -- deferring to next tick (stagger; avoids the reboot/cascade overload)')
           continue
         }
+        // Busy-guard: NEVER hard-restart (stop+start) an agent that is actively
+        // generating. The destructive restart kills both the agent's --continue
+        // context AND its in-flight turn -- exactly the "restarted me mid-work"
+        // failure. A genuinely-down channel plugin is still down on the next
+        // tick when the pane is idle, so we restart then instead; this only
+        // costs a slightly longer plugin-down window. A truly wedged (frozen)
+        // TUI is owned by the separate stuck-respawn watchdog, not here, so
+        // deferring on 'busy' cannot strand a hung session. Only confirmed
+        // 'busy' defers; 'unknown'/'idle' proceed.
+        const restartPane = capturePane(t.session) ?? ''
+        if (detectPaneState(restartPane) === 'busy') {
+          logger.info({ agent: t.agentName, provider: t.provider }, 'Channel plugin down, but agent pane is busy (active turn) -- deferring hard restart to avoid interrupting work')
+          continue
+        }
         logger.warn({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down -- auto-restarting')
         agentRestartedThisTick = true
         try {

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1138,6 +1138,14 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
       else agentStuckInput.set(t.session, next)
     }
 
+    // Stagger restarts: at most ONE agent restart per monitor tick. A restart is
+    // fully synchronous (stopAgentProcess + sleep + startAgentProcess block the
+    // event loop), so restarting EVERY down agent in one tick freezes the
+    // dashboard for the whole burst AND makes several channel-plugin MCP servers
+    // fight to start at once -- the 2026-06-26 reboot cascade (all agents down ->
+    // all restarted together -> machine overload). One per tick lets each come up
+    // cleanly; any other down agents are picked up on later ticks.
+    let agentRestartedThisTick = false
     for (const t of targets) {
       const claudePid = getClaudePidForSession(t.session)
       if (!claudePid) {
@@ -1208,7 +1216,12 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           logger.warn({ agent: t.agentName, provider: agentProvider }, 'Agent has no channel token in state dir -- skipping restart to avoid token conflict')
           continue
         }
+        if (agentRestartedThisTick) {
+          logger.info({ agent: t.agentName, provider: t.provider }, 'Channel plugin down, but another agent was already restarted this tick -- deferring to next tick (stagger; avoids the reboot/cascade overload)')
+          continue
+        }
         logger.warn({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down -- auto-restarting')
+        agentRestartedThisTick = true
         try {
           stopAgentProcess(t.agentName!)
           execSync('sleep 2', { timeout: 4000 })

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -76,12 +76,6 @@ const agentLastRestart: Map<string, number> = new Map()
 // short cadence forever -- which restarts the WHOLE agent every few minutes and
 // renders it unusable. Reset to 0 the moment the plugin is seen alive again.
 const agentRestartFailures: Map<string, number> = new Map()
-// Sub-agent sessions for which we have already tried a NON-destructive soft
-// /mcp reconnect during the CURRENT down-spell (keyed by tmux session). The
-// watchdog tries one soft reconnect before escalating to a context-destroying
-// stop+start, mirroring the main session's soft-first cascade; cleared when the
-// agent's plugin is seen alive again so the next down-spell gets a fresh try.
-const agentSoftReconnectTried: Set<string> = new Set()
 
 // --- Back-off persistence (survive dashboard restarts) ---
 // agentRestartFailures + agentLastRestart drive the exponential back-off that
@@ -1221,8 +1215,6 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // Healthy observation clears the exponential back-off so the next
           // down-spell starts again at the base grace.
           if (agentRestartFailures.delete(t.agentName!)) persistRestartState()
-          // End of the down-spell: allow a fresh soft reconnect next time.
-          agentSoftReconnectTried.delete(t.session)
         }
         continue
       }
@@ -1251,27 +1243,21 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           logger.warn({ agent: t.agentName, provider: agentProvider }, 'Agent has no channel token in state dir -- skipping restart to avoid token conflict')
           continue
         }
-        // Soft-first escalation (mirrors the main session's soft /mcp reconnect
-        // before any hard restart). Before stop+start -- which destroys the
-        // agent's --continue context -- try ONE non-destructive /mcp reconnect
-        // per down-spell: it re-handshakes a plugin that registered late or got
-        // wedged WITHOUT killing the conversation. Many "down" reads are exactly
-        // a slow/wedged MCP, not a dead process, so this avoids the context loss
-        // entirely in the common case. Counts toward the per-tick heavy-action
-        // budget (stagger) and re-evaluates next tick; if the plugin is still
-        // down then, the destructive restart below takes over.
-        if (!agentSoftReconnectTried.has(t.session) && !agentRestartedThisTick) {
-          agentSoftReconnectTried.add(t.session)
-          agentRestartedThisTick = true
-          logger.warn({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down -- trying soft /mcp reconnect before hard restart')
-          try {
-            const r = attemptChannelMcpReconnect(t.agentName!)
-            logger.info({ agent: t.agentName, ok: r.ok, message: r.message }, 'Soft channel reconnect attempted -- re-checking next tick before escalating')
-          } catch (err) {
-            logger.warn({ err, agent: t.agentName }, 'Soft channel reconnect threw -- will escalate to hard restart next tick')
-          }
-          continue
-        }
+        // No soft /mcp reconnect for sub-agents (removed 2026-06-27). We used to
+        // drive ONE /mcp+Up+Enter+Enter keystroke "reconnect" here before the
+        // destructive restart, on the theory it would re-handshake a wedged
+        // plugin without killing the agent's --continue context. Two things made
+        // that wrong: (1) channel sub-agents are ALWAYS launched fresh (no
+        // --continue, see agent-process.ts continueFlag), so there is no context
+        // to preserve -- the soft path bought nothing. (2) the /mcp keystroke
+        // navigation is unstable: the MCP server list order differs per agent
+        // (an extra project .mcp.json server shifts every row), so the fixed
+        // "one Up == the channel plugin at the bottom" lands on the WRONG server
+        // and frequently leaves the pane parked in the /mcp modal -- the
+        // deaf-bot / stuck-in-/mcp incident (Reni-reported). So we go straight to
+        // the verified fresh relaunch below; a flaky --channels load that misses
+        // (no bun poller) is simply relaunched again next tick until it attaches
+        // (proven to converge in ~2 tries).
         if (agentRestartedThisTick) {
           logger.info({ agent: t.agentName, provider: t.provider }, 'Channel plugin down, but another agent was already restarted this tick -- deferring to next tick (stagger; avoids the reboot/cascade overload)')
           continue

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -111,6 +111,20 @@ const AGENT_MAX_RESTART_GRACE_MS = 60 * 60 * 1000 // 1h
 // (observed on hacker, 23:49->07:22). 300s lets the slow-but-healthy poller land
 // before any restart, while staying well under the genuinely-dead escalation.
 const AGENT_STARTUP_GRACE_MS = 300_000
+// Fast-retry path for a flaky --channels plugin-load miss. The 300s startup
+// grace above protects a still-COLD-STARTING agent, but a channel sub-agent
+// that has already SETTLED at its idle prompt with no bun poller is a
+// definitive flaky-load miss (the poller attaches within ~10s when it works) --
+// waiting out the full 5min there left a deaf agent down far longer than the
+// manual recipe (Reni-observed: lumi ~110s+). When the pane is settled we use
+// this shorter grace instead. 45s comfortably clears the healthy attach window
+// while still never racing a genuinely-booting process (which reads non-idle).
+const AGENT_FAST_RETRY_GRACE_MS = 45_000
+// The first N relaunch failures retry at the base grace before the exponential
+// back-off starts doubling, so the common flaky-load case (converges in ~2-3
+// fresh relaunches) is not slowed; a genuinely-broken plugin still backs off
+// after these are spent.
+const AGENT_FREE_FAST_RETRIES = 2
 const PLUGIN_ALERT_DEDUP_MS = 30 * 60 * 1000
 
 // Stuck channel-input recovery (MAIN session only). A channel notification
@@ -1224,6 +1238,11 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         if (!agentDownSince.has(t.session)) agentDownSince.set(t.session, Date.now())
         const lastRestart = agentLastRestart.get(t.agentName!)
         const failures = agentRestartFailures.get(t.agentName!) ?? 0
+        // Capture the pane ONCE here and reuse it for both the fast-retry
+        // decision (a settled idle pane == cold-start finished) and the
+        // busy-guard below.
+        const downPane = capturePane(t.session) ?? ''
+        const downPaneState = detectPaneState(downPane)
         const restart = shouldAutoRestartDownAgent({
           processAgeMs: getProcessAgeMs(claudePid),
           msSinceLastRestart: lastRestart != null ? Date.now() - lastRestart : null,
@@ -1231,6 +1250,11 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           restartGraceMs: AGENT_RESTART_GRACE_MS,
           consecutiveFailures: failures,
           maxRestartGraceMs: AGENT_MAX_RESTART_GRACE_MS,
+          // Fast-retry the definitive flaky-load miss: a SETTLED (idle) pane
+          // with no poller finished booting, so relaunch without the full 5min.
+          paneSettled: downPaneState === 'idle',
+          fastRetryGraceMs: AGENT_FAST_RETRY_GRACE_MS,
+          freeFastRetries: AGENT_FREE_FAST_RETRIES,
         })
         if (!restart) {
           logger.debug({ agent: t.agentName, provider: t.provider, failures }, 'Channel plugin probe reports down but agent is within startup/restart back-off -- deferring')
@@ -1270,9 +1294,9 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         // costs a slightly longer plugin-down window. A truly wedged (frozen)
         // TUI is owned by the separate stuck-respawn watchdog, not here, so
         // deferring on 'busy' cannot strand a hung session. Only confirmed
-        // 'busy' defers; 'unknown'/'idle' proceed.
-        const restartPane = capturePane(t.session) ?? ''
-        if (detectPaneState(restartPane) === 'busy') {
+        // 'busy' defers; 'unknown'/'idle' proceed. Reuses the pane state read
+        // once above (no second capture).
+        if (downPaneState === 'busy') {
           logger.info({ agent: t.agentName, provider: t.provider }, 'Channel plugin down, but agent pane is busy (active turn) -- deferring hard restart to avoid interrupting work')
           continue
         }


### PR DESCRIPTION
## Mit es miert

Sub-agent telegram-botok suketsege restart utan: a Claude Code `--channels` plugin betoltese flaky (neha nem regisztral -> nincs bun poller -> a bot nem hall). A recovery ezt rontotta: (1) a monitor egy soft /mcp reconnect-et nyomott a down sub-agentbe, (2) az agent-process egy post-respawn /mcp-unlock keystroke-sort. Mindketto vak `/mcp+Up+Enter+Enter` navigaciot vezetett a pane-be.

Ez ket okbol rossz sub-agentekre:
- A channel sub-agentek MINDIG frissen indulnak (nincs --continue, PR #464), tehat nincs megorzendo kontextus -> a soft path semmit nem ert.
- A /mcp navigacio instabil: az MCP-szerver lista sorrendje agensenkent mas (egy extra project .mcp.json szerver eltol minden sort), ezert a beegetett "egy Up == a channel plugin a lista aljan" ROSSZ szerverre visz, es gyakran a /mcp modalban ragasztja az agenst (deaf-bot / stuck-in-/mcp tunet).

## Fix
A sub-agent soft /mcp reconnect + a post-respawn unlock keystroke-ok kivezetve. A down-path egyenesen a mar meglevo verifikalt fresh relaunchra (stop+start) megy; egy elvetett --channels betoltes a kovetkezo tickben ujra-relaunchol, amig a poller fel nem all. Elesben bizonyitottan ~2 probara konvergal 6 kulonbozo agensen (jack, heli, key, tundi, lumi, pg). A busy-guard es a per-tick stagger valtozatlan.

A MAIN-session soft /mcp reconnect (`attemptChannelMcpReconnect(MAIN_AGENT_ID)`) SZANDEKOSAN erintetlen.

## Teszt
Uj source-assertion teszt (channel-recovery-no-mcp-dance.test.ts). Teljes suite zold (1414).

🤖 Generated with [Claude Code](https://claude.com/claude-code)