### PR TITLE
feat(dashboard): add self-reported agent status as a tab on the Activity page

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -578,6 +578,23 @@ export function initDatabase(dbPathOverride?: string): void {
   // Migration: add agent column to installs that created the table before this column existed.
   try { db.exec(`ALTER TABLE store_file_audit ADD COLUMN agent TEXT`) } catch { /* column already exists */ }
 
+  // Live "what is each agent working on" board. One row per agent (agent_id is
+  // the PK), upserted by the agent itself in human-readable terms: a one-line
+  // headline, a coarse difficulty, a free-text ETA, and an optional blocker.
+  // This is NOT command/log data -- it is the agent narrating its current task.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS agent_status (
+      agent_id TEXT PRIMARY KEY,
+      state TEXT NOT NULL DEFAULT 'idle' CHECK(state IN ('working','idle','blocked','done')),
+      headline TEXT,
+      difficulty TEXT CHECK(difficulty IN ('konnyu','kozepes','nehez') OR difficulty IS NULL),
+      eta TEXT,
+      blocker TEXT,
+      updated_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_status_updated ON agent_status(updated_at)`)
+
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
   // re-importing. Wrapped in a transaction so a crash mid-import is safe.
@@ -614,6 +631,55 @@ function migrateTaskRunsFromJson(): void {
 
 export function getDb(): Database.Database {
   return db
+}
+
+// --- Agent status board (who is working on what) ---
+
+export interface AgentStatus {
+  agent_id: string
+  state: 'working' | 'idle' | 'blocked' | 'done'
+  headline: string | null
+  difficulty: 'konnyu' | 'kozepes' | 'nehez' | null
+  eta: string | null
+  blocker: string | null
+  updated_at: number
+}
+
+export function listAgentStatus(): AgentStatus[] {
+  return db.prepare('SELECT * FROM agent_status ORDER BY updated_at DESC').all() as AgentStatus[]
+}
+
+export function upsertAgentStatus(s: {
+  agent_id: string
+  state?: string
+  headline?: string | null
+  difficulty?: string | null
+  eta?: string | null
+  blocker?: string | null
+}): void {
+  const now = Math.floor(Date.now() / 1000)
+  const state = s.state && ['working', 'idle', 'blocked', 'done'].includes(s.state) ? s.state : 'working'
+  const difficulty =
+    s.difficulty && ['konnyu', 'kozepes', 'nehez'].includes(s.difficulty) ? s.difficulty : null
+  db.prepare(
+    `INSERT INTO agent_status (agent_id, state, headline, difficulty, eta, blocker, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(agent_id) DO UPDATE SET
+       state = excluded.state,
+       headline = excluded.headline,
+       difficulty = excluded.difficulty,
+       eta = excluded.eta,
+       blocker = excluded.blocker,
+       updated_at = excluded.updated_at`
+  ).run(
+    s.agent_id,
+    state,
+    s.headline ?? null,
+    difficulty,
+    s.eta ?? null,
+    s.blocker ?? null,
+    now
+  )
 }
 
 // --- Munkamenetek ---

--- a/src/web.ts
+++ b/src/web.ts
@@ -30,6 +30,7 @@ import { tryHandleAgentTaskState } from './web/routes/agent-taskstate.js'
 import { sweepOrphanTaskStates } from './web/agent-taskstate.js'
 import { tryHandleDailyLog } from './web/routes/daily-log.js'
 import { tryHandleMemories } from './web/routes/memories.js'
+import { tryHandleAgentStatus } from './web/routes/agent-status.js'
 import { tryHandleMigrate } from './web/routes/migrate.js'
 import { tryHandleKanban } from './web/routes/kanban.js'
 import { tryHandleSchedules } from './web/routes/schedules.js'
@@ -145,6 +146,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleMessages(routeCtx)) return
       if (await tryHandleDailyLog(routeCtx)) return
       if (await tryHandleMemories(routeCtx)) return
+      if (await tryHandleAgentStatus(routeCtx)) return
       if (await tryHandleMigrate(routeCtx)) return
       if (await tryHandleKanban(routeCtx)) return
       if (await tryHandleSchedules(routeCtx)) return

--- a/src/web/routes/agent-status.ts
+++ b/src/web/routes/agent-status.ts
@@ -1,0 +1,52 @@
+import { listAgentStatus, upsertAgentStatus } from '../../db.js'
+import { readBody, json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+// Live "who is working on what" board. Agents upsert their own current task in
+// human-readable terms (headline + difficulty + ETA + optional blocker); the
+// dashboard renders one card per agent. This is narration, not command/log data.
+export async function tryHandleAgentStatus(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  if (path === '/api/agent-status' && method === 'GET') {
+    json(res, listAgentStatus())
+    return true
+  }
+
+  if (path === '/api/agent-status' && method === 'POST') {
+    const body = await readBody(req)
+    let data: {
+      agent_id?: string
+      state?: string
+      headline?: string | null
+      difficulty?: string | null
+      eta?: string | null
+      blocker?: string | null
+    }
+    try {
+      data = JSON.parse(body.toString())
+    } catch {
+      json(res, { error: 'Invalid JSON' }, 400)
+      return true
+    }
+    if (!data.agent_id?.trim()) {
+      json(res, { error: 'agent_id is required' }, 400)
+      return true
+    }
+    // Cap free-text fields so a runaway agent can't bloat the board.
+    const clip = (v: string | null | undefined, n: number) =>
+      typeof v === 'string' ? v.trim().slice(0, n) : null
+    upsertAgentStatus({
+      agent_id: data.agent_id.trim().slice(0, 64),
+      state: data.state,
+      headline: clip(data.headline, 280),
+      difficulty: data.difficulty ?? null,
+      eta: clip(data.eta, 80),
+      blocker: clip(data.blocker, 280),
+    })
+    json(res, { ok: true })
+    return true
+  }
+
+  return false
+}

--- a/web/app.js
+++ b/web/app.js
@@ -525,21 +525,82 @@ function stopActivityPoll() {
   }
 }
 
+// --- Self-reported status ("who is working on what") ---
+// Each agent upserts a human-readable status to /api/agent-status; it is shown
+// as the "Status" tab of that agent's card, beside the live "Code / output"
+// terminal tail (the original Activity content).
+const ACT_STATUS_META = {
+  working: { cls: 'wb-working', label: () => t('activity.status.state.working') },
+  blocked: { cls: 'wb-blocked', label: () => t('activity.status.state.blocked') },
+  done: { cls: 'wb-done', label: () => t('activity.status.state.done') },
+  idle: { cls: 'wb-idle', label: () => t('activity.status.state.idle') },
+}
+const ACT_DIFF_LABEL = { konnyu: 'activity.status.diff.konnyu', kozepes: 'activity.status.diff.kozepes', nehez: 'activity.status.diff.nehez' }
+
+function actStatusRelTime(ts) {
+  const sec = Math.max(0, Math.floor(Date.now() / 1000) - ts)
+  if (sec < 60) return t('activity.status.rel.now')
+  if (sec < 3600) return t('activity.status.rel.min', { n: Math.floor(sec / 60) })
+  if (sec < 86400) return t('activity.status.rel.hour', { n: Math.floor(sec / 3600) })
+  return t('activity.status.rel.day', { n: Math.floor(sec / 86400) })
+}
+
+// Build the inner HTML of the "Status" tab from a self-reported status row.
+// Returns a muted placeholder when the agent has not reported a status yet.
+function actStatusPanelHtml(r) {
+  if (!r) return '<p class="activity-tail-empty">' + t('activity.status.none') + '</p>'
+  const STALE = 30 * 60
+  const stale = Math.floor(Date.now() / 1000) - r.updated_at > STALE
+  const stateKey = stale && r.state === 'working' ? 'idle' : r.state
+  const meta = ACT_STATUS_META[stateKey] || ACT_STATUS_META.idle
+  const diff = r.difficulty && ACT_DIFF_LABEL[r.difficulty]
+    ? '<span class="wb-diff wb-diff-' + r.difficulty + '">' + t(ACT_DIFF_LABEL[r.difficulty]) + '</span>'
+    : ''
+  const eta = r.eta ? '<span class="wb-eta">⏱ ' + escapeHtml(r.eta) + '</span>' : ''
+  const blocker = r.state === 'blocked' && r.blocker
+    ? '<div class="wb-blocker">⚠ ' + escapeHtml(r.blocker) + '</div>'
+    : ''
+  const headline = r.headline ? escapeHtml(r.headline) : '<span class="wb-muted">' + t('activity.status.no_headline') + '</span>'
+  const staleTag = stale ? ' <span class="wb-stale">' + t('activity.status.stale') + '</span>' : ''
+  return (
+    '<div class="wb-status-badge-row"><span class="wb-badge ' + meta.cls + '">' + meta.label() + '</span></div>' +
+    '<div class="wb-headline">' + headline + '</div>' +
+    (diff || eta ? '<div class="wb-meta-row">' + diff + eta + '</div>' : '') +
+    blocker +
+    '<div class="wb-foot">' + t('activity.status.updated', { time: actStatusRelTime(r.updated_at) }) + staleTag + '</div>'
+  )
+}
+
+// Which tab ('status' | 'output') is selected per agent. Persists across the
+// 3s poll re-render so the user's choice is not reset on every refresh.
+const activityTab = new Map()
+
 async function loadActivity() {
   try {
-    const res = await fetch('/api/agents/activity')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    const entries = await res.json()
-    renderActivity(entries)
+    // Fetch the live terminal activity and the self-reported status in
+    // parallel, then merge per agent into one card.
+    const [actRes, stRes] = await Promise.all([
+      fetch('/api/agents/activity'),
+      fetch('/api/agent-status').catch(() => null),
+    ])
+    if (!actRes.ok) throw new Error('HTTP ' + actRes.status)
+    const entries = await actRes.json()
+    let statuses = []
+    if (stRes && stRes.ok) { try { statuses = await stRes.json() } catch { statuses = [] } }
+    const statusByAgent = {}
+    for (const s of (Array.isArray(statuses) ? statuses : [])) {
+      if (s && s.agent_id) statusByAgent[String(s.agent_id).toLowerCase()] = s
+    }
+    renderActivity(entries, statusByAgent)
     const upd = document.getElementById('activityUpdated')
-    if (upd) upd.textContent = t('activity.updated', { time: new Date().toLocaleTimeString('hu-HU') })
+    if (upd) upd.textContent = t('activity.updated', { time: new Date().toLocaleTimeString() })
   } catch (e) {
     const list = document.getElementById('activityList')
     if (list) list.innerHTML = '<p class="activity-empty">' + t('activity.error_load') + ': ' + escapeHtml(String(e.message || e)) + '</p>'
   }
 }
 
-function renderActivity(entries) {
+function renderActivity(entries, statusByAgent = {}) {
   const list = document.getElementById('activityList')
   if (!list) return
   if (!Array.isArray(entries) || entries.length === 0) {
@@ -555,8 +616,18 @@ function renderActivity(entries) {
     const termIcon = canOpen
       ? '<svg class="act-term-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" title="' + t('activity.tooltip.terminal') + '"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>'
       : ''
+    const agentAttr = escapeHtml(a.name)
+    const status = statusByAgent[String(a.name).toLowerCase()]
+
+    // Selected tab (default: the human-readable status).
+    const tab = activityTab.get(a.name) || 'status'
+    const statusActive = tab === 'status'
+    const outputPanel = tail
+      ? '<pre class="activity-tail">' + tail + '</pre>'
+      : '<p class="activity-tail-empty">' + (a.running ? t('activity.no_output') : t('activity.session_stopped')) + '</p>'
+
     return (
-      '<div class="activity-card ' + meta.cls + (canOpen ? ' act-clickable' : '') + '" data-agent="' + escapeHtml(a.name) + '">' +
+      '<div class="activity-card ' + meta.cls + '" data-agent="' + agentAttr + '">' +
         '<div class="activity-card-head">' +
           '<span class="activity-name">' + escapeHtml(a.name) + mainBadge + '</span>' +
           '<span style="display:flex;align-items:center;gap:8px">' +
@@ -564,23 +635,46 @@ function renderActivity(entries) {
             '<span class="activity-badge ' + meta.cls + '" title="' + escapeHtml(meta.tip || '') + '">' + meta.label + '</span>' +
           '</span>' +
         '</div>' +
-        (tail
-          ? '<pre class="activity-tail">' + tail + '</pre>'
-          : '<p class="activity-tail-empty">' + (a.running ? 'nincs friss kimenet' : 'a session nem fut') + '</p>') +
+        '<div class="act-tabs" role="tablist">' +
+          '<button type="button" class="act-tab' + (statusActive ? ' active' : '') + '" data-agent="' + agentAttr + '" data-tab="status">' + t('activity.tab.status') + '</button>' +
+          '<button type="button" class="act-tab' + (!statusActive ? ' active' : '') + '" data-agent="' + agentAttr + '" data-tab="output">' + t('activity.tab.output') + '</button>' +
+        '</div>' +
+        '<div class="act-tab-panel act-panel-status"' + (statusActive ? '' : ' hidden') + '>' +
+          actStatusPanelHtml(status) +
+        '</div>' +
+        '<div class="act-tab-panel act-panel-output' + (canOpen ? ' act-clickable' : '') + '"' + (!statusActive ? '' : ' hidden') + ' data-agent="' + agentAttr + '"' + (canOpen ? ' title="' + t('activity.tooltip.terminal') + '"' : '') + '>' +
+          outputPanel +
+        '</div>' +
       '</div>'
     )
   }).join('')
 }
 
-// Event delegation: clicking a running activity-card opens the terminal modal
+// Event delegation for the Activity page:
+//  - clicking a tab switches that card's panel (and remembers the choice)
+//  - clicking the live output panel (when running) opens the terminal modal
 ;(() => {
   const actList = document.getElementById('activityList')
-  if (actList) {
-    actList.addEventListener('click', (e) => {
-      const card = e.target.closest('.activity-card.act-clickable[data-agent]')
-      if (card) openTerminalModal(card.dataset.agent)
-    })
-  }
+  if (!actList) return
+  actList.addEventListener('click', (e) => {
+    const tabBtn = e.target.closest('.act-tab[data-tab][data-agent]')
+    if (tabBtn) {
+      const agent = tabBtn.dataset.agent
+      const tab = tabBtn.dataset.tab
+      activityTab.set(agent, tab)
+      const card = tabBtn.closest('.activity-card')
+      if (card) {
+        card.querySelectorAll('.act-tab').forEach((b) => b.classList.toggle('active', b.dataset.tab === tab))
+        const statusPanel = card.querySelector('.act-panel-status')
+        const outputPanel = card.querySelector('.act-panel-output')
+        if (statusPanel) statusPanel.hidden = tab !== 'status'
+        if (outputPanel) outputPanel.hidden = tab !== 'output'
+      }
+      return
+    }
+    const outPanel = e.target.closest('.act-panel-output.act-clickable[data-agent]')
+    if (outPanel) openTerminalModal(outPanel.dataset.agent)
+  })
 })()
 
 

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -255,13 +255,31 @@ window._i18n.en = {
 
   // --- Activity ---
   'activity.page_title':         'Activity',
-  'activity.page_subtitle':      'What each agent is doing: live view, updates every 3 sec',
+  'activity.page_subtitle':      'What each agent is doing: text status and live code/output, switchable per box via a tab. Updates every 3 sec.',
   'activity.loading':            'Loading…',
   'activity.state.working':      'working',
   'activity.state.idle':         'idle',
   'activity.state.unknown':      'unknown',
   'activity.state.error':        'error',
   'activity.state.stopped':      'stopped',
+  // Per-agent tabs + the self-reported status tab
+  'activity.tab.status':         'Status',
+  'activity.tab.output':         'Code / output',
+  'activity.status.none':        'This agent has not reported a text status yet.',
+  'activity.status.no_headline': 'no description',
+  'activity.status.stale':       'stale',
+  'activity.status.updated':     'updated {time}',
+  'activity.status.state.working': 'working',
+  'activity.status.state.blocked': 'blocked',
+  'activity.status.state.done':    'done',
+  'activity.status.state.idle':    'idle',
+  'activity.status.diff.konnyu':   'easy',
+  'activity.status.diff.kozepes':  'medium',
+  'activity.status.diff.nehez':    'hard',
+  'activity.status.rel.now':       'just now',
+  'activity.status.rel.min':       '{n}m ago',
+  'activity.status.rel.hour':      '{n}h ago',
+  'activity.status.rel.day':       '{n}d ago',
 
   // --- Tasks (Schedules) ---
   'tasks.page_title':            'Schedules',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -374,7 +374,7 @@ window._i18n.hu = {
 
   // --- Activity ---
   'activity.page_title':         'Aktivitás',
-  'activity.page_subtitle':      'Mit csinál épp minden ügynök: élő nézet, 3 mp-enként frissül',
+  'activity.page_subtitle':      'Mit csinál épp minden ügynök: szöveges státusz és élő kód/kimenet, boxonként tabbal. 3 mp-enként frissül.',
 
   'activity.updated':            'Frissítve: {time}',
   'activity.error_load':         'Nem sikerült lekérni az aktivitást',
@@ -383,6 +383,24 @@ window._i18n.hu = {
   'activity.session_stopped':    'a session nem fut',
   'activity.badge.main':         'fő',
   'activity.loading':            'Betöltés…',
+  // Per-agent tabs + the self-reported status tab
+  'activity.tab.status':         'Státusz',
+  'activity.tab.output':         'Kód / kimenet',
+  'activity.status.none':        'Ez az ügynök még nem jelentett szöveges státuszt.',
+  'activity.status.no_headline': 'nincs leírás',
+  'activity.status.stale':       'régi',
+  'activity.status.updated':     'frissítve {time}',
+  'activity.status.state.working': 'dolgozik',
+  'activity.status.state.blocked': 'elakadt',
+  'activity.status.state.done':    'kész',
+  'activity.status.state.idle':    'várakozik',
+  'activity.status.diff.konnyu':   'könnyű',
+  'activity.status.diff.kozepes':  'közepes',
+  'activity.status.diff.nehez':    'nehéz',
+  'activity.status.rel.now':       'most',
+  'activity.status.rel.min':       '{n} perce',
+  'activity.status.rel.hour':      '{n} órája',
+  'activity.status.rel.day':       '{n} napja',
   'activity.state.working':      'dolgozik',
   'activity.state.idle':         'várakozik',
   'activity.state.unknown':      'ismeretlen',

--- a/web/style.css
+++ b/web/style.css
@@ -5554,6 +5554,41 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
 }
 .activity-tail-empty { margin: 0; font-size: 12px; color: var(--text-muted); font-style: italic; }
 
+/* Per-agent tabs inside an activity card: switch between the human-readable
+   "Status" (self-reported) and the live "Code / output" terminal tail. */
+.act-tabs { display: flex; gap: 4px; margin-bottom: 10px; border-bottom: 1px solid var(--border); }
+.act-tab {
+  appearance: none; background: none; border: none; cursor: pointer;
+  font: inherit; font-size: 12px; font-weight: 600; color: var(--text-muted);
+  padding: 6px 10px; border-bottom: 2px solid transparent; margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.act-tab:hover { color: var(--text); }
+.act-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+.act-tab-panel { display: flex; flex-direction: column; gap: 8px; }
+.act-tab-panel[hidden] { display: none; }
+.act-panel-output.act-clickable { cursor: pointer; border-radius: 6px; transition: box-shadow 0.15s; }
+.act-panel-output.act-clickable:hover { box-shadow: 0 0 0 2px var(--accent); }
+
+/* Self-reported status tab content. */
+.wb-status-badge-row { display: flex; }
+.wb-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px; color: #fff; text-transform: lowercase; }
+.wb-badge.wb-working { background: #22c55e; }
+.wb-badge.wb-blocked { background: #ef4444; }
+.wb-badge.wb-done    { background: #3b82f6; }
+.wb-badge.wb-idle    { background: #9ca3af; }
+.wb-headline { font-size: 14px; line-height: 1.45; color: var(--text); }
+.wb-muted { color: var(--text-muted); font-style: italic; }
+.wb-meta-row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.wb-diff { font-size: 11px; font-weight: 600; padding: 1px 7px; border-radius: 6px; border: 1px solid var(--border); }
+.wb-diff-konnyu  { color: #16a34a; border-color: #16a34a55; }
+.wb-diff-kozepes { color: #d97706; border-color: #d9770655; }
+.wb-diff-nehez   { color: #dc2626; border-color: #dc262655; }
+.wb-eta { font-size: 12px; color: var(--text-muted); }
+.wb-blocker { font-size: 12.5px; color: #b91c1c; background: rgba(239, 68, 68, 0.08); border-radius: 7px; padding: 6px 9px; line-height: 1.4; }
+.wb-foot { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.wb-stale { color: #d97706; font-weight: 600; }
+
 /* === Messages / Chat page === */
 .chat-layout {
   display: flex;


### PR DESCRIPTION
## Summary

- **fix(tester):** `#deviceService` modal (Tűzoltó készülékek) was opened via Bootstrap `modal('show')`, bypassing Vue context — `device_id` was missing from the POST payload → 404 → modal stayed open. Fix: click the row's wrench button instead, so Vue receives the correct device context. Result: 18/18 pass.
- **feat(dashboard):** self-reported agent status as a tab on the Activity page
- **fix(pane-state):** recognise the background-monitor idle footer (delivery-reliability)
- **fix(security):** disable Claude Code prompt-suggestions in agent spawn (ghost-text re-submit root)
- **scripts:** add `owncloud-cli.py`, `read-emails.py`, `zoho_crm.py`; update watchdog/channels/morning-briefing scripts

## Test plan

- [x] `nagy-teszt.js` dev run: 18/18 karbantartás sikeres, 5/9 PDF (26 lap)
- [x] Tűzoltó készülékek modal: verify screenshot elkészül, mentés 200 OK
- [x] PDF riport generálva és feltöltve Slack #--fireg-release-test csatornába

🤖 Generated with [Claude Code](https://claude.com/claude-code)