### PR TITLE
Add model-fallback-on-limit auto-switch

### DIFF
--- a/src/__tests__/model-fallback.test.ts
+++ b/src/__tests__/model-fallback.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import {
+  detectsUsageLimit,
+  nextFallbackModel,
+  decideModelAction,
+  normalizeModelFallbackConfig,
+  DEFAULT_MODEL_CHAIN,
+  DEFAULT_MODEL_FALLBACK,
+} from '../model-fallback.js'
+
+const CHAIN = [...DEFAULT_MODEL_CHAIN]
+const PRIMARY = CHAIN[0]
+const SONNET = CHAIN[1]
+const HAIKU = CHAIN[2]
+
+describe('detectsUsageLimit', () => {
+  it('matches Claude plan usage-limit banners in the live region', () => {
+    expect(detectsUsageLimit('You have reached your usage limit. Try again later.')).toBe(true)
+    expect(detectsUsageLimit('5-hour limit reached ∙ resets 3pm')).toBe(true)
+    expect(detectsUsageLimit('Approaching usage limit')).toBe(true)
+    expect(detectsUsageLimit('Your limit will reset at 18:00')).toBe(true)
+    expect(detectsUsageLimit('/upgrade to increase your usage limit')).toBe(true)
+  })
+
+  it('does NOT match a transient API 429 / generic rate limit', () => {
+    expect(detectsUsageLimit('  ⎿  API Error: 429 rate_limit_error: too many requests')).toBe(false)
+    expect(detectsUsageLimit('  ⎿  API Error: 429 overloaded_error: server busy, retrying')).toBe(false)
+  })
+
+  it('ignores the phrase when it is only up in scrollback, not the live region', () => {
+    const scrollback = ['you reached your usage limit', ...Array(40).fill('normal output line')].join('\n')
+    expect(detectsUsageLimit(scrollback)).toBe(false)
+  })
+
+  it('returns false for empty / whitespace panes', () => {
+    expect(detectsUsageLimit('')).toBe(false)
+    expect(detectsUsageLimit('   \n  ')).toBe(false)
+  })
+})
+
+describe('nextFallbackModel', () => {
+  it('walks one step down the chain', () => {
+    expect(nextFallbackModel(PRIMARY, CHAIN)).toBe(SONNET)
+    expect(nextFallbackModel(SONNET, CHAIN)).toBe(HAIKU)
+  })
+  it('returns null at the bottom', () => {
+    expect(nextFallbackModel(HAIKU, CHAIN)).toBeNull()
+  })
+  it('treats an unknown current model as the primary', () => {
+    expect(nextFallbackModel('some-unknown-model', CHAIN)).toBe(SONNET)
+  })
+  it('returns null for a degenerate chain', () => {
+    expect(nextFallbackModel(PRIMARY, [PRIMARY])).toBeNull()
+    expect(nextFallbackModel(PRIMARY, [])).toBeNull()
+  })
+})
+
+describe('decideModelAction', () => {
+  const base = { chain: CHAIN, now: 1_000_000, revertAfterMs: 60_000 }
+
+  it('downgrades when a limit is detected and a lower model exists', () => {
+    expect(decideModelAction({ ...base, limitDetected: true, currentModel: PRIMARY, downgradedAt: null }))
+      .toEqual({ kind: 'downgrade', model: SONNET })
+    expect(decideModelAction({ ...base, limitDetected: true, currentModel: SONNET, downgradedAt: 500_000 }))
+      .toEqual({ kind: 'downgrade', model: HAIKU })
+  })
+
+  it('does nothing when limited at the bottom of the chain', () => {
+    expect(decideModelAction({ ...base, limitDetected: true, currentModel: HAIKU, downgradedAt: 500_000 }))
+      .toEqual({ kind: 'none' })
+  })
+
+  it('reverts to the primary after the window once limit-free', () => {
+    expect(decideModelAction({ ...base, limitDetected: false, currentModel: HAIKU, downgradedAt: 1_000_000 - 60_000 }))
+      .toEqual({ kind: 'revert', model: PRIMARY })
+  })
+
+  it('does not revert before the window elapses', () => {
+    expect(decideModelAction({ ...base, limitDetected: false, currentModel: SONNET, downgradedAt: 1_000_000 - 59_999 }))
+      .toEqual({ kind: 'none' })
+  })
+
+  it('does nothing when on the primary and limit-free', () => {
+    expect(decideModelAction({ ...base, limitDetected: false, currentModel: PRIMARY, downgradedAt: null }))
+      .toEqual({ kind: 'none' })
+  })
+
+  it('does not re-revert when already back on the primary', () => {
+    expect(decideModelAction({ ...base, limitDetected: false, currentModel: PRIMARY, downgradedAt: 0 }))
+      .toEqual({ kind: 'none' })
+  })
+})
+
+describe('normalizeModelFallbackConfig', () => {
+  it('defaults on junk input', () => {
+    expect(normalizeModelFallbackConfig(null)).toEqual(DEFAULT_MODEL_FALLBACK)
+    expect(normalizeModelFallbackConfig('nope')).toEqual(DEFAULT_MODEL_FALLBACK)
+    expect(normalizeModelFallbackConfig({})).toEqual(DEFAULT_MODEL_FALLBACK)
+  })
+
+  it('honors a valid override', () => {
+    const cfg = normalizeModelFallbackConfig({ enabled: true, chain: ['a', 'b', 'c'], revertAfterMinutes: 120 })
+    expect(cfg).toEqual({ enabled: true, chain: ['a', 'b', 'c'], revertAfterMinutes: 120 })
+  })
+
+  it('rejects a too-short chain and non-string entries', () => {
+    expect(normalizeModelFallbackConfig({ chain: ['only-one'] }).chain).toEqual(DEFAULT_MODEL_FALLBACK.chain)
+    expect(normalizeModelFallbackConfig({ chain: ['a', 2, '', 'b'] }).chain).toEqual(['a', 'b'])
+  })
+
+  it('rejects a non-positive revert window', () => {
+    expect(normalizeModelFallbackConfig({ revertAfterMinutes: 0 }).revertAfterMinutes).toBe(DEFAULT_MODEL_FALLBACK.revertAfterMinutes)
+    expect(normalizeModelFallbackConfig({ revertAfterMinutes: -5 }).revertAfterMinutes).toBe(DEFAULT_MODEL_FALLBACK.revertAfterMinutes)
+  })
+})

--- a/src/model-fallback.ts
+++ b/src/model-fallback.ts
@@ -1,0 +1,140 @@
+// Pure logic for the model-fallback-on-limit feature.
+//
+// Motivation: when an agent's Claude plan usage limit is reached, the Claude
+// Code session pauses and prints a usage-limit banner in its tmux pane. Until
+// the window resets (or the user intervenes) the agent is deaf. This feature
+// detects that banner and downgrades the agent one step down a configured model
+// chain (e.g. opus -> sonnet -> haiku), respawning the session so the cheaper
+// model -- on a separate budget -- takes over without losing the conversation.
+// After a revert window with no limit in sight, it climbs back to the primary.
+//
+// This module is dependency-free so every decision is unit-testable without a
+// clock, tmux, or the filesystem. The I/O (capture-pane, model write, restart)
+// lives in src/web/model-fallback-runner.ts; the config store lives in
+// src/web/model-fallback-store.ts.
+
+// Resolved full model IDs, mirroring MODEL_ALIASES in src/web/agent-config.ts.
+// chain[0] is the primary (what we revert UP to); each subsequent entry is the
+// next downgrade target. Kept as literals here to preserve the zero-import,
+// trivially-testable property of this module.
+export const DEFAULT_MODEL_CHAIN: readonly string[] = [
+  'claude-opus-4-8[1m]',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5-20251001',
+]
+
+// Revert only well after the typical 5-hour plan window so we do not climb back
+// to the primary just to re-trip the same limit. Configurable.
+export const DEFAULT_REVERT_AFTER_MINUTES = 330
+
+export interface ModelFallbackConfig {
+  /** Master toggle. When false no agent is ever auto-switched. */
+  enabled: boolean
+  /** Primary-first model chain. Downgrades walk forward; revert goes to [0]. */
+  chain: string[]
+  /** Minutes a downgraded agent must stay limit-free before climbing back. */
+  revertAfterMinutes: number
+}
+
+export const DEFAULT_MODEL_FALLBACK: ModelFallbackConfig = {
+  enabled: false,
+  chain: [...DEFAULT_MODEL_CHAIN],
+  revertAfterMinutes: DEFAULT_REVERT_AFTER_MINUTES,
+}
+
+/** Coerce an untrusted parsed-JSON value into a valid config (defaults on junk). */
+export function normalizeModelFallbackConfig(raw: unknown): ModelFallbackConfig {
+  const o = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const enabled = o.enabled === true
+  let chain = DEFAULT_MODEL_FALLBACK.chain
+  if (Array.isArray(o.chain)) {
+    const cleaned = o.chain.filter((m): m is string => typeof m === 'string' && m.trim().length > 0)
+    // A chain needs at least a primary + one fallback to be meaningful.
+    if (cleaned.length >= 2) chain = cleaned
+  }
+  let revertAfterMinutes = DEFAULT_MODEL_FALLBACK.revertAfterMinutes
+  if (typeof o.revertAfterMinutes === 'number' && Number.isFinite(o.revertAfterMinutes) && o.revertAfterMinutes > 0) {
+    revertAfterMinutes = Math.floor(o.revertAfterMinutes)
+  }
+  return { enabled, chain, revertAfterMinutes }
+}
+
+// The Claude Code usage-limit banner appears at the bottom of the pane (above
+// the footer) when the plan budget is exhausted or nearly so. Match only the
+// live banner region so a message body or scrollback that merely quotes the
+// phrase does not trip a downgrade.
+const USAGE_LIMIT_BANNER_REGION_LINES = 15
+
+// Distinctive plan-limit phrasings. Deliberately NARROW: a generic "rate limit"
+// / "API Error: 429" (transient overload, handled elsewhere) must NOT match --
+// that is a momentary blip, not a plan-budget exhaustion that warrants a model
+// switch.
+const USAGE_LIMIT_RX =
+  /(usage limit reached|reached your usage limit|hit (?:your|the) usage limit|approaching (?:your )?usage limit|usage limit (?:will )?reset|limit will reset at|\d+-hour limit reached|upgrade to increase your usage limit)/i
+
+/**
+ * True when the live pane shows a Claude *plan usage-limit* banner (not a
+ * transient API 429). Pure + dependency-free. Restricted to the bottom region
+ * so quoted text in scrollback or a reply body cannot trigger it.
+ */
+export function detectsUsageLimit(pane: string): boolean {
+  if (!pane || !pane.trim()) return false
+  const lines = pane.split('\n')
+  const region = lines.slice(-USAGE_LIMIT_BANNER_REGION_LINES).join('\n')
+  return USAGE_LIMIT_RX.test(region)
+}
+
+/**
+ * The next model one step down the chain from `current`, or null if already at
+ * the bottom. An unrecognised current model is treated as the primary, so the
+ * first downgrade target (chain[1]) applies.
+ */
+export function nextFallbackModel(current: string, chain: string[]): string | null {
+  if (chain.length < 2) return null
+  const idx = chain.indexOf(current)
+  if (idx < 0) return chain[1] ?? null
+  if (idx >= chain.length - 1) return null
+  return chain[idx + 1]
+}
+
+export interface ModelFallbackFacts {
+  /** Whether the agent's pane currently shows a usage-limit banner. */
+  limitDetected: boolean
+  /** The agent's current resolved model id. */
+  currentModel: string
+  /** Primary-first model chain. */
+  chain: string[]
+  /** When this agent was last downgraded (ms epoch), or null if on primary. */
+  downgradedAt: number | null
+  /** Current time (ms epoch). */
+  now: number
+  /** Revert window in ms. */
+  revertAfterMs: number
+}
+
+export type ModelAction =
+  | { kind: 'none' }
+  | { kind: 'downgrade'; model: string }
+  | { kind: 'revert'; model: string }
+
+/**
+ * Decide what to do for one agent. Pure: the runner gates the I/O (idle pane,
+ * actual write+restart) separately.
+ *
+ *   - limit detected & a lower model exists -> downgrade to it.
+ *   - limit detected & already at the bottom -> nothing (cannot go lower).
+ *   - no limit & downgraded long enough ago -> revert to the primary (chain[0]).
+ *   - otherwise -> nothing.
+ */
+export function decideModelAction(f: ModelFallbackFacts): ModelAction {
+  if (f.limitDetected) {
+    const next = nextFallbackModel(f.currentModel, f.chain)
+    if (next && next !== f.currentModel) return { kind: 'downgrade', model: next }
+    return { kind: 'none' }
+  }
+  if (f.downgradedAt !== null && f.now - f.downgradedAt >= f.revertAfterMs) {
+    const primary = f.chain[0]
+    if (primary && f.currentModel !== primary) return { kind: 'revert', model: primary }
+  }
+  return { kind: 'none' }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -20,6 +20,7 @@ import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
 import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
 import { startReauthHealer } from './web/reauth-healer.js'
 import { startAutoRestartRunner } from './web/auto-restart-runner.js'
+import { startModelFallbackRunner } from './web/model-fallback-runner.js'
 import { collectTokenUsage } from './web/token-usage.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
@@ -330,6 +331,9 @@ export function startWebServer(port = 3420): http.Server {
   const autoRestartInterval = webOnly ? undefined : startAutoRestartRunner()
   if (!webOnly) logger.info('Auto-restart runner started (60s poll, 40s offset)')
 
+  const modelFallbackInterval = webOnly ? undefined : startModelFallbackRunner()
+  if (!webOnly) logger.info('Model-fallback runner started (60s poll, 50s offset)')
+
   const updateCheckerInterval = webOnly ? undefined : startUpdateChecker()
   if (!webOnly) logger.info('Update checker started (15min poll)')
 
@@ -411,6 +415,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(stuckToolCallInterval)
     if (reauthHealerInterval) clearInterval(reauthHealerInterval)
     clearInterval(autoRestartInterval)
+    clearInterval(modelFallbackInterval)
     clearInterval(updateCheckerInterval)
     clearInterval(tokenCollectInterval)
     return origClose(cb)

--- a/src/web/model-fallback-runner.ts
+++ b/src/web/model-fallback-runner.ts
@@ -1,0 +1,151 @@
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID, SERVICE_ID, PROJECT_ROOT } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+import {
+  listAgentNames,
+  readAgentRemoteHost,
+  readAgentModel,
+  writeAgentModel,
+  resolveModelId,
+  DEFAULT_MODEL,
+} from './agent-config.js'
+import {
+  agentRunState,
+  agentSessionName,
+  restartAgentProcess,
+  capturePane,
+} from './agent-process.js'
+import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { paneLooksIdle } from '../pane-state.js'
+import { readModelFallbackConfig } from './model-fallback-store.js'
+import { detectsUsageLimit, decideModelAction } from '../model-fallback.js'
+
+// Drives the model-fallback-on-limit feature (see src/model-fallback.ts for the
+// why and the pure decision logic). Mirrors the auto-restart runner: a 60s
+// sweep, offset from the other watchers so tmux calls do not pile onto one tick.
+//
+// Per agent each tick: capture the pane, detect a plan usage-limit banner, ask
+// the pure decision function what to do, and -- only when the pane is idle --
+// rewrite the agent's model and respawn the session (keeping the conversation)
+// so the new model takes effect. A revert climbs back to the primary once the
+// agent has been limit-free past the configured window.
+
+const INITIAL_DELAY_MS = 50_000
+const INTERVAL_MS = 60_000
+
+// agent name -> when we last downgraded it (ms). Absent => currently on primary.
+// In-memory: a dashboard restart loses this, so a downgraded agent would not be
+// auto-reverted until the next downgrade cycle. Acceptable; the agent keeps
+// working on the fallback model, and the operator can revert manually.
+const downgradedAt = new Map<string, number>()
+
+const MAIN_SETTINGS_PATH = join(PROJECT_ROOT, '.claude', 'settings.json')
+
+function readMainModel(): string {
+  try {
+    const cfg = JSON.parse(readFileSync(MAIN_SETTINGS_PATH, 'utf-8'))
+    return resolveModelId((cfg && typeof cfg.model === 'string' && cfg.model) || DEFAULT_MODEL)
+  } catch {
+    return DEFAULT_MODEL
+  }
+}
+
+function writeMainModel(model: string): void {
+  let cfg: Record<string, unknown> = {}
+  try { cfg = JSON.parse(readFileSync(MAIN_SETTINGS_PATH, 'utf-8')) } catch {}
+  cfg.model = model
+  atomicWriteFileSync(MAIN_SETTINGS_PATH, JSON.stringify(cfg, null, 2))
+}
+
+function readModelFor(name: string): string {
+  return name === MAIN_AGENT_ID ? readMainModel() : readAgentModel(name)
+}
+
+function writeModelFor(name: string, model: string): void {
+  if (name === MAIN_AGENT_ID) writeMainModel(model)
+  else writeAgentModel(name, model)
+}
+
+function sessionFor(name: string): string {
+  return name === MAIN_AGENT_ID ? MAIN_CHANNELS_SESSION : agentSessionName(name)
+}
+
+function restartFor(name: string): void {
+  if (name === MAIN_AGENT_ID) {
+    // The main channels session is launchd-managed; a kickstart re-reads
+    // .claude/settings.json (and thus the new model) on relaunch. KeepAlive
+    // brings it straight back. channels.sh always starts fresh for main, so a
+    // conversation is not preserved here -- the model swap is what matters.
+    const uid = typeof process.getuid === 'function' ? process.getuid() : ''
+    execFileSync('/bin/launchctl', ['kickstart', '-k', `gui/${uid}/com.${SERVICE_ID}.channels`], { timeout: 10_000 })
+  } else {
+    // 'continue' (fresh: false) re-spawns with --continue so the conversation
+    // survives the model swap.
+    restartAgentProcess(name, { fresh: false })
+  }
+}
+
+function checkAgent(name: string, nowMs: number, revertAfterMs: number, chain: string[]): void {
+  // Sub-agents must be up; the main session is launchd-managed (always present).
+  if (name !== MAIN_AGENT_ID && agentRunState(name) !== 'running') return
+
+  const session = sessionFor(name)
+  const host = name === MAIN_AGENT_ID ? null : readAgentRemoteHost(name)
+  const pane = capturePane(session, host)
+  if (pane == null) return
+
+  const limitDetected = detectsUsageLimit(pane)
+  const currentModel = readModelFor(name)
+  const action = decideModelAction({
+    limitDetected,
+    currentModel,
+    chain,
+    downgradedAt: downgradedAt.get(name) ?? null,
+    now: nowMs,
+    revertAfterMs,
+  })
+  if (action.kind === 'none') return
+
+  // Downgrade may run on a limit-paused pane (which reads idle); revert must not
+  // cut a live turn. Both go through restart, so require idle for both.
+  if (!paneLooksIdle(pane)) {
+    logger.info({ name, action: action.kind }, 'model-fallback: action due but pane busy, deferring')
+    return
+  }
+
+  try {
+    writeModelFor(name, action.model)
+    restartFor(name)
+    if (action.kind === 'downgrade') downgradedAt.set(name, nowMs)
+    else downgradedAt.delete(name)
+    logger.info(
+      { name, from: currentModel, to: action.model, action: action.kind },
+      'model-fallback: switched model',
+    )
+  } catch (err) {
+    logger.warn({ err, name }, 'model-fallback: switch failed')
+  }
+}
+
+export function startModelFallbackRunner(): NodeJS.Timeout {
+  function sweep() {
+    const cfg = readModelFallbackConfig()
+    if (!cfg.enabled) {
+      if (downgradedAt.size > 0) downgradedAt.clear() // re-seed cleanly if re-enabled
+      return
+    }
+    const now = Date.now()
+    const revertAfterMs = cfg.revertAfterMinutes * 60_000
+    try { checkAgent(MAIN_AGENT_ID, now, revertAfterMs, cfg.chain) }
+    catch (err) { logger.debug({ err }, 'model-fallback: main check error') }
+    for (const name of listAgentNames()) {
+      try { checkAgent(name, now, revertAfterMs, cfg.chain) }
+      catch (err) { logger.debug({ err, agent: name }, 'model-fallback: agent check error') }
+    }
+  }
+  setTimeout(sweep, INITIAL_DELAY_MS)
+  return setInterval(sweep, INTERVAL_MS)
+}

--- a/src/web/model-fallback-store.ts
+++ b/src/web/model-fallback-store.ts
@@ -1,0 +1,30 @@
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { PROJECT_ROOT } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+import {
+  normalizeModelFallbackConfig,
+  DEFAULT_MODEL_FALLBACK,
+  type ModelFallbackConfig,
+} from '../model-fallback.js'
+
+// Single global config for the model-fallback-on-limit feature (one safety-net
+// policy for the whole fleet, unlike per-agent auto-restart). Default disabled,
+// so an upgrade is inert until the operator turns it on from the dashboard.
+const STORE_PATH = join(PROJECT_ROOT, 'store', 'model-fallback.json')
+
+export function readModelFallbackConfig(): ModelFallbackConfig {
+  try {
+    const parsed = JSON.parse(readFileSync(STORE_PATH, 'utf-8'))
+    return normalizeModelFallbackConfig(parsed)
+  } catch {
+    return { ...DEFAULT_MODEL_FALLBACK, chain: [...DEFAULT_MODEL_FALLBACK.chain] }
+  }
+}
+
+export function writeModelFallbackConfig(cfg: Partial<ModelFallbackConfig>): ModelFallbackConfig {
+  const current = readModelFallbackConfig()
+  const merged = normalizeModelFallbackConfig({ ...current, ...cfg })
+  atomicWriteFileSync(STORE_PATH, JSON.stringify(merged, null, 2))
+  return merged
+}


### PR DESCRIPTION
## Mit csinál

Amikor egy agent **Claude plan usage-limitje** elfogy, a Claude Code session megáll és a tmux pane-ben usage-limit bannert ír ki. Eddig semmi nem kezelte: az agent siket maradt a window resetig (pont ez volt a Jarvis-szal a probléma). Ez a feature detektálja a bannert, és egy konfigurált modell-láncon (`opus → sonnet → haiku`) **egy lépést lefelé vált**, újraindítva a sessiont (`--continue`, a beszélgetés megmarad), így az olcsóbb modell -- külön budgeten -- átveszi. A revert-window után, limit-mentesen, visszamászik a primary modellre.

## Architektúra

A meglévő `auto-restart` runner mintáját követi (pure logika + I/O runner szétválasztva, 60s sweep).

- **`src/model-fallback.ts`** -- tiszta, dependency-free logika: `detectsUsageLimit`, `nextFallbackModel`, `decideModelAction`, config-normalizálás. Óra/tmux/fs nélkül unit-tesztelhető.
- **`src/web/model-fallback-store.ts`** -- globális config `store/model-fallback.json`-ban, **default DISABLED**. A feature inert, amíg az operator be nem kapcsolja.
- **`src/web/model-fallback-runner.ts`** -- 60s sweep (50s offset). Per agent: `capturePane` → `detectsUsageLimit` → `decideModelAction` → idle-gate → modell-írás + restart.
  - **Main agent (Jarvis)**: `.claude/settings.json` `.model` + `launchctl kickstart` (channels.sh ezt olvassa relaunch-kor).
  - **Sub-agentek**: `agent-config.json` `.model` + `restartAgentProcess({fresh:false})` (continue).
- **`src/web.ts`** -- runner indítása + cleanup bekötve a többi watcher mellé.
- **`src/__tests__/model-fallback.test.ts`** -- 18 unit teszt.

## Biztonsági / scope döntések

- **Szűk detektor**: a transient `API Error: 429` (overload, máshol kezelve) NEM trippeli, csak a valódi plan-budget kimerülés. A banner-régió a pane alja (utolsó 15 sor), így scrollback / reply-body idézet nem indít váltást.
- **Idle-gate**: a restart sosem vág el élő turn-t.
- **Default off**: bekapcsolásig nincs viselkedésváltozás.

## Engedélyezés

`store/model-fallback.json`:
\`\`\`json
{ "enabled": true, "chain": ["claude-opus-4-8[1m]","claude-sonnet-4-6","claude-haiku-4-5-20251001"], "revertAfterMinutes": 330 }
\`\`\`

## FIX-SOON (follow-up, külön PR)
- Dashboard toggle + REST route a be/kikapcsoláshoz (most fájl-alapú). Szándékosan kihagyva, hogy ne ütközzön a jelenleg main-en lévő in-flight `routes/marveen.ts` szerkesztésekkel.
- In-memory revert-state: dashboard-restartkor elveszik, a downgrade-elt agent a fallback modellen marad a következő ciklusig (működőképes, csak a visszamászás csúszik). Perzisztálható, ha kell.

## Verifikáció
- `tsc --noEmit`: 0 hiba
- `vitest run` (model-fallback): 18/18 pass
- `biome check`: 0

## Megjegyzés
A marveen repóban nincs `.claude/agents/` reviewer-set és nincs Reviewy, így a Molyo pre-merge pipeline itt nem alkalmazható. Saját felelősségre, alapos önellenőrzéssel készült.

🤖 Generated with [Claude Code](https://claude.com/claude-code)