### PR TITLE
fix(channels): extract #472 unique value — idle-guard + MAIN ghost-env

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -106,7 +106,14 @@ TMUX="$(command -v tmux)"
 # mitigation. Set them inline on the launch command -- the tmux SERVER predates
 # this script and does not inherit its environment, so exporting here alone
 # would not reach the new claude. Mirrors the sub-agent launch.
-MCP_BATCH_ENV="export MCP_SERVER_CONNECTION_BATCH_SIZE=10 MCP_CONNECTION_NONBLOCKING=1 MCP_TIMEOUT=60000 && "
+#
+# CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false also added here: the sub-agent spawn
+# (startAgentProcess) sets it to suppress the DIM ghost-text autocomplete, but
+# the MAIN channels session never got it -- so a dim ghost in the main box was
+# the one place the pane-scrape recovery could still misread it (the v1.15.0
+# dim-strip catches it on the recovery side, but killing it at the SOURCE on MAIN
+# too closes the gap end-to-end). Parity with the sub-agent launch.
+MCP_BATCH_ENV="export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false MCP_SERVER_CONNECTION_BATCH_SIZE=10 MCP_CONNECTION_NONBLOCKING=1 MCP_TIMEOUT=60000 && "
 
 # Read the main agent's default model from .claude/settings.json so we can
 # pass --model explicitly. Without --model claude-code falls back to its

--- a/src/__tests__/channel-mcp-reconnect.test.ts
+++ b/src/__tests__/channel-mcp-reconnect.test.ts
@@ -180,6 +180,30 @@ const ENABLE_RX = /\benable\b/i
 describe('attemptChannelMcpReconnect', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // attemptChannelMcpReconnect now does a preflight capturePane + busy-guard
+    // BEFORE pressing any key (so it never interrupts an actively generating
+    // pane). Queue a non-busy preflight read first; each test's own capture
+    // sequence then flows behind it unchanged. A 'no idle footer' string reads
+    // as 'unknown' (not 'busy'), so the guard lets the reconnect proceed.
+    mockCapturePane.mockReturnValueOnce('preflight-not-busy')
+  })
+
+  it('defers (sends NO keys) when the pane is actively generating', () => {
+    // Reni-reported root cause: the soft /mcp reconnect blindly pressed Escape
+    // into a live session, interrupting work in progress. The busy-guard must
+    // bail before any send-keys when detectPaneState reads 'busy'.
+    mockCapturePane.mockReset()
+    mockCapturePane.mockReturnValueOnce('· Synthesizing… (8s · ↓ 1.2k tokens · esc to interrupt)')
+
+    const result = attemptChannelMcpReconnect('marveen')
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('busy')
+    // The hard assertion: not a single key was sent into the pane.
+    const sendKeyCalls = mockExecFileSync.mock.calls.filter(
+      (c) => Array.isArray(c[1]) && c[1].includes('send-keys'),
+    )
+    expect(sendKeyCalls.length).toBe(0)
   })
 
   it('connected state: steps Down onto Reconnect, then activates it', () => {

--- a/src/web/channel-mcp-reconnect.ts
+++ b/src/web/channel-mcp-reconnect.ts
@@ -6,7 +6,7 @@ import { readAgentChannelProvider } from './agent-config.js'
 import { agentSessionName, capturePane } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { getProvider, type ChannelProviderType } from '../channel-provider.js'
-import { paneLooksIdle } from '../pane-state.js'
+import { paneLooksIdle, detectPaneState } from '../pane-state.js'
 
 const TMUX = resolveFromPath('tmux')
 const MAX_UP_ATTEMPTS = 8
@@ -161,6 +161,20 @@ export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
   const session = resolveAgentSession(agentName)
   const providerType = resolveAgentProviderType(agentName)
   const pluginPattern = getPluginPattern(providerType)
+
+  // Idle-guard: NEVER drive the /mcp menu (which starts by pressing Escape and
+  // then navigates Up/Enter/Down) into a pane that is actively generating. The
+  // Escape would interrupt the agent's in-flight turn and the navigation keys
+  // would inject stray input into a live session -- i.e. it kills work in
+  // progress. A 'busy' read means an Escape lands as an interrupt, so we defer
+  // and let the caller retry on a later tick when the pane is back at the idle
+  // prompt. (detectPaneState reads the live footer / busy indicators; scrollback
+  // mentions of "esc to interrupt" are footer-scoped so they don't false-trip.)
+  const preflight = capturePane(session) ?? ''
+  if (detectPaneState(preflight) === 'busy') {
+    logger.info({ agentName, session }, 'channel-mcp-reconnect: pane busy -- deferring reconnect to avoid interrupting active work')
+    return { ok: false, message: 'Pane busy -- reconnect deferred to avoid interrupting active work' }
+  }
 
   try {
     execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })


### PR DESCRIPTION
## Focused extract of #472's unique value (idle-guard + MAIN ghost-env)

Per Marveen's GO: extract only the genuinely-unique value from #472 (which overlaps the already-merged #467/#465/#464 and conflicts with develop after v1.16.1). #472 to be closed as "superseded by #467/#465/#464 + this focused extract".

**Included (2 clean pieces):**
- **idle-guard** (`channel-mcp-reconnect.ts`, cherry-picked 0a3f386): the soft /mcp reconnect never interrupts active work.
- **MAIN ghost-env** (`channels.sh`): adds `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false` to the MAIN session launch (parity with sub-agents) — closes the dim-ghost vector at the source on MAIN, complementing the v1.15.0 recovery-side dim-strip.

**Deliberately NOT included — the /mcp-dance-drop (656cce5):** it conflicts substantively with the merged recovery stack — #472 solved restart-churn via *restart-state persistence* while the merged #464/#465 used *stagger*; they collide in the same `channel-monitor.ts` regions. The soft /mcp reconnect it removes is also now moot (#464 launches channel sub-agents fresh, so there's no --continue context to preserve). Recommend it as a separate careful integration or a tutker rebase rather than forcing a risky resolution into just-stabilized recovery code.

tsc clean; idle-guard tests green (23).

Co-authored-by: tutker <6787615+tutker@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
