### PR TITLE
Fix token-usage double-counting of tool-calling turns

### DIFF
--- a/src/__tests__/token-usage-collapse.test.ts
+++ b/src/__tests__/token-usage-collapse.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { collapseByMessageId } from '../web/token-usage.js'
+
+// Minimal ParsedCall factory (the type is module-internal; the shape is what
+// collapseByMessageId reads).
+function call(over: Partial<Record<string, unknown>> = {}): any {
+  return {
+    agent: 'jarvis',
+    sessionId: 's1',
+    timestamp: 1000,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    contentPreview: '',
+    toolName: null,
+    messageId: null,
+    ...over,
+  }
+}
+
+describe('collapseByMessageId', () => {
+  it('collapses the text + tool_use lines of one turn into a single row', () => {
+    // Real-world shape: same message id, identical usage, 2-3s apart; the first
+    // line has the text block (tool_name null), the second the tool_use block.
+    const rows = [
+      call({ messageId: 'msg_A', timestamp: 1000, outputTokens: 267, toolName: null, contentPreview: 'let me search' }),
+      call({ messageId: 'msg_A', timestamp: 1003, outputTokens: 267, toolName: 'ToolSearch', contentPreview: '' }),
+    ]
+    const out = collapseByMessageId(rows)
+    expect(out).toHaveLength(1)
+    expect(out[0].outputTokens).toBe(267) // counted ONCE, not 534
+    expect(out[0].toolName).toBe('ToolSearch') // tool name preserved
+    expect(out[0].contentPreview).toBe('let me search') // first non-empty preview
+    expect(out[0].timestamp).toBe(1000) // first occurrence kept
+  })
+
+  it('collapses three+ lines (parallel tool calls) into one', () => {
+    const rows = [
+      call({ messageId: 'msg_B', outputTokens: 461, toolName: null }),
+      call({ messageId: 'msg_B', outputTokens: 461, toolName: null }),
+      call({ messageId: 'msg_B', outputTokens: 461, toolName: 'Bash' }),
+    ]
+    const out = collapseByMessageId(rows)
+    expect(out).toHaveLength(1)
+    expect(out[0].outputTokens).toBe(461)
+    expect(out[0].toolName).toBe('Bash')
+  })
+
+  it('keeps distinct turns separate and preserves order', () => {
+    const rows = [
+      call({ messageId: 'msg_A', outputTokens: 10, toolName: 'Read' }),
+      call({ messageId: 'msg_B', outputTokens: 20 }),
+      call({ messageId: 'msg_A', outputTokens: 10, toolName: 'Read' }),
+    ]
+    const out = collapseByMessageId(rows)
+    expect(out.map((c) => c.messageId)).toEqual(['msg_A', 'msg_B'])
+    expect(out[0].outputTokens).toBe(10)
+    expect(out[1].outputTokens).toBe(20)
+  })
+
+  it('passes through rows without a message id (older transcripts)', () => {
+    const rows = [
+      call({ messageId: null, outputTokens: 5 }),
+      call({ messageId: null, outputTokens: 7 }),
+    ]
+    const out = collapseByMessageId(rows)
+    expect(out).toHaveLength(2)
+    expect(out.map((c) => c.outputTokens)).toEqual([5, 7])
+  })
+
+  it('takes the max per usage field if a partial line differs', () => {
+    const rows = [
+      call({ messageId: 'msg_C', inputTokens: 100, outputTokens: 5, cacheReadTokens: 9 }),
+      call({ messageId: 'msg_C', inputTokens: 100, outputTokens: 50, cacheReadTokens: 9, toolName: 'Edit' }),
+    ]
+    const out = collapseByMessageId(rows)
+    expect(out).toHaveLength(1)
+    expect(out[0].inputTokens).toBe(100)
+    expect(out[0].outputTokens).toBe(50)
+    expect(out[0].cacheReadTokens).toBe(9)
+  })
+})

--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -77,6 +77,45 @@ interface ParsedCall {
   cacheCreationTokens: number
   contentPreview: string
   toolName: string | null
+  /** The API message id (msg_...). One assistant turn that calls a tool is
+   *  written to the transcript as SEVERAL `assistant` lines sharing this id --
+   *  a text block (tool_name=null) plus one line per tool_use block -- and EACH
+   *  carries the SAME cumulative `usage`. Counting each line would double (or
+   *  triple) the turn's tokens, which is exactly the dashboard-inflation bug.
+   *  Used only to collapse those lines back into one row; not persisted. */
+  messageId?: string | null
+}
+
+/**
+ * Collapse transcript rows that belong to the same assistant turn (same
+ * message id) into a single row, so a tool-calling turn is counted ONCE.
+ *
+ * Usage is identical across a turn's lines, so we take the max per field
+ * (defensive against a partial/streaming line) rather than summing. The tool
+ * name and preview are filled from whichever line carries them. Rows without a
+ * message id (older transcripts) pass through untouched. Pure + order-stable
+ * for unit testing.
+ */
+export function collapseByMessageId(calls: ParsedCall[]): ParsedCall[] {
+  const byId = new Map<string, ParsedCall>()
+  const out: ParsedCall[] = []
+  for (const c of calls) {
+    if (!c.messageId) { out.push(c); continue }
+    const ex = byId.get(c.messageId)
+    if (!ex) {
+      const copy = { ...c }
+      byId.set(c.messageId, copy)
+      out.push(copy)
+      continue
+    }
+    ex.inputTokens = Math.max(ex.inputTokens, c.inputTokens)
+    ex.outputTokens = Math.max(ex.outputTokens, c.outputTokens)
+    ex.cacheReadTokens = Math.max(ex.cacheReadTokens, c.cacheReadTokens)
+    ex.cacheCreationTokens = Math.max(ex.cacheCreationTokens, c.cacheCreationTokens)
+    if (!ex.toolName && c.toolName) ex.toolName = c.toolName
+    if (!ex.contentPreview && c.contentPreview) ex.contentPreview = c.contentPreview
+  }
+  return out
 }
 
 async function parseJsonlFile(
@@ -144,10 +183,13 @@ async function parseJsonlFile(
       cacheCreationTokens: (u.cache_creation_input_tokens || 0),
       contentPreview: preview,
       toolName,
+      messageId: obj.message?.id || null,
     })
   }
 
-  return { calls, linesRead: lineNum }
+  // Collapse the multi-line tool-turn rows (same message id, repeated usage)
+  // before they reach the DB -- this is the fix for the ~2x token inflation.
+  return { calls: collapseByMessageId(calls), linesRead: lineNum }
 }
 
 export async function collectTokenUsage(): Promise<{ inserted: number; files: number }> {


### PR DESCRIPTION
## Bug

A `token_usage` táblában minden tool-hívó turnhoz **több sor** keletkezett (Jarvis jelentette): egy `tool_name=null` és egy (vagy több) `tool_name=<eszköznév>` sor, **azonos `output_tokens`** értékkel, 2-3 másodperccel egymás után. Eredmény: output és cache tokenek ~2x (párhuzamos tool-hívásnál 3x) inflálva a dashboardon.

## Ok

A Claude Code transcript egy assistant turn-t (ami tool-t hív) **több `assistant` JSONL sorként** ír ki, azonos `message.id`-vel: egy text-blokk sor (`tool_name=null`) + soronként egy `tool_use`-blokk sor (`tool_name` kitöltve), és **mindegyik ugyanazt a kumulált `usage`-et hordozza**. A `parseJsonlFile` soronként push-olt → a turn tokenjei többszöröződtek.

A meglévő UNIQUE dedup index `(agent, session_id, timestamp, input_tokens, output_tokens)` ezt **nem** fogja meg, mert a duplikált sorok `timestamp`-ja 2-3s-mal eltér.

Valós transcripten ellenőrizve:
\`\`\`
1962 assistant+usage sor / 942 egyedi message.id / 514 duplikált message.id
msg_01FisUEB...: ts=...55.203 out=267 tool=None
                 ts=...55.532 out=267 tool=ToolSearch   <- ugyanaz a turn, +267 duplán
\`\`\`

## Fix

A parser most **`message.id` szerint összevonja** egy turn sorait egyetlen sorra a DB-be írás előtt (`collapseByMessageId`). A usage soronként azonos, ezért mezőnként **max**-ot veszünk (defenzív részleges/streaming sor ellen), a `tool_name` és preview a megfelelő sorból töltődik. `message.id` nélküli (régi) sorok változatlanul átmennek.

- **`src/web/token-usage.ts`** -- `messageId` mező + `collapseByMessageId` (exportált, pure, order-stable) + összevonás a `parseJsonlFile` végén.
- **`src/__tests__/token-usage-collapse.test.ts`** -- 5 unit teszt (collapse 2/3 soros turn, distinct turn-ök, id-nélküli passthrough, max-mező).

## Hatókör / megjegyzés

- **Going-forward fix.** A már betárolt inflált sorok benne maradnak. Tisztításuk külön lépés (pl. `message_id` oszlop + egyszeri dedup) lehet follow-up -- **destruktív törlést Zsolt jóváhagyása nélkül nem csináltam**.
- Cross-sweep edge: ha a gyűjtő sweep pont a ~3s-os írási ablakban fut, egy message sorai két sweep közt szakadhatnak. Óránkénti gyűjtésnél elhanyagolható; a perzisztens `message_id`-alapú dedup ezt is megfogná (follow-up).

## Verifikáció
- `tsc --noEmit`: 0
- `vitest run` (collapse): 5/5 pass
- `biome check`: 0

A marveen repóban nincs reviewer-set / Reviewy, így a pre-merge pipeline nem alkalmazható. Saját felelősségre, önellenőrzéssel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)