### PR TITLE
fix(installer): provision C/C++ toolchain for native better-sqlite3 build

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -161,6 +161,20 @@ for pkg in ffmpeg git tmux lsof curl python3 pipx unzip; do
   fi
 done
 
+# C/C++ toolchain a native npm modulok forditasahoz. A better-sqlite3 elobb egy
+# prebuilt binarist probal letolteni (prebuild-install); ha az nem elerheto vagy
+# a letoltes idotullepes miatt elbukik, node-gyp-pel forditja forrasbol, amihez
+# make + gcc/g++ kell. A csomagnev a 'command -v' nevtol elter, ezert kulon
+# ellenorizzuk (make/cc), es managerenkent a megfelelo csomagot adjuk hozza
+# (apt: build-essential -- make/gcc/g++; dnf: make gcc gcc-c++).
+if ! command -v make &>/dev/null || ! command -v cc &>/dev/null; then
+  if [ "$PKG_MANAGER" = "apt" ]; then
+    MISSING_PKGS="$MISSING_PKGS build-essential"
+  else
+    MISSING_PKGS="$MISSING_PKGS make gcc gcc-c++"
+  fi
+fi
+
 # Node.js v20+ ellenorzes
 NODE_OK=false
 if command -v node &>/dev/null; then
@@ -207,6 +221,7 @@ command -v npm &>/dev/null || fail "npm nem talalhato a nodejs csomag utan sem. 
 
 ok "ffmpeg $(ffmpeg -version | awk 'NR==1 {print $3}')"
 ok "git $(git --version | awk '{print $3}')"
+ok "make $(make --version | awk 'NR==1 {print $3}')"
 ok "lsof $(lsof -v 2>&1 | awk '/^    revision:/ {print $2}')"
 ok "node $(node --version)"
 ok "npm $(npm --version)"


### PR DESCRIPTION
## Problem

On a clean Ubuntu/Fedora machine without a C/C++ compiler, `install-linux.sh` fails at the `npm-install` step with the generic message *"npm install sikertelen"*. The real error underneath:

```
npm error path .../node_modules/better-sqlite3
npm error command sh -c prebuild-install || node-gyp rebuild --release
npm error prebuild-install warn install Request timed out
npm error gyp ERR! stack Error: not found: make
```

`better-sqlite3` is a native addon. When the `prebuild-install` binary download is unavailable or times out, it falls back to `node-gyp rebuild`, which needs `make` + `gcc`/`g++`. The installer's dependency check only ensured `ffmpeg git tmux lsof curl python3 pipx unzip` — never the build toolchain — so the install dies on any box without a compiler (e.g. fresh Ubuntu 26.04 / WSL2).

## Fix

Add a dedicated toolchain check. It can't go in the existing `for pkg` loop because that loop assumes command-name == package-name, which isn't true for `build-essential`, and the package name differs per manager:

- **apt** → `build-essential` (make/gcc/g++)
- **dnf** → `make gcc gcc-c++`

The existing `apt-get install` / `dnf install $MISSING_PKGS` logic then provisions it. Also added a `make` line to the verification block.

Reproduced the failure and confirmed `bash -n` passes on the patched script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)