### PR TITLE
fix(agents): per-agent isolated CLAUDE_CONFIG_DIR with shared OAuth-token auth (supersedes #459)

### DIFF
--- a/src/__tests__/isolated-channel-config.test.ts
+++ b/src/__tests__/isolated-channel-config.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  mkdtempSync, mkdirSync, writeFileSync, rmSync, lstatSync, readlinkSync, readFileSync, existsSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Redirect homedir() (used inside ensureIsolatedChannelConfigDir to find the
+// shared ~/.claude) and agentDir() (used to find the agent cwd) at the temp
+// sandbox built per test. tmpdir() stays real so we can create the sandbox.
+let SANDBOX = ''
+vi.mock('node:os', async (orig) => {
+  const actual = await orig<typeof import('node:os')>()
+  return { ...actual, homedir: () => join(SANDBOX, 'home') }
+})
+vi.mock('../web/agent-config.js', async (orig) => {
+  const actual = await orig<typeof import('../web/agent-config.js')>()
+  return { ...actual, agentDir: (name: string) => join(SANDBOX, 'agents', name) }
+})
+
+// Imported AFTER the mocks are registered.
+const { ensureIsolatedChannelConfigDir, CHANNEL_PLUGIN_IDS } = await import('../web/agent-process.js')
+const TG = CHANNEL_PLUGIN_IDS.telegram
+const SL = CHANNEL_PLUGIN_IDS.slack
+const DI = CHANNEL_PLUGIN_IDS.discord
+
+function seedSharedClaude(home: string) {
+  const claude = join(home, '.claude')
+  mkdirSync(claude, { recursive: true })
+  // shared top-level entries; projects/ must end up symlinked (transcripts),
+  // .credentials.json must NOT (auth comes from CLAUDE_CODE_OAUTH_TOKEN env).
+  writeFileSync(join(claude, '.credentials.json'), '{"claudeAiOauth":{}}')
+  mkdirSync(join(claude, 'projects'), { recursive: true })
+  // settings.json must be OWNED (copied), not symlinked
+  writeFileSync(join(claude, 'settings.json'), JSON.stringify({ hooks: { Stop: [] }, enabledPlugins: { [TG]: true } }))
+  // plugins/: cache+marketplaces+data symlinked, install state owned
+  const plugins = join(claude, 'plugins')
+  mkdirSync(join(plugins, 'cache'), { recursive: true })
+  mkdirSync(join(plugins, 'marketplaces'), { recursive: true })
+  mkdirSync(join(plugins, 'data'), { recursive: true })
+  writeFileSync(join(plugins, 'known_marketplaces.json'), '{"claude-plugins-official":{}}')
+  writeFileSync(join(plugins, 'installed_plugins.json'), JSON.stringify({
+    plugins: {
+      [TG]: [{ scope: 'project', projectPath: '/some/other/agent', installPath: '/x', version: '0.0.6' }],
+    },
+  }))
+}
+
+beforeEach(() => {
+  SANDBOX = mkdtempSync(join(tmpdir(), 'isocfg-'))
+  seedSharedClaude(join(SANDBOX, 'home'))
+  mkdirSync(join(SANDBOX, 'agents', 'testagent'), { recursive: true })
+})
+afterEach(() => {
+  rmSync(SANDBOX, { recursive: true, force: true })
+})
+
+describe('ensureIsolatedChannelConfigDir', () => {
+  it('returns the per-agent .claude-config path', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'telegram')
+    expect(cfg).toBe(join(SANDBOX, 'agents', 'testagent', '.claude-config'))
+  })
+
+  it('symlinks shared transcripts so --continue stays shared', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'telegram')!
+    expect(lstatSync(join(cfg, 'projects')).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(join(cfg, 'projects'))).toBe(join(SANDBOX, 'home', '.claude', 'projects'))
+  })
+
+  it('does NOT symlink or copy .credentials.json (auth via CLAUDE_CODE_OAUTH_TOKEN env)', () => {
+    // Szotasz #459 review: a symlinked .credentials.json breaks on the first
+    // atomic token refresh (temp+rename replaces the link, diverging the creds
+    // and racing the single-use refresh token). The isolated dir must carry NO
+    // credentials file at all -- the launcher injects a long-lived OAuth token.
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'telegram')!
+    expect(existsSync(join(cfg, '.credentials.json'))).toBe(false)
+  })
+
+  it('removes a stale .credentials.json left by an older build', () => {
+    const cfg = join(SANDBOX, 'agents', 'testagent', '.claude-config')
+    mkdirSync(cfg, { recursive: true })
+    writeFileSync(join(cfg, '.credentials.json'), '{"stale":true}')
+    ensureIsolatedChannelConfigDir('testagent', 'telegram')
+    expect(existsSync(join(cfg, '.credentials.json'))).toBe(false)
+  })
+
+  it('OWNS settings.json (real file) with only the agent provider plugin enabled', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'telegram')!
+    const sp = join(cfg, 'settings.json')
+    expect(lstatSync(sp).isSymbolicLink()).toBe(false)
+    const s = JSON.parse(readFileSync(sp, 'utf-8'))
+    expect(s.enabledPlugins[TG]).toBe(true)
+    expect(s.enabledPlugins[SL]).toBe(false)
+    expect(s.enabledPlugins[DI]).toBe(false)
+    expect(s.hooks).toEqual({ Stop: [] }) // shared non-plugin settings preserved
+  })
+
+  it('a slack agent enables ONLY slack in its isolated settings', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'slack')!
+    const s = JSON.parse(readFileSync(join(cfg, 'settings.json'), 'utf-8'))
+    expect(s.enabledPlugins[SL]).toBe(true)
+    expect(s.enabledPlugins[TG]).toBe(false)
+  })
+
+  it('OWNS plugins/installed_plugins.json re-pointed at this agent cwd, symlinks the cache', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', 'telegram')!
+    expect(lstatSync(join(cfg, 'plugins', 'cache')).isSymbolicLink()).toBe(true)
+    const ip = join(cfg, 'plugins', 'installed_plugins.json')
+    expect(lstatSync(ip).isSymbolicLink()).toBe(false)
+    const inst = JSON.parse(readFileSync(ip, 'utf-8'))
+    expect(inst.plugins[TG][0].projectPath).toBe(join(SANDBOX, 'agents', 'testagent'))
+  })
+
+  it('is idempotent: a second call leaves a valid isolated dir', () => {
+    const first = ensureIsolatedChannelConfigDir('testagent', 'telegram')
+    const second = ensureIsolatedChannelConfigDir('testagent', 'telegram')
+    expect(second).toBe(first)
+    expect(existsSync(join(second!, 'settings.json'))).toBe(true)
+    expect(lstatSync(join(second!, 'plugins', 'cache')).isSymbolicLink()).toBe(true)
+  })
+
+  it('returns null (degraded, not fatal) when the shared ~/.claude is absent', () => {
+    rmSync(join(SANDBOX, 'home', '.claude'), { recursive: true, force: true })
+    expect(ensureIsolatedChannelConfigDir('testagent', 'telegram')).toBeNull()
+  })
+})
+
+// Source-level contract for the launcher wiring (startAgentProcess). These
+// guard the auth mechanism Szotasz asked for: no symlinked creds, a long-lived
+// OAuth token injected via env, and isolation gated on that token's presence.
+const SRC = readFileSync(join(__dirname, '../web/agent-process.ts'), 'utf-8')
+
+describe('isolated-config launcher wiring', () => {
+  it('skips .credentials.json from the symlink set', () => {
+    expect(SRC).toMatch(/ISOLATED_CONFIG_SKIP\s*=\s*new Set\(\[[^\]]*'\.credentials\.json'/)
+  })
+
+  it('gates auto-isolation on the fleet OAuth token', () => {
+    expect(SRC).toMatch(/if\s*\(hasFleetOauthToken\(\)\)/)
+  })
+
+  it('injects CLAUDE_CODE_OAUTH_TOKEN by reading the 0600 file at launch (secret never in the command string)', () => {
+    expect(SRC).toMatch(/CLAUDE_CODE_OAUTH_TOKEN="\$\(cat '\$\{FLEET_OAUTH_TOKEN_PATH\}'\)"/)
+    expect(SRC).toMatch(/\$\{oauthTokenEnv\}/)
+  })
+
+  it('falls back to the shared ~/.claude (no isolation) when the token is missing', () => {
+    // The warning branch keeps the pre-isolation behaviour rather than launching
+    // a logged-out sub-agent.
+    expect(SRC).toMatch(/no fleet OAuth token/)
+  })
+})

--- a/src/store-watcher.ts
+++ b/src/store-watcher.ts
@@ -19,7 +19,7 @@ const SYSTEM_FILES = new Set([
   // Fleet and agent management
   'agents-desired.json', 'auto-restart.json', 'autonomy-config.json',
   // Auth and secrets
-  '.dashboard-token', '.vault-key', 'vault.json',
+  '.dashboard-token', '.vault-key', 'vault.json', '.claude-oauth-token',
   // Usage and keepalive
   'claude-usage.json', '.channel-keepalive', '.channel-last-respawn',
   // Known Marveen-written log files
@@ -34,7 +34,7 @@ const SYSTEM_RE = /\.pid$|\.tmp$|\.tmp\.[a-f0-9]+$|\.migrated$|\.bak$|^\.DS_Stor
 
 // Filenames whose presence is sensitive; the audit row is flagged so the UI
 // can show a sanitised label instead of hinting at secret values.
-const SENSITIVE_NAMES = new Set(['.dashboard-token', 'vault.json', '.vault-key'])
+const SENSITIVE_NAMES = new Set(['.dashboard-token', 'vault.json', '.vault-key', '.claude-oauth-token'])
 
 // --- Agent attribution slot ---
 // Node.js is single-threaded; a route handler sets this before writing,

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, lstatSync, symlinkSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync, execFileSync } from 'node:child_process'
@@ -29,7 +29,7 @@ import {
 } from './ssh-tmux.js'
 import { parseTelegramToken } from './telegram.js'
 import { getProvider, getProviderType, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
-import { CHANNEL_PROVIDER, MAIN_AGENT_ID } from '../config.js'
+import { CHANNEL_PROVIDER, MAIN_AGENT_ID, STORE_DIR } from '../config.js'
 import { loadProfileTemplate } from './profiles.js'
 import { resolveAgentSecurityProfile } from './agent-team.js'
 import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
@@ -93,6 +93,161 @@ export function ownChannelProviderForScope(
   resolvedProvider: string | null,
 ): string | null {
   return hasOwnToken && resolvedProvider ? resolvedProvider : null
+}
+
+// The fleet's shared long-lived OAuth token (from `claude setup-token`), stored
+// 0600 in store/. Isolated channel sub-agents authenticate via this token in the
+// CLAUDE_CODE_OAUTH_TOKEN env var -- NOT via a copied/symlinked .credentials.json.
+// See ensureIsolatedChannelConfigDir for why.
+export const FLEET_OAUTH_TOKEN_PATH = join(STORE_DIR, '.claude-oauth-token')
+
+// True when the fleet OAuth token file exists and is non-empty. Provisioning an
+// isolated config dir WITHOUT auth would launch the sub-agent logged-out, so
+// isolation is gated on this: no token -> keep the shared ~/.claude (degraded
+// dup-poller risk, but never a broken login).
+export function hasFleetOauthToken(): boolean {
+  try {
+    return existsSync(FLEET_OAUTH_TOKEN_PATH) && readFileSync(FLEET_OAUTH_TOKEN_PATH, 'utf-8').trim().length > 0
+  } catch {
+    return false
+  }
+}
+
+// Per-agent isolated CLAUDE_CONFIG_DIR provisioning (2026-06-26 fleet outage).
+//
+// Claude Code records a plugin's PROJECT-scoped install in a single shared file
+// -- ~/.claude/plugins/installed_plugins.json -- keyed by ONE projectPath per
+// plugin id. Every sub-agent ran out of the SAME ~/.claude, so each agent launch
+// (claude --channels plugin:telegram@...) rewrote that single slot to its OWN
+// project, evicting whichever agent registered before it. Net effect: only ONE
+// agent's channel plugin could be registered (one bun getUpdates poller / one
+// bot.pid) fleet-wide; every other agent saw "No MCP servers configured", spawned
+// no poller, and went deaf. Sequentialising restarts did NOT help (the slot is
+// shared state, not a startup race); the only structural fix is to stop the
+// agents sharing one plugin-install file.
+//
+// This gives each channel sub-agent its own CLAUDE_CONFIG_DIR: symlink every
+// top-level ~/.claude entry so project transcripts and plugin marketplaces stay
+// shared, EXCEPT settings.json and plugins/ which become per-agent (so each
+// agent's project-scoped install lives in its own installed_plugins.json and can
+// never evict another's).
+//
+// AUTH (2026-06-28, addressing Szotasz's #459 review): we DELIBERATELY do NOT
+// symlink or copy .credentials.json. On Linux/Windows Claude Code refreshes the
+// OAuth token atomically (temp file + rename), which would replace a symlink with
+// a standalone file -- the isolated agent's token then diverges from the shared
+// one, and because OAuth refresh tokens are single-use, concurrent refreshes from
+// multiple isolated dirs race and break the shared login (confirmed: claude-code
+// issues #27933, #24317, #43392). Instead the launcher passes a long-lived
+// CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`, ~1y, no refresh) via env.
+// With that env var present Claude Code authenticates from it and writes NO
+// .credentials.json into the config dir -- so there is nothing to diverge and no
+// refresh race. .credentials.json is therefore in the skip set below.
+//
+// Idempotent and best-effort: returns the dir on success, or null so the caller
+// falls back to the shared ~/.claude (degraded, but never a launch failure).
+const ISOLATED_CONFIG_SKIP = new Set(['settings.json', 'plugins', '.credentials.json'])
+
+export function ensureIsolatedChannelConfigDir(
+  name: string,
+  providerType: ChannelProviderType,
+): string | null {
+  try {
+    const cwd = agentDir(name)
+    const cfg = join(cwd, '.claude-config')
+    const realClaude = join(homedir(), '.claude')
+    if (!existsSync(realClaude)) return null
+    mkdirSync(cfg, { recursive: true })
+
+    // 1. Symlink every top-level ~/.claude entry except the ones we own or that
+    //    must stay out of the isolated dir (.credentials.json -- see header). A
+    //    stale non-symlink (e.g. a prior copy, or a .credentials.json left by an
+    //    earlier build) is removed so it can never shadow the env-var auth.
+    for (const entry of readdirSync(realClaude)) {
+      if (ISOLATED_CONFIG_SKIP.has(entry)) {
+        // Defensively drop a real .credentials.json that an older build may have
+        // symlinked/copied here, so the env-var token is the only auth source.
+        const stale = join(cfg, entry)
+        if (entry === '.credentials.json') {
+          try { rmSync(stale, { force: true }) } catch { /* absent */ }
+        }
+        continue
+      }
+      const link = join(cfg, entry)
+      let needsLink = true
+      try {
+        if (lstatSync(link).isSymbolicLink()) needsLink = false
+        else rmSync(link, { recursive: true, force: true })
+      } catch { /* absent -> create */ }
+      if (needsLink) {
+        try { symlinkSync(join(realClaude, entry), link) }
+        catch (err) { logger.warn({ err, entry, name }, 'isolated-config: symlink failed') }
+      }
+    }
+
+    // 2. Own settings.json: copy the shared one (keeps hooks etc.) but force
+    //    enabledPlugins to this agent's own provider only (all other channel
+    //    plugins false), matching the spawn-time scope decision.
+    const sharedSettings = join(realClaude, 'settings.json')
+    let settings: Record<string, unknown> = {}
+    if (existsSync(sharedSettings)) {
+      try { settings = JSON.parse(readFileSync(sharedSettings, 'utf-8')) as Record<string, unknown> }
+      catch { settings = {} }
+    }
+    const scopedPlugins = scopeChannelPlugins(
+      providerType,
+      settings.enabledPlugins as Record<string, boolean> | undefined,
+    )
+    settings.enabledPlugins = scopedPlugins
+    writeFileSync(join(cfg, 'settings.json'), JSON.stringify(settings, null, 2) + '\n')
+
+    // 3. Own plugins/ dir: symlink the heavy shared parts, own the install state.
+    const pluginsDir = join(cfg, 'plugins')
+    mkdirSync(pluginsDir, { recursive: true })
+    const sharedPlugins = join(realClaude, 'plugins')
+    for (const sub of ['cache', 'marketplaces', 'data']) {
+      const link = join(pluginsDir, sub)
+      const target = join(sharedPlugins, sub)
+      if (!existsSync(target)) continue
+      let needsLink = true
+      try {
+        if (lstatSync(link).isSymbolicLink()) needsLink = false
+        else rmSync(link, { recursive: true, force: true })
+      } catch { /* absent -> create */ }
+      if (needsLink) {
+        try { symlinkSync(target, link) }
+        catch (err) { logger.warn({ err, sub, name }, 'isolated-config: plugin symlink failed') }
+      }
+    }
+    const sharedKnown = join(sharedPlugins, 'known_marketplaces.json')
+    if (existsSync(sharedKnown)) {
+      writeFileSync(join(pluginsDir, 'known_marketplaces.json'), readFileSync(sharedKnown, 'utf-8'))
+    }
+    // Seed installed_plugins.json with every project-scoped install re-pointed at
+    // THIS agent's cwd, so the channel plugin is registered for this project from
+    // first launch (Claude Code keeps maintaining it thereafter).
+    const sharedInstalled = join(sharedPlugins, 'installed_plugins.json')
+    if (existsSync(sharedInstalled)) {
+      try {
+        const inst = JSON.parse(readFileSync(sharedInstalled, 'utf-8')) as {
+          plugins?: Record<string, Array<{ scope?: string; projectPath?: string }>>
+        }
+        for (const entries of Object.values(inst.plugins ?? {})) {
+          for (const e of entries) {
+            if (e.scope === 'project') e.projectPath = cwd
+          }
+        }
+        writeFileSync(join(pluginsDir, 'installed_plugins.json'), JSON.stringify(inst, null, 2) + '\n')
+      } catch (err) {
+        logger.warn({ err, name }, 'isolated-config: failed to seed installed_plugins.json')
+      }
+    }
+
+    return cfg
+  } catch (err) {
+    logger.warn({ err, name }, 'isolated-config: provisioning failed, falling back to shared ~/.claude')
+    return null
+  }
 }
 
 function resolveAgentProvider(name: string): ChannelProviderType {
@@ -386,7 +541,31 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // e.g. for routing this agent to a separate Anthropic login). When the
     // agent-config field is missing or blank, claudeConfigDir is null and we
     // emit no export, preserving the default Claude Code behavior.
-    const claudeConfigDir = readAgentClaudeConfigDir(name)
+    // An explicit per-agent config dir wins. Otherwise, a channel sub-agent gets
+    // an auto-provisioned isolated config dir so its plugin install cannot collide
+    // with the rest of the fleet in the shared ~/.claude (see
+    // ensureIsolatedChannelConfigDir). The main agent comes up via channels.sh and
+    // keeps the shared root. Isolation is GATED on the fleet OAuth token: the
+    // isolated dir carries no .credentials.json, so without CLAUDE_CODE_OAUTH_TOKEN
+    // the sub-agent would launch logged-out -- so when the token is absent we skip
+    // isolation and keep the shared ~/.claude (the pre-isolation, still-stable
+    // behaviour) rather than break auth.
+    let claudeConfigDir = readAgentClaudeConfigDir(name)
+    let oauthTokenEnv = ''
+    if (!claudeConfigDir && hasChannel && name !== MAIN_AGENT_ID) {
+      if (hasFleetOauthToken()) {
+        const isolated = ensureIsolatedChannelConfigDir(name, agentProvider)
+        if (isolated) {
+          claudeConfigDir = isolated
+          // Read the token at launch via $(cat) so the literal secret never
+          // appears in the JS-built command string or in `ps`. The file is 0600
+          // and the value lands only in this process's own environment.
+          oauthTokenEnv = `export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')" && `
+        }
+      } else {
+        logger.warn({ name }, 'isolated-config: no fleet OAuth token (store/.claude-oauth-token); keeping shared ~/.claude. Run `claude setup-token` and store it to enable per-agent isolation.')
+      }
+    }
     const claudeConfigEnv = claudeConfigDir ? `export CLAUDE_CONFIG_DIR="${claudeConfigDir}" && ` : ''
     // `--continue` requires an existing session; on a brand-new agent the
     // Claude Code projects directory does not yet exist and `claude` exits
@@ -447,7 +626,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     const promptSuggestionEnv = 'export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && '
     // Single-quote `${model}` so values like `claude-opus-4-8[1m]` (1M-context
     // suffix) are not glob-expanded by the shell that tmux spawns the command in.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
     runTmux(null, ['new-session', '-d', '-s', session, cmd], { timeout: 10000 })
 
     logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')


### PR DESCRIPTION
Reworks #459 to address @Szotasz's review. The fragile part — symlinking .credentials.json into each isolated config dir — is removed: on Linux/Windows the atomic temp+rename token refresh replaces the symlink with a standalone file, the isolated agent's creds diverge, and single-use OAuth refresh tokens race across dirs and break the shared login (claude-code #27933, #24317, #43392).

Instead the launcher passes a long-lived CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`) via env. With that var set, Claude Code authenticates from it and writes NO .credentials.json into the config dir — nothing to diverge, no refresh race. Verified locally: an isolated empty CLAUDE_CONFIG_DIR with only the token authenticates (exit 0) and materialises no creds file; the apiKeyHelper path is rejected ("Invalid API key") since a subscription OAuth token is not an API key.

Token lives 0600 in store/.claude-oauth-token (gitignored, flagged sensitive), read at spawn via $(cat) so it never hits the command string or ps. Isolation is gated on the token: absent → keep the shared ~/.claude (pre-isolation, stable). Tests: 1412 pass; tsc + build clean.