### PR TITLE
fix(channel-monitor): 3 watchdog bugs causing infinite restart flapping

### DIFF
--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -75,7 +75,50 @@ const agentLastRestart: Map<string, number> = new Map()
 // launch (e.g. a broken third-party channel plugin) is not restarted on a fixed
 // short cadence forever -- which restarts the WHOLE agent every few minutes and
 // renders it unusable. Reset to 0 the moment the plugin is seen alive again.
+// Persisted to disk so a dashboard process restart does not reset the counter and
+// restart a channel plugin that has already been given up on (bug: dashboard PID
+// bounce wiped in-memory counters, restarting agents indefinitely on every boot).
 const agentRestartFailures: Map<string, number> = new Map()
+let agentRestartFailuresInitialized = false
+
+function agentFailuresPath(agentName: string): string {
+  return join(PROJECT_ROOT, 'store', `.agent-failures-${agentName}`)
+}
+
+function loadPersistedAgentFailures(agentName: string): number {
+  try {
+    const n = parseInt(readFileSync(agentFailuresPath(agentName), 'utf-8').trim(), 10)
+    return Number.isFinite(n) && n >= 0 ? n : 0
+  } catch {
+    return 0
+  }
+}
+
+function savePersistedAgentFailures(agentName: string, count: number): void {
+  try {
+    writeFileSync(agentFailuresPath(agentName), String(count))
+  } catch (err) {
+    logger.debug({ err, agentName }, 'Failed to persist agent restart failures (non-fatal)')
+  }
+}
+
+function clearPersistedAgentFailures(agentName: string): void {
+  try {
+    writeFileSync(agentFailuresPath(agentName), '0')
+  } catch { /* best effort */ }
+}
+
+function ensureAgentRestartFailuresInitialized(): void {
+  if (agentRestartFailuresInitialized) return
+  agentRestartFailuresInitialized = true
+  for (const a of listAgentNames()) {
+    const persisted = loadPersistedAgentFailures(a)
+    if (persisted > 0) {
+      agentRestartFailures.set(a, persisted)
+      logger.info({ agent: a, failures: persisted }, 'channel-monitor: restored persisted restart failure count from disk')
+    }
+  }
+}
 // Global stagger for channel-down restarts. On Claude Code 2.1.193 a sub-agent's
 // --channels plugin only LOADS on a fresh (no --continue) launch, and several
 // such cold-boots at once race on the shared plugin cache so NONE attach a
@@ -738,8 +781,12 @@ function schedulePostResumePluginGuard(provider: ChannelProviderType): void {
 }
 
 export function hardRestartMarveenChannels(): { ok: boolean; error?: string } {
-  // macOS: bounce the launchd job (its own process group -- safe).
-  if (process.platform !== 'linux') {
+  // macOS: bounce the launchd job when the plist exists. If the channels session
+  // is NOT managed by launchd on this install (plist absent -- only
+  // com.jarvis.dashboard exists), fall through to the respawn-pane path below.
+  // The previous unconditional launchctl call was a silent no-op: launchctl
+  // accepts a non-existent plist with exit 0, leaving the session untouched.
+  if (process.platform !== 'linux' && existsSync(MAIN_CHANNELS_PLIST)) {
     try {
       execFileSync('/bin/launchctl', ['unload', MAIN_CHANNELS_PLIST], { timeout: 5000 })
       execFileSync('/bin/sleep', ['2'], { timeout: 4000 })
@@ -752,6 +799,10 @@ export function hardRestartMarveenChannels(): { ok: boolean; error?: string } {
       logger.error({ err }, 'Hard restart failed (launchctl)')
       return { ok: false, error: err instanceof Error ? err.message : String(err) }
     }
+  }
+
+  if (process.platform !== 'linux') {
+    logger.warn({ plist: MAIN_CHANNELS_PLIST }, 'Hard restart: launchd channels plist absent -- falling back to respawn-pane')
   }
 
   // Linux: respawn-pane ONLY -- NEVER `systemctl --user restart`. The channels
@@ -1114,6 +1165,10 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
   const mainProvider = getMainAgentProvider()
 
   function check() {
+    // Restore persisted failure counts on first tick so a dashboard restart
+    // does not reset the cap and restart agents that have already been given up on.
+    ensureAgentRestartFailuresInitialized()
+
     type Target = { session: string; isMarveen: boolean; agentName?: string; provider: ChannelProviderType }
     const targets: Target[] = [{ session: MAIN_CHANNELS_SESSION, isMarveen: true, provider: mainProvider }]
     for (const a of listAgentNames()) {
@@ -1253,6 +1308,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // Healthy observation clears the exponential back-off so the next
           // down-spell starts again at the base grace.
           agentRestartFailures.delete(t.agentName!)
+          clearPersistedAgentFailures(t.agentName!)
         }
         continue
       }
@@ -1283,6 +1339,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           logger.error({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down after max restart attempts -- giving up, alerting operator')
           sendAlert(`⛔ A(z) ${t.agentName} agens ${t.provider} csatornaja ${AGENT_MAX_RESTART_ATTEMPTS} automatikus ujrainditas utan sem allt helyre. Tovabb nem indinitom ujra (minden restart elveszi a session kontextusat). Kezi beavatkozas kell: nezd meg a ${t.session} session-t es a ${SERVICE_ID} csatorna-plugint.`)
           agentRestartFailures.set(t.agentName!, failures + 1)
+          savePersistedAgentFailures(t.agentName!, failures + 1)
           agentDownSince.delete(t.session)
           continue
         }
@@ -1314,7 +1371,9 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // Count this restart as failed until a later sweep sees the plugin
           // alive (which resets the counter). Repeated failures back off the
           // next restart exponentially instead of churning every base-grace.
+          // Persisted to disk so a dashboard restart does not reset the counter.
           agentRestartFailures.set(t.agentName!, failures + 1)
+          savePersistedAgentFailures(t.agentName!, failures + 1)
         } catch (err) {
           logger.error({ err, agent: t.agentName }, 'Failed to auto-restart agent after channel plugin down')
         }

--- a/src/web/channel-plugin-unlock.ts
+++ b/src/web/channel-plugin-unlock.ts
@@ -125,12 +125,37 @@ function isSessionReadyForUnlock(session: string): boolean {
   }
 }
 
-function sendUnlockKeystrokes(session: string): void {
+function sendUnlockKeystrokes(session: string, provider: ChannelProviderType): void {
   try {
     // Open the MCP dialog. Claude renders the server list within ~2s; the
     // 3s settle ensures the cursor is on the first item before we move.
     execFileSync(TMUX, ['send-keys', '-t', session, '/mcp', 'Enter'], { timeout: 5000 })
     execFileSync('/bin/sleep', [String(MCP_OPEN_SETTLE_MS / 1000)], { timeout: MCP_OPEN_SETTLE_MS + 2000 })
+
+    // Safety gate: check whether the channel plugin appears in the /mcp list
+    // before navigating to it. When the CC regression prevents the plugin from
+    // loading at all, the list only shows google-workspace / spotify / computer-use
+    // -- the Up key would select the wrong entry and Enable/Reconnect an unrelated
+    // MCP server. If the provider slug is absent, bail out with Escape.
+    let paneAfterOpen = ''
+    try {
+      paneAfterOpen = execFileSync(TMUX, ['capture-pane', '-t', session, '-p'], {
+        timeout: 3000,
+        encoding: 'utf-8',
+      })
+    } catch (err) {
+      logger.warn({ err, session }, 'channel-plugin-unlock: capture-pane after /mcp open failed -- aborting')
+      try { execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 5000 }) } catch { /* ignore */ }
+      return
+    }
+    if (!paneAfterOpen.includes(provider)) {
+      // Plugin is not in the MCP list (never loaded, not Failed/disabled) --
+      // the unlock sequence cannot help and would target the wrong entry.
+      logger.warn({ session, provider }, 'channel-plugin-unlock: provider plugin absent from /mcp list -- skipping unlock (plugin never loaded, not recoverable via /mcp)')
+      try { execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 5000 }) } catch { /* ignore */ }
+      return
+    }
+
     // Up wraps to the bottom of the list, where the plugin servers live
     // (claude lists them last). Built-in MCPs are above Plugin MCPs in the
     // sort order, so the bottommost entry is the channel plugin we want.
@@ -200,7 +225,7 @@ function runUnlockProbe(state: UnlockProbeState): void {
     { session: state.session, claudePid, provider: state.provider },
     'channel-plugin-unlock: bun child absent after cold-start window, firing /mcp unlock sequence',
   )
-  sendUnlockKeystrokes(state.session)
+  sendUnlockKeystrokes(state.session, state.provider)
 }
 
 /**


### PR DESCRIPTION
Bug #1 (hardRestartMarveenChannels): macOS launchctl path was a silent no-op because the channels launchd plist does not exist on installs that use a different service label (only the dashboard plist is present). Added existsSync guard; falls through to respawnMarveenSessionFresh() when the plist is absent.

Bug #2 (channel-plugin-unlock): /mcp+Up+Enter+Enter fired even when the channel plugin never loaded into /mcp at all (CC 2.1.195 regression), causing the Up key to land on an unrelated MCP server (google-workspace, spotify, computer-use) and potentially disable it. Added pane capture after /mcp opens: if the provider string is absent, bail with Escape.

Bug #3 (agentRestartFailures): in-memory failure counter was wiped on every dashboard process restart, restarting agents indefinitely across boot cycles (observed: 3 different dashboard PIDs each looping to 5 restarts before dying, then starting fresh). Fix: persist the counter to store/.agent-failures-<name> so a new dashboard process restores the cap and goes straight to alert+skip instead of restarting from 0.

This change was authored with AI assistance, reviewed by the maintainer before submission.
