### PR TITLE
feat(channels): Teams as a sub-agent channel provider (teams-only, live-validated)

### DIFF
--- a/src/channel-coordinator/provider-poller-match.ts
+++ b/src/channel-coordinator/provider-poller-match.ts
@@ -51,6 +51,7 @@ const SLUG_RX: Record<ChannelProviderType, RegExp> = {
   slack: /\/slack(?:-channel)?(?:\/|\s|$)/,
   discord: /\/discord(?:\/|\s|$)/,
   googlechat: /\/googlechat(?:\/|\s|$)/,
+  teams: /\/teams(?:\/|\s|$)/,
 }
 
 // Slack-specific behavior-preserving fallback. The pre-fix cross-tree scan

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -5,7 +5,7 @@ import { homedir } from 'node:os'
 import { logger } from './logger.js'
 import { formatForTelegram, splitMessage } from './format.js'
 
-export type ChannelProviderType = 'telegram' | 'slack' | 'discord' | 'googlechat'
+export type ChannelProviderType = 'telegram' | 'slack' | 'discord' | 'googlechat' | 'teams'
 
 export interface ChannelProvider {
   readonly type: ChannelProviderType
@@ -348,6 +348,47 @@ const googlechatProvider: ChannelProvider = {
   splitMessage: (text) => splitMessage(text, GOOGLECHAT_MAX_MESSAGE_LENGTH),
 }
 
+// -- Microsoft Teams implementation --
+//
+// Teams (Azure Bot Service) has no single bot token: the channel plugin
+// authenticates with an app id + client secret + tenant id (TEAMS_BOT_*) and
+// receives Activities over an inbound webhook (JWT-validated). So the
+// token-based dashboard helpers below are minimal -- actual delivery happens
+// through the plugin's MCP tools, not these direct-send methods (same shape as
+// the Google Chat stub). "Configured" is detected via TEAMS_BOT_APP_ID in the
+// agent's channel .env (see readChannelToken), standing in for the token.
+
+const TEAMS_MAX_MESSAGE_LENGTH = 28000
+
+const teamsProvider: ChannelProvider = {
+  type: 'teams',
+  pluginId: 'teams@marveen-marketplace',
+  pluginPaneId: 'plugin:teams:marveen-marketplace',
+  envKeys: ['TEAMS_BOT_APP_ID', 'TEAMS_BOT_APP_PASSWORD', 'TEAMS_BOT_TENANT_ID'],
+  stateDir: 'teams',
+  chatIdFormat: 'Teams conversation id (managed by the plugin per pairing)',
+
+  async sendMessage() {
+    // Direct dashboard send is not supported for Teams; the agent delivers via
+    // the plugin's reply tool inside its own session (Bot Framework outbound
+    // needs the per-conversation serviceUrl + a client_credentials token).
+    throw new Error('teams: direct dashboard send not supported (delivery via plugin MCP tools)')
+  },
+
+  async sendPhoto() {
+    throw new Error('teams: direct dashboard send not supported (delivery via plugin MCP tools)')
+  },
+
+  async validateToken() {
+    // No simple token model; real validation happens in the plugin (app id +
+    // secret + tenant, JWT). Report ok so channel-config flows don't false-negative.
+    return { ok: true, botName: 'Microsoft Teams' }
+  },
+
+  formatMessage: (text) => text,
+  splitMessage: (text) => splitMessage(text, TEAMS_MAX_MESSAGE_LENGTH),
+}
+
 // -- Slack App manifest --
 
 const SLACK_BOT_SCOPES = [
@@ -418,6 +459,7 @@ export function getChannelToken(provider: ChannelProviderType, env: Record<strin
   if (provider === 'slack') return env['SLACK_BOT_TOKEN'] ?? ''
   if (provider === 'discord') return env['DISCORD_BOT_TOKEN'] ?? ''
   if (provider === 'googlechat') return env['GOOGLECHAT_PROJECT_ID'] ?? ''
+  if (provider === 'teams') return env['TEAMS_BOT_APP_ID'] ?? ''
   return env['TELEGRAM_BOT_TOKEN'] ?? ''
 }
 
@@ -425,6 +467,7 @@ export function getChannelChatId(provider: ChannelProviderType, env: Record<stri
   if (provider === 'slack') return env['SLACK_CHANNEL_ID'] ?? ''
   if (provider === 'discord') return env['DISCORD_CHANNEL_ID'] ?? ''
   if (provider === 'googlechat') return env['GOOGLECHAT_SPACE_ID'] ?? ''
+  if (provider === 'teams') return env['TEAMS_ALLOWED_CONVERSATION_ID'] ?? ''
   return env['ALLOWED_CHAT_ID'] ?? ''
 }
 
@@ -435,6 +478,7 @@ const providers: Record<ChannelProviderType, ChannelProvider> = {
   slack: slackProvider,
   discord: discordProvider,
   googlechat: googlechatProvider,
+  teams: teamsProvider,
 }
 
 export function getProvider(type: ChannelProviderType): ChannelProvider {
@@ -445,6 +489,7 @@ export function getProviderType(envValue: string | undefined): ChannelProviderTy
   if (envValue === 'slack') return 'slack'
   if (envValue === 'discord') return 'discord'
   if (envValue === 'googlechat') return 'googlechat'
+  if (envValue === 'teams') return 'teams'
   return 'telegram'
 }
 
@@ -456,6 +501,7 @@ export function channelStateDir(provider: ChannelProviderType, agentDir?: string
     provider === 'slack' ? 'slack'
     : provider === 'discord' ? 'discord'
     : provider === 'googlechat' ? 'googlechat'
+    : provider === 'teams' ? 'teams'
     : 'telegram'
   return join(base, subdir)
 }
@@ -474,6 +520,7 @@ export function readChannelToken(provider: ChannelProviderType, envFilePath: str
     provider === 'slack' ? 'SLACK_BOT_TOKEN'
     : provider === 'discord' ? 'DISCORD_BOT_TOKEN'
     : provider === 'googlechat' ? 'GOOGLECHAT_PROJECT_ID'
+    : provider === 'teams' ? 'TEAMS_BOT_APP_ID'
     : 'TELEGRAM_BOT_TOKEN'
   const match = content.match(new RegExp(`${key}=(.+)`))
   return match ? match[1].trim() : null

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -49,6 +49,7 @@ export const CHANNEL_PLUGIN_IDS: Record<string, string> = {
   slack: 'slack-channel@marveen-marketplace',
   discord: 'discord@claude-plugins-official',
   googlechat: 'googlechat@claude-channel-googlechat',
+  teams: 'teams@marveen-marketplace',
 }
 
 // Pure: compute the enabledPlugins map for a sub-agent so that exactly its own
@@ -97,7 +98,7 @@ export function ownChannelProviderForScope(
 
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
-  if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord' || perAgent === 'googlechat') return perAgent
+  if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord' || perAgent === 'googlechat' || perAgent === 'teams') return perAgent
   return CHANNEL_PROVIDER
 }
 
@@ -411,7 +412,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // price of a reachable bot (file/db memory persists either way). Channel-
     // less agents keep --continue to preserve their accumulated context.
     const continueFlag = (hasPriorSession && !opts.fresh && !hasChannel) ? '--continue ' : ''
-    const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : agentProvider === 'googlechat' ? 'GOOGLECHAT_STATE_DIR' : 'TELEGRAM_STATE_DIR'
+    const stateEnvVar = agentProvider === 'slack' ? 'SLACK_STATE_DIR' : agentProvider === 'discord' ? 'DISCORD_STATE_DIR' : agentProvider === 'googlechat' ? 'GOOGLECHAT_STATE_DIR' : agentProvider === 'teams' ? 'TEAMS_STATE_DIR' : 'TELEGRAM_STATE_DIR'
     const unsetTokens = 'unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN'
     // Slack plugin is third-party; its "not on approved allowlist" check is
     // bypassed via `allowedChannelPlugins` in /Library/Application Support/ClaudeCode/managed-settings.json.

--- a/src/web/channel-poller-reap.ts
+++ b/src/web/channel-poller-reap.ts
@@ -34,6 +34,7 @@ const STATE_ENV_VAR: Record<ChannelProviderType, string> = {
   slack: 'SLACK_STATE_DIR',
   discord: 'DISCORD_STATE_DIR',
   googlechat: 'GOOGLECHAT_STATE_DIR',
+  teams: 'TEAMS_STATE_DIR',
 }
 
 // Parse `ps eww -e` output and return every PID whose process environment

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -110,7 +110,7 @@ import { suggestForAgent, type AgentSignals } from '../model-suggest.js'
 import { getTokenSummary } from '../token-usage.js'
 import { listScheduledTasks } from '../scheduled-tasks-io.js'
 
-const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord', 'googlechat'])
+const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord', 'googlechat', 'teams'])
 
 // Short-TTL caches so the synchronous, frequently-polled status endpoints
 // (`/api/agents` on load, `/api/agents/activity` every 3s) don't issue a fresh
@@ -147,7 +147,7 @@ function parseChannelProvider(raw: string): ChannelProviderType | null {
 // Match both new /channels/:provider/ and legacy /telegram/ URL patterns.
 // Returns [agentName, provider] or null. Legacy routes always resolve to 'telegram'.
 function matchChannelRoute(path: string, suffix: string): [string, ChannelProviderType] | null {
-  const newPattern = new RegExp(`^/api/agents/([^/]+)/channels/(telegram|slack|discord|googlechat)${suffix}$`)
+  const newPattern = new RegExp(`^/api/agents/([^/]+)/channels/(telegram|slack|discord|googlechat|teams)${suffix}$`)
   const newMatch = path.match(newPattern)
   if (newMatch) {
     const provider = parseChannelProvider(newMatch[2])
@@ -229,6 +229,7 @@ export function setAgentEnabledPlugins(name: string, provider: ChannelProviderTy
     slack: 'slack-channel@marveen-marketplace',
     discord: 'discord@claude-plugins-official',
     googlechat: 'googlechat@claude-channel-googlechat',
+    teams: 'teams@marveen-marketplace',
   }
   for (const [p, pluginKey] of Object.entries(allPlugins)) {
     plugins[pluginKey] = p === provider


### PR DESCRIPTION
Teams-only split of #484 (which mixed in an unrelated clinic reauth commit). This PR is **a50d412 only** — the Teams sub-agent channel provider.

## Mit csinál
A `teams` providert beköti a **sub-agent** channel-path-ba (`channel-provider.ts` + `agent-process.ts`). A #478 csak a main `channels.sh`-t wire-olta; ez a sub-agent megfelelője, így egy sub-agent (pl. a Teamer teszt-agent) futtathatja a Teams-csatornát. A `googlechat` stub-provider mintájára (delivery a plugin MCP reply-tool, dashboard direct-send throw; "configured" = `TEAMS_BOT_APP_ID`).

Érintett (5 fájl, tisztán additív): `channel-provider.ts`, `agent-process.ts`, `provider-poller-match.ts`, `channel-poller-reap.ts`, `routes/agents.ts`.

## Validáció
Élesben validálva a Teamer sub-agenten (2026-06-29): valódi Teams-DM → fogadás → reply → outbound tiszta. `npx tsc --noEmit` zöld develop-on. Zéró regresszió (telegram/slack/discord/googlechat változatlan).

NB: a clinic BUG#1.3 reauth-headless-guard (5cd111a) NINCS ebben a PR-ben — az külön clinic-workstream PR-be megy (külön review/verify/dedup a #479-cel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)