### PR TITLE
fix(reauth): suppress autonomous /login on headless hosts (auth-cascade guard, BUG#1.3)

### DIFF
--- a/src/__tests__/reauth-healer.test.ts
+++ b/src/__tests__/reauth-healer.test.ts
@@ -6,6 +6,7 @@ const base = (over: Partial<Parameters<typeof decideReauthAction>[0]> = {}) => (
   isDeadToken: true,
   sessionAlive: true,
   isMain: false,
+  canInteractiveLogin: true,
   prev: NO_REAUTH_STATE,
   nowMs: 1_000_000,
   ...over,
@@ -46,6 +47,14 @@ describe('decideReauthAction', () => {
 
   it('main agent at threshold escalates but does NOT send-keys', () => {
     const d = decideReauthAction(base({ isMain: true, prev: { consecutiveDead: 2, lastActionAtMs: null } }), T)
+    expect(d.escalate).toBe(true)
+    expect(d.sendKeys).toBe(false)
+  })
+
+  it('headless host at threshold escalates but does NOT send-keys (cascade guard)', () => {
+    // A headless Linux fleet host: /login would fail AND rotate the shared OAuth
+    // token into a fleet-wide 401 cascade, so escalate-only even for a sub-agent.
+    const d = decideReauthAction(base({ canInteractiveLogin: false, prev: { consecutiveDead: 2, lastActionAtMs: null } }), T)
     expect(d.escalate).toBe(true)
     expect(d.sendKeys).toBe(false)
   })

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -45,6 +45,14 @@ export interface ReauthHealerInput {
   isDeadToken: boolean
   sessionAlive: boolean
   isMain: boolean
+  /**
+   * Whether this host can actually complete an interactive /login (a browser
+   * authorize step). FALSE on a headless Linux box: there a /login send-keys can
+   * never finish AND it rotates the SHARED single-use OAuth refresh token, which
+   * kicks every other fleet process into 401 -- the auth cascade. So on headless
+   * we escalate-only and never inject /login.
+   */
+  canInteractiveLogin: boolean
   prev: ReauthHealerState
   nowMs: number
 }
@@ -70,7 +78,7 @@ export const NO_REAUTH_STATE: ReauthHealerState = { consecutiveDead: 0, lastActi
  * into the session every tick) and never fires for the main agent.
  */
 export function decideReauthAction(input: ReauthHealerInput, t: ReauthHealerThresholds): ReauthHealerDecision {
-  const { isDeadToken, sessionAlive, isMain, prev, nowMs } = input
+  const { isDeadToken, sessionAlive, isMain, canInteractiveLogin, prev, nowMs } = input
 
   // Clean / not-applicable: end the spell, allow a fresh alert next time.
   if (!isDeadToken || !sessionAlive) {
@@ -83,13 +91,25 @@ export function decideReauthAction(input: ReauthHealerInput, t: ReauthHealerThre
   const fireNow = atThreshold && cooldownElapsed
 
   return {
-    sendKeys: fireNow && !isMain,
+    // Autonomous /login only where it can actually help: a sub-agent, at a host
+    // that can complete the browser step. On headless it would amplify the
+    // cascade (rotates the shared token), so suppress it and escalate-only.
+    sendKeys: fireNow && !isMain && canInteractiveLogin,
     escalate: fireNow,
     next: {
       consecutiveDead,
       lastActionAtMs: fireNow ? nowMs : prev.lastActionAtMs,
     },
   }
+}
+
+// True when this host can complete an interactive browser /login. macOS dev
+// hosts can; a headless Linux fleet host (no display server) cannot -- and there
+// a /login both fails AND rotates the shared OAuth token into a fleet-wide 401
+// cascade, so we escalate-only instead (BUG #1.3 from the isapp06 report).
+function hostCanInteractiveLogin(): boolean {
+  if (process.platform === 'darwin') return true
+  return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY)
 }
 
 const watchState = new Map<string, ReauthHealerState>()
@@ -128,7 +148,7 @@ function checkSession(label: string, session: string, isMain: boolean): void {
   const prev = watchState.get(session) ?? NO_REAUTH_STATE
 
   const decision = decideReauthAction(
-    { isDeadToken: reauth.needsReauth, sessionAlive, isMain, prev, nowMs: Date.now() },
+    { isDeadToken: reauth.needsReauth, sessionAlive, isMain, canInteractiveLogin: hostCanInteractiveLogin(), prev, nowMs: Date.now() },
     { threshold: DEAD_PROBE_THRESHOLD, cooldownMs: ESCALATION_COOLDOWN_MS },
   )
 


### PR DESCRIPTION
Clinic auth-cascade BUG#1.3. Split out of the now-closed #484 (which mixed it with the Teams provider; Teams went separately as #485).

## Mit csinál
A reauth-healer autonóm `/login` send-keys-ét elnyomja **headless hostokon** (`canInteractiveLogin=false`): ott a `/login` (a) sosem fejeződik be (nincs böngésző), és (b) rotálja a MEGOSZTOTT single-use OAuth refresh-tokent → fleet-wide 401 cascade. Headless-en escalate-only. macOS-en (`hostCanInteractiveLogin()=true`) változatlan a viselkedés.

Érintett: `src/web/reauth-healer.ts` + `src/__tests__/reauth-healer.test.ts` (+1 teszt). Tisztán additív (új `canInteractiveLogin` mező a döntésbe).

## Megjegyzés
A #479 (per-agent isolated config) MÁR develop-on van; a dedup megerősítette: ez a reauth-guard KÜLÖN concern (nincs fájl-átfedés). A develop->main release-promote a Linux clinic-host (isapp06) + Szabi auth-verify-t igényli ELŐSZÖR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)