### PR TITLE
chore: gitignore SOUL.md (per-operator agent persona)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ test-results/
 # Generated from template (personal config)
 CLAUDE.md
 
+# Agent persona / soul (per-operator personality; never ship upstream)
+SOUL.md
+
 # Custom MCP servers and config (user-specific)
 mcp-servers/
 .mcp.json


### PR DESCRIPTION
`SOUL.md` holds the operator's agent persona -- the analogue of the already-ignored `CLAUDE.md` (generated personal config). Ignoring it keeps a local persona file from being committed by accident (e.g. `git add -A`) on contributor machines.

One line, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)