### PR TITLE
feat(install): allow Teams in managed-settings at install time (sudo-elimination)

### DIFF
--- a/install-lang.sh
+++ b/install-lang.sh
@@ -133,8 +133,8 @@ _t() {
     hu:macos.managed_update) echo "  A managed-settings.json frissítése szükséges (sudo)." ;;
     en:macos.managed_updated) echo "  managed-settings.json updated" ;;
     hu:macos.managed_updated) echo "  managed-settings.json frissítve" ;;
-    en:macos.managed_has_slack) echo "  managed-settings.json already contains the Slack plugin" ;;
-    hu:macos.managed_has_slack) echo "  managed-settings.json mar tartalmazza a Slack plugint" ;;
+    en:macos.managed_has_slack) echo "  managed-settings.json already contains the channel plugins" ;;
+    hu:macos.managed_has_slack) echo "  managed-settings.json mar tartalmazza a csatorna-pluginokat" ;;
     en:macos.managed_create) echo "  Managed settings creation required (sudo)." ;;
     hu:macos.managed_create) echo "  Managed settings létrehozása szükséges (sudo)." ;;
     en:macos.managed_created) echo "  managed-settings.json created" ;;

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -300,18 +300,26 @@ else
   MANAGED_FILE="$MANAGED_DIR/managed-settings.json"
   SLACK_ENTRY='{"plugin":"slack-channel","marketplace":"marveen-marketplace"}'
   TELEGRAM_ENTRY='{"plugin":"telegram","marketplace":"claude-plugins-official"}'
-  REQUIRED_JSON="{\"allowedChannelPlugins\":[$SLACK_ENTRY,$TELEGRAM_ENTRY]}"
+  TEAMS_ENTRY='{"plugin":"teams","marketplace":"marveen-marketplace"}'
+  REQUIRED_JSON="{\"allowedChannelPlugins\":[$SLACK_ENTRY,$TELEGRAM_ENTRY,$TEAMS_ENTRY]}"
 
   if [ -f "$MANAGED_FILE" ]; then
-    HAS_SLACK=$(sudo python3 -c "
+    # Gate on ALL required plugins being present (not just slack) -- otherwise an
+    # install that already has slack/telegram but not teams skips the merge and
+    # the Teams bot is silently dropped (online but never replies). This is the
+    # per-customer sudo-elimination: the installer (already sudo) allows teams
+    # at install time, so no manual managed-settings edit is needed later.
+    HAS_ALL=$(sudo python3 -c "
 import json, sys
+required = [('slack-channel','marveen-marketplace'),('telegram','claude-plugins-official'),('teams','marveen-marketplace')]
 try:
   d = json.load(open('$MANAGED_FILE'))
   plugins = d.get('allowedChannelPlugins', [])
-  sys.exit(0 if any(p.get('plugin')=='slack-channel' and p.get('marketplace')=='marveen-marketplace' for p in plugins) else 1)
+  have = {(p.get('plugin'),p.get('marketplace')) for p in plugins}
+  sys.exit(0 if all(r in have for r in required) else 1)
 except: sys.exit(1)
 " 2>/dev/null && echo "yes" || echo "no")
-    if [ "$HAS_SLACK" = "no" ]; then
+    if [ "$HAS_ALL" = "no" ]; then
       echo -e "  ${ORANGE}⚠${NC} $(_t macos.managed_update)"
       echo "$REQUIRED_JSON" | sudo python3 -c "
 import json, sys


### PR DESCRIPTION
Card #3 of the Teams productization (Szabi-priority). Eliminates the per-customer manual sudo for the Teams silent-drop gate.

## Change (install-macos.sh)
The macOS installer already merges slack/telegram into `managed-settings.json` `allowedChannelPlugins` (with sudo, at install time). Add `teams`:
- `TEAMS_ENTRY` in `REQUIRED_JSON` (the existing merge is idempotent — appends only missing).
- The "already configured" gate now checks **all** required plugins (slack + telegram + teams), not just slack — otherwise an install that has slack but not teams would skip the merge and the Teams bot would be silently dropped (online, never replies).
- `managed_has_slack` string generalized to "channel plugins".

## Validation
- `bash -n` clean (install-macos.sh + install-lang.sh).
- Isolated dry-run of the gate+merge: existing slack+telegram → gate False → merge appends teams (no dup); all-present → gate True → skip (no sudo rewrite).

## Known gap (separate)
The Linux + Windows installers do **not** manage managed-settings at all (Linux uses `/etc/claude-code/managed-settings.json`). Out of scope here; Linux path is host-gated (clinic) anyway. Flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)