### PR TITLE
feat(agents): auto-sync TEAMS_BOT_DISPLAY_NAME from displayName (name-sync companion)

### DIFF
--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -427,6 +427,26 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // Channel-less agents (inter-agent only, no direct Telegram/Slack) are allowed to start
   }
 
+  // Teams name-sync (companion to make-teams-manifest.sh): keep
+  // TEAMS_BOT_DISPLAY_NAME in the agent's teams .env equal to the agent's
+  // displayName, so the generated Teams manifest names the bot after the agent
+  // (not the generic fallback). Idempotent; writes only on drift, non-fatal.
+  if (agentProvider === 'teams' && hasChannel) {
+    try {
+      const envPath = join(agentChannelDir, '.env')
+      const displayName = readAgentDisplayName(name)
+      const raw = existsSync(envPath) ? readFileSync(envPath, 'utf-8') : ''
+      const current = raw.match(/^TEAMS_BOT_DISPLAY_NAME=(.*)$/m)?.[1]?.trim()
+      if (displayName && current !== displayName) {
+        const line = `TEAMS_BOT_DISPLAY_NAME=${displayName}`
+        const next = current !== undefined
+          ? raw.replace(/^TEAMS_BOT_DISPLAY_NAME=.*$/m, line)
+          : (raw === '' || raw.endsWith('\n') ? raw + line + '\n' : raw + '\n' + line + '\n')
+        writeFileSync(envPath, next)
+      }
+    } catch { /* best-effort name-sync; never block launch */ }
+  }
+
   const session = agentSessionName(name)
 
   try {


### PR DESCRIPTION
Fleet companion to the make-teams-manifest.sh name-sync (fork PR #1, merged). Makes the per-agent Teams name fully automatic.

## Change (agent-process.ts)
At launch of a teams sub-agent, ensure `TEAMS_BOT_DISPLAY_NAME=<displayName>` in the agent's teams `.env` (idempotent — writes only on drift, wrapped in try/catch so it never blocks launch). So `make-teams-manifest.sh` (which defaults `--name` from that env) names the Teams bot after the agent, with no manual `.env` edit.

## Validation
- `npx tsc --noEmit` clean.
- Logic dry-run: no key → append; existing different → replace; already correct → no-op (idempotent).

## ⚠️ Merge order
**Depends on #485** (the teams `ChannelProviderType` / sub-agent provider — `agentProvider === 'teams'` needs that type). This branch is based on #485 so it compiles. **Merge #485 first**, then this; after #485 lands in develop the net diff here is just the agent-process.ts block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)