### PR TITLE
fix(agents): seed onboarding/consent state in isolated CLAUDE_CONFIG_…

### DIFF
--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -244,6 +244,43 @@ export function ensureIsolatedChannelConfigDir(
       }
     }
 
+    // 4. Seed onboarding/consent state so the FIRST interactive launch of this
+    //    fresh CLAUDE_CONFIG_DIR does not drop into Claude Code's first-run
+    //    dialogs. A brand-new config dir triggers a CHAIN of interactive prompts
+    //    -- "Select login method" (gated on hasCompletedOnboarding) and the
+    //    per-project "allow external imports" trust dialog (gated on
+    //    projects[cwd].hasTrustDialogAccepted) -- each of which blocks the
+    //    channels TUI before it ever authenticates from CLAUDE_CODE_OAUTH_TOKEN
+    //    (the env token works headlessly but the interactive pickers bypass it).
+    //    Rather than enumerate every flag (the set grows across Claude Code
+    //    versions; confirmed on 2.1.195, 2026-06-29 fleet rollout), seed the
+    //    isolated .claude.json from a COPY of the already-consented shared
+    //    ~/.claude.json on first provision, so every consent flag is inherited.
+    //    Only seed when absent -- once Claude Code owns the file we leave its
+    //    evolved state alone, just guaranteeing hasCompletedOnboarding stays set.
+    try {
+      const dotClaude = join(cfg, '.claude.json')
+      const sharedDot = join(homedir(), '.claude.json')
+      if (!existsSync(dotClaude)) {
+        let seed: Record<string, unknown> = { hasCompletedOnboarding: true }
+        if (existsSync(sharedDot)) {
+          try { seed = JSON.parse(readFileSync(sharedDot, 'utf-8')) as Record<string, unknown> } catch { /* keep minimal */ }
+        }
+        seed.hasCompletedOnboarding = true
+        writeFileSync(dotClaude, JSON.stringify(seed, null, 2) + '\n')
+      } else {
+        try {
+          const cur = JSON.parse(readFileSync(dotClaude, 'utf-8')) as Record<string, unknown>
+          if (cur.hasCompletedOnboarding !== true) {
+            cur.hasCompletedOnboarding = true
+            writeFileSync(dotClaude, JSON.stringify(cur, null, 2) + '\n')
+          }
+        } catch { /* unparseable -> leave for Claude Code to recreate */ }
+      }
+    } catch (err) {
+      logger.warn({ err, name }, 'isolated-config: failed to seed onboarding state')
+    }
+
     return cfg
   } catch (err) {
     logger.warn({ err, name }, 'isolated-config: provisioning failed, falling back to shared ~/.claude')


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

HU: A #479 per-agent izolált CLAUDE_CONFIG_DIR headless módban működik, de minden FRISS izolált config-dir első interaktív `--channels` indítása beleesik a Claude Code first-run dialógusláncába ("Select login method", majd a per-project "allow external imports" trust dialógus), ami blokkolja a channels TUI-t MIELŐTT a `CLAUDE_CODE_OAUTH_TOKEN`-ból bejelentkezne. Az env-token érvényes (headless `claude -p`-vel igazolható), csak az interaktív picker megkerüli, így a sub-ágens "Select login method"-nál ragad és nem spawnol pollert. Megoldás: az `ensureIsolatedChannelConfigDir` az izolált `.claude.json`-t első provisionkor a már jóváhagyott shared `~/.claude.json` másolatából seedeli (örökli az összes consent flaget: `hasCompletedOnboarding`, `projects[].hasTrustDialogAccepted`, és a jövőbeli flageket is), és garantálja a `hasCompletedOnboarding`-ot a meglévő fájlokon. Egy flag seedelése nem elég, mert a dialógusok láncot alkotnak és a flag-halmaz verziónként nő.

EN: #479's per-agent isolated CLAUDE_CONFIG_DIR works headlessly, but the FIRST interactive `--channels` launch of a fresh isolated dir drops into Claude Code's first-run dialog chain ("Select login method", then the per-project "allow external imports" trust dialog), blocking the channels TUI before it authenticates from `CLAUDE_CODE_OAUTH_TOKEN`. The env token is valid (verified via headless `claude -p`) but the interactive pickers bypass it, so the sub-agent hangs at "Select login method" and spawns no poller. Fix: `ensureIsolatedChannelConfigDir` now seeds the isolated `.claude.json` from a copy of the already-consented shared `~/.claude.json` on first provision (inheriting every consent flag), and guarantees `hasCompletedOnboarding` on existing files. Seeding a single flag is insufficient because the dialogs form a chain and the flag set grows across versions. Validated on claude-code 2.1.195: wiping an agent's `.claude-config` and restarting now boots clean with no interactive dialog and a live poller.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch.
---

This change was authored with AI assistance, reviewed by @cett before submission.