### PR TITLE
feat(kanban): add Gantt/timeline view for due-date cards

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -12082,7 +12082,7 @@ function downloadMarkdown(name, content) {
     const todayPct = Math.max(0, Math.min(100, (nowMs - rangeStart) / totalMs * 100))
 
     // Filter: cards that have a due_date
-    let cards = (typeof kanbanCards !== 'undefined' ? kanbanCards : []).filter(c => c.due_date)
+    let cards = (Array.isArray(kanbanCards) ? kanbanCards : []).filter(c => c.due_date)
 
     if (ganttOverdueOnly) {
       // Keep cards that are overdue OR due within 7 days

--- a/web/app.js
+++ b/web/app.js
@@ -12002,6 +12002,7 @@ function downloadMarkdown(name, content) {
 ;(function () {
   // --- State ---
   let ganttPeriod = 'week'  // 'week' | 'month' | 'quarter'
+  let ganttPeriodOffset = 0  // periods stepped from the current one (0 = current, -1 = prev, +1 = next)
   let ganttOverdueOnly = false
   let _initialized = false
 
@@ -12020,17 +12021,19 @@ function downloadMarkdown(name, content) {
     start.setHours(0, 0, 0, 0)
     const end = new Date(start)
     if (ganttPeriod === 'week') {
-      // Mon..Sun of current week
+      // Mon..Sun of current week, shifted by ganttPeriodOffset weeks
       const dow = (start.getDay() + 6) % 7  // Mon=0
-      start.setDate(start.getDate() - dow)
+      start.setDate(start.getDate() - dow + ganttPeriodOffset * 7)
+      end.setTime(start.getTime())
       end.setDate(start.getDate() + 7)
     } else if (ganttPeriod === 'month') {
       start.setDate(1)
+      start.setMonth(start.getMonth() + ganttPeriodOffset)
       end.setFullYear(start.getFullYear(), start.getMonth() + 1, 1)
     } else {  // quarter
-      const qStart = Math.floor(start.getMonth() / 3) * 3
+      const qStart = Math.floor(start.getMonth() / 3) * 3 + ganttPeriodOffset * 3
       start.setMonth(qStart, 1)
-      end.setFullYear(start.getFullYear(), qStart + 3, 1)
+      end.setFullYear(start.getFullYear(), start.getMonth() + 3, 1)
     }
     return { rangeStart: start, rangeEnd: end }
   }
@@ -12174,7 +12177,9 @@ function downloadMarkdown(name, content) {
         const rowLabel = document.createElement('div')
         rowLabel.style.cssText = 'width:220px;min-width:220px;font-size:12px;color:var(--fg);padding:4px 8px;border-right:1px solid var(--border);overflow:hidden;white-space:nowrap;text-overflow:ellipsis;cursor:pointer;'
         rowLabel.title = card.title
-        rowLabel.textContent = `#${card.id} ${card.title}`
+        // Show the running display number (#N, card.seq) like the board, not the hex id.
+        const seqLabel = card.seq != null ? `#${card.seq}` : `#${card.id}`
+        rowLabel.textContent = `${seqLabel} ${card.title}`
         rowLabel.addEventListener('click', () => { if (typeof openCardDetail === 'function') openCardDetail(card.id) })
 
         const rowTrack = document.createElement('div')
@@ -12209,8 +12214,8 @@ function downloadMarkdown(name, content) {
           `z-index:2`,
           isOverdue ? 'background-image:repeating-linear-gradient(45deg,rgba(0,0,0,.12) 0px,rgba(0,0,0,.12) 4px,transparent 4px,transparent 8px)' : '',
         ].filter(Boolean).join(';')
-        bar.title = `#${card.id} ${card.title}\n${fmtDateShort(new Date(barStartMs))} - ${fmtDateShort(new Date(barEndMs))}`
-        bar.textContent = `#${card.id} ${card.title}`
+        bar.title = `${seqLabel} ${card.title}\n${fmtDateShort(new Date(barStartMs))} - ${fmtDateShort(new Date(barEndMs))}`
+        bar.textContent = `${seqLabel} ${card.title}`
         bar.addEventListener('click', () => { if (typeof openCardDetail === 'function') openCardDetail(card.id) })
         rowTrack.appendChild(bar)
         row.appendChild(rowLabel)
@@ -12243,6 +12248,25 @@ function downloadMarkdown(name, content) {
     wrap.appendChild(legend)
 
     container.appendChild(wrap)
+
+    // --- Period stepper (below the timeline): step back/forward by one period unit ---
+    const nav = document.createElement('div')
+    nav.style.cssText = 'display:flex;align-items:center;justify-content:center;gap:10px;margin-top:12px;'
+    const prevBtn = document.createElement('button')
+    prevBtn.className = 'view-btn'
+    prevBtn.style.cssText = 'width:auto;padding:0 14px;'
+    prevBtn.textContent = '‹ ' + t('kanban.gantt.nav_prev')
+    prevBtn.addEventListener('click', () => { ganttPeriodOffset--; renderGantt() })
+    const rangeLbl = document.createElement('span')
+    rangeLbl.style.cssText = 'font-size:12px;color:var(--muted);min-width:130px;text-align:center;'
+    rangeLbl.textContent = `${fmtDateShort(rangeStart)} - ${fmtDateShort(new Date(rangeEnd.getTime() - 1))}`
+    const nextBtn = document.createElement('button')
+    nextBtn.className = 'view-btn'
+    nextBtn.style.cssText = 'width:auto;padding:0 14px;'
+    nextBtn.textContent = t('kanban.gantt.nav_next') + ' ›'
+    nextBtn.addEventListener('click', () => { ganttPeriodOffset++; renderGantt() })
+    nav.append(prevBtn, rangeLbl, nextBtn)
+    container.appendChild(nav)
   }
 
   // --- View switcher init (called once after DOM ready) ---
@@ -12283,6 +12307,7 @@ function downloadMarkdown(name, content) {
     document.querySelectorAll('#kanbanGanttFilters [data-period]').forEach(btn => {
       btn.addEventListener('click', () => {
         ganttPeriod = btn.dataset.period
+        ganttPeriodOffset = 0  // recenter on the current period when switching granularity
         document.querySelectorAll('#kanbanGanttFilters [data-period]').forEach(b => b.classList.remove('active'))
         btn.classList.add('active')
         renderGantt()

--- a/web/app.js
+++ b/web/app.js
@@ -250,7 +250,7 @@ function switchPage(pageId) {
   // Kanban auto-refresh: start on enter, stop on leave.
   if (pageId !== 'kanban') stopKanbanRefresh()
   if (pageId === 'overview') loadOverview()
-  if (pageId === 'kanban') { loadKanban(); startKanbanRefresh() }
+  if (pageId === 'kanban') { if (typeof _initGanttViewSwitcher === 'function') _initGanttViewSwitcher(); loadKanban(); startKanbanRefresh() }
   if (pageId === 'tasks') loadSchedules()
   if (pageId === 'agents') loadAgents()
   if (pageId === 'memories') { loadMemAgents(); loadMemStats(); loadMemories() }
@@ -11996,4 +11996,318 @@ function downloadMarkdown(name, content) {
   }
 
   window.loadNaplo = loadNaplo
+})()
+
+// === Kanban Gantt / timeline view ===
+;(function () {
+  // --- State ---
+  let ganttPeriod = 'week'  // 'week' | 'month' | 'quarter'
+  let ganttOverdueOnly = false
+  let _initialized = false
+
+  // --- Color map by status (vars from theme) ---
+  const STATUS_COLOR = {
+    planned:     { bg: 'var(--accent)',  border: 'var(--accent)' },
+    in_progress: { bg: '#4f8ef7',        border: '#3a7be0' },
+    waiting:     { bg: '#e8a838',        border: '#c88c20' },
+    done:        { bg: '#3dbf79',        border: '#28a560' },
+  }
+
+  // Period window: returns { rangeStart: Date, rangeEnd: Date } (midnight boundaries)
+  function periodWindow() {
+    const now = new Date()
+    const start = new Date(now)
+    start.setHours(0, 0, 0, 0)
+    const end = new Date(start)
+    if (ganttPeriod === 'week') {
+      // Mon..Sun of current week
+      const dow = (start.getDay() + 6) % 7  // Mon=0
+      start.setDate(start.getDate() - dow)
+      end.setDate(start.getDate() + 7)
+    } else if (ganttPeriod === 'month') {
+      start.setDate(1)
+      end.setFullYear(start.getFullYear(), start.getMonth() + 1, 1)
+    } else {  // quarter
+      const qStart = Math.floor(start.getMonth() / 3) * 3
+      start.setMonth(qStart, 1)
+      end.setFullYear(start.getFullYear(), qStart + 3, 1)
+    }
+    return { rangeStart: start, rangeEnd: end }
+  }
+
+  // Format date as short label (e.g. "jún 15" / "Jun 15")
+  function fmtDateShort(d) {
+    return d.toLocaleDateString(typeof _lang !== 'undefined' && _lang === 'en' ? 'en-US' : 'hu-HU', { month: 'short', day: 'numeric' })
+  }
+
+  // Return header tick labels for the visible range
+  function buildHeaderTicks(rangeStart, rangeEnd) {
+    const ticks = []
+    const totalMs = rangeEnd - rangeStart
+    // Aim for ~5-8 ticks; snap to day boundaries
+    let stepDays = 1
+    if (ganttPeriod === 'month') stepDays = 7
+    else if (ganttPeriod === 'quarter') stepDays = 14
+    const cur = new Date(rangeStart)
+    while (cur < rangeEnd) {
+      ticks.push({
+        date: new Date(cur),
+        pct: (cur - rangeStart) / totalMs * 100,
+      })
+      cur.setDate(cur.getDate() + stepDays)
+    }
+    return ticks
+  }
+
+  // Group visible cards by project (or 'Nincs projekt' for null)
+  function groupCardsByProject(cards) {
+    const map = new Map()
+    for (const c of cards) {
+      const key = c.project || t('kanban.gantt.no_project')
+      if (!map.has(key)) map.set(key, [])
+      map.get(key).push(c)
+    }
+    return map
+  }
+
+  // Build and inject the Gantt DOM into #kanbanGanttView
+  function renderGantt() {
+    const container = document.getElementById('kanbanGanttView')
+    if (!container) return
+    container.innerHTML = ''
+
+    const { rangeStart, rangeEnd } = periodWindow()
+    const totalMs = rangeEnd - rangeStart
+    const nowMs = Date.now()
+    const todayPct = Math.max(0, Math.min(100, (nowMs - rangeStart) / totalMs * 100))
+
+    // Filter: cards that have a due_date
+    let cards = (typeof kanbanCards !== 'undefined' ? kanbanCards : []).filter(c => c.due_date)
+
+    if (ganttOverdueOnly) {
+      // Keep cards that are overdue OR due within 7 days
+      const cutoff = (nowMs + 7 * 86400000) / 1000
+      cards = cards.filter(c => c.due_date <= cutoff / 1 && c.status !== 'done')
+    }
+
+    // Exclude cards whose entire bar lies outside the window
+    cards = cards.filter(c => {
+      const barStart = c.created_at ? c.created_at * 1000 : rangeStart.getTime()
+      const barEnd   = c.due_date * 1000
+      return barEnd >= rangeStart && barStart <= rangeEnd
+    })
+
+    if (cards.length === 0) {
+      container.innerHTML = `<p style="color:var(--muted);padding:24px 0;text-align:center;">${t('kanban.gantt.no_cards')}</p>`
+      return
+    }
+
+    const grouped = groupCardsByProject(cards)
+
+    // --- Outer layout ---
+    const wrap = document.createElement('div')
+    wrap.className = 'gantt-wrap'
+    wrap.style.cssText = 'display:flex;flex-direction:column;overflow:hidden;'
+
+    // --- Header row: left label + tick strip ---
+    const headerRow = document.createElement('div')
+    headerRow.style.cssText = 'display:flex;border-bottom:1px solid var(--border);margin-bottom:4px;'
+
+    const headerLabel = document.createElement('div')
+    headerLabel.style.cssText = 'width:220px;min-width:220px;font-size:12px;color:var(--muted);padding:4px 8px;border-right:1px solid var(--border);'
+    headerLabel.textContent = t('kanban.gantt.col_label')
+    headerRow.appendChild(headerLabel)
+
+    const headerTrack = document.createElement('div')
+    headerTrack.style.cssText = 'flex:1;position:relative;height:28px;overflow:hidden;'
+    const ticks = buildHeaderTicks(rangeStart, rangeEnd)
+    for (const tick of ticks) {
+      const el = document.createElement('div')
+      el.style.cssText = `position:absolute;left:${tick.pct.toFixed(2)}%;transform:translateX(-50%);font-size:11px;color:var(--muted);top:6px;white-space:nowrap;`
+      el.textContent = fmtDateShort(tick.date)
+      headerTrack.appendChild(el)
+    }
+    // Today marker in header
+    if (todayPct >= 0 && todayPct <= 100) {
+      const todayHead = document.createElement('div')
+      todayHead.style.cssText = `position:absolute;left:${todayPct.toFixed(2)}%;top:0;bottom:0;width:2px;background:var(--danger,#e05252);opacity:0.6;`
+      headerTrack.appendChild(todayHead)
+    }
+    headerRow.appendChild(headerTrack)
+    wrap.appendChild(headerRow)
+
+    // --- Body rows ---
+    const body = document.createElement('div')
+    body.style.cssText = 'overflow-y:auto;max-height:70vh;'
+
+    for (const [project, projCards] of grouped) {
+      // Group header
+      const groupHeader = document.createElement('div')
+      groupHeader.style.cssText = 'display:flex;align-items:center;background:var(--bg2,var(--sidebar-bg));border-bottom:1px solid var(--border);'
+      const ghLabel = document.createElement('div')
+      ghLabel.style.cssText = 'width:220px;min-width:220px;font-size:12px;font-weight:600;color:var(--fg);padding:5px 8px;border-right:1px solid var(--border);'
+      ghLabel.textContent = `${project} (${projCards.length})`
+      groupHeader.appendChild(ghLabel)
+      const ghStripe = document.createElement('div')
+      ghStripe.style.cssText = 'flex:1;height:26px;background:var(--bg2,var(--sidebar-bg));'
+      groupHeader.appendChild(ghStripe)
+      body.appendChild(groupHeader)
+
+      // Card rows
+      for (const card of projCards) {
+        const barStartMs = card.created_at ? card.created_at * 1000 : rangeStart.getTime()
+        const barEndMs   = card.due_date * 1000
+        const isOverdue  = card.status !== 'done' && barEndMs < nowMs
+
+        // Clamp to window
+        const clampedStart = Math.max(barStartMs, rangeStart.getTime())
+        const clampedEnd   = Math.min(barEndMs,   rangeEnd.getTime())
+        const leftPct  = (clampedStart - rangeStart) / totalMs * 100
+        const widthPct = Math.max(0.5, (clampedEnd - clampedStart) / totalMs * 100)
+
+        const col = isOverdue ? { bg: 'var(--danger,#e05252)', border: '#b83030' }
+                              : (STATUS_COLOR[card.status] || STATUS_COLOR.planned)
+
+        const row = document.createElement('div')
+        row.style.cssText = 'display:flex;align-items:center;border-bottom:1px solid var(--border);min-height:32px;'
+
+        const rowLabel = document.createElement('div')
+        rowLabel.style.cssText = 'width:220px;min-width:220px;font-size:12px;color:var(--fg);padding:4px 8px;border-right:1px solid var(--border);overflow:hidden;white-space:nowrap;text-overflow:ellipsis;cursor:pointer;'
+        rowLabel.title = card.title
+        rowLabel.textContent = `#${card.id} ${card.title}`
+        rowLabel.addEventListener('click', () => { if (typeof openCardDetail === 'function') openCardDetail(card.id) })
+
+        const rowTrack = document.createElement('div')
+        rowTrack.style.cssText = 'flex:1;position:relative;height:32px;overflow:hidden;'
+
+        // Today line (in each row)
+        if (todayPct >= 0 && todayPct <= 100) {
+          const tl = document.createElement('div')
+          tl.style.cssText = `position:absolute;left:${todayPct.toFixed(2)}%;top:0;bottom:0;width:2px;background:var(--danger,#e05252);z-index:1;pointer-events:none;`
+          rowTrack.appendChild(tl)
+        }
+
+        const bar = document.createElement('div')
+        bar.style.cssText = [
+          `position:absolute`,
+          `left:${leftPct.toFixed(2)}%`,
+          `width:${widthPct.toFixed(2)}%`,
+          `top:5px`,
+          `bottom:5px`,
+          `background:${col.bg}`,
+          `border:1px solid ${col.border}`,
+          `border-radius:4px`,
+          `overflow:hidden`,
+          `white-space:nowrap`,
+          `font-size:11px`,
+          `color:#fff`,
+          `display:flex`,
+          `align-items:center`,
+          `padding:0 6px`,
+          `box-sizing:border-box`,
+          `cursor:pointer`,
+          `z-index:2`,
+          isOverdue ? 'background-image:repeating-linear-gradient(45deg,rgba(0,0,0,.12) 0px,rgba(0,0,0,.12) 4px,transparent 4px,transparent 8px)' : '',
+        ].filter(Boolean).join(';')
+        bar.title = `#${card.id} ${card.title}\n${fmtDateShort(new Date(barStartMs))} - ${fmtDateShort(new Date(barEndMs))}`
+        bar.textContent = `#${card.id} ${card.title}`
+        bar.addEventListener('click', () => { if (typeof openCardDetail === 'function') openCardDetail(card.id) })
+        rowTrack.appendChild(bar)
+        row.appendChild(rowLabel)
+        row.appendChild(rowTrack)
+        body.appendChild(row)
+      }
+    }
+
+    wrap.appendChild(body)
+
+    // --- Legend ---
+    const legend = document.createElement('div')
+    legend.style.cssText = 'display:flex;align-items:center;gap:16px;margin-top:10px;font-size:12px;flex-wrap:wrap;'
+    const legendItems = [
+      { key: 'planned',     color: STATUS_COLOR.planned.bg },
+      { key: 'in_progress', color: STATUS_COLOR.in_progress.bg },
+      { key: 'waiting',     color: STATUS_COLOR.waiting.bg },
+      { key: 'done',        color: STATUS_COLOR.done.bg },
+      { key: 'overdue',     color: 'var(--danger,#e05252)' },
+    ]
+    for (const item of legendItems) {
+      const dot = document.createElement('span')
+      dot.innerHTML = `<span style="display:inline-block;width:12px;height:12px;border-radius:2px;background:${item.color};vertical-align:middle;margin-right:4px;"></span>${t('kanban.gantt.legend.' + item.key)}`
+      legend.appendChild(dot)
+    }
+    const todayLegend = document.createElement('span')
+    todayLegend.style.cssText = 'margin-left:auto;color:var(--muted);'
+    todayLegend.innerHTML = `<span style="display:inline-block;width:12px;height:2px;background:var(--danger,#e05252);vertical-align:middle;margin-right:4px;"></span>${t('kanban.gantt.legend.today')}`
+    legend.appendChild(todayLegend)
+    wrap.appendChild(legend)
+
+    container.appendChild(wrap)
+  }
+
+  // --- View switcher init (called once after DOM ready) ---
+  function initGanttViewSwitcher() {
+    if (_initialized) return
+    _initialized = true
+
+    const boardBtn  = document.getElementById('kanbanViewBoard')
+    const ganttBtn  = document.getElementById('kanbanViewGantt')
+    const boardFilters = document.getElementById('kanbanBoardFilters')
+    const ganttFilters = document.getElementById('kanbanGanttFilters')
+    const boardEls  = [document.getElementById('kanbanBoard'), document.getElementById('kanbanSwimlaneBoard')]
+    const ganttEl   = document.getElementById('kanbanGanttView')
+
+    function activateBoard() {
+      boardBtn.classList.add('active')
+      ganttBtn.classList.remove('active')
+      boardFilters.style.display = 'flex'
+      ganttFilters.style.display = 'none'
+      boardEls.forEach(el => { if (el) el.style.removeProperty('display') })
+      ganttEl.style.display = 'none'
+    }
+
+    function activateGantt() {
+      ganttBtn.classList.add('active')
+      boardBtn.classList.remove('active')
+      ganttFilters.style.display = 'flex'
+      boardFilters.style.display = 'none'
+      boardEls.forEach(el => { if (el) el.style.display = 'none' })
+      ganttEl.style.display = 'block'
+      renderGantt()
+    }
+
+    boardBtn.addEventListener('click', activateBoard)
+    ganttBtn.addEventListener('click', activateGantt)
+
+    // Period buttons
+    document.querySelectorAll('#kanbanGanttFilters [data-period]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        ganttPeriod = btn.dataset.period
+        document.querySelectorAll('#kanbanGanttFilters [data-period]').forEach(b => b.classList.remove('active'))
+        btn.classList.add('active')
+        renderGantt()
+      })
+    })
+
+    // Overdue toggle
+    const overdueChk = document.getElementById('ganttOverdueOnly')
+    if (overdueChk) {
+      overdueChk.addEventListener('change', () => {
+        ganttOverdueOnly = overdueChk.checked
+        renderGantt()
+      })
+    }
+
+    // Re-render on data refresh (hook into global loadKanban completion)
+    const _origRenderKanban = window.renderKanban
+    if (typeof _origRenderKanban === 'function') {
+      window.renderKanban = function () {
+        _origRenderKanban.apply(this, arguments)
+        if (ganttEl.style.display !== 'none') renderGantt()
+      }
+    }
+  }
+
+  window._initGanttViewSwitcher = initGanttViewSwitcher
+  window.renderGantt = renderGantt
 })()

--- a/web/index.html
+++ b/web/index.html
@@ -226,9 +226,9 @@
 
       <!-- Gantt-specific filter row (hidden when board active) -->
       <div id="kanbanGanttFilters" style="display:none;margin-bottom:12px;align-items:center;gap:6px;flex-wrap:wrap;">
-        <button class="view-btn active" id="ganttPeriodWeek" data-period="week" data-i18n="kanban.gantt.filter.period_week">Ezen hét</button>
-        <button class="view-btn" id="ganttPeriodMonth" data-period="month" data-i18n="kanban.gantt.filter.period_month">Hónap</button>
-        <button class="view-btn" id="ganttPeriodQuarter" data-period="quarter" data-i18n="kanban.gantt.filter.period_quarter">Negyedév</button>
+        <button class="view-btn active" id="ganttPeriodWeek" style="width:auto;padding:0 10px;" data-period="week" data-i18n="kanban.gantt.filter.period_week">Ezen hét</button>
+        <button class="view-btn" id="ganttPeriodMonth" style="width:auto;padding:0 10px;" data-period="month" data-i18n="kanban.gantt.filter.period_month">Hónap</button>
+        <button class="view-btn" id="ganttPeriodQuarter" style="width:auto;padding:0 10px;" data-period="quarter" data-i18n="kanban.gantt.filter.period_quarter">Negyedév</button>
         <label style="display:flex;align-items:center;gap:5px;font-size:13px;color:var(--muted);margin-left:10px;cursor:pointer;">
           <input type="checkbox" id="ganttOverdueOnly" style="cursor:pointer;">
           <span data-i18n="kanban.gantt.filter.overdue_only">Csak lejárt/közelgő</span>

--- a/web/index.html
+++ b/web/index.html
@@ -203,7 +203,14 @@
 
     <!-- === Kanban Page === -->
     <div class="page" id="kanbanPage" hidden>
-      <div style="margin-bottom:12px;display:flex;align-items:center;gap:8px;">
+      <!-- View switcher: board vs gantt (top, always visible) -->
+      <div id="kanbanViewSwitcher" style="display:flex;align-items:center;gap:6px;margin-bottom:10px;">
+        <button class="view-btn active" id="kanbanViewBoard" style="width:auto;padding:0 12px;" data-i18n="kanban.view.board">Tábla</button>
+        <button class="view-btn" id="kanbanViewGantt" style="width:auto;padding:0 12px;" data-i18n="kanban.view.gantt">Idővonal</button>
+      </div>
+
+      <!-- Board-specific filter row (hidden when gantt active) -->
+      <div id="kanbanBoardFilters" style="margin-bottom:12px;display:flex;align-items:center;gap:8px;">
         <label for="kanbanProjectFilter" style="font-size:13px;color:var(--muted);white-space:nowrap;">Projekt:</label>
         <select id="kanbanProjectFilter" style="font-size:13px;padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--fg);min-width:140px;">
           <option value="">Mind</option>
@@ -216,6 +223,18 @@
         </select>
         <div class="kanban-quick-filters" id="kanbanQuickFilters" style="margin-left:auto; display:flex; gap:6px; flex-wrap:wrap; align-items:center;"></div>
       </div>
+
+      <!-- Gantt-specific filter row (hidden when board active) -->
+      <div id="kanbanGanttFilters" style="display:none;margin-bottom:12px;align-items:center;gap:6px;flex-wrap:wrap;">
+        <button class="view-btn active" id="ganttPeriodWeek" data-period="week" data-i18n="kanban.gantt.filter.period_week">Ezen hét</button>
+        <button class="view-btn" id="ganttPeriodMonth" data-period="month" data-i18n="kanban.gantt.filter.period_month">Hónap</button>
+        <button class="view-btn" id="ganttPeriodQuarter" data-period="quarter" data-i18n="kanban.gantt.filter.period_quarter">Negyedév</button>
+        <label style="display:flex;align-items:center;gap:5px;font-size:13px;color:var(--muted);margin-left:10px;cursor:pointer;">
+          <input type="checkbox" id="ganttOverdueOnly" style="cursor:pointer;">
+          <span data-i18n="kanban.gantt.filter.overdue_only">Csak lejárt/közelgő</span>
+        </label>
+      </div>
+
       <div class="kanban-board" id="kanbanBoard">
         <div class="kanban-col" data-status="planned">
           <div class="kanban-col-header">
@@ -250,6 +269,8 @@
         </div>
       </div>
       <div class="kanban-board kanban-swimlane-board" id="kanbanSwimlaneBoard" hidden></div>
+      <!-- Gantt / timeline view container -->
+      <div id="kanbanGanttView" style="display:none;"></div>
     </div>
 
     <!-- === Archived Cards Page === -->

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1329,6 +1329,23 @@ window._i18n.en = {
   'kanban.filter.group_assignee':'By assignee',
   'kanban.filter.group_priority':'By priority',
 
+  // --- Kanban Gantt/timeline view ---
+  'kanban.view.board':              'Board',
+  'kanban.view.gantt':              'Timeline',
+  'kanban.gantt.filter.period_week':    'This week',
+  'kanban.gantt.filter.period_month':   'Month',
+  'kanban.gantt.filter.period_quarter': 'Quarter',
+  'kanban.gantt.filter.overdue_only':   'Only overdue/upcoming',
+  'kanban.gantt.no_cards':          'No cards with a due date',
+  'kanban.gantt.legend.planned':    'Planned',
+  'kanban.gantt.legend.in_progress':'In Progress',
+  'kanban.gantt.legend.waiting':    'Waiting',
+  'kanban.gantt.legend.done':       'Done',
+  'kanban.gantt.legend.overdue':    'Overdue',
+  'kanban.gantt.legend.today':      'TODAY = today line (red)',
+  'kanban.gantt.col_label':         'Project / Card',
+  'kanban.gantt.no_project':        '(no project)',
+
   // --- Activity tooltip ---
   'activity.tooltip.terminal':   'Open terminal',
 

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1345,6 +1345,8 @@ window._i18n.en = {
   'kanban.gantt.legend.today':      'TODAY = today line (red)',
   'kanban.gantt.col_label':         'Project / Card',
   'kanban.gantt.no_project':        '(no project)',
+  'kanban.gantt.nav_prev':          'Previous',
+  'kanban.gantt.nav_next':          'Next',
 
   // --- Activity tooltip ---
   'activity.tooltip.terminal':   'Open terminal',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1327,6 +1327,23 @@ window._i18n.hu = {
   'kanban.filter.group_assignee':'Felelős szerint',
   'kanban.filter.group_priority':'Prioritás szerint',
 
+  // --- Kanban Gantt/idővonal nézet ---
+  'kanban.view.board':              'Tábla',
+  'kanban.view.gantt':              'Idővonal',
+  'kanban.gantt.filter.period_week':    'Ezen hét',
+  'kanban.gantt.filter.period_month':   'Hónap',
+  'kanban.gantt.filter.period_quarter': 'Negyedév',
+  'kanban.gantt.filter.overdue_only':   'Csak lejárt/közelgő',
+  'kanban.gantt.no_cards':          'Nincs határidős kártya',
+  'kanban.gantt.legend.planned':    'Tervezett',
+  'kanban.gantt.legend.in_progress':'Folyamatban',
+  'kanban.gantt.legend.waiting':    'Várakozó',
+  'kanban.gantt.legend.done':       'Kész',
+  'kanban.gantt.legend.overdue':    'Lejárt',
+  'kanban.gantt.legend.today':      'MA = mai nap (piros vonal)',
+  'kanban.gantt.col_label':         'Projekt / Kártya',
+  'kanban.gantt.no_project':        '(nincs projekt)',
+
   // --- Activity tooltip ---
   'activity.tooltip.terminal':   'Terminal megnyitása',
 

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1343,6 +1343,8 @@ window._i18n.hu = {
   'kanban.gantt.legend.today':      'MA = mai nap (piros vonal)',
   'kanban.gantt.col_label':         'Projekt / Kártya',
   'kanban.gantt.no_project':        '(nincs projekt)',
+  'kanban.gantt.nav_prev':          'Előző',
+  'kanban.gantt.nav_next':          'Következő',
 
   // --- Activity tooltip ---
   'activity.tooltip.terminal':   'Terminal megnyitása',


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary

HU: Új Tábla/Idővonal nézet-váltó a Kanban oldalon, nézet-specifikus szűrősorral. Az idővonal natív CSS/div sávokként rendereli a határidős (due_date) kártyákat: a sáv a created_at -> due_date tartományt fedi, státusz szerint színezve, a lejárt kártyák piros sraffozással, MA-vonallal és projekt szerinti csoportosítással. Period-szűrő (hét/hónap/negyedév), alatta Előző/Következő léptetőkkel, amik az aktív periódus egységével tolják a látható ablakot. A sávok/címkék a kártya futó sorszámát (#N) mutatják. Első kör read-only (nincs drag/resize). Teljes i18n (HU/EN).

EN: Adds a Board/Timeline view switcher on the Kanban page with a view-specific filter row. The timeline renders due-date cards as native CSS/div bars (created_at -> due_date), coloured by status, overdue cards hatched red, with a today line and project grouping. A period filter (week/month/quarter) with Previous/Next steppers shifts the visible window by one unit of the active period. Bars/labels show the card's running display number (#N). Read-only first pass (no drag/resize). Fully internationalized (HU/EN).

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (dashboard); built and screenshot-verified the view switching, bars, today line, overdue highlight, project grouping and period stepping.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch.

---

This change was authored with AI assistance, reviewed by the maintainer before submission.