### PR TITLE
fix(parked-input): escalate main-agent stuck box to operator, never auto-clear it (#2 delivery fix)

### DIFF
--- a/src/__tests__/parked-input-escalation.test.ts
+++ b/src/__tests__/parked-input-escalation.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+
+// Escalation behavior of clearStaleParkedInput (agent-process.ts), the #2 fix for
+// the 2026-06-30 1h SILENT fleet-stall: a real reply ("Igen, írd meg Baloghnak a
+// választ") parked in the MAIN agent's box wedged all inter-agent delivery while
+// the auto-clear failed 109x behind a lone WARN. Contract:
+//   - MAIN agent box: NEVER auto-cleared (Ctrl-U would destroy a real reply) ->
+//     NOTIFY the operator once per stuck episode instead.
+//   - sub-agent box: keep the existing Ctrl-U clear path.
+//   - escalation is ONE-SHOT per stuck text (no spam).
+//
+// capturePane / runTmux are LOCAL to agent-process and both go through
+// node:child_process execFileSync, so we mock execFileSync with arg-inspection:
+// a 'capture-pane' call returns a stable parked pane; everything else (sleeps,
+// send-keys) is a no-op we can inspect.
+
+const h = vi.hoisted(() => {
+  const SEP = '─'.repeat(80)
+  const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+  // A stranded, never-submitted real reply parked in the input box.
+  const PARKED = ['', SEP, '❯ Igen, írd meg Baloghnak a választ', SEP, FOOTER].join('\n')
+  const calls: string[][] = []
+  return { PARKED, calls }
+})
+
+vi.mock('node:child_process', async (orig) => ({
+  ...(await orig() as object),
+  execFileSync: vi.fn((_file: string, args?: string[]) => {
+    if (Array.isArray(args)) {
+      h.calls.push(args)
+      if (args.includes('capture-pane')) return h.PARKED
+    }
+    return ''
+  }),
+}))
+vi.mock('../notify.js', () => ({ notifyChannel: vi.fn(async () => {}), notifyTelegram: vi.fn(async () => {}) }))
+
+import { clearStaleParkedInput } from '../web/agent-process.js'
+import { notifyChannel } from '../notify.js'
+import { MAIN_CHANNELS_SESSION } from '../web/main-agent.js'
+
+let clock = 1_000_000
+const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock)
+const COOLDOWN = 31_000 // > UNWEDGE_COOLDOWN_MS so each call increments `fails`
+
+function clearKeystrokes(): string[][] {
+  return h.calls.filter(a => a.includes('send-keys') && (a.includes('C-u') || a.includes('C-k')))
+}
+
+beforeEach(() => {
+  h.calls.length = 0
+  vi.mocked(notifyChannel).mockClear()
+})
+afterAll(() => { nowSpy.mockRestore() })
+
+describe('parked-input escalation', () => {
+  it('NEVER auto-clears the main agent box, and escalates exactly ONCE after K detections', () => {
+    // 3 confirmed-stuck detections past the cooldown -> escalate on the 3rd.
+    for (let i = 0; i < 3; i++) { clearStaleParkedInput(MAIN_CHANNELS_SESSION); clock += COOLDOWN }
+    // CRITICAL contract: the main box is never touched with a clearing keystroke.
+    expect(clearKeystrokes().length).toBe(0)
+    expect(vi.mocked(notifyChannel)).toHaveBeenCalledTimes(1)
+    // one-shot: further detections of the SAME parked text do not re-notify.
+    clearStaleParkedInput(MAIN_CHANNELS_SESSION); clock += COOLDOWN
+    clearStaleParkedInput(MAIN_CHANNELS_SESSION)
+    expect(vi.mocked(notifyChannel)).toHaveBeenCalledTimes(1)
+    expect(clearKeystrokes().length).toBe(0)
+  })
+
+  it('still attempts the Ctrl-U clear for a SUB-agent box', () => {
+    clearStaleParkedInput('subagent-zara-channels')
+    expect(clearKeystrokes().length).toBeGreaterThan(0)
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -36,6 +36,8 @@ import { writeAgentSettingsFromProfile } from './agent-scaffold.js'
 import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import { getSecret } from './vault.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
+import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { notifyChannel } from '../notify.js'
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
@@ -1223,9 +1225,18 @@ const PARKED_CLEAR_MAX = 3
 // (health probes read 000) and drive the watchdog into a dashboard restart loop.
 // Retry the SAME stuck text at most once per this window, per session.
 const UNWEDGE_COOLDOWN_MS = 30_000
-// Per-session record of the last un-wedge attempt: when, on what text, and how
-// many consecutive attempts failed to actually empty the box.
-const unwedgeAttempts = new Map<string, { last: number; sig: string; fails: number }>()
+// Escalate to the operator (NOTIFY only -- a Telegram message, never a
+// keystroke) once per stuck episode after this many consecutive confirmed-stuck
+// detections (~one per UNWEDGE_COOLDOWN_MS). The main agent escalates sooner
+// because its box is NEVER auto-cleared (the parked line may be a real reply),
+// so escalation is the only recovery; a sub-agent escalates only after the
+// auto-clear has genuinely failed several times.
+const MAIN_PARKED_ESCALATE_AFTER = 3      // ~90s for the main agent (never auto-cleared)
+const SUBAGENT_PARKED_ESCALATE_AFTER = 6  // ~3min for a sub-agent whose auto-clear keeps failing
+// Per-session record of the last un-wedge attempt: when, on what text, how many
+// consecutive attempts failed to empty the box, and whether we already notified
+// the operator for this exact stuck text (one-shot; resets when sig/clears).
+const unwedgeAttempts = new Map<string, { last: number; sig: string; fails: number; escalated: boolean }>()
 
 // Un-wedge a session whose input box holds STALE parked text: a non-submitted
 // line (e.g. a weak local model that typed its heartbeat reply into the box
@@ -1257,6 +1268,30 @@ export function clearStaleParkedInput(session: string, host: string | null = nul
   // record an attempt (this was never a stuck box).
   if (b == null || detectPaneState(b) !== 'typing' || parkedInputText(b) !== parked) return false
 
+  // The main agent's input box is NEVER auto-cleared: a parked line there is
+  // very likely a real, intended reply (e.g. an operator answer typed into the
+  // channel session) -- a Ctrl-U would silently destroy it (the 2026-06-30 "Balogh
+  // reply" near-miss). Instead, leave the box untouched and escalate to the
+  // operator ONCE per stuck episode (NOTIFY only, zero keystrokes -- respects the
+  // hardened no-raw-keystroke area). The operator sends or clears the line.
+  if (session === MAIN_CHANNELS_SESSION) {
+    const fails = (prev && prev.sig === parked ? prev.fails : 0) + 1
+    const alreadyEscalated = !!(prev && prev.sig === parked && prev.escalated)
+    if (!alreadyEscalated && fails >= MAIN_PARKED_ESCALATE_AFTER) {
+      const preview = parked.slice(0, 80).replace(/[<>&]/g, ' ')
+      notifyChannel(
+        '⚠️ Beragadt egy parkolt (el nem kuldott) sor a fo-agent input-mezojeben, ' +
+        'a beerkezo uzenetek kezbesitese all. Kuldd el VAGY torold azt a sort (Escape a prompt-boxban), ' +
+        `hogy a varakozok megerkezzenek. Reszlet: "${preview}"`,
+      ).catch(() => { /* notify is best-effort */ })
+      unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated: true })
+      logger.warn({ session, parked: parked.slice(0, 60), fails }, 'message-router: main-agent parked input -- escalated to operator (NOT auto-cleared)')
+    } else {
+      unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated: alreadyEscalated })
+    }
+    return false
+  }
+
   for (let i = 0; i < PARKED_CLEAR_MAX; i++) {
     runTmux(host, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
     try { execFileSync('/bin/sleep', [PARKED_CLEAR_SETTLE_S], { timeout: 2000 }) } catch { /* best effort */ }
@@ -1283,11 +1318,27 @@ export function clearStaleParkedInput(session: string, host: string | null = nul
   // the cooldown guard above backs us off instead of hammering every tick.
   const final = capturePane(session, host)
   const stillStuck = final != null && detectPaneState(final) === 'typing' && parkedInputText(final) === parked
-  unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails: stillStuck ? ((prev && prev.sig === parked ? prev.fails : 0) + 1) : 0 })
   if (stillStuck) {
-    logger.warn({ session, parked: parked.slice(0, 60), fails: unwedgeAttempts.get(key)!.fails }, 'message-router: parked input resisted clearing, backing off')
+    const fails = (prev && prev.sig === parked ? prev.fails : 0) + 1
+    let escalated = !!(prev && prev.sig === parked && prev.escalated)
+    // A sub-agent box that resists the Ctrl-U clear this many times is genuinely
+    // wedged (not the usual junk heartbeat line the auto-clear handles) -- surface
+    // it to the operator ONCE so it cannot stall silently like the 1h main-agent
+    // incident did behind a lone WARN.
+    if (!escalated && fails >= SUBAGENT_PARKED_ESCALATE_AFTER) {
+      const preview = parked.slice(0, 80).replace(/[<>&]/g, ' ')
+      notifyChannel(
+        `⚠️ Egy sub-agent (${session}) input-mezojebe beragadt egy parkolt sor, ` +
+        `az auto-tisztitas ${fails}x sikertelen -- lehet kezi beavatkozas kell. Reszlet: "${preview}"`,
+      ).catch(() => { /* notify is best-effort */ })
+      escalated = true
+      logger.warn({ session, parked: parked.slice(0, 60), fails }, 'message-router: sub-agent parked input resisted clearing -- escalated to operator')
+    }
+    unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated })
+    logger.warn({ session, parked: parked.slice(0, 60), fails }, 'message-router: parked input resisted clearing, backing off')
     return false
   }
+  unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails: 0, escalated: false })
   logger.warn({ session, parked: parked.slice(0, 60) }, 'message-router: cleared stale parked input (channel un-wedge)')
   return true
 }

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1281,7 +1281,7 @@ export function clearStaleParkedInput(session: string, host: string | null = nul
       const preview = parked.slice(0, 80).replace(/[<>&]/g, ' ')
       notifyChannel(
         '⚠️ Beragadt egy parkolt (el nem kuldott) sor a fo-agent input-mezojeben, ' +
-        'a beerkezo uzenetek kezbesitese all. Kuldd el VAGY torold azt a sort (Escape a prompt-boxban), ' +
+        'a beerkezo uzenetek kezbesitese all. Kuldd el (Enter) VAGY torold a sort (Ctrl+U a prompt-boxban), ' +
         `hogy a varakozok megerkezzenek. Reszlet: "${preview}"`,
       ).catch(() => { /* notify is best-effort */ })
       unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated: true })


### PR DESCRIPTION
## Problem
2026-06-30 ~1h **silent** inter-agent delivery stall: a real, intended reply (`"Igen, írd meg Baloghnak a választ"`) was parked in the MAIN agent's channel input box. The stale-parked janitor tried to Ctrl-U clear it **109×**, failed every time, and only logged a lone WARN. Every inter-agent message to the main agent (an email-send hand-off, a #498 verify-GO, status reports) stranded as `pending` for an hour with no operator-visible signal. And had the Ctrl-U *succeeded*, it would have silently destroyed the operator's real reply.

## Fix (`clearStaleParkedInput`)
1. **MAIN agent box is NEVER auto-cleared.** A parked line there is very likely a real reply, so we send **zero keystrokes** (respects the hardened no-raw-keystroke area, #481) and instead **escalate to the operator** via `notifyChannel()` — the same Bot-API path `channel-monitor` uses, independent of the wedged session — **once** per stuck episode. The operator sends or clears the line.
2. **Sub-agent box** keeps the existing Ctrl-U clear (its parked text is the usual junk heartbeat line), but now also escalates **once** if the clear genuinely resists several times, so a stuck sub-agent can't silently stall either.

Escalation is **one-shot** per stuck text (tracked by sig on the `unwedgeAttempts` record; resets when the text changes or the box clears) — no spam, mirroring the kanban 2-round pattern.

## Co-review emphases (per the design agreement)
- ✅ Main-agent box never silently auto-cleared (the most critical constraint).
- ✅ Escalation is NOTIFY-only (a Telegram message to the operator) — **no keystroke / phantom-injection**.
- ✅ One-shot per episode (no spam).
- Orthogonal to #498 (STT throttle, already shipped) and to the forthcoming #1 pull-model (busy-delivery).

## Verification
- `tsc --noEmit`: clean.
- 27/27 recovery-surface tests pass: `janitor-parked-input` (unchanged contract, no regression), the new `parked-input-escalation` (main never-clear + escalate-once + one-shot + sub-agent still clears), `router-abandon`, `channel-inbound-framing`, `remote-routing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)