### PR TITLE
fix(scheduler): scope busy-detect to live region so a stale token-counter can't pin an idle pane

### DIFF
--- a/src/__tests__/pane-looks-idle.test.ts
+++ b/src/__tests__/pane-looks-idle.test.ts
@@ -56,6 +56,29 @@ const IDLE_AFTER_TOOL_USE = [
   '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
 ].join('\n')
 
+// Regression guard for the 94-retry starvation incident (2026-06-30): a
+// COMPLETED turn's final spinner frame "Accomplishing… (Ns · ↓ N tokens)" is
+// not always overwritten on completion -- it can stay rendered in scrollback
+// well ABOVE the now-empty idle input box. The whole-pane BUSY_INDICATORS scan
+// matched it and pinned the (genuinely idle) session busy forever, so the
+// scheduler deferred every tick. The token-counter scan is now region-scoped;
+// a stale counter ≥13 lines up must NOT count. Idle.
+const IDLE_STALE_TOKEN_COUNTER = [
+  '✶ Accomplishing… (3m 8s · ↓ 9.3k tokens)',
+  '  ⎿  Tip: Use /btw to ask a quick side question',
+  '⏺ Done: rebuilt and restarted the dashboard.',
+  '⏺ Verified all endpoints return 200.',
+  '⏺ Logged the fix to the daily log.',
+  '⏺ Another line of completed scrollback output.',
+  '⏺ And one more, pushing the counter out of the live region.',
+  '⏺ Final trailing summary line before the idle box.',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
 // Multibyte / non-ASCII content sitting in scrollback above an empty, idle
 // input box. The idle classification must not be perturbed by wide glyphs,
 // accented Latin, CJK or emoji in the reply text above.
@@ -86,6 +109,20 @@ const BUSY_FULL_FOOTER = [
 // closes (a tick here previously sent a prompt into a mid-turn pane).
 const BUSY_FOOTER_FRAME_GAP = [
   '✢ Combobulating… (52s · ↓ 2.6k tokens · thinking some more)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Live turn with real scrollback above: the spinner/token line renders just
+// above the input box (inside the live region) while older output sits higher.
+// The region scope must still catch this genuine mid-turn pane. Busy.
+const BUSY_LIVE_SPINNER_WITH_SCROLLBACK = [
+  '⏺ Earlier completed output line one.',
+  '⏺ Earlier completed output line two.',
+  '✶ Accomplishing… (52s · ↓ 2.6k tokens)',
   '',
   SEP,
   '❯ ',
@@ -173,6 +210,9 @@ describe('paneLooksIdle', () => {
     it('multibyte / emoji content in scrollback above an empty idle box', () => {
       expect(paneLooksIdle(IDLE_MULTIBYTE_SCROLLBACK)).toBe(true)
     })
+    it('stale token-counter scrolled above the idle box (94-retry regression)', () => {
+      expect(paneLooksIdle(IDLE_STALE_TOKEN_COUNTER)).toBe(true)
+    })
   })
 
   describe('busy surfaces -> false', () => {
@@ -184,6 +224,9 @@ describe('paneLooksIdle', () => {
     })
     it('esc to interrupt footer marker alone', () => {
       expect(paneLooksIdle(BUSY_ESC_ONLY)).toBe(false)
+    })
+    it('live spinner just above the box with older scrollback present', () => {
+      expect(paneLooksIdle(BUSY_LIVE_SPINNER_WITH_SCROLLBACK)).toBe(false)
     })
   })
 

--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -530,6 +530,29 @@ describe('detectPaneState', () => {
     expect(detectPaneState(IDLE_AFTER_TOOL_USE)).toBe('idle')
   })
 
+  it('does NOT classify a stale token-counter scrolled above the box as busy', () => {
+    // 94-retry starvation regression (2026-06-30): a completed turn's final
+    // "Accomplishing… (Ns · ↓ N tokens)" frame lingered well above the idle
+    // input box. The token-counter scan is region-scoped, so a counter that
+    // has scrolled out of the live bottom region must not pin the pane busy.
+    const staleCounter = [
+      '✶ Accomplishing… (3m 8s · ↓ 9.3k tokens)',
+      '⏺ Done: rebuilt and restarted the dashboard.',
+      '⏺ Verified endpoints, logged the fix.',
+      '⏺ Extra trailing scrollback line one.',
+      '⏺ Extra trailing scrollback line two.',
+      '⏺ Extra trailing scrollback line three.',
+      '⏺ Extra trailing scrollback line four.',
+      '⏺ Extra trailing scrollback line five.',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectPaneState(staleCounter)).toBe('idle')
+  })
+
   it('detects typing when text is parked in the input box', () => {
     expect(detectPaneState(TYPING_PARKED)).toBe('typing')
   })

--- a/src/__tests__/schedule-runner-resubmit-escalation.test.ts
+++ b/src/__tests__/schedule-runner-resubmit-escalation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { decideScheduledResubmitAction } from '../web/schedule-runner.js'
+
+// A scheduled prompt's closing Enter is occasionally swallowed by the Claude
+// TUI in raw mode, leaving the prompt parked in the input box. A parked box
+// reads 'typing' (not idle), so isSessionReadyForPrompt() stays false and every
+// subsequent scheduled task is deferred -- the session pins itself busy for
+// hours on one stranded prompt (2026-07-01: 3223 deferrals, 0/96 heartbeats
+// fired in 24h). The old resubmit only pressed bare Enter and gave up after 5;
+// a persistently swallowed Enter never recovered. The escalation ladder now
+// escalates to a real clear + re-inject.
+
+describe('decideScheduledResubmitAction: post-send resubmit escalation ladder', () => {
+  it('does nothing when the prompt is not parked (already submitted)', () => {
+    expect(decideScheduledResubmitAction(0, false)).toBe('none')
+    expect(decideScheduledResubmitAction(3, false)).toBe('none')
+  })
+
+  it('tries a cheap bare Enter for the first two attempts', () => {
+    expect(decideScheduledResubmitAction(0, true)).toBe('enter')
+    expect(decideScheduledResubmitAction(1, true)).toBe('enter')
+  })
+
+  it('escalates to clear + re-inject once bare Enter keeps failing', () => {
+    expect(decideScheduledResubmitAction(2, true)).toBe('reinject')
+    expect(decideScheduledResubmitAction(3, true)).toBe('reinject')
+    expect(decideScheduledResubmitAction(5, true)).toBe('reinject')
+  })
+
+  it('gives up at the hard cap so a truly wedged box does not spin forever', () => {
+    expect(decideScheduledResubmitAction(6, true)).toBe('giveup')
+    expect(decideScheduledResubmitAction(10, true)).toBe('giveup')
+  })
+
+  it('never gives up while the box is empty, regardless of attempt count', () => {
+    expect(decideScheduledResubmitAction(6, false)).toBe('none')
+  })
+})
+
+describe('schedule-runner: resubmit wiring uses the real clear + re-inject', () => {
+  const SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+
+  it('imports the verified parked-input clear routine', () => {
+    expect(SRC).toMatch(/clearStaleParkedInput/)
+  })
+
+  it('re-injects the full prompt with the idle gate off (box is typing, not idle)', () => {
+    expect(SRC).toMatch(/sendPromptToSession\(session, fullPrompt, host, \{ waitForIdle: false \}\)/)
+  })
+
+  it('routes the resubmit action through the pure decision function', () => {
+    expect(SRC).toMatch(/decideScheduledResubmitAction\(attempt, stuck\)/)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -86,13 +86,23 @@ const IDLE_FOOTER_RX = /bypass permissions on(?: \(shift\+tab to cycle\)| · [^\
 // that renames the spinner labels will miss the label regex but still
 // be caught by the tokens pattern.
 const BUSY_INDICATORS: RegExp[] = [
-  // NOTE: /\besc to interrupt\b/ is NOT in this whole-pane list.
+  // NOTE: /\besc to interrupt\b/ is NOT in this list.
   // It is checked separately via BUSY_ESC_TO_INTERRUPT_RX scoped to the
   // bottom LIVE_FOOTER_REGION_LINES lines, because a watchdog report or
   // tool-call output that quotes the phrase in scrollback would otherwise
   // permanently pin the session as busy (81-retry starvation incident).
-  // Tokens-down-arrow counter: "(52s · ↓ 2.6k tokens ..." Turn-scoped,
-  // overwritten with whitespace the moment the turn completes.
+  //
+  // These patterns are ALSO region-scoped (to BUSY_LIVE_REGION_LINES, see
+  // below) for the same reason: a completed turn's final spinner frame
+  // "Accomplishing… (3m 8s · ↓ 9.3k tokens)" is NOT always overwritten on
+  // completion -- only the footer line is. A stale token-counter line left
+  // rendered ABOVE the live (empty) input box of a genuinely idle session
+  // would otherwise match whole-pane and pin it busy forever (observed:
+  // 94 consecutive scheduler retries on an idle neo-channels session,
+  // 2026-06-30). The live spinner/token line renders just above the input
+  // box during a real turn, so the bottom-region scope still catches it.
+  //
+  // Tokens-down-arrow counter: "(52s · ↓ 2.6k tokens ..."
   /\(\s*\d+s\s*·\s*↓\s*\d/,
   // Known spinner labels paired with the turn-scoped `(Ns · ↓` tail on
   // the same line. The tail requirement kills the "Thinking…" prose
@@ -110,6 +120,14 @@ const BUSY_INDICATORS: RegExp[] = [
 // contained the phrase in its body).
 const BUSY_ESC_TO_INTERRUPT_RX = /\besc to interrupt\b/
 const LIVE_FOOTER_REGION_LINES = 5
+
+// How many trailing lines the BUSY_INDICATORS (spinner / token-counter)
+// scan inspects. During a live turn the status line renders just above the
+// input box (footer ~3 lines + box ~2 lines + the spinner line + a little
+// tool-output tail), comfortably inside this window. Must exceed
+// LIVE_FOOTER_REGION_LINES so the spinner line above the box is included,
+// while a stale counter scrolled higher (from a completed turn) is excluded.
+const BUSY_LIVE_REGION_LINES = 12
 
 // Pasted-text placeholder. Claude Code lifts a single large input write
 // (empirically a tmux send-keys -l of more than ~700 chars) into a
@@ -398,9 +416,9 @@ export interface DetectPaneStateOptions {
  *
  * Algorithm, in order:
  *   1. Empty / whitespace-only -> 'unknown'.
- *   2. Any BUSY_INDICATOR matches anywhere -> 'busy'. This includes the
- *      wider spinner/token-count fallbacks that catch the frame-level
- *      footer gap.
+ *   2. Any BUSY_INDICATOR matches in the live bottom region -> 'busy'.
+ *      Covers the spinner/token-count fallbacks that catch the frame-level
+ *      footer gap; region-scoped so a stale counter does not pin idle.
  *   3. No idle footer visible -> 'unknown' (pane is not Claude Code).
  *   4. Wedged thinking-block API error in the live tail -> 'error'.
  *      Checked after the busy guard (a live turn is never 'error') and
@@ -416,15 +434,20 @@ export function detectPaneState(
 ): PaneState {
   if (!pane || !pane.trim()) return 'unknown'
 
+  const paneLines = pane.split('\n')
+
+  // Spinner / token-counter busy signals, scoped to the live bottom region.
+  // Whole-pane scanning let a completed turn's stale token-counter line pin
+  // an idle session busy (see BUSY_LIVE_REGION_LINES).
+  const busyRegion = paneLines.slice(-BUSY_LIVE_REGION_LINES).join('\n')
   for (const rx of BUSY_INDICATORS) {
-    if (rx.test(pane)) return 'busy'
+    if (rx.test(busyRegion)) return 'busy'
   }
 
   // Scope `esc to interrupt` check to the live footer region only.
   // Checking the whole pane would let a scrollback quote of the phrase
   // (e.g. in a watchdog report or a log analysis) permanently classify
   // an idle session as busy.
-  const paneLines = pane.split('\n')
   const footerRegion = paneLines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return 'busy'
 
@@ -625,12 +648,16 @@ export function shouldRetrySubmit(
 ): boolean {
   if (!pane || !pane.trim()) return false
 
-  // Busy pane: the turn is mid-flight, no retry needed.
+  const retryPaneLines = pane.split('\n')
+
+  // Busy pane: the turn is mid-flight, no retry needed. Region-scoped (same
+  // as detectPaneState) so a stale token-counter line does not suppress a
+  // legitimate retry on an idle pane.
+  const retryBusyRegion = retryPaneLines.slice(-BUSY_LIVE_REGION_LINES).join('\n')
   for (const rx of BUSY_INDICATORS) {
-    if (rx.test(pane)) return false
+    if (rx.test(retryBusyRegion)) return false
   }
   // Footer-region `esc to interrupt` check (same scoping as detectPaneState).
-  const retryPaneLines = pane.split('\n')
   const retryFooterRegion = retryPaneLines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
   if (BUSY_ESC_TO_INTERRUPT_RX.test(retryFooterRegion)) return false
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -36,10 +36,42 @@ import {
   sessionExistsOnHost,
   capturePane,
   sendEnterToSession,
+  clearStaleParkedInput,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
 import { runCommandTask } from './command-task.js'
+
+// How many bare-Enter attempts the post-send resubmit tries before escalating
+// to a clear + re-inject, and the hard cap after which it gives up.
+const RESUBMIT_BARE_ENTER_ATTEMPTS = 2
+const RESUBMIT_MAX_ATTEMPTS = 6
+
+export type ResubmitAction = 'none' | 'enter' | 'reinject' | 'giveup'
+
+// Decide what the post-send resubmit loop should do on a given attempt. Pure
+// so the escalation ladder is unit-tested without tmux I/O.
+//
+// A scheduled prompt's closing Enter is occasionally swallowed by the Claude
+// TUI in raw mode, leaving the prompt parked in the input box. A parked box
+// reads 'typing' (not idle), so isSessionReadyForPrompt() stays false and
+// EVERY subsequent scheduled task is deferred -- the session pins itself busy
+// for hours on a single stranded prompt (observed 2026-07-01: 3223 deferrals
+// and 0/96 heartbeats fired in 24h, while the b7bda8f region-scope fix only
+// covered the spinner/busy path, not this typing/parked-input path). Bare
+// Enter alone loses to a persistently swallowed Enter, so after
+// RESUBMIT_BARE_ENTER_ATTEMPTS Enters we escalate to a real clear + re-inject
+// of the prompt. Re-injecting is safe here: the scheduled prompt is locally
+// authored (SKILL.md / bearer-gated editor), not the ghost-suggestion text
+// that gates the MAIN plain-text re-inject path in stuck-input-watcher.
+export function decideScheduledResubmitAction(
+  attempt: number,
+  stuck: boolean,
+): ResubmitAction {
+  if (!stuck) return 'none'
+  if (attempt >= RESUBMIT_MAX_ATTEMPTS) return 'giveup'
+  return attempt < RESUBMIT_BARE_ENTER_ATTEMPTS ? 'enter' : 'reinject'
+}
 
 // --- Schedule Runner ---
 // Checks every minute if any scheduled task is due and injects the prompt
@@ -200,12 +232,28 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
         // hit the laptop session, not a (nonexistent) local one.
         const pane = capturePane(session, host)
         const stuck = pane != null && /❯\s+\S/.test(pane) && pane.includes(marker)
-        if (!stuck) return
-        if (attempt >= 5) {
-          logger.warn({ task: task.name, session }, 'Scheduled prompt still stuck after 5 Enter retries -- giving up')
+        const action = decideScheduledResubmitAction(attempt, stuck)
+        if (action === 'none') return
+        if (action === 'giveup') {
+          logger.warn({ task: task.name, session }, 'Scheduled prompt still stuck after Enter + re-inject retries -- giving up')
           return
         }
-        sendEnterToSession(session, host)
+        if (action === 'reinject') {
+          // The Enter is being swallowed persistently. Clear the parked prompt
+          // and re-type it. clearStaleParkedInput verifies the box is empty
+          // before returning true; if it can't clear (box changed under us, or
+          // its cooldown fired), fall back to one more bare Enter. waitForIdle
+          // is off because the box is 'typing', not idle -- the pre-flight gate
+          // would otherwise burn its whole budget and time out every attempt.
+          if (clearStaleParkedInput(session, host)) {
+            sendPromptToSession(session, fullPrompt, host, { waitForIdle: false })
+            logger.info({ task: task.name, session, attempt }, 'Scheduled prompt re-injected after swallowed Enter')
+          } else {
+            sendEnterToSession(session, host)
+          }
+        } else {
+          sendEnterToSession(session, host)
+        }
         setTimeout(() => resubmit(attempt + 1), 3000)
       } catch (err) {
         logger.warn({ err, task: task.name }, 'Post-send resubmit failed')


### PR DESCRIPTION
--- PR törzs (sablon kitöltve) ---
## A változtatás típusa / Type of change
- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary
A scheduler csak idle pane-be küld promptot. A "busy" detektor (detectPaneState / shouldRetrySubmit, src/pane-state.ts) a spinner/token-számláló mintát az EGÉSZ pane-en kereste. Egy befejezett forduló ottragadt "Accomplishing… (Ns · ↓ N tokens)" sora a beviteli mező felett maradt, és idle session-t is busy-nak jelölt -> a reggeli-napindító 94x, a kanban-audit 64x ragadt be (2026-06-30). Megoldás: a BUSY_INDICATORS scan az alsó 12 sorra (BUSY_LIVE_REGION_LINES) szűkítve, ahogy az "esc to interrupt" már szűkítve volt. Élő fordulónál a spinner a mező felett van (elkapja), a feljebb görgött stale sort nem. +2 regresszió-teszt.

EN: The scheduler only delivers into an idle pane. The busy detector scanned the whole pane for the spinner/token-counter pattern; a completed turn's lingering "(Ns · ↓ N tokens)" line above the empty input box pinned an idle session as busy, starving two scheduled tasks. Fix: scope the BUSY_INDICATORS scan to the bottom 12 lines, mirroring the existing esc-to-interrupt footer scoping. Adds 2 regression tests.

## Kapcsolódó issue / Related issue
Closes #

## Ellenőrzőlista / Checklist
- [x] Kipróbáltam lokálisan (dashboard rebuild + restart, végpontok 200, élesben fut).
- [x] docs/ nem érintett (belső bugfix, nincs telepítés/architektúra-változás).
- [x] Nincs beleégetett szenzitív adat.
- [x] Saját, beszédes nevű branch-ről (fix/scheduler-busy-pin-stale-token-counter).
Teszt: teljes suite zöld (1513 teszt).

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
