### PR TITLE
fix(parked-input): stale-frame guard on #500 main escalation (suppress false-positive)

### DIFF
--- a/src/__tests__/parked-input-escalation.test.ts
+++ b/src/__tests__/parked-input-escalation.test.ts
@@ -34,9 +34,13 @@ vi.mock('node:child_process', async (orig) => ({
   }),
 }))
 vi.mock('../notify.js', () => ({ notifyChannel: vi.fn(async () => {}), notifyTelegram: vi.fn(async () => {}) }))
+// Stale-frame guard liveness probe: default = no recent activity (idle/wedged),
+// so the existing escalate path fires; a test flips it true to assert suppression.
+vi.mock('../db.js', async (orig) => ({ ...(await orig() as object), agentHasActivitySince: vi.fn(() => false) }))
 
 import { clearStaleParkedInput } from '../web/agent-process.js'
 import { notifyChannel } from '../notify.js'
+import { agentHasActivitySince } from '../db.js'
 import { MAIN_CHANNELS_SESSION } from '../web/main-agent.js'
 
 let clock = 1_000_000
@@ -50,6 +54,7 @@ function clearKeystrokes(): string[][] {
 beforeEach(() => {
   h.calls.length = 0
   vi.mocked(notifyChannel).mockClear()
+  vi.mocked(agentHasActivitySince).mockReturnValue(false) // default: idle/wedged
 })
 afterAll(() => { nowSpy.mockRestore() })
 
@@ -70,5 +75,15 @@ describe('parked-input escalation', () => {
   it('still attempts the Ctrl-U clear for a SUB-agent box', () => {
     clearStaleParkedInput('subagent-zara-channels')
     expect(clearKeystrokes().length).toBeGreaterThan(0)
+  })
+
+  it('SUPPRESSES the main escalation when the agent has recent activity (stale frame, not a real wedge)', () => {
+    // 2026-06-30 incident: a leftover delivery fragment ("Koszi a halakat.") read
+    // as parked while the main agent was actively turning -> stale capture, not a
+    // wedge. With recent conversation_log activity, the escalation must NOT fire.
+    vi.mocked(agentHasActivitySince).mockReturnValue(true)
+    for (let i = 0; i < 5; i++) { clearStaleParkedInput(MAIN_CHANNELS_SESSION); clock += COOLDOWN }
+    expect(vi.mocked(notifyChannel)).toHaveBeenCalledTimes(0) // suppressed
+    expect(clearKeystrokes().length).toBe(0)                  // and still never auto-cleared
   })
 })

--- a/src/db.ts
+++ b/src/db.ts
@@ -1407,6 +1407,18 @@ export function getPendingMessages(toAgent?: string): AgentMessage[] {
     .all() as AgentMessage[]
 }
 
+// True if the agent logged any conversation_log turn (inbound OR outbound) since
+// `sinceUnixSec`. Used by the stale-parked-input escalation as a liveness probe:
+// a GENUINELY stuck input box blocks all delivery, so the agent is idle (no
+// turns) for the whole window. Recent activity therefore means the 'typing'
+// +parked capture is a STALE FRAME (the agent is actually busy), not a real
+// wedge -- so the escalation must NOT fire. Indexed by idx_convlog_agent.
+export function agentHasActivitySince(agentId: string, sinceUnixSec: number): boolean {
+  return db.prepare(
+    "SELECT 1 FROM conversation_log WHERE agent_id = ? AND created_at > ? LIMIT 1",
+  ).get(agentId, sinceUnixSec) != null
+}
+
 export function markMessageDelivered(id: number): boolean {
   const now = Math.floor(Date.now() / 1000)
   return db.prepare("UPDATE agent_messages SET status = 'delivered', delivered_at = ? WHERE id = ?").run(now, id).changes > 0

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -38,6 +38,7 @@ import { getSecret } from './vault.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
+import { agentHasActivitySince } from '../db.js'
 
 const TMUX = resolveFromPath('tmux')
 const CLAUDE = resolveFromPath('claude')
@@ -1232,6 +1233,14 @@ const UNWEDGE_COOLDOWN_MS = 30_000
 // so escalation is the only recovery; a sub-agent escalates only after the
 // auto-clear has genuinely failed several times.
 const MAIN_PARKED_ESCALATE_AFTER = 3      // ~90s for the main agent (never auto-cleared)
+// Stale-frame guard window: if the main agent logged ANY conversation_log turn
+// within this window, it is actively processing -- so a 'typing'+parked capture
+// is a STALE FRAME (a leftover delivery fragment / phantom), NOT a real wedge,
+// and the escalation must be suppressed. A genuinely stuck box blocks delivery,
+// so the agent would be idle (no turns) for the whole window. (2026-06-30: the
+// "Koszi a halakat." persona-fragment false-positive fired while the main agent
+// was actively turning for 28 min -- proof the capture was stale, not stuck.)
+const MAIN_PARKED_STALE_ACTIVITY_MS = 120_000
 const SUBAGENT_PARKED_ESCALATE_AFTER = 6  // ~3min for a sub-agent whose auto-clear keeps failing
 // Per-session record of the last un-wedge attempt: when, on what text, how many
 // consecutive attempts failed to empty the box, and whether we already notified
@@ -1278,6 +1287,16 @@ export function clearStaleParkedInput(session: string, host: string | null = nul
     const fails = (prev && prev.sig === parked ? prev.fails : 0) + 1
     const alreadyEscalated = !!(prev && prev.sig === parked && prev.escalated)
     if (!alreadyEscalated && fails >= MAIN_PARKED_ESCALATE_AFTER) {
+      // STALE-FRAME GUARD: only escalate if the main agent is genuinely idle/wedged.
+      // If it logged any turn within the activity window, the box is NOT actually
+      // blocking delivery -- the capture is a stale frame showing a leftover
+      // delivery fragment/phantom -- so suppress (no operator NOTIFY). This is the
+      // fix for the 2026-06-30 "Koszi a halakat." false-positive.
+      if (agentHasActivitySince(MAIN_AGENT_ID, Math.floor((nowMs - MAIN_PARKED_STALE_ACTIVITY_MS) / 1000))) {
+        unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated: false })
+        logger.warn({ session, parked: parked.slice(0, 60), fails }, 'message-router: main-agent parked input -- recent agent activity, treating capture as STALE FRAME; escalation suppressed')
+        return false
+      }
       const preview = parked.slice(0, 80).replace(/[<>&]/g, ' ')
       notifyChannel(
         '⚠️ Beragadt egy parkolt (el nem kuldott) sor a fo-agent input-mezojeben, ' +


### PR DESCRIPTION
## Incident
#500's main-agent escalation sent a **false-positive** to the operator (2026-06-30 16:25): `parked="Koszi a halakat."` — a leftover fragment of the main agent's own persona text (planted by a send-keys delivery into the main box), not a real unsent reply.

**Forensic:** the fragment read as "parked" for **28 min while the main agent was actively turning**. A genuinely stuck box blocks all delivery → the agent would be idle the whole window. So the `'typing'`+parked capture was a **stale frame**, and the escalation fired on it.

## Fix
Gate the main escalation on a liveness probe: `agentHasActivitySince()` (new, indexed `conversation_log` query) checks whether the main agent logged any turn (in/out) within 120s. If it did, the box is **not** actually blocking delivery — the capture is stale — so **suppress** the NOTIFY. Only a genuinely idle/wedged box (no recent turns) escalates, preserving the real case the escalation exists for (operator typed a reply and forgot to send). `main-never-clear` unchanged (still zero keystrokes to the main box).

This is the **stale-frame guard** answer to the design question: a pure 2-capture stability check can't detect a stale frame (both reads are identically stale); the cross-check against *actual agent activity* is the robust discriminator (a real wedge ⇒ no activity).

## Verification
- `tsc`: clean.
- `vitest`: **10/10** — new "suppress on recent activity" + existing escalate-once / one-shot / sub-agent-still-clears / router-abandon / janitor.

## Relation to the pull-model (#1)
The pull-model removes the **root cause** (send-keys delivery fragments in the main box) separately. This guard hardens the escalation against stale frames regardless, and is independently worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)