### PR TITLE
fix(parked-input): dim-text guard -- ghost lines are not real parked input (Szabi-validated root fix)

### DIFF
--- a/src/__tests__/parked-input-escalation.test.ts
+++ b/src/__tests__/parked-input-escalation.test.ts
@@ -1,26 +1,30 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 
-// Escalation behavior of clearStaleParkedInput (agent-process.ts), the #2 fix for
-// the 2026-06-30 1h SILENT fleet-stall: a real reply ("Igen, írd meg Baloghnak a
-// választ") parked in the MAIN agent's box wedged all inter-agent delivery while
-// the auto-clear failed 109x behind a lone WARN. Contract:
-//   - MAIN agent box: NEVER auto-cleared (Ctrl-U would destroy a real reply) ->
-//     NOTIFY the operator once per stuck episode instead.
-//   - sub-agent box: keep the existing Ctrl-U clear path.
-//   - escalation is ONE-SHOT per stuck text (no spam).
+// clearStaleParkedInput (agent-process.ts) contract, as of v1.18.3 + the dim-guard:
+//   - MAIN agent box: NEVER auto-cleared (a parked line could be a real reply --
+//     the 2026-06-30 "Balogh" near-miss); the operator escalation is MUTED
+//     (v1.18.3) so NO notifyChannel fires on the main box either.
+//   - sub-agent box: keep the Ctrl-U clear path for a REAL parked line.
+//   - DIM-GUARD (Szabi insight): a ghost/phantom line renders DIM (SGR-2 faint);
+//     captureParkedInputView strips it, so it reads as NO parked text and is NEVER
+//     treated as a wedge (no clear, no escalate) -- for ANY agent. This is the fix
+//     for the 2026-06-30 "Koszi a halakat." dim-fragment false-positive.
 //
-// capturePane / runTmux are LOCAL to agent-process and both go through
-// node:child_process execFileSync, so we mock execFileSync with arg-inspection:
-// a 'capture-pane' call returns a stable parked pane; everything else (sleeps,
-// send-keys) is a no-op we can inspect.
+// capturePane (-p) and captureParkedInputView (-e) are LOCAL to agent-process and
+// go through node:child_process execFileSync, so we mock execFileSync with
+// arg-inspection: a 'capture-pane' call returns a pane; the -e variant returns
+// `eView` so a test can make the dim-stripped view differ from the plain one.
 
 const h = vi.hoisted(() => {
   const SEP = '─'.repeat(80)
   const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
-  // A stranded, never-submitted real reply parked in the input box.
-  const PARKED = ['', SEP, '❯ Igen, írd meg Baloghnak a választ', SEP, FOOTER].join('\n')
-  const calls: string[][] = []
-  return { PARKED, calls }
+  const LINE = '❯ Igen, írd meg Baloghnak a választ'
+  // Real, normal-intensity parked line (survives the dim strip).
+  const PARKED = ['', SEP, LINE, SEP, FOOTER].join('\n')
+  // Ghost/phantom: the text after the prompt is DIM (SGR-2 faint) -> stripped to
+  // an empty box by captureParkedInputView -> reads as no parked text.
+  const PARKED_DIM = ['', SEP, '❯ \x1b[2mKoszi a halakat.\x1b[22m', SEP, FOOTER].join('\n')
+  return { PARKED, PARKED_DIM, calls: [] as string[][], eView: null as string | null }
 })
 
 vi.mock('node:child_process', async (orig) => ({
@@ -28,7 +32,9 @@ vi.mock('node:child_process', async (orig) => ({
   execFileSync: vi.fn((_file: string, args?: string[]) => {
     if (Array.isArray(args)) {
       h.calls.push(args)
-      if (args.includes('capture-pane')) return h.PARKED
+      if (args.includes('capture-pane')) {
+        return args.includes('-e') ? (h.eView ?? h.PARKED) : h.PARKED
+      }
     }
     return ''
   }),
@@ -41,7 +47,7 @@ import { MAIN_CHANNELS_SESSION } from '../web/main-agent.js'
 
 let clock = 1_000_000
 const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock)
-const COOLDOWN = 31_000 // > UNWEDGE_COOLDOWN_MS so each call increments `fails`
+const COOLDOWN = 31_000 // > UNWEDGE_COOLDOWN_MS so each call re-runs (not cooldown-skipped)
 
 function clearKeystrokes(): string[][] {
   return h.calls.filter(a => a.includes('send-keys') && (a.includes('C-u') || a.includes('C-k')))
@@ -49,26 +55,29 @@ function clearKeystrokes(): string[][] {
 
 beforeEach(() => {
   h.calls.length = 0
+  h.eView = null // default: dim-stripped view == plain (real, non-dim parked line)
   vi.mocked(notifyChannel).mockClear()
 })
 afterAll(() => { nowSpy.mockRestore() })
 
-describe('parked-input escalation', () => {
-  it('NEVER auto-clears the main agent box, and escalates exactly ONCE after K detections', () => {
-    // 3 confirmed-stuck detections past the cooldown -> escalate on the 3rd.
-    for (let i = 0; i < 3; i++) { clearStaleParkedInput(MAIN_CHANNELS_SESSION); clock += COOLDOWN }
-    // CRITICAL contract: the main box is never touched with a clearing keystroke.
-    expect(clearKeystrokes().length).toBe(0)
-    expect(vi.mocked(notifyChannel)).toHaveBeenCalledTimes(1)
-    // one-shot: further detections of the SAME parked text do not re-notify.
-    clearStaleParkedInput(MAIN_CHANNELS_SESSION); clock += COOLDOWN
-    clearStaleParkedInput(MAIN_CHANNELS_SESSION)
-    expect(vi.mocked(notifyChannel)).toHaveBeenCalledTimes(1)
-    expect(clearKeystrokes().length).toBe(0)
+describe('clearStaleParkedInput', () => {
+  it('NEVER auto-clears the main agent box, and (escalation muted) never notifies', () => {
+    for (let i = 0; i < 4; i++) { clearStaleParkedInput(MAIN_CHANNELS_SESSION); clock += COOLDOWN }
+    expect(clearKeystrokes().length).toBe(0)        // main box untouched by clearing keystrokes
+    expect(vi.mocked(notifyChannel)).toHaveBeenCalledTimes(0) // muted (v1.18.3)
   })
 
-  it('still attempts the Ctrl-U clear for a SUB-agent box', () => {
+  it('attempts the Ctrl-U clear for a SUB-agent box with a REAL parked line', () => {
     clearStaleParkedInput('subagent-zara-channels')
     expect(clearKeystrokes().length).toBeGreaterThan(0)
+  })
+
+  it('DIM-GUARD: a dim ghost line is NOT treated as parked -> no clear (any agent)', () => {
+    h.eView = h.PARKED_DIM // the -e/dim-stripped view shows an empty box
+    clearStaleParkedInput('subagent-zara-channels')
+    expect(clearKeystrokes().length).toBe(0) // ghost stripped -> no parked text -> no action
+    // and the main box likewise stays untouched + silent on a dim ghost
+    clearStaleParkedInput(MAIN_CHANNELS_SESSION)
+    expect(vi.mocked(notifyChannel)).toHaveBeenCalledTimes(0)
   })
 })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1248,7 +1248,15 @@ const unwedgeAttempts = new Map<string, { last: number; sig: string; fails: numb
 export function clearStaleParkedInput(session: string, host: string | null = null): boolean {
   const a = capturePane(session, host)
   if (a == null || detectPaneState(a) !== 'typing') return false
-  const parked = parkedInputText(a)
+  // DIM-GUARD (2026-06-30, Szabi insight): extract the parked TEXT from the
+  // dim-stripped (-e) view. Ghost/phantom frames -- stale captures, placeholder
+  // hints, a persona fragment left by a send-keys delivery (the "Koszi a halakat."
+  // false-positive) -- render DIM (SGR-2 faint) and are stripped by
+  // captureParkedInputView, so they read as NO parked text and are never treated
+  // as a wedge (no clear, no escalate). Only a REAL typed line (normal intensity)
+  // survives the strip. Falls back to the plain capture only if the -e capture
+  // fails (rare), preserving prior behaviour in that edge case.
+  const parked = parkedInputText(captureParkedInputView(session, host) ?? a)
   if (!parked) return false
 
   // Cooldown guard FIRST, before any blocking sleep: if the same parked text was
@@ -1264,8 +1272,9 @@ export function clearStaleParkedInput(session: string, host: string | null = nul
   try { execFileSync('/bin/sleep', [PARKED_STABLE_CONFIRM_S], { timeout: 4000 }) } catch { /* best effort */ }
   const b = capturePane(session, host)
   // Changed (someone is typing) or already cleared -> leave it alone, and do not
-  // record an attempt (this was never a stuck box).
-  if (b == null || detectPaneState(b) !== 'typing' || parkedInputText(b) !== parked) return false
+  // record an attempt (this was never a stuck box). Compare on the SAME dim-
+  // stripped view as the initial extraction so a dim ghost can't flip the result.
+  if (b == null || detectPaneState(b) !== 'typing' || parkedInputText(captureParkedInputView(session, host) ?? b) !== parked) return false
 
   // The main agent's input box is NEVER auto-cleared (a parked line could be a
   // real reply -- the 2026-06-30 "Balogh" near-miss). The operator escalation is


### PR DESCRIPTION
## Root fix for the parked-input false-positive
2026-06-30: #500's escalation fired on `"Koszi a halakat."` — a **dim persona fragment** read as a parked reply while the main agent was actively turning for 28 min. **Szabi's insight:** ghost/phantom lines render **DIM (SGR-2 faint)** in the terminal, distinguishable from a real typed command.

The machinery already exists: `captureParkedInputView` (`-e` capture + `stripGhostSuggestion`, which strips **all** SGR-2 dim text) — but `clearStaleParkedInput` extracted the parked text from the **plain** `capturePane`, so a dim ghost read as real parked input.

## Fix
`clearStaleParkedInput` now extracts the parked **text** from the dim-stripped `captureParkedInputView` (plain-capture fallback if the `-e` capture fails), at both the initial detection and the stability re-check. A dim ghost strips to an empty box → `parkedInputText` returns null → the box is **not** treated as a wedge (no clear, no escalate) — for **any** agent. `detectPaneState` still reads the plain capture (state detection unchanged); only the parked-text extraction is dim-aware. A **real** typed line (normal intensity) survives the strip and is handled exactly as before.

Also **repairs the test** that the v1.18.3 escalation-mute left asserting a now-removed `notifyChannel` call.

## Verification
- `tsc`: clean.
- `vitest`: **10/10** — new contract: main box never auto-cleared + never notifies (muted); sub-agent real line still Ctrl-U cleared; **DIM ghost → no clear / no notify** (the guard); + janitor + router-abandon.

## Relation to other work
- Supersedes #502 (the activity-guard workaround) — the dim-guard distinguishes ghost-vs-real at the **detection source**, the precise root fix. I'll close #502.
- Complements the inbox **pull-model (#1)**, which removes the phantom **source** (send-keys delivery fragments). With this dim-guard in, the muted main escalation can be safely re-enabled (fires only on a real, non-dim parked line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)