### PR TITLE
fix(reliability): loud alert on shared-config collision when fleet OAuth token missing

### DIFF
--- a/src/__tests__/silent-degradation-alert.test.ts
+++ b/src/__tests__/silent-degradation-alert.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { shouldAlertSharedConfigCollision } from '../web/agent-process.js'
+
+// H1 silent-degradation hardening. When the fleet OAuth token is missing,
+// channel sub-agents fall back to the shared ~/.claude. One agent is fine; two
+// or more collide on the single plugin-install slot and silently go deaf. This
+// locks the decision that turns that previously WARN-only degradation into a
+// loud operator alert -- and, crucially, that a PRESENT token never alerts no
+// matter how many channel agents run.
+
+describe('shouldAlertSharedConfigCollision', () => {
+  it('alerts when the token is missing and >1 channel sub-agent shares ~/.claude', () => {
+    expect(shouldAlertSharedConfigCollision(false, 2)).toBe(true)
+    expect(shouldAlertSharedConfigCollision(false, 5)).toBe(true)
+  })
+
+  it('does NOT alert for a single channel sub-agent (it owns the shared dir)', () => {
+    expect(shouldAlertSharedConfigCollision(false, 1)).toBe(false)
+  })
+
+  it('does NOT alert when there are no channel sub-agents', () => {
+    expect(shouldAlertSharedConfigCollision(false, 0)).toBe(false)
+  })
+
+  it('never alerts when the token is present, regardless of agent count', () => {
+    expect(shouldAlertSharedConfigCollision(true, 0)).toBe(false)
+    expect(shouldAlertSharedConfigCollision(true, 1)).toBe(false)
+    expect(shouldAlertSharedConfigCollision(true, 99)).toBe(false)
+  })
+
+  it('threshold is strict (exactly one does not alert, two does)', () => {
+    expect(shouldAlertSharedConfigCollision(false, 1)).toBe(false)
+    expect(shouldAlertSharedConfigCollision(false, 2)).toBe(true)
+  })
+})
+
+// Source-level contract for the launcher wiring, mirroring the
+// isolated-channel-config.test.ts approach: assert the loud-alert path is
+// actually wired into the token-absent branch and that it re-arms when the
+// token returns.
+const SRC = readFileSync(join(__dirname, '../web/agent-process.ts'), 'utf-8')
+
+describe('silent-degradation alert wiring', () => {
+  it('routes the alert through notifyChannel (direct Bot API, not the inter-agent relay)', () => {
+    expect(SRC).toMatch(/import \{ notifyChannel \} from '\.\.\/notify\.js'/)
+    expect(SRC).toMatch(/notifyChannel\(/)
+  })
+
+  it('fires the loud alert from the token-ABSENT branch', () => {
+    expect(SRC).toMatch(/maybeAlertSharedConfigCollision\(name\)/)
+  })
+
+  it('re-arms the one-shot alert when the token reappears', () => {
+    expect(SRC).toMatch(/resetSharedConfigCollisionAlert\(\)/)
+  })
+
+  it('counts channel sub-agents excluding the main agent', () => {
+    expect(SRC).toMatch(/n !== MAIN_AGENT_ID && agentHasChannel\(n\)/)
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -14,7 +14,7 @@ import {
   parkedInputText,
   stripGhostSuggestion,
 } from '../pane-state.js'
-import { agentDir, readAgentModel, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost } from './agent-config.js'
+import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost } from './agent-config.js'
 import {
   buildTmuxInvocation,
   buildSshExec,
@@ -114,6 +114,61 @@ export function hasFleetOauthToken(): boolean {
   } catch {
     return false
   }
+}
+
+// H1 silent-degradation hardening (2026-06-30).
+//
+// When the fleet OAuth token is absent, channel sub-agents skip isolation and
+// fall back to the SHARED ~/.claude (the pre-isolation behaviour, gated in
+// startAgentProcess). ONE channel sub-agent on the shared dir is harmless -- it
+// owns the single plugin-install slot and poller. TWO OR MORE collide on that
+// slot, which is exactly the fleet outage isolation was built to end (only one
+// agent registers its plugin, the rest go deaf -- see
+// ensureIsolatedChannelConfigDir). Today that collision is logged at WARN only,
+// so it stays invisible until a bot silently stops answering.
+//
+// The decision is pure (token-absent AND more-than-one channel sub-agent) so it
+// is unit-tested without I/O, mirroring shouldSendDeferAlert. Token PRESENT ->
+// isolation works -> never alerts, regardless of agent count.
+export function shouldAlertSharedConfigCollision(
+  hasToken: boolean,
+  channelSubAgentCount: number,
+): boolean {
+  return !hasToken && channelSubAgentCount > 1
+}
+
+// Count of channel-HAVING sub-agents in the fleet (main agent excluded -- it
+// comes up via channels.sh and keeps the shared root by design). Uses the same
+// own-token signal as the launch path, so the count reflects which agents will
+// actually contend for the shared ~/.claude plugin slot.
+export function countChannelSubAgents(): number {
+  return listAgentNames().filter((n) => n !== MAIN_AGENT_ID && agentHasChannel(n)).length
+}
+
+// One operator alert per degradation episode: spamming on every spawn would
+// bury the signal. Cleared the moment the token reappears (isolation restored),
+// so a later token-loss re-alerts. Process-local, like defer-alert's dedup set.
+let sharedConfigCollisionAlerted = false
+
+export function resetSharedConfigCollisionAlert(): void {
+  sharedConfigCollisionAlerted = false
+}
+
+// Loud, owner-facing alert routed via notifyChannel (direct Bot API POST from
+// the dashboard process) -- NOT an inter-agent relay, which would itself need a
+// healthy channel agent to deliver. No-op unless the token is absent AND >1
+// channel sub-agent would share ~/.claude.
+function maybeAlertSharedConfigCollision(name: string): void {
+  const count = countChannelSubAgents()
+  if (!shouldAlertSharedConfigCollision(false, count) || sharedConfigCollisionAlerted) return
+  sharedConfigCollisionAlerted = true
+  logger.error(
+    { name, channelSubAgentCount: count },
+    'isolated-config: fleet OAuth token missing with multiple channel sub-agents -- shared ~/.claude plugin-slot collision, bots will go deaf',
+  )
+  void notifyChannel(
+    `⚠️ Flotta-figyelmeztetes: hianyzik a fleet OAuth token (store/.claude-oauth-token), de ${count} csatornas sub-agent fut. Izolacio nelkul mind a kozos ~/.claude-ot hasznalja, igy a plugin-slot utkozik es csak egy bot marad eleresheto (a tobbi elnemul). Javitas: futtasd a \`claude setup-token\`-t, mentsd a store/.claude-oauth-token fajlba, majd inditsd ujra az agenseket.`,
+  ).catch(() => { /* notifyChannel logs internally */ })
 }
 
 // Per-agent isolated CLAUDE_CONFIG_DIR provisioning (2026-06-26 fleet outage).
@@ -614,6 +669,9 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     let oauthTokenEnv = ''
     if (!claudeConfigDir && hasChannel && name !== MAIN_AGENT_ID) {
       if (hasFleetOauthToken()) {
+        // Token present -> isolation works; any earlier degradation is resolved,
+        // so re-arm the one-shot alert for a future token loss.
+        resetSharedConfigCollisionAlert()
         const isolated = ensureIsolatedChannelConfigDir(name, agentProvider)
         if (isolated) {
           claudeConfigDir = isolated
@@ -624,6 +682,9 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
         }
       } else {
         logger.warn({ name }, 'isolated-config: no fleet OAuth token (store/.claude-oauth-token); keeping shared ~/.claude. Run `claude setup-token` and store it to enable per-agent isolation.')
+        // H1: the WARN above is silent. With >1 channel sub-agent sharing
+        // ~/.claude this is an active plugin-slot collision -> raise a loud alert.
+        maybeAlertSharedConfigCollision(name)
       }
     }
     const claudeConfigEnv = claudeConfigDir ? `export CLAUDE_CONFIG_DIR="${claudeConfigDir}" && ` : ''


### PR DESCRIPTION
## Problem

When the fleet OAuth token (`store/.claude-oauth-token`) is absent, channel sub-agents skip per-agent config isolation and fall back to the **shared `~/.claude`** (a deliberate gate in `startAgentProcess` -- a logged-out launch is worse than the dup-poller risk). Today that fallback only emits a `logger.warn`.

That is fine for a single channel sub-agent: it owns the one plugin-install slot and poller. But with **two or more** channel sub-agents sharing `~/.claude`, they collide on `plugins/installed_plugins.json` -- only one agent registers its channel plugin, the rest spawn no poller and go **silently deaf**. This is the exact fleet outage that `ensureIsolatedChannelConfigDir` was built to end, and right now it is invisible until someone notices a bot has stopped answering.

`upstream/main` already has the token-gate and the silent `WARN`, but **no loud alert** -- so the degradation is net-new uncovered here (no existing PR/issue addresses it; adjacent only).

## Change

Promote the previously WARN-only degradation to a loud, owner-facing alert:

- `shouldAlertSharedConfigCollision(hasToken, count)` -- pure gate: alert iff the token is **absent** AND **more than one** channel sub-agent would share `~/.claude`. Unit-tested in isolation, mirroring `shouldSendDeferAlert`. A **present** token never alerts, regardless of agent count.
- `countChannelSubAgents()` -- counts channel-having sub-agents via the same own-token signal as the launch path; the main agent is excluded (it comes up via `channels.sh` and keeps the shared root by design).
- Delivery via `notifyChannel` (direct Bot API POST from the dashboard process), **not** the inter-agent relay -- the relay would itself need a healthy channel agent to deliver, which is precisely what may be broken.
- One-shot dedup so a respawn storm cannot bury the signal; re-armed the moment the token reappears (isolation restored), so a later token loss re-alerts.

Wired into the token-absent branch right after the existing `WARN`.

## Tests

`src/__tests__/silent-degradation-alert.test.ts` -- 9 pure-decision cases (token-absent + >1 alerts; single/zero does not; token-present never alerts; strict threshold) plus 4 source-level wiring assertions, following the `isolated-channel-config.test.ts` pattern. `tsc --noEmit` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
