### PR TITLE
feat(fleet): model-aware context-compaction watcher for non-Claude sub-agents

### DIFF
--- a/src/__tests__/context-compaction.test.ts
+++ b/src/__tests__/context-compaction.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseIdleContextTokensK,
+  decideContextCompaction,
+  type ContextCompactionState,
+  type ContextCompactionThresholds,
+} from '../pane-state.js'
+
+const T: ContextCompactionThresholds = {
+  compactK: 400,
+  ceilingK: 480,
+  confirmMs: 60_000,
+  compactDedupMs: 300_000,
+  alertDedupMs: 1_800_000,
+}
+const EMPTY: ContextCompactionState = { firstOverAt: null, lastCompactAt: null, lastAlertAt: null }
+
+describe('parseIdleContextTokensK', () => {
+  it('parses the idle /clear hint', () => {
+    const pane = 'Churned for 4m 3s\n            new task? /clear to save 292.3k tokens\n❯'
+    expect(parseIdleContextTokensK(pane)).toBeCloseTo(292.3)
+  })
+  it('returns null when the hint is absent (busy / small context)', () => {
+    expect(parseIdleContextTokensK('❯ esc to interrupt')).toBeNull()
+    expect(parseIdleContextTokensK(null)).toBeNull()
+    expect(parseIdleContextTokensK('')).toBeNull()
+  })
+})
+
+describe('decideContextCompaction', () => {
+  it('does nothing below the compact threshold and resets state', () => {
+    const d = decideContextCompaction(292.3, { firstOverAt: 5, lastCompactAt: 5, lastAlertAt: 5 }, 1000, T)
+    expect(d.action).toBe('none')
+    expect(d.next).toEqual(EMPTY)
+  })
+
+  it('null reading (busy tick) HOLDS the spell unchanged so the window survives busy gaps', () => {
+    const prev: ContextCompactionState = { firstOverAt: 100, lastCompactAt: 200, lastAlertAt: 300 }
+    const d = decideContextCompaction(null, prev, 1000, T)
+    expect(d.action).toBe('none')
+    expect(d.next).toEqual(prev)
+  })
+
+  it('accumulates the confirm window across intermittent busy (null) ticks, then compacts', () => {
+    const t0 = 1_000_000
+    // idle over-threshold sighting anchors the spell
+    const s1 = decideContextCompaction(420, EMPTY, t0, T)
+    expect(s1.action).toBe('none')
+    expect(s1.next.firstOverAt).toBe(t0)
+    // agent goes busy (null) mid-window -> spell must be held, not reset
+    const s2 = decideContextCompaction(null, s1.next, t0 + 30_000, T)
+    expect(s2.next.firstOverAt).toBe(t0)
+    // idle again past the confirm window -> compact
+    const s3 = decideContextCompaction(420, s2.next, t0 + 61_000, T)
+    expect(s3.action).toBe('compact')
+    expect(s3.next.lastCompactAt).toBe(t0 + 61_000)
+  })
+
+  it('records but does not compact until the confirm window passes', () => {
+    const t0 = 1_000_000
+    const first = decideContextCompaction(420, EMPTY, t0, T)
+    expect(first.action).toBe('none')
+    const soon = decideContextCompaction(420, first.next, t0 + 30_000, T)
+    expect(soon.action).toBe('none')
+    const later = decideContextCompaction(420, first.next, t0 + 61_000, T)
+    expect(later.action).toBe('compact')
+  })
+
+  it('COMPACTS (not alerts) on first encounter with an already-huge context', () => {
+    const t0 = 5_000_000
+    // huge (>= ceiling) but never compacted this spell: rescue via /compact first
+    const first = decideContextCompaction(941, EMPTY, t0, T)
+    expect(first.action).toBe('none') // confirm window
+    const act = decideContextCompaction(941, first.next, t0 + 61_000, T)
+    expect(act.action).toBe('compact')
+    expect(act.next.lastCompactAt).toBe(t0 + 61_000)
+  })
+
+  it('dedups /compact within the compaction window, re-fires after', () => {
+    const t0 = 2_000_000
+    const prev: ContextCompactionState = { firstOverAt: t0 - 100_000, lastCompactAt: t0, lastAlertAt: null }
+    const blocked = decideContextCompaction(420, prev, t0 + 100_000, T)
+    expect(blocked.action).toBe('none')
+    const refire = decideContextCompaction(420, prev, t0 + 300_001, T)
+    expect(refire.action).toBe('compact')
+  })
+
+  it('escalates to ALERT only after a prior /compact failed to bring it below the ceiling', () => {
+    const t0 = 3_000_000
+    // already compacted this spell, dedup window elapsed, still >= ceiling -> alert
+    const prev: ContextCompactionState = { firstOverAt: t0 - 400_000, lastCompactAt: t0 - 300_001, lastAlertAt: null }
+    const alert = decideContextCompaction(490, prev, t0, T)
+    expect(alert.action).toBe('alert')
+    expect(alert.next.lastAlertAt).toBe(t0)
+    // deduped within alert window
+    const blocked = decideContextCompaction(490, alert.next, t0 + 60_000, T)
+    expect(blocked.action).toBe('none')
+    // re-alert after the alert dedup window (still no fresh compact possible)
+    const reAlert = decideContextCompaction(490, alert.next, t0 + 1_800_001, T)
+    expect(reAlert.action).toBe('alert')
+  })
+
+  it('treats future-dated timestamps (clock skew) as elapsed', () => {
+    const now = 1_000
+    const prev: ContextCompactionState = { firstOverAt: 999_999, lastCompactAt: 999_999, lastAlertAt: null }
+    const d = decideContextCompaction(420, prev, now, T)
+    expect(d.action).toBe('none')
+    expect(d.next.firstOverAt).toBe(now)
+  })
+})

--- a/src/__tests__/model-context-window.test.ts
+++ b/src/__tests__/model-context-window.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { modelContextWindowK, isClaudeModel } from '../web/agent-config.js'
+
+describe('isClaudeModel', () => {
+  it('recognises Claude-routed models (native auto-compaction, watcher skips them)', () => {
+    expect(isClaudeModel('claude-opus-4-8[1m]')).toBe(true)
+    expect(isClaudeModel('claude-sonnet-4-6')).toBe(true)
+  })
+  it('is false for non-Claude routed models (watcher-managed)', () => {
+    expect(isClaudeModel('MiniMax-M3')).toBe(false)
+    expect(isClaudeModel('deepseek-chat')).toBe(false)
+    expect(isClaudeModel('litellm/minimax-m3')).toBe(false)
+    expect(isClaudeModel('qwen3:8b')).toBe(false)
+  })
+})
+
+describe('modelContextWindowK', () => {
+  it('maps known models to their usable window (k tokens), case-insensitive', () => {
+    expect(modelContextWindowK('MiniMax-M3')).toBe(1000)
+    expect(modelContextWindowK('minimax-m2.5')).toBe(200)
+    expect(modelContextWindowK('deepseek-chat')).toBe(120)
+    expect(modelContextWindowK('claude-opus-4-8[1m]')).toBe(1000)
+    expect(modelContextWindowK('claude-haiku-4-5')).toBe(200)
+  })
+  it('peeks at the litellm/<alias> backend', () => {
+    expect(modelContextWindowK('litellm/minimax-m3')).toBe(1000)
+    expect(modelContextWindowK('litellm/minimax-m2')).toBe(200)
+  })
+  it('falls back conservatively for unknown models (compact early, never wedge)', () => {
+    expect(modelContextWindowK('some-unknown-local-model:latest')).toBe(180)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1386,3 +1386,135 @@ export function decideStuckToolCallRecovery(
     next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant, stagnantSince: nextStagnantSince, attempts: 1 },
   }
 }
+
+// ---------------------------------------------------------------------------
+// Context-compaction watcher (2026-07-01, G "context full -> nem valaszol").
+//
+// MiniMax-routed sub-agents run the Claude Code harness against a custom
+// ANTHROPIC_BASE_URL. Claude Code's auto-compaction is keyed to the model's
+// assumed context window, which is miscalibrated for MiniMax-M3 (advertised
+// 1M, but the serving provider caps far lower ~512k). So the conversation can
+// grow toward MiniMax's real cap without Claude Code compacting in time; the
+// API then rejects the oversized request and the agent wedges with no reply.
+//
+// Fix A (prevention): proactively fire `/compact` while the agent is IDLE and
+// its context has grown past a safe threshold, well below the provider cap.
+// Non-destructive -- /compact summarises, and the PreCompact hook saves
+// memory/skill/task-state first, so an early compaction costs little.
+// Fix B (safety net): if context reaches the danger ceiling (compaction not
+// keeping up, or a 429 wedge where /compact itself can't run), ALERT the owner
+// rather than auto-reset -- consistent with decidePaneErrorAlert's deliberate
+// "never auto-nuke a sub-agent on an imperfectly-understood trigger" stance.
+//
+// The token count is read from Claude Code's idle footer hint
+// ("new task? /clear to save 292.3k tokens"), which appears ONLY when the
+// agent is idle -- so a non-null parse doubles as the "safe to compact" gate.
+
+/** Parse the idle context-size hint ("/clear to save N.Nk tokens") into a
+ * token count in thousands (k). Returns null when the hint is absent, i.e.
+ * the agent is busy or its context is too small to bother -- either way,
+ * not a moment to act. */
+export function parseIdleContextTokensK(pane: string | null): number | null {
+  if (!pane) return null
+  const m = pane.match(/\/clear to save\s+([\d.]+)k tokens/)
+  if (!m) return null
+  const v = parseFloat(m[1])
+  return Number.isFinite(v) ? v : null
+}
+
+export interface ContextCompactionState {
+  /** First tick (ms) the context was observed at/over compactK in this spell. */
+  firstOverAt: number | null
+  /** Last tick (ms) a /compact was issued -- dedups the multi-minute compaction. */
+  lastCompactAt: number | null
+  /** Last tick (ms) an owner alert was escalated -- dedups the ceiling alert. */
+  lastAlertAt: number | null
+}
+
+export interface ContextCompactionThresholds {
+  /** Compact once context grows past this (thousand tokens). */
+  compactK: number
+  /** Danger ceiling (thousand tokens): compaction isn't keeping up -> alert. */
+  ceilingK: number
+  /** Context must stay over compactK this long before acting (anti-fluke). */
+  confirmMs: number
+  /** Min gap between /compact issuances (compaction runs for minutes). */
+  compactDedupMs: number
+  /** Min gap between owner alerts within one spell. */
+  alertDedupMs: number
+}
+
+export type ContextCompactionAction = 'none' | 'compact' | 'alert'
+
+export interface ContextCompactionDecision {
+  action: ContextCompactionAction
+  next: ContextCompactionState
+}
+
+const NO_COMPACTION_STATE: ContextCompactionState = { firstOverAt: null, lastCompactAt: null, lastAlertAt: null }
+
+/**
+ * Pure decision for the context-compaction watcher. Dependency-free so it is
+ * unit-testable without tmux/timers. Priority: a danger-ceiling context
+ * escalates to 'alert' (deduped); otherwise an over-threshold context issues
+ * 'compact' (deduped, since compaction takes minutes); otherwise 'none'.
+ *
+ * Guards mirror the other pane-state state machines: a null reading (busy /
+ * idle-low) does not act and HOLDS the spell unchanged (a busy agent's context
+ * hasn't shrunk, so the confirm window survives busy gaps); only a real
+ * below-threshold reading fully resets; a confirm window requires the
+ * over-threshold state to persist before the first action; at the ceiling we
+ * compact first and only alert if a prior compaction failed to bring it down;
+ * future-dated stored timestamps (clock skew) are treated as "elapsed" rather
+ * than stalling the machine.
+ */
+export function decideContextCompaction(
+  tokensK: number | null,
+  prev: ContextCompactionState,
+  now: number,
+  t: ContextCompactionThresholds,
+): ContextCompactionDecision {
+  // Null reading: agent is busy (mid-turn, no idle hint) or its context is too
+  // small to show the hint. This is "unknown this tick", NOT "recovered" -- a
+  // busy agent's context has not shrunk. HOLD the spell unchanged so an agent
+  // that is only intermittently idle (a working sub-agent) still accumulates
+  // its confirm window across busy gaps. Only a real below-threshold reading
+  // clears the spell. Because an action is only emitted on a non-null tick,
+  // /compact is always sent while the agent is idle (safe), never mid-turn.
+  if (tokensK === null) {
+    return { action: 'none', next: { ...prev } }
+  }
+  // Comfortably below threshold: fully reset (fresh spell next time).
+  if (tokensK < t.compactK) {
+    return { action: 'none', next: { ...NO_COMPACTION_STATE } }
+  }
+  // Over threshold. Anchor the spell; clock-skew (future firstOverAt) restarts it.
+  let firstOverAt = prev.firstOverAt ?? now
+  if (now < firstOverAt) firstOverAt = now
+  const sustained = now - firstOverAt >= t.confirmMs
+  if (!sustained) {
+    return { action: 'none', next: { firstOverAt, lastCompactAt: prev.lastCompactAt, lastAlertAt: prev.lastAlertAt } }
+  }
+  const compactElapsed = prev.lastCompactAt === null || now < prev.lastCompactAt || now - prev.lastCompactAt >= t.compactDedupMs
+  // Danger ceiling AND a prior /compact already ran this spell but the context
+  // is still at/above the ceiling after the compaction window -- compaction
+  // isn't keeping up (or it's a wedge where /compact can't run, e.g. a 429).
+  // Escalate to the owner (deduped). Never auto-reset. A FIRST encounter with
+  // an already-huge context (no prior compact this spell) falls through to
+  // /compact below: rescue it before alerting.
+  if (tokensK >= t.ceilingK && prev.lastCompactAt !== null && compactElapsed) {
+    const alertElapsed = prev.lastAlertAt === null || now < prev.lastAlertAt || now - prev.lastAlertAt >= t.alertDedupMs
+    if (alertElapsed) {
+      return { action: 'alert', next: { firstOverAt, lastCompactAt: prev.lastCompactAt, lastAlertAt: now } }
+    }
+    return { action: 'none', next: { firstOverAt, lastCompactAt: prev.lastCompactAt, lastAlertAt: prev.lastAlertAt } }
+  }
+  // Compact zone: fire /compact (deduped so we don't stack summarisations).
+  // Covers the normal over-threshold case AND the first encounter with an
+  // already-huge (>= ceiling) context -- compact first, alert only if that
+  // fails to bring it down.
+  if (compactElapsed) {
+    return { action: 'compact', next: { firstOverAt, lastCompactAt: now, lastAlertAt: prev.lastAlertAt } }
+  }
+  return { action: 'none', next: { firstOverAt, lastCompactAt: prev.lastCompactAt, lastAlertAt: prev.lastAlertAt } }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -18,6 +18,7 @@ import { startInboundProber } from './web/inbound-probe.js'
 import { startChannelHealthMonitor } from './web/channel-health-monitor.js'
 import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
 import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
+import { startContextCompactionWatcher } from './web/context-compaction-watcher.js'
 import { startReauthHealer } from './web/reauth-healer.js'
 import { startAutoRestartRunner } from './web/auto-restart-runner.js'
 import { startModelFallbackRunner } from './web/model-fallback-runner.js'
@@ -325,6 +326,9 @@ export function startWebServer(port = 3420): http.Server {
   const stuckToolCallInterval = webOnly ? undefined : startStuckToolCallWatcher()
   if (!webOnly) logger.info('Stuck-tool-call watcher started (30s poll, 35s offset)')
 
+  const contextCompactionInterval = webOnly ? undefined : startContextCompactionWatcher()
+  if (!webOnly) logger.info('Context-compaction watcher started (60s poll, 50s offset)')
+
   const reauthHealerInterval = webOnly ? undefined : startReauthHealer()
   if (!webOnly && reauthHealerInterval) logger.info('Reauth healer started (3min poll, 90s offset)')
 
@@ -413,6 +417,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(channelHealthInterval)
     clearInterval(stuckInputInterval)
     clearInterval(stuckToolCallInterval)
+    clearInterval(contextCompactionInterval)
     if (reauthHealerInterval) clearInterval(reauthHealerInterval)
     clearInterval(autoRestartInterval)
     clearInterval(modelFallbackInterval)

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -64,6 +64,36 @@ export function readAgentModel(name: string): string {
   }
 }
 
+// True for Claude-routed agents. The Claude Code harness knows a Claude
+// model's real context window and auto-compacts correctly, so those agents
+// don't need the context-compaction watcher. Everything else (MiniMax,
+// DeepSeek, litellm bridge, local Ollama) is routed through a custom
+// ANTHROPIC_BASE_URL whose window the harness can't infer -> watcher-managed.
+export function isClaudeModel(model: string): boolean {
+  return model.toLowerCase().startsWith('claude-')
+}
+
+// Usable context window, in THOUSANDS of tokens, per model. Drives the
+// model-aware compaction thresholds so the watcher works for whatever model
+// an agent is set to -- not just MiniMax-M3. Deliberately conservative
+// (slightly under the advertised max) to leave headroom below the real cap,
+// and the unknown-model fallback is small so an unrecognised model compacts
+// early rather than wedging. Percentages (not this absolute) are what the
+// watcher applies, so tuning the safety margin lives there.
+export function modelContextWindowK(model: string): number {
+  const m = model.toLowerCase()
+  // litellm/<alias>: peek at the aliased backend after the slash.
+  const key = m.startsWith('litellm/') ? m.slice('litellm/'.length) : m
+  if (key.startsWith('minimax-m3')) return 1000   // advertised 1M (direct MiniMax API)
+  if (key.startsWith('minimax-m1')) return 1000
+  if (key.startsWith('minimax-')) return 200      // M2 family ~204k
+  if (key.startsWith('deepseek-')) return 120     // ~128k, conservative
+  if (key.startsWith('claude-opus') || key.startsWith('claude-sonnet')) return 1000
+  if (key.startsWith('claude-haiku')) return 200
+  if (key.startsWith('claude-')) return 200
+  return 180  // unknown (e.g. local Ollama tags): compact early, never wedge
+}
+
 export function writeAgentModel(name: string, model: string): void {
   const configPath = join(agentDir(name), 'agent-config.json')
   let config: Record<string, unknown> = {}

--- a/src/web/context-compaction-watcher.ts
+++ b/src/web/context-compaction-watcher.ts
@@ -1,0 +1,143 @@
+import { execFile } from 'node:child_process'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { PROJECT_ROOT } from '../config.js'
+import { listAgentNames, readAgentRemoteHost, readAgentModel, isClaudeModel, modelContextWindowK } from './agent-config.js'
+import { isAgentRunning, capturePane, sendPromptToSession } from './agent-process.js'
+import { resolveAgentSession } from './channel-mcp-reconnect.js'
+import {
+  parseIdleContextTokensK,
+  decideContextCompaction,
+  type ContextCompactionState,
+  type ContextCompactionThresholds,
+} from '../pane-state.js'
+
+// Proactive context compaction for MiniMax-routed sub-agents (2026-07-01).
+//
+// See pane-state.ts (Context-compaction watcher block) for the full rationale.
+// In short: Claude Code's auto-compaction is miscalibrated against MiniMax's
+// custom endpoint, so a sub-agent's context can grow toward the provider's
+// real cap (~512k for M3) without compacting, then the API rejects the
+// oversized request and the agent wedges with no reply ("Kutasz nem
+// válaszolt"). This watcher reads each MiniMax agent's idle context-size hint
+// and (A) fires `/compact` before the cap, (B) alerts the owner if context
+// reaches the danger ceiling (compaction not keeping up / a 429 wedge).
+//
+// All decision logic is the pure decideContextCompaction() in pane-state.ts
+// (unit-tested); this module is only the I/O + per-session state map,
+// mirroring stuck-input-watcher.ts.
+//
+// Scope: MiniMax agents only. The Claude-routed main agent (Alfred) has a
+// correctly-calibrated native auto-compaction and must NOT be force-compacted.
+
+const NOTIFY_SCRIPT = join(PROJECT_ROOT, 'scripts', 'notify.sh')
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const v = parseInt(raw, 10)
+  return Number.isFinite(v) && v > 0 ? v : fallback
+}
+
+function envFloat(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const v = parseFloat(raw)
+  return Number.isFinite(v) && v > 0 && v <= 1 ? v : fallback
+}
+
+// Model-aware thresholds: compact/ceiling are FRACTIONS of each agent's own
+// context window (from modelContextWindowK), so the watcher works for whatever
+// model an agent is set to -- a 200k model compacts around 156k, a 1M model
+// around 780k. Compact at 78% leaves room for the summarising call itself;
+// alert-ceiling at 94% is the "compaction isn't keeping up" danger line, still
+// below the real cap. Timing is model-independent. All env-tunable.
+const COMPACT_PCT = envFloat('MARVEEN_CTX_COMPACT_PCT', 0.78)
+const CEILING_PCT = envFloat('MARVEEN_CTX_CEILING_PCT', 0.94)
+const CONFIRM_MS = envInt('MARVEEN_CTX_CONFIRM_MS', 60_000)
+const COMPACT_DEDUP_MS = envInt('MARVEEN_CTX_COMPACT_DEDUP_MS', 300_000)
+const ALERT_DEDUP_MS = envInt('MARVEEN_CTX_ALERT_DEDUP_MS', 1_800_000)
+
+function thresholdsForModel(model: string): ContextCompactionThresholds {
+  const windowK = modelContextWindowK(model)
+  return {
+    compactK: Math.round(windowK * COMPACT_PCT),
+    ceilingK: Math.round(windowK * CEILING_PCT),
+    confirmMs: CONFIRM_MS,
+    compactDedupMs: COMPACT_DEDUP_MS,
+    alertDedupMs: ALERT_DEDUP_MS,
+  }
+}
+
+// Offset from the other watchers (15s/30s/45s/60s) so the capture-pane calls
+// do not pile on one tick. Compaction is not latency-sensitive.
+const INITIAL_DELAY_MS = 50_000
+const INTERVAL_MS = 60_000
+
+const NO_STATE: ContextCompactionState = { firstOverAt: null, lastCompactAt: null, lastAlertAt: null }
+
+const watchState = new Map<string, ContextCompactionState>()
+
+// Non-Claude routed agents share the harness's window-miscalibration and are
+// watcher-managed; Claude-routed agents auto-compact correctly on their own.
+function isManagedContextAgent(name: string): boolean {
+  return !isClaudeModel(readAgentModel(name))
+}
+
+function alertOwner(label: string, session: string, tokensK: number): void {
+  const msg =
+    `⚠️ ${label}: a context elérte a veszélyzónát (~${tokensK}k token) és a /compact nem tartja a lépést ` +
+    `(elakadás vagy 429 lehet). Nézd meg: tmux attach -t ${session}. Auto-reset szándékosan NEM fut (kontextusvesztés-védelem).`
+  execFile('/bin/bash', [NOTIFY_SCRIPT, msg], { timeout: 10_000 }, (err) => {
+    if (err) logger.warn({ err, label }, 'context-compaction-watcher: notify.sh escalation failed')
+  })
+}
+
+function checkAgent(name: string, session: string, host: string | null): void {
+  const pane = capturePane(session, host)
+  const tokensK = parseIdleContextTokensK(pane)
+
+  const thresholds = thresholdsForModel(readAgentModel(name))
+  const prev = watchState.get(session) ?? NO_STATE
+  const { action, next } = decideContextCompaction(tokensK, prev, Date.now(), thresholds)
+
+  if (next.firstOverAt === null && next.lastCompactAt === null && next.lastAlertAt === null) {
+    watchState.delete(session)
+  } else {
+    watchState.set(session, next)
+  }
+
+  if (action === 'compact') {
+    logger.info(
+      { agent: name, session, tokensK, compactK: thresholds.compactK },
+      'context-compaction-watcher: context past threshold, firing /compact proactively',
+    )
+    sendPromptToSession(session, '/compact', host)
+  } else if (action === 'alert') {
+    logger.warn(
+      { agent: name, session, tokensK, ceilingK: thresholds.ceilingK },
+      'context-compaction-watcher: context at danger ceiling, escalating to owner (no auto-reset)',
+    )
+    alertOwner(name, session, tokensK ?? thresholds.ceilingK)
+  }
+}
+
+export function startContextCompactionWatcher(): NodeJS.Timeout {
+  function sweep() {
+    for (const name of listAgentNames()) {
+      if (!isAgentRunning(name)) {
+        watchState.delete(resolveAgentSession(name))
+        continue
+      }
+      if (!isManagedContextAgent(name)) continue
+      try {
+        checkAgent(name, resolveAgentSession(name), readAgentRemoteHost(name))
+      } catch (err) {
+        logger.debug({ err, agent: name }, 'context-compaction-watcher: agent check error')
+      }
+    }
+  }
+
+  setTimeout(sweep, INITIAL_DELAY_MS)
+  return setInterval(sweep, INTERVAL_MS)
+}


### PR DESCRIPTION
feat(fleet): model-aware context-compaction watcher for non-Claude sub-agents

Prevents the "context full -> agent stops responding" wedge on non-Claude
routed sub-agents (MiniMax/DeepSeek/litellm/Ollama), whose real context
window the Claude Code harness cannot infer.

- New watcher: reads each agent's idle context-size hint, proactively fires
  /compact past a safe threshold; escalates to an owner alert (no auto-reset)
  only if compaction can't keep up (wedge/429).
- Thresholds are a fraction of each agent's OWN context window
  (modelContextWindowK; compact 78% / ceiling 94%, env-tunable) -> works for
  any model. Claude-routed agents keep native auto-compaction and are skipped.
- Robust to intermittently-idle agents: a busy tick HOLDS the confirm window;
  actions only fire while idle; first huge context compacts before alerting.

15 unit tests; typecheck clean against current develop.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Verified: typecheck clean + 15 unit tests pass against current develop (origin +185). Cherry-picked from the live box and pushed via fork by Alfred.