### PR TITLE
self-pace-gate: strip curl -d/--data payloads before matching (bash-quote-aware)

### DIFF
--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -102,6 +102,43 @@ export function splitSegments(command) {
     .map((s) => s.trim())
 }
 
+// Blank out curl/HTTP DATA-PAYLOAD arguments before self-pace matching. A -d /
+// --data body is data sent over the wire, NEVER a shell invocation, so a trigger
+// token that only appears INSIDE the payload must not false-deny. The classic
+// false-positive: an /api/messages inter-agent dispatch (a legit peer message in
+// a green, operator-authorised review-loop) whose JSON body happens to mention
+// "/api/schedules", "tmux send-keys", "scheduled_tasks.json" or "/loop" -- pure
+// text, not an invocation. Only PROVABLY-LITERAL payloads are stripped:
+// single-quoted '...', ANSI-C $'...', and double-quoted "..." WITHOUT
+// $(...)/backtick. A payload that can run a command substitution (double-quoted
+// with $(...) / backticks) is left intact so a real command-substitution payload
+// is not blanked. A `$(...)` payload is then still denied by SCHEDULER_RX (its `(`
+// sits at a command boundary the anchor recognises); a backtick one leans on the
+// ScheduleWakeup/Cron* runtime tool-deny layer, since SCHEDULER_RX's boundary
+// anchor omits the backtick -- a pre-existing denylist limit (see splitSegments
+// notes), not something this payload-strip introduces. The data FLAG itself is
+// kept, so HTTP-write detection (-d /
+// --data) is unchanged; the URL and method args live OUTSIDE the payload, so a
+// real WRITE to /api/schedules is still denied.
+//
+// Quote classes match BASH parsing, not C. Inside a plain '...' a backslash is
+// LITERAL and the FIRST following ' always closes the string, so the class is
+// '[^']*'. A C-style '(?:[^'\\]|\\.)*' would treat \' as an escaped quote and
+// scan PAST bash's real closing quote -- e.g. `curl -d 'x\' ; crontab -r` would
+// blank the out-of-band `; crontab -r` and let a real self-pace command slip.
+// ANSI-C $'...' DOES process \', so that branch keeps the \\. escape form; "..."
+// keeps it too (backslash is special inside bash double quotes).
+export function stripDataPayloads(seg) {
+  return String(seg ?? '').replace(
+    /((?:^|\s)(?:-d|--data(?:-(?:raw|binary|ascii|urlencode))?)(?:\s+|=))('[^']*'|\$'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")/gi,
+    (full, flag, arg) => {
+      const dq = arg.startsWith('"')
+      if (dq && (arg.includes('$(') || arg.includes('`'))) return full // may substitute -> keep
+      return flag + (dq ? '""' : "''") // literal payload -> blank the content
+    },
+  )
+}
+
 // Pure decision: does this tool call set up self-pace / self-injection?
 export function gateDecision(toolName, toolInput) {
   const name = String(toolName ?? '')
@@ -112,9 +149,17 @@ export function gateDecision(toolName, toolInput) {
     if (SCHEDULE_STORE_RX.test(fp)) return { deny: true }
   }
   if (name === 'Bash') {
+    // Strip -d/--data payloads on the WHOLE command BEFORE splitting. A payload is
+    // data, not an invocation; and since splitSegments is NOT quote-aware, a shell
+    // separator (; && | &) INSIDE a dispatch body would otherwise orphan a fragment
+    // that false-matches. Stripping first blanks the body (incl. any separators in
+    // it), so the URL/method args still match but the body text never does. A
+    // separator OUTSIDE the payload still splits, so `curl -d '' x ; crontab -r`
+    // is still caught.
+    const safeCommand = stripDataPayloads(String(toolInput?.command ?? ''))
     // Per-segment so an unrelated token elsewhere in a compound command cannot
     // turn a legit read (store inspection, schedule-API GET) into a false deny.
-    for (const seg of splitSegments(toolInput?.command)) {
+    for (const seg of splitSegments(safeCommand)) {
       if (SELF_PACE_BASH_PATTERNS.some((re) => re.test(seg))) return { deny: true }
       // scheduler binaries: deny the exec/submit forms, allow pure read-listing
       if (SCHEDULER_RX.test(seg) && !SCHEDULER_READ_RX.test(seg)) return { deny: true }

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 // @ts-expect-error -- plain .mjs hook script, no types
-import { gateDecision as selfPaceDecision } from '../../scripts/self-pace-gate.mjs'
+import { gateDecision as selfPaceDecision, stripDataPayloads } from '../../scripts/self-pace-gate.mjs'
 import {
   agentGetsGovernanceGates,
   injectSelfPaceGate,
@@ -66,6 +66,76 @@ describe('self-pace-gate gateDecision', () => {
   it('ALLOWS read-only tools', () => {
     expect(selfPaceDecision('Read', {}).deny).toBe(false)
     expect(selfPaceDecision('Grep', {}).deny).toBe(false)
+  })
+})
+
+// --- stripDataPayloads: a curl -d/--data body is DATA sent over the wire, never
+// a shell invocation, so a trigger token INSIDE the payload must not false-deny a
+// legit dispatch. Only provably-literal payloads are blanked; a payload that can
+// command-substitute ($(...)/backtick) is kept so a real substitution still trips. ---
+describe('self-pace-gate stripDataPayloads (data-payload false-positive guard)', () => {
+  it('blanks a single-quoted -d payload but keeps the flag', () => {
+    expect(stripDataPayloads(`curl -d '{"x":"/api/schedules"}' u`)).toBe(`curl -d '' u`)
+  })
+  it('blanks a double-quoted -d payload without substitution', () => {
+    expect(stripDataPayloads(`curl -d "{tmux send-keys}" u`)).toBe(`curl -d "" u`)
+  })
+  it("blanks an ANSI-C $'...' payload", () => {
+    expect(stripDataPayloads(`curl -d $'{"a":"/loop"}' u`)).toBe(`curl -d '' u`)
+  })
+  it('KEEPS a payload that can command-substitute ($(...))', () => {
+    const cmd = `curl -d "$(crontab -r)" u`
+    expect(stripDataPayloads(cmd)).toBe(cmd)
+  })
+  it('KEEPS a payload with a backtick substitution', () => {
+    const cmd = 'curl -d "`crontab -r`" u'
+    expect(stripDataPayloads(cmd)).toBe(cmd)
+  })
+  it('handles --data / --data-raw / --data-binary / --data-urlencode long forms', () => {
+    for (const flag of ['--data', '--data-raw', '--data-binary', '--data-urlencode']) {
+      expect(stripDataPayloads(`curl ${flag} '/api/schedules' u`)).toBe(`curl ${flag} '' u`)
+    }
+  })
+  it('supports the --data=VALUE equals form', () => {
+    expect(stripDataPayloads(`curl --data='{"/loop":1}' u`)).toBe(`curl --data='' u`)
+  })
+  it('leaves URL/method args outside the payload untouched', () => {
+    expect(stripDataPayloads(`curl -X POST /api/schedules -d '{}'`)).toBe(`curl -X POST /api/schedules -d ''`)
+  })
+  it('is a no-op when there is no -d/--data flag', () => {
+    expect(stripDataPayloads('git status && ls -la')).toBe('git status && ls -la')
+  })
+  it('matches bash single-quote parsing: backslash is literal, first quote closes', () => {
+    // bash: the -d value is `x\`; a C-style escape regex would scan PAST the real
+    // closing quote and blank the out-of-band `; crontab -r`.
+    expect(stripDataPayloads(`curl -d 'x\\' ; crontab -r`)).toBe(`curl -d '' ; crontab -r`)
+  })
+})
+
+// --- integration: the payload-blanking must NOT weaken real WRITE/substitution
+// detection; only the false-deny on a legit dispatch body is removed ---
+describe('self-pace-gate: data-payload guard does not weaken real detection', () => {
+  it('ALLOWS a dispatch whose JSON body merely MENTIONS /api/schedules', () => {
+    expect(selfPaceDecision('Bash', { command: `curl -X POST http://localhost:3420/api/messages -d '{"to":"dev4","content":"please read the /api/schedules docs"}'` }).deny).toBe(false)
+  })
+  it('ALLOWS a dispatch body mentioning tmux send-keys / scheduled_tasks.json / /loop as text', () => {
+    expect(selfPaceDecision('Bash', { command: `curl -X POST http://localhost:3420/api/messages -d '{"to":"dev3","content":"the tmux send-keys path writes scheduled_tasks.json on /loop"}'` }).deny).toBe(false)
+  })
+  it('STILL denies a real WRITE to /api/schedules (URL/method live outside the payload)', () => {
+    expect(selfPaceDecision('Bash', { command: `curl -X POST http://localhost:3420/api/schedules -d '{"schedule":"*/5 * * * *"}'` }).deny).toBe(true)
+  })
+  it('STILL denies a command-substitution payload ($(...) is kept, not blanked)', () => {
+    expect(selfPaceDecision('Bash', { command: `curl -d "$(crontab -r)" http://x` }).deny).toBe(true)
+  })
+  it('STILL denies a blocked binary outside the payload after a separator', () => {
+    expect(selfPaceDecision('Bash', { command: `curl -d '{}' http://x ; crontab -r` }).deny).toBe(true)
+  })
+  it('STILL denies a self-pace after a bash single-quote close (backslash-literal parity)', () => {
+    // regression for the C-vs-bash single-quote desync: the -d value is `x\`, then
+    // the real `; <blocked>` executes -- must still deny for every self-pace route.
+    for (const tail of ['crontab -r', "tmux send-keys -t s 'go' Enter", 'curl -X POST http://h/api/schedules', 'claude /loop 5m foo']) {
+      expect(selfPaceDecision('Bash', { command: `curl -d 'x\\' ; ${tail} ; echo 'z'` }).deny).toBe(true)
+    }
   })
 })
 


### PR DESCRIPTION
## Why this matters

The self-pace Bash hook (a PreToolUse governance gate that stops a sub-agent from scheduling its own future turns) inspects a command by splitting it into segments and matching each against a denylist (scheduler binaries, tmux injection, the schedule store/API, `/loop`). The matcher ran on the RAW command, so a token appearing only inside a `curl -d`/`--data` JSON body was treated as if it were a shell invocation.

Concrete false-positive: a legitimate inter-agent dispatch

    curl -X POST http://host/api/messages -d '{"to":"peer","content":"please read the /api/schedules docs"}'

was DENIED, because `/api/schedules` appeared in the payload -- even though the body is data sent over the wire, never executed. In a green, operator-authorised review loop this silently blocks real peer messages.

## Change

`gateDecision()` now calls a new `stripDataPayloads()` on the whole command before `splitSegments()`. It blanks the CONTENT of a `-d`/`--data*` literal payload while keeping the flag, so:

- the URL and method args (which live OUTSIDE the payload) still match, so a real WRITE stays detected;
- a trigger token that exists ONLY inside the payload no longer false-denies.

Only provably-literal payloads are blanked, and the quote classes match BASH parsing, not C: single-quoted is `'[^']*'` (in bash a backslash is literal and the first `'` closes), while ANSI-C `$'...'` and double-quoted `"..."` keep the escape form (bash processes `\` there). A double-quoted payload containing `$(...)` or a backtick is kept intact, so a real command substitution is still caught.

## Scope / compatibility

- No behavior change for any command without a `-d`/`--data` flag.
- HTTP-write detection (`-d`/`--data` presence) is unchanged -- only the payload CONTENT is blanked, never the flag.
- A real WRITE to `/api/schedules`, a scheduler binary (crontab/at/launchctl), tmux send-keys, `claude /loop`, or a `$(...)` substitution payload after a real separator are all still DENIED (regression-tested).

## Test plan

- `npx vitest run src/__tests__/governance-gates.test.ts` -> 46 passed (30 prior + 16 new: `stripDataPayloads` unit + `gateDecision` integration invariants).
- Full core suite green (103 files / 1533 tests).
- Adversarial review over three rounds. Round 1 found a HIGH false-negative: a C-style single-quote regex over-ran bash's closing quote, so `curl -d 'x\' ; crontab -r` blanked the out-of-band `; crontab -r` and let it slip. Fixed with the bash-parity `'[^']*'` class plus a regression test. Rounds 2 and 3 (375+216 differential fuzz combos against a real-bash execution oracle) found no new false-negative introduced by the strip.

## Known limitations

`SCHEDULER_RX`'s command-boundary anchor does not include a backtick, so a backtick command-substitution is not caught by this Bash layer -- but this is PRE-EXISTING (present with or without this change, and outside `-d` payloads too), documented in the file's KNOWN LIMITATIONS, and covered by the runtime scheduler tool-deny layer. `xargs`-invoked schedulers sit mid-segment and are likewise a pre-existing anchor gap. Neither is introduced or worsened by this change.
