### PR TITLE
installer: key the standalone service labels off SERVICE_ID, fix status detection

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -1,9 +1,10 @@
 import { execSync, spawnSync } from 'node:child_process'
-import { existsSync, readFileSync, writeFileSync, copyFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync, copyFileSync, unlinkSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createInterface } from 'node:readline'
 import { homedir, platform } from 'node:os'
+import { SERVICE_ID, BRAND_NAME, appServiceLabel, LEGACY_SERVICE_ID, LEGACY_APP_SERVICE_LABEL } from '../src/config.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PROJECT_ROOT = join(__dirname, '..')
@@ -192,8 +193,9 @@ async function main() {
   if (os === 'darwin') {
     const installService = await ask('Telepited hatterszolgaltatasnak? (i/n):')
     if (installService.toLowerCase() === 'i' || installService.toLowerCase() === 'igen') {
-      const plistName = 'com.claudeclaw.app'
+      const plistName = appServiceLabel(SERVICE_ID)
       const plistPath = join(homedir(), 'Library', 'LaunchAgents', `${plistName}.plist`)
+      const logPath = `/tmp/${SERVICE_ID}.log`
       const nodePath = execSync('which node', { encoding: 'utf-8' }).trim()
 
       const plist = `<?xml version="1.0" encoding="UTF-8"?>
@@ -216,9 +218,9 @@ async function main() {
   <key>ThrottleInterval</key>
   <integer>5</integer>
   <key>StandardOutPath</key>
-  <string>/tmp/claudeclaw.log</string>
+  <string>${logPath}</string>
   <key>StandardErrorPath</key>
-  <string>/tmp/claudeclaw.log</string>
+  <string>${logPath}</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
@@ -227,6 +229,17 @@ async function main() {
 </dict>
 </plist>`
 
+      // Retire a service unit from an older install that used the legacy fixed
+      // name, so an in-place re-run does not leave an orphan launchd job
+      // fighting for the same port as the newly named one.
+      if (plistName !== LEGACY_APP_SERVICE_LABEL) {
+        const legacyPlist = join(homedir(), 'Library', 'LaunchAgents', `${LEGACY_APP_SERVICE_LABEL}.plist`)
+        if (existsSync(legacyPlist)) {
+          try { execSync(`launchctl unload ${legacyPlist} 2>/dev/null`, { stdio: 'ignore' }) } catch { /* not loaded */ }
+          try { unlinkSync(legacyPlist) } catch { /* already gone */ }
+          warn(`Regi ${LEGACY_APP_SERVICE_LABEL} szolgaltatas eltavolitva (atnevezve: ${plistName})`)
+        }
+      }
       writeFileSync(plistPath, plist)
       try {
         execSync(`launchctl unload ${plistPath} 2>/dev/null`, { stdio: 'ignore' })
@@ -236,7 +249,7 @@ async function main() {
       execSync(`launchctl load ${plistPath}`)
       ok(`Hatterszolgaltatas telepitve: ${plistPath}`)
       ok('Automatikusan indul a gep bekapcsolasakor')
-      console.log(`  Naplo: tail -f /tmp/claudeclaw.log`)
+      console.log(`  Naplo: tail -f ${logPath}`)
       console.log(`  Leallitas: launchctl unload ${plistPath}`)
     }
   } else if (os === 'linux') {
@@ -245,10 +258,10 @@ async function main() {
       const nodePath = execSync('which node', { encoding: 'utf-8' }).trim()
       const serviceDir = join(homedir(), '.config', 'systemd', 'user')
       execSync(`mkdir -p ${serviceDir}`)
-      const servicePath = join(serviceDir, 'claudeclaw.service')
+      const servicePath = join(serviceDir, `${SERVICE_ID}.service`)
 
       const service = `[Unit]
-Description=Marveen AI Asszisztens
+Description=${BRAND_NAME} AI Asszisztens
 After=network.target
 
 [Service]
@@ -262,17 +275,27 @@ RestartSec=5
 WantedBy=default.target`
 
       writeFileSync(servicePath, service)
+      // Retire a legacy-named unit from an older install so the two do not run
+      // side by side after a rename.
+      if (SERVICE_ID !== LEGACY_SERVICE_ID) {
+        const legacyUnit = join(serviceDir, `${LEGACY_SERVICE_ID}.service`)
+        if (existsSync(legacyUnit)) {
+          try { execSync(`systemctl --user disable --now ${LEGACY_SERVICE_ID} 2>/dev/null`, { stdio: 'ignore' }) } catch { /* not active */ }
+          try { unlinkSync(legacyUnit) } catch { /* already gone */ }
+          warn(`Regi ${LEGACY_SERVICE_ID} systemd egyseg eltavolitva`)
+        }
+      }
       execSync('systemctl --user daemon-reload')
-      execSync('systemctl --user enable claudeclaw')
-      execSync('systemctl --user start claudeclaw')
+      execSync(`systemctl --user enable ${SERVICE_ID}`)
+      execSync(`systemctl --user start ${SERVICE_ID}`)
       ok('Systemd szolgaltatas telepitve es elindítva')
-      console.log('  Allapot: systemctl --user status claudeclaw')
-      console.log('  Naplo: journalctl --user -u claudeclaw -f')
+      console.log(`  Allapot: systemctl --user status ${SERVICE_ID}`)
+      console.log(`  Naplo: journalctl --user -u ${SERVICE_ID} -f`)
     }
   } else {
     warn('Windows: hasznald a PM2-t a hatterszolgaltatashoz:')
     console.log('  npm install -g pm2')
-    console.log(`  pm2 start ${join(PROJECT_ROOT, 'dist', 'index.js')} --name claudeclaw`)
+    console.log(`  pm2 start ${join(PROJECT_ROOT, 'dist', 'index.js')} --name ${SERVICE_ID}`)
     console.log('  pm2 save && pm2 startup')
   }
 

--- a/scripts/status.ts
+++ b/scripts/status.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { platform } from 'node:os'
+import { SERVICE_ID, launchdStatusPattern, systemdStatusUnits } from '../src/config.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PROJECT_ROOT = join(__dirname, '..')
@@ -108,7 +109,7 @@ if (existsSync(dbPath)) {
 const os = platform()
 if (os === 'darwin') {
   try {
-    const out = execSync('launchctl list | grep claudeclaw 2>/dev/null', {
+    const out = execSync(`launchctl list | grep -E "${launchdStatusPattern(SERVICE_ID)}" 2>/dev/null`, {
       encoding: 'utf-8',
     }).trim()
     if (out) {
@@ -121,7 +122,7 @@ if (os === 'darwin') {
   }
 } else if (os === 'linux') {
   try {
-    execSync('systemctl --user is-active claudeclaw 2>/dev/null', { encoding: 'utf-8' })
+    execSync(systemdStatusUnits(SERVICE_ID).map((u) => `systemctl --user is-active ${u} 2>/dev/null`).join(' || '), { encoding: 'utf-8' })
     ok('Hatterszolgaltatas (systemd)', 'aktiv')
   } catch {
     warn('Hatterszolgaltatas (systemd)', 'nem aktiv')

--- a/src/__tests__/service-label.test.ts
+++ b/src/__tests__/service-label.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import {
+  appServiceLabel,
+  launchdStatusPattern,
+  systemdStatusUnits,
+  LEGACY_SERVICE_ID,
+  LEGACY_APP_SERVICE_LABEL,
+} from '../config.js'
+
+describe('appServiceLabel derives the standalone-installer service label from SERVICE_ID', () => {
+  it('default install keeps the marveen-derived app label (byte-identical to the pre-change literal minus the legacy name)', () => {
+    expect(appServiceLabel('marveen')).toBe('com.marveen.app')
+  })
+
+  it('a branded install names the app service after the brand slug', () => {
+    expect(appServiceLabel('acme')).toBe('com.acme.app')
+  })
+
+  it('legacy constants are the original claudeclaw names', () => {
+    expect(LEGACY_SERVICE_ID).toBe('claudeclaw')
+    expect(LEGACY_APP_SERVICE_LABEL).toBe('com.claudeclaw.app')
+  })
+})
+
+describe('launchdStatusPattern matches every install shape (fixes the status false-negative)', () => {
+  const re = new RegExp(launchdStatusPattern('marveen'))
+
+  it('matches the standalone-installer app unit', () => {
+    expect(re.test('com.marveen.app')).toBe(true)
+  })
+
+  it('matches the install-macos.sh dashboard unit -- the exact bug the old "grep claudeclaw" check missed', () => {
+    expect(re.test('com.marveen.dashboard')).toBe(true)
+  })
+
+  it('still matches a legacy claudeclaw unit (upgrade compatibility)', () => {
+    expect(re.test('com.claudeclaw.app')).toBe(true)
+  })
+
+  it('does NOT count an ancillary com.<id>.* helper as the dashboard running', () => {
+    // Regression guard for a real host: the broad "com.marveen." prefix wrongly
+    // matched com.marveen.telegram-progress-watchdog and reported the dashboard
+    // as running when it was not.
+    expect(re.test('com.marveen.telegram-progress-watchdog')).toBe(false)
+    expect(re.test('com.marveen.channels')).toBe(false)
+    expect(re.test('com.marveen.channel-coordinator')).toBe(false)
+  })
+
+  it('is right-anchored: a longer segment that merely starts with app/dashboard does not match', () => {
+    // Guards the boundary the comment claims: without the trailing `$` these
+    // would false-positive.
+    expect(re.test('com.marveen.dashboard-helper')).toBe(false)
+    expect(re.test('com.marveen.appliance')).toBe(false)
+    expect(re.test('com.marveen.app.helper')).toBe(false)
+    expect(re.test('com.marveen.dashboardx')).toBe(false)
+  })
+
+  it('does not match an unrelated service or a prefix without the specific suffix', () => {
+    expect(re.test('com.apple.somethingd')).toBe(false)
+    expect(re.test('com.othertool.dashboard')).toBe(false)
+    expect(re.test('com.marveenistnoise')).toBe(false)
+  })
+
+  it('a branded install matches its own dashboard/app plus the legacy name, not an unrelated brand', () => {
+    const reAcme = new RegExp(launchdStatusPattern('acme'))
+    expect(reAcme.test('com.acme.dashboard')).toBe(true)
+    expect(reAcme.test('com.acme.app')).toBe(true)
+    expect(reAcme.test('com.claudeclaw.app')).toBe(true)
+    expect(reAcme.test('com.marveen.dashboard')).toBe(false)
+  })
+})
+
+describe('systemdStatusUnits probes newest install shape first with a legacy fallback', () => {
+  it('lists dashboard, bare id, then legacy for a default install', () => {
+    expect(systemdStatusUnits('marveen')).toEqual(['marveen-dashboard', 'marveen', 'claudeclaw'])
+  })
+
+  it('lists the branded units with the legacy fallback', () => {
+    expect(systemdStatusUnits('acme')).toEqual(['acme-dashboard', 'acme', 'claudeclaw'])
+  })
+
+  it('deduplicates when the id already equals the legacy id', () => {
+    expect(systemdStatusUnits('claudeclaw')).toEqual(['claudeclaw-dashboard', 'claudeclaw'])
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,48 @@ export const MAIN_AGENT_ID = env['MAIN_AGENT_ID'] ?? 'marveen'
 // (launchctl unload/load, kickstart) still targets the right unit.
 export const SERVICE_ID = env['SERVICE_ID'] ?? MAIN_AGENT_ID
 
+// Legacy service id from before the OS service units were keyed off SERVICE_ID
+// (the project originally shipped as "claudeclaw"). Retained so the standalone
+// installer can retire a stale unit on re-run and the status command still
+// recognizes a service created by an older install.
+export const LEGACY_SERVICE_ID = 'claudeclaw'
+export const LEGACY_APP_SERVICE_LABEL = `com.${LEGACY_SERVICE_ID}.app`
+
+// launchd Label for the standalone interactive installer's app process
+// (scripts/setup.ts, `npm run setup`). Keyed off SERVICE_ID so a branded
+// install names its background service after the brand, matching how
+// install-macos.sh already derives its com.<id>.dashboard / .channels units.
+export function appServiceLabel(serviceId: string): string {
+  return `com.${serviceId}.app`
+}
+
+// grep -E alternation matching this install's dashboard/app launchd unit
+// regardless of which installer created it: the SERVICE_ID-derived app service
+// (com.<id>.app from the standalone installer) or dashboard service
+// (com.<id>.dashboard from install-macos.sh), plus the legacy
+// "com.claudeclaw.app". The status command uses it so a running dashboard is
+// detected on every install shape -- the old check only matched the legacy name
+// and silently reported a modern (brand-aware) install as stopped. Anchored
+// with a trailing `$` (the launchd Label is the last field of a
+// `launchctl list` line) so only the exact unit matches -- an ancillary unit
+// whose final segment merely starts with app/dashboard (e.g.
+// com.<id>.dashboard-helper, com.<id>.appliance) does NOT count as "the
+// dashboard is running". The pattern is used unchanged in both `grep -E` and a
+// JS RegExp, so it sticks to features common to both (`$`, groups, `\.`).
+// serviceId is an ASCII slug, so no regex escaping is needed.
+export function launchdStatusPattern(serviceId: string): string {
+  return `(com\\.${serviceId}\\.(app|dashboard)|com\\.${LEGACY_SERVICE_ID}\\.app)$`
+}
+
+// systemd --user unit names to probe for the dashboard, newest install shape
+// first: install-linux.sh's "<id>-dashboard", the standalone installer's
+// "<id>", then the legacy "claudeclaw". The status command reports active if
+// any is active. Deduplicated so an id that already equals the legacy id does
+// not probe the same unit twice.
+export function systemdStatusUnits(serviceId: string): string[] {
+  return [...new Set([`${serviceId}-dashboard`, serviceId, LEGACY_SERVICE_ID])]
+}
+
 export const WEB_PORT = parseInt(env['WEB_PORT'] ?? '3420', 10)
 
 export const WEB_HOST = env['WEB_HOST'] ?? '127.0.0.1'


### PR DESCRIPTION
## Why this matters

Two related loose ends left the project's original "claudeclaw" name where a brand-aware install cannot override it, and left the status command broken:

- The standalone interactive installer (`scripts/setup.ts`, `npm run setup`) hardcodes a `com.claudeclaw.app` launchd label (plus `/tmp/claudeclaw.log`, a `claudeclaw` systemd unit, a `claudeclaw` pm2 name), so it creates a "claudeclaw" service regardless of the operator's brand. The brand-aware `install-macos.sh` / `install-linux.sh` already key their units off `SERVICE_ID` (`com.${SERVICE_ID}.dashboard` / `.channels`); only this standalone path lagged behind.
- `scripts/status.ts` reports the background service by grepping `launchctl list | grep claudeclaw`. On any install created by `install-macos.sh` (default or branded) the service is `com.${SERVICE_ID}.dashboard`, which that grep never matches, so `npm run status` reports a running dashboard as "not running". Repro: install via `install-macos.sh` with defaults, then run `npm run status` -> "Hatterszolgaltatas (launchd): nem fut" while the dashboard is actually up.

## Change

Both now key off `SERVICE_ID` via pure, unit-tested helpers in `src/config.ts`:

- `appServiceLabel(serviceId)` -> `com.<id>.app` (the standalone installer's unit).
- `launchdStatusPattern(serviceId)` -> a right-anchored `grep -E` alternation matching the dashboard/app unit on every install shape (`com.<id>.app`, `com.<id>.dashboard`, legacy `com.claudeclaw.app`) but NOT an ancillary `com.<id>.*` helper (e.g. a progress watchdog, or a longer segment like `com.<id>.dashboard-helper`).
- `systemdStatusUnits(serviceId)` -> the `--user` units to probe, newest shape first (`<id>-dashboard`, `<id>`, legacy `claudeclaw`).

`setup.ts` uses `appServiceLabel` / `BRAND_NAME` for the launchd label, log path, systemd unit + Description, and pm2 name, and retires a legacy-named unit (unload + remove) on an explicit re-run so a rename does not orphan the old one. `status.ts` uses the two status helpers.

## Scope / compatibility

- The legacy names are retained as `LEGACY_SERVICE_ID` / `LEGACY_APP_SERVICE_LABEL` constants and are still matched by `status.ts` and retired by the migration, so a service created by an older `setup.ts` run keeps being detected and is cleanly replaced.
- The default standalone install's label does change: `com.claudeclaw.app` -> `com.marveen.app` (`SERVICE_ID` defaults to `marveen`). This is the one deliberate behavior change. An in-place `git pull` upgrade never re-runs `setup.ts`, so a running default install is untouched until an explicit `npm run setup`; and `status.ts` still matches the legacy label, so it keeps reporting correctly across the transition.
- The persistent-store filenames (`claudeclaw.db` / `.pid`) are intentionally left unchanged: renaming them would break backup/restore and in-place upgrades, and they are not user-facing service labels.

## Test plan

- `npm run typecheck` -- clean.
- `npm run build` -- clean.
- `npx vitest run` -- 104 files, 1546 tests pass, including a new `src/__tests__/service-label.test.ts` (13 tests) covering: the SERVICE_ID-derived + legacy labels; the status pattern matching `com.<id>.app` / `.dashboard` / legacy on default and branded ids while rejecting ancillary units and right-anchor boundary cases (`com.<id>.dashboard-helper`, `.appliance`, `.app.helper`, `.dashboardx`); and the systemd unit probe order + dedup.
- The read-only `scripts/status.ts` path was additionally run live (`npm run status`) to confirm the config import resolves under tsx and the emitted `grep -E` command runs correctly against a real `launchctl list`.

## Known limitations

The install-time launchd/systemd lifecycle (`launchctl load` / `unload`, `systemctl enable`) runs only through the standalone installer, which this change does not exercise end-to-end here (it creates real OS services). The label-derivation logic is unit-tested and the emitted commands were validated in isolation, but a full install / re-run / upgrade cycle is best confirmed on a target machine before release.
