### PR TITLE
feat(message-router): confirmed inter-agent delivery + owner escalati…

### DIFF
--- a/docs/inter-agent-delivery-plan.md
+++ b/docs/inter-agent-delivery-plan.md
@@ -1,0 +1,40 @@
+# Megbízható inter-agent üzenetkézbesítés — terv
+
+**Készült:** 2026-07-02 (Nagymester), a heti önfejlesztési benchmark nyomán.
+**Kiváltó ok:** a migráció utáni ágens-teszt során kétszer beragadt a restic-ads input-mezője, a válaszok késve / rossz sorrendben vagy sehogy érkeztek, és a restic-ads rossz toollal (`SendMessage`) próbált válaszolni, ami némán elveszett.
+
+## 1. A probléma
+
+Az ágensek közti üzenetküldés jelenleg úgy működik, hogy a dashboard **billentyűzet-szimulációval** (`tmux send-keys`) a cél-ágens Claude Code TUI beviteli mezőjébe „gépeli" az üzenetet, majd egy záró `Enter`-t küld (`src/web/agent-process.ts` → `sendPromptToSession`, hívja `src/web/message-router.ts`).
+
+Ez a réteg már **erősen meg van támogatva** (wait-until-idle kapu, 80 karakteres chunkolás, post-send retry loop `retry-enter` és `clear-and-resend` ágakkal a bracketed-paste placeholder ellen). Mégis marad reziduális törékenység, mert egy TUI-ba szimulált billentyűzet elvileg sem determinisztikus:
+
+- A záró `Enter`-t a TUI raw módban időnként lenyeli → az üzenet **parkolva** marad a mezőben.
+- PTY-kontenció esetén több chunk egy >700 bájtos olvasásba csúszik → `[Pasted text #N]` placeholder, amit sima Enter nem submitol.
+- Ha a parkolt szöveg több vizuális sorra nyúlik, a sima Enter újsort szúr be, nem küld.
+
+## 2. Gyökérokok (rangsorolva)
+
+1. **Kézbesítés-igazolás hiánya.** A `message-router` a `sendPromptToSession` visszatérése után **azonnal** `markMessageDelivered`-et hív — nem azt igazolja, hogy az ágens ténylegesen *elindított egy kört* az üzenettel. Ha az Enter lenyelődött, az üzenet „delivered"-ként könyvelődik, de valójában parkol.
+2. **Két „üzenetküldés" fogalom keveredik.** Az ágens a Claude Agent SDK `SendMessage`-ét (in-session al-ágensekre) tévesztette össze a helyes `POST /api/messages` úttal (perzisztens fleet-ágensekre). Nincs EGY validált, egyértelmű tool a válaszra.
+3. **Alapból törékeny transzport.** Billentyűzet-szimuláció egy interaktív TUI-ba — a 2026-os multi-agent best practice szerint (out-of-order, swallowed-input hibák) event-driven, közvetlen kézbesítésre kell váltani ACK+retry-jal.
+
+## 3. Terv — 3 lépcső
+
+### 1. lépcső — Submission-igazolt kézbesítés (gyors, ~1-2 nap, kis kockázat)
+- A `markMessageDelivered` csak akkor fusson le, ha a küldés utáni pane-capture **igazolja a submitet** (a TUI busy-be váltott / a box kiürült), nem pedig a `send-keys` puszta lefutásakor. A meglévő post-send retry loop már mintavételezi a pane-t — ott van a jel, csak a `delivered` flag-et kell utána tenni.
+- Ha a retry-budget kimerül és nincs igazolt submit → ne `delivered`, hanem **maradjon pending + emeljünk figyelmeztetést** (Telegram Bakkinak / log), hogy egy válasz beragadt. Így soha nem tűnik el némán üzenet.
+- **Haszon:** megszűnik a „delivered de parkol" hazugság; a te visszatérő „miért néma?" élményed gyökérokát célozza.
+
+### 2. lépcső — Egy megbízható válasz-tool (közepes, ~1 hét)
+- Vezessünk be egy **dedikált inter-agent MCP toolt** (`send_to_agent` / `reply_to_agent`), ami a validált `/api/messages` úton megy, sanitizált from/to-val, és **read-receipttel** (a küldő visszakapja: kézbesítve/olvasva). Ezzel megszűnik a `SendMessage` vs `curl` találgatás — EGY út van.
+- Az ágensek CLAUDE.md-jében a kézi `curl`-t cseréljük erre a toolra.
+- **Haszon:** a restic-ads-féle „rossz tool, néma veszteség" nem fordulhat elő.
+
+### 3. lépcső — SDK-alapú üzenetsor (stratégiai, nagyobb)
+- Közép távon az ágens-futtatást a **tmux-TUI helyett a Claude Agent SDK-ra** vinni: programozott input-queue, valódi kézbesítési garancia, strukturált state-átadás (a kutatás szerint: tipizált state-objektumok, nem nyers history), **nulla billentyűzet-szimuláció**.
+- Ez a „végleges" megoldás, de nagy refaktor — csak az 1-2. lépcső mérése után érdemes eldönteni, kell-e egyáltalán (lehet, hogy az 1-2. lépcső elég megbízhatóvá teszi a jelenlegit).
+
+## 4. Ajánlás
+
+Kezdjük az **1. lépcsővel** (submission-igazolt kézbesítés + „beragadt üzenet" riasztás) — ez a legkisebb kockázat, a legnagyobb közvetlen haszon, és nem bontja meg a meglévő, jól hangolt retry-logikát. A 2. lépcső utána logikusan ráépül. A 3. lépcsőt csak mérés után.

--- a/src/__tests__/confirmed-delivery.test.ts
+++ b/src/__tests__/confirmed-delivery.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Tier-1 contract tests for confirmed inter-agent delivery.
+//
+// Root cause: the message router marked a message "delivered" the instant
+// send-keys returned, but the Claude TUI occasionally swallows the closing
+// Enter, leaving the prompt parked in the input box. That booked a silent-lie
+// "delivered" while the target never saw the message. The fix makes
+// sendPromptToSession report whether the submit was CONFIRMED and gates the
+// router's bookkeeping on it: confirmed -> delivered; unconfirmed -> failed +
+// escalate to the owner via the main agent (never vanish silently).
+
+const AGENT_PROCESS = readFileSync(join(__dirname, '../web/agent-process.ts'), 'utf-8')
+const MESSAGE_ROUTER = readFileSync(join(__dirname, '../web/message-router.ts'), 'utf-8')
+
+describe('sendPromptToSession confirmed-submit signal', () => {
+  it('returns a boolean (submit-confirmed) instead of void', () => {
+    const sigIdx = AGENT_PROCESS.indexOf('export function sendPromptToSession(')
+    expect(sigIdx).toBeGreaterThan(0)
+    // The closing of the signature must declare a boolean return type.
+    const sig = AGENT_PROCESS.slice(sigIdx, sigIdx + 320)
+    expect(sig).toMatch(/\}\s*=\s*\{\},\s*\)\s*:\s*boolean\s*\{/)
+  })
+
+  it("confirms only on decideSubmitFollowup === 'done' and returns that flag", () => {
+    expect(AGENT_PROCESS).toMatch(/let submitted = false/)
+    // 'done' is the only path that flips submitted true.
+    expect(AGENT_PROCESS).toMatch(/if \(action === 'done'\) \{ submitted = true; break \}/)
+    // The give-up path must NOT set submitted true (stays false -> unconfirmed).
+    const giveUp = AGENT_PROCESS.slice(AGENT_PROCESS.indexOf("if (action === 'give-up')"), AGENT_PROCESS.indexOf("if (action === 'give-up')") + 160)
+    expect(giveUp).not.toMatch(/submitted = true/)
+    // And the function returns the flag.
+    expect(AGENT_PROCESS).toMatch(/\n  return submitted\n\}/)
+  })
+})
+
+describe('message-router gates delivery on confirmed submit', () => {
+  it('captures the sendPromptToSession return value', () => {
+    expect(MESSAGE_ROUTER).toMatch(/const submitted = sendPromptToSession\(session, prefix \+ wrapped, host\)/)
+  })
+
+  it('marks delivered ONLY inside the submitted branch', () => {
+    // markMessageDelivered must sit under `if (submitted)`.
+    const ifIdx = MESSAGE_ROUTER.indexOf('if (submitted) {')
+    expect(ifIdx).toBeGreaterThan(0)
+    const elseIdx = MESSAGE_ROUTER.indexOf('} else {', ifIdx)
+    expect(elseIdx).toBeGreaterThan(ifIdx)
+    const submittedBranch = MESSAGE_ROUTER.slice(ifIdx, elseIdx)
+    expect(submittedBranch).toMatch(/markMessageDelivered\(msg\.id\)/)
+    // markMessageDelivered must NOT appear in the unconfirmed (else) branch.
+    const afterElse = MESSAGE_ROUTER.slice(elseIdx, elseIdx + 2200)
+    expect(afterElse).not.toMatch(/markMessageDelivered/)
+  })
+
+  it('on unconfirmed submit: marks failed and does not claim delivery', () => {
+    const elseIdx = MESSAGE_ROUTER.indexOf('} else {', MESSAGE_ROUTER.indexOf('if (submitted) {'))
+    const branch = MESSAGE_ROUTER.slice(elseIdx, elseIdx + 2200)
+    expect(branch).toMatch(/markMessageFailed\(msg\.id, 'Submit unconfirmed/)
+    expect(branch).toMatch(/logger\.error\(/)
+  })
+
+  it('escalates to the owner via the main agent, guarded against alert->alert recursion', () => {
+    const elseIdx = MESSAGE_ROUTER.indexOf('} else {', MESSAGE_ROUTER.indexOf('if (submitted) {'))
+    const branch = MESSAGE_ROUTER.slice(elseIdx, elseIdx + 2200)
+    // Recursion guard: only escalate when the stranded message was NOT itself
+    // bound for the main agent (the alert is delivered to MAIN_AGENT_ID).
+    expect(branch).toMatch(/if \(msg\.to_agent !== MAIN_AGENT_ID\)/)
+    expect(branch).toMatch(/createAgentMessage\(\s*'message-router',\s*MAIN_AGENT_ID,/)
+  })
+
+  it('imports createAgentMessage from db', () => {
+    expect(MESSAGE_ROUTER).toMatch(/import \{[\s\S]*createAgentMessage[\s\S]*\} from '\.\.\/db\.js'/)
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -699,12 +699,18 @@ function discardPlaceholderBuffer(session: string, host: string | null = null): 
 // still reports stuck, send up to SUBMIT_RETRY_MAX_ATTEMPTS extra
 // Enters. The retry budget bounds the loop so a pathologically stuck
 // pane gives up rather than spinning.
+// Returns whether the submit was CONFIRMED (the post-send retry loop observed
+// the pane leave the parked state -- decideSubmitFollowup === 'done'). Callers
+// that care about delivery integrity (the message router) must gate their
+// "delivered" bookkeeping on this: a `false` return means the prompt is still
+// parked in the target TUI after the retry budget, so claiming delivery would
+// be a silent lie. Legacy callers that ignore the return value are unaffected.
 export function sendPromptToSession(
   session: string,
   text: string,
   host: string | null = null,
   opts: { waitForIdle?: boolean } = {},
-): void {
+): boolean {
   dismissSurveyModalIfPresent(session, host)
   dismissResumeSummaryModalIfPresent(session, host)
 
@@ -794,11 +800,17 @@ export function sendPromptToSession(
   //     multi-row verbatim buffer that a plain Enter cannot submit, so a
   //     resend that itself parks is re-cleared and retried until it lands.
   const payloadHint = oneLine.slice(0, Math.min(oneLine.length, 96))
+  // Confirmed only when the loop observes decideSubmitFollowup === 'done' (the
+  // pane left the parked state). Any terminal 'give-up' -- budget spent, a
+  // failed capture we cannot interpret, or a send error mid-recovery -- leaves
+  // this false so the caller can surface an unconfirmed delivery instead of
+  // silently booking it as delivered.
+  let submitted = false
   for (let attempt = 0; ; attempt++) {
     try { execFileSync('/bin/sleep', [SUBMIT_RETRY_POLL_MS], { timeout: 2000 }) } catch { /* best effort */ }
     const pane = capturePane(session, host)
     const action = decideSubmitFollowup(pane, payloadHint, attempt, SUBMIT_RETRY_MAX_ATTEMPTS)
-    if (action === 'done') break
+    if (action === 'done') { submitted = true; break }
     if (action === 'give-up') {
       logger.warn({ session, attempt }, 'sendPromptToSession: prompt still parked after retries')
       break
@@ -828,6 +840,7 @@ export function sendPromptToSession(
       break
     }
   }
+  return submitted
 }
 
 // How long to wait between the two capture samples when the first one

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -4,6 +4,7 @@ import {
   getPendingMessages,
   markMessageDelivered,
   markMessageFailed,
+  createAgentMessage,
 } from '../db.js'
 import {
   wrapUntrusted,
@@ -158,12 +159,49 @@ export function startMessageRouter(): NodeJS.Timeout {
         }
         // Inline preamble so a fresh session (post hard-restart) doesn't miss
         // the context that explains the tag semantics.
-        sendPromptToSession(session, prefix + wrapped, host)
-        if (!markMessageDelivered(msg.id)) {
-          logger.warn({ id: msg.id }, 'markMessageDelivered affected 0 rows (deleted concurrently?)')
+        //
+        // Gate the "delivered" bookkeeping on a CONFIRMED submit. Previously we
+        // marked delivered the instant send-keys returned -- but the closing
+        // Enter is occasionally swallowed by the Claude TUI, leaving the prompt
+        // parked in the input box. That booked a silent-lie "delivered" while
+        // the target never saw the message (the incident that motivated this).
+        // sendPromptToSession now returns false when its retry budget could not
+        // confirm the submit; treat that as a surfaced failure, not a success.
+        const submitted = sendPromptToSession(session, prefix + wrapped, host)
+        if (submitted) {
+          if (!markMessageDelivered(msg.id)) {
+            logger.warn({ id: msg.id }, 'markMessageDelivered affected 0 rows (deleted concurrently?)')
+          }
+          routerLoggedMisses.delete(msg.id)
+          logger.info({ id: msg.id, from: msg.from_agent, to: msg.to_agent, category: isChannelInbound ? 'channel-inbound' : trusted ? 'trusted-peer' : 'untrusted' }, 'Agent message delivered')
+        } else {
+          // Submit unconfirmed: the prompt is parked in the target TUI after
+          // the send-retry budget. Do NOT claim delivery. Mark failed so the
+          // router stops re-scanning it (the text is already sitting in the box
+          // -- re-sending next tick would just duplicate it), and escalate to
+          // the owner through the main agent instead of vanishing silently.
+          logger.error({ id: msg.id, from: msg.from_agent, to: msg.to_agent }, 'Agent message delivery UNCONFIRMED (parked in target TUI after retry budget); marking failed and alerting owner')
+          if (!markMessageFailed(msg.id, 'Submit unconfirmed: parked in target TUI after retry budget')) {
+            logger.warn({ id: msg.id }, 'markMessageFailed affected 0 rows (deleted concurrently?)')
+          }
+          routerLoggedMisses.delete(msg.id)
+          // Escalate via the main agent, UNLESS the stranded message was itself
+          // bound for the main agent -- the alert below is delivered to
+          // MAIN_AGENT_ID through this same router, so alerting on a failed
+          // main-agent delivery would loop (alert -> fails -> alert -> ...).
+          if (msg.to_agent !== MAIN_AGENT_ID) {
+            const preview = msg.content.slice(0, 80).replace(/\s+/g, ' ')
+            try {
+              createAgentMessage(
+                'message-router',
+                MAIN_AGENT_ID,
+                `⚠️ Kézbesítési figyelmeztetés: a(z) "${msg.from_agent}" → "${msg.to_agent}" üzenet (#${msg.id}) nem tudott igazoltan beérni — beragadt a cél input-mezőjében a retry-budget után. Tartalom eleje: "${preview}". Nézz rá a(z) ${msg.to_agent} ágensre, és jelezd Bakkinak, ha kézi beavatkozás kell.`,
+              )
+            } catch (err) {
+              logger.warn({ err, id: msg.id }, 'Failed to enqueue stuck-delivery alert to main agent')
+            }
+          }
         }
-        routerLoggedMisses.delete(msg.id)
-        logger.info({ id: msg.id, from: msg.from_agent, to: msg.to_agent, category: isChannelInbound ? 'channel-inbound' : trusted ? 'trusted-peer' : 'untrusted' }, 'Agent message delivered')
       } catch (err) {
         logger.warn({ err, id: msg.id }, 'Failed to deliver agent message')
         if (!markMessageFailed(msg.id, 'Failed to inject into tmux session')) {


### PR DESCRIPTION
…on (Tier 1)

The router marked a message "delivered" the instant send-keys returned, but the Claude TUI occasionally swallows the closing Enter, leaving the prompt parked in the target input box. That booked a silent-lie "delivered" while the receiver never saw the message (the incident that motivated this: two stuck inter-agent messages during the post-migration fleet test).

sendPromptToSession now returns whether the submit was CONFIRMED (the existing post-send retry loop observed decideSubmitFollowup === 'done'). The router gates its bookkeeping on it:
  - confirmed   -> markMessageDelivered (unchanged healthy path)
  - unconfirmed -> markMessageFailed + LOUD logger.error, and escalate to the
    owner via the main agent (createAgentMessage -> MAIN_AGENT_ID), guarded
    against alert->alert recursion when the stranded message was itself bound
    for the main agent.

No message vanishes silently anymore: a parked delivery surfaces as a failure plus an owner-facing alert instead of a false success. Healthy deliveries are unaffected.

Adds docs/inter-agent-delivery-plan.md (the 3-tier plan) and a source-contract test suite. Full suite green (1331 passed), typecheck + build clean.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
