### PR TITLE
fix(channels): escalate absent-plugin agents after one restart, not five

### DIFF
--- a/src/__tests__/agent-restart-policy.test.ts
+++ b/src/__tests__/agent-restart-policy.test.ts
@@ -313,4 +313,32 @@ describe('decideDownAgentAction', () => {
     // No cap -> never escalates to 'alert', however high the failure count.
     expect(decideDownAgentAction({ ...restartable, consecutiveFailures: 999 }, 0)).toBe('restart')
   })
+
+  // The channel-monitor passes maxRestartAttempts=1 when the unlock probe has
+  // confirmed the plugin ABSENT from /mcp (never loaded). Fresh-restarting
+  // cannot reload it, so one attempt then escalate. Pin that exact semantics.
+  describe("absent-plugin cap (maxRestartAttempts=1)", () => {
+    const ABSENT_MAX = 1
+
+    it("allows exactly one restart, then alerts", () => {
+      // First down-spell: no prior watchdog restart yet -> restart once.
+      expect(decideDownAgentAction({ ...restartable, consecutiveFailures: 0 }, ABSENT_MAX)).toBe('restart')
+      // After that restart ticked the counter to 1, the next confirmed-absent
+      // sweep escalates instead of nuking the agent's context again.
+      expect(decideDownAgentAction({ ...restartable, consecutiveFailures: 1 }, ABSENT_MAX)).toBe('alert')
+      // And stays silent thereafter.
+      expect(decideDownAgentAction({ ...restartable, consecutiveFailures: 2 }, ABSENT_MAX)).toBe('skip')
+    })
+
+    it("still honours the startup grace on the first attempt", () => {
+      // A brand-new session that came up absent must not be torn down before it
+      // has had its full startup window (the absent verdict does not override
+      // the young-process guard).
+      expect(decideDownAgentAction({
+        ...restartable,
+        processAgeMs: 20_000, // within startup grace
+        consecutiveFailures: 0,
+      }, ABSENT_MAX)).toBe('skip')
+    })
+  })
 })

--- a/src/__tests__/channel-plugin-unlock.test.ts
+++ b/src/__tests__/channel-plugin-unlock.test.ts
@@ -125,3 +125,51 @@ describe('channel-monitor wires the unlock probe into both in-process respawn pa
     expect(body).toMatch(/schedulePluginUnlockAfterRespawn\(MAIN_CHANNELS_SESSION/)
   })
 })
+
+describe('absent-plugin verdict feeds the down-cascade restart budget', () => {
+  // 2026-07-01: rocket + mantis fresh-restarted 5x each on a plugin that was
+  // ABSENT from /mcp (never loaded, distinct from Failed/disabled). Fresh
+  // restarts cannot reload an absent plugin and each one wipes the agent's
+  // session context. The probe records the absent verdict; the monitor caps the
+  // restart budget at one for that case. These pin the wiring end to end.
+
+  it('records the absent verdict in the "plugin absent from /mcp list" branch', () => {
+    // The absent branch must call markPluginAbsent so the monitor can react;
+    // and it must be gated to the absent (not the slow/Failed) case.
+    expect(helper).toMatch(/provider plugin absent from \/mcp list/)
+    const sendStart = helper.indexOf('function sendUnlockKeystrokes')
+    const sendEnd = helper.indexOf('\n}\n', sendStart)
+    const sendBody = helper.slice(sendStart, sendEnd > sendStart ? sendEnd : undefined)
+    const absentLogIdx = sendBody.indexOf('provider plugin absent from /mcp list')
+    const markIdx = sendBody.indexOf('markPluginAbsent(')
+    expect(markIdx, 'markPluginAbsent not called in the absent branch').toBeGreaterThan(absentLogIdx)
+  })
+
+  it('exports the accessors the monitor reads and clears', () => {
+    expect(helper).toMatch(/export\s+function\s+wasPluginConfirmedAbsent\b/)
+    expect(helper).toMatch(/export\s+function\s+clearPluginAbsent\b/)
+  })
+
+  it('retires the absent verdict once the probe sees the plugin healthy', () => {
+    const probeStart = helper.indexOf('function runUnlockProbe')
+    const probeEnd = helper.indexOf('\n}\n', probeStart)
+    const probeBody = helper.slice(probeStart, probeEnd > probeStart ? probeEnd : undefined)
+    const healthyIdx = probeBody.indexOf('plugin healthy')
+    const clearIdx = probeBody.indexOf('clearPluginAbsent(')
+    expect(clearIdx, 'clearPluginAbsent not called in the healthy branch').toBeGreaterThan(0)
+    expect(clearIdx).toBeLessThan(healthyIdx)
+  })
+
+  it('monitor caps the restart budget at one attempt when absent-confirmed', () => {
+    expect(monitor).toMatch(/wasPluginConfirmedAbsent/)
+    expect(monitor).toMatch(/const\s+PLUGIN_ABSENT_MAX_RESTART_ATTEMPTS\s*=\s*1\b/)
+    // The absent verdict must select the reduced cap, not the full one.
+    expect(monitor).toMatch(/absentConfirmed\s*\n?\s*\?\s*PLUGIN_ABSENT_MAX_RESTART_ATTEMPTS/)
+    // And the chosen cap must be what decideDownAgentAction receives.
+    expect(monitor).toMatch(/\}\s*,\s*maxRestartAttempts\)/)
+  })
+
+  it('monitor clears the absent verdict on a healthy sweep', () => {
+    expect(monitor).toMatch(/clearPluginAbsent\(t\.session\)/)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -21,7 +21,7 @@ import {
 } from './agent-process.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
 import { probeTelegramConflict } from './channel-conflict-probe.js'
-import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
+import { schedulePluginUnlockAfterRespawn, wasPluginConfirmedAbsent, clearPluginAbsent } from './channel-plugin-unlock.js'
 import {
   detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
@@ -135,6 +135,16 @@ const AGENT_MAX_RESTART_GRACE_MS = 60 * 60 * 1000 // 1h
 // the plugin only after a slow session load). Never restart a process younger
 // than this on a "plugin down" reading, or the watchdog crash-loops it.
 const AGENT_STARTUP_GRACE_MS = 180_000
+// When the unlock probe has confirmed the plugin ABSENT from /mcp (never
+// loaded, not merely Failed/disabled), a fresh restart cannot bring it back --
+// it comes up absent again, and each restart wipes the agent's session context
+// (2026-07-01: rocket + mantis burned 5 fresh-restarts each on an absent plugin
+// before the watchdog gave up). Cap the restart budget at ONE for that case so
+// the watchdog escalates to the operator after a single attempt instead of the
+// full AGENT_MAX_RESTART_ATTEMPTS. The absent verdict is honoured only while
+// fresh (re-stamped by each post-respawn probe, cleared on recovery).
+const PLUGIN_ABSENT_MAX_RESTART_ATTEMPTS = 1
+const PLUGIN_ABSENT_TTL_MS = 15 * 60 * 1000
 const PLUGIN_ALERT_DEDUP_MS = 30 * 60 * 1000
 
 // Stuck channel-input recovery (MAIN session only). A channel notification
@@ -1309,6 +1319,9 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // down-spell starts again at the base grace.
           agentRestartFailures.delete(t.agentName!)
           clearPersistedAgentFailures(t.agentName!)
+          // Retire any stale absent verdict too, so a future down-spell starts
+          // with the full restart budget rather than the absent-capped one.
+          clearPluginAbsent(t.session)
         }
         continue
       }
@@ -1318,6 +1331,15 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         if (!agentDownSince.has(t.session)) agentDownSince.set(t.session, Date.now())
         const lastRestart = agentLastRestart.get(t.agentName!)
         const failures = agentRestartFailures.get(t.agentName!) ?? 0
+        // If the unlock probe confirmed the plugin ABSENT from /mcp (never
+        // loaded), fresh-restarting cannot fix it -- cap the budget at one
+        // attempt so we escalate to the operator instead of nuking the agent's
+        // context 5x. A merely Failed/disabled plugin (still in the list) keeps
+        // the full budget: a restart genuinely helps that case.
+        const absentConfirmed = wasPluginConfirmedAbsent(t.session, PLUGIN_ABSENT_TTL_MS)
+        const maxRestartAttempts = absentConfirmed
+          ? PLUGIN_ABSENT_MAX_RESTART_ATTEMPTS
+          : AGENT_MAX_RESTART_ATTEMPTS
         const action = decideDownAgentAction({
           processAgeMs: getProcessAgeMs(claudePid),
           msSinceLastRestart: lastRestart != null ? Date.now() - lastRestart : null,
@@ -1325,7 +1347,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           restartGraceMs: AGENT_RESTART_GRACE_MS,
           consecutiveFailures: failures,
           maxRestartGraceMs: AGENT_MAX_RESTART_GRACE_MS,
-        }, AGENT_MAX_RESTART_ATTEMPTS)
+        }, maxRestartAttempts)
         if (action === 'skip') {
           logger.debug({ agent: t.agentName, provider: t.provider, failures }, 'Channel plugin probe reports down but agent is within startup/restart back-off -- deferring')
           continue
@@ -1336,8 +1358,10 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // loop and hand it to a human. Tick the counter past the cap so this
           // fires exactly once; a later healthy sweep resets it (re-arming the
           // alert for a future down-spell).
-          logger.error({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down after max restart attempts -- giving up, alerting operator')
-          sendAlert(`⛔ A(z) ${t.agentName} agens ${t.provider} csatornaja ${AGENT_MAX_RESTART_ATTEMPTS} automatikus ujrainditas utan sem allt helyre. Tovabb nem indinitom ujra (minden restart elveszi a session kontextusat). Kezi beavatkozas kell: nezd meg a ${t.session} session-t es a ${SERVICE_ID} csatorna-plugint.`)
+          logger.error({ agent: t.agentName, provider: t.provider, failures, absentConfirmed }, 'Agent channel plugin down after max restart attempts -- giving up, alerting operator')
+          sendAlert(absentConfirmed
+            ? `⛔ A(z) ${t.agentName} agens ${t.provider} plugin-je BE SEM TOLTODOTT (absent a /mcp listabol), a fresh-restart ezt nem javitja -- tovabb nem probalom (minden restart elveszi a session kontextusat). Kezi TISZTA ujrainditas kell (uresen, mas agens indulasaval nem atlapolva): ${t.session}.`
+            : `⛔ A(z) ${t.agentName} agens ${t.provider} csatornaja ${AGENT_MAX_RESTART_ATTEMPTS} automatikus ujrainditas utan sem allt helyre. Tovabb nem indinitom ujra (minden restart elveszi a session kontextusat). Kezi beavatkozas kell: nezd meg a ${t.session} session-t es a ${SERVICE_ID} csatorna-plugint.`)
           agentRestartFailures.set(t.agentName!, failures + 1)
           savePersistedAgentFailures(t.agentName!, failures + 1)
           agentDownSince.delete(t.session)
@@ -1359,7 +1383,15 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         logger.warn({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down -- auto-restarting')
         try {
           stopAgentProcess(t.agentName!)
-          execSync('sleep 2', { timeout: 4000 })
+          // Settle before the fresh start. stopAgentProcess already reaps this
+          // agent's channel orphans + waits 2s; add more so the shared plugin
+          // cache (bun run --cwd <plugin>, .in_use markers) fully releases from
+          // the torn-down claude before the new one loads the plugin. A too-short
+          // gap is the suspected trigger for the plugin coming up ABSENT on a
+          // rapid restart (2026-07-01 rocket/mantis loop). Fleet-wide staggering
+          // (CHANNEL_RESTART_STAGGER_MS) means this extra block runs at most once
+          // per 90s, so it does not stall the monitor's per-agent sweep.
+          execSync('sleep 8', { timeout: 10000 })
           lastChannelAgentRestartAt = Date.now()
           // FRESH (no --continue): on CC 2.1.193 a --continue resume does NOT load
           // the --channels plugin MCP server, so the agent comes up with no plugin

--- a/src/web/channel-plugin-unlock.ts
+++ b/src/web/channel-plugin-unlock.ts
@@ -67,6 +67,38 @@ const KEYSTROKE_SETTLE_MS = 1500
 // out of the action menu.
 const POST_UNLOCK_SETTLE_MS = 3000
 
+// Sessions whose most recent unlock probe found the channel plugin ABSENT from
+// the /mcp list -- i.e. the plugin MCP server never loaded at all (distinct from
+// a Failed/disabled plugin, which the /mcp unlock sequence CAN revive). A fresh
+// restart cannot fix an absent plugin: it comes up absent again (observed
+// 2026-07-01, rocket + mantis looped 5x fresh-restarts, each absent, until the
+// watchdog gave up -- every restart cost the agent its whole session context).
+// The down-cascade reads this to escalate to the operator after ONE restart
+// instead of burning the full AGENT_MAX_RESTART_ATTEMPTS on a condition no
+// restart can repair. Keyed by tmux session name; entries are re-stamped by each
+// probe and cleared once the plugin is observed healthy again.
+const pluginAbsentAt = new Map<string, number>()
+
+function markPluginAbsent(session: string): void {
+  pluginAbsentAt.set(session, Date.now())
+}
+
+/** Clear the absent mark once the plugin is observed healthy (recovery). */
+export function clearPluginAbsent(session: string): void {
+  pluginAbsentAt.delete(session)
+}
+
+/**
+ * True iff an unlock probe confirmed the plugin ABSENT from the /mcp list for
+ * this session within the last `withinMs`. The down-cascade uses this to cut the
+ * restart budget for the absent case, since fresh-restarting cannot reload a
+ * plugin that never registered.
+ */
+export function wasPluginConfirmedAbsent(session: string, withinMs: number): boolean {
+  const at = pluginAbsentAt.get(session)
+  return at != null && Date.now() - at <= withinMs
+}
+
 function getSessionClaudePid(session: string): number | null {
   try {
     const raw = execFileSync(TMUX, ['list-panes', '-t', session, '-F', '#{pane_pid}'], {
@@ -152,6 +184,9 @@ function sendUnlockKeystrokes(session: string, provider: ChannelProviderType): v
       // Plugin is not in the MCP list (never loaded, not Failed/disabled) --
       // the unlock sequence cannot help and would target the wrong entry.
       logger.warn({ session, provider }, 'channel-plugin-unlock: provider plugin absent from /mcp list -- skipping unlock (plugin never loaded, not recoverable via /mcp)')
+      // Record the absent verdict so the down-cascade escalates to the operator
+      // after one restart instead of looping fresh-restarts that cannot help.
+      markPluginAbsent(session)
       try { execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 5000 }) } catch { /* ignore */ }
       return
     }
@@ -201,6 +236,9 @@ function runUnlockProbe(state: UnlockProbeState): void {
   }
 
   if (hasBunChild(claudePid)) {
+    // Plugin is up again -- retire any stale absent verdict so a future
+    // down-spell starts from a clean restart budget.
+    clearPluginAbsent(state.session)
     logger.info(
       { session: state.session, claudePid, provider: state.provider },
       'channel-plugin-unlock: bun child present, plugin healthy - no unlock needed',


### PR DESCRIPTION
When a sub-agent's channel plugin comes up ABSENT from /mcp (the MCP server never registered -- distinct from a Failed/disabled plugin), a fresh restart cannot bring it back: it comes up absent again. The down-cascade nonetheless fresh-restarted up to AGENT_MAX_RESTART_ATTEMPTS (5) times, each restart wiping the agent's whole session context, before giving up.

Observed 2026-07-01: rocket + mantis looped 5 fresh-restarts each on an absent telegram plugin (no bun poller, no bot.pid, no telegram mcp-logs dir; the other MCP servers loaded fine) while star-lord/max -- started once, cleanly -- were healthy. Not a model-tier or resume-time issue: rocket's claude was a FRESH zero-context session still absent 11 min later, so raising the probe delay would not help.

The unlock probe already detects the absent case ("provider plugin absent from /mcp list"). Feed that verdict back into the restart decision:

- channel-plugin-unlock: track sessions confirmed absent (mark in the absent branch, clear when the probe later sees the plugin healthy); export wasPluginConfirmedAbsent / clearPluginAbsent.
- channel-monitor: when the plugin is confirmed absent, cap the restart budget at 1 (PLUGIN_ABSENT_MAX_RESTART_ATTEMPTS) so the watchdog escalates to the operator after a single attempt with an absent-specific alert (asks for a clean, non-overlapping restart). The startup grace still protects a young process; a Failed/disabled plugin keeps the full budget since a restart helps it. Also clear the verdict on a healthy sweep.
- Widen the post-stop settle before the fresh start (2s -> 8s) so the shared plugin cache releases from the torn-down claude -- the suspected trigger for the absent-on-rapid-restart condition. Gated once per 90s by the fleet-wide restart stagger.

Tests: absent-cap semantics (one restart then alert, startup grace still honoured) in agent-restart-policy; contract tests pinning the probe-to-monitor wiring in channel-plugin-unlock.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
