### PR TITLE
fix(startup): rebuild better-sqlite3 native binding before services start

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1146,6 +1146,11 @@ Type=simple
 # the node main process on stop/restart, leaving the agents running.
 KillMode=process
 WorkingDirectory=$INSTALL_DIR
+# Rebuild the better-sqlite3 native binding if it can't load for the current
+# Node ABI before starting. Prevents the "Could not locate the bindings file"
+# crash-loop after an npm install / Node upgrade (root-caused 2026-07-03: ~350
+# restarts, StartLimit hit, dashboard + channels down ~42 min).
+ExecStartPre=$INSTALL_DIR/scripts/ensure-native-modules.sh
 ExecStart=$NODE_PATH $INSTALL_DIR/dist/index.js
 Restart=on-failure
 RestartSec=5
@@ -1180,6 +1185,9 @@ Type=simple
 # its own "\$SESSION" before new-session so the surviving session doesn't collide.
 KillMode=process
 WorkingDirectory=$INSTALL_DIR
+# See the dashboard unit: rebuild the better-sqlite3 native binding if it can't
+# load for the current Node ABI before starting (2026-07-03 crash-loop fix).
+ExecStartPre=$INSTALL_DIR/scripts/ensure-native-modules.sh
 ExecStart=$INSTALL_DIR/scripts/channels.sh
 Restart=on-failure
 RestartSec=10

--- a/scripts/ensure-native-modules.sh
+++ b/scripts/ensure-native-modules.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Startup guard: ensure the better-sqlite3 native binding loads for the current
+# Node ABI before the dashboard/channels services start. If it is missing or
+# ABI-mismatched (the recurring "Could not locate the bindings file" crash-loop,
+# root-caused 2026-07-03), rebuild it in place. Idempotent, safe to run on every
+# start. Wired in as ExecStartPre= on the *-dashboard and *-channels units.
+set -u
+
+# Derive the project root from this script's location (scripts/ -> repo root),
+# so the guard is portable across install dirs instead of hardcoding a path.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR" || exit 0   # never block startup on a cd failure
+
+# Health check must INSTANTIATE a Database -- better-sqlite3 loads its native
+# binding lazily on `new Database()`, not on require(), so a bare require passes
+# even when the .node file is missing (learned the hard way, 2026-07-03).
+CHECK="const D=require('better-sqlite3'); new D(':memory:').close();"
+if node -e "$CHECK" >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "ensure-native-modules: better-sqlite3 binding not loadable, rebuilding for Node $(node -v)..." >&2
+npm rebuild better-sqlite3 >&2 2>&1
+
+# Verify the rebuild worked; log but do not hard-fail (systemd would just retry).
+if node -e "$CHECK" >/dev/null 2>&1; then
+  echo "ensure-native-modules: rebuild OK." >&2
+else
+  echo "ensure-native-modules: rebuild FAILED, dashboard will likely crash-loop." >&2
+fi
+exit 0

--- a/scripts/systemd/marveen-channels.service
+++ b/scripts/systemd/marveen-channels.service
@@ -18,6 +18,10 @@ Type=simple
 # session does not collide on relaunch.
 KillMode=process
 WorkingDirectory=/path/to/marveen
+# Rebuild the better-sqlite3 native binding if it can't load for the current Node
+# ABI before starting. Prevents the "Could not locate the bindings file"
+# crash-loop after an npm install / Node upgrade (root-caused 2026-07-03).
+ExecStartPre=/path/to/marveen/scripts/ensure-native-modules.sh
 ExecStart=/path/to/marveen/scripts/channels.sh
 # P1 FIX: always (not on-failure). channels.sh exits 0 when the tmux session
 # dies normally, which on-failure did NOT restart -> the bridge was dead for


### PR DESCRIPTION
## Probléma

Egy `npm install` vagy Node-frissítés után a `better-sqlite3` natív binding a régi ABI-hoz marad buildelve. A `require('better-sqlite3')` **még sikeres** (a `.node` fájl lustán, csak a `new Database()`-nél töltődik), így semmi sem bukik el egészen addig, amíg a dashboard ténylegesen meg nem nyitja a DB-t az `initDatabase`-ben:

```
Could not locate the bindings file ... node-v127
```

Ez FATAL `exit 1`. A systemd `Restart=on-failure` ekkor crash-loopba megy (2026-07-03-án ~350 restart figyelve, counter 351), amíg a `StartLimit` fel nem adja, és a channels bridge-et is magával rántja (~42 perc kiesés, 10:25 -> 11:07).

## Megoldás

Új `scripts/ensure-native-modules.sh`: idempotens `ExecStartPre` guard, ami
- **instanciál** egy `new Database(':memory:')`-t a betölthetőség detektálásához (a bare `require` nem elég, lustán tölt),
- ha nem tölthető / ABI-mismatch, `npm rebuild better-sqlite3` helyben, indulás előtt,
- soha nem blokkolja hard-failjel az indulást (a systemd úgyis retry-olna).

A guard a repo gyökeret a saját helyéből vezeti le, így hordozható az install dir-ek között.

## Változtatások

- `scripts/ensure-native-modules.sh` (új) — a guard.
- `install-linux.sh` — `ExecStartPre=` a dashboard **és** a channels unit generátorába.
- `scripts/systemd/marveen-channels.service` — referencia-template szinkronban.

## Teszt

- `bash -n` mindkét scriptre OK.
- A guard éles gépen lefuttatva egészséges binding mellett némán `exit 0`.
- Az éles gépen párhuzamosan drop-in override (`*.service.d/native-guard.conf`) is be lett téve az azonnali hatáshoz; a legutóbbi service-restartkor lefutott, status=0.

## Megjegyzés

Csak Linux (itt történt az incidens). macOS/launchd követheti egy külön PR-ben, ha kell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)