### PR TITLE
fix(dispatch): refuse prompts to context-saturated sessions

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -15,6 +15,7 @@ import {
   parkedInputText,
   parkedInputRowCount,
   submitLanded,
+  paneShowsContextSaturation,
 } from '../pane-state.js'
 
 // Realistic pane fixtures modelled on actual `tmux capture-pane -p`
@@ -1969,5 +1970,53 @@ describe('footer-less welcome-screen parked input', () => {
     const noBox = ['some scrollback line', SEP, 'plain text, no prompt glyph', SEP, ''].join('\n')
     expect(detectPaneState(noBox)).toBe('unknown')
     expect(parkedInputRowCount(noBox)).toBe(0)
+  })
+})
+
+describe('paneShowsContextSaturation', () => {
+  // Real capture shape observed live: an idle, ready-looking footer with the
+  // saturation banner one line above it — the combination that lets a
+  // saturated session keep silently accepting new dispatches.
+  const CTX_SAT_IDLE = [
+    '  some prior assistant output',
+    '',
+    '✻ Cooked for 3m 7s',
+    '                                                              100% context used',
+    SEP,
+    '❯ ',
+    SEP,
+    '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+  ].join('\n')
+
+  it('detects the saturation banner on an otherwise-idle pane', () => {
+    expect(detectPaneState(CTX_SAT_IDLE)).toBe('idle') // sanity: still reads as idle
+    expect(paneShowsContextSaturation(CTX_SAT_IDLE)).toBe(true)
+  })
+
+  it('is false on a normal idle pane', () => {
+    expect(paneShowsContextSaturation(IDLE_BYPASS)).toBe(false)
+    expect(paneShowsContextSaturation(IDLE_STRICT)).toBe(false)
+  })
+
+  it('is false on a normal busy pane (no false alarm mid-turn)', () => {
+    expect(paneShowsContextSaturation(BUSY_FULL_FOOTER)).toBe(false)
+  })
+
+  it('does NOT misfire on a scrollback quote of the same phrase', () => {
+    const quoted = [
+      '  QA report: the watchdog now greps for "100% context used" in the footer.',
+      '  This is a scrollback quote, not the live indicator.',
+      ...Array.from({ length: 10 }, () => '  more scrollback padding'),
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(paneShowsContextSaturation(quoted)).toBe(false)
+  })
+
+  it('is false on empty/null-ish input', () => {
+    expect(paneShowsContextSaturation('')).toBe(false)
+    expect(paneShowsContextSaturation('   \n  ')).toBe(false)
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1413,3 +1413,25 @@ export function decideStuckToolCallRecovery(
     next: { ...prev, lastSeconds: sig.seconds, stagnantPolls: nextStagnant, stagnantSince: nextStagnantSince, attempts: 1 },
   }
 }
+
+// --- Context-saturation predicate -------------------------------------------
+// Claude Code prints "100% context used" (and a few equivalent phrasings) in
+// its footer when a pane can no longer accept useful work, yet the pane can
+// still otherwise present as perfectly idle -- empty prompt, ready-looking
+// footer. paneLooksIdle() therefore returns true for a saturated session, and
+// a caller that only checks idleness will happily dispatch new work into a
+// pane that cannot act on it. paneShowsContextSaturation() closes that gap.
+//
+// The banner renders one row ABOVE the bypass-mode footer, so the window is a
+// little wider than LIVE_FOOTER_REGION_LINES (which anchors on the footer line
+// itself); still tail-scoped, so a scrollback quote of the same phrase does
+// not trip it.
+const CTX_SAT_FOOTER_REGION_LINES = 8
+const CTX_SAT_RX = /100% context used|context (?:is |limit reached|window )?full\b|context limit|auto-?compact required/i
+
+export function paneShowsContextSaturation(capture: string): boolean {
+  if (!capture || !capture.trim()) return false
+  const lines = capture.split('\n')
+  const footerRegion = lines.slice(-CTX_SAT_FOOTER_REGION_LINES).join('\n')
+  return CTX_SAT_RX.test(footerRegion)
+}

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -13,6 +13,7 @@ import {
   detectPaneState,
   parkedInputText,
   stripGhostSuggestion,
+  paneShowsContextSaturation,
 } from '../pane-state.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost } from './agent-config.js'
 import {
@@ -1260,15 +1261,29 @@ export function captureParkedInputView(session: string, host: string | null = nu
 //      returns true. Cost on the ready path: ~250ms sleep plus a second
 //      tmux capture-pane round-trip (typically tens of ms). Busy pass
 //      through layer 1 and return immediately without the delay.
+//
+// A saturated pane ("100% context used") is refused up front: it can present
+// as perfectly idle, so without this a new prompt would be dispatched into a
+// session that cannot act on it. We only log/audit the refusal here; how (or
+// whether) to recover the session is left to the caller / operator tooling, so
+// this predicate stays a pure, dependency-free readiness check.
 export function isSessionReadyForPrompt(session: string, host: string | null = null): boolean {
   const first = capturePane(session, host)
   if (first == null) return false
+  if (paneShowsContextSaturation(first)) {
+    logger.warn({ session }, 'dispatch: refusing prompt — session shows context saturation (100% context)')
+    return false
+  }
   if (!paneLooksIdle(first)) return false
 
   try { execFileSync('/bin/sleep', [PANE_READY_CONFIRM_DELAY_S], { timeout: 2000 }) } catch { /* best effort */ }
 
   const second = capturePane(session, host)
   if (second == null) return false
+  if (paneShowsContextSaturation(second)) {
+    logger.warn({ session }, 'dispatch: refusing prompt — session shows context saturation (100% context)')
+    return false
+  }
   return paneLooksIdle(second)
 }
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -160,6 +160,12 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
   // will process it at the next idle slot. This prevents the infinite
   // retry loop observed when the target session stays busy for hours
   // (275 retries overnight in production).
+  //
+  // KNOWN FOLLOW-UP: forceSend also bypasses the context-saturation refusal
+  // now folded into isSessionReadyForPrompt(). A forceSend task can therefore
+  // still land on a 100%-context session. Left open deliberately -- forceSend's
+  // contract is "always eventually land, never silently drop", and a saturated
+  // session needs a separate delivery policy, tracked as future work.
   if (!task.forceSend && !isSessionReadyForPrompt(session, host)) {
     logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session busy or has pending input, will retry')
     return 'busy'


### PR DESCRIPTION
## What
A Claude Code pane can show "100% context used" while still presenting as perfectly idle (empty prompt, ready-looking footer). `paneLooksIdle()` — and therefore `isSessionReadyForPrompt()` — treats such a session as dispatchable, so new inter-agent messages and scheduled tasks land on a session that cannot act on them and sit pending indefinitely.

## Change
- **pane-state**: add `paneShowsContextSaturation()`, a pure predicate that matches "100% context used" (and equivalent phrasings) scoped to the live footer region — so a scrollback quote of the same phrase does not trip it. The window is slightly wider than `LIVE_FOOTER_REGION_LINES` because the banner renders one row above the bypass-mode footer.
- **agent-process**: `isSessionReadyForPrompt()` refuses a saturated pane up front (both capture samples) and logs an audit line. Closes the gap for both the inter-agent router and the scheduled-task runner in one place.
- **schedule-runner**: documents that `forceSend` still bypasses the refusal (known follow-up).
- **tests**: 5 unit tests for the predicate, including a self-referential scrollback false-positive case and a reads-as-idle sanity check.

## Design / scope
- The predicate stays **pure and dependency-free**: detect + refuse + log only. **How** (or whether) to recover a saturated session is deliberately left to the caller / operator tooling — a configurable recovery hook could be a separate follow-up PR.
- **forceSend** intentionally still bypasses this (its contract is "always eventually land, never silently drop"); a saturated-session delivery policy for forceSend is tracked as future work.
- Out of scope: recovery script, capacity-aware model routing, deployment-local config.

## Testing
- `npm run build` (tsc): clean.
- Full suite: 1592 passed / 1 skipped, 0 regressions.
- Rebased on current `develop` — integrates with the existing live-region scoping (#501); no conflicts.
