### PR TITLE
feat(kanban): add card status-change audit trail

### DIFF
--- a/src/__tests__/kanban-move-audit.test.ts
+++ b/src/__tests__/kanban-move-audit.test.ts
@@ -1,0 +1,78 @@
+// Contract tests for the kanban status-change audit trail.
+//
+// moveKanbanCard records a kanban_card_events row on every REAL status
+// transition (who moved the card, when, from/to status). A pure sort_order
+// reorder within the same column, or a move that touches no row, records
+// nothing. getKanbanCardEvents returns a card's events in chronological order.
+//
+// These tests call the real production entry points (moveKanbanCard,
+// getKanbanCardEvents) on an in-memory database seeded with the production
+// schema, the same way the other kanban db tests do.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, createKanbanCard, moveKanbanCard, getKanbanCardEvents } from '../db.js'
+
+beforeEach(() => {
+  // Re-init with an in-memory database for isolation.
+  initDatabase(':memory:')
+})
+
+describe('kanban move audit trail', () => {
+  it('records exactly one event with correct from/to status and actor on a status change', () => {
+    createKanbanCard({ id: 'card-a', title: 'Audited card' })
+
+    const moved = moveKanbanCard('card-a', 'in_progress', 1, 'marveen')
+    expect(moved).toBe(true)
+
+    const events = getKanbanCardEvents('card-a')
+    expect(events).toHaveLength(1)
+    expect(events[0].card_id).toBe('card-a')
+    expect(events[0].from_status).toBe('planned')
+    expect(events[0].to_status).toBe('in_progress')
+    expect(events[0].actor).toBe('marveen')
+    expect(typeof events[0].created_at).toBe('number')
+  })
+
+  it('records no event when the status is unchanged (pure reorder)', () => {
+    createKanbanCard({ id: 'card-b', title: 'Reordered card' })
+
+    // Same status (planned), only sort_order differs -> not a transition.
+    const moved = moveKanbanCard('card-b', 'planned', 5, 'marveen')
+    expect(moved).toBe(true)
+    expect(getKanbanCardEvents('card-b')).toHaveLength(0)
+  })
+
+  it('records no event when no row matches', () => {
+    const moved = moveKanbanCard('nonexistent-card', 'done', 0, 'marveen')
+    expect(moved).toBe(false)
+    expect(getKanbanCardEvents('nonexistent-card')).toHaveLength(0)
+  })
+
+  it('leaves actor null when none is supplied (backward-compatible callers)', () => {
+    createKanbanCard({ id: 'card-c', title: 'No actor' })
+
+    const moved = moveKanbanCard('card-c', 'waiting', 0)
+    expect(moved).toBe(true)
+
+    const events = getKanbanCardEvents('card-c')
+    expect(events).toHaveLength(1)
+    expect(events[0].actor).toBeNull()
+  })
+
+  it('returns events in chronological order across multiple moves', () => {
+    createKanbanCard({ id: 'card-d', title: 'Multi-move card' })
+
+    moveKanbanCard('card-d', 'in_progress', 0, 'marveen')
+    moveKanbanCard('card-d', 'waiting', 0, 'samu')
+    moveKanbanCard('card-d', 'done', 0, 'marveen')
+
+    const events = getKanbanCardEvents('card-d')
+    expect(events.map((e) => e.to_status)).toEqual(['in_progress', 'waiting', 'done'])
+    expect(events.map((e) => e.from_status)).toEqual(['planned', 'in_progress', 'waiting'])
+    // created_at is monotonically non-decreasing and the id ordering breaks ties.
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].created_at).toBeGreaterThanOrEqual(events[i - 1].created_at)
+      expect(events[i].id).toBeGreaterThan(events[i - 1].id)
+    }
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -330,6 +330,21 @@ export function initDatabase(dbPathOverride?: string): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_kanban_comments_card ON kanban_comments(card_id)`)
 
+  // Status-change audit trail: one row per real status transition so the board
+  // can answer "who moved this card, when, from/to status". Written by
+  // moveKanbanCard only when the status actually changes.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS kanban_card_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      card_id TEXT NOT NULL,
+      from_status TEXT,
+      to_status TEXT NOT NULL,
+      actor TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_kanban_events_card ON kanban_card_events(card_id, created_at)`)
+
   // --- Kanban labels (tags) -----------------------------------------------
   // Labels are a separate registry (not hardcoded per-card strings) so the
   // same label can be reused across many cards and recolored in one place.
@@ -1141,11 +1156,20 @@ export function getChildCards(parentId: string): KanbanCard[] {
   return db.prepare('SELECT * FROM kanban_cards WHERE parent_id = ? AND archived_at IS NULL ORDER BY sort_order ASC').all(parentId) as KanbanCard[]
 }
 
-export function moveKanbanCard(id: string, status: KanbanCard['status'], sortOrder: number): boolean {
+export function moveKanbanCard(id: string, status: KanbanCard['status'], sortOrder: number, actor?: string): boolean {
   const now = Math.floor(Date.now() / 1000)
-  return db.prepare(
+  // Read the previous status first so we only record an audit event on a real
+  // status transition (not a pure sort_order reorder within the same column).
+  const prev = (db.prepare('SELECT status FROM kanban_cards WHERE id=?').get(id) as { status: string } | undefined)?.status
+  const changed = db.prepare(
     'UPDATE kanban_cards SET status=?, sort_order=?, updated_at=? WHERE id=?'
   ).run(status, sortOrder, now, id).changes > 0
+  if (changed && prev !== undefined && prev !== status) {
+    db.prepare(
+      'INSERT INTO kanban_card_events (card_id, from_status, to_status, actor, created_at) VALUES (?, ?, ?, ?, ?)'
+    ).run(id, prev, status, actor ?? null, now)
+  }
+  return changed
 }
 
 // Stamp the once-only kanban -> agent dispatch guard. Returns false if the
@@ -1242,6 +1266,19 @@ export function deleteKanbanCard(id: string): boolean {
 
 export function getKanbanComments(cardId: string): KanbanComment[] {
   return db.prepare('SELECT * FROM kanban_comments WHERE card_id = ? ORDER BY created_at ASC').all(cardId) as KanbanComment[]
+}
+
+export interface KanbanCardEvent {
+  id: number
+  card_id: string
+  from_status: string | null
+  to_status: string
+  actor: string | null
+  created_at: number
+}
+
+export function getKanbanCardEvents(cardId: string): KanbanCardEvent[] {
+  return db.prepare('SELECT * FROM kanban_card_events WHERE card_id = ? ORDER BY created_at ASC, id ASC').all(cardId) as KanbanCardEvent[]
 }
 
 // Lookup a kanban card's `seq` (its sqlite rowid) by the 8-char hex id stored

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import {
   listKanbanCards, createKanbanCard, updateKanbanCard,
   deleteKanbanCard, moveKanbanCard, archiveKanbanCard, unarchiveKanbanCard,
-  getKanbanComments, addKanbanComment, listKanbanProjects,
+  getKanbanComments, addKanbanComment, getKanbanCardEvents, listKanbanProjects,
   getKanbanCard, getChildCards, getDb,
   createAgentMessage, markKanbanCardDispatched,
   getKanbanSeqByIdPrefix,
@@ -210,8 +210,8 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   if (kanbanMoveMatch && method === 'POST') {
     const id = decodeURIComponent(kanbanMoveMatch[1])
     const body = await readBody(req)
-    const { status, sort_order } = JSON.parse(body.toString())
-    if (moveKanbanCard(id, status, sort_order ?? 0)) {
+    const { status, sort_order, actor } = JSON.parse(body.toString())
+    if (moveKanbanCard(id, status, sort_order ?? 0, actor)) {
       // Wake the assigned agent once when the card enters in_progress.
       if (status === 'in_progress') fireKanbanDispatch(id)
       json(res, { ok: true })
@@ -269,6 +269,13 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
     // (#75 Cuzcoo dispatch). Random hex / non-matching tokens pass through.
     const normalizedContent = normalizeKanbanRefs(content, getKanbanSeqByIdPrefix)
     json(res, addKanbanComment(cardId, author, normalizedContent))
+    return true
+  }
+
+  const kanbanEventsMatch = path.match(/^\/api\/kanban\/([^/]+)\/events$/)
+  if (kanbanEventsMatch && method === 'GET') {
+    const cardId = decodeURIComponent(kanbanEventsMatch[1])
+    json(res, getKanbanCardEvents(cardId))
     return true
   }
 


### PR DESCRIPTION
## Summary

Adds a lightweight **status-change audit trail** for kanban cards, so the board can answer *"who moved this card, when, and from which status to which"* — information that is currently unrecoverable (the `kanban_cards` table only keeps `updated_at`).

Motivation: in a multi-agent setup, cards are moved to `done` by whichever agent claims completion, and there is no record of who/when. When a "done" card later turns out to lack its deliverable, there is no way to trace the transition. This adds that trace.

## What's included

- **New `kanban_card_events` table** (`card_id`, `from_status`, `to_status`, `actor`, `created_at`) + `idx_kanban_events_card`. Additive only — no migration on `kanban_cards`.
- **`moveKanbanCard(id, status, sortOrder, actor?)`** — new optional, appended-last `actor` param (backward compatible; existing 3-arg callers are unchanged). Records an event **only on a real status transition** — a pure `sort_order` reorder within the same column records nothing.
- **`getKanbanCardEvents(cardId)`** + **`GET /api/kanban/:id/events`**, mirroring the existing comments getter/route.
- **5 vitest cases** (`src/__tests__/kanban-move-audit.test.ts`): real transition → exactly one event with correct from/to/actor; unchanged status → none; no-op move → none; null actor when omitted; chronological ordering.

## What's not included

- No UI. This is the data layer + read endpoint; a board view can consume `/events` later.
- No change to existing behaviour — `actor` is optional and the event write is a no-op when status is unchanged.

## Testing

- `npm run build` (tsc): clean.
- `npm test`: 108 files, 1597 passed, 1 pre-existing skip. No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
