### PR TITLE
fix(dashboard): show main agent BOT_NAME in Messages view, not its routing id

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -8679,6 +8679,21 @@ const CHAT_SYSTEM_AGENTS = new Set(['heartbeat','telegram-coordinator','channel-
 // recognizes its real owner. Empty until _marveen resolves (no false match).
 function chatOwnerName() { return window._marveen?.ownerName || '' }
 
+// The main agent's display name (BOT_NAME). mainAgentId() is the routing id
+// (e.g. "marveen") used for matching, avatar lookups and API calls; this is
+// what the user should SEE. Sourced from the backend (/api/marveen -> name,
+// mirrored into _brandTokens.bot by initSidebarBrand), so a renamed install
+// shows its real bot name. Falls back to the id before _marveen resolves.
+function mainAgentDisplayName() {
+  return window._marveen?.name || window._brandTokens?.bot || mainAgentId()
+}
+// Map a routing agent id to its user-facing label: the main agent's id becomes
+// its BOT_NAME display name; every other agent already carries a human name as
+// its id, so it passes through unchanged.
+function chatDisplayName(name) {
+  return name === mainAgentId() ? mainAgentDisplayName() : name
+}
+
 function chatLastSeenKey(agentName) { return 'chat_last_seen_' + agentName }
 function chatGetLastSeen(agentName) { return parseInt(localStorage.getItem(chatLastSeenKey(agentName)) || '0', 10) }
 function chatMarkSeen(agentName, maxId) {
@@ -8751,7 +8766,7 @@ async function loadChatAgentList() {
       const isSelected = name === chatSelectedAgent ? ' selected' : ''
       const dimmed = info ? '' : ' style="opacity:0.5"'
       const unread = chatIsUnread(name, info)
-      const displayName = owner && name === owner ? owner + ' (te)' : name
+      const displayName = owner && name === owner ? owner + ' (te)' : chatDisplayName(name)
       return `<div class="chat-agent-item${isSelected}${unread ? ' unread' : ''}" data-agent="${escapeHtml(name)}"${dimmed}>
         <div class="chat-agent-avatar">${chatAvatarHtml(name, 40)}</div>
         <div class="chat-agent-info">
@@ -8795,7 +8810,7 @@ async function loadChatThread(agentName) {
   chatThreadState.loading = false
 
   const owner = chatOwnerName()
-  const threadDisplayName = owner && agentName === owner ? owner + ' (te)' : agentName
+  const threadDisplayName = owner && agentName === owner ? owner + ' (te)' : chatDisplayName(agentName)
 
   panel.innerHTML = `
     <div class="chat-thread-header">
@@ -8808,7 +8823,7 @@ async function loadChatThread(agentName) {
     <div class="chat-bubbles" id="chatBubbles"><div class="chat-loading-indicator" id="chatLoadingTop" style="display:none;text-align:center;padding:8px;font-size:11px;color:var(--text-muted)">${t('messages.loading')}</div></div>
     <div class="chat-compose">
       <div class="chat-compose-row">
-        <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="${t('messages.placeholder', { agent: escapeHtml(agentName) })}"></textarea>
+        <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="${t('messages.placeholder', { agent: escapeHtml(chatDisplayName(agentName)) })}"></textarea>
         <button class="btn-primary btn-compact chat-send-btn" id="chatSendBtn">${t('messages.send_btn')}</button>
       </div>
     </div>
@@ -8848,7 +8863,10 @@ async function loadChatThread(agentName) {
 
 function buildBubbleHtml(m) {
   const isOutgoing = m.from_agent === mainAgentId()
+  // senderName stays the routing id (avatar lookup keys off it); senderLabel is
+  // what the user sees, so the main agent reads as its BOT_NAME, not "marveen".
   const senderName = isOutgoing ? mainAgentId() : m.from_agent
+  const senderLabel = chatDisplayName(senderName)
   const when = m.created_at ? new Date(m.created_at * 1000).toLocaleString('hu-HU', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : ''
   const statusMetaRaw = MSG_STATUS_META[m.status] || { label: m.status || '', cls: 'badge' }
   const statusMeta = { ...statusMetaRaw, label: typeof statusMetaRaw.label === 'function' ? statusMetaRaw.label() : statusMetaRaw.label }
@@ -8856,7 +8874,7 @@ function buildBubbleHtml(m) {
     ${!isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml(senderName, 28)}</div>` : ''}
     <div class="chat-bubble ${isOutgoing ? 'bubble-out' : 'bubble-in'}">
       <div class="bubble-meta">
-        ${!isOutgoing ? `<span class="bubble-sender">${escapeHtml(senderName)}</span>` : ''}
+        ${!isOutgoing ? `<span class="bubble-sender">${escapeHtml(senderLabel)}</span>` : ''}
         <span class="bubble-id-chip">#${m.id}</span>
         <span class="badge ${statusMeta.cls}" style="font-size:10px">${escapeHtml(statusMeta.label)}</span>
       </div>


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

**HU:** Az inter-agent Üzenetek nézet a fő agent routing-azonosítóját (`mainAgentId()`) mutatta a BOT_NAME display neve helyett négy megjelenítési ponton: thread-oldalsáv, thread-fejléc, compose placeholder és a buborék feladó-címkéje. Bevezetek két helper-t (`mainAgentDisplayName()` a BOT_NAME-hez a `/api/marveen` -> `name` / `_brandTokens.bot` alapján, és `chatDisplayName()` a routing-id -> display-név leképezéshez), és ezeken a pontokon használom. A routing-id érintetlen: az avatar-lookup, az `isOutgoing` match, a `data-agent` attribútumok és az `/api/messages` hívások továbbra is `mainAgentId()`-t használnak, csak a látható címke változik. Feloldás előtt a helper a id-re esik vissza (nincs false match).

**EN:** The inter-agent Messages view showed the main agent's routing id (`mainAgentId()`) instead of its BOT_NAME display name at four render points: thread sidebar, thread header, compose placeholder and the bubble sender label. I add two helpers (`mainAgentDisplayName()` sourcing BOT_NAME from `/api/marveen` -> `name` / `_brandTokens.bot`, and `chatDisplayName()` mapping a routing id to its display name) and use them at those points. Routing ids are untouched: avatar lookups, the `isOutgoing` match, `data-agent` attributes and `/api/messages` calls all keep using `mainAgentId()`; only the visible label changes. The helper falls back to the id before `_marveen` resolves (no false match).

## Kapcsolódó issue / Related issue

Closes #519

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást lokálisan: szintaxis-ellenőrzés (`node --check`), a helper-logika izolált verifikációja (stock+átnevezett, elslugosított id, feloldás-előtti fallback), ÉS böngészős teszt a futó dashboard ellen (headless Chromium, a patch futásidőben injektálva a valódi backendhez) — az Üzenetek nézet a fő agent BOT_NAME-jét mutatja a routing-id helyett, before/after igazolva. / Tested locally: syntax check (`node --check`), isolated helper-logic verification (renamed install, slugified id, pre-resolve fallback), AND a browser test against the running dashboard (headless Chromium, patch injected at runtime against the real backend) — the Messages view now shows the main agent's BOT_NAME instead of its routing id, confirmed before/after.
- [ ] docs — n/a (nem érinti a telepítést/architektúrát / no install/architecture change).
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom. / Opened from an own, descriptively named branch.

---
_AI-agent (Ysah / YsahYarik) készítette, emberi operátor felügyeletével (@YsahYarik). / Authored by an AI agent (Ysah) under its human operator's supervision (@YsahYarik)._
