### PR TITLE
feat(vault): SSH Vault -- central SSH server & key management

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -39,3 +39,29 @@ scripts/vault-resolve.mjs      # secret ID → plaintext feloldás
 ### Ügynök-használat
 
 Az ügynökök programatikusan kiolvashatják a titkot (pl. egy press-CLI auth beállításához) a dist vault-modulon át — érték kiírása nélkül. A titkok címke (label) szerint azonosítva. A dashboard `/api/autonomy`-hoz hasonlóan Bearer-token védett API.
+
+---
+
+## 🔑 SSH Vault (szerver- és kulcskezelés)
+
+> Központi SSH szerver- és kulcsnyilvántartás a flottának -- külön a generikus titkosított titkoktól.
+
+A generikus secret-vault mellett a dashboard egy dedikált **SSH Vault** modult is biztosít, ami a flotta által elért SSH szervereket és a hozzájuk tartozó kulcsokat tartja nyilván.
+
+### Adatmodell
+
+- `vault_ssh_servers`: nyilvántartott szerverek (host, user, opcionális `ssh_key_id` hivatkozás).
+- `vault_ssh_keys`: megosztott SSH kulcs-készlet (label, username, publikus kulcs, fingerprint, kulcstípus). Egy kulcs **több szerverhez** is hozzárendelhető (many-servers-to-one-key modell).
+- A privát kulcsok a generikus `vault.ts` titkosított tárolóban élnek (`ssh-key-<id>` prefixű bejegyzésként), de a generikus `/api/vault` listázásból ki vannak szűrve -- kizárólag a Kulcstároló saját endpointján (`/api/vault/ssh-keys`) érhetők el, hogy ne duplikálódjanak a UI-n.
+
+### API végpontok
+
+- `GET/POST /api/vault/ssh-servers`, `PUT/DELETE /api/vault/ssh-servers/:id` -- szerver CRUD.
+- `GET/POST /api/vault/ssh-keys` -- kulcs-készlet listázás/generálás (új ed25519 pár).
+- `POST /api/vault/ssh-keys/import` -- meglévő privát kulcs importálása (publikus kulcs + fingerprint automatikus levezetéssel, `ssh-keygen -y`).
+- `GET /api/vault/ssh-keys/:id/public-key` -- publikus kulcs + telepítési (`authorized_keys`) instrukció lekérése.
+- `DELETE /api/vault/ssh-keys/:id` -- kulcs törlése; a hozzárendelt szerverek referenciája is törlődik, és a mögöttes titkosított secret is takarítva (`deleteSecret`), nincs árva bejegyzés.
+
+### UI
+
+A dashboard Vault oldalán külön szekció (Kulcstároló) mutatja a kulcs-készletet (lista/másolás/törlés), és a SSH Szerverek szekció (kártya- és táblázat-nézet) a szerverekhez rendelt kulcsot egy legördülőben lehet váltani. Új szerver felvételekor egy önálló, csak-kulcsválasztós info-modal mutatja a telepítési parancsokat -- szerver-kiválasztás nélkül, mivel az új szerver még nincs felvéve.

--- a/src/db.ts
+++ b/src/db.ts
@@ -578,6 +578,49 @@ export function initDatabase(dbPathOverride?: string): void {
   // Migration: add agent column to installs that created the table before this column existed.
   try { db.exec(`ALTER TABLE store_file_audit ADD COLUMN agent TEXT`) } catch { /* column already exists */ }
 
+  // --- Vault SSH Keys (shared pool) ---
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS vault_ssh_keys (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      username TEXT NOT NULL,
+      vault_key_id TEXT NOT NULL,
+      public_key TEXT NOT NULL,
+      fingerprint TEXT NOT NULL,
+      key_type TEXT NOT NULL DEFAULT 'ed25519',
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_keys_label ON vault_ssh_keys(label)`)
+
+  // --- Vault SSH Servers ---
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS vault_ssh_servers (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      host TEXT NOT NULL,
+      port INTEGER NOT NULL DEFAULT 22,
+      username TEXT NOT NULL,
+      ssh_key_id TEXT REFERENCES vault_ssh_keys(id),
+      description TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_name ON vault_ssh_servers(name)`)
+  // Migrations for installs that ran earlier schema versions. MUST run before
+  // the ssh_key_id index below: on an install where vault_ssh_servers already
+  // existed (pre-dating this column), CREATE TABLE IF NOT EXISTS above is a
+  // no-op and never adds ssh_key_id -- indexing it before this ALTER TABLE
+  // runs throws "no such column: ssh_key_id" and crashes startup entirely
+  // (2026-07-01 incident: dashboard 502'd, crash-looped on every restart).
+  try { db.exec('ALTER TABLE vault_ssh_servers ADD COLUMN key_type TEXT') } catch { /* pre-existing */ }
+  try { db.exec('ALTER TABLE vault_ssh_servers ADD COLUMN fingerprint TEXT') } catch { /* pre-existing */ }
+  try { db.exec('ALTER TABLE vault_ssh_servers ADD COLUMN vault_key_id TEXT') } catch { /* pre-existing */ }
+  try { db.exec('ALTER TABLE vault_ssh_servers ADD COLUMN key_expires_at INTEGER') } catch { /* pre-existing */ }
+  try { db.exec('ALTER TABLE vault_ssh_servers ADD COLUMN ssh_key_id TEXT REFERENCES vault_ssh_keys(id)') } catch { /* already exists */ }
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_key ON vault_ssh_servers(ssh_key_id)`)
+
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
   // re-importing. Wrapped in a transaction so a crash mid-import is safe.
@@ -2229,5 +2272,110 @@ export function pruneTokenUsage(): number {
   const cutoff = Math.floor(Date.now() / 1000) - retentionDays * 86400
   const info = db.prepare('DELETE FROM token_usage WHERE timestamp < ?').run(cutoff)
   return info.changes
+}
+
+// --- Vault SSH Keys (shared key pool) ---
+// Each key is independent of any server -- one key may be assigned to many
+// servers. The private key blob lives in the AES-256-GCM vault (vault.ts);
+// only its id (vault_key_id) is stored here. public_key and fingerprint are
+// safe to surface in the API; the private key never leaves the backend.
+
+export interface VaultSshKey {
+  id: string
+  label: string
+  username: string
+  vault_key_id: string
+  public_key: string
+  fingerprint: string
+  key_type: string
+  created_at: number
+}
+
+export function listVaultSshKeys(): VaultSshKey[] {
+  return db.prepare('SELECT * FROM vault_ssh_keys ORDER BY label ASC').all() as VaultSshKey[]
+}
+
+export function getVaultSshKey(id: string): VaultSshKey | undefined {
+  return db.prepare('SELECT * FROM vault_ssh_keys WHERE id = ?').get(id) as VaultSshKey | undefined
+}
+
+export function createVaultSshKey(key: Pick<VaultSshKey, 'id' | 'label' | 'username' | 'vault_key_id' | 'public_key' | 'fingerprint' | 'key_type'>): VaultSshKey {
+  const now = Math.floor(Date.now() / 1000)
+  db.prepare(
+    `INSERT INTO vault_ssh_keys (id, label, username, vault_key_id, public_key, fingerprint, key_type, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(key.id, key.label, key.username, key.vault_key_id, key.public_key, key.fingerprint, key.key_type, now)
+  return { ...key, created_at: now }
+}
+
+// Unassign the key from all servers, then delete it. Returns the count of
+// servers that were unassigned so callers can surface that in the response.
+export function deleteVaultSshKey(id: string): { deleted: boolean; unassigned: number } {
+  return db.transaction(() => {
+    const unassigned = db.prepare(
+      'UPDATE vault_ssh_servers SET ssh_key_id = NULL, updated_at = ? WHERE ssh_key_id = ?'
+    ).run(Math.floor(Date.now() / 1000), id).changes
+    const deleted = db.prepare('DELETE FROM vault_ssh_keys WHERE id = ?').run(id).changes > 0
+    return { deleted, unassigned }
+  })()
+}
+
+// --- Vault SSH Servers ---
+// Stores server metadata. The ssh_key_id FK points to vault_ssh_keys (nullable;
+// null = no key assigned = keyStatus "missing"). Legacy per-server key columns
+// (vault_key_id, key_type, fingerprint, key_expires_at) are kept in the schema
+// for backward compatibility but are no longer the source of truth.
+
+export interface VaultSshServer {
+  id: string
+  name: string
+  host: string
+  port: number
+  username: string
+  ssh_key_id: string | null
+  description: string | null
+  created_at: number
+  updated_at: number
+}
+
+export type SshKeyStatus = 'ok' | 'missing'
+
+export function computeSshKeyStatus(server: VaultSshServer): SshKeyStatus {
+  return server.ssh_key_id ? 'ok' : 'missing'
+}
+
+export function listVaultSshServers(): VaultSshServer[] {
+  return db.prepare('SELECT * FROM vault_ssh_servers ORDER BY name ASC').all() as VaultSshServer[]
+}
+
+export function getVaultSshServer(id: string): VaultSshServer | undefined {
+  return db.prepare('SELECT * FROM vault_ssh_servers WHERE id = ?').get(id) as VaultSshServer | undefined
+}
+
+export function createVaultSshServer(server: Pick<VaultSshServer, 'id' | 'name' | 'host' | 'port' | 'username' | 'description'>): VaultSshServer {
+  const now = Math.floor(Date.now() / 1000)
+  db.prepare(
+    `INSERT INTO vault_ssh_servers (id, name, host, port, username, description, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(server.id, server.name, server.host, server.port, server.username, server.description ?? null, now, now)
+  return { ...server, ssh_key_id: null, created_at: now, updated_at: now }
+}
+
+export function updateVaultSshServer(id: string, patch: Partial<Pick<VaultSshServer, 'name' | 'host' | 'port' | 'username' | 'ssh_key_id' | 'description'>>): boolean {
+  const now = Math.floor(Date.now() / 1000)
+  const sets: string[] = ['updated_at = ?']
+  const params: unknown[] = [now]
+  if (patch.name !== undefined)        { sets.push('name = ?');        params.push(patch.name) }
+  if (patch.host !== undefined)        { sets.push('host = ?');        params.push(patch.host) }
+  if (patch.port !== undefined)        { sets.push('port = ?');        params.push(patch.port) }
+  if (patch.username !== undefined)    { sets.push('username = ?');    params.push(patch.username) }
+  if (patch.ssh_key_id !== undefined)  { sets.push('ssh_key_id = ?'); params.push(patch.ssh_key_id) }
+  if (patch.description !== undefined) { sets.push('description = ?'); params.push(patch.description) }
+  params.push(id)
+  return db.prepare(`UPDATE vault_ssh_servers SET ${sets.join(', ')} WHERE id = ?`).run(...params).changes > 0
+}
+
+export function deleteVaultSshServer(id: string): boolean {
+  return db.prepare('DELETE FROM vault_ssh_servers WHERE id = ?').run(id).changes > 0
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -54,6 +54,8 @@ import { tryHandleSettings } from './web/routes/settings.js'
 import { tryHandleAuditLog } from './web/routes/audit-log.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import { tryHandleVoice } from './web/routes/voice.js'
+import { tryHandleVaultSsh } from './web/routes/vault-ssh.js'
+import { tryHandleVaultSshKeys } from './web/routes/vault-ssh-keys.js'
 import type { RouteContext } from './web/routes/types.js'
 
 const WEB_DIR = join(PROJECT_ROOT, 'web')
@@ -171,6 +173,8 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleToolLog(routeCtx)) return
       if (await tryHandleSettings(routeCtx)) return
       if (await tryHandleVoice(routeCtx)) return
+      if (await tryHandleVaultSshKeys(routeCtx)) return
+      if (await tryHandleVaultSsh(routeCtx)) return
       if (await tryHandleAuditLog(routeCtx)) return
       if (await tryHandleStatic(routeCtx, WEB_DIR)) return
 

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -661,7 +661,9 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
 
   // === Vault ===
   if (path === '/api/vault' && method === 'GET') {
-    json(res, { secrets: listSecrets() })
+    // ssh-key-* entries are managed exclusively via the SSH key pool
+    // (/api/vault/ssh-keys) and must not appear as generic secret cards too.
+    json(res, { secrets: listSecrets().filter(s => !s.id.startsWith('ssh-key-')) })
     return true
   }
 
@@ -676,7 +678,12 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   }
 
   const vaultMatch = path.match(/^\/api\/vault\/([^/]+)$/)
-  const isVaultSubroute = vaultMatch && ['bindings', 'sync', 'scan', 'import'].includes(vaultMatch[1])
+  // 'ssh-servers' is the dedicated SSH-server sub-resource (routes/vault-ssh.ts),
+  // handled later in the web.ts chain -- without this exclusion, a bare GET
+  // /api/vault/ssh-servers matches THIS generic secret-store route first
+  // (id="ssh-servers"), finds no such secret, and returns 404 before
+  // tryHandleVaultSsh ever runs (2026-07-01, frontend/backend Vault epic).
+  const isVaultSubroute = vaultMatch && ['bindings', 'sync', 'scan', 'import', 'ssh-servers', 'ssh-keys'].includes(vaultMatch[1])
   if (vaultMatch && !isVaultSubroute && method === 'GET') {
     const id = decodeURIComponent(vaultMatch[1])
     const val = getSecret(id)

--- a/src/web/routes/vault-ssh-keys.ts
+++ b/src/web/routes/vault-ssh-keys.ts
@@ -1,0 +1,188 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createHash, randomBytes } from 'node:crypto'
+import { readBody, json } from '../http-helpers.js'
+import { logger } from '../../logger.js'
+import {
+  listVaultSshKeys,
+  getVaultSshKey,
+  createVaultSshKey,
+  deleteVaultSshKey,
+  type VaultSshKey,
+} from '../../db.js'
+import { setSecret, getSecret, deleteSecret } from '../vault.js'
+import type { RouteContext } from './types.js'
+
+function fingerprintFromPubKey(authorizedKeyLine: string): string {
+  const parts = authorizedKeyLine.trim().split(' ')
+  if (parts.length < 2) return ''
+  const raw = Buffer.from(parts[1], 'base64')
+  return 'SHA256:' + createHash('sha256').update(raw).digest('base64').replace(/=+$/, '')
+}
+
+export function generateSshKeyPair(comment: string): { privateKey: string; publicKey: string; fingerprint: string } {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'marveen-ssh-'))
+  const keyPath = join(tmpDir, 'key')
+  try {
+    execFileSync('ssh-keygen', ['-t', 'ed25519', '-f', keyPath, '-N', '', '-C', comment], { stdio: 'pipe' })
+    const privateKey = readFileSync(keyPath, 'utf-8')
+    const publicKey = readFileSync(`${keyPath}.pub`, 'utf-8').trim()
+    return { privateKey, publicKey, fingerprint: fingerprintFromPubKey(publicKey) }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+}
+
+export function extractPublicKeyFromVault(vaultKeyId: string): string | null {
+  const privateKeyPem = getSecret(vaultKeyId)
+  if (!privateKeyPem) return null
+  const tmpDir = mkdtempSync(join(tmpdir(), 'marveen-ssh-'))
+  const keyPath = join(tmpDir, 'key')
+  try {
+    writeFileSync(keyPath, privateKeyPem, { mode: 0o600 })
+    chmodSync(keyPath, 0o600)
+    return execFileSync('ssh-keygen', ['-y', '-f', keyPath], { stdio: 'pipe' }).toString().trim()
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+}
+
+function toApiShape(key: VaultSshKey) {
+  return {
+    id: key.id,
+    label: key.label,
+    username: key.username,
+    publicKey: key.public_key,
+    fingerprint: key.fingerprint,
+    keyType: key.key_type,
+    createdAt: new Date(key.created_at * 1000).toISOString(),
+  }
+}
+
+export async function tryHandleVaultSshKeys(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  if (!path.startsWith('/api/vault/ssh-keys')) return false
+
+  // GET /api/vault/ssh-keys
+  if (path === '/api/vault/ssh-keys' && method === 'GET') {
+    json(res, { keys: listVaultSshKeys().map(toApiShape) })
+    return true
+  }
+
+  // POST /api/vault/ssh-keys
+  if (path === '/api/vault/ssh-keys' && method === 'POST') {
+    try {
+      const body = await readBody(req)
+      const data = JSON.parse(body.toString())
+
+      const label    = typeof data.label    === 'string' ? data.label.trim()    : ''
+      const username = typeof data.username === 'string' ? data.username.trim() : ''
+
+      if (!label || !username) {
+        json(res, { error: 'label and username are required' }, 400)
+        return true
+      }
+
+      const id = randomBytes(8).toString('hex')
+      const comment = `${username} (${label})`
+      const { privateKey, publicKey, fingerprint } = generateSshKeyPair(comment)
+
+      const vaultKeyId = `ssh-key-${id}`
+      setSecret(vaultKeyId, `SSH private key: ${label}`, privateKey)
+
+      const key = createVaultSshKey({ id, label, username, vault_key_id: vaultKeyId, public_key: publicKey, fingerprint, key_type: 'ed25519' })
+      logger.info({ id, label, fingerprint }, 'SSH key created')
+      json(res, { key: toApiShape(key), publicKey }, 201)
+    } catch (err: any) {
+      logger.error({ err }, 'Failed to create SSH key')
+      json(res, { error: 'Key generation failed: ' + (err?.message ?? String(err)) }, 500)
+    }
+    return true
+  }
+
+  // POST /api/vault/ssh-keys/import
+  if (path === '/api/vault/ssh-keys/import' && method === 'POST') {
+    try {
+      const body = await readBody(req)
+      const data = JSON.parse(body.toString())
+
+      const label      = typeof data.label      === 'string' ? data.label.trim()      : ''
+      const username   = typeof data.username   === 'string' ? data.username.trim()   : ''
+      const privateKey = typeof data.privateKey === 'string' ? data.privateKey.trim() : ''
+
+      if (!label || !username || !privateKey) {
+        json(res, { error: 'label, username and privateKey are required' }, 400)
+        return true
+      }
+
+      // Validate key and extract public key via ssh-keygen -y (same pattern as extractPublicKeyFromVault)
+      const tmpDir = mkdtempSync(join(tmpdir(), 'marveen-ssh-'))
+      const keyPath = join(tmpDir, 'key')
+      let publicKey: string
+      try {
+        const keyContent = privateKey.endsWith('\n') ? privateKey : privateKey + '\n'
+        writeFileSync(keyPath, keyContent, { mode: 0o600 })
+        chmodSync(keyPath, 0o600)
+        publicKey = execFileSync('ssh-keygen', ['-y', '-f', keyPath], { stdio: 'pipe' }).toString().trim()
+      } catch (err: any) {
+        json(res, { error: 'Invalid private key: ' + (err?.stderr?.toString().trim() ?? err?.message ?? String(err)) }, 400)
+        return true
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
+
+      // Autodetect key type from public key prefix
+      const keyType = publicKey.startsWith('ssh-ed25519') ? 'ed25519'
+                    : publicKey.startsWith('ssh-rsa')     ? 'rsa'
+                    : publicKey.startsWith('ecdsa-')      ? 'ecdsa'
+                    : 'unknown'
+
+      const fingerprint = fingerprintFromPubKey(publicKey)
+      const id = randomBytes(8).toString('hex')
+      const vaultKeyId = `ssh-key-${id}`
+
+      setSecret(vaultKeyId, `SSH private key: ${label}`, privateKey)
+      const key = createVaultSshKey({ id, label, username, vault_key_id: vaultKeyId, public_key: publicKey, fingerprint, key_type: keyType })
+      logger.info({ id, label, fingerprint, keyType }, 'SSH key imported')
+      json(res, { key: toApiShape(key), publicKey }, 201)
+    } catch (err: any) {
+      logger.error({ err }, 'Failed to import SSH key')
+      json(res, { error: 'Import failed: ' + (err?.message ?? String(err)) }, 500)
+    }
+    return true
+  }
+
+  // GET /api/vault/ssh-keys/:id/public-key
+  const pubKeyMatch = path.match(/^\/api\/vault\/ssh-keys\/([^/]+)\/public-key$/)
+  if (pubKeyMatch && method === 'GET') {
+    const id = decodeURIComponent(pubKeyMatch[1])
+    const key = getVaultSshKey(id)
+    if (!key) { json(res, { error: `Key "${id}" not found` }, 404); return true }
+    json(res, { publicKey: key.public_key, fingerprint: key.fingerprint, keyType: key.key_type })
+    return true
+  }
+
+  // DELETE /api/vault/ssh-keys/:id
+  const delMatch = path.match(/^\/api\/vault\/ssh-keys\/([^/]+)$/)
+  if (delMatch && method === 'DELETE') {
+    const id = decodeURIComponent(delMatch[1])
+    const key = getVaultSshKey(id)
+    if (!key) { json(res, { error: `Key "${id}" not found` }, 404); return true }
+    const { deleted, unassigned } = deleteVaultSshKey(id)
+    if (!deleted) { json(res, { error: `Key "${id}" not found` }, 404); return true }
+    // The pool row is gone, but the encrypted private key still sits in the
+    // generic vault.ts secret store (vault_key_id) unless we remove it too --
+    // otherwise it lingers as an orphaned "ssh-key-*" entry, visible/revealable
+    // in the generic secrets list with no pool entry pointing back to it
+    // (2026-07-01, found during Vault key-pool redesign verification).
+    deleteSecret(key.vault_key_id)
+    logger.info({ id, unassigned }, 'SSH key deleted')
+    json(res, { ok: true, unassigned })
+    return true
+  }
+
+  return false
+}

--- a/src/web/routes/vault-ssh.ts
+++ b/src/web/routes/vault-ssh.ts
@@ -1,0 +1,215 @@
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { execFileSync } from 'node:child_process'
+import { readBody, json } from '../http-helpers.js'
+import { logger } from '../../logger.js'
+import {
+  listVaultSshServers,
+  getVaultSshServer,
+  createVaultSshServer,
+  updateVaultSshServer,
+  deleteVaultSshServer,
+  computeSshKeyStatus,
+  getVaultSshKey,
+  listVaultSshKeys,
+  type VaultSshServer,
+  type VaultSshKey,
+} from '../../db.js'
+import { generateSshKeyPair } from './vault-ssh-keys.js'
+import { setSecret } from '../vault.js'
+import type { RouteContext } from './types.js'
+
+function toApiShape(server: VaultSshServer, key?: VaultSshKey | null) {
+  return {
+    id: server.id,
+    name: server.name,
+    host: server.host,
+    port: server.port,
+    user: server.username,
+    desc: server.description ?? '',
+    keyStatus: computeSshKeyStatus(server),
+    sshKeyId: server.ssh_key_id ?? null,
+    keyType: key?.key_type ?? null,
+    fingerprint: key?.fingerprint ?? null,
+    createdAt: new Date(server.created_at * 1000).toISOString(),
+    updatedAt: new Date(server.updated_at * 1000).toISOString(),
+  }
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 64)
+}
+
+function validateId(id: string): boolean {
+  return /^[a-z0-9][a-z0-9-]{0,63}$/.test(id)
+}
+
+function buildKeyMap(servers: VaultSshServer[]): Map<string, VaultSshKey> {
+  const keyIds = [...new Set(servers.map(s => s.ssh_key_id).filter(Boolean) as string[])]
+  const map = new Map<string, VaultSshKey>()
+  for (const id of keyIds) {
+    const k = getVaultSshKey(id)
+    if (k) map.set(id, k)
+  }
+  return map
+}
+
+export async function tryHandleVaultSsh(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  if (!path.startsWith('/api/vault/ssh-servers')) return false
+
+  // GET /api/vault/ssh-servers
+  if (path === '/api/vault/ssh-servers' && method === 'GET') {
+    const servers = listVaultSshServers()
+    const keyMap = buildKeyMap(servers)
+    json(res, { servers: servers.map(s => toApiShape(s, s.ssh_key_id ? keyMap.get(s.ssh_key_id) : null)) })
+    return true
+  }
+
+  // POST /api/vault/ssh-servers
+  if (path === '/api/vault/ssh-servers' && method === 'POST') {
+    try {
+      const body = await readBody(req)
+      const data = JSON.parse(body.toString())
+
+      const name = typeof data.name === 'string' ? data.name.trim() : ''
+      const host = typeof data.host === 'string' ? data.host.trim() : ''
+      const user = typeof data.user === 'string' ? data.user.trim() : ''
+      const port = Number.isInteger(data.port) && data.port > 0 && data.port <= 65535 ? data.port : 22
+      const desc = typeof data.desc === 'string' ? data.desc.trim() : null
+
+      if (!name || !host || !user) {
+        json(res, { error: 'name, host and user are required' }, 400)
+        return true
+      }
+
+      const id = data.id && validateId(data.id) ? data.id : slugify(name) || slugify(host)
+      if (!validateId(id)) {
+        json(res, { error: 'Could not derive a valid id from the name' }, 400)
+        return true
+      }
+
+      if (getVaultSshServer(id)) {
+        json(res, { error: `Server with id "${id}" already exists` }, 409)
+        return true
+      }
+
+      const server = createVaultSshServer({ id, name, host, port, username: user, description: desc || null })
+      logger.info({ id }, 'vault ssh server created')
+      json(res, { server: toApiShape(server) }, 201)
+    } catch (err) {
+      logger.error({ err }, 'Failed to create vault ssh server')
+      json(res, { error: 'Failed to create server' }, 500)
+    }
+    return true
+  }
+
+  // PUT /api/vault/ssh-servers/:id
+  const singleMatch = path.match(/^\/api\/vault\/ssh-servers\/([^/]+)$/)
+
+  if (singleMatch && method === 'PUT') {
+    const id = decodeURIComponent(singleMatch[1])
+    try {
+      const existing = getVaultSshServer(id)
+      if (!existing) { json(res, { error: `Server "${id}" not found` }, 404); return true }
+
+      const body = await readBody(req)
+      const data = JSON.parse(body.toString())
+
+      const patch: Parameters<typeof updateVaultSshServer>[1] = {}
+      if (typeof data.name === 'string')     patch.name        = data.name.trim()
+      if (typeof data.host === 'string')     patch.host        = data.host.trim()
+      if (typeof data.user === 'string')     patch.username    = data.user.trim()
+      if (Number.isInteger(data.port) && data.port > 0 && data.port <= 65535) patch.port = data.port
+      if (data.desc !== undefined)           patch.description = typeof data.desc === 'string' ? (data.desc.trim() || null) : null
+      // Key assignment: sshKeyId (assign existing pool key) or null (unassign)
+      if (data.sshKeyId !== undefined) {
+        if (data.sshKeyId !== null && !getVaultSshKey(data.sshKeyId)) {
+          json(res, { error: `SSH key "${data.sshKeyId}" not found` }, 404)
+          return true
+        }
+        patch.ssh_key_id = data.sshKeyId ?? null
+      }
+
+      updateVaultSshServer(id, patch)
+      const updated = getVaultSshServer(id)!
+      const key = updated.ssh_key_id ? getVaultSshKey(updated.ssh_key_id) : null
+      logger.info({ id }, 'vault ssh server updated')
+      json(res, { server: toApiShape(updated, key) })
+    } catch (err) {
+      logger.error({ err }, 'Failed to update vault ssh server')
+      json(res, { error: 'Failed to update server' }, 500)
+    }
+    return true
+  }
+
+  // DELETE /api/vault/ssh-servers/:id
+  if (singleMatch && method === 'DELETE') {
+    const id = decodeURIComponent(singleMatch[1])
+    if (!deleteVaultSshServer(id)) {
+      json(res, { error: `Server "${id}" not found` }, 404)
+      return true
+    }
+    logger.info({ id }, 'vault ssh server deleted')
+    json(res, { ok: true })
+    return true
+  }
+
+  // POST /api/vault/ssh-servers/:id/generate-key
+  // Legacy convenience: generates a new pool key and immediately assigns it.
+  const genKeyMatch = path.match(/^\/api\/vault\/ssh-servers\/([^/]+)\/generate-key$/)
+  if (genKeyMatch && method === 'POST') {
+    const id = decodeURIComponent(genKeyMatch[1])
+    const server = getVaultSshServer(id)
+    if (!server) { json(res, { error: `Server "${id}" not found` }, 404); return true }
+    try {
+      let keyUser = server.username
+      const bodyRaw = await readBody(req)
+      if (bodyRaw.length > 0) {
+        try {
+          const data = JSON.parse(bodyRaw.toString())
+          if (typeof data.username === 'string' && data.username.trim()) keyUser = data.username.trim()
+        } catch { /* use default */ }
+      }
+
+      const { randomBytes } = await import('node:crypto')
+      const keyId = randomBytes(8).toString('hex')
+      const label = `${server.name} (${keyUser})`
+      const comment = `${keyUser}@${server.host}`
+      const { privateKey, publicKey, fingerprint } = generateSshKeyPair(comment)
+
+      const vaultKeyId = `ssh-key-${keyId}`
+      setSecret(vaultKeyId, `SSH private key: ${label}`, privateKey)
+
+      const { createVaultSshKey } = await import('../../db.js')
+      createVaultSshKey({ id: keyId, label, username: keyUser, vault_key_id: vaultKeyId, public_key: publicKey, fingerprint, key_type: 'ed25519' })
+
+      updateVaultSshServer(id, { ssh_key_id: keyId })
+      const updated = getVaultSshServer(id)!
+      const key = getVaultSshKey(keyId)!
+      logger.info({ id, keyId, fingerprint }, 'SSH keypair generated and assigned to server')
+      json(res, { server: toApiShape(updated, key), publicKey, fingerprint })
+    } catch (err: any) {
+      logger.error({ err, id }, 'Failed to generate SSH keypair')
+      json(res, { error: 'Key generation failed: ' + (err?.message ?? String(err)) }, 500)
+    }
+    return true
+  }
+
+  // GET /api/vault/ssh-servers/:id/public-key
+  const pubKeyMatch = path.match(/^\/api\/vault\/ssh-servers\/([^/]+)\/public-key$/)
+  if (pubKeyMatch && method === 'GET') {
+    const id = decodeURIComponent(pubKeyMatch[1])
+    const server = getVaultSshServer(id)
+    if (!server) { json(res, { error: `Server "${id}" not found` }, 404); return true }
+    if (!server.ssh_key_id) { json(res, { error: 'No key assigned to this server' }, 404); return true }
+    const key = getVaultSshKey(server.ssh_key_id)
+    if (!key) { json(res, { error: 'Assigned key not found' }, 404); return true }
+    json(res, { publicKey: key.public_key, fingerprint: key.fingerprint, keyType: key.key_type })
+    return true
+  }
+
+  return false
+}

--- a/web/app.js
+++ b/web/app.js
@@ -7543,7 +7543,19 @@ async function _sshInfoLoadKey(keyId, serverUser) {
     if (res.ok) { const d = await res.json(); pubkey = d.publicKey || '' }
   } catch {}
 
-  document.getElementById('sshInfoUser').textContent = serverUser || 'root'
+  const targetUser = serverUser || 'root'
+  document.getElementById('sshInfoUser').textContent = targetUser
+
+  // root always exists -- only show the "create user" step for a real,
+  // non-root target user (e.g. a fresh server that needs the account first).
+  const step0 = document.getElementById('sshInfoStep0')
+  if (targetUser === 'root') {
+    step0.hidden = true
+  } else {
+    step0.hidden = false
+    document.getElementById('sshInfoCmd0').textContent = `useradd -m -s /bin/bash ${targetUser}`
+  }
+
   const cmd2text = pubkey
     ? `echo "${pubkey}" >> ~/.ssh/authorized_keys`
     : `echo "<publikus kulcs ide>" >> ~/.ssh/authorized_keys`
@@ -7598,8 +7610,11 @@ function openSshInfoModal(preselectedServerId, { keyOnly = false } = {}) {
     const formKeyId = document.getElementById('sshKeySelectInput')?.value || ''
     keySel.value = formKeyId
 
+    // Use the username typed into the new-server form, not a hardcoded root
+    const formUser = document.getElementById('sshUserInput')?.value.trim() || 'root'
+
     openModal(overlay)
-    _sshInfoLoadKey(formKeyId, 'root')
+    _sshInfoLoadKey(formKeyId, formUser)
   } else {
     // Normal mode: show server selector, pick first server by default
     serverSection.hidden = false
@@ -7636,8 +7651,11 @@ function openSshInfoModal(preselectedServerId, { keyOnly = false } = {}) {
 
   keySel?.addEventListener('change', async () => {
     const keyId = keySel.value || null
-    const server = _sshServers.find(s => s.id === _sshInfoServerId)
-    const targetUser = (server && server.user) || 'root'
+    // Key-only mode (new-server flow) has no _sshInfoServerId -- read the
+    // username from the new-server form instead of falling back to root.
+    const targetUser = _sshInfoServerId
+      ? ((_sshServers.find(s => s.id === _sshInfoServerId) || {}).user || 'root')
+      : (document.getElementById('sshUserInput')?.value.trim() || 'root')
 
     if (_sshInfoServerId) {
       try {

--- a/web/app.js
+++ b/web/app.js
@@ -7226,6 +7226,524 @@ function showEnvVarModal(envVars) {
   })
 })()
 
+// --- SSH Vault ---
+let _sshServers = []
+let _sshKeys = []
+let _sshView = 'table'
+
+async function loadSshServers() {
+  try {
+    const res = await fetch('/api/vault/ssh-servers')
+    const data = await res.json()
+    _sshServers = data.servers || []
+    renderSshServers()
+  } catch { /* ignore */ }
+}
+
+async function loadSshKeys() {
+  try {
+    const res = await fetch('/api/vault/ssh-keys')
+    if (!res.ok) return
+    const data = await res.json()
+    _sshKeys = data.keys || []
+    renderSshKeys()
+    _refreshKeySelects()
+  } catch { /* ignore */ }
+}
+
+function renderSshKeys() {
+  const tbody = document.getElementById('sshKeysTableBody')
+  const keysView = document.getElementById('sshKeysView')
+  const emptyEl = document.getElementById('sshKeysEmpty')
+  if (!tbody) return
+  if (_sshKeys.length === 0) {
+    keysView.hidden = true
+    emptyEl.hidden = false
+    return
+  }
+  keysView.hidden = false
+  emptyEl.hidden = true
+  tbody.innerHTML = _sshKeys.map(k => `
+    <tr>
+      <td class="ssh-table-name">${escapeHtml(k.label || k.id)}</td>
+      <td class="ssh-table-mono">${escapeHtml(k.username || '')}</td>
+      <td class="ssh-table-mono">${escapeHtml(k.keyType || 'ed25519')}</td>
+      <td class="ssh-table-mono" style="font-size:11px">${k.fingerprint ? escapeHtml(k.fingerprint.slice(0,28)) + '…' : ''}</td>
+      <td class="ssh-table-mono">${k.createdAt ? new Date(k.createdAt).toLocaleDateString('hu-HU') : ''}</td>
+      <td><div class="ssh-table-actions">
+        <button class="btn-secondary btn-compact ssh-key-copy-btn" data-id="${escapeHtml(k.id)}" title="Publikus kulcs másolása">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+        </button>
+        <button class="btn-secondary btn-compact ssh-key-delete-btn" data-id="${escapeHtml(k.id)}" title="Törlés">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
+        </button>
+      </div></td>
+    </tr>
+  `).join('')
+  tbody.querySelectorAll('.ssh-key-copy-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const key = _sshKeys.find(k => k.id === btn.dataset.id)
+      if (!key) return
+      try {
+        const res = await fetch(`/api/vault/ssh-keys/${encodeURIComponent(btn.dataset.id)}/public-key`)
+        if (res.ok) {
+          const data = await res.json()
+          await navigator.clipboard.writeText(data.publicKey || '')
+          btn.textContent = '✓'
+          setTimeout(() => { btn.innerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>' }, 1500)
+        }
+      } catch { /* ignore */ }
+    })
+  })
+  tbody.querySelectorAll('.ssh-key-delete-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      if (!confirm('Biztosan törlöd ezt a kulcsot?')) return
+      await fetch(`/api/vault/ssh-keys/${encodeURIComponent(btn.dataset.id)}`, { method: 'DELETE' })
+      await loadSshKeys()
+    })
+  })
+}
+
+function _refreshKeySelects() {
+  const opts = ['<option value="">-- Nincs kulcs --</option>',
+    ..._sshKeys.map(k => `<option value="${escapeHtml(k.id)}">${escapeHtml(k.label || k.id)} (${escapeHtml(k.username || '')})</option>`)
+  ].join('')
+  document.querySelectorAll('.ssh-key-select').forEach(sel => {
+    const prev = sel.value
+    sel.innerHTML = opts
+    sel.value = prev
+  })
+}
+
+function _sshKeyBadge(status) {
+  const labels = { ok: 'OK', missing: 'Hiányzó', expired: 'Lejárt' }
+  const icons = {
+    ok: '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>',
+    missing: '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>',
+    expired: '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>',
+  }
+  return `<span class="ssh-key-badge ${status}">${icons[status] || ''} ${labels[status] || status}</span>`
+}
+
+function _sshKeyAssignSelect(s) {
+  const currentKeyId = s.sshKeyId || s.assignedKeyId || s.vaultKeyId || ''
+  const opts = ['<option value="">-- Nincs kulcs --</option>',
+    ..._sshKeys.map(k => {
+      const sel = (currentKeyId && currentKeyId === k.id) ? ' selected' : ''
+      return `<option value="${escapeHtml(k.id)}"${sel}>${escapeHtml(k.label || k.id)}</option>`
+    })
+  ].join('')
+  return `<select class="ssh-key-assign ssh-key-select" data-id="${escapeHtml(s.id)}" title="Kulcs hozzárendelése">${opts}</select>`
+}
+
+function _sshInfoBtn(s) {
+  return `<button class="ssh-info-btn" data-id="${escapeHtml(s.id)}" data-user="${escapeHtml(s.user)}" title="Telepítési útmutató">i</button>`
+}
+
+function renderSshServers() {
+  const cardsEl = document.getElementById('sshCardsView')
+  const tableView = document.getElementById('sshTableView')
+  const tableBody = document.getElementById('sshTableBody')
+  const emptyEl = document.getElementById('sshEmpty')
+  if (!cardsEl || !tableBody || !emptyEl) return
+
+  // Sync view state with _sshView
+  const isTable = _sshView === 'table'
+  cardsEl.hidden = isTable
+  if (tableView) tableView.hidden = !isTable
+  document.getElementById('sshViewCards')?.classList.toggle('active', !isTable)
+  document.getElementById('sshViewTable')?.classList.toggle('active', isTable)
+
+  if (_sshServers.length === 0) {
+    cardsEl.innerHTML = ''
+    tableBody.innerHTML = ''
+    emptyEl.hidden = false
+    return
+  }
+  emptyEl.hidden = true
+
+  // Cards
+  cardsEl.innerHTML = _sshServers.map(s => `
+    <div class="ssh-card" data-id="${escapeHtml(s.id)}">
+      <div class="ssh-card-head">
+        <div class="ssh-card-icon">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg>
+        </div>
+        <div class="ssh-card-title">
+          <div class="ssh-card-name">${escapeHtml(s.name)}</div>
+          ${s.desc ? `<div class="ssh-card-desc">${escapeHtml(s.desc)}</div>` : ''}
+        </div>
+      </div>
+      <div class="ssh-card-meta">
+        <div class="ssh-card-row">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+          <span>${escapeHtml(s.host)}</span>
+        </div>
+        <div class="ssh-card-row">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+          <span>${escapeHtml(s.user)}${s.port !== 22 ? ` :${s.port}` : ''}</span>
+        </div>
+        ${s.fingerprint ? `<div class="ssh-card-row"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg><span>${escapeHtml(s.keyType || '')} ${escapeHtml(s.fingerprint.slice(0,24))}…</span></div>` : ''}
+      </div>
+      <div class="ssh-card-footer">
+        <div style="display:flex;align-items:center;gap:4px;width:100%">
+          ${_sshKeyAssignSelect(s)}
+          <div class="ssh-card-actions">
+            <button class="btn-secondary btn-compact ssh-edit-btn" data-id="${escapeHtml(s.id)}" title="Szerkesztés">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+            </button>
+            <button class="btn-secondary btn-compact ssh-delete-btn" data-id="${escapeHtml(s.id)}" title="Törlés">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `).join('')
+
+  // Table
+  tableBody.innerHTML = _sshServers.map(s => `
+    <tr data-id="${escapeHtml(s.id)}">
+      <td class="ssh-table-name">${escapeHtml(s.name)}</td>
+      <td class="ssh-table-mono">${escapeHtml(s.host)}</td>
+      <td class="ssh-table-mono">${escapeHtml(s.user)}</td>
+      <td class="ssh-table-mono">${s.port}</td>
+      <td>${_sshKeyAssignSelect(s)}</td>
+      <td style="color:var(--text-muted)">${escapeHtml(s.desc || '')}</td>
+      <td><div class="ssh-table-actions">
+        <button class="btn-secondary btn-compact ssh-edit-btn" data-id="${escapeHtml(s.id)}" title="Szerkesztés">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+        </button>
+        <button class="btn-secondary btn-compact ssh-delete-btn" data-id="${escapeHtml(s.id)}" title="Törlés">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+        </button>
+      </div></td>
+    </tr>
+  `).join('')
+
+  // Delete handlers
+  document.querySelectorAll('.ssh-delete-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const id = btn.getAttribute('data-id')
+      if (!confirm(`Törlöd: ${id}?`)) return
+      try {
+        await fetch(`/api/vault/ssh-servers/${encodeURIComponent(id)}`, { method: 'DELETE' })
+        await loadSshServers()
+      } catch { showToast('Törlés sikertelen') }
+    })
+  })
+
+  // Key assign select handlers
+  document.querySelectorAll('.ssh-key-assign').forEach(sel => {
+    sel.addEventListener('change', async () => {
+      const id = sel.getAttribute('data-id')
+      const sshKeyId = sel.value || null
+      try {
+        await fetch(`/api/vault/ssh-servers/${encodeURIComponent(id)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sshKeyId }),
+        })
+        await loadSshServers()
+      } catch { /* ignore */ }
+    })
+  })
+
+}
+
+// --- SSH Keygen modal (standalone key creation for Kulcstároló) ---
+let _sshKeygenCallback = null  // called with new key after successful generation
+
+function openSshKeygenModal(callback) {
+  const overlay = document.getElementById('sshKeygenOverlay')
+  document.getElementById('sshKeygenLabelInput').value = ''
+  document.getElementById('sshKeygenUserInput').value = ''
+  document.getElementById('sshKeygenSpinner').hidden = true
+  document.getElementById('sshKeygenResult').hidden = true
+  document.getElementById('sshKeygenFooter').hidden = false
+  document.getElementById('sshKeygenForm').hidden = false
+  document.getElementById('sshKeygenPubkeyBox').value = ''
+  _sshKeygenCallback = callback || null
+  openModal(overlay)
+  document.getElementById('sshKeygenLabelInput').focus()
+}
+
+;(function wireSshKeygenModal() {
+  const overlay = document.getElementById('sshKeygenOverlay')
+  const closeBtn = document.getElementById('sshKeygenClose')
+  const submitBtn = document.getElementById('sshKeygenSubmitBtn')
+  const copyBtn = document.getElementById('sshKeygenCopyBtn')
+  if (!overlay) return
+
+  overlay.addEventListener('click', e => { if (e.target === overlay) closeModal(overlay) })
+  closeBtn.addEventListener('click', () => closeModal(overlay))
+
+  submitBtn.addEventListener('click', async () => {
+    const label = document.getElementById('sshKeygenLabelInput').value.trim()
+    const username = document.getElementById('sshKeygenUserInput').value.trim()
+    if (!label || !username) { showToast('Cimke és felhasználónév megadása kötelező'); return }
+
+    document.getElementById('sshKeygenForm').hidden = true
+    document.getElementById('sshKeygenSpinner').hidden = false
+    document.getElementById('sshKeygenResult').hidden = true
+    document.getElementById('sshKeygenFooter').hidden = true
+
+    try {
+      const res = await fetch('/api/vault/ssh-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label, username }),
+      })
+      const data = await res.json()
+      if (!res.ok) { showToast(data.error || 'Generálás sikertelen'); resetKeygenForm(); return }
+
+      const pubkey = data.publicKey || (data.key && data.key.publicKey) || ''
+      document.getElementById('sshKeygenPubkeyBox').value = pubkey
+      document.getElementById('sshKeygenSpinner').hidden = true
+      document.getElementById('sshKeygenResult').hidden = false
+
+      await loadSshKeys()
+      if (_sshKeygenCallback) _sshKeygenCallback(data.key || data)
+    } catch { showToast('Hálózati hiba'); resetKeygenForm() }
+  })
+
+  copyBtn?.addEventListener('click', () => {
+    const val = document.getElementById('sshKeygenPubkeyBox').value
+    navigator.clipboard.writeText(val).then(() => {
+      copyBtn.textContent = 'Másolva!'
+      setTimeout(() => { copyBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Másolás' }, 2000)
+    }).catch(() => {})
+  })
+
+  function resetKeygenForm() {
+    document.getElementById('sshKeygenForm').hidden = false
+    document.getElementById('sshKeygenSpinner').hidden = true
+    document.getElementById('sshKeygenResult').hidden = true
+    document.getElementById('sshKeygenFooter').hidden = false
+  }
+})()
+
+// --- SSH Info modal ---
+let _sshInfoServerId = null
+
+async function _sshInfoLoadKey(keyId, serverUser) {
+  const installSection = document.getElementById('sshInfoInstallSection')
+  const noKeyEl = document.getElementById('sshInfoNoKey')
+  if (!keyId) {
+    installSection.hidden = true
+    noKeyEl.hidden = false
+    return
+  }
+  installSection.hidden = false
+  noKeyEl.hidden = true
+
+  let pubkey = ''
+  try {
+    const res = await fetch(`/api/vault/ssh-keys/${encodeURIComponent(keyId)}/public-key`)
+    if (res.ok) { const d = await res.json(); pubkey = d.publicKey || '' }
+  } catch {}
+
+  document.getElementById('sshInfoUser').textContent = serverUser || 'root'
+  const cmd2text = pubkey
+    ? `echo "${pubkey}" >> ~/.ssh/authorized_keys`
+    : `echo "<publikus kulcs ide>" >> ~/.ssh/authorized_keys`
+  document.getElementById('sshInfoCmd2').textContent = cmd2text
+  document.getElementById('sshInfoPubkey').textContent = pubkey || '(kulcs nem elérhető)'
+
+  const overlay = document.getElementById('sshInfoOverlay')
+  overlay.querySelectorAll('.ssh-code-copy').forEach(btn => {
+    const clone = btn.cloneNode(true)
+    btn.parentNode.replaceChild(clone, btn)
+    clone.addEventListener('click', () => {
+      const text = document.getElementById(clone.getAttribute('data-target'))?.textContent || ''
+      navigator.clipboard.writeText(text).then(() => {
+        clone.classList.add('copied')
+        setTimeout(() => clone.classList.remove('copied'), 2000)
+      }).catch(() => {})
+    })
+  })
+}
+
+function _sshInfoLoadServer(serverId) {
+  _sshInfoServerId = serverId
+  const server = _sshServers.find(s => s.id === serverId)
+
+  document.getElementById('sshInfoServerName').textContent = server ? server.name : (serverId || '')
+
+  const keySel = document.getElementById('sshInfoKeySelect')
+  keySel.innerHTML = ['<option value="">-- Nincs kulcs --</option>',
+    ..._sshKeys.map(k => `<option value="${escapeHtml(k.id)}">${escapeHtml(k.label || k.id)} (${escapeHtml(k.username || '')})</option>`)
+  ].join('')
+  const assignedKeyId = (server && (server.sshKeyId || server.assignedKeyId || server.vaultKeyId)) || ''
+  keySel.value = assignedKeyId
+  return { server, assignedKeyId }
+}
+
+function openSshInfoModal(preselectedServerId, { keyOnly = false } = {}) {
+  const overlay = document.getElementById('sshInfoOverlay')
+  const serverSection = overlay.querySelector('.ssh-info-server-section')
+
+  if (keyOnly) {
+    // Key-only mode: hide server selector, reset server context
+    serverSection.hidden = true
+    _sshInfoServerId = null
+    document.getElementById('sshInfoServerName').textContent = 'Új szerver'
+
+    // Populate key selector without a pre-selected key
+    const keySel = document.getElementById('sshInfoKeySelect')
+    keySel.innerHTML = ['<option value="">-- Válassz kulcsot --</option>',
+      ..._sshKeys.map(k => `<option value="${escapeHtml(k.id)}">${escapeHtml(k.label || k.id)} (${escapeHtml(k.username || '')})</option>`)
+    ].join('')
+    // Pre-select whatever is chosen in the form's key dropdown
+    const formKeyId = document.getElementById('sshKeySelectInput')?.value || ''
+    keySel.value = formKeyId
+
+    openModal(overlay)
+    _sshInfoLoadKey(formKeyId, 'root')
+  } else {
+    // Normal mode: show server selector, pick first server by default
+    serverSection.hidden = false
+    const serverSel = document.getElementById('sshInfoServerSelect')
+    serverSel.innerHTML = ['<option value="">-- Válassz szervert --</option>',
+      ..._sshServers.map(s => `<option value="${escapeHtml(s.id)}">${escapeHtml(s.name)} (${escapeHtml(s.host)})</option>`)
+    ].join('')
+
+    const firstId = preselectedServerId || (_sshServers[0] && _sshServers[0].id) || ''
+    serverSel.value = firstId
+
+    const { server, assignedKeyId } = _sshInfoLoadServer(firstId)
+    const targetUser = (server && server.user) || 'root'
+
+    openModal(overlay)
+    _sshInfoLoadKey(assignedKeyId, targetUser)
+  }
+}
+
+;(function wireSshInfoModal() {
+  const overlay = document.getElementById('sshInfoOverlay')
+  const closeBtn = document.getElementById('sshInfoClose')
+  const serverSel = document.getElementById('sshInfoServerSelect')
+  const keySel = document.getElementById('sshInfoKeySelect')
+  if (!overlay) return
+
+  overlay.addEventListener('click', e => { if (e.target === overlay) closeModal(overlay) })
+  closeBtn.addEventListener('click', () => closeModal(overlay))
+
+  serverSel?.addEventListener('change', () => {
+    const { server, assignedKeyId } = _sshInfoLoadServer(serverSel.value)
+    _sshInfoLoadKey(assignedKeyId, (server && server.user) || 'root')
+  })
+
+  keySel?.addEventListener('change', async () => {
+    const keyId = keySel.value || null
+    const server = _sshServers.find(s => s.id === _sshInfoServerId)
+    const targetUser = (server && server.user) || 'root'
+
+    if (_sshInfoServerId) {
+      try {
+        await fetch(`/api/vault/ssh-servers/${encodeURIComponent(_sshInfoServerId)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sshKeyId: keyId }),
+        })
+        await loadSshServers()
+      } catch { /* ignore */ }
+    }
+    await _sshInfoLoadKey(keyId, targetUser)
+  })
+})()
+
+;(function wireSshSection() {
+  const newBtn = document.getElementById('sshNewBtn')
+  const panel = document.getElementById('sshAddPanel')
+  const closeBtn = document.getElementById('sshAddPanelClose')
+  const addBtn = document.getElementById('sshAddBtn')
+  const cardViewBtn = document.getElementById('sshViewCards')
+  const tableViewBtn = document.getElementById('sshViewTable')
+  const cardsView = document.getElementById('sshCardsView')
+  const tableView = document.getElementById('sshTableView')
+
+  if (!newBtn) return
+
+  newBtn.addEventListener('click', () => {
+    panel.hidden = !panel.hidden
+    if (!panel.hidden) document.getElementById('sshNameInput').focus()
+  })
+  closeBtn?.addEventListener('click', () => { panel.hidden = true })
+
+  // (i) install guide button inside the "new server" form -- key-only mode
+  document.getElementById('sshKeyInstallFromFormBtn')?.addEventListener('click', () => {
+    openSshInfoModal(null, { keyOnly: true })
+  })
+
+  // "+ Új kulcs" button inside the "new server" form
+  document.getElementById('sshKeyNewFromFormBtn')?.addEventListener('click', () => {
+    openSshKeygenModal(newKey => {
+      // After key created, select it in the form dropdown
+      if (newKey && newKey.id) {
+        const sel = document.getElementById('sshKeySelectInput')
+        if (sel) sel.value = newKey.id
+      }
+    })
+  })
+
+  addBtn?.addEventListener('click', async () => {
+    const name = document.getElementById('sshNameInput').value.trim()
+    const host = document.getElementById('sshHostInput').value.trim()
+    const user = document.getElementById('sshUserInput').value.trim()
+    const port = parseInt(document.getElementById('sshPortInput').value, 10) || 22
+    const desc = document.getElementById('sshDescInput').value.trim()
+    const sshKeyId = document.getElementById('sshKeySelectInput')?.value || null
+    if (!name || !host || !user) { showToast('Név, IP és felhasználó megadása kötelező'); return }
+    try {
+      const res = await fetch('/api/vault/ssh-servers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, host, user, port, desc, sshKeyId: sshKeyId || undefined }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        showToast(err.error || 'Hiba a mentéskor'); return
+      }
+      document.getElementById('sshNameInput').value = ''
+      document.getElementById('sshHostInput').value = ''
+      document.getElementById('sshUserInput').value = ''
+      document.getElementById('sshPortInput').value = '22'
+      document.getElementById('sshDescInput').value = ''
+      if (document.getElementById('sshKeySelectInput')) document.getElementById('sshKeySelectInput').value = ''
+      panel.hidden = true
+      await loadSshServers()
+      showToast('Szerver hozzáadva')
+    } catch { showToast('Hálózati hiba') }
+  })
+
+  cardViewBtn?.addEventListener('click', () => {
+    _sshView = 'cards'
+    cardViewBtn.classList.add('active')
+    tableViewBtn.classList.remove('active')
+    cardsView.hidden = false
+    tableView.hidden = true
+  })
+
+  tableViewBtn?.addEventListener('click', () => {
+    _sshView = 'table'
+    tableViewBtn.classList.add('active')
+    cardViewBtn.classList.remove('active')
+    cardsView.hidden = true
+    tableView.hidden = false
+  })
+
+  // Kulcstároló "Új kulcs generálása" button
+  document.getElementById('sshKeyNewBtn')?.addEventListener('click', () => {
+    openSshKeygenModal()
+  })
+
+  // Global (i) info button in section header
+  document.getElementById('sshInfoGlobalBtn')?.addEventListener('click', () => {
+    openSshInfoModal()
+  })
+})()
+
 // --- Vault Page ---
 let _vaultSecrets = []
 
@@ -7244,6 +7762,7 @@ async function loadVaultPage() {
     document.getElementById('vaultStatTotal').textContent = String(_vaultSecrets.length)
     document.getElementById('vaultStatBindings').textContent = String(_vaultBindings.length)
     renderVaultGrid(_vaultSecrets)
+    await Promise.all([loadSshKeys(), loadSshServers()])
   } catch { /* ignore */ }
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -7230,6 +7230,7 @@ function showEnvVarModal(envVars) {
 let _sshServers = []
 let _sshKeys = []
 let _sshView = 'table'
+let _sshEditingId = null
 
 async function loadSshServers() {
   try {
@@ -7430,6 +7431,31 @@ function renderSshServers() {
         await fetch(`/api/vault/ssh-servers/${encodeURIComponent(id)}`, { method: 'DELETE' })
         await loadSshServers()
       } catch { showToast('Törlés sikertelen') }
+    })
+  })
+
+  // Edit handlers -- open the add-server panel pre-filled, switch it to edit mode
+  document.querySelectorAll('.ssh-edit-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.getAttribute('data-id')
+      const server = _sshServers.find(s => s.id === id)
+      if (!server) return
+      _sshEditingId = id
+
+      document.getElementById('sshNameInput').value = server.name || ''
+      document.getElementById('sshHostInput').value = server.host || ''
+      document.getElementById('sshUserInput').value = server.user || ''
+      document.getElementById('sshPortInput').value = server.port || 22
+      document.getElementById('sshDescInput').value = server.desc || ''
+      const keySel = document.getElementById('sshKeySelectInput')
+      if (keySel) keySel.value = server.sshKeyId || server.assignedKeyId || server.vaultKeyId || ''
+
+      const titleEl = document.getElementById('sshAddPanelTitle')
+      if (titleEl) titleEl.textContent = `Szerver szerkesztése – ${server.name}`
+
+      const panel = document.getElementById('sshAddPanel')
+      panel.hidden = false
+      document.getElementById('sshNameInput').focus()
     })
   })
 
@@ -7683,11 +7709,24 @@ function openSshInfoModal(preselectedServerId, { keyOnly = false } = {}) {
 
   if (!newBtn) return
 
+  function resetSshAddForm() {
+    _sshEditingId = null
+    const titleEl = document.getElementById('sshAddPanelTitle')
+    if (titleEl) titleEl.textContent = 'Szerver hozzáadása'
+    document.getElementById('sshNameInput').value = ''
+    document.getElementById('sshHostInput').value = ''
+    document.getElementById('sshUserInput').value = ''
+    document.getElementById('sshPortInput').value = '22'
+    document.getElementById('sshDescInput').value = ''
+    if (document.getElementById('sshKeySelectInput')) document.getElementById('sshKeySelectInput').value = ''
+  }
+
   newBtn.addEventListener('click', () => {
+    if (panel.hidden) resetSshAddForm()
     panel.hidden = !panel.hidden
     if (!panel.hidden) document.getElementById('sshNameInput').focus()
   })
-  closeBtn?.addEventListener('click', () => { panel.hidden = true })
+  closeBtn?.addEventListener('click', () => { panel.hidden = true; resetSshAddForm() })
 
   // (i) install guide button inside the "new server" form -- key-only mode
   document.getElementById('sshKeyInstallFromFormBtn')?.addEventListener('click', () => {
@@ -7713,25 +7752,24 @@ function openSshInfoModal(preselectedServerId, { keyOnly = false } = {}) {
     const desc = document.getElementById('sshDescInput').value.trim()
     const sshKeyId = document.getElementById('sshKeySelectInput')?.value || null
     if (!name || !host || !user) { showToast('Név, IP és felhasználó megadása kötelező'); return }
+    const isEdit = !!_sshEditingId
     try {
-      const res = await fetch('/api/vault/ssh-servers', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, host, user, port, desc, sshKeyId: sshKeyId || undefined }),
-      })
+      const res = await fetch(
+        isEdit ? `/api/vault/ssh-servers/${encodeURIComponent(_sshEditingId)}` : '/api/vault/ssh-servers',
+        {
+          method: isEdit ? 'PUT' : 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, host, user, port, desc, sshKeyId: sshKeyId || undefined }),
+        }
+      )
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
         showToast(err.error || 'Hiba a mentéskor'); return
       }
-      document.getElementById('sshNameInput').value = ''
-      document.getElementById('sshHostInput').value = ''
-      document.getElementById('sshUserInput').value = ''
-      document.getElementById('sshPortInput').value = '22'
-      document.getElementById('sshDescInput').value = ''
-      if (document.getElementById('sshKeySelectInput')) document.getElementById('sshKeySelectInput').value = ''
+      resetSshAddForm()
       panel.hidden = true
       await loadSshServers()
-      showToast('Szerver hozzáadva')
+      showToast(isEdit ? 'Szerver frissítve' : 'Szerver hozzáadva')
     } catch { showToast('Hálózati hiba') }
   })
 

--- a/web/index.html
+++ b/web/index.html
@@ -1399,8 +1399,17 @@
             <!-- Part 2: Install commands -->
             <div id="sshInfoInstallSection">
               <p class="vault-scan-desc" style="margin-bottom:12px">Futtasd az alábbi parancsokat a célszerveren (<strong id="sshInfoUser"></strong> felhasználóval) a kiválasztott kulcs telepítéséhez:</p>
+              <div class="ssh-install-step" id="sshInfoStep0">
+                <div class="ssh-install-step-label">1. Felhasználó létrehozása (ha még nincs, root-tal futtatva)</div>
+                <div class="ssh-code-wrap">
+                  <code class="ssh-code" id="sshInfoCmd0"></code>
+                  <button class="ssh-code-copy" data-target="sshInfoCmd0" title="Másolás">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                  </button>
+                </div>
+              </div>
               <div class="ssh-install-step">
-                <div class="ssh-install-step-label">1. SSH könyvtár létrehozása (ha még nincs)</div>
+                <div class="ssh-install-step-label">2. SSH könyvtár létrehozása (ha még nincs)</div>
                 <div class="ssh-code-wrap">
                   <code class="ssh-code" id="sshInfoCmd1">mkdir -p ~/.ssh &amp;&amp; chmod 700 ~/.ssh</code>
                   <button class="ssh-code-copy" data-target="sshInfoCmd1" title="Másolás">
@@ -1409,7 +1418,7 @@
                 </div>
               </div>
               <div class="ssh-install-step">
-                <div class="ssh-install-step-label">2. Publikus kulcs hozzáfűzése</div>
+                <div class="ssh-install-step-label">3. Publikus kulcs hozzáfűzése</div>
                 <div class="ssh-code-wrap">
                   <code class="ssh-code" id="sshInfoCmd2"></code>
                   <button class="ssh-code-copy" data-target="sshInfoCmd2" title="Másolás">
@@ -1418,7 +1427,7 @@
                 </div>
               </div>
               <div class="ssh-install-step">
-                <div class="ssh-install-step-label">3. Jogosultság beállítása</div>
+                <div class="ssh-install-step-label">4. Jogosultság beállítása</div>
                 <div class="ssh-code-wrap">
                   <code class="ssh-code" id="sshInfoCmd3">chmod 600 ~/.ssh/authorized_keys</code>
                   <button class="ssh-code-copy" data-target="sshInfoCmd3" title="Másolás">

--- a/web/index.html
+++ b/web/index.html
@@ -1235,7 +1235,7 @@
               <button class="view-btn active" id="sshViewTable" title="Táblázat nézet">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
               </button>
-              <button class="view-btn" id="sshInfoGlobalBtn" title="Telepítési útmutató">
+              <button class="view-btn" id="sshInfoGlobalBtn" title="Telepítési útmutató (meglévő szerver)">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
               </button>
             </div>
@@ -1279,7 +1279,7 @@
                   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                   Új kulcs
                 </button>
-                <button type="button" class="ssh-info-btn" id="sshKeyInstallFromFormBtn" title="Telepítési útmutató">i</button>
+                <button type="button" class="ssh-info-btn" id="sshKeyInstallFromFormBtn" title="Telepítési útmutató (ehhez az új szerverhez)">i</button>
               </div>
             </div>
             <div class="vault-field-group">

--- a/web/index.html
+++ b/web/index.html
@@ -1249,7 +1249,7 @@
         <!-- Add server panel -->
         <div class="vault-add-panel" id="sshAddPanel" hidden>
           <div class="vault-add-panel-header">
-            <h3>Szerver hozzáadása</h3>
+            <h3 id="sshAddPanelTitle">Szerver hozzáadása</h3>
             <button class="modal-close" id="sshAddPanelClose">&times;</button>
           </div>
           <div class="vault-add-fields" style="grid-template-columns:1fr 1fr 1fr">

--- a/web/index.html
+++ b/web/index.html
@@ -1178,6 +1178,267 @@
         <p class="vault-empty-hint" data-i18n="vault.empty_hint">Adj hozza egyet az "Uj kulcs" gombbal</p>
       </div>
 
+      <!-- === SSH Key Store section === -->
+      <div class="ssh-section ssh-key-store-section">
+        <div class="ssh-section-header">
+          <div>
+            <h2 class="ssh-section-title">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+              Kulcstároló
+            </h2>
+            <p class="ssh-section-sub">Generált ed25519 kulcspárok – ezeket rendelheted a szerverekhez</p>
+          </div>
+          <div class="ssh-section-actions">
+            <button class="btn-primary btn-compact" id="sshKeyNewBtn">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              Új kulcs generálása
+            </button>
+          </div>
+        </div>
+        <div class="ssh-table-wrap" id="sshKeysView" hidden>
+          <table class="ssh-table">
+            <thead>
+              <tr>
+                <th>Cimke</th>
+                <th>Felhasználónév</th>
+                <th>Típus</th>
+                <th>Ujjlenyomat</th>
+                <th>Létrehozva</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="sshKeysTableBody"></tbody>
+          </table>
+        </div>
+        <div id="sshKeysEmpty" class="vault-empty">
+          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+          <p>Még nincs kulcs</p>
+          <p class="vault-empty-hint">Generálj egyet, majd rendeld hozzá a szerverekhez</p>
+        </div>
+      </div>
+
+      <!-- === SSH Servers section === -->
+      <div class="ssh-section">
+        <div class="ssh-section-header">
+          <div>
+            <h2 class="ssh-section-title">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg>
+              SSH Szerverek
+            </h2>
+            <p class="ssh-section-sub">Szerver hozzáférések és SSH kulcs állapotok</p>
+          </div>
+          <div class="ssh-section-actions">
+            <div class="schedule-view-toggle">
+              <button class="view-btn" id="sshViewCards" title="Kártya nézet">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+              </button>
+              <button class="view-btn active" id="sshViewTable" title="Táblázat nézet">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+              </button>
+              <button class="view-btn" id="sshInfoGlobalBtn" title="Telepítési útmutató">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+              </button>
+            </div>
+            <button class="btn-primary btn-compact" id="sshNewBtn">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              Új szerver
+            </button>
+          </div>
+        </div>
+
+        <!-- Add server panel -->
+        <div class="vault-add-panel" id="sshAddPanel" hidden>
+          <div class="vault-add-panel-header">
+            <h3>Szerver hozzáadása</h3>
+            <button class="modal-close" id="sshAddPanelClose">&times;</button>
+          </div>
+          <div class="vault-add-fields" style="grid-template-columns:1fr 1fr 1fr">
+            <div class="vault-field-group">
+              <label class="vault-field-label">Név</label>
+              <input type="text" id="sshNameInput" class="input" placeholder="pl. web-prod-01">
+            </div>
+            <div class="vault-field-group">
+              <label class="vault-field-label">IP / Hostnév</label>
+              <input type="text" id="sshHostInput" class="input" placeholder="192.168.1.10">
+            </div>
+            <div class="vault-field-group">
+              <label class="vault-field-label">Felhasználónév</label>
+              <input type="text" id="sshUserInput" class="input" placeholder="root">
+            </div>
+            <div class="vault-field-group">
+              <label class="vault-field-label">Port</label>
+              <input type="number" id="sshPortInput" class="input" placeholder="22" value="22">
+            </div>
+            <div class="vault-field-group">
+              <label class="vault-field-label">SSH kulcs</label>
+              <div class="ssh-key-select-wrap">
+                <select id="sshKeySelectInput" class="input ssh-key-select">
+                  <option value="">-- Nincs kulcs --</option>
+                </select>
+                <button type="button" class="btn-secondary btn-compact" id="sshKeyNewFromFormBtn" title="Új kulcs generálása">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                  Új kulcs
+                </button>
+                <button type="button" class="ssh-info-btn" id="sshKeyInstallFromFormBtn" title="Telepítési útmutató">i</button>
+              </div>
+            </div>
+            <div class="vault-field-group">
+              <label class="vault-field-label">Leírás (opcionális)</label>
+              <input type="text" id="sshDescInput" class="input" placeholder="pl. Produkciós webszerver">
+            </div>
+          </div>
+          <div class="vault-add-actions">
+            <button class="btn-primary" id="sshAddBtn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/></svg>
+              Szerver mentése
+            </button>
+          </div>
+        </div>
+
+        <!-- Card view -->
+        <div class="ssh-cards schedule-view" id="sshCardsView"></div>
+
+        <!-- Table view -->
+        <div class="schedule-view" id="sshTableView" hidden>
+          <div class="ssh-table-wrap">
+            <table class="ssh-table">
+              <thead>
+                <tr>
+                  <th>Név</th>
+                  <th>IP / Hostnév</th>
+                  <th>Felhasználó</th>
+                  <th>Port</th>
+                  <th>Hozzárendelt kulcs</th>
+                  <th>Leírás</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="sshTableBody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div id="sshEmpty" class="vault-empty" hidden>
+          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg>
+          <p>Még nincs szerver</p>
+          <p class="vault-empty-hint">Add hozzá az "Új szerver" gombbal</p>
+        </div>
+      </div>
+
+      <!-- SSH Key Generation modal (standalone key store) -->
+      <div class="modal-overlay" id="sshKeygenOverlay">
+        <div class="modal" style="max-width:520px">
+          <div class="modal-header">
+            <h2>SSH kulcs generálása</h2>
+            <button class="modal-close" id="sshKeygenClose">&times;</button>
+          </div>
+          <div class="modal-body">
+            <p class="vault-scan-desc">Új ed25519 kulcspár generálása. A privát kulcs titkosítva tárolódik a Vault-ban, soha nem hagyja el a szervert.</p>
+            <div id="sshKeygenForm">
+              <div class="form-group">
+                <label for="sshKeygenLabelInput">Cimke</label>
+                <input type="text" id="sshKeygenLabelInput" class="input" placeholder="pl. bishop-ro jumphost">
+              </div>
+              <div class="form-group">
+                <label for="sshKeygenUserInput">Felhasználónév (ssh komment)</label>
+                <input type="text" id="sshKeygenUserInput" class="input" placeholder="pl. bishop-ro">
+              </div>
+            </div>
+            <div id="sshKeygenSpinner" hidden style="text-align:center;padding:20px 0">
+              <svg class="spin" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+              <p style="margin-top:8px;font-size:13px;color:var(--text-muted)">Generálás folyamatban...</p>
+            </div>
+            <div id="sshKeygenResult" hidden>
+              <div class="ssh-pubkey-label">
+                <span>Publikus kulcs</span>
+                <button class="btn-secondary btn-compact" id="sshKeygenCopyBtn">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                  Másolás
+                </button>
+              </div>
+              <textarea id="sshKeygenPubkeyBox" class="ssh-pubkey-box" readonly rows="3"></textarea>
+              <p class="ssh-pubkey-hint">A kulcs mentve a Kulcstárolóba. Rendeld hozzá egy szerverhez, majd telepítsd az (i) gomb segítségével.</p>
+            </div>
+          </div>
+          <div class="modal-footer" id="sshKeygenFooter">
+            <button class="btn-primary" id="sshKeygenSubmitBtn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+              Generálás
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- SSH Install Info modal -->
+      <div class="modal-overlay" id="sshInfoOverlay">
+        <div class="modal" style="max-width:580px">
+          <div class="modal-header">
+            <h2>Kulcs telepítése – <span id="sshInfoServerName"></span></h2>
+            <button class="modal-close" id="sshInfoClose">&times;</button>
+          </div>
+          <div class="modal-body">
+            <!-- Part 0: Server selector -->
+            <div class="ssh-info-server-section">
+              <div class="ssh-info-key-section-label">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg>
+                Szerver
+              </div>
+              <select id="sshInfoServerSelect" class="input ssh-key-select" style="width:100%;max-width:100%;height:34px;font-size:13px"></select>
+            </div>
+
+            <!-- Part 1: Key selector -->
+            <div class="ssh-info-key-section">
+              <div class="ssh-info-key-section-label">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+                Kulcs kiválasztása
+              </div>
+              <p class="ssh-section-sub" style="margin:0 0 8px">Válaszd ki, melyik Kulcstárolóban lévő kulcsot rendeled ehhez a szerverhez. A változás azonnal mentésre kerül.</p>
+              <select id="sshInfoKeySelect" class="input ssh-key-select"></select>
+            </div>
+
+            <!-- Part 2: Install commands -->
+            <div id="sshInfoInstallSection">
+              <p class="vault-scan-desc" style="margin-bottom:12px">Futtasd az alábbi parancsokat a célszerveren (<strong id="sshInfoUser"></strong> felhasználóval) a kiválasztott kulcs telepítéséhez:</p>
+              <div class="ssh-install-step">
+                <div class="ssh-install-step-label">1. SSH könyvtár létrehozása (ha még nincs)</div>
+                <div class="ssh-code-wrap">
+                  <code class="ssh-code" id="sshInfoCmd1">mkdir -p ~/.ssh &amp;&amp; chmod 700 ~/.ssh</code>
+                  <button class="ssh-code-copy" data-target="sshInfoCmd1" title="Másolás">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                  </button>
+                </div>
+              </div>
+              <div class="ssh-install-step">
+                <div class="ssh-install-step-label">2. Publikus kulcs hozzáfűzése</div>
+                <div class="ssh-code-wrap">
+                  <code class="ssh-code" id="sshInfoCmd2"></code>
+                  <button class="ssh-code-copy" data-target="sshInfoCmd2" title="Másolás">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                  </button>
+                </div>
+              </div>
+              <div class="ssh-install-step">
+                <div class="ssh-install-step-label">3. Jogosultság beállítása</div>
+                <div class="ssh-code-wrap">
+                  <code class="ssh-code" id="sshInfoCmd3">chmod 600 ~/.ssh/authorized_keys</code>
+                  <button class="ssh-code-copy" data-target="sshInfoCmd3" title="Másolás">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                  </button>
+                </div>
+              </div>
+              <div class="info-box" style="margin-top:16px">
+                <strong>Publikus kulcs:</strong>
+                <div id="sshInfoPubkey" style="font-family:monospace;font-size:11px;word-break:break-all;margin-top:4px;color:var(--text-muted)"></div>
+              </div>
+            </div>
+
+            <div id="sshInfoNoKey" hidden style="text-align:center;padding:16px 0;color:var(--text-muted);font-size:13px">
+              Nincs kulcs kiválasztva. Válassz egyet fentebb, vagy generálj újat a Kulcstárolóban.
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- Binding modal -->
       <div class="modal-overlay" id="vaultBindOverlay">
         <div class="modal" style="max-width:500px">

--- a/web/style.css
+++ b/web/style.css
@@ -4005,6 +4005,336 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
 }
 .vault-card-edit-form .input { flex: 1; }
 
+/* === SSH Vault Section === */
+.ssh-section {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+}
+.ssh-key-store-section { margin-top: 28px; }
+
+/* Key assign select in card/table */
+.ssh-key-select {
+  font-size: 12px;
+  padding: 3px 6px;
+  height: 28px;
+  min-width: 0;
+  max-width: 160px;
+}
+.ssh-key-select-wrap {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.ssh-key-select-wrap .ssh-key-select { flex: 1; }
+
+/* Info modal server section */
+.ssh-info-server-section {
+  margin-bottom: 14px;
+}
+.ssh-info-server-section .ssh-info-key-section-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+
+/* Info modal key section */
+.ssh-info-key-section {
+  background: var(--bg-hover, rgba(127,127,127,.05));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin-bottom: 20px;
+}
+.ssh-info-key-section-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 8px;
+}
+.ssh-info-key-section .ssh-key-select {
+  width: 100%;
+  max-width: 100%;
+  height: 34px;
+  font-size: 13px;
+}
+.ssh-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.ssh-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+}
+.ssh-section-sub {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.ssh-section-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* SSH key status badges */
+.ssh-key-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+.ssh-key-badge.ok { background: rgba(34,197,94,.15); color: #16a34a; }
+.ssh-key-badge.missing { background: rgba(234,179,8,.15); color: #b45309; }
+.ssh-key-badge.expired { background: rgba(239,68,68,.15); color: #dc2626; }
+[data-theme="dark"] .ssh-key-badge.ok { color: #4ade80; }
+[data-theme="dark"] .ssh-key-badge.missing { color: #fbbf24; }
+[data-theme="dark"] .ssh-key-badge.expired { color: #f87171; }
+
+/* SSH card grid */
+.ssh-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+.ssh-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+.ssh-card:hover { border-color: var(--accent); box-shadow: 0 2px 8px rgba(0,0,0,.08); }
+.ssh-card-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+.ssh-card-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.ssh-card-title { flex: 1; min-width: 0; }
+.ssh-card-name {
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ssh-card-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ssh-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+.ssh-card-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+}
+.ssh-card-row svg { flex-shrink: 0; opacity: 0.6; }
+.ssh-card-row span { color: var(--text); font-family: monospace; font-size: 12px; }
+.ssh-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+.ssh-card-actions { display: flex; gap: 4px; }
+
+/* SSH table */
+.ssh-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.ssh-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.ssh-table th {
+  background: var(--bg-card);
+  padding: 10px 14px;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.ssh-table td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+.ssh-table tr:last-child td { border-bottom: none; }
+.ssh-table tbody tr:hover { background: var(--bg-hover, rgba(127,127,127,.05)); }
+.ssh-table .ssh-table-name { font-weight: 600; }
+.ssh-table .ssh-table-mono { font-family: monospace; font-size: 12px; color: var(--text-muted); }
+.ssh-table .ssh-table-actions { display: flex; gap: 4px; justify-content: flex-end; }
+
+@media (max-width: 600px) {
+  .ssh-cards { grid-template-columns: 1fr; }
+  .ssh-section-header { flex-direction: column; }
+}
+
+/* SSH keygen + info modal styles */
+.ssh-pubkey-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+.ssh-pubkey-box {
+  width: 100%;
+  font-family: monospace;
+  font-size: 11px;
+  padding: 10px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  resize: none;
+  line-height: 1.5;
+  word-break: break-all;
+}
+.ssh-pubkey-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 8px;
+}
+.ssh-install-step {
+  margin-bottom: 14px;
+}
+.ssh-install-step-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+.ssh-code-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+}
+.ssh-code {
+  flex: 1;
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--text);
+  word-break: break-all;
+  white-space: pre-wrap;
+  user-select: all;
+}
+.ssh-code-copy {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+.ssh-code-copy:hover { color: var(--accent); border-color: var(--accent); }
+.ssh-code-copy.copied { color: var(--success); border-color: var(--success); }
+@keyframes spin { to { transform: rotate(360deg); } }
+.spin { animation: spin 0.8s linear infinite; }
+
+/* Keygen button -- inline on card/table */
+.ssh-keygen-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 20px;
+  border: 1px solid currentColor;
+  background: transparent;
+  cursor: pointer;
+  transition: all var(--transition);
+  color: #b45309;
+}
+[data-theme="dark"] .ssh-keygen-btn { color: #fbbf24; }
+.ssh-keygen-btn:hover { background: rgba(234,179,8,.12); }
+
+.ssh-info-btn {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+  transition: all var(--transition);
+  flex-shrink: 0;
+}
+.ssh-info-btn:hover { color: var(--accent); border-color: var(--accent); }
+
 .vault-bind-status {
   font-size: 13px;
   padding: 8px 12px;


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Új funkció (feature / new feature)
- [x] Dokumentáció (docs)

## Rövid leírás / Summary

Adds an **SSH Vault** module to the dashboard: a central registry of the SSH servers the fleet reaches and the keys used to reach them, separate from the generic secret vault.

- Data model: `vault_ssh_servers` + a shared `vault_ssh_keys` pool (many-servers-to-one-key).
- Private keys live in the AES-256-GCM `vault.ts` store (`ssh-key-<id>`), filtered out of `/api/vault` and never printed to logs/transcripts.
- Endpoints: server CRUD, key pool list/generate (ed25519), import (`ssh-keygen -y`), public-key + install instructions, cascade-safe delete (no orphans).
- UI: key store + SSH Servers (card/table) with a per-server key dropdown; key-only install modal for new servers (optional non-root `useradd` step).

## Kapcsolódó issue / Related issue

Nincs kapcsolódó upstream issue. / No tracked upstream issue.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard). / Tested locally (Telegram/Slack + dashboard).
- [x] Frissítettem a `docs/` mappát. / Updated `docs/` (`docs/vault.md`).
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (nem `develop`-ra). / Opened from an own branch (not `develop`).