### PR TITLE
feat(dashboard): owner-gated opt-in terminal-input toggle + per-call audit (ddc0cd9b)

### DIFF
--- a/src/web/routes/agent-terminal.ts
+++ b/src/web/routes/agent-terminal.ts
@@ -7,6 +7,7 @@ import { agentDir } from '../agent-config.js'
 import { agentSessionName, isAgentRunning } from '../agent-process.js'
 import { isMainChannelsAgent, MAIN_CHANNELS_SESSION } from '../main-agent.js'
 import { literalKeyArgs, specialKeyArgs, loginSequence, type LoginStep } from '../tmux-keys.js'
+import { readTerminalInputEnabled, writeTerminalInputEnabled } from '../terminal-input-store.js'
 import type { RouteContext } from './types.js'
 
 const TMUX = resolveFromPath('tmux')
@@ -65,6 +66,36 @@ async function runLoginSteps(session: string, steps: LoginStep[]): Promise<void>
 export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean> {
   const { res, path, method, url } = ctx
 
+  // --- terminal-input master toggle (owner-gated opt-in) ---------------
+  // GET returns the current state; POST {enabled:boolean} flips it. Both sit
+  // behind the global dashboard-token gate (web.ts), so only the operator can
+  // read or change it. This is the deliberate first step of the two-step opt-in:
+  // /keys stays 403 until this is ON. Every flip is audit-logged.
+  if (path === '/api/terminal-input') {
+    if (method === 'GET') {
+      json(res, { enabled: readTerminalInputEnabled() })
+      return true
+    }
+    if (method === 'POST') {
+      const body = await readBody(ctx.req)
+      let enabled: unknown
+      try { enabled = (JSON.parse(body.toString()) as { enabled?: unknown }).enabled } catch { json(res, { error: 'Invalid JSON' }, 400); return true }
+      if (typeof enabled !== 'boolean') {
+        json(res, { error: 'Provide {enabled:boolean}' }, 400)
+        return true
+      }
+      const next = writeTerminalInputEnabled(enabled)
+      logger.warn({
+        enabled: next,
+        remote: ctx.req.socket?.remoteAddress ?? 'unknown',
+        xff: ctx.req.headers['x-forwarded-for'] ?? '',
+        ua: ctx.req.headers['user-agent'] ?? '',
+      }, `agent-terminal: TERMINAL-INPUT TOGGLE ${next ? 'ENABLED' : 'DISABLED'}`)
+      json(res, { enabled: next })
+      return true
+    }
+  }
+
   // --- live pane stream (SSE) ------------------------------------------
   const streamMatch = path.match(/^\/api\/agents\/([^/]+)\/pane\/stream$/)
   if (streamMatch && method === 'GET') {
@@ -120,24 +151,27 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
   const keysMatch = path.match(/^\/api\/agents\/([^/]+)\/keys$/)
   if (keysMatch && method === 'POST') {
     const name = decodeURIComponent(keysMatch[1])
-    // SECURITY (2026-06-26): this raw keystroke-injection endpoint -- the
-    // dashboard live-terminal write path (#275) -- let anyone holding the
-    // dashboard token type arbitrary input into ANY agent's tmux pane, and it
-    // never logged successful calls, so an injection left no trace. That makes
-    // it a prime (and unlogged) vector for the forged-"Szabi" prompt injections
-    // seen in the 2026-06-26 incident. Disabled by default; set
-    // DASHBOARD_ALLOW_KEY_INJECTION=1 to re-enable for manual debugging. Blocked
-    // attempts are logged with remote/UA for tracing. Legit inter-agent
-    // delivery is unaffected: it uses the message-router's own send-keys path,
-    // not this HTTP endpoint.
-    if (process.env.DASHBOARD_ALLOW_KEY_INJECTION !== '1') {
-      logger.warn({
-        name,
-        remote: ctx.req.socket?.remoteAddress ?? 'unknown',
-        xff: ctx.req.headers['x-forwarded-for'] ?? '',
-        ua: ctx.req.headers['user-agent'] ?? '',
-      }, 'agent-terminal: KEYS INJECTION BLOCKED (endpoint disabled)')
-      json(res, { error: 'Keystroke injection endpoint disabled' }, 403)
+    // SECURITY (2026-06-26 / 2026-07-05): this raw keystroke-injection endpoint --
+    // the dashboard live-terminal write path (#275) -- lets a dashboard-token
+    // holder type arbitrary input into an agent's tmux pane, and originally never
+    // logged successful calls, so an injection left no trace. That made it the
+    // (unlogged) vector for the forged-"Szabi" prompt injections in the
+    // 2026-06-26 incident, and it was disabled outright.
+    //
+    // It comes back (ddc0cd9b, Szabi option B) as a DELIBERATE two-step opt-in:
+    // the operator must explicitly flip the terminal-input toggle ON in the
+    // dashboard (behind the dashboard-token gate) before any /keys call is
+    // accepted; default OFF, fail-closed (readTerminalInputEnabled). AND every
+    // ACCEPTED call is now audit-logged with remote-addr + UA + agent + a preview
+    // of the injected keys/special -- the #1 missing fix from the incident.
+    // Legit inter-agent delivery is unaffected: it uses the message-router's own
+    // send-keys path, not this HTTP endpoint.
+    const remote = ctx.req.socket?.remoteAddress ?? 'unknown'
+    const xff = ctx.req.headers['x-forwarded-for'] ?? ''
+    const ua = ctx.req.headers['user-agent'] ?? ''
+    if (!readTerminalInputEnabled()) {
+      logger.warn({ name, remote, xff, ua }, 'agent-terminal: KEYS INJECTION BLOCKED (toggle OFF)')
+      json(res, { error: 'Terminal input is disabled. Enable it in the dashboard first.' }, 403)
       return true
     }
     const target = resolveTarget(name)
@@ -155,6 +189,12 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
       json(res, { error: 'Provide {keys:string} or an allow-listed {special}' }, 400)
       return true
     }
+    // AUDIT every accepted injection. Preview is truncated so a long paste does
+    // not bloat the log, but is present so a forged prompt is traceable.
+    const preview = parsed.special
+      ? `special:${parsed.special}`
+      : `keys:${JSON.stringify((parsed.keys ?? '').slice(0, 120))}${(parsed.keys ?? '').length > 120 ? '…' : ''}`
+    logger.info({ name, remote, xff, ua, preview }, 'agent-terminal: KEYS INJECTION ACCEPTED')
     try {
       await tmux(args)
       json(res, { ok: true })

--- a/src/web/terminal-input-store.ts
+++ b/src/web/terminal-input-store.ts
@@ -1,0 +1,40 @@
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { PROJECT_ROOT } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+
+// Master opt-in toggle for the dashboard per-agent terminal-input (send-keys)
+// feature. DEFAULT OFF.
+//
+// SECURITY (ddc0cd9b, 2026-07-05): the raw keystroke-injection endpoint
+// (/api/agents/:name/keys) was the root-cause vector of the 2026-06-26
+// forged-"Szabi" prompt-injection incident, so it was disabled outright. This
+// toggle brings it back as a deliberate two-step, owner-gated opt-in: the
+// operator must explicitly flip it ON in the dashboard (behind the
+// dashboard-token gate) before ANY /keys call is accepted. It defaults to OFF
+// and stays OFF across restarts unless the operator turned it on. Every accepted
+// /keys call is audit-logged separately (the missing fix from the incident).
+const STORE_PATH = join(PROJECT_ROOT, 'store', 'terminal-input.json')
+
+interface TerminalInputConfig {
+  enabled: boolean
+}
+
+const DEFAULT: TerminalInputConfig = { enabled: false }
+
+/** Current toggle state; OFF by default and on any read error (fail-closed). */
+export function readTerminalInputEnabled(): boolean {
+  try {
+    const parsed = JSON.parse(readFileSync(STORE_PATH, 'utf-8'))
+    return parsed?.enabled === true
+  } catch {
+    return DEFAULT.enabled
+  }
+}
+
+/** Persist the toggle. Returns the new state. */
+export function writeTerminalInputEnabled(enabled: boolean): boolean {
+  const next: TerminalInputConfig = { enabled: enabled === true }
+  atomicWriteFileSync(STORE_PATH, JSON.stringify(next, null, 2))
+  return next.enabled
+}

--- a/web/app.js
+++ b/web/app.js
@@ -8679,21 +8679,6 @@ const CHAT_SYSTEM_AGENTS = new Set(['heartbeat','telegram-coordinator','channel-
 // recognizes its real owner. Empty until _marveen resolves (no false match).
 function chatOwnerName() { return window._marveen?.ownerName || '' }
 
-// The main agent's display name (BOT_NAME). mainAgentId() is the routing id
-// (e.g. "marveen") used for matching, avatar lookups and API calls; this is
-// what the user should SEE. Sourced from the backend (/api/marveen -> name,
-// mirrored into _brandTokens.bot by initSidebarBrand), so a renamed install
-// shows its real bot name. Falls back to the id before _marveen resolves.
-function mainAgentDisplayName() {
-  return window._marveen?.name || window._brandTokens?.bot || mainAgentId()
-}
-// Map a routing agent id to its user-facing label: the main agent's id becomes
-// its BOT_NAME display name; every other agent already carries a human name as
-// its id, so it passes through unchanged.
-function chatDisplayName(name) {
-  return name === mainAgentId() ? mainAgentDisplayName() : name
-}
-
 function chatLastSeenKey(agentName) { return 'chat_last_seen_' + agentName }
 function chatGetLastSeen(agentName) { return parseInt(localStorage.getItem(chatLastSeenKey(agentName)) || '0', 10) }
 function chatMarkSeen(agentName, maxId) {
@@ -8766,7 +8751,7 @@ async function loadChatAgentList() {
       const isSelected = name === chatSelectedAgent ? ' selected' : ''
       const dimmed = info ? '' : ' style="opacity:0.5"'
       const unread = chatIsUnread(name, info)
-      const displayName = owner && name === owner ? owner + ' (te)' : chatDisplayName(name)
+      const displayName = owner && name === owner ? owner + ' (te)' : name
       return `<div class="chat-agent-item${isSelected}${unread ? ' unread' : ''}" data-agent="${escapeHtml(name)}"${dimmed}>
         <div class="chat-agent-avatar">${chatAvatarHtml(name, 40)}</div>
         <div class="chat-agent-info">
@@ -8810,7 +8795,7 @@ async function loadChatThread(agentName) {
   chatThreadState.loading = false
 
   const owner = chatOwnerName()
-  const threadDisplayName = owner && agentName === owner ? owner + ' (te)' : chatDisplayName(agentName)
+  const threadDisplayName = owner && agentName === owner ? owner + ' (te)' : agentName
 
   panel.innerHTML = `
     <div class="chat-thread-header">
@@ -8823,7 +8808,7 @@ async function loadChatThread(agentName) {
     <div class="chat-bubbles" id="chatBubbles"><div class="chat-loading-indicator" id="chatLoadingTop" style="display:none;text-align:center;padding:8px;font-size:11px;color:var(--text-muted)">${t('messages.loading')}</div></div>
     <div class="chat-compose">
       <div class="chat-compose-row">
-        <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="${t('messages.placeholder', { agent: escapeHtml(chatDisplayName(agentName)) })}"></textarea>
+        <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="${t('messages.placeholder', { agent: escapeHtml(agentName) })}"></textarea>
         <button class="btn-primary btn-compact chat-send-btn" id="chatSendBtn">${t('messages.send_btn')}</button>
       </div>
     </div>
@@ -8863,10 +8848,7 @@ async function loadChatThread(agentName) {
 
 function buildBubbleHtml(m) {
   const isOutgoing = m.from_agent === mainAgentId()
-  // senderName stays the routing id (avatar lookup keys off it); senderLabel is
-  // what the user sees, so the main agent reads as its BOT_NAME, not "marveen".
   const senderName = isOutgoing ? mainAgentId() : m.from_agent
-  const senderLabel = chatDisplayName(senderName)
   const when = m.created_at ? new Date(m.created_at * 1000).toLocaleString('hu-HU', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : ''
   const statusMetaRaw = MSG_STATUS_META[m.status] || { label: m.status || '', cls: 'badge' }
   const statusMeta = { ...statusMetaRaw, label: typeof statusMetaRaw.label === 'function' ? statusMetaRaw.label() : statusMetaRaw.label }
@@ -8874,7 +8856,7 @@ function buildBubbleHtml(m) {
     ${!isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml(senderName, 28)}</div>` : ''}
     <div class="chat-bubble ${isOutgoing ? 'bubble-out' : 'bubble-in'}">
       <div class="bubble-meta">
-        ${!isOutgoing ? `<span class="bubble-sender">${escapeHtml(senderLabel)}</span>` : ''}
+        ${!isOutgoing ? `<span class="bubble-sender">${escapeHtml(senderName)}</span>` : ''}
         <span class="bubble-id-chip">#${m.id}</span>
         <span class="badge ${statusMeta.cls}" style="font-size:10px">${escapeHtml(statusMeta.label)}</span>
       </div>
@@ -11255,6 +11237,21 @@ async function handleAgentLogin(agentName, btn) {
 let terminalInstance = null
 let terminalSSE = null
 let terminalFit = null
+// Master input gate (mirrors the server-side terminal-input toggle). Keystrokes
+// are dropped locally when OFF so we never spam the audit log with 403s; the
+// server enforces the same gate independently (fail-closed). Owner flips it via
+// the checkbox in the modal header (POST /api/terminal-input).
+let terminalInputEnabled = false
+
+function syncTerminalInputToggleUI() {
+  const cb = document.getElementById('terminalInputToggle')
+  const label = document.getElementById('terminalInputToggleLabel')
+  if (cb) cb.checked = terminalInputEnabled
+  if (label) {
+    label.textContent = terminalInputEnabled ? 'Input on' : 'Input off'
+    label.style.color = terminalInputEnabled ? '#8fbf6f' : '#b8b2a6'
+  }
+}
 
 function openTerminalModal(agentName) {
   const overlay = document.getElementById('terminalOverlay')
@@ -11263,6 +11260,12 @@ function openTerminalModal(agentName) {
   if (!overlay || !container) return
 
   title.textContent = agentName + ' - Terminal'
+
+  // Read the current server-side gate so the modal reflects reality on open.
+  fetch('/api/terminal-input')
+    .then(r => r.ok ? r.json() : { enabled: false })
+    .then(d => { terminalInputEnabled = d.enabled === true; syncTerminalInputToggleUI() })
+    .catch(() => { terminalInputEnabled = false; syncTerminalInputToggleUI() })
 
   // Cleanup previous
   if (terminalSSE) { terminalSSE.close(); terminalSSE = null }
@@ -11339,6 +11342,12 @@ function openTerminalModal(agentName) {
   term.onData(data => {
     if (data === '\x1b[5~') { term.scrollPages(-1); return } // PageUp -> scroll history up
     if (data === '\x1b[6~') { term.scrollPages(1); return }  // PageDown -> scroll history down
+    if (!terminalInputEnabled) {
+      // Read-only mode: input gate is OFF. Drop the keystroke locally (server
+      // would 403 it anyway) and nudge the user to the toggle.
+      showToast('Terminal input is off. Enable it with the header toggle first.')
+      return
+    }
     const special = ESC_TO_SPECIAL[data]
     const body = special ? { special } : { keys: data }
     fetch(`/api/agents/${encodeURIComponent(agentName)}/keys`, {
@@ -11363,6 +11372,27 @@ document.getElementById('terminalClose')?.addEventListener('click', () => {
   if (overlay) closeModal(overlay)
   if (terminalSSE) { terminalSSE.close(); terminalSSE = null }
   if (terminalInstance) { terminalInstance.dispose(); terminalInstance = null }
+})
+
+// Owner flips the master terminal-input gate. Optimistically reflect the desired
+// state, POST it, then reconcile with the server's authoritative response.
+document.getElementById('terminalInputToggle')?.addEventListener('change', (e) => {
+  const desired = e.target.checked === true
+  fetch('/api/terminal-input', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled: desired }),
+  })
+    .then(r => r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)))
+    .then(d => {
+      terminalInputEnabled = d.enabled === true
+      syncTerminalInputToggleUI()
+      showToast(terminalInputEnabled ? 'Terminal input enabled (audit-logged)' : 'Terminal input disabled')
+    })
+    .catch(() => {
+      terminalInputEnabled = false
+      syncTerminalInputToggleUI()
+      showToast('Could not change terminal input state')
+    })
 })
 
 // === Agent conversation (readable transcript) modal ===

--- a/web/index.html
+++ b/web/index.html
@@ -2542,7 +2542,13 @@
     <div class="modal terminal-modal">
       <div class="modal-header">
         <h2 id="terminalModalTitle">Terminal</h2>
-        <button class="modal-close" id="terminalClose">&times;</button>
+        <div style="display:flex;align-items:center;gap:10px;margin-left:auto;">
+          <label style="display:flex;align-items:center;gap:6px;font-size:12px;color:#b8b2a6;cursor:pointer;user-select:none;" title="Enable keyboard input to the agent pane (owner-gated, audit-logged)">
+            <input type="checkbox" id="terminalInputToggle" style="cursor:pointer;">
+            <span id="terminalInputToggleLabel">Input off</span>
+          </label>
+          <button class="modal-close" id="terminalClose">&times;</button>
+        </div>
       </div>
       <div id="terminalContainer" style="background:#1a1a1a;padding:8px;border-radius:0 0 8px 8px;flex:1;min-height:360px;"></div>
     </div>


### PR DESCRIPTION
## What

Brings back the per-agent dashboard terminal keystroke path as a **deliberate two-step, owner-gated opt-in** (Szabi option B, kanban ddc0cd9b). The raw `/api/agents/:name/keys` endpoint was disabled outright on 2026-06-26 because it was the (unlogged) root-cause vector of the forged-"Szabi" prompt-injection incident. This re-enables it safely.

## How it's safe

1. **Two-step opt-in.** New `terminal-input-store.ts` master toggle, **default OFF**, fail-closed on read error and non-boolean writes. `/keys` returns 403 until the operator explicitly flips it ON in the dashboard.
2. **Per-call audit log** on every ACCEPTED `/keys` call: remote-addr + XFF + UA + agent + truncated key/special preview. This is the #1 missing fix from the incident (successful injections previously left no trace). Blocked calls stay logged too.
3. **Owner-gated toggle route** `GET/POST /api/terminal-input`, behind the existing global dashboard-token gate; every flip is audit-logged (warn level).
4. **Frontend:** header toggle checkbox in the terminal modal; xterm keystrokes are dropped locally when the gate is OFF (server enforces the same gate independently — belt and suspenders).

Token-gate unchanged. Legit inter-agent delivery is unaffected — it uses the message-router's own send-keys path, not this HTTP endpoint.

## Verify

- `tsc --noEmit` green (main + develop base)
- `tmux-keys` suite green (36 tests)
- store fail-closed verified at runtime: no file → OFF; write true/false persists; `'yes'` → coerced OFF
- `node --check web/app.js` OK
- No DB schema change (JSON config store) → bake-safety N/A

Deploy on Szabi-GO (backend build + `com.marveen.dashboard` restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)