### PR TITLE
fix(dashboard): trim/strip whitespace on pasted terminal-input keys (v1.19.0 QoL)

### DIFF
--- a/src/__tests__/agent-terminal-sanitize.test.ts
+++ b/src/__tests__/agent-terminal-sanitize.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeLiteralKeys } from '../web/routes/agent-terminal.js'
+
+describe('sanitizeLiteralKeys', () => {
+  it('passes a single keystroke through untouched (incl. a deliberate space)', () => {
+    expect(sanitizeLiteralKeys('a')).toBe('a')
+    expect(sanitizeLiteralKeys(' ')).toBe(' ')
+    expect(sanitizeLiteralKeys('')).toBe('')
+  })
+
+  it('trims leading/trailing whitespace on a paste', () => {
+    expect(sanitizeLiteralKeys('  hello  ')).toBe('hello')
+    expect(sanitizeLiteralKeys('\t/login token\t')).toBe('/login token')
+  })
+
+  it('strips a trailing newline so a pasted line does not pre-submit', () => {
+    expect(sanitizeLiteralKeys('https://claude.ai/auth?code=abc123\n')).toBe('https://claude.ai/auth?code=abc123')
+    expect(sanitizeLiteralKeys('code-xyz\r\n')).toBe('code-xyz')
+  })
+
+  it('drops embedded CR/LF from a multi-line paste (login code/URL is single-line)', () => {
+    expect(sanitizeLiteralKeys('abc\ndef')).toBe('abcdef')
+    expect(sanitizeLiteralKeys('  http://x\r\n?y=1  ')).toBe('http://x?y=1')
+  })
+
+  it('strips xterm bracketed-paste markers', () => {
+    expect(sanitizeLiteralKeys('\x1b[200~pasted-token\x1b[201~')).toBe('pasted-token')
+    expect(sanitizeLiteralKeys('\x1b[200~  spaced  \n\x1b[201~')).toBe('spaced')
+  })
+
+  it('collapses an all-whitespace paste to empty (no-op send)', () => {
+    expect(sanitizeLiteralKeys('   \n\t ')).toBe('')
+  })
+})

--- a/src/web/routes/agent-terminal.ts
+++ b/src/web/routes/agent-terminal.ts
@@ -53,6 +53,24 @@ function tmux(args: string[]): Promise<void> {
   })
 }
 
+// Sanitize a literal keys payload before it hits send-keys. Motivation
+// (v1.19.0, Szabi UX): on a VPS the operator pastes a token-login link / auth
+// code into the terminal input, and copy-paste often drags along leading/trailing
+// whitespace or a trailing newline -- the newline would prematurely SUBMIT the
+// half-pasted line, and stray spaces corrupt the code/URL. So for a PASTE
+// (multi-char payload) we strip bracketed-paste markers, drop all CR/LF (a login
+// URL/code is single-line; an embedded newline can only hurt), and trim the
+// outer whitespace. A single keystroke (length <= 1) is passed through untouched
+// so deliberately typing a space still works. The intentional Enter is a
+// SEPARATE {special:'Enter'} action, never part of the text payload, so trimming
+// the text is safe.
+export function sanitizeLiteralKeys(keys: string): string {
+  if (keys.length <= 1) return keys // single keystroke -- literal passthrough
+  const noPasteMarkers = keys.replace(/\x1b\[20[01]~/g, '')
+  const singleLine = noPasteMarkers.replace(/[\r\n]+/g, '')
+  return singleLine.replace(/^\s+|\s+$/g, '')
+}
+
 async function runLoginSteps(session: string, steps: LoginStep[]): Promise<void> {
   for (const step of steps) {
     const args = step.kind === 'literal'
@@ -182,18 +200,22 @@ export async function tryHandleAgentTerminal(ctx: RouteContext): Promise<boolean
     let parsed: { keys?: string; special?: string }
     try { parsed = JSON.parse(body.toString()) } catch { json(res, { error: 'Invalid JSON' }, 400); return true }
 
+    // Sanitize a pasted literal payload (strip surrounding whitespace + stray
+    // newlines) so a pasted login link/code doesn't pre-submit or get corrupted.
+    const literalKeys = typeof parsed.keys === 'string' ? sanitizeLiteralKeys(parsed.keys) : null
     const args = parsed.special
       ? specialKeyArgs(session, parsed.special)
-      : (typeof parsed.keys === 'string' ? literalKeyArgs(session, parsed.keys) : null)
+      : (literalKeys ? literalKeyArgs(session, literalKeys) : null)
     if (!args) {
       json(res, { error: 'Provide {keys:string} or an allow-listed {special}' }, 400)
       return true
     }
-    // AUDIT every accepted injection. Preview is truncated so a long paste does
-    // not bloat the log, but is present so a forged prompt is traceable.
+    // AUDIT every accepted injection. Preview reflects the SANITIZED payload
+    // actually sent (truncated so a long paste does not bloat the log, but
+    // present so a forged prompt is traceable).
     const preview = parsed.special
       ? `special:${parsed.special}`
-      : `keys:${JSON.stringify((parsed.keys ?? '').slice(0, 120))}${(parsed.keys ?? '').length > 120 ? '…' : ''}`
+      : `keys:${JSON.stringify((literalKeys ?? '').slice(0, 120))}${(literalKeys ?? '').length > 120 ? '…' : ''}`
     logger.info({ name, remote, xff, ua, preview }, 'agent-terminal: KEYS INJECTION ACCEPTED')
     try {
       await tmux(args)


### PR DESCRIPTION
## What

Follow-up QoL to the terminal-input feature (#522). On a VPS the operator uses terminal-input to send `/login`, then **pastes** the token-login link / auth code from the browser. Copy-paste often drags along leading/trailing whitespace or a trailing newline — the newline **pre-submits** the half-pasted line and stray spaces corrupt the code/URL.

## Fix

`sanitizeLiteralKeys()` runs before send-keys on the literal `{keys}` path:
- **single keystroke** (len ≤ 1) → passthrough untouched (deliberate space still types)
- **paste** (multi-char) → strip xterm bracketed-paste markers, drop all CR/LF (a login URL/code is single-line), trim outer whitespace

The intentional Enter is a **separate `{special:'Enter'}` action**, never part of the text payload — so trimming the text is safe (Marveen's exact note). `{special}` keys are untouched. The audit-log preview reflects the sanitized payload actually sent.

## Verify

- 6 unit tests added (`agent-terminal-sanitize.test.ts`): single-char passthrough incl. space, outer-trim, trailing-newline strip, embedded CR/LF drop, bracketed-paste markers, all-whitespace → empty no-op
- `tsc --noEmit` green (develop base)
- No DB change, no toggle/security-gate change — the opt-in + audit path from #522 is untouched

Small QoL, not urgent. Ships with the next mini-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)