### PR TITLE
feat(costops): local cost ledger + monthly summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marveen",
-  "version": "1.13.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marveen",
-      "version": "1.13.0",
+      "version": "1.19.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",

--- a/src/__tests__/costops-api.test.ts
+++ b/src/__tests__/costops-api.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { tryHandleCosts } from '../web/routes/costs.js'
+import { monthWindow } from '../costops/ledger.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+// Minimal fake ServerResponse capturing what json() writes.
+function fakeCtx(path: string, method = 'GET'): { ctx: RouteContext; out: { status: number; body: any } } {
+  const out: { status: number; body: any } = { status: 0, body: null }
+  const res: any = {
+    writeHead(status: number) { out.status = status; return res },
+    end(chunk?: string) { if (chunk) out.body = JSON.parse(chunk) },
+  }
+  const url = new URL(`http://localhost:3420${path}`)
+  const ctx = { req: {} as any, res, path: url.pathname, method, url } as RouteContext
+  return { ctx, out }
+}
+
+describe('costops API (route smoke)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('GET /api/costs/summary returns a well-formed read-only summary', async () => {
+    // seed a current-month token_usage row -> proves volume is reported but NOT priced
+    const now = Math.floor(Date.now() / 1000)
+    const w = monthWindow(now)
+    getDb().prepare("INSERT INTO token_usage (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens) VALUES ('marveen','s',?,1234,5678,0,0)").run(w.start + 100)
+
+    const { ctx, out } = fakeCtx('/api/costs/summary')
+    const handled = await tryHandleCosts(ctx)
+    expect(handled).toBe(true)
+    expect(out.status).toBe(200)
+    // shape
+    expect(out.body).toHaveProperty('month')
+    expect(out.body).toHaveProperty('current_spend')
+    expect(out.body).toHaveProperty('forecast_month_end')
+    expect(out.body).toHaveProperty('top_sources')
+    expect(out.body).toHaveProperty('confidence_breakdown')
+    expect(out.body).toHaveProperty('breakdown')
+    expect(out.body).toHaveProperty('budget')
+    expect(out.body).toHaveProperty('token_usage')
+    // token usage reported as VOLUME
+    expect(out.body.token_usage.input_tokens).toBe(1234)
+    expect(out.body.token_usage.output_tokens).toBe(5678)
+    expect(out.body.token_usage.note).toContain('not priced')
+    // money never derived from tokens (config amounts are 0 placeholders)
+    expect(typeof out.body.current_spend).toBe('number')
+    // no secret / account id leaks into the response
+    expect(JSON.stringify(out.body)).not.toMatch(/secret|api[_-]?key|password|token=/i)
+  })
+
+  it('GET /api/costs/sources returns an array', async () => {
+    const { ctx, out } = fakeCtx('/api/costs/sources')
+    expect(await tryHandleCosts(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    expect(Array.isArray(out.body)).toBe(true)
+  })
+
+  it('falls through (returns false) for unrelated paths', async () => {
+    const { ctx } = fakeCtx('/api/kanban')
+    expect(await tryHandleCosts(ctx)).toBe(false)
+  })
+})

--- a/src/__tests__/costops-api.test.ts
+++ b/src/__tests__/costops-api.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { writeFileSync, unlinkSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
 import { initDatabase, getDb } from '../db.js'
-import { tryHandleCosts } from '../web/routes/costs.js'
+import { tryHandleCosts, startCostsSyncTask } from '../web/routes/costs.js'
 import { monthWindow } from '../costops/ledger.js'
+import { COSTOPS_CONFIG_PATH } from '../costops/config.js'
 import type { RouteContext } from '../web/routes/types.js'
 
 // Minimal fake ServerResponse capturing what json() writes.
@@ -58,5 +61,38 @@ describe('costops API (route smoke)', () => {
   it('falls through (returns false) for unrelated paths', async () => {
     const { ctx } = fakeCtx('/api/kanban')
     expect(await tryHandleCosts(ctx)).toBe(false)
+  })
+
+  // Review blocker (Szotasz, PR #524): "the GET endpoint performs writes". Proven with a
+  // REAL fixed cost configured (not the empty default), so there is something a buggy
+  // sync-on-GET would actually have inserted -- an empty-config test wouldn't distinguish
+  // "no write call" from "nothing to write".
+  describe('GET /api/costs/summary is read-only (review blocker regression)', () => {
+    const hadConfig = existsSync(COSTOPS_CONFIG_PATH)
+    beforeEach(() => {
+      mkdirSync(dirname(COSTOPS_CONFIG_PATH), { recursive: true })
+      writeFileSync(COSTOPS_CONFIG_PATH, JSON.stringify({
+        version: 1, currency: 'HUF',
+        fixed_costs: [{ source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 22000 }],
+        budgets: [],
+      }))
+    })
+    afterEach(() => { if (!hadConfig) { try { unlinkSync(COSTOPS_CONFIG_PATH) } catch { /* already gone */ } } })
+
+    it('never inserts into cost_line_items/cost_sources, even with a real fixed cost configured', async () => {
+      const { ctx } = fakeCtx('/api/costs/summary')
+      expect(await tryHandleCosts(ctx)).toBe(true)
+      expect(await tryHandleCosts(ctx)).toBe(true) // twice, to also rule out a one-shot lazy-write pattern
+      const items = (getDb().prepare('SELECT COUNT(*) as n FROM cost_line_items').get() as { n: number }).n
+      const sources = (getDb().prepare('SELECT COUNT(*) as n FROM cost_sources').get() as { n: number }).n
+      expect(items).toBe(0)
+      expect(sources).toBe(0)
+    })
+
+    it('startCostsSyncTask() is where the write actually happens, and it works', () => {
+      startCostsSyncTask(24 * 60 * 60 * 1000) // long interval -- test only needs the immediate one-shot run
+      const row = getDb().prepare("SELECT billed_cost FROM cost_line_items WHERE source_id='anthropic-max'").get() as { billed_cost: number } | undefined
+      expect(row?.billed_cost).toBe(22000)
+    })
   })
 })

--- a/src/__tests__/costops-ledger.test.ts
+++ b/src/__tests__/costops-ledger.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  monthWindow,
+  hashRef,
+  confidenceBucket,
+  syncFixedCostsToLedger,
+  getCostSummary,
+} from '../costops/ledger.js'
+import { validateConfig } from '../costops/config.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+// 2026-07-15T12:00:00Z -> mid-July, deterministic "now" for all summary tests.
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+function cfg(over: Partial<CostOpsConfig> = {}): CostOpsConfig {
+  return {
+    version: 1,
+    currency: 'HUF',
+    fixed_costs: [
+      { source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 22000, period: 'monthly', charge_category: 'subscription', confidence: 'manual', currency: 'HUF' },
+      { source_id: 'openai', name: 'ChatGPT', provider: 'openai', source_type: 'subscription', amount: 8000, period: 'monthly', charge_category: 'subscription', confidence: 'manual', currency: 'HUF' },
+    ],
+    budgets: [
+      { id: 'global-monthly', name: 'Global', scope: 'global', amount: 60000, warning_threshold: 0.8, hard_threshold: 1.0, currency: 'HUF' },
+    ],
+    ...over,
+  }
+}
+
+describe('costops month math', () => {
+  it('computes UTC month window + days', () => {
+    const w = monthWindow(NOW)
+    expect(w.key).toBe('2026-07')
+    expect(w.start).toBe(Math.floor(Date.UTC(2026, 6, 1) / 1000))
+    expect(w.end).toBe(Math.floor(Date.UTC(2026, 7, 1) / 1000))
+    expect(w.daysInMonth).toBe(31)
+    // 14.5 days elapsed of 31
+    expect(w.fractionElapsed).toBeCloseTo(14.5 / 31, 4)
+  })
+  it('honours an explicit month key', () => {
+    expect(monthWindow(NOW, '2026-02').daysInMonth).toBe(28)
+    expect(monthWindow(NOW, '2026-02').key).toBe('2026-02')
+  })
+})
+
+describe('costops hashRef', () => {
+  it('is deterministic and salt-sensitive and non-reversible', () => {
+    expect(hashRef('salt', 'acct-123')).toBe(hashRef('salt', 'acct-123'))
+    expect(hashRef('salt', 'acct-123')).not.toBe(hashRef('salt2', 'acct-123'))
+    expect(hashRef('salt', 'acct-123')).not.toContain('acct-123')
+    expect(hashRef('salt', 'acct-123')).toHaveLength(32)
+  })
+})
+
+describe('costops confidenceBucket', () => {
+  it('maps confidence tiers to buckets', () => {
+    expect(confidenceBucket('manual')).toBe('fixed_manual')
+    expect(confidenceBucket('actual_invoice')).toBe('provider')
+    expect(confidenceBucket('provider_api')).toBe('provider')
+    expect(confidenceBucket('estimate')).toBe('estimate')
+    expect(confidenceBucket('local_usage')).toBe('estimate')
+  })
+})
+
+describe('costops config validation', () => {
+  it('accepts a valid config and applies defaults', () => {
+    const r = validateConfig({ currency: 'HUF', fixed_costs: [{ source_id: 'x', amount: 100 }], budgets: [{ id: 'b', amount: 500 }] })
+    expect(r.errors).toEqual([])
+    expect(r.config.fixed_costs[0].confidence).toBe('manual')
+    expect(r.config.fixed_costs[0].provider).toBe('other')
+    expect(r.config.budgets[0].warning_threshold).toBe(0.8)
+  })
+  it('drops invalid entries with error notes, keeps valid ones', () => {
+    const r = validateConfig({ fixed_costs: [{ source_id: 'ok', amount: 100 }, { amount: 5 }, { source_id: 'neg', amount: -1 }], budgets: [] })
+    expect(r.config.fixed_costs).toHaveLength(1)
+    expect(r.config.fixed_costs[0].source_id).toBe('ok')
+    expect(r.errors.length).toBe(2)
+  })
+  it('rejects non-monthly periods in v0.1', () => {
+    const r = validateConfig({ fixed_costs: [{ source_id: 'y', amount: 1, period: 'yearly' }], budgets: [] })
+    expect(r.config.fixed_costs).toHaveLength(0)
+    expect(r.errors[0]).toContain('monthly')
+  })
+})
+
+describe('costops ledger + summary', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('syncs fixed costs idempotently (no duplicates on re-run)', () => {
+    const db = getDb()
+    const c = cfg()
+    expect(syncFixedCostsToLedger(db, c, NOW)).toBe(2)
+    syncFixedCostsToLedger(db, c, NOW)
+    syncFixedCostsToLedger(db, c, NOW)
+    const rows = db.prepare('SELECT COUNT(*) as n FROM cost_line_items').get() as { n: number }
+    expect(rows.n).toBe(2) // still 2, not 6
+    const sources = db.prepare('SELECT COUNT(*) as n FROM cost_sources').get() as { n: number }
+    expect(sources.n).toBe(2)
+  })
+
+  it('reflects updated config amounts on re-sync (upsert, not insert)', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const c2 = cfg({ fixed_costs: [{ source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 30000, period: 'monthly', confidence: 'manual', currency: 'HUF' }] })
+    syncFixedCostsToLedger(db, c2, NOW)
+    const row = db.prepare("SELECT billed_cost FROM cost_line_items WHERE source_id='anthropic-max'").get() as { billed_cost: number }
+    expect(row.billed_cost).toBe(30000)
+  })
+
+  it('computes a deterministic monthly summary (golden values)', () => {
+    const db = getDb()
+    const c = cfg()
+    syncFixedCostsToLedger(db, c, NOW)
+    const s = getCostSummary(db, c, NOW)
+    expect(s.month).toBe('2026-07')
+    expect(s.current_spend).toBe(30000)            // 22000 + 8000
+    expect(s.forecast_month_end).toBe(30000)       // fixed = whole-month, no proration
+    expect(s.breakdown.fixed_manual).toBe(30000)
+    expect(s.breakdown.provider).toBe(0)
+    expect(s.confidence_breakdown.manual).toBe(30000)
+    expect(s.top_sources[0]).toEqual({ source_id: 'anthropic-max', name: 'Claude Max', spend: 22000 })
+    expect(s.top_sources[1].source_id).toBe('openai')
+    expect(s.budget?.amount).toBe(60000)
+    expect(s.budget?.used_pct).toBe(0.5)
+    expect(s.budget?.status).toBe('ok')
+  })
+
+  it('all_sources lists every configured source (not capped like top_sources)', () => {
+    const db = getDb()
+    const c = cfg()
+    syncFixedCostsToLedger(db, c, NOW)
+    const s = getCostSummary(db, c, NOW)
+    expect(s.all_sources).toHaveLength(2) // both, even at 0 or any spend
+    const ids = s.all_sources.map(x => x.source_id).sort()
+    expect(ids).toEqual(['anthropic-max', 'openai'])
+    const anthropic = s.all_sources.find(x => x.source_id === 'anthropic-max')!
+    expect(anthropic.provider).toBe('anthropic')
+    expect(anthropic.source_type).toBe('subscription')
+    expect(anthropic.confidence).toBe('manual')
+    expect(anthropic.spend).toBe(22000)
+    expect(anthropic).toHaveProperty('name')
+  })
+
+  it('classifies budget status at thresholds (display-only, no action)', () => {
+    const db = getDb()
+    // amount tuned so current_spend hits exactly 80% then 100% of a 10000 budget
+    const warnCfg = cfg({
+      fixed_costs: [{ source_id: 's', name: 'S', provider: 'other', source_type: 'saas', amount: 8000, period: 'monthly', confidence: 'manual', currency: 'HUF' }],
+      budgets: [{ id: 'global-monthly', amount: 10000, warning_threshold: 0.8, hard_threshold: 1.0 }],
+    })
+    syncFixedCostsToLedger(db, warnCfg, NOW)
+    expect(getCostSummary(db, warnCfg, NOW).budget?.status).toBe('warning') // 0.8 -> warning
+
+    initDatabase(':memory:')
+    const db2 = getDb()
+    const hardCfg = cfg({
+      fixed_costs: [{ source_id: 's', name: 'S', provider: 'other', source_type: 'saas', amount: 10000, period: 'monthly', confidence: 'manual', currency: 'HUF' }],
+      budgets: [{ id: 'global-monthly', amount: 10000, warning_threshold: 0.8, hard_threshold: 1.0 }],
+    })
+    syncFixedCostsToLedger(db2, hardCfg, NOW)
+    expect(getCostSummary(db2, hardCfg, NOW).budget?.status).toBe('hard') // 1.0 -> hard
+
+    initDatabase(':memory:')
+    const db3 = getDb()
+    const okCfg = cfg({
+      fixed_costs: [{ source_id: 's', name: 'S', provider: 'other', source_type: 'saas', amount: 7999, period: 'monthly', confidence: 'manual', currency: 'HUF' }],
+      budgets: [{ id: 'global-monthly', amount: 10000, warning_threshold: 0.8, hard_threshold: 1.0 }],
+    })
+    syncFixedCostsToLedger(db3, okCfg, NOW)
+    expect(getCostSummary(db3, okCfg, NOW).budget?.status).toBe('ok') // 0.7999 -> ok
+  })
+
+  it('prorates usage-type line items to month-end for forecast', () => {
+    const db = getDb()
+    // insert a usage line directly (source + line) representing partial-month usage
+    db.prepare("INSERT INTO cost_sources (id,name,provider,source_type,currency,active,created_at,updated_at) VALUES ('u','U','other','usage','HUF',1,?,?)").run(NOW, NOW)
+    const w = monthWindow(NOW)
+    db.prepare(`INSERT INTO cost_line_items (source_id,charge_period_start,charge_period_end,charge_category,service_name,billed_cost,currency,confidence,data_freshness,dedup_key,created_at)
+      VALUES ('u',?,?,'usage','U',1450,'HUF','estimate',?,'u|2026-07',?)`).run(w.start, w.end, NOW, NOW)
+    const s = getCostSummary(db, cfg({ fixed_costs: [] }), NOW)
+    expect(s.current_spend).toBe(1450)
+    // forecast = 1450 / fractionElapsed (14.5/31) ~= 3100
+    expect(s.forecast_month_end).toBeGreaterThan(3000)
+    expect(s.breakdown.estimate).toBe(1450)
+  })
+
+  it('reports token_usage as VOLUME only, never priced', () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    const ins = db.prepare("INSERT INTO token_usage (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens) VALUES (?,?,?,?,?,?,?)")
+    ins.run('marveen', 's1', w.start + 100, 1000, 5000, 200, 50)
+    ins.run('qa', 's2', w.start + 200, 500, 2000, 0, 0)
+    ins.run('marveen', 's3', w.end + 100, 999, 999, 0, 0) // next month, excluded
+    const s = getCostSummary(db, cfg({ fixed_costs: [] }), NOW)
+    expect(s.token_usage.calls).toBe(2)
+    expect(s.token_usage.agents).toBe(2)
+    expect(s.token_usage.input_tokens).toBe(1500)
+    expect(s.token_usage.output_tokens).toBe(7000)
+    expect(s.token_usage.note).toContain('not priced')
+    // token usage must NOT contribute to money
+    expect(s.current_spend).toBe(0)
+  })
+})

--- a/src/costops/README.md
+++ b/src/costops/README.md
@@ -1,0 +1,61 @@
+# CostOps -- local cost ledger (base)
+
+A deterministic, read-mostly local cost ledger for the operator's own recurring
+costs (subscriptions, hosting, domain, SaaS). Pure SQL + arithmetic: no LLM, no
+provider API calls, no secrets. Real amounts and account references live in a
+gitignored local config, never in the repo.
+
+This is the base slice: manual/fixed cost sources, a monthly summary with
+budget thresholds, and token-usage **volume** reporting (activity only, never
+priced). Provider collectors, provider-API imports, and token-cost pricing are
+intentionally out of scope here and land in follow-up changes.
+
+## Data model
+
+- `cost_sources` -- provider/subscription origin (id, name, provider, type,
+  currency, active). No raw account IDs.
+- `cost_line_items` -- individual charge rows for a charge period (billed_cost,
+  confidence, dedup_key for idempotent upserts). FOCUS-inspired.
+- `budgets` -- display-only warning/hard thresholds. No action is ever taken;
+  status is informational.
+
+## Config (local, gitignored)
+
+The operator's fixed/manual monthly costs and budgets live in
+`store/costops-config.json` (under the gitignored `store/` tree, so real amounts
+and account references never enter git). A safe `*.example` is generated on first
+load if no config exists. With no config present the summary is simply empty --
+it never fabricates numbers and never blocks the rest of the app.
+
+```json
+{
+  "currency": "HUF",
+  "fixed_costs": [
+    { "source_id": "example-subscription", "name": "Example subscription", "provider": "other", "source_type": "subscription", "amount": 0, "confidence": "manual" }
+  ],
+  "budgets": [
+    { "id": "global-monthly", "name": "Monthly budget", "amount": 0, "warning_threshold": 0.8, "hard_threshold": 1.0 }
+  ]
+}
+```
+
+## API (Bearer-gated, read-only)
+
+- `GET /api/costs/summary` -- monthly spend, forecast, per-source and confidence
+  breakdown, budget status, and token-usage volume. On read it idempotently
+  reflects the config's fixed costs into the ledger (upsert by dedup_key).
+- `GET /api/costs/sources` -- active cost sources.
+- `GET /api/costs/budgets` -- configured budgets.
+
+No client writes, no LLM, no provider API, no secrets in any response.
+
+## Guardrails
+
+- Deterministic: every function takes `db` and `now`, unit-tested against an
+  in-memory database.
+- Manual/fallback is the only cost source in this slice; the provider-derived
+  path is empty and handled gracefully.
+- Token usage is reported as **volume only** and explicitly not priced; no money
+  is ever derived from tokens here.
+- Additive schema (`CREATE TABLE IF NOT EXISTS`); with no CostOps config the rest
+  of the app behaves exactly as before.

--- a/src/costops/config.ts
+++ b/src/costops/config.ts
@@ -1,0 +1,181 @@
+// CostOps v0.1 -- local cost config loader.
+//
+// The operator's fixed/manual monthly costs (Claude Max, ChatGPT, hosting,
+// domain, SaaS, ...) and budgets live in store/costops-config.json. That path
+// is under the gitignored store/ tree, so real amounts / account references
+// NEVER enter a tracked file. A safe placeholder skeleton is generated as
+// store/costops-config.json.example on first load if no config exists.
+//
+// This module is pure I/O + validation. No secrets, no network, no LLM.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+import { logger } from '../logger.js'
+
+export const COSTOPS_CONFIG_PATH = join(PROJECT_ROOT, 'store', 'costops-config.json')
+export const COSTOPS_EXAMPLE_PATH = join(PROJECT_ROOT, 'store', 'costops-config.json.example')
+
+export type CostConfidence =
+  | 'actual_invoice'
+  | 'provider_api'
+  | 'billing_export'
+  | 'local_usage'
+  | 'estimate'
+  | 'manual'
+
+export type ChargeCategory =
+  | 'usage'
+  | 'subscription'
+  | 'purchase'
+  | 'tax'
+  | 'credit'
+  | 'adjustment'
+
+export interface FixedCostEntry {
+  source_id: string
+  name: string
+  provider: string          // 'anthropic' | 'openai' | 'github' | 'render' | 'namecheap' | 'aware' | 'other'
+  source_type: string       // 'subscription' | 'hosting' | 'domain' | 'saas' | 'usage' | 'manual'
+  amount: number            // per-period amount in `currency`
+  period?: 'monthly'        // v0.1 supports monthly only
+  charge_category?: ChargeCategory
+  confidence?: CostConfidence
+  currency?: string
+  notes?: string
+}
+
+export interface BudgetEntry {
+  id: string
+  name?: string
+  scope?: 'global' | 'source' | 'provider' | 'product' | 'agent'
+  scope_ref?: string
+  amount: number
+  currency?: string
+  warning_threshold?: number  // fraction, default 0.8
+  hard_threshold?: number     // fraction, default 1.0
+}
+
+export interface CostOpsConfig {
+  version: number
+  currency: string
+  fixed_costs: FixedCostEntry[]
+  budgets: BudgetEntry[]
+}
+
+const EMPTY_CONFIG: CostOpsConfig = {
+  version: 1,
+  currency: 'HUF',
+  fixed_costs: [],
+  budgets: [],
+}
+
+// Safe skeleton with placeholder (zero) values -- contains no real amounts,
+// account IDs or secrets, so it is safe to keep as a tracked example too.
+const EXAMPLE_CONFIG = {
+  version: 1,
+  currency: 'HUF',
+  _doc: 'CostOps local config. Copy to store/costops-config.json and fill in real values. Amounts are per month. No secrets/API keys here -- put those in the Vault.',
+  fixed_costs: [
+    { source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 0, period: 'monthly', charge_category: 'subscription', confidence: 'manual' },
+    { source_id: 'openai-chatgpt', name: 'ChatGPT', provider: 'openai', source_type: 'subscription', amount: 0, period: 'monthly', confidence: 'manual' },
+    { source_id: 'github', name: 'GitHub', provider: 'github', source_type: 'saas', amount: 0, period: 'monthly', confidence: 'manual' },
+    { source_id: 'hosting', name: 'Hosting', provider: 'other', source_type: 'hosting', amount: 0, period: 'monthly', confidence: 'manual' },
+    { source_id: 'domain', name: 'Domain', provider: 'other', source_type: 'domain', amount: 0, period: 'monthly', confidence: 'manual' },
+  ],
+  budgets: [
+    { id: 'global-monthly', name: 'Global monthly', scope: 'global', amount: 0, warning_threshold: 0.8, hard_threshold: 1.0 },
+  ],
+}
+
+export interface ConfigLoadResult {
+  config: CostOpsConfig
+  exists: boolean
+  errors: string[]
+}
+
+/**
+ * Load and validate the local CostOps config. Never throws: a missing or
+ * malformed config yields an empty (but valid) config plus a list of errors,
+ * so the read-only summary endpoint degrades gracefully instead of 500ing.
+ * On a missing config, writes the placeholder example alongside for guidance.
+ */
+export function loadCostopsConfig(): ConfigLoadResult {
+  if (!existsSync(COSTOPS_CONFIG_PATH)) {
+    ensureExampleConfig()
+    return { config: { ...EMPTY_CONFIG }, exists: false, errors: [] }
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(COSTOPS_CONFIG_PATH, 'utf-8'))
+  } catch (err) {
+    logger.warn({ err }, 'costops-config.json is not valid JSON')
+    return { config: { ...EMPTY_CONFIG }, exists: true, errors: ['config is not valid JSON'] }
+  }
+  return validateConfig(raw)
+}
+
+export function ensureExampleConfig(): void {
+  try {
+    if (!existsSync(COSTOPS_EXAMPLE_PATH)) {
+      writeFileSync(COSTOPS_EXAMPLE_PATH, JSON.stringify(EXAMPLE_CONFIG, null, 2) + '\n', 'utf-8')
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to write costops-config example')
+  }
+}
+
+/**
+ * Pure validation of a parsed config object. Exported for unit tests.
+ * Drops invalid entries (with an error note) rather than failing the whole load.
+ */
+export function validateConfig(raw: unknown): ConfigLoadResult {
+  const errors: string[] = []
+  const obj = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const currency = typeof obj.currency === 'string' ? obj.currency : 'HUF'
+
+  const fixed_costs: FixedCostEntry[] = []
+  const rawFixed = Array.isArray(obj.fixed_costs) ? obj.fixed_costs : []
+  for (const [i, e] of rawFixed.entries()) {
+    const c = e as Record<string, unknown>
+    if (typeof c?.source_id !== 'string' || !c.source_id) { errors.push(`fixed_costs[${i}]: missing source_id`); continue }
+    if (typeof c?.amount !== 'number' || !isFinite(c.amount) || c.amount < 0) { errors.push(`fixed_costs[${i}] (${c.source_id}): amount must be a non-negative number`); continue }
+    if (c.period !== undefined && c.period !== 'monthly') { errors.push(`fixed_costs[${i}] (${c.source_id}): only period 'monthly' is supported in v0.1`); continue }
+    fixed_costs.push({
+      source_id: c.source_id,
+      name: typeof c.name === 'string' ? c.name : c.source_id,
+      provider: typeof c.provider === 'string' ? c.provider : 'other',
+      source_type: typeof c.source_type === 'string' ? c.source_type : 'manual',
+      amount: c.amount,
+      period: 'monthly',
+      charge_category: (typeof c.charge_category === 'string' ? c.charge_category : 'subscription') as ChargeCategory,
+      confidence: (typeof c.confidence === 'string' ? c.confidence : 'manual') as CostConfidence,
+      currency: typeof c.currency === 'string' ? c.currency : currency,
+      notes: typeof c.notes === 'string' ? c.notes : undefined,
+    })
+  }
+
+  const budgets: BudgetEntry[] = []
+  const rawBudgets = Array.isArray(obj.budgets) ? obj.budgets : []
+  for (const [i, e] of rawBudgets.entries()) {
+    const b = e as Record<string, unknown>
+    if (typeof b?.id !== 'string' || !b.id) { errors.push(`budgets[${i}]: missing id`); continue }
+    if (typeof b?.amount !== 'number' || !isFinite(b.amount) || b.amount < 0) { errors.push(`budgets[${i}] (${b.id}): amount must be a non-negative number`); continue }
+    budgets.push({
+      id: b.id,
+      name: typeof b.name === 'string' ? b.name : b.id,
+      scope: (typeof b.scope === 'string' ? b.scope : 'global') as BudgetEntry['scope'],
+      scope_ref: typeof b.scope_ref === 'string' ? b.scope_ref : undefined,
+      amount: b.amount,
+      currency: typeof b.currency === 'string' ? b.currency : currency,
+      warning_threshold: typeof b.warning_threshold === 'number' ? b.warning_threshold : 0.8,
+      hard_threshold: typeof b.hard_threshold === 'number' ? b.hard_threshold : 1.0,
+    })
+  }
+
+  return {
+    config: { version: typeof obj.version === 'number' ? obj.version : 1, currency, fixed_costs, budgets },
+    exists: true,
+    errors,
+  }
+}

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -1,0 +1,288 @@
+// CostOps v0.1 -- deterministic cost ledger core.
+//
+// Pure SQL + arithmetic. NO LLM, no network, no secrets. `db` and `now` are
+// passed in so every function is deterministic and unit-testable against an
+// in-memory database. FOCUS-inspired: cost_sources (ProviderName/BillingAccount),
+// cost_line_items (ChargeRow: ChargePeriod, ChargeCategory, BilledCost,
+// ConsumedQuantity/Unit, confidence), budgets (display-only).
+
+import type Database from 'better-sqlite3'
+import { createHash } from 'node:crypto'
+import type { CostOpsConfig, CostConfidence } from './config.js'
+
+// ---- month math (UTC, deterministic given `now`) ---------------------------
+
+export interface MonthWindow {
+  key: string          // 'YYYY-MM'
+  start: number        // epoch sec, inclusive
+  end: number          // epoch sec, exclusive (start of next month)
+  daysInMonth: number
+  fractionElapsed: number  // (0,1], how much of the month has passed at `now`
+}
+
+export function monthWindow(now: number, monthKey?: string): MonthWindow {
+  let year: number, month: number  // month 0-based
+  if (monthKey && /^\d{4}-\d{2}$/.test(monthKey)) {
+    year = parseInt(monthKey.slice(0, 4))
+    month = parseInt(monthKey.slice(5, 7)) - 1
+  } else {
+    const d = new Date(now * 1000)
+    year = d.getUTCFullYear()
+    month = d.getUTCMonth()
+  }
+  const start = Math.floor(Date.UTC(year, month, 1) / 1000)
+  const end = Math.floor(Date.UTC(year, month + 1, 1) / 1000)
+  const daysInMonth = Math.round((end - start) / 86400)
+  const elapsed = Math.min(Math.max(now - start, 1), end - start)
+  const fractionElapsed = elapsed / (end - start)
+  const key = `${year}-${String(month + 1).padStart(2, '0')}`
+  return { key, start, end, daysInMonth, fractionElapsed }
+}
+
+// ---- hashing (no raw account IDs / invoice refs ever stored) ----------------
+
+/** Deterministic, non-reversible ref for account/resource/invoice identifiers. */
+export function hashRef(salt: string, raw: string): string {
+  return createHash('sha256').update(salt).update('|').update(raw).digest('hex').slice(0, 32)
+}
+
+// ---- confidence -> breakdown bucket ----------------------------------------
+
+export type CostBucket = 'fixed_manual' | 'provider' | 'estimate'
+
+export function confidenceBucket(c: CostConfidence): CostBucket {
+  switch (c) {
+    case 'actual_invoice':
+    case 'provider_api':
+    case 'billing_export':
+      return 'provider'
+    case 'estimate':
+    case 'local_usage':
+      return 'estimate'
+    case 'manual':
+    default:
+      return 'fixed_manual'
+  }
+}
+
+// ---- write path: reflect config fixed costs into the ledger (idempotent) -----
+
+/**
+ * Upsert the config's fixed/manual monthly costs as cost_line_items for the
+ * target month, and upsert their cost_sources. Idempotent via a stable
+ * dedup_key (`fixed|<source_id>|<YYYY-MM>`) so re-running never duplicates.
+ * Returns the number of line items written/updated.
+ */
+export function syncFixedCostsToLedger(
+  db: Database.Database,
+  config: CostOpsConfig,
+  now: number,
+  monthKey?: string,
+): number {
+  const win = monthWindow(now, monthKey)
+  const upsertSource = db.prepare(`
+    INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at)
+    VALUES (@id, @name, @provider, @source_type, @currency, 1, @now, @now)
+    ON CONFLICT(id) DO UPDATE SET
+      name=excluded.name, provider=excluded.provider, source_type=excluded.source_type,
+      currency=excluded.currency, active=1, updated_at=excluded.updated_at
+  `)
+  const upsertLine = db.prepare(`
+    INSERT INTO cost_line_items
+      (source_id, charge_period_start, charge_period_end, charge_category, service_name,
+       usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
+       confidence, data_freshness, source_ref, dedup_key, created_at)
+    VALUES
+      (@source_id, @start, @end, @charge_category, @service_name,
+       NULL, 1, 'month', @billed_cost, NULL, @currency,
+       @confidence, @now, NULL, @dedup_key, @now)
+    ON CONFLICT(dedup_key) DO UPDATE SET
+      billed_cost=excluded.billed_cost, charge_category=excluded.charge_category,
+      service_name=excluded.service_name, currency=excluded.currency,
+      confidence=excluded.confidence, data_freshness=excluded.data_freshness
+  `)
+  const tx = db.transaction((entries: CostOpsConfig['fixed_costs']) => {
+    let count = 0
+    for (const e of entries) {
+      upsertSource.run({
+        id: e.source_id, name: e.name, provider: e.provider,
+        source_type: e.source_type, currency: e.currency ?? config.currency, now,
+      })
+      upsertLine.run({
+        source_id: e.source_id, start: win.start, end: win.end,
+        charge_category: e.charge_category ?? 'subscription', service_name: e.name,
+        billed_cost: e.amount, currency: e.currency ?? config.currency,
+        confidence: e.confidence ?? 'manual', now,
+        dedup_key: `fixed|${e.source_id}|${win.key}`,
+      })
+      count++
+    }
+    return count
+  })
+  return tx(config.fixed_costs)
+}
+
+// ---- read path: deterministic monthly summary ------------------------------
+
+export interface CostSummary {
+  month: string
+  currency: string
+  current_spend: number
+  forecast_month_end: number
+  top_sources: Array<{ source_id: string; name: string; spend: number }>
+  // Full list of every configured/active source (not capped) -- top_sources is
+  // the top-5 by spend; all_sources is the complete set for the dashboard table.
+  all_sources: Array<{ source_id: string; name: string; provider: string; source_type: string; spend: number; confidence: string }>
+  confidence_breakdown: Record<string, number>
+  breakdown: { fixed_manual: number; provider: number; estimate: number }
+  budget: {
+    id: string
+    amount: number
+    used_pct: number
+    forecast_pct: number
+    status: 'ok' | 'warning' | 'hard'
+    warning_threshold: number
+    hard_threshold: number
+  } | null
+  token_usage: {
+    note: string
+    calls: number
+    agents: number
+    input_tokens: number
+    output_tokens: number
+    cache_read_tokens: number
+    cache_creation_tokens: number
+  }
+  data_freshness: number | null
+  config_present: boolean
+  config_errors: string[]
+  generated_at: number
+}
+
+interface LineRow {
+  source_id: string
+  billed_cost: number
+  charge_category: string
+  confidence: CostConfidence
+  data_freshness: number
+}
+
+export function getCostSummary(
+  db: Database.Database,
+  config: CostOpsConfig,
+  now: number,
+  opts: { monthKey?: string; configExists?: boolean; configErrors?: string[] } = {},
+): CostSummary {
+  const win = monthWindow(now, opts.monthKey)
+
+  const lines = db.prepare(`
+    SELECT source_id, billed_cost, charge_category, confidence, data_freshness
+    FROM cost_line_items
+    WHERE charge_period_start < @end AND charge_period_end > @start
+  `).all({ start: win.start, end: win.end }) as LineRow[]
+
+  let current_spend = 0
+  let forecast_month_end = 0
+  const confidence_breakdown: Record<string, number> = {}
+  const breakdown = { fixed_manual: 0, provider: 0, estimate: 0 }
+  const perSource = new Map<string, number>()
+  const perSourceConfidence = new Map<string, string>()
+  let latestFreshness: number | null = null
+
+  for (const l of lines) {
+    current_spend += l.billed_cost
+    // Usage-type lines are prorated to month-end; committed/fixed lines are
+    // already whole-month (no proration).
+    forecast_month_end += l.charge_category === 'usage'
+      ? l.billed_cost / win.fractionElapsed
+      : l.billed_cost
+    confidence_breakdown[l.confidence] = (confidence_breakdown[l.confidence] || 0) + l.billed_cost
+    breakdown[confidenceBucket(l.confidence)] += l.billed_cost
+    perSource.set(l.source_id, (perSource.get(l.source_id) || 0) + l.billed_cost)
+    perSourceConfidence.set(l.source_id, l.confidence)
+    if (latestFreshness === null || l.data_freshness > latestFreshness) latestFreshness = l.data_freshness
+  }
+  current_spend = round2(current_spend)
+  forecast_month_end = round2(forecast_month_end)
+
+  // resolve source metadata (name/provider/source_type) for every active source
+  const srcRows = db.prepare(`SELECT id, name, provider, source_type FROM cost_sources WHERE active = 1`).all() as Array<{ id: string; name: string; provider: string; source_type: string }>
+  const nameMap = new Map(srcRows.map(r => [r.id, r.name]))
+  const top_sources = [...perSource.entries()]
+    .map(([source_id, spend]) => ({ source_id, name: nameMap.get(source_id) || source_id, spend: round2(spend) }))
+    .sort((a, b) => b.spend - a.spend)
+    .slice(0, 5)
+
+  // Full list: every configured/active source with spend (0 if none this month).
+  const all_sources = srcRows
+    .map(r => ({
+      source_id: r.id, name: r.name, provider: r.provider, source_type: r.source_type,
+      spend: round2(perSource.get(r.id) || 0), confidence: perSourceConfidence.get(r.id) || 'manual',
+    }))
+    .sort((a, b) => b.spend - a.spend || a.name.localeCompare(b.name))
+
+  // budget (first budget, or the 'global-monthly' one if present)
+  const budgetDef = config.budgets.find(b => b.id === 'global-monthly') || config.budgets[0] || null
+  let budget: CostSummary['budget'] = null
+  if (budgetDef && budgetDef.amount > 0) {
+    const warning = budgetDef.warning_threshold ?? 0.8
+    const hard = budgetDef.hard_threshold ?? 1.0
+    const used_pct = current_spend / budgetDef.amount
+    const forecast_pct = forecast_month_end / budgetDef.amount
+    // Status is display-only. No action is ever taken here.
+    const status: 'ok' | 'warning' | 'hard' =
+      used_pct >= hard ? 'hard' : used_pct >= warning ? 'warning' : 'ok'
+    budget = {
+      id: budgetDef.id, amount: budgetDef.amount,
+      used_pct: round4(used_pct), forecast_pct: round4(forecast_pct),
+      status, warning_threshold: warning, hard_threshold: hard,
+    }
+  }
+
+  // token_usage: VOLUME/ACTIVITY only -- NOT priced in v0.1 (no model column).
+  const tu = db.prepare(`
+    SELECT COUNT(*) as calls, COUNT(DISTINCT agent) as agents,
+      COALESCE(SUM(input_tokens),0) as input_tokens,
+      COALESCE(SUM(output_tokens),0) as output_tokens,
+      COALESCE(SUM(cache_read_tokens),0) as cache_read_tokens,
+      COALESCE(SUM(cache_creation_tokens),0) as cache_creation_tokens
+    FROM token_usage WHERE timestamp >= @start AND timestamp < @end
+  `).get({ start: win.start, end: win.end }) as {
+    calls: number; agents: number; input_tokens: number; output_tokens: number
+    cache_read_tokens: number; cache_creation_tokens: number
+  }
+
+  return {
+    month: win.key,
+    currency: config.currency,
+    current_spend,
+    forecast_month_end,
+    top_sources,
+    all_sources,
+    confidence_breakdown: roundValues(confidence_breakdown),
+    breakdown: { fixed_manual: round2(breakdown.fixed_manual), provider: round2(breakdown.provider), estimate: round2(breakdown.estimate) },
+    budget,
+    token_usage: {
+      note: 'volume/activity only -- not priced in v0.1 (token_usage has no model column; token->cost mapping lands in v0.2 after model/session enrichment)',
+      calls: tu.calls, agents: tu.agents,
+      input_tokens: tu.input_tokens, output_tokens: tu.output_tokens,
+      cache_read_tokens: tu.cache_read_tokens, cache_creation_tokens: tu.cache_creation_tokens,
+    },
+    data_freshness: latestFreshness,
+    config_present: opts.configExists ?? true,
+    config_errors: opts.configErrors ?? [],
+    generated_at: now,
+  }
+}
+
+export function getCostSources(db: Database.Database): unknown[] {
+  return db.prepare(`SELECT id, name, provider, source_type, currency, active, updated_at FROM cost_sources WHERE active = 1 ORDER BY name`).all()
+}
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }
+function round4(n: number): number { return Math.round(n * 10000) / 10000 }
+function roundValues(obj: Record<string, number>): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const [k, v] of Object.entries(obj)) out[k] = round2(v)
+  return out
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -595,8 +595,14 @@ export function initDatabase(dbPathOverride?: string): void {
 
   // --- CostOps (local cost ledger) ---
   // Read-mostly, FOCUS-inspired. cost_sources = provider/subscription origin,
-  // cost_line_items = individual charge rows (estimate or provider-sourced),
-  // budgets = display-only warning thresholds. No secrets/account IDs stored raw.
+  // cost_line_items = individual charge rows (estimate or provider-sourced).
+  // No secrets/account IDs stored raw. Budgets are config-driven (costops/config.ts's
+  // BudgetEntry, from store/costops-config.json) -- there is deliberately no separate
+  // `budgets` DB table: an earlier draft of this schema had one, but it was never
+  // read from or written to (config.budgets was always the actual source), so it was
+  // a dead, unused second source of truth. Removed rather than wired up, since the
+  // config file already covers this fully and a DB table would just be a sync burden
+  // for no benefit.
   db.exec(`
     CREATE TABLE IF NOT EXISTS cost_sources (
       id TEXT PRIMARY KEY,
@@ -634,22 +640,6 @@ export function initDatabase(dbPathOverride?: string): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_period ON cost_line_items(charge_period_start, charge_period_end)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_source ON cost_line_items(source_id)`)
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS budgets (
-      id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      scope TEXT NOT NULL DEFAULT 'global',
-      scope_ref TEXT,
-      period TEXT NOT NULL DEFAULT 'monthly',
-      amount REAL NOT NULL,
-      currency TEXT NOT NULL DEFAULT 'HUF',
-      warning_threshold REAL NOT NULL DEFAULT 0.8,
-      hard_threshold REAL NOT NULL DEFAULT 1.0,
-      active INTEGER NOT NULL DEFAULT 1,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `)
 
   // --- Vault SSH Keys (shared pool) ---
   db.exec(`

--- a/src/db.ts
+++ b/src/db.ts
@@ -593,6 +593,64 @@ export function initDatabase(dbPathOverride?: string): void {
   // Migration: add agent column to installs that created the table before this column existed.
   try { db.exec(`ALTER TABLE store_file_audit ADD COLUMN agent TEXT`) } catch { /* column already exists */ }
 
+  // --- CostOps (local cost ledger) ---
+  // Read-mostly, FOCUS-inspired. cost_sources = provider/subscription origin,
+  // cost_line_items = individual charge rows (estimate or provider-sourced),
+  // budgets = display-only warning thresholds. No secrets/account IDs stored raw.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cost_sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      source_type TEXT NOT NULL,
+      account_ref TEXT,
+      currency TEXT NOT NULL DEFAULT 'HUF',
+      active INTEGER NOT NULL DEFAULT 1,
+      notes TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cost_line_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_id TEXT NOT NULL REFERENCES cost_sources(id),
+      charge_period_start INTEGER NOT NULL,
+      charge_period_end INTEGER NOT NULL,
+      charge_category TEXT NOT NULL,
+      service_name TEXT,
+      usage_type TEXT,
+      consumed_quantity REAL,
+      consumed_unit TEXT,
+      billed_cost REAL NOT NULL,
+      effective_cost REAL,
+      currency TEXT NOT NULL DEFAULT 'HUF',
+      confidence TEXT NOT NULL,
+      data_freshness INTEGER NOT NULL,
+      source_ref TEXT,
+      dedup_key TEXT UNIQUE,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_period ON cost_line_items(charge_period_start, charge_period_end)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_source ON cost_line_items(source_id)`)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS budgets (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'global',
+      scope_ref TEXT,
+      period TEXT NOT NULL DEFAULT 'monthly',
+      amount REAL NOT NULL,
+      currency TEXT NOT NULL DEFAULT 'HUF',
+      warning_threshold REAL NOT NULL DEFAULT 0.8,
+      hard_threshold REAL NOT NULL DEFAULT 1.0,
+      active INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `)
+
   // --- Vault SSH Keys (shared pool) ---
   db.exec(`
     CREATE TABLE IF NOT EXISTS vault_ssh_keys (

--- a/src/web.ts
+++ b/src/web.ts
@@ -48,7 +48,7 @@ import { tryHandleUpdates } from './web/routes/updates.js'
 import { tryHandleStatus } from './web/routes/status.js'
 import { tryHandleAutonomy } from './web/routes/autonomy.js'
 import { tryHandleTokenUsage } from './web/routes/token-usage.js'
-import { tryHandleCosts } from './web/routes/costs.js'
+import { tryHandleCosts, startCostsSyncTask } from './web/routes/costs.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleSettings } from './web/routes/settings.js'
@@ -333,6 +333,12 @@ export function startWebServer(port = 3420): http.Server {
   const channelHealthInterval = webOnly ? undefined : startChannelHealthMonitor()
   if (!webOnly) logger.info('Channel MCP health monitor started (60s poll, 45s offset)')
 
+  // CostOps: reflect the local config's fixed costs into the ledger once at boot + every
+  // 10 minutes. Deliberately NOT done inside the GET /api/costs/summary handler -- a read
+  // endpoint must not write (was flagged in review); this is the one place that does.
+  const costsSyncInterval = webOnly ? undefined : startCostsSyncTask()
+  if (!webOnly) logger.info('CostOps fixed-cost sync started (10min poll + startup)')
+
   const stuckInputInterval = webOnly ? undefined : startStuckInputWatcher()
   if (!webOnly) logger.info('Stuck-input watcher started (15s poll, 20s offset)')
 
@@ -425,6 +431,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(scheduleInterval)
     if (pluginMonitorInterval) clearInterval(pluginMonitorInterval)
     clearInterval(channelHealthInterval)
+    if (costsSyncInterval) clearInterval(costsSyncInterval)
     clearInterval(stuckInputInterval)
     clearInterval(stuckToolCallInterval)
     if (reauthHealerInterval) clearInterval(reauthHealerInterval)

--- a/src/web.ts
+++ b/src/web.ts
@@ -48,6 +48,7 @@ import { tryHandleUpdates } from './web/routes/updates.js'
 import { tryHandleStatus } from './web/routes/status.js'
 import { tryHandleAutonomy } from './web/routes/autonomy.js'
 import { tryHandleTokenUsage } from './web/routes/token-usage.js'
+import { tryHandleCosts } from './web/routes/costs.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleSettings } from './web/routes/settings.js'
@@ -177,6 +178,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleStatus(routeCtx)) return
       if (await tryHandleAutonomy(routeCtx)) return
       if (await tryHandleTokenUsage(routeCtx)) return
+      if (await tryHandleCosts(routeCtx)) return
       if (await tryHandleIdeas(routeCtx)) return
       if (await tryHandleToolLog(routeCtx)) return
       if (await tryHandleSettings(routeCtx)) return

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -1,0 +1,58 @@
+// CostOps v0.1 -- read-mostly HTTP API. Bearer-gated like every /api/* route.
+// No writes from the client: the only DB write is an idempotent reconciliation
+// of the local config's fixed costs into the ledger on a summary read. No LLM,
+// no provider API, no secrets in the response.
+
+import { json } from '../http-helpers.js'
+import { logger } from '../../logger.js'
+import { getDb } from '../../db.js'
+import { loadCostopsConfig } from '../../costops/config.js'
+import { syncFixedCostsToLedger, getCostSummary, getCostSources } from '../../costops/ledger.js'
+import type { RouteContext } from './types.js'
+
+export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method, url } = ctx
+
+  if (path === '/api/costs/summary' && method === 'GET') {
+    try {
+      const monthKey = url.searchParams.get('month') || undefined
+      const now = Math.floor(Date.now() / 1000)
+      const { config, exists, errors } = loadCostopsConfig()
+      const db = getDb()
+      // Idempotent: reflect the local config's fixed monthly costs into the
+      // ledger for this month (upsert by dedup_key). Deterministic, no LLM.
+      syncFixedCostsToLedger(db, config, now, monthKey)
+      const summary = getCostSummary(db, config, now, {
+        monthKey, configExists: exists, configErrors: errors,
+      })
+      json(res, summary)
+    } catch (err) {
+      logger.error({ err }, 'CostOps summary failed')
+      json(res, { error: 'Cost summary failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/sources' && method === 'GET') {
+    try {
+      json(res, getCostSources(getDb()))
+    } catch (err) {
+      logger.error({ err }, 'CostOps sources failed')
+      json(res, { error: 'Cost sources failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/budgets' && method === 'GET') {
+    try {
+      const { config } = loadCostopsConfig()
+      json(res, config.budgets)
+    } catch (err) {
+      logger.error({ err }, 'CostOps budgets failed')
+      json(res, { error: 'Cost budgets failed' }, 500)
+    }
+    return true
+  }
+
+  return false
+}

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -1,7 +1,8 @@
 // CostOps v0.1 -- read-mostly HTTP API. Bearer-gated like every /api/* route.
-// No writes from the client: the only DB write is an idempotent reconciliation
-// of the local config's fixed costs into the ledger on a summary read. No LLM,
-// no provider API, no secrets in the response.
+// GET never writes: reflecting the local config's fixed costs into the ledger
+// (an idempotent upsert by dedup_key) happens on its own schedule via
+// startCostsSyncTask() below (called once at server boot), not as a side effect
+// of a client request. No LLM, no provider API, no secrets in the response.
 
 import { json } from '../http-helpers.js'
 import { logger } from '../../logger.js'
@@ -9,6 +10,27 @@ import { getDb } from '../../db.js'
 import { loadCostopsConfig } from '../../costops/config.js'
 import { syncFixedCostsToLedger, getCostSummary, getCostSources } from '../../costops/ledger.js'
 import type { RouteContext } from './types.js'
+
+// Runs the fixed-cost -> ledger reflection once immediately (so the summary is
+// fresh from the moment the server comes up) and then on a fixed interval, so a
+// manual edit to the local costops config eventually shows up without needing a
+// restart. 10 minutes is deliberately coarse -- this is a manually-edited local
+// config file, not something that needs near-real-time reflection, and this is
+// the only place in the whole CostOps slice that writes to the DB at all.
+const SYNC_INTERVAL_MS = 10 * 60 * 1000
+
+export function startCostsSyncTask(intervalMs = SYNC_INTERVAL_MS): NodeJS.Timeout {
+  const sync = () => {
+    try {
+      const { config } = loadCostopsConfig()
+      syncFixedCostsToLedger(getDb(), config, Math.floor(Date.now() / 1000))
+    } catch (err) {
+      logger.warn({ err }, 'CostOps fixed-cost sync failed')
+    }
+  }
+  sync()
+  return setInterval(sync, intervalMs).unref()
+}
 
 export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
   const { res, path, method, url } = ctx
@@ -18,11 +40,7 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
       const monthKey = url.searchParams.get('month') || undefined
       const now = Math.floor(Date.now() / 1000)
       const { config, exists, errors } = loadCostopsConfig()
-      const db = getDb()
-      // Idempotent: reflect the local config's fixed monthly costs into the
-      // ledger for this month (upsert by dedup_key). Deterministic, no LLM.
-      syncFixedCostsToLedger(db, config, now, monthKey)
-      const summary = getCostSummary(db, config, now, {
+      const summary = getCostSummary(getDb(), config, now, {
         monthKey, configExists: exists, configErrors: errors,
       })
       json(res, summary)

--- a/tests/smoke/dashboard.spec.ts
+++ b/tests/smoke/dashboard.spec.ts
@@ -65,4 +65,23 @@ test.describe('Dashboard smoke', () => {
     await page.waitForTimeout(500)
     expect(errors).toHaveLength(0)
   })
+
+  // Card 2ed90db1 / PR #524 review blocker: "no UI is wired, /api/costs isn't
+  // reachable from the dashboard" -- this proves the Costs nav link is real, the
+  // page actually renders live data from /api/costs/summary (not dead scaffolding),
+  // and no JS error fires.
+  test('costs page loads and renders live summary data without errors', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+    await page.goto(`/?token=${TOKEN}`)
+    await page.click('.sb-link[data-page="costs"]')
+    await page.waitForTimeout(500)
+    const content = page.locator('#costsContent')
+    await expect(content).toBeVisible()
+    // The summary always includes a "month" stat (YYYY-MM), regardless of whether
+    // any real fixed costs are configured -- proves the fetch to /api/costs/summary
+    // actually happened and rendered, not just an empty/loading shell.
+    await expect(content).toContainText(/\d{4}-\d{2}/)
+    expect(errors).toHaveLength(0)
+  })
 })

--- a/web/app.js
+++ b/web/app.js
@@ -286,6 +286,7 @@ function switchPage(pageId) {
   if (pageId === 'team') { loadTeamGraph() }
   if (pageId === 'messages') loadMessagesPage()
   if (pageId === 'tokenUsage') loadTokenUsage()
+  if (pageId === 'costs') loadCosts()
   if (pageId === 'ideas') loadIdeasPage()
   if (pageId === 'archived') loadArchivedPage()
   if (pageId === 'naplo') loadNaplo()
@@ -331,7 +332,7 @@ const NAV_I18N = {
   skills: 'nav.skills', connectors: 'nav.connectors', migrate: 'nav.migrate',
   docs: 'nav.docs', status: 'nav.status', autonomy: 'nav.autonomy',
   settings: 'nav.settings', vault: 'nav.vault', tokenUsage: 'nav.tokenUsage',
-  ideas: 'nav.ideas', updates: 'nav.updates',
+  ideas: 'nav.ideas', updates: 'nav.updates', costs: 'nav.costs',
 }
 
 function renderNav() {
@@ -374,6 +375,7 @@ const PAGE_HEADER_I18N = {
   tokenUsagePage: { title: 'tokenUsage.page_title',  sub: 'tokenUsage.page_subtitle' },
   updatesPage:    { title: 'updates.page_title',     sub: null },
   naploPage:      { title: 'naplo.page_title',       sub: 'naplo.page_subtitle' },
+  costsPage:      { title: 'costs.page_title',       sub: 'costs.page_subtitle' },
 }
 
 function renderStaticI18n() {
@@ -8585,6 +8587,68 @@ async function loadStatus() {
   } catch (err) {
     overallEl.className = 'status-overall unknown'
     overallEl.textContent = 'Nem sikerult betolteni a statuszt'
+  }
+}
+
+// ============================================================
+// === CostOps (v0.1, PR #524): local cost ledger summary ===
+// ============================================================
+
+document.getElementById('refreshCostsBtn').addEventListener('click', loadCosts)
+
+async function loadCosts() {
+  const el = document.getElementById('costsContent')
+  const mutedStyle = 'color:var(--text-muted);font-size:13px'
+  el.innerHTML = `<div style="${mutedStyle}">${t('costs.loading')}</div>`
+  try {
+    const res = await fetch('/api/costs/summary')
+    const s = await res.json()
+    if (!res.ok) throw new Error(s?.error || 'request failed')
+
+    const fmtMoney = (n) => (typeof n === 'number' ? n.toLocaleString('hu-HU') : '—') + ' ' + escapeHtml(s.currency || '')
+
+    let html = ''
+
+    if (!s.config_present) {
+      html += `<div style="${mutedStyle};margin-bottom:12px">${t('costs.no_config')}</div>`
+    }
+
+    html += `<div class="overview-stats">
+      <div class="overview-stat"><div class="overview-stat-value">${fmtMoney(s.current_spend)}</div><div class="overview-stat-label">${t('costs.current_spend')}</div></div>
+      <div class="overview-stat"><div class="overview-stat-value">${fmtMoney(s.forecast_month_end)}</div><div class="overview-stat-label">${t('costs.forecast')}</div></div>
+      <div class="overview-stat"><div class="overview-stat-value">${escapeHtml(s.month || '—')}</div><div class="overview-stat-label">${t('costs.month')}</div></div>
+    </div>`
+
+    if (s.budget) {
+      const pct = Math.round((s.budget.used_pct || 0) * 100)
+      const color = s.budget.status === 'hard' ? 'var(--danger,#e74c3c)' : s.budget.status === 'warning' ? 'var(--warn,#e0a800)' : 'var(--text-muted)'
+      html += `<div style="margin-top:16px;padding:12px 16px;border:1px solid var(--border,#333);border-radius:8px">
+        <div style="font-weight:600;margin-bottom:6px">${t('costs.budget_title')}: ${escapeHtml(s.budget.id)} (${fmtMoney(s.budget.amount)})</div>
+        <div style="${mutedStyle}">${t('costs.budget_used')}: <strong style="color:${color}">${pct}%</strong></div>
+      </div>`
+    }
+
+    const sources = Array.isArray(s.all_sources) ? s.all_sources : []
+    if (sources.length === 0) {
+      html += `<div style="${mutedStyle};margin-top:12px">${t('costs.no_sources')}</div>`
+    } else {
+      html += `<div style="overflow-x:auto;margin-top:16px"><table style="width:100%;border-collapse:collapse">
+        <thead><tr style="text-align:left;border-bottom:1px solid var(--border,#333)">
+          <th style="padding:6px 8px">${t('costs.source_name')}</th><th style="padding:6px 8px">${t('costs.source_provider')}</th><th style="padding:6px 8px">${t('costs.source_spend')}</th>
+        </tr></thead>
+        <tbody>${sources.map((src) => `<tr style="border-bottom:1px solid var(--border,#222)">
+          <td style="padding:6px 8px">${escapeHtml(src.name)}</td>
+          <td style="padding:6px 8px;${mutedStyle}">${escapeHtml(src.provider)}</td>
+          <td style="padding:6px 8px">${fmtMoney(src.spend)}</td>
+        </tr>`).join('')}</tbody>
+      </table></div>`
+    }
+
+    html += `<p style="${mutedStyle};margin-top:16px">${t('costs.token_usage_note')} (${(s.token_usage?.calls ?? 0)} ${t('costs.calls')}, ${(s.token_usage?.input_tokens ?? 0) + (s.token_usage?.output_tokens ?? 0)} tokens)</p>`
+
+    el.innerHTML = html
+  } catch (err) {
+    el.innerHTML = `<div style="${mutedStyle}">${t('costs.load_failed')}</div>`
   }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -132,6 +132,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20V10"/><path d="M18 20V4"/><path d="M6 20v-4"/></svg>
         <span class="sb-label">Token Monitor</span>
       </a>
+      <a href="#" class="sb-link" data-page="costs">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        <span class="sb-label">Költségek</span>
+      </a>
       <a href="#" class="sb-link" data-page="ideas">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4"/><path d="M12 16h.01"/></svg>
         <span class="sb-label">Ötletláda</span>
@@ -1611,6 +1615,26 @@
         <h3 data-i18n="tokenUsage.changes_title">Változások</h3>
         <div id="updatesCommitList" class="updates-commit-list"></div>
       </div>
+    </div>
+
+    <!-- Costs page (CostOps v0.1, PR #524) -->
+    <div class="page" id="costsPage" hidden>
+      <div class="page-header">
+        <div class="page-header-row">
+          <div>
+            <h1 data-i18n="costs.page_title">Költségek</h1>
+            <p class="subtitle" data-i18n="costs.page_subtitle">Havi költség-összefoglaló a helyi konfigurációból</p>
+          </div>
+          <button class="btn-secondary btn-compact" id="refreshCostsBtn" data-i18n="common.btn.refresh">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+            </svg>
+            Frissítés
+          </button>
+        </div>
+      </div>
+
+      <div id="costsContent"></div>
     </div>
 
     <!-- Naplo page -->

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -88,6 +88,7 @@ window._i18n.en = {
   'nav.tokenUsage':   'Token Monitor',
   'nav.ideas':        'Ideas',
   'nav.updates':      'Updates',
+  'nav.costs':        'Costs',
 
   // --- Overview ---
   'overview.card.team_meta':     'live status',
@@ -522,6 +523,25 @@ window._i18n.en = {
   'status.comp.partial_outage':  'partial outage',
   'status.comp.major_outage':    'major outage',
   'status.comp.maintenance':     'under maintenance',
+
+  // --- Costs (CostOps v0.1, PR #524) ---
+  'costs.page_title':            'Costs',
+  'costs.page_subtitle':         'Monthly cost summary from the local config',
+  'costs.loading':               'Loading...',
+  'costs.load_failed':           'Failed to load the cost summary.',
+  'costs.no_config':             'No local cost config yet -- numbers stay empty until one is set up.',
+  'costs.current_spend':         'Spend this month',
+  'costs.forecast':              'Month-end forecast',
+  'costs.month':                 'Period',
+  'costs.budget_title':          'Budget',
+  'costs.budget_used':           'Used',
+  'costs.no_sources':            'No active cost sources.',
+  'costs.source_name':           'Source',
+  'costs.source_provider':       'Provider',
+  'costs.source_spend':          'Spend',
+  'costs.token_usage_note':      'Token usage volume (not priced)',
+  'costs.calls':                 'calls',
+
   'tokenUsage.col.time':         'Time',
   'tokenUsage.col.agent':        'Agent',
   'tokenUsage.col.content':      'Content',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -88,6 +88,7 @@ window._i18n.hu = {
   'nav.tokenUsage':   'Token Monitor',
   'nav.ideas':        'Ötletláda',
   'nav.updates':      'Frissítések',
+  'nav.costs':        'Költségek',
 
   // --- Overview ---
   'overview.card.team_meta':     'élő állapot',
@@ -771,6 +772,25 @@ window._i18n.hu = {
   'status.comp.partial_outage':  'részleges kimaradás',
   'status.comp.major_outage':    'kimaradás',
   'status.comp.maintenance':     'karbantartás',
+
+  // --- Costs (CostOps v0.1, PR #524) ---
+  'costs.page_title':            'Költségek',
+  'costs.page_subtitle':         'Havi költség-összefoglaló a helyi konfigurációból',
+  'costs.loading':               'Betöltés...',
+  'costs.load_failed':           'Nem sikerült betölteni a költség-összefoglalót.',
+  'costs.no_config':             'Nincs helyi költség-konfiguráció -- a számok üresek, amíg nem kerül beállításra.',
+  'costs.current_spend':         'Havi eddigi költség',
+  'costs.forecast':              'Hónap végi előrejelzés',
+  'costs.month':                 'Időszak',
+  'costs.budget_title':          'Büdzsé',
+  'costs.budget_used':           'Felhasználva',
+  'costs.no_sources':            'Nincs aktív költségforrás.',
+  'costs.source_name':           'Forrás',
+  'costs.source_provider':       'Szolgáltató',
+  'costs.source_spend':          'Költség',
+  'costs.token_usage_note':      'Token-felhasználás mennyisége (nincs árazva)',
+  'costs.calls':                 'hívás',
+
   'tokenUsage.col.time':         'Idő',
   'tokenUsage.col.agent':        'Ágens',
   'tokenUsage.col.content':      'Tartalom',


### PR DESCRIPTION
## Summary

Adds a deterministic, read-mostly **local cost ledger** for the operator's own recurring costs (subscriptions, hosting, domain, SaaS). Pure SQL + arithmetic: no LLM, no provider API, no secrets. Real amounts / account references live in a gitignored local config, never in the repo.

This is the base slice; later slices add the provider layer.

## What's in

- **Additive DB schema** (all `CREATE TABLE IF NOT EXISTS`): `cost_sources`, `cost_line_items`, `budgets` (+ 2 indexes). No raw account IDs stored.
- **Config loader with safe defaults** — absent config yields an empty summary; it never fabricates numbers and never blocks the app.
- **Monthly summary endpoint** — `GET /api/costs/summary` (+ `/sources`, `/budgets`), Bearer-gated, read-only. Summary idempotently reflects the config's fixed costs into the ledger on read (upsert by dedup_key).
- **Manual / bootstrap fallback** cost path; the provider-derived path is empty and handled gracefully.
- Token usage reported as **volume only**, explicitly **not priced** (no money is derived from tokens in this slice).
- Unit + route-smoke tests; short README.

## What's intentionally out (follow-up PRs)

Provider collector framework, Render plan-derived collector, provider-API imports, scheduled sync, token-cost pricing, operational (provider-preferred) spend semantics, and the operational dashboard UX.

## Safety / compatibility

- **Additive schema only** — no `ALTER`/`DROP`, no data migration. With no CostOps config, existing behavior is unchanged.
- **No secrets, no provider credentials, no external API calls, no scheduled tasks, no new env vars.**
- No raw provider/account/service IDs; no real pricing values.

## Tests / build

- Full suite: **110 files, 1614 passed, 1 skipped, 0 failed**.
- `npm run build` (tsc): **green**.

_Draft — not for merge yet; opening for early review of the base slice._
