### PR TITLE
feat(context-clean): size-triggered safe warn+save+restart + multi-trigger auto-resume

### DIFF
--- a/src/__tests__/context-clean.test.ts
+++ b/src/__tests__/context-clean.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decideContextClean,
+  normalizeContextCleanConfig,
+  normalizeSignal,
+  isLargeContextModel,
+  defaultContextCleanForModel,
+  DEFAULT_CONTEXT_CLEAN,
+  DEFAULT_CONTEXT_CLEAN_LARGE,
+  DEFAULT_CONTEXT_CLEAN_STANDARD,
+  INITIAL_STATE,
+  NO_SIGNAL,
+  type ContextCleanConfig,
+  type ContextCleanState,
+} from '../context-clean.js'
+
+const CFG: ContextCleanConfig = {
+  enabled: true,
+  softThreshold: 400_000,
+  hardThreshold: 500_000,
+  graceMinutes: 15,
+}
+const IDLE: ContextCleanState = { phase: 'idle', warnedAtMs: null }
+const warned = (warnedAtMs: number): ContextCleanState => ({ phase: 'warned', warnedAtMs })
+
+describe('normalizeContextCleanConfig', () => {
+  it('fills defaults for an empty object', () => {
+    expect(normalizeContextCleanConfig({})).toEqual(DEFAULT_CONTEXT_CLEAN)
+  })
+
+  it('defaults enabled to true when the field is absent', () => {
+    expect(normalizeContextCleanConfig({ softThreshold: 300_000 }).enabled).toBe(true)
+  })
+
+  it('respects an explicit enabled:false', () => {
+    expect(normalizeContextCleanConfig({ enabled: false }).enabled).toBe(false)
+  })
+
+  it('repairs hard < soft by lifting hard to soft', () => {
+    const c = normalizeContextCleanConfig({ softThreshold: 400_000, hardThreshold: 100_000 })
+    expect(c.hardThreshold).toBe(400_000)
+  })
+
+  it('rejects non-positive / non-finite numbers back to defaults', () => {
+    const c = normalizeContextCleanConfig({ softThreshold: -5, hardThreshold: 'x', graceMinutes: 0 })
+    expect(c.softThreshold).toBe(DEFAULT_CONTEXT_CLEAN.softThreshold)
+    expect(c.hardThreshold).toBe(DEFAULT_CONTEXT_CLEAN.hardThreshold)
+    expect(c.graceMinutes).toBe(DEFAULT_CONTEXT_CLEAN.graceMinutes)
+  })
+})
+
+describe('model-aware defaults', () => {
+  it('detects a [1m] model as large-context', () => {
+    expect(isLargeContextModel('claude-opus-4-8[1m]')).toBe(true)
+    expect(isLargeContextModel('claude-sonnet-5[1m]')).toBe(true)
+  })
+
+  it('treats a plain Sonnet id (no [1m]) as standard-window', () => {
+    expect(isLargeContextModel('claude-sonnet-5')).toBe(false)
+    expect(isLargeContextModel(null)).toBe(false)
+    expect(isLargeContextModel(undefined)).toBe(false)
+  })
+
+  it('picks the large profile (400k/500k) for a [1m] model', () => {
+    expect(defaultContextCleanForModel('claude-opus-4-8[1m]')).toEqual(DEFAULT_CONTEXT_CLEAN_LARGE)
+    expect(DEFAULT_CONTEXT_CLEAN_LARGE.softThreshold).toBe(400_000)
+    expect(DEFAULT_CONTEXT_CLEAN_LARGE.hardThreshold).toBe(500_000)
+  })
+
+  it('picks the proportionally-lower profile (120k/160k) for a standard model', () => {
+    expect(defaultContextCleanForModel('claude-sonnet-5')).toEqual(DEFAULT_CONTEXT_CLEAN_STANDARD)
+    expect(DEFAULT_CONTEXT_CLEAN_STANDARD.softThreshold).toBe(120_000)
+    expect(DEFAULT_CONTEXT_CLEAN_STANDARD.hardThreshold).toBe(160_000)
+  })
+
+  it('standard soft/hard sit below the large soft, so the clean pre-empts native compaction', () => {
+    expect(DEFAULT_CONTEXT_CLEAN_STANDARD.hardThreshold).toBeLessThan(DEFAULT_CONTEXT_CLEAN_LARGE.softThreshold)
+  })
+
+  it('normalize honours a supplied base for missing fields', () => {
+    // A standard-model agent with only enabled set inherits the standard thresholds.
+    const c = normalizeContextCleanConfig({ enabled: true }, DEFAULT_CONTEXT_CLEAN_STANDARD)
+    expect(c.softThreshold).toBe(120_000)
+    expect(c.hardThreshold).toBe(160_000)
+  })
+})
+
+describe('normalizeSignal', () => {
+  it('treats a missing/garbage payload as no signal', () => {
+    expect(normalizeSignal(null)).toEqual(NO_SIGNAL)
+    expect(normalizeSignal('nope')).toEqual(NO_SIGNAL)
+    expect(normalizeSignal({})).toEqual(NO_SIGNAL)
+  })
+
+  it('reads explicit booleans', () => {
+    expect(normalizeSignal({ hold: true, ready: false })).toEqual({ hold: true, ready: false })
+    expect(normalizeSignal({ hold: false, ready: true })).toEqual({ hold: false, ready: true })
+  })
+})
+
+describe('decideContextClean', () => {
+  const now = 1_000_000_000
+
+  it('does nothing while disabled', () => {
+    expect(decideContextClean({ ...CFG, enabled: false }, IDLE, 999_999, NO_SIGNAL, now)).toBe('none')
+  })
+
+  it('does nothing when context tokens are unknown', () => {
+    expect(decideContextClean(CFG, IDLE, null, NO_SIGNAL, now)).toBe('none')
+  })
+
+  it('stays idle below the soft threshold', () => {
+    expect(decideContextClean(CFG, IDLE, 399_999, NO_SIGNAL, now)).toBe('none')
+  })
+
+  it('warns on crossing the soft threshold', () => {
+    expect(decideContextClean(CFG, IDLE, 400_000, NO_SIGNAL, now)).toBe('warn')
+  })
+
+  it('waits after warning while the agent has not signalled', () => {
+    expect(decideContextClean(CFG, warned(now), 420_000, NO_SIGNAL, now + 60_000)).toBe('wait')
+  })
+
+  it('restarts immediately on an explicit ready signal', () => {
+    expect(decideContextClean(CFG, warned(now), 420_000, { hold: false, ready: true }, now + 1000)).toBe('restart')
+  })
+
+  it('does NOT restart just because the agent looks ready-via-idle (no signal)', () => {
+    // The pure function has no notion of pane-idle; readiness must be explicit.
+    expect(decideContextClean(CFG, warned(now), 420_000, NO_SIGNAL, now + 1000)).toBe('wait')
+  })
+
+  it('forces a restart once the grace window elapses, even without a signal', () => {
+    const graceMs = CFG.graceMinutes * 60_000
+    expect(decideContextClean(CFG, warned(now), 420_000, NO_SIGNAL, now + graceMs)).toBe('restart')
+  })
+
+  it('honours an active hold within the grace window', () => {
+    expect(decideContextClean(CFG, warned(now), 420_000, { hold: true, ready: false }, now + 60_000)).toBe('wait')
+  })
+
+  it('overrides an active hold once the grace window elapses', () => {
+    const graceMs = CFG.graceMinutes * 60_000
+    expect(decideContextClean(CFG, warned(now), 420_000, { hold: true, ready: false }, now + graceMs)).toBe('restart')
+  })
+
+  it('forces on hard threshold when there is no active hold', () => {
+    expect(decideContextClean(CFG, warned(now), 500_000, NO_SIGNAL, now + 60_000)).toBe('restart')
+  })
+
+  it('defers the hard-threshold force while a hold is active (until grace)', () => {
+    expect(decideContextClean(CFG, warned(now), 500_000, { hold: true, ready: false }, now + 60_000)).toBe('wait')
+  })
+
+  it('resets the flow if context falls back below soft after warning', () => {
+    expect(decideContextClean(CFG, warned(now), 399_999, NO_SIGNAL, now + 60_000)).toBe('reset')
+  })
+
+  it('a ready signal wins even at/above the hard threshold', () => {
+    expect(decideContextClean(CFG, warned(now), 600_000, { hold: false, ready: true }, now + 1000)).toBe('restart')
+  })
+})
+
+describe('INITIAL_STATE', () => {
+  it('is idle with no warn timestamp', () => {
+    expect(INITIAL_STATE).toEqual({ phase: 'idle', warnedAtMs: null })
+  })
+})

--- a/src/__tests__/context-clean.test.ts
+++ b/src/__tests__/context-clean.test.ts
@@ -3,6 +3,8 @@ import {
   decideContextClean,
   normalizeContextCleanConfig,
   normalizeSignal,
+  normalizeResumeState,
+  formatResumePrompt,
   isLargeContextModel,
   defaultContextCleanForModel,
   DEFAULT_CONTEXT_CLEAN,
@@ -12,6 +14,7 @@ import {
   NO_SIGNAL,
   type ContextCleanConfig,
   type ContextCleanState,
+  type ContextCleanTrigger,
 } from '../context-clean.js'
 
 const CFG: ContextCleanConfig = {
@@ -19,9 +22,12 @@ const CFG: ContextCleanConfig = {
   softThreshold: 400_000,
   hardThreshold: 500_000,
   graceMinutes: 15,
+  dailyTime: null,
+  intervalHours: null,
 }
-const IDLE: ContextCleanState = { phase: 'idle', warnedAtMs: null }
-const warned = (warnedAtMs: number): ContextCleanState => ({ phase: 'warned', warnedAtMs })
+const IDLE: ContextCleanState = { phase: 'idle', warnedAtMs: null, trigger: null }
+const warned = (warnedAtMs: number, trigger: ContextCleanTrigger = 'token'): ContextCleanState =>
+  ({ phase: 'warned', warnedAtMs, trigger })
 
 describe('normalizeContextCleanConfig', () => {
   it('fills defaults for an empty object', () => {
@@ -162,7 +168,149 @@ describe('decideContextClean', () => {
 })
 
 describe('INITIAL_STATE', () => {
-  it('is idle with no warn timestamp', () => {
-    expect(INITIAL_STATE).toEqual({ phase: 'idle', warnedAtMs: null })
+  it('is idle with no warn timestamp or trigger', () => {
+    expect(INITIAL_STATE).toEqual({ phase: 'idle', warnedAtMs: null, trigger: null })
+  })
+})
+
+describe('normalizeContextCleanConfig schedule fields', () => {
+  it('parses a valid dailyTime and clears intervalHours', () => {
+    const c = normalizeContextCleanConfig({ dailyTime: '04:30', intervalHours: 6 })
+    expect(c.dailyTime).toBe('04:30')
+    expect(c.intervalHours).toBeNull() // dailyTime takes precedence
+  })
+
+  it('keeps intervalHours when no dailyTime is set', () => {
+    const c = normalizeContextCleanConfig({ intervalHours: 8 })
+    expect(c.dailyTime).toBeNull()
+    expect(c.intervalHours).toBe(8)
+  })
+
+  it('rejects an invalid dailyTime and a non-positive intervalHours', () => {
+    const c = normalizeContextCleanConfig({ dailyTime: '99:99', intervalHours: -3 })
+    expect(c.dailyTime).toBeNull()
+    expect(c.intervalHours).toBeNull()
+  })
+})
+
+describe('decideContextClean schedule trigger (v2)', () => {
+  const now = 1_000_000_000
+
+  it('warns from idle when a schedule slot is due even below the soft threshold', () => {
+    expect(decideContextClean(CFG, IDLE, 50_000, NO_SIGNAL, now, true)).toBe('warn')
+  })
+
+  it('warns from idle when tokens are unknown but a schedule slot is due', () => {
+    expect(decideContextClean(CFG, IDLE, null, NO_SIGNAL, now, true)).toBe('warn')
+  })
+
+  it('does NOT reset a schedule-triggered warn when context is low', () => {
+    // A periodic clean must run regardless of context size.
+    expect(decideContextClean(CFG, warned(now, 'schedule'), 10_000, NO_SIGNAL, now + 60_000)).toBe('wait')
+  })
+
+  it('DOES reset a token-triggered warn when context drops below soft', () => {
+    expect(decideContextClean(CFG, warned(now, 'token'), 10_000, NO_SIGNAL, now + 60_000)).toBe('reset')
+  })
+
+  it('a schedule flow still forces at the grace cap', () => {
+    const graceMs = CFG.graceMinutes * 60_000
+    expect(decideContextClean(CFG, warned(now, 'schedule'), 10_000, NO_SIGNAL, now + graceMs)).toBe('restart')
+  })
+
+  it('a schedule flow ignores the hard-threshold force path (token-only)', () => {
+    // Even at/above hard, a schedule flow waits for ready or grace, not the
+    // hard-token fallback (which only applies to token-triggered flows).
+    expect(decideContextClean(CFG, warned(now, 'schedule'), 600_000, NO_SIGNAL, now + 60_000)).toBe('wait')
+  })
+
+  it('a schedule flow honours an explicit ready signal', () => {
+    expect(decideContextClean(CFG, warned(now, 'schedule'), 10_000, { hold: false, ready: true }, now + 1000)).toBe('restart')
+  })
+})
+
+describe('decideContextClean task-boundary trigger (v2)', () => {
+  const now = 1_000_000_000
+
+  it('warns from idle on an external (task) trigger regardless of token count', () => {
+    expect(decideContextClean(CFG, IDLE, 5_000, NO_SIGNAL, now, true)).toBe('warn')
+  })
+
+  it('a task flow does NOT reset when context is low (like schedule, unlike token)', () => {
+    expect(decideContextClean(CFG, warned(now, 'task'), 5_000, NO_SIGNAL, now + 60_000)).toBe('wait')
+  })
+
+  it('a task flow ignores the hard-threshold force path', () => {
+    expect(decideContextClean(CFG, warned(now, 'task'), 600_000, NO_SIGNAL, now + 60_000)).toBe('wait')
+  })
+
+  it('a task flow forces at the grace cap', () => {
+    const graceMs = CFG.graceMinutes * 60_000
+    expect(decideContextClean(CFG, warned(now, 'task'), 5_000, NO_SIGNAL, now + graceMs)).toBe('restart')
+  })
+
+  it('a task flow honours an explicit ready signal', () => {
+    expect(decideContextClean(CFG, warned(now, 'task'), 5_000, { hold: false, ready: true }, now + 1000)).toBe('restart')
+  })
+
+  it('a task flow honours an active hold until grace', () => {
+    expect(decideContextClean(CFG, warned(now, 'task'), 5_000, { hold: true, ready: false }, now + 60_000)).toBe('wait')
+    const graceMs = CFG.graceMinutes * 60_000
+    expect(decideContextClean(CFG, warned(now, 'task'), 5_000, { hold: true, ready: false }, now + graceMs)).toBe('restart')
+  })
+})
+
+describe('normalizeResumeState', () => {
+  it('returns null when there is no active task and no next action', () => {
+    expect(normalizeResumeState({})).toBeNull()
+    expect(normalizeResumeState(null)).toBeNull()
+    expect(normalizeResumeState({ notes: 'x' })).toBeNull()
+  })
+
+  it('reads camelCase fields', () => {
+    const rs = normalizeResumeState({
+      activeTask: 'PR #14 review', currentStep: 'merge conflicts',
+      relevantFiles: ['a.ts', 'b.ts'], nextAction: 'resolve b.ts', notes: 'careful',
+    })
+    expect(rs).toEqual({
+      activeTask: 'PR #14 review', currentStep: 'merge conflicts',
+      relevantFiles: ['a.ts', 'b.ts'], nextAction: 'resolve b.ts', notes: 'careful',
+    })
+  })
+
+  it('accepts snake_case aliases and a single-string relevantFiles', () => {
+    const rs = normalizeResumeState({ active_task: 'T', relevant_files: 'only.ts', next_action: 'go' })
+    expect(rs?.activeTask).toBe('T')
+    expect(rs?.relevantFiles).toEqual(['only.ts'])
+    expect(rs?.nextAction).toBe('go')
+  })
+
+  it('is usable with only an active task', () => {
+    const rs = normalizeResumeState({ activeTask: 'just this' })
+    expect(rs?.activeTask).toBe('just this')
+    expect(rs?.relevantFiles).toEqual([])
+  })
+})
+
+describe('formatResumePrompt', () => {
+  it('renders a self-contained continue instruction, not a question', () => {
+    const out = formatResumePrompt({
+      activeTask: 'Context-clean v2', currentStep: 'tests', relevantFiles: ['runner.ts'],
+      nextAction: 'run vitest', notes: '',
+    })
+    expect(out).toContain('auto-resume')
+    expect(out).toContain('Context-clean v2')
+    expect(out).toContain('run vitest')
+    expect(out).toContain('Folytasd')
+    expect(out).not.toContain('?')
+  })
+
+  it('omits empty optional lines', () => {
+    const out = formatResumePrompt({
+      activeTask: 'T', currentStep: '', relevantFiles: [], nextAction: '', notes: '',
+    })
+    expect(out).not.toContain('Hol tartottal')
+    expect(out).not.toContain('Relevans fajlok')
+    expect(out).not.toContain('Kovetkezo lepes')
   })
 })

--- a/src/context-clean.ts
+++ b/src/context-clean.ts
@@ -1,0 +1,182 @@
+// Pure logic for the context-clean feature.
+//
+// A long-lived Claude Code session accumulates context: every turn re-reads the
+// whole transcript, so a big context is slower, costlier and hits the per-session
+// limit sooner. The auto-restart feature (src/auto-restart.ts) cycles sessions on
+// a *schedule*; context-clean instead reacts to *size*: when an agent's live
+// context grows past a soft threshold, the system cleans it -- but NEVER out of
+// the blue. The requirement (Norbi, kanban bc45f27c) is a safe, signalled flow:
+//
+//   1. WARN the agent first (a prompt injected into its session) so it knows a
+//      clean is coming and can persist what matters (memory, hot task state,
+//      daily log).
+//   2. The agent SAVES on its own terms.
+//   3. The agent gives an EXPLICIT "safe-to-restart" signal -- the runner must
+//      NOT infer readiness from an idle pane. The agent may also HOLD if it is
+//      mid-critical-step (e.g. a multi-step git operation), and the clean waits.
+//   4. Fallbacks so a silent or indefinitely-holding agent still gets cleaned:
+//      a grace cap (force after N minutes) and a hard threshold (force once the
+//      context grows past it, provided no hold is active).
+//
+// Only after that does a *fresh* restart (conversation dropped -- the actual
+// clean) happen.
+//
+// This module is dependency-free so the state-machine decision is unit-testable
+// without a clock, tmux, or the filesystem. The I/O (reading context tokens,
+// injecting the warn prompt, reading the ready/hold signal, performing the
+// restart) lives in src/web/context-clean-runner.ts.
+
+export interface ContextCleanConfig {
+  /** Master toggle. When false the agent is never context-cleaned. */
+  enabled: boolean
+  /** Warn (and begin the flow) at/above this many context tokens. */
+  softThreshold: number
+  /** Force-restart fallback at/above this many tokens, unless a hold is active. */
+  hardThreshold: number
+  /** Max minutes to wait after warning before forcing the restart (grace cap). */
+  graceMinutes: number
+}
+
+// Thresholds are model-aware, NOT one global number. A model exposing a ~1M
+// context window (the [1m] marker in its id) can safely accumulate far more
+// before our deliberate clean should pre-empt the harness's own auto-compaction.
+// A standard ~200k-window model (e.g. Sonnet without [1m]) would auto-compact
+// near its real limit long before a 400k/500k threshold ever fired, so its
+// clean must land at a proportionally lower point -- BEFORE native compaction,
+// so our SIGNALLED clean wins over the harness's silent one, not the reverse.
+export const DEFAULT_CONTEXT_CLEAN_LARGE: ContextCleanConfig = {
+  enabled: true,
+  softThreshold: 400_000,
+  hardThreshold: 500_000,
+  graceMinutes: 15,
+}
+export const DEFAULT_CONTEXT_CLEAN_STANDARD: ContextCleanConfig = {
+  enabled: true,
+  softThreshold: 120_000,
+  hardThreshold: 160_000,
+  graceMinutes: 15,
+}
+
+// Backwards-compatible alias: the large-window profile is the base for field-
+// level fallbacks when normalizing a partial config with no explicit base.
+export const DEFAULT_CONTEXT_CLEAN: ContextCleanConfig = DEFAULT_CONTEXT_CLEAN_LARGE
+
+/** A model exposes the ~1M-token window when its resolved id carries [1m]. */
+export function isLargeContextModel(model: string | null | undefined): boolean {
+  return typeof model === 'string' && model.includes('[1m]')
+}
+
+/** The out-of-the-box config for an agent, picked by its model's context window. */
+export function defaultContextCleanForModel(model: string | null | undefined): ContextCleanConfig {
+  return isLargeContextModel(model)
+    ? { ...DEFAULT_CONTEXT_CLEAN_LARGE }
+    : { ...DEFAULT_CONTEXT_CLEAN_STANDARD }
+}
+
+/**
+ * Coerce arbitrary parsed JSON into a safe, fully-populated config. Unknown /
+ * malformed fields fall back to `base` (the model-appropriate default), and the
+ * invariant soft <= hard is repaired so a hand-edited store can never produce a
+ * nonsensical schedule.
+ */
+export function normalizeContextCleanConfig(
+  raw: unknown,
+  base: ContextCleanConfig = DEFAULT_CONTEXT_CLEAN,
+): ContextCleanConfig {
+  const o = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const num = (v: unknown, fallback: number): number =>
+    (typeof v === 'number' && Number.isFinite(v) && v > 0) ? v : fallback
+  const soft = num(o.softThreshold, base.softThreshold)
+  let hard = num(o.hardThreshold, base.hardThreshold)
+  // Hard must sit at or above soft, else the hard fallback would fire before the
+  // agent is ever warned. Repair by lifting hard to soft.
+  if (hard < soft) hard = soft
+  return {
+    enabled: o.enabled === true || (o.enabled === undefined && base.enabled),
+    softThreshold: soft,
+    hardThreshold: hard,
+    graceMinutes: num(o.graceMinutes, base.graceMinutes),
+  }
+}
+
+/** Per-agent phase, tracked in memory by the runner across ticks. */
+export type ContextCleanPhase = 'idle' | 'warned'
+
+export interface ContextCleanState {
+  phase: ContextCleanPhase
+  /** When the warn prompt was injected (ms), or null while idle. */
+  warnedAtMs: number | null
+}
+
+export const INITIAL_STATE: ContextCleanState = { phase: 'idle', warnedAtMs: null }
+
+/**
+ * The agent-written signal, read from the signal file each tick. Absent /
+ * malformed file -> both false (no explicit readiness, no hold).
+ */
+export interface RestartSignal {
+  hold: boolean
+  ready: boolean
+}
+
+export const NO_SIGNAL: RestartSignal = { hold: false, ready: false }
+
+/** Parse the signal file's JSON into a safe RestartSignal. */
+export function normalizeSignal(raw: unknown): RestartSignal {
+  const o = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  return { hold: o.hold === true, ready: o.ready === true }
+}
+
+export type ContextCleanAction =
+  | 'none'     // nothing to do; stay idle
+  | 'warn'     // cross soft threshold: inject warn, enter 'warned'
+  | 'wait'     // warned, but still waiting for the agent to save + signal
+  | 'restart'  // proceed with the fresh restart (runner still gates on pane-idle)
+  | 'reset'    // warned but context fell back below soft: abandon the flow
+
+/**
+ * Pure decision: given the current context size, the tracked per-agent state,
+ * the agent's signal, and now, what should the runner do?
+ *
+ * The runner layers ONE additional gate the pure function deliberately does not
+ * model: pane-idle. A 'restart' must never cut a live turn, so the runner defers
+ * a 'restart' to the next tick while the pane is busy. Readiness itself, though,
+ * is the agent's explicit signal -- never inferred from idle.
+ *
+ * @param contextTokens  Current session context size (tokens), or null if unknown.
+ */
+export function decideContextClean(
+  cfg: ContextCleanConfig,
+  state: ContextCleanState,
+  contextTokens: number | null,
+  signal: RestartSignal,
+  nowMs: number,
+): ContextCleanAction {
+  if (!cfg.enabled) return 'none'
+  if (contextTokens === null) return 'none'
+
+  if (state.phase === 'idle') {
+    // Begin the flow only when we cross the soft threshold.
+    return contextTokens >= cfg.softThreshold ? 'warn' : 'none'
+  }
+
+  // phase === 'warned'.
+  // The situation resolved itself (e.g. the agent ran its own /clear): the
+  // context dropped back below soft, so abandon the flow.
+  if (contextTokens < cfg.softThreshold) return 'reset'
+
+  // Highest priority: the agent explicitly cleared itself for restart.
+  if (signal.ready) return 'restart'
+
+  // Grace cap: waited long enough -> force regardless of hold. This is the
+  // anti-indefinite-hold backstop.
+  const graceMs = cfg.graceMinutes * 60_000
+  if (state.warnedAtMs !== null && (nowMs - state.warnedAtMs) >= graceMs) return 'restart'
+
+  // Hard threshold: context grew past the ceiling and the agent is NOT actively
+  // holding a critical step -> force. An active hold still defers (until grace).
+  if (contextTokens >= cfg.hardThreshold && !signal.hold) return 'restart'
+
+  // Otherwise keep waiting for the agent to save + signal.
+  return 'wait'
+}

--- a/src/context-clean.ts
+++ b/src/context-clean.ts
@@ -25,6 +25,23 @@
 // without a clock, tmux, or the filesystem. The I/O (reading context tokens,
 // injecting the warn prompt, reading the ready/hold signal, performing the
 // restart) lives in src/web/context-clean-runner.ts.
+//
+// v2 (kanban 5cdc0d14) adds two things on top of the token-triggered flow:
+//   - A SECOND trigger source: an optional schedule (daily time or every-N-hours)
+//     kicks off the same safe warn->save->signal->restart flow even when the
+//     token threshold has not been reached. Kept as context-clean's OWN schedule
+//     (not entangled with the legacy abrupt auto-restart loop) so the two watcher
+//     loops can never both fire a restart on the same tick.
+//   - STRUCTURED task-state resume: the agent persists what it was doing during
+//     the save phase, and the runner auto-injects that as the first prompt after
+//     the fresh restart so the agent continues exactly where it left off, without
+//     waiting for a new instruction.
+
+// Shared with the auto-restart module so the two schedules use one proven,
+// unit-tested set of time helpers instead of a second parser. Imported for local
+// use (normalize) and re-exported for the runner.
+import { parseHHMM, dailyDueAtMs, restartDue } from './auto-restart.js'
+export { parseHHMM, dailyDueAtMs, restartDue }
 
 export interface ContextCleanConfig {
   /** Master toggle. When false the agent is never context-cleaned. */
@@ -35,6 +52,11 @@ export interface ContextCleanConfig {
   hardThreshold: number
   /** Max minutes to wait after warning before forcing the restart (grace cap). */
   graceMinutes: number
+  /** Optional schedule trigger: warn daily at 'HH:MM' local, or null. */
+  dailyTime: string | null
+  /** Optional schedule trigger: warn every N hours, or null. dailyTime wins if
+   *  both are somehow set, so the schedule stays unambiguous. */
+  intervalHours: number | null
 }
 
 // Thresholds are model-aware, NOT one global number. A model exposing a ~1M
@@ -49,12 +71,16 @@ export const DEFAULT_CONTEXT_CLEAN_LARGE: ContextCleanConfig = {
   softThreshold: 400_000,
   hardThreshold: 500_000,
   graceMinutes: 15,
+  dailyTime: null,
+  intervalHours: null,
 }
 export const DEFAULT_CONTEXT_CLEAN_STANDARD: ContextCleanConfig = {
   enabled: true,
   softThreshold: 120_000,
   hardThreshold: 160_000,
   graceMinutes: 15,
+  dailyTime: null,
+  intervalHours: null,
 }
 
 // Backwards-compatible alias: the large-window profile is the base for field-
@@ -91,24 +117,43 @@ export function normalizeContextCleanConfig(
   // Hard must sit at or above soft, else the hard fallback would fire before the
   // agent is ever warned. Repair by lifting hard to soft.
   if (hard < soft) hard = soft
+  const dailyTime = parseHHMM(o.dailyTime) !== null ? (o.dailyTime as string).trim() : null
+  let intervalHours: number | null = null
+  if (typeof o.intervalHours === 'number' && Number.isFinite(o.intervalHours) && o.intervalHours > 0) {
+    intervalHours = o.intervalHours
+  }
+  // dailyTime takes precedence: never keep both, so the schedule is unambiguous.
+  if (dailyTime !== null) intervalHours = null
   return {
     enabled: o.enabled === true || (o.enabled === undefined && base.enabled),
     softThreshold: soft,
     hardThreshold: hard,
     graceMinutes: num(o.graceMinutes, base.graceMinutes),
+    dailyTime,
+    intervalHours,
   }
 }
 
 /** Per-agent phase, tracked in memory by the runner across ticks. */
 export type ContextCleanPhase = 'idle' | 'warned'
 
+/** What kicked off the flow. A TOKEN warn self-cancels if context drops back
+ *  below soft and can be force-restarted at the hard threshold. The non-token
+ *  triggers (a periodic SCHEDULE slot, or a TASK boundary -- an assigned kanban
+ *  card reaching done) run regardless of context size, so they neither reset on
+ *  low tokens nor use the hard-threshold force; they proceed via the ready signal
+ *  or the grace cap. */
+export type ContextCleanTrigger = 'token' | 'schedule' | 'task'
+
 export interface ContextCleanState {
   phase: ContextCleanPhase
   /** When the warn prompt was injected (ms), or null while idle. */
   warnedAtMs: number | null
+  /** Why we are in the warned phase (null while idle). */
+  trigger: ContextCleanTrigger | null
 }
 
-export const INITIAL_STATE: ContextCleanState = { phase: 'idle', warnedAtMs: null }
+export const INITIAL_STATE: ContextCleanState = { phase: 'idle', warnedAtMs: null, trigger: null }
 
 /**
  * The agent-written signal, read from the signal file each tick. Absent /
@@ -136,14 +181,17 @@ export type ContextCleanAction =
 
 /**
  * Pure decision: given the current context size, the tracked per-agent state,
- * the agent's signal, and now, what should the runner do?
+ * the agent's signal, whether a schedule slot is due, and now, what should the
+ * runner do?
  *
  * The runner layers ONE additional gate the pure function deliberately does not
  * model: pane-idle. A 'restart' must never cut a live turn, so the runner defers
  * a 'restart' to the next tick while the pane is busy. Readiness itself, though,
  * is the agent's explicit signal -- never inferred from idle.
  *
- * @param contextTokens  Current session context size (tokens), or null if unknown.
+ * @param contextTokens     Current session context size (tokens), or null if unknown.
+ * @param externalTriggerDue True when a non-token trigger (schedule slot or task
+ *                           boundary) has come due this tick.
  */
 export function decideContextClean(
   cfg: ContextCleanConfig,
@@ -151,32 +199,103 @@ export function decideContextClean(
   contextTokens: number | null,
   signal: RestartSignal,
   nowMs: number,
+  externalTriggerDue = false,
 ): ContextCleanAction {
   if (!cfg.enabled) return 'none'
-  if (contextTokens === null) return 'none'
 
   if (state.phase === 'idle') {
-    // Begin the flow only when we cross the soft threshold.
-    return contextTokens >= cfg.softThreshold ? 'warn' : 'none'
+    // Two entry-point kinds: cross the soft token threshold, OR a non-token
+    // trigger (schedule slot / task boundary) is due. Token unknown (null) does
+    // not block the external trigger.
+    const tokenTrigger = contextTokens !== null && contextTokens >= cfg.softThreshold
+    return (tokenTrigger || externalTriggerDue) ? 'warn' : 'none'
   }
 
   // phase === 'warned'.
-  // The situation resolved itself (e.g. the agent ran its own /clear): the
-  // context dropped back below soft, so abandon the flow.
-  if (contextTokens < cfg.softThreshold) return 'reset'
+  // A TOKEN-triggered flow self-cancels if the situation resolved (e.g. the agent
+  // ran its own /clear and context dropped back below soft). A SCHEDULE-triggered
+  // flow must NOT reset on low tokens -- a periodic clean is meant to run even
+  // when the context is small; it proceeds via the ready signal or the grace cap.
+  if (state.trigger === 'token' && contextTokens !== null && contextTokens < cfg.softThreshold) {
+    return 'reset'
+  }
 
   // Highest priority: the agent explicitly cleared itself for restart.
   if (signal.ready) return 'restart'
 
   // Grace cap: waited long enough -> force regardless of hold. This is the
-  // anti-indefinite-hold backstop.
+  // anti-indefinite-hold backstop (and the sole force path for a schedule flow).
   const graceMs = cfg.graceMinutes * 60_000
   if (state.warnedAtMs !== null && (nowMs - state.warnedAtMs) >= graceMs) return 'restart'
 
-  // Hard threshold: context grew past the ceiling and the agent is NOT actively
-  // holding a critical step -> force. An active hold still defers (until grace).
-  if (contextTokens >= cfg.hardThreshold && !signal.hold) return 'restart'
+  // Hard threshold (token flow only): context grew past the ceiling and the agent
+  // is NOT actively holding a critical step -> force. An active hold still defers
+  // (until grace).
+  if (state.trigger === 'token' && contextTokens !== null && contextTokens >= cfg.hardThreshold && !signal.hold) {
+    return 'restart'
+  }
 
   // Otherwise keep waiting for the agent to save + signal.
   return 'wait'
+}
+
+// ---- structured task-state resume ----------------------------------------
+//
+// The agent writes this during the save phase so the runner can auto-inject it
+// as the first prompt after the fresh restart. This is deliberately MORE than
+// the free-form hot-memory / HANDOFF note: it is structured and reloaded
+// automatically, so the agent continues exactly where it left off without anyone
+// re-asking. All fields are optional strings/arrays; a resume with no active task
+// is treated as absent (nothing to inject).
+
+export interface ResumeState {
+  /** The one task the agent was actively working on. */
+  activeTask: string
+  /** Where in that task it was (which step / phase). */
+  currentStep: string
+  /** Files / paths / branches that are relevant to resuming. */
+  relevantFiles: string[]
+  /** The concrete next action to take on resume. */
+  nextAction: string
+  /** Any extra context worth carrying across the restart. */
+  notes: string
+}
+
+/**
+ * Coerce a parsed resume file into a safe ResumeState, or null if it carries no
+ * usable content (no active task and no next action -> nothing to resume).
+ */
+export function normalizeResumeState(raw: unknown): ResumeState | null {
+  const o = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '')
+  const arr = (v: unknown): string[] =>
+    Array.isArray(v) ? v.map(x => str(x)).filter(Boolean) : (str(v) ? [str(v)] : [])
+  const rs: ResumeState = {
+    activeTask: str(o.activeTask ?? o.active_task),
+    currentStep: str(o.currentStep ?? o.current_step),
+    relevantFiles: arr(o.relevantFiles ?? o.relevant_files),
+    nextAction: str(o.nextAction ?? o.next_action),
+    notes: str(o.notes),
+  }
+  if (!rs.activeTask && !rs.nextAction) return null
+  return rs
+}
+
+/**
+ * Render a resume state into the prompt injected as the agent's first turn after
+ * a fresh restart. It must read as a self-contained instruction to continue, not
+ * a question -- the whole point is that the agent resumes without being asked.
+ */
+export function formatResumePrompt(rs: ResumeState): string {
+  const lines = [
+    `[CONTEXT-CLEAN auto-resume] A kontextusod tisztitva lett (fresh restart). A korabbi munkadat FOLYTASD onnan ahol abbahagytad -- ne varj uj utasitasra.`,
+    ``,
+    `Aktiv feladat: ${rs.activeTask || '(nincs megadva)'}`,
+  ]
+  if (rs.currentStep) lines.push(`Hol tartottal: ${rs.currentStep}`)
+  if (rs.relevantFiles.length) lines.push(`Relevans fajlok/branch: ${rs.relevantFiles.join(', ')}`)
+  if (rs.nextAction) lines.push(`Kovetkezo lepes: ${rs.nextAction}`)
+  if (rs.notes) lines.push(`Megjegyzes: ${rs.notes}`)
+  lines.push(``, `Folytasd a kovetkezo lepessel.`)
+  return lines.join('\n')
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -1199,6 +1199,18 @@ export function getChildCards(parentId: string): KanbanCard[] {
   return db.prepare('SELECT * FROM kanban_cards WHERE parent_id = ? AND archived_at IS NULL ORDER BY sort_order ASC').all(parentId) as KanbanCard[]
 }
 
+// Cards assigned to `assignee` that transitioned to done after `sinceSec`
+// (updated_at is stored in whole seconds). Used by the context-clean runner to
+// fire a task-boundary clean when an agent finishes a card. archived_at IS NULL
+// keeps the auto-archival of old done cards from re-surfacing here.
+export function getRecentlyDoneCardsForAssignee(
+  assignee: string, sinceSec: number,
+): { id: string; updated_at: number }[] {
+  return db.prepare(
+    "SELECT id, updated_at FROM kanban_cards WHERE assignee = ? AND status = 'done' AND archived_at IS NULL AND updated_at > ? ORDER BY updated_at ASC"
+  ).all(assignee, sinceSec) as { id: string; updated_at: number }[]
+}
+
 export function moveKanbanCard(id: string, status: KanbanCard['status'], sortOrder: number, actor?: string): boolean {
   const now = Math.floor(Date.now() / 1000)
   // Read the previous status first so we only record an audit event on a real

--- a/src/web.ts
+++ b/src/web.ts
@@ -20,6 +20,7 @@ import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
 import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
 import { startReauthHealer } from './web/reauth-healer.js'
 import { startAutoRestartRunner } from './web/auto-restart-runner.js'
+import { startContextCleanRunner } from './web/context-clean-runner.js'
 import { startModelFallbackRunner } from './web/model-fallback-runner.js'
 import { collectTokenUsage } from './web/token-usage.js'
 import { logger } from './logger.js'
@@ -343,6 +344,9 @@ export function startWebServer(port = 3420): http.Server {
   const autoRestartInterval = webOnly ? undefined : startAutoRestartRunner()
   if (!webOnly) logger.info('Auto-restart runner started (60s poll, 40s offset)')
 
+  const contextCleanInterval = webOnly ? undefined : startContextCleanRunner()
+  if (!webOnly) logger.info('Context-clean runner started (60s poll, 50s offset)')
+
   const modelFallbackInterval = webOnly ? undefined : startModelFallbackRunner()
   if (!webOnly) logger.info('Model-fallback runner started (60s poll, 50s offset)')
 
@@ -427,6 +431,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(stuckToolCallInterval)
     if (reauthHealerInterval) clearInterval(reauthHealerInterval)
     clearInterval(autoRestartInterval)
+    clearInterval(contextCleanInterval)
     clearInterval(modelFallbackInterval)
     clearInterval(updateCheckerInterval)
     clearInterval(tokenCollectInterval)

--- a/src/web/context-clean-runner.ts
+++ b/src/web/context-clean-runner.ts
@@ -1,0 +1,198 @@
+import { join } from 'node:path'
+import { readFileSync, existsSync, rmSync } from 'node:fs'
+import { logger } from '../logger.js'
+import { STORE_DIR } from '../config.js'
+import {
+  listAgentNames,
+  agentDir,
+  readAgentClaudeConfigDir,
+  readAgentRemoteHost,
+  readAgentModel,
+} from './agent-config.js'
+import {
+  agentRunState,
+  agentSessionName,
+  restartAgentProcess,
+  capturePane,
+  sendPromptToSession,
+} from './agent-process.js'
+import { paneLooksIdle } from '../pane-state.js'
+import { readContextTokensFromProjectDir } from './active-model.js'
+import { readContextCleanConfig } from './context-clean-store.js'
+import {
+  decideContextClean,
+  normalizeSignal,
+  INITIAL_STATE,
+  NO_SIGNAL,
+  type ContextCleanConfig,
+  type ContextCleanState,
+  type RestartSignal,
+} from '../context-clean.js'
+
+// Drives per-agent context-size-triggered cleans (see src/context-clean.ts for
+// the why and the pure decision). Mirrors the auto-restart runner: a 60s sweep,
+// offset from the others so tmux calls do not pile onto one tick. Sub-agents
+// only -- the main channels session is launchd-managed and always starts a fresh
+// conversation, so it has no accumulating context to clean here.
+//
+// Hard safety rules:
+//   - EXPLICIT-READY: a fresh restart proceeds only on the agent's own signal,
+//     the grace-cap, or the hard threshold -- never inferred from an idle pane.
+//   - IDLE-GUARD: even when a restart is due, never cut a live turn; defer to the
+//     next tick while the pane is busy.
+//   - POST-RESTART COOLDOWN: after a clean, skip the agent for a window so a
+//     stale context reading (or a not-yet-rotated transcript) cannot immediately
+//     re-trigger a second warn.
+
+const INITIAL_DELAY_MS = 50_000
+const INTERVAL_MS = 60_000
+const COOLDOWN_MS = 5 * 60_000
+
+// agent name -> tracked state across ticks.
+const states = new Map<string, ContextCleanState>()
+// agent name -> when it was last context-cleaned (ms), for the cooldown guard.
+const lastClean = new Map<string, number>()
+
+// Signal-file name is derived from the agent name; guard it so a malformed name
+// can never escape STORE_DIR. Agent names from listAgentNames() are already
+// real directory names, but the whitelist keeps this defensive.
+function signalPathFor(name: string): string | null {
+  if (!/^[a-zA-Z0-9._-]+$/.test(name)) return null
+  return join(STORE_DIR, `restart-signal.${name}.json`)
+}
+
+function readSignal(name: string): RestartSignal {
+  const p = signalPathFor(name)
+  if (!p || !existsSync(p)) return NO_SIGNAL
+  try {
+    return normalizeSignal(JSON.parse(readFileSync(p, 'utf-8')))
+  } catch {
+    return NO_SIGNAL
+  }
+}
+
+function clearSignal(name: string): void {
+  const p = signalPathFor(name)
+  if (p && existsSync(p)) {
+    try { rmSync(p) } catch (err) { logger.debug({ err, name }, 'context-clean: signal clear failed') }
+  }
+}
+
+function paneIsIdle(session: string, host: string | null): boolean {
+  const pane = capturePane(session, host)
+  if (pane == null) return false
+  return paneLooksIdle(pane)
+}
+
+// The warn prompt injected into the agent's session. It must be actionable on its
+// own: the agent needs the exact signal-file path and copy-paste commands, since
+// the whole point is that it can save + signal without any further hand-holding.
+function buildWarnPrompt(name: string, ctx: number, cfg: ContextCleanConfig, signalPath: string): string {
+  const k = (n: number) => `${Math.round(n / 1000)}K`
+  return [
+    `[CONTEXT-CLEAN figyelmeztetes] A session-kontextusod elerte a ${k(ctx)} tokent (kuszob ${k(cfg.softThreshold)}).`,
+    `Hamarosan FRISS restart (context-clear) kovetkezik, hogy a session ne lassuljon be es ne fusson limitbe. A restart ELDOBJA a jelenlegi beszelgetest, ezert a mentes rajtad all.`,
+    ``,
+    `TEENDO most:`,
+    `1) Ments el mindent amit meg kell orizned: memoria (/api/memories), hot task state, napi naplo (/api/daily-log). Ha akarod, futtasd a /handoff-ot.`,
+    `2) Ha KESZEN allsz a restartra, jelezd EXPLICIT modon (a runner NEM az idle-bol kovetkeztet):`,
+    `   echo '{"hold":false,"ready":true}' > ${signalPath}`,
+    `3) Ha epp meg-nem-szakithato kritikus lepes kozepen vagy (pl. multi-step git muvelet, fajliras), keslelteshetsz:`,
+    `   echo '{"hold":true,"ready":false}' > ${signalPath}`,
+    `   majd amikor vegeztel, ird at ready-re a 2) paranccsal.`,
+    ``,
+    `Ha ${cfg.graceMinutes} percen belul nem jelzel es nincs aktiv hold, vagy ha a kontextus eleri a ${k(cfg.hardThreshold)}-t, a restart automatikusan megtortenik.`,
+  ].join('\n')
+}
+
+function checkAgent(name: string, nowMs: number): void {
+  // Thresholds default per model: a [1m] agent (like Dex) warms at 400k/500k, a
+  // standard ~200k-window Sonnet agent much lower, so our clean pre-empts the
+  // harness's own auto-compaction instead of never firing.
+  const cfg = readContextCleanConfig(name, readAgentModel(name))
+  if (!cfg.enabled) {
+    states.delete(name)
+    return
+  }
+  // Only running sub-agents are eligible. 'unreachable' (remote laptop briefly
+  // out of reach) and 'stopped' are left alone -- same invariant as auto-restart.
+  if (agentRunState(name) !== 'running') {
+    states.delete(name)
+    return
+  }
+  // Post-restart cooldown: give the fresh session time to rotate its transcript
+  // so a stale reading cannot immediately re-warn.
+  const cleanedAt = lastClean.get(name)
+  if (cleanedAt !== undefined && nowMs - cleanedAt < COOLDOWN_MS) return
+
+  const ctx = readContextTokensFromProjectDir(agentDir(name), readAgentClaudeConfigDir(name) ?? undefined)
+  const state = states.get(name) ?? { ...INITIAL_STATE }
+  const signal = readSignal(name)
+  const action = decideContextClean(cfg, state, ctx, signal, nowMs)
+
+  switch (action) {
+    case 'none':
+    case 'wait':
+      states.set(name, state)
+      return
+
+    case 'reset':
+      states.set(name, { ...INITIAL_STATE })
+      clearSignal(name)
+      logger.info({ name }, 'context-clean: context fell back below soft threshold, flow reset')
+      return
+
+    case 'warn': {
+      const session = agentSessionName(name)
+      const host = readAgentRemoteHost(name)
+      const signalPath = signalPathFor(name)
+      if (!signalPath) {
+        logger.warn({ name }, 'context-clean: unsafe agent name, skipping warn')
+        return
+      }
+      clearSignal(name) // clear any stale signal from a previous flow
+      try {
+        sendPromptToSession(session, buildWarnPrompt(name, ctx ?? 0, cfg, signalPath), host)
+        states.set(name, { phase: 'warned', warnedAtMs: nowMs })
+        logger.info({ name, contextTokens: ctx }, 'context-clean: warned agent, awaiting save + signal')
+      } catch (err) {
+        logger.warn({ err, name }, 'context-clean: warn injection failed, will retry next tick')
+        // Leave state idle so the next tick re-attempts the warn.
+      }
+      return
+    }
+
+    case 'restart': {
+      const session = agentSessionName(name)
+      const host = readAgentRemoteHost(name)
+      // IDLE-GUARD: never cut a live turn. Stay 'warned' and retry next tick.
+      if (!paneIsIdle(session, host)) {
+        logger.info({ name, session }, 'context-clean: restart due but pane is busy, deferring to next tick')
+        states.set(name, state)
+        return
+      }
+      try {
+        restartAgentProcess(name, { fresh: true })
+        lastClean.set(name, nowMs)
+        states.set(name, { ...INITIAL_STATE })
+        clearSignal(name)
+        logger.info({ name }, 'context-clean: fresh restart performed')
+      } catch (err) {
+        logger.warn({ err, name }, 'context-clean: restart failed, will retry next tick')
+        states.set(name, state)
+      }
+      return
+    }
+  }
+}
+
+export function startContextCleanRunner(): NodeJS.Timeout {
+  function sweep() {
+    const now = Date.now()
+    for (const name of listAgentNames()) {
+      try { checkAgent(name, now) } catch (err) { logger.debug({ err, agent: name }, 'context-clean: agent check error') }
+    }
+  }
+  setTimeout(sweep, INITIAL_DELAY_MS)
+  return setInterval(sweep, INTERVAL_MS)
+}

--- a/src/web/context-clean-runner.ts
+++ b/src/web/context-clean-runner.ts
@@ -19,46 +19,77 @@ import {
 import { paneLooksIdle } from '../pane-state.js'
 import { readContextTokensFromProjectDir } from './active-model.js'
 import { readContextCleanConfig } from './context-clean-store.js'
+import { getRecentlyDoneCardsForAssignee } from '../db.js'
 import {
   decideContextClean,
   normalizeSignal,
+  normalizeResumeState,
+  formatResumePrompt,
+  parseHHMM,
+  dailyDueAtMs,
+  restartDue,
   INITIAL_STATE,
   NO_SIGNAL,
   type ContextCleanConfig,
   type ContextCleanState,
+  type ContextCleanTrigger,
   type RestartSignal,
 } from '../context-clean.js'
 
-// Drives per-agent context-size-triggered cleans (see src/context-clean.ts for
-// the why and the pure decision). Mirrors the auto-restart runner: a 60s sweep,
-// offset from the others so tmux calls do not pile onto one tick. Sub-agents
-// only -- the main channels session is launchd-managed and always starts a fresh
-// conversation, so it has no accumulating context to clean here.
+// Drives per-agent context cleans (see src/context-clean.ts for the why and the
+// pure decision). Mirrors the auto-restart runner: a 60s sweep, offset from the
+// others so tmux calls do not pile onto one tick. Sub-agents only -- the main
+// channels session is launchd-managed and always starts a fresh conversation, so
+// it has no accumulating context to clean here.
+//
+// Two trigger sources feed the same safe flow: the token threshold, and an
+// optional schedule (daily time / every-N-hours) held in context-clean's OWN
+// config -- deliberately NOT the legacy abrupt auto-restart loop, so the two
+// watchers can never both fire a restart on one tick.
 //
 // Hard safety rules:
 //   - EXPLICIT-READY: a fresh restart proceeds only on the agent's own signal,
 //     the grace-cap, or the hard threshold -- never inferred from an idle pane.
 //   - IDLE-GUARD: even when a restart is due, never cut a live turn; defer to the
 //     next tick while the pane is busy.
-//   - POST-RESTART COOLDOWN: after a clean, skip the agent for a window so a
-//     stale context reading (or a not-yet-rotated transcript) cannot immediately
-//     re-trigger a second warn.
+//   - AUTO-RESUME: after the clean, the structured task-state the agent saved is
+//     re-injected as its first prompt so it continues where it left off.
+//   - POST-RESTART COOLDOWN: after a clean, skip the trigger logic for a window
+//     so a stale context reading cannot immediately re-warn.
 
 const INITIAL_DELAY_MS = 50_000
 const INTERVAL_MS = 60_000
 const COOLDOWN_MS = 5 * 60_000
+// After a fresh restart the new session needs to boot before it can accept the
+// resume prompt; wait at least this long (and for an idle pane) before injecting.
+const BOOT_GRACE_MS = 45_000
 
 // agent name -> tracked state across ticks.
 const states = new Map<string, ContextCleanState>()
 // agent name -> when it was last context-cleaned (ms), for the cooldown guard.
 const lastClean = new Map<string, number>()
+// agent name -> last schedule-triggered warn (ms). Also seeded on first sight (no
+// warn) so a daily slot that already passed before boot does not fire at startup.
+const lastScheduledWarn = new Map<string, number>()
+// agent name -> high-water (whole seconds) of the newest done card already
+// observed. Seeded on first sight so cards that were already done before boot do
+// not fire a task-boundary clean at startup.
+const lastSeenDoneSec = new Map<string, number>()
+// agent name -> pending auto-resume after a restart (records when the restart
+// happened so we can wait out the boot grace before injecting).
+const pendingResume = new Map<string, { restartedAtMs: number }>()
 
-// Signal-file name is derived from the agent name; guard it so a malformed name
-// can never escape STORE_DIR. Agent names from listAgentNames() are already
-// real directory names, but the whitelist keeps this defensive.
+// File names are derived from the agent name; guard so a malformed name can never
+// escape STORE_DIR. Names from listAgentNames() are already real directory names,
+// but the whitelist keeps this defensive.
+function safeName(name: string): boolean {
+  return /^[a-zA-Z0-9._-]+$/.test(name)
+}
 function signalPathFor(name: string): string | null {
-  if (!/^[a-zA-Z0-9._-]+$/.test(name)) return null
-  return join(STORE_DIR, `restart-signal.${name}.json`)
+  return safeName(name) ? join(STORE_DIR, `restart-signal.${name}.json`) : null
+}
+function resumePathFor(name: string): string | null {
+  return safeName(name) ? join(STORE_DIR, `resume-state.${name}.json`) : null
 }
 
 function readSignal(name: string): RestartSignal {
@@ -71,10 +102,9 @@ function readSignal(name: string): RestartSignal {
   }
 }
 
-function clearSignal(name: string): void {
-  const p = signalPathFor(name)
+function removeFile(p: string | null, name: string, what: string): void {
   if (p && existsSync(p)) {
-    try { rmSync(p) } catch (err) { logger.debug({ err, name }, 'context-clean: signal clear failed') }
+    try { rmSync(p) } catch (err) { logger.debug({ err, name }, `context-clean: ${what} clear failed`) }
   }
 }
 
@@ -84,51 +114,153 @@ function paneIsIdle(session: string, host: string | null): boolean {
   return paneLooksIdle(pane)
 }
 
+function localMidnightMs(nowMs: number): number {
+  const d = new Date(nowMs)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+// When is the next schedule slot due, or null if no schedule is configured.
+// Mirrors the auto-restart runner's computeDueAt so the two behave identically.
+function scheduleDueAt(cfg: ContextCleanConfig, name: string, nowMs: number): number | null {
+  if (cfg.dailyTime) {
+    const mins = parseHHMM(cfg.dailyTime)
+    if (mins === null) return null
+    return dailyDueAtMs(localMidnightMs(nowMs), mins)
+  }
+  if (cfg.intervalHours) {
+    const base = lastScheduledWarn.get(name) ?? nowMs
+    return base + cfg.intervalHours * 3_600_000
+  }
+  return null
+}
+
 // The warn prompt injected into the agent's session. It must be actionable on its
-// own: the agent needs the exact signal-file path and copy-paste commands, since
-// the whole point is that it can save + signal without any further hand-holding.
-function buildWarnPrompt(name: string, ctx: number, cfg: ContextCleanConfig, signalPath: string): string {
+// own: the agent needs the exact signal + resume-state paths and copy-paste
+// commands, since the whole point is that it can save + signal without any
+// further hand-holding.
+function buildWarnPrompt(
+  name: string, ctx: number | null, cfg: ContextCleanConfig,
+  trigger: ContextCleanTrigger, signalPath: string, resumePath: string,
+): string {
   const k = (n: number) => `${Math.round(n / 1000)}K`
+  const why =
+    trigger === 'schedule' ? `Utemezett context-clean esedekes.`
+    : trigger === 'task' ? `Egy hozzad rendelt kanban kartya DONE-ba kerult (feladat-hatar) -- ne vigyuk at a kesz feladat kontextusat a kovetkezobe.`
+    : `A session-kontextusod elerte a ${k(ctx ?? 0)} tokent (kuszob ${k(cfg.softThreshold)}).`
   return [
-    `[CONTEXT-CLEAN figyelmeztetes] A session-kontextusod elerte a ${k(ctx)} tokent (kuszob ${k(cfg.softThreshold)}).`,
+    `[CONTEXT-CLEAN figyelmeztetes] ${why}`,
     `Hamarosan FRISS restart (context-clear) kovetkezik, hogy a session ne lassuljon be es ne fusson limitbe. A restart ELDOBJA a jelenlegi beszelgetest, ezert a mentes rajtad all.`,
     ``,
     `TEENDO most:`,
-    `1) Ments el mindent amit meg kell orizned: memoria (/api/memories), hot task state, napi naplo (/api/daily-log). Ha akarod, futtasd a /handoff-ot.`,
-    `2) Ha KESZEN allsz a restartra, jelezd EXPLICIT modon (a runner NEM az idle-bol kovetkeztet):`,
+    `1) Ments el mindent amit meg kell orizned: memoria (/api/memories), napi naplo (/api/daily-log).`,
+    `2) Strukturalt resume-state, hogy a restart UTAN automatikusan folytasd (a runner ezt injektalja elso promptkent):`,
+    `   echo '{"activeTask":"...","currentStep":"...","relevantFiles":["..."],"nextAction":"...","notes":"..."}' > ${resumePath}`,
+    `3) Ha KESZEN allsz a restartra, jelezd EXPLICIT modon (a runner NEM az idle-bol kovetkeztet):`,
     `   echo '{"hold":false,"ready":true}' > ${signalPath}`,
-    `3) Ha epp meg-nem-szakithato kritikus lepes kozepen vagy (pl. multi-step git muvelet, fajliras), keslelteshetsz:`,
+    `4) Ha epp meg-nem-szakithato kritikus lepes kozepen vagy (pl. multi-step git muvelet, fajliras), keslelteshetsz:`,
     `   echo '{"hold":true,"ready":false}' > ${signalPath}`,
-    `   majd amikor vegeztel, ird at ready-re a 2) paranccsal.`,
+    `   majd amikor vegeztel, ird at ready-re a 3) paranccsal.`,
     ``,
-    `Ha ${cfg.graceMinutes} percen belul nem jelzel es nincs aktiv hold, vagy ha a kontextus eleri a ${k(cfg.hardThreshold)}-t, a restart automatikusan megtortenik.`,
+    `Ha ${cfg.graceMinutes} percen belul nem jelzel es nincs aktiv hold, a restart automatikusan megtortenik${trigger === 'token' ? `, vagy ha a kontextus eleri a ${k(cfg.hardThreshold)}-t` : ''}.`,
   ].join('\n')
 }
 
+// After a fresh restart, inject the saved structured task-state so the agent
+// resumes on its own. No-op (beyond clearing the pending flag) if the agent never
+// wrote a resume file or it carries no usable content.
+function tryInjectResume(name: string, session: string, host: string | null): void {
+  const p = resumePathFor(name)
+  let rs = null
+  if (p && existsSync(p)) {
+    try { rs = normalizeResumeState(JSON.parse(readFileSync(p, 'utf-8'))) } catch { rs = null }
+  }
+  if (rs) {
+    try {
+      sendPromptToSession(session, formatResumePrompt(rs), host)
+      logger.info({ name, activeTask: rs.activeTask }, 'context-clean: auto-resume injected after restart')
+    } catch (err) {
+      logger.warn({ err, name }, 'context-clean: resume injection failed')
+    }
+  }
+  removeFile(p, name, 'resume-state')
+  pendingResume.delete(name)
+}
+
 function checkAgent(name: string, nowMs: number): void {
-  // Thresholds default per model: a [1m] agent (like Dex) warms at 400k/500k, a
-  // standard ~200k-window Sonnet agent much lower, so our clean pre-empts the
-  // harness's own auto-compaction instead of never firing.
   const cfg = readContextCleanConfig(name, readAgentModel(name))
   if (!cfg.enabled) {
     states.delete(name)
+    lastScheduledWarn.delete(name)
+    lastSeenDoneSec.delete(name)
+    pendingResume.delete(name)
     return
   }
+
+  // A pending auto-resume takes priority and survives the brief not-running gap
+  // while the fresh session boots. Once the agent is back and settled, inject.
+  const resume = pendingResume.get(name)
+  if (resume) {
+    if (agentRunState(name) !== 'running') return           // still booting
+    if (nowMs - resume.restartedAtMs < BOOT_GRACE_MS) return // give it time to boot
+    const session = agentSessionName(name)
+    const host = readAgentRemoteHost(name)
+    if (!paneIsIdle(session, host)) return                  // wait for a settled prompt
+    tryInjectResume(name, session, host)
+    return
+  }
+
   // Only running sub-agents are eligible. 'unreachable' (remote laptop briefly
   // out of reach) and 'stopped' are left alone -- same invariant as auto-restart.
   if (agentRunState(name) !== 'running') {
     states.delete(name)
     return
   }
+
+  // Seed the schedule + task-boundary high-water on first sight so a daily slot
+  // or a card that was already done before boot does not fire now (mirrors
+  // auto-restart's seed-on-first-sight).
+  if (!lastScheduledWarn.has(name)) lastScheduledWarn.set(name, nowMs)
+  const nowSec = Math.floor(nowMs / 1000)
+  if (!lastSeenDoneSec.has(name)) lastSeenDoneSec.set(name, nowSec)
+
+  const state = states.get(name) ?? { ...INITIAL_STATE }
+
+  // Observe assigned cards that reached done since we last looked, then ALWAYS
+  // advance the high-water so each done card is consumed exactly once -- even
+  // while warned or in cooldown, so a card that finished mid-flow can never
+  // re-fire a redundant clean right after the current one.
+  let taskBoundaryObserved = false
+  try {
+    const done = getRecentlyDoneCardsForAssignee(name, lastSeenDoneSec.get(name) ?? nowSec)
+    if (done.length > 0) {
+      taskBoundaryObserved = true
+      logger.info({ name, cards: done.map(c => c.id) }, 'context-clean: task-boundary (assigned card(s) done)')
+    }
+  } catch (err) {
+    logger.debug({ err, name }, 'context-clean: done-card query failed')
+  }
+  lastSeenDoneSec.set(name, nowSec)
+
   // Post-restart cooldown: give the fresh session time to rotate its transcript
-  // so a stale reading cannot immediately re-warn.
+  // so a stale reading cannot immediately re-warn. (The high-water above is
+  // already advanced, so a card done during cooldown is consumed, not re-fired.)
   const cleanedAt = lastClean.get(name)
   if (cleanedAt !== undefined && nowMs - cleanedAt < COOLDOWN_MS) return
 
   const ctx = readContextTokensFromProjectDir(agentDir(name), readAgentClaudeConfigDir(name) ?? undefined)
-  const state = states.get(name) ?? { ...INITIAL_STATE }
   const signal = readSignal(name)
-  const action = decideContextClean(cfg, state, ctx, signal, nowMs)
+
+  // Non-token triggers only matter from the idle phase (a warn already in flight
+  // must not be re-armed by a passing slot or a card completing mid-flow).
+  let scheduleDue = false
+  const taskBoundaryDue = state.phase === 'idle' && taskBoundaryObserved
+  if (state.phase === 'idle') {
+    const dueAt = scheduleDueAt(cfg, name, nowMs)
+    if (dueAt !== null) scheduleDue = restartDue(lastScheduledWarn.get(name) ?? null, nowMs, dueAt)
+  }
+
+  const action = decideContextClean(cfg, state, ctx, signal, nowMs, scheduleDue || taskBoundaryDue)
 
   switch (action) {
     case 'none':
@@ -138,7 +270,7 @@ function checkAgent(name: string, nowMs: number): void {
 
     case 'reset':
       states.set(name, { ...INITIAL_STATE })
-      clearSignal(name)
+      removeFile(signalPathFor(name), name, 'signal')
       logger.info({ name }, 'context-clean: context fell back below soft threshold, flow reset')
       return
 
@@ -146,15 +278,24 @@ function checkAgent(name: string, nowMs: number): void {
       const session = agentSessionName(name)
       const host = readAgentRemoteHost(name)
       const signalPath = signalPathFor(name)
-      if (!signalPath) {
+      const resumePath = resumePathFor(name)
+      if (!signalPath || !resumePath) {
         logger.warn({ name }, 'context-clean: unsafe agent name, skipping warn')
         return
       }
-      clearSignal(name) // clear any stale signal from a previous flow
+      // Clear any stale signal / resume from a previous flow before this one.
+      removeFile(signalPath, name, 'signal')
+      removeFile(resumePath, name, 'resume-state')
+      // Precedence when several fired on the same tick: token > task > schedule.
+      const trigger: ContextCleanTrigger =
+        (ctx !== null && ctx >= cfg.softThreshold) ? 'token'
+        : taskBoundaryDue ? 'task'
+        : 'schedule'
+      if (trigger === 'schedule') lastScheduledWarn.set(name, nowMs)
       try {
-        sendPromptToSession(session, buildWarnPrompt(name, ctx ?? 0, cfg, signalPath), host)
-        states.set(name, { phase: 'warned', warnedAtMs: nowMs })
-        logger.info({ name, contextTokens: ctx }, 'context-clean: warned agent, awaiting save + signal')
+        sendPromptToSession(session, buildWarnPrompt(name, ctx, cfg, trigger, signalPath, resumePath), host)
+        states.set(name, { phase: 'warned', warnedAtMs: nowMs, trigger })
+        logger.info({ name, contextTokens: ctx, trigger }, 'context-clean: warned agent, awaiting save + signal')
       } catch (err) {
         logger.warn({ err, name }, 'context-clean: warn injection failed, will retry next tick')
         // Leave state idle so the next tick re-attempts the warn.
@@ -174,9 +315,12 @@ function checkAgent(name: string, nowMs: number): void {
       try {
         restartAgentProcess(name, { fresh: true })
         lastClean.set(name, nowMs)
+        // Queue the auto-resume; the saved resume-state file (if any) survives the
+        // restart on disk and gets injected once the fresh session boots.
+        pendingResume.set(name, { restartedAtMs: nowMs })
         states.set(name, { ...INITIAL_STATE })
-        clearSignal(name)
-        logger.info({ name }, 'context-clean: fresh restart performed')
+        removeFile(signalPathFor(name), name, 'signal')
+        logger.info({ name }, 'context-clean: fresh restart performed, auto-resume queued')
       } catch (err) {
         logger.warn({ err, name }, 'context-clean: restart failed, will retry next tick')
         states.set(name, state)

--- a/src/web/context-clean-store.ts
+++ b/src/web/context-clean-store.ts
@@ -1,0 +1,46 @@
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { PROJECT_ROOT } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+import {
+  normalizeContextCleanConfig,
+  defaultContextCleanForModel,
+  type ContextCleanConfig,
+} from '../context-clean.js'
+
+// Per-agent context-clean config lives in one JSON map keyed by agent name,
+// mirroring auto-restart.json. An agent with no entry gets the model-appropriate
+// default (a [1m] model warms at 400k/500k; a standard ~200k-window model far
+// lower, at 120k/160k), so the feature works out of the box and is tunable per
+// agent by editing this file.
+const STORE_PATH = join(PROJECT_ROOT, 'store', 'context-clean.json')
+
+function readRaw(): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(readFileSync(STORE_PATH, 'utf-8'))
+    return (parsed && typeof parsed === 'object') ? parsed as Record<string, unknown> : {}
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * One agent's config, normalized. When there is no explicit entry, the
+ * model-appropriate default is returned (pass the agent's resolved model id so a
+ * standard-window model gets the lower thresholds). A partial explicit entry
+ * falls back field-by-field onto that same model-appropriate base.
+ */
+export function readContextCleanConfig(name: string, model?: string | null): ContextCleanConfig {
+  const base = defaultContextCleanForModel(model)
+  const raw = readRaw()
+  return name in raw ? normalizeContextCleanConfig(raw[name], base) : base
+}
+
+/** Persist one agent's config (normalized first so the store stays clean). */
+export function writeContextCleanConfig(name: string, cfg: unknown, model?: string | null): ContextCleanConfig {
+  const normalized = normalizeContextCleanConfig(cfg, defaultContextCleanForModel(model))
+  const raw = readRaw()
+  raw[name] = normalized
+  atomicWriteFileSync(STORE_PATH, JSON.stringify(raw, null, 2))
+  return normalized
+}


### PR DESCRIPTION
Adds an opt-in context-window auto-management flow for long-running agent sessions.

When an agent's context approaches the hard-compact threshold, instead of silently degrading it runs a safe **warn -> save -> restart -> structured auto-resume** sequence:
- size-triggered detection (with multiple trigger sources in v2)
- persists a structured resume record so the fresh session continues where it left off instead of restarting the task
- fires on task boundaries too (e.g. when an agent finishes a kanban card)

Self-contained: `src/context-clean.ts`, `src/web/context-clean-runner.ts`, a small `db.ts` helper (`getRecentlyDoneCardsForAssignee`), and 50 unit tests. No change to existing behaviour unless enabled.

Cherry-picked clean onto `develop`; `tsc --noEmit` green, context-clean suite 50/50.