### PR TITLE
fix(scripts): rename TMUX -> TMUX_BIN in watchdog scripts (stop env clobber)

### DIFF
--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -46,9 +46,11 @@ MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"
 MAIN_AGENT_ID="${MAIN_AGENT_ID//[^a-zA-Z0-9_-]/}"
 SESSION="${MAIN_AGENT_ID}-channels"
 
-TMUX="$(command -v tmux)"
+# NB: use TMUX_BIN, not TMUX -- the latter is tmux's own env var (socket,pid,
+# session); assigning the binary path to it corrupts server-socket detection.
+TMUX_BIN="$(command -v tmux)"
 CLAUDE="$(command -v claude)"
-if [ -z "$TMUX" ] || [ -z "$CLAUDE" ]; then
+if [ -z "$TMUX_BIN" ] || [ -z "$CLAUDE" ]; then
   log "tmux or claude not on PATH; cannot act. PATH=$PATH"
   exit 0
 fi
@@ -56,7 +58,7 @@ fi
 now=$(date +%s)
 
 # --- gate 1: the channels session must EXIST (bridge "running") ---
-if ! "$TMUX" has-session -t "$SESSION" 2>/dev/null; then
+if ! "$TMUX_BIN" has-session -t "$SESSION" 2>/dev/null; then
   log "session $SESSION not present -- systemd marveen-channels.service owns (re)start; watchdog no-op"
   exit 0
 fi
@@ -108,7 +110,7 @@ MODEL_FLAG=""
 RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && $CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:telegram@claude-plugins-official"
 
 log "keepalive stale ${age}s (>${STALE_SECONDS}s) and session up -- respawn-pane $SESSION (respawn #$((count+1)))"
-if "$TMUX" respawn-pane -k -t "$SESSION" "$RESPAWN_CMD" 2>/dev/null; then
+if "$TMUX_BIN" respawn-pane -k -t "$SESSION" "$RESPAWN_CMD" 2>/dev/null; then
   date +%s > "$RESPAWN_STAMP"
   echo $(( count + 1 )) > "$RESPAWN_COUNT_FILE"
   log "respawn-pane issued"

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -135,10 +135,12 @@ alert_owner() {
 
 # --- live guard ----------------------------------------------------------------
 run_guard() {
-  local TMUX CLAUDE MAIN_AGENT_ID SESSION pane state firstseen now action
+  local TMUX_BIN CLAUDE MAIN_AGENT_ID SESSION pane state firstseen now action
 
-  TMUX="$(command -v tmux)"; CLAUDE="$(command -v claude)"
-  if [ -z "$TMUX" ]; then log "tmux not on PATH; cannot act"; return 0; fi
+  # NB: use TMUX_BIN, not TMUX -- the latter is tmux's own env var (socket,pid,
+  # session); assigning the binary path to it corrupts server-socket detection.
+  TMUX_BIN="$(command -v tmux)"; CLAUDE="$(command -v claude)"
+  if [ -z "$TMUX_BIN" ]; then log "tmux not on PATH; cannot act"; return 0; fi
 
   # Ensure the state dir exists BEFORE any stamp/lock write. Without it, a cold
   # install / post-cleanup run fails `exec 9>` on the lock file; flock then reads
@@ -162,9 +164,9 @@ run_guard() {
   if [ -z "$SESSION" ]; then
     log "no channels session configured (set CHANNELS_SESSION or MAIN_AGENT_ID in .env) -- no-op"; return 0
   fi
-  "$TMUX" has-session -t "$SESSION" 2>/dev/null || { log "session $SESSION absent -- no-op"; return 0; }
+  "$TMUX_BIN" has-session -t "$SESSION" 2>/dev/null || { log "session $SESSION absent -- no-op"; return 0; }
 
-  pane="$("$TMUX" capture-pane -t "$SESSION" -p 2>/dev/null || true)"
+  pane="$("$TMUX_BIN" capture-pane -t "$SESSION" -p 2>/dev/null || true)"
   state="$(printf '%s' "$pane" | classify_pane)"
   now="$(date +%s)"
   firstseen=0; [ -f "$FIRSTSEEN_STAMP" ] && firstseen="$(cat "$FIRSTSEEN_STAMP" 2>/dev/null || echo 0)"
@@ -192,14 +194,14 @@ run_guard() {
   # --- recovery: Escape (bounded), like ensure_modal_closed --------------------
   local i p
   for i in $(seq 1 "$MAX_ESCAPES"); do
-    p="$("$TMUX" capture-pane -t "$SESSION" -p 2>/dev/null || true)"
+    p="$("$TMUX_BIN" capture-pane -t "$SESSION" -p 2>/dev/null || true)"
     case "$(printf '%s' "$p" | classify_pane)" in
       idle|busy) log "modal closed via Escape -- session healthy"; rm -f "$FIRSTSEEN_STAMP" 2>/dev/null || true; return 0 ;;
     esac
-    "$TMUX" send-keys -t "$SESSION" Escape 2>/dev/null || true
+    "$TMUX_BIN" send-keys -t "$SESSION" Escape 2>/dev/null || true
     sleep 0.5
   done
-  p="$("$TMUX" capture-pane -t "$SESSION" -p 2>/dev/null || true)"
+  p="$("$TMUX_BIN" capture-pane -t "$SESSION" -p 2>/dev/null || true)"
   case "$(printf '%s' "$p" | classify_pane)" in
     idle|busy) log "modal closed via Escape -- session healthy"; rm -f "$FIRSTSEEN_STAMP" 2>/dev/null || true; return 0 ;;
   esac
@@ -256,7 +258,7 @@ run_guard() {
   log "stuck modal not cleared by Escape -- respawn-pane $SESSION (respawn #$((count+1)))"
   # G: alert ONLY after the respawn-pane actually succeeds, so a failed respawn
   # never sends the owner a false "respawned" message.
-  if [ -n "$CLAUDE" ] && "$TMUX" respawn-pane -k -t "$SESSION" "$RESPAWN_CMD" 2>/dev/null; then
+  if [ -n "$CLAUDE" ] && "$TMUX_BIN" respawn-pane -k -t "$SESSION" "$RESPAWN_CMD" 2>/dev/null; then
     date +%s > "$RESPAWN_STAMP" 2>/dev/null || true
     echo $(( count + 1 )) > "$RESPAWN_COUNT_FILE" 2>/dev/null || true
     rm -f "$FIRSTSEEN_STAMP" 2>/dev/null || true


### PR DESCRIPTION
Generic bugfix. The watchdog scripts set a shell variable named `TMUX` (`TMUX="$(command -v tmux)"`). But `TMUX` is a reserved tmux environment variable: overriding it with the binary path breaks tmux's own server-socket detection, so tmux commands inside the watchdog can target the wrong/absent server. Renaming the variable to `TMUX_BIN` stops the clobber.

Two scripts (`channel-watchdog.sh`, `stuck-modal-guard.sh`), pure rename, no behaviour change other than fixing the clobber.