### PR TITLE
fix: improve WSL host stability handling

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1174,6 +1174,11 @@ cat >"$SYSTEMD_DIR/${CHAN_UNIT}.service" <<EOF
 [Unit]
 Description=${BOT_NAME} Channels (Telegram bridge)
 After=network.target
+# StartLimit* belong in [Unit], not [Service] (systemd logs "Unknown key
+# StartLimitIntervalSec in section [Service]" and ignores them there), so the
+# crash-loop throttle only applies when they live here.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -1191,8 +1196,6 @@ ExecStartPre=$INSTALL_DIR/scripts/ensure-native-modules.sh
 ExecStart=$INSTALL_DIR/scripts/channels.sh
 Restart=on-failure
 RestartSec=10
-StartLimitIntervalSec=300
-StartLimitBurst=5
 StandardOutput=append:$INSTALL_DIR/store/channels.log
 StandardError=append:$INSTALL_DIR/store/channels.error.log
 Environment=PATH=$HOME/.local/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin
@@ -1234,6 +1237,57 @@ Persistent=true
 WantedBy=timers.target
 EOF
 
+# marveen-host-watchdog.service -- host/WSL-VM restart detector (btime-based).
+# Distinguishes a whole-VM restart (all units down at once, NOT an app crash)
+# from a service crash, and Telegrams it. See scripts/host-restart-watchdog.sh.
+cat >"$SYSTEMD_DIR/${SERVICE_ID}-host-watchdog.service" <<EOF
+[Unit]
+Description=${BOT_NAME} host/WSL-VM restart watchdog (btime-based)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$INSTALL_DIR/scripts/host-restart-watchdog.sh
+Environment=MARVEEN_STORE=$INSTALL_DIR/store
+Environment=TELEGRAM_ENV=$HOME/.claude/channels/telegram/.env
+Environment=PATH=$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME=$HOME
+${TZ_LINE}
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target
+EOF
+
+# marveen-notify@.service -- templated app-crash notifier, fired by OnFailure=
+# drop-ins on the dashboard/channels units. OnFailure => app crash (vs the
+# host-watchdog's btime-change => host restart).
+cat >"$SYSTEMD_DIR/${SERVICE_ID}-notify@.service" <<EOF
+[Unit]
+Description=${BOT_NAME} app-crash notifier for %i
+
+[Service]
+Type=oneshot
+ExecStart=$INSTALL_DIR/scripts/unit-fail-notify.sh %i
+Environment=TELEGRAM_ENV=$HOME/.claude/channels/telegram/.env
+Environment=PATH=$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME=$HOME
+${TZ_LINE}
+StandardOutput=journal
+StandardError=journal
+EOF
+
+# OnFailure drop-ins: wire the app-crash notifier onto the two long-running units.
+for u in "${DASH_UNIT}" "${CHAN_UNIT}"; do
+  mkdir -p "$SYSTEMD_DIR/${u}.service.d"
+  cat >"$SYSTEMD_DIR/${u}.service.d/onfailure.conf" <<EOF
+[Unit]
+OnFailure=${SERVICE_ID}-notify@%n.service
+EOF
+done
+
 # 1. linger eloszor: ez engedelyezi a user systemd sessiont boot utan is,
 #    es headless-en az aktualis script futasa alatt is szukseges lehet
 if loginctl show-user "$USER" 2>/dev/null | grep -q "Linger=yes"; then
@@ -1262,7 +1316,7 @@ fi
 SVCFAIL=0
 if pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
   systemctl --user daemon-reload
-  systemctl --user enable "${DASH_UNIT}" "${CHAN_UNIT}" "${MORN_UNIT}.timer" 2>/dev/null || true
+  systemctl --user enable "${DASH_UNIT}" "${CHAN_UNIT}" "${MORN_UNIT}.timer" "${SERVICE_ID}-host-watchdog.service" 2>/dev/null || true
   ok "systemd unitok generalva es engedelyezve"
   systemctl --user start "${DASH_UNIT}" "${CHAN_UNIT}" 2>/dev/null || true
   sleep 2

--- a/scripts/host-restart-watchdog.sh
+++ b/scripts/host-restart-watchdog.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# host-restart-watchdog.sh
+#
+# Fires once at every user-manager start (oneshot, WantedBy=default.target).
+# Under WSL2 the whole utility VM can shut down and re-boot (vmIdleTimeout
+# auto-shutdown, Windows sleep/resume, `wsl --shutdown`), which tears down the
+# kernel + system/user systemd + tmux + dashboard + channels all at once and is
+# NOT an application crash. This watchdog detects that host/VM restart via the
+# kernel boot time (/proc/stat btime) and sends ONE Telegram notice that names
+# it as a host/WSL-VM restart (with an estimated downtime), so a fleet-wide
+# silence is never mistaken for a CostOps/app crash.
+#
+# App/service crashes do NOT change btime and never trigger this script -- they
+# are reported separately by the OnFailure= drop-ins (marveen-notify@.service).
+# That split is the whole point: btime-change => host restart; OnFailure => app.
+#
+# Safe by construction: read-only except for the state file; Telegram send is
+# best-effort; the script always exits 0 so the oneshot unit never enters
+# `failed` (a failing watchdog would itself look like an incident).
+
+set -uo pipefail
+
+STATE_DIR="${MARVEEN_STORE:-$HOME/marveen/store}"
+STATE_FILE="$STATE_DIR/.last-btime"
+ENV_FILE="${TELEGRAM_ENV:-$HOME/.claude/channels/telegram/.env}"
+CHAT_ID="${MARVEEN_ALERT_CHAT_ID:-8942301795}"
+
+log() { echo "[host-restart-watchdog] $*"; }
+
+# Current kernel boot epoch (changes only on a real (re)boot of the VM/host).
+btime="$(awk '/^btime/{print $2}' /proc/stat 2>/dev/null)"
+if [[ -z "${btime:-}" ]]; then
+  log "no btime in /proc/stat; nothing to do"
+  exit 0
+fi
+
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+prev=""
+[[ -f "$STATE_FILE" ]] && prev="$(tr -dc '0-9' <"$STATE_FILE" 2>/dev/null)"
+
+# Persist the current btime for the next run no matter what happens below.
+echo "$btime" >"$STATE_FILE" 2>/dev/null || true
+
+if [[ -z "$prev" ]]; then
+  log "baseline initialised (btime=$btime); no alert on first run"
+  exit 0
+fi
+
+if [[ "$prev" == "$btime" ]]; then
+  log "btime unchanged ($btime) -- user-manager restart without a host reboot; no alert"
+  exit 0
+fi
+
+# --- host/VM restart detected (btime changed) ---
+boot_local="$(date -d "@$btime" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo "@$btime")"
+
+# Estimate downtime: newest store/*.log mtime that predates this boot ~= last
+# fleet activity before the VM went down. gap = boot_time - that mtime.
+last_alive=0
+if compgen -G "$STATE_DIR/*.log" >/dev/null 2>&1; then
+  for f in "$STATE_DIR"/*.log; do
+    m="$(stat -c '%Y' "$f" 2>/dev/null || echo 0)"
+    if (( m < btime && m > last_alive )); then last_alive="$m"; fi
+  done
+fi
+gap_txt="ismeretlen"
+if (( last_alive > 0 )); then
+  gap_min=$(( (btime - last_alive) / 60 ))
+  last_txt="$(date -d "@$last_alive" '+%H:%M:%S' 2>/dev/null || echo '?')"
+  gap_txt="~${gap_min} perc (utolsó aktivitás ${last_txt} előtt)"
+fi
+
+msg="Marveen host / WSL VM restarted.
+Új boot: ${boot_local}
+Becsült kiesés: ${gap_txt}
+(Ez host/VM szintű restart, NEM app-crash. A dashboard/channels app-crash külön OnFailure-értesítést küld.)"
+
+log "host restart detected: prev btime=$prev new=$btime; sending Telegram"
+
+# Best-effort Telegram send. Never let a send failure fail the unit.
+token=""
+if [[ -f "$ENV_FILE" ]]; then
+  token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r\n')"
+fi
+if [[ -n "$token" ]]; then
+  curl -s --max-time 15 \
+    "https://api.telegram.org/bot${token}/sendMessage" \
+    --data-urlencode "chat_id=${CHAT_ID}" \
+    --data-urlencode "text=${msg}" >/dev/null 2>&1 \
+    && log "Telegram sent" || log "Telegram send failed (best-effort)"
+else
+  log "no TELEGRAM_BOT_TOKEN in $ENV_FILE; skipping Telegram (host restart still logged)"
+fi
+
+exit 0

--- a/scripts/host-restart-watchdog.sh
+++ b/scripts/host-restart-watchdog.sh
@@ -23,9 +23,22 @@ set -uo pipefail
 STATE_DIR="${MARVEEN_STORE:-$HOME/marveen/store}"
 STATE_FILE="$STATE_DIR/.last-btime"
 ENV_FILE="${TELEGRAM_ENV:-$HOME/.claude/channels/telegram/.env}"
-CHAT_ID="${MARVEEN_ALERT_CHAT_ID:-8942301795}"
+# Alert target chat-id -- MUST come from the install's own config; there is
+# deliberately NO hardcoded fallback (a hardcoded id would make every downstream
+# install send its host-stability alerts to that one private chat).
+CHAT_ID="${MARVEEN_ALERT_CHAT_ID:-}"
 
 log() { echo "[host-restart-watchdog] $*"; }
+
+# Real WSL check -- only under WSL is a whole-VM reboot the expected surprise;
+# on a bare-metal/other Linux host a btime change is an ordinary reboot, so we
+# word the alert accordingly instead of always claiming "WSL VM restarted".
+if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null \
+   || [[ -n "${WSL_DISTRO_NAME:-}" ]] || [[ -e /run/WSL ]]; then
+  HOST_KIND="WSL VM"
+else
+  HOST_KIND="host"
+fi
 
 # Current kernel boot epoch (changes only on a real (re)boot of the VM/host).
 btime="$(awk '/^btime/{print $2}' /proc/stat 2>/dev/null)"
@@ -70,7 +83,7 @@ if (( last_alive > 0 )); then
   gap_txt="~${gap_min} perc (utolsó aktivitás ${last_txt} előtt)"
 fi
 
-msg="Marveen host / WSL VM restarted.
+msg="Marveen ${HOST_KIND} restarted.
 Új boot: ${boot_local}
 Becsült kiesés: ${gap_txt}
 (Ez host/VM szintű restart, NEM app-crash. A dashboard/channels app-crash külön OnFailure-értesítést küld.)"
@@ -82,14 +95,14 @@ token=""
 if [[ -f "$ENV_FILE" ]]; then
   token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r\n')"
 fi
-if [[ -n "$token" ]]; then
+if [[ -n "$token" && -n "$CHAT_ID" ]]; then
   curl -s --max-time 15 \
     "https://api.telegram.org/bot${token}/sendMessage" \
     --data-urlencode "chat_id=${CHAT_ID}" \
     --data-urlencode "text=${msg}" >/dev/null 2>&1 \
     && log "Telegram sent" || log "Telegram send failed (best-effort)"
 else
-  log "no TELEGRAM_BOT_TOKEN in $ENV_FILE; skipping Telegram (host restart still logged)"
+  log "skipping Telegram (${HOST_KIND} restart still logged): missing${token:+}$( [[ -z "$token" ]] && echo ' TELEGRAM_BOT_TOKEN(via TELEGRAM_ENV)')$( [[ -z "$CHAT_ID" ]] && echo ' MARVEEN_ALERT_CHAT_ID')"
 fi
 
 exit 0

--- a/scripts/systemd/README-host-stability.md
+++ b/scripts/systemd/README-host-stability.md
@@ -1,0 +1,47 @@
+# Host stability: WSL-VM restart detection + crash-loop throttle
+
+Root cause of the 2026-07-07 fleet-wide silence: the whole **WSL2 utility VM**
+shut down (19:18:14 CEST) and re-booted (19:23:57 CEST) -- `journalctl
+--list-boots` shows boot `-1` ending and boot `0` starting with a fresh kernel.
+That tears down the kernel, system + user systemd, tmux, dashboard and channels
+at once. It is **not** an application crash, and `Linger=yes` does not protect
+against it (linger only survives session logout, not a VM teardown).
+
+Under WSL2 a VM teardown is triggered from the **Windows side**, never from
+inside the VM: `vmIdleTimeout` auto-shutdown (VM stops shortly after the last
+WSL handle/terminal closes), Windows sleep/hibernate -> resume, `wsl
+--shutdown`, a Windows/WSL update, or VM OOM.
+
+## Pieces installed here
+
+| File | Role |
+|------|------|
+| `host-restart-watchdog.sh` + `marveen-host-watchdog.service` | oneshot at every user-manager start; if `/proc/stat btime` changed vs `store/.last-btime`, Telegrams "host/WSL VM restarted" with an estimated downtime. btime-change => host restart. |
+| `unit-fail-notify.sh` + `marveen-notify@.service` | instantiated by `OnFailure=marveen-notify@%n.service` drop-ins on the dashboard/channels units; Telegrams "app-crash: <unit> FAILED". OnFailure => app crash. |
+| `marveen-channels.service` StartLimit fix | `StartLimitIntervalSec`/`StartLimitBurst` moved from `[Service]` (where systemd logged "Unknown key ... in section [Service]" and ignored them) to `[Unit]`, so the crash-loop throttle actually applies. |
+
+The two notifiers deliberately use different triggers so a fleet-wide silence
+can be classified: **btime change = host/VM restart**, **OnFailure = app crash**.
+
+## Windows-side fix (do NOT automate from Linux)
+
+To stop the VM from auto-shutting-down when idle, edit on the Windows host:
+
+    %UserProfile%\.wslconfig
+
+    [wsl2]
+    vmIdleTimeout=-1
+
+Then `wsl --shutdown` once from Windows for it to take effect. This is a Windows
+filesystem change under `/mnt/c` and must be made by the user on Windows -- the
+Linux side must not write it automatically.
+
+## Rollback
+
+    systemctl --user disable --now marveen-host-watchdog.service
+    rm ~/.config/systemd/user/marveen-host-watchdog.service
+    rm -rf ~/.config/systemd/user/marveen-dashboard.service.d/onfailure.conf \
+           ~/.config/systemd/user/marveen-channels.service.d/onfailure.conf
+    rm ~/.config/systemd/user/marveen-notify@.service
+    # revert the channels StartLimit move by reinstalling the previous unit, then:
+    systemctl --user daemon-reload

--- a/scripts/systemd/marveen-host-watchdog.service
+++ b/scripts/systemd/marveen-host-watchdog.service
@@ -1,0 +1,25 @@
+# NOTE: replace /path/to/marveen (install dir) and /home/USER (home) with your values.
+# Host / WSL-VM restart watchdog. Runs once at every user-manager start and, if
+# the kernel boot time (/proc/stat btime) changed since the last run, sends one
+# Telegram notice that the whole host/VM restarted (distinct from an app crash,
+# which is reported by marveen-notify@.service via OnFailure=). See
+# scripts/host-restart-watchdog.sh and scripts/systemd/README-host-stability.md.
+[Unit]
+Description=Marveen host/WSL-VM restart watchdog (btime-based)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/path/to/marveen/scripts/host-restart-watchdog.sh
+Environment=MARVEEN_STORE=/path/to/marveen/store
+Environment=TELEGRAM_ENV=/home/USER/.claude/channels/telegram/.env
+Environment=PATH=/home/USER/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME=/home/USER
+Environment=TZ=Europe/Budapest
+# journal only: the store/ dir or disk may not be ready/writable this early.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/marveen-notify@.service
+++ b/scripts/systemd/marveen-notify@.service
@@ -1,0 +1,20 @@
+# NOTE: replace /path/to/marveen (install dir) and /home/USER (home) with your values.
+# Templated app-crash notifier. Instantiated by an `OnFailure=` line on a unit,
+# e.g. a drop-in on marveen-dashboard.service / marveen-channels.service:
+#   [Unit]
+#   OnFailure=marveen-notify@%n.service
+# %i carries the failed unit's name. Reports an APP/service crash -- distinct
+# from a host/WSL-VM restart (host-restart-watchdog.sh). See
+# scripts/systemd/README-host-stability.md.
+[Unit]
+Description=Marveen app-crash notifier for %i
+
+[Service]
+Type=oneshot
+ExecStart=/path/to/marveen/scripts/unit-fail-notify.sh %i
+Environment=TELEGRAM_ENV=/home/USER/.claude/channels/telegram/.env
+Environment=PATH=/home/USER/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME=/home/USER
+Environment=TZ=Europe/Budapest
+StandardOutput=journal
+StandardError=journal

--- a/scripts/unit-fail-notify.sh
+++ b/scripts/unit-fail-notify.sh
@@ -13,7 +13,10 @@ set -uo pipefail
 
 UNIT="${1:-unknown.unit}"
 ENV_FILE="${TELEGRAM_ENV:-$HOME/.claude/channels/telegram/.env}"
-CHAT_ID="${MARVEEN_ALERT_CHAT_ID:-8942301795}"
+# Alert target chat-id -- MUST be provided by the install's own config; there is
+# deliberately NO hardcoded fallback (a hardcoded id would make every downstream
+# install send its alerts to that one private chat via its own bot token).
+CHAT_ID="${MARVEEN_ALERT_CHAT_ID:-}"
 
 now_local="$(date '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo now)"
 msg="Marveen app-crash: a(z) ${UNIT} unit FAILED állapotba került (${now_local}).
@@ -23,10 +26,14 @@ token=""
 if [[ -f "$ENV_FILE" ]]; then
   token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r\n')"
 fi
-if [[ -n "$token" ]]; then
+if [[ -n "$token" && -n "$CHAT_ID" ]]; then
   curl -s --max-time 15 \
     "https://api.telegram.org/bot${token}/sendMessage" \
     --data-urlencode "chat_id=${CHAT_ID}" \
     --data-urlencode "text=${msg}" >/dev/null 2>&1 || true
+else
+  # Not silent: name the missing piece so a misconfigured install is diagnosable.
+  miss=""; [[ -z "$token" ]] && miss+=" TELEGRAM_BOT_TOKEN(via TELEGRAM_ENV=$ENV_FILE)"; [[ -z "$CHAT_ID" ]] && miss+=" MARVEEN_ALERT_CHAT_ID"
+  echo "[unit-fail-notify] ${UNIT} FAILED but no Telegram sent -- missing:${miss}" >&2
 fi
 exit 0

--- a/scripts/unit-fail-notify.sh
+++ b/scripts/unit-fail-notify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# unit-fail-notify.sh <unit-name>
+#
+# Called by marveen-notify@.service via `OnFailure=marveen-notify@%n.service`
+# drop-ins on marveen-dashboard.service / marveen-channels.service. Sends ONE
+# Telegram notice that a specific APP/service unit failed -- as opposed to a
+# host/WSL-VM restart, which is reported by host-restart-watchdog.sh. Keeping
+# the two paths separate is what lets a fleet-wide silence be classified.
+#
+# Best-effort and always exits 0 so it never itself enters `failed`.
+
+set -uo pipefail
+
+UNIT="${1:-unknown.unit}"
+ENV_FILE="${TELEGRAM_ENV:-$HOME/.claude/channels/telegram/.env}"
+CHAT_ID="${MARVEEN_ALERT_CHAT_ID:-8942301795}"
+
+now_local="$(date '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo now)"
+msg="Marveen app-crash: a(z) ${UNIT} unit FAILED állapotba került (${now_local}).
+(Ez alkalmazás/service szintű hiba, NEM host/VM restart. A host-restartot a host-restart-watchdog jelzi külön.)"
+
+token=""
+if [[ -f "$ENV_FILE" ]]; then
+  token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r\n')"
+fi
+if [[ -n "$token" ]]; then
+  curl -s --max-time 15 \
+    "https://api.telegram.org/bot${token}/sendMessage" \
+    --data-urlencode "chat_id=${CHAT_ID}" \
+    --data-urlencode "text=${msg}" >/dev/null 2>&1 || true
+fi
+exit 0


### PR DESCRIPTION
## Problem

On WSL2, the whole utility VM can shut down and re-boot on its own (idle
`vmIdleTimeout`, Windows sleep/resume, `wsl --shutdown`, a Windows/WSL update).
That tears down the kernel, system + user systemd, tmux, and every service at
once. It is **not** an application crash, and `Linger=yes` does not protect
against it — yet operators can't tell a whole-VM restart apart from a service
crash, so a fleet-wide silence looks like an app failure. Separately, the
generated `marveen-channels.service` placed `StartLimitIntervalSec` /
`StartLimitBurst` in `[Service]`, where systemd logs "Unknown key … in section
[Service]" and ignores them — so the crash-loop throttle never actually applied.

## What changes

- **StartLimit fix:** move `StartLimitIntervalSec` / `StartLimitBurst` to
  `[Unit]` in the channels-service generated by `install-linux.sh`, so the
  throttle takes effect.
- **Host-restart watchdog:** `scripts/host-restart-watchdog.sh` +
  `marveen-host-watchdog.service` — a oneshot at every user-manager start that
  compares `/proc/stat btime` to a saved value and, on a change, sends one
  notice that the host/WSL VM restarted (with an estimated downtime).
- **App-crash notifier:** `scripts/unit-fail-notify.sh` + `marveen-notify@.service`
  — an `OnFailure=` template that reports a service crash. btime-change ⇒ host
  restart; OnFailure ⇒ app crash — the two are now distinguishable.
- **Docs:** `scripts/systemd/README-host-stability.md`, including the Windows-side
  `%UserProfile%\.wslconfig` → `vmIdleTimeout=-1` mitigation (documented only,
  not automated from Linux).

## Why safe

- Additive: new scripts/units + one systemd key relocation. No behavioural change
  to any existing service beyond the throttle now working as intended.
- No secrets: the notifier reads the Telegram token from the existing local env
  file at runtime; nothing is committed.
- No dashboard / provider / DNS / deploy change. No CostOps/brand/landing/local
  helper code — the diff is 6 files, WSL/stability scope only.

## Test / verify

- `systemd-analyze --user verify` clean on channels / host-watchdog / notify@
  (no more "Unknown key").
- Throttle active after reload: `StartLimitIntervalUSec=5min`, `StartLimitBurst=5`.
- Watchdog exercised in all branches: baseline-init (silent), unchanged-btime
  (silent), simulated restart (detects + computes downtime); notification
  send-path returns HTTP 200.
