### PR TITLE
feat(memory): opt-in per-agent auto-memory isolation (memoryIsolation flag, default OFF)

### DIFF
--- a/src/__tests__/memory-boundary.test.ts
+++ b/src/__tests__/memory-boundary.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { provisionMemoryBoundaryDir } from '../web/memory-boundary.js'
+
+describe('provisionMemoryBoundaryDir', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'mem-boundary-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('creates a stub git root with an ignore-everything exclude', () => {
+    expect(provisionMemoryBoundaryDir(dir)).toBe(true)
+    expect(existsSync(join(dir, '.git'))).toBe(true)
+    expect(readFileSync(join(dir, '.git', 'info', 'exclude'), 'utf-8')).toBe('*\n')
+    // the boundary is a real git root: rev-parse resolves to the agent dir itself
+    const top = execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd: dir, encoding: 'utf-8' }).trim()
+    expect(top).toBe(execFileSync('realpath', [dir], { encoding: 'utf-8' }).trim())
+  })
+
+  it('keeps the working tree clean: git status reports nothing despite files', () => {
+    writeFileSync(join(dir, 'CLAUDE.md'), '# agent instructions\n')
+    mkdirSync(join(dir, 'workspace'))
+    writeFileSync(join(dir, 'workspace', 'note.txt'), 'data\n')
+    expect(provisionMemoryBoundaryDir(dir)).toBe(true)
+    const status = execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf-8' })
+    expect(status).toBe('')
+  })
+
+  it('is idempotent and repairs a missing exclude on re-run', () => {
+    expect(provisionMemoryBoundaryDir(dir)).toBe(true)
+    rmSync(join(dir, '.git', 'info', 'exclude'))
+    expect(provisionMemoryBoundaryDir(dir)).toBe(true)
+    expect(readFileSync(join(dir, '.git', 'info', 'exclude'), 'utf-8')).toBe('*\n')
+  })
+
+  it('does not re-init an existing repo (preserves .git contents)', () => {
+    expect(provisionMemoryBoundaryDir(dir)).toBe(true)
+    writeFileSync(join(dir, '.git', 'marker'), 'keep me\n')
+    expect(provisionMemoryBoundaryDir(dir)).toBe(true)
+    expect(readFileSync(join(dir, '.git', 'marker'), 'utf-8')).toBe('keep me\n')
+  })
+
+  it('returns false for a missing dir without throwing', () => {
+    expect(provisionMemoryBoundaryDir(join(dir, 'does-not-exist'))).toBe(false)
+  })
+})

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -318,6 +318,20 @@ export function readAgentAuthMode(name: string): AuthMode {
   return 'shared'
 }
 
+// Opt-in per-agent auto-memory isolation (default OFF). When true, the
+// launcher plants a stub git root in the agent dir so Claude Code's
+// file-based auto-memory resolves to the agent's own project key instead of
+// the shared install-root key. See src/web/memory-boundary.ts for the full
+// mechanism and trade-offs. Absent/false = current shared behavior, unchanged.
+export function readAgentMemoryIsolation(name: string): boolean {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  try {
+    const config = JSON.parse(readFileOr(configPath, '{}'))
+    return config.memoryIsolation === true
+  } catch { /* fall through */ }
+  return false
+}
+
 export function writeAgentAuthMode(name: string, mode: AuthMode): void {
   if (!VALID_AUTH_MODES.has(mode)) return
   const configPath = join(agentDir(name), 'agent-config.json')

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -15,7 +15,8 @@ import {
   stripGhostSuggestion,
   paneShowsContextSaturation,
 } from '../pane-state.js'
-import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost } from './agent-config.js'
+import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentMemoryIsolation } from './agent-config.js'
+import { provisionMemoryBoundaryDir } from './memory-boundary.js'
 import {
   buildTmuxInvocation,
   buildSshExec,
@@ -514,6 +515,13 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
   if (remote.host && remote.workdir) {
     return startRemoteAgentProcess(name, remote.host, remote.workdir, opts)
   }
+
+  // Opt-in per-agent auto-memory isolation (local agents only; a remote
+  // workdir cannot be provisioned from here). Default OFF: without the
+  // memoryIsolation flag this is a no-op and the shared-memory behavior of
+  // existing installs is byte-identical.
+  if (readAgentMemoryIsolation(name)) provisionMemoryBoundaryDir(dir)
+
 
   if (isAgentRunning(name)) return { ok: false, error: 'Agent is already running' }
 

--- a/src/web/memory-boundary.ts
+++ b/src/web/memory-boundary.ts
@@ -1,0 +1,47 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+
+// --- Per-agent auto-memory isolation (opt-in) --------------------------------
+//
+// Claude Code keys its file-based auto-memory (MEMORY.md + memory/*.md under
+// ~/.claude/projects/<key>/) to the ENCLOSING GIT WORKTREE ROOT of the session
+// cwd, falling back to the cwd itself outside any repo. Agent sessions run with
+// cwd = agents/<name> INSIDE the install repo, so by default every sub-agent
+// and the main agent resolve to the SAME install-root project key and share
+// one auto-memory.
+//
+// On a single-operator install that sharing is desirable: one fleet-wide
+// MEMORY.md carries the operator's corrections to every agent. On a multi-user
+// install (one human principal per agent) it is a cross-principal leak.
+//
+// Planting a stub git repo in the agent dir stops the walk-up there, so the
+// agent's auto-memory lands under its own per-agent project key. Everything
+// else is untouched: session transcripts already use per-cwd keys, and the
+// shared ~/.claude/projects tree (or a .claude-config projects symlink) keeps
+// working exactly as before. The stub ignores all content via .git/info/exclude
+// so the agent dir never shows up as a dirty checkout. Reverting is
+// `rm -rf agents/<name>/.git`.
+//
+// Trade-off the operator opts into: an isolated agent no longer sees the
+// shared fleet MEMORY.md; fleet-wide rules must reach it via CLAUDE.md or
+// shared SQLite memories instead.
+export function provisionMemoryBoundaryDir(dir: string): boolean {
+  if (!existsSync(dir)) return false
+  try {
+    const gitDir = join(dir, '.git')
+    if (!existsSync(gitDir)) {
+      execFileSync('git', ['init', '--quiet'], { cwd: dir, timeout: 10_000 })
+    }
+    // (Re)write the exclude on every call: idempotent, and it also repairs a
+    // stub whose exclude was lost. `*` keeps `git status` empty forever.
+    const infoDir = join(gitDir, 'info')
+    mkdirSync(infoDir, { recursive: true })
+    writeFileSync(join(infoDir, 'exclude'), '*\n')
+    return true
+  } catch (err) {
+    logger.warn({ dir, err }, 'memory-boundary: could not provision stub git root; agent keeps the shared auto-memory key')
+    return false
+  }
+}


### PR DESCRIPTION
Fixes the multi-user cross-principal auto-memory leak (iS report) at its actual root cause.

**Root cause (investigated + live-verified):** Claude Code keys file-based auto-memory to the enclosing **git worktree root** of the session cwd (cwd fallback outside a repo). All agent sessions run inside the install repo, so every agent + the main agent resolve to the same install-root project key and share one `MEMORY.md`. The `.claude-config/projects` symlink is not the root cause -- installs without it share memory the same way.

**Fix:** opt-in `"memoryIsolation": true` in `agents/<name>/agent-config.json`. On launch the agent dir gets a stub git root (`git init` + `info/exclude '*'`), stopping the walk-up: that agent's auto-memory lands under its own per-agent project key.

- **Default OFF** -- no flag, no-op: single-operator installs (shared fleet MEMORY.md) are byte-identical.
- Local agents only (remote workdir cannot be provisioned from the launcher); idempotent; failure degrades to the shared key with a warn log.
- Revert: `rm -rf agents/<name>/.git`.

**Pilot on a live agent (fresh session, objective jsonl evidence):** memory key isolated to `-...-agents-<name>` (0 root-key refs), parent-repo CLAUDE.md discovery **unaffected**, `git status` stays empty via the exclude.

**Known trade-off (in module header):** an isolated agent no longer receives the shared fleet MEMORY.md; fleet-wide rules must reach it via CLAUDE.md or shared SQLite memories. This is the intended semantics for multi-user installs.

Tests: 5 new unit tests (provision/idempotence/clean-status/no-reinit/missing-dir); full suite 1611/1611 green; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)