### PR TITLE
fix(worker): survive CC 2.1.202 first-run chrome (agent-creation 90s timeout)

### DIFF
--- a/src/__tests__/worker-firstrun-cc202.test.ts
+++ b/src/__tests__/worker-firstrun-cc202.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { idleConsideringDimGhost, paneLooksIdle, detectPaneState } from '../pane-state.js'
+import { stampWorkerFirstRun } from '../web/agent-worker.js'
+
+// Regression tests for the CC >=2.1.202 first-run breakage that made
+// dashboard agent creation fail with "worker session not ready":
+//  1. the "Try the new fullscreen renderer?" upsell parks the worker before
+//     its first idle prompt -> stampWorkerFirstRun pre-accepts it;
+//  2. the new dim empty-input placeholder reads as parked text in a plain
+//     capture -> idleConsideringDimGhost consults the dim-stripped view.
+
+const SEP = '─'.repeat(80)
+
+// Plain (`capture-pane -p`) view of an EMPTY box showing the new dim
+// placeholder: escape codes are not part of -p output, so the hint reads as
+// literal parked text.
+const PLAIN_WITH_PLACEHOLDER = [
+  '',
+  SEP,
+  '❯ Try refactor src/utils.ts to use the new API',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// The SAME pane read through captureParkedInputView (-e capture with dim spans
+// stripped): the placeholder was SGR-2 faint, so the box reads empty -> idle.
+const DIM_STRIPPED_EMPTY = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// REAL typed input: normal intensity, so it survives the dim strip too.
+const DIM_STRIPPED_REAL_TEXT = [
+  '',
+  SEP,
+  '❯ deploy the thing please',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A genuinely busy pane (spinner + esc-to-interrupt footer).
+const BUSY = [
+  '✻ Baking… (12s · 1.2k tokens · esc to interrupt)',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+describe('idleConsideringDimGhost', () => {
+  it('fixture sanity: the placeholder pane classifies as typing on the plain view', () => {
+    expect(detectPaneState(PLAIN_WITH_PLACEHOLDER)).toBe('typing')
+    expect(paneLooksIdle(DIM_STRIPPED_EMPTY)).toBe(true)
+  })
+
+  it('treats a dim-placeholder-only box as idle (the CC 2.1.202 readiness fix)', () => {
+    expect(idleConsideringDimGhost(PLAIN_WITH_PLACEHOLDER, DIM_STRIPPED_EMPTY)).toBe(true)
+  })
+
+  it('still refuses when REAL typed text is parked (survives the dim strip)', () => {
+    expect(idleConsideringDimGhost(PLAIN_WITH_PLACEHOLDER, DIM_STRIPPED_REAL_TEXT)).toBe(false)
+  })
+
+  it('refuses a busy pane without even consulting the dim view', () => {
+    expect(idleConsideringDimGhost(BUSY, DIM_STRIPPED_EMPTY)).toBe(false)
+  })
+
+  it('fails safe when the dim-stripped capture is unavailable', () => {
+    expect(idleConsideringDimGhost(PLAIN_WITH_PLACEHOLDER, null)).toBe(false)
+  })
+
+  it('a plainly idle pane is idle regardless of the dim view', () => {
+    expect(idleConsideringDimGhost(DIM_STRIPPED_EMPTY, null)).toBe(true)
+  })
+})
+
+describe('stampWorkerFirstRun', () => {
+  it('stamps onboarding and the fullscreen upsell counter on a fresh config', () => {
+    const parsed: Record<string, unknown> = {}
+    stampWorkerFirstRun(parsed)
+    expect(parsed.hasCompletedOnboarding).toBe(true)
+    expect(parsed.fullscreenUpsellSeenCount).toBe(99)
+  })
+
+  it('never lowers an already-higher seen count', () => {
+    const parsed: Record<string, unknown> = { fullscreenUpsellSeenCount: 250 }
+    stampWorkerFirstRun(parsed)
+    expect(parsed.fullscreenUpsellSeenCount).toBe(250)
+  })
+
+  it('repairs a non-numeric counter and preserves unrelated keys', () => {
+    const parsed: Record<string, unknown> = { fullscreenUpsellSeenCount: 'nope', projects: { '/x': { hasTrustDialogAccepted: true } } }
+    stampWorkerFirstRun(parsed)
+    expect(parsed.fullscreenUpsellSeenCount).toBe(99)
+    expect(parsed.projects).toEqual({ '/x': { hasTrustDialogAccepted: true } })
+  })
+
+  it('is idempotent', () => {
+    const parsed: Record<string, unknown> = {}
+    stampWorkerFirstRun(parsed)
+    stampWorkerFirstRun(parsed)
+    expect(parsed.fullscreenUpsellSeenCount).toBe(99)
+    expect(parsed.hasCompletedOnboarding).toBe(true)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -528,6 +528,23 @@ export function isReadyForPrompt(pane: string): boolean {
   return paneLooksIdle(pane)
 }
 
+/**
+ * Idle check that tolerates DIM-only "parked text". Claude Code >=2.1.202
+ * renders a placeholder hint (e.g. "Try refactor...") in dim (SGR-2 faint)
+ * inside the EMPTY input box; a plain capture-pane read shows it as parked
+ * text, detectPaneState classifies 'typing', and a readiness poll never turns
+ * true. Ghost/placeholder text is dim while real typed input is not (the same
+ * invariant clearStaleParkedInput's DIM-GUARD relies on), so when the plain
+ * view says 'typing' the caller re-reads the pane through the dim-stripping
+ * view (captureParkedInputView) and passes it here: if the stripped view is
+ * idle, the box only ever held ghost text and the session IS ready.
+ */
+export function idleConsideringDimGhost(plain: string, dimStripped: string | null): boolean {
+  if (paneLooksIdle(plain)) return true
+  if (detectPaneState(plain) !== 'typing') return false
+  return dimStripped != null && paneLooksIdle(dimStripped)
+}
+
 // Locate the live Claude Code input box and return its inner content as
 // one string. Bounded strictly to the region between the two most
 // recent BOX_SEP_RX separators above the idle footer, so a parked input

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -14,6 +14,7 @@ import {
   parkedInputText,
   stripGhostSuggestion,
   paneShowsContextSaturation,
+  idleConsideringDimGhost,
 } from '../pane-state.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentMemoryIsolation } from './agent-config.js'
 import { provisionMemoryBoundaryDir } from './memory-boundary.js'
@@ -1283,13 +1284,20 @@ export function captureParkedInputView(session: string, host: string | null = nu
 // whether) to recover the session is left to the caller / operator tooling, so
 // this predicate stays a pure, dependency-free readiness check.
 export function isSessionReadyForPrompt(session: string, host: string | null = null): boolean {
+  // Dim-ghost tolerant idle read: CC >=2.1.202 paints a dim placeholder into
+  // the empty input box, which a plain capture reads as parked text. Only when
+  // the plain view says 'typing' do we pay for the second (-e, dim-stripped)
+  // capture to decide whether anything REAL is parked (see
+  // idleConsideringDimGhost / captureParkedInputView).
+  const idleOrGhost = (plain: string): boolean =>
+    idleConsideringDimGhost(plain, detectPaneState(plain) === 'typing' ? captureParkedInputView(session, host) : null)
   const first = capturePane(session, host)
   if (first == null) return false
   if (paneShowsContextSaturation(first)) {
     logger.warn({ session }, 'dispatch: refusing prompt — session shows context saturation (100% context)')
     return false
   }
-  if (!paneLooksIdle(first)) return false
+  if (!idleOrGhost(first)) return false
 
   try { execFileSync('/bin/sleep', [PANE_READY_CONFIRM_DELAY_S], { timeout: 2000 }) } catch { /* best effort */ }
 
@@ -1299,7 +1307,7 @@ export function isSessionReadyForPrompt(session: string, host: string | null = n
     logger.warn({ session }, 'dispatch: refusing prompt — session shows context saturation (100% context)')
     return false
   }
-  return paneLooksIdle(second)
+  return idleOrGhost(second)
 }
 
 // How long to wait between the two parked-input captures when deciding whether

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -277,7 +277,7 @@ export function ensureWorkerCwd(): void {
     const homeClaudeJson = join(homedir(), '.claude.json')
     const parsed: { projects?: Record<string, unknown>; hasCompletedOnboarding?: boolean; [k: string]: unknown } =
       existsSync(homeClaudeJson) ? JSON.parse(readFileSync(homeClaudeJson, 'utf-8')) : {}
-    parsed.hasCompletedOnboarding = true
+    stampWorkerFirstRun(parsed)
     const projects: Record<string, unknown> = (parsed.projects && typeof parsed.projects === 'object') ? parsed.projects : {}
     const base = (projects[PROJECT_ROOT] && typeof projects[PROJECT_ROOT] === 'object')
       ? projects[PROJECT_ROOT] as Record<string, unknown>
@@ -291,6 +291,25 @@ export function ensureWorkerCwd(): void {
   } catch (err) {
     logger.warn({ err }, 'worker: failed to materialise .claude.json (worker may park on a first-run modal)')
   }
+}
+
+/**
+ * Pre-accept Claude Code's global first-run chrome for the worker so a fresh
+ * install's very first generation call never parks on a modal:
+ *  - hasCompletedOnboarding: theme picker + login onboarding;
+ *  - fullscreenUpsellSeenCount: the CC >=2.1.202 "Try the new fullscreen
+ *    renderer?" upsell, which otherwise sits over the input box and the 90s
+ *    boot poll times out. Stamped HIGH (never lowered) so the modal never
+ *    renders. We deliberately do NOT opt INTO the fullscreen renderer: the
+ *    worker's whole output pipeline is a tmux capture-pane scrape and the
+ *    pane-state heuristics assume the classic renderer's layout.
+ * Pure (mutates the parsed object only) so it is unit-testable; idempotent and
+ * harmless on CC versions that do not know these keys.
+ */
+export function stampWorkerFirstRun(parsed: { hasCompletedOnboarding?: boolean; fullscreenUpsellSeenCount?: unknown; [k: string]: unknown }): void {
+  parsed.hasCompletedOnboarding = true
+  const seen = Number(parsed.fullscreenUpsellSeenCount)
+  parsed.fullscreenUpsellSeenCount = Number.isFinite(seen) ? Math.max(99, seen) : 99
 }
 
 // --- session lifecycle ---------------------------------------------------------


### PR DESCRIPTION
Ports a remote install's diagnosed-and-locally-fixed regression to the canonical repo.

**Symptom:** creating an agent from the dashboard fails CLAUDE.md/SOUL.md generation with `worker session not ready` (~90s timeout) on Claude Code >= 2.1.202.

**Fixes (both idempotent, no-ops on older CC):**
1. `stampWorkerFirstRun` (pure, unit-tested): pre-accepts the new "Try the new fullscreen renderer?" upsell via `fullscreenUpsellSeenCount` (never lowered), next to the existing `hasCompletedOnboarding` stamp, on every worker boot. We intentionally do NOT enable the fullscreen renderer: the worker pipeline scrapes tmux `capture-pane` and the pane-state heuristics assume the classic layout.
2. `idleConsideringDimGhost` (pure, unit-tested): the readiness check tolerates the new DIM empty-input placeholder. When the plain capture classifies `typing`, it re-reads through the dim-stripping `captureParkedInputView` (same DIM-GUARD invariant as `clearStaleParkedInput`); an after-strip-empty box is idle, real typed input still blocks.

Key name `fullscreenUpsellSeenCount` cross-checked against a live `~/.claude.json` (present since at least CC 2.1.170).

Tests: 10 new (readiness fixtures incl. busy/real-text/failsafe paths + stamp idempotence); `tsc --noEmit` clean; full suite 1621/1621. Live regression baseline: disposable dashboard agent creation verified on the current install (CC 2.1.170), then fully removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)