### PR TITLE
fix(worker): self-heal parked modals + version log + central not-ready retry (layers 2-3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marveen",
-  "version": "1.13.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marveen",
-      "version": "1.13.0",
+      "version": "1.19.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",

--- a/src/__tests__/worker-firstrun-cc202.test.ts
+++ b/src/__tests__/worker-firstrun-cc202.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { idleConsideringDimGhost, paneLooksIdle, detectPaneState } from '../pane-state.js'
+import { stampWorkerFirstRun } from '../web/agent-worker.js'
+
+// Regression tests for the CC >=2.1.202 first-run breakage that made
+// dashboard agent creation fail with "worker session not ready":
+//  1. the "Try the new fullscreen renderer?" upsell parks the worker before
+//     its first idle prompt -> stampWorkerFirstRun pre-accepts it;
+//  2. the new dim empty-input placeholder reads as parked text in a plain
+//     capture -> idleConsideringDimGhost consults the dim-stripped view.
+
+const SEP = '─'.repeat(80)
+
+// Plain (`capture-pane -p`) view of an EMPTY box showing the new dim
+// placeholder: escape codes are not part of -p output, so the hint reads as
+// literal parked text.
+const PLAIN_WITH_PLACEHOLDER = [
+  '',
+  SEP,
+  '❯ Try refactor src/utils.ts to use the new API',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// The SAME pane read through captureParkedInputView (-e capture with dim spans
+// stripped): the placeholder was SGR-2 faint, so the box reads empty -> idle.
+const DIM_STRIPPED_EMPTY = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// REAL typed input: normal intensity, so it survives the dim strip too.
+const DIM_STRIPPED_REAL_TEXT = [
+  '',
+  SEP,
+  '❯ deploy the thing please',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// A genuinely busy pane (spinner + esc-to-interrupt footer).
+const BUSY = [
+  '✻ Baking… (12s · 1.2k tokens · esc to interrupt)',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+describe('idleConsideringDimGhost', () => {
+  it('fixture sanity: the placeholder pane classifies as typing on the plain view', () => {
+    expect(detectPaneState(PLAIN_WITH_PLACEHOLDER)).toBe('typing')
+    expect(paneLooksIdle(DIM_STRIPPED_EMPTY)).toBe(true)
+  })
+
+  it('treats a dim-placeholder-only box as idle (the CC 2.1.202 readiness fix)', () => {
+    expect(idleConsideringDimGhost(PLAIN_WITH_PLACEHOLDER, DIM_STRIPPED_EMPTY)).toBe(true)
+  })
+
+  it('still refuses when REAL typed text is parked (survives the dim strip)', () => {
+    expect(idleConsideringDimGhost(PLAIN_WITH_PLACEHOLDER, DIM_STRIPPED_REAL_TEXT)).toBe(false)
+  })
+
+  it('refuses a busy pane without even consulting the dim view', () => {
+    expect(idleConsideringDimGhost(BUSY, DIM_STRIPPED_EMPTY)).toBe(false)
+  })
+
+  it('fails safe when the dim-stripped capture is unavailable', () => {
+    expect(idleConsideringDimGhost(PLAIN_WITH_PLACEHOLDER, null)).toBe(false)
+  })
+
+  it('a plainly idle pane is idle regardless of the dim view', () => {
+    expect(idleConsideringDimGhost(DIM_STRIPPED_EMPTY, null)).toBe(true)
+  })
+})
+
+describe('stampWorkerFirstRun', () => {
+  it('stamps onboarding and the fullscreen upsell counter on a fresh config', () => {
+    const parsed: Record<string, unknown> = {}
+    stampWorkerFirstRun(parsed)
+    expect(parsed.hasCompletedOnboarding).toBe(true)
+    expect(parsed.fullscreenUpsellSeenCount).toBe(99)
+  })
+
+  it('never lowers an already-higher seen count', () => {
+    const parsed: Record<string, unknown> = { fullscreenUpsellSeenCount: 250 }
+    stampWorkerFirstRun(parsed)
+    expect(parsed.fullscreenUpsellSeenCount).toBe(250)
+  })
+
+  it('repairs a non-numeric counter and preserves unrelated keys', () => {
+    const parsed: Record<string, unknown> = { fullscreenUpsellSeenCount: 'nope', projects: { '/x': { hasTrustDialogAccepted: true } } }
+    stampWorkerFirstRun(parsed)
+    expect(parsed.fullscreenUpsellSeenCount).toBe(99)
+    expect(parsed.projects).toEqual({ '/x': { hasTrustDialogAccepted: true } })
+  })
+
+  it('is idempotent', () => {
+    const parsed: Record<string, unknown> = {}
+    stampWorkerFirstRun(parsed)
+    stampWorkerFirstRun(parsed)
+    expect(parsed.fullscreenUpsellSeenCount).toBe(99)
+    expect(parsed.hasCompletedOnboarding).toBe(true)
+  })
+})

--- a/src/__tests__/worker-selfheal.test.ts
+++ b/src/__tests__/worker-selfheal.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { classifyWorkerPane, shouldSelfHeal } from '../web/agent-worker.js'
+
+// Layer-2 regression tests for the worker stuck-modal self-heal (card
+// e7c1bc7e): the classifier must single out parked dialog chrome without ever
+// flagging a busy turn, a healthy prompt, or the auth chrome (those have their
+// own handling). Fixtures reproduce real `tmux capture-pane -p` output.
+
+const SEP = '─'.repeat(80)
+
+// The actual CC 2.1.202 fullscreen-renderer upsell, captured live on the
+// production worker session on 2026-07-08.
+const FULLSCREEN_UPSELL = [
+  ' ⚠ 1 setup issue: MCP · /doctor',
+  '',
+  SEP,
+  '  Try the new fullscreen renderer?',
+  '',
+  '  · Flicker-free output, mouse support, clipboard auto-copy',
+  '',
+  '  ❯ 1. Yes, try it',
+  '    2. Not now',
+  '',
+  '  Enter to confirm · Esc to cancel',
+].join('\n')
+
+// Trust-folder style first-run dialog (same family, option list).
+const TRUST_DIALOG = [
+  '  Do you trust the files in this folder?',
+  '',
+  '  ❯ 1. Yes, proceed',
+  '    2. No, exit',
+  '',
+  '  Enter to confirm · Esc to cancel',
+].join('\n')
+
+const IDLE = ['', SEP, '❯ ', SEP, '  ⏵⏵ bypass permissions on (shift+tab to cycle)'].join('\n')
+
+const BUSY = [
+  '✻ Baking… (12s · 1.2k tokens · esc to interrupt)',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+const AUTH_FAILURE = [
+  '',
+  '  Please run /login',
+  '',
+  '❯ ',
+].join('\n')
+
+// Unrecognised overlay: text, but no idle footer, no busy marker, no options.
+const UNKNOWN_OVERLAY = [
+  '  Something new the harness shipped',
+  '  that we have never seen before',
+].join('\n')
+
+describe('classifyWorkerPane', () => {
+  it('classifies the live-captured fullscreen upsell as modal', () => {
+    expect(classifyWorkerPane(FULLSCREEN_UPSELL)).toBe('modal')
+  })
+
+  it('classifies the trust-dialog family as modal', () => {
+    expect(classifyWorkerPane(TRUST_DIALOG)).toBe('modal')
+  })
+
+  it('never flags a healthy prompt or a live turn', () => {
+    expect(classifyWorkerPane(IDLE)).toBe('idle')
+    expect(classifyWorkerPane(BUSY)).toBe('busy')
+  })
+
+  it('routes the auth chrome to the auth recovery, not the self-heal', () => {
+    expect(classifyWorkerPane(AUTH_FAILURE)).toBe('auth')
+  })
+
+  it('treats an empty capture as inconclusive (still booting)', () => {
+    expect(classifyWorkerPane(null)).toBe('empty')
+    expect(classifyWorkerPane('   \n  ')).toBe('empty')
+  })
+
+  it('flags unrecognised full-screen overlays as unknown', () => {
+    expect(classifyWorkerPane(UNKNOWN_OVERLAY)).toBe('unknown')
+  })
+})
+
+describe('shouldSelfHeal', () => {
+  it('heals modal and unknown panes only', () => {
+    expect(shouldSelfHeal('modal')).toBe(true)
+    expect(shouldSelfHeal('unknown')).toBe(true)
+    expect(shouldSelfHeal('idle')).toBe(false)
+    expect(shouldSelfHeal('busy')).toBe(false)
+    expect(shouldSelfHeal('auth')).toBe(false)
+    expect(shouldSelfHeal('empty')).toBe(false)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -528,6 +528,23 @@ export function isReadyForPrompt(pane: string): boolean {
   return paneLooksIdle(pane)
 }
 
+/**
+ * Idle check that tolerates DIM-only "parked text". Claude Code >=2.1.202
+ * renders a placeholder hint (e.g. "Try refactor...") in dim (SGR-2 faint)
+ * inside the EMPTY input box; a plain capture-pane read shows it as parked
+ * text, detectPaneState classifies 'typing', and a readiness poll never turns
+ * true. Ghost/placeholder text is dim while real typed input is not (the same
+ * invariant clearStaleParkedInput's DIM-GUARD relies on), so when the plain
+ * view says 'typing' the caller re-reads the pane through the dim-stripping
+ * view (captureParkedInputView) and passes it here: if the stripped view is
+ * idle, the box only ever held ghost text and the session IS ready.
+ */
+export function idleConsideringDimGhost(plain: string, dimStripped: string | null): boolean {
+  if (paneLooksIdle(plain)) return true
+  if (detectPaneState(plain) !== 'typing') return false
+  return dimStripped != null && paneLooksIdle(dimStripped)
+}
+
 // Locate the live Claude Code input box and return its inner content as
 // one string. Bounded strictly to the region between the two most
 // recent BOX_SEP_RX separators above the idle footer, so a parked input

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -14,6 +14,7 @@ import {
   parkedInputText,
   stripGhostSuggestion,
   paneShowsContextSaturation,
+  idleConsideringDimGhost,
 } from '../pane-state.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentMemoryIsolation } from './agent-config.js'
 import { provisionMemoryBoundaryDir } from './memory-boundary.js'
@@ -1283,13 +1284,20 @@ export function captureParkedInputView(session: string, host: string | null = nu
 // whether) to recover the session is left to the caller / operator tooling, so
 // this predicate stays a pure, dependency-free readiness check.
 export function isSessionReadyForPrompt(session: string, host: string | null = null): boolean {
+  // Dim-ghost tolerant idle read: CC >=2.1.202 paints a dim placeholder into
+  // the empty input box, which a plain capture reads as parked text. Only when
+  // the plain view says 'typing' do we pay for the second (-e, dim-stripped)
+  // capture to decide whether anything REAL is parked (see
+  // idleConsideringDimGhost / captureParkedInputView).
+  const idleOrGhost = (plain: string): boolean =>
+    idleConsideringDimGhost(plain, detectPaneState(plain) === 'typing' ? captureParkedInputView(session, host) : null)
   const first = capturePane(session, host)
   if (first == null) return false
   if (paneShowsContextSaturation(first)) {
     logger.warn({ session }, 'dispatch: refusing prompt — session shows context saturation (100% context)')
     return false
   }
-  if (!paneLooksIdle(first)) return false
+  if (!idleOrGhost(first)) return false
 
   try { execFileSync('/bin/sleep', [PANE_READY_CONFIRM_DELAY_S], { timeout: 2000 }) } catch { /* best effort */ }
 
@@ -1299,7 +1307,7 @@ export function isSessionReadyForPrompt(session: string, host: string | null = n
     logger.warn({ session }, 'dispatch: refusing prompt — session shows context saturation (100% context)')
     return false
   }
-  return paneLooksIdle(second)
+  return idleOrGhost(second)
 }
 
 // How long to wait between the two parked-input captures when deciding whether

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -13,6 +13,8 @@ import {
   sessionExistsOnHost,
 } from './agent-process.js'
 import { readClaudeCodeOauthJson } from './claude-credentials.js'
+import { detectPaneState } from '../pane-state.js'
+import { notifyChannel } from '../notify.js'
 
 // =============================================================================
 // Interactive-tmux agent worker (jun.15 subscription migration).
@@ -154,6 +156,40 @@ export function buildWorkerPrompt(callerPrompt: string, outPath: string, donePat
     `   ${donePath}`,
     'Do not print the response in the chat. Those two files are your only output.',
   ].join('\n')
+}
+
+/**
+ * Coarse classification of a NOT-ready worker pane, used by the boot-time
+ * self-heal. TS port of scripts/stuck-modal-guard.sh classify_pane (the
+ * channels-session guard), tuned for the worker:
+ *  - 'busy'/'idle': a live turn or a healthy prompt -- never self-heal these;
+ *  - 'auth': the login/401 chrome -- handled by the existing auth recovery;
+ *  - 'modal': confirm/option-list chrome without an idle footer (e.g. the CC
+ *    2.1.202 fullscreen-renderer upsell, or whatever first-run dialog a future
+ *    CC ships) -- the self-heal target;
+ *  - 'empty': inconclusive (still booting);
+ *  - 'unknown': text without any recognised marker -- also a self-heal target,
+ *    because an unrecognised full-screen overlay hides the idle footer.
+ */
+export type WorkerPaneClass = 'idle' | 'busy' | 'auth' | 'modal' | 'empty' | 'unknown'
+
+export function classifyWorkerPane(pane: string | null): WorkerPaneClass {
+  if (pane == null || pane.trim() === '') return 'empty'
+  const tail = pane.split('\n').slice(-30).join('\n')
+  if (WORKER_AUTH_FAILURE_RX.test(tail)) return 'auth'
+  const st = detectPaneState(pane)
+  if (st === 'busy') return 'busy'
+  if (st === 'idle' || st === 'typing') return 'idle'
+  // Modal chrome: a numbered option list or a confirm footer. Matches the
+  // fullscreen-upsell dialog captured live on 2026-07-08 and the Trust-folder /
+  // onboarding dialog family.
+  if (/Enter to confirm|Esc to cancel|\u276F\s*1\./.test(pane)) return 'modal'
+  return 'unknown'
+}
+
+/** Pure decision: should the boot poll attempt a self-heal for this pane class? */
+export function shouldSelfHeal(cls: WorkerPaneClass): boolean {
+  return cls === 'modal' || cls === 'unknown'
 }
 
 export type PollDecision = 'ready' | 'timeout' | 'dead' | 'wait'
@@ -338,19 +374,98 @@ export function startWorkerSession(): void {
     `claude --dangerously-skip-permissions --model ${shArg(WORKER_MODEL)}`
   execFileSync(TMUX, ['new-session', '-d', '-s', WORKER_SESSION, '-c', WORKER_HOME, 'bash', '-lc', launch], { timeout: 8000 })
   logger.info({ session: WORKER_SESSION, cwd: WORKER_HOME }, 'agent-worker: launched interactive worker session')
+  logWorkerClaudeVersion()
+}
+
+/**
+ * Log the Claude Code version the worker will run and persist the last seen
+ * value; a change since the previous boot gets a WARN so a CC upgrade (the
+ * usual source of brand-new first-run chrome, like the 2.1.202 fullscreen
+ * upsell) is visible in the log timeline instead of being reverse-engineered
+ * from a stuck pane. Best effort: a probe failure never blocks the boot.
+ */
+function logWorkerClaudeVersion(): void {
+  try {
+    const claudeBin = resolveFromPath('claude')
+    const v = execFileSync(claudeBin, ['--version'], { encoding: 'utf-8', timeout: 10_000 }).trim()
+    const stampPath = join(WORKER_HOME, '.last-claude-version')
+    const prev = existsSync(stampPath) ? readFileSync(stampPath, 'utf-8').trim() : null
+    if (prev && prev !== v) {
+      logger.warn({ prev, current: v }, 'agent-worker: Claude Code version changed since the last worker boot -- watch for new first-run chrome')
+    } else {
+      logger.info({ version: v }, 'agent-worker: claude version')
+    }
+    writeFileSync(stampPath, v + '\n')
+  } catch (err) {
+    logger.warn({ err }, 'agent-worker: claude version probe failed (continuing)')
+  }
 }
 
 function shArg(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`
 }
 
+// Give a booting worker this long to reach an idle prompt on its own before
+// the self-heal inspects the pane: normal boot chrome (MOTD, plugin load)
+// resolves well within this window, so Escape is never fired into a healthy
+// startup sequence.
+const WORKER_SELF_HEAL_GRACE_MS = 20_000
+// Bounded Escape presses against a parked dialog, with a ready-recheck between.
+const WORKER_SELF_HEAL_MAX_ESCAPES = 3
+// Operator alert at most once per hour per process, so a persistently broken
+// worker does not spam the channel while still never failing silently.
+const WORKER_STUCK_ALERT_COOLDOWN_MS = 60 * 60 * 1000
+let lastWorkerStuckAlert = 0
+
+/**
+ * One bounded self-heal pass for a worker parked on unexpected chrome:
+ * Escape up to N times (rechecking between), then a full session restart if
+ * the pane still is not healthy. Never touches a busy/idle/auth pane.
+ * Returns true if it acted.
+ */
+function selfHealWorkerOnce(): boolean {
+  const cls = classifyWorkerPane(capturePane(WORKER_SESSION))
+  if (!shouldSelfHeal(cls)) return false
+  logger.warn({ cls }, 'agent-worker: pane parked on unexpected chrome -- bounded Escape self-heal')
+  for (let i = 0; i < WORKER_SELF_HEAL_MAX_ESCAPES; i++) {
+    try { execFileSync(TMUX, ['send-keys', '-t', WORKER_SESSION, 'Escape'], { timeout: 5000 }) } catch { break }
+    try { execFileSync('/bin/sleep', ['0.5'], { timeout: 2000 }) } catch { /* best effort */ }
+    const now = classifyWorkerPane(capturePane(WORKER_SESSION))
+    if (now === 'idle' || now === 'busy') {
+      logger.info({ escapes: i + 1 }, 'agent-worker: self-heal cleared the parked chrome via Escape')
+      return true
+    }
+  }
+  logger.warn('agent-worker: Escape did not clear the parked chrome -- restarting the worker session')
+  restartWorkerSession()
+  return true
+}
+
+/** Loud, rate-limited operator signal: the worker never became ready. */
+function alertWorkerStuck(paneTail: string): void {
+  logger.error({ paneTail }, 'agent-worker: worker never became ready (agent-gen / capability-summary / heartbeat / digest consumers will fail)')
+  if (Date.now() - lastWorkerStuckAlert < WORKER_STUCK_ALERT_COOLDOWN_MS) return
+  lastWorkerStuckAlert = Date.now()
+  void notifyChannel(
+    '\u26A0\uFE0F Marveen worker: a hatter-worker session nem all keszen (beragadt dialogus vagy ismeretlen kepernyo). Onjavitas lefutott (Escape + restart), de a keszenlet nem allt helyre. Erintett: agens-generalas, capability-osszefoglalo, heartbeat, digest. Nezz ra: tmux attach -t marveen-worker',
+  ).catch(() => { /* notifyChannel logs internally */ })
+}
+
 async function ensureWorkerReady(): Promise<boolean> {
   startWorkerSession()
-  const deadline = Date.now() + WORKER_BOOT_TIMEOUT_MS
+  const start = Date.now()
+  const deadline = start + WORKER_BOOT_TIMEOUT_MS
+  let healed = false
   while (Date.now() < deadline) {
     if (isSessionReadyForPrompt(WORKER_SESSION)) return true
+    if (!healed && Date.now() - start > WORKER_SELF_HEAL_GRACE_MS) {
+      healed = true
+      try { selfHealWorkerOnce() } catch (err) { logger.warn({ err }, 'agent-worker: self-heal pass failed') }
+    }
     await sleepMs(2000)
   }
+  const pane = capturePane(WORKER_SESSION)
+  alertWorkerStuck((pane ?? '').split('\n').slice(-12).join('\n'))
   return false
 }
 
@@ -453,7 +568,19 @@ export async function runViaWorker(message: string, timeoutMs: number): Promise<
     for (let attempt = 0; attempt < 2; attempt++) {
       const r = await runWorkerAttempt(message, timeoutMs)
       if (r.kind === 'ok') return { text: r.text, error: r.error }
-      if (r.kind === 'fail') return { text: null, error: r.error }
+      if (r.kind === 'fail') {
+        // A momentary not-ready is TRANSIENT, not terminal: the boot-time
+        // self-heal (or a plain restart here) usually brings the worker back,
+        // and every consumer (agent-gen, capability-summary, heartbeat,
+        // digest) reaches this single choke point -- so one central retry
+        // fixes them all. Mirrors the auth-recovery retry-once shape above.
+        if (r.error === 'worker session not ready' && attempt === 0) {
+          logger.warn('agent-worker: worker not ready -- restarting once and retrying the request')
+          restartWorkerSession()
+          continue
+        }
+        return { text: null, error: r.error }
+      }
       // r.kind === 'auth'
       if (attempt === 0) {
         logger.warn('agent-worker: auth failure -> recovering (reseed creds + clear keychain + restart)')

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -277,7 +277,7 @@ export function ensureWorkerCwd(): void {
     const homeClaudeJson = join(homedir(), '.claude.json')
     const parsed: { projects?: Record<string, unknown>; hasCompletedOnboarding?: boolean; [k: string]: unknown } =
       existsSync(homeClaudeJson) ? JSON.parse(readFileSync(homeClaudeJson, 'utf-8')) : {}
-    parsed.hasCompletedOnboarding = true
+    stampWorkerFirstRun(parsed)
     const projects: Record<string, unknown> = (parsed.projects && typeof parsed.projects === 'object') ? parsed.projects : {}
     const base = (projects[PROJECT_ROOT] && typeof projects[PROJECT_ROOT] === 'object')
       ? projects[PROJECT_ROOT] as Record<string, unknown>
@@ -291,6 +291,25 @@ export function ensureWorkerCwd(): void {
   } catch (err) {
     logger.warn({ err }, 'worker: failed to materialise .claude.json (worker may park on a first-run modal)')
   }
+}
+
+/**
+ * Pre-accept Claude Code's global first-run chrome for the worker so a fresh
+ * install's very first generation call never parks on a modal:
+ *  - hasCompletedOnboarding: theme picker + login onboarding;
+ *  - fullscreenUpsellSeenCount: the CC >=2.1.202 "Try the new fullscreen
+ *    renderer?" upsell, which otherwise sits over the input box and the 90s
+ *    boot poll times out. Stamped HIGH (never lowered) so the modal never
+ *    renders. We deliberately do NOT opt INTO the fullscreen renderer: the
+ *    worker's whole output pipeline is a tmux capture-pane scrape and the
+ *    pane-state heuristics assume the classic renderer's layout.
+ * Pure (mutates the parsed object only) so it is unit-testable; idempotent and
+ * harmless on CC versions that do not know these keys.
+ */
+export function stampWorkerFirstRun(parsed: { hasCompletedOnboarding?: boolean; fullscreenUpsellSeenCount?: unknown; [k: string]: unknown }): void {
+  parsed.hasCompletedOnboarding = true
+  const seen = Number(parsed.fullscreenUpsellSeenCount)
+  parsed.fullscreenUpsellSeenCount = Number.isFinite(seen) ? Math.max(99, seen) : 99
 }
 
 // --- session lifecycle ---------------------------------------------------------


### PR DESCRIPTION
Layers 2-3 of the worker CC-first-run hardening (card e7c1bc7e), building on the layer-1 flag fix (#535). The worker is a real interactive Claude Code session; a new CC modal can park it forever, and then EVERY worker consumer fails silently: agent creation, capability-summary generation (a missing summary dropped an expert from the main agent's catalog, so it could not delegate), heartbeat, digest, scheduled tasks.

**Layer 2 -- self-heal + signal (the real defense against the moving target):**
- `classifyWorkerPane` / `shouldSelfHeal` (pure, unit-tested): a worker-tuned TS port of `scripts/stuck-modal-guard.sh classify_pane`. Flags parked dialog chrome (`modal`) and unrecognised overlays (`unknown`); never touches a busy/idle/auth pane.
- `ensureWorkerReady`: after a 20s grace, one bounded self-heal pass (Escape up to 3x with a ready-recheck, then a session restart) when the pane is parked; on final timeout it alerts the operator via `notifyChannel` (rate-limited 1/h, pane tail included) so it never fails silently. Worker-session counterpart to the channels-session `stuck-modal-guard.sh`, in code.
- `logWorkerClaudeVersion`: logs + persists the worker's `claude --version` each boot and WARNs on a change, so a CC upgrade (the usual source of new first-run chrome) is visible in the log timeline.

**Layer 3 -- forgiving callers, in one place:**
- `runViaWorker` treats `worker session not ready` as transient: restart once and retry (mirrors the existing auth-recovery retry). Every consumer funnels through this choke point, so agent-gen / capability-summary / heartbeat / digest all get the retry with no duplication.

**Tests/QA:** 7 new unit tests (classifier on the live-captured 2.1.202 upsell + idle/busy/auth/unknown/empty, `shouldSelfHeal` matrix); full suite green; `tsc --noEmit` clean; no em-dash. Live read-only check: the real captured modal classifies modal/heal, the healthy worker pane idle/no-heal. The Escape-and-restart action is unit-tested at the decision level; a live tmux modal-injection was not driven from the agent shell (harness governance blocks keystroke injection from the agent), and the happy path is structurally inert (a healthy worker returns before the 20s grace).

Stacks on #535 (layer 1). Merge #535 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
