### PR TITLE
feat(updates): group the update view by release (PR-A of update-system overhaul)

### DIFF
--- a/src/__tests__/update-release-grouping.test.ts
+++ b/src/__tests__/update-release-grouping.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { groupByRelease, type UpdateCommit } from '../web/update-checker.js'
+
+// Unit tests for the release-grouping that turns the flat newest-first commit
+// list into version buckets (card cbe2a240, PR-A). A `chore(release): vX`
+// commit starts a version group; the non-release commits older than it (down to
+// the next release marker) are what shipped in vX; commits newer than the newest
+// release marker form the leading "upcoming" group.
+
+function c(short: string, message: string): UpdateCommit {
+  return { sha: short.padEnd(40, '0'), short, message, author: 'Dev', date: '2026-07-09T00:00:00Z' }
+}
+
+describe('groupByRelease', () => {
+  it('groups commits under their enclosing release, newest-first', () => {
+    const commits = [
+      c('aaa', 'feat: upcoming thing'),
+      c('bbb', 'chore(release): v1.20.0 -- memory isolation + worker robustness'),
+      c('ccc', 'fix(voice): self-heal'),
+      c('ddd', 'feat(memory): isolation'),
+      c('eee', 'chore(release): v1.19.0 -- SSH Vault'),
+      c('fff', 'feat(vault): SSH Vault'),
+    ]
+    const msgs = commits.map(x => x.message)
+    const groups = groupByRelease(commits, msgs)
+
+    expect(groups.map(g => g.version)).toEqual(['', 'v1.20.0', 'v1.19.0'])
+    // upcoming = commits above the newest release marker
+    expect(groups[0].commits.map(x => x.short)).toEqual(['aaa'])
+    // v1.20.0 = the commits older than its marker, down to the next marker
+    expect(groups[1].commits.map(x => x.short)).toEqual(['ccc', 'ddd'])
+    expect(groups[1].summary).toBe('memory isolation + worker robustness')
+    // v1.19.0 = the remaining older commits
+    expect(groups[2].commits.map(x => x.short)).toEqual(['fff'])
+    expect(groups[2].summary).toBe('SSH Vault')
+  })
+
+  it('prefers the release-commit body over the subject summary, stripping trailers', () => {
+    const relMsg = [
+      'chore(release): v1.21.0 -- short subject',
+      '',
+      '- feature one',
+      '- feature two',
+      '',
+      'Co-Authored-By: Claude <noreply@anthropic.com>',
+    ].join('\n')
+    const commits = [c('rel', 'chore(release): v1.21.0 -- short subject'), c('x1', 'feat: thing')]
+    const groups = groupByRelease(commits, [relMsg, 'feat: thing'])
+    expect(groups[0].version).toBe('v1.21.0')
+    expect(groups[0].summary).toBe('- feature one\n- feature two')
+    expect(groups[0].summary).not.toContain('Co-Authored-By')
+  })
+
+  it('falls back to the subject summary when the body is empty (historical inconsistency)', () => {
+    const commits = [c('rel', 'chore(release): v1.19.0 -- SSH Vault, owner-gated toggle')]
+    const groups = groupByRelease(commits, ['chore(release): v1.19.0 -- SSH Vault, owner-gated toggle\n\nCo-Authored-By: x <y@z>'])
+    expect(groups[0].summary).toBe('SSH Vault, owner-gated toggle')
+  })
+
+  it('matches an em-dash separator in a release subject', () => {
+    const commits = [c('rel', 'chore(release): v1.18.0 — em dash release')]
+    const groups = groupByRelease(commits, ['chore(release): v1.18.0 — em dash release'])
+    expect(groups[0].version).toBe('v1.18.0')
+    expect(groups[0].summary).toBe('em dash release')
+  })
+
+  it('puts everything in upcoming when there is no release marker', () => {
+    const commits = [c('a', 'feat: a'), c('b', 'fix: b')]
+    const groups = groupByRelease(commits, ['feat: a', 'fix: b'])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].version).toBe('')
+    expect(groups[0].commits.map(x => x.short)).toEqual(['a', 'b'])
+  })
+
+  it('omits the empty upcoming group when the newest commit is a release', () => {
+    const commits = [c('rel', 'chore(release): v1.20.0 -- x'), c('a', 'feat: a')]
+    const groups = groupByRelease(commits, ['chore(release): v1.20.0 -- x', 'feat: a'])
+    expect(groups.map(g => g.version)).toEqual(['v1.20.0'])
+  })
+})

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -9,11 +9,25 @@ export interface UpdateCommit {
   date: string
 }
 
+export interface UpdateRelease {
+  /** Release tag, e.g. "v1.20.0"; empty string for the not-yet-released group. */
+  version: string
+  /** Human-language summary for the version (release-commit subject after "--",
+   * or the release-commit body when present). Empty when none is available. */
+  summary: string
+  commits: UpdateCommit[]
+}
+
 export interface UpdateStatus {
   current: string
   latest: string
   behind: number
   commits: UpdateCommit[]
+  /** Commits grouped by release tag (newest first; the first group is the
+   * not-yet-released "upcoming" commits with version=""). Derived from the
+   * chore(release) commits in the list. Absent/empty when there is nothing to
+   * group; the flat `commits` list is always populated for backward compat. */
+  releases?: UpdateRelease[]
   remote: string
   lastChecked: number
   error?: string
@@ -70,19 +84,65 @@ async function fetchCompare(remote: string, base: string, head: string): Promise
   return null
 }
 
-// Map a GitHub compare body onto the status (behind count + newest-first commit
-// list).
+// Matches a `chore(release): vX.Y.Z` subject and captures the version + the
+// human summary that follows a "--" / "—" separator (if any).
+const RELEASE_RE = /^chore\(release\):\s*(v\d+\.\d+\.\d+)\s*(?:--|—)?\s*(.*)$/
+
+// Strip trailing git trailers (Co-Authored-By, Signed-off-by) and blank lines
+// from a release-commit body so only the human summary remains.
+function releaseBodySummary(fullMessage: string): string {
+  const lines = fullMessage.split('\n').slice(1) // drop the subject line
+  const kept: string[] = []
+  for (const line of lines) {
+    if (/^(Co-Authored-By|Signed-off-by|Co-authored-by):/i.test(line.trim())) continue
+    kept.push(line)
+  }
+  return kept.join('\n').trim()
+}
+
+// Map a GitHub compare body onto the status: the flat newest-first commit list
+// (backward compat) plus a release-grouped view derived from the chore(release)
+// commits already present in the list.
 function applyCompare(status: UpdateStatus, cmp: GhCompare): void {
   status.behind = cmp.ahead_by ?? 0
   // GitHub returns commits oldest-first; flip to newest-first for the UI.
   const raw = (cmp.commits ?? []).slice().reverse()
-  status.commits = raw.map(c => ({
+  const commits: UpdateCommit[] = raw.map(c => ({
     sha: c.sha,
     short: c.sha.slice(0, 7),
     message: (c.commit.message || '').split('\n')[0],
     author: c.commit.author?.name || '',
     date: c.commit.author?.date || '',
   }))
+  status.commits = commits
+  status.releases = groupByRelease(commits, raw.map(c => c.commit.message || ''))
+}
+
+// Group a newest-first commit list into release buckets. A `chore(release): vX`
+// commit starts a version group; the non-release commits OLDER than it (until
+// the next release marker) are the changes shipped in vX. Commits newer than
+// the newest release marker form the leading "upcoming" group (version="").
+export function groupByRelease(commits: UpdateCommit[], fullMessages: string[]): UpdateRelease[] {
+  const groups: UpdateRelease[] = []
+  let cur: UpdateRelease | null = null
+  const upcoming: UpdateRelease = { version: '', summary: '', commits: [] }
+  for (let i = 0; i < commits.length; i++) {
+    const c = commits[i]
+    const m = c.message.match(RELEASE_RE)
+    if (m) {
+      const subjectSummary = (m[2] || '').trim()
+      const bodySummary = releaseBodySummary(fullMessages[i] || '')
+      cur = { version: m[1], summary: bodySummary || subjectSummary, commits: [] }
+      groups.push(cur)
+    } else if (cur) {
+      cur.commits.push(c)
+    } else {
+      upcoming.commits.push(c)
+    }
+  }
+  const out: UpdateRelease[] = []
+  if (upcoming.commits.length) out.push(upcoming)
+  return out.concat(groups)
 }
 
 // Merge-base of local HEAD with the upstream tracking ref (origin/main, which

--- a/web/app.js
+++ b/web/app.js
@@ -9829,16 +9829,37 @@ async function loadUpdates() {
       summary.innerHTML = `<strong>${t('updates.behind', { n: data.behind })}</strong> ${t('updates.available_on', { remote: `<code>${escapeHtmlUpdates(data.remote)}</code>` })}<br>${t('updates.current_label')} <code>${cur}</code> → ${t('updates.latest_label')} <code>${lat}</code>`
       applyBtn.hidden = false
     }
-    if (data.commits && data.commits.length) {
-      list.innerHTML = data.commits.map(c => `
+    const commitCard = (c) => `
         <div class="updates-commit">
           <div class="updates-commit-head">
             <span>${escapeHtmlUpdates(c.short)} · ${escapeHtmlUpdates(c.author)}</span>
             <span>${escapeHtmlUpdates((c.date || '').slice(0, 10))}</span>
           </div>
           <div class="updates-commit-msg">${escapeHtmlUpdates(c.message)}</div>
-        </div>
-      `).join('')
+        </div>`
+    if (data.releases && data.releases.length) {
+      // Grouped-by-release view: one collapsible <details> per version, newest
+      // open by default. Falls back to the flat list below when absent.
+      list.innerHTML = data.releases.map((rel, idx) => {
+        const label = rel.version
+          ? escapeHtmlUpdates(rel.version)
+          : t('updates.group.upcoming')
+        const summary = rel.summary
+          ? `<span class="updates-group-summary">${escapeHtmlUpdates(rel.summary)}</span>`
+          : ''
+        const count = t('updates.group.commit_count', { n: rel.commits.length })
+        return `
+        <details class="updates-group"${idx === 0 ? ' open' : ''}>
+          <summary class="updates-group-head">
+            <span class="updates-group-tag">${label}</span>
+            ${summary}
+            <span class="updates-group-count">${count}</span>
+          </summary>
+          <div class="updates-commit-list">${rel.commits.map(commitCard).join('')}</div>
+        </details>`
+      }).join('')
+    } else if (data.commits && data.commits.length) {
+      list.innerHTML = data.commits.map(commitCard).join('')
     } else if (data.behind === 0) {
       list.innerHTML = `<p style="color:var(--text-muted);font-size:13px">${t('updates.no_changes')}</p>`
     }

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1057,6 +1057,8 @@ window._i18n.en = {
   'updates.up_to_date_html':     'You are on the latest version',
   'updates.no_changes':          'No changes.',
   'updates.btn.update_now':      'Update now',
+  'updates.group.upcoming':    'Upcoming changes',
+  'updates.group.commit_count': '{n} commits',
   'updates.behind':              '{n} new commits available',
   'updates.available_on':        'on {remote}.',
   'updates.latest_label':        'Latest:',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1055,6 +1055,8 @@ window._i18n.hu = {
   'updates.up_to_date_html':     'A legfrissebb verzión vagy',
   'updates.no_changes':          'Nincs változás.',
   'updates.btn.update_now':      'Frissítés most',
+  'updates.group.upcoming':    'Közelgő változások',
+  'updates.group.commit_count': '{n} commit',
   'updates.behind':              '{n} új commit elérhető',
   'updates.available_on':        'a {remote} repón.',
   'updates.latest_label':        'Legfrissebb:',

--- a/web/style.css
+++ b/web/style.css
@@ -6421,3 +6421,14 @@ body {
     padding-bottom: max(20px, env(safe-area-inset-bottom));
   }
 }
+
+/* Update view: release-grouped collapsible list */
+.updates-group { border: 1px solid var(--border); border-radius: var(--radius-sm); margin-bottom: 10px; overflow: hidden; }
+.updates-group > summary.updates-group-head { list-style: none; cursor: pointer; display: flex; align-items: baseline; gap: 10px; padding: 12px 14px; background: var(--bg-input); font-size: 14px; }
+.updates-group > summary.updates-group-head::-webkit-details-marker { display: none; }
+.updates-group > summary.updates-group-head::before { content: "\25B8"; color: var(--text-muted); transition: transform .15s; }
+.updates-group[open] > summary.updates-group-head::before { transform: rotate(90deg); }
+.updates-group-tag { font-weight: 600; color: var(--accent, #dc2626); white-space: nowrap; }
+.updates-group-summary { color: var(--text); flex: 1; }
+.updates-group-count { color: var(--text-muted); font-size: 12px; white-space: nowrap; }
+.updates-group .updates-commit-list { padding: 6px 14px 12px; }


### PR DESCRIPTION
PR-A of the update-system overhaul (card cbe2a240). Fixes the "tons of updates" impression: the dashboard listed raw commits; now they group by release tag.

- `update-checker.ts`: `applyCompare` keeps the flat `commits[]` (backward-compat) and derives a `releases[]` view via `groupByRelease` (newest-first; a `chore(release): vX.Y.Z` commit starts a version group, older commits down to the next marker are what shipped in it, commits above the newest marker form an "upcoming" group). Human summary = the release-commit body (git trailers stripped), falling back to the subject after the `--`/`—` separator for historical releases whose body is only a trailer.
- `web/app.js`: renders `releases[]` as one collapsible `<details>` per version (newest open) with tag + summary + commit count; per-commit cards inside. Falls back to the flat list when `releases[]` is absent.
- i18n hu/en + group CSS.

Grouping source is the chore(release) commits (not the closed/stale CHANGELOG PR #424), per the approved plan. Go-forward summaries come from the release body; historical inconsistency is handled gracefully (subject fallback).

QA: 6 new unit tests, full suite 1643/1643, `tsc --noEmit` clean, no em-dash in shipped copy, browser-verified the grouped render against the live dashboard via route interception (2 groups, newest open, summary + counts correct, 0 pageerrors).

Part of A -> B -> C; B (robust update) and C (auto-update) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)