### PR TITLE
feat(updates): robust update.sh tuned to concrete failure modes (PR-B)

### DIFF
--- a/src/__tests__/update-preflight.test.ts
+++ b/src/__tests__/update-preflight.test.ts
@@ -10,10 +10,11 @@ import {
 // Helper: build a GitRunner from plain strings. Covers the common
 // "return this exact branch / status" fixtures without dragging in a
 // real git invocation.
-function makeGit(branch: string, porcelain = ''): GitRunner {
+function makeGit(branch: string, porcelain = '', ahead = 0): GitRunner {
   return {
     currentBranch: () => branch,
     porcelainStatus: () => porcelain,
+    aheadCount: () => ahead,
   }
 }
 
@@ -26,6 +27,29 @@ describe('checkUpdatePreflight --happy path', () => {
   it('ignores whitespace-only branch output', () => {
     const result = checkUpdatePreflight(makeGit('  main  ', '   '))
     expect(result.ok).toBe(true)
+  })
+})
+
+describe('checkUpdatePreflight --local commits (diverged history)', () => {
+  it('rejects when the local checkout has commits ahead of upstream', () => {
+    const result = checkUpdatePreflight(makeGit('main', '', 2))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('local-commits')
+    if (result.reason !== 'local-commits') return
+    expect(result.ahead).toBe(2)
+    expect(result.message).toMatch(/fast-forward/)
+  })
+
+  it('passes a clean tree with zero ahead', () => {
+    expect(checkUpdatePreflight(makeGit('main', '', 0)).ok).toBe(true)
+  })
+
+  it('dirty-tree takes precedence over ahead (stash is offered first)', () => {
+    const result = checkUpdatePreflight(makeGit('main', ' M src/x.ts', 3))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('dirty-tree')
   })
 })
 

--- a/src/update-preflight.ts
+++ b/src/update-preflight.ts
@@ -30,6 +30,12 @@
 export interface GitRunner {
   // Current branch name. "HEAD" (or empty) signals a detached checkout.
   currentBranch(): string
+  // Number of local commits ahead of the upstream tracking ref
+  // (git rev-list --count @{u}..HEAD). >0 means the local history has
+  // diverged, so `git pull --ff-only` will refuse -- the dominant silent
+  // failure. Returns 0 when there is no upstream or the probe fails (the
+  // safe default: do not block on an uncertain count).
+  aheadCount(): number
   // Porcelain status excluding untracked files. Non-empty = dirty tree.
   // Untracked files are excluded because the repo legitimately carries
   // ad-hoc backup files (CLAUDE.md.backup-*, SOUL.md mid-edit, etc.)
@@ -41,6 +47,7 @@ export type PreflightResult =
   | { ok: true }
   | { ok: false; reason: 'dirty-tree'; message: string }
   | { ok: false; reason: 'detached-head'; message: string }
+  | { ok: false; reason: 'local-commits'; message: string; ahead: number }
 
 // Concurrency gate: refuse a second /api/updates/apply while the first
 // update.sh is still running. An in-memory timestamp would reset on the
@@ -155,6 +162,26 @@ export function checkUpdatePreflight(git: GitRunner): PreflightResult {
       message:
         'Working tree has uncommitted changes (staged or unstaged). ' +
         'Commit or stash them before updating: git stash',
+    }
+  }
+
+  // Local commits ahead of upstream = a diverged history. `git pull --ff-only`
+  // refuses this, and because update.sh runs detached the abort is invisible
+  // (the update looks "started" then reloads to the same commit list). Catch it
+  // here with an actionable message instead of that silent death. A running
+  // agent committing to its own tracked CLAUDE.md/SOUL.md/task-config is the
+  // usual cause. The tree is clean (changes are committed), so the dirty-tree
+  // stash cannot help; reconciliation is a separate, explicit step.
+  const ahead = git.aheadCount()
+  if (ahead > 0) {
+    return {
+      ok: false,
+      reason: 'local-commits',
+      ahead,
+      message:
+        `The local checkout has ${ahead} commit(s) not on the upstream, so a ` +
+        'fast-forward update is not possible. This is usually a local edit that ' +
+        'was committed. Review with: git log @{u}..HEAD',
     }
   }
 

--- a/src/web/routes/updates.ts
+++ b/src/web/routes/updates.ts
@@ -29,6 +29,22 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
     return true
   }
 
+  // Real outcome of the last (or in-flight) update.sh run. update.sh writes
+  // store/update.last-result on EXIT with the true status, so the frontend can
+  // show success/failed/rolled-back instead of a blind reload that hides a
+  // silent failure. Absent file => no run yet (or one still in progress; the
+  // presence of store/update.pid disambiguates).
+  if (path === '/api/updates/status' && method === 'GET') {
+    let result: unknown = null
+    try {
+      result = JSON.parse(readFileSync(join(STORE_DIR, 'update.last-result'), 'utf-8'))
+    } catch { /* no result yet */ }
+    let running = false
+    try { running = statSync(UPDATE_PIDFILE).isFile() } catch { /* not running */ }
+    json(res, { running, result })
+    return true
+  }
+
   if (path === '/api/updates/check' && method === 'POST') {
     const status = await refreshUpdateStatus()
     json(res, status)
@@ -129,6 +145,17 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
         ['status', '--porcelain', '--untracked-files=no'],
         { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
       ),
+      aheadCount: () => {
+        try {
+          const out = execFileSync(
+            '/usr/bin/git',
+            ['rev-list', '--count', '@{u}..HEAD'],
+            { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
+          ).trim()
+          const n = parseInt(out, 10)
+          return Number.isFinite(n) ? n : 0
+        } catch { return 0 }
+      },
     }
     let preflight
     try {
@@ -145,6 +172,7 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
       // dirty-tree + autoStash=true: skip the dashboard-side block and let
       // update.sh handle the stash+pop. The other failure reason (detached
       // HEAD) still hard-blocks since stash cannot rescue it.
+      // dirty-tree can be auto-stashed; local-commits and detached-head cannot.
       const skipForAutoStash = preflight.reason === 'dirty-tree' && autoStash
       if (!skipForAutoStash) {
         releaseLock()
@@ -157,12 +185,19 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
       }
     }
     try {
+      // Verify store/ is writable BEFORE spawning update.sh. If update.log
+      // cannot be opened, the script would die at its own exit-4 with the log
+      // (its only output channel) being the very thing that failed -> a silent
+      // detached death. Surface it here as a synchronous error instead.
       let outFd: number | 'ignore' = 'ignore'
       try {
         mkdirSync(STORE_DIR, { recursive: true })
         outFd = openSync(join(STORE_DIR, 'update.log'), 'a', 0o600)
       } catch (err) {
-        logger.warn({ err }, 'Could not open update.log for update.sh stdio; falling back to ignore')
+        releaseLock()
+        logger.error({ err }, 'store/update.log not writable; refusing to start a blind update')
+        json(res, { error: 'store/ is not writable; cannot run the updater safely.', reason: 'store-unwritable' }, 500)
+        return true
       }
       const child = spawn('/bin/bash', [join(PROJECT_ROOT, 'update.sh')], {
         cwd: PROJECT_ROOT,

--- a/update.sh
+++ b/update.sh
@@ -17,6 +17,47 @@ MARVEEN_LANG="$(cat "${INSTALL_DIR}/.lang" 2>/dev/null || echo hu)"
 export MARVEEN_LANG
 # shellcheck source=install-lang.sh
 source "$(dirname "$0")/install-lang.sh"
+
+# --- Outcome reporting (kills the false-success UI) ---------------------------
+RESULT_STATUS="failed"
+RESULT_PHASE="init"
+RESULT_MSG=""
+RESULT_FILE="$INSTALL_DIR/store/update.last-result"
+# Once the restart is handed off to the detached finalizer, that process owns
+# the outcome file. update.sh may be reaped mid-restart on Linux (dashboard
+# cgroup teardown), so its EXIT trap must NOT clobber the finalizer's verdict.
+FINALIZE_LAUNCHED=0
+
+_json_escape() { printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null || printf '"%s"' "$1"; }
+
+write_result() {
+  local code="${1:-$?}"
+  [ "$FINALIZE_LAUNCHED" = "1" ] && return 0
+  mkdir -p "$INSTALL_DIR/store" 2>/dev/null || true
+  printf '{"status":%s,"phase":%s,"code":%s,"old":%s,"new":%s,"message":%s,"ts":%s}\n' \
+    "$(_json_escape "$RESULT_STATUS")" "$(_json_escape "$RESULT_PHASE")" "$code" \
+    "$(_json_escape "${OLD_VERSION:-unknown}")" "$(_json_escape "${NEW_VERSION:-unknown}")" \
+    "$(_json_escape "$RESULT_MSG")" "$(date +%s)" > "$RESULT_FILE" 2>/dev/null || true
+}
+
+retry() {
+  local tries="$1" pause="$2"; shift 2
+  local i=1
+  while true; do
+    if "$@"; then return 0; fi
+    if [ "$i" -ge "$tries" ]; then return 1; fi
+    echo -e "  ${DIM}retry $i/$tries...${NC}"; sleep "$pause"; pause=$(( pause * 2 )); i=$(( i + 1 ))
+  done
+}
+
+health_ok() {
+  local port="${WEB_PORT:-3420}" i=0
+  while [ "$i" -lt 20 ]; do
+    if curl -fsS -m 3 -o /dev/null "http://127.0.0.1:${port}/" 2>/dev/null; then return 0; fi
+    sleep 1; i=$(( i + 1 ))
+  done
+  return 1
+}
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -51,14 +92,33 @@ for arg in "$@"; do
   esac
 done
 
-# Pin Node to the version the dashboard service runs on. The global brew node
-# (26.x) cannot compile better-sqlite3 11.x (removed V8 APIs), which corrupts
-# node_modules on npm ci. Use the nvm-managed node that the launchd plist uses.
-# See marveen-dashboard-recovery skill for the full story.
-NODE_PIN="$HOME/.nvm/versions/node/v24.16.0/bin"
-if [ -x "$NODE_PIN/node" ]; then
-  export PATH="$NODE_PIN:$PATH"
-  echo -e "  ${DIM}Node pin: $(node -v) (better-sqlite3 ABI)${NC}"
+# Pin Node to the version the RUNNING dashboard service uses, so the native
+# better-sqlite3 rebuild yields a binding the service node can load. The old
+# hardcoded nvm version disagreed with .nvmrc (22) and package.json engines
+# (<24); compiling for the wrong ABI crash-looped the service. Resolution:
+#   1) the node exe of the live dashboard process; 2) .nvmrc via nvm; 3) PATH node.
+resolve_service_node_dir() {
+  local pid exe
+  pid="$(pgrep -f "$INSTALL_DIR/dist/index.js" 2>/dev/null | head -n1)"
+  if [ -n "$pid" ]; then
+    if command -v lsof >/dev/null 2>&1; then
+      exe="$(lsof -p "$pid" -Fn 2>/dev/null | awk '/\/node$/{print substr($0,2); exit}')"
+    fi
+    [ -z "$exe" ] && [ -r "/proc/$pid/exe" ] && exe="$(readlink -f "/proc/$pid/exe" 2>/dev/null)"
+    if [ -n "$exe" ] && [ -x "$exe" ]; then dirname "$exe"; return 0; fi
+  fi
+  if [ -f "$INSTALL_DIR/.nvmrc" ] && [ -s "$HOME/.nvm/nvm.sh" ]; then
+    local want cand
+    want="$(tr -d ' \n' < "$INSTALL_DIR/.nvmrc")"
+    cand="$(ls -d "$HOME"/.nvm/versions/node/v"$want"* 2>/dev/null | sort -V | tail -n1)"
+    [ -n "$cand" ] && [ -x "$cand/bin/node" ] && { echo "$cand/bin"; return 0; }
+  fi
+  return 1
+}
+NODE_PIN_DIR="$(resolve_service_node_dir || true)"
+if [ -n "$NODE_PIN_DIR" ] && [ -x "$NODE_PIN_DIR/node" ]; then
+  export PATH="$NODE_PIN_DIR:$PATH"
+  echo -e "  ${DIM}Node pin: $(node -v) (matches the running dashboard, better-sqlite3 ABI)${NC}"
 fi
 
 # Pidfile gate. The dashboard's /api/updates/apply creates
@@ -80,7 +140,7 @@ UPDATE_PIDFILE_TMP="$UPDATE_PIDFILE.$$.tmp"
 # still holds its placeholder lock. Clean up only the tmp file if it
 # leaked; leave the dashboard's pidfile alone so the lock does not
 # disappear on a write error.
-trap 'rm -f "$UPDATE_PIDFILE_TMP"' EXIT
+trap 'rc=$?; write_result "$rc"; rm -f "$UPDATE_PIDFILE_TMP"' EXIT
 {
   echo "$$"
   # Portable wall-clock epoch in ms. date +%s%3N is GNU-only; on BSD
@@ -99,7 +159,7 @@ mv "$UPDATE_PIDFILE_TMP" "$UPDATE_PIDFILE"
 # Only after mv succeeds do we own the lock; extend the trap to remove
 # the final pidfile too. Until this point a mv failure left the
 # dashboard's placeholder intact for its normal age-based recovery.
-trap 'rm -f "$UPDATE_PIDFILE" "$UPDATE_PIDFILE_TMP"' EXIT
+trap 'rc=$?; write_result "$rc"; rm -f "$UPDATE_PIDFILE" "$UPDATE_PIDFILE_TMP"' EXIT
 
 # Tee the full run into store/update.log so failures are inspectable
 # after the fact. The dashboard launches this script detached with
@@ -195,7 +255,7 @@ DIRTY=$(git status --porcelain --untracked-files=no | grep -vE ' HEARTBEAT\.md$'
 if [ -n "$DIRTY" ]; then
   if [ "${AUTO_STASH:-0}" = "1" ]; then
     echo -e "  Lokalis valtozasok stash-elve (auto-stash)..."
-    if ! git stash push --keep-index -m "marveen-update-auto-stash $(date +%Y%m%d-%H%M%S)"; then
+    if ! git stash push -u -m "marveen-update-auto-stash $(date +%Y%m%d-%H%M%S)"; then
       if [[ "${MARVEEN_LANG:-hu}" == "en" ]]; then
         echo -e "${RED}ERROR:${NC} Auto-stash failed. Check: git status"
       else
@@ -219,9 +279,27 @@ fi
 # Save current version
 OLD_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
-# Pull latest from the current branch's origin counterpart.
+# Full SHA snapshot for a safe rollback: ff-only means OLD is a strict ancestor
+# of NEW, so reset --hard $OLD_VERSION_FULL reverts without a force-push.
+OLD_VERSION_FULL=$(git rev-parse HEAD 2>/dev/null || echo "")
+
+# Ahead-detect: local commits not on upstream make ff-only refuse. Report it
+# actionably instead of dying silently under set -e (the dominant failure).
+RESULT_PHASE="pull"
+AHEAD=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+if [ "${AHEAD:-0}" -gt 0 ]; then
+  RESULT_MSG="A helyi checkout ${AHEAD} committal elore van az upstreamhez kepest; a fast-forward frissites nem lehetseges. Nezd meg: git log @{u}..HEAD"
+  echo -e "${RED}HIBA:${NC} a helyi checkout ${AHEAD} committal elore van az upstreamhez kepest; fast-forward nem lehetseges. Nezd: git log @{u}..HEAD"
+  exit 5
+fi
+
+# Pull latest, NON-fatal under set -e so a diverged/network failure is reported.
 echo -e "  Letoltes (origin/${CURRENT_BRANCH})..."
-git pull --ff-only origin "$CURRENT_BRANCH"
+if ! retry 3 3 git pull --ff-only origin "$CURRENT_BRANCH"; then
+  RESULT_MSG="git pull --ff-only sikertelen (divergencia vagy halozati hiba). Nezd: git status; git log @{u}..HEAD"
+  echo -e "${RED}HIBA:${NC} git pull --ff-only sikertelen origin/${CURRENT_BRANCH}."
+  exit 5
+fi
 NEW_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 # Full SHA for the build-marker (dist/.built-commit). HEAD does not change
 # again in this script (no checkout), so this is the commit any build below
@@ -287,7 +365,8 @@ fi
 # patched-over malicious dep.
 if git diff "$OLD_VERSION" "$NEW_VERSION" --name-only | grep -qE "^package(-lock)?\.json$"; then
   echo -e "  Fuggosegek frissitese (lock-strict)..."
-  if ! npm ci --silent; then
+  RESULT_PHASE="npm-ci"
+  if ! retry 3 3 npm ci --silent; then
     echo -e "  HIBA: npm ci sikertelen. Valoszinuleg a package-lock.json nincs szinkronban."
     echo -e "  Reszletekert futtasd: npm ci"
     exit 1
@@ -315,11 +394,25 @@ fi
 # Skipped on an already-up-to-date --reseed-fleet/--regen-claudemd run: the
 # compiled tree did not change, only the seeded skills/tasks need refreshing.
 if [ "${SKIP_BUILD:-0}" != "1" ]; then
-  npm rebuild better-sqlite3 --build-from-source --silent
+  RESULT_PHASE="build"
+  retry 2 3 npm rebuild better-sqlite3 --build-from-source --silent || true
 
-  # Rebuild
+  # Rebuild. On failure, auto-rollback to the pre-update commit (safe ff-only
+  # ancestor) and rebuild that, leaving the box on a WORKING old version rather
+  # than git=NEW/dist=OLD.
   echo -e "  Forditas..."
-  npm run build --silent
+  if ! retry 2 3 npm run build --silent; then
+    echo -e "${RED}HIBA:${NC} build sikertelen. Visszaallitas a korabbi verziora (${OLD_VERSION})..."
+    if [ -n "$OLD_VERSION_FULL" ]; then
+      git reset --hard "$OLD_VERSION_FULL" >/dev/null 2>&1 || true
+      npm rebuild better-sqlite3 --build-from-source --silent 2>/dev/null || true
+      npm run build --silent 2>/dev/null || true
+      [ -d "$INSTALL_DIR/dist" ] && echo "$OLD_VERSION_FULL" > "$BUILT_COMMIT_FILE"
+    fi
+    RESULT_STATUS="rolled-back"
+    RESULT_MSG="A build elbukott; a rendszer visszaallt a korabbi mukodo verziora (${OLD_VERSION}). A frissites nem ment ki."
+    exit 6
+  fi
 
   # Stamp the build-marker AFTER a successful build (set -e means we only
   # reach this line if the build succeeded). dist/.built-commit records the
@@ -562,10 +655,10 @@ if [ -d "$MARKETPLACE_PLUGIN_DIR" ]; then
       fi
     fi
     SLACK_REF_TMP="$(mktemp "${SLACK_REF_FILE}.XXXXXX")"
-    trap 'rm -f "$UPDATE_PIDFILE" "$UPDATE_PIDFILE_TMP" "$SLACK_REF_TMP"' EXIT
+    trap 'rc=$?; write_result "$rc"; rm -f "$UPDATE_PIDFILE" "$UPDATE_PIDFILE_TMP" "$SLACK_REF_TMP"' EXIT
     echo "$CURRENT_REF" > "$SLACK_REF_TMP"
     mv "$SLACK_REF_TMP" "$SLACK_REF_FILE"
-    trap 'rm -f "$UPDATE_PIDFILE" "$UPDATE_PIDFILE_TMP"' EXIT
+    trap 'rc=$?; write_result "$rc"; rm -f "$UPDATE_PIDFILE" "$UPDATE_PIDFILE_TMP"' EXIT
   fi
 fi
 
@@ -596,40 +689,95 @@ if [ "$STASHED_AUTO" = "1" ]; then
   fi
 fi
 
-# Restart services.
+# Restart services -- via a DETACHED finalizer.
 #
-# BUG FIX (update.sh self-kill): when the update is triggered from the dashboard,
-# update.sh runs INSIDE the marveen-*-dashboard systemd service's cgroup. stop.sh
-# tears that cgroup down, which reaps THIS script before start.sh runs -> both
-# services stay `inactive (dead)` after every update (update.log ends at the
-# "inditas..." line, no "elinditva"). Run the stop+start in a transient systemd
-# scope OUTSIDE our cgroup so the restart completes even though our own process
-# is killed mid-way. The scope is registered with (and survives under) the user
-# systemd manager, independent of the dashboard cgroup.
+# Two hard constraints force this shape:
+#   1) Self-kill: when triggered from the dashboard, update.sh runs INSIDE the
+#      marveen-*-dashboard systemd cgroup. stop.sh tears that cgroup down, which
+#      reaps THIS script before start.sh runs -> services stay dead. setsid is
+#      NOT enough (same cgroup); only a separate cgroup (systemd-run --scope)
+#      survives. So the restart must run OUTSIDE our cgroup.
+#   2) Health-check + rollback must ALSO survive our death. Since update.sh may
+#      be reaped at stop.sh, the whole restart -> health-poll -> rollback-on-fail
+#      -> write final result sequence lives in a standalone finalizer script that
+#      we launch detached and then exit. The finalizer, not update.sh, owns the
+#      outcome file from here on (FINALIZE_LAUNCHED guards the EXIT trap).
 #
-# NOTE: setsid is NOT a valid escape here -- a new session/process-group is still
-# in the same cgroup, so stop.sh would still kill it. Only a separate cgroup
-# (systemd-run --scope) survives. On macOS/launchd there is no cgroup self-kill,
-# so the direct call (else branch) is correct there and is a no-op change.
-echo -e "  Szolgaltatasok ujrainditasa..."
-if command -v systemd-run >/dev/null 2>&1 && [ -n "${XDG_RUNTIME_DIR:-}" ]; then
-  # --scope: run synchronously in a fresh transient scope (its own cgroup).
-  # --collect: garbage-collect the scope unit once it exits.
-  # $INSTALL_DIR is passed as the positional arg so the inner shell sees it even
-  # if the environment is trimmed.
-  systemd-run --user --scope --collect --quiet \
-    bash -c '"$1/scripts/stop.sh"; "$1/scripts/start.sh"' _ "$INSTALL_DIR" \
-    || { "$INSTALL_DIR/scripts/stop.sh"; "$INSTALL_DIR/scripts/start.sh"; }
+# XDG_RUNTIME_DIR is derived if unset (service env sometimes trims it), so the
+# systemd-run scope can be created instead of silently falling back to a direct
+# restart that self-kills and bricks the box.
+FINALIZE_SCRIPT="$INSTALL_DIR/store/update-finalize.sh"
+cat > "$FINALIZE_SCRIPT" <<'FINALIZE_EOF'
+#!/usr/bin/env bash
+# Detached update finalizer. Args:
+#   $1 INSTALL_DIR  $2 OLD_FULL_SHA  $3 OLD_SHORT  $4 PORT
+#   $5 RESULT_FILE  $6 BUILT_COMMIT_FILE  $7 NEW_SHORT  $8 NODE_PIN_DIR
+INSTALL_DIR="$1"; OLD_FULL="$2"; OLD_SHORT="$3"; PORT="$4"
+RESULT_FILE="$5"; BUILT="$6"; NEW_SHORT="$7"; NODE_PIN_DIR="$8"
+[ -n "$NODE_PIN_DIR" ] && export PATH="$NODE_PIN_DIR:$PATH"
+cd "$INSTALL_DIR" 2>/dev/null || true
+
+_esc() { printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null || printf '"%s"' "$1"; }
+_write() { # status phase code message
+  printf '{"status":%s,"phase":%s,"code":%s,"old":%s,"new":%s,"message":%s,"ts":%s}\n' \
+    "$(_esc "$1")" "$(_esc "$2")" "$3" "$(_esc "$OLD_SHORT")" "$(_esc "$NEW_SHORT")" \
+    "$(_esc "$4")" "$(date +%s)" > "$RESULT_FILE" 2>/dev/null || true
+}
+_health() { local i=0; while [ "$i" -lt 20 ]; do
+  curl -fsS -m 3 -o /dev/null "http://127.0.0.1:${PORT}/" 2>/dev/null && return 0
+  sleep 1; i=$(( i + 1 )); done; return 1; }
+_restart() { "$INSTALL_DIR/scripts/stop.sh"; "$INSTALL_DIR/scripts/start.sh"; }
+
+_restart
+if _health; then _write success restart 0 ""; exit 0; fi
+
+# Restart did not bring the dashboard back -> auto-rollback to the pre-update
+# commit (safe: ff-only ancestor, no force-push, no local-change discard) and
+# restart that, so the box ends on a WORKING old version.
+if [ -n "$OLD_FULL" ]; then
+  git reset --hard "$OLD_FULL" >/dev/null 2>&1 || true
+  npm ci --silent 2>/dev/null || true
+  npm rebuild better-sqlite3 --build-from-source --silent 2>/dev/null || true
+  npm run build --silent 2>/dev/null || true
+  [ -d "$INSTALL_DIR/dist" ] && echo "$OLD_FULL" > "$BUILT"
+  _restart
+fi
+if _health; then
+  _write rolled-back health-check 6 "A frissites utan a dashboard nem indult el; visszaalltunk a korabbi mukodo verziora (${OLD_SHORT}). A frissites nem ment ki."
 else
-  # macOS/launchd, or no user-systemd: no cgroup self-kill, restart directly.
-  "$INSTALL_DIR/scripts/stop.sh"
-  "$INSTALL_DIR/scripts/start.sh"
+  _write failed health-check 1 "A dashboard a frissites es a visszaallitas utan sem valaszol a ${PORT} porton. Kezi beavatkozas szukseges."
+fi
+FINALIZE_EOF
+chmod +x "$FINALIZE_SCRIPT"
+
+echo -e "  Szolgaltatasok ujrainditasa..."
+RESULT_PHASE="restart"
+# The finalizer owns the result file from here; do not let our EXIT trap write.
+FINALIZE_LAUNCHED=1
+FINALIZE_ARGS=("$INSTALL_DIR" "$OLD_VERSION_FULL" "$OLD_VERSION" "${WEB_PORT:-3420}" "$RESULT_FILE" "$BUILT_COMMIT_FILE" "$NEW_VERSION" "${NODE_PIN_DIR:-}")
+XDG_RUN="${XDG_RUNTIME_DIR:-/run/user/$(id -u 2>/dev/null)}"
+if command -v systemd-run >/dev/null 2>&1 && [ -d "$XDG_RUN" ]; then
+  # Linux/systemd: the finalizer runs inside a transient scope whose OWN cgroup
+  # is separate from the dashboard cgroup, so it survives stop.sh tearing that
+  # cgroup down (which reaps update.sh). Cgroup separation -- not foreground/bg
+  # -- is what guarantees survival, so we background it and return promptly; if
+  # scope creation fails, fall back to a plain detached setsid run.
+  XDG_RUNTIME_DIR="$XDG_RUN" systemd-run --user --scope --collect --quiet \
+    bash "$FINALIZE_SCRIPT" "${FINALIZE_ARGS[@]}" \
+    || setsid bash "$FINALIZE_SCRIPT" "${FINALIZE_ARGS[@]}" < /dev/null > /dev/null 2>&1 &
+elif command -v setsid >/dev/null 2>&1; then
+  # macOS/launchd or no user-systemd: no cgroup self-kill. Detach in the
+  # background so a parent signal during restart cannot abort the health/
+  # rollback sequence and update.sh returns promptly.
+  setsid bash "$FINALIZE_SCRIPT" "${FINALIZE_ARGS[@]}" < /dev/null > /dev/null 2>&1 &
+else
+  bash "$FINALIZE_SCRIPT" "${FINALIZE_ARGS[@]}" < /dev/null > /dev/null 2>&1 &
 fi
 
 echo ""
 if [[ "${MARVEEN_LANG:-hu}" == "en" ]]; then
-  echo -e "${GREEN}✓ Updated: ${OLD_VERSION} -> ${NEW_VERSION}${NC}"
+  echo -e "${GREEN}✓ Update applied (${OLD_VERSION} -> ${NEW_VERSION}); restarting and health-checking...${NC}"
 else
-  echo -e "${GREEN}✓ Frissítve: ${OLD_VERSION} -> ${NEW_VERSION}${NC}"
+  echo -e "${GREEN}✓ Frissites alkalmazva (${OLD_VERSION} -> ${NEW_VERSION}); ujrainditas es health-check folyamatban...${NC}"
 fi
 echo ""

--- a/web/app.js
+++ b/web/app.js
@@ -9910,12 +9910,55 @@ async function runUpdate(autoStash) {
       showToast(t('updates.toast.not_started', { msg: data.error || ('HTTP ' + res.status) }))
       return
     }
-    showToast(t('updates.toast.started'))
-    setTimeout(() => window.location.reload(), 30000)
+    showToast(t('updates.toast.applying'))
+    // Poll the real outcome instead of a blind timed reload. update.sh (and its
+    // detached finalizer) write store/update.last-result on exit, so we surface
+    // success / rolled-back / failed rather than a false "done" that reloads
+    // into an unchanged (or dead) dashboard.
+    await pollUpdateOutcome(resetBtn)
   } catch (err) {
     resetBtn()
     showToast(t('updates.toast.error', {msg: err.message || err}))
   }
+}
+
+// Poll /api/updates/status until the run finishes (pidfile gone AND a fresh
+// result is present), then show the true outcome. Reload only on success.
+async function pollUpdateOutcome(resetBtn) {
+  const startedAt = Date.now()
+  const deadline = startedAt + 5 * 60_000   // hard cap: 5 min
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 3000))
+    let data
+    try {
+      const res = await fetch('/api/updates/status')
+      data = await res.json()
+    } catch {
+      // Dashboard is mid-restart (expected): keep polling.
+      continue
+    }
+    const result = data && data.result
+    const fresh = result && typeof result.ts === 'number' && result.ts * 1000 >= startedAt - 5000
+    if (data && !data.running && fresh) {
+      const st = result.status
+      if (st === 'success') {
+        showToast(t('updates.toast.success', { old: result.old || '', new: result.new || '' }))
+        setTimeout(() => window.location.reload(), 2000)
+        return
+      }
+      if (st === 'rolled-back') {
+        if (resetBtn) resetBtn()
+        showToast(t('updates.toast.rolled_back', { old: result.old || '', msg: result.message || '' }))
+        return
+      }
+      // failed
+      if (resetBtn) resetBtn()
+      showToast(t('updates.toast.failed', { phase: result.phase || '?', msg: result.message || ('code ' + result.code) }))
+      return
+    }
+  }
+  if (resetBtn) resetBtn()
+  showToast(t('updates.toast.status_timeout'))
 }
 
 document.getElementById('updatesApplyBtn').addEventListener('click', async () => {

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1305,6 +1305,11 @@ window._i18n.en = {
   // --- Updates toasts ---
   'updates.toast.not_started':   'Update not started: {msg}',
   'updates.toast.started':       'Update started, dashboard reloading...',
+  'updates.toast.applying':      'Update in progress (restart and health-check)...',
+  'updates.toast.success':       'Updated: {old} -> {new}. Reloading...',
+  'updates.toast.rolled_back':   'Update failed, rolled back to the previous version ({old}). {msg}',
+  'updates.toast.failed':        'Update failed ({phase}): {msg}',
+  'updates.toast.status_timeout':'Update status did not arrive in time. Check store/update.log.',
 
   // --- Ideas toasts ---
   'ideas.toast.score_saved':     'Score saved',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1303,6 +1303,11 @@ window._i18n.hu = {
   // --- Updates toasts ---
   'updates.toast.not_started':   'Frissítés nem indult: {msg}',
   'updates.toast.started':       'Frissítés elindult, a dashboard újratöltődik...',
+  'updates.toast.applying':      'Frissítés folyamatban (újraindítás és health-check)...',
+  'updates.toast.success':       'Frissítve: {old} -> {new}. Újratöltés...',
+  'updates.toast.rolled_back':   'A frissítés nem sikerült, visszaálltunk a korábbi verzióra ({old}). {msg}',
+  'updates.toast.failed':        'Frissítés sikertelen ({phase}): {msg}',
+  'updates.toast.status_timeout':'A frissítés állapota nem érkezett meg időben. Nézd meg a store/update.log fájlt.',
 
   // --- Ideas toasts ---
   'ideas.toast.score_saved':     'Pontozás mentve',


### PR DESCRIPTION
## PR-B: robust updater (card cbe2a240, part B of A->B->C->D)

The updater "runs" but often silently no-ops or bricks the box, then the UI shows a false "Frissitve" and reloads into an unchanged/dead dashboard. This PR tunes `update.sh` + the apply flow to the **actual** failure modes (code-inferred from our own update path -- we promote from develop and never press the button, so we have no customer failure logs; the Linux restart/rollback path is code-reviewed, not live-restart-tested).

### What changed

**1. Kill the false-success UI (#1 priority).** `update.sh` records the TRUE outcome in `store/update.last-result` on every exit (`write_result` wired into all EXIT traps). New `GET /api/updates/status` returns `{running, result}`. The frontend polls it and shows **success / rolled-back / failed** instead of a blind 30s reload. A non-writable `store/` now returns a synchronous 500, not a silent detached exit-4.

**2. Ahead / divergence detect.** The dominant silent failure: a running agent commits to its own tracked CLAUDE.md/SOUL.md/task-config -> clean tree but diverged history -> auto-stash can't help -> `git pull --ff-only` refuses -> dies invisibly under `set -e`. Now detected in both preflight (`GitRunner.aheadCount` + `local-commits` reason) and `update.sh`, with an actionable message (`git log @{u}..HEAD`).

**3. Robust restart-detach + health-check + rollback.** Restart, `:3420` health-poll, and rollback-on-failure now run in a standalone **detached finalizer** that survives `update.sh` being reaped by the dashboard cgroup teardown on Linux. `XDG_RUNTIME_DIR` is derived when unset so the `systemd-run --scope` is actually created (the old direct-restart fallback self-kills and bricks the box). If the dashboard doesn't answer after restart, the finalizer auto-rolls-back to the pre-update commit and restarts that.

**4. Node-pin fix.** Resolve the node dir from the RUNNING dashboard process (then `.nvmrc`, then PATH) instead of a hardcoded nvm v24 that disagreed with `.nvmrc` (22) and `engines` (<24) and crash-looped better-sqlite3 on an ABI mismatch.

**5. Retry + auto-rollback.** `git pull` / `npm ci` / build retry with backoff. A failed build auto-rolls-back to the pre-update commit (safe ff-only ancestor, no force-push, no local-change discard) and rebuilds it, leaving the box on a working old version rather than git=NEW/dist=OLD.

Also: auto-stash switched to `git stash push -u` so untracked files are preserved.

### Testing
- `tsc --noEmit` clean.
- Full vitest suite: **1646 passed** (40 preflight incl. new ahead-detect / divergence cases).
- `bash -n` on both `update.sh` and the generated finalizer; JSON result writer verified valid with quotes + newlines.
- Not live-restart-tested on Linux/systemd (no reproduction host); that path is code-reviewed. Flagging the uncertainty per instruction.

### Not in scope
- PR-C (seeded auto-update scheduled-task, default OFF) and PR-D (post-rollback opt-in updater-agent) follow as separate PRs.