### PR TITLE
feat(updates): opt-in weekly auto-update scheduled-task (PR-C)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,9 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # OLLAMA_URL=http://localhost:11434
 # MARVEEN_ENV=linux-server  # platform override: macos | linux-server | linux-gui
 # GOOGLE_API_KEY=your_google_api_key
+
+# Opt-in automatikus frissítés. Alapértelmezetten KI. Ha 1-re állítod, a seedelt
+# "auto-update" ütemezett feladat minden szerdán 04:00-kor lefuttatja a robusztus
+# update.sh-t (pull + build + restart + health-check + szükség esetén rollback),
+# és a kimenetről Telegram-riasztást küld. Bármi más érték = kikapcsolva.
+# AUTO_UPDATE_ENABLED=0

--- a/seed-scheduled-tasks/auto-update/task-config.json
+++ b/seed-scheduled-tasks/auto-update/task-config.json
@@ -1,0 +1,11 @@
+{
+  "schedule": "0 4 * * 3",
+  "agent": "{{MAIN_AGENT_ID}}",
+  "enabled": true,
+  "type": "command",
+  "description": "Auto-update (opt-in): heti egyszer meghivja a robusztus update.sh-t. ALAPERTELMEZETTEN KIKAPCSOLVA -- a parancs csak akkor futtatja a frissitest, ha az .env-ben AUTO_UPDATE_ENABLED=1. A frissites, restart, health-check es szukseg eseten a rollback a update.sh dolga; a kimenetrol a finalizer kuld Telegram-riasztast (MARVEEN_UPDATE_NOTIFY=1).",
+  "command": "AUE=$(grep '^AUTO_UPDATE_ENABLED=' '{{INSTALL_DIR}}/.env' 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' \\r\"'); [ \"$AUE\" = \"1\" ] || exit 0; cd '{{INSTALL_DIR}}' || exit 1; if command -v setsid >/dev/null 2>&1; then DETACH=setsid; else DETACH=nohup; fi; MARVEEN_UPDATE_NOTIFY=1 AUTO_STASH=1 $DETACH bash '{{INSTALL_DIR}}/update.sh' >> '{{INSTALL_DIR}}/store/update.log' 2>&1 < /dev/null & exit 0",
+  "timeoutMs": 30000,
+  "failThreshold": 1,
+  "createdAt": 0
+}

--- a/src/__tests__/auto-update-seed-task.test.ts
+++ b/src/__tests__/auto-update-seed-task.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Guards the seeded auto-update scheduled task (PR-C). It is a command-type
+// (LLM-free) task that calls PR-B's robust update.sh weekly, but is OPT-IN:
+// the command must no-op unless the operator sets AUTO_UPDATE_ENABLED=1 in
+// .env. These assertions lock the safety-critical shape so an accidental edit
+// cannot silently turn auto-update ON for every install or drop the gate.
+const CONFIG_PATH = join(__dirname, '..', '..', 'seed-scheduled-tasks', 'auto-update', 'task-config.json')
+
+interface TaskConfig {
+  schedule: string
+  agent: string
+  enabled: boolean
+  type: string
+  description: string
+  command: string
+  timeoutMs: number
+  failThreshold: number
+  createdAt: number
+}
+
+const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8')) as TaskConfig
+
+describe('auto-update seed task', () => {
+  it('is a command-type task on the Wednesday 04:00 cron', () => {
+    expect(config.type).toBe('command')
+    expect(config.schedule).toBe('0 4 * * 3')
+  })
+
+  it('targets the main agent via the distribution placeholder (no hardcoded id)', () => {
+    expect(config.agent).toBe('{{MAIN_AGENT_ID}}')
+  })
+
+  it('gates on AUTO_UPDATE_ENABLED and no-ops when it is not 1', () => {
+    expect(config.command).toContain('AUTO_UPDATE_ENABLED=')
+    // The gate must exit before ever launching update.sh.
+    const gateIdx = config.command.indexOf('|| exit 0')
+    const launchIdx = config.command.indexOf('update.sh')
+    expect(gateIdx).toBeGreaterThan(-1)
+    expect(launchIdx).toBeGreaterThan(gateIdx)
+  })
+
+  it('calls PR-B update.sh with the notify flag, not its own update logic', () => {
+    expect(config.command).toContain('MARVEEN_UPDATE_NOTIFY=1')
+    expect(config.command).toContain('AUTO_STASH=1')
+    expect(config.command).toContain('{{INSTALL_DIR}}/update.sh')
+  })
+
+  it('detaches portably (setsid on Linux, nohup fallback on macOS)', () => {
+    expect(config.command).toContain('setsid')
+    expect(config.command).toContain('nohup')
+  })
+
+  it('uses install-dir placeholders, never a hardcoded absolute path', () => {
+    expect(config.command).toContain('{{INSTALL_DIR}}')
+    expect(config.command).not.toMatch(/\/Users\/|\/home\//)
+  })
+})

--- a/update.sh
+++ b/update.sh
@@ -712,8 +712,10 @@ cat > "$FINALIZE_SCRIPT" <<'FINALIZE_EOF'
 # Detached update finalizer. Args:
 #   $1 INSTALL_DIR  $2 OLD_FULL_SHA  $3 OLD_SHORT  $4 PORT
 #   $5 RESULT_FILE  $6 BUILT_COMMIT_FILE  $7 NEW_SHORT  $8 NODE_PIN_DIR
+#   $9 NOTIFY (1 = also send a channel report after the outcome; used by the
+#             unattended auto-update task, silent for a dashboard-triggered run)
 INSTALL_DIR="$1"; OLD_FULL="$2"; OLD_SHORT="$3"; PORT="$4"
-RESULT_FILE="$5"; BUILT="$6"; NEW_SHORT="$7"; NODE_PIN_DIR="$8"
+RESULT_FILE="$5"; BUILT="$6"; NEW_SHORT="$7"; NODE_PIN_DIR="$8"; NOTIFY="${9:-0}"
 [ -n "$NODE_PIN_DIR" ] && export PATH="$NODE_PIN_DIR:$PATH"
 cd "$INSTALL_DIR" 2>/dev/null || true
 
@@ -723,13 +725,29 @@ _write() { # status phase code message
     "$(_esc "$1")" "$(_esc "$2")" "$3" "$(_esc "$OLD_SHORT")" "$(_esc "$NEW_SHORT")" \
     "$(_esc "$4")" "$(date +%s)" > "$RESULT_FILE" 2>/dev/null || true
 }
+# Channel report for the unattended auto-update. Plugin-independent (Bot API via
+# notify.sh), because at 4am the Telegram plugin may be down and the finalizer
+# runs detached with no tmux session. Silent (NOTIFY!=1) for manual runs, where
+# the dashboard UI already polls /api/updates/status.
+_notify() { # status
+  [ "$NOTIFY" = "1" ] || return 0
+  [ -x "$INSTALL_DIR/scripts/notify.sh" ] || [ -f "$INSTALL_DIR/scripts/notify.sh" ] || return 0
+  local msg
+  case "$1" in
+    success)     msg="✅ Auto-update kesz: ${OLD_SHORT} -> ${NEW_SHORT}. A dashboard ujraindult es valaszol (health OK)." ;;
+    rolled-back) msg="⚠️ Auto-update: a frissites nem sikerult (a dashboard nem indult), visszaalltunk a korabbi mukodo verziora (${OLD_SHORT}). Reszletek: store/update.log" ;;
+    *)           msg="🔴 Auto-update SIKERTELEN: a dashboard a frissites ES a rollback utan sem valaszol a ${PORT} porton. Kezi beavatkozas kell. Reszletek: store/update.log" ;;
+  esac
+  bash "$INSTALL_DIR/scripts/notify.sh" "$msg" >/dev/null 2>&1 || true
+}
+_finish() { _write "$1" "$2" "$3" "$4"; _notify "$1"; exit "$3"; }
 _health() { local i=0; while [ "$i" -lt 20 ]; do
   curl -fsS -m 3 -o /dev/null "http://127.0.0.1:${PORT}/" 2>/dev/null && return 0
   sleep 1; i=$(( i + 1 )); done; return 1; }
 _restart() { "$INSTALL_DIR/scripts/stop.sh"; "$INSTALL_DIR/scripts/start.sh"; }
 
 _restart
-if _health; then _write success restart 0 ""; exit 0; fi
+if _health; then _finish success restart 0 ""; fi
 
 # Restart did not bring the dashboard back -> auto-rollback to the pre-update
 # commit (safe: ff-only ancestor, no force-push, no local-change discard) and
@@ -743,9 +761,9 @@ if [ -n "$OLD_FULL" ]; then
   _restart
 fi
 if _health; then
-  _write rolled-back health-check 6 "A frissites utan a dashboard nem indult el; visszaalltunk a korabbi mukodo verziora (${OLD_SHORT}). A frissites nem ment ki."
+  _finish rolled-back health-check 6 "A frissites utan a dashboard nem indult el; visszaalltunk a korabbi mukodo verziora (${OLD_SHORT}). A frissites nem ment ki."
 else
-  _write failed health-check 1 "A dashboard a frissites es a visszaallitas utan sem valaszol a ${PORT} porton. Kezi beavatkozas szukseges."
+  _finish failed health-check 1 "A dashboard a frissites es a visszaallitas utan sem valaszol a ${PORT} porton. Kezi beavatkozas szukseges."
 fi
 FINALIZE_EOF
 chmod +x "$FINALIZE_SCRIPT"
@@ -754,7 +772,10 @@ echo -e "  Szolgaltatasok ujrainditasa..."
 RESULT_PHASE="restart"
 # The finalizer owns the result file from here; do not let our EXIT trap write.
 FINALIZE_LAUNCHED=1
-FINALIZE_ARGS=("$INSTALL_DIR" "$OLD_VERSION_FULL" "$OLD_VERSION" "${WEB_PORT:-3420}" "$RESULT_FILE" "$BUILT_COMMIT_FILE" "$NEW_VERSION" "${NODE_PIN_DIR:-}")
+# MARVEEN_UPDATE_NOTIFY=1 (set by the unattended auto-update task) makes the
+# finalizer send a channel report after the restart+health outcome. A manual
+# dashboard-triggered run leaves it unset -> silent (the UI polls the status).
+FINALIZE_ARGS=("$INSTALL_DIR" "$OLD_VERSION_FULL" "$OLD_VERSION" "${WEB_PORT:-3420}" "$RESULT_FILE" "$BUILT_COMMIT_FILE" "$NEW_VERSION" "${NODE_PIN_DIR:-}" "${MARVEEN_UPDATE_NOTIFY:-0}")
 XDG_RUN="${XDG_RUNTIME_DIR:-/run/user/$(id -u 2>/dev/null)}"
 if command -v systemd-run >/dev/null 2>&1 && [ -d "$XDG_RUN" ]; then
   # Linux/systemd: the finalizer runs inside a transient scope whose OWN cgroup


### PR DESCRIPTION
## PR-C: opt-in weekly auto-update (card cbe2a240, part C of A->B->C->D)

Seeds a **command-type (LLM-free)** scheduled task that calls PR-B's robust `update.sh` weekly. **Off by default** -- a fresh install never auto-updates.

### What changed

**`seed-scheduled-tasks/auto-update/task-config.json`** -- `type: command`, cron `0 4 * * 3` (Wed 04:00). The command:
- gates on `AUTO_UPDATE_ENABLED` in `.env` and `exit 0` (no-op) unless it is exactly `1` -> **opt-in**;
- when enabled, launches `update.sh` **detached** (`setsid` on Linux, `nohup` fallback on macOS) with `AUTO_STASH=1` and returns immediately;
- **never reimplements update logic** -- all pull/build/restart/health/rollback is PR-B's `update.sh`.

**`update.sh` finalizer** -- new `NOTIFY` arg (from `MARVEEN_UPDATE_NOTIFY=1`) sends a **channel report after the restart+health outcome** (success / rolled-back / failed) via `scripts/notify.sh`. Plugin-independent (Bot API direct), because the finalizer runs detached with no tmux session and the Telegram plugin may be down at 04:00. A **manual** dashboard-triggered update leaves `NOTIFY` unset and stays silent (the UI already polls `/api/updates/status`).

**`.env.example`** documents `AUTO_UPDATE_ENABLED` (default off).

### Safety
- Opt-in gate is the first thing the command does; `update.sh` is only reached after it.
- Distribution-safe: `{{MAIN_AGENT_ID}}` / `{{INSTALL_DIR}}` placeholders, no hardcoded ids or absolute paths.
- Report channel is the plugin-independent Bot API path, so a 04:00 plugin outage does not swallow the outcome.

### Testing
- `tsc` clean, full vitest **1652 passed** (6 new: opt-in gate ordering, notify/stash wiring, portable detach, no-hardcoded-path).
- `bash -n` on `update.sh` + generated finalizer.
- Gate verified by execution: OFF (no/other `AUTO_UPDATE_ENABLED`) = no-op exit 0; ON = launches `update.sh` with `MARVEEN_UPDATE_NOTIFY=1 AUTO_STASH=1`.
- Same standing caveat as PR-B: the live restart/rollback path is not exercised on a Linux/systemd host here; that belongs to the pre-promote live-test (ties into the AVX-VPS pilot per Marveen's promote-gate).

### Next
- PR-D: post-rollback opt-in updater-agent (built after this).