### PR TITLE
feat(updates): post-rollback opt-in diagnosis agent (PR-D)

### DIFF
--- a/seed-scheduled-tasks/post-rollback-diagnose/SKILL.md
+++ b/seed-scheduled-tasks/post-rollback-diagnose/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: post-rollback-diagnose
+description: On-demand diagnózis egy sikertelen frissítés + auto-rollback után. A dashboard "Frissítés diagnózisa" gombja indítja (opt-in). NEM cron-vezérelt.
+---
+
+[Operator-kezdeményezett feladat a dashboardról: sikertelen frissítés diagnózisa]
+
+A legutóbbi frissítés elbukott, és a rendszer automatikusan visszaállt a korábbi, működő verzióra. A box MOST a régi, működő verzión fut, tehát NINCS sürgősség. Nyugodtan, körültekintően dolgozz. A felhasználó a dashboardon explicit kérte ezt a diagnózist (Claude kredit jóváhagyva).
+
+Cél: derítsd ki, MIÉRT bukott a frissítés, és ha biztonságosan javítható, javítsd.
+
+Ha van backend/dev al-ügynököd, delegáld neki a diagnózist és a javítást, majd ellenőrizd; ha nincs, végezd el magad.
+
+Diagnózis források (olvasd ELŐSZÖR):
+- `{{INSTALL_DIR}}/store/update.log` -- a bukás konkrét oka (a legutóbbi futás a fájl végén)
+- `{{INSTALL_DIR}}/store/update.last-result` -- a rögzített kimenet (status, phase, message)
+- `git status`, `git log @{u}..HEAD`, `git log --oneline -10`
+
+KÖTELEZŐ guardrailek (SOHA ne szegd meg):
+- SOHA ne `git push --force` / `-f`. Force-push tilos.
+- SOHA ne dobj el helyi változást. Ha a working tree piszkos: `git stash` (NEM `git checkout`/`reset --hard` a helyi munkára). A stash-t hagyd meg, ne dropold.
+- A frissítés/rollback maga a robusztus `update.sh` dolga. NE írj párhuzamos update- vagy rollback-logikát; a diagnózisod arról szóljon, miért bukott, és a javítás a gyökér-okot célozza (pl. package-lock szinkron, node ABI, build-hiba, divergált history).
+- Ha kódot módosítasz a javításhoz: előbb LOKÁLISAN `npm run build`, majd győződj meg róla, hogy a build zöld, MIELŐTT bármit késznek jelentesz. Ne indítsd újra magadtól a szolgáltatást éles környezetben; a következő frissítés/restart úgyis ezt teszi.
+- Ha divergált history a gyökér-ok (a helyi checkout előrébb van az upstreamnél): NE reszeteld erőszakkal. Írd le pontosan, mely helyi commitok vannak (`git log @{u}..HEAD`), és kérd az operatőr döntését, mielőtt bármit átrendezel.
+
+Amikor kész vagy (akár javítottad, akár csak diagnózis): jelentsd az eredményt röviden -- a gyökér-ok, mit tettél (vagy mit javasolsz), és hogy a build zöld-e. A box közben végig a működő régi verzión maradt.

--- a/seed-scheduled-tasks/post-rollback-diagnose/task-config.json
+++ b/seed-scheduled-tasks/post-rollback-diagnose/task-config.json
@@ -1,0 +1,8 @@
+{
+  "schedule": "0 0 1 1 *",
+  "agent": "{{MAIN_AGENT_ID}}",
+  "enabled": false,
+  "type": "task",
+  "description": "On-demand (opt-in) diagnózis egy sikertelen frissítés + automatikus rollback UTÁN. NEM cron-vezérelt (enabled:false): kizárólag a dashboard 'Frissítés diagnózisa' gombja indítja, a POST /api/updates/diagnose végponton át, miután a felhasználó jóváhagyta (Claude kredit). A box ilyenkor már a működő régi verzión fut.",
+  "createdAt": 0
+}

--- a/src/__tests__/post-rollback-diagnose-seed.test.ts
+++ b/src/__tests__/post-rollback-diagnose-seed.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Guards the seeded post-rollback diagnosis task (PR-D). It is an on-demand-only
+// task (enabled:false so cron never fires it) that the guarded
+// POST /api/updates/diagnose endpoint triggers. These assertions lock its
+// dormant shape and its structural guardrails into the delivered prompt.
+const DIR = join(__dirname, '..', '..', 'seed-scheduled-tasks', 'post-rollback-diagnose')
+const config = JSON.parse(readFileSync(join(DIR, 'task-config.json'), 'utf-8')) as {
+  agent: string; enabled: boolean; type: string
+}
+const skill = readFileSync(join(DIR, 'SKILL.md'), 'utf-8')
+
+describe('post-rollback-diagnose seed task', () => {
+  it('is a dormant (enabled:false) LLM task on the main agent placeholder', () => {
+    expect(config.type).toBe('task')
+    expect(config.enabled).toBe(false)
+    expect(config.agent).toBe('{{MAIN_AGENT_ID}}')
+  })
+
+  it('encodes the structural guardrails in the delivered prompt', () => {
+    // no force-push, stash-not-drop, verify build, report back
+    expect(skill).toMatch(/force-push/i)
+    expect(skill).toMatch(/git stash/i)
+    expect(skill).toMatch(/npm run build/i)
+    expect(skill).toMatch(/update\.sh/)
+  })
+
+  it('uses placeholders, never a hardcoded absolute path or agent name', () => {
+    expect(skill).toContain('{{INSTALL_DIR}}')
+    expect(skill).not.toMatch(/\/Users\/|\/home\//)
+  })
+})

--- a/src/__tests__/update-agent-capability.test.ts
+++ b/src/__tests__/update-agent-capability.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { cpuinfoHasAvx, claudeAgentRunnable } from '../update-agent-capability.js'
+
+const X86_WITH_AVX = `processor\t: 0
+vendor_id\t: GenuineIntel
+flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sep avx avx2 fma
+`
+const X86_NO_AVX = `processor\t: 0
+vendor_id\t: GenuineIntel
+model name\t: QEMU Virtual CPU version 2.5+
+flags\t\t: fpu de pse tsc msr pae mce cx8 apic sep mtrr sse sse2
+`
+const ARM = `processor\t: 0
+BogoMIPS\t: 48.00
+Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32
+CPU implementer\t: 0x41
+`
+
+describe('cpuinfoHasAvx', () => {
+  it('detects avx when present in the flags line', () => {
+    expect(cpuinfoHasAvx(X86_WITH_AVX)).toBe(true)
+  })
+  it('returns false when the flags line has no avx', () => {
+    expect(cpuinfoHasAvx(X86_NO_AVX)).toBe(false)
+  })
+  it('matches only the standalone avx token, not a substring of another flag', () => {
+    // Real cpuinfo lists the standalone "avx" flag separately from avx512*.
+    expect(cpuinfoHasAvx('flags : fpu avx avx512f')).toBe(true)
+    // avx512* WITHOUT a standalone avx token must not match (word-boundary).
+    expect(cpuinfoHasAvx('flags : fpu avx512f')).toBe(false)
+    expect(cpuinfoHasAvx('flags : fpu xavxy')).toBe(false)
+  })
+})
+
+describe('claudeAgentRunnable', () => {
+  it('linux x86 WITH avx -> runnable', () => {
+    expect(claudeAgentRunnable('linux', () => X86_WITH_AVX)).toBe(true)
+  })
+  it('linux x86 WITHOUT avx -> NOT runnable (the AVX-less VPS case)', () => {
+    expect(claudeAgentRunnable('linux', () => X86_NO_AVX)).toBe(false)
+  })
+  it('linux ARM (Features:, no flags line) -> runnable', () => {
+    expect(claudeAgentRunnable('linux', () => ARM)).toBe(true)
+  })
+  it('linux with unreadable cpuinfo -> runnable (no block on uncertain probe)', () => {
+    expect(claudeAgentRunnable('linux', () => '')).toBe(true)
+  })
+  it('macOS -> runnable regardless of cpuinfo', () => {
+    expect(claudeAgentRunnable('darwin', () => X86_NO_AVX)).toBe(true)
+  })
+})

--- a/src/update-agent-capability.ts
+++ b/src/update-agent-capability.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { platform } from 'node:os'
+
+// Can a Claude Code agent be spawned on THIS host? The Claude Code binary is a
+// Bun standalone that requires AVX; on a CPU without it the agent segfaults /
+// SIGILLs on launch (see the AVX-less QEMU-VPS incident). The post-rollback
+// fixer (PR-D) must NOT be offered on such a host -- there we surface a
+// "needs a human" note instead of spawning an agent that cannot start.
+//
+// The core is a pure function over /proc/cpuinfo text so it is unit-testable.
+
+// Does this x86 cpuinfo advertise the AVX flag? The flags line looks like:
+//   flags : fpu vme de ... avx avx2 ...
+export function cpuinfoHasAvx(cpuinfo: string): boolean {
+  return /^flags\s*:.*\bavx\b/m.test(cpuinfo)
+}
+
+// Is this an x86 cpuinfo at all? x86 uses "flags :"; ARM uses "Features :".
+function cpuinfoIsX86(cpuinfo: string): boolean {
+  return /^flags\s*:/m.test(cpuinfo)
+}
+
+// Decide from platform + a cpuinfo reader whether a Claude agent can run.
+//   - Linux x86: require the AVX flag.
+//   - Linux ARM (no "flags :" line): the arm64 binary has no AVX concept -> ok.
+//   - Linux with an unreadable/empty cpuinfo: do NOT block on an uncertain probe.
+//   - macOS: Apple Silicon runs the arm64 binary; Intel Macs that run Claude
+//     have AVX. Treat as runnable.
+//   - Anything else: runnable (never block on an unknown platform).
+export function claudeAgentRunnable(
+  plat: string = platform(),
+  readCpuinfo: () => string = () => {
+    try { return readFileSync('/proc/cpuinfo', 'utf-8') } catch { return '' }
+  },
+): boolean {
+  if (plat !== 'linux') return true
+  const info = readCpuinfo()
+  if (!info) return true
+  if (cpuinfoIsX86(info) && !cpuinfoHasAvx(info)) return false
+  return true
+}

--- a/src/web/routes/updates.ts
+++ b/src/web/routes/updates.ts
@@ -13,6 +13,8 @@ import {
   type GitRunner, type PidfileRunner,
 } from '../../update-preflight.js'
 import { json, readBody } from '../http-helpers.js'
+import { claudeAgentRunnable } from '../../update-agent-capability.js'
+import { runScheduledTaskNow } from '../schedule-runner.js'
 import type { RouteContext } from './types.js'
 
 // Pidfile path owned by update.sh for the lifetime of an update run.
@@ -20,6 +22,22 @@ import type { RouteContext } from './types.js'
 // via a trap -- so the gate survives the stop.sh / start.sh dashboard
 // restart that happens inside a successful update.
 const UPDATE_PIDFILE = join(PROJECT_ROOT, 'store', 'update.pid')
+
+// The seeded on-demand (enabled:false) task the post-rollback diagnosis fires.
+const DIAGNOSE_TASK = 'post-rollback-diagnose'
+// One-diagnosis-per-rollback marker (keyed by the last-result timestamp).
+const DIAGNOSE_MARKER = join(PROJECT_ROOT, 'store', 'update-diagnose.last')
+
+type LastResult = { status?: string; ts?: number; phase?: string; message?: string }
+function readLastResult(): LastResult | null {
+  try { return JSON.parse(readFileSync(join(STORE_DIR, 'update.last-result'), 'utf-8')) as LastResult }
+  catch { return null }
+}
+// A post-rollback diagnosis is meaningful only after a terminal FAILED /
+// ROLLED-BACK outcome (a success or an in-progress run is not diagnosable).
+function isDiagnosable(r: LastResult | null): boolean {
+  return r?.status === 'rolled-back' || r?.status === 'failed'
+}
 
 export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
   const { res, path, method } = ctx
@@ -35,13 +53,60 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
   // silent failure. Absent file => no run yet (or one still in progress; the
   // presence of store/update.pid disambiguates).
   if (path === '/api/updates/status' && method === 'GET') {
-    let result: unknown = null
-    try {
-      result = JSON.parse(readFileSync(join(STORE_DIR, 'update.last-result'), 'utf-8'))
-    } catch { /* no result yet */ }
+    const result = readLastResult()
     let running = false
     try { running = statSync(UPDATE_PIDFILE).isFile() } catch { /* not running */ }
-    json(res, { running, result })
+    // Post-rollback diagnosis offer (PR-D). Offer the opt-in fixer only when the
+    // last update FAILED/ROLLED-BACK *and* this host can actually run a Claude
+    // agent. On an AVX-less host (agent cannot start) we flag needsHuman so the
+    // UI shows a "manual intervention" note instead of a dead-end button.
+    const diagnosable = isDiagnosable(result)
+    const claudeRunnable = claudeAgentRunnable()
+    json(res, {
+      running,
+      result,
+      canDiagnose: diagnosable && claudeRunnable && !running,
+      needsHuman: diagnosable && !claudeRunnable,
+    })
+    return true
+  }
+
+  // Opt-in post-rollback diagnosis (PR-D). The operator explicitly requests it
+  // from the dashboard (credit consent handled in the UI). Fires the seeded,
+  // guardrailed post-rollback-diagnose task at the main agent. Guarded so it is
+  // only reachable in a genuine rollback state and never on a host that cannot
+  // run the agent.
+  if (path === '/api/updates/diagnose' && method === 'POST') {
+    const result = readLastResult()
+    if (!isDiagnosable(result)) {
+      json(res, { error: 'No failed or rolled-back update to diagnose.', reason: 'no-rollback' }, 409)
+      return true
+    }
+    if (!claudeAgentRunnable()) {
+      json(res, {
+        error: 'This host cannot run a Claude agent (CPU lacks AVX), so auto-diagnosis is unavailable. Manual intervention needed.',
+        reason: 'claude-unrunnable',
+      }, 400)
+      return true
+    }
+    // Idempotency: one diagnosis per rollback, keyed by the outcome timestamp,
+    // so a double-click (or a re-poll) does not spawn a second agent.
+    const key = String(result?.ts ?? '')
+    try {
+      if (key && readFileSync(DIAGNOSE_MARKER, 'utf-8').trim() === key) {
+        json(res, { ok: true, already: true })
+        return true
+      }
+    } catch { /* no marker yet */ }
+    const fired = runScheduledTaskNow(DIAGNOSE_TASK, { allowDisabled: true })
+    if (!fired.ok) {
+      logger.warn({ err: fired.error }, 'post-rollback diagnosis could not be fired')
+      json(res, { error: fired.error || 'Could not start the diagnosis agent.', reason: 'fire-failed' }, 500)
+      return true
+    }
+    try { writeFileSync(DIAGNOSE_MARKER, key, { mode: 0o600 }) } catch { /* best-effort */ }
+    logger.info({ result: fired.result }, 'post-rollback diagnosis fired')
+    json(res, { ok: true, result: fired.result })
     return true
   }
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -287,10 +287,16 @@ function attemptFireTask(task: ScheduledTask, agentName: string, now: number): '
 // for it). Reuses attemptFireTask, so a stopped agent is auto-started and the
 // prompt is queued for delivery exactly like a real cron fire. Returns a
 // per-target summary string for the API/UI.
-export function runScheduledTaskNow(taskName: string): { ok: boolean; result?: string; error?: string } {
+export function runScheduledTaskNow(
+  taskName: string,
+  opts: { allowDisabled?: boolean } = {},
+): { ok: boolean; result?: string; error?: string } {
   const task = listScheduledTasks().find(t => t.name === taskName)
   if (!task) return { ok: false, error: 'Schedule not found' }
-  if (!task.enabled) return { ok: false, error: 'Schedule is disabled' }
+  // allowDisabled: for on-demand-only tasks that are intentionally kept
+  // enabled:false so the cron never fires them, but a guarded endpoint can
+  // still trigger them (e.g. the post-rollback diagnosis, PR-D).
+  if (!task.enabled && !opts.allowDisabled) return { ok: false, error: 'Schedule is disabled' }
 
   const now = Date.now()
   const targets = task.agent === 'all'

--- a/tests/smoke/update-diagnose.spec.ts
+++ b/tests/smoke/update-diagnose.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * PR-D smoke: the post-rollback diagnosis offer on the Updates page.
+ *
+ * Prerequisites: the dashboard must be running and DASHBOARD_TOKEN set.
+ *   DASHBOARD_TOKEN=$(cat store/.dashboard-token) npm run smoke
+ *
+ * Uses route interception (never boots a second server) to feed the three
+ * update states and asserts the UI offers / withholds the opt-in fixer, and
+ * that clicking it POSTs to /api/updates/diagnose. The diagnose POST is
+ * intercepted, so this never spawns a real agent.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const TOKEN = process.env.DASHBOARD_TOKEN || ''
+
+// Block the service worker so our /api route overrides are not shadowed by the
+// SW cache (the PR-A lesson).
+test.use({ serviceWorkers: 'block' })
+
+async function stubUpdates(page: import('@playwright/test').Page, status: Record<string, unknown>) {
+  // Keep the page's own update-check cheap and deterministic.
+  await page.route('**/api/updates', (r) =>
+    r.fulfill({ json: { current: 'aaaaaaa', latest: 'aaaaaaa', behind: 0, remote: 'origin/develop' } }))
+  await page.route('**/api/updates/status', (r) => r.fulfill({ json: status }))
+}
+
+test.describe('post-rollback diagnosis offer', () => {
+  test('offers the opt-in fixer when canDiagnose and POSTs on confirm', async ({ page }) => {
+    await stubUpdates(page, {
+      running: false,
+      result: { status: 'rolled-back', old: 'abc1234', ts: Math.floor(Date.now() / 1000) },
+      canDiagnose: true,
+      needsHuman: false,
+    })
+    let diagnosePosted = false
+    await page.route('**/api/updates/diagnose', (r) => {
+      diagnosePosted = true
+      return r.fulfill({ json: { ok: true } })
+    })
+    page.on('dialog', (d) => d.accept()) // credit-consent confirm
+
+    await page.goto(`/?token=${TOKEN}#updates`)
+    await page.evaluate(() => (window as unknown as { loadUpdates: () => Promise<void> }).loadUpdates())
+
+    const btn = page.locator('#updatesDiagnoseBtn')
+    await expect(btn).toBeVisible()
+    await btn.click()
+    await expect.poll(() => diagnosePosted).toBe(true)
+  })
+
+  test('shows a manual-intervention note (no button) when the host lacks AVX', async ({ page }) => {
+    await stubUpdates(page, {
+      running: false,
+      result: { status: 'failed', ts: Math.floor(Date.now() / 1000) },
+      canDiagnose: false,
+      needsHuman: true,
+    })
+    await page.goto(`/?token=${TOKEN}#updates`)
+    await page.evaluate(() => (window as unknown as { loadUpdates: () => Promise<void> }).loadUpdates())
+
+    await expect(page.locator('#updatesDiagnose.needs-human')).toBeVisible()
+    await expect(page.locator('#updatesDiagnoseBtn')).toHaveCount(0)
+  })
+
+  test('offers nothing after a successful update', async ({ page }) => {
+    await stubUpdates(page, {
+      running: false,
+      result: { status: 'success', old: 'abc1234', new: 'def5678', ts: Math.floor(Date.now() / 1000) },
+      canDiagnose: false,
+      needsHuman: false,
+    })
+    await page.goto(`/?token=${TOKEN}#updates`)
+    await page.evaluate(() => (window as unknown as { loadUpdates: () => Promise<void> }).loadUpdates())
+    await expect(page.locator('#updatesDiagnose')).toBeHidden()
+  })
+})

--- a/web/app.js
+++ b/web/app.js
@@ -9868,6 +9868,50 @@ async function loadUpdates() {
     summary.textContent = 'Hiba: ' + (err.message || err)
     applyBtn.hidden = true
   }
+  renderDiagnoseOffer()
+}
+
+// Post-rollback diagnosis offer (PR-D). Reads /api/updates/status: if the last
+// update failed/rolled-back and this host can run a Claude agent, offer the
+// opt-in fixer; if it cannot (AVX), show a manual-intervention note instead.
+async function renderDiagnoseOffer() {
+  const box = document.getElementById('updatesDiagnose')
+  if (!box) return
+  let data
+  try { data = await (await fetch('/api/updates/status')).json() } catch { box.hidden = true; return }
+  if (data.needsHuman) {
+    box.hidden = false
+    box.className = 'updates-diagnose needs-human'
+    box.innerHTML = `<strong>${escapeHtmlUpdates(t('updates.diagnose.title'))}</strong><p>${escapeHtmlUpdates(t('updates.diagnose.needs_human'))}</p>`
+    return
+  }
+  if (!data.canDiagnose) { box.hidden = true; box.innerHTML = ''; return }
+  box.hidden = false
+  box.className = 'updates-diagnose'
+  box.innerHTML = `<strong>${escapeHtmlUpdates(t('updates.diagnose.title'))}</strong>`
+    + `<p>${escapeHtmlUpdates(t('updates.diagnose.body'))}</p>`
+    + `<button class="btn-secondary btn-compact" id="updatesDiagnoseBtn">${escapeHtmlUpdates(t('updates.diagnose.btn'))}</button>`
+  document.getElementById('updatesDiagnoseBtn').addEventListener('click', runDiagnose)
+}
+
+async function runDiagnose() {
+  if (!confirm(t('updates.diagnose.consent'))) return
+  const btn = document.getElementById('updatesDiagnoseBtn')
+  if (btn) btn.disabled = true
+  try {
+    const res = await fetch('/api/updates/diagnose', { method: 'POST' })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      if (btn) btn.disabled = false
+      showToast(t('updates.diagnose.failed', { msg: data.error || ('HTTP ' + res.status) }))
+      return
+    }
+    showToast(data.already ? t('updates.diagnose.already') : t('updates.diagnose.started'))
+    if (btn) { btn.hidden = true }
+  } catch (err) {
+    if (btn) btn.disabled = false
+    showToast(t('updates.diagnose.failed', { msg: err.message || err }))
+  }
 }
 
 document.getElementById('updatesCheckBtn').addEventListener('click', async () => {
@@ -9949,11 +9993,13 @@ async function pollUpdateOutcome(resetBtn) {
       if (st === 'rolled-back') {
         if (resetBtn) resetBtn()
         showToast(t('updates.toast.rolled_back', { old: result.old || '', msg: result.message || '' }))
+        renderDiagnoseOffer()
         return
       }
       // failed
       if (resetBtn) resetBtn()
       showToast(t('updates.toast.failed', { phase: result.phase || '?', msg: result.message || ('code ' + result.code) }))
+      renderDiagnoseOffer()
       return
     }
   }

--- a/web/index.html
+++ b/web/index.html
@@ -1607,6 +1607,8 @@
 
       <div id="updatesSummary" class="updates-summary"></div>
 
+      <div id="updatesDiagnose" class="updates-diagnose" hidden></div>
+
       <div class="updates-commits">
         <h3 data-i18n="tokenUsage.changes_title">Változások</h3>
         <div id="updatesCommitList" class="updates-commit-list"></div>

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1310,6 +1310,14 @@ window._i18n.en = {
   'updates.toast.rolled_back':   'Update failed, rolled back to the previous version ({old}). {msg}',
   'updates.toast.failed':        'Update failed ({phase}): {msg}',
   'updates.toast.status_timeout':'Update status did not arrive in time. Check store/update.log.',
+  'updates.diagnose.title':      'The last update failed',
+  'updates.diagnose.body':       'The system rolled back to the previous working version. You can start an AI diagnosis that inspects why the update failed and, within safe limits (no force-push, no discarding of local changes), attempts a fix.',
+  'updates.diagnose.btn':        'Diagnose update (AI agent)',
+  'updates.diagnose.consent':    'This starts an AI agent that uses Claude credits. Start the diagnosis?',
+  'updates.diagnose.started':    'Diagnosis started. The agent will report back with the result.',
+  'updates.diagnose.already':    'A diagnosis for this failure has already been started.',
+  'updates.diagnose.failed':     'Diagnosis did not start: {msg}',
+  'updates.diagnose.needs_human':'The last update failed, and this machine cannot run an AI agent (the CPU lacks AVX). Manual intervention needed. Check store/update.log.',
 
   // --- Ideas toasts ---
   'ideas.toast.score_saved':     'Score saved',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1308,6 +1308,14 @@ window._i18n.hu = {
   'updates.toast.rolled_back':   'A frissítés nem sikerült, visszaálltunk a korábbi verzióra ({old}). {msg}',
   'updates.toast.failed':        'Frissítés sikertelen ({phase}): {msg}',
   'updates.toast.status_timeout':'A frissítés állapota nem érkezett meg időben. Nézd meg a store/update.log fájlt.',
+  'updates.diagnose.title':      'A legutóbbi frissítés sikertelen volt',
+  'updates.diagnose.body':       'A rendszer visszaállt a korábbi, működő verzióra. Elindíthatsz egy AI-diagnózist, ami megnézi miért bukott a frissítés, és biztonságos keretek közt (nincs force-push, nincs helyi-változás-dobás) megpróbálja javítani.',
+  'updates.diagnose.btn':        'Frissítés diagnózisa (AI-agens)',
+  'updates.diagnose.consent':    'Ez egy AI-agenst indít, ami Claude kreditet használ. Elindítsam a diagnózist?',
+  'updates.diagnose.started':    'Diagnózis elindítva. Az ügynök jelentkezik az eredménnyel.',
+  'updates.diagnose.already':    'A diagnózis ehhez a bukáshoz már el lett indítva.',
+  'updates.diagnose.failed':     'A diagnózis nem indult el: {msg}',
+  'updates.diagnose.needs_human':'A legutóbbi frissítés sikertelen volt, és ez a gép nem tud AI-agenst futtatni (a CPU nem támogatja az AVX-et). Kézi beavatkozás szükséges. Nézd meg a store/update.log fájlt.',
 
   // --- Ideas toasts ---
   'ideas.toast.score_saved':     'Pontozás mentve',

--- a/web/style.css
+++ b/web/style.css
@@ -336,6 +336,22 @@ nav { display: flex; gap: 4px; }
 .updates-summary.error {
   border-left: 4px solid #e53e3e;
 }
+.updates-diagnose {
+  padding: 16px 18px;
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  border-left: 4px solid #e53e3e;
+  margin: 0 0 20px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+.updates-diagnose.needs-human {
+  border-left-color: #f59e0b;
+}
+.updates-diagnose p {
+  margin: 8px 0 12px;
+  color: var(--text-muted);
+}
 .updates-summary code {
   background: var(--bg-card);
   padding: 2px 6px;


### PR DESCRIPTION
## PR-D: post-rollback opt-in diagnosis agent (card cbe2a240, final part of A->B->C->D)

After PR-B auto-rolls-back a failed update, the box runs the working **OLD** version, so a Claude agent can start there. This offers the operator an **opt-in** fixer to diagnose (and safely attempt to fix) why the update failed.

### What changed

**`src/update-agent-capability.ts`** -- `claudeAgentRunnable()`. The Claude Code Bun binary needs AVX; on an AVX-less x86 host the agent segfaults on launch. Pure `/proc/cpuinfo`-based, unit-tested (x86 with/without avx, ARM `Features:`, macOS, unreadable-probe).

**`GET /api/updates/status`** now also returns:
- `canDiagnose` = last update is `rolled-back|failed` AND host can run an agent AND not mid-run;
- `needsHuman` = `rolled-back|failed` but the host **cannot** run an agent -> UI shows a manual-intervention note instead of a dead-end button.

**`POST /api/updates/diagnose`** (opt-in; credit-consent in the UI): guarded to a genuine rollback state (409 otherwise), refuses on an AVX-less host (400 `claude-unrunnable`), idempotent per rollback (marker keyed by the outcome `ts`), then fires the seeded task.

**`seed-scheduled-tasks/post-rollback-diagnose`** -- an **on-demand-only** task (`enabled:false` so cron never fires it; only the guarded endpoint triggers it via a new `runScheduledTaskNow(..., {allowDisabled})`). Its `SKILL.md` prompt encodes the **structural guardrails**: never force-push, `git stash` (never drop) local changes, never write parallel update/rollback logic, verify `npm run build` before claiming a fix, report the outcome back. Diverged-history is called out as "ask the operator, do not force-reset".

**Frontend** -- opt-in offer card on the Updates page (and right after a failed/rolled-back apply). Credit-consent `confirm()` before POSTing. AVX-less hosts get the manual note, no button.

### Safety / design
- Only offered **after** an auto-rollback, when the box is already on a working version -- never mid-failure.
- Opt-in + credit consent; the operator initiates it, framed to the main agent as an operator task (seeded-task delivery).
- AVX gate means we never offer to spawn an agent that would crash on launch; that path routes to a human.
- Distribution-safe: `{{MAIN_AGENT_ID}}`/`{{INSTALL_DIR}}` placeholders, no hardcoded ids or paths.

### Testing
- `tsc` clean, `syntax-check` clean, no em-dash in shipped copy.
- Full vitest **1663 passed** (11 new: AVX capability matrix + seed guardrail asserts).
- **Real-browser verified** (global Playwright, route-interception against the live origin serving the worktree assets): offer visible + click POSTs `/api/updates/diagnose` for `rolled-back`; manual-note + no button for AVX-less; nothing offered after `success`; zero page errors.
- `tests/smoke/update-diagnose.spec.ts` committed for the post-deploy smoke run.

### Note
Ties into the same promote-gate as B/C: the live Linux/systemd restart+rollback path (which produces the rollback state this feature reacts to) is exercised on the AVX-VPS pilot before customer-facing promote.