### PR TITLE
feat(memory): recency-weighted retrieval on all FTS search paths

### DIFF
--- a/src/__tests__/memory-recency-weighting.test.ts
+++ b/src/__tests__/memory-recency-weighting.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import {
+  initDatabase,
+  saveAgentMemory,
+  searchAgentMemories,
+  recencyWeightedScore,
+  reRankByRecency,
+  getDb,
+  RECENCY_TAU_SEC,
+} from '../db.js'
+
+// Recency-weighted retrieval (Roitman 17.4.2): score = λ·relevance + (1−λ)·exp(−age/τ).
+// Pure-function tests pin the blend semantics; the integration test proves the
+// tie-break end-to-end through FTS5 on a real (in-memory) database.
+
+const DAY = 86400
+
+describe('recencyWeightedScore / reRankByRecency (pure)', () => {
+  const now = 1_800_000_000
+
+  it('holtverseny: azonos relevancia mellett a frissebb memória nyer', () => {
+    const older = { rank: -2.0, created_at: now - 30 * DAY }
+    const newer = { rank: -2.0, created_at: now - 1 * DAY }
+    expect(recencyWeightedScore(newer, now)).toBeGreaterThan(recencyWeightedScore(older, now))
+    const ranked = reRankByRecency([older, newer], 2, now)
+    expect(ranked[0]).toBe(newer)
+    expect(ranked[1]).toBe(older)
+  })
+
+  it('erős relevancia-különbség legyőzi a frissességet (λ = 0.7 dominancia)', () => {
+    // Strong match from a month ago vs a barely-matching memory from today.
+    const strongOld = { rank: -8.0, created_at: now - 30 * DAY }
+    const weakNew = { rank: -0.1, created_at: now }
+    const ranked = reRankByRecency([weakNew, strongOld], 2, now)
+    expect(ranked[0]).toBe(strongOld)
+  })
+
+  it('nem-negatív bm25 rank relevanciája 0 (degenerált eset, nem dob hibát)', () => {
+    const row = { rank: 0, created_at: now }
+    // Only the recency term remains: (1−λ)·exp(0) = 0.3
+    expect(recencyWeightedScore(row, now)).toBeCloseTo(0.3, 10)
+  })
+
+  it('a jövőbeli created_at nem kap 1-nél nagyobb recency-t (age clamp 0-ra)', () => {
+    const future = { rank: -1.0, created_at: now + 10 * DAY }
+    const present = { rank: -1.0, created_at: now }
+    expect(recencyWeightedScore(future, now)).toBeCloseTo(recencyWeightedScore(present, now), 10)
+  })
+
+  it('limitre vág és a sorrend determinisztikus', () => {
+    const rows = [
+      { rank: -1.0, created_at: now - 10 * DAY },
+      { rank: -1.0, created_at: now - 5 * DAY },
+      { rank: -1.0, created_at: now - 1 * DAY },
+    ]
+    const ranked = reRankByRecency(rows, 2, now)
+    expect(ranked).toHaveLength(2)
+    expect(ranked[0].created_at).toBe(now - 1 * DAY)
+    expect(ranked[1].created_at).toBe(now - 5 * DAY)
+  })
+
+  it('tau: az exponens időállandója szerint cseng le a recency', () => {
+    const atTau = { rank: 0, created_at: now - RECENCY_TAU_SEC }
+    // (1−λ)·exp(−1) = 0.3·0.3679
+    expect(recencyWeightedScore(atTau, now)).toBeCloseTo(0.3 * Math.exp(-1), 10)
+  })
+})
+
+describe('searchAgentMemories recency tie-break (integration, in-memory FTS5)', () => {
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test'
+    initDatabase(':memory:')
+  })
+
+  it('azonos kulcsszavú régi és új memóriából az új jön előrébb', () => {
+    const now = Math.floor(Date.now() / 1000)
+    // Same content shape -> near-identical bm25; only the age differs.
+    const oldId = saveAgentMemory('tester', 'A dizel generátor állapota: LEÁLLT tegnap óta.', 'hot', 'generátor, státusz').id
+    const newId = saveAgentMemory('tester', 'A dizel generátor állapota: ÚJRA MŰKÖDIK mostantól.', 'hot', 'generátor, státusz').id
+    // Backdate the first memory by 30 days directly in the DB.
+    getDb().prepare('UPDATE memories SET created_at = ? WHERE id = ?').run(now - 30 * DAY, oldId)
+
+    const results = searchAgentMemories('tester', 'generátor állapota', 5)
+    const ids = results.map((m) => m.id)
+    expect(ids).toContain(oldId)
+    expect(ids).toContain(newId)
+    expect(ids.indexOf(newId)).toBeLessThan(ids.indexOf(oldId))
+    // The public shape must not leak the internal FTS rank column.
+    expect('rank' in results[0]).toBe(false)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -789,19 +789,73 @@ export function buildFtsMatchExpression(query: string): string {
   return tokens.join(' ')
 }
 
+// -- Recency-weighted retrieval (Roitman 17.4.2) --
+//
+// score = λ·relevance + (1−λ)·recency, where recency = exp(−age/τ). Pure
+// keyword rank returns whichever memory FTS scores highest regardless of age,
+// so a stale fact ("reply tool down") can outrank its own correction ("reply
+// tool up"). The blend keeps relevance dominant (λ = 0.7) but breaks
+// near-ties in favour of the newer memory.
+//
+// FTS5 `rank` is bm25: negative, more negative = better. Normalized to 0..1
+// via −rank/(1−rank) (monotonic, no unbounded tail). The blend runs in JS on
+// an oversampled candidate set rather than in SQL so it does not depend on
+// SQLite being compiled with math functions, and stays unit-testable.
+export const RECENCY_LAMBDA = 0.7
+export const RECENCY_TAU_SEC = 7 * 86400
+// Candidates fetched per requested row before re-ranking. Bounded so a broad
+// query still touches at most 4x the requested rows.
+const RECENCY_OVERSAMPLE = 4
+
+export interface RecencyRankable {
+  rank: number
+  created_at: number
+}
+
+export function recencyWeightedScore(
+  row: RecencyRankable,
+  nowSec: number,
+  lambda = RECENCY_LAMBDA,
+  tauSec = RECENCY_TAU_SEC,
+): number {
+  const relevance = row.rank < 0 ? -row.rank / (1 - row.rank) : 0
+  const ageSec = Math.max(0, nowSec - row.created_at)
+  const recency = Math.exp(-ageSec / tauSec)
+  return lambda * relevance + (1 - lambda) * recency
+}
+
+export function reRankByRecency<T extends RecencyRankable>(
+  rows: T[],
+  limit: number,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): T[] {
+  return rows
+    .map((row) => ({ row, score: recencyWeightedScore(row, nowSec) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((x) => x.row)
+}
+
+// Strip the FTS rank column the oversampled queries select for re-ranking, so
+// the public return shape stays exactly Memory.
+function withoutRank<T extends { rank: number }>(rows: T[]): Omit<T, 'rank'>[] {
+  return rows.map(({ rank: _rank, ...rest }) => rest)
+}
+
 export function searchMemories(query: string, chatId: string, limit = 3): Memory[] {
   const terms = buildFtsMatchExpression(query)
   if (!terms) return []
   try {
-    return db
+    const candidates = db
       .prepare(
-        `SELECT m.* FROM memories m
+        `SELECT m.*, f.rank AS rank FROM memories m
          JOIN memories_fts f ON m.id = f.rowid
          WHERE f.content MATCH ? AND m.chat_id = ?
          ORDER BY rank
          LIMIT ?`
       )
-      .all(terms, chatId, limit) as Memory[]
+      .all(terms, chatId, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
+    return withoutRank(reRankByRecency(candidates, limit)) as Memory[]
   } catch {
     return []
   }
@@ -866,12 +920,13 @@ export function searchAgentMemories(agentId: string, query: string, limit: numbe
   const terms = buildFtsMatchExpression(query)
   if (!terms) return []
   try {
-    return db.prepare(
-      `SELECT m.* FROM memories m
+    const candidates = db.prepare(
+      `SELECT m.*, f.rank AS rank FROM memories m
        JOIN memories_fts f ON m.id = f.rowid
        WHERE f.memories_fts MATCH ? AND (m.agent_id = ? OR m.category = 'shared')
        ORDER BY rank LIMIT ?`
-    ).all(terms, agentId, limit) as Memory[]
+    ).all(terms, agentId, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
+    return withoutRank(reRankByRecency(candidates, limit)) as Memory[]
   } catch {
     return db.prepare(
       "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') AND (content LIKE ? OR keywords LIKE ?) ORDER BY accessed_at DESC LIMIT ?"
@@ -970,12 +1025,16 @@ export function recallSearch(query: string, agentId?: string, limit = 50): Recal
   const escaped = escapeLike(query)
   if (terms) {
     try {
+      // Was ORDER BY created_at DESC (pure recency, relevance ignored); now the
+      // same λ-blend as the other search paths, so a strongly matching older
+      // memory can still surface above barely-matching fresh noise.
       const sql = agentId
-        ? `SELECT m.* FROM memories m JOIN memories_fts f ON m.id = f.rowid WHERE f.memories_fts MATCH ? AND (m.agent_id = ? OR m.category = 'shared') ORDER BY m.created_at DESC LIMIT ?`
-        : `SELECT m.* FROM memories m JOIN memories_fts f ON m.id = f.rowid WHERE f.memories_fts MATCH ? ORDER BY m.created_at DESC LIMIT ?`
-      memories = agentId
-        ? db.prepare(sql).all(terms, agentId, limit) as Memory[]
-        : db.prepare(sql).all(terms, limit) as Memory[]
+        ? `SELECT m.*, f.rank AS rank FROM memories m JOIN memories_fts f ON m.id = f.rowid WHERE f.memories_fts MATCH ? AND (m.agent_id = ? OR m.category = 'shared') ORDER BY rank LIMIT ?`
+        : `SELECT m.*, f.rank AS rank FROM memories m JOIN memories_fts f ON m.id = f.rowid WHERE f.memories_fts MATCH ? ORDER BY rank LIMIT ?`
+      const candidates = agentId
+        ? db.prepare(sql).all(terms, agentId, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
+        : db.prepare(sql).all(terms, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
+      memories = withoutRank(reRankByRecency(candidates, limit)) as Memory[]
     } catch {
       const sql = agentId
         ? "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') AND (content LIKE ? ESCAPE '\\' OR keywords LIKE ? ESCAPE '\\') ORDER BY created_at DESC LIMIT ?"


### PR DESCRIPTION
## Summary
- Memory search ordering is now `score = λ·relevance + (1−λ)·exp(−age/τ)` (λ=0.7, τ=7d) instead of pure bm25 rank, on all three FTS paths: `searchMemories` (chat recall), `searchAgentMemories` (agent API) and `recallSearch` (dashboard recall).
- Motivation: with pure keyword rank a stale fact ("deploy in progress") outranks its own later correction ("deploy done") — reproduced on real data. The blend keeps relevance dominant but breaks near-ties in favour of the newer memory.
- `recallSearch`'s FTS branch previously ordered by `created_at DESC` (pure recency, relevance ignored) — it now gets the same blend, so a strongly matching older memory can still surface above barely-matching fresh noise.
- The re-rank runs in JS over a 4× oversampled candidate set: no dependency on SQLite math builtins, unit-testable, and the public return shape is unchanged (internal `rank` column stripped).

## Test plan
- New `memory-recency-weighting.test.ts`: pure-function semantics (relevance tie → newer wins; strong relevance beats freshness; non-negative-rank and future-timestamp clamps; deterministic slice) + end-to-end FTS5 tie-break on an in-memory DB (backdated duplicate loses to its correction, `rank` not leaked).
- Full suite: 1675/1675 green, `tsc --noEmit` clean.
- Manual demo on a copy of a production DB: a 30-day-old "checkpoint (in progress)" memory ranked FIRST under pure bm25, above its own "closed/done" correction; with the blend the correction wins and the stale memory drops to 4th.

🤖 Generated with [Claude Code](https://claude.com/claude-code)