### PR TITLE
fix(install): managed-settings channelsEnabled to prevent silent inbound-drop

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -314,6 +314,15 @@ else
   fi
 fi
 
+# Channel inbound org-policy gate: ensure the system managed-settings enable
+# channels. claude-code >= 2.1.205 silently drops channel-plugin INBOUND
+# notifications on a team/enterprise org unless managed-settings has
+# channelsEnabled:true (harmless / no-op on a personal org). Idempotent.
+if [ -f "$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh" ]; then
+  echo -e "  Managed-settings channel-kapu ellenorzese..."
+  bash "$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh" || true
+fi
+
 # Linuxbrew (ha telepitve van)
 if [ -x "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
   ensure_in_rc 'linuxbrew' 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv bash)"'

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -346,6 +346,16 @@ print(json.dumps(existing, indent=2))
   fi
 fi
 
+# Channel inbound org-policy gate: ensure the system managed-settings enable
+# channels (runs unconditionally, not only in the Slack branch above). claude-code
+# >= 2.1.205 silently drops channel-plugin INBOUND notifications on a team/
+# enterprise org unless managed-settings has channelsEnabled:true (harmless /
+# no-op on a personal org). Idempotent + preserves existing managed keys.
+if [ -f "$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh" ]; then
+  echo -e "  Managed-settings channel-kapu ellenorzese..."
+  bash "$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh" || true
+fi
+
 read -rp "$(_t prompt_bot_name)" BOT_NAME
 BOT_NAME=${BOT_NAME:-"Marveen"}
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -51,6 +51,24 @@ if ! bash scripts/verify-channels-health.sh &>/dev/null; then
   FAIL=1
 fi
 
+# --- Managed-settings channel org-policy gate ---
+# claude-code >= 2.1.205 silently drops channel-plugin INBOUND notifications on a
+# team/enterprise org unless the system managed-settings has channelsEnabled:true.
+# Diagnostic only (warn, not fail): a personal org ignores the flag.
+echo -e "\n${BOLD}Managed-settings${RESET}"
+case "$(uname -s)" in
+  Darwin) MANAGED_FILE="/Library/Application Support/ClaudeCode/managed-settings.json" ;;
+  Linux)  MANAGED_FILE="/etc/claude-code/managed-settings.json" ;;
+  *)      MANAGED_FILE="" ;;
+esac
+if [ -z "$MANAGED_FILE" ]; then
+  warn "channelsEnabled: nem tamogatott OS -- kihagyva"
+elif [ -f "$MANAGED_FILE" ] && python3 -c "import json,sys; sys.exit(0 if json.load(open('$MANAGED_FILE')).get('channelsEnabled') is True else 1)" 2>/dev/null; then
+  ok "channelsEnabled: OK ($MANAGED_FILE)"
+else
+  warn "channelsEnabled: HIANYZIK -- team/enterprise orgnal a bejovo channel-uzenetek eldobodhatnak. Fix: bash scripts/ensure-managed-channels-enabled.sh"
+fi
+
 # --- Channel keepalive ---
 echo -e "\n${BOLD}Keepalive${RESET}"
 KA_FILE="store/.channel-keepalive"

--- a/scripts/ensure-managed-channels-enabled.sh
+++ b/scripts/ensure-managed-channels-enabled.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Ensure the SYSTEM-level Claude Code managed-settings.json enables channels.
+#
+# WHY: claude-code >= 2.1.205 SILENTLY drops channel-plugin INBOUND
+# notifications on a TEAM/ENTERPRISE org unless the managed (org-policy) settings
+# contain "channelsEnabled": true. The bot still sends OUTBOUND and the poller
+# still runs (pending 0), so it looks "almost working" -- but replies never reach
+# the session (plugin log: "Channel notifications skipped: channels not enabled
+# by org policy"). channelsEnabled is a MANAGED-settings-only key; user/project
+# settings have no effect. See the channel-inbound-org-policy-gate skill.
+#
+# ALWAYS-ENSURE (not org-type detection): on a personal org the key is simply
+# ignored (harmless), and an account can move personal -> team AFTER install, so
+# detecting org type at install time is fragile. Setting it unconditionally in
+# the managed layer is the simple, robust, correct-for-all-cases choice.
+#
+# Idempotent, reversible (delete the key), and a SAFE JSON merge (never sed):
+# existing managed keys -- e.g. allowedChannelPlugins -- are preserved.
+#
+# Managed-settings paths (authoritative, code.claude.com/docs/en/settings.md):
+#   macOS: /Library/Application Support/ClaudeCode/managed-settings.json
+#   Linux/WSL: /etc/claude-code/managed-settings.json
+set -u
+
+case "$(uname -s)" in
+  Darwin) MANAGED_FILE="/Library/Application Support/ClaudeCode/managed-settings.json" ;;
+  Linux)  MANAGED_FILE="/etc/claude-code/managed-settings.json" ;;
+  *) echo "  channelsEnabled: nem tamogatott OS ($(uname -s)); kihagyva."; exit 0 ;;
+esac
+
+# Root-aware privilege prefix. The managed dir is root-owned on both platforms.
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+  else
+    echo "  ! channelsEnabled: nem root es nincs sudo -- kihagyva."
+    echo "    Kezi lepes (root): tedd be a(z) {\"channelsEnabled\": true}-t ide: $MANAGED_FILE"
+    exit 0
+  fi
+fi
+
+# Idempotent: already true -> nothing to do.
+if [ -f "$MANAGED_FILE" ] && $SUDO python3 - "$MANAGED_FILE" 2>/dev/null <<'PY'
+import json, sys
+try:
+    sys.exit(0 if json.load(open(sys.argv[1])).get("channelsEnabled") is True else 1)
+except Exception:
+    sys.exit(1)
+PY
+then
+  echo "  channelsEnabled: mar be van kapcsolva ($MANAGED_FILE)"
+  exit 0
+fi
+
+if ! $SUDO mkdir -p "$(dirname "$MANAGED_FILE")" 2>/dev/null; then
+  echo "  ! channelsEnabled: nem sikerult letrehozni $(dirname "$MANAGED_FILE") -- kezi root-lepes szukseges."
+  exit 0
+fi
+
+# Safe JSON merge: load existing (or {}), set channelsEnabled=true, atomic write.
+if $SUDO python3 - "$MANAGED_FILE" <<'PY'
+import json, os, sys
+p = sys.argv[1]
+try:
+    d = json.load(open(p)) if os.path.exists(p) else {}
+    if not isinstance(d, dict):
+        d = {}
+except Exception:
+    d = {}
+d["channelsEnabled"] = True
+tmp = p + ".tmp"
+with open(tmp, "w") as f:
+    f.write(json.dumps(d, indent=2) + "\n")
+os.replace(tmp, p)
+PY
+then
+  echo "  channelsEnabled=true beallitva a managed-settings-ben ($MANAGED_FILE)"
+  echo "    (a bejovo channel-uzenetek team/enterprise orgnal is celba ernek; restart utan lep eletbe.)"
+else
+  echo "  ! channelsEnabled: a managed-settings frissitese sikertelen."
+  echo "    Kezi lepes (root): tedd be a(z) {\"channelsEnabled\": true}-t ide: $MANAGED_FILE"
+fi
+exit 0


### PR DESCRIPTION
## Problem

A fresh Marveen/channels install can start, send OUTBOUND, and keep the poller alive (pending 0), yet INBOUND channel messages never reach the session — the user writes and nothing replies. **Root cause:** claude-code >= 2.1.205 **silently drops** channel-plugin inbound notifications on a **team/enterprise** org unless the system-level `managed-settings.json` has `"channelsEnabled": true` (plugin log: `Channel notifications skipped: channels not enabled by org policy`). It is a **managed-settings-only** key — user/project settings have no effect. Hit on a real customer MacMini install.

## Change (installer prevention)

- **`scripts/ensure-managed-channels-enabled.sh`** (new, shared): idempotently sets `channelsEnabled:true` in the system managed-settings. OS-aware paths (macOS `/Library/Application Support/ClaudeCode/`, Linux/WSL `/etc/claude-code/` — confirmed against `code.claude.com/docs/en/settings.md`). Root-aware (sudo only when needed; clean guidance if neither). **Safe JSON merge** via python + atomic write (never sed) so existing managed keys (e.g. `allowedChannelPlugins`) are preserved.
- **`install-linux.sh` + `install-macos.sh`**: call it **unconditionally** at install time (on macOS not only inside the Slack branch, where the managed block used to live).
- **`scripts/doctor.sh`**: diagnostic line `channelsEnabled: OK / HIANYZIK` with the one-command fix.

### Design decision: always-ensure (not org-type detection)
A personal org ignores the key (harmless no-op), an account can move personal→team **after** install, and org detection at install time is fragile — so unconditionally setting the managed layer is the simplest, most robust, correct-for-all-cases choice. Justified inline in the script.

## Safety
Idempotent, reversible (delete the key), preserves existing managed keys, macOS + Linux only (no Windows change here). `channelsEnabled:true` only **enables** a feature, so it cannot break a co-resident claude-code install.

## Testing
- `bash -n` + **shellcheck clean** for all 4 files.
- Merge-preservation unit-checked (existing `allowedChannelPlugins` + arbitrary org keys survive).
- **Live end-to-end on the AVX-less pilot VPS** (Linux, root, `/etc/claude-code/`): create → valid JSON → idempotent 2nd run → merge preserves existing keys → doctor reports OK. Pilot restored clean afterwards.

Pairs with the channel-inbound-org-policy-gate diagnosis skill (this is the install-time prevention). Ships with the normal release.
