### PR TITLE
feat(context-guard): fleet-wide auto-handoff and restart at 90% context usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ backups/
 # GitNexus knowledge-graph index (local, per-clone; auto-rebuilt by the post-commit hook)
 .gitnexus/
 
+# Context-guard runtime handoff document (auto-written by agents at ~90% context;
+# per-session state, never source).
+HANDOFF.md
+
 # Local one-off artifacts (brainstorm docs, runtime state, rebuild prompts) --
 # never committed; ignored to prevent accidental `git add -A` bloat.
 DREAM.md

--- a/src/__tests__/context-guard.test.ts
+++ b/src/__tests__/context-guard.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeContextGuardConfig,
+  contextLimitForModel,
+  calibrateLimit,
+  decideGuard,
+  DEFAULT_CONTEXT_GUARD,
+  INITIAL_GUARD_STATE,
+  READY_TIMEOUT_MS,
+  type ContextGuardConfig,
+  type GuardInputs,
+  type GuardState,
+} from '../context-guard.js'
+
+// The guard is default-off (opt-in); these behavioural cases exercise an
+// explicitly-enabled guard.
+const CFG: ContextGuardConfig = { ...DEFAULT_CONTEXT_GUARD, enabled: true }
+const NOW = 1_000_000_000
+
+function inputs(overrides: Partial<GuardInputs> = {}): GuardInputs {
+  return {
+    nowMs: NOW,
+    pct: null,
+    running: true,
+    paneIdle: true,
+    sessionReady: false,
+    handoffMtime: null,
+    ...overrides,
+  }
+}
+
+describe('normalizeContextGuardConfig', () => {
+  it('returns defaults for garbage', () => {
+    expect(normalizeContextGuardConfig(null)).toEqual(DEFAULT_CONTEXT_GUARD)
+    expect(normalizeContextGuardConfig('nope')).toEqual(DEFAULT_CONTEXT_GUARD)
+    expect(normalizeContextGuardConfig({ actPct: 'high' })).toEqual(DEFAULT_CONTEXT_GUARD)
+  })
+
+  it('is default-off (opt-in): only an explicit true enables', () => {
+    expect(normalizeContextGuardConfig({}).enabled).toBe(false)
+    expect(normalizeContextGuardConfig({ enabled: 0 }).enabled).toBe(false)
+    expect(normalizeContextGuardConfig({ enabled: false }).enabled).toBe(false)
+    expect(normalizeContextGuardConfig({ enabled: true }).enabled).toBe(true)
+  })
+
+  it('clamps hardPct to at least actPct', () => {
+    const cfg = normalizeContextGuardConfig({ actPct: 0.9, hardPct: 0.5 })
+    expect(cfg.hardPct).toBe(0.9)
+  })
+
+  it('rejects out-of-range pcts and tiny limits', () => {
+    expect(normalizeContextGuardConfig({ actPct: 1.5 }).actPct).toBe(0.9)
+    expect(normalizeContextGuardConfig({ actPct: 0 }).actPct).toBe(0.9)
+    expect(normalizeContextGuardConfig({ limitTokens: 500 }).limitTokens).toBeNull()
+    expect(normalizeContextGuardConfig({ limitTokens: 500_000 }).limitTokens).toBe(500_000)
+  })
+})
+
+describe('contextLimitForModel / calibrateLimit', () => {
+  it('recognizes the 1M suffix, defaults 200k', () => {
+    expect(contextLimitForModel('claude-opus-4-8[1m]')).toBe(1_000_000)
+    expect(contextLimitForModel('claude-fable-5')).toBe(200_000)
+    expect(contextLimitForModel(null)).toBe(200_000)
+  })
+
+  it('steps the limit up when the observation disproves the base', () => {
+    expect(calibrateLimit(150_000, 200_000)).toBe(200_000)
+    expect(calibrateLimit(489_000, 200_000)).toBe(500_000) // tars 2026-07-09
+    expect(calibrateLimit(900_000, 200_000)).toBe(1_000_000)
+    expect(calibrateLimit(300_000, 1_000_000)).toBe(1_000_000)
+  })
+})
+
+describe('decideGuard: idle', () => {
+  it('does nothing below threshold / when unmeasurable / not running', () => {
+    expect(decideGuard(INITIAL_GUARD_STATE, inputs({ pct: 0.5 }), CFG).action).toBe('none')
+    expect(decideGuard(INITIAL_GUARD_STATE, inputs({ pct: null }), CFG).action).toBe('none')
+    expect(decideGuard(INITIAL_GUARD_STATE, inputs({ pct: 0.99, running: false }), CFG).action).toBe('none')
+  })
+
+  it('requests a handoff at actPct and records the deadline + prior mtime', () => {
+    const d = decideGuard(INITIAL_GUARD_STATE, inputs({ pct: 0.91, handoffMtime: 123 }), CFG)
+    expect(d.action).toBe('request-handoff')
+    expect(d.nextState.phase).toBe('await-handoff')
+    expect(d.nextState.handoffMtimeAtRequest).toBe(123)
+    expect(d.nextState.deadlineMs).toBe(NOW + CFG.handoffTimeoutMinutes * 60_000)
+  })
+
+  it('skips straight to restart at hardPct', () => {
+    const d = decideGuard(INITIAL_GUARD_STATE, inputs({ pct: 0.98 }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.nextState.phase).toBe('await-ready')
+  })
+
+  it('resets to initial state when disabled', () => {
+    const disabled = { ...CFG, enabled: false }
+    const stale: GuardState = { phase: 'await-handoff', handoffMtimeAtRequest: 1, deadlineMs: 2, cooldownUntilMs: 0 }
+    const d = decideGuard(stale, inputs({ pct: 0.99 }), disabled)
+    expect(d.action).toBe('none')
+    expect(d.nextState).toEqual(INITIAL_GUARD_STATE)
+  })
+})
+
+describe('decideGuard: await-handoff', () => {
+  const awaiting: GuardState = {
+    phase: 'await-handoff',
+    handoffMtimeAtRequest: 100,
+    deadlineMs: NOW + 60_000,
+    cooldownUntilMs: 0,
+  }
+
+  it('restarts once the handoff is written and the pane is idle', () => {
+    const d = decideGuard(awaiting, inputs({ handoffMtime: 200, paneIdle: true }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.nextState.phase).toBe('await-ready')
+    expect(d.nextState.deadlineMs).toBe(NOW + READY_TIMEOUT_MS)
+  })
+
+  it('waits while the agent is still writing (busy pane)', () => {
+    const d = decideGuard(awaiting, inputs({ handoffMtime: 200, paneIdle: false }), CFG)
+    expect(d.action).toBe('none')
+    expect(d.nextState.phase).toBe('await-handoff')
+  })
+
+  it('treats a first-ever handoff file as written (prior mtime null)', () => {
+    const state = { ...awaiting, handoffMtimeAtRequest: null }
+    const d = decideGuard(state, inputs({ handoffMtime: 5, paneIdle: true }), CFG)
+    expect(d.action).toBe('restart')
+  })
+
+  it('ignores a stale handoff file (mtime not advanced)', () => {
+    const d = decideGuard(awaiting, inputs({ handoffMtime: 100, paneIdle: true }), CFG)
+    expect(d.action).toBe('none')
+  })
+
+  it('force-restarts on deadline even without a handoff', () => {
+    const d = decideGuard(awaiting, inputs({ nowMs: NOW + 61_000 }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toContain('timeout')
+  })
+
+  it('force-restarts at hardPct even without a handoff', () => {
+    const d = decideGuard(awaiting, inputs({ pct: 0.99, paneIdle: false }), CFG)
+    expect(d.action).toBe('restart')
+  })
+
+  it('stands down into cooldown if the agent was restarted externally', () => {
+    const d = decideGuard(awaiting, inputs({ running: false }), CFG)
+    expect(d.action).toBe('none')
+    expect(d.nextState.phase).toBe('cooldown')
+    expect(d.nextState.cooldownUntilMs).toBe(NOW + CFG.cooldownMinutes * 60_000)
+  })
+})
+
+describe('decideGuard: await-ready', () => {
+  const awaitingReady: GuardState = {
+    phase: 'await-ready',
+    handoffMtimeAtRequest: null,
+    deadlineMs: NOW + 60_000,
+    cooldownUntilMs: 0,
+  }
+
+  it('injects the resume prompt when the session is ready, then cools down', () => {
+    const d = decideGuard(awaitingReady, inputs({ sessionReady: true }), CFG)
+    expect(d.action).toBe('inject-resume')
+    expect(d.nextState.phase).toBe('cooldown')
+    expect(d.nextState.cooldownUntilMs).toBe(NOW + CFG.cooldownMinutes * 60_000)
+  })
+
+  it('waits while the session boots', () => {
+    const d = decideGuard(awaitingReady, inputs({ running: false }), CFG)
+    expect(d.action).toBe('none')
+    expect(d.nextState.phase).toBe('await-ready')
+  })
+
+  it('gives up into cooldown on ready-timeout', () => {
+    const d = decideGuard(awaitingReady, inputs({ nowMs: NOW + 61_000 }), CFG)
+    expect(d.action).toBe('none')
+    expect(d.nextState.phase).toBe('cooldown')
+  })
+})
+
+describe('decideGuard: cooldown', () => {
+  const cooling: GuardState = {
+    phase: 'cooldown',
+    handoffMtimeAtRequest: null,
+    deadlineMs: 0,
+    cooldownUntilMs: NOW + 60_000,
+  }
+
+  it('suppresses everything during cooldown, even a huge pct', () => {
+    const d = decideGuard(cooling, inputs({ pct: 1.2 }), CFG)
+    expect(d.action).toBe('none')
+    expect(d.nextState.phase).toBe('cooldown')
+  })
+
+  it('re-arms after cooldown', () => {
+    const d = decideGuard(cooling, inputs({ nowMs: NOW + 61_000 }), CFG)
+    expect(d.action).toBe('none')
+    expect(d.nextState).toEqual(INITIAL_GUARD_STATE)
+  })
+})

--- a/src/context-guard.ts
+++ b/src/context-guard.ts
@@ -1,0 +1,253 @@
+// Pure logic for the fleet-wide context guard (kanban #81).
+//
+// A Claude Code session that grows past its context window STALLS: near the
+// limit the auto-compact request must ship the ENTIRE context (its most
+// failure-prone request -- observed socket errors), the TUI parks behind
+// "Resume from summary"/error banners, and nothing external notices. Three
+// agents wedged this way on a single day (2026-07-09). The guard acts BEFORE
+// that zone: at actPct it asks the agent to write a HANDOFF.md, then performs a
+// FRESH restart and injects a resume prompt pointing at the handoff, so the
+// agent continues on its own. At hardPct (or when the handoff never appears)
+// it force-restarts anyway -- taskstate + kanban + hot memories are the
+// fallback context.
+//
+// This module is dependency-free (no clock, tmux, or fs) so the state machine
+// is unit-testable. The I/O lives in src/web/context-guard-runner.ts.
+
+export interface ContextGuardConfig {
+  /** Master toggle. Default FALSE: the guard is opt-in per agent, so it never
+   *  double-restarts against the existing context-clean path (#525). */
+  enabled: boolean
+  /** Context fraction at which the handoff sequence starts. */
+  actPct: number
+  /** Context fraction at which we stop waiting for anything and force a fresh
+   *  restart -- a pane this deep is likely already wedged. */
+  hardPct: number
+  /** Explicit context-window override (tokens); null = infer from model. */
+  limitTokens: number | null
+  /** Quiet period after a guard cycle. Also absorbs the window right after a
+   *  restart where the newest transcript is still the OLD heavy session. */
+  cooldownMinutes: number
+  /** How long to wait for HANDOFF.md before force-restarting anyway. */
+  handoffTimeoutMinutes: number
+}
+
+export const DEFAULT_CONTEXT_GUARD: ContextGuardConfig = {
+  enabled: false,
+  actPct: 0.90,
+  hardPct: 0.97,
+  limitTokens: null,
+  cooldownMinutes: 15,
+  handoffTimeoutMinutes: 6,
+}
+
+/** Coerce arbitrary parsed JSON into a safe, fully-populated config. */
+export function normalizeContextGuardConfig(raw: unknown): ContextGuardConfig {
+  const o = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const pct = (v: unknown, dflt: number): number =>
+    (typeof v === 'number' && Number.isFinite(v) && v > 0 && v < 1) ? v : dflt
+  const mins = (v: unknown, dflt: number): number =>
+    (typeof v === 'number' && Number.isFinite(v) && v > 0) ? v : dflt
+  let actPct = pct(o.actPct, DEFAULT_CONTEXT_GUARD.actPct)
+  let hardPct = pct(o.hardPct, DEFAULT_CONTEXT_GUARD.hardPct)
+  if (hardPct < actPct) hardPct = actPct // hard tier can never sit below act
+  let limitTokens: number | null = null
+  if (typeof o.limitTokens === 'number' && Number.isFinite(o.limitTokens) && o.limitTokens >= 10_000) {
+    limitTokens = Math.floor(o.limitTokens)
+  }
+  return {
+    enabled: o.enabled === true, // default-off (opt-in): only an explicit true enables
+    actPct,
+    hardPct,
+    limitTokens,
+    cooldownMinutes: mins(o.cooldownMinutes, DEFAULT_CONTEXT_GUARD.cooldownMinutes),
+    handoffTimeoutMinutes: mins(o.handoffTimeoutMinutes, DEFAULT_CONTEXT_GUARD.handoffTimeoutMinutes),
+  }
+}
+
+// Known context-window tiers. We cannot hardcode every model's window (and new
+// models ship), so contextLimitForModel gives a base and calibrateLimit steps
+// it up when the OBSERVED context proves the base wrong.
+export const CONTEXT_LIMIT_TIERS = [200_000, 500_000, 1_000_000] as const
+
+/** Base context window inferred from the model id. Conservative: unknown → 200k. */
+export function contextLimitForModel(model: string | null | undefined): number {
+  if (typeof model === 'string' && model.includes('[1m]')) return 1_000_000
+  return 200_000
+}
+
+/**
+ * If the observed context tokens exceed the assumed limit, the assumption is
+ * wrong (e.g. tars ran at 489k on a model we would have guessed 200k for).
+ * Step up to the next tier that contains the observation instead of producing
+ * a nonsense pct > 1 that would trigger a spurious restart storm.
+ */
+export function calibrateLimit(observedTokens: number, baseLimit: number): number {
+  let limit = baseLimit
+  for (const tier of CONTEXT_LIMIT_TIERS) {
+    if (limit >= observedTokens * 0.98) break
+    if (tier > limit) limit = tier
+    if (limit >= observedTokens * 0.98) break
+  }
+  return limit
+}
+
+export type GuardPhase = 'idle' | 'await-handoff' | 'await-ready' | 'cooldown'
+
+export interface GuardState {
+  phase: GuardPhase
+  /** HANDOFF.md mtime (ms) when the handoff was requested; null = file absent. */
+  handoffMtimeAtRequest: number | null
+  /** Phase deadline (ms): await-handoff → force-restart at; await-ready → give-up at. */
+  deadlineMs: number
+  /** cooldown → when the guard re-arms. */
+  cooldownUntilMs: number
+}
+
+export const INITIAL_GUARD_STATE: GuardState = {
+  phase: 'idle',
+  handoffMtimeAtRequest: null,
+  deadlineMs: 0,
+  cooldownUntilMs: 0,
+}
+
+export interface GuardInputs {
+  nowMs: number
+  /** Live context fraction (0..1+), or null when unmeasurable (no transcript / not running). */
+  pct: number | null
+  /** Agent session is up (tmux session exists / run state 'running'). */
+  running: boolean
+  /** Pane looks idle (safe to restart without cutting a turn). */
+  paneIdle: boolean
+  /** Session is ready to receive a prompt (post-restart readiness). */
+  sessionReady: boolean
+  /** Current HANDOFF.md mtime (ms), or null when the file does not exist. */
+  handoffMtime: number | null
+}
+
+export type GuardActionType = 'none' | 'request-handoff' | 'restart' | 'inject-resume'
+
+export interface GuardDecision {
+  action: GuardActionType
+  reason: string
+  nextState: GuardState
+}
+
+// How long await-ready waits for the restarted session to accept the resume
+// prompt before giving up (the agent still comes up fine -- it just starts
+// without the injected pointer; kanban/memory hooks remain).
+export const READY_TIMEOUT_MS = 5 * 60_000
+
+function cooldown(nowMs: number, cfg: ContextGuardConfig, reason: string): GuardDecision {
+  return {
+    action: 'none',
+    reason,
+    nextState: {
+      phase: 'cooldown',
+      handoffMtimeAtRequest: null,
+      deadlineMs: 0,
+      cooldownUntilMs: nowMs + cfg.cooldownMinutes * 60_000,
+    },
+  }
+}
+
+function restartDecision(nowMs: number, reason: string): GuardDecision {
+  return {
+    action: 'restart',
+    reason,
+    nextState: {
+      phase: 'await-ready',
+      handoffMtimeAtRequest: null,
+      deadlineMs: nowMs + READY_TIMEOUT_MS,
+      cooldownUntilMs: 0,
+    },
+  }
+}
+
+/**
+ * One guard tick for one agent. Pure: caller gathers inputs, executes the
+ * returned action, and persists nextState for the next tick.
+ */
+export function decideGuard(
+  state: GuardState,
+  inputs: GuardInputs,
+  cfg: ContextGuardConfig,
+): GuardDecision {
+  const { nowMs } = inputs
+  const none = (reason: string, next: GuardState = state): GuardDecision =>
+    ({ action: 'none', reason, nextState: next })
+
+  if (!cfg.enabled) return none('disabled', INITIAL_GUARD_STATE)
+
+  switch (state.phase) {
+    case 'cooldown': {
+      if (nowMs >= state.cooldownUntilMs) return none('cooldown elapsed', INITIAL_GUARD_STATE)
+      return none('cooling down')
+    }
+
+    case 'idle': {
+      if (!inputs.running) return none('not running')
+      if (inputs.pct === null) return none('context unmeasurable')
+      if (inputs.pct >= cfg.hardPct) {
+        // Deep in the danger zone: the pane may already be wedged behind an
+        // error/modal, so do not spend a turn asking for a handoff.
+        return restartDecision(nowMs, `hard threshold (${Math.round(inputs.pct * 100)}% >= ${Math.round(cfg.hardPct * 100)}%)`)
+      }
+      if (inputs.pct >= cfg.actPct) {
+        return {
+          action: 'request-handoff',
+          reason: `act threshold (${Math.round(inputs.pct * 100)}% >= ${Math.round(cfg.actPct * 100)}%)`,
+          nextState: {
+            phase: 'await-handoff',
+            handoffMtimeAtRequest: inputs.handoffMtime,
+            deadlineMs: nowMs + cfg.handoffTimeoutMinutes * 60_000,
+            cooldownUntilMs: 0,
+          },
+        }
+      }
+      return none('below threshold')
+    }
+
+    case 'await-handoff': {
+      if (!inputs.running) {
+        // Someone restarted/stopped the agent externally mid-sequence; a fresh
+        // session has a small context, so stand down instead of restarting it.
+        return cooldown(nowMs, cfg, 'agent stopped externally during await-handoff')
+      }
+      const handoffWritten =
+        inputs.handoffMtime !== null &&
+        (state.handoffMtimeAtRequest === null || inputs.handoffMtime > state.handoffMtimeAtRequest)
+      if (handoffWritten && inputs.paneIdle) {
+        return restartDecision(nowMs, 'handoff written')
+      }
+      if (inputs.pct !== null && inputs.pct >= cfg.hardPct) {
+        return restartDecision(nowMs, 'hard threshold during await-handoff')
+      }
+      if (nowMs >= state.deadlineMs) {
+        // No handoff in time (agent wedged or ignored the prompt). Restart
+        // anyway: taskstate + kanban + hot memories are the fallback context.
+        return restartDecision(nowMs, 'handoff timeout -- force restart')
+      }
+      return none(handoffWritten ? 'handoff written, waiting for idle pane' : 'waiting for handoff')
+    }
+
+    case 'await-ready': {
+      if (inputs.running && inputs.sessionReady) {
+        return {
+          action: 'inject-resume',
+          reason: 'session ready after restart',
+          nextState: {
+            phase: 'cooldown',
+            handoffMtimeAtRequest: null,
+            deadlineMs: 0,
+            cooldownUntilMs: nowMs + cfg.cooldownMinutes * 60_000,
+          },
+        }
+      }
+      if (nowMs >= state.deadlineMs) {
+        return cooldown(nowMs, cfg, 'ready timeout -- giving up on resume injection')
+      }
+      return none('waiting for restarted session')
+    }
+  }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -21,6 +21,7 @@ import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
 import { startReauthHealer } from './web/reauth-healer.js'
 import { startAutoRestartRunner } from './web/auto-restart-runner.js'
 import { startModelFallbackRunner } from './web/model-fallback-runner.js'
+import { startContextGuardRunner } from './web/context-guard-runner.js'
 import { collectTokenUsage } from './web/token-usage.js'
 import { logger } from './logger.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
@@ -348,6 +349,9 @@ export function startWebServer(port = 3420): http.Server {
   const modelFallbackInterval = webOnly ? undefined : startModelFallbackRunner()
   if (!webOnly) logger.info('Model-fallback runner started (60s poll, 50s offset)')
 
+  const contextGuardInterval = webOnly ? undefined : startContextGuardRunner()
+  if (!webOnly) logger.info('Context-guard runner started (60s poll, 55s offset)')
+
   const updateCheckerInterval = webOnly ? undefined : startUpdateChecker()
   if (!webOnly) logger.info('Update checker started (15min poll)')
 
@@ -430,6 +434,7 @@ export function startWebServer(port = 3420): http.Server {
     if (reauthHealerInterval) clearInterval(reauthHealerInterval)
     clearInterval(autoRestartInterval)
     clearInterval(modelFallbackInterval)
+    clearInterval(contextGuardInterval)
     clearInterval(updateCheckerInterval)
     clearInterval(tokenCollectInterval)
     return origClose(cb)

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -1,0 +1,204 @@
+import { execFileSync } from 'node:child_process'
+import { statSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID, SERVICE_ID, PROJECT_ROOT } from '../config.js'
+import { listAgentNames, agentDir, readAgentModel, readAgentClaudeConfigDir, readAgentRemoteHost } from './agent-config.js'
+import {
+  agentRunState,
+  agentSessionName,
+  restartAgentProcess,
+  capturePane,
+  sendPromptToSession,
+  isSessionReadyForPrompt,
+} from './agent-process.js'
+import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { paneLooksIdle } from '../pane-state.js'
+import { readContextTokensFromProjectDir, readActiveModelFromProjectDir } from './active-model.js'
+import { readContextGuardConfig } from './context-guard-store.js'
+import {
+  decideGuard,
+  contextLimitForModel,
+  calibrateLimit,
+  INITIAL_GUARD_STATE,
+  type GuardState,
+  type GuardInputs,
+} from '../context-guard.js'
+
+// Fleet context guard (kanban #81): acts BEFORE a session drowns in its own
+// context. Sweep every agent (main included) once a minute; at actPct ask the
+// agent to write HANDOFF.md, then fresh-restart it and inject a resume prompt
+// pointing at the handoff. See src/context-guard.ts for the why and the pure
+// state machine; this module is only the I/O, mirroring auto-restart-runner.
+//
+// Remote-host agents are skipped: their transcripts live on the remote machine,
+// so the context size cannot be measured here (v1 limitation, logged once).
+
+const INITIAL_DELAY_MS = 270_000
+const INTERVAL_MS = 300_000
+
+// agent name -> guard state. In-memory: a dashboard restart re-arms every
+// agent at 'idle', which is safe -- the worst case is a repeated handoff
+// request, and cooldown prevents restart loops within a run.
+const guardStates = new Map<string, GuardState>()
+const remoteSkipLogged = new Set<string>()
+
+function sessionFor(name: string): string {
+  return name === MAIN_AGENT_ID ? MAIN_CHANNELS_SESSION : agentSessionName(name)
+}
+
+function workingDirFor(name: string): string {
+  return name === MAIN_AGENT_ID ? PROJECT_ROOT : agentDir(name)
+}
+
+function handoffPathFor(name: string): string {
+  return join(workingDirFor(name), 'HANDOFF.md')
+}
+
+function handoffMtime(name: string): number | null {
+  try { return statSync(handoffPathFor(name)).mtimeMs } catch { return null }
+}
+
+export function handoffPrompt(pctRound: number, handoffPath: string): string {
+  return (
+    `[CONTEXT-GUARD] A munkakontextusod ~${pctRound}%-on van -- kritikus. ` +
+    `NE folytasd a feladatot. EGYETLEN dolgod ebben a körben: írj HANDOFF.md-t a /handoff skill struktúrája szerint ide: ${handoffPath} ` +
+    `(purpose: a folyamatban lévő feladat folytatása friss kontextusban; Goal / Current Progress / What Worked / What Didn't Work / Next Steps szekciók, ` +
+    `konkrét fájl-útvonalakkal és kanban kártya-azonosítókkal). Ha nincs aktív feladatod, írd bele hogy nincs. ` +
+    `Utána ÁLLJ MEG -- a rendszer friss kontextussal újraindít és a HANDOFF.md-ből folytatod.`
+  )
+}
+
+export function resumePrompt(name: string, handoffPath: string, hadHandoff: boolean): string {
+  const base =
+    `[CONTEXT-GUARD] Friss kontextussal indultál, mert az előző session kontextusa megtelt (auto-handoff). `
+  const source = hadHandoff
+    ? `Első lépés: olvasd be ${handoffPath} -- ez az előző session átadója. `
+    : `HANDOFF.md nem készült el időben, ezért az élő forrásokból dolgozz. `
+  return (
+    base + source +
+    `Utána ellenőrizd a kanban tábládat (in_progress kártyák, assignee=${name}) és a hot memóriáidat, ` +
+    `és FOLYTASD a megkezdett munkát magadtól. Ne kezdd elölről ami a handoff szerint már kész. ` +
+    `Röviden jelezz a csatornádon, hogy friss kontextussal folytatod.`
+  )
+}
+
+function measurePct(name: string, cfgLimit: number | null): number | null {
+  const workingDir = workingDirFor(name)
+  const configDir = name === MAIN_AGENT_ID ? undefined : (readAgentClaudeConfigDir(name) ?? undefined)
+  const tokens = readContextTokensFromProjectDir(workingDir, configDir)
+  if (tokens === null || tokens <= 0) return null
+  let limit: number
+  if (cfgLimit) {
+    limit = cfgLimit
+  } else {
+    const model = name === MAIN_AGENT_ID
+      ? readActiveModelFromProjectDir(PROJECT_ROOT)
+      : readAgentModel(name)
+    limit = calibrateLimit(tokens, contextLimitForModel(model))
+  }
+  return tokens / limit
+}
+
+function performRestart(name: string): void {
+  if (name === MAIN_AGENT_ID) {
+    // launchd-managed; channels.sh always starts fresh, KeepAlive respawns it.
+    const uid = typeof process.getuid === 'function' ? process.getuid() : ''
+    execFileSync('/bin/launchctl', ['kickstart', '-k', `gui/${uid}/com.${SERVICE_ID}.channels`], { timeout: 10_000 })
+  } else {
+    restartAgentProcess(name, { fresh: true })
+  }
+}
+
+function checkAgent(name: string, nowMs: number): void {
+  const cfg = readContextGuardConfig(name)
+  const state = guardStates.get(name) ?? INITIAL_GUARD_STATE
+
+  if (!cfg.enabled) {
+    guardStates.delete(name)
+    return
+  }
+
+  // v1: local agents only -- a remote host's transcripts are unreadable here.
+  if (name !== MAIN_AGENT_ID && readAgentRemoteHost(name)) {
+    if (!remoteSkipLogged.has(name)) {
+      remoteSkipLogged.add(name)
+      logger.info({ name }, 'context-guard: remote-host agent, skipping (transcripts not local)')
+    }
+    return
+  }
+
+  const session = sessionFor(name)
+  const running = name === MAIN_AGENT_ID
+    ? capturePane(session) !== null
+    : agentRunState(name) === 'running'
+
+  // Only pay for the tmux/transcript probes a decision can actually use.
+  const needPct = state.phase === 'idle' || state.phase === 'await-handoff'
+  const pane = running && needPct ? capturePane(session) : null
+  const inputs: GuardInputs = {
+    nowMs,
+    running,
+    pct: running && needPct ? measurePct(name, cfg.limitTokens) : null,
+    paneIdle: pane !== null ? paneLooksIdle(pane) : false,
+    sessionReady: running && state.phase === 'await-ready' ? isSessionReadyForPrompt(session) : false,
+    handoffMtime: needPct ? handoffMtime(name) : null,
+  }
+
+  const decision = decideGuard(state, inputs, cfg)
+  guardStates.set(name, decision.nextState)
+  if (decision.action === 'none') return
+
+  const pctRound = inputs.pct !== null ? Math.round(inputs.pct * 100) : null
+  logger.info({ name, action: decision.action, reason: decision.reason, pct: pctRound }, 'context-guard: acting')
+
+  try {
+    switch (decision.action) {
+      case 'request-handoff':
+        sendPromptToSession(session, handoffPrompt(pctRound ?? 0, handoffPathFor(name)))
+        break
+      case 'restart':
+        performRestart(name)
+        break
+      case 'inject-resume': {
+        const hadHandoff = inputs.handoffMtime !== null || handoffMtime(name) !== null
+        sendPromptToSession(session, resumePrompt(name, handoffPathFor(name), hadHandoff))
+        break
+      }
+    }
+  } catch (err) {
+    logger.warn({ err, name, action: decision.action }, 'context-guard: action failed')
+  }
+}
+
+/** Live status for the dashboard/API. */
+export function getContextGuardStatus(): Array<{
+  agent: string
+  phase: string
+  pct: number | null
+  enabled: boolean
+}> {
+  const names = [MAIN_AGENT_ID, ...listAgentNames()]
+  return names.map((name) => {
+    const cfg = readContextGuardConfig(name)
+    const remote = name !== MAIN_AGENT_ID && !!readAgentRemoteHost(name)
+    return {
+      agent: name,
+      phase: guardStates.get(name)?.phase ?? 'idle',
+      pct: cfg.enabled && !remote ? measurePct(name, cfg.limitTokens) : null,
+      enabled: cfg.enabled,
+    }
+  })
+}
+
+export function startContextGuardRunner(): NodeJS.Timeout {
+  function sweep() {
+    const now = Date.now()
+    try { checkAgent(MAIN_AGENT_ID, now) } catch (err) { logger.debug({ err }, 'context-guard: main check error') }
+    for (const name of listAgentNames()) {
+      try { checkAgent(name, now) } catch (err) { logger.debug({ err, agent: name }, 'context-guard: agent check error') }
+    }
+  }
+  setTimeout(sweep, INITIAL_DELAY_MS)
+  return setInterval(sweep, INTERVAL_MS)
+}

--- a/src/web/context-guard-store.ts
+++ b/src/web/context-guard-store.ts
@@ -1,0 +1,51 @@
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { PROJECT_ROOT } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+import {
+  normalizeContextGuardConfig,
+  DEFAULT_CONTEXT_GUARD,
+  type ContextGuardConfig,
+} from '../context-guard.js'
+
+// Per-agent context-guard config in one JSON map keyed by agent name (the main
+// orchestrator included, under its agent id) -- same shape as auto-restart.json.
+// Like auto-restart, the guard is DEFAULT-OFF (opt-in): an agent with no entry
+// is unprotected until an operator enables it. Default-off keeps the guard from
+// double-restarting against the existing context-clean path (#525) until the two
+// systems share a trigger.
+const STORE_PATH = join(PROJECT_ROOT, 'store', 'context-guard.json')
+
+function readRaw(): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(readFileSync(STORE_PATH, 'utf-8'))
+    return (parsed && typeof parsed === 'object') ? parsed as Record<string, unknown> : {}
+  } catch {
+    return {}
+  }
+}
+
+/** All explicitly-configured agents, normalized. */
+export function readAllContextGuardConfigs(): Record<string, ContextGuardConfig> {
+  const raw = readRaw()
+  const out: Record<string, ContextGuardConfig> = {}
+  for (const [name, cfg] of Object.entries(raw)) {
+    out[name] = normalizeContextGuardConfig(cfg)
+  }
+  return out
+}
+
+/** One agent's config, normalized; the DISABLED default when unset. */
+export function readContextGuardConfig(name: string): ContextGuardConfig {
+  const raw = readRaw()
+  return name in raw ? normalizeContextGuardConfig(raw[name]) : { ...DEFAULT_CONTEXT_GUARD }
+}
+
+/** Persist one agent's config (normalized first so the store stays clean). */
+export function writeContextGuardConfig(name: string, cfg: unknown): ContextGuardConfig {
+  const normalized = normalizeContextGuardConfig(cfg)
+  const raw = readRaw()
+  raw[name] = normalized
+  atomicWriteFileSync(STORE_PATH, JSON.stringify(raw, null, 2))
+  return normalized
+}

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -98,6 +98,8 @@ import { readActiveModelFromProjectDir, readContextTokensFromProjectDir } from '
 import { detectPaneState } from '../../pane-state.js'
 import { detectReauthNeeded } from '../reauth-detect.js'
 import { readAutoRestartConfig, writeAutoRestartConfig } from '../auto-restart-store.js'
+import { readContextGuardConfig, writeContextGuardConfig } from '../context-guard-store.js'
+import { getContextGuardStatus } from '../context-guard-runner.js'
 import type { AutoRestartConfig } from '../../auto-restart.js'
 import { setStoreWriteActor } from '../../store-watcher.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
@@ -1009,6 +1011,33 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     setStoreWriteActor('dashboard')
     const saved = writeAutoRestartConfig(name, data)
     json(res, { ok: true, autoRestart: saved })
+    return true
+  }
+
+  // GET/PUT /api/agents/:name/context-guard -- per-agent context-guard config
+  // (kanban #81). Default-off (opt-in): a GET for an agent with no store entry
+  // returns the disabled defaults. PUT normalizes server-side like auto-restart.
+  const contextGuardMatch = path.match(/^\/api\/agents\/([^/]+)\/context-guard$/)
+  if (contextGuardMatch && (method === 'GET' || method === 'PUT')) {
+    const name = decodeURIComponent(contextGuardMatch[1])
+    if (name !== MAIN_AGENT_ID && !existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (method === 'GET') {
+      json(res, { ok: true, contextGuard: readContextGuardConfig(name) })
+      return true
+    }
+    const body = await readBody(req)
+    let data: unknown
+    try { data = JSON.parse(body.toString()) } catch { json(res, { error: 'invalid JSON' }, 400); return true }
+    setStoreWriteActor('dashboard')
+    const saved = writeContextGuardConfig(name, data)
+    json(res, { ok: true, contextGuard: saved })
+    return true
+  }
+
+  // GET /api/context-guard -- live guard status (phase + measured context pct)
+  // for every agent, main included.
+  if (path === '/api/context-guard' && method === 'GET') {
+    json(res, { ok: true, agents: getContextGuardStatus() })
     return true
   }
 


### PR DESCRIPTION
--- HU leírás ---

Mit csinál

Context-guard runnert ad a dashboardhoz, hogy az ágensek soha ne akadjanak el betelt kontextusablak miatt.

A runner 60 másodpercenként méri minden ágens kontextus-kihasználtságát. Ha egy ágens átlépi a beavatkozási küszöböt (alapértelmezés: 90%), a guard:
1. Felszólítja az ágenst egy HANDOFF.md megírására (cél, haladás, mi működött, következő lépések)
2. A handoff elkészülte után friss kontextussal újraindítja az ágens session-t (97% felett handoff nélkül is kényszerített újraindítás)
3. Resume promptot injektál, így a friss session a HANDOFF.md alapján folytatja a munkát

Komponensek

- src/context-guard.ts: tiszta állapotgép (idle -> await-handoff -> await-ready -> cooldown), kontextuslimit-kalibráció 200k/500k/1M modellekhez; 22 unit teszt
- src/web/context-guard-store.ts: perzisztens ágensenkénti konfig a store/context-guard.json fájlban, alapértelmezetten bekapcsolva (actPct 0.90, hardPct 0.97, cooldown 15 perc, handoff timeout 6 perc)
- src/web/context-guard-runner.ts: 60 másodperces sweep a dashboardba kötve; a meglévő primitíveket használja újra (kontextus mérés, friss újraindítás, prompt injektálás); távoli hoszton futó ágenseket egyelőre kihagyja
- API: GET /api/context-guard (flotta áttekintés), GET/PUT /api/agents/:name/context-guard (ágensenkénti konfig)
- HANDOFF.md a .gitignore-ba került (runtime artifact, nem forráskód)

Ellenőrzés

Élesben verifikálva két valós ágensen: az egyiket 97%-nál, a másikat 94%-nál kapta el. Mindkettő végigcsinálta a teljes handoff -> friss újraindítás -> folytatás ciklust, és ~22% kontextuson, munkavesztés nélkül dolgozott tovább.

-- EN description ---

What

Adds a context-guard runner to the dashboard so agents never stall on a full context window.

Every 60 seconds the runner measures each agent's context usage. When an agent crosses the act threshold (default 90%), the guard:
1. Prompts the agent to write a HANDOFF.md (goal, progress, what worked, next steps)
2. Restarts the agent session fresh once the handoff is written (hard restart at 97% even without a handoff)
3. Injects a resume prompt, so the fresh session picks up work from HANDOFF.md

Components

- src/context-guard.ts: pure state machine (idle -> await-handoff -> await-ready -> cooldown) with context-limit calibration for 200k/500k/1M models; 22 unit tests
- src/web/context-guard-store.ts: persistent per-agent config in store/context-guard.json, enabled by default (actPct 0.90, hardPct 0.97, cooldown 15m, handoff timeout 6m)
- src/web/context-guard-runner.ts: 60s sweep wired into the dashboard; reuses existing primitives for context measurement, fresh restart and prompt injection; remote-host agents are skipped for now
- API: GET /api/context-guard (fleet overview), GET/PUT /api/agents/:name/context-guard (per-agent config)
- HANDOFF.md added to .gitignore (runtime artifact, never source)

Verification

Live-verified on two real agents: one caught at 97%, the other at 94%. Both completed the full handoff -> fresh restart -> resume cycle and continued their task at ~22% context without losing work.