### PR TITLE
feat(reauth-healer): quiet hours (23:00-06:00) for dead-token escalation with morning summary

### DIFF
--- a/src/__tests__/reauth-quiet-hours.test.ts
+++ b/src/__tests__/reauth-quiet-hours.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isQuietHour,
+  budapestHour,
+  routeEscalation,
+  flushQuietSummary,
+  buildQuietSummaryMessage,
+  buildEscalationMessage,
+  type QuietSuppressedEntry,
+} from '../web/reauth-healer.js'
+
+// Quiet hours (23:00-06:00 Europe/Budapest) for the reauth-healer escalation.
+// Motivated by 2026-07-09 night: spock+scotty re-alerted every 30 minutes all
+// night about a dead token nobody could fix before morning. The probe keeps
+// running; ONLY notify.sh is held back, and the first sweep after 06:00 sends
+// ONE summary about the agents still dead at that moment.
+
+const entry = (session: string, label = session, consecutiveDead = 10): QuietSuppressedEntry => ({
+  session,
+  label,
+  reason: 'API Error: 401',
+  consecutiveDead,
+})
+
+describe('isQuietHour / budapestHour', () => {
+  it('23:00-05:59 csendes, 06:00-22:59 nem', () => {
+    expect(isQuietHour(23)).toBe(true)
+    expect(isQuietHour(0)).toBe(true)
+    expect(isQuietHour(5)).toBe(true)
+    expect(isQuietHour(6)).toBe(false)
+    expect(isQuietHour(12)).toBe(false)
+    expect(isQuietHour(22)).toBe(false)
+  })
+
+  it('budapestHour a host TZ-től függetlenül Europe/Budapest órát ad (CEST=UTC+2 nyáron)', () => {
+    // 2026-07-09T22:30:00Z = 2026-07-10 00:30 Budapest -> 0 (quiet)
+    expect(budapestHour(Date.UTC(2026, 6, 9, 22, 30))).toBe(0)
+    // 2026-07-10T04:05:00Z = 06:05 Budapest -> 6 (not quiet)
+    expect(budapestHour(Date.UTC(2026, 6, 10, 4, 5))).toBe(6)
+    // 2026-01-10T22:30:00Z = 23:30 Budapest (CET=UTC+1 télen) -> 23 (quiet)
+    expect(budapestHour(Date.UTC(2026, 0, 10, 22, 30))).toBe(23)
+  })
+})
+
+describe('routeEscalation', () => {
+  it('nappal azonnal notify-ol, nem gyűjt', () => {
+    const sent: string[] = []
+    const suppressed = new Map<string, QuietSuppressedEntry>()
+    routeEscalation(entry('agent-spock', 'spock'), false, (m) => sent.push(m), suppressed)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toContain('spock')
+    expect(suppressed.size).toBe(0)
+  })
+
+  it('csendes sávban NINCS notify, a riasztás a reggeli összegzőre vár', () => {
+    const sent: string[] = []
+    const suppressed = new Map<string, QuietSuppressedEntry>()
+    routeEscalation(entry('agent-spock', 'spock'), true, (m) => sent.push(m), suppressed)
+    routeEscalation(entry('agent-scotty', 'scotty'), true, (m) => sent.push(m), suppressed)
+    expect(sent).toHaveLength(0)
+    expect([...suppressed.keys()]).toEqual(['agent-spock', 'agent-scotty'])
+  })
+
+  it('ismételt éjszakai eszkaláció felülírja a bejegyzést, nem duplikál', () => {
+    const suppressed = new Map<string, QuietSuppressedEntry>()
+    routeEscalation(entry('agent-spock', 'spock', 10), true, () => {}, suppressed)
+    routeEscalation(entry('agent-spock', 'spock', 20), true, () => {}, suppressed)
+    expect(suppressed.size).toBe(1)
+    expect(suppressed.get('agent-spock')?.consecutiveDead).toBe(20)
+  })
+})
+
+describe('flushQuietSummary', () => {
+  it('csendes sáv alatt no-op (a gyűjtő érintetlen marad)', () => {
+    const sent: string[] = []
+    const suppressed = new Map([['agent-spock', entry('agent-spock', 'spock')]])
+    flushQuietSummary(true, () => 10, (m) => sent.push(m), () => {}, suppressed)
+    expect(sent).toHaveLength(0)
+    expect(suppressed.size).toBe(1)
+  })
+
+  it('06:00 után EGY összegző megy ki a még mindig halott agensekről, cooldown-stampeléssel', () => {
+    const sent: string[] = []
+    const stamped: string[] = []
+    const suppressed = new Map([
+      ['agent-spock', entry('agent-spock', 'spock', 50)],
+      ['agent-scotty', entry('agent-scotty', 'scotty', 40)],
+    ])
+    const stillDead = (s: string) => (s === 'agent-spock' ? 120 : s === 'agent-scotty' ? 110 : 0)
+    flushQuietSummary(false, stillDead, (m) => sent.push(m), (s) => stamped.push(s), suppressed)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toContain('spock')
+    expect(sent[0]).toContain('scotty')
+    expect(sent[0]).toContain('Reggeli token-összegzés')
+    expect(stamped.sort()).toEqual(['agent-scotty', 'agent-spock'])
+    expect(suppressed.size).toBe(0)
+  })
+
+  it('reggelre meggyógyult agent kimarad; ha mind meggyógyult, nincs üzenet', () => {
+    const sent: string[] = []
+    const suppressed = new Map([
+      ['agent-spock', entry('agent-spock', 'spock')],
+      ['agent-scotty', entry('agent-scotty', 'scotty')],
+    ])
+    flushQuietSummary(false, (s) => (s === 'agent-spock' ? 99 : 0), (m) => sent.push(m), () => {}, suppressed)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toContain('spock')
+    expect(sent[0]).not.toContain('scotty')
+
+    const sent2: string[] = []
+    const allHealed = new Map([['agent-data', entry('agent-data', 'data')]])
+    flushQuietSummary(false, () => 0, (m) => sent2.push(m), () => {}, allHealed)
+    expect(sent2).toHaveLength(0)
+    expect(allHealed.size).toBe(0)
+  })
+})
+
+describe('éjszaka -> reggel szimuláció (a 2026-07-09-es spock+scotty eset)', () => {
+  it('23:10-től 05:40-ig 14 eszkaláció-tick alatt NULLA notify, 06:0x-kor pontosan EGY összegző', () => {
+    const sent: string[] = []
+    const suppressed = new Map<string, QuietSuppressedEntry>()
+    const notify = (m: string) => sent.push(m)
+
+    // Night: the healer's 30-min cooldown fires ~14 escalation decisions
+    // across two agents between 23:10 and 05:40 -- all routed during quiet.
+    for (let i = 0; i < 7; i++) {
+      routeEscalation(entry('agent-spock', 'spock', 10 + i * 10), true, notify, suppressed)
+      routeEscalation(entry('agent-scotty', 'scotty', 10 + i * 10), true, notify, suppressed)
+      // Mid-night sweeps with nothing to flush stay silent too.
+      flushQuietSummary(true, () => 999, notify, () => {}, suppressed)
+    }
+    expect(sent).toHaveLength(0)
+
+    // 06:0x, first non-quiet sweep: both still dead -> one summary, then the
+    // suppression buffer is empty so later sweeps send nothing extra.
+    const stamped: string[] = []
+    flushQuietSummary(false, () => 130, notify, (s) => stamped.push(s), suppressed)
+    expect(sent).toHaveLength(1)
+    expect(sent[0].split('\n').filter((l) => l.startsWith('•'))).toHaveLength(2)
+    expect(stamped).toHaveLength(2)
+    flushQuietSummary(false, () => 130, notify, () => {}, suppressed)
+    expect(sent).toHaveLength(1)
+  })
+})
+
+describe('üzenet-szövegek', () => {
+  it('az egyedi eszkaláció szövege változatlan formátumú', () => {
+    const msg = buildEscalationMessage('spock', 'API Error: 401', 3)
+    expect(msg).toContain('spock')
+    expect(msg).toContain('API Error: 401')
+    expect(msg).toContain('Manuális browser /login')
+  })
+
+  it('az összegző megnevezi a sávot és agensenként a hozzávetőleges időt', () => {
+    const msg = buildQuietSummaryMessage([entry('agent-spock', 'spock', 140)])
+    expect(msg).toContain('23:00-06:00')
+    expect(msg).toContain('• spock')
+    expect(msg).toMatch(/~\d+ perce/)
+  })
+})

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -130,18 +130,110 @@ async function sendBestEffortLogin(session: string): Promise<void> {
   }
 }
 
-function escalate(label: string, reason: string, consecutiveDead: number): void {
+// -- Quiet hours (23:00-06:00 Europe/Budapest) -------------------------------
+//
+// Overnight a dead token is not actionable: the fix is a manual browser
+// /login, and nobody does that at 03:00 -- but the healer used to re-alert
+// every 30 minutes all night (2026-07-09: spock+scotty alerted until morning).
+// Inside the window the PROBE keeps running and the state stays accurate;
+// ONLY the notify.sh escalation is held back. The first sweep after 06:00
+// sends ONE summary naming the agents that are STILL dead at that moment
+// (suppressed intermediates are dropped, healed agents are dropped silently),
+// and the normal 30-min re-alert cadence resumes from that summary.
+export const QUIET_START_HOUR = 23 // inclusive
+export const QUIET_END_HOUR = 6    // exclusive
+
+export function isQuietHour(hourLocal: number): boolean {
+  return hourLocal >= QUIET_START_HOUR || hourLocal < QUIET_END_HOUR
+}
+
+// Local wall-clock hour in Europe/Budapest regardless of the host TZ (the
+// same explicit-TZ rule the rest of the fleet follows for time handling).
+export function budapestHour(nowMs: number): number {
+  return parseInt(
+    new Intl.DateTimeFormat('en-GB', { timeZone: 'Europe/Budapest', hour: '2-digit', hour12: false }).format(new Date(nowMs)),
+    10,
+  )
+}
+
+export interface QuietSuppressedEntry {
+  session: string
+  label: string
+  reason: string
+  consecutiveDead: number
+}
+
+const quietSuppressed = new Map<string, QuietSuppressedEntry>()
+
+export function buildEscalationMessage(label: string, reason: string, consecutiveDead: number): string {
   // Dynamic duration: consecutiveDead probes at PROBE_INTERVAL_MS each. On a
   // re-alert (after the 30min cooldown, still dead) this grows past the initial
   // ~9min, so a hardcoded value would lie -- compute it from the probe count.
   const approxMin = Math.round((consecutiveDead * PROBE_INTERVAL_MS) / 60_000)
-  const msg = `🔐 A(z) ${label} ágens halott OAuth tokent jelez (${reason}) több mint ~${approxMin} perce. Manuális browser /login kell a dashboardon (az ügynök kártyáján a "Bejelentkezés" gomb), automatikusan nem gyógyítható.`
+  return `🔐 A(z) ${label} ágens halott OAuth tokent jelez (${reason}) több mint ~${approxMin} perce. Manuális browser /login kell a dashboardon (az ügynök kártyáján a "Bejelentkezés" gomb), automatikusan nem gyógyítható.`
+}
+
+export function buildQuietSummaryMessage(entries: QuietSuppressedEntry[]): string {
+  const lines = entries.map((e) => {
+    const approxMin = Math.round((e.consecutiveDead * PROBE_INTERVAL_MS) / 60_000)
+    return `• ${e.label}: ${e.reason} (~${approxMin} perce)`
+  })
+  return [
+    `🔐 Reggeli token-összegzés: az éjszakai csendes sáv (${QUIET_START_HOUR}:00-0${QUIET_END_HOUR}:00) alatt elnyomott riasztások. MOST IS halott tokent jelez:`,
+    ...lines,
+    'Manuális browser /login kell a dashboardon (az ügynök kártyáján a "Bejelentkezés" gomb).',
+  ].join('\n')
+}
+
+/**
+ * Route one escalation decision: outside quiet hours notify immediately;
+ * inside, record it for the morning summary instead. Pure over its deps so
+ * the night->morning sequence is simulatable in tests.
+ */
+export function routeEscalation(
+  entry: QuietSuppressedEntry,
+  quiet: boolean,
+  notify: (msg: string) => void,
+  suppressed: Map<string, QuietSuppressedEntry> = quietSuppressed,
+): void {
+  if (quiet) {
+    suppressed.set(entry.session, entry)
+    logger.warn({ label: entry.label, session: entry.session, reason: entry.reason }, 'reauth-healer: dead token escalation suppressed (quiet hours), queued for morning summary')
+    return
+  }
+  notify(buildEscalationMessage(entry.label, entry.reason, entry.consecutiveDead))
+}
+
+/**
+ * First sweep after quiet hours: send ONE summary for agents still dead now,
+ * stamp their cooldown from the summary (it IS an alert), and drop everything
+ * else silently. No-op while still quiet or when nothing was suppressed.
+ */
+export function flushQuietSummary(
+  quiet: boolean,
+  stillDeadCount: (session: string) => number,
+  notify: (msg: string) => void,
+  stampAlert: (session: string) => void,
+  suppressed: Map<string, QuietSuppressedEntry> = quietSuppressed,
+): void {
+  if (quiet || suppressed.size === 0) return
+  const entries = [...suppressed.values()]
+  suppressed.clear()
+  const stillDead = entries
+    .map((e) => ({ ...e, consecutiveDead: stillDeadCount(e.session) }))
+    .filter((e) => e.consecutiveDead > 0)
+  if (stillDead.length === 0) return
+  notify(buildQuietSummaryMessage(stillDead))
+  for (const e of stillDead) stampAlert(e.session)
+}
+
+function sendNotify(msg: string): void {
   execFile('/bin/bash', [NOTIFY_SCRIPT, msg], { timeout: 10_000 }, (err) => {
-    if (err) logger.warn({ err, label }, 'reauth-healer: notify.sh escalation failed')
+    if (err) logger.warn({ err }, 'reauth-healer: notify.sh escalation failed')
   })
 }
 
-function checkSession(label: string, session: string, isMain: boolean): void {
+function checkSession(label: string, session: string, isMain: boolean, quiet: boolean): void {
   const pane = capturePane(session)
   const sessionAlive = pane != null
   const reauth = detectReauthNeeded(pane)
@@ -154,6 +246,9 @@ function checkSession(label: string, session: string, isMain: boolean): void {
 
   if (decision.next.consecutiveDead === 0) {
     watchState.delete(session)
+    // A healed agent's suppressed overnight alert is obsolete -- drop it so it
+    // never appears in the morning summary.
+    quietSuppressed.delete(session)
   } else {
     watchState.set(session, decision.next)
   }
@@ -163,8 +258,12 @@ function checkSession(label: string, session: string, isMain: boolean): void {
     void sendBestEffortLogin(session)
   }
   if (decision.escalate) {
-    logger.error({ label, session, reason: reauth.reason }, 'reauth-healer: dead OAuth token on live session -- escalating to owner')
-    escalate(label, reauth.reason ?? 'auth failure', decision.next.consecutiveDead)
+    logger.error({ label, session, reason: reauth.reason, quiet }, 'reauth-healer: dead OAuth token on live session -- escalating to owner')
+    routeEscalation(
+      { session, label, reason: reauth.reason ?? 'auth failure', consecutiveDead: decision.next.consecutiveDead },
+      quiet,
+      sendNotify,
+    )
   }
 }
 
@@ -177,10 +276,11 @@ export function startReauthHealer(): NodeJS.Timeout | null {
   }
 
   function sweep(): void {
+    const quiet = isQuietHour(budapestHour(Date.now()))
     // Main agent: escalate-only (no autonomous /login into a live always-on
     // conversation). capturePane returns null when it is down -> spell ends.
     try {
-      checkSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, true)
+      checkSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, true, quiet)
     } catch (err) {
       logger.debug({ err }, 'reauth-healer: main agent check error')
     }
@@ -188,14 +288,26 @@ export function startReauthHealer(): NodeJS.Timeout | null {
       const session = resolveAgentSession(name)
       if (!isAgentRunning(name)) {
         watchState.delete(session)
+        quietSuppressed.delete(session)
         continue
       }
       try {
-        checkSession(name, session, false)
+        checkSession(name, session, false, quiet)
       } catch (err) {
         logger.debug({ err, agent: name }, 'reauth-healer: agent check error')
       }
     }
+    // First sweep after 06:00: one summary for the agents still dead now.
+    // The summary counts as the alert, so the 30-min cadence restarts from it.
+    flushQuietSummary(
+      quiet,
+      (session) => watchState.get(session)?.consecutiveDead ?? 0,
+      sendNotify,
+      (session) => {
+        const st = watchState.get(session)
+        if (st) watchState.set(session, { ...st, lastActionAtMs: Date.now() })
+      },
+    )
   }
 
   setTimeout(sweep, INITIAL_DELAY_MS)


### PR DESCRIPTION
## Summary
- Inside **23:00–06:00 Europe/Budapest** (explicit TZ via `Intl`, host-independent) the reauth-healer's `notify.sh` escalation is suppressed; the probe, the dead-counting and the cooldown/`/login` cadence run unchanged (`decideReauthAction` untouched).
- Suppressed escalations are queued per session; the **first sweep after 06:00 sends ONE summary** naming only the agents *still* dead at that moment. Agents that healed overnight drop out silently; suppressed intermediates are never replayed.
- The morning summary counts as an alert: it stamps the cooldown, so the normal 30-min re-alert cadence resumes from it.
- Motivation: 2026-07-09 night, two agents with a dead token (manual browser login impossible before morning) re-alerted every 30 minutes all night.

## Test plan
- New `reauth-quiet-hours.test.ts` (12 tests): window boundaries (23/0/5 quiet; 6/12/22 not), Budapest-hour conversion incl. CEST/CET, immediate notify outside the window, suppression without notify inside, overwrite-not-duplicate on repeated night escalations, summary content + cooldown stamping, healed-agent dropout, empty-summary no-op.
- **Night→morning simulation** (the reported incident): 14 escalation ticks across two agents between 23:10 and 05:40 → **zero** notify calls; first non-quiet sweep → **exactly one** summary listing both agents; subsequent sweeps send nothing.
- Full suite: 1679/1679 green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)