### PR TITLE
fix(alerts): shared-config plugin-slot alert -- running + per-provider count, no false alarm on macOS

### DIFF
--- a/src/__tests__/silent-degradation-alert.test.ts
+++ b/src/__tests__/silent-degradation-alert.test.ts
@@ -1,38 +1,107 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { shouldAlertSharedConfigCollision } from '../web/agent-process.js'
+import {
+  shouldAlertSharedConfigCollision,
+  maxSameProviderContenders,
+} from '../web/agent-process.js'
 
 // H1 silent-degradation hardening. When the fleet OAuth token is missing,
-// channel sub-agents fall back to the shared ~/.claude. One agent is fine; two
-// or more collide on the single plugin-install slot and silently go deaf. This
-// locks the decision that turns that previously WARN-only degradation into a
-// loud operator alert -- and, crucially, that a PRESENT token never alerts no
-// matter how many channel agents run.
+// channel sub-agents fall back to the shared ~/.claude. One agent per provider
+// slot is fine; two or more RUNNING agents on the SAME provider contend for
+// that provider's single plugin-install slot. 2026-07-10 refinement: the
+// original decision counted CONFIGURED agents across ALL providers and fired
+// on macOS where the collision demonstrably does not manifest -- it cried
+// wolf. These tests lock the refined decision: running-only, per-provider,
+// platform-aware -- and, crucially, that a PRESENT token never alerts.
 
 describe('shouldAlertSharedConfigCollision', () => {
-  it('alerts when the token is missing and >1 channel sub-agent shares ~/.claude', () => {
-    expect(shouldAlertSharedConfigCollision(false, 2)).toBe(true)
-    expect(shouldAlertSharedConfigCollision(false, 5)).toBe(true)
+  it('alerts on Linux when the token is missing and >1 same-provider agent runs', () => {
+    expect(shouldAlertSharedConfigCollision(false, 2, 'linux')).toBe(true)
+    expect(shouldAlertSharedConfigCollision(false, 5, 'linux')).toBe(true)
   })
 
-  it('does NOT alert for a single channel sub-agent (it owns the shared dir)', () => {
-    expect(shouldAlertSharedConfigCollision(false, 1)).toBe(false)
+  it('never alerts on macOS, regardless of count (collision empirically absent there)', () => {
+    // 2026-07-10 origin-host verification: three concurrent telegram pollers
+    // (main + two sub-agents, own tokens, live bun server.ts each) on the
+    // shared ~/.claude -- no eviction, no deaf bot. Keychain auth also removes
+    // the Linux credentials-refresh motive.
+    expect(shouldAlertSharedConfigCollision(false, 2, 'darwin')).toBe(false)
+    expect(shouldAlertSharedConfigCollision(false, 6, 'darwin')).toBe(false)
+  })
+
+  it('does NOT alert for a single same-provider agent (it owns the slot)', () => {
+    expect(shouldAlertSharedConfigCollision(false, 1, 'linux')).toBe(false)
   })
 
   it('does NOT alert when there are no channel sub-agents', () => {
-    expect(shouldAlertSharedConfigCollision(false, 0)).toBe(false)
+    expect(shouldAlertSharedConfigCollision(false, 0, 'linux')).toBe(false)
   })
 
   it('never alerts when the token is present, regardless of agent count', () => {
-    expect(shouldAlertSharedConfigCollision(true, 0)).toBe(false)
-    expect(shouldAlertSharedConfigCollision(true, 1)).toBe(false)
-    expect(shouldAlertSharedConfigCollision(true, 99)).toBe(false)
+    expect(shouldAlertSharedConfigCollision(true, 0, 'linux')).toBe(false)
+    expect(shouldAlertSharedConfigCollision(true, 1, 'linux')).toBe(false)
+    expect(shouldAlertSharedConfigCollision(true, 99, 'linux')).toBe(false)
   })
 
-  it('threshold is strict (exactly one does not alert, two does)', () => {
-    expect(shouldAlertSharedConfigCollision(false, 1)).toBe(false)
-    expect(shouldAlertSharedConfigCollision(false, 2)).toBe(true)
+  it('threshold is strict (exactly one does not alert, two does) on Linux', () => {
+    expect(shouldAlertSharedConfigCollision(false, 1, 'linux')).toBe(false)
+    expect(shouldAlertSharedConfigCollision(false, 2, 'linux')).toBe(true)
+  })
+})
+
+describe('maxSameProviderContenders', () => {
+  // The origin-host fleet shape that triggered the false alarm: 6 configured
+  // channel sub-agents, but only 2 running on telegram + 1 running on teams.
+  const originFleet = [
+    { provider: 'telegram', running: true, hasChannel: true }, // boni
+    { provider: 'telegram', running: false, hasChannel: true }, // deeper
+    { provider: 'telegram', running: false, hasChannel: true }, // iris
+    { provider: 'telegram', running: true, hasChannel: true }, // samu
+    { provider: 'teams', running: true, hasChannel: true }, // teamer
+    { provider: 'telegram', running: false, hasChannel: true }, // zara
+  ]
+
+  it('counts only RUNNING agents: 6 configured / 2 running telegram -> 2, not 6', () => {
+    expect(maxSameProviderContenders(originFleet)).toBe(2)
+  })
+
+  it('with the refined count, the origin fleet does NOT alert on macOS', () => {
+    const count = maxSameProviderContenders(originFleet)
+    expect(shouldAlertSharedConfigCollision(false, count, 'darwin')).toBe(false)
+  })
+
+  it('a real Linux multi-bot collision (2 running same-provider) STILL alerts', () => {
+    const linuxFleet = [
+      { provider: 'telegram', running: true, hasChannel: true },
+      { provider: 'telegram', running: true, hasChannel: true },
+      { provider: 'telegram', running: false, hasChannel: true },
+    ]
+    const count = maxSameProviderContenders(linuxFleet)
+    expect(count).toBe(2)
+    expect(shouldAlertSharedConfigCollision(false, count, 'linux')).toBe(true)
+  })
+
+  it('different providers occupy different slots: telegram + teams do not collide', () => {
+    const mixed = [
+      { provider: 'telegram', running: true, hasChannel: true },
+      { provider: 'teams', running: true, hasChannel: true },
+    ]
+    expect(maxSameProviderContenders(mixed)).toBe(1)
+    expect(shouldAlertSharedConfigCollision(false, maxSameProviderContenders(mixed), 'linux')).toBe(false)
+  })
+
+  it('channel-less agents never count, running or not', () => {
+    const fleet = [
+      { provider: 'telegram', running: true, hasChannel: false },
+      { provider: 'telegram', running: true, hasChannel: false },
+      { provider: 'telegram', running: true, hasChannel: true },
+    ]
+    expect(maxSameProviderContenders(fleet)).toBe(1)
+  })
+
+  it('empty fleet -> 0', () => {
+    expect(maxSameProviderContenders([])).toBe(0)
   })
 })
 
@@ -56,7 +125,14 @@ describe('silent-degradation alert wiring', () => {
     expect(SRC).toMatch(/resetSharedConfigCollisionAlert\(\)/)
   })
 
-  it('counts channel sub-agents excluding the main agent', () => {
-    expect(SRC).toMatch(/n !== MAIN_AGENT_ID && agentHasChannel\(n\)/)
+  it('counts contenders from live run state, excluding the main agent', () => {
+    expect(SRC).toMatch(/countSameProviderChannelContenders\(name\)/)
+    expect(SRC).toMatch(/\.filter\(\(n\) => n !== MAIN_AGENT_ID\)/)
+    expect(SRC).toMatch(/n === startingName \|\| agentRunState\(n\) === 'running'/)
+  })
+
+  it('the platform guard is process.platform-based, not host-specific', () => {
+    expect(SRC).toMatch(/platform: NodeJS\.Platform = process\.platform/)
+    expect(SRC).not.toMatch(/os\.hostname/)
   })
 })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -120,33 +120,81 @@ export function hasFleetOauthToken(): boolean {
   }
 }
 
-// H1 silent-degradation hardening (2026-06-30).
+// H1 silent-degradation hardening (2026-06-30, refined 2026-07-10).
 //
 // When the fleet OAuth token is absent, channel sub-agents skip isolation and
 // fall back to the SHARED ~/.claude (the pre-isolation behaviour, gated in
 // startAgentProcess). ONE channel sub-agent on the shared dir is harmless -- it
-// owns the single plugin-install slot and poller. TWO OR MORE collide on that
-// slot, which is exactly the fleet outage isolation was built to end (only one
-// agent registers its plugin, the rest go deaf -- see
-// ensureIsolatedChannelConfigDir). Today that collision is logged at WARN only,
-// so it stays invisible until a bot silently stops answering.
+// owns the single plugin-install slot and poller. The collision the alert
+// guards against needs TWO OR MORE agents actually contending for the SAME
+// provider's plugin slot at the same time (only one registers its plugin, the
+// rest go deaf -- see ensureIsolatedChannelConfigDir).
 //
-// The decision is pure (token-absent AND more-than-one channel sub-agent) so it
-// is unit-tested without I/O, mirroring shouldSendDeferAlert. Token PRESENT ->
-// isolation works -> never alerts, regardless of agent count.
+// 2026-07-10 refinement -- the original check over-triggered ("cried wolf"):
+//   - It counted CONFIGURED channel sub-agents. An agent that is not running
+//     cannot contend for anything: 6 configured / 2 running must not read as
+//     a 6-way collision.
+//   - It counted across providers. Plugin installs are keyed per plugin id
+//     (telegram/slack/teams/... are separate slots in installed_plugins.json),
+//     so a running Teams agent never collides with running Telegram agents.
+//   - On macOS the collision does not manifest (verified empirically
+//     2026-07-10 on the origin host: three concurrent telegram pollers --
+//     main + two sub-agents, distinct own tokens, a live `bun server.ts`
+//     each, all on the shared ~/.claude while the installed_plugins.json
+//     telegram slot pointed at a THIRD agent's projectPath). Channel agents
+//     always launch fresh with an explicit --channels plugin:<id> flag, which
+//     loads the plugin regardless of the project-scoped install slot; and
+//     macOS auth lives in the Keychain, so the Linux credentials-refresh
+//     motive for isolation does not apply either. The guard is
+//     process.platform-based -- nothing host-specific is baked into this
+//     distribution artifact. On Linux/other the alert stays: the shared-config
+//     multi-bot eviction remains the documented failure mode there and has
+//     not been empirically cleared. If a real macOS collision is ever
+//     observed again, drop the darwin early-return.
+//
+// The decision stays pure (token, same-provider contender count, platform) so
+// it is unit-tested without I/O, mirroring shouldSendDeferAlert. Token PRESENT
+// -> isolation works -> never alerts, regardless of agent count.
 export function shouldAlertSharedConfigCollision(
   hasToken: boolean,
-  channelSubAgentCount: number,
+  sameProviderContenderCount: number,
+  platform: NodeJS.Platform = process.platform,
 ): boolean {
-  return !hasToken && channelSubAgentCount > 1
+  if (platform === 'darwin') return false
+  return !hasToken && sameProviderContenderCount > 1
 }
 
-// Count of channel-HAVING sub-agents in the fleet (main agent excluded -- it
-// comes up via channels.sh and keeps the shared root by design). Uses the same
-// own-token signal as the launch path, so the count reflects which agents will
-// actually contend for the shared ~/.claude plugin slot.
-export function countChannelSubAgents(): number {
-  return listAgentNames().filter((n) => n !== MAIN_AGENT_ID && agentHasChannel(n)).length
+// Pure: the largest number of channel sub-agents contending for a single
+// provider's plugin slot. Only RUNNING agents with a channel of their own
+// count; agents on different providers occupy different slots and never
+// collide with each other.
+export function maxSameProviderContenders(
+  agents: Array<{ provider: string; running: boolean; hasChannel: boolean }>,
+): number {
+  const counts = new Map<string, number>()
+  for (const a of agents) {
+    if (!a.running || !a.hasChannel) continue
+    counts.set(a.provider, (counts.get(a.provider) ?? 0) + 1)
+  }
+  return counts.size ? Math.max(...counts.values()) : 0
+}
+
+// Same-provider contender count for the fleet (main agent excluded -- it comes
+// up via channels.sh and keeps the shared root by design). Uses the same
+// own-token signal as the launch path. `startingName` is the agent being
+// spawned right now: its tmux session does not exist yet at alert time, so it
+// is treated as running -- otherwise the very launch that completes a real
+// collision would never see itself in the count.
+export function countSameProviderChannelContenders(startingName: string): number {
+  return maxSameProviderContenders(
+    listAgentNames()
+      .filter((n) => n !== MAIN_AGENT_ID)
+      .map((n) => ({
+        provider: resolveAgentProvider(n),
+        running: n === startingName || agentRunState(n) === 'running',
+        hasChannel: agentHasChannel(n),
+      })),
+  )
 }
 
 // One operator alert per degradation episode: spamming on every spawn would
@@ -161,17 +209,18 @@ export function resetSharedConfigCollisionAlert(): void {
 // Loud, owner-facing alert routed via notifyChannel (direct Bot API POST from
 // the dashboard process) -- NOT an inter-agent relay, which would itself need a
 // healthy channel agent to deliver. No-op unless the token is absent AND >1
-// channel sub-agent would share ~/.claude.
+// RUNNING same-provider channel sub-agent would share ~/.claude (and never on
+// macOS -- see shouldAlertSharedConfigCollision).
 function maybeAlertSharedConfigCollision(name: string): void {
-  const count = countChannelSubAgents()
+  const count = countSameProviderChannelContenders(name)
   if (!shouldAlertSharedConfigCollision(false, count) || sharedConfigCollisionAlerted) return
   sharedConfigCollisionAlerted = true
   logger.error(
-    { name, channelSubAgentCount: count },
-    'isolated-config: fleet OAuth token missing with multiple channel sub-agents -- shared ~/.claude plugin-slot collision, bots will go deaf',
+    { name, sameProviderContenders: count },
+    'isolated-config: fleet OAuth token missing with multiple RUNNING same-provider channel sub-agents -- shared ~/.claude plugin-slot collision, bots may go deaf',
   )
   void notifyChannel(
-    `⚠️ Flotta-figyelmeztetes: hianyzik a fleet OAuth token (store/.claude-oauth-token), de ${count} csatornas sub-agent fut. Izolacio nelkul mind a kozos ~/.claude-ot hasznalja, igy a plugin-slot utkozik es csak egy bot marad eleresheto (a tobbi elnemul). Javitas: futtasd a \`claude setup-token\`-t, mentsd a store/.claude-oauth-token fajlba, majd inditsd ujra az agenseket.`,
+    `⚠️ Flotta-figyelmeztetes: hianyzik a fleet OAuth token (store/.claude-oauth-token), es ${count} AZONOS csatorna-providerü sub-agent fut egyszerre. Izolacio nelkul mind a kozos ~/.claude-ot hasznalja, igy a plugin-slot utkozhet es bot nemulhat el. Javitas: futtasd a \`claude setup-token\`-t, mentsd a store/.claude-oauth-token fajlba, majd inditsd ujra az agenseket.`,
   ).catch(() => { /* notifyChannel logs internally */ })
 }
 


### PR DESCRIPTION
## Problem

The H1 shared-config collision alert over-triggers. It fires whenever the fleet OAuth token is absent and more than one channel sub-agent is **configured** -- regardless of whether those agents run, which provider they use, or whether the collision can manifest at all on the platform. On the origin fleet (6 configured channel sub-agents, of which 2 telegram + 1 teams actually running, macOS) it cries wolf on every channel-agent spawn.

## Empirical verification (before writing code)

Checked the running fleet on the affected macOS host (2026-07-10):

- 3 concurrent telegram pollers: main + boni + samu, each a live `bun server.ts` with its **own** bot token and own `TELEGRAM_STATE_DIR`, all on the shared `~/.claude` (no fleet OAuth token, no isolated config dirs).
- Meanwhile `installed_plugins.json`'s telegram slot pointed at a **third** agent's projectPath (teamer) -- and nobody went deaf. Both sub-agent bots have delivered inbox traffic while sharing `~/.claude`.
- Explanation: channel agents always launch fresh with an explicit `--channels plugin:<id>` flag, which loads the plugin regardless of the project-scoped install slot; and macOS auth lives in the Keychain, so the Linux credentials-refresh motive for isolation does not apply either.

So on macOS the alert's premise is empirically false; on Linux the documented eviction failure mode has not been cleared, so the alert must stay.

## Changes

- `countChannelSubAgents()` -> `countSameProviderChannelContenders(startingName)`: counts only **running** agents (the one being spawned counts as running -- its session doesn't exist yet at alert time), grouped **per provider** plugin slot via the new pure `maxSameProviderContenders()`. A running Teams agent no longer counts against Telegram agents.
- `shouldAlertSharedConfigCollision(hasToken, count, platform = process.platform)`: never fires on `darwin` (see above), unchanged threshold elsewhere. Platform guard is `process.platform`-based -- nothing host-specific is baked into the distribution artifact.
- Alert log/message updated to reflect same-provider contention.

## Tests

`silent-degradation-alert.test.ts` reproduces both required behaviours:
- (a) the origin fleet shape (6 configured / 2 running telegram, darwin) does **not** alert;
- (b) a Linux 2-running-same-provider collision **still** alerts;
- plus: per-provider separation (telegram+teams -> no alert), stopped/channel-less agents never count, token-present never alerts, and source-level wiring contracts.

`tsc --noEmit` clean, full suite 120 files / 1687 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)