### PR TITLE
chore(context-guard): fix stale cadence in startup log and runner header

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -350,7 +350,7 @@ export function startWebServer(port = 3420): http.Server {
   if (!webOnly) logger.info('Model-fallback runner started (60s poll, 50s offset)')
 
   const contextGuardInterval = webOnly ? undefined : startContextGuardRunner()
-  if (!webOnly) logger.info('Context-guard runner started (60s poll, 55s offset)')
+  if (!webOnly) logger.info('Context-guard runner started (5min poll, 4.5min initial delay)')
 
   const updateCheckerInterval = webOnly ? undefined : startUpdateChecker()
   if (!webOnly) logger.info('Update checker started (15min poll)')

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -26,7 +26,7 @@ import {
 } from '../context-guard.js'
 
 // Fleet context guard (kanban #81): acts BEFORE a session drowns in its own
-// context. Sweep every agent (main included) once a minute; at actPct ask the
+// context. Sweep every agent (main included) every five minutes; at actPct ask the
 // agent to write HANDOFF.md, then fresh-restart it and inject a resume prompt
 // pointing at the handoff. See src/context-guard.ts for the why and the pure
 // state machine; this module is only the I/O, mirroring auto-restart-runner.


### PR DESCRIPTION
Follow-up to #552 (nits flagged during re-verify). The runner polls every 5 minutes (300s interval, 270s initial delay), but the startup log in `src/web.ts` claimed "60s poll, 55s offset" and the runner header comment said "once a minute". Text-only, no behavior change. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)