### PR TITLE
feat(reliability): per-tool outgoing HTTP deadline (Closes #560)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, chmodSync, openSync, c
 import { STORE_DIR, DB_FILENAME, ALLOWED_CHAT_ID, OLLAMA_URL } from './config.js'
 import { getEffectiveSettingValue } from './settings-store.js'
 import { logger } from './logger.js'
+import { TOOL_TIMEOUTS } from './tool-timeouts.js'
 
 let db: Database.Database
 
@@ -1805,6 +1806,7 @@ export async function generateEmbedding(text: string): Promise<number[] | null> 
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ model: EMBED_MODEL, prompt: text.slice(0, 2000) }),
+      signal: AbortSignal.timeout(TOOL_TIMEOUTS['ollama-embedding']),
     })
     const data = await resp.json() as { embedding?: number[] }
     return data.embedding || null

--- a/src/google-api.ts
+++ b/src/google-api.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { logger } from './logger.js'
+import { TOOL_TIMEOUTS } from './tool-timeouts.js'
 
 const TOKENS_PATH = join(homedir(), '.config', 'google-calendar-mcp', 'tokens.json')
 const CLIENT_CREDS_PATH = join(homedir(), '.gmail-mcp', 'gcp-oauth.keys.json')
@@ -77,7 +78,12 @@ function loadClientCredentials(): ClientCredentials {
   return cachedClient!
 }
 
-function httpsRequest(url: string, options: https.RequestOptions, body?: string): Promise<{ status: number; data: string }> {
+function httpsRequest(
+  url: string,
+  options: https.RequestOptions,
+  body?: string,
+  timeoutMs = TOOL_TIMEOUTS['google-calendar'],
+): Promise<{ status: number; data: string }> {
   return new Promise((resolve, reject) => {
     const req = https.request(url, options, (res) => {
       const chunks: Buffer[] = []
@@ -89,6 +95,9 @@ function httpsRequest(url: string, options: https.RequestOptions, body?: string)
         })
       })
       res.on('error', reject)
+    })
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`Google API request timed out after ${timeoutMs}ms`))
     })
     req.on('error', reject)
     if (body) req.write(body)

--- a/src/tool-timeouts.ts
+++ b/src/tool-timeouts.ts
@@ -1,0 +1,11 @@
+// Per-tool outgoing HTTP deadline (ms).
+// If an external service doesn't respond within the allotted time, the
+// request is aborted and the caller receives an Error so it can log and fall
+// back gracefully instead of hanging the whole agent session.
+export const TOOL_TIMEOUTS = {
+  'google-calendar': 5_000,
+  'telegram':        10_000,
+  'github':          10_000,
+  'slack':           10_000,
+  'ollama-embedding': 30_000,
+} as const

--- a/src/web/channel-request-watcher.ts
+++ b/src/web/channel-request-watcher.ts
@@ -5,6 +5,7 @@ import { CHANNEL_PROVIDER } from '../config.js'
 import { channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
 import { upsertChannelRequest, listPendingChannelRequests, updateChannelRequestName } from '../db.js'
+import { TOOL_TIMEOUTS } from '../tool-timeouts.js'
 
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
@@ -76,6 +77,7 @@ async function lookupChannelName(agent: string, channelId: string): Promise<void
         'Authorization': `Bearer ${token}`,
       },
       body: `channel=${encodeURIComponent(channelId)}`,
+      signal: AbortSignal.timeout(TOOL_TIMEOUTS['slack']),
     })
     const data = await resp.json() as { ok: boolean; channel?: { name: string } }
     if (data.ok && data.channel?.name) {

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os'
 import { PROJECT_ROOT, ALLOWED_CHAT_ID } from '../config.js'
 import { logger } from '../logger.js'
 import { agentDir, readFileOr, findAvatarForAgent } from './agent-config.js'
+import { TOOL_TIMEOUTS } from '../tool-timeouts.js'
 
 export function readAgentTelegramConfig(name: string): { hasTelegram: boolean; botUsername?: string } {
   const envPath = join(agentDir(name), '.claude', 'channels', 'telegram', '.env')
@@ -98,7 +99,7 @@ export async function refreshMarveenBotUsername(): Promise<void> {
   const token = tokenMatch?.[1]?.trim()
   if (!token) return
   try {
-    const r = await fetch(`https://api.telegram.org/bot${token}/getMe`)
+    const r = await fetch(`https://api.telegram.org/bot${token}/getMe`, { signal: AbortSignal.timeout(TOOL_TIMEOUTS['telegram']) })
     const data = await r.json() as { ok?: boolean; result?: { username?: string } }
     if (data.ok && data.result?.username) {
       marveenBotUsernameCache.value = `@${data.result.username}`
@@ -112,6 +113,7 @@ export async function sendTelegramMessage(token: string, chatId: string, text: s
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ chat_id: chatId, text }),
+    signal: AbortSignal.timeout(TOOL_TIMEOUTS['telegram']),
   })
   // fetch does not throw on 4xx -- a wrong chat_id or revoked token resolves
   // silently, which historically made "alert sent" log lines lies. Throw so
@@ -136,6 +138,7 @@ export async function sendTelegramPhoto(token: string, chatId: string, photoPath
     method: 'POST',
     headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
     body: Buffer.concat(parts),
+    signal: AbortSignal.timeout(TOOL_TIMEOUTS['telegram']),
   })
 }
 
@@ -211,7 +214,7 @@ export async function sendAvatarChangeMessage(agentName: string, avatarPath: str
 
 export async function validateTelegramToken(token: string): Promise<{ ok: boolean; botUsername?: string; botId?: number; error?: string }> {
   try {
-    const resp = await fetch(`https://api.telegram.org/bot${token}/getMe`)
+    const resp = await fetch(`https://api.telegram.org/bot${token}/getMe`, { signal: AbortSignal.timeout(TOOL_TIMEOUTS['telegram']) })
     const data = await resp.json() as { ok: boolean; result?: { username: string; id: number } }
     if (data.ok && data.result) {
       return { ok: true, botUsername: data.result.username, botId: data.result.id }

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import { PROJECT_ROOT } from '../config.js'
+import { TOOL_TIMEOUTS } from '../tool-timeouts.js'
 
 export interface UpdateCommit {
   sha: string
@@ -78,7 +79,7 @@ const GH_HEADERS = { 'Accept': 'application/vnd.github+json', 'User-Agent': 'mar
 // sentinel { notFound: true } on a 404 (base or head not on the remote), or
 // null on any other failure.
 async function fetchCompare(remote: string, base: string, head: string): Promise<GhCompare | { notFound: true } | null> {
-  const res = await fetch(`https://api.github.com/repos/${remote}/compare/${base}...${head}`, { headers: GH_HEADERS })
+  const res = await fetch(`https://api.github.com/repos/${remote}/compare/${base}...${head}`, { headers: GH_HEADERS, signal: AbortSignal.timeout(TOOL_TIMEOUTS['github']) })
   if (res.ok) return await res.json() as GhCompare
   if (res.status === 404) return { notFound: true }
   return null
@@ -178,6 +179,7 @@ export async function refreshUpdateStatus(): Promise<UpdateStatus> {
     // 1) find HEAD of default branch (main) via the commits endpoint
     const latestRes = await fetch(`https://api.github.com/repos/${remote}/commits/main`, {
       headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'marveen-update-check' },
+      signal: AbortSignal.timeout(TOOL_TIMEOUTS['github']),
     })
     if (!latestRes.ok) throw new Error(`GitHub /commits/main -> ${latestRes.status}`)
     const latestJson = await latestRes.json() as { sha?: string }


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

Per-tool timeout (deadline_ms) konfiguráció bevezetése. Eddig az összes külső API hívás korlátlan ideig blokkolhatott -- hálózati hiba vagy lassú végpont esetén az egész folyamat felfüggesztve maradt.

Új src/tool-timeouts.ts modul tartalmazza az eszközönkénti határértékeket (Google Calendar: 5s, Telegram/GitHub/Slack: 10s, Ollama embedding: 30s). A timeout guard minden érintett modulban be van kötve: google-api.ts (httpsRequest), telegram.ts (mind a 4 fetch), update-checker.ts, channel-request-watcher.ts, db.ts.

Per-tool timeout (deadline_ms) configuration. Previously all external API calls could block indefinitely -- a slow or failing endpoint would freeze the entire process. New src/tool-timeouts.ts holds per-tool limits; guards wired into google-api.ts, telegram.ts, update-checker.ts, channel-request-watcher.ts, db.ts.

## Kapcsolódó issue / Related issue

Closes #560

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben, az ágensek hiba nélkül kommunikálnak. / Tested locally; agents communicate without errors.
- [ ] Frissítettem a docs/ mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated docs/ if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (per-tool-deadline_ms). / Opened from descriptively named branch.