### PR TITLE
feat(fleet): GET /.well-known/fleetq capability manifest (Closes #562)

### DIFF
--- a/seed-config/agent-capabilities.json
+++ b/seed-config/agent-capabilities.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Default capability tags per agent. The fleet manifest endpoint (GET /.well-known/fleetq) reads these as the fallback; an agent's agent-config.json 'capabilities' field overrides when present.",
+  "dave":  ["it-management", "project-management", "vendor-management", "sla", "budget", "risk", "it-governance", "ai-monitoring"],
+  "peter": ["garmin", "training", "health-data", "fitness", "sport", "exercise-planning"],
+  "poly":  ["design", "image-generation", "video", "visual", "graphics", "creative"],
+  "rick":  ["architecture", "system-design", "tech-decisions", "cloud", "integrations", "code-review"],
+  "zack":  ["backend", "api", "database", "github", "code-review", "typescript", "nodejs", "python"],
+  "zoe":   ["finance", "invoices", "expenses", "accounting", "budget", "financial-reporting"]
+}

--- a/seed-config/agent-capabilities.json
+++ b/seed-config/agent-capabilities.json
@@ -1,9 +1,3 @@
 {
-  "_doc": "Default capability tags per agent. The fleet manifest endpoint (GET /.well-known/fleetq) reads these as the fallback; an agent's agent-config.json 'capabilities' field overrides when present.",
-  "dave":  ["it-management", "project-management", "vendor-management", "sla", "budget", "risk", "it-governance", "ai-monitoring"],
-  "peter": ["garmin", "training", "health-data", "fitness", "sport", "exercise-planning"],
-  "poly":  ["design", "image-generation", "video", "visual", "graphics", "creative"],
-  "rick":  ["architecture", "system-design", "tech-decisions", "cloud", "integrations", "code-review"],
-  "zack":  ["backend", "api", "database", "github", "code-review", "typescript", "nodejs", "python"],
-  "zoe":   ["finance", "invoices", "expenses", "accounting", "budget", "financial-reporting"]
+  "_doc": "Default capability tags per agent. The fleet manifest endpoint (GET /.well-known/fleetq) reads these as the fallback; an agent's agent-config.json 'capabilities' field overrides when present."
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -7,7 +7,7 @@ import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-au
 import { isBlockedCrossOriginWrite, originMatchesServedHost } from './web/csrf-origin.js'
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
-import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
+import { AGENTS_BASE_DIR, listAgentNames, bootstrapCapabilities } from './web/agent-config.js'
 import { ensureAgentHooks, ensureAgentStalenessHook, ensureDefaultScheduledTasks } from './web/agent-scaffold.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
 import { startMessageRouter } from './web/message-router.js'
@@ -65,6 +65,7 @@ const WEB_DIR = join(PROJECT_ROOT, 'web')
 
 function ensureDirs() {
   mkdirSync(AGENTS_BASE_DIR, { recursive: true })
+  bootstrapCapabilities()
 }
 
 export function startWebServer(port = 3420): http.Server {

--- a/src/web.ts
+++ b/src/web.ts
@@ -54,6 +54,7 @@ import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleSettings } from './web/routes/settings.js'
 import { tryHandleAuditLog } from './web/routes/audit-log.js'
+import { tryHandleFleetQ } from './web/routes/fleet-q.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import { tryHandleVoice } from './web/routes/voice.js'
 import { tryHandleVaultSsh } from './web/routes/vault-ssh.js'
@@ -187,6 +188,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleVaultSshKeys(routeCtx)) return
       if (await tryHandleVaultSsh(routeCtx)) return
       if (await tryHandleAuditLog(routeCtx)) return
+      if (await tryHandleFleetQ(routeCtx)) return
       if (await tryHandleStatic(routeCtx, WEB_DIR)) return
 
       res.writeHead(404)

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -461,33 +461,37 @@ export function isKnownAgent(name: string): boolean {
   }
 }
 
-// Seed defaults live in seed-config/agent-capabilities.json (git-tracked).
-// An agent's agent-config.json "capabilities" field overrides when present.
-let _capabilitiesSeed: Record<string, string[]> | null = null
-function loadCapabilitiesSeed(): Record<string, string[]> {
-  if (!_capabilitiesSeed) {
-    const seedPath = join(PROJECT_ROOT, 'seed-config', 'agent-capabilities.json')
-    try {
-      const raw = JSON.parse(readFileSync(seedPath, 'utf-8'))
-      _capabilitiesSeed = Object.fromEntries(
-        Object.entries(raw)
-          .filter(([k]) => k !== '_doc')
-          .map(([k, v]) => [k, Array.isArray(v) ? v : []])
-      )
-    } catch {
-      _capabilitiesSeed = {}
-    }
+// Parse YAML frontmatter capabilities from a persona file.
+// Expected format (first block in the file):
+//   ---
+//   capabilities: [tag1, tag2, tag3]
+//   ---
+// Returns [] if the file has no frontmatter or no capabilities key.
+function parsePersonaCapabilities(name: string): string[] {
+  const personaPath = join(PROJECT_ROOT, 'personas', `${name}.md`)
+  try {
+    const content = readFileSync(personaPath, 'utf-8')
+    const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+    if (!fmMatch) return []
+    // Simple YAML inline array: capabilities: [a, b, c]
+    const lineMatch = fmMatch[1].match(/^capabilities:\s*\[([^\]]*)\]/m)
+    if (!lineMatch) return []
+    return lineMatch[1].split(',').map(s => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean)
+  } catch {
+    return []
   }
-  return _capabilitiesSeed
 }
 
+// Capability resolution order (first match wins):
+//   1. agent-config.json "capabilities" field (runtime override via PUT API)
+//   2. personas/<name>.md YAML frontmatter "capabilities:" line (auto-derived)
 export function readAgentCapabilities(name: string): string[] {
   const configPath = join(agentDir(name), 'agent-config.json')
   try {
     const config = JSON.parse(readFileOr(configPath, '{}'))
     if (Array.isArray(config.capabilities)) return config.capabilities
-  } catch { /* fall through to seed */ }
-  return loadCapabilitiesSeed()[name] ?? []
+  } catch { /* fall through to persona */ }
+  return parsePersonaCapabilities(name)
 }
 
 export function writeAgentCapabilities(name: string, capabilities: string[]): void {
@@ -498,21 +502,6 @@ export function writeAgentCapabilities(name: string, capabilities: string[]): vo
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
-// On startup: write seed defaults into each agent's agent-config.json if the
-// "capabilities" field is absent. This ensures that after a `git pull` +
-// restart the live system immediately serves the manifest without any manual
-// editing. Existing per-agent overrides (already present in agent-config.json)
-// are never touched.
-export function bootstrapCapabilities(): void {
-  const seed = loadCapabilitiesSeed()
-  for (const name of listAgentNames()) {
-    const configPath = join(agentDir(name), 'agent-config.json')
-    try {
-      const config = JSON.parse(readFileOr(configPath, '{}'))
-      if (!Array.isArray(config.capabilities) && seed[name]) {
-        config.capabilities = seed[name]
-        atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
-      }
-    } catch { /* skip agents whose config can't be read/written */ }
-  }
-}
+// No-op kept for API compatibility; persona-based derivation is always live so
+// there is nothing to bootstrap at startup anymore.
+export function bootstrapCapabilities(): void { /* intentionally empty */ }

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -489,3 +489,30 @@ export function readAgentCapabilities(name: string): string[] {
   } catch { /* fall through to seed */ }
   return loadCapabilitiesSeed()[name] ?? []
 }
+
+export function writeAgentCapabilities(name: string, capabilities: string[]): void {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  let config: Record<string, unknown> = {}
+  try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
+  config.capabilities = capabilities
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
+// On startup: write seed defaults into each agent's agent-config.json if the
+// "capabilities" field is absent. This ensures that after a `git pull` +
+// restart the live system immediately serves the manifest without any manual
+// editing. Existing per-agent overrides (already present in agent-config.json)
+// are never touched.
+export function bootstrapCapabilities(): void {
+  const seed = loadCapabilitiesSeed()
+  for (const name of listAgentNames()) {
+    const configPath = join(agentDir(name), 'agent-config.json')
+    try {
+      const config = JSON.parse(readFileOr(configPath, '{}'))
+      if (!Array.isArray(config.capabilities) && seed[name]) {
+        config.capabilities = seed[name]
+        atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+      }
+    } catch { /* skip agents whose config can't be read/written */ }
+  }
+}

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -460,3 +460,32 @@ export function isKnownAgent(name: string): boolean {
     return false
   }
 }
+
+// Seed defaults live in seed-config/agent-capabilities.json (git-tracked).
+// An agent's agent-config.json "capabilities" field overrides when present.
+let _capabilitiesSeed: Record<string, string[]> | null = null
+function loadCapabilitiesSeed(): Record<string, string[]> {
+  if (!_capabilitiesSeed) {
+    const seedPath = join(PROJECT_ROOT, 'seed-config', 'agent-capabilities.json')
+    try {
+      const raw = JSON.parse(readFileSync(seedPath, 'utf-8'))
+      _capabilitiesSeed = Object.fromEntries(
+        Object.entries(raw)
+          .filter(([k]) => k !== '_doc')
+          .map(([k, v]) => [k, Array.isArray(v) ? v : []])
+      )
+    } catch {
+      _capabilitiesSeed = {}
+    }
+  }
+  return _capabilitiesSeed
+}
+
+export function readAgentCapabilities(name: string): string[] {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  try {
+    const config = JSON.parse(readFileOr(configPath, '{}'))
+    if (Array.isArray(config.capabilities)) return config.capabilities
+  } catch { /* fall through to seed */ }
+  return loadCapabilitiesSeed()[name] ?? []
+}

--- a/src/web/routes/fleet-q.ts
+++ b/src/web/routes/fleet-q.ts
@@ -1,20 +1,41 @@
-import { listAgentNames, readAgentCapabilities } from '../agent-config.js'
-import { json } from '../http-helpers.js'
+import { listAgentNames, readAgentCapabilities, writeAgentCapabilities, isKnownAgent } from '../agent-config.js'
+import { readBody, json } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
 
 // GET /.well-known/fleetq
-// Returns a machine-readable capability manifest for the agent fleet.
-// Each key is an agent id; the value is a list of capability tags declared
-// in that agent's agent-config.json ("capabilities" field). Agents with no
-// declared capabilities return an empty array.
-// This endpoint is intentionally unauthenticated (standard .well-known convention).
+// Machine-readable fleet capability manifest. Intentionally unauthenticated
+// (standard .well-known convention) so any agent or tool can discover capabilities
+// without needing a Bearer token.
+//
+// PUT /api/agents/:name/capabilities
+// Update a specific agent's capability tags at runtime. Requires Bearer auth
+// (handled by the outer auth gate in web.ts). Body: { "capabilities": string[] }
 export async function tryHandleFleetQ(ctx: RouteContext): Promise<boolean> {
-  if (ctx.path !== '/.well-known/fleetq' || ctx.method !== 'GET') return false
+  const { req, res, path, method } = ctx
 
-  const manifest: Record<string, string[]> = {}
-  for (const name of listAgentNames()) {
-    manifest[name] = readAgentCapabilities(name)
+  if (path === '/.well-known/fleetq' && method === 'GET') {
+    const manifest: Record<string, string[]> = {}
+    for (const name of listAgentNames()) {
+      manifest[name] = readAgentCapabilities(name)
+    }
+    json(res, manifest)
+    return true
   }
-  json(ctx.res, manifest)
-  return true
+
+  const capMatch = path.match(/^\/api\/agents\/([^/]+)\/capabilities$/)
+  if (capMatch && method === 'PUT') {
+    const name = decodeURIComponent(capMatch[1])
+    if (!isKnownAgent(name)) { json(res, { error: 'Agent nem található' }, 404); return true }
+    const body = await readBody(req)
+    const parsed = JSON.parse(body.toString()) as { capabilities?: unknown }
+    if (!Array.isArray(parsed.capabilities) || !parsed.capabilities.every((c: unknown) => typeof c === 'string')) {
+      json(res, { error: 'capabilities: string[] required' }, 400)
+      return true
+    }
+    writeAgentCapabilities(name, parsed.capabilities)
+    json(res, { ok: true, capabilities: parsed.capabilities })
+    return true
+  }
+
+  return false
 }

--- a/src/web/routes/fleet-q.ts
+++ b/src/web/routes/fleet-q.ts
@@ -1,0 +1,20 @@
+import { listAgentNames, readAgentCapabilities } from '../agent-config.js'
+import { json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+// GET /.well-known/fleetq
+// Returns a machine-readable capability manifest for the agent fleet.
+// Each key is an agent id; the value is a list of capability tags declared
+// in that agent's agent-config.json ("capabilities" field). Agents with no
+// declared capabilities return an empty array.
+// This endpoint is intentionally unauthenticated (standard .well-known convention).
+export async function tryHandleFleetQ(ctx: RouteContext): Promise<boolean> {
+  if (ctx.path !== '/.well-known/fleetq' || ctx.method !== 'GET') return false
+
+  const manifest: Record<string, string[]> = {}
+  for (const name of listAgentNames()) {
+    manifest[name] = readAgentCapabilities(name)
+  }
+  json(ctx.res, manifest)
+  return true
+}


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

Capability manifest végpont: GET /.well-known/fleetq -- publikus, unauthenticated .well-known endpoint, amely visszaadja az egyes sub-agentek képességlistáját JSON formátumban.

A képességek forrása: personas/<agentNév>.md YAML frontmatter (capabilities: [...]), amelyet a rendszer élőben parse-ol -- ha a fájl változik, a következő kérés már az új értéket adja vissza. Runtime felülírás: PUT /api/agents/:name/capabilities endpoint az agent-config.json-ba ír (elsőbbsége van a persona frontmatter felett).

Capability manifest endpoint: GET /.well-known/fleetq -- public, unauthenticated endpoint returning each sub-agent's capability list as JSON. Source: personas/<agentName>.md YAML frontmatter, parsed live (no stale cache). Runtime override via PUT /api/agents/:name/capabilities writes to agent-config.json and takes precedence over the persona file.

## Kapcsolódó issue / Related issue

Closes #562

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben, az ágensek hiba nélkül kommunikálnak. / Tested locally; agents communicate without errors.
- [ ] Frissítettem a docs/ mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated docs/ if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (capability-manifest). / Opened from descriptively named branch.