### PR TITLE
onboarding: detect macOS Keychain Claude auth to prevent a false wizard

### DIFF
--- a/src/__tests__/onboarding-auth.test.ts
+++ b/src/__tests__/onboarding-auth.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest'
+import { decideClaudeAuthPresent } from '../web/routes/onboarding.js'
+
+type Probes = Parameters<typeof decideClaudeAuthPresent>[0]
+
+// No auth anywhere by default; each case overrides one probe.
+function probes(over: Partial<Probes> = {}): Probes {
+  return {
+    oauthTokenEnv: null,
+    apiKeyEnv: null,
+    credentialsJson: null,
+    platform: 'linux',
+    keychainHasCredentials: () => false,
+    ...over,
+  }
+}
+
+describe('decideClaudeAuthPresent', () => {
+  it('true when an OAuth token env var is set', () => {
+    expect(decideClaudeAuthPresent(probes({ oauthTokenEnv: 'oat-placeholder' }))).toBe(true)
+  })
+
+  it('true when an API key env var is set', () => {
+    expect(decideClaudeAuthPresent(probes({ apiKeyEnv: 'key-placeholder' }))).toBe(true)
+  })
+
+  it('empty-string env values are falsy, treated as no auth', () => {
+    expect(decideClaudeAuthPresent(probes({ oauthTokenEnv: '', apiKeyEnv: '' }))).toBe(false)
+  })
+
+  it('true when credentials.json carries an OAuth accessToken', () => {
+    const json = JSON.stringify({ claudeAiOauth: { accessToken: 'tok' } })
+    expect(decideClaudeAuthPresent(probes({ credentialsJson: json }))).toBe(true)
+  })
+
+  it('true when credentials.json carries an apiKey', () => {
+    expect(decideClaudeAuthPresent(probes({ credentialsJson: JSON.stringify({ apiKey: 'k' }) }))).toBe(true)
+  })
+
+  it('false when credentials.json is an empty object', () => {
+    expect(decideClaudeAuthPresent(probes({ credentialsJson: '{}' }))).toBe(false)
+  })
+
+  it('malformed credentials.json is ignored without throwing', () => {
+    expect(decideClaudeAuthPresent(probes({ credentialsJson: 'not-json {' }))).toBe(false)
+  })
+
+  it('macOS: true when only the Keychain holds the credential', () => {
+    expect(decideClaudeAuthPresent(probes({ platform: 'darwin', keychainHasCredentials: () => true }))).toBe(true)
+  })
+
+  it('macOS: false when neither env/file nor Keychain has a credential', () => {
+    expect(decideClaudeAuthPresent(probes({ platform: 'darwin', keychainHasCredentials: () => false }))).toBe(false)
+  })
+
+  it('non-macOS: the Keychain is never consulted, result is false', () => {
+    const keychain = vi.fn(() => true)
+    expect(decideClaudeAuthPresent(probes({ platform: 'linux', keychainHasCredentials: keychain }))).toBe(false)
+    expect(keychain).not.toHaveBeenCalled()
+  })
+
+  it('lazy: an env token short-circuits before the Keychain probe (darwin)', () => {
+    const keychain = vi.fn(() => true)
+    expect(decideClaudeAuthPresent(probes({ platform: 'darwin', oauthTokenEnv: 'oat', keychainHasCredentials: keychain }))).toBe(true)
+    expect(keychain).not.toHaveBeenCalled()
+  })
+
+  it('lazy: a file credential short-circuits before the Keychain probe (darwin)', () => {
+    const keychain = vi.fn(() => true)
+    const json = JSON.stringify({ claudeAiOauth: { accessToken: 'tok' } })
+    expect(decideClaudeAuthPresent(probes({ platform: 'darwin', credentialsJson: json, keychainHasCredentials: keychain }))).toBe(true)
+    expect(keychain).not.toHaveBeenCalled()
+  })
+
+  it('macOS: the Keychain probe runs exactly once when it is the deciding signal', () => {
+    const keychain = vi.fn(() => true)
+    expect(decideClaudeAuthPresent(probes({ platform: 'darwin', keychainHasCredentials: keychain }))).toBe(true)
+    expect(keychain).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -34,19 +34,59 @@ function readEnvValue(key: string): string | null {
   return null
 }
 
-// True auth presence -- an env OAuth token / API key, OR a real credentials.json
-// OAuth credential. NOT merely "the .env line exists" (it could be empty).
-function claudeAuthPresent(): boolean {
-  if (readEnvValue('CLAUDE_CODE_OAUTH_TOKEN')) return true
-  if (readEnvValue('ANTHROPIC_API_KEY')) return true
-  try {
-    const d = JSON.parse(readFileSync(HOME_CREDENTIALS, 'utf-8')) as {
-      claudeAiOauth?: { accessToken?: string }; apiKey?: string
-    }
-    if (d?.claudeAiOauth?.accessToken) return true
-    if (d?.apiKey) return true
-  } catch { /* no / unreadable credentials.json */ }
+// Pure auth-presence decision, testable without I/O. Given the probe results
+// (env values, raw credentials.json content, platform, and a lazy Keychain
+// probe) decide whether a usable Claude credential exists. The Keychain probe
+// is only consulted on macOS after the env/file checks miss, so a caller that
+// already has a token (or is not on darwin) never triggers it.
+export function decideClaudeAuthPresent(p: {
+  oauthTokenEnv: string | null
+  apiKeyEnv: string | null
+  credentialsJson: string | null
+  platform: NodeJS.Platform
+  keychainHasCredentials: () => boolean
+}): boolean {
+  if (p.oauthTokenEnv) return true
+  if (p.apiKeyEnv) return true
+  if (p.credentialsJson) {
+    try {
+      const d = JSON.parse(p.credentialsJson) as {
+        claudeAiOauth?: { accessToken?: string }; apiKey?: string
+      }
+      if (d?.claudeAiOauth?.accessToken) return true
+      if (d?.apiKey) return true
+    } catch { /* malformed credentials.json -- treat as absent */ }
+  }
+  // macOS keeps Claude Code credentials in the login Keychain, not in a
+  // credentials.json file. Without this probe a fully-authenticated Mac
+  // install falsely reports no-auth and pops the onboarding wizard over a
+  // working dashboard.
+  if (p.platform === 'darwin' && p.keychainHasCredentials()) return true
   return false
+}
+
+// Probe the macOS login Keychain for the Claude Code credential item. Any
+// non-zero exit (item absent, `security` unavailable) means "no auth".
+function keychainHasClaudeCredentials(): boolean {
+  try {
+    execFileSync('security', ['find-generic-password', '-s', 'Claude Code-credentials'], { stdio: 'ignore', timeout: 5000 })
+    return true
+  } catch { return false }
+}
+
+// True auth presence -- an env OAuth token / API key, a real credentials.json
+// OAuth credential, or (on macOS) a Keychain credential. NOT merely "the .env
+// line exists" (it could be empty).
+function claudeAuthPresent(): boolean {
+  let credentialsJson: string | null = null
+  try { credentialsJson = readFileSync(HOME_CREDENTIALS, 'utf-8') } catch { /* no / unreadable credentials.json */ }
+  return decideClaudeAuthPresent({
+    oauthTokenEnv: readEnvValue('CLAUDE_CODE_OAUTH_TOKEN'),
+    apiKeyEnv: readEnvValue('ANTHROPIC_API_KEY'),
+    credentialsJson,
+    platform: process.platform,
+    keychainHasCredentials: keychainHasClaudeCredentials,
+  })
 }
 
 function telegramConfigured(): boolean {


### PR DESCRIPTION
## Why this matters

On macOS, Claude Code stores its credentials in the login Keychain and writes no `~/.claude/.credentials.json` file. The onboarding auth check (`claudeAuthPresent()`) only inspected `.env` tokens and that credentials file, so a fully authenticated Mac reported "no auth" and set `needsOnboarding: true`. The first-run onboarding wizard (#550) then rendered its blocking full-screen overlay on top of an already-working dashboard, with no dismiss control.

Repro (authenticated macOS install; no `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` in `.env`; no credentials.json):

`GET /api/onboarding/status` returns `{"claudeAuthPresent": false, "agentsRunning": true, "telegramConfigured": true, "paired": true, "needsOnboarding": true}` and the overlay appears.

## Change

`src/web/routes/onboarding.ts`:
- Extract the auth-presence decision into a pure, exported `decideClaudeAuthPresent(probes)` (env OAuth token, API key, raw credentials.json, platform, and a lazy Keychain probe).
- Add `keychainHasClaudeCredentials()`: on macOS only, probe the `Claude Code-credentials` Keychain item via `security find-generic-password -s ...`. This is an existence check only (no `-w`), so no secret material is read. It is consulted lazily, only after the env and file checks miss.
- `claudeAuthPresent()` becomes a thin I/O wrapper over the pure function.

The Keychain service name matches the credential item the shipping heartbeat/worker code already reads.

## Scope / compatibility

- Off macOS (Linux / Windows) the Keychain probe is never invoked; behavior is exactly as before (env then credentials.json).
- When an env token or a valid credentials.json already proves auth, the probe is not consulted (lazy short-circuit).
- No secret is read or logged; the probe only checks that the item exists.

## Test plan

- `npm run typecheck`: clean.
- New `src/__tests__/onboarding-auth.test.ts` (13 cases): env token, API key, empty-string env, credentials.json OAuth / apiKey, empty object, malformed JSON, darwin+keychain true and false, non-darwin skip (probe never called), lazy short-circuit on env and on file, and probe-called-exactly-once.
- Full suite: 120 files / 1681 tests pass.

## Known limitations

`needsOnboarding` also requires `telegramConfigured` and `paired`. A Mac user with working Claude auth but no Telegram configured still sees the wizard, now correctly at the Telegram step rather than falsely blocked at step 1. That is the wizard's existing design; this change only fixes the Claude-auth false negative on macOS.
