### PR TITLE
fix(hooks): guard hook registration against worktree instances + prune stale entries

### DIFF
--- a/src/__tests__/hook-registration-guard.test.ts
+++ b/src/__tests__/hook-registration-guard.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  isWorktreeRoot,
+  shouldRegisterHooks,
+  pruneStaleHookEntries,
+  pruneStaleHooksFromSettingsFile,
+  KNOWN_HOOK_SCRIPTS,
+} from '../web/hook-registration-guard.js'
+
+// 2026-07-11 incident: a WEB_ONLY smoke instance running from a git worktree
+// registered UserPromptSubmit/SessionStart hooks into the user-global
+// ~/.claude/settings.json with worktree-absolute paths. After the worktree was
+// deleted, the hook exited 2 and BLOCKED every prompt (main agent deaf).
+// These tests pin the guard (never register from a worktree / staging
+// instance) and the self-heal (prune our stale entries, keep foreign ones).
+
+const notAGitFile = () => false
+
+describe('isWorktreeRoot', () => {
+  it('detects a .claude/worktrees checkout by path', () => {
+    expect(isWorktreeRoot('/home/user/app/.claude/worktrees/agent-abc123', { isGitFile: notAGitFile })).toBe(true)
+  })
+  it('detects a generic linked worktree via the .git-is-a-file signal', () => {
+    expect(isWorktreeRoot('/tmp/some-linked-checkout', { isGitFile: () => true })).toBe(true)
+  })
+  it('treats a normal checkout (git dir, non-worktree path) as non-worktree', () => {
+    expect(isWorktreeRoot('/opt/app', { isGitFile: notAGitFile })).toBe(false)
+  })
+})
+
+describe('shouldRegisterHooks', () => {
+  it('registers for a normal root in normal mode', () => {
+    const d = shouldRegisterHooks({ projectRoot: '/opt/app', webOnly: false, isGitFile: notAGitFile })
+    expect(d.register).toBe(true)
+  })
+  it('skips for a worktree root', () => {
+    const d = shouldRegisterHooks({
+      projectRoot: '/opt/app/.claude/worktrees/agent-xyz',
+      webOnly: false,
+      isGitFile: notAGitFile,
+    })
+    expect(d.register).toBe(false)
+    expect(d.reason).toMatch(/worktree/)
+  })
+  it('skips in WEB_ONLY staging mode even from a normal root', () => {
+    const d = shouldRegisterHooks({ projectRoot: '/opt/app', webOnly: true, isGitFile: notAGitFile })
+    expect(d.register).toBe(false)
+    expect(d.reason).toMatch(/WEB_ONLY/)
+  })
+})
+
+function settingsFixture(): Record<string, unknown> {
+  return {
+    enabledPlugins: { 'telegram@claude-plugins-official': true },
+    hooks: {
+      UserPromptSubmit: [
+        {
+          hooks: [
+            { type: 'command', command: 'python3 /opt/app/scripts/hooks/staleness-guard.py', timeout: 10 },
+            { type: 'command', command: 'python3 /opt/app/.claude/worktrees/agent-dead/scripts/hooks/voice-reply-directive.py', timeout: 60 },
+          ],
+        },
+        { hooks: [{ type: 'command', command: 'python3 /home/user/my-own-hook.py', timeout: 5 }] },
+      ],
+      SessionStart: [
+        {
+          matcher: 'compact|resume',
+          hooks: [{ type: 'command', command: 'python3 /opt/app/.claude/worktrees/agent-dead/scripts/hooks/taskstate-replay.py', timeout: 15 }],
+        },
+      ],
+      PreCompact: [
+        { matcher: 'auto', hooks: [{ type: 'agent', prompt: 'save memories', timeout: 180 }] },
+      ],
+    },
+  }
+}
+
+describe('pruneStaleHookEntries', () => {
+  const liveFiles = new Set(['/opt/app/scripts/hooks/staleness-guard.py'])
+  const fileExists = (p: string) => liveFiles.has(p)
+
+  it('prunes stale worktree entries and keeps valid + foreign entries', () => {
+    const settings = settingsFixture()
+    const { changed, removed } = pruneStaleHookEntries(settings, { fileExists })
+    expect(changed).toBe(true)
+    expect(removed).toHaveLength(2)
+    expect(removed.join(' ')).toContain('voice-reply-directive.py')
+    expect(removed.join(' ')).toContain('taskstate-replay.py')
+
+    const hooks = settings.hooks as Record<string, Array<{ hooks: Array<{ command?: string; prompt?: string }> }>>
+    // Valid our-entry kept.
+    expect(JSON.stringify(hooks.UserPromptSubmit)).toContain('staleness-guard.py')
+    // Foreign entry kept even though its file does not exist.
+    expect(JSON.stringify(hooks.UserPromptSubmit)).toContain('/home/user/my-own-hook.py')
+    // SessionStart group emptied by pruning: the whole event key is dropped.
+    expect(hooks.SessionStart).toBeUndefined()
+    // Agent-type (non-command) hooks are never touched.
+    expect(hooks.PreCompact[0].hooks[0].prompt).toBe('save memories')
+  })
+
+  it('prunes a missing-file NON-worktree entry when it matches our script names', () => {
+    const settings = {
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'python3 /old/install/scripts/hooks/voice-reply-directive.py', timeout: 60 }] },
+        ],
+      },
+    }
+    const { changed, removed } = pruneStaleHookEntries(settings, { fileExists: () => false })
+    expect(changed).toBe(true)
+    expect(removed).toEqual(['python3 /old/install/scripts/hooks/voice-reply-directive.py'])
+    expect((settings.hooks as Record<string, unknown>).UserPromptSubmit).toBeUndefined()
+  })
+
+  it('keeps our entry when the script file exists', () => {
+    const settings = {
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'python3 /opt/app/scripts/hooks/staleness-guard.py', timeout: 10 }] },
+        ],
+      },
+    }
+    const before = JSON.stringify(settings)
+    const { changed, removed } = pruneStaleHookEntries(settings, { fileExists })
+    expect(changed).toBe(false)
+    expect(removed).toEqual([])
+    expect(JSON.stringify(settings)).toBe(before)
+  })
+
+  it('keeps a foreign hook whose file is missing (not ours, not worktree-pathed)', () => {
+    const settings = {
+      hooks: {
+        PreToolUse: [
+          { matcher: 'Bash', hooks: [{ type: 'command', command: 'node /somewhere/else/custom-gate.mjs', timeout: 10 }] },
+        ],
+      },
+    }
+    const before = JSON.stringify(settings)
+    const { changed } = pruneStaleHookEntries(settings, { fileExists: () => false })
+    expect(changed).toBe(false)
+    expect(JSON.stringify(settings)).toBe(before)
+  })
+
+  it('prunes an unknown-named script when its path lies inside .claude/worktrees/', () => {
+    const settings = {
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: 'command', command: 'bash /x/.claude/worktrees/agent-1/scripts/some-future-hook.sh' }] },
+        ],
+      },
+    }
+    const { changed, removed } = pruneStaleHookEntries(settings, { fileExists: () => false })
+    expect(changed).toBe(true)
+    expect(removed).toHaveLength(1)
+  })
+
+  it('is a no-op on settings without a hooks block', () => {
+    const settings: Record<string, unknown> = { permissions: { allow: [] } }
+    const { changed, removed } = pruneStaleHookEntries(settings, { fileExists: () => false })
+    expect(changed).toBe(false)
+    expect(removed).toEqual([])
+  })
+
+  it('covers the incident hook script names in KNOWN_HOOK_SCRIPTS', () => {
+    expect(KNOWN_HOOK_SCRIPTS).toContain('voice-reply-directive.py')
+    expect(KNOWN_HOOK_SCRIPTS).toContain('taskstate-replay.py')
+    expect(KNOWN_HOOK_SCRIPTS).toContain('staleness-guard.py')
+  })
+})
+
+describe('pruneStaleHooksFromSettingsFile', () => {
+  it('rewrites the file without stale entries and preserves the rest', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hook-guard-test-'))
+    try {
+      // A real script file that must survive pruning.
+      const liveScript = join(dir, 'staleness-guard.py')
+      writeFileSync(liveScript, '# live')
+      const settingsPath = join(dir, 'settings.json')
+      writeFileSync(settingsPath, JSON.stringify({
+        enabledPlugins: { x: true },
+        hooks: {
+          UserPromptSubmit: [
+            {
+              hooks: [
+                { type: 'command', command: `python3 ${liveScript}`, timeout: 10 },
+                { type: 'command', command: `python3 ${join(dir, '.claude', 'worktrees', 'agent-gone', 'voice-reply-directive.py')}`, timeout: 60 },
+              ],
+            },
+          ],
+        },
+      }, null, 2))
+
+      const removed = pruneStaleHooksFromSettingsFile(settingsPath)
+      expect(removed).toHaveLength(1)
+      const after = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      expect(JSON.stringify(after.hooks)).toContain(liveScript)
+      expect(JSON.stringify(after.hooks)).not.toContain('agent-gone')
+      expect(after.enabledPlugins).toEqual({ x: true })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves a missing or unparseable file untouched', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hook-guard-test-'))
+    try {
+      expect(pruneStaleHooksFromSettingsFile(join(dir, 'nope.json'))).toEqual([])
+      const badPath = join(dir, 'settings.json')
+      writeFileSync(badPath, '{ not json')
+      expect(pruneStaleHooksFromSettingsFile(badPath)).toEqual([])
+      expect(readFileSync(badPath, 'utf-8')).toBe('{ not json')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -8,7 +8,8 @@ import { isBlockedCrossOriginWrite, originMatchesServedHost } from './web/csrf-o
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
 import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
-import { ensureAgentHooks, ensureAgentStalenessHook, ensureDefaultScheduledTasks } from './web/agent-scaffold.js'
+import { ensureAgentHooks, ensureAgentStalenessHook, ensureDefaultScheduledTasks, agentSettingsPath } from './web/agent-scaffold.js'
+import { shouldRegisterHooks, pruneStaleHooksFromSettingsFile } from './web/hook-registration-guard.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
 import { startMessageRouter } from './web/message-router.js'
 import { startUpdateChecker } from './web/update-checker.js'
@@ -396,19 +397,36 @@ export function startWebServer(port = 3420): http.Server {
   // Backfill the PreCompact hook into existing agents' settings.json so the
   // auto-skill / auto-memory flow runs on context compaction. No-op if the
   // agent already has its own hooks block.
-  try {
-    const patched: string[] = []
-    const stalePatched: string[] = []
-    // Include the main agent (MAIN_AGENT_ID) so the voice hook is also seeded
-    // into ~/.claude/settings.json alongside existing hooks (e.g. telegram_progress.py).
-    for (const agentName of [MAIN_AGENT_ID, ...listAgentNames()]) {
-      if (ensureAgentHooks(agentName)) patched.push(agentName)
-      if (ensureAgentStalenessHook(agentName)) stalePatched.push(agentName)
+  //
+  // Guarded: a worktree checkout or a WEB_ONLY staging instance must NEVER
+  // register hooks -- its PROJECT_ROOT is temporary, and baking it into the
+  // user-global ~/.claude/settings.json leaves stale absolute paths behind
+  // once the worktree is deleted. A failing (exit 2) UserPromptSubmit hook
+  // then BLOCKS every prompt and deafens the main agent (2026-07-11 incident).
+  const hookDecision = shouldRegisterHooks({ projectRoot: PROJECT_ROOT, webOnly })
+  if (!hookDecision.register) {
+    logger.info({ reason: hookDecision.reason, projectRoot: PROJECT_ROOT }, 'Hook registration skipped')
+  } else {
+    try {
+      const patched: string[] = []
+      const stalePatched: string[] = []
+      const pruned: string[] = []
+      // Include the main agent (MAIN_AGENT_ID) so the voice hook is also seeded
+      // into ~/.claude/settings.json alongside existing hooks (e.g. telegram_progress.py).
+      for (const agentName of [MAIN_AGENT_ID, ...listAgentNames()]) {
+        // Self-heal FIRST: drop entries this app previously wrote whose script
+        // file no longer exists (e.g. a deleted worktree instance's paths), so
+        // the re-registration below lands on a clean, unblocked settings file.
+        pruned.push(...pruneStaleHooksFromSettingsFile(agentSettingsPath(agentName)))
+        if (ensureAgentHooks(agentName)) patched.push(agentName)
+        if (ensureAgentStalenessHook(agentName)) stalePatched.push(agentName)
+      }
+      if (pruned.length) logger.info({ pruned }, 'Stale hook entries pruned from agent settings.json')
+      if (patched.length) logger.info({ patched }, 'PreCompact hook backfilled into agent settings.json')
+      if (stalePatched.length) logger.info({ patched: stalePatched }, 'staleness-guard UserPromptSubmit hook backfilled into agent settings.json')
+    } catch (err) {
+      logger.warn({ err }, 'Agent hook backfill skipped')
     }
-    if (patched.length) logger.info({ patched }, 'PreCompact hook backfilled into agent settings.json')
-    if (stalePatched.length) logger.info({ patched: stalePatched }, 'staleness-guard UserPromptSubmit hook backfilled into agent settings.json')
-  } catch (err) {
-    logger.warn({ err }, 'Agent hook backfill skipped')
   }
 
   try {

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -47,7 +47,9 @@ export function resolveTemplatePlaceholders(content: string): string {
 
 // Return the settings.json path for an agent.
 // The main agent's settings live at ~/.claude/settings.json (not inside agents/).
-function agentSettingsPath(name: string): string {
+// Exported so the startup self-heal (hook-registration-guard) can prune stale
+// entries from the same files this module writes.
+export function agentSettingsPath(name: string): string {
   if (name === MAIN_AGENT_ID) return join(homedir(), '.claude', 'settings.json')
   return join(agentDir(name), '.claude', 'settings.json')
 }

--- a/src/web/hook-registration-guard.ts
+++ b/src/web/hook-registration-guard.ts
@@ -1,0 +1,190 @@
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { join, sep } from 'node:path'
+import { atomicWriteFileSync } from './atomic-write.js'
+
+// Guard + self-heal for hook registration into user-global settings.json.
+//
+// Incident (2026-07-11): an app instance started from a git worktree (a
+// WEB_ONLY smoke instance under .claude/worktrees/agent-XXXX) ran the startup
+// hook backfill and registered UserPromptSubmit / SessionStart hooks into the
+// USER-GLOBAL ~/.claude/settings.json with absolute paths rooted in its own
+// (temporary) PROJECT_ROOT. When the worktree was deleted, python3 exited 2
+// ("can't open file") -- and a non-zero UserPromptSubmit hook BLOCKS the
+// prompt, so the main agent went deaf to all inbound messages until the stale
+// entries were removed by hand.
+//
+// Two layers:
+//   1. shouldRegisterHooks(): skip registration entirely when the running
+//      instance is a worktree checkout (its PROJECT_ROOT is temporary) or a
+//      WEB_ONLY staging instance (not the install that owns the settings).
+//   2. pruneStaleHookEntries(): during normal startup, remove entries THIS
+//      app previously wrote whose script file no longer exists. Foreign hook
+//      entries (not our script names, not worktree-pathed) are never touched.
+
+// Hook script filenames this app registers into settings.json files
+// (templates/settings.json.template, ensureAgentStalenessHook, the
+// PreToolUse gates, and the telegram-progress installer). Used to decide
+// whether a missing-file hook entry is OURS (prunable) or foreign (kept).
+export const KNOWN_HOOK_SCRIPTS: readonly string[] = [
+  'taskstate-replay.py',
+  'voice-reply-directive.py',
+  'staleness-guard.py',
+  'email-send-gate.mjs',
+  'self-pace-gate.mjs',
+  'telegram_progress.py',
+  'telegram_progress_clear.py',
+  'telegram_progress_watchdog.py',
+  'inbox-drain.py',
+  'ledger-capture.py',
+]
+
+// Path fragment that marks a checkout as an agent worktree. Kept
+// separator-agnostic by normalizing before matching.
+const WORKTREES_FRAGMENT = '/.claude/worktrees/'
+
+function normalizeSeparators(p: string): string {
+  return p.split(sep).join('/')
+}
+
+// True when the .git entry at the given root is a FILE (a linked worktree's
+// gitdir pointer) rather than a directory (a normal checkout's object store).
+// This is the generic worktree signal: in every `git worktree add` checkout,
+// .git is a plain file, so PROJECT_ROOT differs from the common dir's toplevel.
+function gitEntryIsFile(root: string): boolean {
+  try {
+    return statSync(join(root, '.git')).isFile()
+  } catch {
+    return false
+  }
+}
+
+// Is the resolved project root a git-worktree checkout (and therefore a
+// temporary location that must never be baked into user-global settings)?
+// The isGitFile dependency is injectable so the decision logic is unit-testable
+// without a real filesystem.
+export function isWorktreeRoot(
+  projectRoot: string,
+  deps: { isGitFile?: (root: string) => boolean } = {},
+): boolean {
+  const normalized = normalizeSeparators(projectRoot)
+  if (normalized.includes(WORKTREES_FRAGMENT)) return true
+  return (deps.isGitFile ?? gitEntryIsFile)(projectRoot)
+}
+
+export interface HookRegistrationDecision {
+  register: boolean
+  reason?: string
+}
+
+// Central decision: may this instance register hooks into settings.json?
+// Skips worktree checkouts (temporary PROJECT_ROOT) and WEB_ONLY staging
+// instances (not the install that owns the user's settings).
+export function shouldRegisterHooks(opts: {
+  projectRoot: string
+  webOnly: boolean
+  isGitFile?: (root: string) => boolean
+}): HookRegistrationDecision {
+  if (isWorktreeRoot(opts.projectRoot, { isGitFile: opts.isGitFile })) {
+    return { register: false, reason: 'project root is a git worktree checkout (temporary path)' }
+  }
+  if (opts.webOnly) {
+    return { register: false, reason: 'WEB_ONLY staging mode' }
+  }
+  return { register: true }
+}
+
+type CommandHook = { type?: string; command?: string; [k: string]: unknown }
+type HookGroup = { hooks?: CommandHook[]; [k: string]: unknown }
+
+// Extract the candidate script paths from a hook command string: tokens that
+// end with one of our known hook script names, or that point into a
+// .claude/worktrees/ checkout. Anything else in the command is ignored, so a
+// foreign hook that merely mentions python3 is never considered ours.
+function ourScriptPaths(command: string, knownScripts: readonly string[]): string[] {
+  const paths: string[] = []
+  for (const raw of command.split(/\s+/)) {
+    const token = raw.replace(/^['"]+|['"]+$/g, '')
+    if (!token) continue
+    const normalized = normalizeSeparators(token)
+    const base = normalized.slice(normalized.lastIndexOf('/') + 1)
+    if (knownScripts.includes(base) || normalized.includes(WORKTREES_FRAGMENT)) {
+      paths.push(token)
+    }
+  }
+  return paths
+}
+
+export interface PruneResult {
+  changed: boolean
+  removed: string[]
+}
+
+// Self-heal: remove hook entries this app previously wrote whose script file
+// no longer exists on disk. An entry is prunable only when BOTH hold:
+//   - its command references a path matching our known hook script names, or
+//     a path inside a .claude/worktrees/ checkout, AND
+//   - that referenced file is missing.
+// Everything else (foreign commands, agent-type hooks, our entries whose file
+// still exists) is preserved byte-identically. Mutates `settings` in place;
+// the caller persists it (read-modify-write with an atomic write).
+export function pruneStaleHookEntries(
+  settings: Record<string, unknown>,
+  opts: { fileExists: (path: string) => boolean; knownScripts?: readonly string[] },
+): PruneResult {
+  const knownScripts = opts.knownScripts ?? KNOWN_HOOK_SCRIPTS
+  const removed: string[] = []
+  const hooks = settings.hooks
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) return { changed: false, removed }
+  const hooksRecord = hooks as Record<string, unknown>
+
+  for (const [event, groups] of Object.entries(hooksRecord)) {
+    if (!Array.isArray(groups)) continue
+    const keptGroups: HookGroup[] = []
+    let eventChanged = false
+    for (const group of groups as HookGroup[]) {
+      if (!group || typeof group !== 'object' || !Array.isArray(group.hooks)) {
+        keptGroups.push(group)
+        continue
+      }
+      const keptHooks = group.hooks.filter((h) => {
+        if (!h || typeof h !== 'object' || h.type !== 'command' || typeof h.command !== 'string') return true
+        const scriptPaths = ourScriptPaths(h.command, knownScripts)
+        if (scriptPaths.length === 0) return true // foreign entry: never touch
+        const stale = scriptPaths.some((p) => !opts.fileExists(p))
+        if (stale) removed.push(h.command)
+        return !stale
+      })
+      if (keptHooks.length !== group.hooks.length) {
+        eventChanged = true
+        // Drop the group entirely when pruning emptied it; a matcher with no
+        // hooks is dead weight. Groups that keep at least one hook survive.
+        if (keptHooks.length > 0) keptGroups.push({ ...group, hooks: keptHooks })
+      } else {
+        keptGroups.push(group)
+      }
+    }
+    if (eventChanged) {
+      if (keptGroups.length > 0) hooksRecord[event] = keptGroups
+      else delete hooksRecord[event]
+    }
+  }
+  return { changed: removed.length > 0, removed }
+}
+
+// File-level wrapper: parse a settings.json, prune stale entries, and write it
+// back atomically when anything changed. Unparseable or missing files are left
+// untouched (never destroy a user's settings on a parse error). Returns the
+// pruned command strings for logging.
+export function pruneStaleHooksFromSettingsFile(settingsPath: string): string[] {
+  if (!existsSync(settingsPath)) return []
+  let settings: Record<string, unknown>
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>
+  } catch {
+    return []
+  }
+  if (!settings || typeof settings !== 'object') return []
+  const { changed, removed } = pruneStaleHookEntries(settings, { fileExists: existsSync })
+  if (changed) atomicWriteFileSync(settingsPath, JSON.stringify(settings, null, 2))
+  return removed
+}


### PR DESCRIPTION
## Problem

An app instance started from a git worktree (a WEB_ONLY smoke checkout under `.claude/worktrees/`) registered UserPromptSubmit and SessionStart hooks into the user-global `~/.claude/settings.json` using absolute paths rooted in its own temporary PROJECT_ROOT. When the worktree was later deleted, the hook commands exited 2 ("can't open file"). A non-zero UserPromptSubmit hook blocks the prompt, so the main agent stopped receiving ALL inbound messages until the stale entries were removed by hand (2026-07-11 incident).

## Root cause

The startup hook backfill in `src/web.ts` (`ensureAgentHooks` / `ensureAgentStalenessHook`) resolves `{{PROJECT_ROOT}}` from `templates/settings.json.template` to the RUNNING instance's root and merges the result into the user-global settings. It ran unconditionally: worktree checkouts and WEB_ONLY staging instances performed the same write as the real install.

## Fix layers

New module `src/web/hook-registration-guard.ts`, wired into the startup backfill in `src/web.ts`:

1. **Guard**: `shouldRegisterHooks()` skips registration entirely when the resolved PROJECT_ROOT is a worktree checkout (path contains `.claude/worktrees/`, or the generic linked-worktree signal: `.git` is a file, not a directory) or when running in WEB_ONLY staging mode. Logs a one-line info with the reason.
2. **Self-heal**: during normal startup registration, `pruneStaleHooksFromSettingsFile()` first removes entries this app previously wrote whose referenced script file no longer exists, matched by our known hook script names or a `.claude/worktrees/` path. Foreign hook entries (unrecognized commands), agent-type hooks, and valid entries are preserved untouched. Writes are atomic (existing `atomicWriteFileSync`); missing or unparseable settings files are never modified.
3. No change to which hooks normal installs register.

## Test coverage

15 new vitest cases (`src/__tests__/hook-registration-guard.test.ts`):
- register on a normal root; skip on worktree path; skip on `.git`-file signal; skip on WEB_ONLY
- stale worktree entry pruned; foreign missing-file entry kept; missing-file non-worktree entry with our script name pruned; valid our-entry kept; agent-type (prompt) hooks untouched; emptied groups/events dropped
- file-level round-trip on a temp dir + missing/unparseable file no-ops

Full suite: 129 files / 1794 tests green. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)