### PR TITLE
feat(intel): proactive intelligence registry subsystem (schema + collector + brief)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Minden lap két szemszögből mutatja be a funkciót:
 | [connectors.hu](connectors-hu.md) | Üzleti API-átjáró (NAV, Billingo, Wise, fal.ai) MCP-n |
 | [Vault & titkosítás](vault.md) | Titkosított titok-tár (AES-256-GCM) OS-kulcstárral |
 | [Dream-engine](dream-engine.md) | Éjszakai tudás-konszolidáció + reggeli prioritás-javaslatok |
+| [Proaktív hírszerző (intel registry)](intel-registry.md) | Óránkénti gyűjtő + napi brief közös SQLite tény-registry-vel, dedup + tény-életciklus |
 | [Háttér-feladatok](background-tasks.md) | Leválasztott, hosszú feladatok futtatása + értesítés |
 
 *A dokumentáció él; javításokat/bővítéseket szívesen fogadunk.*

--- a/docs/intel-registry.md
+++ b/docs/intel-registry.md
@@ -1,0 +1,79 @@
+# Proaktív hírszerző (intel registry)
+
+> Óránkénti gyűjtő + napi brief, közös SQLite registry-vel -- a reggeli összefoglaló nem a session emlékezetéből, hanem felhalmozott, strukturált tényekből épül.
+
+---
+
+## 🎯 Mit tud / miért érdekes
+
+A legtöbb "napi hírösszefoglaló" automatizáció ugyanabba a falba ütközik: a reggeli brief csak azt látja, ami épp a kontextusában van, ezért vagy üres, vagy minden nap ugyanazt ismétli. Az intel registry ezt választja szét két szerepre:
+
+- **Gyűjtő (intel-collector)**: óránként fut, csendben. Átfésüli az általad megadott témákat (versenytársak, árfolyamok, jogszabályi határidők -- bármi), és minden releváns találatot beír egy SQLite registry-be. Telegramot CSAK riasztás-szintű eseménynél küld (pl. sávon kívüli árfolyam).
+- **Brief (intel-daily-brief)**: reggel 07:00-kor fut, és a registry utolsó 14 napjából épít priorizált összefoglalót: top 3 döntési jel, domainenkénti bontás, watchlist.
+
+Amit ettől kapsz:
+
+- **Deduplikáció**: ugyanaz a hír óránként újra felbukkanhat -- a determinista fact-id és a tartalom-hash miatt update lesz belőle, nem 24 duplikátum.
+- **Tény-életciklus**: egy tény `new` → `evolving` → `stable` → `closed` státuszon megy át; a lezárt és a 14 napnál régebbi tételek kiesnek a briefből.
+- **Watchlist**: ami még nem tény, csak irány ("figyelni érdemes, merre mozdul"), külön listán él, és a brief végén jelenik meg.
+- **Döntésnapló**: az ajánlásokat feltevéssel, bizonyítékkal és falszifikálási feltétellel együtt rögzíti -- utólag visszamérhető, mi jött be.
+
+## 🛠 Hogyan működik
+
+### Komponensek
+
+| Darab | Hely | Szerep |
+|-------|------|--------|
+| Séma + Python API + CLI | `scripts/intel_db.py` | 4 tábla, olvasó/író függvények, argparse CLI |
+| Adatbázis | `store/intel.db` (override: `INTEL_DB` env) | első használatkor magától létrejön |
+| Gyűjtő sablon | `seed-scheduled-tasks/intel-collector/` | óránkénti heartbeat, alapból kikapcsolva |
+| Brief sablon | `seed-scheduled-tasks/intel-daily-brief/` | napi task 07:00, alapból kikapcsolva |
+
+### Táblák
+
+- `known_facts_registry`: id, title, domain, source, source_tier (1-3), status (new/evolving/stable/closed), priority_score (0..1), content, fact_hash (UNIQUE), created/updated/expires_at
+- `watchlist`: követendő irányok, amelyek még nem tények
+- `decision_log`: recommendation, reasoning, assumption, evidence, what_would_falsify, owner_reaction, outcome
+- `active_focus`: aktuálisan kiemelt témák, deep/transient móddal és lejárattal
+
+A séma idempotens (`CREATE TABLE IF NOT EXISTS`), minden CLI-hívás és import biztosítja -- friss telepítésen nincs külön migrációs lépés, de explicit is futtatható: `python3 scripts/intel_db.py init`.
+
+### CLI
+
+```bash
+# Tény beírása (a collector fő útvonala)
+python3 scripts/intel_db.py add-fact \
+  --title "Versenytárs árcsökkentés" --domain market \
+  --source "https://example.com/cikk" --tier 2 \
+  --content "X termék ára 12%-kal csökkent Y piacon" --priority 0.7
+
+# Watchlist / fókusz / döntés
+python3 scripts/intel_db.py add-watch --title "Alapanyag-ár" --domain market --direction "emelkedő trend"
+python3 scripts/intel_db.py add-focus --topic "Q3 beszerzés" --mode deep --days 30
+python3 scripts/intel_db.py log-decision --recommendation "..." --reasoning "..."
+
+# Minden, amit a brief olvas (JSON)
+python3 scripts/intel_db.py dump --days 14   # vagy: --dump
+
+# Health check (sorszámlálók)
+python3 scripts/intel_db.py
+```
+
+Fact-id: ha nem adsz `--id`-t, a CLI determinista azonosítót generál (`<domain>-<YYYYMMDD>-<hash8>`), így ugyanaz a találat ugyanazon a napon update-be fut. Azonos tartalom MÁS id alatt (UNIQUE `fact_hash`) tiszta no-op: `DUPLICATE content already in registry`, exit 0 -- a collector-promptnak nem kell hibaágat kezelnie.
+
+### Bekapcsolás
+
+1. A telepítő a két sablont a `~/.claude/scheduled-tasks/` alá seedeli (`{{INSTALL_DIR}}`, `{{MAIN_AGENT_ID}}`, `{{OWNER_NAME}}` behelyettesítéssel), **kikapcsolt** állapotban.
+2. Írd át az `intel-collector/SKILL.md` DOMAIN blokkjait a saját figyelt témáidra (a "FUTÁS VÉGE" registry-írás rész a fix kontraktus, azt hagyd meg).
+3. Kapcsold be mindkét taskot (dashboard → Ütemezés, vagy `task-config.json` → `"enabled": true`).
+
+### Python API
+
+A brief (vagy bármely más fogyasztó) importálhatja is:
+
+```python
+import sys; sys.path.insert(0, "scripts")
+from intel_db import get_active_registry, get_watchlist, get_active_focus
+```
+
+*Kapcsolódó: [Ütemezett feladatok](scheduled-tasks.md), [Heartbeat + autonómia](heartbeat-autonomy.md), [Dream-engine](dream-engine.md)*

--- a/scripts/__tests__/intel-db.test.sh
+++ b/scripts/__tests__/intel-db.test.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Unit tests for scripts/intel_db.py (intel registry CLI).
+# Run: bash scripts/__tests__/intel-db.test.sh
+
+set -e
+
+PASS=0
+FAIL=0
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CLI="$INSTALL_DIR/scripts/intel_db.py"
+export INTEL_DB="$TMPDIR_BASE/intel.db"
+
+echo "intel_db tests"
+echo "=============="
+
+# --- Test 1: plain run on a fresh install creates the schema and exits 0 ---
+echo ""
+echo "Test 1: plain run bootstraps the schema"
+OUT=$(python3 "$CLI")
+if echo "$OUT" | grep -q "OK"; then
+  pass "no-arg run exits 0 with OK"
+else
+  fail "no-arg run output unexpected: $OUT"
+fi
+TABLES=$(sqlite3 "$INTEL_DB" ".tables")
+for t in known_facts_registry watchlist decision_log active_focus; do
+  if echo "$TABLES" | grep -q "$t"; then
+    pass "table $t exists"
+  else
+    fail "table $t missing"
+  fi
+done
+
+# --- Test 2: explicit init is idempotent ---
+echo ""
+echo "Test 2: init is idempotent"
+python3 "$CLI" init > /dev/null
+python3 "$CLI" init > /dev/null
+pass "init twice exits 0"
+
+# --- Test 3: add-fact generates a deterministic id ---
+echo ""
+echo "Test 3: add-fact deterministic id"
+ID1=$(python3 "$CLI" add-fact --title "T1" --domain market --source "src" --tier 2 --content "price moved 5%")
+DAY=$(date +%Y%m%d)
+if [[ "$ID1" == market-"$DAY"-* ]]; then
+  pass "id has <domain>-<YYYYMMDD>-<hash> shape: $ID1"
+else
+  fail "unexpected id: $ID1"
+fi
+
+# --- Test 4: same content again -> same id -> update, not duplicate ---
+echo ""
+echo "Test 4: repeat sighting is an update"
+ID2=$(python3 "$CLI" add-fact --title "T1b" --domain market --source "src" --tier 2 --content "price moved 5%" --status evolving)
+COUNT=$(sqlite3 "$INTEL_DB" "SELECT COUNT(*) FROM known_facts_registry")
+STATUS=$(sqlite3 "$INTEL_DB" "SELECT status FROM known_facts_registry WHERE id='$ID1'")
+if [ "$ID1" = "$ID2" ] && [ "$COUNT" = "1" ] && [ "$STATUS" = "evolving" ]; then
+  pass "same content upserted in place (1 row, status=evolving)"
+else
+  fail "expected upsert, got id=$ID2 count=$COUNT status=$STATUS"
+fi
+
+# --- Test 5: same content under a DIFFERENT id -> clean no-op ---
+echo ""
+echo "Test 5: duplicate content under another id is a no-op"
+OUT=$(python3 "$CLI" add-fact --id other-id --title "T1c" --domain market --source "src" --tier 2 --content "price moved 5%")
+COUNT=$(sqlite3 "$INTEL_DB" "SELECT COUNT(*) FROM known_facts_registry")
+if echo "$OUT" | grep -q "DUPLICATE" && [ "$COUNT" = "1" ]; then
+  pass "DUPLICATE reported, still 1 row, exit 0"
+else
+  fail "expected DUPLICATE no-op, got: $OUT (count=$COUNT)"
+fi
+
+# --- Test 6: add-watch / add-focus / log-decision write their tables ---
+echo ""
+echo "Test 6: secondary writers"
+python3 "$CLI" add-watch --title "raw material price" --domain market --direction "upward" > /dev/null
+python3 "$CLI" add-focus --topic "Q3 sourcing" --mode deep --days 30 > /dev/null
+python3 "$CLI" log-decision --recommendation "hold" --reasoning "band intact" > /dev/null
+for t in watchlist active_focus decision_log; do
+  N=$(sqlite3 "$INTEL_DB" "SELECT COUNT(*) FROM $t")
+  if [ "$N" = "1" ]; then
+    pass "$t has 1 row"
+  else
+    fail "$t expected 1 row, got $N"
+  fi
+done
+
+# --- Test 7: dump (and --dump alias) returns the fact as JSON ---
+echo ""
+echo "Test 7: dump JSON"
+for form in "dump" "--dump"; do
+  OUT=$(python3 "$CLI" $form)
+  if echo "$OUT" | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+assert len(d['registry']) == 1 and d['registry'][0]['id'] == '$ID1'
+assert len(d['watchlist']) == 1 and len(d['active_focus']) == 1
+"; then
+    pass "$form returns registry+watchlist+active_focus"
+  else
+    fail "$form JSON shape wrong"
+  fi
+done
+
+# --- Test 8: expired focus and closed facts drop out of dump ---
+echo ""
+echo "Test 8: lifecycle filtering"
+sqlite3 "$INTEL_DB" "UPDATE known_facts_registry SET status='closed' WHERE id='$ID1'"
+sqlite3 "$INTEL_DB" "UPDATE active_focus SET expires_at=1"
+OUT=$(python3 "$CLI" dump)
+if echo "$OUT" | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+assert d['registry'] == [] and d['active_focus'] == []
+"; then
+  pass "closed fact and expired focus filtered out"
+else
+  fail "lifecycle filtering broken"
+fi
+
+echo ""
+echo "=============="
+echo "PASS: $PASS  FAIL: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/intel_db.py
+++ b/scripts/intel_db.py
@@ -33,6 +33,8 @@ Usage from Python:
 See docs/intel-registry.md for how the collector and the brief fit together.
 """
 
+from __future__ import annotations
+
 import hashlib
 import os
 import sqlite3

--- a/scripts/intel_db.py
+++ b/scripts/intel_db.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""
+intel_db.py -- Proactive Intelligence registry: schema + Python API + CLI.
+
+A small SQLite-backed store that lets an hourly "collector" scheduled task
+persist findings and a daily "brief" scheduled task read them back, so the
+brief is built from accumulated structured facts instead of whatever happens
+to be in the session context. Ships with two seed task templates:
+seed-scheduled-tasks/intel-collector and seed-scheduled-tasks/intel-daily-brief.
+
+Tables (created automatically on first use, see SCHEMA):
+  known_facts_registry  facts with domain, source tier, status and priority
+  watchlist             directions worth tracking that are not yet facts
+  decision_log          recommendations with reasoning and falsifiability
+  active_focus          currently prioritized topics with expiry
+
+Database location: store/intel.db next to this repo by default; override
+with the INTEL_DB environment variable (absolute path).
+
+CLI (see --help of each subcommand):
+  intel_db.py init                          create the schema (idempotent)
+  intel_db.py add-fact --title .. --domain .. --source .. --tier 1 --content ..
+  intel_db.py add-watch --title .. --domain .. --direction ..
+  intel_db.py add-focus --topic .. [--mode deep|transient] [--days N]
+  intel_db.py log-decision --recommendation .. --reasoning .. ...
+  intel_db.py dump [--days N]               JSON of everything the brief reads
+  intel_db.py                               health counters (row counts)
+
+Usage from Python:
+  import sys; sys.path.insert(0, "scripts")
+  from intel_db import get_active_registry, get_watchlist, get_active_focus
+
+See docs/intel-registry.md for how the collector and the brief fit together.
+"""
+
+import hashlib
+import os
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+
+DB_PATH = Path(
+    os.environ.get("INTEL_DB", Path(__file__).resolve().parent.parent / "store" / "intel.db")
+)
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS known_facts_registry (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  domain TEXT,
+  source TEXT,
+  source_tier INTEGER CHECK(source_tier IN (1,2,3)),
+  status TEXT CHECK(status IN ('new','evolving','stable','closed')),
+  priority_score REAL,
+  content TEXT,
+  fact_hash TEXT UNIQUE,
+  created_at INTEGER,
+  updated_at INTEGER,
+  expires_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS watchlist (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  domain TEXT,
+  direction TEXT,
+  days_tracked INTEGER,
+  notes TEXT,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS decision_log (
+  id TEXT PRIMARY KEY,
+  date INTEGER,
+  recommendation TEXT,
+  reasoning TEXT,
+  assumption TEXT,
+  evidence TEXT,
+  what_would_falsify TEXT,
+  owner_reaction TEXT,
+  outcome TEXT,
+  created_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS active_focus (
+  id TEXT PRIMARY KEY,
+  topic TEXT,
+  mode TEXT CHECK(mode IN ('deep','transient')),
+  started_at INTEGER,
+  expires_at INTEGER,
+  status TEXT CHECK(status IN ('active','closed')),
+  notes TEXT
+);
+"""
+
+
+def _conn():
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(DB_PATH)
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA)
+    return con
+
+
+def init_db() -> None:
+    """Create the database and all tables (idempotent)."""
+    with _conn():
+        pass
+
+
+def get_active_registry(days: int = 14) -> list[dict]:
+    """Return known_facts_registry rows updated within `days` days, excluding closed."""
+    cutoff = int(time.time()) - days * 86400
+    with _conn() as con:
+        rows = con.execute(
+            """
+            SELECT * FROM known_facts_registry
+            WHERE status != 'closed'
+              AND updated_at >= ?
+            ORDER BY priority_score DESC, updated_at DESC
+            """,
+            (cutoff,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_watchlist() -> list[dict]:
+    """Return all watchlist entries ordered by creation date desc."""
+    with _conn() as con:
+        rows = con.execute(
+            "SELECT * FROM watchlist ORDER BY created_at DESC"
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_active_focus() -> list[dict]:
+    """Return active_focus rows with status='active' and not yet expired."""
+    now = int(time.time())
+    with _conn() as con:
+        rows = con.execute(
+            """
+            SELECT * FROM active_focus
+            WHERE status = 'active'
+              AND (expires_at IS NULL OR expires_at > ?)
+            ORDER BY started_at DESC
+            """,
+            (now,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def upsert_registry_fact(
+    id: str,
+    title: str,
+    domain: str,
+    source: str,
+    source_tier: int,
+    content: str,
+    status: str = "new",
+    priority_score: float = 0.5,
+) -> str:
+    """Insert or update a fact in known_facts_registry. Returns the id."""
+    now = int(time.time())
+    fact_hash = hashlib.sha256(content.encode()).hexdigest()[:32]
+    with _conn() as con:
+        existing = con.execute(
+            "SELECT id FROM known_facts_registry WHERE id = ?", (id,)
+        ).fetchone()
+        if existing:
+            con.execute(
+                """
+                UPDATE known_facts_registry
+                SET title=?, domain=?, source=?, source_tier=?, status=?,
+                    priority_score=?, content=?, fact_hash=?, updated_at=?
+                WHERE id=?
+                """,
+                (title, domain, source, source_tier, status,
+                 priority_score, content, fact_hash, now, id),
+            )
+        else:
+            con.execute(
+                """
+                INSERT INTO known_facts_registry
+                  (id, title, domain, source, source_tier, status,
+                   priority_score, content, fact_hash, created_at, updated_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                """,
+                (id, title, domain, source, source_tier, status,
+                 priority_score, content, fact_hash, now, now),
+            )
+    return id
+
+
+def add_watchlist(
+    title: str,
+    domain: str,
+    direction: str,
+    notes: str = "",
+) -> str:
+    """Add a new entry to the watchlist. Returns the generated id."""
+    now = int(time.time())
+    wid = str(uuid.uuid4())
+    with _conn() as con:
+        con.execute(
+            """
+            INSERT INTO watchlist (id, title, domain, direction, days_tracked, notes, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 0, ?, ?, ?)
+            """,
+            (wid, title, domain, direction, notes, now, now),
+        )
+    return wid
+
+
+def add_focus(
+    topic: str,
+    mode: str = "transient",
+    days: int | None = None,
+    notes: str = "",
+) -> str:
+    """Add an active_focus topic; expires after `days` days if given. Returns the id."""
+    now = int(time.time())
+    fid = str(uuid.uuid4())
+    expires_at = now + days * 86400 if days else None
+    with _conn() as con:
+        con.execute(
+            """
+            INSERT INTO active_focus (id, topic, mode, started_at, expires_at, status, notes)
+            VALUES (?, ?, ?, ?, ?, 'active', ?)
+            """,
+            (fid, topic, mode, now, expires_at, notes),
+        )
+    return fid
+
+
+def log_decision(
+    recommendation: str,
+    reasoning: str,
+    assumption: str,
+    evidence: str,
+    what_would_falsify: str,
+    owner_reaction: str = "",
+    outcome: str = "",
+) -> str:
+    """Append a record to decision_log. Returns the generated id."""
+    now = int(time.time())
+    did = str(uuid.uuid4())
+    with _conn() as con:
+        con.execute(
+            """
+            INSERT INTO decision_log
+              (id, date, recommendation, reasoning, assumption, evidence,
+               what_would_falsify, owner_reaction, outcome, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (did, now, recommendation, reasoning, assumption, evidence,
+             what_would_falsify, owner_reaction, outcome, now),
+        )
+    return did
+
+
+def make_fact_id(domain: str, content: str, date_str: str | None = None) -> str:
+    """Deterministic fact id: <domain>-<YYYYMMDD>-<sha256(content)[:8]>.
+
+    The same finding collected twice on the same day maps to the same id, so
+    the collector's repeated hourly runs hit the UPDATE path of
+    upsert_registry_fact instead of piling up duplicates.
+    """
+    day = date_str or time.strftime("%Y%m%d")
+    return f"{domain}-{day}-{hashlib.sha256(content.encode()).hexdigest()[:8]}"
+
+
+def dump_active(days: int = 14) -> dict:
+    """Everything the daily brief reads, as one JSON-serializable dict."""
+    return {
+        "registry": get_active_registry(days),
+        "watchlist": get_watchlist(),
+        "active_focus": get_active_focus(),
+    }
+
+
+def _cli() -> int:
+    """argparse CLI so agent prompts can write the registry without inline Python."""
+    import argparse
+    import json
+    import sys
+
+    # The daily-brief task calls `intel_db.py --dump`; accept the flag form as
+    # an alias for the subcommand so that contract keeps working.
+    argv = sys.argv[1:]
+    if argv and argv[0] == "--dump":
+        argv = ["dump"] + argv[1:]
+
+    parser = argparse.ArgumentParser(description="Proactive Intelligence registry CLI")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sub.add_parser("init", help="Create the database and schema (idempotent)")
+
+    p_fact = sub.add_parser("add-fact", help="Upsert a fact into known_facts_registry")
+    p_fact.add_argument("--id", help="Fact id; omitted -> deterministic <domain>-<YYYYMMDD>-<hash8>")
+    p_fact.add_argument("--title", required=True)
+    p_fact.add_argument("--domain", required=True, help="free-form topic slug, e.g. market / finance / legal")
+    p_fact.add_argument("--source", required=True, help="URL or source name")
+    p_fact.add_argument("--tier", required=True, type=int, choices=(1, 2, 3), help="source tier (1=primary)")
+    p_fact.add_argument("--content", required=True)
+    p_fact.add_argument("--status", default="new", choices=("new", "evolving", "stable", "closed"))
+    p_fact.add_argument("--priority", default=0.5, type=float, help="priority_score 0..1")
+
+    p_watch = sub.add_parser("add-watch", help="Add a watchlist entry")
+    p_watch.add_argument("--title", required=True)
+    p_watch.add_argument("--domain", required=True)
+    p_watch.add_argument("--direction", required=True, help="what movement/direction is being tracked")
+    p_watch.add_argument("--notes", default="")
+
+    p_focus = sub.add_parser("add-focus", help="Add an active_focus topic")
+    p_focus.add_argument("--topic", required=True)
+    p_focus.add_argument("--mode", default="transient", choices=("deep", "transient"))
+    p_focus.add_argument("--days", type=int, help="expire after N days (omit = no expiry)")
+    p_focus.add_argument("--notes", default="")
+
+    p_dec = sub.add_parser("log-decision", help="Append a decision_log record")
+    p_dec.add_argument("--recommendation", required=True)
+    p_dec.add_argument("--reasoning", required=True)
+    p_dec.add_argument("--assumption", default="")
+    p_dec.add_argument("--evidence", default="")
+    p_dec.add_argument("--what-would-falsify", default="")
+    p_dec.add_argument("--owner-reaction", default="")
+    p_dec.add_argument("--outcome", default="")
+
+    p_dump = sub.add_parser("dump", help="Print registry + watchlist + active_focus as JSON")
+    p_dump.add_argument("--days", default=14, type=int)
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "init":
+        init_db()
+        print(f"OK: schema ready at {DB_PATH}")
+        return 0
+
+    if args.cmd == "add-fact":
+        fact_id = args.id or make_fact_id(args.domain, args.content)
+        try:
+            upsert_registry_fact(
+                id=fact_id, title=args.title, domain=args.domain, source=args.source,
+                source_tier=args.tier, content=args.content, status=args.status,
+                priority_score=max(0.0, min(1.0, args.priority)),
+            )
+        except sqlite3.IntegrityError:
+            # fact_hash is UNIQUE: same content under a DIFFERENT id means the
+            # fact is already known -- a repeat sighting, not an error.
+            print(f"DUPLICATE content already in registry (id={fact_id} skipped)")
+            return 0
+        print(fact_id)
+        return 0
+
+    if args.cmd == "add-watch":
+        print(add_watchlist(args.title, args.domain, args.direction, args.notes))
+        return 0
+
+    if args.cmd == "add-focus":
+        print(add_focus(args.topic, args.mode, args.days, args.notes))
+        return 0
+
+    if args.cmd == "log-decision":
+        print(log_decision(
+            args.recommendation, args.reasoning, args.assumption, args.evidence,
+            args.what_would_falsify, args.owner_reaction, args.outcome,
+        ))
+        return 0
+
+    if args.cmd == "dump":
+        print(json.dumps(dump_active(args.days), ensure_ascii=False, indent=2))
+        return 0
+
+    # No subcommand: health counters (also creates the schema on first run).
+    print(f"DB: {DB_PATH}")
+    print(f"Active registry (14d): {len(get_active_registry())} rows")
+    print(f"Watchlist: {len(get_watchlist())} rows")
+    print(f"Active focus: {len(get_active_focus())} rows")
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/seed-scheduled-tasks/intel-collector/SKILL.md
+++ b/seed-scheduled-tasks/intel-collector/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: intel-collector
+description: Proaktív hírszerző -- óránkénti gyűjtés a saját figyelt témáidban, eredmény az intel registry-be (store/intel.db). A napi brief (intel-napi-brief) ebből épül.
+---
+
+# Proaktív hírszerző -- óránkénti gyűjtő ciklus
+
+> ⚠️ SABLON: alapból KIKAPCSOLVA érkezik (task-config.json: `"enabled": false`).
+> Mielőtt bekapcsolod, cseréld le az alábbi DOMAIN blokkokat a SAJÁT figyelt
+> témáidra. A "FUTÁS VÉGE" szakasz (registry-írás) a rendszer fix része, azt
+> ne vedd ki -- az táplálja a napi briefet.
+
+Cél: a megadott domainek átfésülése, és MINDEN releváns találat beírása a
+registry-be. CSAK akkor küldj Telegram üzenetet a tulajdonosnak ({{OWNER_NAME}}),
+ha riasztás-szintű esemény van (általad definiált küszöb átlépése, sürgős
+határidő). Egyébként csendes futás: registry + napi napló.
+
+## DOMAIN 1 -- [CSERÉLD LE: pl. iparági hírek / versenytársak]
+
+1. WebSearch query-k (2-4 darab, a te témádra szabva):
+   - "[KULCSSZÓ 1] 2026" site:[MEGBÍZHATÓ FORRÁS]
+   - "[VERSENYTÁRS NÉV]" (legfrissebb hír)
+
+2. Minden találatnál rövid triage: tartalmaz-e számszerű adatot, bejelentést,
+   határidőt ami a tulajdonost érinti? Ha van helyi LLM (Ollama MCP), az
+   előszűrést delegálhatod oda IGEN/NEM formátumban -- token-takarékos.
+
+3. Csak a releváns rekordokat dolgozd fel. Ha a saját küszöbödet átlépi
+   (pl. >X% árelmozdulás) -> Telegram értesítés.
+
+## DOMAIN 2 -- [CSERÉLD LE: pl. árfolyamok / piaci adatok]
+
+1. WebFetch [HIVATALOS FORRÁS URL, pl. jegybanki árfolyamoldal]
+   Sáv-trigger példa: ha az érték a [ALSÓ]..[FELSŐ] sávon kívül van -> AZONNALI Telegram.
+
+2. Ritkább ellenőrzések időkapuval (pl. csak 09:00-kor, csak hétfőn, csak a
+   hónap 1-jén): így az óránkénti futás olcsó marad. Első lépésként `date`
+   Bash paranccsal nézd meg a pontos időt.
+
+## DOMAIN 3 -- [CSERÉLD LE: pl. jogszabály / pályázat / határidők -- vagy töröld]
+
+1. WebFetch [FORRÁS URL]
+   Triage: van-e új kör / új határidő? Ha IGEN -> Telegram.
+
+## FUTÁS VÉGE (fix rész -- ez táplálja a napi briefet)
+
+1. REGISTRY-ÍRÁS (kötelező): MINDEN releváns találatot írj be a
+   known_facts_registry-be a CLI-vel:
+   ```
+   python3 {{INSTALL_DIR}}/scripts/intel_db.py add-fact \
+     --title "RÖVID CÍM" --domain <a-te-domain-sluggod> \
+     --source "URL vagy forrásnév" --tier <1|2|3> \
+     --content "A tény tömör tartalma számokkal" --priority <0.0-1.0>
+   ```
+   - Az --id-t NE add meg: a CLI determinista id-t generál (domain-YYYYMMDD-hash8),
+     így az óránkénti ismételt találat update lesz, nem duplikátum.
+   - "DUPLICATE content already in registry" kimenet = már ismert tény, rendben, lépj tovább.
+   - priority ökölszabály: riasztás-szintű trigger = 0.9; számszerű adat vagy
+     határidő = 0.7; egyéb releváns = 0.5. Tier-1 forrás: +0.1, tier-3: -0.1
+     (0..1 közé vágva).
+   - Ha egy KORÁBBI tény fejlődött tovább (ugyanaz a téma új számmal), ugyanazzal
+     az --id-vel írd felül és --status evolving.
+2. Új követendő irány (még nem tény, de figyelni érdemes): add-watch:
+   ```
+   python3 {{INSTALL_DIR}}/scripts/intel_db.py add-watch \
+     --title "MIT" --domain <domain> --direction "MERRE mozdulhat" --notes "MIÉRT"
+   ```
+3. POST /api/daily-log (agent_id: {{MAIN_AGENT_ID}}) -- mi futott, hány fact
+   került a registry-be, státusz.
+4. Ha nincs riasztás: csend (a registry-írás NEM riasztás, arról nem megy Telegram).
+5. Ha riasztás: Telegram a tulajdonosnak, tömören, actionable formában.

--- a/seed-scheduled-tasks/intel-collector/task-config.json
+++ b/seed-scheduled-tasks/intel-collector/task-config.json
@@ -1,0 +1,8 @@
+{
+  "schedule": "0 * * * *",
+  "agent": "{{MAIN_AGENT_ID}}",
+  "enabled": false,
+  "type": "heartbeat",
+  "skipIfBusy": true,
+  "createdAt": 0
+}

--- a/seed-scheduled-tasks/intel-daily-brief/SKILL.md
+++ b/seed-scheduled-tasks/intel-daily-brief/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: intel-daily-brief
+description: Proaktív hírszerző -- napi brief 07:00-kor az intel registry-ből (store/intel.db). Az intel-collector párja, azzal együtt kapcsold be.
+---
+
+# Proaktív hírszerző -- napi brief
+
+> ⚠️ SABLON: alapból KIKAPCSOLVA érkezik (task-config.json: `"enabled": false`).
+> Az intel-collector taskkal együtt kapcsold be -- a brief abból a registry-ből
+> épül, amit a collector tölt fel.
+
+## Adatok betöltése
+
+Futtasd: `python3 {{INSTALL_DIR}}/scripts/intel_db.py --dump`
+(JSON: registry utolsó 14 nap + watchlist + active_focus.)
+
+## Priority Score (Claude végzi, nem a collector)
+
+Minden Registry tételre: Relevancia 40% + Sürgősség 25% + Hatás a tulajdonosra
+20% + Megbízhatóság (forrás-tier) 15%. Alacsony konfidenciájú tétel: max
+Watchlist-említés, nem kerül a brief törzsébe.
+
+## Brief formátum (Telegram, MarkdownV2)
+
+```
+📊 Mai állapot: Nyugodt / Figyelendő / Feszült / Kritikus
+⭐ Top 3 döntési jel ma: 1. ... 2. ... 3. ...
+
+🟦 [DOMAIN NÉV]
+• Mi történt: [1 mondat, forrás + tier]
+  → Miért számít: [...] → Hatás: 🔴/🟠/🟢
+  → Mit tehetsz: [akció vagy "csak figyeld"]
+
+🔍 Mi maradt ki: X ismétlés · Y gyenge forrás
+👁 Watchlist: [...] 🎯 Aktív fókusz: [...]
+```
+
+Üres domain: hagyd ki teljesen, ne írj "nincs mozgás" sorokat.
+
+## Küldés
+
+Telegram a tulajdonosnak ({{OWNER_NAME}}) a reply tool-lal, MarkdownV2 formátumban.
+Escapelni kell: . - ( ) + = ! { } [ ] | ~ > # karaktereket.
+
+## Ha a Registry üres
+
+Küldd: "📊 Reggeli brief: az adatgyűjtés még inicializálás alatt. Az óránkénti
+ciklus ma feltölti a Registry-t." Ha 2+ napja üres, jelezd hogy az
+intel-collector task valószínűleg nem fut vagy nem ír a registry-be.

--- a/seed-scheduled-tasks/intel-daily-brief/task-config.json
+++ b/seed-scheduled-tasks/intel-daily-brief/task-config.json
@@ -1,0 +1,8 @@
+{
+  "schedule": "0 7 * * *",
+  "agent": "{{MAIN_AGENT_ID}}",
+  "enabled": false,
+  "type": "task",
+  "skipIfBusy": false,
+  "createdAt": 0
+}


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [x] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

Generalized follow-up to #558, which was closed with an invitation to contribute the whole proactive-intelligence subsystem "in a generalized form (schema + collector + the brief wiring, with config placeholders instead of personal values)". This PR ships exactly that, self-contained:

**`scripts/intel_db.py`** — schema + Python API + argparse CLI for the intel registry (4 tables: `known_facts_registry`, `watchlist`, `decision_log`, `active_focus`).
- The schema is embedded and idempotent (`CREATE TABLE IF NOT EXISTS`), ensured on every connect plus an explicit `init` subcommand — a plain run on a fresh install now bootstraps the DB and prints health counters instead of exiting.
- No install-specific values: DB path defaults to repo-relative `store/intel.db`, overridable via `INTEL_DB`; the personal column name from #558 is generalized (`arnold_reaction` → `owner_reaction`); domain slugs are free-form.
- Every table has a writer (`add-fact`, `add-watch`, `add-focus`, `log-decision`) so no dead tables; `dump` / `--dump` emits the JSON the brief reads.
- Dedup contract: omitted `--id` yields a deterministic `<domain>-<YYYYMMDD>-<hash8>` id (hourly repeat sightings become updates), and identical content under a different id (UNIQUE `fact_hash`) is a clean no-op with exit 0.

**`seed-scheduled-tasks/intel-collector/`** — hourly heartbeat template. Domain blocks are explicit `[CSERÉLD LE]` placeholders the user customizes; the registry-write section is documented as the fixed contract. Ships `"enabled": false` (same dormant-seed pattern as `post-rollback-diagnose`) so it never fires with placeholder content. Uses only installer placeholders (`{{INSTALL_DIR}}`, `{{MAIN_AGENT_ID}}`, `{{OWNER_NAME}}`).

**`seed-scheduled-tasks/intel-daily-brief/`** — 07:00 task template: reads `intel_db.py --dump`, scores and formats the MarkdownV2 brief, degrades gracefully on an empty registry (and flags a probably-dead collector after 2+ empty days). Also `enabled: false`.

**Docs**: `docs/intel-registry.md` (🎯/🛠 structure like the other feature pages) + index row in `docs/README.md`.

**Tests**: `scripts/__tests__/intel-db.test.sh` following the existing shell-test pattern — 15 assertions on an isolated temp DB (`INTEL_DB` override): fresh-install bootstrap, idempotent init, deterministic ids, upsert/dedup paths, secondary writers, dump JSON shape (both invocation forms), lifecycle filtering (closed facts / expired focus drop out of dump).

Test run:
```
$ bash scripts/__tests__/intel-db.test.sh
...
PASS: 15  FAIL: 0
$ python3 -m py_compile scripts/intel_db.py   # clean
```

Stdlib only, no network, no credential access (same properties as #558).

## Kapcsolódó issue / Related issue

Follow-up to #558 (closed with a request for this generalized form).

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors. *(A non-generalized variant of this subsystem has been running in production on our install since 2026-06-28; the generalized CLI itself is covered by the included test suite.)*
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
