### PR TITLE
Channel self-heal, sub-agent inbox wake-nudge, and Graphify dashboard panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ scripts/support-mail/no-support-reply.html
 # Python bytecode cache
 __pycache__/
 *.pyc
+web/icons/graphify-graph.html

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -46,6 +46,32 @@ case "$CHANNEL_PROVIDER" in
   *)        PLUGIN_ID="telegram@claude-plugins-official" ;;
 esac
 
+# Self-healing guard: ensure PLUGIN_ID is enabled in both project and global
+# settings.json before launch. Any PR review-reset or branch-switch that
+# reverts .claude/settings.json loses this entry; the guard re-adds it
+# automatically, preventing silent Telegram outages.
+_ensure_plugin_enabled() {
+  local settings_file="$1"
+  [ -f "$settings_file" ] || return
+  python3 - "$settings_file" "$PLUGIN_ID" <<'PYEOF'
+import json, sys
+path, plugin_id = sys.argv[1], sys.argv[2]
+try:
+    d = json.load(open(path))
+except Exception:
+    d = {}
+plugins = d.setdefault("enabledPlugins", {})
+if plugins.get(plugin_id) is not True:
+    plugins[plugin_id] = True
+    with open(path, "w") as f:
+        json.dump(d, f, indent=2)
+    print(f"channels.sh: enabled {plugin_id} in {path}", flush=True)
+PYEOF
+}
+_ensure_plugin_enabled "$INSTALL_DIR/.claude/settings.json"
+_ensure_plugin_enabled "$HOME/.claude/settings.json"
+unset -f _ensure_plugin_enabled
+
 # ROOT-CAUSE NOTE (kali-linux WSL, claude-code 2.1.152, 2026-05-27):
 # Inbound MCP notifications from the `--channels` plugin go through a SECOND
 # gate beyond --dangerously-skip-permissions / --dangerously-load-development-

--- a/scripts/regen-graphify.sh
+++ b/scripts/regen-graphify.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# regen-graphify.sh -- rebuild the Graphify knowledge-graph HTML for the dashboard.
+#
+# The dashboard "Graphify" panel serves web/icons/graphify-graph.html, which is
+# gitignored (a ~2.5MB generated artifact, see .gitignore). After a fresh
+# checkout/deploy that file is missing, so the iframe would 404. This script
+# regenerates it from the current src/ using tree-sitter AST (zero API cost),
+# plus local ollama community naming when available.
+#
+# Best-effort and idempotent: if graphify or its inputs are absent it exits 0
+# without touching anything, so it NEVER breaks a deploy. Re-uses the graphify
+# extract cache under store/ so repeat runs only re-parse changed files.
+
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_DIR="$PROJECT_ROOT/src"
+DEST="$PROJECT_ROOT/web/icons/graphify-graph.html"
+WORK="$PROJECT_ROOT/store/graphify-work"
+OLLAMA_MODEL="qwen2.5-coder:7b"
+
+# graphify installs as a uv tool under ~/.local/bin; make sure it is on PATH.
+export PATH="$HOME/.local/bin:$PATH"
+# Do not spam ~/.cache/graphify-queries.log during an unattended deploy run.
+export GRAPHIFY_QUERY_LOG_DISABLE=1
+
+# --- Graceful skips: never fail a deploy just because graphify is absent. -----
+if ! command -v graphify >/dev/null 2>&1; then
+  echo "regen-graphify: graphify not installed (uv tool install graphifyy) -- skipping."
+  exit 0
+fi
+if [ ! -d "$SRC_DIR" ]; then
+  echo "regen-graphify: $SRC_DIR missing -- skipping."
+  exit 0
+fi
+
+mkdir -p "$WORK"
+
+# --- 1. Index the codebase: local tree-sitter AST only, no API key, no cost. --
+echo "regen-graphify: indexing $SRC_DIR (code-only, tree-sitter AST)..."
+if ! graphify extract "$SRC_DIR" --code-only --out "$WORK" >/dev/null 2>&1; then
+  echo "regen-graphify: extract failed -- keeping the existing graph."
+  exit 1
+fi
+
+# --- 2. Build graph.html. Prefer local ollama naming (zero cost); fall back ---
+#        to placeholder community names if ollama or the model is unavailable.
+if curl -fsS -m 3 -o /dev/null http://localhost:11434/api/tags 2>/dev/null \
+   && curl -fsS -m 3 http://localhost:11434/api/tags 2>/dev/null | grep -q "$OLLAMA_MODEL"; then
+  echo "regen-graphify: naming communities via local ollama ($OLLAMA_MODEL)..."
+  graphify label "$WORK" --backend=ollama --model="$OLLAMA_MODEL" >/dev/null 2>&1 \
+    || graphify cluster-only "$WORK" --no-label >/dev/null 2>&1
+else
+  echo "regen-graphify: ollama/$OLLAMA_MODEL unavailable -- placeholder community names."
+  graphify cluster-only "$WORK" --no-label >/dev/null 2>&1
+fi
+
+# --- 3. Publish the freshly built graph to the dashboard-served location. -----
+GRAPH_HTML="$WORK/graphify-out/graph.html"
+if [ ! -s "$GRAPH_HTML" ]; then
+  echo "regen-graphify: graph.html not produced -- keeping the existing graph."
+  exit 1
+fi
+mkdir -p "$(dirname "$DEST")"
+cp "$GRAPH_HTML" "$DEST"
+echo "regen-graphify: updated $DEST ($(du -h "$DEST" | cut -f1))."
+exit 0

--- a/src/__tests__/telegram-inbox-wake.test.ts
+++ b/src/__tests__/telegram-inbox-wake.test.ts
@@ -1,0 +1,50 @@
+// Tests for the sub-agent Telegram inbox wake-nudge.
+//
+// The pure gate decision (shouldWakeForTelegramInbox) is tested exhaustively
+// with no filesystem or tmux, mirroring shouldWakeMainAgent. All five conditions
+// (hasPending + age + debounce + session-exists + session-idle) are exercised.
+
+import { describe, it, expect } from 'vitest'
+import { shouldWakeForTelegramInbox } from '../web/telegram-inbox-wake.js'
+
+const BASE = {
+  inboxAgeMs: 60_000,
+  hasPending: true,
+  now: 1_000_000_000,
+  lastWakeAt: 0,
+  sessionExists: true,
+  sessionIdle: true,
+  minAgeMs: 25_000,
+  debounceMs: 60_000,
+}
+
+describe('shouldWakeForTelegramInbox (pure gate decision)', () => {
+  it('wakes when inbox has pending content, is old enough, session idle, debounce elapsed', () => {
+    expect(shouldWakeForTelegramInbox(BASE)).toBe(true)
+  })
+
+  it('does NOT wake when there is nothing pending', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, hasPending: false })).toBe(false)
+  })
+
+  it('does NOT wake for a fresh inbox (age gate, strict >)', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, inboxAgeMs: 10_000 })).toBe(false)
+    // exactly at the threshold is still not old enough
+    expect(shouldWakeForTelegramInbox({ ...BASE, inboxAgeMs: 25_000 })).toBe(false)
+    expect(shouldWakeForTelegramInbox({ ...BASE, inboxAgeMs: 25_001 })).toBe(true)
+  })
+
+  it('does NOT wake within the debounce window of the last nudge', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, lastWakeAt: BASE.now - 30_000 })).toBe(false)
+    // exactly at the debounce boundary is allowed
+    expect(shouldWakeForTelegramInbox({ ...BASE, lastWakeAt: BASE.now - 60_000 })).toBe(true)
+  })
+
+  it('does NOT wake when the sub-agent session is absent', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, sessionExists: false })).toBe(false)
+  })
+
+  it('does NOT wake when the session is busy/mid-turn -- avoids the inject race', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, sessionIdle: false })).toBe(false)
+  })
+})

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -17,6 +17,7 @@ import {
 import { setLastInboundModality } from './voice-modality.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from './agent-message-wrap.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { maybeWakeSubAgentsForTelegram } from './telegram-inbox-wake.js'
 
 // A message that cannot be delivered within this window (target session never
 // exists / stays busy) is marked failed so it stops clogging the pending
@@ -237,6 +238,12 @@ export async function runMessageRouterTick(): Promise<void> {
         routerLoggedMisses.delete(msg.id)
       }
     }
+
+    // Independently of the inter-agent queue above: wake idle sub-agents whose
+    // Telegram inbox (inbox-pending.jsonl) has stuck inbound messages the drain
+    // hook cannot pull without a turn. Runs every tick; cheap statSync-gated so
+    // an empty fleet costs one stat per agent and no tmux I/O.
+    maybeWakeSubAgentsForTelegram(now)
 }
 
 // ---- voice helpers (message-router level) ----------------------------------

--- a/src/web/telegram-inbox-wake.ts
+++ b/src/web/telegram-inbox-wake.ts
@@ -1,0 +1,156 @@
+import { statSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID } from '../config.js'
+import { resolveAgentChannelStateDir } from './voice-directive.js'
+import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
+import {
+  agentSessionName,
+  isSessionReadyForPrompt,
+  sendPromptToSession,
+  sessionExistsOnHost,
+} from './agent-process.js'
+
+// --- sub-agent Telegram inbox wake-nudge --------------------------------------
+// Extends the main-agent wake-nudge (message-router.ts) to the
+// sub-agents. Sub-agents load the official channel plugin
+// as a plain MCP server (per-agent mcp.json) to dodge the plugin in_use lock, so
+// Claude Code drops that server's channel notifications. scripts/channel-inbound-
+// tee.mjs persists each inbound to <state>/inbox-pending.jsonl, and the
+// channel-inbox-drain.py UserPromptSubmit hook pulls it into the NEXT turn.
+//
+// The gap: the drain hook only fires when the agent takes a turn. An idle
+// sub-agent (no user prompt, no --channels registration to start one) never
+// drains, so a Telegram message can sit in inbox-pending.jsonl forever. This
+// watcher closes that gap the same way the main agent's does: when a sub-agent's
+// pending inbox has been stuck long enough AND its tmux session is idle, inject a
+// minimal, CONTENT-FREE prompt so the drain hook fires and claims the backlog.
+//
+// The nudge carries NO content and does NOT touch the inbox file: the drain hook
+// owns the atomic claim (rename) and the <channel> security framing (single
+// source, no drift). This is the exact operation the scheduler already performs
+// against sub-agent sessions for heartbeats (sendPromptToSession, idle-gated) --
+// only the trigger differs, which is why the risk is low.
+
+// How long the pending inbox must have sat untouched before the first wake-nudge.
+// Measured as now - mtime(inbox-pending.jsonl): the age of the LAST inbound. A
+// fresh file means a message just arrived (let the natural drain try first, or
+// let a burst finish arriving before we nudge once for the whole batch).
+const SUB_TELEGRAM_WAKE_MIN_AGE_MS = 25 * 1000
+// Minimum gap between wake-nudges per agent. One nudge starts a turn whose drain
+// claims the WHOLE pending file, so re-nudging sooner just piles redundant
+// prompts on a session already handling its inbox.
+const SUB_TELEGRAM_WAKE_DEBOUNCE_MS = 60 * 1000
+// Content-free wake prompt. The channel-inbox-drain UserPromptSubmit hook
+// PREPENDS the claimed (already security-framed) <channel> messages above this
+// line, so the nudge is only a trailing trigger -- it must never carry inbound
+// content itself.
+const SUB_TELEGRAM_WAKE_NUDGE =
+  '[telegram-wake] Bejövő Telegram üzenet(ek) várnak; a drain hook behúzta őket a kontextusba fentebb. Dolgozd fel és válaszolj.'
+
+// Last wake-nudge timestamp per agent name (module-scoped debounce state).
+const _lastSubWakeAt = new Map<string, number>()
+
+/**
+ * Pure decision: should the watcher send a wake-nudge to a sub-agent's session
+ * for a stuck Telegram inbox? Dependency-free so it is unit-testable without
+ * tmux or the filesystem, mirroring shouldWakeMainAgent. ALL conditions hold:
+ *   - the inbox has pending content (nothing to drain otherwise);
+ *   - it has sat untouched longer than minAgeMs (let a fresh arrival drain via a
+ *     natural turn / let a burst settle first);
+ *   - the debounce window since the last nudge for THIS agent has elapsed;
+ *   - the session exists (nothing to wake otherwise);
+ *   - it is idle (never inject a prompt mid-turn -- that is the race the main
+ *     wake-nudge was designed to avoid).
+ */
+export function shouldWakeForTelegramInbox(params: {
+  inboxAgeMs: number
+  hasPending: boolean
+  now: number
+  lastWakeAt: number
+  sessionExists: boolean
+  sessionIdle: boolean
+  minAgeMs: number
+  debounceMs: number
+}): boolean {
+  const { inboxAgeMs, hasPending, now, lastWakeAt, sessionExists, sessionIdle, minAgeMs, debounceMs } = params
+  if (!hasPending) return false
+  if (inboxAgeMs <= minAgeMs) return false
+  if (now - lastWakeAt < debounceMs) return false
+  if (!sessionExists) return false
+  if (!sessionIdle) return false
+  return true
+}
+
+// I/O wrapper around shouldWakeForTelegramInbox: for each sub-agent, probes the
+// pending-inbox file and (only when it looks stuck) the session's presence and
+// idle state, then nudges. Called once per message-router tick.
+//
+// Cheap gates run FIRST so the common case (no stuck inbox) costs one statSync
+// per agent and ZERO tmux I/O: isSessionReadyForPrompt does a blocking sleep +
+// two capture-panes, so probing it for every agent every tick would pin the
+// event loop. Only an agent with a genuinely stuck, out-of-debounce inbox pays
+// for the session probe.
+export function maybeWakeSubAgentsForTelegram(now: number): void {
+  let names: string[]
+  try {
+    names = listAgentNames()
+  } catch (err) {
+    logger.warn({ err }, 'telegram-inbox-wake: listAgentNames failed')
+    return
+  }
+  for (const name of names) {
+    // The main agent runs with --channels and receives notifications natively;
+    // it has no local derived inbox to drain.
+    if (name === MAIN_AGENT_ID) continue
+    try {
+      const stateDir = resolveAgentChannelStateDir(name, 'telegram')
+      const inboxPath = join(stateDir, 'inbox-pending.jsonl')
+      let size: number
+      let mtimeMs: number
+      try {
+        const st = statSync(inboxPath)
+        size = st.size
+        mtimeMs = st.mtimeMs
+      } catch {
+        continue // no inbox file -> nothing pending for this agent
+      }
+      if (size === 0) continue
+      const inboxAgeMs = now - mtimeMs
+      // Cheap gates before any tmux I/O (mirrors maybeWakeMainAgent).
+      if (inboxAgeMs <= SUB_TELEGRAM_WAKE_MIN_AGE_MS) continue
+      const lastWakeAt = _lastSubWakeAt.get(name) ?? 0
+      if (now - lastWakeAt < SUB_TELEGRAM_WAKE_DEBOUNCE_MS) continue
+
+      const host = readAgentRemoteHost(name)
+      const session = agentSessionName(name)
+      const sessionExists = sessionExistsOnHost(host, session)
+      // isSessionReadyForPrompt already reports a widget-over-idle ('unknown')
+      // pane as NOT ready, so a TodoWrite-widget session is conservatively left
+      // alone rather than nudged mid-widget -- the safe default for injection.
+      const sessionIdle = sessionExists && isSessionReadyForPrompt(session, host)
+
+      if (!shouldWakeForTelegramInbox({
+        inboxAgeMs,
+        hasPending: true,
+        now,
+        lastWakeAt,
+        sessionExists,
+        sessionIdle,
+        minAgeMs: SUB_TELEGRAM_WAKE_MIN_AGE_MS,
+        debounceMs: SUB_TELEGRAM_WAKE_DEBOUNCE_MS,
+      })) continue
+
+      sendPromptToSession(session, SUB_TELEGRAM_WAKE_NUDGE, host)
+      _lastSubWakeAt.set(name, now)
+      logger.info({ agent: name, session, ageMs: Math.round(inboxAgeMs) }, 'telegram-inbox-wake: nudged idle sub-agent (pending inbox)')
+    } catch (err) {
+      logger.warn({ err, agent: name }, 'telegram-inbox-wake: wake check failed')
+    }
+  }
+}
+
+// Test-only: reset the per-agent debounce state between unit tests.
+export function _resetSubWakeStateForTest(): void {
+  _lastSubWakeAt.clear()
+}

--- a/update.sh
+++ b/update.sh
@@ -433,6 +433,16 @@ if [ -x "$INSTALL_DIR/scripts/sync-hooks.sh" ]; then
   bash "$INSTALL_DIR/scripts/sync-hooks.sh" || echo -e "  FIGYELEM: sync-hooks.sh nem-nulla exit; manualisan ellenorizd."
 fi
 
+# Graphify tudasgraf regeneralasa (best-effort). A web/icons/graphify-graph.html
+# gitignore-olt runtime artifact, ezert friss checkout utan hianyzik -> a dashboard
+# Graphify panelje 404-ezne. Ez a script ujraepiti a friss src/-bol (tree-sitter
+# AST + lokalis ollama nevadas, nulla API-koltseg); graphify/ollama hianyaban
+# gracefully kilep, a deployt nem tori.
+if [ -x "$INSTALL_DIR/scripts/regen-graphify.sh" ]; then
+  echo -e "  Graphify graf frissitese (hatterben)..."
+  setsid bash "$INSTALL_DIR/scripts/regen-graphify.sh" </dev/null >>"$INSTALL_DIR/store/regen-graphify.log" 2>&1 &
+fi
+
 # Seed skills & scheduled tasks (idempotent: skip existing)
 # Source .env for template variables needed by seed-scheduled-tasks
 MAIN_AGENT_ID=""

--- a/web/app.js
+++ b/web/app.js
@@ -290,6 +290,11 @@ function switchPage(pageId) {
   if (pageId === 'ideas') loadIdeasPage()
   if (pageId === 'archived') loadArchivedPage()
   if (pageId === 'naplo') loadNaplo()
+  // Graphify: lazy-load the ~2.5MB standalone graph iframe only on first entry.
+  if (pageId === 'graphify') {
+    const gf = document.getElementById('graphifyFrame')
+    if (gf && !gf.src) gf.src = gf.dataset.src
+  }
 }
 
 // Mobile off-canvas sidebar toggle. No-op visual effect on desktop (the

--- a/web/index.html
+++ b/web/index.html
@@ -159,6 +159,10 @@
         <span class="sb-label">Frissítések</span>
         <span class="updates-badge sb-badge" id="updatesBadge" hidden></span>
       </a>
+      <a href="#" class="sb-link" data-page="graphify">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="2.5"/><circle cx="19" cy="6" r="2.5"/><circle cx="12" cy="18" r="2.5"/><line x1="7" y1="7" x2="10.5" y2="16"/><line x1="17" y1="7" x2="13.5" y2="16"/><line x1="7.3" y1="6" x2="16.7" y2="6"/></svg>
+        <span class="sb-label">Graphify</span>
+      </a>
     </nav>
     <div class="sidebar-footer">
       <button class="theme-toggle" id="langToggle" title="Language / Nyelv">HU</button>
@@ -1664,6 +1668,16 @@
       </div>
 
       <div id="costsContent"></div>
+    </div>
+
+    <!-- Graphify page -->
+    <div class="page" id="graphifyPage" hidden>
+      <div class="page-header">
+        <h1>Graphify</h1>
+        <p class="subtitle">Marveen <code>src/</code> kódbázis interaktív tudásgráf. D3 force-directed, tree-sitter AST (2123 node, 6165 edge)</p>
+      </div>
+      <iframe id="graphifyFrame" data-src="/icons/graphify-graph.html" title="Marveen Graphify graph" loading="lazy"
+        style="width:100%;height:calc(100vh - 190px);min-height:480px;border:1px solid var(--border,#333);border-radius:8px;background:#fff"></iframe>
     </div>
 
     <!-- Naplo page -->

--- a/web/index.html
+++ b/web/index.html
@@ -102,6 +102,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3C7.5 3 4 6.5 4 11v4l-2 3h4v2a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v0a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v-2h4l-2-3v-4c0-4.5-3.5-8-8-8z"/></svg>
         <span class="sb-label">Memória</span>
       </a>
+      <a href="#" class="sb-link" data-page="graphify">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="2.5"/><circle cx="19" cy="6" r="2.5"/><circle cx="12" cy="18" r="2.5"/><line x1="7" y1="7" x2="10.5" y2="16"/><line x1="17" y1="7" x2="13.5" y2="16"/><line x1="7.3" y1="6" x2="16.7" y2="6"/></svg>
+        <span class="sb-label">Graphify</span>
+      </a>
       <a href="#" class="sb-link" data-page="naplo">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
         <span class="sb-label">Napló</span>
@@ -158,10 +162,6 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
         <span class="sb-label">Frissítések</span>
         <span class="updates-badge sb-badge" id="updatesBadge" hidden></span>
-      </a>
-      <a href="#" class="sb-link" data-page="graphify">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="2.5"/><circle cx="19" cy="6" r="2.5"/><circle cx="12" cy="18" r="2.5"/><line x1="7" y1="7" x2="10.5" y2="16"/><line x1="17" y1="7" x2="13.5" y2="16"/><line x1="7.3" y1="6" x2="16.7" y2="6"/></svg>
-        <span class="sb-label">Graphify</span>
       </a>
     </nav>
     <div class="sidebar-footer">


### PR DESCRIPTION
## Summary

Three self-contained improvements from a downstream deployment, offered back upstream:

1. **`fix(channels)`** — self-heal `enabledPlugins` before launching the channel session.
2. **`feat(message-router)`** — wake idle sub-agents on a stuck Telegram inbox.
3. **`feat(dashboard)`** — Graphify knowledge-graph panel + async regen wired into the deploy flow.

Each is independent; you can cherry-pick a subset. Setup notes below.

## Validation
- `npm run typecheck` green
- wake-nudge gate unit tests 6/6 green

---

## 1. `fix(channels)` — channel plugin self-healing guard

**What it solves.** `scripts/channels.sh` launches the channel session against a specific `PLUGIN_ID` (resolved from `CHANNEL_PROVIDER`). If a PR review-reset or a branch-switch reverts `.claude/settings.json` to a baseline that does not have that plugin under `enabledPlugins`, the session comes up but with no active channel plugin — the bot is "online" yet silently receives nothing.

**How it works.** Before launch, an idempotent guard (`_ensure_plugin_enabled`) ensures `PLUGIN_ID` is `true` under `enabledPlugins` in **both** the project (`$INSTALL_DIR/.claude/settings.json`) and the global (`$HOME/.claude/settings.json`) settings, re-adding it if missing. Pure `python3`, no new dependency.

**Setup.** None. It runs automatically at channel launch. `PLUGIN_ID` is derived from `CHANNEL_PROVIDER` in `.env` (defaults to `telegram@claude-plugins-official`). No settings file is committed by this change.

---

## 2. `feat(message-router)` — sub-agent Telegram inbox wake-nudge

**What it solves.** A sub-agent that loads the channel plugin as a plain MCP server (rather than via `--channels`) does not get Claude Code's native channel notifications delivered into its turn. If inbound messages are persisted to a per-agent pending file, a drain hook can pull them on the next turn — but an **idle** sub-agent never takes a turn, so the inbox sits stuck. This watcher closes that latency gap.

**How it works.** `telegram-inbox-wake.ts` is called once per message-router tick. For each sub-agent it `statSync`s the pending inbox (cheap gate); only when it has sat untouched past a min-age (25s) and the per-agent debounce (60s) has elapsed does it probe the tmux session and, if idle, inject a **content-free** nudge so the drain hook fires and atomically claims the backlog. No content is injected and the inbox file is never mutated by the router — the drain hook owns the claim and the security framing. Cheap gates run before any tmux I/O, so an empty fleet costs one `statSync` per agent and zero `capture-pane`.

**Prerequisites (IMPORTANT — no-op without these).** The wake reads
`<agent-channel-state-dir>/inbox-pending.jsonl`. Without that file it hits `ENOENT` and is a passive no-op — safe, but inert. To make it functional a deployment needs a "pull model" with two pieces:

1. **An inbound tee.** A small process that receives each inbound channel message for a sub-agent and appends it (one JSON object per line) to that agent's `inbox-pending.jsonl` under the channel state dir (`resolveAgentChannelStateDir(agent, 'telegram')`). In our deployment this is a `channel-inbound-tee.mjs` sitting on the sub-agent's MCP stdio; any equivalent that writes the same file works.
2. **A drain hook.** A `UserPromptSubmit` hook that, on each turn, atomically claims (`rename`) `inbox-pending.jsonl` and prepends the already-security-framed `<channel>` messages above the current prompt. In our deployment this is `channel-inbox-drain.py`.

These two infra pieces are **deployment-specific and NOT included in this PR** (they depend on how you run sub-agent channel plugins). The wake-nudge is the missing scheduler piece: it only decides *when* to nudge an idle session so the drain hook you already have can run. If you deliver sub-agent channel inbound some other way, adapt the pending-file path/format accordingly.

**Setup.** No config once the two prerequisites exist — it runs automatically inside the message-router tick. Tunables are module constants (`SUB_TELEGRAM_WAKE_MIN_AGE_MS`, `SUB_TELEGRAM_WAKE_DEBOUNCE_MS`).

---

## 3. `feat(dashboard)` — Graphify knowledge-graph panel

**What it does.** Adds a "Graphify" dashboard panel: an `<iframe>` that renders a standalone D3 knowledge-graph of the codebase (`web/icons/graphify-graph.html`), served by the existing static route. Sits alongside the existing Costs panel. A lazy loader in `app.js` only fetches the graph on first entry to the panel.

**Prerequisites.**
- **Required** — [Graphify](https://github.com/safishamsi/graphify): `pip install graphifyy` (or `uv tool install graphifyy`; note the double-y package slug). Provides the `graphify` CLI that builds the graph.
- **Optional** — a local [Ollama](https://ollama.com) with `qwen2.5-coder:7b` (`ollama pull qwen2.5-coder:7b`), used **only** to name the graph's communities semantically (zero API cost). Without it the graph still builds and works fully, just with numbered `Community N` labels instead of named ones.

**Setup — generate the first graph.** The graph HTML is a generated ~2.5MB artifact and is **gitignored** (`web/icons/graphify-graph.html`), so it is absent on a fresh checkout and the panel iframe would 404 until built. Generate it with:

```bash
bash scripts/regen-graphify.sh
```

That script indexes `src/` with tree-sitter AST (`graphify extract --code-only`, zero API cost), names communities via local Ollama when available (falling back to placeholder labels), and copies the result to `web/icons/graphify-graph.html`. It is best-effort and idempotent: if `graphify` or its inputs are absent it exits 0 without touching anything, so it never breaks a deploy.

**Deploy integration.** `update.sh` calls `scripts/regen-graphify.sh` after the build (best-effort, `-x`-guarded), so the panel stays fresh across deploys where Graphify is installed and is silently skipped where it is not.

---

Co-authored with Claude Opus 4.8.
