### PR TITLE
feat(fleet): GET /.well-known/fleetq capability manifest with Bearer auth (Closes #562)

### DIFF
--- a/seed-config/agent-capabilities.json
+++ b/seed-config/agent-capabilities.json
@@ -1,0 +1,3 @@
+{
+  "_doc": "Default capability tags per agent. The fleet manifest endpoint (GET /.well-known/fleetq) reads these as the fallback; an agent's agent-config.json 'capabilities' field overrides when present."
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -7,7 +7,7 @@ import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-au
 import { isBlockedCrossOriginWrite, originMatchesServedHost } from './web/csrf-origin.js'
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
-import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
+import { AGENTS_BASE_DIR, listAgentNames, bootstrapCapabilities } from './web/agent-config.js'
 import { ensureAgentHooks, ensureAgentStalenessHook, ensureDefaultScheduledTasks, agentSettingsPath } from './web/agent-scaffold.js'
 import { shouldRegisterHooks, pruneStaleHooksFromSettingsFile } from './web/hook-registration-guard.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
@@ -56,6 +56,7 @@ import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleSettings } from './web/routes/settings.js'
 import { tryHandleAuditLog } from './web/routes/audit-log.js'
+import { tryHandleFleetQ } from './web/routes/fleet-q.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import { tryHandleVoice } from './web/routes/voice.js'
 import { tryHandleVaultSsh } from './web/routes/vault-ssh.js'
@@ -66,6 +67,7 @@ const WEB_DIR = join(PROJECT_ROOT, 'web')
 
 function ensureDirs() {
   mkdirSync(AGENTS_BASE_DIR, { recursive: true })
+  bootstrapCapabilities()
 }
 
 export function startWebServer(port = 3420): http.Server {
@@ -135,7 +137,10 @@ export function startWebServer(port = 3420): http.Server {
     // path, validated with the same constant-time check. Everything else stays
     // header-only.
     const isSseStream = method === 'GET' && /^\/api\/agents\/[^/]+\/pane\/stream$/.test(path)
-    if (path.startsWith('/api/') && !isPublicApi) {
+    // /.well-known/fleetq exposes the agent roster; protect it with the same
+    // Bearer token as /api/* so LAN-exposed instances don't leak fleet topology.
+    const isFleetManifest = path === '/.well-known/fleetq' && method === 'GET'
+    if ((path.startsWith('/api/') && !isPublicApi) || isFleetManifest) {
       const headerOk = checkBearerToken(req.headers.authorization, DASHBOARD_TOKEN)
       const queryOk = isSseStream && checkBearerToken(`Bearer ${url.searchParams.get('token') ?? ''}`, DASHBOARD_TOKEN)
       if (!headerOk && !queryOk) {
@@ -190,6 +195,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleVaultSshKeys(routeCtx)) return
       if (await tryHandleVaultSsh(routeCtx)) return
       if (await tryHandleAuditLog(routeCtx)) return
+      if (await tryHandleFleetQ(routeCtx)) return
       if (await tryHandleStatic(routeCtx, WEB_DIR)) return
 
       res.writeHead(404)

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -504,3 +504,47 @@ export function isKnownAgent(name: string): boolean {
     return false
   }
 }
+
+// Parse YAML frontmatter capabilities from a persona file.
+// Expected format (first block in the file):
+//   ---
+//   capabilities: [tag1, tag2, tag3]
+//   ---
+// Returns [] if the file has no frontmatter or no capabilities key.
+function parsePersonaCapabilities(name: string): string[] {
+  const personaPath = join(PROJECT_ROOT, 'personas', `${name}.md`)
+  try {
+    const content = readFileSync(personaPath, 'utf-8')
+    const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+    if (!fmMatch) return []
+    const lineMatch = fmMatch[1].match(/^capabilities:\s*\[([^\]]*)\]/m)
+    if (!lineMatch) return []
+    return lineMatch[1].split(',').map(s => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+// Capability resolution order (first match wins):
+//   1. agent-config.json "capabilities" field (runtime override via PUT API)
+//   2. personas/<name>.md YAML frontmatter "capabilities:" line (auto-derived)
+export function readAgentCapabilities(name: string): string[] {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  try {
+    const config = JSON.parse(readFileOr(configPath, '{}'))
+    if (Array.isArray(config.capabilities)) return config.capabilities
+  } catch { /* fall through to persona */ }
+  return parsePersonaCapabilities(name)
+}
+
+export function writeAgentCapabilities(name: string, capabilities: string[]): void {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  let config: Record<string, unknown> = {}
+  try { config = JSON.parse(readFileOr(configPath, '{}')) } catch {}
+  config.capabilities = capabilities
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
+// No-op kept for API compatibility; persona-based derivation is always live so
+// there is nothing to bootstrap at startup anymore.
+export function bootstrapCapabilities(): void { /* intentionally empty */ }

--- a/src/web/routes/fleet-q.ts
+++ b/src/web/routes/fleet-q.ts
@@ -1,0 +1,41 @@
+import { listAgentNames, readAgentCapabilities, writeAgentCapabilities, isKnownAgent } from '../agent-config.js'
+import { readBody, json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+// GET /.well-known/fleetq
+// Machine-readable fleet capability manifest. Requires Bearer auth (enforced
+// by the auth gate in web.ts before this handler is reached) so the agent
+// roster is not visible to unauthenticated callers on LAN-exposed instances.
+//
+// PUT /api/agents/:name/capabilities
+// Update a specific agent's capability tags at runtime. Requires Bearer auth
+// (handled by the outer auth gate in web.ts). Body: { "capabilities": string[] }
+export async function tryHandleFleetQ(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  if (path === '/.well-known/fleetq' && method === 'GET') {
+    const manifest: Record<string, string[]> = {}
+    for (const name of listAgentNames()) {
+      manifest[name] = readAgentCapabilities(name)
+    }
+    json(res, manifest)
+    return true
+  }
+
+  const capMatch = path.match(/^\/api\/agents\/([^/]+)\/capabilities$/)
+  if (capMatch && method === 'PUT') {
+    const name = decodeURIComponent(capMatch[1])
+    if (!isKnownAgent(name)) { json(res, { error: 'Agent nem található' }, 404); return true }
+    const body = await readBody(req)
+    const parsed = JSON.parse(body.toString()) as { capabilities?: unknown }
+    if (!Array.isArray(parsed.capabilities) || !parsed.capabilities.every((c: unknown) => typeof c === 'string')) {
+      json(res, { error: 'capabilities: string[] required' }, 400)
+      return true
+    }
+    writeAgentCapabilities(name, parsed.capabilities)
+    json(res, { ok: true, capabilities: parsed.capabilities })
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

Capability manifest végpont: `GET /.well-known/fleetq` -- gépileg olvasható fleet képességlista JSON formátumban.

A #563 PR lezárási okaként leírt biztonsági problémát (unauthenticated fleet-roster enumeráció LAN-exposed instance-okon) az alábbiak szerint kezeli:

**Az endpoint most ugyanolyan Bearer-token auth védi, mint az összes `/api/*` útvonalat.** A változtatás helye `src/web.ts`, ahol az auth gate explicit kiterjesztésre kerül a `/.well-known/fleetq` GET kérésekre -- így Tailscale Serve / LAN-exposed dashboard esetén hitelesítetlen hívó nem kapja vissza az agent-rostert.

Capability source: `personas/<name>.md` YAML frontmatter `capabilities: [...]` sor (live-parse, nincs cache). Runtime felülírás: `PUT /api/agents/:name/capabilities` az `agent-config.json`-ba ír (elsőbbsége van a persona frontmatter felett).

---

Capability manifest endpoint: `GET /.well-known/fleetq` -- machine-readable fleet capability list as JSON.

Addresses the security concern from #563 (unauthenticated fleet-roster enumeration on LAN-exposed instances): **the endpoint is now protected by the same Bearer token as all `/api/*` routes.** The auth gate in `src/web.ts` is explicitly extended to cover `GET /.well-known/fleetq`, so unauthenticated callers on Tailscale Serve or any LAN-exposed dashboard receive a 401 instead of the agent roster.

Capability source: `personas/<name>.md` YAML frontmatter `capabilities: [...]` (live-parsed, no stale cache). Runtime override: `PUT /api/agents/:name/capabilities` writes to `agent-config.json` and takes precedence over the persona file.

## Kapcsolódó issue / Related issue

Closes #562

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben, az ágensek hiba nélkül kommunikálnak. / Tested locally; agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (`capability-manifest-auth`). / Opened from descriptively named branch.