### PR TITLE
chore(fleet): remove dead agent-capabilities seed + no-op bootstrapCapabilities

### DIFF
--- a/seed-config/agent-capabilities.json
+++ b/seed-config/agent-capabilities.json
@@ -1,3 +1,0 @@
-{
-  "_doc": "Default capability tags per agent. The fleet manifest endpoint (GET /.well-known/fleetq) reads these as the fallback; an agent's agent-config.json 'capabilities' field overrides when present."
-}

--- a/src/web.ts
+++ b/src/web.ts
@@ -7,7 +7,7 @@ import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-au
 import { isBlockedCrossOriginWrite, originMatchesServedHost } from './web/csrf-origin.js'
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
-import { AGENTS_BASE_DIR, listAgentNames, bootstrapCapabilities } from './web/agent-config.js'
+import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
 import { ensureAgentHooks, ensureAgentStalenessHook, ensureDefaultScheduledTasks, agentSettingsPath } from './web/agent-scaffold.js'
 import { shouldRegisterHooks, pruneStaleHooksFromSettingsFile } from './web/hook-registration-guard.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
@@ -67,7 +67,6 @@ const WEB_DIR = join(PROJECT_ROOT, 'web')
 
 function ensureDirs() {
   mkdirSync(AGENTS_BASE_DIR, { recursive: true })
-  bootstrapCapabilities()
 }
 
 export function startWebServer(port = 3420): http.Server {

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -544,7 +544,3 @@ export function writeAgentCapabilities(name: string, capabilities: string[]): vo
   config.capabilities = capabilities
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
-
-// No-op kept for API compatibility; persona-based derivation is always live so
-// there is nothing to bootstrap at startup anymore.
-export function bootstrapCapabilities(): void { /* intentionally empty */ }


### PR DESCRIPTION
## What

Removes two dead artifacts carried over from PR #563 into #569, both flagged in #569 review as non-blocking cleanups:

1. **seed-config/agent-capabilities.json** deleted. Nothing in src/ or scripts/ reads it; the install/update scripts only glob-copy seed-config/*.json into store/, and no code reads the copied file by name either. Its `_doc` field falsely claimed the fleetq manifest endpoint reads it as the fallback; the actual fallback is persona frontmatter derivation. Misleading for future installs and devs.
2. **bootstrapCapabilities()** removed (definition in src/web/agent-config.ts, import + call in src/web.ts ensureDirs()). It was a documented no-op kept only for API compatibility, now with a single pointless call site.

## Why

Zero readers, misleading documentation, dead code. Verified on current develop (post #568/#569): repo-wide grep shows no consumer of either artifact besides the definition/import/call removed here.

## Untouched

The fleetq endpoint (GET /.well-known/fleetq), persona-frontmatter capability derivation, and the PUT capabilities route are all intact.

## Verification

- tsc --noEmit clean
- vitest: 129 files, 1794 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)