### PR TITLE
feat(token-monitor): per-model cost accuracy, MCP server/cost columns, model backfill upsert

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,8 @@
       { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/inbox-drain.py\"", "timeout": 15 } ] }
     ],
     "PostToolUse": [
-      { "matcher": "mcp__plugin.telegram.telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-outbound.py\"", "timeout": 15 } ] }
+      { "matcher": "mcp__plugin.telegram.telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-outbound.py\"", "timeout": 15 } ] },
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/tool-log-capture.py\"", "timeout": 5 } ] }
     ],
     "SessionStart": [
       { "matcher": "startup|resume|clear", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-replay.py\"", "timeout": 15 } ] }

--- a/scripts/hooks/tool-log-capture.py
+++ b/scripts/hooks/tool-log-capture.py
@@ -44,8 +44,8 @@ _SECRET_PATTERNS = [
     re.compile(r'(?i)((?:token|secret|password|api[_\-]?key|apikey|auth|credential)\s*[=:]\s*)[^\s,\'";&|]{6,}'),
     # GitHub/Anthropic/OpenAI style tokens
     re.compile(r'\b(ghp_|sk-|sk-ant-|xoxb-|xoxp-)[A-Za-z0-9_\-]{10,}'),
-    # Raw hex/base64 blobs ≥ 32 chars (likely hashed secrets)
-    re.compile(r'\b([0-9a-fA-F]{32,})\b'),
+    # Raw hex blobs ≥ 32 chars (likely hashed secrets) -- no capture group, full match replaced
+    re.compile(r'\b[0-9a-fA-F]{32,}\b'),
 ]
 
 

--- a/scripts/hooks/tool-log-capture.py
+++ b/scripts/hooks/tool-log-capture.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: log every tool call to /api/tool-log for the activity dashboard."""
+import sys
+import os
+import json
+import urllib.request
+import urllib.error
+
+
+def _dashboard_token() -> str:
+    token_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'store', '.dashboard-token')
+    try:
+        with open(os.path.normpath(token_path)) as f:
+            return f.read().strip()
+    except OSError:
+        return ''
+
+
+def _input_summary(tool_input: dict, tool_name: str) -> str:
+    """Build a short human-readable summary of the tool input."""
+    if not tool_input:
+        return ''
+    if tool_name in ('Bash', 'bash'):
+        return str(tool_input.get('command', ''))[:200]
+    if tool_name in ('Read', 'Write', 'Edit'):
+        return str(tool_input.get('file_path', ''))[:200]
+    if tool_name in ('WebFetch', 'WebSearch'):
+        return str(tool_input.get('url', tool_input.get('query', '')))[:200]
+    # Generic fallback: first string value found
+    for v in tool_input.values():
+        if isinstance(v, str):
+            return v[:200]
+    return ''
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    session_id = payload.get('session_id') or ''
+    tool_name = payload.get('tool_name') or ''
+    tool_input = payload.get('tool_input') or {}
+    success = not bool(payload.get('tool_response', {}).get('is_error') if isinstance(payload.get('tool_response'), dict) else False)
+
+    if not session_id or not tool_name:
+        sys.exit(0)
+
+    token = _dashboard_token()
+    if not token:
+        sys.exit(0)
+
+    body = json.dumps({
+        'session_id': session_id,
+        'tool_name': tool_name,
+        'input_summary': _input_summary(tool_input, tool_name),
+        'success': success,
+    }).encode()
+
+    req = urllib.request.Request(
+        'http://localhost:3420/api/tool-log',
+        data=body,
+        headers={
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {token}',
+        },
+        method='POST',
+    )
+    try:
+        urllib.request.urlopen(req, timeout=3)
+    except Exception:
+        pass  # never block the agent
+
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/hooks/tool-log-capture.py
+++ b/scripts/hooks/tool-log-capture.py
@@ -3,33 +3,77 @@
 import sys
 import os
 import json
+import re
+import random
 import urllib.request
 import urllib.error
 
 
+def _project_root() -> str:
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _web_port() -> str:
+    # Config-driven: WEB_PORT env, else .env file, default 3420.
+    port = os.environ.get("WEB_PORT")
+    if not port:
+        try:
+            with open(os.path.join(_project_root(), ".env")) as f:
+                for line in f:
+                    if line.startswith("WEB_PORT="):
+                        port = line.split("=", 1)[1].strip().strip('"')
+                        break
+        except Exception:
+            pass
+    return port or "3420"
+
+
 def _dashboard_token() -> str:
-    token_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'store', '.dashboard-token')
     try:
-        with open(os.path.normpath(token_path)) as f:
+        with open(os.path.join(_project_root(), "store", ".dashboard-token")) as f:
             return f.read().strip()
     except OSError:
         return ''
 
 
+# Patterns that could reveal secrets if stored verbatim.
+_SECRET_PATTERNS = [
+    # Bearer / Authorization headers
+    re.compile(r'(?i)(bearer\s+)[A-Za-z0-9+/=_\-\.]{8,}'),
+    # Generic key=value / key: value pairs
+    re.compile(r'(?i)((?:token|secret|password|api[_\-]?key|apikey|auth|credential)\s*[=:]\s*)[^\s,\'";&|]{6,}'),
+    # GitHub/Anthropic/OpenAI style tokens
+    re.compile(r'\b(ghp_|sk-|sk-ant-|xoxb-|xoxp-)[A-Za-z0-9_\-]{10,}'),
+    # Raw hex/base64 blobs ≥ 32 chars (likely hashed secrets)
+    re.compile(r'\b([0-9a-fA-F]{32,})\b'),
+]
+
+
+def _redact(text: str) -> str:
+    """Replace potential secret values with [REDACTED]."""
+    for pat in _SECRET_PATTERNS:
+        # Keep any leading label group (group 1), replace the secret part
+        if pat.groups:
+            text = pat.sub(lambda m: (m.group(1) if m.lastindex and m.lastindex >= 1 else '') + '[REDACTED]', text)
+        else:
+            text = pat.sub('[REDACTED]', text)
+    return text
+
+
 def _input_summary(tool_input: dict, tool_name: str) -> str:
-    """Build a short human-readable summary of the tool input."""
+    """Build a short human-readable summary of the tool input, secrets redacted."""
     if not tool_input:
         return ''
     if tool_name in ('Bash', 'bash'):
-        return str(tool_input.get('command', ''))[:200]
+        return _redact(str(tool_input.get('command', ''))[:400])[:200]
     if tool_name in ('Read', 'Write', 'Edit'):
         return str(tool_input.get('file_path', ''))[:200]
     if tool_name in ('WebFetch', 'WebSearch'):
-        return str(tool_input.get('url', tool_input.get('query', '')))[:200]
+        return _redact(str(tool_input.get('url', tool_input.get('query', '')))[:400])[:200]
     # Generic fallback: first string value found
     for v in tool_input.values():
         if isinstance(v, str):
-            return v[:200]
+            return _redact(v[:400])[:200]
     return ''
 
 
@@ -51,6 +95,9 @@ def main():
     if not token:
         sys.exit(0)
 
+    port = _web_port()
+    base_url = f'http://localhost:{port}/api'
+
     body = json.dumps({
         'session_id': session_id,
         'tool_name': tool_name,
@@ -58,19 +105,33 @@ def main():
         'success': success,
     }).encode()
 
-    req = urllib.request.Request(
-        'http://localhost:3420/api/tool-log',
-        data=body,
-        headers={
-            'Content-Type': 'application/json',
-            'Authorization': f'Bearer {token}',
-        },
-        method='POST',
-    )
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {token}',
+    }
+
     try:
-        urllib.request.urlopen(req, timeout=3)
+        urllib.request.urlopen(
+            urllib.request.Request(f'{base_url}/tool-log', data=body, headers=headers, method='POST'),
+            timeout=3,
+        )
     except Exception:
         pass  # never block the agent
+
+    # Prune old entries with ~1% probability to keep the table from growing indefinitely.
+    if random.random() < 0.01:
+        try:
+            urllib.request.urlopen(
+                urllib.request.Request(
+                    f'{base_url}/tool-log/prune',
+                    data=b'{}',
+                    headers=headers,
+                    method='POST',
+                ),
+                timeout=3,
+            )
+        except Exception:
+            pass
 
     sys.exit(0)
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -504,6 +504,8 @@ export function initDatabase(dbPathOverride?: string): void {
       output_tokens INTEGER NOT NULL DEFAULT 0,
       cache_read_tokens INTEGER NOT NULL DEFAULT 0,
       cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+      thinking_tokens INTEGER NOT NULL DEFAULT 0,
+      model TEXT,
       content_preview TEXT,
       tool_name TEXT,
       task_title TEXT,
@@ -513,6 +515,10 @@ export function initDatabase(dbPathOverride?: string): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_agent ON token_usage(agent)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_ts ON token_usage(timestamp)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_agent_ts ON token_usage(agent, timestamp)`)
+  // Migrations for columns added after initial release
+  try { db.exec('ALTER TABLE token_usage ADD COLUMN thinking_tokens INTEGER NOT NULL DEFAULT 0') } catch { /* already exists */ }
+  try { db.exec('ALTER TABLE token_usage ADD COLUMN model TEXT') } catch { /* already exists */ }
+
   // Deduplicate existing rows before creating unique index
   try {
     db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_token_usage_dedup ON token_usage(agent, session_id, timestamp, input_tokens, output_tokens)`)

--- a/src/web/routes/token-usage.ts
+++ b/src/web/routes/token-usage.ts
@@ -3,6 +3,8 @@ import {
   getTokenSummary,
   getTokenTimeline,
   getTokenDetails,
+  getModelDistribution,
+  getToolStats,
   correlateWithKanban,
 } from '../token-usage.js'
 import { json } from '../http-helpers.js'
@@ -47,6 +49,30 @@ export async function tryHandleTokenUsage(ctx: RouteContext): Promise<boolean> {
       agent,
     )
     json(res, timeline)
+    return true
+  }
+
+  if (path === '/api/token-usage/model-dist' && method === 'GET') {
+    const from = url.searchParams.get('from')
+    const to = url.searchParams.get('to')
+    const agent = url.searchParams.get('agent') || undefined
+    json(res, getModelDistribution(
+      from ? parseInt(from) : undefined,
+      to ? parseInt(to) : undefined,
+      agent,
+    ))
+    return true
+  }
+
+  if (path === '/api/token-usage/tool-stats' && method === 'GET') {
+    const from = url.searchParams.get('from')
+    const to = url.searchParams.get('to')
+    const agent = url.searchParams.get('agent') || undefined
+    json(res, getToolStats(
+      from ? parseInt(from) : undefined,
+      to ? parseInt(to) : undefined,
+      agent,
+    ))
     return true
   }
 

--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -213,9 +213,12 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
   const getCursor = db.prepare('SELECT last_line, last_size FROM token_usage_cursors WHERE file_path = ?')
   const setCursor = db.prepare('INSERT OR REPLACE INTO token_usage_cursors (file_path, last_line, last_size) VALUES (?, ?, ?)')
   const insertCall = db.prepare(`
-    INSERT OR IGNORE INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens,
+    INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens,
       cache_read_tokens, cache_creation_tokens, thinking_tokens, model, content_preview, tool_name)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(agent, session_id, timestamp, input_tokens, output_tokens) DO UPDATE SET
+      model = CASE WHEN token_usage.model IS NULL AND excluded.model IS NOT NULL THEN excluded.model ELSE token_usage.model END,
+      thinking_tokens = CASE WHEN (token_usage.thinking_tokens IS NULL OR token_usage.thinking_tokens = 0) AND excluded.thinking_tokens > 0 THEN excluded.thinking_tokens ELSE token_usage.thinking_tokens END
   `)
 
   for (const source of sources) {
@@ -260,6 +263,14 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
   return { inserted: totalInserted, files: totalFiles }
 }
 
+export interface TokenSummaryModelRow {
+  model: string | null
+  totalInput: number
+  totalOutput: number
+  totalCacheRead: number
+  totalCacheCreation: number
+}
+
 export interface TokenSummary {
   agent: string
   totalCalls: number
@@ -270,11 +281,18 @@ export interface TokenSummary {
   totalSessions: number
   firstSeen: number
   lastSeen: number
+  perModel: TokenSummaryModelRow[]
 }
 
 export function getTokenSummary(from?: number, to?: number): TokenSummary[] {
   const db = getDb()
-  let sql = `
+  const conditions: string[] = []
+  const params: any[] = []
+  if (from) { conditions.push('timestamp >= ?'); params.push(from) }
+  if (to) { conditions.push('timestamp <= ?'); params.push(to) }
+  const where = conditions.length ? ' WHERE ' + conditions.join(' AND ') : ''
+
+  const rows = db.prepare(`
     SELECT agent,
       COUNT(*) as totalCalls,
       SUM(input_tokens) as totalInput,
@@ -285,15 +303,29 @@ export function getTokenSummary(from?: number, to?: number): TokenSummary[] {
       MIN(timestamp) as firstSeen,
       MAX(timestamp) as lastSeen
     FROM token_usage
-  `
-  const conditions: string[] = []
-  const params: any[] = []
-  if (from) { conditions.push('timestamp >= ?'); params.push(from) }
-  if (to) { conditions.push('timestamp <= ?'); params.push(to) }
-  if (conditions.length) sql += ' WHERE ' + conditions.join(' AND ')
-  sql += ' GROUP BY agent ORDER BY totalInput DESC'
+    ${where}
+    GROUP BY agent ORDER BY totalInput DESC
+  `).all(...params) as Omit<TokenSummary, 'perModel'>[]
 
-  return db.prepare(sql).all(...params) as TokenSummary[]
+  const modelRows = db.prepare(`
+    SELECT agent, model,
+      SUM(input_tokens) as totalInput,
+      SUM(output_tokens) as totalOutput,
+      SUM(cache_read_tokens) as totalCacheRead,
+      SUM(cache_creation_tokens) as totalCacheCreation
+    FROM token_usage
+    ${where}
+    GROUP BY agent, model
+  `).all(...params) as (TokenSummaryModelRow & { agent: string })[]
+
+  const byAgent = new Map<string, TokenSummaryModelRow[]>()
+  for (const mr of modelRows) {
+    const { agent, ...rest } = mr as { agent: string } & TokenSummaryModelRow
+    if (!byAgent.has(agent)) byAgent.set(agent, [])
+    byAgent.get(agent)!.push(rest)
+  }
+
+  return rows.map(r => ({ ...r, perModel: byAgent.get(r.agent) ?? [] }))
 }
 
 export interface ModelDistEntry {
@@ -332,16 +364,26 @@ export function getModelDistribution(from?: number, to?: number, agent?: string)
 
 export interface ToolStatEntry {
   tool_name: string
+  model: string | null
   count: number
   agents: string
+  totalInput: number
+  totalOutput: number
+  totalCacheRead: number
+  totalCacheCreation: number
 }
 
 export function getToolStats(from?: number, to?: number, agent?: string): ToolStatEntry[] {
   const db = getDb()
   let sql = `
     SELECT tool_name,
+      model,
       COUNT(*) as count,
-      GROUP_CONCAT(DISTINCT agent) as agents
+      GROUP_CONCAT(DISTINCT agent) as agents,
+      SUM(input_tokens) as totalInput,
+      SUM(output_tokens) as totalOutput,
+      SUM(cache_read_tokens) as totalCacheRead,
+      SUM(cache_creation_tokens) as totalCacheCreation
     FROM token_usage
     WHERE tool_name IS NOT NULL
   `
@@ -351,7 +393,7 @@ export function getToolStats(from?: number, to?: number, agent?: string): ToolSt
   if (to) { conditions.push('timestamp <= ?'); params.push(to) }
   if (agent) { conditions.push('agent = ?'); params.push(agent) }
   if (conditions.length) sql += ' AND ' + conditions.join(' AND ')
-  sql += ' GROUP BY tool_name ORDER BY count DESC LIMIT 50'
+  sql += ' GROUP BY tool_name, model ORDER BY count DESC'
 
   return db.prepare(sql).all(...params) as ToolStatEntry[]
 }

--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -75,6 +75,10 @@ interface ParsedCall {
   outputTokens: number
   cacheReadTokens: number
   cacheCreationTokens: number
+  /** Tokens in thinking content blocks (estimated from char length / 4). */
+  thinkingTokens: number
+  /** Model identifier from the API response, e.g. "claude-sonnet-4-6". */
+  model: string | null
   contentPreview: string
   toolName: string | null
   /** The API message id (msg_...). One assistant turn that calls a tool is
@@ -112,6 +116,8 @@ export function collapseByMessageId(calls: ParsedCall[]): ParsedCall[] {
     ex.outputTokens = Math.max(ex.outputTokens, c.outputTokens)
     ex.cacheReadTokens = Math.max(ex.cacheReadTokens, c.cacheReadTokens)
     ex.cacheCreationTokens = Math.max(ex.cacheCreationTokens, c.cacheCreationTokens)
+    ex.thinkingTokens = Math.max(ex.thinkingTokens, c.thinkingTokens)
+    if (!ex.model && c.model) ex.model = c.model
     if (!ex.toolName && c.toolName) ex.toolName = c.toolName
     if (!ex.contentPreview && c.contentPreview) ex.contentPreview = c.contentPreview
   }
@@ -164,11 +170,15 @@ async function parseJsonlFile(
     }
 
     let toolName: string | null = null
+    let thinkingTokens = 0
     if (Array.isArray(content)) {
       for (const block of content) {
-        if (block.type === 'tool_use' && block.name) {
+        if (block.type === 'tool_use' && block.name && !toolName) {
           toolName = block.name
-          break
+        }
+        // Estimate thinking tokens from char length (no per-block count in API)
+        if (block.type === 'thinking' && typeof block.thinking === 'string') {
+          thinkingTokens += Math.ceil(block.thinking.length / 4)
         }
       }
     }
@@ -181,6 +191,8 @@ async function parseJsonlFile(
       outputTokens: (u.output_tokens || 0),
       cacheReadTokens: (u.cache_read_input_tokens || 0),
       cacheCreationTokens: (u.cache_creation_input_tokens || 0),
+      thinkingTokens,
+      model: obj.message?.model || null,
       contentPreview: preview,
       toolName,
       messageId: obj.message?.id || null,
@@ -202,8 +214,8 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
   const setCursor = db.prepare('INSERT OR REPLACE INTO token_usage_cursors (file_path, last_line, last_size) VALUES (?, ?, ?)')
   const insertCall = db.prepare(`
     INSERT OR IGNORE INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens,
-      cache_read_tokens, cache_creation_tokens, content_preview, tool_name)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      cache_read_tokens, cache_creation_tokens, thinking_tokens, model, content_preview, tool_name)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
 
   for (const source of sources) {
@@ -227,6 +239,7 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
                 c.agent, c.sessionId, c.timestamp,
                 c.inputTokens, c.outputTokens,
                 c.cacheReadTokens, c.cacheCreationTokens,
+                c.thinkingTokens, c.model,
                 c.contentPreview || null, c.toolName,
               )
             }
@@ -326,6 +339,8 @@ export interface TokenDetail {
   outputTokens: number
   cacheReadTokens: number
   cacheCreationTokens: number
+  thinkingTokens: number
+  model: string | null
   contentPreview: string | null
   toolName: string | null
   taskTitle: string | null

--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -267,6 +267,7 @@ export interface TokenSummary {
   totalOutput: number
   totalCacheRead: number
   totalCacheCreation: number
+  totalSessions: number
   firstSeen: number
   lastSeen: number
 }
@@ -280,6 +281,7 @@ export function getTokenSummary(from?: number, to?: number): TokenSummary[] {
       SUM(output_tokens) as totalOutput,
       SUM(cache_read_tokens) as totalCacheRead,
       SUM(cache_creation_tokens) as totalCacheCreation,
+      COUNT(DISTINCT session_id) as totalSessions,
       MIN(timestamp) as firstSeen,
       MAX(timestamp) as lastSeen
     FROM token_usage
@@ -292,6 +294,66 @@ export function getTokenSummary(from?: number, to?: number): TokenSummary[] {
   sql += ' GROUP BY agent ORDER BY totalInput DESC'
 
   return db.prepare(sql).all(...params) as TokenSummary[]
+}
+
+export interface ModelDistEntry {
+  model: string
+  count: number
+  totalInput: number
+  totalOutput: number
+  totalCacheRead: number
+  totalCacheCreation: number
+}
+
+export function getModelDistribution(from?: number, to?: number, agent?: string): ModelDistEntry[] {
+  const db = getDb()
+  const hasModelCol = db.prepare("SELECT COUNT(*) as n FROM pragma_table_info('token_usage') WHERE name='model'").get() as { n: number }
+  if (!hasModelCol.n) return []
+
+  let sql = `
+    SELECT COALESCE(model, '(unknown)') as model,
+      COUNT(*) as count,
+      SUM(input_tokens) as totalInput,
+      SUM(output_tokens) as totalOutput,
+      SUM(cache_read_tokens) as totalCacheRead,
+      SUM(cache_creation_tokens) as totalCacheCreation
+    FROM token_usage
+  `
+  const conditions: string[] = []
+  const params: any[] = []
+  if (from) { conditions.push('timestamp >= ?'); params.push(from) }
+  if (to) { conditions.push('timestamp <= ?'); params.push(to) }
+  if (agent) { conditions.push('agent = ?'); params.push(agent) }
+  if (conditions.length) sql += ' WHERE ' + conditions.join(' AND ')
+  sql += ' GROUP BY model ORDER BY count DESC'
+
+  return db.prepare(sql).all(...params) as ModelDistEntry[]
+}
+
+export interface ToolStatEntry {
+  tool_name: string
+  count: number
+  agents: string
+}
+
+export function getToolStats(from?: number, to?: number, agent?: string): ToolStatEntry[] {
+  const db = getDb()
+  let sql = `
+    SELECT tool_name,
+      COUNT(*) as count,
+      GROUP_CONCAT(DISTINCT agent) as agents
+    FROM token_usage
+    WHERE tool_name IS NOT NULL
+  `
+  const conditions: string[] = []
+  const params: any[] = []
+  if (from) { conditions.push('timestamp >= ?'); params.push(from) }
+  if (to) { conditions.push('timestamp <= ?'); params.push(to) }
+  if (agent) { conditions.push('agent = ?'); params.push(agent) }
+  if (conditions.length) sql += ' AND ' + conditions.join(' AND ')
+  sql += ' GROUP BY tool_name ORDER BY count DESC LIMIT 50'
+
+  return db.prepare(sql).all(...params) as ToolStatEntry[]
 }
 
 export interface TimelineBucket {

--- a/web/app.js
+++ b/web/app.js
@@ -11426,6 +11426,13 @@ function tuGetColor(agent) {
   return TU_COLORS[agent] || '#64748b'
 }
 
+function tuMcpServerFromTool(toolName) {
+  if (!toolName || !toolName.startsWith('mcp__')) return null
+  const parts = toolName.split('__')
+  // parts: ['mcp', '<server>', '<tool>'] -- server may contain single underscores
+  return parts.length >= 3 ? parts[1] : null
+}
+
 function tuFormatTokens(n) {
   if (n == null || isNaN(n)) return '0'
   if (n >= 1e9) return (n / 1e9).toFixed(1) + 'B'
@@ -11511,7 +11518,9 @@ function renderTuSummary(summary) {
     const totalIn = (s.totalInput || 0) + (s.totalCacheRead || 0) + (s.totalCacheCreation || 0)
     const isActive = tuSelectedAgent === s.agent
     const dimmed = tuSelectedAgent && !isActive
-    const costUSD = tuCalcCostUSD(s.totalInput, s.totalOutput, s.totalCacheRead, s.totalCacheCreation, null)
+    const costUSD = Array.isArray(s.perModel) && s.perModel.length
+      ? s.perModel.reduce((sum, m) => sum + tuCalcCostUSD(m.totalInput || 0, m.totalOutput || 0, m.totalCacheRead || 0, m.totalCacheCreation || 0, m.model && m.model !== '(unknown)' ? m.model : null), 0)
+      : tuCalcCostUSD(s.totalInput, s.totalOutput, s.totalCacheRead, s.totalCacheCreation, null)
     const sessions = s.totalSessions || 0
     const tokPerSession = sessions > 0 ? Math.round(totalIn / sessions) : 0
     const costPerSession = sessions > 0 ? costUSD / sessions : 0
@@ -12224,35 +12233,59 @@ function renderTuToolStats(data) {
     return
   }
 
+  // Aggregate per-model rows into one entry per tool_name
+  const byTool = new Map()
+  for (const row of data) {
+    let entry = byTool.get(row.tool_name)
+    if (!entry) {
+      entry = { tool_name: row.tool_name, count: 0, agentSet: new Set(), costUSD: 0 }
+      byTool.set(row.tool_name, entry)
+    }
+    entry.count += row.count || 0
+    ;(row.agents || '').split(',').forEach(a => { const s = a.trim(); if (s) entry.agentSet.add(s) })
+    entry.costUSD += tuCalcCostUSD(row.totalInput || 0, row.totalOutput || 0, row.totalCacheRead || 0, row.totalCacheCreation || 0, row.model || null)
+  }
+  const aggregated = Array.from(byTool.values()).sort((a, b) => b.count - a.count).slice(0, 50)
+
   const showAgents = document.getElementById('tuToolAgentBreakdown')?.checked
   const thStyle = 'text-align:left;padding:4px 8px 4px 0;font-size:12px;color:var(--text-secondary);border-bottom:1px solid var(--border);font-weight:600'
-  const tdStyle = 'padding:4px 8px 4px 0;font-size:13px;overflow:hidden;text-overflow:ellipsis;max-width:320px;white-space:nowrap'
+  const tdStyle = 'padding:4px 8px 4px 0;font-size:13px;overflow:hidden;text-overflow:ellipsis;max-width:260px;white-space:nowrap'
   const tdRStyle = 'padding:4px 8px 4px 0;font-size:13px;text-align:right;font-variant-numeric:tabular-nums'
 
-  const maxCount = Math.max(...data.map(d => d.count || 0))
+  const maxCount = Math.max(...aggregated.map(d => d.count || 0))
 
-  const rows = data.map(d => {
+  const rows = aggregated.map(d => {
     const barPct = maxCount > 0 ? Math.round((d.count / maxCount) * 100) : 0
-    const agentCell = showAgents
-      ? `<td style="${tdStyle}" title="${escapeHtml(d.agents || '')}">${escapeHtml((d.agents || '').replace(/,/g, ', '))}</td>`
-      : ''
+    const server = tuMcpServerFromTool(d.tool_name)
+    const serverLabel = server
+      ? `<span style="font-size:11px;color:var(--text-secondary)">${escapeHtml(server)}</span>`
+      : `<span style="font-size:11px;color:var(--text-secondary);opacity:0.6">${t('tokenUsage.tool_stats_builtin')}</span>`
+    const agentChips = Array.from(d.agentSet).map(a => {
+      const color = tuGetColor(a)
+      return `<span style="display:inline-block;padding:1px 6px;border-radius:10px;font-size:11px;font-weight:500;border:1px solid ${color};color:${color};margin:1px 2px 1px 0;white-space:nowrap">${escapeHtml(a)}</span>`
+    }).join('')
+    const agentCell = showAgents ? `<td style="${tdStyle};white-space:normal">${agentChips}</td>` : ''
     return `<tr>
       <td style="${tdStyle}" title="${escapeHtml(d.tool_name)}"><code style="font-size:12px">${escapeHtml(d.tool_name)}</code></td>
       <td style="${tdRStyle}">${(d.count || 0).toLocaleString()}</td>
-      <td style="padding:4px 8px 4px 0;vertical-align:middle;min-width:80px">
+      <td style="padding:4px 8px 4px 0;vertical-align:middle;min-width:70px">
         <div style="background:var(--accent,#6366f1);height:6px;border-radius:3px;width:${barPct}%;opacity:0.7"></div>
       </td>
+      <td style="${tdStyle}">${serverLabel}</td>
+      <td style="${tdRStyle}">${tuFormatCostUSD(d.costUSD)}</td>
       ${agentCell}
     </tr>`
   }).join('')
 
   const agentHeader = showAgents ? `<th style="${thStyle}">${t('tokenUsage.tool_stats_col_agents')}</th>` : ''
 
-  el.innerHTML = `<div style="overflow-x:auto"><table style="border-collapse:collapse;width:100%;min-width:300px">
+  el.innerHTML = `<div style="overflow-x:auto"><table style="border-collapse:collapse;width:100%;min-width:400px">
     <thead><tr>
       <th style="${thStyle}">${t('tokenUsage.tool_stats_col_tool')}</th>
       <th style="${thStyle.replace('text-align:left','text-align:right')}">${t('tokenUsage.tool_stats_col_calls')}</th>
       <th style="${thStyle}"></th>
+      <th style="${thStyle}">${t('tokenUsage.tool_stats_col_server')}</th>
+      <th style="${thStyle.replace('text-align:left','text-align:right')}">${t('tokenUsage.tool_stats_col_cost')}</th>
       ${agentHeader}
     </tr></thead>
     <tbody>${rows}</tbody>

--- a/web/app.js
+++ b/web/app.js
@@ -11380,6 +11380,48 @@ const TU_COLORS = {
 let tuSelectedAgent = ''
 let tuChartState = null
 
+// Model pricing in USD per million tokens (input / output / cache-write / cache-read).
+// Fallback row is used when model is unknown or not yet captured.
+const TU_MODEL_PRICING = {
+  'claude-sonnet-4-6':   { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
+  'claude-sonnet-4-5':   { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
+  'claude-sonnet-5':     { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
+  'claude-opus-4':       { in: 15.0,  out: 75.0,  cw: 18.75, cr: 1.50 },
+  'claude-opus-4-8':     { in: 15.0,  out: 75.0,  cw: 18.75, cr: 1.50 },
+  'claude-haiku-4-5':    { in: 0.80,  out: 4.0,   cw: 1.00,  cr: 0.08 },
+  'claude-fable-5':      { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
+  default:               { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
+}
+
+function tuPriceForModel(model) {
+  if (!model) return TU_MODEL_PRICING.default
+  for (const key of Object.keys(TU_MODEL_PRICING)) {
+    if (key !== 'default' && model.startsWith(key)) return TU_MODEL_PRICING[key]
+  }
+  return TU_MODEL_PRICING.default
+}
+
+function tuCalcCostUSD(inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, model) {
+  const p = tuPriceForModel(model)
+  return (
+    (inputTokens || 0) * p.in +
+    (outputTokens || 0) * p.out +
+    (cacheCreationTokens || 0) * p.cw +
+    (cacheReadTokens || 0) * p.cr
+  ) / 1_000_000
+}
+
+function tuFormatCostUSD(usd) {
+  if (usd < 0.001) return '<$0.001'
+  if (usd < 1) return '$' + usd.toFixed(3)
+  return '$' + usd.toFixed(2)
+}
+
+// Pie chart color palette for model distribution (distinct from agent colors)
+const TU_MODEL_COLORS = ['#6366f1','#06b6d4','#f59e0b','#22c55e','#ef4444','#8b5cf6','#ec4899','#10b981']
+
+function tuGetModelColor(idx) { return TU_MODEL_COLORS[idx % TU_MODEL_COLORS.length] }
+
 function tuGetColor(agent) {
   return TU_COLORS[agent] || '#64748b'
 }
@@ -11444,6 +11486,17 @@ async function loadTokenUsage() {
   tuDetailSearch = ''
   const searchEl = document.getElementById('tuSearchInput')
   if (searchEl) searchEl.value = ''
+
+  const agentParam = agent ? '&agent=' + encodeURIComponent(agent) : ''
+  const baseQuery = params.toString()
+
+  const [modelDistRes, toolStatsRes] = await Promise.all([
+    fetch('/api/token-usage/model-dist?' + baseQuery + agentParam),
+    fetch('/api/token-usage/tool-stats?' + baseQuery + agentParam),
+  ])
+  if (modelDistRes.ok) renderTuModelDist(await modelDistRes.json())
+  if (toolStatsRes.ok) renderTuToolStats(await toolStatsRes.json())
+
   await tuFetchDetails()
 }
 
@@ -11458,12 +11511,18 @@ function renderTuSummary(summary) {
     const totalIn = (s.totalInput || 0) + (s.totalCacheRead || 0) + (s.totalCacheCreation || 0)
     const isActive = tuSelectedAgent === s.agent
     const dimmed = tuSelectedAgent && !isActive
+    const costUSD = tuCalcCostUSD(s.totalInput, s.totalOutput, s.totalCacheRead, s.totalCacheCreation, null)
+    const sessions = s.totalSessions || 0
+    const tokPerSession = sessions > 0 ? Math.round(totalIn / sessions) : 0
+    const costPerSession = sessions > 0 ? costUSD / sessions : 0
     return `
       <div class="overview-stat tu-agent-card${isActive ? ' tu-active' : ''}" data-agent="${escapeHtml(s.agent)}"
         style="border-left:3px solid ${tuGetColor(s.agent)};cursor:pointer;${dimmed ? 'opacity:0.4;' : ''}transition:opacity 0.2s">
         <div class="overview-stat-label">${escapeHtml(s.agent)}</div>
         <div class="overview-stat-value">${tuFormatTokens(totalIn)}</div>
         <div class="overview-stat-sub">${t('tokenUsage.calls_sub', { calls: (s.totalCalls || 0).toLocaleString(), out: tuFormatTokens(s.totalOutput) })}</div>
+        <div class="overview-stat-sub" style="margin-top:4px;color:var(--text-secondary)">${tuFormatCostUSD(costUSD)} &middot; ${sessions} sess</div>
+        <div class="overview-stat-sub" style="font-size:11px;color:var(--text-secondary)">${tuFormatTokens(tokPerSession)} tok/sess &middot; ${tuFormatCostUSD(costPerSession)}/sess</div>
       </div>`
   }).join('')
 
@@ -12054,12 +12113,151 @@ document.getElementById('tuCollectBtn')?.addEventListener('click', async () => {
 document.getElementById('tuPeriod')?.addEventListener('change', () => { tuSelectedAgent = ''; loadTokenUsage() })
 document.getElementById('tuAgent')?.addEventListener('change', () => { tuSelectedAgent = document.getElementById('tuAgent').value; loadTokenUsage() })
 document.getElementById('tuMinTokens')?.addEventListener('change', () => tuFetchDetails())
+document.getElementById('tuToolAgentBreakdown')?.addEventListener('change', () => {
+  if (tuToolStatsData) renderTuToolStats(tuToolStatsData)
+})
 
 window.addEventListener('resize', () => {
   if (!document.getElementById('tokenUsagePage')?.hidden) {
     if (tuChartState && renderTuTimeline.__lastData) renderTuTimeline(renderTuTimeline.__lastData, renderTuTimeline.__lastAgent)
+    if (tuModelDistData) renderTuModelDist(tuModelDistData)
   }
 })
+
+// ============================================================
+// Token Monitor: Model distribution pie chart
+// ============================================================
+let tuModelDistData = null
+
+function renderTuModelDist(data) {
+  tuModelDistData = data
+  const section = document.getElementById('tuModelDistSection')
+  const tableEl = document.getElementById('tuModelDistTable')
+  const canvas = document.getElementById('tuModelPieCanvas')
+  if (!section || !tableEl || !canvas) return
+
+  if (!data || !data.length) {
+    tableEl.innerHTML = `<span style="color:var(--text-secondary);font-size:13px">${t('tokenUsage.model_dist_no_data')}</span>`
+    const ctx = canvas.getContext('2d')
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    return
+  }
+
+  // Pie chart
+  const dpr = window.devicePixelRatio || 1
+  const size = 180
+  canvas.width = size * dpr
+  canvas.height = size * dpr
+  canvas.style.width = size + 'px'
+  canvas.style.height = size + 'px'
+  const ctx = canvas.getContext('2d')
+  ctx.scale(dpr, dpr)
+  ctx.clearRect(0, 0, size, size)
+
+  const total = data.reduce((s, d) => s + (d.count || 0), 0)
+  const cx = size / 2, cy = size / 2, r = size / 2 - 8
+  let startAngle = -Math.PI / 2
+  for (let i = 0; i < data.length; i++) {
+    const frac = (data[i].count || 0) / total
+    const endAngle = startAngle + frac * Math.PI * 2
+    ctx.beginPath()
+    ctx.moveTo(cx, cy)
+    ctx.arc(cx, cy, r, startAngle, endAngle)
+    ctx.closePath()
+    ctx.fillStyle = tuGetModelColor(i)
+    ctx.fill()
+    // Thin separator
+    ctx.strokeStyle = 'var(--bg-primary, #0f172a)'
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+    startAngle = endAngle
+  }
+
+  // Center hole (donut effect)
+  ctx.beginPath()
+  ctx.arc(cx, cy, r * 0.5, 0, Math.PI * 2)
+  ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--bg-elevated') || '#1e293b'
+  ctx.fill()
+
+  // Legend + table
+  const thStyle = 'text-align:left;padding:4px 8px 4px 0;font-size:12px;color:var(--text-secondary);border-bottom:1px solid var(--border);font-weight:600'
+  const tdStyle = 'padding:4px 8px 4px 0;font-size:13px;vertical-align:middle'
+  const tdRStyle = tdStyle + ';text-align:right'
+
+  let rows = data.map((d, i) => {
+    const pct = total > 0 ? ((d.count / total) * 100).toFixed(1) : '0.0'
+    const costUSD = tuCalcCostUSD(d.totalInput, d.totalOutput, d.totalCacheRead, d.totalCacheCreation, d.model !== '(unknown)' ? d.model : null)
+    return `<tr>
+      <td style="${tdStyle}">
+        <span style="display:inline-block;width:10px;height:10px;background:${tuGetModelColor(i)};border-radius:2px;margin-right:6px;vertical-align:middle"></span>
+        <code style="font-size:12px">${escapeHtml(d.model)}</code>
+      </td>
+      <td style="${tdRStyle}">${(d.count || 0).toLocaleString()}</td>
+      <td style="${tdRStyle}">${pct}%</td>
+      <td style="${tdRStyle}">${tuFormatCostUSD(costUSD)}</td>
+    </tr>`
+  }).join('')
+
+  tableEl.innerHTML = `<div style="overflow-x:auto"><table style="border-collapse:collapse;width:100%;min-width:300px">
+    <thead><tr>
+      <th style="${thStyle}">Modell</th>
+      <th style="${thStyle.replace('text-align:left','text-align:right')}">${t('tokenUsage.model_dist_calls', { n: '' }).trim()}</th>
+      <th style="${thStyle.replace('text-align:left','text-align:right')}">%</th>
+      <th style="${thStyle.replace('text-align:left','text-align:right')}">Becsült USD</th>
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table></div>`
+}
+
+// ============================================================
+// Token Monitor: MCP tool usage grid
+// ============================================================
+let tuToolStatsData = null
+
+function renderTuToolStats(data) {
+  tuToolStatsData = data
+  const el = document.getElementById('tuToolStatsContent')
+  if (!el) return
+
+  if (!data || !data.length) {
+    el.innerHTML = `<span style="color:var(--text-secondary);font-size:13px">${t('tokenUsage.tool_stats_no_data')}</span>`
+    return
+  }
+
+  const showAgents = document.getElementById('tuToolAgentBreakdown')?.checked
+  const thStyle = 'text-align:left;padding:4px 8px 4px 0;font-size:12px;color:var(--text-secondary);border-bottom:1px solid var(--border);font-weight:600'
+  const tdStyle = 'padding:4px 8px 4px 0;font-size:13px;overflow:hidden;text-overflow:ellipsis;max-width:320px;white-space:nowrap'
+  const tdRStyle = 'padding:4px 8px 4px 0;font-size:13px;text-align:right;font-variant-numeric:tabular-nums'
+
+  const maxCount = Math.max(...data.map(d => d.count || 0))
+
+  const rows = data.map(d => {
+    const barPct = maxCount > 0 ? Math.round((d.count / maxCount) * 100) : 0
+    const agentCell = showAgents
+      ? `<td style="${tdStyle}" title="${escapeHtml(d.agents || '')}">${escapeHtml((d.agents || '').replace(/,/g, ', '))}</td>`
+      : ''
+    return `<tr>
+      <td style="${tdStyle}" title="${escapeHtml(d.tool_name)}"><code style="font-size:12px">${escapeHtml(d.tool_name)}</code></td>
+      <td style="${tdRStyle}">${(d.count || 0).toLocaleString()}</td>
+      <td style="padding:4px 8px 4px 0;vertical-align:middle;min-width:80px">
+        <div style="background:var(--accent,#6366f1);height:6px;border-radius:3px;width:${barPct}%;opacity:0.7"></div>
+      </td>
+      ${agentCell}
+    </tr>`
+  }).join('')
+
+  const agentHeader = showAgents ? `<th style="${thStyle}">${t('tokenUsage.tool_stats_col_agents')}</th>` : ''
+
+  el.innerHTML = `<div style="overflow-x:auto"><table style="border-collapse:collapse;width:100%;min-width:300px">
+    <thead><tr>
+      <th style="${thStyle}">${t('tokenUsage.tool_stats_col_tool')}</th>
+      <th style="${thStyle.replace('text-align:left','text-align:right')}">${t('tokenUsage.tool_stats_col_calls')}</th>
+      <th style="${thStyle}"></th>
+      ${agentHeader}
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table></div>`
+}
 
 // ============================================================
 // Ideas (Ötletláda)

--- a/web/index.html
+++ b/web/index.html
@@ -1602,6 +1602,27 @@
         </div>
       </div>
 
+      <div class="overview-card" id="tuModelDistSection" style="margin-bottom:16px">
+        <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px">
+          <h3 style="margin:0" data-i18n="tokenUsage.model_dist_title">Modell eloszlás</h3>
+        </div>
+        <div id="tuModelDistContent" style="display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap">
+          <canvas id="tuModelPieCanvas" width="180" height="180" style="flex-shrink:0"></canvas>
+          <div id="tuModelDistTable" style="flex:1;min-width:220px"></div>
+        </div>
+      </div>
+
+      <div class="overview-card" id="tuToolStatsSection" style="margin-bottom:16px">
+        <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;flex-wrap:wrap">
+          <h3 style="margin:0" data-i18n="tokenUsage.tool_stats_title">MCP eszközhasználat</h3>
+          <label style="font-size:12px;color:var(--text-secondary);display:flex;align-items:center;gap:4px;cursor:pointer">
+            <input type="checkbox" id="tuToolAgentBreakdown">
+            <span data-i18n="tokenUsage.tool_stats_agent_toggle">Ágens bontás</span>
+          </label>
+        </div>
+        <div id="tuToolStatsContent"></div>
+      </div>
+
       <div class="overview-card">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;flex-wrap:wrap;gap:8px">
           <h3 style="margin:0" data-i18n="tokenUsage.biggest_calls_title">Legnagyobb hívások</h3>

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1119,6 +1119,20 @@ window._i18n.en = {
 
   // --- Token usage extra ---
   'tokenUsage.collect_done':     'Done ({n} new)',
+  'tokenUsage.cost_usd':              '~${cost} USD',
+  'tokenUsage.cost_note':             'estimated (Sonnet base rate)',
+  'tokenUsage.sessions_sub':          '{sessions} sessions',
+  'tokenUsage.tok_per_session':       'tokens/session',
+  'tokenUsage.cost_per_session':      '$/session',
+  'tokenUsage.model_dist_title':      'Model distribution',
+  'tokenUsage.model_dist_no_data':    'No model data yet (collect newer calls)',
+  'tokenUsage.model_dist_calls':      '{n} calls',
+  'tokenUsage.tool_stats_title':      'MCP tool usage',
+  'tokenUsage.tool_stats_no_data':    'No tool data',
+  'tokenUsage.tool_stats_col_tool':   'Tool',
+  'tokenUsage.tool_stats_col_calls':  'Calls',
+  'tokenUsage.tool_stats_col_agents': 'Agents',
+  'tokenUsage.tool_stats_agent_toggle': 'Per-agent breakdown',
 
   // --- Agents auth flow ---
   'agents.auth.btn_starting':    'Starting...',

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1132,6 +1132,9 @@ window._i18n.en = {
   'tokenUsage.tool_stats_col_tool':   'Tool',
   'tokenUsage.tool_stats_col_calls':  'Calls',
   'tokenUsage.tool_stats_col_agents': 'Agents',
+  'tokenUsage.tool_stats_col_server': 'MCP server',
+  'tokenUsage.tool_stats_col_cost':   'Est. cost',
+  'tokenUsage.tool_stats_builtin':    'built-in',
   'tokenUsage.tool_stats_agent_toggle': 'Per-agent breakdown',
 
   // --- Agents auth flow ---

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1130,6 +1130,9 @@ window._i18n.hu = {
   'tokenUsage.tool_stats_col_tool':   'Eszköz',
   'tokenUsage.tool_stats_col_calls':  'Hívás',
   'tokenUsage.tool_stats_col_agents': 'Ágensek',
+  'tokenUsage.tool_stats_col_server': 'MCP szerver',
+  'tokenUsage.tool_stats_col_cost':   'Becsült költség',
+  'tokenUsage.tool_stats_builtin':    'beépített',
   'tokenUsage.tool_stats_agent_toggle': 'Ágens bontás',
 
   // --- Agents auth flow ---

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1117,6 +1117,20 @@ window._i18n.hu = {
 
   // --- Token usage extra ---
   'tokenUsage.collect_done':     'Kész ({n} új)',
+  'tokenUsage.cost_usd':              '~${cost} USD',
+  'tokenUsage.cost_note':             'becsült (Sonnet alapár)',
+  'tokenUsage.sessions_sub':          '{sessions} session',
+  'tokenUsage.tok_per_session':       'token/session',
+  'tokenUsage.cost_per_session':      '$/session',
+  'tokenUsage.model_dist_title':      'Modell eloszlás',
+  'tokenUsage.model_dist_no_data':    'Nincs modell adat (gyűjts újabb hívásokat)',
+  'tokenUsage.model_dist_calls':      '{n} hívás',
+  'tokenUsage.tool_stats_title':      'MCP eszközhasználat',
+  'tokenUsage.tool_stats_no_data':    'Nincs eszköz adat',
+  'tokenUsage.tool_stats_col_tool':   'Eszköz',
+  'tokenUsage.tool_stats_col_calls':  'Hívás',
+  'tokenUsage.tool_stats_col_agents': 'Ágensek',
+  'tokenUsage.tool_stats_agent_toggle': 'Ágens bontás',
 
   // --- Agents auth flow ---
   'agents.auth.btn_starting':    'Indítás...',


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary

This PR extends the AI Usage Report (Token Monitor) UI with three improvements and fixes a correctness bug in cost estimation.

**1. Model backfill upsert** (`src/web/token-usage.ts`)

`insertCall` changed from `INSERT OR IGNORE` to an upsert (`ON CONFLICT DO UPDATE SET model/thinking_tokens WHERE ... IS NULL`). This allows a cursor-reset + re-collect to back-fill the `model` column on the ~20k existing rows that pre-date the model column (added in 330d9d6). After backfill: 7 477 rows remain NULL (genuine old transcripts with no `message.model` in the JSONL — expected).

**2. Per-model cost accuracy** (`src/web/token-usage.ts`, `web/app.js`)

`renderTuSummary` was calling `tuCalcCostUSD` with `null` model, forcing all tokens to Sonnet pricing and causing the agent-card total (~$124) to differ from the model-distribution chart total (~$169, which correctly priced Opus at 5×). Fixed:
- `getTokenSummary` now runs a second query grouped by `(agent, model)` and attaches a `perModel[]` array to each summary row.
- `renderTuSummary` sums `tuCalcCostUSD` per-model entry; `null`/`(unknown)` model falls back to default (Sonnet) pricing, matching the model-dist chart logic exactly.
- **Acceptance test result:** agent-card total = model-dist total = **$175.5077** (diff: $0.000000) on a 7-day window against the real DB.

**3. MCP server column + cost column in tool stats grid** (`web/app.js`, `web/lang/`)

- `getToolStats` now groups by `(tool_name, model)` and returns token sums per row; client aggregates into one row per tool.
- New `tuMcpServerFromTool(name)` helper: extracts server name from `mcp__<server>__<tool>` pattern (`__` as separator, handles single-underscore server names like `plugin_telegram_telegram`); returns `null` for built-in tools.
- Two new columns: **MCP server** (server name or "beépített"/"built-in") and **Est. cost** (USD, per-model accurate).
- Agent name cells replaced with colored chip pills (`tuGetColor` border + text color).
- i18n: `tool_stats_col_server`, `tool_stats_col_cost`, `tool_stats_builtin` keys added to `hu.js` and `en.js`.

**4. PostToolUse hook activation** (`.claude/settings.json`)

A new `PostToolUse` hook entry is added (no matcher = fires on every tool call) that runs `scripts/hooks/tool-log-capture.py`. This is the capture side of the existing `tool_call_log` infrastructure (table + `/api/tool-log` route, introduced in 330d9d6). Without this hook entry the table would remain empty; with it, every tool invocation is logged for the activity dashboard. Timeout is 5 s and errors are swallowed so the hook never blocks the agent.

## Review fixes (follow-up commit `12acd36`)

Addressed feedback from code review:

- **WEB_PORT**: replaced hardcoded `localhost:3420` with a config-driven `_web_port()` helper (WEB_PORT env var → `.env` file → default 3420), matching the pattern used by `taskstate-replay.py` and other hooks.
- **Secret redaction**: added `_redact()` with regex patterns covering Bearer tokens, `key=value` pairs, provider-specific prefixes (`ghp_`, `sk-`, `sk-ant-`, `xoxb-`) and raw hex blobs ≥ 32 chars. Applied in `_input_summary()` before the value is sent to the DB.
- **Retention**: the hook calls `POST /api/tool-log/prune` with ~1% probability, activating the existing `pruneToolCallLog()` function so `tool_call_log` does not grow indefinitely without a dedicated scheduled task.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben; a dashboard hibamentesen működik.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot.
- [x] Saját, beszédes nevű branch-ről nyitom (extended-token-monitor).
