### PR TITLE
feat(message-router): opt-in wake-nudge for idle sub-agents with stuck Telegram inbox

### DIFF
--- a/scripts/__tests__/channel-inbox-drain.test.sh
+++ b/scripts/__tests__/channel-inbox-drain.test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Contract test for scripts/hooks/channel-inbox-drain.py.
+# Run: bash scripts/__tests__/channel-inbox-drain.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOK="$INSTALL_DIR/scripts/hooks/channel-inbox-drain.py"
+
+echo "channel-inbox-drain tests"
+echo "========================="
+
+OUT="$(python3 "$HOOK" --self-test 2>&1)"
+STATUS=$?
+if [ "$STATUS" -eq 0 ]; then
+  pass "self-test exits 0"
+else
+  fail "self-test exits $STATUS: $OUT"
+fi
+
+case "$OUT" in
+  *"channel-inbox-drain self-test passed"*) pass "self-test reports success" ;;
+  *) fail "self-test did not report success: $OUT" ;;
+esac
+
+echo ""
+echo "========================="
+TOTAL=$((PASS + FAIL))
+echo "Results: $PASS/$TOTAL passed"
+if [ "$FAIL" -gt 0 ]; then echo "FAILED: $FAIL tests"; exit 1; fi
+echo "All tests passed."

--- a/scripts/channel-inbound-tee.mjs
+++ b/scripts/channel-inbound-tee.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { mkdirSync, appendFileSync, writeSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
+
+const childArgs = process.argv.slice(2)
+if (childArgs.length === 0) {
+  console.error('channel-inbound-tee: missing child command')
+  process.exit(2)
+}
+
+const [command, ...args] = childArgs
+const child = spawn(command, args, {
+  env: process.env,
+  stdio: ['pipe', 'pipe', 'pipe'],
+})
+
+const stateDir = process.env.TELEGRAM_STATE_DIR || ''
+const inboxPath = stateDir ? join(stateDir, 'inbox-pending.jsonl') : ''
+let warnedInboxWrite = false
+let lineBuffer = ''
+const decoder = new StringDecoder('utf8')
+
+function warnInboxWrite(err) {
+  if (warnedInboxWrite) return
+  warnedInboxWrite = true
+  const msg = err instanceof Error ? err.message : String(err)
+  writeSync(2, `channel-inbound-tee: could not append inbound inbox: ${msg}\n`)
+}
+
+function teeLine(line) {
+  if (!inboxPath) return
+
+  let frame
+  try {
+    frame = JSON.parse(line)
+  } catch {
+    return
+  }
+
+  if (!frame || typeof frame !== 'object') return
+  if (frame.method !== 'notifications/claude/channel') return
+  if (!frame.params || typeof frame.params !== 'object' || Array.isArray(frame.params)) return
+
+  try {
+    mkdirSync(dirname(inboxPath), { recursive: true })
+    appendFileSync(
+      inboxPath,
+      JSON.stringify({
+        receivedAt: Math.floor(Date.now() / 1000),
+        params: frame.params,
+      }) + '\n',
+      'utf8',
+    )
+  } catch (err) {
+    warnInboxWrite(err)
+  }
+}
+
+function inspectChunk(chunk) {
+  lineBuffer += decoder.write(chunk)
+  for (;;) {
+    const idx = lineBuffer.indexOf('\n')
+    if (idx < 0) break
+    const line = lineBuffer.slice(0, idx).replace(/\r$/, '')
+    lineBuffer = lineBuffer.slice(idx + 1)
+    teeLine(line)
+  }
+}
+
+child.stdout.on('data', (chunk) => {
+  writeSync(1, chunk)
+  inspectChunk(chunk)
+})
+
+child.stderr.on('data', (chunk) => {
+  writeSync(2, chunk)
+})
+
+// EPIPE guard: the child can die between our destroyed-check and the write
+// (e.g. plugin crash); an unhandled 'error' on its stdin would crash the relay.
+child.stdin.on('error', () => {})
+
+process.stdin.on('data', (chunk) => {
+  if (!child.stdin.destroyed) child.stdin.write(chunk)
+})
+
+process.stdin.on('end', () => {
+  if (!child.stdin.destroyed) child.stdin.end()
+})
+
+process.stdin.on('close', () => {
+  if (!child.stdin.destroyed) child.stdin.end()
+})
+
+child.on('error', (err) => {
+  writeSync(2, `channel-inbound-tee: child spawn failed: ${err.message}\n`)
+  process.exit(127)
+})
+
+// 'close' (not 'exit'): it fires only after the child's stdio streams are
+// fully drained, so a final stdout burst right before death still passes
+// through before we tear down.
+child.on('close', (code, signal) => {
+  const tail = decoder.end()
+  if (tail) lineBuffer += tail
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  // Exit EXPLICITLY: the open parent stdin would otherwise keep this relay
+  // alive as a zombie after a plugin crash (exitCode alone never applies while
+  // the loop is held). All passthrough writes are writeSync -> already flushed.
+  process.exit(code ?? 0)
+})

--- a/scripts/hooks/channel-inbox-drain.py
+++ b/scripts/hooks/channel-inbox-drain.py
@@ -7,11 +7,13 @@ notifications, so scripts/channel-inbound-tee.mjs persists them to a local JSONL
 inbox. This hook pulls that local queue into the next prompt, using the same
 <channel> framing the --channels path would have produced.
 
-This template is shared with the main agent. Main --channels sessions already
-receive notifications directly, and they normally do not have TELEGRAM_STATE_DIR
-set to a per-agent channel directory; when no local derived inbox exists this
-hook exits silently. All errors are fail-open so prompt submission is never
-blocked.
+This template is shared with the main agent. The MAIN --channels session
+receives Telegram notifications natively and has no local derived inbox to drain;
+draining there would widen the main session's injection surface (the deliberately
+minimal path hardened after the phantom-injection incident). So this hook is
+guarded to the SUB-agents only: the agent_id is derived from the session cwd
+(mirroring inbox-drain.py, inverted) and the MAIN agent exits immediately. All
+errors are fail-open so prompt submission is never blocked.
 """
 import glob
 import html
@@ -19,6 +21,9 @@ import json
 import os
 import sys
 import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ledger_lib  # noqa: E402
 
 
 PREFIX = "[Telegram inbox drain -- %d fuggoben levo uzenet erkezett mikozben a session masszal foglalkozott:]"
@@ -187,6 +192,16 @@ def main():
     payload = _load_payload()
     if payload is None:
         sys.exit(0)
+    # MAIN-agent guard (mirrors inbox-drain.py, inverted). The main --channels
+    # session gets Telegram natively and must not have a file-drop injected into
+    # its prompt; only sub-agents (which load the plugin via mcp.json and drop the
+    # plugin's notifications) drain here. agent_id is derived from the session cwd.
+    try:
+        agent_id = ledger_lib.agent_id_from_cwd(payload.get("cwd") if isinstance(payload, dict) else None)
+        if agent_id == ledger_lib.main_agent_id():
+            sys.exit(0)
+    except Exception:
+        pass  # fail-open: a resolution error must never block prompt submission
     try:
         drain(payload)
     except Exception:

--- a/scripts/hooks/channel-inbox-drain.py
+++ b/scripts/hooks/channel-inbox-drain.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: drain sub-agent Telegram channel notifications.
+
+Telegram sub-agents load the official channel plugin as a plain MCP server to
+avoid the plugin in_use lock. Claude Code ignores that server's channel
+notifications, so scripts/channel-inbound-tee.mjs persists them to a local JSONL
+inbox. This hook pulls that local queue into the next prompt, using the same
+<channel> framing the --channels path would have produced.
+
+This template is shared with the main agent. Main --channels sessions already
+receive notifications directly, and they normally do not have TELEGRAM_STATE_DIR
+set to a per-agent channel directory; when no local derived inbox exists this
+hook exits silently. All errors are fail-open so prompt submission is never
+blocked.
+"""
+import glob
+import html
+import json
+import os
+import sys
+import tempfile
+
+
+PREFIX = "[Telegram inbox drain -- %d fuggoben levo uzenet erkezett mikozben a session masszal foglalkozott:]"
+
+
+def _load_payload():
+    try:
+        return json.load(sys.stdin)
+    except Exception:
+        return None
+
+
+def _state_dir(payload):
+    env_dir = os.environ.get("TELEGRAM_STATE_DIR")
+    if env_dir:
+        return env_dir
+    cwd = ""
+    if isinstance(payload, dict):
+        cwd = payload.get("cwd") or ""
+    if not cwd:
+        return ""
+    return os.path.join(cwd, ".claude", "channels", "telegram")
+
+
+def _claim_one(state_dir):
+    pending = os.path.join(state_dir, "inbox-pending.jsonl")
+    draining = sorted(
+        glob.glob(os.path.join(state_dir, "inbox-draining-*.jsonl")),
+        key=lambda p: (os.path.getmtime(p), p),
+    )
+    for path in draining + [pending]:
+        try:
+            if not os.path.exists(path) or os.path.getsize(path) == 0:
+                continue
+            if os.path.basename(path).startswith("inbox-draining-"):
+                return path
+            claimed = os.path.join(state_dir, "inbox-draining-%d.jsonl" % os.getpid())
+            os.rename(path, claimed)
+            return claimed
+        except FileNotFoundError:
+            return None
+        except Exception:
+            return None
+    return None
+
+
+def _attr(value):
+    return html.escape(str(value), quote=True)
+
+
+def _format_entry(entry):
+    params = entry.get("params") if isinstance(entry, dict) else None
+    if not isinstance(params, dict):
+        return None
+    meta = params.get("meta") if isinstance(params.get("meta"), dict) else {}
+    content = params.get("content")
+    if content is None:
+        content = ""
+    body = str(content).replace("</channel>", "")
+
+    attrs = [('source', 'telegram')]
+    for key in ("chat_id", "message_id", "user", "ts", "image_path"):
+        if key in meta and meta.get(key) is not None:
+            attrs.append((key, meta.get(key)))
+    for key in sorted(meta.keys()):
+        if key.startswith("attachment_") and meta.get(key) is not None:
+            attrs.append((key, meta.get(key)))
+
+    attr_text = " ".join('%s="%s"' % (key, _attr(value)) for key, value in attrs)
+    return "<channel %s>%s</channel>" % (attr_text, body)
+
+
+def _read_entries(path):
+    out = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                formatted = _format_entry(json.loads(line))
+                if formatted:
+                    out.append(formatted)
+            except Exception:
+                continue
+    return out
+
+
+def drain(payload):
+    state_dir = _state_dir(payload)
+    if not state_dir or not os.path.isdir(state_dir):
+        return ""
+    claimed = _claim_one(state_dir)
+    if not claimed:
+        return ""
+
+    entries = _read_entries(claimed)
+    if not entries:
+        try:
+            os.unlink(claimed)
+        except Exception:
+            pass
+        return ""
+
+    text = PREFIX % len(entries) + "\n" + "\n".join(entries)
+    sys.stdout.write(text)
+    sys.stdout.write("\n")
+    os.unlink(claimed)
+    return text
+
+
+def self_test():
+    with tempfile.TemporaryDirectory() as td:
+        state = os.path.join(td, ".claude", "channels", "telegram")
+        os.makedirs(state)
+        pending = os.path.join(state, "inbox-pending.jsonl")
+        entries = [
+            {
+                "receivedAt": 1,
+                "params": {
+                    "content": "hello </channel> world",
+                    "meta": {
+                        "chat_id": "c1",
+                        "message_id": "m1",
+                        "user": "u1",
+                        "ts": "123",
+                        "image_path": "/tmp/img.png",
+                        "attachment_0_name": "a.png",
+                    },
+                },
+            },
+            {"receivedAt": 2, "params": {"content": "second", "meta": {"chat_id": "c2"}}},
+        ]
+        with open(pending, "w", encoding="utf-8") as f:
+            f.write(json.dumps(entries[0]) + "\n")
+            f.write("{malformed\n")
+            f.write(json.dumps(entries[1]) + "\n")
+
+        old_stdout = sys.stdout
+        capture = tempfile.TemporaryFile("w+", encoding="utf-8")
+        try:
+            sys.stdout = capture
+            os.environ["TELEGRAM_STATE_DIR"] = state
+            drain({"cwd": td})
+            capture.seek(0)
+            out = capture.read()
+        finally:
+            sys.stdout = old_stdout
+            os.environ.pop("TELEGRAM_STATE_DIR", None)
+            capture.close()
+
+        assert "2 fuggoben levo uzenet" in out
+        assert "hello  world</channel>" in out
+        assert out.count("<channel ") == 2
+        assert 'image_path="/tmp/img.png"' in out
+        assert 'attachment_0_name="a.png"' in out
+        assert not os.path.exists(pending)
+        assert not glob.glob(os.path.join(state, "inbox-draining-*.jsonl"))
+    print("channel-inbox-drain self-test passed")
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        self_test()
+        sys.exit(0)
+    payload = _load_payload()
+    if payload is None:
+        sys.exit(0)
+    try:
+        drain(payload)
+    except Exception:
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__tests__/channel-inbound-tee.test.ts
+++ b/src/__tests__/channel-inbound-tee.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import { buildTelegramMcpServerConfig } from '../web/agent-process.js'
+import { PROJECT_ROOT } from '../config.js'
+
+const WRAPPER = join(PROJECT_ROOT, 'scripts', 'channel-inbound-tee.mjs')
+
+function runWrapper(stateDir: string, childCode: string): Promise<{ stdout: string, stderr: string, code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [WRAPPER, process.execPath, '-e', childCode], {
+      env: { ...process.env, TELEGRAM_STATE_DIR: stateDir },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => { stdout += chunk })
+    child.stderr.on('data', (chunk) => { stderr += chunk })
+    child.on('error', reject)
+    child.on('exit', (code) => resolve({ stdout, stderr, code }))
+    // MCP-contract: the parent owns the wrapper's stdin; close it so the
+    // wrapper can exit once its child is done (mirrors a client disconnect).
+    child.stdin.end()
+  })
+}
+
+describe('channel-inbound-tee', () => {
+  it('passes stdout through byte-for-byte and tees split channel notifications to the inbox', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'channel-inbound-tee-'))
+    try {
+      const notification = JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'notifications/claude/channel',
+        params: {
+          content: 'hello',
+          meta: { chat_id: 'c1', message_id: 'm1', user: 'u1', ts: '123' },
+        },
+      })
+      const response = JSON.stringify({ jsonrpc: '2.0', id: 1, result: { ok: true } })
+      const nonJson = 'not json'
+      const expected = notification + '\n' + response + '\n' + nonJson + '\n'
+      const childCode = `
+        const fs = require('node:fs');
+        const notification = ${JSON.stringify(notification)};
+        const response = ${JSON.stringify(response)};
+        fs.writeSync(1, notification.slice(0, 35));
+        setTimeout(() => {
+          fs.writeSync(1, notification.slice(35) + '\\n');
+          fs.writeSync(1, response + '\\n');
+          fs.writeSync(1, ${JSON.stringify(nonJson + '\n')});
+        }, 10);
+      `
+
+      const result = await runWrapper(dir, childCode)
+      expect(result.code).toBe(0)
+      expect(result.stderr).toBe('')
+      expect(result.stdout).toBe(expected)
+
+      const inbox = readFileSync(join(dir, 'inbox-pending.jsonl'), 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+      expect(inbox).toHaveLength(1)
+      expect(inbox[0].receivedAt).toEqual(expect.any(Number))
+      expect(inbox[0].params).toEqual({
+        content: 'hello',
+        meta: { chat_id: 'c1', message_id: 'm1', user: 'u1', ts: '123' },
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('buildTelegramMcpServerConfig', () => {
+  it('routes the per-agent telegram MCP server through the inbound tee wrapper', () => {
+    const cfg = buildTelegramMcpServerConfig('/home/me/.bun/bin/bun', '/plugins/telegram/0.0.6', '/agents/nova/.claude/channels/telegram')
+    expect(cfg.command).toBe('node')
+    expect(cfg.args).toEqual([
+      join(PROJECT_ROOT, 'scripts', 'channel-inbound-tee.mjs'),
+      '/home/me/.bun/bin/bun',
+      'run',
+      '--cwd',
+      '/plugins/telegram/0.0.6',
+      '--shell=bun',
+      '--silent',
+      'start',
+    ])
+    expect(cfg.env).toEqual({ TELEGRAM_STATE_DIR: '/agents/nova/.claude/channels/telegram' })
+  })
+})

--- a/src/__tests__/hook-registration-guard.test.ts
+++ b/src/__tests__/hook-registration-guard.test.ts
@@ -168,6 +168,9 @@ describe('pruneStaleHookEntries', () => {
     expect(KNOWN_HOOK_SCRIPTS).toContain('voice-reply-directive.py')
     expect(KNOWN_HOOK_SCRIPTS).toContain('taskstate-replay.py')
     expect(KNOWN_HOOK_SCRIPTS).toContain('staleness-guard.py')
+    // channel-inbox-drain.py is app-registered (templates/settings.json.template),
+    // so a missing-file entry must be prunable-as-ours, not treated as foreign.
+    expect(KNOWN_HOOK_SCRIPTS).toContain('channel-inbox-drain.py')
   })
 })
 

--- a/src/__tests__/message-router-tick-cap.test.ts
+++ b/src/__tests__/message-router-tick-cap.test.ts
@@ -24,6 +24,10 @@ vi.mock('../logger.js', () => ({
 
 vi.mock('../config.js', () => ({
   MAIN_AGENT_ID: 'orin',
+  // message-router imports maybeWakeSubAgentsForTelegram, which reads this flag
+  // from config; keep it OFF so the wake watcher early-returns and this test
+  // stays isolated to the per-tick message cap.
+  SUBAGENT_TELEGRAM_WAKE_ENABLED: false,
 }))
 
 vi.mock('../db.js', () => ({

--- a/src/__tests__/scope-channel-plugins.test.ts
+++ b/src/__tests__/scope-channel-plugins.test.ts
@@ -147,11 +147,18 @@ describe('spawn-time enable decision (ownChannelProviderForScope + scopeChannelP
 describe('spawn-time scoping is gated on the own token, not the explicit provider field', () => {
   const SRC = readFileSync(join(__dirname, '../web/agent-process.ts'), 'utf-8')
 
-  it('the scopeChannelPlugins call argument is ownChannelProviderForScope(...)', () => {
+  it('the scopeChannelPlugins source is gated on ownChannelProviderForScope(...), not readAgentChannelProvider', () => {
+    // The per-agent mcp.json feature (35fdef8) routes the scope through a local
+    // `scopeProvider` (null on the mcp.json path, ownChannelProviderForScope(...)
+    // otherwise) instead of inlining the argument. The regression-locked invariant
+    // is unchanged: the provider still comes from the own-token gate, never from
+    // readAgentChannelProvider. Check the scopeProvider definition that feeds the call.
+    const defIdx = SRC.indexOf('const scopeProvider')
     const callIdx = SRC.indexOf('s.enabledPlugins = scopeChannelPlugins(')
-    expect(callIdx).toBeGreaterThan(0)
-    const arg = SRC.slice(callIdx, callIdx + 120)
-    expect(arg).toMatch(/ownChannelProviderForScope\(/)
-    expect(arg).not.toMatch(/readAgentChannelProvider\(/)
+    expect(defIdx).toBeGreaterThan(0)
+    expect(callIdx).toBeGreaterThan(defIdx)
+    const def = SRC.slice(defIdx, callIdx)
+    expect(def).toMatch(/ownChannelProviderForScope\(/)
+    expect(def).not.toMatch(/readAgentChannelProvider\(/)
   })
 })

--- a/src/__tests__/telegram-inbox-wake.test.ts
+++ b/src/__tests__/telegram-inbox-wake.test.ts
@@ -5,7 +5,7 @@
 // (hasPending + age + debounce + session-exists + session-idle) are exercised.
 
 import { describe, it, expect } from 'vitest'
-import { shouldWakeForTelegramInbox } from '../web/telegram-inbox-wake.js'
+import { shouldWakeForTelegramInbox, wakeBackoffMs } from '../web/telegram-inbox-wake.js'
 
 const BASE = {
   inboxAgeMs: 60_000,
@@ -46,5 +46,41 @@ describe('shouldWakeForTelegramInbox (pure gate decision)', () => {
 
   it('does NOT wake when the session is busy/mid-turn -- avoids the inject race', () => {
     expect(shouldWakeForTelegramInbox({ ...BASE, sessionIdle: false })).toBe(false)
+  })
+
+  it('stops nudging once the per-agent attempt budget is exhausted', () => {
+    // debounce elapsed and everything else ready, but attempts >= maxAttempts
+    expect(shouldWakeForTelegramInbox({
+      ...BASE, lastWakeAt: 0, attempts: 5, maxAttempts: 5,
+    })).toBe(false)
+    // one under the budget still wakes (backoff window permitting)
+    expect(shouldWakeForTelegramInbox({
+      ...BASE, lastWakeAt: 0, attempts: 4, maxAttempts: 5,
+    })).toBe(true)
+  })
+
+  it('applies exponential backoff: a higher attempt count needs a longer gap', () => {
+    const commonDebounce = { ...BASE, debounceMs: 60_000, maxDebounceMs: 30 * 60_000 }
+    // attempt 2 -> effective gap 60s * 2^2 = 240s. 200s since last nudge: too soon.
+    expect(shouldWakeForTelegramInbox({
+      ...commonDebounce, attempts: 2, lastWakeAt: BASE.now - 200_000,
+    })).toBe(false)
+    // 240s since last nudge: exactly at the backed-off boundary -> allowed.
+    expect(shouldWakeForTelegramInbox({
+      ...commonDebounce, attempts: 2, lastWakeAt: BASE.now - 240_000,
+    })).toBe(true)
+  })
+})
+
+describe('wakeBackoffMs (exponential gap with cap)', () => {
+  it('is the base gap at attempt 0 (unchanged first-retry behaviour)', () => {
+    expect(wakeBackoffMs(0, 60_000, 30 * 60_000)).toBe(60_000)
+  })
+  it('doubles per attempt', () => {
+    expect(wakeBackoffMs(1, 60_000, 30 * 60_000)).toBe(120_000)
+    expect(wakeBackoffMs(3, 60_000, 30 * 60_000)).toBe(480_000)
+  })
+  it('never exceeds the cap', () => {
+    expect(wakeBackoffMs(10, 60_000, 30 * 60_000)).toBe(30 * 60_000)
   })
 })

--- a/src/__tests__/telegram-inbox-wake.test.ts
+++ b/src/__tests__/telegram-inbox-wake.test.ts
@@ -1,0 +1,50 @@
+// Tests for the sub-agent Telegram inbox wake-nudge.
+//
+// The pure gate decision (shouldWakeForTelegramInbox) is tested exhaustively
+// with no filesystem or tmux, mirroring shouldWakeMainAgent. All five conditions
+// (hasPending + age + debounce + session-exists + session-idle) are exercised.
+
+import { describe, it, expect } from 'vitest'
+import { shouldWakeForTelegramInbox } from '../web/telegram-inbox-wake.js'
+
+const BASE = {
+  inboxAgeMs: 60_000,
+  hasPending: true,
+  now: 1_000_000_000,
+  lastWakeAt: 0,
+  sessionExists: true,
+  sessionIdle: true,
+  minAgeMs: 25_000,
+  debounceMs: 60_000,
+}
+
+describe('shouldWakeForTelegramInbox (pure gate decision)', () => {
+  it('wakes when inbox has pending content, is old enough, session idle, debounce elapsed', () => {
+    expect(shouldWakeForTelegramInbox(BASE)).toBe(true)
+  })
+
+  it('does NOT wake when there is nothing pending', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, hasPending: false })).toBe(false)
+  })
+
+  it('does NOT wake for a fresh inbox (age gate, strict >)', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, inboxAgeMs: 10_000 })).toBe(false)
+    // exactly at the threshold is still not old enough
+    expect(shouldWakeForTelegramInbox({ ...BASE, inboxAgeMs: 25_000 })).toBe(false)
+    expect(shouldWakeForTelegramInbox({ ...BASE, inboxAgeMs: 25_001 })).toBe(true)
+  })
+
+  it('does NOT wake within the debounce window of the last nudge', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, lastWakeAt: BASE.now - 30_000 })).toBe(false)
+    // exactly at the debounce boundary is allowed
+    expect(shouldWakeForTelegramInbox({ ...BASE, lastWakeAt: BASE.now - 60_000 })).toBe(true)
+  })
+
+  it('does NOT wake when the sub-agent session is absent', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, sessionExists: false })).toBe(false)
+  })
+
+  it('does NOT wake when the session is busy/mid-turn -- avoids the inject race', () => {
+    expect(shouldWakeForTelegramInbox({ ...BASE, sessionIdle: false })).toBe(false)
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -254,6 +254,18 @@ export const HEARTBEAT_START_HOUR = parseInt(env['HEARTBEAT_START_HOUR'] ?? '9',
 export const HEARTBEAT_AGENT_ENABLED =
   ['1', 'true', 'yes', 'on'].includes((cfg('HEARTBEAT_AGENT_ENABLED') ?? '').trim().toLowerCase())
 
+// Sub-agent Telegram inbox wake-nudge (opt-in, DEFAULT OFF).
+// The message-router can nudge an idle sub-agent whose derived Telegram inbox
+// (<state>/inbox-pending.jsonl) has stuck inbound messages, so its drain hook
+// fires and claims the backlog. PREREQUISITE not yet upstream: the inbound-tee
+// writer and the UserPromptSubmit drain hook that produce/consume that inbox
+// file. Until they land, no inbox file exists and the watcher is a no-op even
+// when enabled. Ships DISABLED so an upstream install sees zero behaviour change
+// and pays no per-tick cost; enable with SUBAGENT_TELEGRAM_WAKE_ENABLED=1 once
+// the drain path is in place.
+export const SUBAGENT_TELEGRAM_WAKE_ENABLED =
+  ['1', 'true', 'yes', 'on'].includes((cfg('SUBAGENT_TELEGRAM_WAKE_ENABLED') ?? '').trim().toLowerCase())
+
 // Google Calendar account the heartbeat summarises (next 2h). Empty (the
 // default) means the agent uses whatever calendar its MCP server is
 // authenticated as, so no personal address is baked into the shipped

--- a/src/config.ts
+++ b/src/config.ts
@@ -254,15 +254,27 @@ export const HEARTBEAT_START_HOUR = parseInt(env['HEARTBEAT_START_HOUR'] ?? '9',
 export const HEARTBEAT_AGENT_ENABLED =
   ['1', 'true', 'yes', 'on'].includes((cfg('HEARTBEAT_AGENT_ENABLED') ?? '').trim().toLowerCase())
 
+// Sub-agent Telegram inbox delivery-path tee (opt-in, DEFAULT OFF).
+// When enabled, a telegram sub-agent loads the channel plugin via a per-agent
+// mcp.json wrapped in the inbound-tee (scripts/channel-inbound-tee.mjs), which
+// persists each inbound notification to <state>/inbox-pending.jsonl for the
+// channel-inbox-drain UserPromptSubmit hook to pull into the next turn. This
+// swaps the default `--channels` delivery path, so it is DEFAULT OFF: an install
+// that does not opt in keeps the exact upstream `--channels` behaviour and never
+// writes message content to disk. Enable with SUBAGENT_INBOX_TEE=1 (required for
+// SUBAGENT_TELEGRAM_WAKE_ENABLED to have an inbox to wake on).
+export const SUBAGENT_INBOX_TEE =
+  ['1', 'true', 'yes', 'on'].includes((cfg('SUBAGENT_INBOX_TEE') ?? '').trim().toLowerCase())
+
 // Sub-agent Telegram inbox wake-nudge (opt-in, DEFAULT OFF).
 // The message-router can nudge an idle sub-agent whose derived Telegram inbox
 // (<state>/inbox-pending.jsonl) has stuck inbound messages, so its drain hook
-// fires and claims the backlog. PREREQUISITE not yet upstream: the inbound-tee
-// writer and the UserPromptSubmit drain hook that produce/consume that inbox
-// file. Until they land, no inbox file exists and the watcher is a no-op even
-// when enabled. Ships DISABLED so an upstream install sees zero behaviour change
-// and pays no per-tick cost; enable with SUBAGENT_TELEGRAM_WAKE_ENABLED=1 once
-// the drain path is in place.
+// fires and claims the backlog. This is the ACTIVE tail of the SUBAGENT_INBOX_TEE
+// delivery path: the tee writer and the UserPromptSubmit drain hook now ship in
+// this repo, but both are gated -- with SUBAGENT_INBOX_TEE off no inbox file is
+// produced and this watcher is a no-op even when enabled. Ships DISABLED so an
+// upstream install sees zero behaviour change and pays no per-tick cost; enable
+// with SUBAGENT_TELEGRAM_WAKE_ENABLED=1 (alongside SUBAGENT_INBOX_TEE=1).
 export const SUBAGENT_TELEGRAM_WAKE_ENABLED =
   ['1', 'true', 'yes', 'on'].includes((cfg('SUBAGENT_TELEGRAM_WAKE_ENABLED') ?? '').trim().toLowerCase())
 

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -104,6 +104,21 @@ export function ownChannelProviderForScope(
   return hasOwnToken && resolvedProvider ? resolvedProvider : null
 }
 
+// Wrap the telegram plugin's bun stdio server in a tee that persists each
+// inbound channel notification to <stateDir>/inbox-pending.jsonl, which the
+// channel-inbox-drain UserPromptSubmit hook then pulls into the next turn.
+// Sub-agents load the plugin as a plain MCP server, so Claude Code drops its
+// channel notifications; this tee is what makes SUBAGENT_TELEGRAM_WAKE_ENABLED
+// have an inbox to wake on.
+export function buildTelegramMcpServerConfig(bunBin: string, pluginDir: string, stateDir: string) {
+  const wrapper = join(PROJECT_ROOT, 'scripts', 'channel-inbound-tee.mjs')
+  return {
+    command: 'node',
+    args: [wrapper, bunBin, 'run', '--cwd', pluginDir, '--shell=bun', '--silent', 'start'],
+    env: { TELEGRAM_STATE_DIR: stateDir },
+  }
+}
+
 // The fleet's shared long-lived OAuth token (from `claude setup-token`), stored
 // 0600 in store/. Isolated channel sub-agents authenticate via this token in the
 // CLAUDE_CODE_OAUTH_TOKEN env var -- NOT via a copied/symlinked .credentials.json.
@@ -757,21 +772,57 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // its channel comes up via channels.sh -- but if a future caller ever passed
     // MAIN_AGENT_ID in, scopeChannelPlugins(null) would DISABLE the owner's
     // telegram channel (Szabi's primary line). Refuse outright.
+    //
+    // Telegram agents use a per-agent .mcp.json to spawn their own bun process
+    // instead of the shared --channels flag path. The --channels path goes
+    // through the plugin's .in_use/<pid> lock: if one process already holds the
+    // lock, every other agent that starts with --channels gets "already in use"
+    // and ends up with No MCP servers configured -- no bun, no bot.pid, deaf to
+    // inbound Telegram. The mcp.json path bypasses the lock: Claude Code spawns a
+    // fresh bun stdio server per agent, each with its own TELEGRAM_STATE_DIR. The
+    // stdio tee wrapper restores inbound delivery by persisting notifications to a
+    // local inbox that the UserPromptSubmit drain hook pulls into context.
+    let useMcpJsonForChannel = false
+    if (hasChannel && agentProvider === 'telegram' && name !== MAIN_AGENT_ID) {
+      try {
+        const pluginCacheDir = join(homedir(), '.claude', 'plugins', 'cache', 'claude-plugins-official', 'telegram')
+        const versions = existsSync(pluginCacheDir)
+          ? readdirSync(pluginCacheDir).filter(v => /^\d+\.\d+\.\d+$/.test(v)).sort().reverse()
+          : []
+        const pluginVersion = versions[0] ?? '0.0.6'
+        const pluginDir = join(pluginCacheDir, pluginVersion)
+        const bunBin = join(homedir(), '.bun', 'bin', 'bun')
+        // The agent working-dir .mcp.json (NOT .claude/mcp.json) is what Claude Code
+        // loads as project-scope MCP config. An empty .mcp.json already present would
+        // override .claude/mcp.json, so write to the same file Claude Code reads.
+        const mcpJsonPath = join(agentDir(name), '.mcp.json')
+        const mcpConfig = {
+          mcpServers: {
+            'plugin:telegram:telegram': buildTelegramMcpServerConfig(bunBin, pluginDir, agentChannelDir),
+          },
+        }
+        writeFileSync(mcpJsonPath, JSON.stringify(mcpConfig, null, 2))
+        useMcpJsonForChannel = true
+        logger.info({ name, pluginVersion, pluginDir }, 'Wrote per-agent mcp.json for telegram plugin')
+      } catch (err) {
+        logger.warn({ err, name }, 'Could not write mcp.json for telegram agent; falling back to --channels flag')
+      }
+    }
+
     if (name !== MAIN_AGENT_ID) {
       const settingsPath = join(agentDir(name), '.claude', 'settings.json')
       try {
         const s = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>
-        // Gate the enable decision on the SAME signal as the --channels launch
-        // flag: a real own bot token in this agent's channel .env (token, above).
-        // A genuine own-token agent enables its own provider's plugin; a channel-
-        // less agent (no own token, only the legacy/global fallback that still
-        // marks hasChannel) yields null -> all providers disabled, so it never
-        // fights the main agent over the shared getUpdates slot. Keying on the
-        // explicit channelProvider config field instead (always null for sub-agents)
-        // was the regression that disabled the plugin for every legitimately-
-        // channelled sub-agent after a respawn (truly-unreachable plugin, no poller).
+        // When mcp.json is used for the telegram plugin, force enabledPlugins.telegram
+        // to false so Claude Code does not ALSO load the plugin via the marketplace
+        // enabledPlugins path -- that would spawn a second bun process and produce
+        // 409 Conflict / poller races. When --channels is still used (non-telegram
+        // providers or mcp.json write failure), keep the original token-gated logic.
+        const scopeProvider = useMcpJsonForChannel
+          ? null
+          : ownChannelProviderForScope(!!token, agentProvider)
         s.enabledPlugins = scopeChannelPlugins(
-          ownChannelProviderForScope(!!token, agentProvider),
+          scopeProvider,
           s.enabledPlugins as Record<string, boolean> | undefined,
         )
         writeFileSync(settingsPath, JSON.stringify(s, null, 2))

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -34,7 +34,7 @@ import {
 } from './ssh-tmux.js'
 import { parseTelegramToken } from './telegram.js'
 import { getProvider, getProviderType, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
-import { CHANNEL_PROVIDER, MAIN_AGENT_ID, STORE_DIR, PROJECT_ROOT } from '../config.js'
+import { CHANNEL_PROVIDER, MAIN_AGENT_ID, STORE_DIR, PROJECT_ROOT, SUBAGENT_INBOX_TEE } from '../config.js'
 import { getEffectiveSettingValue } from '../settings-store.js'
 import { loadProfileTemplate } from './profiles.js'
 import { resolveAgentSecurityProfile } from './agent-team.js'
@@ -782,8 +782,15 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // fresh bun stdio server per agent, each with its own TELEGRAM_STATE_DIR. The
     // stdio tee wrapper restores inbound delivery by persisting notifications to a
     // local inbox that the UserPromptSubmit drain hook pulls into context.
+    //
+    // OPT-IN / DEFAULT OFF (SUBAGENT_INBOX_TEE). This mcp.json+tee swap is a
+    // delivery-path change: it writes inbound message content to a local inbox
+    // file for the drain hook to pull. With the flag off, telegram sub-agents
+    // keep the upstream `--channels` path unchanged and nothing is written to
+    // disk. Only opt in together with the channel-inbox-drain hook + (optionally)
+    // SUBAGENT_TELEGRAM_WAKE_ENABLED.
     let useMcpJsonForChannel = false
-    if (hasChannel && agentProvider === 'telegram' && name !== MAIN_AGENT_ID) {
+    if (SUBAGENT_INBOX_TEE && hasChannel && agentProvider === 'telegram' && name !== MAIN_AGENT_ID) {
       try {
         const pluginCacheDir = join(homedir(), '.claude', 'plugins', 'cache', 'claude-plugins-official', 'telegram')
         const versions = existsSync(pluginCacheDir)
@@ -923,7 +930,14 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     const channelSetup = hasChannel
       ? `export ${stateEnvVar}="${agentChannelDir}"${auditLogEnv} && `
       : ''
-    const channelFlag = hasChannel ? `--channels plugin:${provider.pluginId}` : ''
+    // When the per-agent mcp.json+tee path is active (SUBAGENT_INBOX_TEE), the
+    // plugin is already loaded as a plain MCP server, so ALSO passing --channels
+    // would register the plugin a SECOND way -- a duplicate poller racing the tee
+    // process over the same getUpdates slot. Suppress --channels in that case and
+    // rely solely on mcp.json (enabledPlugins is already forced false above for
+    // the same reason). Every other agent (non-telegram, main, or flag off) keeps
+    // the --channels launch path unchanged.
+    const channelFlag = hasChannel && !useMcpJsonForChannel ? `--channels plugin:${provider.pluginId}` : ''
     // Channel-plugin MCP-registration guard (2026-06-23): the telegram/slack/etc.
     // channel plugin registers as a stdio MCP server loaded via --channels. Claude
     // Code connects stdio MCP servers in batches of MCP_SERVER_CONNECTION_BATCH_SIZE

--- a/src/web/hook-registration-guard.ts
+++ b/src/web/hook-registration-guard.ts
@@ -35,6 +35,7 @@ export const KNOWN_HOOK_SCRIPTS: readonly string[] = [
   'telegram_progress_clear.py',
   'telegram_progress_watchdog.py',
   'inbox-drain.py',
+  'channel-inbox-drain.py',
   'ledger-capture.py',
 ]
 

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -17,6 +17,7 @@ import {
 import { setLastInboundModality } from './voice-modality.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from './agent-message-wrap.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { maybeWakeSubAgentsForTelegram } from './telegram-inbox-wake.js'
 
 // A message that cannot be delivered within this window (target session never
 // exists / stays busy) is marked failed so it stops clogging the pending
@@ -237,6 +238,13 @@ export async function runMessageRouterTick(): Promise<void> {
         routerLoggedMisses.delete(msg.id)
       }
     }
+
+    // Independently of the inter-agent queue above: wake idle sub-agents whose
+    // Telegram inbox (inbox-pending.jsonl) has stuck inbound messages the drain
+    // hook cannot pull without a turn. No-op unless SUBAGENT_TELEGRAM_WAKE_ENABLED
+    // (default off); when enabled it is cheap statSync-gated so an empty fleet
+    // costs one stat per agent and no tmux I/O.
+    maybeWakeSubAgentsForTelegram(now)
 }
 
 // ---- voice helpers (message-router level) ----------------------------------

--- a/src/web/telegram-inbox-wake.ts
+++ b/src/web/telegram-inbox-wake.ts
@@ -1,0 +1,167 @@
+import { statSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID, SUBAGENT_TELEGRAM_WAKE_ENABLED } from '../config.js'
+import { resolveAgentChannelStateDir } from './voice-directive.js'
+import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
+import {
+  agentSessionName,
+  isSessionReadyForPrompt,
+  sendPromptToSession,
+  sessionExistsOnHost,
+} from './agent-process.js'
+
+// --- sub-agent Telegram inbox wake-nudge --------------------------------------
+// Extends the main-agent wake-nudge (message-router.ts) to the
+// sub-agents. Sub-agents load the official channel plugin
+// as a plain MCP server (per-agent mcp.json) to dodge the plugin in_use lock, so
+// Claude Code drops that server's channel notifications. An inbound-tee persists
+// each inbound to <state>/inbox-pending.jsonl, and a UserPromptSubmit drain hook
+// pulls it into the NEXT turn.
+//
+// The gap: the drain hook only fires when the agent takes a turn. An idle
+// sub-agent (no user prompt, no --channels registration to start one) never
+// drains, so a Telegram message can sit in inbox-pending.jsonl forever. This
+// watcher closes that gap the same way the main agent's does: when a sub-agent's
+// pending inbox has been stuck long enough AND its tmux session is idle, inject a
+// minimal, CONTENT-FREE prompt so the drain hook fires and claims the backlog.
+//
+// The nudge carries NO content and does NOT touch the inbox file: the drain hook
+// owns the atomic claim (rename) and the <channel> security framing (single
+// source, no drift). This is the exact operation the scheduler already performs
+// against sub-agent sessions for heartbeats (sendPromptToSession, idle-gated) --
+// only the trigger differs, which is why the risk is low.
+//
+// OPT-IN / DEFAULT-OFF: gated by SUBAGENT_TELEGRAM_WAKE_ENABLED. The inbound-tee
+// writer and drain hook that produce/consume inbox-pending.jsonl are NOT yet
+// upstream, so with them absent there is no inbox file to wake on and this is a
+// no-op regardless. Shipping it disabled means an upstream install pays zero
+// per-tick cost and sees no behaviour change until the drain path lands and the
+// operator explicitly opts in.
+
+// How long the pending inbox must have sat untouched before the first wake-nudge.
+// Measured as now - mtime(inbox-pending.jsonl): the age of the LAST inbound. A
+// fresh file means a message just arrived (let the natural drain try first, or
+// let a burst finish arriving before we nudge once for the whole batch).
+const SUB_TELEGRAM_WAKE_MIN_AGE_MS = 25 * 1000
+// Minimum gap between wake-nudges per agent. One nudge starts a turn whose drain
+// claims the WHOLE pending file, so re-nudging sooner just piles redundant
+// prompts on a session already handling its inbox.
+const SUB_TELEGRAM_WAKE_DEBOUNCE_MS = 60 * 1000
+// Content-free wake prompt. The channel-inbox-drain UserPromptSubmit hook
+// PREPENDS the claimed (already security-framed) <channel> messages above this
+// line, so the nudge is only a trailing trigger -- it must never carry inbound
+// content itself.
+const SUB_TELEGRAM_WAKE_NUDGE =
+  '[telegram-wake] Bejövő Telegram üzenet(ek) várnak; a drain hook behúzta őket a kontextusba fentebb. Dolgozd fel és válaszolj.'
+
+// Last wake-nudge timestamp per agent name (module-scoped debounce state).
+const _lastSubWakeAt = new Map<string, number>()
+
+/**
+ * Pure decision: should the watcher send a wake-nudge to a sub-agent's session
+ * for a stuck Telegram inbox? Dependency-free so it is unit-testable without
+ * tmux or the filesystem, mirroring shouldWakeMainAgent. ALL conditions hold:
+ *   - the inbox has pending content (nothing to drain otherwise);
+ *   - it has sat untouched longer than minAgeMs (let a fresh arrival drain via a
+ *     natural turn / let a burst settle first);
+ *   - the debounce window since the last nudge for THIS agent has elapsed;
+ *   - the session exists (nothing to wake otherwise);
+ *   - it is idle (never inject a prompt mid-turn -- that is the race the main
+ *     wake-nudge was designed to avoid).
+ */
+export function shouldWakeForTelegramInbox(params: {
+  inboxAgeMs: number
+  hasPending: boolean
+  now: number
+  lastWakeAt: number
+  sessionExists: boolean
+  sessionIdle: boolean
+  minAgeMs: number
+  debounceMs: number
+}): boolean {
+  const { inboxAgeMs, hasPending, now, lastWakeAt, sessionExists, sessionIdle, minAgeMs, debounceMs } = params
+  if (!hasPending) return false
+  if (inboxAgeMs <= minAgeMs) return false
+  if (now - lastWakeAt < debounceMs) return false
+  if (!sessionExists) return false
+  if (!sessionIdle) return false
+  return true
+}
+
+// I/O wrapper around shouldWakeForTelegramInbox: for each sub-agent, probes the
+// pending-inbox file and (only when it looks stuck) the session's presence and
+// idle state, then nudges. Called once per message-router tick.
+//
+// Cheap gates run FIRST so the common case (no stuck inbox) costs one statSync
+// per agent and ZERO tmux I/O: isSessionReadyForPrompt does a blocking sleep +
+// two capture-panes, so probing it for every agent every tick would pin the
+// event loop. Only an agent with a genuinely stuck, out-of-debounce inbox pays
+// for the session probe.
+export function maybeWakeSubAgentsForTelegram(now: number): void {
+  // OPT-IN gate (DEFAULT OFF). Cheapest possible early-out: when disabled the
+  // whole watcher is a single boolean check per tick and touches no filesystem.
+  if (!SUBAGENT_TELEGRAM_WAKE_ENABLED) return
+
+  let names: string[]
+  try {
+    names = listAgentNames()
+  } catch (err) {
+    logger.warn({ err }, 'telegram-inbox-wake: listAgentNames failed')
+    return
+  }
+  for (const name of names) {
+    // The main agent runs with --channels and receives notifications natively;
+    // it has no local derived inbox to drain.
+    if (name === MAIN_AGENT_ID) continue
+    try {
+      const stateDir = resolveAgentChannelStateDir(name, 'telegram')
+      const inboxPath = join(stateDir, 'inbox-pending.jsonl')
+      let size: number
+      let mtimeMs: number
+      try {
+        const st = statSync(inboxPath)
+        size = st.size
+        mtimeMs = st.mtimeMs
+      } catch {
+        continue // no inbox file -> nothing pending for this agent
+      }
+      if (size === 0) continue
+      const inboxAgeMs = now - mtimeMs
+      // Cheap gates before any tmux I/O (mirrors maybeWakeMainAgent).
+      if (inboxAgeMs <= SUB_TELEGRAM_WAKE_MIN_AGE_MS) continue
+      const lastWakeAt = _lastSubWakeAt.get(name) ?? 0
+      if (now - lastWakeAt < SUB_TELEGRAM_WAKE_DEBOUNCE_MS) continue
+
+      const host = readAgentRemoteHost(name)
+      const session = agentSessionName(name)
+      const sessionExists = sessionExistsOnHost(host, session)
+      // isSessionReadyForPrompt already reports a widget-over-idle ('unknown')
+      // pane as NOT ready, so a TodoWrite-widget session is conservatively left
+      // alone rather than nudged mid-widget -- the safe default for injection.
+      const sessionIdle = sessionExists && isSessionReadyForPrompt(session, host)
+
+      if (!shouldWakeForTelegramInbox({
+        inboxAgeMs,
+        hasPending: true,
+        now,
+        lastWakeAt,
+        sessionExists,
+        sessionIdle,
+        minAgeMs: SUB_TELEGRAM_WAKE_MIN_AGE_MS,
+        debounceMs: SUB_TELEGRAM_WAKE_DEBOUNCE_MS,
+      })) continue
+
+      sendPromptToSession(session, SUB_TELEGRAM_WAKE_NUDGE, host)
+      _lastSubWakeAt.set(name, now)
+      logger.info({ agent: name, session, ageMs: Math.round(inboxAgeMs) }, 'telegram-inbox-wake: nudged idle sub-agent (pending inbox)')
+    } catch (err) {
+      logger.warn({ err, agent: name }, 'telegram-inbox-wake: wake check failed')
+    }
+  }
+}
+
+// Test-only: reset the per-agent debounce state between unit tests.
+export function _resetSubWakeStateForTest(): void {
+  _lastSubWakeAt.clear()
+}

--- a/src/web/telegram-inbox-wake.ts
+++ b/src/web/telegram-inbox-wake.ts
@@ -33,21 +33,33 @@ import {
 // only the trigger differs, which is why the risk is low.
 //
 // OPT-IN / DEFAULT-OFF: gated by SUBAGENT_TELEGRAM_WAKE_ENABLED. The inbound-tee
-// writer and drain hook that produce/consume inbox-pending.jsonl are NOT yet
-// upstream, so with them absent there is no inbox file to wake on and this is a
-// no-op regardless. Shipping it disabled means an upstream install pays zero
-// per-tick cost and sees no behaviour change until the drain path lands and the
-// operator explicitly opts in.
+// writer and drain hook that produce/consume inbox-pending.jsonl ship in this
+// repo but are themselves gated behind SUBAGENT_INBOX_TEE (default off), so with
+// that path disabled there is no inbox file to wake on and this is a no-op
+// regardless. Shipping it disabled means an upstream install pays zero per-tick
+// cost and sees no behaviour change until BOTH flags are opted in.
 
 // How long the pending inbox must have sat untouched before the first wake-nudge.
 // Measured as now - mtime(inbox-pending.jsonl): the age of the LAST inbound. A
 // fresh file means a message just arrived (let the natural drain try first, or
 // let a burst finish arriving before we nudge once for the whole batch).
 const SUB_TELEGRAM_WAKE_MIN_AGE_MS = 25 * 1000
-// Minimum gap between wake-nudges per agent. One nudge starts a turn whose drain
+// Base gap between wake-nudges per agent. One nudge starts a turn whose drain
 // claims the WHOLE pending file, so re-nudging sooner just piles redundant
-// prompts on a session already handling its inbox.
+// prompts on a session already handling its inbox. This is the FIRST-retry gap;
+// the effective gap grows exponentially with the per-agent attempt count (see
+// backoff below).
 const SUB_TELEGRAM_WAKE_DEBOUNCE_MS = 60 * 1000
+// Backoff cap: the exponential gap never exceeds this, so a stuck session is
+// probed at most ~twice an hour rather than every minute.
+const SUB_TELEGRAM_WAKE_MAX_DEBOUNCE_MS = 30 * 60 * 1000
+// Max wake-nudges spent on ONE stuck inbox before giving up. A session that
+// never drains after this many nudges is not going to; further nudges just spam
+// it every backoff window forever (the failure mode called out in review). The
+// budget is per DISTINCT backlog: when a NEW inbound arrives (the inbox file's
+// mtime advances) the attempt counter resets, so a genuinely new message always
+// gets a fresh round of nudges.
+const SUB_TELEGRAM_WAKE_MAX_ATTEMPTS = 5
 // Content-free wake prompt. The channel-inbox-drain UserPromptSubmit hook
 // PREPENDS the claimed (already security-framed) <channel> messages above this
 // line, so the nudge is only a trailing trigger -- it must never carry inbound
@@ -55,8 +67,24 @@ const SUB_TELEGRAM_WAKE_DEBOUNCE_MS = 60 * 1000
 const SUB_TELEGRAM_WAKE_NUDGE =
   '[telegram-wake] Bejövő Telegram üzenet(ek) várnak; a drain hook behúzta őket a kontextusba fentebb. Dolgozd fel és válaszolj.'
 
-// Last wake-nudge timestamp per agent name (module-scoped debounce state).
-const _lastSubWakeAt = new Map<string, number>()
+// Per-agent wake state (module-scoped). `attempts` counts nudges spent on the
+// CURRENT stuck backlog; `inboxMtimeMs` is the mtime we last acted on, used to
+// detect a fresh inbound (mtime advance) and reset the attempt budget.
+interface SubWakeState {
+  lastWakeAt: number
+  attempts: number
+  inboxMtimeMs: number
+}
+const _subWakeState = new Map<string, SubWakeState>()
+
+/**
+ * Compute the effective backoff gap for the Nth wake attempt: base * 2^attempts,
+ * capped at maxMs. attempts=0 -> base (unchanged first-retry behaviour). Pure.
+ */
+export function wakeBackoffMs(attempts: number, baseMs: number, maxMs: number): number {
+  const grown = baseMs * Math.pow(2, Math.max(0, attempts))
+  return Math.min(grown, maxMs)
+}
 
 /**
  * Pure decision: should the watcher send a wake-nudge to a sub-agent's session
@@ -65,10 +93,17 @@ const _lastSubWakeAt = new Map<string, number>()
  *   - the inbox has pending content (nothing to drain otherwise);
  *   - it has sat untouched longer than minAgeMs (let a fresh arrival drain via a
  *     natural turn / let a burst settle first);
- *   - the debounce window since the last nudge for THIS agent has elapsed;
+ *   - the per-agent attempt budget is not yet exhausted (a never-draining session
+ *     is not nudged forever -- it resumes only when a new inbound resets attempts);
+ *   - the backoff window since the last nudge for THIS agent has elapsed (the gap
+ *     grows exponentially with attempts);
  *   - the session exists (nothing to wake otherwise);
  *   - it is idle (never inject a prompt mid-turn -- that is the race the main
  *     wake-nudge was designed to avoid).
+ *
+ * `attempts`/`maxAttempts`/`maxDebounceMs` are optional and default to the
+ * pre-backoff behaviour (attempts 0, no cap on tries, no debounce cap), so
+ * existing callers/tests are unchanged.
  */
 export function shouldWakeForTelegramInbox(params: {
   inboxAgeMs: number
@@ -79,11 +114,18 @@ export function shouldWakeForTelegramInbox(params: {
   sessionIdle: boolean
   minAgeMs: number
   debounceMs: number
+  attempts?: number
+  maxAttempts?: number
+  maxDebounceMs?: number
 }): boolean {
   const { inboxAgeMs, hasPending, now, lastWakeAt, sessionExists, sessionIdle, minAgeMs, debounceMs } = params
+  const attempts = params.attempts ?? 0
+  const maxAttempts = params.maxAttempts ?? Infinity
+  const maxDebounceMs = params.maxDebounceMs ?? Infinity
   if (!hasPending) return false
   if (inboxAgeMs <= minAgeMs) return false
-  if (now - lastWakeAt < debounceMs) return false
+  if (attempts >= maxAttempts) return false // budget exhausted for this backlog
+  if (now - lastWakeAt < wakeBackoffMs(attempts, debounceMs, maxDebounceMs)) return false
   if (!sessionExists) return false
   if (!sessionIdle) return false
   return true
@@ -124,14 +166,28 @@ export function maybeWakeSubAgentsForTelegram(now: number): void {
         size = st.size
         mtimeMs = st.mtimeMs
       } catch {
-        continue // no inbox file -> nothing pending for this agent
+        _subWakeState.delete(name) // no inbox file -> drop stale state, start fresh next time
+        continue
       }
-      if (size === 0) continue
+      if (size === 0) {
+        _subWakeState.delete(name) // drained/empty -> reset the attempt budget
+        continue
+      }
       const inboxAgeMs = now - mtimeMs
       // Cheap gates before any tmux I/O (mirrors maybeWakeMainAgent).
       if (inboxAgeMs <= SUB_TELEGRAM_WAKE_MIN_AGE_MS) continue
-      const lastWakeAt = _lastSubWakeAt.get(name) ?? 0
-      if (now - lastWakeAt < SUB_TELEGRAM_WAKE_DEBOUNCE_MS) continue
+
+      // Per-agent backoff state. A NEW inbound (the tee appended, so mtime
+      // advanced past what we last acted on) is a distinct backlog: reset the
+      // attempt budget so a fresh message always earns a fresh round of nudges.
+      let state = _subWakeState.get(name)
+      if (!state || state.inboxMtimeMs !== mtimeMs) {
+        state = { lastWakeAt: state?.lastWakeAt ?? 0, attempts: 0, inboxMtimeMs: mtimeMs }
+        _subWakeState.set(name, state)
+      }
+      // Budget + backoff cheap gates (no tmux I/O yet).
+      if (state.attempts >= SUB_TELEGRAM_WAKE_MAX_ATTEMPTS) continue
+      if (now - state.lastWakeAt < wakeBackoffMs(state.attempts, SUB_TELEGRAM_WAKE_DEBOUNCE_MS, SUB_TELEGRAM_WAKE_MAX_DEBOUNCE_MS)) continue
 
       const host = readAgentRemoteHost(name)
       const session = agentSessionName(name)
@@ -145,23 +201,27 @@ export function maybeWakeSubAgentsForTelegram(now: number): void {
         inboxAgeMs,
         hasPending: true,
         now,
-        lastWakeAt,
+        lastWakeAt: state.lastWakeAt,
         sessionExists,
         sessionIdle,
         minAgeMs: SUB_TELEGRAM_WAKE_MIN_AGE_MS,
         debounceMs: SUB_TELEGRAM_WAKE_DEBOUNCE_MS,
+        attempts: state.attempts,
+        maxAttempts: SUB_TELEGRAM_WAKE_MAX_ATTEMPTS,
+        maxDebounceMs: SUB_TELEGRAM_WAKE_MAX_DEBOUNCE_MS,
       })) continue
 
       sendPromptToSession(session, SUB_TELEGRAM_WAKE_NUDGE, host)
-      _lastSubWakeAt.set(name, now)
-      logger.info({ agent: name, session, ageMs: Math.round(inboxAgeMs) }, 'telegram-inbox-wake: nudged idle sub-agent (pending inbox)')
+      state.lastWakeAt = now
+      state.attempts += 1
+      logger.info({ agent: name, session, ageMs: Math.round(inboxAgeMs), attempt: state.attempts }, 'telegram-inbox-wake: nudged idle sub-agent (pending inbox)')
     } catch (err) {
       logger.warn({ err, agent: name }, 'telegram-inbox-wake: wake check failed')
     }
   }
 }
 
-// Test-only: reset the per-agent debounce state between unit tests.
+// Test-only: reset the per-agent wake state between unit tests.
 export function _resetSubWakeStateForTest(): void {
-  _lastSubWakeAt.clear()
+  _subWakeState.clear()
 }

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -38,6 +38,11 @@
           },
           {
             "type": "command",
+            "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/channel-inbox-drain.py",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/voice-reply-directive.py",
             "timeout": 60
           }


### PR DESCRIPTION
Splits the sub-agent inbox wake-nudge out of #567 as its own PR, **opt-in and default-OFF**.

## What
`src/web/telegram-inbox-wake.ts`, called once per message-router tick, wakes an idle sub-agent whose derived Telegram inbox (`<state>/inbox-pending.jsonl`) has stuck inbound messages its drain hook cannot pull without a turn. It statSync-gates the inbox (cheap) and, only when it is stuck past a min-age + per-agent debounce, probes the session and injects a **content-free** nudge so the drain hook fires and atomically claims the backlog. No content-inject, no inbox mutation.

## Default-OFF / infra-only
Gated behind `SUBAGENT_TELEGRAM_WAKE_ENABLED`, **default OFF**. The prerequisite inbound-tee writer and the UserPromptSubmit drain hook that produce/consume `inbox-pending.jsonl` are **not yet upstream**, so with them absent there is no inbox file to wake on and the watcher is a no-op even when enabled. Shipping it disabled makes this PR infra-only: an upstream install sees zero behaviour change and pays no per-tick cost until the drain path lands and the operator opts in.

## Verification
- `npm run typecheck` clean.
- The pure gate decision (`shouldWakeForTelegramInbox`) is unit-tested across all five conditions -- 6 tests green.

Part of the #567 split. Kept default-OFF per review so it can be merged now and activated after the drain path lands.