### PR TITLE
feat(dashboard): Graphify knowledge-graph panel + deploy regen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ scripts/support-mail/no-support-reply.html
 # Python bytecode cache
 __pycache__/
 *.pyc
+web/icons/graphify-graph.html

--- a/scripts/regen-graphify.sh
+++ b/scripts/regen-graphify.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# regen-graphify.sh -- rebuild the Graphify knowledge-graph HTML for the dashboard.
+#
+# The dashboard "Graphify" panel serves web/icons/graphify-graph.html, which is
+# gitignored (a ~2.5MB generated artifact, see .gitignore). After a fresh
+# checkout/deploy that file is missing, so the iframe would 404. This script
+# regenerates it from the current src/ using tree-sitter AST (zero API cost),
+# plus local ollama community naming when available.
+#
+# Best-effort and idempotent: if graphify or its inputs are absent it exits 0
+# without touching anything, so it NEVER breaks a deploy. Re-uses the graphify
+# extract cache under store/ so repeat runs only re-parse changed files.
+
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_DIR="$PROJECT_ROOT/src"
+DEST="$PROJECT_ROOT/web/icons/graphify-graph.html"
+WORK="$PROJECT_ROOT/store/graphify-work"
+OLLAMA_MODEL="qwen2.5-coder:7b"
+
+# graphify installs as a uv tool under ~/.local/bin; make sure it is on PATH.
+export PATH="$HOME/.local/bin:$PATH"
+# Do not spam ~/.cache/graphify-queries.log during an unattended deploy run.
+export GRAPHIFY_QUERY_LOG_DISABLE=1
+
+# --- Graceful skips: never fail a deploy just because graphify is absent. -----
+if ! command -v graphify >/dev/null 2>&1; then
+  echo "regen-graphify: graphify not installed (uv tool install graphifyy) -- skipping."
+  exit 0
+fi
+if [ ! -d "$SRC_DIR" ]; then
+  echo "regen-graphify: $SRC_DIR missing -- skipping."
+  exit 0
+fi
+
+mkdir -p "$WORK"
+
+# --- 1. Index the codebase: local tree-sitter AST only, no API key, no cost. --
+echo "regen-graphify: indexing $SRC_DIR (code-only, tree-sitter AST)..."
+if ! graphify extract "$SRC_DIR" --code-only --out "$WORK" >/dev/null 2>&1; then
+  echo "regen-graphify: extract failed -- keeping the existing graph."
+  exit 1
+fi
+
+# --- 2. Build graph.html. Prefer local ollama naming (zero cost); fall back ---
+#        to placeholder community names if ollama or the model is unavailable.
+if curl -fsS -m 3 -o /dev/null http://localhost:11434/api/tags 2>/dev/null \
+   && curl -fsS -m 3 http://localhost:11434/api/tags 2>/dev/null | grep -q "$OLLAMA_MODEL"; then
+  echo "regen-graphify: naming communities via local ollama ($OLLAMA_MODEL)..."
+  graphify label "$WORK" --backend=ollama --model="$OLLAMA_MODEL" >/dev/null 2>&1 \
+    || graphify cluster-only "$WORK" --no-label >/dev/null 2>&1
+else
+  echo "regen-graphify: ollama/$OLLAMA_MODEL unavailable -- placeholder community names."
+  graphify cluster-only "$WORK" --no-label >/dev/null 2>&1
+fi
+
+# --- 3. Publish the freshly built graph to the dashboard-served location. -----
+GRAPH_HTML="$WORK/graphify-out/graph.html"
+if [ ! -s "$GRAPH_HTML" ]; then
+  echo "regen-graphify: graph.html not produced -- keeping the existing graph."
+  exit 1
+fi
+mkdir -p "$(dirname "$DEST")"
+cp "$GRAPH_HTML" "$DEST"
+echo "regen-graphify: updated $DEST ($(du -h "$DEST" | cut -f1))."
+exit 0

--- a/update.sh
+++ b/update.sh
@@ -433,6 +433,16 @@ if [ -x "$INSTALL_DIR/scripts/sync-hooks.sh" ]; then
   bash "$INSTALL_DIR/scripts/sync-hooks.sh" || echo -e "  FIGYELEM: sync-hooks.sh nem-nulla exit; manualisan ellenorizd."
 fi
 
+# Graphify tudasgraf regeneralasa (best-effort). A web/icons/graphify-graph.html
+# gitignore-olt runtime artifact, ezert friss checkout utan hianyzik -> a dashboard
+# Graphify panelje 404-ezne. Ez a script ujraepiti a friss src/-bol (tree-sitter
+# AST + lokalis ollama nevadas, nulla API-koltseg); graphify/ollama hianyaban
+# gracefully kilep, a deployt nem tori.
+if [ -x "$INSTALL_DIR/scripts/regen-graphify.sh" ]; then
+  echo -e "  Graphify graf frissitese (hatterben)..."
+  setsid bash "$INSTALL_DIR/scripts/regen-graphify.sh" </dev/null >>"$INSTALL_DIR/store/regen-graphify.log" 2>&1 &
+fi
+
 # Seed skills & scheduled tasks (idempotent: skip existing)
 # Source .env for template variables needed by seed-scheduled-tasks
 MAIN_AGENT_ID=""

--- a/web/app.js
+++ b/web/app.js
@@ -290,6 +290,11 @@ function switchPage(pageId) {
   if (pageId === 'ideas') loadIdeasPage()
   if (pageId === 'archived') loadArchivedPage()
   if (pageId === 'naplo') loadNaplo()
+  // Graphify: lazy-load the ~2.5MB standalone graph iframe only on first entry.
+  if (pageId === 'graphify') {
+    const gf = document.getElementById('graphifyFrame')
+    if (gf && !gf.src) gf.src = gf.dataset.src
+  }
 }
 
 // Mobile off-canvas sidebar toggle. No-op visual effect on desktop (the

--- a/web/index.html
+++ b/web/index.html
@@ -159,6 +159,10 @@
         <span class="sb-label">Frissítések</span>
         <span class="updates-badge sb-badge" id="updatesBadge" hidden></span>
       </a>
+      <a href="#" class="sb-link" data-page="graphify">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="2.5"/><circle cx="19" cy="6" r="2.5"/><circle cx="12" cy="18" r="2.5"/><line x1="7" y1="7" x2="10.5" y2="16"/><line x1="17" y1="7" x2="13.5" y2="16"/><line x1="7.3" y1="6" x2="16.7" y2="6"/></svg>
+        <span class="sb-label">Graphify</span>
+      </a>
     </nav>
     <div class="sidebar-footer">
       <button class="theme-toggle" id="langToggle" title="Language / Nyelv">HU</button>
@@ -1664,6 +1668,16 @@
       </div>
 
       <div id="costsContent"></div>
+    </div>
+
+    <!-- Graphify page -->
+    <div class="page" id="graphifyPage" hidden>
+      <div class="page-header">
+        <h1>Graphify</h1>
+        <p class="subtitle">Marveen <code>src/</code> kódbázis interaktív tudásgráf. D3 force-directed, tree-sitter AST (2123 node, 6165 edge)</p>
+      </div>
+      <iframe id="graphifyFrame" data-src="/icons/graphify-graph.html" title="Marveen Graphify graph" loading="lazy"
+        style="width:100%;height:calc(100vh - 190px);min-height:480px;border:1px solid var(--border,#333);border-radius:8px;background:#fff"></iframe>
     </div>
 
     <!-- Naplo page -->

--- a/web/index.html
+++ b/web/index.html
@@ -102,6 +102,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3C7.5 3 4 6.5 4 11v4l-2 3h4v2a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v0a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v-2h4l-2-3v-4c0-4.5-3.5-8-8-8z"/></svg>
         <span class="sb-label">Memória</span>
       </a>
+      <a href="#" class="sb-link" data-page="graphify">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="2.5"/><circle cx="19" cy="6" r="2.5"/><circle cx="12" cy="18" r="2.5"/><line x1="7" y1="7" x2="10.5" y2="16"/><line x1="17" y1="7" x2="13.5" y2="16"/><line x1="7.3" y1="6" x2="16.7" y2="6"/></svg>
+        <span class="sb-label">Graphify</span>
+      </a>
       <a href="#" class="sb-link" data-page="naplo">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
         <span class="sb-label">Napló</span>
@@ -158,10 +162,6 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
         <span class="sb-label">Frissítések</span>
         <span class="updates-badge sb-badge" id="updatesBadge" hidden></span>
-      </a>
-      <a href="#" class="sb-link" data-page="graphify">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="2.5"/><circle cx="19" cy="6" r="2.5"/><circle cx="12" cy="18" r="2.5"/><line x1="7" y1="7" x2="10.5" y2="16"/><line x1="17" y1="7" x2="13.5" y2="16"/><line x1="7.3" y1="6" x2="16.7" y2="6"/></svg>
-        <span class="sb-label">Graphify</span>
       </a>
     </nav>
     <div class="sidebar-footer">


### PR DESCRIPTION
> **DRAFT -- not for merge yet.** Opened as a draft per the #567 split so it can be tracked separately.

## What
Adds a Graphify knowledge-graph panel to the dashboard (iframe over a pre-rendered `web/icons/graphify-graph.html`), a nav item below Memory, and a best-effort `scripts/regen-graphify.sh` wired into `update.sh` to rebuild the graph on deploy (graceful no-op when graphify/ollama are absent).

## Why draft -- two open items
1. **Supply-chain review needed.** The dashboard tool binary is `graphify`, but it installs from PyPI as **`graphifyy`** (double-y) via `uv tool install graphifyy`. That name mismatch needs provenance / typosquat review before this ships.
2. **Product decision pending.** Overlap with GitNexus -- whether a second code-graph surface belongs in the dashboard is a product call.

Holding as draft until both are resolved. Part of the #567 split.