### PR TITLE
fix(scheduler): pin cron parsing to Europe/Budapest timezone

### DIFF
--- a/src/web/cron.ts
+++ b/src/web/cron.ts
@@ -1,7 +1,17 @@
 import { CronExpressionParser } from 'cron-parser'
 
+// All scheduled-task cron expressions (SKILL.md/task-config.json, the
+// dashboard schedule editor) are authored in Budapest wall-clock time -- "30
+// 7 * * *" means 7:30 for Ricsi, not 7:30 on whatever timezone the host
+// happens to boot in. cron-parser defaults to the PROCESS timezone when no
+// `tz` is given; on this host that's UTC, so every schedule silently fired
+// 2h late in summer (CEST, UTC+2) / 1h late in winter (CET, UTC+1) until this
+// was pinned. Matches the 'Europe/Budapest' literal already used for display
+// formatting elsewhere (db.ts, heartbeat.ts).
+const CRON_TZ = 'Europe/Budapest'
+
 export function computeNextRun(cronExpression: string): number {
-  const expr = CronExpressionParser.parse(cronExpression)
+  const expr = CronExpressionParser.parse(cronExpression, { tz: CRON_TZ })
   return Math.floor(expr.next().getTime() / 1000)
 }
 
@@ -17,7 +27,7 @@ export function isValidCronShape(cron: unknown): cron is string {
   if (!trimmed || trimmed.length > 100) return false
   if (!CRON_SHAPE_RX.test(trimmed)) return false
   try {
-    const expr = CronExpressionParser.parse(trimmed)
+    const expr = CronExpressionParser.parse(trimmed, { tz: CRON_TZ })
     expr.next()
     return true
   } catch {
@@ -27,7 +37,7 @@ export function isValidCronShape(cron: unknown): cron is string {
 
 export function cronMatchesNow(cron: string, catchUpMs: number = 60000): boolean {
   try {
-    const expr = CronExpressionParser.parse(cron)
+    const expr = CronExpressionParser.parse(cron, { tz: CRON_TZ })
     const prev = expr.prev()
     const prevTime = prev.getTime()
     const now = Date.now()


### PR DESCRIPTION
## Summary
- `cron-parser` defaulted to the process timezone (UTC on this host), so every scheduled task authored in Budapest wall-clock time (e.g. "30 7" meaning 7:30) silently fired 1-2h late (2h in CEST summer, 1h in CET winter).
- Pin `{ tz: 'Europe/Budapest' }` across all three `CronExpressionParser.parse()` call sites in `src/web/cron.ts`: `computeNextRun`, `isValidCronShape`, `cronMatchesNow`.
- Cherry-picked (cron.ts only) from an orphaned commit (8ae8a57) that already fixed this but never made it onto develop. That commit's other change (schedule-runner.ts chat_id:0 resolution + fired_late tracking) has since diverged from develop and is left for a separate follow-up PR.

## Verification
- `node -e "computeNextRun('0 19 * * 0')"` before: `2026-07-12T19:00:00.000Z` (UTC, wrong). After: `2026-07-12T17:00:00.000Z` (17:00 UTC = 19:00 CEST, correct).
- `npx tsc -p . --noEmit` clean.

Generated with Claude Code