### PR TITLE
fix(security+logic): path-traversal guards, FTS punctuation, daily-log TZ, idea impact/effort

### DIFF
--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -105,7 +105,7 @@ describe('buildFtsMatchExpression', () => {
     // No bare *, no doubled **.
     expect(out).not.toMatch(/\*\*/)
     expect(out).not.toMatch(/(^| )\*/)
-    expect(out).toBe('foo* bar* baz* quxzap*')
+    expect(out).toBe('foo* bar* baz* qux* zap*')
   })
 
   it('caps at 20 tokens', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -833,7 +833,10 @@ export function buildFtsMatchExpression(query: string): string {
   const MAX_TOKEN_LEN = 64
   const sanitized = query
     .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s]/gu, '')
+    // Replace punctuation with a space (not delete) so "rank-check" / "serper.dev"
+    // tokenize the same way unicode61 indexed them (rank + check), instead of
+    // fusing into a single unfindable token "rankcheck".
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
     .trim()
   if (!sanitized) return ''
   const tokens = sanitized
@@ -1016,7 +1019,10 @@ export function updateMemory(id: number, content: string, category?: string, age
 
 export function appendDailyLog(agentId: string, content: string): void {
   const now = Math.floor(Date.now() / 1000)
-  const today = new Date().toISOString().split('T')[0]
+  // Budapest calendar day, not UTC -- otherwise an entry written 00:00-02:00
+  // local time lands on the previous day and the "ma" recall query misses it.
+  // en-CA formats as YYYY-MM-DD.
+  const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Budapest' })
   db.prepare('INSERT INTO daily_logs (agent_id, date, content, created_at) VALUES (?, ?, ?, ?)').run(agentId, today, content, now)
 }
 

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -111,7 +111,7 @@ import {
   loadProfileTemplate,
   resolveProfilePlaceholders,
 } from '../profiles.js'
-import { sanitizeAgentName } from '../sanitize.js'
+import { sanitizeAgentName, safeJoin } from '../sanitize.js'
 import { parseMultipart } from '../multipart.js'
 import { readBody, json, serveFile } from '../http-helpers.js'
 import {
@@ -1360,8 +1360,12 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       const access = JSON.parse(readFileOr(accessPath, '{}'))
       if (kind === 'user') {
         access.allowFrom = (access.allowFrom || []).filter((s: string) => s !== id)
-        const approvedFile = join(chDir, 'approved', id)
-        try { if (existsSync(approvedFile)) unlinkSync(approvedFile) } catch { /* ignore */ }
+        // safeJoin blocks a traversal id (e.g. "..%2F..%2Ftmp%2Fvictim") from
+        // escaping the approved/ dir into an arbitrary unlinkSync target.
+        try {
+          const approvedFile = safeJoin(join(chDir, 'approved'), id)
+          if (existsSync(approvedFile)) unlinkSync(approvedFile)
+        } catch { /* ignore missing file or rejected traversal */ }
       } else {
         if (access.groups) delete access.groups[id]
       }

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -476,7 +476,13 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   if (connectorAssignMatch && method === 'POST') {
     const connectorName = decodeURIComponent(connectorAssignMatch[1])
     const body = await readBody(req)
-    const { agents: targetAgents, allAgents: visibleAgents } = JSON.parse(body.toString()) as { agents: string[], allAgents?: string[] }
+    const { agents: rawTargetAgents, allAgents: rawVisibleAgents } = JSON.parse(body.toString()) as { agents: string[], allAgents?: string[] }
+
+    // Only ever touch .mcp.json of real, known agents -- a caller-supplied name
+    // like "../../../../tmp/evil" must never reach join()+atomicWriteFileSync.
+    const knownAgents = new Set(listAgentNames())
+    const targetAgents = (Array.isArray(rawTargetAgents) ? rawTargetAgents : []).filter(a => knownAgents.has(a))
+    const visibleAgents = Array.isArray(rawVisibleAgents) ? rawVisibleAgents.filter(a => knownAgents.has(a)) : undefined
 
     if (connectorName.startsWith('plugin:')) {
       json(res, { ok: true, note: 'plugin:* connectors are global to every agent -- nothing to assign.' })

--- a/src/web/routes/ideas.ts
+++ b/src/web/routes/ideas.ts
@@ -45,8 +45,23 @@ export async function tryHandleIdeas(ctx: RouteContext): Promise<boolean> {
       description?: string
       category?: string
       source?: string
+      impact?: number | null
+      effort?: number | null
     }
     if (!data.title) { json(res, { error: 'title required' }, 400); return true }
+    // Same 1-5 validation as PUT -- previously POST silently dropped these fields
+    let impact: number | null = null
+    if (data.impact !== undefined && data.impact !== null) {
+      const v = Math.round(Number(data.impact))
+      if (!Number.isFinite(v) || v < 1 || v > 5) { json(res, { error: 'impact must be 1-5 or null' }, 400); return true }
+      impact = v
+    }
+    let effort: number | null = null
+    if (data.effort !== undefined && data.effort !== null) {
+      const v = Math.round(Number(data.effort))
+      if (!Number.isFinite(v) || v < 1 || v > 5) { json(res, { error: 'effort must be 1-5 or null' }, 400); return true }
+      effort = v
+    }
     const id = randomUUID().slice(0, 8)
     createIdea({
       id,
@@ -56,8 +71,8 @@ export async function tryHandleIdeas(ctx: RouteContext): Promise<boolean> {
       status: 'new',
       source: data.source ?? 'manual',
       kanban_id: null,
-      impact: null,
-      effort: null,
+      impact,
+      effort,
     })
     json(res, { ok: true, id })
     return true

--- a/src/web/routes/schedules.ts
+++ b/src/web/routes/schedules.ts
@@ -10,7 +10,7 @@ import { toPendingRetryView } from '../../pending-retries.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { isValidCronShape } from '../cron.js'
 import { readBody, json, RequestBodyTooLargeError } from '../http-helpers.js'
-import { sanitizeScheduleName } from '../sanitize.js'
+import { sanitizeScheduleName, safeJoin } from '../sanitize.js'
 import { listAgentNames } from '../agent-config.js'
 import { readFileOr } from '../agent-config.js'
 import {
@@ -19,6 +19,21 @@ import {
 } from '../scheduled-tasks-io.js'
 import { runScheduledTaskNow } from '../schedule-runner.js'
 import type { RouteContext } from './types.js'
+
+// Resolve a URL-supplied schedule name to an on-disk dir, blocking path
+// traversal. sanitizeScheduleName strips everything outside [a-z0-9-] (so no
+// "." or "/" survives), the empty check rejects a name that sanitized away
+// (which would otherwise resolve to the tasks root and delete/overwrite it),
+// and safeJoin is a belt-and-suspenders guard against escaping the base.
+function resolveScheduleDir(rawName: string): { name: string; dir: string } | null {
+  let decoded: string
+  try { decoded = decodeURIComponent(rawName) } catch { return null }
+  const name = sanitizeScheduleName(decoded)
+  if (!name) return null
+  try {
+    return { name, dir: safeJoin(SCHEDULED_TASKS_DIR, name) }
+  } catch { return null }
+}
 
 export async function tryHandleSchedules(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
@@ -146,8 +161,9 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
 
   const scheduleUpdateMatch = path.match(/^\/api\/schedules\/([^/]+)$/)
   if (scheduleUpdateMatch && method === 'PUT') {
-    const name = decodeURIComponent(scheduleUpdateMatch[1])
-    const dir = join(SCHEDULED_TASKS_DIR, name)
+    const resolved = resolveScheduleDir(scheduleUpdateMatch[1])
+    if (!resolved) { json(res, { error: 'Schedule not found' }, 404); return true }
+    const { name, dir } = resolved
     if (!existsSync(dir)) { json(res, { error: 'Schedule not found' }, 404); return true }
 
     let body: Buffer
@@ -180,8 +196,9 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
   }
 
   if (scheduleUpdateMatch && method === 'DELETE') {
-    const name = decodeURIComponent(scheduleUpdateMatch[1])
-    const dir = join(SCHEDULED_TASKS_DIR, name)
+    const resolved = resolveScheduleDir(scheduleUpdateMatch[1])
+    if (!resolved) { json(res, { error: 'Schedule not found' }, 404); return true }
+    const { name, dir } = resolved
     if (!existsSync(dir)) { json(res, { error: 'Schedule not found' }, 404); return true }
     rmSync(dir, { recursive: true, force: true })
     logger.info({ name }, 'Scheduled task deleted')
@@ -191,8 +208,9 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
 
   const scheduleToggleMatch = path.match(/^\/api\/schedules\/([^/]+)\/toggle$/)
   if (scheduleToggleMatch && method === 'POST') {
-    const name = decodeURIComponent(scheduleToggleMatch[1])
-    const dir = join(SCHEDULED_TASKS_DIR, name)
+    const resolved = resolveScheduleDir(scheduleToggleMatch[1])
+    if (!resolved) { json(res, { error: 'Schedule not found' }, 404); return true }
+    const { name, dir } = resolved
     if (!existsSync(dir)) { json(res, { error: 'Schedule not found' }, 404); return true }
 
     const configPath = join(dir, 'task-config.json')
@@ -208,8 +226,9 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
 
   const scheduleRunMatch = path.match(/^\/api\/schedules\/([^/]+)\/run$/)
   if (scheduleRunMatch && method === 'POST') {
-    const name = decodeURIComponent(scheduleRunMatch[1])
-    const dir = join(SCHEDULED_TASKS_DIR, name)
+    const resolved = resolveScheduleDir(scheduleRunMatch[1])
+    if (!resolved) { json(res, { error: 'Schedule not found' }, 404); return true }
+    const { name, dir } = resolved
     if (!existsSync(dir)) { json(res, { error: 'Schedule not found' }, 404); return true }
     const result = runScheduledTaskNow(name)
     if (!result.ok) { json(res, { error: result.error }, 400); return true }
@@ -227,8 +246,9 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
 
   const scheduleRunsMatch = path.match(/^\/api\/schedules\/([^/]+)\/runs$/)
   if (scheduleRunsMatch && method === 'GET') {
-    const name = decodeURIComponent(scheduleRunsMatch[1])
-    const dir = join(SCHEDULED_TASKS_DIR, name)
+    const resolved = resolveScheduleDir(scheduleRunsMatch[1])
+    if (!resolved) { json(res, { error: 'Schedule not found' }, 404); return true }
+    const { name, dir } = resolved
     if (!existsSync(dir)) { json(res, { error: 'Schedule not found' }, 404); return true }
     const runs = listTaskRunHistory(name, 10)
     json(res, runs)


### PR DESCRIPTION
## Mit csinál

Egy rendszer-átvilágítás (ütemező / API / memória / channels rétegek) során talált, igazolt hibák biztonságos, önálló javításai. A döntést igénylő tételek (message-router kézbesítés-visszaigazolás, DST cron edge case-ek, retry-drop elv, migrate/vault olvasás-allowlist) külön követve, nincsenek ebben a PR-ban.

## Biztonság — path traversal (a dashboard-tokennel elérhető)

- **schedules**: a DELETE/PUT/toggle/run/runs nyers `decodeURIComponent` névvel dolgozott (`join` + `rmSync`/írás); egy `..%2F..%2Fskills` név tetszőleges mappát törölhetett/felülírhatott. Új `resolveScheduleDir()`: sanitize + `safeJoin` + üres-név elutasítás.
- **agents allowlist-törlés**: az `unlink` célja nyers `id`-ből épült, most `safeJoin` védi.
- **connectors assign**: a cél-agent nevek most a `listAgentNames()` ismert listájához szűrve, mielőtt bármilyen `.mcp.json` művelet történne.

## Logikai hibák

- **FTS kereső**: a központozást törölte szóköz helyett (`rank-check` → `rankcheck*`), így az ilyen emlékek kereshetetlenek voltak; most szóközzé alakul.
- **appendDailyLog**: UTC naptári napot bélyegzett, egy 00:00–02:00 (Budapest) közti bejegyzés az előző napra került; most Europe/Budapest napot használ.
- **POST /api/ideas**: csendben eldobta a body `impact`/`effort` mezőit; most elfogadja, ugyanazzal az 1–5 validációval mint a PUT.

Minden javítás élesben ellenőrizve a futó dashboardon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
