### PR TITLE
fix(onboarding): recognise the macOS Keychain credential as Claude auth (port of #564 to develop)

### DIFF
--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
+import { homedir, userInfo } from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { PROJECT_ROOT, STORE_DIR } from '../../config.js'
 import { logger } from '../../logger.js'
@@ -8,7 +8,6 @@ import { resolveFromPath } from '../../platform.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { channelStateDir } from '../../channel-provider.js'
 import { sessionExistsOnHost } from '../agent-process.js'
-import { readClaudeCodeOauthJson } from '../claude-credentials.js'
 import { MAIN_CHANNELS_SESSION } from '../main-agent.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
 import { json, readBody } from '../http-helpers.js'
@@ -43,9 +42,22 @@ function readEnvValue(key: string): string | null {
 // in the login Keychain and writes NO ~/.claude/.credentials.json, so a fully
 // authenticated fleet looked logged-out to the wizard and the dashboard nagged
 // for a token that would have created a second, drifting credential path.
-// readClaudeCodeOauthJson() already fails closed (null off macOS / on any
-// lookup error), so a Keychain ACL that refused `security` just falls back to
-// the previous behaviour.
+// The probe is presence-only: no `-w`, so the credential secret itself never
+// enters this process just to answer a yes/no question. It fails closed (false
+// off macOS / on any lookup error), so a Keychain ACL that refused `security`
+// just falls back to the previous behaviour.
+function keychainHasClaudeCredentials(): boolean {
+  if (process.platform !== 'darwin') return false
+  try {
+    execFileSync(
+      '/usr/bin/security',
+      ['find-generic-password', '-s', 'Claude Code-credentials', '-a', userInfo().username],
+      { timeout: 3000, stdio: 'ignore' },
+    )
+    return true
+  } catch { return false }
+}
+
 function claudeAuthPresent(): boolean {
   if (readEnvValue('CLAUDE_CODE_OAUTH_TOKEN')) return true
   if (readEnvValue('ANTHROPIC_API_KEY')) return true
@@ -56,7 +68,7 @@ function claudeAuthPresent(): boolean {
     if (d?.claudeAiOauth?.accessToken) return true
     if (d?.apiKey) return true
   } catch { /* no / unreadable credentials.json */ }
-  return readClaudeCodeOauthJson() !== null
+  return keychainHasClaudeCredentials()
 }
 
 function telegramConfigured(): boolean {

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -8,6 +8,7 @@ import { resolveFromPath } from '../../platform.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { channelStateDir } from '../../channel-provider.js'
 import { sessionExistsOnHost } from '../agent-process.js'
+import { readClaudeCodeOauthJson } from '../claude-credentials.js'
 import { MAIN_CHANNELS_SESSION } from '../main-agent.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
 import { json, readBody } from '../http-helpers.js'
@@ -34,8 +35,17 @@ function readEnvValue(key: string): string | null {
   return null
 }
 
-// True auth presence -- an env OAuth token / API key, OR a real credentials.json
-// OAuth credential. NOT merely "the .env line exists" (it could be empty).
+// True auth presence -- an env OAuth token / API key, a real credentials.json
+// OAuth credential, or (macOS) the login Keychain credential. NOT merely "the
+// .env line exists" (it could be empty).
+//
+// The Keychain leg matters: on macOS Claude Code stores the subscription login
+// in the login Keychain and writes NO ~/.claude/.credentials.json, so a fully
+// authenticated fleet looked logged-out to the wizard and the dashboard nagged
+// for a token that would have created a second, drifting credential path.
+// readClaudeCodeOauthJson() already fails closed (null off macOS / on any
+// lookup error), so a Keychain ACL that refused `security` just falls back to
+// the previous behaviour.
 function claudeAuthPresent(): boolean {
   if (readEnvValue('CLAUDE_CODE_OAUTH_TOKEN')) return true
   if (readEnvValue('ANTHROPIC_API_KEY')) return true
@@ -46,7 +56,7 @@ function claudeAuthPresent(): boolean {
     if (d?.claudeAiOauth?.accessToken) return true
     if (d?.apiKey) return true
   } catch { /* no / unreadable credentials.json */ }
-  return false
+  return readClaudeCodeOauthJson() !== null
 }
 
 function telegramConfigured(): boolean {


### PR DESCRIPTION
## Problem

#564 fixed the false first-run wizard on macOS, but it landed on `main` only. `develop` still has the old `claudeAuthPresent()`, so the next release cut brings the bug back.

On macOS Claude Code stores the subscription login in the login Keychain and writes **no** `~/.claude/.credentials.json`. The gate checked only `.env` + that file, so a fully authenticated fleet (5 agents running fine on the Keychain credential) looked logged-out: the dashboard nagged for a token, and entering one would have created a second, drifting credential path next to the Keychain one.

## Fix

Add the Keychain as the last leg of the gate, reusing the `readClaudeCodeOauthJson()` helper `develop` already has in `src/web/claude-credentials.ts` (the worker does the same lookup) rather than re-implementing the `security` call.

The helper fails closed: `null` off macOS and on any lookup error, with a 3s timeout and stderr dropped. So a Keychain ACL that refuses `security` falls back to the previous behaviour instead of hanging the status endpoint.

## Verification

On this machine (Keychain-only login, no `.credentials.json`):

```
claudeAuthPresent: true
needsOnboarding: false
```

Status endpoint responds in ~45 ms, no GUI permission prompt. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfnBdCdNQfryGz6t1B7G17