### PR TITLE
fix(token-monitor): exclude synthetic/unknown from model dist, group MCP tools by server

### DIFF
--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -343,7 +343,7 @@ export function getModelDistribution(from?: number, to?: number, agent?: string)
   if (!hasModelCol.n) return []
 
   let sql = `
-    SELECT COALESCE(model, '(unknown)') as model,
+    SELECT model,
       COUNT(*) as count,
       SUM(input_tokens) as totalInput,
       SUM(output_tokens) as totalOutput,
@@ -351,12 +351,16 @@ export function getModelDistribution(from?: number, to?: number, agent?: string)
       SUM(cache_creation_tokens) as totalCacheCreation
     FROM token_usage
   `
-  const conditions: string[] = []
+  const conditions: string[] = [
+    "model IS NOT NULL",
+    "model != ''",
+    "model != '<synthetic>'",
+  ]
   const params: any[] = []
   if (from) { conditions.push('timestamp >= ?'); params.push(from) }
   if (to) { conditions.push('timestamp <= ?'); params.push(to) }
   if (agent) { conditions.push('agent = ?'); params.push(agent) }
-  if (conditions.length) sql += ' WHERE ' + conditions.join(' AND ')
+  sql += ' WHERE ' + conditions.join(' AND ')
   sql += ' GROUP BY model ORDER BY count DESC'
 
   return db.prepare(sql).all(...params) as ModelDistEntry[]

--- a/web/app.js
+++ b/web/app.js
@@ -11429,8 +11429,10 @@ function tuGetColor(agent) {
 function tuMcpServerFromTool(toolName) {
   if (!toolName || !toolName.startsWith('mcp__')) return null
   const parts = toolName.split('__')
-  // parts: ['mcp', '<server>', '<tool>'] -- server may contain single underscores
-  return parts.length >= 3 ? parts[1] : null
+  // parts: ['mcp', '<server>', '<tool>'] for a full tool name, or
+  // ['mcp', '<server>'] for a tuMcpGroupKey() group key -- without accepting
+  // the 2-part form, every grouped MCP row would be mislabelled as builtin.
+  return parts.length >= 2 && parts[1] ? parts[1] : null
 }
 
 function tuMcpGroupKey(toolName) {

--- a/web/app.js
+++ b/web/app.js
@@ -11433,6 +11433,12 @@ function tuMcpServerFromTool(toolName) {
   return parts.length >= 3 ? parts[1] : null
 }
 
+function tuMcpGroupKey(toolName) {
+  if (!toolName || !toolName.startsWith('mcp__')) return toolName
+  const parts = toolName.split('__')
+  return parts.length >= 3 ? 'mcp__' + parts[1] : toolName
+}
+
 function tuFormatTokens(n) {
   if (n == null || isNaN(n)) return '0'
   if (n >= 1e9) return (n / 1e9).toFixed(1) + 'B'
@@ -12233,13 +12239,14 @@ function renderTuToolStats(data) {
     return
   }
 
-  // Aggregate per-model rows into one entry per tool_name
+  // Aggregate per-model rows into one entry per tool (MCP tools grouped by server)
   const byTool = new Map()
   for (const row of data) {
-    let entry = byTool.get(row.tool_name)
+    const key = tuMcpGroupKey(row.tool_name)
+    let entry = byTool.get(key)
     if (!entry) {
-      entry = { tool_name: row.tool_name, count: 0, agentSet: new Set(), costUSD: 0 }
-      byTool.set(row.tool_name, entry)
+      entry = { tool_name: key, count: 0, agentSet: new Set(), costUSD: 0 }
+      byTool.set(key, entry)
     }
     entry.count += row.count || 0
     ;(row.agents || '').split(',').forEach(a => { const s = a.trim(); if (s) entry.agentSet.add(s) })


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: A token monitor modell-eloszlás chart-ból kiszűri a &lt;synthetic&gt; rendszerbejegyzéseket (timeout, API hiba, no-response) és a modell nélküli tool call rekordokat, amelyek korábban (unknown) névvel torzították a képet. Az MCP eszközhasználat táblában az egyedi tool hívásokat szerver szinten összesíti (mcp__server kulcson) ahelyett, hogy minden tool külön sorban jelenne meg.

EN: Filters &lt;synthetic&gt; system events and model-less tool-call rows from the model distribution chart. In the MCP tool usage table, individual calls are now grouped by server (mcp__server) instead of per tool.

Technical changes:
- src/web/token-usage.ts — getModelDistribution(): WHERE model IS NOT NULL AND model != '' AND model != '&lt;synthetic&gt;'
- web/app.js — renderTuToolStats(): new tuMcpGroupKey() helper maps mcp__server__tool to mcp__server

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot.
- [x] Saját, beszédes nevű branch-ről nyitom.

---
This change was authored with AI assistance, reviewed by the maintainer before submission.