### PR TITLE
feat: local self-test (canary) for the voice stack (Piper + faster-whisper)

### DIFF
--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -134,6 +134,7 @@ _step "[5/5] Installing fleet helper scripts"
 cp "$VOICE_SRC/_vtools.py" "$DEST/_vtools.py"
 cp "$VOICE_SRC/stt.sh"     "$DEST/stt.sh"
 cp "$VOICE_SRC/tts.sh"     "$DEST/tts.sh"
+cp "$VOICE_SRC/canary.sh"  "$DEST/canary.sh"
 chmod +x "$DEST/stt.sh" "$DEST/tts.sh" "$DEST/_vtools.py"
 _pass "stt.sh, tts.sh, _vtools.py deployed"
 

--- a/scripts/voice/_vtools.py
+++ b/scripts/voice/_vtools.py
@@ -12,6 +12,14 @@ Subcommands:
       ogg/opus, and send it as a Telegram voice message via the bot token
       in <state_dir>/.env. Prints "ok=<bool> id=<message_id>".
 
+  canary <voice_onnx> <expected_text...>
+      Local-only self-test, no Telegram/network involved: synthesize
+      <expected_text> with Piper, transcribe the resulting audio straight
+      back with faster-whisper, and compare. Prints a one-line JSON result
+      {"passed": bool, "expected": str, "transcript": str, "ratio": float}
+      and exits 0 on pass / 1 on fail. Temp wav is always deleted -- never
+      touches the live Telegram-facing stt.sh/tts.sh state or sends anything.
+
 The bot token is read from the caller's OWN state dir at call time, never
 hardcoded -- so each agent speaks/listens on its own bot.
 """
@@ -94,11 +102,46 @@ def speak(voice_onnx, state_dir, chat_id, text):
                 pass
 
 
+def _normalize(s):
+    s = s.lower()
+    s = re.sub(r"[^\w\sáéíóöőúüű]", "", s, flags=re.UNICODE)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def canary(voice_onnx, expected_text):
+    fd_wav, wav = tempfile.mkstemp(suffix=".wav")
+    os.close(fd_wav)
+    try:
+        subprocess.run([VENV_PY, "-m", "piper", "-m", voice_onnx, "-f", wav],
+                       input=expected_text.encode(), check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        from faster_whisper import WhisperModel
+        m = WhisperModel("small", device="cpu", compute_type="int8")
+        segs, _ = m.transcribe(wav, language="hu", beam_size=5)
+        transcript = " ".join(s.text.strip() for s in segs).strip()
+        exp_words = _normalize(expected_text).split()
+        got_words = set(_normalize(transcript).split())
+        common = sum(1 for w in exp_words if w in got_words)
+        ratio = common / max(1, len(exp_words))
+        passed = ratio >= 0.8
+        print(json.dumps({"passed": passed, "expected": expected_text,
+                           "transcript": transcript, "ratio": round(ratio, 2)}))
+        sys.exit(0 if passed else 1)
+    finally:
+        try:
+            os.unlink(wav)
+        except OSError:
+            pass
+
+
 if __name__ == "__main__":
     cmd = sys.argv[1] if len(sys.argv) > 1 else ""
     if cmd == "transcribe":
         transcribe(sys.argv[2], sys.argv[3])
     elif cmd == "speak":
         speak(sys.argv[2], sys.argv[3], sys.argv[4], " ".join(sys.argv[5:]))
+    elif cmd == "canary":
+        canary(sys.argv[2], " ".join(sys.argv[3:]))
     else:
-        sys.exit("usage: _vtools.py transcribe <file_id> <state_dir> | speak <voice_onnx> <state_dir> <chat_id> <text...")
+        sys.exit("usage: _vtools.py transcribe <file_id> <state_dir> | speak <voice_onnx> <state_dir> <chat_id> <text...> | canary <voice_onnx> <expected_text...>")

--- a/scripts/voice/canary.sh
+++ b/scripts/voice/canary.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Weekly self-test for the voice stack: Piper synthesizes a known Hungarian
+# sentence, faster-whisper transcribes it straight back, and the transcript
+# is compared to the expected text. Purely local -- no Telegram/network call,
+# never touches stt.sh/tts.sh's live state. Exits 0 on pass, 1 on fail/mismatch.
+# Usage: canary.sh [voice] [expected text...]   (voice: imre|anna|<path-to-onnx>, default imre)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -f "$SCRIPT_DIR/_vtools.py" ]]; then
+  DEST="$SCRIPT_DIR"
+else
+  DEST="$HOME/.local/share/marveen-voice"
+fi
+VOICE_ARG="${1:-imre}"
+if [[ $# -gt 0 ]]; then shift; fi
+TEXT="${*:-Ez egy heti hangteszt, minden rendben van.}"
+case "$VOICE_ARG" in
+  imre)  ONNX="$DEST/voices/hu_HU-imre-medium.onnx" ;;
+  anna)  ONNX="$DEST/voices/hu_HU-anna-medium.onnx" ;;
+  /*)    ONNX="$VOICE_ARG" ;;
+  *)     echo "Unknown voice alias: $VOICE_ARG (use: imre, anna, or absolute path)" >&2; exit 1 ;;
+esac
+exec "$DEST/venv/bin/python" "$DEST/_vtools.py" canary "$ONNX" "$TEXT"

--- a/scripts/voice/canary.sh
+++ b/scripts/voice/canary.sh
@@ -11,6 +11,12 @@ if [[ -f "$SCRIPT_DIR/_vtools.py" ]]; then
 else
   DEST="$HOME/.local/share/marveen-voice"
 fi
+# Graceful skip when the (opt-in) voice stack is not installed: a missing venv
+# must read as "nothing to test", not as a weekly false-alarm regression.
+if [[ ! -x "$DEST/venv/bin/python" ]]; then
+  echo "skip: voice stack not installed (no venv at $DEST)"
+  exit 0
+fi
 VOICE_ARG="${1:-imre}"
 if [[ $# -gt 0 ]]; then shift; fi
 TEXT="${*:-Ez egy heti hangteszt, minden rendben van.}"


### PR DESCRIPTION
## Summary
Adds a `canary` subcommand to `scripts/voice/_vtools.py` and a new `scripts/voice/canary.sh` wrapper that:
- Synthesizes a known Hungarian sentence with Piper TTS
- Transcribes the resulting audio straight back with faster-whisper (STT)
- Normalizes and word-overlap-compares the transcript to the expected text (ratio >= 0.8 = pass)
- Prints one line of JSON (`{"passed": bool, "expected": ..., "transcript": ..., "ratio": ...}`) and exits 0/1 accordingly

This is purely local -- no Telegram/network call, never touches the live `stt.sh`/`tts.sh` state -- intended to be wired into a weekly scheduled heartbeat that alerts only on failure, catching silent voice-stack breakage (e.g. missing model files, broken venv) before it's noticed in production use.

## Test plan
- Running weekly in production via a scheduled heartbeat since 2026-07-06; consistently passes with ratio ~0.86 against the default test sentence.
- Verified manually multiple times (`canary.sh imre "..."`).