### PR TITLE
feat(fleet): portable full-fleet export/import (migration)

### DIFF
--- a/docs/flotta-migracio.md
+++ b/docs/flotta-migracio.md
@@ -1,0 +1,57 @@
+# Flotta migráció (export / import)
+
+> Egyetlen hordozható JSON a teljes flottáról, amivel gépek között lehet átköltözni anélkül, hogy minden ügynököt és memóriát kézzel kellene újrakonfigurálni.
+
+---
+
+## Mit csinál a teljes flotta migráció?
+
+Egyetlen hordozható JSON-t készít a teljes flottáról, amit egy friss telepítésre be lehet tölteni. Segítségével gépek között lehet átköltözni anélkül, hogy az összes ügynököt és memóriát kézzel kellene újrakonfigurálni.
+
+## Mit visz magával az export?
+
+- Fő ügynök persona: CLAUDE.md, SOUL.md, agent-config.json, beállítások, csatorna-párosítás
+- Al-ügynökök: teljes konfiguráció, személyiség, csatornák, képek
+- Memóriák: az összes ügynök memóriabejegyzése (fő ügynök és al-ügynökök)
+- Napi napló bejegyzések
+- Skillek: globális és ügynök-szintű
+- Ütemezett feladatok (szüneteltetve: enabled=false érkeznek)
+- Kanban tábla: kártyák, kommentek, címkék
+- Ötletláda (idea box)
+- Dashboard beállítások (autonómia, auto-restart, preferenciák)
+- Vault (opcionális, jelszóval): MCP-szerver titkok, API kulcsok
+
+## Mit NEM visz magával?
+
+- Csatorna bot-tokenek (Telegram stb.): a párosítás-config (allowlist, policy) átmegy, de a bot-token NEM. A célgépen újra kell párosítani. Ez szándékos: két élő példány ugyanazzal a bottal ütközne (a forrás bot elnémulna, dupla üzenetek)
+- Google/Gmail/Calendar OAuth bejelentkezések: a célgépen újra kell hitelesíteni
+- Dashboard-token: a célgép saját tokenjét kell használni
+- Forráskód és build-eredmények: a normál telepítésből jönnek (npm ci, npm run build)
+- Telemetria, session-logok, conversation-history
+
+## Dry-run biztonság
+
+Az "Ellenőrzés" gomb csak beolvassa a fájlt és megmutatja, mi jönne létre, de nem ír semmit a rendszerbe. Az "Apply" gomb csak a dry-run után érhető el, és egy megerősítési lépéssel véd a véletlen felülírás ellen.
+
+## Vault jelszó szerepe
+
+Ha az exportnál megadsz jelszót, a TELJES export JSON egyetlen titkosított blobbá válik (scrypt+AES-256-GCM), így minden titok egyben védve van. Importáláskor ugyanezt a jelszót kell megadni, az import automatikusan felismeri a titkosított fájlt. Rossz jelszónál nem ír semmit.
+
+Jelszó nélkül az export garantáltan titok-mentes: a rendszer kiszűri a titkokat, és ha bármi titkosítatlan titok bennmaradna (pl. egy MCP-token), hibát dob az export helyett hogy kiszivárogtatná.
+
+## Fő ügynök identitása (import után)
+
+Import után a cél rendszer ÁTVESZI a forrás fő ügynökének identitását: a fő ügynök neve a forrásé lesz, és minden adata is a forrás nevén marad. Ez azért kell, hogy a memóriák, naplók és a sub-agentek CLAUDE.md-hivatkozásai konzisztensek maradjanak, semmit nem kell kézzel átnevezni. A rendszer generikus: bármi is a forrás fő ügynökének neve, azt veszi át.
+
+A beállítás a `store/config-overrides.json`-ba íródik (fő ügynök azonosító, megjelenített név, brand, tulajdonos), és a dashboard ÚJRAINDÍTÁSA után lép életbe. Az apply után az import figyelmeztet erre.
+
+## Lépéssor
+
+1. A régi gépen: Export, opcionálisan vault jelszóval. Mentsd el a JSON-t.
+2. Az új gépen: telepítsd a dashboardot (git clone, npm ci, npm run build, indítás).
+3. Tallózd be a JSON-t, add meg a vault jelszót (ha volt), futtasd az Ellenőrzést.
+4. Ellenőrizd a dry-run összefoglalót: ügynökök, memóriák, kanban számai és a felülírás-figyelmeztetések helyesek-e.
+5. Végrehajtás (apply): az ügynökök, memóriák és beállítások beírva, a cél átveszi a forrás fő ügynökének identitását.
+6. Indítsd újra a dashboard szolgáltatást (service restart), hogy a fő ügynök az átvett identitáson induljon.
+7. Csatornák: párosítsd újra a Telegram (stb.) botokat a célgépen.
+8. Hitelesítsd újra az OAuth-kapcsolatokat (Gmail, naptár stb.).

--- a/src/__tests__/fleet-transfer.test.ts
+++ b/src/__tests__/fleet-transfer.test.ts
@@ -1,0 +1,363 @@
+// Fleet export/import unit tests.
+//
+// Covers: encrypted round-trip, wrong-password fast-fail (no writes),
+// args/url secret detection in placeholderMcp, avatarExt path-traversal guard.
+//
+// importFleet requires a live DB and filesystem, so those paths are integration-tested
+// by calling importFleet with a pre-encrypted payload and mocked DB / FS module.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { _encryptForTest, _decryptForTest, ENCRYPTED_FLEET_VERSION, MIN_VAULT_PASSWORD_LEN } from '../web/fleet-transfer.js'
+
+// ---------------------------------------------------------------------------
+// Crypto round-trip
+// ---------------------------------------------------------------------------
+
+describe('encrypt/decrypt round-trip', () => {
+  it('decrypts to the original plaintext', () => {
+    const plaintext = JSON.stringify({ hello: 'world', num: 42 })
+    const password = 'correct-horse-battery-staple'
+    const blob = _encryptForTest(plaintext, password)
+    expect(_decryptForTest(blob, password)).toBe(plaintext)
+  })
+
+  it('throws on wrong password (GCM auth tag mismatch)', () => {
+    const blob = _encryptForTest('secret data', 'right-password-1234')
+    expect(() => _decryptForTest(blob, 'wrong-password-1234')).toThrow()
+  })
+
+  it('throws on truncated blob (L1 sanity check)', () => {
+    const tooShort = Buffer.from('dGVzdA==').toString('base64')
+    expect(() => _decryptForTest(tooShort, 'any-password-here')).toThrow(/Érvénytelen titkosított blob/)
+  })
+
+  it('produces a non-trivially-parseable blob that differs from plaintext JSON', () => {
+    const fleet = JSON.stringify({ schemaVersion: 1, agents: [] })
+    const blob = _encryptForTest(fleet, 'pw-12345678')
+    expect(() => JSON.parse(blob)).toThrow()
+  })
+
+  it('constants are correct values', () => {
+    expect(ENCRYPTED_FLEET_VERSION).toBe(1)
+    expect(MIN_VAULT_PASSWORD_LEN).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// importFleet: encrypted wrapper detection (with mocked FS / DB)
+// ---------------------------------------------------------------------------
+
+vi.mock('../db.js', () => ({
+  getDb: () => ({
+    prepare: () => ({
+      all: () => [],
+      get: () => null,
+      run: () => ({ changes: 0 }),
+    }),
+    transaction: (fn: Function) => fn,
+  }),
+  backfillEmbeddings: () => Promise.resolve(),
+  initDatabase: () => {},
+}))
+
+vi.mock('../web/agent-config.js', () => ({
+  AGENTS_BASE_DIR: '/mock/agents',
+  listAgentNames: () => [],
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const real = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...real,
+    existsSync: () => false,
+    mkdirSync: () => undefined,
+    unlinkSync: () => undefined,
+    rmSync: () => undefined,
+    readdirSync: () => [],
+  }
+})
+
+vi.mock('../web/atomic-write.js', () => ({
+  atomicWriteFileSync: vi.fn(),
+}))
+
+vi.mock('../web/scheduled-tasks-io.js', () => ({
+  SCHEDULED_TASKS_DIR: '/mock/tasks',
+}))
+
+vi.mock('../config.js', () => ({
+  PROJECT_ROOT: '/mock/project',
+  STORE_DIR: '/mock/store',
+  MAIN_AGENT_ID: 'marveen',
+  BOT_NAME: 'Marveen',
+  BRAND_NAME: 'Marveen',
+  OWNER_NAME: 'Szabolcs',
+  CHANNEL_PROVIDER: 'telegram',
+}))
+
+vi.mock('../web/vault-bindings.js', () => ({
+  getBindings: () => [],
+}))
+
+vi.mock('../env.js', () => ({
+  updateEnvFile: vi.fn(),
+}))
+
+vi.mock('../logger.js', () => ({
+  logger: { info: () => {}, warn: () => {}, error: () => {} },
+}))
+
+// Minimal valid FleetJson for tests
+const MINIMAL_FLEET = JSON.stringify({
+  schemaVersion: 1,
+  exportedAt: '2026-01-01T00:00:00.000Z',
+  sourceHost: 'test-host',
+  agents: [],
+  skills: [],
+  scheduledTasks: [],
+  memories: [],
+  dailyLogs: [],
+  kanban: { cards: [], comments: [], cardEvents: [], labels: [], cardLabels: [] },
+  ideaBox: { ideas: [], comments: [], statusLog: [] },
+  dashboardSettings: { autonomy: {}, autoRestart: {}, agentsDesired: {}, norbertPersonal: {} },
+})
+
+describe('importFleet: encrypted wrapper detection', () => {
+  it('returns error DiffReport when encrypted but no password given', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const blob = _encryptForTest(MINIMAL_FLEET, 'test-password-ok')
+    const wrapper = JSON.stringify({ enc: ENCRYPTED_FLEET_VERSION, blob })
+
+    const result = importFleet(wrapper, { apply: false })
+    expect('dryRun' in result).toBe(true)
+    expect((result as any).errors).toContain(
+      'A fájl titkosítva van -- add meg a vault jelszót az importhoz.'
+    )
+  })
+
+  it('returns error DiffReport on wrong password (no file writes)', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const { atomicWriteFileSync } = await import('../web/atomic-write.js')
+
+    const blob = _encryptForTest(MINIMAL_FLEET, 'correct-pw-12345')
+    const wrapper = JSON.stringify({ enc: ENCRYPTED_FLEET_VERSION, blob })
+
+    const result = importFleet(wrapper, { vaultPassword: 'wrong-pw-12345678', apply: false })
+    expect('dryRun' in result).toBe(true)
+    expect((result as any).errors).toContain(
+      'Helytelen vault jelszó -- a titkosított fájl nem dekódolható.'
+    )
+    expect(atomicWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('succeeds (dry-run) with correct password', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const blob = _encryptForTest(MINIMAL_FLEET, 'correct-pw-12345')
+    const wrapper = JSON.stringify({ enc: ENCRYPTED_FLEET_VERSION, blob })
+
+    const result = importFleet(wrapper, { vaultPassword: 'correct-pw-12345', apply: false })
+    expect('dryRun' in result).toBe(true)
+    expect((result as any).errors).toHaveLength(0)
+  })
+
+  it('accepts plaintext fleet JSON without password', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const result = importFleet(MINIMAL_FLEET, { apply: false })
+    expect('dryRun' in result).toBe(true)
+    expect((result as any).errors).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DiffReport: wouldOverwrite is present in dry-run result
+// ---------------------------------------------------------------------------
+
+describe('importFleet: wouldOverwrite in DiffReport', () => {
+  it('DiffReport contains wouldOverwrite fields', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const result = importFleet(MINIMAL_FLEET, { apply: false })
+    expect('dryRun' in result).toBe(true)
+    const diff = result as any
+    expect(diff).toHaveProperty('wouldOverwrite')
+    expect(Array.isArray(diff.wouldOverwrite.agents)).toBe(true)
+    expect(typeof diff.wouldOverwrite.mainAgent).toBe('boolean')
+  })
+
+  it('wouldOverwrite.agents empty when no existing agents (mocked listAgentNames returns [])', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const withAgents = JSON.stringify({
+      schemaVersion: 1,
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      sourceHost: 'test-host',
+      agents: [{ name: 'newbot', config: {}, claudeMd: '', soulMd: '', mcp: {}, settings: {}, channelsAccess: {}, agentSkills: [] }],
+      skills: [], scheduledTasks: [], memories: [], dailyLogs: [],
+      kanban: { cards: [], comments: [], cardEvents: [], labels: [], cardLabels: [] },
+      ideaBox: { ideas: [], comments: [], statusLog: [] },
+      dashboardSettings: { autonomy: {}, autoRestart: {}, agentsDesired: {}, norbertPersonal: {} },
+    })
+    const result = importFleet(withAgents, { apply: false })
+    const diff = result as any
+    // listAgentNames is mocked to return [] so nothing to overwrite
+    expect(diff.wouldOverwrite.agents).toHaveLength(0)
+    // newbot is a new agent (not existing)
+    expect(diff.wouldCreate.agents).toContain('newbot')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// VaultExport: bot tokens NOT exported (channels re-pair model)
+// ---------------------------------------------------------------------------
+
+describe('exportFleet: channelEnvs not in VaultExport', () => {
+  it('exported plaintext fleet JSON has no channelEnvs key in vault', async () => {
+    // exportFleet requires real FS -- only assert on the type shape via importFleet round-trip
+    // The VaultExport interface has no channelEnvs field by design; verify via a crafted import
+    // that ignores channelEnvs even if present in the JSON.
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const fleetWithChannelEnvs = JSON.stringify({
+      schemaVersion: 1,
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      sourceHost: 'source',
+      vault: {
+        vaultKey: 'key',
+        entries: [],
+        bindings: [],
+        channelEnvs: { telegram: 'BOT_TOKEN=secret123' }, // legacy / attacker-supplied field
+      },
+      agents: [], skills: [], scheduledTasks: [], memories: [], dailyLogs: [],
+      kanban: { cards: [], comments: [], cardEvents: [], labels: [], cardLabels: [] },
+      ideaBox: { ideas: [], comments: [], statusLog: [] },
+      dashboardSettings: { autonomy: {}, autoRestart: {}, agentsDesired: {}, norbertPersonal: {} },
+    })
+    // Should dry-run cleanly (channelEnvs is ignored, not written)
+    const result = importFleet(fleetWithChannelEnvs, { apply: false })
+    expect('dryRun' in result).toBe(true)
+    expect((result as any).errors).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Identity takeover: source mainAgent.agentId preserved as-is; config-overrides written on apply
+// ---------------------------------------------------------------------------
+
+const FLEET_WITH_SOURCE_ID = JSON.stringify({
+  schemaVersion: 1,
+  exportedAt: '2026-01-01T00:00:00.000Z',
+  sourceHost: 'source',
+  mainAgent: {
+    agentId: 'atlas',
+    identity: {
+      MAIN_AGENT_ID: 'atlas',
+      BOT_NAME: 'Atlas',
+      BRAND_NAME: 'Atlas',
+      OWNER_NAME: 'Norbert',
+      CHANNEL_PROVIDER: 'telegram',
+    },
+    claudeMd: '', soulMd: '', config: {}, mcp: {}, settings: {}, channelsAccess: {},
+  },
+  memories: [
+    { agent_id: 'atlas', content: 'atlas memory', sector: 'warm', salience: 0.5, created_at: 1000, category: 'project', auto_generated: 0 },
+    { agent_id: 'hestia', content: 'hestia memory', sector: 'warm', salience: 0.5, created_at: 1000, category: 'project', auto_generated: 0 },
+  ],
+  dailyLogs: [
+    { agent_id: 'atlas', date: '2026-01-01', content: 'log', created_at: 1000 },
+  ],
+  agents: [], skills: [], scheduledTasks: [],
+  kanban: { cards: [], comments: [], cardEvents: [], labels: [], cardLabels: [] },
+  ideaBox: { ideas: [], comments: [], statusLog: [] },
+  dashboardSettings: { autonomy: {}, autoRestart: {}, agentsDesired: {}, norbertPersonal: {} },
+})
+
+describe('importFleet: identity takeover', () => {
+  it('dry-run includes identity warning when mainAgent.agentId is present', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const result = importFleet(FLEET_WITH_SOURCE_ID, { apply: false })
+    expect('dryRun' in result).toBe(true)
+    expect((result as any).errors).toHaveLength(0)
+    const warnings: string[] = (result as any).warnings
+    expect(warnings.some(w => w.includes('atlas') && w.includes('identitás'))).toBe(true)
+    // Counts: 2 memories (atlas + hestia) preserved with original agent_ids
+    expect((result as any).wouldCreate.memories).toBe(2)
+  })
+
+  it('apply writes all identity keys to config-overrides.json and returns warning', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const { atomicWriteFileSync } = await import('../web/atomic-write.js')
+
+    const result = importFleet(FLEET_WITH_SOURCE_ID, { apply: true })
+    // ImportResult (not DiffReport)
+    expect('ok' in result).toBe(true)
+    const ir = result as any
+    // config-overrides.json written with full identity set
+    const configOverrideCalls = (atomicWriteFileSync as any).mock.calls
+      .filter((c: string[]) => c[0]?.includes('config-overrides.json'))
+    expect(configOverrideCalls.length).toBeGreaterThan(0)
+    const written = JSON.parse(configOverrideCalls[configOverrideCalls.length - 1][1])
+    expect(written['MAIN_AGENT_ID']).toBe('atlas')
+    expect(written['BOT_NAME']).toBe('Atlas')
+    expect(written['BRAND_NAME']).toBe('Atlas')
+    expect(written['OWNER_NAME']).toBe('Norbert')
+    expect(written['CHANNEL_PROVIDER']).toBe('telegram')
+    // Warning present in ImportResult
+    expect(ir.warnings).toBeDefined()
+    expect(ir.warnings.some((w: string) => w.includes('atlas'))).toBe(true)
+  })
+
+  it('apply mirrors the full identity into .env (channels.sh reads .env, not config-overrides)', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const { updateEnvFile } = await import('../env.js')
+
+    importFleet(FLEET_WITH_SOURCE_ID, { apply: true })
+
+    expect(updateEnvFile as any).toHaveBeenCalled()
+    const envArg = (updateEnvFile as any).mock.calls.at(-1)[0]
+    expect(envArg).toEqual({
+      MAIN_AGENT_ID: 'atlas',
+      BOT_NAME: 'Atlas',
+      BRAND_NAME: 'Atlas',
+      OWNER_NAME: 'Norbert',
+      CHANNEL_PROVIDER: 'telegram',
+    })
+  })
+
+  it('dry-run counts both atlas and hestia memories (no remap dedup)', async () => {
+    // If remap were active (atlas -> marveen), duplicate dedup could collapse rows.
+    // With original agent_ids preserved, all 2 memories count as new.
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const result = importFleet(FLEET_WITH_SOURCE_ID, { apply: false })
+    expect('dryRun' in result).toBe(true)
+    expect((result as any).wouldCreate.memories).toBe(2)
+    // Daily logs: 1 entry (atlas) counted
+    expect((result as any).wouldCreate.dailyLogs).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateNames: avatarExt path-traversal guard (B1)
+// ---------------------------------------------------------------------------
+
+describe('importFleet: avatarExt traversal rejected', () => {
+  it('returns nameErrors for traversal avatarExt', async () => {
+    const { importFleet } = await import('../web/fleet-transfer.js')
+    const malicious = JSON.stringify({
+      schemaVersion: 1,
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      sourceHost: 'attacker',
+      agents: [{
+        name: 'testbot',
+        avatar: 'aGVsbG8=',
+        avatarExt: 'png/../../../../etc/cron.d/x',
+        config: {}, claudeMd: '', soulMd: '', mcp: {}, settings: {}, channelsAccess: {}, agentSkills: [],
+      }],
+      skills: [], scheduledTasks: [], memories: [], dailyLogs: [],
+      kanban: { cards: [], comments: [], cardEvents: [], labels: [], cardLabels: [] },
+      ideaBox: { ideas: [], comments: [], statusLog: [] },
+      dashboardSettings: { autonomy: {}, autoRestart: {}, agentsDesired: {}, norbertPersonal: {} },
+    })
+
+    const result = importFleet(malicious, { apply: false })
+    expect('dryRun' in result).toBe(true)
+    const errors = (result as any).errors as string[]
+    expect(errors.some(e => e.includes('avatarExt') && e.includes('testbot'))).toBe(true)
+  })
+})

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { atomicWriteFileSync } from './web/atomic-write.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PROJECT_ROOT = join(__dirname, '..')
@@ -32,4 +33,52 @@ export function readEnvFile(keys?: string[]): Record<string, string> {
     result[key] = value
   }
   return result
+}
+
+// Update (or append) the given keys in .env, preserving every other line,
+// comment, and the original ordering. Used by fleet import to mirror the
+// main-agent identity takeover into .env: the dashboard resolves identity via
+// cfg() (config-overrides.json > .env), but the shell-side launchers -- most
+// importantly scripts/channels.sh -- read MAIN_AGENT_ID / CHANNEL_PROVIDER
+// DIRECTLY from .env. Without this mirror the dashboard shows the taken-over
+// identity while channels.sh still launches `${old-id}-channels`, so the main
+// agent comes up under the wrong identity (and the dashboard sees it as down).
+//
+// Values are written UNQUOTED: channels.sh parses with `cut -d= -f2-` and does
+// no quote-stripping, so a quoted value would leak the quotes. Only non-empty
+// string values are written; empty updates are a no-op (no file touch).
+export function updateEnvFile(updates: Record<string, string>): void {
+  const envPath = join(PROJECT_ROOT, '.env')
+  const entries = Object.entries(updates).filter(
+    ([, v]) => typeof v === 'string' && v.length > 0,
+  )
+  if (entries.length === 0) return
+
+  let content = ''
+  try {
+    content = readFileSync(envPath, 'utf-8')
+  } catch {
+    content = ''
+  }
+
+  const remaining = new Map(entries)
+  const lines = content.length > 0 ? content.split('\n') : []
+  const out = lines.map((line) => {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) return line
+    const eqIdx = trimmed.indexOf('=')
+    if (eqIdx === -1) return line
+    const key = trimmed.slice(0, eqIdx).trim()
+    if (!remaining.has(key)) return line
+    const val = remaining.get(key)!
+    remaining.delete(key)
+    return `${key}=${val}`
+  })
+
+  // Append keys that were not already present.
+  for (const [key, val] of remaining) {
+    out.push(`${key}=${val}`)
+  }
+
+  atomicWriteFileSync(envPath, out.join('\n'))
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -60,6 +60,7 @@ import { tryHandleFleetQ } from './web/routes/fleet-q.js'
 import { tryHandleStatic } from './web/routes/static.js'
 import { tryHandleVoice } from './web/routes/voice.js'
 import { tryHandleVaultSsh } from './web/routes/vault-ssh.js'
+import { tryHandleFleet } from './web/routes/fleet.js'
 import { tryHandleVaultSshKeys } from './web/routes/vault-ssh-keys.js'
 import type { RouteContext } from './web/routes/types.js'
 
@@ -195,6 +196,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleVaultSsh(routeCtx)) return
       if (await tryHandleAuditLog(routeCtx)) return
       if (await tryHandleFleetQ(routeCtx)) return
+      if (await tryHandleFleet(routeCtx)) return
       if (await tryHandleStatic(routeCtx, WEB_DIR)) return
 
       res.writeHead(404)

--- a/src/web/fleet-transfer.ts
+++ b/src/web/fleet-transfer.ts
@@ -1,0 +1,1283 @@
+// Fleet export / import.
+//
+// Builds a single portable JSON snapshot of fleet content (agents, skills,
+// scheduled tasks, DB tables, dashboard settings, optional vault) so it can
+// be loaded into a freshly-installed, clean-git dashboard on another machine.
+//
+// Source code, build artefacts, OAuth tokens, and machine-specific paths are
+// NOT included -- those come from a normal `npm ci && npm run build` install.
+
+import {
+  existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, unlinkSync,
+} from 'node:fs'
+import { join, extname } from 'node:path'
+import { homedir, hostname } from 'node:os'
+import {
+  randomBytes, createCipheriv, createDecipheriv, scryptSync,
+} from 'node:crypto'
+import { PROJECT_ROOT, STORE_DIR, MAIN_AGENT_ID, BOT_NAME, BRAND_NAME, OWNER_NAME, CHANNEL_PROVIDER } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+import { updateEnvFile } from '../env.js'
+import { AGENTS_BASE_DIR, listAgentNames } from './agent-config.js'
+import { safeJoin } from './sanitize.js'
+import { SCHEDULED_TASKS_DIR } from './scheduled-tasks-io.js'
+import { getBindings } from './vault-bindings.js'
+import { getDb, backfillEmbeddings } from '../db.js'
+import { logger } from '../logger.js'
+
+// ---------------------------------------------------------------------------
+// Schema version -- bump when the JSON shape changes incompatibly.
+// ---------------------------------------------------------------------------
+export const FLEET_SCHEMA_VERSION = 1
+
+// ---------------------------------------------------------------------------
+// UserFacingError -- user-fixable condition; route maps to 400 (not 500).
+// ---------------------------------------------------------------------------
+export class UserFacingError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UserFacingError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Name validation (used to guard all import-side path joins -- B1)
+// ---------------------------------------------------------------------------
+const SAFE_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/
+
+function assertSafeName(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !SAFE_NAME_RE.test(value)) {
+    throw new Error(`Érvénytelen ${field} érték: "${String(value).slice(0, 60)}" -- csak [a-z0-9_-] megengedett.`)
+  }
+  return value
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FleetJson {
+  schemaVersion: 1
+  exportedAt: string
+  sourceHost: string
+  mainAgent?: MainAgentExport
+  agents: AgentExport[]
+  skills: SkillExport[]
+  scheduledTasks: ScheduledTaskExport[]
+  memories: MemoryRow[]      // ALL agent_ids (main + sub-agents)
+  dailyLogs: DailyLogRow[]   // ALL agent_ids
+  kanban: KanbanExport
+  ideaBox: IdeaBoxExport
+  dashboardSettings: DashboardSettingsExport
+  vault?: VaultExport
+}
+
+// Identity set transferred with the fleet so the target becomes an exact copy of the source.
+export interface FleetIdentity {
+  MAIN_AGENT_ID: string
+  BOT_NAME: string
+  BRAND_NAME: string
+  OWNER_NAME: string
+  CHANNEL_PROVIDER: string
+}
+
+// Main agent lives at PROJECT_ROOT (not under agents/), so it needs its own export section.
+export interface MainAgentExport {
+  agentId: string  // source MAIN_AGENT_ID -- kept for backward-compat; identity supersedes this
+  identity?: FleetIdentity  // full identity set; absent in exports from older versions
+  claudeMd: string
+  soulMd: string
+  config: Record<string, unknown>
+  mcp: Record<string, unknown>
+  settings: Record<string, unknown>
+  channelsAccess: Record<string, unknown>  // provider -> access.json (pairing config, NOT bot token)
+}
+
+export interface AgentExport {
+  name: string
+  config: Record<string, unknown>
+  claudeMd: string
+  soulMd: string
+  mcp: Record<string, unknown>
+  settings: Record<string, unknown>
+  channelsAccess: Record<string, unknown>
+  avatar: string | null  // base64
+  avatarExt: string      // 'png' or 'jpg'
+  agentSkills: SkillExport[]
+}
+
+export interface SkillExport {
+  name: string
+  skillMd: string
+}
+
+export interface ScheduledTaskExport {
+  dirName: string
+  skillMd: string
+  config: Record<string, unknown>
+}
+
+export interface KanbanExport {
+  cards: Record<string, unknown>[]
+  comments: Record<string, unknown>[]
+  cardEvents: Record<string, unknown>[]
+  labels: Record<string, unknown>[]
+  cardLabels: Record<string, unknown>[]
+}
+
+export interface IdeaBoxExport {
+  ideas: Record<string, unknown>[]
+  comments: Record<string, unknown>[]
+  statusLog: Record<string, unknown>[]
+}
+
+export interface DashboardSettingsExport {
+  autonomy: Record<string, unknown>
+  autoRestart: Record<string, unknown>
+  agentsDesired: Record<string, unknown>
+  norbertPersonal: Record<string, unknown>
+}
+
+export interface MemoryRow {
+  agent_id: string
+  content: string
+  sector: string
+  salience: number
+  created_at: number
+  accessed_at: number
+  category: string
+  auto_generated: number
+  keywords: string | null
+}
+
+export interface DailyLogRow {
+  agent_id: string
+  date: string
+  content: string
+  created_at: number
+}
+
+export interface VaultExport {
+  vaultKey: string  // raw base64 content of .vault-key (safe: whole JSON is encrypted when password given)
+  entries: Record<string, unknown>[]
+  bindings: Record<string, unknown>[]
+  // NOTE: channel .env (bot tokens) deliberately NOT exported -- re-pair model:
+  // a Telegram bot accepts only one active poller; exporting+auto-activating tokens
+  // would cause 409 errors and silent messages on the source. Target must re-pair manually.
+}
+
+export interface DiffReport {
+  dryRun: true
+  wouldCreate: {
+    mainAgent: boolean
+    agents: string[]
+    globalSkills: number
+    scheduledTasks: number
+    memories: number
+    kanbanCards: number
+    kanbanComments: number
+    labels: number
+    dailyLogs: number
+    ideaBox: number
+  }
+  wouldOverwrite: {
+    agents: string[]  // existing sub-agent names that would be overwritten
+    mainAgent: boolean
+  }
+  warnings: string[]
+  errors: string[]
+}
+
+export interface ImportResult {
+  ok: true
+  imported: {
+    mainAgent: boolean
+    agents: string[]
+    globalSkills: number
+    scheduledTasks: number
+    memories: number
+    kanbanCards: number
+    labels: number
+    dailyLogs: number
+    ideaBox: number
+  }
+  warnings?: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Crypto helpers -- M7: versioned packed blob, scrypt N=2^17
+// ---------------------------------------------------------------------------
+
+const KDF_VERSION = 1
+const KDF_N_LOG2 = 17   // N = 2^17 = 131072 (appropriate for user-chosen password on portable file)
+const KDF_R = 8
+const KDF_P = 1
+const KDF_KEYLEN = 32
+const KDF_SALT_LEN = 32
+const GCM_IV_LEN = 12   // GCM standard is 12 bytes
+const GCM_TAG_LEN = 16
+
+// Packed format: [version:1][N_log2:1][r:1][p:1][salt:32][iv:12][tag:16][ciphertext:...]
+function encryptWithPassword(plaintext: string, password: string): string {
+  const salt = randomBytes(KDF_SALT_LEN)
+  const key = scryptSync(password, salt, KDF_KEYLEN, { N: 2 ** KDF_N_LOG2, r: KDF_R, p: KDF_P, maxmem: 256 * 1024 * 1024 })
+  const iv = randomBytes(GCM_IV_LEN)
+  const cipher = createCipheriv('aes-256-gcm', key, iv)
+  const enc = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  const header = Buffer.from([KDF_VERSION, KDF_N_LOG2, KDF_R, KDF_P])
+  return Buffer.concat([header, salt, iv, tag, enc]).toString('base64')
+}
+
+// Exported for unit testing (crypto round-trip verification)
+export function _encryptForTest(plaintext: string, password: string): string {
+  return encryptWithPassword(plaintext, password)
+}
+export function _decryptForTest(packed: string, password: string): string {
+  return decryptWithPassword(packed, password)
+}
+
+function decryptWithPassword(packed: string, password: string): string {
+  const buf = Buffer.from(packed, 'base64')
+  const MIN_PACKED_LEN = 4 + KDF_SALT_LEN + GCM_IV_LEN + GCM_TAG_LEN
+  if (buf.length < MIN_PACKED_LEN) {
+    throw new Error(`Érvénytelen titkosított blob: várt legalább ${MIN_PACKED_LEN} byte, kapott ${buf.length}.`)
+  }
+  // version byte (offset 0) reserved for future format changes; currently always 1
+  const nLog2 = buf[1]
+  const r = buf[2]
+  const p = buf[3]
+  const off = 4
+  const salt = buf.subarray(off, off + KDF_SALT_LEN)
+  const iv = buf.subarray(off + KDF_SALT_LEN, off + KDF_SALT_LEN + GCM_IV_LEN)
+  const tag = buf.subarray(off + KDF_SALT_LEN + GCM_IV_LEN, off + KDF_SALT_LEN + GCM_IV_LEN + GCM_TAG_LEN)
+  const ciphertext = buf.subarray(off + KDF_SALT_LEN + GCM_IV_LEN + GCM_TAG_LEN)
+  const key = scryptSync(password, salt, KDF_KEYLEN, { N: 2 ** nLog2, r, p, maxmem: 256 * 1024 * 1024 })
+  const decipher = createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(tag)
+  // Buffer.concat avoids multi-byte UTF-8 split corruption at chunk boundary
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf-8')
+}
+
+export const MIN_VAULT_PASSWORD_LEN = 8
+
+// ---------------------------------------------------------------------------
+// Path normalization (H4: applied to the entire serialized FleetJson)
+// ---------------------------------------------------------------------------
+
+// Collision-resistant sentinels: namespaced so memory/skill content can't accidentally contain them
+const PROJECT_ROOT_PLACEHOLDER = '{{FLEET:PROJECT_ROOT}}'
+const HOME_PLACEHOLDER = '{{FLEET:HOME}}'
+
+function normalizePaths(text: string): string {
+  // Replace PROJECT_ROOT before HOME: on typical installs HOME is a prefix of PROJECT_ROOT.
+  return text
+    .replaceAll(PROJECT_ROOT, PROJECT_ROOT_PLACEHOLDER)
+    .replaceAll(homedir(), HOME_PLACEHOLDER)
+}
+
+function denormalizePaths(text: string): string {
+  return text
+    .replaceAll(PROJECT_ROOT_PLACEHOLDER, PROJECT_ROOT)
+    .replaceAll(HOME_PLACEHOLDER, homedir())
+}
+
+// ---------------------------------------------------------------------------
+// .mcp.json placeholder handling (B2: scan env AND headers, entropy hard-fail)
+// ---------------------------------------------------------------------------
+
+// Patterns that suggest a value is NOT a secret (safe to export plaintext).
+const NON_SECRET_VALUE_RE = [
+  /^(true|false)$/i,
+  /^https?:\/\//,
+  /^\d+$/,
+  /^\//,
+  /^\$\{/,
+  /^vault:/,
+  /^\{\{VAULT:/,
+  // Note: no /\s/ exemption -- "Bearer sk-live-..." contains whitespace but IS a secret
+]
+
+function looksLikeSecret(value: string): boolean {
+  if (value.length < 16) return false
+  for (const re of NON_SECRET_VALUE_RE) {
+    if (re.test(value)) return false
+  }
+  return true
+}
+
+// Auth scheme prefixes to strip before entropy check on header values
+const HEADER_AUTH_SCHEME_RE = /^(?:Bearer|Basic|Token|Digest)\s+/i
+// Header keys that always carry secrets (unless already vault-bound)
+const ALWAYS_SECRET_HEADER_KEY_RE = /^(authorization|x-api-key|x-auth-token|.*-token|.*-key)$/i
+// Well-known non-secret header keys: content/transport metadata, never credentials
+const NON_SECRET_HEADER_KEY_RE = /^(content-type|accept|accept-encoding|accept-language|content-length|user-agent|connection|host|origin|referer|cache-control|if-modified-since|if-none-match|pragma|transfer-encoding|upgrade)$/i
+// Non-secret patterns for header values -- note: no URL exemption (https://user:cred@host IS a secret)
+const NON_SECRET_HEADER_VALUE_RE = [
+  /^(true|false)$/i,
+  /^\d+$/,
+  /^\//,
+  /^\$\{/,
+  /^vault:/,
+  /^\{\{VAULT:/,
+]
+
+function looksLikeHeaderSecret(key: string, value: string): boolean {
+  if (NON_SECRET_HEADER_KEY_RE.test(key)) return false
+  if (ALWAYS_SECRET_HEADER_KEY_RE.test(key)) return true
+  // Strip auth scheme prefix ("Bearer ", "Basic "…) then check the credential part
+  const stripped = value.replace(HEADER_AUTH_SCHEME_RE, '')
+  if (stripped.length < 16) return false
+  for (const re of NON_SECRET_HEADER_VALUE_RE) {
+    if (re.test(stripped)) return false
+  }
+  return true
+}
+
+// Build lookup: mcpFilePath -> serverName -> envVar -> vaultSecretId
+function buildBindingLookup(): Map<string, Map<string, Map<string, string>>> {
+  const lookup = new Map<string, Map<string, Map<string, string>>>()
+  for (const binding of getBindings()) {
+    for (const target of binding.targets) {
+      if (!lookup.has(target.mcpFilePath)) lookup.set(target.mcpFilePath, new Map())
+      const byServer = lookup.get(target.mcpFilePath)!
+      if (!byServer.has(target.serverName)) byServer.set(target.serverName, new Map())
+      byServer.get(target.serverName)!.set(binding.envVar, binding.vaultSecretId)
+    }
+  }
+  return lookup
+}
+
+// Scan env AND headers for secrets; convert known vault refs to {{VAULT:id}};
+// hard-fail on unbound high-entropy literals (B2).
+function placeholderMcp(
+  mcpObj: Record<string, unknown>,
+  mcpFilePath: string,
+  lookup: Map<string, Map<string, Map<string, string>>>,
+): Record<string, unknown> {
+  const result = JSON.parse(JSON.stringify(mcpObj)) as Record<string, unknown>
+  const byServer = lookup.get(mcpFilePath)
+  const servers = result.mcpServers as Record<string, Record<string, unknown>> | undefined
+  if (!servers) return result
+
+  for (const [serverName, cfg] of Object.entries(servers)) {
+    if (!cfg || typeof cfg !== 'object') continue
+    const c = cfg as Record<string, unknown>
+    const byEnv = byServer?.get(serverName)
+
+    const blockingFields: string[] = []
+    for (const field of ['env', 'headers'] as const) {
+      const dict = c[field] as Record<string, string> | undefined
+      if (!dict) continue
+      for (const [key, val] of Object.entries(dict)) {
+        if (typeof val !== 'string') continue
+        if (val.startsWith('vault:')) {
+          dict[key] = `{{VAULT:${val.slice(6)}}}`
+        } else if (byEnv?.has(key)) {
+          dict[key] = `{{VAULT:${byEnv.get(key)!}}}`
+        } else {
+          const isSecret = field === 'headers' ? looksLikeHeaderSecret(key, val) : looksLikeSecret(val)
+          if (isSecret) {
+            blockingFields.push(`mező="${field}", kulcs="${key}"`)
+          }
+        }
+      }
+    }
+
+    // H1: also scan args (string[]) and url/command (string) for embedded secrets
+    const args = c.args
+    if (Array.isArray(args)) {
+      for (let i = 0; i < args.length; i++) {
+        const arg = args[i]
+        if (typeof arg === 'string' && looksLikeSecret(arg)) {
+          blockingFields.push(`mező="args[${i}]"`)
+        }
+      }
+    }
+    for (const fld of ['url', 'command'] as const) {
+      const val = c[fld]
+      if (typeof val === 'string' && looksLikeSecret(val)) {
+        blockingFields.push(`mező="${fld}"`)
+      }
+    }
+
+    if (blockingFields.length > 0) {
+      throw new UserFacingError(
+        `Titkosítatlan secret az .mcp.json-ban: szerver="${serverName}": ${blockingFields.join('; ')}. ` +
+        `Kösd be a vault-ba a dashboard Vault oldalán, majd próbáld újra az exportot.`
+      )
+    }
+  }
+  return result
+}
+
+// Reverse: {{VAULT:<id>}} -> vault:<id> (vault-env-wrapper.sh resolves at runtime)
+function deplaceholderMcp(mcpObj: Record<string, unknown>): Record<string, unknown> {
+  const result = JSON.parse(JSON.stringify(mcpObj)) as Record<string, unknown>
+  const servers = result.mcpServers as Record<string, Record<string, unknown>> | undefined
+  if (!servers) return result
+  for (const [, cfg] of Object.entries(servers)) {
+    if (!cfg || typeof cfg !== 'object') continue
+    const c = cfg as Record<string, unknown>
+    for (const field of ['env', 'headers'] as const) {
+      const dict = c[field] as Record<string, string> | undefined
+      if (!dict) continue
+      for (const [k, v] of Object.entries(dict)) {
+        if (typeof v === 'string' && v.startsWith('{{VAULT:') && v.endsWith('}}')) {
+          dict[k] = `vault:${v.slice(8, -2)}`
+        }
+      }
+    }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// File helpers
+// ---------------------------------------------------------------------------
+
+function safeReadJson(path: string): Record<string, unknown> {
+  try { return JSON.parse(readFileSync(path, 'utf-8')) } catch { return {} }
+}
+
+function safeReadText(path: string): string {
+  try { return readFileSync(path, 'utf-8') } catch { return '' }
+}
+
+function safeReadBase64(path: string): string | null {
+  try { return readFileSync(path).toString('base64') } catch { return null }
+}
+
+function listSkillsInDir(dir: string): SkillExport[] {
+  if (!existsSync(dir)) return []
+  const skills: SkillExport[] = []
+  for (const entry of readdirSync(dir)) {
+    const skillMdPath = join(dir, entry, 'SKILL.md')
+    if (existsSync(skillMdPath)) {
+      skills.push({ name: entry, skillMd: safeReadText(skillMdPath) })
+    }
+  }
+  return skills
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+function exportChannelsAccess(channelsDir: string): Record<string, unknown> {
+  const channelsAccess: Record<string, unknown> = {}
+  if (existsSync(channelsDir)) {
+    for (const provider of readdirSync(channelsDir)) {
+      const accessPath = join(channelsDir, provider, 'access.json')
+      if (existsSync(accessPath)) {
+        channelsAccess[provider] = safeReadJson(accessPath)
+      }
+    }
+  }
+  return channelsAccess
+}
+
+// Main agent lives at PROJECT_ROOT -- exported separately since it's not under agents/.
+function exportMainAgent(
+  bindingLookup: Map<string, Map<string, Map<string, string>>>,
+  withSecrets: boolean,
+): MainAgentExport {
+  const claudeDir = join(PROJECT_ROOT, '.claude')
+  const mcpPath = join(PROJECT_ROOT, '.mcp.json')
+  const settingsPath = join(claudeDir, 'settings.json')
+
+  const rawMcp = safeReadJson(mcpPath)
+  // withSecrets: whole JSON will be encrypted -- skip placeholder/hard-fail
+  const mcp = withSecrets ? rawMcp : placeholderMcp(rawMcp, mcpPath, bindingLookup)
+
+  const settingsRaw = safeReadText(settingsPath)
+  const settings = settingsRaw ? JSON.parse(settingsRaw) as Record<string, unknown> : {}
+
+  // M4: in plaintext export, hard-fail if settings.env contains secrets
+  if (!withSecrets && typeof settings.env === 'object' && settings.env !== null) {
+    for (const [key, val] of Object.entries(settings.env as Record<string, unknown>)) {
+      if (typeof val === 'string' && looksLikeSecret(val)) {
+        throw new UserFacingError(
+          `Titkosítatlan secret a settings.json env blokkjában: kulcs="${key}". ` +
+          `Adj meg vault jelszót az exporthoz, vagy távolítsd el a titkot a settings.json-ból.`
+        )
+      }
+    }
+  }
+
+  // Main agent channel access lives at ~/.claude/channels/<provider>/access.json
+  const channelsAccess = exportChannelsAccess(join(homedir(), '.claude', 'channels'))
+
+  return {
+    agentId: MAIN_AGENT_ID,
+    identity: {
+      MAIN_AGENT_ID,
+      BOT_NAME,
+      BRAND_NAME,
+      OWNER_NAME,
+      CHANNEL_PROVIDER,
+    },
+    claudeMd: safeReadText(join(PROJECT_ROOT, 'CLAUDE.md')),
+    soulMd: safeReadText(join(PROJECT_ROOT, 'SOUL.md')),
+    config: safeReadJson(join(PROJECT_ROOT, 'agent-config.json')),
+    mcp,
+    settings,
+    channelsAccess,
+  }
+}
+
+function exportAgent(
+  name: string,
+  bindingLookup: Map<string, Map<string, Map<string, string>>>,
+  withSecrets: boolean,
+): AgentExport {
+  const dir = join(AGENTS_BASE_DIR, name)
+  const claudeDir = join(dir, '.claude')
+  const mcpPath = join(dir, '.mcp.json')
+  const settingsPath = join(claudeDir, 'settings.json')
+
+  const rawMcp = safeReadJson(mcpPath)
+  // withSecrets: whole JSON will be encrypted -- skip placeholder/hard-fail
+  const mcp = withSecrets ? rawMcp : placeholderMcp(rawMcp, mcpPath, bindingLookup)
+
+  const settingsRaw = safeReadText(settingsPath)
+  const settings = settingsRaw ? JSON.parse(settingsRaw) as Record<string, unknown> : {}
+
+  // M4: in plaintext export, hard-fail if settings.env contains secrets
+  if (!withSecrets && typeof settings.env === 'object' && settings.env !== null) {
+    for (const [key, val] of Object.entries(settings.env as Record<string, unknown>)) {
+      if (typeof val === 'string' && looksLikeSecret(val)) {
+        throw new UserFacingError(
+          `Titkosítatlan secret az agent "${name}" settings.json env blokkjában: kulcs="${key}". ` +
+          `Adj meg vault jelszót az exporthoz, vagy távolítsd el a titkot a settings.json-ból.`
+        )
+      }
+    }
+  }
+
+  // channels/access.json per provider (not .env -- vault-gated)
+  const channelsAccess = exportChannelsAccess(join(claudeDir, 'channels'))
+
+  // avatar -- preserve actual extension
+  let avatar: string | null = null
+  let avatarExt = 'png'
+  const pngPath = join(dir, 'avatar.png')
+  const jpgPath = join(dir, 'avatar.jpg')
+  if (existsSync(pngPath)) {
+    avatar = safeReadBase64(pngPath)
+    avatarExt = 'png'
+  } else if (existsSync(jpgPath)) {
+    avatar = safeReadBase64(jpgPath)
+    avatarExt = 'jpg'
+  }
+
+  return {
+    name,
+    config: safeReadJson(join(dir, 'agent-config.json')),
+    claudeMd: safeReadText(join(dir, 'CLAUDE.md')),
+    soulMd: safeReadText(join(dir, 'SOUL.md')),
+    mcp,
+    settings,
+    channelsAccess,
+    avatar,
+    avatarExt,
+    agentSkills: listSkillsInDir(join(claudeDir, 'skills')),
+  }
+}
+
+function exportScheduledTasks(): ScheduledTaskExport[] {
+  if (!existsSync(SCHEDULED_TASKS_DIR)) return []
+  const result: ScheduledTaskExport[] = []
+  for (const dirName of readdirSync(SCHEDULED_TASKS_DIR)) {
+    const dir = join(SCHEDULED_TASKS_DIR, dirName)
+    try { if (!statSync(dir).isDirectory()) continue } catch { continue }
+    const skillMd = safeReadText(join(dir, 'SKILL.md'))
+    const configRaw = safeReadJson(join(dir, 'task-config.json'))
+    result.push({ dirName, skillMd, config: { ...configRaw, enabled: false } })
+  }
+  return result
+}
+
+function exportDashboardSettings(): DashboardSettingsExport {
+  const read = (name: string) => safeReadJson(join(STORE_DIR, name))
+  return {
+    autonomy: read('autonomy-config.json'),
+    autoRestart: read('auto-restart.json'),
+    agentsDesired: read('agents-desired.json'),
+    norbertPersonal: read('norbert-personal.json'),
+  }
+}
+
+function exportVault(): VaultExport | null {
+  const vaultKeyPath = join(STORE_DIR, '.vault-key')
+  const vaultKeyMigratedPath = join(STORE_DIR, '.vault-key.migrated')
+  const vaultPath = join(STORE_DIR, 'vault.json')
+  const bindingsPath = join(STORE_DIR, 'vault-bindings.json')
+
+  if (!existsSync(vaultKeyPath)) {
+    // macOS Keychain migration -- vault-key.migrated means key is in Keychain
+    if (existsSync(vaultKeyMigratedPath)) {
+      throw new Error(
+        'A vault kulcs macOS Keychain-be lett migrálva (.vault-key.migrated megtalálható). ' +
+        'A vault szekció exportja ebben a konfigurációban nem támogatott -- adj meg vault jelszót.'
+      )
+    }
+    return null
+  }
+
+  // Raw export: the entire FleetJson will be encrypted, so vault data is safe as plaintext here.
+  const vaultKey = readFileSync(vaultKeyPath, 'utf-8').trim()
+  const vaultStore = safeReadJson(vaultPath)
+  const entries = (vaultStore.entries as Record<string, unknown>[]) ?? []
+  const bindingsStore = safeReadJson(bindingsPath)
+  const bindings = (bindingsStore.bindings as Record<string, unknown>[]) ?? []
+
+  // Channel .env (bot tokens) are intentionally NOT exported -- see re-pair model comment in VaultExport.
+  return { vaultKey, entries, bindings }
+}
+
+// Encrypted export wrapper: {"enc":1,"blob":"<base64-of-encrypted-fleet-json>"}
+// The enc field signals the import side to decrypt before parsing.
+export const ENCRYPTED_FLEET_VERSION = 1
+
+export type ExportedFleet = { data: string; exportedAt: string }
+
+export function exportFleet(options: { vaultPassword?: string } = {}): ExportedFleet {
+  if (options.vaultPassword !== undefined && options.vaultPassword.length < MIN_VAULT_PASSWORD_LEN) {
+    throw new Error(`A vault jelszó legalább ${MIN_VAULT_PASSWORD_LEN} karakter kell legyen.`)
+  }
+
+  const withSecrets = !!options.vaultPassword
+  const db = getDb()
+  const bindingLookup = withSecrets ? new Map() : buildBindingLookup()
+
+  const mainAgent = exportMainAgent(bindingLookup, withSecrets)
+  const agents = listAgentNames().map(name => exportAgent(name, bindingLookup, withSecrets))
+  const skills = listSkillsInDir(join(homedir(), '.claude', 'skills'))
+  const scheduledTasks = exportScheduledTasks()
+
+  // Export ALL memories and daily_logs across every agent_id
+  const memories = db.prepare(
+    `SELECT agent_id, content, sector, salience, created_at, accessed_at,
+            category, auto_generated, keywords
+     FROM memories ORDER BY agent_id ASC, created_at ASC`
+  ).all() as MemoryRow[]
+
+  const dailyLogs = db.prepare(
+    'SELECT agent_id, date, content, created_at FROM daily_logs ORDER BY agent_id ASC, date ASC'
+  ).all() as DailyLogRow[]
+
+  const kanban: KanbanExport = {
+    cards: db.prepare('SELECT * FROM kanban_cards').all() as Record<string, unknown>[],
+    comments: db.prepare('SELECT * FROM kanban_comments').all() as Record<string, unknown>[],
+    cardEvents: db.prepare('SELECT * FROM kanban_card_events').all() as Record<string, unknown>[],
+    labels: db.prepare('SELECT * FROM labels').all() as Record<string, unknown>[],
+    cardLabels: db.prepare('SELECT * FROM kanban_card_labels').all() as Record<string, unknown>[],
+  }
+
+  const ideaBox: IdeaBoxExport = {
+    ideas: db.prepare('SELECT * FROM idea_box').all() as Record<string, unknown>[],
+    comments: db.prepare('SELECT * FROM idea_comments').all() as Record<string, unknown>[],
+    statusLog: db.prepare('SELECT * FROM idea_status_log').all() as Record<string, unknown>[],
+  }
+
+  // Vault section is only included in encrypted exports (whole-JSON encryption makes it safe)
+  const vault = withSecrets ? exportVault() : undefined
+
+  const fleet: FleetJson = {
+    schemaVersion: 1,
+    exportedAt: new Date().toISOString(),
+    sourceHost: hostname(),
+    mainAgent,
+    agents,
+    skills,
+    scheduledTasks,
+    memories,
+    dailyLogs,
+    kanban,
+    ideaBox,
+    dashboardSettings: exportDashboardSettings(),
+    ...(vault ? { vault } : {}),
+  }
+
+  // Normalize ALL absolute paths in the entire JSON in one pass
+  const normalized = normalizePaths(JSON.stringify(fleet))
+
+  if (withSecrets) {
+    // Encrypt the entire JSON -- vault secrets, MCP tokens, settings.env all protected as a unit
+    const blob = encryptWithPassword(normalized, options.vaultPassword!)
+    const data = JSON.stringify({ enc: ENCRYPTED_FLEET_VERSION, blob })
+    return { data, exportedAt: fleet.exportedAt }
+  }
+
+  return { data: normalized, exportedAt: fleet.exportedAt }
+}
+
+// ---------------------------------------------------------------------------
+// Import -- validate, dry-run, and apply
+// ---------------------------------------------------------------------------
+
+function validateSchema(fleet: unknown): string[] {
+  const errors: string[] = []
+  if (!fleet || typeof fleet !== 'object') {
+    errors.push('Érvénytelen JSON: a gyökér nem objektum.')
+    return errors
+  }
+  const f = fleet as Record<string, unknown>
+  if (f.schemaVersion === undefined || f.schemaVersion === null) {
+    errors.push('schemaVersion hiányzik -- az export nem kompatibilis vagy pre-v1 build hozta létre.')
+    return errors
+  }
+  if (f.schemaVersion !== FLEET_SCHEMA_VERSION) {
+    const v = f.schemaVersion
+    errors.push(
+      `Az export schema v${v}, a telepített dashboard v${FLEET_SCHEMA_VERSION}-t támogat. ` +
+      (Number(v) > FLEET_SCHEMA_VERSION
+        ? 'Frissítsd a dashboardot az import előtt.'
+        : 'Az export túl régi.')
+    )
+    return errors
+  }
+  if (!Array.isArray(f.agents)) errors.push('agents mező hiányzik vagy nem tömb.')
+  return errors
+}
+
+// B1: validate all untrusted names before any file operation
+function validateNames(fleet: FleetJson): string[] {
+  const errors: string[] = []
+
+  // mainAgent channel providers (written to ~/.claude/channels/<provider>/)
+  for (const provider of Object.keys(fleet.mainAgent?.channelsAccess ?? {})) {
+    if (!SAFE_NAME_RE.test(provider)) {
+      errors.push(`Érvénytelen mainAgent channel provider: "${provider.slice(0, 60)}"`)
+    }
+  }
+
+  for (const agent of fleet.agents ?? []) {
+    if (!SAFE_NAME_RE.test(String(agent.name ?? ''))) {
+      errors.push(`Érvénytelen agent.name: "${String(agent.name).slice(0, 60)}"`)
+    }
+    // B1: avatarExt defense-in-depth guard (primary enforcement in writeAgentFiles)
+    if (agent.avatar && agent.avatarExt !== undefined &&
+        !/^(png|jpe?g|webp)$/i.test(String(agent.avatarExt))) {
+      errors.push(`Érvénytelen avatarExt (agent ${agent.name}): "${String(agent.avatarExt).slice(0, 20)}"`)
+    }
+    for (const skill of agent.agentSkills ?? []) {
+      if (!SAFE_NAME_RE.test(String(skill.name ?? ''))) {
+        errors.push(`Érvénytelen skill.name (agent ${agent.name}): "${String(skill.name).slice(0, 60)}"`)
+      }
+    }
+    for (const provider of Object.keys(agent.channelsAccess ?? {})) {
+      if (!SAFE_NAME_RE.test(provider)) {
+        errors.push(`Érvénytelen channel provider (agent ${agent.name}): "${provider.slice(0, 60)}"`)
+      }
+    }
+  }
+  for (const skill of fleet.skills ?? []) {
+    if (!SAFE_NAME_RE.test(String(skill.name ?? ''))) {
+      errors.push(`Érvénytelen global skill.name: "${String(skill.name).slice(0, 60)}"`)
+    }
+  }
+  for (const task of fleet.scheduledTasks ?? []) {
+    if (!SAFE_NAME_RE.test(String(task.dirName ?? ''))) {
+      errors.push(`Érvénytelen scheduledTask.dirName: "${String(task.dirName).slice(0, 60)}"`)
+    }
+  }
+  return errors
+}
+
+function buildDiffReport(fleet: FleetJson): DiffReport {
+  const db = getDb()
+  const warnings: string[] = []
+
+  const existingAgents = new Set(listAgentNames())
+  const newAgents = (fleet.agents ?? []).map(a => a.name).filter(n => !existingAgents.has(n))
+
+  let newMemories = 0
+  for (const mem of fleet.memories ?? []) {
+    if (!db.prepare('SELECT 1 FROM memories WHERE agent_id = ? AND content = ?').get(mem.agent_id, mem.content)) {
+      newMemories++
+    }
+  }
+
+  let newCards = 0
+  for (const card of fleet.kanban?.cards ?? []) {
+    if (!db.prepare('SELECT 1 FROM kanban_cards WHERE id = ?').get((card as any).id)) newCards++
+  }
+
+  let newLabels = 0
+  for (const label of fleet.kanban?.labels ?? []) {
+    if (!db.prepare('SELECT 1 FROM labels WHERE id = ?').get((label as any).id)) newLabels++
+  }
+
+  let newDailyLogs = 0
+  for (const log of fleet.dailyLogs ?? []) {
+    if (!db.prepare('SELECT 1 FROM daily_logs WHERE agent_id = ? AND date = ? AND content = ?').get(log.agent_id, log.date, log.content)) {
+      newDailyLogs++
+    }
+  }
+
+  let newComments = 0
+  for (const c of fleet.kanban?.comments ?? []) {
+    if (!db.prepare('SELECT 1 FROM kanban_comments WHERE card_id = ? AND content = ?')
+      .get((c as any).card_id, (c as any).content)) newComments++
+  }
+
+  if (!fleet.vault) {
+    warnings.push('vault szekció hiányzik -- az MCP szerverek token nélkül indulnak el, manuális re-auth szükséges.')
+  }
+
+  // H3: track which existing agents and main agent would be overwritten
+  const existingAgentsToOverwrite = (fleet.agents ?? []).map(a => a.name).filter(n => existingAgents.has(n))
+  const mainAgentOverwrite = !!fleet.mainAgent && existsSync(join(PROJECT_ROOT, 'CLAUDE.md'))
+
+  // Channels: always warn -- bot tokens are not exported (re-pair model)
+  const hasChannels = Object.keys(fleet.mainAgent?.channelsAccess ?? {}).length > 0 ||
+    (fleet.agents ?? []).some(a => Object.keys(a.channelsAccess ?? {}).length > 0)
+  if (hasChannels) {
+    warnings.push('Csatornák: újra-párosítás szükséges a célgépen (bot token újboli megadása).')
+  }
+
+  // Identity takeover preview
+  const drySourceId = fleet.mainAgent?.identity?.MAIN_AGENT_ID ?? fleet.mainAgent?.agentId
+  if (drySourceId && typeof drySourceId === 'string') {
+    warnings.push(
+      `Fő-agent identitás átvéve: ${drySourceId}. Apply után újraindítás szükséges hogy a dashboard ${drySourceId}-ként induljon.`
+    )
+  }
+
+  return {
+    dryRun: true,
+    wouldCreate: {
+      mainAgent: !!fleet.mainAgent,
+      agents: newAgents,
+      globalSkills: (fleet.skills ?? []).length,
+      scheduledTasks: (fleet.scheduledTasks ?? []).length,
+      memories: newMemories,
+      kanbanCards: newCards,
+      kanbanComments: newComments,
+      labels: newLabels,
+      dailyLogs: newDailyLogs,
+      ideaBox: (fleet.ideaBox?.ideas ?? []).length,
+    },
+    wouldOverwrite: {
+      agents: existingAgentsToOverwrite,
+      mainAgent: mainAgentOverwrite,
+    },
+    warnings,
+    errors: [],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Apply helpers -- tracked writes for partial cleanup (H3)
+// ---------------------------------------------------------------------------
+
+interface WriteEntry {
+  path: string
+  preexisted: boolean
+}
+
+interface WriteTracker {
+  files: WriteEntry[]
+  dirs: string[]
+}
+
+function trackedMkdir(path: string, tracker: WriteTracker): void {
+  if (!existsSync(path)) {
+    mkdirSync(path, { recursive: true })
+    tracker.dirs.push(path)
+  }
+}
+
+function trackedWrite(path: string, content: string | Buffer, tracker: WriteTracker, opts?: { mode?: number }): void {
+  const preexisted = existsSync(path)
+  atomicWriteFileSync(path, content as string, opts)
+  tracker.files.push({ path, preexisted })
+}
+
+function cleanupTracked(tracker: WriteTracker): void {
+  // Only delete files that did not exist before the import started; pre-existing overwritten files
+  // cannot be restored (no backup), so we leave them rather than delete them (H3).
+  for (const { path, preexisted } of tracker.files) {
+    if (!preexisted) {
+      try { unlinkSync(path) } catch { /* best effort */ }
+    }
+  }
+  // Remove dirs in reverse order (deepest first), only if empty
+  for (const d of [...tracker.dirs].reverse()) {
+    try { rmSync(d, { recursive: true, force: true }) } catch { /* best effort */ }
+  }
+}
+
+function writeMainAgentFiles(ma: MainAgentExport, tracker: WriteTracker): void {
+  const claudeDir = join(PROJECT_ROOT, '.claude')
+  trackedMkdir(claudeDir, tracker)
+
+  if (ma.claudeMd) trackedWrite(join(PROJECT_ROOT, 'CLAUDE.md'), ma.claudeMd, tracker)
+  if (ma.soulMd) trackedWrite(join(PROJECT_ROOT, 'SOUL.md'), ma.soulMd, tracker)
+  if (ma.config && Object.keys(ma.config).length)
+    trackedWrite(join(PROJECT_ROOT, 'agent-config.json'), JSON.stringify(ma.config, null, 2), tracker)
+  trackedWrite(join(PROJECT_ROOT, '.mcp.json'), JSON.stringify(deplaceholderMcp(ma.mcp), null, 2), tracker)
+  trackedWrite(join(claudeDir, 'settings.json'), JSON.stringify(ma.settings, null, 2), tracker)
+
+  // Main agent channel access: ~/.claude/channels/<provider>/access.json
+  // B1: provider names validated by validateNames() before this is called
+  const channelsBase = join(homedir(), '.claude', 'channels')
+  for (const [provider, access] of Object.entries(ma.channelsAccess ?? {})) {
+    const provDir = safeJoin(channelsBase, provider)
+    trackedMkdir(provDir, tracker)
+    trackedWrite(join(provDir, 'access.json'), JSON.stringify(access, null, 2), tracker)
+  }
+}
+
+function writeAgentFiles(agent: AgentExport, tracker: WriteTracker): void {
+  // B1: names already validated by validateNames() before this is called
+  const dir = safeJoin(AGENTS_BASE_DIR, agent.name)
+  const claudeDir = safeJoin(dir, '.claude')
+  trackedMkdir(claudeDir, tracker)
+
+  trackedWrite(join(dir, 'agent-config.json'), JSON.stringify(agent.config, null, 2), tracker)
+  if (agent.claudeMd) trackedWrite(join(dir, 'CLAUDE.md'), agent.claudeMd, tracker)
+  if (agent.soulMd) trackedWrite(join(dir, 'SOUL.md'), agent.soulMd, tracker)
+
+  // .mcp.json: de-placeholder vault refs (path denormalization happens at fleet level)
+  trackedWrite(join(dir, '.mcp.json'), JSON.stringify(deplaceholderMcp(agent.mcp), null, 2), tracker)
+
+  trackedWrite(join(claudeDir, 'settings.json'), JSON.stringify(agent.settings, null, 2), tracker)
+
+  for (const [provider, access] of Object.entries(agent.channelsAccess ?? {})) {
+    const provDir = safeJoin(claudeDir, 'channels', provider)
+    trackedMkdir(provDir, tracker)
+    trackedWrite(join(provDir, 'access.json'), JSON.stringify(access, null, 2), tracker)
+  }
+
+  if (agent.avatar) {
+    // B1: whitelist extension to prevent path traversal via malicious avatarExt
+    const ext = /^(png|jpe?g|webp)$/i.test(String(agent.avatarExt || '')) ? String(agent.avatarExt) : 'png'
+    trackedWrite(safeJoin(dir, `avatar.${ext}`), Buffer.from(agent.avatar, 'base64'), tracker)
+  }
+
+  for (const skill of agent.agentSkills ?? []) {
+    const skillDir = safeJoin(claudeDir, 'skills', skill.name)
+    trackedMkdir(skillDir, tracker)
+    trackedWrite(join(skillDir, 'SKILL.md'), skill.skillMd, tracker)
+  }
+}
+
+function importVaultSection(vault: VaultExport, tracker: WriteTracker): void {
+  // vault.vaultKey is plaintext -- the caller already decrypted the whole JSON with the user password
+  trackedWrite(join(STORE_DIR, '.vault-key'), vault.vaultKey, tracker, { mode: 0o600 })
+  trackedWrite(join(STORE_DIR, 'vault.json'), JSON.stringify({ entries: vault.entries }, null, 2), tracker, { mode: 0o600 })
+  trackedWrite(join(STORE_DIR, 'vault-bindings.json'), JSON.stringify({ bindings: vault.bindings }, null, 2), tracker)
+  // Channel .env (bot tokens) are intentionally NOT imported -- target must re-pair channels manually.
+}
+
+const EMPTY_DIFF: DiffReport = {
+  dryRun: true,
+  wouldCreate: { mainAgent: false, agents: [], globalSkills: 0, scheduledTasks: 0, memories: 0, kanbanCards: 0, kanbanComments: 0, labels: 0, dailyLogs: 0, ideaBox: 0 },
+  wouldOverwrite: { agents: [], mainAgent: false },
+  warnings: [],
+  errors: [],
+}
+
+export function importFleet(
+  rawBody: string,
+  options: { vaultPassword?: string; apply: boolean },
+): DiffReport | ImportResult {
+  // Auto-detect encrypted export: {"enc":1,"blob":"..."}
+  // H2/M2: decrypt FIRST, before any file writes or DB commits (fail-fast on wrong password)
+  let jsonBody: string
+  try {
+    const parsed = JSON.parse(rawBody)
+    if (parsed && typeof parsed === 'object' && parsed.enc === ENCRYPTED_FLEET_VERSION && typeof parsed.blob === 'string') {
+      // Encrypted fleet -- password required
+      if (!options.vaultPassword) {
+        return { ...EMPTY_DIFF, errors: ['A fájl titkosítva van -- add meg a vault jelszót az importhoz.'] }
+      }
+      if (options.vaultPassword.length < MIN_VAULT_PASSWORD_LEN) {
+        return { ...EMPTY_DIFF, errors: [`A vault jelszó legalább ${MIN_VAULT_PASSWORD_LEN} karakter kell legyen.`] }
+      }
+      try {
+        jsonBody = decryptWithPassword(parsed.blob, options.vaultPassword)
+      } catch {
+        return { ...EMPTY_DIFF, errors: ['Helytelen vault jelszó -- a titkosított fájl nem dekódolható.'] }
+      }
+    } else {
+      // Plaintext fleet JSON
+      jsonBody = rawBody
+    }
+  } catch (err: any) {
+    return { ...EMPTY_DIFF, errors: [`Érvénytelen JSON: ${err.message}`] }
+  }
+
+  // Denormalize paths in the entire JSON before any processing
+  const fleet = JSON.parse(denormalizePaths(jsonBody)) as FleetJson
+
+  const schemaErrors = validateSchema(fleet)
+  if (schemaErrors.length > 0) {
+    return { ...EMPTY_DIFF, errors: schemaErrors }
+  }
+
+  // B1: validate all names before dry-run or apply
+  const nameErrors = validateNames(fleet)
+  if (nameErrors.length > 0) {
+    return { ...EMPTY_DIFF, errors: nameErrors }
+  }
+
+  if (!options.apply) {
+    const report = buildDiffReport(fleet)
+    // M1: vault present in export but no password at import -> warning (apply would skip vault)
+    if (fleet.vault && !options.vaultPassword) {
+      report.warnings.push('vault szekció jelen van, de nem adtál meg jelszót -- a vault-titkok kihagyásra kerülnek.')
+    }
+    return report
+  }
+
+  // -------------------------------------------------------------------------
+  // Apply phase -- H3: track ALL writes, cleanup on any failure
+  // -------------------------------------------------------------------------
+  const db = getDb()
+  const tracker: WriteTracker = { files: [], dirs: [] }
+  const globalSkillsDir = join(homedir(), '.claude', 'skills')
+
+  try {
+    // 0. Main agent files (PROJECT_ROOT level -- main agent persona, settings, channel pairing)
+    if (fleet.mainAgent) {
+      writeMainAgentFiles(fleet.mainAgent, tracker)
+    }
+
+    // 1. Sub-agent files
+    for (const agent of fleet.agents ?? []) {
+      writeAgentFiles(agent, tracker)
+    }
+
+    // 2. Global skills
+    trackedMkdir(globalSkillsDir, tracker)
+    for (const skill of fleet.skills ?? []) {
+      const skillDir = safeJoin(globalSkillsDir, skill.name)
+      trackedMkdir(skillDir, tracker)
+      trackedWrite(join(skillDir, 'SKILL.md'), skill.skillMd, tracker)
+    }
+
+    // 3. Scheduled tasks (all paused: enabled=false already set at export time)
+    if (existsSync(SCHEDULED_TASKS_DIR) || fleet.scheduledTasks?.length) {
+      trackedMkdir(SCHEDULED_TASKS_DIR, tracker)
+    }
+    for (const task of fleet.scheduledTasks ?? []) {
+      const dir = safeJoin(SCHEDULED_TASKS_DIR, task.dirName)
+      trackedMkdir(dir, tracker)
+      if (task.skillMd) trackedWrite(join(dir, 'SKILL.md'), task.skillMd, tracker)
+      trackedWrite(
+        join(dir, 'task-config.json'),
+        JSON.stringify({ ...task.config, enabled: false }, null, 2),
+        tracker,
+      )
+    }
+
+    // 4. Dashboard settings
+    const s = fleet.dashboardSettings ?? {}
+    if (s.autonomy && Object.keys(s.autonomy).length)
+      trackedWrite(join(STORE_DIR, 'autonomy-config.json'), JSON.stringify(s.autonomy, null, 2), tracker)
+    if (s.autoRestart && Object.keys(s.autoRestart).length)
+      trackedWrite(join(STORE_DIR, 'auto-restart.json'), JSON.stringify(s.autoRestart, null, 2), tracker)
+    if (s.agentsDesired && Object.keys(s.agentsDesired).length)
+      trackedWrite(join(STORE_DIR, 'agents-desired.json'), JSON.stringify(s.agentsDesired, null, 2), tracker)
+    if (s.norbertPersonal && Object.keys(s.norbertPersonal).length)
+      trackedWrite(join(STORE_DIR, 'norbert-personal.json'), JSON.stringify(s.norbertPersonal, null, 2), tracker)
+
+    // 5. DB -- single transaction (H3: before vault so vault is last and cleanup is cleaner)
+    const importTx = db.transaction(() => {
+      // labels first (FK dep for kanban_card_labels)
+      // M3: skip rows with missing required fields to avoid SQLite constraint errors -> 500
+      for (const label of fleet.kanban?.labels ?? []) {
+        const l = label as any
+        if (!l.id || !l.name) { logger.warn({ id: l.id }, 'Fleet import: skipping label with missing required fields'); continue }
+        db.prepare('INSERT OR IGNORE INTO labels (id, name, color, created_at) VALUES (?, ?, ?, ?)')
+          .run(l.id, l.name, l.color, l.created_at)
+      }
+
+      for (const card of fleet.kanban?.cards ?? []) {
+        const c = card as any
+        if (!c.id || !c.title || !c.status || !c.priority || c.sort_order == null) {
+          logger.warn({ id: c.id }, 'Fleet import: skipping kanban card with missing required fields'); continue
+        }
+        db.prepare(
+          `INSERT OR IGNORE INTO kanban_cards
+           (id, title, description, status, assignee, priority, project,
+            due_date, sort_order, created_at, updated_at, archived_at, parent_id, dispatched_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ).run(c.id, c.title, c.description ?? null, c.status, c.assignee ?? null,
+          c.priority, c.project ?? null, c.due_date ?? null, c.sort_order,
+          c.created_at, c.updated_at, c.archived_at ?? null, c.parent_id ?? null, c.dispatched_at ?? null)
+      }
+
+      // kanban comments (idempotent: card_id + content)
+      for (const comment of fleet.kanban?.comments ?? []) {
+        const c = comment as any
+        if (!c.card_id || !c.content) continue
+        if (!db.prepare('SELECT 1 FROM kanban_comments WHERE card_id = ? AND content = ?').get(c.card_id, c.content)) {
+          db.prepare('INSERT INTO kanban_comments (card_id, author, content, created_at) VALUES (?, ?, ?, ?)')
+            .run(c.card_id, c.author, c.content, c.created_at)
+        }
+      }
+
+      // kanban card events -- idempotent on (card_id, created_at, to_status)
+      for (const ev of fleet.kanban?.cardEvents ?? []) {
+        const e = ev as any
+        if (!e.card_id || !e.to_status) continue
+        if (!db.prepare('SELECT 1 FROM kanban_card_events WHERE card_id = ? AND created_at = ? AND to_status = ?')
+          .get(e.card_id, e.created_at, e.to_status)) {
+          db.prepare('INSERT INTO kanban_card_events (card_id, from_status, to_status, actor, created_at) VALUES (?, ?, ?, ?, ?)')
+            .run(e.card_id, e.from_status ?? null, e.to_status, e.actor, e.created_at)
+        }
+      }
+
+      for (const cl of fleet.kanban?.cardLabels ?? []) {
+        const c = cl as any
+        if (!c.card_id || !c.label_id) continue
+        db.prepare('INSERT OR IGNORE INTO kanban_card_labels (card_id, label_id, created_at) VALUES (?, ?, ?)')
+          .run(c.card_id, c.label_id, c.created_at)
+      }
+
+      // memories -- idempotent on (agent_id, content); covers ALL agent_ids
+      // agent_id-k pontosan a forrásból kerülnek át (a cél átveszi a forrás főagent identitását)
+      const now = Math.floor(Date.now() / 1000)
+      for (const mem of fleet.memories ?? []) {
+        if (!db.prepare('SELECT 1 FROM memories WHERE agent_id = ? AND content = ?').get(mem.agent_id, mem.content)) {
+          db.prepare(
+            `INSERT INTO memories
+             (chat_id, topic_key, content, sector, salience, created_at, accessed_at,
+              agent_id, category, auto_generated, keywords)
+             VALUES ('', NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+          ).run(mem.content, mem.sector, mem.salience, mem.created_at, mem.accessed_at ?? now,
+            mem.agent_id, mem.category, mem.auto_generated ?? 0, mem.keywords ?? null)
+        }
+      }
+
+      // daily logs -- idempotent on (agent_id, date, content); multiple rows per date are preserved
+      for (const log of fleet.dailyLogs ?? []) {
+        if (!db.prepare('SELECT 1 FROM daily_logs WHERE agent_id = ? AND date = ? AND content = ?').get(log.agent_id, log.date, log.content)) {
+          db.prepare('INSERT INTO daily_logs (agent_id, date, content, created_at) VALUES (?, ?, ?, ?)')
+            .run(log.agent_id, log.date, log.content, log.created_at)
+        }
+      }
+
+      // idea_box -- idempotent on id
+      for (const idea of fleet.ideaBox?.ideas ?? []) {
+        const i = idea as any
+        db.prepare(
+          `INSERT OR IGNORE INTO idea_box
+           (id, title, description, category, status, source, kanban_id, impact, effort, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ).run(i.id, i.title, i.description ?? null, i.category, i.status, i.source ?? '',
+          i.kanban_id ?? null, i.impact ?? null, i.effort ?? null, i.created_at, i.updated_at)
+      }
+
+      // idea_comments -- M5: idempotent on (idea_id, created_at, content)
+      for (const comment of fleet.ideaBox?.comments ?? []) {
+        const c = comment as any
+        if (!db.prepare('SELECT 1 FROM idea_comments WHERE idea_id = ? AND created_at = ? AND content = ?')
+          .get(c.idea_id, c.created_at, c.content)) {
+          db.prepare('INSERT INTO idea_comments (idea_id, author, content, created_at) VALUES (?, ?, ?, ?)')
+            .run(c.idea_id, c.author, c.content, c.created_at)
+        }
+      }
+
+      // idea_status_log -- M5: idempotent on (idea_id, created_at, to_status)
+      for (const log of fleet.ideaBox?.statusLog ?? []) {
+        const l = log as any
+        if (!db.prepare('SELECT 1 FROM idea_status_log WHERE idea_id = ? AND created_at = ? AND to_status = ?')
+          .get(l.idea_id, l.created_at, l.to_status)) {
+          db.prepare(
+            'INSERT INTO idea_status_log (idea_id, from_status, to_status, actor, note, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+          ).run(l.idea_id, l.from_status ?? null, l.to_status, l.actor, l.note ?? null, l.created_at)
+        }
+      }
+
+      // FTS rebuild after all memory inserts
+      db.prepare("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')").run()
+    })
+
+    importTx()
+
+    // 6. Vault -- LAST: vault data is plaintext (decrypted at the top of importFleet)
+    if (fleet.vault) {
+      importVaultSection(fleet.vault, tracker)
+    }
+
+    // M3: fire-and-forget re-embed imported memories (embedding was stripped at export)
+    backfillEmbeddings().catch(err => logger.warn({ err: err?.message }, 'Fleet import: embedding backfill failed'))
+
+    // Identity takeover: write the source identity set into config-overrides.json so the
+    // target install adopts the source persona (name, brand, owner) on next restart.
+    // Preference: use identity object (full set) if present; fall back to agentId-only for
+    // exports produced before the identity field was added.
+    const applyWarnings: string[] = []
+    const sourceIdentity = fleet.mainAgent?.identity
+    const sourceAgentId = sourceIdentity?.MAIN_AGENT_ID ?? fleet.mainAgent?.agentId
+    if (sourceAgentId && typeof sourceAgentId === 'string') {
+      const overridesPath = join(STORE_DIR, 'config-overrides.json')
+      let overrides: Record<string, unknown> = {}
+      try {
+        if (existsSync(overridesPath)) {
+          overrides = JSON.parse(readFileSync(overridesPath, 'utf-8')) as Record<string, unknown>
+        }
+      } catch { /* start fresh if file is corrupt */ }
+      if (sourceIdentity && typeof sourceIdentity === 'object') {
+        // Full identity takeover: iterate all keys generically (no hardcoded names)
+        for (const [key, val] of Object.entries(sourceIdentity)) {
+          if (typeof val === 'string' && val.length > 0) {
+            overrides[key] = val
+          }
+        }
+      } else {
+        // Backward-compat: old export without identity -- only set MAIN_AGENT_ID
+        overrides['MAIN_AGENT_ID'] = sourceAgentId
+      }
+      atomicWriteFileSync(overridesPath, JSON.stringify(overrides, null, 2))
+
+      // Mirror the identity into .env as well. The dashboard reads identity via
+      // cfg() (config-overrides.json > .env), but shell-side launchers -- above
+      // all scripts/channels.sh -- read MAIN_AGENT_ID / CHANNEL_PROVIDER
+      // DIRECTLY from .env. Without this the main agent would launch under the
+      // pre-import identity (`${old-id}-channels`) while the dashboard looks for
+      // `${new-id}-channels` and reports the main agent as down.
+      const envIdentity: Record<string, string> = {}
+      if (sourceIdentity && typeof sourceIdentity === 'object') {
+        for (const [key, val] of Object.entries(sourceIdentity)) {
+          if (typeof val === 'string' && val.length > 0) envIdentity[key] = val
+        }
+      } else {
+        envIdentity['MAIN_AGENT_ID'] = sourceAgentId
+      }
+      updateEnvFile(envIdentity)
+
+      applyWarnings.push(
+        `Fő-agent identitás átvéve: ${sourceAgentId}. Újraindítás kell hogy a dashboard ${sourceAgentId}-ként induljon.`
+      )
+    }
+
+    logger.info({ agents: (fleet.agents ?? []).map(a => a.name) }, 'Fleet import completed')
+
+    return {
+      ok: true,
+      imported: {
+        mainAgent: !!fleet.mainAgent,
+        agents: (fleet.agents ?? []).map(a => a.name),
+        globalSkills: (fleet.skills ?? []).length,
+        scheduledTasks: (fleet.scheduledTasks ?? []).length,
+        memories: (fleet.memories ?? []).length,
+        kanbanCards: (fleet.kanban?.cards ?? []).length,
+        labels: (fleet.kanban?.labels ?? []).length,
+        dailyLogs: (fleet.dailyLogs ?? []).length,
+        ideaBox: (fleet.ideaBox?.ideas ?? []).length,
+      },
+      ...(applyWarnings.length > 0 ? { warnings: applyWarnings } : {}),
+    }
+  } catch (err: any) {
+    cleanupTracked(tracker)
+    logger.error({ err: err.message }, 'Fleet import failed, tracked writes cleaned up')
+    throw err
+  }
+}

--- a/src/web/routes/fleet.ts
+++ b/src/web/routes/fleet.ts
@@ -1,0 +1,73 @@
+import { logger } from '../../logger.js'
+import { readBody, json } from '../http-helpers.js'
+import { exportFleet, importFleet, MIN_VAULT_PASSWORD_LEN, UserFacingError, type ExportedFleet } from '../fleet-transfer.js'
+import type { RouteContext } from './types.js'
+
+export async function tryHandleFleet(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+
+  if (path !== '/api/fleet/export' && path !== '/api/fleet/import') return false
+
+  // H1: vault password via header, not query string (avoids access-log / proxy-log / browser-history leakage)
+  const vaultPassword = req.headers['x-vault-password'] as string | undefined
+
+  if (path === '/api/fleet/export' && method === 'GET') {
+    if (vaultPassword !== undefined && vaultPassword.length < MIN_VAULT_PASSWORD_LEN) {
+      json(res, { error: `X-Vault-Password must be at least ${MIN_VAULT_PASSWORD_LEN} characters.` }, 400)
+      return true
+    }
+    try {
+      const exported: ExportedFleet = exportFleet({ vaultPassword: vaultPassword || undefined })
+      const buf = Buffer.from(exported.data)
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="fleet-export-${exported.exportedAt.slice(0, 10)}.json"`,
+        'Content-Length': buf.byteLength,
+      })
+      res.end(buf)
+    } catch (err: any) {
+      if (err instanceof UserFacingError) {
+        json(res, { error: err.message }, 400)
+      } else {
+        logger.error({ err: err.message }, 'Fleet export failed')
+        json(res, { error: `Export hiba: ${err.message}` }, 500)
+      }
+    }
+    return true
+  }
+
+  if (path === '/api/fleet/import' && method === 'POST') {
+    const apply = ctx.url.searchParams.get('apply') === 'true'
+
+    // M1: check vault password length for import side too
+    if (vaultPassword !== undefined && vaultPassword.length < MIN_VAULT_PASSWORD_LEN) {
+      json(res, { error: `X-Vault-Password must be at least ${MIN_VAULT_PASSWORD_LEN} characters.` }, 400)
+      return true
+    }
+
+    let rawBody: string
+    try {
+      const buf = await readBody(req)
+      rawBody = buf.toString()
+    } catch (err: any) {
+      json(res, { error: `Kérés olvasási hiba: ${err.message}` }, 400)
+      return true
+    }
+
+    // importFleet handles JSON parse (and encrypted blob detection) internally
+    try {
+      const result = importFleet(rawBody, { vaultPassword: vaultPassword || undefined, apply })
+      if ('dryRun' in result && result.errors.length > 0) {
+        json(res, result, 400)
+      } else {
+        json(res, result, 200)
+      }
+    } catch (err: any) {
+      logger.error({ err: err.message }, 'Fleet import failed')
+      json(res, { error: `Import hiba: ${err.message}` }, 500)
+    }
+    return true
+  }
+
+  return false
+}

--- a/web/app.js
+++ b/web/app.js
@@ -9245,6 +9245,200 @@ document.getElementById('migrateNewBtn').addEventListener('click', () => {
 })
 
 // ============================================================
+// === Fleet Migration ===
+// ============================================================
+
+// Holds the last successfully parsed fleet JSON text (for apply after dry-run)
+let fleetLastBody = null
+
+document.getElementById('fleetExportBtn').addEventListener('click', async () => {
+  const btn = document.getElementById('fleetExportBtn')
+  const password = document.getElementById('fleetExportPassword').value.trim()
+
+  btn.disabled = true
+  btn.querySelector('.btn-text').hidden = true
+  btn.querySelector('.btn-loading').hidden = false
+
+  try {
+    const headers = {}
+    if (password) headers['X-Vault-Password'] = password
+
+    const res = await fetch('/api/fleet/export', { headers })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      showToast(data.error || t('fleet.export.error'))
+      return
+    }
+
+    const blob = await res.blob()
+    const cd = res.headers.get('Content-Disposition') || ''
+    const nameMatch = cd.match(/filename="?([^";\s]+)"?/)
+    const filename = nameMatch ? nameMatch[1] : `fleet-export-${new Date().toISOString().slice(0, 10)}.json`
+
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+
+    showToast(t('fleet.export.success'))
+  } catch (err) {
+    showToast(`${t('fleet.export.error')}: ${err.message}`)
+  } finally {
+    btn.disabled = false
+    btn.querySelector('.btn-text').hidden = false
+    btn.querySelector('.btn-loading').hidden = true
+  }
+})
+
+document.getElementById('fleetDryRunBtn').addEventListener('click', async () => {
+  const fileInput = document.getElementById('fleetImportFile')
+  if (!fileInput.files.length) {
+    showToast(t('fleet.import.no_file'))
+    return
+  }
+
+  const btn = document.getElementById('fleetDryRunBtn')
+  btn.disabled = true
+  btn.querySelector('.btn-text').hidden = true
+  btn.querySelector('.btn-loading').hidden = false
+
+  const applyBtn = document.getElementById('fleetApplyBtn')
+  applyBtn.disabled = true
+  fleetLastBody = null
+
+  const resultEl = document.getElementById('fleetDryRunResult')
+  resultEl.hidden = true
+  resultEl.innerHTML = ''
+
+  try {
+    const text = await fileInput.files[0].text()
+    // Validate JSON client-side first
+    try { JSON.parse(text) } catch { showToast(t('fleet.import.invalid_json')); return }
+
+    const password = document.getElementById('fleetImportPassword').value.trim()
+    const headers = { 'Content-Type': 'application/json' }
+    if (password) headers['X-Vault-Password'] = password
+
+    const res = await fetch('/api/fleet/import', { method: 'POST', headers, body: text })
+    const data = await res.json()
+
+    const wc = data.wouldCreate || {}
+    const hasErrors = data.errors && data.errors.length > 0
+    const hasWarnings = data.warnings && data.warnings.length > 0
+
+    resultEl.className = `fleet-dry-run-result ${hasErrors ? 'has-errors' : 'ok'}`
+    resultEl.hidden = false
+
+    const agentNames = Array.isArray(wc.agents) ? wc.agents : []
+    const agentLabel = agentNames.length
+      ? `${agentNames.length} (${agentNames.join(', ')})`
+      : '0'
+
+    resultEl.innerHTML = `
+      <div class="fleet-dry-run-title">${hasErrors ? '❌ ' + t('fleet.import.dryrun_errors') : '✅ ' + t('fleet.import.dryrun_ok')}</div>
+      ${!hasErrors ? `
+      <div class="fleet-dry-run-grid">
+        <div class="fleet-dry-run-stat">
+          <div class="fleet-dry-run-stat-value">${wc.mainAgent ? '✓' : '—'}</div>
+          <div class="fleet-dry-run-stat-label">${t('fleet.stat.main_agent')}</div>
+        </div>
+        <div class="fleet-dry-run-stat">
+          <div class="fleet-dry-run-stat-value">${agentNames.length}</div>
+          <div class="fleet-dry-run-stat-label">${t('fleet.stat.agents')}</div>
+        </div>
+        <div class="fleet-dry-run-stat">
+          <div class="fleet-dry-run-stat-value">${wc.memories ?? 0}</div>
+          <div class="fleet-dry-run-stat-label">${t('fleet.stat.memories')}</div>
+        </div>
+        <div class="fleet-dry-run-stat">
+          <div class="fleet-dry-run-stat-value">${wc.kanbanCards ?? 0}</div>
+          <div class="fleet-dry-run-stat-label">${t('fleet.stat.kanban')}</div>
+        </div>
+        <div class="fleet-dry-run-stat">
+          <div class="fleet-dry-run-stat-value">${wc.globalSkills ?? 0}</div>
+          <div class="fleet-dry-run-stat-label">${t('fleet.stat.skills')}</div>
+        </div>
+        <div class="fleet-dry-run-stat">
+          <div class="fleet-dry-run-stat-value">${wc.scheduledTasks ?? 0}</div>
+          <div class="fleet-dry-run-stat-label">${t('fleet.stat.tasks')}</div>
+        </div>
+      </div>
+      ${agentNames.length ? `<div style="font-size:12px;color:var(--text-muted);margin-bottom:6px">${t('fleet.stat.agent_names')}: ${escapeHtml(agentNames.join(', '))}</div>` : ''}
+      ` : ''}
+      ${hasErrors ? `<div class="fleet-dry-run-errors">${data.errors.map(e => escapeHtml(e)).join('<br>')}</div>` : ''}
+      ${hasWarnings ? `<div class="fleet-dry-run-warnings">⚠️ ${data.warnings.map(w => escapeHtml(w)).join('<br>')}</div>` : ''}
+    `
+
+    if (!hasErrors) {
+      fleetLastBody = text
+      applyBtn.disabled = false
+    }
+  } catch (err) {
+    showToast(`${t('fleet.import.error')}: ${err.message}`)
+  } finally {
+    btn.disabled = false
+    btn.querySelector('.btn-text').hidden = false
+    btn.querySelector('.btn-loading').hidden = true
+  }
+})
+
+document.getElementById('fleetApplyBtn').addEventListener('click', async () => {
+  if (!fleetLastBody) return
+
+  if (!confirm(t('fleet.import.apply_confirm'))) return
+
+  const btn = document.getElementById('fleetApplyBtn')
+  btn.disabled = true
+  btn.querySelector('.btn-text').hidden = true
+  btn.querySelector('.btn-loading').hidden = false
+
+  const resultEl = document.getElementById('fleetDryRunResult')
+
+  try {
+    const password = document.getElementById('fleetImportPassword').value.trim()
+    const headers = { 'Content-Type': 'application/json' }
+    if (password) headers['X-Vault-Password'] = password
+
+    const res = await fetch('/api/fleet/import?apply=true', { method: 'POST', headers, body: fleetLastBody })
+    const data = await res.json()
+
+    if (!res.ok) throw new Error(data.error || t('fleet.import.error'))
+
+    const imp = data.imported || {}
+    const agentNames = Array.isArray(imp.agents) ? imp.agents : []
+
+    resultEl.className = 'fleet-apply-result'
+    resultEl.hidden = false
+    resultEl.innerHTML = `
+      <div class="fleet-apply-result-title">✅ ${t('fleet.import.apply_success')}</div>
+      <div>
+        ${imp.mainAgent ? `<div>${t('fleet.stat.main_agent')}: ✓</div>` : ''}
+        ${agentNames.length ? `<div>${t('fleet.stat.agents')}: ${escapeHtml(agentNames.join(', '))}</div>` : ''}
+        <div>${t('fleet.stat.memories')}: ${imp.memories ?? 0}</div>
+        <div>${t('fleet.stat.kanban')}: ${imp.kanbanCards ?? 0}</div>
+        <div>${t('fleet.stat.skills')}: ${imp.globalSkills ?? 0}</div>
+        <div>${t('fleet.stat.tasks')}: ${imp.scheduledTasks ?? 0}</div>
+      </div>
+    `
+
+    fleetLastBody = null
+    btn.disabled = true
+  } catch (err) {
+    showToast(`${t('fleet.import.error')}: ${err.message}`)
+    btn.disabled = false
+    btn.querySelector('.btn-text').hidden = false
+    btn.querySelector('.btn-loading').hidden = true
+  } finally {
+    btn.querySelector('.btn-text').hidden = false
+    btn.querySelector('.btn-loading').hidden = true
+  }
+})
+
+// ============================================================
 // === Skills Page ===
 // ============================================================
 

--- a/web/index.html
+++ b/web/index.html
@@ -841,6 +841,63 @@
           <button class="btn-secondary btn-compact" id="migrateNewBtn" style="margin-top:16px" data-i18n="migrate.btn.new">Új költöztetés</button>
         </div>
       </div>
+
+      <!-- === Teljes flotta migráció === -->
+      <div class="fleet-section">
+        <div class="fleet-section-header">
+          <h2 class="fleet-section-title" data-i18n="fleet.section_title">Teljes flotta migráció</h2>
+          <p class="fleet-section-desc" data-i18n="fleet.section_desc">Az összes ügynök, memória, kanban és beállítás egyetlen JSON-ban.</p>
+        </div>
+
+        <div class="fleet-warning">
+          <span class="fleet-warning-icon">⚠️</span>
+          <span data-i18n="fleet.warning">Az import kizárólag üres/friss telepítésre való, nem merge-re. Google/Gmail OAuth és a dashboard-token nem utazik: a célgépen re-auth szükséges.</span>
+        </div>
+
+        <div class="fleet-cards">
+          <!-- Export -->
+          <div class="fleet-card">
+            <h3 class="fleet-card-title" data-i18n="fleet.export.title">Export</h3>
+            <p class="fleet-card-desc" data-i18n="fleet.export.desc">A teljes flotta egy JSON-ban. Jelszó megadásával a vault-titkok is (titkosítva).</p>
+            <div class="form-group" style="margin-bottom:12px">
+              <label for="fleetExportPassword" data-i18n="fleet.vault_password_label">Vault jelszó (opcionális)</label>
+              <input type="password" id="fleetExportPassword" data-i18n-ph="fleet.vault_password_ph" placeholder="Ha üresen hagyod, titkok nélkül exportál">
+            </div>
+            <button class="btn-primary btn-compact" id="fleetExportBtn">
+              <span class="btn-text" data-i18n="fleet.export.btn">Letöltés (JSON)</span>
+              <span class="btn-loading" hidden><span class="spinner"></span> <span data-i18n="fleet.export.loading">Exportálás...</span></span>
+            </button>
+          </div>
+
+          <!-- Import -->
+          <div class="fleet-card">
+            <h3 class="fleet-card-title" data-i18n="fleet.import.title">Import</h3>
+            <p class="fleet-card-desc" data-i18n="fleet.import.desc">Tallózz egy korábban exportált fleet-export-*.json fájlt.</p>
+            <div class="form-group" style="margin-bottom:12px">
+              <label for="fleetImportFile" data-i18n="fleet.import.file_label">Fleet JSON fájl</label>
+              <input type="file" id="fleetImportFile" accept="application/json,.json" class="fleet-file-input">
+            </div>
+            <div class="form-group" style="margin-bottom:12px">
+              <label for="fleetImportPassword" data-i18n="fleet.vault_password_label">Vault jelszó (opcionális)</label>
+              <input type="password" id="fleetImportPassword" data-i18n-ph="fleet.import_vault_password_ph" placeholder="Ha üresen hagyod, titkok nélkül importál">
+            </div>
+            <div style="display:flex;gap:8px;flex-wrap:wrap">
+              <button class="btn-secondary btn-compact" id="fleetDryRunBtn">
+                <span class="btn-text" data-i18n="fleet.import.dryrun_btn">Ellenőrzés (dry-run)</span>
+                <span class="btn-loading" hidden><span class="spinner"></span> <span data-i18n="fleet.import.dryrun_loading">Ellenőrzés...</span></span>
+              </button>
+              <button class="btn-primary btn-compact" id="fleetApplyBtn" disabled>
+                <span class="btn-text" data-i18n="fleet.import.apply_btn">Végrehajtás (apply)</span>
+                <span class="btn-loading" hidden><span class="spinner"></span> <span data-i18n="fleet.import.apply_loading">Importálás...</span></span>
+              </button>
+            </div>
+
+            <!-- Dry-run result -->
+            <div id="fleetDryRunResult" hidden></div>
+          </div>
+        </div>
+
+      </div>
     </div>
 
     <!-- === Docs Page === -->

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1506,4 +1506,43 @@ window._i18n.en = {
   'agents.deepseek_link': 'Add API key',
   'agents.deepseek_hint_post': 'on the Vault page.',
   'channel.btn.slack_manifest': 'Create Slack App (manifest)',
+
+  // --- Fleet Migration ---
+  'fleet.section_title':          'Full fleet migration',
+  'fleet.section_desc':           'All agents, memories, kanban and settings in a single JSON.',
+  'fleet.warning':                'Import is for empty/fresh installations only, not merge. Google/Gmail OAuth and dashboard-token are not included: re-auth required on the target machine.',
+  'fleet.vault_password_label':   'Vault password (optional)',
+  'fleet.vault_password_ph':      'Leave empty to export without secrets',
+  'fleet.import_vault_password_ph': 'Leave empty to import without secrets',
+
+  'fleet.export.title':           'Export',
+  'fleet.export.desc':            'Full fleet in one JSON. Supply a password to include vault secrets (encrypted).',
+  'fleet.export.btn':             'Download (JSON)',
+  'fleet.export.loading':         'Exporting...',
+  'fleet.export.success':         'Export downloaded.',
+  'fleet.export.error':           'Export error',
+
+  'fleet.import.title':           'Import',
+  'fleet.import.desc':            'Browse a previously exported fleet-export-*.json file.',
+  'fleet.import.file_label':      'Fleet JSON file',
+  'fleet.import.dryrun_btn':      'Check (dry-run)',
+  'fleet.import.dryrun_loading':  'Checking...',
+  'fleet.import.apply_btn':       'Execute (apply)',
+  'fleet.import.apply_loading':   'Importing...',
+  'fleet.import.no_file':         'Select a fleet JSON file.',
+  'fleet.import.invalid_json':    'The file is not valid JSON.',
+  'fleet.import.dryrun_ok':       'Dry-run successful, apply enabled.',
+  'fleet.import.dryrun_errors':   'Errors in import:',
+  'fleet.import.apply_confirm':   'Are you sure? Import will overwrite existing agent configs. This is for empty/fresh installations only.',
+  'fleet.import.apply_success':   'Import completed successfully.',
+  'fleet.import.error':           'Import error',
+
+  'fleet.stat.main_agent':        'Main agent',
+  'fleet.stat.agents':            'Sub-agents',
+  'fleet.stat.memories':          'Memories',
+  'fleet.stat.kanban':            'Kanban cards',
+  'fleet.stat.skills':            'Global skills',
+  'fleet.stat.tasks':             'Scheduled tasks',
+  'fleet.stat.agent_names':       'Agents',
+
 }

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1503,4 +1503,43 @@ window._i18n.hu = {
   'agents.deepseek_link': 'API kulcs hozzáadása',
   'agents.deepseek_hint_post': 'a Vault oldalon.',
   'channel.btn.slack_manifest': 'Slack App létrehozása (manifest)',
+
+  // --- Fleet Migration ---
+  'fleet.section_title':          'Teljes flotta migráció',
+  'fleet.section_desc':           'Az összes ügynök, memória, kanban és beállítás egyetlen JSON-ban.',
+  'fleet.warning':                'Az import kizárólag üres/friss telepítésre való, nem merge-re. Google/Gmail OAuth és a dashboard-token nem utazik: a célgépen re-auth szükséges.',
+  'fleet.vault_password_label':   'Vault jelszó (opcionális)',
+  'fleet.vault_password_ph':      'Ha üresen hagyod, titkok nélkül exportál',
+  'fleet.import_vault_password_ph': 'Ha üresen hagyod, titkok nélkül importál',
+
+  'fleet.export.title':           'Export',
+  'fleet.export.desc':            'A teljes flotta egy JSON-ban. Jelszó megadásával a vault-titkok is (titkosítva).',
+  'fleet.export.btn':             'Letöltés (JSON)',
+  'fleet.export.loading':         'Exportálás...',
+  'fleet.export.success':         'Export letöltve.',
+  'fleet.export.error':           'Export hiba',
+
+  'fleet.import.title':           'Import',
+  'fleet.import.desc':            'Tallózz egy korábban exportált fleet-export-*.json fájlt.',
+  'fleet.import.file_label':      'Fleet JSON fájl',
+  'fleet.import.dryrun_btn':      'Ellenőrzés (dry-run)',
+  'fleet.import.dryrun_loading':  'Ellenőrzés...',
+  'fleet.import.apply_btn':       'Végrehajtás (apply)',
+  'fleet.import.apply_loading':   'Importálás...',
+  'fleet.import.no_file':         'Válassz egy fleet JSON fájlt.',
+  'fleet.import.invalid_json':    'A fájl nem érvényes JSON.',
+  'fleet.import.dryrun_ok':       'Dry-run sikeres, apply engedélyezve.',
+  'fleet.import.dryrun_errors':   'Hibák az importban:',
+  'fleet.import.apply_confirm':   'Biztos vagy benne? Az import felülírja a meglévő ügynök-konfigurációkat. Ez kizárólag üres/friss telepítésre való.',
+  'fleet.import.apply_success':   'Import sikeresen elvégezve.',
+  'fleet.import.error':           'Import hiba',
+
+  'fleet.stat.main_agent':        'Fő ügynök',
+  'fleet.stat.agents':            'Al-ügynökök',
+  'fleet.stat.memories':          'Memóriák',
+  'fleet.stat.kanban':            'Kanban kártyák',
+  'fleet.stat.skills':            'Globális skillek',
+  'fleet.stat.tasks':             'Ütemezett feladatok',
+  'fleet.stat.agent_names':       'Ügynökök',
+
 }

--- a/web/style.css
+++ b/web/style.css
@@ -6463,6 +6463,156 @@ body {
   height: calc(52px + env(safe-area-inset-top));
   padding-top: env(safe-area-inset-top);
 }
+/* === Fleet Migration Section === */
+.fleet-section {
+  margin-top: 40px;
+  padding-top: 32px;
+  border-top: 1px solid var(--border);
+  max-width: 860px;
+}
+
+.fleet-section-header {
+  margin-bottom: 16px;
+}
+
+.fleet-section-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.fleet-section-desc {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.fleet-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px 16px;
+  background: rgba(201, 160, 0, 0.1);
+  border: 1px solid rgba(201, 160, 0, 0.35);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  line-height: 1.5;
+  margin-bottom: 20px;
+}
+
+.fleet-warning-icon { flex-shrink: 0; }
+
+.fleet-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.fleet-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow-sm);
+}
+
+.fleet-card-title {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.fleet-card-desc {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.fleet-file-input {
+  display: block;
+  width: 100%;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.fleet-dry-run-result {
+  margin-top: 16px;
+  padding: 14px 16px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.fleet-dry-run-result.ok {
+  background: var(--info-soft);
+  border: 1px solid var(--info);
+}
+
+.fleet-dry-run-result.has-errors {
+  background: var(--danger-soft);
+  border: 1px solid var(--danger);
+}
+
+.fleet-dry-run-title {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.fleet-dry-run-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.fleet-dry-run-stat {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  text-align: center;
+}
+
+.fleet-dry-run-stat-value {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.fleet-dry-run-stat-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.fleet-dry-run-warnings {
+  color: #c9a000;
+  font-size: 12px;
+  margin-top: 6px;
+}
+
+.fleet-dry-run-errors {
+  color: var(--danger);
+  font-size: 12px;
+  margin-top: 6px;
+}
+
+.fleet-apply-result {
+  margin-top: 16px;
+  padding: 14px 16px;
+  background: var(--success-soft);
+  border: 1px solid var(--success);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.fleet-apply-result-title {
+  font-weight: 600;
+  color: var(--success);
+  margin-bottom: 6px;
+}
+
 @media (max-width: 768px) {
   /* Off-canvas drawer is position:fixed, so it ignores the <body> padding above.
    * When opened in portrait, keep its top brand below the notch and its footer


### PR DESCRIPTION
Dashboard Migrate-page feature to export the entire fleet -- main agent persona, sub-agents, memories, daily logs, skills, scheduled tasks (re-imported paused), kanban, idea box, dashboard settings, optional vault -- to a single portable JSON, and re-import it on a fresh install.

- Whole-JSON encryption: with a vault password the entire export becomes one AES-256-GCM blob (scrypt N=2^17); import auto-detects and requires the password, fail-fast with no writes on a wrong password. Password-less export is guaranteed secret-free (hard-fails rather than leak an unencrypted token).
- Channel re-pair model: bot tokens are NOT exported (avoids dual-instance 409); only pairing config (access.json) travels.
- Identity takeover on import: the target adopts the source main-agent identity (id, name, brand, owner, channel provider) written to both config-overrides.json and .env, so the dashboard AND the shell-side channels.sh launcher agree.
- Dry-run 'Ellenorzes' shows what would be created/overwritten before Apply; Apply is gated behind a confirmation.
- Path-traversal guards on avatar filenames, secret scanner over MCP env/args/ url/command, malformed-row skip on import.
- 17 unit tests (crypto round-trip, wrong-password fast-fail, secret detection, identity takeover incl. .env mirror). Docs in docs/flotta-migracio.md.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
