### PR TITLE
feat(channels): MAIN_AGENT_CONFIG_DIR -- explicit config dir for a main agent with its own Claude login

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -215,31 +215,47 @@ MODEL_FLAG=""
 # dist/web/agent-process.js) and authenticates the main agent from the fleet
 # setup-token instead.
 #
-# The ON/OFF decision lives ENTIRELY in the helper (ensureMainAgentIsolatedConfigDir):
-# it reads the effective MAIN_AGENT_ISOLATED_CONFIG setting (dashboard toggle in
+# The decision lives ENTIRELY in the helper, which prints "<mode>\t<path>" (or
+# nothing) and covers the two mutually exclusive ways the main agent can get its
+# own CLAUDE_CONFIG_DIR:
+#
+#   explicit -- MAIN_AGENT_CONFIG_DIR points at an EXISTING dir the operator has
+#     already logged into (the bot has its OWN Claude account, separate from the
+#     fleet's). That dir carries its own .credentials.json, so we must NOT inject
+#     the fleet token: doing so would authenticate the bot as the fleet. Works on
+#     every platform.
+#   isolated -- MAIN_AGENT_ISOLATED_CONFIG=1 on macOS with a fleet setup-token:
+#     the helper provisions a credential-less dir and we export the fleet token
+#     (same code path as the sub-agents), so the bot stops depending on the
+#     rotating Keychain OAuth session.
+#
+# Both settings resolve through the settings-store (dashboard toggle in
 # store/config-overrides.json OR a hand-set .env key -- resolution override>.env>
-# default '0') plus the fleet-token gate. So on macOS we ALWAYS call the helper;
-# it prints a path only when isolation is enabled AND a valid fleet token exists,
-# otherwise CFG_ENV stays EMPTY and the agent keeps the shared root. Strict no-op
-# for existing installs (non-macOS, setting off, no fleet token, or no dist build).
+# default), and explicit wins over isolated. When neither applies the helper
+# prints nothing, CFG_ENV stays EMPTY and the agent keeps the shared ~/.claude --
+# strict no-op for existing installs (no setting, no fleet token, no dist build).
 CFG_ENV=""
-if [ "$(uname)" = "Darwin" ]; then
-  mkdir -p "$INSTALL_DIR/store" 2>/dev/null || true
-  _node_bin="$(command -v node || true)"
-  if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
-    _iso_cfg="$("$_node_bin" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$CHANNEL_PROVIDER" 2>>"$INSTALL_DIR/store/channels-failures.log" || true)"
-    if [ -n "$_iso_cfg" ] && [ -d "$_iso_cfg" ]; then
+mkdir -p "$INSTALL_DIR/store" 2>/dev/null || true
+_node_bin="$(command -v node || true)"
+if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
+  _cfg_line="$("$_node_bin" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$CHANNEL_PROVIDER" 2>>"$INSTALL_DIR/store/channels-failures.log" || true)"
+  _cfg_mode="${_cfg_line%%	*}"
+  _cfg_dir="${_cfg_line#*	}"
+  if [ -n "$_cfg_line" ] && [ -d "$_cfg_dir" ]; then
+    if [ "$_cfg_mode" = "explicit" ]; then
+      CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && "
+    else
       # Seed the token from the SAME 0600 file the isolated dir is gated on, so
       # the config dir and the active token always match (the isolated dir carries
       # no .credentials.json). $(cat) is evaluated in the launched shell so the
       # secret never lands in the argv/`ps` command string.
-      CFG_ENV="export CLAUDE_CONFIG_DIR='$_iso_cfg' && export CLAUDE_CODE_OAUTH_TOKEN=\"\$(cat '$INSTALL_DIR/store/.claude-oauth-token')\" && "
-      echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: main-agent isolated CLAUDE_CONFIG_DIR=$_iso_cfg" >> "$INSTALL_DIR/store/channels-failures.log"
+      CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && export CLAUDE_CODE_OAUTH_TOKEN=\"\$(cat '$INSTALL_DIR/store/.claude-oauth-token')\" && "
     fi
-    unset _iso_cfg
+    echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: main-agent $_cfg_mode CLAUDE_CONFIG_DIR=$_cfg_dir" >> "$INSTALL_DIR/store/channels-failures.log"
   fi
-  unset _node_bin
+  unset _cfg_line _cfg_mode _cfg_dir
 fi
+unset _node_bin
 
 # Régi session takarítás
 $TMUX kill-session -t "$SESSION" 2>/dev/null

--- a/scripts/main-agent-isolated-config.mjs
+++ b/scripts/main-agent-isolated-config.mjs
@@ -20,10 +20,20 @@ import { fileURLToPath } from 'node:url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const projectRoot = join(__dirname, '..')
 
-const { ensureMainAgentIsolatedConfigDir } = await import(
+const { ensureMainAgentIsolatedConfigDir, resolveMainAgentConfigDir } = await import(
   join(projectRoot, 'dist', 'web', 'agent-process.js')
 )
 
-const provider = process.argv[2] || undefined
-const dir = ensureMainAgentIsolatedConfigDir(provider)
-if (dir) process.stdout.write(dir + '\n')
+// Output contract (consumed by scripts/channels.sh): "<mode>\t<path>", or nothing
+// at all when neither path applies. The mode decides how the caller authenticates
+// the agent: an `explicit` dir carries its OWN .credentials.json (login already
+// done there -- do NOT inject the fleet token, that would swap the identity),
+// while an `isolated` dir carries none and needs the fleet setup-token exported.
+const explicit = resolveMainAgentConfigDir()
+if (explicit) {
+  process.stdout.write(`explicit\t${explicit}\n`)
+} else {
+  const provider = process.argv[2] || undefined
+  const dir = ensureMainAgentIsolatedConfigDir(provider)
+  if (dir) process.stdout.write(`isolated\t${dir}\n`)
+}

--- a/src/__tests__/main-agent-config-dir.test.ts
+++ b/src/__tests__/main-agent-config-dir.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// MAIN_AGENT_CONFIG_DIR: an EXPLICIT CLAUDE_CONFIG_DIR for the main channels
+// agent, for the operator whose bot has its own Claude login (separate from the
+// fleet's). Distinct from MAIN_AGENT_ISOLATED_CONFIG, which authenticates from
+// the fleet setup-token and therefore cannot keep the two identities apart.
+let SANDBOX = ''
+let SETTING = ''
+
+vi.mock('node:os', async (orig) => {
+  const actual = await orig<typeof import('node:os')>()
+  return { ...actual, homedir: () => join(SANDBOX, 'home') }
+})
+vi.mock('../settings-store.js', async (orig) => {
+  const actual = await orig<typeof import('../settings-store.js')>()
+  return {
+    ...actual,
+    getEffectiveSettingValue: (key: string) =>
+      key === 'MAIN_AGENT_CONFIG_DIR' ? SETTING : actual.getEffectiveSettingValue(key),
+  }
+})
+
+const { resolveMainAgentConfigDir } = await import('../web/agent-process.js')
+
+beforeEach(() => {
+  SANDBOX = mkdtempSync(join(tmpdir(), 'maincfg-'))
+  mkdirSync(join(SANDBOX, 'home', '.claude-bot'), { recursive: true })
+  SETTING = ''
+})
+afterEach(() => {
+  rmSync(SANDBOX, { recursive: true, force: true })
+})
+
+describe('resolveMainAgentConfigDir', () => {
+  it('returns null when the setting is unset (shared ~/.claude, unchanged default)', () => {
+    expect(resolveMainAgentConfigDir()).toBeNull()
+  })
+
+  it('resolves an absolute path that exists', () => {
+    SETTING = join(SANDBOX, 'home', '.claude-bot')
+    expect(resolveMainAgentConfigDir()).toBe(join(SANDBOX, 'home', '.claude-bot'))
+  })
+
+  it('expands a leading ~ against the home dir', () => {
+    SETTING = '~/.claude-bot'
+    expect(resolveMainAgentConfigDir()).toBe(join(SANDBOX, 'home', '.claude-bot'))
+  })
+
+  it('returns null (not the unresolved path) when the dir does not exist', () => {
+    // Falling back to the shared root is the safe failure: launching with a
+    // non-existent CLAUDE_CONFIG_DIR would start the bot logged-out.
+    SETTING = join(SANDBOX, 'home', '.claude-nope')
+    expect(resolveMainAgentConfigDir()).toBeNull()
+  })
+
+  it('trims surrounding whitespace from a hand-edited .env value', () => {
+    SETTING = `  ${join(SANDBOX, 'home', '.claude-bot')}  `
+    expect(resolveMainAgentConfigDir()).toBe(join(SANDBOX, 'home', '.claude-bot'))
+  })
+})
+
+describe('launcher wiring', () => {
+  const HELPER = readFileSync(join(__dirname, '../../scripts/main-agent-isolated-config.mjs'), 'utf-8')
+  const CHANNELS = readFileSync(join(__dirname, '../../scripts/channels.sh'), 'utf-8')
+
+  it('the helper prefers the explicit dir over the isolated one', () => {
+    expect(HELPER).toMatch(/const explicit = resolveMainAgentConfigDir\(\)[\s\S]*if \(explicit\)/)
+  })
+
+  it('the helper tags each path with its mode so the caller knows how to authenticate', () => {
+    expect(HELPER).toMatch(/explicit\\t/)
+    expect(HELPER).toMatch(/isolated\\t/)
+  })
+
+  it('channels.sh never injects the fleet token for an explicit dir', () => {
+    // The explicit dir carries its OWN .credentials.json -- exporting the fleet
+    // token there would silently authenticate the bot as the fleet.
+    const explicitBranch = CHANNELS.match(/if \[ "\$_cfg_mode" = "explicit" \]; then\n([\s\S]*?)\n\s*else/)
+    expect(explicitBranch).not.toBeNull()
+    expect(explicitBranch?.[1]).not.toMatch(/CLAUDE_CODE_OAUTH_TOKEN/)
+    expect(explicitBranch?.[1]).toMatch(/CLAUDE_CONFIG_DIR/)
+  })
+})

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -364,6 +364,15 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: false,
     requiresRestart: true,
   },
+  {
+    key: 'MAIN_AGENT_CONFIG_DIR',
+    type: 'string',
+    default: '',
+    description: 'A fő channels-agent explicit CLAUDE_CONFIG_DIR-je (pl. ~/.claude-bot). Akkor kell, ha a botnak SAJÁT Claude-loginja van, külön a flottáétól: a MAIN_AGENT_ISOLATED_CONFIG erre nem alkalmas, mert az a fleet setup-tokenből hitelesít, tehát a flotta identitását adja a botnak (és token nélkül no-op). Üresen hagyva a fő agent a közös ~/.claude-ot használja (alapértelmezés). Ha a megadott könyvtár nem létezik, a beállítás no-op és figyelmeztetést logol. Elsőbbséget élvez a MAIN_AGENT_ISOLATED_CONFIG-gal szemben. A módosítás a channels session újraindításakor lép életbe.',
+    module: 'channels',
+    secret: false,
+    requiresRestart: true,
+  },
 ]
 
 export function getSettingDefinition(key: string): SettingDefinition | undefined {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -309,6 +309,32 @@ export function ensureMainAgentIsolatedConfigDir(
   )
 }
 
+// An EXPLICIT config dir for the main channels agent (MAIN_AGENT_CONFIG_DIR),
+// for the operator who already keeps a separate Claude login for the main bot --
+// e.g. a personal subscription for the bot and a different one for the fleet.
+// The isolated-config path above cannot serve that case: it provisions a dir with
+// NO .credentials.json and authenticates from the fleet setup-token, so the main
+// agent necessarily shares the fleet's identity, and it is a hard no-op without
+// that token. Pointing CLAUDE_CONFIG_DIR at an existing, separately logged-in dir
+// is the only way to keep the two identities apart.
+//
+// Fails closed: unset -> null (shared ~/.claude, unchanged default); set but
+// missing on disk -> null + a warn, because silently falling back to the shared
+// root with the WRONG identity is how a bot ends up authenticated as the fleet.
+// Takes precedence over MAIN_AGENT_ISOLATED_CONFIG: an explicit dir is a
+// deliberate choice, and the two cannot both own CLAUDE_CONFIG_DIR.
+export function resolveMainAgentConfigDir(): string | null {
+  let raw = ''
+  try { raw = String(getEffectiveSettingValue('MAIN_AGENT_CONFIG_DIR') ?? '').trim() } catch { return null }
+  if (!raw) return null
+  const dir = raw.startsWith('~') ? join(homedir(), raw.slice(1)) : raw
+  if (!existsSync(dir)) {
+    logger.warn({ dir }, 'main-agent config dir: MAIN_AGENT_CONFIG_DIR does not exist, keeping the shared ~/.claude')
+    return null
+  }
+  return dir
+}
+
 // Shared provisioning core for BOTH the sub-agents (ensureIsolatedChannelConfigDir)
 // and the main agent (ensureMainAgentIsolatedConfigDir) -- one code path so the
 // two can never diverge. `cfg` is the isolated CLAUDE_CONFIG_DIR to create; `cwd`


### PR DESCRIPTION
## Problem

`MAIN_AGENT_ISOLATED_CONFIG` (#568) solves the rotating-Keychain 401, but it does so by provisioning a **credential-less** dir and authenticating the main agent from the **fleet setup-token**. Two consequences:

1. The bot necessarily runs with the *fleet's* Claude identity.
2. On an install with no fleet token it is a hard no-op.

An operator who deliberately keeps a **separate Claude login for the bot** (one subscription for the bot, another for the fleet — so a plan change on one side cannot silently kill the other) has no supported option today. The practical workaround is hand-editing `scripts/channels.sh` to inject `CLAUDE_CONFIG_DIR`, which every update then fights over.

## Fix

`MAIN_AGENT_CONFIG_DIR`: point it at an existing, already-logged-in config dir; the launcher exports it as `CLAUDE_CONFIG_DIR`.

- The explicit dir carries its **own** `.credentials.json`, so the fleet token is deliberately **not** injected — that would re-authenticate the bot as the fleet, i.e. exactly what the setting exists to prevent. A test asserts the explicit branch never exports `CLAUDE_CODE_OAUTH_TOKEN`.
- **Explicit wins over isolated** — the two cannot both own `CLAUDE_CONFIG_DIR`.
- **Fails closed both ways**: unset → shared `~/.claude` (today's default, byte-for-byte no-op); set but missing on disk → shared root + a warn, because launching with a non-existent config dir would start the bot logged-out.
- Resolves through the settings-store, so the dashboard override and a hand-set `.env` key both work (override > .env > default).
- Not macOS-gated: a separate bot login is not a macOS-specific need. The isolated path stays darwin-only, unchanged.

The helper now prints `<mode>\t<path>` so `channels.sh` knows how to authenticate; when neither mode applies it prints nothing and `CFG_ENV` stays empty, as before.

## Verification

On a machine with no fleet token (where `MAIN_AGENT_ISOLATED_CONFIG` cannot engage at all):

```
$ node scripts/main-agent-isolated-config.mjs telegram      # setting unset
$ echo "MAIN_AGENT_CONFIG_DIR=~/.claude-bot" >> .env
$ node scripts/main-agent-isolated-config.mjs telegram
explicit	/Users/…/.claude-bot
```

Assembled launch line: `export CLAUDE_CONFIG_DIR='/Users/…/.claude-bot' && claude --dangerously-skip-permissions …` — no token export.

8 new tests, 32/32 green across the config suites, typecheck clean, `bash -n scripts/channels.sh` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfnBdCdNQfryGz6t1B7G17