### PR TITLE
fix(update): record already-up-to-date run as success, not failed

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -340,6 +340,11 @@ if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
     else
       echo -e "  ${GREEN}✓${NC} Már a legfrissebb verzión vagy ($NEW_VERSION)"
     fi
+    # This "no new commit, dist fresh" branch is a genuine SUCCESS. Without this
+    # the EXIT trap's write_result() would emit the default RESULT_STATUS="failed"
+    # for the most common healthy run, and the dashboard would falsely show a
+    # failed/rolled-back update. (The other branches set status explicitly.)
+    RESULT_STATUS="success"
     exit 0
   else
     # --reseed-fleet / --regen-claudemd are explicit refresh requests, so they


### PR DESCRIPTION
The most common healthy auto-update path (OLD==NEW commit, dist fresh) exit-0s
with RESULT_STATUS still at its default `failed`, so the EXIT trap wrote a
failed result for a genuinely successful run. This meant the dashboard would
show a false failed/rolled-back update and offer a diagnose action on every
healthy update cycle.

This sets RESULT_STATUS to success in that one branch before exit 0. The
other branches (genuinely-failed exits, rollback, detached finalizer success
path) are unchanged.

Tested against the real write_result() logic across all branches (bash -n clean).