### PR TITLE
fix(governance): self-pace-gate must not false-deny long git commit messages

### DIFF
--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -139,6 +139,29 @@ export function stripDataPayloads(seg) {
   )
 }
 
+// Blank out git commit/tag/stash -m/--message LITERAL text before self-pace
+// matching. A commit message is prose, NEVER a shell invocation, so a trigger
+// token that only appears INSIDE the message must not false-deny (2026-07-13,
+// DrCode: a long `git commit -m "...batch...; at..."` blocked twice, the short
+// one passed -- the message text was split as shell segments). Same principle
+// and same literal-only quote handling as stripDataPayloads: single-quoted,
+// ANSI-C $'...', and double-quoted WITHOUT $(...)/backtick are blanked; a
+// double-quoted message that CAN command-substitute (`git commit -m "$(crontab
+// -r)"`) is left intact so SCHEDULER_RX still catches the real substitution.
+// Scoped to git commit/tag/stash so a `-m` on an unrelated binary is untouched.
+export function stripGitCommitMessages(command) {
+  const cmd = String(command ?? '')
+  if (!/\bgit\b[\s\S]*\b(commit|tag|stash)\b/i.test(cmd)) return cmd
+  return cmd.replace(
+    /((?:^|\s)(?:-m|--message)(?:\s+|=))('[^']*'|\$'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")/gi,
+    (full, flag, arg) => {
+      const dq = arg.startsWith('"')
+      if (dq && (arg.includes('$(') || arg.includes('`'))) return full // may substitute -> keep
+      return flag + (dq ? '""' : "''") // literal message -> blank the content
+    },
+  )
+}
+
 // Pure decision: does this tool call set up self-pace / self-injection?
 export function gateDecision(toolName, toolInput) {
   const name = String(toolName ?? '')
@@ -156,7 +179,7 @@ export function gateDecision(toolName, toolInput) {
     // it), so the URL/method args still match but the body text never does. A
     // separator OUTSIDE the payload still splits, so `curl -d '' x ; crontab -r`
     // is still caught.
-    const safeCommand = stripDataPayloads(String(toolInput?.command ?? ''))
+    const safeCommand = stripDataPayloads(stripGitCommitMessages(String(toolInput?.command ?? '')))
     // Per-segment so an unrelated token elsewhere in a compound command cannot
     // turn a legit read (store inspection, schedule-API GET) into a false deny.
     for (const seg of splitSegments(safeCommand)) {

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 // @ts-expect-error -- plain .mjs hook script, no types
-import { gateDecision as selfPaceDecision, stripDataPayloads } from '../../scripts/self-pace-gate.mjs'
+import { gateDecision as selfPaceDecision, stripDataPayloads, stripGitCommitMessages } from '../../scripts/self-pace-gate.mjs'
 import {
   agentGetsGovernanceGates,
   injectSelfPaceGate,
@@ -231,5 +231,36 @@ describe('governance gate scaffold wiring', () => {
     // operator-confirmation-gate is intentionally NOT wired: merge/deploy is
     // operator-authorized autonomously; the self-decide vector is covered above.
     expect(pre.some((e) => JSON.stringify(e).includes('operator-confirmation-gate.mjs'))).toBe(false)
+  })
+})
+
+
+// --- stripGitCommitMessages: a `git commit -m` message is PROSE, never a shell
+// invocation, so a trigger token inside it must not false-deny (2026-07-13 DrCode
+// report: long commit blocked, short passed). Same literal-only quote handling as
+// stripDataPayloads; a $()/backtick double-quoted message is kept so a REAL
+// substitution stays gated. ---
+describe('self-pace-gate stripGitCommitMessages (commit-message false-positive guard)', () => {
+  it('blanks a single-quoted commit message', () => {
+    expect(stripGitCommitMessages(`git commit -m 'batch queue; at offset'`)).toBe(`git commit -m ''`)
+  })
+  it('blanks a double-quoted commit message with trigger words', () => {
+    expect(stripGitCommitMessages(`git commit -m "orchestration: tmux send-keys nem"`)).toBe(`git commit -m ""`)
+  })
+  it('keeps a $()-substituting double-quoted message intact (still gated downstream)', () => {
+    const cmd = `git commit -m "$(crontab -r)"`
+    expect(stripGitCommitMessages(cmd)).toBe(cmd)
+  })
+  it('leaves non-git -m flags untouched', () => {
+    const cmd = `mkdir -m 755 dir`
+    expect(stripGitCommitMessages(cmd)).toBe(cmd)
+  })
+  it('gateDecision: legit commit with trigger words in the message is ALLOWED', () => {
+    expect(selfPaceDecision('Bash', { command: `git commit -m "ETA; at offset; batch observe"` }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: `git commit -m "gui token-auth /api/schedules read-only"` }).deny).toBe(false)
+  })
+  it('gateDecision: a REAL self-pace after the commit (outside the message) is still DENIED', () => {
+    expect(selfPaceDecision('Bash', { command: `git commit -m "ok" ; crontab -r` }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: `git commit -m "$(crontab -r)"` }).deny).toBe(true)
   })
 })


### PR DESCRIPTION
## Problem

The self-pace-gate PreToolUse hook splits a Bash command into shell-ish segments before matching its self-pace / scheduler patterns. A `git commit -m "..."` **message is prose, not a shell invocation**, but its text was being split as if it were segments, so a trigger token that appears only *inside the commit message* (e.g. a message mentioning `tmux send-keys`, or containing `; at ...`) got denied. Observed in a fleet install: a long `git commit -m` was blocked twice while the short version passed, purely because of the message wording.

## Fix

New `stripGitCommitMessages(command)` blanks the **literal** `-m`/`--message` text of `git commit`/`tag`/`stash` *before* matching, reusing the exact literal-only quote handling already used by `stripDataPayloads`:

- single-quoted, ANSI-C `$'...'`, and double-quoted **without** `$()`/backtick are blanked (their prose can't be a command);
- a double-quoted message that **can** command-substitute (`git commit -m "$(crontab -r)"`) is left intact, so `SCHEDULER_RX` still gates the real substitution;
- scoped to `git commit|tag|stash` so a `-m` flag on an unrelated binary (`mkdir -m 755`) is untouched.

Wired into `gateDecision` as `stripDataPayloads(stripGitCommitMessages(command))`.

## Security property preserved

- A `$()`-substituting commit message stays gated.
- A real self-pace **outside** the message (`git commit -m "ok" ; crontab -r`) is still denied (the separator is outside the blanked payload).

## Tests

+6 regression tests in `governance-gates.test.ts` (single/double-quoted blanking, `$()` kept, non-git `-m` untouched, gateDecision allow legit / still-deny real substitution). Full suite green: **52/52**.
