### PR TITLE
fix(dashboard): restore Messages-view BOT_NAME + guard against re-revert (#519/#520 regression)

### DIFF
--- a/src/__tests__/messages-view-display-name.test.ts
+++ b/src/__tests__/messages-view-display-name.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// Regression guard for #519/#520: the inter-agent Messages view must render the
+// main agent's BOT_NAME display name, never its internal routing id (mainAgentId(),
+// e.g. "marveen"). The original fix (PR #520) was later silently reverted by a
+// refactor, so the raw slug leaked back into four display points -- the thread
+// sidebar item, the thread header, the compose placeholder and the message-bubble
+// sender label. This test pins both the behaviour of the display-name helpers and
+// their wiring at the four render sites, so any future refactor that strips them
+// fails CI instead of shipping the regression again.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const appJsPath = join(__dirname, '..', '..', 'web', 'app.js')
+const src = readFileSync(appJsPath, 'utf8')
+
+// Pull a top-level `function name(...) { ... }` body out of the source by brace
+// matching, so we can evaluate the real shipped helper (not a copy) in isolation.
+function extractFn(name: string): string | null {
+  const re = new RegExp(`function ${name}\\s*\\([^)]*\\)\\s*\\{`)
+  const m = re.exec(src)
+  if (!m) return null
+  let depth = 0
+  for (let j = src.indexOf('{', m.index); j < src.length; j++) {
+    if (src[j] === '{') depth++
+    else if (src[j] === '}' && --depth === 0) return src.slice(m.index, j + 1)
+  }
+  return null
+}
+
+// Instantiate the real mainAgentDisplayName()/chatDisplayName() from source
+// against a mock window + a stubbed mainAgentId(), so the assertions exercise the
+// actual fallback chain the browser runs.
+function loadHelpers(win: Record<string, unknown>, mainId: string) {
+  const displayFn = extractFn('mainAgentDisplayName')
+  const chatFn = extractFn('chatDisplayName')
+  if (!displayFn || !chatFn) {
+    throw new Error('mainAgentDisplayName/chatDisplayName missing from web/app.js -- #520 fix reverted')
+  }
+  const body = `
+    function mainAgentId() { return MAIN_ID }
+    ${displayFn}
+    ${chatFn}
+    return { mainAgentDisplayName, chatDisplayName }
+  `
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function('window', 'MAIN_ID', body)(win, mainId) as {
+    mainAgentDisplayName: () => string
+    chatDisplayName: (name: string) => string
+  }
+}
+
+describe('Messages view maps the main agent id to BOT_NAME (regression #519/#520)', () => {
+  it('shows the BOT_NAME from /api/marveen for the main agent, not the routing id', () => {
+    const { chatDisplayName } = loadHelpers({ _marveen: { name: 'Nova' } }, 'nova')
+    expect(chatDisplayName('nova')).toBe('Nova')
+  })
+
+  it('passes every other agent id through unchanged (they already carry a human name)', () => {
+    const { chatDisplayName } = loadHelpers({ _marveen: { name: 'Nova' } }, 'nova')
+    expect(chatDisplayName('ysahyarik')).toBe('ysahyarik')
+  })
+
+  it('falls back to _brandTokens.bot when _marveen has not resolved yet', () => {
+    const { chatDisplayName } = loadHelpers({ _brandTokens: { bot: 'Nova' } }, 'nova')
+    expect(chatDisplayName('nova')).toBe('Nova')
+  })
+
+  it('falls back to the routing id when no brand info is available (no crash, no empty label)', () => {
+    const { chatDisplayName } = loadHelpers({}, 'nova')
+    expect(chatDisplayName('nova')).toBe('nova')
+  })
+
+  it('leaves a stock (unrenamed) install reading "Marveen", never the "marveen" slug', () => {
+    const { chatDisplayName } = loadHelpers({ _marveen: { name: 'Marveen' } }, 'marveen')
+    expect(chatDisplayName('marveen')).toBe('Marveen')
+  })
+})
+
+describe('Messages view wiring: all four display points route through chatDisplayName', () => {
+  it('the thread-sidebar item label uses chatDisplayName(name)', () => {
+    expect(src).toMatch(/const displayName = owner && name === owner \? owner \+ ' \(te\)' : chatDisplayName\(name\)/)
+  })
+
+  it('the thread header label uses chatDisplayName(agentName)', () => {
+    expect(src).toMatch(/const threadDisplayName = owner && agentName === owner \? owner \+ ' \(te\)' : chatDisplayName\(agentName\)/)
+  })
+
+  it('the compose placeholder uses chatDisplayName(agentName)', () => {
+    expect(src).toMatch(/messages\.placeholder',\s*\{\s*agent:\s*escapeHtml\(chatDisplayName\(agentName\)\)/)
+  })
+
+  it('the message-bubble sender label renders senderLabel derived from chatDisplayName, not the raw id', () => {
+    expect(src).toMatch(/const senderLabel = chatDisplayName\(senderName\)/)
+    // The visible sender span must use the mapped label, never senderName/from_agent directly.
+    expect(src).toMatch(/<span class="bubble-sender">\$\{escapeHtml\(senderLabel\)\}<\/span>/)
+    expect(src).not.toMatch(/<span class="bubble-sender">\$\{escapeHtml\(senderName\)\}<\/span>/)
+  })
+})

--- a/web/app.js
+++ b/web/app.js
@@ -9583,6 +9583,24 @@ const CHAT_SYSTEM_AGENTS = new Set(['heartbeat','telegram-coordinator','channel-
 // recognizes its real owner. Empty until _marveen resolves (no false match).
 function chatOwnerName() { return window._marveen?.ownerName || '' }
 
+// The main agent's display name (BOT_NAME). mainAgentId() is the routing id
+// (e.g. "marveen") used for matching, avatar lookups and API calls; this is
+// what the user should SEE. Sourced from the backend (/api/marveen -> name,
+// mirrored into _brandTokens.bot by initSidebarBrand), so a renamed install
+// shows its real bot name. Falls back to the id before _marveen resolves.
+// Regression #519/#520: keep the four Messages-view display points routing the
+// main agent id through chatDisplayName -- a later refactor once stripped this
+// and leaked the raw routing id again. Guarded by messages-view-display-name.test.ts.
+function mainAgentDisplayName() {
+  return window._marveen?.name || window._brandTokens?.bot || mainAgentId()
+}
+// Map a routing agent id to its user-facing label: the main agent's id becomes
+// its BOT_NAME display name; every other agent already carries a human name as
+// its id, so it passes through unchanged.
+function chatDisplayName(name) {
+  return name === mainAgentId() ? mainAgentDisplayName() : name
+}
+
 function chatLastSeenKey(agentName) { return 'chat_last_seen_' + agentName }
 function chatGetLastSeen(agentName) { return parseInt(localStorage.getItem(chatLastSeenKey(agentName)) || '0', 10) }
 function chatMarkSeen(agentName, maxId) {
@@ -9655,7 +9673,7 @@ async function loadChatAgentList() {
       const isSelected = name === chatSelectedAgent ? ' selected' : ''
       const dimmed = info ? '' : ' style="opacity:0.5"'
       const unread = chatIsUnread(name, info)
-      const displayName = owner && name === owner ? owner + ' (te)' : name
+      const displayName = owner && name === owner ? owner + ' (te)' : chatDisplayName(name)
       return `<div class="chat-agent-item${isSelected}${unread ? ' unread' : ''}" data-agent="${escapeHtml(name)}"${dimmed}>
         <div class="chat-agent-avatar">${chatAvatarHtml(name, 40)}</div>
         <div class="chat-agent-info">
@@ -9699,7 +9717,7 @@ async function loadChatThread(agentName) {
   chatThreadState.loading = false
 
   const owner = chatOwnerName()
-  const threadDisplayName = owner && agentName === owner ? owner + ' (te)' : agentName
+  const threadDisplayName = owner && agentName === owner ? owner + ' (te)' : chatDisplayName(agentName)
 
   panel.innerHTML = `
     <div class="chat-thread-header">
@@ -9712,7 +9730,7 @@ async function loadChatThread(agentName) {
     <div class="chat-bubbles" id="chatBubbles"><div class="chat-loading-indicator" id="chatLoadingTop" style="display:none;text-align:center;padding:8px;font-size:11px;color:var(--text-muted)">${t('messages.loading')}</div></div>
     <div class="chat-compose">
       <div class="chat-compose-row">
-        <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="${t('messages.placeholder', { agent: escapeHtml(agentName) })}"></textarea>
+        <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="${t('messages.placeholder', { agent: escapeHtml(chatDisplayName(agentName)) })}"></textarea>
         <button class="btn-primary btn-compact chat-send-btn" id="chatSendBtn">${t('messages.send_btn')}</button>
       </div>
     </div>
@@ -9752,7 +9770,10 @@ async function loadChatThread(agentName) {
 
 function buildBubbleHtml(m) {
   const isOutgoing = m.from_agent === mainAgentId()
+  // senderName stays the routing id (avatar lookup keys off it); senderLabel is
+  // what the user sees, so the main agent reads as its BOT_NAME, not "marveen".
   const senderName = isOutgoing ? mainAgentId() : m.from_agent
+  const senderLabel = chatDisplayName(senderName)
   const when = m.created_at ? new Date(m.created_at * 1000).toLocaleString('hu-HU', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : ''
   const statusMetaRaw = MSG_STATUS_META[m.status] || { label: m.status || '', cls: 'badge' }
   const statusMeta = { ...statusMetaRaw, label: typeof statusMetaRaw.label === 'function' ? statusMetaRaw.label() : statusMetaRaw.label }
@@ -9760,7 +9781,7 @@ function buildBubbleHtml(m) {
     ${!isOutgoing ? `<div class="chat-bubble-avatar">${chatAvatarHtml(senderName, 28)}</div>` : ''}
     <div class="chat-bubble ${isOutgoing ? 'bubble-out' : 'bubble-in'}">
       <div class="bubble-meta">
-        ${!isOutgoing ? `<span class="bubble-sender">${escapeHtml(senderName)}</span>` : ''}
+        ${!isOutgoing ? `<span class="bubble-sender">${escapeHtml(senderLabel)}</span>` : ''}
         <span class="bubble-id-chip">#${m.id}</span>
         <span class="badge ${statusMeta.cls}" style="font-size:10px">${escapeHtml(statusMeta.label)}</span>
       </div>


### PR DESCRIPTION
Closes #595

## What / Mit

**EN:** Restores the Messages-view `BOT_NAME` display fix from PR #520, which a later refactor silently reverted, and adds a regression guard so it cannot be dropped again unnoticed.

**HU:** Visszaállítja a #520 Messages-view `BOT_NAME` megjelenítési javítását, amit egy későbbi refaktor csendben visszavont, és hozzáad egy regressziós guardot, hogy ne lehessen újra észrevétlenül kiejteni.

## Changes

- **`web/app.js`** — re-add `mainAgentDisplayName()` / `chatDisplayName()` and re-wire the four display points (thread sidebar item, thread header, compose placeholder, message-bubble sender). Routing ids stay untouched: avatar lookups, the `isOutgoing` match, `data-agent` attributes and `/api/messages` calls all keep using `mainAgentId()`, so only the visible label changes. A comment at the helper records the #519/#520 regression and points to the guard test.
- **`src/__tests__/messages-view-display-name.test.ts`** — a hybrid regression guard:
  1. **Behaviour:** extracts the real helpers from `web/app.js` by brace-matching and evaluates them against a mock `window` + stubbed `mainAgentId()`, proving `id -> BOT_NAME` mapping, pass-through for other agents, and the full fallback chain (`_marveen.name` -> `_brandTokens.bot` -> id).
  2. **Wiring (source-contract):** asserts all four display points route through `chatDisplayName`, and that the bubble sender never renders the raw id.

## Verification

- `npx vitest run src/__tests__/messages-view-display-name.test.ts` -> 9/9 green.
- Adversarially verified: reverting any one display point turns the guard red; restoring it goes green again.
- Related brand suite (`brand-completeness`, `configurable-brand`, `template-identity-hygiene`, `dashboard-modal-css-contract`) all green.
- `web/app.js` is served directly (no bundle/build step for the frontend), so the change is effective as-is.

Authored by an AI agent (Ysah) under its human operator's supervision (@YsahYarik).