### PR TITLE
fix(governance): self-pace-gate catches backtick command substitution

### DIFF
--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -63,10 +63,15 @@ const SELF_PACE_BASH_PATTERNS = [
 // "netstat" / "crontab-helper.sh"; (?!\s*=) so a bare NAME=value assignment
 // (`at=$(...)`) is not mistaken for the `at` binary.
 const SCHED_PREFIX = String.raw`(?:(?:[A-Za-z_]\w*=\S*|sudo|env|command|exec|nice|builtin|time)\s+)*(?:\S*/)?`
-const SCHEDULER_RX = new RegExp(String.raw`(^|[;&|(]\s*)${SCHED_PREFIX}(crontab|launchctl|systemd-run|batch|at)\b(?!-)(?!\s*=)`, 'i')
+// The command-boundary anchor includes `(` so a $(...) command substitution
+// (`X=$(crontab -)`) is caught, AND a backtick so a legacy `...` substitution
+// (`X=`crontab -r``) is caught too -- both run the enclosed command in a shell
+// context, so a scheduler binary immediately inside either is a real self-pace.
+const SCHED_BOUNDARY = '[;&|(`]'
+const SCHEDULER_RX = new RegExp(String.raw`(^|${SCHED_BOUNDARY}\s*)${SCHED_PREFIX}(crontab|launchctl|systemd-run|batch|at)\b(?!-)(?!\s*=)`, 'i')
 // ...but allow a pure READ-listing of one's own schedule (parity with the store /
 // schedule-API read exemptions): crontab -l, launchctl list/print, atq.
-const SCHEDULER_READ_RX = new RegExp(String.raw`(^|[;&|(]\s*)${SCHED_PREFIX}(crontab\s+-l\b|launchctl\s+(?:list|print|dumpstate|blame|examine)\b|atq\b)`, 'i')
+const SCHEDULER_READ_RX = new RegExp(String.raw`(^|${SCHED_BOUNDARY}\s*)${SCHED_PREFIX}(crontab\s+-l\b|launchctl\s+(?:list|print|dumpstate|blame|examine)\b|atq\b)`, 'i')
 
 // The Claude self-schedule store. Blocked for WRITE on any route (a Bash write,
 // or the native Write/Edit/NotebookEdit tool); a read/grep is legit diagnostics.
@@ -91,9 +96,9 @@ const HTTP_WRITE_RX = /(-X\s*(POST|PUT|PATCH|DELETE)|--request\s+(POST|PUT|PATCH
 //     `git commit -m "fix; crontab -r"`) splits and could false-deny. Rare
 //     enough (the quoted ; must be immediately followed by a blocked binary at a
 //     segment start) that a full shell-tokenizer is not warranted here.
-//   - Backtick / $(...) substitution that assigns a scheduler result
-//     (`X=$(crontab -)`) can slip; the exotic-route tail is the documented
-//     denylist limit, covered by the ScheduleWakeup/Cron* tool-deny layer.
+//   - A $(...) or backtick substitution that assigns a scheduler result
+//     (`X=$(crontab -)`, `X=`crontab -``) is caught by SCHEDULER_RX's boundary
+//     anchor, which now includes both `(` and the backtick.
 export function splitSegments(command) {
   return String(command ?? '')
     .replace(/\\\r?\n/g, ' ')
@@ -112,12 +117,10 @@ export function splitSegments(command) {
 // single-quoted '...', ANSI-C $'...', and double-quoted "..." WITHOUT
 // $(...)/backtick. A payload that can run a command substitution (double-quoted
 // with $(...) / backticks) is left intact so a real command-substitution payload
-// is not blanked. A `$(...)` payload is then still denied by SCHEDULER_RX (its `(`
-// sits at a command boundary the anchor recognises); a backtick one leans on the
-// ScheduleWakeup/Cron* runtime tool-deny layer, since SCHEDULER_RX's boundary
-// anchor omits the backtick -- a pre-existing denylist limit (see splitSegments
-// notes), not something this payload-strip introduces. The data FLAG itself is
-// kept, so HTTP-write detection (-d /
+// is not blanked. Such a payload is then still denied by SCHEDULER_RX, whose
+// boundary anchor recognises both `$(` and the backtick as a command boundary,
+// so a scheduler binary inside either substitution form is caught. The data FLAG
+// itself is kept, so HTTP-write detection (-d /
 // --data) is unchanged; the URL and method args live OUTSIDE the payload, so a
 // real WRITE to /api/schedules is still denied.
 //

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -264,3 +264,32 @@ describe('self-pace-gate stripGitCommitMessages (commit-message false-positive g
     expect(selfPaceDecision('Bash', { command: `git commit -m "$(crontab -r)"` }).deny).toBe(true)
   })
 })
+
+// --- backtick command substitution: the boundary anchor recognises `...` the
+// same as $(...), so a scheduler binary inside a legacy backtick substitution is
+// caught (was a documented pre-existing denylist gap: $() denied, backtick not).
+describe('self-pace-gate backtick command-substitution boundary', () => {
+  it('denies a bare backtick scheduler substitution', () => {
+    expect(selfPaceDecision('Bash', { command: 'git status `crontab -r`' }).deny).toBe(true)
+  })
+  it('denies an assignment via backtick substitution', () => {
+    expect(selfPaceDecision('Bash', { command: 'X=`crontab -r`' }).deny).toBe(true)
+  })
+  it('denies a backtick substitution after a commit message (message blanked, op remains)', () => {
+    expect(selfPaceDecision('Bash', { command: 'git commit -m "a" `crontab -r`' }).deny).toBe(true)
+  })
+  it('denies a backtick launchctl load', () => {
+    expect(selfPaceDecision('Bash', { command: 'echo `launchctl load x`' }).deny).toBe(true)
+  })
+  it('parity with $(): both substitution forms of the same op are denied', () => {
+    expect(selfPaceDecision('Bash', { command: 'git status $(crontab -r)' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'git status `crontab -r`' }).deny).toBe(true)
+  })
+  it('does not over-fire: a backtick substitution of a NON-scheduler binary is allowed', () => {
+    expect(selfPaceDecision('Bash', { command: 'echo `date`' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'FILES=`ls -1`' }).deny).toBe(false)
+  })
+  it('still allows a legit read-listing inside a substitution (crontab -l)', () => {
+    expect(selfPaceDecision('Bash', { command: 'echo `crontab -l`' }).deny).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

Follow-up to the #594 verify. The self-pace-gate scheduler boundary anchor recognised the open-paren (so a dollar-paren command substitution was caught) but **not the backtick**, so a legacy backtick substitution slipped past the Bash hook. This was a documented pre-existing denylist gap (the dollar-paren form denied, the backtick form allowed), confirmed on `develop` independently of #594.

## Fix

Both substitution forms run the enclosed command in a shell context, so a scheduler binary immediately inside either is a real self-pace. `SCHED_BOUNDARY` now includes the backtick alongside the existing separators, bringing the two forms to parity. Applied to both `SCHEDULER_RX` and `SCHEDULER_READ_RX` (so the read-listing exemption still works inside a substitution). Stale comments in `splitSegments` / `stripDataPayloads` that called the backtick an accepted limit are updated.

## Verification

- New adversarial tests (7): bare backtick scheduler substitution, assignment via backtick substitution, backtick after a commit message, backtick launchctl-load, dollar-paren vs backtick parity, and the over-fire guards — non-scheduler backtick substitutions and the read-listing form stay **allowed**.
- `governance-gates` 59/59, full suite **1840 pass**, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
