### PR TITLE
fix(message-router): retry transient inter-agent inject failures + never-silent handoff

### DIFF
--- a/src/__tests__/router-inject-retry.test.ts
+++ b/src/__tests__/router-inject-retry.test.ts
@@ -1,0 +1,41 @@
+// Contract tests for shouldGiveUpOnInject: an inter-agent tmux-inject failure
+// must RETRY across ticks, not silently instant-fail.
+//
+// Root cause (2026-07-13 incident): message-router's delivery catch block marked
+// a message 'failed' on the FIRST sendPromptToSession throw ("Failed to inject
+// into tmux session"), with no retry and no signal. A transient throw (the pane
+// momentarily un-ready mid-turn) permanently dropped the handoff -- FXShark's
+// collector finding to DrCode was lost, and nobody was told, so inter-agent
+// comms silently wedged.
+//
+// Fix: an inject throw is treated as transient -- the message stays pending and
+// retries next tick -- and is only marked failed (and surfaced to the
+// orchestrator) after MAX_INJECT_FAILURES consecutive throws.
+// shouldGiveUpOnInject(failCount, maxFailures) is the pure decision extracted
+// from the loop body; these tests pin it.
+
+import { describe, it, expect } from 'vitest'
+import { shouldGiveUpOnInject } from '../web/message-router.js'
+
+const MAX = 3 // same as MAX_INJECT_FAILURES
+
+describe('shouldGiveUpOnInject: retry transient inject throws before giving up', () => {
+  it('keeps retrying (false) below the failure cap', () => {
+    // The core invariant: the first throws must NOT drop the message -- this was
+    // the bug (instant-fail on attempt 1).
+    expect(shouldGiveUpOnInject(1, MAX)).toBe(false)
+    expect(shouldGiveUpOnInject(2, MAX)).toBe(false)
+  })
+
+  it('gives up (true) once the cap is reached', () => {
+    // Only after MAX consecutive throws is the message finally failed + surfaced.
+    expect(shouldGiveUpOnInject(3, MAX)).toBe(true)
+    expect(shouldGiveUpOnInject(4, MAX)).toBe(true)
+  })
+
+  it('reaching the cap is inclusive (>=, not strict >)', () => {
+    // failCount === maxFailures gives up, so exactly MAX attempts are made.
+    expect(shouldGiveUpOnInject(MAX, MAX)).toBe(true)
+    expect(shouldGiveUpOnInject(MAX - 1, MAX)).toBe(false)
+  })
+})

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -5,6 +5,8 @@ import {
   getPendingMessages,
   markMessageDelivered,
   markMessageFailed,
+  createAgentMessage,
+  type AgentMessage,
 } from '../db.js'
 import { readAgentRemoteHost, readAgentVoiceConfig } from './agent-config.js'
 import {
@@ -31,6 +33,53 @@ const JANITOR_PARKED_MIN_AGE_MS = 45 * 1000
 // Log "skipping, target not ready" at most once per message id so a busy
 // receiver over many 5s ticks does not spam the log.
 const routerLoggedMisses: Set<number> = new Set()
+// Per-message consecutive tmux-inject-failure counter. A send that THROWS
+// (send-keys hit the pane at a bad instant -- e.g. the receiver was mid-turn /
+// momentarily un-ready despite passing the readiness check) used to instant-
+// fail the message with NO retry and NO signal: the sender believed it handed
+// off, the target never got it, and inter-agent comms silently wedged (2026-07-13
+// incident: FXShark->DrCode collector finding lost). Now an inject throw is
+// treated as transient -- retry across ticks -- and only a message that fails
+// MAX_INJECT_FAILURES times in a row is finally marked failed AND surfaced to
+// the orchestrator, so a handoff failure is never silent.
+const routerInjectFailures: Map<number, number> = new Map()
+const MAX_INJECT_FAILURES = 3
+
+/**
+ * Pure decision: has a message exhausted its tmux-inject retries?
+ *
+ * A single inject throw is usually transient (the pane briefly un-ready); we
+ * retry it across router ticks like a busy target, instead of the old instant-
+ * fail-with-no-retry. Only give up after failCount reaches maxFailures.
+ */
+export function shouldGiveUpOnInject(failCount: number, maxFailures: number): boolean {
+  return failCount >= maxFailures
+}
+
+/**
+ * Never-silent handoff-failure signal. When a sub-agent message is finally
+ * abandoned (target gone for the full window) or exhausts its inject retries,
+ * enqueue a note to the MAIN agent (the orchestrator) so the failure surfaces
+ * for re-send / investigation instead of vanishing. Safe against recursion: the
+ * note is addressed to the main agent, which drains via the pull model and
+ * never hits this inject path.
+ */
+function notifyOrchestratorOfFailedHandoff(msg: AgentMessage, reason: string): void {
+  try {
+    // A failed message to the main agent can't happen (pull model), but guard
+    // anyway so we never loop a notification back onto itself.
+    if (msg.to_agent === MAIN_AGENT_ID) return
+    const preview = (msg.content ?? '').slice(0, 220)
+    createAgentMessage(
+      'system',
+      MAIN_AGENT_ID,
+      `[handoff-failure] Inter-agent message (id ${msg.id}) ${msg.from_agent} -> ${msg.to_agent} could NOT be delivered: ${reason}. Consider re-sending or checking the target agent. Content preview: ${preview}`,
+    )
+    logger.info({ id: msg.id, from: msg.from_agent, to: msg.to_agent, reason }, 'handoff-failure surfaced to orchestrator')
+  } catch (err) {
+    logger.warn({ err, id: msg.id }, 'Failed to enqueue handoff-failure notification')
+  }
+}
 // Wakeup cooldown for the main agent: the router fires at most one
 // sendPromptToSession wakeup per COOLDOWN_MS window to avoid spamming the
 // channels session. 45s gives enough headroom that a normal turn (typically
@@ -136,6 +185,8 @@ export async function runMessageRouterTick(): Promise<void> {
         if (!markMessageFailed(msg.id, 'Abandoned: target session absent for full retry window')) {
           logger.warn({ id: msg.id }, 'markMessageFailed affected 0 rows (deleted concurrently?)')
         }
+        notifyOrchestratorOfFailedHandoff(msg, 'target session was absent for the entire retry window')
+        routerInjectFailures.delete(msg.id)
         routerLoggedMisses.delete(msg.id)
         continue
       }
@@ -227,13 +278,26 @@ export async function runMessageRouterTick(): Promise<void> {
         if (!markMessageDelivered(msg.id)) {
           logger.warn({ id: msg.id }, 'markMessageDelivered affected 0 rows (deleted concurrently?)')
         }
+        routerInjectFailures.delete(msg.id)
         routerLoggedMisses.delete(msg.id)
         logger.info({ id: msg.id, from: msg.from_agent, to: msg.to_agent, category: isChannelInbound ? 'channel-inbound' : trusted ? 'trusted-peer' : 'untrusted' }, 'Agent message delivered')
       } catch (err) {
-        logger.warn({ err, id: msg.id }, 'Failed to deliver agent message')
-        if (!markMessageFailed(msg.id, 'Failed to inject into tmux session')) {
+        // An inject throw is usually transient (pane un-ready at the instant of
+        // send-keys). Retry across ticks instead of the old silent instant-fail;
+        // only give up after MAX_INJECT_FAILURES consecutive throws, and then
+        // surface the failure to the orchestrator so it is never silent.
+        const failCount = (routerInjectFailures.get(msg.id) ?? 0) + 1
+        routerInjectFailures.set(msg.id, failCount)
+        if (!shouldGiveUpOnInject(failCount, MAX_INJECT_FAILURES)) {
+          logger.warn({ err, id: msg.id, failCount }, 'Failed to inject agent message, will retry next tick')
+          continue
+        }
+        logger.error({ err, id: msg.id, failCount }, 'Failed to inject agent message after retries, giving up')
+        if (!markMessageFailed(msg.id, `Failed to inject into tmux session after ${failCount} attempts`)) {
           logger.warn({ id: msg.id }, 'markMessageFailed affected 0 rows (deleted concurrently?)')
         }
+        notifyOrchestratorOfFailedHandoff(msg, `tmux inject failed ${failCount}x`)
+        routerInjectFailures.delete(msg.id)
         routerLoggedMisses.delete(msg.id)
       }
     }


### PR DESCRIPTION
## Problem

When the router delivers an inter-agent message, a `sendPromptToSession` throw ("Failed to inject into tmux session") marked the message **failed on the first attempt** with no retry and no signal. The throw is usually transient -- the target pane was momentarily un-ready at the instant of `send-keys`, even though it passed the readiness check a line earlier. Result: the sender believes it handed off, the target never receives the message, and inter-agent comms silently wedge. In a live fleet an agent-to-agent finding was lost this way and nobody was informed until a human noticed the downstream effect.

This mirrors the class of bug already fixed for the session-absent path by `shouldAbandon` (a busy-but-alive session must never be dropped) -- the inject-throw path just hadn't gotten the same treatment.

## Fix

An inject throw is now treated as transient:

- The message stays **pending and retries across router ticks** (like a busy target), instead of instant-failing.
- It is only marked failed after `MAX_INJECT_FAILURES` (3) consecutive throws.
- On final give-up -- and on the existing session-absent abandon path -- a note is enqueued to the **main agent** (the orchestrator), which drains via the pull model and so never hits this inject path (no recursion). A failed handoff is therefore **never silent**: it surfaces for re-send / investigation.

`shouldGiveUpOnInject(failCount, maxFailures)` is extracted as a pure decision function (mirroring the existing `shouldAbandon`) and pinned by 3 contract tests in `router-inject-retry.test.ts`.

## Tests

`router-inject-retry.test.ts` (3 assertions: retry below the cap, give up at the cap, inclusive boundary). The existing router suite (`router-abandon`, `message-router-tick-cap`) stays green.
