### PR TITLE
fix(hooks): skip user-global hook registration from a temp-dir clone too (extends #565)

### DIFF
--- a/src/__tests__/hook-registration-guard.test.ts
+++ b/src/__tests__/hook-registration-guard.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   isWorktreeRoot,
+  isTemporaryRoot,
   shouldRegisterHooks,
   pruneStaleHookEntries,
   pruneStaleHooksFromSettingsFile,
@@ -49,6 +50,54 @@ describe('shouldRegisterHooks', () => {
     const d = shouldRegisterHooks({ projectRoot: '/opt/app', webOnly: true, isGitFile: notAGitFile })
     expect(d.register).toBe(false)
     expect(d.reason).toMatch(/WEB_ONLY/)
+  })
+  // 2026-07-13 canary incident: a plain `git clone` under /private/tmp is NOT a
+  // worktree (.git is a dir) and not WEB_ONLY, yet it registered hooks into the
+  // user-global settings.json -- the same deaf-agent trap, one class wider.
+  it('skips a plain clone under /private/tmp (canary/second-instance)', () => {
+    const d = shouldRegisterHooks({
+      projectRoot: '/private/tmp/marveen-work',
+      webOnly: false,
+      isGitFile: notAGitFile,
+    })
+    expect(d.register).toBe(false)
+    expect(d.reason).toMatch(/temp dir/)
+  })
+  it('skips a clone under /tmp', () => {
+    const d = shouldRegisterHooks({ projectRoot: '/tmp/marveen-work', webOnly: false, isGitFile: notAGitFile })
+    expect(d.register).toBe(false)
+  })
+  it('skips a clone under the injected OS tmpDir (e.g. macOS /var/folders/..)', () => {
+    const d = shouldRegisterHooks({
+      projectRoot: '/var/folders/xy/abc/T/marveen-clone',
+      webOnly: false,
+      isGitFile: notAGitFile,
+      tmpDir: '/var/folders/xy/abc/T',
+    })
+    expect(d.register).toBe(false)
+  })
+  it('still registers for a real install path that merely contains "tmp" mid-path', () => {
+    const d = shouldRegisterHooks({ projectRoot: '/home/user/mytmpapp', webOnly: false, isGitFile: notAGitFile })
+    expect(d.register).toBe(true)
+  })
+})
+
+describe('isTemporaryRoot', () => {
+  it('true for /tmp and /private/tmp prefixes', () => {
+    expect(isTemporaryRoot('/tmp/x')).toBe(true)
+    expect(isTemporaryRoot('/private/tmp/x')).toBe(true)
+    expect(isTemporaryRoot('/var/folders/a/b/T/x')).toBe(true)
+  })
+  it('false for a normal install root', () => {
+    expect(isTemporaryRoot('/Users/marvin/ClaudeClaw')).toBe(false)
+    expect(isTemporaryRoot('/opt/app')).toBe(false)
+  })
+  it('honours an injected OS tmpdir prefix (with or without trailing slash)', () => {
+    expect(isTemporaryRoot('/custom/tmp/clone', { tmpDir: '/custom/tmp' })).toBe(true)
+    expect(isTemporaryRoot('/custom/tmp/clone', { tmpDir: '/custom/tmp/' })).toBe(true)
+  })
+  it('does not match a path that merely contains a temp fragment mid-string', () => {
+    expect(isTemporaryRoot('/home/tmpish/app')).toBe(false)
   })
 })
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,7 @@
 import http from 'node:http'
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { execSync, execFileSync } from 'node:child_process'
 import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL, DASHBOARD_ALLOWED_ORIGINS, MAIN_AGENT_ID } from './config.js'
 import { loadOrCreateDashboardToken, checkBearerToken } from './web/dashboard-auth.js'
@@ -408,7 +409,7 @@ export function startWebServer(port = 3420): http.Server {
   // user-global ~/.claude/settings.json leaves stale absolute paths behind
   // once the worktree is deleted. A failing (exit 2) UserPromptSubmit hook
   // then BLOCKS every prompt and deafens the main agent (2026-07-11 incident).
-  const hookDecision = shouldRegisterHooks({ projectRoot: PROJECT_ROOT, webOnly })
+  const hookDecision = shouldRegisterHooks({ projectRoot: PROJECT_ROOT, webOnly, tmpDir: tmpdir() })
   if (!hookDecision.register) {
     logger.info({ reason: hookDecision.reason, projectRoot: PROJECT_ROOT }, 'Hook registration skipped')
   } else {

--- a/src/web/hook-registration-guard.ts
+++ b/src/web/hook-registration-guard.ts
@@ -71,21 +71,51 @@ export function isWorktreeRoot(
   return (deps.isGitFile ?? gitEntryIsFile)(projectRoot)
 }
 
+// Temp-dir prefixes that mark a checkout as transient. A plain `git clone` under
+// a temp dir (NOT a git worktree, so isWorktreeRoot misses it) is exactly the
+// canary / second-instance case: 2026-07-13 a develop canary started from
+// /private/tmp/marveen-work registered hooks into the USER-GLOBAL settings.json
+// with /tmp-rooted paths -- the same deaf-agent trap isWorktreeRoot was added to
+// prevent, one class wider. A real install never runs from a temp dir, so
+// skipping here can never suppress a legitimate owner's registration.
+const TEMP_ROOT_PREFIXES = ['/tmp/', '/private/tmp/', '/var/folders/', '/private/var/folders/']
+
+// Is the project root under a temporary directory (a transient second instance
+// -- canary, throwaway clone -- that does not own the user's settings)? The
+// tmpDir dependency is injectable so the OS tmpdir is included and the logic is
+// unit-testable without touching the environment.
+export function isTemporaryRoot(
+  projectRoot: string,
+  deps: { tmpDir?: string } = {},
+): boolean {
+  const normalized = normalizeSeparators(projectRoot)
+  const prefixes = [...TEMP_ROOT_PREFIXES]
+  if (deps.tmpDir) {
+    const t = normalizeSeparators(deps.tmpDir).replace(/\/+$/, '') + '/'
+    prefixes.push(t)
+  }
+  return prefixes.some((p) => normalized.startsWith(p))
+}
+
 export interface HookRegistrationDecision {
   register: boolean
   reason?: string
 }
 
 // Central decision: may this instance register hooks into settings.json?
-// Skips worktree checkouts (temporary PROJECT_ROOT) and WEB_ONLY staging
-// instances (not the install that owns the user's settings).
+// Skips worktree checkouts, temp-dir clones (both temporary PROJECT_ROOTs), and
+// WEB_ONLY staging instances (not the install that owns the user's settings).
 export function shouldRegisterHooks(opts: {
   projectRoot: string
   webOnly: boolean
   isGitFile?: (root: string) => boolean
+  tmpDir?: string
 }): HookRegistrationDecision {
   if (isWorktreeRoot(opts.projectRoot, { isGitFile: opts.isGitFile })) {
     return { register: false, reason: 'project root is a git worktree checkout (temporary path)' }
+  }
+  if (isTemporaryRoot(opts.projectRoot, { tmpDir: opts.tmpDir })) {
+    return { register: false, reason: 'project root is under a temp dir (transient second instance)' }
   }
   if (opts.webOnly) {
     return { register: false, reason: 'WEB_ONLY staging mode' }


### PR DESCRIPTION
## Problem

Follow-up to #565 (worktree hook-registration guard) and a real finding from the 2026-07-13 develop-promote validation. `shouldRegisterHooks` skipped hook registration into the user-global `~/.claude/settings.json` only for git **worktrees** (`.claude/worktrees/` path, or `.git`-is-a-file) and `WEB_ONLY`. A plain `git clone` under a temp dir is **neither** — its `.git` is a directory and its path has no worktrees fragment — so a transient second instance (a develop canary, a throwaway clone) still registered `UserPromptSubmit` / `SessionStart` hooks with temp-rooted absolute paths.

When that clone is later deleted, `python3` exits 2 and a non-zero `UserPromptSubmit` hook **blocks every prompt**, deafening the main agent — the exact 2026-07-11 failure mode #565 fixed, one class wider. Confirmed live: a develop canary started from `/private/tmp/marveen-work` polluted the user-global settings.json (had to be hand-cleaned).

## Fix

New `isTemporaryRoot()` adds a third skip to `shouldRegisterHooks`: a `PROJECT_ROOT` under `/tmp`, `/private/tmp`, `/var/folders`, or the injected `os.tmpdir()`. `web.ts` passes `tmpdir()` at the call site. A real install never runs from a temp dir, so this can never suppress a legitimate owner's registration — and it's a prefix match, so `/home/user/mytmpapp` (temp fragment mid-path) is unaffected.

## Verification
- `tsc --noEmit` clean.
- `hook-registration-guard` **23/23** (+8: `/private/tmp`, `/tmp`, injected OS tmpdir, the mid-path-"tmp" negative, and `isTemporaryRoot` unit cases).
- Full suite **1848 pass**.

Reduces the second-instance / canary risk called out in the develop-promote validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
