### PR TITLE
feat(scaffold): resolve dashboard API URL from DASHBOARD_PUBLIC_URL for distributed workers

### DIFF
--- a/src/__tests__/agent-scaffold-dashboard-origin.test.ts
+++ b/src/__tests__/agent-scaffold-dashboard-origin.test.ts
@@ -1,0 +1,179 @@
+// Tests for the DASHBOARD_PUBLIC_URL -> dashboardOrigin resolution in agent
+// scaffolding. Background: agents running on k3s PODs or any remote host must
+// reach the dashboard at its public URL, not at localhost. The scaffold embeds
+// curl examples into the generated CLAUDE.md; those must use the operator-
+// configured public URL when set, and fall back to localhost:port otherwise.
+//
+// Two surfaces are covered:
+//   1. resolveDashboardOrigin() -- the pure resolver exported from
+//      agent-scaffold.ts (unit-testable without any config or I/O).
+//   2. generateClaudeMd source -- source-level assertion that no literal
+//      localhost:3420 URL leaks into the LLM prompt (which would bake a wrong
+//      host into every agent CLAUDE.md on non-localhost deployments).
+//   3. renderHeartbeatClaudeMd -- the pure heartbeat renderer already accepts
+//      dashboardOrigin as part of its identity; these tests verify it emits the
+//      public URL when supplied.
+//   4. currentHeartbeatIdentity source -- the config-bound factory must delegate
+//      to resolveDashboardOrigin so it picks up DASHBOARD_PUBLIC_URL.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { resolveDashboardOrigin } from '../web/agent-scaffold.js'
+import { renderHeartbeatClaudeMd, type HeartbeatIdentity } from '../web/heartbeat-agent-scaffold.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SCAFFOLD_SRC = join(__dirname, '..', 'web', 'agent-scaffold.ts')
+const HEARTBEAT_SRC = join(__dirname, '..', 'web', 'heartbeat-agent-scaffold.ts')
+
+// ---------------------------------------------------------------------------
+// 1. resolveDashboardOrigin -- pure function, no config dependency
+// ---------------------------------------------------------------------------
+describe('resolveDashboardOrigin', () => {
+  it('returns localhost URL when publicUrl is empty', () => {
+    expect(resolveDashboardOrigin('', 3420)).toBe('http://localhost:3420')
+  })
+
+  it('uses the supplied public URL when set', () => {
+    expect(resolveDashboardOrigin('https://marveen.example.com', 3420)).toBe('https://marveen.example.com')
+  })
+
+  it('strips a trailing slash from the public URL', () => {
+    expect(resolveDashboardOrigin('https://marveen.example.com/', 3420)).toBe('https://marveen.example.com')
+  })
+
+  it('strips a trailing slash from a localhost fallback (non-standard port)', () => {
+    // Defensive: the fallback template never produces a trailing slash, but
+    // if port were somehow empty the .replace() still leaves the result sane.
+    expect(resolveDashboardOrigin('', '4000')).toBe('http://localhost:4000')
+  })
+
+  it('does not strip a path prefix from the public URL', () => {
+    // An operator might host the dashboard under a sub-path.
+    expect(resolveDashboardOrigin('https://example.com/marveen', 3420)).toBe('https://example.com/marveen')
+  })
+
+  it('strips trailing slash even from a sub-path URL', () => {
+    expect(resolveDashboardOrigin('https://example.com/marveen/', 3420)).toBe('https://example.com/marveen')
+  })
+
+  it('accepts a non-default port in the public URL', () => {
+    expect(resolveDashboardOrigin('https://example.com:8443', 3420)).toBe('https://example.com:8443')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. agent-scaffold.ts source -- no literal localhost:3420 in generateClaudeMd
+// ---------------------------------------------------------------------------
+describe('generateClaudeMd prompt: no hardcoded localhost:3420', () => {
+  const src = readFileSync(SCAFFOLD_SRC, 'utf-8')
+
+  // Isolate only the generateClaudeMd function body to avoid flagging
+  // other legitimate uses of localhost elsewhere in the same file.
+  const fnStart = src.indexOf('export async function generateClaudeMd')
+  expect(fnStart, 'generateClaudeMd not found in source').toBeGreaterThan(0)
+  const fnEnd = src.indexOf('export async function generateSoulMd')
+  expect(fnEnd, 'generateSoulMd terminator not found').toBeGreaterThan(fnStart)
+  const fnBody = src.slice(fnStart, fnEnd)
+
+  it('imports DASHBOARD_PUBLIC_URL from config', () => {
+    expect(src).toMatch(/import\s*{[^}]*\bDASHBOARD_PUBLIC_URL\b[^}]*}\s*from\s*'\.\.\/config\.js'/)
+  })
+
+  it('does not contain the literal localhost:3420 URL in the prompt body', () => {
+    // Any surviving literal would bake the wrong host into every scaffolded
+    // agent on a non-localhost deployment.
+    expect(fnBody).not.toContain('http://localhost:3420')
+  })
+
+  it('references dashboardOrigin in the memory API curl example', () => {
+    expect(fnBody).toContain('${dashboardOrigin}/api/memories')
+  })
+
+  it('references dashboardOrigin in the daily-log API curl example', () => {
+    expect(fnBody).toContain('${dashboardOrigin}/api/daily-log')
+  })
+
+  it('references dashboardOrigin in the schedules API curl example', () => {
+    expect(fnBody).toContain('${dashboardOrigin}/api/schedules')
+  })
+
+  it('references dashboardOrigin in the inter-agent messages API curl example', () => {
+    expect(fnBody).toContain('${dashboardOrigin}/api/messages')
+  })
+
+  it('defines dashboardOrigin using resolveDashboardOrigin', () => {
+    // Ensures the fallback logic lives in one place (resolveDashboardOrigin),
+    // not as an ad-hoc inline expression that could diverge from the heartbeat
+    // scaffold.
+    expect(src).toContain('resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT)')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. renderHeartbeatClaudeMd with a public-URL dashboardOrigin
+// ---------------------------------------------------------------------------
+describe('renderHeartbeatClaudeMd: respects dashboardOrigin', () => {
+  const BASE: HeartbeatIdentity = {
+    ownerName: 'Nina',
+    botName: 'Helios',
+    mainAgentId: 'helios',
+    storeDir: '/srv/app/store',
+    dashboardOrigin: 'http://localhost:3420',
+    calendarAccount: '',
+  }
+
+  it('uses a public URL when dashboardOrigin is set to one', () => {
+    const id: HeartbeatIdentity = { ...BASE, dashboardOrigin: 'https://marveen.example.com' }
+    const out = renderHeartbeatClaudeMd(id)
+    expect(out).toContain('https://marveen.example.com/api/messages')
+    expect(out).not.toContain('http://localhost:3420/api/messages')
+  })
+
+  it('falls back to localhost when dashboardOrigin is the localhost default', () => {
+    const out = renderHeartbeatClaudeMd(BASE)
+    expect(out).toContain('http://localhost:3420/api/messages')
+  })
+
+  it('emits no hardcoded hostname other than the dashboardOrigin host', () => {
+    const id: HeartbeatIdentity = { ...BASE, dashboardOrigin: 'https://marveen.example.com' }
+    const out = renderHeartbeatClaudeMd(id)
+    // The only host that should appear in the output is the one we supplied;
+    // no stale 'localhost' sneaks in alongside it.
+    expect(out).not.toMatch(/http:\/\/localhost:\d+\/api\//)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. heartbeat-agent-scaffold.ts source -- currentHeartbeatIdentity delegates
+// ---------------------------------------------------------------------------
+describe('currentHeartbeatIdentity: delegates to resolveDashboardOrigin', () => {
+  const src = readFileSync(HEARTBEAT_SRC, 'utf-8')
+
+  it('imports DASHBOARD_PUBLIC_URL from config', () => {
+    expect(src).toMatch(/DASHBOARD_PUBLIC_URL/)
+  })
+
+  it('imports resolveDashboardOrigin from agent-scaffold', () => {
+    expect(src).toMatch(/resolveDashboardOrigin.*agent-scaffold/)
+  })
+
+  it('uses resolveDashboardOrigin for dashboardOrigin in currentHeartbeatIdentity', () => {
+    // Grep the factory function body for the call.
+    const fnStart = src.indexOf('export function currentHeartbeatIdentity')
+    expect(fnStart).toBeGreaterThan(0)
+    const fnEnd = src.indexOf('\n}', fnStart)
+    const fnBody = src.slice(fnStart, fnEnd)
+    expect(fnBody).toContain('resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT)')
+  })
+
+  it('does not hardcode localhost:PORT as a string literal in currentHeartbeatIdentity', () => {
+    const fnStart = src.indexOf('export function currentHeartbeatIdentity')
+    const fnEnd = src.indexOf('\n}', fnStart)
+    const fnBody = src.slice(fnStart, fnEnd)
+    // The literal template would be: `http://localhost:${WEB_PORT}` -- that
+    // belongs inside resolveDashboardOrigin now, not here.
+    expect(fnBody).not.toContain('`http://localhost:')
+  })
+})

--- a/src/__tests__/fleet-roster-section.test.ts
+++ b/src/__tests__/fleet-roster-section.test.ts
@@ -14,6 +14,7 @@ vi.mock('../config.js', () => ({
   CHANNEL_PROVIDER: 'telegram',
   WEB_PORT: 3420,
   OWNER_DRIVE_FOLDER: '',
+  DASHBOARD_PUBLIC_URL: '',
 }))
 
 vi.mock('../web/agent-config.js', () => ({

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,13 +1,25 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ } from '../config.js'
+import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ, DASHBOARD_PUBLIC_URL } from '../config.js'
 import { channelStateDir } from '../channel-provider.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { agentDir, agentConfigRoot, listAgentNames, readAgentCapabilities } from './agent-config.js'
 import { resolveProfilePlaceholders, type ProfileTemplate } from './profiles.js'
 import { sanitizeCapabilityTag, CAPABILITY_TAG_MAX_PER_AGENT } from '../prompt-safety.js'
+
+// Resolve the base URL agents should use to reach the dashboard API.
+// DASHBOARD_PUBLIC_URL wins when set (distributed / k3s deployment); falls
+// back to localhost for single-host installs. Exported so heartbeat-agent-
+// scaffold and tests can import the same logic without duplicating it.
+export function resolveDashboardOrigin(publicUrl: string, port: number | string): string {
+  return (publicUrl || `http://localhost:${port}`).replace(/\/$/, '')
+}
+
+// Resolved once at module load; DASHBOARD_PUBLIC_URL requires a restart
+// (see config-registry.ts `requiresRestart` flag), so a const is safe.
+const dashboardOrigin = resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT)
 
 // Identity values the template substitution injects. Pulled out so the
 // substitution is a pure, parameterizable function (the runtime binds these to
@@ -532,20 +544,20 @@ A memoria 3 retegbol all (hot/warm/cold) + napi naplo.
 Minden /api/* végpont Bearer tokenes: a token a store/.dashboard-token fájlban.
 
 Memória mentés:
-curl -s -X POST http://localhost:3420/api/memories -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"agent_id":"AGENT_NAME","content":"MIT","category":"CATEGORY","keywords":"kulcsszo1, kulcsszo2"}'
+curl -s -X POST ${dashboardOrigin}/api/memories -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"agent_id":"AGENT_NAME","content":"MIT","category":"CATEGORY","keywords":"kulcsszo1, kulcsszo2"}'
 
 Napi napló (append-only):
-curl -s -X POST http://localhost:3420/api/daily-log -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"agent_id":"AGENT_NAME","content":"## HH:MM -- Tema\nMi tortent, mi lett az eredmeny"}'
+curl -s -X POST ${dashboardOrigin}/api/daily-log -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"agent_id":"AGENT_NAME","content":"## HH:MM -- Tema\nMi tortent, mi lett az eredmeny"}'
 
 Keresés (mielőtt válaszolsz, nézd meg van-e releváns emlék):
-curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" "http://localhost:3420/api/memories?agent=AGENT_NAME&q=KULCSSZO&category=warm"
+curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" "${dashboardOrigin}/api/memories?agent=AGENT_NAME&q=KULCSSZO&category=warm"
 
 ## Ütemezett feladatok
 
 Az ütemezett feladatok a ~/.claude/scheduled-tasks/ mappában élnek, fájl-alapúak (SKILL.md + task-config.json). A schedule runner 60 másodpercenként ellenőrzi és a te tmux session-ödbe küldi a promptot.
 
 Feladat létrehozása API-n keresztül:
-curl -s -X POST http://localhost:3420/api/schedules -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"name": "feladat-nev", "description": "Rövid leírás", "prompt": "A részletes prompt", "schedule": "0 8 * * *", "agent": "AGENT_NAME", "type": "heartbeat"}'
+curl -s -X POST ${dashboardOrigin}/api/schedules -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"name": "feladat-nev", "description": "Rövid leírás", "prompt": "A részletes prompt", "schedule": "0 8 * * *", "agent": "AGENT_NAME", "type": "heartbeat"}'
 
 Típusok: task (mindig szól az eredménnyel) vagy heartbeat (csak fontosnál szól).
 Cron formátum: perc óra nap hónap hétnapja (pl. 0 8 * * * = minden nap 8:00).
@@ -602,7 +614,7 @@ Ha egy senderId üzen a csatornán AKIT EDDIG NEM ISMERSZ — nem szerepel az ak
 Az AGENT TULAJDONOSA (az első, aki ezt az ügynököt telepítette és párosította) az ALAPÉRTELMEZETT engedélyezett sender — őt nem kell ellenőrizni. MINDEN további senderId első üzenete (a 2., 3., stb. párosított személy vagy csoport) pinging-trigger.
 
 Példa ping ${BOT_NAME}-nek:
-curl -s -X POST http://localhost:3420/api/messages -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d "{\\"from\\":\\"AGENT_NAME\\",\\"to\\":\\"${MAIN_AGENT_ID}\\",\\"content\\":\\"Ismeretlen sender [ID] jelezett első üzenettel: '[üzenet röviden]'. Ki ez, mit válaszoljak?\\"}"
+curl -s -X POST ${dashboardOrigin}/api/messages -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d "{\\"from\\":\\"AGENT_NAME\\",\\"to\\":\\"${MAIN_AGENT_ID}\\",\\"content\\":\\"Ismeretlen sender [ID] jelezett első üzenettel: '[üzenet röviden]'. Ki ez, mit válaszoljak?\\"}"
 
 Addig a sender-nek csak generikus "Egy pillanat, ellenőrzöm" típusú választ adj. NE adj ki belső projekt-infót, NE mutatkozz be hosszan, NE listázd ki mit tudsz, NE említs SAJÁT BELSŐ PROJEKTEKET sem közvetlenül, sem közvetve. ${BOT_NAME} visszajelzi a kontextust és a szabályokat amelyekkel folytathatod.
 

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -44,7 +44,9 @@ import {
   WEB_PORT,
   HEARTBEAT_CALENDAR_ACCOUNT,
   APP_TZ,
+  DASHBOARD_PUBLIC_URL,
 } from '../config.js'
+import { resolveDashboardOrigin } from './agent-scaffold.js'
 import { logger } from '../logger.js'
 
 const HEARTBEAT_AGENT_NAME = 'heartbeat'
@@ -107,7 +109,7 @@ export function currentHeartbeatIdentity(): HeartbeatIdentity {
     botName: BOT_NAME,
     mainAgentId: MAIN_AGENT_ID,
     storeDir: STORE_DIR,
-    dashboardOrigin: `http://localhost:${WEB_PORT}`,
+    dashboardOrigin: resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT),
     calendarAccount: HEARTBEAT_CALENDAR_ACCOUNT,
   }
 }


### PR DESCRIPTION
<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A fejlesztés a **Network API + distributed workers** irány első lépése: lehetővé teszi, hogy az ágensek k3s POD-okon vagy bármilyen remote hoston is elérjék a közös dashboard API-t, memóriát és kanbant.

Korábban az agent-scaffold `generateClaudeMd` promptjában és a `currentHeartbeatIdentity`-ben minden API curl URL `http://localhost:3420`-ra volt égetve. Ha egy ágens nem a dashboard hostján fut, ezek a hívások csendesen elveszenek.

Megoldás: exportált `resolveDashboardOrigin(publicUrl, port)` pure function, amely ha `DASHBOARD_PUBLIC_URL` be van állítva, azt adja vissza (trailing slash normalizálva), különben fallback `http://localhost:<WEB_PORT>`. Az összes érintett curl példa (memory, daily-log, search, schedules, inter-agent messages) ezt használja a generált CLAUDE.md-ben.

**EN:** First step toward the **Network API + distributed workers** direction: agents running on k3s PODs or any remote host can now reach the shared dashboard API, memory and kanban at the correct public URL.

Previously every curl example in the generated CLAUDE.md and `currentHeartbeatIdentity` hardcoded `http://localhost:3420`. On a remote host those calls would silently fail.

Fix: exported `resolveDashboardOrigin(publicUrl, port)` -- returns `DASHBOARD_PUBLIC_URL` (trailing-slash normalised) when set, falls back to `http://localhost:<WEB_PORT>`. All five curl endpoints in `generateClaudeMd` (memory POST, daily-log, memory search, schedules, inter-agent messages) and `currentHeartbeatIdentity` now use it.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).