### PR TITLE
feat(worker): dual worker sessions + 15s schedule tick

### DIFF
--- a/src/__tests__/dual-worker.test.ts
+++ b/src/__tests__/dual-worker.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { classifyPriority, makeWorkerCtx } from '../web/agent-worker.js'
+import { SCHEDULE_TICK_MS } from '../web/schedule-runner.js'
+
+// ---------------------------------------------------------------------------
+// 1. Message priority routing heuristic
+// ---------------------------------------------------------------------------
+describe('classifyPriority', () => {
+  it('short conversational message -> fast', () => {
+    expect(classifyPriority('Mi az idő?')).toBe('fast')
+  })
+
+  it('message >= 300 chars -> slow regardless of content', () => {
+    const long = 'x'.repeat(300)
+    expect(classifyPriority(long)).toBe('slow')
+  })
+
+  it('message just under 300 chars without keywords -> fast', () => {
+    const short = 'x'.repeat(299)
+    expect(classifyPriority(short)).toBe('fast')
+  })
+
+  it('"analyze" keyword -> slow', () => {
+    expect(classifyPriority('Kérlek analyze ezt a fájlt')).toBe('slow')
+  })
+
+  it('"elemezd" keyword -> slow', () => {
+    expect(classifyPriority('elemezd a logokat')).toBe('slow')
+  })
+
+  it('"keresd" keyword -> slow', () => {
+    expect(classifyPriority('keresd meg a hibát')).toBe('slow')
+  })
+
+  it('"összefoglaló" keyword -> slow', () => {
+    expect(classifyPriority('Adj összefoglaló-t')).toBe('slow')
+  })
+
+  it('"search" keyword -> slow', () => {
+    expect(classifyPriority('search for the bug')).toBe('slow')
+  })
+
+  it('"summary" keyword -> slow', () => {
+    expect(classifyPriority('give me a summary')).toBe('slow')
+  })
+
+  it('"report" keyword -> slow', () => {
+    expect(classifyPriority('generate a report')).toBe('slow')
+  })
+
+  it('keyword match is case-insensitive', () => {
+    expect(classifyPriority('Please ANALYZE this')).toBe('slow')
+    expect(classifyPriority('Write a SUMMARY')).toBe('slow')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. makeWorkerCtx -- correct path derivation
+// ---------------------------------------------------------------------------
+describe('makeWorkerCtx', () => {
+  it('derives configDir and scratchDir from homeDir', () => {
+    const ctx = makeWorkerCtx('test-session', '/tmp/test-home')
+    expect(ctx.session).toBe('test-session')
+    expect(ctx.home).toBe('/tmp/test-home')
+    expect(ctx.configDir).toBe('/tmp/test-home/.claude-config')
+    expect(ctx.scratchDir).toBe('/tmp/test-home/scratch')
+  })
+
+  it('initialises chain as a resolved promise', async () => {
+    const ctx = makeWorkerCtx('s', '/tmp/h')
+    // A resolved chain should allow the next .then to run immediately.
+    let ran = false
+    await ctx.chain.then(() => { ran = true })
+    expect(ran).toBe(true)
+  })
+
+  it('initialises lastStuckAlert to 0', () => {
+    const ctx = makeWorkerCtx('s', '/tmp/h')
+    expect(ctx.lastStuckAlert).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. Per-session chain isolation
+// ---------------------------------------------------------------------------
+describe('WorkerCtx chain isolation', () => {
+  it('slow and fast sessions have independent chains', async () => {
+    const slow = makeWorkerCtx('slow', '/tmp/slow')
+    const fast = makeWorkerCtx('fast', '/tmp/fast')
+
+    const order: string[] = []
+
+    // Block the slow chain for a tick.
+    let resolveSlow!: () => void
+    slow.chain = slow.chain.then(() => new Promise<void>(r => { resolveSlow = r }))
+
+    // Queue work on both sessions.
+    const slowWork = slow.chain.then(() => { order.push('slow') })
+    const fastWork = fast.chain.then(() => { order.push('fast') })
+
+    // Fast chain should resolve without waiting for slow.
+    await fastWork
+    expect(order).toContain('fast')
+    expect(order).not.toContain('slow')
+
+    // Unblock slow.
+    resolveSlow()
+    await slowWork
+    expect(order).toContain('slow')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. Schedule tick interval
+// ---------------------------------------------------------------------------
+describe('SCHEDULE_TICK_MS', () => {
+  it('is 15 seconds (15000 ms)', () => {
+    expect(SCHEDULE_TICK_MS).toBe(15_000)
+  })
+})

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -40,17 +40,6 @@ import { notifyChannel } from '../notify.js'
 
 const TMUX = resolveFromPath('tmux')
 
-// Session name keys off MAIN_AGENT_ID so notify.sh's "${MAIN_AGENT_ID}-worker"
-// branch matches on renamed installs (BOT_NAME != Marveen). Default installs are
-// unchanged: MAIN_AGENT_ID falls back to 'marveen' -> 'marveen-worker' as before.
-const WORKER_SESSION = process.env.MARVEEN_WORKER_SESSION || `${MAIN_AGENT_ID}-worker`
-// MUST be OUTSIDE PROJECT_ROOT so Claude Code's upward CLAUDE.md discovery never
-// finds Marveen's persona CLAUDE.md -- one-shot generations (scaffold CLAUDE.md/
-// SOUL.md for a NEW agent, memory digests) must be UNTINTED. The caller prompt
-// is the only instruction. (Refinement #1.)
-const WORKER_HOME = process.env.MARVEEN_WORKER_DIR || join(homedir(), '.marveen-worker')
-const WORKER_CONFIG_DIR = join(WORKER_HOME, '.claude-config')
-const SCRATCH_DIR = join(WORKER_HOME, 'scratch')
 const WORKER_MODEL = process.env.MARVEEN_WORKER_MODEL || 'claude-opus-4-8[1m]'
 
 // How long to wait for a freshly launched worker to reach an idle prompt.
@@ -63,6 +52,65 @@ const WORKER_DISABLED_PLUGINS = ['telegram', 'slack-channel']
 //  - settings.json: we own it (enabledPlugins:{} override).
 //  - CLAUDE.md: skipped so global user memory never tints one-shot gens (refinement #1).
 const WORKER_CONFIG_SKIP = new Set(['settings.json', 'CLAUDE.md', '.DS_Store', '.lock'])
+
+// --- Per-session context ------------------------------------------------------
+//
+// Each interactive Claude Code session (slow + fast) has its own home dir and
+// isolated CLAUDE_CONFIG_DIR so they never share a Telegram long-poll connection
+// (the root cause of the 409 Conflicts; see the comment at the top of this file).
+// All per-session mutable state (promise-chain mutex, stuck-alert timer) lives
+// in WorkerCtx so tests can instantiate independent contexts.
+
+export interface WorkerCtx {
+  readonly session: string
+  readonly home: string
+  readonly configDir: string
+  readonly scratchDir: string
+  chain: Promise<unknown>
+  lastStuckAlert: number
+}
+
+export function makeWorkerCtx(session: string, homeDir: string): WorkerCtx {
+  return {
+    session,
+    home: homeDir,
+    configDir: join(homeDir, '.claude-config'),
+    scratchDir: join(homeDir, 'scratch'),
+    chain: Promise.resolve() as Promise<unknown>,
+    lastStuckAlert: 0,
+  }
+}
+
+// Slow session: long-running tasks (analysis, reports, search). The original
+// worker -- all existing callers default to this. Session name keys off
+// MAIN_AGENT_ID (per #611) so notify.sh's "${MAIN_AGENT_ID}-worker" branch
+// matches on renamed installs; default installs stay "marveen-worker". The
+// WORKER_DIR stays fixed (.marveen-worker) -- the config-dir hash depends on it.
+const ctxSlow = makeWorkerCtx(
+  process.env.MARVEEN_WORKER_SESSION || `${MAIN_AGENT_ID}-worker`,
+  process.env.MARVEEN_WORKER_DIR || join(homedir(), '.marveen-worker'),
+)
+// Fast session: short, conversational tasks (< 300 chars, no analysis keywords).
+// Separate home + config dir eliminates any shared state with the slow session.
+const ctxFast = makeWorkerCtx(
+  process.env.MARVEEN_WORKER_SESSION_FAST || `${MAIN_AGENT_ID}-worker-fast`,
+  process.env.MARVEEN_WORKER_DIR_FAST || join(homedir(), '.marveen-worker-fast'),
+)
+
+// --- Message priority routing -------------------------------------------------
+//
+// Short, conversational messages go to the fast session; anything that suggests
+// a long-running analysis or search goes to the slow session. Exported so the
+// routing logic is unit-testable without live sessions.
+
+const SLOW_MESSAGE_KEYWORDS = /elemezd|keresd|összefoglaló|analyze|search|summary|report/i
+const FAST_MESSAGE_MAX_LEN = 300
+
+export function classifyPriority(message: string): 'fast' | 'slow' {
+  if (message.length >= FAST_MESSAGE_MAX_LEN) return 'slow'
+  if (SLOW_MESSAGE_KEYWORDS.test(message)) return 'slow'
+  return 'fast'
+}
 
 // =============================================================================
 // macOS auth precedence (discovered 2026-06-10 debugging the worker 401):
@@ -99,16 +147,16 @@ export function configDirKeychainService(configDir: string): string {
   return `Claude Code-credentials-${suffix}`
 }
 
-function workerKeychainService(): string {
-  return configDirKeychainService(WORKER_CONFIG_DIR)
+function workerKeychainService(ctx: WorkerCtx): string {
+  return configDirKeychainService(ctx.configDir)
 }
 
 /** Delete the worker's path-hashed Keychain entry so .credentials.json is the
  * authoritative source. No-op if absent. Never touches the host default entry. */
-function clearWorkerKeychainEntry(): void {
+function clearWorkerKeychainEntry(ctx: WorkerCtx): void {
   try {
     execFileSync('/usr/bin/security',
-      ['delete-generic-password', '-s', workerKeychainService(), '-a', userInfo().username],
+      ['delete-generic-password', '-s', workerKeychainService(ctx), '-a', userInfo().username],
       { timeout: 3000, stdio: ['ignore', 'ignore', 'ignore'] })
   } catch { /* absent -> nothing to clear */ }
 }
@@ -122,18 +170,18 @@ function clearWorkerKeychainEntry(): void {
  * macOS readClaudeCodeOauthJson returns null and the worker runs logged-out.
  * Returns true if a credential file was written.
  */
-function seedWorkerCredentials(): boolean {
-  if (process.platform === 'darwin') clearWorkerKeychainEntry()
+function seedWorkerCredentials(ctx: WorkerCtx): boolean {
+  if (process.platform === 'darwin') clearWorkerKeychainEntry(ctx)
   const credentialsJson = readClaudeCodeOauthJson()
   if (!credentialsJson) return false
-  if (!existsSync(WORKER_CONFIG_DIR)) mkdirSync(WORKER_CONFIG_DIR, { recursive: true })
-  writeFileSync(join(WORKER_CONFIG_DIR, '.credentials.json'), credentialsJson, { mode: 0o600 })
+  if (!existsSync(ctx.configDir)) mkdirSync(ctx.configDir, { recursive: true })
+  writeFileSync(join(ctx.configDir, '.credentials.json'), credentialsJson, { mode: 0o600 })
   return true
 }
 
 /** Scan the worker pane tail for Claude Code's auth-failure chrome. */
-function workerPaneHasAuthFailure(): boolean {
-  const pane = capturePane(WORKER_SESSION)
+function workerPaneHasAuthFailure(ctx: WorkerCtx): boolean {
+  const pane = capturePane(ctx.session)
   if (!pane) return false
   const tail = pane.split('\n').slice(-30).join('\n')
   return WORKER_AUTH_FAILURE_RX.test(tail)
@@ -186,7 +234,7 @@ export function classifyWorkerPane(pane: string | null): WorkerPaneClass {
   // Modal chrome: a numbered option list or a confirm footer. Matches the
   // fullscreen-upsell dialog captured live on 2026-07-08 and the Trust-folder /
   // onboarding dialog family.
-  if (/Enter to confirm|Esc to cancel|\u276F\s*1\./.test(pane)) return 'modal'
+  if (/Enter to confirm|Esc to cancel|❯\s*1\./.test(pane)) return 'modal'
   return 'unknown'
 }
 
@@ -220,16 +268,12 @@ export function decidePoll(opts: {
   return 'wait'
 }
 
-// --- single-worker mutex -------------------------------------------------------
+// --- per-session mutex ---------------------------------------------------------
 
-// The worker is one interactive session -> one prompt at a time. Serialize all
-// runViaWorker calls through a promise chain so an hourly heartbeat and an
-// ad-hoc scheduled task never interleave on the same pane.
-let workerChain: Promise<unknown> = Promise.resolve()
-function withWorkerLock<T>(fn: () => Promise<T>): Promise<T> {
-  const run = workerChain.then(fn, fn)
+function withWorkerLockFor<T>(ctx: WorkerCtx, fn: () => Promise<T>): Promise<T> {
+  const run = ctx.chain.then(fn, fn)
   // Keep the chain alive regardless of this call's outcome.
-  workerChain = run.then(() => undefined, () => undefined)
+  ctx.chain = run.then(() => undefined, () => undefined)
   return run
 }
 
@@ -248,25 +292,25 @@ interface WorkerSettings { enabledPlugins?: Record<string, boolean>; [k: string]
  *    (so auth/transcripts/marketplaces stay shared, persona memory does not);
  *  - settings.json with every channel plugin disabled (no 409);
  *  - .credentials.json seeded from the host login (subscription auth);
- *  - .claude.json with projects[WORKER_HOME] mirroring projects[PROJECT_ROOT]
+ *  - .claude.json with projects[ctx.home] mirroring projects[PROJECT_ROOT]
  *    so the worker inherits Marveen's project-scoped MCP servers.
  * No CLAUDE.md is written here: the cwd is outside PROJECT_ROOT, so the worker
  * boots with a neutral context.
  */
-export function ensureWorkerCwd(): void {
-  if (!existsSync(WORKER_HOME)) mkdirSync(WORKER_HOME, { recursive: true })
-  if (!existsSync(SCRATCH_DIR)) mkdirSync(SCRATCH_DIR, { recursive: true })
+export function ensureWorkerCwd(ctx: WorkerCtx = ctxSlow): void {
+  if (!existsSync(ctx.home)) mkdirSync(ctx.home, { recursive: true })
+  if (!existsSync(ctx.scratchDir)) mkdirSync(ctx.scratchDir, { recursive: true })
 
-  const mcpPath = join(WORKER_HOME, '.mcp.json')
+  const mcpPath = join(ctx.home, '.mcp.json')
   if (!existsSync(mcpPath)) writeFileSync(mcpPath, '{"mcpServers":{}}\n')
 
-  if (!existsSync(WORKER_CONFIG_DIR)) mkdirSync(WORKER_CONFIG_DIR, { recursive: true })
+  if (!existsSync(ctx.configDir)) mkdirSync(ctx.configDir, { recursive: true })
 
   const realClaude = join(homedir(), '.claude')
   if (existsSync(realClaude)) {
     for (const entry of readdirSync(realClaude)) {
       if (WORKER_CONFIG_SKIP.has(entry)) continue
-      const linkPath = join(WORKER_CONFIG_DIR, entry)
+      const linkPath = join(ctx.configDir, entry)
       const target = join(realClaude, entry)
       let needsLink = true
       const st = lstatSyncSafe(linkPath)
@@ -283,7 +327,7 @@ export function ensureWorkerCwd(): void {
 
   // settings.json: own it; force all channel plugins off (merge-preserve any
   // hook config Claude Code wrote in a prior run).
-  const settingsPath = join(WORKER_CONFIG_DIR, 'settings.json')
+  const settingsPath = join(ctx.configDir, 'settings.json')
   let current: WorkerSettings = {}
   const sst = lstatSyncSafe(settingsPath)
   if (sst?.isSymbolicLink()) {
@@ -304,13 +348,13 @@ export function ensureWorkerCwd(): void {
   // Subscription auth: materialise the host login JSON as .credentials.json AND
   // clear the stale path-hashed Keychain entry that would shadow it (see the
   // macOS auth-precedence note at the top of this file).
-  seedWorkerCredentials()
+  seedWorkerCredentials(ctx)
 
   // Inherit project-scoped MCP servers under the worker's own cwd key, AND
   // pre-accept the first-run dialogs so the headless interactive session never
   // parks on a modal (Trust folder / project onboarding). hasCompletedOnboarding
   // (global) suppresses the theme picker + login onboarding. We stamp the trust
-  // flags on BOTH WORKER_HOME and its realpath (macOS /var, symlinked $HOME
+  // flags on BOTH ctx.home and its realpath (macOS /var, symlinked $HOME
   // edge-cases) since Claude Code keys trust by the resolved workspace path.
   try {
     const homeClaudeJson = join(homedir(), '.claude.json')
@@ -322,11 +366,11 @@ export function ensureWorkerCwd(): void {
       ? projects[PROJECT_ROOT] as Record<string, unknown>
       : {}
     const trusted = { ...base, hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true, projectOnboardingSeenCount: 1 }
-    const keys = new Set<string>([WORKER_HOME])
-    try { keys.add(realpathSync(WORKER_HOME)) } catch { /* dir may not resolve yet */ }
+    const keys = new Set<string>([ctx.home])
+    try { keys.add(realpathSync(ctx.home)) } catch { /* dir may not resolve yet */ }
     for (const k of keys) projects[k] = { ...trusted }
     parsed.projects = projects
-    writeFileSync(join(WORKER_CONFIG_DIR, '.claude.json'), JSON.stringify(parsed, null, 2) + '\n', { mode: 0o600 })
+    writeFileSync(join(ctx.configDir, '.claude.json'), JSON.stringify(parsed, null, 2) + '\n', { mode: 0o600 })
   } catch (err) {
     logger.warn({ err }, 'worker: failed to materialise .claude.json (worker may park on a first-run modal)')
   }
@@ -353,8 +397,8 @@ export function stampWorkerFirstRun(parsed: { hasCompletedOnboarding?: boolean; 
 
 // --- session lifecycle ---------------------------------------------------------
 
-function workerSessionExists(): boolean {
-  return sessionExistsOnHost(null, WORKER_SESSION)
+function workerSessionExists(ctx: WorkerCtx): boolean {
+  return sessionExistsOnHost(null, ctx.session)
 }
 
 function sleepMs(ms: number): Promise<void> {
@@ -362,22 +406,31 @@ function sleepMs(ms: number): Promise<void> {
 }
 
 /**
- * Launch the interactive worker session if it is not already up. Subscription
+ * Launch one interactive worker session if it is not already up. Subscription
  * login via the isolated CLAUDE_CONFIG_DIR; no --channels, bypassPermissions so
  * the Write-to-scratch capture works. Idempotent.
  */
-export function startWorkerSession(): void {
-  if (workerSessionExists()) return
-  ensureWorkerCwd()
+function startWorkerSessionFor(ctx: WorkerCtx): void {
+  if (workerSessionExists(ctx)) return
+  ensureWorkerCwd(ctx)
   // Detached session; launch claude via a login shell so PATH + the config-dir
   // env are set. The model suffix ([1m]) is single-quoted so it is not globbed.
   const launch =
-    `export CLAUDE_CONFIG_DIR=${shArg(WORKER_CONFIG_DIR)}; ` +
-    `cd ${shArg(WORKER_HOME)} && ` +
+    `export CLAUDE_CONFIG_DIR=${shArg(ctx.configDir)}; ` +
+    `cd ${shArg(ctx.home)} && ` +
     `claude --dangerously-skip-permissions --model ${shArg(WORKER_MODEL)}`
-  execFileSync(TMUX, ['new-session', '-d', '-s', WORKER_SESSION, '-c', WORKER_HOME, 'bash', '-lc', launch], { timeout: 8000 })
-  logger.info({ session: WORKER_SESSION, cwd: WORKER_HOME }, 'agent-worker: launched interactive worker session')
-  logWorkerClaudeVersion()
+  execFileSync(TMUX, ['new-session', '-d', '-s', ctx.session, '-c', ctx.home, 'bash', '-lc', launch], { timeout: 8000 })
+  logger.info({ session: ctx.session, cwd: ctx.home }, 'agent-worker: launched interactive worker session')
+  logWorkerClaudeVersion(ctx)
+}
+
+/**
+ * Pre-start both worker sessions. Called at server startup to amortise boot
+ * latency across first requests. Idempotent -- a running session is a no-op.
+ */
+export function startWorkerSession(): void {
+  startWorkerSessionFor(ctxSlow)
+  startWorkerSessionFor(ctxFast)
 }
 
 /**
@@ -387,11 +440,11 @@ export function startWorkerSession(): void {
  * upsell) is visible in the log timeline instead of being reverse-engineered
  * from a stuck pane. Best effort: a probe failure never blocks the boot.
  */
-function logWorkerClaudeVersion(): void {
+function logWorkerClaudeVersion(ctx: WorkerCtx): void {
   try {
     const claudeBin = resolveFromPath('claude')
     const v = execFileSync(claudeBin, ['--version'], { encoding: 'utf-8', timeout: 10_000 }).trim()
-    const stampPath = join(WORKER_HOME, '.last-claude-version')
+    const stampPath = join(ctx.home, '.last-claude-version')
     const prev = existsSync(stampPath) ? readFileSync(stampPath, 'utf-8').trim() : null
     if (prev && prev !== v) {
       logger.warn({ prev, current: v }, 'agent-worker: Claude Code version changed since the last worker boot -- watch for new first-run chrome')
@@ -415,10 +468,9 @@ function shArg(s: string): string {
 const WORKER_SELF_HEAL_GRACE_MS = 20_000
 // Bounded Escape presses against a parked dialog, with a ready-recheck between.
 const WORKER_SELF_HEAL_MAX_ESCAPES = 3
-// Operator alert at most once per hour per process, so a persistently broken
+// Operator alert at most once per hour per session, so a persistently broken
 // worker does not spam the channel while still never failing silently.
 const WORKER_STUCK_ALERT_COOLDOWN_MS = 60 * 60 * 1000
-let lastWorkerStuckAlert = 0
 
 /**
  * One bounded self-heal pass for a worker parked on unexpected chrome:
@@ -426,63 +478,63 @@ let lastWorkerStuckAlert = 0
  * the pane still is not healthy. Never touches a busy/idle/auth pane.
  * Returns true if it acted.
  */
-function selfHealWorkerOnce(): boolean {
-  const cls = classifyWorkerPane(capturePane(WORKER_SESSION))
+function selfHealWorkerOnce(ctx: WorkerCtx): boolean {
+  const cls = classifyWorkerPane(capturePane(ctx.session))
   if (!shouldSelfHeal(cls)) return false
-  logger.warn({ cls }, 'agent-worker: pane parked on unexpected chrome -- bounded Escape self-heal')
+  logger.warn({ cls, session: ctx.session }, 'agent-worker: pane parked on unexpected chrome -- bounded Escape self-heal')
   for (let i = 0; i < WORKER_SELF_HEAL_MAX_ESCAPES; i++) {
-    try { execFileSync(TMUX, ['send-keys', '-t', WORKER_SESSION, 'Escape'], { timeout: 5000 }) } catch { break }
+    try { execFileSync(TMUX, ['send-keys', '-t', ctx.session, 'Escape'], { timeout: 5000 }) } catch { break }
     try { execFileSync('/bin/sleep', ['0.5'], { timeout: 2000 }) } catch { /* best effort */ }
-    const now = classifyWorkerPane(capturePane(WORKER_SESSION))
+    const now = classifyWorkerPane(capturePane(ctx.session))
     if (now === 'idle' || now === 'busy') {
-      logger.info({ escapes: i + 1 }, 'agent-worker: self-heal cleared the parked chrome via Escape')
+      logger.info({ escapes: i + 1, session: ctx.session }, 'agent-worker: self-heal cleared the parked chrome via Escape')
       return true
     }
   }
-  logger.warn('agent-worker: Escape did not clear the parked chrome -- restarting the worker session')
-  restartWorkerSession()
+  logger.warn({ session: ctx.session }, 'agent-worker: Escape did not clear the parked chrome -- restarting the worker session')
+  restartWorkerSession(ctx)
   return true
 }
 
 /** Loud, rate-limited operator signal: the worker never became ready. */
-function alertWorkerStuck(paneTail: string): void {
-  logger.error({ paneTail }, 'agent-worker: worker never became ready (agent-gen / capability-summary / heartbeat / digest consumers will fail)')
-  if (Date.now() - lastWorkerStuckAlert < WORKER_STUCK_ALERT_COOLDOWN_MS) return
-  lastWorkerStuckAlert = Date.now()
+function alertWorkerStuck(ctx: WorkerCtx, paneTail: string): void {
+  logger.error({ paneTail, session: ctx.session }, 'agent-worker: worker never became ready (agent-gen / capability-summary / heartbeat / digest consumers will fail)')
+  if (Date.now() - ctx.lastStuckAlert < WORKER_STUCK_ALERT_COOLDOWN_MS) return
+  ctx.lastStuckAlert = Date.now()
   void notifyChannel(
-    '\u26A0\uFE0F Marveen worker: a hatter-worker session nem all keszen (beragadt dialogus vagy ismeretlen kepernyo). Onjavitas lefutott (Escape + restart), de a keszenlet nem allt helyre. Erintett: agens-generalas, capability-osszefoglalo, heartbeat, digest. Nezz ra: tmux attach -t marveen-worker',
+    `⚠️ Marveen worker [${ctx.session}]: a hatter-worker session nem all keszen (beragadt dialogus vagy ismeretlen kepernyo). Onjavitas lefutott (Escape + restart), de a keszenlet nem allt helyre. Erintett: agens-generalas, capability-osszefoglalo, heartbeat, digest. Nezz ra: tmux attach -t ${ctx.session}`,
   ).catch(() => { /* notifyChannel logs internally */ })
 }
 
-async function ensureWorkerReady(): Promise<boolean> {
-  startWorkerSession()
+async function ensureWorkerReady(ctx: WorkerCtx): Promise<boolean> {
+  startWorkerSessionFor(ctx)
   const start = Date.now()
   const deadline = start + WORKER_BOOT_TIMEOUT_MS
   let healed = false
   while (Date.now() < deadline) {
-    if (isSessionReadyForPrompt(WORKER_SESSION)) return true
+    if (isSessionReadyForPrompt(ctx.session)) return true
     if (!healed && Date.now() - start > WORKER_SELF_HEAL_GRACE_MS) {
       healed = true
-      try { selfHealWorkerOnce() } catch (err) { logger.warn({ err }, 'agent-worker: self-heal pass failed') }
+      try { selfHealWorkerOnce(ctx) } catch (err) { logger.warn({ err }, 'agent-worker: self-heal pass failed') }
     }
     await sleepMs(2000)
   }
-  const pane = capturePane(WORKER_SESSION)
-  alertWorkerStuck((pane ?? '').split('\n').slice(-12).join('\n'))
+  const pane = capturePane(ctx.session)
+  alertWorkerStuck(ctx, (pane ?? '').split('\n').slice(-12).join('\n'))
   return false
 }
 
-function restartWorkerSession(): void {
-  try { execFileSync(TMUX, ['kill-session', '-t', WORKER_SESSION], { timeout: 5000 }) } catch { /* not running */ }
-  try { startWorkerSession() } catch (err) { logger.warn({ err }, 'agent-worker: restart failed') }
+function restartWorkerSession(ctx: WorkerCtx): void {
+  try { execFileSync(TMUX, ['kill-session', '-t', ctx.session], { timeout: 5000 }) } catch { /* not running */ }
+  try { startWorkerSessionFor(ctx) } catch (err) { logger.warn({ err, session: ctx.session }, 'agent-worker: restart failed') }
 }
 
 // Reset context between requests so unrelated one-shots never share/grow context.
-function clearWorkerContext(): void {
+function clearWorkerContext(ctx: WorkerCtx): void {
   try {
-    execFileSync(TMUX, ['send-keys', '-t', WORKER_SESSION, '-l', '/clear'], { timeout: 5000 })
+    execFileSync(TMUX, ['send-keys', '-t', ctx.session, '-l', '/clear'], { timeout: 5000 })
     execFileSync('/bin/sleep', ['0.2'], { timeout: 2000 })
-    execFileSync(TMUX, ['send-keys', '-t', WORKER_SESSION, 'Enter'], { timeout: 5000 })
+    execFileSync(TMUX, ['send-keys', '-t', ctx.session, 'Enter'], { timeout: 5000 })
     execFileSync('/bin/sleep', ['0.5'], { timeout: 2000 })
   } catch (err) {
     logger.warn({ err }, 'agent-worker: /clear failed (continuing)')
@@ -502,23 +554,23 @@ type AttemptResult =
   | { kind: 'auth' }
   | { kind: 'fail'; error: string }
 
-async function runWorkerAttempt(message: string, timeoutMs: number): Promise<AttemptResult> {
-  const ready = await ensureWorkerReady()
+async function runWorkerAttempt(ctx: WorkerCtx, message: string, timeoutMs: number): Promise<AttemptResult> {
+  const ready = await ensureWorkerReady(ctx)
   if (!ready) {
     // A non-ready worker can be a dead auth (the session boots, prints the
     // login/401 chrome, never reaches an idle prompt) -- distinguish it.
-    if (workerPaneHasAuthFailure()) return { kind: 'auth' }
-    logger.warn('agent-worker: worker not ready, failing request (text=null)')
+    if (workerPaneHasAuthFailure(ctx)) return { kind: 'auth' }
+    logger.warn({ session: ctx.session }, 'agent-worker: worker not ready, failing request (text=null)')
     return { kind: 'fail', error: 'worker session not ready' }
   }
 
   const reqId = nextReqId()
-  const outPath = join(SCRATCH_DIR, `${reqId}.out`)
-  const donePath = join(SCRATCH_DIR, `${reqId}.done`)
+  const outPath = join(ctx.scratchDir, `${reqId}.out`)
+  const donePath = join(ctx.scratchDir, `${reqId}.done`)
   for (const p of [outPath, donePath]) { try { rmSync(p, { force: true }) } catch { /* none */ } }
 
-  clearWorkerContext()
-  sendPromptToSession(WORKER_SESSION, buildWorkerPrompt(message, outPath, donePath))
+  clearWorkerContext(ctx)
+  sendPromptToSession(ctx.session, buildWorkerPrompt(message, outPath, donePath))
 
   const start = Date.now()
   try {
@@ -526,7 +578,7 @@ async function runWorkerAttempt(message: string, timeoutMs: number): Promise<Att
       await sleepMs(CAPTURE_POLL_MS)
       const decision = decidePoll({
         doneExists: existsSync(donePath),
-        sessionAlive: workerSessionExists(),
+        sessionAlive: workerSessionExists(ctx),
         elapsedMs: Date.now() - start,
         timeoutMs,
       })
@@ -536,17 +588,17 @@ async function runWorkerAttempt(message: string, timeoutMs: number): Promise<Att
       }
       // Not done yet: catch a mid-flight auth failure (the access token can
       // expire while the session is up) BEFORE burning the full timeout.
-      if (workerPaneHasAuthFailure()) {
-        logger.warn({ reqId }, 'agent-worker: auth failure detected mid-request')
+      if (workerPaneHasAuthFailure(ctx)) {
+        logger.warn({ reqId, session: ctx.session }, 'agent-worker: auth failure detected mid-request')
         return { kind: 'auth' }
       }
       if (decision === 'timeout') {
-        logger.warn({ reqId, timeoutMs }, 'agent-worker: request timed out')
+        logger.warn({ reqId, timeoutMs, session: ctx.session }, 'agent-worker: request timed out')
         return { kind: 'fail', error: `worker timeout after ${Math.round(timeoutMs / 1000)}s` }
       }
       if (decision === 'dead') {
-        logger.warn({ reqId }, 'agent-worker: session died mid-request, restarting (fail-fast)')
-        restartWorkerSession()
+        logger.warn({ reqId, session: ctx.session }, 'agent-worker: session died mid-request, restarting (fail-fast)')
+        restartWorkerSession(ctx)
         return { kind: 'fail', error: 'worker session died mid-request' }
       }
     }
@@ -557,8 +609,11 @@ async function runWorkerAttempt(message: string, timeoutMs: number): Promise<Att
 
 /**
  * Run one prompt through the interactive worker and return its text output.
- * Serialized via the worker mutex. Returns text=null + error on timeout, a
- * mid-flight worker death (fail-fast + restart), or a non-ready worker.
+ * Routes to the fast or slow session based on message length + keyword heuristic
+ * (overridable via the `priority` parameter). Serialized within each session via
+ * its own mutex so slow and fast tasks never block each other. Returns
+ * text=null + error on timeout, a mid-flight worker death (fail-fast + restart),
+ * or a non-ready worker.
  *
  * Auth self-healing: on an auth failure (stale path-hashed Keychain token /
  * expired login) the worker re-seeds its credentials, clears the shadowing
@@ -566,10 +621,16 @@ async function runWorkerAttempt(message: string, timeoutMs: number): Promise<Att
  * authFailed=true so runAgent can fall back to the SDK backend for this call
  * rather than dying silently (the 2026-06-10 bake failure mode).
  */
-export async function runViaWorker(message: string, timeoutMs: number): Promise<{ text: string | null; error?: string; authFailed?: boolean }> {
-  return withWorkerLock(async () => {
+export async function runViaWorker(
+  message: string,
+  timeoutMs: number,
+  priority?: 'fast' | 'slow',
+): Promise<{ text: string | null; error?: string; authFailed?: boolean }> {
+  const p = priority ?? classifyPriority(message)
+  const ctx = p === 'fast' ? ctxFast : ctxSlow
+  return withWorkerLockFor(ctx, async () => {
     for (let attempt = 0; attempt < 2; attempt++) {
-      const r = await runWorkerAttempt(message, timeoutMs)
+      const r = await runWorkerAttempt(ctx, message, timeoutMs)
       if (r.kind === 'ok') return { text: r.text, error: r.error }
       if (r.kind === 'fail') {
         // A momentary not-ready is TRANSIENT, not terminal: the boot-time
@@ -578,20 +639,20 @@ export async function runViaWorker(message: string, timeoutMs: number): Promise<
         // digest) reaches this single choke point -- so one central retry
         // fixes them all. Mirrors the auth-recovery retry-once shape above.
         if (r.error === 'worker session not ready' && attempt === 0) {
-          logger.warn('agent-worker: worker not ready -- restarting once and retrying the request')
-          restartWorkerSession()
+          logger.warn({ session: ctx.session }, 'agent-worker: worker not ready -- restarting once and retrying the request')
+          restartWorkerSession(ctx)
           continue
         }
         return { text: null, error: r.error }
       }
       // r.kind === 'auth'
       if (attempt === 0) {
-        logger.warn('agent-worker: auth failure -> recovering (reseed creds + clear keychain + restart)')
-        seedWorkerCredentials()
-        restartWorkerSession()
+        logger.warn({ session: ctx.session }, 'agent-worker: auth failure -> recovering (reseed creds + clear keychain + restart)')
+        seedWorkerCredentials(ctx)
+        restartWorkerSession(ctx)
         continue
       }
-      logger.error('agent-worker: auth failure persists after recovery -> signalling SDK fallback (authFailed)')
+      logger.error({ session: ctx.session }, 'agent-worker: auth failure persists after recovery -> signalling SDK fallback (authFailed)')
       return { text: null, error: 'worker auth failed (401/login) after recovery', authFailed: true }
     }
     return { text: null, error: 'worker auth failed', authFailed: true }

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -516,6 +516,11 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   })()
 }
 
+// Tick interval for the schedule runner. 15 s gives 4x faster inter-agent
+// message delivery and scheduled-task triggering; each tick is a cheap
+// SQLite SELECT so the load is negligible.
+export const SCHEDULE_TICK_MS = 15_000
+
 export function startScheduleRunner(): NodeJS.Timeout {
   // Reload the persisted last-run times so a restart inside a task's catch-up
   // window does not re-fire an already-run task.
@@ -549,7 +554,7 @@ export function startScheduleRunner(): NodeJS.Timeout {
     const now = Date.now()
     // Scan the real interval elapsed since the previous tick (30 min on the
     // first tick), not a fixed 60s window -- a late/dropped tick must not let a
-    // sparse daily cron's single occurrence slip through a gap unscanned.
+    // sparse daily cron's single occurrence slip through a gap unscanned (#621).
     const fromMs = lastCheckMs
 
     // Retry tasks that were busy-skipped on earlier ticks (persisted in
@@ -706,5 +711,5 @@ export function startScheduleRunner(): NodeJS.Timeout {
 
   // Run immediately on start (catches missed tasks)
   setTimeout(runCheck, 5000)
-  return setInterval(runCheck, 60000)
+  return setInterval(runCheck, SCHEDULE_TICK_MS)
 }


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**Problem.** The single `marveen-worker` tmux session processed every request through one promise-chain mutex. A long-running analysis task (heartbeat digest, agent scaffold, scheduled report) blocked all subsequent Telegram messages for its full duration. The 60 s schedule-runner tick also meant that an inter-agent message could wait up to a minute before the target agent received the prompt.

**Solution.**

### 1 — Dual worker sessions

A `WorkerCtx` interface encapsulates all per-session state (session name, home / config / scratch dirs, promise-chain mutex, stuck-alert timer). Two independent instances are created at module level:

- **`marveen-worker` (slow)** — long-running tasks: analysis, reports, search, scaffold.
- **`marveen-worker-fast` (fast)** — short conversational tasks (< 300 chars, no analysis keywords).

Each session has its own isolated `CLAUDE_CONFIG_DIR` and home directory, eliminating any shared Telegram long-poll state (the original source of 409 Conflicts). Auth recovery, self-heal, and stuck-alert logic are fully parametrised through `WorkerCtx` — both sessions share one code path with zero duplication.

Routing is performed by the exported `classifyPriority(message)` function:
- message ≥ 300 chars → **slow**
- message contains `elemezd|keresd|összefoglaló|analyze|search|summary|report` → **slow**
- otherwise → **fast**

`runViaWorker(message, timeoutMs, priority?)` accepts an optional override so callers can force a lane. `startWorkerSession()` now pre-warms both sessions at server boot.

### 2 — Schedule tick: 60 s → 15 s

`SCHEDULE_TICK_MS = 15_000` (exported constant) replaces the hard-coded `60000` in both `setInterval` and the catch-up window calculation. Each tick is a cheap indexed SQLite `SELECT`; the load increase is negligible. Inter-agent message delivery latency drops from up to 60 s to up to 15 s.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).