### PR TITLE
fix(reauth-healer): stop self-quote loop + credentials-guard at boot on all installs

### DIFF
--- a/src/__tests__/reauth-detect.test.ts
+++ b/src/__tests__/reauth-detect.test.ts
@@ -106,4 +106,24 @@ describe('detectReauthNeeded', () => {
     expect(r.needsReauth).toBe(true)
     expect(r.reason).toMatch(/not logged in/i)
   })
+
+  it('does NOT fire when a prior escalation message is quoted back into the pane (self-loop)', () => {
+    // Reproduces the 2026-07-13 bug: the owner pastes the healer's own alert
+    // (which embeds the raw marker text) back into the chat, and it re-matches.
+    const pane = [
+      ...Array.from({ length: 10 }, (_, i) => `... work line ${i} ...`),
+      '🔐 A(z) bigme ágens halott OAuth tokent jelez (Please run /login) több mint ~9 perce.',
+      'Manuális browser /login kell a dashboardon (az ügynök kártyáján a "Bejelentkezés" gomb), automatikusan nem gyógyítható.',
+    ].join('\n')
+    expect(detectReauthNeeded(pane).needsReauth).toBe(false)
+  })
+
+  it('does NOT fire on the quiet-hours morning summary quoted back either', () => {
+    const pane = [
+      '🔐 Reggeli token-összegzés: az éjszakai csendes sáv (23:00-06:00) alatt elnyomott riasztások. MOST IS halott tokent jelez:',
+      '• bigme: Invalid authentication credentials (401) (~45 perce)',
+      'Manuális browser /login kell a dashboardon (az ügynök kártyáján a "Bejelentkezés" gomb).',
+    ].join('\n')
+    expect(detectReauthNeeded(pane).needsReauth).toBe(false)
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -448,14 +448,19 @@ async function main(): Promise<void> {
   // sub-agent that reads the operator's calendar and DB, and a gated-off
   // machine (e.g. a dev box) must not fight the production host over the
   // channel.
+  // Linux credentials-guard, once at boot before any agent starts (opt-in,
+  // default OFF, no-op on macOS). Retires the rotating credentials.json so
+  // even the systemd-managed main channels agent comes up on the stable
+  // setup-token; startAgentProcess re-runs it per launch for self-healing.
+  // Was previously nested inside the heartbeat-agent boot branch below, so on
+  // any install with the heartbeat sub-agent disabled (the common case) this
+  // never ran at boot at all (found 2026-07-13 while diagnosing recurring
+  // dead-token incidents).
+  renameSharedCredentialsIfSafe()
+
   if (shouldBootHeartbeatAgent({ respawnEnabled: RESPAWN_ENABLED, agentEnabled: HEARTBEAT_AGENT_ENABLED })) {
     ensureHeartbeatAgent()
     logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent scaffold ensured (channel-less, dashboard-hidden)')
-    // Linux credentials-guard, once at boot before any agent starts (opt-in,
-    // default OFF, no-op on macOS). Retires the rotating credentials.json so
-    // even the systemd-managed main channels agent comes up on the stable
-    // setup-token; startAgentProcess re-runs it per launch for self-healing.
-    renameSharedCredentialsIfSafe()
     const heartbeatStart = startAgentProcess(HEARTBEAT_AGENT_NAME)
     if (heartbeatStart.ok) {
       logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent started')

--- a/src/web/reauth-detect.ts
+++ b/src/web/reauth-detect.ts
@@ -34,6 +34,20 @@ const REAUTH_MARKERS: { rx: RegExp; reason: string }[] = [
 // markers from reading reauth-detect.ts and would have falsely badged.)
 const TAIL_LINES = 15
 
+// Self-quote guard (found 2026-07-13: 5 false escalations in ~18h, each
+// shortly after the alert text was pasted back into the chat). The healer's
+// own escalation message embeds the raw marker `reason` string verbatim, e.g.
+// "... jelez (Please run /login) ...". Once that message is quoted back into
+// the pane -- the owner forwarding it, the dashboard rendering it, or the
+// agent discussing the bug -- it re-matches REAUTH_MARKERS against its own
+// alert and re-fires, forever. These substrings are unique to
+// buildEscalationMessage / buildQuietSummaryMessage in reauth-healer.ts and
+// never appear in a real Claude Code CLI auth failure.
+const ESCALATION_QUOTE_MARKERS: RegExp[] = [
+  /ágens halott OAuth tokent jelez/i,
+  /Manuális browser \/login kell a dashboardon/i,
+]
+
 function tailOf(pane: string, n: number): string {
   const lines = pane.split('\n')
   return lines.slice(Math.max(0, lines.length - n)).join('\n')
@@ -74,11 +88,13 @@ function liveStatusRegion(pane: string): string | null {
  * running) -- absence of evidence is not evidence of an auth problem. Scans the
  * live status region when the pane has Claude Code's input box, else falls back
  * to the last TAIL_LINES, so scrollback that merely mentions the markers does
- * not trigger a false badge.
+ * not trigger a false badge. A region that is itself a quote of a prior
+ * escalation message is also excluded (see ESCALATION_QUOTE_MARKERS).
  */
 export function detectReauthNeeded(pane: string | null | undefined): ReauthState {
   if (!pane) return { needsReauth: false }
   const region = liveStatusRegion(pane) ?? tailOf(pane, TAIL_LINES)
+  if (ESCALATION_QUOTE_MARKERS.some((rx) => rx.test(region))) return { needsReauth: false }
   for (const m of REAUTH_MARKERS) {
     if (m.rx.test(region)) return { needsReauth: true, reason: m.reason }
   }


### PR DESCRIPTION
## Két dead-token / hamis-eszkaláció bug (2026-07-13)

### 1. Self-quote loop
A healer eszkalációs üzenete a nyers marker `reason`-t szó szerint beágyazza, így amint ez a riasztás visszakerült a pane-be (owner továbbküldi, dashboard rendereli, agent a bugról beszél), újra matchelt a `REAUTH_MARKERS`-re és újra tüzelt -- **5 hamis eszkaláció ~18 óra alatt**. A `detectReauthNeeded` mostantól kizárja azokat a tail-eket, amik maguk egy korábbi eszkalációs / quiet-summary üzenet idézetei (`ESCALATION_QUOTE_MARKERS`).

### 2. credentials-guard sosem futott boot-kor a gyakori installon
A `renameSharedCredentialsIfSafe()` a heartbeat-agent boot ágba volt ágyazva, így letiltott heartbeat sub-agent esetén (a gyakori eset) boot-kor sosem futott. Kiemelve, hogy egyszer lefusson boot-kor, minden agent indulása előtt (macOS-en továbbra is no-op).

Két regressziós teszt hozzáadva az idézett-riasztás esetre. `vitest run src/__tests__/reauth-detect.test.ts` -> 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)