### PR TITLE
fix(update): report success on already-up-to-date path (kill false "failed/pull")

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -364,6 +364,16 @@ if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
     else
       echo -e "  ${GREEN}✓${NC} Már a legfrissebb verzión vagy ($NEW_VERSION)"
     fi
+    # Report SUCCESS explicitly. RESULT_STATUS defaults to "failed" (line 22)
+    # and is only flipped to a success verdict by the detached restart
+    # finalizer (_finish success ...). This happy path exits 0 WITHOUT
+    # restarting, so without setting the status here the EXIT trap's
+    # write_result records {status:"failed",phase:"pull",code:0} -- a false
+    # failure that the dashboard shows as "update failed" every time the box
+    # is already current. Set the real outcome before the clean exit.
+    RESULT_STATUS="success"
+    RESULT_PHASE="up-to-date"
+    RESULT_MSG="Mar a legfrissebb verzion ($NEW_VERSION); nincs teendo."
     # Nothing to pull, but an auto-stash may still be sitting on top of HEAD
     # (dashboard's "stash + update" run against an already-current checkout).
     # Without this, the operator's local files stay stashed with no restore.


### PR DESCRIPTION
## Root cause

`update.sh` initializes `RESULT_STATUS="failed"` (the safe default) and the **only** place a success verdict is written is the detached restart finalizer (`_finish success restart 0 ""`), which runs solely on the restart path.

The "already on latest commit + dist fresh" happy path exits `0` **without** restarting. So the `EXIT` trap's `write_result` records the untouched default:

```json
{"status":"failed","phase":"pull","code":0,"old":"66c631a","new":"66c631a","message":""}
```

That is a **false failure**: every time the box is already current, `store/update.last-result` reads `failed/pull` and the dashboard shows "update failed" — which can then trigger a rollback-diagnosis even though nothing failed and no rollback happened (reflog confirms a clean fast-forward, working tree clean, dist self-healed to HEAD).

## Fix

Set `RESULT_STATUS="success"` (plus a clear phase/message) right before the clean `exit 0` on the already-up-to-date branch. No change to the pull / build / restart / rollback machinery.

## Verification
- `bash -n update.sh` clean
- `npm run build` green (tsc, exit 0)
- Audited every `exit` point: line 381 is the only clean `exit 0`; all others are genuine failures (exit 1-6) and the reseed/regen path falls through to the restart finalizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)