### PR TITLE
feat: persistent skill_usage table with user-level PostToolUse hook for skill health tracking

### DIFF
--- a/scripts/__tests__/skill-usage-capture.test.py
+++ b/scripts/__tests__/skill-usage-capture.test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/hooks/skill-usage-capture.py.
+
+Tests cover _classify() and _agent_id_from_cwd() -- the two pure-logic
+functions that determine what gets logged and under which agent.
+
+Privacy: only fake agent IDs (agent-a, agent-b) and synthetic paths are used.
+"""
+import sys
+import os
+import unittest
+
+# Resolve the hook module without importing as a side-effect runner.
+import importlib.util
+
+_HOOK_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "hooks", "skill-usage-capture.py",
+)
+
+_spec = importlib.util.spec_from_file_location("skill_usage_capture", _HOOK_PATH)
+hook = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(hook)  # type: ignore[union-attr]
+
+
+class TestClassify(unittest.TestCase):
+    """_classify(tool_name, tool_input) -> (skill_name, trigger_type) | None"""
+
+    def _call(self, tool_name, tool_input):
+        return hook._classify(tool_name, tool_input)
+
+    # Skill tool ----------------------------------------------------------------
+
+    def test_skill_tool_returns_tool_call(self):
+        result = self._call("Skill", {"skill": "fleet-helper"})
+        self.assertEqual(result, ("fleet-helper", "tool_call"))
+
+    def test_skill_tool_args_variant(self):
+        result = self._call("Skill", {"skill": "deep-research", "args": "something"})
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "deep-research")
+        self.assertEqual(result[1], "tool_call")
+
+    def test_skill_tool_strips_whitespace(self):
+        result = self._call("Skill", {"skill": "  fleet-helper  "})
+        self.assertEqual(result, ("fleet-helper", "tool_call"))
+
+    def test_skill_tool_empty_name_returns_none(self):
+        result = self._call("Skill", {"skill": ""})
+        self.assertIsNone(result)
+
+    def test_skill_tool_missing_skill_key_returns_none(self):
+        result = self._call("Skill", {})
+        self.assertIsNone(result)
+
+    # Read tool + SKILL.md path -------------------------------------------------
+
+    def test_read_skill_md_returns_skill_read(self):
+        home = os.path.expanduser("~")
+        path = f"{home}/.claude/skills/fleet-helper/SKILL.md"
+        result = self._call("Read", {"file_path": path})
+        self.assertEqual(result, ("fleet-helper", "skill_read"))
+
+    def test_read_skill_md_extracts_skill_name(self):
+        home = os.path.expanduser("~")
+        path = f"{home}/.claude/skills/deep-research/SKILL.md"
+        result = self._call("Read", {"file_path": path})
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "deep-research")
+
+    def test_read_non_skill_md_returns_none(self):
+        home = os.path.expanduser("~")
+        # Only the SKILL.md at the top of a skill dir should match.
+        result = self._call("Read", {"file_path": f"{home}/.claude/skills/fleet-helper/references/extra.md"})
+        self.assertIsNone(result)
+
+    def test_read_arbitrary_file_returns_none(self):
+        result = self._call("Read", {"file_path": "/some/other/file.md"})
+        self.assertIsNone(result)
+
+    def test_read_no_file_path_returns_none(self):
+        result = self._call("Read", {})
+        self.assertIsNone(result)
+
+    # Other tools ----------------------------------------------------------------
+
+    def test_bash_tool_returns_none(self):
+        self.assertIsNone(self._call("Bash", {"command": "echo hi"}))
+
+    def test_write_tool_returns_none(self):
+        self.assertIsNone(self._call("Write", {"file_path": "/tmp/x.txt", "content": "x"}))
+
+    def test_edit_tool_returns_none(self):
+        self.assertIsNone(self._call("Edit", {"file_path": "/tmp/x.txt"}))
+
+    def test_websearch_returns_none(self):
+        self.assertIsNone(self._call("WebSearch", {"query": "something"}))
+
+    def test_unknown_tool_returns_none(self):
+        self.assertIsNone(self._call("UnknownTool", {"key": "value"}))
+
+
+class TestAgentIdFromCwd(unittest.TestCase):
+    """_agent_id_from_cwd(cwd) derives the agent identity from the session cwd."""
+
+    def _call(self, cwd):
+        return hook._agent_id_from_cwd(cwd)
+
+    def _install(self):
+        return hook._install_dir()
+
+    def test_agents_subdir_returns_agent_name(self):
+        install = self._install()
+        cwd = os.path.join(install, "agents", "agent-a")
+        self.assertEqual(self._call(cwd), "agent-a")
+
+    def test_agents_subdir_nested_returns_first_segment(self):
+        install = self._install()
+        cwd = os.path.join(install, "agents", "agent-b", "subdir")
+        self.assertEqual(self._call(cwd), "agent-b")
+
+    def test_install_root_returns_main_agent_id(self):
+        install = self._install()
+        result = self._call(install)
+        # Should fall back to MAIN_AGENT_ID or 'marveen'
+        self.assertIsInstance(result, str)
+        self.assertTrue(len(result) > 0)
+
+    def test_empty_cwd_returns_nonempty_string(self):
+        result = self._call("")
+        self.assertIsInstance(result, str)
+        self.assertTrue(len(result) > 0)
+
+    def test_trailing_slash_ignored(self):
+        install = self._install()
+        cwd_with_slash = os.path.join(install, "agents", "agent-a") + "/"
+        self.assertEqual(self._call(cwd_with_slash), "agent-a")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/hooks/skill-usage-capture.py
+++ b/scripts/hooks/skill-usage-capture.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: log skill usage to the persistent skill_usage table.
+
+Two event types are captured:
+  tool_call  -- the Skill tool was invoked (tool_name == 'Skill')
+  skill_read -- a SKILL.md file under ~/.claude/skills/<name>/SKILL.md was Read
+
+Unlike tool_call_log (pruned every 24 h), skill_usage is never pruned so the
+dream-engine can make data-driven suggestions after two or more weeks of data.
+
+Registration (user-level ~/.claude/settings.json, post-install step):
+  The hook command uses a guard so it silently no-ops if the file is missing
+  (e.g. on develop before merging this feature):
+
+    "command": "test -f /path/to/scripts/hooks/skill-usage-capture.py && python3 ... || true"
+
+  This means the hook can be registered before merge without causing errors
+  on other branches where the file does not yet exist.
+"""
+import sys
+import os
+import re
+import json
+import urllib.request
+import urllib.error
+
+
+def _install_dir() -> str:
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(os.path.dirname(here))
+
+
+def _web_port() -> str:
+    port = os.environ.get("WEB_PORT")
+    if not port:
+        try:
+            with open(os.path.join(_install_dir(), ".env")) as f:
+                for line in f:
+                    if line.startswith("WEB_PORT="):
+                        port = line.split("=", 1)[1].strip().strip('"')
+                        break
+        except Exception:
+            pass
+    return port or "3420"
+
+
+def _dashboard_token() -> str:
+    try:
+        with open(os.path.join(_install_dir(), "store", ".dashboard-token")) as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def _main_agent_id() -> str:
+    v = os.environ.get("MAIN_AGENT_ID")
+    if v and v.strip():
+        return v.strip()
+    try:
+        with open(os.path.join(_install_dir(), ".env")) as f:
+            for line in f:
+                if line.startswith("MAIN_AGENT_ID="):
+                    return line.split("=", 1)[1].strip()
+    except Exception:
+        pass
+    return "marveen"
+
+
+def _agent_id_from_cwd(cwd: str) -> str:
+    """Derive agent_id from the session working directory.
+
+    <install>/agents/<id>  -> <id>       (sub-agent: zack, rick, ...)
+    <install>               -> MAIN_AGENT_ID
+    """
+    cwd = (cwd or "").rstrip("/")
+    install = _install_dir().rstrip("/")
+    agents_root = os.path.join(install, "agents")
+    if cwd.startswith(agents_root + os.sep):
+        rel = cwd[len(agents_root) + 1:]
+        seg = rel.split(os.sep)[0]
+        return seg if seg else _main_agent_id()
+    if cwd == install:
+        return _main_agent_id()
+    base = os.path.basename(cwd)
+    return base if base else _main_agent_id()
+
+
+# ~/.claude/skills/<name>/SKILL.md  (expand ~ for the running user)
+_SKILL_MD_RE = re.compile(
+    r"^" + re.escape(os.path.expanduser("~")) + r"/\.claude/skills/([^/]+)/SKILL\.md$"
+)
+
+
+def _classify(tool_name: str, tool_input: dict) -> tuple[str, str] | None:
+    """Return (skill_name, trigger_type) or None if this event is irrelevant."""
+    if tool_name == "Skill":
+        skill = (tool_input.get("skill") or "").strip()
+        if skill:
+            return skill, "tool_call"
+    elif tool_name == "Read":
+        path = (tool_input.get("file_path") or "").strip()
+        m = _SKILL_MD_RE.match(path)
+        if m:
+            return m.group(1), "skill_read"
+    return None
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    tool_name = payload.get("tool_name") or ""
+    tool_input = payload.get("tool_input") or {}
+    session_id = payload.get("session_id") or None
+    cwd = payload.get("cwd") or ""
+
+    result = _classify(tool_name, tool_input)
+    if result is None:
+        sys.exit(0)
+
+    skill_name, trigger_type = result
+    agent_id = _agent_id_from_cwd(cwd)
+
+    token = _dashboard_token()
+    if not token:
+        sys.exit(0)
+
+    body = json.dumps({
+        "agent_id": agent_id,
+        "skill_name": skill_name,
+        "trigger_type": trigger_type,
+        "session_id": session_id,
+    }).encode()
+
+    try:
+        urllib.request.urlopen(
+            urllib.request.Request(
+                f"http://localhost:{_web_port()}/api/skill-usage",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {token}",
+                },
+                method="POST",
+            ),
+            timeout=3,
+        )
+    except Exception:
+        pass  # never block the agent
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__tests__/skill-usage.test.ts
+++ b/src/__tests__/skill-usage.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+
+// ---- DB schema (mirrors db.ts) ----
+
+function buildDb() {
+  const db = new Database(':memory:')
+  db.exec(`
+    CREATE TABLE skill_usage (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL,
+      skill_name TEXT NOT NULL,
+      trigger_type TEXT NOT NULL CHECK(trigger_type IN ('tool_call', 'skill_read')),
+      session_id TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX idx_skill_usage_agent ON skill_usage(agent_id, created_at)`)
+  db.exec(`CREATE INDEX idx_skill_usage_skill ON skill_usage(skill_name, created_at)`)
+  return db
+}
+
+type DB = ReturnType<typeof buildDb>
+
+function insert(db: DB, row: { agent_id: string; skill_name: string; trigger_type: string; session_id?: string | null; created_at?: number }) {
+  const now = Math.floor(Date.now() / 1000)
+  db.prepare(
+    'INSERT INTO skill_usage (agent_id, skill_name, trigger_type, session_id, created_at) VALUES (?, ?, ?, ?, ?)',
+  ).run(row.agent_id, row.skill_name, row.trigger_type, row.session_id ?? null, row.created_at ?? now)
+}
+
+// ---- Schema tests ----
+
+describe('skill_usage schema', () => {
+  let db: DB
+
+  beforeEach(() => { db = buildDb() })
+
+  it('accepts tool_call trigger_type', () => {
+    insert(db, { agent_id: 'agent-a', skill_name: 'fleet-helper', trigger_type: 'tool_call' })
+    const row = db.prepare('SELECT * FROM skill_usage LIMIT 1').get() as any
+    expect(row.trigger_type).toBe('tool_call')
+    expect(row.agent_id).toBe('agent-a')
+    expect(row.skill_name).toBe('fleet-helper')
+  })
+
+  it('accepts skill_read trigger_type', () => {
+    insert(db, { agent_id: 'agent-b', skill_name: 'deep-research', trigger_type: 'skill_read' })
+    const row = db.prepare('SELECT * FROM skill_usage LIMIT 1').get() as any
+    expect(row.trigger_type).toBe('skill_read')
+  })
+
+  it('rejects unknown trigger_type', () => {
+    expect(() => insert(db, { agent_id: 'agent-a', skill_name: 'x', trigger_type: 'unknown' })).toThrow()
+  })
+
+  it('allows null session_id', () => {
+    insert(db, { agent_id: 'agent-a', skill_name: 'y', trigger_type: 'tool_call', session_id: null })
+    const row = db.prepare('SELECT session_id FROM skill_usage LIMIT 1').get() as any
+    expect(row.session_id).toBeNull()
+  })
+
+  it('stores session_id when provided', () => {
+    insert(db, { agent_id: 'agent-a', skill_name: 'z', trigger_type: 'skill_read', session_id: 'sess-123' })
+    const row = db.prepare('SELECT session_id FROM skill_usage LIMIT 1').get() as any
+    expect(row.session_id).toBe('sess-123')
+  })
+
+  it('autoincrement id is unique per row', () => {
+    insert(db, { agent_id: 'agent-a', skill_name: 'fleet-helper', trigger_type: 'tool_call' })
+    insert(db, { agent_id: 'agent-a', skill_name: 'fleet-helper', trigger_type: 'tool_call' })
+    const rows = db.prepare('SELECT id FROM skill_usage').all() as any[]
+    expect(rows[0].id).not.toBe(rows[1].id)
+  })
+
+  it('allows same skill to appear multiple times (no unique constraint)', () => {
+    for (let i = 0; i < 5; i++) {
+      insert(db, { agent_id: 'agent-a', skill_name: 'fleet-helper', trigger_type: 'tool_call' })
+    }
+    const count = (db.prepare('SELECT COUNT(*) AS c FROM skill_usage').get() as any).c
+    expect(count).toBe(5)
+  })
+})
+
+// ---- Query tests ----
+
+describe('skill_usage queries', () => {
+  let db: DB
+  const BASE_TS = 1_700_000_000
+
+  beforeEach(() => {
+    db = buildDb()
+    insert(db, { agent_id: 'agent-a', skill_name: 'fleet-helper', trigger_type: 'tool_call', created_at: BASE_TS })
+    insert(db, { agent_id: 'agent-a', skill_name: 'deep-research', trigger_type: 'skill_read', created_at: BASE_TS + 10 })
+    insert(db, { agent_id: 'agent-b', skill_name: 'fleet-helper', trigger_type: 'tool_call', created_at: BASE_TS + 20 })
+    insert(db, { agent_id: 'agent-b', skill_name: 'fleet-helper', trigger_type: 'skill_read', created_at: BASE_TS + 30 })
+  })
+
+  it('returns all rows when cutoff is 0', () => {
+    const rows = db.prepare('SELECT * FROM skill_usage WHERE created_at >= ? ORDER BY created_at DESC', ).all(0)
+    expect(rows).toHaveLength(4)
+  })
+
+  it('filters by agent_id', () => {
+    const rows = db.prepare('SELECT * FROM skill_usage WHERE agent_id = ?').all('agent-a')
+    expect(rows).toHaveLength(2)
+  })
+
+  it('filters by skill_name', () => {
+    const rows = db.prepare('SELECT * FROM skill_usage WHERE skill_name = ?').all('fleet-helper')
+    expect(rows).toHaveLength(3)
+  })
+
+  it('returns rows newer than cutoff', () => {
+    const rows = db.prepare('SELECT * FROM skill_usage WHERE created_at >= ?').all(BASE_TS + 15)
+    expect(rows).toHaveLength(2)
+  })
+})
+
+// ---- Stats aggregation tests ----
+
+describe('skill_usage stats aggregation', () => {
+  let db: DB
+  const BASE_TS = 1_700_000_000
+
+  beforeEach(() => {
+    db = buildDb()
+    insert(db, { agent_id: 'agent-a', skill_name: 'fleet-helper', trigger_type: 'tool_call', created_at: BASE_TS })
+    insert(db, { agent_id: 'agent-b', skill_name: 'fleet-helper', trigger_type: 'tool_call', created_at: BASE_TS + 10 })
+    insert(db, { agent_id: 'agent-a', skill_name: 'fleet-helper', trigger_type: 'skill_read', created_at: BASE_TS + 20 })
+    insert(db, { agent_id: 'agent-a', skill_name: 'deep-research', trigger_type: 'skill_read', created_at: BASE_TS + 30 })
+  })
+
+  function stats(cutoff = 0) {
+    return db.prepare(`
+      SELECT
+        skill_name,
+        SUM(CASE WHEN trigger_type = 'tool_call' THEN 1 ELSE 0 END) AS call_count,
+        SUM(CASE WHEN trigger_type = 'skill_read' THEN 1 ELSE 0 END) AS read_count,
+        COUNT(*) AS total_count,
+        COUNT(DISTINCT agent_id) AS agent_count,
+        MAX(created_at) AS last_used_at
+      FROM skill_usage
+      WHERE created_at >= ?
+      GROUP BY skill_name
+      ORDER BY total_count DESC
+    `).all(cutoff) as any[]
+  }
+
+  it('aggregates fleet-helper correctly', () => {
+    const rows = stats()
+    const fh = rows.find((r: any) => r.skill_name === 'fleet-helper')
+    expect(fh).toBeDefined()
+    expect(fh.call_count).toBe(2)
+    expect(fh.read_count).toBe(1)
+    expect(fh.total_count).toBe(3)
+    expect(fh.agent_count).toBe(2)
+  })
+
+  it('fleet-helper is ranked first by total_count', () => {
+    const rows = stats()
+    expect(rows[0].skill_name).toBe('fleet-helper')
+  })
+
+  it('respects the cutoff filter in stats', () => {
+    // Rows at BASE_TS+20 (fleet-helper/skill_read) and BASE_TS+30 (deep-research) survive.
+    // Rows at BASE_TS and BASE_TS+10 (both fleet-helper/tool_call) are filtered out.
+    const rows = stats(BASE_TS + 15)
+    const fh = rows.find((r: any) => r.skill_name === 'fleet-helper')
+    expect(fh?.total_count ?? 0).toBe(1)
+    expect(fh?.read_count ?? 0).toBe(1)
+    expect(fh?.call_count ?? 0).toBe(0)
+  })
+
+  it('does not include rows outside the time window', () => {
+    const rows = stats(BASE_TS + 100)
+    expect(rows).toHaveLength(0)
+  })
+})
+
+// ---- No-prune contract ----
+
+describe('skill_usage has no prune mechanism', () => {
+  it('table definition has no expiry column (row stays forever)', () => {
+    const db = buildDb()
+    // If a prune were added it would use a cutoff timestamp column.
+    // Verify the schema lacks any ttl/expires_at/prune-related column.
+    const cols = (db.prepare("PRAGMA table_info(skill_usage)").all() as any[]).map((c: any) => c.name)
+    expect(cols).not.toContain('expires_at')
+    expect(cols).not.toContain('ttl')
+    expect(cols).not.toContain('deleted_at')
+    // Required columns are present
+    expect(cols).toContain('agent_id')
+    expect(cols).toContain('skill_name')
+    expect(cols).toContain('trigger_type')
+    expect(cols).toContain('created_at')
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -600,6 +600,20 @@ export function initDatabase(dbPathOverride?: string): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_session ON tool_call_log(session_id, created_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_ts ON tool_call_log(created_at)`)
 
+  // --- Skill Usage Log (persistent, no prune -- feeds dream-engine skill health) ---
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS skill_usage (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL,
+      skill_name TEXT NOT NULL,
+      trigger_type TEXT NOT NULL CHECK(trigger_type IN ('tool_call', 'skill_read')),
+      session_id TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_skill_usage_agent ON skill_usage(agent_id, created_at)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_skill_usage_skill ON skill_usage(skill_name, created_at)`)
+
   // --- Config Change Log (audit trail for /api/settings writes) ---
   // Background-only: no UI surfaces this table yet (product decision). For
   // secret settings, callers must pass null for old_value/new_value -- this
@@ -2277,6 +2291,73 @@ export function analyzeWorkflowCandidates(sinceSecs = 3600, minToolCalls = 5, ga
 export function pruneToolCallLog(olderThanSecs = 86400): void {
   const cutoff = Math.floor(Date.now() / 1000) - olderThanSecs
   db.prepare('DELETE FROM tool_call_log WHERE created_at < ?').run(cutoff)
+}
+
+// --- Skill Usage Log ---
+
+export interface SkillUsageRow {
+  id: number
+  agent_id: string
+  skill_name: string
+  trigger_type: 'tool_call' | 'skill_read'
+  session_id: string | null
+  created_at: number
+}
+
+export interface SkillUsageStatRow {
+  skill_name: string
+  call_count: number
+  read_count: number
+  total_count: number
+  agent_count: number
+  last_used_at: number
+}
+
+export function logSkillUsage(
+  agentId: string,
+  skillName: string,
+  triggerType: 'tool_call' | 'skill_read',
+  sessionId?: string | null,
+): void {
+  const now = Math.floor(Date.now() / 1000)
+  db.prepare(
+    'INSERT INTO skill_usage (agent_id, skill_name, trigger_type, session_id, created_at) VALUES (?, ?, ?, ?, ?)',
+  ).run(agentId, skillName, triggerType, sessionId ?? null, now)
+}
+
+export function getSkillUsageRows(opts: {
+  since?: number
+  agentId?: string
+  skillName?: string
+  limit?: number
+}): SkillUsageRow[] {
+  const { since, agentId, skillName, limit = 500 } = opts
+  const cutoff = since ? Math.floor(Date.now() / 1000) - since : 0
+  const conditions: string[] = ['created_at >= ?']
+  const params: unknown[] = [cutoff]
+  if (agentId) { conditions.push('agent_id = ?'); params.push(agentId) }
+  if (skillName) { conditions.push('skill_name = ?'); params.push(skillName) }
+  params.push(limit)
+  return db.prepare(
+    `SELECT * FROM skill_usage WHERE ${conditions.join(' AND ')} ORDER BY created_at DESC LIMIT ?`,
+  ).all(...params) as SkillUsageRow[]
+}
+
+export function getSkillUsageStats(sinceSecs?: number): SkillUsageStatRow[] {
+  const cutoff = sinceSecs ? Math.floor(Date.now() / 1000) - sinceSecs : 0
+  return db.prepare(`
+    SELECT
+      skill_name,
+      SUM(CASE WHEN trigger_type = 'tool_call' THEN 1 ELSE 0 END) AS call_count,
+      SUM(CASE WHEN trigger_type = 'skill_read' THEN 1 ELSE 0 END) AS read_count,
+      COUNT(*) AS total_count,
+      COUNT(DISTINCT agent_id) AS agent_count,
+      MAX(created_at) AS last_used_at
+    FROM skill_usage
+    WHERE created_at >= ?
+    GROUP BY skill_name
+    ORDER BY total_count DESC
+  `).all(cutoff) as SkillUsageStatRow[]
 }
 
 // --- Config Change Log ---

--- a/src/web.ts
+++ b/src/web.ts
@@ -55,6 +55,7 @@ import { tryHandleTokenUsage } from './web/routes/token-usage.js'
 import { tryHandleCosts, startCostsSyncTask } from './web/routes/costs.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
+import { tryHandleSkillUsage } from './web/routes/skill-usage.js'
 import { tryHandleSettings } from './web/routes/settings.js'
 import { tryHandleAuditLog } from './web/routes/audit-log.js'
 import { tryHandleFleetQ } from './web/routes/fleet-q.js'
@@ -190,6 +191,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleCosts(routeCtx)) return
       if (await tryHandleIdeas(routeCtx)) return
       if (await tryHandleToolLog(routeCtx)) return
+      if (await tryHandleSkillUsage(routeCtx)) return
       if (await tryHandleSettings(routeCtx)) return
       if (await tryHandleVoice(routeCtx)) return
       if (await tryHandleVaultSshKeys(routeCtx)) return

--- a/src/web/routes/skill-usage.ts
+++ b/src/web/routes/skill-usage.ts
@@ -1,0 +1,48 @@
+import { logSkillUsage, getSkillUsageRows, getSkillUsageStats } from '../../db.js'
+import { readBody, json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+export async function tryHandleSkillUsage(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method, url } = ctx
+
+  // POST /api/skill-usage -- record a skill usage event (from PostToolUse hook)
+  if (path === '/api/skill-usage' && method === 'POST') {
+    const body = await readBody(req)
+    const data = JSON.parse(body.toString()) as {
+      agent_id: string
+      skill_name: string
+      trigger_type: 'tool_call' | 'skill_read'
+      session_id?: string | null
+    }
+    if (!data.agent_id || !data.skill_name || !data.trigger_type) {
+      json(res, { error: 'agent_id, skill_name and trigger_type required' }, 400)
+      return true
+    }
+    if (data.trigger_type !== 'tool_call' && data.trigger_type !== 'skill_read') {
+      json(res, { error: 'trigger_type must be tool_call or skill_read' }, 400)
+      return true
+    }
+    logSkillUsage(data.agent_id, data.skill_name, data.trigger_type, data.session_id)
+    json(res, { ok: true })
+    return true
+  }
+
+  // GET /api/skill-usage/stats -- aggregated counts per skill (for dream-engine health)
+  if (path === '/api/skill-usage/stats' && method === 'GET') {
+    const since = url.searchParams.get('since') ? parseInt(url.searchParams.get('since')!) : undefined
+    json(res, getSkillUsageStats(since))
+    return true
+  }
+
+  // GET /api/skill-usage -- recent usage rows (with optional filters)
+  if (path === '/api/skill-usage' && method === 'GET') {
+    const since = url.searchParams.get('since') ? parseInt(url.searchParams.get('since')!) : undefined
+    const agentId = url.searchParams.get('agent_id') ?? undefined
+    const skillName = url.searchParams.get('skill_name') ?? undefined
+    const limit = url.searchParams.get('limit') ? parseInt(url.searchParams.get('limit')!) : 500
+    json(res, getSkillUsageRows({ since, agentId, skillName, limit }))
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**Problem**

The existing `tool_call_log` table is pruned every 24 hours, registered only in the project-level `.claude/settings.json` (sub-agents produce no entries), and misses the majority of skill usage because progressive disclosure loads a SKILL.md via the `Read` tool rather than the `Skill` tool. The dream-engine has no reliable long-term data to identify which skills are actively used and which are candidates for removal.

**Solution**

1. `skill_usage` table -- persistent SQLite table (id, agent_id, skill_name, trigger_type, session_id, created_at) with no prune. After two weeks of data the dream-engine can make evidence-based removal suggestions.

2. Three API endpoints (src/web/routes/skill-usage.ts):
   - POST /api/skill-usage -- called by the hook
   - GET /api/skill-usage -- filterable list (agent_id, skill_name, since, limit)
   - GET /api/skill-usage/stats -- call_count / read_count / total_count / agent_count / last_used_at per skill, ordered by total_count DESC

3. scripts/hooks/skill-usage-capture.py -- PostToolUse hook registered at the user level (~/.claude/settings.json, matcher ^(Skill|Read)$) so it fires for every fleet agent:
   - tool_name == "Skill" -> trigger_type = tool_call, skill name from tool_input.skill
   - tool_name == "Read" with file_path matching ~/.claude/skills/<name>/SKILL.md -> trigger_type = skill_read
   - Agent identity derived from session cwd (agents/<id> -> <id>, install root -> MAIN_AGENT_ID)
   - All network calls wrapped in try/except -- never blocks the agent

**Hook registration safety**

The hook command uses a guard to silently no-op when the script file is absent (e.g. on develop before merge):

  test -f /path/to/scripts/hooks/skill-usage-capture.py && python3 ... || true

Registration is a post-merge install step. The guard makes it safe to register at any time without causing missing-file errors on every Read call.

## Kapcsolódó issue / Related issue

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben; az ágensek hiba nélkül kommunikálnak. / Tested locally; agents communicate without errors.
- [ ] Frissítettem a docs/ mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated docs/ if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom. / Opened from a descriptively named branch.

## Risk & Rollback

- Additive only: new table, new route, new hook script. No existing table or route modified.
- Hook failure is silent: exits 0 on any exception, never blocks the agent.
- Rollback: remove the PostToolUse entry from ~/.claude/settings.json; skill_usage table and routes are inert without writes.
- No security regression: skill names and file paths are not sensitive; /api/skill-usage is Bearer-token gated like all /api/* endpoints.