### PR TITLE
fix(install): AVX-less hosts -- pin claude 2.1.110 + persistent DISABLE_AUTOUPDATER

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -274,11 +274,12 @@ export PATH="$HOME/.local/bin:$PATH"
 # binary cannot wedge the installer).
 _claude_runs() { command -v claude >/dev/null 2>&1 && timeout 25 claude --version </dev/null >/dev/null 2>&1; }
 
-# Pinned Node-based fallback for AVX-less hosts. @2.0.76 ships bin=cli.js (a
-# `#!/usr/bin/env node` entrypoint) that runs without AVX; npm-latest (2.1.x)
-# still bundles the Bun ELF binary, so DO NOT use latest here. Verified on the
-# AVX-less pilot VPS.
-CLAUDE_PIN="2.0.76"
+# Pinned Node-based fallback for AVX-less hosts. @2.1.110 is the LAST version
+# that ships bin=cli.js (a `#!/usr/bin/env node` entrypoint) running without
+# AVX -- 2.1.120+ bundles only the Bun ELF binary, so DO NOT use latest here.
+# Unlike the old 2.0.76 pin, 2.1.110 also understands `--channels`, which
+# channels.sh requires to boot the bot. Verified on the AVX-less pilot VPS.
+CLAUDE_PIN="2.1.110"
 
 if _claude_runs; then
   ok "claude mar telepitve es fut: $(claude --version 2>/dev/null || echo 'ok')"
@@ -289,6 +290,11 @@ else
   if grep -qE '^flags[[:space:]]*:' /proc/cpuinfo 2>/dev/null && ! grep -qiw avx /proc/cpuinfo 2>/dev/null; then
     warn "A CPU nem tamogatja az AVX-et; a hivatalos installer Bun-binaryja elszallna (SIGILL)."
     echo -e "  ${DIM}Pinnelt Node-verzio telepitese: @${CLAUDE_PIN} (nehany legfrissebb Claude Code fix kimaradhat, de fut AVX nelkul).${NC}"
+    # The auto-updater would replace the pinned Node cli.js with the latest
+    # Bun binary on first run -> SIGILL. Disable it persistently (rc files for
+    # interactive shells; channels.sh exports it for the agent sessions).
+    ensure_in_rc 'DISABLE_AUTOUPDATER' 'export DISABLE_AUTOUPDATER=1'
+    export DISABLE_AUTOUPDATER=1
     if command -v npm >/dev/null 2>&1; then
       npm install -g "@anthropic-ai/claude-code@${CLAUDE_PIN}" || warn "npm install sikertelen (@${CLAUDE_PIN})."
     else

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -153,6 +153,15 @@ export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HO
 # documented sandbox escape hatch. Harmless for non-root (guarded by uid check).
 [ "$(id -u)" = "0" ] && export IS_SANDBOX=1
 
+# AVX-less x86 host: the install pinned a Node-based claude (cli.js entrypoint,
+# see install-linux.sh CLAUDE_PIN) because the Bun standalone binary SIGILLs
+# without AVX. The auto-updater would swap the pin for the latest Bun binary on
+# first run, killing every session -- disable it here so all agent sessions
+# inherit the guard via tmux. No-op on AVX-capable and ARM hosts.
+if grep -qE '^flags[[:space:]]*:' /proc/cpuinfo 2>/dev/null && ! grep -qiw avx /proc/cpuinfo 2>/dev/null; then
+  export DISABLE_AUTOUPDATER=1
+fi
+
 # Disable Claude Code's "Prompt Suggestions" (the grayed-out/DIM suggested command
 # shown in the input box, picked from git history / conversation). For headless
 # agent sessions it is pure noise AND it caused a false-positive incident: the


### PR DESCRIPTION
## Summary

Fixes both AVX findings from the v1.22 pre-promote validation (clean AVX-less x86 VPS):

- **CLAUDE_PIN 2.0.76 -> 2.1.110**: the old pin predates the `--channels` flag, so an AVX-less install could never boot the channel bot. 2.1.110 is the last release shipping the Node `cli.js` entrypoint (2.1.120+ bundles only the Bun ELF binary, which SIGILLs without AVX) and it supports `--channels`.
- **Persistent `DISABLE_AUTOUPDATER=1`**: the AVX branch never disabled the auto-updater, so the first `claude` run replaced the pinned Node build with the latest Bun binary -> SIGILL. Now persisted via rc files at install time, and `channels.sh` exports it gated on the same `/proc/cpuinfo` AVX pre-flight so every agent session inherits it via tmux.

Both changes are no-ops on AVX-capable x86 and ARM hosts (the pre-flight gate takes the official-installer path there, and the channels.sh export never fires).

## Testing

- `bash -n` on both scripts.
- The 2.1.110 pin + `DISABLE_AUTOUPDATER` combination was validated end-to-end manually on the AVX-less pilot VPS: fresh develop install, session up, `claude --channels` accepted, plugin connects, config-dir scoping works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)