### PR TITLE
fix(rename): honor SERVICE_ID/MAIN_AGENT_ID for progress-watchdog unit + worker session

### DIFF
--- a/scripts/install-telegram-progress-hook.sh
+++ b/scripts/install-telegram-progress-hook.sh
@@ -31,6 +31,20 @@ SRC_DIR="$(cd "$(dirname "$0")" && pwd)/hooks"
 DEST_DIR="$HOME/.claude/hooks"
 SETTINGS="$HOME/.claude/settings.json"
 
+# The watchdog unit/label name keys off SERVICE_ID, matching install-linux.sh's
+# ${SERVICE_ID}-dashboard/-channels units and the macOS com.${SERVICE_ID}.*
+# launchd labels. Derive it from the install .env so a renamed install
+# (BOT_NAME != Marveen) does NOT get an orphaned marveen-* unit left behind.
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -f "$INSTALL_DIR/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$INSTALL_DIR/.env"
+  set +a
+fi
+SERVICE_ID="${SERVICE_ID:-${MAIN_AGENT_ID:-marveen}}"
+BOT_NAME="${BOT_NAME:-Marveen}"
+
 SUBMIT_HOOK="$DEST_DIR/telegram_progress.py"
 STOP_HOOK="$DEST_DIR/telegram_progress_clear.py"
 REPLY_HOOK="$DEST_DIR/telegram_progress_reply_clear.py"
@@ -137,7 +151,7 @@ PYEOF
 OS="$(uname -s)"
 if [ "$OS" = "Darwin" ]; then
   PLIST_DIR="$HOME/Library/LaunchAgents"
-  LABEL="com.marveen.telegram-progress-watchdog"
+  LABEL="com.${SERVICE_ID}.telegram-progress-watchdog"
   PLIST="$PLIST_DIR/$LABEL.plist"
   LOG="$HOME/.claude/channels/telegram-progress-watchdog.log"
   mkdir -p "$PLIST_DIR" "$HOME/.claude/channels"
@@ -176,11 +190,11 @@ PLISTEOF
 else
   # Linux: systemd user service + timer
   UNIT_DIR="$HOME/.config/systemd/user"
-  SVC="marveen-telegram-progress-watchdog"
+  SVC="${SERVICE_ID}-telegram-progress-watchdog"
   mkdir -p "$UNIT_DIR"
   cat > "$UNIT_DIR/$SVC.service" <<UNITEOF
 [Unit]
-Description=Marveen Telegram progress-indicator watchdog (sentry)
+Description=${BOT_NAME} Telegram progress-indicator watchdog (sentry)
 
 [Service]
 Type=oneshot

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -5,7 +5,7 @@ import { homedir, userInfo } from 'node:os'
 import { createHash } from 'node:crypto'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
-import { PROJECT_ROOT } from '../config.js'
+import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
 import {
   capturePane,
   isSessionReadyForPrompt,
@@ -40,7 +40,10 @@ import { notifyChannel } from '../notify.js'
 
 const TMUX = resolveFromPath('tmux')
 
-const WORKER_SESSION = process.env.MARVEEN_WORKER_SESSION || 'marveen-worker'
+// Session name keys off MAIN_AGENT_ID so notify.sh's "${MAIN_AGENT_ID}-worker"
+// branch matches on renamed installs (BOT_NAME != Marveen). Default installs are
+// unchanged: MAIN_AGENT_ID falls back to 'marveen' -> 'marveen-worker' as before.
+const WORKER_SESSION = process.env.MARVEEN_WORKER_SESSION || `${MAIN_AGENT_ID}-worker`
 // MUST be OUTSIDE PROJECT_ROOT so Claude Code's upward CLAUDE.md discovery never
 // finds Marveen's persona CLAUDE.md -- one-shot generations (scaffold CLAUDE.md/
 // SOUL.md for a NEW agent, memory digests) must be UNTINTED. The caller prompt


### PR DESCRIPTION
## Problem

On a **renamed install** (`BOT_NAME` != `Marveen`) two names stayed hardcoded to `marveen`, so they never matched the rest of the install. Found while auditing a live Linux install where `BOT_NAME=bigme`: every unit was `bigme-*` except one stray `marveen-telegram-progress-watchdog`, and the background worker ran as `marveen-worker` while `notify.sh` looked for `bigme-worker`.

### 1. Orphaned progress-watchdog unit
`scripts/install-telegram-progress-hook.sh` hardcoded the systemd unit / launchd label as `marveen-telegram-progress-watchdog` / `com.marveen.telegram-progress-watchdog`, whereas `install-linux.sh` names every other unit `${SERVICE_ID}-*` (`${SERVICE_ID}-dashboard`, `-channels`, ...). On a renamed install this leaves exactly one orphaned `marveen-*` unit that `migrate-main-agent-id.sh` also does not rename (its service-rename branch is macOS-only).

Fix: derive the name from `SERVICE_ID` (sourced from the install `.env`, same slug `install-linux.sh` uses), and take the unit `Description` from `BOT_NAME`.

### 2. Worker session vs notify.sh mismatch
`src/web/agent-worker.ts` defaulted `WORKER_SESSION` to `'marveen-worker'`, but `scripts/notify.sh` attributes the sender via the `"${MAIN_AGENT_ID}-worker"` case branch. On any renamed install the worker session never matched that branch, so worker-originated notifications lost their `SENDER` attribution.

Fix: default to `` `${MAIN_AGENT_ID}-worker` ``.

## Backward compatibility
Default installs are **unchanged**: `MAIN_AGENT_ID` / `SERVICE_ID` fall back to `marveen`, producing the exact previous names (`marveen-worker`, `marveen-telegram-progress-watchdog`). The `MARVEEN_WORKER_SESSION` / `MARVEEN_WORKER_DIR` env overrides still win. `WORKER_DIR` default (`~/.marveen-worker`) is intentionally left alone — renaming it would churn existing worker homes and the keychain-service test.

## Validation
- `bash -n scripts/install-telegram-progress-hook.sh` — parses
- Derivation dry-run: renamed → `bigme-telegram-progress-watchdog`; default (unset) → `marveen-telegram-progress-watchdog`
- `tsc --noEmit` — clean
- No test references the worker **session** name (only `WORKER_DIR`, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)