### PR TITLE
fix(channel-monitor): stop the watchdog killing working agents on a false plugin-down

### DIFF
--- a/src/__tests__/channel-watchdog-busy-guard.test.ts
+++ b/src/__tests__/channel-watchdog-busy-guard.test.ts
@@ -1,0 +1,141 @@
+// Regression tests for the 2026-07-14 incident: the channel-plugin watchdog
+// hard-restarted (FRESH session, context destroyed) any agent whose plugin read
+// "down" on a SINGLE probe sample -- including agents that were mid-task, and
+// including one whose plugin reported healthy a minute later without ever having
+// been restarted. Ten such kills in one day; hours of in-flight work lost.
+//
+// The guards under test: a confirmation window (a lone down sample is not a
+// verdict), and a busy-guard (never kill work in flight; escalate instead).
+import { describe, it, expect } from 'vitest'
+import { decideDownAgentAction } from '../web/agent-restart-policy.js'
+
+const STARTUP = 180_000
+const RESTART = 90_000
+const CONFIRM = 150_000
+const BUSY_CAP = 30 * 60_000
+const MAX_ATTEMPTS = 5
+
+// An agent well past every grace: without the new guards this always restarts.
+const restartable = {
+  processAgeMs: 60 * 60_000,
+  msSinceLastRestart: null,
+  startupGraceMs: STARTUP,
+  restartGraceMs: RESTART,
+  consecutiveFailures: 0,
+}
+
+describe('down-confirmation window', () => {
+  it('does NOT restart on the first down sample (the 19:33 false positive)', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      msDown: 0,
+      downConfirmMs: CONFIRM,
+    }, MAX_ATTEMPTS)).toBe('skip')
+  })
+
+  it('does NOT restart while the down-spell is shorter than the confirm window', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      msDown: 60_000,
+      downConfirmMs: CONFIRM,
+    }, MAX_ATTEMPTS)).toBe('skip')
+  })
+
+  it('restarts once the down-spell is confirmed across sweeps', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      msDown: CONFIRM,
+      downConfirmMs: CONFIRM,
+    }, MAX_ATTEMPTS)).toBe('restart')
+  })
+
+  it('keeps the legacy single-sample behaviour when no window is configured', () => {
+    expect(decideDownAgentAction({ ...restartable }, MAX_ATTEMPTS)).toBe('restart')
+  })
+})
+
+describe('busy-guard', () => {
+  it('defers the restart while the agent is generating', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      msDown: 10 * 60_000,
+      downConfirmMs: CONFIRM,
+      agentBusy: true,
+      busyDeferMaxMs: BUSY_CAP,
+    }, MAX_ATTEMPTS)).toBe('skip')
+  })
+
+  it('restarts a confirmed-down agent that is idle', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      msDown: 10 * 60_000,
+      downConfirmMs: CONFIRM,
+      agentBusy: false,
+      busyDeferMaxMs: BUSY_CAP,
+    }, MAX_ATTEMPTS)).toBe('restart')
+  })
+
+  it('escalates to the operator instead of killing a still-busy agent past the cap', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      msDown: BUSY_CAP,
+      downConfirmMs: CONFIRM,
+      agentBusy: true,
+      busyDeferMaxMs: BUSY_CAP,
+    }, MAX_ATTEMPTS)).toBe('alert-busy')
+  })
+
+  it('defers indefinitely while busy when no cap is configured', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      msDown: 10 * 60 * 60_000,
+      downConfirmMs: CONFIRM,
+      agentBusy: true,
+    }, MAX_ATTEMPTS)).toBe('skip')
+  })
+
+  it('never restarts a busy agent that is still inside the confirm window', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      msDown: 1_000,
+      downConfirmMs: CONFIRM,
+      agentBusy: true,
+      busyDeferMaxMs: BUSY_CAP,
+    }, MAX_ATTEMPTS)).toBe('skip')
+  })
+})
+
+describe('guard interaction with the existing failure cap', () => {
+  it('still alerts at the restart cap, even for a busy agent (cap wins)', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      consecutiveFailures: MAX_ATTEMPTS,
+      msDown: 60 * 60_000,
+      downConfirmMs: CONFIRM,
+      agentBusy: true,
+      busyDeferMaxMs: BUSY_CAP,
+    }, MAX_ATTEMPTS)).toBe('alert')
+  })
+
+  it('still honours the startup grace under the new guards', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      processAgeMs: 20_000,
+      msDown: 60 * 60_000,
+      downConfirmMs: CONFIRM,
+      agentBusy: false,
+      busyDeferMaxMs: BUSY_CAP,
+    }, MAX_ATTEMPTS)).toBe('skip')
+  })
+
+  it('still honours the restart back-off under the new guards', () => {
+    expect(decideDownAgentAction({
+      ...restartable,
+      msSinceLastRestart: 30_000,
+      msDown: 60 * 60_000,
+      downConfirmMs: CONFIRM,
+      agentBusy: false,
+      busyDeferMaxMs: BUSY_CAP,
+    }, MAX_ATTEMPTS)).toBe('skip')
+  })
+})

--- a/src/__tests__/poller-evidence.test.ts
+++ b/src/__tests__/poller-evidence.test.ts
@@ -1,0 +1,65 @@
+// The watchdog's "channel plugin down" verdict destroyed its own evidence: the
+// restart reaps the poller and respawns the session, so a post-mortem can never
+// tell whether the plugin died or the liveness probe merely lost a live one.
+// buildPollerEvidence is the snapshot taken at the moment the verdict forms.
+import { describe, it, expect } from 'vitest'
+import { buildPollerEvidence, type ProcRow } from '../web/channel-poller-reap.js'
+
+const CLAUDE = 100
+
+// claude(100) -> bun run wrapper(200) -> bun server.ts(300): the healthy shape.
+const healthyTree: ProcRow[] = [
+  { pid: CLAUDE, ppid: 1, command: 'claude --channels plugin:telegram' },
+  { pid: 200, ppid: CLAUDE, command: 'bun run --cwd /plugins/telegram start' },
+  { pid: 300, ppid: 200, command: 'bun server.ts' },
+]
+
+describe('buildPollerEvidence', () => {
+  it('reads a live in-tree poller as the PROBE being wrong, not the plugin', () => {
+    const e = buildPollerEvidence(healthyTree, 300, [200, 300], CLAUDE)
+    expect(e.interpretation).toBe('in-tree')
+    expect(e.botPidAlive).toBe(true)
+    expect(e.rows.find((r) => r.pid === 300)?.inClaudeTree).toBe(true)
+  })
+
+  it('reads a live poller outside the tree as orphaned (reparented / previous claude)', () => {
+    const procs: ProcRow[] = [
+      { pid: CLAUDE, ppid: 1, command: 'claude --channels plugin:telegram' },
+      // Reparented to init: its ancestor chain never reaches claude.
+      { pid: 300, ppid: 1, command: 'bun server.ts' },
+    ]
+    const e = buildPollerEvidence(procs, null, [300], CLAUDE)
+    expect(e.interpretation).toBe('orphaned')
+    expect(e.rows).toEqual([{ pid: 300, ppid: 1, inClaudeTree: false }])
+  })
+
+  it('reads no live poller as the plugin genuinely having exited', () => {
+    const procs: ProcRow[] = [{ pid: CLAUDE, ppid: 1, command: 'claude --channels plugin:telegram' }]
+    // bot.pid still names a pid, but that pid is not in the ps snapshot.
+    const e = buildPollerEvidence(procs, 300, [], CLAUDE)
+    expect(e.interpretation).toBe('no-poller')
+    expect(e.botPid).toBe(300)
+    expect(e.botPidAlive).toBe(false)
+    expect(e.rows).toEqual([])
+  })
+
+  it('counts a poller reached through the wrapper as in-tree (grandchild, not child)', () => {
+    const e = buildPollerEvidence(healthyTree, null, [300], CLAUDE)
+    expect(e.rows).toEqual([{ pid: 300, ppid: 200, inClaudeTree: true }])
+    expect(e.interpretation).toBe('in-tree')
+  })
+
+  it('merges the bot.pid candidate with the env-scan candidates without duplicating', () => {
+    const e = buildPollerEvidence(healthyTree, 300, [300], CLAUDE)
+    expect(e.rows.map((r) => r.pid)).toEqual([300])
+  })
+
+  it('does not hang on a parent cycle in the ps snapshot', () => {
+    const procs: ProcRow[] = [
+      { pid: 300, ppid: 301, command: 'bun server.ts' },
+      { pid: 301, ppid: 300, command: 'weird' },
+    ]
+    const e = buildPollerEvidence(procs, null, [300], CLAUDE)
+    expect(e.interpretation).toBe('orphaned')
+  })
+})

--- a/src/channel-coordinator/liveness.ts
+++ b/src/channel-coordinator/liveness.ts
@@ -129,9 +129,26 @@ export function decideHasPluginAlive(ctx: PluginAliveContext): boolean {
   return false
 }
 
-export function hasChannelPluginAlive(claudePid: number, providerType: ChannelProviderType, agentName?: string): boolean {
+// Tri-state liveness verdict. 'unknown' means the PROBE failed (ps timed out on
+// a loaded box, the state dir was unreadable, ...) -- not that the plugin is
+// down. Collapsing that into 'down' let a hiccup in the monitor's own probe
+// hard-restart a healthy agent and destroy its session context, so the caller
+// must treat 'unknown' as "no information" and leave the agent alone.
+export type PluginLiveness = 'alive' | 'down' | 'unknown'
+
+export function probeChannelPluginLiveness(
+  claudePid: number,
+  providerType: ChannelProviderType,
+  agentName?: string,
+): PluginLiveness {
+  let psOutput: string
   try {
-    const psOutput = execFileSync('/bin/ps', ['-axo', 'pid,ppid,command'], { timeout: 3000, encoding: 'utf-8' })
+    psOutput = execFileSync('/bin/ps', ['-axo', 'pid,ppid,command'], { timeout: 3000, encoding: 'utf-8' })
+  } catch (err) {
+    logger.warn({ err, claudePid, agentName, providerType }, 'Channel-plugin liveness probe failed (ps) -- verdict unknown, not restarting')
+    return 'unknown'
+  }
+  try {
     const stateDir = agentName
       ? channelStateDir(providerType, agentDir(agentName))
       : channelStateDir(providerType)
@@ -141,7 +158,7 @@ export function hasChannelPluginAlive(claudePid: number, providerType: ChannelPr
       const parsed = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10)
       if (Number.isFinite(parsed)) botPid = parsed
     }
-    return decideHasPluginAlive({
+    const alive = decideHasPluginAlive({
       psOutput,
       claudePid,
       providerType,
@@ -152,9 +169,19 @@ export function hasChannelPluginAlive(claudePid: number, providerType: ChannelPr
       },
       debugLog: (event, fields) => logger.debug(fields, event),
     })
-  } catch {
-    return false
+    return alive ? 'alive' : 'down'
+  } catch (err) {
+    logger.warn({ err, claudePid, agentName, providerType }, 'Channel-plugin liveness probe failed (state dir) -- verdict unknown, not restarting')
+    return 'unknown'
   }
+}
+
+// Boolean view for callers that only act on a positive verdict (a failed probe
+// and a genuinely absent plugin are both "not alive" to them). Anything that
+// RESTARTS on the negative answer must use probeChannelPluginLiveness instead,
+// so it can distinguish 'down' from 'unknown'.
+export function hasChannelPluginAlive(claudePid: number, providerType: ChannelProviderType, agentName?: string): boolean {
+  return probeChannelPluginLiveness(claudePid, providerType, agentName) === 'alive'
 }
 
 // --- coordinator-side decision layer ---

--- a/src/channel-coordinator/liveness.ts
+++ b/src/channel-coordinator/liveness.ts
@@ -143,7 +143,19 @@ export function probeChannelPluginLiveness(
 ): PluginLiveness {
   let psOutput: string
   try {
-    psOutput = execFileSync('/bin/ps', ['-axo', 'pid,ppid,command'], { timeout: 3000, encoding: 'utf-8' })
+    // Parity with the reaper's snapshotProcs: `-ww` (never truncate a command,
+    // the poller match lives deep in a long path), an 8MB buffer (the default
+    // 1MB is only ~3x the measured fleet-wide ps output, and blowing it makes
+    // execFileSync THROW) and a 5s timeout. A probe that throws is a probe that
+    // knows nothing -- and knowing nothing used to mean "restart the agent".
+    // Keep the HEADER form (`-o pid,ppid,command`, not `-o pid=,...`):
+    // decideHasPluginAlive drops the first line as the header, so a headerless
+    // output would silently lose the first process row.
+    psOutput = execFileSync('/bin/ps', ['-axww', '-o', 'pid,ppid,command'], {
+      timeout: 5000,
+      encoding: 'utf-8',
+      maxBuffer: 8 * 1024 * 1024,
+    })
   } catch (err) {
     logger.warn({ err, claudePid, agentName, providerType }, 'Channel-plugin liveness probe failed (ps) -- verdict unknown, not restarting')
     return 'unknown'

--- a/src/web/agent-restart-policy.ts
+++ b/src/web/agent-restart-policy.ts
@@ -37,6 +37,27 @@ export interface AgentRestartDecisionInput {
   // long-down plugin occasionally (it may recover after an external fix) rather
   // than backing off unboundedly. Omitted = no cap beyond the exponent.
   maxRestartGraceMs?: number
+  // How long the plugin has been CONTINUOUSLY observed down in this spell, in
+  // milliseconds (0 on the first down sweep). A single down observation is not
+  // proof: the probe walks a process tree and can miss a poller that is mid-
+  // respawn, and a loaded machine can time the ps call out. Observed 2026-07-14:
+  // a down verdict at 19:33 whose restart FAILED, yet the plugin reported healthy
+  // again at 19:34 -- it was never dead. Restarting on one sample cost agents
+  // their whole session context ~10x that day. Omitted = no confirmation window
+  // (legacy single-sample behaviour).
+  msDown?: number
+  // A down-spell must last at least this long before any restart, so a transient
+  // miss heals on the next sweep instead of nuking the agent. Omitted = 0.
+  downConfirmMs?: number
+  // True when the agent's pane is actively generating (busy/typing). Restarting
+  // then throws away in-flight work, and the agent CAN still work with a down
+  // channel -- it just cannot receive messages. Defer to the idle window.
+  agentBusy?: boolean
+  // Cap on busy-deferral. A permanently busy agent with a dead channel is deaf,
+  // which is the failure mode the watchdog exists to prevent, so past this the
+  // decision escalates to the operator ('alert-busy') rather than deferring for
+  // ever OR killing the work. Omitted = defer indefinitely while busy.
+  busyDeferMaxMs?: number
 }
 
 // The restart grace after applying exponential back-off for repeated failed
@@ -76,7 +97,7 @@ export function shouldAutoRestartDownAgent(input: AgentRestartDecisionInput): bo
   return true
 }
 
-export type DownAgentAction = 'restart' | 'alert' | 'skip'
+export type DownAgentAction = 'restart' | 'alert' | 'alert-busy' | 'skip'
 
 // Hard cap on consecutive watchdog restarts that never bring the plugin back
 // up. The exponential back-off above only SLOWS the churn; on its own a plugin
@@ -100,6 +121,10 @@ export const AGENT_MAX_RESTART_ATTEMPTS = 5
 // acts on 'alert', so subsequent ticks fall through to 'skip' and the alert
 // fires exactly once per down-spell (the counter is reset when the plugin
 // recovers, re-arming the alert for any future spell).
+// 'alert-busy' is the same escalation for a different cause: the plugin stayed
+// down past the busy-deferral cap while the agent kept working, so the watchdog
+// refuses to choose between killing live work and leaving the agent deaf, and
+// asks the operator instead.
 export function decideDownAgentAction(
   input: AgentRestartDecisionInput,
   maxRestartAttempts: number,
@@ -110,7 +135,19 @@ export function decideDownAgentAction(
   if (maxRestartAttempts > 0 && failures >= maxRestartAttempts) {
     return failures === maxRestartAttempts ? 'alert' : 'skip'
   }
-  return shouldAutoRestartDownAgent(input) ? 'restart' : 'skip'
+  // Confirmation window: one down sample is a suspicion, not a verdict.
+  const msDown = Number.isFinite(input.msDown) ? (input.msDown as number) : 0
+  const downConfirmMs = Number.isFinite(input.downConfirmMs) ? (input.downConfirmMs as number) : 0
+  if (msDown < downConfirmMs) return 'skip'
+  if (!shouldAutoRestartDownAgent(input)) return 'skip'
+  // Busy-guard: the restart is a FRESH session, so it destroys whatever the
+  // agent is generating right now. Wait for idle; escalate if that never comes.
+  if (input.agentBusy) {
+    const cap = input.busyDeferMaxMs
+    if (cap != null && Number.isFinite(cap) && msDown >= cap) return 'alert-busy'
+    return 'skip'
+  }
+  return 'restart'
 }
 
 // Parse the elapsed-time string from `ps -o etime=` into seconds.

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -40,7 +40,7 @@ import { readLastIngestionTimestamp, TRANSCRIPT_DIR } from './inbound-probe.js'
 import { decideDownAgentAction, AGENT_MAX_RESTART_ATTEMPTS, parseEtimeToSeconds } from './agent-restart-policy.js'
 // getClaudePidForSession + hasChannelPluginAlive live in the shared liveness
 // module so the standalone channel-coordinator reuses the exact same probe.
-import { getClaudePidForSession, hasChannelPluginAlive } from '../channel-coordinator/liveness.js'
+import { getClaudePidForSession, hasChannelPluginAlive, probeChannelPluginLiveness } from '../channel-coordinator/liveness.js'
 import { getDesiredAgents } from './agent-desired-state.js'
 
 const TMUX = resolveFromPath('tmux')
@@ -72,6 +72,10 @@ function resolveAgentProvider(name: string): ChannelProviderType {
 
 const agentDownSince: Map<string, number> = new Map()
 const agentLastRestart: Map<string, number> = new Map()
+// Sessions whose busy-deferral cap has already been reported to the operator, so
+// the alert fires once per down-spell instead of every sweep. Cleared when the
+// plugin recovers (or when the agent is restarted after it goes idle).
+const agentBusyDeferAlerted: Set<string> = new Set()
 // Consecutive watchdog restarts (keyed by agent name) that did NOT bring the
 // plugin back up. Drives exponential back-off so a plugin that crashes on every
 // launch (e.g. a broken third-party channel plugin) is not restarted on a fixed
@@ -137,6 +141,20 @@ const AGENT_MAX_RESTART_GRACE_MS = 60 * 60 * 1000 // 1h
 // the plugin only after a slow session load). Never restart a process younger
 // than this on a "plugin down" reading, or the watchdog crash-loops it.
 const AGENT_STARTUP_GRACE_MS = 180_000
+// A single "down" sample is a suspicion, not a verdict: the probe walks a
+// process tree and can miss a poller that is mid-respawn, and ps can time out
+// on a loaded box. The sweep runs every 60s, so requiring the down-spell to
+// persist this long means at least two consecutive down observations before any
+// restart. Measured cost of the old single-sample rule (2026-07-14): 10 agent
+// hard-restarts in one day, one of them on a plugin that reported healthy again
+// a minute later without ever being restarted -- it was never down.
+const AGENT_DOWN_CONFIRM_MS = 150_000
+// A restart is a FRESH session: it destroys the work in flight. While the agent
+// is actively generating, defer -- a down channel does not stop it working, it
+// only stops it hearing. But a permanently busy agent with a dead channel is
+// deaf, which is exactly what the watchdog exists to catch, so past this cap the
+// watchdog stops choosing and asks the operator.
+const AGENT_BUSY_DEFER_MAX_MS = 30 * 60 * 1000 // 30m
 // When the unlock probe has confirmed the plugin ABSENT from /mcp (never
 // loaded, not merely Failed/disabled), a fresh restart cannot bring it back --
 // it comes up absent again, and each restart wipes the agent's session context
@@ -1328,8 +1346,16 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         }
         continue
       }
-      const alive = hasChannelPluginAlive(claudePid, t.provider, t.agentName)
-      if (alive) {
+      const liveness = probeChannelPluginLiveness(claudePid, t.provider, t.agentName)
+      if (liveness === 'unknown') {
+        // The PROBE failed (ps timed out, state dir unreadable) -- that is not
+        // evidence about the plugin. Leave every counter untouched (down-since,
+        // failure budget, main escalation) and re-probe on the next sweep, so a
+        // hiccup in our own monitoring can never hard-restart a healthy agent.
+        logger.debug({ session: t.session, provider: t.provider }, 'Channel-plugin liveness unknown (probe failed) -- no action this sweep')
+        continue
+      }
+      if (liveness === 'alive') {
         if (t.isMarveen) {
           handleMarveenUp()
           // Process-alive does NOT prove the inbound MCP pipe is healthy (the
@@ -1344,6 +1370,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // down-spell starts again at the base grace.
           agentRestartFailures.delete(t.agentName!)
           clearPersistedAgentFailures(t.agentName!)
+          agentBusyDeferAlerted.delete(t.session)
           // Retire any stale absent verdict too, so a future down-spell starts
           // with the full restart budget rather than the absent-capped one.
           clearPluginAbsent(t.session)
@@ -1365,6 +1392,13 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         const maxRestartAttempts = absentConfirmed
           ? PLUGIN_ABSENT_MAX_RESTART_ATTEMPTS
           : AGENT_MAX_RESTART_ATTEMPTS
+        const msDown = Date.now() - (agentDownSince.get(t.session) ?? Date.now())
+        // Busy-guard input: a pane that is generating must not be hard-restarted
+        // out from under its own work. An unreadable pane reads 'unknown', which
+        // is NOT busy -- we only defer on positive evidence of work in flight.
+        const agentPane = capturePane(t.session)
+        const agentPaneState = agentPane != null ? detectPaneState(agentPane) : null
+        const agentBusy = shouldDeferKeepaliveRespawn(agentPaneState)
         const action = decideDownAgentAction({
           processAgeMs: getProcessAgeMs(claudePid),
           msSinceLastRestart: lastRestart != null ? Date.now() - lastRestart : null,
@@ -1372,9 +1406,29 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           restartGraceMs: AGENT_RESTART_GRACE_MS,
           consecutiveFailures: failures,
           maxRestartGraceMs: AGENT_MAX_RESTART_GRACE_MS,
+          msDown,
+          downConfirmMs: AGENT_DOWN_CONFIRM_MS,
+          agentBusy,
+          busyDeferMaxMs: AGENT_BUSY_DEFER_MAX_MS,
         }, maxRestartAttempts)
+        if (action === 'alert-busy') {
+          // The channel has been down past the deferral cap while the agent kept
+          // working. Killing it would destroy live work; deferring further would
+          // leave it deaf. Ask the operator once, then keep deferring.
+          if (!agentBusyDeferAlerted.has(t.session)) {
+            logger.error({ agent: t.agentName, provider: t.provider, msDown }, 'Agent channel plugin down past busy-defer cap -- agent still working, alerting operator instead of killing it')
+            sendAlert(`⚠️ A(z) ${t.agentName} agens ${t.provider} csatornaja ${Math.round(msDown / 60000)} perce halott, de az agens KOZBEN DOLGOZIK. Nem inditom ujra (a restart FRISS session -- elveszne a folyamatban levo munkaja). Dontsd el: varjuk meg amig vegez (akkor magatol ujraindul), vagy kezzel allitsd meg. Session: ${t.session}.`)
+            agentBusyDeferAlerted.add(t.session)
+          }
+          continue
+        }
         if (action === 'skip') {
-          logger.debug({ agent: t.agentName, provider: t.provider, failures }, 'Channel plugin probe reports down but agent is within startup/restart back-off -- deferring')
+          logger.debug({ agent: t.agentName, provider: t.provider, failures, msDown, agentBusy, paneState: agentPaneState },
+            agentBusy
+              ? 'Channel plugin down but agent is BUSY -- deferring restart until it goes idle (never kill work in flight)'
+              : msDown < AGENT_DOWN_CONFIRM_MS
+                ? 'Channel plugin reported down once -- awaiting confirmation on the next sweep before restarting'
+                : 'Channel plugin probe reports down but agent is within startup/restart back-off -- deferring')
           continue
         }
         if (action === 'alert') {
@@ -1390,6 +1444,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           agentRestartFailures.set(t.agentName!, failures + 1)
           savePersistedAgentFailures(t.agentName!, failures + 1)
           agentDownSince.delete(t.session)
+          agentBusyDeferAlerted.delete(t.session)
           continue
         }
         const agentProvider = resolveAgentProvider(t.agentName!)
@@ -1425,6 +1480,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           startAgentProcess(t.agentName!, { fresh: true })
           agentLastRestart.set(t.agentName!, Date.now())
           agentDownSince.delete(t.session)
+          agentBusyDeferAlerted.delete(t.session)
           // Count this restart as failed until a later sweep sees the plugin
           // alive (which resets the counter). Repeated failures back off the
           // next restart exponentially instead of churning every base-grace.

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -21,7 +21,7 @@ import {
   ensureMainAgentIsolatedConfigDir,
   FLEET_OAUTH_TOKEN_PATH,
 } from './agent-process.js'
-import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
+import { reapChannelOrphans, reapDetachedChannelClaudes, collectPollerEvidence } from './channel-poller-reap.js'
 import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { schedulePluginUnlockAfterRespawn, wasPluginConfirmedAbsent, clearPluginAbsent } from './channel-plugin-unlock.js'
 import {
@@ -1380,7 +1380,24 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
       if (t.isMarveen) {
         if (shouldEscalateMarveenDown()) handleMarveenDown()
       } else {
-        if (!agentDownSince.has(t.session)) agentDownSince.set(t.session, Date.now())
+        if (!agentDownSince.has(t.session)) {
+          agentDownSince.set(t.session, Date.now())
+          // First down observation of this spell: capture WHY before anything is
+          // torn down. Without this the restart destroys the evidence and the
+          // log can only say "down" -- which is exactly why the 10x/day churn
+          // went undiagnosed. Once per spell, not per sweep.
+          try {
+            const evidence = collectPollerEvidence(t.provider, agentDir(t.agentName!), claudePid)
+            logger.warn({ agent: t.agentName, provider: t.provider, claudePid, ...evidence },
+              evidence.interpretation === 'in-tree'
+                ? 'Plugin-down FORENSICS: a live poller IS in the claude tree -- the liveness probe is wrong, not the plugin'
+                : evidence.interpretation === 'orphaned'
+                  ? 'Plugin-down FORENSICS: a live poller exists but is OUTSIDE the claude tree (reparented / left over from a previous claude)'
+                  : 'Plugin-down FORENSICS: no poller process alive for this channel dir -- the plugin really did exit')
+          } catch (err) {
+            logger.warn({ err, agent: t.agentName }, 'Plugin-down forensics failed (continuing)')
+          }
+        }
         const lastRestart = agentLastRestart.get(t.agentName!)
         const failures = agentRestartFailures.get(t.agentName!) ?? 0
         // If the unlock probe confirmed the plugin ABSENT from /mcp (never

--- a/src/web/channel-poller-reap.ts
+++ b/src/web/channel-poller-reap.ts
@@ -89,6 +89,107 @@ export interface ReapResult {
   source: { fromBotPid: number | null; fromEnvScan: number[] }
 }
 
+// ---------------------------------------------------------------------------
+// Down-verdict forensics (2026-07-14).
+//
+// The watchdog restarted agents ~10x/day on a "channel plugin down" verdict,
+// and the restart DESTROYS the evidence: the poller is reaped, the session is
+// respawned, and the post-mortem log says only "down -- auto-restarting". So
+// the interesting question -- did the poller really die, or did the tree-walk
+// lose a live one? -- could not be answered from the logs at all.
+//
+// This captures the state at the MOMENT the verdict is formed, before anything
+// is torn down: is a poller process for this chanDir alive at all, is it in the
+// claude process tree, and does bot.pid still point at it. One WARN per
+// down-spell, so it costs a ps per spell, not per sweep.
+
+export interface PollerEvidenceRow {
+  pid: number
+  ppid: number
+  // Whether claudePid is an ancestor of this pid. FALSE with a live pid is the
+  // interesting case: the poller exists but hangs outside the tree the liveness
+  // probe walks (reparented / attached to a previous claude).
+  inClaudeTree: boolean
+}
+
+export interface PollerEvidence {
+  botPid: number | null
+  botPidAlive: boolean
+  // Pollers found by env-var scan, i.e. every process started against this
+  // channel state dir regardless of parentage.
+  envScanPids: number[]
+  rows: PollerEvidenceRow[]
+  // The verdict this evidence supports, spelled out so the log line is readable
+  // without re-deriving it:
+  //   'no-poller'      -> nothing alive: the plugin really did die.
+  //   'orphaned'       -> a live poller exists but is NOT under claude.
+  //   'in-tree'        -> a live poller IS under claude: the probe was WRONG.
+  interpretation: 'no-poller' | 'orphaned' | 'in-tree'
+}
+
+// Pure core: exported for tests (no ps, no fs).
+export function buildPollerEvidence(
+  procs: ProcRow[],
+  botPid: number | null,
+  envScanPids: number[],
+  claudePid: number,
+): PollerEvidence {
+  const byPid = new Map<number, ProcRow>()
+  for (const p of procs) byPid.set(p.pid, p)
+
+  const isUnderClaude = (pid: number): boolean => {
+    let cur = pid
+    const seen = new Set<number>()
+    for (let hops = 0; hops < 8; hops++) {
+      if (cur === claudePid) return true
+      if (seen.has(cur)) break
+      seen.add(cur)
+      const next = byPid.get(cur)?.ppid
+      if (next === undefined || next === cur || next <= 1) break
+      cur = next
+    }
+    return false
+  }
+
+  const candidates = new Set<number>(envScanPids)
+  if (botPid != null) candidates.add(botPid)
+
+  const rows: PollerEvidenceRow[] = []
+  for (const pid of candidates) {
+    const row = byPid.get(pid)
+    if (!row) continue // not in the ps snapshot -> dead
+    rows.push({ pid, ppid: row.ppid, inClaudeTree: isUnderClaude(pid) })
+  }
+
+  const interpretation: PollerEvidence['interpretation'] = rows.length === 0
+    ? 'no-poller'
+    : rows.some((r) => r.inClaudeTree) ? 'in-tree' : 'orphaned'
+
+  return {
+    botPid,
+    botPidAlive: botPid != null && byPid.has(botPid),
+    envScanPids,
+    rows,
+    interpretation,
+  }
+}
+
+// Collect the evidence for one agent. Call this ONCE per down-spell, at the
+// first down observation, BEFORE any teardown.
+export function collectPollerEvidence(
+  provider: ChannelProviderType,
+  agentDirPath: string,
+  claudePid: number,
+): PollerEvidence {
+  const chanDir = channelStateDir(provider, agentDirPath)
+  return buildPollerEvidence(
+    snapshotProcs(),
+    readBotPid(chanDir),
+    listPollerPidsByStateDir(STATE_ENV_VAR[provider], chanDir),
+    claudePid,
+  )
+}
+
 /**
  * Reap every channel-plugin poller process associated with this agent.
  * Combines bot.pid (cheap, supervised pid) with a `ps eww -e` env-var scan


### PR DESCRIPTION
## A hiba

A channel-plugin watchdog **egyetlen** "down" mintavétel után azonnal hard-restartolta az agenst. A restart FRISS session (nem `--continue`), tehát a folyamatban lévő munka kontextusa elveszett.

2026-07-14, egyetlen nap alatt **10 ilyen kill** (`/tmp/marveen.log`): VoiceDev 3x (mindháromszor PR-munka közben), Devy 3x, Disy 1x. A 19:33-as eset bizonyítja hogy a verdikt hamis volt:

```
19:33:38  WARN  Agent channel plugin down -- auto-restarting
19:33:59  ERROR Failed to auto-restart agent after channel plugin down
19:34:32  INFO  Agent channel plugin recovered      <-- restart nélkül. Sosem volt halott.
```

Az agens ilyenkor némán újraindul, utána üres prompton áll órákig: az új session nem tudja hogy dolga volt, a régi már nem tud üzenni.

## Gyökérok

`channel-monitor.ts` sweep (60s): `hasChannelPluginAlive()` → `false` → azonnali `stopAgentProcess()` + fresh `startAgentProcess()`. Nincs sem megerősítés, sem busy-check. Ráadásul a probe `catch { return false }`-t csinál, tehát **a saját monitorozásunk hibája** (ps timeout terhelt gépen, olvashatatlan state dir) is "halott plugin"-nak látszik és kill-t vált ki.

## A javítás -- 3 réteg

**1. Tri-state liveness** (`liveness.ts`): `probeChannelPluginLiveness()` → `'alive' | 'down' | 'unknown'`. Az `'unknown'` (probe-hiba) mostantól *nem információ*: a monitor érintetlenül hagy minden számlálót és újrapróbál a következő sweep-ben. `hasChannelPluginAlive()` bool wrapper lett (DRY), viselkedése változatlan.

**2. Down-confirmation window** (`AGENT_DOWN_CONFIRM_MS = 150s`): egy down-minta gyanú, nem verdikt. A sweep 60s-enként fut, tehát legalább két egymást követő down megfigyelés kell a restarthoz. Ez önmagában kiszűrte volna a 19:33-as esetet.

**3. Busy-guard** (`AGENT_BUSY_DEFER_MAX_MS = 30 perc`): dolgozó pane-t (busy/typing) nem ölünk meg. A halott csatorna nem akadályozza az agenst a munkában, csak a hallásban -- idle-ig halasztunk. Ha 30 percen túl is dolgozik halott csatornával, az új `'alert-busy'` verdikt Zsolthoz eszkalál (egyszer), ahelyett hogy a rendszer választana a munka megölése és a süket agens között. A stuck-input ág ezt a busy-guardot már használja (cde0153) -- a plugin-down ág maradt ki belőle.

## Tesztek

- 12 új regressziós teszt: `src/__tests__/channel-watchdog-busy-guard.test.ts` (confirm-window, busy-defer, cap-eszkaláció, és hogy a startup/restart grace + failure-cap változatlanul él)
- Teljes suite: **1860/1860 zöld**, `tsc --noEmit` tiszta
- Back-compat: minden új policy-mező opcionális, elhagyva a régi viselkedés marad (a meglévő 45 `agent-restart-policy` teszt módosítás nélkül zöld)

## Amit ez NEM old meg (külön PR-ek, kártya: a23320c8)

- **Recovery-brief**: a restart után az új session kapjon automatikus briefet ("a sessionöd újraindult, a munkád uncommitted a branchen, folytasd")
- **`runState: running` hazudik**: üres prompton álló, halott session is running-nak látszik -- valódi liveness-jel kellene
- **Miért esik le a plugin ennyiszer**: ez a PR a tünetet kezeli (a kill-t), a plugin instabilitásának oka külön vizsgálat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bFiGwyyJTNjtUBwMeubfi

---

## 2. commit (4093ab0) -- forensics a down-verdikt pillanatában + ps-probe paritás

Az a23320c8 kártya **3. pontja** ("miért esik le a plugin naponta 10x") a fentiekkel nincs megválaszolva, és a logokból nem is rekonstruálható: **a restart megsemmisíti a bizonyítékot** (a reap megöli a pollert, a session újraindul, a log annyit mond hogy "down").

**Amit mértem és kizártam:** nincs OOM/jetsam kill-bizonyíték; a `ps` kimenet normál terhelésen 370KB / 0.2s (a limit 1MB / 3s); a detached-claude reaper ma 0x futott és van fail-safe-je (üres tmux pane-lista → nem öl).

**Amit találtam:** a 10 down-eseményből **9-nél a reap ÉLŐ poller processzt ölt meg ugyanabban a másodpercben** -- tehát a plugin a kill pillanatában többnyire élt. Hogy a claude process-fáján *belül* volt-e (⇒ a probe hibás) vagy *kívül* (⇒ reparenting), azt a jelenlegi log nem árulja el.

**Ezért:** `collectPollerEvidence()` a verdikt pillanatában, **teardown előtt** rögzít egy pillanatfelvételt, és kiírja a három lehetséges olvasat egyikét:

| olvasat | jelentés |
|---|---|
| `in-tree` | él a poller ÉS a claude fájában van → **a probe hibás**, nem a plugin |
| `orphaned` | él a poller, de a fán kívül → reparenting / előző claude maradéka |
| `no-poller` | nincs élő poller → a plugin tényleg kilépett |

Down-spellenként **egyszer** fut (nem sweepenként), tehát egy `ps` a költsége.

**Plusz egy konkrét hamis-down ok javítva:** a liveness-probe (ami a kill-t eldönti) `ps -axo` hívást használt **default 1MB maxBuffer + 3s timeout**-tal, míg a reaper `snapshotProcs`-a már `-axww` + 8MB + 5s-tel dolgozik. Túllépésnél az `execFileSync` **dob** -- és a dobó probe (az 1. commit előtt) "halott plugin"-t jelentett. Most paritás van. A fejléces `-o pid,ppid,command` alak marad, mert a `decideHasPluginAlive` az első sort fejlécként dobja.

**Tesztek:** +6 (`poller-evidence.test.ts`). Teljes suite: **1866/1866 zöld**.

## Mellékletet a vizsgálatból (NEM ez a PR javítja, külön kártya)

A **finy** agens **5+ napja süket** volt: `store/.agent-failures-finy = 6` (a cap 5), befagyva 07-09 óta. A failure-számláló csak *egészséges* plugin-észleléskor nullázódik -- az viszont sosem jön, mert a cap fölött már nincs restart-kísérlet. Önfenntartó holtpont: egyetlen riasztás 07-09-én, azóta némaság, a dashboard végig `running`-ot mutatott.
