### PR TITLE
feat(onboarding): identity wizard step (agent + owner name) + self-rename seed skill

### DIFF
--- a/seed-skills/self-rename/SKILL.md
+++ b/seed-skills/self-rename/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: self-rename
+description: A gazda megkér, hogy nevezd át magad ("mostantól legyél X", "nevezd át magad X-re", "hívjunk inkább X-nek"). Biztonságos önátnevezés: persona (CLAUDE.md/SOUL.md) + BRAND_NAME + dashboard-restart. SOHA nem nyúl a BOT_NAME/MAIN_AGENT_ID/SERVICE_ID plumbinghoz.
+---
+# Self-rename -- az agent biztonságos átnevezése
+
+## Mikor használd
+A GAZDA (az install tulajdonosa) kér meg, hogy nevezd át magad. Idegen/nem-gazda kérésre NE futtasd.
+
+## Biztonsági alapszabály (EZT SOHA NE SZEGD MEG)
+A `BOT_NAME`, `MAIN_AGENT_ID` és `SERVICE_ID` értékek telepítéskor beégnek a rendszerbe: tmux session-név, adatbázis-sorok, OS service-unit nevek (`com.<SERVICE_ID>.app`, `<SERVICE_ID>-dashboard`, `<SERVICE_ID>-channels`) származnak belőlük. Utólagos átírásuk elárvítja a futó szolgáltatásokat és akár a gazdát is kizárhatja. **A megjelenített név és a belső azonosító nyugodtan eltérhet** -- ez a skill CSAK a megjelenített nevet és a personát állítja.
+
+Amit ez a skill ír: `BRAND_NAME` az .env-ben + a persona-fájlok (CLAUDE.md, SOUL.md).
+Amit SOHA: `BOT_NAME`, `MAIN_AGENT_ID`, `SERVICE_ID`, access.json, owner-config.
+
+## Eljárás
+
+1. **Install-könyvtár azonosítása** (semmi hardcode-olt path): a fő-agent munkakönyvtára maga az install-könyvtár -- ellenőrizd, hogy a cwd-ben van `.env` ÉS `CLAUDE.md`. Ha nem, keresd meg a futó dashboard cwd-jét, és kérdezz rá a gazdánál mielőtt máshol írnál.
+
+2. **Jelenlegi név kiolvasása**: az `.env`-ből a `BRAND_NAME` (ha nincs, `BOT_NAME`; ha az sincs, a CLAUDE.md első `# <Név>` sora). Ez lesz a csere forrás-tokenje.
+
+3. **Persona-fájlok átírása** (CLAUDE.md + SOUL.md, ha létezik): a régi név MINDEN önálló előfordulását cseréld az újra. Célzott csere, atomikusan:
+```bash
+python3 - "$PWD" "REGI_NEV" "UJ_NEV" <<'PYEOF'
+import os, sys
+root, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+for name in ('CLAUDE.md', 'SOUL.md'):
+    p = os.path.join(root, name)
+    if not os.path.exists(p): continue
+    s = open(p, encoding='utf-8').read()
+    if old not in s: continue
+    tmp = p + '.tmp'
+    open(tmp, 'w', encoding='utf-8').write(s.replace(old, new))
+    os.replace(tmp, p)
+    print(name, 'renamed')
+PYEOF
+```
+
+4. **BRAND_NAME az .env-ben** -- atomikus kulcs-csere (a többi sor byte-ra változatlan, chmod 600):
+```bash
+python3 - "$PWD/.env" "UJ_NEV" <<'PYEOF'
+import os, sys
+envp, new = sys.argv[1], sys.argv[2]
+lines = [l for l in open(envp, encoding='utf-8').read().split('\n') if l and not l.startswith('BRAND_NAME=')]
+lines.append('BRAND_NAME=' + new)
+tmp = envp + '.tmp'
+open(tmp, 'w', encoding='utf-8').write('\n'.join(lines) + '\n')
+os.chmod(tmp, 0o600)
+os.replace(tmp, envp)
+print('BRAND_NAME set')
+PYEOF
+```
+
+5. **Restart a megjelenítéshez.** A `SERVICE_ID`-t az `.env`-ből olvasd (ha nincs: `MAIN_AGENT_ID`; ha az sincs: `marveen`):
+   - **macOS**: `launchctl kickstart -k gui/$(id -u)/com.<SERVICE_ID>.app`
+   - **Linux (systemd user)**: `systemctl --user restart <SERVICE_ID>-dashboard` (root-VPS-en, ahol nincs user-session: `systemctl restart <SERVICE_ID>-dashboard`)
+   - A persona (ahogy magadról beszélsz) a KÖVETKEZŐ agent-session-indulásnál frissül. **Solo installon** (csak fő-agent fut) mehet a channels-restart is: `systemctl --user restart <SERVICE_ID>-channels` -- FIGYELEM: ez a te saját sessionödet is újraindítja, ezért ELŐBB válaszolj a gazdának ("átneveztem magam, újraindulok az új névvel"), és CSAK UTÁNA add ki. **Multi-agent flottán** NE indítsd újra a channels-t (a tmux-szervert osztjátok) -- a persona a következő természetes restartnál él.
+
+6. **Visszajelzés a gazdának**: mit írtál át (persona + megjelenített név), és hogy a belső azonosítók szándékosan változatlanok.
+
+## Buktatók
+- A régi név gyakori szó is lehet (pl. rövid név) -- csere előtt nézd át hol fordul elő (`grep -c "REGI_NEV" CLAUDE.md`), és ha gyanúsan sok a találat, csak a persona-szekciók név-előfordulásait cseréld kézzel.
+- SOHA ne `sed -i`-vel írd az .env-t (nem atomikus, elveszhet a chmod 600) -- a fenti python-minta a helyes.
+- Ha a dashboard nem jön vissza a restart után (`curl -s http://localhost:<port>/health` vagy a dashboard-port a .env-ből), jelezd a gazdának azonnal -- NE próbálkozz service-fájl átírással.
+
+## Ellenőrzés
+- `.env`-ben `BRAND_NAME=<új név>`, és a `BOT_NAME`/`MAIN_AGENT_ID`/`SERVICE_ID` sorok byte-ra változatlanok (`git diff` ha git-checkout, különben diff a mentett másolattal).
+- Dashboard él és az új nevet mutatja (böngésző-cím / topbar).
+- `tmux ls`: a session-nevek VÁLTOZATLANOK (ha megváltoztak volna, azonnal állj le és jelezz).

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -102,6 +102,22 @@ function setEnvKey(key: string, value: string): void {
   atomicWriteFileSync(ENV_FILE, kept.join('\n') + '\n', { mode: 0o600 })
 }
 
+// Replace every standalone occurrence of `from` with `to` in a persona file
+// (CLAUDE.md / SOUL.md). Plain global string replace -- the persona files are
+// generated from templates where the name appears verbatim. Atomic write, and
+// a no-op when the file is missing or nothing matched.
+function renameInPersonaFile(file: string, from: string, to: string): void {
+  if (!from || !to || from === to) return
+  let content: string
+  try { content = readFileSync(file, 'utf-8') } catch { return }
+  if (!content.includes(from)) return
+  atomicWriteFileSync(file, content.split(from).join(to))
+}
+
+function identityConfirmed(): boolean {
+  return readEnvValue('IDENTITY_CONFIRMED') === '1'
+}
+
 export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
 
@@ -112,12 +128,68 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
     const tg = telegramConfigured()
     const pr = paired()
     json(res, {
+      identityConfirmed: identityConfirmed(),
+      currentAgentName: readEnvValue('BRAND_NAME') || readEnvValue('BOT_NAME') || 'Marveen',
+      currentOwnerName: readEnvValue('OWNER_NAME') || '',
       claudeAuthPresent: claude,
       agentsRunning: running,
       telegramConfigured: tg,
       paired: pr,
+      // The identity step never re-opens the wizard on an already-configured
+      // install: it only participates while first-run setup is incomplete.
       needsOnboarding: !claude || !running || !tg || !pr,
     })
+    return true
+  }
+
+  // Identity step: agent display name + owner name. SAFETY: MAIN_AGENT_ID and
+  // SERVICE_ID are baked into the plumbing at install time (tmux session name,
+  // DB rows, OS service-unit names) -- rewriting them after the services exist
+  // orphans running units and can lock the owner out. The display name and the
+  // internal id may freely differ, so:
+  //   - services not yet launched: BOT_NAME + BRAND_NAME + OWNER_NAME may all
+  //     be set (launch picks them up from .env); the id plumbing stays as the
+  //     installer derived it.
+  //   - services already running: only BRAND_NAME + OWNER_NAME + the persona
+  //     files change. BOT_NAME is left alone with the rest of the plumbing.
+  if (path === '/api/onboarding/identity' && method === 'POST') {
+    let body: { agentName?: string; ownerName?: string } = {}
+    try { body = JSON.parse((await readBody(req)).toString()) as typeof body } catch { /* empty */ }
+    const agentName = (body.agentName ?? '').trim()
+    const ownerName = (body.ownerName ?? '').trim()
+    if (!agentName || !ownerName) { json(res, { error: 'agentName es ownerName szukseges.', reason: 'missing' }, 400); return true }
+    if (agentName.length > 40 || ownerName.length > 60 || /[\n\r\0=]/.test(agentName + ownerName)) {
+      json(res, { error: 'A nev tul hosszu vagy tiltott karaktert tartalmaz.', reason: 'bad-name' }, 400)
+      return true
+    }
+
+    const servicesUp = agentsRunning()
+    const prevAgentName = readEnvValue('BOT_NAME') || 'Marveen'
+    const prevOwnerName = readEnvValue('OWNER_NAME') || ''
+    try {
+      setEnvKey('OWNER_NAME', ownerName)
+      setEnvKey('BRAND_NAME', agentName)
+      if (!servicesUp) setEnvKey('BOT_NAME', agentName)
+      setEnvKey('IDENTITY_CONFIRMED', '1')
+    } catch (err) {
+      logger.error({ err }, 'onboarding: failed to persist identity to .env')
+      json(res, { error: 'Nem sikerult elmenteni az .env-be.', reason: 'write-failed' }, 500)
+      return true
+    }
+
+    // Persona files: the agent introduces itself by this name. Never touches
+    // owner/access config, only the two persona documents.
+    try {
+      for (const f of [join(PROJECT_ROOT, 'CLAUDE.md'), join(PROJECT_ROOT, 'SOUL.md')]) {
+        renameInPersonaFile(f, prevAgentName, agentName)
+        if (prevOwnerName) renameInPersonaFile(f, prevOwnerName, ownerName)
+      }
+    } catch (err) {
+      logger.warn({ err }, 'onboarding: persona rename failed (identity saved to .env regardless)')
+    }
+
+    logger.info({ servicesUp, botNameUpdated: !servicesUp }, 'onboarding: identity configured')
+    json(res, { ok: true, botNameUpdated: !servicesUp })
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -10366,9 +10366,10 @@ async function fetchOnboardingStatus() {
   try { return await (await fetch('/api/onboarding/status')).json() } catch { return null }
 }
 function onboardingCurrentStep(s) {
-  if (!s.claudeAuthPresent || !s.agentsRunning) return 1
-  if (!s.telegramConfigured) return 2
-  if (!s.paired) return 3
+  if (!s.identityConfirmed) return 1
+  if (!s.claudeAuthPresent || !s.agentsRunning) return 2
+  if (!s.telegramConfigured) return 3
+  if (!s.paired) return 4
   return 0
 }
 async function initOnboarding() {
@@ -10394,14 +10395,25 @@ function renderOnboarding(s) {
     el.classList.toggle('done', n < step)
   })
   const body = document.getElementById('onboardingBody')
-  if (step === 1) body.innerHTML = onbStep1Html(s)
-  else if (step === 2) body.innerHTML = onbStep2Html()
+  if (step === 1) body.innerHTML = onbIdentityHtml(s)
+  else if (step === 2) body.innerHTML = onbStep1Html(s)
+  else if (step === 3) body.innerHTML = onbStep2Html()
   else body.innerHTML = onbStep3Html()
   wireOnboarding(step)
 }
 function onbMsg(text, isErr) {
   const el = document.getElementById('onbMsg')
   if (el) { el.textContent = text; el.className = 'onb-msg' + (isErr ? ' err' : ' ok') }
+}
+function onbIdentityHtml(s) {
+  return `<p>${escapeHtml(t('onboarding.identity.desc'))}</p>`
+    + `<label class="form-label-sm">${escapeHtml(t('onboarding.identity.agent_label'))}</label>`
+    + `<input id="onbAgentName" type="text" class="onb-input" maxlength="40" value="${escapeHtml(s.currentAgentName || '')}" autocomplete="off">`
+    + `<label class="form-label-sm">${escapeHtml(t('onboarding.identity.owner_label'))}</label>`
+    + `<input id="onbOwnerName" type="text" class="onb-input" maxlength="60" value="${escapeHtml(s.currentOwnerName || '')}" autocomplete="off">`
+    + `<div class="onb-hint">${escapeHtml(t('onboarding.identity.hint'))}</div>`
+    + `<button class="btn-primary btn-compact" id="onbIdentityBtn">${escapeHtml(t('onboarding.identity.save_btn'))}</button>`
+    + `<div id="onbMsg" class="onb-msg"></div>`
 }
 function onbStep1Html(s) {
   return `<p>${escapeHtml(t('onboarding.step1.desc'))}</p>`
@@ -10433,6 +10445,23 @@ function onbStep3Html() {
 }
 function wireOnboarding(step) {
   if (step === 1) {
+    const idBtn = document.getElementById('onbIdentityBtn')
+    if (idBtn) idBtn.addEventListener('click', async () => {
+      const agentName = (document.getElementById('onbAgentName').value || '').trim()
+      const ownerName = (document.getElementById('onbOwnerName').value || '').trim()
+      if (!agentName || !ownerName) { onbMsg(t('onboarding.identity.empty'), true); return }
+      idBtn.disabled = true; onbMsg(t('onboarding.saving'))
+      try {
+        const res = await fetch('/api/onboarding/identity', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ agentName, ownerName }) })
+        const d = await res.json().catch(() => ({}))
+        if (!res.ok) { idBtn.disabled = false; onbMsg(d.error || t('onboarding.error'), true); return }
+        onbMsg(t('onboarding.identity.saved'))
+        await refreshOnboarding()
+      } catch (e) { idBtn.disabled = false; onbMsg((e && e.message) || t('onboarding.error'), true) }
+    })
+    return
+  }
+  if (step === 2) {
     const authBtn = document.getElementById('onbAuthBtn')
     if (authBtn) authBtn.addEventListener('click', async () => {
       const token = (document.getElementById('onbToken').value || '').trim()
@@ -10457,7 +10486,7 @@ function wireOnboarding(step) {
         setTimeout(refreshOnboarding, 2500)
       } catch (e) { launchBtn.disabled = false; onbMsg((e && e.message) || t('onboarding.error'), true) }
     })
-  } else if (step === 2) {
+  } else if (step === 3) {
     const botBtn = document.getElementById('onbBotBtn')
     if (botBtn) botBtn.addEventListener('click', async () => {
       const botToken = (document.getElementById('onbBotToken').value || '').trim()
@@ -10471,7 +10500,7 @@ function wireOnboarding(step) {
         setTimeout(refreshOnboarding, 2000)
       } catch (e) { botBtn.disabled = false; onbMsg((e && e.message) || t('onboarding.error'), true) }
     })
-  } else if (step === 3) {
+  } else if (step === 4) {
     const refreshBtn = document.getElementById('onbRefreshBtn')
     const loadPending = async () => {
       try {

--- a/web/index.html
+++ b/web/index.html
@@ -42,9 +42,10 @@
       <h2 data-i18n="onboarding.title">Marveen beállítása</h2>
       <p class="onb-sub" data-i18n="onboarding.subtitle">Fejezd be a beállítást innen, a dashboardból -- SSH nélkül.</p>
       <div class="onboarding-steps" id="onboardingSteps">
-        <div class="onboarding-step" data-ostep="1"><span class="onb-num">1</span> <span data-i18n="onboarding.step1.tab">Claude auth</span></div>
-        <div class="onboarding-step" data-ostep="2"><span class="onb-num">2</span> <span data-i18n="onboarding.step2.tab">Telegram bot</span></div>
-        <div class="onboarding-step" data-ostep="3"><span class="onb-num">3</span> <span data-i18n="onboarding.step3.tab">Párosítás</span></div>
+        <div class="onboarding-step" data-ostep="1"><span class="onb-num">1</span> <span data-i18n="onboarding.identity.tab">Név</span></div>
+        <div class="onboarding-step" data-ostep="2"><span class="onb-num">2</span> <span data-i18n="onboarding.step1.tab">Claude auth</span></div>
+        <div class="onboarding-step" data-ostep="3"><span class="onb-num">3</span> <span data-i18n="onboarding.step2.tab">Telegram bot</span></div>
+        <div class="onboarding-step" data-ostep="4"><span class="onb-num">4</span> <span data-i18n="onboarding.step3.tab">Párosítás</span></div>
       </div>
       <div id="onboardingBody" class="onboarding-body"></div>
     </div>

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1365,6 +1365,14 @@ window._i18n.en = {
   'updates.toast.status_timeout':'Update status did not arrive in time. Check store/update.log.',
 
   // --- Onboarding wizard ---
+  'onboarding.identity.tab':     'Name',
+  'onboarding.identity.desc':    'Name your assistant and tell it your name. You can change these later.',
+  'onboarding.identity.agent_label': 'Assistant name',
+  'onboarding.identity.owner_label': 'Your name',
+  'onboarding.identity.hint':    'This sets the displayed name only: internal system ids are not affected.',
+  'onboarding.identity.save_btn': 'Save and continue',
+  'onboarding.identity.empty':   'Both names are required.',
+  'onboarding.identity.saved':   'Name saved.',
   'onboarding.title':            'Set up Marveen',
   'onboarding.subtitle':         'Finish setup here, from the dashboard, no SSH needed.',
   'onboarding.saving':           'Saving...',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1363,6 +1363,14 @@ window._i18n.hu = {
   'updates.toast.status_timeout':'A frissítés állapota nem érkezett meg időben. Nézd meg a store/update.log fájlt.',
 
   // --- Onboarding wizard ---
+  'onboarding.identity.tab':     'Név',
+  'onboarding.identity.desc':    'Nevezd el az asszisztensed, és add meg a saját neved. Ezt később is átírhatod.',
+  'onboarding.identity.agent_label': 'Az asszisztens neve',
+  'onboarding.identity.owner_label': 'A te neved',
+  'onboarding.identity.hint':    'A megjelenített nevet állítod: a rendszer belső azonosítóit ez nem érinti.',
+  'onboarding.identity.save_btn': 'Mentés és tovább',
+  'onboarding.identity.empty':   'Mindkét név megadása kötelező.',
+  'onboarding.identity.saved':   'Név elmentve.',
   'onboarding.title':            'Marveen beállítása',
   'onboarding.subtitle':         'Fejezd be a beállítást innen, a dashboardból, SSH nélkül.',
   'onboarding.saving':           'Mentés...',


### PR DESCRIPTION
## Summary

Bootcamp ask: participants with pre-installed Marveen should personalize their assistant from the dashboard, without SSH and without bricking the install.

### 1. Wizard identity step (new step 1 of 4)

- `POST /api/onboarding/identity` (`{agentName, ownerName}`) + `identityConfirmed`/`currentAgentName`/`currentOwnerName` in `/api/onboarding/status`.
- **State-aware safety branch** (the id plumbing -- `MAIN_AGENT_ID`, `SERVICE_ID` -- bakes into tmux session names, DB rows and OS service-unit names at install time and is NEVER written):
  - services not yet launched -> `BOT_NAME` + `BRAND_NAME` + `OWNER_NAME` into `.env` (the launch derives its runtime from `.env`),
  - channels session already running -> only `BRAND_NAME` + `OWNER_NAME` + persona files. `BOT_NAME` deliberately left with the plumbing (display/id may differ).
- Persona rename: targeted atomic replace of the previous name tokens in `CLAUDE.md` / `SOUL.md`. No owner/access-config clobber anywhere.
- Atomic `.env` writes via the existing `setEnvKey` (chmod 600, other lines byte-identical).
- Gating: `IDENTITY_CONFIRMED=1` written by the endpoint. The wizard trigger (`needsOnboarding`) is unchanged, so fully configured installs NEVER get re-prompted after update; installs still in first-run see the name step first, prefilled with current values.
- Validation: both names required, length caps, newline/`=`/NUL rejected.

### 2. `seed-skills/self-rename`

Owner-triggered safe self-rename for already-installed agents: persona (CLAUDE.md/SOUL.md) + `BRAND_NAME` (atomic python temp+rename, chmod 600) + platform-aware dashboard restart (`launchctl kickstart com.<SERVICE_ID>.app` / `systemctl --user restart <SERVICE_ID>-dashboard`), channels restart only on solo installs with reply-first warning. Hard rule stated twice: never `BOT_NAME`/`MAIN_AGENT_ID`/`SERVICE_ID`, never access/owner config. Zero hardcoded owner/agent/path/chat-id -- everything resolves from the install's own `.env`/`CLAUDE.md` at runtime (distribution hardcode rule). Ships to fresh installs via the existing idempotent seed-skills copy.

## Verification (live test install, AVX-less VPS, develop build)

- **Case services-up**: POST left `BOT_NAME`/`MAIN_AGENT_ID`/`SERVICE_ID` and the tmux sessions byte-identical; `BRAND_NAME`/`OWNER_NAME`/`IDENTITY_CONFIRMED` written; CLAUDE.md persona fully renamed (old token 0 occurrences).
- **Case services-down** (session temporarily renamed away, no kill): `botNameUpdated:true`, `BOT_NAME` also written.
- Validation: empty name -> 400 `missing`; `=` in name -> 400 `bad-name`.
- Real-browser test (Playwright over SSH tunnel): wizard overlay appears, step 1 "Nev" active, both inputs prefilled from `.env`, zero page errors.
- `tsc --noEmit` clean, `node --check` clean on app.js + lang files.
- Test install restored from backups afterwards (env/persona/tmux names verified back to original).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
