### PR TITLE
fix(onboarding): wizard pairing step never completed -- approve contract mismatch

### DIFF
--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1227,7 +1227,11 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
 
       const approvedDir = join(chDir, 'approved')
       mkdirSync(approvedDir, { recursive: true })
-      writeFileSync(join(approvedDir, entry.senderId), '')
+      // Marker contents = chatId, per the plugin's /telegram:access pair
+      // contract (the channel server polls approved/ to send the "Paired!"
+      // confirmation; current server keys off the filename, the chatId
+      // contents keep us aligned with the documented format).
+      writeFileSync(join(approvedDir, entry.senderId), String(entry.chatId ?? ''))
 
       logger.info({ name, provider, senderId: entry.senderId, code }, 'Channel pairing approved')
       json(res, { ok: true, senderId: entry.senderId })

--- a/web/app.js
+++ b/web/app.js
@@ -10505,19 +10505,25 @@ function wireOnboarding(step) {
     const loadPending = async () => {
       try {
         const p = await (await fetch(`/api/agents/${encodeURIComponent(mainAgentId())}/channels/telegram/pending`)).json()
-        const list = Array.isArray(p) ? p : (p.pending || [])
+        // Backend contract: [{code, senderId, chatId, createdAt, expiresAt}].
+        // `code` is the approve key (the same code the bot sent the user) --
+        // POSTing anything else gets a 400 and the pairing never completes.
+        const now = Date.now()
+        const list = (Array.isArray(p) ? p : (p.pending || [])).filter((x) => x && x.code && (!x.expiresAt || x.expiresAt > now))
         const box = document.getElementById('onbPending')
         if (!box) return
         if (!list.length) { box.innerHTML = `<span class="onb-hint">${escapeHtml(t('onboarding.step3.no_pending'))}</span>`; return }
         box.innerHTML = list.map((x) => {
-          const id = escapeHtml(String(x.id || x.chatId || x.userId || ''))
-          const label = escapeHtml(String(x.name || x.username || id))
-          return `<div class="onb-pending-row"><span>${label}</span><button class="btn-primary btn-compact onb-approve" data-id="${id}">${escapeHtml(t('onboarding.step3.approve_btn'))}</button></div>`
+          const code = escapeHtml(String(x.code))
+          const label = escapeHtml(String(x.senderId || x.chatId || '?')) + ' · ' + code
+          return `<div class="onb-pending-row"><span>${label}</span><button class="btn-primary btn-compact onb-approve" data-code="${code}">${escapeHtml(t('onboarding.step3.approve_btn'))}</button></div>`
         }).join('')
         box.querySelectorAll('.onb-approve').forEach((b) => b.addEventListener('click', async () => {
           b.disabled = true
           try {
-            await fetch(`/api/agents/${encodeURIComponent(mainAgentId())}/channels/telegram/approve`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id: b.dataset.id }) })
+            const res = await fetch(`/api/agents/${encodeURIComponent(mainAgentId())}/channels/telegram/approve`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ code: b.dataset.code }) })
+            const d = await res.json().catch(() => ({}))
+            if (!res.ok) { b.disabled = false; onbMsg(d.error || t('onboarding.error'), true); return }
             onbMsg(t('onboarding.step3.approved'))
             setTimeout(refreshOnboarding, 1500)
           } catch (e) { b.disabled = false; onbMsg((e && e.message) || t('onboarding.error'), true) }


### PR DESCRIPTION
## Summary

Live bootcamp blocker: the wizard's pairing step never completed an approval. Root cause is a frontend/backend contract mismatch, not a missing endpoint:

- `GET .../channels/telegram/pending` returns `[{code, senderId, chatId, createdAt, expiresAt}]`
- the wizard rendered `x.id || x.chatId || x.userId` (no `id`/`userId` exists) and POSTed `{id}` to `.../approve`
- the approve endpoint requires `{code}` -> every click died with 400 "Code is required", `allowFrom` never updated, the bot kept issuing fresh codes and participants were stuck.

## Changes

- **Wizard step (web/app.js)**: renders senderId + code from the real contract, filters expired entries, POSTs `{code}`, and surfaces backend errors in the step message instead of silently claiming success.
- **Approve handler (agents.ts)**: writes the `chatId` as the `approved/<senderId>` marker contents, matching the plugin's documented `/telegram:access pair` contract (the current channel server keys off the filename only -- compatibility alignment, no behavior change).

## Config-dir divergence (verified, no code needed)

Checked against the telegram plugin source (0.0.6): the plugin resolves its state dir as `TELEGRAM_STATE_DIR ?? ~/.claude/channels/telegram`, and `TELEGRAM_STATE_DIR` is only exported for sub-agents (pointed at their agentDir, which `channelStateDir(provider, agentDir)` mirrors). The MAIN agent's plugin therefore always uses `~/.claude/channels/telegram` regardless of `MAIN_AGENT_CONFIG_DIR`/isolated config -- exactly where the dashboard's `channelStateDir(provider)` points. Dashboard and plugin cannot diverge on access.json today; documented in the commit instead of adding speculative plumbing.

## Verification (live test install, real browser)

Seeded a pending entry in the plugin's exact on-disk format (senderId/chatId/createdAt/expiresAt/replies), then drove the deployed wizard over an SSH tunnel with Playwright:

- step 4 "Párosítás" active, pending row rendered as `999888777 · a1b2c3`
- clicking approve: success message, `allowFrom=["999888777"]`, `pending={}`, `dmPolicy=allowlist`
- `approved/999888777` marker created with chatId contents
- `paired()` flipped true -> the wizard overlay closed (all steps complete)
- zero page errors; `tsc --noEmit` + `node --check` clean
- test install restored afterwards (access.json/.env/dashboard back to original, sessions untouched)

The Telegram network leg (code delivery / "Paired!" confirmation) is the untouched plugin's own path, exercised daily in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
