### PR TITLE
feat(config): configurable timezone (SCHEDULER_TZ) for scheduling AND…

### DIFF
--- a/src/__tests__/reauth-quiet-hours.test.ts
+++ b/src/__tests__/reauth-quiet-hours.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect } from 'vitest'
 import {
   isQuietHour,
-  budapestHour,
+  localHour,
   routeEscalation,
   flushQuietSummary,
   buildQuietSummaryMessage,
   buildEscalationMessage,
   type QuietSuppressedEntry,
 } from '../web/reauth-healer.js'
+import { APP_TZ } from '../config.js'
 
-// Quiet hours (23:00-06:00 Europe/Budapest) for the reauth-healer escalation.
+// Quiet hours (23:00-06:00 in the install zone, APP_TZ) for the reauth-healer escalation.
 // Motivated by 2026-07-09 night: spock+scotty re-alerted every 30 minutes all
 // night about a dead token nobody could fix before morning. The probe keeps
 // running; ONLY notify.sh is held back, and the first sweep after 06:00 sends
@@ -22,7 +23,7 @@ const entry = (session: string, label = session, consecutiveDead = 10): QuietSup
   consecutiveDead,
 })
 
-describe('isQuietHour / budapestHour', () => {
+describe('isQuietHour / localHour', () => {
   it('23:00-05:59 csendes, 06:00-22:59 nem', () => {
     expect(isQuietHour(23)).toBe(true)
     expect(isQuietHour(0)).toBe(true)
@@ -32,13 +33,15 @@ describe('isQuietHour / budapestHour', () => {
     expect(isQuietHour(22)).toBe(false)
   })
 
-  it('budapestHour a host TZ-től függetlenül Europe/Budapest órát ad (CEST=UTC+2 nyáron)', () => {
-    // 2026-07-09T22:30:00Z = 2026-07-10 00:30 Budapest -> 0 (quiet)
-    expect(budapestHour(Date.UTC(2026, 6, 9, 22, 30))).toBe(0)
-    // 2026-07-10T04:05:00Z = 06:05 Budapest -> 6 (not quiet)
-    expect(budapestHour(Date.UTC(2026, 6, 10, 4, 5))).toBe(6)
-    // 2026-01-10T22:30:00Z = 23:30 Budapest (CET=UTC+1 télen) -> 23 (quiet)
-    expect(budapestHour(Date.UTC(2026, 0, 10, 22, 30))).toBe(23)
+  it('localHour a host TZ-től függetlenül az install-zóna (APP_TZ) óráját adja', () => {
+    // TZ-agnostic: localHour must equal an independent hour extraction in APP_TZ,
+    // whatever APP_TZ is (Europe/London on this install). No hardcoded zone -> a
+    // future SCHEDULER_TZ change does not break this test.
+    const hourIn = (ms: number) =>
+      parseInt(new Intl.DateTimeFormat('en-GB', { timeZone: APP_TZ, hour: '2-digit', hour12: false }).format(new Date(ms)), 10)
+    for (const ms of [Date.UTC(2026, 6, 9, 22, 30), Date.UTC(2026, 6, 10, 4, 5), Date.UTC(2026, 0, 10, 22, 30)]) {
+      expect(localHour(ms)).toBe(hourIn(ms))
+    }
   })
 })
 

--- a/src/__tests__/recall.test.ts
+++ b/src/__tests__/recall.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { parseDateExpression } from '../web/routes/recall.js'
 
-// Pin "today" to 2026-05-19 (Tuesday) Europe/Budapest for deterministic tests
+// Pin "today" to 2026-05-19 (Tuesday) in the install zone for deterministic tests
 const FAKE_TODAY = '2026-05-19'
 
 vi.mock('../web/routes/recall.js', async (importOriginal) => {

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -373,6 +373,17 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: false,
     requiresRestart: true,
   },
+  // --- System module ---
+  {
+    key: 'SCHEDULER_TZ',
+    type: 'string',
+    default: '',
+    description: 'A telepítés időzónája (IANA, pl. Europe/Budapest). EGY zóna vezérli az ütemezést (cron) ÉS minden megjelenített időt (heartbeat, napi napló, memória-címkék). Üresen hagyva a gép saját időzónáját használja. A módosítás a szolgáltatás újraindításakor lép életbe.',
+    module: 'system',
+    secret: false,
+    requiresRestart: true,
+    valueSet: ['Europe/London', 'Europe/Budapest', 'UTC', 'Europe/Dublin', 'Europe/Berlin', 'Europe/Bucharest', 'America/New_York'],
+  },
 ]
 
 export function getSettingDefinition(key: string): SettingDefinition | undefined {

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,14 @@ function cfg(key: string): string | undefined {
   return env[key]
 }
 
+// The single timezone for this install -- drives BOTH cron scheduling (cron.ts)
+// AND every human-facing time render (heartbeat, daily-log, memory labels, etc.).
+// One env var (SCHEDULER_TZ) so the whole box shares one zone; falls back to the
+// process zone (the TZ env / OS) when unset. Replaces the ~15 hardcoded
+// 'Europe/Budapest' literals -- change the zone in ONE place, and an update that
+// re-introduces a hardcoded literal is caught by a single grep, not a full review.
+export const APP_TZ = cfg('SCHEDULER_TZ') || Intl.DateTimeFormat().resolvedOptions().timeZone
+
 export const TELEGRAM_BOT_TOKEN = env['TELEGRAM_BOT_TOKEN'] ?? ''
 export const ALLOWED_CHAT_ID = env['ALLOWED_CHAT_ID'] ?? ''
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3'
 import { join } from 'node:path'
 import { existsSync, mkdirSync, readFileSync, renameSync, chmodSync, openSync, closeSync } from 'node:fs'
-import { STORE_DIR, DB_FILENAME, ALLOWED_CHAT_ID, OLLAMA_URL } from './config.js'
+import { STORE_DIR, DB_FILENAME, ALLOWED_CHAT_ID, OLLAMA_URL, APP_TZ } from './config.js'
 import { getEffectiveSettingValue } from './settings-store.js'
 import { logger } from './logger.js'
 import { TOOL_TIMEOUTS } from './tool-timeouts.js'
@@ -1022,7 +1022,7 @@ export function appendDailyLog(agentId: string, content: string): void {
   // Budapest calendar day, not UTC -- otherwise an entry written 00:00-02:00
   // local time lands on the previous day and the "ma" recall query misses it.
   // en-CA formats as YYYY-MM-DD.
-  const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Budapest' })
+  const today = new Date().toLocaleDateString('en-CA', { timeZone: APP_TZ })
   db.prepare('INSERT INTO daily_logs (agent_id, date, content, created_at) VALUES (?, ?, ?, ?)').run(agentId, today, content, now)
 }
 
@@ -1044,7 +1044,7 @@ export interface RecallResult {
 
 function toBudapestTs(dateStr: string, endOfDay: boolean): number {
   const fmt = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'Europe/Budapest',
+    timeZone: APP_TZ,
     year: 'numeric', month: '2-digit', day: '2-digit',
     hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
   })

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -9,6 +9,7 @@ import {
   DB_FILENAME,
   PROJECT_ROOT,
   OWNER_NAME,
+  APP_TZ,
 } from './config.js'
 import { getHeartbeatKanbanSummary, getActiveScheduledTaskCount } from './db.js'
 import { getCalendarEvents, type CalendarEvent } from './google-api.js'
@@ -379,7 +380,7 @@ function shouldNotify(data: HeartbeatData): boolean {
 // --- Agent prompt ---
 
 function buildAgentPrompt(data: HeartbeatData): string {
-  const timeStr = data.timestamp.toLocaleString('hu-HU', { timeZone: 'Europe/Budapest' })
+  const timeStr = data.timestamp.toLocaleString('hu-HU', { timeZone: APP_TZ })
 
   // Preamble first so the <untrusted> tag convention is established before any
   // attacker-controlled strings (calendar/kanban/email titles) appear.
@@ -397,7 +398,7 @@ function buildAgentPrompt(data: HeartbeatData): string {
   } else {
     for (const ev of data.calendar) {
       const start = ev.start?.dateTime
-        ? new Date(ev.start.dateTime).toLocaleTimeString('hu-HU', { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Budapest' })
+        ? new Date(ev.start.dateTime).toLocaleTimeString('hu-HU', { hour: '2-digit', minute: '2-digit', timeZone: APP_TZ })
         : 'egesz napos'
       const attendeesRaw = ev.attendees?.map((a) => a.displayName || a.email).join(', ') || '-'
       const summaryWrapped = wrapUntrusted('gcal-event-summary', ev.summary ?? '(cim nelkul)')
@@ -428,7 +429,7 @@ function buildAgentPrompt(data: HeartbeatData): string {
   prompt += `- Aktiv utemezett feladatok: ${data.tasks.count}\n`
   if (data.tasks.nextRun) {
     const nextDate = new Date(data.tasks.nextRun * 1000)
-    prompt += `- Kovetkezo feladat: ${nextDate.toLocaleString('hu-HU', { timeZone: 'Europe/Budapest' })}\n`
+    prompt += `- Kovetkezo feladat: ${nextDate.toLocaleString('hu-HU', { timeZone: APP_TZ })}\n`
   }
 
   return prompt
@@ -542,8 +543,8 @@ function scheduleNext(delayMs: number): void {
     const nextDelayMs = msUntilNextHeartbeat()
     const nextRun = new Date(Date.now() + nextDelayMs)
     logger.info(
-      { nextRun: nextRun.toLocaleString('hu-HU', { timeZone: 'Europe/Budapest' }) },
-      `Heartbeat kovetkezo: ${nextRun.toLocaleTimeString('hu-HU', { timeZone: 'Europe/Budapest' })}`
+      { nextRun: nextRun.toLocaleString('hu-HU', { timeZone: APP_TZ }) },
+      `Heartbeat kovetkezo: ${nextRun.toLocaleTimeString('hu-HU', { timeZone: APP_TZ })}`
     )
     scheduleNext(nextDelayMs)
   }, delayMs)
@@ -553,8 +554,8 @@ export function initHeartbeat(): void {
   const delayMs = msUntilNextHeartbeat()
   const nextRun = new Date(Date.now() + delayMs)
   logger.info(
-    { nextRun: nextRun.toLocaleString('hu-HU', { timeZone: 'Europe/Budapest' }) },
-    `Heartbeat utemezve (kovetkezo: ${nextRun.toLocaleTimeString('hu-HU', { timeZone: 'Europe/Budapest' })})`
+    { nextRun: nextRun.toLocaleString('hu-HU', { timeZone: APP_TZ }) },
+    `Heartbeat utemezve (kovetkezo: ${nextRun.toLocaleTimeString('hu-HU', { timeZone: APP_TZ })})`
   )
   scheduleNext(delayMs)
 }

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER } from '../config.js'
+import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ } from '../config.js'
 import { channelStateDir } from '../channel-provider.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
@@ -585,13 +585,13 @@ Minden kontextus-tömörítés előtt (PreCompact hook) automatikusan vizsgáld 
 
 ## Időkezelés
 
-MINDIG a megfelelő lokális időt használd (Europe/Budapest CEST/CET).
+MINDIG az install időzónáját használd: **${APP_TZ}** (a teljes telepítés ebben az EGY zónában dolgozik: ütemezés ÉS megjelenítés).
 
-- **Jelenlegi idő**: \`date\` Bash első lépés időponti feladatoknál (heartbeat, naptár-művelet, scheduled-task analízis)
-- **Channel message \`ts\`**: UTC-ben jön (postfix \`Z\`), átkonvertálni Europe/Budapest-re (CEST = UTC+2 nyáron, CET = UTC+1 télen)
-- **Google Calendar list_events \`dateTime\`**: már lokál ISO 8601 (\`+02:00\` offset Budapestnek), OK
+- **Jelenlegi idő**: \`date\` Bash első lépés időponti feladatoknál (heartbeat, naptár-művelet, scheduled-task analízis) — a rendszeróra is ${APP_TZ}
+- **Channel message \`ts\`**: UTC-ben jön (postfix \`Z\`), átkonvertálni ${APP_TZ}-re
+- **Google Calendar list_events \`dateTime\`**: már lokál ISO 8601 offszettel, OK
 - **SQLite \`unixepoch()\`**: UTC, humán-megjelenítéshez \`localtime\` modifier kell
-- **Cron expressions** (scheduled-tasks task-config.json): node lokális TZ, Europe/Budapest
+- **Cron expressions** (scheduled-tasks + fleet-timer): a scheduler ${APP_TZ} időben értelmezi (SCHEDULER_TZ); a fleet-timer \`once --at\` = ${APP_TZ} fali óra
 
 Heartbeat-eknél és minden időpontot kezelő feladatnál kötelező: \`date\` Bash parancs az elemzés ELŐTT.
 

--- a/src/web/cron.ts
+++ b/src/web/cron.ts
@@ -1,4 +1,5 @@
 import { CronExpressionParser } from 'cron-parser'
+import { APP_TZ } from '../config.js'
 
 // All scheduled-task cron expressions (SKILL.md/task-config.json, the
 // dashboard schedule editor) are authored in the operator's own wall-clock
@@ -10,7 +11,9 @@ import { CronExpressionParser } from 'cron-parser'
 // each install pin its own IANA zone; unset falls back to the host's zone
 // (Intl reflects the OS/TZ env at process start), matching the pre-fix
 // behaviour for installs where host tz already equals the operator's.
-const CRON_TZ = process.env.SCHEDULER_TZ || Intl.DateTimeFormat().resolvedOptions().timeZone
+// One install-wide zone (config.APP_TZ = SCHEDULER_TZ || process zone), shared
+// with every human-facing time render so cron and display never diverge.
+const CRON_TZ = APP_TZ
 
 export function computeNextRun(cronExpression: string): number {
   const expr = CronExpressionParser.parse(cronExpression, { tz: CRON_TZ })

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -43,6 +43,7 @@ import {
   MAIN_AGENT_ID,
   WEB_PORT,
   HEARTBEAT_CALENDAR_ACCOUNT,
+  APP_TZ,
 } from '../config.js'
 import { logger } from '../logger.js'
 
@@ -180,7 +181,7 @@ When you receive the heartbeat prompt:
 2. **Format** the result as a single inter-agent message:
 
    \`\`\`
-   ## Heartbeat YYYY-MM-DD HH:MM (Europe/Budapest)
+   ## Heartbeat YYYY-MM-DD HH:MM (${APP_TZ})
 
    ### Calendar (next 2h)
    - HH:MM -- <summary> (<attendees>)

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process'
 import { join } from 'node:path'
 import { logger } from '../logger.js'
-import { MAIN_AGENT_ID, PROJECT_ROOT, RESPAWN_ENABLED } from '../config.js'
+import { MAIN_AGENT_ID, PROJECT_ROOT, RESPAWN_ENABLED, APP_TZ } from '../config.js'
 import { resolveFromPath } from '../platform.js'
 import { listAgentNames } from './agent-config.js'
 import { isAgentRunning, capturePane } from './agent-process.js'
@@ -130,7 +130,7 @@ async function sendBestEffortLogin(session: string): Promise<void> {
   }
 }
 
-// -- Quiet hours (23:00-06:00 Europe/Budapest) -------------------------------
+// -- Quiet hours (23:00-06:00 in the install zone, config.APP_TZ) ------------
 //
 // Overnight a dead token is not actionable: the fix is a manual browser
 // /login, and nobody does that at 03:00 -- but the healer used to re-alert
@@ -147,11 +147,11 @@ export function isQuietHour(hourLocal: number): boolean {
   return hourLocal >= QUIET_START_HOUR || hourLocal < QUIET_END_HOUR
 }
 
-// Local wall-clock hour in Europe/Budapest regardless of the host TZ (the
-// same explicit-TZ rule the rest of the fleet follows for time handling).
-export function budapestHour(nowMs: number): number {
+// Wall-clock hour in the install zone (config.APP_TZ) regardless of the host TZ,
+// the same explicit-TZ rule the whole fleet follows for time handling.
+export function localHour(nowMs: number): number {
   return parseInt(
-    new Intl.DateTimeFormat('en-GB', { timeZone: 'Europe/Budapest', hour: '2-digit', hour12: false }).format(new Date(nowMs)),
+    new Intl.DateTimeFormat('en-GB', { timeZone: APP_TZ, hour: '2-digit', hour12: false }).format(new Date(nowMs)),
     10,
   )
 }
@@ -276,7 +276,7 @@ export function startReauthHealer(): NodeJS.Timeout | null {
   }
 
   function sweep(): void {
-    const quiet = isQuietHour(budapestHour(Date.now()))
+    const quiet = isQuietHour(localHour(Date.now()))
     // Main agent: escalate-only (no autonomous /login into a live always-on
     // conversation). capturePane returns null when it is down -> spell ends.
     try {

--- a/src/web/routes/background-tasks.ts
+++ b/src/web/routes/background-tasks.ts
@@ -6,6 +6,7 @@ import {
   type BackgroundTask,
 } from '../../db.js'
 import { resolveFromPath } from '../../platform.js'
+import { APP_TZ } from '../../config.js'
 import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
@@ -15,7 +16,7 @@ const CLAUDE = resolveFromPath('claude')
 const MAX_CONCURRENT = 3
 const TIMEOUT_MS = 30 * 60 * 1000
 
-const TZ = 'Europe/Budapest'
+const TZ = APP_TZ  // install zone (config.APP_TZ); was hardcoded Europe/Budapest
 
 function bgSessionName(id: string): string {
   return `bg-${id}`

--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -4,7 +4,7 @@ import {
   searchMemories, getMemoriesForChat, getDb,
   type Memory,
 } from '../../db.js'
-import { MAIN_AGENT_ID, ALLOWED_CHAT_ID, OLLAMA_URL } from '../../config.js'
+import { MAIN_AGENT_ID, ALLOWED_CHAT_ID, OLLAMA_URL, APP_TZ } from '../../config.js'
 import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
@@ -95,8 +95,8 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
     const formatted = results.map(m => ({
       ...m,
       embedding: undefined,
-      created_label: new Date(m.created_at * 1000).toLocaleString('hu-HU', { timeZone: 'Europe/Budapest' }),
-      accessed_label: new Date(m.accessed_at * 1000).toLocaleString('hu-HU', { timeZone: 'Europe/Budapest' }),
+      created_label: new Date(m.created_at * 1000).toLocaleString('hu-HU', { timeZone: APP_TZ }),
+      accessed_label: new Date(m.accessed_at * 1000).toLocaleString('hu-HU', { timeZone: APP_TZ }),
     }))
     json(res, formatted)
     return true

--- a/src/web/routes/recall.ts
+++ b/src/web/routes/recall.ts
@@ -1,9 +1,9 @@
 import { recallByDateRange, recallSearch, getDailyLogDates } from '../../db.js'
-import { MAIN_AGENT_ID } from '../../config.js'
+import { MAIN_AGENT_ID, APP_TZ } from '../../config.js'
 import { json } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
 
-const TZ = 'Europe/Budapest'
+const TZ = APP_TZ  // install zone (config.APP_TZ); was hardcoded Europe/Budapest
 
 function todayBudapest(): string {
   return new Intl.DateTimeFormat('sv-SE', { timeZone: TZ }).format(new Date())


### PR DESCRIPTION
… display

The scheduler already read SCHEDULER_TZ (falling back to the host zone), but every human-facing time was separately hardcoded to Europe/Budapest, so display and scheduling could diverge on a host in another zone.

- Add a single APP_TZ constant (config.ts): SCHEDULER_TZ, else the host zone.
- cron.ts and all display sites (heartbeat, daily-log, memory labels, recall, background-tasks, reauth quiet-hours, the agent scaffolds) now use APP_TZ, so cron and display share one zone.
- Rename reauth-healer budapestHour -> localHour (it was never Budapest-specific).
- Expose SCHEDULER_TZ on the dashboard Settings page via the existing registry (config-registry.ts), a requiresRestart string setting with a timezone dropdown.
- Tests made timezone-agnostic (no hardcoded zone), so a zone change never breaks them.

Default behaviour is unchanged for existing installs: with SCHEDULER_TZ unset the host zone is used exactly as before.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
