### PR TITLE
fix(stuck-input): recover parked [Pasted text #N] placeholder in watcher

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -10,6 +10,7 @@ import {
   decideSubmitFollowup,
   decidePaneErrorAlert,
   stuckInputSignature,
+  parkedPasteSignature,
   decideStuckInputRecovery,
   parkedChannelInput,
   parkedInputText,
@@ -2018,5 +2019,78 @@ describe('paneShowsContextSaturation', () => {
   it('is false on empty/null-ish input', () => {
     expect(paneShowsContextSaturation('')).toBe(false)
     expect(paneShowsContextSaturation('   \n  ')).toBe(false)
+  })
+})
+
+describe('parkedPasteSignature (stuck [Pasted text #N] recovery)', () => {
+  it('returns a stable signature for a parked placeholder (current build, idle footer)', () => {
+    const sig = parkedPasteSignature(PENDING_PASTE)
+    expect(sig).not.toBeNull()
+    expect(sig).toContain('[Pasted text #1')
+  })
+
+  it('recovers the older build shape too (paste again to expand, no idle footer)', () => {
+    // The 'typing'-gated stuckInputSignature is null here (placeholder reads as
+    // busy), which is exactly the gap this function fills.
+    expect(stuckInputSignature(PENDING_PASTE_REALISTIC)).toBeNull()
+    expect(parkedPasteSignature(PENDING_PASTE_REALISTIC)).not.toBeNull()
+  })
+
+  it('recovers the real wrapped-stub production shape', () => {
+    expect(parkedPasteSignature(PENDING_PASTE_WRAPPED_REAL_SHAPE)).not.toBeNull()
+    expect(parkedPasteSignature(PENDING_PASTE_WRAPPED_DIGIT_SPLIT)).not.toBeNull()
+  })
+
+  it('is null when NO placeholder is parked (plain typing / idle / empty)', () => {
+    expect(parkedPasteSignature(TYPING_PARKED)).toBeNull()
+    expect(parkedPasteSignature('')).toBeNull()
+    expect(parkedPasteSignature('   \n  ')).toBeNull()
+  })
+
+  it('does NOT misfire on a placeholder quoted only in scrollback', () => {
+    expect(parkedPasteSignature(PASTE_ECHO_IN_SCROLLBACK_ONLY)).toBeNull()
+  })
+
+  it('is null while a live busy indicator is present (genuine in-progress paste)', () => {
+    // Placeholder in the box AND a live spinner/token line just above it: the
+    // turn is actually running, so recovery must NOT pre-empt it.
+    const busyPaste = [
+      '  Beaming… (12s · ↓ 3.1k tokens · esc to interrupt)',
+      SEP,
+      '❯ [Pasted text #7 +512 chars]',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(parkedPasteSignature(busyPaste)).toBeNull()
+  })
+
+  it('is null when a token-counter busy tail is present without a spinner label', () => {
+    const busyTail = [
+      '  (52s · ↓ 2.6k tokens · esc to interrupt)',
+      SEP,
+      '❯ [Pasted text #9]',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(parkedPasteSignature(busyTail)).toBeNull()
+  })
+
+  it('sanitized real incident shape: finished turn + parked paste -> recoverable', () => {
+    // Mirrors the observed Aura capture: a past-tense "Baked for Ns" stamp (NOT
+    // a live busy indicator) above the idle hint, with the scheduled-task notice
+    // collapsed into a paste stub in the box.
+    const auraShape = [
+      '● Kihagytam a delelotti nudge-ot, mert ma mar boven volt interakcio.',
+      '',
+      '✻ Baked for 33s',
+      '                    new task? /clear to save 108.3k tokens',
+      SEP,
+      '❯ SCHEDULED TASK NOTICE -- the next <scheduled-task source="..."> [Pasted text',
+      '  #2 +1 lines]',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(stuckInputSignature(auraShape)).toBeNull()
+    expect(parkedPasteSignature(auraShape)).not.toBeNull()
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -922,6 +922,44 @@ export function stuckInputSignature(pane: string): string | null {
   return sig.length > 0 ? sig : null
 }
 
+// A stable signature of a PARKED `[Pasted text #N]` placeholder sitting in the
+// live input box that the trailing Enter never submitted, or null when there is
+// no such stuck paste. The paste-placeholder sibling of stuckInputSignature().
+//
+// It exists because detectPaneState() deliberately reads a paste placeholder as
+// 'busy' (so the scheduler / keepalive do not pile a second prompt onto it),
+// which makes stuckInputSignature() -- and the whole 'typing'-gated recovery
+// chain (parkedChannelInput, parkedInputText, recoverStuckInputForSession) --
+// return null for it. A long inbound prompt (e.g. a scheduled-task notice
+// > ~700 chars) that the TUI collapses into a `[Pasted text #N]` stub therefore
+// sat parked FOREVER, recoverable only by a manual keystroke (observed on
+// sub-agents repeatedly). This signature lets the stuck-input watcher time-gate
+// a BARE recovery Enter for it -- a placeholder submits on a SINGLE Enter even
+// though it renders across multiple visual rows, so it must never go through the
+// multi-row 'hold' guard, and its collapsed body is NOT recoverable from the
+// pane so clear + re-inject would destroy it.
+//
+// A live busy indicator (spinner / token counter / `esc to interrupt`) means a
+// genuine in-progress paste about to submit on its own -> returns null so a
+// healthy turn is never pre-empted; combined with the watcher's confirm window
+// (the SAME signature must persist for confirmMs) a paste that submits within a
+// second or two is never Enter-spammed. detectsPastePlaceholder() already scopes
+// the stub match to the live input box, so a `[Pasted text #N]` quoted in a
+// reply line or deep scrollback cannot trigger a false recovery.
+export function parkedPasteSignature(pane: string): string | null {
+  if (!pane || !pane.trim()) return null
+  const lines = pane.split('\n')
+  const busyRegion = lines.slice(-BUSY_LIVE_REGION_LINES).join('\n')
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(busyRegion)) return null
+  }
+  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return null
+  if (!detectsPastePlaceholder(pane)) return null
+  const sig = pastePlaceholderRegion(pane).replace(/\s+/g, ' ').trim()
+  return sig.length > 0 ? sig : null
+}
+
 export interface ParkedChannelInput {
   /** True only when the parked block is captured intact -- opening
    * <channel source="plugin:..."> tag WITH a chat_id AND a closing

--- a/src/web/stuck-input-watcher.ts
+++ b/src/web/stuck-input-watcher.ts
@@ -7,6 +7,7 @@ import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { recoverStuckInputForSession, sendAlert } from './channel-monitor.js'
 import {
   stuckInputSignature,
+  parkedPasteSignature,
   decideStuckInputRecovery,
   type StuckInputState,
   type StuckInputThresholds,
@@ -77,6 +78,57 @@ const INTERVAL_MS = 15_000
 const NO_STATE: StuckInputState = { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
 
 const watchState = new Map<string, StuckInputState>()
+
+// Backstop for a PARKED `[Pasted text #N]` placeholder -- a long inbound prompt
+// (e.g. a scheduled-task notice > ~700 chars) the TUI collapsed into a paste
+// stub whose trailing Enter was swallowed. detectPaneState reads a placeholder
+// as 'busy' (correct for the scheduler: don't pile a second prompt on), so the
+// 'typing'-gated recovery in checkLocalSession / bareEnterRecovery NEVER fires
+// for it and the stub sat parked until a manual keystroke. This runs FIRST per
+// session: a placeholder and a typing-parked box are mutually exclusive (a
+// placeholder forces detectPaneState -> 'busy', so stuckInputSignature is null),
+// so handling the paste case here and skipping the normal path on the same tick
+// cannot double-act on one session.
+//
+// Recovery is a BARE Enter only -- a placeholder submits on a single Enter even
+// though it renders across multiple visual rows, and the collapsed paste body is
+// not recoverable from the pane (clear + re-inject would DESTROY it). A bare
+// Enter submits the real pasted content verbatim, exactly what the manual
+// keystroke does. Host-aware, so a remote sub-agent is covered too. Time-gated
+// through the shared decideStuckInputRecovery so a healthy paste that submits on
+// its own within the confirm window is never Enter-spammed.
+//
+// Returns true when a parked-paste spell is active (recovered or still inside
+// its confirm/dedup window) so the caller SKIPS the normal recovery this tick;
+// false when there is no parked paste (caller runs the normal 'typing' path).
+function recoverParkedPaste(
+  label: string,
+  session: string,
+  host: string | null,
+  thresholds: StuckInputThresholds,
+): boolean {
+  const pane = captureParkedInputView(session, host)
+  const sig = pane == null ? null : parkedPasteSignature(pane)
+  if (sig == null) return false
+
+  const prev = watchState.get(session) ?? NO_STATE
+  const { recover, next } = decideStuckInputRecovery(sig, prev, Date.now(), thresholds)
+  watchState.set(session, next)
+
+  if (recover) {
+    logger.info(
+      { label, session, attempt: next.attempts },
+      'stuck-input-watcher: parked paste placeholder persisted past confirm window, sending recovery Enter',
+    )
+    sendEnterToSession(session, host)
+  } else if (next.attempts >= thresholds.maxAttempts && prev.attempts < thresholds.maxAttempts) {
+    logger.warn(
+      { label, session },
+      'stuck-input-watcher: paste placeholder still parked after max recovery Enters, giving up for this spell',
+    )
+  }
+  return true
+}
 
 // Bare-Enter recovery (host-aware). Used for the MAIN session (host null) and
 // for REMOTE sub-agents, where the local-tmux clear+re-inject is not
@@ -171,7 +223,12 @@ export function startStuckInputWatcher(): NodeJS.Timeout {
     // (no prompt-suggestion env-var on the main session). The give-up alert +
     // the rate-limited hard restart stay owned by channel-monitor (alert=false).
     try {
-      checkLocalSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, false, false)
+      // Parked paste placeholder takes precedence (mutually exclusive with a
+      // typing-parked box); only run the normal 'typing' recovery when there is
+      // no stuck paste this tick.
+      if (!recoverParkedPaste(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, null, LOCAL_FAST_THRESHOLDS)) {
+        checkLocalSession(MAIN_AGENT_ID, MAIN_CHANNELS_SESSION, false, false)
+      }
     } catch (err) {
       logger.debug({ err }, 'stuck-input-watcher: main agent check error')
     }
@@ -185,11 +242,17 @@ export function startStuckInputWatcher(): NodeJS.Timeout {
       try {
         // Local sub-agents get the full robust escalation (with a give-up
         // alert); remote-host ones (no local tmux for clear+re-inject) stay on
-        // the host-aware bare Enter.
+        // the host-aware bare Enter. In both cases a parked paste placeholder is
+        // handled first via a time-gated bare Enter (the 'typing'-gated paths
+        // below never see it -- a placeholder reads as 'busy').
         if (host == null) {
-          checkLocalSession(name, session, true, true)
+          if (!recoverParkedPaste(name, session, null, LOCAL_FAST_THRESHOLDS)) {
+            checkLocalSession(name, session, true, true)
+          }
         } else {
-          bareEnterRecovery(name, session, host)
+          if (!recoverParkedPaste(name, session, host, THRESHOLDS)) {
+            bareEnterRecovery(name, session, host)
+          }
         }
       } catch (err) {
         logger.debug({ err, agent: name }, 'stuck-input-watcher: agent check error')


### PR DESCRIPTION
## Problem

A long inbound prompt (e.g. a scheduled-task notice or inter-agent message > ~700 chars) is collapsed by the Claude Code TUI into a `[Pasted text #N]` stub in the input box. `detectPaneState()` deliberately classifies such a placeholder as `'busy'` so the scheduler/keepalive don't pile a second prompt on top — but that also makes `stuckInputSignature()`, `parkedChannelInput()` and `parkedInputText()` (all gated on the `'typing'` state) return `null` for it.

Result: the entire stuck-input recovery chain never fires for a paste placeholder. When the trailing Enter is swallowed, the stub sits **parked forever**, recoverable only by a manual keystroke. Observed repeatedly on sub-agents (most recently a scheduled-task notice wedged in a sub-agent's input box).

## Fix

- **`parkedPasteSignature()`** in `pane-state.ts`: a stable signature of a parked placeholder, returned only when **no live busy indicator** is present (a genuine in-progress paste about to submit returns `null`, so a healthy turn is never pre-empted). Combined with the watcher's confirm window, a paste that submits on its own within a second or two is never Enter-spammed.
- **`stuck-input-watcher.ts`** tries this first per session and, time-gated through the shared `decideStuckInputRecovery`, sends a **bare recovery Enter**. A placeholder submits on a single Enter even though it renders across multiple visual rows, and its collapsed body is not recoverable from the pane, so clear + re-inject would destroy it — a bare Enter submits the real pasted content verbatim, exactly what the manual keystroke does.
- Covers the MAIN channels session and both local and remote sub-agents.

## Safety

Fully additive — the `'typing'` recovery path is untouched. A placeholder and a typing-parked box are mutually exclusive (a placeholder forces `detectPaneState` → `'busy'`), so handling the paste case first and skipping the normal path on the same tick cannot double-act. No clear/re-inject and no re-typing, so there is no phantom-injection surface; `detectsPastePlaceholder()` already scopes the stub match to the live input box (a `[Pasted text #N]` quoted in a reply or scrollback cannot trigger it).

## Tests

8 new unit tests in `pane-state.test.ts` (current + older build shapes, wrapped-stub real shape, scrollback-quote false-positive guard, live-busy suppression, sanitized real incident shape). Full suite: **1855 passing**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
