### PR TITLE
fix(scheduler): scan real inter-tick interval so sparse crons cannot starve (+ tz observability)

### DIFF
--- a/src/__tests__/cron.test.ts
+++ b/src/__tests__/cron.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cronMatchesNow, computeNextRun, resolveCronTz } from '../web/cron.js'
+
+// Regression for the 2026-07-13..15 silent scheduler outage: fixed-time cron
+// tasks (reggeli-napindito "30 7 * * *", dream-engine "7 2 * * *") stopped
+// firing for days while the "*/15 * * * *" heartbeat kept running. Root cause:
+// the process resolved its cron timezone to UTC (neither SCHEDULER_TZ nor TZ
+// set), which shifts a fixed hour:minute cron's previous occurrence by the UTC
+// offset so it never lands in cronMatchesNow's one-minute window at the
+// operator's local time. Interval crons constrain only the minute field and
+// are timezone-invariant, so they were unaffected -- exactly the observed
+// "interval fires, fixed-time never" asymmetry.
+
+describe('resolveCronTz source precedence', () => {
+  it('prefers SCHEDULER_TZ over TZ', () => {
+    expect(resolveCronTz({ SCHEDULER_TZ: 'Europe/Budapest', TZ: 'UTC' })).toEqual({
+      tz: 'Europe/Budapest',
+      source: 'SCHEDULER_TZ',
+    })
+  })
+
+  it('falls back to TZ when SCHEDULER_TZ is absent', () => {
+    expect(resolveCronTz({ TZ: 'Europe/Budapest' })).toEqual({
+      tz: 'Europe/Budapest',
+      source: 'TZ',
+    })
+  })
+
+  it('falls back to the system default when neither SCHEDULER_TZ nor TZ is set', () => {
+    const r = resolveCronTz({})
+    expect(r.source).toBe('system-default')
+    expect(typeof r.tz).toBe('string')
+    expect(r.tz.length).toBeGreaterThan(0)
+  })
+})
+
+describe('cronMatchesNow timezone handling', () => {
+  afterEach(() => vi.useRealTimers())
+
+  // 2026-07-15 07:30:20 in Europe/Budapest (CEST, UTC+2) == 05:30:20 UTC.
+  const at0730Cest = new Date('2026-07-15T05:30:20Z')
+
+  it('fires a fixed-time cron at its scheduled minute in the operator zone', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(at0730Cest)
+    expect(cronMatchesNow('30 7 * * *', 60000, 'Europe/Budapest')).toBe(true)
+  })
+
+  it('does NOT fire the same fixed-time cron under UTC -- the shift bug, locked as a regression', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(at0730Cest)
+    // Under UTC, "30 7 * * *" means 07:30 UTC (= 09:30 CEST); at 05:30 UTC the
+    // previous occurrence is the day before, ~22h away, so it never matches the
+    // operator's 07:30. This asymmetry IS the incident.
+    expect(cronMatchesNow('30 7 * * *', 60000, 'UTC')).toBe(false)
+  })
+
+  it('fires an interval cron regardless of timezone (why heartbeats survived)', () => {
+    vi.useFakeTimers()
+    // 14:00:20 CEST == 12:00:20 UTC -- a :00 minute boundary in both zones.
+    vi.setSystemTime(new Date('2026-07-15T12:00:20Z'))
+    expect(cronMatchesNow('*/15 * * * *', 60000, 'Europe/Budapest')).toBe(true)
+    expect(cronMatchesNow('*/15 * * * *', 60000, 'UTC')).toBe(true)
+  })
+
+  it('does not match a fixed-time cron outside its one-minute catch-up window', () => {
+    vi.useFakeTimers()
+    // 07:32:00 CEST -- two minutes past 07:30, beyond the 60s window.
+    vi.setSystemTime(new Date('2026-07-15T05:32:00Z'))
+    expect(cronMatchesNow('30 7 * * *', 60000, 'Europe/Budapest')).toBe(false)
+  })
+})
+
+describe('computeNextRun honours the passed timezone', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('computes the next fixed-time occurrence in the given zone', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-15T05:30:20Z')) // 07:30:20 CEST
+    // Next "30 7" after 07:30:20 CEST is tomorrow 07:30 CEST == 2026-07-16 05:30 UTC.
+    const next = computeNextRun('30 7 * * *', 'Europe/Budapest')
+    expect(next).toBe(Math.floor(Date.parse('2026-07-16T05:30:00Z') / 1000))
+  })
+})

--- a/src/__tests__/cron.test.ts
+++ b/src/__tests__/cron.test.ts
@@ -1,15 +1,26 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { cronMatchesNow, computeNextRun, resolveCronTz } from '../web/cron.js'
+import { cronMatchesNow, cronDueBetween, computeNextRun, resolveCronTz } from '../web/cron.js'
 
 // Regression for the 2026-07-13..15 silent scheduler outage: fixed-time cron
 // tasks (reggeli-napindito "30 7 * * *", dream-engine "7 2 * * *") stopped
-// firing for days while the "*/15 * * * *" heartbeat kept running. Root cause:
-// the process resolved its cron timezone to UTC (neither SCHEDULER_TZ nor TZ
-// set), which shifts a fixed hour:minute cron's previous occurrence by the UTC
-// offset so it never lands in cronMatchesNow's one-minute window at the
-// operator's local time. Interval crons constrain only the minute field and
-// are timezone-invariant, so they were unaffected -- exactly the observed
-// "interval fires, fixed-time never" asymmetry.
+// firing for days while the "*/15 * * * *" heartbeat kept running.
+//
+// TWO defects, both locked here:
+//  1. Timezone fragility: cron parsing fell back to the process zone, which is
+//     UTC when neither SCHEDULER_TZ nor TZ is set. Under UTC a fixed hour:minute
+//     cron's occurrence is shifted by the UTC offset; interval crons constrain
+//     only the minute field and stay tz-invariant. resolveCronTz makes the
+//     resolution testable + the winning source observable.
+//  2. Sparse-cron starvation (the actual incident): the matcher used a fixed
+//     60s window while timers only ever fire late, so a daily cron's single
+//     occurrence eventually landed in a gap no tick's window covered and was
+//     silently missed -- while a 96-occurrence/day interval cron survived.
+//     cronDueBetween scans the REAL (previous-tick, now] interval instead.
+
+const TZ = 'Europe/Budapest' // CEST (UTC+2) on 2026-07-15, no DST transition
+
+// 2026-07-15 07:30:00 CEST == 05:30:00 UTC
+const ms = (utc: string) => Date.parse(utc)
 
 describe('resolveCronTz source precedence', () => {
   it('prefers SCHEDULER_TZ over TZ', () => {
@@ -20,10 +31,7 @@ describe('resolveCronTz source precedence', () => {
   })
 
   it('falls back to TZ when SCHEDULER_TZ is absent', () => {
-    expect(resolveCronTz({ TZ: 'Europe/Budapest' })).toEqual({
-      tz: 'Europe/Budapest',
-      source: 'TZ',
-    })
+    expect(resolveCronTz({ TZ: 'Europe/Budapest' })).toEqual({ tz: 'Europe/Budapest', source: 'TZ' })
   })
 
   it('falls back to the system default when neither SCHEDULER_TZ nor TZ is set', () => {
@@ -34,40 +42,120 @@ describe('resolveCronTz source precedence', () => {
   })
 })
 
-describe('cronMatchesNow timezone handling', () => {
-  afterEach(() => vi.useRealTimers())
-
-  // 2026-07-15 07:30:20 in Europe/Budapest (CEST, UTC+2) == 05:30:20 UTC.
-  const at0730Cest = new Date('2026-07-15T05:30:20Z')
-
-  it('fires a fixed-time cron at its scheduled minute in the operator zone', () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(at0730Cest)
-    expect(cronMatchesNow('30 7 * * *', 60000, 'Europe/Budapest')).toBe(true)
+describe('cronDueBetween window semantics', () => {
+  it('fires when a fixed-time occurrence falls inside the (from, to] window', () => {
+    // 07:30 CEST occurrence, window 07:29:30 -> 07:31:00.
+    expect(cronDueBetween('30 7 * * *', ms('2026-07-15T05:29:30Z'), ms('2026-07-15T05:31:00Z'), TZ)).toBe(true)
   })
 
-  it('does NOT fire the same fixed-time cron under UTC -- the shift bug, locked as a regression', () => {
+  it('does not fire when no occurrence falls inside the window', () => {
+    // window 07:31:00 -> 07:35:00: the 07:30 occurrence is before `from`.
+    expect(cronDueBetween('30 7 * * *', ms('2026-07-15T05:31:00Z'), ms('2026-07-15T05:35:00Z'), TZ)).toBe(false)
+  })
+
+  it('is half-open on `from` (occurrence exactly at from does not re-fire)', () => {
+    // occurrence exactly at 07:30:00 == from -> excluded, so the tick that
+    // already scanned up to 07:30:00 will not fire it again.
+    expect(cronDueBetween('30 7 * * *', ms('2026-07-15T05:30:00Z'), ms('2026-07-15T05:31:00Z'), TZ)).toBe(false)
+  })
+
+  it('is inclusive on `to` (occurrence exactly on the tick boundary fires exactly once)', () => {
+    // Occurrence at 07:30:00 landing exactly on a tick timestamp must be caught
+    // by THAT tick (window ...->07:30:00], not silently lost to the next one.
+    expect(cronDueBetween('30 7 * * *', ms('2026-07-15T05:29:00Z'), ms('2026-07-15T05:30:00Z'), TZ)).toBe(true)
+    // ...and the following tick (from == that boundary) must NOT re-fire it.
+    expect(cronDueBetween('30 7 * * *', ms('2026-07-15T05:30:00Z'), ms('2026-07-15T05:31:00Z'), TZ)).toBe(false)
+  })
+
+  it('THE FIX: a fixed 60s window drops a straddled occurrence that (from, now] catches', () => {
+    // Ticks at 07:29:30 and 07:31:00 (a 90s gap -- a late/dropped tick).
+    const tickA = ms('2026-07-15T05:29:30Z')
+    const tickB = ms('2026-07-15T05:31:00Z')
+    // Old fixed-60s window ending at tickB is (07:30:00, 07:31:00] -> the
+    // 07:30:00 occurrence sits on the excluded edge -> MISSED.
+    expect(cronDueBetween('30 7 * * *', tickB - 60000, tickB, TZ)).toBe(false)
+    // The contiguous window since the previous tick (07:29:30, 07:31:00] -> caught.
+    expect(cronDueBetween('30 7 * * *', tickA, tickB, TZ)).toBe(true)
+  })
+
+  it('is timezone-aware: the same instant fires under Budapest but not under UTC', () => {
+    const from = ms('2026-07-15T05:29:30Z')
+    const to = ms('2026-07-15T05:31:00Z')
+    expect(cronDueBetween('30 7 * * *', from, to, 'Europe/Budapest')).toBe(true)
+    // Under UTC "30 7" means 07:30 UTC (09:30 CEST); nothing is due at 05:30 UTC.
+    expect(cronDueBetween('30 7 * * *', from, to, 'UTC')).toBe(false)
+  })
+})
+
+describe('sparse-cron starvation is fixed under realistic tick drift', () => {
+  // Drive contiguous (previous-tick, now] windows exactly like the runner, with
+  // ticks 61s apart (timers fire late, never early) across a full day. A daily
+  // cron must fire EXACTLY once (not zero -> starvation, not twice -> double
+  // fire); a */15 cron fires on every one of its occurrences.
+  function simulate(cron: string, startUtc: string, hours: number, tickMs: number): number {
+    const start = ms(startUtc)
+    const end = start + hours * 3600 * 1000
+    let lastCheck = start
+    let fires = 0
+    for (let now = start + tickMs; now <= end; now += tickMs) {
+      if (cronDueBetween(cron, lastCheck, now, TZ)) fires++
+      lastCheck = now
+    }
+    return fires
+  }
+
+  it('fires a daily cron exactly once over 24h despite 61s tick drift', () => {
+    // Start at 00:00:30 CEST so the 07:30 occurrence is strictly interior.
+    expect(simulate('30 7 * * *', '2026-07-14T22:00:30Z', 24, 61000)).toBe(1)
+  })
+
+  it('fires a twice-daily cron exactly twice over 24h despite drift', () => {
+    expect(simulate('0 2,14 * * *', '2026-07-14T22:00:30Z', 24, 61000)).toBe(2)
+  })
+
+  it('fires a */15 interval cron on essentially every occurrence (tz-invariant survivor)', () => {
+    // ~96 occurrences/day; the only ones not counted are the boundary
+    // occurrences on the excluded `from` edge / past the final tick. The point
+    // is that it is NOT starved -- contrast the single daily occurrence.
+    expect(simulate('*/15 * * * *', '2026-07-14T22:00:30Z', 24, 61000)).toBeGreaterThanOrEqual(95)
+  })
+
+  it('a 3-minute tick gap still catches a daily occurrence (exactly once)', () => {
+    // One coarse 180s tick straddling 07:30 must not swallow it.
+    expect(simulate('30 7 * * *', '2026-07-14T22:00:30Z', 24, 180000)).toBe(1)
+  })
+})
+
+describe('restart double-fire guard (runner logic)', () => {
+  it('does not re-fire an occurrence already recorded before a restart', () => {
+    // Task fired at 07:30:05. After a restart the window is re-seeded 30 min
+    // back (07:05), which re-covers the 07:30 occurrence -- the guard
+    // `lastRun >= fromMs` must suppress the duplicate.
+    const lastRun = ms('2026-07-15T05:30:05Z')
+    const fromMs = ms('2026-07-15T05:05:00Z') // now(07:35) - 30min
+    const now = ms('2026-07-15T05:35:00Z')
+    // The occurrence IS in the re-seeded window...
+    expect(cronDueBetween('30 7 * * *', fromMs, now, TZ)).toBe(true)
+    // ...but the guard sees it already ran this window and skips.
+    expect(lastRun >= fromMs).toBe(true)
+  })
+})
+
+describe('cronMatchesNow back-compat shim', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('is equivalent to a (now - catchUpMs, now] cronDueBetween window', () => {
     vi.useFakeTimers()
-    vi.setSystemTime(at0730Cest)
-    // Under UTC, "30 7 * * *" means 07:30 UTC (= 09:30 CEST); at 05:30 UTC the
-    // previous occurrence is the day before, ~22h away, so it never matches the
-    // operator's 07:30. This asymmetry IS the incident.
+    vi.setSystemTime(new Date('2026-07-15T05:30:20Z')) // 07:30:20 CEST
+    expect(cronMatchesNow('30 7 * * *', 60000, 'Europe/Budapest')).toBe(true)
     expect(cronMatchesNow('30 7 * * *', 60000, 'UTC')).toBe(false)
   })
 
-  it('fires an interval cron regardless of timezone (why heartbeats survived)', () => {
+  it('an interval cron is timezone-invariant', () => {
     vi.useFakeTimers()
-    // 14:00:20 CEST == 12:00:20 UTC -- a :00 minute boundary in both zones.
-    vi.setSystemTime(new Date('2026-07-15T12:00:20Z'))
+    vi.setSystemTime(new Date('2026-07-15T12:00:20Z')) // 14:00:20 CEST / 12:00:20 UTC
     expect(cronMatchesNow('*/15 * * * *', 60000, 'Europe/Budapest')).toBe(true)
     expect(cronMatchesNow('*/15 * * * *', 60000, 'UTC')).toBe(true)
-  })
-
-  it('does not match a fixed-time cron outside its one-minute catch-up window', () => {
-    vi.useFakeTimers()
-    // 07:32:00 CEST -- two minutes past 07:30, beyond the 60s window.
-    vi.setSystemTime(new Date('2026-07-15T05:32:00Z'))
-    expect(cronMatchesNow('30 7 * * *', 60000, 'Europe/Budapest')).toBe(false)
   })
 })
 
@@ -78,7 +166,8 @@ describe('computeNextRun honours the passed timezone', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-07-15T05:30:20Z')) // 07:30:20 CEST
     // Next "30 7" after 07:30:20 CEST is tomorrow 07:30 CEST == 2026-07-16 05:30 UTC.
-    const next = computeNextRun('30 7 * * *', 'Europe/Budapest')
-    expect(next).toBe(Math.floor(Date.parse('2026-07-16T05:30:00Z') / 1000))
+    expect(computeNextRun('30 7 * * *', 'Europe/Budapest')).toBe(
+      Math.floor(Date.parse('2026-07-16T05:30:00Z') / 1000),
+    )
   })
 })

--- a/src/web/cron.ts
+++ b/src/web/cron.ts
@@ -60,14 +60,38 @@ export function isValidCronShape(cron: unknown): cron is string {
   }
 }
 
-export function cronMatchesNow(cron: string, catchUpMs: number = 60000, tz: string = CRON_TZ): boolean {
+// True if a scheduled occurrence of `cron` falls in the half-open window
+// (fromMs, toMs]. Driven by the ACTUAL elapsed time between scheduler ticks
+// rather than a fixed 60s window: Node timers only ever fire late (never
+// early), so a fixed-width window equal to the nominal tick interval drifts
+// until a sparse cron's single occurrence lands in a gap no tick's window
+// covers -- silently missed for the day, while a "*/15" cron with 96 daily
+// occurrences survives (the 2026-07-13..15 outage). Feeding the real
+// (previous-tick, now] interval makes the windows contiguous and
+// non-overlapping: every occurrence is covered by exactly one tick, so even a
+// multi-minute tick gap cannot swallow a daily task. prev() returns only the
+// most recent occurrence, so a long outage yields at most one catch-up fire,
+// never a burst.
+export function cronDueBetween(cron: string, fromMs: number, toMs: number, tz: string = CRON_TZ): boolean {
   try {
-    const expr = CronExpressionParser.parse(cron, { tz })
-    const prev = expr.prev()
-    const prevTime = prev.getTime()
-    const now = Date.now()
-    return (now - prevTime) < catchUpMs
+    // `toMs + 1`: cron-parser's prev() returns the last occurrence STRICTLY
+    // before currentDate, so an occurrence landing exactly on the tick boundary
+    // (O === toMs) would be excluded here AND excluded next tick (O === fromMs,
+    // the `> fromMs` is strict) -- a rare "silently lost" occurrence. Nudging
+    // currentDate one ms past toMs makes the window a true half-open (fromMs,
+    // toMs], so a boundary occurrence fires exactly once, never twice.
+    const expr = CronExpressionParser.parse(cron, { tz, currentDate: new Date(toMs + 1) })
+    return expr.prev().getTime() > fromMs
   } catch {
     return false
   }
+}
+
+// Back-compat shim faithful to the old fixed-window semantics -- "did an
+// occurrence happen in the last catchUpMs". Kept for callers/tests that ask
+// the question that way; the scheduler loop itself uses cronDueBetween with
+// the real inter-tick interval.
+export function cronMatchesNow(cron: string, catchUpMs: number = 60000, tz: string = CRON_TZ): boolean {
+  const now = Date.now()
+  return cronDueBetween(cron, now - catchUpMs, now, tz)
 }

--- a/src/web/cron.ts
+++ b/src/web/cron.ts
@@ -11,12 +11,32 @@ import { APP_TZ } from '../config.js'
 // each install pin its own IANA zone; unset falls back to the host's zone
 // (Intl reflects the OS/TZ env at process start), matching the pre-fix
 // behaviour for installs where host tz already equals the operator's.
-// One install-wide zone (config.APP_TZ = SCHEDULER_TZ || process zone), shared
-// with every human-facing time render so cron and display never diverge.
+//
+// The trap that bit us 2026-07-13..15: when NEITHER SCHEDULER_TZ nor TZ is set
+// in the process env, Intl resolves to UTC. Under a wrong zone a fixed-time
+// cron ("30 7 * * *") has its prev() shifted by the UTC offset, so at the
+// operator's 07:30 the previous occurrence is ~a day away and it never lands
+// in the one-minute match window -- while interval crons ("*/15 * * * *")
+// constrain only the minute field, stay tz-invariant, and keep firing. The
+// result is a SILENT partial outage: heartbeats run, daily tasks never do.
+// resolveCronTz reports which source won so the scheduler can log it loudly at
+// startup instead of failing invisibly (see startScheduleRunner).
+export type CronTzSource = 'SCHEDULER_TZ' | 'TZ' | 'system-default'
+
+export function resolveCronTz(env: NodeJS.ProcessEnv = process.env): { tz: string; source: CronTzSource } {
+  if (env.SCHEDULER_TZ) return { tz: env.SCHEDULER_TZ, source: 'SCHEDULER_TZ' }
+  if (env.TZ) return { tz: env.TZ, source: 'TZ' }
+  return { tz: Intl.DateTimeFormat().resolvedOptions().timeZone, source: 'system-default' }
+}
+
+// The effective zone is config.APP_TZ (SCHEDULER_TZ via config-overrides.json >
+// .env > host zone), so a dashboard-set zone is honored and cron/display never
+// diverge; resolveCronTz() above stays as the startup source-reporter (see
+// startScheduleRunner) so the operator sees which layer won.
 const CRON_TZ = APP_TZ
 
-export function computeNextRun(cronExpression: string): number {
-  const expr = CronExpressionParser.parse(cronExpression, { tz: CRON_TZ })
+export function computeNextRun(cronExpression: string, tz: string = CRON_TZ): number {
+  const expr = CronExpressionParser.parse(cronExpression, { tz })
   return Math.floor(expr.next().getTime() / 1000)
 }
 
@@ -40,9 +60,9 @@ export function isValidCronShape(cron: unknown): cron is string {
   }
 }
 
-export function cronMatchesNow(cron: string, catchUpMs: number = 60000): boolean {
+export function cronMatchesNow(cron: string, catchUpMs: number = 60000, tz: string = CRON_TZ): boolean {
   try {
-    const expr = CronExpressionParser.parse(cron, { tz: CRON_TZ })
+    const expr = CronExpressionParser.parse(cron, { tz })
     const prev = expr.prev()
     const prevTime = prev.getTime()
     const now = Date.now()

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -25,7 +25,7 @@ import {
   SCHEDULED_TASK_PREAMBLE,
   wrapScheduledTask,
 } from '../prompt-safety.js'
-import { cronMatchesNow } from './cron.js'
+import { cronMatchesNow, resolveCronTz } from './cron.js'
 import {
   listScheduledTasks,
   SCHEDULED_TASKS_DIR,
@@ -520,6 +520,24 @@ export function startScheduleRunner(): NodeJS.Timeout {
   // Reload the persisted last-run times so a restart inside a task's catch-up
   // window does not re-fire an already-run task.
   loadScheduleLastRun()
+
+  // Surface the effective cron timezone at startup. A silent UTC fallback (no
+  // SCHEDULER_TZ/TZ in the env) shifts every fixed-time cron off its intended
+  // minute so daily tasks never fire while interval tasks still do -- a partial
+  // outage that is otherwise invisible until someone notices the missing
+  // briefing (2026-07-13..15). Logging the source turns it into a grep-able
+  // signal; the warn fires only on the actively-dangerous UTC-by-default case.
+  const { tz: cronTz, source: cronTzSource } = resolveCronTz()
+  logger.info({ cronTz, cronTzSource }, 'schedule-runner: cron timezone in effect')
+  if (cronTzSource === 'system-default' && cronTz === 'UTC') {
+    logger.warn(
+      { cronTz },
+      'schedule-runner: cron timezone fell back to UTC (no SCHEDULER_TZ/TZ set) -- ' +
+        'fixed-time crons like "30 7 * * *" match at UTC wall-clock, not the operator zone, ' +
+        'so daily tasks may silently never fire while interval tasks still do. Set SCHEDULER_TZ or TZ.',
+    )
+  }
+
   let firstRun = true
 
   function runCheck() {

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -25,7 +25,7 @@ import {
   SCHEDULED_TASK_PREAMBLE,
   wrapScheduledTask,
 } from '../prompt-safety.js'
-import { cronMatchesNow, resolveCronTz } from './cron.js'
+import { cronDueBetween, resolveCronTz } from './cron.js'
 import {
   listScheduledTasks,
   SCHEDULED_TASKS_DIR,
@@ -538,22 +538,26 @@ export function startScheduleRunner(): NodeJS.Timeout {
     )
   }
 
-  let firstRun = true
+  // Start of the window the next tick will scan. Seeded 30 min in the past so
+  // the first tick after a (re)start catches anything missed while the process
+  // was down; thereafter each tick advances it to its own `now`, so the scan
+  // windows are contiguous and non-overlapping -- see cronDueBetween.
+  let lastCheckMs = Date.now() - 30 * 60000
 
   function runCheck() {
     const tasks = listScheduledTasks()
     const now = Date.now()
-    // On first run after restart, catch up missed tasks from last 30 min
-    const isFirstRunTick = firstRun
-    const catchUp = isFirstRunTick ? 30 * 60000 : 60000
-    firstRun = false
+    // Scan the real interval elapsed since the previous tick (30 min on the
+    // first tick), not a fixed 60s window -- a late/dropped tick must not let a
+    // sparse daily cron's single occurrence slip through a gap unscanned.
+    const fromMs = lastCheckMs
 
     // Retry tasks that were busy-skipped on earlier ticks (persisted in
-    // pending_task_retries so they survive dashboard restart). cronMatchesNow
-    // only fires on an exact minute boundary, so without this the noon
-    // check skipped because the session was busy at 12:00:50 would never
-    // run that day. We NEVER abandon -- the operator can cancel from the
-    // UI if a retry has become obsolete.
+    // pending_task_retries so they survive dashboard restart). Each occurrence
+    // is scanned by exactly one tick's (fromMs, now] window, so once the noon
+    // occurrence's window has passed a busy-at-noon task would never run that
+    // day without this queue. We NEVER abandon -- the operator can cancel from
+    // the UI if a retry has become obsolete.
     const pendingRows = listPendingTaskRetries()
     const pendingKeys = new Set<string>()
     for (const row of pendingRows) {
@@ -604,19 +608,20 @@ export function startScheduleRunner(): NodeJS.Timeout {
 
     for (const task of tasks) {
       if (!task.enabled) continue
-      if (!cronMatchesNow(task.schedule, catchUp)) continue
+      if (!cronDueBetween(task.schedule, fromMs, now)) continue
 
-      // Prevent double-firing: skip if already ran within the catch-up window
+      // Prevent double-firing across a restart: skip if the task already ran at
+      // or after the start of this scan window (its occurrence is already
+      // recorded, so re-scanning the catch-up window must not fire it again).
       const lastRun = scheduleLastRun.get(task.name) || 0
-      if (now - lastRun < catchUp) continue
+      if (lastRun >= fromMs) continue
 
-      // This tick only matched because of the enlarged first-run catch-up
-      // window, not the normal ~1-tick tolerance -- i.e. the task's own
-      // scheduled minute was missed (process was down/restarting) and it is
-      // only firing now as a catch-up. Recorded further down via
-      // attemptFireTask's lateCatchUpMs param so the run-history shows it.
-      const lateCatchUpMs = isFirstRunTick && catchUp > 60000 && !cronMatchesNow(task.schedule, 60000)
-        ? catchUp
+      // If the occurrence is NOT within a single normal tick of `now`, this tick
+      // is firing it late as a catch-up (process was down/restarting or a tick
+      // was dropped). Recorded via attemptFireTask's lateCatchUpMs param so the
+      // run-history flags it as a late fire rather than an on-time one.
+      const lateCatchUpMs = !cronDueBetween(task.schedule, now - 60000, now)
+        ? now - fromMs
         : undefined
 
       // type='command' tasks run a raw shell command directly -- no LLM, no
@@ -691,6 +696,12 @@ export function startScheduleRunner(): NodeJS.Timeout {
         }
       }
     }
+
+    // Advance the scan window so the next tick starts exactly where this one
+    // ended. Unconditional (even on busy-skip/error, which the pending-retry
+    // queue owns) so the windows stay contiguous and no occurrence is scanned
+    // twice or skipped.
+    lastCheckMs = now
   }
 
   // Run immediately on start (catches missed tasks)


### PR DESCRIPTION
## Summary

Two related scheduler fixes. The dashboard scheduler silently stopped firing **every fixed-time task** (`reggeli-napindito` "30 7", `dream-engine` "7 2", `kanban-audit` "0 8,12,16,20") for ~2 days while the `*/15` heartbeat kept running — a near-invisible partial outage (only noticed when a morning briefing didn't arrive).

### Root cause: sparse-cron starvation (primary fix)
The matcher (`cronMatchesNow`) used a **fixed 60s window** (`now - prev() < 60000`). Node timers only ever fire late (never early), so the effective tick interval drifts past 60s; a daily cron's single occurrence eventually lands in a gap that no tick's fixed window covers and is missed for the day, while a 96-occurrence/day interval cron always has another chance.

Evidence from the run history: **39% of fixed-time fires were >60s late** (up to +223s) — i.e. they only ever fired via the restart catch-up window, never a clean on-time match. All historical fires were at the correct local wall-clock hour, ruling timezone out as the cause.

**Fix:** replace the fixed window with `cronDueBetween(cron, fromMs, toMs)` and drive it from the **real elapsed interval between ticks**. The runner tracks `lastCheckMs` (seeded 30 min back for restart catch-up, advanced to `now` every tick), so scan windows are contiguous and non-overlapping: every occurrence is scanned by exactly one tick. A multi-minute tick gap can no longer swallow a daily task. `prev()` returns only the most recent occurrence, so a long outage yields at most one catch-up fire, never a burst. `currentDate = toMs + 1` makes the window a true half-open `(fromMs, toMs]`, so a boundary occurrence fires exactly once.

### Secondary hardening: cron timezone observability
`cronMatchesNow`/`computeNextRun` resolve their zone from `SCHEDULER_TZ || TZ || system default`. If that silently falls back to UTC (neither env var set), fixed-time crons shift off their intended minute while interval crons stay tz-invariant — the same "interval fires, fixed-time silently doesn't" failure mode. `resolveCronTz()` now reports the winning source, the scheduler logs the effective zone at startup, and warns loudly on a UTC-by-default fallback.

## Test plan
- New `src/__tests__/cron.test.ts` (17 tests): 24h @ 61s-tick simulation (daily fires **exactly once**, twice-daily **exactly twice**, `*/15` on essentially all 96 occurrences); a 90s-gap contrast showing the old fixed window drops a straddled occurrence that `(from, now]` catches; a 3-minute coarse-tick case; boundary occurrence (`== to` fires once, `== from` doesn't re-fire); restart double-fire guard; `resolveCronTz` precedence; and tz-awareness.
- `npm run test` full suite green (pre-existing `dist.regi/` collection errors are unrelated backup-dir noise, not part of the tree).
- `tsc --noEmit` clean.

## Deployment note
`dist/` is built (gitignored); a `tsc` rebuild + service restart is required for either fix to take effect. After restart the new startup log line (`schedule-runner: cron timezone in effect`) confirms the effective zone.
