### PR TITLE
fix(ledger): enforce processing replayed context before answering new inbound

### DIFF
--- a/scripts/hooks/ledger-replay.py
+++ b/scripts/hooks/ledger-replay.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """SessionStart hook: on every session start/resume (incl. a respawn's fresh
-session), inject the recent conversation CONTEXT for THIS agent -- the last ~20
-turns in chronological order PLUS a highlighted OPEN QUESTION (the most recent
+session), inject the recent conversation CONTEXT for THIS agent -- up to the last
+DEFAULT_WINDOW turns (trimmed to DEFAULT_CHAR_BUDGET chars, ~4k tokens) in
+chronological order PLUS a highlighted OPEN QUESTION (the most recent
 inbound with no later reply). This is the deterministic mechanism: the fresh
 session does not need to REMEMBER anything; its context window already carries
 the conversation and the question to answer.
@@ -17,16 +18,25 @@ import json
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import ledger_lib  # noqa: E402
 
-# Roughly 4000 tokens of transcript context (~4 chars/token). If the recent
-# window exceeds this, the OLDEST turns are dropped so the injected context
-# stays bounded regardless of how chatty the recent conversation was.
-CONTEXT_CHAR_BUDGET = 16000
+# How many chars of transcript context to inject (~4 chars/token, so 16000 chars
+# ~= 4000 tokens). If the recent window exceeds this, the OLDEST turns are
+# dropped so the injected context stays bounded regardless of how chatty the
+# recent conversation was. Env override: LEDGER_CONTEXT_CHAR_BUDGET (raise it
+# only if a specific install genuinely needs a deeper replay -- the default is
+# deliberately lean so a fresh session does not carry needless context).
+DEFAULT_CHAR_BUDGET = 16000
+
+# How many recent turns to consider before the char budget trims. 20 keeps the
+# injected context lean; the continuity failure mode is NOT a too-short window
+# (a key fact usually sits well within 20 turns) but the fresh session not
+# *reading* the loaded block -- addressed by the mandatory directive below.
+# Env override: LEDGER_CONTEXT_WINDOW.
+DEFAULT_WINDOW = 20
 
 
-def _window_limit():
-    """How many recent turns to replay. Env override LEDGER_CONTEXT_WINDOW,
-    default ledger_lib.RECENT_LIMIT (20). Non-positive / non-numeric -> default."""
-    v = os.environ.get("LEDGER_CONTEXT_WINDOW")
+def _env_int(name, default):
+    """Positive int from env var `name`, else `default`. Non-positive / non-numeric -> default."""
+    v = os.environ.get(name)
     if v:
         try:
             n = int(v)
@@ -34,7 +44,15 @@ def _window_limit():
                 return n
         except ValueError:
             pass
-    return ledger_lib.RECENT_LIMIT
+    return default
+
+
+def _window_limit():
+    return _env_int("LEDGER_CONTEXT_WINDOW", DEFAULT_WINDOW)
+
+
+def _char_budget():
+    return _env_int("LEDGER_CONTEXT_CHAR_BUDGET", DEFAULT_CHAR_BUDGET)
 
 
 def main():
@@ -63,8 +81,9 @@ def main():
         transcript.append(f'  [{ts}] {who}: "{snippet}"')
 
     # Token guard: drop the OLDEST turns until the transcript fits the budget.
+    char_budget = _char_budget()
     total = sum(len(line) + 1 for line in transcript)
-    while len(transcript) > 1 and total > CONTEXT_CHAR_BUDGET:
+    while len(transcript) > 1 and total > char_budget:
         total -= len(transcript[0]) + 1
         transcript.pop(0)
 
@@ -85,6 +104,19 @@ def main():
             f'MOST a telegram reply tool (mcp__plugin_telegram_telegram__reply) '
             f'meghívásával a megfelelő chat_id-re, a fenti kontextusból folytatva.'
         )
+
+    # Nyomatékos záró direktíva. A betöltés önmagában nem elég: egy friss session
+    # hajlamos a legfrissebb BEJÖVŐ ingerre (pl. egy most érkezett kép) ugrani és
+    # a fenti kontextust háttérként kezelni. Ez a sor kötelezővé teszi a
+    # feldolgozást MIELŐTT bármely új üzenetre reagálna, hogy ne kérdezzen vissza
+    # olyat, ami fent már eldőlt.
+    parts.append(
+        "KÖTELEZŐ: MIELŐTT bármely új bejövő üzenetre válaszolsz, dolgozd fel a "
+        "fenti beszélgetést. A benne szereplő döntések, megállapodások és "
+        "folyamatban lévő szálak ÉRVÉNYESEK és folytatandók. NE kérdezz vissza "
+        "olyat, amit fent már megbeszéltetek (pl. \"mihez kell ez?\", ha fent már "
+        "eldőlt); a betöltött kontextusból folytass, ne kezdd elölről."
+    )
 
     out = {
         "hookSpecificOutput": {


### PR DESCRIPTION
## Bug

The SessionStart replay hook (`scripts/hooks/ledger-replay.py`) injects the recent conversation context so a fresh or respawned session can continue where it left off. Loading the context, however, is not enough on its own: a fresh session tends to jump straight to the most recent **inbound** stimulus (e.g. a just-arrived image) and treats the loaded block as mere background. It then re-asks something that was already settled earlier in the conversation ("what is this for?"), breaking continuity.

## Fix

- **Mandatory closing directive.** Append a strong closing instruction to the replay output telling the session to process the loaded conversation *before* reacting to any new inbound message, and to continue in-flight threads instead of starting over or re-asking resolved questions.
- **Env-configurable window/budget.** Make the replay window and char budget overridable via `LEDGER_CONTEXT_WINDOW` / `LEDGER_CONTEXT_CHAR_BUDGET`, through a shared `_env_int` helper. **Defaults unchanged:** `DEFAULT_WINDOW=20`, `DEFAULT_CHAR_BUDGET=16000`.

## How it was tested

`bash scripts/__tests__/conversation-ledger.test.sh` -> **33/34 pass**. The single failure (`replay: missing direction prefixes`) is a pre-existing, unrelated issue that fails identically on the base revision (verified by stashing this change and re-running).

🤖 Generated with Claude Code