### PR TITLE
fix(channel-health): detached MCP-reconnect worker -- take blocking reconnect off the event loop

### DIFF
--- a/src/__tests__/channel-health-monitor.test.ts
+++ b/src/__tests__/channel-health-monitor.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+// The health monitor runs the (synchronous, blocking) MCP reconnect in a
+// DETACHED child process so it can never starve the dashboard event loop, so we
+// assert on spawn(), not on an inline attemptChannelMcpReconnect call.
+const { mockSpawn } = vi.hoisted(() => ({ mockSpawn: vi.fn() }))
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
   execSync: vi.fn(),
+  spawn: mockSpawn,
 }))
 
 vi.mock('../platform.js', () => ({
@@ -70,6 +75,8 @@ describe('startChannelHealthMonitor', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
+    // Fake detached child: the monitor calls .once('exit'|'error', ...) + .unref().
+    mockSpawn.mockReturnValue({ once: vi.fn(), unref: vi.fn() })
   })
 
   afterEach(() => {
@@ -88,12 +95,11 @@ describe('startChannelHealthMonitor', () => {
 
     vi.advanceTimersByTime(46_000)
 
-    expect(mockReconnect).not.toHaveBeenCalled()
+    expect(mockSpawn).not.toHaveBeenCalled()
     clearInterval(timer)
   })
 
-  it('triggers reconnect when pane shows plugin failure', () => {
-    mockReconnect.mockReturnValue({ ok: false, message: 'test' })
+  it('spawns a detached reconnect worker when pane shows plugin failure', () => {
     const timer = startChannelHealthMonitor()
     mockCapturePane.mockReturnValue(
       'plugin:telegram:telegram  ✘ failed\nsome other output',
@@ -101,7 +107,12 @@ describe('startChannelHealthMonitor', () => {
 
     vi.advanceTimersByTime(46_000)
 
-    expect(mockReconnect).toHaveBeenCalled()
+    // Off-main-loop: a detached child (reconnect-cli.js) is spawned instead of
+    // calling attemptChannelMcpReconnect inline (event-loop starvation fix).
+    expect(mockSpawn).toHaveBeenCalled()
+    const [, args] = mockSpawn.mock.calls[0]
+    expect(String(args[0])).toContain('reconnect-cli')
+    expect(args[1]).toBe('marveen')
     clearInterval(timer)
   })
 })

--- a/src/web/channel-health-monitor.ts
+++ b/src/web/channel-health-monitor.ts
@@ -1,14 +1,50 @@
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID } from '../config.js'
 import { listAgentNames } from './agent-config.js'
 import { isAgentRunning, capturePane } from './agent-process.js'
 import {
-  attemptChannelMcpReconnect,
   resolveAgentSession,
   resolveAgentProviderType,
 } from './channel-mcp-reconnect.js'
 import { getProvider } from '../channel-provider.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+
+// The MCP reconnect (attemptChannelMcpReconnect) is deliberately synchronous --
+// it drives the interactive /mcp tmux menu with execFileSync('/bin/sleep', ...)
+// pacing. Calling it INLINE from this 60s timer BLOCKS the libuv event loop for
+// the full tmux+sleep duration; with several agents stuck in '✘ failed' the loop
+// is starved continuously and the dashboard accepts TCP but never services HTTP
+// (observed 2026-06-30: deaf for hours, 0% CPU, wedged in SyncProcessRunner under
+// uv__run_timers). So run it in a DETACHED child (reconnect-cli.js) -- the
+// blocking work happens off the main event loop. One in-flight reconnect per
+// agent (the child clears the flag on exit).
+const RECONNECT_CLI = fileURLToPath(new URL('./reconnect-cli.js', import.meta.url))
+const inFlightReconnects = new Set<string>()
+
+function spawnDetachedReconnect(agentName: string): boolean {
+  if (inFlightReconnects.has(agentName)) return false
+  inFlightReconnects.add(agentName)
+  try {
+    const child = spawn(process.execPath, [RECONNECT_CLI, agentName], {
+      detached: true,
+      stdio: 'ignore',
+      env: process.env,
+    })
+    child.once('exit', () => inFlightReconnects.delete(agentName))
+    child.once('error', (err) => {
+      inFlightReconnects.delete(agentName)
+      logger.warn({ agentName, err }, 'channel-health-monitor: failed to spawn reconnect worker')
+    })
+    child.unref()
+    return true
+  } catch (err) {
+    inFlightReconnects.delete(agentName)
+    logger.warn({ agentName, err }, 'channel-health-monitor: reconnect spawn threw')
+    return false
+  }
+}
 
 // Detect `plugin:X · ✘ failed` (or ✘ error / ✘ disconnected) in the
 // pane output. Claude Code renders this in the MCP status area when a
@@ -81,12 +117,20 @@ function checkAgent(agentName: string, session: string): void {
   }
 
   const attempt = state ? state.attempts : 0
+  // A detached reconnect for this agent may still be running from a prior tick;
+  // don't pile on (the blocking /mcp walk can outlast one 60s tick).
+  if (inFlightReconnects.has(agentName)) {
+    logger.debug({ agentName, attempt }, 'channel-health-monitor: reconnect already in flight, skipping')
+    return
+  }
   logger.warn(
     { agentName, attempt, provider: providerType },
-    'channel-health-monitor: plugin failure detected, attempting reconnect',
+    'channel-health-monitor: plugin failure detected, spawning detached reconnect',
   )
 
-  const result = attemptChannelMcpReconnect(agentName)
+  // Off-main-loop: the outcome is logged by reconnect-cli itself; here we only
+  // record that we attempted, for backoff. Spawn-failure keeps the old backoff.
+  spawnDetachedReconnect(agentName)
 
   const backoffMs = getBackoffMs(attempt)
   reconnectState.set(agentName, {
@@ -94,15 +138,6 @@ function checkAgent(agentName: string, session: string): void {
     lastAttemptAt: now,
     nextRetryAt: now + backoffMs,
   })
-
-  if (result.ok) {
-    logger.info({ agentName, attempt }, 'channel-health-monitor: reconnect succeeded')
-  } else {
-    logger.warn(
-      { agentName, attempt, message: result.message },
-      'channel-health-monitor: reconnect failed',
-    )
-  }
 }
 
 export function startChannelHealthMonitor(): NodeJS.Timeout {

--- a/src/web/reconnect-cli.ts
+++ b/src/web/reconnect-cli.ts
@@ -1,0 +1,34 @@
+// Standalone entry so the channel health monitor can run the (deliberately
+// synchronous, tmux-driven) MCP reconnect OFF the dashboard's main event loop.
+//
+// Root cause it fixes: attemptChannelMcpReconnect() walks the interactive /mcp
+// tmux menu with execFileSync('/bin/sleep', ...) pacing. Run inline from the
+// 60s health-monitor timer, that sequence BLOCKS the libuv event loop for the
+// full tmux+sleep duration; with several agents in '✘ failed' state the loop is
+// starved continuously and the dashboard accepts TCP connections but never
+// services HTTP requests (observed 2026-06-30: deaf for hours, 0% CPU, stuck in
+// node::SyncProcessRunner::Spawn under uv__run_timers). Spawning this CLI
+// detached keeps the blocking work in a throwaway child process.
+//
+// Usage: node dist/web/reconnect-cli.js <agentName>
+import { attemptChannelMcpReconnect } from './channel-mcp-reconnect.js'
+import { logger } from '../logger.js'
+
+const agentName = process.argv[2]
+if (!agentName) {
+  // eslint-disable-next-line no-console
+  console.error('reconnect-cli: missing agentName argument')
+  process.exit(2)
+}
+
+try {
+  const result = attemptChannelMcpReconnect(agentName)
+  logger.info(
+    { agentName, ok: result.ok, message: result.message },
+    'reconnect-cli: reconnect attempt finished',
+  )
+  process.exit(result.ok ? 0 : 1)
+} catch (err) {
+  logger.error({ agentName, err }, 'reconnect-cli: reconnect attempt threw')
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

Extracts the safe, high-value slice of #555 (which is too stale to rebase — see its verify verdict): the `reconnect-cli.ts` detached worker. Credited to zollak.

The `channel-health-monitor` called `attemptChannelMcpReconnect()` **inline** on its 60s timer. That routine drives the interactive `/mcp` tmux menu with blocking `execFileSync('/bin/sleep', ...)` pacing, so with several agents in `✘ failed` the libuv event loop is starved continuously — the dashboard accepts TCP but never services HTTP (2026-06-30: deaf for hours, 0% CPU, wedged in `SyncProcessRunner` under `uv__run_timers`). This is the concrete starvation source the #555 verify flagged as still-present on develop.

## Changes (minimal, additive)

- **`src/web/reconnect-cli.ts`** (net-new): standalone entry that runs the (still synchronous) `attemptChannelMcpReconnect` and exits 0/1. The blocking work now lives in a throwaway child process.
- **`channel-health-monitor.ts`**: spawns `reconnect-cli.js` **detached** (`stdio:'ignore'`, `unref()`) instead of calling reconnect inline, with a **one-in-flight-per-agent** guard (a reconnect that outlasts a 60s tick isn't piled on). Backoff/state and every other health-monitor path are unchanged; the outcome is logged by the CLI child.
- **test**: updated to assert a detached `spawn` of `reconnect-cli` (with the agent name) instead of an inline reconnect call.

The broader sync→async conversion in #555 (34 `execFileSync('/bin/sleep')` across `sendPromptToSession`/`waitForPaneIdle`/etc.) stays OUT of this PR — it's the systemic fix but crash-loop-prone and too stale to rebase; scoped separately for staged in-house work.

## Testing

- `tsc --noEmit` clean; build emits `dist/web/reconnect-cli.js`.
- `channel-health-monitor.test.ts` 4/4 (spawn-detached asserted).
- Full suite green from a non-/tmp checkout (90/90 on the 4 relevant files incl. the 3 hook-registration suites). Note: those 3 hook suites FALSE-fail from a `/tmp` worktree because `isUnsafeHookCommand` correctly rejects `/private/tmp` paths — environmental, not a regression (verified 90/90 from `.claude/worktrees`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)