### PR TITLE
feat(costops): provider collectors + forecast/FX/reconciliation (slice 2 of the CostOps series)

### DIFF
--- a/src/__tests__/costops-collectors-dryrun.test.ts
+++ b/src/__tests__/costops-collectors-dryrun.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { anthropicCollector } from '../costops/collectors/anthropic.js'
+import { dryRunCollector, describeShape } from '../costops/collectors/runner.js'
+import { monthWindow } from '../costops/ledger.js'
+import type { CollectOpts, HttpGetJson } from '../costops/collectors/types.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const FX = 308.91
+const SECRET = 'sk-DRYRUN-must-not-leak-9876543210'
+
+// Offline fixture -- NO live API is ever called in tests.
+const FIXTURE = {
+  data: [{
+    starting_at: '2026-07-01T00:00:00Z',
+    ending_at: '2026-07-31T00:00:00Z',
+    results: [
+      { currency: 'USD', amount: '30', cost_type: 'api_usage', model: 'claude-opus-4-8' },
+      { currency: 'USD', amount: '20', cost_type: 'api_usage', model: 'claude-sonnet-4-6' },
+    ],
+  }],
+  has_more: false,
+}
+
+function opts(httpGetJson: HttpGetJson): CollectOpts {
+  const w = monthWindow(NOW)
+  return { periodStart: w.start, periodEnd: w.end, secret: SECRET, fxUsdHuf: FX, idSalt: 'salt', httpGetJson }
+}
+
+describe('describeShape (types only, no values)', () => {
+  it('returns structure with no scalar values', () => {
+    const shape = describeShape(FIXTURE)
+    // shape carries keys + types + array lengths, but NOT the numbers/strings themselves
+    const dump = JSON.stringify(shape)
+    expect(dump).not.toContain('claude-opus-4-8')  // no model value
+    expect(dump).not.toContain('30')               // no amount value
+    expect(dump).not.toContain('2026-07-01')       // no date value
+    // but the schema IS described
+    expect(shape).toMatchObject({ type: 'object' })
+    expect((shape as any).keys.data).toMatchObject({ type: 'array', length: 1 })
+    expect((shape as any).keys.data.of.keys.results).toMatchObject({ type: 'array', length: 2 })
+    expect((shape as any).keys.has_more).toBe('boolean')
+  })
+})
+
+describe('dryRunCollector (offline, persists NOTHING to cost_line_items)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('normalizes and shows planned lines + dedup_keys + response shape', async () => {
+    const stub: HttpGetJson = async () => FIXTURE
+    const rep = await dryRunCollector({ db: getDb(), collector: anthropicCollector, opts: opts(stub), now: NOW })
+    expect(rep.status).toBe('dry_run')
+    expect(rep.wouldImportCount).toBe(1)
+    // normalized: (30+20)*308.91 = 15445.5
+    expect(rep.plannedLines[0].amount).toBe(15445.5)
+    expect(rep.plannedLines[0].confidence).toBe('provider_api')
+    expect(rep.dedupKeys).toEqual(['provider|anthropic|anthropic-api|2026-07|provider_api'])
+    // sanitized response shape present, types only
+    expect(rep.responseShape).not.toBeNull()
+    expect((rep.responseShape as any).keys.has_more).toBe('boolean')
+  })
+
+  it('does NOT write any provider_api cost_line_item', async () => {
+    const db = getDb()
+    await dryRunCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    const n = db.prepare("SELECT COUNT(*) n FROM cost_line_items WHERE confidence='provider_api'").get() as { n: number }
+    expect(n.n).toBe(0)
+    const anyLine = db.prepare('SELECT COUNT(*) n FROM cost_line_items').get() as { n: number }
+    expect(anyLine.n).toBe(0)
+  })
+
+  it('does NOT write a final import; only a dry_run audit row with count 0', async () => {
+    const db = getDb()
+    await dryRunCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    const rows = db.prepare('SELECT status, imported_count FROM import_runs').all() as Array<{ status: string; imported_count: number }>
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe('dry_run')
+    expect(rows[0].imported_count).toBe(0)
+    // NO 'ok' import ever recorded by a dry-run
+    const okRuns = db.prepare("SELECT COUNT(*) n FROM import_runs WHERE status='ok'").get() as { n: number }
+    expect(okRuns.n).toBe(0)
+  })
+
+  it('recordRun:false persists absolutely nothing', async () => {
+    const db = getDb()
+    await dryRunCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW, recordRun: false })
+    const runs = db.prepare('SELECT COUNT(*) n FROM import_runs').get() as { n: number }
+    const lines = db.prepare('SELECT COUNT(*) n FROM cost_line_items').get() as { n: number }
+    expect(runs.n).toBe(0)
+    expect(lines.n).toBe(0)
+  })
+
+  it('on error: status=error, sanitized, writes NO cost line, secret never leaks', async () => {
+    const db = getDb()
+    const throwing: HttpGetJson = async () => { throw new Error(`rate limited, key ${SECRET} and token abcdef1234567890abcdef1234567890`) }
+    const rep = await dryRunCollector({ db, collector: anthropicCollector, opts: opts(throwing), now: NOW })
+    expect(rep.status).toBe('error')
+    expect(rep.errorMessageSanitized).not.toContain('sk-DRYRUN-must-not-leak')
+    expect(rep.wouldImportCount).toBe(0)
+    // nothing persisted to cost_line_items
+    const lines = db.prepare('SELECT COUNT(*) n FROM cost_line_items').get() as { n: number }
+    expect(lines.n).toBe(0)
+    // the whole DB + report never contain the secret
+    const dump = JSON.stringify(db.prepare('SELECT * FROM import_runs').all()) + JSON.stringify(rep)
+    expect(dump).not.toContain('sk-DRYRUN-must-not-leak')
+    expect(dump).not.toContain('9876543210')
+  })
+
+  it('report + audit row never contain the secret on the happy path', async () => {
+    const db = getDb()
+    const rep = await dryRunCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    const dump = JSON.stringify(rep) + JSON.stringify(db.prepare('SELECT * FROM import_runs').all())
+    expect(dump).not.toContain(SECRET)
+    expect(dump).not.toContain('sk-DRYRUN')
+  })
+})

--- a/src/__tests__/costops-collectors.test.ts
+++ b/src/__tests__/costops-collectors.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { mapAnthropicCostReport, anthropicCollector } from '../costops/collectors/anthropic.js'
+import { runCollector, sanitizeError } from '../costops/collectors/runner.js'
+import { validateCollectorsConfig } from '../costops/collectors/config.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+import type { CollectOpts, HttpGetJson } from '../costops/collectors/types.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const FX = 308.91
+
+function emptyConfig(): CostOpsConfig { return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] } }
+
+// Offline fixture -- matches the mapper; NO live API is ever called in tests.
+const FIXTURE = {
+  data: [{
+    starting_at: '2026-07-01T00:00:00Z',
+    ending_at: '2026-07-31T00:00:00Z',
+    results: [
+      { currency: 'USD', amount: '30', cost_type: 'api_usage', model: 'claude-opus-4-8' },
+      { currency: 'USD', amount: '20', cost_type: 'api_usage', model: 'claude-sonnet-4-6' },
+    ],
+  }],
+  has_more: false,
+}
+
+function opts(httpGetJson: HttpGetJson): CollectOpts {
+  const w = monthWindow(NOW)
+  return { periodStart: w.start, periodEnd: w.end, secret: 'sk-SECRET-must-not-leak-1234567890', fxUsdHuf: FX, idSalt: 'salt', httpGetJson }
+}
+
+describe('anthropic mapper (pure, offline)', () => {
+  it('aggregates USD -> HUF into one provider_api line for anthropic-api', () => {
+    const w = monthWindow(NOW)
+    const lines = mapAnthropicCostReport(FIXTURE, { periodStart: w.start, periodEnd: w.end, fxUsdHuf: FX, idSalt: 'salt', now: NOW })
+    expect(lines).toHaveLength(1)
+    expect(lines[0].service).toBe('anthropic-api')
+    expect(lines[0].provider).toBe('anthropic')
+    expect(lines[0].confidence).toBe('provider_api')
+    // (30 + 20) * 308.91 = 15445.5
+    expect(lines[0].amount).toBe(15445.5)
+    expect(lines[0].currency).toBe('HUF')
+    expect(lines[0].dedup_key).toBe('provider|anthropic|anthropic-api|2026-07|provider_api')
+    expect(lines[0].raw_ref_hash).not.toContain('anthropic-cost-report') // hashed
+  })
+  it('returns [] for an empty report', () => {
+    const w = monthWindow(NOW)
+    expect(mapAnthropicCostReport({ data: [] }, { periodStart: w.start, periodEnd: w.end, fxUsdHuf: FX, idSalt: 's', now: NOW })).toHaveLength(0)
+  })
+})
+
+describe('sanitizeError (no secret leaks)', () => {
+  it('redacts key-like substrings', () => {
+    const s = sanitizeError(new Error('auth failed for x-api-key: sk-abcdef1234567890abcdef and token abcdef1234567890abcdef1234567890'))
+    expect(s.message).not.toContain('sk-abcdef1234567890')
+    expect(s.message).toMatch(/\*\*\*/)
+  })
+})
+
+describe('collectors config validation', () => {
+  it('rejects a raw secret in secret_ref (must be vault:)', () => {
+    const r = validateCollectorsConfig({ collectors: [{ provider: 'anthropic', secret_ref: 'sk-raw-key' }] })
+    expect(r.config.collectors).toHaveLength(0)
+    expect(r.errors[0]).toContain('vault:')
+  })
+  it('accepts a vault: secret_ref', () => {
+    const r = validateCollectorsConfig({ fx_usd_huf: 308.91, collectors: [{ provider: 'anthropic', enabled: true, secret_ref: 'vault:costops.anthropic_admin_key' }] })
+    expect(r.config.collectors[0].secret_ref).toBe('vault:costops.anthropic_admin_key')
+    expect(r.errors).toEqual([])
+  })
+})
+
+describe('runCollector (offline stub, no live call)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('imports a provider_api line and records an ok import_run; idempotent', async () => {
+    const stub: HttpGetJson = async () => FIXTURE
+    const res1 = await runCollector({ db: getDb(), collector: anthropicCollector, opts: opts(stub), now: NOW })
+    expect(res1.status).toBe('ok')
+    expect(res1.importedCount).toBe(1)
+    // re-run -> no duplicate (dedup_key upsert)
+    await runCollector({ db: getDb(), collector: anthropicCollector, opts: opts(stub), now: NOW })
+    const n = getDb().prepare("SELECT COUNT(*) n FROM cost_line_items WHERE confidence='provider_api'").get() as { n: number }
+    expect(n.n).toBe(1)
+    const runs = getDb().prepare("SELECT COUNT(*) n FROM import_runs").get() as { n: number }
+    expect(runs.n).toBe(2) // two runs recorded, one line
+  })
+
+  it('does NOT overwrite the manual estimate; both coexist; headline resolves to actual', async () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    // seed a manual estimate for anthropic-api (like the v0.1 config sync)
+    db.prepare("INSERT INTO cost_sources (id,name,provider,source_type,currency,active,created_at,updated_at) VALUES ('anthropic-api','Anthropic API','anthropic','usage','HUF',1,?,?)").run(NOW, NOW)
+    db.prepare(`INSERT INTO cost_line_items (source_id,charge_period_start,charge_period_end,charge_category,service_name,billed_cost,currency,confidence,data_freshness,dedup_key,created_at)
+      VALUES ('anthropic-api',?,?,'usage','Anthropic API',17655,'HUF','estimate',?,'fixed|anthropic-api|2026-07',?)`).run(w.start, w.end, NOW, NOW)
+    await runCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    // both lines exist
+    const both = db.prepare("SELECT confidence, billed_cost FROM cost_line_items WHERE source_id='anthropic-api' ORDER BY confidence").all() as Array<{ confidence: string; billed_cost: number }>
+    expect(both.map(x => x.confidence).sort()).toEqual(['estimate', 'provider_api'])
+    // summary: headline resolves to provider_api actual (15445.5), reconcile shows both
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    expect(s.current_spend).toBe(15445.5)               // actual, not estimate, not summed
+    const rec = s.reconcile.find(r => r.source_id === 'anthropic-api')!
+    expect(rec.estimate).toBe(17655)
+    expect(rec.actual).toBe(15445.5)
+    expect(rec.variance).toBe(-2209.5)
+    expect(rec.resolved_confidence).toBe('provider_api')
+  })
+
+  it('on collector error: records status=error, sanitized, deletes NOTHING', async () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    // pre-existing good data
+    db.prepare("INSERT INTO cost_sources (id,name,provider,source_type,currency,active,created_at,updated_at) VALUES ('x','X','other','usage','HUF',1,?,?)").run(NOW, NOW)
+    db.prepare("INSERT INTO cost_line_items (source_id,charge_period_start,charge_period_end,charge_category,service_name,billed_cost,currency,confidence,data_freshness,dedup_key,created_at) VALUES ('x',?,?,'usage','X',100,'HUF','manual',?,'k',?)").run(w.start, w.end, NOW, NOW)
+    const throwing: HttpGetJson = async () => { throw new Error('rate limited, key sk-abcdef1234567890abcdef') }
+    const res = await runCollector({ db, collector: anthropicCollector, opts: opts(throwing), now: NOW })
+    expect(res.status).toBe('error')
+    expect(res.errorMessageSanitized).not.toContain('sk-abcdef1234567890')
+    // nothing deleted
+    const n = db.prepare("SELECT COUNT(*) n FROM cost_line_items").get() as { n: number }
+    expect(n.n).toBe(1)
+    // secret never appears in import_runs
+    const dump = JSON.stringify(db.prepare("SELECT * FROM import_runs").all())
+    expect(dump).not.toContain('sk-abcdef1234567890')
+    expect(dump).not.toContain('sk-SECRET-must-not-leak')
+  })
+
+  it('provider_sync appears in the summary after a run', async () => {
+    const db = getDb()
+    await runCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    const ps = s.provider_sync.find(p => p.provider === 'anthropic')!
+    expect(ps.status).toBe('ok')
+    expect(ps.imported_count).toBe(1)
+    expect(ps.collector_name).toBe('anthropic-cost-report')
+  })
+})

--- a/src/__tests__/costops-correction.test.ts
+++ b/src/__tests__/costops-correction.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { createCorrection, getCorrectionChain } from '../costops/correction.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const cfg: CostOpsConfig = { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] }
+
+function insertLine(db: import('better-sqlite3').Database, sourceId: string, amount: number, confidence = 'manual', actualSource = 'manual_entry'): number {
+  const win = monthWindow(NOW)
+  db.prepare(`INSERT OR IGNORE INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, 'other', 'usage', 'HUF', 1, ?, ?)`)
+    .run(sourceId, sourceId, NOW, NOW)
+  const info = db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+    VALUES (?, ?, ?, 'usage', ?, 'HUF', ?, ?, ?, ?, ?)
+  `).run(sourceId, win.start, win.end, amount, confidence, NOW, NOW, `test|${sourceId}|${Math.random()}`, actualSource)
+  return info.lastInsertRowid as number
+}
+
+describe('createCorrection (CostOps Phase 1, GAP-05/06/14 -- correction relationship)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('voids the original and inserts a linked correction row with the new amount', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: 'invoice was overstated' }, { now: NOW + 100 })
+    expect(r.ok).toBe(true)
+    expect(r.newLineId).toBeDefined()
+
+    const original = db.prepare(`SELECT voided_at, void_reason, billed_cost, corrects_line_id FROM cost_line_items WHERE id = ?`).get(originalId) as any
+    expect(original.voided_at).toBe(NOW + 100)
+    expect(original.void_reason).toContain('invoice was overstated')
+    expect(original.billed_cost).toBe(10000) // amount preserved, never erased
+    expect(original.corrects_line_id).toBeNull() // the ORIGINAL doesn't point anywhere
+
+    const corrected = db.prepare(`SELECT billed_cost, corrects_line_id, voided_at FROM cost_line_items WHERE id = ?`).get(r.newLineId) as any
+    expect(corrected.billed_cost).toBe(8500)
+    expect(corrected.corrects_line_id).toBe(originalId)
+    expect(corrected.voided_at).toBeNull() // the correction itself is active
+  })
+
+  it('the corrected amount, not the original, is what the ledger reports going forward', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: 'fix' }, { now: NOW + 100 })
+    const s = getCostSummary(db, cfg, NOW)
+    const row = s.all_sources.find(x => x.source_id === 'render-hosting')!
+    expect(row.spend).toBe(8500)
+  })
+
+  it('preserves source_id/period/currency/confidence/actual_source from the original', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000, 'provider_api', 'provider_api')
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: 9000, reason: 'provider corrected their number' }, { now: NOW + 100 })
+    const corrected = db.prepare(`SELECT source_id, currency, confidence, actual_source FROM cost_line_items WHERE id = ?`).get(r.newLineId) as any
+    expect(corrected.source_id).toBe('render-hosting')
+    expect(corrected.currency).toBe('HUF')
+    expect(corrected.confidence).toBe('provider_api')
+    expect(corrected.actual_source).toBe('provider_api')
+  })
+
+  it('404s on a nonexistent line id', () => {
+    const db = getDb()
+    const r = createCorrection(db, { originalLineId: 99999, newAmount: 100, reason: 'x' }, { now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(404)
+  })
+
+  it('409s when correcting an already-voided line', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: 'first fix' }, { now: NOW + 100 })
+    const r2 = createCorrection(db, { originalLineId: originalId, newAmount: 7000, reason: 'second attempt on the same original' }, { now: NOW + 200 })
+    expect(r2.ok).toBe(false)
+    expect(r2.status).toBe(409)
+  })
+
+  it('409s when the original already has a correction pointing at it (correct the newer link instead)', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    const first = createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: 'first fix' }, { now: NOW + 100 })
+    // Attempting to correct the ORIGINAL again (not the new line) must fail --
+    // it's already voided, so this hits the voided guard, same 409 class.
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: 7000, reason: 'oops' }, { now: NOW + 200 })
+    expect(r.ok).toBe(false)
+    // But correcting the NEW line (the actual current link) works fine.
+    const r2 = createCorrection(db, { originalLineId: first.newLineId!, newAmount: 7500, reason: 'second, correct fix' }, { now: NOW + 300 })
+    expect(r2.ok).toBe(true)
+  })
+
+  it('rejects a missing reason -- correction must always be explainable', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: '' }, { now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(400)
+  })
+
+  it('rejects a negative newAmount', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: -5, reason: 'x' }, { now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(400)
+  })
+})
+
+describe('getCorrectionChain', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('returns just the one row when there is no correction yet', () => {
+    const db = getDb()
+    const id = insertLine(db, 'render-hosting', 10000)
+    const chain = getCorrectionChain(db, id)
+    expect(chain).toHaveLength(1)
+    expect(chain[0].id).toBe(id)
+  })
+
+  it('walks a multi-link chain oldest-first, regardless of which link id is passed in', () => {
+    const db = getDb()
+    const original = insertLine(db, 'render-hosting', 10000)
+    const c1 = createCorrection(db, { originalLineId: original, newAmount: 8500, reason: 'fix 1' }, { now: NOW + 100 })
+    const c2 = createCorrection(db, { originalLineId: c1.newLineId!, newAmount: 9200, reason: 'fix 2' }, { now: NOW + 200 })
+
+    for (const queryId of [original, c1.newLineId!, c2.newLineId!]) {
+      const chain = getCorrectionChain(db, queryId)
+      expect(chain.map(c => c.id)).toEqual([original, c1.newLineId, c2.newLineId])
+      expect(chain.map(c => c.billed_cost)).toEqual([10000, 8500, 9200])
+      expect(chain[chain.length - 1].voided_at).toBeNull() // only the latest link is active
+    }
+  })
+})

--- a/src/__tests__/costops-deepseek.test.ts
+++ b/src/__tests__/costops-deepseek.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { deriveMtdSpend, parseDeepSeekBalanceUsd, syncDeepSeekBalance } from '../costops/collectors/deepseek.js'
+
+describe('deriveMtdSpend (pure)', () => {
+  it('sums balance drops, ignoring top-ups (rises)', () => {
+    // 10 -> 8 (drop 2) -> 12 (top-up, ignore) -> 9 (drop 3) => spend 5
+    const snaps = [10, 8, 12, 9].map((b, i) => ({ balance: b, captured_at: i }))
+    expect(deriveMtdSpend(snaps)).toBe(5)
+  })
+  it('is 0 for a single snapshot (baseline)', () => {
+    expect(deriveMtdSpend([{ balance: 4.55, captured_at: 1 }])).toBe(0)
+    expect(deriveMtdSpend([])).toBe(0)
+  })
+})
+
+describe('parseDeepSeekBalanceUsd', () => {
+  it('reads the USD total_balance from the /user/balance shape', () => {
+    expect(parseDeepSeekBalanceUsd({ is_available: true, balance_infos: [{ currency: 'USD', total_balance: '4.55' }] })).toBe(4.55)
+    expect(parseDeepSeekBalanceUsd({ balance_infos: [{ currency: 'CNY', total_balance: '30' }] })).toBe(30) // falls back to first
+    expect(parseDeepSeekBalanceUsd(null)).toBe(0)
+  })
+})
+
+describe('syncDeepSeekBalance (offline stub)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('records a snapshot + baseline line on first sync, then MTD spend on a later drop', async () => {
+    const db = getDb()
+    const t0 = Math.floor(Date.UTC(2026, 6, 5) / 1000)
+    const bal = (v: string) => async () => ({ is_available: true, balance_infos: [{ currency: 'USD', total_balance: v }] })
+    // first sync: balance 5.00 -> baseline, spend 0
+    const r1 = await syncDeepSeekBalance(db, t0, { apiKey: 'k', fxUsdHuf: 360, httpGetJson: bal('5.00') })
+    expect(r1.ok).toBe(true)
+    expect(r1.balance_usd).toBe(5)
+    expect(r1.mtd_spend_usd).toBe(0)
+    const line0 = db.prepare("SELECT billed_cost, confidence FROM cost_line_items WHERE source_id='deepseek-api'").get() as { billed_cost: number; confidence: string }
+    expect(line0.billed_cost).toBe(0)
+    expect(line0.confidence).toBe('provider_api')
+
+    // second sync later same month: balance dropped to 3.20 -> spend 1.80 usd -> 648 HUF
+    const r2 = await syncDeepSeekBalance(db, t0 + 86400, { apiKey: 'k', fxUsdHuf: 360, httpGetJson: bal('3.20') })
+    expect(r2.mtd_spend_usd).toBeCloseTo(1.8, 4)
+    const line1 = db.prepare("SELECT billed_cost FROM cost_line_items WHERE source_id='deepseek-api'").get() as { billed_cost: number }
+    expect(line1.billed_cost).toBeCloseTo(1.8 * 360, 2) // idempotent upsert, single line
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='deepseek-api'").get() as { c: number }).c).toBe(1)
+    // secret never in audit rows
+    expect(JSON.stringify(db.prepare('SELECT * FROM import_runs').all())).not.toContain('"k"')
+  })
+
+  it('errors (no line) when the vault key is missing', async () => {
+    const db = getDb()
+    const r = await syncDeepSeekBalance(db, Math.floor(Date.now() / 1000), { apiKey: null, fxUsdHuf: 360, httpGetJson: async () => ({}) })
+    expect(r.ok).toBe(false)
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='deepseek-api'").get() as { c: number }).c).toBe(0)
+  })
+})

--- a/src/__tests__/costops-email-ingest.test.ts
+++ b/src/__tests__/costops-email-ingest.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { ingestEmailCosts, toHuf } from '../costops/email-ingest.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 6) / 1000)
+
+describe('toHuf', () => {
+  it('passes HUF through, converts USD, flags others', () => {
+    expect(toHuf(8990, 'HUF', 360)).toBe(8990)
+    expect(toHuf(2, 'USD', 360)).toBe(720)
+    expect(toHuf(5, 'EUR', 360)).toBeNull() // not converted here
+  })
+})
+
+describe('ingestEmailCosts', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('ingests receipts as actual_invoice lines, idempotent per (email, month)', () => {
+    const db = getDb()
+    const entries = [
+      { source_id: 'anthropic-pro', name: 'Claude Pro', provider: 'anthropic', amount: 8990, currency: 'HUF', month: '2026-06', message_ref: 'gmail-abc' },
+      { source_id: 'openai-api', name: 'OpenAI API', provider: 'openai', amount: 3.5, currency: 'USD', month: '2026-06', message_ref: 'gmail-def' },
+    ]
+    const r1 = ingestEmailCosts(db, entries, { fxUsdHuf: 360, now: NOW })
+    expect(r1.ingested).toBe(2)
+    expect(r1.errors).toHaveLength(0)
+
+    const pro = db.prepare("SELECT billed_cost, confidence, charge_category FROM cost_line_items WHERE source_id='anthropic-pro'").get() as any
+    expect(pro.billed_cost).toBe(8990)
+    expect(pro.confidence).toBe('actual_invoice')
+    expect(pro.charge_category).toBe('invoice')
+    const oa = db.prepare("SELECT billed_cost FROM cost_line_items WHERE source_id='openai-api'").get() as any
+    expect(oa.billed_cost).toBe(3.5 * 360)
+
+    // re-ingest the SAME receipts -> idempotent, no duplicates
+    ingestEmailCosts(db, entries, { fxUsdHuf: 360, now: NOW + 100 })
+    expect((db.prepare('SELECT COUNT(*) c FROM cost_line_items').get() as any).c).toBe(2)
+  })
+
+  it('same provider, different months coexist (not deduped across months)', () => {
+    const db = getDb()
+    ingestEmailCosts(db, [{ source_id: 'render-hosting', name: 'Render', provider: 'render', amount: 40000, currency: 'HUF', month: '2026-06', message_ref: 'r-jun' }], { fxUsdHuf: 360, now: NOW })
+    ingestEmailCosts(db, [{ source_id: 'render-hosting', name: 'Render', provider: 'render', amount: 41000, currency: 'HUF', month: '2026-07', message_ref: 'r-jul' }], { fxUsdHuf: 360, now: NOW })
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='render-hosting'").get() as any).c).toBe(2)
+  })
+
+  it('collects errors for bad month / unconvertible currency / missing id, ingests the rest', () => {
+    const db = getDb()
+    const r = ingestEmailCosts(db, [
+      { source_id: 'ok', name: 'Ok', provider: 'x', amount: 100, currency: 'HUF', month: '2026-06', message_ref: 'm1' },
+      { source_id: 'bad-month', name: 'B', provider: 'x', amount: 100, currency: 'HUF', month: 'June', message_ref: 'm2' },
+      { source_id: 'bad-cur', name: 'C', provider: 'x', amount: 5, currency: 'EUR', month: '2026-06', message_ref: 'm3' },
+      { source_id: '', name: 'D', provider: 'x', amount: 5, currency: 'HUF', month: '2026-06', message_ref: 'm4' },
+    ] as any, { fxUsdHuf: 360, now: NOW })
+    expect(r.ingested).toBe(1)
+    expect(r.errors.length).toBe(3)
+  })
+
+  it('stores no raw message ref -- only a hash in source_ref/dedup_key', () => {
+    const db = getDb()
+    ingestEmailCosts(db, [{ source_id: 's', name: 'S', provider: 'x', amount: 1, currency: 'HUF', month: '2026-06', message_ref: 'SENSITIVE-gmail-id-12345' }], { fxUsdHuf: 360, now: NOW })
+    const dump = JSON.stringify(db.prepare('SELECT * FROM cost_line_items').all())
+    expect(dump).not.toContain('SENSITIVE-gmail-id-12345')
+  })
+})

--- a/src/__tests__/costops-forecast-capture.test.ts
+++ b/src/__tests__/costops-forecast-capture.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { captureForecastSnapshots, listForecastSnapshots } from '../costops/forecast-capture.js'
+import { monthWindow } from '../costops/ledger.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+function insertSource(db: import('better-sqlite3').Database, id: string, provider: string) {
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, ?, 'usage', 'HUF', 1, ?, ?)`)
+    .run(id, id, provider, NOW, NOW)
+}
+
+function insertLine(db: import('better-sqlite3').Database, sourceId: string, amount: number, confidence: string, category = 'subscription') {
+  const win = monthWindow(NOW)
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key)
+    VALUES (?, ?, ?, ?, ?, 'HUF', ?, ?, ?, ?)
+  `).run(sourceId, win.start, win.end, category, amount, confidence, NOW, NOW, `test|${sourceId}|${Math.random()}`)
+}
+
+describe('captureForecastSnapshots (CostOps Phase 1, GAP-10 orchestration)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('captures one snapshot per active source plus a whole-deployment TOTAL row', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other')
+    insertSource(db, 'hosting', 'other')
+    insertLine(db, 'domain', 3000, 'manual')
+    insertLine(db, 'hosting', 5000, 'manual')
+
+    const results = captureForecastSnapshots(db, NOW)
+    expect(results).toHaveLength(3) // domain + hosting + TOTAL
+    const total = results.find(r => r.source_id === null)!
+    expect(total.result.amount).toBe(8000)
+
+    const stored = listForecastSnapshots(db)
+    expect(stored).toHaveLength(3)
+  })
+
+  it('a fixed subscription (no usage category) forecasts full amount, not prorated', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other')
+    insertLine(db, 'domain', 3000, 'manual', 'subscription')
+    const [r] = captureForecastSnapshots(db, NOW)
+    expect(r.result.method).toBe('fixed_subscription')
+    expect(r.result.amount).toBe(3000)
+  })
+
+  it('a usage-category source forecasts by run-rate, greater than the MTD amount mid-month', () => {
+    const db = getDb()
+    insertSource(db, 'api-usage', 'other')
+    insertLine(db, 'api-usage', 1000, 'provider_api', 'usage')
+    const results = captureForecastSnapshots(db, NOW)
+    const r = results.find(x => x.source_id === 'api-usage')!
+    expect(r.result.method).toBe('time_proportional_usage')
+    expect(r.result.amount).toBeGreaterThan(1000)
+  })
+
+  it('a source with balance snapshots (DeepSeek-shaped) uses balance_delta, not fixed/usage defaults', () => {
+    const db = getDb()
+    insertSource(db, 'deepseek-api', 'deepseek')
+    const win = monthWindow(NOW)
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',100,?)`).run(win.start + 86400)
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',80,?)`).run(win.start + 5 * 86400)
+    const results = captureForecastSnapshots(db, NOW)
+    const r = results.find(x => x.source_id === 'deepseek-api')!
+    expect(r.result.method).toBe('balance_delta')
+  })
+
+  it('a source with no cost_line_items this month still gets a forecast row (0 mtd, fixed_subscription default)', () => {
+    const db = getDb()
+    insertSource(db, 'idle-source', 'other')
+    const results = captureForecastSnapshots(db, NOW)
+    const r = results.find(x => x.source_id === 'idle-source')!
+    expect(r.result.amount).toBe(0)
+  })
+
+  it('a pending_permission or provider_plan_estimate line is excluded from the resolved mtd amount', () => {
+    const db = getDb()
+    insertSource(db, 'aws', 'aws')
+    insertLine(db, 'aws', 0, 'pending_permission')
+    const results = captureForecastSnapshots(db, NOW)
+    const r = results.find(x => x.source_id === 'aws')!
+    expect(r.result.amount).toBe(0) // never fabricated from the excluded pending line
+  })
+
+  it('capturing twice the same day is idempotent -- no duplicate rows (dedup_key includes the day)', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other')
+    insertLine(db, 'domain', 3000, 'manual')
+    captureForecastSnapshots(db, NOW)
+    captureForecastSnapshots(db, NOW + 3600) // same day, 1h later
+    const stored = listForecastSnapshots(db)
+    expect(stored).toHaveLength(2) // domain + TOTAL, not 4
+  })
+
+  it('listForecastSnapshots filters by month when given one', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other')
+    insertLine(db, 'domain', 3000, 'manual')
+    captureForecastSnapshots(db, NOW)
+    const win = monthWindow(NOW)
+    expect(listForecastSnapshots(db, { month: win.key })).toHaveLength(2)
+    expect(listForecastSnapshots(db, { month: '2020-01' })).toHaveLength(0)
+  })
+})

--- a/src/__tests__/costops-forecast.test.ts
+++ b/src/__tests__/costops-forecast.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  forecastFixedSubscription,
+  forecastTimeProportionalUsage,
+  forecastBalanceDelta,
+  forecastInvoiceCadence,
+  forecastOneTime,
+  forecastManual,
+  resolveSourceForecast,
+  computeForecastError,
+  summarizeForecastAccuracy,
+  forecastSnapshotDedupKey,
+  initForecastSchema,
+  type ForecastContext,
+} from '../costops/forecast.js'
+import type { MonthWindow } from '../costops/ledger.js'
+import type { BalanceSnapshot } from '../costops/collectors/deepseek.js'
+
+// Hand-built MonthWindow fixtures -- these functions are pure over the
+// interface shape, not tied to monthWindow()'s calendar math.
+function win(fractionElapsed: number): MonthWindow {
+  const daysInMonth = 30
+  const start = 0
+  const end = daysInMonth * 86400
+  return { key: '2026-07', start, end, daysInMonth, fractionElapsed }
+}
+
+describe('forecastFixedSubscription', () => {
+  it('returns the full period amount regardless of elapsed fraction', () => {
+    const r = forecastFixedSubscription(22000, 'manual')
+    expect(r.method).toBe('fixed_subscription')
+    expect(r.amount).toBe(22000)
+  })
+
+  it('is high confidence for invoice/provider-observed amounts, medium for manual/estimate', () => {
+    expect(forecastFixedSubscription(1000, 'actual_invoice').confidence).toBe('high')
+    expect(forecastFixedSubscription(1000, 'provider_api').confidence).toBe('high')
+    expect(forecastFixedSubscription(1000, 'billing_export').confidence).toBe('high')
+    expect(forecastFixedSubscription(1000, 'manual').confidence).toBe('medium')
+    expect(forecastFixedSubscription(1000, 'estimate').confidence).toBe('medium')
+  })
+})
+
+describe('forecastTimeProportionalUsage', () => {
+  it('projects month-end as MTD / fractionElapsed', () => {
+    const r = forecastTimeProportionalUsage(1000, win(0.5))
+    expect(r.amount).toBe(2000)
+    expect(r.method).toBe('time_proportional_usage')
+  })
+
+  it('confidence is low early in the month, medium mid-month, high late', () => {
+    expect(forecastTimeProportionalUsage(100, win(0.1)).confidence).toBe('low')
+    expect(forecastTimeProportionalUsage(100, win(0.3)).confidence).toBe('medium')
+    expect(forecastTimeProportionalUsage(100, win(0.9)).confidence).toBe('high')
+  })
+})
+
+describe('forecastBalanceDelta', () => {
+  const NOW = 15 * 86400 // mid-month
+
+  it('falls back to MTD-only, low confidence, with fewer than 2 snapshots', () => {
+    const snaps: BalanceSnapshot[] = [{ balance: 100, captured_at: 1 * 86400 }]
+    const r = forecastBalanceDelta(snaps, win(0.5), NOW)
+    expect(r.confidence).toBe('low')
+    expect(r.amount).toBe(0)
+  })
+
+  it('falls back to MTD-only when the observed span is too short', () => {
+    const snaps: BalanceSnapshot[] = [
+      { balance: 100, captured_at: 1 * 3600 },
+      { balance: 90, captured_at: 2 * 3600 }, // 1 hour apart, well under MIN_FORECAST_SPAN_SECONDS
+    ]
+    const r = forecastBalanceDelta(snaps, win(0.5), NOW)
+    expect(r.confidence).toBe('low')
+  })
+
+  it('extrapolates month-end from a daily burn rate over a longer span', () => {
+    // 10 days of history, dropping 10/day -> burn rate 10/day, 100 total spend.
+    const snaps: BalanceSnapshot[] = []
+    for (let d = 0; d <= 10; d++) snaps.push({ balance: 200 - d * 10, captured_at: d * 86400 })
+    const r = forecastBalanceDelta(snaps, win(0.5), 10 * 86400)
+    // MTD (within month window [0, 30d)) = full 100 spend observed so far.
+    // remaining days = (end - now) / 86400 = (30*86400 - 10*86400)/86400 = 20
+    // projected = 100 + 10*20 = 300
+    expect(r.amount).toBe(300)
+    expect(r.confidence).toBe('high')
+  })
+
+  it('ignores balance RISES (top-ups) when deriving spend', () => {
+    const snaps: BalanceSnapshot[] = [
+      { balance: 100, captured_at: 0 },
+      { balance: 50, captured_at: 5 * 86400 },   // spend 50
+      { balance: 150, captured_at: 6 * 86400 },  // top-up, ignored
+      { balance: 100, captured_at: 11 * 86400 }, // spend 50
+    ]
+    const r = forecastBalanceDelta(snaps, win(0.5), 11 * 86400)
+    // total observed spend = 100 (50+50), span = 11 days -> ~9.09/day burn
+    expect(r.amount).toBeGreaterThan(100) // mtd + remaining-day extrapolation
+  })
+})
+
+describe('forecastInvoiceCadence', () => {
+  it('uses the full amount when this month IS the invoice month', () => {
+    const r = forecastInvoiceCadence(120000, 'annual', { isInvoiceMonth: true })
+    expect(r.amount).toBe(120000)
+    expect(r.confidence).toBe('high')
+  })
+
+  it('accrues evenly across the cadence when not the invoice month', () => {
+    const r = forecastInvoiceCadence(120000, 'annual')
+    expect(r.amount).toBe(10000) // 120000 / 12
+    expect(r.confidence).toBe('medium')
+  })
+
+  it('quarterly accrual divides by 3', () => {
+    const r = forecastInvoiceCadence(9000, 'quarterly')
+    expect(r.amount).toBe(3000)
+  })
+
+  it('monthly cadence is high confidence even without isInvoiceMonth (accrual == full amount)', () => {
+    const r = forecastInvoiceCadence(5000, 'monthly')
+    expect(r.amount).toBe(5000)
+    expect(r.confidence).toBe('high')
+  })
+})
+
+describe('forecastOneTime', () => {
+  it('equals the actual when already occurred, high confidence', () => {
+    const r = forecastOneTime(4500, null)
+    expect(r.amount).toBe(4500)
+    expect(r.confidence).toBe('high')
+  })
+
+  it('uses the planned amount when not yet occurred but known in advance, medium confidence', () => {
+    const r = forecastOneTime(null, 3000)
+    expect(r.amount).toBe(3000)
+    expect(r.confidence).toBe('medium')
+  })
+
+  it('forecasts 0, low confidence, when nothing is known -- never fabricated', () => {
+    const r = forecastOneTime(null, null)
+    expect(r.amount).toBe(0)
+    expect(r.confidence).toBe('low')
+  })
+})
+
+describe('forecastManual', () => {
+  it('passes through the operator figure at low confidence', () => {
+    const r = forecastManual(7777)
+    expect(r.amount).toBe(7777)
+    expect(r.confidence).toBe('low')
+    expect(r.method).toBe('manual_forecast')
+  })
+})
+
+describe('resolveSourceForecast dispatcher precedence', () => {
+  const base: ForecastContext = { mtd_amount: 1000, win: win(0.5), now: 15 * 86400 }
+
+  it('manual_override wins over everything else', () => {
+    const ctx: ForecastContext = { ...base, manual_override: 999, charge_category: 'usage', balance_snapshots: [{ balance: 1, captured_at: 0 }, { balance: 0, captured_at: 86400 * 5 }] }
+    expect(resolveSourceForecast(ctx).method).toBe('manual_forecast')
+  })
+
+  it('balance_snapshots beats cadence and charge_category', () => {
+    const ctx: ForecastContext = { ...base, balance_snapshots: [{ balance: 1, captured_at: 0 }], cadence: 'annual', last_invoice_amount: 1000, charge_category: 'usage' }
+    expect(resolveSourceForecast(ctx).method).toBe('balance_delta')
+  })
+
+  it('non-monthly cadence beats charge_category when a last invoice amount is known', () => {
+    const ctx: ForecastContext = { ...base, cadence: 'annual', last_invoice_amount: 12000, charge_category: 'purchase' }
+    expect(resolveSourceForecast(ctx).method).toBe('invoice_cadence')
+  })
+
+  it('monthly cadence does NOT trigger invoice_cadence (falls through)', () => {
+    const ctx: ForecastContext = { ...base, cadence: 'monthly', last_invoice_amount: 12000, charge_category: 'subscription' }
+    expect(resolveSourceForecast(ctx).method).toBe('fixed_subscription')
+  })
+
+  it('purchase charge_category resolves to one_time', () => {
+    const ctx: ForecastContext = { ...base, charge_category: 'purchase', occurred_amount: 500 }
+    const r = resolveSourceForecast(ctx)
+    expect(r.method).toBe('one_time')
+    expect(r.amount).toBe(500)
+  })
+
+  it('usage charge_category resolves to time_proportional_usage', () => {
+    const ctx: ForecastContext = { ...base, charge_category: 'usage' }
+    expect(resolveSourceForecast(ctx).method).toBe('time_proportional_usage')
+  })
+
+  it('defaults to fixed_subscription for subscription/no category', () => {
+    const ctx: ForecastContext = { ...base, charge_category: 'subscription' }
+    expect(resolveSourceForecast(ctx).method).toBe('fixed_subscription')
+    expect(resolveSourceForecast({ ...base }).method).toBe('fixed_subscription')
+  })
+})
+
+describe('computeForecastError', () => {
+  it('is positive when the forecast under-shot the actual', () => {
+    const e = computeForecastError(100, 120)
+    expect(e.absolute_error).toBe(20)
+    expect(e.percent_error).toBeCloseTo(20 / 120, 4)
+  })
+
+  it('is negative when the forecast over-shot the actual', () => {
+    const e = computeForecastError(150, 100)
+    expect(e.absolute_error).toBe(-50)
+    expect(e.percent_error).toBeCloseTo(-50 / 100, 4)
+  })
+
+  it('percent_error is null (never fabricated) when actual is 0', () => {
+    const e = computeForecastError(100, 0)
+    expect(e.absolute_error).toBe(-100)
+    expect(e.percent_error).toBeNull()
+  })
+})
+
+describe('summarizeForecastAccuracy', () => {
+  it('groups by an arbitrary key and reports mean absolute/percent error', () => {
+    const records = [
+      { provider: 'render', forecast_amount: 100, actual_amount: 120 },
+      { provider: 'render', forecast_amount: 200, actual_amount: 180 },
+      { provider: 'anthropic', forecast_amount: 50, actual_amount: 50 },
+    ]
+    const summary = summarizeForecastAccuracy(records, r => r.provider)
+    const render = summary.find(s => s.key === 'render')!
+    expect(render.count).toBe(2)
+    // |120-100| + |180-200| = 20 + 20 = 40 -> mean 20
+    expect(render.mean_absolute_error).toBe(20)
+    const anthropic = summary.find(s => s.key === 'anthropic')!
+    expect(anthropic.mean_absolute_error).toBe(0)
+    expect(anthropic.mean_percent_error).toBe(0)
+  })
+
+  it('mean_percent_error is null only when EVERY record in the group has actual 0', () => {
+    const records = [
+      { provider: 'x', forecast_amount: 10, actual_amount: 0 },
+      { provider: 'x', forecast_amount: 5, actual_amount: 0 },
+    ]
+    const summary = summarizeForecastAccuracy(records, r => r.provider)
+    expect(summary[0].mean_percent_error).toBeNull()
+  })
+})
+
+describe('forecastSnapshotDedupKey', () => {
+  it('is deterministic per source per UTC day', () => {
+    const t1 = Math.floor(Date.UTC(2026, 6, 15, 1, 0, 0) / 1000)
+    const t2 = Math.floor(Date.UTC(2026, 6, 15, 23, 0, 0) / 1000)
+    expect(forecastSnapshotDedupKey('render-hosting', '2026-07', t1)).toBe(forecastSnapshotDedupKey('render-hosting', '2026-07', t2))
+  })
+
+  it('differs across days and uses TOTAL for a null source', () => {
+    const t1 = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+    const t2 = Math.floor(Date.UTC(2026, 6, 16, 12, 0, 0) / 1000)
+    expect(forecastSnapshotDedupKey('render-hosting', '2026-07', t1)).not.toBe(forecastSnapshotDedupKey('render-hosting', '2026-07', t2))
+    expect(forecastSnapshotDedupKey(null, '2026-07', t1)).toBe('TOTAL|2026-07|2026-07-15')
+  })
+})
+
+describe('initForecastSchema', () => {
+  it('is idempotent and the table accepts a row keyed by dedup_key', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initForecastSchema(db)
+    initForecastSchema(db) // second call must not throw (IF NOT EXISTS)
+    const now = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-hosting','Render','render','hosting','HUF',1,@now,@now)`).run({ now })
+    db.prepare(`
+      INSERT INTO forecast_snapshots (source_id, month, snapshot_at, method, forecast_amount, confidence, dedup_key, created_at)
+      VALUES ('render-hosting', '2026-07', @now, 'fixed_subscription', 12000, 'high', @dk, @now)
+    `).run({ now, dk: forecastSnapshotDedupKey('render-hosting', '2026-07', now) })
+    const row = db.prepare(`SELECT * FROM forecast_snapshots WHERE source_id = 'render-hosting'`).get() as { forecast_amount: number; actual_amount: number | null }
+    expect(row.forecast_amount).toBe(12000)
+    expect(row.actual_amount).toBeNull() // never fabricated until period close
+  })
+
+  it('rejects a duplicate dedup_key (same source, same day)', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initForecastSchema(db)
+    const now = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-hosting','Render','render','hosting','HUF',1,@now,@now)`).run({ now })
+    const dk = forecastSnapshotDedupKey('render-hosting', '2026-07', now)
+    db.prepare(`INSERT INTO forecast_snapshots (source_id, month, snapshot_at, method, forecast_amount, confidence, dedup_key, created_at) VALUES ('render-hosting','2026-07',@now,'fixed_subscription',12000,'high',@dk,@now)`).run({ now, dk })
+    expect(() => {
+      db.prepare(`INSERT INTO forecast_snapshots (source_id, month, snapshot_at, method, forecast_amount, confidence, dedup_key, created_at) VALUES ('render-hosting','2026-07',@now,'fixed_subscription',13000,'high',@dk,@now)`).run({ now, dk })
+    }).toThrow()
+  })
+})

--- a/src/__tests__/costops-fx.test.ts
+++ b/src/__tests__/costops-fx.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  resolveFxRate,
+  roundHuf,
+  resolveRateDate,
+  convertToHufWithProvenance,
+  canRecomputeFx,
+  convertCorrectionToHuf,
+  lookupHistoricalRate,
+  fxRateDedupKey,
+  initFxSchema,
+  type FxRateTable,
+  type FxRateRecord,
+} from '../costops/fx.js'
+
+const RATES: FxRateTable = { USD: 350, EUR: 380 }
+
+describe('resolveFxRate', () => {
+  it('HUF is always rate 1, regardless of the table', () => {
+    expect(resolveFxRate('HUF', {})).toBe(1)
+    expect(resolveFxRate('huf', { HUF: 999 })).toBe(1)
+  })
+
+  it('resolves USD/EUR from the table, case-insensitively', () => {
+    expect(resolveFxRate('USD', RATES)).toBe(350)
+    expect(resolveFxRate('eur', RATES)).toBe(380)
+  })
+
+  it('returns null (never fabricated) for an unsupported currency', () => {
+    expect(resolveFxRate('GBP', RATES)).toBeNull()
+  })
+
+  it('returns null for a zero or negative rate in the table (never a bogus conversion)', () => {
+    expect(resolveFxRate('USD', { USD: 0 })).toBeNull()
+    expect(resolveFxRate('USD', { USD: -5 })).toBeNull()
+  })
+})
+
+describe('roundHuf', () => {
+  it('rounds to 2 decimal places', () => {
+    expect(roundHuf(100.005)).toBeCloseTo(100.01, 2)
+    expect(roundHuf(99.994)).toBe(99.99)
+    expect(roundHuf(1234.5)).toBe(1234.5)
+  })
+})
+
+describe('resolveRateDate', () => {
+  it('prefers the invoice date when known', () => {
+    const r = resolveRateDate(1000, 2000)
+    expect(r.date).toBe(1000)
+    expect(r.basis).toBe('invoice_date')
+  })
+
+  it('falls back to the service date when there is no invoice', () => {
+    const r = resolveRateDate(null, 2000)
+    expect(r.date).toBe(2000)
+    expect(r.basis).toBe('service_date')
+  })
+})
+
+describe('convertToHufWithProvenance', () => {
+  it('carries full provenance for a USD conversion at the invoice date', () => {
+    const c = convertToHufWithProvenance(10, 'USD', RATES, { fxSource: 'render_pricing_config', invoiceDate: 500, serviceDate: 100, now: 999 })
+    expect(c).not.toBeNull()
+    expect(c!.original_amount).toBe(10)
+    expect(c!.original_currency).toBe('USD')
+    expect(c!.fx_rate).toBe(350)
+    expect(c!.fx_source).toBe('render_pricing_config')
+    expect(c!.fx_date).toBe(500) // invoice date wins
+    expect(c!.conversion_method).toBe('invoice_date_rate')
+    expect(c!.huf_amount).toBe(3500)
+    expect(c!.converted_at).toBe(999)
+  })
+
+  it('uses service_date_rate when no invoice date is given', () => {
+    const c = convertToHufWithProvenance(10, 'EUR', RATES, { fxSource: 'manual', invoiceDate: null, serviceDate: 100, now: 999 })
+    expect(c!.conversion_method).toBe('service_date_rate')
+    expect(c!.fx_date).toBe(100)
+    expect(c!.huf_amount).toBe(3800)
+  })
+
+  it('HUF passes through at rate 1 with huf_amount == original amount', () => {
+    const c = convertToHufWithProvenance(5000, 'HUF', RATES, { fxSource: 'manual', invoiceDate: null, serviceDate: 1, now: 1 })
+    expect(c!.fx_rate).toBe(1)
+    expect(c!.huf_amount).toBe(5000)
+  })
+
+  it('returns null (never a fabricated conversion) for an unsupported currency', () => {
+    const c = convertToHufWithProvenance(10, 'GBP', RATES, { fxSource: 'manual', invoiceDate: null, serviceDate: 1, now: 1 })
+    expect(c).toBeNull()
+  })
+})
+
+describe('canRecomputeFx', () => {
+  it('forbids recomputation only for closed periods', () => {
+    expect(canRecomputeFx('closed')).toBe(false)
+    expect(canRecomputeFx('open')).toBe(true)
+    expect(canRecomputeFx('provisional')).toBe(true)
+    expect(canRecomputeFx('reopened')).toBe(true)
+  })
+})
+
+describe('convertCorrectionToHuf', () => {
+  it('produces an independent conversion rated as of the CORRECTION date, not the original', () => {
+    const correction = convertCorrectionToHuf({
+      originalCurrency: 'usd',
+      correctionAmountOriginalCurrency: -10, // a refund/credit
+      correctionDate: 5000,
+      correctionRate: 360, // a DIFFERENT rate than the original conversion used
+      correctionSource: 'provider_invoice',
+      now: 5001,
+    })
+    expect(correction.original_currency).toBe('USD')
+    expect(correction.fx_rate).toBe(360)
+    expect(correction.fx_date).toBe(5000)
+    expect(correction.conversion_method).toBe('correction_date_rate')
+    expect(correction.huf_amount).toBe(-3600)
+  })
+})
+
+describe('lookupHistoricalRate', () => {
+  const records: FxRateRecord[] = [
+    { currency: 'USD', rate: 340, fx_source: 'render_pricing_config', effective_date: 1000 },
+    { currency: 'USD', rate: 350, fx_source: 'render_pricing_config', effective_date: 2000 },
+    { currency: 'USD', rate: 360, fx_source: 'render_pricing_config', effective_date: 3000 },
+    { currency: 'EUR', rate: 380, fx_source: 'render_pricing_config', effective_date: 2500 },
+  ]
+
+  it('returns the most recent record at or before the requested date', () => {
+    expect(lookupHistoricalRate(records, 'USD', 2500)?.rate).toBe(350)
+    expect(lookupHistoricalRate(records, 'USD', 3000)?.rate).toBe(360)
+  })
+
+  it('never applies a future rate to a past date', () => {
+    expect(lookupHistoricalRate(records, 'USD', 500)).toBeNull()
+  })
+
+  it('filters by currency', () => {
+    expect(lookupHistoricalRate(records, 'EUR', 2500)?.rate).toBe(380)
+  })
+
+  it('is reproducible: same snapshot + same date always resolves the same rate', () => {
+    const a = lookupHistoricalRate(records, 'USD', 2500)
+    const b = lookupHistoricalRate(records, 'USD', 2500)
+    expect(a).toEqual(b)
+  })
+})
+
+describe('fxRateDedupKey', () => {
+  it('is stable within the same UTC day and differs across days', () => {
+    const t1 = Math.floor(Date.UTC(2026, 6, 15, 1, 0, 0) / 1000)
+    const t2 = Math.floor(Date.UTC(2026, 6, 15, 23, 0, 0) / 1000)
+    const t3 = Math.floor(Date.UTC(2026, 6, 16, 1, 0, 0) / 1000)
+    expect(fxRateDedupKey('USD', 'render_pricing_config', t1)).toBe(fxRateDedupKey('USD', 'render_pricing_config', t2))
+    expect(fxRateDedupKey('USD', 'render_pricing_config', t1)).not.toBe(fxRateDedupKey('USD', 'render_pricing_config', t3))
+  })
+
+  it('differs by currency and source', () => {
+    const t = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    expect(fxRateDedupKey('USD', 'render_pricing_config', t)).not.toBe(fxRateDedupKey('EUR', 'render_pricing_config', t))
+    expect(fxRateDedupKey('USD', 'render_pricing_config', t)).not.toBe(fxRateDedupKey('USD', 'manual', t))
+  })
+})
+
+describe('initFxSchema', () => {
+  it('is idempotent and adds fx_source/conversion_method columns onto cost_line_items', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initFxSchema(db)
+    initFxSchema(db) // second call must not throw
+    const now = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('anthropic-api','Anthropic API','anthropic','usage','HUF',1,@now,@now)`).run({ now })
+    db.prepare(`
+      INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, fx_source, conversion_method, original_amount, original_currency, fx_rate, fx_date)
+      VALUES ('anthropic-api', @now, @now, 'usage', 3500, 'HUF', 'provider_api', @now, @now, 'render_pricing_config', 'invoice_date_rate', 10, 'USD', 350, @now)
+    `).run({ now })
+    const row = db.prepare(`SELECT fx_source, conversion_method FROM cost_line_items WHERE source_id = 'anthropic-api'`).get() as { fx_source: string; conversion_method: string }
+    expect(row.fx_source).toBe('render_pricing_config')
+    expect(row.conversion_method).toBe('invoice_date_rate')
+  })
+
+  it('creates the fx_rates table and enforces one row per dedup_key', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initFxSchema(db)
+    const now = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    const dk = fxRateDedupKey('USD', 'render_pricing_config', now)
+    db.prepare(`INSERT INTO fx_rates (currency, rate, fx_source, effective_date, captured_at, dedup_key) VALUES ('USD', 350, 'render_pricing_config', @now, @now, @dk)`).run({ now, dk })
+    expect(() => {
+      db.prepare(`INSERT INTO fx_rates (currency, rate, fx_source, effective_date, captured_at, dedup_key) VALUES ('USD', 360, 'render_pricing_config', @now, @now, @dk)`).run({ now, dk })
+    }).toThrow()
+    const row = db.prepare(`SELECT rate FROM fx_rates WHERE dedup_key = ?`).get(dk) as { rate: number }
+    expect(row.rate).toBe(350)
+  })
+})

--- a/src/__tests__/costops-github.test.ts
+++ b/src/__tests__/costops-github.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { mapGitHubUsage, githubCollector, syncGitHubCollector } from '../costops/collectors/github.js'
+import { monthWindow } from '../costops/ledger.js'
+import type { CollectOpts } from '../costops/collectors/types.js'
+
+const START = Math.floor(Date.UTC(2026, 6, 1) / 1000)
+const END = Math.floor(Date.UTC(2026, 7, 1) / 1000)
+
+function report(amounts: number[]) {
+  return { usageItems: amounts.map((a, i) => ({ date: '2026-07-0' + (i + 1), product: 'actions', sku: 'x', quantity: 1, unitType: 'min', netAmount: a })) }
+}
+
+describe('mapGitHubUsage (pure, offline)', () => {
+  it('sums netAmount USD into one HUF provider_api line for github', () => {
+    const lines = mapGitHubUsage(report([2, 3]), { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })
+    expect(lines).toHaveLength(1)
+    expect(lines[0].provider).toBe('github')
+    expect(lines[0].confidence).toBe('provider_api')
+    expect(lines[0].amount).toBe(Math.round(5 * 360 * 100) / 100)
+    expect(lines[0].dedup_key).toBe('provider|github|github|2026-07|provider_api')
+  })
+
+  it('emits an EXPLICIT 0 provider_api line on a valid empty report (API-observed zero)', () => {
+    const lines = mapGitHubUsage({ usageItems: [] }, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })
+    expect(lines).toHaveLength(1)
+    expect(lines[0].amount).toBe(0)
+    expect(lines[0].confidence).toBe('provider_api')
+  })
+
+  it('returns [] only when the raw is not a usage report', () => {
+    expect(mapGitHubUsage(null, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })).toHaveLength(0)
+    expect(mapGitHubUsage({ message: 'Not Found' }, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })).toHaveLength(0)
+  })
+})
+
+describe('githubCollector + syncGitHubCollector (offline stub)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('sync imports a provider_api line (even at 0) with a stubbed key + fetcher; idempotent', async () => {
+    const db = getDb()
+    const now = Math.floor(Date.UTC(2026, 6, 10) / 1000)
+    const r1 = await syncGitHubCollector(db, now, { apiKey: 'ghp-stub', fxUsdHuf: 360, httpGetJson: async () => report([]) })
+    expect(r1.ok).toBe(true)
+    expect(r1.imported_count).toBe(1)
+    const row = db.prepare("SELECT billed_cost, confidence FROM cost_line_items WHERE source_id='github'").get() as { billed_cost: number; confidence: string }
+    expect(row.billed_cost).toBe(0)
+    expect(row.confidence).toBe('provider_api')
+    // idempotent
+    await syncGitHubCollector(db, now, { apiKey: 'ghp-stub', fxUsdHuf: 360, httpGetJson: async () => report([]) })
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='github'").get() as { c: number }).c).toBe(1)
+    const audit = JSON.stringify(db.prepare('SELECT * FROM import_runs').all())
+    expect(audit).not.toContain('ghp-stub')
+  })
+
+  it('errors (no import) when the vault token is missing', async () => {
+    const db = getDb()
+    const r = await syncGitHubCollector(db, Math.floor(Date.now() / 1000), { apiKey: null, fxUsdHuf: 360, httpGetJson: async () => report([1]) })
+    expect(r.ok).toBe(false)
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='github'").get() as { c: number }).c).toBe(0)
+  })
+})

--- a/src/__tests__/costops-openai.test.ts
+++ b/src/__tests__/costops-openai.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { mapOpenAiCosts, openaiCollector, syncOpenAiCollector } from '../costops/collectors/openai.js'
+import { monthWindow } from '../costops/ledger.js'
+import type { CollectOpts } from '../costops/collectors/types.js'
+
+// Fixture modelling the OpenAI /v1/organizations/costs page shape.
+function fixturePage(vals: number[]) {
+  const now = Math.floor(Date.UTC(2026, 6, 1) / 1000)
+  return {
+    object: 'page',
+    data: vals.map((v, i) => ({
+      object: 'bucket',
+      start_time: now + i * 86400,
+      end_time: now + (i + 1) * 86400,
+      results: [{ object: 'organization.costs.result', amount: { value: v, currency: 'usd' }, line_item: null, project_id: null }],
+    })),
+    has_more: false,
+    next_page: null,
+  }
+}
+
+const START = Math.floor(Date.UTC(2026, 6, 1) / 1000)
+const END = Math.floor(Date.UTC(2026, 7, 1) / 1000)
+
+describe('mapOpenAiCosts (pure, offline)', () => {
+  it('sums daily USD costs into one HUF provider_api line for openai-api', () => {
+    const lines = mapOpenAiCosts(fixturePage([1.5, 2.0, 0.5]), { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 'salt', now: START })
+    expect(lines).toHaveLength(1)
+    const l = lines[0]
+    expect(l.provider).toBe('openai')
+    expect(l.service).toBe('openai-api')
+    expect(l.confidence).toBe('provider_api')
+    expect(l.currency).toBe('HUF')
+    expect(l.amount).toBe(Math.round(4.0 * 360 * 100) / 100) // (1.5+2.0+0.5)*360
+    expect(l.dedup_key).toBe('provider|openai|openai-api|2026-07|provider_api')
+    expect(l.raw_ref_hash).not.toContain('openai-costs') // hashed, no raw
+  })
+
+  it('returns [] for an empty page (caller reports explicit 0)', () => {
+    expect(mapOpenAiCosts({ object: 'page', data: [] }, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })).toHaveLength(0)
+    expect(mapOpenAiCosts(null, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })).toHaveLength(0)
+  })
+})
+
+describe('openaiCollector + syncOpenAiCollector (offline stub, no live call)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('collect() returns normalized lines from the injected fetcher (no network)', async () => {
+    const now = Math.floor(Date.UTC(2026, 6, 10) / 1000)
+    const w = monthWindow(now)
+    const opts: CollectOpts = {
+      periodStart: w.start, periodEnd: w.end, secret: 'sk-admin-never-logged', fxUsdHuf: 360, idSalt: 'openai-salt',
+      httpGetJson: async () => fixturePage([3.0, 1.0]),
+    }
+    const lines = await openaiCollector.collect(opts)
+    expect(lines).toHaveLength(1)
+    expect(lines[0].amount).toBe(Math.round(4.0 * 360 * 100) / 100)
+  })
+
+  it('sync imports a provider_api line + import_run using a stubbed key and fetcher (idempotent)', async () => {
+    const db = getDb()
+    const now = Math.floor(Date.UTC(2026, 6, 10) / 1000)
+    const stub = async () => fixturePage([2.0, 2.0])
+    const r1 = await syncOpenAiCollector(db, now, { apiKey: 'sk-admin-stub', fxUsdHuf: 360, httpGetJson: stub })
+    expect(r1.ok).toBe(true)
+    expect(r1.imported_count).toBe(1)
+    const lineCount = () => (db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='openai-api'").get() as { c: number }).c
+    expect(lineCount()).toBe(1)
+    const r2 = await syncOpenAiCollector(db, now, { apiKey: 'sk-admin-stub', fxUsdHuf: 360, httpGetJson: stub })
+    expect(r2.ok).toBe(true)
+    expect(lineCount()).toBe(1) // idempotent upsert by dedup_key
+
+    // secret must not leak into the import_runs audit rows
+    const audit = JSON.stringify(db.prepare('SELECT * FROM import_runs').all())
+    expect(audit).not.toContain('sk-admin-stub')
+  })
+
+  it('reports error (no import) when the vault key is missing', async () => {
+    const db = getDb()
+    const now = Math.floor(Date.UTC(2026, 6, 10) / 1000)
+    const r = await syncOpenAiCollector(db, now, { apiKey: null, fxUsdHuf: 360, httpGetJson: async () => fixturePage([1]) })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe('error')
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='openai-api'").get() as { c: number }).c).toBe(0)
+  })
+})

--- a/src/__tests__/costops-operational.test.ts
+++ b/src/__tests__/costops-operational.test.ts
@@ -35,6 +35,21 @@ describe('resolveOperational (provider-preferred, no double count)', () => {
     expect(render.confidence).toBe('provider_plan_estimate')
   })
 
+  it('a REAL invoice supersedes the plan estimate for the same provider (no double count)', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      // same provider "render": a real invoice AND the plan-estimate proxy both present
+      { source_id: 'render-hosting', provider: 'render', billed_cost: 4000, charge_category: 'hosting', confidence: 'actual_invoice', data_freshness: NOW },
+      { source_id: 'render-plan', provider: 'render', billed_cost: 32000, charge_category: 'usage', confidence: 'provider_plan_estimate', data_freshness: NOW },
+    ], win)
+    // operational = 4000 (the real invoice), NOT 4000 + 32000; the plan proxy is dropped
+    expect(r.operational_spend).toBe(4000)
+    expect(r.provider_derived_spend).toBe(4000)
+    const render = r.provider_breakdown.find(p => p.provider === 'render')!
+    expect(render.spend).toBe(4000)
+    expect(render.confidence).toBe('actual_invoice')
+  })
+
   it('provider_api_actual usage forecasts by run-rate; plan forecasts full monthly', () => {
     const win = monthWindow(NOW) // mid-month, fractionElapsed < 1
     const r = resolveOperational([

--- a/src/__tests__/costops-operational.test.ts
+++ b/src/__tests__/costops-operational.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { getCostSummary, monthWindow, resolveOperational } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+function emptyConfig(): CostOpsConfig { return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [{ id: 'global-monthly', amount: 200000, warning_threshold: 0.8, hard_threshold: 1.0 }] } }
+
+function seedSource(db: any, id: string, provider: string) {
+  db.prepare("INSERT OR IGNORE INTO cost_sources (id,name,provider,source_type,currency,active,created_at,updated_at) VALUES (?,?,?,?,'HUF',1,?,?)").run(id, id, provider, 'usage', NOW, NOW)
+}
+function seedLine(db: any, sid: string, amount: number, conf: string, cat = 'subscription', win = monthWindow(NOW), dk?: string) {
+  db.prepare(`INSERT INTO cost_line_items (source_id,charge_period_start,charge_period_end,charge_category,service_name,billed_cost,currency,confidence,data_freshness,dedup_key,created_at)
+    VALUES (?,?,?,?,?,?,'HUF',?,?,?,?)`).run(sid, win.start, win.end, cat, sid, amount, conf, NOW, dk || `${sid}|${conf}|${win.key}`, NOW)
+}
+
+// Synthetic amounts only -- NO real cost figures in this tracked test file.
+describe('resolveOperational (provider-preferred, no double count)', () => {
+  it('a provider plan estimate wins over the manual fallback; not summed', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      { source_id: 'render-hosting', provider: 'render', billed_cost: 3000, charge_category: 'subscription', confidence: 'manual', data_freshness: NOW },
+      { source_id: 'render-plan', provider: 'render', billed_cost: 2500, charge_category: 'usage', confidence: 'provider_plan_estimate', data_freshness: NOW },
+      { source_id: 'sub-a', provider: 'acme', billed_cost: 5000, charge_category: 'subscription', confidence: 'manual', data_freshness: NOW },
+    ], win)
+    // operational: render 2500 (plan, not 3000) + acme 5000 (manual, no derived) = 7500
+    expect(r.operational_spend).toBe(7500)
+    expect(r.provider_derived_spend).toBe(2500)
+    // manual_spend (fallback view) = 3000 + 5000 = 8000
+    expect(r.manual_spend).toBe(8000)
+    // variance for derived providers: 2500 - 3000 = -500
+    expect(r.manual_vs_provider_variance).toBe(-500)
+    const render = r.provider_breakdown.find(p => p.provider === 'render')!
+    expect(render.spend).toBe(2500)
+    expect(render.confidence).toBe('provider_plan_estimate')
+  })
+
+  it('provider_api_actual usage forecasts by run-rate; plan forecasts full monthly', () => {
+    const win = monthWindow(NOW) // mid-month, fractionElapsed < 1
+    const r = resolveOperational([
+      { source_id: 'x-api', provider: 'x', billed_cost: 1000, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW },
+      { source_id: 'render-plan', provider: 'render', billed_cost: 2500, charge_category: 'usage', confidence: 'provider_plan_estimate', data_freshness: NOW },
+    ], win)
+    // x-api actual usage -> 1000 / fractionElapsed (run-rate, > 1000); render plan -> full 2500
+    expect(r.operational_forecast_month_end).toBeGreaterThan(1000 + 2500)
+    expect(r.operational_spend).toBe(3500)
+  })
+})
+
+describe('getCostSummary v0.4 operational fields', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('operational_spend prefers provider; current_spend legacy unaffected; render uses plan', () => {
+    const db = getDb()
+    seedSource(db, 'render-hosting', 'render'); seedLine(db, 'render-hosting', 3000, 'manual')
+    seedSource(db, 'render-plan', 'render'); seedLine(db, 'render-plan', 2500, 'provider_plan_estimate', 'usage')
+    seedSource(db, 'sub-a', 'acme'); seedLine(db, 'sub-a', 5000, 'manual')
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    // operational: 2500 + 5000 = 7500 (render manual dropped)
+    expect(s.operational_spend).toBe(7500)
+    // legacy current_spend still EXCLUDES provider_plan_estimate -> render manual 3000 + acme 5000 = 8000
+    expect(s.current_spend).toBe(8000)
+    expect(s.operational.manual_vs_provider_variance).toBe(-500)
+    // budget usage on operational
+    expect(s.budget!.operational_used_pct).toBeCloseTo(7500 / 200000, 4)
+  })
+
+  it('previous_month: no data -> null (never fabricated)', () => {
+    const db = getDb()
+    seedSource(db, 'render-plan', 'render'); seedLine(db, 'render-plan', 2500, 'provider_plan_estimate', 'usage')
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    expect(s.previous_month).toBeNull()
+    expect(s.month_over_month_delta).toBeNull()
+  })
+
+  it('previous_month: aggregates from prior month lines + MoM delta', () => {
+    const db = getDb()
+    const prevWin = monthWindow(monthWindow(NOW).start - 86400) // June
+    seedSource(db, 'render-plan', 'render')
+    seedLine(db, 'render-plan', 2000, 'provider_plan_estimate', 'usage', prevWin, 'render-plan|prev')
+    seedLine(db, 'render-plan', 2500, 'provider_plan_estimate', 'usage', monthWindow(NOW), 'render-plan|cur')
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    expect(s.previous_month).not.toBeNull()
+    expect(s.previous_month!.operational_spend).toBe(2000)
+    expect(s.previous_month!.month).toBe(prevWin.key)
+    expect(s.month_over_month_delta).toBe(500) // 2500 - 2000
+  })
+})

--- a/src/__tests__/costops-pricing.test.ts
+++ b/src/__tests__/costops-pricing.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { deriveProvider, validatePricing, getTokenCostEstimate, type PricingConfig } from '../costops/pricing.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+function emptyConfig(): CostOpsConfig {
+  return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] }
+}
+
+// input 5000/MTok, output 25000/MTok, cache_read 500/MTok, cache_write 6250/MTok
+const PRICING: PricingConfig = {
+  version: 1, currency: 'HUF',
+  models: {
+    'claude-opus-4-8': { input_per_mtok: 5000, output_per_mtok: 25000, cache_read_per_mtok: 500, cache_write_per_mtok: 6250 },
+  },
+}
+
+let tsCounter = 0
+function insertUsage(model: string | null, input: number, output: number, cacheRead = 0, cacheCreate = 0, session = 's1') {
+  const w = monthWindow(NOW)
+  const ts = w.start + (tsCounter++) // unique per insert -> no dedup-index collision
+  getDb().prepare(`INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, model, provider, model_source)
+    VALUES ('marveen', ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    session, ts, input, output, cacheRead, cacheCreate,
+    model, model ? deriveProvider(model) : null, model ? 'transcript' : null,
+  )
+}
+
+describe('costops deriveProvider', () => {
+  it('classifies known model families, else unknown', () => {
+    expect(deriveProvider('claude-opus-4-8')).toBe('anthropic')
+    expect(deriveProvider('deepseek-v4-pro')).toBe('deepseek')
+    expect(deriveProvider('gpt-4o')).toBe('openai')
+    expect(deriveProvider('gemini-2.0')).toBe('google')
+    expect(deriveProvider(null)).toBe('unknown')
+    expect(deriveProvider('some-weird-model')).toBe('unknown')
+  })
+})
+
+describe('costops validatePricing', () => {
+  it('accepts valid rates, drops invalid, defaults cache rates to 0', () => {
+    const r = validatePricing({ currency: 'HUF', models: {
+      'a': { input_per_mtok: 1, output_per_mtok: 2 },
+      'bad': { input_per_mtok: -1, output_per_mtok: 2 },
+      'nope': { output_per_mtok: 2 },
+    } })
+    expect(r.pricing.models['a']).toEqual({ input_per_mtok: 1, output_per_mtok: 2, cache_read_per_mtok: 0, cache_write_per_mtok: 0 })
+    expect(r.pricing.models['bad']).toBeUndefined()
+    expect(r.pricing.models['nope']).toBeUndefined()
+    expect(r.errors.length).toBe(2)
+  })
+})
+
+describe('costops getTokenCostEstimate', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('prices a known model deterministically (golden)', () => {
+    // 1,000,000 input; 500,000 output; 2,000,000 cache_read; 100,000 cache_write
+    insertUsage('claude-opus-4-8', 1_000_000, 500_000, 2_000_000, 100_000)
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), PRICING, true, w.start, w.end)
+    // 5000 + 12500 + 1000 + 625 = 19125
+    expect(e.total_estimated_huf).toBe(19125)
+    expect(e.pricing_profile_status).toBe('loaded')
+    expect(e.priced_by_model[0].model).toBe('claude-opus-4-8')
+    expect(e.priced_by_model[0].provider).toBe('anthropic')
+    expect(e.unpriced.unknown_model_tokens).toBe(0)
+    expect(e.unpriced.no_rate_tokens).toBe(0)
+  })
+
+  it('leaves unknown-model rows UNPRICED (never guessed)', () => {
+    insertUsage(null, 1_000_000, 1_000_000)
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), PRICING, true, w.start, w.end)
+    expect(e.total_estimated_huf).toBe(0)
+    expect(e.unpriced.unknown_model_tokens).toBe(2_000_000)
+  })
+
+  it('leaves model rows with NO matching rate UNPRICED', () => {
+    insertUsage('mystery-model-x', 1_000_000, 0)
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), PRICING, true, w.start, w.end)
+    expect(e.total_estimated_huf).toBe(0)
+    expect(e.unpriced.no_rate_tokens).toBe(1_000_000)
+  })
+
+  it('reports no_pricing_config when there is no pricing', () => {
+    insertUsage('claude-opus-4-8', 1_000_000, 0)
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), { version: 1, currency: 'HUF', models: {} }, false, w.start, w.end)
+    expect(e.total_estimated_huf).toBe(0)
+    expect(e.pricing_profile_status).toBe('no_pricing_config')
+  })
+
+  it('reports partial when some priced and some not', () => {
+    insertUsage('claude-opus-4-8', 1_000_000, 0, 0, 0, 'a')
+    insertUsage(null, 500_000, 0, 0, 0, 'b')
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), PRICING, true, w.start, w.end)
+    expect(e.pricing_profile_status).toBe('partial')
+    expect(e.total_estimated_huf).toBe(5000)
+    expect(e.unpriced.unknown_model_tokens).toBe(500_000)
+  })
+})
+
+describe('costops summary includes token_cost_estimate (separate from spend)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('adds token_cost_estimate + estimated_total_with_token_cost without touching current_spend', () => {
+    insertUsage('claude-opus-4-8', 1_000_000, 0) // priced 5000
+    const s = getCostSummary(getDb(), emptyConfig(), NOW, { pricing: PRICING, pricingExists: true })
+    expect(s.current_spend).toBe(0)                       // token cost NOT folded in
+    expect(s.token_cost_estimate.total_estimated_huf).toBe(5000)
+    expect(s.token_cost_estimate.confidence).toBe('estimate')
+    expect(s.estimated_total_with_token_cost).toBe(5000)  // 0 fixed + 5000 token
+  })
+})

--- a/src/__tests__/costops-reconciliation.test.ts
+++ b/src/__tests__/costops-reconciliation.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { buildReconciliation } from '../costops/reconciliation.js'
+import { monthWindow } from '../costops/ledger.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+function insertSource(db: import('better-sqlite3').Database, id: string, provider = 'other') {
+  db.prepare(`INSERT OR IGNORE INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, ?, 'usage', 'HUF', 1, ?, ?)`)
+    .run(id, id, provider, NOW, NOW)
+}
+
+function insertLine(db: import('better-sqlite3').Database, sourceId: string, amount: number, confidence: string, actualSource: string | null, chargeCategory = 'subscription') {
+  const win = monthWindow(NOW)
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+    VALUES (?, ?, ?, ?, ?, 'HUF', ?, ?, ?, ?, ?)
+  `).run(sourceId, win.start, win.end, chargeCategory, amount, confidence, NOW, NOW, `test|${sourceId}|${Math.random()}`, actualSource)
+}
+
+describe('buildReconciliation (CostOps Phase 1, GAP-06)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('a source with no lines this month is no_data, everything null', () => {
+    const db = getDb()
+    insertSource(db, 'idle')
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('no_data')
+    expect(r.expected_amount).toBeNull()
+    expect(r.observed_provider_amount).toBeNull()
+    expect(r.invoice_amount).toBeNull()
+    expect(r.operationally_selected_amount).toBeNull()
+  })
+
+  it('provider API amount matching the invoice amount within tolerance is matched', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertLine(db, 'render-hosting', 10000, 'provider_api', 'provider_api')
+    insertLine(db, 'render-hosting', 10050, 'actual_invoice', 'email_invoice') // 0.5% apart, within 2% tolerance
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.observed_provider_amount).toBe(10000)
+    expect(r.invoice_amount).toBe(10050)
+    expect(r.status).toBe('matched')
+    expect(r.variance_reason).toBe('invoice vs provider API')
+  })
+
+  it('a material mismatch between invoice and provider API is flagged as variance', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertLine(db, 'render-hosting', 10000, 'provider_api', 'provider_api')
+    insertLine(db, 'render-hosting', 12000, 'actual_invoice', 'email_invoice') // 20% apart
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('variance')
+    expect(r.variance).toBe(2000)
+  })
+
+  it('provider API present but no invoice yet -> missing_invoice', () => {
+    const db = getDb()
+    insertSource(db, 'openai-api', 'openai')
+    insertLine(db, 'openai-api', 5000, 'provider_api', 'provider_api')
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('missing_invoice')
+    expect(r.observed_provider_amount).toBe(5000)
+    expect(r.invoice_amount).toBeNull()
+  })
+
+  it('invoice present but no provider API data -> missing_provider_data', () => {
+    const db = getDb()
+    insertSource(db, 'domain')
+    insertLine(db, 'domain', 3000, 'actual_invoice', 'email_invoice')
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('missing_provider_data')
+  })
+
+  it('only manual/estimate data -> estimate_only', () => {
+    const db = getDb()
+    insertSource(db, 'hosting')
+    insertLine(db, 'hosting', 3000, 'manual', 'manual_entry')
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('estimate_only')
+    expect(r.observed_provider_amount).toBeNull()
+    expect(r.invoice_amount).toBeNull()
+    expect(r.operationally_selected_amount).toBe(3000)
+  })
+
+  it('operationally_selected_amount always matches the ledger CONF_PRIORITY resolution', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertLine(db, 'render-hosting', 9000, 'manual', 'manual_entry')
+    insertLine(db, 'render-hosting', 10000, 'provider_api', 'provider_api') // higher CONF_PRIORITY wins
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.operationally_selected_amount).toBe(10000)
+  })
+
+  it('expected_amount comes from the latest forecast_snapshots row for that source+month, when one exists', async () => {
+    const db = getDb()
+    insertSource(db, 'domain')
+    insertLine(db, 'domain', 3000, 'manual', 'manual_entry')
+    const { captureForecastSnapshots } = await import('../costops/forecast-capture.js')
+    captureForecastSnapshots(db, NOW)
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.expected_amount).toBe(3000) // fixed_subscription forecast == the mtd amount
+  })
+
+  it('reports per-month when a specific month is requested', () => {
+    const db = getDb()
+    insertSource(db, 'domain')
+    insertLine(db, 'domain', 3000, 'manual', 'manual_entry')
+    const win = monthWindow(NOW)
+    const [r] = buildReconciliation(db, NOW, win.key)
+    expect(r.month).toBe(win.key)
+    const [empty] = buildReconciliation(db, NOW, '2020-01')
+    expect(empty.status).toBe('no_data')
+  })
+})

--- a/src/__tests__/costops-render.test.ts
+++ b/src/__tests__/costops-render.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { mapRenderPlanCost, makeRenderCollector, type RenderPricing } from '../costops/collectors/render.js'
+import { runCollector } from '../costops/collectors/runner.js'
+import { dryRunCollector } from '../costops/collectors/runner.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+import type { HttpGetJson } from '../costops/collectors/types.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+const PRICING: RenderPricing = {
+  version: 1, currency: 'HUF', fx_usd_huf: 300,
+  plans: {
+    web_service: { free: 0, starter: 7, standard: 25, pro: 85 },
+    static_site: { free: 0 },
+    postgres: { free: 0, basic_1gb: 19 },
+  },
+}
+
+// Offline fixture -- NO live Render API is ever called in tests.
+const RAW = {
+  services: [
+    { service: { id: 'srv-1', type: 'web_service', serviceDetails: { plan: 'starter', numInstances: 1 } } },
+    { service: { id: 'srv-2', type: 'web_service', serviceDetails: { plan: 'standard', numInstances: 2 } } }, // 25*2=50
+    { service: { id: 'srv-3', type: 'static_site', serviceDetails: {} } },                                   // 0, bandwidth flag
+    { service: { id: 'srv-4', type: 'web_service', suspended: 'suspended', serviceDetails: { plan: 'pro' } } }, // 0 suspended
+    { service: { id: 'srv-5', type: 'web_service', serviceDetails: { plan: 'mystery', numInstances: 1 } } },   // unpriced
+  ],
+  postgres: [
+    { postgres: { id: 'pg-1', plan: 'basic_1gb' } }, // 19
+  ],
+}
+
+function opts() { const w = monthWindow(NOW); return { periodStart: w.start, periodEnd: w.end, pricing: PRICING, idSalt: 'salt', now: NOW } }
+
+describe('mapRenderPlanCost (pure, offline)', () => {
+  it('prices by plan, aggregates to one HUF line, flags the rest', () => {
+    const { lines, breakdown } = mapRenderPlanCost(RAW, opts())
+    // total USD = 7 + 50 + 19 = 76 ; HUF = 76 * 300 = 22800
+    expect(breakdown.total_usd).toBe(76)
+    expect(breakdown.total_huf).toBe(22800)
+    expect(lines).toHaveLength(1)
+    expect(lines[0].amount).toBe(22800)
+    expect(lines[0].confidence).toBe('provider_plan_estimate')
+    expect(lines[0].provider).toBe('render')
+    expect(lines[0].service).toBe('render-plan')
+    expect(lines[0].dedup_key).toBe('provider|render|render-plan|2026-07|provider_plan_estimate')
+    // no raw service id in the line
+    expect(JSON.stringify(lines[0])).not.toContain('srv-')
+    expect(JSON.stringify(lines[0])).not.toContain('pg-')
+  })
+  it('handles static/suspended/unknown + records undercount flags', () => {
+    const { breakdown } = mapRenderPlanCost(RAW, opts())
+    expect(breakdown.suspended_count).toBe(1)
+    expect(breakdown.unpriced.some(u => u.plan === 'mystery')).toBe(true)
+    expect(breakdown.by_type_plan['web_service/standard']).toEqual({ count: 2, usd: 50 })
+    expect(breakdown.undercount_flags.some(f => /static_site/.test(f))).toBe(true)
+    expect(breakdown.undercount_flags.some(f => /unpriced/.test(f))).toBe(true)
+  })
+  it('fx=0 -> HUF total 0 + flag (no fabricated amount)', () => {
+    const p = { ...PRICING, fx_usd_huf: 0 }
+    const { lines, breakdown } = mapRenderPlanCost(RAW, { ...opts(), pricing: p })
+    expect(breakdown.total_huf).toBe(0)
+    expect(lines).toHaveLength(0)
+    expect(breakdown.undercount_flags.some(f => /fx_usd_huf/.test(f))).toBe(true)
+  })
+})
+
+describe('render collector via runner (offline)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('dry-run does NOT persist a render-plan line', async () => {
+    const stub: HttpGetJson = async (url) => url.includes('postgres') ? RAW.postgres : RAW.services
+    const col = makeRenderCollector(PRICING)
+    const w = monthWindow(NOW)
+    const rep = await dryRunCollector({ db: getDb(), collector: col, opts: { periodStart: w.start, periodEnd: w.end, secret: 'rnd_SECRET', fxUsdHuf: 0, idSalt: 'salt', httpGetJson: stub }, now: NOW })
+    expect(rep.status).toBe('dry_run')
+    expect(rep.plannedLines[0].amount).toBe(22800)
+    const n = getDb().prepare("SELECT COUNT(*) n FROM cost_line_items").get() as { n: number }
+    expect(n.n).toBe(0)
+  })
+
+  it('import writes a provider_plan_estimate line; idempotent', async () => {
+    const stub: HttpGetJson = async (url) => url.includes('postgres') ? RAW.postgres : RAW.services
+    const col = makeRenderCollector(PRICING)
+    const w = monthWindow(NOW)
+    const o = { periodStart: w.start, periodEnd: w.end, secret: 'rnd_SECRET', fxUsdHuf: 0, idSalt: 'salt', httpGetJson: stub }
+    await runCollector({ db: getDb(), collector: col, opts: o, now: NOW })
+    await runCollector({ db: getDb(), collector: col, opts: o, now: NOW }) // re-run
+    const rows = getDb().prepare("SELECT confidence, billed_cost FROM cost_line_items WHERE source_id='render-plan'").all() as Array<{ confidence: string; billed_cost: number }>
+    expect(rows).toHaveLength(1) // idempotent
+    expect(rows[0].confidence).toBe('provider_plan_estimate')
+    expect(rows[0].billed_cost).toBe(22800)
+    // secret never in import_runs
+    expect(JSON.stringify(getDb().prepare('SELECT * FROM import_runs').all())).not.toContain('rnd_SECRET')
+  })
+})
+
+describe('summary: render plan is advisory (no override of manual)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  function emptyConfig(): CostOpsConfig { return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] } }
+
+  it('render_plan block shows manual vs plan vs variance; current_spend excludes plan estimate', async () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    // seed a MANUAL render-hosting estimate (like the config sync)
+    db.prepare("INSERT INTO cost_sources (id,name,provider,source_type,currency,active,created_at,updated_at) VALUES ('render-hosting','Render hosting','render','hosting','HUF',1,?,?)").run(NOW, NOW)
+    db.prepare("INSERT INTO cost_line_items (source_id,charge_period_start,charge_period_end,charge_category,service_name,billed_cost,currency,confidence,data_freshness,dedup_key,created_at) VALUES ('render-hosting',?,?,'subscription','Render hosting',30000,'HUF','manual',?,'fixed|render-hosting|2026-07',?)").run(w.start, w.end, NOW, NOW)
+    // import the plan-based estimate
+    const stub: HttpGetJson = async (url) => url.includes('postgres') ? RAW.postgres : RAW.services
+    await runCollector({ db, collector: makeRenderCollector(PRICING), opts: { periodStart: w.start, periodEnd: w.end, secret: 'x', fxUsdHuf: 0, idSalt: 'salt', httpGetJson: stub }, now: NOW })
+
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    // headline current_spend = manual 30000 ONLY (plan estimate excluded)
+    expect(s.current_spend).toBe(30000)
+    // render-plan source NOT in all_sources
+    expect(s.all_sources.find(x => x.source_id === 'render-plan')).toBeUndefined()
+    // render_plan advisory block present with variance
+    expect(s.render_plan).not.toBeNull()
+    expect(s.render_plan!.plan_estimate_total).toBe(22800)
+    expect(s.render_plan!.manual_estimate).toBe(30000)
+    expect(s.render_plan!.variance).toBe(-7200) // plan - manual
+    expect(s.render_plan!.not_covered.length).toBeGreaterThan(0)
+  })
+
+  it('render_plan is null when no plan import exists', () => {
+    const s = getCostSummary(getDb(), emptyConfig(), NOW)
+    expect(s.render_plan).toBeNull()
+  })
+})

--- a/src/__tests__/costops-sync.test.ts
+++ b/src/__tests__/costops-sync.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { syncRenderCollector, type RenderPricing } from '../costops/collectors/render.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+import type { HttpGetJson } from '../costops/collectors/types.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+function emptyConfig(): CostOpsConfig { return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] } }
+
+// Offline fixture -- NO live Render API is ever called.
+const SERVICES = [
+  { service: { id: 'srv-1', type: 'web_service', serviceDetails: { plan: 'starter', numInstances: 1 } } },
+  { service: { id: 'srv-2', type: 'static_site', serviceDetails: {} } },
+]
+const POSTGRES = [{ postgres: { id: 'pg-1', plan: 'basic_1gb' } }]
+const stub: HttpGetJson = async (url) => url.includes('postgres') ? POSTGRES : SERVICES
+
+// syncRenderCollector loads pricing from disk; inject via deps.apiKey + httpGetJson,
+// but pricing comes from loadRenderPricing() -- for a deterministic test we rely on
+// the real store pricing if present; assert structurally rather than on an exact HUF.
+
+describe('syncRenderCollector (offline, v0.5 sync spine)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('imports idempotently, records an ok run with detail_json (no raw IDs)', async () => {
+    const db = getDb()
+    const r1 = await syncRenderCollector(db, NOW, { httpGetJson: stub, apiKey: 'rnd_TESTKEY' })
+    expect(r1.provider).toBe('render')
+    expect(r1.status).toBe('ok')
+    // re-run -> idempotent (same month, one line)
+    await syncRenderCollector(db, NOW, { httpGetJson: stub, apiKey: 'rnd_TESTKEY' })
+    const lines = db.prepare("SELECT COUNT(*) n FROM cost_line_items WHERE source_id='render-plan'").get() as { n: number }
+    expect(lines.n).toBeLessThanOrEqual(1) // 0 if fx=0 in store pricing, else 1 -- never duplicated
+    const runs = db.prepare("SELECT detail_json FROM import_runs WHERE provider='render' AND status='ok' ORDER BY started_at DESC LIMIT 1").get() as { detail_json: string | null } | undefined
+    expect(runs).toBeDefined()
+    if (runs?.detail_json) {
+      const d = JSON.parse(runs.detail_json)
+      expect(typeof d.service_count).toBe('number')
+      expect(runs.detail_json).not.toContain('srv-')  // no raw service IDs
+      expect(runs.detail_json).not.toContain('pg-')
+    }
+    // secret never stored
+    expect(JSON.stringify(db.prepare('SELECT * FROM import_runs').all())).not.toContain('rnd_TESTKEY')
+  })
+
+  it('summary provider_sync exposes v0.5 freshness fields + render_plan.detail', async () => {
+    const db = getDb()
+    await syncRenderCollector(db, NOW, { httpGetJson: stub, apiKey: 'rnd_TESTKEY' })
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    const ps = s.provider_sync.find(p => p.provider === 'render')
+    expect(ps).toBeDefined()
+    if (ps) {
+      expect(['ok', 'stale', 'failed', 'no_data']).toContain(ps.status)
+      expect(ps).toHaveProperty('last_success')
+      expect(ps).toHaveProperty('last_failed')
+      expect(ps).toHaveProperty('data_age_secs')
+      expect(ps.current_period).toBe(monthWindow(NOW).key)
+      expect(ps).toHaveProperty('previous_period_coverage')
+    }
+  })
+
+  it('no api key -> error result, nothing imported', async () => {
+    const db = getDb()
+    const r = await syncRenderCollector(db, NOW, { httpGetJson: stub, apiKey: null })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe('error')
+    const n = db.prepare('SELECT COUNT(*) n FROM cost_line_items').get() as { n: number }
+    expect(n.n).toBe(0)
+  })
+})

--- a/src/costops/README.md
+++ b/src/costops/README.md
@@ -129,6 +129,23 @@ manual/estimate rows, and with a strict secrets-in-Vault-only posture.
 **Vault**: real Admin keys go into `src/web/vault.ts` via the secure handover, never
 into config/log/transcript/dashboard-response.
 
+## v0.3 -- Render plan-based infra collector (`provider_plan_estimate`, advisory)
+
+`src/costops/collectors/render.ts` reads Render services (+ `/v1/postgres`) READ-ONLY
+and maps each service's PLAN to a monthly HUF estimate via a local plan->price map
+(`store/costops-render-pricing.json`, gitignored; safe 0-rate example tracked at
+`render-pricing.example.json`). Key points:
+- **`provider_plan_estimate` confidence** -- NOT an invoice, NOT provider_api actual.
+  It is **excluded from the headline `current_spend`** and never overrides the manual
+  `render-hosting` estimate. It surfaces only in the summary `render_plan` block:
+  `plan_estimate_total`, `manual_estimate`, `variance`, `not_covered[]`.
+- **Aggregated** to one `render-plan` line/month (idempotent dedup_key). Raw service/
+  account IDs are NEVER stored/returned -- only a `raw_ref_hash` + type/plan labels.
+  `static_site`/`suspended` = 0; unknown plan -> unpriced warning (never fabricated).
+- **Lower bound**: bandwidth/storage overage, seats, tax, credits, one-off charges are
+  structurally invisible -> listed in `render_plan.not_covered`. Design:
+  `audits/costops-v0.3-render-plan-collector-plan.md`.
+
 ## Known limitations
 
 - Provider API calls only happen when Vault keys are configured and a live run is

--- a/src/costops/README.md
+++ b/src/costops/README.md
@@ -116,6 +116,16 @@ manual/estimate rows, and with a strict secrets-in-Vault-only posture.
   double counting. New `reconcile[]` (per-source estimate vs actual vs variance) and
   `provider_sync[]` (last run per provider: status, freshness, stale/failed marker).
 
+- **Dry-run mode** (`dryRunCollector` in `runner.ts`): a safety layer that runs
+  fetch + normalize EXACTLY like a real import but persists **no** `provider_api`
+  cost line. It returns the planned normalized lines, their `dedup_key`s, a
+  `wouldImportCount`, and a **sanitized response shape** (`describeShape` -- types,
+  object keys and array lengths ONLY, never a scalar value, so no secret / account
+  id / invoice ref / raw datum can travel in it). Its only optional write is a
+  `status='dry_run'`, `imported_count=0` audit row in `import_runs` (no cost, no
+  secret, no raw); pass `recordRun:false` to persist nothing at all. This is the
+  gate before any real import: preview the shape and the planned lines first.
+
 **Vault**: real Admin keys go into `src/web/vault.ts` via the secure handover, never
 into config/log/transcript/dashboard-response.
 

--- a/src/costops/README.md
+++ b/src/costops/README.md
@@ -59,3 +59,73 @@ No client writes, no LLM, no provider API, no secrets in any response.
   is ever derived from tokens here.
 - Additive schema (`CREATE TABLE IF NOT EXISTS`); with no CostOps config the rest
   of the app behaves exactly as before.
+- No autonomous action of any kind. `warning_threshold` / `hard_threshold` are
+  **display-only** -- never stop an agent, switch a model, change a spend cap,
+  top-up, or modify a subscription.
+- No LLM anywhere in CostOps (summary is pure SQL + arithmetic). Future periodic
+  collectors must run as `type: "command"` scheduled tasks (raw shell, no LLM),
+  never as an LLM heartbeat.
+- No raw account IDs / invoice refs / secrets in DB, logs, audit or API response.
+  Use `hashRef(salt, raw)` for identifiers if ever needed.
+
+## v0.2 -- token-cost ESTIMATE (deterministic, no LLM/provider API)
+
+v0.2 adds a **separate, estimate-only** token cost derived from `token_usage`.
+It is never folded into `current_spend` and is clearly labelled as an estimate.
+
+**Model enrichment (forward-only).** `token_usage` now has nullable `model`,
+`provider`, `model_source` columns. The ingestion (`src/web/token-usage.ts`)
+captures `message.model` from the transcript for NEW rows (`model_source =
+'transcript'`) and derives a coarse `provider` (`deriveProvider`). Existing rows
+stay `NULL` (unknown) -- no uncertain backfill. **The model-capture activates on
+the next dashboard restart**; rows ingested before that stay unknown.
+
+**Pricing config (local, gitignored).** Per-model rates live in
+`store/costops-pricing.json` (gitignored; a safe 0-rate `.example` is generated).
+Rates are **per 1,000,000 tokens** in `currency`. No provider prices are hardcoded
+in tracked source.
+
+**Summary block.** `GET /api/costs/summary` gains `token_cost_estimate`
+(`total_estimated_huf`, `priced_by_model[]`, `unpriced.{unknown_model_tokens,
+no_rate_tokens}`, `pricing_profile_status`, `confidence: "estimate"`) and
+`estimated_total_with_token_cost` (= `current_spend` + token estimate, clearly
+labelled -- not added to `current_spend`).
+
+**Provider billing/usage API collector is v0.3** (still no external API in v0.2).
+
+## v0.3 -- provider cost collector framework
+
+v0.3 adds a generic, deterministic framework to import ACTUAL provider cost as
+high-confidence `provider_api` line items -- **without** overwriting the local
+manual/estimate rows, and with a strict secrets-in-Vault-only posture.
+
+- **Framework** (`src/costops/collectors/`): `ProviderCollector` interface with an
+  INJECTED HTTP fetcher (so collectors are unit-tested fully offline with fixtures
+  -- no live call unless a real fetcher is passed after explicit approval).
+- **`runner.ts`**: loads a collector's normalized lines, idempotently upserts them
+  into `cost_line_items` as `confidence='provider_api'`, and records an `import_runs`
+  row. On error it DELETES NOTHING and records a **sanitized** failure (keys redacted).
+- **`import_runs` table**: run history / sync status. No raw account id, no raw API
+  response, no secret ever stored.
+- **Config**: gitignored `store/costops-collectors.json` holds only non-secret
+  wiring -- an `enabled` flag and a `secret_ref` (validated to REQUIRE the `vault:`
+  form, never a raw key). A tracked safe example lives at
+  `src/costops/collectors/collectors-config.example.json` (no key, no account id).
+- **Summary reconcile**: the headline `current_spend` resolves each source to its
+  single highest-confidence line so an actual supersedes an estimate WITHOUT
+  double counting. New `reconcile[]` (per-source estimate vs actual vs variance) and
+  `provider_sync[]` (last run per provider: status, freshness, stale/failed marker).
+
+**Vault**: real Admin keys go into `src/web/vault.ts` via the secure handover, never
+into config/log/transcript/dashboard-response.
+
+## Known limitations
+
+- Provider API calls only happen when Vault keys are configured and a live run is
+  explicitly approved. Until then `provider_sync`/`reconcile` stay empty.
+- Forward-only enrichment: token costs only appear for rows ingested AFTER
+  the dashboard restart that activates model-capture.
+- Forecast is a naive linear proration of usage-type lines; fixed monthly costs
+  are attributed whole-month (no proration).
+- No provider billing integration yet (see the maturity model in
+  `audits/costops-v0.1-pr1-local-ledger-plan.md`).

--- a/src/costops/collectors/anthropic.ts
+++ b/src/costops/collectors/anthropic.ts
@@ -1,0 +1,108 @@
+// CostOps v0.3 -- Anthropic cost collector (LIVE-READY, but no live call in PR1).
+//
+// The mapper is a PURE function tested offline against a fixture. collect()
+// builds the request and calls the INJECTED httpGetJson, so no network happens
+// unless a real fetcher is passed after explicit approval. The Admin API key is
+// received via opts.secret (from the Vault) and is NEVER logged.
+//
+// NOTE: the exact Anthropic Admin cost_report field names must be verified on
+// the first approved live dry-run; the fixture + mapper here are a matched pair
+// modelling the documented shape (time buckets -> per-line cost results in USD).
+
+import { createHash } from 'node:crypto'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine } from './types.js'
+
+const ANTHROPIC_COST_URL = 'https://api.anthropic.com/v1/organizations/cost_report'
+const ANTHROPIC_VERSION = '2023-06-01'
+// All Anthropic API usage reconciles against this source (matches the v0.1
+// manual/estimate line 'anthropic-api' so estimate and actual share a source).
+const ANTHROPIC_API_SOURCE = 'anthropic-api'
+
+function hashRef(salt: string, raw: string): string {
+  return createHash('sha256').update(salt).update('|').update(raw).digest('hex').slice(0, 32)
+}
+
+interface AnthropicCostResult {
+  currency?: string
+  amount?: number | string
+  cost_type?: string
+  model?: string
+  service?: string
+  description?: string
+}
+interface AnthropicCostBucket {
+  starting_at?: string
+  ending_at?: string
+  results?: AnthropicCostResult[]
+}
+interface AnthropicCostReport {
+  data?: AnthropicCostBucket[]
+  has_more?: boolean
+}
+
+/**
+ * PURE mapper: Anthropic cost_report -> a single aggregated provider_api line
+ * for the anthropic-api source for the requested period. USD amounts are
+ * converted to HUF via fxUsdHuf. Deterministic; no I/O. Returns [] if nothing.
+ */
+export function mapAnthropicCostReport(
+  raw: unknown,
+  opts: { periodStart: number; periodEnd: number; fxUsdHuf: number; idSalt: string; now: number },
+): NormalizedCostLine[] {
+  const report = (raw && typeof raw === 'object') ? raw as AnthropicCostReport : {}
+  const buckets = Array.isArray(report.data) ? report.data : []
+  let usdTotal = 0
+  let latestEnd = 0
+  let any = false
+  for (const b of buckets) {
+    const endSec = b.ending_at ? Math.floor(new Date(b.ending_at).getTime() / 1000) : 0
+    if (endSec > latestEnd) latestEnd = endSec
+    for (const r of (Array.isArray(b.results) ? b.results : [])) {
+      const amt = typeof r.amount === 'number' ? r.amount : parseFloat(String(r.amount ?? ''))
+      if (!isFinite(amt)) continue
+      // report may already be in the account currency; treat as USD only when labelled USD (default).
+      const cur = (r.currency || 'USD').toUpperCase()
+      usdTotal += cur === 'USD' ? amt : amt // v0.1: assume USD; non-USD handled at live-verify time
+      any = true
+    }
+  }
+  if (!any) return []
+  const monthKey = new Date(opts.periodStart * 1000).toISOString().slice(0, 7)
+  const amountHuf = Math.round(usdTotal * opts.fxUsdHuf * 100) / 100
+  return [{
+    provider: 'anthropic',
+    service: ANTHROPIC_API_SOURCE,
+    billing_period_start: opts.periodStart,
+    billing_period_end: opts.periodEnd,
+    amount: amountHuf,
+    currency: 'HUF',
+    confidence: 'provider_api',
+    usage_type: 'api_usage',
+    quantity: null,
+    unit: null,
+    data_freshness_at: latestEnd || opts.now,
+    raw_ref_hash: hashRef(opts.idSalt, `anthropic-cost-report|${monthKey}`),
+    dedup_key: `provider|anthropic|${ANTHROPIC_API_SOURCE}|${monthKey}|provider_api`,
+  }]
+}
+
+export const anthropicCollector: ProviderCollector = {
+  provider: 'anthropic',
+  collectorName: 'anthropic-cost-report',
+  async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+    const startIso = new Date(opts.periodStart * 1000).toISOString()
+    const endIso = new Date(opts.periodEnd * 1000).toISOString()
+    const url = `${ANTHROPIC_COST_URL}?starting_at=${encodeURIComponent(startIso)}&ending_at=${encodeURIComponent(endIso)}`
+    // secret used ONLY as the auth header; never logged.
+    const headers = {
+      'x-api-key': opts.secret,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    }
+    const raw = await opts.httpGetJson(url, headers)
+    return mapAnthropicCostReport(raw, {
+      periodStart: opts.periodStart, periodEnd: opts.periodEnd,
+      fxUsdHuf: opts.fxUsdHuf, idSalt: opts.idSalt, now: opts.periodStart,
+    })
+  },
+}

--- a/src/costops/collectors/anthropic.ts
+++ b/src/costops/collectors/anthropic.ts
@@ -89,7 +89,10 @@ export function mapAnthropicCostReport(
 export const anthropicCollector: ProviderCollector = {
   provider: 'anthropic',
   collectorName: 'anthropic-cost-report',
-  async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+  // READ the cost report and return BOTH the raw response and the normalized
+  // lines. The raw is used ONLY to describe its shape in a dry-run (never
+  // persisted, never logged). The secret is used only as the auth header.
+  async collectRaw(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }> {
     const startIso = new Date(opts.periodStart * 1000).toISOString()
     const endIso = new Date(opts.periodEnd * 1000).toISOString()
     const url = `${ANTHROPIC_COST_URL}?starting_at=${encodeURIComponent(startIso)}&ending_at=${encodeURIComponent(endIso)}`
@@ -100,9 +103,13 @@ export const anthropicCollector: ProviderCollector = {
       'content-type': 'application/json',
     }
     const raw = await opts.httpGetJson(url, headers)
-    return mapAnthropicCostReport(raw, {
+    const lines = mapAnthropicCostReport(raw, {
       periodStart: opts.periodStart, periodEnd: opts.periodEnd,
       fxUsdHuf: opts.fxUsdHuf, idSalt: opts.idSalt, now: opts.periodStart,
     })
+    return { raw, lines }
+  },
+  async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+    return (await this.collectRaw!(opts)).lines
   },
 }

--- a/src/costops/collectors/collectors-config.example.json
+++ b/src/costops/collectors/collectors-config.example.json
@@ -1,0 +1,13 @@
+{
+  "_doc": "CostOps v0.3 collectors config EXAMPLE. Copy to store/costops-collectors.json (gitignored) to enable a collector. NEVER put an API key or raw account id here -- only a 'vault:<id>' secret_ref. The real Admin key goes into the Vault (src/web/vault.ts) via the secure handover, never into this file, a log, or a transcript. enabled=false and no live call until explicitly approved.",
+  "version": 1,
+  "fx_usd_huf": 0,
+  "collectors": [
+    {
+      "provider": "anthropic",
+      "enabled": false,
+      "secret_ref": "vault:costops.anthropic_admin_key",
+      "account_ref_hash": null
+    }
+  ]
+}

--- a/src/costops/collectors/config.ts
+++ b/src/costops/collectors/config.ts
@@ -1,0 +1,69 @@
+// CostOps v0.3 -- local collectors config loader.
+//
+// store/costops-collectors.json is gitignored/local. It holds ONLY non-secret
+// wiring: enable flags, a `secret_ref` pointing at a Vault id (NOT the value),
+// an optional account_ref_hash (never a raw account id), and the FX rate.
+// NO API key, account id, or invoice ref ever lives here or is logged.
+
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../../config.js'
+import { logger } from '../../logger.js'
+
+export const COLLECTORS_CONFIG_PATH = join(PROJECT_ROOT, 'store', 'costops-collectors.json')
+
+export interface CollectorEntry {
+  provider: string
+  enabled: boolean
+  secret_ref: string          // e.g. 'vault:costops.anthropic_admin_key' -- NOT the key
+  account_ref_hash?: string | null
+}
+
+export interface CollectorsConfig {
+  version: number
+  fx_usd_huf: number
+  collectors: CollectorEntry[]
+}
+
+const EMPTY: CollectorsConfig = { version: 1, fx_usd_huf: 0, collectors: [] }
+
+export interface CollectorsLoadResult {
+  config: CollectorsConfig
+  exists: boolean
+  errors: string[]
+}
+
+export function loadCollectorsConfig(): CollectorsLoadResult {
+  if (!existsSync(COLLECTORS_CONFIG_PATH)) {
+    return { config: { ...EMPTY }, exists: false, errors: [] }
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(COLLECTORS_CONFIG_PATH, 'utf-8'))
+  } catch (err) {
+    logger.warn({ err }, 'costops-collectors.json is not valid JSON')
+    return { config: { ...EMPTY }, exists: true, errors: ['collectors config is not valid JSON'] }
+  }
+  return validateCollectorsConfig(raw)
+}
+
+export function validateCollectorsConfig(raw: unknown): CollectorsLoadResult {
+  const errors: string[] = []
+  const obj = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const fx = typeof obj.fx_usd_huf === 'number' && isFinite(obj.fx_usd_huf) && obj.fx_usd_huf >= 0 ? obj.fx_usd_huf : 0
+  const collectors: CollectorEntry[] = []
+  for (const [i, e] of (Array.isArray(obj.collectors) ? obj.collectors : []).entries()) {
+    const c = e as Record<string, unknown>
+    if (typeof c?.provider !== 'string' || !c.provider) { errors.push(`collectors[${i}]: missing provider`); continue }
+    // A raw key would look like 'sk-...'; a secret_ref must be a 'vault:' reference.
+    const ref = typeof c.secret_ref === 'string' ? c.secret_ref : ''
+    if (ref && !ref.startsWith('vault:')) { errors.push(`collectors[${i}] (${c.provider}): secret_ref must be a 'vault:<id>' reference, not a raw value`); continue }
+    collectors.push({
+      provider: c.provider,
+      enabled: c.enabled === true,
+      secret_ref: ref,
+      account_ref_hash: typeof c.account_ref_hash === 'string' ? c.account_ref_hash : null,
+    })
+  }
+  return { config: { version: typeof obj.version === 'number' ? obj.version : 1, fx_usd_huf: fx, collectors }, exists: true, errors }
+}

--- a/src/costops/collectors/deepseek.ts
+++ b/src/costops/collectors/deepseek.ts
@@ -1,0 +1,122 @@
+// CostOps -- DeepSeek cost collector (LIVE, read-only, prepaid-balance based).
+//
+// DeepSeek exposes remaining prepaid BALANCE (GET /user/balance), not per-period
+// cost. So month-to-date spend is derived from the balance DROP across snapshots:
+// each sync records a snapshot, and MTD spend = the sum of decreases between
+// consecutive this-month snapshots (increases are top-ups and are ignored, so a
+// mid-month top-up does not distort spend). The API key comes from the Vault and
+// is NEVER logged. Pure GET, no provider-side write.
+//
+// First sync of a month just records the baseline (spend 0 until a later sync
+// shows a drop). This is a provider_usage_actual signal (API-observed), an
+// upgrade over a manual DeepSeek estimate.
+
+const DEEPSEEK_BALANCE_URL = 'https://api.deepseek.com/user/balance'
+const DEEPSEEK_API_SOURCE = 'deepseek-api'
+
+export interface BalanceSnapshot { balance: number; captured_at: number }
+
+/**
+ * PURE: month-to-date spend in the balance currency, from ascending-by-time
+ * snapshots. Sums only the DROPS between consecutive snapshots (a rise is a
+ * top-up, ignored). Deterministic; no I/O.
+ */
+export function deriveMtdSpend(snapshotsAsc: BalanceSnapshot[]): number {
+  let spend = 0
+  for (let i = 1; i < snapshotsAsc.length; i++) {
+    const drop = snapshotsAsc[i - 1].balance - snapshotsAsc[i].balance
+    if (drop > 0) spend += drop
+  }
+  return Math.round(spend * 10000) / 10000
+}
+
+interface DeepSeekBalanceInfo { currency?: string; total_balance?: string | number }
+interface DeepSeekBalanceResp { is_available?: boolean; balance_infos?: DeepSeekBalanceInfo[] }
+
+/** Extract the USD total balance from the /user/balance response (0 if absent). */
+export function parseDeepSeekBalanceUsd(raw: unknown): number {
+  const r = (raw && typeof raw === 'object') ? raw as DeepSeekBalanceResp : {}
+  const infos = Array.isArray(r.balance_infos) ? r.balance_infos : []
+  const usd = infos.find(i => (i.currency || '').toUpperCase() === 'USD') || infos[0]
+  if (!usd) return 0
+  const v = typeof usd.total_balance === 'number' ? usd.total_balance : parseFloat(String(usd.total_balance ?? ''))
+  return isFinite(v) ? v : 0
+}
+
+export const DEEPSEEK_VAULT_SECRET_ID = 'DEEPSEEK_API_KEY'
+
+/**
+ * LIVE read-only sync: read the prepaid balance, record a snapshot, derive MTD
+ * spend from this month's balance drops, and upsert a provider line +
+ * import_runs row. Injected deps let tests stub the key, fetcher, fx and clock.
+ */
+export async function syncDeepSeekBalance(
+  db: import('better-sqlite3').Database,
+  now: number,
+  deps: {
+    httpGetJson?: import('./types.js').HttpGetJson
+    apiKey?: string | null
+    fxUsdHuf?: number
+  } = {},
+): Promise<{ ok: boolean; provider: string; status: string; imported_count: number; balance_usd?: number; mtd_spend_usd?: number; error?: string; period?: string }> {
+  const { monthWindow } = await import('../ledger.js')
+  const { sanitizeError } = await import('./runner.js')
+  let apiKey = deps.apiKey
+  if (apiKey === undefined) {
+    try { const { getSecret } = await import('../../web/vault.js'); apiKey = getSecret(DEEPSEEK_VAULT_SECRET_ID) } catch { apiKey = null }
+  }
+  const w = monthWindow(now)
+  if (!apiKey) {
+    recordRun(db, 'error', 0, w, now, 'no DeepSeek key in vault')
+    return { ok: false, provider: 'deepseek', status: 'error', imported_count: 0, error: `no DeepSeek key in vault (${DEEPSEEK_VAULT_SECRET_ID})`, period: w.key }
+  }
+  let fxUsdHuf = deps.fxUsdHuf
+  if (fxUsdHuf === undefined) {
+    try { const { loadRenderPricing } = await import('./render.js'); fxUsdHuf = loadRenderPricing().pricing.fx_usd_huf || 0 } catch { fxUsdHuf = 0 }
+  }
+  const httpGetJson = deps.httpGetJson || (async (url: string, headers: Record<string, string>) => {
+    const r = await fetch(url, { method: 'GET', headers }); if (!r.ok) throw new Error(`deepseek api ${r.status}`); return r.json()
+  })
+  let balanceUsd: number
+  try {
+    const raw = await httpGetJson(DEEPSEEK_BALANCE_URL, { authorization: `Bearer ${apiKey}` })
+    balanceUsd = parseDeepSeekBalanceUsd(raw)
+  } catch (err) {
+    const s = sanitizeError(err)
+    recordRun(db, 'error', 0, w, now, s.message)
+    return { ok: false, provider: 'deepseek', status: 'error', imported_count: 0, error: s.code, period: w.key }
+  }
+  // record the snapshot, then derive MTD spend from this-month snapshots (asc)
+  db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',?,?)`).run(balanceUsd, now)
+  const rows = db.prepare(
+    `SELECT balance, captured_at FROM provider_balance_snapshots WHERE provider='deepseek' AND captured_at >= ? AND captured_at < ? ORDER BY captured_at ASC`,
+  ).all(w.start, w.end) as Array<{ balance: number; captured_at: number }>
+  const mtdSpendUsd = deriveMtdSpend(rows.map(r => ({ balance: r.balance, captured_at: r.captured_at })))
+  const amountHuf = Math.round(mtdSpendUsd * (fxUsdHuf || 0) * 100) / 100
+
+  // upsert the provider line (usage actual, derived) for deepseek-api
+  upsertLine(db, {
+    source: DEEPSEEK_API_SOURCE, provider: 'deepseek', start: w.start, end: w.end,
+    amount: amountHuf, confidence: 'provider_api', freshness: now,
+    dedup_key: `provider|deepseek|${DEEPSEEK_API_SOURCE}|${w.key}|provider_api`, now,
+  })
+  recordRun(db, 'ok', 1, w, now, null)
+  return { ok: true, provider: 'deepseek', status: 'ok', imported_count: 1, balance_usd: balanceUsd, mtd_spend_usd: mtdSpendUsd, period: w.key }
+}
+
+function upsertLine(db: import('better-sqlite3').Database, a: { source: string; provider: string; start: number; end: number; amount: number; confidence: string; freshness: number; dedup_key: string; now: number }): void {
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at)
+    VALUES (@id,@id,@provider,'usage','HUF',1,@now,@now)
+    ON CONFLICT(id) DO UPDATE SET provider=excluded.provider, updated_at=excluded.updated_at`).run({ id: a.source, provider: a.provider, now: a.now })
+  db.prepare(`INSERT INTO cost_line_items
+      (source_id, charge_period_start, charge_period_end, charge_category, service_name, usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency, confidence, data_freshness, source_ref, dedup_key, created_at)
+    VALUES (@source,@start,@end,'usage',@source,NULL,NULL,NULL,@amount,NULL,'HUF',@confidence,@freshness,NULL,@dedup_key,@now)
+    ON CONFLICT(dedup_key) DO UPDATE SET billed_cost=excluded.billed_cost, confidence=excluded.confidence, data_freshness=excluded.data_freshness`).run(a)
+}
+
+function recordRun(db: import('better-sqlite3').Database, status: string, count: number, w: { start: number; end: number }, now: number, errMsg: string | null): void {
+  db.prepare(`INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status, period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at)
+    VALUES ('deepseek','deepseek-balance',@now,@now,@status,@ps,@pe,@count,@ec,@em,@now)`).run({
+    now, status, ps: w.start, pe: w.end, count, ec: status === 'error' ? 'balance_error' : null, em: errMsg,
+  })
+}

--- a/src/costops/collectors/github.ts
+++ b/src/costops/collectors/github.ts
@@ -74,8 +74,8 @@ export function mapGitHubUsage(
   }]
 }
 
-/** The account whose billing is read. */
-export const GITHUB_BILLING_USER = 'iszzu80-dev'
+/** The account whose billing is read. Set via COSTOPS_GITHUB_BILLING_USER env var. */
+export const GITHUB_BILLING_USER = process.env.COSTOPS_GITHUB_BILLING_USER || ''
 
 export function makeGitHubCollector(user: string = GITHUB_BILLING_USER): ProviderCollector {
   return {

--- a/src/costops/collectors/github.ts
+++ b/src/costops/collectors/github.ts
@@ -1,0 +1,152 @@
+// CostOps -- GitHub billing collector (LIVE, read-only).
+//
+// Uses the GitHub enhanced billing platform usage report
+// (GET /users/{user}/settings/billing/usage) which returns per-line usage with a
+// netAmount (USD). A fine-grained PAT with "Plan: read-only" is required. The
+// mapper is PURE and offline-tested; collect() calls the INJECTED httpGetJson so
+// no network happens unless a real fetcher is passed. The token arrives via
+// opts.secret (from the Vault) and is NEVER logged. Pure GET, no provider write.
+//
+// Unlike usage-billing providers that omit an empty period, GitHub reports an
+// EXPLICIT 0-with-freshness line on a successful empty response, so the dashboard
+// shows a provider_api-observed 0 (not a manual estimate) for a no-usage month.
+
+import { createHash } from 'node:crypto'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine } from './types.js'
+
+const GITHUB_API = 'https://api.github.com'
+const GITHUB_API_SOURCE = 'github'
+
+function hashRef(salt: string, raw: string): string {
+  return createHash('sha256').update(salt).update('|').update(raw).digest('hex').slice(0, 32)
+}
+
+interface GitHubUsageItem {
+  date?: string
+  product?: string
+  sku?: string
+  quantity?: number
+  unitType?: string
+  pricePerUnit?: number
+  grossAmount?: number
+  discountAmount?: number
+  netAmount?: number | string
+  organizationName?: string
+  repositoryName?: string
+}
+interface GitHubUsageReport { usageItems?: GitHubUsageItem[] }
+
+/**
+ * PURE mapper: GitHub billing usage report -> a single aggregated provider_api
+ * line for the github source. netAmount (USD) is summed and converted to HUF.
+ * A valid-but-empty report yields an explicit 0 line (API-observed zero), so the
+ * caller can show GitHub as provider_api with a real freshness even at $0.
+ * Returns [] only when the raw is not a recognizable usage report.
+ */
+export function mapGitHubUsage(
+  raw: unknown,
+  opts: { periodStart: number; periodEnd: number; fxUsdHuf: number; idSalt: string; now: number },
+): NormalizedCostLine[] {
+  const report = (raw && typeof raw === 'object') ? raw as GitHubUsageReport : null
+  if (!report || !Array.isArray(report.usageItems)) return []
+  let usdTotal = 0
+  for (const it of report.usageItems) {
+    const raw2 = it.netAmount
+    const amt = typeof raw2 === 'number' ? raw2 : parseFloat(String(raw2 ?? ''))
+    if (isFinite(amt)) usdTotal += amt
+  }
+  const monthKey = new Date(opts.periodStart * 1000).toISOString().slice(0, 7)
+  const amountHuf = Math.round(usdTotal * opts.fxUsdHuf * 100) / 100
+  return [{
+    provider: 'github',
+    service: GITHUB_API_SOURCE,
+    billing_period_start: opts.periodStart,
+    billing_period_end: opts.periodEnd,
+    amount: amountHuf,
+    currency: 'HUF',
+    confidence: 'provider_api',
+    usage_type: 'usage_billing',
+    quantity: null,
+    unit: null,
+    data_freshness_at: opts.now,
+    raw_ref_hash: hashRef(opts.idSalt, `github-usage|${monthKey}`),
+    dedup_key: `provider|github|${GITHUB_API_SOURCE}|${monthKey}|provider_api`,
+  }]
+}
+
+/** The account whose billing is read. */
+export const GITHUB_BILLING_USER = 'iszzu80-dev'
+
+export function makeGitHubCollector(user: string = GITHUB_BILLING_USER): ProviderCollector {
+  return {
+    provider: 'github',
+    collectorName: 'github-billing-usage',
+    async collectRaw(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }> {
+      const d = new Date(opts.periodStart * 1000)
+      const url = `${GITHUB_API}/users/${user}/settings/billing/usage?year=${d.getUTCFullYear()}&month=${d.getUTCMonth() + 1}`
+      // secret used ONLY as the auth header; never logged.
+      const headers = {
+        'authorization': `Bearer ${opts.secret}`,
+        'accept': 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+      }
+      const raw = await opts.httpGetJson(url, headers)
+      const lines = mapGitHubUsage(raw, {
+        periodStart: opts.periodStart, periodEnd: opts.periodEnd,
+        fxUsdHuf: opts.fxUsdHuf, idSalt: opts.idSalt, now: opts.periodStart,
+      })
+      return { raw, lines }
+    },
+    async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+      return (await this.collectRaw!(opts)).lines
+    },
+  }
+}
+
+export const githubCollector: ProviderCollector = makeGitHubCollector()
+
+/** Vault secret id for the GitHub fine-grained PAT (Plan: read-only). */
+export const GITHUB_VAULT_SECRET_ID = 'github_plan'
+
+/**
+ * LIVE read-only sync: pulls the PAT from the Vault (never logged), reads the
+ * billing usage report for the current month, and records a provider_api line +
+ * import_runs row. No provider-side write.
+ */
+export async function syncGitHubCollector(
+  db: import('better-sqlite3').Database,
+  now: number,
+  deps: { httpGetJson?: import('./types.js').HttpGetJson; apiKey?: string | null; fxUsdHuf?: number } = {},
+): Promise<{ ok: boolean; provider: string; status: string; imported_count: number; error?: string; period?: string }> {
+  const { runCollector } = await import('./runner.js')
+  const { monthWindow } = await import('../ledger.js')
+  let apiKey = deps.apiKey
+  if (apiKey === undefined) {
+    try {
+      const { getSecret } = await import('../../web/vault.js')
+      apiKey = getSecret(GITHUB_VAULT_SECRET_ID)
+    } catch { apiKey = null }
+  }
+  if (!apiKey) {
+    return { ok: false, provider: 'github', status: 'error', imported_count: 0, error: `no GitHub token in vault (${GITHUB_VAULT_SECRET_ID})` }
+  }
+  let fxUsdHuf = deps.fxUsdHuf
+  if (fxUsdHuf === undefined) {
+    try {
+      const { loadRenderPricing } = await import('./render.js')
+      fxUsdHuf = loadRenderPricing().pricing.fx_usd_huf || 0
+    } catch { fxUsdHuf = 0 }
+  }
+  const httpGetJson = deps.httpGetJson || (async (url: string, headers: Record<string, string>) => {
+    const r = await fetch(url, { method: 'GET', headers })
+    if (!r.ok) throw new Error(`github api ${r.status}`)
+    return r.json()
+  })
+  const w = monthWindow(now)
+  const opts = { periodStart: w.start, periodEnd: w.end, secret: apiKey, fxUsdHuf: fxUsdHuf || 0, idSalt: 'github-salt', httpGetJson }
+  const res = await runCollector({ db, collector: githubCollector, opts, now })
+  return {
+    ok: res.status === 'ok', provider: 'github', status: res.status,
+    imported_count: res.importedCount, error: res.errorMessageSanitized || undefined, period: w.key,
+  }
+}

--- a/src/costops/collectors/openai.ts
+++ b/src/costops/collectors/openai.ts
@@ -1,0 +1,143 @@
+// CostOps -- OpenAI cost collector (LIVE, read-only).
+//
+// Uses the OpenAI Costs API (GET /v1/organizations/costs) which returns daily
+// USD cost buckets and REQUIRES an admin key. The mapper is a PURE function
+// tested offline against a fixture; collect() calls the INJECTED httpGetJson so
+// no network happens unless a real fetcher is passed. The admin key arrives via
+// opts.secret (from the Vault) and is NEVER logged or persisted. No provider-
+// side write ever happens (pure GET).
+
+import { createHash } from 'node:crypto'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine } from './types.js'
+
+const OPENAI_COSTS_URL = 'https://api.openai.com/v1/organizations/costs'
+// All OpenAI API usage reconciles against this source id (matches the manual
+// 'openai-api' / 'openai-chatgpt' line family so estimate and actual share it).
+const OPENAI_API_SOURCE = 'openai-api'
+
+function hashRef(salt: string, raw: string): string {
+  return createHash('sha256').update(salt).update('|').update(raw).digest('hex').slice(0, 32)
+}
+
+interface OpenAiAmount { value?: number | string; currency?: string }
+interface OpenAiCostResult { amount?: OpenAiAmount; line_item?: string | null; project_id?: string | null }
+interface OpenAiCostBucket { start_time?: number; end_time?: number; results?: OpenAiCostResult[] }
+interface OpenAiCostsPage { object?: string; data?: OpenAiCostBucket[]; has_more?: boolean; next_page?: string | null }
+
+/**
+ * PURE mapper: OpenAI /organizations/costs page -> a single aggregated
+ * provider_api line for the openai-api source for the requested period. Daily
+ * USD amounts are summed and converted to HUF via fxUsdHuf. Deterministic; no
+ * I/O. Returns [] if the page carries no cost results (so an all-zero month can
+ * still be reported by the caller as an explicit 0-with-freshness line).
+ */
+export function mapOpenAiCosts(
+  raw: unknown,
+  opts: { periodStart: number; periodEnd: number; fxUsdHuf: number; idSalt: string; now: number },
+): NormalizedCostLine[] {
+  const page = (raw && typeof raw === 'object') ? raw as OpenAiCostsPage : {}
+  const buckets = Array.isArray(page.data) ? page.data : []
+  let usdTotal = 0
+  let latestEnd = 0
+  let any = false
+  for (const b of buckets) {
+    if (typeof b.end_time === 'number' && b.end_time > latestEnd) latestEnd = b.end_time
+    for (const r of (Array.isArray(b.results) ? b.results : [])) {
+      const rawAmt = r.amount?.value
+      const amt = typeof rawAmt === 'number' ? rawAmt : parseFloat(String(rawAmt ?? ''))
+      if (!isFinite(amt)) continue
+      // OpenAI costs are USD. Non-USD is not expected; if seen, still sum the
+      // numeric value and let the live-verify step flag the currency mismatch.
+      usdTotal += amt
+      any = true
+    }
+  }
+  if (!any) return []
+  const monthKey = new Date(opts.periodStart * 1000).toISOString().slice(0, 7)
+  const amountHuf = Math.round(usdTotal * opts.fxUsdHuf * 100) / 100
+  return [{
+    provider: 'openai',
+    service: OPENAI_API_SOURCE,
+    billing_period_start: opts.periodStart,
+    billing_period_end: opts.periodEnd,
+    amount: amountHuf,
+    currency: 'HUF',
+    confidence: 'provider_api',
+    usage_type: 'api_usage',
+    quantity: null,
+    unit: null,
+    data_freshness_at: latestEnd || opts.now,
+    raw_ref_hash: hashRef(opts.idSalt, `openai-costs|${monthKey}`),
+    dedup_key: `provider|openai|${OPENAI_API_SOURCE}|${monthKey}|provider_api`,
+  }]
+}
+
+export const openaiCollector: ProviderCollector = {
+  provider: 'openai',
+  collectorName: 'openai-costs',
+  async collectRaw(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }> {
+    // OpenAI Costs API takes unix start_time; daily buckets; limit covers a month.
+    const url = `${OPENAI_COSTS_URL}?start_time=${opts.periodStart}&end_time=${opts.periodEnd}&bucket_width=1d&limit=31`
+    // secret used ONLY as the auth header; never logged.
+    const headers = {
+      'authorization': `Bearer ${opts.secret}`,
+      'content-type': 'application/json',
+    }
+    const raw = await opts.httpGetJson(url, headers)
+    const lines = mapOpenAiCosts(raw, {
+      periodStart: opts.periodStart, periodEnd: opts.periodEnd,
+      fxUsdHuf: opts.fxUsdHuf, idSalt: opts.idSalt, now: opts.periodStart,
+    })
+    return { raw, lines }
+  },
+  async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+    return (await this.collectRaw!(opts)).lines
+  },
+}
+
+/** Vault secret id for the OpenAI admin (read-only) key. */
+export const OPENAI_VAULT_SECRET_ID = 'open_api_adminkey_readonly'
+
+/**
+ * LIVE read-only sync: pulls the admin key from the Vault (never logged), calls
+ * the Costs API for the current month, and records a provider_api line + an
+ * import_runs row. No provider-side write. Injected deps let tests stub both the
+ * key and the fetcher.
+ */
+export async function syncOpenAiCollector(
+  db: import('better-sqlite3').Database,
+  now: number,
+  deps: { httpGetJson?: import('./types.js').HttpGetJson; apiKey?: string | null; fxUsdHuf?: number } = {},
+): Promise<{ ok: boolean; provider: string; status: string; imported_count: number; error?: string; period?: string }> {
+  const { runCollector } = await import('./runner.js')
+  const { monthWindow } = await import('../ledger.js')
+  let apiKey = deps.apiKey
+  if (apiKey === undefined) {
+    try {
+      const { getSecret } = await import('../../web/vault.js')
+      apiKey = getSecret(OPENAI_VAULT_SECRET_ID)
+    } catch { apiKey = null }
+  }
+  if (!apiKey) {
+    return { ok: false, provider: 'openai', status: 'error', imported_count: 0, error: `no OpenAI key in vault (${OPENAI_VAULT_SECRET_ID})` }
+  }
+  let fxUsdHuf = deps.fxUsdHuf
+  if (fxUsdHuf === undefined) {
+    try {
+      const { loadRenderPricing } = await import('./render.js')
+      fxUsdHuf = loadRenderPricing().pricing.fx_usd_huf || 0
+    } catch { fxUsdHuf = 0 }
+  }
+  const httpGetJson = deps.httpGetJson || (async (url: string, headers: Record<string, string>) => {
+    const r = await fetch(url, { method: 'GET', headers })
+    if (!r.ok) throw new Error(`openai api ${r.status}`)
+    return r.json()
+  })
+  const w = monthWindow(now)
+  const opts = { periodStart: w.start, periodEnd: w.end, secret: apiKey, fxUsdHuf: fxUsdHuf || 0, idSalt: 'openai-salt', httpGetJson }
+  const res = await runCollector({ db, collector: openaiCollector, opts, now })
+  return {
+    ok: res.status === 'ok', provider: 'openai', status: res.status,
+    imported_count: res.importedCount, error: res.errorMessageSanitized || undefined, period: w.key,
+  }
+}

--- a/src/costops/collectors/render-pricing.example.json
+++ b/src/costops/collectors/render-pricing.example.json
@@ -1,0 +1,15 @@
+{
+  "_doc": "CostOps v0.3 Render plan->USD/month map EXAMPLE. Copy to store/costops-render-pricing.json (gitignored) and fill REAL Render list prices + fx_usd_huf. All zero here (safe example, no real amounts). Unknown plan -> unpriced warning, never a fabricated amount. static_site/suspended = 0. Overage/seat/tax NOT modelled (see not_covered).",
+  "version": 1,
+  "currency": "HUF",
+  "fx_usd_huf": 0,
+  "plans": {
+    "web_service": { "free": 0, "starter": 0, "standard": 0, "pro": 0, "pro_plus": 0, "pro_max": 0, "pro_ultra": 0 },
+    "private_service": { "free": 0, "starter": 0, "standard": 0, "pro": 0 },
+    "background_worker": { "free": 0, "starter": 0, "standard": 0, "pro": 0 },
+    "cron_job": { "starter": 0 },
+    "static_site": { "free": 0 },
+    "postgres": { "free": 0, "basic_256mb": 0, "basic_1gb": 0, "basic_4gb": 0, "pro_4gb": 0 },
+    "key_value": { "free": 0, "starter": 0, "standard": 0, "pro": 0 }
+  }
+}

--- a/src/costops/collectors/render.ts
+++ b/src/costops/collectors/render.ts
@@ -190,6 +190,68 @@ export function mapRenderPlanCost(
   return { lines, breakdown }
 }
 
+// v0.5: read the Render API key WITHOUT logging it. process.env first, then the
+// gitignored root .env. Returns null if absent (caller reports a config error).
+export function getRenderApiKey(): string | null {
+  const fromEnv = process.env.RENDER_API_KEY
+  if (fromEnv && fromEnv.trim()) return fromEnv.trim()
+  try {
+    const envFile = readFileSync(join(PROJECT_ROOT, '.env'), 'utf-8')
+    const line = envFile.split('\n').find(l => l.startsWith('RENDER_API_KEY'))
+    if (line) return line.slice(line.indexOf('=') + 1).trim().replace(/^["']|["']$/g, '')
+  } catch { /* no .env */ }
+  return null
+}
+
+export interface RenderSyncResult {
+  ok: boolean
+  provider: 'render'
+  status: string
+  imported_count: number
+  error?: string
+  service_count?: number
+  total_huf?: number
+  period?: string
+}
+
+/**
+ * v0.5 sync spine: run the Render collector LIVE (read-only GET) and idempotently
+ * import the aggregated provider_plan_estimate line for the current month, storing
+ * a sanitized breakdown on the import_runs row. NO provider-side write. Injected
+ * httpGetJson defaults to a real GET fetcher; tests pass a stub.
+ */
+export async function syncRenderCollector(
+  db: import('better-sqlite3').Database,
+  now: number,
+  deps: { httpGetJson?: import('./types.js').HttpGetJson; apiKey?: string | null } = {},
+): Promise<RenderSyncResult> {
+  const { runCollector } = await import('./runner.js')
+  const { monthWindow } = await import('../ledger.js')
+  const { pricing } = loadRenderPricing()
+  const apiKey = deps.apiKey !== undefined ? deps.apiKey : getRenderApiKey()
+  if (!apiKey) return { ok: false, provider: 'render', status: 'error', imported_count: 0, error: 'no RENDER_API_KEY configured' }
+  const httpGetJson = deps.httpGetJson || (async (url: string, headers: Record<string, string>) => {
+    const r = await fetch(url, { method: 'GET', headers })
+    if (!r.ok) throw new Error(`render api ${r.status}`)
+    return r.json()
+  })
+  const w = monthWindow(now)
+  const collector = makeRenderCollector(pricing)
+  const opts = { periodStart: w.start, periodEnd: w.end, secret: apiKey, fxUsdHuf: pricing.fx_usd_huf, idSalt: 'render-salt', httpGetJson }
+  // pre-compute the sanitized breakdown for the run detail (no raw IDs)
+  let detail: RenderBreakdown | null = null
+  try {
+    const { raw } = await collector.collectRaw!(opts)
+    detail = mapRenderPlanCost(raw, { periodStart: w.start, periodEnd: w.end, pricing, idSalt: 'render-salt', now }).breakdown
+  } catch { /* runCollector will re-run + record the sanitized error */ }
+  const res = await runCollector({ db, collector, opts, now, detailJson: detail ? JSON.stringify(detail) : undefined })
+  return {
+    ok: res.status === 'ok', provider: 'render', status: res.status, imported_count: res.importedCount,
+    error: res.errorMessageSanitized || undefined,
+    service_count: detail?.service_count, total_huf: detail?.total_huf, period: w.key,
+  }
+}
+
 /** Build the Render collector bound to a loaded pricing config. READ-ONLY. */
 export function makeRenderCollector(pricing: RenderPricing): ProviderCollector {
   return {

--- a/src/costops/collectors/render.ts
+++ b/src/costops/collectors/render.ts
@@ -1,0 +1,215 @@
+// CostOps v0.3 -- Render plan-based infra cost collector.
+//
+// READ-ONLY. Enumerates Render services (+ postgres) and maps their PLAN to a
+// monthly HUF estimate from a local, configurable plan->price map. This is a
+// `provider_plan_estimate` (advisory) -- NOT an invoice, NOT provider_api actual.
+// It never modifies any Render resource. Raw service/account IDs are NEVER stored
+// or returned: only a hashed ref + a sanitized type/plan label. The API key is
+// used only as an auth header (in the live fetcher) and is never logged/persisted.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+import { PROJECT_ROOT } from '../../config.js'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine } from './types.js'
+
+export const RENDER_PRICING_PATH = join(PROJECT_ROOT, 'store', 'costops-render-pricing.json')
+export const RENDER_PRICING_EXAMPLE = join(PROJECT_ROOT, 'src', 'costops', 'collectors', 'render-pricing.example.json')
+
+const RENDER_SERVICES_URL = 'https://api.render.com/v1/services?limit=100'
+const RENDER_POSTGRES_URL = 'https://api.render.com/v1/postgres?limit=100'
+
+export interface RenderPricing {
+  version: number
+  currency: string
+  fx_usd_huf: number
+  plans: Record<string, Record<string, number>>  // type -> plan -> USD/month
+}
+
+function hashRef(salt: string, raw: string): string {
+  return createHash('sha256').update(salt).update('|').update(raw).digest('hex').slice(0, 32)
+}
+
+/** Load the local (gitignored) Render plan->price map. Missing -> zero-rate, flagged. */
+export function loadRenderPricing(): { pricing: RenderPricing; exists: boolean } {
+  const empty: RenderPricing = { version: 1, currency: 'HUF', fx_usd_huf: 0, plans: {} }
+  if (!existsSync(RENDER_PRICING_PATH)) {
+    // write a safe zero-rate example next to the config for guidance (once)
+    try {
+      if (!existsSync(RENDER_PRICING_EXAMPLE)) {
+        writeFileSync(RENDER_PRICING_EXAMPLE, JSON.stringify(EXAMPLE_PRICING, null, 2) + '\n')
+      }
+    } catch { /* best effort */ }
+    return { pricing: empty, exists: false }
+  }
+  try {
+    const raw = JSON.parse(readFileSync(RENDER_PRICING_PATH, 'utf-8')) as Partial<RenderPricing>
+    return {
+      pricing: {
+        version: typeof raw.version === 'number' ? raw.version : 1,
+        currency: typeof raw.currency === 'string' ? raw.currency : 'HUF',
+        fx_usd_huf: typeof raw.fx_usd_huf === 'number' ? raw.fx_usd_huf : 0,
+        plans: (raw.plans && typeof raw.plans === 'object') ? raw.plans as RenderPricing['plans'] : {},
+      },
+      exists: true,
+    }
+  } catch {
+    return { pricing: empty, exists: true }
+  }
+}
+
+const EXAMPLE_PRICING = {
+  _doc: 'CostOps v0.3 Render plan->USD/month map. Copy to store/costops-render-pricing.json (gitignored) and fill REAL Render list prices + fx_usd_huf. All zero here (safe example). Unknown plan -> unpriced warning, never a fabricated amount. static_site/suspended = 0. Overage/seat/tax NOT modelled (see not_covered).',
+  version: 1,
+  currency: 'HUF',
+  fx_usd_huf: 0,
+  plans: {
+    web_service: { free: 0, starter: 0, standard: 0, pro: 0, pro_plus: 0, pro_max: 0, pro_ultra: 0 },
+    private_service: { starter: 0, standard: 0, pro: 0 },
+    background_worker: { starter: 0, standard: 0, pro: 0 },
+    cron_job: { starter: 0 },
+    static_site: { free: 0 },
+    postgres: { free: 0, basic_256mb: 0, basic_1gb: 0, basic_4gb: 0, pro: 0 },
+    key_value: { starter: 0, standard: 0, pro: 0 },
+  },
+}
+
+// ---- normalized shapes seen from the Render API (READ) ----------------------
+interface RenderServiceDetails { plan?: string; numInstances?: number; env?: string; region?: string }
+interface RenderService { id?: string; name?: string; type?: string; suspended?: string; serviceDetails?: RenderServiceDetails }
+interface RenderPostgres { id?: string; name?: string; plan?: string; suspended?: string; status?: string }
+
+export interface RenderBreakdown {
+  service_count: number
+  by_type_plan: Record<string, { count: number; usd: number }>   // "web_service/starter" -> {...}
+  unpriced: Array<{ type: string; plan: string; count: number }>
+  undercount_flags: string[]
+  suspended_count: number
+  total_usd: number
+  total_huf: number
+  fx_usd_huf: number
+}
+
+const RENDER_SOURCE = 'render-plan'
+
+/**
+ * PURE mapper: {services, postgres} raw -> ONE aggregated provider_plan_estimate
+ * line for the render-plan source + a breakdown. Deterministic, no I/O, no secret.
+ * static_site/suspended -> 0. Unknown plan -> unpriced (0 + flag), never fabricated.
+ */
+export function mapRenderPlanCost(
+  raw: unknown,
+  opts: { periodStart: number; periodEnd: number; pricing: RenderPricing; idSalt: string; now: number },
+): { lines: NormalizedCostLine[]; breakdown: RenderBreakdown } {
+  const r = (raw && typeof raw === 'object') ? raw as { services?: unknown; postgres?: unknown } : {}
+  const serviceItems = Array.isArray(r.services) ? r.services : []
+  const pgItems = Array.isArray(r.postgres) ? r.postgres : []
+  const plans = opts.pricing.plans || {}
+  const fx = opts.pricing.fx_usd_huf || 0
+
+  const by_type_plan: RenderBreakdown['by_type_plan'] = {}
+  const unpricedMap = new Map<string, { type: string; plan: string; count: number }>()
+  const flags: string[] = []
+  let total_usd = 0
+  let count = 0
+  let suspended_count = 0
+  let staticCount = 0
+  let missingInstances = 0
+
+  const addUnit = (type: string, plan: string, suspended: boolean) => {
+    count++
+    if (suspended) { suspended_count++; return }  // suspended -> not billed
+    if (type === 'static_site') { staticCount++; return }  // free flat; bandwidth uncounted
+    const table = plans[type]
+    const price = table ? table[plan] : undefined
+    if (typeof price !== 'number') {
+      const key = `${type}/${plan || 'unknown'}`
+      const u = unpricedMap.get(key) || { type, plan: plan || 'unknown', count: 0 }
+      u.count++; unpricedMap.set(key, u)
+      return
+    }
+    total_usd += price
+    const key = `${type}/${plan}`
+    const b = by_type_plan[key] || { count: 0, usd: 0 }
+    b.count++; b.usd = Math.round((b.usd + price) * 100) / 100
+    by_type_plan[key] = b
+  }
+
+  for (const it of serviceItems) {
+    const svc = (it && typeof it === 'object' && 'service' in (it as object))
+      ? (it as { service: RenderService }).service
+      : (it as RenderService)
+    const type = String(svc?.type || 'unknown')
+    const plan = String(svc?.serviceDetails?.plan || (type === 'static_site' ? 'free' : ''))
+    const suspended = !!svc?.suspended && svc.suspended !== 'not_suspended'
+    let instances = svc?.serviceDetails?.numInstances
+    if (typeof instances !== 'number' || instances < 1) { instances = 1; if (type !== 'static_site' && !suspended) missingInstances++ }
+    for (let i = 0; i < instances; i++) addUnit(type, plan, suspended)
+  }
+  for (const it of pgItems) {
+    const pg = (it && typeof it === 'object' && 'postgres' in (it as object))
+      ? (it as { postgres: RenderPostgres }).postgres
+      : (it as RenderPostgres)
+    const suspended = !!pg?.suspended && pg.suspended !== 'not_suspended'
+    addUnit('postgres', String(pg?.plan || ''), suspended)
+  }
+
+  const unpriced = [...unpricedMap.values()]
+  if (staticCount > 0) flags.push(`${staticCount} static_site: bandwidth overage not counted (0 Ft)`)
+  if (missingInstances > 0) flags.push(`${missingInstances} service(s): instance count missing -> counted as 1`)
+  if (unpriced.length > 0) flags.push(`${unpriced.reduce((s, u) => s + u.count, 0)} service(s): unknown/unpriced plan -> excluded from total`)
+  if (pgItems.length === 0) flags.push('no postgres resources seen (if you have DBs, add /v1/postgres pricing)')
+  if (fx <= 0) flags.push('fx_usd_huf missing/zero -> HUF total is 0; set it in the pricing config')
+
+  const total_huf = Math.round(total_usd * fx * 100) / 100
+  const monthKey = new Date(opts.periodStart * 1000).toISOString().slice(0, 7)
+
+  const breakdown: RenderBreakdown = {
+    service_count: count, by_type_plan, unpriced, undercount_flags: flags,
+    suspended_count, total_usd: Math.round(total_usd * 100) / 100, total_huf, fx_usd_huf: fx,
+  }
+
+  // No line if there is literally nothing priced (keeps the ledger clean); the
+  // breakdown still carries flags for the report.
+  const lines: NormalizedCostLine[] = total_huf > 0 ? [{
+    provider: 'render',
+    service: RENDER_SOURCE,
+    billing_period_start: opts.periodStart,
+    billing_period_end: opts.periodEnd,
+    amount: total_huf,
+    currency: 'HUF',
+    confidence: 'provider_plan_estimate',
+    usage_type: 'plan_estimate',
+    quantity: count,
+    unit: 'service',
+    data_freshness_at: opts.now,
+    raw_ref_hash: hashRef(opts.idSalt, `render-plan|${monthKey}`),
+    dedup_key: `provider|render|${RENDER_SOURCE}|${monthKey}|provider_plan_estimate`,
+  }] : []
+
+  return { lines, breakdown }
+}
+
+/** Build the Render collector bound to a loaded pricing config. READ-ONLY. */
+export function makeRenderCollector(pricing: RenderPricing): ProviderCollector {
+  return {
+    provider: 'render',
+    collectorName: 'render-plan-report',
+    async collectRaw(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }> {
+      // secret used ONLY as the auth header; never logged.
+      const headers = { authorization: `Bearer ${opts.secret}`, accept: 'application/json' }
+      const services = await opts.httpGetJson(RENDER_SERVICES_URL, headers)
+      let postgres: unknown = []
+      try { postgres = await opts.httpGetJson(RENDER_POSTGRES_URL, headers) } catch { postgres = [] }
+      const raw = { services, postgres }
+      const { lines } = mapRenderPlanCost(raw, {
+        periodStart: opts.periodStart, periodEnd: opts.periodEnd,
+        pricing, idSalt: opts.idSalt, now: opts.periodStart,
+      })
+      return { raw, lines }
+    },
+    async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+      return (await this.collectRaw!(opts)).lines
+    },
+  }
+}

--- a/src/costops/collectors/runner.ts
+++ b/src/costops/collectors/runner.ts
@@ -7,7 +7,7 @@
 // Secrets never enter the DB, logs, or the returned result.
 
 import type Database from 'better-sqlite3'
-import type { ProviderCollector, CollectOpts, NormalizedCostLine, ImportRunResult, ImportStatus } from './types.js'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine, ImportRunResult, ImportStatus, ShapeNode, DryRunReport } from './types.js'
 
 /** Redact anything that looks like a key/token before it can reach a log/DB. */
 export function sanitizeError(err: unknown): { code: string; message: string } {
@@ -58,11 +58,103 @@ function upsertProviderLines(db: Database.Database, lines: NormalizedCostLine[],
   return tx(lines)
 }
 
+/**
+ * Describe a value's STRUCTURE only -- types, object keys, and array lengths.
+ * NEVER includes a scalar value, so no secret / account id / invoice ref / raw
+ * provider datum can leak through it. Depth-bounded to stay finite.
+ */
+export function describeShape(value: unknown, depth = 0): ShapeNode {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  if (Array.isArray(value)) {
+    return { type: 'array', length: value.length, of: value.length ? describeShape(value[0], depth + 1) : 'undefined' }
+  }
+  const t = typeof value
+  if (t === 'string') return 'string'
+  if (t === 'number') return 'number'
+  if (t === 'boolean') return 'boolean'
+  if (t === 'object') {
+    const keys: Record<string, ShapeNode> = {}
+    if (depth < 6) for (const k of Object.keys(value as Record<string, unknown>)) {
+      keys[k] = describeShape((value as Record<string, unknown>)[k], depth + 1)
+    }
+    return { type: 'object', keys }
+  }
+  return 'undefined' // functions/symbols are not represented
+}
+
 export interface RunCollectorArgs {
   db: Database.Database
   collector: ProviderCollector
   opts: CollectOpts
   now: number
+}
+
+export interface DryRunArgs {
+  db: Database.Database
+  collector: ProviderCollector
+  opts: CollectOpts
+  now: number
+  // If true (default), record an audit row in import_runs with status='dry_run'
+  // and imported_count=0 (NO cost line, NO secret, NO raw provider datum). If
+  // false, persist nothing at all.
+  recordRun?: boolean
+}
+
+/**
+ * DRY-RUN a collector: fetch + normalize exactly like a real run, but write NO
+ * provider_api cost_line_items. It returns the planned normalized lines, their
+ * dedup_keys, and a sanitized SHAPE of the provider response (types only). The
+ * only optional write is a status='dry_run' import_runs audit row (count 0).
+ * Secret-free by construction: raw responses and secrets never reach the DB,
+ * the log, or the returned report.
+ */
+export async function dryRunCollector(args: DryRunArgs): Promise<DryRunReport> {
+  const { db, collector, opts, now } = args
+  const recordRun = args.recordRun !== false
+  let status: 'dry_run' | 'error' = 'dry_run'
+  let plannedLines: NormalizedCostLine[] = []
+  let responseShape: ShapeNode | null = null
+  let errorCode: string | null = null
+  let errorMsg: string | null = null
+  let freshness: number | null = null
+  try {
+    if (collector.collectRaw) {
+      const { raw, lines } = await collector.collectRaw(opts)
+      responseShape = describeShape(raw)   // types only -- never values
+      plannedLines = lines
+    } else {
+      // No raw access on this collector -> lines only, shape unavailable.
+      plannedLines = await collector.collect(opts)
+      responseShape = null
+    }
+    freshness = plannedLines.reduce((m, l) => Math.max(m, l.data_freshness_at), 0) || now
+  } catch (err) {
+    status = 'error'
+    const s = sanitizeError(err)
+    errorCode = s.code
+    errorMsg = s.message
+  }
+  // CRITICAL: no provider_api cost_line_items are ever written in a dry-run.
+  // Optionally leave a clearly-marked audit trail (no cost, no secret, no raw).
+  if (recordRun) {
+    db.prepare(`
+      INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status,
+        period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at)
+      VALUES (@provider, @collector, @started, @finished, @status, @ps, @pe, 0, @ecode, @emsg, @fresh)
+    `).run({
+      provider: collector.provider, collector: collector.collectorName,
+      started: now, finished: now, status,
+      ps: opts.periodStart, pe: opts.periodEnd,
+      ecode: errorCode, emsg: errorMsg, fresh: freshness,
+    })
+  }
+  return {
+    provider: collector.provider, collectorName: collector.collectorName,
+    status, plannedLines, dedupKeys: plannedLines.map(l => l.dedup_key),
+    responseShape, wouldImportCount: plannedLines.length,
+    errorCode, errorMessageSanitized: errorMsg,
+  }
 }
 
 /**

--- a/src/costops/collectors/runner.ts
+++ b/src/costops/collectors/runner.ts
@@ -88,6 +88,9 @@ export interface RunCollectorArgs {
   collector: ProviderCollector
   opts: CollectOpts
   now: number
+  // v0.5: optional sanitized per-run detail JSON (breakdown) stored on import_runs.
+  // MUST be secret-free and contain no raw account/service IDs (type/plan labels only).
+  detailJson?: string
 }
 
 export interface DryRunArgs {
@@ -166,9 +169,9 @@ export async function runCollector(args: RunCollectorArgs): Promise<ImportRunRes
   const { db, collector, opts, now } = args
   const insertRun = db.prepare(`
     INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status,
-      period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at)
+      period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at, detail_json)
     VALUES (@provider, @collector, @started, @finished, @status,
-      @ps, @pe, @count, @ecode, @emsg, @fresh)
+      @ps, @pe, @count, @ecode, @emsg, @fresh, @detail)
   `)
   let status: ImportStatus = 'ok'
   let importedCount = 0
@@ -190,7 +193,7 @@ export async function runCollector(args: RunCollectorArgs): Promise<ImportRunRes
     provider: collector.provider, collector: collector.collectorName,
     started: now, finished: now, status,
     ps: opts.periodStart, pe: opts.periodEnd, count: importedCount,
-    ecode: errorCode, emsg: errorMsg, fresh: freshness,
+    ecode: errorCode, emsg: errorMsg, fresh: freshness, detail: args.detailJson ?? null,
   })
   return {
     provider: collector.provider, collectorName: collector.collectorName,

--- a/src/costops/collectors/runner.ts
+++ b/src/costops/collectors/runner.ts
@@ -1,0 +1,107 @@
+// CostOps v0.3 -- collector runner. Deterministic, no LLM.
+//
+// Loads a collector's normalized lines, upserts them into cost_line_items as
+// confidence='provider_api' (idempotent by dedup_key, NEVER overwriting the
+// manual/estimate rows -- they have a different dedup_key), and records an
+// import_runs row. On error it DELETES NOTHING and records a sanitized failure.
+// Secrets never enter the DB, logs, or the returned result.
+
+import type Database from 'better-sqlite3'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine, ImportRunResult, ImportStatus } from './types.js'
+
+/** Redact anything that looks like a key/token before it can reach a log/DB. */
+export function sanitizeError(err: unknown): { code: string; message: string } {
+  const e = err as { code?: string; name?: string; message?: string; status?: number }
+  const code = String(e?.code ?? e?.status ?? e?.name ?? 'error').slice(0, 40)
+  let msg = String(e?.message ?? 'collector error').slice(0, 300)
+  msg = msg
+    .replace(/sk-[A-Za-z0-9_-]{6,}/g, 'sk-***')
+    .replace(/(x-api-key|authorization|bearer)\s*[:=]\s*\S+/gi, '$1 ***')
+    .replace(/[A-Za-z0-9_-]{32,}/g, '***')
+  return { code, message: msg }
+}
+
+function upsertProviderLines(db: Database.Database, lines: NormalizedCostLine[], now: number): number {
+  const upsertSource = db.prepare(`
+    INSERT INTO cost_sources (id, name, provider, source_type, account_ref, currency, active, created_at, updated_at)
+    VALUES (@id, @id, @provider, 'usage', NULL, @currency, 1, @now, @now)
+    ON CONFLICT(id) DO UPDATE SET provider=excluded.provider, updated_at=excluded.updated_at
+  `)
+  const upsertLine = db.prepare(`
+    INSERT INTO cost_line_items
+      (source_id, charge_period_start, charge_period_end, charge_category, service_name,
+       usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
+       confidence, data_freshness, source_ref, dedup_key, created_at)
+    VALUES
+      (@source_id, @start, @end, 'usage', @source_id,
+       @usage_type, @quantity, @unit, @amount, NULL, @currency,
+       @confidence, @freshness, @source_ref, @dedup_key, @now)
+    ON CONFLICT(dedup_key) DO UPDATE SET
+      billed_cost=excluded.billed_cost, currency=excluded.currency,
+      confidence=excluded.confidence, data_freshness=excluded.data_freshness,
+      source_ref=excluded.source_ref, usage_type=excluded.usage_type
+  `)
+  const tx = db.transaction((ls: NormalizedCostLine[]) => {
+    let n = 0
+    for (const l of ls) {
+      upsertSource.run({ id: l.service, provider: l.provider, currency: l.currency, now })
+      upsertLine.run({
+        source_id: l.service, start: l.billing_period_start, end: l.billing_period_end,
+        usage_type: l.usage_type ?? null, quantity: l.quantity ?? null, unit: l.unit ?? null,
+        amount: l.amount, currency: l.currency, confidence: l.confidence,
+        freshness: l.data_freshness_at, source_ref: l.raw_ref_hash ?? null, dedup_key: l.dedup_key, now,
+      })
+      n++
+    }
+    return n
+  })
+  return tx(lines)
+}
+
+export interface RunCollectorArgs {
+  db: Database.Database
+  collector: ProviderCollector
+  opts: CollectOpts
+  now: number
+}
+
+/**
+ * Run a collector end to end and record an import_runs row. Never throws on a
+ * collector error -- it records a sanitized failure and imports nothing. Returns
+ * the run result (also secret-free).
+ */
+export async function runCollector(args: RunCollectorArgs): Promise<ImportRunResult> {
+  const { db, collector, opts, now } = args
+  const insertRun = db.prepare(`
+    INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status,
+      period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at)
+    VALUES (@provider, @collector, @started, @finished, @status,
+      @ps, @pe, @count, @ecode, @emsg, @fresh)
+  `)
+  let status: ImportStatus = 'ok'
+  let importedCount = 0
+  let errorCode: string | null = null
+  let errorMsg: string | null = null
+  let freshness: number | null = null
+  try {
+    const lines = await collector.collect(opts)
+    importedCount = upsertProviderLines(db, lines, now)
+    freshness = lines.reduce((m, l) => Math.max(m, l.data_freshness_at), 0) || now
+  } catch (err) {
+    status = 'error'
+    const s = sanitizeError(err)
+    errorCode = s.code
+    errorMsg = s.message
+    // IMPORTANT: delete nothing. Last good data stays.
+  }
+  insertRun.run({
+    provider: collector.provider, collector: collector.collectorName,
+    started: now, finished: now, status,
+    ps: opts.periodStart, pe: opts.periodEnd, count: importedCount,
+    ecode: errorCode, emsg: errorMsg, fresh: freshness,
+  })
+  return {
+    provider: collector.provider, collectorName: collector.collectorName,
+    status, importedCount, errorCode, errorMessageSanitized: errorMsg, dataFreshnessAt: freshness,
+  }
+}

--- a/src/costops/collectors/types.ts
+++ b/src/costops/collectors/types.ts
@@ -41,9 +41,36 @@ export interface ProviderCollector {
   collectorName: string
   // PURE network READ + normalize. Never writes to the provider. No LLM.
   collect(opts: CollectOpts): Promise<NormalizedCostLine[]>
+  // Optional: same READ, but also returns the raw response so a DRY-RUN can
+  // describe its SHAPE (types only, never values). No secret is in `raw`'s
+  // shape description. Collectors without this fall back to lines-only dry-run.
+  collectRaw?(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }>
 }
 
-export type ImportStatus = 'ok' | 'partial' | 'rate_limited' | 'error'
+// 'dry_run' marks a preview run that imported NOTHING (imported_count always 0).
+export type ImportStatus = 'ok' | 'partial' | 'rate_limited' | 'error' | 'dry_run'
+
+// A sanitized description of a value's STRUCTURE -- types, object keys, and
+// array lengths ONLY. It carries NO scalar values, so no secret, account id,
+// invoice ref, or raw provider datum can travel in it.
+export type ShapeNode =
+  | 'string' | 'number' | 'boolean' | 'null' | 'undefined'
+  | { type: 'array'; length: number; of: ShapeNode }
+  | { type: 'object'; keys: Record<string, ShapeNode> }
+
+// Result of a DRY-RUN: what a real import WOULD do, without persisting any
+// provider_api cost line. Secret-free by construction.
+export interface DryRunReport {
+  provider: string
+  collectorName: string
+  status: 'dry_run' | 'error'
+  plannedLines: NormalizedCostLine[]  // normalized lines (raw_ref_hash is a hash, no raw id)
+  dedupKeys: string[]                 // the idempotent keys a real import would upsert on
+  responseShape: ShapeNode | null     // sanitized shape of the provider response (null if unavailable)
+  wouldImportCount: number            // how many provider_api lines a real import WOULD write
+  errorCode: string | null
+  errorMessageSanitized: string | null
+}
 
 export interface ImportRunResult {
   provider: string

--- a/src/costops/collectors/types.ts
+++ b/src/costops/collectors/types.ts
@@ -5,7 +5,7 @@
 // call happens unless a real fetcher is passed in by an explicitly-approved run.
 // Secrets are passed in by the runner (from the Vault) and are NEVER logged.
 
-export type CostConfidenceApi = 'provider_api' | 'billing_export'
+export type CostConfidenceApi = 'provider_api' | 'billing_export' | 'provider_plan_estimate'
 
 export interface NormalizedCostLine {
   provider: string

--- a/src/costops/collectors/types.ts
+++ b/src/costops/collectors/types.ts
@@ -1,0 +1,56 @@
+// CostOps v0.3 -- provider cost collector framework (types).
+//
+// Provider-agnostic, deterministic, NO LLM. The HTTP fetcher is INJECTED so
+// collectors are unit-tested fully offline with fixtures -- no live provider
+// call happens unless a real fetcher is passed in by an explicitly-approved run.
+// Secrets are passed in by the runner (from the Vault) and are NEVER logged.
+
+export type CostConfidenceApi = 'provider_api' | 'billing_export'
+
+export interface NormalizedCostLine {
+  provider: string
+  service: string                 // maps to a cost_sources.id (e.g. 'anthropic-api')
+  billing_period_start: number    // epoch sec
+  billing_period_end: number      // epoch sec
+  amount: number                  // in `currency`
+  currency: string
+  confidence: CostConfidenceApi
+  usage_type?: string | null
+  quantity?: number | null
+  unit?: string | null
+  data_freshness_at: number       // provider "as of" time (epoch sec)
+  raw_ref_hash?: string | null    // sha256(salt, raw id) -- NEVER a raw account/invoice id
+  dedup_key: string               // idempotent upsert key
+}
+
+// Injected HTTP GET returning parsed JSON. Tests pass a stub that returns a
+// fixture; a live run would pass a real implementation (only after approval).
+export type HttpGetJson = (url: string, headers: Record<string, string>) => Promise<unknown>
+
+export interface CollectOpts {
+  periodStart: number
+  periodEnd: number
+  secret: string                  // from Vault; NEVER logged/persisted
+  fxUsdHuf: number
+  idSalt: string                  // for raw_ref_hash
+  httpGetJson: HttpGetJson        // injected -- offline in tests
+}
+
+export interface ProviderCollector {
+  provider: string
+  collectorName: string
+  // PURE network READ + normalize. Never writes to the provider. No LLM.
+  collect(opts: CollectOpts): Promise<NormalizedCostLine[]>
+}
+
+export type ImportStatus = 'ok' | 'partial' | 'rate_limited' | 'error'
+
+export interface ImportRunResult {
+  provider: string
+  collectorName: string
+  status: ImportStatus
+  importedCount: number
+  errorCode: string | null
+  errorMessageSanitized: string | null
+  dataFreshnessAt: number | null
+}

--- a/src/costops/config.ts
+++ b/src/costops/config.ts
@@ -20,6 +20,7 @@ export type CostConfidence =
   | 'actual_invoice'
   | 'provider_api'
   | 'billing_export'
+  | 'provider_plan_estimate'  // v0.3: derived from provider plan inventory (Render), NOT an invoice; advisory
   | 'local_usage'
   | 'estimate'
   | 'manual'

--- a/src/costops/correction.ts
+++ b/src/costops/correction.ts
@@ -1,0 +1,148 @@
+// CostOps Phase 1 (GAP-05/GAP-06/GAP-14) -- correction relationship for
+// cost_line_items, extending Phase 0's void/archive pattern.
+//
+// A void alone answers "this row is gone from the active ledger." A
+// correction answers the stronger question the gap-analysis calls out:
+// "what REPLACED it, and can I trace back from the new number to the old
+// one." createCorrection() voids the original row (same auditable mechanism
+// as manual-entry.ts's deleteManualCost) AND inserts a new row carrying
+// corrects_line_id -> the original's id, so the relationship survives in
+// the schema itself, not just by matching source_id/month/timing.
+//
+// Unlike Phase 0's void (manual entries only), a correction can apply to ANY
+// active line -- a provider_api or invoice-derived amount can be wrong too
+// (GAP-14 explicitly covers correcting invoice/provider amounts, not just
+// manual ones). The guard is narrower instead: a line can only be corrected
+// ONCE (correct the newer replacement if it's still wrong, not the original
+// a second time) -- keeps the correction chain linear and traceable.
+
+import type Database from 'better-sqlite3'
+
+export interface CreateCorrectionInput {
+  originalLineId: number
+  newAmount: number
+  reason: string
+}
+
+export interface CorrectionResult {
+  ok: boolean
+  error?: string
+  status?: number
+  newLineId?: number
+}
+
+interface OriginalRow {
+  id: number
+  source_id: string
+  charge_period_start: number
+  charge_period_end: number
+  charge_category: string
+  service_name: string | null
+  usage_type: string | null
+  consumed_quantity: number | null
+  consumed_unit: string | null
+  currency: string
+  confidence: string
+  source_ref: string | null
+  dedup_key: string | null
+  actual_source: string | null
+  original_amount: number | null
+  original_currency: string | null
+  fx_rate: number | null
+  fx_date: number | null
+  voided_at: number | null
+}
+
+export function createCorrection(
+  db: Database.Database,
+  input: CreateCorrectionInput,
+  opts: { now: number },
+): CorrectionResult {
+  if (!input || !Number.isFinite(input.originalLineId) || input.originalLineId <= 0) {
+    return { ok: false, error: 'missing or invalid originalLineId', status: 400 }
+  }
+  if (!Number.isFinite(input.newAmount) || input.newAmount < 0) {
+    return { ok: false, error: 'newAmount must be a non-negative number', status: 400 }
+  }
+  if (!input.reason || !input.reason.trim()) {
+    return { ok: false, error: 'reason is required for a correction (auditability)', status: 400 }
+  }
+
+  const original = db.prepare(`SELECT * FROM cost_line_items WHERE id = ?`).get(input.originalLineId) as OriginalRow | undefined
+  if (!original) return { ok: false, error: `no cost_line_items row with id ${input.originalLineId}`, status: 404 }
+  if (original.voided_at != null) return { ok: false, error: `line ${input.originalLineId} is already voided/corrected`, status: 409 }
+
+  const alreadyCorrected = db.prepare(`SELECT 1 FROM cost_line_items WHERE corrects_line_id = ?`).get(input.originalLineId)
+  if (alreadyCorrected) return { ok: false, error: `line ${input.originalLineId} already has a correction -- correct the newer replacement instead, not the original again`, status: 409 }
+
+  const newDedupKey = `correction|${input.originalLineId}|${opts.now}`
+
+  const tx = db.transaction(() => {
+    db.prepare(`
+      UPDATE cost_line_items SET voided_at = @now, void_reason = @reason, dedup_key = @voidedDedupKey
+      WHERE id = @id
+    `).run({
+      now: opts.now, reason: `superseded by correction: ${input.reason}`,
+      voidedDedupKey: original.dedup_key ? `${original.dedup_key}|corrected|${opts.now}` : `corrected|${input.originalLineId}|${opts.now}`,
+      id: input.originalLineId,
+    })
+    const info = db.prepare(`
+      INSERT INTO cost_line_items
+        (source_id, charge_period_start, charge_period_end, charge_category, service_name,
+         usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
+         confidence, data_freshness, source_ref, dedup_key, created_at, actual_source,
+         original_amount, original_currency, fx_rate, fx_date, corrects_line_id)
+      VALUES
+        (@source_id, @start, @end, @charge_category, @service_name,
+         @usage_type, @consumed_quantity, @consumed_unit, @billed_cost, NULL, @currency,
+         @confidence, @now, @source_ref, @dedup_key, @now, @actual_source,
+         @original_amount, @original_currency, @fx_rate, @fx_date, @corrects_line_id)
+    `).run({
+      source_id: original.source_id, start: original.charge_period_start, end: original.charge_period_end,
+      charge_category: original.charge_category, service_name: original.service_name,
+      usage_type: original.usage_type, consumed_quantity: original.consumed_quantity, consumed_unit: original.consumed_unit,
+      billed_cost: input.newAmount, currency: original.currency, confidence: original.confidence,
+      now: opts.now, source_ref: original.source_ref, dedup_key: newDedupKey, actual_source: original.actual_source,
+      original_amount: original.original_amount, original_currency: original.original_currency,
+      fx_rate: original.fx_rate, fx_date: original.fx_date, corrects_line_id: input.originalLineId,
+    })
+    return info.lastInsertRowid as number
+  })
+
+  const newLineId = tx()
+  return { ok: true, newLineId }
+}
+
+export interface CorrectionChainEntry {
+  id: number
+  billed_cost: number
+  voided_at: number | null
+  void_reason: string | null
+  created_at: number
+}
+
+/**
+ * Walk the full correction chain for a line, oldest first -- the original
+ * (possibly voided-by-correction) plus every correction that followed,
+ * however many links deep. Read-only, used for audit/drill-down.
+ */
+export function getCorrectionChain(db: Database.Database, lineId: number): CorrectionChainEntry[] {
+  const chain: CorrectionChainEntry[] = []
+  // Walk BACKWARD to find the true root first (a caller might pass a
+  // mid-chain id), then forward to collect every link.
+  let rootId = lineId
+  for (;;) {
+    const row = db.prepare(`SELECT corrects_line_id FROM cost_line_items WHERE id = ?`).get(rootId) as { corrects_line_id: number | null } | undefined
+    if (!row?.corrects_line_id) break
+    rootId = row.corrects_line_id
+  }
+  let currentId: number | null = rootId
+  while (currentId != null) {
+    const row = db.prepare(`SELECT id, billed_cost, voided_at, void_reason, created_at FROM cost_line_items WHERE id = ?`).get(currentId) as CorrectionChainEntry | undefined
+    if (!row) break
+    chain.push(row)
+    const next = db.prepare(`SELECT id FROM cost_line_items WHERE corrects_line_id = ?`).get(currentId) as { id: number } | undefined
+    currentId = next?.id ?? null
+  }
+  return chain
+}

--- a/src/costops/email-ingest.ts
+++ b/src/costops/email-ingest.ts
@@ -1,0 +1,99 @@
+// CostOps -- email-sourced cost ingest.
+//
+// Invoices/receipts that land in the operator's mailbox are the most authoritative
+// cost signal (an actual charged amount). An agent-side sweep reads Gmail (which
+// is not reachable from this backend), extracts a structured entry per receipt,
+// and POSTs them here. This module is the PURE, deterministic ingest: it upserts
+// one cost_line_item per (email, month) with an idempotent dedup key, so a sweep
+// can safely re-run and re-ingest the same month without duplicating. NO raw email
+// body, subject, sender address or PII is ever stored -- only the extracted amount,
+// provider/source labels, the billing month, and a HASH of the message ref.
+
+import { createHash } from 'node:crypto'
+import type Database from 'better-sqlite3'
+
+export interface EmailCostEntry {
+  source_id: string          // stable id, e.g. 'anthropic-max' or 'aws'
+  name: string               // human label, e.g. 'Claude Max'
+  provider: string           // e.g. 'anthropic'
+  amount: number             // in `currency`
+  currency: string           // 'HUF' | 'USD' | ...
+  month: string              // 'YYYY-MM' billing month
+  message_ref: string        // opaque per-email ref (Gmail message id); hashed here
+  confidence?: string        // default 'actual_invoice'
+  source_type?: string       // default 'subscription'
+}
+
+export interface IngestResult {
+  ingested: number
+  skipped: number
+  errors: Array<{ source_id: string; reason: string }>
+}
+
+function monthWindow(month: string): { start: number; end: number } | null {
+  if (!/^\d{4}-\d{2}$/.test(month)) return null
+  const y = parseInt(month.slice(0, 4)), m = parseInt(month.slice(5, 7)) - 1
+  return { start: Math.floor(Date.UTC(y, m, 1) / 1000), end: Math.floor(Date.UTC(y, m + 1, 1) / 1000) }
+}
+
+/** Convert an amount to HUF. HUF passes through; USD uses fx; unknown -> flagged. */
+export function toHuf(amount: number, currency: string, fxUsdHuf: number): number | null {
+  const cur = (currency || 'HUF').toUpperCase()
+  if (cur === 'HUF') return Math.round(amount * 100) / 100
+  if (cur === 'USD') return Math.round(amount * fxUsdHuf * 100) / 100
+  // EUR/other not converted here (needs its own fx) -- caller should pre-convert.
+  return null
+}
+
+/**
+ * Idempotently upsert email-sourced cost lines. Deterministic, no I/O beyond the
+ * passed db. Dedup key = `email|<sha256(message_ref)[:32]>|<month>`, so the same
+ * receipt for the same month is updated in place, never duplicated.
+ */
+export function ingestEmailCosts(
+  db: Database.Database,
+  entries: EmailCostEntry[],
+  opts: { fxUsdHuf: number; now: number; idSalt?: string },
+): IngestResult {
+  const salt = opts.idSalt ?? 'costops-email'
+  const upsertSource = db.prepare(`
+    INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at)
+    VALUES (@id, @name, @provider, @source_type, 'HUF', 1, @now, @now)
+    ON CONFLICT(id) DO UPDATE SET name=excluded.name, provider=excluded.provider,
+      source_type=excluded.source_type, updated_at=excluded.updated_at
+  `)
+  const upsertLine = db.prepare(`
+    INSERT INTO cost_line_items
+      (source_id, charge_period_start, charge_period_end, charge_category, service_name,
+       usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
+       confidence, data_freshness, source_ref, dedup_key, created_at)
+    VALUES
+      (@source_id, @start, @end, 'invoice', @name,
+       NULL, NULL, NULL, @amount, NULL, 'HUF',
+       @confidence, @now, @ref_hash, @dedup_key, @now)
+    ON CONFLICT(dedup_key) DO UPDATE SET
+      billed_cost=excluded.billed_cost, confidence=excluded.confidence,
+      data_freshness=excluded.data_freshness, source_ref=excluded.source_ref
+  `)
+  const out: IngestResult = { ingested: 0, skipped: 0, errors: [] }
+  const tx = db.transaction((list: EmailCostEntry[]) => {
+    for (const e of list) {
+      if (!e || typeof e.source_id !== 'string' || !e.source_id) { out.errors.push({ source_id: String(e?.source_id), reason: 'missing source_id' }); continue }
+      const win = monthWindow(e.month)
+      if (!win) { out.errors.push({ source_id: e.source_id, reason: `bad month '${e.month}'` }); continue }
+      const amountHuf = toHuf(Number(e.amount), e.currency, opts.fxUsdHuf)
+      if (amountHuf === null || !isFinite(amountHuf)) { out.errors.push({ source_id: e.source_id, reason: `uncconvertible currency '${e.currency}'` }); continue }
+      const refHash = createHash('sha256').update(salt).update('|').update(String(e.message_ref)).digest('hex').slice(0, 32)
+      const dedup = `email|${refHash}|${e.month}`
+      upsertSource.run({ id: e.source_id, name: e.name || e.source_id, provider: e.provider || 'other', source_type: e.source_type || 'subscription', now: opts.now })
+      upsertLine.run({
+        source_id: e.source_id, start: win.start, end: win.end, name: e.name || e.source_id,
+        amount: amountHuf, confidence: e.confidence || 'actual_invoice', now: opts.now,
+        ref_hash: refHash, dedup_key: dedup,
+      })
+      out.ingested++
+    }
+  })
+  tx(entries)
+  return out
+}

--- a/src/costops/forecast-capture.ts
+++ b/src/costops/forecast-capture.ts
@@ -1,0 +1,151 @@
+// CostOps Phase 1 -- forecast-snapshot capture (GAP-10 orchestration layer).
+//
+// Anvil's forecast.ts (buildfejleszto-costops-forecast) is pure computation
+// only, by design -- no DB reads. This module is the thin orchestration on
+// top: gather each active source's current-month signals from the DB, call
+// resolveSourceForecast() per source, and persist one snapshot row per source
+// (+ one whole-deployment TOTAL row) via forecast_snapshots. Wired into the
+// boot seam (startCostOpsBackgroundTasks) for the daily capture cadence.
+
+import type Database from 'better-sqlite3'
+import { monthWindow, CONF_PRIORITY, type MonthWindow } from './ledger.js'
+import { resolveSourceForecast, forecastSnapshotDedupKey, type ForecastResult, type ForecastContext } from './forecast.js'
+import type { BalanceSnapshot } from './collectors/deepseek.js'
+
+interface SourceRow {
+  id: string
+  provider: string
+}
+
+interface LineRow {
+  source_id: string
+  billed_cost: number
+  charge_category: string
+  confidence: string
+}
+
+function resolveBestLinePerSource(db: Database.Database, win: MonthWindow): Map<string, LineRow> {
+  const lines = db.prepare(`
+    SELECT source_id, billed_cost, charge_category, confidence
+    FROM cost_line_items
+    WHERE charge_period_start < @end AND charge_period_end > @start
+      AND voided_at IS NULL AND confidence NOT IN ('pending_permission', 'provider_plan_estimate')
+  `).all({ start: win.start, end: win.end }) as LineRow[]
+  const bySource = new Map<string, LineRow[]>()
+  for (const l of lines) {
+    const arr = bySource.get(l.source_id); if (arr) arr.push(l); else bySource.set(l.source_id, [l])
+  }
+  const resolved = new Map<string, LineRow>()
+  for (const [sid, ls] of bySource) {
+    resolved.set(sid, ls.reduce((a, b) => (CONF_PRIORITY[b.confidence] || 0) > (CONF_PRIORITY[a.confidence] || 0) ? b : a))
+  }
+  return resolved
+}
+
+function balanceSnapshotsForProvider(db: Database.Database, provider: string): BalanceSnapshot[] {
+  return db.prepare(`
+    SELECT balance, captured_at FROM provider_balance_snapshots
+    WHERE provider = ? ORDER BY captured_at ASC
+  `).all(provider) as BalanceSnapshot[]
+}
+
+interface StoredForecast {
+  source_id: string | null
+  result: ForecastResult
+}
+
+function insertSnapshot(db: Database.Database, opts: { sourceId: string | null; month: string; now: number; result: ForecastResult }): void {
+  const dedup = forecastSnapshotDedupKey(opts.sourceId, opts.month, opts.now)
+  db.prepare(`
+    INSERT OR IGNORE INTO forecast_snapshots
+      (source_id, month, snapshot_at, method, forecast_amount, confidence, note, dedup_key, created_at)
+    VALUES (@source_id, @month, @now, @method, @amount, @confidence, @note, @dedup, @now)
+  `).run({
+    source_id: opts.sourceId, month: opts.month, now: opts.now,
+    method: opts.result.method, amount: opts.result.amount, confidence: opts.result.confidence,
+    note: opts.result.note, dedup: dedup,
+  })
+}
+
+/**
+ * Capture one forecast snapshot per active source for the current month,
+ * plus one whole-deployment TOTAL snapshot (source_id null, per
+ * forecast.ts's documented convention). Idempotent per calendar day (dedup_key
+ * includes the day) -- a second capture the same day is a no-op, matching
+ * "every historical forecast stays reproducible, never silently rewritten."
+ *
+ * Signal availability today: cadence/last_invoice_amount/manual_override are
+ * not yet threaded from costops-subscriptions.json, so resolveSourceForecast
+ * falls through to its usage/fixed-subscription defaults for those sources --
+ * honest given the data actually on hand, not a fabricated cadence guess.
+ * Wiring subscriptions-derived cadence is a natural Phase 1 follow-up, not
+ * done here to keep this capture pass additive and independently testable.
+ */
+export function captureForecastSnapshots(db: Database.Database, now: number): StoredForecast[] {
+  const win = monthWindow(now)
+  const sources = db.prepare(`SELECT id, provider FROM cost_sources WHERE active = 1`).all() as SourceRow[]
+  const bestLine = resolveBestLinePerSource(db, win)
+  const results: StoredForecast[] = []
+  let total = 0
+
+  for (const s of sources) {
+    const line = bestLine.get(s.id)
+    const mtd_amount = line?.billed_cost ?? 0
+    const ctx: ForecastContext = {
+      mtd_amount,
+      win,
+      now,
+      data_confidence: (line?.confidence as ForecastContext['data_confidence']) ?? 'manual',
+      charge_category: line?.charge_category,
+      balance_snapshots: (() => {
+        const snaps = balanceSnapshotsForProvider(db, s.provider)
+        return snaps.length > 0 ? snaps : undefined
+      })(),
+    }
+    const result = resolveSourceForecast(ctx)
+    insertSnapshot(db, { sourceId: s.id, month: win.key, now, result })
+    results.push({ source_id: s.id, result })
+    total += result.amount
+  }
+
+  const totalResult: ForecastResult = {
+    method: 'fixed_subscription',
+    amount: Math.round(total * 100) / 100,
+    confidence: results.length > 0 ? 'medium' : 'low',
+    note: `whole-deployment total -- sum of ${results.length} per-source forecasts`,
+  }
+  insertSnapshot(db, { sourceId: null, month: win.key, now, result: totalResult })
+  results.push({ source_id: null, result: totalResult })
+
+  return results
+}
+
+export interface ForecastSnapshotRow {
+  source_id: string | null
+  month: string
+  snapshot_at: number
+  method: string
+  forecast_amount: number
+  confidence: string
+  note: string | null
+  actual_amount: number | null
+  forecast_error_absolute: number | null
+  forecast_error_percent: number | null
+}
+
+/** Read back stored forecast snapshots, most recent first, optionally filtered to one month. */
+export function listForecastSnapshots(db: Database.Database, opts: { month?: string; limit?: number } = {}): ForecastSnapshotRow[] {
+  const limit = opts.limit ?? 200
+  if (opts.month) {
+    return db.prepare(`
+      SELECT source_id, month, snapshot_at, method, forecast_amount, confidence, note,
+        actual_amount, forecast_error_absolute, forecast_error_percent
+      FROM forecast_snapshots WHERE month = ? ORDER BY snapshot_at DESC LIMIT ?
+    `).all(opts.month, limit) as ForecastSnapshotRow[]
+  }
+  return db.prepare(`
+    SELECT source_id, month, snapshot_at, method, forecast_amount, confidence, note,
+      actual_amount, forecast_error_absolute, forecast_error_percent
+    FROM forecast_snapshots ORDER BY snapshot_at DESC LIMIT ?
+  `).all(limit) as ForecastSnapshotRow[]
+}

--- a/src/costops/forecast.ts
+++ b/src/costops/forecast.ts
@@ -1,0 +1,330 @@
+// CostOps -- Phase 1 forecasting (GAP-10 / core-functional-scope-v1.0.1.md §10).
+//
+// Pure, deterministic, I/O-free computation layer -- one function per forecast
+// method (fixed subscription, time-proportional usage, balance-delta, invoice
+// cadence, one-time, manual override), a dispatcher that picks a method per
+// source, and forecast-vs-actual / forecast-error scoring once a month closes.
+// NO db.ts/web.ts edits: `initForecastSchema` is a schema DEFINER only, not
+// mounted anywhere yet -- the seam-refactor's `initCostOpsSchema(db)`
+// aggregator (Mason, accounting-core seam) calls it, per
+// docs/fork-upstream-policy.md §2a's thin-seam rule.
+
+import type Database from 'better-sqlite3'
+import type { MonthWindow } from './ledger.js'
+import type { CostConfidence } from './config.js'
+import { deriveMtdSpend, type BalanceSnapshot } from './collectors/deepseek.js'
+
+// ---- shared types ------------------------------------------------------------
+
+export type ForecastMethod =
+  | 'fixed_subscription'
+  | 'time_proportional_usage'
+  | 'balance_delta'
+  | 'invoice_cadence'
+  | 'one_time'
+  | 'manual_forecast'
+
+export type ForecastConfidence = 'high' | 'medium' | 'low'
+
+export interface ForecastResult {
+  method: ForecastMethod
+  amount: number
+  confidence: ForecastConfidence
+  note: string
+}
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }
+function round4(n: number): number { return Math.round(n * 10000) / 10000 }
+
+// ---- method 1: fixed monthly subscription / hosting / SaaS -------------------
+
+/**
+ * A fixed recurring fee (subscription, hosting, SaaS, domain) is owed in full
+ * for the period whether observed on day 1 or day 30 -- NEVER prorated by
+ * elapsed time (that would understate a fee seen early in the month).
+ * Confidence reflects how the AMOUNT itself was sourced: an invoice/provider-
+ * observed amount is a known fact (high); a manual/estimate amount is a known
+ * fee but self-reported (medium) -- never low, a fixed fee is not volatile.
+ */
+export function forecastFixedSubscription(periodAmount: number, dataConfidence: CostConfidence = 'manual'): ForecastResult {
+  const confidence: ForecastConfidence =
+    dataConfidence === 'actual_invoice' || dataConfidence === 'provider_api' || dataConfidence === 'billing_export'
+      ? 'high' : 'medium'
+  return {
+    method: 'fixed_subscription',
+    amount: round2(periodAmount),
+    confidence,
+    note: 'fixed monthly fee -- full period amount, not prorated (a fixed cost is owed whether seen day 1 or day 30)',
+  }
+}
+
+// ---- method 2: time-proportional usage ----------------------------------------
+
+// Below this fraction of the month elapsed, a straight run-rate is noisy (a
+// single heavy day can double it) -- confidence buckets, not a hard cutoff.
+const EARLY_MONTH_FRACTION = 0.15
+const MID_MONTH_FRACTION = 0.5
+
+/**
+ * Variable usage costs (metered API calls, token spend): month-end forecast =
+ * MTD amount scaled by the inverse of the elapsed fraction (a straight
+ * run-rate). Confidence rises as more of the month has actually been observed.
+ */
+export function forecastTimeProportionalUsage(mtdAmount: number, win: MonthWindow): ForecastResult {
+  const projected = mtdAmount / win.fractionElapsed
+  const confidence: ForecastConfidence =
+    win.fractionElapsed < EARLY_MONTH_FRACTION ? 'low'
+    : win.fractionElapsed < MID_MONTH_FRACTION ? 'medium'
+    : 'high'
+  return {
+    method: 'time_proportional_usage',
+    amount: round2(projected),
+    confidence,
+    note: `variable usage -- run-rate from ${Math.round(win.fractionElapsed * 100)}% of the month observed`,
+  }
+}
+
+// ---- method 3: balance-delta (prepaid providers, e.g. DeepSeek) --------------
+
+// Below this observed span, a burn rate is too noisy to extrapolate from --
+// mirrors collectors/deepseek.ts's exhaustion-forecast guard, but a month-end
+// AMOUNT forecast degrades to "MTD only" instead of returning null (there is
+// always a real MTD figure to show, unlike an exhaustion date).
+const MIN_FORECAST_SPAN_SECONDS = 86400
+
+/**
+ * Prepaid-balance sources: spend is derived from balance DROPS between
+ * snapshots (reuses `deriveMtdSpend` from collectors/deepseek.ts -- one
+ * definition of "a rise is a top-up, ignore it", not reimplemented here).
+ * Month-end forecast = this month's observed spend + (daily burn rate,
+ * computed from ALL supplied snapshots for a steadier base) * remaining days.
+ */
+export function forecastBalanceDelta(snapshotsAsc: BalanceSnapshot[], win: MonthWindow, now: number): ForecastResult {
+  const monthSnapshots = snapshotsAsc.filter(s => s.captured_at >= win.start && s.captured_at < win.end)
+  const mtd = deriveMtdSpend(monthSnapshots)
+
+  if (snapshotsAsc.length < 2) {
+    return { method: 'balance_delta', amount: round2(mtd), confidence: 'low', note: 'balance-delta: fewer than 2 snapshots -- MTD spend only, no extrapolation' }
+  }
+  const first = snapshotsAsc[0]
+  const last = snapshotsAsc[snapshotsAsc.length - 1]
+  const spanSeconds = last.captured_at - first.captured_at
+  const allSpend = deriveMtdSpend(snapshotsAsc)
+  if (spanSeconds < MIN_FORECAST_SPAN_SECONDS || allSpend <= 0) {
+    return { method: 'balance_delta', amount: round2(mtd), confidence: 'low', note: 'balance-delta: insufficient span or no net spend observed -- MTD only, no extrapolation' }
+  }
+  const dailyBurn = allSpend / (spanSeconds / 86400)
+  const remainingDays = Math.max(0, (win.end - now) / 86400)
+  const projected = mtd + dailyBurn * remainingDays
+  const confidence: ForecastConfidence =
+    spanSeconds < 3 * 86400 ? 'low'
+    : spanSeconds < 10 * 86400 ? 'medium'
+    : 'high'
+  return {
+    method: 'balance_delta',
+    amount: round2(projected),
+    confidence,
+    note: `balance-delta: MTD ${round2(mtd)} + ${round2(dailyBurn)}/day burn * ${round2(remainingDays)} remaining days`,
+  }
+}
+
+// ---- method 4: invoice cadence (non-monthly billing) --------------------------
+
+export type BillingCadence = 'monthly' | 'quarterly' | 'semiannual' | 'annual'
+
+const CADENCE_MONTHS: Record<BillingCadence, number> = { monthly: 1, quarterly: 3, semiannual: 6, annual: 12 }
+
+/**
+ * A cost billed less often than monthly (annual domain renewal, quarterly
+ * SaaS plan): the forecast contribution for THIS month is an ACCRUAL --
+ * the last known invoice divided evenly across its cadence -- not "the whole
+ * annual fee lands in one month." If the current month IS the actual invoice
+ * month, the full amount is used instead (the real cash event), via
+ * `isInvoiceMonth` -- the caller knows the renewal/billing date, this
+ * function does not guess it.
+ */
+export function forecastInvoiceCadence(
+  lastInvoiceAmount: number,
+  cadence: BillingCadence,
+  opts: { isInvoiceMonth?: boolean } = {},
+): ForecastResult {
+  const months = CADENCE_MONTHS[cadence]
+  if (opts.isInvoiceMonth) {
+    return { method: 'invoice_cadence', amount: round2(lastInvoiceAmount), confidence: 'high', note: `invoice cadence (${cadence}): this month is the invoice month -- full amount` }
+  }
+  const monthlyAccrual = lastInvoiceAmount / months
+  return {
+    method: 'invoice_cadence',
+    amount: round2(monthlyAccrual),
+    confidence: months === 1 ? 'high' : 'medium',
+    note: `invoice cadence (${cadence}): ${round2(lastInvoiceAmount)} / ${months} months monthly accrual, not an invoice month`,
+  }
+}
+
+// ---- method 5: one-time cost ---------------------------------------------------
+
+/**
+ * A one-time cost is never extrapolated from a run-rate. Already occurred
+ * this month -> the forecast equals the actual (no further growth expected).
+ * Not yet occurred -> 0 unless a planned amount is explicitly known in
+ * advance (e.g. a scheduled one-off) -- never fabricated.
+ */
+export function forecastOneTime(occurredAmount: number | null, plannedAmount: number | null = null): ForecastResult {
+  if (occurredAmount != null) {
+    return { method: 'one_time', amount: round2(occurredAmount), confidence: 'high', note: 'one-time cost already occurred this month -- forecast equals the actual, no extrapolation' }
+  }
+  if (plannedAmount != null) {
+    return { method: 'one_time', amount: round2(plannedAmount), confidence: 'medium', note: 'one-time cost planned but not yet occurred -- forecast uses the known planned amount' }
+  }
+  return { method: 'one_time', amount: 0, confidence: 'low', note: 'one-time cost not yet occurred and no planned amount known -- forecast 0, never fabricated from a run-rate' }
+}
+
+// ---- method 6: manual override -------------------------------------------------
+
+/** An operator-entered forecast figure, not derived from any observed data. */
+export function forecastManual(manualEstimate: number): ForecastResult {
+  return { method: 'manual_forecast', amount: round2(manualEstimate), confidence: 'low', note: 'operator-entered manual forecast -- not derived from observed data' }
+}
+
+// ---- dispatcher: pick a method per source --------------------------------------
+
+export interface ForecastContext {
+  mtd_amount: number
+  win: MonthWindow
+  now: number
+  data_confidence?: CostConfidence
+  balance_snapshots?: BalanceSnapshot[]
+  cadence?: BillingCadence
+  is_invoice_month?: boolean
+  last_invoice_amount?: number
+  charge_category?: string   // 'usage' | 'subscription' | 'purchase' | 'tax' | 'credit' | 'adjustment'
+  occurred_amount?: number | null
+  planned_amount?: number | null
+  manual_override?: number
+}
+
+/**
+ * Resolves ONE forecast method per source from context, in a fixed precedence
+ * order (documented, not implicit):
+ *   1. `manual_override` -- an operator's explicit figure always wins.
+ *   2. `balance_snapshots` present -- prepaid-balance sources.
+ *   3. non-monthly `cadence` + a known last invoice -- accrual/invoice-cadence.
+ *   4. `charge_category === 'purchase'` -- one-time cost.
+ *   5. `charge_category === 'usage'` -- time-proportional run-rate.
+ *   6. default -- fixed monthly subscription/hosting/SaaS.
+ */
+export function resolveSourceForecast(ctx: ForecastContext): ForecastResult {
+  if (ctx.manual_override != null) return forecastManual(ctx.manual_override)
+  if (ctx.balance_snapshots && ctx.balance_snapshots.length > 0) return forecastBalanceDelta(ctx.balance_snapshots, ctx.win, ctx.now)
+  if (ctx.cadence && ctx.cadence !== 'monthly' && ctx.last_invoice_amount != null) {
+    return forecastInvoiceCadence(ctx.last_invoice_amount, ctx.cadence, { isInvoiceMonth: ctx.is_invoice_month })
+  }
+  if (ctx.charge_category === 'purchase') return forecastOneTime(ctx.occurred_amount ?? null, ctx.planned_amount ?? null)
+  if (ctx.charge_category === 'usage') return forecastTimeProportionalUsage(ctx.mtd_amount, ctx.win)
+  return forecastFixedSubscription(ctx.mtd_amount, ctx.data_confidence)
+}
+
+// ---- forecast-vs-actual / forecast error ---------------------------------------
+
+export interface ForecastErrorResult {
+  absolute_error: number        // actual - forecast; positive = under-forecast, negative = over-forecast
+  percent_error: number | null  // (actual - forecast) / actual; null when actual is 0 (undefined, never fabricated)
+}
+
+/** Forecast-vs-actual once a month's real total is known (period close). */
+export function computeForecastError(forecastAmount: number, actualAmount: number): ForecastErrorResult {
+  return {
+    absolute_error: round2(actualAmount - forecastAmount),
+    percent_error: actualAmount !== 0 ? round4((actualAmount - forecastAmount) / actualAmount) : null,
+  }
+}
+
+export interface ForecastAccuracyRecord {
+  forecast_amount: number
+  actual_amount: number
+}
+
+export interface ForecastAccuracySummary {
+  key: string
+  count: number
+  mean_absolute_error: number
+  mean_percent_error: number | null  // null only if every record's actual was 0
+}
+
+/**
+ * Groups closed forecast/actual pairs by a caller-supplied key (provider,
+ * category, source -- caller decides) and reports mean absolute + mean
+ * percent error per group. GAP-10 acceptance: "provider- es kategoriaszintu
+ * pontossag merheto." Pure aggregation, no DB access -- the aggregator
+ * (Mason's seam) supplies already-closed rows from forecast_snapshots.
+ */
+export function summarizeForecastAccuracy<T extends ForecastAccuracyRecord>(records: T[], keyOf: (r: T) => string): ForecastAccuracySummary[] {
+  const groups = new Map<string, T[]>()
+  for (const r of records) {
+    const k = keyOf(r)
+    const arr = groups.get(k)
+    if (arr) arr.push(r); else groups.set(k, [r])
+  }
+  const out: ForecastAccuracySummary[] = []
+  for (const [key, rs] of groups) {
+    const errors = rs.map(r => computeForecastError(r.forecast_amount, r.actual_amount))
+    const mean_absolute_error = round2(errors.reduce((s, e) => s + Math.abs(e.absolute_error), 0) / errors.length)
+    const pcts = errors.map(e => e.percent_error).filter((p): p is number => p !== null)
+    const mean_percent_error = pcts.length > 0 ? round4(pcts.reduce((s, p) => s + Math.abs(p), 0) / pcts.length) : null
+    out.push({ key, count: rs.length, mean_absolute_error, mean_percent_error })
+  }
+  return out.sort((a, b) => b.count - a.count)
+}
+
+// ---- snapshot dedup key (pure -- the actual INSERT is the aggregator's job) ----
+
+/**
+ * One snapshot per source (or the whole-deployment total, `sourceId: null`)
+ * per calendar day (UTC) -- history is APPENDED across days, never
+ * overwritten same-day, matching GAP-10's "naponta vagy fontos valtozaskor
+ * snapshot keszul" / "minden snapshot reprodukalhato." Pure string
+ * construction; the aggregator uses this as `forecast_snapshots.dedup_key`.
+ */
+export function forecastSnapshotDedupKey(sourceId: string | null, month: string, snapshotAt: number): string {
+  const day = new Date(snapshotAt * 1000).toISOString().slice(0, 10)
+  return `${sourceId ?? 'TOTAL'}|${month}|${day}`
+}
+
+// ---- schema (DEFINER ONLY -- not mounted; see file header) ---------------------
+
+/**
+ * Schema DEFINER only. NOT called from db.ts -- per fork-upstream-policy.md
+ * §2a, the ONE seam mount (`initCostOpsSchema(db)` in db.ts calling this
+ * among the module's other schema definers) is the seam-refactor's job, done
+ * once alongside the rest of the accounting-core schema so db.ts gains a
+ * single line, not another scattered inline CREATE TABLE. Safe to call more
+ * than once (`IF NOT EXISTS`).
+ *
+ * `source_id` NULL = a whole-deployment TOTAL snapshot, never a sentinel
+ * string. Rows are APPENDED (one per source per day via `dedup_key`), never
+ * overwritten -- every historical forecast stays reproducible.
+ * `actual_amount`/`forecast_error_*` stay NULL until period close fills them
+ * in; a forecast row is never silently rewritten to look like it always knew
+ * the actual.
+ */
+export function initForecastSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS forecast_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_id TEXT REFERENCES cost_sources(id),
+      month TEXT NOT NULL,
+      snapshot_at INTEGER NOT NULL,
+      method TEXT NOT NULL,
+      forecast_amount REAL NOT NULL,
+      confidence TEXT NOT NULL,
+      note TEXT,
+      actual_amount REAL,
+      forecast_error_absolute REAL,
+      forecast_error_percent REAL,
+      dedup_key TEXT UNIQUE,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_forecast_snapshots_month ON forecast_snapshots(month)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_forecast_snapshots_source ON forecast_snapshots(source_id, month)`)
+}

--- a/src/costops/forecast.ts
+++ b/src/costops/forecast.ts
@@ -6,8 +6,8 @@
 // source, and forecast-vs-actual / forecast-error scoring once a month closes.
 // NO db.ts/web.ts edits: `initForecastSchema` is a schema DEFINER only, not
 // mounted anywhere yet -- the seam-refactor's `initCostOpsSchema(db)`
-// aggregator (Mason, accounting-core seam) calls it, per
-// docs/fork-upstream-policy.md §2a's thin-seam rule.
+// aggregator (Mason, accounting-core seam) calls it, keeping this feature's
+// whole schema behind one mount point in db.ts.
 
 import type Database from 'better-sqlite3'
 import type { MonthWindow } from './ledger.js'
@@ -293,9 +293,9 @@ export function forecastSnapshotDedupKey(sourceId: string | null, month: string,
 // ---- schema (DEFINER ONLY -- not mounted; see file header) ---------------------
 
 /**
- * Schema DEFINER only. NOT called from db.ts -- per fork-upstream-policy.md
- * §2a, the ONE seam mount (`initCostOpsSchema(db)` in db.ts calling this
- * among the module's other schema definers) is the seam-refactor's job, done
+ * Schema DEFINER only. NOT called from db.ts: the ONE seam mount
+ * (`initCostOpsSchema(db)` in db.ts calling this among the module's other
+ * schema definers) is the seam-refactor's job, done
  * once alongside the rest of the accounting-core schema so db.ts gains a
  * single line, not another scattered inline CREATE TABLE. Safe to call more
  * than once (`IF NOT EXISTS`).

--- a/src/costops/fx.ts
+++ b/src/costops/fx.ts
@@ -1,0 +1,243 @@
+// CostOps -- Phase 1 FX provenance (GAP-09 / core-functional-scope-v1.0.1.md §9).
+//
+// Pure, deterministic, I/O-free computation layer -- every converted amount
+// carries its full provenance (original_amount/original_currency/fx_rate/
+// fx_source/fx_date/conversion_method/huf_amount), a documented rounding
+// policy, invoice-date-vs-service-date rate selection, a close-time freeze
+// guard, and late-correction handling as an independent new event (never a
+// rewrite of the original conversion). NO db.ts/web.ts/schema.ts edits:
+// `initFxSchema` is a schema DEFINER only, not mounted anywhere -- the
+// seam-refactor's `initCostOpsSchema(db)` aggregator (Mason, accounting-core
+// seam, src/costops/schema.ts) calls it, per docs/fork-upstream-policy.md §2a.
+
+import type Database from 'better-sqlite3'
+
+// ---- shared types --------------------------------------------------------------
+
+// Where a rate came from -- an audit fact, not a trust ranking (unlike
+// CostConfidence in config.ts, which ranks the LINE ITEM's authoritativeness).
+export type FxSource = 'render_pricing_config' | 'manual' | 'ecb' | 'provider_invoice' | 'other'
+
+export type ConversionMethod =
+  | 'invoice_date_rate'    // rate as of the invoice's own date (preferred whenever an invoice exists)
+  | 'service_date_rate'    // rate as of the service/usage period (fallback when there's no invoice)
+  | 'correction_date_rate' // a late correction/credit/refund, rated as of the CORRECTION event, not the original
+
+export interface FxConversion {
+  original_amount: number
+  original_currency: string
+  fx_rate: number
+  fx_source: FxSource
+  fx_date: number       // epoch seconds -- the date the RATE is for (see resolveRateDate)
+  conversion_method: ConversionMethod
+  huf_amount: number
+  converted_at: number  // epoch seconds -- when this conversion was actually computed (audit, may differ from fx_date)
+}
+
+// ---- rate resolution + rounding policy ------------------------------------------
+
+export interface FxRateTable {
+  [currency: string]: number  // HUF per 1 unit of currency
+}
+
+/**
+ * Resolves a currency to a HUF rate. HUF is ALWAYS rate 1 (identity)
+ * regardless of what the table contains -- HUF never needs an external rate.
+ * Returns null (never a fabricated 1 or 0) for a currency the table doesn't
+ * cover, so the caller can surface "unpriced" the same way the rest of
+ * CostOps never fabricates a missing amount.
+ */
+export function resolveFxRate(currency: string, rates: FxRateTable): number | null {
+  const cur = currency.toUpperCase()
+  if (cur === 'HUF') return 1
+  const r = rates[cur]
+  return typeof r === 'number' && isFinite(r) && r > 0 ? r : null
+}
+
+/**
+ * HUF rounding policy: 2 decimal places -- matches the existing ledger
+ * convention (src/costops/ledger.ts's private round2, duplicated here per
+ * this module's own file-local-helper convention, same as every other
+ * costops/*.ts file). HUF has no minor unit in circulation today, but
+ * keeping 2dp precision here avoids compounding rounding error across a
+ * chain of conversions/corrections; a DISPLAY layer rounds to whole forint
+ * for presentation, this layer never does.
+ */
+export function roundHuf(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+// ---- invoice-date vs service-date rate selection --------------------------------
+
+export type RateDateBasis = 'invoice_date' | 'service_date'
+
+/**
+ * Which date's rate to use for a conversion. An invoice fixes the actual
+ * transaction, so its own date's rate is preferred whenever an invoice date
+ * is known. `service_date` (the line's charge/usage period) is the fallback
+ * for lines with no invoice reference at all (e.g. a manual/estimate cost).
+ */
+export function resolveRateDate(invoiceDate: number | null, serviceDate: number): { date: number; basis: RateDateBasis } {
+  if (invoiceDate != null) return { date: invoiceDate, basis: 'invoice_date' }
+  return { date: serviceDate, basis: 'service_date' }
+}
+
+function methodForBasis(basis: RateDateBasis): ConversionMethod {
+  return basis === 'invoice_date' ? 'invoice_date_rate' : 'service_date_rate'
+}
+
+// ---- the conversion itself --------------------------------------------------------
+
+/**
+ * Converts an original-currency amount to HUF with FULL provenance --
+ * GAP-09's core acceptance criterion: every converted line carries
+ * original_amount/original_currency/fx_rate/fx_source/fx_date/
+ * conversion_method/huf_amount TOGETHER, never a bare converted number.
+ * Returns null (never a fabricated conversion) when the currency has no
+ * resolvable rate in `rates`.
+ */
+export function convertToHufWithProvenance(
+  amount: number,
+  currency: string,
+  rates: FxRateTable,
+  opts: { fxSource: FxSource; invoiceDate: number | null; serviceDate: number; now: number },
+): FxConversion | null {
+  const cur = currency.toUpperCase()
+  const rate = resolveFxRate(cur, rates)
+  if (rate == null) return null
+  const { date, basis } = resolveRateDate(opts.invoiceDate, opts.serviceDate)
+  return {
+    original_amount: amount,
+    original_currency: cur,
+    fx_rate: rate,
+    fx_source: opts.fxSource,
+    fx_date: date,
+    conversion_method: methodForBasis(basis),
+    huf_amount: roundHuf(amount * rate),
+    converted_at: opts.now,
+  }
+}
+
+// ---- close-time FX freeze --------------------------------------------------------
+
+export type PeriodStatus = 'open' | 'provisional' | 'closed' | 'reopened'
+
+/**
+ * GAP-09 acceptance: "closed honap nem valtozik kesobbi FX-frissites miatt."
+ * A CLOSED period's already-stored FX conversion must never be silently
+ * recomputed with a newer rate. `reopened` legitimately allows
+ * recomputation -- that's an explicit, audited action (period-close
+ * module's concern), not a silent background refresh.
+ */
+export function canRecomputeFx(status: PeriodStatus): boolean {
+  return status !== 'closed'
+}
+
+// ---- late correction handling ------------------------------------------------------
+
+export interface FxCorrectionInput {
+  originalCurrency: string
+  correctionAmountOriginalCurrency: number  // signed: negative = credit/refund reducing the original charge
+  correctionDate: number
+  correctionRate: number
+  correctionSource: FxSource
+  now: number
+}
+
+/**
+ * A correction/credit/refund arriving after the original conversion is a
+ * SEPARATE ledger event with its OWN fx rate/date -- rated as of the
+ * correction event, never a rewrite of the original conversion (GAP-09:
+ * "kesoi correction FX-kezelese"; mirrors GAP-14's void/supersede-not-
+ * overwrite principle applied to the FX dimension specifically). The
+ * original FxConversion this correction relates to is untouched by this
+ * function -- it only ever produces a new, independent one.
+ */
+export function convertCorrectionToHuf(input: FxCorrectionInput): FxConversion {
+  return {
+    original_amount: input.correctionAmountOriginalCurrency,
+    original_currency: input.originalCurrency.toUpperCase(),
+    fx_rate: input.correctionRate,
+    fx_source: input.correctionSource,
+    fx_date: input.correctionDate,
+    conversion_method: 'correction_date_rate',
+    huf_amount: roundHuf(input.correctionAmountOriginalCurrency * input.correctionRate),
+    converted_at: input.now,
+  }
+}
+
+// ---- historical rate lookup (reproducibility) --------------------------------------
+
+export interface FxRateRecord {
+  currency: string
+  rate: number
+  fx_source: FxSource
+  effective_date: number
+}
+
+/**
+ * Finds the rate in effect for `currency` at `atDate` from a set of
+ * historical rate records -- the MOST RECENT record with
+ * effective_date <= atDate wins; a future rate is never applied to a past
+ * date. Returns null (never fabricated) if no record exists at or before
+ * atDate for that currency. Pure: caller supplies already-queried rows (the
+ * aggregator reads them from the `fx_rates` table `initFxSchema` defines).
+ * This is what makes GAP-09's "ugyanaz a ledger-sor reprodukalhato
+ * HUF-erteket ad" acceptance criterion possible: re-running a conversion
+ * against the SAME historical snapshot always resolves the same rate, even
+ * after the live/current rate has since moved on.
+ */
+export function lookupHistoricalRate(records: FxRateRecord[], currency: string, atDate: number): FxRateRecord | null {
+  const cur = currency.toUpperCase()
+  const candidates = records.filter(r => r.currency.toUpperCase() === cur && r.effective_date <= atDate)
+  if (candidates.length === 0) return null
+  return candidates.reduce((a, b) => (b.effective_date > a.effective_date ? b : a))
+}
+
+/**
+ * One recorded rate per (currency, source, UTC day) -- multiple captures the
+ * same day update in place rather than accumulating noise, while still
+ * keeping day-level history for `lookupHistoricalRate`. Pure string
+ * construction; the aggregator uses this as `fx_rates.dedup_key`.
+ */
+export function fxRateDedupKey(currency: string, source: FxSource, effectiveDate: number): string {
+  const day = new Date(effectiveDate * 1000).toISOString().slice(0, 10)
+  return `${currency.toUpperCase()}|${source}|${day}`
+}
+
+// ---- schema (DEFINER ONLY -- not mounted; see file header) -----------------------------
+
+/**
+ * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts -- per
+ * fork-upstream-policy.md §2a, the ONE seam mount (`initCostOpsSchema(db)` in
+ * schema.ts calling this among the module's other schema definers) is the
+ * seam-refactor's job. Safe to call more than once (`IF NOT EXISTS` /
+ * `ADD COLUMN` wrapped in try/catch, matching schema.ts's own convention).
+ *
+ * Adds two things:
+ * 1. `fx_source` / `conversion_method` columns on `cost_line_items` --
+ *    additive to the `original_amount`/`original_currency`/`fx_rate`/
+ *    `fx_date` columns schema.ts already has (v0.7); nullable, no default,
+ *    every write site sets them explicitly.
+ * 2. `fx_rates`: an APPENDED history of every rate actually used, keyed by
+ *    (currency, source, day) via `dedup_key` -- the source of truth
+ *    `lookupHistoricalRate` reads from. Without this table, "reproducible
+ *    HUF value" would depend on the live/mutable render-pricing config
+ *    still holding today's rate tomorrow, which it will not.
+ */
+export function initFxSchema(db: Database.Database): void {
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN fx_source TEXT`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN conversion_method TEXT`) } catch { /* already exists */ }
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS fx_rates (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      currency TEXT NOT NULL,
+      rate REAL NOT NULL,
+      fx_source TEXT NOT NULL,
+      effective_date INTEGER NOT NULL,
+      captured_at INTEGER NOT NULL,
+      dedup_key TEXT UNIQUE
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_fx_rates_currency_date ON fx_rates(currency, effective_date)`)
+}

--- a/src/costops/fx.ts
+++ b/src/costops/fx.ts
@@ -8,7 +8,8 @@
 // rewrite of the original conversion). NO db.ts/web.ts/schema.ts edits:
 // `initFxSchema` is a schema DEFINER only, not mounted anywhere -- the
 // seam-refactor's `initCostOpsSchema(db)` aggregator (Mason, accounting-core
-// seam, src/costops/schema.ts) calls it, per docs/fork-upstream-policy.md §2a.
+// seam, src/costops/schema.ts) calls it, keeping every CostOps table behind
+// that single mount point.
 
 import type Database from 'better-sqlite3'
 
@@ -208,10 +209,10 @@ export function fxRateDedupKey(currency: string, source: FxSource, effectiveDate
 // ---- schema (DEFINER ONLY -- not mounted; see file header) -----------------------------
 
 /**
- * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts -- per
- * fork-upstream-policy.md §2a, the ONE seam mount (`initCostOpsSchema(db)` in
- * schema.ts calling this among the module's other schema definers) is the
- * seam-refactor's job. Safe to call more than once (`IF NOT EXISTS` /
+ * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts: the ONE
+ * seam mount (`initCostOpsSchema(db)` in schema.ts calling this among the
+ * module's other schema definers) is the seam-refactor's job. Safe to call more
+ * than once (`IF NOT EXISTS` /
  * `ADD COLUMN` wrapped in try/catch, matching schema.ts's own convention).
  *
  * Adds two things:

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -326,7 +326,7 @@ export function getCostSummary(
   const lines = db.prepare(`
     SELECT source_id, billed_cost, charge_category, confidence, data_freshness
     FROM cost_line_items
-    WHERE charge_period_start < @end AND charge_period_end > @start
+    WHERE charge_period_start < @end AND charge_period_end > @start AND voided_at IS NULL
   `).all({ start: win.start, end: win.end }) as LineRow[]
 
   let current_spend = 0
@@ -431,7 +431,7 @@ export function getCostSummary(
   const prevWin = monthWindow(win.start - 86400)
   const prevRows = db.prepare(`
     SELECT source_id, billed_cost, charge_category, confidence, data_freshness
-    FROM cost_line_items WHERE charge_period_start < @end AND charge_period_end > @start
+    FROM cost_line_items WHERE charge_period_start < @end AND charge_period_end > @start AND voided_at IS NULL
   `).all({ start: prevWin.start, end: prevWin.end }) as LineRow[]
   let previous_month: CostSummary['previous_month'] = null
   if (prevRows.length > 0) {

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -89,6 +89,7 @@ export const OPERATIONAL_TIER: Record<string, number> = {
   estimate: 1, manual: 1,
 }
 const PROVIDER_DERIVED_MIN = 3  // provider_plan_estimate or higher = "provider-derived"
+const REAL_ACTUAL_MIN = 4       // actual_invoice / provider_api / billing_export = a REAL measured cost
 
 interface OpLine { source_id: string; provider: string; billed_cost: number; charge_category: string; confidence: string; data_freshness: number }
 
@@ -116,10 +117,16 @@ export function resolveOperational(lines: OpLine[], win: MonthWindow): Operation
   for (const [sid, ls] of bySource) {
     sourceBest.set(sid, ls.reduce((a, b) => (OPERATIONAL_TIER[b.confidence] || 0) > (OPERATIONAL_TIER[a.confidence] || 0) ? b : a))
   }
-  // which providers have a provider-derived (tier>=3) source
+  // which providers have a provider-derived (tier>=3) source, and which have a REAL
+  // measured actual (tier>=4). A real invoice/api actual SUPERSEDES the whole-provider
+  // provider_plan_estimate proxy for that provider -- otherwise the plan estimate and
+  // the real invoice both count and the provider is double-counted (e.g. Render).
   const providerHasDerived = new Map<string, boolean>()
+  const providerHasRealActual = new Map<string, boolean>()
   for (const best of sourceBest.values()) {
-    if ((OPERATIONAL_TIER[best.confidence] || 0) >= PROVIDER_DERIVED_MIN) providerHasDerived.set(best.provider, true)
+    const t = OPERATIONAL_TIER[best.confidence] || 0
+    if (t >= PROVIDER_DERIVED_MIN) providerHasDerived.set(best.provider, true)
+    if (t >= REAL_ACTUAL_MIN) providerHasRealActual.set(best.provider, true)
   }
   let operational = 0, manual = 0, providerDerived = 0, forecast = 0, manualForDerivedProviders = 0
   let fresh: number | null = null
@@ -129,10 +136,12 @@ export function resolveOperational(lines: OpLine[], win: MonthWindow): Operation
     const tier = OPERATIONAL_TIER[best.confidence] || 0
     const p = best.provider
     if (fresh === null || best.data_freshness > fresh) fresh = best.data_freshness
-    if (tier <= 2) manual += best.billed_cost
-    if (tier >= PROVIDER_DERIVED_MIN) providerDerived += best.billed_cost
-    const isFallbackExcluded = providerHasDerived.get(p) === true && tier < PROVIDER_DERIVED_MIN
+    if (tier <= 2) manual += best.billed_cost  // fallback view: all manual/estimate, pre-exclusion
+    // plan estimate is a proxy for the provider's total -> drop it once a real invoice/api actual exists
+    const planSuperseded = best.confidence === 'provider_plan_estimate' && providerHasRealActual.get(p) === true
+    const isFallbackExcluded = (providerHasDerived.get(p) === true && tier < PROVIDER_DERIVED_MIN) || planSuperseded
     if (isFallbackExcluded) { manualForDerivedProviders += best.billed_cost; continue }
+    if (tier >= PROVIDER_DERIVED_MIN) providerDerived += best.billed_cost
     operational += best.billed_cost
     confBreakdown[best.confidence] = round2((confBreakdown[best.confidence] || 0) + best.billed_cost)
     const agg = providerAgg.get(p) || { spend: 0, conf: best.confidence, tier: -1 }

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -48,6 +48,12 @@ export function hashRef(salt: string, raw: string): string {
 
 // ---- confidence -> breakdown bucket ----------------------------------------
 
+// Higher = more authoritative. Used to resolve a source to one headline line
+// (v0.3) so a provider_api actual supersedes a manual estimate without double count.
+export const CONF_PRIORITY: Record<string, number> = {
+  actual_invoice: 6, provider_api: 5, billing_export: 4, local_usage: 3, estimate: 2, manual: 1,
+}
+
 export type CostBucket = 'fixed_manual' | 'provider' | 'estimate'
 
 export function confidenceBucket(c: CostConfidence): CostBucket {
@@ -153,6 +159,15 @@ export interface CostSummary {
     cache_read_tokens: number
     cache_creation_tokens: number
   }
+  // v0.2: deterministic token-cost ESTIMATE (separate from fixed/manual spend).
+  token_cost_estimate: TokenCostEstimate
+  // current_spend (fixed/manual) + token_cost_estimate.total -- clearly labeled,
+  // NOT folded into current_spend.
+  estimated_total_with_token_cost: number
+  // v0.3: per-source estimate-vs-actual (only sources that have a provider_api line).
+  reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }>
+  // v0.3: last collector run per provider (from import_runs).
+  provider_sync: Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; last_sync: number; stale: boolean; error_code: string | null }>
   data_freshness: number | null
   config_present: boolean
   config_errors: string[]
@@ -189,18 +204,31 @@ export function getCostSummary(
   const perSourceConfidence = new Map<string, string>()
   let latestFreshness: number | null = null
 
+  // Group lines per source. The HEADLINE spend resolves each source to its
+  // single highest-confidence line (v0.3: a provider_api actual supersedes the
+  // manual/estimate WITHOUT double-counting), while all lines are kept for the
+  // estimate-vs-actual reconcile view.
+  const bySource = new Map<string, LineRow[]>()
   for (const l of lines) {
-    current_spend += l.billed_cost
-    // Usage-type lines are prorated to month-end; committed/fixed lines are
-    // already whole-month (no proration).
-    forecast_month_end += l.charge_category === 'usage'
-      ? l.billed_cost / win.fractionElapsed
-      : l.billed_cost
-    confidence_breakdown[l.confidence] = (confidence_breakdown[l.confidence] || 0) + l.billed_cost
-    breakdown[confidenceBucket(l.confidence)] += l.billed_cost
-    perSource.set(l.source_id, (perSource.get(l.source_id) || 0) + l.billed_cost)
-    perSourceConfidence.set(l.source_id, l.confidence)
+    const arr = bySource.get(l.source_id); if (arr) arr.push(l); else bySource.set(l.source_id, [l])
     if (latestFreshness === null || l.data_freshness > latestFreshness) latestFreshness = l.data_freshness
+  }
+  const EST_CONF = ['manual', 'estimate', 'local_usage']
+  const ACT_CONF = ['provider_api', 'billing_export', 'actual_invoice']
+  const reconcile: CostSummary['reconcile'] = []
+  for (const [sid, ls] of bySource) {
+    const resolved = ls.reduce((a, b) => (CONF_PRIORITY[b.confidence] || 0) > (CONF_PRIORITY[a.confidence] || 0) ? b : a)
+    current_spend += resolved.billed_cost
+    forecast_month_end += resolved.charge_category === 'usage'
+      ? resolved.billed_cost / win.fractionElapsed
+      : resolved.billed_cost
+    confidence_breakdown[resolved.confidence] = (confidence_breakdown[resolved.confidence] || 0) + resolved.billed_cost
+    breakdown[confidenceBucket(resolved.confidence)] += resolved.billed_cost
+    perSource.set(sid, resolved.billed_cost)
+    perSourceConfidence.set(sid, resolved.confidence)
+    const estAmt = ls.filter(l => EST_CONF.includes(l.confidence)).reduce((s, l) => s + l.billed_cost, 0)
+    const actAmt = ls.filter(l => ACT_CONF.includes(l.confidence)).reduce((s, l) => s + l.billed_cost, 0)
+    if (actAmt > 0) reconcile.push({ source_id: sid, estimate: round2(estAmt), actual: round2(actAmt), variance: round2(actAmt - estAmt), resolved_confidence: resolved.confidence })
   }
   current_spend = round2(current_spend)
   forecast_month_end = round2(forecast_month_end)
@@ -252,6 +280,29 @@ export function getCostSummary(
     cache_read_tokens: number; cache_creation_tokens: number
   }
 
+  // v0.2 token-cost estimate (deterministic; unknown model / no rate -> unpriced).
+  const pricing = opts.pricing ?? { version: 1, currency: config.currency, models: {} }
+  const token_cost_estimate = getTokenCostEstimate(db, pricing, opts.pricingExists ?? false, win.start, win.end)
+  const estimated_total_with_token_cost = round2(current_spend + token_cost_estimate.total_estimated_huf)
+
+  // v0.3 per-source estimate-vs-actual reconciliation
+  const reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }> = []
+
+  // v0.3 provider sync status: the latest import_runs row per provider.
+  const STALE_SECS = 3 * 24 * 3600
+  const syncRows = db.prepare(`
+    SELECT provider, collector_name, status, imported_count, data_freshness_at, started_at, error_code
+    FROM import_runs r
+    WHERE started_at = (SELECT MAX(started_at) FROM import_runs WHERE provider = r.provider)
+    GROUP BY provider
+  `).all() as Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; started_at: number; error_code: string | null }>
+  const provider_sync = syncRows.map(r => ({
+    provider: r.provider, collector_name: r.collector_name, status: r.status,
+    imported_count: r.imported_count, data_freshness_at: r.data_freshness_at, last_sync: r.started_at,
+    stale: r.data_freshness_at != null ? (now - r.data_freshness_at) > STALE_SECS : true,
+    error_code: r.error_code,
+  }))
+
   return {
     month: win.key,
     currency: config.currency,
@@ -268,6 +319,10 @@ export function getCostSummary(
       input_tokens: tu.input_tokens, output_tokens: tu.output_tokens,
       cache_read_tokens: tu.cache_read_tokens, cache_creation_tokens: tu.cache_creation_tokens,
     },
+    token_cost_estimate,
+    estimated_total_with_token_cost,
+    reconcile,
+    provider_sync,
     data_freshness: latestFreshness,
     config_present: opts.configExists ?? true,
     config_errors: opts.configErrors ?? [],

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -9,6 +9,7 @@
 import type Database from 'better-sqlite3'
 import { createHash } from 'node:crypto'
 import type { CostOpsConfig, CostConfidence } from './config.js'
+import { getTokenCostEstimate, type PricingConfig, type TokenCostEstimate } from './pricing.js'
 
 // ---- month math (UTC, deterministic given `now`) ---------------------------
 
@@ -81,7 +82,7 @@ export const RENDER_NOT_COVERED: string[] = [
 // manual fallback, per source's provider: provider_api_actual > provider_plan_estimate
 // > local_usage > manual/estimate. A provider that HAS a provider-derived line drops
 // its manual/estimate lines from operational (they become fallback/comparison only),
-// so manual + provider are never double-counted (e.g. Render: plan 37080 wins over manual 40000).
+// so manual + provider are never double-counted (e.g. a provider-plan estimate wins over a manual entry for the same source).
 export const OPERATIONAL_TIER: Record<string, number> = {
   actual_invoice: 4, provider_api: 4, billing_export: 4,
   provider_plan_estimate: 3,
@@ -481,9 +482,6 @@ export function getCostSummary(
   const pricing = opts.pricing ?? { version: 1, currency: config.currency, models: {} }
   const token_cost_estimate = getTokenCostEstimate(db, pricing, opts.pricingExists ?? false, win.start, win.end)
   const estimated_total_with_token_cost = round2(current_spend + token_cost_estimate.total_estimated_huf)
-
-  // v0.3 per-source estimate-vs-actual reconciliation
-  const reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }> = []
 
   // v0.3/v0.5 provider sync status: the latest run per provider + last ok/failed +
   // derived status (ok / stale / failed / no_data) + data age + period coverage.

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -52,7 +52,30 @@ export function hashRef(salt: string, raw: string): string {
 // (v0.3) so a provider_api actual supersedes a manual estimate without double count.
 export const CONF_PRIORITY: Record<string, number> = {
   actual_invoice: 6, provider_api: 5, billing_export: 4, local_usage: 3, estimate: 2, manual: 1,
+  // provider_plan_estimate is ADVISORY only: it is excluded from the headline
+  // current_spend entirely (see getCostSummary), so its priority never applies
+  // to a headline resolution. Kept here for completeness / bucketing.
+  provider_plan_estimate: 0,
 }
+
+// provider_plan_estimate lines never enter the headline spend; they surface in a
+// dedicated render_plan block (manual vs plan vs variance).
+export const ADVISORY_CONF = new Set<string>(['provider_plan_estimate'])
+
+// Costs a plan-based Render estimate structurally CANNOT see -> the estimate is a
+// lower bound. Surfaced verbatim so the number is never mistaken for an invoice.
+export const RENDER_NOT_COVERED: string[] = [
+  'bandwidth overage (web + static site)',
+  'database storage / backup overage above the plan',
+  'logs / metrics / observability add-ons',
+  'team / workspace seats',
+  'tax / VAT',
+  'credits / discounts',
+  'invoice adjustments',
+  'one-off charges',
+  'cron per-run compute above the flat approximation',
+  'preview environments (excluded)',
+]
 
 export type CostBucket = 'fixed_manual' | 'provider' | 'estimate'
 
@@ -64,6 +87,7 @@ export function confidenceBucket(c: CostConfidence): CostBucket {
       return 'provider'
     case 'estimate':
     case 'local_usage':
+    case 'provider_plan_estimate':
       return 'estimate'
     case 'manual':
     default:
@@ -168,6 +192,16 @@ export interface CostSummary {
   reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }>
   // v0.3: last collector run per provider (from import_runs).
   provider_sync: Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; last_sync: number; stale: boolean; error_code: string | null }>
+  // v0.3 Render plan-based estimate (ADVISORY -- NOT in current_spend). null until a Render import.
+  render_plan: {
+    currency: string
+    plan_estimate_total: number
+    manual_estimate: number
+    variance: number
+    confidence: string
+    data_freshness_at: number | null
+    not_covered: string[]
+  } | null
   data_freshness: number | null
   config_present: boolean
   config_errors: string[]
@@ -208,9 +242,16 @@ export function getCostSummary(
   // single highest-confidence line (v0.3: a provider_api actual supersedes the
   // manual/estimate WITHOUT double-counting), while all lines are kept for the
   // estimate-vs-actual reconcile view.
+  // provider_plan_estimate lines are ADVISORY -- excluded from the headline
+  // current_spend and from all_sources; they surface only in the render_plan block.
+  const headlineLines = lines.filter(l => !ADVISORY_CONF.has(l.confidence))
+  const planLines = lines.filter(l => ADVISORY_CONF.has(l.confidence))
+  const advisorySourceIds = new Set(planLines.map(l => l.source_id))
   const bySource = new Map<string, LineRow[]>()
-  for (const l of lines) {
+  for (const l of headlineLines) {
     const arr = bySource.get(l.source_id); if (arr) arr.push(l); else bySource.set(l.source_id, [l])
+  }
+  for (const l of lines) {
     if (latestFreshness === null || l.data_freshness > latestFreshness) latestFreshness = l.data_freshness
   }
   const EST_CONF = ['manual', 'estimate', 'local_usage']
@@ -242,12 +283,33 @@ export function getCostSummary(
     .slice(0, 5)
 
   // Full list: every configured/active source with spend (0 if none this month).
+  // Advisory-only sources (render-plan / provider_plan_estimate) are excluded --
+  // they appear in the render_plan block, never in the headline source list.
   const all_sources = srcRows
+    .filter(r => !advisorySourceIds.has(r.id))
     .map(r => ({
       source_id: r.id, name: r.name, provider: r.provider, source_type: r.source_type,
       spend: round2(perSource.get(r.id) || 0), confidence: perSourceConfidence.get(r.id) || 'manual',
     }))
     .sort((a, b) => b.spend - a.spend || a.name.localeCompare(b.name))
+
+  // v0.3 Render plan-based estimate (ADVISORY): manual render estimate vs plan-based
+  // estimate vs variance. NEVER folded into current_spend. Empty until a Render import.
+  const plan_estimate_total = round2(planLines.reduce((s, l) => s + l.billed_cost, 0))
+  const manual_render_estimate = round2(
+    srcRows.filter(r => r.provider === 'render' && !advisorySourceIds.has(r.id))
+      .reduce((s, r) => s + (perSource.get(r.id) || 0), 0),
+  )
+  const planFreshness = planLines.reduce((m, l) => Math.max(m, l.data_freshness), 0) || null
+  const render_plan: CostSummary['render_plan'] = planLines.length > 0 ? {
+    currency: config.currency,
+    plan_estimate_total,
+    manual_estimate: manual_render_estimate,
+    variance: round2(plan_estimate_total - manual_render_estimate),
+    confidence: 'provider_plan_estimate',
+    data_freshness_at: planFreshness,
+    not_covered: RENDER_NOT_COVERED,
+  } : null
 
   // budget (first budget, or the 'global-monthly' one if present)
   const budgetDef = config.budgets.find(b => b.id === 'global-monthly') || config.budgets[0] || null
@@ -323,6 +385,7 @@ export function getCostSummary(
     estimated_total_with_token_cost,
     reconcile,
     provider_sync,
+    render_plan,
     data_freshness: latestFreshness,
     config_present: opts.configExists ?? true,
     config_errors: opts.configErrors ?? [],

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -277,9 +277,9 @@ export interface CostSummary {
   estimated_total_with_token_cost: number
   // v0.3: per-source estimate-vs-actual (only sources that have a provider_api line).
   reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }>
-  // v0.3: last collector run per provider (from import_runs).
-  provider_sync: Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; last_sync: number; stale: boolean; error_code: string | null }>
-  // v0.3 Render plan-based estimate (ADVISORY -- NOT in current_spend). null until a Render import.
+  // v0.3/v0.5: last collector run per provider + sync state (ok/stale/failed).
+  provider_sync: Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; last_sync: number; last_success: number | null; last_failed: number | null; data_age_secs: number | null; current_period: string; previous_period_coverage: boolean; stale: boolean; error_code: string | null }>
+  // v0.3/v0.5 Render plan-based estimate (ADVISORY -- NOT in current_spend). null until a Render import.
   render_plan: {
     currency: string
     plan_estimate_total: number
@@ -288,6 +288,8 @@ export interface CostSummary {
     confidence: string
     data_freshness_at: number | null
     not_covered: string[]
+    detail: unknown            // sanitized breakdown from the latest sync (service_count, by_type_plan, ...)
+    last_sync: number | null
   } | null
   data_freshness: number | null
   config_present: boolean
@@ -388,6 +390,11 @@ export function getCostSummary(
       .reduce((s, r) => s + (perSource.get(r.id) || 0), 0),
   )
   const planFreshness = planLines.reduce((m, l) => Math.max(m, l.data_freshness), 0) || null
+  // v0.5: latest successful Render sync -> sanitized breakdown (service_count, plan
+  // breakdown, undercount) + last_sync for the dashboard Render detail.
+  const renderRun = db.prepare(`SELECT detail_json, started_at FROM import_runs WHERE provider='render' AND status='ok' ORDER BY started_at DESC LIMIT 1`).get() as { detail_json: string | null; started_at: number } | undefined
+  let renderDetail: unknown = null
+  if (renderRun?.detail_json) { try { renderDetail = JSON.parse(renderRun.detail_json) } catch { renderDetail = null } }
   const render_plan: CostSummary['render_plan'] = planLines.length > 0 ? {
     currency: config.currency,
     plan_estimate_total,
@@ -396,6 +403,8 @@ export function getCostSummary(
     confidence: 'provider_plan_estimate',
     data_freshness_at: planFreshness,
     not_covered: RENDER_NOT_COVERED,
+    detail: renderDetail,
+    last_sync: renderRun?.started_at ?? null,
   } : null
 
   // v0.4: provider-preferred OPERATIONAL spend (new main KPI). Uses ALL lines
@@ -467,20 +476,34 @@ export function getCostSummary(
   // v0.3 per-source estimate-vs-actual reconciliation
   const reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }> = []
 
-  // v0.3 provider sync status: the latest import_runs row per provider.
+  // v0.3/v0.5 provider sync status: the latest run per provider + last ok/failed +
+  // derived status (ok / stale / failed / no_data) + data age + period coverage.
   const STALE_SECS = 3 * 24 * 3600
-  const syncRows = db.prepare(`
+  const latestRows = db.prepare(`
     SELECT provider, collector_name, status, imported_count, data_freshness_at, started_at, error_code
     FROM import_runs r
     WHERE started_at = (SELECT MAX(started_at) FROM import_runs WHERE provider = r.provider)
     GROUP BY provider
   `).all() as Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; started_at: number; error_code: string | null }>
-  const provider_sync = syncRows.map(r => ({
-    provider: r.provider, collector_name: r.collector_name, status: r.status,
-    imported_count: r.imported_count, data_freshness_at: r.data_freshness_at, last_sync: r.started_at,
-    stale: r.data_freshness_at != null ? (now - r.data_freshness_at) > STALE_SECS : true,
-    error_code: r.error_code,
-  }))
+  const lastOkStmt = db.prepare(`SELECT MAX(started_at) t FROM import_runs WHERE provider = ? AND status = 'ok'`)
+  const lastFailStmt = db.prepare(`SELECT MAX(started_at) t FROM import_runs WHERE provider = ? AND status IN ('error','failed','partial','rate_limited')`)
+  const prevProviders = new Set(prevRows.map(l => providerBySource.get(l.source_id) || 'other'))
+  const provider_sync = latestRows.map(r => {
+    const lastOk = (lastOkStmt.get(r.provider) as { t: number | null }).t || null
+    const lastFailed = (lastFailStmt.get(r.provider) as { t: number | null }).t || null
+    // "stale" means we have not SYNCED recently (not about the billing-period age).
+    const syncAge = now - r.started_at
+    const stale = syncAge > STALE_SECS
+    const status = r.status !== 'ok' ? 'failed' : (stale ? 'stale' : 'ok')
+    return {
+      provider: r.provider, collector_name: r.collector_name, status,
+      imported_count: r.imported_count, data_freshness_at: r.data_freshness_at,
+      last_sync: r.started_at, last_success: lastOk, last_failed: lastFailed,
+      data_age_secs: syncAge,
+      current_period: win.key, previous_period_coverage: prevProviders.has(r.provider),
+      stale, error_code: r.error_code,
+    }
+  })
 
   return {
     month: win.key,

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -77,6 +77,83 @@ export const RENDER_NOT_COVERED: string[] = [
   'preview environments (excluded)',
 ]
 
+// v0.4: operational spend preference. The MAIN KPI prefers provider data over the
+// manual fallback, per source's provider: provider_api_actual > provider_plan_estimate
+// > local_usage > manual/estimate. A provider that HAS a provider-derived line drops
+// its manual/estimate lines from operational (they become fallback/comparison only),
+// so manual + provider are never double-counted (e.g. Render: plan 37080 wins over manual 40000).
+export const OPERATIONAL_TIER: Record<string, number> = {
+  actual_invoice: 4, provider_api: 4, billing_export: 4,
+  provider_plan_estimate: 3,
+  local_usage: 2,
+  estimate: 1, manual: 1,
+}
+const PROVIDER_DERIVED_MIN = 3  // provider_plan_estimate or higher = "provider-derived"
+
+interface OpLine { source_id: string; provider: string; billed_cost: number; charge_category: string; confidence: string; data_freshness: number }
+
+export interface OperationalResult {
+  operational_spend: number
+  manual_spend: number
+  provider_derived_spend: number
+  operational_forecast_month_end: number
+  provider_breakdown: Array<{ provider: string; spend: number; confidence: string }>
+  confidence_breakdown: Record<string, number>
+  manual_vs_provider_variance: number
+  data_freshness: number | null
+}
+
+/**
+ * Resolve the provider-preferred OPERATIONAL spend for a set of month lines.
+ * Per source -> best line by OPERATIONAL_TIER. Per provider -> if it has any
+ * provider-derived source, its manual/estimate sources are excluded from operational
+ * (fallback only). No double counting. `win` is used for the forecast run-rate.
+ */
+export function resolveOperational(lines: OpLine[], win: MonthWindow): OperationalResult {
+  const bySource = new Map<string, OpLine[]>()
+  for (const l of lines) { const a = bySource.get(l.source_id); if (a) a.push(l); else bySource.set(l.source_id, [l]) }
+  const sourceBest = new Map<string, OpLine>()
+  for (const [sid, ls] of bySource) {
+    sourceBest.set(sid, ls.reduce((a, b) => (OPERATIONAL_TIER[b.confidence] || 0) > (OPERATIONAL_TIER[a.confidence] || 0) ? b : a))
+  }
+  // which providers have a provider-derived (tier>=3) source
+  const providerHasDerived = new Map<string, boolean>()
+  for (const best of sourceBest.values()) {
+    if ((OPERATIONAL_TIER[best.confidence] || 0) >= PROVIDER_DERIVED_MIN) providerHasDerived.set(best.provider, true)
+  }
+  let operational = 0, manual = 0, providerDerived = 0, forecast = 0, manualForDerivedProviders = 0
+  let fresh: number | null = null
+  const providerAgg = new Map<string, { spend: number; conf: string; tier: number }>()
+  const confBreakdown: Record<string, number> = {}
+  for (const [, best] of sourceBest) {
+    const tier = OPERATIONAL_TIER[best.confidence] || 0
+    const p = best.provider
+    if (fresh === null || best.data_freshness > fresh) fresh = best.data_freshness
+    if (tier <= 2) manual += best.billed_cost
+    if (tier >= PROVIDER_DERIVED_MIN) providerDerived += best.billed_cost
+    const isFallbackExcluded = providerHasDerived.get(p) === true && tier < PROVIDER_DERIVED_MIN
+    if (isFallbackExcluded) { manualForDerivedProviders += best.billed_cost; continue }
+    operational += best.billed_cost
+    confBreakdown[best.confidence] = round2((confBreakdown[best.confidence] || 0) + best.billed_cost)
+    const agg = providerAgg.get(p) || { spend: 0, conf: best.confidence, tier: -1 }
+    agg.spend += best.billed_cost
+    if (tier > agg.tier) { agg.tier = tier; agg.conf = best.confidence }
+    providerAgg.set(p, agg)
+    // forecast policy: provider_api_actual usage MTD -> run-rate; plan/manual -> full monthly
+    forecast += (tier >= 4 && best.charge_category === 'usage') ? best.billed_cost / win.fractionElapsed : best.billed_cost
+  }
+  return {
+    operational_spend: round2(operational),
+    manual_spend: round2(manual),
+    provider_derived_spend: round2(providerDerived),
+    operational_forecast_month_end: round2(forecast),
+    provider_breakdown: [...providerAgg.entries()].map(([provider, v]) => ({ provider, spend: round2(v.spend), confidence: v.conf })).sort((a, b) => b.spend - a.spend),
+    confidence_breakdown: confBreakdown,
+    manual_vs_provider_variance: round2(providerDerived - manualForDerivedProviders),
+    data_freshness: fresh,
+  }
+}
+
 export type CostBucket = 'fixed_manual' | 'provider' | 'estimate'
 
 export function confidenceBucket(c: CostConfidence): CostBucket {
@@ -157,8 +234,16 @@ export function syncFixedCostsToLedger(
 export interface CostSummary {
   month: string
   currency: string
+  // legacy manual/estimate headline (kept for back-compat; excludes provider_plan_estimate)
   current_spend: number
   forecast_month_end: number
+  // v0.4: provider-preferred OPERATIONAL spend -- the NEW main KPI.
+  operational_spend: number
+  operational_forecast_month_end: number
+  operational: OperationalResult
+  // previous month operational aggregate (null == no_previous_month_data; never fabricated)
+  previous_month: { month: string; operational_spend: number; by_provider: Array<{ provider: string; spend: number; confidence: string }> } | null
+  month_over_month_delta: number | null
   top_sources: Array<{ source_id: string; name: string; spend: number }>
   // Full list of every configured/active source (not capped) -- top_sources is
   // the top-5 by spend; all_sources is the complete set for the dashboard table.
@@ -173,6 +258,8 @@ export interface CostSummary {
     status: 'ok' | 'warning' | 'hard'
     warning_threshold: number
     hard_threshold: number
+    operational_used_pct: number
+    operational_forecast_pct: number
   } | null
   token_usage: {
     note: string
@@ -311,6 +398,32 @@ export function getCostSummary(
     not_covered: RENDER_NOT_COVERED,
   } : null
 
+  // v0.4: provider-preferred OPERATIONAL spend (new main KPI). Uses ALL lines
+  // (manual + plan + provider actual), mapped to their provider, resolved so a
+  // provider's manual is dropped once it has provider-derived data (no double count).
+  const providerBySource = new Map(srcRows.map(r => [r.id, r.provider]))
+  const opLines: OpLine[] = lines.map(l => ({
+    source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
+    billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
+  }))
+  const op = resolveOperational(opLines, win)
+
+  // previous month: aggregate from cost_line_items; NEVER fabricated. null if no data.
+  const prevWin = monthWindow(win.start - 86400)
+  const prevRows = db.prepare(`
+    SELECT source_id, billed_cost, charge_category, confidence, data_freshness
+    FROM cost_line_items WHERE charge_period_start < @end AND charge_period_end > @start
+  `).all({ start: prevWin.start, end: prevWin.end }) as LineRow[]
+  let previous_month: CostSummary['previous_month'] = null
+  if (prevRows.length > 0) {
+    const prevOp = resolveOperational(prevRows.map(l => ({
+      source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
+      billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
+    })), prevWin)
+    previous_month = { month: prevWin.key, operational_spend: prevOp.operational_spend, by_provider: prevOp.provider_breakdown }
+  }
+  const month_over_month_delta = previous_month ? round2(op.operational_spend - previous_month.operational_spend) : null
+
   // budget (first budget, or the 'global-monthly' one if present)
   const budgetDef = config.budgets.find(b => b.id === 'global-monthly') || config.budgets[0] || null
   let budget: CostSummary['budget'] = null
@@ -319,12 +432,16 @@ export function getCostSummary(
     const hard = budgetDef.hard_threshold ?? 1.0
     const used_pct = current_spend / budgetDef.amount
     const forecast_pct = forecast_month_end / budgetDef.amount
-    // Status is display-only. No action is ever taken here.
+    // v0.4: budget usage against the OPERATIONAL spend (the main KPI).
+    const op_used_pct = op.operational_spend / budgetDef.amount
+    const op_forecast_pct = op.operational_forecast_month_end / budgetDef.amount
+    // Status is display-only. No action is ever taken here. Driven by operational.
     const status: 'ok' | 'warning' | 'hard' =
-      used_pct >= hard ? 'hard' : used_pct >= warning ? 'warning' : 'ok'
+      op_used_pct >= hard ? 'hard' : op_used_pct >= warning ? 'warning' : 'ok'
     budget = {
       id: budgetDef.id, amount: budgetDef.amount,
       used_pct: round4(used_pct), forecast_pct: round4(forecast_pct),
+      operational_used_pct: round4(op_used_pct), operational_forecast_pct: round4(op_forecast_pct),
       status, warning_threshold: warning, hard_threshold: hard,
     }
   }
@@ -370,6 +487,11 @@ export function getCostSummary(
     currency: config.currency,
     current_spend,
     forecast_month_end,
+    operational_spend: op.operational_spend,
+    operational_forecast_month_end: op.operational_forecast_month_end,
+    operational: op,
+    previous_month,
+    month_over_month_delta,
     top_sources,
     all_sources,
     confidence_breakdown: roundValues(confidence_breakdown),

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -319,7 +319,7 @@ export function getCostSummary(
   db: Database.Database,
   config: CostOpsConfig,
   now: number,
-  opts: { monthKey?: string; configExists?: boolean; configErrors?: string[] } = {},
+  opts: { monthKey?: string; configExists?: boolean; configErrors?: string[]; pricing?: PricingConfig; pricingExists?: boolean } = {},
 ): CostSummary {
   const win = monthWindow(now, opts.monthKey)
 

--- a/src/costops/pricing.ts
+++ b/src/costops/pricing.ts
@@ -1,0 +1,315 @@
+// CostOps v0.2 -- local, deterministic token-cost ESTIMATE.
+//
+// Pure arithmetic over the existing token_usage rows + a local pricing config.
+// NO LLM, no provider API, no external pricing API, no secrets. Token cost is
+// an ESTIMATE (confidence: estimate), kept SEPARATE from the v0.1 fixed/manual
+// spend -- it is never an invoice.
+//
+// Rows without a model (unknown) or without a matching pricing entry are left
+// UNPRICED (counted as volume only), never guessed.
+
+import type Database from 'better-sqlite3'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+import { logger } from '../logger.js'
+
+export const PRICING_CONFIG_PATH = join(PROJECT_ROOT, 'store', 'costops-pricing.json')
+export const PRICING_EXAMPLE_PATH = join(PROJECT_ROOT, 'store', 'costops-pricing.json.example')
+
+// Per-million-token rates, in the config's `currency` (default HUF).
+export interface ModelRate {
+  input_per_mtok: number
+  output_per_mtok: number
+  cache_read_per_mtok: number
+  cache_write_per_mtok: number
+}
+
+export interface PricingConfig {
+  version: number
+  currency: string
+  models: Record<string, ModelRate>
+}
+
+export interface PricingLoadResult {
+  pricing: PricingConfig
+  exists: boolean
+  errors: string[]
+}
+
+const EMPTY_PRICING: PricingConfig = { version: 1, currency: 'HUF', models: {} }
+
+// Safe skeleton -- ALL rates 0 (placeholder, no real provider prices). Operator
+// fills real per-MTok rates locally. Generated to the gitignored store/ dir.
+const EXAMPLE_PRICING = {
+  version: 1,
+  currency: 'HUF',
+  _doc: 'CostOps v0.2 token pricing (gitignored, local). Rates are per 1,000,000 tokens in `currency`. All 0 here = no cost estimate until you fill real rates. Keys are model ids as they appear in the transcript (message.model), e.g. claude-opus-4-8. No secrets/API keys here.',
+  models: {
+    'claude-opus-4-8': { input_per_mtok: 0, output_per_mtok: 0, cache_read_per_mtok: 0, cache_write_per_mtok: 0 },
+    'claude-sonnet-4-6': { input_per_mtok: 0, output_per_mtok: 0, cache_read_per_mtok: 0, cache_write_per_mtok: 0 },
+    'claude-haiku-4-5': { input_per_mtok: 0, output_per_mtok: 0, cache_read_per_mtok: 0, cache_write_per_mtok: 0 },
+    'deepseek-v4-pro': { input_per_mtok: 0, output_per_mtok: 0, cache_read_per_mtok: 0, cache_write_per_mtok: 0 },
+  },
+}
+
+/**
+ * Derive a coarse provider from a model id string. Deterministic, no network.
+ * Returns 'unknown' when it cannot be classified (never guessed downstream).
+ */
+export function deriveProvider(model: string | null | undefined): string {
+  if (!model) return 'unknown'
+  const m = model.toLowerCase()
+  if (/(claude|anthropic|opus|sonnet|haiku|fable)/.test(m)) return 'anthropic'
+  if (/(deepseek)/.test(m)) return 'deepseek'
+  if (/(gpt|openai|o1|o3|o4|davinci|codex)/.test(m)) return 'openai'
+  if (/(gemini|google|palm|bard)/.test(m)) return 'google'
+  if (/(grok|xai)/.test(m)) return 'xai'
+  if (/(mistral|mixtral)/.test(m)) return 'mistral'
+  if (/(llama|meta)/.test(m)) return 'meta'
+  return 'unknown'
+}
+
+export function loadPricingConfig(): PricingLoadResult {
+  if (!existsSync(PRICING_CONFIG_PATH)) {
+    ensurePricingExample()
+    return { pricing: { ...EMPTY_PRICING }, exists: false, errors: [] }
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(PRICING_CONFIG_PATH, 'utf-8'))
+  } catch (err) {
+    logger.warn({ err }, 'costops-pricing.json is not valid JSON')
+    return { pricing: { ...EMPTY_PRICING }, exists: true, errors: ['pricing config is not valid JSON'] }
+  }
+  return validatePricing(raw)
+}
+
+export function ensurePricingExample(): void {
+  try {
+    if (!existsSync(PRICING_EXAMPLE_PATH)) {
+      writeFileSync(PRICING_EXAMPLE_PATH, JSON.stringify(EXAMPLE_PRICING, null, 2) + '\n', 'utf-8')
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to write costops-pricing example')
+  }
+}
+
+export function validatePricing(raw: unknown): PricingLoadResult {
+  const errors: string[] = []
+  const obj = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const currency = typeof obj.currency === 'string' ? obj.currency : 'HUF'
+  const models: Record<string, ModelRate> = {}
+  const rawModels = (obj.models && typeof obj.models === 'object') ? obj.models as Record<string, unknown> : {}
+  for (const [id, v] of Object.entries(rawModels)) {
+    const r = v as Record<string, unknown>
+    const num = (x: unknown) => (typeof x === 'number' && isFinite(x) && x >= 0) ? x : null
+    const inp = num(r?.input_per_mtok), out = num(r?.output_per_mtok)
+    const cr = num(r?.cache_read_per_mtok), cw = num(r?.cache_write_per_mtok)
+    if (inp === null || out === null) { errors.push(`models['${id}']: input_per_mtok and output_per_mtok must be non-negative numbers`); continue }
+    models[id] = {
+      input_per_mtok: inp, output_per_mtok: out,
+      cache_read_per_mtok: cr ?? 0, cache_write_per_mtok: cw ?? 0,
+    }
+  }
+  return { pricing: { version: typeof obj.version === 'number' ? obj.version : 1, currency, models }, exists: true, errors }
+}
+
+// ---- deterministic token-cost estimate over token_usage for a month ---------
+
+export interface TokenCostEstimate {
+  currency: string
+  total_estimated_huf: number
+  confidence: 'estimate'
+  pricing_profile_status: 'no_pricing_config' | 'loaded' | 'partial'
+  priced_by_model: Array<{
+    model: string
+    provider: string
+    input_tokens: number
+    output_tokens: number
+    cache_read_tokens: number
+    cache_creation_tokens: number
+    estimated_huf: number
+  }>
+  unpriced: {
+    unknown_model_tokens: number   // rows with NULL model
+    no_rate_tokens: number         // model present but no pricing entry
+    calls: number
+  }
+  note: string
+}
+
+interface ModelAgg {
+  model: string | null
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+  calls: number
+}
+
+/**
+ * Compute a deterministic token-cost estimate for [start,end) from token_usage,
+ * grouped by model, using the local pricing config. Pure SQL + arithmetic.
+ * `pricingExists` distinguishes "no config at all" from "config with no match".
+ */
+export function getTokenCostEstimate(
+  db: Database.Database,
+  pricing: PricingConfig,
+  pricingExists: boolean,
+  start: number,
+  end: number,
+): TokenCostEstimate {
+  const rows = db.prepare(`
+    SELECT model,
+      COALESCE(SUM(input_tokens),0) as input_tokens,
+      COALESCE(SUM(output_tokens),0) as output_tokens,
+      COALESCE(SUM(cache_read_tokens),0) as cache_read_tokens,
+      COALESCE(SUM(cache_creation_tokens),0) as cache_creation_tokens,
+      COUNT(*) as calls
+    FROM token_usage
+    WHERE timestamp >= @start AND timestamp < @end
+    GROUP BY model
+  `).all({ start, end }) as ModelAgg[]
+
+  const priced_by_model: TokenCostEstimate['priced_by_model'] = []
+  let total = 0
+  let unknownTokens = 0, noRateTokens = 0, unpricedCalls = 0
+  let anyPriced = false, anyUnpriced = false
+
+  for (const r of rows) {
+    const tokenSum = r.input_tokens + r.output_tokens + r.cache_read_tokens + r.cache_creation_tokens
+    const rate = r.model ? pricing.models[r.model] : undefined
+    if (!r.model) {
+      unknownTokens += tokenSum; unpricedCalls += r.calls; anyUnpriced = true; continue
+    }
+    if (!rate) {
+      noRateTokens += tokenSum; unpricedCalls += r.calls; anyUnpriced = true; continue
+    }
+    const est = round2(
+      (r.input_tokens / 1e6) * rate.input_per_mtok +
+      (r.output_tokens / 1e6) * rate.output_per_mtok +
+      (r.cache_read_tokens / 1e6) * rate.cache_read_per_mtok +
+      (r.cache_creation_tokens / 1e6) * rate.cache_write_per_mtok,
+    )
+    total += est
+    anyPriced = true
+    priced_by_model.push({
+      model: r.model, provider: deriveProvider(r.model),
+      input_tokens: r.input_tokens, output_tokens: r.output_tokens,
+      cache_read_tokens: r.cache_read_tokens, cache_creation_tokens: r.cache_creation_tokens,
+      estimated_huf: est,
+    })
+  }
+  priced_by_model.sort((a, b) => b.estimated_huf - a.estimated_huf)
+
+  const pricing_profile_status: TokenCostEstimate['pricing_profile_status'] =
+    !pricingExists || Object.keys(pricing.models).length === 0 ? 'no_pricing_config'
+    : (anyUnpriced && anyPriced) ? 'partial'
+    : 'loaded'
+
+  return {
+    currency: pricing.currency,
+    total_estimated_huf: round2(total),
+    confidence: 'estimate',
+    pricing_profile_status,
+    priced_by_model,
+    unpriced: { unknown_model_tokens: unknownTokens, no_rate_tokens: noRateTokens, calls: unpricedCalls },
+    note: 'ESTIMATE only, not an invoice. Separate from fixed/manual spend. Rows with unknown model or no pricing rate are left unpriced (volume only).',
+  }
+}
+
+// ---- v0.8 (card 6f4d1332 §5): agent-grouped token cost + run-rate forecast --------------------
+// Sibling of getTokenCostEstimate() -- same pricing config, same per-row pricing logic, just
+// GROUP BY agent, model instead of model alone. No new columns needed: token_usage already has
+// agent/model/provider on every row (db.ts). limit_usage_pct is always null here (honest, not
+// invented) -- this function has no subscription-limit context; a caller can overlay a real
+// ceiling (e.g. SubscriptionEntry.weekly_limit_tokens, if the operator ever supplies one) separately.
+
+// v0.8.1 (card d9739cf3, label/naming polish): label/naming polish, no math change. The token-runrate
+// number is an ESTIMATE, never an invoice -- "actual_cost" was misleading (implied a confirmed
+// charge). Renamed to estimated_cost_mtd; billed_status/source are new explicit per-row fields
+// so a reader doesn't have to infer "is this actually charged?" from card-header prose.
+export interface TokenCostByAgentEntry {
+  agent: string
+  provider: string
+  model: string
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+  estimated_cost_mtd: number
+  forecast_month_end: number | null   // null when fractionElapsed is not meaningful (e.g. 0 rows)
+  forecast_basis: 'token_runrate'
+  // 'not_billed': provider has an active flat-fee subscription (Claude Max/Pro) that already
+  // covers this usage -- the number is visibility, not a separate charge. 'unknown': no
+  // subscription-coverage signal for this provider here (this is a pure function with no
+  // subscription context) -- genuinely don't know, never guessed as either not_billed or billed.
+  billed_status: 'not_billed' | 'unknown'
+  source: 'local_token_usage'
+  limit_usage_pct: number | null      // always null -- see module comment above
+}
+
+interface AgentModelAgg {
+  agent: string
+  model: string | null
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+}
+
+/**
+ * Per-(agent, model) token cost estimate + run-rate forecast for [start,end). Rows with no
+ * model or no matching pricing rate are excluded from the result (same "never guess" rule as
+ * getTokenCostEstimate) rather than returned with a fabricated cost.
+ */
+export function getTokenCostByAgent(
+  db: Database.Database,
+  pricing: PricingConfig,
+  start: number,
+  end: number,
+  fractionElapsed: number,
+): TokenCostByAgentEntry[] {
+  const rows = db.prepare(`
+    SELECT agent, model,
+      COALESCE(SUM(input_tokens),0) as input_tokens,
+      COALESCE(SUM(output_tokens),0) as output_tokens,
+      COALESCE(SUM(cache_read_tokens),0) as cache_read_tokens,
+      COALESCE(SUM(cache_creation_tokens),0) as cache_creation_tokens
+    FROM token_usage
+    WHERE timestamp >= @start AND timestamp < @end
+    GROUP BY agent, model
+  `).all({ start, end }) as AgentModelAgg[]
+
+  const out: TokenCostByAgentEntry[] = []
+  for (const r of rows) {
+    const rate = r.model ? pricing.models[r.model] : undefined
+    if (!r.model || !rate) continue // unpriced (unknown model / no rate) -- volume only, not returned here
+    const est = round2(
+      (r.input_tokens / 1e6) * rate.input_per_mtok +
+      (r.output_tokens / 1e6) * rate.output_per_mtok +
+      (r.cache_read_tokens / 1e6) * rate.cache_read_per_mtok +
+      (r.cache_creation_tokens / 1e6) * rate.cache_write_per_mtok,
+    )
+    const provider = deriveProvider(r.model)
+    out.push({
+      agent: r.agent, provider, model: r.model,
+      input_tokens: r.input_tokens, output_tokens: r.output_tokens,
+      cache_read_tokens: r.cache_read_tokens, cache_creation_tokens: r.cache_creation_tokens,
+      estimated_cost_mtd: est,
+      forecast_month_end: fractionElapsed > 0 ? round2(est / fractionElapsed) : null,
+      forecast_basis: 'token_runrate',
+      // Anthropic usage in this fleet runs under a flat-fee Claude Max/Pro subscription, not a
+      // metered API key -- local token counting is visibility only, never a separate charge.
+      // Every other provider: no subscription-coverage signal available in this pure function,
+      // stays honestly 'unknown' rather than assumed either way.
+      billed_status: provider === 'anthropic' ? 'not_billed' : 'unknown',
+      source: 'local_token_usage',
+      limit_usage_pct: null,
+    })
+  }
+  return out.sort((a, b) => b.estimated_cost_mtd - a.estimated_cost_mtd)
+}
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }

--- a/src/costops/reconciliation.ts
+++ b/src/costops/reconciliation.ts
@@ -1,0 +1,129 @@
+// CostOps Phase 1 (GAP-06) -- per-source reconciliation view.
+//
+// Formalizes the "is this number believable" check the gap-analysis calls
+// for: per source, what did the provider API say, what did the invoice say,
+// what did we forecast, and what did the ledger actually select as the
+// operational headline -- with an explicit variance and status, instead of
+// only the existing summary-level reconciliation-delta-0 guarantee (which
+// proves internal consistency, not cross-source-of-truth agreement).
+//
+// Read-only, additive: does not change getCostSummary's contract or write
+// anything. Reuses the same CONF_PRIORITY resolution as ledger.ts so
+// "operationally selected" here always matches what the dashboard actually
+// shows for that source.
+
+import type Database from 'better-sqlite3'
+import { monthWindow, CONF_PRIORITY } from './ledger.js'
+
+export type ReconciliationStatus =
+  | 'matched'
+  | 'variance'
+  | 'missing_invoice'
+  | 'missing_provider_data'
+  | 'estimate_only'
+  | 'no_data'
+
+export interface SourceReconciliation {
+  source_id: string
+  name: string
+  provider: string
+  month: string
+  expected_amount: number | null
+  observed_provider_amount: number | null
+  invoice_amount: number | null
+  operationally_selected_amount: number | null
+  variance: number | null
+  variance_reason: string | null
+  status: ReconciliationStatus
+}
+
+// Relative variance tolerance below which two numbers are considered
+// "matched" rather than a genuine discrepancy worth flagging -- not
+// business-specified (same flagged-placeholder convention as warnings.ts's
+// MATERIAL_FRACTION/LARGE_INCREASE_FRACTION), tune once real invoice-vs-
+// provider-API data accumulates.
+const VARIANCE_TOLERANCE_FRACTION = 0.02
+
+interface SourceRow { id: string; name: string; provider: string }
+interface LineRow { source_id: string; billed_cost: number; confidence: string; actual_source: string | null }
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }
+
+function isWithinTolerance(a: number, b: number): boolean {
+  const base = Math.max(Math.abs(a), Math.abs(b), 1)
+  return Math.abs(a - b) / base <= VARIANCE_TOLERANCE_FRACTION
+}
+
+/**
+ * Build the reconciliation view for every active source, for `month`
+ * (defaults to the month containing `now`). Pure DB read, no writes.
+ */
+export function buildReconciliation(db: Database.Database, now: number, month?: string): SourceReconciliation[] {
+  const win = monthWindow(now, month)
+  const sources = db.prepare(`SELECT id, name, provider FROM cost_sources WHERE active = 1`).all() as SourceRow[]
+  const lines = db.prepare(`
+    SELECT source_id, billed_cost, confidence, actual_source
+    FROM cost_line_items
+    WHERE charge_period_start < @end AND charge_period_end > @start AND voided_at IS NULL
+  `).all({ start: win.start, end: win.end }) as LineRow[]
+
+  const bySource = new Map<string, LineRow[]>()
+  for (const l of lines) { const a = bySource.get(l.source_id); if (a) a.push(l); else bySource.set(l.source_id, [l]) }
+
+  const latestForecast = db.prepare(`
+    SELECT forecast_amount FROM forecast_snapshots
+    WHERE source_id = ? AND month = ? ORDER BY snapshot_at DESC LIMIT 1
+  `)
+
+  return sources.map((s): SourceReconciliation => {
+    const ls = bySource.get(s.id) ?? []
+    if (ls.length === 0) {
+      return {
+        source_id: s.id, name: s.name, provider: s.provider, month: win.key,
+        expected_amount: null, observed_provider_amount: null, invoice_amount: null,
+        operationally_selected_amount: null, variance: null, variance_reason: null,
+        status: 'no_data',
+      }
+    }
+
+    const providerLines = ls.filter(l => l.actual_source === 'provider_api')
+    const invoiceLines = ls.filter(l => l.actual_source === 'email_invoice')
+    const observed_provider_amount = providerLines.length > 0 ? round2(providerLines.reduce((sum, l) => sum + l.billed_cost, 0)) : null
+    const invoice_amount = invoiceLines.length > 0 ? round2(invoiceLines.reduce((sum, l) => sum + l.billed_cost, 0)) : null
+
+    const resolved = ls.reduce((a, b) => (CONF_PRIORITY[b.confidence] || 0) > (CONF_PRIORITY[a.confidence] || 0) ? b : a)
+    const operationally_selected_amount = round2(resolved.billed_cost)
+
+    const forecastRow = latestForecast.get(s.id, win.key) as { forecast_amount: number } | undefined
+    const expected_amount = forecastRow ? round2(forecastRow.forecast_amount) : null
+
+    let variance: number | null = null
+    let variance_reason: string | null = null
+    if (observed_provider_amount != null && invoice_amount != null) {
+      variance = round2(invoice_amount - observed_provider_amount)
+      variance_reason = 'invoice vs provider API'
+    } else if (expected_amount != null && operationally_selected_amount != null) {
+      variance = round2(operationally_selected_amount - expected_amount)
+      variance_reason = 'actual vs forecast'
+    }
+
+    let status: ReconciliationStatus
+    if (observed_provider_amount != null && invoice_amount == null) {
+      status = 'missing_invoice'
+    } else if (invoice_amount != null && observed_provider_amount == null) {
+      status = 'missing_provider_data'
+    } else if (observed_provider_amount == null && invoice_amount == null) {
+      status = 'estimate_only'
+    } else if (variance != null && !isWithinTolerance(invoice_amount!, observed_provider_amount!)) {
+      status = 'variance'
+    } else {
+      status = 'matched'
+    }
+
+    return {
+      source_id: s.id, name: s.name, provider: s.provider, month: win.key,
+      expected_amount, observed_provider_amount, invoice_amount, operationally_selected_amount,
+      variance, variance_reason, status,
+    }
+  })
+}

--- a/src/costops/schema.ts
+++ b/src/costops/schema.ts
@@ -1,0 +1,138 @@
+// CostOps schema -- ALL CostOps CREATE TABLE / ALTER TABLE / CREATE INDEX
+// statements live here, not in src/db.ts. This is the "schema" seam
+// (docs/fork-upstream-policy.md §2a): db.ts owns exactly one call,
+// `initCostOpsSchema(db)`, marked `// LOCAL-FORK: costops seam`. Every table
+// this feature has ever added (v0.1 through PR-B) is consolidated here,
+// verbatim, so the upstream-owned db.ts stops growing a table per CostOps
+// release. Idempotent by construction (CREATE TABLE IF NOT EXISTS, ALTER
+// TABLE wrapped in try/catch) -- calling this on an already-migrated DB is a
+// safe no-op, exactly like the individual statements were before the move.
+
+import type Database from 'better-sqlite3'
+import { initForecastSchema } from './forecast.js'
+import { initFxSchema } from './fx.js'
+
+export function initCostOpsSchema(db: Database.Database): void {
+  // CostOps v0.2: model/provider enrichment on the CORE token_usage table
+  // (not CostOps-owned, but this feature bolts 2 nullable columns onto it for
+  // token-cost estimation). Nullable + forward-only: NEW ingested rows carry
+  // the model from the transcript; existing rows stay NULL (unknown) -> left
+  // unpriced, never guessed. Must run after token_usage itself exists --
+  // db.ts calls initCostOpsSchema() after that table's own setup.
+  try { db.exec(`ALTER TABLE token_usage ADD COLUMN model TEXT`) } catch { /* column already exists */ }
+  try { db.exec(`ALTER TABLE token_usage ADD COLUMN provider TEXT`) } catch { /* column already exists */ }
+  try { db.exec(`ALTER TABLE token_usage ADD COLUMN model_source TEXT`) } catch { /* column already exists */ }
+  // --- CostOps (local cost ledger, v0.1) ---
+  // Read-mostly, FOCUS-inspired. cost_sources = provider/subscription origin,
+  // cost_line_items = individual charge rows (estimate or provider-sourced).
+  // No secrets/account IDs stored raw. Budgets are config-driven (costops/config.ts's
+  // BudgetEntry, from store/costops-config.json) -- there is deliberately no separate
+  // `budgets` DB table: an earlier draft of this schema had one, but it was never
+  // read from or written to (config.budgets was always the actual source), so it was
+  // a dead, unused second source of truth. Removed rather than wired up, since the
+  // config file already covers this fully and a DB table would just be a sync burden
+  // for no benefit.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cost_sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      source_type TEXT NOT NULL,
+      account_ref TEXT,
+      currency TEXT NOT NULL DEFAULT 'HUF',
+      active INTEGER NOT NULL DEFAULT 1,
+      notes TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cost_line_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_id TEXT NOT NULL REFERENCES cost_sources(id),
+      charge_period_start INTEGER NOT NULL,
+      charge_period_end INTEGER NOT NULL,
+      charge_category TEXT NOT NULL,
+      service_name TEXT,
+      usage_type TEXT,
+      consumed_quantity REAL,
+      consumed_unit TEXT,
+      billed_cost REAL NOT NULL,
+      effective_cost REAL,
+      currency TEXT NOT NULL DEFAULT 'HUF',
+      confidence TEXT NOT NULL,
+      data_freshness INTEGER NOT NULL,
+      source_ref TEXT,
+      dedup_key TEXT UNIQUE,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_period ON cost_line_items(charge_period_start, charge_period_end)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_source ON cost_line_items(source_id)`)
+  // Currency-retention (Phase-3 per spec): when a line's billed_cost is
+  // HUF-converted from a foreign-currency invoice, keep the original
+  // amount/currency/fx_rate/fx_date alongside it so the UI can show "11.15 USD ->
+  // 4014 HUF" instead of just the converted number. NULL for lines that were never
+  // converted (already-HUF entries) -- never fabricated, no existing calc touched.
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN original_amount REAL`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN original_currency TEXT`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN fx_rate REAL`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN fx_date INTEGER`) } catch { /* already exists */ }
+  // v0.8: distinguishes "we queried the provider API live" (provider_api) from
+  // "we read an email invoice" (email_invoice) from "config-driven fixed cost" (manual_entry) --
+  // neither `confidence` (the priority/authoritativeness axis) nor `cost_sources.source_type`
+  // (a category axis) cleanly carries this. Nullable, no default: every write site sets it
+  // explicitly; a NULL row (pre-migration history) falls back to 'no_data' at read time, never guessed.
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN actual_source TEXT`) } catch { /* already exists */ }
+  // CostOps Phase 0: a financial ledger row must never silently disappear --
+  // void/archive instead of hard DELETE, so a mistaken/superseded manual entry
+  // stays auditable. NULL = active (the overwhelming majority of rows, including
+  // all pre-Phase-0 history); every read path that aggregates cost_line_items
+  // must filter `voided_at IS NULL`.
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN voided_at INTEGER`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN void_reason TEXT`) } catch { /* already exists */ }
+  // A correction voids the wrong row AND inserts a new row pointing back at it
+  // via corrects_line_id, so "what replaced this, and why" stays traceable
+  // instead of two unrelated void+POST rows correlated only by matching
+  // source_id/month/timing. See correction.ts.
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN corrects_line_id INTEGER REFERENCES cost_line_items(id)`) } catch { /* already exists */ }
+  // Phase 1 (GAP-09): fx_source/conversion_method columns + fx_rates table
+  initFxSchema(db)
+  // Phase 1 (GAP-10): forecast_snapshots table
+  initForecastSchema(db)
+  // CostOps v0.3: provider cost-collector run history / sync status. No raw
+  // account id, no raw API response, no secret ever stored here.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS import_runs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      collector_name TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      finished_at INTEGER,
+      status TEXT NOT NULL,
+      period_start INTEGER,
+      period_end INTEGER,
+      imported_count INTEGER NOT NULL DEFAULT 0,
+      error_code TEXT,
+      error_message_sanitized TEXT,
+      data_freshness_at INTEGER
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_import_runs_provider ON import_runs(provider, started_at)`)
+  // v0.5: sanitized per-run detail (service_count, plan breakdown, not_covered) as JSON.
+  // NO raw service/account IDs -- the breakdown carries only type/plan labels + counts.
+  try { db.exec(`ALTER TABLE import_runs ADD COLUMN detail_json TEXT`) } catch { /* already exists */ }
+  // CostOps: provider prepaid-balance snapshots. For prepaid providers (e.g.
+  // DeepSeek) that expose remaining balance but not per-period cost, MTD spend
+  // is derived from the balance DROP across snapshots. No secret, no raw id.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS provider_balance_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      currency TEXT NOT NULL,
+      balance REAL NOT NULL,
+      captured_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_balance_snapshots_provider ON provider_balance_snapshots(provider, captured_at)`)
+}

--- a/src/costops/schema.ts
+++ b/src/costops/schema.ts
@@ -1,7 +1,7 @@
 // CostOps schema -- ALL CostOps CREATE TABLE / ALTER TABLE / CREATE INDEX
-// statements live here, not in src/db.ts. This is the "schema" seam
-// (docs/fork-upstream-policy.md §2a): db.ts owns exactly one call,
-// `initCostOpsSchema(db)`, marked `// LOCAL-FORK: costops seam`. Every table
+// statements live here, not in src/db.ts. This is the "schema" seam: db.ts
+// owns exactly one call, `initCostOpsSchema(db)`, marked
+// `// LOCAL-FORK: costops seam`. Every table
 // this feature has ever added (v0.1 through PR-B) is consolidated here,
 // verbatim, so the upstream-owned db.ts stops growing a table per CostOps
 // release. Idempotent by construction (CREATE TABLE IF NOT EXISTS, ALTER

--- a/src/db.ts
+++ b/src/db.ts
@@ -973,6 +973,9 @@ export function initDatabase(dbPathOverride?: string): void {
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_import_runs_provider ON import_runs(provider, started_at)`)
+  // v0.5: sanitized per-run detail (service_count, plan breakdown, not_covered) as JSON.
+  // NO raw service/account IDs -- the breakdown carries only type/plan labels + counts.
+  try { db.exec(`ALTER TABLE import_runs ADD COLUMN detail_json TEXT`) } catch { /* already exists */ }
   db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_name ON vault_ssh_servers(name)`)
   // Migrations for installs that ran earlier schema versions. MUST run before
   // the ssh_key_id index below: on an install where vault_ssh_servers already

--- a/src/db.ts
+++ b/src/db.ts
@@ -722,6 +722,8 @@ export function initDatabase(dbPathOverride?: string): void {
   // Migrations for columns added after initial release
   try { db.exec('ALTER TABLE token_usage ADD COLUMN thinking_tokens INTEGER NOT NULL DEFAULT 0') } catch { /* already exists */ }
   try { db.exec('ALTER TABLE token_usage ADD COLUMN model TEXT') } catch { /* already exists */ }
+  try { db.exec('ALTER TABLE token_usage ADD COLUMN provider TEXT') } catch { /* already exists */ }
+  try { db.exec('ALTER TABLE token_usage ADD COLUMN model_source TEXT') } catch { /* already exists */ }
 
   // Deduplicate existing rows before creating unique index
   try {

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,6 +5,7 @@ import { STORE_DIR, DB_FILENAME, ALLOWED_CHAT_ID, OLLAMA_URL, APP_TZ } from './c
 import { getEffectiveSettingValue } from './settings-store.js'
 import { logger } from './logger.js'
 import { TOOL_TIMEOUTS } from './tool-timeouts.js'
+import { initCostOpsSchema } from './costops/schema.js'
 
 let db: Database.Database
 // The path the CURRENT handle was opened on (null for ':memory:'). Kept so
@@ -721,9 +722,6 @@ export function initDatabase(dbPathOverride?: string): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_agent_ts ON token_usage(agent, timestamp)`)
   // Migrations for columns added after initial release
   try { db.exec('ALTER TABLE token_usage ADD COLUMN thinking_tokens INTEGER NOT NULL DEFAULT 0') } catch { /* already exists */ }
-  try { db.exec('ALTER TABLE token_usage ADD COLUMN model TEXT') } catch { /* already exists */ }
-  try { db.exec('ALTER TABLE token_usage ADD COLUMN provider TEXT') } catch { /* already exists */ }
-  try { db.exec('ALTER TABLE token_usage ADD COLUMN model_source TEXT') } catch { /* already exists */ }
 
   // Deduplicate existing rows before creating unique index
   try {
@@ -879,53 +877,11 @@ export function initDatabase(dbPathOverride?: string): void {
   // Migration: add agent column to installs that created the table before this column existed.
   try { db.exec(`ALTER TABLE store_file_audit ADD COLUMN agent TEXT`) } catch { /* column already exists */ }
 
-  // --- CostOps (local cost ledger) ---
-  // Read-mostly, FOCUS-inspired. cost_sources = provider/subscription origin,
-  // cost_line_items = individual charge rows (estimate or provider-sourced).
-  // No secrets/account IDs stored raw. Budgets are config-driven (costops/config.ts's
-  // BudgetEntry, from store/costops-config.json) -- there is deliberately no separate
-  // `budgets` DB table: an earlier draft of this schema had one, but it was never
-  // read from or written to (config.budgets was always the actual source), so it was
-  // a dead, unused second source of truth. Removed rather than wired up, since the
-  // config file already covers this fully and a DB table would just be a sync burden
-  // for no benefit.
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS cost_sources (
-      id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      provider TEXT NOT NULL,
-      source_type TEXT NOT NULL,
-      account_ref TEXT,
-      currency TEXT NOT NULL DEFAULT 'HUF',
-      active INTEGER NOT NULL DEFAULT 1,
-      notes TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `)
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS cost_line_items (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      source_id TEXT NOT NULL REFERENCES cost_sources(id),
-      charge_period_start INTEGER NOT NULL,
-      charge_period_end INTEGER NOT NULL,
-      charge_category TEXT NOT NULL,
-      service_name TEXT,
-      usage_type TEXT,
-      consumed_quantity REAL,
-      consumed_unit TEXT,
-      billed_cost REAL NOT NULL,
-      effective_cost REAL,
-      currency TEXT NOT NULL DEFAULT 'HUF',
-      confidence TEXT NOT NULL,
-      data_freshness INTEGER NOT NULL,
-      source_ref TEXT,
-      dedup_key TEXT UNIQUE,
-      created_at INTEGER NOT NULL
-    )
-  `)
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_period ON cost_line_items(charge_period_start, charge_period_end)`)
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_source ON cost_line_items(source_id)`)
+  // LOCAL-FORK: costops seam (keep on rebase). All CostOps tables/columns/
+  // indexes live in src/costops/schema.ts's initCostOpsSchema(), not here --
+  // see docs/fork-upstream-policy.md §2a. This one call is the entire
+  // upstream-file footprint of the CostOps schema.
+  initCostOpsSchema(db)
 
   // --- Vault SSH Keys (shared pool) ---
   db.exec(`
@@ -956,41 +912,6 @@ export function initDatabase(dbPathOverride?: string): void {
       updated_at INTEGER NOT NULL
     )
   `)
-  // CostOps v0.3: provider cost-collector run history / sync status. No raw
-  // account id, no raw API response, no secret ever stored here.
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS import_runs (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      provider TEXT NOT NULL,
-      collector_name TEXT NOT NULL,
-      started_at INTEGER NOT NULL,
-      finished_at INTEGER,
-      status TEXT NOT NULL,
-      period_start INTEGER,
-      period_end INTEGER,
-      imported_count INTEGER NOT NULL DEFAULT 0,
-      error_code TEXT,
-      error_message_sanitized TEXT,
-      data_freshness_at INTEGER
-    )
-  `)
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_import_runs_provider ON import_runs(provider, started_at)`)
-  // v0.5: sanitized per-run detail (service_count, plan breakdown, not_covered) as JSON.
-  // NO raw service/account IDs -- the breakdown carries only type/plan labels + counts.
-  try { db.exec(`ALTER TABLE import_runs ADD COLUMN detail_json TEXT`) } catch { /* already exists */ }
-  // CostOps: provider prepaid-balance snapshots. For prepaid providers (e.g.
-  // DeepSeek) that expose remaining balance but not per-period cost, MTD spend
-  // is derived from the balance DROP across snapshots. No secret, no raw id.
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS provider_balance_snapshots (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      provider TEXT NOT NULL,
-      currency TEXT NOT NULL,
-      balance REAL NOT NULL,
-      captured_at INTEGER NOT NULL
-    )
-  `)
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_balance_snapshots_provider ON provider_balance_snapshots(provider, captured_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_name ON vault_ssh_servers(name)`)
   // Migrations for installs that ran earlier schema versions. MUST run before
   // the ssh_key_id index below: on an install where vault_ssh_servers already

--- a/src/db.ts
+++ b/src/db.ts
@@ -878,9 +878,9 @@ export function initDatabase(dbPathOverride?: string): void {
   try { db.exec(`ALTER TABLE store_file_audit ADD COLUMN agent TEXT`) } catch { /* column already exists */ }
 
   // LOCAL-FORK: costops seam (keep on rebase). All CostOps tables/columns/
-  // indexes live in src/costops/schema.ts's initCostOpsSchema(), not here --
-  // see docs/fork-upstream-policy.md §2a. This one call is the entire
-  // upstream-file footprint of the CostOps schema.
+  // indexes live in src/costops/schema.ts's initCostOpsSchema(), not here, so
+  // this file gains one line instead of a table per CostOps release. This one
+  // call is the entire footprint of the CostOps schema in db.ts.
   initCostOpsSchema(db)
 
   // --- Vault SSH Keys (shared pool) ---

--- a/src/db.ts
+++ b/src/db.ts
@@ -976,6 +976,19 @@ export function initDatabase(dbPathOverride?: string): void {
   // v0.5: sanitized per-run detail (service_count, plan breakdown, not_covered) as JSON.
   // NO raw service/account IDs -- the breakdown carries only type/plan labels + counts.
   try { db.exec(`ALTER TABLE import_runs ADD COLUMN detail_json TEXT`) } catch { /* already exists */ }
+  // CostOps: provider prepaid-balance snapshots. For prepaid providers (e.g.
+  // DeepSeek) that expose remaining balance but not per-period cost, MTD spend
+  // is derived from the balance DROP across snapshots. No secret, no raw id.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS provider_balance_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      currency TEXT NOT NULL,
+      balance REAL NOT NULL,
+      captured_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_balance_snapshots_provider ON provider_balance_snapshots(provider, captured_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_name ON vault_ssh_servers(name)`)
   // Migrations for installs that ran earlier schema versions. MUST run before
   // the ssh_key_id index below: on an install where vault_ssh_servers already

--- a/src/db.ts
+++ b/src/db.ts
@@ -954,6 +954,25 @@ export function initDatabase(dbPathOverride?: string): void {
       updated_at INTEGER NOT NULL
     )
   `)
+  // CostOps v0.3: provider cost-collector run history / sync status. No raw
+  // account id, no raw API response, no secret ever stored here.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS import_runs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      collector_name TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      finished_at INTEGER,
+      status TEXT NOT NULL,
+      period_start INTEGER,
+      period_end INTEGER,
+      imported_count INTEGER NOT NULL DEFAULT 0,
+      error_code TEXT,
+      error_message_sanitized TEXT,
+      data_freshness_at INTEGER
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_import_runs_provider ON import_runs(provider, started_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_name ON vault_ssh_servers(name)`)
   // Migrations for installs that ran earlier schema versions. MUST run before
   // the ssh_key_id index below: on an install where vault_ssh_servers already

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -51,6 +51,23 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     return true
   }
 
+  // v0.5: sync spine -- run the Render collector LIVE (read-only GET) + idempotent import.
+  // Bearer-gated (like every /api/*). NO provider-side write; same-month re-run is idempotent.
+  if (path === '/api/costs/sync' && method === 'POST') {
+    try {
+      const provider = url.searchParams.get('provider') || 'render'
+      if (provider !== 'render') { json(res, { error: 'only provider=render is supported in v0.5' }, 400); return true }
+      const { syncRenderCollector } = await import('../../costops/collectors/render.js')
+      const now = Math.floor(Date.now() / 1000)
+      const result = await syncRenderCollector(getDb(), now)
+      json(res, result, result.ok ? 200 : 502)
+    } catch (err) {
+      logger.error({ err }, 'CostOps sync failed')
+      json(res, { ok: false, error: 'sync failed' }, 500)
+    }
+    return true
+  }
+
   if (path === '/api/costs/sources' && method === 'GET') {
     try {
       json(res, getCostSources(getDb()))

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -56,10 +56,23 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
   if (path === '/api/costs/sync' && method === 'POST') {
     try {
       const provider = url.searchParams.get('provider') || 'render'
-      if (provider !== 'render') { json(res, { error: 'only provider=render is supported in v0.5' }, 400); return true }
-      const { syncRenderCollector } = await import('../../costops/collectors/render.js')
       const now = Math.floor(Date.now() / 1000)
-      const result = await syncRenderCollector(getDb(), now)
+      const db = getDb()
+      let result: { ok: boolean }
+      if (provider === 'render') {
+        const { syncRenderCollector } = await import('../../costops/collectors/render.js')
+        result = await syncRenderCollector(db, now)
+      } else if (provider === 'openai') {
+        // LIVE read-only OpenAI Costs API sync; admin key pulled from the Vault, never logged.
+        const { syncOpenAiCollector } = await import('../../costops/collectors/openai.js')
+        result = await syncOpenAiCollector(db, now)
+      } else if (provider === 'github') {
+        // LIVE read-only GitHub billing usage sync; PAT pulled from the Vault, never logged.
+        const { syncGitHubCollector } = await import('../../costops/collectors/github.js')
+        result = await syncGitHubCollector(db, now)
+      } else {
+        json(res, { error: `unsupported provider '${provider}' (supported: render, openai, github)` }, 400); return true
+      }
       json(res, result, result.ok ? 200 : 502)
     } catch (err) {
       logger.error({ err }, 'CostOps sync failed')

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -70,8 +70,12 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
         // LIVE read-only GitHub billing usage sync; PAT pulled from the Vault, never logged.
         const { syncGitHubCollector } = await import('../../costops/collectors/github.js')
         result = await syncGitHubCollector(db, now)
+      } else if (provider === 'deepseek') {
+        // LIVE read-only DeepSeek prepaid-balance sync; key from the Vault, never logged.
+        const { syncDeepSeekBalance } = await import('../../costops/collectors/deepseek.js')
+        result = await syncDeepSeekBalance(db, now)
       } else {
-        json(res, { error: `unsupported provider '${provider}' (supported: render, openai, github)` }, 400); return true
+        json(res, { error: `unsupported provider '${provider}' (supported: render, openai, github, deepseek)` }, 400); return true
       }
       json(res, result, result.ok ? 200 : 502)
     } catch (err) {

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -4,7 +4,7 @@
 // startCostsSyncTask() below (called once at server boot), not as a side effect
 // of a client request. No LLM, no provider API, no secrets in the response.
 
-import { json } from '../http-helpers.js'
+import { json, readBody } from '../http-helpers.js'
 import { logger } from '../../logger.js'
 import { getDb } from '../../db.js'
 import { loadCostopsConfig } from '../../costops/config.js'
@@ -81,6 +81,25 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     } catch (err) {
       logger.error({ err }, 'CostOps sync failed')
       json(res, { ok: false, error: 'sync failed' }, 500)
+    }
+    return true
+  }
+
+  // Email-sourced cost ingest: an agent-side Gmail sweep POSTs structured receipt
+  // entries here. Idempotent per (email, month). No raw email content is stored.
+  if (path === '/api/costs/email-ingest' && method === 'POST') {
+    try {
+      const body = await readBody(ctx.req) as { entries?: unknown }
+      const entries = Array.isArray(body?.entries) ? body.entries : []
+      const now = Math.floor(Date.now() / 1000)
+      let fxUsdHuf = 0
+      try { const { loadRenderPricing } = await import('../../costops/collectors/render.js'); fxUsdHuf = loadRenderPricing().pricing.fx_usd_huf || 0 } catch { /* fx 0 -> USD entries flagged */ }
+      const { ingestEmailCosts } = await import('../../costops/email-ingest.js')
+      const result = ingestEmailCosts(getDb(), entries as import('../../costops/email-ingest.js').EmailCostEntry[], { fxUsdHuf, now })
+      json(res, { ok: result.errors.length === 0, ...result })
+    } catch (err) {
+      logger.error({ err }, 'CostOps email-ingest failed')
+      json(res, { ok: false, error: 'email-ingest failed' }, 500)
     }
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -10151,6 +10151,32 @@ async function loadStatus() {
 // ============================================================
 
 document.getElementById('refreshCostsBtn').addEventListener('click', loadCosts)
+document.getElementById('costsSyncBtn').addEventListener('click', costopsSyncNow)
+
+// v0.5 sync spine: kick the Render collector (read-only on the provider side,
+// idempotent import on ours), then re-render. No Authorization header is built
+// here on purpose -- window.fetch is wrapped near the top of this file and
+// already attaches the Bearer token to every same-origin /api/ call.
+async function costopsSyncNow() {
+  const btn = document.getElementById('costsSyncBtn')
+  const status = document.getElementById('costsSyncStatus')
+  btn.disabled = true
+  if (status) status.textContent = t('costs.sync_running')
+  try {
+    const res = await fetch('/api/costs/sync?provider=render', { method: 'POST' })
+    const d = await res.json().catch(() => ({}))
+    if (status) {
+      status.textContent = res.ok && d?.ok
+        ? t('costs.sync_ok', { count: d.service_count ?? d.imported_count ?? 0 })
+        : t('costs.sync_failed', { error: String(d?.error || res.status) })
+    }
+  } catch (err) {
+    if (status) status.textContent = t('costs.sync_failed', { error: t('costs.sync_network_error') })
+  } finally {
+    btn.disabled = false
+  }
+  await loadCosts()
+}
 
 async function loadCosts() {
   const el = document.getElementById('costsContent')
@@ -10198,6 +10224,41 @@ async function loadCosts() {
           <td style="padding:6px 8px">${fmtMoney(src.spend)}</td>
         </tr>`).join('')}</tbody>
       </table></div>`
+    }
+
+    // v0.5: provider sync freshness. Rendered only once a collector has run, so
+    // an install that never syncs looks exactly as it did before this section.
+    const syncRows = Array.isArray(s.provider_sync) ? s.provider_sync : []
+    if (syncRows.length > 0) {
+      const fmtTs = (ts) => (ts ? new Date(ts * 1000).toLocaleString('hu-HU') : '-')
+      const statusLabel = (row) => {
+        if (row.status === 'failed') return { text: t('costs.sync_status_failed') + (row.error_code ? ' (' + escapeHtml(row.error_code) + ')' : ''), color: 'var(--danger,#e74c3c)' }
+        if (row.status === 'stale') return { text: t('costs.sync_status_stale'), color: 'var(--warn,#e0a800)' }
+        return { text: t('costs.sync_status_ok'), color: 'var(--text-muted)' }
+      }
+      html += `<div style="margin-top:24px">
+        <div style="font-weight:600;margin-bottom:6px">${t('costs.sync_section_title')}</div>
+        <div style="${mutedStyle};margin-bottom:8px">${t('costs.sync_section_note')}</div>
+        <div style="overflow-x:auto"><table style="width:100%;border-collapse:collapse">
+          <thead><tr style="text-align:left;border-bottom:1px solid var(--border,#333)">
+            <th style="padding:6px 8px">${t('costs.source_provider')}</th>
+            <th style="padding:6px 8px">${t('costs.sync_col_status')}</th>
+            <th style="padding:6px 8px">${t('costs.sync_col_imported')}</th>
+            <th style="padding:6px 8px">${t('costs.sync_col_last_success')}</th>
+            <th style="padding:6px 8px">${t('costs.sync_col_last_failure')}</th>
+          </tr></thead>
+          <tbody>${syncRows.map((row) => {
+            const st = statusLabel(row)
+            return `<tr style="border-bottom:1px solid var(--border,#222)">
+              <td style="padding:6px 8px">${escapeHtml(row.provider)}</td>
+              <td style="padding:6px 8px;color:${st.color}">${st.text}</td>
+              <td style="padding:6px 8px">${Number(row.imported_count) || 0}</td>
+              <td style="padding:6px 8px;${mutedStyle}">${escapeHtml(fmtTs(row.last_success))}</td>
+              <td style="padding:6px 8px;${mutedStyle}">${escapeHtml(fmtTs(row.last_failed))}</td>
+            </tr>`
+          }).join('')}</tbody>
+        </table></div>
+      </div>`
     }
 
     html += `<p style="${mutedStyle};margin-top:16px">${t('costs.token_usage_note')} (${(s.token_usage?.calls ?? 0)} ${t('costs.calls')}, ${(s.token_usage?.input_tokens ?? 0) + (s.token_usage?.output_tokens ?? 0)} tokens)</p>`

--- a/web/index.html
+++ b/web/index.html
@@ -1914,12 +1914,18 @@
             <h1 data-i18n="costs.page_title">Költségek</h1>
             <p class="subtitle" data-i18n="costs.page_subtitle">Havi költség-összefoglaló a helyi konfigurációból</p>
           </div>
-          <button class="btn-secondary btn-compact" id="refreshCostsBtn" data-i18n="common.btn.refresh">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
-            </svg>
-            Frissítés
-          </button>
+          <div class="header-actions">
+            <span id="costsSyncStatus" class="subtitle"></span>
+            <button class="btn-secondary btn-compact" id="costsSyncBtn" data-i18n="costs.sync_btn">
+              Provider szinkron
+            </button>
+            <button class="btn-secondary btn-compact" id="refreshCostsBtn" data-i18n="common.btn.refresh">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+              </svg>
+              Frissítés
+            </button>
+          </div>
         </div>
       </div>
 

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -655,6 +655,22 @@ window._i18n.en = {
   'costs.token_usage_note':      'Token usage volume (not priced)',
   'costs.calls':                 'calls',
 
+  // --- Costs: provider sync spine (v0.5) ---
+  'costs.sync_btn':              'Sync providers',
+  'costs.sync_running':          'Sync running...',
+  'costs.sync_ok':               'Sync finished ({count} units).',
+  'costs.sync_failed':           'Sync failed: {error}',
+  'costs.sync_network_error':    'network error',
+  'costs.sync_section_title':    'Provider sync',
+  'costs.sync_section_note':     'Read-only on the provider side; re-importing the same period is idempotent, so nothing is double counted.',
+  'costs.sync_col_status':       'Status',
+  'costs.sync_col_imported':     'Imported items',
+  'costs.sync_col_last_success': 'Last success',
+  'costs.sync_col_last_failure': 'Last failure',
+  'costs.sync_status_ok':        'ok',
+  'costs.sync_status_stale':     'stale',
+  'costs.sync_status_failed':    'failed',
+
   'tokenUsage.col.time':         'Time',
   'tokenUsage.col.agent':        'Agent',
   'tokenUsage.col.content':      'Content',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -920,6 +920,22 @@ window._i18n.hu = {
   'costs.token_usage_note':      'Token-felhasználás mennyisége (nincs árazva)',
   'costs.calls':                 'hívás',
 
+  // --- Costs: provider sync spine (v0.5) ---
+  'costs.sync_btn':              'Provider szinkron',
+  'costs.sync_running':          'Szinkron fut...',
+  'costs.sync_ok':               'Szinkron kész ({count} egység).',
+  'costs.sync_failed':           'Szinkron sikertelen: {error}',
+  'costs.sync_network_error':    'hálózati hiba',
+  'costs.sync_section_title':    'Provider szinkron',
+  'costs.sync_section_note':     'A provider oldalán csak olvasunk; az import ugyanarra az időszakra ismételhető, nem duplázódik.',
+  'costs.sync_col_status':       'Állapot',
+  'costs.sync_col_imported':     'Importált tételek',
+  'costs.sync_col_last_success': 'Utolsó sikeres',
+  'costs.sync_col_last_failure': 'Utolsó hiba',
+  'costs.sync_status_ok':        'rendben',
+  'costs.sync_status_stale':     'elavult',
+  'costs.sync_status_failed':    'sikertelen',
+
   'tokenUsage.col.time':         'Idő',
   'tokenUsage.col.agent':        'Ágens',
   'tokenUsage.col.content':      'Tartalom',


### PR DESCRIPTION
## Summary

Second slice of the CostOps series, building on the merged ledger base (#524, v1.22.2). Two layers, staged together because the second is thin without the first:

**Provider collector framework + collectors (read-only)**
- `src/costops/collectors/` — `types/config/runner` framework + Render, Anthropic, OpenAI, GitHub, DeepSeek, Codex collectors. All read-only, vault/env-keyed, no credential stored in repo (example configs only: `*.example.json`).
- `email-ingest.ts` — idempotent invoice ingest (real invoice supersedes `provider_plan_estimate`, no double count).
- `import-durability.ts` + `import_runs` table — per-provider sync state, freshness, failure taxonomy.
- API sync spine in `web/routes/costs.ts` (`/api/costs/sync`, freshness/sync-state in summary).

**Forecast + FX + accounting-core**
- `forecast.ts` / `forecast-capture.ts` — deterministic month-end projection + snapshotting.
- `fx.ts` — `fx_rates` table + `fx_source`/`conversion_method` columns; no live FX call, rates are data.
- `reconciliation.ts` / `correction.ts` — correction line-items linked via `corrects_line_id`, original amount/currency preserved.

## Safety / compatibility

- **Additive schema only** — every table/column is `CREATE TABLE IF NOT EXISTS` / guarded `ALTER TABLE ADD COLUMN` via the existing `initCostOpsSchema` seam. No migration, no behavior change without a local CostOps config.
- **No secrets** — collectors read keys from the deployment-local vault/env at runtime; the repo carries example configs only.
- **No scheduled tasks armed** by this slice; sync is an explicit Bearer-gated endpoint.
- Genericized: no operator/brand hardcodes (owner + billing user come from env).

## Tests / build

- Full suite on this branch: **147 files, 1987 passed / 1 skipped, 0 failed**.
- `npm run build` (tsc): **clean**.
- Slice's own tests standalone-green: `costops-{collectors,collectors-dryrun,render,openai,github,deepseek,email-ingest,sync,operational,pricing,forecast,forecast-capture,fx,reconciliation,correction}`.

## Series context

Remaining staged slices (alerts/budgets, period-close/export/invoice, optimization advisor, UI command center) follow as separate PRs once this lands — same additive rules, each standalone-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
