### PR TITLE
fix(auth): bootcamp token-handling hardening (onboarding-gate re-seed, fleet-token lifecycle, verify-first wizard)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -746,6 +746,17 @@ if [ -n "${CLAUDE_AUTH_ENV_LINE:-}" ]; then
   echo "$CLAUDE_AUTH_ENV_LINE" >> "$INSTALL_DIR/.env"
 fi
 chmod 600 "$INSTALL_DIR/.env"
+# Fleet setup-token file: per-agent config-dir isolation and the credentials
+# guard are BOTH gated on store/.claude-oauth-token; without it every
+# sub-agent silently falls back to the shared rotating
+# ~/.claude/.credentials.json (2026-07-15 bootcamp bug family). Parity with
+# the dashboard wizard (/api/onboarding/claude-auth) and scripts/auth.sh.
+if [ -n "${OAUTH_TOKEN_INPUT:-}" ]; then
+  mkdir -p "$INSTALL_DIR/store"
+  printf '%s' "$OAUTH_TOKEN_INPUT" > "$INSTALL_DIR/store/.claude-oauth-token"
+  chmod 600 "$INSTALL_DIR/store/.claude-oauth-token"
+  ok "Fleet setup-token eltarolva (store/.claude-oauth-token) -- per-agent izolacio aktiv"
+fi
 ok ".env letrehozva (chmod 600)"
 
 # CLAUDE.md generalasa template-bol

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -751,10 +751,11 @@ chmod 600 "$INSTALL_DIR/.env"
 # sub-agent silently falls back to the shared rotating
 # ~/.claude/.credentials.json (2026-07-15 bootcamp bug family). Parity with
 # the dashboard wizard (/api/onboarding/claude-auth) and scripts/auth.sh.
-if [ -n "${OAUTH_TOKEN_INPUT:-}" ]; then
+# Shape-gated (a garbage paste must not poison every sub-agent launch) and
+# written under umask 077 (no 644 window before a chmod).
+if [ -n "${OAUTH_TOKEN_INPUT:-}" ] && printf '%s' "$OAUTH_TOKEN_INPUT" | grep -Eq '^sk-ant-oat01-[A-Za-z0-9_-]{40,}$'; then
   mkdir -p "$INSTALL_DIR/store"
-  printf '%s' "$OAUTH_TOKEN_INPUT" > "$INSTALL_DIR/store/.claude-oauth-token"
-  chmod 600 "$INSTALL_DIR/store/.claude-oauth-token"
+  (umask 077 && printf '%s' "$OAUTH_TOKEN_INPUT" > "$INSTALL_DIR/store/.claude-oauth-token")
   ok "Fleet setup-token eltarolva (store/.claude-oauth-token) -- per-agent izolacio aktiv"
 fi
 ok ".env letrehozva (chmod 600)"

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -274,6 +274,30 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
 fi
 unset _node_bin
 
+# Re-seed hasCompletedOnboarding in the SHARED ~/.claude.json BEFORE launching
+# the main claude. If the key was lost (2026-07-15 bootcamp incident), the
+# fresh TUI parks on the first-run "Select login method" picker -- and the
+# first-run guard below would blindly Enter it into a browser sign-in screen
+# no headless box can complete. Atomic tmp+rename; an unparseable file is left
+# for Claude Code to recover. Mirrors ensureSharedClaudeOnboarded() (the
+# in-process respawn paths); this covers the channels.sh cold-boot path.
+if command -v node >/dev/null 2>&1; then
+  node -e '
+    const fs = require("fs")
+    const p = require("path").join(require("os").homedir(), ".claude.json")
+    try {
+      let j = {}
+      if (fs.existsSync(p)) j = JSON.parse(fs.readFileSync(p, "utf-8"))
+      if (j.hasCompletedOnboarding !== true) {
+        j.hasCompletedOnboarding = true
+        const t = p + ".tmp-" + process.pid
+        fs.writeFileSync(t, JSON.stringify(j, null, 2) + "\n", { mode: 0o600 })
+        fs.renameSync(t, p)
+      }
+    } catch (e) { /* unparseable/unwritable: leave for Claude Code */ }
+  ' 2>/dev/null || true
+fi
+
 # Régi session takarítás
 $TMUX kill-session -t "$SESSION" 2>/dev/null
 

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -31,6 +31,14 @@ if [ -f "$INSTALL_DIR/.env" ]; then
   _api_key="$(grep -E '^ANTHROPIC_API_KEY=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
   [ -n "$_api_key" ] && export ANTHROPIC_API_KEY="$_api_key"
   _oauth="$(grep -E '^CLAUDE_CODE_OAUTH_TOKEN=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
+  # Fallback: the fleet setup-token file (written by the wizard / auth.sh /
+  # the boot-time credentials sync). Keeps the MAIN agent on the same stable
+  # token the sub-agents launch with, instead of the rotating
+  # ~/.claude/.credentials.json, even when .env carries no auth key
+  # (2026-07-15 bootcamp: terminal-pasted setup-token never reached .env).
+  if [ -z "$_oauth" ] && [ -s "$INSTALL_DIR/store/.claude-oauth-token" ]; then
+    _oauth="$(cat "$INSTALL_DIR/store/.claude-oauth-token")"
+  fi
   [ -n "$_oauth" ] && export CLAUDE_CODE_OAUTH_TOKEN="$_oauth"
   unset _api_key _oauth
 fi

--- a/src/__tests__/channel-deafness-recovery.test.ts
+++ b/src/__tests__/channel-deafness-recovery.test.ts
@@ -50,6 +50,28 @@ describe('buildMainSessionRespawnCmd', () => {
     expect(buildMainSessionRespawnCmd({ ...base, continueSession: true })).toContain('--continue')
     expect(buildMainSessionRespawnCmd({ ...base, continueSession: false })).not.toContain('--continue')
   })
+
+  // 2026-07-15 bootcamp bug 2 latent path: on Linux isolatedConfigDir is always
+  // null, so a wizard-entered fleet token NEVER reached a respawned main
+  // session -- it silently fell back to ~/.claude/.credentials.json. The
+  // fleetToken leg closes that: token export WITHOUT a config-dir override.
+  it('exports the fleet token (no CLAUDE_CONFIG_DIR) when fleetToken is set and isolation is off', () => {
+    const cmd = buildMainSessionRespawnCmd({ ...base, continueSession: false, fleetToken: true })
+    expect(cmd).toContain('export CLAUDE_CODE_OAUTH_TOKEN="$(cat ')
+    expect(cmd).not.toContain('CLAUDE_CONFIG_DIR')
+  })
+
+  it('exports BOTH the isolated config dir and the token when isolation is on (unchanged macOS contract)', () => {
+    const cmd = buildMainSessionRespawnCmd({ ...base, continueSession: false, isolatedConfigDir: '/tmp/iso', fleetToken: true })
+    expect(cmd).toContain("export CLAUDE_CONFIG_DIR='/tmp/iso'")
+    expect(cmd).toContain('export CLAUDE_CODE_OAUTH_TOKEN="$(cat ')
+  })
+
+  it('exports no auth env at all without a fleet token or isolation (unchanged legacy contract)', () => {
+    const cmd = buildMainSessionRespawnCmd({ ...base, continueSession: false })
+    expect(cmd).not.toContain('CLAUDE_CODE_OAUTH_TOKEN')
+    expect(cmd).not.toContain('CLAUDE_CONFIG_DIR')
+  })
 })
 
 // CONTRACT: the post-resume guard (CC 2.1.193) escalates to a fresh respawn iff

--- a/src/__tests__/claude-credentials-guard.test.ts
+++ b/src/__tests__/claude-credentials-guard.test.ts
@@ -78,3 +78,78 @@ describe('renameSharedCredentialsIfSafe (flag/platform gates, no fs mutation)', 
     }
   })
 })
+
+// 2026-07-16 review blocker 1: the sk-ant-oat01 prefix ALONE does not
+// discriminate a long-lived setup-token from a rotating browser-login access
+// token (both can carry it). Promotion must be longevity-gated, or the boot
+// sync would flip healthy rotating-login installs into env-token mode and
+// self-inflict the bootcamp incident when the token rotates.
+describe('isPromotableSetupCredential', () => {
+  const NOW = 1_784_000_000_000
+  const DAY = 24 * 60 * 60 * 1000
+  const oat = 'sk-ant-oat01-' + 'A'.repeat(80)
+
+  it('promotes the bootcamp shape: oat01 + ~1-year expiry (refreshToken presence is irrelevant)', async () => {
+    const { isPromotableSetupCredential } = await import('../web/claude-credentials-guard.js')
+    expect(isPromotableSetupCredential({ accessToken: oat, expiresAt: NOW + 365 * DAY }, NOW)).toBe(true)
+  })
+
+  it('REJECTS a rotating-family oat01 with short expiry (hours/days)', async () => {
+    const { isPromotableSetupCredential } = await import('../web/claude-credentials-guard.js')
+    expect(isPromotableSetupCredential({ accessToken: oat, expiresAt: NOW + 8 * 60 * 60 * 1000 }, NOW)).toBe(false)
+    expect(isPromotableSetupCredential({ accessToken: oat, expiresAt: NOW + 30 * DAY }, NOW)).toBe(false)
+  })
+
+  it('rejects at exactly the boundary minus one, accepts at the 90-day boundary', async () => {
+    const { isPromotableSetupCredential, MIN_PROMOTABLE_LIFETIME_MS } = await import('../web/claude-credentials-guard.js')
+    expect(isPromotableSetupCredential({ accessToken: oat, expiresAt: NOW + MIN_PROMOTABLE_LIFETIME_MS }, NOW)).toBe(true)
+    expect(isPromotableSetupCredential({ accessToken: oat, expiresAt: NOW + MIN_PROMOTABLE_LIFETIME_MS - 1 }, NOW)).toBe(false)
+  })
+
+  it('rejects a non-setup-token prefix and a missing/absent expiresAt (conservative)', async () => {
+    const { isPromotableSetupCredential } = await import('../web/claude-credentials-guard.js')
+    expect(isPromotableSetupCredential({ accessToken: 'sk-ant-sid01-' + 'A'.repeat(80), expiresAt: NOW + 365 * DAY }, NOW)).toBe(false)
+    expect(isPromotableSetupCredential({ accessToken: oat }, NOW)).toBe(false)
+    expect(isPromotableSetupCredential({}, NOW)).toBe(false)
+  })
+})
+
+// 2026-07-16 live-verify FAIL on the reference VPS: `claude auth status` exits
+// 0 for a garbage token (it reports the auth SOURCE, it does not validate).
+// The real validator is a `claude -p` probe; this classifier turns its outcome
+// into ok / auth-rejected / inconclusive so callers never treat a network
+// flake as a dead credential.
+describe('classifyAuthProbe', () => {
+  it('ok: ran clean and answered OK', async () => {
+    const { classifyAuthProbe } = await import('../web/claude-credentials-guard.js')
+    expect(classifyAuthProbe({ ran: true, exitedNonZero: false, output: 'OK' })).toBe('ok')
+  })
+
+  it('auth-rejected: the live bug-3 signature (401 Invalid bearer token)', async () => {
+    const { classifyAuthProbe } = await import('../web/claude-credentials-guard.js')
+    expect(classifyAuthProbe({
+      ran: true, exitedNonZero: true,
+      output: 'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid bearer token"}}',
+    })).toBe('auth-rejected')
+  })
+
+  it('auth-rejected: invalid API key variant', async () => {
+    const { classifyAuthProbe } = await import('../web/claude-credentials-guard.js')
+    expect(classifyAuthProbe({ ran: true, exitedNonZero: true, output: 'Invalid API key' })).toBe('auth-rejected')
+  })
+
+  it('inconclusive: nonzero exit WITHOUT an auth signature (network flake) must not kill a credential', async () => {
+    const { classifyAuthProbe } = await import('../web/claude-credentials-guard.js')
+    expect(classifyAuthProbe({ ran: true, exitedNonZero: true, output: 'fetch failed: ETIMEDOUT' })).toBe('inconclusive')
+  })
+
+  it('inconclusive: the probe never ran (binary missing)', async () => {
+    const { classifyAuthProbe } = await import('../web/claude-credentials-guard.js')
+    expect(classifyAuthProbe({ ran: false, exitedNonZero: true, output: '' })).toBe('inconclusive')
+  })
+
+  it('inconclusive: clean exit with an unexpected answer (no OK)', async () => {
+    const { classifyAuthProbe } = await import('../web/claude-credentials-guard.js')
+    expect(classifyAuthProbe({ ran: true, exitedNonZero: false, output: 'I cannot comply' })).toBe('inconclusive')
+  })
+})

--- a/src/__tests__/reauth-detect.test.ts
+++ b/src/__tests__/reauth-detect.test.ts
@@ -156,3 +156,30 @@ describe('detectReauthNeeded', () => {
     expect(detectReauthNeeded(pane).needsReauth).toBe(false)
   })
 })
+
+// Second first-run-gate marker: the state a blind Enter on the picker advances
+// into (observed live 2026-07-16: channels.sh's first-run guard selected
+// option 1 and parked the session on the browser sign-in screen).
+describe('detectReauthNeeded: browser sign-in screen', () => {
+  it('detects the sign-in URL screen', () => {
+    const pane = [
+      ' Use the url below to sign in:',
+      '',
+      ' https://claude.ai/oauth/authorize?code=...',
+      '',
+      ' Paste code here if prompted >',
+    ].join('\n')
+    const r = detectReauthNeeded(pane)
+    expect(r.needsReauth).toBe(true)
+    expect(r.reason).toMatch(/sign-in screen/i)
+  })
+
+  it('does NOT re-fire on the healer escalation quoting the picker reason (self-loop regression)', () => {
+    const pane = [
+      ...Array.from({ length: 10 }, (_, i) => `... work line ${i} ...`),
+      '🔐 A(z) boni ágens halott OAuth tokent jelez (First-run onboarding picker (Select login method)) több mint ~9 perce.',
+      'Manuális browser /login kell a dashboardon (az ügynök kártyáján a "Bejelentkezés" gomb), automatikusan nem gyógyítható.',
+    ].join('\n')
+    expect(detectReauthNeeded(pane).needsReauth).toBe(false)
+  })
+})

--- a/src/__tests__/reauth-detect.test.ts
+++ b/src/__tests__/reauth-detect.test.ts
@@ -126,4 +126,33 @@ describe('detectReauthNeeded', () => {
     ].join('\n')
     expect(detectReauthNeeded(pane).needsReauth).toBe(false)
   })
+
+  // 2026-07-15 bootcamp "mass /login": the pane was NOT an auth failure but
+  // Claude Code's first-run picker (hasCompletedOnboarding lost from
+  // ~/.claude.json). It blocks the agent identically, so it must badge.
+  it('detects the first-run "Select login method" onboarding picker', () => {
+    const pane = [
+      ' Welcome to Claude Code',
+      '',
+      ' Select login method:',
+      '',
+      ' ❯ 1. Claude account with subscription',
+      '   2. Anthropic Console account',
+    ].join('\n')
+    const r = detectReauthNeeded(pane)
+    expect(r.needsReauth).toBe(true)
+    expect(r.reason).toMatch(/onboarding picker/i)
+  })
+
+  it('does NOT fire on a chat that merely mentions the picker in scrollback', () => {
+    const pane = [
+      '❯ a "Select login method" képernyőről beszéltünk',
+      ...Array.from({ length: 20 }, (_, i) => `... work line ${i} ...`),
+      '──────────────────────────────────────────────────────────────────────',
+      '❯ ',
+      '──────────────────────────────────────────────────────────────────────',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectReauthNeeded(pane).needsReauth).toBe(false)
+  })
 })

--- a/src/__tests__/reauth-healer.test.ts
+++ b/src/__tests__/reauth-healer.test.ts
@@ -95,3 +95,43 @@ describe('decideReauthAction', () => {
     expect(last.escalate).toBe(true)
   })
 })
+
+// 2026-07-16 first-run gate (bootcamp): the "Select login method" picker /
+// browser sign-in screen is NOT a dead token. A /login send-keys there is
+// actively harmful (Enter accepts a login method -> browser OAuth on a VALID
+// credential); the heal is a sub-agent restart, which re-seeds the flag.
+describe('decideReauthAction: first-run gate', () => {
+  const gated = { consecutiveDead: 2, lastActionAtMs: null } as ReauthHealerState
+
+  it('suppresses /login send-keys and restarts instead (sub-agent, at threshold)', () => {
+    const d = decideReauthAction(base({ isFirstRunGate: true, prev: gated }), T)
+    expect(d.sendKeys).toBe(false)
+    expect(d.restartAgent).toBe(true)
+    expect(d.escalate).toBe(true)
+  })
+
+  it('restart works headless too (canInteractiveLogin false)', () => {
+    const d = decideReauthAction(base({ isFirstRunGate: true, canInteractiveLogin: false, prev: gated }), T)
+    expect(d.sendKeys).toBe(false)
+    expect(d.restartAgent).toBe(true)
+  })
+
+  it('main agent: never restarted, never send-keys -- escalate-only', () => {
+    const d = decideReauthAction(base({ isFirstRunGate: true, isMain: true, prev: gated }), T)
+    expect(d.sendKeys).toBe(false)
+    expect(d.restartAgent).toBe(false)
+    expect(d.escalate).toBe(true)
+  })
+
+  it('a genuine 401 (not first-run gate) keeps the legacy behavior: send-keys, no restart', () => {
+    const d = decideReauthAction(base({ prev: gated }), T)
+    expect(d.sendKeys).toBe(true)
+    expect(d.restartAgent).toBe(false)
+  })
+
+  it('below threshold: no restart', () => {
+    const d = decideReauthAction(base({ isFirstRunGate: true, prev: NO_REAUTH_STATE }), T)
+    expect(d.restartAgent).toBe(false)
+    expect(d.escalate).toBe(false)
+  })
+})

--- a/src/__tests__/shared-claude-onboarded.test.ts
+++ b/src/__tests__/shared-claude-onboarded.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { ensureSharedClaudeOnboarded } from '../web/agent-process.js'
+
+// 2026-07-15 bootcamp: ~/.claude.json lost hasCompletedOnboarding, so every
+// fresh (re)spawn on the shared config root parked on the first-run
+// "Select login method" picker while the on-disk credential was valid.
+// ensureSharedClaudeOnboarded is the idempotent pre-launch re-seed.
+describe('ensureSharedClaudeOnboarded', () => {
+  let dir: string
+  let dotClaude: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'onboarded-'))
+    dotClaude = join(dir, '.claude.json')
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('creates a minimal file with the flag when ~/.claude.json is missing', () => {
+    expect(ensureSharedClaudeOnboarded(dotClaude)).toBe(true)
+    const parsed = JSON.parse(readFileSync(dotClaude, 'utf-8'))
+    expect(parsed.hasCompletedOnboarding).toBe(true)
+  })
+
+  it('re-seeds a clobbered flag while PRESERVING every other key (the bootcamp case)', () => {
+    writeFileSync(dotClaude, JSON.stringify({
+      projects: { '/root/marveen': { hasTrustDialogAccepted: true } },
+      mcpServers: { fs: { command: 'x' } },
+    }))
+    expect(ensureSharedClaudeOnboarded(dotClaude)).toBe(true)
+    const parsed = JSON.parse(readFileSync(dotClaude, 'utf-8'))
+    expect(parsed.hasCompletedOnboarding).toBe(true)
+    expect(parsed.projects['/root/marveen'].hasTrustDialogAccepted).toBe(true)
+    expect(parsed.mcpServers.fs.command).toBe('x')
+  })
+
+  it('is a no-op (returns false) when the flag is already true', () => {
+    const original = JSON.stringify({ hasCompletedOnboarding: true, other: 1 }, null, 2) + '\n'
+    writeFileSync(dotClaude, original)
+    expect(ensureSharedClaudeOnboarded(dotClaude)).toBe(false)
+    expect(readFileSync(dotClaude, 'utf-8')).toBe(original)
+  })
+
+  it('re-seeds when the flag exists but is not exactly true', () => {
+    writeFileSync(dotClaude, JSON.stringify({ hasCompletedOnboarding: false }))
+    expect(ensureSharedClaudeOnboarded(dotClaude)).toBe(true)
+    expect(JSON.parse(readFileSync(dotClaude, 'utf-8')).hasCompletedOnboarding).toBe(true)
+  })
+
+  it('leaves an UNPARSEABLE file alone (Claude Code owns its recovery)', () => {
+    writeFileSync(dotClaude, '{ not json')
+    expect(ensureSharedClaudeOnboarded(dotClaude)).toBe(false)
+    expect(readFileSync(dotClaude, 'utf-8')).toBe('{ not json')
+  })
+
+  it('leaves no tmp litter next to the target (atomic write)', () => {
+    writeFileSync(dotClaude, JSON.stringify({ a: 1 }))
+    ensureSharedClaudeOnboarded(dotClaude)
+    expect(existsSync(dotClaude)).toBe(true)
+    const leftovers = readFileSync(dotClaude, 'utf-8')
+    expect(() => JSON.parse(leftovers)).not.toThrow()
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
 import { ensureHeartbeatAgent, shouldBootHeartbeatAgent, HEARTBEAT_AGENT_NAME } from './web/heartbeat-agent-scaffold.js'
 import { startAgentProcess } from './web/agent-process.js'
-import { renameSharedCredentialsIfSafe, syncFleetTokenFromSharedCredentials } from './web/claude-credentials-guard.js'
+import { renameSharedCredentialsIfSafe, fleetTokenBootPass } from './web/claude-credentials-guard.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
 import { startInviteMonitor, stopInviteMonitor } from './web/channel-invites.js'
@@ -494,14 +494,20 @@ async function main(): Promise<void> {
   // any install with the heartbeat sub-agent disabled (the common case) this
   // never ran at boot at all (found 2026-07-13 while diagnosing recurring
   // dead-token incidents).
-  //
-  // The sync runs FIRST: it backfills store/.claude-oauth-token from a
-  // terminal-pasted `claude setup-token` (which lands only in
-  // ~/.claude/.credentials.json and silently disables per-agent isolation AND
-  // the rename guard -- 2026-07-15 bootcamp root gap). Live-tested, oat01-only,
-  // no-op when the fleet file already exists.
-  syncFleetTokenFromSharedCredentials()
   renameSharedCredentialsIfSafe()
+
+  // Fleet-token boot pass, DEFERRED and fire-and-forget: it live-probes a
+  // credential (one real `claude -p` call, up to 60s) so it must never block
+  // boot. Backfills store/.claude-oauth-token from a terminal-pasted
+  // `claude setup-token` (which lands only in ~/.claude/.credentials.json and
+  // silently disables per-agent isolation AND the rename guard -- 2026-07-15
+  // bootcamp root gap), validates a never-verified existing fleet token, and
+  // quarantines one the probe proves dead.
+  setTimeout(() => {
+    fleetTokenBootPass()
+      .then((result) => logger.info({ result }, 'credentials-guard: fleet-token boot pass'))
+      .catch((err) => logger.warn({ err }, 'credentials-guard: fleet-token boot pass failed'))
+  }, 15_000)
 
   if (shouldBootHeartbeatAgent({ respawnEnabled: RESPAWN_ENABLED, agentEnabled: HEARTBEAT_AGENT_ENABLED })) {
     ensureHeartbeatAgent()

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
 import { ensureHeartbeatAgent, shouldBootHeartbeatAgent, HEARTBEAT_AGENT_NAME } from './web/heartbeat-agent-scaffold.js'
 import { startAgentProcess } from './web/agent-process.js'
-import { renameSharedCredentialsIfSafe } from './web/claude-credentials-guard.js'
+import { renameSharedCredentialsIfSafe, syncFleetTokenFromSharedCredentials } from './web/claude-credentials-guard.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
 import { startInviteMonitor, stopInviteMonitor } from './web/channel-invites.js'
@@ -494,6 +494,13 @@ async function main(): Promise<void> {
   // any install with the heartbeat sub-agent disabled (the common case) this
   // never ran at boot at all (found 2026-07-13 while diagnosing recurring
   // dead-token incidents).
+  //
+  // The sync runs FIRST: it backfills store/.claude-oauth-token from a
+  // terminal-pasted `claude setup-token` (which lands only in
+  // ~/.claude/.credentials.json and silently disables per-agent isolation AND
+  // the rename guard -- 2026-07-15 bootcamp root gap). Live-tested, oat01-only,
+  // no-op when the fleet file already exists.
+  syncFleetTokenFromSharedCredentials()
   renameSharedCredentialsIfSafe()
 
   if (shouldBootHeartbeatAgent({ respawnEnabled: RESPAWN_ENABLED, agentEnabled: HEARTBEAT_AGENT_ENABLED })) {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -508,14 +508,14 @@ function provisionIsolatedConfigDir(
 export function ensureSharedClaudeOnboarded(dotClaudePath: string = join(homedir(), '.claude.json')): boolean {
   try {
     if (!existsSync(dotClaudePath)) {
-      atomicWriteFileSync(dotClaudePath, JSON.stringify({ hasCompletedOnboarding: true }, null, 2) + '\n')
+      atomicWriteFileSync(dotClaudePath, JSON.stringify({ hasCompletedOnboarding: true }, null, 2) + '\n', { mode: 0o600 })
       logger.info({ dotClaudePath }, 'shared-config: created ~/.claude.json with hasCompletedOnboarding')
       return true
     }
     const cur = JSON.parse(readFileSync(dotClaudePath, 'utf-8')) as Record<string, unknown>
     if (cur.hasCompletedOnboarding === true) return false
     cur.hasCompletedOnboarding = true
-    atomicWriteFileSync(dotClaudePath, JSON.stringify(cur, null, 2) + '\n')
+    atomicWriteFileSync(dotClaudePath, JSON.stringify(cur, null, 2) + '\n', { mode: 0o600 })
     logger.warn({ dotClaudePath }, 'shared-config: re-seeded missing hasCompletedOnboarding (prevents the first-run "Select login method" picker)')
     return true
   } catch (err) {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -20,6 +20,7 @@ import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, rea
 import { resolveAgentConfigDir } from './claude-plans.js'
 import { provisionMemoryBoundaryDir } from './memory-boundary.js'
 import { renameSharedCredentialsIfSafe } from './claude-credentials-guard.js'
+import { atomicWriteFileSync } from './atomic-write.js'
 import {
   buildTmuxInvocation,
   buildSshExec,
@@ -487,6 +488,42 @@ function provisionIsolatedConfigDir(
   }
 }
 
+// Guarantee hasCompletedOnboarding in the SHARED ~/.claude.json.
+//
+// 2026-07-15 bootcamp field incident (root-caused live on the reference VPS):
+// the key vanished from ~/.claude.json within ~1h of install despite
+// install-linux.sh seeding it, so EVERY fresh (re)spawn of an agent on the
+// shared config root parked on Claude Code's first-run "Select login method"
+// picker -- looking exactly like a mass /login ejection -- while the on-disk
+// credential was valid the whole time (the picker is gated ONLY on this flag;
+// even a valid CLAUDE_CODE_OAUTH_TOKEN env does not bypass it, see the
+// provisionIsolatedConfigDir comment above). Isolated config dirs already get
+// this guarantee at provision time; this closes the same gap for the shared
+// root. Called before every main-session respawn and sub-agent launch.
+//
+// The write is ATOMIC (tmp + rename): a non-atomic rewrite racing a live
+// Claude Code process is the leading suspect for how the key got clobbered in
+// the first place. An unparseable file is left alone -- Claude Code owns its
+// recovery, and overwriting would destroy MCP/project state.
+export function ensureSharedClaudeOnboarded(dotClaudePath: string = join(homedir(), '.claude.json')): boolean {
+  try {
+    if (!existsSync(dotClaudePath)) {
+      atomicWriteFileSync(dotClaudePath, JSON.stringify({ hasCompletedOnboarding: true }, null, 2) + '\n')
+      logger.info({ dotClaudePath }, 'shared-config: created ~/.claude.json with hasCompletedOnboarding')
+      return true
+    }
+    const cur = JSON.parse(readFileSync(dotClaudePath, 'utf-8')) as Record<string, unknown>
+    if (cur.hasCompletedOnboarding === true) return false
+    cur.hasCompletedOnboarding = true
+    atomicWriteFileSync(dotClaudePath, JSON.stringify(cur, null, 2) + '\n')
+    logger.warn({ dotClaudePath }, 'shared-config: re-seeded missing hasCompletedOnboarding (prevents the first-run "Select login method" picker)')
+    return true
+  } catch (err) {
+    logger.warn({ err, dotClaudePath }, 'shared-config: could not guarantee hasCompletedOnboarding (unparseable or unwritable ~/.claude.json)')
+    return false
+  }
+}
+
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
   if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord' || perAgent === 'googlechat' || perAgent === 'teams') return perAgent
@@ -669,6 +706,11 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
   // the rotating ~/.claude/.credentials.json; idempotent, so calling it per
   // start also self-heals if Claude Code recreates the file on a refresh.
   renameSharedCredentialsIfSafe(CLAUDE)
+
+  // Shared-root agents park on the first-run "Select login method" picker when
+  // ~/.claude.json lost hasCompletedOnboarding (2026-07-15 bootcamp incident);
+  // idempotent re-seed before every launch.
+  ensureSharedClaudeOnboarded()
 
 
   if (isAgentRunning(name)) return { ok: false, error: 'Agent is already running' }

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -11,6 +11,8 @@ import {
   isSessionReadyForPrompt,
   sendPromptToSession,
   sessionExistsOnHost,
+  hasFleetOauthToken,
+  FLEET_OAUTH_TOKEN_PATH,
 } from './agent-process.js'
 import { readClaudeCodeOauthJson } from './claude-credentials.js'
 import { detectPaneState } from '../pane-state.js'
@@ -308,8 +310,21 @@ export function ensureWorkerCwd(ctx: WorkerCtx = ctxSlow): void {
 
   const realClaude = join(homedir(), '.claude')
   if (existsSync(realClaude)) {
+    // With a fleet setup-token present the worker authenticates from the
+    // CLAUDE_CODE_OAUTH_TOKEN env injected at launch (env strictly overrides
+    // the credentials file anyway); symlinking the shared rotating
+    // ~/.claude/.credentials.json would re-join the worker to the very
+    // cross-process refresh race the fleet token exists to avoid (the Linux
+    // #537 failure family; 2026-07-15 bootcamp). Without a fleet token the
+    // symlink stays -- it is then the worker's only auth source.
+    const skipSharedCreds = hasFleetOauthToken()
+    if (skipSharedCreds) {
+      const credsLink = join(ctx.configDir, '.credentials.json')
+      if (lstatSyncSafe(credsLink)?.isSymbolicLink()) rmSync(credsLink, { force: true })
+    }
     for (const entry of readdirSync(realClaude)) {
       if (WORKER_CONFIG_SKIP.has(entry)) continue
+      if (skipSharedCreds && entry === '.credentials.json') continue
       const linkPath = join(ctx.configDir, entry)
       const target = join(realClaude, entry)
       let needsLink = true
@@ -415,7 +430,11 @@ function startWorkerSessionFor(ctx: WorkerCtx): void {
   ensureWorkerCwd(ctx)
   // Detached session; launch claude via a login shell so PATH + the config-dir
   // env are set. The model suffix ([1m]) is single-quoted so it is not globbed.
+  // Fleet setup-token (when present) via $(cat) at launch so the secret never
+  // lands in argv/`ps` -- same pattern as startAgentProcess. Keeps the worker
+  // on the stable token instead of the shared rotating credentials file.
   const launch =
+    (hasFleetOauthToken() ? `export CLAUDE_CODE_OAUTH_TOKEN="$(cat ${shArg(FLEET_OAUTH_TOKEN_PATH)})"; ` : '') +
     `export CLAUDE_CONFIG_DIR=${shArg(ctx.configDir)}; ` +
     `cd ${shArg(ctx.home)} && ` +
     `claude --dangerously-skip-permissions --model ${shArg(WORKER_MODEL)}`

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -19,6 +19,8 @@ import {
   stopAgentProcess,
   scheduleIdentitySetup,
   ensureMainAgentIsolatedConfigDir,
+  ensureSharedClaudeOnboarded,
+  hasFleetOauthToken,
   FLEET_OAUTH_TOKEN_PATH,
 } from './agent-process.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes, collectPollerEvidence } from './channel-poller-reap.js'
@@ -498,6 +500,15 @@ export function buildMainSessionRespawnCmd(opts: {
    * the shared root (unchanged behaviour for installs with isolation off).
    */
   isolatedConfigDir?: string | null
+  /**
+   * When true (fleet setup-token file present) and there is NO isolated config
+   * dir, the respawn still exports CLAUDE_CODE_OAUTH_TOKEN from the fleet token
+   * file. On Linux the isolatedConfigDir is always null (macOS-only), so before
+   * this leg a wizard-entered token never reached a respawned main session at
+   * all -- it fell back to ~/.claude/.credentials.json (2026-07-15 bootcamp,
+   * bug 2 latent path). Keeps main + sub-agents on the SAME auth source.
+   */
+  fleetToken?: boolean
 }): string {
   return [
     'export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"',
@@ -514,7 +525,9 @@ export function buildMainSessionRespawnCmd(opts: {
     // token is read at launch via $(cat) so the secret never lands in argv/`ps`.
     ...(opts.isolatedConfigDir
       ? [`&& export CLAUDE_CONFIG_DIR='${opts.isolatedConfigDir}' && export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')"`]
-      : []),
+      : opts.fleetToken
+        ? [`&& export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')"`]
+        : []),
     '&&', opts.claudePath,
     ...(opts.continueSession ? ['--continue'] : []),
     '--dangerously-skip-permissions',
@@ -560,6 +573,11 @@ export async function resumeMarveenSession(): Promise<boolean> {
       logger.warn({ err }, 'resumeMarveenSession: detached-claude reap failed (continuing)')
     }
 
+    // A respawn onto the shared ~/.claude parks on the first-run "Select login
+    // method" picker when ~/.claude.json lost hasCompletedOnboarding (2026-07-15
+    // bootcamp mass-"/login"); idempotent re-seed before every respawn.
+    ensureSharedClaudeOnboarded()
+
     const claudeCmd = buildMainSessionRespawnCmd({
       claudePath: CLAUDE,
       pluginId: provider.pluginId,
@@ -570,6 +588,7 @@ export async function resumeMarveenSession(): Promise<boolean> {
       // rotating Keychain and 401s. Returns null when isolation is off/no token,
       // preserving the prior shared-root behaviour.
       isolatedConfigDir: ensureMainAgentIsolatedConfigDir(),
+      fleetToken: hasFleetOauthToken(),
     })
     execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
 
@@ -762,6 +781,8 @@ export function createMainChannelsSession(): boolean {
 function respawnMarveenSessionFresh(): boolean {
   const provider = getProvider(getMainAgentProvider())
   try {
+    // Same first-run-picker guard as resumeMarveenSession.
+    ensureSharedClaudeOnboarded()
     const claudeCmd = buildMainSessionRespawnCmd({
       claudePath: CLAUDE,
       pluginId: provider.pluginId,
@@ -771,6 +792,7 @@ function respawnMarveenSessionFresh(): boolean {
       // respawn also skips channels.sh, so it must carry the isolated config
       // itself or it 401s on the rotating macOS Keychain. null when off/no token.
       isolatedConfigDir: ensureMainAgentIsolatedConfigDir(),
+      fleetToken: hasFleetOauthToken(),
     })
     execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
     logger.warn({ provider: provider.type }, 'Hard restart: marveen session respawned fresh (no --continue)')

--- a/src/web/claude-credentials-guard.ts
+++ b/src/web/claude-credentials-guard.ts
@@ -109,6 +109,51 @@ function tokenIsValid(claudeBin: string): boolean {
 }
 
 /**
+ * Backfill the fleet token file from a setup-token that was pasted into a bare
+ * terminal `claude setup-token` run instead of the wizard.
+ *
+ * 2026-07-15 bootcamp root gap: `claude setup-token` writes its sk-ant-oat01
+ * pair ONLY into ~/.claude/.credentials.json. The wizard's claudeAuthPresent()
+ * then passes from that file alone, so the token-paste step is silently
+ * skipped, store/.claude-oauth-token is never created, and BOTH the per-agent
+ * config-dir isolation and this guard stay disabled -- the whole fleet keeps
+ * sharing one credentials.json. This sync closes that path at boot: when the
+ * fleet file is missing but the shared credentials.json holds a well-formed
+ * setup-token, live-test it and promote it to store/.claude-oauth-token (plus
+ * the verified stamp, so the guard does not re-test). Only ever promotes an
+ * sk-ant-oat01 (1-year, non-rotating) credential -- a rotating `claude auth
+ * login` session token never matches OAUTH_TOKEN_RX and is left alone.
+ *
+ * Deliberately does NOT touch .env: the wizard/auth.sh own that file, and a
+ * boot-time .env rewrite would silently flip the MAIN agent's auth source on
+ * existing installs. Sub-agent launches read the store file directly.
+ */
+export type FleetTokenSyncResult =
+  | 'fleet-token-present' | 'no-credentials' | 'not-setup-token' | 'live-test-failed' | 'synced' | 'error'
+
+export function syncFleetTokenFromSharedCredentials(claudeBin?: string): FleetTokenSyncResult {
+  try {
+    if (readFleetToken()) return 'fleet-token-present'
+    let accessToken = ''
+    try {
+      const parsed = JSON.parse(readFileSync(HOME_CREDENTIALS, 'utf-8')) as { claudeAiOauth?: { accessToken?: string } }
+      accessToken = (parsed?.claudeAiOauth?.accessToken ?? '').trim()
+    } catch { return 'no-credentials' }
+    if (!looksLikeSetupToken(accessToken)) return 'not-setup-token'
+    const bin = claudeBin ?? resolveFromPath('claude')
+    logger.info('credentials-guard: found a terminal-pasted setup-token in ~/.claude/.credentials.json with no fleet token file; live-testing before promoting it')
+    if (!liveTestToken(accessToken, bin)) { logger.warn('credentials-guard: setup-token in credentials.json failed the live test; not promoted'); return 'live-test-failed' }
+    writeFileSync(FLEET_OAUTH_TOKEN_PATH, accessToken, { mode: 0o600 })
+    try { writeFileSync(VERIFIED_STAMP, tokenHash(accessToken) + '\n', { mode: 0o600 }) } catch { /* stamp is an optimisation */ }
+    logger.warn({ to: FLEET_OAUTH_TOKEN_PATH }, 'credentials-guard: promoted the setup-token from ~/.claude/.credentials.json to the fleet token file; per-agent config isolation is now active for newly launched sub-agents')
+    return 'synced'
+  } catch (err) {
+    logger.warn({ err }, 'credentials-guard: fleet-token sync failed (continuing)')
+    return 'error'
+  }
+}
+
+/**
  * The guarded, idempotent, reversible action. Returns a short status for logging
  * and tests. Never throws; never logs the token.
  */

--- a/src/web/claude-credentials-guard.ts
+++ b/src/web/claude-credentials-guard.ts
@@ -246,15 +246,18 @@ export async function syncFleetTokenFromSharedCredentials(claudeBin?: string): P
 // hasFleetOauthToken() is false, launches fall back to shared-file auth, and
 // the boot sync will only re-promote a credential that passes a live probe.
 
-const BAD_FLEET_TOKEN_PATH = FLEET_OAUTH_TOKEN_PATH + '.bad'
+// Lazy: FLEET_OAUTH_TOKEN_PATH comes through the agent-process <-> guard
+// import cycle, so a module-level concatenation evaluates in the TDZ and
+// crashes boot (ReferenceError; found live on the round-2 verify deploy).
+const badFleetTokenPath = () => FLEET_OAUTH_TOKEN_PATH + '.bad'
 
 export function quarantineFleetToken(reasonLabel: string): boolean {
   try {
     if (!existsSync(FLEET_OAUTH_TOKEN_PATH)) return false
-    renameSync(FLEET_OAUTH_TOKEN_PATH, BAD_FLEET_TOKEN_PATH)
+    renameSync(FLEET_OAUTH_TOKEN_PATH, badFleetTokenPath())
     try { rmSync(VERIFIED_STAMP, { force: true }) } catch { /* best effort */ }
     logger.error(
-      { to: BAD_FLEET_TOKEN_PATH, reason: reasonLabel },
+      { to: badFleetTokenPath(), reason: reasonLabel },
       'credentials-guard: QUARANTINED the fleet token (dead on live probe); newly launched agents fall back to shared-file auth. Restore with mv if this was a false positive.',
     )
     return true

--- a/src/web/claude-credentials-guard.ts
+++ b/src/web/claude-credentials-guard.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process'
+import { execFileSync, execFile } from 'node:child_process'
 import { existsSync, readFileSync, writeFileSync, renameSync, mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir, tmpdir } from 'node:os'
@@ -108,6 +108,89 @@ function tokenIsValid(claudeBin: string): boolean {
   return true
 }
 
+// --- Live auth probe (async) --------------------------------------------------
+//
+// `claude auth status` does NOT validate a credential remotely -- it reports
+// the auth SOURCE and exits 0 even for a garbage token (proven live on the
+// bootcamp reference VPS, claude 2.1.110). The only real validation is a tiny
+// `claude -p` call. This is the async twin of liveTestToken with a three-way
+// answer, so callers can tell "the credential is dead" (quarantine/reject)
+// apart from "the probe could not run / network flake" (do nothing harmful).
+
+export type AuthProbeResult = 'ok' | 'auth-rejected' | 'inconclusive'
+
+const AUTH_FAILURE_RX =
+  /\b401\b|Invalid bearer token|Invalid API key|authentication_error|Invalid authentication|Failed to authenticate|OAuth (?:token|authentication) (?:has )?expired/i
+
+/** Pure classifier for a probe run. Exported for tests. */
+export function classifyAuthProbe(input: { ran: boolean; exitedNonZero: boolean; output: string }): AuthProbeResult {
+  if (!input.ran) return 'inconclusive'
+  if (!input.exitedNonZero && /\bOK\b/.test(input.output)) return 'ok'
+  if (AUTH_FAILURE_RX.test(input.output)) return 'auth-rejected'
+  return 'inconclusive'
+}
+
+/**
+ * Probe ONE credential in an isolated CLAUDE_CONFIG_DIR. Sibling auth env vars
+ * are stripped first: CLAUDE_CODE_OAUTH_TOKEN strictly overrides everything
+ * else, so a stale inherited token would otherwise be the credential under
+ * test instead of `envOverride`. Never logs or returns the secret.
+ */
+export async function liveProbeAuth(envOverride: Record<string, string>, claudeBin?: string): Promise<AuthProbeResult> {
+  let dir: string | null = null
+  try {
+    const bin = claudeBin ?? resolveFromPath('claude')
+    dir = mkdtempSync(join(tmpdir(), 'auth-probe-'))
+    const env: Record<string, string | undefined> = { ...process.env, CLAUDE_CONFIG_DIR: dir }
+    delete env.CLAUDE_CODE_OAUTH_TOKEN
+    delete env.ANTHROPIC_API_KEY
+    Object.assign(env, envOverride)
+    const run = await new Promise<{ ran: boolean; exitedNonZero: boolean; output: string }>((resolve) => {
+      execFile(
+        bin,
+        ['-p', 'Reply with exactly: OK', '--model', LIVE_TEST_MODEL],
+        { timeout: 60_000, encoding: 'utf-8', env: env as NodeJS.ProcessEnv },
+        (err, stdout, stderr) => {
+          if (err && (err as { code?: unknown }).code === 'ENOENT') { resolve({ ran: false, exitedNonZero: true, output: '' }); return }
+          resolve({ ran: true, exitedNonZero: Boolean(err), output: `${stdout ?? ''}\n${stderr ?? ''}` })
+        },
+      )
+    })
+    return classifyAuthProbe(run)
+  } catch {
+    return 'inconclusive'
+  } finally {
+    if (dir) { try { rmSync(dir, { recursive: true, force: true }) } catch { /* best effort */ } }
+  }
+}
+
+/** Record a token as live-verified (skips future re-tests). Exported for the wizard. */
+export function stampTokenVerified(token: string): void {
+  try { writeFileSync(VERIFIED_STAMP, tokenHash(token) + '\n', { mode: 0o600 }) } catch { /* optimisation only */ }
+}
+
+// --- Fleet-token promotion + lifecycle ----------------------------------------
+
+/**
+ * Promotion discriminator. The sk-ant-oat01 PREFIX alone does NOT distinguish a
+ * long-lived `claude setup-token` credential from a rotating browser-login
+ * access token (both can carry it; verified on a live install 2026-07-16).
+ * The reliable signal is LONGEVITY: setup-tokens are issued for ~1 year,
+ * rotating session tokens expire within hours/days. Promoting a rotating token
+ * would self-inflict the exact bootcamp incident on healthy installs: the env
+ * token strictly overrides the (still-refreshing) credentials file, so once it
+ * rotates every agent launched with it 401s. Pure + exported for tests.
+ */
+export const MIN_PROMOTABLE_LIFETIME_MS = 90 * 24 * 60 * 60 * 1000
+export function isPromotableSetupCredential(
+  cred: { accessToken?: string; expiresAt?: number },
+  nowMs: number,
+): boolean {
+  if (!looksLikeSetupToken((cred.accessToken ?? '').trim())) return false
+  if (typeof cred.expiresAt !== 'number') return false
+  return cred.expiresAt - nowMs >= MIN_PROMOTABLE_LIFETIME_MS
+}
+
 /**
  * Backfill the fleet token file from a setup-token that was pasted into a bare
  * terminal `claude setup-token` run instead of the wizard.
@@ -117,12 +200,10 @@ function tokenIsValid(claudeBin: string): boolean {
  * then passes from that file alone, so the token-paste step is silently
  * skipped, store/.claude-oauth-token is never created, and BOTH the per-agent
  * config-dir isolation and this guard stay disabled -- the whole fleet keeps
- * sharing one credentials.json. This sync closes that path at boot: when the
- * fleet file is missing but the shared credentials.json holds a well-formed
- * setup-token, live-test it and promote it to store/.claude-oauth-token (plus
- * the verified stamp, so the guard does not re-test). Only ever promotes an
- * sk-ant-oat01 (1-year, non-rotating) credential -- a rotating `claude auth
- * login` session token never matches OAUTH_TOKEN_RX and is left alone.
+ * sharing one credentials.json. This sync closes that path: when the fleet
+ * file is missing but the shared credentials.json holds a long-lived
+ * setup-token (see isPromotableSetupCredential), live-probe it and promote it
+ * to store/.claude-oauth-token (plus the verified stamp).
  *
  * Deliberately does NOT touch .env: the wizard/auth.sh own that file, and a
  * boot-time .env rewrite would silently flip the MAIN agent's auth source on
@@ -131,26 +212,97 @@ function tokenIsValid(claudeBin: string): boolean {
 export type FleetTokenSyncResult =
   | 'fleet-token-present' | 'no-credentials' | 'not-setup-token' | 'live-test-failed' | 'synced' | 'error'
 
-export function syncFleetTokenFromSharedCredentials(claudeBin?: string): FleetTokenSyncResult {
+export async function syncFleetTokenFromSharedCredentials(claudeBin?: string): Promise<FleetTokenSyncResult> {
   try {
     if (readFleetToken()) return 'fleet-token-present'
-    let accessToken = ''
+    let cred: { accessToken?: string; expiresAt?: number } = {}
     try {
-      const parsed = JSON.parse(readFileSync(HOME_CREDENTIALS, 'utf-8')) as { claudeAiOauth?: { accessToken?: string } }
-      accessToken = (parsed?.claudeAiOauth?.accessToken ?? '').trim()
+      const parsed = JSON.parse(readFileSync(HOME_CREDENTIALS, 'utf-8')) as { claudeAiOauth?: { accessToken?: string; expiresAt?: number } }
+      cred = parsed?.claudeAiOauth ?? {}
     } catch { return 'no-credentials' }
-    if (!looksLikeSetupToken(accessToken)) return 'not-setup-token'
-    const bin = claudeBin ?? resolveFromPath('claude')
-    logger.info('credentials-guard: found a terminal-pasted setup-token in ~/.claude/.credentials.json with no fleet token file; live-testing before promoting it')
-    if (!liveTestToken(accessToken, bin)) { logger.warn('credentials-guard: setup-token in credentials.json failed the live test; not promoted'); return 'live-test-failed' }
+    if (!isPromotableSetupCredential(cred, Date.now())) return 'not-setup-token'
+    const accessToken = (cred.accessToken ?? '').trim()
+    logger.info('credentials-guard: found a long-lived terminal-pasted setup-token in ~/.claude/.credentials.json with no fleet token file; live-probing before promoting it')
+    if ((await liveProbeAuth({ CLAUDE_CODE_OAUTH_TOKEN: accessToken }, claudeBin)) !== 'ok') {
+      logger.warn('credentials-guard: setup-token in credentials.json did not pass the live probe; not promoted')
+      return 'live-test-failed'
+    }
     writeFileSync(FLEET_OAUTH_TOKEN_PATH, accessToken, { mode: 0o600 })
-    try { writeFileSync(VERIFIED_STAMP, tokenHash(accessToken) + '\n', { mode: 0o600 }) } catch { /* stamp is an optimisation */ }
+    stampTokenVerified(accessToken)
     logger.warn({ to: FLEET_OAUTH_TOKEN_PATH }, 'credentials-guard: promoted the setup-token from ~/.claude/.credentials.json to the fleet token file; per-agent config isolation is now active for newly launched sub-agents')
     return 'synced'
   } catch (err) {
     logger.warn({ err }, 'credentials-guard: fleet-token sync failed (continuing)')
     return 'error'
   }
+}
+
+// --- Fleet-token quarantine (stale-token recovery) -----------------------------
+//
+// Once respawns/launches bind to the fleet token, a token that later goes bad
+// (server-side revocation) would 401 every NEW launch while nothing removes it
+// -- and the operator's manual delete would be undone by the boot sync above.
+// Quarantine (rename to .bad + drop the stamp) is the demotion path: after it,
+// hasFleetOauthToken() is false, launches fall back to shared-file auth, and
+// the boot sync will only re-promote a credential that passes a live probe.
+
+const BAD_FLEET_TOKEN_PATH = FLEET_OAUTH_TOKEN_PATH + '.bad'
+
+export function quarantineFleetToken(reasonLabel: string): boolean {
+  try {
+    if (!existsSync(FLEET_OAUTH_TOKEN_PATH)) return false
+    renameSync(FLEET_OAUTH_TOKEN_PATH, BAD_FLEET_TOKEN_PATH)
+    try { rmSync(VERIFIED_STAMP, { force: true }) } catch { /* best effort */ }
+    logger.error(
+      { to: BAD_FLEET_TOKEN_PATH, reason: reasonLabel },
+      'credentials-guard: QUARANTINED the fleet token (dead on live probe); newly launched agents fall back to shared-file auth. Restore with mv if this was a false positive.',
+    )
+    return true
+  } catch (err) {
+    logger.warn({ err }, 'credentials-guard: fleet-token quarantine failed')
+    return false
+  }
+}
+
+/**
+ * Probe the CURRENT fleet token and quarantine it if the probe proves it dead.
+ * Called by the reauth-healer when an agent shows a confirmed 401 family
+ * failure while a fleet token is present -- the event-driven recovery for a
+ * token that was valid at write time but got revoked later. 'inconclusive'
+ * (network flake / no binary) never quarantines.
+ */
+export async function quarantineFleetTokenIfDead(claudeBin?: string): Promise<'no-token' | 'healthy' | 'quarantined' | 'inconclusive'> {
+  const token = readFleetToken()
+  if (!token) return 'no-token'
+  const probe = await liveProbeAuth({ CLAUDE_CODE_OAUTH_TOKEN: token }, claudeBin)
+  if (probe === 'ok') { stampTokenVerified(token); return 'healthy' }
+  if (probe === 'auth-rejected') { quarantineFleetToken('reauth-healer: agent 401 + fleet token failed live probe'); return 'quarantined' }
+  return 'inconclusive'
+}
+
+/**
+ * One boot-time pass over the fleet-token lifecycle. Deferred + async at the
+ * call site (a real API probe must never block boot):
+ *  - fleet token present but never live-verified (no/stale stamp): probe it;
+ *    dead -> quarantine (a bad paste from the pre-verify-first era, or a
+ *    revoked token, stops poisoning launches at the next boot);
+ *  - fleet token absent: try promoting a long-lived terminal setup-token from
+ *    the shared credentials.json (see syncFleetTokenFromSharedCredentials).
+ */
+export type FleetTokenBootPassResult = FleetTokenSyncResult | 'validated' | 'validated-cached' | 'quarantined' | 'validate-inconclusive' | 'malformed-left-alone'
+
+export async function fleetTokenBootPass(claudeBin?: string): Promise<FleetTokenBootPassResult> {
+  const token = readFleetToken()
+  if (!token) return syncFleetTokenFromSharedCredentials(claudeBin)
+  if (!looksLikeSetupToken(token)) {
+    logger.warn('credentials-guard: fleet token file content is not a well-formed setup-token; leaving it alone (operator-managed?)')
+    return 'malformed-left-alone'
+  }
+  if (readVerifiedHash() === tokenHash(token)) return 'validated-cached'
+  const probe = await liveProbeAuth({ CLAUDE_CODE_OAUTH_TOKEN: token }, claudeBin)
+  if (probe === 'ok') { stampTokenVerified(token); return 'validated' }
+  if (probe === 'auth-rejected') { quarantineFleetToken('boot validation: live probe auth-rejected'); return 'quarantined' }
+  return 'validate-inconclusive'
 }
 
 /**

--- a/src/web/reauth-detect.ts
+++ b/src/web/reauth-detect.ts
@@ -23,6 +23,10 @@ const REAUTH_MARKERS: { rx: RegExp; reason: string }[] = [
   // valid the whole time) and needs the same owner-visible badge/escalation.
   // A monitored respawn self-heals it via ensureSharedClaudeOnboarded().
   { rx: /Select login method/i, reason: 'First-run onboarding picker (Select login method)' },
+  // The state the picker advances into when something blindly hits Enter on it
+  // (e.g. channels.sh's first-run guard): a browser OAuth prompt no headless
+  // box can complete. Same first-run-gate family, same restart heal.
+  { rx: /Use the url below to sign in|Paste code here if prompted/i, reason: 'Browser sign-in screen (first-run gate)' },
   { rx: /Invalid authentication credentials/i, reason: 'Invalid authentication credentials (401)' },
   { rx: /Please run\s+\/login/i, reason: 'Please run /login' },
   { rx: /Not logged in/i, reason: 'Not logged in' },

--- a/src/web/reauth-detect.ts
+++ b/src/web/reauth-detect.ts
@@ -17,6 +17,12 @@ export interface ReauthState {
 // Each entry: a distinctive marker Claude Code renders on an auth failure, and
 // the short reason surfaced to the UI. Ordered most-specific first.
 const REAUTH_MARKERS: { rx: RegExp; reason: string }[] = [
+  // Not a token failure: Claude Code's FIRST-RUN picker, shown when
+  // ~/.claude.json lost hasCompletedOnboarding. It blocks the TUI exactly like
+  // a dead login (2026-07-15 bootcamp "mass /login": the on-disk credential was
+  // valid the whole time) and needs the same owner-visible badge/escalation.
+  // A monitored respawn self-heals it via ensureSharedClaudeOnboarded().
+  { rx: /Select login method/i, reason: 'First-run onboarding picker (Select login method)' },
   { rx: /Invalid authentication credentials/i, reason: 'Invalid authentication credentials (401)' },
   { rx: /Please run\s+\/login/i, reason: 'Please run /login' },
   { rx: /Not logged in/i, reason: 'Not logged in' },

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -4,7 +4,8 @@ import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, PROJECT_ROOT, RESPAWN_ENABLED, APP_TZ } from '../config.js'
 import { resolveFromPath } from '../platform.js'
 import { listAgentNames } from './agent-config.js'
-import { isAgentRunning, capturePane } from './agent-process.js'
+import { isAgentRunning, capturePane, startAgentProcess } from './agent-process.js'
+import { quarantineFleetTokenIfDead } from './claude-credentials-guard.js'
 import { resolveAgentSession } from './channel-mcp-reconnect.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { detectReauthNeeded } from './reauth-detect.js'
@@ -53,6 +54,15 @@ export interface ReauthHealerInput {
    * we escalate-only and never inject /login.
    */
   canInteractiveLogin: boolean
+  /**
+   * The pane shows Claude Code's FIRST-RUN gate (the "Select login method"
+   * picker, or the browser sign-in screen it advances into), not a dead token.
+   * A /login send-keys is actively harmful there: on the picker the trailing
+   * Enter accepts a login method and launches a browser OAuth flow on a
+   * session whose credential is VALID (2026-07-15 bootcamp). The heal is a
+   * restart -- startAgentProcess re-seeds hasCompletedOnboarding.
+   */
+  isFirstRunGate?: boolean
   prev: ReauthHealerState
   nowMs: number
 }
@@ -64,6 +74,7 @@ export interface ReauthHealerThresholds {
 
 export interface ReauthHealerDecision {
   sendKeys: boolean   // best-effort autonomous /login (sub-agents only)
+  restartAgent: boolean // first-run-gate heal: restart the sub-agent (re-seeds the onboarding flag)
   escalate: boolean   // notify.sh alert to the owner
   next: ReauthHealerState
 }
@@ -78,11 +89,11 @@ export const NO_REAUTH_STATE: ReauthHealerState = { consecutiveDead: 0, lastActi
  * into the session every tick) and never fires for the main agent.
  */
 export function decideReauthAction(input: ReauthHealerInput, t: ReauthHealerThresholds): ReauthHealerDecision {
-  const { isDeadToken, sessionAlive, isMain, canInteractiveLogin, prev, nowMs } = input
+  const { isDeadToken, sessionAlive, isMain, canInteractiveLogin, isFirstRunGate, prev, nowMs } = input
 
   // Clean / not-applicable: end the spell, allow a fresh alert next time.
   if (!isDeadToken || !sessionAlive) {
-    return { sendKeys: false, escalate: false, next: NO_REAUTH_STATE }
+    return { sendKeys: false, restartAgent: false, escalate: false, next: NO_REAUTH_STATE }
   }
 
   const consecutiveDead = prev.consecutiveDead + 1
@@ -94,7 +105,13 @@ export function decideReauthAction(input: ReauthHealerInput, t: ReauthHealerThre
     // Autonomous /login only where it can actually help: a sub-agent, at a host
     // that can complete the browser step. On headless it would amplify the
     // cascade (rotates the shared token), so suppress it and escalate-only.
-    sendKeys: fireNow && !isMain && canInteractiveLogin,
+    // NEVER on the first-run gate: a /login there advances the picker into a
+    // browser OAuth flow on a valid credential.
+    sendKeys: fireNow && !isMain && canInteractiveLogin && isFirstRunGate !== true,
+    // First-run gate on a sub-agent: a restart heals it (startAgentProcess runs
+    // ensureSharedClaudeOnboarded first). Works headless -- no browser step.
+    // The main agent stays escalate-only; its monitored respawn paths re-seed.
+    restartAgent: fireNow && !isMain && isFirstRunGate === true,
     escalate: fireNow,
     next: {
       consecutiveDead,
@@ -238,9 +255,11 @@ function checkSession(label: string, session: string, isMain: boolean, quiet: bo
   const sessionAlive = pane != null
   const reauth = detectReauthNeeded(pane)
   const prev = watchState.get(session) ?? NO_REAUTH_STATE
+  // The reasons produced by the two first-run-gate markers in reauth-detect.
+  const isFirstRunGate = /onboarding picker|sign-in screen/i.test(reauth.reason ?? '')
 
   const decision = decideReauthAction(
-    { isDeadToken: reauth.needsReauth, sessionAlive, isMain, canInteractiveLogin: hostCanInteractiveLogin(), prev, nowMs: Date.now() },
+    { isDeadToken: reauth.needsReauth, sessionAlive, isMain, canInteractiveLogin: hostCanInteractiveLogin(), isFirstRunGate, prev, nowMs: Date.now() },
     { threshold: DEAD_PROBE_THRESHOLD, cooldownMs: ESCALATION_COOLDOWN_MS },
   )
 
@@ -257,6 +276,10 @@ function checkSession(label: string, session: string, isMain: boolean, quiet: bo
     logger.warn({ label, session }, 'reauth-healer: confirmed dead token on live sub-agent -- best-effort /login send-keys')
     void sendBestEffortLogin(session)
   }
+  if (decision.restartAgent) {
+    logger.warn({ label, session, reason: reauth.reason }, 'reauth-healer: first-run gate on live sub-agent -- restarting it (re-seeds hasCompletedOnboarding)')
+    void restartFirstRunGatedAgent(label, session)
+  }
   if (decision.escalate) {
     logger.error({ label, session, reason: reauth.reason, quiet }, 'reauth-healer: dead OAuth token on live session -- escalating to owner')
     routeEscalation(
@@ -264,6 +287,35 @@ function checkSession(label: string, session: string, isMain: boolean, quiet: bo
       quiet,
       sendNotify,
     )
+    // A genuine 401 family failure while a fleet token exists: probe that token
+    // once and quarantine it if the probe proves it dead (server-side
+    // revocation). Without this there is NO recovery path -- every new launch
+    // re-injects the dead env token (which strictly overrides valid file
+    // creds), and a manual delete would be undone by the boot sync. Cadence is
+    // bounded by the escalation cooldown. Skipped for the first-run gate: the
+    // credential there is typically fine.
+    if (!isFirstRunGate) {
+      quarantineFleetTokenIfDead()
+        .then((r) => { if (r !== 'no-token') logger.warn({ label, result: r }, 'reauth-healer: fleet-token liveness check') })
+        .catch((err) => logger.debug({ err }, 'reauth-healer: fleet-token liveness check failed'))
+    }
+  }
+}
+
+// First-run-gate heal for a SUB-agent: kill the parked session (nothing is
+// in-flight -- the TUI is blocked pre-boot on the picker) and relaunch it;
+// startAgentProcess runs ensureSharedClaudeOnboarded before the fresh claude
+// starts, so the relaunch comes up past the gate.
+async function restartFirstRunGatedAgent(name: string, session: string): Promise<void> {
+  await new Promise<void>((resolve) => {
+    execFile(TMUX, ['kill-session', '-t', session], { timeout: 5000 }, () => resolve())
+  })
+  await sleep(1000)
+  try {
+    const r = startAgentProcess(name)
+    if (!r.ok) logger.warn({ name, error: r.error }, 'reauth-healer: first-run-gate relaunch failed')
+  } catch (err) {
+    logger.warn({ err, name }, 'reauth-healer: first-run-gate relaunch threw')
   }
 }
 

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -204,6 +204,37 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
     if (token && !/^sk-ant-oat/.test(token)) { json(res, { error: 'A setup-token formatuma nem stimmel (sk-ant-oat...).', reason: 'bad-token' }, 400); return true }
     if (apiKey && !/^sk-ant-/.test(apiKey)) { json(res, { error: 'Az API-kulcs formatuma nem stimmel (sk-ant-...).', reason: 'bad-key' }, 400); return true }
 
+    // Verify BEFORE persisting (no API spend: `claude auth status` only inspects
+    // the token). 2026-07-15 bootcamp bug 3: the old persist-then-verify order
+    // stored a mistyped/revoked token into .env + the fleet token file and still
+    // returned ok:true -- and since CLAUDE_CODE_OAUTH_TOKEN env strictly
+    // overrides a valid ~/.claude/.credentials.json, that single bad paste
+    // 401-ed ("Invalid bearer token") every sub-agent launched afterwards while
+    // the env-less main agent kept working. A rejected credential must never
+    // land on disk. Only a verification that RAN and failed blocks the persist;
+    // when the check itself cannot run (claude binary missing / timeout) we keep
+    // the old best-effort behaviour and store it as verified:false.
+    let verified = false
+    let verifyRejected = false
+    try {
+      execFileSync(resolveFromPath('claude'), ['auth', 'status'], {
+        timeout: 25_000,
+        stdio: 'ignore',
+        env: { ...process.env, ...(token ? { CLAUDE_CODE_OAUTH_TOKEN: token } : { ANTHROPIC_API_KEY: apiKey }) },
+      })
+      verified = true
+    } catch (err) {
+      // execFileSync sets a numeric `status` only when the process ran and
+      // exited non-zero (= the CLI actively rejected the credential); ENOENT
+      // and timeout leave it undefined/null.
+      verifyRejected = typeof (err as { status?: unknown }).status === 'number'
+    }
+    if (verifyRejected) {
+      logger.warn({ mode: token ? 'oauth' : 'apikey' }, 'onboarding: Claude auth REJECTED by `claude auth status`; nothing persisted')
+      json(res, { error: 'A megadott token/kulcs nem ervenyes (a claude auth status elutasitotta). Ellenorizd, hogy a teljes setup-tokent illesztetted-e be.', reason: 'verify-failed', verified: false }, 400)
+      return true
+    }
+
     try {
       if (token) {
         setEnvKey('CLAUDE_CODE_OAUTH_TOKEN', token)
@@ -217,17 +248,6 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
       json(res, { error: 'Nem sikerult elmenteni az .env-be.', reason: 'write-failed' }, 500)
       return true
     }
-
-    // Verify WITHOUT an API spend: `claude auth status` only inspects the token.
-    let verified = false
-    try {
-      execFileSync(resolveFromPath('claude'), ['auth', 'status'], {
-        timeout: 25_000,
-        stdio: 'ignore',
-        env: { ...process.env, ...(token ? { CLAUDE_CODE_OAUTH_TOKEN: token } : { ANTHROPIC_API_KEY: apiKey }) },
-      })
-      verified = true
-    } catch { verified = false }
     logger.info({ verified, mode: token ? 'oauth' : 'apikey' }, 'onboarding: Claude auth stored')
     json(res, { ok: true, verified })
     return true

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -10,6 +10,7 @@ import { channelStateDir } from '../../channel-provider.js'
 import { sessionExistsOnHost } from '../agent-process.js'
 import { MAIN_CHANNELS_SESSION } from '../main-agent.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
+import { liveProbeAuth, stampTokenVerified } from '../claude-credentials-guard.js'
 import { json, readBody } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
 
@@ -204,42 +205,33 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
     if (token && !/^sk-ant-oat/.test(token)) { json(res, { error: 'A setup-token formatuma nem stimmel (sk-ant-oat...).', reason: 'bad-token' }, 400); return true }
     if (apiKey && !/^sk-ant-/.test(apiKey)) { json(res, { error: 'Az API-kulcs formatuma nem stimmel (sk-ant-...).', reason: 'bad-key' }, 400); return true }
 
-    // Verify BEFORE persisting (no API spend: `claude auth status` only inspects
-    // the token). 2026-07-15 bootcamp bug 3: the old persist-then-verify order
-    // stored a mistyped/revoked token into .env + the fleet token file and still
-    // returned ok:true -- and since CLAUDE_CODE_OAUTH_TOKEN env strictly
-    // overrides a valid ~/.claude/.credentials.json, that single bad paste
-    // 401-ed ("Invalid bearer token") every sub-agent launched afterwards while
-    // the env-less main agent kept working. A rejected credential must never
-    // land on disk. Only a verification that RAN and failed blocks the persist;
-    // when the check itself cannot run (claude binary missing / timeout) we keep
-    // the old best-effort behaviour and store it as verified:false.
-    let verified = false
-    let verifyRejected = false
-    try {
-      execFileSync(resolveFromPath('claude'), ['auth', 'status'], {
-        timeout: 25_000,
-        stdio: 'ignore',
-        env: { ...process.env, ...(token ? { CLAUDE_CODE_OAUTH_TOKEN: token } : { ANTHROPIC_API_KEY: apiKey }) },
-      })
-      verified = true
-    } catch (err) {
-      // execFileSync sets a numeric `status` only when the process ran and
-      // exited non-zero (= the CLI actively rejected the credential); ENOENT
-      // and timeout leave it undefined/null.
-      verifyRejected = typeof (err as { status?: unknown }).status === 'number'
-    }
-    if (verifyRejected) {
-      logger.warn({ mode: token ? 'oauth' : 'apikey' }, 'onboarding: Claude auth REJECTED by `claude auth status`; nothing persisted')
-      json(res, { error: 'A megadott token/kulcs nem ervenyes (a claude auth status elutasitotta). Ellenorizd, hogy a teljes setup-tokent illesztetted-e be.', reason: 'verify-failed', verified: false }, 400)
+    // Verify BEFORE persisting, with a REAL probe. 2026-07-15 bootcamp bug 3:
+    // the old persist-then-verify order stored a mistyped/revoked token into
+    // .env + the fleet token file and still returned ok:true -- and since
+    // CLAUDE_CODE_OAUTH_TOKEN env strictly overrides a valid
+    // ~/.claude/.credentials.json, that single bad paste 401-ed ("Invalid
+    // bearer token") every sub-agent launched afterwards while the env-less
+    // main agent kept working. NOTE: `claude auth status` is NOT a validator --
+    // it exits 0 for a garbage token (it reports the auth source; proven live
+    // on the reference VPS) -- so this uses liveProbeAuth (one tiny haiku
+    // `claude -p` call). Only a probe that PROVES the credential dead blocks
+    // the persist; an inconclusive probe (binary missing / network flake)
+    // keeps the old best-effort behaviour and stores it as verified:false.
+    const probe = await liveProbeAuth(token ? { CLAUDE_CODE_OAUTH_TOKEN: token } : { ANTHROPIC_API_KEY: apiKey })
+    if (probe === 'auth-rejected') {
+      logger.warn({ mode: token ? 'oauth' : 'apikey' }, 'onboarding: Claude auth REJECTED by live probe; nothing persisted')
+      json(res, { error: 'A megadott token/kulcs nem ervenyes (a proba-hivast a szerver elutasitotta). Ellenorizd, hogy a teljes setup-tokent illesztetted-e be.', reason: 'verify-failed', verified: false }, 400)
       return true
     }
+    const verified = probe === 'ok'
 
     try {
       if (token) {
         setEnvKey('CLAUDE_CODE_OAUTH_TOKEN', token)
         // Keep the credentials-guard fleet token file in sync (harmless if unused).
         try { mkdirSync(STORE_DIR, { recursive: true }); writeFileSync(FLEET_TOKEN_FILE, token, { mode: 0o600 }) } catch { /* optional */ }
+        // A live-verified token needs no boot-time re-probe.
+        if (verified) stampTokenVerified(token)
       } else {
         setEnvKey('ANTHROPIC_API_KEY', apiKey)
       }


### PR DESCRIPTION
## Summary

Fixes the 2026-07-15 bootcamp token-handling incident (4 field bugs), root-caused LIVE on the bootcamp reference VPS with an 8-agent investigation + adversarial refutation pass, then verified in two live rounds on the same box.

### Root causes (all live-proven, hypotheses refuted where wrong)

1. **"Mass /login ejection" was NOT auth loss.** `~/.claude.json` lost `hasCompletedOnboarding` (clobbered within ~1h of install), so every fresh respawn parked on Claude Code's first-run "Select login method" picker while the on-disk 1-year `sk-ant-oat01` credential stayed valid the whole time (live probe: HTTP 200). The reauth stack only knew 401-style markers, so nothing detected or healed it.
2. **Sub-agent "bad bearer token" while main survived = env-token override.** `CLAUDE_CODE_OAUTH_TOKEN` env strictly overrides a valid `~/.claude/.credentials.json` (proven: bogus env + valid file = exactly `401 Invalid bearer token`). Sub-agents get the env injected at every launch; the env-less main authenticates from the file.
3. **The setup-token + `claude auth login` "corruption race" hypothesis was REFUTED.** Both write the same single-slot credentials.json last-writer-wins, but each write leaves a valid credential; a 1-year oat01 never refreshes overnight.
4. **Connecting root gap:** a terminal-run `claude setup-token` lands only in credentials.json; the wizard's `claudeAuthPresent()` passes from that alone, so `store/.claude-oauth-token` was never created and per-agent isolation + the #537 guard silently disabled themselves.
5. **`claude auth status` is NOT a validator** — it exits 0 for a garbage token (reports the auth source only). Found when round-1's verify-first gate turned out to be a no-op live.

### Changes

- **`ensureSharedClaudeOnboarded()`** (agent-process): guarantee `hasCompletedOnboarding` in the shared `~/.claude.json` (atomic 0600 write, unparseable left alone) before every sub-agent launch and main respawn; `channels.sh` cold-boot does the same inline (live-observed: cold boot with the key missing had the first-run guard blindly Enter the picker into an unrecoverable browser sign-in screen).
- **reauth-detect**: two new first-run-gate markers (picker + sign-in screen). **reauth-healer**: on the first-run gate it never types `/login` (that Enter launches a browser OAuth flow on a valid credential); sub-agents get a restart heal instead, main stays escalate-only.
- **Wizard `claude-auth` verify-first with a real probe** (`liveProbeAuth`, one tiny haiku `claude -p`, sibling auth env stripped): a credential the probe PROVES dead gets HTTP 400 and never lands on disk; inconclusive probes (no binary / network flake) fall back to the old persist-unverified behavior.
- **Fleet-token lifecycle** (claude-credentials-guard):
  - `syncFleetTokenFromSharedCredentials()`: boot-time promotion of a terminal-pasted setup-token into `store/.claude-oauth-token` — **longevity-gated** (`expiresAt` ≥ 90 days; the oat01 prefix alone does NOT discriminate setup-tokens from rotating access tokens) + live-probed first.
  - `fleetTokenBootPass()` (deferred 15s, never blocks boot): validates a never-verified existing fleet token; **quarantines** (`.bad` + stamp drop) one the probe proves dead. The healer runs the same quarantine check on a confirmed agent 401 — the recovery path for tokens revoked after write time.
- **Auth-source consistency**: main-session respawns and `channels.sh` export the fleet token when the store file exists (previously the token leg was gated on the macOS-only isolated config dir, so Linux respawns silently fell back to shared file auth); workers stop symlinking the shared rotating credentials.json when a fleet token exists and get the token env at launch.
- **install-linux.sh**: captured setup-token also written to `store/.claude-oauth-token` (shape-gated, umask 077).

### Live verification (hermes test VPS, bootcamp-clone install)

Round 1: boot-sync promotion, channels.sh fallback, respawn token export, onboarding re-seed via restart endpoint — PASS; caught the `claude auth status` no-op (fixed in round 2). Round 2 (final HEAD): bogus-paste 400 + nothing persisted, real-paste 200 verified, boot-pass validated-cached, poison → QUARANTINE → self-re-promotion loop, channels.sh cold-boot re-seed with clean pane — all PASS. The VPS runs this exact HEAD now.

Tests: 2200 passed (13 pre-existing hook-path failures are a /tmp-worktree location artifact, identical on clean develop). `tsc` clean, `bash -n` clean on both scripts.

## ⚠️ Prod-impact (distribution notes for Marveen)

- **install/update flow behavior change**: on installs where a long-lived setup-token sits in `~/.claude/.credentials.json` (every bootcamp box), the first boot after update promotes it to `store/.claude-oauth-token` → per-agent isolation activates for newly launched sub-agents and the main respawn/boot switches to env-token auth. This is the intended fix, but it is a day-one auth-source change on existing installs.
- **One extra haiku API call** possible at boot (probe; cached via the `.verified` stamp) and one per wizard token paste.
- The bootcamp boxes additionally still need this update to get the v1.22.2 pairing fix (they run v1.22.1).
- Open question (not blocking, untestable headlessly): whether re-running `claude setup-token` server-side revokes the previously issued token — the plausible midday trigger for bug 3 on the bootcamp machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
