### PR TITLE
Fix boot crash when claude/tmux transiently unresolvable on PATH

### DIFF
--- a/src/__tests__/platform-bin-resolve.test.ts
+++ b/src/__tests__/platform-bin-resolve.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Regression cover for the 04:00 auto-update boot crash: a transient PATH gap
+// makes `which claude` fail, and a module-level `resolveFromPath('claude')`
+// then threw at import time, taking the whole dashboard (and the scheduler that
+// lives in it) down. tryResolveFromPath must fall back to known install dirs,
+// and makeLazyBinResolver must not resolve (or throw) until first use.
+
+const mockExecSync = vi.fn()
+const mockExistsSync = vi.fn()
+
+vi.mock('node:child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const real = await importOriginal<typeof import('node:fs')>()
+  return { ...real, existsSync: (p: string) => mockExistsSync(p) }
+})
+
+import { tryResolveFromPath, resolveFromPath, makeLazyBinResolver } from '../platform.js'
+
+beforeEach(() => {
+  mockExecSync.mockReset()
+  mockExistsSync.mockReset()
+  mockExistsSync.mockReturnValue(false)
+})
+
+describe('tryResolveFromPath', () => {
+  it('returns the which-resolved path when PATH resolves the binary', () => {
+    mockExecSync.mockReturnValue('/opt/homebrew/bin/claude\n')
+    expect(tryResolveFromPath('claude')).toBe('/opt/homebrew/bin/claude')
+    expect(mockExistsSync).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a known install dir when which fails (transient PATH gap)', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('which: no claude in PATH') })
+    mockExistsSync.mockImplementation((p: string) => p === '/opt/homebrew/bin/claude')
+    expect(tryResolveFromPath('claude')).toBe('/opt/homebrew/bin/claude')
+  })
+
+  it('probes /usr/local/bin when /opt/homebrew/bin has no binary', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('which failed') })
+    mockExistsSync.mockImplementation((p: string) => p === '/usr/local/bin/tmux')
+    expect(tryResolveFromPath('tmux')).toBe('/usr/local/bin/tmux')
+  })
+
+  it('returns null (does NOT throw) when the binary is absent everywhere', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('which failed') })
+    mockExistsSync.mockReturnValue(false)
+    expect(tryResolveFromPath('claude')).toBeNull()
+  })
+
+  it('rejects an invalid binary name before touching the shell', () => {
+    expect(() => tryResolveFromPath('claude; rm -rf /')).toThrow(/Invalid binary name/)
+    expect(mockExecSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveFromPath', () => {
+  it('throws only when the binary is truly unresolvable', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('which failed') })
+    mockExistsSync.mockReturnValue(false)
+    expect(() => resolveFromPath('claude')).toThrow(/Required binary not found/)
+  })
+})
+
+describe('makeLazyBinResolver', () => {
+  it('does not resolve at construction time (safe during a boot-time PATH gap)', () => {
+    makeLazyBinResolver('claude')
+    expect(mockExecSync).not.toHaveBeenCalled()
+    expect(mockExistsSync).not.toHaveBeenCalled()
+  })
+
+  it('resolves on first call and memoises the result', () => {
+    mockExecSync.mockReturnValue('/opt/homebrew/bin/tmux\n')
+    const tmuxBin = makeLazyBinResolver('tmux')
+    expect(tmuxBin()).toBe('/opt/homebrew/bin/tmux')
+    expect(tmuxBin()).toBe('/opt/homebrew/bin/tmux')
+    expect(mockExecSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces the not-found error on first use, not at import', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('which failed') })
+    mockExistsSync.mockReturnValue(false)
+    const claudeBin = makeLazyBinResolver('claude')
+    expect(() => claudeBin()).toThrow(/Required binary not found/)
+  })
+})

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,4 +1,6 @@
 import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 
 export type PlatformType = 'macos' | 'linux-server' | 'linux-gui'
 
@@ -15,11 +17,47 @@ function detect(): PlatformType {
 
 export const PLATFORM: PlatformType = detect()
 
-export function resolveFromPath(name: string): string {
+// Standard install locations probed when `which` cannot resolve a binary. A
+// transient PATH gap is the failure this guards against: the 04:00 auto-update
+// finalizer restarts the dashboard with only NODE_PIN_DIR prepended to PATH, so
+// /opt/homebrew/bin (where `claude` and `tmux` live) is briefly absent and
+// `which claude` fails -- even though the binary is present on disk. Probing
+// these dirs recovers the real path instead of hard-failing.
+const KNOWN_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin']
+
+// Resolve a binary to an absolute path, or null if it cannot be found on PATH
+// or in any known install dir. Never throws for a missing binary (only for an
+// invalid name), so callers can decide whether absence is fatal.
+export function tryResolveFromPath(name: string): string | null {
   if (!/^[a-zA-Z0-9._-]+$/.test(name)) throw new Error('Invalid binary name: ' + name)
   try {
     return execSync(`which ${name}`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
   } catch {
-    throw new Error(`Required binary not found on PATH: ${name}`)
+    for (const dir of KNOWN_BIN_DIRS) {
+      const candidate = join(dir, name)
+      if (existsSync(candidate)) return candidate
+    }
+    return null
+  }
+}
+
+export function resolveFromPath(name: string): string {
+  const resolved = tryResolveFromPath(name)
+  if (!resolved) throw new Error(`Required binary not found on PATH: ${name}`)
+  return resolved
+}
+
+// Lazy, memoised binary resolver. Unlike a module-level `resolveFromPath(...)`
+// const -- which throws at IMPORT time and takes the whole dashboard (and the
+// scheduler that lives in it) down if the binary is transiently unresolvable --
+// this defers resolution to first use. A boot that happens during a PATH gap
+// therefore succeeds; only the first actual use of the binary can throw, and
+// that call site can handle it. The resolved path is cached after the first
+// successful lookup.
+export function makeLazyBinResolver(name: string): () => string {
+  let cached: string | null = null
+  return () => {
+    if (cached === null) cached = resolveFromPath(name)
+    return cached
   }
 }

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync, execFileSync } from 'node:child_process'
 import { OLLAMA_URL } from '../config.js'
-import { resolveFromPath } from '../platform.js'
+import { makeLazyBinResolver } from '../platform.js'
 import { logger } from '../logger.js'
 import {
   paneLooksIdle,
@@ -46,8 +46,12 @@ import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
 
-const TMUX = resolveFromPath('tmux')
-const CLAUDE = resolveFromPath('claude')
+// Lazy so a transient PATH gap at import time (e.g. the 04:00 auto-update
+// restart, where the finalizer omits the bin dir from PATH) cannot hard-crash
+// the dashboard boot and take the scheduler down with it. Resolution happens on
+// first use; see makeLazyBinResolver.
+const tmuxBin = makeLazyBinResolver('tmux')
+const claudeBin = makeLazyBinResolver('claude')
 
 // Shared async pacing helper. Replaces the blocking synchronous `/bin/sleep`
 // (execFileSync) pauses in the tmux-driving injection hot-path so a pacing wait
@@ -544,7 +548,7 @@ function runTmux(host: string | null, tmuxArgs: string[], opts: { timeout?: numb
   // call (idempotent, ~free). Without this a watcher-first remote call after a
   // marveen restart would lose connection multiplexing and re-handshake each tick.
   if (host) ensureControlDir()
-  const inv = buildTmuxInvocation(host, TMUX, tmuxArgs)
+  const inv = buildTmuxInvocation(host, tmuxBin(), tmuxArgs)
   // stdio: capture the child's stderr into the thrown error instead of letting
   // execFileSync's default inherit it to the parent stderr. A restarting agent
   // makes tmux emit `can't find session: agent-X` / `no server running`; without
@@ -555,7 +559,7 @@ function runTmux(host: string | null, tmuxArgs: string[], opts: { timeout?: numb
 
 function captureTmux(host: string | null, tmuxArgs: string[], opts: { timeout?: number } = {}): string {
   if (host) ensureControlDir()
-  const inv = buildTmuxInvocation(host, TMUX, tmuxArgs)
+  const inv = buildTmuxInvocation(host, tmuxBin(), tmuxArgs)
   // stdout piped (we return it); stderr piped too so tmux's `can't find session`
   // noise lands in err.stderr on failure rather than the parent stderr / dashboard.log.
   return execFileSync(inv.file, inv.args, { timeout: opts.timeout ?? (host ? 8000 : 3000), encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] })
@@ -705,7 +709,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
   // and without the flag). Runs before launch so a valid setup-token retires
   // the rotating ~/.claude/.credentials.json; idempotent, so calling it per
   // start also self-heals if Claude Code recreates the file on a refresh.
-  renameSharedCredentialsIfSafe(CLAUDE)
+  renameSharedCredentialsIfSafe(claudeBin())
 
   // Shared-root agents park on the first-run "Select login method" picker when
   // ~/.claude.json lost hasCompletedOnboarding (2026-07-15 bootcamp incident);
@@ -776,7 +780,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // this agent's tmux session above, so its leftover claude is now detached;
     // pane attribution spares every live sibling and the main session.
     try {
-      reapDetachedChannelClaudes({ tmuxPath: TMUX })
+      reapDetachedChannelClaudes({ tmuxPath: tmuxBin() })
     } catch (err) {
       logger.warn({ err, name }, 'pre-launch detached-claude reap failed (continuing)')
     }
@@ -979,7 +983,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     const promptSuggestionEnv = 'export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && '
     // Single-quote `${model}` so values like `claude-opus-4-8[1m]` (1M-context
     // suffix) are not glob-expanded by the shell that tmux spawns the command in.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${CLAUDE} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${claudeBin()} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
     runTmux(null, ['new-session', '-d', '-s', session, cmd], { timeout: 10000 })
 
     logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')


### PR DESCRIPTION
## Probléma (P1)

A 04:00 auto-update finalizer (`store/update-finalize.sh`) a dashboard-t úgy indítja újra, hogy csak a `NODE_PIN_DIR`-t rakja a PATH-ra, a `/opt/homebrew/bin`-t (ahol a `claude` és `tmux` él) **nem**. Ilyenkor a `which claude` bukik, és mivel az `agent-process.ts` (plusz 12 további modul) **modul-import szinten** hívta a `resolveFromPath('claude')`-ot, a hiba fatálisan dobott import-időben → a teljes dashboard boot elszállt (`Required binary not found on PATH: claude`), és vele a benne élő scheduler is.

2026-07-16-án ez ~7 óra némaságot okozott: sem a 6:30 reggeli-napindító, sem a 8:00 hotel-brief nem firelt. Gyökér: `dist/web/agent-process.js` modul-eval → `platform.js` `execSync("which claude")` fatálisan dob. (Jarvis lelet.)

## Fix — két réteg

**1. `platform.ts` — gyökér-fix, mind a 13 eager hívó-helyet védi.** A `resolveFromPath` a `which` bukása után végigpróbálja a szokványos install-direket (`/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`). A 2026-07-16-i incidensben a `claude` **létezett** `/opt/homebrew/bin`-ben, csak a PATH-ból hiányzott — a fallback ezt crash nélkül feloldja. Új `tryResolveFromPath()` null-t ad hiánynál (nem dob); a `resolveFromPath` továbbra is dob, ha tényleg sehol nincs.

**2. `agent-process.ts` — a stack trace által nevesített modul, Jarvis preferált megközelítése.** A `TMUX`/`CLAUDE` feloldás **lazy** lett (`makeLazyBinResolver`): első használatkor resolvál, nem import-kor. Egy PATH-gap alatti boot így akkor is átmegy, ha a fallback valamiért nem találná; a hiba csak az első tényleges használatkor jelentkezhet, ahol kezelhető.

A többi eager hívó-hely (`channel-monitor.ts`, `agent-worker.ts`, stb.) a `platform.ts` fallbackjától védve van. A teljes lazy-migráció külön, opcionális follow-up.

## Repró

- Régi kód: `env -i PATH=/usr/bin:/bin node dist/index.js` → crash import-időben.
- Új: `tryResolveFromPath('claude')` a `/opt/homebrew/bin`-ből oldja fel, boot nem crashel.

## Teszt

Új `platform-bin-resolve.test.ts`, 9 eset: which-hit, fallback minden dirre, null-hiány (nem dob), invalid-name reject, lazy nem-resolvál konstruktorkor, memoizáció, első-használatkori dobás. **Teljes suite zöld: 2247 teszt / 161 fájl.** Typecheck tiszta.

## Reviewer findings

Nincs Molyo-reviewer csapat a marveen repóhoz (a `.claude/agents/` a Molyóé), így a pre-merge pipeline itt nem alkalmazható. Manuális ellenőrzés: teljes vitest suite + tsc + repró.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XL7FNQiYjDcSwqFik3vCh1