### PR TITLE
fix(platform): probe user-level bin dirs (~/.local/bin, ~/.bun/bin) in the PATH-gap fallback

### DIFF
--- a/src/__tests__/platform-bin-resolve.test.ts
+++ b/src/__tests__/platform-bin-resolve.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
 // Regression cover for the 04:00 auto-update boot crash: a transient PATH gap
 // makes `which claude` fail, and a module-level `resolveFromPath('claude')`
@@ -43,6 +45,23 @@ describe('tryResolveFromPath', () => {
     mockExecSync.mockImplementation(() => { throw new Error('which failed') })
     mockExistsSync.mockImplementation((p: string) => p === '/usr/local/bin/tmux')
     expect(tryResolveFromPath('tmux')).toBe('/usr/local/bin/tmux')
+  })
+
+  it('probes the user-level install dirs (~/.local/bin native, ~/.bun/bin bun) -- the bootcamp/AVX-fallback layout', () => {
+    const home = homedir()
+    mockExecSync.mockImplementation(() => { throw new Error('which failed') })
+    mockExistsSync.mockImplementation((p: string) => p === join(home, '.local', 'bin', 'claude'))
+    expect(tryResolveFromPath('claude')).toBe(join(home, '.local', 'bin', 'claude'))
+    mockExistsSync.mockImplementation((p: string) => p === join(home, '.bun', 'bin', 'claude'))
+    expect(tryResolveFromPath('claude')).toBe(join(home, '.bun', 'bin', 'claude'))
+  })
+
+  it('user-level dirs win over system dirs (PATH-precedence parity)', () => {
+    const home = homedir()
+    mockExecSync.mockImplementation(() => { throw new Error('which failed') })
+    mockExistsSync.mockImplementation((p: string) =>
+      p === join(home, '.local', 'bin', 'claude') || p === '/usr/bin/claude')
+    expect(tryResolveFromPath('claude')).toBe(join(home, '.local', 'bin', 'claude'))
   })
 
   it('returns null (does NOT throw) when the binary is absent everywhere', () => {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { homedir } from 'node:os'
 
 export type PlatformType = 'macos' | 'linux-server' | 'linux-gui'
 
@@ -23,7 +24,18 @@ export const PLATFORM: PlatformType = detect()
 // /opt/homebrew/bin (where `claude` and `tmux` live) is briefly absent and
 // `which claude` fails -- even though the binary is present on disk. Probing
 // these dirs recovers the real path instead of hard-failing.
-const KNOWN_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin']
+// The user-level dirs cover the two most common `claude` install locations
+// (native installer -> ~/.local/bin, bun -> ~/.bun/bin) -- exactly the layout
+// on bootcamp/AVX-fallback boxes, which would otherwise still hard-fail during
+// a PATH gap (#632 follow-up).
+const KNOWN_BIN_DIRS = [
+  join(homedir(), '.local', 'bin'),
+  join(homedir(), '.bun', 'bin'),
+  '/opt/homebrew/bin',
+  '/usr/local/bin',
+  '/usr/bin',
+  '/bin',
+]
 
 // Resolve a binary to an absolute path, or null if it cannot be found on PATH
 // or in any known install dir. Never throws for a missing binary (only for an


### PR DESCRIPTION
Follow-up to #632 (verify note 1): the fallback probe list covered only system/homebrew dirs, while the two most common claude install locations are user-level (native installer: ~/.local/bin, bun: ~/.bun/bin) -- the bootcamp/AVX-fallback layout. During a transient PATH gap those installs still hard-failed. User dirs probed first (PATH-precedence parity). Tests extended: user-dir probing both locations + precedence over system dirs. Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)