### PR TITLE
fix(ledger-replay): byte-based self-trim so the fresh conversation end survives harness injection

### DIFF
--- a/scripts/__tests__/conversation-ledger.test.sh
+++ b/scripts/__tests__/conversation-ledger.test.sh
@@ -36,7 +36,7 @@ run_hook() {
     # OWNER_NAME is pinned to 'Gyula' so the replay's inbound prefix is
     # deterministic regardless of the install's .env (assertions below grep for
     # "Gyula:"). Same reasoning as pinning MAIN_AGENT_ID.
-    LEDGER_DB_PATH="$db" LEDGER_OWNER_CHAT="8517922966" MAIN_AGENT_ID="marveen" \
+    LEDGER_DB_PATH="$db" LEDGER_OWNER_CHAT="10000000001" MAIN_AGENT_ID="marveen" \
         OWNER_NAME="Gyula" \
         python3 "$HOOKS_DIR/$hook" "$@"
 }
@@ -45,7 +45,7 @@ run_hook() {
 # (matching the capture/outbound rows). The drain's dedup statefile lands beside
 # the DB (dirname of LEDGER_DB_PATH), so per-case subdirs keep it isolated.
 run_drain() { # db
-    ( cd "$INSTALL_DIR" && LEDGER_DB_PATH="$1" LEDGER_OWNER_CHAT="8517922966" \
+    ( cd "$INSTALL_DIR" && LEDGER_DB_PATH="$1" LEDGER_OWNER_CHAT="10000000001" \
         MAIN_AGENT_ID="marveen" python3 "$HOOKS_DIR/ledger-live-drain.py" )
 }
 
@@ -137,13 +137,13 @@ echo ""
 echo "(a) Inbound capture"
 
 DB_A="$TMPDIR_BASE/a.db"
-emit_inbound 8517922966 1054 "Jok a Fokusz e-mail cimek" | run_hook ledger-capture.py "$DB_A"
+emit_inbound 10000000001 1054 "Jok a Fokusz e-mail cimek" | run_hook ledger-capture.py "$DB_A"
 
 assert_eq "inbound capture: exactly 1 row" "1" \
     "$(db_scalar "$DB_A" "SELECT COUNT(*) FROM conversation_log")"
 assert_eq "inbound capture: direction='in'" "in" \
     "$(db_scalar "$DB_A" "SELECT direction FROM conversation_log")"
-assert_eq "inbound capture: chat_id" "8517922966" \
+assert_eq "inbound capture: chat_id" "10000000001" \
     "$(db_scalar "$DB_A" "SELECT chat_id FROM conversation_log")"
 assert_eq "inbound capture: message_id" "1054" \
     "$(db_scalar "$DB_A" "SELECT message_id FROM conversation_log")"
@@ -157,20 +157,20 @@ echo ""
 echo "(b) Outbound capture"
 
 DB_B="$TMPDIR_BASE/b.db"
-emit_inbound 8517922966 1054 "kerdes" | run_hook ledger-capture.py "$DB_B"
-emit_reply 8517922966 "ez a valaszom" | run_hook ledger-outbound.py "$DB_B"
+emit_inbound 10000000001 1054 "kerdes" | run_hook ledger-capture.py "$DB_B"
+emit_reply 10000000001 "ez a valaszom" | run_hook ledger-outbound.py "$DB_B"
 
 assert_eq "outbound: exactly 1 out row" "1" \
     "$(db_scalar "$DB_B" "SELECT COUNT(*) FROM conversation_log WHERE direction='out'")"
 assert_eq "outbound: reply text recorded" "ez a valaszom" \
     "$(db_scalar "$DB_B" "SELECT text FROM conversation_log WHERE direction='out'")"
-assert_eq "outbound: out row chat_id" "8517922966" \
+assert_eq "outbound: out row chat_id" "10000000001" \
     "$(db_scalar "$DB_B" "SELECT chat_id FROM conversation_log WHERE direction='out'")"
 
 # chat_id=0 shorthand resolves to the owner chat
 DB_B2="$TMPDIR_BASE/b2.db"
 emit_reply 0 "valasz nullaval" | run_hook ledger-outbound.py "$DB_B2"
-assert_eq "outbound: chat_id=0 shorthand resolves to owner chat" "8517922966" \
+assert_eq "outbound: chat_id=0 shorthand resolves to owner chat" "10000000001" \
     "$(db_scalar "$DB_B2" "SELECT chat_id FROM conversation_log WHERE direction='out'")"
 
 # ---------------------------------------------------------------------------
@@ -181,7 +181,7 @@ echo "(c) Startup replay"
 
 # Open question present: single unanswered inbound
 DB_C="$TMPDIR_BASE/c.db"
-emit_inbound 8517922966 1054 "Jok a Fokusz cimek" | run_hook ledger-capture.py "$DB_C"
+emit_inbound 10000000001 1054 "Jok a Fokusz cimek" | run_hook ledger-capture.py "$DB_C"
 emit_session | run_hook ledger-replay.py "$DB_C" > "$TMPDIR_BASE/c.json"
 C_CTX="$(ctx_of "$TMPDIR_BASE/c.json")"
 if [ -n "$C_CTX" ]; then pass "replay: produced output for open conversation"; else fail "replay: expected output, got empty"; fi
@@ -198,9 +198,9 @@ fi
 
 # Context window is chronological and prefixed (Gyula: / Te:)
 DB_CW="$TMPDIR_BASE/cw.db"
-emit_inbound 8517922966 1 "ELSO_UZENET"  | run_hook ledger-capture.py  "$DB_CW"
-emit_reply   8517922966   "VALASZ_KOZEP" | run_hook ledger-outbound.py "$DB_CW"
-emit_inbound 8517922966 2 "MASODIK_UZENET" | run_hook ledger-capture.py "$DB_CW"
+emit_inbound 10000000001 1 "ELSO_UZENET"  | run_hook ledger-capture.py  "$DB_CW"
+emit_reply   10000000001   "VALASZ_KOZEP" | run_hook ledger-outbound.py "$DB_CW"
+emit_inbound 10000000001 2 "MASODIK_UZENET" | run_hook ledger-capture.py "$DB_CW"
 emit_session | run_hook ledger-replay.py "$DB_CW" > "$TMPDIR_BASE/cw.json"
 CW_CTX="$(ctx_of "$TMPDIR_BASE/cw.json")"
 if printf '%s' "$CW_CTX" | grep -q "Gyula:" && printf '%s' "$CW_CTX" | grep -q "Te:"; then
@@ -232,8 +232,8 @@ assert_eq "replay: empty ledger prints nothing" "" "$EMPTY_OUT"
 
 # All-answered ledger -> STILL prints transcript context, but NO open-question block
 DB_C_DONE="$TMPDIR_BASE/c_done.db"
-emit_inbound 8517922966 1054 "regi kerdes" | run_hook ledger-capture.py "$DB_C_DONE"
-emit_reply 8517922966 "regi valasz" | run_hook ledger-outbound.py "$DB_C_DONE"
+emit_inbound 10000000001 1054 "regi kerdes" | run_hook ledger-capture.py "$DB_C_DONE"
+emit_reply 10000000001 "regi valasz" | run_hook ledger-outbound.py "$DB_C_DONE"
 emit_session | run_hook ledger-replay.py "$DB_C_DONE" > "$TMPDIR_BASE/c_done.json"
 DONE_CTX="$(ctx_of "$TMPDIR_BASE/c_done.json")"
 if [ -n "$DONE_CTX" ]; then
@@ -255,7 +255,7 @@ echo "(d) Context-window N-limit"
 
 DB_N="$TMPDIR_BASE/n.db"
 for i in 1 2 3 4 5; do
-    emit_inbound 8517922966 "$i" "MSG_NUM_${i}" | run_hook ledger-capture.py "$DB_N"
+    emit_inbound 10000000001 "$i" "MSG_NUM_${i}" | run_hook ledger-capture.py "$DB_N"
 done
 LEDGER_CONTEXT_WINDOW=3 run_hook ledger-replay.py "$DB_N" < <(emit_session) > "$TMPDIR_BASE/n.json"
 N_CTX="$(ctx_of "$TMPDIR_BASE/n.json")"
@@ -286,11 +286,11 @@ payload_bytes() { LC_ALL=C wc -c < "$1" | tr -d ' '; }
 DB_BB="$TMPDIR_BASE/bb.db"
 # 40 chatty turns with accented (2-byte UTF-8) content -> well over any KB cap.
 for i in $(seq 1 40); do
-    emit_inbound 8517922966 "$i" "UZENET_${i} árvíztűrő tükörfúrógép őőőűűű ééé ááá visszavisszhang" \
+    emit_inbound 10000000001 "$i" "UZENET_${i} árvíztűrő tükörfúrógép őőőűűű ééé ááá visszavisszhang" \
         | run_hook ledger-capture.py "$DB_BB"
 done
 # The very last turn carries a unique marker we must NOT lose to preview-truncation.
-emit_inbound 8517922966 999 "LEGFRISSEBB_VEG_MARKER a friss veg amit latni kell" \
+emit_inbound 10000000001 999 "LEGFRISSEBB_VEG_MARKER a friss veg amit latni kell" \
     | run_hook ledger-capture.py "$DB_BB"
 
 # Force a tight budget (4096 B) AND a wide window (no N-limit interference) so the
@@ -327,7 +327,7 @@ fi
 # budget (no drop-to-empty). Build a >8KB single message.
 DB_BB2="$TMPDIR_BASE/bb2.db"
 HUGE="$(python3 -c 'print("Q" + "óőűá"*3000 + "_VEGE")')"
-emit_inbound 8517922966 1 "$HUGE" | run_hook ledger-capture.py "$DB_BB2"
+emit_inbound 10000000001 1 "$HUGE" | run_hook ledger-capture.py "$DB_BB2"
 LEDGER_CONTEXT_BYTE_BUDGET=8192 run_hook ledger-replay.py "$DB_BB2" < <(emit_session) > "$TMPDIR_BASE/bb2.json"
 BB2_BYTES="$(payload_bytes "$TMPDIR_BASE/bb2.json")"
 if [ "$BB2_BYTES" -le 8192 ] && [ "$BB2_BYTES" -gt 0 ]; then
@@ -343,8 +343,8 @@ echo ""
 echo "(e) Idempotency"
 
 DB_D="$TMPDIR_BASE/d.db"
-emit_inbound 8517922966 1054 "ugyanaz" | run_hook ledger-capture.py "$DB_D"
-emit_inbound 8517922966 1054 "ugyanaz" | run_hook ledger-capture.py "$DB_D"
+emit_inbound 10000000001 1054 "ugyanaz" | run_hook ledger-capture.py "$DB_D"
+emit_inbound 10000000001 1054 "ugyanaz" | run_hook ledger-capture.py "$DB_D"
 assert_eq "idempotency: duplicate inbound capture -> exactly 1 row" "1" \
     "$(db_scalar "$DB_D" "SELECT COUNT(*) FROM conversation_log WHERE direction='in'")"
 
@@ -403,7 +403,7 @@ printf 'not json' | run_hook ledger-outbound.py "$DB_E2" \
 
 # Edge 3: outbound hook with a non-telegram tool -> no out row recorded
 DB_E3="$TMPDIR_BASE/e3.db"
-echo '{"tool_name":"mcp__github__create_issue","tool_input":{"chat_id":"8517922966","text":"irrelevant"}}' \
+echo '{"tool_name":"mcp__github__create_issue","tool_input":{"chat_id":"10000000001","text":"irrelevant"}}' \
     | run_hook ledger-outbound.py "$DB_E3"
 E3_OUT="$(db_scalar "$DB_E3" "SELECT COUNT(*) FROM conversation_log WHERE direction='out'")"
 if [ "$E3_OUT" = "0" ] || [ "$E3_OUT" = "NULL" ]; then
@@ -420,10 +420,10 @@ echo "(g) Live-session open-question drain"
 
 # (g1) aged + unanswered + not yet surfaced -> writes block + updates statefile
 mkdir -p "$TMPDIR_BASE/ld1"; DB_LD1="$TMPDIR_BASE/ld1/x.db"
-emit_inbound 8517922966 1122 "Elveszett elo kerdes" | run_hook ledger-capture.py "$DB_LD1"
+emit_inbound 10000000001 1122 "Elveszett elo kerdes" | run_hook ledger-capture.py "$DB_LD1"
 age_rows "$DB_LD1" 120
 OUT_G1="$(run_drain "$DB_LD1")"
-if printf '%s' "$OUT_G1" | grep -q "OPEN_QUESTION chat_id=8517922966 message_id=1122"; then
+if printf '%s' "$OUT_G1" | grep -q "OPEN_QUESTION chat_id=10000000001 message_id=1122"; then
     pass "live drain: surfaces an aged, unanswered open question"
 else
     fail "live drain: did not surface the open question (got: $OUT_G1)"
@@ -442,15 +442,15 @@ assert_eq "live drain: dedup suppresses re-surfacing the same message_id" "" "$O
 
 # (g3) a later 'out' answered it -> no output
 mkdir -p "$TMPDIR_BASE/ld3"; DB_LD3="$TMPDIR_BASE/ld3/x.db"
-emit_inbound 8517922966 1130 "Megvalaszolt kerdes" | run_hook ledger-capture.py "$DB_LD3"
+emit_inbound 10000000001 1130 "Megvalaszolt kerdes" | run_hook ledger-capture.py "$DB_LD3"
 age_rows "$DB_LD3" 120
-emit_reply 8517922966 "Itt a valasz" | run_hook ledger-outbound.py "$DB_LD3"
+emit_reply 10000000001 "Itt a valasz" | run_hook ledger-outbound.py "$DB_LD3"
 OUT_G3="$(run_drain "$DB_LD3")"
 assert_eq "live drain: an answered question is not surfaced" "" "$OUT_G3"
 
 # (g4) open question younger than the grace window (in-flight) -> no output
 mkdir -p "$TMPDIR_BASE/ld4"; DB_LD4="$TMPDIR_BASE/ld4/x.db"
-emit_inbound 8517922966 1131 "Epp most erkezett" | run_hook ledger-capture.py "$DB_LD4"
+emit_inbound 10000000001 1131 "Epp most erkezett" | run_hook ledger-capture.py "$DB_LD4"
 OUT_G4="$(run_drain "$DB_LD4")"
 assert_eq "live drain: in-flight question (within grace) is not surfaced" "" "$OUT_G4"
 

--- a/scripts/__tests__/conversation-ledger.test.sh
+++ b/scripts/__tests__/conversation-ledger.test.sh
@@ -33,7 +33,11 @@ run_hook() {
     local hook="$1"
     local db="$2"
     shift 2
+    # OWNER_NAME is pinned to 'Gyula' so the replay's inbound prefix is
+    # deterministic regardless of the install's .env (assertions below grep for
+    # "Gyula:"). Same reasoning as pinning MAIN_AGENT_ID.
     LEDGER_DB_PATH="$db" LEDGER_OWNER_CHAT="8517922966" MAIN_AGENT_ID="marveen" \
+        OWNER_NAME="Gyula" \
         python3 "$HOOKS_DIR/$hook" "$@"
 }
 
@@ -264,6 +268,72 @@ if printf '%s' "$N_CTX" | grep -q "MSG_NUM_1" || printf '%s' "$N_CTX" | grep -q 
     fail "replay: N-limit did not drop the oldest turns"
 else
     pass "replay: N-limit drops turns beyond the window"
+fi
+
+# ---------------------------------------------------------------------------
+# (d2) BYTE-BUDGET SELF-TRIM -- the FINAL payload stays under the harness cap,
+#      dropping oldest turns while the freshest END survives uncut.
+#      Regression guard for the ~11KB harness preview-truncation bug: the hook
+#      must self-measure real UTF-8 bytes (accents included) and keep the whole
+#      json.dumps(...) blob under LEDGER_CONTEXT_BYTE_BUDGET.
+# ---------------------------------------------------------------------------
+echo ""
+echo "(d2) Byte-budget self-trim"
+
+# Byte size of a replay hook's raw stdout (the exact blob the harness measures).
+payload_bytes() { LC_ALL=C wc -c < "$1" | tr -d ' '; }
+
+DB_BB="$TMPDIR_BASE/bb.db"
+# 40 chatty turns with accented (2-byte UTF-8) content -> well over any KB cap.
+for i in $(seq 1 40); do
+    emit_inbound 8517922966 "$i" "UZENET_${i} árvíztűrő tükörfúrógép őőőűűű ééé ááá visszavisszhang" \
+        | run_hook ledger-capture.py "$DB_BB"
+done
+# The very last turn carries a unique marker we must NOT lose to preview-truncation.
+emit_inbound 8517922966 999 "LEGFRISSEBB_VEG_MARKER a friss veg amit latni kell" \
+    | run_hook ledger-capture.py "$DB_BB"
+
+# Force a tight budget (4096 B) AND a wide window (no N-limit interference) so the
+# byte loop is what actually trims. LEGFRISSEBB marker must survive; oldest drops.
+LEDGER_CONTEXT_BYTE_BUDGET=4096 LEDGER_CONTEXT_WINDOW=100 \
+    run_hook ledger-replay.py "$DB_BB" < <(emit_session) > "$TMPDIR_BASE/bb.json"
+
+BB_BYTES="$(payload_bytes "$TMPDIR_BASE/bb.json")"
+if [ "$BB_BYTES" -le 4096 ]; then
+    pass "byte-budget: final payload ($BB_BYTES B) stays under the 4096 B budget"
+else
+    fail "byte-budget: payload $BB_BYTES B exceeds the 4096 B budget"
+fi
+
+BB_CTX="$(ctx_of "$TMPDIR_BASE/bb.json")"
+if printf '%s' "$BB_CTX" | grep -q "LEGFRISSEBB_VEG_MARKER"; then
+    pass "byte-budget: freshest END survives the trim"
+else
+    fail "byte-budget: freshest END was dropped (preview-truncation regression)"
+fi
+if printf '%s' "$BB_CTX" | grep -q "UZENET_1 "; then
+    fail "byte-budget: oldest turn should have been trimmed but is present"
+else
+    pass "byte-budget: oldest turns dropped first (freshest-end reorder preserved)"
+fi
+# Closing directive (KÖTELEZŐ) must always survive -- it is rebuilt into every payload.
+if printf '%s' "$BB_CTX" | grep -q "KÖTELEZŐ:"; then
+    pass "byte-budget: mandatory directive present in the trimmed payload"
+else
+    fail "byte-budget: mandatory directive lost during trim"
+fi
+
+# Single oversized freshest turn: snippet cap keeps even a lone huge turn under
+# budget (no drop-to-empty). Build a >8KB single message.
+DB_BB2="$TMPDIR_BASE/bb2.db"
+HUGE="$(python3 -c 'print("Q" + "óőűá"*3000 + "_VEGE")')"
+emit_inbound 8517922966 1 "$HUGE" | run_hook ledger-capture.py "$DB_BB2"
+LEDGER_CONTEXT_BYTE_BUDGET=8192 run_hook ledger-replay.py "$DB_BB2" < <(emit_session) > "$TMPDIR_BASE/bb2.json"
+BB2_BYTES="$(payload_bytes "$TMPDIR_BASE/bb2.json")"
+if [ "$BB2_BYTES" -le 8192 ] && [ "$BB2_BYTES" -gt 0 ]; then
+    pass "byte-budget: a lone oversized turn is snippet-capped under budget ($BB2_BYTES B)"
+else
+    fail "byte-budget: lone oversized turn not bounded ($BB2_BYTES B)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/hooks/ledger-replay.py
+++ b/scripts/hooks/ledger-replay.py
@@ -7,10 +7,16 @@ the deterministic mechanism: the fresh session does not need to REMEMBER
 anything; its context window already carries the conversation and the question
 to answer.
 
-The block is ordered so its actionable core survives context-preview truncation
-(the harness may spill a large additionalContext to a file and inline only a
-small preview taken from the block START): mandatory directive first, then the
-open question, then the freshest turns, then older turns as backfill.
+Two layers keep the fresh end of the conversation actually reaching the fresh
+session:
+  1. A BYTE budget (DEFAULT_BYTE_BUDGET) on the FINAL payload: the hook measures
+     its own real UTF-8 output size and drops the OLDEST turns until it fits,
+     so the harness always injects the block WHOLE (no file-spill, no preview).
+  2. Block ORDER as a belt-and-braces fallback: if a payload ever does exceed
+     the cap, the harness spills it to a file and inlines only a small preview
+     taken from the block START -- so the mandatory directive and the open
+     question (the actionable core) lead the block, then the freshest turns,
+     then older turns as backfill.
 
 Generic across the three channel agents -- agent_id is derived from cwd, so a
 session only ever replays its OWN chat. Outputs the SessionStart additionalContext
@@ -24,14 +30,36 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import ledger_lib  # noqa: E402
 
 # How many chars of transcript context to inject (~4 chars/token, so 16000 chars
-# ~= 4000 tokens). If the recent window exceeds this, the OLDEST turns are
-# dropped so the injected context stays bounded regardless of how chatty the
-# recent conversation was. Env override: LEDGER_CONTEXT_CHAR_BUDGET (raise it
-# only if a specific install genuinely needs a deeper replay -- the default is
-# deliberately lean so a fresh session does not carry needless context).
+# ~= 4000 tokens). This is a CHEAP coarse pre-trim only; the authoritative guard
+# is the BYTE budget below (see _fit_output). If the recent window exceeds this,
+# the OLDEST turns are dropped so the injected context stays bounded regardless
+# of how chatty the recent conversation was. Env override:
+# LEDGER_CONTEXT_CHAR_BUDGET.
 DEFAULT_CHAR_BUDGET = 16000
 
-# How many recent turns to consider before the char budget trims. 20 keeps the
+# Hard BYTE budget on the FINAL hook payload (the whole json.dumps(...) blob,
+# UTF-8 encoded: frame + directive + open-question + transcript). This is the
+# real guard. WHY bytes, not chars: the Claude Code harness caps a hook's
+# additionalContext by BYTE size -- above the cap it does NOT inject the block,
+# it saves it to a file and inlines only a small (~2KB) PREVIEW taken from the
+# block START, so a large payload's fresh (most recent) turns are lost and the
+# restarted session has no memory of them. Hungarian accents (á é ő ű) are 2
+# bytes each in UTF-8, so a char-only measure UNDERCOUNTS and can silently
+# overshoot the cap. 8192 is a conservative target well under the empirical
+# too-large threshold (an ~11.1KB payload was already rejected by the harness).
+# Env override: LEDGER_CONTEXT_BYTE_BUDGET. Lower this if a future harness build
+# shrinks its internal limit -- the reliability lives in OUR self-measuring
+# trim, not the harness's discretion.
+DEFAULT_BYTE_BUDGET = 8192
+
+# Per-message snippet cap (chars). A single very long turn is truncated with an
+# ellipsis rather than letting it dominate (or, if it is the freshest turn,
+# blow) the whole byte budget. This is the depth optimization: bounding each
+# line lets MORE turns fit under the byte budget, and guarantees even a single
+# huge freshest turn still fits. Env override: LEDGER_CONTEXT_MAX_SNIPPET.
+DEFAULT_MAX_SNIPPET = 1200
+
+# How many recent turns to consider before the budgets trim. 20 keeps the
 # injected context lean; the continuity failure mode is NOT a too-short window
 # (a key fact usually sits well within 20 turns) but the fresh session not
 # *reading* the loaded block -- addressed by the mandatory directive below.
@@ -67,6 +95,100 @@ def _char_budget():
     return _env_int("LEDGER_CONTEXT_CHAR_BUDGET", DEFAULT_CHAR_BUDGET)
 
 
+def _byte_budget():
+    return _env_int("LEDGER_CONTEXT_BYTE_BUDGET", DEFAULT_BYTE_BUDGET)
+
+
+def _max_snippet():
+    return _env_int("LEDGER_CONTEXT_MAX_SNIPPET", DEFAULT_MAX_SNIPPET)
+
+
+def _snippet(text, limit):
+    """One-line, whitespace-collapsed snippet, truncated to `limit` chars with an
+    ellipsis marker so a single runaway message cannot dominate the budget."""
+    s = (text or "").strip().replace("\n", " ")
+    if limit > 0 and len(s) > limit:
+        s = s[:limit].rstrip() + " [...]"
+    return s
+
+
+def _build_output(transcript, open_q, owner):
+    """Assemble the final SessionStart hook payload dict from the (already
+    snippet-trimmed, oldest-first) transcript lines + optional open question.
+
+    Block order puts the actionable core first (directive, open question), then
+    the freshest turns, then older backfill -- so even a preview taken from the
+    block START carries the essence. Pure function of its inputs so the byte-fit
+    loop can rebuild and re-measure cheaply.
+    """
+    # Split into the most-recent highlight window and the older backfill. The
+    # recent turns are the newest, so the byte/char guards (which drop from the
+    # OLDEST end) never touch them until the older backfill is already empty.
+    if len(transcript) > RECENT_TURNS_HIGHLIGHT:
+        recent = transcript[-RECENT_TURNS_HIGHLIGHT:]
+        older = transcript[:-RECENT_TURNS_HIGHLIGHT]
+    else:
+        recent = transcript
+        older = []
+
+    parts = [
+        "KÖTELEZŐ: MIELŐTT bármely új bejövő üzenetre válaszolsz, dolgozd fel az "
+        "alábbi beszélgetés-kontextust. A kapcsolatod újraindult egy friss "
+        "sessionben, ami NEM emlékszik az élő beszélgetésre; a folytonosságot ez "
+        "a blokk adja. A benne szereplő döntések, megállapodások és folyamatban "
+        "lévő szálak ÉRVÉNYESEK és folytatandók. NE kérdezz vissza olyat, amit "
+        "lent már megbeszéltetek (pl. \"mihez kell ez?\", ha lent már eldőlt); a "
+        "betöltött kontextusból folytass, ne kezdd elölről."
+    ]
+    if open_q:
+        chat_id, message_id, text, ts = open_q
+        snippet = _snippet(text, _max_snippet())
+        parts.append(
+            f'NYITOTT KÉRDÉS (még NEM válaszoltad meg): {owner} utolsó üzenete '
+            f'(chat {chat_id}, message_id {message_id}): "{snippet}". Válaszolj rá '
+            f'MOST a telegram reply tool (mcp__plugin_telegram_telegram__reply) '
+            f'meghívásával a megfelelő chat_id-re, a lenti kontextusból folytatva.'
+        )
+    if recent:
+        parts.append(
+            "LEGFRISSEBB FORDULÓK (időrendben, a beszélgetés vége -- innen "
+            "folytasd):\n" + "\n".join(recent)
+        )
+    if older:
+        parts.append(
+            "KORÁBBI HÁTTÉR (régebbi fordulók, csak kontextusnak, időrendben):\n"
+            + "\n".join(older)
+        )
+
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": "\n\n".join(parts),
+        }
+    }
+
+
+def _payload_bytes(out):
+    """Real byte size of the serialized hook payload -- the exact quantity the
+    harness measures against its internal cap (ensure_ascii=False keeps accented
+    chars as multi-byte UTF-8, matching print(..., ensure_ascii=False) below)."""
+    return len(json.dumps(out, ensure_ascii=False).encode("utf-8"))
+
+
+def _fit_output(transcript, open_q, owner, byte_budget):
+    """Build the payload and keep it under `byte_budget` by dropping the OLDEST
+    turn and re-measuring, iteratively (build -> measure -> trim -> repeat). The
+    freshest END survives, the oldest turns fall off first. At least one turn is
+    kept when any exist (its snippet is already bounded by _max_snippet, so a
+    lone freshest turn still fits)."""
+    transcript = list(transcript)
+    out = _build_output(transcript, open_q, owner)
+    while len(transcript) > 1 and _payload_bytes(out) > byte_budget:
+        transcript.pop(0)
+        out = _build_output(transcript, open_q, owner)
+    return out
+
+
 def main():
     cwd = None
     try:
@@ -86,71 +208,27 @@ def main():
 
     owner = ledger_lib.owner_name()
 
+    max_snippet = _max_snippet()
     transcript = []
     for direction, chat_id, text, ts in rows:
         who = owner if direction == "in" else "Te"
-        snippet = (text or "").strip().replace("\n", " ")
+        snippet = _snippet(text, max_snippet)
         transcript.append(f'  [{ts}] {who}: "{snippet}"')
 
-    # Token guard: drop the OLDEST turns until the transcript fits the budget.
+    # Coarse char pre-trim (cheap): drop the OLDEST turns until the transcript
+    # roughly fits the char budget, so the authoritative byte-fit loop below has
+    # less to iterate over. The byte budget is the real guard.
     char_budget = _char_budget()
     total = sum(len(line) + 1 for line in transcript)
     while len(transcript) > 1 and total > char_budget:
         total -= len(transcript[0]) + 1
         transcript.pop(0)
 
-    # Split the (budget-trimmed) turns into the most-recent highlight window and
-    # the older backfill. The recent turns are the newest, so they are never the
-    # ones the budget guard drops.
-    if len(transcript) > RECENT_TURNS_HIGHLIGHT:
-        recent = transcript[-RECENT_TURNS_HIGHLIGHT:]
-        older = transcript[:-RECENT_TURNS_HIGHLIGHT]
-    else:
-        recent = transcript
-        older = []
+    # Authoritative guard: keep the FINAL payload's real UTF-8 byte size under the
+    # harness's injection cap, dropping oldest turns and re-measuring until it
+    # fits (freshest END survives).
+    out = _fit_output(transcript, open_q, owner, _byte_budget())
 
-    # Order the block so the essence survives ANY context-preview truncation: the
-    # Claude Code harness may spill a large SessionStart additionalContext to a
-    # file and inline only a ~2KB preview taken from the BLOCK START. So the
-    # mandatory directive and the open question -- the actionable core -- lead the
-    # block, then the freshest turns, then the older backfill last. (Previously
-    # the directive and open question sat at the END, so on a large/chatty block
-    # they fell off the visible preview edge and the fresh session missed them.)
-    parts = [
-        "KÖTELEZŐ: MIELŐTT bármely új bejövő üzenetre válaszolsz, dolgozd fel az "
-        "alábbi beszélgetés-kontextust. A kapcsolatod újraindult egy friss "
-        "sessionben, ami NEM emlékszik az élő beszélgetésre; a folytonosságot ez "
-        "a blokk adja. A benne szereplő döntések, megállapodások és folyamatban "
-        "lévő szálak ÉRVÉNYESEK és folytatandók. NE kérdezz vissza olyat, amit "
-        "lent már megbeszéltetek (pl. \"mihez kell ez?\", ha lent már eldőlt); a "
-        "betöltött kontextusból folytass, ne kezdd elölről."
-    ]
-    if open_q:
-        chat_id, message_id, text, ts = open_q
-        snippet = (text or "").strip().replace("\n", " ")
-        parts.append(
-            f'NYITOTT KÉRDÉS (még NEM válaszoltad meg): {owner} utolsó üzenete '
-            f'(chat {chat_id}, message_id {message_id}): "{snippet}". Válaszolj rá '
-            f'MOST a telegram reply tool (mcp__plugin_telegram_telegram__reply) '
-            f'meghívásával a megfelelő chat_id-re, a lenti kontextusból folytatva.'
-        )
-    if recent:
-        parts.append(
-            "LEGFRISSEBB FORDULÓK (időrendben, a beszélgetés vége -- innen "
-            "folytasd):\n" + "\n".join(recent)
-        )
-    if older:
-        parts.append(
-            "KORÁBBI HÁTTÉR (régebbi fordulók, csak kontextusnak, időrendben):\n"
-            + "\n".join(older)
-        )
-
-    out = {
-        "hookSpecificOutput": {
-            "hookEventName": "SessionStart",
-            "additionalContext": "\n\n".join(parts),
-        }
-    }
     print(json.dumps(out, ensure_ascii=False))
     sys.exit(0)
 


### PR DESCRIPTION
## Problem

On a respawn the SessionStart hook (`ledger-replay.py`) injects the recent conversation as `additionalContext`. When that payload exceeds the Claude Code harness's internal size cap, the harness does **not** inject it whole — it spills it to a file and inlines only a small (~2KB) **preview taken from the block START**. On a large/chatty ledger the freshest turns fall off the preview edge, so the restarted session has **no memory of the most recent exchange**.

Observed on 2026-07-16: an ~11.1KB payload was rejected by the harness, and a password-continuity test failed after restart.

The prior char budget (16000 chars) does not prevent this: the harness cap is in **bytes**, and Hungarian accents (á é ő ű) are 2 bytes each in UTF-8, so a char-only measure undercounts and silently overshoots the cap.

## Fix: byte-based self-trim

The hook now self-measures the real UTF-8 byte size of its **final** payload (the whole `json.dumps(...)` blob: frame + directive + open question + transcript) and iteratively drops the **oldest** turn until it fits a conservative byte budget:

```
build -> measure -> drop-oldest -> repeat
```

`DEFAULT_BYTE_BUDGET = 8192`, well under the observed ~11KB reject line. The freshest END always survives. The reliability lives in **our** trim, not the harness's discretion — if a future harness build shrinks its cap, just lower `LEDGER_CONTEXT_BYTE_BUDGET`.

Details:
- **New env override** `LEDGER_CONTEXT_BYTE_BUDGET` (authoritative guard).
- **Per-message snippet cap** (`DEFAULT_MAX_SNIPPET=1200`, env `LEDGER_CONTEXT_MAX_SNIPPET`) bounds any single runaway turn, so a lone huge freshest turn still fits and more turns pack under the budget.
- The existing **char budget** stays as a cheap coarse pre-trim.
- The block **ordering** from the previous continuity fix is preserved as belt-and-braces: if a payload ever does exceed the cap, the directive + open question still lead the preview.

## Tests

New `(d2)` byte-budget section in `conversation-ledger.test.sh` proves:
- the final payload stays under the byte budget (accents counted),
- the freshest END marker survives the trim,
- oldest turns drop first,
- the mandatory directive is always present,
- a lone oversized turn is snippet-capped under budget.

`run_hook` now pins `OWNER_NAME=Gyula` so the prefix assertions are hermetic regardless of the install's `.env`. **39/39 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)