### PR TITLE
fix(telegram): manual Bot API fallback clears its placeholder so the Stop hook never re-delivers

### DIFF
--- a/scripts/__tests__/telegram-fallback-dedup.test.sh
+++ b/scripts/__tests__/telegram-fallback-dedup.test.sh
@@ -71,7 +71,7 @@ PORT="$(cat "$PORTFILE" 2>/dev/null)"
 if [ -z "$PORT" ]; then echo "FATAL: stub did not start"; exit 1; fi
 export TELEGRAM_API_BASE="http://127.0.0.1:$PORT"
 
-CHAT="8517922966"
+CHAT="10000000001"
 SID="TESTSID"
 
 # Per-case state dir with a token + a pending placeholder + a transcript whose

--- a/scripts/__tests__/telegram-fallback-dedup.test.sh
+++ b/scripts/__tests__/telegram-fallback-dedup.test.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# Contract tests for the Telegram Bot API fallback de-duplication.
+# Run: bash scripts/__tests__/telegram-fallback-dedup.test.sh
+#
+# Bug being locked out: when the reply MCP tool drops mid-turn, the agent sends
+# its answer via the Bot API directly. A RAW send does not clear the "✍️
+# Dolgozom rajta…" placeholder, so the Stop hook's enforce path re-delivers the
+# same answer at turn end -> the user gets it TWICE, and gets nudged to reply.
+#
+# Fix under test: telegram_fallback_send.py sends AND clears the placeholder
+# (mirroring the reply tool), so the Stop hook finds nothing pending -> no
+# duplicate, no nudge, no restart.
+#
+# All Bot API traffic is routed to a local stub via TELEGRAM_API_BASE, so the
+# tests are hermetic (no real Telegram calls) and can count what was sent.
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (expected '$2', got '$3')"; fi; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOKS_DIR="$INSTALL_DIR/scripts/hooks"
+FALLBACK="$HOOKS_DIR/telegram_fallback_send.py"
+STOP_HOOK="$HOOKS_DIR/telegram_progress_clear.py"
+
+TMP="$(mktemp -d)"
+trap 'kill "$STUB_PID" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+# --- Local Bot API stub -----------------------------------------------------
+# Logs one line per request ("<method> <body>") to $REQLOG and returns Bot
+# API-shaped JSON. Binds to an OS-assigned port, written to $PORTFILE.
+REQLOG="$TMP/requests.log"
+PORTFILE="$TMP/port"
+cat > "$TMP/stub.py" <<'PYEOF'
+import json, sys, os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+reqlog = sys.argv[1]
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(n).decode("utf-8") if n else ""
+        method = self.path.rsplit("/", 1)[-1]  # /bot<token>/<method>
+        with open(reqlog, "a", encoding="utf-8") as f:
+            f.write(f"{method} {body}\n")
+        if method == "sendMessage":
+            out = {"ok": True, "result": {"message_id": 9001}}
+        elif method == "deleteMessage":
+            out = {"ok": True, "result": True}
+        else:
+            out = {"ok": True, "result": {}}
+        payload = json.dumps(out).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+srv = HTTPServer(("127.0.0.1", 0), H)
+with open(sys.argv[2], "w") as f:
+    f.write(str(srv.server_address[1]))
+srv.serve_forever()
+PYEOF
+python3 "$TMP/stub.py" "$REQLOG" "$PORTFILE" &
+STUB_PID=$!
+# Wait for the stub to report its port.
+for _ in $(seq 1 50); do [ -s "$PORTFILE" ] && break; sleep 0.1; done
+PORT="$(cat "$PORTFILE" 2>/dev/null)"
+if [ -z "$PORT" ]; then echo "FATAL: stub did not start"; exit 1; fi
+export TELEGRAM_API_BASE="http://127.0.0.1:$PORT"
+
+CHAT="8517922966"
+SID="TESTSID"
+
+# Per-case state dir with a token + a pending placeholder + a transcript whose
+# last assistant message is the agent's final answer.
+make_state() { # dir
+    local sd="$1"
+    mkdir -p "$sd/progress"
+    printf 'TELEGRAM_BOT_TOKEN=TESTTOKEN\n' > "$sd/.env"
+    # pending placeholder: message_id 555 is the "Dolgozom rajta…" bubble
+    printf '[{"chat_id": "%s", "message_id": 555}]\n' "$CHAT" > "$sd/progress/$SID.json"
+    printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"AGENT_FINAL_ANSWER"}]}}' \
+        > "$sd/transcript.jsonl"
+}
+pend_has_chat() { # dir -> "yes"/"no"
+    python3 - "$1/progress/$SID.json" "$CHAT" <<'PYEOF'
+import json, sys
+try:
+    pend = json.load(open(sys.argv[1]))
+except Exception:
+    print("no"); sys.exit(0)
+print("yes" if any(str(p.get("chat_id")) == sys.argv[2] for p in pend) else "no")
+PYEOF
+}
+count() { grep -c "^$1 " "$REQLOG" 2>/dev/null || echo 0; }
+run_stop() { # dir stop_active(true/false)
+    local sd="$1" active="$2"
+    printf '{"session_id":"%s","transcript_path":"%s","stop_hook_active":%s}' \
+        "$SID" "$sd/transcript.jsonl" "$active" \
+        | TELEGRAM_STATE_DIR="$sd" python3 "$STOP_HOOK"
+}
+
+echo "telegram-fallback-dedup tests"
+echo "============================="
+
+# ---------------------------------------------------------------------------
+# (a) The helper delivers AND clears the placeholder
+# ---------------------------------------------------------------------------
+echo ""
+echo "(a) Fallback helper: send + clear placeholder"
+SD_A="$TMP/a"; make_state "$SD_A"
+: > "$REQLOG"
+assert_eq "pend has the chat before send" "yes" "$(pend_has_chat "$SD_A")"
+OUT_A="$(TELEGRAM_STATE_DIR="$SD_A" python3 "$FALLBACK" "$CHAT" "AGENT_FINAL_ANSWER" --sid "$SID")"
+RC_A=$?
+assert_eq "helper exit 0 on success" "0" "$RC_A"
+assert_eq "helper sent exactly one sendMessage" "1" "$(count sendMessage)"
+assert_eq "helper deleted the placeholder (deleteMessage)" "1" "$(count deleteMessage)"
+assert_eq "placeholder cleared from pend after helper" "no" "$(pend_has_chat "$SD_A")"
+
+# ---------------------------------------------------------------------------
+# (b) FIXED PATH: after the helper cleared the placeholder, the Stop hook does
+#     NOT re-deliver (no duplicate) and does NOT nudge (no restart).
+# ---------------------------------------------------------------------------
+echo ""
+echo "(b) After helper: Stop hook produces no duplicate, no nudge"
+# First Stop (fresh): pend empty -> no block/nudge decision on stdout.
+STOP_FIRST="$(run_stop "$SD_A" false)"
+if printf '%s' "$STOP_FIRST" | grep -q '"decision"'; then
+    fail "first Stop after clear must NOT block/nudge (would force a restart)"
+else
+    pass "first Stop after clear allows stop (no nudge, no restart)"
+fi
+# Second Stop (enforce): still nothing pending -> zero extra sends.
+run_stop "$SD_A" true >/dev/null
+assert_eq "no duplicate: sendMessage count stays 1 across both Stops" "1" "$(count sendMessage)"
+
+# ---------------------------------------------------------------------------
+# (c) CONTROL: the RAW path (placeholder NOT cleared) is exactly what the Stop
+#     hook re-delivers -> proves clearing is what prevents the dupe.
+# ---------------------------------------------------------------------------
+echo ""
+echo "(c) Control: un-cleared placeholder -> enforce re-delivers"
+SD_C="$TMP/c"; make_state "$SD_C"
+: > "$REQLOG"
+# Simulate a raw manual send (one message out) WITHOUT clearing the placeholder.
+# We don't actually need to send here; we assert the enforce path would send the
+# agent's answer because the placeholder is still pending.
+assert_eq "control: pend still has the chat" "yes" "$(pend_has_chat "$SD_C")"
+run_stop "$SD_C" true >/dev/null   # enforce fallback branch (stop_hook_active)
+assert_eq "control: enforce re-delivers the answer (the duplicate)" "1" "$(count sendMessage)"
+assert_eq "control: enforce cleared the placeholder afterwards" "no" "$(pend_has_chat "$SD_C")"
+
+# ---------------------------------------------------------------------------
+# (d) Helper delivery FAILURE -> exit 2, nothing cleared (caller escalates)
+# ---------------------------------------------------------------------------
+echo ""
+echo "(d) Delivery failure surfaces exit 2, keeps placeholder"
+SD_D="$TMP/d"; make_state "$SD_D"
+: > "$REQLOG"
+# Point at a dead port so sendMessage cannot connect.
+DEAD_BASE="http://127.0.0.1:1"
+OUT_D="$(TELEGRAM_API_BASE="$DEAD_BASE" TELEGRAM_STATE_DIR="$SD_D" \
+    python3 "$FALLBACK" "$CHAT" "text" --sid "$SID" 2>/dev/null)"
+RC_D=$?
+assert_eq "helper exits 2 when Bot API is unreachable" "2" "$RC_D"
+assert_eq "failed send does NOT clear the placeholder" "yes" "$(pend_has_chat "$SD_D")"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================="
+TOTAL=$((PASS + FAIL))
+echo "Results: $PASS/$TOTAL passed"
+if [ "$FAIL" -gt 0 ]; then echo "FAILED: $FAIL tests"; exit 1; fi
+echo "All tests passed."

--- a/scripts/hooks/telegram_fallback_send.py
+++ b/scripts/hooks/telegram_fallback_send.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Telegram Bot API fallback SENDER (agent-invoked CLI, not a harness hook).
+
+When the in-session Telegram MCP `reply` tool is dropped mid-turn ("MCP servers
+have disconnected: plugin:telegram:telegram"), the agent must still reach the
+user. The telegram-botapi-fallback skill used to `curl` sendMessage directly --
+but a raw send does NOT clear the "✍️ Dolgozom rajta…" placeholder (only the
+reply TOOL's PostToolUse hook does that). So the Stop hook, seeing a still-
+pending placeholder, delivered the agent's final answer a SECOND time at turn
+end -> the user got the message twice.
+
+This helper closes that gap by making a manual fallback behave EXACTLY like the
+reply tool: it sends the message AND then clears the placeholder for that chat
+(deleteMessage + trim the session's pending list), mirroring
+telegram_progress_reply_clear.py. With the placeholder gone, the Stop hook's
+enforce path finds nothing pending -> no duplicate, no "you never replied" nudge,
+no restart needed.
+
+Usage:
+    telegram_fallback_send.py <chat_id> <text> [--sid SID] [--state-dir DIR]
+
+Exit code:
+    0  message delivered (placeholder cleared best-effort)
+    2  delivery FAILED (Bot API not ok / unreachable) -> caller should escalate
+       (per the skill: fall through to email). Nothing was cleared.
+
+Resolution mirrors the plugin/hooks: state dir from --state-dir else
+TELEGRAM_STATE_DIR else ~/.claude/channels/telegram; token from <state_dir>/.env
+(TELEGRAM_BOT_TOKEN=); session id from --sid else CLAUDE_CODE_SESSION_ID else
+"default". Bot API base from TELEGRAM_API_BASE (default https://api.telegram.org)
+so tests can point it at a local stub.
+"""
+import sys
+import os
+import json
+import urllib.request
+
+MAX_LEN = 4000  # Telegram hard limit is 4096; match the Stop hook's trim.
+
+
+def api_base():
+    return os.environ.get("TELEGRAM_API_BASE", "https://api.telegram.org").rstrip("/")
+
+
+def state_dir(cli_dir=None):
+    return (cli_dir or os.environ.get("TELEGRAM_STATE_DIR")
+            or os.path.expanduser("~/.claude/channels/telegram"))
+
+
+def session_id(cli_sid=None):
+    return cli_sid or os.environ.get("CLAUDE_CODE_SESSION_ID") or "default"
+
+
+def log(sd, msg):
+    try:
+        os.makedirs(os.path.join(sd, "progress"), exist_ok=True)
+        with open(os.path.join(sd, "progress", "debug.log"), "a", encoding="utf-8") as f:
+            f.write(msg + "\n")
+    except Exception:
+        pass
+
+
+def token(sd):
+    try:
+        for line in open(os.path.join(sd, ".env"), encoding="utf-8"):
+            line = line.strip()
+            if line.startswith("TELEGRAM_BOT_TOKEN="):
+                return line.split("=", 1)[1].strip()
+    except Exception:
+        return None
+    return None
+
+
+def api(tok, method, payload):
+    url = f"{api_base()}/bot{tok}/{method}"
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=data,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=8) as r:
+        return json.loads(r.read().decode())
+
+
+def clear_placeholder(sd, sid, chat_id, tok):
+    """Delete this session's pending placeholder(s) for `chat_id` and trim the
+    pending list -- the exact bookkeeping telegram_progress_reply_clear.py does
+    when the reply tool fires, so the Stop hook won't re-deliver. Best-effort:
+    any failure is logged, never raised (the message is already out)."""
+    path = os.path.join(sd, "progress", f"{sid}.json")
+    try:
+        pend = json.load(open(path))
+    except Exception:
+        return  # nothing pending for this session (e.g. not a placeholder turn)
+    keep, drop = [], []
+    for p in pend:
+        (drop if str(p.get("chat_id")) == str(chat_id) else keep).append(p)
+    if not drop:
+        return
+    for p in drop:
+        try:
+            api(tok, "deleteMessage",
+                {"chat_id": p.get("chat_id"), "message_id": p.get("message_id")})
+        except Exception as e:
+            log(sd, f"[fallback-send] placeholder delete failed: {e}")
+    try:
+        if keep:
+            json.dump(keep, open(path, "w"))
+        else:
+            os.remove(path)
+    except Exception as e:
+        log(sd, f"[fallback-send] pend trim failed: {e}")
+
+
+def parse_args(argv):
+    pos, sid, sdir = [], None, None
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--sid" and i + 1 < len(argv):
+            sid = argv[i + 1]; i += 2; continue
+        if a == "--state-dir" and i + 1 < len(argv):
+            sdir = argv[i + 1]; i += 2; continue
+        pos.append(a); i += 1
+    return pos, sid, sdir
+
+
+def main():
+    pos, cli_sid, cli_dir = parse_args(sys.argv[1:])
+    if len(pos) < 2:
+        sys.stderr.write("usage: telegram_fallback_send.py <chat_id> <text> "
+                         "[--sid SID] [--state-dir DIR]\n")
+        sys.exit(2)
+    chat_id, text = pos[0], pos[1]
+    sd = state_dir(cli_dir)
+    sid = session_id(cli_sid)
+
+    tok = token(sd)
+    if not tok:
+        sys.stderr.write("telegram_fallback_send: no TELEGRAM_BOT_TOKEN in "
+                         f"{os.path.join(sd, '.env')}\n")
+        sys.exit(2)
+
+    try:
+        resp = api(tok, "sendMessage", {"chat_id": chat_id, "text": text[:MAX_LEN]})
+    except Exception as e:
+        sys.stderr.write(f"telegram_fallback_send: sendMessage failed: {e}\n")
+        sys.exit(2)
+
+    if not (isinstance(resp, dict) and resp.get("ok")):
+        sys.stderr.write(f"telegram_fallback_send: Bot API not ok: {resp}\n")
+        sys.exit(2)
+
+    # Delivered -> mirror the reply tool: clear the placeholder so the Stop hook
+    # does not re-deliver the same answer.
+    clear_placeholder(sd, sid, chat_id, tok)
+    mid = (resp.get("result") or {}).get("message_id")
+    log(sd, f"[fallback-send] delivered chat={chat_id} message_id={mid} "
+            f"(placeholder cleared) sid={sid}")
+    # Echo the API result so the agent can record the message_id.
+    print(json.dumps(resp, ensure_ascii=False))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/telegram_progress_clear.py
+++ b/scripts/hooks/telegram_progress_clear.py
@@ -65,7 +65,10 @@ def token(sd):
 
 
 def api(tok, method, payload):
-    url = f"https://api.telegram.org/bot{tok}/{method}"
+    # Base is overridable (TELEGRAM_API_BASE) so tests can point it at a local
+    # stub; defaults to the real Bot API, so production is unchanged.
+    base = os.environ.get("TELEGRAM_API_BASE", "https://api.telegram.org").rstrip("/")
+    url = f"{base}/bot{tok}/{method}"
     data = json.dumps(payload).encode()
     req = urllib.request.Request(url, data=data,
                                  headers={"Content-Type": "application/json"})

--- a/scripts/install-telegram-progress-hook.sh
+++ b/scripts/install-telegram-progress-hook.sh
@@ -49,9 +49,13 @@ SUBMIT_HOOK="$DEST_DIR/telegram_progress.py"
 STOP_HOOK="$DEST_DIR/telegram_progress_clear.py"
 REPLY_HOOK="$DEST_DIR/telegram_progress_reply_clear.py"
 WATCHDOG="$DEST_DIR/telegram_progress_watchdog.py"
+# Agent-invoked CLI (not a settings.json hook): the Bot API fallback sender that
+# clears the placeholder on manual delivery so the Stop hook never re-sends.
+FALLBACK_SEND="$DEST_DIR/telegram_fallback_send.py"
 
 for f in telegram_progress.py telegram_progress_clear.py \
-         telegram_progress_reply_clear.py telegram_progress_watchdog.py; do
+         telegram_progress_reply_clear.py telegram_progress_watchdog.py \
+         telegram_fallback_send.py; do
   if [ ! -f "$SRC_DIR/$f" ]; then
     echo "❌ Source hook not found: $SRC_DIR/$f" >&2
     exit 1
@@ -63,7 +67,8 @@ cp "$SRC_DIR/telegram_progress.py"             "$SUBMIT_HOOK"
 cp "$SRC_DIR/telegram_progress_clear.py"       "$STOP_HOOK"
 cp "$SRC_DIR/telegram_progress_reply_clear.py" "$REPLY_HOOK"
 cp "$SRC_DIR/telegram_progress_watchdog.py"    "$WATCHDOG"
-chmod +x "$SUBMIT_HOOK" "$STOP_HOOK" "$REPLY_HOOK" "$WATCHDOG"
+cp "$SRC_DIR/telegram_fallback_send.py"        "$FALLBACK_SEND"
+chmod +x "$SUBMIT_HOOK" "$STOP_HOOK" "$REPLY_HOOK" "$WATCHDOG" "$FALLBACK_SEND"
 echo "✓ Hooks installed in $DEST_DIR"
 
 if [ ! -f "$SETTINGS" ]; then


### PR DESCRIPTION
## Problem (item a — clean dedup)

When the Telegram MCP `reply` tool drops mid-turn ("MCP servers have disconnected: plugin:telegram:telegram"), the agent delivers its answer via the Bot API directly (the `telegram-botapi-fallback` skill). But a **raw** `sendMessage` does **not** clear the `✍️ Dolgozom rajta…` placeholder — only the reply **tool**'s PostToolUse hook (`telegram_progress_reply_clear.py`) does.

So the Stop hook (`telegram_progress_clear.py`) still sees a pending placeholder and, on its enforce path, **re-delivers** the agent's final answer at turn end:
- the user gets the message **twice**, and
- gets nudged with "you never replied" → reads as *frozen* → **Csaba has to restart**.

## Fix

New agent-invoked helper **`telegram_fallback_send.py`** makes a manual fallback behave **exactly like the reply tool**: it sends the message **and then clears the placeholder** for that chat (`deleteMessage` + trim the session's pending list, mirroring `telegram_progress_reply_clear.py`). With the placeholder gone, the Stop hook finds nothing pending → **no duplicate, no nudge, no restart**.

- `telegram_fallback_send.py` — send via Bot API; on success clear the placeholder; **exit 2** on delivery failure (nothing cleared) so the caller escalates (email, per the skill). Session id from `CLAUDE_CODE_SESSION_ID`/`--sid`, state dir from `TELEGRAM_STATE_DIR`.
- `install-telegram-progress-hook.sh` — install the helper alongside the existing hooks.
- `telegram_progress_clear.py` — add a `TELEGRAM_API_BASE` seam (**default = real Bot API, production unchanged**) so the enforce path is testable against a stub. This is the only change to the enforce hook.

## Tests

New hermetic `scripts/__tests__/telegram-fallback-dedup.test.sh` (spins up a local Bot API stub, routes traffic via `TELEGRAM_API_BASE`, **12/12 pass**):
- **(a)** helper sends exactly once **and** clears the placeholder;
- **(b)** after the helper: the Stop hook produces **no duplicate** (send count stays 1) and **no nudge** (first Stop allows stop → no restart);
- **(c)** control: an **un-cleared** placeholder is exactly what the enforce path re-delivers — proving clearing is what prevents the dupe;
- **(d)** delivery failure → **exit 2**, placeholder kept (caller escalates).

## Companion (not in this PR)

The `telegram-botapi-fallback` skill is a **global, non-repo artifact**, so it is not part of this PR. It must be updated to call this helper instead of a raw `curl` `sendMessage`. Roll that out **after** this lands and the install runs (otherwise agents would call a helper that isn't installed yet).

## Not addressed here (item b — separate investigation)

The **deeper freeze** — when the dropped reply-tool call itself hangs so the round never reaches the Stop hook, so even the guaranteed 2nd-Stop fallback never fires — is a separate investigation into the plugin's stdio/reconnect timeout (`telegram/0.0.6/server.ts`). Diagnosis to follow; no fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)