### PR TITLE
fix(telegram): watchdog delivers the REAL answer fast on a wedged (hung-reply) turn

### DIFF
--- a/scripts/__tests__/telegram-watchdog-wedged.test.sh
+++ b/scripts/__tests__/telegram-watchdog-wedged.test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Contract tests for telegram_progress_watchdog.py — the wedged-turn sentry.
+# Contract tests for telegram_progress_watchdog.py -- the wedged-turn sentry.
 # Run: bash scripts/__tests__/telegram-watchdog-wedged.test.sh
 #
 # Locks the item-(b) fix: when a turn is WEDGED (agent up, but the reply MCP
@@ -55,7 +55,7 @@ PORT="$(cat "$PORTFILE" 2>/dev/null)"
 [ -z "$PORT" ] && { echo "FATAL: stub did not start"; exit 1; }
 API_BASE="http://127.0.0.1:$PORT"
 
-CHAT="8517922966"
+CHAT="10000000001"
 ANSWER="EZ_A_VALODI_VALASZ amit a usernek latnia kell"
 
 # Build a per-case agent state dir + transcript, then return the progress dir.
@@ -90,7 +90,7 @@ PY
 }
 pend_exists() { [ -f "$1/SID.json" ] && echo yes || echo no; }
 # REQLOG always exists (recreated per run); grep -c prints exactly one integer
-# line ("0" on no match) — no `|| echo 0` fallback (that would double the 0).
+# line ("0" on no match) -- no `|| echo 0` fallback (that would double the 0).
 count() { grep -c "^$1 " "$REQLOG" 2>/dev/null; }
 body_has() { grep -q "$1" "$REQLOG" && echo yes || echo no; }
 run_wd() { # force_up wedged_up_sec

--- a/scripts/__tests__/telegram-watchdog-wedged.test.sh
+++ b/scripts/__tests__/telegram-watchdog-wedged.test.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Contract tests for telegram_progress_watchdog.py — the wedged-turn sentry.
+# Run: bash scripts/__tests__/telegram-watchdog-wedged.test.sh
+#
+# Locks the item-(b) fix: when a turn is WEDGED (agent up, but the reply MCP
+# call is hung so the turn never ends), the watchdog must (1) react well before
+# the 15-min blunt backstop and (2) deliver the agent's REAL answer, not a
+# generic error. A legitimately long task (no hung reply) must NOT be touched
+# before the backstop.
+#
+# Fully hermetic: HOME and MARVEEN_ROOT are pinned to a temp tree so the
+# watchdog only ever scans test dirs (never the real ~/.claude), and all Bot API
+# traffic is routed to a local stub via TELEGRAM_API_BASE.
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (expected '$2', got '$3')"; fi; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+WATCHDOG="$INSTALL_DIR/scripts/hooks/telegram_progress_watchdog.py"
+
+TMP="$(mktemp -d)"
+trap 'kill "$STUB_PID" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+# --- Local Bot API stub (logs "<method> <body>" per request) -----------------
+REQLOG="$TMP/requests.log"; PORTFILE="$TMP/port"
+cat > "$TMP/stub.py" <<'PYEOF'
+import json, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+reqlog = sys.argv[1]
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(n).decode("utf-8") if n else ""
+        method = self.path.rsplit("/", 1)[-1]
+        with open(reqlog, "a", encoding="utf-8") as f:
+            f.write(f"{method} {body}\n")
+        out = {"ok": True, "result": {"message_id": 9001}}
+        payload = json.dumps(out).encode()
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload))); self.end_headers()
+        self.wfile.write(payload)
+srv = HTTPServer(("127.0.0.1", 0), H)
+with open(sys.argv[2], "w") as f: f.write(str(srv.server_address[1]))
+srv.serve_forever()
+PYEOF
+python3 "$TMP/stub.py" "$REQLOG" "$PORTFILE" &
+STUB_PID=$!
+for _ in $(seq 1 50); do [ -s "$PORTFILE" ] && break; sleep 0.1; done
+PORT="$(cat "$PORTFILE" 2>/dev/null)"
+[ -z "$PORT" ] && { echo "FATAL: stub did not start"; exit 1; }
+API_BASE="http://127.0.0.1:$PORT"
+
+CHAT="8517922966"
+ANSWER="EZ_A_VALODI_VALASZ amit a usernek latnia kell"
+
+# Build a per-case agent state dir + transcript, then return the progress dir.
+# kind = hung  -> last tool_use is a Telegram reply with NO result (round hung)
+# kind = work  -> last tool_use is a Bash WITH a result (legit long task)
+# kind = noans -> hung reply but NO assistant text (nothing to deliver)
+make_case() { # name kind age_seconds
+    local name="$1" kind="$2" age="$3"
+    local pdir="$TMP/root/agents/$name/.claude/channels/telegram/progress"
+    local sdir="$TMP/root/agents/$name/.claude/channels/telegram"
+    mkdir -p "$pdir"
+    printf 'TELEGRAM_BOT_TOKEN=TESTTOKEN\n' > "$sdir/.env"
+    local tr="$sdir/transcript.jsonl"
+    case "$kind" in
+      hung)
+        { printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"'"$ANSWER"'"}]}}';
+          printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tuReply1","name":"mcp__plugin_telegram_telegram__reply"}]}}'; } > "$tr" ;;
+      noans)
+        printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tuReply1","name":"mcp__plugin_telegram_telegram__reply"}]}}' > "$tr" ;;
+      work)
+        { printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"'"$ANSWER"'"},{"type":"tool_use","id":"tuBash1","name":"Bash"}]}}';
+          printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tuBash1"}]}}'; } > "$tr" ;;
+    esac
+    printf '[{"chat_id":"%s","message_id":555,"transcript_path":"%s"}]\n' "$CHAT" "$tr" \
+        > "$pdir/SID.json"
+    # Backdate the state file so its age exceeds the tested threshold.
+    python3 - "$pdir/SID.json" "$age" <<'PY'
+import os, sys, time
+os.utime(sys.argv[1], (time.time()-int(sys.argv[2]),)*2)
+PY
+    echo "$pdir"
+}
+pend_exists() { [ -f "$1/SID.json" ] && echo yes || echo no; }
+# REQLOG always exists (recreated per run); grep -c prints exactly one integer
+# line ("0" on no match) — no `|| echo 0` fallback (that would double the 0).
+count() { grep -c "^$1 " "$REQLOG" 2>/dev/null; }
+body_has() { grep -q "$1" "$REQLOG" && echo yes || echo no; }
+run_wd() { # force_up wedged_up_sec
+    : > "$REQLOG"
+    HOME="$TMP" MARVEEN_ROOT="$TMP/root" TELEGRAM_API_BASE="$API_BASE" \
+      TELEGRAM_WATCHDOG_FORCE_AGENT_UP="$1" TELEGRAM_WATCHDOG_WEDGED_UP_SEC="$2" \
+      python3 "$WATCHDOG"
+}
+
+echo "telegram-watchdog-wedged tests"
+echo "=============================="
+
+# ---------------------------------------------------------------------------
+# (a) Agent UP + hung reply + past the fast threshold -> deliver REAL answer
+# ---------------------------------------------------------------------------
+echo ""
+echo "(a) Wedged (hung reply): fast, real answer"
+PA="$(make_case wa hung 100)"
+run_wd 1 1
+assert_eq "fires fast: one real-answer sendMessage" "1" "$(count sendMessage)"
+assert_eq "delivers the REAL answer text (not a generic error)" "yes" "$(body_has "EZ_A_VALODI_VALASZ")"
+assert_eq "clears the placeholder (deleteMessage)" "1" "$(count deleteMessage)"
+assert_eq "no generic-error edit" "0" "$(count editMessageText)"
+assert_eq "state file removed after handling" "no" "$(pend_exists "$PA")"
+
+# ---------------------------------------------------------------------------
+# (b) Agent UP + NO hung reply, before the backstop -> DO NOT touch it
+# ---------------------------------------------------------------------------
+echo ""
+echo "(b) Legit long task (no hung reply): untouched before backstop"
+PB="$(make_case wb work 100)"
+run_wd 1 1
+assert_eq "no delivery for a legitimately working task" "0" "$(count sendMessage)"
+assert_eq "no error edit for a working task" "0" "$(count editMessageText)"
+assert_eq "placeholder preserved (task still running)" "yes" "$(pend_exists "$PB")"
+
+# ---------------------------------------------------------------------------
+# (c) Agent UP + no hung reply but past the 15-min backstop -> fire
+# ---------------------------------------------------------------------------
+echo ""
+echo "(c) Backstop: no hung reply but very old -> fire with real answer"
+PC="$(make_case wc work 1000)"   # 1000s > WEDGED_SEC (900)
+run_wd 1 1
+assert_eq "backstop fires: one delivery" "1" "$(count sendMessage)"
+assert_eq "state file removed" "no" "$(pend_exists "$PC")"
+
+# ---------------------------------------------------------------------------
+# (d) Agent DOWN + past the down grace -> fire with real answer
+# ---------------------------------------------------------------------------
+echo ""
+echo "(d) Agent down: fire with real answer"
+PD="$(make_case wd hung 200)"    # 200s > DOWN_GRACE_SEC (120)
+run_wd 0 1
+assert_eq "down path fires: one delivery" "1" "$(count sendMessage)"
+assert_eq "delivers the real answer" "yes" "$(body_has "EZ_A_VALODI_VALASZ")"
+
+# ---------------------------------------------------------------------------
+# (e) Hung reply but NO recoverable answer -> generic error, keep placeholder
+# ---------------------------------------------------------------------------
+echo ""
+echo "(e) Nothing to deliver: falls back to generic error edit"
+PE="$(make_case we noans 100)"
+run_wd 1 1
+assert_eq "no real-answer send (nothing to deliver)" "0" "$(count sendMessage)"
+assert_eq "rewrites placeholder into a generic error" "1" "$(count editMessageText)"
+assert_eq "error text used" "yes" "$(body_has "Valami elakadt")"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=============================="
+TOTAL=$((PASS + FAIL))
+echo "Results: $PASS/$TOTAL passed"
+if [ "$FAIL" -gt 0 ]; then echo "FAILED: $FAIL tests"; exit 1; fi
+echo "All tests passed."

--- a/scripts/hooks/telegram_progress.py
+++ b/scripts/hooks/telegram_progress.py
@@ -85,6 +85,11 @@ def main():
         return
     prompt = ev.get("prompt") or ""
     sid = ev.get("session_id") or "default"
+    # Stash the transcript path so the standalone watchdog (which gets no hook
+    # event) can read the agent's final answer + detect a hung reply tool call
+    # for a placeholder that never got cleared. Absent on some CC versions ->
+    # the watchdog just falls back to its generic-error behavior.
+    transcript_path = ev.get("transcript_path") or ""
     sd = state_dir()
 
     blocks = re.findall(r'<channel\b[^>]*\bsource="[^"]*telegram[^"]*"[^>]*>', prompt)
@@ -116,7 +121,10 @@ def main():
             resp = api(tok, "sendMessage", {"chat_id": chat_id, "text": PLACEHOLDER})
             pmid = resp.get("result", {}).get("message_id")
             if pmid:
-                pending.append({"chat_id": chat_id, "message_id": pmid})
+                entry = {"chat_id": chat_id, "message_id": pmid}
+                if transcript_path:
+                    entry["transcript_path"] = transcript_path
+                pending.append(entry)
         except Exception as e:
             log(sd, f"[submit] placeholder failed: {e}")
 

--- a/scripts/hooks/telegram_progress_watchdog.py
+++ b/scripts/hooks/telegram_progress_watchdog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-telegram_progress_watchdog.py — the "őrszem" (sentry) for the Telegram progress
+telegram_progress_watchdog.py -- the "őrszem" (sentry) for the Telegram progress
 indicator. Runs independently of the agent sessions (via launchd/systemd), so it
 can speak even when an agent is wedged or down.
 
@@ -12,11 +12,11 @@ wondering "is it working or broken?".
 
 Two delivery modes, best-effort per pending placeholder:
   - REAL ANSWER (preferred): if the agent's final answer is recoverable from the
-    transcript, deliver it for real (sendMessage) and remove the placeholder —
+    transcript, deliver it for real (sendMessage) and remove the placeholder --
     the same answer the Stop hook's guaranteed fallback would have sent, but
     without waiting for a turn end that may never come. This is the fix for the
     "reply tool dropped mid-turn -> round hangs -> Stop hook never fires ->
-    Csaba has to restart" freeze: the user gets the actual answer, restart-free.
+    the owner has to restart" freeze: the user gets the actual answer, restart-free.
   - GENERIC ERROR (fallback): if no answer is recoverable, rewrite the
     placeholder into a clear error (editMessageText), as before.
 
@@ -39,7 +39,7 @@ via TELEGRAM_API_BASE (tests point it at a local stub).
 import os, glob, json, time, subprocess, urllib.request
 
 # State dirs to scan: per-agent dirs under the fleet, plus the default dir.
-# No hardcoded user paths — derive from $HOME (override with MARVEEN_ROOT).
+# No hardcoded user paths -- derive from $HOME (override with MARVEEN_ROOT).
 FLEET_ROOT = os.environ.get("MARVEEN_ROOT") or os.path.expanduser("~/marveen")
 SCAN_GLOBS = [
     os.path.join(FLEET_ROOT, "agents", "*", ".claude", "channels", "telegram", "progress"),

--- a/scripts/hooks/telegram_progress_watchdog.py
+++ b/scripts/hooks/telegram_progress_watchdog.py
@@ -1,28 +1,40 @@
 #!/usr/bin/env python3
 """
 telegram_progress_watchdog.py — the "őrszem" (sentry) for the Telegram progress
-indicator. Runs independently of the agent sessions (via launchd), so it can
-speak even when an agent is wedged or down.
+indicator. Runs independently of the agent sessions (via launchd/systemd), so it
+can speak even when an agent is wedged or down.
 
 Problem it solves: the UserPromptSubmit hook posts a "✍️ Dolgozom rajta…"
 placeholder; the Stop hook deletes it when the turn ends. If a turn never ends
-(agent crashed, session killed, wedged), the placeholder would sit there
-forever and the user is left wondering "is it working or broken?". This watchdog
-detects those orphans and rewrites the placeholder into a CLEAR error message,
-so the user always gets an unambiguous signal.
+(agent crashed, session killed, or WEDGED on a dropped MCP reply-tool call that
+never returns), the placeholder would sit there forever and the user is left
+wondering "is it working or broken?".
 
-Detection (per pending placeholder, identified by its session state file):
-  - agent process DOWN (its tmux `agent-<name>` session is gone) and the
-    placeholder is older than DOWN_GRACE_SEC  -> error (covers crash / not
-    reachable, with a short grace so a fleet restart isn't flagged), or
-  - agent UP but the placeholder is older than WEDGED_SEC -> error (covers a
-    genuinely stuck turn; generous so long legit tasks aren't killed).
+Two delivery modes, best-effort per pending placeholder:
+  - REAL ANSWER (preferred): if the agent's final answer is recoverable from the
+    transcript, deliver it for real (sendMessage) and remove the placeholder —
+    the same answer the Stop hook's guaranteed fallback would have sent, but
+    without waiting for a turn end that may never come. This is the fix for the
+    "reply tool dropped mid-turn -> round hangs -> Stop hook never fires ->
+    Csaba has to restart" freeze: the user gets the actual answer, restart-free.
+  - GENERIC ERROR (fallback): if no answer is recoverable, rewrite the
+    placeholder into a clear error (editMessageText), as before.
 
-On error it edits the existing placeholder message (editMessageText) into the
-error text and removes the state file so it fires once.
+Detection (per pending placeholder, keyed by its session state file):
+  - agent DOWN (its tmux `agent-<name>` session is gone) and the placeholder is
+    older than DOWN_GRACE_SEC -> fire (crash / unreachable), or
+  - agent UP but the transcript shows a HUNG reply -- the most recent tool call
+    is the Telegram `reply` and it has no result yet -- and the placeholder is
+    older than WEDGED_UP_SEC -> fire FAST. This precisely targets the dropped-
+    MCP freeze and does NOT misfire on a legitimately long task (which has no
+    dangling reply call), so the threshold can be far below the blunt backstop.
+  - agent UP with no hung-reply signal but the placeholder is older than
+    WEDGED_SEC -> fire (blunt backstop for genuinely stuck turns; generous so
+    long legit tasks aren't cut short).
 
 Standalone: scans every agent's per-agent telegram state dir. No marveen src
-dependency; only Python stdlib + the `tmux` binary.
+dependency; only Python stdlib + the `tmux` binary. Bot API base is overridable
+via TELEGRAM_API_BASE (tests point it at a local stub).
 """
 import os, glob, json, time, subprocess, urllib.request
 
@@ -33,10 +45,30 @@ SCAN_GLOBS = [
     os.path.join(FLEET_ROOT, "agents", "*", ".claude", "channels", "telegram", "progress"),
     os.path.expanduser("~/.claude/channels/telegram/progress"),
 ]
-DOWN_GRACE_SEC = 120        # agent down + placeholder older than this -> error
-WEDGED_SEC = 15 * 60        # agent up but placeholder this old -> error
+DOWN_GRACE_SEC = 120        # agent down + placeholder older than this -> fire
+WEDGED_SEC = 15 * 60        # agent up, no hung-reply signal, this old -> fire (backstop)
+# agent up + a HUNG reply detected + placeholder older than this -> fire FAST.
+# Far below WEDGED_SEC because the hung-reply signal is precise. Env-tunable so
+# a live install can adjust without a code change.
+DEFAULT_WEDGED_UP_SEC = 180
 ERROR_TEXT = ("⚠️ Valami elakadt, és erre nem érkezett válasz. "
               "Lehet, hogy újra kell indítani az ügynököt, vagy próbáld újra kicsit később.")
+
+
+def _env_int(name, default):
+    v = os.environ.get(name)
+    if v:
+        try:
+            n = int(v)
+            if n > 0:
+                return n
+        except ValueError:
+            pass
+    return default
+
+
+def wedged_up_sec():
+    return _env_int("TELEGRAM_WATCHDOG_WEDGED_UP_SEC", DEFAULT_WEDGED_UP_SEC)
 
 
 def token(state_dir):
@@ -51,7 +83,8 @@ def token(state_dir):
 
 
 def api(tok, method, payload):
-    url = f"https://api.telegram.org/bot{tok}/{method}"
+    base = os.environ.get("TELEGRAM_API_BASE", "https://api.telegram.org").rstrip("/")
+    url = f"{base}/bot{tok}/{method}"
     data = json.dumps(payload).encode()
     req = urllib.request.Request(url, data=data,
                                  headers={"Content-Type": "application/json"})
@@ -70,11 +103,80 @@ def agent_name_from(progress_dir):
 
 
 def tmux_session_alive(session):
+    # Test/override seam: force the agent-up verdict without a real tmux probe.
+    forced = os.environ.get("TELEGRAM_WATCHDOG_FORCE_AGENT_UP")
+    if forced in ("0", "1"):
+        return forced == "1"
     try:
         return subprocess.run(["tmux", "has-session", "-t", session],
                               capture_output=True, timeout=5).returncode == 0
     except Exception:
         return True  # if tmux probe fails, assume alive (don't false-alarm)
+
+
+def _iter_events(transcript_path):
+    if not transcript_path:
+        return
+    try:
+        f = open(transcript_path, encoding="utf-8")
+    except Exception:
+        return
+    with f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except Exception:
+                continue
+
+
+def _is_reply_tool(name):
+    n = (name or "").lower()
+    return "telegram" in n and "reply" in n
+
+
+def read_transcript(transcript_path):
+    """Return (last_assistant_text, reply_is_hung).
+
+    last_assistant_text: the agent's final user-facing answer (last non-empty
+    assistant text block) -- the same source the Stop hook's fallback uses.
+
+    reply_is_hung: True iff the MOST RECENT tool call is the Telegram `reply`
+    tool and it has no matching tool_result yet -- i.e. the agent tried to reply
+    and the call never returned (dropped MCP). Keyed on the LAST tool_use so a
+    stale dangling reply from an already-handled earlier turn can't misfire.
+    """
+    text = ""
+    results = set()               # tool_use_ids that have a tool_result
+    last_tool_use = None          # (id, is_reply) of the most recent tool_use
+    for ev in _iter_events(transcript_path):
+        msg = ev.get("message") or {}
+        role = msg.get("role") or ev.get("role")
+        content = msg.get("content", ev.get("content"))
+        is_assistant = ev.get("type") == "assistant" or role == "assistant"
+        if isinstance(content, list):
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                bt = b.get("type")
+                if bt == "tool_use":
+                    last_tool_use = (b.get("id"), _is_reply_tool(b.get("name")))
+                elif bt == "tool_result":
+                    tid = b.get("tool_use_id")
+                    if tid is not None:
+                        results.add(tid)
+                elif bt == "text" and is_assistant:
+                    t = (b.get("text") or "").strip()
+                    if t:
+                        text = t
+        elif isinstance(content, str) and is_assistant:
+            if content.strip():
+                text = content.strip()
+    reply_is_hung = bool(last_tool_use and last_tool_use[1]
+                         and last_tool_use[0] not in results)
+    return text, reply_is_hung
 
 
 def log(progress_dir, msg):
@@ -83,6 +185,30 @@ def log(progress_dir, msg):
             f.write(f"[watchdog {time.strftime('%H:%M:%S')}] {msg}\n")
     except Exception:
         pass
+
+
+def deliver(tok, chat_id, message_id, answer, progress_dir):
+    """Deliver the real answer if we have one (sendMessage + drop the
+    placeholder), else rewrite the placeholder into a generic error. Returns a
+    short label for logging."""
+    if answer:
+        try:
+            api(tok, "sendMessage", {"chat_id": chat_id, "text": answer[:4000]})
+        except Exception as e:
+            log(progress_dir, f"real-answer send failed (mid={message_id}): {e}")
+            return "send-failed"
+        try:
+            api(tok, "deleteMessage", {"chat_id": chat_id, "message_id": message_id})
+        except Exception as e:
+            log(progress_dir, f"placeholder delete failed (mid={message_id}): {e}")
+        return "real-answer"
+    # No recoverable answer -> generic error, keep the (edited) placeholder.
+    try:
+        api(tok, "editMessageText",
+            {"chat_id": chat_id, "message_id": message_id, "text": ERROR_TEXT})
+    except Exception as e:
+        log(progress_dir, f"error edit failed (mid={message_id}): {e}")
+    return "generic-error"
 
 
 def handle_dir(progress_dir):
@@ -98,37 +224,60 @@ def handle_dir(progress_dir):
         except Exception:
             pass
     tok = None
+    up_sec = wedged_up_sec()
     for path in glob.glob(os.path.join(progress_dir, "*.json")):
         try:
             age = now - os.path.getmtime(path)
         except Exception:
             continue
-        # Decide if this is an orphan needing an error.
-        orphan = (not agent_up and age > DOWN_GRACE_SEC) or (age > WEDGED_SEC)
-        if not orphan:
-            continue
         try:
             pend = json.load(open(path))
         except Exception:
             pend = []
+        if not pend:
+            continue
+
+        # The transcript path is stamped onto the pending entries by the submit
+        # hook (same for the whole turn); read the agent's answer + hung-reply
+        # signal once.
+        transcript_path = ""
+        for p in pend:
+            if p.get("transcript_path"):
+                transcript_path = p["transcript_path"]
+                break
+        answer, reply_hung = read_transcript(transcript_path)
+
+        # Fire decision.
+        if not agent_up:
+            fire = age > DOWN_GRACE_SEC
+            reason = "agent-down"
+        elif reply_hung and age > up_sec:
+            fire = True
+            reason = "reply-hung"
+        elif age > WEDGED_SEC:
+            fire = True
+            reason = "wedged-backstop"
+        else:
+            fire = False
+            reason = ""
+        if not fire:
+            continue
+
         if tok is None:
             tok = token(state_dir)
+        if not tok:
+            continue
+        modes = []
         for p in pend:
-            if not tok:
-                break
-            try:
-                api(tok, "editMessageText", {
-                    "chat_id": p["chat_id"], "message_id": p["message_id"],
-                    "text": ERROR_TEXT,
-                })
-            except Exception as e:
-                log(progress_dir, f"edit failed (mid={p.get('message_id')}): {e}")
+            modes.append(deliver(tok, p.get("chat_id"), p.get("message_id"),
+                                 answer, progress_dir))
         try:
             os.remove(path)
-            log(progress_dir, f"orphan handled: {os.path.basename(path)} "
-                              f"agent_up={agent_up} age={int(age)}s")
         except Exception:
             pass
+        log(progress_dir, f"orphan handled ({reason}): {os.path.basename(path)} "
+                          f"agent_up={agent_up} age={int(age)}s "
+                          f"delivered={','.join(modes)}")
 
 
 def main():


### PR DESCRIPTION
## Item (b) — the deeper freeze (direction C, marveen-owned, no plugin-cache changes)

When the reply MCP tool drops mid-turn, the agent's `reply` call can **hang** so the round never ends → the Stop hook never fires → its guaranteed 2nd-Stop fallback never runs → the turn looks **frozen** and Csaba has to restart.

The standalone watchdog (`telegram_progress_watchdog.py`) was the only net, but it:
1. only fired after the **15-min** blunt backstop, and
2. rewrote the placeholder into a **generic error** (`editMessageText`) — it never delivered the agent's actual answer.

This teaches the watchdog to recognize a wedged turn **precisely** and deliver the **real answer**:

- **`telegram_progress.py`** stamps `transcript_path` onto each pending placeholder entry (additive — the other hooks ignore the extra key), so the standalone watchdog (which gets no hook event) can read the transcript.
- **`telegram_progress_watchdog.py`** parses that transcript for:
  - the agent's **final answer** (last assistant text — same source as the Stop hook's fallback in `telegram_progress_clear.py`), and
  - a **hung-reply signal**: the *most recent* `tool_use` is the Telegram `reply` tool and it has **no `tool_result`** yet. Keyed on the **last** tool call, so a stale dangling reply from an already-handled earlier turn can't misfire, and a legitimately long task (no dangling reply) is **never touched early**.
  On agent-down (grace) or a hung reply past **`WEDGED_UP_SEC`** (default **180s**, env `TELEGRAM_WATCHDOG_WEDGED_UP_SEC`) it now **delivers the real answer** (`sendMessage` + drop the placeholder). Only when no answer is recoverable does it fall back to the old generic-error edit. The 15-min backstop remains for genuinely stuck turns with no hung-reply signal.
- **`TELEGRAM_API_BASE`** + **`TELEGRAM_WATCHDOG_FORCE_AGENT_UP`** seams make it hermetically testable (defaults = real Bot API / real tmux probe → production unchanged).

## Tests

`scripts/__tests__/telegram-watchdog-wedged.test.sh` — local Bot API stub, `HOME`+`MARVEEN_ROOT` pinned to a temp tree so the **real `~/.claude` is never scanned**, **15/15**:
- **(a)** wedged (hung reply) → fires fast, delivers the **real answer**, clears the placeholder, no error edit;
- **(b)** legit long task (no hung reply) → **untouched** before the backstop;
- **(c)** backstop still fires for a very old turn with no hung-reply signal;
- **(d)** agent down → fires with the real answer;
- **(e)** no recoverable answer → falls back to the generic-error edit.

## Relationship to the other PRs

Independent of #638 (item a, the fallback-send dedup helper) — no shared files. Together: #638 stops duplicates when the reply tool drops but the round *does* end; this PR delivers the real answer restart-free when the round *doesn't* end. Item (a)'s companion skill change and this both leave the enforce path intact.

Note: direction **A** (client-side per-tool-call timeout — the root cure) is harness/Claude Code scope and deliberately out of scope here; direction **B** (plugin `server.ts` flake) touches the fragile plugin cache and is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)