### PR TITLE
Fix/memories get agent id alias

### DIFF
--- a/src/__tests__/memories-get-agent-id-alias.test.ts
+++ b/src/__tests__/memories-get-agent-id-alias.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression test for GET /api/memories agent_id alias bug.
+ *
+ * Root cause: the GET handler only read `?agent=`, so callers using `?agent_id=`
+ * (which matches the POST body field name) got the global `searchMemories()` path
+ * instead — silently returning every agent's memories. Zero error, wrong data.
+ *
+ * Fix: accept `agent_id` as a deprecated alias for `agent` in GET query params.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { initDatabase, saveAgentMemory } from '../db.js'
+import { tryHandleMemories } from '../web/routes/memories.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+vi.mock('../config.js', async () => {
+  const actual = await vi.importActual<typeof import('../config.js')>('../config.js')
+  return {
+    ...actual,
+    MAIN_AGENT_ID: 'agent-a',
+    ALLOWED_CHAT_ID: 'test-chat',
+    OLLAMA_URL: '',
+  }
+})
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+function makeCtx(path: string, searchParams: Record<string, string> = {}): { ctx: RouteContext; getBody: () => any } {
+  const url = new URL(`http://localhost:3420${path}`)
+  for (const [k, v] of Object.entries(searchParams)) url.searchParams.set(k, v)
+
+  let responseBody = ''
+  const res = {
+    writeHead: vi.fn(),
+    end: (body?: string) => { responseBody = body || '' },
+  }
+
+  return {
+    ctx: { req: {} as any, res: res as any, path, method: 'GET', url },
+    getBody: () => (responseBody ? JSON.parse(responseBody) : null),
+  }
+}
+
+beforeAll(() => {
+  initDatabase(':memory:')
+  // agent-a memory -- canonical owner
+  saveAgentMemory('agent-a', 'alpha contract detail', 'warm', 'contract')
+  // agent-b memory -- must NOT leak into agent-a queries
+  saveAgentMemory('agent-b', 'beta private data', 'warm', 'private')
+})
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
+
+describe('GET /api/memories agent_id alias', () => {
+  it('?agent_id= returns same results as ?agent= for a keyword search', async () => {
+    const { ctx: ctxAgent, getBody: getBodyAgent } = makeCtx('/api/memories', { agent: 'agent-a', q: 'alpha' })
+    await tryHandleMemories(ctxAgent)
+    const byAgent = getBodyAgent() as any[]
+
+    const { ctx: ctxAlias, getBody: getBodyAlias } = makeCtx('/api/memories', { agent_id: 'agent-a', q: 'alpha' })
+    await tryHandleMemories(ctxAlias)
+    const byAlias = getBodyAlias() as any[]
+
+    expect(byAlias.length).toBeGreaterThan(0)
+    expect(byAlias.map((m: any) => m.id).sort()).toEqual(byAgent.map((m: any) => m.id).sort())
+  })
+
+  it('?agent_id=agent-a does NOT return agent-b memories', async () => {
+    const { ctx, getBody } = makeCtx('/api/memories', { agent_id: 'agent-a', q: 'beta' })
+    await tryHandleMemories(ctx)
+    const results = getBody() as any[]
+    // Without the fix, this returns agent-b's memory because the handler falls
+    // through to the global searchMemories() path.
+    const agentBLeaked = results.some((m: any) => m.agent_id === 'agent-b')
+    expect(agentBLeaked).toBe(false)
+  })
+
+  it('?agent_id= without q lists only that agent memories', async () => {
+    const { ctx, getBody } = makeCtx('/api/memories', { agent_id: 'agent-a' })
+    await tryHandleMemories(ctx)
+    const results = getBody() as any[]
+    expect(results.length).toBeGreaterThan(0)
+    for (const m of results) {
+      expect(m.agent_id).toBe('agent-a')
+    }
+  })
+})

--- a/src/__tests__/memories-get-agent-id-alias.test.ts
+++ b/src/__tests__/memories-get-agent-id-alias.test.ts
@@ -46,8 +46,9 @@ beforeAll(() => {
   initDatabase(':memory:')
   // agent-a memory -- canonical owner
   saveAgentMemory('agent-a', 'alpha contract detail', 'warm', 'contract')
-  // agent-b memory -- must NOT leak into agent-a queries
-  saveAgentMemory('agent-b', 'beta private data', 'warm', 'private')
+  // agent-b memory with overlapping keyword -- without the fix, the global search
+  // would return this row too, causing the same-results test to diverge.
+  saveAgentMemory('agent-b', 'alpha data owned by b', 'warm', 'contract')
 })
 
 afterAll(() => {
@@ -69,11 +70,12 @@ describe('GET /api/memories agent_id alias', () => {
   })
 
   it('?agent_id=agent-a does NOT return agent-b memories', async () => {
-    const { ctx, getBody } = makeCtx('/api/memories', { agent_id: 'agent-a', q: 'beta' })
+    // Both agents have 'alpha' content, so the global path would return both.
+    const { ctx, getBody } = makeCtx('/api/memories', { agent_id: 'agent-a', q: 'alpha' })
     await tryHandleMemories(ctx)
     const results = getBody() as any[]
-    // Without the fix, this returns agent-b's memory because the handler falls
-    // through to the global searchMemories() path.
+    // Without the fix, the handler falls through to global searchMemories() and
+    // agent-b's 'alpha data owned by b' row leaks in.
     const agentBLeaked = results.some((m: any) => m.agent_id === 'agent-b')
     expect(agentBLeaked).toBe(false)
   })

--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -63,7 +63,11 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
 
   if (path === '/api/memories' && method === 'GET') {
     const q = url.searchParams.get('q')?.trim() || ''
-    const agentId = url.searchParams.get('agent') || ''
+    const agentIdAlias = url.searchParams.get('agent_id')
+    if (agentIdAlias && !url.searchParams.get('agent')) {
+      logger.warn({ agent_id: agentIdAlias }, '[DEPRECATED] GET /api/memories: use "agent" instead of "agent_id"')
+    }
+    const agentId = url.searchParams.get('agent') || agentIdAlias || ''
     const tier = url.searchParams.get('tier') || url.searchParams.get('category') || ''
     const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200)
     const mode = url.searchParams.get('mode') || 'fts'


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A `GET /api/memories` végpont némán eldobta az `?agent_id=` query paramétert, holott a `POST /api/memories` body-jában pontosan ez a kanonikus mezőnév. A handler csak az `?agent=` paramétert olvasta, így `agent_id=` esetén az `agentId` üres stringre esett, és a kérés átcsúszott a globális `searchMemories()` ágra.

Az eredmény a legrosszabb hibafajta: **HTTP 200, nulla hiba, nulla figyelmeztetés, de a válasz minden ágens emlékét tartalmazta**, nem csak a kértet. Egy több ágenses fleetben ez ágensek közötti adatszivárgás: `?agent_id=agent-a&q=foo` az `agent-b` emlékeit is visszaadta. A hívó oldalán ez úgy néz ki, mintha a szűrés működne.

A javítás a GET handlerben elfogadja az `agent_id`-t az `agent` **deprecated aliasaként**: ha csak `agent_id=` érkezik (és nincs explicit `agent=`), a szerver deprecation warningot logol, és az `agent_id` értékét használja szűrőként. Ha mindkettő jelen van, az `agent=` marad a mérvadó, így a meglévő hívók viselkedése nem változik.

A megközelítés nem új mintát vezet be: ugyanez az alias + deprecation-log minta már létezik ugyanebben a fájlban, a POST handlerben, ahol a legacy `tier` a `category` aliasaként van kezelve.

**EN:** `GET /api/memories` silently discarded the `?agent_id=` query parameter, even though `agent_id` is the canonical field name in the POST body. The handler only read `?agent=`, so an `agent_id=` request fell through to the global `searchMemories()` path and returned **every agent's memories with HTTP 200 and no error or warning**. In a multi-agent fleet this is cross-agent data leakage: `?agent_id=agent-a&q=foo` also returned `agent-b`'s memories, while looking like a working filter to the caller.

The fix accepts `agent_id` as a deprecated alias for `agent` in the GET query params: when only `agent_id=` is present, the server logs a deprecation warning and uses its value. An explicit `agent=` still wins, so existing callers are unaffected. This mirrors the existing `tier`/`category` alias-plus-deprecation pattern already present in the POST handler of the same file.

**Teszt / Tests:** 3 eset — (1) az alias ugyanazt adja, mint a kanonikus paraméter, (2) nincs ágensek közötti szivárgás, (3) `q` nélküli listázás is szűrve marad. A fix visszavételével mind a 3 teszt piros (reverttel igazolva), a fix-szel mind a 3 zöld. Teljes suite: 165 tesztfájl, 2323 teszt, nulla regresszió. A fixture semleges (`agent-a` / `agent-b`), személyes adatot nem tartalmaz.

## Kapcsolódó issue / Related issue

Nincs kapcsolódó nyitott issue: a hibát éles használat közben találtuk, nem bejelentésből.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
  <br>→ Unit- és integrációs teszttel igazolva (2323 teszt, a hibát reverttel is bizonyítva); a futó dashboardon még nem lett kipróbálva. / Verified by the test suite (2323 tests, bug proven by revert); not yet exercised on a running dashboard instance.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
  <br>→ Nem érinti a telepítést vagy az architektúrát, `docs/` frissítés nem szükséges. / No installation or architecture impact; no `docs/` update needed.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
