### PR TITLE
fix(skill-index): add AGENT_DIR arg for per-agent merged skill index

### DIFF
--- a/scheduled-tasks/memoria-heartbeat/SKILL.md
+++ b/scheduled-tasks/memoria-heartbeat/SKILL.md
@@ -36,7 +36,10 @@ Először döntsd el az alábbi 3 kérdéssel:
 **Ha A vagy B vagy C IGEN: KÖTELEZŐ skill akció, nem kihagyható.**
 
 Lépések:
-1. Nézd meg `ls ~/.claude/skills/`-szel hogy van-e már lefedő skill (a `.skill-index.md`-ben szöveges keresés)
+1. Keress meglévő skillt a globális és az ágensspecifikus indexben egyaránt:
+   - Globális: `~/.claude/skills/.skill-index.md` (szöveges keresés)
+   - Ágensspecifikus (ha van): `./.claude/skills/.skill-index.md` a munkamappádban (szöveges keresés)
+   - Az ágensspecifikus index mindkét szintet tartalmazza, tehát ha az létezik, elég azt nézegetni.
 2. Ha van releváns skill: PATCH (csak a megváltozott rész cseréje, ne az egész fájl).
    - A `## Buktatók` szekciót preferáld ha hiba/recovery volt.
    - A `## Eljárás` szekciót ha a folyamat változott.
@@ -63,7 +66,11 @@ Lépések:
    - ...
    EOF
    ```
-4. Index regen: `bash {{INSTALL_DIR}}/scripts/skill-index.sh`
+4. Index regen (mindkét szint):
+   ```bash
+   bash {{INSTALL_DIR}}/scripts/skill-index.sh          # globális index frissítése
+   bash {{INSTALL_DIR}}/scripts/skill-index.sh "$(pwd)" # ágensspecifikus merged index frissítése
+   ```
 
 **Ha kihagytad a skill akciót, pedig A/B/C valamelyike IGEN volt:** kötelezően írj `hot` tier memóriát "skip-skill: <konkrét ok>" tartalommal, hogy később lássuk miért. Ne csendben hagyd ki.
 

--- a/scripts/skill-index.sh
+++ b/scripts/skill-index.sh
@@ -2,46 +2,88 @@
 # Skill Index Generator
 # Generates a Level 0 index of all available skills (name + description only)
 # This keeps token usage low while making all skills discoverable
+#
+# Usage: skill-index.sh [AGENT_DIR]
+#   Without arg: generates global index at ~/.claude/skills/.skill-index.md
+#   With AGENT_DIR: generates merged index (global + agent-specific) at
+#                   <AGENT_DIR>/.claude/skills/.skill-index.md
+#                   (backward-compatible format for no-arg callers)
 
-SKILLS_DIR="$HOME/.claude/skills"
-OUTPUT="$SKILLS_DIR/.skill-index.md"
+GLOBAL_SKILLS_DIR="$HOME/.claude/skills"
 
-if [ ! -d "$SKILLS_DIR" ]; then
-  echo "No skills directory found at $SKILLS_DIR"
+if [ $# -ge 1 ]; then
+  AGENT_DIR="$1"
+  AGENT_SKILLS_DIR="$AGENT_DIR/.claude/skills"
+  OUTPUT="$AGENT_SKILLS_DIR/.skill-index.md"
+  MERGED=1
+  mkdir -p "$AGENT_SKILLS_DIR"
+else
+  AGENT_DIR=""
+  AGENT_SKILLS_DIR=""
+  OUTPUT="$GLOBAL_SKILLS_DIR/.skill-index.md"
+  MERGED=0
+fi
+
+if [ ! -d "$GLOBAL_SKILLS_DIR" ]; then
+  echo "No global skills directory found at $GLOBAL_SKILLS_DIR"
   exit 0
 fi
 
 echo "# Skill Index (Level 0)" > "$OUTPUT"
 echo "" >> "$OUTPUT"
-echo "Ez az összes elérhető skill rövid indexe. Csak a nevet és leírást tartalmazza (Level 0)." >> "$OUTPUT"
-echo "Ha egy skill releváns, olvasd be a teljes SKILL.md-t (Level 1)." >> "$OUTPUT"
-echo "Ha segédfájlokra is szükség van, nézd meg a scripts/ és references/ mappákat (Level 2)." >> "$OUTPUT"
-echo "" >> "$OUTPUT"
-echo "| Skill | Leírás |" >> "$OUTPUT"
-echo "|-------|--------|" >> "$OUTPUT"
+
+if [ "$MERGED" = "1" ]; then
+  echo "Ez az ágensspecifikus skill index: globális (~/.claude/skills) és ágensspecifikus (.claude/skills) skilleket egyaránt tartalmaz." >> "$OUTPUT"
+  echo "Ha egy skill releváns, olvasd be a teljes SKILL.md-t (Level 1)." >> "$OUTPUT"
+  echo "Ha segédfájlokra is szükség van, nézd meg a scripts/ és references/ mappákat (Level 2)." >> "$OUTPUT"
+  echo "" >> "$OUTPUT"
+  echo "| Skill | Leírás | Scope |" >> "$OUTPUT"
+  echo "|-------|--------|-------|" >> "$OUTPUT"
+else
+  echo "Ez az összes elérhető skill rövid indexe. Csak a nevet és leírást tartalmazza (Level 0)." >> "$OUTPUT"
+  echo "Ha egy skill releváns, olvasd be a teljes SKILL.md-t (Level 1)." >> "$OUTPUT"
+  echo "Ha segédfájlokra is szükség van, nézd meg a scripts/ és references/ mappákat (Level 2)." >> "$OUTPUT"
+  echo "" >> "$OUTPUT"
+  echo "| Skill | Leírás |" >> "$OUTPUT"
+  echo "|-------|--------|" >> "$OUTPUT"
+fi
 
 SKILL_COUNT=0
 
-for skill_dir in "$SKILLS_DIR"/*/; do
-  [ -d "$skill_dir" ] || continue
-  skill_md="$skill_dir/SKILL.md"
-  [ -f "$skill_md" ] || continue
+index_skills_dir() {
+  local dir="$1"
+  local scope="$2"  # only used when MERGED=1
+  for skill_dir in "$dir"/*/; do
+    [ -d "$skill_dir" ] || continue
+    local skill_md="$skill_dir/SKILL.md"
+    [ -f "$skill_md" ] || continue
 
-  # Extract name from frontmatter
-  name=$(grep -m1 "^name:" "$skill_md" 2>/dev/null | sed 's/^name: *//' | tr -d '"' | tr -d "'")
-  if [ -z "$name" ]; then
-    name=$(basename "$skill_dir")
-  fi
+    local name
+    name=$(grep -m1 "^name:" "$skill_md" 2>/dev/null | sed 's/^name: *//' | tr -d '"' | tr -d "'")
+    if [ -z "$name" ]; then
+      name=$(basename "$skill_dir")
+    fi
 
-  # Extract description from frontmatter
-  desc=$(grep -m1 "^description:" "$skill_md" 2>/dev/null | sed 's/^description: *//' | tr -d '"' | tr -d "'" | cut -c1-120)
-  if [ -z "$desc" ]; then
-    desc="(nincs leírás)"
-  fi
+    local desc
+    desc=$(grep -m1 "^description:" "$skill_md" 2>/dev/null | sed 's/^description: *//' | tr -d '"' | tr -d "'" | cut -c1-120)
+    if [ -z "$desc" ]; then
+      desc="(nincs leírás)"
+    fi
 
-  echo "| \`$name\` | $desc |" >> "$OUTPUT"
-  SKILL_COUNT=$((SKILL_COUNT + 1))
-done
+    if [ "$MERGED" = "1" ]; then
+      echo "| \`$name\` | $desc | $scope |" >> "$OUTPUT"
+    else
+      echo "| \`$name\` | $desc |" >> "$OUTPUT"
+    fi
+    SKILL_COUNT=$((SKILL_COUNT + 1))
+  done
+}
+
+index_skills_dir "$GLOBAL_SKILLS_DIR" "global"
+
+if [ "$MERGED" = "1" ] && [ -d "$AGENT_SKILLS_DIR" ]; then
+  index_skills_dir "$AGENT_SKILLS_DIR" "agent"
+fi
 
 echo "" >> "$OUTPUT"
 echo "_${SKILL_COUNT} skill indexelve. Generálva: $(date '+%Y-%m-%d %H:%M')_" >> "$OUTPUT"

--- a/src/__tests__/skill-index.test.ts
+++ b/src/__tests__/skill-index.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const SCRIPT = join(REPO_ROOT, 'scripts', 'skill-index.sh')
+
+function makeSkillMd(name: string, description: string): string {
+  return `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`
+}
+
+function runScript(args: string[], env: Record<string, string>): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execSync(`bash "${SCRIPT}" ${args.map(a => `"${a}"`).join(' ')}`, {
+      encoding: 'utf-8',
+      env: { ...process.env, ...env },
+    })
+    return { stdout, exitCode: 0 }
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; status?: number }
+    return { stdout: e.stdout ?? '', exitCode: e.status ?? 1 }
+  }
+}
+
+describe('skill-index.sh -- no-arg mode (backward compat)', () => {
+  let tmpHome: string
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'skill-index-test-'))
+    mkdirSync(join(tmpHome, '.claude', 'skills', 'skill-alpha'), { recursive: true })
+    writeFileSync(
+      join(tmpHome, '.claude', 'skills', 'skill-alpha', 'SKILL.md'),
+      makeSkillMd('skill-alpha', 'Global skill alpha description'),
+    )
+  })
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('writes the index to ~/.claude/skills/.skill-index.md', () => {
+    runScript([], { HOME: tmpHome })
+    const indexPath = join(tmpHome, '.claude', 'skills', '.skill-index.md')
+    expect(existsSync(indexPath)).toBe(true)
+  })
+
+  it('includes global skill in the index', () => {
+    runScript([], { HOME: tmpHome })
+    const content = readFileSync(join(tmpHome, '.claude', 'skills', '.skill-index.md'), 'utf-8')
+    expect(content).toContain('skill-alpha')
+    expect(content).toContain('Global skill alpha description')
+  })
+
+  it('uses the two-column table format (no Scope column)', () => {
+    runScript([], { HOME: tmpHome })
+    const content = readFileSync(join(tmpHome, '.claude', 'skills', '.skill-index.md'), 'utf-8')
+    expect(content).toContain('| Skill | Leírás |')
+    expect(content).not.toContain('| Scope |')
+  })
+
+  it('does NOT create an index in any other directory', () => {
+    const agentDir = join(tmpHome, 'agents', 'agent-a')
+    mkdirSync(join(agentDir, '.claude', 'skills', 'skill-beta'), { recursive: true })
+    writeFileSync(
+      join(agentDir, '.claude', 'skills', 'skill-beta', 'SKILL.md'),
+      makeSkillMd('skill-beta', 'Agent-specific skill beta'),
+    )
+    runScript([], { HOME: tmpHome })
+    const agentIndex = join(agentDir, '.claude', 'skills', '.skill-index.md')
+    expect(existsSync(agentIndex)).toBe(false)
+  })
+})
+
+describe('skill-index.sh -- AGENT_DIR mode (merged index)', () => {
+  let tmpHome: string
+  let agentDir: string
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'skill-index-test-'))
+    // Global skill
+    mkdirSync(join(tmpHome, '.claude', 'skills', 'skill-global'), { recursive: true })
+    writeFileSync(
+      join(tmpHome, '.claude', 'skills', 'skill-global', 'SKILL.md'),
+      makeSkillMd('skill-global', 'A global skill visible to all agents'),
+    )
+    // Agent-specific skill
+    agentDir = join(tmpHome, 'agents', 'agent-a')
+    mkdirSync(join(agentDir, '.claude', 'skills', 'skill-local'), { recursive: true })
+    writeFileSync(
+      join(agentDir, '.claude', 'skills', 'skill-local', 'SKILL.md'),
+      makeSkillMd('skill-local', 'An agent-local skill for agent-a only'),
+    )
+  })
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('writes the merged index to <AGENT_DIR>/.claude/skills/.skill-index.md', () => {
+    runScript([agentDir], { HOME: tmpHome })
+    const indexPath = join(agentDir, '.claude', 'skills', '.skill-index.md')
+    expect(existsSync(indexPath)).toBe(true)
+  })
+
+  it('includes global skill in the merged index', () => {
+    runScript([agentDir], { HOME: tmpHome })
+    const content = readFileSync(join(agentDir, '.claude', 'skills', '.skill-index.md'), 'utf-8')
+    expect(content).toContain('skill-global')
+    expect(content).toContain('A global skill visible to all agents')
+  })
+
+  it('includes agent-specific skill in the merged index', () => {
+    // This is the core regression test: fails when AGENT_DIR handling is removed
+    runScript([agentDir], { HOME: tmpHome })
+    const content = readFileSync(join(agentDir, '.claude', 'skills', '.skill-index.md'), 'utf-8')
+    expect(content).toContain('skill-local')
+    expect(content).toContain('An agent-local skill for agent-a only')
+  })
+
+  it('labels global and agent-specific skills with scope', () => {
+    runScript([agentDir], { HOME: tmpHome })
+    const content = readFileSync(join(agentDir, '.claude', 'skills', '.skill-index.md'), 'utf-8')
+    expect(content).toContain('| global |')
+    expect(content).toContain('| agent |')
+  })
+
+  it('does NOT modify the global index when running in agent mode', () => {
+    const globalIndexPath = join(tmpHome, '.claude', 'skills', '.skill-index.md')
+    // Ensure there is no stale global index before the run
+    expect(existsSync(globalIndexPath)).toBe(false)
+    runScript([agentDir], { HOME: tmpHome })
+    expect(existsSync(globalIndexPath)).toBe(false)
+  })
+
+  it('creates agent .claude/skills/ directory if it does not exist yet', () => {
+    const freshAgentDir = join(tmpHome, 'agents', 'agent-b')
+    // Only the agent dir exists, no .claude/skills/ inside
+    mkdirSync(freshAgentDir, { recursive: true })
+    runScript([freshAgentDir], { HOME: tmpHome })
+    expect(existsSync(join(freshAgentDir, '.claude', 'skills', '.skill-index.md'))).toBe(true)
+  })
+
+  it('two different agents get independent indexes with their own agent-local skills', () => {
+    // agent-b has a different local skill
+    const agentBDir = join(tmpHome, 'agents', 'agent-b')
+    mkdirSync(join(agentBDir, '.claude', 'skills', 'skill-b-only'), { recursive: true })
+    writeFileSync(
+      join(agentBDir, '.claude', 'skills', 'skill-b-only', 'SKILL.md'),
+      makeSkillMd('skill-b-only', 'Only for agent-b'),
+    )
+
+    runScript([agentDir], { HOME: tmpHome })
+    runScript([agentBDir], { HOME: tmpHome })
+
+    const indexA = readFileSync(join(agentDir, '.claude', 'skills', '.skill-index.md'), 'utf-8')
+    const indexB = readFileSync(join(agentBDir, '.claude', 'skills', '.skill-index.md'), 'utf-8')
+
+    // agent-a sees skill-local but not skill-b-only
+    expect(indexA).toContain('skill-local')
+    expect(indexA).not.toContain('skill-b-only')
+
+    // agent-b sees skill-b-only but not skill-local
+    expect(indexB).toContain('skill-b-only')
+    expect(indexB).not.toContain('skill-local')
+
+    // both see the global skill
+    expect(indexA).toContain('skill-global')
+    expect(indexB).toContain('skill-global')
+  })
+})
+
+describe('skill-index.sh -- graceful handling of missing global dir', () => {
+  it('exits cleanly when ~/.claude/skills does not exist', () => {
+    const emptyHome = mkdtempSync(join(tmpdir(), 'skill-index-test-'))
+    try {
+      const { exitCode } = runScript([], { HOME: emptyHome })
+      expect(exitCode).toBe(0)
+    } finally {
+      rmSync(emptyHome, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A `scripts/skill-index.sh` csak a globális `~/.claude/skills/` könyvtárat indexelte, az ágensek saját `.claude/skills/` mappáját nem. Amint egy telepítésben a skillek egy része ágens-szintre kerül, a heartbeat-promptok — amelyek a `.skill-index.md`-ben keresik, hogy létezik-e már lefedő skill — arra a következtetésre jutnak, hogy nincs ilyen, és **duplikátumot generálnak**. A hiba néma: az index sikeresen legenerálódik, csak hiányos.

A javítás egy opcionális `AGENT_DIR` pozicionális argumentumot ad a scripthez:

- **argumentum nélkül** a viselkedés változatlan (visszafelé kompatibilis, a meglévő hívások nem törnek);
- **argumentummal** egy egyesített indexet ír az `<AGENT_DIR>/.claude/skills/.skill-index.md` fájlba, amely a globális és az ágens-specifikus skilleket egyaránt tartalmazza, `Scope` oszloppal (`global` / `agent`).

Minden ágens a saját munkakönyvtárából hívja (`skill-index.sh "$(pwd)"`), így automatikusan a hozzá tartozó indexet kapja. A `scheduled-tasks/memoria-heartbeat/SKILL.md` sablon is frissült: kereséskor mindkét indexet nézi, újraépítéskor mindkettőt regenerálja.

**EN:** `scripts/skill-index.sh` only indexed the global `~/.claude/skills/`; agent-level `.claude/skills/` directories were invisible to it. Once part of an installation's skills live at agent level, heartbeat prompts — which search `.skill-index.md` to decide whether a covering skill already exists — conclude that none does and generate duplicates. The failure is silent: the index builds fine, it is just incomplete.

The fix adds an optional `AGENT_DIR` positional argument: without it, behavior is unchanged (backward compatible); with it, the script writes a merged index (global + agent-specific, with a `Scope` column) to `<AGENT_DIR>/.claude/skills/.skill-index.md`. Each agent invokes it from its own working directory, so it gets its own index. The `scheduled-tasks/memoria-heartbeat/SKILL.md` template now checks both indexes on lookup and regenerates both on rebuild.

**Tervezési megjegyzés / Design note:** egyetlen közös, egyesített index nem működne, mert ágensenként eltér a látható skill-készlet (globális + saját). Ezért kapott a script per-ágens kimenetet a közös helyett. / A single shared merged index would not work, since the visible skill set differs per agent (global + own). Hence per-agent output rather than one shared file.

**Teszt / Tests:** 12 új eset (`src/__tests__/skill-index.test.ts`), izolált ideiglenes könyvtárakon. A fix visszavételével a 12-ből 7 piros — pontosan azok, amelyek az új viselkedést fedik —, míg az 5 visszafelé-kompatibilitási eset zöld marad, mert azok a változatlan működést mérik. Teljes suite: 165 tesztfájl, 2332 teszt, nulla regresszió.

## Kapcsolódó issue / Related issue

Nincs kapcsolódó nyitott issue: a hibát éles használat közben azonosítottuk, nem bejelentésből.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
  <br>→ Bash script: 12 automatizált teszttel igazolva izolált ideiglenes könyvtárakon, a hibát reverttel bizonyítva. Éles heartbeat-futásban még nem szerepelt. / Bash script: verified by 12 automated tests in isolated temp dirs, bug proven by revert. Not yet exercised in a live heartbeat run.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
  <br>→ Nem érinti a telepítést vagy az architektúrát; a változás a script usage-kommentjét és a heartbeat-sablont érinti. / No installation or architecture impact.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
