### PR TITLE
fix(scheduler): Hungarian accents in pending-retry Telegram alert text

### DIFF
--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -486,14 +486,14 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
     : null
   const text = (mcpMissing
     ? [
-        `[${BOT_NAME} scheduler] A(z) "${view.taskName}" (${view.agentName}) feladat NEM tud lefutni: a szukseges MCP szerver(ek) nem futnak a cel-sessionben: ${mcpMissing}.`,
-        `Elso probalkozas: ${firstAttempt} (${ageMinutes} perce).`,
-        'Amint az MCP szerver ujra el, a feladat magatol lefut; a dashboard /Utemezesek oldalan visszavonhato.',
+        `[${BOT_NAME} scheduler] A(z) "${view.taskName}" (${view.agentName}) feladat NEM tud lefutni: a szükséges MCP szerver(ek) nem futnak a cél-sessionben: ${mcpMissing}.`,
+        `Első próbálkozás: ${firstAttempt} (${ageMinutes} perce).`,
+        'Amint az MCP szerver újra elérhető, a feladat magától lefut; a dashboard /Ütemezések oldalán visszavonható.',
       ]
     : [
-        `[${BOT_NAME} scheduler] A(z) "${view.taskName}" (${view.agentName}) utemezett feladat ${ageMinutes} perce varakozik.`,
-        `Elso probalkozas: ${firstAttempt}.`,
-        'A rendszer tovabb probalkozik; a dashboard /Utemezesek oldalan visszavonhato.',
+        `[${BOT_NAME} scheduler] A(z) "${view.taskName}" (${view.agentName}) ütemezett feladat ${ageMinutes} perce várakozik.`,
+        `Első próbálkozás: ${firstAttempt}.`,
+        'A rendszer tovább próbálkozik; a dashboard /Ütemezések oldalán visszavonható.',
       ]).join('\n')
   ;(async () => {
     try {


### PR DESCRIPTION
## Mit
A `[Marveen scheduler] ... perce varakozik` pending-retry Telegram-riasztasok (es az mcp-missing valtozat) ekezet nelkul mentek. Ricsi screenshotot kuldott a garbolt szovegrol.

## Javitas
`src/web/schedule-runner.ts` alert-builder szovege helyes magyar ekezettel (varakozik/utemezett/Elso probalkozas/Utemezesek/szukseges/cel-session/ujra elerheto/magatol/visszavonhato). Text-only, nincs logikai valtozas.

## Kontextus
A riasztasok azert jottek, mert 7 napi task pending-be ragadt (a channels session orak ota busy volt egy hosszu beszelgetestol); a beragadt backlogot kulon kitakaritottam (runtime, nem kod). Ez a PR csak a szoveg-hibat rogziti a source-ba, hogy a szerdai auto-update rebuild ne vigye vissza.

Generated with Claude Code