### PR TITLE
fix(ui): remove duplicate autonomy entry point -- keep the Settings tab

### DIFF
--- a/src/__tests__/autonomy-standalone-removal.test.ts
+++ b/src/__tests__/autonomy-standalone-removal.test.ts
@@ -1,0 +1,71 @@
+// String-contract guard for the standalone autonomy page removal (house idiom:
+// reads frontend files as strings and asserts short, formatting-proof fragments).
+// Guards that: (a) the sidebar no longer contains data-page="autonomy",
+// (b) the settings-tab autonomy panel is intact (settingsAutonomyGrid present,
+//     renderAutonomyContent wired, refresh button added), and
+// (c) the removed i18n keys are gone while the rest of autonomy.* stays.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const APP  = readFileSync(join(__dirname, '../../web/app.js'),      'utf-8')
+const HTML = readFileSync(join(__dirname, '../../web/index.html'),  'utf-8')
+const HU   = readFileSync(join(__dirname, '../../web/lang/hu.js'),  'utf-8')
+const EN   = readFileSync(join(__dirname, '../../web/lang/en.js'),  'utf-8')
+
+describe('standalone autonomy page removal', () => {
+  it('sidebar has NO data-page="autonomy" nav item', () => {
+    expect(HTML).not.toContain('data-page="autonomy"')
+  })
+
+  it('standalone autonomy page div is removed from HTML', () => {
+    expect(HTML).not.toContain('id="autonomyPage"')
+    expect(HTML).not.toContain('id="autonomyGrid"')
+    expect(HTML).not.toContain('id="autonomyUpdatedAt"')
+  })
+
+  it('standalone page router entry and loader are removed from app.js', () => {
+    expect(APP).not.toMatch(/pageId === 'autonomy'/)
+    expect(APP).not.toMatch(/function loadAutonomy\(/)
+    expect(APP).not.toContain("'autonomy: 'nav.autonomy'")
+    expect(APP).not.toContain("autonomy: 'nav.autonomy'")
+    expect(APP).not.toContain("autonomyPage: {")
+    expect(APP).not.toContain("id='refreshAutonomyBtn'")
+    expect(APP).not.toContain('id="refreshAutonomyBtn"')
+  })
+
+  it('renderAutonomyContent function is preserved in app.js', () => {
+    expect(APP).toMatch(/async function renderAutonomyContent\(/)
+    expect(APP).toContain('/api/autonomy')
+  })
+
+  it('settings tab autonomy panel has settingsAutonomyGrid and settingsAutonomyUpdatedAt', () => {
+    expect(APP).toContain("grid.id = 'settingsAutonomyGrid'")
+    expect(APP).toContain("footer.id = 'settingsAutonomyUpdatedAt'")
+    expect(APP).toMatch(/renderAutonomyContent\(grid,\s*footer\)/)
+  })
+
+  it('settings tab autonomy panel has a refresh button wired to renderAutonomyContent', () => {
+    expect(APP).toContain("refreshBtn.className = 'btn-secondary btn-compact'")
+    expect(APP).toContain("t('common.btn.refresh')")
+    expect(APP).toContain("refreshBtn.addEventListener('click', () => renderAutonomyContent(grid, footer))")
+  })
+
+  it('removed i18n keys are gone from both language files', () => {
+    for (const src of [HU, EN]) {
+      expect(src).not.toContain("'nav.autonomy'")
+      expect(src).not.toContain("'autonomy.page_title'")
+      expect(src).not.toContain("'autonomy.page_subtitle'")
+    }
+  })
+
+  it('remaining autonomy.* i18n keys are intact in both language files', () => {
+    for (const src of [HU, EN]) {
+      expect(src).toContain("'autonomy.loading'")
+      expect(src).toContain("'autonomy.level.2'")
+      expect(src).toContain("'autonomy.level.3'")
+    }
+  })
+})

--- a/web/app.js
+++ b/web/app.js
@@ -296,7 +296,6 @@ function switchPage(pageId) {
   if (pageId === 'recall') loadRecallPage()
   if (pageId === 'bgTasks') loadBgTasksPage()
   if (pageId === 'vault') loadVaultPage()
-  if (pageId === 'autonomy') loadAutonomy()
   if (pageId === 'settings') loadSettings()
   if (pageId === 'updates') loadUpdates()
   if (pageId === 'team') { loadTeamGraph() }
@@ -347,7 +346,7 @@ const NAV_I18N = {
   messages: 'nav.messages', tasks: 'nav.tasks', memories: 'nav.memories',
   recall: 'nav.recall', naplo: 'nav.recall', bgTasks: 'nav.bgTasks',
   skills: 'nav.skills', connectors: 'nav.connectors', migrate: 'nav.migrate',
-  docs: 'nav.docs', status: 'nav.status', autonomy: 'nav.autonomy',
+  docs: 'nav.docs', status: 'nav.status',
   settings: 'nav.settings', vault: 'nav.vault', tokenUsage: 'nav.tokenUsage',
   ideas: 'nav.ideas', federation: 'nav.federation', updates: 'nav.updates', costs: 'nav.costs',
 }
@@ -385,7 +384,6 @@ const PAGE_HEADER_I18N = {
   statusPage:     { title: 'status.page_title',      sub: 'status.page_subtitle' },
   teamPage:       { title: 'team.page_title',        sub: 'team.page_subtitle' },
   messagesPage:   { title: 'messages.page_title',    sub: 'messages.page_subtitle' },
-  autonomyPage:   { title: 'autonomy.page_title',    sub: 'autonomy.page_subtitle' },
   settingsPage:   { title: 'settings.page_title',    sub: 'settings.page_subtitle' },
   ideasPage:      { title: 'ideas.page_title',       sub: 'ideas.page_subtitle' },
   vaultPage:      { title: 'vault.page_title',       sub: 'vault.page_subtitle' },
@@ -11302,8 +11300,6 @@ async function cancelBgTask(id) {
 // === Autonomy ===
 // ============================================================
 
-document.getElementById('refreshAutonomyBtn').addEventListener('click', loadAutonomy)
-
 async function renderAutonomyContent(gridEl, footerEl) {
   gridEl.innerHTML = `<p style="color:var(--text-muted);font-size:13px">${t('autonomy.loading')}</p>`
 
@@ -11368,13 +11364,6 @@ async function renderAutonomyContent(gridEl, footerEl) {
   }
 }
 
-async function loadAutonomy() {
-  await renderAutonomyContent(
-    document.getElementById('autonomyGrid'),
-    document.getElementById('autonomyUpdatedAt')
-  )
-}
-
 async function setAutonomyLevel(key, level) {
   try {
     const res = await fetch('/api/autonomy', {
@@ -11387,10 +11376,7 @@ async function setAutonomyLevel(key, level) {
       showToast(data.error || 'Hiba')
       return
     }
-    // Refresh all visible autonomy grids
-    const pageGrid = document.getElementById('autonomyGrid')
-    const pageFooter = document.getElementById('autonomyUpdatedAt')
-    if (pageGrid) renderAutonomyContent(pageGrid, pageFooter)
+    // Refresh the settings tab autonomy grid if it is visible
     const tabGrid = document.getElementById('settingsAutonomyGrid')
     const tabFooter = document.getElementById('settingsAutonomyUpdatedAt')
     if (tabGrid) renderAutonomyContent(tabGrid, tabFooter)
@@ -11413,7 +11399,7 @@ window.addEventListener('beforeunload', (e) => {
 // entry never requires a frontend change just to render a sane heading.
 function settingsModuleLabel(mod) {
   const key = `settings.module.${mod}`
-  const known = { kanban: true, system: true, heartbeat: true, audit: true, ideabox: true, channels: true, autonomy: true }
+  const known = { kanban: true, system: true, heartbeat: true, audit: true, ideabox: true, channels: true }
   return known[mod] ? t(key) : (mod.charAt(0).toUpperCase() + mod.slice(1))
 }
 
@@ -11538,6 +11524,12 @@ async function loadSettings() {
       footer.className = 'autonomy-footer'
       footer.id = 'settingsAutonomyUpdatedAt'
       panel.appendChild(footer)
+
+      const refreshBtn = document.createElement('button')
+      refreshBtn.className = 'btn-secondary btn-compact'
+      refreshBtn.textContent = t('common.btn.refresh')
+      refreshBtn.addEventListener('click', () => renderAutonomyContent(grid, footer))
+      panel.appendChild(refreshBtn)
 
       tabPanels.appendChild(panel)
 

--- a/web/index.html
+++ b/web/index.html
@@ -131,10 +131,6 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
         <span class="sb-label">Státusz</span>
       </a>
-      <a href="#" class="sb-link" data-page="autonomy">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-        <span class="sb-label">Autonómia</span>
-      </a>
       <a href="#" class="sb-link" data-page="settings">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
         <span class="sb-label">Beállítások</span>
@@ -996,41 +992,6 @@
     </div>
 
     <!-- === Autonomy Page === -->
-    <div class="page" id="autonomyPage" hidden>
-      <div class="page-header">
-        <div class="page-header-row">
-          <div>
-            <h1 data-i18n="autonomy.page_title">Autonómia</h1>
-            <p class="subtitle" data-i18n="autonomy.page_subtitle">Heartbeat fokozatos autonómia szintek</p>
-          </div>
-          <button class="btn-secondary btn-compact" id="refreshAutonomyBtn" data-i18n="common.btn.refresh">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
-            </svg>
-            Frissítés
-          </button>
-        </div>
-      </div>
-
-      <div class="autonomy-legend">
-        <div class="autonomy-legend-item">
-          <span class="autonomy-level-dot" style="background:var(--text-muted)"></span>
-          <span><strong>1</strong> Csak jelez</span>
-        </div>
-        <div class="autonomy-legend-item">
-          <span class="autonomy-level-dot" style="background:var(--accent)"></span>
-          <span><strong>2</strong> <span data-i18n="autonomy.level.2">Javasol, jóváhagyásra vár</span></span>
-        </div>
-        <div class="autonomy-legend-item">
-          <span class="autonomy-level-dot" style="background:var(--success)"></span>
-          <span><strong>3</strong> <span data-i18n="autonomy.level.3">Autonóm, utólag jelent</span></span>
-        </div>
-      </div>
-
-      <div class="autonomy-grid" id="autonomyGrid"></div>
-      <p class="autonomy-footer" id="autonomyUpdatedAt"></p>
-    </div>
-
     <!-- === Settings Page === -->
     <div class="page" id="settingsPage" hidden>
       <div class="page-header">

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -82,7 +82,6 @@ window._i18n.en = {
   'nav.migrate':      'Migrate',
   'nav.docs':         'Documentation',
   'nav.status':       'Status',
-  'nav.autonomy':     'Autonomy',
   'nav.settings':     'Settings',
   'nav.vault':        'Vault',
   'nav.tokenUsage':   'Token Monitor',
@@ -628,8 +627,6 @@ window._i18n.en = {
   'messages.select_agent':       'Select an agent',
 
   // --- Autonomy ---
-  'autonomy.page_title':         'Autonomy',
-  'autonomy.page_subtitle':      'Heartbeat graduated autonomy levels',
   'autonomy.level.2':            '2 Propose, awaits approval',
   'autonomy.level.3':            '3 Autonomous, reports after',
 

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -82,7 +82,6 @@ window._i18n.hu = {
   'nav.migrate':      'Költöztetés',
   'nav.docs':         'Dokumentáció',
   'nav.status':       'Státusz',
-  'nav.autonomy':     'Autonómia',
   'nav.settings':     'Beállítások',
   'nav.vault':        'Vault',
   'nav.tokenUsage':   'Token Monitor',
@@ -910,8 +909,6 @@ window._i18n.hu = {
 
 
   // --- Autonomy ---
-  'autonomy.page_title':         'Autonómia',
-  'autonomy.page_subtitle':      'Heartbeat fokozatos autonómia szintek',
   'autonomy.loading':            'Betöltés...',
   'autonomy.lock_label':         'Biztonsági zár',
   'autonomy.cap_label':          'Max {n}. szint',


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A dashboardon **két belépési pont** vezetett ugyanahhoz az autonómia-felülethez: egy önálló *Autonómia* menüpont az oldalsávban, és egy *Autonómia* fül a Beállítások alatt. Nem két különböző nézet volt — mindkettő ugyanazt a `renderAutonomyContent()` függvényt hívta, tehát a felhasználó ugyanazt látta kétszer, két helyről.

Az önálló oldal a granuláris autonómia-vezérlés bevezetésekor készült; a Beállítások fül-navigációja később érkezett, és hozott egy saját autonómia fület, de a régi menüpontot nem vette ki. A duplikáció azóta él.

Ez a PR az **önálló oldalt** távolítja el, és a **Beállítások fület** tartja meg. Az érintett telepítés tulajdonosának döntése: az autonómia-szintek a többi konfigurációs felület mellett a helyükön vannak, és eggyel kevesebb oldalsáv-elem tisztább navigációt ad.

**Funkcióvesztés nincs.** Az önálló oldal egyetlen dolgot tudott, amit a fül nem: volt rajta egy frissítés gomb. Ez átkerült a fülre, ugyanazt a renderelőt hívja.

Eltávolítva: az oldalsáv nav-elem, az `#autonomyPage` blokk, a `loadAutonomy()` és a hozzá tartozó router-ág, valamint három árvává vált i18n kulcs (`nav.autonomy`, `autonomy.page_title`, `autonomy.page_subtitle` — mindkét nyelvből). Megmaradt minden, amit a fül használ, beleértve a `renderAutonomyContent()`-et és a `settings.module.autonomy` címkét.

Mellékesen megszűnt egy fölösleges csatolás is: a `setAutonomyLevel()` eddig szintváltáskor **mindkét** rácsot frissítette, hogy a két nézet szinkronban maradjon. Egy nézettel ez a kód is elhagyható.

**EN:** The dashboard had **two entry points** to the same autonomy UI: a standalone *Autonomy* sidebar page and an *Autonomy* tab under Settings. They were not two views — both called the same `renderAutonomyContent()`, so users saw the same thing twice, from two places.

The standalone page came with granular autonomy control; the Settings tab navigation arrived later and added its own autonomy tab without removing the original nav item. The duplication has been shipping since.

This PR removes the **standalone page** and keeps the **Settings tab** (the deciding install's preference: autonomy levels sit naturally with the other configuration surfaces, and one fewer sidebar item keeps navigation clean).

**No functionality is lost.** The standalone page had exactly one thing the tab lacked — a refresh button — and it moved to the tab, calling the same renderer.

Removed: the sidebar nav item, the `#autonomyPage` block, `loadAutonomy()` and its router branch, and three now-orphaned i18n keys (from both languages). Everything the tab uses is untouched, including `renderAutonomyContent()` and the `settings.module.autonomy` label. A redundant coupling also goes away: `setAutonomyLevel()` used to refresh **both** grids to keep the two views in sync — with one view, that is no longer needed.

## Kapcsolódó issue / Related issue

Nincs kapcsolódó nyitott issue: a duplikációt éles használat során vettük észre.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
  <br>→ 8 automatizált teszt fedi (`autonomy-standalone-removal.test.ts`), a repó bevett UI-kontraktus mintája szerint: az oldalsávban már nincs autonómia nav-elem, a Beállítások fül továbbra is létezik és rendereli a tartalmat, a frissítés gomb a fülön van. Az őrt reverttel ellenőriztük: a nav-elem visszatételére a teszt pirosra vált. Teljes suite: 165 fájl, 2328 teszt, nulla regresszió. A **vizuális** átnézés (a fül helyesen jelenik meg, a frissítés gomb működik) a tulajdonos kézi tesztjén múlik. / Covered by 8 automated tests following the repo's UI-contract idiom; the guard was verified by reverting it. Full suite green, no regression. **Visual** review is left to the owner's manual test.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
  <br>→ Nem érinti a telepítést vagy az architektúrát; kizárólag dashboard-felület. / No installation or architecture impact; dashboard UI only.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
