### PR TITLE
fix(web): unify MD rendering -- single renderMarkdown, language class…

### DIFF
--- a/src/__tests__/md-rendering-unify.test.ts
+++ b/src/__tests__/md-rendering-unify.test.ts
@@ -1,0 +1,41 @@
+// String-contract guard for MD rendering unification (house idiom: reads
+// frontend files as strings and asserts short, formatting-proof fragments).
+// Guards: (a) single renderMarkdown definition, (b) language class on fenced
+// code blocks, (c) unified md-rendered class on both skill modal and docs page.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const APP  = readFileSync(join(__dirname, '../../web/app.js'),     'utf-8')
+const HTML = readFileSync(join(__dirname, '../../web/index.html'), 'utf-8')
+const CSS  = readFileSync(join(__dirname, '../../web/style.css'),  'utf-8')
+
+describe('md rendering unification', () => {
+  it('app.js has exactly one renderMarkdown function definition', () => {
+    const matches = APP.match(/^function renderMarkdown\b/gm)
+    expect(matches).not.toBeNull()
+    expect(matches!.length).toBe(1)
+  })
+
+  it('renderMarkdown emits language class on fenced code blocks', () => {
+    // The fence branch must include class="language-... in its output push
+    expect(APP).toContain('class="language-')
+    expect(APP).toMatch(/class="language-' \+ escapeHtml\(fence\[1\]\)/)
+  })
+
+  it('skill detail container has md-rendered class', () => {
+    expect(HTML).toContain('id="skillDetailContent"')
+    expect(HTML).toMatch(/class="[^"]*md-rendered[^"]*"\s+id="skillDetailContent"/)
+  })
+
+  it('docs page container gets md-rendered class', () => {
+    expect(APP).toContain('"docs-rendered markdown-body md-rendered"')
+  })
+
+  it('style.css defines .md-rendered with code/pre rules', () => {
+    expect(CSS).toContain('.md-rendered code')
+    expect(CSS).toContain('.md-rendered pre code')
+  })
+})

--- a/web/app.js
+++ b/web/app.js
@@ -9550,94 +9550,6 @@ function deriveSkillCategory(name) {
   return seg.split('-')[0] || seg
 }
 
-// Simple inline markdown renderer -- no external dependencies.
-// Handles: headings, bold, italic, code blocks, inline code, lists, hr, links.
-function renderMarkdown(text) {
-  if (!text) return ''
-  const escHtml = s => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  const lines = text.split('\n')
-  let html = ''
-  let inCodeBlock = false
-  let codeAccum = ''
-  let codeLang = ''
-  let inList = false
-
-  const flushList = () => {
-    if (inList) { html += '</ul>'; inList = false }
-  }
-
-  const inlineRender = (raw) => {
-    let s = escHtml(raw)
-    // inline code
-    s = s.replace(/`([^`]+)`/g, '<code>$1</code>')
-    // bold
-    s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-    // italic (single *)
-    s = s.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<em>$1</em>')
-    // links
-    s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
-    return s
-  }
-
-  for (const line of lines) {
-    if (line.trim().startsWith('```')) {
-      if (inCodeBlock) {
-        html += `<pre><code class="language-${escHtml(codeLang)}">${escHtml(codeAccum.replace(/\n$/, ''))}</code></pre>`
-        codeAccum = ''
-        codeLang = ''
-        inCodeBlock = false
-      } else {
-        flushList()
-        codeLang = line.trim().slice(3).trim()
-        inCodeBlock = true
-      }
-      continue
-    }
-    if (inCodeBlock) { codeAccum += line + '\n'; continue }
-
-    const trimmed = line.trim()
-
-    if (/^---+$/.test(trimmed)) { flushList(); html += '<hr>'; continue }
-
-    const headingMatch = trimmed.match(/^(#{1,4})\s+(.+)/)
-    if (headingMatch) {
-      flushList()
-      const level = headingMatch[1].length
-      html += `<h${level}>${inlineRender(headingMatch[2])}</h${level}>`
-      continue
-    }
-
-    const listMatch = trimmed.match(/^[-*]\s+(.+)/)
-    if (listMatch) {
-      if (!inList) { html += '<ul>'; inList = true }
-      html += `<li>${inlineRender(listMatch[1])}</li>`
-      continue
-    }
-
-    const olMatch = trimmed.match(/^\d+\.\s+(.+)/)
-    if (olMatch) {
-      if (inList) { html += '</ul>'; inList = false }
-      html += `<li>${inlineRender(olMatch[1])}</li>`
-      continue
-    }
-
-    if (trimmed === '') {
-      flushList()
-      html += '<br>'
-      continue
-    }
-
-    flushList()
-    html += `<p>${inlineRender(trimmed)}</p>`
-  }
-
-  if (inCodeBlock) {
-    html += `<pre><code>${escHtml(codeAccum)}</code></pre>`
-  }
-  flushList()
-  return html
-}
-
 function formatMtime(ms) {
   if (!ms) return ''
   const d = new Date(ms)
@@ -14099,7 +14011,7 @@ function renderMarkdown(md) {
       i++
       while (i < lines.length && !/^```\s*$/.test(lines[i])) { code.push(lines[i]); i++ }
       i++
-      out.push('<pre><code>' + escapeHtml(code.join('\n')) + '</code></pre>')
+      out.push('<pre><code' + (fence[1] ? ' class="language-' + escapeHtml(fence[1]) + '"' : '') + '>' + escapeHtml(code.join('\n')) + '</code></pre>')
       continue
     }
     const h = line.match(/^(#{1,6})\s+(.*)$/)
@@ -14195,7 +14107,7 @@ async function openDoc(name) {
       '<div class="docs-content-toolbar">' +
         '<button class="btn-secondary btn-compact" id="docsDownloadBtn">' + t('docs.download_btn') + '</button>' +
       '</div>' +
-      '<div class="docs-rendered markdown-body">' + renderMarkdown(content) + '</div>'
+      '<div class="docs-rendered markdown-body md-rendered">' + renderMarkdown(content) + '</div>'
     const dl = document.getElementById('docsDownloadBtn')
     if (dl) dl.addEventListener('click', () => downloadMarkdown(name, content))
   } catch (e) {

--- a/web/index.html
+++ b/web/index.html
@@ -2945,7 +2945,7 @@
             <label class="form-label-sm" style="margin:0">SKILL.md tartalom</label>
             <span class="skill-detail-health" id="skillDetailHealth"></span>
           </div>
-          <div class="skill-detail-content skill-detail-rendered" id="skillDetailContent"></div>
+          <div class="skill-detail-content skill-detail-rendered md-rendered" id="skillDetailContent"></div>
           <textarea class="skill-detail-editor" id="skillDetailEditor" hidden rows="20" spellcheck="false"></textarea>
           <div class="skill-detail-edit-actions" id="skillDetailEditActions" hidden>
             <button class="btn-primary btn-compact" id="skillDetailSaveBtn" data-i18n="skills.btn.save">Mentés</button>

--- a/web/style.css
+++ b/web/style.css
@@ -5422,6 +5422,12 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
 .skill-detail-rendered strong { font-weight: 700; }
 .skill-detail-rendered em { font-style: italic; }
 
+/* Shared marker class for all renderMarkdown() output containers.
+   Context-specific sizing lives in .skill-detail-rendered / .markdown-body. */
+.md-rendered code { font-family: 'SF Mono','Fira Code',ui-monospace,Menlo,monospace; }
+.md-rendered pre code { background: none; padding: 0; }
+.md-rendered :not(pre) > code { border-radius: 3px; padding: 1px 5px; }
+
 .skills-stats {
   display: flex;
   gap: 12px;


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A dashboard `web/app.js`-e **két** `renderMarkdown()` függvényt definiált. Mivel JavaScriptben a később deklarált függvény felülírja a korábbit, az első definíció (~90 sor) **halott kód** volt: minden hívó — a skill-modál és a dokumentáció-oldal egyaránt — a másodikat kapta. A duplikáció önmagában nem okozott hibás megjelenítést, de garantálta, hogy előbb-utóbb okozzon: aki az első definíciót javította volna, semmit nem ér el vele.

Ez a PR:

- **Törli a halott első definíciót** (−90 sor). A megmaradó renderelő a bővebb: táblázatot, idézetblokkot és kerítéses kódblokkot is kezel.
- **Nyelv-osztályt tesz a kerítéses kódblokkokra** (`language-…`), így a kiemelés a nyelvet is ismeri, nem csak azt, hogy „ez kód”.
- **Bevezet egy közös `.md-rendered` marker osztályt** minden konténerre, ami `renderMarkdown()` kimenetét jeleníti meg (jelenleg: skill-modál, docs-oldal). A kód-tipográfia így egy helyen dől el; a kontextusfüggő méretezés marad a `.skill-detail-rendered` / `.markdown-body` osztályokon.

**Hatókör — amit ez a PR NEM csinál:** csak a **renderelt** markdown-nézeteket egységesíti. A dashboard nyers `<textarea>` szerkesztői (MCP-konfig, ágens-CLAUDE.md, SOUL.md) érintetlenek: ott nincs és ezután sincs szintaxis-kiemelés, mert az szerkesztő-komponenst igényelne, nem renderelőt. Ez tudatos hatókör-korlát, nem kihagyás.

**EN:** `web/app.js` defined `renderMarkdown()` **twice**. Since a later function declaration shadows the earlier one, the first (~90 lines) was **dead code**: every caller — the skill modal and the docs page alike — got the second one. The duplication caused no visible bug, but guaranteed a future one: anyone fixing the first definition would have changed nothing.

This PR removes the dead definition (−90 lines; the surviving renderer is the richer one, handling tables, blockquotes and fenced code), adds `language-…` classes to fenced code blocks so highlighting knows the language, and introduces a shared `.md-rendered` marker class on every container that displays `renderMarkdown()` output, so code typography is defined in one place while context-specific sizing stays on `.skill-detail-rendered` / `.markdown-body`.

**Scope — what this PR does not do:** it unifies **rendered** markdown views only. The dashboard's raw `<textarea>` editors (MCP config, agent CLAUDE.md, SOUL.md) are untouched: they have no syntax highlighting and still won't, since that needs an editor component rather than a renderer. A deliberate scope boundary, not an omission.

## Kapcsolódó issue / Related issue

Nincs kapcsolódó nyitott issue: a különbséget éles használat során vettük észre.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
  <br>→ 5 automatizált teszt fedi (`md-rendering-unify.test.ts`) a repó UI-kontraktus mintája szerint: pontosan egy `renderMarkdown` definíció létezik, a kerítéses kódblokk nyelv-osztályt kap, a marker osztály ott van a konténereken. Az őrt reverttel ellenőriztük: egy második definíció visszatételére a teszt pirosra vált. Teljes suite: 168 fájl, 2348 teszt, nulla regresszió. A **vizuális** átnézés (a skill-modál és a docs-oldal ugyanúgy néz ki, mint eddig) a tulajdonos kézi tesztjén múlik. / Covered by 5 automated tests following the repo's UI-contract idiom; the guard was verified by reverting it. Full suite green. **Visual** review left to the owner's manual test.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
  <br>→ Nem érinti a telepítést vagy az architektúrát; kizárólag dashboard-felület. / No installation or architecture impact; dashboard UI only.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
