### PR TITLE
fix(onboarding): provider-aware status check + closeable wizard

### DIFF
--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -2,11 +2,11 @@ import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir, userInfo } from 'node:os'
 import { execFileSync } from 'node:child_process'
-import { PROJECT_ROOT, STORE_DIR } from '../../config.js'
+import { PROJECT_ROOT, STORE_DIR, CHANNEL_PROVIDER } from '../../config.js'
 import { logger } from '../../logger.js'
 import { resolveFromPath } from '../../platform.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
-import { channelStateDir } from '../../channel-provider.js'
+import { channelStateDir, readChannelToken } from '../../channel-provider.js'
 import { sessionExistsOnHost } from '../agent-process.js'
 import { MAIN_CHANNELS_SESSION } from '../main-agent.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
@@ -72,15 +72,17 @@ function claudeAuthPresent(): boolean {
   return keychainHasClaudeCredentials()
 }
 
-function telegramConfigured(): boolean {
-  try {
-    return /^TELEGRAM_BOT_TOKEN=\S/m.test(readFileSync(join(channelStateDir('telegram'), '.env'), 'utf-8'))
-  } catch { return false }
+// Active-channel checks, provider-aware (NOT hardcoded to Telegram). A
+// Discord-switched (or Slack/etc.) install has no telegram/ state dir, so a
+// telegram-only probe would report "not configured" forever and pop the wizard
+// over a working dashboard. readChannelToken knows each provider's env key.
+function channelConfigured(): boolean {
+  return readChannelToken(CHANNEL_PROVIDER, join(channelStateDir(CHANNEL_PROVIDER), '.env')) != null
 }
 
 function paired(): boolean {
   try {
-    const a = JSON.parse(readFileSync(join(channelStateDir('telegram'), 'access.json'), 'utf-8')) as {
+    const a = JSON.parse(readFileSync(join(channelStateDir(CHANNEL_PROVIDER), 'access.json'), 'utf-8')) as {
       allowFrom?: unknown[]; groups?: Record<string, unknown>
     }
     const allow = Array.isArray(a.allowFrom) ? a.allowFrom.length : 0
@@ -126,7 +128,7 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
   if (path === '/api/onboarding/status' && method === 'GET') {
     const claude = claudeAuthPresent()
     const running = agentsRunning()
-    const tg = telegramConfigured()
+    const ch = channelConfigured()
     const pr = paired()
     json(res, {
       identityConfirmed: identityConfirmed(),
@@ -134,11 +136,11 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
       currentOwnerName: readEnvValue('OWNER_NAME') || '',
       claudeAuthPresent: claude,
       agentsRunning: running,
-      telegramConfigured: tg,
+      channelConfigured: ch,
       paired: pr,
       // The identity step never re-opens the wizard on an already-configured
       // install: it only participates while first-run setup is incomplete.
-      needsOnboarding: !claude || !running || !tg || !pr,
+      needsOnboarding: !claude || !running || !ch || !pr,
     })
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -11177,11 +11177,25 @@ async function fetchOnboardingStatus() {
 function onboardingCurrentStep(s) {
   if (!s.identityConfirmed) return 1
   if (!s.claudeAuthPresent || !s.agentsRunning) return 2
-  if (!s.telegramConfigured) return 3
+  if (!s.channelConfigured) return 3
   if (!s.paired) return 4
   return 0
 }
+// Operator can dismiss the wizard (skip/close). A false positive must never
+// lock the dashboard, so the choice persists across reloads; normal UI still
+// covers any real setup that remains.
+const ONBOARDING_DISMISS_KEY = 'mvOnboardingDismissed'
+function onboardingDismissed() {
+  try { return localStorage.getItem(ONBOARDING_DISMISS_KEY) === '1' } catch { return false }
+}
+function dismissOnboarding() {
+  try { localStorage.setItem(ONBOARDING_DISMISS_KEY, '1') } catch { /* private mode */ }
+  const overlay = document.getElementById('onboardingOverlay')
+  if (overlay) { overlay.classList.remove('active'); overlay.hidden = true }
+  document.body.style.overflow = ''
+}
 async function initOnboarding() {
+  if (onboardingDismissed()) return
   const s = await fetchOnboardingStatus()
   if (!s || !s.needsOnboarding) return
   renderOnboarding(s)
@@ -11191,6 +11205,7 @@ async function refreshOnboarding() {
   if (s) renderOnboarding(s)
 }
 function renderOnboarding(s) {
+  if (onboardingDismissed()) return
   const overlay = document.getElementById('onboardingOverlay')
   if (!overlay) return
   const step = onboardingCurrentStep(s)
@@ -11349,6 +11364,10 @@ populateAvatarGrid()
 loadMemAgents()
 loadOverview()
 loadAvailableModels()
+{
+  const onbClose = document.getElementById('onboardingClose')
+  if (onbClose) onbClose.addEventListener('click', dismissOnboarding)
+}
 initOnboarding()
 
 // "DeepSeek API kulcs hozzáadása" link az agent edit panel-en --

--- a/web/index.html
+++ b/web/index.html
@@ -39,6 +39,7 @@
   <!-- First-run onboarding wizard (shown by app.js when /api/onboarding/status needs setup) -->
   <div class="modal-overlay onboarding-overlay" id="onboardingOverlay" hidden>
     <div class="modal onboarding-modal">
+      <button class="modal-close" id="onboardingClose" title="Bezárás" aria-label="Bezárás">&times;</button>
       <h2 data-i18n="onboarding.title">Marveen beállítása</h2>
       <p class="onb-sub" data-i18n="onboarding.subtitle">Fejezd be a beállítást innen, a dashboardból -- SSH nélkül.</p>
       <div class="onboarding-steps" id="onboardingSteps">

--- a/web/style.css
+++ b/web/style.css
@@ -6966,7 +6966,8 @@ body {
 .updates-version-details .updates-commit-list { padding: 10px 0 2px; }
 /* First-run onboarding wizard */
 .onboarding-overlay { z-index: 10000; }
-.onboarding-modal { max-width: 540px; width: 92%; }
+.onboarding-modal { max-width: 540px; width: 92%; position: relative; }
+.onboarding-modal .modal-close { position: absolute; top: 12px; right: 12px; }
 .onboarding-modal h2 { margin: 0 0 4px; }
 .onb-sub { color: var(--text-muted); font-size: 13px; margin: 0 0 16px; }
 .onboarding-steps { display: flex; gap: 8px; margin-bottom: 18px; }


### PR DESCRIPTION
## Probléma

A first-run onboarding varázsló a channel-configured és paired ellenőrzésnél hardcode-olta a Telegramot. Discordra váltott (vagy bármely nem-Telegram) installon nincs `telegram/` state dir, így a `/api/onboarding/status` örökre `telegramConfigured=false` / `paired=false`-t adott, és a varázsló egy teljesen működő dashboard fölé ugrott.

Élőben megerősítve a futó Discord-installon:
```
{"claudeAuthPresent":true,"agentsRunning":true,"telegramConfigured":false,"paired":false,"needsOnboarding":true}
```
Az auth és az agentek rendben, csak a Telegram-only ellenőrzések buknak.

## Megoldás

**1) Provider-aware status check.** `channelConfigured()` a `CHANNEL_PROVIDER`-t nézi és a provider saját env-kulcsát olvassa (`readChannelToken`), `paired()` a provider `access.json`-ját. A válasz mező `telegramConfigured` -> `channelConfigured` (az egyetlen frontend fogyasztó frissítve). A Discord `access.json` ugyanolyan szerkezetű (`allowFrom`/`groups`), így a pairing helyesen igaznak jön.

**2) Becsukható overlay.** Close (x) gomb a modal sarkában (a meglévő `.modal-close` mintát követi). A dismiss `localStorage`-ba perzisztál, így egy téves pozitív SEM zárhatja be a dashboardot; a valós beállítást a normál UI így is lefedi.

## Teszt

- Mind az 1681 teszt zöld (473 suite, 0 bukás)
- `tsc --noEmit` tiszta, `node --check web/app.js` tiszta

🤖 Generated with [Claude Code](https://claude.com/claude-code)