### PR TITLE
fix(memory): stamp accessed_at on agent-memory recall (staleness detection was broken)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1019,6 +1019,19 @@ export function touchMemory(id: number): void {
   ).run(now, id)
 }
 
+// Mark a batch of memories as just-recalled (bumps accessed_at only). Used by
+// the agent-memory read endpoint so that accessed_at reflects real usage --
+// without this, agent memories keep accessed_at == created_at forever and any
+// "not accessed in N days" staleness check (e.g. the Dream Engine hygiene pass)
+// treats even freshly-recalled memories as stale. Salience is intentionally
+// left untouched here; this is a lightweight recency stamp, not a ranking bump.
+export function touchMemoriesAccessed(ids: number[]): void {
+  if (ids.length === 0) return
+  const now = Math.floor(Date.now() / 1000)
+  const placeholders = ids.map(() => '?').join(',')
+  db.prepare(`UPDATE memories SET accessed_at = ? WHERE id IN (${placeholders})`).run(now, ...ids)
+}
+
 export function decayMemories(): void {
   const oneWeekAgo = Math.floor(Date.now() / 1000) - 7 * 86400
   // Gentler decay: 0.5% per day, only for memories older than 1 week

--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -1,7 +1,7 @@
 import {
   saveAgentMemory, getAgentMemories, searchAgentMemories, getMemoryStats, updateMemory,
   hybridSearch, backfillEmbeddings, clearMemoryCache,
-  searchMemories, getMemoriesForChat, getDb,
+  searchMemories, getMemoriesForChat, getDb, touchMemoriesAccessed,
   type Memory,
 } from '../../db.js'
 import { MAIN_AGENT_ID, ALLOWED_CHAT_ID, OLLAMA_URL, APP_TZ } from '../../config.js'
@@ -95,6 +95,13 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
     }
 
     if (tier) results = results.filter(m => m.category === tier)
+
+    // A search query (q) is a genuine recall: stamp the surfaced memories as
+    // just-accessed so accessed_at reflects real usage. Plain listing (no q,
+    // e.g. the dashboard browsing all memories) is NOT a recall and must not
+    // refresh accessed_at -- otherwise every poll would keep everything "fresh"
+    // and defeat staleness detection.
+    if (q && results.length) touchMemoriesAccessed(results.map(m => m.id))
 
     const formatted = results.map(m => ({
       ...m,


### PR DESCRIPTION
## Summary
Agent memories never had their `accessed_at` updated on read, so any staleness check based on `accessed_at` treated **every** memory — even one recalled seconds ago — as ancient. This wires the existing recency-stamp mechanism into the agent-memory read path.

## Root cause
- The `memories` table has `accessed_at INTEGER NOT NULL`, set to `created_at` at INSERT and meant to advance whenever a memory is recalled.
- `touchMemory(id)` (db.ts) exists and updates `accessed_at` — but it is only used by the **legacy chat-recall** path.
- The **agent** memory read/search endpoint (`GET /api/memories?agent=&q=` in `src/web/routes/memories.ts`) surfaces memories via `searchAgentMemories` / `hybridSearch` / `getAgentMemories` / LIKE fallbacks and **never** stamps `accessed_at`.
- Result: for all agent memories, `accessed_at == created_at` permanently (verified: 136/136 rows).

## Impact / how it surfaced
The Dream Engine's nightly memory-hygiene pass (a `WHERE accessed_at < now-7d` "stale hot → cold" sweep) ran for the first time and matched the entire table, moving freshly-active `hot` memories to `cold`. It was a latent design gap, unrelated to any recent change — it simply had never been exercised before.

## Fix
- `db.ts`: add `touchMemoriesAccessed(ids: number[])` — a bulk `UPDATE memories SET accessed_at = now WHERE id IN (...)`. Deliberately does **not** bump `salience` (unlike `touchMemory`); this is a lightweight recency stamp, not a ranking signal.
- `src/web/routes/memories.ts`: in the `GET /api/memories` handler, after results are gathered, call `touchMemoriesAccessed` **only when a search query `q` is present** — i.e. a genuine recall.

### Why gate on `q`
A search is real usage; plain listing (no `q`, e.g. the dashboard browsing all memories, or a polling UI) is browsing, not recall. Stamping on listing would keep everything artificially "fresh" and defeat staleness detection in the opposite direction.

Net effect: `accessed_at` now reflects real usage, and `accessed_at`-based staleness logic is correct — no change to the Dream task's query needed.

## Test (live)
- Recall (`GET /api/memories?agent=bigme&q=dashboard`) → the surfaced rows' `accessed_at` advanced to `now`.
- Plain listing (`GET /api/memories?agent=bigme&limit=100`) → an old memory's `accessed_at` stayed unchanged.
- `tsc` build clean.

## Files
- `src/db.ts` — `touchMemoriesAccessed`
- `src/web/routes/memories.ts` — call it on recall

🤖 Generated with [Claude Code](https://claude.com/claude-code)