### PR TITLE
fix(dashboard): main agent model select shows its real model, not Fable 5

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2498,7 +2498,24 @@ async function openMarveenDetail() {
   // Sync the settings tab model select with Marveen's actual model so it
   // doesn't carry over the previously opened sub-agent's selection.
   const marveenModelSelect = document.getElementById('editAgentModel')
-  if (marveenModelSelect) marveenModelSelect.value = m.activeModel || m.model || ''
+  if (marveenModelSelect) {
+    // The main agent's real model (e.g. 'claude-opus-4-8') may not match any
+    // static option verbatim (the option is 'claude-opus-4-8[1m]'), so a plain
+    // .value assignment finds no match and the select silently displays the
+    // first option (Fable 5), misrepresenting what the agent actually runs.
+    // Inject the real id as an option so the (read-only) select shows the truth
+    // -- same trick as the sub-agent panel's dynamic-model-opt.
+    const mv = m.activeModel || m.model || ''
+    Array.from(marveenModelSelect.querySelectorAll('option.dynamic-model-opt')).forEach(o => o.remove())
+    if (mv && !Array.from(marveenModelSelect.options).some(o => o.value === mv)) {
+      const opt = document.createElement('option')
+      opt.value = mv
+      opt.className = 'dynamic-model-opt'
+      opt.textContent = mv
+      marveenModelSelect.appendChild(opt)
+    }
+    marveenModelSelect.value = mv
+  }
   // Surface the "channels restart" button -- destructive, but mobile-safe
   // when the Telegram plugin wedges and you're away from a terminal.
   document.getElementById('marveenRestartBtn').hidden = false


### PR DESCRIPTION
## Summary
On the main agent's Settings tab, the model dropdown displayed **Fable 5** regardless of the model the agent actually runs. This is a display-only bug in a read-only field, so the operator could not correct it and the panel actively misinformed.

## Root cause
`openMarveenDetail()` sets the model `<select>` value to the raw id reported by `/api/marveen` (e.g. `claude-opus-4-8`). The matching static `<option>` in the markup is `claude-opus-4-8[1m]` — not an exact string match. With no matching option, the browser leaves the select on its **first** option, which is `claude-fable-5` (Fable 5). The field is read-only for the main agent (its model is managed via `channels.sh`, not the dashboard), so nothing ever corrects the display.

## Fix
Inject the real model id as a `<option>` before selecting it — the same `dynamic-model-opt` trick the **sub-agent** panel already uses to display arbitrary/manual model ids. The read-only select now shows the true model.

Generic: it displays whatever `/api/marveen` reports on any install, not a hardcoded value.

## Test (live, via CDP)
- Main agent Settings tab: select shows `claude-opus-4-8` (the real model), still `disabled`.
- Previously: showed `claude-fable-5`.

## Files
- `web/app.js` — `openMarveenDetail()` main-agent model injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)