### PR TITLE
feat(fleet): OpenRouter models for agents (no proxy, auto + curated manual)

### DIFF
--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -42,6 +42,7 @@ import { resolveAgentSecurityProfile } from './agent-team.js'
 import { writeAgentSettingsFromProfile, ensureFleetRosterSection, ensureAutonomySection } from './agent-scaffold.js'
 import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import { getSecret } from './vault.js'
+import { resolveOpenRouterModel } from './openrouter-models.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
@@ -800,11 +801,16 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
       logger.warn({ err, name }, 'pre-launch detached-claude reap failed (continuing)')
     }
 
-    const model = readAgentModel(name)
+    // `openrouter-auto:<tier>` resolves to the tier's current recommended model
+    // (weekly-refreshed); a concrete OpenRouter id (contains '/') passes through.
+    const model = resolveOpenRouterModel(readAgentModel(name))
     const authMode = readAgentAuthMode(name)
     const isClaude = model.startsWith('claude-')
     const isDeepseek = model.startsWith('deepseek-')
-    const isOllama = !isClaude && !isDeepseek
+    // OpenRouter model ids are `provider/model` (contain '/'); Ollama tags use
+    // ':' and no '/'. This discriminator keeps OpenRouter ids off the Ollama path.
+    const isOpenRouter = !isClaude && !isDeepseek && model.includes('/')
+    const isOllama = !isClaude && !isDeepseek && !isOpenRouter
     // ANTHROPIC_MODEL is REQUIRED for non-Claude models: the interactive TUI
     // validates the `--model` flag against known Anthropic models and silently
     // falls back to the built-in default (claude-opus-...) for an unrecognized
@@ -815,6 +821,10 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     const ollamaEnv = isOllama ? `export ANTHROPIC_AUTH_TOKEN=ollama && export ANTHROPIC_BASE_URL=${OLLAMA_URL} && export ANTHROPIC_MODEL='${model}' && ` : ''
     const deepseekKey = isDeepseek ? (getSecret('DEEPSEEK_API_KEY') ?? '') : ''
     const deepseekEnv = isDeepseek ? `export ANTHROPIC_AUTH_TOKEN="${deepseekKey}" && export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic && export ANTHROPIC_MODEL='${model}' && ` : ''
+    // OpenRouter: Anthropic-compatible endpoint at https://openrouter.ai/api
+    // (the SDK appends /v1/messages). Key from the vault (openrouter-fleet-key).
+    const openrouterKey = isOpenRouter ? (getSecret('openrouter-fleet-key') ?? '') : ''
+    const openrouterEnv = isOpenRouter ? `export ANTHROPIC_AUTH_TOKEN="${openrouterKey}" && export ANTHROPIC_BASE_URL=https://openrouter.ai/api && export ANTHROPIC_MODEL='${model}' && ` : ''
     // When authMode is 'api', the agent uses its own ANTHROPIC_API_KEY from
     // the vault instead of the host's OAuth. The vault entry ID follows the
     // convention `agent-{name}-api-key`. We inject it as an env var so Claude
@@ -1049,7 +1059,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     const promptSuggestionEnv = 'export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && '
     // Single-quote `${model}` so values like `claude-opus-4-8[1m]` (1M-context
     // suffix) are not glob-expanded by the shell that tmux spawns the command in.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}cd "${dir}" && ${claudeBin()} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}${openrouterEnv}cd "${dir}" && ${claudeBin()} ${continueFlag}${skipFlag}--model '${model}' ${channelFlag}`.trimEnd()
     runTmux(null, ['new-session', '-d', '-s', session, cmd], { timeout: 10000 })
 
     logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')

--- a/src/web/openrouter-models.ts
+++ b/src/web/openrouter-models.ts
@@ -67,6 +67,46 @@ export function loadOpenRouterCatalog(): OpenRouterCatalog {
   return DEFAULT_CATALOG
 }
 
+// --- Full catalog for the manual picker ---
+// The dashboard "OpenRouter" browse popup lists every model so the operator can
+// pick/test any of them (not just the tier picks). OpenRouter's /models list is
+// public; we cache it in-memory to avoid re-fetching on every popup open.
+
+export interface OpenRouterModelInfo {
+  id: string
+  name: string
+  contextLength: number
+  promptPrice: number      // USD per 1M prompt tokens
+  completionPrice: number  // USD per 1M completion tokens
+  free: boolean
+}
+
+let allModelsCache: { at: number; models: OpenRouterModelInfo[] } | null = null
+const ALL_MODELS_TTL_MS = 6 * 60 * 60 * 1000 // 6h
+
+export async function fetchAllOpenRouterModels(nowMs: number): Promise<OpenRouterModelInfo[]> {
+  if (allModelsCache && nowMs - allModelsCache.at < ALL_MODELS_TTL_MS) return allModelsCache.models
+  const resp = await fetch('https://openrouter.ai/api/v1/models')
+  if (!resp.ok) throw new Error(`openrouter models fetch: HTTP ${resp.status}`)
+  const data = await resp.json() as { data?: Array<Record<string, unknown>> }
+  const models: OpenRouterModelInfo[] = (data.data ?? []).map(m => {
+    const pricing = (m.pricing ?? {}) as Record<string, string>
+    const prompt = parseFloat(pricing.prompt ?? '0') * 1_000_000
+    const completion = parseFloat(pricing.completion ?? '0') * 1_000_000
+    return {
+      id: String(m.id ?? ''),
+      name: String(m.name ?? m.id ?? ''),
+      contextLength: Number(m.context_length ?? 0),
+      promptPrice: Number.isFinite(prompt) ? prompt : 0,
+      completionPrice: Number.isFinite(completion) ? completion : 0,
+      free: prompt === 0 && completion === 0,
+    }
+  }).filter(m => m.id)
+  models.sort((a, b) => a.id.localeCompare(b.id))
+  allModelsCache = { at: nowMs, models }
+  return models
+}
+
 // Resolve a stored model value to a concrete model id the launcher can use.
 // `openrouter-auto:<tierKey>` -> that tier's current `auto` model. Anything
 // else is returned unchanged. Never throws.

--- a/src/web/openrouter-models.ts
+++ b/src/web/openrouter-models.ts
@@ -1,0 +1,81 @@
+// OpenRouter fleet-model catalog + auto-tier resolution.
+//
+// The fleet can run its non-main agents on OpenRouter models. OpenRouter
+// exposes an Anthropic-compatible Messages endpoint (https://openrouter.ai/api
+// -> /v1/messages), so the launcher points ANTHROPIC_BASE_URL there with the
+// openrouter-fleet-key, exactly like the DeepSeek branch -- no proxy needed.
+//
+// Two selection modes surface in the dashboard:
+//   - AUTO: the agent's model is stored as `openrouter-auto:<tierKey>`; at
+//     launch we resolve it to the tier's currently-recommended model, so the
+//     weekly research task can keep the fleet on the best model without any
+//     per-agent re-config.
+//   - MANUAL: the agent's model is a concrete OpenRouter id (e.g.
+//     `deepseek/deepseek-chat-v3.1`), chosen from the tier's 2 options.
+//
+// The catalog lives in store/openrouter-models.json (maintained by the
+// openrouter-weekly-llm-research scheduled task). A hardcoded default keeps the
+// feature working before the first weekly refresh writes the file.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { STORE_DIR } from '../config.js'
+import { logger } from '../logger.js'
+
+export const AUTO_PREFIX = 'openrouter-auto:'
+export const OPENROUTER_MODELS_FILE = join(STORE_DIR, 'openrouter-models.json')
+
+export interface OpenRouterTier {
+  key: string
+  label: string
+  auto: string        // the currently-recommended concrete model id for this tier
+  manual: string[]    // 2 selectable concrete model ids
+}
+
+export interface OpenRouterCatalog {
+  updated: string
+  tiers: OpenRouterTier[]
+}
+
+// Fallback catalog (fleet-model-allocation.md, 2026-07-13). Used until the
+// weekly task writes store/openrouter-models.json.
+const DEFAULT_CATALOG: OpenRouterCatalog = {
+  updated: '2026-07-13 (default)',
+  tiers: [
+    { key: 'tier0', label: 'Tier 0 — Free / bulk', auto: 'meta-llama/llama-3.3-70b-instruct:free',
+      manual: ['meta-llama/llama-3.3-70b-instruct:free', 'qwen/qwen3-coder:free'] },
+    { key: 'tier1', label: 'Tier 1 — Workhorse', auto: 'deepseek/deepseek-chat-v3.1',
+      manual: ['deepseek/deepseek-chat-v3.1', 'google/gemini-2.5-flash'] },
+    { key: 'tier2', label: 'Tier 2 — Code', auto: 'qwen/qwen3-coder',
+      manual: ['qwen/qwen3-coder', 'mistralai/codestral-2508'] },
+    { key: 'tier3', label: 'Tier 3 — Heavy reasoning', auto: 'anthropic/claude-sonnet-5',
+      manual: ['anthropic/claude-sonnet-5', 'google/gemini-3.1-pro'] },
+    { key: 'tier4', label: 'Tier 4 — Vision', auto: 'google/gemini-2.5-flash',
+      manual: ['google/gemini-2.5-flash', 'qwen/qwen3-vl-30b-a3b-instruct'] },
+  ],
+}
+
+export function loadOpenRouterCatalog(): OpenRouterCatalog {
+  try {
+    if (existsSync(OPENROUTER_MODELS_FILE)) {
+      const parsed = JSON.parse(readFileSync(OPENROUTER_MODELS_FILE, 'utf-8')) as OpenRouterCatalog
+      if (parsed && Array.isArray(parsed.tiers) && parsed.tiers.length > 0) return parsed
+    }
+  } catch (err) {
+    logger.warn({ err }, 'openrouter catalog parse failed; using default')
+  }
+  return DEFAULT_CATALOG
+}
+
+// Resolve a stored model value to a concrete model id the launcher can use.
+// `openrouter-auto:<tierKey>` -> that tier's current `auto` model. Anything
+// else is returned unchanged. Never throws.
+export function resolveOpenRouterModel(model: string): string {
+  if (!model.startsWith(AUTO_PREFIX)) return model
+  const tierKey = model.slice(AUTO_PREFIX.length)
+  const cat = loadOpenRouterCatalog()
+  const tier = cat.tiers.find(t => t.key === tierKey)
+  if (tier?.auto) return tier.auto
+  logger.warn({ model, tierKey }, 'openrouter-auto tier not found; falling back to tier1/deepseek')
+  return cat.tiers.find(t => t.key === 'tier1')?.auto ?? 'deepseek/deepseek-chat-v3.1'
+}

--- a/src/web/openrouter-models.ts
+++ b/src/web/openrouter-models.ts
@@ -25,7 +25,7 @@ import { logger } from '../logger.js'
 export const AUTO_PREFIX = 'openrouter-auto:'
 export const OPENROUTER_MODELS_FILE = join(STORE_DIR, 'openrouter-models.json')
 // User-curated "manual" model list. The main agent's OpenRouter browse popup
-// ticks/unticks models here; the ticked set becomes the "OpenRouter — kézi"
+// ticks/unticks models here; the ticked set becomes the "OpenRouter - kézi"
 // optgroup available in EVERY agent's model dropdown. Curation (this file) is
 // deliberately separate from per-agent assignment (writeAgentModel).
 export const OPENROUTER_MANUAL_FILE = join(STORE_DIR, 'openrouter-manual.json')
@@ -47,15 +47,15 @@ export interface OpenRouterCatalog {
 const DEFAULT_CATALOG: OpenRouterCatalog = {
   updated: '2026-07-13 (default)',
   tiers: [
-    { key: 'tier0', label: 'Tier 0 — Free / bulk', auto: 'meta-llama/llama-3.3-70b-instruct:free',
+    { key: 'tier0', label: 'Tier 0 - Free / bulk', auto: 'meta-llama/llama-3.3-70b-instruct:free',
       manual: ['meta-llama/llama-3.3-70b-instruct:free', 'qwen/qwen3-coder:free'] },
-    { key: 'tier1', label: 'Tier 1 — Workhorse', auto: 'deepseek/deepseek-chat-v3.1',
+    { key: 'tier1', label: 'Tier 1 - Workhorse', auto: 'deepseek/deepseek-chat-v3.1',
       manual: ['deepseek/deepseek-chat-v3.1', 'google/gemini-2.5-flash'] },
-    { key: 'tier2', label: 'Tier 2 — Code', auto: 'qwen/qwen3-coder',
+    { key: 'tier2', label: 'Tier 2 - Code', auto: 'qwen/qwen3-coder',
       manual: ['qwen/qwen3-coder', 'mistralai/codestral-2508'] },
-    { key: 'tier3', label: 'Tier 3 — Heavy reasoning', auto: 'anthropic/claude-sonnet-5',
+    { key: 'tier3', label: 'Tier 3 - Heavy reasoning', auto: 'anthropic/claude-sonnet-5',
       manual: ['anthropic/claude-sonnet-5', 'google/gemini-3.1-pro'] },
-    { key: 'tier4', label: 'Tier 4 — Vision', auto: 'google/gemini-2.5-flash',
+    { key: 'tier4', label: 'Tier 4 - Vision', auto: 'google/gemini-2.5-flash',
       manual: ['google/gemini-2.5-flash', 'qwen/qwen3-vl-30b-a3b-instruct'] },
   ],
 }

--- a/src/web/openrouter-models.ts
+++ b/src/web/openrouter-models.ts
@@ -17,13 +17,18 @@
 // openrouter-weekly-llm-research scheduled task). A hardcoded default keeps the
 // feature working before the first weekly refresh writes the file.
 
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { STORE_DIR } from '../config.js'
 import { logger } from '../logger.js'
 
 export const AUTO_PREFIX = 'openrouter-auto:'
 export const OPENROUTER_MODELS_FILE = join(STORE_DIR, 'openrouter-models.json')
+// User-curated "manual" model list. The main agent's OpenRouter browse popup
+// ticks/unticks models here; the ticked set becomes the "OpenRouter — kézi"
+// optgroup available in EVERY agent's model dropdown. Curation (this file) is
+// deliberately separate from per-agent assignment (writeAgentModel).
+export const OPENROUTER_MANUAL_FILE = join(STORE_DIR, 'openrouter-manual.json')
 
 export interface OpenRouterTier {
   key: string
@@ -105,6 +110,53 @@ export async function fetchAllOpenRouterModels(nowMs: number): Promise<OpenRoute
   models.sort((a, b) => a.id.localeCompare(b.id))
   allModelsCache = { at: nowMs, models }
   return models
+}
+
+// --- User-curated manual model list ---
+// The ticked set from the main agent's browse popup. Persisted as a flat list
+// so the dropdown's "kézi" optgroup is identical for every agent, while each
+// agent still picks its own model from that shared set.
+
+export interface CuratedModel {
+  id: string
+  name: string
+}
+
+export function loadCuratedManual(): CuratedModel[] {
+  try {
+    if (existsSync(OPENROUTER_MANUAL_FILE)) {
+      const parsed = JSON.parse(readFileSync(OPENROUTER_MANUAL_FILE, 'utf-8')) as { models?: CuratedModel[] }
+      if (parsed && Array.isArray(parsed.models)) {
+        return parsed.models.filter(m => m && typeof m.id === 'string' && m.id)
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, 'openrouter curated-manual parse failed; using empty list')
+  }
+  return []
+}
+
+function saveCuratedManual(models: CuratedModel[]): void {
+  writeFileSync(OPENROUTER_MANUAL_FILE, JSON.stringify({ models }, null, 2))
+}
+
+// Add a model to the curated list (no-op if already present). Returns the new list.
+export function addCuratedManual(id: string, name: string): CuratedModel[] {
+  const list = loadCuratedManual()
+  if (!list.some(m => m.id === id)) {
+    list.push({ id, name: name || id })
+    list.sort((a, b) => a.id.localeCompare(b.id))
+    saveCuratedManual(list)
+  }
+  return list
+}
+
+// Remove a model from the curated list (no-op if absent). Returns the new list.
+export function removeCuratedManual(id: string): CuratedModel[] {
+  const list = loadCuratedManual()
+  const next = list.filter(m => m.id !== id)
+  if (next.length !== list.length) saveCuratedManual(next)
+  return next
 }
 
 // Resolve a stored model value to a concrete model id the launcher can use.

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -505,7 +505,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
           }
         : null,
       // User-curated manual models (ticked in the main agent's browse popup).
-      // Feeds the "OpenRouter — kézi" optgroup in every agent's model dropdown.
+      // Feeds the "OpenRouter - kézi" optgroup in every agent's model dropdown.
       openrouterManual: hasOpenRouter ? loadCuratedManual() : [],
       openrouterConfigured: hasOpenRouter,
     })

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -9,6 +9,7 @@ import { classifyAgentMessage, wrapAgentMessageForDelivery } from '../agent-mess
 import { ensureFederationClaudeMdSection } from '../federation/onboarding.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { getSecret, setSecret, deleteSecret, listSecrets } from '../vault.js'
+import { loadOpenRouterCatalog } from '../openrouter-models.js'
 import {
   agentDir,
   agentConfigRoot,
@@ -470,6 +471,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   // both in the "new agent" wizard and the agent edit panel.
   if (path === '/api/models/available' && method === 'GET') {
     const hasDeepseek = getSecret('DEEPSEEK_API_KEY') !== null
+    // OpenRouter is gated behind the vault key, same as DeepSeek: surfacing the
+    // options without the key would let the operator pick a model that 401s.
+    const hasOpenRouter = getSecret('openrouter-fleet-key') !== null
+    const orCatalog = loadOpenRouterCatalog()
     json(res, {
       claude: [
         { id: 'claude-fable-5', label: 'Fable 5 (legújabb)' },
@@ -484,6 +489,22 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
           ]
         : [],
       deepseekConfigured: hasDeepseek,
+      // OpenRouter tiers for the model picker. `auto` per tier feeds the "Auto"
+      // mode (stored as `openrouter-auto:<tierKey>`, resolved weekly-fresh at
+      // launch); `manual` (2 ids) feeds the "Manual" mode.
+      openrouter: hasOpenRouter
+        ? {
+            updated: orCatalog.updated,
+            tiers: orCatalog.tiers.map(t => ({
+              key: t.key,
+              label: t.label,
+              autoId: `openrouter-auto:${t.key}`,
+              auto: t.auto,
+              manual: t.manual,
+            })),
+          }
+        : null,
+      openrouterConfigured: hasOpenRouter,
     })
     return true
   }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -9,7 +9,7 @@ import { classifyAgentMessage, wrapAgentMessageForDelivery } from '../agent-mess
 import { ensureFederationClaudeMdSection } from '../federation/onboarding.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { getSecret, setSecret, deleteSecret, listSecrets } from '../vault.js'
-import { loadOpenRouterCatalog } from '../openrouter-models.js'
+import { loadOpenRouterCatalog, fetchAllOpenRouterModels } from '../openrouter-models.js'
 import {
   agentDir,
   agentConfigRoot,
@@ -506,6 +506,24 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
         : null,
       openrouterConfigured: hasOpenRouter,
     })
+    return true
+  }
+
+  // Full OpenRouter model list for the manual "browse all" picker popup.
+  // Gated behind the vault key like the tier group. The upstream /models list
+  // is public; the module caches it for 6h.
+  if (path === '/api/openrouter/models' && method === 'GET') {
+    if (getSecret('openrouter-fleet-key') === null) {
+      json(res, { error: 'OpenRouter not configured' }, 403)
+      return true
+    }
+    try {
+      const models = await fetchAllOpenRouterModels(Date.now())
+      json(res, { models })
+    } catch (err) {
+      logger.warn({ err }, 'openrouter models list fetch failed')
+      json(res, { error: 'Could not fetch OpenRouter models' }, 502)
+    }
     return true
   }
 

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -9,7 +9,7 @@ import { classifyAgentMessage, wrapAgentMessageForDelivery } from '../agent-mess
 import { ensureFederationClaudeMdSection } from '../federation/onboarding.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
 import { getSecret, setSecret, deleteSecret, listSecrets } from '../vault.js'
-import { loadOpenRouterCatalog, fetchAllOpenRouterModels } from '../openrouter-models.js'
+import { loadOpenRouterCatalog, fetchAllOpenRouterModels, loadCuratedManual, addCuratedManual, removeCuratedManual } from '../openrouter-models.js'
 import {
   agentDir,
   agentConfigRoot,
@@ -504,8 +504,35 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
             })),
           }
         : null,
+      // User-curated manual models (ticked in the main agent's browse popup).
+      // Feeds the "OpenRouter — kézi" optgroup in every agent's model dropdown.
+      openrouterManual: hasOpenRouter ? loadCuratedManual() : [],
       openrouterConfigured: hasOpenRouter,
     })
+    return true
+  }
+
+  // Curated manual-model list read/toggle. Curation is main-agent-only in the UI
+  // (the browse popup is hidden for sub-agents), but the API just gates on the
+  // vault key; the ticked set is shared across all agents' dropdowns.
+  if (path === '/api/openrouter/manual' && method === 'GET') {
+    if (getSecret('openrouter-fleet-key') === null) {
+      json(res, { error: 'OpenRouter not configured' }, 403)
+      return true
+    }
+    json(res, { models: loadCuratedManual() })
+    return true
+  }
+  if (path === '/api/openrouter/manual' && method === 'POST') {
+    if (getSecret('openrouter-fleet-key') === null) {
+      json(res, { error: 'OpenRouter not configured' }, 403)
+      return true
+    }
+    const body = await readBody(req)
+    const { id, name, checked } = JSON.parse(body.toString()) as { id?: string; name?: string; checked?: boolean }
+    if (!id || typeof id !== 'string') { json(res, { error: 'id is required' }, 400); return true }
+    const models = checked ? addCuratedManual(id, name || id) : removeCuratedManual(id)
+    json(res, { ok: true, models })
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -2499,6 +2499,11 @@ async function openMarveenDetail() {
   // doesn't carry over the previously opened sub-agent's selection.
   const marveenModelSelect = document.getElementById('editAgentModel')
   if (marveenModelSelect) marveenModelSelect.value = m.activeModel || m.model || ''
+  // Populate the model dropdown groups (auto/manual) AND surface the OpenRouter
+  // curation button -- this is the main agent, the only place curation lives.
+  // The select itself is read-only for Marveen, but the browse button (managing
+  // the shared manual list) is enabled here.
+  loadAvailableModels()
   // Surface the "channels restart" button -- destructive, but mobile-safe
   // when the Telegram plugin wedges and you're away from a terminal.
   document.getElementById('marveenRestartBtn').hidden = false
@@ -3395,8 +3400,16 @@ async function loadAvailableModels() {
     }
     // Browse popup = the curation UI (tick/untick which manual models exist).
     // MAIN AGENT ONLY -- sub-agents just pick from the curated dropdown above.
+    // The main agent opens via openMarveenDetail(), whose currentAgent comes
+    // from window._marveen and has NO `role` field -- so detect it by name too.
+    const mid = (typeof mainAgentId === 'function') ? mainAgentId() : ''
+    const isMainAgent = !!currentAgent && (
+      currentAgent.role === 'main' ||
+      currentAgent.name === mid ||
+      currentAgent.agentId === mid
+    )
     const orBtn = document.getElementById('openrouterBrowseBtn')
-    if (orBtn) orBtn.style.display = (data.openrouterConfigured && currentAgent && currentAgent.role === 'main') ? '' : 'none'
+    if (orBtn) orBtn.style.display = (data.openrouterConfigured && isMainAgent) ? '' : 'none'
   } catch { /* dashboard not available */ }
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -3377,6 +3377,9 @@ async function openOpenrouterModal() {
   const searchEl = document.getElementById('openrouterModalSearch')
   const freeEl = document.getElementById('openrouterModalFreeOnly')
   if (!modal || !listEl) return
+  // The modal markup lives inside the (hidden) connectors page; reparent it to
+  // <body> so it renders full-viewport regardless of which tab is active.
+  if (modal.parentElement !== document.body) document.body.appendChild(modal)
   if (agentEl) agentEl.textContent = (currentAgent && (currentAgent.displayName || currentAgent.name)) || 'ágens'
   // Two competing .modal-overlay CSS rules: one hides via [hidden], the other
   // via opacity/visibility (toggled by .active). Set both so the modal shows

--- a/web/app.js
+++ b/web/app.js
@@ -2844,7 +2844,22 @@ async function openAgentDetail(agentName) {
   // Settings tab - load Ollama + DeepSeek models then set value
   loadAvailableModels()
   loadOllamaModels().then(() => {
-    document.getElementById('editAgentModel').value = currentAgent.activeModel || currentAgent.model || 'claude-opus-4-8[1m]'
+    const sel = document.getElementById('editAgentModel')
+    const mv = currentAgent.activeModel || currentAgent.model || 'claude-opus-4-8[1m]'
+    // The model <select> is one shared element reused per agent. A manual
+    // OpenRouter id (or openrouter-auto:tier) may not be among the static/auto
+    // options, so setting .value would silently show nothing. Inject THIS
+    // agent's model as a selectable option (cleaning any stale injected ones
+    // first) so every agent always displays its own model, per-agent.
+    Array.from(sel.querySelectorAll('option.dynamic-model-opt')).forEach(o => o.remove())
+    if (!Array.from(sel.options).some(o => o.value === mv)) {
+      const opt = document.createElement('option')
+      opt.value = mv
+      opt.className = 'dynamic-model-opt'
+      opt.textContent = mv.startsWith('openrouter-auto:') ? `🔀 ${mv}` : `🔀 ${mv}`
+      sel.appendChild(opt)
+    }
+    sel.value = mv
   })
   populateProfileSelect(
     document.getElementById('editAgentProfile'),
@@ -3440,6 +3455,7 @@ function selectOpenrouterModel(id) {
     if (!opt) {
       opt = document.createElement('option')
       opt.value = id
+      opt.className = 'dynamic-model-opt'
       opt.textContent = `🔀 ${id}`
       sel.appendChild(opt)
     }

--- a/web/app.js
+++ b/web/app.js
@@ -3345,9 +3345,9 @@ async function loadAvailableModels() {
     // ids per tier). Backend gates the whole block behind the vault key, so a
     // null payload means OpenRouter is not connected -> keep the groups hidden.
     const or = data.openrouter
-    const autoGroups = [document.getElementById('openrouterAutoGroup'), document.getElementById('agentModelOpenrouterAutoGroup')]
-    const manualGroups = [document.getElementById('openrouterManualGroup'), document.getElementById('agentModelOpenrouterManualGroup')]
     const orTiers = or && Array.isArray(or.tiers) ? or.tiers : []
+    // Auto = one entry per tier in the dropdown (weekly-fresh recommendation).
+    const autoGroups = [document.getElementById('openrouterAutoGroup'), document.getElementById('agentModelOpenrouterAutoGroup')]
     for (const g of autoGroups) {
       if (!g) continue
       g.innerHTML = ''
@@ -3360,22 +3360,94 @@ async function loadAvailableModels() {
         g.appendChild(opt)
       }
     }
-    for (const g of manualGroups) {
-      if (!g) continue
-      g.innerHTML = ''
-      if (orTiers.length === 0) { g.style.display = 'none'; continue }
-      g.style.display = ''
-      for (const t of orTiers) {
-        for (const mid of (Array.isArray(t.manual) ? t.manual : [])) {
-          const opt = document.createElement('option')
-          opt.value = mid
-          opt.textContent = `${t.label.replace(/ —.*/, '')}: ${mid}`
-          g.appendChild(opt)
-        }
-      }
-    }
+    // Manual = the "OpenRouter" browse button (searchable popup over ALL models);
+    // only usable when the key is connected.
+    const orBtn = document.getElementById('openrouterBrowseBtn')
+    if (orBtn) orBtn.style.display = data.openrouterConfigured ? '' : 'none'
   } catch { /* dashboard not available */ }
 }
+
+// --- OpenRouter manual model picker (browse all ~340 models) ---
+let openrouterAllModels = null
+
+async function openOpenrouterModal() {
+  const modal = document.getElementById('openrouterModal')
+  const listEl = document.getElementById('openrouterModalList')
+  const agentEl = document.getElementById('openrouterModalAgent')
+  const searchEl = document.getElementById('openrouterModalSearch')
+  const freeEl = document.getElementById('openrouterModalFreeOnly')
+  if (!modal || !listEl) return
+  if (agentEl) agentEl.textContent = (currentAgent && (currentAgent.displayName || currentAgent.name)) || 'ágens'
+  modal.hidden = false
+  listEl.innerHTML = '<div style="padding:14px;color:var(--text-muted);font-size:13px">Modellek betöltése…</div>'
+  if (searchEl) searchEl.value = ''
+  if (freeEl) freeEl.checked = false
+  try {
+    if (!openrouterAllModels) {
+      const res = await fetch('/api/openrouter/models')
+      if (!res.ok) throw new Error('fetch failed')
+      const data = await res.json()
+      openrouterAllModels = Array.isArray(data.models) ? data.models : []
+    }
+    renderOpenrouterList()
+  } catch {
+    listEl.innerHTML = '<div style="padding:14px;color:var(--danger,#dc2626);font-size:13px">Nem sikerült betölteni az OpenRouter modelleket.</div>'
+  }
+}
+
+function renderOpenrouterList() {
+  const listEl = document.getElementById('openrouterModalList')
+  const countEl = document.getElementById('openrouterModalCount')
+  const q = (document.getElementById('openrouterModalSearch')?.value || '').toLowerCase().trim()
+  const freeOnly = !!document.getElementById('openrouterModalFreeOnly')?.checked
+  if (!listEl || !openrouterAllModels) return
+  const rows = openrouterAllModels.filter(m => {
+    if (freeOnly && !m.free) return false
+    if (!q) return true
+    return (m.id + ' ' + m.name).toLowerCase().includes(q)
+  })
+  if (countEl) countEl.textContent = `${rows.length} modell`
+  listEl.innerHTML = ''
+  for (const m of rows.slice(0, 400)) {
+    const row = document.createElement('div')
+    row.className = 'openrouter-model-row'
+    row.style.cssText = 'padding:8px 10px;border-bottom:1px solid var(--border);cursor:pointer;font-size:13px'
+    const price = m.free ? '<span style="color:var(--success,#16a34a);font-weight:600">ingyenes</span>'
+      : `$${m.promptPrice.toFixed(2)}/$${m.completionPrice.toFixed(2)} /M`
+    const ctx = m.contextLength ? ` · ${Math.round(m.contextLength / 1000)}k ctx` : ''
+    row.innerHTML = `<div style="font-weight:600">${escapeHtml(m.name)}</div>`
+      + `<div style="color:var(--text-muted);font-size:11.5px"><code>${escapeHtml(m.id)}</code> · ${price}${ctx}</div>`
+    row.addEventListener('mouseenter', () => { row.style.background = 'var(--surface-hover, #f1f5f9)' })
+    row.addEventListener('mouseleave', () => { row.style.background = '' })
+    row.addEventListener('click', () => selectOpenrouterModel(m.id))
+    listEl.appendChild(row)
+  }
+  if (rows.length === 0) listEl.innerHTML = '<div style="padding:14px;color:var(--text-muted);font-size:13px">Nincs találat.</div>'
+}
+
+function selectOpenrouterModel(id) {
+  const sel = document.getElementById('editAgentModel')
+  if (sel) {
+    // Ensure the chosen id exists as an option, then select it.
+    let opt = Array.from(sel.options).find(o => o.value === id)
+    if (!opt) {
+      opt = document.createElement('option')
+      opt.value = id
+      opt.textContent = `🔀 ${id}`
+      sel.appendChild(opt)
+    }
+    sel.value = id
+    sel.dispatchEvent(new Event('change'))
+  }
+  const modal = document.getElementById('openrouterModal')
+  if (modal) modal.hidden = true
+}
+
+document.getElementById('openrouterBrowseBtn')?.addEventListener('click', openOpenrouterModal)
+document.getElementById('openrouterModalClose')?.addEventListener('click', () => { document.getElementById('openrouterModal').hidden = true })
+document.getElementById('openrouterModalCancel')?.addEventListener('click', () => { document.getElementById('openrouterModal').hidden = true })
+document.getElementById('openrouterModalSearch')?.addEventListener('input', renderOpenrouterList)
+document.getElementById('openrouterModalFreeOnly')?.addEventListener('change', renderOpenrouterList)
 
 let modelRestartPollTimer = null
 let modelRestartPollName = null

--- a/web/app.js
+++ b/web/app.js
@@ -3375,15 +3375,34 @@ async function loadAvailableModels() {
         g.appendChild(opt)
       }
     }
-    // Manual = the "OpenRouter" browse button (searchable popup over ALL models);
-    // only usable when the key is connected.
+    // Manual = the user-curated list -> "OpenRouter — kézi" optgroup in every
+    // select. Curated once (main agent's browse popup, checkboxes); assignable
+    // per agent here. Empty list -> group hidden.
+    const orManual = Array.isArray(data.openrouterManual) ? data.openrouterManual : []
+    openrouterCurated = new Set(orManual.map(m => m.id))
+    const manualGroups = [document.getElementById('openrouterManualGroup'), document.getElementById('agentModelOpenrouterManualGroup')]
+    for (const g of manualGroups) {
+      if (!g) continue
+      g.innerHTML = ''
+      if (orManual.length === 0) { g.style.display = 'none'; continue }
+      g.style.display = ''
+      for (const m of orManual) {
+        const opt = document.createElement('option')
+        opt.value = m.id
+        opt.textContent = `🔀 ${m.name || m.id}`
+        g.appendChild(opt)
+      }
+    }
+    // Browse popup = the curation UI (tick/untick which manual models exist).
+    // MAIN AGENT ONLY -- sub-agents just pick from the curated dropdown above.
     const orBtn = document.getElementById('openrouterBrowseBtn')
-    if (orBtn) orBtn.style.display = data.openrouterConfigured ? '' : 'none'
+    if (orBtn) orBtn.style.display = (data.openrouterConfigured && currentAgent && currentAgent.role === 'main') ? '' : 'none'
   } catch { /* dashboard not available */ }
 }
 
-// --- OpenRouter manual model picker (browse all ~340 models) ---
+// --- OpenRouter manual-list curation (tick models into the shared dropdown) ---
 let openrouterAllModels = null
+let openrouterCurated = new Set()  // ids currently in the curated manual list
 
 async function openOpenrouterModal() {
   const modal = document.getElementById('openrouterModal')
@@ -3405,11 +3424,20 @@ async function openOpenrouterModal() {
   if (searchEl) searchEl.value = ''
   if (freeEl) freeEl.checked = false
   try {
-    if (!openrouterAllModels) {
-      const res = await fetch('/api/openrouter/models')
-      if (!res.ok) throw new Error('fetch failed')
-      const data = await res.json()
+    // Load the full model list (cached) and the current curated set in parallel
+    // so the checkboxes render already ticked for the manual models in the list.
+    const [allRes, curRes] = await Promise.all([
+      openrouterAllModels ? Promise.resolve(null) : fetch('/api/openrouter/models'),
+      fetch('/api/openrouter/manual'),
+    ])
+    if (allRes) {
+      if (!allRes.ok) throw new Error('fetch failed')
+      const data = await allRes.json()
       openrouterAllModels = Array.isArray(data.models) ? data.models : []
+    }
+    if (curRes && curRes.ok) {
+      const cur = await curRes.json()
+      openrouterCurated = new Set((Array.isArray(cur.models) ? cur.models : []).map(m => m.id))
     }
     renderOpenrouterList()
   } catch {
@@ -3428,41 +3456,66 @@ function renderOpenrouterList() {
     if (!q) return true
     return (m.id + ' ' + m.name).toLowerCase().includes(q)
   })
-  if (countEl) countEl.textContent = `${rows.length} modell`
+  // Ticked (curated) models float to the top so the current selection is visible.
+  rows.sort((a, b) => {
+    const ca = openrouterCurated.has(a.id), cb = openrouterCurated.has(b.id)
+    if (ca !== cb) return ca ? -1 : 1
+    return a.id.localeCompare(b.id)
+  })
+  if (countEl) countEl.textContent = `${rows.length} modell · ${openrouterCurated.size} kézi listán`
   listEl.innerHTML = ''
   for (const m of rows.slice(0, 400)) {
-    const row = document.createElement('div')
+    const checked = openrouterCurated.has(m.id)
+    const row = document.createElement('label')
     row.className = 'openrouter-model-row'
-    row.style.cssText = 'padding:8px 10px;border-bottom:1px solid var(--border);cursor:pointer;font-size:13px'
+    row.style.cssText = 'display:flex;align-items:flex-start;gap:10px;padding:8px 10px;border-bottom:1px solid var(--border);cursor:pointer;font-size:13px'
     const price = m.free ? '<span style="color:var(--success,#16a34a);font-weight:600">ingyenes</span>'
       : `$${m.promptPrice.toFixed(2)}/$${m.completionPrice.toFixed(2)} /M`
     const ctx = m.contextLength ? ` · ${Math.round(m.contextLength / 1000)}k ctx` : ''
-    row.innerHTML = `<div style="font-weight:600">${escapeHtml(m.name)}</div>`
+    const cb = document.createElement('input')
+    cb.type = 'checkbox'
+    cb.checked = checked
+    cb.style.cssText = 'margin-top:3px;flex:0 0 auto'
+    cb.addEventListener('change', () => toggleCuratedModel(m.id, m.name, cb.checked))
+    const info = document.createElement('div')
+    info.style.cssText = 'flex:1 1 auto;min-width:0'
+    info.innerHTML = `<div style="font-weight:600">${escapeHtml(m.name)}</div>`
       + `<div style="color:var(--text-muted);font-size:11.5px"><code>${escapeHtml(m.id)}</code> · ${price}${ctx}</div>`
+    row.appendChild(cb)
+    row.appendChild(info)
     row.addEventListener('mouseenter', () => { row.style.background = 'var(--surface-hover, #f1f5f9)' })
     row.addEventListener('mouseleave', () => { row.style.background = '' })
-    row.addEventListener('click', () => selectOpenrouterModel(m.id))
     listEl.appendChild(row)
   }
   if (rows.length === 0) listEl.innerHTML = '<div style="padding:14px;color:var(--text-muted);font-size:13px">Nincs találat.</div>'
 }
 
-function selectOpenrouterModel(id) {
-  const sel = document.getElementById('editAgentModel')
-  if (sel) {
-    // Ensure the chosen id exists as an option, then select it.
-    let opt = Array.from(sel.options).find(o => o.value === id)
-    if (!opt) {
-      opt = document.createElement('option')
-      opt.value = id
-      opt.className = 'dynamic-model-opt'
-      opt.textContent = `🔀 ${id}`
-      sel.appendChild(opt)
-    }
-    sel.value = id
-    sel.dispatchEvent(new Event('change'))
+// Tick/untick a model into the curated manual list. Persists server-side, then
+// refreshes the shared dropdown so the "kézi" optgroup reflects the change.
+async function toggleCuratedModel(id, name, checked) {
+  // Optimistic local update so the checkbox + counter feel instant.
+  if (checked) openrouterCurated.add(id); else openrouterCurated.delete(id)
+  const countEl = document.getElementById('openrouterModalCount')
+  if (countEl) {
+    const total = countEl.textContent.split('·')[0].trim()
+    countEl.textContent = `${total} · ${openrouterCurated.size} kézi listán`
   }
-  closeOpenrouterModal()
+  try {
+    const res = await fetch('/api/openrouter/manual', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, name, checked }),
+    })
+    if (!res.ok) throw new Error('save failed')
+    const data = await res.json()
+    openrouterCurated = new Set((Array.isArray(data.models) ? data.models : []).map(m => m.id))
+    // Repopulate the dropdown "kézi" optgroups without disturbing selections.
+    loadAvailableModels()
+  } catch {
+    // Roll back the optimistic change on failure.
+    if (checked) openrouterCurated.delete(id); else openrouterCurated.add(id)
+    renderOpenrouterList()
+  }
 }
 
 function closeOpenrouterModal() {

--- a/web/app.js
+++ b/web/app.js
@@ -3378,7 +3378,11 @@ async function openOpenrouterModal() {
   const freeEl = document.getElementById('openrouterModalFreeOnly')
   if (!modal || !listEl) return
   if (agentEl) agentEl.textContent = (currentAgent && (currentAgent.displayName || currentAgent.name)) || 'ágens'
+  // Two competing .modal-overlay CSS rules: one hides via [hidden], the other
+  // via opacity/visibility (toggled by .active). Set both so the modal shows
+  // regardless of which rule wins the cascade.
   modal.hidden = false
+  modal.classList.add('active')
   listEl.innerHTML = '<div style="padding:14px;color:var(--text-muted);font-size:13px">Modellek betöltése…</div>'
   if (searchEl) searchEl.value = ''
   if (freeEl) freeEl.checked = false
@@ -3439,13 +3443,17 @@ function selectOpenrouterModel(id) {
     sel.value = id
     sel.dispatchEvent(new Event('change'))
   }
+  closeOpenrouterModal()
+}
+
+function closeOpenrouterModal() {
   const modal = document.getElementById('openrouterModal')
-  if (modal) modal.hidden = true
+  if (modal) { modal.hidden = true; modal.classList.remove('active') }
 }
 
 document.getElementById('openrouterBrowseBtn')?.addEventListener('click', openOpenrouterModal)
-document.getElementById('openrouterModalClose')?.addEventListener('click', () => { document.getElementById('openrouterModal').hidden = true })
-document.getElementById('openrouterModalCancel')?.addEventListener('click', () => { document.getElementById('openrouterModal').hidden = true })
+document.getElementById('openrouterModalClose')?.addEventListener('click', closeOpenrouterModal)
+document.getElementById('openrouterModalCancel')?.addEventListener('click', closeOpenrouterModal)
 document.getElementById('openrouterModalSearch')?.addEventListener('input', renderOpenrouterList)
 document.getElementById('openrouterModalFreeOnly')?.addEventListener('change', renderOpenrouterList)
 

--- a/web/app.js
+++ b/web/app.js
@@ -3339,6 +3339,41 @@ async function loadAvailableModels() {
       }
     }
     if (hint) hint.style.display = deepseekModels.length === 0 ? 'block' : 'none'
+
+    // OpenRouter: two optgroups per select (Auto = weekly-fresh tier
+    // recommendation, value `openrouter-auto:<tier>`; Manual = the 2 concrete
+    // ids per tier). Backend gates the whole block behind the vault key, so a
+    // null payload means OpenRouter is not connected -> keep the groups hidden.
+    const or = data.openrouter
+    const autoGroups = [document.getElementById('openrouterAutoGroup'), document.getElementById('agentModelOpenrouterAutoGroup')]
+    const manualGroups = [document.getElementById('openrouterManualGroup'), document.getElementById('agentModelOpenrouterManualGroup')]
+    const orTiers = or && Array.isArray(or.tiers) ? or.tiers : []
+    for (const g of autoGroups) {
+      if (!g) continue
+      g.innerHTML = ''
+      if (orTiers.length === 0) { g.style.display = 'none'; continue }
+      g.style.display = ''
+      for (const t of orTiers) {
+        const opt = document.createElement('option')
+        opt.value = t.autoId
+        opt.textContent = `${t.label} — auto (${t.auto})`
+        g.appendChild(opt)
+      }
+    }
+    for (const g of manualGroups) {
+      if (!g) continue
+      g.innerHTML = ''
+      if (orTiers.length === 0) { g.style.display = 'none'; continue }
+      g.style.display = ''
+      for (const t of orTiers) {
+        for (const mid of (Array.isArray(t.manual) ? t.manual : [])) {
+          const opt = document.createElement('option')
+          opt.value = mid
+          opt.textContent = `${t.label.replace(/ —.*/, '')}: ${mid}`
+          g.appendChild(opt)
+        }
+      }
+    }
   } catch { /* dashboard not available */ }
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -3376,11 +3376,11 @@ async function loadAvailableModels() {
       for (const t of orTiers) {
         const opt = document.createElement('option')
         opt.value = t.autoId
-        opt.textContent = `${t.label} — auto (${t.auto})`
+        opt.textContent = `${t.label} - auto (${t.auto})`
         g.appendChild(opt)
       }
     }
-    // Manual = the user-curated list -> "OpenRouter — kézi" optgroup in every
+    // Manual = the user-curated list -> "OpenRouter - kézi" optgroup in every
     // select. Curated once (main agent's browse popup, checkboxes); assignable
     // per agent here. Empty list -> group hidden.
     const orManual = Array.isArray(data.openrouterManual) ? data.openrouterManual : []

--- a/web/index.html
+++ b/web/index.html
@@ -2107,6 +2107,10 @@
               </optgroup>
               <optgroup label="🌊 DeepSeek (alternatív)" id="agentModelDeepseekGroup">
               </optgroup>
+              <optgroup label="🔀 OpenRouter — Auto (heti frissítésű ajánlott)" id="agentModelOpenrouterAutoGroup" style="display:none">
+              </optgroup>
+              <optgroup label="🔀 OpenRouter — Kézi (tierenként)" id="agentModelOpenrouterManualGroup" style="display:none">
+              </optgroup>
             </select>
           </div>
           <div class="form-group">
@@ -2260,6 +2264,10 @@
                 <option value="claude-haiku-4-5-20251001" data-i18n="agents.model.haiku45">Haiku 4.5 (leggyorsabb)</option>
               </optgroup>
               <optgroup label="🌊 DeepSeek (alternatív)" id="deepseekModelGroup">
+              </optgroup>
+              <optgroup label="🔀 OpenRouter — Auto (heti frissítésű ajánlott)" id="openrouterAutoGroup" style="display:none">
+              </optgroup>
+              <optgroup label="🔀 OpenRouter — Kézi (tierenként)" id="openrouterManualGroup" style="display:none">
               </optgroup>
               <optgroup label="🏠 Ollama (lokális)" id="ollamaModelGroup">
               </optgroup>

--- a/web/index.html
+++ b/web/index.html
@@ -807,6 +807,25 @@
         </div>
       </div>
 
+      <div class="modal-overlay" id="openrouterModal" hidden>
+        <div class="modal-content" style="max-width:660px">
+          <div class="modal-header">
+            <h3>🔀 OpenRouter modell (kézi)</h3>
+            <button class="modal-close" id="openrouterModalClose">&times;</button>
+          </div>
+          <div class="modal-body">
+            <p class="modal-desc">Válassz bármelyik OpenRouter modellt (<span id="openrouterModalAgent"></span>). A kiválasztás a modell-mezőbe kerül; utána Mentés + restart.</p>
+            <input type="text" id="openrouterModalSearch" placeholder="Keresés: név, provider, id..." style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--text);margin-bottom:8px">
+            <label style="font-size:12px;color:var(--text-muted);display:flex;align-items:center;gap:6px;margin-bottom:8px"><input type="checkbox" id="openrouterModalFreeOnly"> Csak ingyenes (:free)</label>
+            <div id="openrouterModalCount" style="font-size:11px;color:var(--text-muted);margin-bottom:4px"></div>
+            <div id="openrouterModalList" style="max-height:340px;overflow-y:auto;border:1px solid var(--border);border-radius:6px"></div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn-secondary" id="openrouterModalCancel">Mégse</button>
+          </div>
+        </div>
+      </div>
+
       <!-- Gallery tab -->
       <div class="connector-tab-content" id="connectorGalleryTab" hidden>
         <div class="catalog-filters" id="catalogFilters">
@@ -2109,8 +2128,6 @@
               </optgroup>
               <optgroup label="🔀 OpenRouter — Auto (heti frissítésű ajánlott)" id="agentModelOpenrouterAutoGroup" style="display:none">
               </optgroup>
-              <optgroup label="🔀 OpenRouter — Kézi (tierenként)" id="agentModelOpenrouterManualGroup" style="display:none">
-              </optgroup>
             </select>
           </div>
           <div class="form-group">
@@ -2267,13 +2284,12 @@
               </optgroup>
               <optgroup label="🔀 OpenRouter — Auto (heti frissítésű ajánlott)" id="openrouterAutoGroup" style="display:none">
               </optgroup>
-              <optgroup label="🔀 OpenRouter — Kézi (tierenként)" id="openrouterManualGroup" style="display:none">
-              </optgroup>
               <optgroup label="🏠 Ollama (lokális)" id="ollamaModelGroup">
               </optgroup>
             </select>
             <button class="btn-secondary btn-compact agent-save-section" id="saveModelBtn" data-i18n="common.btn.save">Mentés</button>
             <button class="btn-secondary btn-compact" id="modelSuggestBtn" style="margin-left:6px" data-i18n="agents.settings.model_suggest_btn">Javaslat</button>
+            <button class="btn-secondary btn-compact" id="openrouterBrowseBtn" style="margin-left:6px;display:none" title="Válassz bármelyik OpenRouter modellt (kézi)">🔀 OpenRouter</button>
             <small id="deepseekHint" style="display:none;margin-top:6px;color:var(--text-muted);font-size:12px;line-height:1.4">
               <span data-i18n="agents.deepseek_hint_pre">DeepSeek-V4-Pro nincs konfigurálva.</span> <a href="#" id="deepseekConfigLink" data-i18n="agents.deepseek_link">API kulcs hozzáadása</a> <span data-i18n="agents.deepseek_hint_post">a Vault oldalon.</span>
             </small>

--- a/web/index.html
+++ b/web/index.html
@@ -814,7 +814,7 @@
             <button class="modal-close" id="openrouterModalClose">&times;</button>
           </div>
           <div class="modal-body">
-            <p class="modal-desc">Pipáld be azokat a modelleket, amelyek megjelenjenek a legördülő "OpenRouter — kézi" csoportjában (minden ágensnél választható lesz). A pipa levétele lekerül a listáról. A hozzárendelést utána ágensenként a legördülőben végzed.</p>
+            <p class="modal-desc">Pipáld be azokat a modelleket, amelyek megjelenjenek a legördülő "OpenRouter - kézi" csoportjában (minden ágensnél választható lesz). A pipa levétele lekerül a listáról. A hozzárendelést utána ágensenként a legördülőben végzed.</p>
             <input type="text" id="openrouterModalSearch" placeholder="Keresés: név, provider, id..." style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--text);margin-bottom:8px">
             <label style="font-size:12px;color:var(--text-muted);display:flex;align-items:center;gap:6px;margin-bottom:8px"><input type="checkbox" id="openrouterModalFreeOnly"> Csak ingyenes (:free)</label>
             <div id="openrouterModalCount" style="font-size:11px;color:var(--text-muted);margin-bottom:4px"></div>
@@ -2126,9 +2126,9 @@
               </optgroup>
               <optgroup label="🌊 DeepSeek (alternatív)" id="agentModelDeepseekGroup">
               </optgroup>
-              <optgroup label="🔀 OpenRouter — Auto (heti frissítésű ajánlott)" id="agentModelOpenrouterAutoGroup" style="display:none">
+              <optgroup label="🔀 OpenRouter - Auto (heti frissítésű ajánlott)" id="agentModelOpenrouterAutoGroup" style="display:none">
               </optgroup>
-              <optgroup label="🔀 OpenRouter — kézi" id="agentModelOpenrouterManualGroup" style="display:none">
+              <optgroup label="🔀 OpenRouter - kézi" id="agentModelOpenrouterManualGroup" style="display:none">
               </optgroup>
             </select>
           </div>
@@ -2284,9 +2284,9 @@
               </optgroup>
               <optgroup label="🌊 DeepSeek (alternatív)" id="deepseekModelGroup">
               </optgroup>
-              <optgroup label="🔀 OpenRouter — Auto (heti frissítésű ajánlott)" id="openrouterAutoGroup" style="display:none">
+              <optgroup label="🔀 OpenRouter - Auto (heti frissítésű ajánlott)" id="openrouterAutoGroup" style="display:none">
               </optgroup>
-              <optgroup label="🔀 OpenRouter — kézi" id="openrouterManualGroup" style="display:none">
+              <optgroup label="🔀 OpenRouter - kézi" id="openrouterManualGroup" style="display:none">
               </optgroup>
               <optgroup label="🏠 Ollama (lokális)" id="ollamaModelGroup">
               </optgroup>

--- a/web/index.html
+++ b/web/index.html
@@ -810,18 +810,18 @@
       <div class="modal-overlay" id="openrouterModal" hidden>
         <div class="modal-content" style="max-width:660px">
           <div class="modal-header">
-            <h3>🔀 OpenRouter modell (kézi)</h3>
+            <h3>🔀 OpenRouter kézi modellek</h3>
             <button class="modal-close" id="openrouterModalClose">&times;</button>
           </div>
           <div class="modal-body">
-            <p class="modal-desc">Válassz bármelyik OpenRouter modellt (<span id="openrouterModalAgent"></span>). A kiválasztás a modell-mezőbe kerül; utána Mentés + restart.</p>
+            <p class="modal-desc">Pipáld be azokat a modelleket, amelyek megjelenjenek a legördülő "OpenRouter — kézi" csoportjában (minden ágensnél választható lesz). A pipa levétele lekerül a listáról. A hozzárendelést utána ágensenként a legördülőben végzed.</p>
             <input type="text" id="openrouterModalSearch" placeholder="Keresés: név, provider, id..." style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--text);margin-bottom:8px">
             <label style="font-size:12px;color:var(--text-muted);display:flex;align-items:center;gap:6px;margin-bottom:8px"><input type="checkbox" id="openrouterModalFreeOnly"> Csak ingyenes (:free)</label>
             <div id="openrouterModalCount" style="font-size:11px;color:var(--text-muted);margin-bottom:4px"></div>
             <div id="openrouterModalList" style="max-height:340px;overflow-y:auto;border:1px solid var(--border);border-radius:6px"></div>
           </div>
           <div class="modal-footer">
-            <button class="btn-secondary" id="openrouterModalCancel">Mégse</button>
+            <button class="btn-secondary" id="openrouterModalCancel">Kész</button>
           </div>
         </div>
       </div>
@@ -2128,6 +2128,8 @@
               </optgroup>
               <optgroup label="🔀 OpenRouter — Auto (heti frissítésű ajánlott)" id="agentModelOpenrouterAutoGroup" style="display:none">
               </optgroup>
+              <optgroup label="🔀 OpenRouter — kézi" id="agentModelOpenrouterManualGroup" style="display:none">
+              </optgroup>
             </select>
           </div>
           <div class="form-group">
@@ -2284,12 +2286,14 @@
               </optgroup>
               <optgroup label="🔀 OpenRouter — Auto (heti frissítésű ajánlott)" id="openrouterAutoGroup" style="display:none">
               </optgroup>
+              <optgroup label="🔀 OpenRouter — kézi" id="openrouterManualGroup" style="display:none">
+              </optgroup>
               <optgroup label="🏠 Ollama (lokális)" id="ollamaModelGroup">
               </optgroup>
             </select>
             <button class="btn-secondary btn-compact agent-save-section" id="saveModelBtn" data-i18n="common.btn.save">Mentés</button>
             <button class="btn-secondary btn-compact" id="modelSuggestBtn" style="margin-left:6px" data-i18n="agents.settings.model_suggest_btn">Javaslat</button>
-            <button class="btn-secondary btn-compact" id="openrouterBrowseBtn" style="margin-left:6px;display:none" title="Válassz bármelyik OpenRouter modellt (kézi)">🔀 OpenRouter</button>
+            <button class="btn-secondary btn-compact" id="openrouterBrowseBtn" style="margin-left:6px;display:none" title="Kézi OpenRouter modellek listájának szerkesztése (pipával)">🔀 OpenRouter kézi lista</button>
             <small id="deepseekHint" style="display:none;margin-top:6px;color:var(--text-muted);font-size:12px;line-height:1.4">
               <span data-i18n="agents.deepseek_hint_pre">DeepSeek-V4-Pro nincs konfigurálva.</span> <a href="#" id="deepseekConfigLink" data-i18n="agents.deepseek_link">API kulcs hozzáadása</a> <span data-i18n="agents.deepseek_hint_post">a Vault oldalon.</span>
             </small>


### PR DESCRIPTION
## Summary
Lets fleet agents run on **OpenRouter** models, alongside the existing Claude / DeepSeek / Ollama options. OpenRouter exposes an Anthropic-compatible Messages endpoint, so the launcher just points `ANTHROPIC_BASE_URL` at it with the fleet key — **no LiteLLM/proxy**, mirroring the DeepSeek branch.

Two selection modes in the dashboard:
- **Auto** — the agent stores `openrouter-auto:<tier>`; resolved at launch to the tier's currently-recommended model, so a weekly research task can keep the fleet on the best model with no per-agent reconfig.
- **Manual (curated)** — the main agent curates a shared list of concrete OpenRouter models via checkboxes; the ticked set appears as an "OpenRouter — kézi" optgroup in every agent's model dropdown.

## Backend
- `src/web/openrouter-models.ts` (new): tiered catalog + `resolveOpenRouterModel()` (auto→concrete), full-model-list fetch (public `/models`, 6h cache), and the curated-manual store (`loadCuratedManual`/`add`/`remove`).
- `src/web/agent-process.ts`: provider switch adds OpenRouter (model id contains `/`) — sets `ANTHROPIC_BASE_URL=https://openrouter.ai/api` + `ANTHROPIC_MODEL` + the fleet key. Ollama branch now excludes it.
- `src/web/routes/agents.ts`: `/api/models/available` gains an `openrouter` group + `openrouterManual`; adds `GET /api/openrouter/models` (browse-all) and `GET|POST /api/openrouter/manual` (curated list). All gated behind the `openrouter-fleet-key` vault secret — the options never surface without a key (so no model that 401s on first prompt).

## Frontend (`web/app.js`, `web/index.html`)
- Auto optgroups in both the wizard and edit selects.
- A main-agent-only "OpenRouter kézi lista" browse button opening a searchable modal over all ~340 models, each with a checkbox; ticking curates it into the shared dropdown, unticking removes it. Curation (main agent) is deliberately separate from assignment (per agent).
- Robustness fixes folded in: modal `.active` cascade + reparent-to-body (it lived in a hidden tab), and per-agent model display in the shared picker.

## Gating / safety
- Entire feature is invisible without the `openrouter-fleet-key` secret.
- Curation is main-agent-only in the UI; sub-agents only pick from the curated dropdown.

## Test (live, via CDP)
- Modal renders ~344 checkboxes; ticking persists to the store and populates the dropdown "kézi" group; unticking removes it.
- Browse button shows on the main agent's Settings tab, hidden for sub-agents.
- `tsc` clean on top of `develop`.

## Notes
Kept deliberately separate from the unrelated fixes in flight (memory `accessed_at` #650, main-agent model-display #651) — this branch is OpenRouter-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)