### PR TITLE
fix(context-guard): always-on saturation net -- rescue 100%-context wedged agents

### DIFF
--- a/src/__tests__/context-guard.test.ts
+++ b/src/__tests__/context-guard.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CONTEXT_GUARD,
   INITIAL_GUARD_STATE,
   READY_TIMEOUT_MS,
+  SATURATION_CONFIRM_SWEEPS,
   type ContextGuardConfig,
   type GuardInputs,
   type GuardState,
@@ -25,6 +26,7 @@ function inputs(overrides: Partial<GuardInputs> = {}): GuardInputs {
     paneIdle: true,
     sessionReady: false,
     handoffMtime: null,
+    paneSaturated: false,
     ...overrides,
   }
 }
@@ -92,10 +94,97 @@ describe('decideGuard: idle', () => {
     expect(d.nextState.phase).toBe('await-ready')
   })
 
-  it('resets to initial state when disabled', () => {
-    const disabled = { ...CFG, enabled: false }
-    const stale: GuardState = { phase: 'await-handoff', handoffMtimeAtRequest: 1, deadlineMs: 2, cooldownUntilMs: 0 }
-    const d = decideGuard(stale, inputs({ pct: 0.99 }), disabled)
+  it('resets to initial state when fully disarmed (guard + net off)', () => {
+    const disarmed = { ...CFG, enabled: false, saturationRestart: false }
+    const stale: GuardState = { phase: 'await-handoff', handoffMtimeAtRequest: 1, deadlineMs: 2, cooldownUntilMs: 0, saturatedStreak: 0 }
+    const d = decideGuard(stale, inputs({ pct: 0.99, paneSaturated: true }), disarmed)
+    expect(d.action).toBe('none')
+    expect(d.nextState).toEqual(INITIAL_GUARD_STATE)
+  })
+
+  it('stands down a stale await-handoff into cooldown when the guard is disabled mid-sequence', () => {
+    const netOnly = { ...CFG, enabled: false }
+    const stale: GuardState = { phase: 'await-handoff', handoffMtimeAtRequest: 1, deadlineMs: 2, cooldownUntilMs: 0, saturatedStreak: 0 }
+    const d = decideGuard(stale, inputs({ pct: 0.99 }), netOnly)
+    expect(d.action).toBe('none')
+    expect(d.nextState.phase).toBe('cooldown')
+  })
+})
+
+describe('saturation net (samu 2026-07-18 stall)', () => {
+  // A saturated pane refuses prompt dispatch, so Claude Code's next-turn
+  // auto-compact can never run: only an external fresh restart recovers it.
+  const netOnly: ContextGuardConfig = { ...DEFAULT_CONTEXT_GUARD } // enabled:false, saturationRestart:true
+
+  it('is armed by default and survives garbage config', () => {
+    expect(DEFAULT_CONTEXT_GUARD.saturationRestart).toBe(true)
+    expect(normalizeContextGuardConfig(null).saturationRestart).toBe(true)
+    expect(normalizeContextGuardConfig({ saturationRestart: 0 }).saturationRestart).toBe(true)
+    expect(normalizeContextGuardConfig({ saturationRestart: false }).saturationRestart).toBe(false)
+  })
+
+  it('restarts a saturated pane after the confirmation sweep, even with the proactive guard off and pct null', () => {
+    let state = INITIAL_GUARD_STATE
+    for (let sweep = 1; sweep < SATURATION_CONFIRM_SWEEPS; sweep++) {
+      const d = decideGuard(state, inputs({ paneSaturated: true }), netOnly)
+      expect(d.action).toBe('none')
+      expect(d.nextState.saturatedStreak).toBe(sweep)
+      state = d.nextState
+    }
+    const final = decideGuard(state, inputs({ paneSaturated: true }), netOnly)
+    expect(final.action).toBe('restart')
+    expect(final.reason).toContain('saturated')
+    expect(final.nextState.phase).toBe('await-ready')
+  })
+
+  it('clears the streak when the pane recovers before confirmation', () => {
+    const first = decideGuard(INITIAL_GUARD_STATE, inputs({ paneSaturated: true }), netOnly)
+    expect(first.nextState.saturatedStreak).toBe(1)
+    const second = decideGuard(first.nextState, inputs({ paneSaturated: false }), netOnly)
+    expect(second.action).toBe('none')
+    expect(second.nextState.saturatedStreak).toBe(0)
+  })
+
+  it('outranks the proactive tiers when both would fire (no handoff request into a dead pane)', () => {
+    const state: GuardState = { ...INITIAL_GUARD_STATE, saturatedStreak: SATURATION_CONFIRM_SWEEPS - 1 }
+    const d = decideGuard(state, inputs({ pct: 0.91, paneSaturated: true }), CFG)
+    expect(d.action).toBe('restart')
+  })
+
+  it('restarts without debounce when saturation appears during await-handoff', () => {
+    const awaiting: GuardState = {
+      phase: 'await-handoff',
+      handoffMtimeAtRequest: 100,
+      deadlineMs: NOW + 60_000,
+      cooldownUntilMs: 0,
+      saturatedStreak: 0,
+    }
+    const d = decideGuard(awaiting, inputs({ paneSaturated: true, paneIdle: false }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toContain('saturated')
+  })
+
+  it('does nothing for a saturated pane when the net is explicitly disarmed', () => {
+    const disarmed = { ...DEFAULT_CONTEXT_GUARD, saturationRestart: false }
+    const d = decideGuard(INITIAL_GUARD_STATE, inputs({ paneSaturated: true }), disarmed)
+    expect(d.action).toBe('none')
+  })
+
+  it('respects cooldown after a net restart (no restart loop)', () => {
+    const cooling: GuardState = {
+      phase: 'cooldown',
+      handoffMtimeAtRequest: null,
+      deadlineMs: 0,
+      cooldownUntilMs: NOW + 60_000,
+      saturatedStreak: 0,
+    }
+    const d = decideGuard(cooling, inputs({ paneSaturated: true }), netOnly)
+    expect(d.action).toBe('none')
+    expect(d.nextState.phase).toBe('cooldown')
+  })
+
+  it('does not touch a stopped agent', () => {
+    const d = decideGuard(INITIAL_GUARD_STATE, inputs({ paneSaturated: true, running: false }), netOnly)
     expect(d.action).toBe('none')
     expect(d.nextState).toEqual(INITIAL_GUARD_STATE)
   })
@@ -107,6 +196,7 @@ describe('decideGuard: await-handoff', () => {
     handoffMtimeAtRequest: 100,
     deadlineMs: NOW + 60_000,
     cooldownUntilMs: 0,
+    saturatedStreak: 0,
   }
 
   it('restarts once the handoff is written and the pane is idle', () => {
@@ -158,6 +248,7 @@ describe('decideGuard: await-ready', () => {
     handoffMtimeAtRequest: null,
     deadlineMs: NOW + 60_000,
     cooldownUntilMs: 0,
+    saturatedStreak: 0,
   }
 
   it('injects the resume prompt when the session is ready, then cools down', () => {
@@ -186,6 +277,7 @@ describe('decideGuard: cooldown', () => {
     handoffMtimeAtRequest: null,
     deadlineMs: 0,
     cooldownUntilMs: NOW + 60_000,
+    saturatedStreak: 0,
   }
 
   it('suppresses everything during cooldown, even a huge pct', () => {

--- a/src/context-guard.ts
+++ b/src/context-guard.ts
@@ -11,13 +11,29 @@
 // it force-restarts anyway -- taskstate + kanban + hot memories are the
 // fallback context.
 //
+// On top of the (opt-in) proactive tiers sits an ALWAYS-ON saturation net:
+// once a pane reads "100% context used", prompt dispatch refuses it and the
+// in-TUI auto-compact -- which only runs when a new turn starts -- can never
+// fire, so without external action the agent is wedged forever (samu,
+// 2026-07-18). The net fresh-restarts such a pane after a confirmation sweep.
+//
 // This module is dependency-free (no clock, tmux, or fs) so the state machine
 // is unit-testable. The I/O lives in src/web/context-guard-runner.ts.
 
 export interface ContextGuardConfig {
-  /** Master toggle. Default FALSE: the guard is opt-in per agent, so it never
-   *  double-restarts against the existing context-clean path (#525). */
+  /** Master toggle for the PROACTIVE tiers (actPct handoff / hardPct restart).
+   *  Default FALSE: opt-in per agent. (The original rationale -- avoiding a
+   *  double-restart against the #525 context-clean path -- is moot, #525 was
+   *  closed unmerged; the toggle stays because a proactive handoff/restart
+   *  cycle remains an operator choice.) */
   enabled: boolean
+  /** Saturation safety net: fresh-restart an agent whose pane shows "100%
+   *  context used". Default TRUE and independent of `enabled`, because a
+   *  saturated pane can NEVER recover on its own: prompt dispatch refuses it
+   *  (isSessionReadyForPrompt), so Claude Code's next-turn auto-compact never
+   *  gets a turn to run in -- a pull-model deadlock (samu, 2026-07-18: 34h
+   *  session wedged at 976k tokens, 20k+ dispatch refusals, zero compacts). */
+  saturationRestart: boolean
   /** Context fraction at which the handoff sequence starts. */
   actPct: number
   /** Context fraction at which we stop waiting for anything and force a fresh
@@ -34,6 +50,7 @@ export interface ContextGuardConfig {
 
 export const DEFAULT_CONTEXT_GUARD: ContextGuardConfig = {
   enabled: false,
+  saturationRestart: true,
   actPct: 0.90,
   hardPct: 0.97,
   limitTokens: null,
@@ -57,6 +74,7 @@ export function normalizeContextGuardConfig(raw: unknown): ContextGuardConfig {
   }
   return {
     enabled: o.enabled === true, // default-off (opt-in): only an explicit true enables
+    saturationRestart: o.saturationRestart !== false, // default-ON: only an explicit false disarms the net
     actPct,
     hardPct,
     limitTokens,
@@ -102,6 +120,8 @@ export interface GuardState {
   deadlineMs: number
   /** cooldown → when the guard re-arms. */
   cooldownUntilMs: number
+  /** Consecutive idle-phase sweeps that saw a saturated pane (debounce). */
+  saturatedStreak: number
 }
 
 export const INITIAL_GUARD_STATE: GuardState = {
@@ -109,7 +129,15 @@ export const INITIAL_GUARD_STATE: GuardState = {
   handoffMtimeAtRequest: null,
   deadlineMs: 0,
   cooldownUntilMs: 0,
+  saturatedStreak: 0,
 }
+
+/** Idle-phase sweeps that must agree the pane is saturated before the net
+ *  restarts (one sweep apart, so ~one runner interval of extra latency). A
+ *  genuinely saturated pane stays saturated forever; anything transient --
+ *  a scrollback quote scrolling through the footer region, a mid-render
+ *  frame -- clears by the next sweep. */
+export const SATURATION_CONFIRM_SWEEPS = 2
 
 export interface GuardInputs {
   nowMs: number
@@ -123,6 +151,8 @@ export interface GuardInputs {
   sessionReady: boolean
   /** Current HANDOFF.md mtime (ms), or null when the file does not exist. */
   handoffMtime: number | null
+  /** Pane footer shows context saturation ("100% context used" & co). */
+  paneSaturated: boolean
 }
 
 export type GuardActionType = 'none' | 'request-handoff' | 'restart' | 'inject-resume'
@@ -147,6 +177,7 @@ function cooldown(nowMs: number, cfg: ContextGuardConfig, reason: string): Guard
       handoffMtimeAtRequest: null,
       deadlineMs: 0,
       cooldownUntilMs: nowMs + cfg.cooldownMinutes * 60_000,
+      saturatedStreak: 0,
     },
   }
 }
@@ -160,6 +191,7 @@ function restartDecision(nowMs: number, reason: string): GuardDecision {
       handoffMtimeAtRequest: null,
       deadlineMs: nowMs + READY_TIMEOUT_MS,
       cooldownUntilMs: 0,
+      saturatedStreak: 0,
     },
   }
 }
@@ -177,7 +209,7 @@ export function decideGuard(
   const none = (reason: string, next: GuardState = state): GuardDecision =>
     ({ action: 'none', reason, nextState: next })
 
-  if (!cfg.enabled) return none('disabled', INITIAL_GUARD_STATE)
+  if (!cfg.enabled && !cfg.saturationRestart) return none('disabled', INITIAL_GUARD_STATE)
 
   switch (state.phase) {
     case 'cooldown': {
@@ -186,8 +218,20 @@ export function decideGuard(
     }
 
     case 'idle': {
-      if (!inputs.running) return none('not running')
-      if (inputs.pct === null) return none('context unmeasurable')
+      if (!inputs.running) return none('not running', INITIAL_GUARD_STATE)
+      // Saturation net first: it needs no pct (works even when the transcript
+      // is unreadable or the limit is miscalibrated) and outranks the
+      // proactive tiers -- a saturated pane is already past all of them.
+      if (cfg.saturationRestart && inputs.paneSaturated) {
+        const streak = state.saturatedStreak + 1
+        if (streak >= SATURATION_CONFIRM_SWEEPS) {
+          return restartDecision(nowMs, `pane saturated (100% context) for ${streak} sweeps -- unrecoverable without restart`)
+        }
+        return none('pane saturated, awaiting confirmation sweep', { ...state, saturatedStreak: streak })
+      }
+      const cleared = state.saturatedStreak > 0 ? { ...state, saturatedStreak: 0 } : state
+      if (!cfg.enabled) return none('proactive guard disabled (saturation net armed)', cleared)
+      if (inputs.pct === null) return none('context unmeasurable', cleared)
       if (inputs.pct >= cfg.hardPct) {
         // Deep in the danger zone: the pane may already be wedged behind an
         // error/modal, so do not spend a turn asking for a handoff.
@@ -202,17 +246,28 @@ export function decideGuard(
             handoffMtimeAtRequest: inputs.handoffMtime,
             deadlineMs: nowMs + cfg.handoffTimeoutMinutes * 60_000,
             cooldownUntilMs: 0,
+            saturatedStreak: 0,
           },
         }
       }
-      return none('below threshold')
+      return none('below threshold', cleared)
     }
 
     case 'await-handoff': {
+      if (!cfg.enabled) {
+        // Operator disabled the proactive guard mid-sequence; stand down.
+        return cooldown(nowMs, cfg, 'guard disabled during await-handoff')
+      }
       if (!inputs.running) {
         // Someone restarted/stopped the agent externally mid-sequence; a fresh
         // session has a small context, so stand down instead of restarting it.
         return cooldown(nowMs, cfg, 'agent stopped externally during await-handoff')
+      }
+      if (cfg.saturationRestart && inputs.paneSaturated) {
+        // The pane tipped over while we waited for the handoff: the agent can
+        // no longer act on the request, so restart now (no debounce -- the
+        // act-threshold pct already corroborates a near-full context).
+        return restartDecision(nowMs, 'pane saturated during await-handoff')
       }
       const handoffWritten =
         inputs.handoffMtime !== null &&
@@ -241,6 +296,7 @@ export function decideGuard(
             handoffMtimeAtRequest: null,
             deadlineMs: 0,
             cooldownUntilMs: nowMs + cfg.cooldownMinutes * 60_000,
+            saturatedStreak: 0,
           },
         }
       }

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1593,9 +1593,13 @@ export function captureParkedInputView(session: string, host: string | null = nu
 //
 // A saturated pane ("100% context used") is refused up front: it can present
 // as perfectly idle, so without this a new prompt would be dispatched into a
-// session that cannot act on it. We only log/audit the refusal here; how (or
-// whether) to recover the session is left to the caller / operator tooling, so
-// this predicate stays a pure, dependency-free readiness check.
+// session that cannot act on it. We only log/audit the refusal here; recovery
+// is the context-guard runner's saturation net (fresh restart -- see
+// src/web/context-guard-runner.ts), so this predicate stays a pure,
+// dependency-free readiness check. NOTE the refusal is part of a deadlock by
+// design: Claude Code's auto-compact only runs when a new turn starts, and
+// this refusal is exactly what prevents a new turn -- so a saturated session
+// never self-heals and MUST be restarted from outside.
 export async function isSessionReadyForPrompt(session: string, host: string | null = null): Promise<boolean> {
   // Dim-ghost tolerant idle read: CC >=2.1.202 paints a dim placeholder into
   // the empty input box, which a plain capture reads as parked text. Only when

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -13,7 +13,7 @@ import {
   isSessionReadyForPrompt,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-import { paneLooksIdle } from '../pane-state.js'
+import { paneLooksIdle, paneShowsContextSaturation } from '../pane-state.js'
 import { readContextTokensFromProjectDir, readActiveModelFromProjectDir } from './active-model.js'
 import { readContextGuardConfig } from './context-guard-store.js'
 import {
@@ -28,8 +28,11 @@ import {
 // Fleet context guard (kanban #81): acts BEFORE a session drowns in its own
 // context. Sweep every agent (main included) every five minutes; at actPct ask the
 // agent to write HANDOFF.md, then fresh-restart it and inject a resume prompt
-// pointing at the handoff. See src/context-guard.ts for the why and the pure
-// state machine; this module is only the I/O, mirroring auto-restart-runner.
+// pointing at the handoff. The always-on saturation net additionally rescues a
+// pane already showing "100% context used" -- unreachable by prompt dispatch,
+// so nothing else can recover it (samu stall, 2026-07-18). See
+// src/context-guard.ts for the why and the pure state machine; this module is
+// only the I/O, mirroring auto-restart-runner.
 //
 // Remote-host agents are skipped: their transcripts live on the remote machine,
 // so the context size cannot be measured here (v1 limitation, logged once).
@@ -114,7 +117,10 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
   const cfg = readContextGuardConfig(name)
   const state = guardStates.get(name) ?? INITIAL_GUARD_STATE
 
-  if (!cfg.enabled) {
+  // Fully disarmed only when BOTH the proactive tiers and the always-on
+  // saturation net are off; the net alone keeps the sweep alive so a
+  // 100%-context pane (which dispatch refuses to prompt) still gets rescued.
+  if (!cfg.enabled && !cfg.saturationRestart) {
     guardStates.delete(name)
     return
   }
@@ -142,10 +148,13 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
   const inputs: GuardInputs = {
     nowMs,
     running,
-    pct: running && needPct ? measurePct(name, cfg.limitTokens) : null,
+    // The saturation net decides from the pane alone; only the proactive
+    // tiers need the (transcript-reading) pct probe.
+    pct: running && needPct && cfg.enabled ? measurePct(name, cfg.limitTokens) : null,
     paneIdle: pane !== null ? paneLooksIdle(pane) : false,
     sessionReady,
     handoffMtime: needPct ? handoffMtime(name) : null,
+    paneSaturated: pane !== null ? paneShowsContextSaturation(pane) : false,
   }
 
   const decision = decideGuard(state, inputs, cfg)
@@ -180,6 +189,7 @@ export function getContextGuardStatus(): Array<{
   phase: string
   pct: number | null
   enabled: boolean
+  saturationRestart: boolean
 }> {
   const names = [MAIN_AGENT_ID, ...listAgentNames()]
   return names.map((name) => {
@@ -190,6 +200,7 @@ export function getContextGuardStatus(): Array<{
       phase: guardStates.get(name)?.phase ?? 'idle',
       pct: cfg.enabled && !remote ? measurePct(name, cfg.limitTokens) : null,
       enabled: cfg.enabled,
+      saturationRestart: cfg.saturationRestart,
     }
   })
 }


### PR DESCRIPTION
## Diagnózis (AUTOCOMPACT kártya)

**Gyökér-ok: pull-model deadlock, hipotézis A bizonyítva.**

1. A 34 órás agent-session kontextusa folyamatosan nőtt (~976k tokenig, fable-5, 1M ablak). Az utolsó turn normálisan lezárult, compact-esemény a TELJES sessionben nulla.
2. Ezután a pane '100% context used'-ot mutatott, és a dispatch minden injektálást megtagadott: `dispatch: refusing prompt -- session shows context saturation` percenként, 20 717 alkalommal a logban (`agent-process.ts isSessionReadyForPrompt`).
3. A Claude Code auto-compact CSAK új turn indulásakor fut. Új turn a refusal miatt soha nem indult. A védelem maga akadályozza meg a gyógyulást: chicken-and-egg, kézi restartig áll minden.
4. **Hipotézis B (PreCompact agent-hook blokkol) cáfolva**: compact el sem indult, a hook futási lehetőséget sem kapott. (Megjegyzés: a hook 92%+ kontextuson továbbra is kockázat, de nem ez volt az ok.)
5. A meglévő context-guard (#81/#552) 90%-nál pont ezt előzte volna meg, de **opt-in és senkinek nincs bekapcsolva** (store/context-guard.json nem létezik). A default-off indoka a #525 context-clean path volt, ami **mergeletlen zárult** -- az indok elavult.
6. Mellékes: a --continue-halmozódás channel-es agenteknél NEM áll fenn (azok mindig fresh-indulnak, agent-process.ts); itt egyetlen hosszú session telt be.

## Fix

Always-on **saturation net** a context-guard állapotgépben, az opt-in proaktív tier-ektől függetlenül:

- Ha egy futó agent pane-je 2 egymást követő sweepen (5 perces kadencia, tranziens frame-ek debounce-olva) szaturációt mutat -> `restartAgentProcess(name, {fresh:true})` + standard resume-prompt injektálás (kanban + hot memóriák a fallback kontextus). Main agentnél launchctl kickstart, mint eddig.
- Cooldown véd a restart-looptól; per-agent `saturationRestart:false` kikapcsolja.
- await-handoff közben megjelenő szaturáció debounce nélkül restartol (a pct már megerősítette a közel-teli kontextust).
- pct-mérés (transcript-olvasás) továbbra is csak enabled guardnál fut; a net a pane-ből dönt.

## Verifikáció

- `tsc --noEmit` clean
- 31/31 context-guard unit teszt zöld (8 új: default-arming, debounce+restart, streak-clear, precedencia, disarm, cooldown, stopped-agent, mid-sequence disable)
- Teljes suite: 2423 passed; a 13 fail (hook-path/email-gate/governance) clean develop-on is azonosan bukik /tmp worktree-ből futtatva (lokáció-érzékeny tesztek), nem regresszió

## Ajánlás merge után

A proaktív tier-ek (90% handoff + 97% hard restart) bekapcsolása a hosszan futó sub-agentekre (store/context-guard.json, `enabled:true`) -- a net a beragadást gyógyítja, a proaktív tier a kontextus-vesztést is minimalizálja (handoff-fal). Ez operátor-döntés, a PR nem változtat rajta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)