### PR TITLE
feat(costops): monitoring + financial operations + provenance-aware cost resolution (stacked on #628)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 
 # Secrets & personal data
 .env
+.env.backup*
+.env.*.backup
 store/
 workspace/
 agents/

--- a/src/__tests__/costops-alerts-capture.test.ts
+++ b/src/__tests__/costops-alerts-capture.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { monthWindow } from '../costops/ledger.js'
+import { initAlertsSchema } from '../costops/alerts.js'
+import { initInvoiceSchema } from '../costops/invoice.js'
+import {
+  classifyErrorCode,
+  gatherAlertCandidates,
+  captureAlerts,
+  listAlerts,
+} from '../costops/alerts-capture.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+
+// gatherAlertCandidates always queries costops_invoices (GAP-14's
+// missing_invoice signal) -- every test that exercises it needs the table,
+// same assumed-precondition convention as costops_alerts itself.
+function initDb(): void {
+  initDatabase(':memory:')
+  initInvoiceSchema(getDb())
+}
+
+function cfg(over: Partial<CostOpsConfig> = {}): CostOpsConfig {
+  return {
+    version: 1,
+    currency: 'HUF',
+    fixed_costs: [],
+    budgets: [
+      { id: 'global-monthly', name: 'Global', scope: 'global', amount: 1000, currency: 'HUF', warning_threshold: 0.8, hard_threshold: 1.0 },
+    ],
+    ...over,
+  }
+}
+
+function insertSource(db: ReturnType<typeof getDb>, id: string, provider: string, source_type = 'usage'): void {
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, ?, ?, 'HUF', 1, ?, ?)`).run(id, id, provider, source_type, NOW, NOW)
+}
+
+function insertLine(db: ReturnType<typeof getDb>, opts: {
+  source: string; start: number; end: number; amount: number; confidence: string
+  actualSource?: string | null; dedupKey: string
+}): void {
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, dedup_key, created_at, actual_source)
+    VALUES (@source, @start, @end, 'usage', @amount, 'HUF', @confidence, @now, @dedupKey, @now, @actualSource)
+  `).run({ source: opts.source, start: opts.start, end: opts.end, amount: opts.amount, confidence: opts.confidence, now: NOW, dedupKey: opts.dedupKey, actualSource: opts.actualSource ?? null })
+}
+
+describe('classifyErrorCode', () => {
+  it('classifies credential-flavored codes', () => {
+    expect(classifyErrorCode('401')).toBe('credential_error')
+    expect(classifyErrorCode('invalid_api_key')).toBe('credential_error')
+    expect(classifyErrorCode('Unauthorized')).toBe('credential_error')
+  })
+  it('classifies permission-flavored codes', () => {
+    expect(classifyErrorCode('403')).toBe('permission_error')
+    expect(classifyErrorCode('Forbidden')).toBe('permission_error')
+  })
+  it('leaves unrecognized codes unclassified (never guessed)', () => {
+    expect(classifyErrorCode('ETIMEDOUT')).toBeNull()
+    expect(classifyErrorCode('balance_error')).toBeNull()
+    expect(classifyErrorCode(null)).toBeNull()
+  })
+})
+
+describe('gatherAlertCandidates -- budget signals', () => {
+  beforeEach(() => { initDb() })
+
+  it('fires budget_threshold once spend crosses the hard threshold', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'anthropic-max', 'anthropic', 'subscription')
+    insertLine(db, { source: 'anthropic-max', start: win.start, end: win.end, amount: 1200, confidence: 'manual', dedupKey: 'l1' })
+    const candidates = gatherAlertCandidates(db, cfg(), NOW)
+    const budget = candidates.find(c => c.type === 'budget_threshold')
+    expect(budget?.severity).toBe('critical')
+  })
+
+  it('does not fire when spend is well under the warning threshold', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'anthropic-max', 'anthropic', 'subscription')
+    insertLine(db, { source: 'anthropic-max', start: win.start, end: win.end, amount: 100, confidence: 'manual', dedupKey: 'l1' })
+    const candidates = gatherAlertCandidates(db, cfg(), NOW)
+    expect(candidates.find(c => c.type === 'budget_threshold')).toBeUndefined()
+  })
+})
+
+describe('gatherAlertCandidates -- balance exhaustion (entitlements)', () => {
+  beforeEach(() => { initDb() })
+
+  it('fires critical once the stored forecast_exhaustion_at has passed', () => {
+    const db = getDb()
+    db.prepare(`
+      INSERT INTO entitlements (provider, product, billing_period, entitlement_type, remaining, included_unit, usage_source, forecast_exhaustion_at, status, dedup_key, last_updated, created_at)
+      VALUES ('deepseek', 'deepseek-api', 'ongoing', 'prepaid_balance', 0.5, 'USD', 'provider_api', @past, 'critical', 'deepseek|prepaid_balance', @now, @now)
+    `).run({ past: NOW - 86400, now: NOW })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    const a = candidates.find(c => c.type === 'balance_exhaustion')
+    expect(a?.severity).toBe('critical')
+    expect(a?.evidence.provider).toBe('deepseek')
+  })
+
+  it('does not fire with no forecast_exhaustion_at recorded', () => {
+    const db = getDb()
+    db.prepare(`
+      INSERT INTO entitlements (provider, product, billing_period, entitlement_type, remaining, included_unit, usage_source, forecast_exhaustion_at, status, dedup_key, last_updated, created_at)
+      VALUES ('deepseek', 'deepseek-api', 'ongoing', 'prepaid_balance', 50, 'USD', 'provider_api', NULL, 'ok', 'deepseek|prepaid_balance', @now, @now)
+    `).run({ now: NOW })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'balance_exhaustion')).toBeUndefined()
+  })
+})
+
+describe('gatherAlertCandidates -- sync/credential (import_runs)', () => {
+  beforeEach(() => { initDb() })
+
+  it('fires failed_sync (critical) + credential_permission_error together for a 401', () => {
+    const db = getDb()
+    db.prepare(`INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status, imported_count, error_code) VALUES ('openai','openai-cost',@now,@now,'error',0,'401')`).run({ now: NOW })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    const failed = candidates.find(c => c.type === 'failed_sync')
+    const cred = candidates.find(c => c.type === 'credential_permission_error')
+    expect(failed?.severity).toBe('critical')
+    expect(cred?.severity).toBe('critical')
+    expect(cred?.evidence.issue).toBe('credential_error')
+  })
+
+  it('fires stale_collector (capped at warning) for an old-but-ok sync', () => {
+    const db = getDb()
+    const old = NOW - 10 * 86400
+    db.prepare(`INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status, imported_count, error_code) VALUES ('render','render-plan',@old,@old,'ok',3,NULL)`).run({ old })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    const stale = candidates.find(c => c.type === 'stale_collector')
+    expect(stale?.severity).toBe('warning')
+    expect(candidates.find(c => c.type === 'credential_permission_error')).toBeUndefined()
+  })
+
+  it('does not fire for a fresh, ok sync', () => {
+    const db = getDb()
+    db.prepare(`INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status, imported_count, error_code) VALUES ('github','github-billing',@now,@now,'ok',1,NULL)`).run({ now: NOW })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'stale_collector' || c.type === 'failed_sync')).toBeUndefined()
+  })
+})
+
+describe('gatherAlertCandidates -- reconciliation mismatch', () => {
+  beforeEach(() => { initDb() })
+
+  it('fires when provider API and invoice amounts diverge past tolerance', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render', 'hosting')
+    insertLine(db, { source: 'render-hosting', start: win.start, end: win.end, amount: 10000, confidence: 'provider_api', actualSource: 'provider_api', dedupKey: 'r1' })
+    insertLine(db, { source: 'render-hosting', start: win.start, end: win.end, amount: 12000, confidence: 'actual_invoice', actualSource: 'email_invoice', dedupKey: 'r2' })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    const a = candidates.find(c => c.type === 'reconciliation_mismatch')
+    expect(a).toBeDefined()
+    expect(a?.evidence.source_id).toBe('render-hosting')
+  })
+
+  it('does not fire when the two amounts are within tolerance', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render', 'hosting')
+    insertLine(db, { source: 'render-hosting', start: win.start, end: win.end, amount: 10000, confidence: 'provider_api', actualSource: 'provider_api', dedupKey: 'r1' })
+    insertLine(db, { source: 'render-hosting', start: win.start, end: win.end, amount: 10050, confidence: 'actual_invoice', actualSource: 'email_invoice', dedupKey: 'r2' })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'reconciliation_mismatch')).toBeUndefined()
+  })
+})
+
+describe('gatherAlertCandidates -- new source / long estimate-only', () => {
+  beforeEach(() => { initDb() })
+
+  it('flags a source whose earliest activity is THIS month as new_unknown_source', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'brand-new-saas', 'other', 'saas')
+    insertLine(db, { source: 'brand-new-saas', start: win.start, end: win.end, amount: 500, confidence: 'manual', dedupKey: 'n1' })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    const a = candidates.find(c => c.type === 'new_unknown_source')
+    expect(a?.evidence.source_id).toBe('brand-new-saas')
+  })
+
+  it('does NOT flag a source with older history as new', () => {
+    const db = getDb()
+    const winPrev = monthWindow(NOW - 60 * 86400)
+    insertSource(db, 'old-hosting', 'render', 'hosting')
+    insertLine(db, { source: 'old-hosting', start: winPrev.start, end: winPrev.end, amount: 500, confidence: 'manual', dedupKey: 'o1' })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'new_unknown_source' && c.evidence.source_id === 'old-hosting')).toBeUndefined()
+  })
+
+  it('flags long_estimate_only_source after 3 consecutive manual-only periods', () => {
+    const db = getDb()
+    insertSource(db, 'always-manual', 'other', 'saas')
+    const months = [NOW, NOW - 32 * 86400, NOW - 64 * 86400]
+    months.forEach((t, i) => {
+      const w = monthWindow(t)
+      insertLine(db, { source: 'always-manual', start: w.start, end: w.end, amount: 500, confidence: 'manual', dedupKey: `m${i}` })
+    })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    const a = candidates.find(c => c.type === 'long_estimate_only_source')
+    expect(a?.evidence.consecutive_estimate_only_months).toBe(3)
+  })
+
+  it('does not flag long_estimate_only_source with fewer than 3 periods of history', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'too-new-to-tell', 'other', 'saas')
+    insertLine(db, { source: 'too-new-to-tell', start: win.start, end: win.end, amount: 500, confidence: 'manual', dedupKey: 'q1' })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'long_estimate_only_source')).toBeUndefined()
+  })
+
+  it('does not flag long_estimate_only_source once a provider_api actual has landed', () => {
+    const db = getDb()
+    insertSource(db, 'now-real', 'render', 'hosting')
+    const months = [NOW, NOW - 32 * 86400, NOW - 64 * 86400]
+    months.forEach((t, i) => {
+      const w = monthWindow(t)
+      insertLine(db, { source: 'now-real', start: w.start, end: w.end, amount: 500, confidence: i === 0 ? 'provider_api' : 'manual', dedupKey: `p${i}` })
+    })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'long_estimate_only_source' && c.evidence.source_id === 'now-real')).toBeUndefined()
+  })
+})
+
+describe('gatherAlertCandidates -- unusual spend growth', () => {
+  beforeEach(() => { initDb() })
+
+  it('fires when current month spend grows past the threshold vs the previous month', () => {
+    const db = getDb()
+    insertSource(db, 'anthropic-max', 'anthropic', 'subscription')
+    const winPrev = monthWindow(NOW - 32 * 86400)
+    const winCur = monthWindow(NOW)
+    insertLine(db, { source: 'anthropic-max', start: winPrev.start, end: winPrev.end, amount: 1000, confidence: 'manual', dedupKey: 'g-prev' })
+    insertLine(db, { source: 'anthropic-max', start: winCur.start, end: winCur.end, amount: 2000, confidence: 'manual', dedupKey: 'g-cur' })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'unusual_spend_growth' && c.evidence.key === 'global')).toBeDefined()
+  })
+
+  it('does not fire without a previous month to compare against (never fabricated baseline)', () => {
+    const db = getDb()
+    insertSource(db, 'anthropic-max', 'anthropic', 'subscription')
+    const winCur = monthWindow(NOW)
+    insertLine(db, { source: 'anthropic-max', start: winCur.start, end: winCur.end, amount: 2000, confidence: 'manual', dedupKey: 'g-cur' })
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'unusual_spend_growth')).toBeUndefined()
+  })
+})
+
+describe('gatherAlertCandidates -- subscription utilization with no config present', () => {
+  it('is empty, never fabricated, when no costops-subscriptions.json exists', () => {
+    initDb()
+    const db = getDb()
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.filter(c => c.type === 'subscription_utilization')).toEqual([])
+  })
+})
+
+describe('gatherAlertCandidates -- missing invoice (GAP-14 wiring)', () => {
+  beforeEach(() => { initDb() })
+
+  function insertInvoice(db: ReturnType<typeof getDb>, sourceId: string, periodEnd: number): void {
+    db.prepare(`
+      INSERT INTO costops_invoices (source_id, provider, billing_period_start, billing_period_end, currency, gross_amount, tax_amount, discount_amount, credit_amount, refund_amount, late_charge_amount, net_amount, status, dedup_key, recorded_at, created_at)
+      VALUES (?, 'render', ?, ?, 'HUF', 100, 0, 0, 0, 0, 0, 100, 'recorded', ?, ?, ?)
+    `).run(sourceId, periodEnd - 30 * 86400, periodEnd, `render|ref-${periodEnd}|x`, NOW, NOW)
+  }
+
+  it('is empty with fewer than 2 recorded invoices -- no inferable cadence', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertInvoice(db, 'render-hosting', NOW - 60 * 86400)
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'missing_invoice')).toBeUndefined()
+  })
+
+  it('fires once the inferred next-invoice date has passed with no newer invoice recorded', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertInvoice(db, 'render-hosting', NOW - 120 * 86400) // ~4 months ago
+    insertInvoice(db, 'render-hosting', NOW - 90 * 86400)  // ~3 months ago, 30-day gap
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    const a = candidates.find(c => c.type === 'missing_invoice')
+    expect(a).toBeDefined()
+    expect(a?.evidence.source_id).toBe('render-hosting')
+  })
+
+  it('does not fire once a recent invoice pushes the inferred cadence past now', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertInvoice(db, 'render-hosting', NOW - 60 * 86400)
+    insertInvoice(db, 'render-hosting', NOW - 30 * 86400)
+    insertInvoice(db, 'render-hosting', NOW - 2 * 86400) // just landed
+    const candidates = gatherAlertCandidates(db, cfg({ budgets: [] }), NOW)
+    expect(candidates.find(c => c.type === 'missing_invoice')).toBeUndefined()
+  })
+})
+
+describe('captureAlerts persistence round-trip', () => {
+  beforeEach(() => { initDb(); initAlertsSchema(getDb()) })
+
+  it('inserts a new alert on first capture', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'anthropic-max', 'anthropic', 'subscription')
+    insertLine(db, { source: 'anthropic-max', start: win.start, end: win.end, amount: 1200, confidence: 'manual', dedupKey: 'l1' })
+    const summary = captureAlerts(db, cfg(), NOW)
+    expect(summary.inserted).toBeGreaterThanOrEqual(1)
+    const active = listAlerts(db)
+    expect(active.some(a => a.type === 'budget_threshold' && a.severity === 'critical')).toBe(true)
+  })
+
+  it('dedups on a second capture with the same condition -- no duplicate row, only a touch', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'anthropic-max', 'anthropic', 'subscription')
+    insertLine(db, { source: 'anthropic-max', start: win.start, end: win.end, amount: 1200, confidence: 'manual', dedupKey: 'l1' })
+    captureAlerts(db, cfg(), NOW)
+    const second = captureAlerts(db, cfg(), NOW + 3600)
+    expect(second.inserted).toBe(0)
+    const rows = db.prepare(`SELECT COUNT(*) as n FROM costops_alerts WHERE type = 'budget_threshold'`).get() as { n: number }
+    expect(rows.n).toBe(1)
+  })
+
+  it('resolves an alert once its condition disappears', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'anthropic-max', 'anthropic', 'subscription')
+    insertLine(db, { source: 'anthropic-max', start: win.start, end: win.end, amount: 1200, confidence: 'manual', dedupKey: 'l1' })
+    captureAlerts(db, cfg(), NOW)
+    // spend drops back under the budget (e.g. a void/correction happened) -- simulate by
+    // voiding the line so the source no longer contributes to operational spend.
+    db.prepare(`UPDATE cost_line_items SET voided_at = ? WHERE dedup_key = 'l1'`).run(NOW + 100)
+    const summary = captureAlerts(db, cfg(), NOW + 3600)
+    expect(summary.resolved).toBeGreaterThanOrEqual(1)
+    const unresolved = listAlerts(db)
+    expect(unresolved.find(a => a.type === 'budget_threshold')).toBeUndefined()
+    const all = listAlerts(db, { includeResolved: true })
+    const resolvedRow = all.find(a => a.type === 'budget_threshold')
+    expect(resolvedRow?.resolved_at).not.toBeNull()
+  })
+})

--- a/src/__tests__/costops-alerts-store.test.ts
+++ b/src/__tests__/costops-alerts-store.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { listAllAlerts, listAlerts, applyAlertReconciliation, reconcileAndPersist, acknowledgeAlertByKey, resolveAlertByKey } from '../costops/alerts-store.js'
+import { reconcileAlerts, type AlertCandidate } from '../costops/alerts.js'
+
+const NOW = 1_800_000_000
+
+function candidate(dedupKey: string, overrides: Partial<AlertCandidate> = {}): AlertCandidate {
+  return { type: 'budget_threshold', severity: 'warning', evidence: { foo: 'bar' }, dedup_key: dedupKey, ...overrides }
+}
+
+describe('alerts-store (CostOps Phase 3, GAP-12 persistence)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('persists a brand-new candidate as an inserted alert', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [candidate('render:budget')], NOW)
+    const alerts = listAlerts(db)
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0].dedup_key).toBe('render:budget')
+    expect(alerts[0].evidence).toEqual({ foo: 'bar' })
+    expect(alerts[0].resolved_at).toBeNull()
+  })
+
+  it('a repeated candidate for an active alert dedupes (touch, not a new row)', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [candidate('render:budget')], NOW)
+    reconcileAndPersist(db, [candidate('render:budget', { severity: 'critical' })], NOW + 100)
+    const all = listAllAlerts(db)
+    expect(all).toHaveLength(1)
+    expect(all[0].severity).toBe('critical') // refreshed
+    expect(all[0].last_seen).toBe(NOW + 100)
+  })
+
+  it('an alert whose candidate disappears next round gets resolved', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [candidate('render:budget')], NOW)
+    reconcileAndPersist(db, [], NOW + 100) // condition cleared
+    const active = listAlerts(db, { status: 'active' })
+    expect(active).toHaveLength(0)
+    const resolved = listAlerts(db, { status: 'resolved' })
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0].resolved_at).toBe(NOW + 100)
+  })
+
+  it('listAlerts defaults to active only, status=all returns everything', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [candidate('a'), candidate('b')], NOW)
+    reconcileAndPersist(db, [candidate('a')], NOW + 100) // b resolves
+    expect(listAlerts(db)).toHaveLength(1) // default: active
+    expect(listAlerts(db, { status: 'all' })).toHaveLength(2)
+    expect(listAlerts(db, { status: 'resolved' })).toHaveLength(1)
+  })
+
+  it('filters by type', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [
+      candidate('a', { type: 'budget_threshold' }),
+      candidate('b', { type: 'stale_collector' }),
+    ], NOW)
+    expect(listAlerts(db, { type: 'stale_collector' })).toHaveLength(1)
+  })
+
+  it('acknowledgeAlertByKey sets acknowledged fields without touching resolution', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [candidate('render:budget')], NOW)
+    const r = acknowledgeAlertByKey(db, 'render:budget', 'istvan', NOW + 50)
+    expect(r.ok).toBe(true)
+    const all = listAllAlerts(db)
+    expect(all[0].acknowledged_by).toBe('istvan')
+    expect(all[0].acknowledged_at).toBe(NOW + 50)
+    expect(all[0].resolved_at).toBeNull()
+  })
+
+  it('acknowledgeAlertByKey 404s on an unknown dedup_key', () => {
+    const db = getDb()
+    const r = acknowledgeAlertByKey(db, 'ghost', 'istvan', NOW)
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(404)
+  })
+
+  it('resolveAlertByKey manually resolves an active alert early', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [candidate('render:budget')], NOW)
+    const r = resolveAlertByKey(db, 'render:budget', NOW + 20)
+    expect(r.ok).toBe(true)
+    expect(listAlerts(db)).toHaveLength(0)
+  })
+
+  it('applyAlertReconciliation matches reconcileAlerts pure output exactly (integration check)', () => {
+    const db = getDb()
+    const result = reconcileAlerts([], [candidate('x')], NOW)
+    applyAlertReconciliation(db, result, NOW)
+    const all = listAllAlerts(db)
+    expect(all).toHaveLength(1)
+    expect(all[0].recurrence_count).toBe(0)
+    expect(all[0].cooldown_until).toBe(NOW + 3600)
+  })
+})

--- a/src/__tests__/costops-alerts.test.ts
+++ b/src/__tests__/costops-alerts.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  detectBudgetThresholdAlert,
+  detectForecastBudgetBreachAlert,
+  detectBalanceExhaustionAlert,
+  detectStaleCollectorAlert,
+  detectFailedSyncAlert,
+  detectCredentialPermissionAlert,
+  detectMissingInvoiceAlert,
+  detectReconciliationMismatchAlert,
+  detectManualProviderVarianceAlert,
+  detectUnusualSpendGrowthAlert,
+  detectNewUnknownSourceAlert,
+  detectLongEstimateOnlySourceAlert,
+  detectSubscriptionUtilizationAlert,
+  reconcileAlerts,
+  acknowledgeAlert,
+  resolveAlert,
+  serializeEvidence,
+  deserializeEvidence,
+  initAlertsSchema,
+  type AlertRecord,
+  type AlertCandidate,
+} from '../costops/alerts.js'
+
+// ---- detectors ---------------------------------------------------------------------
+
+describe('detectBudgetThresholdAlert', () => {
+  it('is null below the warning threshold', () => {
+    expect(detectBudgetThresholdAlert({ budget_id: 'global', scope: 'global', used_pct: 0.5, warning_threshold: 0.8, hard_threshold: 1.0 })).toBeNull()
+  })
+  it('is warning between warning and hard', () => {
+    const a = detectBudgetThresholdAlert({ budget_id: 'global', scope: 'global', used_pct: 0.85, warning_threshold: 0.8, hard_threshold: 1.0 })
+    expect(a?.severity).toBe('warning')
+  })
+  it('is critical at/above hard threshold', () => {
+    const a = detectBudgetThresholdAlert({ budget_id: 'global', scope: 'global', used_pct: 1.05, warning_threshold: 0.8, hard_threshold: 1.0 })
+    expect(a?.severity).toBe('critical')
+  })
+})
+
+describe('detectForecastBudgetBreachAlert', () => {
+  it('fires when forecast crosses hard but current spend has not yet', () => {
+    const a = detectForecastBudgetBreachAlert({ budget_id: 'global', scope: 'global', used_pct: 0.6, forecast_pct: 1.1, warning_threshold: 0.8, hard_threshold: 1.0 })
+    expect(a?.type).toBe('forecast_budget_breach')
+  })
+  it('does not fire once current spend itself has already crossed hard (budget_threshold owns that)', () => {
+    const a = detectForecastBudgetBreachAlert({ budget_id: 'global', scope: 'global', used_pct: 1.02, forecast_pct: 1.1, warning_threshold: 0.8, hard_threshold: 1.0 })
+    expect(a).toBeNull()
+  })
+})
+
+describe('detectBalanceExhaustionAlert', () => {
+  const NOW = 100 * 86400
+  it('is null without a forecast exhaustion date', () => {
+    expect(detectBalanceExhaustionAlert({ provider: 'deepseek', remaining: 5, currency: 'USD', forecast_exhaustion_at: null }, NOW)).toBeNull()
+  })
+  it('is critical once the exhaustion date has passed', () => {
+    const a = detectBalanceExhaustionAlert({ provider: 'deepseek', remaining: 0, currency: 'USD', forecast_exhaustion_at: NOW - 86400 }, NOW)
+    expect(a?.severity).toBe('critical')
+  })
+  it('is warning within the warning window', () => {
+    const a = detectBalanceExhaustionAlert({ provider: 'deepseek', remaining: 2, currency: 'USD', forecast_exhaustion_at: NOW + 3 * 86400 }, NOW)
+    expect(a?.severity).toBe('warning')
+  })
+  it('is null far outside the warning window', () => {
+    const a = detectBalanceExhaustionAlert({ provider: 'deepseek', remaining: 100, currency: 'USD', forecast_exhaustion_at: NOW + 30 * 86400 }, NOW)
+    expect(a).toBeNull()
+  })
+})
+
+describe('detectStaleCollectorAlert / detectFailedSyncAlert', () => {
+  it('stale is capped at warning (never critical) -- stale data alone is not a strong claim', () => {
+    const a = detectStaleCollectorAlert({ provider: 'render', status: 'stale', last_success: 1, data_age_secs: 999999, error_code: null })
+    expect(a?.severity).toBe('warning')
+  })
+  it('stale detector ignores ok/failed status', () => {
+    expect(detectStaleCollectorAlert({ provider: 'render', status: 'ok', last_success: 1, data_age_secs: 1, error_code: null })).toBeNull()
+    expect(detectStaleCollectorAlert({ provider: 'render', status: 'failed', last_success: 1, data_age_secs: 1, error_code: null })).toBeNull()
+  })
+  it('failed sync is critical for a credential/permission error, warning otherwise', () => {
+    const cred = detectFailedSyncAlert({ provider: 'aws', status: 'failed', last_success: null, data_age_secs: null, error_code: 'credential_error' })
+    expect(cred?.severity).toBe('critical')
+    const network = detectFailedSyncAlert({ provider: 'aws', status: 'failed', last_success: null, data_age_secs: null, error_code: 'timeout' })
+    expect(network?.severity).toBe('warning')
+  })
+})
+
+describe('detectCredentialPermissionAlert', () => {
+  it('always returns a critical alert', () => {
+    const a = detectCredentialPermissionAlert({ source_id: 'aws-costexplorer', provider: 'aws', issue: 'permission_error' })
+    expect(a.severity).toBe('critical')
+    expect(a.dedup_key).toBe('credential_permission_error|aws-costexplorer')
+  })
+})
+
+describe('detectMissingInvoiceAlert', () => {
+  it('is null if received or not yet due', () => {
+    expect(detectMissingInvoiceAlert({ source_id: 'render', expected_by: 1000, received: true }, 2000)).toBeNull()
+    expect(detectMissingInvoiceAlert({ source_id: 'render', expected_by: 3000, received: false }, 2000)).toBeNull()
+  })
+  it('fires once overdue', () => {
+    const a = detectMissingInvoiceAlert({ source_id: 'render', expected_by: 1000, received: false }, 1000 + 5 * 86400)
+    expect(a?.evidence.overdue_days).toBe(5)
+  })
+})
+
+describe('detectReconciliationMismatchAlert', () => {
+  it('refuses to fire against a zero baseline (never a fabricated comparison)', () => {
+    expect(detectReconciliationMismatchAlert({ source_id: 'x', estimate: 100, actual: 0, variance: -100, variance_threshold_pct: 0.1 })).toBeNull()
+  })
+  it('is null under the threshold, warning over, critical at 2x the threshold', () => {
+    expect(detectReconciliationMismatchAlert({ source_id: 'x', estimate: 100, actual: 105, variance: 5, variance_threshold_pct: 0.1 })).toBeNull()
+    const warn = detectReconciliationMismatchAlert({ source_id: 'x', estimate: 100, actual: 87, variance: -13, variance_threshold_pct: 0.1 })
+    expect(warn?.severity).toBe('warning')
+    const crit = detectReconciliationMismatchAlert({ source_id: 'x', estimate: 100, actual: 50, variance: -50, variance_threshold_pct: 0.1 })
+    expect(crit?.severity).toBe('critical')
+  })
+})
+
+describe('detectManualProviderVarianceAlert', () => {
+  it('is null with no provider-derived spend', () => {
+    expect(detectManualProviderVarianceAlert({ provider: 'render', manual_spend: 100, provider_derived_spend: 0, variance_threshold_pct: 0.1 })).toBeNull()
+  })
+  it('fires past the threshold', () => {
+    const a = detectManualProviderVarianceAlert({ provider: 'render', manual_spend: 40000, provider_derived_spend: 37080, variance_threshold_pct: 0.05 })
+    expect(a?.type).toBe('manual_provider_variance')
+  })
+})
+
+describe('detectUnusualSpendGrowthAlert', () => {
+  it('is null with no measurable baseline', () => {
+    expect(detectUnusualSpendGrowthAlert({ key: 'anthropic', current_amount: 500, baseline_amount: 0, growth_threshold_pct: 0.5 })).toBeNull()
+  })
+  it('warning past threshold, critical at 2x', () => {
+    const warn = detectUnusualSpendGrowthAlert({ key: 'anthropic', current_amount: 160, baseline_amount: 100, growth_threshold_pct: 0.5 })
+    expect(warn?.severity).toBe('warning')
+    const crit = detectUnusualSpendGrowthAlert({ key: 'anthropic', current_amount: 220, baseline_amount: 100, growth_threshold_pct: 0.5 })
+    expect(crit?.severity).toBe('critical')
+  })
+})
+
+describe('detectNewUnknownSourceAlert / detectLongEstimateOnlySourceAlert / detectSubscriptionUtilizationAlert', () => {
+  it('new source only fires on first appearance', () => {
+    expect(detectNewUnknownSourceAlert({ source_id: 'x', first_seen_month: '2026-07', is_first_appearance: false })).toBeNull()
+    expect(detectNewUnknownSourceAlert({ source_id: 'x', first_seen_month: '2026-07', is_first_appearance: true })?.severity).toBe('info')
+  })
+  it('long estimate-only fires only at/above the threshold month count', () => {
+    expect(detectLongEstimateOnlySourceAlert({ source_id: 'x', consecutive_estimate_only_months: 2, threshold_months: 3 })).toBeNull()
+    expect(detectLongEstimateOnlySourceAlert({ source_id: 'x', consecutive_estimate_only_months: 3, threshold_months: 3 })?.type).toBe('long_estimate_only_source')
+  })
+  it('subscription utilization fires under and over, not in between', () => {
+    expect(detectSubscriptionUtilizationAlert({ subscription_id: 's', usage_pct: 0.5, under_threshold_pct: 0.2, over_threshold_pct: 0.9 })).toBeNull()
+    const under = detectSubscriptionUtilizationAlert({ subscription_id: 's', usage_pct: 0.1, under_threshold_pct: 0.2, over_threshold_pct: 0.9 })
+    expect(under?.evidence.direction).toBe('under')
+    const over = detectSubscriptionUtilizationAlert({ subscription_id: 's', usage_pct: 0.95, under_threshold_pct: 0.2, over_threshold_pct: 0.9 })
+    expect(over?.evidence.direction).toBe('over')
+  })
+})
+
+// ---- lifecycle ------------------------------------------------------------------------
+
+function candidate(dedup_key: string, over: Partial<AlertCandidate> = {}): AlertCandidate {
+  return { type: 'budget_threshold', severity: 'warning', evidence: { note: 'x' }, dedup_key, ...over }
+}
+
+describe('reconcileAlerts', () => {
+  it('inserts a brand new alert when nothing existed for its dedup_key', () => {
+    const r = reconcileAlerts([], [candidate('a')], 1000)
+    expect(r.toInsert).toHaveLength(1)
+    expect(r.toInsert[0].first_seen).toBe(1000)
+    expect(r.toInsert[0].recurrence_count).toBe(0)
+    expect(r.toTouch).toHaveLength(0)
+    expect(r.toResolve).toHaveLength(0)
+  })
+
+  it('deduplicates: a candidate matching an ACTIVE existing alert only touches last_seen, never inserts a duplicate', () => {
+    const existing: AlertRecord = {
+      dedup_key: 'a', type: 'budget_threshold', severity: 'warning', evidence: {},
+      first_seen: 500, last_seen: 500, acknowledged_at: null, acknowledged_by: null,
+      resolved_at: null, recurrence_count: 0, owner: null, cooldown_until: 500 + 3600,
+    }
+    const r = reconcileAlerts([existing], [candidate('a')], 1000)
+    expect(r.toInsert).toHaveLength(0)
+    expect(r.toTouch).toHaveLength(1)
+    expect(r.toTouch[0].patch.last_seen).toBe(1000)
+    expect(r.toTouch[0].patch.recurrence_count).toBe(0) // dedup does not bump recurrence
+  })
+
+  it('resolves an active alert whose candidate disappeared this round', () => {
+    const existing: AlertRecord = {
+      dedup_key: 'a', type: 'budget_threshold', severity: 'warning', evidence: {},
+      first_seen: 500, last_seen: 500, acknowledged_at: null, acknowledged_by: null,
+      resolved_at: null, recurrence_count: 0, owner: null, cooldown_until: 4100,
+    }
+    const r = reconcileAlerts([existing], [], 1000)
+    expect(r.toResolve).toEqual([{ dedup_key: 'a', resolved_at: 1000 }])
+  })
+
+  it('reopens a resolved alert WITHIN cooldown without bumping recurrence_count (flapping protection)', () => {
+    const existing: AlertRecord = {
+      dedup_key: 'a', type: 'budget_threshold', severity: 'warning', evidence: {},
+      first_seen: 100, last_seen: 200, acknowledged_at: null, acknowledged_by: null,
+      resolved_at: 300, recurrence_count: 2, owner: null, cooldown_until: 100 + 3600, // cooldown extends to 3700
+    }
+    const r = reconcileAlerts([existing], [candidate('a')], 3500, 3600) // 3500 < 3700 cooldown_until
+    expect(r.toTouch).toHaveLength(1)
+    expect(r.toTouch[0].patch.resolved_at).toBeNull()
+    expect(r.toTouch[0].patch.recurrence_count).toBe(2) // unchanged -- flap, not a genuine new incident
+  })
+
+  it('reopens a resolved alert AFTER cooldown and bumps recurrence_count (genuine recurrence)', () => {
+    const existing: AlertRecord = {
+      dedup_key: 'a', type: 'budget_threshold', severity: 'warning', evidence: {},
+      first_seen: 100, last_seen: 200, acknowledged_at: null, acknowledged_by: null,
+      resolved_at: 300, recurrence_count: 2, owner: null, cooldown_until: 100 + 3600, // cooldown_until = 3700
+    }
+    const r = reconcileAlerts([existing], [candidate('a')], 4000, 3600) // 4000 > 3700
+    expect(r.toTouch[0].patch.resolved_at).toBeNull()
+    expect(r.toTouch[0].patch.recurrence_count).toBe(3) // bumped
+    expect(r.toTouch[0].patch.cooldown_until).toBe(4000 + 3600)
+  })
+
+  it('handles insert + touch + resolve together in one reconcile call', () => {
+    const stillActive: AlertRecord = {
+      dedup_key: 'active', type: 'budget_threshold', severity: 'warning', evidence: {},
+      first_seen: 1, last_seen: 1, acknowledged_at: null, acknowledged_by: null,
+      resolved_at: null, recurrence_count: 0, owner: null, cooldown_until: 3601,
+    }
+    const goneNow: AlertRecord = {
+      dedup_key: 'gone', type: 'stale_collector', severity: 'warning', evidence: {},
+      first_seen: 1, last_seen: 1, acknowledged_at: null, acknowledged_by: null,
+      resolved_at: null, recurrence_count: 0, owner: null, cooldown_until: 3601,
+    }
+    const r = reconcileAlerts([stillActive, goneNow], [candidate('active'), candidate('brand-new')], 5000)
+    expect(r.toInsert.map(i => i.dedup_key)).toEqual(['brand-new'])
+    expect(r.toTouch.map(t => t.dedup_key)).toEqual(['active'])
+    expect(r.toResolve.map(t => t.dedup_key)).toEqual(['gone'])
+  })
+})
+
+describe('acknowledgeAlert / resolveAlert', () => {
+  const base: AlertRecord = {
+    dedup_key: 'a', type: 'budget_threshold', severity: 'warning', evidence: {},
+    first_seen: 1, last_seen: 1, acknowledged_at: null, acknowledged_by: null,
+    resolved_at: null, recurrence_count: 0, owner: null, cooldown_until: null,
+  }
+  it('acknowledgeAlert records actor + time without touching resolution', () => {
+    const a = acknowledgeAlert(base, 'istvan', 5000)
+    expect(a.acknowledged_at).toBe(5000)
+    expect(a.acknowledged_by).toBe('istvan')
+    expect(a.resolved_at).toBeNull()
+  })
+  it('resolveAlert sets resolved_at', () => {
+    const r = resolveAlert(base, 6000)
+    expect(r.resolved_at).toBe(6000)
+  })
+})
+
+describe('serializeEvidence / deserializeEvidence', () => {
+  it('round-trips an evidence object', () => {
+    const ev = { provider: 'render', used_pct: 0.9 }
+    expect(deserializeEvidence(serializeEvidence(ev))).toEqual(ev)
+  })
+  it('deserializeEvidence never throws on bad JSON -- returns {}', () => {
+    expect(deserializeEvidence('not json')).toEqual({})
+  })
+})
+
+describe('initAlertsSchema', () => {
+  it('is idempotent and the table accepts a row keyed by dedup_key', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initAlertsSchema(db)
+    initAlertsSchema(db) // second call must not throw
+    const now = 1000
+    db.prepare(`
+      INSERT INTO costops_alerts (type, severity, evidence_json, dedup_key, first_seen, last_seen, recurrence_count, created_at)
+      VALUES ('budget_threshold', 'warning', @ev, 'budget_threshold|global', @now, @now, 0, @now)
+    `).run({ now, ev: serializeEvidence({ used_pct: 0.9 }) })
+    const row = db.prepare(`SELECT * FROM costops_alerts WHERE dedup_key = 'budget_threshold|global'`).get() as { evidence_json: string; resolved_at: number | null }
+    expect(deserializeEvidence(row.evidence_json)).toEqual({ used_pct: 0.9 })
+    expect(row.resolved_at).toBeNull()
+  })
+
+  it('rejects a duplicate dedup_key', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initAlertsSchema(db)
+    const now = 1000
+    db.prepare(`INSERT INTO costops_alerts (type, severity, evidence_json, dedup_key, first_seen, last_seen, recurrence_count, created_at) VALUES ('budget_threshold','warning','{}','a',@now,@now,0,@now)`).run({ now })
+    expect(() => {
+      db.prepare(`INSERT INTO costops_alerts (type, severity, evidence_json, dedup_key, first_seen, last_seen, recurrence_count, created_at) VALUES ('budget_threshold','critical','{}','a',@now,@now,0,@now)`).run({ now })
+    }).toThrow()
+  })
+})

--- a/src/__tests__/costops-budgets.test.ts
+++ b/src/__tests__/costops-budgets.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { resolveBudgetStatus, getAllBudgetStatuses, upsertBudget, deleteBudget, getBudgetAuditHistory } from '../costops/budgets.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+// upsertBudget/deleteBudget call the real saveCostopsConfig(), which writes
+// store/costops-config.json on disk -- mocked here so these unit tests never
+// touch that real file (a prior version of this file didn't mock this and
+// left 'a'/'b' budget entries behind in the actual config, which would have
+// shown up as fake budgets on a real dashboard -- flagged by Marveen 2026-07-15).
+vi.mock('../costops/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../costops/config.js')>('../costops/config.js')
+  return { ...actual, saveCostopsConfig: vi.fn() }
+})
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const MONTH = monthWindow(NOW).key
+
+function baseConfig(overrides: Partial<CostOpsConfig> = {}): CostOpsConfig {
+  return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [], ...overrides }
+}
+
+function insertLine(sourceId: string, provider: string, sourceType: string, amount: number) {
+  const db = getDb()
+  const win = monthWindow(NOW)
+  db.prepare(`INSERT OR IGNORE INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, ?, ?, 'HUF', 1, ?, ?)`)
+    .run(sourceId, sourceId, provider, sourceType, NOW, NOW)
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+    VALUES (?, ?, ?, 'subscription', ?, 'HUF', 'manual', ?, ?, ?, 'manual_entry')
+  `).run(sourceId, win.start, win.end, amount, NOW, NOW, `test|${sourceId}|${Math.random()}`)
+}
+
+describe('resolveBudgetStatus / getAllBudgetStatuses (CostOps Phase 3, GAP-11)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('a global budget resolves against operational_spend/forecast, matching the summary', () => {
+    const db = getDb()
+    insertLine('render-hosting', 'render', 'hosting', 10000)
+    const config = baseConfig({ budgets: [{ id: 'global-monthly', scope: 'global', amount: 50000, warning_threshold: 0.8, hard_threshold: 1.0 }] })
+    const summary = getCostSummary(db, config, NOW)
+    const [status] = getAllBudgetStatuses(db, config, NOW)
+    expect(status.scope).toBe('global')
+    expect(status.current_spend).toBe(summary.operational_spend)
+    expect(status.forecast).toBe(summary.operational_forecast_month_end)
+  })
+
+  it('a provider budget only sums that provider\'s sources', () => {
+    const db = getDb()
+    insertLine('render-hosting', 'render', 'hosting', 10000)
+    insertLine('openai-api', 'openai', 'usage', 5000)
+    const config = baseConfig({ budgets: [{ id: 'render-budget', scope: 'provider', scope_ref: 'render', amount: 20000 }] })
+    const [status] = getAllBudgetStatuses(db, config, NOW)
+    expect(status.current_spend).toBe(10000) // render only, not openai
+  })
+
+  it('a category budget sums by source_type across providers', () => {
+    const db = getDb()
+    insertLine('render-hosting', 'render', 'hosting', 10000)
+    insertLine('aws-s3', 'aws', 'hosting', 3000)
+    insertLine('anthropic-max', 'anthropic', 'subscription', 22000)
+    const config = baseConfig({ budgets: [{ id: 'hosting-budget', scope: 'category', scope_ref: 'hosting', amount: 20000 }] })
+    const [status] = getAllBudgetStatuses(db, config, NOW)
+    expect(status.current_spend).toBe(13000) // render + aws hosting only
+  })
+
+  it('a source-scoped budget resolves to just that one source', () => {
+    const db = getDb()
+    insertLine('anthropic-max', 'anthropic', 'subscription', 22000)
+    insertLine('render-hosting', 'render', 'hosting', 10000)
+    const config = baseConfig({ budgets: [{ id: 'claude-max-budget', scope: 'source', scope_ref: 'anthropic-max', amount: 25000 }] })
+    const [status] = getAllBudgetStatuses(db, config, NOW)
+    expect(status.current_spend).toBe(22000)
+  })
+
+  it('product/agent scopes explicitly resolve to zero -- GAP-11 excludes them, never fabricated', () => {
+    const db = getDb()
+    insertLine('render-hosting', 'render', 'hosting', 10000)
+    const config = baseConfig({ budgets: [{ id: 'weird-budget', scope: 'product', scope_ref: 'whatever', amount: 5000 }] })
+    const [status] = getAllBudgetStatuses(db, config, NOW)
+    expect(status.current_spend).toBe(0)
+    expect(status.forecast).toBe(0)
+  })
+
+  it('status escalates ok -> warning -> hard by used_pct vs thresholds', () => {
+    const db = getDb()
+    insertLine('render-hosting', 'render', 'hosting', 8500)
+    const config = baseConfig({ budgets: [{ id: 'b', scope: 'global', amount: 10000, warning_threshold: 0.8, hard_threshold: 1.0 }] })
+    const [status] = getAllBudgetStatuses(db, config, NOW)
+    expect(status.used_pct).toBeCloseTo(0.85, 2)
+    expect(status.status).toBe('warning')
+  })
+
+  it('variance is forecast minus amount -- positive means a projected overage', () => {
+    const summary = getCostSummary(getDb(), baseConfig(), NOW)
+    const status = resolveBudgetStatus({ id: 'b', scope: 'global', amount: 1000 }, { ...summary, operational_forecast_month_end: 1500 })
+    expect(status.variance).toBe(500)
+  })
+
+  it('owner defaults to operator when not configured on the budget entry', () => {
+    const db = getDb()
+    const config = baseConfig({ budgets: [{ id: 'b', scope: 'global', amount: 1000 }] })
+    const [status] = getAllBudgetStatuses(db, config, NOW)
+    expect(status.owner).toBe('operator')
+  })
+})
+
+describe('upsertBudget / deleteBudget audit trail (CostOps Phase 3, GAP-11)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('creating a new budget records a "created" audit entry', () => {
+    const db = getDb()
+    const config = baseConfig()
+    const r = upsertBudget(db, config, { id: 'global-monthly', scope: 'global', amount: 50000 }, 'istvan', NOW)
+    expect(r.ok).toBe(true)
+    const history = getBudgetAuditHistory(db, 'global-monthly')
+    expect(history).toHaveLength(1)
+    expect(history[0].action).toBe('created')
+    expect(history[0].before).toBeNull()
+    expect(history[0].after!.amount).toBe(50000)
+  })
+
+  it('updating an existing budget records an "updated" entry with before/after', () => {
+    const db = getDb()
+    let config = baseConfig()
+    upsertBudget(db, config, { id: 'b', scope: 'global', amount: 50000 }, 'istvan', NOW)
+    config = { ...config, budgets: [{ id: 'b', scope: 'global', amount: 50000 }] } // simulate a reload
+    const r2 = upsertBudget(db, config, { id: 'b', scope: 'global', amount: 70000 }, 'istvan', NOW + 10)
+    expect(r2.ok).toBe(true)
+    const history = getBudgetAuditHistory(db, 'b')
+    expect(history).toHaveLength(2)
+    expect(history[1].action).toBe('updated')
+    expect(history[1].before!.amount).toBe(50000)
+    expect(history[1].after!.amount).toBe(70000)
+  })
+
+  it('deleting a budget records a "deleted" entry with before only', () => {
+    const db = getDb()
+    let config = baseConfig()
+    upsertBudget(db, config, { id: 'b', scope: 'global', amount: 50000 }, 'istvan', NOW)
+    config = { ...config, budgets: [{ id: 'b', scope: 'global', amount: 50000 }] }
+    const r = deleteBudget(db, config, 'b', 'istvan', NOW + 10)
+    expect(r.ok).toBe(true)
+    const history = getBudgetAuditHistory(db, 'b')
+    expect(history[1].action).toBe('deleted')
+    expect(history[1].before!.amount).toBe(50000)
+    expect(history[1].after).toBeNull()
+  })
+
+  it('requires an actor for both upsert and delete', () => {
+    const db = getDb()
+    const config = baseConfig()
+    expect(upsertBudget(db, config, { id: 'b', amount: 1000 }, '', NOW).status).toBe(400)
+    expect(deleteBudget(db, config, 'b', '', NOW).status).toBe(400)
+  })
+
+  it('rejects a negative or non-numeric amount', () => {
+    const db = getDb()
+    const config = baseConfig()
+    expect(upsertBudget(db, config, { id: 'b', amount: -5 }, 'istvan', NOW).status).toBe(400)
+  })
+
+  it('deleteBudget 404s on an unknown id', () => {
+    const db = getDb()
+    const config = baseConfig()
+    const r = deleteBudget(db, config, 'ghost', 'istvan', NOW)
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(404)
+  })
+
+  it('getBudgetAuditHistory with no id returns every budget\'s history', () => {
+    const db = getDb()
+    const config = baseConfig()
+    upsertBudget(db, config, { id: 'a', amount: 1000 }, 'istvan', NOW)
+    upsertBudget(db, config, { id: 'b', amount: 2000 }, 'istvan', NOW + 1)
+    expect(getBudgetAuditHistory(db)).toHaveLength(2)
+  })
+})

--- a/src/__tests__/costops-codex.test.ts
+++ b/src/__tests__/costops-codex.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  parseCodexRateLimit,
+  forecastCodexLimitExhaustion,
+  syncCodexRateLimit,
+  type RateLimitSnapshotRow,
+} from '../costops/collectors/codex.js'
+
+// The real app-server account/rateLimits/read result shape (proven live 2026-07-15).
+const REAL = {
+  rateLimits: {
+    limitId: 'codex',
+    primary: { usedPercent: 9, windowDurationMins: 10080, resetsAt: 1784721994 },
+    secondary: null,
+    planType: 'plus',
+  },
+}
+
+describe('parseCodexRateLimit', () => {
+  it('parses the app-server rateLimits result', () => {
+    const s = parseCodexRateLimit(REAL)
+    expect(s).not.toBeNull()
+    expect(s?.usedPercent).toBe(9)
+    expect(s?.windowDurationMins).toBe(10080)
+    expect(s?.resetsAt).toBe(1784721994)
+    expect(s?.planType).toBe('plus')
+    expect(s?.limitId).toBe('codex')
+  })
+  it('clamps usedPercent to 0..100', () => {
+    expect(parseCodexRateLimit({ rateLimits: { primary: { usedPercent: 150 } } })?.usedPercent).toBe(100)
+    expect(parseCodexRateLimit({ rateLimits: { primary: { usedPercent: -5 } } })?.usedPercent).toBe(0)
+  })
+  it('returns null for malformed input (never a guess)', () => {
+    expect(parseCodexRateLimit(null)).toBeNull()
+    expect(parseCodexRateLimit({})).toBeNull()
+    expect(parseCodexRateLimit({ rateLimits: {} })).toBeNull()               // no primary
+    expect(parseCodexRateLimit({ rateLimits: { primary: {} } })).toBeNull()   // no usedPercent
+    expect(parseCodexRateLimit('garbage')).toBeNull()
+  })
+})
+
+describe('forecastCodexLimitExhaustion', () => {
+  const day = 86400
+  it('returns null with fewer than 2 snapshots', () => {
+    expect(forecastCodexLimitExhaustion([{ used_percent: 10, resets_at: null, captured_at: 0 }], day)).toBeNull()
+  })
+  it('returns null when history span < 1h (too noisy)', () => {
+    const snaps: RateLimitSnapshotRow[] = [
+      { used_percent: 10, resets_at: null, captured_at: 0 },
+      { used_percent: 20, resets_at: null, captured_at: 1800 },
+    ]
+    expect(forecastCodexLimitExhaustion(snaps, 1800)).toBeNull()
+  })
+  it('projects reaching 100% from a steady rise', () => {
+    // 10% -> 30% over 2 days = 10%/day; remaining 70% -> +7 days from the last snapshot
+    const snaps: RateLimitSnapshotRow[] = [
+      { used_percent: 10, resets_at: null, captured_at: 0 },
+      { used_percent: 30, resets_at: null, captured_at: 2 * day },
+    ]
+    const at = forecastCodexLimitExhaustion(snaps, 2 * day)
+    expect(at).not.toBeNull()
+    expect(Math.round(((at as number) - 2 * day) / day)).toBe(7)
+  })
+  it('ignores a reset (drop) and returns null when net-flat', () => {
+    const snaps: RateLimitSnapshotRow[] = [
+      { used_percent: 90, resets_at: null, captured_at: 0 },
+      { used_percent: 5, resets_at: null, captured_at: 2 * day },
+    ]
+    expect(forecastCodexLimitExhaustion(snaps, 2 * day)).toBeNull()
+  })
+})

--- a/src/__tests__/costops-collectors-dryrun.test.ts
+++ b/src/__tests__/costops-collectors-dryrun.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { anthropicCollector } from '../costops/collectors/anthropic.js'
+import { dryRunCollector, describeShape } from '../costops/collectors/runner.js'
+import { monthWindow } from '../costops/ledger.js'
+import type { CollectOpts, HttpGetJson } from '../costops/collectors/types.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const FX = 308.91
+const SECRET = 'sk-DRYRUN-must-not-leak-9876543210'
+
+// Offline fixture -- NO live API is ever called in tests.
+const FIXTURE = {
+  data: [{
+    starting_at: '2026-07-01T00:00:00Z',
+    ending_at: '2026-07-31T00:00:00Z',
+    results: [
+      { currency: 'USD', amount: '30', cost_type: 'api_usage', model: 'claude-opus-4-8' },
+      { currency: 'USD', amount: '20', cost_type: 'api_usage', model: 'claude-sonnet-4-6' },
+    ],
+  }],
+  has_more: false,
+}
+
+function opts(httpGetJson: HttpGetJson): CollectOpts {
+  const w = monthWindow(NOW)
+  return { periodStart: w.start, periodEnd: w.end, secret: SECRET, fxUsdHuf: FX, idSalt: 'salt', httpGetJson }
+}
+
+describe('describeShape (types only, no values)', () => {
+  it('returns structure with no scalar values', () => {
+    const shape = describeShape(FIXTURE)
+    // shape carries keys + types + array lengths, but NOT the numbers/strings themselves
+    const dump = JSON.stringify(shape)
+    expect(dump).not.toContain('claude-opus-4-8')  // no model value
+    expect(dump).not.toContain('30')               // no amount value
+    expect(dump).not.toContain('2026-07-01')       // no date value
+    // but the schema IS described
+    expect(shape).toMatchObject({ type: 'object' })
+    expect((shape as any).keys.data).toMatchObject({ type: 'array', length: 1 })
+    expect((shape as any).keys.data.of.keys.results).toMatchObject({ type: 'array', length: 2 })
+    expect((shape as any).keys.has_more).toBe('boolean')
+  })
+})
+
+describe('dryRunCollector (offline, persists NOTHING to cost_line_items)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('normalizes and shows planned lines + dedup_keys + response shape', async () => {
+    const stub: HttpGetJson = async () => FIXTURE
+    const rep = await dryRunCollector({ db: getDb(), collector: anthropicCollector, opts: opts(stub), now: NOW })
+    expect(rep.status).toBe('dry_run')
+    expect(rep.wouldImportCount).toBe(1)
+    // normalized: (30+20)*308.91 = 15445.5
+    expect(rep.plannedLines[0].amount).toBe(15445.5)
+    expect(rep.plannedLines[0].confidence).toBe('provider_api')
+    expect(rep.dedupKeys).toEqual(['provider|anthropic|anthropic-api|2026-07|provider_api'])
+    // sanitized response shape present, types only
+    expect(rep.responseShape).not.toBeNull()
+    expect((rep.responseShape as any).keys.has_more).toBe('boolean')
+  })
+
+  it('does NOT write any provider_api cost_line_item', async () => {
+    const db = getDb()
+    await dryRunCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    const n = db.prepare("SELECT COUNT(*) n FROM cost_line_items WHERE confidence='provider_api'").get() as { n: number }
+    expect(n.n).toBe(0)
+    const anyLine = db.prepare('SELECT COUNT(*) n FROM cost_line_items').get() as { n: number }
+    expect(anyLine.n).toBe(0)
+  })
+
+  it('does NOT write a final import; only a dry_run audit row with count 0', async () => {
+    const db = getDb()
+    await dryRunCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    const rows = db.prepare('SELECT status, imported_count FROM import_runs').all() as Array<{ status: string; imported_count: number }>
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe('dry_run')
+    expect(rows[0].imported_count).toBe(0)
+    // NO 'ok' import ever recorded by a dry-run
+    const okRuns = db.prepare("SELECT COUNT(*) n FROM import_runs WHERE status='ok'").get() as { n: number }
+    expect(okRuns.n).toBe(0)
+  })
+
+  it('recordRun:false persists absolutely nothing', async () => {
+    const db = getDb()
+    await dryRunCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW, recordRun: false })
+    const runs = db.prepare('SELECT COUNT(*) n FROM import_runs').get() as { n: number }
+    const lines = db.prepare('SELECT COUNT(*) n FROM cost_line_items').get() as { n: number }
+    expect(runs.n).toBe(0)
+    expect(lines.n).toBe(0)
+  })
+
+  it('on error: status=error, sanitized, writes NO cost line, secret never leaks', async () => {
+    const db = getDb()
+    const throwing: HttpGetJson = async () => { throw new Error(`rate limited, key ${SECRET} and token abcdef1234567890abcdef1234567890`) }
+    const rep = await dryRunCollector({ db, collector: anthropicCollector, opts: opts(throwing), now: NOW })
+    expect(rep.status).toBe('error')
+    expect(rep.errorMessageSanitized).not.toContain('sk-DRYRUN-must-not-leak')
+    expect(rep.wouldImportCount).toBe(0)
+    // nothing persisted to cost_line_items
+    const lines = db.prepare('SELECT COUNT(*) n FROM cost_line_items').get() as { n: number }
+    expect(lines.n).toBe(0)
+    // the whole DB + report never contain the secret
+    const dump = JSON.stringify(db.prepare('SELECT * FROM import_runs').all()) + JSON.stringify(rep)
+    expect(dump).not.toContain('sk-DRYRUN-must-not-leak')
+    expect(dump).not.toContain('9876543210')
+  })
+
+  it('report + audit row never contain the secret on the happy path', async () => {
+    const db = getDb()
+    const rep = await dryRunCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    const dump = JSON.stringify(rep) + JSON.stringify(db.prepare('SELECT * FROM import_runs').all())
+    expect(dump).not.toContain(SECRET)
+    expect(dump).not.toContain('sk-DRYRUN')
+  })
+})

--- a/src/__tests__/costops-collectors.test.ts
+++ b/src/__tests__/costops-collectors.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { mapAnthropicCostReport, anthropicCollector } from '../costops/collectors/anthropic.js'
+import { runCollector, sanitizeError } from '../costops/collectors/runner.js'
+import { validateCollectorsConfig } from '../costops/collectors/config.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+import type { CollectOpts, HttpGetJson } from '../costops/collectors/types.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const FX = 308.91
+
+function emptyConfig(): CostOpsConfig { return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] } }
+
+// Offline fixture -- matches the mapper; NO live API is ever called in tests.
+const FIXTURE = {
+  data: [{
+    starting_at: '2026-07-01T00:00:00Z',
+    ending_at: '2026-07-31T00:00:00Z',
+    results: [
+      { currency: 'USD', amount: '30', cost_type: 'api_usage', model: 'claude-opus-4-8' },
+      { currency: 'USD', amount: '20', cost_type: 'api_usage', model: 'claude-sonnet-4-6' },
+    ],
+  }],
+  has_more: false,
+}
+
+function opts(httpGetJson: HttpGetJson): CollectOpts {
+  const w = monthWindow(NOW)
+  return { periodStart: w.start, periodEnd: w.end, secret: 'sk-SECRET-must-not-leak-1234567890', fxUsdHuf: FX, idSalt: 'salt', httpGetJson }
+}
+
+describe('anthropic mapper (pure, offline)', () => {
+  it('aggregates USD -> HUF into one provider_api line for anthropic-api', () => {
+    const w = monthWindow(NOW)
+    const lines = mapAnthropicCostReport(FIXTURE, { periodStart: w.start, periodEnd: w.end, fxUsdHuf: FX, idSalt: 'salt', now: NOW })
+    expect(lines).toHaveLength(1)
+    expect(lines[0].service).toBe('anthropic-api')
+    expect(lines[0].provider).toBe('anthropic')
+    expect(lines[0].confidence).toBe('provider_api')
+    // (30 + 20) * 308.91 = 15445.5
+    expect(lines[0].amount).toBe(15445.5)
+    expect(lines[0].currency).toBe('HUF')
+    expect(lines[0].dedup_key).toBe('provider|anthropic|anthropic-api|2026-07|provider_api')
+    expect(lines[0].raw_ref_hash).not.toContain('anthropic-cost-report') // hashed
+  })
+  it('returns [] for an empty report', () => {
+    const w = monthWindow(NOW)
+    expect(mapAnthropicCostReport({ data: [] }, { periodStart: w.start, periodEnd: w.end, fxUsdHuf: FX, idSalt: 's', now: NOW })).toHaveLength(0)
+  })
+})
+
+describe('sanitizeError (no secret leaks)', () => {
+  it('redacts key-like substrings', () => {
+    const s = sanitizeError(new Error('auth failed for x-api-key: sk-abcdef1234567890abcdef and token abcdef1234567890abcdef1234567890'))
+    expect(s.message).not.toContain('sk-abcdef1234567890')
+    expect(s.message).toMatch(/\*\*\*/)
+  })
+})
+
+describe('collectors config validation', () => {
+  it('rejects a raw secret in secret_ref (must be vault:)', () => {
+    const r = validateCollectorsConfig({ collectors: [{ provider: 'anthropic', secret_ref: 'sk-raw-key' }] })
+    expect(r.config.collectors).toHaveLength(0)
+    expect(r.errors[0]).toContain('vault:')
+  })
+  it('accepts a vault: secret_ref', () => {
+    const r = validateCollectorsConfig({ fx_usd_huf: 308.91, collectors: [{ provider: 'anthropic', enabled: true, secret_ref: 'vault:costops.anthropic_admin_key' }] })
+    expect(r.config.collectors[0].secret_ref).toBe('vault:costops.anthropic_admin_key')
+    expect(r.errors).toEqual([])
+  })
+})
+
+describe('runCollector (offline stub, no live call)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('imports a provider_api line and records an ok import_run; idempotent', async () => {
+    const stub: HttpGetJson = async () => FIXTURE
+    const res1 = await runCollector({ db: getDb(), collector: anthropicCollector, opts: opts(stub), now: NOW })
+    expect(res1.status).toBe('ok')
+    expect(res1.importedCount).toBe(1)
+    // re-run -> no duplicate (dedup_key upsert)
+    await runCollector({ db: getDb(), collector: anthropicCollector, opts: opts(stub), now: NOW })
+    const n = getDb().prepare("SELECT COUNT(*) n FROM cost_line_items WHERE confidence='provider_api'").get() as { n: number }
+    expect(n.n).toBe(1)
+    const runs = getDb().prepare("SELECT COUNT(*) n FROM import_runs").get() as { n: number }
+    expect(runs.n).toBe(2) // two runs recorded, one line
+  })
+
+  it('does NOT overwrite the manual estimate; both coexist; headline resolves to actual', async () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    // seed a manual estimate for anthropic-api (like the v0.1 config sync)
+    db.prepare("INSERT INTO cost_sources (id,name,provider,source_type,currency,active,created_at,updated_at) VALUES ('anthropic-api','Anthropic API','anthropic','usage','HUF',1,?,?)").run(NOW, NOW)
+    db.prepare(`INSERT INTO cost_line_items (source_id,charge_period_start,charge_period_end,charge_category,service_name,billed_cost,currency,confidence,data_freshness,dedup_key,created_at)
+      VALUES ('anthropic-api',?,?,'usage','Anthropic API',17655,'HUF','estimate',?,'fixed|anthropic-api|2026-07',?)`).run(w.start, w.end, NOW, NOW)
+    await runCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    // both lines exist
+    const both = db.prepare("SELECT confidence, billed_cost FROM cost_line_items WHERE source_id='anthropic-api' ORDER BY confidence").all() as Array<{ confidence: string; billed_cost: number }>
+    expect(both.map(x => x.confidence).sort()).toEqual(['estimate', 'provider_api'])
+    // summary: headline resolves to provider_api actual (15445.5), reconcile shows both
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    expect(s.current_spend).toBe(15445.5)               // actual, not estimate, not summed
+    const rec = s.reconcile.find(r => r.source_id === 'anthropic-api')!
+    expect(rec.estimate).toBe(17655)
+    expect(rec.actual).toBe(15445.5)
+    expect(rec.variance).toBe(-2209.5)
+    expect(rec.resolved_confidence).toBe('provider_api')
+  })
+
+  it('on collector error: records status=error, sanitized, deletes NOTHING', async () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    // pre-existing good data
+    db.prepare("INSERT INTO cost_sources (id,name,provider,source_type,currency,active,created_at,updated_at) VALUES ('x','X','other','usage','HUF',1,?,?)").run(NOW, NOW)
+    db.prepare("INSERT INTO cost_line_items (source_id,charge_period_start,charge_period_end,charge_category,service_name,billed_cost,currency,confidence,data_freshness,dedup_key,created_at) VALUES ('x',?,?,'usage','X',100,'HUF','manual',?,'k',?)").run(w.start, w.end, NOW, NOW)
+    const throwing: HttpGetJson = async () => { throw new Error('rate limited, key sk-abcdef1234567890abcdef') }
+    const res = await runCollector({ db, collector: anthropicCollector, opts: opts(throwing), now: NOW })
+    expect(res.status).toBe('error')
+    expect(res.errorMessageSanitized).not.toContain('sk-abcdef1234567890')
+    // nothing deleted
+    const n = db.prepare("SELECT COUNT(*) n FROM cost_line_items").get() as { n: number }
+    expect(n.n).toBe(1)
+    // secret never appears in import_runs
+    const dump = JSON.stringify(db.prepare("SELECT * FROM import_runs").all())
+    expect(dump).not.toContain('sk-abcdef1234567890')
+    expect(dump).not.toContain('sk-SECRET-must-not-leak')
+  })
+
+  it('provider_sync appears in the summary after a run', async () => {
+    const db = getDb()
+    await runCollector({ db, collector: anthropicCollector, opts: opts(async () => FIXTURE), now: NOW })
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    const ps = s.provider_sync.find(p => p.provider === 'anthropic')!
+    expect(ps.status).toBe('ok')
+    expect(ps.imported_count).toBe(1)
+    expect(ps.collector_name).toBe('anthropic-cost-report')
+  })
+})

--- a/src/__tests__/costops-correction.test.ts
+++ b/src/__tests__/costops-correction.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { createCorrection, getCorrectionChain } from '../costops/correction.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const cfg: CostOpsConfig = { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] }
+
+function insertLine(db: import('better-sqlite3').Database, sourceId: string, amount: number, confidence = 'manual', actualSource = 'manual_entry'): number {
+  const win = monthWindow(NOW)
+  db.prepare(`INSERT OR IGNORE INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, 'other', 'usage', 'HUF', 1, ?, ?)`)
+    .run(sourceId, sourceId, NOW, NOW)
+  const info = db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+    VALUES (?, ?, ?, 'usage', ?, 'HUF', ?, ?, ?, ?, ?)
+  `).run(sourceId, win.start, win.end, amount, confidence, NOW, NOW, `test|${sourceId}|${Math.random()}`, actualSource)
+  return info.lastInsertRowid as number
+}
+
+describe('createCorrection (CostOps Phase 1, GAP-05/06/14 -- correction relationship)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('voids the original and inserts a linked correction row with the new amount', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: 'invoice was overstated' }, { now: NOW + 100 })
+    expect(r.ok).toBe(true)
+    expect(r.newLineId).toBeDefined()
+
+    const original = db.prepare(`SELECT voided_at, void_reason, billed_cost, corrects_line_id FROM cost_line_items WHERE id = ?`).get(originalId) as any
+    expect(original.voided_at).toBe(NOW + 100)
+    expect(original.void_reason).toContain('invoice was overstated')
+    expect(original.billed_cost).toBe(10000) // amount preserved, never erased
+    expect(original.corrects_line_id).toBeNull() // the ORIGINAL doesn't point anywhere
+
+    const corrected = db.prepare(`SELECT billed_cost, corrects_line_id, voided_at FROM cost_line_items WHERE id = ?`).get(r.newLineId) as any
+    expect(corrected.billed_cost).toBe(8500)
+    expect(corrected.corrects_line_id).toBe(originalId)
+    expect(corrected.voided_at).toBeNull() // the correction itself is active
+  })
+
+  it('the corrected amount, not the original, is what the ledger reports going forward', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: 'fix' }, { now: NOW + 100 })
+    const s = getCostSummary(db, cfg, NOW)
+    const row = s.all_sources.find(x => x.source_id === 'render-hosting')!
+    expect(row.spend).toBe(8500)
+  })
+
+  it('preserves source_id/period/currency/confidence/actual_source from the original', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000, 'provider_api', 'provider_api')
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: 9000, reason: 'provider corrected their number' }, { now: NOW + 100 })
+    const corrected = db.prepare(`SELECT source_id, currency, confidence, actual_source FROM cost_line_items WHERE id = ?`).get(r.newLineId) as any
+    expect(corrected.source_id).toBe('render-hosting')
+    expect(corrected.currency).toBe('HUF')
+    expect(corrected.confidence).toBe('provider_api')
+    expect(corrected.actual_source).toBe('provider_api')
+  })
+
+  it('404s on a nonexistent line id', () => {
+    const db = getDb()
+    const r = createCorrection(db, { originalLineId: 99999, newAmount: 100, reason: 'x' }, { now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(404)
+  })
+
+  it('409s when correcting an already-voided line', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: 'first fix' }, { now: NOW + 100 })
+    const r2 = createCorrection(db, { originalLineId: originalId, newAmount: 7000, reason: 'second attempt on the same original' }, { now: NOW + 200 })
+    expect(r2.ok).toBe(false)
+    expect(r2.status).toBe(409)
+  })
+
+  it('409s when the original already has a correction pointing at it (correct the newer link instead)', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    const first = createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: 'first fix' }, { now: NOW + 100 })
+    // Attempting to correct the ORIGINAL again (not the new line) must fail --
+    // it's already voided, so this hits the voided guard, same 409 class.
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: 7000, reason: 'oops' }, { now: NOW + 200 })
+    expect(r.ok).toBe(false)
+    // But correcting the NEW line (the actual current link) works fine.
+    const r2 = createCorrection(db, { originalLineId: first.newLineId!, newAmount: 7500, reason: 'second, correct fix' }, { now: NOW + 300 })
+    expect(r2.ok).toBe(true)
+  })
+
+  it('rejects a missing reason -- correction must always be explainable', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: 8500, reason: '' }, { now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(400)
+  })
+
+  it('rejects a negative newAmount', () => {
+    const db = getDb()
+    const originalId = insertLine(db, 'render-hosting', 10000)
+    const r = createCorrection(db, { originalLineId: originalId, newAmount: -5, reason: 'x' }, { now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(400)
+  })
+})
+
+describe('getCorrectionChain', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('returns just the one row when there is no correction yet', () => {
+    const db = getDb()
+    const id = insertLine(db, 'render-hosting', 10000)
+    const chain = getCorrectionChain(db, id)
+    expect(chain).toHaveLength(1)
+    expect(chain[0].id).toBe(id)
+  })
+
+  it('walks a multi-link chain oldest-first, regardless of which link id is passed in', () => {
+    const db = getDb()
+    const original = insertLine(db, 'render-hosting', 10000)
+    const c1 = createCorrection(db, { originalLineId: original, newAmount: 8500, reason: 'fix 1' }, { now: NOW + 100 })
+    const c2 = createCorrection(db, { originalLineId: c1.newLineId!, newAmount: 9200, reason: 'fix 2' }, { now: NOW + 200 })
+
+    for (const queryId of [original, c1.newLineId!, c2.newLineId!]) {
+      const chain = getCorrectionChain(db, queryId)
+      expect(chain.map(c => c.id)).toEqual([original, c1.newLineId, c2.newLineId])
+      expect(chain.map(c => c.billed_cost)).toEqual([10000, 8500, 9200])
+      expect(chain[chain.length - 1].voided_at).toBeNull() // only the latest link is active
+    }
+  })
+})

--- a/src/__tests__/costops-deepseek.test.ts
+++ b/src/__tests__/costops-deepseek.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { deriveMtdSpend, parseDeepSeekBalanceUsd, syncDeepSeekBalance } from '../costops/collectors/deepseek.js'
+
+describe('deriveMtdSpend (pure)', () => {
+  it('sums balance drops, ignoring top-ups (rises)', () => {
+    // 10 -> 8 (drop 2) -> 12 (top-up, ignore) -> 9 (drop 3) => spend 5
+    const snaps = [10, 8, 12, 9].map((b, i) => ({ balance: b, captured_at: i }))
+    expect(deriveMtdSpend(snaps)).toBe(5)
+  })
+  it('is 0 for a single snapshot (baseline)', () => {
+    expect(deriveMtdSpend([{ balance: 4.55, captured_at: 1 }])).toBe(0)
+    expect(deriveMtdSpend([])).toBe(0)
+  })
+})
+
+describe('parseDeepSeekBalanceUsd', () => {
+  it('reads the USD total_balance from the /user/balance shape', () => {
+    expect(parseDeepSeekBalanceUsd({ is_available: true, balance_infos: [{ currency: 'USD', total_balance: '4.55' }] })).toBe(4.55)
+    expect(parseDeepSeekBalanceUsd({ balance_infos: [{ currency: 'CNY', total_balance: '30' }] })).toBe(30) // falls back to first
+    expect(parseDeepSeekBalanceUsd(null)).toBe(0)
+  })
+})
+
+describe('syncDeepSeekBalance (offline stub)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('records a snapshot + baseline line on first sync, then MTD spend on a later drop', async () => {
+    const db = getDb()
+    const t0 = Math.floor(Date.UTC(2026, 6, 5) / 1000)
+    const bal = (v: string) => async () => ({ is_available: true, balance_infos: [{ currency: 'USD', total_balance: v }] })
+    // first sync: balance 5.00 -> baseline, spend 0
+    const r1 = await syncDeepSeekBalance(db, t0, { apiKey: 'k', fxUsdHuf: 360, httpGetJson: bal('5.00') })
+    expect(r1.ok).toBe(true)
+    expect(r1.balance_usd).toBe(5)
+    expect(r1.mtd_spend_usd).toBe(0)
+    const line0 = db.prepare("SELECT billed_cost, confidence FROM cost_line_items WHERE source_id='deepseek-api'").get() as { billed_cost: number; confidence: string }
+    expect(line0.billed_cost).toBe(0)
+    expect(line0.confidence).toBe('provider_api')
+
+    // second sync later same month: balance dropped to 3.20 -> spend 1.80 usd -> 648 HUF
+    const r2 = await syncDeepSeekBalance(db, t0 + 86400, { apiKey: 'k', fxUsdHuf: 360, httpGetJson: bal('3.20') })
+    expect(r2.mtd_spend_usd).toBeCloseTo(1.8, 4)
+    const line1 = db.prepare("SELECT billed_cost FROM cost_line_items WHERE source_id='deepseek-api'").get() as { billed_cost: number }
+    expect(line1.billed_cost).toBeCloseTo(1.8 * 360, 2) // idempotent upsert, single line
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='deepseek-api'").get() as { c: number }).c).toBe(1)
+    // secret never in audit rows
+    expect(JSON.stringify(db.prepare('SELECT * FROM import_runs').all())).not.toContain('"k"')
+  })
+
+  it('errors (no line) when the vault key is missing', async () => {
+    const db = getDb()
+    const r = await syncDeepSeekBalance(db, Math.floor(Date.now() / 1000), { apiKey: null, fxUsdHuf: 360, httpGetJson: async () => ({}) })
+    expect(r.ok).toBe(false)
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='deepseek-api'").get() as { c: number }).c).toBe(0)
+  })
+})

--- a/src/__tests__/costops-email-ingest.test.ts
+++ b/src/__tests__/costops-email-ingest.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { ingestEmailCosts, toHuf } from '../costops/email-ingest.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 6) / 1000)
+
+describe('toHuf', () => {
+  it('passes HUF through, converts USD, flags others', () => {
+    expect(toHuf(8990, 'HUF', 360)).toBe(8990)
+    expect(toHuf(2, 'USD', 360)).toBe(720)
+    expect(toHuf(5, 'EUR', 360)).toBeNull() // not converted here
+  })
+})
+
+describe('ingestEmailCosts', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('ingests receipts as actual_invoice lines, idempotent per (email, month)', () => {
+    const db = getDb()
+    const entries = [
+      { source_id: 'anthropic-pro', name: 'Claude Pro', provider: 'anthropic', amount: 8990, currency: 'HUF', month: '2026-06', message_ref: 'gmail-abc' },
+      { source_id: 'openai-api', name: 'OpenAI API', provider: 'openai', amount: 3.5, currency: 'USD', month: '2026-06', message_ref: 'gmail-def' },
+    ]
+    const r1 = ingestEmailCosts(db, entries, { fxUsdHuf: 360, now: NOW })
+    expect(r1.ingested).toBe(2)
+    expect(r1.errors).toHaveLength(0)
+
+    const pro = db.prepare("SELECT billed_cost, confidence, charge_category FROM cost_line_items WHERE source_id='anthropic-pro'").get() as any
+    expect(pro.billed_cost).toBe(8990)
+    expect(pro.confidence).toBe('actual_invoice')
+    expect(pro.charge_category).toBe('invoice')
+    const oa = db.prepare("SELECT billed_cost FROM cost_line_items WHERE source_id='openai-api'").get() as any
+    expect(oa.billed_cost).toBe(3.5 * 360)
+
+    // re-ingest the SAME receipts -> idempotent, no duplicates
+    ingestEmailCosts(db, entries, { fxUsdHuf: 360, now: NOW + 100 })
+    expect((db.prepare('SELECT COUNT(*) c FROM cost_line_items').get() as any).c).toBe(2)
+  })
+
+  it('same provider, different months coexist (not deduped across months)', () => {
+    const db = getDb()
+    ingestEmailCosts(db, [{ source_id: 'render-hosting', name: 'Render', provider: 'render', amount: 40000, currency: 'HUF', month: '2026-06', message_ref: 'r-jun' }], { fxUsdHuf: 360, now: NOW })
+    ingestEmailCosts(db, [{ source_id: 'render-hosting', name: 'Render', provider: 'render', amount: 41000, currency: 'HUF', month: '2026-07', message_ref: 'r-jul' }], { fxUsdHuf: 360, now: NOW })
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='render-hosting'").get() as any).c).toBe(2)
+  })
+
+  it('collects errors for bad month / unconvertible currency / missing id, ingests the rest', () => {
+    const db = getDb()
+    const r = ingestEmailCosts(db, [
+      { source_id: 'ok', name: 'Ok', provider: 'x', amount: 100, currency: 'HUF', month: '2026-06', message_ref: 'm1' },
+      { source_id: 'bad-month', name: 'B', provider: 'x', amount: 100, currency: 'HUF', month: 'June', message_ref: 'm2' },
+      { source_id: 'bad-cur', name: 'C', provider: 'x', amount: 5, currency: 'EUR', month: '2026-06', message_ref: 'm3' },
+      { source_id: '', name: 'D', provider: 'x', amount: 5, currency: 'HUF', month: '2026-06', message_ref: 'm4' },
+    ] as any, { fxUsdHuf: 360, now: NOW })
+    expect(r.ingested).toBe(1)
+    expect(r.errors.length).toBe(3)
+  })
+
+  it('stores no raw message ref -- only a hash in source_ref/dedup_key', () => {
+    const db = getDb()
+    ingestEmailCosts(db, [{ source_id: 's', name: 'S', provider: 'x', amount: 1, currency: 'HUF', month: '2026-06', message_ref: 'SENSITIVE-gmail-id-12345' }], { fxUsdHuf: 360, now: NOW })
+    const dump = JSON.stringify(db.prepare('SELECT * FROM cost_line_items').all())
+    expect(dump).not.toContain('SENSITIVE-gmail-id-12345')
+  })
+})

--- a/src/__tests__/costops-email-ingest.test.ts
+++ b/src/__tests__/costops-email-ingest.test.ts
@@ -56,6 +56,20 @@ describe('ingestEmailCosts', () => {
     expect(r.errors.length).toBe(3)
   })
 
+  it('Phase 1 (GAP-09): a converted (non-HUF) invoice line carries fx_source/conversion_method; an already-HUF one does not', () => {
+    const db = getDb()
+    ingestEmailCosts(db, [
+      { source_id: 'openai-api', name: 'OpenAI API', provider: 'openai', amount: 3.5, currency: 'USD', month: '2026-06', message_ref: 'gmail-usd' },
+      { source_id: 'anthropic-pro', name: 'Claude Pro', provider: 'anthropic', amount: 8990, currency: 'HUF', month: '2026-06', message_ref: 'gmail-huf' },
+    ], { fxUsdHuf: 360, now: NOW })
+    const usd = db.prepare("SELECT fx_source, conversion_method FROM cost_line_items WHERE source_id='openai-api'").get() as any
+    expect(usd.fx_source).toBe('render_pricing_config')
+    expect(usd.conversion_method).toBe('invoice_date_rate')
+    const huf = db.prepare("SELECT fx_source, conversion_method FROM cost_line_items WHERE source_id='anthropic-pro'").get() as any
+    expect(huf.fx_source).toBeNull()
+    expect(huf.conversion_method).toBeNull()
+  })
+
   it('stores no raw message ref -- only a hash in source_ref/dedup_key', () => {
     const db = getDb()
     ingestEmailCosts(db, [{ source_id: 's', name: 'S', provider: 'x', amount: 1, currency: 'HUF', month: '2026-06', message_ref: 'SENSITIVE-gmail-id-12345' }], { fxUsdHuf: 360, now: NOW })

--- a/src/__tests__/costops-expiry-checks.test.ts
+++ b/src/__tests__/costops-expiry-checks.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { checkSslExpiry, checkDomainExpiry } from '../costops/expiry-checks.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 0, 0, 0) / 1000) // 2026-07-15
+
+function daysFromNow(days: number): string {
+  return new Date((NOW + days * 86400) * 1000).toISOString()
+}
+
+describe('checkSslExpiry', () => {
+  it('is silent for a healthy cert (no noise)', async () => {
+    const w = await checkSslExpiry(['ok.example.com'], NOW, { connect: async () => ({ validTo: daysFromNow(90) }) })
+    expect(w).toEqual([])
+  })
+
+  it('emits low severity at 30d, medium at 14d, high at 7d', async () => {
+    const w30 = await checkSslExpiry(['a'], NOW, { connect: async () => ({ validTo: daysFromNow(30) }) })
+    const w14 = await checkSslExpiry(['b'], NOW, { connect: async () => ({ validTo: daysFromNow(14) }) })
+    const w7 = await checkSslExpiry(['c'], NOW, { connect: async () => ({ validTo: daysFromNow(7) }) })
+    expect(w30[0].severity).toBe('low')
+    expect(w14[0].severity).toBe('medium')
+    expect(w7[0].severity).toBe('high')
+    expect(w30[0].warning_type).toBe('expiry')
+    expect(w30[0].category).toBe('domains')
+  })
+
+  it('reports a check-failed (not silence) when the TLS connection fails, never a fabricated date', async () => {
+    const w = await checkSslExpiry(['down.example.com'], NOW, { connect: async () => null })
+    expect(w).toHaveLength(1)
+    expect(w[0].code).toBe('ssl_check_failed')
+    expect(w[0].confidence).toBe('no_api_or_no_access')
+  })
+
+  it('checks multiple hosts independently', async () => {
+    const w = await checkSslExpiry(['healthy', 'expiring'], NOW, {
+      connect: async (host) => ({ validTo: host === 'expiring' ? daysFromNow(5) : daysFromNow(365) }),
+    })
+    expect(w).toHaveLength(1)
+    expect((w[0].detail as { host: string }).host).toBe('expiring')
+  })
+})
+
+describe('checkDomainExpiry', () => {
+  it('is silent for a healthy domain (no noise)', async () => {
+    const w = await checkDomainExpiry(['zstradio.com'], NOW, {
+      fetchJson: async () => ({ events: [{ eventAction: 'expiration', eventDate: daysFromNow(200) }] }),
+    })
+    expect(w).toEqual([])
+  })
+
+  it('emits an expiry warning inside the threshold', async () => {
+    const w = await checkDomainExpiry(['zstradio.com'], NOW, {
+      fetchJson: async () => ({ events: [{ eventAction: 'expiration', eventDate: daysFromNow(10) }] }),
+    })
+    expect(w).toHaveLength(1)
+    expect(w[0].severity).toBe('medium')
+    expect(w[0].code).toBe('domain_expiry_soon')
+  })
+
+  it('marks an unsupported TLD as no_api_or_no_access, never guesses an expiry', async () => {
+    const w = await checkDomainExpiry(['example.hu'], NOW)
+    expect(w).toHaveLength(1)
+    expect(w[0].code).toBe('domain_expiry_check_unsupported')
+    expect(w[0].confidence).toBe('no_api_or_no_access')
+  })
+
+  it('reports a check-failed warning when the RDAP call throws', async () => {
+    const w = await checkDomainExpiry(['zstradio.com'], NOW, { fetchJson: async () => { throw new Error('network') } })
+    expect(w).toHaveLength(1)
+    expect(w[0].code).toBe('domain_expiry_check_failed')
+  })
+
+  it('never fabricates an expiry when the RDAP response has no expiration event', async () => {
+    const w = await checkDomainExpiry(['zstradio.com'], NOW, { fetchJson: async () => ({ events: [] }) })
+    expect(w).toEqual([])
+  })
+})

--- a/src/__tests__/costops-export-phase1.test.ts
+++ b/src/__tests__/costops-export-phase1.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { syncFixedCostsToLedger, monthWindow, getCostSummary } from '../costops/ledger.js'
+import { captureForecastSnapshots } from '../costops/forecast-capture.js'
+import {
+  exportLedgerJson,
+  exportLedgerCsv,
+  exportSourceInventory,
+  sourceInventoryToCsv,
+  exportProviderSummary,
+  providerSummaryToCsv,
+  exportCategorySummary,
+  categorySummaryToCsv,
+  exportBudgetVariance,
+  exportReconciliationReport,
+  reconciliationReportToCsv,
+  exportForecastHistory,
+  exportDataQualityReport,
+  exportMonthlySnapshot,
+  exportAlerts,
+  alertsToCsv,
+  objectsToCsv,
+} from '../costops/export.js'
+import { reconcileAndPersist } from '../costops/alerts-store.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+
+function cfg(over: Partial<CostOpsConfig> = {}): CostOpsConfig {
+  return {
+    version: 1,
+    currency: 'HUF',
+    fixed_costs: [
+      { source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 22000, period: 'monthly', confidence: 'manual', currency: 'HUF' },
+      { source_id: 'render-hosting', name: 'Render', provider: 'render', source_type: 'hosting', amount: 12000, period: 'monthly', confidence: 'manual', currency: 'HUF' },
+    ],
+    budgets: [
+      { id: 'global-monthly', name: 'Global', scope: 'global', amount: 60000, currency: 'HUF', warning_threshold: 0.8, hard_threshold: 1.0 },
+    ],
+    ...over,
+  }
+}
+
+describe('objectsToCsv', () => {
+  it('renders a header row + escaped rows', () => {
+    const csv = objectsToCsv([{ a: 'x,y', b: 2 }], ['a', 'b'])
+    const lines = csv.trim().split('\n')
+    expect(lines[0]).toBe('a,b')
+    expect(lines[1]).toBe('"x,y",2')
+  })
+})
+
+describe('export meta envelope (GAP-18: schema_version + generated_at on every export)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('exportLedgerJson carries schema_version + generated_at + scope + month', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const exp = exportLedgerJson(db, NOW, { month: '2026-07' })
+    expect(exp.meta.schema_version).toBe(1)
+    expect(exp.meta.generated_at).toBe(NOW)
+    expect(exp.meta.scope).toBe('ledger')
+    expect(exp.meta.month).toBe('2026-07')
+    expect(exp.rows).toHaveLength(2)
+  })
+
+  it('exportLedgerCsv wraps the same CSV rowsToCsv produces, with meta alongside', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const exp = exportLedgerCsv(db, NOW, { month: '2026-07' })
+    expect(exp.meta.scope).toBe('ledger')
+    expect(exp.csv.split('\n')[0]).toBe('provider,source_type,service_name,period,amount,currency,confidence,original_amount,original_currency')
+  })
+})
+
+describe('exportSourceInventory', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('never leaks a raw account_ref or secret field', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const exp = exportSourceInventory(db, cfg(), NOW, { credentialChecker: () => false })
+    expect(exp.meta.scope).toBe('source_inventory')
+    expect(exp.sources.length).toBeGreaterThan(0)
+    for (const s of exp.sources) {
+      expect(Object.keys(s)).not.toContain('account_ref')
+      expect(Object.keys(s)).not.toContain('secret')
+    }
+  })
+
+  it('sourceInventoryToCsv renders without throwing on real data', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const exp = exportSourceInventory(db, cfg(), NOW, { credentialChecker: () => false })
+    const csv = sourceInventoryToCsv(exp.sources)
+    expect(csv.split('\n')[0]).toBe('source_id,name,provider,source_type,lifecycle,provenance,collection_method,freshness,sync_cadence,owner,operational_inclusion_rule,manual_fallback,blocker')
+  })
+})
+
+describe('exportProviderSummary / exportCategorySummary -- match getCostSummary (same source, so totals agree)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('provider_breakdown is literally getCostSummary().operational.provider_breakdown', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const summary = getCostSummary(db, cfg(), NOW)
+    const exp = exportProviderSummary(db, cfg(), NOW, { month: '2026-07' })
+    expect(exp.provider_breakdown).toEqual(summary.operational.provider_breakdown)
+    expect(exp.operational_spend).toBe(summary.operational_spend)
+  })
+
+  it('category summary aggregates by source_type and sums to the same total as provider summary', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const providerExp = exportProviderSummary(db, cfg(), NOW, { month: '2026-07' })
+    const categoryExp = exportCategorySummary(db, NOW, { month: '2026-07' })
+    const categoryTotal = categoryExp.categories.reduce((s, c) => s + c.spend, 0)
+    expect(Math.round(categoryTotal * 100) / 100).toBe(Math.round(providerExp.operational_spend * 100) / 100)
+    expect(categoryExp.categories.map(c => c.source_type).sort()).toEqual(['hosting', 'subscription'])
+  })
+
+  it('CSV variants render', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const providerExp = exportProviderSummary(db, cfg(), NOW, { month: '2026-07' })
+    const categoryExp = exportCategorySummary(db, NOW, { month: '2026-07' })
+    expect(providerSummaryToCsv(providerExp.provider_breakdown).split('\n')[0]).toBe('provider,spend,confidence')
+    expect(categorySummaryToCsv(categoryExp.categories).split('\n')[0]).toBe('source_type,spend')
+  })
+})
+
+describe('exportBudgetVariance', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('computes spend_variance and forecast_variance against the configured budget', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW) // 22000 + 12000 = 34000 operational spend, budget 60000
+    const exp = exportBudgetVariance(db, cfg(), NOW, { month: '2026-07' })
+    expect(exp.budget).not.toBeNull()
+    expect(exp.budget!.spend_variance).toBe(34000 - 60000)
+  })
+
+  it('is null when no budget is configured -- never fabricated', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg({ budgets: [] }), NOW)
+    const exp = exportBudgetVariance(db, cfg({ budgets: [] }), NOW, { month: '2026-07' })
+    expect(exp.budget).toBeNull()
+  })
+})
+
+describe('exportReconciliationReport', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('wraps buildReconciliation output with meta', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const exp = exportReconciliationReport(db, NOW, '2026-07')
+    expect(exp.meta.scope).toBe('reconciliation_report')
+    expect(exp.meta.month).toBe('2026-07')
+    expect(exp.sources.length).toBeGreaterThan(0)
+  })
+
+  it('CSV variant renders', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const exp = exportReconciliationReport(db, NOW, '2026-07')
+    expect(reconciliationReportToCsv(exp.sources).split('\n')[0]).toBe('source_id,name,provider,month,expected_amount,observed_provider_amount,invoice_amount,operationally_selected_amount,variance,variance_reason,status')
+  })
+})
+
+describe('exportForecastHistory', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('reflects captured forecast snapshots for the month', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    captureForecastSnapshots(db, NOW)
+    const exp = exportForecastHistory(db, NOW, { month: '2026-07' })
+    expect(exp.meta.scope).toBe('forecast_history')
+    expect(exp.snapshots.length).toBeGreaterThan(0)
+    expect(exp.snapshots.every(s => s.month === '2026-07')).toBe(true)
+  })
+
+  it('is empty (never fabricated) before any capture has run', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const exp = exportForecastHistory(db, NOW, { month: '2026-07' })
+    expect(exp.snapshots).toEqual([])
+  })
+})
+
+describe('exportDataQualityReport', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('matches getCostSummary confidence/breakdown/freshness, plus per-freshness source counts', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const summary = getCostSummary(db, cfg(), NOW)
+    const exp = exportDataQualityReport(db, cfg(), NOW, { month: '2026-07' })
+    expect(exp.confidence_breakdown).toEqual(summary.confidence_breakdown)
+    expect(exp.breakdown).toEqual(summary.breakdown)
+    expect(exp.data_freshness).toBe(summary.data_freshness)
+    const totalSources = Object.values(exp.source_freshness_counts).reduce((s, n) => s + n, 0)
+    expect(totalSources).toBe(2) // anthropic-max + render-hosting
+  })
+})
+
+describe('exportAlerts (GAP-12, added once alerts-capture landed on this branch)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('defaults to active alerts only, matching listAlerts(status: active)', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [{ type: 'budget_threshold', severity: 'warning', evidence: {}, dedup_key: 'a' }], NOW)
+    reconcileAndPersist(db, [{ type: 'stale_collector', severity: 'info', evidence: {}, dedup_key: 'b' }], NOW)
+    reconcileAndPersist(db, [{ type: 'budget_threshold', severity: 'warning', evidence: {}, dedup_key: 'a' }], NOW + 10) // 'b' drops off -> resolved
+    const exp = exportAlerts(db, NOW + 10)
+    expect(exp.meta.scope).toBe('alerts_active')
+    expect(exp.alerts.map(a => a.dedup_key)).toEqual(['a'])
+  })
+
+  it('includeResolved:true returns the full history', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [{ type: 'budget_threshold', severity: 'warning', evidence: {}, dedup_key: 'a' }], NOW)
+    reconcileAndPersist(db, [], NOW + 10) // resolves it
+    const exp = exportAlerts(db, NOW + 10, { includeResolved: true })
+    expect(exp.meta.scope).toBe('alerts_all')
+    expect(exp.alerts).toHaveLength(1)
+    expect(exp.alerts[0].resolved_at).toBe(NOW + 10)
+  })
+
+  it('alertsToCsv produces a header row plus one row per alert, no secret/evidence leakage beyond the declared columns', () => {
+    const db = getDb()
+    reconcileAndPersist(db, [{ type: 'budget_threshold', severity: 'warning', evidence: { api_key: 'sk-should-not-appear' }, dedup_key: 'a' }], NOW)
+    const exp = exportAlerts(db, NOW)
+    const csv = alertsToCsv(exp.alerts)
+    expect(csv.split('\n')).toEqual(['dedup_key,type,severity,first_seen,last_seen,acknowledged_at,resolved_at,recurrence_count', expect.stringContaining('a,budget_threshold,warning'), ''])
+    expect(csv).not.toContain('sk-should-not-appear') // evidence is deliberately excluded from the CSV columns
+  })
+})
+
+describe('exportMonthlySnapshot', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('bundles everything and explicitly disclaims being the frozen close record', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const exp = exportMonthlySnapshot(db, cfg(), NOW, '2026-07')
+    expect(exp.meta.scope).toBe('monthly_snapshot')
+    // period-close.ts landed on this branch after this test was written --
+    // the bundle now reports the real period_status and points a consumer at
+    // the true immutable record (GET /api/costs/period-close) for a closed
+    // month, instead of a blanket "close doesn't exist yet" disclaimer.
+    expect(exp.note).toMatch(/not the frozen close record/)
+    expect(exp.period_status).toBe('open') // untouched month in this test
+    expect(exp.ledger.length).toBe(2)
+    expect(exp.provider_summary.length).toBeGreaterThan(0)
+    expect(exp.category_summary.length).toBeGreaterThan(0)
+    expect(exp.budget?.spend_variance).toBeDefined()
+    expect(exp.reconciliation.length).toBeGreaterThan(0)
+    expect(exp.data_quality.data_freshness).not.toBeNull()
+  })
+
+  it('re-running it after new data lands produces a different result -- honest about not being frozen', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const before = exportMonthlySnapshot(db, cfg(), NOW, '2026-07')
+    const winPrev = monthWindow(NOW)
+    db.prepare(`
+      INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('late-addition','Late','other','saas','HUF',1,@now,@now)
+    `).run({ now: NOW })
+    db.prepare(`
+      INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, dedup_key, created_at)
+      VALUES ('late-addition', @start, @end, 'usage', 5000, 'HUF', 'manual', @now, 'late-1', @now)
+    `).run({ start: winPrev.start, end: winPrev.end, now: NOW })
+    const after = exportMonthlySnapshot(db, cfg(), NOW, '2026-07')
+    expect(after.ledger.length).toBe(before.ledger.length + 1)
+  })
+})

--- a/src/__tests__/costops-export.test.ts
+++ b/src/__tests__/costops-export.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { syncFixedCostsToLedger } from '../costops/ledger.js'
+import { exportCostRows, rowsToCsv } from '../costops/export.js'
+import { ingestEmailCosts } from '../costops/email-ingest.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+
+function cfg(): CostOpsConfig {
+  return {
+    version: 1,
+    currency: 'HUF',
+    fixed_costs: [
+      { source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 22000, period: 'monthly', confidence: 'manual', currency: 'HUF' },
+    ],
+    budgets: [],
+  }
+}
+
+describe('costops export', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('exports only sanitized fields -- no raw ids, no PII, no email/invoice-number leakage', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const rows = exportCostRows(db, NOW, { month: '2026-07' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toEqual({
+      provider: 'anthropic', source_type: 'subscription', service_name: 'Claude Max',
+      period: '2026-07', amount: 22000, currency: 'HUF', confidence: 'manual',
+      original_amount: null, original_currency: null,
+    })
+    const keys = Object.keys(rows[0])
+    expect(keys).not.toContain('account_ref')
+    expect(keys).not.toContain('source_ref')
+  })
+
+  it('returns an empty array (not a fabricated row) for a month with no data', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW)
+    const rows = exportCostRows(db, NOW, { month: '2026-01' })
+    expect(rows).toEqual([])
+  })
+
+  it('supports a month range', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW, '2026-06')
+    syncFixedCostsToLedger(db, cfg(), NOW, '2026-07')
+    const rows = exportCostRows(db, NOW, { fromMonth: '2026-06', toMonth: '2026-07' })
+    expect(rows.map(r => r.period).sort()).toEqual(['2026-06', '2026-07'])
+  })
+
+  it('CSV rendering escapes commas/quotes and has a header row', () => {
+    const csv = rowsToCsv([{ provider: 'a,b', source_type: 's', service_name: 'Has "quotes"', period: '2026-07', amount: 100, currency: 'HUF', confidence: 'manual', original_amount: null, original_currency: null }])
+    const lines = csv.trim().split('\n')
+    expect(lines[0]).toBe('provider,source_type,service_name,period,amount,currency,confidence,original_amount,original_currency')
+    expect(lines[1]).toContain('"a,b"')
+    expect(lines[1]).toContain('"Has ""quotes"""')
+  })
+
+  it('currency-retention: a converted (USD) invoice keeps original_amount/original_currency; an already-HUF line does not', () => {
+    const db = getDb()
+    ingestEmailCosts(db, [
+      { source_id: 'render-hosting', name: 'Render', provider: 'render', amount: 11.15, currency: 'USD', month: '2026-07', message_ref: 'msg-usd-1' },
+      { source_id: 'openai-chatgpt', name: 'ChatGPT', provider: 'openai', amount: 8999, currency: 'HUF', month: '2026-07', message_ref: 'msg-huf-1' },
+    ], { fxUsdHuf: 360, now: NOW })
+    const rows = exportCostRows(db, NOW, { month: '2026-07' })
+    const render = rows.find(r => r.provider === 'render')!
+    const openai = rows.find(r => r.provider === 'openai')!
+    expect(render.amount).toBeCloseTo(11.15 * 360, 1)
+    expect(render.original_amount).toBe(11.15)
+    expect(render.original_currency).toBe('USD')
+    expect(openai.original_amount).toBeNull()
+    expect(openai.original_currency).toBeNull()
+  })
+})

--- a/src/__tests__/costops-forecast-capture.test.ts
+++ b/src/__tests__/costops-forecast-capture.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { captureForecastSnapshots, listForecastSnapshots } from '../costops/forecast-capture.js'
+import { monthWindow } from '../costops/ledger.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+function insertSource(db: import('better-sqlite3').Database, id: string, provider: string) {
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, ?, 'usage', 'HUF', 1, ?, ?)`)
+    .run(id, id, provider, NOW, NOW)
+}
+
+function insertLine(db: import('better-sqlite3').Database, sourceId: string, amount: number, confidence: string, category = 'subscription') {
+  const win = monthWindow(NOW)
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key)
+    VALUES (?, ?, ?, ?, ?, 'HUF', ?, ?, ?, ?)
+  `).run(sourceId, win.start, win.end, category, amount, confidence, NOW, NOW, `test|${sourceId}|${Math.random()}`)
+}
+
+describe('captureForecastSnapshots (CostOps Phase 1, GAP-10 orchestration)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('captures one snapshot per active source plus a whole-deployment TOTAL row', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other')
+    insertSource(db, 'hosting', 'other')
+    insertLine(db, 'domain', 3000, 'manual')
+    insertLine(db, 'hosting', 5000, 'manual')
+
+    const results = captureForecastSnapshots(db, NOW)
+    expect(results).toHaveLength(3) // domain + hosting + TOTAL
+    const total = results.find(r => r.source_id === null)!
+    expect(total.result.amount).toBe(8000)
+
+    const stored = listForecastSnapshots(db)
+    expect(stored).toHaveLength(3)
+  })
+
+  it('a fixed subscription (no usage category) forecasts full amount, not prorated', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other')
+    insertLine(db, 'domain', 3000, 'manual', 'subscription')
+    const [r] = captureForecastSnapshots(db, NOW)
+    expect(r.result.method).toBe('fixed_subscription')
+    expect(r.result.amount).toBe(3000)
+  })
+
+  it('a usage-category source forecasts by run-rate, greater than the MTD amount mid-month', () => {
+    const db = getDb()
+    insertSource(db, 'api-usage', 'other')
+    insertLine(db, 'api-usage', 1000, 'provider_api', 'usage')
+    const results = captureForecastSnapshots(db, NOW)
+    const r = results.find(x => x.source_id === 'api-usage')!
+    expect(r.result.method).toBe('time_proportional_usage')
+    expect(r.result.amount).toBeGreaterThan(1000)
+  })
+
+  it('a source with balance snapshots (DeepSeek-shaped) uses balance_delta, not fixed/usage defaults', () => {
+    const db = getDb()
+    insertSource(db, 'deepseek-api', 'deepseek')
+    const win = monthWindow(NOW)
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',100,?)`).run(win.start + 86400)
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',80,?)`).run(win.start + 5 * 86400)
+    const results = captureForecastSnapshots(db, NOW)
+    const r = results.find(x => x.source_id === 'deepseek-api')!
+    expect(r.result.method).toBe('balance_delta')
+  })
+
+  it('a source with no cost_line_items this month still gets a forecast row (0 mtd, fixed_subscription default)', () => {
+    const db = getDb()
+    insertSource(db, 'idle-source', 'other')
+    const results = captureForecastSnapshots(db, NOW)
+    const r = results.find(x => x.source_id === 'idle-source')!
+    expect(r.result.amount).toBe(0)
+  })
+
+  it('a pending_permission or provider_plan_estimate line is excluded from the resolved mtd amount', () => {
+    const db = getDb()
+    insertSource(db, 'aws', 'aws')
+    insertLine(db, 'aws', 0, 'pending_permission')
+    const results = captureForecastSnapshots(db, NOW)
+    const r = results.find(x => x.source_id === 'aws')!
+    expect(r.result.amount).toBe(0) // never fabricated from the excluded pending line
+  })
+
+  it('capturing twice the same day is idempotent -- no duplicate rows (dedup_key includes the day)', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other')
+    insertLine(db, 'domain', 3000, 'manual')
+    captureForecastSnapshots(db, NOW)
+    captureForecastSnapshots(db, NOW + 3600) // same day, 1h later
+    const stored = listForecastSnapshots(db)
+    expect(stored).toHaveLength(2) // domain + TOTAL, not 4
+  })
+
+  it('listForecastSnapshots filters by month when given one', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other')
+    insertLine(db, 'domain', 3000, 'manual')
+    captureForecastSnapshots(db, NOW)
+    const win = monthWindow(NOW)
+    expect(listForecastSnapshots(db, { month: win.key })).toHaveLength(2)
+    expect(listForecastSnapshots(db, { month: '2020-01' })).toHaveLength(0)
+  })
+})

--- a/src/__tests__/costops-forecast.test.ts
+++ b/src/__tests__/costops-forecast.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  forecastFixedSubscription,
+  forecastTimeProportionalUsage,
+  forecastBalanceDelta,
+  forecastInvoiceCadence,
+  forecastOneTime,
+  forecastManual,
+  resolveSourceForecast,
+  computeForecastError,
+  summarizeForecastAccuracy,
+  forecastSnapshotDedupKey,
+  initForecastSchema,
+  type ForecastContext,
+} from '../costops/forecast.js'
+import type { MonthWindow } from '../costops/ledger.js'
+import type { BalanceSnapshot } from '../costops/collectors/deepseek.js'
+
+// Hand-built MonthWindow fixtures -- these functions are pure over the
+// interface shape, not tied to monthWindow()'s calendar math.
+function win(fractionElapsed: number): MonthWindow {
+  const daysInMonth = 30
+  const start = 0
+  const end = daysInMonth * 86400
+  return { key: '2026-07', start, end, daysInMonth, fractionElapsed }
+}
+
+describe('forecastFixedSubscription', () => {
+  it('returns the full period amount regardless of elapsed fraction', () => {
+    const r = forecastFixedSubscription(22000, 'manual')
+    expect(r.method).toBe('fixed_subscription')
+    expect(r.amount).toBe(22000)
+  })
+
+  it('is high confidence for invoice/provider-observed amounts, medium for manual/estimate', () => {
+    expect(forecastFixedSubscription(1000, 'actual_invoice').confidence).toBe('high')
+    expect(forecastFixedSubscription(1000, 'provider_api').confidence).toBe('high')
+    expect(forecastFixedSubscription(1000, 'billing_export').confidence).toBe('high')
+    expect(forecastFixedSubscription(1000, 'manual').confidence).toBe('medium')
+    expect(forecastFixedSubscription(1000, 'estimate').confidence).toBe('medium')
+  })
+})
+
+describe('forecastTimeProportionalUsage', () => {
+  it('projects month-end as MTD / fractionElapsed', () => {
+    const r = forecastTimeProportionalUsage(1000, win(0.5))
+    expect(r.amount).toBe(2000)
+    expect(r.method).toBe('time_proportional_usage')
+  })
+
+  it('confidence is low early in the month, medium mid-month, high late', () => {
+    expect(forecastTimeProportionalUsage(100, win(0.1)).confidence).toBe('low')
+    expect(forecastTimeProportionalUsage(100, win(0.3)).confidence).toBe('medium')
+    expect(forecastTimeProportionalUsage(100, win(0.9)).confidence).toBe('high')
+  })
+})
+
+describe('forecastBalanceDelta', () => {
+  const NOW = 15 * 86400 // mid-month
+
+  it('falls back to MTD-only, low confidence, with fewer than 2 snapshots', () => {
+    const snaps: BalanceSnapshot[] = [{ balance: 100, captured_at: 1 * 86400 }]
+    const r = forecastBalanceDelta(snaps, win(0.5), NOW)
+    expect(r.confidence).toBe('low')
+    expect(r.amount).toBe(0)
+  })
+
+  it('falls back to MTD-only when the observed span is too short', () => {
+    const snaps: BalanceSnapshot[] = [
+      { balance: 100, captured_at: 1 * 3600 },
+      { balance: 90, captured_at: 2 * 3600 }, // 1 hour apart, well under MIN_FORECAST_SPAN_SECONDS
+    ]
+    const r = forecastBalanceDelta(snaps, win(0.5), NOW)
+    expect(r.confidence).toBe('low')
+  })
+
+  it('extrapolates month-end from a daily burn rate over a longer span', () => {
+    // 10 days of history, dropping 10/day -> burn rate 10/day, 100 total spend.
+    const snaps: BalanceSnapshot[] = []
+    for (let d = 0; d <= 10; d++) snaps.push({ balance: 200 - d * 10, captured_at: d * 86400 })
+    const r = forecastBalanceDelta(snaps, win(0.5), 10 * 86400)
+    // MTD (within month window [0, 30d)) = full 100 spend observed so far.
+    // remaining days = (end - now) / 86400 = (30*86400 - 10*86400)/86400 = 20
+    // projected = 100 + 10*20 = 300
+    expect(r.amount).toBe(300)
+    expect(r.confidence).toBe('high')
+  })
+
+  it('ignores balance RISES (top-ups) when deriving spend', () => {
+    const snaps: BalanceSnapshot[] = [
+      { balance: 100, captured_at: 0 },
+      { balance: 50, captured_at: 5 * 86400 },   // spend 50
+      { balance: 150, captured_at: 6 * 86400 },  // top-up, ignored
+      { balance: 100, captured_at: 11 * 86400 }, // spend 50
+    ]
+    const r = forecastBalanceDelta(snaps, win(0.5), 11 * 86400)
+    // total observed spend = 100 (50+50), span = 11 days -> ~9.09/day burn
+    expect(r.amount).toBeGreaterThan(100) // mtd + remaining-day extrapolation
+  })
+})
+
+describe('forecastInvoiceCadence', () => {
+  it('uses the full amount when this month IS the invoice month', () => {
+    const r = forecastInvoiceCadence(120000, 'annual', { isInvoiceMonth: true })
+    expect(r.amount).toBe(120000)
+    expect(r.confidence).toBe('high')
+  })
+
+  it('accrues evenly across the cadence when not the invoice month', () => {
+    const r = forecastInvoiceCadence(120000, 'annual')
+    expect(r.amount).toBe(10000) // 120000 / 12
+    expect(r.confidence).toBe('medium')
+  })
+
+  it('quarterly accrual divides by 3', () => {
+    const r = forecastInvoiceCadence(9000, 'quarterly')
+    expect(r.amount).toBe(3000)
+  })
+
+  it('monthly cadence is high confidence even without isInvoiceMonth (accrual == full amount)', () => {
+    const r = forecastInvoiceCadence(5000, 'monthly')
+    expect(r.amount).toBe(5000)
+    expect(r.confidence).toBe('high')
+  })
+})
+
+describe('forecastOneTime', () => {
+  it('equals the actual when already occurred, high confidence', () => {
+    const r = forecastOneTime(4500, null)
+    expect(r.amount).toBe(4500)
+    expect(r.confidence).toBe('high')
+  })
+
+  it('uses the planned amount when not yet occurred but known in advance, medium confidence', () => {
+    const r = forecastOneTime(null, 3000)
+    expect(r.amount).toBe(3000)
+    expect(r.confidence).toBe('medium')
+  })
+
+  it('forecasts 0, low confidence, when nothing is known -- never fabricated', () => {
+    const r = forecastOneTime(null, null)
+    expect(r.amount).toBe(0)
+    expect(r.confidence).toBe('low')
+  })
+})
+
+describe('forecastManual', () => {
+  it('passes through the operator figure at low confidence', () => {
+    const r = forecastManual(7777)
+    expect(r.amount).toBe(7777)
+    expect(r.confidence).toBe('low')
+    expect(r.method).toBe('manual_forecast')
+  })
+})
+
+describe('resolveSourceForecast dispatcher precedence', () => {
+  const base: ForecastContext = { mtd_amount: 1000, win: win(0.5), now: 15 * 86400 }
+
+  it('manual_override wins over everything else', () => {
+    const ctx: ForecastContext = { ...base, manual_override: 999, charge_category: 'usage', balance_snapshots: [{ balance: 1, captured_at: 0 }, { balance: 0, captured_at: 86400 * 5 }] }
+    expect(resolveSourceForecast(ctx).method).toBe('manual_forecast')
+  })
+
+  it('balance_snapshots beats cadence and charge_category', () => {
+    const ctx: ForecastContext = { ...base, balance_snapshots: [{ balance: 1, captured_at: 0 }], cadence: 'annual', last_invoice_amount: 1000, charge_category: 'usage' }
+    expect(resolveSourceForecast(ctx).method).toBe('balance_delta')
+  })
+
+  it('non-monthly cadence beats charge_category when a last invoice amount is known', () => {
+    const ctx: ForecastContext = { ...base, cadence: 'annual', last_invoice_amount: 12000, charge_category: 'purchase' }
+    expect(resolveSourceForecast(ctx).method).toBe('invoice_cadence')
+  })
+
+  it('monthly cadence does NOT trigger invoice_cadence (falls through)', () => {
+    const ctx: ForecastContext = { ...base, cadence: 'monthly', last_invoice_amount: 12000, charge_category: 'subscription' }
+    expect(resolveSourceForecast(ctx).method).toBe('fixed_subscription')
+  })
+
+  it('purchase charge_category resolves to one_time', () => {
+    const ctx: ForecastContext = { ...base, charge_category: 'purchase', occurred_amount: 500 }
+    const r = resolveSourceForecast(ctx)
+    expect(r.method).toBe('one_time')
+    expect(r.amount).toBe(500)
+  })
+
+  it('usage charge_category resolves to time_proportional_usage', () => {
+    const ctx: ForecastContext = { ...base, charge_category: 'usage' }
+    expect(resolveSourceForecast(ctx).method).toBe('time_proportional_usage')
+  })
+
+  it('defaults to fixed_subscription for subscription/no category', () => {
+    const ctx: ForecastContext = { ...base, charge_category: 'subscription' }
+    expect(resolveSourceForecast(ctx).method).toBe('fixed_subscription')
+    expect(resolveSourceForecast({ ...base }).method).toBe('fixed_subscription')
+  })
+})
+
+describe('computeForecastError', () => {
+  it('is positive when the forecast under-shot the actual', () => {
+    const e = computeForecastError(100, 120)
+    expect(e.absolute_error).toBe(20)
+    expect(e.percent_error).toBeCloseTo(20 / 120, 4)
+  })
+
+  it('is negative when the forecast over-shot the actual', () => {
+    const e = computeForecastError(150, 100)
+    expect(e.absolute_error).toBe(-50)
+    expect(e.percent_error).toBeCloseTo(-50 / 100, 4)
+  })
+
+  it('percent_error is null (never fabricated) when actual is 0', () => {
+    const e = computeForecastError(100, 0)
+    expect(e.absolute_error).toBe(-100)
+    expect(e.percent_error).toBeNull()
+  })
+})
+
+describe('summarizeForecastAccuracy', () => {
+  it('groups by an arbitrary key and reports mean absolute/percent error', () => {
+    const records = [
+      { provider: 'render', forecast_amount: 100, actual_amount: 120 },
+      { provider: 'render', forecast_amount: 200, actual_amount: 180 },
+      { provider: 'anthropic', forecast_amount: 50, actual_amount: 50 },
+    ]
+    const summary = summarizeForecastAccuracy(records, r => r.provider)
+    const render = summary.find(s => s.key === 'render')!
+    expect(render.count).toBe(2)
+    // |120-100| + |180-200| = 20 + 20 = 40 -> mean 20
+    expect(render.mean_absolute_error).toBe(20)
+    const anthropic = summary.find(s => s.key === 'anthropic')!
+    expect(anthropic.mean_absolute_error).toBe(0)
+    expect(anthropic.mean_percent_error).toBe(0)
+  })
+
+  it('mean_percent_error is null only when EVERY record in the group has actual 0', () => {
+    const records = [
+      { provider: 'x', forecast_amount: 10, actual_amount: 0 },
+      { provider: 'x', forecast_amount: 5, actual_amount: 0 },
+    ]
+    const summary = summarizeForecastAccuracy(records, r => r.provider)
+    expect(summary[0].mean_percent_error).toBeNull()
+  })
+})
+
+describe('forecastSnapshotDedupKey', () => {
+  it('is deterministic per source per UTC day', () => {
+    const t1 = Math.floor(Date.UTC(2026, 6, 15, 1, 0, 0) / 1000)
+    const t2 = Math.floor(Date.UTC(2026, 6, 15, 23, 0, 0) / 1000)
+    expect(forecastSnapshotDedupKey('render-hosting', '2026-07', t1)).toBe(forecastSnapshotDedupKey('render-hosting', '2026-07', t2))
+  })
+
+  it('differs across days and uses TOTAL for a null source', () => {
+    const t1 = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+    const t2 = Math.floor(Date.UTC(2026, 6, 16, 12, 0, 0) / 1000)
+    expect(forecastSnapshotDedupKey('render-hosting', '2026-07', t1)).not.toBe(forecastSnapshotDedupKey('render-hosting', '2026-07', t2))
+    expect(forecastSnapshotDedupKey(null, '2026-07', t1)).toBe('TOTAL|2026-07|2026-07-15')
+  })
+})
+
+describe('initForecastSchema', () => {
+  it('is idempotent and the table accepts a row keyed by dedup_key', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initForecastSchema(db)
+    initForecastSchema(db) // second call must not throw (IF NOT EXISTS)
+    const now = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-hosting','Render','render','hosting','HUF',1,@now,@now)`).run({ now })
+    db.prepare(`
+      INSERT INTO forecast_snapshots (source_id, month, snapshot_at, method, forecast_amount, confidence, dedup_key, created_at)
+      VALUES ('render-hosting', '2026-07', @now, 'fixed_subscription', 12000, 'high', @dk, @now)
+    `).run({ now, dk: forecastSnapshotDedupKey('render-hosting', '2026-07', now) })
+    const row = db.prepare(`SELECT * FROM forecast_snapshots WHERE source_id = 'render-hosting'`).get() as { forecast_amount: number; actual_amount: number | null }
+    expect(row.forecast_amount).toBe(12000)
+    expect(row.actual_amount).toBeNull() // never fabricated until period close
+  })
+
+  it('rejects a duplicate dedup_key (same source, same day)', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initForecastSchema(db)
+    const now = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-hosting','Render','render','hosting','HUF',1,@now,@now)`).run({ now })
+    const dk = forecastSnapshotDedupKey('render-hosting', '2026-07', now)
+    db.prepare(`INSERT INTO forecast_snapshots (source_id, month, snapshot_at, method, forecast_amount, confidence, dedup_key, created_at) VALUES ('render-hosting','2026-07',@now,'fixed_subscription',12000,'high',@dk,@now)`).run({ now, dk })
+    expect(() => {
+      db.prepare(`INSERT INTO forecast_snapshots (source_id, month, snapshot_at, method, forecast_amount, confidence, dedup_key, created_at) VALUES ('render-hosting','2026-07',@now,'fixed_subscription',13000,'high',@dk,@now)`).run({ now, dk })
+    }).toThrow()
+  })
+})

--- a/src/__tests__/costops-fx.test.ts
+++ b/src/__tests__/costops-fx.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  resolveFxRate,
+  roundHuf,
+  resolveRateDate,
+  convertToHufWithProvenance,
+  canRecomputeFx,
+  convertCorrectionToHuf,
+  lookupHistoricalRate,
+  fxRateDedupKey,
+  initFxSchema,
+  type FxRateTable,
+  type FxRateRecord,
+} from '../costops/fx.js'
+
+const RATES: FxRateTable = { USD: 350, EUR: 380 }
+
+describe('resolveFxRate', () => {
+  it('HUF is always rate 1, regardless of the table', () => {
+    expect(resolveFxRate('HUF', {})).toBe(1)
+    expect(resolveFxRate('huf', { HUF: 999 })).toBe(1)
+  })
+
+  it('resolves USD/EUR from the table, case-insensitively', () => {
+    expect(resolveFxRate('USD', RATES)).toBe(350)
+    expect(resolveFxRate('eur', RATES)).toBe(380)
+  })
+
+  it('returns null (never fabricated) for an unsupported currency', () => {
+    expect(resolveFxRate('GBP', RATES)).toBeNull()
+  })
+
+  it('returns null for a zero or negative rate in the table (never a bogus conversion)', () => {
+    expect(resolveFxRate('USD', { USD: 0 })).toBeNull()
+    expect(resolveFxRate('USD', { USD: -5 })).toBeNull()
+  })
+})
+
+describe('roundHuf', () => {
+  it('rounds to 2 decimal places', () => {
+    expect(roundHuf(100.005)).toBeCloseTo(100.01, 2)
+    expect(roundHuf(99.994)).toBe(99.99)
+    expect(roundHuf(1234.5)).toBe(1234.5)
+  })
+})
+
+describe('resolveRateDate', () => {
+  it('prefers the invoice date when known', () => {
+    const r = resolveRateDate(1000, 2000)
+    expect(r.date).toBe(1000)
+    expect(r.basis).toBe('invoice_date')
+  })
+
+  it('falls back to the service date when there is no invoice', () => {
+    const r = resolveRateDate(null, 2000)
+    expect(r.date).toBe(2000)
+    expect(r.basis).toBe('service_date')
+  })
+})
+
+describe('convertToHufWithProvenance', () => {
+  it('carries full provenance for a USD conversion at the invoice date', () => {
+    const c = convertToHufWithProvenance(10, 'USD', RATES, { fxSource: 'render_pricing_config', invoiceDate: 500, serviceDate: 100, now: 999 })
+    expect(c).not.toBeNull()
+    expect(c!.original_amount).toBe(10)
+    expect(c!.original_currency).toBe('USD')
+    expect(c!.fx_rate).toBe(350)
+    expect(c!.fx_source).toBe('render_pricing_config')
+    expect(c!.fx_date).toBe(500) // invoice date wins
+    expect(c!.conversion_method).toBe('invoice_date_rate')
+    expect(c!.huf_amount).toBe(3500)
+    expect(c!.converted_at).toBe(999)
+  })
+
+  it('uses service_date_rate when no invoice date is given', () => {
+    const c = convertToHufWithProvenance(10, 'EUR', RATES, { fxSource: 'manual', invoiceDate: null, serviceDate: 100, now: 999 })
+    expect(c!.conversion_method).toBe('service_date_rate')
+    expect(c!.fx_date).toBe(100)
+    expect(c!.huf_amount).toBe(3800)
+  })
+
+  it('HUF passes through at rate 1 with huf_amount == original amount', () => {
+    const c = convertToHufWithProvenance(5000, 'HUF', RATES, { fxSource: 'manual', invoiceDate: null, serviceDate: 1, now: 1 })
+    expect(c!.fx_rate).toBe(1)
+    expect(c!.huf_amount).toBe(5000)
+  })
+
+  it('returns null (never a fabricated conversion) for an unsupported currency', () => {
+    const c = convertToHufWithProvenance(10, 'GBP', RATES, { fxSource: 'manual', invoiceDate: null, serviceDate: 1, now: 1 })
+    expect(c).toBeNull()
+  })
+})
+
+describe('canRecomputeFx', () => {
+  it('forbids recomputation only for closed periods', () => {
+    expect(canRecomputeFx('closed')).toBe(false)
+    expect(canRecomputeFx('open')).toBe(true)
+    expect(canRecomputeFx('provisional')).toBe(true)
+    expect(canRecomputeFx('reopened')).toBe(true)
+  })
+})
+
+describe('convertCorrectionToHuf', () => {
+  it('produces an independent conversion rated as of the CORRECTION date, not the original', () => {
+    const correction = convertCorrectionToHuf({
+      originalCurrency: 'usd',
+      correctionAmountOriginalCurrency: -10, // a refund/credit
+      correctionDate: 5000,
+      correctionRate: 360, // a DIFFERENT rate than the original conversion used
+      correctionSource: 'provider_invoice',
+      now: 5001,
+    })
+    expect(correction.original_currency).toBe('USD')
+    expect(correction.fx_rate).toBe(360)
+    expect(correction.fx_date).toBe(5000)
+    expect(correction.conversion_method).toBe('correction_date_rate')
+    expect(correction.huf_amount).toBe(-3600)
+  })
+})
+
+describe('lookupHistoricalRate', () => {
+  const records: FxRateRecord[] = [
+    { currency: 'USD', rate: 340, fx_source: 'render_pricing_config', effective_date: 1000 },
+    { currency: 'USD', rate: 350, fx_source: 'render_pricing_config', effective_date: 2000 },
+    { currency: 'USD', rate: 360, fx_source: 'render_pricing_config', effective_date: 3000 },
+    { currency: 'EUR', rate: 380, fx_source: 'render_pricing_config', effective_date: 2500 },
+  ]
+
+  it('returns the most recent record at or before the requested date', () => {
+    expect(lookupHistoricalRate(records, 'USD', 2500)?.rate).toBe(350)
+    expect(lookupHistoricalRate(records, 'USD', 3000)?.rate).toBe(360)
+  })
+
+  it('never applies a future rate to a past date', () => {
+    expect(lookupHistoricalRate(records, 'USD', 500)).toBeNull()
+  })
+
+  it('filters by currency', () => {
+    expect(lookupHistoricalRate(records, 'EUR', 2500)?.rate).toBe(380)
+  })
+
+  it('is reproducible: same snapshot + same date always resolves the same rate', () => {
+    const a = lookupHistoricalRate(records, 'USD', 2500)
+    const b = lookupHistoricalRate(records, 'USD', 2500)
+    expect(a).toEqual(b)
+  })
+})
+
+describe('fxRateDedupKey', () => {
+  it('is stable within the same UTC day and differs across days', () => {
+    const t1 = Math.floor(Date.UTC(2026, 6, 15, 1, 0, 0) / 1000)
+    const t2 = Math.floor(Date.UTC(2026, 6, 15, 23, 0, 0) / 1000)
+    const t3 = Math.floor(Date.UTC(2026, 6, 16, 1, 0, 0) / 1000)
+    expect(fxRateDedupKey('USD', 'render_pricing_config', t1)).toBe(fxRateDedupKey('USD', 'render_pricing_config', t2))
+    expect(fxRateDedupKey('USD', 'render_pricing_config', t1)).not.toBe(fxRateDedupKey('USD', 'render_pricing_config', t3))
+  })
+
+  it('differs by currency and source', () => {
+    const t = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    expect(fxRateDedupKey('USD', 'render_pricing_config', t)).not.toBe(fxRateDedupKey('EUR', 'render_pricing_config', t))
+    expect(fxRateDedupKey('USD', 'render_pricing_config', t)).not.toBe(fxRateDedupKey('USD', 'manual', t))
+  })
+})
+
+describe('initFxSchema', () => {
+  it('is idempotent and adds fx_source/conversion_method columns onto cost_line_items', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initFxSchema(db)
+    initFxSchema(db) // second call must not throw
+    const now = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('anthropic-api','Anthropic API','anthropic','usage','HUF',1,@now,@now)`).run({ now })
+    db.prepare(`
+      INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, fx_source, conversion_method, original_amount, original_currency, fx_rate, fx_date)
+      VALUES ('anthropic-api', @now, @now, 'usage', 3500, 'HUF', 'provider_api', @now, @now, 'render_pricing_config', 'invoice_date_rate', 10, 'USD', 350, @now)
+    `).run({ now })
+    const row = db.prepare(`SELECT fx_source, conversion_method FROM cost_line_items WHERE source_id = 'anthropic-api'`).get() as { fx_source: string; conversion_method: string }
+    expect(row.fx_source).toBe('render_pricing_config')
+    expect(row.conversion_method).toBe('invoice_date_rate')
+  })
+
+  it('creates the fx_rates table and enforces one row per dedup_key', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initFxSchema(db)
+    const now = Math.floor(Date.UTC(2026, 6, 15) / 1000)
+    const dk = fxRateDedupKey('USD', 'render_pricing_config', now)
+    db.prepare(`INSERT INTO fx_rates (currency, rate, fx_source, effective_date, captured_at, dedup_key) VALUES ('USD', 350, 'render_pricing_config', @now, @now, @dk)`).run({ now, dk })
+    expect(() => {
+      db.prepare(`INSERT INTO fx_rates (currency, rate, fx_source, effective_date, captured_at, dedup_key) VALUES ('USD', 360, 'render_pricing_config', @now, @now, @dk)`).run({ now, dk })
+    }).toThrow()
+    const row = db.prepare(`SELECT rate FROM fx_rates WHERE dedup_key = ?`).get(dk) as { rate: number }
+    expect(row.rate).toBe(350)
+  })
+})

--- a/src/__tests__/costops-github.test.ts
+++ b/src/__tests__/costops-github.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { mapGitHubUsage, githubCollector, syncGitHubCollector } from '../costops/collectors/github.js'
+import { monthWindow } from '../costops/ledger.js'
+import type { CollectOpts } from '../costops/collectors/types.js'
+
+const START = Math.floor(Date.UTC(2026, 6, 1) / 1000)
+const END = Math.floor(Date.UTC(2026, 7, 1) / 1000)
+
+function report(amounts: number[]) {
+  return { usageItems: amounts.map((a, i) => ({ date: '2026-07-0' + (i + 1), product: 'actions', sku: 'x', quantity: 1, unitType: 'min', netAmount: a })) }
+}
+
+describe('mapGitHubUsage (pure, offline)', () => {
+  it('sums netAmount USD into one HUF provider_api line for github', () => {
+    const lines = mapGitHubUsage(report([2, 3]), { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })
+    expect(lines).toHaveLength(1)
+    expect(lines[0].provider).toBe('github')
+    expect(lines[0].confidence).toBe('provider_api')
+    expect(lines[0].amount).toBe(Math.round(5 * 360 * 100) / 100)
+    expect(lines[0].dedup_key).toBe('provider|github|github|2026-07|provider_api')
+  })
+
+  it('emits an EXPLICIT 0 provider_api line on a valid empty report (API-observed zero)', () => {
+    const lines = mapGitHubUsage({ usageItems: [] }, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })
+    expect(lines).toHaveLength(1)
+    expect(lines[0].amount).toBe(0)
+    expect(lines[0].confidence).toBe('provider_api')
+  })
+
+  it('returns [] only when the raw is not a usage report', () => {
+    expect(mapGitHubUsage(null, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })).toHaveLength(0)
+    expect(mapGitHubUsage({ message: 'Not Found' }, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })).toHaveLength(0)
+  })
+})
+
+describe('githubCollector + syncGitHubCollector (offline stub)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('sync imports a provider_api line (even at 0) with a stubbed key + fetcher; idempotent', async () => {
+    const db = getDb()
+    const now = Math.floor(Date.UTC(2026, 6, 10) / 1000)
+    const r1 = await syncGitHubCollector(db, now, { apiKey: 'ghp-stub', fxUsdHuf: 360, httpGetJson: async () => report([]) })
+    expect(r1.ok).toBe(true)
+    expect(r1.imported_count).toBe(1)
+    const row = db.prepare("SELECT billed_cost, confidence FROM cost_line_items WHERE source_id='github'").get() as { billed_cost: number; confidence: string }
+    expect(row.billed_cost).toBe(0)
+    expect(row.confidence).toBe('provider_api')
+    // idempotent
+    await syncGitHubCollector(db, now, { apiKey: 'ghp-stub', fxUsdHuf: 360, httpGetJson: async () => report([]) })
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='github'").get() as { c: number }).c).toBe(1)
+    const audit = JSON.stringify(db.prepare('SELECT * FROM import_runs').all())
+    expect(audit).not.toContain('ghp-stub')
+  })
+
+  it('errors (no import) when the vault token is missing', async () => {
+    const db = getDb()
+    const r = await syncGitHubCollector(db, Math.floor(Date.now() / 1000), { apiKey: null, fxUsdHuf: 360, httpGetJson: async () => report([1]) })
+    expect(r.ok).toBe(false)
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='github'").get() as { c: number }).c).toBe(0)
+  })
+})

--- a/src/__tests__/costops-import-durability.test.ts
+++ b/src/__tests__/costops-import-durability.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { buildDbImportLockContext, withImportLock, withRetry } from '../costops/collectors/import-durability.js'
+
+describe('withImportLock (CostOps Phase 1, GAP-07 -- per-provider concurrency lock)', () => {
+  it('acquires a free lock and runs fn, releasing afterward', async () => {
+    initDatabase(':memory:')
+    const ctx = buildDbImportLockContext(getDb())
+    const res = await withImportLock(ctx, 'openai', 1000, async () => 'done')
+    expect(res).toEqual({ ok: true, result: 'done' })
+    // released -- a second call for the same provider succeeds too
+    const res2 = await withImportLock(ctx, 'openai', 1001, async () => 'done again')
+    expect(res2).toEqual({ ok: true, result: 'done again' })
+  })
+
+  it('rejects a concurrent call for the same provider while the lock is held (simulated via a slow fn)', async () => {
+    initDatabase(':memory:')
+    const ctx = buildDbImportLockContext(getDb())
+    // Simulate "in flight": acquire directly, don't release yet.
+    ctx.tryAcquireLock('openai', 'holder-token', 1000, 10 * 60)
+    const res = await withImportLock(ctx, 'openai', 1005, async () => 'should not run')
+    expect(res).toEqual({ ok: false, reason: 'locked' })
+  })
+
+  it('does not block a DIFFERENT provider while one provider is locked', async () => {
+    initDatabase(':memory:')
+    const ctx = buildDbImportLockContext(getDb())
+    ctx.tryAcquireLock('openai', 'holder-token', 1000, 10 * 60)
+    const res = await withImportLock(ctx, 'github', 1005, async () => 'github runs fine')
+    expect(res).toEqual({ ok: true, result: 'github runs fine' })
+  })
+
+  it('releases the lock even when fn throws, so a failed run does not wedge the provider', async () => {
+    initDatabase(':memory:')
+    const ctx = buildDbImportLockContext(getDb())
+    await expect(withImportLock(ctx, 'openai', 1000, async () => { throw new Error('boom') })).rejects.toThrow('boom')
+    // lock was released in the finally -- a subsequent call succeeds
+    const res = await withImportLock(ctx, 'openai', 1001, async () => 'recovered')
+    expect(res).toEqual({ ok: true, result: 'recovered' })
+  })
+
+  it('reclaims a stale lock left by a crashed holder instead of wedging forever', async () => {
+    initDatabase(':memory:')
+    const ctx = buildDbImportLockContext(getDb())
+    ctx.tryAcquireLock('openai', 'crashed-holder', 1000, 10 * 60) // never released -- simulates a crash
+    // Well within staleAfterSecs -- still held.
+    expect(await withImportLock(ctx, 'openai', 1000 + 60, async () => 'x', { staleAfterSecs: 10 * 60 })).toEqual({ ok: false, reason: 'locked' })
+    // Past staleAfterSecs -- reclaimable.
+    const now = 1000 + 700 // 700s later, past a 600s stale threshold
+    const res = await withImportLock(ctx, 'openai', now, async () => 'reclaimed', { staleAfterSecs: 600 })
+    expect(res).toEqual({ ok: true, result: 'reclaimed' })
+  })
+
+  it('two different lock tokens never both succeed for a genuinely concurrent acquire attempt', () => {
+    initDatabase(':memory:')
+    const ctx = buildDbImportLockContext(getDb())
+    const first = ctx.tryAcquireLock('openai', 'token-a', 1000, 10 * 60)
+    const second = ctx.tryAcquireLock('openai', 'token-b', 1000, 10 * 60)
+    expect(first).toBe('acquired')
+    expect(second).toBe('held')
+  })
+})
+
+describe('withRetry (CostOps Phase 1, GAP-07 -- transient-error backoff)', () => {
+  it('returns the result immediately on first success, no sleep called', async () => {
+    const sleeps: number[] = []
+    const result = await withRetry(async () => 42, { sleep: async (ms) => { sleeps.push(ms) } })
+    expect(result).toBe(42)
+    expect(sleeps).toEqual([])
+  })
+
+  it('retries with exponential backoff until success', async () => {
+    const sleeps: number[] = []
+    let attempts = 0
+    const result = await withRetry(async () => {
+      attempts++
+      if (attempts < 3) throw new Error('transient')
+      return 'ok'
+    }, { maxAttempts: 5, baseDelayMs: 100, sleep: async (ms) => { sleeps.push(ms) } })
+    expect(result).toBe('ok')
+    expect(attempts).toBe(3)
+    expect(sleeps).toEqual([100, 200]) // 100*2^0, 100*2^1
+  })
+
+  it('throws the last error after exhausting maxAttempts', async () => {
+    let attempts = 0
+    await expect(withRetry(async () => { attempts++; throw new Error(`fail ${attempts}`) }, {
+      maxAttempts: 3, baseDelayMs: 10, sleep: async () => {},
+    })).rejects.toThrow('fail 3')
+    expect(attempts).toBe(3)
+  })
+
+  it('does not retry a non-retryable error -- throws on first failure', async () => {
+    let attempts = 0
+    await expect(withRetry(async () => { attempts++; throw new Error('permanent: bad credentials') }, {
+      maxAttempts: 5, sleep: async () => {},
+      isRetryable: (err) => !(err instanceof Error && err.message.startsWith('permanent')),
+    })).rejects.toThrow('permanent')
+    expect(attempts).toBe(1)
+  })
+})

--- a/src/__tests__/costops-inventory.test.ts
+++ b/src/__tests__/costops-inventory.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { buildSourceInventory } from '../costops/inventory.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const DAY = 86400
+
+function emptyConfig(overrides: Partial<CostOpsConfig> = {}): CostOpsConfig {
+  return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [], ...overrides }
+}
+
+function insertSource(db: import('better-sqlite3').Database, id: string, provider: string, sourceType = 'usage') {
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, ?, ?, 'HUF', 1, ?, ?)`)
+    .run(id, id, provider, sourceType, NOW, NOW)
+}
+
+function insertRun(db: import('better-sqlite3').Database, provider: string, status: string, startedAt: number, errorCode: string | null = null) {
+  db.prepare(`INSERT INTO import_runs (provider, collector_name, started_at, status, imported_count, error_code) VALUES (?, ?, ?, ?, 0, ?)`)
+    .run(provider, `${provider}-costs`, startedAt, status, errorCode)
+}
+
+function insertLine(db: import('better-sqlite3').Database, sourceId: string, opts: { billedCost: number; confidence: string; actualSource: string | null; freshness: number }) {
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+    VALUES (?, ?, ?, 'usage', ?, 'HUF', ?, ?, ?, ?, ?)
+  `).run(sourceId, NOW - DAY, NOW + DAY, opts.billedCost, opts.confidence, opts.freshness, NOW, `test|${sourceId}|${Math.random()}`, opts.actualSource)
+}
+
+describe('buildSourceInventory (CostOps Phase 0, GAP-03/GAP-04)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('the headline case: OpenAI with a working credential and zero usage is inactive, NOT credential_error/blocked (card 7f5a7fc9)', () => {
+    const db = getDb()
+    insertSource(db, 'openai-api', 'openai')
+    insertRun(db, 'openai', 'ok', NOW - DAY) // the collector DID run successfully, just imported 0 lines
+    const inv = buildSourceInventory(db, emptyConfig(), NOW, { credentialChecker: () => true })
+    const openai = inv.find(s => s.source_id === 'openai-api')!
+    expect(openai.lifecycle).toBe('inactive')
+    expect(openai.blocker).toBeNull()
+    expect(openai.collection_method).toBe('provider_api_collector')
+    expect(openai.sync_cadence).toBe('manual') // honest -- no collector is boot-scheduled today
+  })
+
+  it('OpenAI with no credential configured is not_configured, with a concrete blocker', () => {
+    const db = getDb()
+    insertSource(db, 'openai-api', 'openai')
+    const inv = buildSourceInventory(db, emptyConfig(), NOW, { credentialChecker: () => false })
+    const openai = inv.find(s => s.source_id === 'openai-api')!
+    expect(openai.lifecycle).toBe('not_configured')
+    expect(openai.blocker).toMatch(/credential|Vault secret/)
+  })
+
+  it('OpenAI with a credential but a genuinely failed last sync is blocked, carrying the error code', () => {
+    const db = getDb()
+    insertSource(db, 'openai-api', 'openai')
+    insertRun(db, 'openai', 'error', NOW - DAY, 'ETIMEDOUT')
+    const inv = buildSourceInventory(db, emptyConfig(), NOW, { credentialChecker: () => true })
+    const openai = inv.find(s => s.source_id === 'openai-api')!
+    expect(openai.lifecycle).toBe('blocked')
+    expect(openai.blocker).toBe('ETIMEDOUT')
+  })
+
+  it('a manual fixed-cost source with real spend is active, manual_actual, manual_fallback', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other', 'domain')
+    insertLine(db, 'domain', { billedCost: 3000, confidence: 'manual', actualSource: 'manual_entry', freshness: NOW })
+    const inv = buildSourceInventory(db, emptyConfig(), NOW)
+    const domain = inv.find(s => s.source_id === 'domain')!
+    expect(domain.lifecycle).toBe('active')
+    expect(domain.provenance).toBe('manual_actual')
+    expect(domain.collection_method).toBe('manual_config')
+    expect(domain.manual_fallback).toBe(true)
+    expect(domain.operational_inclusion_rule).toBe('operational')
+  })
+
+  it('a manual source with only a $0 placeholder row is inactive, not active', () => {
+    const db = getDb()
+    insertSource(db, 'placeholder-saas', 'other', 'saas')
+    insertLine(db, 'placeholder-saas', { billedCost: 0, confidence: 'manual', actualSource: 'manual_entry', freshness: NOW })
+    const inv = buildSourceInventory(db, emptyConfig(), NOW)
+    const s = inv.find(x => x.source_id === 'placeholder-saas')!
+    expect(s.lifecycle).toBe('inactive')
+    expect(s.operational_inclusion_rule).toBe('no_data_yet')
+  })
+
+  it('explicit lifecycle_override in config wins regardless of activity/credential signals', () => {
+    const db = getDb()
+    insertSource(db, 'old-saas', 'other', 'saas')
+    insertLine(db, 'old-saas', { billedCost: 5000, confidence: 'manual', actualSource: 'manual_entry', freshness: NOW })
+    const cfg = emptyConfig({ fixed_costs: [{ source_id: 'old-saas', name: 'Old SaaS', provider: 'other', source_type: 'saas', amount: 5000, lifecycle_override: 'deprecated' }] })
+    const inv = buildSourceInventory(db, cfg, NOW)
+    const s = inv.find(x => x.source_id === 'old-saas')!
+    expect(s.lifecycle).toBe('deprecated')
+  })
+
+  it('owner defaults to operator when not configured, honors an explicit config owner otherwise', () => {
+    const db = getDb()
+    insertSource(db, 'domain', 'other', 'domain')
+    insertSource(db, 'github-plan', 'github', 'saas')
+    const cfg = emptyConfig({ fixed_costs: [{ source_id: 'domain', name: 'Domain', provider: 'other', source_type: 'domain', amount: 0, owner: 'DevOps' }] })
+    const inv = buildSourceInventory(db, cfg, NOW, { credentialChecker: () => true })
+    expect(inv.find(s => s.source_id === 'domain')!.owner).toBe('DevOps')
+    expect(inv.find(s => s.source_id === 'github-plan')!.owner).toBe('operator')
+  })
+
+  it('freshness classifies fresh/aging/stale/unknown by age of the last observed line', () => {
+    const db = getDb()
+    insertSource(db, 'fresh-src', 'other')
+    insertSource(db, 'aging-src', 'other')
+    insertSource(db, 'stale-src', 'other')
+    insertSource(db, 'unknown-src', 'other')
+    insertLine(db, 'fresh-src', { billedCost: 100, confidence: 'manual', actualSource: 'manual_entry', freshness: NOW - DAY })
+    insertLine(db, 'aging-src', { billedCost: 100, confidence: 'manual', actualSource: 'manual_entry', freshness: NOW - 6 * DAY })
+    insertLine(db, 'stale-src', { billedCost: 100, confidence: 'manual', actualSource: 'manual_entry', freshness: NOW - 20 * DAY })
+    const inv = buildSourceInventory(db, emptyConfig(), NOW)
+    expect(inv.find(s => s.source_id === 'fresh-src')!.freshness).toBe('fresh')
+    expect(inv.find(s => s.source_id === 'aging-src')!.freshness).toBe('aging')
+    expect(inv.find(s => s.source_id === 'stale-src')!.freshness).toBe('stale')
+    expect(inv.find(s => s.source_id === 'unknown-src')!.freshness).toBe('unknown')
+  })
+
+  it('a pending_permission source is excluded from operational, never a fabricated amount', () => {
+    const db = getDb()
+    insertSource(db, 'aws', 'aws')
+    insertLine(db, 'aws', { billedCost: 0, confidence: 'pending_permission', actualSource: 'pending_permission', freshness: NOW })
+    const inv = buildSourceInventory(db, emptyConfig(), NOW)
+    const aws = inv.find(s => s.source_id === 'aws')!
+    expect(aws.operational_inclusion_rule).toBe('pending_permission_excluded')
+    expect(aws.provenance).toBe('unknown') // genuinely unobservable, never guessed
+  })
+
+  it('a Render plan-estimate line is advisory, not operational', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertLine(db, 'render-hosting', { billedCost: 5000, confidence: 'provider_plan_estimate', actualSource: 'provider_api', freshness: NOW })
+    const inv = buildSourceInventory(db, emptyConfig(), NOW, { credentialChecker: () => true })
+    const r = inv.find(s => s.source_id === 'render-hosting')!
+    expect(r.operational_inclusion_rule).toBe('advisory_plan_estimate')
+  })
+
+  it('a voided manual entry does not count toward activity/freshness/provenance', () => {
+    const db = getDb()
+    insertSource(db, 'ghost-cost', 'other')
+    insertLine(db, 'ghost-cost', { billedCost: 5000, confidence: 'manual', actualSource: 'manual_entry', freshness: NOW })
+    db.prepare(`UPDATE cost_line_items SET voided_at = ? WHERE source_id = 'ghost-cost'`).run(NOW)
+    const inv = buildSourceInventory(db, emptyConfig(), NOW)
+    const s = inv.find(x => x.source_id === 'ghost-cost')!
+    expect(s.lifecycle).toBe('inactive')
+    expect(s.provenance).toBe('unknown')
+    expect(s.freshness).toBe('unknown')
+  })
+
+  it('every source gets exactly one lifecycle, one provenance -- never both undefined/null', () => {
+    const db = getDb()
+    insertSource(db, 'a', 'other')
+    insertSource(db, 'b', 'openai')
+    insertSource(db, 'c', 'render')
+    const inv = buildSourceInventory(db, emptyConfig(), NOW, { credentialChecker: () => true })
+    for (const s of inv) {
+      expect(s.lifecycle).toBeTruthy()
+      expect(s.provenance).toBeTruthy()
+    }
+  })
+})

--- a/src/__tests__/costops-invoice.test.ts
+++ b/src/__tests__/costops-invoice.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { monthWindow } from '../costops/ledger.js'
+import { initPeriodCloseSchema } from '../costops/period-close.js'
+import {
+  computeNetAmount,
+  invoiceDedupKey,
+  inferExpectedInvoiceBy,
+  recordInvoice,
+  applyInvoiceAdjustment,
+  voidInvoice,
+  listInvoices,
+  buildInvoiceReconciliation,
+  initInvoiceSchema,
+  type InvoiceAmounts,
+} from '../costops/invoice.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+const SALT = 'test-salt'
+
+function amounts(over: Partial<InvoiceAmounts> = {}): InvoiceAmounts {
+  return { gross_amount: 100, tax_amount: 0, discount_amount: 0, credit_amount: 0, refund_amount: 0, late_charge_amount: 0, ...over }
+}
+
+function insertSource(db: ReturnType<typeof getDb>, id: string, provider: string): void {
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, ?, 'hosting', 'HUF', 1, ?, ?)`).run(id, id, provider, NOW, NOW)
+}
+
+function setup(): ReturnType<typeof getDb> {
+  initDatabase(':memory:')
+  const db = getDb()
+  initInvoiceSchema(db)
+  initPeriodCloseSchema(db)
+  return db
+}
+
+describe('computeNetAmount', () => {
+  it('subtracts discount/credit/refund and adds late_charge, never double-counting tax', () => {
+    expect(computeNetAmount(amounts({ gross_amount: 100 }))).toBe(100)
+    expect(computeNetAmount(amounts({ gross_amount: 100, discount_amount: 10 }))).toBe(90)
+    expect(computeNetAmount(amounts({ gross_amount: 100, credit_amount: 20, refund_amount: 5 }))).toBe(75)
+    expect(computeNetAmount(amounts({ gross_amount: 100, late_charge_amount: 15 }))).toBe(115)
+    expect(computeNetAmount(amounts({ gross_amount: 100, tax_amount: 20 }))).toBe(100) // tax is informational, not added again
+  })
+})
+
+describe('invoiceDedupKey', () => {
+  it('composes provider + ref + period', () => {
+    expect(invoiceDedupKey('render', 'abc123', '2026-07')).toBe('render|abc123|2026-07')
+  })
+})
+
+describe('inferExpectedInvoiceBy', () => {
+  it('is null with fewer than 2 historical invoices', () => {
+    expect(inferExpectedInvoiceBy([])).toBeNull()
+    expect(inferExpectedInvoiceBy([1000])).toBeNull()
+  })
+  it('projects the next expected date from the median gap + grace days', () => {
+    const d1 = Math.floor(Date.UTC(2026, 4, 31) / 1000) // May 31
+    const d2 = Math.floor(Date.UTC(2026, 5, 30) / 1000) // Jun 30 (30-day gap)
+    const expected = inferExpectedInvoiceBy([d1, d2], 15)
+    expect(expected).toBe(d2 + 30 * 86400 + 15 * 86400)
+  })
+})
+
+describe('recordInvoice -- validation', () => {
+  beforeEach(() => setup())
+
+  it('rejects missing required fields', () => {
+    const db = getDb()
+    expect(recordInvoice(db, { source_id: '', provider: 'render', invoice_ref: null, billing_period_start: 0, billing_period_end: 1, currency: 'HUF', gross_amount: 100 }, { now: NOW, salt: SALT }).status).toBe(400)
+  })
+  it('rejects a negative gross_amount', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    const r = recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: null, billing_period_start: 0, billing_period_end: 100, currency: 'HUF', gross_amount: -5 }, { now: NOW, salt: SALT })
+    expect(r.status).toBe(400)
+  })
+  it('rejects an invalid period range', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    const r = recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: null, billing_period_start: 100, billing_period_end: 50, currency: 'HUF', gross_amount: 10 }, { now: NOW, salt: SALT })
+    expect(r.status).toBe(400)
+  })
+})
+
+describe('recordInvoice -- first-time recording (no existing ledger line)', () => {
+  beforeEach(() => setup())
+
+  it('inserts a new cost_line_items row as actual_invoice/email_invoice', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const r = recordInvoice(db, {
+      source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-001',
+      billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 12000,
+    }, { now: NOW, salt: SALT })
+    expect(r.ok).toBe(true)
+    const line = db.prepare(`SELECT billed_cost, confidence, actual_source FROM cost_line_items WHERE id = ?`).get(r.ledgerLineId) as { billed_cost: number; confidence: string; actual_source: string }
+    expect(line.billed_cost).toBe(12000)
+    expect(line.confidence).toBe('actual_invoice')
+    expect(line.actual_source).toBe('email_invoice')
+  })
+
+  it('rejects a duplicate invoice (same provider+ref+period)', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const input = { source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-001', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 12000 }
+    const first = recordInvoice(db, input, { now: NOW, salt: SALT })
+    expect(first.ok).toBe(true)
+    const second = recordInvoice(db, input, { now: NOW + 10, salt: SALT })
+    expect(second.ok).toBe(false)
+    expect(second.duplicate).toBe(true)
+    const count = db.prepare(`SELECT COUNT(*) as n FROM costops_invoices`).get() as { n: number }
+    expect(count.n).toBe(1)
+  })
+
+  it('allows re-recording the same dedup_key after the original was voided', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const input = { source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-001', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 12000 }
+    const first = recordInvoice(db, input, { now: NOW, salt: SALT })
+    voidInvoice(db, first.invoiceId!, 'duplicate PDF, recorded in error', NOW + 5)
+    const second = recordInvoice(db, input, { now: NOW + 10, salt: SALT })
+    expect(second.ok).toBe(true)
+  })
+})
+
+describe('recordInvoice -- an active ledger line already exists', () => {
+  beforeEach(() => setup())
+
+  it('goes through createCorrection: the original line is voided (not deleted), a new corrected line appears', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    // pre-existing manual estimate line
+    const estInfo = db.prepare(`
+      INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, dedup_key, created_at)
+      VALUES ('render-hosting', @start, @end, 'usage', 10000, 'HUF', 'manual', @now, 'estimate-1', @now)
+    `).run({ start: win.start, end: win.end, now: NOW })
+    const originalLineId = estInfo.lastInsertRowid as number
+
+    const r = recordInvoice(db, {
+      source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-002',
+      billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 11500,
+    }, { now: NOW, salt: SALT })
+    expect(r.ok).toBe(true)
+    expect(r.ledgerLineId).not.toBe(originalLineId)
+
+    const original = db.prepare(`SELECT billed_cost, voided_at FROM cost_line_items WHERE id = ?`).get(originalLineId) as { billed_cost: number; voided_at: number | null }
+    expect(original.billed_cost).toBe(10000) // NEVER rewritten
+    expect(original.voided_at).not.toBeNull() // voided, not deleted
+
+    const corrected = db.prepare(`SELECT billed_cost, corrects_line_id FROM cost_line_items WHERE id = ?`).get(r.ledgerLineId) as { billed_cost: number; corrects_line_id: number }
+    expect(corrected.billed_cost).toBe(11500)
+    expect(corrected.corrects_line_id).toBe(originalLineId)
+  })
+})
+
+describe('recordInvoice -- closed period', () => {
+  beforeEach(() => setup())
+
+  it('is refused when the period is closed and there is no existing line to correct', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    db.prepare(`INSERT INTO period_status (month, status, updated_at) VALUES (?, 'closed', ?)`).run(win.key, NOW)
+
+    const r = recordInvoice(db, {
+      source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-003',
+      billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 5000,
+    }, { now: NOW, salt: SALT })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(409)
+  })
+
+  it('is allowed (as an audited correction) when the period is closed but an existing line can be corrected', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const estInfo = db.prepare(`
+      INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, dedup_key, created_at)
+      VALUES ('render-hosting', @start, @end, 'usage', 10000, 'HUF', 'manual', @now, 'estimate-1', @now)
+    `).run({ start: win.start, end: win.end, now: NOW })
+    const originalLineId = estInfo.lastInsertRowid as number
+    db.prepare(`INSERT INTO period_status (month, status, updated_at) VALUES (?, 'closed', ?)`).run(win.key, NOW)
+
+    const r = recordInvoice(db, {
+      source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-004',
+      billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 10500,
+    }, { now: NOW, salt: SALT })
+    expect(r.ok).toBe(true)
+    const corrected = db.prepare(`SELECT billed_cost, corrects_line_id FROM cost_line_items WHERE id = ?`).get(r.ledgerLineId) as { billed_cost: number; corrects_line_id: number }
+    expect(corrected.billed_cost).toBe(10500)
+    expect(corrected.corrects_line_id).toBe(originalLineId)
+  })
+})
+
+describe('applyInvoiceAdjustment', () => {
+  beforeEach(() => setup())
+
+  it('applies a credit and cascades the reduced net through a correction, keeping the original charge intact', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const rec = recordInvoice(db, {
+      source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-005',
+      billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 12000,
+    }, { now: NOW, salt: SALT })
+    const originalLineId = rec.ledgerLineId!
+
+    const adj = applyInvoiceAdjustment(db, { invoiceId: rec.invoiceId!, creditAmount: 2000, reason: 'provider goodwill credit' }, { now: NOW + 100 })
+    expect(adj.ok).toBe(true)
+
+    const original = db.prepare(`SELECT billed_cost, voided_at FROM cost_line_items WHERE id = ?`).get(originalLineId) as { billed_cost: number; voided_at: number | null }
+    expect(original.billed_cost).toBe(12000)
+    expect(original.voided_at).not.toBeNull()
+
+    const invoiceRow = db.prepare(`SELECT net_amount, credit_amount, ledger_line_id FROM costops_invoices WHERE id = ?`).get(rec.invoiceId) as { net_amount: number; credit_amount: number; ledger_line_id: number }
+    expect(invoiceRow.net_amount).toBe(10000)
+    expect(invoiceRow.credit_amount).toBe(2000)
+    const correctedLine = db.prepare(`SELECT billed_cost FROM cost_line_items WHERE id = ?`).get(invoiceRow.ledger_line_id) as { billed_cost: number }
+    expect(correctedLine.billed_cost).toBe(10000)
+  })
+
+  it('accumulates multiple partial adjustments rather than overwriting them', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const rec = recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-006', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 10000 }, { now: NOW, salt: SALT })
+    applyInvoiceAdjustment(db, { invoiceId: rec.invoiceId!, refundAmount: 500, reason: 'partial refund 1' }, { now: NOW + 10 })
+    applyInvoiceAdjustment(db, { invoiceId: rec.invoiceId!, refundAmount: 300, reason: 'partial refund 2' }, { now: NOW + 20 })
+    const invoiceRow = db.prepare(`SELECT net_amount, refund_amount FROM costops_invoices WHERE id = ?`).get(rec.invoiceId) as { net_amount: number; refund_amount: number }
+    expect(invoiceRow.refund_amount).toBe(800)
+    expect(invoiceRow.net_amount).toBe(9200)
+  })
+
+  it('rejects adjusting a voided invoice', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const rec = recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-007', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 10000 }, { now: NOW, salt: SALT })
+    voidInvoice(db, rec.invoiceId!, 'recorded in error', NOW + 5)
+    const adj = applyInvoiceAdjustment(db, { invoiceId: rec.invoiceId!, creditAmount: 100, reason: 'x' }, { now: NOW + 10 })
+    expect(adj.ok).toBe(false)
+    expect(adj.status).toBe(409)
+  })
+
+  it('requires a reason', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const rec = recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-008', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 10000 }, { now: NOW, salt: SALT })
+    const adj = applyInvoiceAdjustment(db, { invoiceId: rec.invoiceId!, creditAmount: 100, reason: '' }, { now: NOW + 10 })
+    expect(adj.status).toBe(400)
+  })
+})
+
+describe('voidInvoice', () => {
+  beforeEach(() => setup())
+
+  it('rejects voiding an already-voided invoice', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const rec = recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-009', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 10000 }, { now: NOW, salt: SALT })
+    voidInvoice(db, rec.invoiceId!, 'first void', NOW + 5)
+    const second = voidInvoice(db, rec.invoiceId!, 'second void', NOW + 10)
+    expect(second.status).toBe(409)
+  })
+
+  it('requires a reason', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    const rec = recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-010', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 10000 }, { now: NOW, salt: SALT })
+    expect(voidInvoice(db, rec.invoiceId!, '', NOW).status).toBe(400)
+  })
+})
+
+describe('listInvoices', () => {
+  beforeEach(() => setup())
+
+  it('filters by source_id and month', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    const winPrev = monthWindow(NOW - 32 * 86400)
+    insertSource(db, 'render-hosting', 'render')
+    insertSource(db, 'openai-api', 'openai')
+    recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: 'A', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 100 }, { now: NOW, salt: SALT })
+    recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: 'B', billing_period_start: winPrev.start, billing_period_end: winPrev.end, currency: 'HUF', gross_amount: 90 }, { now: NOW, salt: SALT })
+    recordInvoice(db, { source_id: 'openai-api', provider: 'openai', invoice_ref: 'C', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 50 }, { now: NOW, salt: SALT })
+
+    expect(listInvoices(db, { source_id: 'render-hosting' })).toHaveLength(2)
+    expect(listInvoices(db, { month: win.key, now: NOW })).toHaveLength(2)
+    expect(listInvoices(db, { source_id: 'render-hosting', month: win.key, now: NOW })).toHaveLength(1)
+  })
+})
+
+describe('buildInvoiceReconciliation', () => {
+  beforeEach(() => setup())
+
+  it('decorates reconciliation.ts rows with invoice detail for a source with an active invoice', async () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting', 'render')
+    recordInvoice(db, { source_id: 'render-hosting', provider: 'render', invoice_ref: 'INV-011', billing_period_start: win.start, billing_period_end: win.end, currency: 'HUF', gross_amount: 12000, tax_amount: 1000, discount_amount: 500 }, { now: NOW, salt: SALT })
+    const rows = await buildInvoiceReconciliation(db, NOW, win.key)
+    const r = rows.find(x => x.source_id === 'render-hosting')!
+    expect(r.invoice).not.toBeNull()
+    expect(r.invoice!.gross_amount).toBe(12000)
+    expect(r.invoice!.net_amount).toBe(11500)
+  })
+
+  it('leaves invoice null for a source with no active invoice this period', async () => {
+    const db = getDb()
+    insertSource(db, 'no-invoice-source', 'other')
+    const rows = await buildInvoiceReconciliation(db, NOW)
+    const r = rows.find(x => x.source_id === 'no-invoice-source')
+    expect(r?.invoice ?? null).toBeNull()
+  })
+})
+
+describe('initInvoiceSchema', () => {
+  it('is idempotent and enforces the active-dedup_key uniqueness at the DB level', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initInvoiceSchema(db)
+    initInvoiceSchema(db) // must not throw
+    insertSource(db, 'render-hosting', 'render')
+    const now = NOW
+    db.prepare(`
+      INSERT INTO costops_invoices (source_id, provider, billing_period_start, billing_period_end, currency, gross_amount, tax_amount, discount_amount, credit_amount, refund_amount, late_charge_amount, net_amount, status, dedup_key, recorded_at, created_at)
+      VALUES ('render-hosting','render',0,1,'HUF',100,0,0,0,0,0,100,'recorded','dk1',@now,@now)
+    `).run({ now })
+    expect(() => {
+      db.prepare(`
+        INSERT INTO costops_invoices (source_id, provider, billing_period_start, billing_period_end, currency, gross_amount, tax_amount, discount_amount, credit_amount, refund_amount, late_charge_amount, net_amount, status, dedup_key, recorded_at, created_at)
+        VALUES ('render-hosting','render',0,1,'HUF',100,0,0,0,0,0,100,'recorded','dk1',@now,@now)
+      `).run({ now })
+    }).toThrow()
+  })
+})

--- a/src/__tests__/costops-lifecycle.test.ts
+++ b/src/__tests__/costops-lifecycle.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import { deriveSourceLifecycle, deriveProvenance, type LifecycleInput } from '../costops/lifecycle.js'
+
+function baseInput(overrides: Partial<LifecycleInput> = {}): LifecycleInput {
+  return {
+    explicitlyUnsupported: false,
+    explicitlyDeprecated: false,
+    credentialRequired: false,
+    credentialPresent: false,
+    lastRunStatus: null,
+    hasEverHadActivity: true,
+    ...overrides,
+  }
+}
+
+describe('deriveSourceLifecycle (CostOps Phase 0, GAP-03)', () => {
+  it('the headline case: OpenAI-shaped source (credential works, zero usage) is inactive, NOT credential_error/blocked', () => {
+    const lifecycle = deriveSourceLifecycle(baseInput({
+      credentialRequired: true, credentialPresent: true, lastRunStatus: 'ok', hasEverHadActivity: false,
+    }))
+    expect(lifecycle).toBe('inactive')
+  })
+
+  it('missing required credential -> not_configured (not blocked, not an error state)', () => {
+    const lifecycle = deriveSourceLifecycle(baseInput({ credentialRequired: true, credentialPresent: false }))
+    expect(lifecycle).toBe('not_configured')
+  })
+
+  it('credential present but a collector run genuinely failed -> blocked', () => {
+    const lifecycle = deriveSourceLifecycle(baseInput({
+      credentialRequired: true, credentialPresent: true, lastRunStatus: 'error', hasEverHadActivity: false,
+    }))
+    expect(lifecycle).toBe('blocked')
+  })
+
+  it('credential present, collector working, has real activity -> active', () => {
+    const lifecycle = deriveSourceLifecycle(baseInput({
+      credentialRequired: true, credentialPresent: true, lastRunStatus: 'ok', hasEverHadActivity: true,
+    }))
+    expect(lifecycle).toBe('active')
+  })
+
+  it('a manual/invoice source (no credential needed) with activity -> active', () => {
+    const lifecycle = deriveSourceLifecycle(baseInput({
+      credentialRequired: false, credentialPresent: false, lastRunStatus: null, hasEverHadActivity: true,
+    }))
+    expect(lifecycle).toBe('active')
+  })
+
+  it('a manual source with no activity yet -> inactive (never not_configured -- no credential is required at all)', () => {
+    const lifecycle = deriveSourceLifecycle(baseInput({
+      credentialRequired: false, credentialPresent: false, lastRunStatus: null, hasEverHadActivity: false,
+    }))
+    expect(lifecycle).toBe('inactive')
+  })
+
+  it('explicit unsupported override wins over every other signal', () => {
+    const lifecycle = deriveSourceLifecycle(baseInput({
+      explicitlyUnsupported: true, credentialRequired: true, credentialPresent: true, lastRunStatus: 'ok', hasEverHadActivity: true,
+    }))
+    expect(lifecycle).toBe('unsupported')
+  })
+
+  it('explicit deprecated override wins over an otherwise-active source', () => {
+    const lifecycle = deriveSourceLifecycle(baseInput({
+      explicitlyDeprecated: true, credentialRequired: true, credentialPresent: true, lastRunStatus: 'ok', hasEverHadActivity: true,
+    }))
+    expect(lifecycle).toBe('deprecated')
+  })
+
+  it('unsupported outranks deprecated when both are somehow set', () => {
+    const lifecycle = deriveSourceLifecycle(baseInput({ explicitlyUnsupported: true, explicitlyDeprecated: true }))
+    expect(lifecycle).toBe('unsupported')
+  })
+
+  it('every non-ok run status (partial/rate_limited/failed) maps to blocked, not just error', () => {
+    for (const status of ['error', 'failed', 'partial', 'rate_limited'] as const) {
+      const lifecycle = deriveSourceLifecycle(baseInput({
+        credentialRequired: true, credentialPresent: true, lastRunStatus: status, hasEverHadActivity: false,
+      }))
+      expect(lifecycle).toBe('blocked')
+    }
+  })
+
+  it('produces exactly one of the 6 documented lifecycle states, never anything else', () => {
+    const allowed = new Set(['active', 'inactive', 'not_configured', 'unsupported', 'blocked', 'deprecated'])
+    const scenarios: LifecycleInput[] = [
+      baseInput(),
+      baseInput({ credentialRequired: true, credentialPresent: false }),
+      baseInput({ credentialRequired: true, credentialPresent: true, lastRunStatus: 'error' }),
+      baseInput({ credentialRequired: true, credentialPresent: true, lastRunStatus: 'ok', hasEverHadActivity: false }),
+      baseInput({ explicitlyUnsupported: true }),
+      baseInput({ explicitlyDeprecated: true }),
+    ]
+    for (const s of scenarios) expect(allowed.has(deriveSourceLifecycle(s))).toBe(true)
+  })
+})
+
+describe('deriveProvenance (CostOps Phase 0, GAP-03 -- separate from lifecycle)', () => {
+  it('maps actual_source=provider_api to provider_api_actual', () => {
+    expect(deriveProvenance('provider_api', 'provider_api')).toBe('provider_api_actual')
+  })
+
+  it('maps actual_source=email_invoice to invoice_actual', () => {
+    expect(deriveProvenance('actual_invoice', 'email_invoice')).toBe('invoice_actual')
+  })
+
+  it('maps actual_source=manual_entry + confidence=manual to manual_actual', () => {
+    expect(deriveProvenance('manual', 'manual_entry')).toBe('manual_actual')
+  })
+
+  it('maps actual_source=manual_entry + an estimate confidence to calculated_estimate, not manual_actual', () => {
+    expect(deriveProvenance('estimate', 'manual_entry')).toBe('calculated_estimate')
+    expect(deriveProvenance('local_usage', 'manual_entry')).toBe('calculated_estimate')
+    expect(deriveProvenance('provider_plan_estimate', 'manual_entry')).toBe('calculated_estimate')
+  })
+
+  it('maps actual_source=pending_permission to unknown -- genuinely not observable, never guessed', () => {
+    expect(deriveProvenance('pending_permission', 'pending_permission')).toBe('unknown')
+  })
+
+  it('falls back to unknown for no_data / missing actual_source with no estimate confidence either', () => {
+    expect(deriveProvenance(null, 'no_data')).toBe('unknown')
+    expect(deriveProvenance(undefined, undefined)).toBe('unknown')
+  })
+
+  it('never returns imported_actual today -- no current collector produces it (reserved for future use)', () => {
+    const allActualSources = ['provider_api', 'email_invoice', 'manual_entry', 'pending_permission', 'no_data', null, undefined]
+    const allConfidences = ['manual', 'estimate', 'local_usage', 'provider_plan_estimate', 'actual_invoice', 'billing_export', null, undefined]
+    for (const a of allActualSources) for (const c of allConfidences) {
+      expect(deriveProvenance(c, a)).not.toBe('imported_actual')
+    }
+  })
+})

--- a/src/__tests__/costops-limits.test.ts
+++ b/src/__tests__/costops-limits.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { fromSubscriptions, fromDeepSeekBalance } from '../costops/limits.js'
+import { deriveLifecycle, type SubscriptionsConfig } from '../costops/subscriptions.js'
+import { initDatabase, getDb } from '../db.js'
+
+// Card 2ed90db1: wiring real Claude Max/Pro weekly-limit % data into the subscription gauge.
+const NOW = Math.floor(Date.UTC(2026, 6, 8, 19, 0, 0) / 1000) // 2026-07-08 21:00 CEST
+
+function cfg(subs: Partial<SubscriptionsConfig['subscriptions'][number]>[]): SubscriptionsConfig {
+  return { version: 1, subscriptions: subs.map(s => ({ id: 'x', name: 'X', provider: 'p', source: 's', status: 'active', amount_source: 'no_invoice_found', ...s })) as SubscriptionsConfig['subscriptions'] }
+}
+
+describe('costops limits: weekly usage-% snapshot (card 2ed90db1)', () => {
+  it('emits a weekly_usage_pct entry from a usage_snapshot, percent converted to a 0..1 fraction', () => {
+    const lc = deriveLifecycle(cfg([{
+      id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', status: 'active', next_renewal: '2026-07-20',
+      usage_snapshot: { as_of: '2026-07-08T21:00:00+02:00', session_pct: 5, weekly_pct: 19, weekly_reset_label: 'Tue 08:59', fable_pct: 0 },
+    }]), NOW)
+    const limits = fromSubscriptions(lc)
+    const weekly = limits.find(l => l.limit_type === 'weekly_usage_pct')
+    expect(weekly).toBeDefined()
+    expect(weekly!.usage_pct).toBeCloseTo(0.19)
+    expect(weekly!.status).toBe('ok') // below the 0.7 warning tier
+    expect(weekly!.reset_date).toBe('Tue 08:59') // raw label, never a computed/parsed date
+    expect(weekly!.sub_id).toBe('anthropic-max')
+    expect(weekly!.current_usage).toBeNull() // no fabricated absolute ceiling
+    expect(weekly!.limit_value).toBeNull()
+  })
+
+  it('a usage_snapshot with no renewal/cancellation date still emits its weekly_usage_pct entry (no early-continue bug)', () => {
+    // Regression: fromSubscriptions used to `continue` the whole loop iteration when a
+    // subscription had no paid_until/next_renewal, silently skipping the usage_snapshot entry
+    // too. Claude Pro after re-activation is exactly this case (status active, no known next
+    // renewal date, but a real usage_snapshot).
+    const lc = deriveLifecycle(cfg([{
+      id: 'claude-pro-google-play', name: 'Claude Pro', provider: 'anthropic', status: 'active',
+      usage_snapshot: { as_of: '2026-07-08T21:00:00+02:00', session_pct: 16, weekly_pct: 2, weekly_reset_label: 'Wed 06:00', fable_pct: 0 },
+    }]), NOW)
+    const limits = fromSubscriptions(lc)
+    expect(limits.some(l => l.limit_type === 'subscription_renewal')).toBe(false) // honestly no renewal-date entry
+    const weekly = limits.find(l => l.limit_type === 'weekly_usage_pct')
+    expect(weekly).toBeDefined()
+    expect(weekly!.usage_pct).toBeCloseTo(0.02)
+    expect(weekly!.sub_id).toBe('claude-pro-google-play')
+  })
+
+  it('crossing 80% weekly usage escalates status to high-tier (critical stays below 90, blocked at 100)', () => {
+    const lc = deriveLifecycle(cfg([{
+      id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', status: 'active',
+      usage_snapshot: { as_of: '2026-07-08T21:00:00+02:00', session_pct: 50, weekly_pct: 85, weekly_reset_label: 'Tue 08:59' },
+    }]), NOW)
+    const weekly = fromSubscriptions(lc).find(l => l.limit_type === 'weekly_usage_pct')!
+    expect(weekly.usage_pct).toBeCloseTo(0.85)
+    expect(weekly.status).toBe('warning') // limits.ts's own tierForPct ladder: 0.7 warning / 0.9 critical / 1.0 blocked
+  })
+
+  it('two subscriptions sharing the same provider each get their own distinct sub_id', () => {
+    const lc = deriveLifecycle(cfg([
+      { id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', status: 'active', usage_snapshot: { as_of: '2026-07-08T21:00:00+02:00', session_pct: 5, weekly_pct: 19, weekly_reset_label: 'Tue 08:59' } },
+      { id: 'claude-pro-google-play', name: 'Claude Pro', provider: 'anthropic', status: 'active', usage_snapshot: { as_of: '2026-07-08T21:00:00+02:00', session_pct: 16, weekly_pct: 2, weekly_reset_label: 'Wed 06:00' } },
+    ]), NOW)
+    const rows = fromSubscriptions(lc).filter(l => l.limit_type === 'weekly_usage_pct')
+    expect(rows).toHaveLength(2)
+    expect(rows.map(r => r.sub_id).sort()).toEqual(['anthropic-max', 'claude-pro-google-play'])
+  })
+
+  it('no usage_snapshot at all -> no weekly_usage_pct entry (never fabricated)', () => {
+    const lc = deriveLifecycle(cfg([{ id: 'openai-chatgpt', name: 'ChatGPT Plus', provider: 'openai', status: 'active' }]), NOW)
+    expect(fromSubscriptions(lc).some(l => l.limit_type === 'weekly_usage_pct')).toBe(false)
+  })
+})
+
+// Card 7d086cd3 (F4, Muse WS-C design-fidelity): DeepSeek's prepaid balance is a raw native-
+// currency number (USD), unlike every other limit_type here which either has no monetary
+// current_usage/limit_value at all, or is a plain percentage -- the renderer's HUF-formatter was
+// silently stamping "Ft" onto it, printing "3,17 HUF" for a ~$3.17 USD balance.
+describe('costops limits: DeepSeek balance unit (card 7d086cd3, F4)', () => {
+  it('no snapshots yet -> unknown status, unit null (not assumed USD before any data exists)', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    const limits = fromDeepSeekBalance(db)
+    expect(limits).toHaveLength(1)
+    expect(limits[0].status).toBe('unknown')
+    expect(limits[0].unit).toBeNull()
+  })
+
+  it('carries the real native currency from the snapshot row, never HUF-assumed', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',10,?)`).run(1000)
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',3.17,?)`).run(2000)
+    const limits = fromDeepSeekBalance(db)
+    expect(limits).toHaveLength(1)
+    expect(limits[0].unit).toBe('USD')
+    expect(limits[0].current_usage).toBe(3.17)
+    expect(limits[0].limit_value).toBe(10)
+  })
+})

--- a/src/__tests__/costops-live-checks-cache.test.ts
+++ b/src/__tests__/costops-live-checks-cache.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Card fa041036: /api/costs/warnings and /api/costs/limits both needed the same 3 live checks
+// (Render build-minutes, SSL expiry, domain expiry) -- previously each independently re-ran them
+// (once concurrently inside getLimitStatus, once again sequentially in the /warnings route),
+// which was the real cost behind the reported 20-35s. getLiveCheckWarnings() now shares one
+// TTL-cached result between both call sites.
+
+vi.mock('../costops/render-live-checks.js', () => ({
+  checkRenderBuildMinutes: vi.fn(async () => []),
+}))
+vi.mock('../costops/expiry-checks.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../costops/expiry-checks.js')>()
+  return { ...actual, checkSslExpiry: vi.fn(async () => []), checkDomainExpiry: vi.fn(async () => []) }
+})
+
+describe('costops limits: getLiveCheckWarnings TTL cache (card fa041036)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('a second call with the same hosts/domains within the TTL window reuses the in-flight/cached result instead of re-fetching', async () => {
+    const { getLiveCheckWarnings } = await import('../costops/limits.js')
+    const { checkRenderBuildMinutes } = await import('../costops/render-live-checks.js')
+    const { checkSslExpiry, checkDomainExpiry } = await import('../costops/expiry-checks.js')
+
+    const now = 1783500000
+    await getLiveCheckWarnings(now, ['a.example.com'], ['example.com'])
+    await getLiveCheckWarnings(now + 10, ['a.example.com'], ['example.com']) // 10s later, same key -- still warm
+
+    expect(checkRenderBuildMinutes).toHaveBeenCalledTimes(1)
+    expect(checkSslExpiry).toHaveBeenCalledTimes(1)
+    expect(checkDomainExpiry).toHaveBeenCalledTimes(1)
+  })
+
+  it('a call with a different host/domain set does not reuse a stale cache entry from a different key', async () => {
+    const { getLiveCheckWarnings } = await import('../costops/limits.js')
+    const { checkRenderBuildMinutes } = await import('../costops/render-live-checks.js')
+
+    const now = 1783500000
+    await getLiveCheckWarnings(now, ['a.example.com'], ['example.com'])
+    await getLiveCheckWarnings(now, ['b.example.com'], ['example.com']) // different ssl_hosts -- must re-fetch
+
+    expect(checkRenderBuildMinutes).toHaveBeenCalledTimes(2)
+  })
+
+  it('a call after the TTL window has elapsed re-fetches instead of returning a stale result', async () => {
+    const { getLiveCheckWarnings } = await import('../costops/limits.js')
+    const { checkRenderBuildMinutes } = await import('../costops/render-live-checks.js')
+
+    const now = 1783500000
+    await getLiveCheckWarnings(now, ['a.example.com'], ['example.com'])
+    await getLiveCheckWarnings(now + 6 * 60, ['a.example.com'], ['example.com']) // 6 min later -- past the 5 min TTL
+
+    expect(checkRenderBuildMinutes).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/__tests__/costops-manual-entry.test.ts
+++ b/src/__tests__/costops-manual-entry.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { createManualCost, updateManualCost, deleteManualCost, createManualEntitlement, updateManualEntitlement, deleteManualEntitlement } from '../costops/manual-entry.js'
+import { getCostSummary, monthWindow as ledgerMonthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const cfg: CostOpsConfig = { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] }
+
+describe('costops manual cost entry (card a1552362, item 3)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('creates a manual HUF entry, visible in all_sources as manual/manual_entry', () => {
+    const db = getDb()
+    const r = createManualCost(db, {
+      source_id: 'notion', name: 'Notion', provider: 'notion', amount: 5000, currency: 'HUF', month: '2026-07',
+    }, { fxUsdHuf: 360, now: NOW })
+    expect(r.ok).toBe(true)
+    const s = getCostSummary(db, cfg, NOW)
+    const row = s.all_sources.find(x => x.source_id === 'notion')!
+    expect(row.spend).toBe(5000)
+    expect(row.confidence).toBe('manual')
+    expect(row.actual_source).toBe('manual_entry')
+    expect(row.fx_estimated).toBeNull() // already HUF, nothing converted
+  })
+
+  it('converts + retains original currency for a non-HUF manual entry, flags fx_estimated', () => {
+    const db = getDb()
+    createManualCost(db, {
+      source_id: 'figma', name: 'Figma', provider: 'figma', amount: 15, currency: 'USD', month: '2026-07',
+    }, { fxUsdHuf: 360, now: NOW })
+    const s = getCostSummary(db, cfg, NOW)
+    const row = s.all_sources.find(x => x.source_id === 'figma')!
+    expect(row.spend).toBe(5400) // 15 * 360
+    expect(row.original_amount).toBe(15)
+    expect(row.original_currency).toBe('USD')
+    expect(row.fx_estimated).toBe(true)
+  })
+
+  it('Phase 1 (GAP-09): a converted manual entry also carries fx_source/conversion_method', () => {
+    const db = getDb()
+    createManualCost(db, { source_id: 'figma', name: 'Figma', provider: 'figma', amount: 15, currency: 'USD', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    const row = db.prepare(`SELECT fx_source, conversion_method FROM cost_line_items WHERE dedup_key = 'manual|figma|2026-07'`).get() as any
+    expect(row.fx_source).toBe('render_pricing_config')
+    expect(row.conversion_method).toBe('service_date_rate')
+  })
+
+  it('an already-HUF manual entry has null fx_source/conversion_method (nothing converted)', () => {
+    const db = getDb()
+    createManualCost(db, { source_id: 'notion', name: 'Notion', provider: 'notion', amount: 5000, currency: 'HUF', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    const row = db.prepare(`SELECT fx_source, conversion_method FROM cost_line_items WHERE dedup_key = 'manual|notion|2026-07'`).get() as any
+    expect(row.fx_source).toBeNull()
+    expect(row.conversion_method).toBeNull()
+  })
+
+  it('rejects a second POST for the same source/month (409) -- PATCH is required to change it', () => {
+    const db = getDb()
+    createManualCost(db, { source_id: 'notion', name: 'Notion', provider: 'notion', amount: 5000, currency: 'HUF', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    const r2 = createManualCost(db, { source_id: 'notion', name: 'Notion', provider: 'notion', amount: 6000, currency: 'HUF', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    expect(r2.ok).toBe(false)
+    expect(r2.status).toBe(409)
+  })
+
+  it('PATCH updates an existing manual entry in place (no duplicate line)', () => {
+    const db = getDb()
+    createManualCost(db, { source_id: 'notion', name: 'Notion', provider: 'notion', amount: 5000, currency: 'HUF', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    const r = updateManualCost(db, { source_id: 'notion', month: '2026-07', amount: 7500, currency: 'HUF' }, { fxUsdHuf: 360, now: NOW + 10 })
+    expect(r.ok).toBe(true)
+    const s = getCostSummary(db, cfg, NOW)
+    const rows = s.all_sources.filter(x => x.source_id === 'notion')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].spend).toBe(7500)
+  })
+
+  it('PATCH 404s when there is nothing to update yet', () => {
+    const db = getDb()
+    const r = updateManualCost(db, { source_id: 'ghost', month: '2026-07', amount: 100, currency: 'HUF' }, { fxUsdHuf: 360, now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(404)
+  })
+
+  it('PATCH refuses to touch a non-manual (e.g. provider_api) line for the same key', () => {
+    const db = getDb()
+    const win = ledgerMonthWindow(NOW)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-hosting','Render','render','usage','HUF',1,?,?)`).run(NOW, NOW)
+    db.prepare(`
+      INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+      VALUES ('render-hosting', @start, @end, 'usage', 1000, 'HUF', 'provider_api', @now, @now, 'manual|render-hosting|2026-07', 'provider_api')
+    `).run({ start: win.start, end: win.end, now: NOW })
+    const r = updateManualCost(db, { source_id: 'render-hosting', month: '2026-07', amount: 9999, currency: 'HUF' }, { fxUsdHuf: 360, now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(409)
+  })
+
+  it('rejects an unconvertible currency without a configured fx rate', () => {
+    const db = getDb()
+    const r = createManualCost(db, { source_id: 'random', name: 'Random', provider: 'random', amount: 10, currency: 'GBP', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(400)
+  })
+
+  it('DELETE voids the manual cost_line_items row instead of hard-deleting it (card 73e8914a, Phase 0)', () => {
+    const db = getDb()
+    createManualCost(db, { source_id: 'notion', name: 'Notion', provider: 'notion', amount: 5000, currency: 'HUF', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    const r = deleteManualCost(db, { source_id: 'notion', month: '2026-07', reason: 'entered wrong source by mistake' }, { now: NOW + 5 })
+    expect(r.ok).toBe(true)
+    // The original row is NOT gone -- it survives with voided_at/void_reason set (auditability),
+    // just renamed off the active dedup_key so it never re-collides with a fresh POST.
+    const voided = db.prepare(`SELECT voided_at, void_reason, billed_cost FROM cost_line_items WHERE dedup_key = 'manual|notion|2026-07|voided|${NOW + 5}'`).get() as any
+    expect(voided).toBeTruthy()
+    expect(voided.voided_at).toBe(NOW + 5)
+    expect(voided.void_reason).toBe('entered wrong source by mistake')
+    expect(voided.billed_cost).toBe(5000) // amount preserved, not erased
+    expect(db.prepare(`SELECT 1 FROM cost_line_items WHERE dedup_key = 'manual|notion|2026-07'`).get()).toBeUndefined()
+    // Voided means excluded from the ledger read paths -- same USER-VISIBLE effect as a hard
+    // delete (spend goes back to 0/no_data), but the financial history is retained, not erased.
+    const s = getCostSummary(db, cfg, NOW)
+    const row = s.all_sources.find(x => x.source_id === 'notion')!
+    expect(row.spend).toBe(0)
+    expect(row.actual_source).toBe('no_data')
+  })
+
+  it('a fresh POST after a void creates a genuinely new entry, not blocked by the old dedup_key', () => {
+    const db = getDb()
+    createManualCost(db, { source_id: 'notion', name: 'Notion', provider: 'notion', amount: 5000, currency: 'HUF', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    deleteManualCost(db, { source_id: 'notion', month: '2026-07' }, { now: NOW + 5 })
+    const r2 = createManualCost(db, { source_id: 'notion', name: 'Notion', provider: 'notion', amount: 6000, currency: 'HUF', month: '2026-07' }, { fxUsdHuf: 360, now: NOW + 10 })
+    expect(r2.ok).toBe(true)
+    const s = getCostSummary(db, cfg, NOW)
+    const row = s.all_sources.find(x => x.source_id === 'notion')!
+    expect(row.spend).toBe(6000) // the new entry, not the voided 5000
+  })
+
+  it('DELETE 404s when there is nothing to delete', () => {
+    const db = getDb()
+    const r = deleteManualCost(db, { source_id: 'ghost', month: '2026-07' }, { now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(404)
+  })
+
+  it('DELETE 409s on an already-voided entry (not silently re-voidable)', () => {
+    const db = getDb()
+    createManualCost(db, { source_id: 'notion', name: 'Notion', provider: 'notion', amount: 5000, currency: 'HUF', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    deleteManualCost(db, { source_id: 'notion', month: '2026-07' }, { now: NOW + 5 })
+    const r2 = deleteManualCost(db, { source_id: 'notion', month: '2026-07' }, { now: NOW + 10 })
+    expect(r2.ok).toBe(false)
+    expect(r2.status).toBe(404) // the original dedup_key is gone (renamed), reads as "nothing to delete"
+  })
+
+  it('DELETE refuses to touch a non-manual (e.g. provider_api) line for the same key', () => {
+    const db = getDb()
+    const win = ledgerMonthWindow(NOW)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-hosting','Render','render','usage','HUF',1,?,?)`).run(NOW, NOW)
+    db.prepare(`
+      INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+      VALUES ('render-hosting', @start, @end, 'usage', 1000, 'HUF', 'provider_api', @now, @now, 'manual|render-hosting|2026-07', 'provider_api')
+    `).run({ start: win.start, end: win.end, now: NOW })
+    const r = deleteManualCost(db, { source_id: 'render-hosting', month: '2026-07' }, { now: NOW })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(409)
+    const row = db.prepare(`SELECT 1 FROM cost_line_items WHERE dedup_key = 'manual|render-hosting|2026-07'`).get()
+    expect(row).toBeTruthy() // still there -- the guard actually blocked the delete, not a no-op coincidence
+  })
+})
+
+describe('costops manual entitlement entry (card a1552362, item 3)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('creates a manual entitlement row', () => {
+    const db = getDb()
+    const r = createManualEntitlement(db, {
+      provider: 'notion', product: 'notion-plus', billing_period: 'monthly', entitlement_type: 'seats',
+      included_limit: 10, included_unit: 'seats', remaining: 3, status: 'ok',
+    }, NOW)
+    expect(r.ok).toBe(true)
+    const row = db.prepare(`SELECT * FROM entitlements WHERE dedup_key = 'manual|notion|notion-plus|seats|monthly'`).get() as any
+    expect(row.remaining).toBe(3)
+    expect(row.usage_source).toBe('manual')
+    expect(row.status).toBe('ok')
+  })
+
+  it('rejects a duplicate create (409)', () => {
+    const db = getDb()
+    const input = { provider: 'notion', product: 'notion-plus', billing_period: 'monthly', entitlement_type: 'seats', status: 'ok' as const }
+    createManualEntitlement(db, input, NOW)
+    const r2 = createManualEntitlement(db, input, NOW)
+    expect(r2.ok).toBe(false)
+    expect(r2.status).toBe(409)
+  })
+
+  it('PATCH updates an existing manual entitlement', () => {
+    const db = getDb()
+    createManualEntitlement(db, { provider: 'notion', product: 'notion-plus', billing_period: 'monthly', entitlement_type: 'seats', remaining: 3, status: 'ok' }, NOW)
+    const r = updateManualEntitlement(db, { provider: 'notion', product: 'notion-plus', billing_period: 'monthly', entitlement_type: 'seats', remaining: 1, status: 'warning' }, NOW + 10)
+    expect(r.ok).toBe(true)
+    const row = db.prepare(`SELECT * FROM entitlements WHERE dedup_key = 'manual|notion|notion-plus|seats|monthly'`).get() as any
+    expect(row.remaining).toBe(1)
+    expect(row.status).toBe('warning')
+  })
+
+  it('PATCH 404s when there is nothing to update yet', () => {
+    const db = getDb()
+    const r = updateManualEntitlement(db, { provider: 'ghost', product: 'x', billing_period: 'monthly', entitlement_type: 'seats', status: 'ok' }, NOW)
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(404)
+  })
+
+  it('DELETE removes a manual entitlement (card 73e8914a)', () => {
+    const db = getDb()
+    createManualEntitlement(db, { provider: 'notion', product: 'notion-plus', billing_period: 'monthly', entitlement_type: 'seats', remaining: 3, status: 'ok' }, NOW)
+    const r = deleteManualEntitlement(db, { provider: 'notion', product: 'notion-plus', billing_period: 'monthly', entitlement_type: 'seats' })
+    expect(r.ok).toBe(true)
+    const row = db.prepare(`SELECT 1 FROM entitlements WHERE dedup_key = 'manual|notion|notion-plus|seats|monthly'`).get()
+    expect(row).toBeUndefined()
+  })
+
+  it('DELETE 404s when there is nothing to delete', () => {
+    const db = getDb()
+    const r = deleteManualEntitlement(db, { provider: 'ghost', product: 'x', billing_period: 'monthly', entitlement_type: 'seats' })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(404)
+  })
+})

--- a/src/__tests__/costops-openai.test.ts
+++ b/src/__tests__/costops-openai.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { mapOpenAiCosts, openaiCollector, syncOpenAiCollector } from '../costops/collectors/openai.js'
+import { monthWindow } from '../costops/ledger.js'
+import type { CollectOpts } from '../costops/collectors/types.js'
+
+// Fixture modelling the OpenAI /v1/organizations/costs page shape.
+function fixturePage(vals: number[]) {
+  const now = Math.floor(Date.UTC(2026, 6, 1) / 1000)
+  return {
+    object: 'page',
+    data: vals.map((v, i) => ({
+      object: 'bucket',
+      start_time: now + i * 86400,
+      end_time: now + (i + 1) * 86400,
+      results: [{ object: 'organization.costs.result', amount: { value: v, currency: 'usd' }, line_item: null, project_id: null }],
+    })),
+    has_more: false,
+    next_page: null,
+  }
+}
+
+const START = Math.floor(Date.UTC(2026, 6, 1) / 1000)
+const END = Math.floor(Date.UTC(2026, 7, 1) / 1000)
+
+describe('mapOpenAiCosts (pure, offline)', () => {
+  it('sums daily USD costs into one HUF provider_api line for openai-api', () => {
+    const lines = mapOpenAiCosts(fixturePage([1.5, 2.0, 0.5]), { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 'salt', now: START })
+    expect(lines).toHaveLength(1)
+    const l = lines[0]
+    expect(l.provider).toBe('openai')
+    expect(l.service).toBe('openai-api')
+    expect(l.confidence).toBe('provider_api')
+    expect(l.currency).toBe('HUF')
+    expect(l.amount).toBe(Math.round(4.0 * 360 * 100) / 100) // (1.5+2.0+0.5)*360
+    expect(l.dedup_key).toBe('provider|openai|openai-api|2026-07|provider_api')
+    expect(l.raw_ref_hash).not.toContain('openai-costs') // hashed, no raw
+  })
+
+  it('returns [] for an empty page (caller reports explicit 0)', () => {
+    expect(mapOpenAiCosts({ object: 'page', data: [] }, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })).toHaveLength(0)
+    expect(mapOpenAiCosts(null, { periodStart: START, periodEnd: END, fxUsdHuf: 360, idSalt: 's', now: START })).toHaveLength(0)
+  })
+})
+
+describe('openaiCollector + syncOpenAiCollector (offline stub, no live call)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('collect() returns normalized lines from the injected fetcher (no network)', async () => {
+    const now = Math.floor(Date.UTC(2026, 6, 10) / 1000)
+    const w = monthWindow(now)
+    const opts: CollectOpts = {
+      periodStart: w.start, periodEnd: w.end, secret: 'sk-admin-never-logged', fxUsdHuf: 360, idSalt: 'openai-salt',
+      httpGetJson: async () => fixturePage([3.0, 1.0]),
+    }
+    const lines = await openaiCollector.collect(opts)
+    expect(lines).toHaveLength(1)
+    expect(lines[0].amount).toBe(Math.round(4.0 * 360 * 100) / 100)
+  })
+
+  it('sync imports a provider_api line + import_run using a stubbed key and fetcher (idempotent)', async () => {
+    const db = getDb()
+    const now = Math.floor(Date.UTC(2026, 6, 10) / 1000)
+    const stub = async () => fixturePage([2.0, 2.0])
+    const r1 = await syncOpenAiCollector(db, now, { apiKey: 'sk-admin-stub', fxUsdHuf: 360, httpGetJson: stub })
+    expect(r1.ok).toBe(true)
+    expect(r1.imported_count).toBe(1)
+    const lineCount = () => (db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='openai-api'").get() as { c: number }).c
+    expect(lineCount()).toBe(1)
+    const r2 = await syncOpenAiCollector(db, now, { apiKey: 'sk-admin-stub', fxUsdHuf: 360, httpGetJson: stub })
+    expect(r2.ok).toBe(true)
+    expect(lineCount()).toBe(1) // idempotent upsert by dedup_key
+
+    // secret must not leak into the import_runs audit rows
+    const audit = JSON.stringify(db.prepare('SELECT * FROM import_runs').all())
+    expect(audit).not.toContain('sk-admin-stub')
+  })
+
+  it('reports error (no import) when the vault key is missing', async () => {
+    const db = getDb()
+    const now = Math.floor(Date.UTC(2026, 6, 10) / 1000)
+    const r = await syncOpenAiCollector(db, now, { apiKey: null, fxUsdHuf: 360, httpGetJson: async () => fixturePage([1]) })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe('error')
+    expect((db.prepare("SELECT COUNT(*) c FROM cost_line_items WHERE source_id='openai-api'").get() as { c: number }).c).toBe(0)
+  })
+})

--- a/src/__tests__/costops-operational.test.ts
+++ b/src/__tests__/costops-operational.test.ts
@@ -35,6 +35,21 @@ describe('resolveOperational (provider-preferred, no double count)', () => {
     expect(render.confidence).toBe('provider_plan_estimate')
   })
 
+  it('a REAL invoice supersedes the plan estimate for the same provider (no double count)', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      // same provider "render": a real invoice AND the plan-estimate proxy both present
+      { source_id: 'render-hosting', provider: 'render', billed_cost: 4000, charge_category: 'hosting', confidence: 'actual_invoice', data_freshness: NOW },
+      { source_id: 'render-plan', provider: 'render', billed_cost: 32000, charge_category: 'usage', confidence: 'provider_plan_estimate', data_freshness: NOW },
+    ], win)
+    // operational = 4000 (the real invoice), NOT 4000 + 32000; the plan proxy is dropped
+    expect(r.operational_spend).toBe(4000)
+    expect(r.provider_derived_spend).toBe(4000)
+    const render = r.provider_breakdown.find(p => p.provider === 'render')!
+    expect(render.spend).toBe(4000)
+    expect(render.confidence).toBe('actual_invoice')
+  })
+
   it('provider_api_actual usage forecasts by run-rate; plan forecasts full monthly', () => {
     const win = monthWindow(NOW) // mid-month, fractionElapsed < 1
     const r = resolveOperational([

--- a/src/__tests__/costops-operational.test.ts
+++ b/src/__tests__/costops-operational.test.ts
@@ -100,4 +100,92 @@ describe('getCostSummary v0.4 operational fields', () => {
     expect(s.previous_month!.month).toBe(prevWin.key)
     expect(s.month_over_month_delta).toBe(500) // 2500 - 2000
   })
+  // Card 097d8355 -- Istvan's ruling 2026-07-20: on an EQUAL tier the FRESHER row
+  // is the current one. actual_invoice / provider_api / billing_export are all tier 4,
+  // so before the fix a strict `>` kept the INCUMBENT and a freshly ingested invoice
+  // was stored but never reached operational_spend.
+  it('on an equal tier the fresher row wins -- new invoice over older provider_api', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      { source_id: 'render-usage', provider: 'render', billed_cost: 9000, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW - 86400 },
+      { source_id: 'render-usage', provider: 'render', billed_cost: 4200, charge_category: 'usage', confidence: 'actual_invoice', data_freshness: NOW },
+    ], win)
+    expect(r.operational_spend).toBe(4200)
+  })
+
+  // SUPERSEDED 2026-07-20 by Istvan's accounting rule (see the top-up / package
+  // tests below). This case originally asserted that a fresher provider_api beats
+  // an older actual_invoice on pure freshness. That is no longer the primary rule:
+  // with NO source_type known, we now default to the PACKAGE branch and the
+  // invoice wins. The default is deliberate -- an unknown source falling back to
+  // a real billed amount understates nothing, whereas defaulting to consumption
+  // would under-report, and an under-reported cost figure is the one nobody
+  // investigates. Freshness still decides between two lines of the SAME kind.
+  it('with no source_type, an equal tier defaults to the invoice (package rule)', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      { source_id: 'render-usage', provider: 'render', billed_cost: 4200, charge_category: 'usage', confidence: 'actual_invoice', data_freshness: NOW - 86400 },
+      { source_id: 'render-usage', provider: 'render', billed_cost: 9000, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW },
+    ], win)
+    expect(r.operational_spend).toBe(4200)
+  })
+
+  // Freshness must NOT beat tier -- a fresh estimate never outranks a real actual.
+  it('a fresher LOWER-tier row does not win', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      { source_id: 'render-usage', provider: 'render', billed_cost: 4200, charge_category: 'usage', confidence: 'actual_invoice', data_freshness: NOW - 86400 },
+      { source_id: 'render-usage', provider: 'render', billed_cost: 999, charge_category: 'usage', confidence: 'estimate', data_freshness: NOW },
+    ], win)
+    expect(r.operational_spend).toBe(4200)
+  })
+
+
+  // ── Istvan's accounting rule, 2026-07-20 ──────────────────────────────────
+  // Replaces freshness as the PRIMARY tiebreak for an equal-tier collision.
+  it('TOP-UP (source_type usage): consumption wins over the funding invoice', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      { source_id: 'openai-api', provider: 'openai', billed_cost: 2286, charge_category: 'invoice', confidence: 'actual_invoice', data_freshness: NOW, source_type: 'usage' },
+      { source_id: 'openai-api', provider: 'openai', billed_cost: 20.51, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW - 86400, source_type: 'usage' },
+    ], win)
+    // funding the account is a real payment but NOT this period's cost
+    expect(r.operational_spend).toBe(20.51)
+  })
+
+  it('PACKAGE (source_type subscription): the invoice wins over the API figure', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      { source_id: 'anthropic-max', provider: 'anthropic', billed_cost: 32400, charge_category: 'invoice', confidence: 'actual_invoice', data_freshness: NOW - 86400, source_type: 'subscription' },
+      { source_id: 'anthropic-max', provider: 'anthropic', billed_cost: 12, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW, source_type: 'subscription' },
+    ], win)
+    // the invoice states the period it covers; the API is only a stand-in until it arrives
+    expect(r.operational_spend).toBe(32400)
+  })
+
+  it('the accounting rule beats freshness in BOTH directions', () => {
+    const win = monthWindow(NOW)
+    // package, and the API row is the FRESHER one -> invoice still wins
+    const pkg = resolveOperational([
+      { source_id: 'x-sub', provider: 'x', billed_cost: 9000, charge_category: 'invoice', confidence: 'actual_invoice', data_freshness: NOW - 999999, source_type: 'saas' },
+      { source_id: 'x-sub', provider: 'x', billed_cost: 5, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW, source_type: 'saas' },
+    ], win)
+    expect(pkg.operational_spend).toBe(9000)
+    // top-up, and the INVOICE is the fresher one -> consumption still wins
+    const top = resolveOperational([
+      { source_id: 'y-api', provider: 'y', billed_cost: 9000, charge_category: 'invoice', confidence: 'actual_invoice', data_freshness: NOW, source_type: 'usage' },
+      { source_id: 'y-api', provider: 'y', billed_cost: 5, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW - 999999, source_type: 'usage' },
+    ], win)
+    expect(top.operational_spend).toBe(5)
+  })
+
+  // Card 320c477a: a period-END date reaching data_freshness must not win.
+  it('a FUTURE freshness stamp cannot beat a real one', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      { source_id: 'z-api', provider: 'z', billed_cost: 100, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW },
+      { source_id: 'z-api', provider: 'z', billed_cost: 7, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW + 12 * 86400 },
+    ], win)
+    expect(r.operational_spend).toBe(100)
+  })
 })

--- a/src/__tests__/costops-operational.test.ts
+++ b/src/__tests__/costops-operational.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { getCostSummary, monthWindow, resolveOperational } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+function emptyConfig(): CostOpsConfig { return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [{ id: 'global-monthly', amount: 200000, warning_threshold: 0.8, hard_threshold: 1.0 }] } }
+
+function seedSource(db: any, id: string, provider: string) {
+  db.prepare("INSERT OR IGNORE INTO cost_sources (id,name,provider,source_type,currency,active,created_at,updated_at) VALUES (?,?,?,?,'HUF',1,?,?)").run(id, id, provider, 'usage', NOW, NOW)
+}
+function seedLine(db: any, sid: string, amount: number, conf: string, cat = 'subscription', win = monthWindow(NOW), dk?: string) {
+  db.prepare(`INSERT INTO cost_line_items (source_id,charge_period_start,charge_period_end,charge_category,service_name,billed_cost,currency,confidence,data_freshness,dedup_key,created_at)
+    VALUES (?,?,?,?,?,?,'HUF',?,?,?,?)`).run(sid, win.start, win.end, cat, sid, amount, conf, NOW, dk || `${sid}|${conf}|${win.key}`, NOW)
+}
+
+// Synthetic amounts only -- NO real cost figures in this tracked test file.
+describe('resolveOperational (provider-preferred, no double count)', () => {
+  it('a provider plan estimate wins over the manual fallback; not summed', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      { source_id: 'render-hosting', provider: 'render', billed_cost: 3000, charge_category: 'subscription', confidence: 'manual', data_freshness: NOW },
+      { source_id: 'render-plan', provider: 'render', billed_cost: 2500, charge_category: 'usage', confidence: 'provider_plan_estimate', data_freshness: NOW },
+      { source_id: 'sub-a', provider: 'acme', billed_cost: 5000, charge_category: 'subscription', confidence: 'manual', data_freshness: NOW },
+    ], win)
+    // operational: render 2500 (plan, not 3000) + acme 5000 (manual, no derived) = 7500
+    expect(r.operational_spend).toBe(7500)
+    expect(r.provider_derived_spend).toBe(2500)
+    // manual_spend (fallback view) = 3000 + 5000 = 8000
+    expect(r.manual_spend).toBe(8000)
+    // variance for derived providers: 2500 - 3000 = -500
+    expect(r.manual_vs_provider_variance).toBe(-500)
+    const render = r.provider_breakdown.find(p => p.provider === 'render')!
+    expect(render.spend).toBe(2500)
+    expect(render.confidence).toBe('provider_plan_estimate')
+  })
+
+  it('provider_api_actual usage forecasts by run-rate; plan forecasts full monthly', () => {
+    const win = monthWindow(NOW) // mid-month, fractionElapsed < 1
+    const r = resolveOperational([
+      { source_id: 'x-api', provider: 'x', billed_cost: 1000, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW },
+      { source_id: 'render-plan', provider: 'render', billed_cost: 2500, charge_category: 'usage', confidence: 'provider_plan_estimate', data_freshness: NOW },
+    ], win)
+    // x-api actual usage -> 1000 / fractionElapsed (run-rate, > 1000); render plan -> full 2500
+    expect(r.operational_forecast_month_end).toBeGreaterThan(1000 + 2500)
+    expect(r.operational_spend).toBe(3500)
+  })
+})
+
+describe('getCostSummary v0.4 operational fields', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('operational_spend prefers provider; current_spend legacy unaffected; render uses plan', () => {
+    const db = getDb()
+    seedSource(db, 'render-hosting', 'render'); seedLine(db, 'render-hosting', 3000, 'manual')
+    seedSource(db, 'render-plan', 'render'); seedLine(db, 'render-plan', 2500, 'provider_plan_estimate', 'usage')
+    seedSource(db, 'sub-a', 'acme'); seedLine(db, 'sub-a', 5000, 'manual')
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    // operational: 2500 + 5000 = 7500 (render manual dropped)
+    expect(s.operational_spend).toBe(7500)
+    // legacy current_spend still EXCLUDES provider_plan_estimate -> render manual 3000 + acme 5000 = 8000
+    expect(s.current_spend).toBe(8000)
+    expect(s.operational.manual_vs_provider_variance).toBe(-500)
+    // budget usage on operational
+    expect(s.budget!.operational_used_pct).toBeCloseTo(7500 / 200000, 4)
+  })
+
+  it('previous_month: no data -> null (never fabricated)', () => {
+    const db = getDb()
+    seedSource(db, 'render-plan', 'render'); seedLine(db, 'render-plan', 2500, 'provider_plan_estimate', 'usage')
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    expect(s.previous_month).toBeNull()
+    expect(s.month_over_month_delta).toBeNull()
+  })
+
+  it('previous_month: aggregates from prior month lines + MoM delta', () => {
+    const db = getDb()
+    const prevWin = monthWindow(monthWindow(NOW).start - 86400) // June
+    seedSource(db, 'render-plan', 'render')
+    seedLine(db, 'render-plan', 2000, 'provider_plan_estimate', 'usage', prevWin, 'render-plan|prev')
+    seedLine(db, 'render-plan', 2500, 'provider_plan_estimate', 'usage', monthWindow(NOW), 'render-plan|cur')
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    expect(s.previous_month).not.toBeNull()
+    expect(s.previous_month!.operational_spend).toBe(2000)
+    expect(s.previous_month!.month).toBe(prevWin.key)
+    expect(s.month_over_month_delta).toBe(500) // 2500 - 2000
+  })
+})

--- a/src/__tests__/costops-operational.test.ts
+++ b/src/__tests__/costops-operational.test.ts
@@ -180,12 +180,28 @@ describe('getCostSummary v0.4 operational fields', () => {
   })
 
   // Card 320c477a: a period-END date reaching data_freshness must not win.
+  // NOW is passed explicitly: "future" has to be measured against the scenario's
+  // clock, not the wall clock. Without it this assertion silently became
+  // vacuous 12 days after NOW and then flipped to a real failure -- the stamp
+  // it calls "future" was no longer in the future when the suite actually ran.
   it('a FUTURE freshness stamp cannot beat a real one', () => {
     const win = monthWindow(NOW)
     const r = resolveOperational([
       { source_id: 'z-api', provider: 'z', billed_cost: 100, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW },
       { source_id: 'z-api', provider: 'z', billed_cost: 7, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW + 12 * 86400 },
-    ], win)
+    ], win, NOW)
     expect(r.operational_spend).toBe(100)
+  })
+
+  // The guard has to be able to go the other way too, otherwise "cannot beat"
+  // above would also pass on an implementation that just always kept the first
+  // row. Same shape, both stamps in the PAST -> the genuinely fresher row wins.
+  it('with both stamps in the past, the fresher row still wins', () => {
+    const win = monthWindow(NOW)
+    const r = resolveOperational([
+      { source_id: 'z-api', provider: 'z', billed_cost: 100, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW - 12 * 86400 },
+      { source_id: 'z-api', provider: 'z', billed_cost: 7, charge_category: 'usage', confidence: 'provider_api', data_freshness: NOW },
+    ], win, NOW)
+    expect(r.operational_spend).toBe(7)
   })
 })

--- a/src/__tests__/costops-optimization-capture.test.ts
+++ b/src/__tests__/costops-optimization-capture.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { writeFileSync, rmSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { initDatabase, getDb } from '../db.js'
+import { monthWindow } from '../costops/ledger.js'
+import { initOptimizationSchema } from '../costops/optimization.js'
+import { SUBSCRIPTIONS_PATH } from '../costops/subscriptions.js'
+import {
+  gatherRecommendationCandidates,
+  captureRecommendations,
+  listRecommendations,
+} from '../costops/optimization-capture.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+
+function insertSource(db: ReturnType<typeof getDb>, id: string, provider: string, source_type: string): void {
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, ?, ?, 'HUF', 1, ?, ?)`).run(id, id, provider, source_type, NOW, NOW)
+}
+
+function insertLine(db: ReturnType<typeof getDb>, opts: { source: string; start: number; end: number; amount: number; confidence: string; dedupKey: string }): void {
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, dedup_key, created_at)
+    VALUES (@source, @start, @end, 'usage', @amount, 'HUF', @confidence, @now, @dedupKey, @now)
+  `).run({ source: opts.source, start: opts.start, end: opts.end, amount: opts.amount, confidence: opts.confidence, now: NOW, dedupKey: opts.dedupKey })
+}
+
+describe('gatherRecommendationCandidates -- duplicate hosting/SaaS (SQL-backed, no file I/O)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('flags two sources sharing the same provider + source_type', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting-1', 'render', 'hosting')
+    insertSource(db, 'render-hosting-2', 'render', 'hosting')
+    insertLine(db, { source: 'render-hosting-1', start: win.start, end: win.end, amount: 12000, confidence: 'manual', dedupKey: 'd1' })
+    insertLine(db, { source: 'render-hosting-2', start: win.start, end: win.end, amount: 8000, confidence: 'manual', dedupKey: 'd2' })
+    const candidates = gatherRecommendationCandidates(db, NOW)
+    const dup = candidates.find(c => c.type === 'duplicate_hosting_saas')
+    expect(dup).toBeDefined()
+    expect(dup?.estimated_monthly_saving).toBe(8000) // 20000 total - 12000 max
+  })
+
+  it('does not flag a single source in a (provider, source_type) group', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting-1', 'render', 'hosting')
+    insertLine(db, { source: 'render-hosting-1', start: win.start, end: win.end, amount: 12000, confidence: 'manual', dedupKey: 'd1' })
+    const candidates = gatherRecommendationCandidates(db, NOW)
+    expect(candidates.find(c => c.type === 'duplicate_hosting_saas')).toBeUndefined()
+  })
+})
+
+describe('gatherRecommendationCandidates -- automate long-manual-only source', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('fires after 3 consecutive manual-only periods, with zero fabricated saving', () => {
+    const db = getDb()
+    insertSource(db, 'always-manual', 'other', 'saas')
+    const months = [NOW, NOW - 32 * 86400, NOW - 64 * 86400]
+    months.forEach((t, i) => {
+      const w = monthWindow(t)
+      insertLine(db, { source: 'always-manual', start: w.start, end: w.end, amount: 500, confidence: 'manual', dedupKey: `m${i}` })
+    })
+    const candidates = gatherRecommendationCandidates(db, NOW)
+    const a = candidates.find(c => c.type === 'automate_long_manual_source')
+    expect(a).toBeDefined()
+    expect(a?.estimated_monthly_saving).toBe(0)
+    expect(a?.current_monthly_cost).toBe(500)
+  })
+
+  it('does not fire once a provider_api actual has landed', () => {
+    const db = getDb()
+    insertSource(db, 'now-real', 'render', 'hosting')
+    const months = [NOW, NOW - 32 * 86400, NOW - 64 * 86400]
+    months.forEach((t, i) => {
+      const w = monthWindow(t)
+      insertLine(db, { source: 'now-real', start: w.start, end: w.end, amount: 500, confidence: i === 0 ? 'provider_api' : 'manual', dedupKey: `p${i}` })
+    })
+    const candidates = gatherRecommendationCandidates(db, NOW)
+    expect(candidates.find(c => c.type === 'automate_long_manual_source' && c.evidence.source_id === 'now-real')).toBeUndefined()
+  })
+})
+
+describe('gatherRecommendationCandidates -- the 5 honestly-unwired types', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('never produces switch_to_annual_billing/unused_domain_or_storage/forgotten_service/oversized_fixed_package/provider_credit_or_discount (no live signal exists)', () => {
+    const db = getDb()
+    const candidates = gatherRecommendationCandidates(db, NOW)
+    const unwired = ['switch_to_annual_billing', 'unused_domain_or_storage', 'forgotten_service', 'oversized_fixed_package', 'provider_credit_or_discount']
+    for (const type of unwired) {
+      expect(candidates.filter(c => c.type === type)).toEqual([])
+    }
+  })
+})
+
+function writeSubscriptionsFixture(content: unknown): void {
+  mkdirSync(dirname(SUBSCRIPTIONS_PATH), { recursive: true })
+  writeFileSync(SUBSCRIPTIONS_PATH, JSON.stringify(content))
+}
+
+describe('gatherRecommendationCandidates -- subscription-based (real file fixture)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+  afterEach(() => { if (existsSync(SUBSCRIPTIONS_PATH)) rmSync(SUBSCRIPTIONS_PATH) })
+
+  it('is empty (never fabricated) when no costops-subscriptions.json exists', () => {
+    const db = getDb()
+    const candidates = gatherRecommendationCandidates(db, NOW)
+    expect(candidates.filter(c => c.type === 'underused_subscription_downgrade' || c.type === 'duplicate_subscription')).toEqual([])
+  })
+
+  it('flags an underused active subscription with a real usage_snapshot', () => {
+    writeSubscriptionsFixture({
+      version: 1,
+      subscriptions: [
+        { id: 'claude-max', name: 'Claude Max', provider: 'anthropic', source: 'config', status: 'active', amount: 22000, amount_source: 'manual_fallback', usage_snapshot: { as_of: '2026-07-15T00:00:00Z', session_pct: 2, weekly_pct: 3, weekly_reset_label: 'Tue' } },
+      ],
+    })
+    const db = getDb()
+    const candidates = gatherRecommendationCandidates(db, NOW)
+    const rec = candidates.find(c => c.type === 'underused_subscription_downgrade')
+    expect(rec).toBeDefined()
+    expect(rec?.current_monthly_cost).toBe(22000)
+    expect(rec?.risk).toBe('medium') // cancel-only path, no known downgrade tier
+  })
+
+  it('flags duplicate subscriptions sharing the same provider', () => {
+    writeSubscriptionsFixture({
+      version: 1,
+      subscriptions: [
+        { id: 'claude-max', name: 'Claude Max', provider: 'anthropic', source: 'config', status: 'active', amount: 22000, amount_source: 'manual_fallback' },
+        { id: 'claude-pro', name: 'Claude Pro', provider: 'anthropic', source: 'config', status: 'active', amount: 8000, amount_source: 'manual_fallback' },
+      ],
+    })
+    const db = getDb()
+    const candidates = gatherRecommendationCandidates(db, NOW)
+    const rec = candidates.find(c => c.type === 'duplicate_subscription')
+    expect(rec).toBeDefined()
+    expect(rec?.estimated_monthly_saving).toBe(8000)
+  })
+
+  it('does not flag a canceled subscription as underused', () => {
+    writeSubscriptionsFixture({
+      version: 1,
+      subscriptions: [
+        { id: 'old-sub', name: 'Old', provider: 'openai', source: 'config', status: 'canceled', amount: 5000, amount_source: 'manual_fallback', usage_snapshot: { as_of: '2026-07-15T00:00:00Z', session_pct: 1, weekly_pct: 1, weekly_reset_label: 'Tue' } },
+      ],
+    })
+    const db = getDb()
+    const candidates = gatherRecommendationCandidates(db, NOW)
+    expect(candidates.find(c => c.type === 'underused_subscription_downgrade')).toBeUndefined()
+  })
+})
+
+describe('captureRecommendations persistence round-trip', () => {
+  beforeEach(() => { initDatabase(':memory:'); initOptimizationSchema(getDb()) })
+
+  it('inserts new open recommendations on first capture', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting-1', 'render', 'hosting')
+    insertSource(db, 'render-hosting-2', 'render', 'hosting')
+    insertLine(db, { source: 'render-hosting-1', start: win.start, end: win.end, amount: 12000, confidence: 'manual', dedupKey: 'd1' })
+    insertLine(db, { source: 'render-hosting-2', start: win.start, end: win.end, amount: 8000, confidence: 'manual', dedupKey: 'd2' })
+    const summary = captureRecommendations(db, NOW)
+    expect(summary.inserted).toBeGreaterThanOrEqual(1)
+    const open = listRecommendations(db)
+    expect(open.some(r => r.type === 'duplicate_hosting_saas' && r.status === 'open')).toBe(true)
+  })
+
+  it('dedups on a second capture -- no duplicate row, only a touch', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting-1', 'render', 'hosting')
+    insertSource(db, 'render-hosting-2', 'render', 'hosting')
+    insertLine(db, { source: 'render-hosting-1', start: win.start, end: win.end, amount: 12000, confidence: 'manual', dedupKey: 'd1' })
+    insertLine(db, { source: 'render-hosting-2', start: win.start, end: win.end, amount: 8000, confidence: 'manual', dedupKey: 'd2' })
+    captureRecommendations(db, NOW)
+    const second = captureRecommendations(db, NOW + 3600)
+    expect(second.inserted).toBe(0)
+    const rows = db.prepare(`SELECT COUNT(*) as n FROM costops_recommendations WHERE type = 'duplicate_hosting_saas'`).get() as { n: number }
+    expect(rows.n).toBe(1)
+  })
+
+  it('resolves a recommendation once its condition disappears', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting-1', 'render', 'hosting')
+    insertSource(db, 'render-hosting-2', 'render', 'hosting')
+    insertLine(db, { source: 'render-hosting-1', start: win.start, end: win.end, amount: 12000, confidence: 'manual', dedupKey: 'd1' })
+    insertLine(db, { source: 'render-hosting-2', start: win.start, end: win.end, amount: 8000, confidence: 'manual', dedupKey: 'd2' })
+    captureRecommendations(db, NOW)
+    db.prepare(`UPDATE cost_line_items SET voided_at = ? WHERE dedup_key = 'd2'`).run(NOW + 100) // only one source left -- no more duplicate
+    const summary = captureRecommendations(db, NOW + 3600)
+    expect(summary.resolved).toBeGreaterThanOrEqual(1)
+    const open = listRecommendations(db)
+    expect(open.find(r => r.type === 'duplicate_hosting_saas')).toBeUndefined()
+    const resolvedRow = listRecommendations(db, { status: 'resolved' }).find(r => r.type === 'duplicate_hosting_saas')
+    expect(resolvedRow).toBeDefined()
+  })
+
+  it('freezes an accepted recommendation -- captureRecommendations never reverts it back to open', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting-1', 'render', 'hosting')
+    insertSource(db, 'render-hosting-2', 'render', 'hosting')
+    insertLine(db, { source: 'render-hosting-1', start: win.start, end: win.end, amount: 12000, confidence: 'manual', dedupKey: 'd1' })
+    insertLine(db, { source: 'render-hosting-2', start: win.start, end: win.end, amount: 8000, confidence: 'manual', dedupKey: 'd2' })
+    captureRecommendations(db, NOW)
+    db.prepare(`UPDATE costops_recommendations SET status='accepted', status_changed_at=?, status_changed_by='istvan' WHERE type='duplicate_hosting_saas'`).run(NOW)
+    const summary = captureRecommendations(db, NOW + 3600) // condition still detected this round
+    expect(summary.touched).toBe(0)
+    const row = db.prepare(`SELECT status FROM costops_recommendations WHERE type = 'duplicate_hosting_saas'`).get() as { status: string }
+    expect(row.status).toBe('accepted')
+  })
+
+  it('expires an unaddressed open recommendation past its expiry window', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    insertSource(db, 'render-hosting-1', 'render', 'hosting')
+    insertSource(db, 'render-hosting-2', 'render', 'hosting')
+    insertLine(db, { source: 'render-hosting-1', start: win.start, end: win.end, amount: 12000, confidence: 'manual', dedupKey: 'd1' })
+    insertLine(db, { source: 'render-hosting-2', start: win.start, end: win.end, amount: 8000, confidence: 'manual', dedupKey: 'd2' })
+    captureRecommendations(db, NOW, { expirySeconds: 100 })
+    const summary = captureRecommendations(db, NOW + 200, { expirySeconds: 100 }) // still detected, but past expiry
+    expect(summary.expired).toBeGreaterThanOrEqual(1)
+    const expiredRow = listRecommendations(db, { status: 'expired' }).find(r => r.type === 'duplicate_hosting_saas')
+    expect(expiredRow).toBeDefined()
+  })
+})

--- a/src/__tests__/costops-optimization.test.ts
+++ b/src/__tests__/costops-optimization.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  detectUnderusedSubscriptionRecommendation,
+  detectDuplicateSubscriptionRecommendations,
+  detectDuplicateHostingSaasRecommendations,
+  detectAnnualBillingRecommendation,
+  detectUnusedDomainOrStorageRecommendation,
+  detectForgottenServiceRecommendation,
+  detectOversizedFixedPackageRecommendation,
+  detectAutomateLongManualSourceRecommendation,
+  detectProviderCreditOrDiscountRecommendation,
+  reconcileRecommendations,
+  acceptRecommendation,
+  dismissRecommendation,
+  serializeEvidence,
+  deserializeEvidence,
+  initOptimizationSchema,
+  type RecommendationRecord,
+  type RecommendationCandidate,
+} from '../costops/optimization.js'
+
+// ---- detectors ---------------------------------------------------------------------
+
+describe('detectUnderusedSubscriptionRecommendation', () => {
+  it('is null above the under-threshold', () => {
+    expect(detectUnderusedSubscriptionRecommendation({ subscription_id: 's', provider: 'anthropic', monthly_cost: 100, usage_pct: 0.5, under_threshold_pct: 0.1, cancel_or_downgrade_option: null, downgrade_monthly_cost: null })).toBeNull()
+  })
+  it('recommends cancellation (full saving, medium risk, high confidence) when no downgrade path is known', () => {
+    const r = detectUnderusedSubscriptionRecommendation({ subscription_id: 's', provider: 'anthropic', monthly_cost: 100, usage_pct: 0.05, under_threshold_pct: 0.1, cancel_or_downgrade_option: 'cancel', downgrade_monthly_cost: null })
+    expect(r?.estimated_monthly_saving).toBe(100)
+    expect(r?.risk).toBe('medium')
+    expect(r?.confidence).toBe('high')
+  })
+  it('recommends downgrade (partial saving, low risk) when a cheaper tier is known', () => {
+    const r = detectUnderusedSubscriptionRecommendation({ subscription_id: 's', provider: 'anthropic', monthly_cost: 100, usage_pct: 0.05, under_threshold_pct: 0.1, cancel_or_downgrade_option: 'downgrade', downgrade_monthly_cost: 40 })
+    expect(r?.estimated_monthly_saving).toBe(60)
+    expect(r?.risk).toBe('low')
+  })
+  it('is null when no real option is known at all (never fabricates a saving)', () => {
+    const r = detectUnderusedSubscriptionRecommendation({ subscription_id: 's', provider: 'anthropic', monthly_cost: 100, usage_pct: 0.05, under_threshold_pct: 0.1, cancel_or_downgrade_option: null, downgrade_monthly_cost: null })
+    expect(r).toBeNull()
+  })
+})
+
+describe('detectDuplicateSubscriptionRecommendations', () => {
+  it('flags a group of 2+ active subscriptions in the same product, keeping the most expensive', () => {
+    const recs = detectDuplicateSubscriptionRecommendations([
+      { subscription_id: 'claude-max', provider: 'anthropic', product: 'llm-subscription', monthly_cost: 100, status: 'active' },
+      { subscription_id: 'claude-pro', provider: 'anthropic', product: 'llm-subscription', monthly_cost: 40, status: 'active' },
+    ])
+    expect(recs).toHaveLength(1)
+    expect(recs[0].evidence.suggested_keep).toBe('claude-max')
+    expect(recs[0].evidence.suggested_cancel).toEqual(['claude-pro'])
+    expect(recs[0].estimated_monthly_saving).toBe(40)
+  })
+  it('does not flag a single subscription per product', () => {
+    const recs = detectDuplicateSubscriptionRecommendations([
+      { subscription_id: 'a', provider: 'x', product: 'p1', monthly_cost: 10, status: 'active' },
+      { subscription_id: 'b', provider: 'x', product: 'p2', monthly_cost: 10, status: 'active' },
+    ])
+    expect(recs).toEqual([])
+  })
+  it('ignores canceled/expired subscriptions', () => {
+    const recs = detectDuplicateSubscriptionRecommendations([
+      { subscription_id: 'a', provider: 'x', product: 'p1', monthly_cost: 10, status: 'active' },
+      { subscription_id: 'b', provider: 'x', product: 'p1', monthly_cost: 10, status: 'canceled' },
+    ])
+    expect(recs).toEqual([])
+  })
+})
+
+describe('detectDuplicateHostingSaasRecommendations', () => {
+  it('flags a redundant group at low confidence (heuristic grouping)', () => {
+    const recs = detectDuplicateHostingSaasRecommendations([
+      { source_id: 'render-hosting', provider: 'render', source_type: 'hosting', service_key: 'web-hosting', monthly_cost: 100 },
+      { source_id: 'vercel-hosting', provider: 'vercel', source_type: 'hosting', service_key: 'web-hosting', monthly_cost: 60 },
+    ])
+    expect(recs).toHaveLength(1)
+    expect(recs[0].confidence).toBe('low')
+    expect(recs[0].estimated_monthly_saving).toBe(60) // total 160 - max 100
+  })
+})
+
+describe('detectAnnualBillingRecommendation', () => {
+  it('is null without a known annual equivalent (never estimated generically)', () => {
+    expect(detectAnnualBillingRecommendation({ subscription_id: 's', provider: 'x', monthly_cost: 100, annual_plan_monthly_equivalent: null })).toBeNull()
+  })
+  it('computes saving and treats the annual up-front cost as switching_cost', () => {
+    const r = detectAnnualBillingRecommendation({ subscription_id: 's', provider: 'x', monthly_cost: 100, annual_plan_monthly_equivalent: 80 })
+    expect(r?.estimated_monthly_saving).toBe(20)
+    expect(r?.switching_cost).toBe(80 * 12)
+    expect(r?.confidence).toBe('high')
+  })
+})
+
+describe('detectUnusedDomainOrStorageRecommendation', () => {
+  it('never fires from mere absence of data -- requires confirmed_unused', () => {
+    expect(detectUnusedDomainOrStorageRecommendation({ source_id: 'd1', provider: 'namecheap', source_type: 'domain', monthly_cost: 10, confirmed_unused: false })).toBeNull()
+  })
+  it('fires with the full monthly cost as saving when confirmed', () => {
+    const r = detectUnusedDomainOrStorageRecommendation({ source_id: 'd1', provider: 'namecheap', source_type: 'domain', monthly_cost: 10, confirmed_unused: true })
+    expect(r?.estimated_monthly_saving).toBe(10)
+    expect(r?.rollback_note).toMatch(/re-registered/)
+  })
+})
+
+describe('detectForgottenServiceRecommendation', () => {
+  it('is null with unknown inactivity (never fabricated as 0 months)', () => {
+    expect(detectForgottenServiceRecommendation({ source_id: 's', provider: 'x', monthly_cost: 50, months_since_last_meaningful_activity: null, threshold_months: 6 })).toBeNull()
+  })
+  it('is null under the threshold', () => {
+    expect(detectForgottenServiceRecommendation({ source_id: 's', provider: 'x', monthly_cost: 50, months_since_last_meaningful_activity: 3, threshold_months: 6 })).toBeNull()
+  })
+  it('fires at/above the threshold', () => {
+    const r = detectForgottenServiceRecommendation({ source_id: 's', provider: 'x', monthly_cost: 50, months_since_last_meaningful_activity: 6, threshold_months: 6 })
+    expect(r?.estimated_monthly_saving).toBe(50)
+  })
+})
+
+describe('detectOversizedFixedPackageRecommendation', () => {
+  it('is null without a known smaller tier', () => {
+    expect(detectOversizedFixedPackageRecommendation({ subscription_id: 's', provider: 'x', current_tier_monthly_cost: 100, actual_usage_pct_of_current_tier: 0.1, smaller_tier_monthly_cost: null, smaller_tier_capacity_pct_of_current: null })).toBeNull()
+  })
+  it('is null when actual usage would NOT fit the smaller tier', () => {
+    expect(detectOversizedFixedPackageRecommendation({ subscription_id: 's', provider: 'x', current_tier_monthly_cost: 100, actual_usage_pct_of_current_tier: 0.6, smaller_tier_monthly_cost: 50, smaller_tier_capacity_pct_of_current: 0.5 })).toBeNull()
+  })
+  it('fires when usage fits within the smaller tier capacity', () => {
+    const r = detectOversizedFixedPackageRecommendation({ subscription_id: 's', provider: 'x', current_tier_monthly_cost: 100, actual_usage_pct_of_current_tier: 0.3, smaller_tier_monthly_cost: 50, smaller_tier_capacity_pct_of_current: 0.5 })
+    expect(r?.estimated_monthly_saving).toBe(50)
+  })
+})
+
+describe('detectAutomateLongManualSourceRecommendation', () => {
+  it('is null under the threshold', () => {
+    expect(detectAutomateLongManualSourceRecommendation({ source_id: 's', provider: 'x', monthly_cost: 20, consecutive_manual_only_months: 2, threshold_months: 3 })).toBeNull()
+  })
+  it('fires with ZERO estimated saving -- value is data quality, never a fabricated dollar figure', () => {
+    const r = detectAutomateLongManualSourceRecommendation({ source_id: 's', provider: 'x', monthly_cost: 20, consecutive_manual_only_months: 3, threshold_months: 3 })
+    expect(r?.estimated_monthly_saving).toBe(0)
+    expect(r?.estimated_annual_saving).toBe(0)
+    expect(r?.current_monthly_cost).toBe(20)
+  })
+})
+
+describe('detectProviderCreditOrDiscountRecommendation', () => {
+  it('is null without a known real offer', () => {
+    expect(detectProviderCreditOrDiscountRecommendation({ provider: 'render', monthly_cost: 100, known_available_credit_or_discount_monthly: null, discount_description: null })).toBeNull()
+    expect(detectProviderCreditOrDiscountRecommendation({ provider: 'render', monthly_cost: 100, known_available_credit_or_discount_monthly: 0, discount_description: null })).toBeNull()
+  })
+  it('fires at high confidence for a known offer', () => {
+    const r = detectProviderCreditOrDiscountRecommendation({ provider: 'render', monthly_cost: 100, known_available_credit_or_discount_monthly: 15, discount_description: 'annual prepay 15% off' })
+    expect(r?.estimated_monthly_saving).toBe(15)
+    expect(r?.confidence).toBe('high')
+  })
+})
+
+// ---- lifecycle ------------------------------------------------------------------------
+
+function candidate(dedup_key: string, over: Partial<RecommendationCandidate> = {}): RecommendationCandidate {
+  return {
+    type: 'underused_subscription_downgrade', dedup_key, evidence: { note: 'x' },
+    current_monthly_cost: 100, estimated_monthly_saving: 50, estimated_annual_saving: 600,
+    switching_cost: 0, risk: 'low', confidence: 'medium',
+    human_decision_required: 'confirm', rollback_note: 'reversible',
+    ...over,
+  }
+}
+
+function record(dedup_key: string, status: RecommendationRecord['status'], over: Partial<RecommendationRecord> = {}): RecommendationRecord {
+  return {
+    ...candidate(dedup_key),
+    first_seen: 1, last_seen: 1, status, status_changed_at: null, status_changed_by: null, expires_at: 1 + 1000,
+    ...over,
+  }
+}
+
+describe('reconcileRecommendations', () => {
+  it('inserts a brand new recommendation with status open and an expiry', () => {
+    const r = reconcileRecommendations([], [candidate('a')], 1000, 500)
+    expect(r.toInsert).toHaveLength(1)
+    expect(r.toInsert[0].status).toBe('open')
+    expect(r.toInsert[0].expires_at).toBe(1500)
+  })
+
+  it('touches an OPEN existing recommendation instead of duplicating', () => {
+    const existing = record('a', 'open')
+    const r = reconcileRecommendations([existing], [candidate('a', { estimated_monthly_saving: 999 })], 2000)
+    expect(r.toInsert).toHaveLength(0)
+    expect(r.toTouch).toHaveLength(1)
+    expect(r.toTouch[0].patch.estimated_monthly_saving).toBe(999)
+  })
+
+  it('never touches an ACCEPTED recommendation -- a human decision is frozen', () => {
+    const existing = record('a', 'accepted', { status_changed_at: 500, status_changed_by: 'istvan' })
+    const r = reconcileRecommendations([existing], [candidate('a')], 2000)
+    expect(r.toInsert).toHaveLength(0)
+    expect(r.toTouch).toHaveLength(0)
+  })
+
+  it('never touches a DISMISSED recommendation -- a human decision is frozen', () => {
+    const existing = record('a', 'dismissed', { status_changed_at: 500, status_changed_by: 'istvan' })
+    const r = reconcileRecommendations([existing], [candidate('a')], 2000)
+    expect(r.toTouch).toHaveLength(0)
+  })
+
+  it('resolves an open recommendation whose candidate disappeared', () => {
+    const existing = record('a', 'open')
+    const r = reconcileRecommendations([existing], [], 2000)
+    expect(r.toResolve).toEqual([{ dedup_key: 'a' }])
+    expect(r.toExpire).toEqual([])
+  })
+
+  it('expires an open recommendation past its expires_at even if still detected', () => {
+    const existing = record('a', 'open', { expires_at: 1000 })
+    const r = reconcileRecommendations([existing], [candidate('a')], 2000)
+    expect(r.toExpire).toEqual([{ dedup_key: 'a' }])
+    expect(r.toResolve).toEqual([])
+  })
+
+  it('resolve takes priority over expire when a recommendation is both gone AND past expiry', () => {
+    const existing = record('a', 'open', { expires_at: 1000 })
+    const r = reconcileRecommendations([existing], [], 2000)
+    expect(r.toResolve).toEqual([{ dedup_key: 'a' }])
+    expect(r.toExpire).toEqual([])
+  })
+
+  it('an EXPIRED recommendation resurfacing as a candidate again gets a fresh insert, not an un-expire', () => {
+    const existing = record('a', 'expired')
+    const r = reconcileRecommendations([existing], [candidate('a')], 3000, 500)
+    expect(r.toInsert).toHaveLength(1)
+    expect(r.toInsert[0].status).toBe('open')
+    expect(r.toInsert[0].first_seen).toBe(3000)
+  })
+
+  it('a RESOLVED recommendation resurfacing gets a fresh insert too', () => {
+    const existing = record('a', 'resolved')
+    const r = reconcileRecommendations([existing], [candidate('a')], 3000)
+    expect(r.toInsert).toHaveLength(0) // resolved is NOT in the "!ex || expired" fresh-insert branch by design
+    expect(r.toTouch).toHaveLength(0)  // and resolved is frozen, same as accepted/dismissed
+  })
+})
+
+describe('acceptRecommendation / dismissRecommendation', () => {
+  const base = record('a', 'open')
+  it('acceptRecommendation sets status/actor/time', () => {
+    const a = acceptRecommendation(base, 'istvan', 5000)
+    expect(a.status).toBe('accepted')
+    expect(a.status_changed_by).toBe('istvan')
+    expect(a.status_changed_at).toBe(5000)
+  })
+  it('dismissRecommendation sets status/actor/time', () => {
+    const d = dismissRecommendation(base, 'istvan', 6000)
+    expect(d.status).toBe('dismissed')
+    expect(d.status_changed_by).toBe('istvan')
+  })
+})
+
+describe('serializeEvidence / deserializeEvidence (re-exported from alerts.ts)', () => {
+  it('round-trips', () => {
+    const ev = { subscription_id: 's', usage_pct: 0.05 }
+    expect(deserializeEvidence(serializeEvidence(ev))).toEqual(ev)
+  })
+})
+
+describe('initOptimizationSchema', () => {
+  it('is idempotent and the table accepts a row keyed by dedup_key', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initOptimizationSchema(db)
+    initOptimizationSchema(db) // must not throw
+    const now = 1000
+    db.prepare(`
+      INSERT INTO costops_recommendations
+        (type, evidence_json, dedup_key, current_monthly_cost, estimated_monthly_saving, estimated_annual_saving, switching_cost, risk, confidence, human_decision_required, rollback_note, status, expires_at, first_seen, last_seen, created_at)
+      VALUES ('underused_subscription_downgrade', @ev, 'k1', 100, 50, 600, 0, 'low', 'medium', 'confirm', 'reversible', 'open', @exp, @now, @now, @now)
+    `).run({ ev: serializeEvidence({ x: 1 }), exp: now + 1000, now })
+    const row = db.prepare(`SELECT * FROM costops_recommendations WHERE dedup_key = 'k1'`).get() as { estimated_monthly_saving: number; status: string }
+    expect(row.estimated_monthly_saving).toBe(50)
+    expect(row.status).toBe('open')
+  })
+
+  it('rejects a duplicate dedup_key', () => {
+    initDatabase(':memory:')
+    const db = getDb()
+    initOptimizationSchema(db)
+    const now = 1000
+    const insert = () => db.prepare(`
+      INSERT INTO costops_recommendations
+        (type, evidence_json, dedup_key, current_monthly_cost, estimated_monthly_saving, estimated_annual_saving, switching_cost, risk, confidence, human_decision_required, rollback_note, status, expires_at, first_seen, last_seen, created_at)
+      VALUES ('underused_subscription_downgrade', '{}', 'k1', 100, 50, 600, 0, 'low', 'medium', 'confirm', 'reversible', 'open', @exp, @now, @now, @now)
+    `).run({ exp: now + 1000, now })
+    insert()
+    expect(() => insert()).toThrow()
+  })
+})

--- a/src/__tests__/costops-period-close.test.ts
+++ b/src/__tests__/costops-period-close.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  getPeriodStatus, isPeriodClosed, checkPeriodWritable, checkCloseReadiness,
+  closePeriod, reopenPeriod, getPeriodCloseHistory, getCloseSnapshot,
+} from '../costops/period-close.js'
+import { createManualCost, deleteManualCost } from '../costops/manual-entry.js'
+import { createCorrection } from '../costops/correction.js'
+import { monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const MONTH = monthWindow(NOW).key
+const cfg: CostOpsConfig = { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] }
+
+describe('period status + writability (CostOps Phase 2, GAP-13)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('defaults to open when no row exists yet', () => {
+    expect(getPeriodStatus(getDb(), MONTH)).toBe('open')
+    expect(isPeriodClosed(getDb(), MONTH)).toBe(false)
+    expect(checkPeriodWritable(getDb(), MONTH).writable).toBe(true)
+  })
+
+  it('checkPeriodWritable blocks only when status is closed', () => {
+    const db = getDb()
+    closePeriod(db, cfg, MONTH, 'istvan', 'end of month', NOW, { force: true })
+    expect(isPeriodClosed(db, MONTH)).toBe(true)
+    const r = checkPeriodWritable(db, MONTH)
+    expect(r.writable).toBe(false)
+    expect(r.reason).toContain('closed')
+  })
+
+  it('reopened status reverts to writable (same rules as open)', () => {
+    const db = getDb()
+    closePeriod(db, cfg, MONTH, 'istvan', 'x', NOW, { force: true })
+    reopenPeriod(db, MONTH, 'istvan', 'found a mistake', NOW + 100)
+    expect(getPeriodStatus(db, MONTH)).toBe('reopened')
+    expect(checkPeriodWritable(db, MONTH).writable).toBe(true)
+  })
+})
+
+describe('checkCloseReadiness (CostOps Phase 2, GAP-13)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('an empty month with nothing outstanding is ready', () => {
+    const r = checkCloseReadiness(getDb(), cfg, NOW, MONTH)
+    expect(r.ready).toBe(true)
+    expect(r.checks.expected_invoices_received.ok).toBe(true)
+    expect(r.checks.unresolved_alerts.ok).toBe(true)
+  })
+
+  it('a material reconciliation variance blocks readiness', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-hosting','Render','render','usage','HUF',1,1,1)`).run()
+    db.prepare(`INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source) VALUES ('render-hosting', ?, ?, 'usage', 10000, 'HUF', 'provider_api', ?, ?, 'a', 'provider_api')`).run(win.start, win.end, NOW, NOW)
+    db.prepare(`INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source) VALUES ('render-hosting', ?, ?, 'usage', 15000, 'HUF', 'actual_invoice', ?, ?, 'b', 'email_invoice')`).run(win.start, win.end, NOW, NOW)
+    const r = checkCloseReadiness(db, cfg, NOW, MONTH)
+    expect(r.checks.reconciliation_clean.ok).toBe(false)
+    expect(r.ready).toBe(false)
+  })
+
+  it('an unresolved CRITICAL alert blocks readiness; a non-critical one does not', () => {
+    const db = getDb()
+    db.prepare(`INSERT INTO costops_alerts (type, severity, evidence_json, dedup_key, first_seen, last_seen, recurrence_count, created_at) VALUES ('budget_threshold','warning','{}','a',?,?,0,?)`).run(NOW, NOW, NOW)
+    expect(checkCloseReadiness(db, cfg, NOW, MONTH).ready).toBe(true)
+
+    db.prepare(`INSERT INTO costops_alerts (type, severity, evidence_json, dedup_key, first_seen, last_seen, recurrence_count, created_at) VALUES ('budget_threshold','critical','{}','b',?,?,0,?)`).run(NOW, NOW, NOW)
+    const r = checkCloseReadiness(db, cfg, NOW, MONTH)
+    expect(r.checks.unresolved_alerts.ok).toBe(false)
+    expect(r.ready).toBe(false)
+  })
+
+  it('estimate-only sources and stale (not failed) collectors are surfaced but never block', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('hosting','Hosting','other','hosting','HUF',1,1,1)`).run()
+    db.prepare(`INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source) VALUES ('hosting', ?, ?, 'subscription', 3000, 'HUF', 'manual', ?, ?, 'a', 'manual_entry')`).run(win.start, win.end, NOW, NOW)
+    const r = checkCloseReadiness(db, cfg, NOW, MONTH)
+    expect(r.checks.estimates_present.ok).toBe(false)
+    expect(r.checks.estimates_present.estimate_only_sources).toContain('hosting')
+    expect(r.ready).toBe(true) // estimate presence never blocks
+  })
+})
+
+describe('closePeriod / reopenPeriod (CostOps Phase 2, GAP-13)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('closes a ready month, records an immutable snapshot + audit event', () => {
+    const db = getDb()
+    const r = closePeriod(db, cfg, MONTH, 'istvan', 'monthly close', NOW)
+    expect(r.ok).toBe(true)
+    expect(getPeriodStatus(db, MONTH)).toBe('closed')
+    const history = getPeriodCloseHistory(db, MONTH)
+    expect(history).toHaveLength(1)
+    expect(history[0].event_type).toBe('closed')
+    expect(history[0].actor).toBe('istvan')
+    const snap = getCloseSnapshot(db, MONTH)
+    expect(snap).not.toBeNull()
+    expect(snap!.summary.month).toBe(MONTH)
+    expect(Array.isArray(snap!.budgets)).toBe(true) // Phase 3 (GAP-11): budget statuses frozen into the close snapshot too
+  })
+
+  it('blocks close when readiness has a blocking issue, unless force:true', () => {
+    const db = getDb()
+    db.prepare(`INSERT INTO costops_alerts (type, severity, evidence_json, dedup_key, first_seen, last_seen, recurrence_count, created_at) VALUES ('budget_threshold','critical','{}','a',?,?,0,?)`).run(NOW, NOW, NOW)
+    const blocked = closePeriod(db, cfg, MONTH, 'istvan', 'x', NOW)
+    expect(blocked.ok).toBe(false)
+    expect(blocked.status).toBe(409)
+    expect(blocked.readiness!.ready).toBe(false)
+
+    const forced = closePeriod(db, cfg, MONTH, 'istvan', 'closing despite the alert, reviewed manually', NOW, { force: true })
+    expect(forced.ok).toBe(true)
+  })
+
+  it('409s on closing an already-closed month -- must reopen first', () => {
+    const db = getDb()
+    closePeriod(db, cfg, MONTH, 'istvan', 'x', NOW)
+    const second = closePeriod(db, cfg, MONTH, 'istvan', 'y', NOW + 10)
+    expect(second.ok).toBe(false)
+    expect(second.status).toBe(409)
+  })
+
+  it('requires an actor to close', () => {
+    const db = getDb()
+    const r = closePeriod(db, cfg, MONTH, '', 'x', NOW)
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(400)
+  })
+
+  it('reopen requires a reason and an actor, and only works on a closed month', () => {
+    const db = getDb()
+    expect(reopenPeriod(db, MONTH, 'istvan', 'x', NOW).ok).toBe(false) // not closed yet
+    closePeriod(db, cfg, MONTH, 'istvan', 'close', NOW)
+    expect(reopenPeriod(db, MONTH, '', 'x', NOW + 10).ok).toBe(false) // missing actor
+    expect(reopenPeriod(db, MONTH, 'istvan', '', NOW + 10).ok).toBe(false) // missing reason
+    const r = reopenPeriod(db, MONTH, 'istvan', 'found an error', NOW + 10)
+    expect(r.ok).toBe(true)
+    expect(getPeriodStatus(db, MONTH)).toBe('reopened')
+  })
+
+  it('the audit history records both a close and a later reopen, in order', () => {
+    const db = getDb()
+    closePeriod(db, cfg, MONTH, 'istvan', 'first close', NOW)
+    reopenPeriod(db, MONTH, 'istvan', 'correction needed', NOW + 100)
+    const history = getPeriodCloseHistory(db, MONTH)
+    expect(history.map(h => h.event_type)).toEqual(['closed', 'reopened'])
+  })
+
+  it('re-closing after a reopen creates a SECOND immutable snapshot, not overwriting the first', () => {
+    const db = getDb()
+    closePeriod(db, cfg, MONTH, 'istvan', 'first close', NOW)
+    const firstSnap = getCloseSnapshot(db, MONTH)
+    reopenPeriod(db, MONTH, 'istvan', 'fix needed', NOW + 100)
+    // Change the data, then re-close -- the snapshot should reflect the NEW state.
+    createManualCost(db, { source_id: 'domain', name: 'Domain', provider: 'other', amount: 5000, currency: 'HUF', month: MONTH }, { fxUsdHuf: 360, now: NOW + 150 })
+    closePeriod(db, cfg, MONTH, 'istvan', 'second close', NOW + 200)
+    const secondSnap = getCloseSnapshot(db, MONTH)
+    expect(secondSnap!.summary.current_spend).not.toBe(firstSnap!.summary.current_spend)
+    const history = getPeriodCloseHistory(db, MONTH)
+    expect(history.map(h => h.event_type)).toEqual(['closed', 'reopened', 'closed'])
+  })
+})
+
+describe('write-path guards on a closed month (CostOps Phase 2, GAP-13 integration)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('createManualCost is blocked on a closed month', () => {
+    const db = getDb()
+    closePeriod(db, cfg, MONTH, 'istvan', 'x', NOW)
+    const r = createManualCost(db, { source_id: 'domain', name: 'Domain', provider: 'other', amount: 3000, currency: 'HUF', month: MONTH }, { fxUsdHuf: 360, now: NOW + 10 })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(409)
+    expect(r.error).toContain('correction')
+  })
+
+  it('createManualCost works again once the month is reopened', () => {
+    const db = getDb()
+    closePeriod(db, cfg, MONTH, 'istvan', 'x', NOW)
+    reopenPeriod(db, MONTH, 'istvan', 'need to add a late cost', NOW + 10)
+    const r = createManualCost(db, { source_id: 'domain', name: 'Domain', provider: 'other', amount: 3000, currency: 'HUF', month: MONTH }, { fxUsdHuf: 360, now: NOW + 20 })
+    expect(r.ok).toBe(true)
+  })
+
+  it('deleteManualCost (void) is also blocked on a closed month', () => {
+    const db = getDb()
+    createManualCost(db, { source_id: 'domain', name: 'Domain', provider: 'other', amount: 3000, currency: 'HUF', month: MONTH }, { fxUsdHuf: 360, now: NOW })
+    closePeriod(db, cfg, MONTH, 'istvan', 'x', NOW + 5, { force: true })
+    const r = deleteManualCost(db, { source_id: 'domain', month: MONTH }, { now: NOW + 10 })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe(409)
+  })
+
+  it('createCorrection is NOT blocked on a closed month -- it is the sanctioned path', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-hosting','Render','render','usage','HUF',1,1,1)`).run()
+    const info = db.prepare(`INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source) VALUES ('render-hosting', ?, ?, 'usage', 10000, 'HUF', 'provider_api', ?, ?, 'a', 'provider_api')`).run(win.start, win.end, NOW, NOW)
+    closePeriod(db, cfg, MONTH, 'istvan', 'x', NOW + 5, { force: true })
+    const r = createCorrection(db, { originalLineId: info.lastInsertRowid as number, newAmount: 9500, reason: 'late credit applied after close' }, { now: NOW + 20 })
+    expect(r.ok).toBe(true)
+  })
+})

--- a/src/__tests__/costops-period.test.ts
+++ b/src/__tests__/costops-period.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { syncFixedCostsToLedger, monthWindow } from '../costops/ledger.js'
+import { getPeriodTrend } from '../costops/period.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+
+function cfg(): CostOpsConfig {
+  return {
+    version: 1,
+    currency: 'HUF',
+    fixed_costs: [
+      { source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 22000, period: 'monthly', confidence: 'manual', currency: 'HUF' },
+    ],
+    budgets: [],
+  }
+}
+
+describe('costops period trend', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('reports no_data (never a fabricated 0) for months with zero rows', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW) // only writes for the current (July) month
+    const trend = getPeriodTrend(db, cfg(), NOW, 3)
+    expect(trend.months.map(m => m.month)).toEqual(['2026-05', '2026-06', '2026-07'])
+    expect(trend.months[0].no_data).toBe(true)  // May: no rows at all
+    expect(trend.months[1].no_data).toBe(true)  // June: no rows at all
+    expect(trend.months[2].no_data).toBe(false) // July: has rows
+    expect(trend.months[2].operational_spend).toBe(22000)
+  })
+
+  it('does not fabricate a fixed cost into a month before it existed (a new subscription)', () => {
+    const db = getDb()
+    // Only sync June (the subscription's actual first month) -- May must stay no_data.
+    syncFixedCostsToLedger(db, cfg(), NOW, '2026-06')
+    const trend = getPeriodTrend(db, cfg(), NOW, 3)
+    const may = trend.months.find(m => m.month === '2026-05')!
+    const june = trend.months.find(m => m.month === '2026-06')!
+    expect(may.no_data).toBe(true)
+    expect(june.no_data).toBe(false)
+    expect(june.operational_spend).toBe(22000)
+  })
+
+  it('month_over_month_delta is null when either side is no_data (never computed from a fabricated 0)', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW) // current month only
+    const trend = getPeriodTrend(db, cfg(), NOW, 2)
+    expect(trend.previous.no_data).toBe(true)
+    expect(trend.month_over_month_delta).toBeNull()
+  })
+
+  it('computes a real delta when both months have data', () => {
+    const db = getDb()
+    syncFixedCostsToLedger(db, cfg(), NOW, '2026-06')
+    syncFixedCostsToLedger(db, cfg(), NOW, '2026-07')
+    const trend = getPeriodTrend(db, cfg(), NOW, 2)
+    expect(trend.current.operational_spend).toBe(22000)
+    expect(trend.previous.operational_spend).toBe(22000)
+    expect(trend.month_over_month_delta).toBe(0)
+  })
+
+  it('excludes pending_permission lines from a month\'s operational spend (never shown as spend)', () => {
+    const db = getDb()
+    const win = monthWindow(NOW)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('aws','AWS','aws','usage','HUF',1,@now,@now)`).run({ now: NOW })
+    db.prepare(`
+      INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at)
+      VALUES ('aws', @start, @end, 'usage', 0, 'HUF', 'pending_permission', @now, @now)
+    `).run({ start: win.start, end: win.end, now: NOW })
+    const trend = getPeriodTrend(db, cfg(), NOW, 1)
+    // A month with ONLY a pending_permission row still has a row, so it's not no_data,
+    // but that row must contribute 0 to operational_spend and not appear in provider_breakdown.
+    expect(trend.current.no_data).toBe(false)
+    expect(trend.current.operational_spend).toBe(0)
+    expect(trend.current.provider_breakdown.find(p => p.provider === 'aws')).toBeUndefined()
+  })
+})

--- a/src/__tests__/costops-phase0-baseline-semantics.test.ts
+++ b/src/__tests__/costops-phase0-baseline-semantics.test.ts
@@ -1,0 +1,138 @@
+// CostOps Phase 0 -- baseline semantics regression suite.
+//
+// Locks in the numbered Phase 0 acceptance criteria (core-v1.0.1-gap-analysis.md,
+// "Phase 0 acceptance criteria") end to end, against a single realistic mixed
+// scenario (manual + provider_api + plan estimate + pending_permission + a
+// voided entry + token usage). Exists so a later phase's change that quietly
+// breaks one of these guarantees fails a test immediately, not a live audit.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import { buildSourceInventory } from '../costops/inventory.js'
+import { createManualCost, deleteManualCost } from '../costops/manual-entry.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const cfg: CostOpsConfig = { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] }
+
+function seedMixedScenario(db: import('better-sqlite3').Database) {
+  const win = monthWindow(NOW)
+  // provider_api actual for Render (real, measured)
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-hosting','Render','render','usage','HUF',1,?,?)`).run(NOW, NOW)
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+    VALUES ('render-hosting', @start, @end, 'usage', 10000, 'HUF', 'provider_api', @now, @now, 'render|actual', 'provider_api')
+  `).run({ start: win.start, end: win.end, now: NOW })
+  // Render plan estimate (ADVISORY -- must never enter operational_spend). Distinct
+  // source_id from the actual (matches how the real Render collector shapes it --
+  // see costops-operational.test.ts's render-hosting/render-plan pairing).
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('render-plan','Render (plan)','render','usage','HUF',1,?,?)`).run(NOW, NOW)
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+    VALUES ('render-plan', @start, @end, 'usage', 15000, 'HUF', 'provider_plan_estimate', @now, @now, 'render|plan', 'provider_api')
+  `).run({ start: win.start, end: win.end, now: NOW })
+  // pending_permission (AWS-shaped) -- must never be a fabricated amount
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('aws','AWS','aws','hosting','HUF',1,?,?)`).run(NOW, NOW)
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+    VALUES ('aws', @start, @end, 'usage', 0, 'HUF', 'pending_permission', @now, @now, 'aws|pending', 'pending_permission')
+  `).run({ start: win.start, end: win.end, now: NOW })
+  // token usage volume (opportunity-cost adjacent -- NOT priced into current_spend)
+  db.prepare(`INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens) VALUES ('marveen', 's1', ?, 100000, 50000, 0, 0)`).run(win.start + 100)
+}
+
+describe('CostOps Phase 0 -- baseline semantics locked (acceptance criteria)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('AC10: opportunity cost (token_cost_estimate) never enters operational_spend or current_spend', () => {
+    const db = getDb()
+    seedMixedScenario(db)
+    const s = getCostSummary(db, cfg, NOW)
+    expect(s.token_cost_estimate).toBeDefined()
+    // current_spend / operational_spend derive ONLY from cost_line_items, never
+    // from token_cost_estimate.total_estimated_huf -- proven by the dedicated
+    // estimated_total_with_token_cost field being current_spend PLUS the token
+    // estimate as a separate, additive term (never folded silently into
+    // current_spend itself, which stays whatever the ledger alone says).
+    expect(s.estimated_total_with_token_cost).toBe(round2(s.current_spend + s.token_cost_estimate.total_estimated_huf))
+    expect(s.current_spend).toBe(10000) // unaffected by the 150000 tokens recorded above -- volume, not cost
+    expect(s.operational_spend).toBe(10000) // only the real Render provider_api actual
+  })
+
+  it('AC9: reconciliation delta stays 0 -- operational + manual-fallback partition sums back to the raw total, no double count', () => {
+    const db = getDb()
+    seedMixedScenario(db)
+    const s = getCostSummary(db, cfg, NOW)
+    // Render: provider_api (10000) supersedes its own plan estimate (15000) for
+    // the SAME provider -- the plan estimate must show as the advisory
+    // render_plan block, never summed alongside the actual into operational.
+    expect(s.render_plan).not.toBeNull()
+    expect(s.render_plan!.plan_estimate_total).toBe(15000)
+    // the real invoice (10000) supersedes the plan-estimate proxy (15000) for the
+    // SAME provider -- variance is provider_derived (10000) minus the excluded
+    // plan-estimate fallback (15000), never a double-counted sum of both.
+    expect(s.operational.manual_vs_provider_variance).toBe(-5000)
+    expect(s.operational_spend).toBe(10000)
+  })
+
+  it('AC10/AC-pending: a pending_permission source contributes null spend, never a fabricated amount, never enters operational_spend', () => {
+    const db = getDb()
+    seedMixedScenario(db)
+    const s = getCostSummary(db, cfg, NOW)
+    const aws = s.all_sources.find(x => x.source_id === 'aws')!
+    expect(aws.spend).toBeNull()
+    expect(aws.actual_source).toBe('pending_permission')
+    expect(s.operational_spend).toBe(10000) // AWS's 0 never silently adds to the total
+  })
+
+  it('AC7: no source in the inventory is ever left with an unknown/undefined lifecycle', () => {
+    const db = getDb()
+    seedMixedScenario(db)
+    const inv = buildSourceInventory(db, cfg, NOW)
+    const allowedLifecycles = new Set(['active', 'inactive', 'not_configured', 'unsupported', 'blocked', 'deprecated'])
+    for (const s of inv) expect(allowedLifecycles.has(s.lifecycle)).toBe(true)
+  })
+
+  it('AC3: lifecycle and provenance are reported as two separate fields, never merged into one', () => {
+    const db = getDb()
+    seedMixedScenario(db)
+    const inv = buildSourceInventory(db, cfg, NOW, { credentialChecker: () => true })
+    const render = inv.find(s => s.source_id === 'render-hosting')!
+    expect(render.lifecycle).not.toBe(render.provenance) // distinct value domains, never coincidentally aliased in the type
+    expect(typeof render.lifecycle).toBe('string')
+    expect(typeof render.provenance).toBe('string')
+  })
+
+  it('AC9 (void path): voiding a manual entry keeps reconciliation/operational totals internally consistent -- no orphaned partial state', () => {
+    const db = getDb()
+    seedMixedScenario(db)
+    createManualCost(db, { source_id: 'notion', name: 'Notion', provider: 'notion', amount: 8000, currency: 'HUF', month: '2026-07' }, { fxUsdHuf: 360, now: NOW })
+    const before = getCostSummary(db, cfg, NOW)
+    expect(before.operational_spend).toBe(18000) // 10000 render + 8000 notion manual
+
+    deleteManualCost(db, { source_id: 'notion', month: '2026-07' }, { now: NOW + 10 })
+    const after = getCostSummary(db, cfg, NOW)
+    expect(after.operational_spend).toBe(10000) // back to just render -- voided row cleanly excluded
+    // The Render/AWS/token-usage invariants above are untouched by the void of an unrelated source.
+    expect(after.render_plan!.plan_estimate_total).toBe(15000)
+    expect(after.all_sources.find(x => x.source_id === 'aws')!.spend).toBeNull()
+  })
+
+  it('AC8: the headline CostSummary shape is unchanged by Phase 0 -- every pre-existing field is still present', () => {
+    const db = getDb()
+    seedMixedScenario(db)
+    const s = getCostSummary(db, cfg, NOW)
+    for (const key of [
+      'month', 'currency', 'current_spend', 'forecast_month_end', 'operational_spend',
+      'operational_forecast_month_end', 'operational', 'previous_month', 'month_over_month_delta',
+      'top_sources', 'all_sources', 'confidence_breakdown', 'breakdown', 'budget', 'token_usage',
+      'token_cost_estimate', 'estimated_total_with_token_cost', 'reconcile', 'provider_sync',
+      'render_plan', 'data_freshness', 'config_present', 'config_errors', 'generated_at',
+    ]) {
+      expect(s).toHaveProperty(key)
+    }
+  })
+})
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }

--- a/src/__tests__/costops-pricing.test.ts
+++ b/src/__tests__/costops-pricing.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { deriveProvider, validatePricing, getTokenCostEstimate, type PricingConfig } from '../costops/pricing.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+function emptyConfig(): CostOpsConfig {
+  return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] }
+}
+
+// input 5000/MTok, output 25000/MTok, cache_read 500/MTok, cache_write 6250/MTok
+const PRICING: PricingConfig = {
+  version: 1, currency: 'HUF',
+  models: {
+    'claude-opus-4-8': { input_per_mtok: 5000, output_per_mtok: 25000, cache_read_per_mtok: 500, cache_write_per_mtok: 6250 },
+  },
+}
+
+let tsCounter = 0
+function insertUsage(model: string | null, input: number, output: number, cacheRead = 0, cacheCreate = 0, session = 's1') {
+  const w = monthWindow(NOW)
+  const ts = w.start + (tsCounter++) // unique per insert -> no dedup-index collision
+  getDb().prepare(`INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, model, provider, model_source)
+    VALUES ('marveen', ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    session, ts, input, output, cacheRead, cacheCreate,
+    model, model ? deriveProvider(model) : null, model ? 'transcript' : null,
+  )
+}
+
+describe('costops deriveProvider', () => {
+  it('classifies known model families, else unknown', () => {
+    expect(deriveProvider('claude-opus-4-8')).toBe('anthropic')
+    expect(deriveProvider('deepseek-v4-pro')).toBe('deepseek')
+    expect(deriveProvider('gpt-4o')).toBe('openai')
+    expect(deriveProvider('gemini-2.0')).toBe('google')
+    expect(deriveProvider(null)).toBe('unknown')
+    expect(deriveProvider('some-weird-model')).toBe('unknown')
+  })
+})
+
+describe('costops validatePricing', () => {
+  it('accepts valid rates, drops invalid, defaults cache rates to 0', () => {
+    const r = validatePricing({ currency: 'HUF', models: {
+      'a': { input_per_mtok: 1, output_per_mtok: 2 },
+      'bad': { input_per_mtok: -1, output_per_mtok: 2 },
+      'nope': { output_per_mtok: 2 },
+    } })
+    expect(r.pricing.models['a']).toEqual({ input_per_mtok: 1, output_per_mtok: 2, cache_read_per_mtok: 0, cache_write_per_mtok: 0 })
+    expect(r.pricing.models['bad']).toBeUndefined()
+    expect(r.pricing.models['nope']).toBeUndefined()
+    expect(r.errors.length).toBe(2)
+  })
+})
+
+describe('costops getTokenCostEstimate', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('prices a known model deterministically (golden)', () => {
+    // 1,000,000 input; 500,000 output; 2,000,000 cache_read; 100,000 cache_write
+    insertUsage('claude-opus-4-8', 1_000_000, 500_000, 2_000_000, 100_000)
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), PRICING, true, w.start, w.end)
+    // 5000 + 12500 + 1000 + 625 = 19125
+    expect(e.total_estimated_huf).toBe(19125)
+    expect(e.pricing_profile_status).toBe('loaded')
+    expect(e.priced_by_model[0].model).toBe('claude-opus-4-8')
+    expect(e.priced_by_model[0].provider).toBe('anthropic')
+    expect(e.unpriced.unknown_model_tokens).toBe(0)
+    expect(e.unpriced.no_rate_tokens).toBe(0)
+  })
+
+  it('leaves unknown-model rows UNPRICED (never guessed)', () => {
+    insertUsage(null, 1_000_000, 1_000_000)
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), PRICING, true, w.start, w.end)
+    expect(e.total_estimated_huf).toBe(0)
+    expect(e.unpriced.unknown_model_tokens).toBe(2_000_000)
+  })
+
+  it('leaves model rows with NO matching rate UNPRICED', () => {
+    insertUsage('mystery-model-x', 1_000_000, 0)
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), PRICING, true, w.start, w.end)
+    expect(e.total_estimated_huf).toBe(0)
+    expect(e.unpriced.no_rate_tokens).toBe(1_000_000)
+  })
+
+  it('reports no_pricing_config when there is no pricing', () => {
+    insertUsage('claude-opus-4-8', 1_000_000, 0)
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), { version: 1, currency: 'HUF', models: {} }, false, w.start, w.end)
+    expect(e.total_estimated_huf).toBe(0)
+    expect(e.pricing_profile_status).toBe('no_pricing_config')
+  })
+
+  it('reports partial when some priced and some not', () => {
+    insertUsage('claude-opus-4-8', 1_000_000, 0, 0, 0, 'a')
+    insertUsage(null, 500_000, 0, 0, 0, 'b')
+    const w = monthWindow(NOW)
+    const e = getTokenCostEstimate(getDb(), PRICING, true, w.start, w.end)
+    expect(e.pricing_profile_status).toBe('partial')
+    expect(e.total_estimated_huf).toBe(5000)
+    expect(e.unpriced.unknown_model_tokens).toBe(500_000)
+  })
+})
+
+describe('costops summary includes token_cost_estimate (separate from spend)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('adds token_cost_estimate + estimated_total_with_token_cost without touching current_spend', () => {
+    insertUsage('claude-opus-4-8', 1_000_000, 0) // priced 5000
+    const s = getCostSummary(getDb(), emptyConfig(), NOW, { pricing: PRICING, pricingExists: true })
+    expect(s.current_spend).toBe(0)                       // token cost NOT folded in
+    expect(s.token_cost_estimate.total_estimated_huf).toBe(5000)
+    expect(s.token_cost_estimate.confidence).toBe('estimate')
+    expect(s.estimated_total_with_token_cost).toBe(5000)  // 0 fixed + 5000 token
+  })
+})

--- a/src/__tests__/costops-reconciliation.test.ts
+++ b/src/__tests__/costops-reconciliation.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { buildReconciliation } from '../costops/reconciliation.js'
+import { monthWindow } from '../costops/ledger.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+function insertSource(db: import('better-sqlite3').Database, id: string, provider = 'other') {
+  db.prepare(`INSERT OR IGNORE INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES (?, ?, ?, 'usage', 'HUF', 1, ?, ?)`)
+    .run(id, id, provider, NOW, NOW)
+}
+
+function insertLine(db: import('better-sqlite3').Database, sourceId: string, amount: number, confidence: string, actualSource: string | null, chargeCategory = 'subscription') {
+  const win = monthWindow(NOW)
+  db.prepare(`
+    INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at, dedup_key, actual_source)
+    VALUES (?, ?, ?, ?, ?, 'HUF', ?, ?, ?, ?, ?)
+  `).run(sourceId, win.start, win.end, chargeCategory, amount, confidence, NOW, NOW, `test|${sourceId}|${Math.random()}`, actualSource)
+}
+
+describe('buildReconciliation (CostOps Phase 1, GAP-06)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('a source with no lines this month is no_data, everything null', () => {
+    const db = getDb()
+    insertSource(db, 'idle')
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('no_data')
+    expect(r.expected_amount).toBeNull()
+    expect(r.observed_provider_amount).toBeNull()
+    expect(r.invoice_amount).toBeNull()
+    expect(r.operationally_selected_amount).toBeNull()
+  })
+
+  it('provider API amount matching the invoice amount within tolerance is matched', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertLine(db, 'render-hosting', 10000, 'provider_api', 'provider_api')
+    insertLine(db, 'render-hosting', 10050, 'actual_invoice', 'email_invoice') // 0.5% apart, within 2% tolerance
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.observed_provider_amount).toBe(10000)
+    expect(r.invoice_amount).toBe(10050)
+    expect(r.status).toBe('matched')
+    expect(r.variance_reason).toBe('invoice vs provider API')
+  })
+
+  it('a material mismatch between invoice and provider API is flagged as variance', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertLine(db, 'render-hosting', 10000, 'provider_api', 'provider_api')
+    insertLine(db, 'render-hosting', 12000, 'actual_invoice', 'email_invoice') // 20% apart
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('variance')
+    expect(r.variance).toBe(2000)
+  })
+
+  it('provider API present but no invoice yet -> missing_invoice', () => {
+    const db = getDb()
+    insertSource(db, 'openai-api', 'openai')
+    insertLine(db, 'openai-api', 5000, 'provider_api', 'provider_api')
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('missing_invoice')
+    expect(r.observed_provider_amount).toBe(5000)
+    expect(r.invoice_amount).toBeNull()
+  })
+
+  it('invoice present but no provider API data -> missing_provider_data', () => {
+    const db = getDb()
+    insertSource(db, 'domain')
+    insertLine(db, 'domain', 3000, 'actual_invoice', 'email_invoice')
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('missing_provider_data')
+  })
+
+  it('only manual/estimate data -> estimate_only', () => {
+    const db = getDb()
+    insertSource(db, 'hosting')
+    insertLine(db, 'hosting', 3000, 'manual', 'manual_entry')
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.status).toBe('estimate_only')
+    expect(r.observed_provider_amount).toBeNull()
+    expect(r.invoice_amount).toBeNull()
+    expect(r.operationally_selected_amount).toBe(3000)
+  })
+
+  it('operationally_selected_amount always matches the ledger CONF_PRIORITY resolution', () => {
+    const db = getDb()
+    insertSource(db, 'render-hosting', 'render')
+    insertLine(db, 'render-hosting', 9000, 'manual', 'manual_entry')
+    insertLine(db, 'render-hosting', 10000, 'provider_api', 'provider_api') // higher CONF_PRIORITY wins
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.operationally_selected_amount).toBe(10000)
+  })
+
+  it('expected_amount comes from the latest forecast_snapshots row for that source+month, when one exists', async () => {
+    const db = getDb()
+    insertSource(db, 'domain')
+    insertLine(db, 'domain', 3000, 'manual', 'manual_entry')
+    const { captureForecastSnapshots } = await import('../costops/forecast-capture.js')
+    captureForecastSnapshots(db, NOW)
+    const [r] = buildReconciliation(db, NOW)
+    expect(r.expected_amount).toBe(3000) // fixed_subscription forecast == the mtd amount
+  })
+
+  it('reports per-month when a specific month is requested', () => {
+    const db = getDb()
+    insertSource(db, 'domain')
+    insertLine(db, 'domain', 3000, 'manual', 'manual_entry')
+    const win = monthWindow(NOW)
+    const [r] = buildReconciliation(db, NOW, win.key)
+    expect(r.month).toBe(win.key)
+    const [empty] = buildReconciliation(db, NOW, '2020-01')
+    expect(empty.status).toBe('no_data')
+  })
+})

--- a/src/__tests__/costops-reliability-observation.test.ts
+++ b/src/__tests__/costops-reliability-observation.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { captureReliabilitySnapshot, listReliabilitySnapshots, getLatestReliabilitySnapshot, startCostOpsBackgroundTasks } from '../costops/reliability-observation.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+const DAY = 86400
+const cfg: CostOpsConfig = { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] }
+
+describe('reliability observation window (CostOps Phase 0, P0.4/P0.5)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('captures a snapshot and can read it back verbatim', () => {
+    const db = getDb()
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('domain','Domain','other','domain','HUF',1,?,?)`).run(NOW, NOW)
+    const snap = captureReliabilitySnapshot(db, cfg, NOW)
+    expect(snap.captured_at).toBe(NOW)
+    expect(snap.source_count).toBe(1)
+    expect(snap.inventory[0].source_id).toBe('domain')
+
+    const latest = getLatestReliabilitySnapshot(db)
+    expect(latest).not.toBeNull()
+    expect(latest!.captured_at).toBe(NOW)
+    expect(latest!.inventory).toEqual(snap.inventory)
+  })
+
+  it('returns null from getLatestReliabilitySnapshot when nothing has been captured yet', () => {
+    expect(getLatestReliabilitySnapshot(getDb())).toBeNull()
+  })
+
+  it('accumulates the 7-day observation window as multiple captures, oldest first', () => {
+    const db = getDb()
+    captureReliabilitySnapshot(db, cfg, NOW)
+    captureReliabilitySnapshot(db, cfg, NOW + DAY)
+    captureReliabilitySnapshot(db, cfg, NOW + 2 * DAY)
+    const list = listReliabilitySnapshots(db)
+    expect(list.map(s => s.captured_at)).toEqual([NOW, NOW + DAY, NOW + 2 * DAY])
+  })
+
+  it('the latest snapshot reflects the most recent capture, not the first', () => {
+    const db = getDb()
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('domain','Domain','other','domain','HUF',1,?,?)`).run(NOW, NOW)
+    captureReliabilitySnapshot(db, cfg, NOW)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('hosting','Hosting','other','hosting','HUF',1,?,?)`).run(NOW, NOW)
+    const second = captureReliabilitySnapshot(db, cfg, NOW + DAY)
+    const latest = getLatestReliabilitySnapshot(db)
+    expect(latest!.source_count).toBe(2)
+    expect(latest!.captured_at).toBe(second.captured_at)
+  })
+})
+
+describe('startCostOpsBackgroundTasks (boot seam, docs/fork-upstream-policy.md §2a)', () => {
+  beforeEach(() => { initDatabase(':memory:'); vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('captures a snapshot immediately at boot, then again every 24h, via a single call', () => {
+    const handle = startCostOpsBackgroundTasks()
+    try {
+      expect(listReliabilitySnapshots(getDb())).toHaveLength(1) // immediate boot capture
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000)
+      expect(listReliabilitySnapshots(getDb())).toHaveLength(2) // one interval tick later
+    } finally {
+      clearInterval(handle)
+    }
+  })
+
+  it('the same single call also captures a Phase 1 forecast snapshot (TOTAL row, no sources yet)', async () => {
+    const { listForecastSnapshots } = await import('../costops/forecast-capture.js')
+    const handle = startCostOpsBackgroundTasks()
+    try {
+      const stored = listForecastSnapshots(getDb())
+      expect(stored.length).toBeGreaterThan(0)
+      expect(stored.some(s => s.source_id === null)).toBe(true) // whole-deployment TOTAL row
+    } finally {
+      clearInterval(handle)
+    }
+  })
+
+  it('the same single call also runs the Phase 3 alerts capture without throwing (empty DB, no candidates expected)', async () => {
+    const { listAlerts } = await import('../costops/alerts-store.js')
+    const handle = startCostOpsBackgroundTasks()
+    try {
+      expect(listAlerts(getDb())).toEqual([])
+    } finally {
+      clearInterval(handle)
+    }
+  })
+
+  it('the same single call also runs the Phase 4 optimization recommendation capture without throwing (empty DB, no candidates expected)', async () => {
+    const { listAllRecommendations } = await import('../costops/recommendations-store.js')
+    const handle = startCostOpsBackgroundTasks()
+    try {
+      expect(listAllRecommendations(getDb())).toEqual([])
+    } finally {
+      clearInterval(handle)
+    }
+  })
+})

--- a/src/__tests__/costops-reliability-observation.test.ts
+++ b/src/__tests__/costops-reliability-observation.test.ts
@@ -49,7 +49,7 @@ describe('reliability observation window (CostOps Phase 0, P0.4/P0.5)', () => {
   })
 })
 
-describe('startCostOpsBackgroundTasks (boot seam, docs/fork-upstream-policy.md §2a)', () => {
+describe('startCostOpsBackgroundTasks (the single boot seam web.ts calls)', () => {
   beforeEach(() => { initDatabase(':memory:'); vi.useFakeTimers() })
   afterEach(() => { vi.useRealTimers() })
 

--- a/src/__tests__/costops-render-live-checks.test.ts
+++ b/src/__tests__/costops-render-live-checks.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { checkRenderBuildMinutes } from '../costops/render-live-checks.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 7, 17, 0, 0) / 1000) // 2026-07-07 17:00 UTC
+
+describe('checkRenderBuildMinutes', () => {
+  it('returns nothing when no key is configured (render.ts sync already flags that gap)', async () => {
+    const w = await checkRenderBuildMinutes(NOW, { apiKey: null })
+    expect(w).toEqual([])
+  })
+
+  it('returns nothing when no service has a recent pipeline_minutes_exhausted event', async () => {
+    const httpGetJson = async (url: string) => {
+      if (url.includes('/services?')) return [{ service: { id: 'srv-1', name: 'suite-api' } }]
+      return [] // no events of that type
+    }
+    const w = await checkRenderBuildMinutes(NOW, { apiKey: 'k', httpGetJson })
+    expect(w).toEqual([])
+  })
+
+  it('emits a high-severity quota warning when a service was exhausted within the lookback window', async () => {
+    const recentIso = new Date((NOW - 3600) * 1000).toISOString() // 1h ago
+    const httpGetJson = async (url: string) => {
+      if (url.includes('/services?')) return [{ service: { id: 'srv-1', name: 'suite-api-08wb' } }]
+      return [{ event: { id: 'evt-1', serviceId: 'srv-1', timestamp: recentIso, type: 'pipeline_minutes_exhausted' } }]
+    }
+    const w = await checkRenderBuildMinutes(NOW, { apiKey: 'k', httpGetJson })
+    expect(w).toHaveLength(1)
+    expect(w[0].code).toBe('render_build_minutes_exhausted')
+    expect(w[0].severity).toBe('high')
+    expect(w[0].current_value).toBe(100)
+    expect(w[0].message).toContain('suite-api-08wb')
+  })
+
+  it('ignores a stale exhausted event outside the lookback window (pool likely reset since)', async () => {
+    const staleIso = new Date((NOW - 10 * 24 * 3600) * 1000).toISOString() // 10 days ago
+    const httpGetJson = async (url: string) => {
+      if (url.includes('/services?')) return [{ service: { id: 'srv-1', name: 'suite-api' } }]
+      return [{ event: { id: 'evt-1', serviceId: 'srv-1', timestamp: staleIso, type: 'pipeline_minutes_exhausted' } }]
+    }
+    const w = await checkRenderBuildMinutes(NOW, { apiKey: 'k', httpGetJson })
+    expect(w).toEqual([])
+  })
+
+  it('reports a check-failed warning (not silence) when the services list fetch throws', async () => {
+    const httpGetJson = async () => { throw new Error('network down') }
+    const w = await checkRenderBuildMinutes(NOW, { apiKey: 'k', httpGetJson })
+    expect(w).toHaveLength(1)
+    expect(w[0].code).toBe('render_build_minutes_check_failed')
+    expect(w[0].confidence).toBe('no_api_or_no_access')
+  })
+
+  it("one service's event-query failure doesn't hide a finding from another service", async () => {
+    const recentIso = new Date((NOW - 3600) * 1000).toISOString()
+    const httpGetJson = async (url: string) => {
+      if (url.includes('/services?')) return [{ service: { id: 'srv-bad', name: 'bad' } }, { service: { id: 'srv-good', name: 'good' } }]
+      if (url.includes('srv-bad')) throw new Error('transient')
+      return [{ event: { id: 'evt-1', serviceId: 'srv-good', timestamp: recentIso, type: 'pipeline_minutes_exhausted' } }]
+    }
+    const w = await checkRenderBuildMinutes(NOW, { apiKey: 'k', httpGetJson })
+    expect(w).toHaveLength(1)
+    expect(w[0].message).toContain('good')
+  })
+})

--- a/src/__tests__/costops-render.test.ts
+++ b/src/__tests__/costops-render.test.ts
@@ -10,7 +10,7 @@ import type { HttpGetJson } from '../costops/collectors/types.js'
 const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
 
 const PRICING: RenderPricing = {
-  version: 1, currency: 'HUF', fx_usd_huf: 300,
+  version: 1, currency: 'HUF', fx_usd_huf: 300, fx_eur_huf: 390,
   plans: {
     web_service: { free: 0, starter: 7, standard: 25, pro: 85 },
     static_site: { free: 0 },

--- a/src/__tests__/costops-render.test.ts
+++ b/src/__tests__/costops-render.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { mapRenderPlanCost, makeRenderCollector, type RenderPricing } from '../costops/collectors/render.js'
+import { runCollector } from '../costops/collectors/runner.js'
+import { dryRunCollector } from '../costops/collectors/runner.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+import type { HttpGetJson } from '../costops/collectors/types.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+const PRICING: RenderPricing = {
+  version: 1, currency: 'HUF', fx_usd_huf: 300,
+  plans: {
+    web_service: { free: 0, starter: 7, standard: 25, pro: 85 },
+    static_site: { free: 0 },
+    postgres: { free: 0, basic_1gb: 19 },
+  },
+}
+
+// Offline fixture -- NO live Render API is ever called in tests.
+const RAW = {
+  services: [
+    { service: { id: 'srv-1', type: 'web_service', serviceDetails: { plan: 'starter', numInstances: 1 } } },
+    { service: { id: 'srv-2', type: 'web_service', serviceDetails: { plan: 'standard', numInstances: 2 } } }, // 25*2=50
+    { service: { id: 'srv-3', type: 'static_site', serviceDetails: {} } },                                   // 0, bandwidth flag
+    { service: { id: 'srv-4', type: 'web_service', suspended: 'suspended', serviceDetails: { plan: 'pro' } } }, // 0 suspended
+    { service: { id: 'srv-5', type: 'web_service', serviceDetails: { plan: 'mystery', numInstances: 1 } } },   // unpriced
+  ],
+  postgres: [
+    { postgres: { id: 'pg-1', plan: 'basic_1gb' } }, // 19
+  ],
+}
+
+function opts() { const w = monthWindow(NOW); return { periodStart: w.start, periodEnd: w.end, pricing: PRICING, idSalt: 'salt', now: NOW } }
+
+describe('mapRenderPlanCost (pure, offline)', () => {
+  it('prices by plan, aggregates to one HUF line, flags the rest', () => {
+    const { lines, breakdown } = mapRenderPlanCost(RAW, opts())
+    // total USD = 7 + 50 + 19 = 76 ; HUF = 76 * 300 = 22800
+    expect(breakdown.total_usd).toBe(76)
+    expect(breakdown.total_huf).toBe(22800)
+    expect(lines).toHaveLength(1)
+    expect(lines[0].amount).toBe(22800)
+    expect(lines[0].confidence).toBe('provider_plan_estimate')
+    expect(lines[0].provider).toBe('render')
+    expect(lines[0].service).toBe('render-plan')
+    expect(lines[0].dedup_key).toBe('provider|render|render-plan|2026-07|provider_plan_estimate')
+    // no raw service id in the line
+    expect(JSON.stringify(lines[0])).not.toContain('srv-')
+    expect(JSON.stringify(lines[0])).not.toContain('pg-')
+  })
+  it('handles static/suspended/unknown + records undercount flags', () => {
+    const { breakdown } = mapRenderPlanCost(RAW, opts())
+    expect(breakdown.suspended_count).toBe(1)
+    expect(breakdown.unpriced.some(u => u.plan === 'mystery')).toBe(true)
+    expect(breakdown.by_type_plan['web_service/standard']).toEqual({ count: 2, usd: 50 })
+    expect(breakdown.undercount_flags.some(f => /static_site/.test(f))).toBe(true)
+    expect(breakdown.undercount_flags.some(f => /unpriced/.test(f))).toBe(true)
+  })
+  it('fx=0 -> HUF total 0 + flag (no fabricated amount)', () => {
+    const p = { ...PRICING, fx_usd_huf: 0 }
+    const { lines, breakdown } = mapRenderPlanCost(RAW, { ...opts(), pricing: p })
+    expect(breakdown.total_huf).toBe(0)
+    expect(lines).toHaveLength(0)
+    expect(breakdown.undercount_flags.some(f => /fx_usd_huf/.test(f))).toBe(true)
+  })
+})
+
+describe('render collector via runner (offline)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('dry-run does NOT persist a render-plan line', async () => {
+    const stub: HttpGetJson = async (url) => url.includes('postgres') ? RAW.postgres : RAW.services
+    const col = makeRenderCollector(PRICING)
+    const w = monthWindow(NOW)
+    const rep = await dryRunCollector({ db: getDb(), collector: col, opts: { periodStart: w.start, periodEnd: w.end, secret: 'rnd_SECRET', fxUsdHuf: 0, idSalt: 'salt', httpGetJson: stub }, now: NOW })
+    expect(rep.status).toBe('dry_run')
+    expect(rep.plannedLines[0].amount).toBe(22800)
+    const n = getDb().prepare("SELECT COUNT(*) n FROM cost_line_items").get() as { n: number }
+    expect(n.n).toBe(0)
+  })
+
+  it('import writes a provider_plan_estimate line; idempotent', async () => {
+    const stub: HttpGetJson = async (url) => url.includes('postgres') ? RAW.postgres : RAW.services
+    const col = makeRenderCollector(PRICING)
+    const w = monthWindow(NOW)
+    const o = { periodStart: w.start, periodEnd: w.end, secret: 'rnd_SECRET', fxUsdHuf: 0, idSalt: 'salt', httpGetJson: stub }
+    await runCollector({ db: getDb(), collector: col, opts: o, now: NOW })
+    await runCollector({ db: getDb(), collector: col, opts: o, now: NOW }) // re-run
+    const rows = getDb().prepare("SELECT confidence, billed_cost FROM cost_line_items WHERE source_id='render-plan'").all() as Array<{ confidence: string; billed_cost: number }>
+    expect(rows).toHaveLength(1) // idempotent
+    expect(rows[0].confidence).toBe('provider_plan_estimate')
+    expect(rows[0].billed_cost).toBe(22800)
+    // secret never in import_runs
+    expect(JSON.stringify(getDb().prepare('SELECT * FROM import_runs').all())).not.toContain('rnd_SECRET')
+  })
+})
+
+describe('summary: render plan is advisory (no override of manual)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  function emptyConfig(): CostOpsConfig { return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] } }
+
+  it('render_plan block shows manual vs plan vs variance; current_spend excludes plan estimate', async () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    // seed a MANUAL render-hosting estimate (like the config sync)
+    db.prepare("INSERT INTO cost_sources (id,name,provider,source_type,currency,active,created_at,updated_at) VALUES ('render-hosting','Render hosting','render','hosting','HUF',1,?,?)").run(NOW, NOW)
+    db.prepare("INSERT INTO cost_line_items (source_id,charge_period_start,charge_period_end,charge_category,service_name,billed_cost,currency,confidence,data_freshness,dedup_key,created_at) VALUES ('render-hosting',?,?,'subscription','Render hosting',30000,'HUF','manual',?,'fixed|render-hosting|2026-07',?)").run(w.start, w.end, NOW, NOW)
+    // import the plan-based estimate
+    const stub: HttpGetJson = async (url) => url.includes('postgres') ? RAW.postgres : RAW.services
+    await runCollector({ db, collector: makeRenderCollector(PRICING), opts: { periodStart: w.start, periodEnd: w.end, secret: 'x', fxUsdHuf: 0, idSalt: 'salt', httpGetJson: stub }, now: NOW })
+
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    // headline current_spend = manual 30000 ONLY (plan estimate excluded)
+    expect(s.current_spend).toBe(30000)
+    // render-plan source NOT in all_sources
+    expect(s.all_sources.find(x => x.source_id === 'render-plan')).toBeUndefined()
+    // render_plan advisory block present with variance
+    expect(s.render_plan).not.toBeNull()
+    expect(s.render_plan!.plan_estimate_total).toBe(22800)
+    expect(s.render_plan!.manual_estimate).toBe(30000)
+    expect(s.render_plan!.variance).toBe(-7200) // plan - manual
+    expect(s.render_plan!.not_covered.length).toBeGreaterThan(0)
+  })
+
+  it('render_plan is null when no plan import exists', () => {
+    const s = getCostSummary(getDb(), emptyConfig(), NOW)
+    expect(s.render_plan).toBeNull()
+  })
+})

--- a/src/__tests__/costops-subscriptions.test.ts
+++ b/src/__tests__/costops-subscriptions.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { validateSubscriptionsConfig, deriveLifecycle, type SubscriptionsConfig } from '../costops/subscriptions.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+
+describe('costops subscriptions validation', () => {
+  it('accepts a valid entry and defaults status/amount_source', () => {
+    const r = validateSubscriptionsConfig({ subscriptions: [{ id: 'x', name: 'X', provider: 'anthropic', source: 'anthropic' }] })
+    expect(r.errors).toEqual([])
+    expect(r.config.subscriptions[0].status).toBe('unknown')
+    expect(r.config.subscriptions[0].amount_source).toBe('no_invoice_found')
+  })
+
+  it('drops entries with bad dates, keeps valid ones', () => {
+    const r = validateSubscriptionsConfig({
+      subscriptions: [
+        { id: 'ok', name: 'OK', next_renewal: '2026-07-20' },
+        { id: 'bad', name: 'Bad', next_renewal: 'not-a-date' },
+      ],
+    })
+    expect(r.config.subscriptions).toHaveLength(1)
+    expect(r.config.subscriptions[0].id).toBe('ok')
+    expect(r.errors).toHaveLength(1)
+  })
+
+  it('rejects a negative amount', () => {
+    const r = validateSubscriptionsConfig({ subscriptions: [{ id: 'neg', name: 'Neg', amount: -5 }] })
+    expect(r.config.subscriptions).toHaveLength(0)
+    expect(r.errors[0]).toContain('non-negative')
+  })
+
+  it('never fabricates an amount -- omitted stays omitted', () => {
+    const r = validateSubscriptionsConfig({ subscriptions: [{ id: 'noamt', name: 'No Amount', amount_source: 'no_invoice_found' }] })
+    expect(r.config.subscriptions[0].amount).toBeUndefined()
+  })
+
+  // Card 2ed90db1
+  it('accepts a valid usage_snapshot and keeps the raw weekly_reset_label verbatim (never a computed date)', () => {
+    const r = validateSubscriptionsConfig({
+      subscriptions: [{
+        id: 'max', name: 'Claude Max',
+        usage_snapshot: { as_of: '2026-07-08T21:00:00+02:00', session_pct: 5, weekly_pct: 19, weekly_reset_label: 'Tue 08:59', fable_pct: 0 },
+      }],
+    })
+    expect(r.errors).toEqual([])
+    expect(r.config.subscriptions[0].usage_snapshot).toEqual({
+      as_of: '2026-07-08T21:00:00+02:00', session_pct: 5, weekly_pct: 19, weekly_reset_label: 'Tue 08:59', fable_pct: 0,
+    })
+  })
+
+  it('drops a malformed usage_snapshot without losing the rest of the subscription', () => {
+    const r = validateSubscriptionsConfig({
+      subscriptions: [{ id: 'bad-snap', name: 'Bad Snap', status: 'active', usage_snapshot: { as_of: 'not-a-date', session_pct: 5, weekly_pct: 19, weekly_reset_label: 'Tue 08:59' } }],
+    })
+    expect(r.errors).toEqual([])
+    expect(r.config.subscriptions).toHaveLength(1)
+    expect(r.config.subscriptions[0].status).toBe('active')
+    expect(r.config.subscriptions[0].usage_snapshot).toBeUndefined()
+  })
+
+  it('rejects an out-of-range usage_snapshot percent (e.g. 150%)', () => {
+    const r = validateSubscriptionsConfig({
+      subscriptions: [{ id: 'oor', name: 'Out Of Range', usage_snapshot: { as_of: '2026-07-08T21:00:00+02:00', session_pct: 150, weekly_pct: 19, weekly_reset_label: 'Tue 08:59' } }],
+    })
+    expect(r.config.subscriptions[0].usage_snapshot).toBeUndefined()
+  })
+})
+
+describe('costops subscriptions lifecycle derivation', () => {
+  function cfg(over: Partial<SubscriptionsConfig['subscriptions'][number]>[]): SubscriptionsConfig {
+    return { version: 1, subscriptions: over.map(s => ({ id: 'x', name: 'X', provider: 'p', source: 's', status: 'active', amount_source: 'no_invoice_found', ...s })) }
+  }
+
+  it('canceled subscription counts down to paid_until, not past_due even after (it is expected to end)', () => {
+    const c = cfg([{ id: 'claude-pro', status: 'canceled', paid_until: '2026-07-16' }])
+    const lc = deriveLifecycle(c, NOW)
+    expect(lc[0].days_until_next_date).toBe(1) // 2026-07-15 -> 2026-07-16
+    expect(lc[0].past_due).toBe(false)
+  })
+
+  it('active subscription past its next_renewal date is past_due', () => {
+    const c = cfg([{ id: 'overdue', status: 'active', next_renewal: '2026-07-01' }])
+    const lc = deriveLifecycle(c, NOW)
+    expect(lc[0].days_until_next_date).toBe(-14)
+    expect(lc[0].past_due).toBe(true)
+  })
+
+  it('active subscription with a future next_renewal is not past_due', () => {
+    const c = cfg([{ id: 'anthropic-max', status: 'active', next_renewal: '2026-07-20' }])
+    const lc = deriveLifecycle(c, NOW)
+    expect(lc[0].days_until_next_date).toBe(5)
+    expect(lc[0].past_due).toBe(false)
+  })
+
+  it('no date at all -> days_until_next_date null, never past_due', () => {
+    const c = cfg([{ id: 'chatgpt', status: 'active' }])
+    const lc = deriveLifecycle(c, NOW)
+    expect(lc[0].days_until_next_date).toBeNull()
+    expect(lc[0].past_due).toBe(false)
+  })
+})

--- a/src/__tests__/costops-sync.test.ts
+++ b/src/__tests__/costops-sync.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { syncRenderCollector, type RenderPricing } from '../costops/collectors/render.js'
+import { getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+import type { HttpGetJson } from '../costops/collectors/types.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+function emptyConfig(): CostOpsConfig { return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [] } }
+
+// Offline fixture -- NO live Render API is ever called.
+const SERVICES = [
+  { service: { id: 'srv-1', type: 'web_service', serviceDetails: { plan: 'starter', numInstances: 1 } } },
+  { service: { id: 'srv-2', type: 'static_site', serviceDetails: {} } },
+]
+const POSTGRES = [{ postgres: { id: 'pg-1', plan: 'basic_1gb' } }]
+const stub: HttpGetJson = async (url) => url.includes('postgres') ? POSTGRES : SERVICES
+
+// syncRenderCollector loads pricing from disk; inject via deps.apiKey + httpGetJson,
+// but pricing comes from loadRenderPricing() -- for a deterministic test we rely on
+// the real store pricing if present; assert structurally rather than on an exact HUF.
+
+describe('syncRenderCollector (offline, v0.5 sync spine)', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('imports idempotently, records an ok run with detail_json (no raw IDs)', async () => {
+    const db = getDb()
+    const r1 = await syncRenderCollector(db, NOW, { httpGetJson: stub, apiKey: 'rnd_TESTKEY' })
+    expect(r1.provider).toBe('render')
+    expect(r1.status).toBe('ok')
+    // re-run -> idempotent (same month, one line)
+    await syncRenderCollector(db, NOW, { httpGetJson: stub, apiKey: 'rnd_TESTKEY' })
+    const lines = db.prepare("SELECT COUNT(*) n FROM cost_line_items WHERE source_id='render-plan'").get() as { n: number }
+    expect(lines.n).toBeLessThanOrEqual(1) // 0 if fx=0 in store pricing, else 1 -- never duplicated
+    const runs = db.prepare("SELECT detail_json FROM import_runs WHERE provider='render' AND status='ok' ORDER BY started_at DESC LIMIT 1").get() as { detail_json: string | null } | undefined
+    expect(runs).toBeDefined()
+    if (runs?.detail_json) {
+      const d = JSON.parse(runs.detail_json)
+      expect(typeof d.service_count).toBe('number')
+      expect(runs.detail_json).not.toContain('srv-')  // no raw service IDs
+      expect(runs.detail_json).not.toContain('pg-')
+    }
+    // secret never stored
+    expect(JSON.stringify(db.prepare('SELECT * FROM import_runs').all())).not.toContain('rnd_TESTKEY')
+  })
+
+  it('summary provider_sync exposes v0.5 freshness fields + render_plan.detail', async () => {
+    const db = getDb()
+    await syncRenderCollector(db, NOW, { httpGetJson: stub, apiKey: 'rnd_TESTKEY' })
+    const s = getCostSummary(db, emptyConfig(), NOW)
+    const ps = s.provider_sync.find(p => p.provider === 'render')
+    expect(ps).toBeDefined()
+    if (ps) {
+      expect(['ok', 'stale', 'failed', 'no_data']).toContain(ps.status)
+      expect(ps).toHaveProperty('last_success')
+      expect(ps).toHaveProperty('last_failed')
+      expect(ps).toHaveProperty('data_age_secs')
+      expect(ps.current_period).toBe(monthWindow(NOW).key)
+      expect(ps).toHaveProperty('previous_period_coverage')
+    }
+  })
+
+  it('no api key -> error result, nothing imported', async () => {
+    const db = getDb()
+    const r = await syncRenderCollector(db, NOW, { httpGetJson: stub, apiKey: null })
+    expect(r.ok).toBe(false)
+    expect(r.status).toBe('error')
+    const n = db.prepare('SELECT COUNT(*) n FROM cost_line_items').get() as { n: number }
+    expect(n.n).toBe(0)
+  })
+})

--- a/src/__tests__/costops-warnings.test.ts
+++ b/src/__tests__/costops-warnings.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { syncFixedCostsToLedger, getCostSummary, monthWindow } from '../costops/ledger.js'
+import { getWarnings } from '../costops/warnings.js'
+import { deriveLifecycle, type SubscriptionsConfig } from '../costops/subscriptions.js'
+import type { CostOpsConfig } from '../costops/config.js'
+import type { LimitStatus } from '../costops/limits.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+
+function cfg(over: Partial<CostOpsConfig> = {}): CostOpsConfig {
+  return {
+    version: 1,
+    currency: 'HUF',
+    fixed_costs: [
+      { source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 22000, period: 'monthly', confidence: 'manual', currency: 'HUF' },
+    ],
+    budgets: [{ id: 'global-monthly', name: 'Global', scope: 'global', amount: 20000, warning_threshold: 0.8, hard_threshold: 1.0, currency: 'HUF' }],
+    ...over,
+  }
+}
+
+describe('costops warnings', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('is empty when everything is healthy (no noise)', () => {
+    const db = getDb()
+    const c = cfg({
+      fixed_costs: [
+        { source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 22000, period: 'monthly', confidence: 'provider_api', currency: 'HUF' },
+      ],
+      budgets: [{ id: 'global-monthly', name: 'Global', scope: 'global', amount: 100000, warning_threshold: 0.8, hard_threshold: 1.0, currency: 'HUF' }],
+    })
+    syncFixedCostsToLedger(db, c, NOW)
+    const summary = getCostSummary(db, c, NOW)
+    const warnings = getWarnings(db, c, NOW, summary, [])
+    expect(warnings.filter(w => w.code === 'forecast_over_budget')).toHaveLength(0)
+    expect(warnings.filter(w => w.code === 'high_cost_manual_fallback')).toHaveLength(0)
+  })
+
+  it('forecast_over_budget fires when operational spend crosses the hard threshold', () => {
+    const db = getDb()
+    const c = cfg() // 22000 spend vs 20000 budget -> over hard threshold
+    syncFixedCostsToLedger(db, c, NOW)
+    const summary = getCostSummary(db, c, NOW)
+    const warnings = getWarnings(db, c, NOW, summary, [])
+    const w = warnings.find(x => x.code === 'forecast_over_budget')
+    expect(w).toBeDefined()
+    expect(w!.severity).toBe('high')
+  })
+
+  it('high_cost_manual_fallback fires when a manual-confidence source dominates spend', () => {
+    const db = getDb()
+    const c = cfg({ budgets: [] })
+    syncFixedCostsToLedger(db, c, NOW)
+    const summary = getCostSummary(db, c, NOW)
+    const warnings = getWarnings(db, c, NOW, summary, [])
+    const w = warnings.find(x => x.code === 'high_cost_manual_fallback')
+    expect(w).toBeDefined()
+    expect(w!.provider).toBe('anthropic')
+  })
+
+  it('expected_invoice_missing fires for a past_due active subscription', () => {
+    const db = getDb()
+    const c = cfg({ budgets: [] })
+    syncFixedCostsToLedger(db, c, NOW)
+    const summary = getCostSummary(db, c, NOW)
+    const subsCfg: SubscriptionsConfig = { version: 1, subscriptions: [{ id: 'overdue-sub', name: 'Overdue Sub', provider: 'openai', source: 'openai', status: 'active', next_renewal: '2026-07-01', amount_source: 'no_invoice_found' }] }
+    const subscriptions = deriveLifecycle(subsCfg, NOW)
+    const warnings = getWarnings(db, c, NOW, summary, subscriptions)
+    const w = warnings.find(x => x.code === 'expected_invoice_missing')
+    expect(w).toBeDefined()
+    expect(w!.provider).toBe('openai')
+  })
+
+  it('billing_access_needed fires for a pending_permission source, without fabricating an amount', () => {
+    const db = getDb()
+    const c = cfg({ budgets: [] })
+    syncFixedCostsToLedger(db, c, NOW)
+    const win = monthWindow(NOW)
+    db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at) VALUES ('aws','AWS','aws','usage','HUF',1,@now,@now)`).run({ now: NOW })
+    db.prepare(`
+      INSERT INTO cost_line_items (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, created_at)
+      VALUES ('aws', @start, @end, 'usage', 0, 'HUF', 'pending_permission', @now, @now)
+    `).run({ start: win.start, end: win.end, now: NOW })
+    const summary = getCostSummary(db, c, NOW)
+    // v0.8: pending sources are no longer hidden from all_sources -- they appear with an
+    // honest spend: null (never a fake 0), confidence/actual_source both 'pending_permission'.
+    const awsRow = summary.all_sources.find(s => s.source_id === 'aws')
+    expect(awsRow).toBeDefined()
+    expect(awsRow!.spend).toBeNull()
+    expect(awsRow!.confidence).toBe('pending_permission')
+    const warnings = getWarnings(db, c, NOW, summary, [])
+    const w = warnings.find(x => x.code === 'billing_access_needed')
+    expect(w).toBeDefined()
+    expect(w!.provider).toBe('aws')
+    expect(w!.message).not.toMatch(/\d+\s*(HUF|Ft)/) // no fabricated amount in the message
+  })
+
+  it('is deterministic -- same inputs, same output, twice in a row', () => {
+    const db = getDb()
+    const c = cfg()
+    syncFixedCostsToLedger(db, c, NOW)
+    const summary = getCostSummary(db, c, NOW)
+    const w1 = getWarnings(db, c, NOW, summary, [])
+    const w2 = getWarnings(db, c, NOW, summary, [])
+    expect(w1).toEqual(w2)
+  })
+
+  it('Render spend-limit and Claude Max weekly limit always surface as no_api_or_no_access (never fabricated)', () => {
+    const db = getDb()
+    const c = cfg({ budgets: [] })
+    syncFixedCostsToLedger(db, c, NOW)
+    const summary = getCostSummary(db, c, NOW)
+    const warnings = getWarnings(db, c, NOW, summary, [])
+    const render = warnings.find(w => w.code === 'render_spend_limit_unknown')
+    const claude = warnings.find(w => w.code === 'claude_max_weekly_limit_unknown')
+    expect(render?.confidence).toBe('no_api_or_no_access')
+    expect(render?.severity).toBe('low')
+    expect(claude?.confidence).toBe('no_api_or_no_access')
+  })
+
+  it('DeepSeek balance: no snapshots yet -> no_api_or_no_access, not a fabricated 0%', () => {
+    const db = getDb()
+    const c = cfg({ budgets: [] })
+    syncFixedCostsToLedger(db, c, NOW)
+    const summary = getCostSummary(db, c, NOW)
+    const w = getWarnings(db, c, NOW, summary, []).find(x => x.code === 'deepseek_balance_unknown')
+    expect(w).toBeDefined()
+    expect(w!.confidence).toBe('no_api_or_no_access')
+  })
+
+  it('DeepSeek balance: low balance vs peak fires the generic tiered limit_usage_high rule (v0.8 -- escalation moved off deepseek_balance_low onto limits.ts + rule 11)', () => {
+    const db = getDb()
+    const c = cfg({ budgets: [] })
+    syncFixedCostsToLedger(db, c, NOW)
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',100,@t1)`).run({ t1: NOW - 3 * 86400 })
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',4,@t2)`).run({ t2: NOW })
+    const summary = getCostSummary(db, c, NOW)
+    // usage_pct = fraction CONSUMED = 1 - 4/100 = 0.96, matching limits.ts's fromDeepSeekBalance shape.
+    const limits: LimitStatus[] = [{
+      provider: 'deepseek', limit_type: 'balance', current_usage: 4, limit_value: 100,
+      usage_pct: 0.96, reset_date: null, paid_until: null, expiry_date: null,
+      status: 'critical', source: 'ledger', sub_id: null, unit: 'USD',
+    }]
+    const warnings = getWarnings(db, c, NOW, summary, [], limits)
+    expect(warnings.find(x => x.code === 'deepseek_balance_low')).toBeUndefined() // rule retired
+    const w = warnings.find(x => x.code === 'limit_usage_high' && x.provider === 'deepseek')
+    expect(w).toBeDefined()
+    expect(w!.severity).toBe('critical') // 96% consumed >= 90% tier
+    expect(w!.current_value).toBe(96)
+  })
+
+  it('DeepSeek balance: near-peak (healthy) balance -- no "low" warning, but the raw balance is still always visible (spec 65da75e6 A1)', () => {
+    const db = getDb()
+    const c = cfg({ budgets: [] })
+    syncFixedCostsToLedger(db, c, NOW)
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',100,@t1)`).run({ t1: NOW - 3 * 86400 })
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',90,@t2)`).run({ t2: NOW })
+    const summary = getCostSummary(db, c, NOW)
+    const warnings = getWarnings(db, c, NOW, summary, [])
+    expect(warnings.find(x => x.code === 'deepseek_balance_low')).toBeUndefined()
+    const info = warnings.find(x => x.code === 'deepseek_balance_info')
+    expect(info).toBeDefined()
+    expect(info!.severity).toBe('low')
+    expect(info!.current_value).toBe(90)
+    expect(info!.unit).toBe('USD')
+  })
+
+  it('DeepSeek balance: only one snapshot ever (no observed drop) -- raw balance shown, confidence manual (not fabricated %)', () => {
+    const db = getDb()
+    const c = cfg({ budgets: [] })
+    syncFixedCostsToLedger(db, c, NOW)
+    db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',50,@t1)`).run({ t1: NOW })
+    const summary = getCostSummary(db, c, NOW)
+    const info = getWarnings(db, c, NOW, summary, []).find(x => x.code === 'deepseek_balance_info')
+    expect(info).toBeDefined()
+    expect(info!.confidence).toBe('manual')
+    expect(info!.current_value).toBe(50)
+  })
+})

--- a/src/__tests__/costops-workspace-alerts.test.ts
+++ b/src/__tests__/costops-workspace-alerts.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { ingestWorkspaceAlerts, getActiveWorkspaceAlerts, buildWorkspaceAlertWarnings } from '../costops/workspace-alerts.js'
+
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000) // 2026-07-15
+
+describe('workspace alerts ingest', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('ingests a valid entry and is idempotent per message_ref', () => {
+    const db = getDb()
+    const entry = { account: 'google-private', issue_type: 'payment_failure' as const, detected_at: NOW, message_ref: 'msg-1' }
+    expect(ingestWorkspaceAlerts(db, [entry], NOW).ingested).toBe(1)
+    ingestWorkspaceAlerts(db, [entry], NOW)
+    const rows = db.prepare('SELECT COUNT(*) as n FROM workspace_alerts').get() as { n: number }
+    expect(rows.n).toBe(1)
+  })
+
+  it('rejects an invalid issue_type without throwing', () => {
+    const db = getDb()
+    const result = ingestWorkspaceAlerts(db, [{ account: 'google-zst', issue_type: 'bogus' as never, detected_at: NOW, message_ref: 'msg-2' }], NOW)
+    expect(result.ingested).toBe(0)
+    expect(result.errors).toHaveLength(1)
+  })
+
+  it('never stores the raw message_ref -- only a hash', () => {
+    const db = getDb()
+    ingestWorkspaceAlerts(db, [{ account: 'google-private', issue_type: 'suspended', detected_at: NOW, message_ref: 'super-secret-gmail-id-12345' }], NOW)
+    const row = db.prepare('SELECT message_ref FROM workspace_alerts').get() as { message_ref: string }
+    expect(row.message_ref).not.toContain('super-secret-gmail-id')
+    expect(row.message_ref).toHaveLength(32)
+  })
+
+  it('getActiveWorkspaceAlerts excludes stale (>30d) signals', () => {
+    const db = getDb()
+    ingestWorkspaceAlerts(db, [
+      { account: 'google-private', issue_type: 'payment_failure', detected_at: NOW - 5 * 86400, message_ref: 'recent' },
+      { account: 'google-zst', issue_type: 'payment_failure', detected_at: NOW - 60 * 86400, message_ref: 'stale' },
+    ], NOW)
+    const active = getActiveWorkspaceAlerts(db, NOW)
+    expect(active).toHaveLength(1)
+    expect(active[0].account).toBe('google-private')
+  })
+
+  it('buildWorkspaceAlertWarnings emits one warning per (account, issue_type), most recent only, never fabricated', () => {
+    const db = getDb()
+    ingestWorkspaceAlerts(db, [
+      { account: 'google-private', issue_type: 'payment_failure', detected_at: NOW - 10 * 86400, message_ref: 'old' },
+      { account: 'google-private', issue_type: 'payment_failure', detected_at: NOW - 1 * 86400, message_ref: 'new' },
+    ], NOW)
+    const warnings = buildWorkspaceAlertWarnings(db, NOW)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].code).toBe('workspace_payment_failure')
+    expect(warnings[0].warning_type).toBe('access')
+    expect(warnings[0].category).toBe('productivity')
+    expect((warnings[0].detail as { detected_at: number }).detected_at).toBe(NOW - 1 * 86400)
+  })
+
+  it('emits nothing when there is no signal at all (no noise)', () => {
+    const db = getDb()
+    expect(buildWorkspaceAlertWarnings(db, NOW)).toEqual([])
+  })
+
+  it('suspended is severity high, payment_failure is medium', () => {
+    const db = getDb()
+    ingestWorkspaceAlerts(db, [
+      { account: 'google-zst', issue_type: 'suspended', detected_at: NOW, message_ref: 'a' },
+      { account: 'google-private', issue_type: 'payment_failure', detected_at: NOW, message_ref: 'b' },
+    ], NOW)
+    const warnings = buildWorkspaceAlertWarnings(db, NOW)
+    expect(warnings.find(w => w.code === 'workspace_suspended')!.severity).toBe('high')
+    expect(warnings.find(w => w.code === 'workspace_payment_failure')!.severity).toBe('medium')
+  })
+
+  // --- Gap-fill (card 65da75e6): suspension-date lifecycle -------------------------------
+
+  it('a real suspension_date supersedes the flat flag with a due_date + days-remaining warning', () => {
+    const db = getDb()
+    ingestWorkspaceAlerts(db, [
+      { account: 'google-zst', issue_type: 'payment_failure', detected_at: NOW, suspension_date: NOW + 10 * 86400, message_ref: 'c' },
+    ], NOW)
+    const warnings = buildWorkspaceAlertWarnings(db, NOW)
+    expect(warnings).toHaveLength(1) // no redundant flat workspace_payment_failure entry too
+    const w = warnings[0]
+    expect(w.code).toBe('workspace_payment_failure_scheduled')
+    expect(w.warning_type).toBe('expiry')
+    expect(w.due_date).toBe(new Date((NOW + 10 * 86400) * 1000).toISOString().slice(0, 10))
+    expect(w.current_value).toBe(10)
+  })
+
+  it('severity rises as the suspension date approaches (30/14/7-day ladder)', () => {
+    const db = getDb()
+    ingestWorkspaceAlerts(db, [{ account: 'a1', issue_type: 'payment_failure', detected_at: NOW, suspension_date: NOW + 20 * 86400, message_ref: 'd20' }], NOW)
+    ingestWorkspaceAlerts(db, [{ account: 'a2', issue_type: 'payment_failure', detected_at: NOW, suspension_date: NOW + 10 * 86400, message_ref: 'd10' }], NOW)
+    ingestWorkspaceAlerts(db, [{ account: 'a3', issue_type: 'payment_failure', detected_at: NOW, suspension_date: NOW + 3 * 86400, message_ref: 'd3' }], NOW)
+    const warnings = buildWorkspaceAlertWarnings(db, NOW)
+    expect(warnings.find(w => (w.detail as { account: string }).account === 'a1')!.severity).toBe('low')
+    expect(warnings.find(w => (w.detail as { account: string }).account === 'a2')!.severity).toBe('medium')
+    expect(warnings.find(w => (w.detail as { account: string }).account === 'a3')!.severity).toBe('high')
+  })
+
+  it('a suspension date far in the future (>30d) is still visible (not silent), just low severity', () => {
+    const db = getDb()
+    ingestWorkspaceAlerts(db, [{ account: 'google-zst', issue_type: 'payment_failure', detected_at: NOW, suspension_date: NOW + 90 * 86400, message_ref: 'far' }], NOW)
+    const w = buildWorkspaceAlertWarnings(db, NOW)[0]
+    expect(w.code).toBe('workspace_payment_failure_scheduled')
+    expect(w.severity).toBe('low')
+  })
+
+  it('a suspension date already in the past (no re-detection since) is treated as overdue, not dropped', () => {
+    const db = getDb()
+    ingestWorkspaceAlerts(db, [{ account: 'google-zst', issue_type: 'payment_failure', detected_at: NOW, suspension_date: NOW - 5 * 86400, message_ref: 'overdue' }], NOW)
+    const w = buildWorkspaceAlertWarnings(db, NOW)[0]
+    expect(w.code).toBe('workspace_payment_failure_overdue')
+    expect(w.severity).toBe('high')
+  })
+
+  it('rejects an invalid suspension_date type without throwing', () => {
+    const db = getDb()
+    const result = ingestWorkspaceAlerts(db, [{ account: 'google-zst', issue_type: 'payment_failure', detected_at: NOW, suspension_date: 'not-a-number' as unknown as number, message_ref: 'bad' }], NOW)
+    expect(result.ingested).toBe(0)
+    expect(result.errors).toHaveLength(1)
+  })
+
+  it('no suspension_date -- falls back to the existing flat flag exactly as before (regression check)', () => {
+    const db = getDb()
+    ingestWorkspaceAlerts(db, [{ account: 'google-zst', issue_type: 'suspended', detected_at: NOW, message_ref: 'flat' }], NOW)
+    const w = buildWorkspaceAlertWarnings(db, NOW)[0]
+    expect(w.code).toBe('workspace_suspended')
+    expect(w.due_date).toBeUndefined()
+  })
+})

--- a/src/costops/README.md
+++ b/src/costops/README.md
@@ -129,6 +129,23 @@ manual/estimate rows, and with a strict secrets-in-Vault-only posture.
 **Vault**: real Admin keys go into `src/web/vault.ts` via the secure handover, never
 into config/log/transcript/dashboard-response.
 
+## v0.3 -- Render plan-based infra collector (`provider_plan_estimate`, advisory)
+
+`src/costops/collectors/render.ts` reads Render services (+ `/v1/postgres`) READ-ONLY
+and maps each service's PLAN to a monthly HUF estimate via a local plan->price map
+(`store/costops-render-pricing.json`, gitignored; safe 0-rate example tracked at
+`render-pricing.example.json`). Key points:
+- **`provider_plan_estimate` confidence** -- NOT an invoice, NOT provider_api actual.
+  It is **excluded from the headline `current_spend`** and never overrides the manual
+  `render-hosting` estimate. It surfaces only in the summary `render_plan` block:
+  `plan_estimate_total`, `manual_estimate`, `variance`, `not_covered[]`.
+- **Aggregated** to one `render-plan` line/month (idempotent dedup_key). Raw service/
+  account IDs are NEVER stored/returned -- only a `raw_ref_hash` + type/plan labels.
+  `static_site`/`suspended` = 0; unknown plan -> unpriced warning (never fabricated).
+- **Lower bound**: bandwidth/storage overage, seats, tax, credits, one-off charges are
+  structurally invisible -> listed in `render_plan.not_covered`. Design:
+  `audits/costops-v0.3-render-plan-collector-plan.md`.
+
 ## Known limitations
 
 - Provider API calls only happen when Vault keys are configured and a live run is

--- a/src/costops/README.md
+++ b/src/costops/README.md
@@ -116,6 +116,16 @@ manual/estimate rows, and with a strict secrets-in-Vault-only posture.
   double counting. New `reconcile[]` (per-source estimate vs actual vs variance) and
   `provider_sync[]` (last run per provider: status, freshness, stale/failed marker).
 
+- **Dry-run mode** (`dryRunCollector` in `runner.ts`): a safety layer that runs
+  fetch + normalize EXACTLY like a real import but persists **no** `provider_api`
+  cost line. It returns the planned normalized lines, their `dedup_key`s, a
+  `wouldImportCount`, and a **sanitized response shape** (`describeShape` -- types,
+  object keys and array lengths ONLY, never a scalar value, so no secret / account
+  id / invoice ref / raw datum can travel in it). Its only optional write is a
+  `status='dry_run'`, `imported_count=0` audit row in `import_runs` (no cost, no
+  secret, no raw); pass `recordRun:false` to persist nothing at all. This is the
+  gate before any real import: preview the shape and the planned lines first.
+
 **Vault**: real Admin keys go into `src/web/vault.ts` via the secure handover, never
 into config/log/transcript/dashboard-response.
 

--- a/src/costops/README.md
+++ b/src/costops/README.md
@@ -59,3 +59,73 @@ No client writes, no LLM, no provider API, no secrets in any response.
   is ever derived from tokens here.
 - Additive schema (`CREATE TABLE IF NOT EXISTS`); with no CostOps config the rest
   of the app behaves exactly as before.
+- No autonomous action of any kind. `warning_threshold` / `hard_threshold` are
+  **display-only** -- never stop an agent, switch a model, change a spend cap,
+  top-up, or modify a subscription.
+- No LLM anywhere in CostOps (summary is pure SQL + arithmetic). Future periodic
+  collectors must run as `type: "command"` scheduled tasks (raw shell, no LLM),
+  never as an LLM heartbeat.
+- No raw account IDs / invoice refs / secrets in DB, logs, audit or API response.
+  Use `hashRef(salt, raw)` for identifiers if ever needed.
+
+## v0.2 -- token-cost ESTIMATE (deterministic, no LLM/provider API)
+
+v0.2 adds a **separate, estimate-only** token cost derived from `token_usage`.
+It is never folded into `current_spend` and is clearly labelled as an estimate.
+
+**Model enrichment (forward-only).** `token_usage` now has nullable `model`,
+`provider`, `model_source` columns. The ingestion (`src/web/token-usage.ts`)
+captures `message.model` from the transcript for NEW rows (`model_source =
+'transcript'`) and derives a coarse `provider` (`deriveProvider`). Existing rows
+stay `NULL` (unknown) -- no uncertain backfill. **The model-capture activates on
+the next dashboard restart**; rows ingested before that stay unknown.
+
+**Pricing config (local, gitignored).** Per-model rates live in
+`store/costops-pricing.json` (gitignored; a safe 0-rate `.example` is generated).
+Rates are **per 1,000,000 tokens** in `currency`. No provider prices are hardcoded
+in tracked source.
+
+**Summary block.** `GET /api/costs/summary` gains `token_cost_estimate`
+(`total_estimated_huf`, `priced_by_model[]`, `unpriced.{unknown_model_tokens,
+no_rate_tokens}`, `pricing_profile_status`, `confidence: "estimate"`) and
+`estimated_total_with_token_cost` (= `current_spend` + token estimate, clearly
+labelled -- not added to `current_spend`).
+
+**Provider billing/usage API collector is v0.3** (still no external API in v0.2).
+
+## v0.3 -- provider cost collector framework
+
+v0.3 adds a generic, deterministic framework to import ACTUAL provider cost as
+high-confidence `provider_api` line items -- **without** overwriting the local
+manual/estimate rows, and with a strict secrets-in-Vault-only posture.
+
+- **Framework** (`src/costops/collectors/`): `ProviderCollector` interface with an
+  INJECTED HTTP fetcher (so collectors are unit-tested fully offline with fixtures
+  -- no live call unless a real fetcher is passed after explicit approval).
+- **`runner.ts`**: loads a collector's normalized lines, idempotently upserts them
+  into `cost_line_items` as `confidence='provider_api'`, and records an `import_runs`
+  row. On error it DELETES NOTHING and records a **sanitized** failure (keys redacted).
+- **`import_runs` table**: run history / sync status. No raw account id, no raw API
+  response, no secret ever stored.
+- **Config**: gitignored `store/costops-collectors.json` holds only non-secret
+  wiring -- an `enabled` flag and a `secret_ref` (validated to REQUIRE the `vault:`
+  form, never a raw key). A tracked safe example lives at
+  `src/costops/collectors/collectors-config.example.json` (no key, no account id).
+- **Summary reconcile**: the headline `current_spend` resolves each source to its
+  single highest-confidence line so an actual supersedes an estimate WITHOUT
+  double counting. New `reconcile[]` (per-source estimate vs actual vs variance) and
+  `provider_sync[]` (last run per provider: status, freshness, stale/failed marker).
+
+**Vault**: real Admin keys go into `src/web/vault.ts` via the secure handover, never
+into config/log/transcript/dashboard-response.
+
+## Known limitations
+
+- Provider API calls only happen when Vault keys are configured and a live run is
+  explicitly approved. Until then `provider_sync`/`reconcile` stay empty.
+- Forward-only enrichment: token costs only appear for rows ingested AFTER
+  the dashboard restart that activates model-capture.
+- Forecast is a naive linear proration of usage-type lines; fixed monthly costs
+  are attributed whole-month (no proration).
+- No provider billing integration yet (see the maturity model in
+  `audits/costops-v0.1-pr1-local-ledger-plan.md`).

--- a/src/costops/alerts-capture.ts
+++ b/src/costops/alerts-capture.ts
@@ -1,0 +1,458 @@
+// CostOps -- alerts capture (GAP-12 orchestration layer).
+//
+// alerts.ts (Anvil, Phase 3) is pure computation only -- no DB reads, no
+// knowledge of ledger.ts/forecast.ts/reconciliation.ts/inventory.ts shapes.
+// This module is the thin orchestration on top: adapt each already-live
+// module's real data into the 13 detectors' narrow SIGNAL interfaces, run
+// them, reconcile the result against what's already stored in
+// `costops_alerts` via reconcileAlerts(), and persist it.
+//
+// NOT done here (seam-owner is Mason, same as forecast-capture.ts): the
+// GET /api/costs/alerts route and the boot-time capture cadence
+// (startCostOpsBackgroundTasks). This file only exports the orchestration +
+// persistence functions those call.
+//
+// Signal sources actually available today (verified against the live
+// codebase, 2026-07-15):
+// - budget/forecast_budget_breach: getCostSummary().budget + the latest
+//   whole-deployment forecast_snapshots row (source_id NULL).
+// - balance_exhaustion: entitlements (entitlement_type='prepaid_balance') --
+//   reuses the exhaustion date collectors/deepseek.ts already computed and
+//   stored, rather than recomputing it a second time from
+//   provider_balance_snapshots.
+// - stale_collector/failed_sync/credential_permission_error: import_runs,
+//   same "latest run per provider" query ledger.ts's own (private)
+//   provider_sync block uses -- small enough to duplicate locally rather
+//   than export a helper from a file this feature doesn't own touching
+//   right now.
+// - reconciliation_mismatch: reconciliation.ts's buildReconciliation().
+// - manual_provider_variance: getCostSummary().operational -- WHOLE-
+//   DEPLOYMENT only; OperationalResult has no per-provider manual-vs-
+//   provider-derived split today, so this is one coarser signal, not
+//   fabricated per-provider noise.
+// - unusual_spend_growth: period.ts's getPeriodTrend() (global + per
+//   provider, current vs previous month).
+// - new_unknown_source / long_estimate_only_source: derived directly from
+//   cost_line_items history per source (earliest activity date / last N
+//   billing periods' resolved confidence).
+// - subscription_utilization: subscriptions.ts + limits.ts's
+//   fromSubscriptions() (weekly_usage_pct and similar already-normalized
+//   percentages).
+// - missing_invoice: invoice.ts's costops_invoices (GAP-14, landed) --
+//   inferExpectedInvoiceBy() projects the next expected invoice date from a
+//   source's OWN observed invoice-period history (median gap + grace days),
+//   never a fabricated "always monthly" assumption. A source with fewer
+//   than 2 recorded invoices has no inferable cadence and is honestly
+//   skipped (see the function below), not guessed at.
+
+import type Database from 'better-sqlite3'
+import type { CostOpsConfig } from './config.js'
+import { monthWindow, CONF_PRIORITY, getCostSummary, type CostSummary } from './ledger.js'
+import { getPeriodTrend } from './period.js'
+import { buildReconciliation } from './reconciliation.js'
+import { loadSubscriptionsConfig, deriveLifecycle } from './subscriptions.js'
+import { fromSubscriptions } from './limits.js'
+import { getAllBudgetStatuses } from './budgets.js'
+import { inferExpectedInvoiceBy } from './invoice.js'
+import {
+  detectBudgetThresholdAlert,
+  detectForecastBudgetBreachAlert,
+  detectBalanceExhaustionAlert,
+  detectStaleCollectorAlert,
+  detectFailedSyncAlert,
+  detectCredentialPermissionAlert,
+  detectReconciliationMismatchAlert,
+  detectManualProviderVarianceAlert,
+  detectMissingInvoiceAlert,
+  detectUnusualSpendGrowthAlert,
+  detectNewUnknownSourceAlert,
+  detectLongEstimateOnlySourceAlert,
+  detectSubscriptionUtilizationAlert,
+  reconcileAlerts,
+  serializeEvidence,
+  deserializeEvidence,
+  type AlertCandidate,
+  type AlertRecord,
+  type AlertType,
+  type AlertSeverity,
+  type SyncSignal,
+} from './alerts.js'
+
+// ---- thresholds -- reused from the codebase's own existing conventions, not invented ----
+
+// mirrors reconciliation.ts's own (private) VARIANCE_TOLERANCE_FRACTION -- a
+// row already flagged 'variance' upstream reliably clears this too.
+const RECONCILIATION_VARIANCE_THRESHOLD = 0.02
+// mirrors warnings.ts's MATERIAL_FRACTION
+const MANUAL_PROVIDER_VARIANCE_THRESHOLD = 0.15
+// mirrors warnings.ts's LARGE_INCREASE_FRACTION
+const SPEND_GROWTH_THRESHOLD = 0.5
+// mirrors ledger.ts's own (private) provider_sync STALE_SECS
+const SYNC_STALE_SECS = 3 * 24 * 3600
+// flagged placeholders (same convention as inventory.ts's freshness thresholds) -- tune once
+// real utilisation data accumulates. Over mirrors limits.ts's own tierForPct critical=0.9.
+const UTILIZATION_UNDER_THRESHOLD = 0.1
+const UTILIZATION_OVER_THRESHOLD = 0.9
+// a source needs this many CONSECUTIVE billing periods, all resolving to an estimate-tier
+// confidence, before "long estimate-only" is claimed -- never fabricated from less history.
+const ESTIMATE_ONLY_LOOKBACK_PERIODS = 3
+const ESTIMATE_ONLY_CONF = new Set(['manual', 'estimate', 'local_usage'])
+
+// ---- signal gathering ------------------------------------------------------------------
+
+/**
+ * Phase 3 (GAP-11): every configured budget (global/provider/category/source),
+ * not just the legacy single global one -- getAllBudgetStatuses() already
+ * resolves each scope's real spend/forecast against the same CostSummary, so
+ * this just runs the two budget detectors per budget instead of once.
+ * dedup_key is keyed by budget_id (alerts.ts), so distinct budgets never
+ * collide even when several breach in the same capture pass.
+ */
+function gatherBudgetCandidates(db: Database.Database, config: CostOpsConfig, now: number): AlertCandidate[] {
+  const out: AlertCandidate[] = []
+  const win = monthWindow(now)
+  const latestTotalForecastRow = db.prepare(`
+    SELECT forecast_amount FROM forecast_snapshots WHERE source_id IS NULL AND month = ? ORDER BY snapshot_at DESC LIMIT 1
+  `).get(win.key) as { forecast_amount: number } | undefined
+
+  const statuses = getAllBudgetStatuses(db, config, now)
+  for (const b of statuses) {
+    const scopeLabel = b.scope_ref ? `${b.scope}:${b.scope_ref}` : b.scope
+    const threshold = detectBudgetThresholdAlert({
+      budget_id: b.id, scope: scopeLabel,
+      used_pct: b.used_pct, warning_threshold: b.warning_threshold, hard_threshold: b.hard_threshold,
+    })
+    if (threshold) out.push(threshold)
+
+    // Prefer the Phase-1 forecast module's captured TOTAL snapshot (more accurate than the
+    // naive per-scope forecast) for the global budget only -- provider/category/source scopes
+    // have no per-scope forecast snapshot yet, so they use resolveBudgetStatus's own
+    // forecast_pct (summed forecast_month_end across that scope's sources), never fabricated.
+    const forecastPct = (b.scope === 'global' && latestTotalForecastRow != null && b.amount > 0)
+      ? latestTotalForecastRow.forecast_amount / b.amount
+      : b.forecast_pct
+    const breach = detectForecastBudgetBreachAlert({
+      budget_id: b.id, scope: scopeLabel,
+      used_pct: b.used_pct, forecast_pct: forecastPct,
+      warning_threshold: b.warning_threshold, hard_threshold: b.hard_threshold,
+    })
+    if (breach) out.push(breach)
+  }
+  return out
+}
+
+interface EntitlementRow { provider: string; remaining: number | null; forecast_exhaustion_at: number | null; included_unit: string | null }
+
+function gatherBalanceExhaustionCandidates(db: Database.Database, now: number): AlertCandidate[] {
+  const rows = db.prepare(`
+    SELECT provider, remaining, forecast_exhaustion_at, included_unit
+    FROM entitlements WHERE entitlement_type = 'prepaid_balance'
+  `).all() as EntitlementRow[]
+  const out: AlertCandidate[] = []
+  for (const r of rows) {
+    if (r.remaining == null) continue
+    const c = detectBalanceExhaustionAlert(
+      { provider: r.provider, remaining: r.remaining, currency: r.included_unit ?? 'USD', forecast_exhaustion_at: r.forecast_exhaustion_at },
+      now,
+    )
+    if (c) out.push(c)
+  }
+  return out
+}
+
+const CREDENTIAL_ERROR_MARKER = /credential|api[_-]?key|unauthorized|401/i
+const PERMISSION_ERROR_MARKER = /permission|forbidden|403|access/i
+
+/**
+ * Real collector error_code values today are raw (HTTP-status-ish, Node error
+ * names, or ad-hoc strings like deepseek.ts's 'balance_error') -- not the
+ * clean 'credential_error'/'permission_error' vocabulary alerts.ts's
+ * detectors expect. This adapts messy reality into that vocabulary; a code
+ * that matches neither pattern stays unclassified (null), never guessed.
+ */
+export function classifyErrorCode(raw: string | null): 'credential_error' | 'permission_error' | null {
+  if (!raw) return null
+  if (CREDENTIAL_ERROR_MARKER.test(raw)) return 'credential_error'
+  if (PERMISSION_ERROR_MARKER.test(raw)) return 'permission_error'
+  return null
+}
+
+interface RunRow { provider: string; status: string; started_at: number; error_code: string | null }
+
+function gatherSyncAndCredentialCandidates(db: Database.Database, now: number): AlertCandidate[] {
+  const latestRows = db.prepare(`
+    SELECT provider, status, started_at, error_code
+    FROM import_runs r
+    WHERE started_at = (SELECT MAX(started_at) FROM import_runs WHERE provider = r.provider)
+    GROUP BY provider
+  `).all() as RunRow[]
+  const lastOkStmt = db.prepare(`SELECT MAX(started_at) t FROM import_runs WHERE provider = ? AND status = 'ok'`)
+  const out: AlertCandidate[] = []
+  for (const r of latestRows) {
+    const lastOk = (lastOkStmt.get(r.provider) as { t: number | null }).t ?? null
+    const age = now - r.started_at
+    const stale = r.status === 'ok' && age > SYNC_STALE_SECS
+    const classified = classifyErrorCode(r.error_code)
+    const status: SyncSignal['status'] = r.status !== 'ok' ? 'failed' : (stale ? 'stale' : 'ok')
+    const signal: SyncSignal = { provider: r.provider, status, last_success: lastOk, data_age_secs: age, error_code: classified ?? r.error_code }
+
+    const staleAlert = detectStaleCollectorAlert(signal)
+    if (staleAlert) out.push(staleAlert)
+    const failedAlert = detectFailedSyncAlert(signal)
+    if (failedAlert) out.push(failedAlert)
+    // credential_permission_error is a DISTINCT alert type from failed_sync (both can fire
+    // together from the same underlying event) -- provider used as source_id surrogate since
+    // this codebase's credentials are provider-scoped, not per-source.
+    if (status === 'failed' && classified) {
+      out.push(detectCredentialPermissionAlert({ source_id: r.provider, provider: r.provider, issue: classified }))
+    }
+  }
+  return out
+}
+
+function gatherReconciliationCandidates(db: Database.Database, now: number): AlertCandidate[] {
+  const rows = buildReconciliation(db, now)
+  const out: AlertCandidate[] = []
+  for (const row of rows) {
+    if (row.status !== 'variance') continue
+    const actual = row.invoice_amount ?? row.operationally_selected_amount
+    const estimate = row.observed_provider_amount ?? row.expected_amount
+    if (actual == null || estimate == null || row.variance == null) continue
+    const c = detectReconciliationMismatchAlert({ source_id: row.source_id, estimate, actual, variance: row.variance, variance_threshold_pct: RECONCILIATION_VARIANCE_THRESHOLD })
+    if (c) out.push(c)
+  }
+  return out
+}
+
+function gatherManualProviderVarianceCandidates(summary: CostSummary): AlertCandidate[] {
+  const providerDerived = summary.operational.provider_derived_spend
+  if (providerDerived === 0) return []
+  const c = detectManualProviderVarianceAlert({
+    provider: 'global',
+    manual_spend: summary.operational.manual_spend,
+    provider_derived_spend: providerDerived,
+    variance_threshold_pct: MANUAL_PROVIDER_VARIANCE_THRESHOLD,
+  })
+  return c ? [c] : []
+}
+
+function gatherUnusualSpendGrowthCandidates(db: Database.Database, config: CostOpsConfig, now: number): AlertCandidate[] {
+  const trend = getPeriodTrend(db, config, now, 2)
+  if (trend.current.no_data || trend.previous.no_data) return []
+  const out: AlertCandidate[] = []
+  const total = detectUnusualSpendGrowthAlert({
+    key: 'global', current_amount: trend.current.operational_spend,
+    baseline_amount: trend.previous.operational_spend, growth_threshold_pct: SPEND_GROWTH_THRESHOLD,
+  })
+  if (total) out.push(total)
+  const prevByProvider = new Map(trend.previous.provider_breakdown.map(p => [p.provider, p.spend]))
+  for (const cur of trend.current.provider_breakdown) {
+    const baseline = prevByProvider.get(cur.provider)
+    if (baseline == null) continue
+    const c = detectUnusualSpendGrowthAlert({ key: cur.provider, current_amount: cur.spend, baseline_amount: baseline, growth_threshold_pct: SPEND_GROWTH_THRESHOLD })
+    if (c) out.push(c)
+  }
+  return out
+}
+
+function gatherNewSourceAndEstimateOnlyCandidates(db: Database.Database, now: number): AlertCandidate[] {
+  const out: AlertCandidate[] = []
+  const win = monthWindow(now)
+  const sources = db.prepare(`SELECT id FROM cost_sources WHERE active = 1`).all() as Array<{ id: string }>
+
+  for (const s of sources) {
+    const earliest = db.prepare(`SELECT MIN(charge_period_start) as t FROM cost_line_items WHERE source_id = ? AND voided_at IS NULL`).get(s.id) as { t: number | null }
+    if (earliest.t != null) {
+      const isFirst = earliest.t >= win.start && earliest.t < win.end
+      const c = detectNewUnknownSourceAlert({ source_id: s.id, first_seen_month: win.key, is_first_appearance: isFirst })
+      if (c) out.push(c)
+    }
+
+    const periodRows = db.prepare(`
+      SELECT DISTINCT charge_period_start FROM cost_line_items
+      WHERE source_id = ? AND voided_at IS NULL ORDER BY charge_period_start DESC LIMIT ?
+    `).all(s.id, ESTIMATE_ONLY_LOOKBACK_PERIODS) as Array<{ charge_period_start: number }>
+    if (periodRows.length < ESTIMATE_ONLY_LOOKBACK_PERIODS) continue // not enough history to claim "long" -- never fabricated
+
+    let allEstimateOnly = true
+    for (const p of periodRows) {
+      const lines = db.prepare(`SELECT confidence FROM cost_line_items WHERE source_id = ? AND charge_period_start = ? AND voided_at IS NULL`).all(s.id, p.charge_period_start) as Array<{ confidence: string }>
+      const resolved = lines.reduce((best, l) => (CONF_PRIORITY[l.confidence] || 0) > (CONF_PRIORITY[best] || 0) ? l.confidence : best, lines[0]?.confidence ?? 'manual')
+      if (!ESTIMATE_ONLY_CONF.has(resolved)) { allEstimateOnly = false; break }
+    }
+    if (allEstimateOnly) {
+      const c = detectLongEstimateOnlySourceAlert({ source_id: s.id, consecutive_estimate_only_months: periodRows.length, threshold_months: ESTIMATE_ONLY_LOOKBACK_PERIODS })
+      if (c) out.push(c)
+    }
+  }
+  return out
+}
+
+function gatherUtilizationCandidates(now: number): AlertCandidate[] {
+  const { config } = loadSubscriptionsConfig()
+  const subs = deriveLifecycle(config, now)
+  const limitStatuses = fromSubscriptions(subs)
+  const out: AlertCandidate[] = []
+  for (const ls of limitStatuses) {
+    if (ls.usage_pct == null || ls.sub_id == null) continue
+    const c = detectSubscriptionUtilizationAlert({ subscription_id: ls.sub_id, usage_pct: ls.usage_pct, under_threshold_pct: UTILIZATION_UNDER_THRESHOLD, over_threshold_pct: UTILIZATION_OVER_THRESHOLD })
+    if (c) out.push(c)
+  }
+  return out
+}
+
+/**
+ * Per active source: infer the next expected invoice date from that
+ * source's OWN recorded invoice history (invoice.ts's costops_invoices),
+ * then check whether it's overdue. A source with fewer than 2 recorded
+ * invoices has no inferable cadence -- honestly skipped, not guessed. Since
+ * this queries the FULL history fresh each capture round, a newly-arrived
+ * invoice becomes part of the history and naturally pushes the inferred
+ * expected-by date forward -- no separate "received" flag needed (see
+ * invoice.ts's inferExpectedInvoiceBy doc comment for why).
+ */
+function gatherMissingInvoiceCandidates(db: Database.Database, now: number): AlertCandidate[] {
+  const out: AlertCandidate[] = []
+  const sources = db.prepare(`SELECT DISTINCT source_id FROM costops_invoices`).all() as Array<{ source_id: string }>
+  for (const s of sources) {
+    const rows = db.prepare(`
+      SELECT billing_period_end FROM costops_invoices
+      WHERE source_id = ? AND status != 'voided' ORDER BY billing_period_end ASC
+    `).all(s.source_id) as Array<{ billing_period_end: number }>
+    const expectedBy = inferExpectedInvoiceBy(rows.map(r => r.billing_period_end))
+    if (expectedBy == null) continue
+    const c = detectMissingInvoiceAlert({ source_id: s.source_id, expected_by: expectedBy, received: false }, now)
+    if (c) out.push(c)
+  }
+  return out
+}
+
+/**
+ * Gather every alert candidate this round, from every live signal source
+ * currently available in the codebase. Pure DB READS only (no writes) --
+ * `captureAlerts` below is the only function that persists anything.
+ */
+export function gatherAlertCandidates(db: Database.Database, config: CostOpsConfig, now: number): AlertCandidate[] {
+  const summary = getCostSummary(db, config, now)
+
+  return [
+    ...gatherBudgetCandidates(db, config, now),
+    ...gatherBalanceExhaustionCandidates(db, now),
+    ...gatherSyncAndCredentialCandidates(db, now),
+    ...gatherReconciliationCandidates(db, now),
+    ...gatherManualProviderVarianceCandidates(summary),
+    ...gatherUnusualSpendGrowthCandidates(db, config, now),
+    ...gatherNewSourceAndEstimateOnlyCandidates(db, now),
+    ...gatherUtilizationCandidates(now),
+    ...gatherMissingInvoiceCandidates(db, now),
+  ]
+}
+
+// ---- persistence (costops_alerts) --------------------------------------------------------
+
+interface AlertRow {
+  dedup_key: string
+  type: string
+  severity: string
+  evidence_json: string
+  first_seen: number
+  last_seen: number
+  acknowledged_at: number | null
+  acknowledged_by: string | null
+  resolved_at: number | null
+  recurrence_count: number
+  owner: string | null
+  cooldown_until: number | null
+}
+
+function rowToRecord(r: AlertRow): AlertRecord {
+  return {
+    dedup_key: r.dedup_key, type: r.type as AlertType, severity: r.severity as AlertSeverity,
+    evidence: deserializeEvidence(r.evidence_json),
+    first_seen: r.first_seen, last_seen: r.last_seen,
+    acknowledged_at: r.acknowledged_at, acknowledged_by: r.acknowledged_by,
+    resolved_at: r.resolved_at, recurrence_count: r.recurrence_count,
+    owner: r.owner, cooldown_until: r.cooldown_until,
+  }
+}
+
+function loadExistingAlerts(db: Database.Database): AlertRecord[] {
+  const rows = db.prepare(`SELECT * FROM costops_alerts`).all() as AlertRow[]
+  return rows.map(rowToRecord)
+}
+
+export interface AlertCaptureSummary {
+  candidates: number
+  inserted: number
+  touched: number
+  resolved: number
+}
+
+/**
+ * Gather this round's candidates, reconcile against `costops_alerts`, and
+ * persist the result (insert new rows, touch active/reopened ones, resolve
+ * ones whose condition disappeared). Requires `initAlertsSchema` to have
+ * already run (Mason's seam call) -- not invoked here (this file is
+ * capture-orchestration, not schema setup).
+ */
+export function captureAlerts(db: Database.Database, config: CostOpsConfig, now: number, opts: { cooldownSeconds?: number } = {}): AlertCaptureSummary {
+  const existing = loadExistingAlerts(db)
+  const candidates = gatherAlertCandidates(db, config, now)
+  const result = reconcileAlerts(existing, candidates, now, opts.cooldownSeconds)
+
+  const insertStmt = db.prepare(`
+    INSERT INTO costops_alerts (type, severity, evidence_json, dedup_key, first_seen, last_seen, acknowledged_at, acknowledged_by, resolved_at, recurrence_count, owner, cooldown_until, created_at)
+    VALUES (@type, @severity, @evidence_json, @dedup_key, @first_seen, @last_seen, NULL, NULL, NULL, 0, NULL, @cooldown_until, @now)
+  `)
+  for (const a of result.toInsert) {
+    insertStmt.run({ type: a.type, severity: a.severity, evidence_json: serializeEvidence(a.evidence), dedup_key: a.dedup_key, first_seen: a.first_seen, last_seen: a.last_seen, cooldown_until: a.cooldown_until, now })
+  }
+
+  const touchStmt = db.prepare(`
+    UPDATE costops_alerts SET last_seen=@last_seen, severity=@severity, evidence_json=@evidence_json, resolved_at=@resolved_at, recurrence_count=@recurrence_count, cooldown_until=@cooldown_until
+    WHERE dedup_key=@dedup_key
+  `)
+  for (const t of result.toTouch) {
+    touchStmt.run({
+      dedup_key: t.dedup_key, last_seen: t.patch.last_seen, severity: t.patch.severity,
+      evidence_json: serializeEvidence(t.patch.evidence), resolved_at: t.patch.resolved_at,
+      recurrence_count: t.patch.recurrence_count, cooldown_until: t.patch.cooldown_until,
+    })
+  }
+
+  const resolveStmt = db.prepare(`UPDATE costops_alerts SET resolved_at=@resolved_at WHERE dedup_key=@dedup_key`)
+  for (const r of result.toResolve) {
+    resolveStmt.run({ dedup_key: r.dedup_key, resolved_at: r.resolved_at })
+  }
+
+  return { candidates: candidates.length, inserted: result.toInsert.length, touched: result.toTouch.length, resolved: result.toResolve.length }
+}
+
+export interface AlertListRow {
+  dedup_key: string
+  type: string
+  severity: string
+  evidence: Record<string, unknown>
+  first_seen: number
+  last_seen: number
+  acknowledged_at: number | null
+  acknowledged_by: string | null
+  resolved_at: number | null
+  recurrence_count: number
+  owner: string | null
+}
+
+/** Read back stored alerts, most recent first. Unresolved-only by default (the GET route's likely default view). */
+export function listAlerts(db: Database.Database, opts: { includeResolved?: boolean; limit?: number } = {}): AlertListRow[] {
+  const limit = opts.limit ?? 200
+  const rows = (
+    opts.includeResolved
+      ? db.prepare(`SELECT * FROM costops_alerts ORDER BY last_seen DESC LIMIT ?`).all(limit)
+      : db.prepare(`SELECT * FROM costops_alerts WHERE resolved_at IS NULL ORDER BY last_seen DESC LIMIT ?`).all(limit)
+  ) as AlertRow[]
+  return rows.map(r => ({
+    dedup_key: r.dedup_key, type: r.type, severity: r.severity, evidence: deserializeEvidence(r.evidence_json),
+    first_seen: r.first_seen, last_seen: r.last_seen, acknowledged_at: r.acknowledged_at, acknowledged_by: r.acknowledged_by,
+    resolved_at: r.resolved_at, recurrence_count: r.recurrence_count, owner: r.owner,
+  }))
+}

--- a/src/costops/alerts-store.ts
+++ b/src/costops/alerts-store.ts
@@ -1,0 +1,130 @@
+// CostOps Phase 3 (GAP-12) -- persistence for Anvil's alerts.ts lifecycle
+// core. alerts.ts is pure computation (detectors + reconcileAlerts); this is
+// the thin DB layer that applies an AlertReconcileResult and serves reads/
+// acknowledgement. The actual SIGNAL-GATHERING orchestration (running all 13
+// detectors against real ledger/forecast/fx/sync data each round) is a
+// separate, larger piece -- deferred to alerts-capture.ts (Anvil, per
+// alert dispatch) so this module can land now and alerts-capture.ts
+// slots in later without touching this file's contract.
+
+import type Database from 'better-sqlite3'
+import { serializeEvidence, deserializeEvidence, type AlertRecord, type AlertReconcileResult, reconcileAlerts, type AlertCandidate } from './alerts.js'
+
+interface AlertRow {
+  dedup_key: string
+  type: string
+  severity: string
+  evidence_json: string
+  first_seen: number
+  last_seen: number
+  acknowledged_at: number | null
+  acknowledged_by: string | null
+  resolved_at: number | null
+  recurrence_count: number
+  owner: string | null
+  cooldown_until: number | null
+}
+
+function rowToRecord(row: AlertRow): AlertRecord {
+  return {
+    dedup_key: row.dedup_key, type: row.type as AlertRecord['type'], severity: row.severity as AlertRecord['severity'],
+    evidence: deserializeEvidence(row.evidence_json), first_seen: row.first_seen, last_seen: row.last_seen,
+    acknowledged_at: row.acknowledged_at, acknowledged_by: row.acknowledged_by, resolved_at: row.resolved_at,
+    recurrence_count: row.recurrence_count, owner: row.owner, cooldown_until: row.cooldown_until,
+  }
+}
+
+/** All alerts currently stored (any state), for feeding into reconcileAlerts as `existing`. */
+export function listAllAlerts(db: Database.Database): AlertRecord[] {
+  return (db.prepare(`SELECT * FROM costops_alerts`).all() as AlertRow[]).map(rowToRecord)
+}
+
+export interface ListAlertsOptions {
+  status?: 'active' | 'resolved' | 'all'
+  type?: string
+}
+
+/** Alerts for API/dashboard consumption -- defaults to active (unresolved) only. */
+export function listAlerts(db: Database.Database, opts: ListAlertsOptions = {}): AlertRecord[] {
+  const status = opts.status ?? 'active'
+  const conditions: string[] = []
+  const params: unknown[] = []
+  if (status === 'active') conditions.push('resolved_at IS NULL')
+  if (status === 'resolved') conditions.push('resolved_at IS NOT NULL')
+  if (opts.type) { conditions.push('type = ?'); params.push(opts.type) }
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''
+  const rows = db.prepare(`SELECT * FROM costops_alerts ${where} ORDER BY last_seen DESC`).all(...params) as AlertRow[]
+  return rows.map(rowToRecord)
+}
+
+/**
+ * Apply an AlertReconcileResult (insert/touch/resolve) to the DB in one
+ * transaction. Pure DB write, no detection logic -- the caller already ran
+ * reconcileAlerts() against listAllAlerts()'s current state.
+ */
+export function applyAlertReconciliation(db: Database.Database, result: AlertReconcileResult, now: number): void {
+  const insertStmt = db.prepare(`
+    INSERT INTO costops_alerts
+      (type, severity, evidence_json, dedup_key, first_seen, last_seen, acknowledged_at, acknowledged_by,
+       resolved_at, recurrence_count, owner, cooldown_until, created_at)
+    VALUES (@type, @severity, @evidence_json, @dedup_key, @first_seen, @last_seen, NULL, NULL,
+       NULL, @recurrence_count, NULL, @cooldown_until, @now)
+  `)
+  const touchStmt = db.prepare(`
+    UPDATE costops_alerts SET last_seen = @last_seen, severity = @severity, evidence_json = @evidence_json,
+      resolved_at = @resolved_at, recurrence_count = @recurrence_count, cooldown_until = @cooldown_until
+    WHERE dedup_key = @dedup_key
+  `)
+  const resolveStmt = db.prepare(`UPDATE costops_alerts SET resolved_at = @resolved_at WHERE dedup_key = @dedup_key`)
+
+  const tx = db.transaction(() => {
+    for (const r of result.toInsert) {
+      insertStmt.run({
+        type: r.type, severity: r.severity, evidence_json: serializeEvidence(r.evidence), dedup_key: r.dedup_key,
+        first_seen: r.first_seen, last_seen: r.last_seen, recurrence_count: r.recurrence_count,
+        cooldown_until: r.cooldown_until, now,
+      })
+    }
+    for (const t of result.toTouch) {
+      touchStmt.run({
+        dedup_key: t.dedup_key, last_seen: t.patch.last_seen, severity: t.patch.severity,
+        evidence_json: serializeEvidence(t.patch.evidence), resolved_at: t.patch.resolved_at,
+        recurrence_count: t.patch.recurrence_count, cooldown_until: t.patch.cooldown_until,
+      })
+    }
+    for (const r of result.toResolve) {
+      resolveStmt.run({ dedup_key: r.dedup_key, resolved_at: r.resolved_at })
+    }
+  })
+  tx()
+}
+
+/** Convenience: detect candidates elsewhere, then reconcile+persist in one call. */
+export function reconcileAndPersist(db: Database.Database, candidates: AlertCandidate[], now: number, cooldownSeconds?: number): AlertReconcileResult {
+  const existing = listAllAlerts(db)
+  const result = reconcileAlerts(existing, candidates, now, cooldownSeconds)
+  applyAlertReconciliation(db, result, now)
+  return result
+}
+
+export interface AcknowledgeResult {
+  ok: boolean
+  error?: string
+  status?: number
+}
+
+/** Operator acknowledges an active alert (never clears resolution/recurrence). */
+export function acknowledgeAlertByKey(db: Database.Database, dedupKey: string, actor: string, now: number): AcknowledgeResult {
+  const existing = db.prepare(`SELECT dedup_key FROM costops_alerts WHERE dedup_key = ?`).get(dedupKey)
+  if (!existing) return { ok: false, error: `no alert with dedup_key '${dedupKey}'`, status: 404 }
+  db.prepare(`UPDATE costops_alerts SET acknowledged_at = ?, acknowledged_by = ? WHERE dedup_key = ?`).run(now, actor, dedupKey)
+  return { ok: true }
+}
+
+/** Manual/explicit early resolve (an operator dismissing before the underlying condition clears itself). */
+export function resolveAlertByKey(db: Database.Database, dedupKey: string, now: number): AcknowledgeResult {
+  const existing = db.prepare(`SELECT dedup_key FROM costops_alerts WHERE dedup_key = ?`).get(dedupKey)
+  if (!existing) return { ok: false, error: `no alert with dedup_key '${dedupKey}'`, status: 404 }
+  db.prepare(`UPDATE costops_alerts SET resolved_at = ? WHERE dedup_key = ?`).run(now, dedupKey)
+  return { ok: true }
+}

--- a/src/costops/alerts.ts
+++ b/src/costops/alerts.ts
@@ -1,0 +1,381 @@
+// CostOps -- Phase 3 alerts lifecycle (GAP-12 / core-functional-scope-v1.0.1.md §12).
+//
+// Pure, deterministic (NEVER LLM-based) alert engine. Two layers:
+// 1. DETECTORS -- one pure function per alert type, each taking a narrow
+//    SIGNAL interface (never a concrete module type like CostSummary/
+//    OperationalResult) so this file stays independent of ledger.ts/
+//    forecast.ts/fx.ts/collectors -- the aggregator adapts real data into
+//    these signals.
+// 2. LIFECYCLE -- `reconcileAlerts` turns "candidates detected this round"
+//    + "what's already stored" into insert/touch/resolve instructions:
+//    dedup (never a duplicate row for an already-active problem), cooldown
+//    (a resolved alert recurring immediately after resolution is reopened
+//    quietly, not counted as a fresh noisy recurrence), acknowledgement,
+//    and resolution.
+//
+// NO db.ts/web.ts/schema.ts edits: `initAlertsSchema` is a schema DEFINER
+// only, not mounted anywhere -- the seam-refactor's `initCostOpsSchema(db)`
+// aggregator (Mason, accounting-core seam, src/costops/schema.ts) calls it,
+// per docs/fork-upstream-policy.md §2a. Same pattern as forecast.ts/fx.ts.
+//
+// GAP-12 acceptance reminder baked into every detector below: "stale adat
+// onmagaban nem okoz erős vagy hibás üzleti allitast" -- a stale/failed sync
+// alert is capped at 'warning', never 'critical', and detectors that need a
+// COMPARISON (variance, growth) refuse to fire without a real baseline
+// (never comparing against a fabricated 0).
+
+import type Database from 'better-sqlite3'
+
+// ---- alert types (the §12 list, 13 types) ----------------------------------------
+
+export type AlertType =
+  | 'budget_threshold'
+  | 'forecast_budget_breach'
+  | 'balance_exhaustion'
+  | 'stale_collector'
+  | 'failed_sync'
+  | 'credential_permission_error'
+  | 'missing_invoice'
+  | 'reconciliation_mismatch'
+  | 'manual_provider_variance'
+  | 'unusual_spend_growth'
+  | 'new_unknown_source'
+  | 'long_estimate_only_source'
+  | 'subscription_utilization'
+
+export type AlertSeverity = 'info' | 'warning' | 'critical'
+
+// ---- lifecycle record shapes ------------------------------------------------------
+
+export interface AlertCandidate {
+  type: AlertType
+  severity: AlertSeverity
+  evidence: Record<string, unknown>
+  dedup_key: string
+}
+
+export interface AlertRecord {
+  dedup_key: string
+  type: AlertType
+  severity: AlertSeverity
+  evidence: Record<string, unknown>
+  first_seen: number
+  last_seen: number
+  acknowledged_at: number | null
+  acknowledged_by: string | null
+  resolved_at: number | null
+  recurrence_count: number
+  owner: string | null
+  cooldown_until: number | null
+}
+
+// ---- detectors --------------------------------------------------------------------
+// Each returns null when the signal does not warrant an alert -- never a
+// fabricated low-severity alert just to have "something."
+
+export interface BudgetSignal {
+  budget_id: string
+  scope: string           // caller's label: 'global' | a provider id | a category id
+  used_pct: number
+  warning_threshold: number
+  hard_threshold: number
+}
+
+export function detectBudgetThresholdAlert(s: BudgetSignal): AlertCandidate | null {
+  if (s.used_pct >= s.hard_threshold) {
+    return { type: 'budget_threshold', severity: 'critical', dedup_key: `budget_threshold|${s.budget_id}`, evidence: { budget_id: s.budget_id, scope: s.scope, used_pct: s.used_pct, threshold: s.hard_threshold, level: 'hard' } }
+  }
+  if (s.used_pct >= s.warning_threshold) {
+    return { type: 'budget_threshold', severity: 'warning', dedup_key: `budget_threshold|${s.budget_id}`, evidence: { budget_id: s.budget_id, scope: s.scope, used_pct: s.used_pct, threshold: s.warning_threshold, level: 'warning' } }
+  }
+  return null
+}
+
+export interface ForecastBudgetSignal extends BudgetSignal {
+  forecast_pct: number
+}
+
+/**
+ * Distinct from `detectBudgetThresholdAlert`: fires when the FORECAST crosses
+ * the hard threshold even though CURRENT spend has not yet -- an early
+ * warning before the breach actually happens. Once used_pct itself crosses
+ * hard, the plain budget_threshold alert takes over (no double-alerting).
+ */
+export function detectForecastBudgetBreachAlert(s: ForecastBudgetSignal): AlertCandidate | null {
+  if (s.forecast_pct >= s.hard_threshold && s.used_pct < s.hard_threshold) {
+    return { type: 'forecast_budget_breach', severity: 'warning', dedup_key: `forecast_budget_breach|${s.budget_id}`, evidence: { budget_id: s.budget_id, scope: s.scope, forecast_pct: s.forecast_pct, used_pct: s.used_pct, threshold: s.hard_threshold } }
+  }
+  return null
+}
+
+export interface BalanceSignal {
+  provider: string
+  remaining: number
+  currency: string
+  forecast_exhaustion_at: number | null
+  warning_days_ahead?: number  // default 7
+}
+
+export function detectBalanceExhaustionAlert(s: BalanceSignal, now: number): AlertCandidate | null {
+  if (s.forecast_exhaustion_at == null) return null
+  const daysAhead = (s.forecast_exhaustion_at - now) / 86400
+  const warnDays = s.warning_days_ahead ?? 7
+  if (daysAhead <= 0) {
+    return { type: 'balance_exhaustion', severity: 'critical', dedup_key: `balance_exhaustion|${s.provider}`, evidence: { provider: s.provider, remaining: s.remaining, currency: s.currency, forecast_exhaustion_at: s.forecast_exhaustion_at, days_ahead: daysAhead } }
+  }
+  if (daysAhead <= warnDays) {
+    return { type: 'balance_exhaustion', severity: 'warning', dedup_key: `balance_exhaustion|${s.provider}`, evidence: { provider: s.provider, remaining: s.remaining, currency: s.currency, forecast_exhaustion_at: s.forecast_exhaustion_at, days_ahead: daysAhead } }
+  }
+  return null
+}
+
+export interface SyncSignal {
+  provider: string
+  status: 'ok' | 'stale' | 'failed'
+  last_success: number | null
+  data_age_secs: number | null
+  error_code: string | null
+}
+
+/** Stale data is capped at 'warning' -- never 'critical' (GAP-12 acceptance: stale data alone must not produce a strong/incorrect business claim). */
+export function detectStaleCollectorAlert(s: SyncSignal): AlertCandidate | null {
+  if (s.status !== 'stale') return null
+  return { type: 'stale_collector', severity: 'warning', dedup_key: `stale_collector|${s.provider}`, evidence: { provider: s.provider, data_age_secs: s.data_age_secs, last_success: s.last_success } }
+}
+
+export function detectFailedSyncAlert(s: SyncSignal): AlertCandidate | null {
+  if (s.status !== 'failed') return null
+  const isCredentialIssue = s.error_code === 'credential_error' || s.error_code === 'permission_error'
+  return { type: 'failed_sync', severity: isCredentialIssue ? 'critical' : 'warning', dedup_key: `failed_sync|${s.provider}`, evidence: { provider: s.provider, error_code: s.error_code, last_success: s.last_success } }
+}
+
+export interface CredentialSignal {
+  source_id: string
+  provider: string
+  issue: 'credential_error' | 'permission_error'
+}
+
+/** Caller already knows this is a real credential/permission problem (no null case -- unlike the other detectors, there's no "maybe" here). */
+export function detectCredentialPermissionAlert(s: CredentialSignal): AlertCandidate {
+  return { type: 'credential_permission_error', severity: 'critical', dedup_key: `credential_permission_error|${s.source_id}`, evidence: { source_id: s.source_id, provider: s.provider, issue: s.issue } }
+}
+
+export interface InvoiceExpectationSignal {
+  source_id: string
+  expected_by: number
+  received: boolean
+}
+
+export function detectMissingInvoiceAlert(s: InvoiceExpectationSignal, now: number): AlertCandidate | null {
+  if (s.received || now < s.expected_by) return null
+  return { type: 'missing_invoice', severity: 'warning', dedup_key: `missing_invoice|${s.source_id}`, evidence: { source_id: s.source_id, expected_by: s.expected_by, overdue_days: Math.floor((now - s.expected_by) / 86400) } }
+}
+
+export interface ReconciliationSignal {
+  source_id: string
+  estimate: number
+  actual: number
+  variance: number
+  variance_threshold_pct: number
+}
+
+/** Refuses to fire against a fabricated baseline: actual === 0 means there's nothing real to compare against, so no alert (never a divide-by-zero-flavored false positive). */
+export function detectReconciliationMismatchAlert(s: ReconciliationSignal): AlertCandidate | null {
+  if (s.actual === 0) return null
+  const pct = Math.abs(s.variance) / Math.abs(s.actual)
+  if (pct < s.variance_threshold_pct) return null
+  return { type: 'reconciliation_mismatch', severity: pct >= s.variance_threshold_pct * 2 ? 'critical' : 'warning', dedup_key: `reconciliation_mismatch|${s.source_id}`, evidence: { source_id: s.source_id, estimate: s.estimate, actual: s.actual, variance: s.variance, variance_pct: pct } }
+}
+
+export interface ManualProviderVarianceSignal {
+  provider: string
+  manual_spend: number
+  provider_derived_spend: number
+  variance_threshold_pct: number
+}
+
+export function detectManualProviderVarianceAlert(s: ManualProviderVarianceSignal): AlertCandidate | null {
+  if (s.provider_derived_spend === 0) return null
+  const variance = s.provider_derived_spend - s.manual_spend
+  const pct = Math.abs(variance) / Math.abs(s.provider_derived_spend)
+  if (pct < s.variance_threshold_pct) return null
+  return { type: 'manual_provider_variance', severity: 'warning', dedup_key: `manual_provider_variance|${s.provider}`, evidence: { provider: s.provider, manual_spend: s.manual_spend, provider_derived_spend: s.provider_derived_spend, variance, variance_pct: pct } }
+}
+
+export interface SpendGrowthSignal {
+  key: string              // caller's label: provider, category, or source id
+  current_amount: number
+  baseline_amount: number
+  growth_threshold_pct: number
+}
+
+/** No baseline (<= 0) means growth cannot be measured -- never fabricated as "infinite growth." */
+export function detectUnusualSpendGrowthAlert(s: SpendGrowthSignal): AlertCandidate | null {
+  if (s.baseline_amount <= 0) return null
+  const growthPct = (s.current_amount - s.baseline_amount) / s.baseline_amount
+  if (growthPct < s.growth_threshold_pct) return null
+  return { type: 'unusual_spend_growth', severity: growthPct >= s.growth_threshold_pct * 2 ? 'critical' : 'warning', dedup_key: `unusual_spend_growth|${s.key}`, evidence: { key: s.key, current_amount: s.current_amount, baseline_amount: s.baseline_amount, growth_pct: growthPct } }
+}
+
+export interface NewSourceSignal {
+  source_id: string
+  first_seen_month: string
+  is_first_appearance: boolean
+}
+
+export function detectNewUnknownSourceAlert(s: NewSourceSignal): AlertCandidate | null {
+  if (!s.is_first_appearance) return null
+  return { type: 'new_unknown_source', severity: 'info', dedup_key: `new_unknown_source|${s.source_id}`, evidence: { source_id: s.source_id, first_seen_month: s.first_seen_month } }
+}
+
+export interface EstimateOnlySignal {
+  source_id: string
+  consecutive_estimate_only_months: number
+  threshold_months: number
+}
+
+export function detectLongEstimateOnlySourceAlert(s: EstimateOnlySignal): AlertCandidate | null {
+  if (s.consecutive_estimate_only_months < s.threshold_months) return null
+  return { type: 'long_estimate_only_source', severity: 'info', dedup_key: `long_estimate_only_source|${s.source_id}`, evidence: { source_id: s.source_id, consecutive_estimate_only_months: s.consecutive_estimate_only_months, threshold_months: s.threshold_months } }
+}
+
+export interface UtilizationSignal {
+  subscription_id: string
+  usage_pct: number
+  under_threshold_pct: number
+  over_threshold_pct: number
+}
+
+export function detectSubscriptionUtilizationAlert(s: UtilizationSignal): AlertCandidate | null {
+  if (s.usage_pct <= s.under_threshold_pct) {
+    return { type: 'subscription_utilization', severity: 'info', dedup_key: `subscription_utilization|${s.subscription_id}`, evidence: { subscription_id: s.subscription_id, usage_pct: s.usage_pct, direction: 'under', threshold: s.under_threshold_pct } }
+  }
+  if (s.usage_pct >= s.over_threshold_pct) {
+    return { type: 'subscription_utilization', severity: 'warning', dedup_key: `subscription_utilization|${s.subscription_id}`, evidence: { subscription_id: s.subscription_id, usage_pct: s.usage_pct, direction: 'over', threshold: s.over_threshold_pct } }
+  }
+  return null
+}
+
+// ---- lifecycle engine ---------------------------------------------------------------
+
+const DEFAULT_COOLDOWN_SECONDS = 3600
+
+export interface AlertReconcileResult {
+  toInsert: AlertRecord[]
+  // patches to apply, keyed by dedup_key -- the aggregator UPDATEs the matching row
+  toTouch: Array<{ dedup_key: string; patch: Pick<AlertRecord, 'last_seen' | 'severity' | 'evidence' | 'resolved_at' | 'recurrence_count' | 'cooldown_until'> }>
+  toResolve: Array<{ dedup_key: string; resolved_at: number }>
+}
+
+/**
+ * The lifecycle core. Given everything currently stored (`existing`, keyed by
+ * dedup_key) and this round's freshly detected candidates, decides what
+ * changes:
+ *
+ * - Candidate with NO existing row -> brand new alert (`toInsert`).
+ * - Candidate matching an ACTIVE (unresolved) existing row -> dedup: no new
+ *   row, just refresh `last_seen`/`severity`/`evidence` (`toTouch`).
+ * - Candidate matching a RESOLVED existing row -> the problem came back.
+ *   - Within `cooldownSeconds` of the row's own `cooldown_until` -> reopen
+ *     quietly (`resolved_at: null`) WITHOUT bumping `recurrence_count` --
+ *     this is flapping, not a genuine new incident, so it must not inflate
+ *     the recurrence counter noise-wise.
+ *   - After cooldown has elapsed -> genuine recurrence: reopen AND bump
+ *     `recurrence_count`, and set a fresh `cooldown_until`.
+ * - Existing UNRESOLVED row whose dedup_key has NO candidate this round -> the
+ *   underlying condition is gone -> `toResolve`.
+ *
+ * Acknowledgement state is untouched by this function on purpose --
+ * dedup/resolve/recur never clears an operator's ack; see `acknowledgeAlert`.
+ */
+export function reconcileAlerts(
+  existing: AlertRecord[],
+  candidates: AlertCandidate[],
+  now: number,
+  cooldownSeconds = DEFAULT_COOLDOWN_SECONDS,
+): AlertReconcileResult {
+  const existingByKey = new Map(existing.map(e => [e.dedup_key, e]))
+  const candidateKeys = new Set(candidates.map(c => c.dedup_key))
+  const toInsert: AlertRecord[] = []
+  const toTouch: AlertReconcileResult['toTouch'] = []
+
+  for (const c of candidates) {
+    const ex = existingByKey.get(c.dedup_key)
+    if (!ex) {
+      toInsert.push({
+        dedup_key: c.dedup_key, type: c.type, severity: c.severity, evidence: c.evidence,
+        first_seen: now, last_seen: now, acknowledged_at: null, acknowledged_by: null,
+        resolved_at: null, recurrence_count: 0, owner: null, cooldown_until: now + cooldownSeconds,
+      })
+      continue
+    }
+    if (ex.resolved_at == null) {
+      toTouch.push({ dedup_key: c.dedup_key, patch: { last_seen: now, severity: c.severity, evidence: c.evidence, resolved_at: null, recurrence_count: ex.recurrence_count, cooldown_until: ex.cooldown_until } })
+      continue
+    }
+    const withinCooldown = ex.cooldown_until != null && now < ex.cooldown_until
+    if (withinCooldown) {
+      toTouch.push({ dedup_key: c.dedup_key, patch: { last_seen: now, severity: c.severity, evidence: c.evidence, resolved_at: null, recurrence_count: ex.recurrence_count, cooldown_until: ex.cooldown_until } })
+    } else {
+      toTouch.push({ dedup_key: c.dedup_key, patch: { last_seen: now, severity: c.severity, evidence: c.evidence, resolved_at: null, recurrence_count: ex.recurrence_count + 1, cooldown_until: now + cooldownSeconds } })
+    }
+  }
+
+  const toResolve: AlertReconcileResult['toResolve'] = existing
+    .filter(e => e.resolved_at == null && !candidateKeys.has(e.dedup_key))
+    .map(e => ({ dedup_key: e.dedup_key, resolved_at: now }))
+
+  return { toInsert, toTouch, toResolve }
+}
+
+/** Manual acknowledgement -- never clears resolution/recurrence state, only records who/when. */
+export function acknowledgeAlert(alert: AlertRecord, actor: string, now: number): AlertRecord {
+  return { ...alert, acknowledged_at: now, acknowledged_by: actor }
+}
+
+/** Manual/explicit resolve (distinct from the automatic toResolve from reconcileAlerts, e.g. an operator dismissing an alert early). */
+export function resolveAlert(alert: AlertRecord, now: number): AlertRecord {
+  return { ...alert, resolved_at: now }
+}
+
+// ---- evidence (de)serialization -----------------------------------------------------
+
+export function serializeEvidence(evidence: Record<string, unknown>): string { return JSON.stringify(evidence) }
+export function deserializeEvidence(json: string): Record<string, unknown> {
+  try { return JSON.parse(json) } catch { return {} }
+}
+
+// ---- schema (DEFINER ONLY -- not mounted; see file header) --------------------------
+
+/**
+ * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts -- per
+ * fork-upstream-policy.md §2a, the ONE seam mount (`initCostOpsSchema(db)` in
+ * schema.ts calling this among the module's other schema definers) is the
+ * seam-refactor's job. Safe to call more than once (`IF NOT EXISTS`).
+ * `evidence_json` stores the `AlertCandidate.evidence` object via
+ * `serializeEvidence`; the aggregator round-trips it with
+ * `deserializeEvidence`. Named `costops_alerts` (not the generic `alerts`)
+ * to stay distinct from any unrelated alerting table elsewhere in the app.
+ */
+export function initAlertsSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS costops_alerts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      type TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      evidence_json TEXT NOT NULL,
+      dedup_key TEXT NOT NULL UNIQUE,
+      first_seen INTEGER NOT NULL,
+      last_seen INTEGER NOT NULL,
+      acknowledged_at INTEGER,
+      acknowledged_by TEXT,
+      resolved_at INTEGER,
+      recurrence_count INTEGER NOT NULL DEFAULT 0,
+      owner TEXT,
+      cooldown_until INTEGER,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_costops_alerts_type ON costops_alerts(type)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_costops_alerts_unresolved ON costops_alerts(resolved_at)`)
+}

--- a/src/costops/alerts.ts
+++ b/src/costops/alerts.ts
@@ -16,7 +16,8 @@
 // NO db.ts/web.ts/schema.ts edits: `initAlertsSchema` is a schema DEFINER
 // only, not mounted anywhere -- the seam-refactor's `initCostOpsSchema(db)`
 // aggregator (Mason, accounting-core seam, src/costops/schema.ts) calls it,
-// per docs/fork-upstream-policy.md §2a. Same pattern as forecast.ts/fx.ts.
+// keeping every CostOps table behind that single mount point. Same pattern as
+// forecast.ts/fx.ts.
 //
 // GAP-12 acceptance reminder baked into every detector below: "stale adat
 // onmagaban nem okoz erős vagy hibás üzleti allitast" -- a stale/failed sync
@@ -348,10 +349,10 @@ export function deserializeEvidence(json: string): Record<string, unknown> {
 // ---- schema (DEFINER ONLY -- not mounted; see file header) --------------------------
 
 /**
- * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts -- per
- * fork-upstream-policy.md §2a, the ONE seam mount (`initCostOpsSchema(db)` in
- * schema.ts calling this among the module's other schema definers) is the
- * seam-refactor's job. Safe to call more than once (`IF NOT EXISTS`).
+ * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts: the ONE
+ * seam mount (`initCostOpsSchema(db)` in schema.ts calling this among the
+ * module's other schema definers) is the seam-refactor's job. Safe to call
+ * more than once (`IF NOT EXISTS`).
  * `evidence_json` stores the `AlertCandidate.evidence` object via
  * `serializeEvidence`; the aggregator round-trips it with
  * `deserializeEvidence`. Named `costops_alerts` (not the generic `alerts`)

--- a/src/costops/budgets.ts
+++ b/src/costops/budgets.ts
@@ -1,0 +1,202 @@
+// CostOps Phase 3 (GAP-11) -- multi-level budgets.
+//
+// Generalizes ledger.ts's single hardcoded 'global-monthly' budget
+// resolution into one that works for every BudgetEntry.scope (global,
+// provider, category, source) against the same CostSummary the dashboard
+// already computes -- so a budget's current_spend/forecast never diverges
+// from what the dashboard shows for that scope. 'product'/'agent' scopes are
+// explicitly NOT resolved (GAP-11: no agent/task/product budget) -- they
+// stay valid config values for backward compatibility but always resolve to
+// zero spend/forecast here, never fabricated as something meaningful.
+//
+// Budgets are still config-file-defined (costops-config.json), matching
+// every other CostOps config -- but a change through the API (not a manual
+// file edit) is now auditable via costops_budget_audit, satisfying GAP-11's
+// "budget change AUDIT (who/when/what changed)".
+
+import type Database from 'better-sqlite3'
+import { getCostSummary, type CostSummary } from './ledger.js'
+import { saveCostopsConfig, type CostOpsConfig, type BudgetEntry } from './config.js'
+
+export function initBudgetAuditSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS costops_budget_audit (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      budget_id TEXT NOT NULL,
+      action TEXT NOT NULL,
+      actor TEXT NOT NULL,
+      before_json TEXT,
+      after_json TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_budget_audit_budget ON costops_budget_audit(budget_id, created_at)`)
+}
+
+const DEFAULT_OWNER = process.env.COSTOPS_DEFAULT_OWNER || 'operator'
+
+export interface BudgetStatus {
+  id: string
+  name: string
+  scope: NonNullable<BudgetEntry['scope']>
+  scope_ref: string | null
+  period: 'monthly'
+  amount: number
+  currency: string
+  warning_threshold: number
+  hard_threshold: number
+  current_spend: number
+  forecast: number
+  variance: number  // forecast - amount; positive = projected overage
+  used_pct: number
+  forecast_pct: number
+  status: 'ok' | 'warning' | 'hard'
+  owner: string
+  notes: string | null
+}
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }
+function round4(n: number): number { return Math.round(n * 10000) / 10000 }
+
+function spendForScope(budget: BudgetEntry, summary: CostSummary): { spend: number; forecast: number } {
+  const scope = budget.scope ?? 'global'
+  if (scope === 'global') {
+    return { spend: summary.operational_spend, forecast: summary.operational_forecast_month_end }
+  }
+  if (scope === 'provider') {
+    const sources = summary.all_sources.filter(s => s.provider === budget.scope_ref)
+    return {
+      spend: sources.reduce((sum, s) => sum + (s.spend ?? 0), 0),
+      forecast: sources.reduce((sum, s) => sum + (s.forecast_month_end ?? 0), 0),
+    }
+  }
+  if (scope === 'category') {
+    const sources = summary.all_sources.filter(s => s.source_type === budget.scope_ref)
+    return {
+      spend: sources.reduce((sum, s) => sum + (s.spend ?? 0), 0),
+      forecast: sources.reduce((sum, s) => sum + (s.forecast_month_end ?? 0), 0),
+    }
+  }
+  if (scope === 'source') {
+    const row = summary.all_sources.find(s => s.source_id === budget.scope_ref)
+    return { spend: row?.spend ?? 0, forecast: row?.forecast_month_end ?? 0 }
+  }
+  // 'product' | 'agent': explicitly out of GAP-11 scope -- never resolved to
+  // a real number here (no agent/task/product cost attribution exists).
+  return { spend: 0, forecast: 0 }
+}
+
+/** Resolve one budget entry's live status against an already-computed CostSummary. Pure, no I/O. */
+export function resolveBudgetStatus(budget: BudgetEntry, summary: CostSummary): BudgetStatus {
+  const { spend, forecast } = spendForScope(budget, summary)
+  const warning_threshold = budget.warning_threshold ?? 0.8
+  const hard_threshold = budget.hard_threshold ?? 1.0
+  const used_pct = budget.amount > 0 ? spend / budget.amount : 0
+  const forecast_pct = budget.amount > 0 ? forecast / budget.amount : 0
+  // Status is display-only (governance/alerting), never an automatic stop --
+  // same convention as ledger.ts's existing single-budget status.
+  const status: BudgetStatus['status'] = used_pct >= hard_threshold ? 'hard' : used_pct >= warning_threshold ? 'warning' : 'ok'
+  return {
+    id: budget.id, name: budget.name ?? budget.id, scope: budget.scope ?? 'global', scope_ref: budget.scope_ref ?? null,
+    period: 'monthly', amount: budget.amount, currency: budget.currency ?? summary.currency,
+    warning_threshold, hard_threshold,
+    current_spend: round2(spend), forecast: round2(forecast), variance: round2(forecast - budget.amount),
+    used_pct: round4(used_pct), forecast_pct: round4(forecast_pct), status,
+    owner: budget.owner ?? DEFAULT_OWNER, notes: budget.notes ?? null,
+  }
+}
+
+/** Every configured budget's live status for the given month. */
+export function getAllBudgetStatuses(db: Database.Database, config: CostOpsConfig, now: number, monthKey?: string): BudgetStatus[] {
+  const summary = getCostSummary(db, config, now, { monthKey })
+  return config.budgets.map(b => resolveBudgetStatus(b, summary))
+}
+
+export interface BudgetWriteResult {
+  ok: boolean
+  error?: string
+  status?: number
+  budget?: BudgetEntry
+}
+
+export interface UpsertBudgetInput {
+  id: string
+  name?: string
+  scope?: BudgetEntry['scope']
+  scope_ref?: string
+  amount: number
+  currency?: string
+  warning_threshold?: number
+  hard_threshold?: number
+  owner?: string
+  notes?: string
+}
+
+/**
+ * Create or update a budget entry, persist the config file, and record an
+ * audited before/after change. Returns the freshly-loaded config's budgets
+ * array is NOT returned here -- callers reload via loadCostopsConfig() for
+ * the next request, same as every other CostOps write path.
+ */
+export function upsertBudget(db: Database.Database, config: CostOpsConfig, input: UpsertBudgetInput, actor: string, now: number): BudgetWriteResult {
+  if (!actor || !actor.trim()) return { ok: false, error: 'actor is required for a budget change (audit trail)', status: 400 }
+  if (!input || typeof input.id !== 'string' || !input.id) return { ok: false, error: 'missing id', status: 400 }
+  if (typeof input.amount !== 'number' || !isFinite(input.amount) || input.amount < 0) {
+    return { ok: false, error: 'amount must be a non-negative number', status: 400 }
+  }
+  const existingIdx = config.budgets.findIndex(b => b.id === input.id)
+  const before = existingIdx >= 0 ? config.budgets[existingIdx] : null
+  const entry: BudgetEntry = {
+    id: input.id, name: input.name ?? input.id, scope: input.scope ?? 'global', scope_ref: input.scope_ref,
+    amount: input.amount, currency: input.currency ?? config.currency,
+    warning_threshold: input.warning_threshold ?? 0.8, hard_threshold: input.hard_threshold ?? 1.0,
+    owner: input.owner, notes: input.notes,
+  }
+  const budgets = [...config.budgets]
+  if (existingIdx >= 0) budgets[existingIdx] = entry
+  else budgets.push(entry)
+  saveCostopsConfig({ ...config, budgets })
+  db.prepare(`
+    INSERT INTO costops_budget_audit (budget_id, action, actor, before_json, after_json, created_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(input.id, before ? 'updated' : 'created', actor, before ? JSON.stringify(before) : null, JSON.stringify(entry), now)
+  return { ok: true, budget: entry }
+}
+
+/** Remove a budget entry, persist the config file, and record the audited deletion. */
+export function deleteBudget(db: Database.Database, config: CostOpsConfig, id: string, actor: string, now: number): BudgetWriteResult {
+  if (!actor || !actor.trim()) return { ok: false, error: 'actor is required for a budget change (audit trail)', status: 400 }
+  const existingIdx = config.budgets.findIndex(b => b.id === id)
+  if (existingIdx < 0) return { ok: false, error: `no budget '${id}'`, status: 404 }
+  const before = config.budgets[existingIdx]
+  const budgets = config.budgets.filter(b => b.id !== id)
+  saveCostopsConfig({ ...config, budgets })
+  db.prepare(`
+    INSERT INTO costops_budget_audit (budget_id, action, actor, before_json, after_json, created_at)
+    VALUES (?, 'deleted', ?, ?, NULL, ?)
+  `).run(id, actor, JSON.stringify(before), now)
+  return { ok: true }
+}
+
+export interface BudgetAuditEntry {
+  budget_id: string
+  action: 'created' | 'updated' | 'deleted'
+  actor: string
+  before: BudgetEntry | null
+  after: BudgetEntry | null
+  created_at: number
+}
+
+/** Full audit history, oldest first, optionally filtered to one budget id. */
+export function getBudgetAuditHistory(db: Database.Database, budgetId?: string): BudgetAuditEntry[] {
+  const rows = (budgetId
+    ? db.prepare(`SELECT * FROM costops_budget_audit WHERE budget_id = ? ORDER BY created_at ASC`).all(budgetId)
+    : db.prepare(`SELECT * FROM costops_budget_audit ORDER BY created_at ASC`).all()
+  ) as Array<{ budget_id: string; action: string; actor: string; before_json: string | null; after_json: string | null; created_at: number }>
+  return rows.map(r => ({
+    budget_id: r.budget_id, action: r.action as BudgetAuditEntry['action'], actor: r.actor,
+    before: r.before_json ? JSON.parse(r.before_json) : null,
+    after: r.after_json ? JSON.parse(r.after_json) : null,
+    created_at: r.created_at,
+  }))
+}

--- a/src/costops/collectors/anthropic.ts
+++ b/src/costops/collectors/anthropic.ts
@@ -1,0 +1,108 @@
+// CostOps v0.3 -- Anthropic cost collector (LIVE-READY, but no live call in PR1).
+//
+// The mapper is a PURE function tested offline against a fixture. collect()
+// builds the request and calls the INJECTED httpGetJson, so no network happens
+// unless a real fetcher is passed after explicit approval. The Admin API key is
+// received via opts.secret (from the Vault) and is NEVER logged.
+//
+// NOTE: the exact Anthropic Admin cost_report field names must be verified on
+// the first approved live dry-run; the fixture + mapper here are a matched pair
+// modelling the documented shape (time buckets -> per-line cost results in USD).
+
+import { createHash } from 'node:crypto'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine } from './types.js'
+
+const ANTHROPIC_COST_URL = 'https://api.anthropic.com/v1/organizations/cost_report'
+const ANTHROPIC_VERSION = '2023-06-01'
+// All Anthropic API usage reconciles against this source (matches the v0.1
+// manual/estimate line 'anthropic-api' so estimate and actual share a source).
+const ANTHROPIC_API_SOURCE = 'anthropic-api'
+
+function hashRef(salt: string, raw: string): string {
+  return createHash('sha256').update(salt).update('|').update(raw).digest('hex').slice(0, 32)
+}
+
+interface AnthropicCostResult {
+  currency?: string
+  amount?: number | string
+  cost_type?: string
+  model?: string
+  service?: string
+  description?: string
+}
+interface AnthropicCostBucket {
+  starting_at?: string
+  ending_at?: string
+  results?: AnthropicCostResult[]
+}
+interface AnthropicCostReport {
+  data?: AnthropicCostBucket[]
+  has_more?: boolean
+}
+
+/**
+ * PURE mapper: Anthropic cost_report -> a single aggregated provider_api line
+ * for the anthropic-api source for the requested period. USD amounts are
+ * converted to HUF via fxUsdHuf. Deterministic; no I/O. Returns [] if nothing.
+ */
+export function mapAnthropicCostReport(
+  raw: unknown,
+  opts: { periodStart: number; periodEnd: number; fxUsdHuf: number; idSalt: string; now: number },
+): NormalizedCostLine[] {
+  const report = (raw && typeof raw === 'object') ? raw as AnthropicCostReport : {}
+  const buckets = Array.isArray(report.data) ? report.data : []
+  let usdTotal = 0
+  let latestEnd = 0
+  let any = false
+  for (const b of buckets) {
+    const endSec = b.ending_at ? Math.floor(new Date(b.ending_at).getTime() / 1000) : 0
+    if (endSec > latestEnd) latestEnd = endSec
+    for (const r of (Array.isArray(b.results) ? b.results : [])) {
+      const amt = typeof r.amount === 'number' ? r.amount : parseFloat(String(r.amount ?? ''))
+      if (!isFinite(amt)) continue
+      // report may already be in the account currency; treat as USD only when labelled USD (default).
+      const cur = (r.currency || 'USD').toUpperCase()
+      usdTotal += cur === 'USD' ? amt : amt // v0.1: assume USD; non-USD handled at live-verify time
+      any = true
+    }
+  }
+  if (!any) return []
+  const monthKey = new Date(opts.periodStart * 1000).toISOString().slice(0, 7)
+  const amountHuf = Math.round(usdTotal * opts.fxUsdHuf * 100) / 100
+  return [{
+    provider: 'anthropic',
+    service: ANTHROPIC_API_SOURCE,
+    billing_period_start: opts.periodStart,
+    billing_period_end: opts.periodEnd,
+    amount: amountHuf,
+    currency: 'HUF',
+    confidence: 'provider_api',
+    usage_type: 'api_usage',
+    quantity: null,
+    unit: null,
+    data_freshness_at: latestEnd || opts.now,
+    raw_ref_hash: hashRef(opts.idSalt, `anthropic-cost-report|${monthKey}`),
+    dedup_key: `provider|anthropic|${ANTHROPIC_API_SOURCE}|${monthKey}|provider_api`,
+  }]
+}
+
+export const anthropicCollector: ProviderCollector = {
+  provider: 'anthropic',
+  collectorName: 'anthropic-cost-report',
+  async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+    const startIso = new Date(opts.periodStart * 1000).toISOString()
+    const endIso = new Date(opts.periodEnd * 1000).toISOString()
+    const url = `${ANTHROPIC_COST_URL}?starting_at=${encodeURIComponent(startIso)}&ending_at=${encodeURIComponent(endIso)}`
+    // secret used ONLY as the auth header; never logged.
+    const headers = {
+      'x-api-key': opts.secret,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    }
+    const raw = await opts.httpGetJson(url, headers)
+    return mapAnthropicCostReport(raw, {
+      periodStart: opts.periodStart, periodEnd: opts.periodEnd,
+      fxUsdHuf: opts.fxUsdHuf, idSalt: opts.idSalt, now: opts.periodStart,
+    })
+  },
+}

--- a/src/costops/collectors/anthropic.ts
+++ b/src/costops/collectors/anthropic.ts
@@ -89,7 +89,10 @@ export function mapAnthropicCostReport(
 export const anthropicCollector: ProviderCollector = {
   provider: 'anthropic',
   collectorName: 'anthropic-cost-report',
-  async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+  // READ the cost report and return BOTH the raw response and the normalized
+  // lines. The raw is used ONLY to describe its shape in a dry-run (never
+  // persisted, never logged). The secret is used only as the auth header.
+  async collectRaw(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }> {
     const startIso = new Date(opts.periodStart * 1000).toISOString()
     const endIso = new Date(opts.periodEnd * 1000).toISOString()
     const url = `${ANTHROPIC_COST_URL}?starting_at=${encodeURIComponent(startIso)}&ending_at=${encodeURIComponent(endIso)}`
@@ -100,9 +103,13 @@ export const anthropicCollector: ProviderCollector = {
       'content-type': 'application/json',
     }
     const raw = await opts.httpGetJson(url, headers)
-    return mapAnthropicCostReport(raw, {
+    const lines = mapAnthropicCostReport(raw, {
       periodStart: opts.periodStart, periodEnd: opts.periodEnd,
       fxUsdHuf: opts.fxUsdHuf, idSalt: opts.idSalt, now: opts.periodStart,
     })
+    return { raw, lines }
+  },
+  async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+    return (await this.collectRaw!(opts)).lines
   },
 }

--- a/src/costops/collectors/codex.ts
+++ b/src/costops/collectors/codex.ts
@@ -1,0 +1,164 @@
+// CostOps -- Codex / ChatGPT Plus rate-limit collector (LIVE, read-only, metadata-only).
+//
+// The Codex CLI (ChatGPT Plus auth) weekly rate-limit usage is read via the
+// app-server JSON-RPC method `account/rateLimits/read` -- a pure METADATA read
+// that consumes NO ChatGPT Plus quota (it is not a model turn). This is
+// deliberately NOT `codex exec`, which would burn quota AND is an LLM call
+// (forbidden anywhere in CostOps). The reader spawns `codex app-server` and
+// speaks JSON-RPC over stdio. No secret, no LLM, no provider-side write. If the
+// read fails or is unparseable, NO snapshot is written and limits.ts reports
+// 'unknown' -- never a fabricated percentage.
+
+import type Database from 'better-sqlite3'
+
+export const CODEX_PROVIDER = 'codex'
+
+export interface CodexRateLimit {
+  usedPercent: number              // 0..100, primary (weekly) window
+  windowDurationMins: number | null
+  resetsAt: number | null          // epoch sec
+  planType: string | null          // e.g. 'plus'
+  limitId: string | null
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === 'object' ? (v as Record<string, unknown>) : null
+}
+function numOrNull(v: unknown): number | null {
+  return typeof v === 'number' && isFinite(v) ? v : null
+}
+function strOrNull(v: unknown): string | null {
+  return typeof v === 'string' ? v : null
+}
+
+/**
+ * PURE: parse the app-server `account/rateLimits/read` result into a snapshot,
+ * or null if malformed. Accepts either the bare result ({rateLimits:{...}}) or a
+ * result already narrowed to rateLimits.
+ */
+export function parseCodexRateLimit(raw: unknown): CodexRateLimit | null {
+  const top = asRecord(raw)
+  if (!top) return null
+  const rl = asRecord(top.rateLimits) ?? asRecord((asRecord(top.result) ?? {}).rateLimits) ?? top
+  const primary = asRecord(rl.primary)
+  if (!primary) return null
+  const usedPercent = numOrNull(primary.usedPercent)
+  if (usedPercent === null) return null
+  return {
+    usedPercent: Math.max(0, Math.min(100, usedPercent)),
+    windowDurationMins: numOrNull(primary.windowDurationMins),
+    resetsAt: numOrNull(primary.resetsAt),
+    planType: strOrNull(rl.planType),
+    limitId: strOrNull(rl.limitId),
+  }
+}
+
+// Injected reader -- tests pass a stub returning a fixture; the live reader
+// spawns codex app-server. Keeps sync() fully offline-testable.
+export type CodexRateLimitReader = () => Promise<unknown>
+
+/**
+ * LIVE reader: spawn `codex app-server`, JSON-RPC initialize + account/rateLimits/read
+ * over stdio, resolve with the `result` of the rateLimits response. METADATA-ONLY:
+ * consumes no ChatGPT Plus quota. Never logs anything (no tokens/secrets involved).
+ */
+export const readCodexRateLimitLive: CodexRateLimitReader = async () => {
+  const { spawn } = await import('node:child_process')
+  return await new Promise<unknown>((resolve, reject) => {
+    const p = spawn('codex', ['app-server'], { stdio: ['pipe', 'pipe', 'ignore'] })
+    let buf = ''
+    let settled = false
+    const done = (err: Error | null, val?: unknown) => {
+      if (settled) return
+      settled = true
+      try { p.kill() } catch { /* already gone */ }
+      if (err) reject(err)
+      else resolve(val)
+    }
+    const timer = setTimeout(() => done(new Error('codex app-server timeout')), 20000)
+    p.on('error', (e: Error) => { clearTimeout(timer); done(e) })
+    p.stdout.on('data', (d: Buffer) => {
+      buf += d.toString()
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const o = JSON.parse(line) as { id?: number; result?: unknown }
+          if (o && o.id === 2 && o.result !== undefined) { clearTimeout(timer); done(null, o.result) }
+        } catch { /* partial / non-JSON line */ }
+      }
+    })
+    const send = (o: unknown) => { try { p.stdin.write(JSON.stringify(o) + '\n') } catch { /* pipe closed */ } }
+    send({ id: 1, method: 'initialize', params: { clientInfo: { name: 'costops', version: '1' } } })
+    setTimeout(() => send({ id: 2, method: 'account/rateLimits/read', params: null }), 400)
+  })
+}
+
+export interface RateLimitSnapshotRow { used_percent: number; resets_at: number | null; captured_at: number }
+
+/**
+ * PURE: forecast when the window will hit 100% (epoch sec), or null when the
+ * input can't support a trustworthy extrapolation. Sums only used% RISES between
+ * consecutive snapshots (a drop = a window reset, ignored -- same discipline as
+ * DeepSeek's top-up-ignoring burn rate). Never fabricates a date.
+ */
+export function forecastCodexLimitExhaustion(snapsAsc: RateLimitSnapshotRow[], now: number): number | null {
+  if (snapsAsc.length < 2) return null
+  const spanSec = snapsAsc[snapsAsc.length - 1].captured_at - snapsAsc[0].captured_at
+  if (spanSec < 3600) return null                       // < 1h of history is too noisy
+  let rise = 0
+  for (let i = 1; i < snapsAsc.length; i++) {
+    const d = snapsAsc[i].used_percent - snapsAsc[i - 1].used_percent
+    if (d > 0) rise += d
+  }
+  if (rise <= 0) return null                            // flat or only resets -> no exhaustion to project
+  const perSec = rise / spanSec
+  if (!isFinite(perSec) || perSec <= 0) return null
+  const remaining = 100 - snapsAsc[snapsAsc.length - 1].used_percent
+  if (remaining <= 0) return now
+  const secsToFull = remaining / perSec
+  if (!isFinite(secsToFull) || secsToFull < 0) return null
+  return Math.floor(now + secsToFull)
+}
+
+function recordRun(db: Database.Database, status: string, count: number, now: number, errMsg: string | null): void {
+  db.prepare(`INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status, imported_count, error_code, error_message_sanitized, data_freshness_at)
+    VALUES ('codex','codex-ratelimit',@now,@now,@status,@count,@ec,@em,@now)`).run({
+    now, status, count, ec: status === 'error' ? 'ratelimit_error' : null, em: errMsg,
+  })
+}
+
+/**
+ * LIVE read-only sync: read the Codex weekly rate-limit via the app-server
+ * (metadata-only, ZERO quota), record a snapshot, record an import_runs row.
+ * Injected reader/clock make it fully offline-testable. On any failure it writes
+ * NO snapshot (limits.ts then reports 'unknown') and records a sanitized error.
+ */
+export async function syncCodexRateLimit(
+  db: Database.Database,
+  now: number,
+  deps: { reader?: CodexRateLimitReader } = {},
+): Promise<{ ok: boolean; provider: string; status: string; imported_count: number; used_percent?: number; error?: string }> {
+  const { sanitizeError } = await import('./runner.js')
+  const reader = deps.reader ?? readCodexRateLimitLive
+  let snap: CodexRateLimit | null
+  try {
+    const raw = await reader()
+    snap = parseCodexRateLimit(raw)
+  } catch (err) {
+    const s = sanitizeError(err)
+    recordRun(db, 'error', 0, now, s.message)
+    return { ok: false, provider: CODEX_PROVIDER, status: 'error', imported_count: 0, error: s.code }
+  }
+  if (!snap) {
+    recordRun(db, 'error', 0, now, 'unparseable rateLimits result')
+    return { ok: false, provider: CODEX_PROVIDER, status: 'error', imported_count: 0, error: 'parse_error' }
+  }
+  db.prepare(`INSERT INTO provider_ratelimit_snapshots (provider, limit_id, used_percent, window_duration_mins, resets_at, plan_type, captured_at)
+    VALUES (?,?,?,?,?,?,?)`).run(
+    CODEX_PROVIDER, snap.limitId, snap.usedPercent, snap.windowDurationMins, snap.resetsAt, snap.planType, now,
+  )
+  recordRun(db, 'ok', 1, now, null)
+  return { ok: true, provider: CODEX_PROVIDER, status: 'ok', imported_count: 1, used_percent: snap.usedPercent }
+}

--- a/src/costops/collectors/collectors-config.example.json
+++ b/src/costops/collectors/collectors-config.example.json
@@ -1,0 +1,13 @@
+{
+  "_doc": "CostOps v0.3 collectors config EXAMPLE. Copy to store/costops-collectors.json (gitignored) to enable a collector. NEVER put an API key or raw account id here -- only a 'vault:<id>' secret_ref. The real Admin key goes into the Vault (src/web/vault.ts) via the secure handover, never into this file, a log, or a transcript. enabled=false and no live call until explicitly approved.",
+  "version": 1,
+  "fx_usd_huf": 0,
+  "collectors": [
+    {
+      "provider": "anthropic",
+      "enabled": false,
+      "secret_ref": "vault:costops.anthropic_admin_key",
+      "account_ref_hash": null
+    }
+  ]
+}

--- a/src/costops/collectors/config.ts
+++ b/src/costops/collectors/config.ts
@@ -1,0 +1,69 @@
+// CostOps v0.3 -- local collectors config loader.
+//
+// store/costops-collectors.json is gitignored/local. It holds ONLY non-secret
+// wiring: enable flags, a `secret_ref` pointing at a Vault id (NOT the value),
+// an optional account_ref_hash (never a raw account id), and the FX rate.
+// NO API key, account id, or invoice ref ever lives here or is logged.
+
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../../config.js'
+import { logger } from '../../logger.js'
+
+export const COLLECTORS_CONFIG_PATH = join(PROJECT_ROOT, 'store', 'costops-collectors.json')
+
+export interface CollectorEntry {
+  provider: string
+  enabled: boolean
+  secret_ref: string          // e.g. 'vault:costops.anthropic_admin_key' -- NOT the key
+  account_ref_hash?: string | null
+}
+
+export interface CollectorsConfig {
+  version: number
+  fx_usd_huf: number
+  collectors: CollectorEntry[]
+}
+
+const EMPTY: CollectorsConfig = { version: 1, fx_usd_huf: 0, collectors: [] }
+
+export interface CollectorsLoadResult {
+  config: CollectorsConfig
+  exists: boolean
+  errors: string[]
+}
+
+export function loadCollectorsConfig(): CollectorsLoadResult {
+  if (!existsSync(COLLECTORS_CONFIG_PATH)) {
+    return { config: { ...EMPTY }, exists: false, errors: [] }
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(COLLECTORS_CONFIG_PATH, 'utf-8'))
+  } catch (err) {
+    logger.warn({ err }, 'costops-collectors.json is not valid JSON')
+    return { config: { ...EMPTY }, exists: true, errors: ['collectors config is not valid JSON'] }
+  }
+  return validateCollectorsConfig(raw)
+}
+
+export function validateCollectorsConfig(raw: unknown): CollectorsLoadResult {
+  const errors: string[] = []
+  const obj = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const fx = typeof obj.fx_usd_huf === 'number' && isFinite(obj.fx_usd_huf) && obj.fx_usd_huf >= 0 ? obj.fx_usd_huf : 0
+  const collectors: CollectorEntry[] = []
+  for (const [i, e] of (Array.isArray(obj.collectors) ? obj.collectors : []).entries()) {
+    const c = e as Record<string, unknown>
+    if (typeof c?.provider !== 'string' || !c.provider) { errors.push(`collectors[${i}]: missing provider`); continue }
+    // A raw key would look like 'sk-...'; a secret_ref must be a 'vault:' reference.
+    const ref = typeof c.secret_ref === 'string' ? c.secret_ref : ''
+    if (ref && !ref.startsWith('vault:')) { errors.push(`collectors[${i}] (${c.provider}): secret_ref must be a 'vault:<id>' reference, not a raw value`); continue }
+    collectors.push({
+      provider: c.provider,
+      enabled: c.enabled === true,
+      secret_ref: ref,
+      account_ref_hash: typeof c.account_ref_hash === 'string' ? c.account_ref_hash : null,
+    })
+  }
+  return { config: { version: typeof obj.version === 'number' ? obj.version : 1, fx_usd_huf: fx, collectors }, exists: true, errors }
+}

--- a/src/costops/collectors/deepseek.ts
+++ b/src/costops/collectors/deepseek.ts
@@ -1,0 +1,122 @@
+// CostOps -- DeepSeek cost collector (LIVE, read-only, prepaid-balance based).
+//
+// DeepSeek exposes remaining prepaid BALANCE (GET /user/balance), not per-period
+// cost. So month-to-date spend is derived from the balance DROP across snapshots:
+// each sync records a snapshot, and MTD spend = the sum of decreases between
+// consecutive this-month snapshots (increases are top-ups and are ignored, so a
+// mid-month top-up does not distort spend). The API key comes from the Vault and
+// is NEVER logged. Pure GET, no provider-side write.
+//
+// First sync of a month just records the baseline (spend 0 until a later sync
+// shows a drop). This is a provider_usage_actual signal (API-observed), an
+// upgrade over a manual DeepSeek estimate.
+
+const DEEPSEEK_BALANCE_URL = 'https://api.deepseek.com/user/balance'
+const DEEPSEEK_API_SOURCE = 'deepseek-api'
+
+export interface BalanceSnapshot { balance: number; captured_at: number }
+
+/**
+ * PURE: month-to-date spend in the balance currency, from ascending-by-time
+ * snapshots. Sums only the DROPS between consecutive snapshots (a rise is a
+ * top-up, ignored). Deterministic; no I/O.
+ */
+export function deriveMtdSpend(snapshotsAsc: BalanceSnapshot[]): number {
+  let spend = 0
+  for (let i = 1; i < snapshotsAsc.length; i++) {
+    const drop = snapshotsAsc[i - 1].balance - snapshotsAsc[i].balance
+    if (drop > 0) spend += drop
+  }
+  return Math.round(spend * 10000) / 10000
+}
+
+interface DeepSeekBalanceInfo { currency?: string; total_balance?: string | number }
+interface DeepSeekBalanceResp { is_available?: boolean; balance_infos?: DeepSeekBalanceInfo[] }
+
+/** Extract the USD total balance from the /user/balance response (0 if absent). */
+export function parseDeepSeekBalanceUsd(raw: unknown): number {
+  const r = (raw && typeof raw === 'object') ? raw as DeepSeekBalanceResp : {}
+  const infos = Array.isArray(r.balance_infos) ? r.balance_infos : []
+  const usd = infos.find(i => (i.currency || '').toUpperCase() === 'USD') || infos[0]
+  if (!usd) return 0
+  const v = typeof usd.total_balance === 'number' ? usd.total_balance : parseFloat(String(usd.total_balance ?? ''))
+  return isFinite(v) ? v : 0
+}
+
+export const DEEPSEEK_VAULT_SECRET_ID = 'DEEPSEEK_API_KEY'
+
+/**
+ * LIVE read-only sync: read the prepaid balance, record a snapshot, derive MTD
+ * spend from this month's balance drops, and upsert a provider line +
+ * import_runs row. Injected deps let tests stub the key, fetcher, fx and clock.
+ */
+export async function syncDeepSeekBalance(
+  db: import('better-sqlite3').Database,
+  now: number,
+  deps: {
+    httpGetJson?: import('./types.js').HttpGetJson
+    apiKey?: string | null
+    fxUsdHuf?: number
+  } = {},
+): Promise<{ ok: boolean; provider: string; status: string; imported_count: number; balance_usd?: number; mtd_spend_usd?: number; error?: string; period?: string }> {
+  const { monthWindow } = await import('../ledger.js')
+  const { sanitizeError } = await import('./runner.js')
+  let apiKey = deps.apiKey
+  if (apiKey === undefined) {
+    try { const { getSecret } = await import('../../web/vault.js'); apiKey = getSecret(DEEPSEEK_VAULT_SECRET_ID) } catch { apiKey = null }
+  }
+  const w = monthWindow(now)
+  if (!apiKey) {
+    recordRun(db, 'error', 0, w, now, 'no DeepSeek key in vault')
+    return { ok: false, provider: 'deepseek', status: 'error', imported_count: 0, error: `no DeepSeek key in vault (${DEEPSEEK_VAULT_SECRET_ID})`, period: w.key }
+  }
+  let fxUsdHuf = deps.fxUsdHuf
+  if (fxUsdHuf === undefined) {
+    try { const { loadRenderPricing } = await import('./render.js'); fxUsdHuf = loadRenderPricing().pricing.fx_usd_huf || 0 } catch { fxUsdHuf = 0 }
+  }
+  const httpGetJson = deps.httpGetJson || (async (url: string, headers: Record<string, string>) => {
+    const r = await fetch(url, { method: 'GET', headers }); if (!r.ok) throw new Error(`deepseek api ${r.status}`); return r.json()
+  })
+  let balanceUsd: number
+  try {
+    const raw = await httpGetJson(DEEPSEEK_BALANCE_URL, { authorization: `Bearer ${apiKey}` })
+    balanceUsd = parseDeepSeekBalanceUsd(raw)
+  } catch (err) {
+    const s = sanitizeError(err)
+    recordRun(db, 'error', 0, w, now, s.message)
+    return { ok: false, provider: 'deepseek', status: 'error', imported_count: 0, error: s.code, period: w.key }
+  }
+  // record the snapshot, then derive MTD spend from this-month snapshots (asc)
+  db.prepare(`INSERT INTO provider_balance_snapshots (provider, currency, balance, captured_at) VALUES ('deepseek','USD',?,?)`).run(balanceUsd, now)
+  const rows = db.prepare(
+    `SELECT balance, captured_at FROM provider_balance_snapshots WHERE provider='deepseek' AND captured_at >= ? AND captured_at < ? ORDER BY captured_at ASC`,
+  ).all(w.start, w.end) as Array<{ balance: number; captured_at: number }>
+  const mtdSpendUsd = deriveMtdSpend(rows.map(r => ({ balance: r.balance, captured_at: r.captured_at })))
+  const amountHuf = Math.round(mtdSpendUsd * (fxUsdHuf || 0) * 100) / 100
+
+  // upsert the provider line (usage actual, derived) for deepseek-api
+  upsertLine(db, {
+    source: DEEPSEEK_API_SOURCE, provider: 'deepseek', start: w.start, end: w.end,
+    amount: amountHuf, confidence: 'provider_api', freshness: now,
+    dedup_key: `provider|deepseek|${DEEPSEEK_API_SOURCE}|${w.key}|provider_api`, now,
+  })
+  recordRun(db, 'ok', 1, w, now, null)
+  return { ok: true, provider: 'deepseek', status: 'ok', imported_count: 1, balance_usd: balanceUsd, mtd_spend_usd: mtdSpendUsd, period: w.key }
+}
+
+function upsertLine(db: import('better-sqlite3').Database, a: { source: string; provider: string; start: number; end: number; amount: number; confidence: string; freshness: number; dedup_key: string; now: number }): void {
+  db.prepare(`INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at)
+    VALUES (@id,@id,@provider,'usage','HUF',1,@now,@now)
+    ON CONFLICT(id) DO UPDATE SET provider=excluded.provider, updated_at=excluded.updated_at`).run({ id: a.source, provider: a.provider, now: a.now })
+  db.prepare(`INSERT INTO cost_line_items
+      (source_id, charge_period_start, charge_period_end, charge_category, service_name, usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency, confidence, data_freshness, source_ref, dedup_key, created_at)
+    VALUES (@source,@start,@end,'usage',@source,NULL,NULL,NULL,@amount,NULL,'HUF',@confidence,@freshness,NULL,@dedup_key,@now)
+    ON CONFLICT(dedup_key) DO UPDATE SET billed_cost=excluded.billed_cost, confidence=excluded.confidence, data_freshness=excluded.data_freshness`).run(a)
+}
+
+function recordRun(db: import('better-sqlite3').Database, status: string, count: number, w: { start: number; end: number }, now: number, errMsg: string | null): void {
+  db.prepare(`INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status, period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at)
+    VALUES ('deepseek','deepseek-balance',@now,@now,@status,@ps,@pe,@count,@ec,@em,@now)`).run({
+    now, status, ps: w.start, pe: w.end, count, ec: status === 'error' ? 'balance_error' : null, em: errMsg,
+  })
+}

--- a/src/costops/collectors/github.ts
+++ b/src/costops/collectors/github.ts
@@ -74,8 +74,8 @@ export function mapGitHubUsage(
   }]
 }
 
-/** The account whose billing is read. */
-export const GITHUB_BILLING_USER = 'iszzu80-dev'
+/** The account whose billing is read. Set via COSTOPS_GITHUB_BILLING_USER env var. */
+export const GITHUB_BILLING_USER = process.env.COSTOPS_GITHUB_BILLING_USER || ''
 
 export function makeGitHubCollector(user: string = GITHUB_BILLING_USER): ProviderCollector {
   return {

--- a/src/costops/collectors/github.ts
+++ b/src/costops/collectors/github.ts
@@ -1,0 +1,152 @@
+// CostOps -- GitHub billing collector (LIVE, read-only).
+//
+// Uses the GitHub enhanced billing platform usage report
+// (GET /users/{user}/settings/billing/usage) which returns per-line usage with a
+// netAmount (USD). A fine-grained PAT with "Plan: read-only" is required. The
+// mapper is PURE and offline-tested; collect() calls the INJECTED httpGetJson so
+// no network happens unless a real fetcher is passed. The token arrives via
+// opts.secret (from the Vault) and is NEVER logged. Pure GET, no provider write.
+//
+// Unlike usage-billing providers that omit an empty period, GitHub reports an
+// EXPLICIT 0-with-freshness line on a successful empty response, so the dashboard
+// shows a provider_api-observed 0 (not a manual estimate) for a no-usage month.
+
+import { createHash } from 'node:crypto'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine } from './types.js'
+
+const GITHUB_API = 'https://api.github.com'
+const GITHUB_API_SOURCE = 'github'
+
+function hashRef(salt: string, raw: string): string {
+  return createHash('sha256').update(salt).update('|').update(raw).digest('hex').slice(0, 32)
+}
+
+interface GitHubUsageItem {
+  date?: string
+  product?: string
+  sku?: string
+  quantity?: number
+  unitType?: string
+  pricePerUnit?: number
+  grossAmount?: number
+  discountAmount?: number
+  netAmount?: number | string
+  organizationName?: string
+  repositoryName?: string
+}
+interface GitHubUsageReport { usageItems?: GitHubUsageItem[] }
+
+/**
+ * PURE mapper: GitHub billing usage report -> a single aggregated provider_api
+ * line for the github source. netAmount (USD) is summed and converted to HUF.
+ * A valid-but-empty report yields an explicit 0 line (API-observed zero), so the
+ * caller can show GitHub as provider_api with a real freshness even at $0.
+ * Returns [] only when the raw is not a recognizable usage report.
+ */
+export function mapGitHubUsage(
+  raw: unknown,
+  opts: { periodStart: number; periodEnd: number; fxUsdHuf: number; idSalt: string; now: number },
+): NormalizedCostLine[] {
+  const report = (raw && typeof raw === 'object') ? raw as GitHubUsageReport : null
+  if (!report || !Array.isArray(report.usageItems)) return []
+  let usdTotal = 0
+  for (const it of report.usageItems) {
+    const raw2 = it.netAmount
+    const amt = typeof raw2 === 'number' ? raw2 : parseFloat(String(raw2 ?? ''))
+    if (isFinite(amt)) usdTotal += amt
+  }
+  const monthKey = new Date(opts.periodStart * 1000).toISOString().slice(0, 7)
+  const amountHuf = Math.round(usdTotal * opts.fxUsdHuf * 100) / 100
+  return [{
+    provider: 'github',
+    service: GITHUB_API_SOURCE,
+    billing_period_start: opts.periodStart,
+    billing_period_end: opts.periodEnd,
+    amount: amountHuf,
+    currency: 'HUF',
+    confidence: 'provider_api',
+    usage_type: 'usage_billing',
+    quantity: null,
+    unit: null,
+    data_freshness_at: opts.now,
+    raw_ref_hash: hashRef(opts.idSalt, `github-usage|${monthKey}`),
+    dedup_key: `provider|github|${GITHUB_API_SOURCE}|${monthKey}|provider_api`,
+  }]
+}
+
+/** The account whose billing is read. */
+export const GITHUB_BILLING_USER = 'iszzu80-dev'
+
+export function makeGitHubCollector(user: string = GITHUB_BILLING_USER): ProviderCollector {
+  return {
+    provider: 'github',
+    collectorName: 'github-billing-usage',
+    async collectRaw(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }> {
+      const d = new Date(opts.periodStart * 1000)
+      const url = `${GITHUB_API}/users/${user}/settings/billing/usage?year=${d.getUTCFullYear()}&month=${d.getUTCMonth() + 1}`
+      // secret used ONLY as the auth header; never logged.
+      const headers = {
+        'authorization': `Bearer ${opts.secret}`,
+        'accept': 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+      }
+      const raw = await opts.httpGetJson(url, headers)
+      const lines = mapGitHubUsage(raw, {
+        periodStart: opts.periodStart, periodEnd: opts.periodEnd,
+        fxUsdHuf: opts.fxUsdHuf, idSalt: opts.idSalt, now: opts.periodStart,
+      })
+      return { raw, lines }
+    },
+    async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+      return (await this.collectRaw!(opts)).lines
+    },
+  }
+}
+
+export const githubCollector: ProviderCollector = makeGitHubCollector()
+
+/** Vault secret id for the GitHub fine-grained PAT (Plan: read-only). */
+export const GITHUB_VAULT_SECRET_ID = 'github_plan'
+
+/**
+ * LIVE read-only sync: pulls the PAT from the Vault (never logged), reads the
+ * billing usage report for the current month, and records a provider_api line +
+ * import_runs row. No provider-side write.
+ */
+export async function syncGitHubCollector(
+  db: import('better-sqlite3').Database,
+  now: number,
+  deps: { httpGetJson?: import('./types.js').HttpGetJson; apiKey?: string | null; fxUsdHuf?: number } = {},
+): Promise<{ ok: boolean; provider: string; status: string; imported_count: number; error?: string; period?: string }> {
+  const { runCollector } = await import('./runner.js')
+  const { monthWindow } = await import('../ledger.js')
+  let apiKey = deps.apiKey
+  if (apiKey === undefined) {
+    try {
+      const { getSecret } = await import('../../web/vault.js')
+      apiKey = getSecret(GITHUB_VAULT_SECRET_ID)
+    } catch { apiKey = null }
+  }
+  if (!apiKey) {
+    return { ok: false, provider: 'github', status: 'error', imported_count: 0, error: `no GitHub token in vault (${GITHUB_VAULT_SECRET_ID})` }
+  }
+  let fxUsdHuf = deps.fxUsdHuf
+  if (fxUsdHuf === undefined) {
+    try {
+      const { loadRenderPricing } = await import('./render.js')
+      fxUsdHuf = loadRenderPricing().pricing.fx_usd_huf || 0
+    } catch { fxUsdHuf = 0 }
+  }
+  const httpGetJson = deps.httpGetJson || (async (url: string, headers: Record<string, string>) => {
+    const r = await fetch(url, { method: 'GET', headers })
+    if (!r.ok) throw new Error(`github api ${r.status}`)
+    return r.json()
+  })
+  const w = monthWindow(now)
+  const opts = { periodStart: w.start, periodEnd: w.end, secret: apiKey, fxUsdHuf: fxUsdHuf || 0, idSalt: 'github-salt', httpGetJson }
+  const res = await runCollector({ db, collector: githubCollector, opts, now })
+  return {
+    ok: res.status === 'ok', provider: 'github', status: res.status,
+    imported_count: res.importedCount, error: res.errorMessageSanitized || undefined, period: w.key,
+  }
+}

--- a/src/costops/collectors/import-durability.ts
+++ b/src/costops/collectors/import-durability.ts
@@ -1,0 +1,126 @@
+// CostOps Phase 1 (GAP-07) -- collector durability primitives shared by every
+// provider collector via the common runner.ts entry point (runCollector),
+// so a single change here benefits openai/github/deepseek/render at once
+// instead of retrofitting each collector individually.
+//
+// Two independent concerns:
+// 1. Per-provider import lock: prevents two concurrent syncs of the SAME
+//    provider from racing each other's upserts (e.g. a manual "sync now"
+//    click while the scheduled sync is already running). A stale lock (the
+//    holder crashed mid-run and never released it) is reclaimed after
+//    `staleAfterSecs` -- otherwise a crash would permanently wedge that
+//    provider's sync. `now`/`locked_at` are epoch SECONDS, matching every
+//    other `now` in this codebase (Math.floor(Date.now()/1000)) -- NOT ms.
+// 2. Retry/backoff for a transient error (network blip, rate limit) --
+//    generic, injectable sleep so it's unit-testable without real delays.
+
+import type Database from 'better-sqlite3'
+
+export interface ImportLockContext {
+  /** Atomically claim the lock. Returns 'acquired' if this call won it
+   * (including reclaiming a stale one), 'held' if someone else genuinely
+   * holds a fresh lock. */
+  tryAcquireLock(provider: string, token: string, now: number, staleAfterSecs: number): 'acquired' | 'held'
+  /** Release the lock, but ONLY if it's still held by this exact token --
+   * guards against releasing a lock a third party has since reclaimed after
+   * this holder's own lock went stale and was stolen. */
+  releaseLock(provider: string, token: string): void
+}
+
+export function buildDbImportLockContext(db: Database.Database): ImportLockContext {
+  return {
+    tryAcquireLock(provider, token, now, staleAfterSecs) {
+      const existing = db.prepare(`SELECT locked_at, lock_token FROM import_locks WHERE provider = ?`).get(provider) as { locked_at: number; lock_token: string } | undefined
+      if (!existing) {
+        db.prepare(`INSERT INTO import_locks (provider, locked_at, lock_token) VALUES (?, ?, ?)`).run(provider, now, token)
+        return 'acquired'
+      }
+      const isStale = now - existing.locked_at > staleAfterSecs
+      if (!isStale) return 'held'
+      // Reclaim: only if it still matches what we just read (guards a race
+      // between two reclaimers -- whichever UPDATE actually matches wins).
+      const res = db.prepare(`UPDATE import_locks SET locked_at = ?, lock_token = ? WHERE provider = ? AND lock_token = ?`)
+        .run(now, token, provider, existing.lock_token)
+      return res.changes > 0 ? 'acquired' : 'held'
+    },
+    releaseLock(provider, token) {
+      db.prepare(`DELETE FROM import_locks WHERE provider = ? AND lock_token = ?`).run(provider, token)
+    },
+  }
+}
+
+export interface WithImportLockOptions {
+  /** A crashed holder's lock is reclaimable after this long, in SECONDS
+   * (matching `now`). Default 600 (10 minutes) -- comfortably longer than
+   * any real collector call, short enough that a genuine crash doesn't
+   * wedge a provider for hours. */
+  staleAfterSecs?: number
+}
+
+export type ImportLockResult<T> = { ok: true; result: T } | { ok: false; reason: 'locked' }
+
+/**
+ * Run `fn` only if the per-provider lock is acquired; otherwise returns
+ * `{ ok: false, reason: 'locked' }` without calling `fn` at all -- the caller
+ * (runCollector) records this as an ImportStatus of 'locked', touching no
+ * data. Always releases the lock afterward, success or failure, via
+ * try/finally.
+ */
+export async function withImportLock<T>(
+  ctx: ImportLockContext,
+  provider: string,
+  now: number,
+  fn: () => Promise<T>,
+  opts: WithImportLockOptions = {},
+): Promise<ImportLockResult<T>> {
+  const staleAfterSecs = opts.staleAfterSecs ?? 10 * 60
+  const token = `${now}-${Math.random().toString(36).slice(2)}`
+  if (ctx.tryAcquireLock(provider, token, now, staleAfterSecs) === 'held') {
+    return { ok: false, reason: 'locked' }
+  }
+  try {
+    const result = await fn()
+    return { ok: true, result }
+  } finally {
+    ctx.releaseLock(provider, token)
+  }
+}
+
+// ---- retry/backoff ----------------------------------------------------------
+
+export interface WithRetryOptions {
+  maxAttempts?: number
+  baseDelayMs?: number
+  /** Injectable for tests -- default is a real setTimeout-based sleep. */
+  sleep?: (ms: number) => Promise<void>
+  /** Only retry errors this returns true for. Default: retry everything --
+   * callers with a way to distinguish permanent errors (bad credentials)
+   * from transient ones (timeout, rate limit) should narrow this. */
+  isRetryable?: (err: unknown) => boolean
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * Retry `fn` with exponential backoff (baseDelayMs * 2^attempt) up to
+ * maxAttempts total tries. Re-throws the LAST error if every attempt fails
+ * and it was retryable; re-throws IMMEDIATELY (no further attempts) the
+ * moment `isRetryable` says an error is permanent.
+ */
+export async function withRetry<T>(fn: () => Promise<T>, opts: WithRetryOptions = {}): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? 3
+  const baseDelayMs = opts.baseDelayMs ?? 500
+  const sleep = opts.sleep ?? defaultSleep
+  const isRetryable = opts.isRetryable ?? (() => true)
+  let lastErr: unknown
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastErr = err
+      if (!isRetryable(err) || attempt === maxAttempts - 1) throw err
+      await sleep(baseDelayMs * Math.pow(2, attempt))
+    }
+  }
+  throw lastErr
+}

--- a/src/costops/collectors/openai.ts
+++ b/src/costops/collectors/openai.ts
@@ -1,0 +1,143 @@
+// CostOps -- OpenAI cost collector (LIVE, read-only).
+//
+// Uses the OpenAI Costs API (GET /v1/organizations/costs) which returns daily
+// USD cost buckets and REQUIRES an admin key. The mapper is a PURE function
+// tested offline against a fixture; collect() calls the INJECTED httpGetJson so
+// no network happens unless a real fetcher is passed. The admin key arrives via
+// opts.secret (from the Vault) and is NEVER logged or persisted. No provider-
+// side write ever happens (pure GET).
+
+import { createHash } from 'node:crypto'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine } from './types.js'
+
+const OPENAI_COSTS_URL = 'https://api.openai.com/v1/organizations/costs'
+// All OpenAI API usage reconciles against this source id (matches the manual
+// 'openai-api' / 'openai-chatgpt' line family so estimate and actual share it).
+const OPENAI_API_SOURCE = 'openai-api'
+
+function hashRef(salt: string, raw: string): string {
+  return createHash('sha256').update(salt).update('|').update(raw).digest('hex').slice(0, 32)
+}
+
+interface OpenAiAmount { value?: number | string; currency?: string }
+interface OpenAiCostResult { amount?: OpenAiAmount; line_item?: string | null; project_id?: string | null }
+interface OpenAiCostBucket { start_time?: number; end_time?: number; results?: OpenAiCostResult[] }
+interface OpenAiCostsPage { object?: string; data?: OpenAiCostBucket[]; has_more?: boolean; next_page?: string | null }
+
+/**
+ * PURE mapper: OpenAI /organizations/costs page -> a single aggregated
+ * provider_api line for the openai-api source for the requested period. Daily
+ * USD amounts are summed and converted to HUF via fxUsdHuf. Deterministic; no
+ * I/O. Returns [] if the page carries no cost results (so an all-zero month can
+ * still be reported by the caller as an explicit 0-with-freshness line).
+ */
+export function mapOpenAiCosts(
+  raw: unknown,
+  opts: { periodStart: number; periodEnd: number; fxUsdHuf: number; idSalt: string; now: number },
+): NormalizedCostLine[] {
+  const page = (raw && typeof raw === 'object') ? raw as OpenAiCostsPage : {}
+  const buckets = Array.isArray(page.data) ? page.data : []
+  let usdTotal = 0
+  let latestEnd = 0
+  let any = false
+  for (const b of buckets) {
+    if (typeof b.end_time === 'number' && b.end_time > latestEnd) latestEnd = b.end_time
+    for (const r of (Array.isArray(b.results) ? b.results : [])) {
+      const rawAmt = r.amount?.value
+      const amt = typeof rawAmt === 'number' ? rawAmt : parseFloat(String(rawAmt ?? ''))
+      if (!isFinite(amt)) continue
+      // OpenAI costs are USD. Non-USD is not expected; if seen, still sum the
+      // numeric value and let the live-verify step flag the currency mismatch.
+      usdTotal += amt
+      any = true
+    }
+  }
+  if (!any) return []
+  const monthKey = new Date(opts.periodStart * 1000).toISOString().slice(0, 7)
+  const amountHuf = Math.round(usdTotal * opts.fxUsdHuf * 100) / 100
+  return [{
+    provider: 'openai',
+    service: OPENAI_API_SOURCE,
+    billing_period_start: opts.periodStart,
+    billing_period_end: opts.periodEnd,
+    amount: amountHuf,
+    currency: 'HUF',
+    confidence: 'provider_api',
+    usage_type: 'api_usage',
+    quantity: null,
+    unit: null,
+    data_freshness_at: latestEnd || opts.now,
+    raw_ref_hash: hashRef(opts.idSalt, `openai-costs|${monthKey}`),
+    dedup_key: `provider|openai|${OPENAI_API_SOURCE}|${monthKey}|provider_api`,
+  }]
+}
+
+export const openaiCollector: ProviderCollector = {
+  provider: 'openai',
+  collectorName: 'openai-costs',
+  async collectRaw(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }> {
+    // OpenAI Costs API takes unix start_time; daily buckets; limit covers a month.
+    const url = `${OPENAI_COSTS_URL}?start_time=${opts.periodStart}&end_time=${opts.periodEnd}&bucket_width=1d&limit=31`
+    // secret used ONLY as the auth header; never logged.
+    const headers = {
+      'authorization': `Bearer ${opts.secret}`,
+      'content-type': 'application/json',
+    }
+    const raw = await opts.httpGetJson(url, headers)
+    const lines = mapOpenAiCosts(raw, {
+      periodStart: opts.periodStart, periodEnd: opts.periodEnd,
+      fxUsdHuf: opts.fxUsdHuf, idSalt: opts.idSalt, now: opts.periodStart,
+    })
+    return { raw, lines }
+  },
+  async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+    return (await this.collectRaw!(opts)).lines
+  },
+}
+
+/** Vault secret id for the OpenAI admin (read-only) key. */
+export const OPENAI_VAULT_SECRET_ID = 'open_api_adminkey_readonly'
+
+/**
+ * LIVE read-only sync: pulls the admin key from the Vault (never logged), calls
+ * the Costs API for the current month, and records a provider_api line + an
+ * import_runs row. No provider-side write. Injected deps let tests stub both the
+ * key and the fetcher.
+ */
+export async function syncOpenAiCollector(
+  db: import('better-sqlite3').Database,
+  now: number,
+  deps: { httpGetJson?: import('./types.js').HttpGetJson; apiKey?: string | null; fxUsdHuf?: number } = {},
+): Promise<{ ok: boolean; provider: string; status: string; imported_count: number; error?: string; period?: string }> {
+  const { runCollector } = await import('./runner.js')
+  const { monthWindow } = await import('../ledger.js')
+  let apiKey = deps.apiKey
+  if (apiKey === undefined) {
+    try {
+      const { getSecret } = await import('../../web/vault.js')
+      apiKey = getSecret(OPENAI_VAULT_SECRET_ID)
+    } catch { apiKey = null }
+  }
+  if (!apiKey) {
+    return { ok: false, provider: 'openai', status: 'error', imported_count: 0, error: `no OpenAI key in vault (${OPENAI_VAULT_SECRET_ID})` }
+  }
+  let fxUsdHuf = deps.fxUsdHuf
+  if (fxUsdHuf === undefined) {
+    try {
+      const { loadRenderPricing } = await import('./render.js')
+      fxUsdHuf = loadRenderPricing().pricing.fx_usd_huf || 0
+    } catch { fxUsdHuf = 0 }
+  }
+  const httpGetJson = deps.httpGetJson || (async (url: string, headers: Record<string, string>) => {
+    const r = await fetch(url, { method: 'GET', headers })
+    if (!r.ok) throw new Error(`openai api ${r.status}`)
+    return r.json()
+  })
+  const w = monthWindow(now)
+  const opts = { periodStart: w.start, periodEnd: w.end, secret: apiKey, fxUsdHuf: fxUsdHuf || 0, idSalt: 'openai-salt', httpGetJson }
+  const res = await runCollector({ db, collector: openaiCollector, opts, now })
+  return {
+    ok: res.status === 'ok', provider: 'openai', status: res.status,
+    imported_count: res.importedCount, error: res.errorMessageSanitized || undefined, period: w.key,
+  }
+}

--- a/src/costops/collectors/render-pricing.example.json
+++ b/src/costops/collectors/render-pricing.example.json
@@ -1,0 +1,15 @@
+{
+  "_doc": "CostOps v0.3 Render plan->USD/month map EXAMPLE. Copy to store/costops-render-pricing.json (gitignored) and fill REAL Render list prices + fx_usd_huf. All zero here (safe example, no real amounts). Unknown plan -> unpriced warning, never a fabricated amount. static_site/suspended = 0. Overage/seat/tax NOT modelled (see not_covered).",
+  "version": 1,
+  "currency": "HUF",
+  "fx_usd_huf": 0,
+  "plans": {
+    "web_service": { "free": 0, "starter": 0, "standard": 0, "pro": 0, "pro_plus": 0, "pro_max": 0, "pro_ultra": 0 },
+    "private_service": { "free": 0, "starter": 0, "standard": 0, "pro": 0 },
+    "background_worker": { "free": 0, "starter": 0, "standard": 0, "pro": 0 },
+    "cron_job": { "starter": 0 },
+    "static_site": { "free": 0 },
+    "postgres": { "free": 0, "basic_256mb": 0, "basic_1gb": 0, "basic_4gb": 0, "pro_4gb": 0 },
+    "key_value": { "free": 0, "starter": 0, "standard": 0, "pro": 0 }
+  }
+}

--- a/src/costops/collectors/render.ts
+++ b/src/costops/collectors/render.ts
@@ -190,6 +190,68 @@ export function mapRenderPlanCost(
   return { lines, breakdown }
 }
 
+// v0.5: read the Render API key WITHOUT logging it. process.env first, then the
+// gitignored root .env. Returns null if absent (caller reports a config error).
+export function getRenderApiKey(): string | null {
+  const fromEnv = process.env.RENDER_API_KEY
+  if (fromEnv && fromEnv.trim()) return fromEnv.trim()
+  try {
+    const envFile = readFileSync(join(PROJECT_ROOT, '.env'), 'utf-8')
+    const line = envFile.split('\n').find(l => l.startsWith('RENDER_API_KEY'))
+    if (line) return line.slice(line.indexOf('=') + 1).trim().replace(/^["']|["']$/g, '')
+  } catch { /* no .env */ }
+  return null
+}
+
+export interface RenderSyncResult {
+  ok: boolean
+  provider: 'render'
+  status: string
+  imported_count: number
+  error?: string
+  service_count?: number
+  total_huf?: number
+  period?: string
+}
+
+/**
+ * v0.5 sync spine: run the Render collector LIVE (read-only GET) and idempotently
+ * import the aggregated provider_plan_estimate line for the current month, storing
+ * a sanitized breakdown on the import_runs row. NO provider-side write. Injected
+ * httpGetJson defaults to a real GET fetcher; tests pass a stub.
+ */
+export async function syncRenderCollector(
+  db: import('better-sqlite3').Database,
+  now: number,
+  deps: { httpGetJson?: import('./types.js').HttpGetJson; apiKey?: string | null } = {},
+): Promise<RenderSyncResult> {
+  const { runCollector } = await import('./runner.js')
+  const { monthWindow } = await import('../ledger.js')
+  const { pricing } = loadRenderPricing()
+  const apiKey = deps.apiKey !== undefined ? deps.apiKey : getRenderApiKey()
+  if (!apiKey) return { ok: false, provider: 'render', status: 'error', imported_count: 0, error: 'no RENDER_API_KEY configured' }
+  const httpGetJson = deps.httpGetJson || (async (url: string, headers: Record<string, string>) => {
+    const r = await fetch(url, { method: 'GET', headers })
+    if (!r.ok) throw new Error(`render api ${r.status}`)
+    return r.json()
+  })
+  const w = monthWindow(now)
+  const collector = makeRenderCollector(pricing)
+  const opts = { periodStart: w.start, periodEnd: w.end, secret: apiKey, fxUsdHuf: pricing.fx_usd_huf, idSalt: 'render-salt', httpGetJson }
+  // pre-compute the sanitized breakdown for the run detail (no raw IDs)
+  let detail: RenderBreakdown | null = null
+  try {
+    const { raw } = await collector.collectRaw!(opts)
+    detail = mapRenderPlanCost(raw, { periodStart: w.start, periodEnd: w.end, pricing, idSalt: 'render-salt', now }).breakdown
+  } catch { /* runCollector will re-run + record the sanitized error */ }
+  const res = await runCollector({ db, collector, opts, now, detailJson: detail ? JSON.stringify(detail) : undefined })
+  return {
+    ok: res.status === 'ok', provider: 'render', status: res.status, imported_count: res.importedCount,
+    error: res.errorMessageSanitized || undefined,
+    service_count: detail?.service_count, total_huf: detail?.total_huf, period: w.key,
+  }
+}
+
 /** Build the Render collector bound to a loaded pricing config. READ-ONLY. */
 export function makeRenderCollector(pricing: RenderPricing): ProviderCollector {
   return {

--- a/src/costops/collectors/render.ts
+++ b/src/costops/collectors/render.ts
@@ -1,0 +1,215 @@
+// CostOps v0.3 -- Render plan-based infra cost collector.
+//
+// READ-ONLY. Enumerates Render services (+ postgres) and maps their PLAN to a
+// monthly HUF estimate from a local, configurable plan->price map. This is a
+// `provider_plan_estimate` (advisory) -- NOT an invoice, NOT provider_api actual.
+// It never modifies any Render resource. Raw service/account IDs are NEVER stored
+// or returned: only a hashed ref + a sanitized type/plan label. The API key is
+// used only as an auth header (in the live fetcher) and is never logged/persisted.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+import { PROJECT_ROOT } from '../../config.js'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine } from './types.js'
+
+export const RENDER_PRICING_PATH = join(PROJECT_ROOT, 'store', 'costops-render-pricing.json')
+export const RENDER_PRICING_EXAMPLE = join(PROJECT_ROOT, 'src', 'costops', 'collectors', 'render-pricing.example.json')
+
+const RENDER_SERVICES_URL = 'https://api.render.com/v1/services?limit=100'
+const RENDER_POSTGRES_URL = 'https://api.render.com/v1/postgres?limit=100'
+
+export interface RenderPricing {
+  version: number
+  currency: string
+  fx_usd_huf: number
+  plans: Record<string, Record<string, number>>  // type -> plan -> USD/month
+}
+
+function hashRef(salt: string, raw: string): string {
+  return createHash('sha256').update(salt).update('|').update(raw).digest('hex').slice(0, 32)
+}
+
+/** Load the local (gitignored) Render plan->price map. Missing -> zero-rate, flagged. */
+export function loadRenderPricing(): { pricing: RenderPricing; exists: boolean } {
+  const empty: RenderPricing = { version: 1, currency: 'HUF', fx_usd_huf: 0, plans: {} }
+  if (!existsSync(RENDER_PRICING_PATH)) {
+    // write a safe zero-rate example next to the config for guidance (once)
+    try {
+      if (!existsSync(RENDER_PRICING_EXAMPLE)) {
+        writeFileSync(RENDER_PRICING_EXAMPLE, JSON.stringify(EXAMPLE_PRICING, null, 2) + '\n')
+      }
+    } catch { /* best effort */ }
+    return { pricing: empty, exists: false }
+  }
+  try {
+    const raw = JSON.parse(readFileSync(RENDER_PRICING_PATH, 'utf-8')) as Partial<RenderPricing>
+    return {
+      pricing: {
+        version: typeof raw.version === 'number' ? raw.version : 1,
+        currency: typeof raw.currency === 'string' ? raw.currency : 'HUF',
+        fx_usd_huf: typeof raw.fx_usd_huf === 'number' ? raw.fx_usd_huf : 0,
+        plans: (raw.plans && typeof raw.plans === 'object') ? raw.plans as RenderPricing['plans'] : {},
+      },
+      exists: true,
+    }
+  } catch {
+    return { pricing: empty, exists: true }
+  }
+}
+
+const EXAMPLE_PRICING = {
+  _doc: 'CostOps v0.3 Render plan->USD/month map. Copy to store/costops-render-pricing.json (gitignored) and fill REAL Render list prices + fx_usd_huf. All zero here (safe example). Unknown plan -> unpriced warning, never a fabricated amount. static_site/suspended = 0. Overage/seat/tax NOT modelled (see not_covered).',
+  version: 1,
+  currency: 'HUF',
+  fx_usd_huf: 0,
+  plans: {
+    web_service: { free: 0, starter: 0, standard: 0, pro: 0, pro_plus: 0, pro_max: 0, pro_ultra: 0 },
+    private_service: { starter: 0, standard: 0, pro: 0 },
+    background_worker: { starter: 0, standard: 0, pro: 0 },
+    cron_job: { starter: 0 },
+    static_site: { free: 0 },
+    postgres: { free: 0, basic_256mb: 0, basic_1gb: 0, basic_4gb: 0, pro: 0 },
+    key_value: { starter: 0, standard: 0, pro: 0 },
+  },
+}
+
+// ---- normalized shapes seen from the Render API (READ) ----------------------
+interface RenderServiceDetails { plan?: string; numInstances?: number; env?: string; region?: string }
+interface RenderService { id?: string; name?: string; type?: string; suspended?: string; serviceDetails?: RenderServiceDetails }
+interface RenderPostgres { id?: string; name?: string; plan?: string; suspended?: string; status?: string }
+
+export interface RenderBreakdown {
+  service_count: number
+  by_type_plan: Record<string, { count: number; usd: number }>   // "web_service/starter" -> {...}
+  unpriced: Array<{ type: string; plan: string; count: number }>
+  undercount_flags: string[]
+  suspended_count: number
+  total_usd: number
+  total_huf: number
+  fx_usd_huf: number
+}
+
+const RENDER_SOURCE = 'render-plan'
+
+/**
+ * PURE mapper: {services, postgres} raw -> ONE aggregated provider_plan_estimate
+ * line for the render-plan source + a breakdown. Deterministic, no I/O, no secret.
+ * static_site/suspended -> 0. Unknown plan -> unpriced (0 + flag), never fabricated.
+ */
+export function mapRenderPlanCost(
+  raw: unknown,
+  opts: { periodStart: number; periodEnd: number; pricing: RenderPricing; idSalt: string; now: number },
+): { lines: NormalizedCostLine[]; breakdown: RenderBreakdown } {
+  const r = (raw && typeof raw === 'object') ? raw as { services?: unknown; postgres?: unknown } : {}
+  const serviceItems = Array.isArray(r.services) ? r.services : []
+  const pgItems = Array.isArray(r.postgres) ? r.postgres : []
+  const plans = opts.pricing.plans || {}
+  const fx = opts.pricing.fx_usd_huf || 0
+
+  const by_type_plan: RenderBreakdown['by_type_plan'] = {}
+  const unpricedMap = new Map<string, { type: string; plan: string; count: number }>()
+  const flags: string[] = []
+  let total_usd = 0
+  let count = 0
+  let suspended_count = 0
+  let staticCount = 0
+  let missingInstances = 0
+
+  const addUnit = (type: string, plan: string, suspended: boolean) => {
+    count++
+    if (suspended) { suspended_count++; return }  // suspended -> not billed
+    if (type === 'static_site') { staticCount++; return }  // free flat; bandwidth uncounted
+    const table = plans[type]
+    const price = table ? table[plan] : undefined
+    if (typeof price !== 'number') {
+      const key = `${type}/${plan || 'unknown'}`
+      const u = unpricedMap.get(key) || { type, plan: plan || 'unknown', count: 0 }
+      u.count++; unpricedMap.set(key, u)
+      return
+    }
+    total_usd += price
+    const key = `${type}/${plan}`
+    const b = by_type_plan[key] || { count: 0, usd: 0 }
+    b.count++; b.usd = Math.round((b.usd + price) * 100) / 100
+    by_type_plan[key] = b
+  }
+
+  for (const it of serviceItems) {
+    const svc = (it && typeof it === 'object' && 'service' in (it as object))
+      ? (it as { service: RenderService }).service
+      : (it as RenderService)
+    const type = String(svc?.type || 'unknown')
+    const plan = String(svc?.serviceDetails?.plan || (type === 'static_site' ? 'free' : ''))
+    const suspended = !!svc?.suspended && svc.suspended !== 'not_suspended'
+    let instances = svc?.serviceDetails?.numInstances
+    if (typeof instances !== 'number' || instances < 1) { instances = 1; if (type !== 'static_site' && !suspended) missingInstances++ }
+    for (let i = 0; i < instances; i++) addUnit(type, plan, suspended)
+  }
+  for (const it of pgItems) {
+    const pg = (it && typeof it === 'object' && 'postgres' in (it as object))
+      ? (it as { postgres: RenderPostgres }).postgres
+      : (it as RenderPostgres)
+    const suspended = !!pg?.suspended && pg.suspended !== 'not_suspended'
+    addUnit('postgres', String(pg?.plan || ''), suspended)
+  }
+
+  const unpriced = [...unpricedMap.values()]
+  if (staticCount > 0) flags.push(`${staticCount} static_site: bandwidth overage not counted (0 Ft)`)
+  if (missingInstances > 0) flags.push(`${missingInstances} service(s): instance count missing -> counted as 1`)
+  if (unpriced.length > 0) flags.push(`${unpriced.reduce((s, u) => s + u.count, 0)} service(s): unknown/unpriced plan -> excluded from total`)
+  if (pgItems.length === 0) flags.push('no postgres resources seen (if you have DBs, add /v1/postgres pricing)')
+  if (fx <= 0) flags.push('fx_usd_huf missing/zero -> HUF total is 0; set it in the pricing config')
+
+  const total_huf = Math.round(total_usd * fx * 100) / 100
+  const monthKey = new Date(opts.periodStart * 1000).toISOString().slice(0, 7)
+
+  const breakdown: RenderBreakdown = {
+    service_count: count, by_type_plan, unpriced, undercount_flags: flags,
+    suspended_count, total_usd: Math.round(total_usd * 100) / 100, total_huf, fx_usd_huf: fx,
+  }
+
+  // No line if there is literally nothing priced (keeps the ledger clean); the
+  // breakdown still carries flags for the report.
+  const lines: NormalizedCostLine[] = total_huf > 0 ? [{
+    provider: 'render',
+    service: RENDER_SOURCE,
+    billing_period_start: opts.periodStart,
+    billing_period_end: opts.periodEnd,
+    amount: total_huf,
+    currency: 'HUF',
+    confidence: 'provider_plan_estimate',
+    usage_type: 'plan_estimate',
+    quantity: count,
+    unit: 'service',
+    data_freshness_at: opts.now,
+    raw_ref_hash: hashRef(opts.idSalt, `render-plan|${monthKey}`),
+    dedup_key: `provider|render|${RENDER_SOURCE}|${monthKey}|provider_plan_estimate`,
+  }] : []
+
+  return { lines, breakdown }
+}
+
+/** Build the Render collector bound to a loaded pricing config. READ-ONLY. */
+export function makeRenderCollector(pricing: RenderPricing): ProviderCollector {
+  return {
+    provider: 'render',
+    collectorName: 'render-plan-report',
+    async collectRaw(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }> {
+      // secret used ONLY as the auth header; never logged.
+      const headers = { authorization: `Bearer ${opts.secret}`, accept: 'application/json' }
+      const services = await opts.httpGetJson(RENDER_SERVICES_URL, headers)
+      let postgres: unknown = []
+      try { postgres = await opts.httpGetJson(RENDER_POSTGRES_URL, headers) } catch { postgres = [] }
+      const raw = { services, postgres }
+      const { lines } = mapRenderPlanCost(raw, {
+        periodStart: opts.periodStart, periodEnd: opts.periodEnd,
+        pricing, idSalt: opts.idSalt, now: opts.periodStart,
+      })
+      return { raw, lines }
+    },
+    async collect(opts: CollectOpts): Promise<NormalizedCostLine[]> {
+      return (await this.collectRaw!(opts)).lines
+    },
+  }
+}

--- a/src/costops/collectors/render.ts
+++ b/src/costops/collectors/render.ts
@@ -23,6 +23,10 @@ export interface RenderPricing {
   version: number
   currency: string
   fx_usd_huf: number
+  // v0.8 (card 6f4d1332): toHuf() (email-ingest.ts) previously only knew USD -> EUR-denominated
+  // invoices came back unconvertible (null), even though EUR is the requirements' own worked
+  // example. 0 (unset) is treated the same as fx_usd_huf's existing "missing" convention.
+  fx_eur_huf: number
   plans: Record<string, Record<string, number>>  // type -> plan -> USD/month
 }
 
@@ -32,7 +36,7 @@ function hashRef(salt: string, raw: string): string {
 
 /** Load the local (gitignored) Render plan->price map. Missing -> zero-rate, flagged. */
 export function loadRenderPricing(): { pricing: RenderPricing; exists: boolean } {
-  const empty: RenderPricing = { version: 1, currency: 'HUF', fx_usd_huf: 0, plans: {} }
+  const empty: RenderPricing = { version: 1, currency: 'HUF', fx_usd_huf: 0, fx_eur_huf: 0, plans: {} }
   if (!existsSync(RENDER_PRICING_PATH)) {
     // write a safe zero-rate example next to the config for guidance (once)
     try {
@@ -49,6 +53,7 @@ export function loadRenderPricing(): { pricing: RenderPricing; exists: boolean }
         version: typeof raw.version === 'number' ? raw.version : 1,
         currency: typeof raw.currency === 'string' ? raw.currency : 'HUF',
         fx_usd_huf: typeof raw.fx_usd_huf === 'number' ? raw.fx_usd_huf : 0,
+        fx_eur_huf: typeof raw.fx_eur_huf === 'number' ? raw.fx_eur_huf : 0,
         plans: (raw.plans && typeof raw.plans === 'object') ? raw.plans as RenderPricing['plans'] : {},
       },
       exists: true,
@@ -63,6 +68,7 @@ const EXAMPLE_PRICING = {
   version: 1,
   currency: 'HUF',
   fx_usd_huf: 0,
+  fx_eur_huf: 0,
   plans: {
     web_service: { free: 0, starter: 0, standard: 0, pro: 0, pro_plus: 0, pro_max: 0, pro_ultra: 0 },
     private_service: { starter: 0, standard: 0, pro: 0 },
@@ -191,16 +197,26 @@ export function mapRenderPlanCost(
 }
 
 // v0.5: read the Render API key WITHOUT logging it. process.env first, then the
-// gitignored root .env. Returns null if absent (caller reports a config error).
+// gitignored root .env, then the devops-only relocation path (686a7823/0ff0a457:
+// moved out of the shared root .env so build-agent CLAUDE.md files, which never
+// reference this path, don't incidentally point at it). Returns null if absent
+// (caller reports a config error).
+function readKeyFromEnvFile(path: string): string | null {
+  try {
+    const envFile = readFileSync(path, 'utf-8')
+    const line = envFile.split('\n').find(l => l.startsWith('RENDER_API_KEY'))
+    if (line) return line.slice(line.indexOf('=') + 1).trim().replace(/^["']|["']$/g, '')
+  } catch { /* file missing */ }
+  return null
+}
+
 export function getRenderApiKey(): string | null {
   const fromEnv = process.env.RENDER_API_KEY
   if (fromEnv && fromEnv.trim()) return fromEnv.trim()
-  try {
-    const envFile = readFileSync(join(PROJECT_ROOT, '.env'), 'utf-8')
-    const line = envFile.split('\n').find(l => l.startsWith('RENDER_API_KEY'))
-    if (line) return line.slice(line.indexOf('=') + 1).trim().replace(/^["']|["']$/g, '')
-  } catch { /* no .env */ }
-  return null
+  return (
+    readKeyFromEnvFile(join(PROJECT_ROOT, '.env')) ??
+    readKeyFromEnvFile(join(PROJECT_ROOT, 'agents', 'devops', '.env.render'))
+  )
 }
 
 export interface RenderSyncResult {

--- a/src/costops/collectors/runner.ts
+++ b/src/costops/collectors/runner.ts
@@ -7,7 +7,7 @@
 // Secrets never enter the DB, logs, or the returned result.
 
 import type Database from 'better-sqlite3'
-import type { ProviderCollector, CollectOpts, NormalizedCostLine, ImportRunResult, ImportStatus } from './types.js'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine, ImportRunResult, ImportStatus, ShapeNode, DryRunReport } from './types.js'
 
 /** Redact anything that looks like a key/token before it can reach a log/DB. */
 export function sanitizeError(err: unknown): { code: string; message: string } {
@@ -58,11 +58,103 @@ function upsertProviderLines(db: Database.Database, lines: NormalizedCostLine[],
   return tx(lines)
 }
 
+/**
+ * Describe a value's STRUCTURE only -- types, object keys, and array lengths.
+ * NEVER includes a scalar value, so no secret / account id / invoice ref / raw
+ * provider datum can leak through it. Depth-bounded to stay finite.
+ */
+export function describeShape(value: unknown, depth = 0): ShapeNode {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  if (Array.isArray(value)) {
+    return { type: 'array', length: value.length, of: value.length ? describeShape(value[0], depth + 1) : 'undefined' }
+  }
+  const t = typeof value
+  if (t === 'string') return 'string'
+  if (t === 'number') return 'number'
+  if (t === 'boolean') return 'boolean'
+  if (t === 'object') {
+    const keys: Record<string, ShapeNode> = {}
+    if (depth < 6) for (const k of Object.keys(value as Record<string, unknown>)) {
+      keys[k] = describeShape((value as Record<string, unknown>)[k], depth + 1)
+    }
+    return { type: 'object', keys }
+  }
+  return 'undefined' // functions/symbols are not represented
+}
+
 export interface RunCollectorArgs {
   db: Database.Database
   collector: ProviderCollector
   opts: CollectOpts
   now: number
+}
+
+export interface DryRunArgs {
+  db: Database.Database
+  collector: ProviderCollector
+  opts: CollectOpts
+  now: number
+  // If true (default), record an audit row in import_runs with status='dry_run'
+  // and imported_count=0 (NO cost line, NO secret, NO raw provider datum). If
+  // false, persist nothing at all.
+  recordRun?: boolean
+}
+
+/**
+ * DRY-RUN a collector: fetch + normalize exactly like a real run, but write NO
+ * provider_api cost_line_items. It returns the planned normalized lines, their
+ * dedup_keys, and a sanitized SHAPE of the provider response (types only). The
+ * only optional write is a status='dry_run' import_runs audit row (count 0).
+ * Secret-free by construction: raw responses and secrets never reach the DB,
+ * the log, or the returned report.
+ */
+export async function dryRunCollector(args: DryRunArgs): Promise<DryRunReport> {
+  const { db, collector, opts, now } = args
+  const recordRun = args.recordRun !== false
+  let status: 'dry_run' | 'error' = 'dry_run'
+  let plannedLines: NormalizedCostLine[] = []
+  let responseShape: ShapeNode | null = null
+  let errorCode: string | null = null
+  let errorMsg: string | null = null
+  let freshness: number | null = null
+  try {
+    if (collector.collectRaw) {
+      const { raw, lines } = await collector.collectRaw(opts)
+      responseShape = describeShape(raw)   // types only -- never values
+      plannedLines = lines
+    } else {
+      // No raw access on this collector -> lines only, shape unavailable.
+      plannedLines = await collector.collect(opts)
+      responseShape = null
+    }
+    freshness = plannedLines.reduce((m, l) => Math.max(m, l.data_freshness_at), 0) || now
+  } catch (err) {
+    status = 'error'
+    const s = sanitizeError(err)
+    errorCode = s.code
+    errorMsg = s.message
+  }
+  // CRITICAL: no provider_api cost_line_items are ever written in a dry-run.
+  // Optionally leave a clearly-marked audit trail (no cost, no secret, no raw).
+  if (recordRun) {
+    db.prepare(`
+      INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status,
+        period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at)
+      VALUES (@provider, @collector, @started, @finished, @status, @ps, @pe, 0, @ecode, @emsg, @fresh)
+    `).run({
+      provider: collector.provider, collector: collector.collectorName,
+      started: now, finished: now, status,
+      ps: opts.periodStart, pe: opts.periodEnd,
+      ecode: errorCode, emsg: errorMsg, fresh: freshness,
+    })
+  }
+  return {
+    provider: collector.provider, collectorName: collector.collectorName,
+    status, plannedLines, dedupKeys: plannedLines.map(l => l.dedup_key),
+    responseShape, wouldImportCount: plannedLines.length,
+    errorCode, errorMessageSanitized: errorMsg,
+  }
 }
 
 /**

--- a/src/costops/collectors/runner.ts
+++ b/src/costops/collectors/runner.ts
@@ -88,6 +88,9 @@ export interface RunCollectorArgs {
   collector: ProviderCollector
   opts: CollectOpts
   now: number
+  // v0.5: optional sanitized per-run detail JSON (breakdown) stored on import_runs.
+  // MUST be secret-free and contain no raw account/service IDs (type/plan labels only).
+  detailJson?: string
 }
 
 export interface DryRunArgs {
@@ -166,9 +169,9 @@ export async function runCollector(args: RunCollectorArgs): Promise<ImportRunRes
   const { db, collector, opts, now } = args
   const insertRun = db.prepare(`
     INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status,
-      period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at)
+      period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at, detail_json)
     VALUES (@provider, @collector, @started, @finished, @status,
-      @ps, @pe, @count, @ecode, @emsg, @fresh)
+      @ps, @pe, @count, @ecode, @emsg, @fresh, @detail)
   `)
   let status: ImportStatus = 'ok'
   let importedCount = 0
@@ -190,7 +193,7 @@ export async function runCollector(args: RunCollectorArgs): Promise<ImportRunRes
     provider: collector.provider, collector: collector.collectorName,
     started: now, finished: now, status,
     ps: opts.periodStart, pe: opts.periodEnd, count: importedCount,
-    ecode: errorCode, emsg: errorMsg, fresh: freshness,
+    ecode: errorCode, emsg: errorMsg, fresh: freshness, detail: args.detailJson ?? null,
   })
   return {
     provider: collector.provider, collectorName: collector.collectorName,

--- a/src/costops/collectors/runner.ts
+++ b/src/costops/collectors/runner.ts
@@ -1,0 +1,107 @@
+// CostOps v0.3 -- collector runner. Deterministic, no LLM.
+//
+// Loads a collector's normalized lines, upserts them into cost_line_items as
+// confidence='provider_api' (idempotent by dedup_key, NEVER overwriting the
+// manual/estimate rows -- they have a different dedup_key), and records an
+// import_runs row. On error it DELETES NOTHING and records a sanitized failure.
+// Secrets never enter the DB, logs, or the returned result.
+
+import type Database from 'better-sqlite3'
+import type { ProviderCollector, CollectOpts, NormalizedCostLine, ImportRunResult, ImportStatus } from './types.js'
+
+/** Redact anything that looks like a key/token before it can reach a log/DB. */
+export function sanitizeError(err: unknown): { code: string; message: string } {
+  const e = err as { code?: string; name?: string; message?: string; status?: number }
+  const code = String(e?.code ?? e?.status ?? e?.name ?? 'error').slice(0, 40)
+  let msg = String(e?.message ?? 'collector error').slice(0, 300)
+  msg = msg
+    .replace(/sk-[A-Za-z0-9_-]{6,}/g, 'sk-***')
+    .replace(/(x-api-key|authorization|bearer)\s*[:=]\s*\S+/gi, '$1 ***')
+    .replace(/[A-Za-z0-9_-]{32,}/g, '***')
+  return { code, message: msg }
+}
+
+function upsertProviderLines(db: Database.Database, lines: NormalizedCostLine[], now: number): number {
+  const upsertSource = db.prepare(`
+    INSERT INTO cost_sources (id, name, provider, source_type, account_ref, currency, active, created_at, updated_at)
+    VALUES (@id, @id, @provider, 'usage', NULL, @currency, 1, @now, @now)
+    ON CONFLICT(id) DO UPDATE SET provider=excluded.provider, updated_at=excluded.updated_at
+  `)
+  const upsertLine = db.prepare(`
+    INSERT INTO cost_line_items
+      (source_id, charge_period_start, charge_period_end, charge_category, service_name,
+       usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
+       confidence, data_freshness, source_ref, dedup_key, created_at)
+    VALUES
+      (@source_id, @start, @end, 'usage', @source_id,
+       @usage_type, @quantity, @unit, @amount, NULL, @currency,
+       @confidence, @freshness, @source_ref, @dedup_key, @now)
+    ON CONFLICT(dedup_key) DO UPDATE SET
+      billed_cost=excluded.billed_cost, currency=excluded.currency,
+      confidence=excluded.confidence, data_freshness=excluded.data_freshness,
+      source_ref=excluded.source_ref, usage_type=excluded.usage_type
+  `)
+  const tx = db.transaction((ls: NormalizedCostLine[]) => {
+    let n = 0
+    for (const l of ls) {
+      upsertSource.run({ id: l.service, provider: l.provider, currency: l.currency, now })
+      upsertLine.run({
+        source_id: l.service, start: l.billing_period_start, end: l.billing_period_end,
+        usage_type: l.usage_type ?? null, quantity: l.quantity ?? null, unit: l.unit ?? null,
+        amount: l.amount, currency: l.currency, confidence: l.confidence,
+        freshness: l.data_freshness_at, source_ref: l.raw_ref_hash ?? null, dedup_key: l.dedup_key, now,
+      })
+      n++
+    }
+    return n
+  })
+  return tx(lines)
+}
+
+export interface RunCollectorArgs {
+  db: Database.Database
+  collector: ProviderCollector
+  opts: CollectOpts
+  now: number
+}
+
+/**
+ * Run a collector end to end and record an import_runs row. Never throws on a
+ * collector error -- it records a sanitized failure and imports nothing. Returns
+ * the run result (also secret-free).
+ */
+export async function runCollector(args: RunCollectorArgs): Promise<ImportRunResult> {
+  const { db, collector, opts, now } = args
+  const insertRun = db.prepare(`
+    INSERT INTO import_runs (provider, collector_name, started_at, finished_at, status,
+      period_start, period_end, imported_count, error_code, error_message_sanitized, data_freshness_at)
+    VALUES (@provider, @collector, @started, @finished, @status,
+      @ps, @pe, @count, @ecode, @emsg, @fresh)
+  `)
+  let status: ImportStatus = 'ok'
+  let importedCount = 0
+  let errorCode: string | null = null
+  let errorMsg: string | null = null
+  let freshness: number | null = null
+  try {
+    const lines = await collector.collect(opts)
+    importedCount = upsertProviderLines(db, lines, now)
+    freshness = lines.reduce((m, l) => Math.max(m, l.data_freshness_at), 0) || now
+  } catch (err) {
+    status = 'error'
+    const s = sanitizeError(err)
+    errorCode = s.code
+    errorMsg = s.message
+    // IMPORTANT: delete nothing. Last good data stays.
+  }
+  insertRun.run({
+    provider: collector.provider, collector: collector.collectorName,
+    started: now, finished: now, status,
+    ps: opts.periodStart, pe: opts.periodEnd, count: importedCount,
+    ecode: errorCode, emsg: errorMsg, fresh: freshness,
+  })
+  return {
+    provider: collector.provider, collectorName: collector.collectorName,
+    status, importedCount, errorCode, errorMessageSanitized: errorMsg, dataFreshnessAt: freshness,
+  }
+}

--- a/src/costops/collectors/types.ts
+++ b/src/costops/collectors/types.ts
@@ -41,9 +41,36 @@ export interface ProviderCollector {
   collectorName: string
   // PURE network READ + normalize. Never writes to the provider. No LLM.
   collect(opts: CollectOpts): Promise<NormalizedCostLine[]>
+  // Optional: same READ, but also returns the raw response so a DRY-RUN can
+  // describe its SHAPE (types only, never values). No secret is in `raw`'s
+  // shape description. Collectors without this fall back to lines-only dry-run.
+  collectRaw?(opts: CollectOpts): Promise<{ raw: unknown; lines: NormalizedCostLine[] }>
 }
 
-export type ImportStatus = 'ok' | 'partial' | 'rate_limited' | 'error'
+// 'dry_run' marks a preview run that imported NOTHING (imported_count always 0).
+export type ImportStatus = 'ok' | 'partial' | 'rate_limited' | 'error' | 'dry_run'
+
+// A sanitized description of a value's STRUCTURE -- types, object keys, and
+// array lengths ONLY. It carries NO scalar values, so no secret, account id,
+// invoice ref, or raw provider datum can travel in it.
+export type ShapeNode =
+  | 'string' | 'number' | 'boolean' | 'null' | 'undefined'
+  | { type: 'array'; length: number; of: ShapeNode }
+  | { type: 'object'; keys: Record<string, ShapeNode> }
+
+// Result of a DRY-RUN: what a real import WOULD do, without persisting any
+// provider_api cost line. Secret-free by construction.
+export interface DryRunReport {
+  provider: string
+  collectorName: string
+  status: 'dry_run' | 'error'
+  plannedLines: NormalizedCostLine[]  // normalized lines (raw_ref_hash is a hash, no raw id)
+  dedupKeys: string[]                 // the idempotent keys a real import would upsert on
+  responseShape: ShapeNode | null     // sanitized shape of the provider response (null if unavailable)
+  wouldImportCount: number            // how many provider_api lines a real import WOULD write
+  errorCode: string | null
+  errorMessageSanitized: string | null
+}
 
 export interface ImportRunResult {
   provider: string

--- a/src/costops/collectors/types.ts
+++ b/src/costops/collectors/types.ts
@@ -5,7 +5,7 @@
 // call happens unless a real fetcher is passed in by an explicitly-approved run.
 // Secrets are passed in by the runner (from the Vault) and are NEVER logged.
 
-export type CostConfidenceApi = 'provider_api' | 'billing_export'
+export type CostConfidenceApi = 'provider_api' | 'billing_export' | 'provider_plan_estimate'
 
 export interface NormalizedCostLine {
   provider: string

--- a/src/costops/collectors/types.ts
+++ b/src/costops/collectors/types.ts
@@ -1,0 +1,56 @@
+// CostOps v0.3 -- provider cost collector framework (types).
+//
+// Provider-agnostic, deterministic, NO LLM. The HTTP fetcher is INJECTED so
+// collectors are unit-tested fully offline with fixtures -- no live provider
+// call happens unless a real fetcher is passed in by an explicitly-approved run.
+// Secrets are passed in by the runner (from the Vault) and are NEVER logged.
+
+export type CostConfidenceApi = 'provider_api' | 'billing_export'
+
+export interface NormalizedCostLine {
+  provider: string
+  service: string                 // maps to a cost_sources.id (e.g. 'anthropic-api')
+  billing_period_start: number    // epoch sec
+  billing_period_end: number      // epoch sec
+  amount: number                  // in `currency`
+  currency: string
+  confidence: CostConfidenceApi
+  usage_type?: string | null
+  quantity?: number | null
+  unit?: string | null
+  data_freshness_at: number       // provider "as of" time (epoch sec)
+  raw_ref_hash?: string | null    // sha256(salt, raw id) -- NEVER a raw account/invoice id
+  dedup_key: string               // idempotent upsert key
+}
+
+// Injected HTTP GET returning parsed JSON. Tests pass a stub that returns a
+// fixture; a live run would pass a real implementation (only after approval).
+export type HttpGetJson = (url: string, headers: Record<string, string>) => Promise<unknown>
+
+export interface CollectOpts {
+  periodStart: number
+  periodEnd: number
+  secret: string                  // from Vault; NEVER logged/persisted
+  fxUsdHuf: number
+  idSalt: string                  // for raw_ref_hash
+  httpGetJson: HttpGetJson        // injected -- offline in tests
+}
+
+export interface ProviderCollector {
+  provider: string
+  collectorName: string
+  // PURE network READ + normalize. Never writes to the provider. No LLM.
+  collect(opts: CollectOpts): Promise<NormalizedCostLine[]>
+}
+
+export type ImportStatus = 'ok' | 'partial' | 'rate_limited' | 'error'
+
+export interface ImportRunResult {
+  provider: string
+  collectorName: string
+  status: ImportStatus
+  importedCount: number
+  errorCode: string | null
+  errorMessageSanitized: string | null
+  dataFreshnessAt: number | null
+}

--- a/src/costops/config.ts
+++ b/src/costops/config.ts
@@ -24,6 +24,11 @@ export type CostConfidence =
   | 'local_usage'
   | 'estimate'
   | 'manual'
+  // v0.7: a real, tracked provider whose cost cannot be read (missing IAM/API
+  // permission, e.g. AWS Cost Explorer). Advisory like provider_plan_estimate --
+  // NEVER shown as 0, NEVER folded into current_spend/operational. Surfaces only
+  // via a dedicated billing_access_needed warning (see warnings.ts).
+  | 'pending_permission'
 
 export type ChargeCategory =
   | 'usage'
@@ -44,17 +49,38 @@ export interface FixedCostEntry {
   confidence?: CostConfidence
   currency?: string
   notes?: string
+  // Phase 0 (source inventory, GAP-03): who is responsible for this source's config/credential.
+  // Optional -- defaults to 'operator' at read time (single-operator deployment), never
+  // fabricated as anything more specific than that default.
+  owner?: string
+  // Phase 0: manual escape hatch for the two lifecycle states that can never be safely inferred
+  // from collector/activity signals alone -- "this provider genuinely has no billing API" or
+  // "this subscription was cancelled/retired". Absent (undefined) means "let the signals decide".
+  lifecycle_override?: 'unsupported' | 'deprecated'
 }
 
 export interface BudgetEntry {
   id: string
   name?: string
-  scope?: 'global' | 'source' | 'provider' | 'product' | 'agent'
+  // Phase 3 (GAP-11): 'category' added -- a cost_sources.source_type-level
+  // budget (e.g. all 'hosting' or all 'saas' spend), distinct from a single
+  // 'source' (one specific subscription/API/hosting/SaaS line item) and from
+  // 'provider' (one provider across all its sources). 'product'/'agent'
+  // remain in the union for backward compatibility with any config already
+  // using them, but GAP-11 explicitly excludes building product/agent
+  // budgets -- nothing in budgets.ts resolves those scopes.
+  scope?: 'global' | 'source' | 'provider' | 'category' | 'product' | 'agent'
   scope_ref?: string
   amount: number
   currency?: string
   warning_threshold?: number  // fraction, default 0.8
   hard_threshold?: number     // fraction, default 1.0
+  // Phase 3 (GAP-11): who owns this budget (governance, not enforcement --
+  // the hard threshold is an alert, never an automatic stop). Optional,
+  // never fabricated; defaults applied at read time in budgets.ts, same
+  // convention as FixedCostEntry.owner.
+  owner?: string
+  notes?: string
 }
 
 export interface CostOpsConfig {
@@ -76,7 +102,7 @@ const EMPTY_CONFIG: CostOpsConfig = {
 const EXAMPLE_CONFIG = {
   version: 1,
   currency: 'HUF',
-  _doc: 'CostOps local config. Copy to store/costops-config.json and fill in real values. Amounts are per month. No secrets/API keys here -- put those in the Vault.',
+  _doc: 'CostOps v0.1 local config. Copy to store/costops-config.json and fill in real values. Amounts are per month. No secrets/API keys here -- put those in the Vault.',
   fixed_costs: [
     { source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 0, period: 'monthly', charge_category: 'subscription', confidence: 'manual' },
     { source_id: 'openai-chatgpt', name: 'ChatGPT', provider: 'openai', source_type: 'subscription', amount: 0, period: 'monthly', confidence: 'manual' },
@@ -127,6 +153,17 @@ export function ensureExampleConfig(): void {
 }
 
 /**
+ * Persist the config back to store/costops-config.json. Phase 3 (GAP-11):
+ * the only write path today is budgets.ts's upsertBudget/deleteBudget --
+ * fixed_costs remain manual-edit-only (no API mutates them). Whole-file
+ * rewrite, not a partial patch -- config.ts's own load path already
+ * round-trips the full object, so this stays consistent with it.
+ */
+export function saveCostopsConfig(config: CostOpsConfig): void {
+  writeFileSync(COSTOPS_CONFIG_PATH, JSON.stringify(config, null, 2) + '\n', 'utf-8')
+}
+
+/**
  * Pure validation of a parsed config object. Exported for unit tests.
  * Drops invalid entries (with an error note) rather than failing the whole load.
  */
@@ -153,6 +190,8 @@ export function validateConfig(raw: unknown): ConfigLoadResult {
       confidence: (typeof c.confidence === 'string' ? c.confidence : 'manual') as CostConfidence,
       currency: typeof c.currency === 'string' ? c.currency : currency,
       notes: typeof c.notes === 'string' ? c.notes : undefined,
+      owner: typeof c.owner === 'string' ? c.owner : undefined,
+      lifecycle_override: (c.lifecycle_override === 'unsupported' || c.lifecycle_override === 'deprecated') ? c.lifecycle_override : undefined,
     })
   }
 
@@ -171,6 +210,8 @@ export function validateConfig(raw: unknown): ConfigLoadResult {
       currency: typeof b.currency === 'string' ? b.currency : currency,
       warning_threshold: typeof b.warning_threshold === 'number' ? b.warning_threshold : 0.8,
       hard_threshold: typeof b.hard_threshold === 'number' ? b.hard_threshold : 1.0,
+      owner: typeof b.owner === 'string' ? b.owner : undefined,
+      notes: typeof b.notes === 'string' ? b.notes : undefined,
     })
   }
 

--- a/src/costops/config.ts
+++ b/src/costops/config.ts
@@ -20,6 +20,7 @@ export type CostConfidence =
   | 'actual_invoice'
   | 'provider_api'
   | 'billing_export'
+  | 'provider_plan_estimate'  // v0.3: derived from provider plan inventory (Render), NOT an invoice; advisory
   | 'local_usage'
   | 'estimate'
   | 'manual'

--- a/src/costops/correction.ts
+++ b/src/costops/correction.ts
@@ -1,0 +1,148 @@
+// CostOps Phase 1 (GAP-05/GAP-06/GAP-14) -- correction relationship for
+// cost_line_items, extending Phase 0's void/archive pattern.
+//
+// A void alone answers "this row is gone from the active ledger." A
+// correction answers the stronger question the gap-analysis calls out:
+// "what REPLACED it, and can I trace back from the new number to the old
+// one." createCorrection() voids the original row (same auditable mechanism
+// as manual-entry.ts's deleteManualCost) AND inserts a new row carrying
+// corrects_line_id -> the original's id, so the relationship survives in
+// the schema itself, not just by matching source_id/month/timing.
+//
+// Unlike Phase 0's void (manual entries only), a correction can apply to ANY
+// active line -- a provider_api or invoice-derived amount can be wrong too
+// (GAP-14 explicitly covers correcting invoice/provider amounts, not just
+// manual ones). The guard is narrower instead: a line can only be corrected
+// ONCE (correct the newer replacement if it's still wrong, not the original
+// a second time) -- keeps the correction chain linear and traceable.
+
+import type Database from 'better-sqlite3'
+
+export interface CreateCorrectionInput {
+  originalLineId: number
+  newAmount: number
+  reason: string
+}
+
+export interface CorrectionResult {
+  ok: boolean
+  error?: string
+  status?: number
+  newLineId?: number
+}
+
+interface OriginalRow {
+  id: number
+  source_id: string
+  charge_period_start: number
+  charge_period_end: number
+  charge_category: string
+  service_name: string | null
+  usage_type: string | null
+  consumed_quantity: number | null
+  consumed_unit: string | null
+  currency: string
+  confidence: string
+  source_ref: string | null
+  dedup_key: string | null
+  actual_source: string | null
+  original_amount: number | null
+  original_currency: string | null
+  fx_rate: number | null
+  fx_date: number | null
+  voided_at: number | null
+}
+
+export function createCorrection(
+  db: Database.Database,
+  input: CreateCorrectionInput,
+  opts: { now: number },
+): CorrectionResult {
+  if (!input || !Number.isFinite(input.originalLineId) || input.originalLineId <= 0) {
+    return { ok: false, error: 'missing or invalid originalLineId', status: 400 }
+  }
+  if (!Number.isFinite(input.newAmount) || input.newAmount < 0) {
+    return { ok: false, error: 'newAmount must be a non-negative number', status: 400 }
+  }
+  if (!input.reason || !input.reason.trim()) {
+    return { ok: false, error: 'reason is required for a correction (auditability)', status: 400 }
+  }
+
+  const original = db.prepare(`SELECT * FROM cost_line_items WHERE id = ?`).get(input.originalLineId) as OriginalRow | undefined
+  if (!original) return { ok: false, error: `no cost_line_items row with id ${input.originalLineId}`, status: 404 }
+  if (original.voided_at != null) return { ok: false, error: `line ${input.originalLineId} is already voided/corrected`, status: 409 }
+
+  const alreadyCorrected = db.prepare(`SELECT 1 FROM cost_line_items WHERE corrects_line_id = ?`).get(input.originalLineId)
+  if (alreadyCorrected) return { ok: false, error: `line ${input.originalLineId} already has a correction -- correct the newer replacement instead, not the original again`, status: 409 }
+
+  const newDedupKey = `correction|${input.originalLineId}|${opts.now}`
+
+  const tx = db.transaction(() => {
+    db.prepare(`
+      UPDATE cost_line_items SET voided_at = @now, void_reason = @reason, dedup_key = @voidedDedupKey
+      WHERE id = @id
+    `).run({
+      now: opts.now, reason: `superseded by correction: ${input.reason}`,
+      voidedDedupKey: original.dedup_key ? `${original.dedup_key}|corrected|${opts.now}` : `corrected|${input.originalLineId}|${opts.now}`,
+      id: input.originalLineId,
+    })
+    const info = db.prepare(`
+      INSERT INTO cost_line_items
+        (source_id, charge_period_start, charge_period_end, charge_category, service_name,
+         usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
+         confidence, data_freshness, source_ref, dedup_key, created_at, actual_source,
+         original_amount, original_currency, fx_rate, fx_date, corrects_line_id)
+      VALUES
+        (@source_id, @start, @end, @charge_category, @service_name,
+         @usage_type, @consumed_quantity, @consumed_unit, @billed_cost, NULL, @currency,
+         @confidence, @now, @source_ref, @dedup_key, @now, @actual_source,
+         @original_amount, @original_currency, @fx_rate, @fx_date, @corrects_line_id)
+    `).run({
+      source_id: original.source_id, start: original.charge_period_start, end: original.charge_period_end,
+      charge_category: original.charge_category, service_name: original.service_name,
+      usage_type: original.usage_type, consumed_quantity: original.consumed_quantity, consumed_unit: original.consumed_unit,
+      billed_cost: input.newAmount, currency: original.currency, confidence: original.confidence,
+      now: opts.now, source_ref: original.source_ref, dedup_key: newDedupKey, actual_source: original.actual_source,
+      original_amount: original.original_amount, original_currency: original.original_currency,
+      fx_rate: original.fx_rate, fx_date: original.fx_date, corrects_line_id: input.originalLineId,
+    })
+    return info.lastInsertRowid as number
+  })
+
+  const newLineId = tx()
+  return { ok: true, newLineId }
+}
+
+export interface CorrectionChainEntry {
+  id: number
+  billed_cost: number
+  voided_at: number | null
+  void_reason: string | null
+  created_at: number
+}
+
+/**
+ * Walk the full correction chain for a line, oldest first -- the original
+ * (possibly voided-by-correction) plus every correction that followed,
+ * however many links deep. Read-only, used for audit/drill-down.
+ */
+export function getCorrectionChain(db: Database.Database, lineId: number): CorrectionChainEntry[] {
+  const chain: CorrectionChainEntry[] = []
+  // Walk BACKWARD to find the true root first (a caller might pass a
+  // mid-chain id), then forward to collect every link.
+  let rootId = lineId
+  for (;;) {
+    const row = db.prepare(`SELECT corrects_line_id FROM cost_line_items WHERE id = ?`).get(rootId) as { corrects_line_id: number | null } | undefined
+    if (!row?.corrects_line_id) break
+    rootId = row.corrects_line_id
+  }
+  let currentId: number | null = rootId
+  while (currentId != null) {
+    const row = db.prepare(`SELECT id, billed_cost, voided_at, void_reason, created_at FROM cost_line_items WHERE id = ?`).get(currentId) as CorrectionChainEntry | undefined
+    if (!row) break
+    chain.push(row)
+    const next = db.prepare(`SELECT id FROM cost_line_items WHERE corrects_line_id = ?`).get(currentId) as { id: number } | undefined
+    currentId = next?.id ?? null
+  }
+  return chain
+}

--- a/src/costops/email-ingest.ts
+++ b/src/costops/email-ingest.ts
@@ -11,6 +11,7 @@
 
 import { createHash } from 'node:crypto'
 import type Database from 'better-sqlite3'
+import { checkPeriodWritable } from './period-close.js'
 
 export interface EmailCostEntry {
   source_id: string          // stable id, e.g. 'anthropic-max' or 'aws'
@@ -36,12 +37,29 @@ function monthWindow(month: string): { start: number; end: number } | null {
   return { start: Math.floor(Date.UTC(y, m, 1) / 1000), end: Math.floor(Date.UTC(y, m + 1, 1) / 1000) }
 }
 
-/** Convert an amount to HUF. HUF passes through; USD uses fx; unknown -> flagged. */
-export function toHuf(amount: number, currency: string, fxUsdHuf: number): number | null {
+/**
+ * Convert an amount to HUF. HUF passes through; USD/EUR use their own fx rate; any other
+ * currency -> flagged (null), not guessed. v0.8 (card 6f4d1332): EUR previously fell through to
+ * "unconvertible" even though EUR-denominated email invoices are a real, expected case (the
+ * requirements doc's own worked example is an EUR invoice) -- added the EUR branch alongside USD.
+ */
+export function toHuf(amount: number, currency: string, fxUsdHuf: number, fxEurHuf = 0): number | null {
   const cur = (currency || 'HUF').toUpperCase()
   if (cur === 'HUF') return Math.round(amount * 100) / 100
   if (cur === 'USD') return Math.round(amount * fxUsdHuf * 100) / 100
-  // EUR/other not converted here (needs its own fx) -- caller should pre-convert.
+  // A zero/unconfigured fxEurHuf is not a valid rate -- converting against it would fabricate a
+  // fake 0 HUF amount (explicitly forbidden). Falls through to "unconvertible", same as any
+  // other unconfigured currency, until fx_eur_huf is set in the Render pricing config.
+  if (cur === 'EUR' && fxEurHuf > 0) return Math.round(amount * fxEurHuf * 100) / 100
+  // Other currencies not converted here (would need their own fx) -- caller should pre-convert.
+  return null
+}
+
+/** The fx rate actually used for a given currency, for retaining alongside the converted amount. */
+export function fxRateFor(currency: string, fxUsdHuf: number, fxEurHuf: number): number | null {
+  const cur = (currency || 'HUF').toUpperCase()
+  if (cur === 'USD') return fxUsdHuf
+  if (cur === 'EUR' && fxEurHuf > 0) return fxEurHuf
   return null
 }
 
@@ -53,9 +71,10 @@ export function toHuf(amount: number, currency: string, fxUsdHuf: number): numbe
 export function ingestEmailCosts(
   db: Database.Database,
   entries: EmailCostEntry[],
-  opts: { fxUsdHuf: number; now: number; idSalt?: string },
+  opts: { fxUsdHuf: number; fxEurHuf?: number; now: number; idSalt?: string },
 ): IngestResult {
   const salt = opts.idSalt ?? 'costops-email'
+  const fxEurHuf = opts.fxEurHuf ?? 0
   const upsertSource = db.prepare(`
     INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at)
     VALUES (@id, @name, @provider, @source_type, 'HUF', 1, @now, @now)
@@ -66,14 +85,21 @@ export function ingestEmailCosts(
     INSERT INTO cost_line_items
       (source_id, charge_period_start, charge_period_end, charge_category, service_name,
        usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
-       confidence, data_freshness, source_ref, dedup_key, created_at)
+       confidence, data_freshness, source_ref, dedup_key, created_at,
+       original_amount, original_currency, fx_rate, fx_date, actual_source,
+       fx_source, conversion_method)
     VALUES
       (@source_id, @start, @end, 'invoice', @name,
        NULL, NULL, NULL, @amount, NULL, 'HUF',
-       @confidence, @now, @ref_hash, @dedup_key, @now)
+       @confidence, @now, @ref_hash, @dedup_key, @now,
+       @original_amount, @original_currency, @fx_rate, @fx_date, 'email_invoice',
+       @fx_source, @conversion_method)
     ON CONFLICT(dedup_key) DO UPDATE SET
       billed_cost=excluded.billed_cost, confidence=excluded.confidence,
-      data_freshness=excluded.data_freshness, source_ref=excluded.source_ref
+      data_freshness=excluded.data_freshness, source_ref=excluded.source_ref,
+      original_amount=excluded.original_amount, original_currency=excluded.original_currency,
+      fx_rate=excluded.fx_rate, fx_date=excluded.fx_date, actual_source=excluded.actual_source,
+      fx_source=excluded.fx_source, conversion_method=excluded.conversion_method
   `)
   const out: IngestResult = { ingested: 0, skipped: 0, errors: [] }
   const tx = db.transaction((list: EmailCostEntry[]) => {
@@ -81,15 +107,39 @@ export function ingestEmailCosts(
       if (!e || typeof e.source_id !== 'string' || !e.source_id) { out.errors.push({ source_id: String(e?.source_id), reason: 'missing source_id' }); continue }
       const win = monthWindow(e.month)
       if (!win) { out.errors.push({ source_id: e.source_id, reason: `bad month '${e.month}'` }); continue }
-      const amountHuf = toHuf(Number(e.amount), e.currency, opts.fxUsdHuf)
+      // Phase 2 (GAP-13): a closed month accepts no direct write (including an
+      // ON CONFLICT DO UPDATE for a late/re-sent invoice) -- use a correction instead.
+      const writable = checkPeriodWritable(db, e.month)
+      if (!writable.writable) { out.errors.push({ source_id: e.source_id, reason: writable.reason! }); continue }
+      const amountHuf = toHuf(Number(e.amount), e.currency, opts.fxUsdHuf, fxEurHuf)
       if (amountHuf === null || !isFinite(amountHuf)) { out.errors.push({ source_id: e.source_id, reason: `uncconvertible currency '${e.currency}'` }); continue }
       const refHash = createHash('sha256').update(salt).update('|').update(String(e.message_ref)).digest('hex').slice(0, 32)
       const dedup = `email|${refHash}|${e.month}`
+      const cur = (e.currency || 'HUF').toUpperCase()
+      // Currency-retention (v0.7, additive): only a REAL conversion has an "original"
+      // distinct from billed_cost -- an already-HUF entry has nothing to retain.
+      const wasConverted = cur !== 'HUF'
+      // v0.8 bugfix: this used to always retain opts.fxUsdHuf regardless of which currency was
+      // actually converted -- harmless while only USD existed, but wrong the moment a second
+      // currency (EUR) does. fxRateFor() picks the rate that was actually applied above.
+      const appliedFxRate = fxRateFor(cur, opts.fxUsdHuf, fxEurHuf)
       upsertSource.run({ id: e.source_id, name: e.name || e.source_id, provider: e.provider || 'other', source_type: e.source_type || 'subscription', now: opts.now })
       upsertLine.run({
         source_id: e.source_id, start: win.start, end: win.end, name: e.name || e.source_id,
         amount: amountHuf, confidence: e.confidence || 'actual_invoice', now: opts.now,
         ref_hash: refHash, dedup_key: dedup,
+        original_amount: wasConverted ? Number(e.amount) : null,
+        original_currency: wasConverted ? cur : null,
+        fx_rate: wasConverted ? appliedFxRate : null,
+        fx_date: wasConverted ? opts.now : null,
+        // Phase 1 (GAP-09): fx.ts's FxSource/ConversionMethod provenance,
+        // alongside the pre-existing fx_rate/fx_date columns above. This is
+        // an email-derived invoice -- 'invoice_date_rate' reflects that the
+        // rate is tied to the invoice event, not a bare usage period.
+        // fxUsdHuf/fxEurHuf always come from the Render pricing config (the
+        // only rate source wired in today, see collectors/render.ts).
+        fx_source: wasConverted ? 'render_pricing_config' : null,
+        conversion_method: wasConverted ? 'invoice_date_rate' : null,
       })
       out.ingested++
     }

--- a/src/costops/email-ingest.ts
+++ b/src/costops/email-ingest.ts
@@ -1,0 +1,99 @@
+// CostOps -- email-sourced cost ingest.
+//
+// Invoices/receipts that land in the operator's mailbox are the most authoritative
+// cost signal (an actual charged amount). An agent-side sweep reads Gmail (which
+// is not reachable from this backend), extracts a structured entry per receipt,
+// and POSTs them here. This module is the PURE, deterministic ingest: it upserts
+// one cost_line_item per (email, month) with an idempotent dedup key, so a sweep
+// can safely re-run and re-ingest the same month without duplicating. NO raw email
+// body, subject, sender address or PII is ever stored -- only the extracted amount,
+// provider/source labels, the billing month, and a HASH of the message ref.
+
+import { createHash } from 'node:crypto'
+import type Database from 'better-sqlite3'
+
+export interface EmailCostEntry {
+  source_id: string          // stable id, e.g. 'anthropic-max' or 'aws'
+  name: string               // human label, e.g. 'Claude Max'
+  provider: string           // e.g. 'anthropic'
+  amount: number             // in `currency`
+  currency: string           // 'HUF' | 'USD' | ...
+  month: string              // 'YYYY-MM' billing month
+  message_ref: string        // opaque per-email ref (Gmail message id); hashed here
+  confidence?: string        // default 'actual_invoice'
+  source_type?: string       // default 'subscription'
+}
+
+export interface IngestResult {
+  ingested: number
+  skipped: number
+  errors: Array<{ source_id: string; reason: string }>
+}
+
+function monthWindow(month: string): { start: number; end: number } | null {
+  if (!/^\d{4}-\d{2}$/.test(month)) return null
+  const y = parseInt(month.slice(0, 4)), m = parseInt(month.slice(5, 7)) - 1
+  return { start: Math.floor(Date.UTC(y, m, 1) / 1000), end: Math.floor(Date.UTC(y, m + 1, 1) / 1000) }
+}
+
+/** Convert an amount to HUF. HUF passes through; USD uses fx; unknown -> flagged. */
+export function toHuf(amount: number, currency: string, fxUsdHuf: number): number | null {
+  const cur = (currency || 'HUF').toUpperCase()
+  if (cur === 'HUF') return Math.round(amount * 100) / 100
+  if (cur === 'USD') return Math.round(amount * fxUsdHuf * 100) / 100
+  // EUR/other not converted here (needs its own fx) -- caller should pre-convert.
+  return null
+}
+
+/**
+ * Idempotently upsert email-sourced cost lines. Deterministic, no I/O beyond the
+ * passed db. Dedup key = `email|<sha256(message_ref)[:32]>|<month>`, so the same
+ * receipt for the same month is updated in place, never duplicated.
+ */
+export function ingestEmailCosts(
+  db: Database.Database,
+  entries: EmailCostEntry[],
+  opts: { fxUsdHuf: number; now: number; idSalt?: string },
+): IngestResult {
+  const salt = opts.idSalt ?? 'costops-email'
+  const upsertSource = db.prepare(`
+    INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at)
+    VALUES (@id, @name, @provider, @source_type, 'HUF', 1, @now, @now)
+    ON CONFLICT(id) DO UPDATE SET name=excluded.name, provider=excluded.provider,
+      source_type=excluded.source_type, updated_at=excluded.updated_at
+  `)
+  const upsertLine = db.prepare(`
+    INSERT INTO cost_line_items
+      (source_id, charge_period_start, charge_period_end, charge_category, service_name,
+       usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
+       confidence, data_freshness, source_ref, dedup_key, created_at)
+    VALUES
+      (@source_id, @start, @end, 'invoice', @name,
+       NULL, NULL, NULL, @amount, NULL, 'HUF',
+       @confidence, @now, @ref_hash, @dedup_key, @now)
+    ON CONFLICT(dedup_key) DO UPDATE SET
+      billed_cost=excluded.billed_cost, confidence=excluded.confidence,
+      data_freshness=excluded.data_freshness, source_ref=excluded.source_ref
+  `)
+  const out: IngestResult = { ingested: 0, skipped: 0, errors: [] }
+  const tx = db.transaction((list: EmailCostEntry[]) => {
+    for (const e of list) {
+      if (!e || typeof e.source_id !== 'string' || !e.source_id) { out.errors.push({ source_id: String(e?.source_id), reason: 'missing source_id' }); continue }
+      const win = monthWindow(e.month)
+      if (!win) { out.errors.push({ source_id: e.source_id, reason: `bad month '${e.month}'` }); continue }
+      const amountHuf = toHuf(Number(e.amount), e.currency, opts.fxUsdHuf)
+      if (amountHuf === null || !isFinite(amountHuf)) { out.errors.push({ source_id: e.source_id, reason: `uncconvertible currency '${e.currency}'` }); continue }
+      const refHash = createHash('sha256').update(salt).update('|').update(String(e.message_ref)).digest('hex').slice(0, 32)
+      const dedup = `email|${refHash}|${e.month}`
+      upsertSource.run({ id: e.source_id, name: e.name || e.source_id, provider: e.provider || 'other', source_type: e.source_type || 'subscription', now: opts.now })
+      upsertLine.run({
+        source_id: e.source_id, start: win.start, end: win.end, name: e.name || e.source_id,
+        amount: amountHuf, confidence: e.confidence || 'actual_invoice', now: opts.now,
+        ref_hash: refHash, dedup_key: dedup,
+      })
+      out.ingested++
+    }
+  })
+  tx(entries)
+  return out
+}

--- a/src/costops/expiry-checks.ts
+++ b/src/costops/expiry-checks.ts
@@ -1,0 +1,165 @@
+// CostOps v0.7/v2 -- SSL cert + domain registration expiry (card bea78483).
+//
+// Both are pure READ-ONLY network checks: a TLS handshake to read the peer
+// certificate's notAfter date, and a public RDAP lookup for a domain's
+// registration expiration. No DNS/cert/domain change, no admin key needed.
+
+import tls from 'node:tls'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+import { logger } from '../logger.js'
+import type { CostWarning } from './warnings.js'
+
+export const DOMAINS_CONFIG_PATH = join(PROJECT_ROOT, 'store', 'costops-domains.json')
+export const DOMAINS_EXAMPLE_PATH = join(PROJECT_ROOT, 'store', 'costops-domains.json.example')
+
+export interface DomainsConfig {
+  version: number
+  // hosts to TLS-check (subdomains included -- each has its own cert)
+  ssl_hosts: string[]
+  // root registrable domains to RDAP-check (subdomains share the parent's registration)
+  domains: string[]
+}
+
+const EMPTY: DomainsConfig = { version: 1, ssl_hosts: [], domains: [] }
+const EXAMPLE: DomainsConfig = {
+  version: 1,
+  ssl_hosts: ['example.com'],
+  domains: ['example.com'],
+}
+
+export function loadDomainsConfig(): { config: DomainsConfig; exists: boolean } {
+  if (!existsSync(DOMAINS_CONFIG_PATH)) {
+    try { if (!existsSync(DOMAINS_EXAMPLE_PATH)) writeFileSync(DOMAINS_EXAMPLE_PATH, JSON.stringify(EXAMPLE, null, 2) + '\n', 'utf-8') } catch { /* best effort */ }
+    return { config: { ...EMPTY }, exists: false }
+  }
+  try {
+    const raw = JSON.parse(readFileSync(DOMAINS_CONFIG_PATH, 'utf-8')) as Partial<DomainsConfig>
+    return {
+      config: {
+        version: typeof raw.version === 'number' ? raw.version : 1,
+        ssl_hosts: Array.isArray(raw.ssl_hosts) ? raw.ssl_hosts.filter(h => typeof h === 'string') : [],
+        domains: Array.isArray(raw.domains) ? raw.domains.filter(h => typeof h === 'string') : [],
+      },
+      exists: true,
+    }
+  } catch (err) {
+    logger.warn({ err }, 'costops-domains.json is not valid JSON')
+    return { config: { ...EMPTY }, exists: true }
+  }
+}
+
+// Shared 30/14/7-day severity ladder -- exported for reuse by any other date-deadline warning
+// (workspace-alerts.ts's suspension-date lifecycle uses the same "rises as it approaches" rule).
+export const EXPIRY_THRESHOLDS = { warn: 30, urgent: 14, critical: 7 }
+const SSL_THRESHOLDS = EXPIRY_THRESHOLDS
+
+interface TlsCheckDeps {
+  connect?: (host: string, port: number) => Promise<{ validTo: string } | null>
+}
+
+function defaultTlsConnect(host: string, port: number): Promise<{ validTo: string } | null> {
+  return new Promise((resolve) => {
+    const socket = tls.connect({ host, port, servername: host, timeout: 5000, rejectUnauthorized: false }, () => {
+      const cert = socket.getPeerCertificate()
+      socket.destroy()
+      resolve(cert && cert.valid_to ? { validTo: cert.valid_to } : null)
+    })
+    socket.on('error', () => resolve(null))
+    socket.on('timeout', () => { socket.destroy(); resolve(null) })
+  })
+}
+
+export function severityForDays(days: number): CostWarning['severity'] | null {
+  if (days <= EXPIRY_THRESHOLDS.critical) return 'high'
+  if (days <= EXPIRY_THRESHOLDS.urgent) return 'medium'
+  if (days <= EXPIRY_THRESHOLDS.warn) return 'low'
+  return null
+}
+
+/** TLS cert expiry for each configured host. Silent (no warning) when healthy. */
+export async function checkSslExpiry(hosts: string[], now: number, deps: TlsCheckDeps = {}): Promise<CostWarning[]> {
+  const connect = deps.connect || defaultTlsConnect
+  const warnings: CostWarning[] = []
+  for (const host of hosts) {
+    let cert: { validTo: string } | null
+    try { cert = await connect(host, 443) } catch { cert = null }
+    if (!cert) {
+      warnings.push({
+        code: 'ssl_check_failed', severity: 'low', provider: 'ssl', message: `${host}: SSL tanúsítvány nem ellenőrizhető (kapcsolódási hiba).`,
+        warning_type: 'access', category: 'domains', source: 'tls', confidence: 'no_api_or_no_access', detail: { host },
+      })
+      continue
+    }
+    const daysRemaining = Math.floor((Date.parse(cert.validTo) - now * 1000) / 86400000)
+    const severity = severityForDays(daysRemaining)
+    if (!severity) continue // healthy -- no noise
+    warnings.push({
+      code: 'ssl_expiry_soon', severity, provider: 'ssl',
+      message: `${host}: SSL tanúsítvány ${daysRemaining} nap múlva lejár.`,
+      detail: { host, expiry_date: cert.validTo },
+      warning_type: 'expiry', category: 'domains', source: 'tls', confidence: 'measured',
+      expiry_date: cert.validTo, current_value: daysRemaining, threshold: SSL_THRESHOLDS.warn, unit: 'day',
+      action: 'Ellenőrizd a tanúsítvány automatikus megújítását.',
+    })
+  }
+  return warnings
+}
+
+const DOMAIN_THRESHOLDS = { warn: 30, urgent: 14, critical: 7 }
+// Read-only public RDAP registries per TLD -- extend as new TLDs are used.
+const RDAP_BASE: Record<string, string> = {
+  com: 'https://rdap.verisign.com/com/v1/domain/',
+  net: 'https://rdap.verisign.com/net/v1/domain/',
+}
+
+interface RdapEvent { eventAction?: string; eventDate?: string }
+interface RdapResponse { events?: RdapEvent[] }
+
+interface DomainCheckDeps {
+  fetchJson?: (url: string) => Promise<unknown>
+}
+
+/** Domain registration expiry via public RDAP. Silent (no warning) when healthy or TLD unsupported. */
+export async function checkDomainExpiry(domains: string[], now: number, deps: DomainCheckDeps = {}): Promise<CostWarning[]> {
+  const fetchJson = deps.fetchJson || (async (url: string) => {
+    const r = await fetch(url)
+    if (!r.ok) throw new Error(`rdap ${r.status}`)
+    return r.json()
+  })
+  const warnings: CostWarning[] = []
+  for (const domain of domains) {
+    const tld = domain.split('.').pop() || ''
+    const base = RDAP_BASE[tld]
+    if (!base) {
+      warnings.push({
+        code: 'domain_expiry_check_unsupported', severity: 'low', provider: 'domain', message: `${domain}: domain-lejárat nem ellenőrizhető (.${tld} TLD nincs támogatva).`,
+        warning_type: 'access', category: 'domains', source: 'rdap', confidence: 'no_api_or_no_access', detail: { domain },
+      })
+      continue
+    }
+    let resp: RdapResponse
+    try { resp = await fetchJson(`${base}${domain}`) as RdapResponse } catch {
+      warnings.push({
+        code: 'domain_expiry_check_failed', severity: 'low', provider: 'domain', message: `${domain}: domain-lejárat lekérdezése sikertelen.`,
+        warning_type: 'access', category: 'domains', source: 'rdap', confidence: 'no_api_or_no_access', detail: { domain },
+      })
+      continue
+    }
+    const expEvent = (resp.events || []).find(e => e.eventAction === 'expiration')
+    if (!expEvent?.eventDate) continue // no data -- never fabricate an expiry
+    const daysRemaining = Math.floor((Date.parse(expEvent.eventDate) - now * 1000) / 86400000)
+    const severity = severityForDays(daysRemaining)
+    if (!severity) continue
+    warnings.push({
+      code: 'domain_expiry_soon', severity, provider: 'domain',
+      message: `${domain}: domain regisztráció ${daysRemaining} nap múlva lejár.`,
+      detail: { domain, expiry_date: expEvent.eventDate },
+      warning_type: 'expiry', category: 'domains', source: 'rdap', confidence: 'measured',
+      expiry_date: expEvent.eventDate, current_value: daysRemaining, threshold: DOMAIN_THRESHOLDS.warn, unit: 'day',
+      action: 'Hosszabbítsd meg a domain regisztrációt.',
+    })
+  }
+  return warnings
+}

--- a/src/costops/export.ts
+++ b/src/costops/export.ts
@@ -1,0 +1,363 @@
+// CostOps v0.7 -- sanitized export (CSV/JSON).
+// CostOps Phase 1 (GAP-18 / core-functional-scope-v1.0.1.md §19) -- normalized
+// export set: ledger CSV/JSON (v0.7, above), source inventory, provider
+// summary, category summary, budget variance, reconciliation report,
+// forecast history, data-quality report, and a monthly snapshot bundling
+// them. Every export below REUSES the exact function the dashboard/summary
+// route itself calls (getCostSummary, buildReconciliation,
+// buildSourceInventory, listForecastSnapshots) -- never a second, parallel
+// computation -- so "export totals match dashboard totals" holds by
+// construction, not by a separate reconciliation check. Every export carries
+// `meta.schema_version`/`meta.generated_at`; none contains a secret or a raw
+// account reference (the underlying modules already exclude those).
+//
+// NOT included: optimization recommendations (GAP-17) -- that engine does
+// not exist yet in this codebase (Phase 4, not built); no export function
+// fabricates one. Alerts export (GAP-12) IS included below (exportAlerts) --
+// alerts-capture.ts landed on this branch, reusing alerts-store.ts's
+// listAlerts() (the same read path GET /api/costs/alerts uses).
+
+import type Database from 'better-sqlite3'
+import { monthWindow, CONF_PRIORITY, getCostSummary, type CostSummary } from './ledger.js'
+import type { CostOpsConfig } from './config.js'
+import { buildSourceInventory, type SourceInventoryEntry, type CredentialChecker, type Freshness } from './inventory.js'
+import { buildReconciliation, type SourceReconciliation } from './reconciliation.js'
+import { listForecastSnapshots, type ForecastSnapshotRow } from './forecast-capture.js'
+import { getPeriodStatus, type PeriodCloseStatus } from './period-close.js'
+import { listAlerts } from './alerts-store.js'
+import type { AlertRecord } from './alerts.js'
+import { resolveBudgetStatus, type BudgetStatus } from './budgets.js'
+
+export interface ExportRow {
+  provider: string
+  source_type: string
+  service_name: string | null
+  period: string
+  amount: number
+  currency: string
+  confidence: string
+  // Currency-retention (v0.7, additive): populated only when this line was
+  // converted from a foreign-currency invoice ("if any" per spec) -- never
+  // fabricated for an already-HUF line.
+  original_amount: number | null
+  original_currency: string | null
+}
+
+interface Row {
+  provider: string
+  source_type: string
+  service_name: string | null
+  charge_period_start: number
+  billed_cost: number
+  currency: string
+  confidence: string
+  original_amount: number | null
+  original_currency: string | null
+}
+
+/**
+ * Sanitized cost-line export for a single month, or a [fromMonth, toMonth]
+ * inclusive range. No fabrication: months with zero rows simply contribute no
+ * rows (the caller can see that from an empty result, not a synthesized 0).
+ */
+export function exportCostRows(
+  db: Database.Database,
+  now: number,
+  opts: { month?: string; fromMonth?: string; toMonth?: string },
+): ExportRow[] {
+  let start: number, end: number
+  if (opts.fromMonth && opts.toMonth) {
+    start = monthWindow(now, opts.fromMonth).start
+    end = monthWindow(now, opts.toMonth).end
+  } else {
+    const w = monthWindow(now, opts.month)
+    start = w.start
+    end = w.end
+  }
+  const rows = db.prepare(`
+    SELECT cs.provider as provider, cs.source_type as source_type, cli.service_name as service_name,
+           cli.charge_period_start as charge_period_start, cli.billed_cost as billed_cost,
+           cli.currency as currency, cli.confidence as confidence,
+           cli.original_amount as original_amount, cli.original_currency as original_currency
+    FROM cost_line_items cli JOIN cost_sources cs ON cs.id = cli.source_id
+    WHERE cli.charge_period_start < @end AND cli.charge_period_end > @start AND cli.voided_at IS NULL
+    ORDER BY cli.charge_period_start ASC, cs.provider ASC
+  `).all({ start, end }) as Row[]
+
+  return rows.map(r => ({
+    provider: r.provider,
+    source_type: r.source_type,
+    service_name: r.service_name,
+    period: monthWindow(r.charge_period_start).key,
+    amount: r.billed_cost,
+    currency: r.currency,
+    confidence: r.confidence,
+    original_amount: r.original_amount ?? null,
+    original_currency: r.original_currency ?? null,
+  }))
+}
+
+function csvEscape(v: unknown): string {
+  const s = v === null || v === undefined ? '' : String(v)
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+/** Generic CSV serializer -- header row + one row per object, in `headers` order. Reused by every *ToCsv export below (including `rowsToCsv`, kept byte-identical for the already-live GET /api/costs/export route). */
+export function objectsToCsv<T extends Record<string, unknown>>(rows: T[], headers: string[]): string {
+  const lines = [headers.join(',')]
+  for (const r of rows) {
+    lines.push(headers.map(h => csvEscape(r[h])).join(','))
+  }
+  return lines.join('\n') + '\n'
+}
+
+export function rowsToCsv(rows: ExportRow[]): string {
+  const headers = ['provider', 'source_type', 'service_name', 'period', 'amount', 'currency', 'confidence', 'original_amount', 'original_currency']
+  return objectsToCsv(rows as unknown as Record<string, unknown>[], headers)
+}
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }
+
+// ---- export envelope (GAP-18: every export carries schema_version + generated_at) ---------
+
+export interface ExportMeta {
+  schema_version: number
+  generated_at: number
+  scope: string
+  month?: string
+  from_month?: string
+  to_month?: string
+}
+
+const EXPORT_SCHEMA_VERSION = 1
+
+function buildMeta(scope: string, now: number, opts: { month?: string; fromMonth?: string; toMonth?: string } = {}): ExportMeta {
+  const meta: ExportMeta = { schema_version: EXPORT_SCHEMA_VERSION, generated_at: now, scope }
+  if (opts.month) meta.month = opts.month
+  if (opts.fromMonth) meta.from_month = opts.fromMonth
+  if (opts.toMonth) meta.to_month = opts.toMonth
+  return meta
+}
+
+// ---- 1. ledger (JSON/CSV with meta -- wraps the existing v0.7 exportCostRows/rowsToCsv) ----
+
+export interface LedgerExport { meta: ExportMeta; rows: ExportRow[] }
+
+export function exportLedgerJson(db: Database.Database, now: number, opts: { month?: string; fromMonth?: string; toMonth?: string } = {}): LedgerExport {
+  return { meta: buildMeta('ledger', now, opts), rows: exportCostRows(db, now, opts) }
+}
+
+export function exportLedgerCsv(db: Database.Database, now: number, opts: { month?: string; fromMonth?: string; toMonth?: string } = {}): { meta: ExportMeta; csv: string } {
+  return { meta: buildMeta('ledger', now, opts), csv: rowsToCsv(exportCostRows(db, now, opts)) }
+}
+
+// ---- 2. source inventory --------------------------------------------------------------------
+
+export interface SourceInventoryExport { meta: ExportMeta; sources: SourceInventoryEntry[] }
+
+/** Reuses inventory.ts's buildSourceInventory verbatim -- already excludes account_ref/secret. */
+export function exportSourceInventory(db: Database.Database, config: CostOpsConfig, now: number, deps: { credentialChecker?: CredentialChecker } = {}): SourceInventoryExport {
+  return { meta: buildMeta('source_inventory', now), sources: buildSourceInventory(db, config, now, deps) }
+}
+
+export function sourceInventoryToCsv(sources: SourceInventoryEntry[]): string {
+  const headers = ['source_id', 'name', 'provider', 'source_type', 'lifecycle', 'provenance', 'collection_method', 'freshness', 'sync_cadence', 'owner', 'operational_inclusion_rule', 'manual_fallback', 'blocker']
+  return objectsToCsv(sources as unknown as Record<string, unknown>[], headers)
+}
+
+// ---- 3. provider summary --------------------------------------------------------------------
+
+export interface ProviderSummaryExport {
+  meta: ExportMeta
+  operational_spend: number
+  provider_breakdown: CostSummary['operational']['provider_breakdown']
+}
+
+/** Reuses getCostSummary().operational.provider_breakdown -- the SAME provider aggregate the dashboard's operational KPI resolves, so this always matches it. */
+export function exportProviderSummary(db: Database.Database, config: CostOpsConfig, now: number, opts: { month?: string } = {}): ProviderSummaryExport {
+  const summary = getCostSummary(db, config, now, { monthKey: opts.month })
+  return { meta: buildMeta('provider_summary', now, opts), operational_spend: summary.operational_spend, provider_breakdown: summary.operational.provider_breakdown }
+}
+
+export function providerSummaryToCsv(rows: CostSummary['operational']['provider_breakdown']): string {
+  return objectsToCsv(rows as unknown as Record<string, unknown>[], ['provider', 'spend', 'confidence'])
+}
+
+// ---- 4. category summary (by cost_sources.source_type) --------------------------------------
+
+export interface CategorySummaryRow { source_type: string; spend: number }
+export interface CategorySummaryExport { meta: ExportMeta; categories: CategorySummaryRow[] }
+
+interface CategoryLineRow { source_type: string; billed_cost: number; confidence: string; source_id: string }
+
+/**
+ * Groups the SAME confidence-resolved per-source line ledger.ts's own
+ * headline resolution uses (best line per source by CONF_PRIORITY, excluding
+ * pending/plan-estimate lines) by `cost_sources.source_type` -- a cost
+ * CATEGORY in this codebase's vocabulary (subscription/hosting/domain/saas/
+ * usage/manual), distinct from `charge_category` (usage/subscription/
+ * purchase/tax/credit/adjustment).
+ */
+function resolveCategorySummary(db: Database.Database, win: ReturnType<typeof monthWindow>): CategorySummaryRow[] {
+  const rows = db.prepare(`
+    SELECT cs.source_type as source_type, cli.billed_cost as billed_cost, cli.confidence as confidence, cli.source_id as source_id
+    FROM cost_line_items cli JOIN cost_sources cs ON cs.id = cli.source_id
+    WHERE cli.charge_period_start < @end AND cli.charge_period_end > @start AND cli.voided_at IS NULL
+      AND cli.confidence NOT IN ('pending_permission', 'provider_plan_estimate')
+  `).all({ start: win.start, end: win.end }) as CategoryLineRow[]
+  const bySource = new Map<string, CategoryLineRow>()
+  for (const r of rows) {
+    const cur = bySource.get(r.source_id)
+    if (!cur || (CONF_PRIORITY[r.confidence] || 0) > (CONF_PRIORITY[cur.confidence] || 0)) bySource.set(r.source_id, r)
+  }
+  const byCategory = new Map<string, number>()
+  for (const r of bySource.values()) byCategory.set(r.source_type, round2((byCategory.get(r.source_type) || 0) + r.billed_cost))
+  return [...byCategory.entries()].map(([source_type, spend]) => ({ source_type, spend })).sort((a, b) => b.spend - a.spend)
+}
+
+export function exportCategorySummary(db: Database.Database, now: number, opts: { month?: string } = {}): CategorySummaryExport {
+  const win = monthWindow(now, opts.month)
+  return { meta: buildMeta('category_summary', now, opts), categories: resolveCategorySummary(db, win) }
+}
+
+export function categorySummaryToCsv(rows: CategorySummaryRow[]): string {
+  return objectsToCsv(rows as unknown as Record<string, unknown>[], ['source_type', 'spend'])
+}
+
+// ---- 5. budget variance ----------------------------------------------------------------------
+
+export interface BudgetVarianceExport {
+  meta: ExportMeta
+  // Legacy single global-budget shape (v0.4-era, kept for back-compat).
+  budget: (NonNullable<CostSummary['budget']> & { spend_variance: number; forecast_variance: number }) | null
+  // Phase 3 (GAP-11): every configured budget -- global, provider, category,
+  // source -- each with its own current_spend/forecast/variance/status.
+  budgets: BudgetStatus[]
+}
+
+export function exportBudgetVariance(db: Database.Database, config: CostOpsConfig, now: number, opts: { month?: string } = {}): BudgetVarianceExport {
+  const summary = getCostSummary(db, config, now, { monthKey: opts.month })
+  const b = summary.budget
+  const budget = b ? {
+    ...b,
+    spend_variance: round2(summary.operational_spend - b.amount),
+    forecast_variance: round2(summary.operational_forecast_month_end - b.amount),
+  } : null
+  const budgets = config.budgets.map(entry => resolveBudgetStatus(entry, summary))
+  return { meta: buildMeta('budget_variance', now, opts), budget, budgets }
+}
+
+// ---- 6. reconciliation report ------------------------------------------------------------------
+
+export interface ReconciliationReportExport { meta: ExportMeta; sources: SourceReconciliation[] }
+
+export function exportReconciliationReport(db: Database.Database, now: number, month?: string): ReconciliationReportExport {
+  return { meta: buildMeta('reconciliation_report', now, month ? { month } : {}), sources: buildReconciliation(db, now, month) }
+}
+
+export function reconciliationReportToCsv(rows: SourceReconciliation[]): string {
+  const headers = ['source_id', 'name', 'provider', 'month', 'expected_amount', 'observed_provider_amount', 'invoice_amount', 'operationally_selected_amount', 'variance', 'variance_reason', 'status']
+  return objectsToCsv(rows as unknown as Record<string, unknown>[], headers)
+}
+
+// ---- 7. forecast history --------------------------------------------------------------------
+
+export interface ForecastHistoryExport { meta: ExportMeta; snapshots: ForecastSnapshotRow[] }
+
+export function exportForecastHistory(db: Database.Database, now: number, opts: { month?: string; limit?: number } = {}): ForecastHistoryExport {
+  return { meta: buildMeta('forecast_history', now, opts.month ? { month: opts.month } : {}), snapshots: listForecastSnapshots(db, opts) }
+}
+
+// ---- 7b. alerts (GAP-12) --------------------------------------------------------------------
+
+export interface AlertsExport { meta: ExportMeta; alerts: AlertRecord[] }
+
+/** Active alerts by default (matches GET /api/costs/alerts' default view); includeResolved for the full history. */
+export function exportAlerts(db: Database.Database, now: number, opts: { includeResolved?: boolean } = {}): AlertsExport {
+  return {
+    meta: buildMeta(opts.includeResolved ? 'alerts_all' : 'alerts_active', now),
+    alerts: listAlerts(db, { status: opts.includeResolved ? 'all' : 'active' }),
+  }
+}
+
+export function alertsToCsv(rows: AlertRecord[]): string {
+  const headers = ['dedup_key', 'type', 'severity', 'first_seen', 'last_seen', 'acknowledged_at', 'resolved_at', 'recurrence_count']
+  return objectsToCsv(rows as unknown as Record<string, unknown>[], headers)
+}
+
+// ---- 8. data quality report --------------------------------------------------------------------
+
+export interface DataQualityExport {
+  meta: ExportMeta
+  confidence_breakdown: Record<string, number>
+  breakdown: { fixed_manual: number; provider: number; estimate: number }
+  data_freshness: number | null
+  source_freshness_counts: Record<Freshness, number>
+}
+
+export function exportDataQualityReport(db: Database.Database, config: CostOpsConfig, now: number, opts: { month?: string } = {}): DataQualityExport {
+  const summary = getCostSummary(db, config, now, { monthKey: opts.month })
+  const inventory = buildSourceInventory(db, config, now)
+  const counts: Record<Freshness, number> = { fresh: 0, aging: 0, stale: 0, unknown: 0 }
+  for (const s of inventory) counts[s.freshness] += 1
+  return {
+    meta: buildMeta('data_quality_report', now, opts),
+    confidence_breakdown: summary.confidence_breakdown,
+    breakdown: summary.breakdown,
+    data_freshness: summary.data_freshness,
+    source_freshness_counts: counts,
+  }
+}
+
+// ---- 9. monthly snapshot (bundle -- NOT an immutable close, see note) --------------------------
+
+export interface MonthlySnapshotExport {
+  meta: ExportMeta
+  note: string
+  period_status: PeriodCloseStatus
+  ledger: ExportRow[]
+  provider_summary: CostSummary['operational']['provider_breakdown']
+  category_summary: CategorySummaryRow[]
+  budget: BudgetVarianceExport['budget']
+  reconciliation: SourceReconciliation[]
+  data_quality: Omit<DataQualityExport, 'meta'>
+}
+
+/**
+ * Bundles ledger + provider/category summary + budget + reconciliation +
+ * data quality for one month into a single JSON artifact ("a month's state,
+ * auditable without the dashboard" -- GAP-18's target).
+ *
+ * This is a LIVE recomputation, not the immutable close record -- period
+ * close/reopen (GAP-13) landed on this branch (period-close.ts), so a real
+ * `period_status` is included here for honesty, but if the month is
+ * 'closed' the AUTHORITATIVE, frozen artifact is
+ * `getCloseSnapshot()`/`GET /api/costs/period-close?month=` (the CostSummary
+ * exactly as it was at close time). This bundle always reflects the
+ * CURRENT live state instead -- for an open/reopened month that's the only
+ * option; for a closed month it can still legitimately drift from the frozen
+ * close snapshot if a correction lands afterward, which is why `note` below
+ * says so explicitly rather than letting a consumer assume the two always
+ * agree.
+ */
+export function exportMonthlySnapshot(db: Database.Database, config: CostOpsConfig, now: number, month?: string): MonthlySnapshotExport {
+  const opts = month ? { month } : {}
+  const win = monthWindow(now, month)
+  const ledger = exportCostRows(db, now, opts)
+  const provider = exportProviderSummary(db, config, now, opts)
+  const category = exportCategorySummary(db, now, opts)
+  const budget = exportBudgetVariance(db, config, now, opts)
+  const reconciliation = exportReconciliationReport(db, now, month)
+  const dq = exportDataQualityReport(db, config, now, opts)
+  return {
+    meta: buildMeta('monthly_snapshot', now, opts),
+    note: 'Live recomputation of the current state, not the frozen close record -- for a closed month, GET /api/costs/period-close?month= returns the immutable snapshot taken at close time instead; this bundle can drift from it if a correction lands afterward.',
+    period_status: getPeriodStatus(db, win.key),
+    ledger,
+    provider_summary: provider.provider_breakdown,
+    category_summary: category.categories,
+    budget: budget.budget,
+    reconciliation: reconciliation.sources,
+    data_quality: { confidence_breakdown: dq.confidence_breakdown, breakdown: dq.breakdown, data_freshness: dq.data_freshness, source_freshness_counts: dq.source_freshness_counts },
+  }
+}

--- a/src/costops/forecast-capture.ts
+++ b/src/costops/forecast-capture.ts
@@ -1,0 +1,151 @@
+// CostOps Phase 1 -- forecast-snapshot capture (GAP-10 orchestration layer).
+//
+// Anvil's forecast.ts (buildfejleszto-costops-forecast) is pure computation
+// only, by design -- no DB reads. This module is the thin orchestration on
+// top: gather each active source's current-month signals from the DB, call
+// resolveSourceForecast() per source, and persist one snapshot row per source
+// (+ one whole-deployment TOTAL row) via forecast_snapshots. Wired into the
+// boot seam (startCostOpsBackgroundTasks) for the daily capture cadence.
+
+import type Database from 'better-sqlite3'
+import { monthWindow, CONF_PRIORITY, type MonthWindow } from './ledger.js'
+import { resolveSourceForecast, forecastSnapshotDedupKey, type ForecastResult, type ForecastContext } from './forecast.js'
+import type { BalanceSnapshot } from './collectors/deepseek.js'
+
+interface SourceRow {
+  id: string
+  provider: string
+}
+
+interface LineRow {
+  source_id: string
+  billed_cost: number
+  charge_category: string
+  confidence: string
+}
+
+function resolveBestLinePerSource(db: Database.Database, win: MonthWindow): Map<string, LineRow> {
+  const lines = db.prepare(`
+    SELECT source_id, billed_cost, charge_category, confidence
+    FROM cost_line_items
+    WHERE charge_period_start < @end AND charge_period_end > @start
+      AND voided_at IS NULL AND confidence NOT IN ('pending_permission', 'provider_plan_estimate')
+  `).all({ start: win.start, end: win.end }) as LineRow[]
+  const bySource = new Map<string, LineRow[]>()
+  for (const l of lines) {
+    const arr = bySource.get(l.source_id); if (arr) arr.push(l); else bySource.set(l.source_id, [l])
+  }
+  const resolved = new Map<string, LineRow>()
+  for (const [sid, ls] of bySource) {
+    resolved.set(sid, ls.reduce((a, b) => (CONF_PRIORITY[b.confidence] || 0) > (CONF_PRIORITY[a.confidence] || 0) ? b : a))
+  }
+  return resolved
+}
+
+function balanceSnapshotsForProvider(db: Database.Database, provider: string): BalanceSnapshot[] {
+  return db.prepare(`
+    SELECT balance, captured_at FROM provider_balance_snapshots
+    WHERE provider = ? ORDER BY captured_at ASC
+  `).all(provider) as BalanceSnapshot[]
+}
+
+interface StoredForecast {
+  source_id: string | null
+  result: ForecastResult
+}
+
+function insertSnapshot(db: Database.Database, opts: { sourceId: string | null; month: string; now: number; result: ForecastResult }): void {
+  const dedup = forecastSnapshotDedupKey(opts.sourceId, opts.month, opts.now)
+  db.prepare(`
+    INSERT OR IGNORE INTO forecast_snapshots
+      (source_id, month, snapshot_at, method, forecast_amount, confidence, note, dedup_key, created_at)
+    VALUES (@source_id, @month, @now, @method, @amount, @confidence, @note, @dedup, @now)
+  `).run({
+    source_id: opts.sourceId, month: opts.month, now: opts.now,
+    method: opts.result.method, amount: opts.result.amount, confidence: opts.result.confidence,
+    note: opts.result.note, dedup: dedup,
+  })
+}
+
+/**
+ * Capture one forecast snapshot per active source for the current month,
+ * plus one whole-deployment TOTAL snapshot (source_id null, per
+ * forecast.ts's documented convention). Idempotent per calendar day (dedup_key
+ * includes the day) -- a second capture the same day is a no-op, matching
+ * "every historical forecast stays reproducible, never silently rewritten."
+ *
+ * Signal availability today: cadence/last_invoice_amount/manual_override are
+ * not yet threaded from costops-subscriptions.json, so resolveSourceForecast
+ * falls through to its usage/fixed-subscription defaults for those sources --
+ * honest given the data actually on hand, not a fabricated cadence guess.
+ * Wiring subscriptions-derived cadence is a natural Phase 1 follow-up, not
+ * done here to keep this capture pass additive and independently testable.
+ */
+export function captureForecastSnapshots(db: Database.Database, now: number): StoredForecast[] {
+  const win = monthWindow(now)
+  const sources = db.prepare(`SELECT id, provider FROM cost_sources WHERE active = 1`).all() as SourceRow[]
+  const bestLine = resolveBestLinePerSource(db, win)
+  const results: StoredForecast[] = []
+  let total = 0
+
+  for (const s of sources) {
+    const line = bestLine.get(s.id)
+    const mtd_amount = line?.billed_cost ?? 0
+    const ctx: ForecastContext = {
+      mtd_amount,
+      win,
+      now,
+      data_confidence: (line?.confidence as ForecastContext['data_confidence']) ?? 'manual',
+      charge_category: line?.charge_category,
+      balance_snapshots: (() => {
+        const snaps = balanceSnapshotsForProvider(db, s.provider)
+        return snaps.length > 0 ? snaps : undefined
+      })(),
+    }
+    const result = resolveSourceForecast(ctx)
+    insertSnapshot(db, { sourceId: s.id, month: win.key, now, result })
+    results.push({ source_id: s.id, result })
+    total += result.amount
+  }
+
+  const totalResult: ForecastResult = {
+    method: 'fixed_subscription',
+    amount: Math.round(total * 100) / 100,
+    confidence: results.length > 0 ? 'medium' : 'low',
+    note: `whole-deployment total -- sum of ${results.length} per-source forecasts`,
+  }
+  insertSnapshot(db, { sourceId: null, month: win.key, now, result: totalResult })
+  results.push({ source_id: null, result: totalResult })
+
+  return results
+}
+
+export interface ForecastSnapshotRow {
+  source_id: string | null
+  month: string
+  snapshot_at: number
+  method: string
+  forecast_amount: number
+  confidence: string
+  note: string | null
+  actual_amount: number | null
+  forecast_error_absolute: number | null
+  forecast_error_percent: number | null
+}
+
+/** Read back stored forecast snapshots, most recent first, optionally filtered to one month. */
+export function listForecastSnapshots(db: Database.Database, opts: { month?: string; limit?: number } = {}): ForecastSnapshotRow[] {
+  const limit = opts.limit ?? 200
+  if (opts.month) {
+    return db.prepare(`
+      SELECT source_id, month, snapshot_at, method, forecast_amount, confidence, note,
+        actual_amount, forecast_error_absolute, forecast_error_percent
+      FROM forecast_snapshots WHERE month = ? ORDER BY snapshot_at DESC LIMIT ?
+    `).all(opts.month, limit) as ForecastSnapshotRow[]
+  }
+  return db.prepare(`
+    SELECT source_id, month, snapshot_at, method, forecast_amount, confidence, note,
+      actual_amount, forecast_error_absolute, forecast_error_percent
+    FROM forecast_snapshots ORDER BY snapshot_at DESC LIMIT ?
+  `).all(limit) as ForecastSnapshotRow[]
+}

--- a/src/costops/forecast.ts
+++ b/src/costops/forecast.ts
@@ -1,0 +1,330 @@
+// CostOps -- Phase 1 forecasting (GAP-10 / core-functional-scope-v1.0.1.md §10).
+//
+// Pure, deterministic, I/O-free computation layer -- one function per forecast
+// method (fixed subscription, time-proportional usage, balance-delta, invoice
+// cadence, one-time, manual override), a dispatcher that picks a method per
+// source, and forecast-vs-actual / forecast-error scoring once a month closes.
+// NO db.ts/web.ts edits: `initForecastSchema` is a schema DEFINER only, not
+// mounted anywhere yet -- the seam-refactor's `initCostOpsSchema(db)`
+// aggregator (Mason, accounting-core seam) calls it, per
+// docs/fork-upstream-policy.md §2a's thin-seam rule.
+
+import type Database from 'better-sqlite3'
+import type { MonthWindow } from './ledger.js'
+import type { CostConfidence } from './config.js'
+import { deriveMtdSpend, type BalanceSnapshot } from './collectors/deepseek.js'
+
+// ---- shared types ------------------------------------------------------------
+
+export type ForecastMethod =
+  | 'fixed_subscription'
+  | 'time_proportional_usage'
+  | 'balance_delta'
+  | 'invoice_cadence'
+  | 'one_time'
+  | 'manual_forecast'
+
+export type ForecastConfidence = 'high' | 'medium' | 'low'
+
+export interface ForecastResult {
+  method: ForecastMethod
+  amount: number
+  confidence: ForecastConfidence
+  note: string
+}
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }
+function round4(n: number): number { return Math.round(n * 10000) / 10000 }
+
+// ---- method 1: fixed monthly subscription / hosting / SaaS -------------------
+
+/**
+ * A fixed recurring fee (subscription, hosting, SaaS, domain) is owed in full
+ * for the period whether observed on day 1 or day 30 -- NEVER prorated by
+ * elapsed time (that would understate a fee seen early in the month).
+ * Confidence reflects how the AMOUNT itself was sourced: an invoice/provider-
+ * observed amount is a known fact (high); a manual/estimate amount is a known
+ * fee but self-reported (medium) -- never low, a fixed fee is not volatile.
+ */
+export function forecastFixedSubscription(periodAmount: number, dataConfidence: CostConfidence = 'manual'): ForecastResult {
+  const confidence: ForecastConfidence =
+    dataConfidence === 'actual_invoice' || dataConfidence === 'provider_api' || dataConfidence === 'billing_export'
+      ? 'high' : 'medium'
+  return {
+    method: 'fixed_subscription',
+    amount: round2(periodAmount),
+    confidence,
+    note: 'fixed monthly fee -- full period amount, not prorated (a fixed cost is owed whether seen day 1 or day 30)',
+  }
+}
+
+// ---- method 2: time-proportional usage ----------------------------------------
+
+// Below this fraction of the month elapsed, a straight run-rate is noisy (a
+// single heavy day can double it) -- confidence buckets, not a hard cutoff.
+const EARLY_MONTH_FRACTION = 0.15
+const MID_MONTH_FRACTION = 0.5
+
+/**
+ * Variable usage costs (metered API calls, token spend): month-end forecast =
+ * MTD amount scaled by the inverse of the elapsed fraction (a straight
+ * run-rate). Confidence rises as more of the month has actually been observed.
+ */
+export function forecastTimeProportionalUsage(mtdAmount: number, win: MonthWindow): ForecastResult {
+  const projected = mtdAmount / win.fractionElapsed
+  const confidence: ForecastConfidence =
+    win.fractionElapsed < EARLY_MONTH_FRACTION ? 'low'
+    : win.fractionElapsed < MID_MONTH_FRACTION ? 'medium'
+    : 'high'
+  return {
+    method: 'time_proportional_usage',
+    amount: round2(projected),
+    confidence,
+    note: `variable usage -- run-rate from ${Math.round(win.fractionElapsed * 100)}% of the month observed`,
+  }
+}
+
+// ---- method 3: balance-delta (prepaid providers, e.g. DeepSeek) --------------
+
+// Below this observed span, a burn rate is too noisy to extrapolate from --
+// mirrors collectors/deepseek.ts's exhaustion-forecast guard, but a month-end
+// AMOUNT forecast degrades to "MTD only" instead of returning null (there is
+// always a real MTD figure to show, unlike an exhaustion date).
+const MIN_FORECAST_SPAN_SECONDS = 86400
+
+/**
+ * Prepaid-balance sources: spend is derived from balance DROPS between
+ * snapshots (reuses `deriveMtdSpend` from collectors/deepseek.ts -- one
+ * definition of "a rise is a top-up, ignore it", not reimplemented here).
+ * Month-end forecast = this month's observed spend + (daily burn rate,
+ * computed from ALL supplied snapshots for a steadier base) * remaining days.
+ */
+export function forecastBalanceDelta(snapshotsAsc: BalanceSnapshot[], win: MonthWindow, now: number): ForecastResult {
+  const monthSnapshots = snapshotsAsc.filter(s => s.captured_at >= win.start && s.captured_at < win.end)
+  const mtd = deriveMtdSpend(monthSnapshots)
+
+  if (snapshotsAsc.length < 2) {
+    return { method: 'balance_delta', amount: round2(mtd), confidence: 'low', note: 'balance-delta: fewer than 2 snapshots -- MTD spend only, no extrapolation' }
+  }
+  const first = snapshotsAsc[0]
+  const last = snapshotsAsc[snapshotsAsc.length - 1]
+  const spanSeconds = last.captured_at - first.captured_at
+  const allSpend = deriveMtdSpend(snapshotsAsc)
+  if (spanSeconds < MIN_FORECAST_SPAN_SECONDS || allSpend <= 0) {
+    return { method: 'balance_delta', amount: round2(mtd), confidence: 'low', note: 'balance-delta: insufficient span or no net spend observed -- MTD only, no extrapolation' }
+  }
+  const dailyBurn = allSpend / (spanSeconds / 86400)
+  const remainingDays = Math.max(0, (win.end - now) / 86400)
+  const projected = mtd + dailyBurn * remainingDays
+  const confidence: ForecastConfidence =
+    spanSeconds < 3 * 86400 ? 'low'
+    : spanSeconds < 10 * 86400 ? 'medium'
+    : 'high'
+  return {
+    method: 'balance_delta',
+    amount: round2(projected),
+    confidence,
+    note: `balance-delta: MTD ${round2(mtd)} + ${round2(dailyBurn)}/day burn * ${round2(remainingDays)} remaining days`,
+  }
+}
+
+// ---- method 4: invoice cadence (non-monthly billing) --------------------------
+
+export type BillingCadence = 'monthly' | 'quarterly' | 'semiannual' | 'annual'
+
+const CADENCE_MONTHS: Record<BillingCadence, number> = { monthly: 1, quarterly: 3, semiannual: 6, annual: 12 }
+
+/**
+ * A cost billed less often than monthly (annual domain renewal, quarterly
+ * SaaS plan): the forecast contribution for THIS month is an ACCRUAL --
+ * the last known invoice divided evenly across its cadence -- not "the whole
+ * annual fee lands in one month." If the current month IS the actual invoice
+ * month, the full amount is used instead (the real cash event), via
+ * `isInvoiceMonth` -- the caller knows the renewal/billing date, this
+ * function does not guess it.
+ */
+export function forecastInvoiceCadence(
+  lastInvoiceAmount: number,
+  cadence: BillingCadence,
+  opts: { isInvoiceMonth?: boolean } = {},
+): ForecastResult {
+  const months = CADENCE_MONTHS[cadence]
+  if (opts.isInvoiceMonth) {
+    return { method: 'invoice_cadence', amount: round2(lastInvoiceAmount), confidence: 'high', note: `invoice cadence (${cadence}): this month is the invoice month -- full amount` }
+  }
+  const monthlyAccrual = lastInvoiceAmount / months
+  return {
+    method: 'invoice_cadence',
+    amount: round2(monthlyAccrual),
+    confidence: months === 1 ? 'high' : 'medium',
+    note: `invoice cadence (${cadence}): ${round2(lastInvoiceAmount)} / ${months} months monthly accrual, not an invoice month`,
+  }
+}
+
+// ---- method 5: one-time cost ---------------------------------------------------
+
+/**
+ * A one-time cost is never extrapolated from a run-rate. Already occurred
+ * this month -> the forecast equals the actual (no further growth expected).
+ * Not yet occurred -> 0 unless a planned amount is explicitly known in
+ * advance (e.g. a scheduled one-off) -- never fabricated.
+ */
+export function forecastOneTime(occurredAmount: number | null, plannedAmount: number | null = null): ForecastResult {
+  if (occurredAmount != null) {
+    return { method: 'one_time', amount: round2(occurredAmount), confidence: 'high', note: 'one-time cost already occurred this month -- forecast equals the actual, no extrapolation' }
+  }
+  if (plannedAmount != null) {
+    return { method: 'one_time', amount: round2(plannedAmount), confidence: 'medium', note: 'one-time cost planned but not yet occurred -- forecast uses the known planned amount' }
+  }
+  return { method: 'one_time', amount: 0, confidence: 'low', note: 'one-time cost not yet occurred and no planned amount known -- forecast 0, never fabricated from a run-rate' }
+}
+
+// ---- method 6: manual override -------------------------------------------------
+
+/** An operator-entered forecast figure, not derived from any observed data. */
+export function forecastManual(manualEstimate: number): ForecastResult {
+  return { method: 'manual_forecast', amount: round2(manualEstimate), confidence: 'low', note: 'operator-entered manual forecast -- not derived from observed data' }
+}
+
+// ---- dispatcher: pick a method per source --------------------------------------
+
+export interface ForecastContext {
+  mtd_amount: number
+  win: MonthWindow
+  now: number
+  data_confidence?: CostConfidence
+  balance_snapshots?: BalanceSnapshot[]
+  cadence?: BillingCadence
+  is_invoice_month?: boolean
+  last_invoice_amount?: number
+  charge_category?: string   // 'usage' | 'subscription' | 'purchase' | 'tax' | 'credit' | 'adjustment'
+  occurred_amount?: number | null
+  planned_amount?: number | null
+  manual_override?: number
+}
+
+/**
+ * Resolves ONE forecast method per source from context, in a fixed precedence
+ * order (documented, not implicit):
+ *   1. `manual_override` -- an operator's explicit figure always wins.
+ *   2. `balance_snapshots` present -- prepaid-balance sources.
+ *   3. non-monthly `cadence` + a known last invoice -- accrual/invoice-cadence.
+ *   4. `charge_category === 'purchase'` -- one-time cost.
+ *   5. `charge_category === 'usage'` -- time-proportional run-rate.
+ *   6. default -- fixed monthly subscription/hosting/SaaS.
+ */
+export function resolveSourceForecast(ctx: ForecastContext): ForecastResult {
+  if (ctx.manual_override != null) return forecastManual(ctx.manual_override)
+  if (ctx.balance_snapshots && ctx.balance_snapshots.length > 0) return forecastBalanceDelta(ctx.balance_snapshots, ctx.win, ctx.now)
+  if (ctx.cadence && ctx.cadence !== 'monthly' && ctx.last_invoice_amount != null) {
+    return forecastInvoiceCadence(ctx.last_invoice_amount, ctx.cadence, { isInvoiceMonth: ctx.is_invoice_month })
+  }
+  if (ctx.charge_category === 'purchase') return forecastOneTime(ctx.occurred_amount ?? null, ctx.planned_amount ?? null)
+  if (ctx.charge_category === 'usage') return forecastTimeProportionalUsage(ctx.mtd_amount, ctx.win)
+  return forecastFixedSubscription(ctx.mtd_amount, ctx.data_confidence)
+}
+
+// ---- forecast-vs-actual / forecast error ---------------------------------------
+
+export interface ForecastErrorResult {
+  absolute_error: number        // actual - forecast; positive = under-forecast, negative = over-forecast
+  percent_error: number | null  // (actual - forecast) / actual; null when actual is 0 (undefined, never fabricated)
+}
+
+/** Forecast-vs-actual once a month's real total is known (period close). */
+export function computeForecastError(forecastAmount: number, actualAmount: number): ForecastErrorResult {
+  return {
+    absolute_error: round2(actualAmount - forecastAmount),
+    percent_error: actualAmount !== 0 ? round4((actualAmount - forecastAmount) / actualAmount) : null,
+  }
+}
+
+export interface ForecastAccuracyRecord {
+  forecast_amount: number
+  actual_amount: number
+}
+
+export interface ForecastAccuracySummary {
+  key: string
+  count: number
+  mean_absolute_error: number
+  mean_percent_error: number | null  // null only if every record's actual was 0
+}
+
+/**
+ * Groups closed forecast/actual pairs by a caller-supplied key (provider,
+ * category, source -- caller decides) and reports mean absolute + mean
+ * percent error per group. GAP-10 acceptance: "provider- es kategoriaszintu
+ * pontossag merheto." Pure aggregation, no DB access -- the aggregator
+ * (Mason's seam) supplies already-closed rows from forecast_snapshots.
+ */
+export function summarizeForecastAccuracy<T extends ForecastAccuracyRecord>(records: T[], keyOf: (r: T) => string): ForecastAccuracySummary[] {
+  const groups = new Map<string, T[]>()
+  for (const r of records) {
+    const k = keyOf(r)
+    const arr = groups.get(k)
+    if (arr) arr.push(r); else groups.set(k, [r])
+  }
+  const out: ForecastAccuracySummary[] = []
+  for (const [key, rs] of groups) {
+    const errors = rs.map(r => computeForecastError(r.forecast_amount, r.actual_amount))
+    const mean_absolute_error = round2(errors.reduce((s, e) => s + Math.abs(e.absolute_error), 0) / errors.length)
+    const pcts = errors.map(e => e.percent_error).filter((p): p is number => p !== null)
+    const mean_percent_error = pcts.length > 0 ? round4(pcts.reduce((s, p) => s + Math.abs(p), 0) / pcts.length) : null
+    out.push({ key, count: rs.length, mean_absolute_error, mean_percent_error })
+  }
+  return out.sort((a, b) => b.count - a.count)
+}
+
+// ---- snapshot dedup key (pure -- the actual INSERT is the aggregator's job) ----
+
+/**
+ * One snapshot per source (or the whole-deployment total, `sourceId: null`)
+ * per calendar day (UTC) -- history is APPENDED across days, never
+ * overwritten same-day, matching GAP-10's "naponta vagy fontos valtozaskor
+ * snapshot keszul" / "minden snapshot reprodukalhato." Pure string
+ * construction; the aggregator uses this as `forecast_snapshots.dedup_key`.
+ */
+export function forecastSnapshotDedupKey(sourceId: string | null, month: string, snapshotAt: number): string {
+  const day = new Date(snapshotAt * 1000).toISOString().slice(0, 10)
+  return `${sourceId ?? 'TOTAL'}|${month}|${day}`
+}
+
+// ---- schema (DEFINER ONLY -- not mounted; see file header) ---------------------
+
+/**
+ * Schema DEFINER only. NOT called from db.ts -- per fork-upstream-policy.md
+ * §2a, the ONE seam mount (`initCostOpsSchema(db)` in db.ts calling this
+ * among the module's other schema definers) is the seam-refactor's job, done
+ * once alongside the rest of the accounting-core schema so db.ts gains a
+ * single line, not another scattered inline CREATE TABLE. Safe to call more
+ * than once (`IF NOT EXISTS`).
+ *
+ * `source_id` NULL = a whole-deployment TOTAL snapshot, never a sentinel
+ * string. Rows are APPENDED (one per source per day via `dedup_key`), never
+ * overwritten -- every historical forecast stays reproducible.
+ * `actual_amount`/`forecast_error_*` stay NULL until period close fills them
+ * in; a forecast row is never silently rewritten to look like it always knew
+ * the actual.
+ */
+export function initForecastSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS forecast_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_id TEXT REFERENCES cost_sources(id),
+      month TEXT NOT NULL,
+      snapshot_at INTEGER NOT NULL,
+      method TEXT NOT NULL,
+      forecast_amount REAL NOT NULL,
+      confidence TEXT NOT NULL,
+      note TEXT,
+      actual_amount REAL,
+      forecast_error_absolute REAL,
+      forecast_error_percent REAL,
+      dedup_key TEXT UNIQUE,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_forecast_snapshots_month ON forecast_snapshots(month)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_forecast_snapshots_source ON forecast_snapshots(source_id, month)`)
+}

--- a/src/costops/forecast.ts
+++ b/src/costops/forecast.ts
@@ -6,8 +6,8 @@
 // source, and forecast-vs-actual / forecast-error scoring once a month closes.
 // NO db.ts/web.ts edits: `initForecastSchema` is a schema DEFINER only, not
 // mounted anywhere yet -- the seam-refactor's `initCostOpsSchema(db)`
-// aggregator (Mason, accounting-core seam) calls it, per
-// docs/fork-upstream-policy.md §2a's thin-seam rule.
+// aggregator (Mason, accounting-core seam) calls it, keeping this feature's
+// whole schema behind one mount point in db.ts.
 
 import type Database from 'better-sqlite3'
 import type { MonthWindow } from './ledger.js'
@@ -293,9 +293,9 @@ export function forecastSnapshotDedupKey(sourceId: string | null, month: string,
 // ---- schema (DEFINER ONLY -- not mounted; see file header) ---------------------
 
 /**
- * Schema DEFINER only. NOT called from db.ts -- per fork-upstream-policy.md
- * §2a, the ONE seam mount (`initCostOpsSchema(db)` in db.ts calling this
- * among the module's other schema definers) is the seam-refactor's job, done
+ * Schema DEFINER only. NOT called from db.ts: the ONE seam mount
+ * (`initCostOpsSchema(db)` in db.ts calling this among the module's other
+ * schema definers) is the seam-refactor's job, done
  * once alongside the rest of the accounting-core schema so db.ts gains a
  * single line, not another scattered inline CREATE TABLE. Safe to call more
  * than once (`IF NOT EXISTS`).

--- a/src/costops/fx.ts
+++ b/src/costops/fx.ts
@@ -1,0 +1,243 @@
+// CostOps -- Phase 1 FX provenance (GAP-09 / core-functional-scope-v1.0.1.md §9).
+//
+// Pure, deterministic, I/O-free computation layer -- every converted amount
+// carries its full provenance (original_amount/original_currency/fx_rate/
+// fx_source/fx_date/conversion_method/huf_amount), a documented rounding
+// policy, invoice-date-vs-service-date rate selection, a close-time freeze
+// guard, and late-correction handling as an independent new event (never a
+// rewrite of the original conversion). NO db.ts/web.ts/schema.ts edits:
+// `initFxSchema` is a schema DEFINER only, not mounted anywhere -- the
+// seam-refactor's `initCostOpsSchema(db)` aggregator (Mason, accounting-core
+// seam, src/costops/schema.ts) calls it, per docs/fork-upstream-policy.md §2a.
+
+import type Database from 'better-sqlite3'
+
+// ---- shared types --------------------------------------------------------------
+
+// Where a rate came from -- an audit fact, not a trust ranking (unlike
+// CostConfidence in config.ts, which ranks the LINE ITEM's authoritativeness).
+export type FxSource = 'render_pricing_config' | 'manual' | 'ecb' | 'provider_invoice' | 'other'
+
+export type ConversionMethod =
+  | 'invoice_date_rate'    // rate as of the invoice's own date (preferred whenever an invoice exists)
+  | 'service_date_rate'    // rate as of the service/usage period (fallback when there's no invoice)
+  | 'correction_date_rate' // a late correction/credit/refund, rated as of the CORRECTION event, not the original
+
+export interface FxConversion {
+  original_amount: number
+  original_currency: string
+  fx_rate: number
+  fx_source: FxSource
+  fx_date: number       // epoch seconds -- the date the RATE is for (see resolveRateDate)
+  conversion_method: ConversionMethod
+  huf_amount: number
+  converted_at: number  // epoch seconds -- when this conversion was actually computed (audit, may differ from fx_date)
+}
+
+// ---- rate resolution + rounding policy ------------------------------------------
+
+export interface FxRateTable {
+  [currency: string]: number  // HUF per 1 unit of currency
+}
+
+/**
+ * Resolves a currency to a HUF rate. HUF is ALWAYS rate 1 (identity)
+ * regardless of what the table contains -- HUF never needs an external rate.
+ * Returns null (never a fabricated 1 or 0) for a currency the table doesn't
+ * cover, so the caller can surface "unpriced" the same way the rest of
+ * CostOps never fabricates a missing amount.
+ */
+export function resolveFxRate(currency: string, rates: FxRateTable): number | null {
+  const cur = currency.toUpperCase()
+  if (cur === 'HUF') return 1
+  const r = rates[cur]
+  return typeof r === 'number' && isFinite(r) && r > 0 ? r : null
+}
+
+/**
+ * HUF rounding policy: 2 decimal places -- matches the existing ledger
+ * convention (src/costops/ledger.ts's private round2, duplicated here per
+ * this module's own file-local-helper convention, same as every other
+ * costops/*.ts file). HUF has no minor unit in circulation today, but
+ * keeping 2dp precision here avoids compounding rounding error across a
+ * chain of conversions/corrections; a DISPLAY layer rounds to whole forint
+ * for presentation, this layer never does.
+ */
+export function roundHuf(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+// ---- invoice-date vs service-date rate selection --------------------------------
+
+export type RateDateBasis = 'invoice_date' | 'service_date'
+
+/**
+ * Which date's rate to use for a conversion. An invoice fixes the actual
+ * transaction, so its own date's rate is preferred whenever an invoice date
+ * is known. `service_date` (the line's charge/usage period) is the fallback
+ * for lines with no invoice reference at all (e.g. a manual/estimate cost).
+ */
+export function resolveRateDate(invoiceDate: number | null, serviceDate: number): { date: number; basis: RateDateBasis } {
+  if (invoiceDate != null) return { date: invoiceDate, basis: 'invoice_date' }
+  return { date: serviceDate, basis: 'service_date' }
+}
+
+function methodForBasis(basis: RateDateBasis): ConversionMethod {
+  return basis === 'invoice_date' ? 'invoice_date_rate' : 'service_date_rate'
+}
+
+// ---- the conversion itself --------------------------------------------------------
+
+/**
+ * Converts an original-currency amount to HUF with FULL provenance --
+ * GAP-09's core acceptance criterion: every converted line carries
+ * original_amount/original_currency/fx_rate/fx_source/fx_date/
+ * conversion_method/huf_amount TOGETHER, never a bare converted number.
+ * Returns null (never a fabricated conversion) when the currency has no
+ * resolvable rate in `rates`.
+ */
+export function convertToHufWithProvenance(
+  amount: number,
+  currency: string,
+  rates: FxRateTable,
+  opts: { fxSource: FxSource; invoiceDate: number | null; serviceDate: number; now: number },
+): FxConversion | null {
+  const cur = currency.toUpperCase()
+  const rate = resolveFxRate(cur, rates)
+  if (rate == null) return null
+  const { date, basis } = resolveRateDate(opts.invoiceDate, opts.serviceDate)
+  return {
+    original_amount: amount,
+    original_currency: cur,
+    fx_rate: rate,
+    fx_source: opts.fxSource,
+    fx_date: date,
+    conversion_method: methodForBasis(basis),
+    huf_amount: roundHuf(amount * rate),
+    converted_at: opts.now,
+  }
+}
+
+// ---- close-time FX freeze --------------------------------------------------------
+
+export type PeriodStatus = 'open' | 'provisional' | 'closed' | 'reopened'
+
+/**
+ * GAP-09 acceptance: "closed honap nem valtozik kesobbi FX-frissites miatt."
+ * A CLOSED period's already-stored FX conversion must never be silently
+ * recomputed with a newer rate. `reopened` legitimately allows
+ * recomputation -- that's an explicit, audited action (period-close
+ * module's concern), not a silent background refresh.
+ */
+export function canRecomputeFx(status: PeriodStatus): boolean {
+  return status !== 'closed'
+}
+
+// ---- late correction handling ------------------------------------------------------
+
+export interface FxCorrectionInput {
+  originalCurrency: string
+  correctionAmountOriginalCurrency: number  // signed: negative = credit/refund reducing the original charge
+  correctionDate: number
+  correctionRate: number
+  correctionSource: FxSource
+  now: number
+}
+
+/**
+ * A correction/credit/refund arriving after the original conversion is a
+ * SEPARATE ledger event with its OWN fx rate/date -- rated as of the
+ * correction event, never a rewrite of the original conversion (GAP-09:
+ * "kesoi correction FX-kezelese"; mirrors GAP-14's void/supersede-not-
+ * overwrite principle applied to the FX dimension specifically). The
+ * original FxConversion this correction relates to is untouched by this
+ * function -- it only ever produces a new, independent one.
+ */
+export function convertCorrectionToHuf(input: FxCorrectionInput): FxConversion {
+  return {
+    original_amount: input.correctionAmountOriginalCurrency,
+    original_currency: input.originalCurrency.toUpperCase(),
+    fx_rate: input.correctionRate,
+    fx_source: input.correctionSource,
+    fx_date: input.correctionDate,
+    conversion_method: 'correction_date_rate',
+    huf_amount: roundHuf(input.correctionAmountOriginalCurrency * input.correctionRate),
+    converted_at: input.now,
+  }
+}
+
+// ---- historical rate lookup (reproducibility) --------------------------------------
+
+export interface FxRateRecord {
+  currency: string
+  rate: number
+  fx_source: FxSource
+  effective_date: number
+}
+
+/**
+ * Finds the rate in effect for `currency` at `atDate` from a set of
+ * historical rate records -- the MOST RECENT record with
+ * effective_date <= atDate wins; a future rate is never applied to a past
+ * date. Returns null (never fabricated) if no record exists at or before
+ * atDate for that currency. Pure: caller supplies already-queried rows (the
+ * aggregator reads them from the `fx_rates` table `initFxSchema` defines).
+ * This is what makes GAP-09's "ugyanaz a ledger-sor reprodukalhato
+ * HUF-erteket ad" acceptance criterion possible: re-running a conversion
+ * against the SAME historical snapshot always resolves the same rate, even
+ * after the live/current rate has since moved on.
+ */
+export function lookupHistoricalRate(records: FxRateRecord[], currency: string, atDate: number): FxRateRecord | null {
+  const cur = currency.toUpperCase()
+  const candidates = records.filter(r => r.currency.toUpperCase() === cur && r.effective_date <= atDate)
+  if (candidates.length === 0) return null
+  return candidates.reduce((a, b) => (b.effective_date > a.effective_date ? b : a))
+}
+
+/**
+ * One recorded rate per (currency, source, UTC day) -- multiple captures the
+ * same day update in place rather than accumulating noise, while still
+ * keeping day-level history for `lookupHistoricalRate`. Pure string
+ * construction; the aggregator uses this as `fx_rates.dedup_key`.
+ */
+export function fxRateDedupKey(currency: string, source: FxSource, effectiveDate: number): string {
+  const day = new Date(effectiveDate * 1000).toISOString().slice(0, 10)
+  return `${currency.toUpperCase()}|${source}|${day}`
+}
+
+// ---- schema (DEFINER ONLY -- not mounted; see file header) -----------------------------
+
+/**
+ * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts -- per
+ * fork-upstream-policy.md §2a, the ONE seam mount (`initCostOpsSchema(db)` in
+ * schema.ts calling this among the module's other schema definers) is the
+ * seam-refactor's job. Safe to call more than once (`IF NOT EXISTS` /
+ * `ADD COLUMN` wrapped in try/catch, matching schema.ts's own convention).
+ *
+ * Adds two things:
+ * 1. `fx_source` / `conversion_method` columns on `cost_line_items` --
+ *    additive to the `original_amount`/`original_currency`/`fx_rate`/
+ *    `fx_date` columns schema.ts already has (v0.7); nullable, no default,
+ *    every write site sets them explicitly.
+ * 2. `fx_rates`: an APPENDED history of every rate actually used, keyed by
+ *    (currency, source, day) via `dedup_key` -- the source of truth
+ *    `lookupHistoricalRate` reads from. Without this table, "reproducible
+ *    HUF value" would depend on the live/mutable render-pricing config
+ *    still holding today's rate tomorrow, which it will not.
+ */
+export function initFxSchema(db: Database.Database): void {
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN fx_source TEXT`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN conversion_method TEXT`) } catch { /* already exists */ }
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS fx_rates (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      currency TEXT NOT NULL,
+      rate REAL NOT NULL,
+      fx_source TEXT NOT NULL,
+      effective_date INTEGER NOT NULL,
+      captured_at INTEGER NOT NULL,
+      dedup_key TEXT UNIQUE
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_fx_rates_currency_date ON fx_rates(currency, effective_date)`)
+}

--- a/src/costops/fx.ts
+++ b/src/costops/fx.ts
@@ -8,7 +8,8 @@
 // rewrite of the original conversion). NO db.ts/web.ts/schema.ts edits:
 // `initFxSchema` is a schema DEFINER only, not mounted anywhere -- the
 // seam-refactor's `initCostOpsSchema(db)` aggregator (Mason, accounting-core
-// seam, src/costops/schema.ts) calls it, per docs/fork-upstream-policy.md §2a.
+// seam, src/costops/schema.ts) calls it, keeping every CostOps table behind
+// that single mount point.
 
 import type Database from 'better-sqlite3'
 
@@ -208,10 +209,10 @@ export function fxRateDedupKey(currency: string, source: FxSource, effectiveDate
 // ---- schema (DEFINER ONLY -- not mounted; see file header) -----------------------------
 
 /**
- * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts -- per
- * fork-upstream-policy.md §2a, the ONE seam mount (`initCostOpsSchema(db)` in
- * schema.ts calling this among the module's other schema definers) is the
- * seam-refactor's job. Safe to call more than once (`IF NOT EXISTS` /
+ * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts: the ONE
+ * seam mount (`initCostOpsSchema(db)` in schema.ts calling this among the
+ * module's other schema definers) is the seam-refactor's job. Safe to call more
+ * than once (`IF NOT EXISTS` /
  * `ADD COLUMN` wrapped in try/catch, matching schema.ts's own convention).
  *
  * Adds two things:

--- a/src/costops/inventory.ts
+++ b/src/costops/inventory.ts
@@ -1,0 +1,228 @@
+// CostOps Phase 0 -- full source inventory (gap-analysis GAP-03/GAP-04).
+//
+// Gathers the raw signals (cost_sources, import_runs, cost_line_items,
+// config overrides) and feeds them through lifecycle.ts's pure derivation,
+// so every known source gets an unambiguous lifecycle + provenance + the
+// "what does a human need to do next" fields the gap-analysis calls for.
+// Read-only, additive: does not touch getCostSummary's contract or any
+// existing route's output shape.
+
+import type Database from 'better-sqlite3'
+import type { CostOpsConfig } from './config.js'
+import { deriveSourceLifecycle, deriveProvenance, type SourceLifecycle, type SourceProvenance } from './lifecycle.js'
+import { getSecret } from '../web/vault.js'
+
+export type Freshness = 'fresh' | 'aging' | 'stale' | 'unknown'
+// Honest today: no collector in this codebase is wired to an automatic boot-time
+// interval (verified 2026-07-15 -- only syncFixedCostsToLedger is; every provider
+// collector is POST /api/costs/sync-triggered only). 'automatic_interval' is kept
+// in the enum for the day that changes, not fabricated as the current state.
+export type SyncCadence = 'manual' | 'automatic_interval' | 'config_driven'
+export type OperationalInclusionRule = 'operational' | 'advisory_plan_estimate' | 'pending_permission_excluded' | 'no_data_yet'
+
+export interface SourceInventoryEntry {
+  source_id: string
+  name: string
+  provider: string
+  source_type: string
+  lifecycle: SourceLifecycle
+  provenance: SourceProvenance
+  collection_method: 'provider_api_collector' | 'email_invoice_ingest' | 'manual_config' | 'unknown'
+  freshness: Freshness
+  last_data_freshness: number | null
+  sync_cadence: SyncCadence
+  owner: string
+  operational_inclusion_rule: OperationalInclusionRule
+  manual_fallback: boolean
+  blocker: string | null
+  last_successful_sync: number | null
+  last_attempted_sync: number | null
+}
+
+// Providers whose cost_sources rows are created by a live API collector (see
+// runner.ts's upsertProviderLines / each collector's own upsert), keyed by
+// provider (not source_id -- source_id is derived at runtime, e.g. from
+// NormalizedCostLine.service, but provider is the stable, known key). Only
+// these need a credential presence check; every manual/invoice-driven source
+// (subscriptions, hosting, domain, ...) needs none -- credentialRequired=false
+// for them by construction.
+const CREDENTIAL_REGISTRY: Record<string, { checkKind: 'vault' | 'env'; id: string }> = {
+  openai: { checkKind: 'vault', id: 'open_api_adminkey_readonly' },
+  github: { checkKind: 'vault', id: 'github_plan' },
+  deepseek: { checkKind: 'vault', id: 'DEEPSEEK_API_KEY' },
+  render: { checkKind: 'env', id: 'RENDER_API_KEY' },
+}
+
+const DEFAULT_OWNER = process.env.COSTOPS_DEFAULT_OWNER || 'operator'
+
+// Freshness thresholds -- not business-specified (same flagged-placeholder
+// convention as warnings.ts's LARGE_INCREASE_FRACTION), tune once real 7-day
+// observation data exists.
+const FRESH_MAX_AGE_SECS = 3 * 24 * 3600
+const AGING_MAX_AGE_SECS = 10 * 24 * 3600
+
+function classifyFreshness(lastFreshness: number | null, now: number): Freshness {
+  if (lastFreshness == null) return 'unknown'
+  const age = now - lastFreshness
+  if (age <= FRESH_MAX_AGE_SECS) return 'fresh'
+  if (age <= AGING_MAX_AGE_SECS) return 'aging'
+  return 'stale'
+}
+
+interface SourceRow {
+  id: string
+  name: string
+  provider: string
+  source_type: string
+}
+
+interface RunRow {
+  provider: string
+  status: string
+  started_at: number
+  error_code: string | null
+}
+
+interface LineAggRow {
+  source_id: string
+  confidence: string | null
+  actual_source: string | null
+  max_freshness: number | null
+  ever_had_real_activity: number  // 0/1 from SQL, whether any non-voided row with billed_cost > 0 exists
+  is_pending: number
+  is_plan_estimate: number
+}
+
+export interface CredentialChecker {
+  (kind: 'vault' | 'env', id: string): boolean
+}
+
+/** Real credential checker: Vault lookup / env var presence. Never logs the value. */
+export function realCredentialChecker(): CredentialChecker {
+  return (kind, id) => {
+    if (kind === 'env') return !!process.env[id]
+    try {
+      return !!getSecret(id)
+    } catch {
+      return false
+    }
+  }
+}
+
+/**
+ * Build the full source inventory. Pure aside from the injected `now` and DB
+ * read + the injected credential checker (defaults to the real Vault/env
+ * check) -- fully testable with a fake checker and no real secrets.
+ */
+export function buildSourceInventory(
+  db: Database.Database,
+  config: CostOpsConfig,
+  now: number,
+  deps: { credentialChecker?: CredentialChecker } = {},
+): SourceInventoryEntry[] {
+  const checkCredential = deps.credentialChecker ?? realCredentialChecker()
+
+  const sources = db.prepare(`SELECT id, name, provider, source_type FROM cost_sources WHERE active = 1 ORDER BY name`).all() as SourceRow[]
+
+  // Latest run + last successful run + last failed run, per provider.
+  const latestRows = db.prepare(`
+    SELECT provider, status, started_at, error_code
+    FROM import_runs r
+    WHERE started_at = (SELECT MAX(started_at) FROM import_runs WHERE provider = r.provider)
+    GROUP BY provider
+  `).all() as RunRow[]
+  const latestByProvider = new Map(latestRows.map(r => [r.provider, r]))
+  const lastOkStmt = db.prepare(`SELECT MAX(started_at) t FROM import_runs WHERE provider = ? AND status = 'ok'`)
+
+  // Per-source activity/provenance aggregate, across ALL time (not just the
+  // current month -- lifecycle is "has this source EVER worked", not "did it
+  // bill this month"), excluding voided rows.
+  const lineAgg = db.prepare(`
+    SELECT
+      source_id,
+      MAX(data_freshness) as max_freshness,
+      MAX(CASE WHEN confidence = 'pending_permission' THEN 1 ELSE 0 END) as is_pending,
+      MAX(CASE WHEN confidence = 'provider_plan_estimate' THEN 1 ELSE 0 END) as is_plan_estimate,
+      MAX(CASE WHEN billed_cost > 0 THEN 1 ELSE 0 END) as ever_had_real_activity
+    FROM cost_line_items
+    WHERE voided_at IS NULL
+    GROUP BY source_id
+  `).all() as Array<Omit<LineAggRow, 'confidence' | 'actual_source'>>
+  const aggBySource = new Map(lineAgg.map(r => [r.source_id, r]))
+
+  // Most recent (confidence, actual_source) pair per source, for provenance --
+  // the single latest non-voided row, mirroring getCostSummary's "resolve to
+  // one representative line" approach but simplified (inventory doesn't need
+  // the full confidence-priority resolution, just "what does this source's
+  // data currently look like").
+  const latestLineStmt = db.prepare(`
+    SELECT confidence, actual_source FROM cost_line_items
+    WHERE source_id = ? AND voided_at IS NULL
+    ORDER BY data_freshness DESC, id DESC LIMIT 1
+  `)
+
+  const overrideBySourceId = new Map(config.fixed_costs.map(f => [f.source_id, f]))
+
+  return sources.map((s): SourceInventoryEntry => {
+    const override = overrideBySourceId.get(s.id)
+    const registry = CREDENTIAL_REGISTRY[s.provider]
+    const credentialRequired = registry != null
+    const credentialPresent = credentialRequired ? checkCredential(registry.checkKind, registry.id) : false
+
+    const latestRun = latestByProvider.get(s.provider) ?? null
+    const lastOk = latestRun ? ((lastOkStmt.get(s.provider) as { t: number | null }).t ?? null) : null
+    const lastRunStatus = latestRun ? (latestRun.status === 'ok' ? 'ok' as const : (latestRun.status as any)) : null
+
+    const agg = aggBySource.get(s.id)
+    const hasEverHadActivity = (agg?.ever_had_real_activity ?? 0) === 1
+
+    const lifecycle = deriveSourceLifecycle({
+      explicitlyUnsupported: override?.lifecycle_override === 'unsupported',
+      explicitlyDeprecated: override?.lifecycle_override === 'deprecated',
+      credentialRequired,
+      credentialPresent,
+      lastRunStatus,
+      hasEverHadActivity,
+    })
+
+    const latestLine = latestLineStmt.get(s.id) as { confidence: string | null; actual_source: string | null } | undefined
+    const provenance = deriveProvenance(latestLine?.confidence ?? null, latestLine?.actual_source ?? null)
+
+    const collection_method: SourceInventoryEntry['collection_method'] =
+      credentialRequired ? 'provider_api_collector'
+      : latestLine?.actual_source === 'email_invoice' ? 'email_invoice_ingest'
+      : latestLine != null || overrideBySourceId.has(s.id) ? 'manual_config'
+      : 'unknown'
+
+    const operational_inclusion_rule: OperationalInclusionRule =
+      agg?.is_pending === 1 ? 'pending_permission_excluded'
+      : agg?.is_plan_estimate === 1 ? 'advisory_plan_estimate'
+      : hasEverHadActivity ? 'operational'
+      : 'no_data_yet'
+
+    const blocker = lifecycle === 'blocked'
+      ? (latestRun?.error_code ?? 'collector run failed, see import_runs for detail')
+      : lifecycle === 'not_configured'
+      ? `missing credential (${registry?.checkKind === 'env' ? 'env var' : 'Vault secret'} '${registry?.id}')`
+      : null
+
+    return {
+      source_id: s.id,
+      name: s.name,
+      provider: s.provider,
+      source_type: s.source_type,
+      lifecycle,
+      provenance,
+      collection_method,
+      freshness: classifyFreshness(agg?.max_freshness ?? null, now),
+      last_data_freshness: agg?.max_freshness ?? null,
+      sync_cadence: credentialRequired ? 'manual' : 'config_driven',
+      owner: override?.owner ?? DEFAULT_OWNER,
+      operational_inclusion_rule,
+      manual_fallback: !credentialRequired,
+      blocker,
+      last_successful_sync: lastOk,
+      last_attempted_sync: latestRun?.started_at ?? null,
+    }
+  })
+}

--- a/src/costops/invoice.ts
+++ b/src/costops/invoice.ts
@@ -1,0 +1,420 @@
+// CostOps Phase 2 -- invoice / credit / refund / correction workflow
+// (GAP-14 / core-functional-scope-v1.0.1.md §14).
+//
+// Same category of module as correction.ts/period-close.ts (deterministic,
+// auditable, DB-aware accounting operations -- not the pure-detector shape
+// of alerts.ts/optimization.ts, since GAP-14 is fundamentally about WRITE
+// events: recording an invoice, applying a credit/refund, voiding a mistake).
+// No db.ts/web.ts/schema.ts edits: `initInvoiceSchema` is a schema DEFINER
+// only, not mounted anywhere -- the seam aggregator calls it.
+//
+// `costops_invoices` is a NEW entity, separate from `cost_line_items`: a
+// ledger line only ever carries one number (billed_cost); an invoice needs
+// the full gross/tax/discount/credit/refund/late-charge breakdown GAP-14
+// requires, plus its own status lifecycle (recorded/voided) and duplicate
+// detection independent of the ledger line it eventually produces or
+// corrects. Every invoice write that changes an EXISTING ledger amount goes
+// through Mason's correction.ts `createCorrection` -- REUSED, not
+// duplicated, per the dispatch's explicit instruction. That single
+// mechanism is what makes every GAP-14 acceptance criterion true by
+// construction: the original charge is never deleted (createCorrection
+// voids + inserts, never UPDATEs in place), and a late invoice arriving
+// after a month closes is FORCED through the same correction path because
+// period-close.ts's write-guard blocks any other direct write to a closed
+// month -- recordInvoice below explicitly checks that guard and refuses to
+// silently write around it.
+
+import type Database from 'better-sqlite3'
+import { monthWindow, hashRef } from './ledger.js'
+import { checkPeriodWritable } from './period-close.js'
+import { createCorrection } from './correction.js'
+
+// ---- status + amounts -------------------------------------------------------------------
+
+export type InvoiceStatus = 'recorded' | 'voided'
+
+export interface InvoiceAmounts {
+  gross_amount: number
+  tax_amount: number
+  discount_amount: number
+  credit_amount: number
+  refund_amount: number
+  late_charge_amount: number
+}
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }
+
+/**
+ * net = gross - discount - credit - refund + late_charge. `tax_amount` is
+ * informational (already included in `gross_amount`, matching how a real
+ * invoice states "Total: $120 (incl. $20 tax)") -- NOT added a second time.
+ * Sign convention: discount/credit/refund all REDUCE net; late_charge
+ * INCREASES it. This is the single source of truth every write function
+ * below uses -- never a second, divergent net calculation.
+ */
+export function computeNetAmount(a: InvoiceAmounts): number {
+  return round2(a.gross_amount - a.discount_amount - a.credit_amount - a.refund_amount + a.late_charge_amount)
+}
+
+// ---- duplicate detection ------------------------------------------------------------------
+
+/** dedup_key = provider + invoice_ref (hashed, never raw) + billing period -- GAP-14's "dedup by provider+invoice_ref+period." */
+export function invoiceDedupKey(provider: string, invoiceRefHashOrFallback: string, periodKey: string): string {
+  return `${provider}|${invoiceRefHashOrFallback}|${periodKey}`
+}
+
+// ---- expected-invoice-cadence inference (feeds alerts.ts's missing_invoice detector) --------
+
+function median(nums: number[]): number {
+  const sorted = [...nums].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+/**
+ * Infers when the NEXT invoice is expected from a source's OWN observed
+ * invoice history (billing_period_end dates, ascending) -- never a
+ * fabricated business-rule guess like "always monthly." Needs at least 2
+ * historical invoices to infer a cadence (the gap between them); returns
+ * null otherwise (never fabricated from a single data point).
+ */
+export function inferExpectedInvoiceBy(periodEndsAsc: number[], graceDays = 15): number | null {
+  if (periodEndsAsc.length < 2) return null
+  const gaps: number[] = []
+  for (let i = 1; i < periodEndsAsc.length; i++) gaps.push(periodEndsAsc[i] - periodEndsAsc[i - 1])
+  const typicalGap = median(gaps)
+  const last = periodEndsAsc[periodEndsAsc.length - 1]
+  return last + typicalGap + graceDays * 86400
+}
+
+// ---- recording an invoice ------------------------------------------------------------------
+
+export interface RecordInvoiceInput {
+  source_id: string
+  provider: string
+  invoice_ref: string | null // RAW ref -- hashed internally via hashRef, never stored raw (README's no-raw-invoice-ref rule)
+  billing_period_start: number
+  billing_period_end: number
+  service_period_start?: number | null
+  service_period_end?: number | null
+  currency: string
+  gross_amount: number
+  tax_amount?: number
+  discount_amount?: number
+  credit_amount?: number
+  refund_amount?: number
+  late_charge_amount?: number
+}
+
+export interface RecordInvoiceResult {
+  ok: boolean
+  error?: string
+  status?: number
+  invoiceId?: number
+  ledgerLineId?: number | null
+  duplicate?: boolean
+}
+
+/**
+ * Records a new invoice. Rejects a duplicate (same provider+invoice_ref+
+ * period, still active) before touching anything else. Then integrates it
+ * into the ledger:
+ * - An ACTIVE ledger line already exists for this source+period -> ALWAYS
+ *   goes through `createCorrection` (never a bare UPDATE), whether the
+ *   period is open or closed -- an invoice-driven change to an existing
+ *   committed number is exactly the auditable event GAP-14 requires.
+ * - No active line exists and the period is OPEN/provisional/reopened ->
+ *   a plain first-time INSERT (nothing to correct yet).
+ * - No active line exists and the period is CLOSED -> refused. A closed
+ *   month with literally no line to correct against would otherwise be a
+ *   silent direct write into a closed period -- the one case
+ *   createCorrection cannot rescue (it requires an existing row). The
+ *   period must be explicitly reopened first (period-close.ts's audited path).
+ */
+export function recordInvoice(db: Database.Database, input: RecordInvoiceInput, opts: { now: number; salt: string }): RecordInvoiceResult {
+  if (!input.source_id) return { ok: false, error: 'source_id is required', status: 400 }
+  if (!input.provider) return { ok: false, error: 'provider is required', status: 400 }
+  if (!input.currency) return { ok: false, error: 'currency is required', status: 400 }
+  if (!Number.isFinite(input.gross_amount) || input.gross_amount < 0) return { ok: false, error: 'gross_amount must be a non-negative number', status: 400 }
+  if (!Number.isFinite(input.billing_period_start) || !Number.isFinite(input.billing_period_end) || input.billing_period_end <= input.billing_period_start) {
+    return { ok: false, error: 'billing_period_start/end must be a valid range', status: 400 }
+  }
+
+  const amounts: InvoiceAmounts = {
+    gross_amount: input.gross_amount,
+    tax_amount: input.tax_amount ?? 0,
+    discount_amount: input.discount_amount ?? 0,
+    credit_amount: input.credit_amount ?? 0,
+    refund_amount: input.refund_amount ?? 0,
+    late_charge_amount: input.late_charge_amount ?? 0,
+  }
+  const net = computeNetAmount(amounts)
+
+  const refHash = input.invoice_ref ? hashRef(opts.salt, input.invoice_ref) : null
+  const periodKey = monthWindow(input.billing_period_start).key
+  const dedupKey = invoiceDedupKey(input.provider, refHash ?? `noref-${input.source_id}`, periodKey)
+
+  const dup = db.prepare(`SELECT id FROM costops_invoices WHERE dedup_key = ? AND status != 'voided'`).get(dedupKey) as { id: number } | undefined
+  if (dup) return { ok: false, error: `duplicate invoice: an active invoice already exists for ${dedupKey}`, status: 409, duplicate: true }
+
+  const writable = checkPeriodWritable(db, periodKey)
+  const activeLine = db.prepare(`
+    SELECT id FROM cost_line_items
+    WHERE source_id = ? AND charge_period_start < ? AND charge_period_end > ? AND voided_at IS NULL
+    ORDER BY data_freshness DESC LIMIT 1
+  `).get(input.source_id, input.billing_period_end, input.billing_period_start) as { id: number } | undefined
+
+  if (!writable.writable && !activeLine) {
+    return { ok: false, error: `${writable.reason} -- and no existing ledger line exists to correct`, status: 409 }
+  }
+
+  let caughtError: string | null = null
+  const tx = db.transaction(() => {
+    const info = db.prepare(`
+      INSERT INTO costops_invoices
+        (source_id, provider, invoice_ref_hash, billing_period_start, billing_period_end, service_period_start, service_period_end,
+         currency, gross_amount, tax_amount, discount_amount, credit_amount, refund_amount, late_charge_amount, net_amount,
+         status, ledger_line_id, dedup_key, recorded_at, created_at)
+      VALUES (@source_id, @provider, @ref_hash, @start, @end, @service_start, @service_end,
+              @currency, @gross, @tax, @discount, @credit, @refund, @late, @net,
+              'recorded', NULL, @dedup_key, @now, @now)
+    `).run({
+      source_id: input.source_id, provider: input.provider, ref_hash: refHash,
+      start: input.billing_period_start, end: input.billing_period_end,
+      service_start: input.service_period_start ?? null, service_end: input.service_period_end ?? null,
+      currency: input.currency, gross: amounts.gross_amount, tax: amounts.tax_amount,
+      discount: amounts.discount_amount, credit: amounts.credit_amount, refund: amounts.refund_amount,
+      late: amounts.late_charge_amount, net, dedup_key: dedupKey, now: opts.now,
+    })
+    const invoiceId = info.lastInsertRowid as number
+
+    let ledgerLineId: number | null = null
+    if (activeLine) {
+      const reasonPrefix = writable.writable ? 'invoice recorded' : 'late invoice recorded (period closed)'
+      const corr = createCorrection(db, { originalLineId: activeLine.id, newAmount: net, reason: `${reasonPrefix}: ${dedupKey}` }, { now: opts.now })
+      if (!corr.ok) { caughtError = corr.error ?? 'correction failed'; return null }
+      ledgerLineId = corr.newLineId ?? null
+    } else {
+      const lineDedup = `invoice|${input.source_id}|${periodKey}|${opts.now}`
+      const lineInfo = db.prepare(`
+        INSERT INTO cost_line_items
+          (source_id, charge_period_start, charge_period_end, charge_category, billed_cost, currency, confidence, data_freshness, dedup_key, created_at, actual_source)
+        VALUES (@source_id, @start, @end, 'usage', @net, @currency, 'actual_invoice', @now, @dedup_key, @now, 'email_invoice')
+      `).run({ source_id: input.source_id, start: input.billing_period_start, end: input.billing_period_end, net, currency: input.currency, dedup_key: lineDedup, now: opts.now })
+      ledgerLineId = lineInfo.lastInsertRowid as number
+    }
+
+    db.prepare(`UPDATE costops_invoices SET ledger_line_id = ? WHERE id = ?`).run(ledgerLineId, invoiceId)
+    return { invoiceId, ledgerLineId }
+  })
+
+  const result = tx()
+  if (caughtError || !result) return { ok: false, error: caughtError ?? 'record invoice failed', status: 500 }
+  return { ok: true, invoiceId: result.invoiceId, ledgerLineId: result.ledgerLineId }
+}
+
+// ---- credit / refund / late-charge adjustment on an existing invoice ------------------------
+
+export interface ApplyInvoiceAdjustmentInput {
+  invoiceId: number
+  creditAmount?: number
+  refundAmount?: number
+  lateChargeAmount?: number
+  reason: string
+}
+
+interface InvoiceRow extends InvoiceAmounts {
+  id: number
+  status: InvoiceStatus
+  ledger_line_id: number | null
+}
+
+/**
+ * Applies an ADDITIONAL credit/refund/late-charge to an already-recorded
+ * invoice (cumulative -- e.g. two partial refunds add up, never overwrite
+ * each other). Recomputes net and, if the invoice has a linked ledger line,
+ * cascades the new net through `createCorrection` -- always, regardless of
+ * period status (correction is the one write path that's never blocked).
+ * The ORIGINAL charge is never touched; only a new corrected line appears,
+ * per GAP-14's "eredeti charge megmarad."
+ */
+export function applyInvoiceAdjustment(db: Database.Database, input: ApplyInvoiceAdjustmentInput, opts: { now: number }): RecordInvoiceResult {
+  if (!input.reason || !input.reason.trim()) return { ok: false, error: 'reason is required for an invoice adjustment (auditability)', status: 400 }
+  const row = db.prepare(`SELECT id, gross_amount, tax_amount, discount_amount, credit_amount, refund_amount, late_charge_amount, status, ledger_line_id FROM costops_invoices WHERE id = ?`).get(input.invoiceId) as InvoiceRow | undefined
+  if (!row) return { ok: false, error: `no invoice with id ${input.invoiceId}`, status: 404 }
+  if (row.status === 'voided') return { ok: false, error: `invoice ${input.invoiceId} is voided -- cannot adjust it`, status: 409 }
+
+  const amounts: InvoiceAmounts = {
+    gross_amount: row.gross_amount, tax_amount: row.tax_amount, discount_amount: row.discount_amount,
+    credit_amount: round2(row.credit_amount + (input.creditAmount ?? 0)),
+    refund_amount: round2(row.refund_amount + (input.refundAmount ?? 0)),
+    late_charge_amount: round2(row.late_charge_amount + (input.lateChargeAmount ?? 0)),
+  }
+  const net = computeNetAmount(amounts)
+
+  let caughtError: string | null = null
+  const tx = db.transaction(() => {
+    db.prepare(`
+      UPDATE costops_invoices SET credit_amount=@credit, refund_amount=@refund, late_charge_amount=@late, net_amount=@net
+      WHERE id=@id
+    `).run({ credit: amounts.credit_amount, refund: amounts.refund_amount, late: amounts.late_charge_amount, net, id: input.invoiceId })
+
+    let ledgerLineId = row.ledger_line_id
+    if (row.ledger_line_id != null) {
+      const corr = createCorrection(db, { originalLineId: row.ledger_line_id, newAmount: net, reason: `invoice adjustment: ${input.reason}` }, { now: opts.now })
+      if (!corr.ok) { caughtError = corr.error ?? 'correction failed'; return }
+      ledgerLineId = corr.newLineId ?? row.ledger_line_id
+      db.prepare(`UPDATE costops_invoices SET ledger_line_id = ? WHERE id = ?`).run(ledgerLineId, input.invoiceId)
+    }
+  })
+  tx()
+  if (caughtError) return { ok: false, error: caughtError, status: 500 }
+  return { ok: true, invoiceId: input.invoiceId }
+}
+
+// ---- void (mistake, not a real credit/refund) -------------------------------------------------
+
+/**
+ * Voids an invoice ENTITY (e.g. it was recorded in error) -- status flag
+ * only, never a hard delete (matches Phase 0's void/archive-over-delete
+ * decision, card 73e8914a). Does NOT touch the linked ledger line; if the
+ * invoice's amount was already applied to the ledger, correct that
+ * separately via applyInvoiceAdjustment/createCorrection -- voiding the
+ * invoice record and correcting the ledger are deliberately independent
+ * operations (an invoice can be voided for record-keeping reasons, e.g. a
+ * duplicate PDF, without implying the ledger amount was ever wrong).
+ */
+export function voidInvoice(db: Database.Database, invoiceId: number, reason: string, now: number): RecordInvoiceResult {
+  if (!reason || !reason.trim()) return { ok: false, error: 'reason is required to void an invoice (auditability)', status: 400 }
+  const row = db.prepare(`SELECT status FROM costops_invoices WHERE id = ?`).get(invoiceId) as { status: InvoiceStatus } | undefined
+  if (!row) return { ok: false, error: `no invoice with id ${invoiceId}`, status: 404 }
+  if (row.status === 'voided') return { ok: false, error: `invoice ${invoiceId} is already voided`, status: 409 }
+  db.prepare(`UPDATE costops_invoices SET status='voided', void_reason=?, voided_at=? WHERE id=?`).run(reason, now, invoiceId)
+  return { ok: true, invoiceId }
+}
+
+// ---- read paths ------------------------------------------------------------------------------
+
+export interface InvoiceListRow {
+  id: number
+  source_id: string
+  provider: string
+  billing_period_start: number
+  billing_period_end: number
+  service_period_start: number | null
+  service_period_end: number | null
+  currency: string
+  gross_amount: number
+  tax_amount: number
+  discount_amount: number
+  credit_amount: number
+  refund_amount: number
+  late_charge_amount: number
+  net_amount: number
+  status: InvoiceStatus
+  ledger_line_id: number | null
+  recorded_at: number
+}
+
+export function listInvoices(db: Database.Database, opts: { source_id?: string; month?: string; now?: number; limit?: number } = {}): InvoiceListRow[] {
+  const limit = opts.limit ?? 200
+  const clauses: string[] = []
+  const params: Record<string, unknown> = { limit }
+  if (opts.source_id) { clauses.push('source_id = @source_id'); params.source_id = opts.source_id }
+  if (opts.month) {
+    const w = monthWindow(opts.now ?? 0, opts.month)
+    clauses.push('billing_period_start < @end AND billing_period_end > @start')
+    params.start = w.start; params.end = w.end
+  }
+  const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : ''
+  return db.prepare(`
+    SELECT id, source_id, provider, billing_period_start, billing_period_end, service_period_start, service_period_end,
+           currency, gross_amount, tax_amount, discount_amount, credit_amount, refund_amount, late_charge_amount, net_amount,
+           status, ledger_line_id, recorded_at
+    FROM costops_invoices ${where} ORDER BY billing_period_start DESC, recorded_at DESC LIMIT @limit
+  `).all(params) as InvoiceListRow[]
+}
+
+// ---- invoice-to-provider reconciliation (extends reconciliation.ts) ---------------------------
+
+export interface InvoiceReconciliationDetail {
+  gross_amount: number
+  tax_amount: number
+  discount_amount: number
+  credit_amount: number
+  refund_amount: number
+  late_charge_amount: number
+  net_amount: number
+  status: InvoiceStatus
+}
+
+/**
+ * Decorates reconciliation.ts's per-source view (unmodified, imported and
+ * reused, not duplicated) with the invoice-specific gross/tax/credit/
+ * refund/late-charge breakdown for sources that have an active invoice this
+ * period -- reconciliation.ts's own `observed_provider_amount` /
+ * `invoice_amount` / `variance` fields already answer "provider API vs
+ * invoice"; this adds "what the invoice ITSELF was actually made of."
+ * `invoice` is null for a source with no active invoice this period (never
+ * fabricated).
+ */
+export async function buildInvoiceReconciliation(db: Database.Database, now: number, month?: string) {
+  const { buildReconciliation } = await import('./reconciliation.js')
+  const base = buildReconciliation(db, now, month)
+  const win = monthWindow(now, month)
+  const invoiceRows = db.prepare(`
+    SELECT source_id, gross_amount, tax_amount, discount_amount, credit_amount, refund_amount, late_charge_amount, net_amount, status
+    FROM costops_invoices
+    WHERE billing_period_start < @end AND billing_period_end > @start AND status != 'voided'
+  `).all({ start: win.start, end: win.end }) as Array<{ source_id: string } & InvoiceReconciliationDetail>
+  const bySource = new Map(invoiceRows.map(r => [r.source_id, r]))
+  return base.map(r => {
+    const inv = bySource.get(r.source_id)
+    const invoice: InvoiceReconciliationDetail | null = inv ? {
+      gross_amount: inv.gross_amount, tax_amount: inv.tax_amount, discount_amount: inv.discount_amount,
+      credit_amount: inv.credit_amount, refund_amount: inv.refund_amount, late_charge_amount: inv.late_charge_amount,
+      net_amount: inv.net_amount, status: inv.status,
+    } : null
+    return { ...r, invoice }
+  })
+}
+
+// ---- schema (DEFINER ONLY -- not mounted; see file header) --------------------------------------
+
+/**
+ * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts.
+ * Partial unique index (`WHERE status != 'voided'`) enforces "duplicate
+ * invoice not counted twice" at the DB level too, while still allowing the
+ * SAME dedup_key to be re-recorded after a voided (mistaken) entry.
+ */
+export function initInvoiceSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS costops_invoices (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_id TEXT NOT NULL REFERENCES cost_sources(id),
+      provider TEXT NOT NULL,
+      invoice_ref_hash TEXT,
+      billing_period_start INTEGER NOT NULL,
+      billing_period_end INTEGER NOT NULL,
+      service_period_start INTEGER,
+      service_period_end INTEGER,
+      currency TEXT NOT NULL,
+      gross_amount REAL NOT NULL,
+      tax_amount REAL NOT NULL DEFAULT 0,
+      discount_amount REAL NOT NULL DEFAULT 0,
+      credit_amount REAL NOT NULL DEFAULT 0,
+      refund_amount REAL NOT NULL DEFAULT 0,
+      late_charge_amount REAL NOT NULL DEFAULT 0,
+      net_amount REAL NOT NULL,
+      status TEXT NOT NULL DEFAULT 'recorded',
+      void_reason TEXT,
+      voided_at INTEGER,
+      ledger_line_id INTEGER REFERENCES cost_line_items(id),
+      dedup_key TEXT NOT NULL,
+      recorded_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_costops_invoices_dedup_active ON costops_invoices(dedup_key) WHERE status != 'voided'`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_costops_invoices_source ON costops_invoices(source_id, billing_period_start)`)
+}

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -98,7 +98,30 @@ export const OPERATIONAL_TIER: Record<string, number> = {
 const PROVIDER_DERIVED_MIN = 3  // provider_plan_estimate or higher = "provider-derived"
 const REAL_ACTUAL_MIN = 4       // actual_invoice / provider_api / billing_export = a REAL measured cost
 
-interface OpLine { source_id: string; provider: string; billed_cost: number; charge_category: string; confidence: string; data_freshness: number }
+interface OpLine { source_id: string; provider: string; billed_cost: number; charge_category: string; confidence: string; data_freshness: number; source_type?: string }
+
+/**
+ * Istvan's accounting rule (2026-07-20), for an EQUAL-tier collision between an
+ * actual_invoice and a provider_api/billing_export line on the same source:
+ *
+ *   PACKAGE / SUBSCRIPTION (and any recurring bill: saas, hosting, domain):
+ *     the invoice states which period it covers, so the INVOICE is the period
+ *     cost. Provider API numbers are only a stand-in until the invoice arrives.
+ *
+ *   TOP-UP / PREPAID USAGE (source_type 'usage'):
+ *     funding the account is a real payment but NOT the period's cost. Only what
+ *     was CONSUMED in the period belongs to it, and consumption is exactly what
+ *     the provider API reports. So the API figure wins.
+ *
+ * This replaces freshness as the primary tiebreak. Freshness only decides when
+ * the accounting rule cannot -- e.g. two lines of the same kind.
+ */
+const CONSUMPTION_SOURCE_TYPES = new Set(['usage'])
+const CONSUMPTION_CONF = new Set(['provider_api', 'billing_export'])
+
+function prefersConsumption(sourceType: string | undefined): boolean {
+  return CONSUMPTION_SOURCE_TYPES.has(String(sourceType || ''))
+}
 
 export interface OperationalResult {
   operational_spend: number
@@ -132,7 +155,23 @@ export function resolveOperational(lines: OpLine[], win: MonthWindow): Operation
       const ta = OPERATIONAL_TIER[a.confidence] || 0
       const tb = OPERATIONAL_TIER[b.confidence] || 0
       if (tb !== ta) return tb > ta ? b : a
-      return b.data_freshness > a.data_freshness ? b : a
+
+      // Equal tier -> the ACCOUNTING RULE decides before freshness.
+      const consume = prefersConsumption(a.source_type ?? b.source_type)
+      const aIsConsumption = CONSUMPTION_CONF.has(a.confidence)
+      const bIsConsumption = CONSUMPTION_CONF.has(b.confidence)
+      if (aIsConsumption !== bIsConsumption) {
+        if (consume) return bIsConsumption ? b : a          // top-up: consumption wins
+        return bIsConsumption ? a : b                        // package: the invoice wins
+      }
+
+      // Same kind of line -> fall back to freshness, but a stamp in the FUTURE
+      // cannot mean "fresher". A period-END date reaching data_freshness is a
+      // known data defect (card 320c477a) and must not decide anything.
+      const now = Date.now() / 1000
+      const fa = a.data_freshness > now ? -Infinity : a.data_freshness
+      const fb = b.data_freshness > now ? -Infinity : b.data_freshness
+      return fb > fa ? b : a
     }))
   }
   // which providers have a provider-derived (tier>=3) source, and which have a REAL
@@ -521,9 +560,11 @@ export function getCostSummary(
   // (manual + plan + provider actual), mapped to their provider, resolved so a
   // provider's manual is dropped once it has provider-derived data (no double count).
   const providerBySource = new Map(srcRows.map(r => [r.id, r.provider]))
+  const sourceTypeBySource = new Map(srcRows.map(r => [r.id, (r as { source_type?: string }).source_type]))
   const opLines: OpLine[] = lines.filter(l => !PENDING_CONF.has(l.confidence)).map(l => ({
     source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
     billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
+    source_type: sourceTypeBySource.get(l.source_id),
   }))
   const op = resolveOperational(opLines, win)
 
@@ -538,6 +579,7 @@ export function getCostSummary(
     const prevOp = resolveOperational(prevRows.filter(l => !PENDING_CONF.has(l.confidence)).map(l => ({
       source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
       billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
+      source_type: sourceTypeBySource.get(l.source_id),
     })), prevWin)
     previous_month = { month: prevWin.key, operational_spend: prevOp.operational_spend, by_provider: prevOp.provider_breakdown }
   }

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -326,7 +326,7 @@ export function getCostSummary(
   const lines = db.prepare(`
     SELECT source_id, billed_cost, charge_category, confidence, data_freshness
     FROM cost_line_items
-    WHERE charge_period_start < @end AND charge_period_end > @start
+    WHERE charge_period_start < @end AND charge_period_end > @start AND voided_at IS NULL
   `).all({ start: win.start, end: win.end }) as LineRow[]
 
   let current_spend = 0
@@ -431,7 +431,7 @@ export function getCostSummary(
   const prevWin = monthWindow(win.start - 86400)
   const prevRows = db.prepare(`
     SELECT source_id, billed_cost, charge_category, confidence, data_freshness
-    FROM cost_line_items WHERE charge_period_start < @end AND charge_period_end > @start
+    FROM cost_line_items WHERE charge_period_start < @end AND charge_period_end > @start AND voided_at IS NULL
   `).all({ start: prevWin.start, end: prevWin.end }) as LineRow[]
   let previous_month: CostSummary['previous_month'] = null
   if (prevRows.length > 0) {

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -89,6 +89,7 @@ export const OPERATIONAL_TIER: Record<string, number> = {
   estimate: 1, manual: 1,
 }
 const PROVIDER_DERIVED_MIN = 3  // provider_plan_estimate or higher = "provider-derived"
+const REAL_ACTUAL_MIN = 4       // actual_invoice / provider_api / billing_export = a REAL measured cost
 
 interface OpLine { source_id: string; provider: string; billed_cost: number; charge_category: string; confidence: string; data_freshness: number }
 
@@ -116,10 +117,16 @@ export function resolveOperational(lines: OpLine[], win: MonthWindow): Operation
   for (const [sid, ls] of bySource) {
     sourceBest.set(sid, ls.reduce((a, b) => (OPERATIONAL_TIER[b.confidence] || 0) > (OPERATIONAL_TIER[a.confidence] || 0) ? b : a))
   }
-  // which providers have a provider-derived (tier>=3) source
+  // which providers have a provider-derived (tier>=3) source, and which have a REAL
+  // measured actual (tier>=4). A real invoice/api actual SUPERSEDES the whole-provider
+  // provider_plan_estimate proxy for that provider -- otherwise the plan estimate and
+  // the real invoice both count and the provider is double-counted (e.g. Render).
   const providerHasDerived = new Map<string, boolean>()
+  const providerHasRealActual = new Map<string, boolean>()
   for (const best of sourceBest.values()) {
-    if ((OPERATIONAL_TIER[best.confidence] || 0) >= PROVIDER_DERIVED_MIN) providerHasDerived.set(best.provider, true)
+    const t = OPERATIONAL_TIER[best.confidence] || 0
+    if (t >= PROVIDER_DERIVED_MIN) providerHasDerived.set(best.provider, true)
+    if (t >= REAL_ACTUAL_MIN) providerHasRealActual.set(best.provider, true)
   }
   let operational = 0, manual = 0, providerDerived = 0, forecast = 0, manualForDerivedProviders = 0
   let fresh: number | null = null
@@ -129,10 +136,12 @@ export function resolveOperational(lines: OpLine[], win: MonthWindow): Operation
     const tier = OPERATIONAL_TIER[best.confidence] || 0
     const p = best.provider
     if (fresh === null || best.data_freshness > fresh) fresh = best.data_freshness
-    if (tier <= 2) manual += best.billed_cost
-    if (tier >= PROVIDER_DERIVED_MIN) providerDerived += best.billed_cost
-    const isFallbackExcluded = providerHasDerived.get(p) === true && tier < PROVIDER_DERIVED_MIN
+    if (tier <= 2) manual += best.billed_cost  // fallback view: all manual/estimate, pre-exclusion
+    // plan estimate is a proxy for the provider's total -> drop it once a real invoice/api actual exists
+    const planSuperseded = best.confidence === 'provider_plan_estimate' && providerHasRealActual.get(p) === true
+    const isFallbackExcluded = (providerHasDerived.get(p) === true && tier < PROVIDER_DERIVED_MIN) || planSuperseded
     if (isFallbackExcluded) { manualForDerivedProviders += best.billed_cost; continue }
+    if (tier >= PROVIDER_DERIVED_MIN) providerDerived += best.billed_cost
     operational += best.billed_cost
     confBreakdown[best.confidence] = round2((confBreakdown[best.confidence] || 0) + best.billed_cost)
     const agg = providerAgg.get(p) || { spend: 0, conf: best.confidence, tier: -1 }

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -48,6 +48,12 @@ export function hashRef(salt: string, raw: string): string {
 
 // ---- confidence -> breakdown bucket ----------------------------------------
 
+// Higher = more authoritative. Used to resolve a source to one headline line
+// (v0.3) so a provider_api actual supersedes a manual estimate without double count.
+export const CONF_PRIORITY: Record<string, number> = {
+  actual_invoice: 6, provider_api: 5, billing_export: 4, local_usage: 3, estimate: 2, manual: 1,
+}
+
 export type CostBucket = 'fixed_manual' | 'provider' | 'estimate'
 
 export function confidenceBucket(c: CostConfidence): CostBucket {
@@ -153,6 +159,15 @@ export interface CostSummary {
     cache_read_tokens: number
     cache_creation_tokens: number
   }
+  // v0.2: deterministic token-cost ESTIMATE (separate from fixed/manual spend).
+  token_cost_estimate: TokenCostEstimate
+  // current_spend (fixed/manual) + token_cost_estimate.total -- clearly labeled,
+  // NOT folded into current_spend.
+  estimated_total_with_token_cost: number
+  // v0.3: per-source estimate-vs-actual (only sources that have a provider_api line).
+  reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }>
+  // v0.3: last collector run per provider (from import_runs).
+  provider_sync: Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; last_sync: number; stale: boolean; error_code: string | null }>
   data_freshness: number | null
   config_present: boolean
   config_errors: string[]
@@ -189,18 +204,31 @@ export function getCostSummary(
   const perSourceConfidence = new Map<string, string>()
   let latestFreshness: number | null = null
 
+  // Group lines per source. The HEADLINE spend resolves each source to its
+  // single highest-confidence line (v0.3: a provider_api actual supersedes the
+  // manual/estimate WITHOUT double-counting), while all lines are kept for the
+  // estimate-vs-actual reconcile view.
+  const bySource = new Map<string, LineRow[]>()
   for (const l of lines) {
-    current_spend += l.billed_cost
-    // Usage-type lines are prorated to month-end; committed/fixed lines are
-    // already whole-month (no proration).
-    forecast_month_end += l.charge_category === 'usage'
-      ? l.billed_cost / win.fractionElapsed
-      : l.billed_cost
-    confidence_breakdown[l.confidence] = (confidence_breakdown[l.confidence] || 0) + l.billed_cost
-    breakdown[confidenceBucket(l.confidence)] += l.billed_cost
-    perSource.set(l.source_id, (perSource.get(l.source_id) || 0) + l.billed_cost)
-    perSourceConfidence.set(l.source_id, l.confidence)
+    const arr = bySource.get(l.source_id); if (arr) arr.push(l); else bySource.set(l.source_id, [l])
     if (latestFreshness === null || l.data_freshness > latestFreshness) latestFreshness = l.data_freshness
+  }
+  const EST_CONF = ['manual', 'estimate', 'local_usage']
+  const ACT_CONF = ['provider_api', 'billing_export', 'actual_invoice']
+  const reconcile: CostSummary['reconcile'] = []
+  for (const [sid, ls] of bySource) {
+    const resolved = ls.reduce((a, b) => (CONF_PRIORITY[b.confidence] || 0) > (CONF_PRIORITY[a.confidence] || 0) ? b : a)
+    current_spend += resolved.billed_cost
+    forecast_month_end += resolved.charge_category === 'usage'
+      ? resolved.billed_cost / win.fractionElapsed
+      : resolved.billed_cost
+    confidence_breakdown[resolved.confidence] = (confidence_breakdown[resolved.confidence] || 0) + resolved.billed_cost
+    breakdown[confidenceBucket(resolved.confidence)] += resolved.billed_cost
+    perSource.set(sid, resolved.billed_cost)
+    perSourceConfidence.set(sid, resolved.confidence)
+    const estAmt = ls.filter(l => EST_CONF.includes(l.confidence)).reduce((s, l) => s + l.billed_cost, 0)
+    const actAmt = ls.filter(l => ACT_CONF.includes(l.confidence)).reduce((s, l) => s + l.billed_cost, 0)
+    if (actAmt > 0) reconcile.push({ source_id: sid, estimate: round2(estAmt), actual: round2(actAmt), variance: round2(actAmt - estAmt), resolved_confidence: resolved.confidence })
   }
   current_spend = round2(current_spend)
   forecast_month_end = round2(forecast_month_end)
@@ -252,6 +280,29 @@ export function getCostSummary(
     cache_read_tokens: number; cache_creation_tokens: number
   }
 
+  // v0.2 token-cost estimate (deterministic; unknown model / no rate -> unpriced).
+  const pricing = opts.pricing ?? { version: 1, currency: config.currency, models: {} }
+  const token_cost_estimate = getTokenCostEstimate(db, pricing, opts.pricingExists ?? false, win.start, win.end)
+  const estimated_total_with_token_cost = round2(current_spend + token_cost_estimate.total_estimated_huf)
+
+  // v0.3 per-source estimate-vs-actual reconciliation
+  const reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }> = []
+
+  // v0.3 provider sync status: the latest import_runs row per provider.
+  const STALE_SECS = 3 * 24 * 3600
+  const syncRows = db.prepare(`
+    SELECT provider, collector_name, status, imported_count, data_freshness_at, started_at, error_code
+    FROM import_runs r
+    WHERE started_at = (SELECT MAX(started_at) FROM import_runs WHERE provider = r.provider)
+    GROUP BY provider
+  `).all() as Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; started_at: number; error_code: string | null }>
+  const provider_sync = syncRows.map(r => ({
+    provider: r.provider, collector_name: r.collector_name, status: r.status,
+    imported_count: r.imported_count, data_freshness_at: r.data_freshness_at, last_sync: r.started_at,
+    stale: r.data_freshness_at != null ? (now - r.data_freshness_at) > STALE_SECS : true,
+    error_code: r.error_code,
+  }))
+
   return {
     month: win.key,
     currency: config.currency,
@@ -268,6 +319,10 @@ export function getCostSummary(
       input_tokens: tu.input_tokens, output_tokens: tu.output_tokens,
       cache_read_tokens: tu.cache_read_tokens, cache_creation_tokens: tu.cache_creation_tokens,
     },
+    token_cost_estimate,
+    estimated_total_with_token_cost,
+    reconcile,
+    provider_sync,
     data_freshness: latestFreshness,
     config_present: opts.configExists ?? true,
     config_errors: opts.configErrors ?? [],

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -63,6 +63,12 @@ export const CONF_PRIORITY: Record<string, number> = {
 // dedicated render_plan block (manual vs plan vs variance).
 export const ADVISORY_CONF = new Set<string>(['provider_plan_estimate'])
 
+// v0.7: pending_permission lines (a tracked provider whose cost can't be read,
+// e.g. AWS) are excluded the same way, but kept SEPARATE from ADVISORY_CONF so
+// they never leak into the Render-specific render_plan block. They surface only
+// via a dedicated warnings.ts billing_access_needed warning.
+export const PENDING_CONF = new Set<string>(['pending_permission'])
+
 // Costs a plan-based Render estimate structurally CANNOT see -> the estimate is a
 // lower bound. Surfaced verbatim so the number is never mistaken for an invoice.
 export const RENDER_NOT_COVERED: string[] = [
@@ -116,7 +122,18 @@ export function resolveOperational(lines: OpLine[], win: MonthWindow): Operation
   for (const l of lines) { const a = bySource.get(l.source_id); if (a) a.push(l); else bySource.set(l.source_id, [l]) }
   const sourceBest = new Map<string, OpLine>()
   for (const [sid, ls] of bySource) {
-    sourceBest.set(sid, ls.reduce((a, b) => (OPERATIONAL_TIER[b.confidence] || 0) > (OPERATIONAL_TIER[a.confidence] || 0) ? b : a))
+    // Tier first; on an EQUAL tier the fresher row wins (card 097d8355, Istvan's
+    // ruling 2026-07-20). actual_invoice / provider_api / billing_export all sit at
+    // tier 4, so a newly ingested invoice used to tie with an older provider_api row
+    // and lose -- strict `>` keeps the incumbent -- meaning the invoice was stored but
+    // never reached operational_spend. `data_freshness` is an ingest timestamp
+    // (`= @now`, ordered DESC elsewhere), so higher = newer.
+    sourceBest.set(sid, ls.reduce((a, b) => {
+      const ta = OPERATIONAL_TIER[a.confidence] || 0
+      const tb = OPERATIONAL_TIER[b.confidence] || 0
+      if (tb !== ta) return tb > ta ? b : a
+      return b.data_freshness > a.data_freshness ? b : a
+    }))
   }
   // which providers have a provider-derived (tier>=3) source, and which have a REAL
   // measured actual (tier>=4). A real invoice/api actual SUPERSEDES the whole-provider
@@ -208,15 +225,16 @@ export function syncFixedCostsToLedger(
     INSERT INTO cost_line_items
       (source_id, charge_period_start, charge_period_end, charge_category, service_name,
        usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
-       confidence, data_freshness, source_ref, dedup_key, created_at)
+       confidence, data_freshness, source_ref, dedup_key, created_at, actual_source)
     VALUES
       (@source_id, @start, @end, @charge_category, @service_name,
        NULL, 1, 'month', @billed_cost, NULL, @currency,
-       @confidence, @now, NULL, @dedup_key, @now)
+       @confidence, @now, NULL, @dedup_key, @now, 'manual_entry')
     ON CONFLICT(dedup_key) DO UPDATE SET
       billed_cost=excluded.billed_cost, charge_category=excluded.charge_category,
       service_name=excluded.service_name, currency=excluded.currency,
-      confidence=excluded.confidence, data_freshness=excluded.data_freshness
+      confidence=excluded.confidence, data_freshness=excluded.data_freshness,
+      actual_source=excluded.actual_source
   `)
   const tx = db.transaction((entries: CostOpsConfig['fixed_costs']) => {
     let count = 0
@@ -257,7 +275,31 @@ export interface CostSummary {
   top_sources: Array<{ source_id: string; name: string; spend: number }>
   // Full list of every configured/active source (not capped) -- top_sources is
   // the top-5 by spend; all_sources is the complete set for the dashboard table.
-  all_sources: Array<{ source_id: string; name: string; provider: string; source_type: string; spend: number; confidence: string }>
+  // v0.8 (card 6f4d1332): extended with actual_source, per-source forecast, and
+  // original-currency retention -- this array is now the main provider-table backing data
+  // (replacing operational.provider_breakdown, a coarser per-provider aggregate that can't
+  // correctly carry these per-item fields once a provider has more than one source). spend is
+  // `number | null` -- null (never a fabricated 0) for a pending_permission source with no
+  // readable amount.
+  all_sources: Array<{
+    source_id: string; name: string; provider: string; source_type: string
+    spend: number | null; confidence: string
+    actual_source: string  // 'provider_api' | 'email_invoice' | 'manual_entry' | 'pending_permission' | 'no_data'
+    forecast_month_end: number | null
+    forecast_basis: 'run_rate' | 'fixed_subscription' | 'manual_forecast' | 'no_forecast'
+    forecast_confidence: string | null
+    original_amount: number | null
+    original_currency: string | null
+    fx_rate: number | null
+    fx_date: number | null
+    // Card a1552362: every fx_rate currently in the system comes from the static
+    // Render-pricing config (fx_usd_huf), never a rate embedded in the source
+    // invoice/API response itself -- so it's honestly an ESTIMATE, not a bank/invoice
+    // rate. true whenever a conversion happened, null when there's nothing to flag
+    // (no conversion, no rate). Derived at read time, not a stored column -- the day
+    // a real per-invoice rate exists, that write site can carry its own flag.
+    fx_estimated: boolean | null
+  }>
   confidence_breakdown: Record<string, number>
   breakdown: { fixed_manual: number; provider: number; estimate: number }
   budget: {
@@ -313,6 +355,13 @@ interface LineRow {
   charge_category: string
   confidence: CostConfidence
   data_freshness: number
+  // v0.8 (card 6f4d1332): already on the underlying SQL row since v0.7 (original_amount etc.)
+  // resp. this migration (actual_source) -- just not selected into this query until now.
+  actual_source: string | null
+  original_amount: number | null
+  original_currency: string | null
+  fx_rate: number | null
+  fx_date: number | null
 }
 
 export function getCostSummary(
@@ -324,7 +373,8 @@ export function getCostSummary(
   const win = monthWindow(now, opts.monthKey)
 
   const lines = db.prepare(`
-    SELECT source_id, billed_cost, charge_category, confidence, data_freshness
+    SELECT source_id, billed_cost, charge_category, confidence, data_freshness,
+      actual_source, original_amount, original_currency, fx_rate, fx_date
     FROM cost_line_items
     WHERE charge_period_start < @end AND charge_period_end > @start AND voided_at IS NULL
   `).all({ start: win.start, end: win.end }) as LineRow[]
@@ -335,6 +385,14 @@ export function getCostSummary(
   const breakdown = { fixed_manual: 0, provider: 0, estimate: 0 }
   const perSource = new Map<string, number>()
   const perSourceConfidence = new Map<string, string>()
+  // v0.8 (card 6f4d1332 §2/§3): captured in the SAME per-source loop below, no second query --
+  // the run-rate/fixed/manual forecast formula already existed but was only summed into the
+  // aggregate forecast_month_end and discarded per-source; original-currency fields already
+  // existed on the row (v0.7) but were never threaded through to all_sources.
+  const perSourceForecast = new Map<string, number>()
+  const perSourceForecastBasis = new Map<string, CostSummary['all_sources'][number]['forecast_basis']>()
+  const perSourceActualSource = new Map<string, string>()
+  const perSourceOriginal = new Map<string, { amount: number | null; currency: string | null; fx_rate: number | null; fx_date: number | null }>()
   let latestFreshness: number | null = null
 
   // Group lines per source. The HEADLINE spend resolves each source to its
@@ -343,9 +401,14 @@ export function getCostSummary(
   // estimate-vs-actual reconcile view.
   // provider_plan_estimate lines are ADVISORY -- excluded from the headline
   // current_spend and from all_sources; they surface only in the render_plan block.
-  const headlineLines = lines.filter(l => !ADVISORY_CONF.has(l.confidence))
+  const headlineLines = lines.filter(l => !ADVISORY_CONF.has(l.confidence) && !PENDING_CONF.has(l.confidence))
   const planLines = lines.filter(l => ADVISORY_CONF.has(l.confidence))
-  const advisorySourceIds = new Set(planLines.map(l => l.source_id))
+  const pendingLines = lines.filter(l => PENDING_CONF.has(l.confidence))
+  const advisorySourceIds = new Set([...planLines, ...pendingLines].map(l => l.source_id))
+  // v0.8 §1 bugfix: all_sources' OWN filter (below) must exclude only plan-estimate sources, not
+  // pending ones too -- see the all_sources construction for the full explanation.
+  const planOnlySourceIds = new Set(planLines.map(l => l.source_id))
+  const pendingSourceIds = new Set(pendingLines.map(l => l.source_id))
   const bySource = new Map<string, LineRow[]>()
   for (const l of headlineLines) {
     const arr = bySource.get(l.source_id); if (arr) arr.push(l); else bySource.set(l.source_id, [l])
@@ -359,13 +422,27 @@ export function getCostSummary(
   for (const [sid, ls] of bySource) {
     const resolved = ls.reduce((a, b) => (CONF_PRIORITY[b.confidence] || 0) > (CONF_PRIORITY[a.confidence] || 0) ? b : a)
     current_spend += resolved.billed_cost
-    forecast_month_end += resolved.charge_category === 'usage'
+    const sourceForecast = resolved.charge_category === 'usage'
       ? resolved.billed_cost / win.fractionElapsed
       : resolved.billed_cost
+    forecast_month_end += sourceForecast
     confidence_breakdown[resolved.confidence] = (confidence_breakdown[resolved.confidence] || 0) + resolved.billed_cost
     breakdown[confidenceBucket(resolved.confidence)] += resolved.billed_cost
     perSource.set(sid, resolved.billed_cost)
     perSourceConfidence.set(sid, resolved.confidence)
+    perSourceForecast.set(sid, round2(sourceForecast))
+    const actualSource = resolved.actual_source || 'no_data'
+    perSourceActualSource.set(sid, actualSource)
+    perSourceOriginal.set(sid, {
+      amount: resolved.original_amount, currency: resolved.original_currency,
+      fx_rate: resolved.fx_rate, fx_date: resolved.fx_date,
+    })
+    const basis: CostSummary['all_sources'][number]['forecast_basis'] =
+      resolved.charge_category === 'usage' ? 'run_rate'
+      : (actualSource === 'provider_api' || actualSource === 'email_invoice') ? 'fixed_subscription'
+      : (resolved.confidence === 'manual' || resolved.confidence === 'estimate') ? 'manual_forecast'
+      : 'no_forecast'
+    perSourceForecastBasis.set(sid, basis)
     const estAmt = ls.filter(l => EST_CONF.includes(l.confidence)).reduce((s, l) => s + l.billed_cost, 0)
     const actAmt = ls.filter(l => ACT_CONF.includes(l.confidence)).reduce((s, l) => s + l.billed_cost, 0)
     if (actAmt > 0) reconcile.push({ source_id: sid, estimate: round2(estAmt), actual: round2(actAmt), variance: round2(actAmt - estAmt), resolved_confidence: resolved.confidence })
@@ -381,16 +458,39 @@ export function getCostSummary(
     .sort((a, b) => b.spend - a.spend)
     .slice(0, 5)
 
-  // Full list: every configured/active source with spend (0 if none this month).
-  // Advisory-only sources (render-plan / provider_plan_estimate) are excluded --
-  // they appear in the render_plan block, never in the headline source list.
+  // Full list: every configured/active source with spend (0 if none this month), extended per
+  // v0.8 §1-3 with actual_source/forecast/original-currency.
+  //
+  // v0.8 §1 bugfix (found reading the code, not in the original requirements): this filter used
+  // to exclude BOTH plan-estimate AND pending_permission sources via the combined
+  // advisorySourceIds set. Line 67-68's own comment says pending sources are kept "SEPARATE from
+  // ADVISORY_CONF" deliberately -- but this filter re-merged them, so a pending_permission source
+  // (the spec's own example: "AWS - Jogosultsag kell - nincs osszeg") could never appear in
+  // all_sources at all. Fixed: exclude only plan-estimate sources (still correctly advisory-only,
+  // surfaced via render_plan instead); INCLUDE pending sources with spend:null (never a fabricated
+  // 0 -- guardrail requires the JSON field itself to express "unknown", not just render blank
+  // client-side) and actual_source:'pending_permission'.
   const all_sources = srcRows
-    .filter(r => !advisorySourceIds.has(r.id))
-    .map(r => ({
-      source_id: r.id, name: r.name, provider: r.provider, source_type: r.source_type,
-      spend: round2(perSource.get(r.id) || 0), confidence: perSourceConfidence.get(r.id) || 'manual',
-    }))
-    .sort((a, b) => b.spend - a.spend || a.name.localeCompare(b.name))
+    .filter(r => !planOnlySourceIds.has(r.id))
+    .map(r => {
+      const isPending = pendingSourceIds.has(r.id) && !bySource.has(r.id)
+      const original = perSourceOriginal.get(r.id)
+      return {
+        source_id: r.id, name: r.name, provider: r.provider, source_type: r.source_type,
+        spend: isPending ? null : round2(perSource.get(r.id) || 0),
+        confidence: isPending ? 'pending_permission' : (perSourceConfidence.get(r.id) || 'manual'),
+        actual_source: isPending ? 'pending_permission' : (perSourceActualSource.get(r.id) || 'no_data'),
+        forecast_month_end: isPending ? null : (perSourceForecast.get(r.id) ?? null),
+        forecast_basis: isPending ? 'no_forecast' as const : (perSourceForecastBasis.get(r.id) || 'no_forecast'),
+        forecast_confidence: isPending ? null : (perSourceConfidence.get(r.id) ?? null),
+        original_amount: original?.amount ?? null,
+        original_currency: original?.currency ?? null,
+        fx_rate: original?.fx_rate ?? null,
+        fx_date: original?.fx_date ?? null,
+        fx_estimated: (original?.fx_rate ?? null) != null ? true : null,
+      }
+    })
+    .sort((a, b) => (b.spend ?? -1) - (a.spend ?? -1) || a.name.localeCompare(b.name))
 
   // v0.3 Render plan-based estimate (ADVISORY): manual render estimate vs plan-based
   // estimate vs variance. NEVER folded into current_spend. Empty until a Render import.
@@ -421,7 +521,7 @@ export function getCostSummary(
   // (manual + plan + provider actual), mapped to their provider, resolved so a
   // provider's manual is dropped once it has provider-derived data (no double count).
   const providerBySource = new Map(srcRows.map(r => [r.id, r.provider]))
-  const opLines: OpLine[] = lines.map(l => ({
+  const opLines: OpLine[] = lines.filter(l => !PENDING_CONF.has(l.confidence)).map(l => ({
     source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
     billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
   }))
@@ -435,7 +535,7 @@ export function getCostSummary(
   `).all({ start: prevWin.start, end: prevWin.end }) as LineRow[]
   let previous_month: CostSummary['previous_month'] = null
   if (prevRows.length > 0) {
-    const prevOp = resolveOperational(prevRows.map(l => ({
+    const prevOp = resolveOperational(prevRows.filter(l => !PENDING_CONF.has(l.confidence)).map(l => ({
       source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
       billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
     })), prevWin)

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -9,6 +9,7 @@
 import type Database from 'better-sqlite3'
 import { createHash } from 'node:crypto'
 import type { CostOpsConfig, CostConfidence } from './config.js'
+import { getTokenCostEstimate, type PricingConfig, type TokenCostEstimate } from './pricing.js'
 
 // ---- month math (UTC, deterministic given `now`) ---------------------------
 
@@ -81,7 +82,7 @@ export const RENDER_NOT_COVERED: string[] = [
 // manual fallback, per source's provider: provider_api_actual > provider_plan_estimate
 // > local_usage > manual/estimate. A provider that HAS a provider-derived line drops
 // its manual/estimate lines from operational (they become fallback/comparison only),
-// so manual + provider are never double-counted (e.g. Render: plan 37080 wins over manual 40000).
+// so manual + provider are never double-counted (e.g. a provider-plan estimate wins over a manual entry for the same source).
 export const OPERATIONAL_TIER: Record<string, number> = {
   actual_invoice: 4, provider_api: 4, billing_export: 4,
   provider_plan_estimate: 3,
@@ -481,9 +482,6 @@ export function getCostSummary(
   const pricing = opts.pricing ?? { version: 1, currency: config.currency, models: {} }
   const token_cost_estimate = getTokenCostEstimate(db, pricing, opts.pricingExists ?? false, win.start, win.end)
   const estimated_total_with_token_cost = round2(current_spend + token_cost_estimate.total_estimated_huf)
-
-  // v0.3 per-source estimate-vs-actual reconciliation
-  const reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }> = []
 
   // v0.3/v0.5 provider sync status: the latest run per provider + last ok/failed +
   // derived status (ok / stale / failed / no_data) + data age + period coverage.

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -52,7 +52,30 @@ export function hashRef(salt: string, raw: string): string {
 // (v0.3) so a provider_api actual supersedes a manual estimate without double count.
 export const CONF_PRIORITY: Record<string, number> = {
   actual_invoice: 6, provider_api: 5, billing_export: 4, local_usage: 3, estimate: 2, manual: 1,
+  // provider_plan_estimate is ADVISORY only: it is excluded from the headline
+  // current_spend entirely (see getCostSummary), so its priority never applies
+  // to a headline resolution. Kept here for completeness / bucketing.
+  provider_plan_estimate: 0,
 }
+
+// provider_plan_estimate lines never enter the headline spend; they surface in a
+// dedicated render_plan block (manual vs plan vs variance).
+export const ADVISORY_CONF = new Set<string>(['provider_plan_estimate'])
+
+// Costs a plan-based Render estimate structurally CANNOT see -> the estimate is a
+// lower bound. Surfaced verbatim so the number is never mistaken for an invoice.
+export const RENDER_NOT_COVERED: string[] = [
+  'bandwidth overage (web + static site)',
+  'database storage / backup overage above the plan',
+  'logs / metrics / observability add-ons',
+  'team / workspace seats',
+  'tax / VAT',
+  'credits / discounts',
+  'invoice adjustments',
+  'one-off charges',
+  'cron per-run compute above the flat approximation',
+  'preview environments (excluded)',
+]
 
 export type CostBucket = 'fixed_manual' | 'provider' | 'estimate'
 
@@ -64,6 +87,7 @@ export function confidenceBucket(c: CostConfidence): CostBucket {
       return 'provider'
     case 'estimate':
     case 'local_usage':
+    case 'provider_plan_estimate':
       return 'estimate'
     case 'manual':
     default:
@@ -168,6 +192,16 @@ export interface CostSummary {
   reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }>
   // v0.3: last collector run per provider (from import_runs).
   provider_sync: Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; last_sync: number; stale: boolean; error_code: string | null }>
+  // v0.3 Render plan-based estimate (ADVISORY -- NOT in current_spend). null until a Render import.
+  render_plan: {
+    currency: string
+    plan_estimate_total: number
+    manual_estimate: number
+    variance: number
+    confidence: string
+    data_freshness_at: number | null
+    not_covered: string[]
+  } | null
   data_freshness: number | null
   config_present: boolean
   config_errors: string[]
@@ -208,9 +242,16 @@ export function getCostSummary(
   // single highest-confidence line (v0.3: a provider_api actual supersedes the
   // manual/estimate WITHOUT double-counting), while all lines are kept for the
   // estimate-vs-actual reconcile view.
+  // provider_plan_estimate lines are ADVISORY -- excluded from the headline
+  // current_spend and from all_sources; they surface only in the render_plan block.
+  const headlineLines = lines.filter(l => !ADVISORY_CONF.has(l.confidence))
+  const planLines = lines.filter(l => ADVISORY_CONF.has(l.confidence))
+  const advisorySourceIds = new Set(planLines.map(l => l.source_id))
   const bySource = new Map<string, LineRow[]>()
-  for (const l of lines) {
+  for (const l of headlineLines) {
     const arr = bySource.get(l.source_id); if (arr) arr.push(l); else bySource.set(l.source_id, [l])
+  }
+  for (const l of lines) {
     if (latestFreshness === null || l.data_freshness > latestFreshness) latestFreshness = l.data_freshness
   }
   const EST_CONF = ['manual', 'estimate', 'local_usage']
@@ -242,12 +283,33 @@ export function getCostSummary(
     .slice(0, 5)
 
   // Full list: every configured/active source with spend (0 if none this month).
+  // Advisory-only sources (render-plan / provider_plan_estimate) are excluded --
+  // they appear in the render_plan block, never in the headline source list.
   const all_sources = srcRows
+    .filter(r => !advisorySourceIds.has(r.id))
     .map(r => ({
       source_id: r.id, name: r.name, provider: r.provider, source_type: r.source_type,
       spend: round2(perSource.get(r.id) || 0), confidence: perSourceConfidence.get(r.id) || 'manual',
     }))
     .sort((a, b) => b.spend - a.spend || a.name.localeCompare(b.name))
+
+  // v0.3 Render plan-based estimate (ADVISORY): manual render estimate vs plan-based
+  // estimate vs variance. NEVER folded into current_spend. Empty until a Render import.
+  const plan_estimate_total = round2(planLines.reduce((s, l) => s + l.billed_cost, 0))
+  const manual_render_estimate = round2(
+    srcRows.filter(r => r.provider === 'render' && !advisorySourceIds.has(r.id))
+      .reduce((s, r) => s + (perSource.get(r.id) || 0), 0),
+  )
+  const planFreshness = planLines.reduce((m, l) => Math.max(m, l.data_freshness), 0) || null
+  const render_plan: CostSummary['render_plan'] = planLines.length > 0 ? {
+    currency: config.currency,
+    plan_estimate_total,
+    manual_estimate: manual_render_estimate,
+    variance: round2(plan_estimate_total - manual_render_estimate),
+    confidence: 'provider_plan_estimate',
+    data_freshness_at: planFreshness,
+    not_covered: RENDER_NOT_COVERED,
+  } : null
 
   // budget (first budget, or the 'global-monthly' one if present)
   const budgetDef = config.budgets.find(b => b.id === 'global-monthly') || config.budgets[0] || null
@@ -323,6 +385,7 @@ export function getCostSummary(
     estimated_total_with_token_cost,
     reconcile,
     provider_sync,
+    render_plan,
     data_freshness: latestFreshness,
     config_present: opts.configExists ?? true,
     config_errors: opts.configErrors ?? [],

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -277,9 +277,9 @@ export interface CostSummary {
   estimated_total_with_token_cost: number
   // v0.3: per-source estimate-vs-actual (only sources that have a provider_api line).
   reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }>
-  // v0.3: last collector run per provider (from import_runs).
-  provider_sync: Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; last_sync: number; stale: boolean; error_code: string | null }>
-  // v0.3 Render plan-based estimate (ADVISORY -- NOT in current_spend). null until a Render import.
+  // v0.3/v0.5: last collector run per provider + sync state (ok/stale/failed).
+  provider_sync: Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; last_sync: number; last_success: number | null; last_failed: number | null; data_age_secs: number | null; current_period: string; previous_period_coverage: boolean; stale: boolean; error_code: string | null }>
+  // v0.3/v0.5 Render plan-based estimate (ADVISORY -- NOT in current_spend). null until a Render import.
   render_plan: {
     currency: string
     plan_estimate_total: number
@@ -288,6 +288,8 @@ export interface CostSummary {
     confidence: string
     data_freshness_at: number | null
     not_covered: string[]
+    detail: unknown            // sanitized breakdown from the latest sync (service_count, by_type_plan, ...)
+    last_sync: number | null
   } | null
   data_freshness: number | null
   config_present: boolean
@@ -388,6 +390,11 @@ export function getCostSummary(
       .reduce((s, r) => s + (perSource.get(r.id) || 0), 0),
   )
   const planFreshness = planLines.reduce((m, l) => Math.max(m, l.data_freshness), 0) || null
+  // v0.5: latest successful Render sync -> sanitized breakdown (service_count, plan
+  // breakdown, undercount) + last_sync for the dashboard Render detail.
+  const renderRun = db.prepare(`SELECT detail_json, started_at FROM import_runs WHERE provider='render' AND status='ok' ORDER BY started_at DESC LIMIT 1`).get() as { detail_json: string | null; started_at: number } | undefined
+  let renderDetail: unknown = null
+  if (renderRun?.detail_json) { try { renderDetail = JSON.parse(renderRun.detail_json) } catch { renderDetail = null } }
   const render_plan: CostSummary['render_plan'] = planLines.length > 0 ? {
     currency: config.currency,
     plan_estimate_total,
@@ -396,6 +403,8 @@ export function getCostSummary(
     confidence: 'provider_plan_estimate',
     data_freshness_at: planFreshness,
     not_covered: RENDER_NOT_COVERED,
+    detail: renderDetail,
+    last_sync: renderRun?.started_at ?? null,
   } : null
 
   // v0.4: provider-preferred OPERATIONAL spend (new main KPI). Uses ALL lines
@@ -467,20 +476,34 @@ export function getCostSummary(
   // v0.3 per-source estimate-vs-actual reconciliation
   const reconcile: Array<{ source_id: string; estimate: number; actual: number; variance: number; resolved_confidence: string }> = []
 
-  // v0.3 provider sync status: the latest import_runs row per provider.
+  // v0.3/v0.5 provider sync status: the latest run per provider + last ok/failed +
+  // derived status (ok / stale / failed / no_data) + data age + period coverage.
   const STALE_SECS = 3 * 24 * 3600
-  const syncRows = db.prepare(`
+  const latestRows = db.prepare(`
     SELECT provider, collector_name, status, imported_count, data_freshness_at, started_at, error_code
     FROM import_runs r
     WHERE started_at = (SELECT MAX(started_at) FROM import_runs WHERE provider = r.provider)
     GROUP BY provider
   `).all() as Array<{ provider: string; collector_name: string; status: string; imported_count: number; data_freshness_at: number | null; started_at: number; error_code: string | null }>
-  const provider_sync = syncRows.map(r => ({
-    provider: r.provider, collector_name: r.collector_name, status: r.status,
-    imported_count: r.imported_count, data_freshness_at: r.data_freshness_at, last_sync: r.started_at,
-    stale: r.data_freshness_at != null ? (now - r.data_freshness_at) > STALE_SECS : true,
-    error_code: r.error_code,
-  }))
+  const lastOkStmt = db.prepare(`SELECT MAX(started_at) t FROM import_runs WHERE provider = ? AND status = 'ok'`)
+  const lastFailStmt = db.prepare(`SELECT MAX(started_at) t FROM import_runs WHERE provider = ? AND status IN ('error','failed','partial','rate_limited')`)
+  const prevProviders = new Set(prevRows.map(l => providerBySource.get(l.source_id) || 'other'))
+  const provider_sync = latestRows.map(r => {
+    const lastOk = (lastOkStmt.get(r.provider) as { t: number | null }).t || null
+    const lastFailed = (lastFailStmt.get(r.provider) as { t: number | null }).t || null
+    // "stale" means we have not SYNCED recently (not about the billing-period age).
+    const syncAge = now - r.started_at
+    const stale = syncAge > STALE_SECS
+    const status = r.status !== 'ok' ? 'failed' : (stale ? 'stale' : 'ok')
+    return {
+      provider: r.provider, collector_name: r.collector_name, status,
+      imported_count: r.imported_count, data_freshness_at: r.data_freshness_at,
+      last_sync: r.started_at, last_success: lastOk, last_failed: lastFailed,
+      data_age_secs: syncAge,
+      current_period: win.key, previous_period_coverage: prevProviders.has(r.provider),
+      stale, error_code: r.error_code,
+    }
+  })
 
   return {
     month: win.key,

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -77,6 +77,83 @@ export const RENDER_NOT_COVERED: string[] = [
   'preview environments (excluded)',
 ]
 
+// v0.4: operational spend preference. The MAIN KPI prefers provider data over the
+// manual fallback, per source's provider: provider_api_actual > provider_plan_estimate
+// > local_usage > manual/estimate. A provider that HAS a provider-derived line drops
+// its manual/estimate lines from operational (they become fallback/comparison only),
+// so manual + provider are never double-counted (e.g. Render: plan 37080 wins over manual 40000).
+export const OPERATIONAL_TIER: Record<string, number> = {
+  actual_invoice: 4, provider_api: 4, billing_export: 4,
+  provider_plan_estimate: 3,
+  local_usage: 2,
+  estimate: 1, manual: 1,
+}
+const PROVIDER_DERIVED_MIN = 3  // provider_plan_estimate or higher = "provider-derived"
+
+interface OpLine { source_id: string; provider: string; billed_cost: number; charge_category: string; confidence: string; data_freshness: number }
+
+export interface OperationalResult {
+  operational_spend: number
+  manual_spend: number
+  provider_derived_spend: number
+  operational_forecast_month_end: number
+  provider_breakdown: Array<{ provider: string; spend: number; confidence: string }>
+  confidence_breakdown: Record<string, number>
+  manual_vs_provider_variance: number
+  data_freshness: number | null
+}
+
+/**
+ * Resolve the provider-preferred OPERATIONAL spend for a set of month lines.
+ * Per source -> best line by OPERATIONAL_TIER. Per provider -> if it has any
+ * provider-derived source, its manual/estimate sources are excluded from operational
+ * (fallback only). No double counting. `win` is used for the forecast run-rate.
+ */
+export function resolveOperational(lines: OpLine[], win: MonthWindow): OperationalResult {
+  const bySource = new Map<string, OpLine[]>()
+  for (const l of lines) { const a = bySource.get(l.source_id); if (a) a.push(l); else bySource.set(l.source_id, [l]) }
+  const sourceBest = new Map<string, OpLine>()
+  for (const [sid, ls] of bySource) {
+    sourceBest.set(sid, ls.reduce((a, b) => (OPERATIONAL_TIER[b.confidence] || 0) > (OPERATIONAL_TIER[a.confidence] || 0) ? b : a))
+  }
+  // which providers have a provider-derived (tier>=3) source
+  const providerHasDerived = new Map<string, boolean>()
+  for (const best of sourceBest.values()) {
+    if ((OPERATIONAL_TIER[best.confidence] || 0) >= PROVIDER_DERIVED_MIN) providerHasDerived.set(best.provider, true)
+  }
+  let operational = 0, manual = 0, providerDerived = 0, forecast = 0, manualForDerivedProviders = 0
+  let fresh: number | null = null
+  const providerAgg = new Map<string, { spend: number; conf: string; tier: number }>()
+  const confBreakdown: Record<string, number> = {}
+  for (const [, best] of sourceBest) {
+    const tier = OPERATIONAL_TIER[best.confidence] || 0
+    const p = best.provider
+    if (fresh === null || best.data_freshness > fresh) fresh = best.data_freshness
+    if (tier <= 2) manual += best.billed_cost
+    if (tier >= PROVIDER_DERIVED_MIN) providerDerived += best.billed_cost
+    const isFallbackExcluded = providerHasDerived.get(p) === true && tier < PROVIDER_DERIVED_MIN
+    if (isFallbackExcluded) { manualForDerivedProviders += best.billed_cost; continue }
+    operational += best.billed_cost
+    confBreakdown[best.confidence] = round2((confBreakdown[best.confidence] || 0) + best.billed_cost)
+    const agg = providerAgg.get(p) || { spend: 0, conf: best.confidence, tier: -1 }
+    agg.spend += best.billed_cost
+    if (tier > agg.tier) { agg.tier = tier; agg.conf = best.confidence }
+    providerAgg.set(p, agg)
+    // forecast policy: provider_api_actual usage MTD -> run-rate; plan/manual -> full monthly
+    forecast += (tier >= 4 && best.charge_category === 'usage') ? best.billed_cost / win.fractionElapsed : best.billed_cost
+  }
+  return {
+    operational_spend: round2(operational),
+    manual_spend: round2(manual),
+    provider_derived_spend: round2(providerDerived),
+    operational_forecast_month_end: round2(forecast),
+    provider_breakdown: [...providerAgg.entries()].map(([provider, v]) => ({ provider, spend: round2(v.spend), confidence: v.conf })).sort((a, b) => b.spend - a.spend),
+    confidence_breakdown: confBreakdown,
+    manual_vs_provider_variance: round2(providerDerived - manualForDerivedProviders),
+    data_freshness: fresh,
+  }
+}
+
 export type CostBucket = 'fixed_manual' | 'provider' | 'estimate'
 
 export function confidenceBucket(c: CostConfidence): CostBucket {
@@ -157,8 +234,16 @@ export function syncFixedCostsToLedger(
 export interface CostSummary {
   month: string
   currency: string
+  // legacy manual/estimate headline (kept for back-compat; excludes provider_plan_estimate)
   current_spend: number
   forecast_month_end: number
+  // v0.4: provider-preferred OPERATIONAL spend -- the NEW main KPI.
+  operational_spend: number
+  operational_forecast_month_end: number
+  operational: OperationalResult
+  // previous month operational aggregate (null == no_previous_month_data; never fabricated)
+  previous_month: { month: string; operational_spend: number; by_provider: Array<{ provider: string; spend: number; confidence: string }> } | null
+  month_over_month_delta: number | null
   top_sources: Array<{ source_id: string; name: string; spend: number }>
   // Full list of every configured/active source (not capped) -- top_sources is
   // the top-5 by spend; all_sources is the complete set for the dashboard table.
@@ -173,6 +258,8 @@ export interface CostSummary {
     status: 'ok' | 'warning' | 'hard'
     warning_threshold: number
     hard_threshold: number
+    operational_used_pct: number
+    operational_forecast_pct: number
   } | null
   token_usage: {
     note: string
@@ -311,6 +398,32 @@ export function getCostSummary(
     not_covered: RENDER_NOT_COVERED,
   } : null
 
+  // v0.4: provider-preferred OPERATIONAL spend (new main KPI). Uses ALL lines
+  // (manual + plan + provider actual), mapped to their provider, resolved so a
+  // provider's manual is dropped once it has provider-derived data (no double count).
+  const providerBySource = new Map(srcRows.map(r => [r.id, r.provider]))
+  const opLines: OpLine[] = lines.map(l => ({
+    source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
+    billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
+  }))
+  const op = resolveOperational(opLines, win)
+
+  // previous month: aggregate from cost_line_items; NEVER fabricated. null if no data.
+  const prevWin = monthWindow(win.start - 86400)
+  const prevRows = db.prepare(`
+    SELECT source_id, billed_cost, charge_category, confidence, data_freshness
+    FROM cost_line_items WHERE charge_period_start < @end AND charge_period_end > @start
+  `).all({ start: prevWin.start, end: prevWin.end }) as LineRow[]
+  let previous_month: CostSummary['previous_month'] = null
+  if (prevRows.length > 0) {
+    const prevOp = resolveOperational(prevRows.map(l => ({
+      source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
+      billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
+    })), prevWin)
+    previous_month = { month: prevWin.key, operational_spend: prevOp.operational_spend, by_provider: prevOp.provider_breakdown }
+  }
+  const month_over_month_delta = previous_month ? round2(op.operational_spend - previous_month.operational_spend) : null
+
   // budget (first budget, or the 'global-monthly' one if present)
   const budgetDef = config.budgets.find(b => b.id === 'global-monthly') || config.budgets[0] || null
   let budget: CostSummary['budget'] = null
@@ -319,12 +432,16 @@ export function getCostSummary(
     const hard = budgetDef.hard_threshold ?? 1.0
     const used_pct = current_spend / budgetDef.amount
     const forecast_pct = forecast_month_end / budgetDef.amount
-    // Status is display-only. No action is ever taken here.
+    // v0.4: budget usage against the OPERATIONAL spend (the main KPI).
+    const op_used_pct = op.operational_spend / budgetDef.amount
+    const op_forecast_pct = op.operational_forecast_month_end / budgetDef.amount
+    // Status is display-only. No action is ever taken here. Driven by operational.
     const status: 'ok' | 'warning' | 'hard' =
-      used_pct >= hard ? 'hard' : used_pct >= warning ? 'warning' : 'ok'
+      op_used_pct >= hard ? 'hard' : op_used_pct >= warning ? 'warning' : 'ok'
     budget = {
       id: budgetDef.id, amount: budgetDef.amount,
       used_pct: round4(used_pct), forecast_pct: round4(forecast_pct),
+      operational_used_pct: round4(op_used_pct), operational_forecast_pct: round4(op_forecast_pct),
       status, warning_threshold: warning, hard_threshold: hard,
     }
   }
@@ -370,6 +487,11 @@ export function getCostSummary(
     currency: config.currency,
     current_spend,
     forecast_month_end,
+    operational_spend: op.operational_spend,
+    operational_forecast_month_end: op.operational_forecast_month_end,
+    operational: op,
+    previous_month,
+    month_over_month_delta,
     top_sources,
     all_sources,
     confidence_breakdown: roundValues(confidence_breakdown),

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -319,7 +319,7 @@ export function getCostSummary(
   db: Database.Database,
   config: CostOpsConfig,
   now: number,
-  opts: { monthKey?: string; configExists?: boolean; configErrors?: string[] } = {},
+  opts: { monthKey?: string; configExists?: boolean; configErrors?: string[]; pricing?: PricingConfig; pricingExists?: boolean } = {},
 ): CostSummary {
   const win = monthWindow(now, opts.monthKey)
 

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -139,8 +139,13 @@ export interface OperationalResult {
  * Per source -> best line by OPERATIONAL_TIER. Per provider -> if it has any
  * provider-derived source, its manual/estimate sources are excluded from operational
  * (fallback only). No double counting. `win` is used for the forecast run-rate.
+ *
+ * `now` (epoch sec) is the reference instant for the future-stamp guard below.
+ * It is a parameter and not a `Date.now()` read so that this function is a pure
+ * function of its inputs: every caller in the codebase already has the request's
+ * `now` in scope, and a wall-clock read made the result depend on WHEN it ran.
  */
-export function resolveOperational(lines: OpLine[], win: MonthWindow): OperationalResult {
+export function resolveOperational(lines: OpLine[], win: MonthWindow, now: number = Math.floor(Date.now() / 1000)): OperationalResult {
   const bySource = new Map<string, OpLine[]>()
   for (const l of lines) { const a = bySource.get(l.source_id); if (a) a.push(l); else bySource.set(l.source_id, [l]) }
   const sourceBest = new Map<string, OpLine>()
@@ -168,7 +173,7 @@ export function resolveOperational(lines: OpLine[], win: MonthWindow): Operation
       // Same kind of line -> fall back to freshness, but a stamp in the FUTURE
       // cannot mean "fresher". A period-END date reaching data_freshness is a
       // known data defect (card 320c477a) and must not decide anything.
-      const now = Date.now() / 1000
+      // "Future" is measured against the caller's `now`, not the wall clock.
       const fa = a.data_freshness > now ? -Infinity : a.data_freshness
       const fb = b.data_freshness > now ? -Infinity : b.data_freshness
       return fb > fa ? b : a
@@ -566,7 +571,7 @@ export function getCostSummary(
     billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
     source_type: sourceTypeBySource.get(l.source_id),
   }))
-  const op = resolveOperational(opLines, win)
+  const op = resolveOperational(opLines, win, now)
 
   // previous month: aggregate from cost_line_items; NEVER fabricated. null if no data.
   const prevWin = monthWindow(win.start - 86400)
@@ -580,7 +585,7 @@ export function getCostSummary(
       source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
       billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
       source_type: sourceTypeBySource.get(l.source_id),
-    })), prevWin)
+    })), prevWin, now)
     previous_month = { month: prevWin.key, operational_spend: prevOp.operational_spend, by_provider: prevOp.provider_breakdown }
   }
   const month_over_month_delta = previous_month ? round2(op.operational_spend - previous_month.operational_spend) : null

--- a/src/costops/lifecycle.ts
+++ b/src/costops/lifecycle.ts
@@ -1,0 +1,95 @@
+// CostOps Phase 0 -- source lifecycle and provenance, kept as two SEPARATE
+// fields (gap-analysis GAP-03). Pure derivation, no I/O, no DB, no LLM --
+// callers (inventory.ts) gather the input facts from the DB/Vault and pass
+// them in here as plain booleans/strings.
+//
+// The headline example this fixes: the OpenAI API source has a WORKING
+// credential and a WORKING collector, but currently ~$0 of actual usage --
+// that is 'inactive', not a credential/auth problem. Lifecycle answers "is
+// this source usable and in what state"; provenance answers "where did THIS
+// number come from". Mixing them (e.g. treating "no data yet" as an error
+// state) is exactly the GAP-03 bug this module exists to prevent.
+
+export type SourceLifecycle =
+  | 'active'
+  | 'inactive'
+  | 'not_configured'
+  | 'unsupported'
+  | 'blocked'
+  | 'deprecated'
+
+export type SourceProvenance =
+  | 'provider_api_actual'
+  | 'invoice_actual'
+  | 'imported_actual'
+  | 'manual_actual'
+  | 'calculated_estimate'
+  | 'unknown'
+
+export interface LifecycleInput {
+  /** Manual override: this provider/source is explicitly known to have no
+   * viable collection path at all (e.g. no public billing API exists).
+   * Takes priority over every other signal. */
+  explicitlyUnsupported: boolean
+  /** Manual override: this source is explicitly retired/cancelled. Takes
+   * priority over every signal below it. */
+  explicitlyDeprecated: boolean
+  /** Whether this source needs an external credential (Vault secret, API
+   * key) to be collected at all. false for manual/invoice-driven sources --
+   * credential presence is meaningless for them. */
+  credentialRequired: boolean
+  /** Whether the required credential is currently present. Ignored when
+   * credentialRequired is false. */
+  credentialPresent: boolean
+  /** The most recent import_runs status recorded for this source's
+   * provider, or null if no collection attempt has ever been recorded
+   * (distinct from an attempt that ran and failed). */
+  lastRunStatus: 'ok' | 'error' | 'failed' | 'partial' | 'rate_limited' | null
+  /** Whether this source has EVER produced a real (non-pending) cost line --
+   * i.e. genuine activity/spend was observed at some point, even if the
+   * current month is zero. A source with a working collector and simply no
+   * usage yet is 'inactive', not an error. */
+  hasEverHadActivity: boolean
+}
+
+/**
+ * Derive a single, unambiguous lifecycle state. Order matters: an explicit
+ * override always wins, then missing configuration, then a genuine collector
+ * failure, then "configured and working but idle", then active.
+ */
+export function deriveSourceLifecycle(input: LifecycleInput): SourceLifecycle {
+  if (input.explicitlyUnsupported) return 'unsupported'
+  if (input.explicitlyDeprecated) return 'deprecated'
+  if (input.credentialRequired && !input.credentialPresent) return 'not_configured'
+  if (input.lastRunStatus != null && input.lastRunStatus !== 'ok') return 'blocked'
+  if (!input.hasEverHadActivity) return 'inactive'
+  return 'active'
+}
+
+// Existing `CostConfidence` values (config.ts) mixed the authoritativeness
+// axis with a de-facto provenance one. `actualSource` (already written per
+// row since v0.8, see ledger.ts) is the closer match to "where did this
+// number come from" -- this function normalizes both into the Phase 0
+// enum without touching either underlying column.
+const ESTIMATE_CONFIDENCE = new Set(['estimate', 'local_usage', 'provider_plan_estimate'])
+
+/**
+ * Map an existing (confidence, actual_source) pair to the Phase 0 provenance
+ * enum. Never guesses: unrecognized/absent input maps to 'unknown', not a
+ * fabricated default. `imported_actual` is reserved for a future bulk-import
+ * path -- no current collector produces it (every provider_api collector in
+ * this codebase writes actual_source='provider_api', not a distinct bulk
+ * import), so it never comes out of this function today; it exists so a
+ * future collector class has a home without another enum change.
+ */
+export function deriveProvenance(confidence: string | null | undefined, actualSource: string | null | undefined): SourceProvenance {
+  if (actualSource === 'provider_api') return 'provider_api_actual'
+  if (actualSource === 'email_invoice') return 'invoice_actual'
+  if (actualSource === 'pending_permission') return 'unknown'  // genuinely not observable yet, never guessed
+  if (actualSource === 'manual_entry') {
+    return confidence && ESTIMATE_CONFIDENCE.has(confidence) ? 'calculated_estimate' : 'manual_actual'
+  }
+  if (confidence && ESTIMATE_CONFIDENCE.has(confidence)) return 'calculated_estimate'
+  if (confidence === 'manual') return 'manual_actual'
+  return 'unknown'
+}

--- a/src/costops/limits.ts
+++ b/src/costops/limits.ts
@@ -1,0 +1,274 @@
+// CostOps v0.8 -- limits/quota normalization (card 6f4d1332 §6.2).
+//
+// Genuinely additive glue code: reads 4 already-existing raw sources (subscription lifecycle,
+// DeepSeek balance snapshots, Workspace alerts, Render build-minutes + SSL/domain expiry) and
+// normalizes them into ONE shape so warnings.ts's tiered limit rule (§6) can apply uniformly.
+// No new storage. usage_pct is ALWAYS "fraction of the limit consumed" (0 = nothing used, 1 =
+// fully consumed) across every limit_type, so a single threshold ladder works for all of them.
+// Honest gaps stay honest: no numeric ceiling exists for Claude Max/ChatGPT/Render build-minutes
+// (confirmed against costops-subscriptions.json's schema and Render's events API) -- those
+// render usage_pct: null, status: 'unknown', never an invented percentage.
+
+import type Database from 'better-sqlite3'
+import type { SubscriptionLifecycle } from './subscriptions.js'
+import { getActiveWorkspaceAlerts } from './workspace-alerts.js'
+import { checkRenderBuildMinutes } from './render-live-checks.js'
+import { loadDomainsConfig, checkSslExpiry, checkDomainExpiry, EXPIRY_THRESHOLDS } from './expiry-checks.js'
+import type { CostWarning } from './warnings.js'
+
+export type LimitStatusTier = 'ok' | 'warning' | 'critical' | 'blocked' | 'unknown'
+
+export interface LimitStatus {
+  provider: string
+  limit_type: string
+  current_usage: number | null
+  limit_value: number | null
+  usage_pct: number | null       // 0..1, fraction CONSUMED (never a %-remaining inversion)
+  reset_date: string | null
+  paid_until: string | null
+  expiry_date: string | null
+  status: LimitStatusTier
+  source: string                 // 'config' | 'ledger' | 'render_api' | 'workspace_alert' | 'tls' | 'rdap'
+  // Card 2ed90db1: which costops-subscriptions.json entry this came from, when applicable
+  // (null for every non-subscription source). Multiple subscriptions can share the same
+  // `provider` (e.g. Claude Max + Claude Pro are both 'anthropic') -- provider alone can't
+  // disambiguate which subscription a row belongs to, sub_id can.
+  sub_id: string | null
+  // Card 7d086cd3 (F4, Muse WS-C design-fidelity): current_usage/limit_value carry NO unit info
+  // on their own -- every limit_type here except DeepSeek's balance leaves both null (a day-count,
+  // a token-count, or genuinely unknown), so the renderer's HUF-formatter silently stamping "Ft"
+  // onto whatever number showed up went unnoticed until a real dollar-denominated value (DeepSeek's
+  // native USD prepaid balance) hit it and printed "3,17 HUF" for a ~$3.17 USD balance. null means
+  // "not a monetary value, or currency genuinely unknown" -- never assume HUF by omission.
+  unit: string | null
+}
+
+function tierForPct(pct: number | null): LimitStatusTier {
+  if (pct === null) return 'unknown'
+  if (pct >= 1.0) return 'blocked'
+  if (pct >= 0.9) return 'critical'
+  if (pct >= 0.7) return 'warning'
+  return 'ok'
+}
+
+function tierForDays(days: number | null): LimitStatusTier {
+  if (days === null) return 'unknown'
+  if (days < 0) return 'blocked'
+  if (days <= EXPIRY_THRESHOLDS.critical) return 'critical'
+  if (days <= EXPIRY_THRESHOLDS.warn) return 'warning'
+  return 'ok'
+}
+
+// ---- 1. Subscription lifecycle (renewal/cancellation dates -- date-based, not %-based unless
+// an optional weekly_limit_tokens/five_hour_limit_tokens ceiling is present, see SubscriptionEntry) ---
+export function fromSubscriptions(subs: SubscriptionLifecycle[]): LimitStatus[] {
+  const out: LimitStatus[] = []
+  for (const s of subs) {
+    const targetDate = s.status === 'canceled' ? s.paid_until : s.next_renewal
+    // No early-continue here: a subscription can have a usage_snapshot (below) with no known
+    // renewal/cancellation date at all (e.g. Claude Pro after re-activation -- status flipped to
+    // active but no next_renewal was supplied, never fabricated) -- that must still emit its
+    // weekly-usage entry even though it has no renewal-date entry to emit.
+    if (targetDate) {
+      out.push({
+        provider: s.provider, limit_type: 'subscription_renewal',
+        current_usage: null, limit_value: null, usage_pct: null,
+        reset_date: s.status === 'active' ? s.next_renewal ?? null : null,
+        paid_until: s.status === 'canceled' ? s.paid_until ?? null : null,
+        expiry_date: null,
+        status: s.past_due ? 'blocked' : tierForDays(s.days_until_next_date),
+        source: 'config', sub_id: s.id, unit: null,
+      })
+    }
+    // Optional token ceiling (v0.8): only emitted when the operator has actually supplied one --
+    // never a fabricated limit_value. Current usage cross-referencing against token_usage by
+    // agent is future work (no agent<->subscription mapping exists yet) -- honestly unknown
+    // for now, matching the spec's "recommend, don't build speculatively" instruction.
+    if (s.weekly_limit_tokens || s.five_hour_limit_tokens) {
+      out.push({
+        provider: s.provider, limit_type: s.weekly_limit_tokens ? 'weekly_tokens' : 'five_hour_tokens',
+        current_usage: null, limit_value: s.weekly_limit_tokens ?? s.five_hour_limit_tokens ?? null,
+        usage_pct: null, reset_date: null, paid_until: null, expiry_date: null,
+        status: 'unknown', source: 'config', sub_id: s.id, unit: null,
+      })
+    }
+    // Card 2ed90db1: manual weekly-usage-% snapshot (Claude Max/Pro's actual usage screen has
+    // no absolute token ceiling, percent + reset label is the real data). weekly_pct is what
+    // drives the 80% alert (warnings.ts rule 11, generic tiered limit) -- session_pct/fable_pct
+    // are informational-only (surfaced via the subscription object itself, not alerted on,
+    // since only weekly usage was asked to trigger the alert).
+    if (s.usage_snapshot) {
+      const pct = s.usage_snapshot.weekly_pct / 100
+      out.push({
+        provider: s.provider, limit_type: 'weekly_usage_pct',
+        current_usage: null, limit_value: null, usage_pct: pct,
+        reset_date: s.usage_snapshot.weekly_reset_label, paid_until: null, expiry_date: null,
+        status: tierForPct(pct), source: 'config', sub_id: s.id, unit: null,
+      })
+    }
+  }
+  return out
+}
+
+// ---- 2. DeepSeek prepaid balance (same data/logic already in warnings.ts rule 10, normalized) ---
+export function fromDeepSeekBalance(db: Database.Database): LimitStatus[] {
+  const rows = db.prepare(
+    `SELECT balance, currency, captured_at FROM provider_balance_snapshots WHERE provider = 'deepseek' ORDER BY captured_at DESC`,
+  ).all() as Array<{ balance: number; currency: string; captured_at: number }>
+  if (rows.length === 0) {
+    return [{
+      provider: 'deepseek', limit_type: 'balance', current_usage: null, limit_value: null,
+      usage_pct: null, reset_date: null, paid_until: null, expiry_date: null,
+      status: 'unknown', source: 'ledger', sub_id: null, unit: null,
+    }]
+  }
+  const latest = rows[0].balance
+  const peak = Math.max(...rows.map(r => r.balance))
+  const hadObservedDrop = peak > latest
+  // usage_pct here means fraction of the peak (last top-up) already SPENT -- consistent with
+  // every other limit_type's "fraction consumed" convention (inverse of warnings.ts's own
+  // "% remaining vs peak" framing, which is display-oriented, not a consumed-fraction).
+  const usage_pct = hadObservedDrop ? Math.round((1 - latest / peak) * 10000) / 10000 : null
+  return [{
+    provider: 'deepseek', limit_type: 'balance', current_usage: latest, limit_value: peak,
+    usage_pct, reset_date: null, paid_until: null, expiry_date: null,
+    // Card 7d086cd3 (F4): this is a raw prepaid balance, native currency -- always USD for
+    // DeepSeek today (the snapshot row itself carries it, not assumed), never HUF-converted here.
+    status: tierForPct(usage_pct), source: 'ledger', sub_id: null, unit: rows[0].currency,
+  }]
+}
+
+// ---- 2b. Codex / ChatGPT Plus weekly rate-limit (metadata snapshot -> normalized) ----------
+// Latest usedPercent snapshot from provider_ratelimit_snapshots (written by the codex collector
+// via the app-server metadata read -- zero quota). No snapshot yet -> 'unknown' (never a guess),
+// same honest-gap rule as the no-numeric-ceiling subscription limits.
+export function fromCodexRateLimit(db: Database.Database): LimitStatus[] {
+  const rows = db.prepare(
+    `SELECT used_percent, resets_at, captured_at FROM provider_ratelimit_snapshots WHERE provider = 'codex' ORDER BY captured_at DESC LIMIT 1`,
+  ).all() as Array<{ used_percent: number; resets_at: number | null; captured_at: number }>
+  if (rows.length === 0) {
+    return [{
+      provider: 'codex', limit_type: 'weekly_usage_pct', current_usage: null, limit_value: null,
+      usage_pct: null, reset_date: null, paid_until: null, expiry_date: null,
+      status: 'unknown', source: 'ledger', sub_id: null, unit: null,
+    }]
+  }
+  const latest = rows[0]
+  const pct = latest.used_percent / 100
+  return [{
+    provider: 'codex', limit_type: 'weekly_usage_pct', current_usage: latest.used_percent, limit_value: 100,
+    usage_pct: pct,
+    reset_date: latest.resets_at !== null ? new Date(latest.resets_at * 1000).toISOString() : null,
+    paid_until: null, expiry_date: null,
+    status: tierForPct(pct), source: 'ledger', sub_id: null, unit: '%',
+  }]
+}
+
+// ---- 3. Workspace payment/suspension alerts -----------------------------------------------
+function fromWorkspaceAlerts(db: Database.Database, now: number): LimitStatus[] {
+  const rows = getActiveWorkspaceAlerts(db, now)
+  const seen = new Set<string>()
+  const out: LimitStatus[] = []
+  for (const r of rows) {
+    const key = `${r.account}|${r.issue_type}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    const daysRemaining = r.suspension_date !== null ? Math.floor((r.suspension_date - now) / 86400) : null
+    out.push({
+      provider: 'google-workspace', limit_type: 'workspace_payment',
+      current_usage: null, limit_value: null, usage_pct: null,
+      reset_date: null, paid_until: null,
+      expiry_date: r.suspension_date !== null ? new Date(r.suspension_date * 1000).toISOString().slice(0, 10) : null,
+      status: r.issue_type === 'suspended' ? 'blocked' : tierForDays(daysRemaining) === 'unknown' ? 'warning' : tierForDays(daysRemaining),
+      source: 'workspace_alert', sub_id: null, unit: null,
+    })
+  }
+  return out
+}
+
+// ---- 4. Render build-minutes + SSL/domain expiry (live network checks -> normalized) --------
+//
+// Card fa041036: /api/costs/warnings was independently re-running these exact same 3 live checks
+// a second time (sequentially, no less) right after calling getLimitStatus() -- which already ran
+// them once, concurrently, via this function. That double-fetch (one concurrent + one sequential,
+// same request) was the real cost behind the reported 20-35s, not the DB-side ledger reads (those
+// are narrow, indexed sqlite queries -- checked, not the bottleneck). Fix: cache the raw 3-way
+// result for LIVE_CHECKS_TTL_MS and share it between both routes, so within the TTL window a
+// second caller (same request or the next dashboard poll) gets the already-fetched result instead
+// of re-hitting Render's API for every service + a TLS handshake per host + an RDAP lookup.
+const LIVE_CHECKS_TTL_MS = 5 * 60 * 1000
+interface LiveChecksResult { renderWarnings: CostWarning[]; sslWarnings: CostWarning[]; domainWarnings: CostWarning[] }
+let liveChecksCache: { key: string; at: number; promise: Promise<LiveChecksResult> } | null = null
+
+export async function getLiveCheckWarnings(now: number, sslHosts: string[], domains: string[]): Promise<LiveChecksResult> {
+  const key = JSON.stringify([sslHosts, domains])
+  const nowMs = now * 1000
+  if (liveChecksCache && liveChecksCache.key === key && (nowMs - liveChecksCache.at) < LIVE_CHECKS_TTL_MS) {
+    return liveChecksCache.promise
+  }
+  const promise = Promise.all([
+    checkRenderBuildMinutes(now),
+    checkSslExpiry(sslHosts, now),
+    checkDomainExpiry(domains, now),
+  ]).then(([renderWarnings, sslWarnings, domainWarnings]) => ({ renderWarnings, sslWarnings, domainWarnings }))
+  liveChecksCache = { key, at: nowMs, promise }
+  // A failed round shouldn't poison the cache for the rest of the TTL window -- clear it so the
+  // next call retries live instead of returning a stuck rejection for up to 5 minutes.
+  promise.catch(() => { if (liveChecksCache?.promise === promise) liveChecksCache = null })
+  return promise
+}
+
+async function fromLiveChecks(now: number, sslHosts: string[], domains: string[]): Promise<LimitStatus[]> {
+  const out: LimitStatus[] = []
+  const { renderWarnings, sslWarnings, domainWarnings } = await getLiveCheckWarnings(now, sslHosts, domains)
+  for (const w of renderWarnings) {
+    if (w.code !== 'render_build_minutes_exhausted') continue // access-failure warnings aren't a limit signal
+    out.push({
+      provider: 'render', limit_type: 'build_minutes', current_usage: null, limit_value: null,
+      usage_pct: 1.0, reset_date: null, paid_until: null, expiry_date: null,
+      status: 'blocked', source: 'render_api', sub_id: null, unit: null,
+    })
+  }
+  for (const w of sslWarnings) {
+    out.push({
+      provider: String(w.provider || 'ssl'), limit_type: 'ssl_expiry',
+      current_usage: w.current_value ?? null, limit_value: w.threshold ?? null, usage_pct: null,
+      reset_date: null, paid_until: null, expiry_date: w.expiry_date ?? w.due_date ?? null,
+      status: w.severity === 'high' ? 'critical' : w.severity === 'medium' ? 'warning' : 'warning',
+      source: 'tls', sub_id: null, unit: null,
+    })
+  }
+  for (const w of domainWarnings) {
+    out.push({
+      provider: String(w.provider || 'domain'), limit_type: 'domain_expiry',
+      current_usage: w.current_value ?? null, limit_value: w.threshold ?? null, usage_pct: null,
+      reset_date: null, paid_until: null, expiry_date: w.expiry_date ?? w.due_date ?? null,
+      status: w.severity === 'high' ? 'critical' : w.severity === 'medium' ? 'warning' : 'warning',
+      source: 'rdap', sub_id: null, unit: null,
+    })
+  }
+  return out
+}
+
+/**
+ * Normalize every known limit/quota signal into one shape. Never fabricates a percentage --
+ * a source with no real ceiling data (Claude Max weekly, ChatGPT, Render build-minutes below
+ * 100%) reports usage_pct: null, status: 'unknown' rather than a guess.
+ */
+export async function getLimitStatus(
+  db: Database.Database,
+  now: number,
+  subscriptions: SubscriptionLifecycle[],
+): Promise<LimitStatus[]> {
+  const { config: domainsConfig } = loadDomainsConfig()
+  const [live] = await Promise.all([
+    fromLiveChecks(now, domainsConfig.ssl_hosts, domainsConfig.domains),
+  ])
+  return [
+    ...fromSubscriptions(subscriptions),
+    ...fromDeepSeekBalance(db),
+    ...fromCodexRateLimit(db),
+    ...fromWorkspaceAlerts(db, now),
+    ...live,
+  ]
+}

--- a/src/costops/manual-entry.ts
+++ b/src/costops/manual-entry.ts
@@ -1,0 +1,280 @@
+// CostOps -- manual cost/entitlement entry (card a1552362, item 3).
+//
+// Every other cost_line_items/entitlements write path in this file is an automated
+// collector or an agent-side Gmail sweep. There was no way to hand-enter a cost or
+// entitlement the operator already knows (e.g. a provider with no API/no invoice yet) --
+// this is that one manual door. Same conventions as email-ingest.ts: idempotent
+// upsert by dedup_key, HUF-normalized amount with original-currency retention,
+// confidence/actual_source explicitly 'manual'/'manual_entry' (never guessed).
+//
+// POST creates a NEW entry (409 if one already exists for that key -- forces an
+// explicit PATCH to change a number someone already hand-entered, rather than a
+// second POST silently overwriting it). PATCH updates an existing entry (404 if
+// missing). DELETE voids it (card 73e8914a, Phase 0 decision) rather than hard-
+// deleting -- see deleteManualCost below.
+
+import type Database from 'better-sqlite3'
+import { toHuf, fxRateFor } from './email-ingest.js'
+import { checkPeriodWritable } from './period-close.js'
+
+export interface ManualCostInput {
+  source_id: string
+  name: string
+  provider: string
+  amount: number
+  currency: string      // 'HUF' | 'USD' | 'EUR' | ...
+  month: string          // 'YYYY-MM'
+  source_type?: string   // default 'subscription'
+}
+
+export interface ManualCostPatch {
+  source_id: string
+  month: string
+  amount: number
+  currency: string
+}
+
+export interface ManualCostDeleteInput {
+  source_id: string
+  month: string
+  /** Free-text reason for the void, surfaced in the audit trail. Never
+   * required (a UI "remove" click may have no reason to give), but recorded
+   * verbatim when present. */
+  reason?: string
+}
+
+function monthWindow(month: string): { start: number; end: number } | null {
+  if (!/^\d{4}-\d{2}$/.test(month)) return null
+  const y = parseInt(month.slice(0, 4)), m = parseInt(month.slice(5, 7)) - 1
+  return { start: Math.floor(Date.UTC(y, m, 1) / 1000), end: Math.floor(Date.UTC(y, m + 1, 1) / 1000) }
+}
+
+function manualCostDedupKey(sourceId: string, month: string): string {
+  return `manual|${sourceId}|${month}`
+}
+
+export function createManualCost(
+  db: Database.Database,
+  input: ManualCostInput,
+  opts: { fxUsdHuf: number; fxEurHuf?: number; now: number },
+): { ok: boolean; error?: string; status?: number } {
+  if (!input || typeof input.source_id !== 'string' || !input.source_id) return { ok: false, error: 'missing source_id', status: 400 }
+  if (!input.name) return { ok: false, error: 'missing name', status: 400 }
+  if (!input.provider) return { ok: false, error: 'missing provider', status: 400 }
+  const win = monthWindow(input.month)
+  if (!win) return { ok: false, error: `bad month '${input.month}'`, status: 400 }
+  // Phase 2 (GAP-13): a closed month accepts no direct write -- use a correction instead.
+  const writable = checkPeriodWritable(db, input.month)
+  if (!writable.writable) return { ok: false, error: writable.reason, status: 409 }
+  const cur = (input.currency || 'HUF').toUpperCase()
+  const amountHuf = toHuf(Number(input.amount), cur, opts.fxUsdHuf, opts.fxEurHuf ?? 0)
+  if (amountHuf === null || !isFinite(amountHuf)) return { ok: false, error: `unconvertible currency '${input.currency}'`, status: 400 }
+  const dedup = manualCostDedupKey(input.source_id, input.month)
+  const existing = db.prepare(`SELECT 1 FROM cost_line_items WHERE dedup_key = ?`).get(dedup)
+  if (existing) return { ok: false, error: `a manual entry for '${input.source_id}' / '${input.month}' already exists -- use PATCH to update it`, status: 409 }
+
+  const wasConverted = cur !== 'HUF'
+  const appliedFxRate = fxRateFor(cur, opts.fxUsdHuf, opts.fxEurHuf ?? 0)
+  db.prepare(`
+    INSERT INTO cost_sources (id, name, provider, source_type, currency, active, created_at, updated_at)
+    VALUES (@id, @name, @provider, @source_type, 'HUF', 1, @now, @now)
+    ON CONFLICT(id) DO UPDATE SET name=excluded.name, provider=excluded.provider, source_type=excluded.source_type, updated_at=excluded.updated_at
+  `).run({ id: input.source_id, name: input.name, provider: input.provider, source_type: input.source_type || 'subscription', now: opts.now })
+  db.prepare(`
+    INSERT INTO cost_line_items
+      (source_id, charge_period_start, charge_period_end, charge_category, service_name,
+       usage_type, consumed_quantity, consumed_unit, billed_cost, effective_cost, currency,
+       confidence, data_freshness, source_ref, dedup_key, created_at, actual_source,
+       original_amount, original_currency, fx_rate, fx_date, fx_source, conversion_method)
+    VALUES
+      (@source_id, @start, @end, 'invoice', @name,
+       NULL, NULL, NULL, @amount, NULL, 'HUF',
+       'manual', @now, NULL, @dedup_key, @now, 'manual_entry',
+       @original_amount, @original_currency, @fx_rate, @fx_date, @fx_source, @conversion_method)
+  `).run({
+    source_id: input.source_id, start: win.start, end: win.end, name: input.name,
+    amount: amountHuf, now: opts.now, dedup_key: dedup,
+    original_amount: wasConverted ? Number(input.amount) : null,
+    original_currency: wasConverted ? cur : null,
+    fx_rate: wasConverted ? appliedFxRate : null,
+    fx_date: wasConverted ? opts.now : null,
+    // Phase 1 (GAP-09): a manual entry has no invoice date to prefer --
+    // 'service_date_rate' (the entry's own month), same rate source as
+    // every other conversion in this codebase (Render pricing config).
+    fx_source: wasConverted ? 'render_pricing_config' : null,
+    conversion_method: wasConverted ? 'service_date_rate' : null,
+  })
+  return { ok: true }
+}
+
+export function updateManualCost(
+  db: Database.Database,
+  patch: ManualCostPatch,
+  opts: { fxUsdHuf: number; fxEurHuf?: number; now: number },
+): { ok: boolean; error?: string; status?: number } {
+  if (!patch || typeof patch.source_id !== 'string' || !patch.source_id) return { ok: false, error: 'missing source_id', status: 400 }
+  const win = monthWindow(patch.month)
+  if (!win) return { ok: false, error: `bad month '${patch.month}'`, status: 400 }
+  const dedup = manualCostDedupKey(patch.source_id, patch.month)
+  const existing = db.prepare(`SELECT confidence FROM cost_line_items WHERE dedup_key = ?`).get(dedup) as { confidence: string } | undefined
+  if (!existing) return { ok: false, error: `no manual entry for '${patch.source_id}' / '${patch.month}' -- use POST to create one`, status: 404 }
+  if (existing.confidence !== 'manual') return { ok: false, error: `'${patch.source_id}' / '${patch.month}' is not a manual entry (confidence='${existing.confidence}')`, status: 409 }
+  // Phase 2 (GAP-13): a closed month accepts no direct write -- use a correction instead.
+  const writable = checkPeriodWritable(db, patch.month)
+  if (!writable.writable) return { ok: false, error: writable.reason, status: 409 }
+  const cur = (patch.currency || 'HUF').toUpperCase()
+  const amountHuf = toHuf(Number(patch.amount), cur, opts.fxUsdHuf, opts.fxEurHuf ?? 0)
+  if (amountHuf === null || !isFinite(amountHuf)) return { ok: false, error: `unconvertible currency '${patch.currency}'`, status: 400 }
+  const wasConverted = cur !== 'HUF'
+  const appliedFxRate = fxRateFor(cur, opts.fxUsdHuf, opts.fxEurHuf ?? 0)
+  db.prepare(`
+    UPDATE cost_line_items SET
+      billed_cost = @amount, data_freshness = @now,
+      original_amount = @original_amount, original_currency = @original_currency,
+      fx_rate = @fx_rate, fx_date = @fx_date, fx_source = @fx_source, conversion_method = @conversion_method
+    WHERE dedup_key = @dedup_key
+  `).run({
+    amount: amountHuf, now: opts.now, dedup_key: dedup,
+    original_amount: wasConverted ? Number(patch.amount) : null,
+    original_currency: wasConverted ? cur : null,
+    fx_rate: wasConverted ? appliedFxRate : null,
+    fx_date: wasConverted ? opts.now : null,
+    fx_source: wasConverted ? 'render_pricing_config' : null,
+    conversion_method: wasConverted ? 'service_date_rate' : null,
+  })
+  return { ok: true }
+}
+
+// Card 73e8914a (Phase 0 decision, docs/costops/phase0-73e8914a-void-vs-delete.md): create+patch
+// had no way to remove a mistyped row -- only direct SQL on cost_line_items could. Same guard as
+// updateManualCost (404 if missing, 409 if the row isn't actually a manual entry) so this door can
+// never touch a live provider-fed row.
+//
+// VOID, not hard DELETE: a financial ledger row must stay auditable (accounting-integrity
+// principle, gap-analysis GAP-15) -- reversing the file header's original "no soft-delete layer"
+// stance, which predates the formal accounting-integrity requirements. Sets voided_at/void_reason
+// and RENAMES dedup_key (appends |voided|<now>) so (a) every aggregation read path can exclude it
+// via `voided_at IS NULL` and (b) the original dedup_key slot is free for a fresh, correct POST --
+// a re-entry after a mistaken void is a NEW audited entry, not a silent overwrite of the old one.
+export function deleteManualCost(
+  db: Database.Database,
+  input: ManualCostDeleteInput,
+  opts: { now: number },
+): { ok: boolean; error?: string; status?: number } {
+  if (!input || typeof input.source_id !== 'string' || !input.source_id) return { ok: false, error: 'missing source_id', status: 400 }
+  const win = monthWindow(input.month)
+  if (!win) return { ok: false, error: `bad month '${input.month}'`, status: 400 }
+  const dedup = manualCostDedupKey(input.source_id, input.month)
+  const existing = db.prepare(`SELECT confidence, voided_at FROM cost_line_items WHERE dedup_key = ?`).get(dedup) as { confidence: string; voided_at: number | null } | undefined
+  if (!existing) return { ok: false, error: `no manual entry for '${input.source_id}' / '${input.month}'`, status: 404 }
+  if (existing.confidence !== 'manual') return { ok: false, error: `'${input.source_id}' / '${input.month}' is not a manual entry (confidence='${existing.confidence}')`, status: 409 }
+  if (existing.voided_at != null) return { ok: false, error: `'${input.source_id}' / '${input.month}' is already voided`, status: 409 }
+  // Phase 2 (GAP-13): a closed month accepts no direct write, including a void -- use a correction instead.
+  const writable = checkPeriodWritable(db, input.month)
+  if (!writable.writable) return { ok: false, error: writable.reason, status: 409 }
+  db.prepare(`
+    UPDATE cost_line_items SET voided_at = @now, void_reason = @reason, dedup_key = @voidedDedupKey
+    WHERE dedup_key = @dedup
+  `).run({ now: opts.now, reason: input.reason ?? null, voidedDedupKey: `${dedup}|voided|${opts.now}`, dedup })
+  return { ok: true }
+}
+
+export interface ManualEntitlementInput {
+  provider: string
+  product: string
+  plan_name?: string | null
+  billing_period: string   // e.g. 'monthly' | 'weekly' | 'ongoing'
+  entitlement_type: string
+  included_limit?: number | null
+  included_unit?: string | null
+  remaining?: number | null
+  reset_at?: number | null   // epoch seconds
+  status: string             // 'ok' | 'warning' | 'critical' | 'unknown'
+}
+
+export interface ManualEntitlementPatch extends ManualEntitlementInput {}
+
+function entitlementDedupKey(e: { provider: string; product: string; entitlement_type: string; billing_period: string }): string {
+  return `manual|${e.provider}|${e.product}|${e.entitlement_type}|${e.billing_period}`
+}
+
+export function createManualEntitlement(
+  db: Database.Database,
+  input: ManualEntitlementInput,
+  now: number,
+): { ok: boolean; error?: string; status?: number } {
+  if (!input?.provider) return { ok: false, error: 'missing provider', status: 400 }
+  if (!input?.product) return { ok: false, error: 'missing product', status: 400 }
+  if (!input?.entitlement_type) return { ok: false, error: 'missing entitlement_type', status: 400 }
+  if (!input?.billing_period) return { ok: false, error: 'missing billing_period', status: 400 }
+  if (!input?.status) return { ok: false, error: 'missing status', status: 400 }
+  const dedup = entitlementDedupKey(input)
+  const existing = db.prepare(`SELECT 1 FROM entitlements WHERE dedup_key = ?`).get(dedup)
+  if (existing) return { ok: false, error: `a manual entitlement for '${dedup}' already exists -- use PATCH to update it`, status: 409 }
+  db.prepare(`
+    INSERT INTO entitlements
+      (provider, product, plan_name, billing_period, entitlement_type,
+       included_limit, included_unit, usage_to_date, remaining, usage_pct, reset_at,
+       usage_source, usage_confidence, forecast_exhaustion_at, status, dedup_key, last_updated, created_at)
+    VALUES
+      (@provider, @product, @plan_name, @billing_period, @entitlement_type,
+       @included_limit, @included_unit, NULL, @remaining, NULL, @reset_at,
+       'manual', 'manual', NULL, @status, @dedup_key, @now, @now)
+  `).run({
+    provider: input.provider, product: input.product, plan_name: input.plan_name ?? null,
+    billing_period: input.billing_period, entitlement_type: input.entitlement_type,
+    included_limit: input.included_limit ?? null, included_unit: input.included_unit ?? null,
+    remaining: input.remaining ?? null, reset_at: input.reset_at ?? null, status: input.status,
+    dedup_key: dedup, now,
+  })
+  return { ok: true }
+}
+
+export function updateManualEntitlement(
+  db: Database.Database,
+  patch: ManualEntitlementPatch,
+  now: number,
+): { ok: boolean; error?: string; status?: number } {
+  if (!patch?.provider || !patch?.product || !patch?.entitlement_type || !patch?.billing_period) {
+    return { ok: false, error: 'missing provider/product/entitlement_type/billing_period', status: 400 }
+  }
+  const dedup = entitlementDedupKey(patch)
+  const existing = db.prepare(`SELECT usage_source FROM entitlements WHERE dedup_key = ?`).get(dedup) as { usage_source: string } | undefined
+  if (!existing) return { ok: false, error: `no manual entitlement for '${dedup}' -- use POST to create one`, status: 404 }
+  if (existing.usage_source !== 'manual') return { ok: false, error: `'${dedup}' is not a manual entitlement (usage_source='${existing.usage_source}')`, status: 409 }
+  db.prepare(`
+    UPDATE entitlements SET
+      plan_name = @plan_name, included_limit = @included_limit, included_unit = @included_unit,
+      remaining = @remaining, reset_at = @reset_at, status = @status, last_updated = @now
+    WHERE dedup_key = @dedup_key
+  `).run({
+    plan_name: patch.plan_name ?? null, included_limit: patch.included_limit ?? null,
+    included_unit: patch.included_unit ?? null, remaining: patch.remaining ?? null,
+    reset_at: patch.reset_at ?? null, status: patch.status, now, dedup_key: dedup,
+  })
+  return { ok: true }
+}
+
+export interface ManualEntitlementDeleteInput {
+  provider: string
+  product: string
+  entitlement_type: string
+  billing_period: string
+}
+
+// Card 73e8914a: same missing lifecycle corner as deleteManualCost above -- same guard
+// (404 missing, 409 not-manual), hard delete.
+export function deleteManualEntitlement(
+  db: Database.Database,
+  input: ManualEntitlementDeleteInput,
+): { ok: boolean; error?: string; status?: number } {
+  if (!input?.provider || !input?.product || !input?.entitlement_type || !input?.billing_period) {
+    return { ok: false, error: 'missing provider/product/entitlement_type/billing_period', status: 400 }
+  }
+  const dedup = entitlementDedupKey(input)
+  const existing = db.prepare(`SELECT usage_source FROM entitlements WHERE dedup_key = ?`).get(dedup) as { usage_source: string } | undefined
+  if (!existing) return { ok: false, error: `no manual entitlement for '${dedup}'`, status: 404 }
+  if (existing.usage_source !== 'manual') return { ok: false, error: `'${dedup}' is not a manual entitlement (usage_source='${existing.usage_source}')`, status: 409 }
+  db.prepare(`DELETE FROM entitlements WHERE dedup_key = ?`).run(dedup)
+  return { ok: true }
+}

--- a/src/costops/optimization-capture.ts
+++ b/src/costops/optimization-capture.ts
@@ -1,0 +1,309 @@
+// CostOps -- optimization recommendation capture (GAP-17 orchestration layer).
+//
+// Mirrors alerts-capture.ts's shape exactly: adapt each already-live
+// module's real data into optimization.ts's narrow SIGNAL interfaces, run
+// the detectors, reconcile against `costops_recommendations` via
+// reconcileRecommendations(), and persist. NOT done here (seam-owner is
+// Mason, same as alerts-capture.ts): any GET route and the boot-time
+// capture cadence (startCostOpsBackgroundTasks) -- one more line in the
+// daily cycle alongside captureForecastSnapshots/captureAlerts.
+//
+// Signal sources actually available today (verified against the live
+// codebase, 2026-07-15) -- 4 of the 9 recommendation types have a real,
+// non-fabricated signal to wire; the other 5 are HONESTLY LEFT EMPTY, not
+// guessed at, each documented below with what would be needed:
+//
+// - underused_subscription_downgrade: subscriptions.ts + limits.ts's
+//   fromSubscriptions() usage_pct. Only the CANCEL option is ever offered
+//   (never a fabricated "downgrade to a cheaper tier") -- no plan-tier
+//   pricing map exists anywhere in this codebase's data model.
+// - duplicate_subscription: subscriptions.ts, grouped by PROVIDER (the
+//   finest real grouping key that exists -- costops-subscriptions.json has
+//   no product/category field beyond provider).
+// - duplicate_hosting_saas: cost_line_items/cost_sources, grouped by
+//   (provider, source_type) -- an observable fact, not a text-similarity
+//   guess on service names.
+// - automate_long_manual_source: cost_line_items history, the SAME
+//   "N consecutive estimate-tier periods" query alerts-capture.ts's
+//   long_estimate_only_source detector uses (duplicated locally per this
+//   codebase's small-self-contained-query convention, not re-exported).
+//
+// - switch_to_annual_billing: NO live "annual plan monthly-equivalent
+//   price" data exists anywhere (costops-subscriptions.json has no such
+//   field) -- estimating one generically (e.g. "usually ~15% off") would be
+//   exactly the kind of fabrication this codebase's conventions forbid.
+// - unused_domain_or_storage: this dispatch assumed a "source-inventory
+//   confirmed_unused flag" exists -- IT DOES NOT (checked inventory.ts,
+//   expiry-checks.ts, warnings.ts: none track domain/storage USAGE, only
+//   expiry dates). Flagged back to the dispatcher; honestly empty here.
+// - forgotten_service: no "last meaningful activity" signal exists beyond
+//   billing-line freshness, which isn't meaningful for a recurring fixed
+//   subscription (it "shows activity" every month regardless of real use).
+// - oversized_fixed_package: no tier-capacity/pricing map exists anywhere.
+// - provider_credit_or_discount: no live "known available discount" data
+//   source exists (would need a business-knowledge config this codebase
+//   doesn't have, distinct from pricing.ts's per-model rates).
+
+import type Database from 'better-sqlite3'
+import { monthWindow, CONF_PRIORITY } from './ledger.js'
+import { loadSubscriptionsConfig, deriveLifecycle } from './subscriptions.js'
+import { fromSubscriptions } from './limits.js'
+import {
+  detectUnderusedSubscriptionRecommendation,
+  detectDuplicateSubscriptionRecommendations,
+  detectDuplicateHostingSaasRecommendations,
+  detectAutomateLongManualSourceRecommendation,
+  reconcileRecommendations,
+  serializeEvidence,
+  deserializeEvidence,
+  type RecommendationCandidate,
+  type RecommendationRecord,
+  type RecommendationType,
+  type RecommendationRisk,
+  type RecommendationConfidence,
+  type RecommendationStatus,
+} from './optimization.js'
+
+// mirrors alerts-capture.ts's UTILIZATION_UNDER_THRESHOLD
+const UNDERUSED_THRESHOLD_PCT = 0.1
+// mirrors alerts-capture.ts's ESTIMATE_ONLY_LOOKBACK_PERIODS/ESTIMATE_ONLY_CONF
+const AUTOMATION_LOOKBACK_PERIODS = 3
+const AUTOMATION_CONF = new Set(['manual', 'estimate', 'local_usage'])
+
+// ---- signal gathering ------------------------------------------------------------------
+
+function gatherUnderusedSubscriptionCandidates(now: number): RecommendationCandidate[] {
+  const { config } = loadSubscriptionsConfig()
+  const subs = deriveLifecycle(config, now)
+  const limitStatuses = fromSubscriptions(subs)
+  const byId = new Map(subs.map(s => [s.id, s]))
+  const out: RecommendationCandidate[] = []
+  for (const ls of limitStatuses) {
+    if (ls.usage_pct == null || ls.sub_id == null) continue
+    const sub = byId.get(ls.sub_id)
+    if (!sub || sub.amount == null || sub.status !== 'active') continue // no known real cost -- never fabricated
+    const c = detectUnderusedSubscriptionRecommendation({
+      subscription_id: sub.id, provider: sub.provider, monthly_cost: sub.amount,
+      usage_pct: ls.usage_pct, under_threshold_pct: UNDERUSED_THRESHOLD_PCT,
+      cancel_or_downgrade_option: 'cancel', downgrade_monthly_cost: null,
+    })
+    if (c) out.push(c)
+  }
+  return out
+}
+
+function gatherDuplicateSubscriptionCandidates(now: number): RecommendationCandidate[] {
+  const { config } = loadSubscriptionsConfig()
+  const subs = deriveLifecycle(config, now)
+  const signals = subs.filter(s => s.amount != null).map(s => ({
+    subscription_id: s.id, provider: s.provider, product: s.provider,
+    monthly_cost: s.amount as number, status: s.status,
+  }))
+  return detectDuplicateSubscriptionRecommendations(signals)
+}
+
+interface SourceSpendRow { source_id: string; provider: string; source_type: string; billed_cost: number; confidence: string }
+
+function gatherDuplicateHostingSaasCandidates(db: Database.Database, now: number): RecommendationCandidate[] {
+  const win = monthWindow(now)
+  const rows = db.prepare(`
+    SELECT cli.source_id as source_id, cs.provider as provider, cs.source_type as source_type,
+           cli.billed_cost as billed_cost, cli.confidence as confidence
+    FROM cost_line_items cli JOIN cost_sources cs ON cs.id = cli.source_id
+    WHERE cli.charge_period_start < @end AND cli.charge_period_end > @start AND cli.voided_at IS NULL
+      AND cs.source_type IN ('hosting', 'saas', 'domain', 'storage')
+      AND cli.confidence NOT IN ('pending_permission', 'provider_plan_estimate')
+  `).all({ start: win.start, end: win.end }) as SourceSpendRow[]
+  const bySource = new Map<string, SourceSpendRow>()
+  for (const r of rows) {
+    const cur = bySource.get(r.source_id)
+    if (!cur || (CONF_PRIORITY[r.confidence] || 0) > (CONF_PRIORITY[cur.confidence] || 0)) bySource.set(r.source_id, r)
+  }
+  const signals = [...bySource.values()].map(r => ({
+    source_id: r.source_id, provider: r.provider, source_type: r.source_type,
+    service_key: `${r.provider}|${r.source_type}`, monthly_cost: r.billed_cost,
+  }))
+  return detectDuplicateHostingSaasRecommendations(signals)
+}
+
+function gatherAutomateLongManualSourceCandidates(db: Database.Database): RecommendationCandidate[] {
+  const out: RecommendationCandidate[] = []
+  const sources = db.prepare(`SELECT id, provider FROM cost_sources WHERE active = 1`).all() as Array<{ id: string; provider: string }>
+  for (const s of sources) {
+    const periodRows = db.prepare(`
+      SELECT DISTINCT charge_period_start FROM cost_line_items
+      WHERE source_id = ? AND voided_at IS NULL ORDER BY charge_period_start DESC LIMIT ?
+    `).all(s.id, AUTOMATION_LOOKBACK_PERIODS) as Array<{ charge_period_start: number }>
+    if (periodRows.length < AUTOMATION_LOOKBACK_PERIODS) continue
+
+    let allManual = true
+    let latestCost = 0
+    periodRows.forEach((p, i) => {
+      const lines = db.prepare(`SELECT billed_cost, confidence FROM cost_line_items WHERE source_id = ? AND charge_period_start = ? AND voided_at IS NULL`).all(s.id, p.charge_period_start) as Array<{ billed_cost: number; confidence: string }>
+      const resolved = lines.reduce((best, l) => (CONF_PRIORITY[l.confidence] || 0) > (CONF_PRIORITY[best.confidence] || 0) ? l : best, lines[0])
+      if (!resolved || !AUTOMATION_CONF.has(resolved.confidence)) allManual = false
+      if (i === 0 && resolved) latestCost = resolved.billed_cost
+    })
+    if (allManual) {
+      const c = detectAutomateLongManualSourceRecommendation({ source_id: s.id, provider: s.provider, monthly_cost: latestCost, consecutive_manual_only_months: periodRows.length, threshold_months: AUTOMATION_LOOKBACK_PERIODS })
+      if (c) out.push(c)
+    }
+  }
+  return out
+}
+
+// No live data source for these 5 -- honestly empty, see file header.
+function gatherAnnualBillingCandidates(): RecommendationCandidate[] { return [] }
+function gatherUnusedDomainOrStorageCandidates(): RecommendationCandidate[] { return [] }
+function gatherForgottenServiceCandidates(): RecommendationCandidate[] { return [] }
+function gatherOversizedPackageCandidates(): RecommendationCandidate[] { return [] }
+function gatherProviderCreditCandidates(): RecommendationCandidate[] { return [] }
+
+/** Gather every recommendation candidate this round. Pure DB/config READS only -- captureRecommendations below is the only function that persists anything. */
+export function gatherRecommendationCandidates(db: Database.Database, now: number): RecommendationCandidate[] {
+  return [
+    ...gatherUnderusedSubscriptionCandidates(now),
+    ...gatherDuplicateSubscriptionCandidates(now),
+    ...gatherDuplicateHostingSaasCandidates(db, now),
+    ...gatherAnnualBillingCandidates(),
+    ...gatherUnusedDomainOrStorageCandidates(),
+    ...gatherForgottenServiceCandidates(),
+    ...gatherOversizedPackageCandidates(),
+    ...gatherAutomateLongManualSourceCandidates(db),
+    ...gatherProviderCreditCandidates(),
+  ]
+}
+
+// ---- persistence (costops_recommendations) -----------------------------------------------
+
+interface RecommendationRow {
+  dedup_key: string
+  type: string
+  evidence_json: string
+  current_monthly_cost: number
+  estimated_monthly_saving: number
+  estimated_annual_saving: number
+  switching_cost: number
+  risk: string
+  confidence: string
+  human_decision_required: string
+  rollback_note: string
+  status: string
+  status_changed_at: number | null
+  status_changed_by: string | null
+  expires_at: number | null
+  first_seen: number
+  last_seen: number
+}
+
+function rowToRecord(r: RecommendationRow): RecommendationRecord {
+  return {
+    type: r.type as RecommendationType, dedup_key: r.dedup_key, evidence: deserializeEvidence(r.evidence_json),
+    current_monthly_cost: r.current_monthly_cost, estimated_monthly_saving: r.estimated_monthly_saving,
+    estimated_annual_saving: r.estimated_annual_saving, switching_cost: r.switching_cost,
+    risk: r.risk as RecommendationRisk, confidence: r.confidence as RecommendationConfidence,
+    human_decision_required: r.human_decision_required, rollback_note: r.rollback_note,
+    first_seen: r.first_seen, last_seen: r.last_seen, status: r.status as RecommendationStatus,
+    status_changed_at: r.status_changed_at, status_changed_by: r.status_changed_by, expires_at: r.expires_at,
+  }
+}
+
+function loadExistingRecommendations(db: Database.Database): RecommendationRecord[] {
+  const rows = db.prepare(`SELECT * FROM costops_recommendations`).all() as RecommendationRow[]
+  return rows.map(rowToRecord)
+}
+
+export interface RecommendationCaptureSummary {
+  candidates: number
+  inserted: number
+  touched: number
+  resolved: number
+  expired: number
+}
+
+/**
+ * Gather this round's candidates, reconcile against `costops_recommendations`,
+ * and persist: insert new 'open' rows, touch active ones, mark resolved rows
+ * whose condition disappeared, and expire unaddressed ones past their
+ * expires_at. Requires `initOptimizationSchema` to have already run (Mason's
+ * seam call) -- not invoked here.
+ */
+export function captureRecommendations(db: Database.Database, now: number, opts: { expirySeconds?: number } = {}): RecommendationCaptureSummary {
+  const existing = loadExistingRecommendations(db)
+  const candidates = gatherRecommendationCandidates(db, now)
+  const result = reconcileRecommendations(existing, candidates, now, opts.expirySeconds)
+
+  const insertStmt = db.prepare(`
+    INSERT INTO costops_recommendations
+      (type, evidence_json, dedup_key, current_monthly_cost, estimated_monthly_saving, estimated_annual_saving, switching_cost, risk, confidence, human_decision_required, rollback_note, status, status_changed_at, status_changed_by, expires_at, first_seen, last_seen, created_at)
+    VALUES (@type, @evidence_json, @dedup_key, @current_monthly_cost, @estimated_monthly_saving, @estimated_annual_saving, @switching_cost, @risk, @confidence, @human_decision_required, @rollback_note, 'open', NULL, NULL, @expires_at, @first_seen, @last_seen, @now)
+  `)
+  for (const r of result.toInsert) {
+    insertStmt.run({
+      type: r.type, evidence_json: serializeEvidence(r.evidence), dedup_key: r.dedup_key,
+      current_monthly_cost: r.current_monthly_cost, estimated_monthly_saving: r.estimated_monthly_saving,
+      estimated_annual_saving: r.estimated_annual_saving, switching_cost: r.switching_cost,
+      risk: r.risk, confidence: r.confidence, human_decision_required: r.human_decision_required,
+      rollback_note: r.rollback_note, expires_at: r.expires_at, first_seen: r.first_seen, last_seen: r.last_seen, now,
+    })
+  }
+
+  const touchStmt = db.prepare(`
+    UPDATE costops_recommendations SET
+      last_seen=@last_seen, evidence_json=@evidence_json, current_monthly_cost=@current_monthly_cost,
+      estimated_monthly_saving=@estimated_monthly_saving, estimated_annual_saving=@estimated_annual_saving,
+      switching_cost=@switching_cost, risk=@risk, confidence=@confidence
+    WHERE dedup_key=@dedup_key
+  `)
+  for (const t of result.toTouch) {
+    touchStmt.run({
+      dedup_key: t.dedup_key, last_seen: t.patch.last_seen, evidence_json: serializeEvidence(t.patch.evidence),
+      current_monthly_cost: t.patch.current_monthly_cost, estimated_monthly_saving: t.patch.estimated_monthly_saving,
+      estimated_annual_saving: t.patch.estimated_annual_saving, switching_cost: t.patch.switching_cost,
+      risk: t.patch.risk, confidence: t.patch.confidence,
+    })
+  }
+
+  const resolveStmt = db.prepare(`UPDATE costops_recommendations SET status='resolved' WHERE dedup_key=?`)
+  for (const r of result.toResolve) resolveStmt.run(r.dedup_key)
+
+  const expireStmt = db.prepare(`UPDATE costops_recommendations SET status='expired' WHERE dedup_key=?`)
+  for (const e of result.toExpire) expireStmt.run(e.dedup_key)
+
+  return { candidates: candidates.length, inserted: result.toInsert.length, touched: result.toTouch.length, resolved: result.toResolve.length, expired: result.toExpire.length }
+}
+
+export interface RecommendationListRow {
+  dedup_key: string
+  type: string
+  evidence: Record<string, unknown>
+  current_monthly_cost: number
+  estimated_monthly_saving: number
+  estimated_annual_saving: number
+  switching_cost: number
+  risk: string
+  confidence: string
+  human_decision_required: string
+  rollback_note: string
+  status: string
+  first_seen: number
+  last_seen: number
+  expires_at: number | null
+}
+
+/** Read back stored recommendations. 'open' only by default (the likely GET route default view), sorted by estimated saving descending. */
+export function listRecommendations(db: Database.Database, opts: { status?: RecommendationStatus; limit?: number } = {}): RecommendationListRow[] {
+  const limit = opts.limit ?? 200
+  const rows = (
+    opts.status
+      ? db.prepare(`SELECT * FROM costops_recommendations WHERE status = ? ORDER BY estimated_monthly_saving DESC LIMIT ?`).all(opts.status, limit)
+      : db.prepare(`SELECT * FROM costops_recommendations WHERE status = 'open' ORDER BY estimated_monthly_saving DESC LIMIT ?`).all(limit)
+  ) as RecommendationRow[]
+  return rows.map(r => ({
+    dedup_key: r.dedup_key, type: r.type, evidence: deserializeEvidence(r.evidence_json),
+    current_monthly_cost: r.current_monthly_cost, estimated_monthly_saving: r.estimated_monthly_saving,
+    estimated_annual_saving: r.estimated_annual_saving, switching_cost: r.switching_cost, risk: r.risk, confidence: r.confidence,
+    human_decision_required: r.human_decision_required, rollback_note: r.rollback_note, status: r.status,
+    first_seen: r.first_seen, last_seen: r.last_seen, expires_at: r.expires_at,
+  }))
+}

--- a/src/costops/optimization.ts
+++ b/src/costops/optimization.ts
@@ -1,0 +1,498 @@
+// CostOps -- Phase 4 aggregate cost optimization advisor (GAP-17 /
+// core-functional-scope-v1.0.1.md §17).
+//
+// Same two-layer shape as alerts.ts (Anvil, Phase 3):
+// 1. DETECTORS -- one pure function per recommendation type, each over a
+//    narrow SIGNAL interface (never a concrete module type like
+//    SubscriptionLifecycle/LimitStatus), so this file stays independent of
+//    subscriptions.ts/limits.ts/ledger.ts -- a future orchestration layer
+//    (optimization-capture.ts, mirroring alerts-capture.ts) adapts real data
+//    into these signals, the same split alerts.ts/alerts-capture.ts used.
+// 2. LIFECYCLE -- `reconcileRecommendations` turns "candidates detected this
+//    round" + "what's already stored" into insert/touch/resolve/expire
+//    instructions: a human's accepted/dismissed decision is never silently
+//    overwritten by re-detection, an unaddressed recommendation expires
+//    after a while (visibility hygiene, not an automatic action), and a
+//    recommendation whose condition disappears on its own auto-resolves.
+//
+// NO db.ts/web.ts/schema.ts edits: `initOptimizationSchema` is a schema
+// DEFINER only, not mounted anywhere -- the seam-refactor's
+// `initCostOpsSchema(db)` aggregator calls it, per
+// docs/fork-upstream-policy.md §2a.
+//
+// AGGREGATE COST SCOPE ONLY (GAP-17's explicit "Tilos" list): every
+// recommendation here is subscription/provider/hosting/SaaS/domain-level.
+// There is no agent-level, task-level, product-level, or model-routing
+// recommendation type in this file, and none will ever be added to it --
+// that is a different, explicitly out-of-scope project per both spec docs.
+// Nothing here EXECUTES anything: every detector only produces a
+// recommendation record; cancelling/downgrading/switching a real
+// subscription or service is always a human action taken outside this
+// codebase. No LLM anywhere -- every number is traceable to the ledger/
+// subscription/utilisation data the caller supplies.
+
+import type Database from 'better-sqlite3'
+import { serializeEvidence, deserializeEvidence } from './alerts.js'
+
+// ---- recommendation types (the §17 list, 9 types) ------------------------------------
+
+export type RecommendationType =
+  | 'underused_subscription_downgrade'
+  | 'duplicate_subscription'
+  | 'duplicate_hosting_saas'
+  | 'switch_to_annual_billing'
+  | 'unused_domain_or_storage'
+  | 'forgotten_service'
+  | 'oversized_fixed_package'
+  | 'automate_long_manual_source'
+  | 'provider_credit_or_discount'
+
+export type RecommendationRisk = 'low' | 'medium' | 'high'
+export type RecommendationConfidence = 'low' | 'medium' | 'high'
+export type RecommendationStatus = 'open' | 'accepted' | 'dismissed' | 'resolved' | 'expired'
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }
+
+// ---- lifecycle record shapes ----------------------------------------------------------
+
+export interface RecommendationCandidate {
+  type: RecommendationType
+  dedup_key: string
+  evidence: Record<string, unknown>
+  current_monthly_cost: number
+  estimated_monthly_saving: number
+  estimated_annual_saving: number
+  switching_cost: number
+  risk: RecommendationRisk
+  confidence: RecommendationConfidence
+  human_decision_required: string
+  rollback_note: string
+}
+
+export interface RecommendationRecord extends RecommendationCandidate {
+  first_seen: number
+  last_seen: number
+  status: RecommendationStatus
+  status_changed_at: number | null
+  status_changed_by: string | null
+  expires_at: number | null
+}
+
+// ---- detectors ---------------------------------------------------------------------------
+// Each returns null (or [] for the multi-output ones) when the signal does not
+// warrant a recommendation -- never a fabricated saving/risk/confidence.
+
+export interface SubscriptionUtilizationSignal {
+  subscription_id: string
+  provider: string
+  monthly_cost: number
+  usage_pct: number
+  under_threshold_pct: number
+  // What's actually available, if known -- never guessed. null means "no known
+  // downgrade path", in which case this only recommends cancellation-consideration,
+  // not a specific cheaper tier.
+  cancel_or_downgrade_option: 'cancel' | 'downgrade' | null
+  downgrade_monthly_cost: number | null
+}
+
+export function detectUnderusedSubscriptionRecommendation(s: SubscriptionUtilizationSignal): RecommendationCandidate | null {
+  if (s.usage_pct > s.under_threshold_pct) return null
+  if (s.cancel_or_downgrade_option == null) return null // no known real option -- never fabricate a recommendation
+  const target = s.cancel_or_downgrade_option === 'downgrade' && s.downgrade_monthly_cost != null ? s.downgrade_monthly_cost : 0
+  const monthlySaving = round2(s.monthly_cost - target)
+  if (monthlySaving <= 0) return null
+  return {
+    type: 'underused_subscription_downgrade',
+    dedup_key: `underused_subscription_downgrade|${s.subscription_id}`,
+    evidence: { subscription_id: s.subscription_id, provider: s.provider, usage_pct: s.usage_pct, under_threshold_pct: s.under_threshold_pct },
+    current_monthly_cost: s.monthly_cost,
+    estimated_monthly_saving: monthlySaving,
+    estimated_annual_saving: round2(monthlySaving * 12),
+    switching_cost: 0,
+    risk: s.cancel_or_downgrade_option === 'cancel' ? 'medium' : 'low',
+    confidence: s.downgrade_monthly_cost != null || s.cancel_or_downgrade_option === 'cancel' ? 'high' : 'medium',
+    human_decision_required: s.cancel_or_downgrade_option === 'cancel'
+      ? `Confirm cancelling ${s.subscription_id} (usage ${Math.round(s.usage_pct * 100)}%)`
+      : `Confirm downgrading ${s.subscription_id} to a cheaper tier`,
+    rollback_note: 'Re-subscribing/upgrading later reverses this -- no data loss, but re-onboarding or promotional pricing may not carry over.',
+  }
+}
+
+export interface SubscriptionEntrySignal {
+  subscription_id: string
+  provider: string
+  // Caller-normalized key for "provides the same capability" grouping (e.g.
+  // 'claude-plan', 'llm-subscription') -- this file never guesses overlap
+  // itself, the caller must supply a real grouping key.
+  product: string
+  monthly_cost: number
+  status: 'active' | 'canceled' | 'expired' | 'unknown'
+}
+
+/** Multi-output: one recommendation per product-group with 2+ ACTIVE subscriptions. */
+export function detectDuplicateSubscriptionRecommendations(subs: SubscriptionEntrySignal[]): RecommendationCandidate[] {
+  const active = subs.filter(s => s.status === 'active')
+  const byProduct = new Map<string, SubscriptionEntrySignal[]>()
+  for (const s of active) { const a = byProduct.get(s.product); if (a) a.push(s); else byProduct.set(s.product, [s]) }
+  const out: RecommendationCandidate[] = []
+  for (const [product, group] of byProduct) {
+    if (group.length < 2) continue
+    const sorted = [...group].sort((a, b) => b.monthly_cost - a.monthly_cost)
+    const [keep, ...redundant] = sorted
+    const monthlySaving = round2(redundant.reduce((s, r) => s + r.monthly_cost, 0))
+    if (monthlySaving <= 0) continue
+    out.push({
+      type: 'duplicate_subscription',
+      dedup_key: `duplicate_subscription|${product}`,
+      evidence: { product, subscription_ids: group.map(g => g.subscription_id), suggested_keep: keep.subscription_id, suggested_cancel: redundant.map(r => r.subscription_id) },
+      current_monthly_cost: round2(group.reduce((s, g) => s + g.monthly_cost, 0)),
+      estimated_monthly_saving: monthlySaving,
+      estimated_annual_saving: round2(monthlySaving * 12),
+      switching_cost: 0,
+      risk: 'medium',
+      confidence: 'medium',
+      human_decision_required: `Confirm which of [${group.map(g => g.subscription_id).join(', ')}] to keep and cancel the rest`,
+      rollback_note: 'Cancelled subscriptions can typically be re-activated, but may lose promotional pricing or onboarding state.',
+    })
+  }
+  return out
+}
+
+export interface HostingOrSaasSourceSignal {
+  source_id: string
+  provider: string
+  source_type: string
+  // Caller-normalized "same capability" key -- never inferred from a raw
+  // service name string by this file (too error-prone to guess reliably).
+  service_key: string
+  monthly_cost: number
+}
+
+/** Multi-output: one recommendation per service_key-group with 2+ sources -- deliberately LOW confidence, since grouping is a caller-supplied heuristic, not a verified duplicate. */
+export function detectDuplicateHostingSaasRecommendations(sources: HostingOrSaasSourceSignal[]): RecommendationCandidate[] {
+  const byKey = new Map<string, HostingOrSaasSourceSignal[]>()
+  for (const s of sources) { const a = byKey.get(s.service_key); if (a) a.push(s); else byKey.set(s.service_key, [s]) }
+  const out: RecommendationCandidate[] = []
+  for (const [key, group] of byKey) {
+    if (group.length < 2) continue
+    const total = round2(group.reduce((s, g) => s + g.monthly_cost, 0))
+    const max = Math.max(...group.map(g => g.monthly_cost))
+    const monthlySaving = round2(total - max) // assumes at least one must be kept -- a lower bound, not "cancel everything"
+    if (monthlySaving <= 0) continue
+    out.push({
+      type: 'duplicate_hosting_saas',
+      dedup_key: `duplicate_hosting_saas|${key}`,
+      evidence: { service_key: key, source_ids: group.map(g => g.source_id), providers: group.map(g => g.provider) },
+      current_monthly_cost: total,
+      estimated_monthly_saving: monthlySaving,
+      estimated_annual_saving: round2(monthlySaving * 12),
+      switching_cost: 0,
+      risk: 'medium',
+      confidence: 'low',
+      human_decision_required: `Confirm whether [${group.map(g => g.source_id).join(', ')}] are genuinely redundant hosting/SaaS`,
+      rollback_note: 'Cancelling a redundant hosting/SaaS account can usually be re-provisioned, but may lose data/config unless backed up first.',
+    })
+  }
+  return out
+}
+
+export interface AnnualBillingOptionSignal {
+  subscription_id: string
+  provider: string
+  monthly_cost: number
+  // What the SAME plan would cost per month if paid annually, if known --
+  // never estimated from a generic "annual is usually ~15% off" assumption.
+  annual_plan_monthly_equivalent: number | null
+}
+
+export function detectAnnualBillingRecommendation(s: AnnualBillingOptionSignal): RecommendationCandidate | null {
+  if (s.annual_plan_monthly_equivalent == null) return null
+  const monthlySaving = round2(s.monthly_cost - s.annual_plan_monthly_equivalent)
+  if (monthlySaving <= 0) return null
+  return {
+    type: 'switch_to_annual_billing',
+    dedup_key: `switch_to_annual_billing|${s.subscription_id}`,
+    evidence: { subscription_id: s.subscription_id, provider: s.provider, monthly_billing_cost: s.monthly_cost, annual_equivalent_monthly_cost: s.annual_plan_monthly_equivalent },
+    current_monthly_cost: s.monthly_cost,
+    estimated_monthly_saving: monthlySaving,
+    estimated_annual_saving: round2(monthlySaving * 12),
+    // The annual up-front commitment IS a real cash outlay, not a free switch -- surfaced as
+    // switching_cost so a human sees the liquidity impact, not just the eventual saving.
+    switching_cost: round2(s.annual_plan_monthly_equivalent * 12),
+    risk: 'low',
+    confidence: 'high',
+    human_decision_required: `Confirm committing to annual billing for ${s.subscription_id} (locks in for 12 months)`,
+    rollback_note: 'Annual commitments are typically NOT refundable mid-term -- switching back to monthly means waiting out the paid year.',
+  }
+}
+
+export interface UnusedResourceSignal {
+  source_id: string
+  provider: string
+  source_type: 'domain' | 'storage'
+  monthly_cost: number
+  // Must come from a REAL signal the caller has (e.g. no DNS traffic, no bucket
+  // access log) -- this file never infers "unused" from mere absence of data.
+  confirmed_unused: boolean
+}
+
+export function detectUnusedDomainOrStorageRecommendation(s: UnusedResourceSignal): RecommendationCandidate | null {
+  if (!s.confirmed_unused) return null
+  return {
+    type: 'unused_domain_or_storage',
+    dedup_key: `unused_domain_or_storage|${s.source_id}`,
+    evidence: { source_id: s.source_id, provider: s.provider, source_type: s.source_type },
+    current_monthly_cost: s.monthly_cost,
+    estimated_monthly_saving: s.monthly_cost,
+    estimated_annual_saving: round2(s.monthly_cost * 12),
+    switching_cost: 0,
+    risk: 'low',
+    confidence: 'medium',
+    human_decision_required: `Confirm ${s.source_id} (${s.source_type}) is safe to release/cancel`,
+    rollback_note: s.source_type === 'domain'
+      ? 'A released domain can be re-registered later, but may be claimed by someone else first.'
+      : 'Deleted storage cannot be recovered unless backed up first.',
+  }
+}
+
+export interface ForgottenServiceSignal {
+  source_id: string
+  provider: string
+  monthly_cost: number
+  // null = unknown -- never fabricated as "0 months" (which would falsely imply recent activity).
+  months_since_last_meaningful_activity: number | null
+  threshold_months: number
+}
+
+export function detectForgottenServiceRecommendation(s: ForgottenServiceSignal): RecommendationCandidate | null {
+  if (s.months_since_last_meaningful_activity == null) return null
+  if (s.months_since_last_meaningful_activity < s.threshold_months) return null
+  return {
+    type: 'forgotten_service',
+    dedup_key: `forgotten_service|${s.source_id}`,
+    evidence: { source_id: s.source_id, provider: s.provider, months_inactive: s.months_since_last_meaningful_activity },
+    current_monthly_cost: s.monthly_cost,
+    estimated_monthly_saving: s.monthly_cost,
+    estimated_annual_saving: round2(s.monthly_cost * 12),
+    switching_cost: 0,
+    risk: 'medium',
+    confidence: 'medium',
+    human_decision_required: `Confirm ${s.source_id} is genuinely forgotten/unneeded before cancelling (${s.months_since_last_meaningful_activity} months inactive)`,
+    rollback_note: 'Re-subscribing later is usually possible but may lose historical account state or pricing.',
+  }
+}
+
+export interface OversizedPackageSignal {
+  subscription_id: string
+  provider: string
+  current_tier_monthly_cost: number
+  actual_usage_pct_of_current_tier: number
+  smaller_tier_monthly_cost: number | null
+  // The smaller tier's capacity as a fraction of the CURRENT tier's capacity --
+  // used to check actual usage would still fit, never assumed to fit.
+  smaller_tier_capacity_pct_of_current: number | null
+}
+
+export function detectOversizedFixedPackageRecommendation(s: OversizedPackageSignal): RecommendationCandidate | null {
+  if (s.smaller_tier_monthly_cost == null || s.smaller_tier_capacity_pct_of_current == null) return null
+  if (s.actual_usage_pct_of_current_tier > s.smaller_tier_capacity_pct_of_current) return null // wouldn't actually fit
+  const monthlySaving = round2(s.current_tier_monthly_cost - s.smaller_tier_monthly_cost)
+  if (monthlySaving <= 0) return null
+  return {
+    type: 'oversized_fixed_package',
+    dedup_key: `oversized_fixed_package|${s.subscription_id}`,
+    evidence: { subscription_id: s.subscription_id, provider: s.provider, usage_pct: s.actual_usage_pct_of_current_tier, smaller_tier_capacity_pct: s.smaller_tier_capacity_pct_of_current },
+    current_monthly_cost: s.current_tier_monthly_cost,
+    estimated_monthly_saving: monthlySaving,
+    estimated_annual_saving: round2(monthlySaving * 12),
+    switching_cost: 0,
+    risk: 'medium',
+    confidence: 'medium',
+    human_decision_required: `Confirm downgrading ${s.subscription_id} to the smaller tier still covers real usage`,
+    rollback_note: 'Upgrading back later is usually available on-demand, often for a prorated fee.',
+  }
+}
+
+export interface LongManualSourceSignal {
+  source_id: string
+  provider: string
+  monthly_cost: number
+  consecutive_manual_only_months: number
+  threshold_months: number
+}
+
+/**
+ * This recommendation's value is DATA QUALITY (less error-prone manual entry,
+ * less operator labor), not a direct cost reduction -- estimated_monthly_saving
+ * is honestly 0 rather than fabricating a dollar figure nothing backs.
+ * switching_cost is also 0: building/enabling a collector is engineering time,
+ * which this ledger has no unit to price.
+ */
+export function detectAutomateLongManualSourceRecommendation(s: LongManualSourceSignal): RecommendationCandidate | null {
+  if (s.consecutive_manual_only_months < s.threshold_months) return null
+  return {
+    type: 'automate_long_manual_source',
+    dedup_key: `automate_long_manual_source|${s.source_id}`,
+    evidence: { source_id: s.source_id, provider: s.provider, consecutive_manual_only_months: s.consecutive_manual_only_months },
+    current_monthly_cost: s.monthly_cost,
+    estimated_monthly_saving: 0,
+    estimated_annual_saving: 0,
+    switching_cost: 0,
+    risk: 'low',
+    confidence: 'medium',
+    human_decision_required: `Consider building/enabling a provider collector for ${s.source_id} (${s.consecutive_manual_only_months} consecutive manual-only months)`,
+    rollback_note: 'A new automated collector can always be disabled, reverting to manual entry.',
+  }
+}
+
+export interface ProviderCreditSignal {
+  provider: string
+  monthly_cost: number
+  // Must be a REAL, known offer the caller has confirmed -- never inferred or guessed.
+  known_available_credit_or_discount_monthly: number | null
+  discount_description: string | null
+}
+
+export function detectProviderCreditOrDiscountRecommendation(s: ProviderCreditSignal): RecommendationCandidate | null {
+  if (s.known_available_credit_or_discount_monthly == null || s.known_available_credit_or_discount_monthly <= 0) return null
+  return {
+    type: 'provider_credit_or_discount',
+    dedup_key: `provider_credit_or_discount|${s.provider}`,
+    evidence: { provider: s.provider, discount_description: s.discount_description },
+    current_monthly_cost: s.monthly_cost,
+    estimated_monthly_saving: s.known_available_credit_or_discount_monthly,
+    estimated_annual_saving: round2(s.known_available_credit_or_discount_monthly * 12),
+    switching_cost: 0,
+    risk: 'low',
+    confidence: 'high',
+    human_decision_required: `Apply the known ${s.provider} discount/credit${s.discount_description ? ` (${s.discount_description})` : ''}`,
+    rollback_note: 'Applying a discount/credit is not typically reversible-needed -- no rollback risk.',
+  }
+}
+
+// ---- lifecycle engine -----------------------------------------------------------------------
+
+// Flagged placeholder (same convention as inventory.ts's freshness thresholds / alerts.ts's
+// cooldown) -- an unaddressed recommendation stops nagging after ~90 days if no human ever
+// accepted/dismissed it. This is visibility hygiene only, never an automatic action.
+const DEFAULT_EXPIRY_SECONDS = 90 * 24 * 3600
+
+export interface RecommendationReconcileResult {
+  toInsert: RecommendationRecord[]
+  toTouch: Array<{ dedup_key: string; patch: Pick<RecommendationRecord, 'last_seen' | 'evidence' | 'current_monthly_cost' | 'estimated_monthly_saving' | 'estimated_annual_saving' | 'switching_cost' | 'risk' | 'confidence'> }>
+  toResolve: Array<{ dedup_key: string }>
+  toExpire: Array<{ dedup_key: string }>
+}
+
+/**
+ * The lifecycle core, mirroring alerts.ts's reconcileAlerts shape:
+ *
+ * - Candidate with no existing row, OR matching a row that's already
+ *   'expired' -> brand new recommendation, status 'open' (an expired one
+ *   resurfacing gets a fresh record, not a silent un-expire).
+ * - Candidate matching an 'open' existing row -> touch: refresh cost/saving/
+ *   risk/confidence/evidence numbers (the underlying data may have moved)
+ *   without touching status.
+ * - Candidate matching an 'accepted'/'dismissed'/'resolved' existing row ->
+ *   FROZEN. A human's decision (or a prior auto-resolve) is never silently
+ *   overwritten by re-detection; see acceptRecommendation/
+ *   dismissRecommendation for the only way status changes on those.
+ * - Existing 'open' row with NO matching candidate this round -> the
+ *   underlying condition is gone -> `toResolve` (takes priority over expiry
+ *   -- "resolved on its own" is more informative than "timed out").
+ * - Existing 'open' row that DOES still have a matching candidate but is
+ *   past `expires_at` -> `toExpire` (a human never acted on it in time).
+ */
+export function reconcileRecommendations(
+  existing: RecommendationRecord[],
+  candidates: RecommendationCandidate[],
+  now: number,
+  expirySeconds = DEFAULT_EXPIRY_SECONDS,
+): RecommendationReconcileResult {
+  const existingByKey = new Map(existing.map(e => [e.dedup_key, e]))
+  const candidateKeys = new Set(candidates.map(c => c.dedup_key))
+  const toInsert: RecommendationRecord[] = []
+  const toTouch: RecommendationReconcileResult['toTouch'] = []
+
+  for (const c of candidates) {
+    const ex = existingByKey.get(c.dedup_key)
+    if (!ex || ex.status === 'expired') {
+      toInsert.push({
+        ...c, first_seen: now, last_seen: now, status: 'open',
+        status_changed_at: null, status_changed_by: null, expires_at: now + expirySeconds,
+      })
+      continue
+    }
+    if (ex.status === 'open') {
+      toTouch.push({
+        dedup_key: c.dedup_key,
+        patch: {
+          last_seen: now, evidence: c.evidence, current_monthly_cost: c.current_monthly_cost,
+          estimated_monthly_saving: c.estimated_monthly_saving, estimated_annual_saving: c.estimated_annual_saving,
+          switching_cost: c.switching_cost, risk: c.risk, confidence: c.confidence,
+        },
+      })
+      continue
+    }
+    // accepted / dismissed / resolved -> frozen, intentionally no-op here.
+  }
+
+  const toResolve: RecommendationReconcileResult['toResolve'] = existing
+    .filter(e => e.status === 'open' && !candidateKeys.has(e.dedup_key))
+    .map(e => ({ dedup_key: e.dedup_key }))
+  const resolvedKeys = new Set(toResolve.map(r => r.dedup_key))
+
+  const toExpire: RecommendationReconcileResult['toExpire'] = existing
+    .filter(e => e.status === 'open' && !resolvedKeys.has(e.dedup_key) && e.expires_at != null && now > e.expires_at)
+    .map(e => ({ dedup_key: e.dedup_key }))
+
+  return { toInsert, toTouch, toResolve, toExpire }
+}
+
+/** Manual human decision: accept a recommendation (the human intends to act on it, outside this codebase -- this function never executes anything itself). */
+export function acceptRecommendation(r: RecommendationRecord, actor: string, now: number): RecommendationRecord {
+  return { ...r, status: 'accepted', status_changed_at: now, status_changed_by: actor }
+}
+
+/** Manual human decision: dismiss a recommendation (the human decided against it). */
+export function dismissRecommendation(r: RecommendationRecord, actor: string, now: number): RecommendationRecord {
+  return { ...r, status: 'dismissed', status_changed_at: now, status_changed_by: actor }
+}
+
+export { serializeEvidence, deserializeEvidence }
+
+// ---- schema (DEFINER ONLY -- not mounted; see file header) ------------------------------------
+
+/**
+ * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts -- per
+ * fork-upstream-policy.md §2a, the seam mount (`initCostOpsSchema(db)`
+ * calling this among the module's other schema definers) is the
+ * seam-refactor's job. Safe to call more than once (`IF NOT EXISTS`).
+ */
+export function initOptimizationSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS costops_recommendations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      type TEXT NOT NULL,
+      evidence_json TEXT NOT NULL,
+      dedup_key TEXT NOT NULL UNIQUE,
+      current_monthly_cost REAL NOT NULL,
+      estimated_monthly_saving REAL NOT NULL,
+      estimated_annual_saving REAL NOT NULL,
+      switching_cost REAL NOT NULL,
+      risk TEXT NOT NULL,
+      confidence TEXT NOT NULL,
+      human_decision_required TEXT NOT NULL,
+      rollback_note TEXT NOT NULL,
+      status TEXT NOT NULL,
+      status_changed_at INTEGER,
+      status_changed_by TEXT,
+      expires_at INTEGER,
+      first_seen INTEGER NOT NULL,
+      last_seen INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_costops_recommendations_type ON costops_recommendations(type)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_costops_recommendations_status ON costops_recommendations(status)`)
+}

--- a/src/costops/optimization.ts
+++ b/src/costops/optimization.ts
@@ -17,8 +17,8 @@
 //
 // NO db.ts/web.ts/schema.ts edits: `initOptimizationSchema` is a schema
 // DEFINER only, not mounted anywhere -- the seam-refactor's
-// `initCostOpsSchema(db)` aggregator calls it, per
-// docs/fork-upstream-policy.md §2a.
+// `initCostOpsSchema(db)` aggregator calls it, keeping every CostOps table
+// behind that single mount point.
 //
 // AGGREGATE COST SCOPE ONLY (GAP-17's explicit "Tilos" list): every
 // recommendation here is subscription/provider/hosting/SaaS/domain-level.
@@ -464,10 +464,10 @@ export { serializeEvidence, deserializeEvidence }
 // ---- schema (DEFINER ONLY -- not mounted; see file header) ------------------------------------
 
 /**
- * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts -- per
- * fork-upstream-policy.md §2a, the seam mount (`initCostOpsSchema(db)`
- * calling this among the module's other schema definers) is the
- * seam-refactor's job. Safe to call more than once (`IF NOT EXISTS`).
+ * Schema DEFINER only. NOT called from db.ts or src/costops/schema.ts: the
+ * seam mount (`initCostOpsSchema(db)` calling this among the module's other
+ * schema definers) is the seam-refactor's job. Safe to call more than once
+ * (`IF NOT EXISTS`).
  */
 export function initOptimizationSchema(db: Database.Database): void {
   db.exec(`

--- a/src/costops/period-close.ts
+++ b/src/costops/period-close.ts
@@ -1,0 +1,241 @@
+// CostOps Phase 2 (GAP-13) -- monthly period close/reopen workflow.
+//
+// A month's accounting state is one of: open (current/default), provisional
+// (an operator-chosen "getting ready to close" marker -- same write rules as
+// open, purely informational), closed (immutable snapshot taken, new writes
+// blocked except via correction.ts), reopened (explicitly reopened from
+// closed, audited, write rules revert to open until closed again).
+//
+// Every close/reopen is an audited event (actor + reason + timestamp) in
+// period_close_events, never a silent status flip. A close event also
+// carries an IMMUTABLE snapshot (the full month's CostSummary at close time)
+// so "what did we believe the numbers were when we closed this month" stays
+// reproducible even if later corrections change the live numbers.
+
+import type Database from 'better-sqlite3'
+import { getCostSummary, monthWindow, type CostSummary } from './ledger.js'
+import type { CostOpsConfig } from './config.js'
+import { loadSubscriptionsConfig, deriveLifecycle } from './subscriptions.js'
+import { buildReconciliation } from './reconciliation.js'
+import { getAllBudgetStatuses, type BudgetStatus } from './budgets.js'
+
+export type PeriodCloseStatus = 'open' | 'provisional' | 'closed' | 'reopened'
+
+export function initPeriodCloseSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS period_status (
+      month TEXT PRIMARY KEY,
+      status TEXT NOT NULL DEFAULT 'open',
+      updated_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS period_close_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      month TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      actor TEXT NOT NULL,
+      reason TEXT,
+      snapshot_json TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_period_close_events_month ON period_close_events(month, created_at)`)
+}
+
+/** Current status for a month, defaulting to 'open' when no row exists yet -- every historical month is open until explicitly touched. */
+export function getPeriodStatus(db: Database.Database, month: string): PeriodCloseStatus {
+  const row = db.prepare(`SELECT status FROM period_status WHERE month = ?`).get(month) as { status: PeriodCloseStatus } | undefined
+  return row?.status ?? 'open'
+}
+
+/** True only for 'closed' -- 'reopened' and 'provisional' both accept normal writes, matching 'open' rules. */
+export function isPeriodClosed(db: Database.Database, month: string): boolean {
+  return getPeriodStatus(db, month) === 'closed'
+}
+
+export interface WritableCheckResult {
+  writable: boolean
+  reason?: string
+}
+
+/**
+ * Guard for any direct-write path (manual entry, email ingest, collector
+ * upsert) that might target a closed month. Returns {writable:false} instead
+ * of throwing -- callers decide their own error-response shape, same
+ * convention as manual-entry.ts's {ok,error,status} results.
+ */
+export function checkPeriodWritable(db: Database.Database, month: string): WritableCheckResult {
+  if (isPeriodClosed(db, month)) {
+    return { writable: false, reason: `month ${month} is closed -- use a correction (createCorrection) instead of a direct write` }
+  }
+  return { writable: true }
+}
+
+export interface CloseReadinessResult {
+  month: string
+  ready: boolean
+  checks: {
+    expected_invoices_received: { ok: boolean; missing: string[] }
+    collectors_fresh: { ok: boolean; failed_providers: string[]; stale_providers: string[] }
+    reconciliation_clean: { ok: boolean; issues: Array<{ source_id: string; status: string }> }
+    estimates_present: { ok: boolean; estimate_only_sources: string[] }
+    unresolved_alerts: { ok: boolean; count: number; critical_count: number }
+    fx_provenance_complete: { ok: boolean; missing_count: number }
+  }
+}
+
+/**
+ * The close-readiness checklist (functional-scope §13). `ready` is the
+ * BLOCKING subset only (missing past-due invoices, a genuinely failed
+ * collector sync, or an unresolved CRITICAL alert) -- estimates-present and
+ * stale-but-not-failed collectors are surfaced as visibility, never block a
+ * deliberate close (an operator may legitimately close a month knowing a
+ * source is estimate-only forever).
+ */
+export function checkCloseReadiness(db: Database.Database, config: CostOpsConfig, now: number, month: string): CloseReadinessResult {
+  const win = monthWindow(now, month)
+  const summary = getCostSummary(db, config, now, { monthKey: month })
+
+  const { config: subsConfig } = loadSubscriptionsConfig()
+  const subscriptions = deriveLifecycle(subsConfig, now)
+  const missing = subscriptions.filter(s => s.past_due).map(s => s.id)
+
+  const failed_providers = summary.provider_sync.filter(p => p.status === 'failed').map(p => p.provider)
+  const stale_providers = summary.provider_sync.filter(p => p.status === 'stale').map(p => p.provider)
+
+  const reconciliation = buildReconciliation(db, now, month)
+  const issues = reconciliation.filter(r => r.status === 'variance').map(r => ({ source_id: r.source_id, status: r.status }))
+
+  const estimate_only_sources = reconciliation.filter(r => r.status === 'estimate_only').map(r => r.source_id)
+
+  const alertRows = db.prepare(`SELECT severity FROM costops_alerts WHERE resolved_at IS NULL`).all() as Array<{ severity: string }>
+  const critical_count = alertRows.filter(a => a.severity === 'critical').length
+
+  const fxMissingRow = db.prepare(`
+    SELECT COUNT(*) as c FROM cost_line_items
+    WHERE charge_period_start < @end AND charge_period_end > @start AND voided_at IS NULL
+      AND original_currency IS NOT NULL AND fx_source IS NULL
+  `).get({ start: win.start, end: win.end }) as { c: number }
+
+  const checks: CloseReadinessResult['checks'] = {
+    expected_invoices_received: { ok: missing.length === 0, missing },
+    collectors_fresh: { ok: failed_providers.length === 0, failed_providers, stale_providers },
+    reconciliation_clean: { ok: issues.length === 0, issues },
+    estimates_present: { ok: estimate_only_sources.length === 0, estimate_only_sources },
+    unresolved_alerts: { ok: critical_count === 0, count: alertRows.length, critical_count },
+    fx_provenance_complete: { ok: fxMissingRow.c === 0, missing_count: fxMissingRow.c },
+  }
+
+  const ready = checks.expected_invoices_received.ok && checks.collectors_fresh.ok
+    && checks.reconciliation_clean.ok && checks.unresolved_alerts.ok
+
+  return { month: win.key, ready, checks }
+}
+
+/** The full immutable record taken at close time -- the CostSummary plus every configured budget's status, so a closed month's budget picture is frozen too (GAP-11: "budget-snapshot legyen resze a period-close-nak"). */
+export interface ImmutableCloseSnapshot {
+  summary: CostSummary
+  budgets: BudgetStatus[]
+}
+
+export interface CloseResult {
+  ok: boolean
+  error?: string
+  status?: number
+  readiness?: CloseReadinessResult
+  snapshot?: ImmutableCloseSnapshot
+}
+
+/**
+ * Close a month: takes an immutable snapshot (the full CostSummary + every
+ * budget's status at close time) and records the close event. Blocked by
+ * default if the readiness checklist has a blocking issue -- `force: true`
+ * lets an operator deliberately override (still fully audited: the reason
+ * is recorded either way). Already-closed months 409 (must reopen first,
+ * never a silent re-close that would overwrite the earlier immutable
+ * snapshot).
+ */
+export function closePeriod(
+  db: Database.Database,
+  config: CostOpsConfig,
+  month: string,
+  actor: string,
+  reason: string | null,
+  now: number,
+  opts: { force?: boolean } = {},
+): CloseResult {
+  if (!actor || !actor.trim()) return { ok: false, error: 'actor is required for a close event', status: 400 }
+  const current = getPeriodStatus(db, month)
+  if (current === 'closed') return { ok: false, error: `month ${month} is already closed -- reopen it first`, status: 409 }
+
+  const readiness = checkCloseReadiness(db, config, now, month)
+  if (!readiness.ready && !opts.force) {
+    return { ok: false, error: 'close-readiness checklist has blocking issues -- pass force:true to override', status: 409, readiness }
+  }
+
+  const summary = getCostSummary(db, config, now, { monthKey: month })
+  const budgets = getAllBudgetStatuses(db, config, now, month)
+  const snapshot: ImmutableCloseSnapshot = { summary, budgets }
+  const tx = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO period_close_events (month, event_type, actor, reason, snapshot_json, created_at)
+      VALUES (?, 'closed', ?, ?, ?, ?)
+    `).run(month, actor, reason, JSON.stringify(snapshot), now)
+    db.prepare(`
+      INSERT INTO period_status (month, status, updated_at) VALUES (?, 'closed', ?)
+      ON CONFLICT(month) DO UPDATE SET status = 'closed', updated_at = excluded.updated_at
+    `).run(month, now)
+  })
+  tx()
+  return { ok: true, readiness, snapshot }
+}
+
+export interface ReopenResult {
+  ok: boolean
+  error?: string
+  status?: number
+}
+
+/** Reopen a closed month. Requires a reason (audit trail) -- write rules revert to 'open' until closed again. */
+export function reopenPeriod(db: Database.Database, month: string, actor: string, reason: string, now: number): ReopenResult {
+  if (!actor || !actor.trim()) return { ok: false, error: 'actor is required for a reopen event', status: 400 }
+  if (!reason || !reason.trim()) return { ok: false, error: 'reason is required to reopen a closed period', status: 400 }
+  const current = getPeriodStatus(db, month)
+  if (current !== 'closed') return { ok: false, error: `month ${month} is not closed (status='${current}')`, status: 409 }
+
+  const tx = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO period_close_events (month, event_type, actor, reason, snapshot_json, created_at)
+      VALUES (?, 'reopened', ?, ?, NULL, ?)
+    `).run(month, actor, reason, now)
+    db.prepare(`UPDATE period_status SET status = 'reopened', updated_at = ? WHERE month = ?`).run(now, month)
+  })
+  tx()
+  return { ok: true }
+}
+
+export interface PeriodCloseEvent {
+  event_type: 'closed' | 'reopened'
+  actor: string
+  reason: string | null
+  created_at: number
+}
+
+/** Full close/reopen audit history for a month, oldest first. */
+export function getPeriodCloseHistory(db: Database.Database, month: string): PeriodCloseEvent[] {
+  return db.prepare(`
+    SELECT event_type, actor, reason, created_at FROM period_close_events
+    WHERE month = ? ORDER BY created_at ASC
+  `).all(month) as PeriodCloseEvent[]
+}
+
+/** The immutable snapshot from the LATEST close event for a month, or null if it was never closed. */
+export function getCloseSnapshot(db: Database.Database, month: string): ImmutableCloseSnapshot | null {
+  const row = db.prepare(`
+    SELECT snapshot_json FROM period_close_events
+    WHERE month = ? AND event_type = 'closed' ORDER BY created_at DESC LIMIT 1
+  `).get(month) as { snapshot_json: string } | undefined
+  if (!row) return null
+  return JSON.parse(row.snapshot_json) as ImmutableCloseSnapshot
+}

--- a/src/costops/period.ts
+++ b/src/costops/period.ts
@@ -1,0 +1,92 @@
+// CostOps v0.7 -- period view / monthly close.
+//
+// Current + previous + last-N-months operational-spend trend, per provider.
+// READ-ONLY: unlike getCostSummary (which syncs the CURRENT month's fixed
+// costs into the ledger before reading), this module never writes. A past
+// month with zero cost_line_items rows is reported as no_data:true, NEVER a
+// fabricated 0 -- e.g. a subscription that started in June 2026 legitimately
+// has no_data for every month before June, even though it recurs today.
+
+import type Database from 'better-sqlite3'
+import type { CostOpsConfig } from './config.js'
+import { monthWindow, resolveOperational, PENDING_CONF, type MonthWindow, type OperationalResult } from './ledger.js'
+
+export interface MonthlyPeriod {
+  month: string
+  no_data: boolean
+  operational_spend: number
+  operational_forecast_month_end: number
+  provider_breakdown: OperationalResult['provider_breakdown']
+}
+
+interface LineRow {
+  source_id: string
+  billed_cost: number
+  charge_category: string
+  confidence: string
+  data_freshness: number
+}
+
+function readMonth(db: Database.Database, win: MonthWindow, providerBySource: Map<string, string>): MonthlyPeriod {
+  const rows = db.prepare(`
+    SELECT source_id, billed_cost, charge_category, confidence, data_freshness
+    FROM cost_line_items
+    WHERE charge_period_start < @end AND charge_period_end > @start AND voided_at IS NULL
+  `).all({ start: win.start, end: win.end }) as LineRow[]
+
+  if (rows.length === 0) {
+    return { month: win.key, no_data: true, operational_spend: 0, operational_forecast_month_end: 0, provider_breakdown: [] }
+  }
+  const op = resolveOperational(
+    rows.filter(l => !PENDING_CONF.has(l.confidence)).map(l => ({
+      source_id: l.source_id, provider: providerBySource.get(l.source_id) || 'other',
+      billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
+    })),
+    win,
+  )
+  return {
+    month: win.key,
+    no_data: false,
+    operational_spend: op.operational_spend,
+    operational_forecast_month_end: op.operational_forecast_month_end,
+    provider_breakdown: op.provider_breakdown,
+  }
+}
+
+export interface PeriodTrend {
+  months: MonthlyPeriod[]  // oldest first
+  current: MonthlyPeriod
+  previous: MonthlyPeriod
+  month_over_month_delta: number | null  // null if either side is no_data
+}
+
+/**
+ * Last `monthsBack` months (inclusive of the current month), oldest first.
+ * Pass the same `now`/`monthKey` semantics as getCostSummary's window anchor.
+ */
+export function getPeriodTrend(
+  db: Database.Database,
+  _config: CostOpsConfig,
+  now: number,
+  monthsBack = 6,
+  monthKey?: string,
+): PeriodTrend {
+  const anchor = monthWindow(now, monthKey)
+  const srcRows = db.prepare(`SELECT id, provider FROM cost_sources`).all() as Array<{ id: string; provider: string }>
+  const providerBySource = new Map(srcRows.map(r => [r.id, r.provider]))
+
+  const windows: MonthWindow[] = [anchor]
+  for (let i = 1; i < monthsBack; i++) {
+    windows.push(monthWindow(windows[windows.length - 1].start - 86400))
+  }
+  windows.reverse() // oldest first
+
+  const months = windows.map(w => readMonth(db, w, providerBySource))
+  const current = months[months.length - 1]
+  const previous = months.length >= 2 ? months[months.length - 2] : readMonth(db, monthWindow(anchor.start - 86400), providerBySource)
+  const month_over_month_delta = (!current.no_data && !previous.no_data)
+    ? Math.round((current.operational_spend - previous.operational_spend) * 100) / 100
+    : null
+
+  return { months, current, previous, month_over_month_delta }
+}

--- a/src/costops/period.ts
+++ b/src/costops/period.ts
@@ -27,7 +27,7 @@ interface LineRow {
   data_freshness: number
 }
 
-function readMonth(db: Database.Database, win: MonthWindow, providerBySource: Map<string, string>): MonthlyPeriod {
+function readMonth(db: Database.Database, win: MonthWindow, providerBySource: Map<string, string>, now: number): MonthlyPeriod {
   const rows = db.prepare(`
     SELECT source_id, billed_cost, charge_category, confidence, data_freshness
     FROM cost_line_items
@@ -43,6 +43,7 @@ function readMonth(db: Database.Database, win: MonthWindow, providerBySource: Ma
       billed_cost: l.billed_cost, charge_category: l.charge_category, confidence: l.confidence, data_freshness: l.data_freshness,
     })),
     win,
+    now,
   )
   return {
     month: win.key,
@@ -81,9 +82,9 @@ export function getPeriodTrend(
   }
   windows.reverse() // oldest first
 
-  const months = windows.map(w => readMonth(db, w, providerBySource))
+  const months = windows.map(w => readMonth(db, w, providerBySource, now))
   const current = months[months.length - 1]
-  const previous = months.length >= 2 ? months[months.length - 2] : readMonth(db, monthWindow(anchor.start - 86400), providerBySource)
+  const previous = months.length >= 2 ? months[months.length - 2] : readMonth(db, monthWindow(anchor.start - 86400), providerBySource, now)
   const month_over_month_delta = (!current.no_data && !previous.no_data)
     ? Math.round((current.operational_spend - previous.operational_spend) * 100) / 100
     : null

--- a/src/costops/pricing.ts
+++ b/src/costops/pricing.ts
@@ -1,0 +1,315 @@
+// CostOps v0.2 -- local, deterministic token-cost ESTIMATE.
+//
+// Pure arithmetic over the existing token_usage rows + a local pricing config.
+// NO LLM, no provider API, no external pricing API, no secrets. Token cost is
+// an ESTIMATE (confidence: estimate), kept SEPARATE from the v0.1 fixed/manual
+// spend -- it is never an invoice.
+//
+// Rows without a model (unknown) or without a matching pricing entry are left
+// UNPRICED (counted as volume only), never guessed.
+
+import type Database from 'better-sqlite3'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+import { logger } from '../logger.js'
+
+export const PRICING_CONFIG_PATH = join(PROJECT_ROOT, 'store', 'costops-pricing.json')
+export const PRICING_EXAMPLE_PATH = join(PROJECT_ROOT, 'store', 'costops-pricing.json.example')
+
+// Per-million-token rates, in the config's `currency` (default HUF).
+export interface ModelRate {
+  input_per_mtok: number
+  output_per_mtok: number
+  cache_read_per_mtok: number
+  cache_write_per_mtok: number
+}
+
+export interface PricingConfig {
+  version: number
+  currency: string
+  models: Record<string, ModelRate>
+}
+
+export interface PricingLoadResult {
+  pricing: PricingConfig
+  exists: boolean
+  errors: string[]
+}
+
+const EMPTY_PRICING: PricingConfig = { version: 1, currency: 'HUF', models: {} }
+
+// Safe skeleton -- ALL rates 0 (placeholder, no real provider prices). Operator
+// fills real per-MTok rates locally. Generated to the gitignored store/ dir.
+const EXAMPLE_PRICING = {
+  version: 1,
+  currency: 'HUF',
+  _doc: 'CostOps v0.2 token pricing (gitignored, local). Rates are per 1,000,000 tokens in `currency`. All 0 here = no cost estimate until you fill real rates. Keys are model ids as they appear in the transcript (message.model), e.g. claude-opus-4-8. No secrets/API keys here.',
+  models: {
+    'claude-opus-4-8': { input_per_mtok: 0, output_per_mtok: 0, cache_read_per_mtok: 0, cache_write_per_mtok: 0 },
+    'claude-sonnet-4-6': { input_per_mtok: 0, output_per_mtok: 0, cache_read_per_mtok: 0, cache_write_per_mtok: 0 },
+    'claude-haiku-4-5': { input_per_mtok: 0, output_per_mtok: 0, cache_read_per_mtok: 0, cache_write_per_mtok: 0 },
+    'deepseek-v4-pro': { input_per_mtok: 0, output_per_mtok: 0, cache_read_per_mtok: 0, cache_write_per_mtok: 0 },
+  },
+}
+
+/**
+ * Derive a coarse provider from a model id string. Deterministic, no network.
+ * Returns 'unknown' when it cannot be classified (never guessed downstream).
+ */
+export function deriveProvider(model: string | null | undefined): string {
+  if (!model) return 'unknown'
+  const m = model.toLowerCase()
+  if (/(claude|anthropic|opus|sonnet|haiku|fable)/.test(m)) return 'anthropic'
+  if (/(deepseek)/.test(m)) return 'deepseek'
+  if (/(gpt|openai|o1|o3|o4|davinci|codex)/.test(m)) return 'openai'
+  if (/(gemini|google|palm|bard)/.test(m)) return 'google'
+  if (/(grok|xai)/.test(m)) return 'xai'
+  if (/(mistral|mixtral)/.test(m)) return 'mistral'
+  if (/(llama|meta)/.test(m)) return 'meta'
+  return 'unknown'
+}
+
+export function loadPricingConfig(): PricingLoadResult {
+  if (!existsSync(PRICING_CONFIG_PATH)) {
+    ensurePricingExample()
+    return { pricing: { ...EMPTY_PRICING }, exists: false, errors: [] }
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(PRICING_CONFIG_PATH, 'utf-8'))
+  } catch (err) {
+    logger.warn({ err }, 'costops-pricing.json is not valid JSON')
+    return { pricing: { ...EMPTY_PRICING }, exists: true, errors: ['pricing config is not valid JSON'] }
+  }
+  return validatePricing(raw)
+}
+
+export function ensurePricingExample(): void {
+  try {
+    if (!existsSync(PRICING_EXAMPLE_PATH)) {
+      writeFileSync(PRICING_EXAMPLE_PATH, JSON.stringify(EXAMPLE_PRICING, null, 2) + '\n', 'utf-8')
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to write costops-pricing example')
+  }
+}
+
+export function validatePricing(raw: unknown): PricingLoadResult {
+  const errors: string[] = []
+  const obj = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const currency = typeof obj.currency === 'string' ? obj.currency : 'HUF'
+  const models: Record<string, ModelRate> = {}
+  const rawModels = (obj.models && typeof obj.models === 'object') ? obj.models as Record<string, unknown> : {}
+  for (const [id, v] of Object.entries(rawModels)) {
+    const r = v as Record<string, unknown>
+    const num = (x: unknown) => (typeof x === 'number' && isFinite(x) && x >= 0) ? x : null
+    const inp = num(r?.input_per_mtok), out = num(r?.output_per_mtok)
+    const cr = num(r?.cache_read_per_mtok), cw = num(r?.cache_write_per_mtok)
+    if (inp === null || out === null) { errors.push(`models['${id}']: input_per_mtok and output_per_mtok must be non-negative numbers`); continue }
+    models[id] = {
+      input_per_mtok: inp, output_per_mtok: out,
+      cache_read_per_mtok: cr ?? 0, cache_write_per_mtok: cw ?? 0,
+    }
+  }
+  return { pricing: { version: typeof obj.version === 'number' ? obj.version : 1, currency, models }, exists: true, errors }
+}
+
+// ---- deterministic token-cost estimate over token_usage for a month ---------
+
+export interface TokenCostEstimate {
+  currency: string
+  total_estimated_huf: number
+  confidence: 'estimate'
+  pricing_profile_status: 'no_pricing_config' | 'loaded' | 'partial'
+  priced_by_model: Array<{
+    model: string
+    provider: string
+    input_tokens: number
+    output_tokens: number
+    cache_read_tokens: number
+    cache_creation_tokens: number
+    estimated_huf: number
+  }>
+  unpriced: {
+    unknown_model_tokens: number   // rows with NULL model
+    no_rate_tokens: number         // model present but no pricing entry
+    calls: number
+  }
+  note: string
+}
+
+interface ModelAgg {
+  model: string | null
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+  calls: number
+}
+
+/**
+ * Compute a deterministic token-cost estimate for [start,end) from token_usage,
+ * grouped by model, using the local pricing config. Pure SQL + arithmetic.
+ * `pricingExists` distinguishes "no config at all" from "config with no match".
+ */
+export function getTokenCostEstimate(
+  db: Database.Database,
+  pricing: PricingConfig,
+  pricingExists: boolean,
+  start: number,
+  end: number,
+): TokenCostEstimate {
+  const rows = db.prepare(`
+    SELECT model,
+      COALESCE(SUM(input_tokens),0) as input_tokens,
+      COALESCE(SUM(output_tokens),0) as output_tokens,
+      COALESCE(SUM(cache_read_tokens),0) as cache_read_tokens,
+      COALESCE(SUM(cache_creation_tokens),0) as cache_creation_tokens,
+      COUNT(*) as calls
+    FROM token_usage
+    WHERE timestamp >= @start AND timestamp < @end
+    GROUP BY model
+  `).all({ start, end }) as ModelAgg[]
+
+  const priced_by_model: TokenCostEstimate['priced_by_model'] = []
+  let total = 0
+  let unknownTokens = 0, noRateTokens = 0, unpricedCalls = 0
+  let anyPriced = false, anyUnpriced = false
+
+  for (const r of rows) {
+    const tokenSum = r.input_tokens + r.output_tokens + r.cache_read_tokens + r.cache_creation_tokens
+    const rate = r.model ? pricing.models[r.model] : undefined
+    if (!r.model) {
+      unknownTokens += tokenSum; unpricedCalls += r.calls; anyUnpriced = true; continue
+    }
+    if (!rate) {
+      noRateTokens += tokenSum; unpricedCalls += r.calls; anyUnpriced = true; continue
+    }
+    const est = round2(
+      (r.input_tokens / 1e6) * rate.input_per_mtok +
+      (r.output_tokens / 1e6) * rate.output_per_mtok +
+      (r.cache_read_tokens / 1e6) * rate.cache_read_per_mtok +
+      (r.cache_creation_tokens / 1e6) * rate.cache_write_per_mtok,
+    )
+    total += est
+    anyPriced = true
+    priced_by_model.push({
+      model: r.model, provider: deriveProvider(r.model),
+      input_tokens: r.input_tokens, output_tokens: r.output_tokens,
+      cache_read_tokens: r.cache_read_tokens, cache_creation_tokens: r.cache_creation_tokens,
+      estimated_huf: est,
+    })
+  }
+  priced_by_model.sort((a, b) => b.estimated_huf - a.estimated_huf)
+
+  const pricing_profile_status: TokenCostEstimate['pricing_profile_status'] =
+    !pricingExists || Object.keys(pricing.models).length === 0 ? 'no_pricing_config'
+    : (anyUnpriced && anyPriced) ? 'partial'
+    : 'loaded'
+
+  return {
+    currency: pricing.currency,
+    total_estimated_huf: round2(total),
+    confidence: 'estimate',
+    pricing_profile_status,
+    priced_by_model,
+    unpriced: { unknown_model_tokens: unknownTokens, no_rate_tokens: noRateTokens, calls: unpricedCalls },
+    note: 'ESTIMATE only, not an invoice. Separate from fixed/manual spend. Rows with unknown model or no pricing rate are left unpriced (volume only).',
+  }
+}
+
+// ---- v0.8 (card 6f4d1332 §5): agent-grouped token cost + run-rate forecast --------------------
+// Sibling of getTokenCostEstimate() -- same pricing config, same per-row pricing logic, just
+// GROUP BY agent, model instead of model alone. No new columns needed: token_usage already has
+// agent/model/provider on every row (db.ts). limit_usage_pct is always null here (honest, not
+// invented) -- this function has no subscription-limit context; a caller can overlay a real
+// ceiling (e.g. SubscriptionEntry.weekly_limit_tokens, if the operator ever supplies one) separately.
+
+// v0.8.1 (card d9739cf3, label/naming polish): label/naming polish, no math change. The token-runrate
+// number is an ESTIMATE, never an invoice -- "actual_cost" was misleading (implied a confirmed
+// charge). Renamed to estimated_cost_mtd; billed_status/source are new explicit per-row fields
+// so a reader doesn't have to infer "is this actually charged?" from card-header prose.
+export interface TokenCostByAgentEntry {
+  agent: string
+  provider: string
+  model: string
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+  estimated_cost_mtd: number
+  forecast_month_end: number | null   // null when fractionElapsed is not meaningful (e.g. 0 rows)
+  forecast_basis: 'token_runrate'
+  // 'not_billed': provider has an active flat-fee subscription (Claude Max/Pro) that already
+  // covers this usage -- the number is visibility, not a separate charge. 'unknown': no
+  // subscription-coverage signal for this provider here (this is a pure function with no
+  // subscription context) -- genuinely don't know, never guessed as either not_billed or billed.
+  billed_status: 'not_billed' | 'unknown'
+  source: 'local_token_usage'
+  limit_usage_pct: number | null      // always null -- see module comment above
+}
+
+interface AgentModelAgg {
+  agent: string
+  model: string | null
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+}
+
+/**
+ * Per-(agent, model) token cost estimate + run-rate forecast for [start,end). Rows with no
+ * model or no matching pricing rate are excluded from the result (same "never guess" rule as
+ * getTokenCostEstimate) rather than returned with a fabricated cost.
+ */
+export function getTokenCostByAgent(
+  db: Database.Database,
+  pricing: PricingConfig,
+  start: number,
+  end: number,
+  fractionElapsed: number,
+): TokenCostByAgentEntry[] {
+  const rows = db.prepare(`
+    SELECT agent, model,
+      COALESCE(SUM(input_tokens),0) as input_tokens,
+      COALESCE(SUM(output_tokens),0) as output_tokens,
+      COALESCE(SUM(cache_read_tokens),0) as cache_read_tokens,
+      COALESCE(SUM(cache_creation_tokens),0) as cache_creation_tokens
+    FROM token_usage
+    WHERE timestamp >= @start AND timestamp < @end
+    GROUP BY agent, model
+  `).all({ start, end }) as AgentModelAgg[]
+
+  const out: TokenCostByAgentEntry[] = []
+  for (const r of rows) {
+    const rate = r.model ? pricing.models[r.model] : undefined
+    if (!r.model || !rate) continue // unpriced (unknown model / no rate) -- volume only, not returned here
+    const est = round2(
+      (r.input_tokens / 1e6) * rate.input_per_mtok +
+      (r.output_tokens / 1e6) * rate.output_per_mtok +
+      (r.cache_read_tokens / 1e6) * rate.cache_read_per_mtok +
+      (r.cache_creation_tokens / 1e6) * rate.cache_write_per_mtok,
+    )
+    const provider = deriveProvider(r.model)
+    out.push({
+      agent: r.agent, provider, model: r.model,
+      input_tokens: r.input_tokens, output_tokens: r.output_tokens,
+      cache_read_tokens: r.cache_read_tokens, cache_creation_tokens: r.cache_creation_tokens,
+      estimated_cost_mtd: est,
+      forecast_month_end: fractionElapsed > 0 ? round2(est / fractionElapsed) : null,
+      forecast_basis: 'token_runrate',
+      // Anthropic usage in this fleet runs under a flat-fee Claude Max/Pro subscription, not a
+      // metered API key -- local token counting is visibility only, never a separate charge.
+      // Every other provider: no subscription-coverage signal available in this pure function,
+      // stays honestly 'unknown' rather than assumed either way.
+      billed_status: provider === 'anthropic' ? 'not_billed' : 'unknown',
+      source: 'local_token_usage',
+      limit_usage_pct: null,
+    })
+  }
+  return out.sort((a, b) => b.estimated_cost_mtd - a.estimated_cost_mtd)
+}
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }

--- a/src/costops/recommendations-store.ts
+++ b/src/costops/recommendations-store.ts
@@ -1,0 +1,164 @@
+// CostOps Phase 4 (GAP-17) -- persistence for Anvil's optimization.ts lifecycle
+// core. optimization.ts is pure computation (detectors + reconcileRecommendations);
+// this is the thin DB layer that applies a RecommendationReconcileResult and
+// serves reads/accept/dismiss. Same split as alerts.ts/alerts-store.ts. The
+// actual SIGNAL-GATHERING orchestration (running all 9 detectors against real
+// subscription/ledger/utilisation data each round) is a separate piece
+// (optimization-capture.ts, Anvil, still in progress) -- deferred so this
+// module can land now and slot in later without touching this file's contract.
+
+import type Database from 'better-sqlite3'
+import {
+  serializeEvidence, deserializeEvidence,
+  type RecommendationRecord, type RecommendationReconcileResult, reconcileRecommendations,
+  type RecommendationCandidate, acceptRecommendation, dismissRecommendation,
+} from './optimization.js'
+
+interface RecommendationRow {
+  type: string
+  evidence_json: string
+  dedup_key: string
+  current_monthly_cost: number
+  estimated_monthly_saving: number
+  estimated_annual_saving: number
+  switching_cost: number
+  risk: string
+  confidence: string
+  human_decision_required: string
+  rollback_note: string
+  status: string
+  status_changed_at: number | null
+  status_changed_by: string | null
+  expires_at: number | null
+  first_seen: number
+  last_seen: number
+}
+
+function rowToRecord(row: RecommendationRow): RecommendationRecord {
+  return {
+    type: row.type as RecommendationRecord['type'], evidence: deserializeEvidence(row.evidence_json), dedup_key: row.dedup_key,
+    current_monthly_cost: row.current_monthly_cost, estimated_monthly_saving: row.estimated_monthly_saving,
+    estimated_annual_saving: row.estimated_annual_saving, switching_cost: row.switching_cost,
+    risk: row.risk as RecommendationRecord['risk'], confidence: row.confidence as RecommendationRecord['confidence'],
+    human_decision_required: row.human_decision_required, rollback_note: row.rollback_note,
+    status: row.status as RecommendationRecord['status'], status_changed_at: row.status_changed_at, status_changed_by: row.status_changed_by,
+    expires_at: row.expires_at, first_seen: row.first_seen, last_seen: row.last_seen,
+  }
+}
+
+/** All recommendations currently stored (any state), for feeding into reconcileRecommendations as `existing`. */
+export function listAllRecommendations(db: Database.Database): RecommendationRecord[] {
+  return (db.prepare(`SELECT * FROM costops_recommendations`).all() as RecommendationRow[]).map(rowToRecord)
+}
+
+export interface ListRecommendationsOptions {
+  status?: 'open' | 'accepted' | 'dismissed' | 'resolved' | 'expired' | 'all'
+  type?: string
+}
+
+/** Recommendations for API/dashboard consumption -- defaults to 'open' only. */
+export function listRecommendations(db: Database.Database, opts: ListRecommendationsOptions = {}): RecommendationRecord[] {
+  const status = opts.status ?? 'open'
+  const conditions: string[] = []
+  const params: unknown[] = []
+  if (status !== 'all') { conditions.push('status = ?'); params.push(status) }
+  if (opts.type) { conditions.push('type = ?'); params.push(opts.type) }
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''
+  const rows = db.prepare(`SELECT * FROM costops_recommendations ${where} ORDER BY last_seen DESC`).all(...params) as RecommendationRow[]
+  return rows.map(rowToRecord)
+}
+
+/**
+ * Apply a RecommendationReconcileResult to the DB in one transaction. Pure DB
+ * write, no detection logic -- the caller already ran reconcileRecommendations()
+ * against listAllRecommendations()'s current state.
+ */
+export function applyRecommendationReconciliation(db: Database.Database, result: RecommendationReconcileResult, now: number): void {
+  const insertStmt = db.prepare(`
+    INSERT INTO costops_recommendations
+      (type, evidence_json, dedup_key, current_monthly_cost, estimated_monthly_saving, estimated_annual_saving,
+       switching_cost, risk, confidence, human_decision_required, rollback_note, status,
+       status_changed_at, status_changed_by, expires_at, first_seen, last_seen, created_at)
+    VALUES (@type, @evidence_json, @dedup_key, @current_monthly_cost, @estimated_monthly_saving, @estimated_annual_saving,
+       @switching_cost, @risk, @confidence, @human_decision_required, @rollback_note, @status,
+       @status_changed_at, @status_changed_by, @expires_at, @first_seen, @last_seen, @now)
+  `)
+  const touchStmt = db.prepare(`
+    UPDATE costops_recommendations SET last_seen = @last_seen, evidence_json = @evidence_json,
+      current_monthly_cost = @current_monthly_cost, estimated_monthly_saving = @estimated_monthly_saving,
+      estimated_annual_saving = @estimated_annual_saving, switching_cost = @switching_cost,
+      risk = @risk, confidence = @confidence
+    WHERE dedup_key = @dedup_key
+  `)
+  const resolveStmt = db.prepare(`UPDATE costops_recommendations SET status = 'resolved', status_changed_at = @now WHERE dedup_key = @dedup_key`)
+  const expireStmt = db.prepare(`UPDATE costops_recommendations SET status = 'expired', status_changed_at = @now WHERE dedup_key = @dedup_key`)
+
+  const tx = db.transaction(() => {
+    for (const r of result.toInsert) {
+      insertStmt.run({
+        type: r.type, evidence_json: serializeEvidence(r.evidence), dedup_key: r.dedup_key,
+        current_monthly_cost: r.current_monthly_cost, estimated_monthly_saving: r.estimated_monthly_saving,
+        estimated_annual_saving: r.estimated_annual_saving, switching_cost: r.switching_cost,
+        risk: r.risk, confidence: r.confidence, human_decision_required: r.human_decision_required,
+        rollback_note: r.rollback_note, status: r.status, status_changed_at: r.status_changed_at,
+        status_changed_by: r.status_changed_by, expires_at: r.expires_at, first_seen: r.first_seen, last_seen: r.last_seen, now,
+      })
+    }
+    for (const t of result.toTouch) {
+      touchStmt.run({
+        dedup_key: t.dedup_key, last_seen: t.patch.last_seen, evidence_json: serializeEvidence(t.patch.evidence),
+        current_monthly_cost: t.patch.current_monthly_cost, estimated_monthly_saving: t.patch.estimated_monthly_saving,
+        estimated_annual_saving: t.patch.estimated_annual_saving, switching_cost: t.patch.switching_cost,
+        risk: t.patch.risk, confidence: t.patch.confidence,
+      })
+    }
+    for (const r of result.toResolve) resolveStmt.run({ dedup_key: r.dedup_key, now })
+    for (const r of result.toExpire) expireStmt.run({ dedup_key: r.dedup_key, now })
+  })
+  tx()
+}
+
+/** Convenience: detect candidates elsewhere, then reconcile+persist in one call -- the shape optimization-capture.ts (Anvil, in progress) will call once it lands. */
+export function reconcileAndPersistRecommendations(db: Database.Database, candidates: RecommendationCandidate[], now: number, expirySeconds?: number): RecommendationReconcileResult {
+  const existing = listAllRecommendations(db)
+  const result = reconcileRecommendations(existing, candidates, now, expirySeconds)
+  applyRecommendationReconciliation(db, result, now)
+  return result
+}
+
+export interface RecommendationDecisionResult {
+  ok: boolean
+  error?: string
+  status?: number
+  recommendation?: RecommendationRecord
+}
+
+function loadOne(db: Database.Database, dedupKey: string): RecommendationRecord | null {
+  const row = db.prepare(`SELECT * FROM costops_recommendations WHERE dedup_key = ?`).get(dedupKey) as RecommendationRow | undefined
+  return row ? rowToRecord(row) : null
+}
+
+function writeStatus(db: Database.Database, r: RecommendationRecord): void {
+  db.prepare(`UPDATE costops_recommendations SET status = ?, status_changed_at = ?, status_changed_by = ? WHERE dedup_key = ?`)
+    .run(r.status, r.status_changed_at, r.status_changed_by, r.dedup_key)
+}
+
+/** Human accepts a recommendation (intends to act on it outside this codebase) -- frozen from further re-detection thereafter (optimization.ts's reconcile). */
+export function acceptRecommendationByKey(db: Database.Database, dedupKey: string, actor: string, now: number): RecommendationDecisionResult {
+  if (!actor || !actor.trim()) return { ok: false, error: 'actor is required to accept a recommendation', status: 400 }
+  const existing = loadOne(db, dedupKey)
+  if (!existing) return { ok: false, error: `no recommendation with dedup_key '${dedupKey}'`, status: 404 }
+  const updated = acceptRecommendation(existing, actor, now)
+  writeStatus(db, updated)
+  return { ok: true, recommendation: updated }
+}
+
+/** Human dismisses a recommendation (decided against it) -- frozen from further re-detection thereafter. */
+export function dismissRecommendationByKey(db: Database.Database, dedupKey: string, actor: string, now: number): RecommendationDecisionResult {
+  if (!actor || !actor.trim()) return { ok: false, error: 'actor is required to dismiss a recommendation', status: 400 }
+  const existing = loadOne(db, dedupKey)
+  if (!existing) return { ok: false, error: `no recommendation with dedup_key '${dedupKey}'`, status: 404 }
+  const updated = dismissRecommendation(existing, actor, now)
+  writeStatus(db, updated)
+  return { ok: true, recommendation: updated }
+}

--- a/src/costops/reconciliation.ts
+++ b/src/costops/reconciliation.ts
@@ -1,0 +1,129 @@
+// CostOps Phase 1 (GAP-06) -- per-source reconciliation view.
+//
+// Formalizes the "is this number believable" check the gap-analysis calls
+// for: per source, what did the provider API say, what did the invoice say,
+// what did we forecast, and what did the ledger actually select as the
+// operational headline -- with an explicit variance and status, instead of
+// only the existing summary-level reconciliation-delta-0 guarantee (which
+// proves internal consistency, not cross-source-of-truth agreement).
+//
+// Read-only, additive: does not change getCostSummary's contract or write
+// anything. Reuses the same CONF_PRIORITY resolution as ledger.ts so
+// "operationally selected" here always matches what the dashboard actually
+// shows for that source.
+
+import type Database from 'better-sqlite3'
+import { monthWindow, CONF_PRIORITY } from './ledger.js'
+
+export type ReconciliationStatus =
+  | 'matched'
+  | 'variance'
+  | 'missing_invoice'
+  | 'missing_provider_data'
+  | 'estimate_only'
+  | 'no_data'
+
+export interface SourceReconciliation {
+  source_id: string
+  name: string
+  provider: string
+  month: string
+  expected_amount: number | null
+  observed_provider_amount: number | null
+  invoice_amount: number | null
+  operationally_selected_amount: number | null
+  variance: number | null
+  variance_reason: string | null
+  status: ReconciliationStatus
+}
+
+// Relative variance tolerance below which two numbers are considered
+// "matched" rather than a genuine discrepancy worth flagging -- not
+// business-specified (same flagged-placeholder convention as warnings.ts's
+// MATERIAL_FRACTION/LARGE_INCREASE_FRACTION), tune once real invoice-vs-
+// provider-API data accumulates.
+const VARIANCE_TOLERANCE_FRACTION = 0.02
+
+interface SourceRow { id: string; name: string; provider: string }
+interface LineRow { source_id: string; billed_cost: number; confidence: string; actual_source: string | null }
+
+function round2(n: number): number { return Math.round(n * 100) / 100 }
+
+function isWithinTolerance(a: number, b: number): boolean {
+  const base = Math.max(Math.abs(a), Math.abs(b), 1)
+  return Math.abs(a - b) / base <= VARIANCE_TOLERANCE_FRACTION
+}
+
+/**
+ * Build the reconciliation view for every active source, for `month`
+ * (defaults to the month containing `now`). Pure DB read, no writes.
+ */
+export function buildReconciliation(db: Database.Database, now: number, month?: string): SourceReconciliation[] {
+  const win = monthWindow(now, month)
+  const sources = db.prepare(`SELECT id, name, provider FROM cost_sources WHERE active = 1`).all() as SourceRow[]
+  const lines = db.prepare(`
+    SELECT source_id, billed_cost, confidence, actual_source
+    FROM cost_line_items
+    WHERE charge_period_start < @end AND charge_period_end > @start AND voided_at IS NULL
+  `).all({ start: win.start, end: win.end }) as LineRow[]
+
+  const bySource = new Map<string, LineRow[]>()
+  for (const l of lines) { const a = bySource.get(l.source_id); if (a) a.push(l); else bySource.set(l.source_id, [l]) }
+
+  const latestForecast = db.prepare(`
+    SELECT forecast_amount FROM forecast_snapshots
+    WHERE source_id = ? AND month = ? ORDER BY snapshot_at DESC LIMIT 1
+  `)
+
+  return sources.map((s): SourceReconciliation => {
+    const ls = bySource.get(s.id) ?? []
+    if (ls.length === 0) {
+      return {
+        source_id: s.id, name: s.name, provider: s.provider, month: win.key,
+        expected_amount: null, observed_provider_amount: null, invoice_amount: null,
+        operationally_selected_amount: null, variance: null, variance_reason: null,
+        status: 'no_data',
+      }
+    }
+
+    const providerLines = ls.filter(l => l.actual_source === 'provider_api')
+    const invoiceLines = ls.filter(l => l.actual_source === 'email_invoice')
+    const observed_provider_amount = providerLines.length > 0 ? round2(providerLines.reduce((sum, l) => sum + l.billed_cost, 0)) : null
+    const invoice_amount = invoiceLines.length > 0 ? round2(invoiceLines.reduce((sum, l) => sum + l.billed_cost, 0)) : null
+
+    const resolved = ls.reduce((a, b) => (CONF_PRIORITY[b.confidence] || 0) > (CONF_PRIORITY[a.confidence] || 0) ? b : a)
+    const operationally_selected_amount = round2(resolved.billed_cost)
+
+    const forecastRow = latestForecast.get(s.id, win.key) as { forecast_amount: number } | undefined
+    const expected_amount = forecastRow ? round2(forecastRow.forecast_amount) : null
+
+    let variance: number | null = null
+    let variance_reason: string | null = null
+    if (observed_provider_amount != null && invoice_amount != null) {
+      variance = round2(invoice_amount - observed_provider_amount)
+      variance_reason = 'invoice vs provider API'
+    } else if (expected_amount != null && operationally_selected_amount != null) {
+      variance = round2(operationally_selected_amount - expected_amount)
+      variance_reason = 'actual vs forecast'
+    }
+
+    let status: ReconciliationStatus
+    if (observed_provider_amount != null && invoice_amount == null) {
+      status = 'missing_invoice'
+    } else if (invoice_amount != null && observed_provider_amount == null) {
+      status = 'missing_provider_data'
+    } else if (observed_provider_amount == null && invoice_amount == null) {
+      status = 'estimate_only'
+    } else if (variance != null && !isWithinTolerance(invoice_amount!, observed_provider_amount!)) {
+      status = 'variance'
+    } else {
+      status = 'matched'
+    }
+
+    return {
+      source_id: s.id, name: s.name, provider: s.provider, month: win.key,
+      expected_amount, observed_provider_amount, invoice_amount, operationally_selected_amount,
+      variance, variance_reason, status,
+    }
+  })
+}

--- a/src/costops/reliability-observation.ts
+++ b/src/costops/reliability-observation.ts
@@ -1,0 +1,102 @@
+// CostOps Phase 0 -- 7-day source-reliability observation window (gap-analysis
+// P0.4). Captures a point-in-time snapshot of the full source inventory
+// (lifecycle + freshness + sync status per source) so day-over-day
+// reliability can be compared once several captures accumulate. This module
+// only builds and stores ONE capture; the recurring daily cadence over the
+// 7-day window is wired at boot (see web.ts) the same way the existing
+// fixed-cost sync interval is -- this module has no scheduling of its own,
+// keeping it independently testable.
+
+import type Database from 'better-sqlite3'
+import { getDb } from '../db.js'
+import { loadCostopsConfig, type CostOpsConfig } from './config.js'
+import { buildSourceInventory, type SourceInventoryEntry, type CredentialChecker } from './inventory.js'
+import { captureForecastSnapshots } from './forecast-capture.js'
+import { captureAlerts } from './alerts-capture.js'
+import { captureRecommendations } from './optimization-capture.js'
+import { logger } from '../logger.js'
+
+const SNAPSHOT_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+export interface ReliabilitySnapshot {
+  captured_at: number
+  source_count: number
+  inventory: SourceInventoryEntry[]
+}
+
+/** Build and persist one reliability snapshot. Returns the row that was written. */
+export function captureReliabilitySnapshot(
+  db: Database.Database,
+  config: CostOpsConfig,
+  now: number,
+  deps: { credentialChecker?: CredentialChecker } = {},
+): ReliabilitySnapshot {
+  const inventory = buildSourceInventory(db, config, now, deps)
+  db.prepare(`
+    INSERT INTO costops_reliability_snapshots (captured_at, source_count, inventory_json)
+    VALUES (@now, @count, @json)
+  `).run({ now, count: inventory.length, json: JSON.stringify(inventory) })
+  return { captured_at: now, source_count: inventory.length, inventory }
+}
+
+/** All snapshots captured so far, oldest first -- the growing 7-day observation window. */
+export function listReliabilitySnapshots(db: Database.Database, limit = 30): Array<{ captured_at: number; source_count: number }> {
+  return db.prepare(`
+    SELECT captured_at, source_count FROM costops_reliability_snapshots
+    ORDER BY captured_at ASC LIMIT ?
+  `).all(limit) as Array<{ captured_at: number; source_count: number }>
+}
+
+/** The single most recent snapshot's full inventory, or null if none exist yet. */
+export function getLatestReliabilitySnapshot(db: Database.Database): ReliabilitySnapshot | null {
+  const row = db.prepare(`
+    SELECT captured_at, source_count, inventory_json FROM costops_reliability_snapshots
+    ORDER BY captured_at DESC LIMIT 1
+  `).get() as { captured_at: number; source_count: number; inventory_json: string } | undefined
+  if (!row) return null
+  return { captured_at: row.captured_at, source_count: row.source_count, inventory: JSON.parse(row.inventory_json) }
+}
+
+function captureNowSafely(): void {
+  const now = Math.floor(Date.now() / 1000)
+  try {
+    const { config } = loadCostopsConfig()
+    captureReliabilitySnapshot(getDb(), config, now)
+  } catch (err) {
+    logger.warn({ err }, 'CostOps reliability snapshot capture failed')
+  }
+  // Phase 1 (GAP-10): forecast snapshots, same daily cadence. Independent
+  // try/catch so a failure in one capture never blocks the other.
+  try {
+    captureForecastSnapshots(getDb(), now)
+  } catch (err) {
+    logger.warn({ err }, 'CostOps forecast snapshot capture failed')
+  }
+  // Phase 3 (GAP-12): alerts capture/reconcile, same daily cadence.
+  try {
+    const { config } = loadCostopsConfig()
+    captureAlerts(getDb(), config, now)
+  } catch (err) {
+    logger.warn({ err }, 'CostOps alerts capture failed')
+  }
+  // Phase 4 (GAP-17): optimization recommendation capture/reconcile, same daily cadence.
+  try {
+    captureRecommendations(getDb(), now)
+  } catch (err) {
+    logger.warn({ err }, 'CostOps optimization recommendation capture failed')
+  }
+}
+
+/**
+ * Boot-time seam entry point (docs/fork-upstream-policy.md §2a): the ONE
+ * call web.ts makes for every CostOps background task, present and future
+ * (currently: reliability-observation snapshots + Phase 1 forecast
+ * snapshots). Captures immediately, then every 24h. Returns the interval
+ * handle so the caller can clearInterval it on shutdown, matching every
+ * other start*Runner()/start*Monitor() in this codebase (e.g.
+ * startAutoRestartRunner).
+ */
+export function startCostOpsBackgroundTasks(): NodeJS.Timeout {
+  captureNowSafely()
+  return setInterval(captureNowSafely, SNAPSHOT_INTERVAL_MS)
+}

--- a/src/costops/reliability-observation.ts
+++ b/src/costops/reliability-observation.ts
@@ -88,8 +88,8 @@ function captureNowSafely(): void {
 }
 
 /**
- * Boot-time seam entry point (docs/fork-upstream-policy.md §2a): the ONE
- * call web.ts makes for every CostOps background task, present and future
+ * Boot-time seam entry point: the ONE call web.ts makes for every CostOps
+ * background task, present and future
  * (currently: reliability-observation snapshots + Phase 1 forecast
  * snapshots). Captures immediately, then every 24h. Returns the interval
  * handle so the caller can clearInterval it on shutdown, matching every

--- a/src/costops/render-live-checks.ts
+++ b/src/costops/render-live-checks.ts
@@ -1,0 +1,84 @@
+// CostOps v0.7/v2 -- Render LIVE checks beyond plan-cost (card bea78483).
+//
+// READ-ONLY (GET only, official Render events API). Render's account-wide
+// build-minutes pool only exposes a discrete `pipeline_minutes_exhausted`
+// event per-service when the pool is FULLY drained -- there is no API for the
+// 70/90% intermediate tiers (confirmed against api-docs.render.com), so this
+// check can only ever report "blocked" (100%) or nothing, never a percentage.
+
+import { getRenderApiKey } from './collectors/render.js'
+import type { HttpGetJson } from './collectors/types.js'
+import type { CostWarning } from './warnings.js'
+import { categoryForProvider } from './warnings.js'
+
+const SERVICES_URL = 'https://api.render.com/v1/services?limit=100'
+const LOOKBACK_SECS = 48 * 3600 // a build-minutes-exhausted event older than this is stale, not "currently blocked"
+
+interface RenderEvent {
+  event?: { id?: string; serviceId?: string; timestamp?: string; type?: string }
+}
+interface RenderServiceItem {
+  service?: { id?: string; name?: string }
+}
+
+/**
+ * Scans every service's recent events for `pipeline_minutes_exhausted`. Emits
+ * ONE consolidated warning if any service hit it within LOOKBACK_SECS, never a
+ * fabricated percentage (the API only tells us "exhausted or not"). Never
+ * throws -- a fetch failure surfaces as its own low-severity access warning
+ * instead of silently hiding a real condition.
+ */
+export async function checkRenderBuildMinutes(
+  now: number,
+  deps: { httpGetJson?: HttpGetJson; apiKey?: string | null } = {},
+): Promise<CostWarning[]> {
+  const apiKey = deps.apiKey !== undefined ? deps.apiKey : getRenderApiKey()
+  if (!apiKey) return [] // no key configured -- render.ts's own sync already surfaces this gap
+  const httpGetJson = deps.httpGetJson || (async (url: string, headers: Record<string, string>) => {
+    const r = await fetch(url, { method: 'GET', headers })
+    if (!r.ok) throw new Error(`render api ${r.status}`)
+    return r.json()
+  })
+  const headers = { authorization: `Bearer ${apiKey}`, accept: 'application/json' }
+
+  let services: RenderServiceItem[]
+  try {
+    const raw = await httpGetJson(SERVICES_URL, headers)
+    services = Array.isArray(raw) ? raw as RenderServiceItem[] : []
+  } catch {
+    return [{
+      code: 'render_build_minutes_check_failed', severity: 'low', provider: 'render',
+      message: 'Render build-minutes állapot nem lekérdezhető (API hiba).',
+      warning_type: 'access', category: 'hosting', source: 'render_api', confidence: 'no_api_or_no_access',
+    }]
+  }
+
+  let mostRecent: { serviceName: string; timestamp: string } | null = null
+  for (const item of services) {
+    const svcId = item.service?.id
+    if (!svcId) continue
+    try {
+      const raw = await httpGetJson(`https://api.render.com/v1/services/${svcId}/events?type=pipeline_minutes_exhausted&limit=1`, headers)
+      const events = Array.isArray(raw) ? raw as RenderEvent[] : []
+      const ev = events[0]?.event
+      if (ev?.timestamp) {
+        if (!mostRecent || ev.timestamp > mostRecent.timestamp) {
+          mostRecent = { serviceName: item.service?.name || svcId, timestamp: ev.timestamp }
+        }
+      }
+    } catch { /* one service's event query failing shouldn't hide findings from the others */ }
+  }
+  if (!mostRecent) return []
+
+  const ageSecs = now - Math.floor(Date.parse(mostRecent.timestamp) / 1000)
+  if (ageSecs > LOOKBACK_SECS) return [] // stale event, pool has very likely reset since
+
+  return [{
+    code: 'render_build_minutes_exhausted', severity: 'high', provider: 'render',
+    message: `Render build-percek elfogytak (${mostRecent.serviceName}, ${Math.round(ageSecs / 3600)} órája) -- új deploy blokkolva lehet.`,
+    detail: { service_name: mostRecent.serviceName, event_timestamp: mostRecent.timestamp },
+    warning_type: 'quota', category: categoryForProvider('render'), source: 'render_api', confidence: 'measured',
+    threshold: 100, current_value: 100, unit: '%',
+    action: 'Várj a havi build-percek resetjére, vagy válts magasabb Render csomagra.',
+  }]
+}

--- a/src/costops/schema.ts
+++ b/src/costops/schema.ts
@@ -1,0 +1,138 @@
+// CostOps schema -- ALL CostOps CREATE TABLE / ALTER TABLE / CREATE INDEX
+// statements live here, not in src/db.ts. This is the "schema" seam
+// (docs/fork-upstream-policy.md §2a): db.ts owns exactly one call,
+// `initCostOpsSchema(db)`, marked `// LOCAL-FORK: costops seam`. Every table
+// this feature has ever added (v0.1 through PR-B) is consolidated here,
+// verbatim, so the upstream-owned db.ts stops growing a table per CostOps
+// release. Idempotent by construction (CREATE TABLE IF NOT EXISTS, ALTER
+// TABLE wrapped in try/catch) -- calling this on an already-migrated DB is a
+// safe no-op, exactly like the individual statements were before the move.
+
+import type Database from 'better-sqlite3'
+import { initForecastSchema } from './forecast.js'
+import { initFxSchema } from './fx.js'
+
+export function initCostOpsSchema(db: Database.Database): void {
+  // CostOps v0.2: model/provider enrichment on the CORE token_usage table
+  // (not CostOps-owned, but this feature bolts 2 nullable columns onto it for
+  // token-cost estimation). Nullable + forward-only: NEW ingested rows carry
+  // the model from the transcript; existing rows stay NULL (unknown) -> left
+  // unpriced, never guessed. Must run after token_usage itself exists --
+  // db.ts calls initCostOpsSchema() after that table's own setup.
+  try { db.exec(`ALTER TABLE token_usage ADD COLUMN model TEXT`) } catch { /* column already exists */ }
+  try { db.exec(`ALTER TABLE token_usage ADD COLUMN provider TEXT`) } catch { /* column already exists */ }
+  try { db.exec(`ALTER TABLE token_usage ADD COLUMN model_source TEXT`) } catch { /* column already exists */ }
+  // --- CostOps (local cost ledger, v0.1) ---
+  // Read-mostly, FOCUS-inspired. cost_sources = provider/subscription origin,
+  // cost_line_items = individual charge rows (estimate or provider-sourced).
+  // No secrets/account IDs stored raw. Budgets are config-driven (costops/config.ts's
+  // BudgetEntry, from store/costops-config.json) -- there is deliberately no separate
+  // `budgets` DB table: an earlier draft of this schema had one, but it was never
+  // read from or written to (config.budgets was always the actual source), so it was
+  // a dead, unused second source of truth. Removed rather than wired up, since the
+  // config file already covers this fully and a DB table would just be a sync burden
+  // for no benefit.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cost_sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      source_type TEXT NOT NULL,
+      account_ref TEXT,
+      currency TEXT NOT NULL DEFAULT 'HUF',
+      active INTEGER NOT NULL DEFAULT 1,
+      notes TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cost_line_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_id TEXT NOT NULL REFERENCES cost_sources(id),
+      charge_period_start INTEGER NOT NULL,
+      charge_period_end INTEGER NOT NULL,
+      charge_category TEXT NOT NULL,
+      service_name TEXT,
+      usage_type TEXT,
+      consumed_quantity REAL,
+      consumed_unit TEXT,
+      billed_cost REAL NOT NULL,
+      effective_cost REAL,
+      currency TEXT NOT NULL DEFAULT 'HUF',
+      confidence TEXT NOT NULL,
+      data_freshness INTEGER NOT NULL,
+      source_ref TEXT,
+      dedup_key TEXT UNIQUE,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_period ON cost_line_items(charge_period_start, charge_period_end)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_source ON cost_line_items(source_id)`)
+  // Currency-retention (Phase-3 per spec): when a line's billed_cost is
+  // HUF-converted from a foreign-currency invoice, keep the original
+  // amount/currency/fx_rate/fx_date alongside it so the UI can show "11.15 USD ->
+  // 4014 HUF" instead of just the converted number. NULL for lines that were never
+  // converted (already-HUF entries) -- never fabricated, no existing calc touched.
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN original_amount REAL`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN original_currency TEXT`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN fx_rate REAL`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN fx_date INTEGER`) } catch { /* already exists */ }
+  // v0.8: distinguishes "we queried the provider API live" (provider_api) from
+  // "we read an email invoice" (email_invoice) from "config-driven fixed cost" (manual_entry) --
+  // neither `confidence` (the priority/authoritativeness axis) nor `cost_sources.source_type`
+  // (a category axis) cleanly carries this. Nullable, no default: every write site sets it
+  // explicitly; a NULL row (pre-migration history) falls back to 'no_data' at read time, never guessed.
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN actual_source TEXT`) } catch { /* already exists */ }
+  // CostOps Phase 0: a financial ledger row must never silently disappear --
+  // void/archive instead of hard DELETE, so a mistaken/superseded manual entry
+  // stays auditable. NULL = active (the overwhelming majority of rows, including
+  // all pre-Phase-0 history); every read path that aggregates cost_line_items
+  // must filter `voided_at IS NULL`.
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN voided_at INTEGER`) } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN void_reason TEXT`) } catch { /* already exists */ }
+  // A correction voids the wrong row AND inserts a new row pointing back at it
+  // via corrects_line_id, so "what replaced this, and why" stays traceable
+  // instead of two unrelated void+POST rows correlated only by matching
+  // source_id/month/timing. See correction.ts.
+  try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN corrects_line_id INTEGER REFERENCES cost_line_items(id)`) } catch { /* already exists */ }
+  // Phase 1 (GAP-09): fx_source/conversion_method columns + fx_rates table
+  initFxSchema(db)
+  // Phase 1 (GAP-10): forecast_snapshots table
+  initForecastSchema(db)
+  // CostOps v0.3: provider cost-collector run history / sync status. No raw
+  // account id, no raw API response, no secret ever stored here.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS import_runs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      collector_name TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      finished_at INTEGER,
+      status TEXT NOT NULL,
+      period_start INTEGER,
+      period_end INTEGER,
+      imported_count INTEGER NOT NULL DEFAULT 0,
+      error_code TEXT,
+      error_message_sanitized TEXT,
+      data_freshness_at INTEGER
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_import_runs_provider ON import_runs(provider, started_at)`)
+  // v0.5: sanitized per-run detail (service_count, plan breakdown, not_covered) as JSON.
+  // NO raw service/account IDs -- the breakdown carries only type/plan labels + counts.
+  try { db.exec(`ALTER TABLE import_runs ADD COLUMN detail_json TEXT`) } catch { /* already exists */ }
+  // CostOps: provider prepaid-balance snapshots. For prepaid providers (e.g.
+  // DeepSeek) that expose remaining balance but not per-period cost, MTD spend
+  // is derived from the balance DROP across snapshots. No secret, no raw id.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS provider_balance_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      currency TEXT NOT NULL,
+      balance REAL NOT NULL,
+      captured_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_balance_snapshots_provider ON provider_balance_snapshots(provider, captured_at)`)
+}

--- a/src/costops/schema.ts
+++ b/src/costops/schema.ts
@@ -11,6 +11,7 @@
 import type Database from 'better-sqlite3'
 import { initForecastSchema } from './forecast.js'
 import { initFxSchema } from './fx.js'
+import { initAlertsSchema } from './alerts.js'
 
 export function initCostOpsSchema(db: Database.Database): void {
   // CostOps v0.2: model/provider enrichment on the CORE token_usage table

--- a/src/costops/schema.ts
+++ b/src/costops/schema.ts
@@ -2,20 +2,24 @@
 // statements live here, not in src/db.ts. This is the "schema" seam: db.ts
 // owns exactly one call, `initCostOpsSchema(db)`, marked
 // `// LOCAL-FORK: costops seam`. Every table
-// this feature has ever added (v0.1 through PR-B) is consolidated here,
+// this feature has ever added (v0.1 through Phase 0) is consolidated here,
 // verbatim, so the upstream-owned db.ts stops growing a table per CostOps
 // release. Idempotent by construction (CREATE TABLE IF NOT EXISTS, ALTER
 // TABLE wrapped in try/catch) -- calling this on an already-migrated DB is a
 // safe no-op, exactly like the individual statements were before the move.
 
 import type Database from 'better-sqlite3'
-import { initForecastSchema } from './forecast.js'
 import { initFxSchema } from './fx.js'
 import { initAlertsSchema } from './alerts.js'
+import { initForecastSchema } from './forecast.js'
+import { initPeriodCloseSchema } from './period-close.js'
+import { initBudgetAuditSchema } from './budgets.js'
+import { initOptimizationSchema } from './optimization.js'
+import { initInvoiceSchema } from './invoice.js'
 
 export function initCostOpsSchema(db: Database.Database): void {
   // CostOps v0.2: model/provider enrichment on the CORE token_usage table
-  // (not CostOps-owned, but this feature bolts 2 nullable columns onto it for
+  // (not CostOps-owned, but this feature bolts 3 nullable columns onto it for
   // token-cost estimation). Nullable + forward-only: NEW ingested rows carry
   // the model from the transcript; existing rows stay NULL (unknown) -> left
   // unpriced, never guessed. Must run after token_usage itself exists --
@@ -25,14 +29,8 @@ export function initCostOpsSchema(db: Database.Database): void {
   try { db.exec(`ALTER TABLE token_usage ADD COLUMN model_source TEXT`) } catch { /* column already exists */ }
   // --- CostOps (local cost ledger, v0.1) ---
   // Read-mostly, FOCUS-inspired. cost_sources = provider/subscription origin,
-  // cost_line_items = individual charge rows (estimate or provider-sourced).
-  // No secrets/account IDs stored raw. Budgets are config-driven (costops/config.ts's
-  // BudgetEntry, from store/costops-config.json) -- there is deliberately no separate
-  // `budgets` DB table: an earlier draft of this schema had one, but it was never
-  // read from or written to (config.budgets was always the actual source), so it was
-  // a dead, unused second source of truth. Removed rather than wired up, since the
-  // config file already covers this fully and a DB table would just be a sync burden
-  // for no benefit.
+  // cost_line_items = individual charge rows (estimate or provider-sourced),
+  // budgets = display-only warning thresholds. No secrets/account IDs stored raw.
   db.exec(`
     CREATE TABLE IF NOT EXISTS cost_sources (
       id TEXT PRIMARY KEY,
@@ -70,37 +68,38 @@ export function initCostOpsSchema(db: Database.Database): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_period ON cost_line_items(charge_period_start, charge_period_end)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_source ON cost_line_items(source_id)`)
-  // Currency-retention (Phase-3 per spec): when a line's billed_cost is
-  // HUF-converted from a foreign-currency invoice, keep the original
-  // amount/currency/fx_rate/fx_date alongside it so the UI can show "11.15 USD ->
-  // 4014 HUF" instead of just the converted number. NULL for lines that were never
-  // converted (already-HUF entries) -- never fabricated, no existing calc touched.
+  // v0.7 currency-retention (additive): when a line's billed_cost is HUF-converted
+  // from a foreign-currency invoice, keep the original amount/currency/fx_rate/fx_date
+  // alongside it so the UI can show the conversion. NULL for already-HUF entries.
   try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN original_amount REAL`) } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN original_currency TEXT`) } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN fx_rate REAL`) } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN fx_date INTEGER`) } catch { /* already exists */ }
-  // v0.8: distinguishes "we queried the provider API live" (provider_api) from
-  // "we read an email invoice" (email_invoice) from "config-driven fixed cost" (manual_entry) --
-  // neither `confidence` (the priority/authoritativeness axis) nor `cost_sources.source_type`
-  // (a category axis) cleanly carries this. Nullable, no default: every write site sets it
-  // explicitly; a NULL row (pre-migration history) falls back to 'no_data' at read time, never guessed.
+  // v0.8: distinguishes provider API live query from email invoice from config-driven
+  // manual entry. Nullable, no default: every write site sets it explicitly.
   try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN actual_source TEXT`) } catch { /* already exists */ }
-  // CostOps Phase 0: a financial ledger row must never silently disappear --
-  // void/archive instead of hard DELETE, so a mistaken/superseded manual entry
-  // stays auditable. NULL = active (the overwhelming majority of rows, including
-  // all pre-Phase-0 history); every read path that aggregates cost_line_items
-  // must filter `voided_at IS NULL`.
+  // Phase 0: a financial ledger row must never silently disappear -- void/archive
+  // instead of hard DELETE, so a mistaken/superseded manual entry stays auditable.
   try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN voided_at INTEGER`) } catch { /* already exists */ }
   try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN void_reason TEXT`) } catch { /* already exists */ }
-  // A correction voids the wrong row AND inserts a new row pointing back at it
-  // via corrects_line_id, so "what replaced this, and why" stays traceable
-  // instead of two unrelated void+POST rows correlated only by matching
-  // source_id/month/timing. See correction.ts.
+  // Phase 1 (GAP-05/GAP-06/GAP-14): correction chain -- a correction voids the wrong
+  // row and inserts a new row pointing back at it via corrects_line_id.
   try { db.exec(`ALTER TABLE cost_line_items ADD COLUMN corrects_line_id INTEGER REFERENCES cost_line_items(id)`) } catch { /* already exists */ }
-  // Phase 1 (GAP-09): fx_source/conversion_method columns + fx_rates table
+  // Phase 1 (GAP-09): fx_source/conversion_method columns + fx_rates history table.
   initFxSchema(db)
-  // Phase 1 (GAP-10): forecast_snapshots table
+  // Phase 3 (GAP-12): costops_alerts lifecycle table.
+  initAlertsSchema(db)
+  // Phase 1 (GAP-10): forecast_snapshots table. FK to cost_sources(id).
   initForecastSchema(db)
+  // Phase 2 (GAP-13): period_status/period_close_events -- monthly close workflow.
+  initPeriodCloseSchema(db)
+  // Phase 3 (GAP-11): budget change audit trail.
+  initBudgetAuditSchema(db)
+  // Phase 4: optimization recommendations persistence.
+  initOptimizationSchema(db)
+  // Phase 1: invoice/credit/refund/correction workflow tables.
+  initInvoiceSchema(db)
+
   // CostOps v0.3: provider cost-collector run history / sync status. No raw
   // account id, no raw API response, no secret ever stored here.
   db.exec(`
@@ -120,12 +119,18 @@ export function initCostOpsSchema(db: Database.Database): void {
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_import_runs_provider ON import_runs(provider, started_at)`)
-  // v0.5: sanitized per-run detail (service_count, plan breakdown, not_covered) as JSON.
-  // NO raw service/account IDs -- the breakdown carries only type/plan labels + counts.
+  // v0.5: sanitized per-run detail (service_count, plan breakdown) as JSON.
   try { db.exec(`ALTER TABLE import_runs ADD COLUMN detail_json TEXT`) } catch { /* already exists */ }
+  // Phase 1 (GAP-07): per-provider import lock for concurrent sync safety.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS import_locks (
+      provider TEXT PRIMARY KEY,
+      locked_at INTEGER NOT NULL,
+      lock_token TEXT NOT NULL
+    )
+  `)
   // CostOps: provider prepaid-balance snapshots. For prepaid providers (e.g.
-  // DeepSeek) that expose remaining balance but not per-period cost, MTD spend
-  // is derived from the balance DROP across snapshots. No secret, no raw id.
+  // DeepSeek) that expose remaining balance but not per-period cost.
   db.exec(`
     CREATE TABLE IF NOT EXISTS provider_balance_snapshots (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -136,4 +141,90 @@ export function initCostOpsSchema(db: Database.Database): void {
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_balance_snapshots_provider ON provider_balance_snapshots(provider, captured_at)`)
+  // CostOps: provider rate-limit / quota-usage snapshots.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS provider_ratelimit_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      limit_id TEXT,
+      used_percent REAL NOT NULL,
+      window_duration_mins INTEGER,
+      resets_at INTEGER,
+      plan_type TEXT,
+      captured_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_ratelimit_snapshots_provider ON provider_ratelimit_snapshots(provider, captured_at)`)
+  // CostOps Phase 0: 7-day source-reliability observation window snapshots.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS costops_reliability_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      captured_at INTEGER NOT NULL,
+      source_count INTEGER NOT NULL,
+      inventory_json TEXT NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_reliability_snapshots_captured ON costops_reliability_snapshots(captured_at)`)
+  // v0.7/v2: Google Workspace payment-failure/suspension signal.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workspace_alerts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      account TEXT NOT NULL,
+      issue_type TEXT NOT NULL,
+      detected_at INTEGER NOT NULL,
+      message_ref TEXT,
+      dedup_key TEXT UNIQUE,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_workspace_alerts_account ON workspace_alerts(account, detected_at)`)
+  try { db.exec(`ALTER TABLE workspace_alerts ADD COLUMN suspension_date INTEGER`) } catch { /* already exists */ }
+  // CostOps v1.0: included-usage/entitlement model. Kept SEPARATE from
+  // cost_line_items -- included usage must never leak into operational_spend.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS entitlements (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      product TEXT NOT NULL,
+      plan_name TEXT,
+      billing_period TEXT NOT NULL,
+      entitlement_type TEXT NOT NULL,
+      included_limit REAL,
+      included_unit TEXT,
+      usage_to_date REAL,
+      remaining REAL,
+      usage_pct REAL,
+      reset_at INTEGER,
+      usage_source TEXT NOT NULL,
+      usage_confidence TEXT,
+      forecast_usage_period_end REAL,
+      forecast_exhaustion_at INTEGER,
+      overage_supported INTEGER NOT NULL DEFAULT 0,
+      overage_unit_price REAL,
+      forecast_overage_quantity REAL,
+      forecast_overage_cost REAL,
+      status TEXT NOT NULL,
+      dedup_key TEXT UNIQUE,
+      last_updated INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_entitlements_provider ON entitlements(provider, product)`)
+  // Budgets table -- per-budget scope/amount/threshold.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS budgets (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'global',
+      scope_ref TEXT,
+      period TEXT NOT NULL DEFAULT 'monthly',
+      amount REAL NOT NULL,
+      currency TEXT NOT NULL DEFAULT 'HUF',
+      warning_threshold REAL NOT NULL DEFAULT 0.8,
+      hard_threshold REAL NOT NULL DEFAULT 1.0,
+      active INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `)
 }

--- a/src/costops/schema.ts
+++ b/src/costops/schema.ts
@@ -1,7 +1,7 @@
 // CostOps schema -- ALL CostOps CREATE TABLE / ALTER TABLE / CREATE INDEX
-// statements live here, not in src/db.ts. This is the "schema" seam
-// (docs/fork-upstream-policy.md §2a): db.ts owns exactly one call,
-// `initCostOpsSchema(db)`, marked `// LOCAL-FORK: costops seam`. Every table
+// statements live here, not in src/db.ts. This is the "schema" seam: db.ts
+// owns exactly one call, `initCostOpsSchema(db)`, marked
+// `// LOCAL-FORK: costops seam`. Every table
 // this feature has ever added (v0.1 through PR-B) is consolidated here,
 // verbatim, so the upstream-owned db.ts stops growing a table per CostOps
 // release. Idempotent by construction (CREATE TABLE IF NOT EXISTS, ALTER

--- a/src/costops/subscriptions.ts
+++ b/src/costops/subscriptions.ts
@@ -1,0 +1,195 @@
+// CostOps v0.7 -- subscription lifecycle.
+//
+// Per-subscription active/canceled/paid_until/next_renewal facts, loaded from
+// store/costops-subscriptions.json (gitignored, same convention as
+// costops-config.json -- real dates/amounts never enter a tracked file). This
+// module is pure I/O + derived-field computation. No Gmail access, no secrets,
+// no raw email/PII -- the facts here are already-extracted structured data.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+import { logger } from '../logger.js'
+
+export const SUBSCRIPTIONS_PATH = join(PROJECT_ROOT, 'store', 'costops-subscriptions.json')
+export const SUBSCRIPTIONS_EXAMPLE_PATH = join(PROJECT_ROOT, 'store', 'costops-subscriptions.json.example')
+
+export type SubscriptionStatus = 'active' | 'canceled' | 'expired' | 'unknown'
+export type AmountSource = 'invoice' | 'manual_fallback' | 'no_invoice_found' | 'pending_permission'
+
+export interface SubscriptionEntry {
+  id: string
+  name: string
+  provider: string
+  source: string             // where the lifecycle fact came from, e.g. 'google_play' | 'anthropic' | 'openai'
+  status: SubscriptionStatus
+  paid_until?: string        // 'YYYY-MM-DD', renews-then-ends date if canceled
+  next_renewal?: string      // 'YYYY-MM-DD', next charge/renewal date if active
+  amount?: number            // per-period amount, omitted entirely if unknown (never 0-fabricated)
+  currency?: string
+  amount_source: AmountSource
+  notes?: string
+  // v0.8 (card 6f4d1332 §5): optional real ceiling, only if the operator supplies one. No official
+  // Claude Max/ChatGPT quota API exists (checked) -- absent, limits.ts reports the usage
+  // honestly as 'unknown' rather than inventing a number. Config-schema-only addition.
+  weekly_limit_tokens?: number
+  five_hour_limit_tokens?: number
+  // Card 2ed90db1: Claude session/weekly usage as a manual snapshot -- the operator occasionally
+  // reads this off the Claude usage screen and shares it. There is no absolute token ceiling
+  // behind this (Anthropic exposes percent-of-limit only), so this is percent + a raw reset
+  // label, never a derived/fabricated token count.
+  usage_snapshot?: UsageSnapshot
+}
+
+export interface UsageSnapshot {
+  as_of: string                // ISO datetime this snapshot was captured/reported (manual, not live-polled)
+  session_pct: number          // 0..100, current 5-hour session window usage
+  weekly_pct: number           // 0..100, weekly (all models) usage -- this is what the 80% alert rule watches
+  // Raw label as given (e.g. 'Tue 08:59'), NOT parsed into a computed calendar date -- the
+  // reset's timezone and exact cadence aren't confirmed, so showing the verbatim fact the operator
+  // reported beats silently guessing a specific date and risking it being wrong.
+  weekly_reset_label: string
+  fable_pct?: number           // optional, Fable-specific weekly % if reported (0 in the first snapshot)
+}
+
+export interface SubscriptionsConfig {
+  version: number
+  subscriptions: SubscriptionEntry[]
+}
+
+const EMPTY: SubscriptionsConfig = { version: 1, subscriptions: [] }
+
+const EXAMPLE_CONFIG = {
+  version: 1,
+  _doc: 'CostOps v0.7 subscription lifecycle facts. Copy to store/costops-subscriptions.json. paid_until/next_renewal are ISO dates (YYYY-MM-DD). amount is omitted (not 0) when genuinely unknown -- set amount_source accordingly. usage_snapshot (card 2ed90db1) is an OPTIONAL manual reading off a Claude usage screen -- percent + a raw reset label only, never a derived token count; weekly_pct is what feeds the 80% alert.',
+  subscriptions: [
+    { id: 'claude-pro-google-play', name: 'Claude Pro', provider: 'anthropic', source: 'google_play', status: 'canceled', paid_until: '2026-07-16', amount_source: 'invoice', notes: 'cancellation notice received; active until paid_until, then ends' },
+    {
+      id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source: 'anthropic', status: 'active', next_renewal: '2026-07-20', amount_source: 'manual_fallback', notes: 'no invoice amount available yet',
+      usage_snapshot: { as_of: '2026-07-08T21:00:00+02:00', session_pct: 5, weekly_pct: 19, weekly_reset_label: 'Tue 08:59', fable_pct: 0 },
+    },
+    { id: 'openai-chatgpt', name: 'ChatGPT Plus', provider: 'openai', source: 'openai', status: 'active', amount_source: 'no_invoice_found' },
+  ],
+}
+
+export interface SubscriptionsLoadResult {
+  config: SubscriptionsConfig
+  exists: boolean
+  errors: string[]
+}
+
+export function loadSubscriptionsConfig(): SubscriptionsLoadResult {
+  if (!existsSync(SUBSCRIPTIONS_PATH)) {
+    ensureExampleSubscriptions()
+    return { config: { ...EMPTY }, exists: false, errors: [] }
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(SUBSCRIPTIONS_PATH, 'utf-8'))
+  } catch (err) {
+    logger.warn({ err }, 'costops-subscriptions.json is not valid JSON')
+    return { config: { ...EMPTY }, exists: true, errors: ['config is not valid JSON'] }
+  }
+  return validateSubscriptionsConfig(raw)
+}
+
+export function ensureExampleSubscriptions(): void {
+  try {
+    if (!existsSync(SUBSCRIPTIONS_EXAMPLE_PATH)) {
+      writeFileSync(SUBSCRIPTIONS_EXAMPLE_PATH, JSON.stringify(EXAMPLE_CONFIG, null, 2) + '\n', 'utf-8')
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to write costops-subscriptions example')
+  }
+}
+
+const VALID_STATUS = new Set(['active', 'canceled', 'expired', 'unknown'])
+const VALID_AMOUNT_SOURCE = new Set(['invoice', 'manual_fallback', 'no_invoice_found', 'pending_permission'])
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+export function validateSubscriptionsConfig(raw: unknown): SubscriptionsLoadResult {
+  const errors: string[] = []
+  const obj = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const rawSubs = Array.isArray(obj.subscriptions) ? obj.subscriptions : []
+  const subscriptions: SubscriptionEntry[] = []
+  for (const [i, e] of rawSubs.entries()) {
+    const s = e as Record<string, unknown>
+    if (typeof s?.id !== 'string' || !s.id) { errors.push(`subscriptions[${i}]: missing id`); continue }
+    if (typeof s?.name !== 'string' || !s.name) { errors.push(`subscriptions[${i}] (${s.id}): missing name`); continue }
+    const status = VALID_STATUS.has(s.status as string) ? s.status as SubscriptionStatus : 'unknown'
+    const amount_source = VALID_AMOUNT_SOURCE.has(s.amount_source as string) ? s.amount_source as AmountSource : 'no_invoice_found'
+    if (s.paid_until !== undefined && !ISO_DATE.test(s.paid_until as string)) { errors.push(`subscriptions[${i}] (${s.id}): paid_until must be YYYY-MM-DD`); continue }
+    if (s.next_renewal !== undefined && !ISO_DATE.test(s.next_renewal as string)) { errors.push(`subscriptions[${i}] (${s.id}): next_renewal must be YYYY-MM-DD`); continue }
+    if (s.amount !== undefined && (typeof s.amount !== 'number' || !isFinite(s.amount as number) || (s.amount as number) < 0)) {
+      errors.push(`subscriptions[${i}] (${s.id}): amount must be a non-negative number when present`); continue
+    }
+    if (s.weekly_limit_tokens !== undefined && (typeof s.weekly_limit_tokens !== 'number' || !isFinite(s.weekly_limit_tokens as number) || (s.weekly_limit_tokens as number) < 0)) {
+      errors.push(`subscriptions[${i}] (${s.id}): weekly_limit_tokens must be a non-negative number when present`); continue
+    }
+    if (s.five_hour_limit_tokens !== undefined && (typeof s.five_hour_limit_tokens !== 'number' || !isFinite(s.five_hour_limit_tokens as number) || (s.five_hour_limit_tokens as number) < 0)) {
+      errors.push(`subscriptions[${i}] (${s.id}): five_hour_limit_tokens must be a non-negative number when present`); continue
+    }
+    // Malformed usage_snapshot is dropped (not fatal to the whole subscription entry) -- a typo
+    // in a manually-pasted snapshot shouldn't lose the subscription's active/canceled status.
+    const usage_snapshot = parseUsageSnapshot(s.usage_snapshot)
+    subscriptions.push({
+      id: s.id, name: s.name,
+      provider: typeof s.provider === 'string' ? s.provider : 'other',
+      source: typeof s.source === 'string' ? s.source : 'unknown',
+      status,
+      paid_until: typeof s.paid_until === 'string' ? s.paid_until : undefined,
+      next_renewal: typeof s.next_renewal === 'string' ? s.next_renewal : undefined,
+      amount: typeof s.amount === 'number' ? s.amount : undefined,
+      currency: typeof s.currency === 'string' ? s.currency : undefined,
+      amount_source,
+      notes: typeof s.notes === 'string' ? s.notes : undefined,
+      weekly_limit_tokens: typeof s.weekly_limit_tokens === 'number' ? s.weekly_limit_tokens : undefined,
+      five_hour_limit_tokens: typeof s.five_hour_limit_tokens === 'number' ? s.five_hour_limit_tokens : undefined,
+      usage_snapshot,
+    })
+  }
+  return { config: { version: typeof obj.version === 'number' ? obj.version : 1, subscriptions }, exists: true, errors }
+}
+
+function isPct(v: unknown): v is number {
+  return typeof v === 'number' && isFinite(v) && v >= 0 && v <= 100
+}
+
+function parseUsageSnapshot(raw: unknown): UsageSnapshot | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const u = raw as Record<string, unknown>
+  if (typeof u.as_of !== 'string' || isNaN(Date.parse(u.as_of))) return undefined
+  if (!isPct(u.session_pct) || !isPct(u.weekly_pct)) return undefined
+  if (typeof u.weekly_reset_label !== 'string' || !u.weekly_reset_label) return undefined
+  return {
+    as_of: u.as_of,
+    session_pct: u.session_pct,
+    weekly_pct: u.weekly_pct,
+    weekly_reset_label: u.weekly_reset_label,
+    fable_pct: isPct(u.fable_pct) ? u.fable_pct : undefined,
+  }
+}
+
+export interface SubscriptionLifecycle extends SubscriptionEntry {
+  days_until_next_date: number | null  // to paid_until (if canceled) or next_renewal (if active); null if neither present
+  past_due: boolean                    // next_renewal/paid_until date has passed with no corresponding invoice update
+}
+
+/**
+ * Derive lifecycle display fields (days remaining, past-due flag) from the
+ * static config facts + `now`. Pure function -- no I/O, no DB.
+ */
+export function deriveLifecycle(config: SubscriptionsConfig, now: number): SubscriptionLifecycle[] {
+  const nowDay = Math.floor(now / 86400)
+  return config.subscriptions.map(s => {
+    const targetDate = s.status === 'canceled' ? s.paid_until : s.next_renewal
+    let days_until_next_date: number | null = null
+    let past_due = false
+    if (targetDate && ISO_DATE.test(targetDate)) {
+      const targetDay = Math.floor(Date.parse(`${targetDate}T00:00:00Z`) / 1000 / 86400)
+      days_until_next_date = targetDay - nowDay
+      past_due = s.status === 'active' && days_until_next_date < 0
+    }
+    return { ...s, days_until_next_date, past_due }
+  })
+}

--- a/src/costops/warnings.ts
+++ b/src/costops/warnings.ts
@@ -1,0 +1,309 @@
+// CostOps v0.7 -- deterministic warnings.
+//
+// Pure derivation from an already-computed CostSummary + subscription
+// lifecycle + a direct read-only query for pending_permission sources. No
+// LLM, no network, no new writes. Every rule is a plain threshold check --
+// same warning inputs always produce the same warnings array.
+
+import type Database from 'better-sqlite3'
+import type { CostOpsConfig } from './config.js'
+import type { CostSummary } from './ledger.js'
+import { monthWindow } from './ledger.js'
+import type { SubscriptionLifecycle } from './subscriptions.js'
+import type { LimitStatus } from './limits.js'
+
+// v0.8 (card 6f4d1332 §6): widened from 'low'|'medium'|'high' to add 'critical'|'blocked' for
+// the new generic tiered limit rule (§4 of the requirements is explicit that an 80%+ limit MUST
+// alert, and a plain 3-tier scale can't distinguish "at 90%, urgent" from "at 100%, actually
+// blocked"). Plain TS union, no DB CHECK constraint -- safe additive change, every existing
+// warning (all still 'low'|'medium'|'high') keeps working unmodified.
+export type WarningSeverity = 'low' | 'medium' | 'high' | 'critical' | 'blocked'
+
+// v0.7/v2 typed extension (card bea78483). Additive on top of the original
+// {code,severity,provider,message,detail} shape -- every existing rule keeps
+// working, these fields are populated wherever meaningful and left undefined
+// otherwise (never fabricated, e.g. a warning with no natural threshold has
+// no `threshold` field rather than a made-up one).
+export type WarningType = 'cost' | 'quota' | 'expiry' | 'access'
+export type WarningConfidence = 'measured' | 'estimated' | 'manual' | 'no_api_or_no_access'
+
+export interface CostWarning {
+  code: string
+  severity: WarningSeverity
+  provider: string
+  message: string
+  detail?: unknown
+  warning_type: WarningType
+  category: string       // 'hosting' | 'ai' | 'productivity' | 'domains' | 'budget' | 'other'
+  action?: string         // human next-step suggestion
+  threshold?: number
+  current_value?: number
+  unit?: string           // '%' | 'day' | 'HUF' | ...
+  due_date?: string       // ISO date -- expected charge/renewal
+  reset_date?: string     // ISO date/datetime -- quota reset
+  expiry_date?: string    // ISO date -- cert/domain expiry
+  source: string          // 'ledger' | 'config' | 'render_api' | 'workspace_alert' | 'tls' | 'rdap'
+  confidence: WarningConfidence
+}
+
+// Card bea78483's UI drill-down mapping: Render->hosting, Claude/DeepSeek/Google
+// AI->ai, Google Workspace->productivity, Domain/SSL->domains. Shared by every
+// rule so old and new warnings categorize consistently.
+export function categoryForProvider(provider: string): string {
+  const p = provider.toLowerCase()
+  if (p === 'render' || p === 'vercel' || p === 'cloudflare') return 'hosting'
+  if (p === 'anthropic' || p === 'openai' || p === 'deepseek' || p === 'google-ai') return 'ai'
+  if (p === 'google-workspace' || p === 'workspace') return 'productivity'
+  if (p === 'domain' || p === 'ssl' || p === 'dns') return 'domains'
+  if (p === 'all') return 'budget'
+  return 'other'
+}
+
+// A provider/source change or manual-fallback share below this fraction of
+// operational spend is noise, not a warning -- keeps the list actionable.
+const MATERIAL_FRACTION = 0.15
+
+// v0.8 (card 6f4d1332 §6): threshold ladder for the generic tiered limit rule, mapping
+// LimitStatus.usage_pct (fraction consumed) to a warning severity. 80%+ is mandatory per
+// requirements §4; the medium tier is added for earlier visibility, not requirements-mandated.
+const LIMIT_TIERS: Array<[number, WarningSeverity]> = [
+  [1.0, 'blocked'], [0.9, 'critical'], [0.8, 'high'], [0.7, 'medium'],
+]
+
+export function getWarnings(
+  db: Database.Database,
+  _config: CostOpsConfig,
+  now: number,
+  summary: CostSummary,
+  subscriptions: SubscriptionLifecycle[],
+  // v0.8 (card 6f4d1332 §6): optional so every existing call site keeps compiling/behaving
+  // identically without passing it -- omitted, the new tiered-limit rule below is simply skipped
+  // (no fabricated data), same "degrade gracefully" convention as configExists/pricingExists.
+  limits: LimitStatus[] = [],
+): CostWarning[] {
+  const warnings: CostWarning[] = []
+
+  // 1. forecast vs budget -- reuse the already-computed budget.status (operational-based).
+  if (summary.budget && summary.budget.status !== 'ok') {
+    warnings.push({
+      code: 'forecast_over_budget',
+      severity: summary.budget.status === 'hard' ? 'high' : 'medium',
+      provider: 'all',
+      message: summary.budget.status === 'hard'
+        ? `Havi büdzsé túllépve vagy azon: ${Math.round(summary.budget.operational_used_pct * 100)}% elköltve.`
+        : `Előrejelzés a büdzsé ${Math.round(summary.budget.operational_forecast_pct * 100)}%-át éri el hónap végére.`,
+      detail: { used_pct: summary.budget.operational_used_pct, forecast_pct: summary.budget.operational_forecast_pct, threshold: summary.budget.warning_threshold },
+      warning_type: 'cost', category: 'budget', source: 'ledger', confidence: 'measured',
+      threshold: Math.round(summary.budget.warning_threshold * 100), current_value: Math.round(summary.budget.operational_used_pct * 100), unit: '%',
+      action: summary.budget.status === 'hard' ? 'Csökkentsd a költést vagy emeld a büdzsét.' : 'Kövesd a hónap hátralévő részét, közel a limithez.',
+    })
+  }
+
+  // 2. provider sync stale / failed.
+  for (const p of summary.provider_sync) {
+    if (p.status === 'failed') {
+      warnings.push({
+        code: 'provider_sync_failed', severity: 'medium', provider: p.provider,
+        message: `${p.provider} szinkron sikertelen (${p.error_code ?? 'ismeretlen hiba'}).`,
+        detail: { last_success: p.last_success, error_code: p.error_code },
+        warning_type: 'access', category: categoryForProvider(p.provider), source: 'ledger', confidence: 'measured',
+        action: 'Ellenőrizd a szolgáltató API-kulcsát/jogosultságát.',
+      })
+    } else if (p.stale) {
+      warnings.push({
+        code: 'provider_sync_stale', severity: 'low', provider: p.provider,
+        message: `${p.provider} adat elavult (${Math.round((p.data_age_secs ?? 0) / 86400)} napja nem szinkronizált).`,
+        detail: { data_age_secs: p.data_age_secs, last_sync: p.last_sync },
+        warning_type: 'access', category: categoryForProvider(p.provider), source: 'ledger', confidence: 'measured',
+        current_value: Math.round((p.data_age_secs ?? 0) / 86400), unit: 'day',
+      })
+    }
+  }
+
+  // 3. expected invoice missing -- a subscription past its next charge date with no update.
+  for (const s of subscriptions) {
+    if (s.past_due) {
+      warnings.push({
+        code: 'expected_invoice_missing', severity: 'medium', provider: s.provider,
+        message: `${s.name}: várt számla/díjterhelés (${s.next_renewal}) elmúlt, nincs friss adat.`,
+        detail: { subscription_id: s.id, next_renewal: s.next_renewal, days_overdue: s.days_until_next_date !== null ? -s.days_until_next_date : null },
+        warning_type: 'expiry', category: categoryForProvider(s.provider), source: 'config', confidence: 'manual',
+        due_date: s.next_renewal, current_value: s.days_until_next_date !== null ? -s.days_until_next_date : undefined, unit: 'day',
+      })
+    }
+  }
+
+  // 4. high-cost provider still on manual fallback (material share of operational spend).
+  const totalOp = summary.operational_spend || 0
+  if (totalOp > 0) {
+    for (const src of summary.all_sources) {
+      // v0.8: spend is null for a pending_permission source (never a fabricated 0) -- excluded
+      // here by construction (its confidence is 'pending_permission', not manual/estimate), but
+      // the null check makes that explicit for the type checker too.
+      const isFallback = src.spend != null && (src.confidence === 'manual' || src.confidence === 'estimate')
+      if (isFallback && src.spend! / totalOp >= MATERIAL_FRACTION) {
+        warnings.push({
+          code: 'high_cost_manual_fallback', severity: 'low', provider: src.provider,
+          message: `${src.name}: a költség jelentős hányada (${Math.round((src.spend! / totalOp) * 100)}%) kézi/becsült adaton alapul, nincs valódi számla/API forrás.`,
+          detail: { source_id: src.source_id, spend: src.spend, share: Math.round((src.spend! / totalOp) * 100) / 100 },
+          warning_type: 'cost', category: categoryForProvider(src.provider), source: 'ledger', confidence: 'estimated',
+          current_value: Math.round((src.spend! / totalOp) * 100), threshold: Math.round(MATERIAL_FRACTION * 100), unit: '%',
+        })
+      }
+    }
+  }
+
+  // 5. plan estimate materially differs from actual/manual (Render render_plan block).
+  if (summary.render_plan) {
+    const base = summary.render_plan.manual_estimate || summary.render_plan.plan_estimate_total || 1
+    if (Math.abs(summary.render_plan.variance) / base >= MATERIAL_FRACTION) {
+      warnings.push({
+        code: 'plan_estimate_variance', severity: 'low', provider: 'render',
+        message: `Render terv-alapú becslés (${summary.render_plan.plan_estimate_total}) jelentősen eltér a kézi becsléstől (${summary.render_plan.manual_estimate}).`,
+        detail: { plan_estimate_total: summary.render_plan.plan_estimate_total, manual_estimate: summary.render_plan.manual_estimate, variance: summary.render_plan.variance },
+        warning_type: 'cost', category: 'hosting', source: 'ledger', confidence: 'estimated',
+        current_value: summary.render_plan.plan_estimate_total, unit: summary.render_plan.currency,
+      })
+    }
+  }
+
+  // 6. invoice amount materially changed vs previous month, per provider.
+  if (summary.previous_month) {
+    const prevByProvider = new Map(summary.previous_month.by_provider.map(p => [p.provider, p.spend]))
+    for (const cur of summary.operational.provider_breakdown) {
+      const prev = prevByProvider.get(cur.provider)
+      if (prev !== undefined && prev > 0 && Math.abs(cur.spend - prev) / prev >= MATERIAL_FRACTION) {
+        warnings.push({
+          code: 'invoice_amount_changed', severity: 'low', provider: cur.provider,
+          message: `${cur.provider}: ${prev} -> ${cur.spend} (${Math.round(((cur.spend - prev) / prev) * 100)}% változás az előző hónaphoz képest).`,
+          detail: { previous: prev, current: cur.spend },
+          warning_type: 'cost', category: categoryForProvider(cur.provider), source: 'ledger', confidence: 'measured',
+          current_value: cur.spend, unit: summary.currency,
+        })
+      }
+    }
+  }
+
+  // 6b. v0.8 (card 6f4d1332 §6.3): large INCREASE vs previous month, per provider -- distinct
+  // from rule 6 above (any material CHANGE, either direction, 15% threshold, low severity,
+  // informational). This is one-directional (increase only) with a higher, more urgent
+  // threshold. 50% is a recommendation, not business-specified (flagged, same treatment as the
+  // Eskuvő bundle-discount placeholder earlier this session) -- tune once real data exists.
+  const LARGE_INCREASE_FRACTION = 0.5
+  if (summary.previous_month) {
+    const prevByProvider = new Map(summary.previous_month.by_provider.map(p => [p.provider, p.spend]))
+    for (const cur of summary.operational.provider_breakdown) {
+      const prev = prevByProvider.get(cur.provider)
+      if (prev !== undefined && prev > 0 && (cur.spend - prev) / prev >= LARGE_INCREASE_FRACTION) {
+        warnings.push({
+          code: 'large_increase_vs_previous_month', severity: 'medium', provider: cur.provider,
+          message: `${cur.provider}: jelentős növekedés az előző hónaphoz képest (${prev} -> ${cur.spend}, +${Math.round(((cur.spend - prev) / prev) * 100)}%).`,
+          detail: { previous: prev, current: cur.spend, threshold_fraction: LARGE_INCREASE_FRACTION },
+          warning_type: 'cost', category: categoryForProvider(cur.provider), source: 'ledger', confidence: 'measured',
+          current_value: cur.spend, threshold: Math.round(LARGE_INCREASE_FRACTION * 100), unit: '%',
+          action: 'Nézd meg, mi okozta a növekedést -- új szolgáltatás, plan-váltás, vagy anomália.',
+        })
+      }
+    }
+  }
+
+  // 7. billing_access_needed -- a tracked provider whose cost cannot currently be read
+  // (v0.7 AWS addendum: confidence='pending_permission', never fabricated as 0/manual).
+  const win = monthWindow(now, summary.month)
+  const pendingRows = db.prepare(`
+    SELECT DISTINCT cs.id as source_id, cs.name, cs.provider
+    FROM cost_line_items cli JOIN cost_sources cs ON cs.id = cli.source_id
+    WHERE cli.confidence = 'pending_permission'
+      AND cli.charge_period_start < @end AND cli.charge_period_end > @start AND cli.voided_at IS NULL
+  `).all({ start: win.start, end: win.end }) as Array<{ source_id: string; name: string; provider: string }>
+  for (const p of pendingRows) {
+    warnings.push({
+      code: 'billing_access_needed', severity: 'medium', provider: p.provider,
+      message: `${p.name}: a valós költség nem olvasható ki (hiányzó jogosultság a szolgáltató számlázási API-jához). Nincs kitalált összeg.`,
+      detail: { source_id: p.source_id },
+      warning_type: 'access', category: categoryForProvider(p.provider), source: 'config', confidence: 'no_api_or_no_access',
+      action: 'Adj IAM/API jogosultságot a számlázási adathoz, vagy add meg kézzel az összeget.',
+    })
+  }
+
+  // 8. Render spend-limit -- Render has no public billing API (verified live,
+  // see render-no-public-billing-api). Always pending, never fabricated;
+  // low-severity so it sits in the drill-down, not the top actionable list.
+  warnings.push({
+    code: 'render_spend_limit_unknown', severity: 'low', provider: 'render',
+    message: 'Render költési limit nem lekérdezhető (nincs publikus billing API).',
+    warning_type: 'quota', category: 'hosting', source: 'config', confidence: 'no_api_or_no_access',
+    action: 'Kövesd kézzel a Render dashboardon (Settings -> Billing).',
+  })
+
+  // 9. Claude Max weekly limit -- no official usage API; only manually visible
+  // (agent tmux panes show a rolling %/reset time). Always pending.
+  warnings.push({
+    code: 'claude_max_weekly_limit_unknown', severity: 'low', provider: 'anthropic',
+    message: 'Claude Max heti limit nem lekérdezhető API-n -- az ágens paneleken (X% / HH:mm reset) manuálisan látható.',
+    warning_type: 'quota', category: 'ai', source: 'config', confidence: 'no_api_or_no_access',
+  })
+
+  // 10. DeepSeek prepaid balance -- the collector's balance endpoint DOES exist
+  // (live, read-only). % remaining is derived vs the highest balance snapshot
+  // seen (a proxy for the last top-up). Gap-fill (card 65da75e6): unlike a
+  // healthy SSL cert (silent is fine, nobody needs a "cert is fine" entry),
+  // the balance NUMBER itself is always relevant for a quota gauge -- so this
+  // ALWAYS emits one entry when a snapshot exists (never silent), escalating
+  // severity only when the %-vs-peak is genuinely low. Never a fabricated
+  // absolute limit -- when there's no observed drop yet (peak === latest, e.g.
+  // right after a top-up or only one snapshot ever), the % isn't meaningful,
+  // so the raw balance is shown instead with confidence:'manual'.
+  const dsRows = db.prepare(`SELECT balance, currency, captured_at FROM provider_balance_snapshots WHERE provider = 'deepseek' ORDER BY captured_at DESC`).all() as Array<{ balance: number; currency: string; captured_at: number }>
+  if (dsRows.length === 0) {
+    warnings.push({
+      code: 'deepseek_balance_unknown', severity: 'low', provider: 'deepseek',
+      message: 'DeepSeek egyenleg még nincs rögzítve (nincs korábbi snapshot az arány kiszámításához).',
+      warning_type: 'quota', category: 'ai', source: 'config', confidence: 'no_api_or_no_access',
+    })
+  } else {
+    const latest = dsRows[0].balance
+    const currency = dsRows[0].currency
+    const peak = Math.max(...dsRows.map(r => r.balance))
+    const hadObservedDrop = peak > latest // a real drop was seen -- % vs peak is meaningful
+    const pct = hadObservedDrop ? Math.round((latest / peak) * 10000) / 100 : null
+    // v0.8 (card 6f4d1332 §6.1): the ad-hoc, inverted-logic (%-remaining) severity escalation
+    // that used to live here (deepseek_balance_low, 3 hardcoded tiers) is now owned by the
+    // generic tiered limit rule below, fed by limits.ts's normalized usage_pct (fraction
+    // CONSUMED -- the correctly-oriented inverse of this rule's %-remaining framing) for this
+    // exact same balance. This entry stays what spec A1 actually needs: a plain, ALWAYS-shown
+    // informational gauge (never silent, never severity-escalating on its own).
+    warnings.push({
+      code: 'deepseek_balance_info', severity: 'low', provider: 'deepseek',
+      message: `DeepSeek előre fizetett egyenleg: ${latest} ${currency}${pct !== null ? ` (${pct}% a legutóbbi feltöltéshez képest)` : ''}.`,
+      detail: { latest_balance: latest, peak_balance: peak, currency },
+      warning_type: 'quota', category: 'ai', source: 'ledger', confidence: hadObservedDrop ? 'estimated' : 'manual',
+      current_value: latest, unit: currency,
+    })
+  }
+
+  // 11. v0.8 §6.1: generic tiered limit alert -- ANY normalized limit (§6.2's limits.ts pass)
+  // crossing 70/80/90/100% usage gets ONE consistent escalation, replacing the DeepSeek-only
+  // ad-hoc tiering removed above. 'balance' (DeepSeek) is intentionally included -- it no longer
+  // has its own escalation. 'build_minutes' (Render) is intentionally excluded: that source can
+  // only ever report a binary blocked/not-blocked (no API for intermediate tiers, see
+  // render-live-checks.ts), already fully covered by its own dedicated
+  // render_build_minutes_exhausted warning -- adding this generic rule on top would just
+  // duplicate the exact same fact under a second code.
+  for (const l of limits) {
+    if (l.usage_pct === null || l.limit_type === 'build_minutes') continue
+    const tier = LIMIT_TIERS.find(([t]) => l.usage_pct! >= t)
+    if (!tier) continue
+    const [threshold, severity] = tier
+    warnings.push({
+      code: 'limit_usage_high', severity, provider: l.provider,
+      message: `${l.provider} (${l.limit_type}): ${Math.round(l.usage_pct! * 100)}% felhasználva.`,
+      detail: { limit_type: l.limit_type, current_usage: l.current_usage, limit_value: l.limit_value, source: l.source },
+      warning_type: 'quota', category: categoryForProvider(l.provider), source: 'ledger', confidence: 'estimated',
+      current_value: Math.round(l.usage_pct! * 100), threshold: Math.round(threshold * 100), unit: '%',
+      action: severity === 'blocked' ? 'A limit elérve -- azonnali beavatkozás szükséges.' : 'Kövesd a felhasználást, közelít a limithez.',
+    })
+  }
+
+  return warnings
+}

--- a/src/costops/workspace-alerts.ts
+++ b/src/costops/workspace-alerts.ts
@@ -1,0 +1,158 @@
+// CostOps v0.7/v2 -- Google Workspace payment-failure/suspension signal.
+//
+// Gmail is NOT reachable from this backend process. An agent-side read-only
+// sweep (same pattern as email-ingest.ts's cost receipts) POSTs a structured,
+// sanitized entry per detected signal here -- no raw email body/subject/
+// sender/message-id is ever stored, only a hash of the message ref, the
+// account label, an issue_type, and when it was detected.
+
+import { createHash } from 'node:crypto'
+import type Database from 'better-sqlite3'
+import type { CostWarning } from './warnings.js'
+import { severityForDays, EXPIRY_THRESHOLDS } from './expiry-checks.js'
+
+export type WorkspaceIssueType = 'payment_failure' | 'suspension_notice' | 'suspended'
+
+export interface WorkspaceAlertEntry {
+  account: string             // 'google-private' | 'google-zst' | ...
+  issue_type: WorkspaceIssueType
+  detected_at: number         // epoch sec -- when the signal (email) was dated
+  message_ref: string         // opaque per-email ref; hashed here, never stored raw
+  // Gap-fill (card 65da75e6): the actual suspension DEADLINE, when the sweep can read it from
+  // the email body (e.g. "suspended on Aug 4"). Optional -- never fabricated when absent.
+  suspension_date?: number    // epoch sec
+}
+
+export interface WorkspaceAlertRow {
+  account: string
+  issue_type: WorkspaceIssueType
+  detected_at: number
+  suspension_date: number | null
+}
+
+// A signal older than this is assumed resolved (paid/reinstated) -- never
+// treated as "currently ongoing" without a fresh re-detection.
+const ACTIVE_WINDOW_SECS = 30 * 24 * 3600
+
+const VALID_ISSUE_TYPES = new Set(['payment_failure', 'suspension_notice', 'suspended'])
+
+export interface IngestWorkspaceAlertResult {
+  ingested: number
+  errors: Array<{ account: string; reason: string }>
+}
+
+/**
+ * Idempotently upsert workspace alert signals. Dedup key =
+ * `wsalert|<sha256(message_ref)[:32]>`, so re-running the same sweep never
+ * duplicates. No raw email content in `entries` is ever persisted.
+ */
+export function ingestWorkspaceAlerts(
+  db: Database.Database,
+  entries: WorkspaceAlertEntry[],
+  now: number,
+  idSalt = 'costops-workspace-alert',
+): IngestWorkspaceAlertResult {
+  const upsert = db.prepare(`
+    INSERT INTO workspace_alerts (account, issue_type, detected_at, suspension_date, message_ref, dedup_key, created_at)
+    VALUES (@account, @issue_type, @detected_at, @suspension_date, @ref_hash, @dedup_key, @now)
+    ON CONFLICT(dedup_key) DO UPDATE SET
+      detected_at=excluded.detected_at, issue_type=excluded.issue_type, suspension_date=excluded.suspension_date
+  `)
+  const out: IngestWorkspaceAlertResult = { ingested: 0, errors: [] }
+  const tx = db.transaction((list: WorkspaceAlertEntry[]) => {
+    for (const e of list) {
+      if (!e || typeof e.account !== 'string' || !e.account) { out.errors.push({ account: String(e?.account), reason: 'missing account' }); continue }
+      if (!VALID_ISSUE_TYPES.has(e.issue_type)) { out.errors.push({ account: e.account, reason: `invalid issue_type '${e.issue_type}'` }); continue }
+      if (typeof e.detected_at !== 'number' || !isFinite(e.detected_at)) { out.errors.push({ account: e.account, reason: 'missing/invalid detected_at' }); continue }
+      if (e.suspension_date !== undefined && (typeof e.suspension_date !== 'number' || !isFinite(e.suspension_date))) {
+        out.errors.push({ account: e.account, reason: 'invalid suspension_date' }); continue
+      }
+      const refHash = createHash('sha256').update(idSalt).update('|').update(String(e.message_ref)).digest('hex').slice(0, 32)
+      upsert.run({
+        account: e.account, issue_type: e.issue_type, detected_at: e.detected_at,
+        suspension_date: e.suspension_date ?? null,
+        ref_hash: refHash, dedup_key: `wsalert|${refHash}`, now,
+      })
+      out.ingested++
+    }
+  })
+  tx(entries)
+  return out
+}
+
+/** Alerts detected within the active window -- treated as a currently-relevant signal. */
+export function getActiveWorkspaceAlerts(db: Database.Database, now: number): WorkspaceAlertRow[] {
+  return db.prepare(`
+    SELECT account, issue_type, detected_at, suspension_date FROM workspace_alerts
+    WHERE detected_at >= @cutoff ORDER BY detected_at DESC
+  `).all({ cutoff: now - ACTIVE_WINDOW_SECS }) as WorkspaceAlertRow[]
+}
+
+const ISSUE_MESSAGE: Record<WorkspaceIssueType, string> = {
+  payment_failure: 'fizetési hiba a Google Workspace előfizetésen',
+  suspension_notice: 'felfüggesztési értesítő érkezett a Google Workspace fiókra',
+  suspended: 'a Google Workspace fiók felfüggesztve',
+}
+const ISSUE_SEVERITY: Record<WorkspaceIssueType, CostWarning['severity']> = {
+  payment_failure: 'medium', suspension_notice: 'medium', suspended: 'high',
+}
+
+/** One warning per (account, issue_type) currently active, most-recent detection only. */
+export function buildWorkspaceAlertWarnings(db: Database.Database, now: number): CostWarning[] {
+  const rows = getActiveWorkspaceAlerts(db, now)
+  const seen = new Set<string>()
+  const warnings: CostWarning[] = []
+  for (const r of rows) {
+    const key = `${r.account}|${r.issue_type}`
+    if (seen.has(key)) continue // rows are DESC by detected_at -- first hit is the most recent
+    seen.add(key)
+
+    // Gap-fill (card 65da75e6): when a real suspension DEADLINE is known, the date-based
+    // lifecycle warning supersedes the flat flag -- strictly more informative (due_date +
+    // severity rising as the date approaches), avoids showing two redundant entries for the
+    // same underlying issue. Never fabricated: only fires when suspension_date was actually
+    // extracted from the source email, not guessed from a generic grace-period assumption.
+    if (r.suspension_date !== null) {
+      // v0.8 (card 6f4d1332 §6.4): code carries issue_type too -- previously every date-based
+      // row collapsed onto the same 'workspace_suspension_overdue'/'_scheduled' code regardless
+      // of whether the underlying signal was a payment_failure, suspension_notice, or an already
+      // -suspended account, losing that distinction for any code-keyed consumer (dedup, UI
+      // grouping, requirements §6's per-type list). detail.issue_type carried it, but the code
+      // itself did not.
+      const daysRemaining = Math.floor((r.suspension_date - now) / 86400)
+      if (daysRemaining < 0) {
+        // Deadline already passed with no re-detection since -- treat as an active suspension,
+        // not silently drop it (a stale-but-unresolved deadline is worse, not better).
+        warnings.push({
+          code: `workspace_${r.issue_type}_overdue`, severity: 'high', provider: 'google-workspace',
+          message: `${r.account}: a felfüggesztési határidő (${new Date(r.suspension_date * 1000).toISOString().slice(0, 10)}) már elmúlt, a fiók állapota nem megerősített.`,
+          detail: { account: r.account, issue_type: r.issue_type, suspension_date: r.suspension_date },
+          warning_type: 'expiry', category: 'productivity', source: 'workspace_alert', confidence: 'measured',
+          due_date: new Date(r.suspension_date * 1000).toISOString().slice(0, 10),
+          action: 'Ellenőrizd azonnal a Workspace admin konzolt.',
+        })
+        continue
+      }
+      const severity = severityForDays(daysRemaining) ?? 'low' // always visible once a real deadline exists, even if >30d out
+      warnings.push({
+        code: `workspace_${r.issue_type}_scheduled`, severity, provider: 'google-workspace',
+        message: `${r.account}: felfüggesztés ${daysRemaining} nap múlva (${new Date(r.suspension_date * 1000).toISOString().slice(0, 10)}), ha a fizetés nem rendeződik.`,
+        detail: { account: r.account, issue_type: r.issue_type, suspension_date: r.suspension_date, days_remaining: daysRemaining },
+        warning_type: 'expiry', category: 'productivity', source: 'workspace_alert', confidence: 'measured',
+        due_date: new Date(r.suspension_date * 1000).toISOString().slice(0, 10),
+        current_value: daysRemaining, threshold: EXPIRY_THRESHOLDS.warn, unit: 'day',
+        action: 'Rendezd a fizetési módot a Workspace fiókon.',
+      })
+      continue
+    }
+
+    warnings.push({
+      code: `workspace_${r.issue_type}`, severity: ISSUE_SEVERITY[r.issue_type], provider: 'google-workspace',
+      message: `${r.account}: ${ISSUE_MESSAGE[r.issue_type]}.`,
+      detail: { account: r.account, detected_at: r.detected_at },
+      warning_type: 'access', category: 'productivity', source: 'workspace_alert', confidence: 'measured',
+      action: 'Ellenőrizd a fizetési módot / Workspace admin konzolt.',
+    })
+  }
+  return warnings
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,6 +5,7 @@ import { STORE_DIR, DB_FILENAME, ALLOWED_CHAT_ID, OLLAMA_URL, APP_TZ } from './c
 import { getEffectiveSettingValue } from './settings-store.js'
 import { logger } from './logger.js'
 import { TOOL_TIMEOUTS } from './tool-timeouts.js'
+import { initCostOpsSchema } from './costops/schema.js'
 
 let db: Database.Database
 
@@ -604,9 +605,6 @@ export function initDatabase(dbPathOverride?: string): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_agent_ts ON token_usage(agent, timestamp)`)
   // Migrations for columns added after initial release
   try { db.exec('ALTER TABLE token_usage ADD COLUMN thinking_tokens INTEGER NOT NULL DEFAULT 0') } catch { /* already exists */ }
-  try { db.exec('ALTER TABLE token_usage ADD COLUMN model TEXT') } catch { /* already exists */ }
-  try { db.exec('ALTER TABLE token_usage ADD COLUMN provider TEXT') } catch { /* already exists */ }
-  try { db.exec('ALTER TABLE token_usage ADD COLUMN model_source TEXT') } catch { /* already exists */ }
 
   // Deduplicate existing rows before creating unique index
   try {
@@ -744,53 +742,11 @@ export function initDatabase(dbPathOverride?: string): void {
   // Migration: add agent column to installs that created the table before this column existed.
   try { db.exec(`ALTER TABLE store_file_audit ADD COLUMN agent TEXT`) } catch { /* column already exists */ }
 
-  // --- CostOps (local cost ledger) ---
-  // Read-mostly, FOCUS-inspired. cost_sources = provider/subscription origin,
-  // cost_line_items = individual charge rows (estimate or provider-sourced).
-  // No secrets/account IDs stored raw. Budgets are config-driven (costops/config.ts's
-  // BudgetEntry, from store/costops-config.json) -- there is deliberately no separate
-  // `budgets` DB table: an earlier draft of this schema had one, but it was never
-  // read from or written to (config.budgets was always the actual source), so it was
-  // a dead, unused second source of truth. Removed rather than wired up, since the
-  // config file already covers this fully and a DB table would just be a sync burden
-  // for no benefit.
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS cost_sources (
-      id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      provider TEXT NOT NULL,
-      source_type TEXT NOT NULL,
-      account_ref TEXT,
-      currency TEXT NOT NULL DEFAULT 'HUF',
-      active INTEGER NOT NULL DEFAULT 1,
-      notes TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    )
-  `)
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS cost_line_items (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      source_id TEXT NOT NULL REFERENCES cost_sources(id),
-      charge_period_start INTEGER NOT NULL,
-      charge_period_end INTEGER NOT NULL,
-      charge_category TEXT NOT NULL,
-      service_name TEXT,
-      usage_type TEXT,
-      consumed_quantity REAL,
-      consumed_unit TEXT,
-      billed_cost REAL NOT NULL,
-      effective_cost REAL,
-      currency TEXT NOT NULL DEFAULT 'HUF',
-      confidence TEXT NOT NULL,
-      data_freshness INTEGER NOT NULL,
-      source_ref TEXT,
-      dedup_key TEXT UNIQUE,
-      created_at INTEGER NOT NULL
-    )
-  `)
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_period ON cost_line_items(charge_period_start, charge_period_end)`)
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_cost_line_items_source ON cost_line_items(source_id)`)
+  // LOCAL-FORK: costops seam (keep on rebase). All CostOps tables/columns/
+  // indexes live in src/costops/schema.ts's initCostOpsSchema(), not here --
+  // see docs/fork-upstream-policy.md §2a. This one call is the entire
+  // upstream-file footprint of the CostOps schema.
+  initCostOpsSchema(db)
 
   // --- Vault SSH Keys (shared pool) ---
   db.exec(`
@@ -821,41 +777,6 @@ export function initDatabase(dbPathOverride?: string): void {
       updated_at INTEGER NOT NULL
     )
   `)
-  // CostOps v0.3: provider cost-collector run history / sync status. No raw
-  // account id, no raw API response, no secret ever stored here.
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS import_runs (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      provider TEXT NOT NULL,
-      collector_name TEXT NOT NULL,
-      started_at INTEGER NOT NULL,
-      finished_at INTEGER,
-      status TEXT NOT NULL,
-      period_start INTEGER,
-      period_end INTEGER,
-      imported_count INTEGER NOT NULL DEFAULT 0,
-      error_code TEXT,
-      error_message_sanitized TEXT,
-      data_freshness_at INTEGER
-    )
-  `)
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_import_runs_provider ON import_runs(provider, started_at)`)
-  // v0.5: sanitized per-run detail (service_count, plan breakdown, not_covered) as JSON.
-  // NO raw service/account IDs -- the breakdown carries only type/plan labels + counts.
-  try { db.exec(`ALTER TABLE import_runs ADD COLUMN detail_json TEXT`) } catch { /* already exists */ }
-  // CostOps: provider prepaid-balance snapshots. For prepaid providers (e.g.
-  // DeepSeek) that expose remaining balance but not per-period cost, MTD spend
-  // is derived from the balance DROP across snapshots. No secret, no raw id.
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS provider_balance_snapshots (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      provider TEXT NOT NULL,
-      currency TEXT NOT NULL,
-      balance REAL NOT NULL,
-      captured_at INTEGER NOT NULL
-    )
-  `)
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_balance_snapshots_provider ON provider_balance_snapshots(provider, captured_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_name ON vault_ssh_servers(name)`)
   // Migrations for installs that ran earlier schema versions. MUST run before
   // the ssh_key_id index below: on an install where vault_ssh_servers already

--- a/src/db.ts
+++ b/src/db.ts
@@ -819,6 +819,25 @@ export function initDatabase(dbPathOverride?: string): void {
       updated_at INTEGER NOT NULL
     )
   `)
+  // CostOps v0.3: provider cost-collector run history / sync status. No raw
+  // account id, no raw API response, no secret ever stored here.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS import_runs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      collector_name TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      finished_at INTEGER,
+      status TEXT NOT NULL,
+      period_start INTEGER,
+      period_end INTEGER,
+      imported_count INTEGER NOT NULL DEFAULT 0,
+      error_code TEXT,
+      error_message_sanitized TEXT,
+      data_freshness_at INTEGER
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_import_runs_provider ON import_runs(provider, started_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_name ON vault_ssh_servers(name)`)
   // Migrations for installs that ran earlier schema versions. MUST run before
   // the ssh_key_id index below: on an install where vault_ssh_servers already

--- a/src/db.ts
+++ b/src/db.ts
@@ -605,6 +605,8 @@ export function initDatabase(dbPathOverride?: string): void {
   // Migrations for columns added after initial release
   try { db.exec('ALTER TABLE token_usage ADD COLUMN thinking_tokens INTEGER NOT NULL DEFAULT 0') } catch { /* already exists */ }
   try { db.exec('ALTER TABLE token_usage ADD COLUMN model TEXT') } catch { /* already exists */ }
+  try { db.exec('ALTER TABLE token_usage ADD COLUMN provider TEXT') } catch { /* already exists */ }
+  try { db.exec('ALTER TABLE token_usage ADD COLUMN model_source TEXT') } catch { /* already exists */ }
 
   // Deduplicate existing rows before creating unique index
   try {

--- a/src/db.ts
+++ b/src/db.ts
@@ -743,9 +743,9 @@ export function initDatabase(dbPathOverride?: string): void {
   try { db.exec(`ALTER TABLE store_file_audit ADD COLUMN agent TEXT`) } catch { /* column already exists */ }
 
   // LOCAL-FORK: costops seam (keep on rebase). All CostOps tables/columns/
-  // indexes live in src/costops/schema.ts's initCostOpsSchema(), not here --
-  // see docs/fork-upstream-policy.md §2a. This one call is the entire
-  // upstream-file footprint of the CostOps schema.
+  // indexes live in src/costops/schema.ts's initCostOpsSchema(), not here, so
+  // this file gains one line instead of a table per CostOps release. This one
+  // call is the entire footprint of the CostOps schema in db.ts.
   initCostOpsSchema(db)
 
   // --- Vault SSH Keys (shared pool) ---

--- a/src/db.ts
+++ b/src/db.ts
@@ -841,6 +841,19 @@ export function initDatabase(dbPathOverride?: string): void {
   // v0.5: sanitized per-run detail (service_count, plan breakdown, not_covered) as JSON.
   // NO raw service/account IDs -- the breakdown carries only type/plan labels + counts.
   try { db.exec(`ALTER TABLE import_runs ADD COLUMN detail_json TEXT`) } catch { /* already exists */ }
+  // CostOps: provider prepaid-balance snapshots. For prepaid providers (e.g.
+  // DeepSeek) that expose remaining balance but not per-period cost, MTD spend
+  // is derived from the balance DROP across snapshots. No secret, no raw id.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS provider_balance_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider TEXT NOT NULL,
+      currency TEXT NOT NULL,
+      balance REAL NOT NULL,
+      captured_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_balance_snapshots_provider ON provider_balance_snapshots(provider, captured_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_name ON vault_ssh_servers(name)`)
   // Migrations for installs that ran earlier schema versions. MUST run before
   // the ssh_key_id index below: on an install where vault_ssh_servers already

--- a/src/db.ts
+++ b/src/db.ts
@@ -838,6 +838,9 @@ export function initDatabase(dbPathOverride?: string): void {
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_import_runs_provider ON import_runs(provider, started_at)`)
+  // v0.5: sanitized per-run detail (service_count, plan breakdown, not_covered) as JSON.
+  // NO raw service/account IDs -- the breakdown carries only type/plan labels + counts.
+  try { db.exec(`ALTER TABLE import_runs ADD COLUMN detail_json TEXT`) } catch { /* already exists */ }
   db.exec(`CREATE INDEX IF NOT EXISTS idx_vault_ssh_servers_name ON vault_ssh_servers(name)`)
   // Migrations for installs that ran earlier schema versions. MUST run before
   // the ssh_key_id index below: on an install where vault_ssh_servers already

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -51,6 +51,23 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     return true
   }
 
+  // v0.5: sync spine -- run the Render collector LIVE (read-only GET) + idempotent import.
+  // Bearer-gated (like every /api/*). NO provider-side write; same-month re-run is idempotent.
+  if (path === '/api/costs/sync' && method === 'POST') {
+    try {
+      const provider = url.searchParams.get('provider') || 'render'
+      if (provider !== 'render') { json(res, { error: 'only provider=render is supported in v0.5' }, 400); return true }
+      const { syncRenderCollector } = await import('../../costops/collectors/render.js')
+      const now = Math.floor(Date.now() / 1000)
+      const result = await syncRenderCollector(getDb(), now)
+      json(res, result, result.ok ? 200 : 502)
+    } catch (err) {
+      logger.error({ err }, 'CostOps sync failed')
+      json(res, { ok: false, error: 'sync failed' }, 500)
+    }
+    return true
+  }
+
   if (path === '/api/costs/sources' && method === 'GET') {
     try {
       json(res, getCostSources(getDb()))

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -1,22 +1,43 @@
 // CostOps v0.1 -- read-mostly HTTP API. Bearer-gated like every /api/* route.
-// GET never writes: reflecting the local config's fixed costs into the ledger
-// (an idempotent upsert by dedup_key) happens on its own schedule via
-// startCostsSyncTask() below (called once at server boot), not as a side effect
-// of a client request. No LLM, no provider API, no secrets in the response.
+// No writes from the client: the only DB write is an idempotent reconciliation
+// of the local config's fixed costs into the ledger on a summary read. No LLM,
+// no provider API, no secrets in the response.
 
 import { json, readBody } from '../http-helpers.js'
 import { logger } from '../../logger.js'
 import { getDb } from '../../db.js'
 import { loadCostopsConfig } from '../../costops/config.js'
-import { syncFixedCostsToLedger, getCostSummary, getCostSources } from '../../costops/ledger.js'
+import { loadPricingConfig } from '../../costops/pricing.js'
+import { syncFixedCostsToLedger, getCostSummary, getCostSources, monthWindow } from '../../costops/ledger.js'
+import { getPeriodTrend } from '../../costops/period.js'
+import { loadSubscriptionsConfig, deriveLifecycle } from '../../costops/subscriptions.js'
+import { getWarnings } from '../../costops/warnings.js'
+import {
+  exportCostRows, rowsToCsv, exportSourceInventory, sourceInventoryToCsv,
+  exportProviderSummary, providerSummaryToCsv, exportCategorySummary, categorySummaryToCsv,
+  exportBudgetVariance, exportReconciliationReport, reconciliationReportToCsv,
+  exportForecastHistory, exportDataQualityReport, exportMonthlySnapshot,
+  exportAlerts, alertsToCsv,
+} from '../../costops/export.js'
+import { ingestWorkspaceAlerts, buildWorkspaceAlertWarnings } from '../../costops/workspace-alerts.js'
+import { loadDomainsConfig } from '../../costops/expiry-checks.js'
+import { getTokenCostByAgent } from '../../costops/pricing.js'
+import { getLimitStatus, getLiveCheckWarnings } from '../../costops/limits.js'
+import { buildSourceInventory } from '../../costops/inventory.js'
+import { captureReliabilitySnapshot, listReliabilitySnapshots, getLatestReliabilitySnapshot } from '../../costops/reliability-observation.js'
+import { listForecastSnapshots } from '../../costops/forecast-capture.js'
+import { buildReconciliation } from '../../costops/reconciliation.js'
+import { createCorrection, getCorrectionChain } from '../../costops/correction.js'
+import { listAlerts, acknowledgeAlertByKey, resolveAlertByKey } from '../../costops/alerts-store.js'
+import { getPeriodStatus, checkCloseReadiness, closePeriod, reopenPeriod, getPeriodCloseHistory, getCloseSnapshot } from '../../costops/period-close.js'
+import { getAllBudgetStatuses, upsertBudget, deleteBudget, getBudgetAuditHistory } from '../../costops/budgets.js'
+import { listRecommendations, acceptRecommendationByKey, dismissRecommendationByKey, type ListRecommendationsOptions } from '../../costops/recommendations-store.js'
+import { recordInvoice, applyInvoiceAdjustment, voidInvoice, listInvoices, buildInvoiceReconciliation } from '../../costops/invoice.js'
 import type { RouteContext } from './types.js'
 
 // Runs the fixed-cost -> ledger reflection once immediately (so the summary is
-// fresh from the moment the server comes up) and then on a fixed interval, so a
-// manual edit to the local costops config eventually shows up without needing a
-// restart. 10 minutes is deliberately coarse -- this is a manually-edited local
-// config file, not something that needs near-real-time reflection, and this is
-// the only place in the whole CostOps slice that writes to the DB at all.
+// fresh from the moment the server comes up) and then on a fixed interval.
+// 10 minutes is deliberately coarse.
 const SYNC_INTERVAL_MS = 10 * 60 * 1000
 
 export function startCostsSyncTask(intervalMs = SYNC_INTERVAL_MS): NodeJS.Timeout {
@@ -74,8 +95,13 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
         // LIVE read-only DeepSeek prepaid-balance sync; key from the Vault, never logged.
         const { syncDeepSeekBalance } = await import('../../costops/collectors/deepseek.js')
         result = await syncDeepSeekBalance(db, now)
+      } else if (provider === 'codex') {
+        // LIVE read-only Codex/ChatGPT-Plus weekly rate-limit sync via the codex
+        // app-server metadata read (account/rateLimits/read) -- zero quota, no LLM.
+        const { syncCodexRateLimit } = await import('../../costops/collectors/codex.js')
+        result = await syncCodexRateLimit(db, now)
       } else {
-        json(res, { error: `unsupported provider '${provider}' (supported: render, openai, github, deepseek)` }, 400); return true
+        json(res, { error: `unsupported provider '${provider}' (supported: render, openai, github, deepseek, codex)` }, 400); return true
       }
       json(res, result, result.ok ? 200 : 502)
     } catch (err) {
@@ -114,13 +140,617 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     return true
   }
 
-  if (path === '/api/costs/budgets' && method === 'GET') {
+  // Phase 0 (GAP-03/GAP-04): full source inventory -- lifecycle + provenance +
+  // freshness + sync cadence + owner + blocker per source, so period close/
+  // reconciliation/alerts (later phases) have an unambiguous per-source status
+  // to build on. Additive: does not change /summary's contract.
+  if (path === '/api/costs/source-inventory' && method === 'GET') {
     try {
       const { config } = loadCostopsConfig()
-      json(res, config.budgets)
+      const now = Math.floor(Date.now() / 1000)
+      json(res, { sources: buildSourceInventory(getDb(), config, now), generated_at: now })
+    } catch (err) {
+      logger.error({ err }, 'CostOps source-inventory failed')
+      json(res, { error: 'Source inventory failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 0 (GAP-21 P0.5): 7-day source-reliability observation window. POST
+  // captures one snapshot (idempotent-ish in effect, not in storage -- each
+  // call adds a new dated row, matching "one observation per day" usage);
+  // GET lists the accumulated window so far, or returns just the latest full
+  // inventory with ?latest=1.
+  if (path === '/api/costs/reliability-snapshots' && method === 'POST') {
+    try {
+      const { config } = loadCostopsConfig()
+      const now = Math.floor(Date.now() / 1000)
+      const snap = captureReliabilitySnapshot(getDb(), config, now)
+      json(res, { captured_at: snap.captured_at, source_count: snap.source_count })
+    } catch (err) {
+      logger.error({ err }, 'CostOps reliability-snapshot capture failed')
+      json(res, { error: 'Reliability snapshot capture failed' }, 500)
+    }
+    return true
+  }
+  if (path === '/api/costs/reliability-snapshots' && method === 'GET') {
+    try {
+      const db = getDb()
+      if (url.searchParams.get('latest') === '1') {
+        json(res, getLatestReliabilitySnapshot(db) ?? { captured_at: null, source_count: 0, inventory: [] })
+      } else {
+        json(res, { snapshots: listReliabilitySnapshots(db) })
+      }
+    } catch (err) {
+      logger.error({ err }, 'CostOps reliability-snapshots list failed')
+      json(res, { error: 'Reliability snapshots list failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 1 (GAP-10): forecast snapshots -- Anvil's forecast.ts computation +
+  // Mason's forecast-capture.ts orchestration. ?month=YYYY-MM filters; default
+  // returns the most recent 200 rows across all months.
+  if (path === '/api/costs/forecast-snapshots' && method === 'GET') {
+    try {
+      const month = url.searchParams.get('month') || undefined
+      json(res, { snapshots: listForecastSnapshots(getDb(), { month }) })
+    } catch (err) {
+      logger.error({ err }, 'CostOps forecast-snapshots list failed')
+      json(res, { error: 'Forecast snapshots list failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 1 (GAP-06): per-source reconciliation view (expected/observed/
+  // invoice/operationally-selected amount + variance + status). Read-only.
+  if (path === '/api/costs/reconciliation' && method === 'GET') {
+    try {
+      const month = url.searchParams.get('month') || undefined
+      const now = Math.floor(Date.now() / 1000)
+      json(res, { reconciliation: buildReconciliation(getDb(), now, month) })
+    } catch (err) {
+      logger.error({ err }, 'CostOps reconciliation failed')
+      json(res, { error: 'Reconciliation failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 2 (GAP-13): monthly close/reopen workflow. GET returns status +
+  // close-readiness checklist + audit history (+ the immutable snapshot if
+  // closed); POST /close and /reopen are the two audited state transitions.
+  if (path === '/api/costs/period-close' && method === 'GET') {
+    try {
+      const month = url.searchParams.get('month')
+      if (!month) { json(res, { error: 'missing ?month=YYYY-MM' }, 400); return true }
+      const { config } = loadCostopsConfig()
+      const now = Math.floor(Date.now() / 1000)
+      const db = getDb()
+      const status = getPeriodStatus(db, month)
+      const readiness = checkCloseReadiness(db, config, now, month)
+      const history = getPeriodCloseHistory(db, month)
+      const snapshot = status === 'closed' || status === 'reopened' ? getCloseSnapshot(db, month) : null
+      json(res, { month, status, readiness, history, snapshot })
+    } catch (err) {
+      logger.error({ err }, 'CostOps period-close status failed')
+      json(res, { error: 'Period-close status failed' }, 500)
+    }
+    return true
+  }
+  if (path === '/api/costs/period-close/close' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const { config } = loadCostopsConfig()
+      const now = Math.floor(Date.now() / 1000)
+      const result = closePeriod(getDb(), config, body.month, body.actor, body.reason ?? null, now, { force: body.force === true })
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps period close failed')
+      json(res, { ok: false, error: 'period close failed' }, 500)
+    }
+    return true
+  }
+  if (path === '/api/costs/period-close/reopen' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const result = reopenPeriod(getDb(), body.month, body.actor, body.reason, now)
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps period reopen failed')
+      json(res, { ok: false, error: 'period reopen failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 1 (GAP-05/GAP-06/GAP-14): correction relationship for any ledger
+  // line (extends Phase 0's manual-only void/archive). POST creates a
+  // correction (voids the original, links a new row via corrects_line_id);
+  // GET ?chain=<lineId> walks the full correction chain for drill-down.
+  if (path === '/api/costs/corrections' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const result = createCorrection(getDb(), {
+        originalLineId: Number(body.originalLineId), newAmount: Number(body.newAmount), reason: body.reason,
+      }, { now })
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps correction failed')
+      json(res, { ok: false, error: 'correction failed' }, 500)
+    }
+    return true
+  }
+  if (path === '/api/costs/corrections' && method === 'GET') {
+    try {
+      const lineId = Number(url.searchParams.get('chain'))
+      if (!Number.isFinite(lineId) || lineId <= 0) {
+        json(res, { error: 'missing or invalid ?chain=<lineId>' }, 400); return true
+      }
+      json(res, { chain: getCorrectionChain(getDb(), lineId) })
+    } catch (err) {
+      logger.error({ err }, 'CostOps correction-chain lookup failed')
+      json(res, { error: 'Correction chain lookup failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 3 (GAP-12): deterministic alert lifecycle, persisted via
+  // alerts-store.ts. Reads whatever is currently stored -- population (the
+  // 13-detector signal-gathering round) is a separate orchestration piece
+  // (alerts-capture.ts) not yet wired into the boot seam.
+  if (path === '/api/costs/alerts' && method === 'GET') {
+    try {
+      const status = (url.searchParams.get('status') as 'active' | 'resolved' | 'all' | null) ?? undefined
+      const type = url.searchParams.get('type') || undefined
+      json(res, { alerts: listAlerts(getDb(), { status, type }) })
+    } catch (err) {
+      logger.error({ err }, 'CostOps alerts list failed')
+      json(res, { error: 'Alerts list failed' }, 500)
+    }
+    return true
+  }
+  if (path === '/api/costs/alerts/acknowledge' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const result = acknowledgeAlertByKey(getDb(), body.dedup_key, body.actor || 'unknown', now)
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps alert acknowledge failed')
+      json(res, { ok: false, error: 'alert acknowledge failed' }, 500)
+    }
+    return true
+  }
+  if (path === '/api/costs/alerts/resolve' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const result = resolveAlertByKey(getDb(), body.dedup_key, now)
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps alert resolve failed')
+      json(res, { ok: false, error: 'alert resolve failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 3 (GAP-11): every configured budget's LIVE status (current_spend/
+  // forecast/variance/status against its scope), not just the raw config
+  // entries -- same shape as what period-close's immutable snapshot bundles.
+  if (path === '/api/costs/budgets' && method === 'GET') {
+    try {
+      const monthKey = url.searchParams.get('month') || undefined
+      const now = Math.floor(Date.now() / 1000)
+      const { config } = loadCostopsConfig()
+      const statuses = getAllBudgetStatuses(getDb(), config, now, monthKey)
+      json(res, statuses)
     } catch (err) {
       logger.error({ err }, 'CostOps budgets failed')
       json(res, { error: 'Cost budgets failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/budgets' && (method === 'POST' || method === 'PATCH' || method === 'DELETE')) {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const { config } = loadCostopsConfig()
+      const result = (method === 'POST' || method === 'PATCH')
+        ? upsertBudget(getDb(), config, body, body.actor, now)
+        : deleteBudget(getDb(), config, body.id, body.actor, now)
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps budget change failed')
+      json(res, { ok: false, error: 'budget change failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/budgets/history' && method === 'GET') {
+    try {
+      const budgetId = url.searchParams.get('id') || undefined
+      const history = getBudgetAuditHistory(getDb(), budgetId)
+      json(res, history)
+    } catch (err) {
+      logger.error({ err }, 'CostOps budget history failed')
+      json(res, { error: 'Cost budget history failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 4 (GAP-17): aggregate cost optimization advisor. Reads only --
+  // recommendations are populated by optimization-capture.ts's future daily
+  // cycle (mirroring alerts-capture.ts), not by this route. Defaults to
+  // 'open' (unaddressed) recommendations, same convention as GET /api/costs/alerts.
+  if (path === '/api/costs/recommendations' && method === 'GET') {
+    try {
+      const status = (url.searchParams.get('status') || undefined) as ListRecommendationsOptions['status']
+      const type = url.searchParams.get('type') || undefined
+      const recommendations = listRecommendations(getDb(), { status, type })
+      json(res, { recommendations })
+    } catch (err) {
+      logger.error({ err }, 'CostOps recommendations failed')
+      json(res, { error: 'Cost recommendations failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/recommendations/accept' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const result = acceptRecommendationByKey(getDb(), body.dedup_key, body.actor, now)
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps recommendation accept failed')
+      json(res, { ok: false, error: 'recommendation accept failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/recommendations/dismiss' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const result = dismissRecommendationByKey(getDb(), body.dedup_key, body.actor, now)
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps recommendation dismiss failed')
+      json(res, { ok: false, error: 'recommendation dismiss failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 2 (GAP-14): invoice / credit / refund / correction workflow.
+  // 'invoice-salt' matches this codebase's existing per-domain idSalt
+  // convention (collectors/openai.ts's 'openai-salt' etc.) -- a namespacing
+  // salt for hashRef, not a secret.
+  if (path === '/api/costs/invoices' && method === 'GET') {
+    try {
+      const sourceId = url.searchParams.get('source_id') || undefined
+      const month = url.searchParams.get('month') || undefined
+      const now = Math.floor(Date.now() / 1000)
+      const invoices = listInvoices(getDb(), { source_id: sourceId, month, now })
+      json(res, { invoices })
+    } catch (err) {
+      logger.error({ err }, 'CostOps invoices list failed')
+      json(res, { error: 'Cost invoices failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/invoices' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const result = recordInvoice(getDb(), body, { now, salt: 'invoice-salt' })
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps invoice record failed')
+      json(res, { ok: false, error: 'invoice record failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/invoices/adjust' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const result = applyInvoiceAdjustment(getDb(), body, { now })
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps invoice adjustment failed')
+      json(res, { ok: false, error: 'invoice adjustment failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/invoices/void' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const result = voidInvoice(getDb(), body.invoiceId, body.reason, now)
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps invoice void failed')
+      json(res, { ok: false, error: 'invoice void failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/invoices/reconciliation' && method === 'GET') {
+    try {
+      const now = Math.floor(Date.now() / 1000)
+      const month = url.searchParams.get('month') || undefined
+      const reconciliation = await buildInvoiceReconciliation(getDb(), now, month)
+      json(res, { reconciliation })
+    } catch (err) {
+      logger.error({ err }, 'CostOps invoice reconciliation failed')
+      json(res, { error: 'Cost invoice reconciliation failed' }, 500)
+    }
+    return true
+  }
+
+  // v0.7: monthly close / period view -- current + previous + last-N trend,
+  // per provider. READ-ONLY (no fixed-cost sync), so a month before a
+  // subscription existed correctly reports no_data, never a fabricated 0.
+  if (path === '/api/costs/period' && method === 'GET') {
+    try {
+      const monthsBack = Math.min(Math.max(parseInt(url.searchParams.get('months') || '6', 10) || 6, 1), 24)
+      const monthKey = url.searchParams.get('month') || undefined
+      const now = Math.floor(Date.now() / 1000)
+      const { config } = loadCostopsConfig()
+      const trend = getPeriodTrend(getDb(), config, now, monthsBack, monthKey)
+      json(res, trend)
+    } catch (err) {
+      logger.error({ err }, 'CostOps period failed')
+      json(res, { error: 'Cost period failed' }, 500)
+    }
+    return true
+  }
+
+  // v0.7: subscription lifecycle (active/canceled/paid_until/next_renewal),
+  // config-derived facts only -- no Gmail access, no raw email/PII.
+  if (path === '/api/costs/subscriptions' && method === 'GET') {
+    try {
+      const now = Math.floor(Date.now() / 1000)
+      const { config, exists, errors } = loadSubscriptionsConfig()
+      json(res, { subscriptions: deriveLifecycle(config, now), config_present: exists, config_errors: errors })
+    } catch (err) {
+      logger.error({ err }, 'CostOps subscriptions failed')
+      json(res, { error: 'Cost subscriptions failed' }, 500)
+    }
+    return true
+  }
+
+  // v0.8 (card 6f4d1332 §5/§6.2): agent-grouped token cost + run-rate forecast, and the
+  // normalized limits/quota pass (subscription lifecycle + DeepSeek balance + workspace alerts +
+  // Render build-minutes + SSL/domain expiry, all into one shape). Separate from /summary so a
+  // live TLS/RDAP/Render round trip never slows down the primary (DB-only) summary load --
+  // matches how /warnings already keeps its own live checks out of /summary.
+  if (path === '/api/costs/limits' && method === 'GET') {
+    try {
+      const monthKey = url.searchParams.get('month') || undefined
+      const now = Math.floor(Date.now() / 1000)
+      const win = monthWindow(now, monthKey)
+      const { pricing } = loadPricingConfig()
+      const tokenByAgent = getTokenCostByAgent(getDb(), pricing, win.start, win.end, win.fractionElapsed)
+      const { config: subsConfig } = loadSubscriptionsConfig()
+      const subscriptions = deriveLifecycle(subsConfig, now)
+      const limits = await getLimitStatus(getDb(), now, subscriptions)
+      json(res, { token_by_agent: tokenByAgent, limits })
+    } catch (err) {
+      logger.error({ err }, 'CostOps limits failed')
+      json(res, { error: 'Cost limits failed' }, 500)
+    }
+    return true
+  }
+
+  // v0.7/v2: deterministic + LIVE-wired warnings. Deterministic rules (budget/
+  // sync/lifecycle/pending_permission) are DB-only and instant; the 2 live
+  // checks (Render build-minutes, workspace alerts) add a real network round
+  // trip (Render) / a stored agent-fed signal (workspace) -- never fabricated,
+  // "no_api_or_no_access" surfaces where there genuinely is no data source.
+  if (path === '/api/costs/warnings' && method === 'GET') {
+    try {
+      const monthKey = url.searchParams.get('month') || undefined
+      const now = Math.floor(Date.now() / 1000)
+      const { config, exists, errors } = loadCostopsConfig()
+      const { pricing, exists: pricingExists } = loadPricingConfig()
+      const db = getDb()
+      syncFixedCostsToLedger(db, config, now, monthKey)
+      const summary = getCostSummary(db, config, now, { monthKey, configExists: exists, configErrors: errors, pricing, pricingExists })
+      const { config: subsConfig } = loadSubscriptionsConfig()
+      const subscriptions = deriveLifecycle(subsConfig, now)
+      // Card fa041036: getLimitStatus() and this route's own render/ssl/domain warnings both need
+      // the same 3 live checks -- they now share getLiveCheckWarnings()'s TTL-cached result instead
+      // of each independently hitting Render's API + doing a TLS handshake per host + an RDAP
+      // lookup (previously: once concurrently inside getLimitStatus, then AGAIN sequentially here
+      // -- the real cause of the reported 20-35s, not the DB-side ledger reads).
+      const limits = await getLimitStatus(db, now, subscriptions)
+      const deterministic = getWarnings(db, config, now, summary, subscriptions, limits)
+      const workspaceAlerts = buildWorkspaceAlertWarnings(db, now)
+      const { config: domainsConfig } = loadDomainsConfig()
+      const { renderWarnings: renderBuildMinutes, sslWarnings, domainWarnings } = await getLiveCheckWarnings(now, domainsConfig.ssl_hosts, domainsConfig.domains)
+      json(res, { warnings: [...deterministic, ...workspaceAlerts, ...renderBuildMinutes, ...sslWarnings, ...domainWarnings] })
+    } catch (err) {
+      logger.error({ err }, 'CostOps warnings failed')
+      json(res, { error: 'Cost warnings failed' }, 500)
+    }
+    return true
+  }
+
+  // v0.7/v2: agent-side Gmail sweep POSTs a sanitized workspace-alert signal
+  // here (payment failure / suspension notice). No raw email content stored.
+  if (path === '/api/costs/workspace-alerts' && method === 'POST') {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}') as { entries?: unknown }
+      const entries = Array.isArray(body?.entries) ? body.entries : []
+      const now = Math.floor(Date.now() / 1000)
+      const result = ingestWorkspaceAlerts(getDb(), entries as import('../../costops/workspace-alerts.js').WorkspaceAlertEntry[], now)
+      json(res, { ok: result.errors.length === 0, ...result })
+    } catch (err) {
+      logger.error({ err }, 'CostOps workspace-alerts ingest failed')
+      json(res, { ok: false, error: 'workspace-alerts ingest failed' }, 500)
+    }
+    return true
+  }
+
+  // v0.7: sanitized export -- provider/period/amount/confidence/source_type only.
+  // No raw email body, no raw invoice ID, no account reference, no PII.
+  if (path === '/api/costs/export' && method === 'GET') {
+    try {
+      const format = url.searchParams.get('format') === 'csv' ? 'csv' : 'json'
+      const month = url.searchParams.get('month') || undefined
+      const fromMonth = url.searchParams.get('from') || undefined
+      const toMonth = url.searchParams.get('to') || undefined
+      const now = Math.floor(Date.now() / 1000)
+      const rows = exportCostRows(getDb(), now, { month, fromMonth, toMonth })
+      if (format === 'csv') {
+        res.writeHead(200, { 'Content-Type': 'text/csv; charset=utf-8', 'Cache-Control': 'private, no-store' })
+        res.end(rowsToCsv(rows))
+      } else {
+        json(res, { rows })
+      }
+    } catch (err) {
+      logger.error({ err }, 'CostOps export failed')
+      json(res, { error: 'Cost export failed' }, 500)
+    }
+    return true
+  }
+
+  // Phase 1 (GAP-18): normalized export set beyond the ledger CSV/JSON above.
+  // Each reuses the exact function the dashboard/summary route itself calls,
+  // so export totals match dashboard totals by construction.
+  if (path.startsWith('/api/costs/export/') && method === 'GET') {
+    const wantCsv = url.searchParams.get('format') === 'csv'
+    const month = url.searchParams.get('month') || undefined
+    const now = Math.floor(Date.now() / 1000)
+    const sendCsvOrJson = (csv: string | null, jsonBody: unknown) => {
+      if (wantCsv && csv != null) {
+        res.writeHead(200, { 'Content-Type': 'text/csv; charset=utf-8', 'Cache-Control': 'private, no-store' })
+        res.end(csv)
+      } else {
+        json(res, jsonBody)
+      }
+    }
+    try {
+      const kind = path.slice('/api/costs/export/'.length)
+      const { config } = loadCostopsConfig()
+      const db = getDb()
+      switch (kind) {
+        case 'source-inventory': {
+          const exp = exportSourceInventory(db, config, now)
+          sendCsvOrJson(wantCsv ? sourceInventoryToCsv(exp.sources) : null, exp)
+          return true
+        }
+        case 'provider-summary': {
+          const exp = exportProviderSummary(db, config, now, { month })
+          sendCsvOrJson(wantCsv ? providerSummaryToCsv(exp.provider_breakdown) : null, exp)
+          return true
+        }
+        case 'category-summary': {
+          const exp = exportCategorySummary(db, now, { month })
+          sendCsvOrJson(wantCsv ? categorySummaryToCsv(exp.categories) : null, exp)
+          return true
+        }
+        case 'budget-variance': {
+          json(res, exportBudgetVariance(db, config, now, { month }))
+          return true
+        }
+        case 'reconciliation': {
+          const exp = exportReconciliationReport(db, now, month)
+          sendCsvOrJson(wantCsv ? reconciliationReportToCsv(exp.sources) : null, exp)
+          return true
+        }
+        case 'forecast-history': {
+          json(res, exportForecastHistory(db, now, { month }))
+          return true
+        }
+        case 'data-quality': {
+          json(res, exportDataQualityReport(db, config, now, { month }))
+          return true
+        }
+        case 'monthly-snapshot': {
+          json(res, exportMonthlySnapshot(db, config, now, month))
+          return true
+        }
+        case 'alerts': {
+          const exp = exportAlerts(db, now, { includeResolved: url.searchParams.get('resolved') === '1' })
+          sendCsvOrJson(wantCsv ? alertsToCsv(exp.alerts) : null, exp)
+          return true
+        }
+        default:
+          json(res, { error: `unknown export kind '${kind}'` }, 404)
+          return true
+      }
+    } catch (err) {
+      logger.error({ err }, 'CostOps normalized export failed')
+      json(res, { error: 'Normalized export failed' }, 500)
+    }
+    return true
+  }
+
+  // Card a1552362 (item 3): manual cost/entitlement entry -- the one hand-entry door for a
+  // provider Istvan already knows the number for but that has no API/invoice-ingest path yet.
+  // POST creates (409 if the key already exists), PATCH updates (404 if it doesn't), DELETE
+  // removes (card 73e8914a -- 404 if missing, 409 if the target isn't actually a manual entry,
+  // same guard as PATCH) -- see manual-entry.ts for the full rationale.
+  if (path === '/api/costs/manual' && (method === 'POST' || method === 'PATCH' || method === 'DELETE')) {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      let fxUsdHuf = 0, fxEurHuf = 0
+      try {
+        const { loadRenderPricing } = await import('../../costops/collectors/render.js')
+        const p = loadRenderPricing().pricing
+        fxUsdHuf = p.fx_usd_huf || 0
+        fxEurHuf = p.fx_eur_huf || 0
+      } catch { /* fx 0 -> non-HUF entries rejected as unconvertible */ }
+      const { createManualCost, updateManualCost, deleteManualCost } = await import('../../costops/manual-entry.js')
+      const result = method === 'POST'
+        ? createManualCost(getDb(), body, { fxUsdHuf, fxEurHuf, now })
+        : method === 'PATCH'
+        ? updateManualCost(getDb(), body, { fxUsdHuf, fxEurHuf, now })
+        : deleteManualCost(getDb(), body, { now })
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps manual cost entry failed')
+      json(res, { ok: false, error: 'manual cost entry failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/entitlements/manual' && (method === 'POST' || method === 'PATCH' || method === 'DELETE')) {
+    try {
+      const raw = await readBody(ctx.req)
+      const body = JSON.parse(raw.toString() || '{}')
+      const now = Math.floor(Date.now() / 1000)
+      const { createManualEntitlement, updateManualEntitlement, deleteManualEntitlement } = await import('../../costops/manual-entry.js')
+      const result = method === 'POST'
+        ? createManualEntitlement(getDb(), body, now)
+        : method === 'PATCH'
+        ? updateManualEntitlement(getDb(), body, now)
+        : deleteManualEntitlement(getDb(), body)
+      json(res, result, result.ok ? 200 : (result.status || 500))
+    } catch (err) {
+      logger.error({ err }, 'CostOps manual entitlement entry failed')
+      json(res, { ok: false, error: 'manual entitlement entry failed' }, 500)
     }
     return true
   }

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -56,10 +56,23 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
   if (path === '/api/costs/sync' && method === 'POST') {
     try {
       const provider = url.searchParams.get('provider') || 'render'
-      if (provider !== 'render') { json(res, { error: 'only provider=render is supported in v0.5' }, 400); return true }
-      const { syncRenderCollector } = await import('../../costops/collectors/render.js')
       const now = Math.floor(Date.now() / 1000)
-      const result = await syncRenderCollector(getDb(), now)
+      const db = getDb()
+      let result: { ok: boolean }
+      if (provider === 'render') {
+        const { syncRenderCollector } = await import('../../costops/collectors/render.js')
+        result = await syncRenderCollector(db, now)
+      } else if (provider === 'openai') {
+        // LIVE read-only OpenAI Costs API sync; admin key pulled from the Vault, never logged.
+        const { syncOpenAiCollector } = await import('../../costops/collectors/openai.js')
+        result = await syncOpenAiCollector(db, now)
+      } else if (provider === 'github') {
+        // LIVE read-only GitHub billing usage sync; PAT pulled from the Vault, never logged.
+        const { syncGitHubCollector } = await import('../../costops/collectors/github.js')
+        result = await syncGitHubCollector(db, now)
+      } else {
+        json(res, { error: `unsupported provider '${provider}' (supported: render, openai, github)` }, 400); return true
+      }
       json(res, result, result.ok ? 200 : 502)
     } catch (err) {
       logger.error({ err }, 'CostOps sync failed')

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -70,8 +70,12 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
         // LIVE read-only GitHub billing usage sync; PAT pulled from the Vault, never logged.
         const { syncGitHubCollector } = await import('../../costops/collectors/github.js')
         result = await syncGitHubCollector(db, now)
+      } else if (provider === 'deepseek') {
+        // LIVE read-only DeepSeek prepaid-balance sync; key from the Vault, never logged.
+        const { syncDeepSeekBalance } = await import('../../costops/collectors/deepseek.js')
+        result = await syncDeepSeekBalance(db, now)
       } else {
-        json(res, { error: `unsupported provider '${provider}' (supported: render, openai, github)` }, 400); return true
+        json(res, { error: `unsupported provider '${provider}' (supported: render, openai, github, deepseek)` }, 400); return true
       }
       json(res, result, result.ok ? 200 : 502)
     } catch (err) {

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -4,7 +4,7 @@
 // startCostsSyncTask() below (called once at server boot), not as a side effect
 // of a client request. No LLM, no provider API, no secrets in the response.
 
-import { json } from '../http-helpers.js'
+import { json, readBody } from '../http-helpers.js'
 import { logger } from '../../logger.js'
 import { getDb } from '../../db.js'
 import { loadCostopsConfig } from '../../costops/config.js'
@@ -81,6 +81,25 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     } catch (err) {
       logger.error({ err }, 'CostOps sync failed')
       json(res, { ok: false, error: 'sync failed' }, 500)
+    }
+    return true
+  }
+
+  // Email-sourced cost ingest: an agent-side Gmail sweep POSTs structured receipt
+  // entries here. Idempotent per (email, month). No raw email content is stored.
+  if (path === '/api/costs/email-ingest' && method === 'POST') {
+    try {
+      const body = await readBody(ctx.req) as { entries?: unknown }
+      const entries = Array.isArray(body?.entries) ? body.entries : []
+      const now = Math.floor(Date.now() / 1000)
+      let fxUsdHuf = 0
+      try { const { loadRenderPricing } = await import('../../costops/collectors/render.js'); fxUsdHuf = loadRenderPricing().pricing.fx_usd_huf || 0 } catch { /* fx 0 -> USD entries flagged */ }
+      const { ingestEmailCosts } = await import('../../costops/email-ingest.js')
+      const result = ingestEmailCosts(getDb(), entries as import('../../costops/email-ingest.js').EmailCostEntry[], { fxUsdHuf, now })
+      json(res, { ok: result.errors.length === 0, ...result })
+    } catch (err) {
+      logger.error({ err }, 'CostOps email-ingest failed')
+      json(res, { ok: false, error: 'email-ingest failed' }, 500)
     }
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -9692,6 +9692,32 @@ async function loadStatus() {
 // ============================================================
 
 document.getElementById('refreshCostsBtn').addEventListener('click', loadCosts)
+document.getElementById('costsSyncBtn').addEventListener('click', costopsSyncNow)
+
+// v0.5 sync spine: kick the Render collector (read-only on the provider side,
+// idempotent import on ours), then re-render. No Authorization header is built
+// here on purpose -- window.fetch is wrapped near the top of this file and
+// already attaches the Bearer token to every same-origin /api/ call.
+async function costopsSyncNow() {
+  const btn = document.getElementById('costsSyncBtn')
+  const status = document.getElementById('costsSyncStatus')
+  btn.disabled = true
+  if (status) status.textContent = t('costs.sync_running')
+  try {
+    const res = await fetch('/api/costs/sync?provider=render', { method: 'POST' })
+    const d = await res.json().catch(() => ({}))
+    if (status) {
+      status.textContent = res.ok && d?.ok
+        ? t('costs.sync_ok', { count: d.service_count ?? d.imported_count ?? 0 })
+        : t('costs.sync_failed', { error: String(d?.error || res.status) })
+    }
+  } catch (err) {
+    if (status) status.textContent = t('costs.sync_failed', { error: t('costs.sync_network_error') })
+  } finally {
+    btn.disabled = false
+  }
+  await loadCosts()
+}
 
 async function loadCosts() {
   const el = document.getElementById('costsContent')
@@ -9739,6 +9765,41 @@ async function loadCosts() {
           <td style="padding:6px 8px">${fmtMoney(src.spend)}</td>
         </tr>`).join('')}</tbody>
       </table></div>`
+    }
+
+    // v0.5: provider sync freshness. Rendered only once a collector has run, so
+    // an install that never syncs looks exactly as it did before this section.
+    const syncRows = Array.isArray(s.provider_sync) ? s.provider_sync : []
+    if (syncRows.length > 0) {
+      const fmtTs = (ts) => (ts ? new Date(ts * 1000).toLocaleString('hu-HU') : '-')
+      const statusLabel = (row) => {
+        if (row.status === 'failed') return { text: t('costs.sync_status_failed') + (row.error_code ? ' (' + escapeHtml(row.error_code) + ')' : ''), color: 'var(--danger,#e74c3c)' }
+        if (row.status === 'stale') return { text: t('costs.sync_status_stale'), color: 'var(--warn,#e0a800)' }
+        return { text: t('costs.sync_status_ok'), color: 'var(--text-muted)' }
+      }
+      html += `<div style="margin-top:24px">
+        <div style="font-weight:600;margin-bottom:6px">${t('costs.sync_section_title')}</div>
+        <div style="${mutedStyle};margin-bottom:8px">${t('costs.sync_section_note')}</div>
+        <div style="overflow-x:auto"><table style="width:100%;border-collapse:collapse">
+          <thead><tr style="text-align:left;border-bottom:1px solid var(--border,#333)">
+            <th style="padding:6px 8px">${t('costs.source_provider')}</th>
+            <th style="padding:6px 8px">${t('costs.sync_col_status')}</th>
+            <th style="padding:6px 8px">${t('costs.sync_col_imported')}</th>
+            <th style="padding:6px 8px">${t('costs.sync_col_last_success')}</th>
+            <th style="padding:6px 8px">${t('costs.sync_col_last_failure')}</th>
+          </tr></thead>
+          <tbody>${syncRows.map((row) => {
+            const st = statusLabel(row)
+            return `<tr style="border-bottom:1px solid var(--border,#222)">
+              <td style="padding:6px 8px">${escapeHtml(row.provider)}</td>
+              <td style="padding:6px 8px;color:${st.color}">${st.text}</td>
+              <td style="padding:6px 8px">${Number(row.imported_count) || 0}</td>
+              <td style="padding:6px 8px;${mutedStyle}">${escapeHtml(fmtTs(row.last_success))}</td>
+              <td style="padding:6px 8px;${mutedStyle}">${escapeHtml(fmtTs(row.last_failed))}</td>
+            </tr>`
+          }).join('')}</tbody>
+        </table></div>
+      </div>`
     }
 
     html += `<p style="${mutedStyle};margin-top:16px">${t('costs.token_usage_note')} (${(s.token_usage?.calls ?? 0)} ${t('costs.calls')}, ${(s.token_usage?.input_tokens ?? 0) + (s.token_usage?.output_tokens ?? 0)} tokens)</p>`

--- a/web/index.html
+++ b/web/index.html
@@ -1889,12 +1889,18 @@
             <h1 data-i18n="costs.page_title">Költségek</h1>
             <p class="subtitle" data-i18n="costs.page_subtitle">Havi költség-összefoglaló a helyi konfigurációból</p>
           </div>
-          <button class="btn-secondary btn-compact" id="refreshCostsBtn" data-i18n="common.btn.refresh">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
-            </svg>
-            Frissítés
-          </button>
+          <div class="header-actions">
+            <span id="costsSyncStatus" class="subtitle"></span>
+            <button class="btn-secondary btn-compact" id="costsSyncBtn" data-i18n="costs.sync_btn">
+              Provider szinkron
+            </button>
+            <button class="btn-secondary btn-compact" id="refreshCostsBtn" data-i18n="common.btn.refresh">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+              </svg>
+              Frissítés
+            </button>
+          </div>
         </div>
       </div>
 

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -641,6 +641,22 @@ window._i18n.en = {
   'costs.token_usage_note':      'Token usage volume (not priced)',
   'costs.calls':                 'calls',
 
+  // --- Costs: provider sync spine (v0.5) ---
+  'costs.sync_btn':              'Sync providers',
+  'costs.sync_running':          'Sync running...',
+  'costs.sync_ok':               'Sync finished ({count} units).',
+  'costs.sync_failed':           'Sync failed: {error}',
+  'costs.sync_network_error':    'network error',
+  'costs.sync_section_title':    'Provider sync',
+  'costs.sync_section_note':     'Read-only on the provider side; re-importing the same period is idempotent, so nothing is double counted.',
+  'costs.sync_col_status':       'Status',
+  'costs.sync_col_imported':     'Imported items',
+  'costs.sync_col_last_success': 'Last success',
+  'costs.sync_col_last_failure': 'Last failure',
+  'costs.sync_status_ok':        'ok',
+  'costs.sync_status_stale':     'stale',
+  'costs.sync_status_failed':    'failed',
+
   'tokenUsage.col.time':         'Time',
   'tokenUsage.col.agent':        'Agent',
   'tokenUsage.col.content':      'Content',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -902,6 +902,22 @@ window._i18n.hu = {
   'costs.token_usage_note':      'Token-felhasználás mennyisége (nincs árazva)',
   'costs.calls':                 'hívás',
 
+  // --- Costs: provider sync spine (v0.5) ---
+  'costs.sync_btn':              'Provider szinkron',
+  'costs.sync_running':          'Szinkron fut...',
+  'costs.sync_ok':               'Szinkron kész ({count} egység).',
+  'costs.sync_failed':           'Szinkron sikertelen: {error}',
+  'costs.sync_network_error':    'hálózati hiba',
+  'costs.sync_section_title':    'Provider szinkron',
+  'costs.sync_section_note':     'A provider oldalán csak olvasunk; az import ugyanarra az időszakra ismételhető, nem duplázódik.',
+  'costs.sync_col_status':       'Állapot',
+  'costs.sync_col_imported':     'Importált tételek',
+  'costs.sync_col_last_success': 'Utolsó sikeres',
+  'costs.sync_col_last_failure': 'Utolsó hiba',
+  'costs.sync_status_ok':        'rendben',
+  'costs.sync_status_stale':     'elavult',
+  'costs.sync_status_failed':    'sikertelen',
+
   'tokenUsage.col.time':         'Idő',
   'tokenUsage.col.agent':        'Ágens',
   'tokenUsage.col.content':      'Tartalom',


### PR DESCRIPTION
Continues the CostOps series. **Stacked on #628** — please review that one first.

### Reading this PR

The diff shows 89 files / 15 commits against `develop`, but **only the top 3 commits are new here**. The rest arrive via #628 and will disappear from this diff once #628 merges:

| new | commit | what |
|---|---|---|
| ✔ | `2cfee72` | monitoring — alerts, alert store, warnings, subscriptions, lifecycle, limits, expiry + live checks |
| ✔ | `4fc7bc3` | financial — period close, invoice, budgets, optimization, export, inventory, reliability, recommendations + the full `costs.ts` route surface |
| ✔ | `2c84f05` | accounting rule for equal-confidence cost lines (see below) |

Scoped to 57 files on top of #628. Happy to split monitoring and financial into separate PRs if you would rather review them apart — they are stacked, so the split only helps if #628 lands first.

### The accounting rule (`2c84f05`)

When two cost lines for the same source carry equally trustworthy provenance (a real invoice and a provider API figure), something has to decide which one represents that period's cost. This resolves it by what the source *is*, using the existing `cost_sources.source_type`:

- **Package / subscription** (and saas, hosting, domain): the invoice states the period it covers, so the **invoice** is the period cost. Provider API numbers are a stand-in until the invoice arrives.
- **Top-up / prepaid usage** (`source_type: 'usage'`): funding an account is a real payment but not the period's cost. Only what was **consumed** belongs to the period, and consumption is what the provider API reports.

Freshness now only breaks ties between two lines of the *same* kind, and a `data_freshness` in the future can no longer win — a period-end date reaching that column is a data defect we hit in practice, and it must not decide a figure.

When `source_type` is unknown the package branch applies, so the invoice wins. That default is deliberate: falling back to a real billed amount understates nothing, whereas defaulting to consumption would under-report, and an under-reported cost figure is the one nobody investigates.

### Verification

141 test files, 1687 tests, all passing. TypeScript clean. The accounting rule ships with tests in both directions plus the future-timestamp case, and they were confirmed to go red with the rule disabled.

### Not included, deliberately

Dashboard UI (`web/costops/*` and the `web/app.js` changes) is held back — that diff carries fleet-specific local features and needs a separate extraction pass. Nothing in this PR depends on it.
