### PR TITLE
fix(scheduler): same-minute injection priority + forceSend saturation deferral + no-token WARN throttle

### DIFF
--- a/src/__tests__/schedule-runner-injection-priority.test.ts
+++ b/src/__tests__/schedule-runner-injection-priority.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { taskInjectionRank } from '../web/schedule-runner.js'
+
+// Same-minute injection starvation (2026-07-20 incident): several tasks due in
+// one scan window are fired sequentially, and a single injection takes seconds
+// to a minute (readiness double-sample, waitForIdle gate, chunked typing).
+// listScheduledTasks() returns directory order, so at 07:30 the alphabetical
+// alkuszoktatas-feedback-figyelo heartbeat was injected before the
+// reggeli-napindito morning briefing every day. Fix: order due tasks by
+// injection priority (forceSend > plain task > heartbeat) before firing.
+//
+// The companion delivery bug (2026-07-17): forceSend bypassed EVERY busy state,
+// including context saturation -- the prompt was typed into a 100%-context
+// session that could never act on it, and the context-guard's rescue restart
+// discarded the queued input. A silent drop wearing a "fired" log line.
+// Fix: forceSend defers ONLY on saturation, via the pending-retry queue.
+
+const SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+
+describe('taskInjectionRank: forceSend outranks tasks outranks heartbeats', () => {
+  it('ranks forceSend first regardless of type', () => {
+    expect(taskInjectionRank({ forceSend: true, type: 'task' })).toBe(0)
+    expect(taskInjectionRank({ forceSend: true, type: 'heartbeat' })).toBe(0)
+  })
+
+  it('ranks plain tasks before heartbeats', () => {
+    expect(taskInjectionRank({ forceSend: false, type: 'task' })).toBeLessThan(
+      taskInjectionRank({ forceSend: false, type: 'heartbeat' }),
+    )
+    expect(taskInjectionRank({ type: 'command' })).toBeLessThan(
+      taskInjectionRank({ type: 'heartbeat' }),
+    )
+  })
+
+  it('reproduces the 07-20 ordering: napindito (forceSend) beats the feedback heartbeat', () => {
+    const due = [
+      { name: 'alkuszoktatas-feedback-figyelo', forceSend: undefined, type: 'heartbeat' },
+      { name: 'reggeli-napindito', forceSend: true, type: 'task' },
+      { name: 'reggeli-penzugyi-riasztasok', forceSend: undefined, type: 'task' },
+    ] as const
+    const ordered = [...due].sort((a, b) => taskInjectionRank(a) - taskInjectionRank(b))
+    expect(ordered.map(t => t.name)).toEqual([
+      'reggeli-napindito',
+      'reggeli-penzugyi-riasztasok',
+      'alkuszoktatas-feedback-figyelo',
+    ])
+  })
+
+  it('the cron loop actually applies the rank ordering', () => {
+    // The task list must be rank-sorted before the fire loop iterates it.
+    const sortIdx = SRC.indexOf('tasks.sort((a, b) => taskInjectionRank(a) - taskInjectionRank(b))')
+    const loopIdx = SRC.indexOf('for (const task of tasks)')
+    expect(sortIdx).toBeGreaterThan(0)
+    expect(loopIdx).toBeGreaterThan(sortIdx)
+  })
+})
+
+describe('forceSend defers on context saturation instead of injecting', () => {
+  it('checks paneShowsContextSaturation inside the forceSend branch and returns busy', () => {
+    const idx = SRC.indexOf('if (task.forceSend) {')
+    expect(idx).toBeGreaterThan(0)
+    const branch = SRC.slice(idx, idx + 1800)
+    expect(branch).toMatch(/paneShowsContextSaturation/)
+    expect(branch).toMatch(/return 'busy'/)
+  })
+
+  it('the skipIfBusy drop exempts forceSend so the deferral queues a retry', () => {
+    // A forceSend 'busy' comes only from the saturation deferral; dropping it
+    // on skipIfBusy would recreate the silent loss the deferral exists to fix.
+    expect(SRC).toMatch(/task\.skipIfBusy && !task\.forceSend/)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -74,6 +74,12 @@ function resolveAgentProvider(name: string): ChannelProviderType {
 
 const agentDownSince: Map<string, number> = new Map()
 const agentLastRestart: Map<string, number> = new Map()
+// Agents already warned about a missing channel token, so the per-sweep probe
+// does not repeat the identical WARN every minute forever (observed 2026-07-20:
+// teamer, an agent with no channel token bound, emitted the same line ~1440x/day
+// and drowned the log). First detection warns; repeats drop to debug. Cleared
+// when a token appears so a later un-bind is announced again.
+const agentNoTokenWarned: Set<string> = new Set()
 // Sessions whose busy-deferral cap has already been reported to the operator, so
 // the alert fires once per down-spell instead of every sweep. Cleared when the
 // plugin recovers (or when the agent is restarted after it goes idle).
@@ -1506,9 +1512,18 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         const stateDir = channelStateDir(agentProvider, agentDir(t.agentName!))
         const agentToken = readChannelToken(agentProvider, join(stateDir, '.env'))
         if (!agentToken) {
-          logger.warn({ agent: t.agentName, provider: agentProvider }, 'Agent has no channel token in state dir -- skipping restart to avoid token conflict')
+          // A token-less agent (never paired a channel) trips the down-probe on
+          // every sweep; the condition is permanent until an operator binds a
+          // token, so warn once and drop the repeats to debug.
+          if (!agentNoTokenWarned.has(t.agentName!)) {
+            agentNoTokenWarned.add(t.agentName!)
+            logger.warn({ agent: t.agentName, provider: agentProvider }, 'Agent has no channel token in state dir -- skipping restart to avoid token conflict (further occurrences logged at debug)')
+          } else {
+            logger.debug({ agent: t.agentName, provider: agentProvider }, 'Agent has no channel token in state dir -- skipping restart to avoid token conflict')
+          }
           continue
         }
+        agentNoTokenWarned.delete(t.agentName!)
         // Stagger: only one channel-down restart per CHANNEL_RESTART_STAGGER_MS
         // fleet-wide, so fresh sub-agent cold-boots serialise instead of racing.
         if (Date.now() - lastChannelAgentRestartAt < CHANNEL_RESTART_STAGGER_MS) {

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -46,6 +46,7 @@ import {
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
 import { runCommandTask } from './command-task.js'
+import { paneShowsContextSaturation } from '../pane-state.js'
 
 // How many bare-Enter attempts the post-send resubmit tries before escalating
 // to a clear + re-inject, and the hard cap after which it gives up.
@@ -234,18 +235,28 @@ async function attemptFireTask(
   // will process it at the next idle slot. This prevents the infinite
   // retry loop observed when the target session stays busy for hours
   // (275 retries overnight in production).
-  //
-  // KNOWN FOLLOW-UP: forceSend also bypasses the context-saturation refusal
-  // now folded into isSessionReadyForPrompt(). A forceSend task can therefore
-  // still land on a 100%-context session. Left open deliberately -- forceSend's
-  // contract is "always eventually land, never silently drop", and a saturated
-  // session needs a separate delivery policy, tracked as future work.
   if (!task.forceSend && !(await isSessionReadyForPrompt(session, host))) {
     logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session busy or has pending input, will retry')
     return 'busy'
   }
 
   if (task.forceSend) {
+    // forceSend's contract is "always eventually land, never silently drop" --
+    // but injecting into a 100%-context session IS a silent drop with extra
+    // steps: the pane accepts the keystrokes and the wedged session never acts
+    // on them, and the context-guard's rescue restart then discards the queued
+    // input (2026-07-17: reggeli-napindito force-injected into a saturated
+    // marveen-channels and vanished without a trace). Closes the KNOWN
+    // FOLLOW-UP that previously lived here: saturation is the one busy-state
+    // forceSend must respect. Defer via the pending-retry queue (the caller
+    // maps 'busy' to a retry row, exempt from skipIfBusy for forceSend); the
+    // retry lands on the first tick after the session has been rescued. All
+    // other busy states keep the bypass.
+    const pane = capturePane(session, host)
+    if (pane != null && paneShowsContextSaturation(pane)) {
+      logger.warn({ task: task.name, agent: agentName, session }, 'forceSend target session is context-saturated (100%) -- deferring to retry queue instead of injecting into a wedged session')
+      return 'busy'
+    }
     logger.info({ task: task.name, agent: agentName, session }, 'forceSend=true, bypassing busy-state check')
   }
 
@@ -394,6 +405,22 @@ async function attemptFireTask(
     appendTaskRun(task.name, agentName, 'error')
     return 'error'
   }
+}
+
+// Injection priority within one tick: when several tasks are due in the same
+// scan window, the order of attemptFireTask calls decides who gets the target
+// session first -- and an injection takes seconds to a minute (readiness
+// double-sample, waitForIdle gate, chunked typing, post-send verify), so the
+// first task can push every later one well past its scheduled minute.
+// listScheduledTasks() returns directory (alphabetical) order, which let a
+// routine 30-min heartbeat outrank the operator-facing morning briefing every
+// day (2026-07-20: alkuszoktatas-feedback-figyelo injected first at 07:30 and
+// reggeli-napindito starved behind it). Rank: forceSend tasks (operator-marked
+// must-deliver) first, plain tasks next, heartbeats (short-cadence, typically
+// skipIfBusy) last. The sort is stable, so name order is kept within a rank.
+export function taskInjectionRank(t: Pick<ScheduledTask, 'forceSend' | 'type'>): number {
+  if (t.forceSend) return 0
+  return t.type === 'heartbeat' ? 2 : 1
 }
 
 // Manual "Run now": fire a scheduled task immediately, bypassing the cron
@@ -624,6 +651,12 @@ export function startScheduleRunner(): NodeJS.Timeout {
       if (stillPresent && view.alertDue) sendPendingRetryAlert(view, now)
     }
 
+    // Fire in injection-priority order, not directory order: with several
+    // tasks due in one window, each injection delays the next by seconds to a
+    // minute, so forceSend/task entries must reach the session before the
+    // routine heartbeats (see taskInjectionRank). listScheduledTasks() builds
+    // a fresh array every tick, so the in-place sort leaks nowhere.
+    tasks.sort((a, b) => taskInjectionRank(a) - taskInjectionRank(b))
     for (const task of tasks) {
       if (!task.enabled) continue
       if (!cronDueBetween(task.schedule, fromMs, now)) continue
@@ -689,7 +722,12 @@ export function startScheduleRunner(): NodeJS.Timeout {
           // pending-retry loop then sends as soon as Claude has booted.
           insertPendingTaskRetryIfNew(task.name, agentName, now, 'starting')
         } else if (result === 'busy') {
-          if (task.skipIfBusy) {
+          // A forceSend task only ever reports 'busy' from the context-
+          // saturation deferral inside attemptFireTask -- every other busy
+          // state is bypassed. Dropping that on skipIfBusy would turn the
+          // deferral into a silent loss, so forceSend is exempt from the
+          // skip and always queues the retry.
+          if (task.skipIfBusy && !task.forceSend) {
             // Opt-in skip for short-cadence tasks (e.g. 30-min heartbeats):
             // a single missed tick is harmless because the next one is
             // already on the way, and queueing them produces spurious


### PR DESCRIPTION
## Context

Morning briefing (reggeli-napindito, 07:30, forceSend) and Boni's financial alert (08:15) did not reach Szabi. Investigation found two distinct delivery bugs plus a log-noise issue.

### What actually happened (prod, running main)

- **07-18..07-20**: the briefing never even fired. Prod main still has the fixed-60s `cronMatchesNow` window; the scheduler tick is slow (sync readiness sleeps + chunked tmux typing) and per-task `Date.now()` evaluation let alphabetically-earlier due tasks (alkuszoktatas-feedback-figyelo, same 07:30 minute) push later tasks past the window -- silent miss, zero log lines. **This root cause is already fixed on develop by #621 (`cronDueBetween` contiguous real-interval windows)** and ships with the next release; the config stagger applied today mitigates prod until then.
- **07-17**: the briefing DID fire -- forceSend bypassed the busy check and injected into a context-saturated (100%) marveen-channels session. The prompt was typed into a wedged pane and vanished: a silent drop wearing a 'fired' log line. This gap (documented KNOWN FOLLOW-UP in the code) exists on develop too.
- `schedule-last-run.json` confirms collateral: reggeli-napindito + reggeli-penzugyi-riasztasok last ran 07-17, memoria-heartbeat 07-13, hourly-heartbeat 07-19.

## Changes (develop base)

1. **Injection priority within a tick** (`taskInjectionRank`, exported + unit-tested): due tasks fire forceSend -> plain task -> heartbeat instead of directory order. With #621 a late task is no longer *lost*, but ordering still decides who reaches the session on time; the operator-facing briefing must not queue behind a routine heartbeat.
2. **forceSend saturation deferral**: forceSend keeps bypassing every busy state EXCEPT context saturation, where injection is provably a silent drop (context-guard restart discards queued input). Defers via the pending-task-retry queue (never abandoned, exempt from skipIfBusy), lands on the first tick after the session is rescued. Closes the KNOWN FOLLOW-UP.
3. **channel-monitor no-token WARN throttle**: an agent with no channel token bound (currently: teamer) tripped the down-probe every sweep -> identical WARN ~1440x/day. Warn once, repeats at debug, re-armed on token appearance/disappearance.

## Verification

- `tsc --noEmit` clean
- `vitest run`: 2429 passed; 13 failures are pre-existing on the clean develop base (hook-path/email-gate/governance suites, unrelated -- verified via git stash A/B)
- New suite `schedule-runner-injection-priority.test.ts`: rank unit tests incl. the 07-20 ordering repro + source contracts for the saturation deferral and skipIfBusy exemption

## Answers to the delegation questions

- **Why didn't forceSend deliver despite 'bypassing busy-state check'?** On 07-17 it injected into a 100%-context session (see above). On 07-18..20 it never fired at all (window miss, #621 fixes it).
- **Does the scheduler hot-reload task-config.json?** Yes -- `listScheduledTasks()` reads from disk on every 60s tick; today's cron stagger edit was live within a minute, no restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)