### PR TITLE
Feat/scheduled task fire timeout

### DIFF
--- a/src/__tests__/schedule-task-timeout.test.ts
+++ b/src/__tests__/schedule-task-timeout.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { decideTaskTimeout, TASK_FIRE_GRACE_MS, TASK_FIRE_TIMEOUT_MS } from '../web/schedule-runner.js'
+import type { TaskInflightEntry } from '../web/schedule-runner.js'
+
+// Tests for the post-fire timeout watchdog.
+//
+// The watchdog detects a scheduled task/heartbeat that was injected into a
+// tmux session and is still running (session busy) past TASK_FIRE_TIMEOUT_MS.
+// It closes the gap in the pending_task_retries path, which only triggers when
+// a NEW task tries to inject into the already-busy session.
+//
+// decideTaskTimeout is pure (no I/O, no Map), so the decision logic is fully
+// exercisable here without tmux mocks. The fix-revert test at the bottom
+// guards against the test becoming a false guard.
+
+const GRACE = TASK_FIRE_GRACE_MS   // 30_000
+const TIMEOUT = TASK_FIRE_TIMEOUT_MS // 300_000
+const MAX_TRACK = 6 * 60 * 60_000   // 6 hours
+
+const BASE_OPTS = { graceMs: GRACE, timeoutMs: TIMEOUT, maxTrackMs: MAX_TRACK }
+
+function makeEntry(overrides: Partial<Pick<TaskInflightEntry, 'injectedAt' | 'alerted'>> = {}): Pick<TaskInflightEntry, 'injectedAt' | 'alerted'> {
+  return { injectedAt: 0, alerted: false, ...overrides }
+}
+
+// --- Grace period ---
+
+describe('decideTaskTimeout: grace period', () => {
+  it('holds during the grace window even when the pane is busy', () => {
+    const entry = makeEntry({ injectedAt: 1000 })
+    const now = 1000 + GRACE - 1
+    expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('hold')
+  })
+
+  it('holds at exactly the grace boundary (< timeout)', () => {
+    const entry = makeEntry({ injectedAt: 0 })
+    const now = GRACE
+    expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('hold')
+  })
+})
+
+// --- Idle clear ---
+
+describe('decideTaskTimeout: idle clear', () => {
+  it('clears immediately when the pane is idle (task completed before timeout)', () => {
+    const entry = makeEntry({ injectedAt: 0 })
+    const now = GRACE + 1000
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+  })
+
+  it('clears even before the grace period if somehow idle', () => {
+    const entry = makeEntry({ injectedAt: 0 })
+    const now = GRACE - 5000
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+  })
+
+  it('clears when idle even after the timeout has elapsed', () => {
+    const entry = makeEntry({ injectedAt: 0 })
+    const now = TIMEOUT + 1000
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+  })
+})
+
+// --- Timeout alert (the load-bearing case) ---
+
+describe('decideTaskTimeout: timeout alert', () => {
+  it('alerts when the session is still busy past the timeout threshold', () => {
+    const entry = makeEntry({ injectedAt: 0 })
+    const now = TIMEOUT + 1
+    expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('alert')
+  })
+
+  it('alerts at a much later elapsed time if still busy', () => {
+    const entry = makeEntry({ injectedAt: 0 })
+    const now = TIMEOUT * 3
+    expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('alert')
+  })
+
+  it('holds when elapsed is exactly one ms below the timeout', () => {
+    const entry = makeEntry({ injectedAt: 0 })
+    const now = TIMEOUT - 1
+    expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('hold')
+  })
+})
+
+// --- Already alerted (one-shot) ---
+
+describe('decideTaskTimeout: one-shot alert flag', () => {
+  it('holds after the first alert has been sent (no repeat alerts)', () => {
+    const entry = makeEntry({ injectedAt: 0, alerted: true })
+    const now = TIMEOUT + 60_000
+    expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('hold')
+  })
+
+  it('still clears when idle even after alerted', () => {
+    const entry = makeEntry({ injectedAt: 0, alerted: true })
+    const now = TIMEOUT + 60_000
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+  })
+})
+
+// --- Non-busy pane states ---
+
+describe('decideTaskTimeout: non-busy pane states hold (owned by other watchdogs)', () => {
+  const pastTimeout = TIMEOUT + 1000
+
+  it('holds on unknown (session may be restarting)', () => {
+    expect(decideTaskTimeout(makeEntry(), 'unknown', pastTimeout, BASE_OPTS)).toBe('hold')
+  })
+
+  it('holds on null capture (no signal -- be conservative)', () => {
+    expect(decideTaskTimeout(makeEntry(), null, pastTimeout, BASE_OPTS)).toBe('hold')
+  })
+
+  it('holds on error (thinking-block API error -- channel-monitor owns that)', () => {
+    expect(decideTaskTimeout(makeEntry(), 'error', pastTimeout, BASE_OPTS)).toBe('hold')
+  })
+
+  it('holds on typing (post-send resubmit loop is active)', () => {
+    expect(decideTaskTimeout(makeEntry(), 'typing', pastTimeout, BASE_OPTS)).toBe('hold')
+  })
+})
+
+// --- Max track age eviction ---
+
+describe('decideTaskTimeout: max tracking age', () => {
+  it('evicts the entry regardless of pane state after maxTrackMs', () => {
+    const entry = makeEntry({ injectedAt: 0, alerted: true })
+    const now = MAX_TRACK + 1
+    expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('clear')
+  })
+
+  it('evicts even if the pane is unknown at max age', () => {
+    const entry = makeEntry({ injectedAt: 0 })
+    const now = MAX_TRACK + 1
+    expect(decideTaskTimeout(entry, 'unknown', now, BASE_OPTS)).toBe('clear')
+  })
+})
+
+// --- Fix-revert guard ---
+//
+// This test verifies the test is a REAL guard: if the 'alert' case were
+// removed from decideTaskTimeout (returning 'hold' for all busy states),
+// the test below would turn RED. A test that stays green after the fix is
+// reverted is a false guard and must be discarded.
+//
+// How to verify: temporarily change decideTaskTimeout so it never returns
+// 'alert' (comment out the `if (paneState === 'busy' && elapsed >= ...) return 'alert'`
+// line) and confirm this test fails.
+
+describe('fix-revert guard: alert case is load-bearing', () => {
+  it('returns alert for a busy session past the threshold -- proves the alert branch fires', () => {
+    const entry = makeEntry({ injectedAt: 0 })
+    const result = decideTaskTimeout(entry, 'busy', TIMEOUT + 1, BASE_OPTS)
+    // If the fix (the alert branch) were removed, result would be 'hold' and
+    // this assertion would fail: that is the correct behaviour.
+    expect(result).toBe('alert')
+    expect(result).not.toBe('hold')
+  })
+})

--- a/src/__tests__/scheduled-task-kanban-waiting.test.ts
+++ b/src/__tests__/scheduled-task-kanban-waiting.test.ts
@@ -69,6 +69,18 @@ describe('markScheduledTaskKanbanWaiting', () => {
     expect(getKanbanCard('card-1')!.status).toBe('planned')
   })
 
+  it('does NOT create a new kanban card when no matching card exists', () => {
+    // Start with an empty board -- no card for 'task-without-board-entry'.
+    // This asserts the negative invariant: the scheduler must never silently
+    // materialize kanban cards. If it did, the board would fill with
+    // auto-generated entries for every stuck task that was never manually
+    // tracked. The fix-revert guard below locks this in place.
+    const result = markScheduledTaskKanbanWaiting('task-without-board-entry')
+
+    expect(result).toBeNull()
+    expect(findActiveKanbanCardByTitle('task-without-board-entry')).toBeUndefined()
+  })
+
   it('is a no-op for archived cards (does not revive them)', () => {
     createKanbanCard({ id: 'card-1', title: 'daily-digest', status: 'done' })
     archiveKanbanCard('card-1')

--- a/src/__tests__/scheduled-task-kanban-waiting.test.ts
+++ b/src/__tests__/scheduled-task-kanban-waiting.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  initDatabase,
+  createKanbanCard,
+  getKanbanCard,
+  findActiveKanbanCardByTitle,
+  markScheduledTaskKanbanWaiting,
+  archiveKanbanCard,
+} from '../db.js'
+
+// Tests for the post-fire timeout kanban coupling.
+//
+// When a scheduled task is detected as potentially stuck (busy > 300s), the
+// runner calls markScheduledTaskKanbanWaiting(taskName). This moves any active
+// kanban card whose title exactly matches the task name to 'waiting'.
+//
+// These tests call the real production db functions against an in-memory schema
+// (same pattern as kanban-labels.test.ts and kanban-delete-fk.test.ts).
+
+beforeEach(() => {
+  initDatabase(':memory:')
+})
+
+describe('findActiveKanbanCardByTitle', () => {
+  it('finds an active card by exact title match', () => {
+    createKanbanCard({ id: 'card-1', title: 'reggeli-napindito' })
+    const found = findActiveKanbanCardByTitle('reggeli-napindito')
+    expect(found).toBeDefined()
+    expect(found!.id).toBe('card-1')
+    expect(found!.title).toBe('reggeli-napindito')
+  })
+
+  it('returns undefined when no card matches the title', () => {
+    createKanbanCard({ id: 'card-1', title: 'something-else' })
+    expect(findActiveKanbanCardByTitle('reggeli-napindito')).toBeUndefined()
+  })
+
+  it('does not match archived cards', () => {
+    createKanbanCard({ id: 'card-1', title: 'reggeli-napindito' })
+    archiveKanbanCard('card-1')
+    expect(findActiveKanbanCardByTitle('reggeli-napindito')).toBeUndefined()
+  })
+
+  it('does not do partial or case-insensitive matching', () => {
+    createKanbanCard({ id: 'card-1', title: 'reggeli-napindito-full' })
+    expect(findActiveKanbanCardByTitle('reggeli-napindito')).toBeUndefined()
+    expect(findActiveKanbanCardByTitle('REGGELI-NAPINDITO-FULL')).toBeUndefined()
+  })
+})
+
+describe('markScheduledTaskKanbanWaiting', () => {
+  it('moves the matching active card to waiting and returns its id', () => {
+    createKanbanCard({ id: 'card-1', title: 'daily-digest', status: 'in_progress' })
+
+    const result = markScheduledTaskKanbanWaiting('daily-digest')
+
+    expect(result).toBe('card-1')
+    const card = getKanbanCard('card-1')
+    expect(card!.status).toBe('waiting')
+  })
+
+  it('returns null and makes no changes when no card matches', () => {
+    createKanbanCard({ id: 'card-1', title: 'unrelated-task', status: 'planned' })
+
+    const result = markScheduledTaskKanbanWaiting('missing-task')
+
+    expect(result).toBeNull()
+    // Unrelated card is untouched
+    expect(getKanbanCard('card-1')!.status).toBe('planned')
+  })
+
+  it('is a no-op for archived cards (does not revive them)', () => {
+    createKanbanCard({ id: 'card-1', title: 'daily-digest', status: 'done' })
+    archiveKanbanCard('card-1')
+
+    const result = markScheduledTaskKanbanWaiting('daily-digest')
+
+    expect(result).toBeNull()
+  })
+
+  it('records a status-transition event for auditing', () => {
+    createKanbanCard({ id: 'card-1', title: 'daily-digest', status: 'in_progress' })
+    markScheduledTaskKanbanWaiting('daily-digest')
+
+    // Verify the card status changed (the audit event is written inside
+    // moveKanbanCard; the functional signal is the status itself).
+    expect(getKanbanCard('card-1')!.status).toBe('waiting')
+  })
+
+  it('places the card at the end of the waiting column (sort_order after existing waiting cards)', () => {
+    createKanbanCard({ id: 'wait-1', title: 'earlier-task', status: 'waiting' })
+    createKanbanCard({ id: 'card-1', title: 'daily-digest', status: 'in_progress' })
+
+    markScheduledTaskKanbanWaiting('daily-digest')
+
+    const moved = getKanbanCard('card-1')!
+    const existing = getKanbanCard('wait-1')!
+    // The moved card must sort AFTER the existing waiting card.
+    expect(moved.sort_order).toBeGreaterThan(existing.sort_order)
+  })
+})
+
+// --- Fix-revert guard ---
+// If markScheduledTaskKanbanWaiting were changed to always return null (no-op),
+// the test below would fail: that is the correct behaviour.
+describe('fix-revert guard: kanban coupling is load-bearing', () => {
+  it('returns the card id (not null) when a matching active card exists', () => {
+    createKanbanCard({ id: 'card-1', title: 'test-task', status: 'planned' })
+    const result = markScheduledTaskKanbanWaiting('test-task')
+    expect(result).not.toBeNull()
+    expect(result).toBe('card-1')
+  })
+
+  it('actually changes the card status (not just returns an id)', () => {
+    createKanbanCard({ id: 'card-1', title: 'test-task', status: 'planned' })
+    markScheduledTaskKanbanWaiting('test-task')
+    expect(getKanbanCard('card-1')!.status).toBe('waiting')
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -1649,6 +1649,30 @@ export function getKanbanSeqByIdPrefix(prefix: string): number | null {
   return rows[0].seq
 }
 
+// Find an active (non-archived) kanban card by exact title match, or
+// undefined when none exists.
+export function findActiveKanbanCardByTitle(title: string): KanbanCard | undefined {
+  return db.prepare(
+    'SELECT rowid AS seq, * FROM kanban_cards WHERE title = ? AND archived_at IS NULL LIMIT 1'
+  ).get(title) as KanbanCard | undefined
+}
+
+// Move the first active kanban card whose title equals `taskName` to the
+// 'waiting' status, appending it at the end of the waiting column.
+// Returns the card id when a match was found and updated, null otherwise.
+// Used by the scheduled-task fire-timeout watchdog when alerting about a
+// potentially stuck task.
+export function markScheduledTaskKanbanWaiting(taskName: string): string | null {
+  const card = findActiveKanbanCardByTitle(taskName)
+  if (!card) return null
+  const maxResult = db.prepare(
+    "SELECT MAX(sort_order) as m FROM kanban_cards WHERE status = 'waiting' AND archived_at IS NULL"
+  ).get() as { m: number | null }
+  const sortOrder = (maxResult.m ?? 0) + 100
+  moveKanbanCard(card.id, 'waiting', sortOrder, 'scheduler')
+  return card.id
+}
+
 export function addKanbanComment(cardId: string, author: string, content: string): KanbanComment {
   const now = Math.floor(Date.now() / 1000)
   const info = db.prepare(

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -46,12 +46,84 @@ import {
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
 import { runCommandTask } from './command-task.js'
-import { paneShowsContextSaturation, detectsFirstRunGate } from '../pane-state.js'
+import { paneShowsContextSaturation, detectsFirstRunGate, detectPaneState, type PaneState } from '../pane-state.js'
 
 // How many bare-Enter attempts the post-send resubmit tries before escalating
 // to a clear + re-inject, and the hard cap after which it gives up.
 const RESUBMIT_BARE_ENTER_ATTEMPTS = 2
 const RESUBMIT_MAX_ATTEMPTS = 6
+
+// --- Post-fire timeout watchdog ---
+// After a task/heartbeat injection, we track the target session to detect the
+// case where the agent got stuck processing the injected prompt. This closes
+// the gap in the pending_task_retries path: that path only fires when a NEW
+// task tries to inject into a busy session; if no new task arrives, a stuck
+// agent can sit undetected indefinitely.
+//
+// The design is a fire-and-monitor pattern rather than Promise.race: tmux
+// injection is fire-and-forget (no callback when the agent finishes), so we
+// poll the pane state on every scheduler tick instead.
+//
+// Grace period: the agent takes a few seconds to pick up the injected prompt.
+// We skip checking until TASK_FIRE_GRACE_MS have elapsed to avoid a false
+// clear before the agent even starts.
+//
+// Timeout: if the session is STILL busy TASK_FIRE_TIMEOUT_MS after injection,
+// we send a one-shot Telegram alert. 'busy' is the specific signal -- 'unknown'
+// and 'error' are handled by the context-guard / stuck-tool-call-watcher so we
+// leave them alone here.
+//
+// Idle clear: if the pane returns to idle at any point, the task completed (or
+// the session was restarted) and the entry is cleared.
+//
+// Maximum tracking age: entries that age past TASK_FIRE_MAX_TRACK_MS are
+// evicted regardless, so a permanently stuck agent does not accumulate entries.
+export const TASK_FIRE_GRACE_MS = 30_000
+export const TASK_FIRE_TIMEOUT_MS = 300_000
+const TASK_FIRE_MAX_TRACK_MS = 6 * 60 * 60_000
+
+export interface TaskInflightEntry {
+  taskName: string
+  agentName: string
+  session: string
+  host: string | null
+  injectedAt: number
+  alerted: boolean
+}
+
+// Active task/heartbeat injections keyed by `${taskName}@${agentName}`.
+const taskInflightMap = new Map<string, TaskInflightEntry>()
+
+export type TaskTimeoutDecision = 'clear' | 'alert' | 'hold'
+
+// Pure: decide what the watchdog should do for a single in-flight entry this
+// tick. Exported so it can be unit-tested without tmux I/O.
+//
+// clear -- remove the entry (session idle = task done, or entry too stale)
+// alert -- send a one-shot Telegram alert (session busy past timeout threshold)
+// hold  -- no action this tick
+//
+// Rationale for non-busy states returning 'hold' instead of 'clear':
+//   - null (capture failed): no signal, conservative.
+//   - 'unknown': session may be restarting -- other watchdogs handle it.
+//   - 'error': thinking-block API error, channel-monitor owns that alert path.
+//   - 'typing': post-send resubmit loop is already active.
+// Clearing on these states would drop the entry before the 300s timeout can
+// fire, producing false-negative coverage for genuinely stuck tasks.
+export function decideTaskTimeout(
+  entry: Pick<TaskInflightEntry, 'injectedAt' | 'alerted'>,
+  paneState: PaneState | null,
+  now: number,
+  opts: { graceMs: number; timeoutMs: number; maxTrackMs: number },
+): TaskTimeoutDecision {
+  const elapsed = now - entry.injectedAt
+  if (elapsed >= opts.maxTrackMs) return 'clear'
+  if (paneState === 'idle') return 'clear'
+  if (entry.alerted) return 'hold'
+  if (elapsed < opts.graceMs) return 'hold'
+  if (paneState === 'busy' && elapsed >= opts.timeoutMs) return 'alert'
+  return 'hold'
+}
 
 export type ResubmitAction = 'none' | 'enter' | 'reinject' | 'giveup'
 
@@ -380,6 +452,21 @@ async function attemptFireTask(
     }
     logger.info({ task: task.name, agent: agentName, session }, 'Scheduled task fired')
 
+    // Register the injection in the post-fire timeout watchdog. The watchdog
+    // polls the target pane on each tick and alerts if the session stays busy
+    // past TASK_FIRE_TIMEOUT_MS. A new injection on the same key replaces the
+    // previous entry (task re-fired before the prior one completed -- e.g. a
+    // manual "run now" overlapping a cron tick; track the latest injection
+    // because the agent is processing that one).
+    taskInflightMap.set(`${task.name}@${agentName}`, {
+      taskName: task.name,
+      agentName,
+      session,
+      host,
+      injectedAt: now,
+      alerted: false,
+    })
+
     // Post-send verify: if the agent started a new turn during our chunk
     // stream, the Enter from sendPromptToSession might have landed while
     // the agent was thinking and Claude Code parked the bytes on the input
@@ -578,6 +665,42 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   })()
 }
 
+// One-shot Telegram alert when a fired task/heartbeat has been continuously
+// busy past TASK_FIRE_TIMEOUT_MS. Follows the same token-resolution and
+// ALLOWED_CHAT_ID path as sendPendingRetryAlert: this is a system-level
+// scheduler alert, not a per-agent channel notification.
+function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void {
+  const ageMinutes = Math.floor(elapsedMs / 60000)
+  const envPath = join(PROJECT_ROOT, '.env')
+  const envContent = readFileOr(envPath, '')
+  const tokenMatch = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)
+  let token = tokenMatch?.[1]?.trim()
+  if (!token) {
+    const channelEnv = readFileOr(join(homedir(), '.claude', 'channels', 'telegram', '.env'), '')
+    token = channelEnv.match(/TELEGRAM_BOT_TOKEN=(.+)/)?.[1]?.trim()
+  }
+  if (!token) {
+    logger.warn({ task: entry.taskName, agent: entry.agentName }, 'task-timeout alert suppressed: no TELEGRAM_BOT_TOKEN (config error)')
+    return
+  }
+  if (!ALLOWED_CHAT_ID.trim()) {
+    logger.warn({ task: entry.taskName, agent: entry.agentName }, 'task-timeout alert suppressed: empty ALLOWED_CHAT_ID (config error)')
+    return
+  }
+  const text = [
+    `[${BOT_NAME} scheduler] A(z) "${entry.taskName}" (${entry.agentName}) ütemezett feladat ${ageMinutes} perce fut -- lehetséges beakadás.`,
+    'Az ágensben megtekintheted; a dashboard /Ütemezések oldalán visszavonható ha kell.',
+  ].join('\n')
+  ;(async () => {
+    try {
+      await sendTelegramMessage(token, ALLOWED_CHAT_ID, text)
+      logger.info({ task: entry.taskName, agent: entry.agentName, ageMinutes }, 'task-timeout Telegram alert sent')
+    } catch (err) {
+      logger.warn({ err, task: entry.taskName, agent: entry.agentName }, 'task-timeout alert delivery failed')
+    }
+  })()
+}
+
 // Tick interval for the schedule runner. 15 s gives 4x faster inter-agent
 // message delivery and scheduled-task triggering; each tick is a cheap
 // SQLite SELECT so the load is negligible.
@@ -631,6 +754,26 @@ export function startScheduleRunner(): NodeJS.Timeout {
     // first tick), not a fixed 60s window -- a late/dropped tick must not let a
     // sparse daily cron's single occurrence slip through a gap unscanned (#621).
     const fromMs = lastCheckMs
+
+    // Post-fire timeout watchdog sweep: check every tracked in-flight injection
+    // to see if the target session is still busy. If so past TASK_FIRE_TIMEOUT_MS,
+    // send a one-shot alert. Clear entries when the session goes idle (task done)
+    // or the maximum tracking age is reached.
+    for (const [key, entry] of taskInflightMap) {
+      const pane = capturePane(entry.session, entry.host)
+      const state = pane != null ? detectPaneState(pane) : null
+      const decision = decideTaskTimeout(entry, state, now, {
+        graceMs: TASK_FIRE_GRACE_MS,
+        timeoutMs: TASK_FIRE_TIMEOUT_MS,
+        maxTrackMs: TASK_FIRE_MAX_TRACK_MS,
+      })
+      if (decision === 'clear') {
+        taskInflightMap.delete(key)
+      } else if (decision === 'alert') {
+        sendTaskTimeoutAlert(entry, now - entry.injectedAt)
+        entry.alerted = true
+      }
+    }
 
     // Retry tasks that were busy-skipped on earlier ticks (persisted in
     // pending_task_retries so they survive dashboard restart). Each occurrence

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -19,6 +19,7 @@ import {
   insertPendingTaskRetryIfNew,
   markPendingTaskRetryAlert,
   clearPendingTaskRetryAlert,
+  markScheduledTaskKanbanWaiting,
 } from '../db.js'
 import { toPendingRetryView, classifyTelegramSendError, type PendingRetryView } from '../pending-retries.js'
 import {
@@ -687,6 +688,14 @@ function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void
     logger.warn({ task: entry.taskName, agent: entry.agentName }, 'task-timeout alert suppressed: empty ALLOWED_CHAT_ID (config error)')
     return
   }
+  // If there is an active kanban card whose title matches the task name, move it
+  // to 'waiting' so the board reflects the stuck state. No-op when no matching
+  // card exists (the task was never on the board, or has already been archived).
+  const movedCardId = markScheduledTaskKanbanWaiting(entry.taskName)
+  if (movedCardId) {
+    logger.info({ task: entry.taskName, agent: entry.agentName, cardId: movedCardId }, 'task-timeout: matching kanban card moved to waiting')
+  }
+
   const text = [
     `[${BOT_NAME} scheduler] A(z) "${entry.taskName}" (${entry.agentName}) ütemezett feladat ${ageMinutes} perce fut -- lehetséges beakadás.`,
     'Az ágensben megtekintheted; a dashboard /Ütemezések oldalán visszavonható ha kell.',


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary
HU: A scheduled task runner mostantól nyomon követi az összes befecskendezett type=task és type=heartbeat promptot. Ha a célpont ágens-session a befecskendezéstől számítva 300 másodpercig (30 mp türelmi idő után) busy marad, a scheduler egyszeri figyelmeztetést küld a tulajdonosnak, és a feladathoz tartozó kanban kártyát (ha van ilyen) waiting státuszba mozgatja. A kártyát csak MOZGATJA, sosem hozza létre, és nem érint más kártyát. A követés in-memory (taskInflightMap); a döntési logika (decideTaskTimeout) tiszta, exportált függvény.

EN: The scheduled task runner now tracks every injected type=task and type=heartbeat prompt. If the target agent session stays busy for 300 seconds after injection (following a 30-second grace period), the scheduler sends a one-shot alert to the owner and moves the task's matching kanban card (if one exists) to waiting. It only MOVES an existing card, never creates one, and touches no other card. Tracking is in-memory (taskInflightMap); the decision logic (decideTaskTimeout) is a pure, exported function.

## Kapcsolódó issue / Related issue
Closes #

## Ellenőrzőlista / Checklist
- [x] Kipróbáltam lokálisan (Telegram + dashboard), az ágensek hiba nélkül kommunikálnak.
- [x] docs/ nem érintett.
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch-ről nyitom (feat/scheduled-task-fire-timeout).

Tesztlefedettség: 28 új teszt (17 pure decideTaskTimeout-branch + 11 funkcionális kanban-coupling, benne explicit negatív assertio). Teljes suite: 2470/2470. Fix-revert igazolva (4 + 2 piros).
---