### PR TITLE
fix(onboarding): claudeAuthPresent recognizes the fleet setup-token (#654)

### DIFF
--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -59,6 +59,18 @@ function keychainHasClaudeCredentials(): boolean {
   } catch { return false }
 }
 
+// The fleet setup-token leg (#654): the wizard's own auth step stores the
+// token into FLEET_TOKEN_FILE (see the /api/onboarding/claude-auth handler
+// below), so an install authenticated ONLY via the fleet token has no env
+// var, no ~/.claude/.credentials.json and no Keychain entry -- without this
+// check the wizard re-nagged on every reload right after completing itself.
+// Presence-only, non-empty, same spirit as the other legs.
+function fleetTokenPresent(): boolean {
+  try {
+    return readFileSync(FLEET_TOKEN_FILE, 'utf-8').trim().length > 0
+  } catch { return false }
+}
+
 function claudeAuthPresent(): boolean {
   if (readEnvValue('CLAUDE_CODE_OAUTH_TOKEN')) return true
   if (readEnvValue('ANTHROPIC_API_KEY')) return true
@@ -69,6 +81,7 @@ function claudeAuthPresent(): boolean {
     if (d?.claudeAiOauth?.accessToken) return true
     if (d?.apiKey) return true
   } catch { /* no / unreadable credentials.json */ }
+  if (fleetTokenPresent()) return true
   return keychainHasClaudeCredentials()
 }
 


### PR DESCRIPTION
## Problem
Issue #654: a fleet-token-only install (the #630 flow -- token stored in `store/.claude-oauth-token` by the wizard's own auth step) has no env var, no `~/.claude/.credentials.json`, no Keychain entry, so `claudeAuthPresent()` reports no-auth and the onboarding wizard re-nags on every reload right after completing itself.

## Fix
Presence-only, non-empty `FLEET_TOKEN_FILE` check added as a new leg in `claudeAuthPresent()` before the Keychain fallback. Same spirit as the other legs (no secret value leaves the check).

## Verify
- `tsc --noEmit`: clean
- `npm test`: 2442 passed, 0 failed
- Matches the hermes soak-box ground truth: the box authenticates via `store/.claude-oauth-token` + `.verified` stamp and runs on a normal prompt.

## Release
Targets `develop` -- intended to ride the v1.23 Tuesday promote so the fleet-token feature ships without the re-nag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)