### PR TITLE
Feat/tool call audit metadata

### DIFF
--- a/scripts/hooks/tool-log-capture.py
+++ b/scripts/hooks/tool-log-capture.py
@@ -5,8 +5,12 @@ import os
 import json
 import re
 import random
+import uuid
 import urllib.request
 import urllib.error
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ledger_lib  # noqa: E402
 
 
 def _project_root() -> str:
@@ -86,6 +90,7 @@ def main():
     session_id = payload.get('session_id') or ''
     tool_name = payload.get('tool_name') or ''
     tool_input = payload.get('tool_input') or {}
+    cwd = payload.get('cwd') or ''
     success = not bool(payload.get('tool_response', {}).get('is_error') if isinstance(payload.get('tool_response'), dict) else False)
 
     if not session_id or not tool_name:
@@ -103,6 +108,8 @@ def main():
         'tool_name': tool_name,
         'input_summary': _input_summary(tool_input, tool_name),
         'success': success,
+        'agent_id': ledger_lib.agent_id_from_cwd(cwd),
+        'trace_id': str(uuid.uuid4()),
     }).encode()
 
     headers = {

--- a/scripts/hooks/tool-log-capture.py
+++ b/scripts/hooks/tool-log-capture.py
@@ -5,7 +5,6 @@ import os
 import json
 import re
 import random
-import uuid
 import urllib.request
 import urllib.error
 
@@ -91,6 +90,13 @@ def main():
     tool_name = payload.get('tool_name') or ''
     tool_input = payload.get('tool_input') or {}
     cwd = payload.get('cwd') or ''
+    # CC provides tool_use_id (stable per-call ID shared with PreToolUse) and
+    # duration_ms (native wall-clock measurement, more accurate than hook-side
+    # timestamps because it excludes hook overhead).
+    tool_use_id = payload.get('tool_use_id') or None
+    duration_ms = payload.get('duration_ms')
+    if not isinstance(duration_ms, int):
+        duration_ms = None
     success = not bool(payload.get('tool_response', {}).get('is_error') if isinstance(payload.get('tool_response'), dict) else False)
 
     if not session_id or not tool_name:
@@ -109,7 +115,12 @@ def main():
         'input_summary': _input_summary(tool_input, tool_name),
         'success': success,
         'agent_id': ledger_lib.agent_id_from_cwd(cwd),
-        'trace_id': str(uuid.uuid4()),
+        # trace_id holds the CC-native tool_use_id: stable, unique per call,
+        # present in both Pre and PostToolUse payloads (empirically verified).
+        # No PreToolUse hook needed -- CC already gives us the correlation key
+        # and the latency measurement in one place.
+        'trace_id': tool_use_id,
+        'duration_ms': duration_ms,
     }).encode()
 
     headers = {

--- a/src/__tests__/tool-call-audit-metadata.test.ts
+++ b/src/__tests__/tool-call-audit-metadata.test.ts
@@ -1,15 +1,26 @@
 // Tests for the tool call audit metadata enrichment.
 //
-// The PostToolUse hook (tool-log-capture.py) now sends agent_id (derived from
-// the session cwd) and trace_id (uuid4 per call) alongside the existing fields.
-// logToolCall persists them to the tool_call_log table; getRecentToolCalls
-// returns them in every row.
+// The PostToolUse hook (tool-log-capture.py) sends three audit fields that
+// Claude Code natively provides in the hook payload:
+//
+//   agent_id   -- derived from session cwd (ledger_lib.agent_id_from_cwd)
+//   trace_id   -- the CC-native tool_use_id (stable, unique per call, present
+//                 in both Pre and PostToolUse payloads -- empirically verified
+//                 2026-07-20). Stored in trace_id rather than a separate column
+//                 because it IS the tracing key.
+//   duration_ms -- CC's own wall-clock measurement (more accurate than hook-
+//                 side timestamps because it excludes hook overhead).
+//
+// No PreToolUse hook is needed: CC provides correlation key + latency in one
+// place (PostToolUse payload), so a separate pre-tracking table would add
+// complexity without adding information.
 //
 // These tests verify:
-//   (a) agent_id and trace_id are stored and retrievable
-//   (b) rows logged WITHOUT agent_id/trace_id (old hook) stay readable (null)
-//   (c) each call gets its own trace_id -- two rows never share one
-//   (d) fix-revert guard: removing the columns drops the fields from results
+//   (a) all three audit fields are stored and retrievable
+//   (b) rows logged WITHOUT the fields (old/minimal hook callers) stay readable
+//   (c) two calls with different tool_use_ids produce distinct trace_ids
+//   (d) duration_ms is stored as an integer
+//   (e) fix-revert guard: removing the new parameters → assertions fail
 
 import { describe, it, expect, beforeEach } from 'vitest'
 import { initDatabase, logToolCall, getRecentToolCalls } from '../db.js'
@@ -18,18 +29,19 @@ beforeEach(() => {
   initDatabase(':memory:')
 })
 
-describe('tool call audit metadata: agent_id + trace_id storage', () => {
-  it('stores agent_id and trace_id and returns them via getRecentToolCalls', () => {
-    logToolCall('sess-1', 'Bash', 'ls -la', true, 'agent-a', 'trace-abc-123')
+describe('tool call audit metadata: agent_id, trace_id, duration_ms storage', () => {
+  it('stores agent_id, trace_id, and duration_ms and returns them via getRecentToolCalls', () => {
+    logToolCall('sess-1', 'Bash', 'ls -la', true, 'agent-a', 'toolu_abc123', 42)
 
     const rows = getRecentToolCalls(3600)
     expect(rows).toHaveLength(1)
     expect(rows[0].agent_id).toBe('agent-a')
-    expect(rows[0].trace_id).toBe('trace-abc-123')
+    expect(rows[0].trace_id).toBe('toolu_abc123')
+    expect(rows[0].duration_ms).toBe(42)
   })
 
-  it('stores session_id, tool_name, input_summary and success alongside the new fields', () => {
-    logToolCall('sess-2', 'Read', '/etc/hosts', false, 'agent-b', 'trace-xyz-999')
+  it('stores core fields alongside the audit fields', () => {
+    logToolCall('sess-2', 'Read', '/etc/hosts', false, 'agent-b', 'toolu_xyz999', 7)
 
     const rows = getRecentToolCalls(3600)
     expect(rows[0].session_id).toBe('sess-2')
@@ -37,58 +49,77 @@ describe('tool call audit metadata: agent_id + trace_id storage', () => {
     expect(rows[0].input_summary).toBe('/etc/hosts')
     expect(rows[0].success).toBe(0)
     expect(rows[0].agent_id).toBe('agent-b')
-    expect(rows[0].trace_id).toBe('trace-xyz-999')
+    expect(rows[0].trace_id).toBe('toolu_xyz999')
+    expect(rows[0].duration_ms).toBe(7)
   })
 
-  it('accepts null agent_id and null trace_id for backward compatibility (old hook callers)', () => {
-    // Callers that do not yet send audit fields must not break.
+  it('accepts null for all three audit fields (backward compat -- old hook callers)', () => {
     logToolCall('sess-old', 'WebFetch', 'https://example.invalid', true)
 
     const rows = getRecentToolCalls(3600)
     expect(rows).toHaveLength(1)
     expect(rows[0].agent_id).toBeNull()
     expect(rows[0].trace_id).toBeNull()
+    expect(rows[0].duration_ms).toBeNull()
   })
 
-  it('two separate calls each get their own distinct trace_id', () => {
-    logToolCall('sess-3', 'Bash', 'pwd', true, 'agent-a', 'trace-first')
-    logToolCall('sess-3', 'Bash', 'date', true, 'agent-a', 'trace-second')
+  it('two calls with different tool_use_ids produce distinct trace_ids', () => {
+    // trace_id = CC tool_use_id, which is unique per call.
+    logToolCall('sess-3', 'Bash', 'pwd',  true, 'agent-a', 'toolu_call1', 10)
+    logToolCall('sess-3', 'Bash', 'date', true, 'agent-a', 'toolu_call2', 20)
 
     const rows = getRecentToolCalls(3600)
     expect(rows).toHaveLength(2)
+    expect(rows[0].trace_id).toBe('toolu_call1')
+    expect(rows[1].trace_id).toBe('toolu_call2')
     expect(rows[0].trace_id).not.toBe(rows[1].trace_id)
   })
 
-  it('rows from multiple agents are independently labeled', () => {
-    logToolCall('sess-4', 'Read', 'a.ts', true, 'agent-a', 'trace-1')
-    logToolCall('sess-5', 'Write', 'b.ts', true, 'agent-b', 'trace-2')
+  it('duration_ms is stored as an integer (not rounded or cast to string)', () => {
+    logToolCall('sess-4', 'Edit', 'x.ts', true, 'agent-a', 'toolu_dur', 1337)
+
+    const rows = getRecentToolCalls(3600)
+    expect(typeof rows[0].duration_ms).toBe('number')
+    expect(rows[0].duration_ms).toBe(1337)
+  })
+
+  it('rows from multiple agents are independently labeled with correct trace_ids', () => {
+    logToolCall('sess-5', 'Read',  'a.ts', true, 'agent-a', 'toolu_a1', 5)
+    logToolCall('sess-6', 'Write', 'b.ts', true, 'agent-b', 'toolu_b1', 8)
 
     const rows = getRecentToolCalls(3600)
     const byAgent = Object.fromEntries(rows.map(r => [r.agent_id, r]))
-    expect(byAgent['agent-a'].session_id).toBe('sess-4')
-    expect(byAgent['agent-b'].session_id).toBe('sess-5')
+    expect(byAgent['agent-a'].trace_id).toBe('toolu_a1')
+    expect(byAgent['agent-b'].trace_id).toBe('toolu_b1')
   })
 })
 
 // --- Fix-revert guard ---
 //
-// If logToolCall were reverted to the 4-arg signature (without agentId/traceId),
-// the assertions below would fail because the columns would stay null even
-// when explicit values are passed. That is the correct behaviour -- these
-// tests must turn RED on revert.
+// If logToolCall were reverted to the 4-arg signature (without agentId,
+// traceId, durationMs), the tests below would turn RED because the columns
+// would stay null even when explicit values are passed. That is correct
+// behaviour -- these tests MUST be red on revert.
 
-describe('fix-revert guard: audit fields are load-bearing', () => {
-  it('agent_id is non-null when explicitly provided (proves column is written)', () => {
-    logToolCall('sess-guard', 'Bash', 'echo hi', true, 'agent-sentinel', 'trace-sentinel')
+describe('fix-revert guard: all three audit fields are load-bearing', () => {
+  it('agent_id is non-null when explicitly provided', () => {
+    logToolCall('sess-g1', 'Bash', 'echo hi', true, 'agent-sentinel', 'toolu_sentinel', 1)
     const rows = getRecentToolCalls(3600)
     expect(rows[0].agent_id).not.toBeNull()
     expect(rows[0].agent_id).toBe('agent-sentinel')
   })
 
-  it('trace_id is non-null when explicitly provided (proves column is written)', () => {
-    logToolCall('sess-guard2', 'Edit', 'x.ts', true, 'agent-sentinel', 'trace-sentinel-2')
+  it('trace_id is non-null when explicitly provided', () => {
+    logToolCall('sess-g2', 'Edit', 'x.ts', true, 'agent-sentinel', 'toolu_sentinel2', 2)
     const rows = getRecentToolCalls(3600)
     expect(rows[0].trace_id).not.toBeNull()
-    expect(rows[0].trace_id).toBe('trace-sentinel-2')
+    expect(rows[0].trace_id).toBe('toolu_sentinel2')
+  })
+
+  it('duration_ms is non-null when explicitly provided', () => {
+    logToolCall('sess-g3', 'Read', 'y.ts', true, 'agent-sentinel', 'toolu_sentinel3', 999)
+    const rows = getRecentToolCalls(3600)
+    expect(rows[0].duration_ms).not.toBeNull()
+    expect(rows[0].duration_ms).toBe(999)
   })
 })

--- a/src/__tests__/tool-call-audit-metadata.test.ts
+++ b/src/__tests__/tool-call-audit-metadata.test.ts
@@ -1,0 +1,94 @@
+// Tests for the tool call audit metadata enrichment.
+//
+// The PostToolUse hook (tool-log-capture.py) now sends agent_id (derived from
+// the session cwd) and trace_id (uuid4 per call) alongside the existing fields.
+// logToolCall persists them to the tool_call_log table; getRecentToolCalls
+// returns them in every row.
+//
+// These tests verify:
+//   (a) agent_id and trace_id are stored and retrievable
+//   (b) rows logged WITHOUT agent_id/trace_id (old hook) stay readable (null)
+//   (c) each call gets its own trace_id -- two rows never share one
+//   (d) fix-revert guard: removing the columns drops the fields from results
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, logToolCall, getRecentToolCalls } from '../db.js'
+
+beforeEach(() => {
+  initDatabase(':memory:')
+})
+
+describe('tool call audit metadata: agent_id + trace_id storage', () => {
+  it('stores agent_id and trace_id and returns them via getRecentToolCalls', () => {
+    logToolCall('sess-1', 'Bash', 'ls -la', true, 'agent-a', 'trace-abc-123')
+
+    const rows = getRecentToolCalls(3600)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].agent_id).toBe('agent-a')
+    expect(rows[0].trace_id).toBe('trace-abc-123')
+  })
+
+  it('stores session_id, tool_name, input_summary and success alongside the new fields', () => {
+    logToolCall('sess-2', 'Read', '/etc/hosts', false, 'agent-b', 'trace-xyz-999')
+
+    const rows = getRecentToolCalls(3600)
+    expect(rows[0].session_id).toBe('sess-2')
+    expect(rows[0].tool_name).toBe('Read')
+    expect(rows[0].input_summary).toBe('/etc/hosts')
+    expect(rows[0].success).toBe(0)
+    expect(rows[0].agent_id).toBe('agent-b')
+    expect(rows[0].trace_id).toBe('trace-xyz-999')
+  })
+
+  it('accepts null agent_id and null trace_id for backward compatibility (old hook callers)', () => {
+    // Callers that do not yet send audit fields must not break.
+    logToolCall('sess-old', 'WebFetch', 'https://example.invalid', true)
+
+    const rows = getRecentToolCalls(3600)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].agent_id).toBeNull()
+    expect(rows[0].trace_id).toBeNull()
+  })
+
+  it('two separate calls each get their own distinct trace_id', () => {
+    logToolCall('sess-3', 'Bash', 'pwd', true, 'agent-a', 'trace-first')
+    logToolCall('sess-3', 'Bash', 'date', true, 'agent-a', 'trace-second')
+
+    const rows = getRecentToolCalls(3600)
+    expect(rows).toHaveLength(2)
+    expect(rows[0].trace_id).not.toBe(rows[1].trace_id)
+  })
+
+  it('rows from multiple agents are independently labeled', () => {
+    logToolCall('sess-4', 'Read', 'a.ts', true, 'agent-a', 'trace-1')
+    logToolCall('sess-5', 'Write', 'b.ts', true, 'agent-b', 'trace-2')
+
+    const rows = getRecentToolCalls(3600)
+    const byAgent = Object.fromEntries(rows.map(r => [r.agent_id, r]))
+    expect(byAgent['agent-a'].session_id).toBe('sess-4')
+    expect(byAgent['agent-b'].session_id).toBe('sess-5')
+  })
+})
+
+// --- Fix-revert guard ---
+//
+// If logToolCall were reverted to the 4-arg signature (without agentId/traceId),
+// the assertions below would fail because the columns would stay null even
+// when explicit values are passed. That is the correct behaviour -- these
+// tests must turn RED on revert.
+
+describe('fix-revert guard: audit fields are load-bearing', () => {
+  it('agent_id is non-null when explicitly provided (proves column is written)', () => {
+    logToolCall('sess-guard', 'Bash', 'echo hi', true, 'agent-sentinel', 'trace-sentinel')
+    const rows = getRecentToolCalls(3600)
+    expect(rows[0].agent_id).not.toBeNull()
+    expect(rows[0].agent_id).toBe('agent-sentinel')
+  })
+
+  it('trace_id is non-null when explicitly provided (proves column is written)', () => {
+    logToolCall('sess-guard2', 'Edit', 'x.ts', true, 'agent-sentinel', 'trace-sentinel-2')
+    const rows = getRecentToolCalls(3600)
+    expect(rows[0].trace_id).not.toBeNull()
+    expect(rows[0].trace_id).toBe('trace-sentinel-2')
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -649,6 +649,10 @@ export function initDatabase(dbPathOverride?: string): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_session ON tool_call_log(session_id, created_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_ts ON tool_call_log(created_at)`)
+  // Idempotent column additions -- guard with PRAGMA so second run does not error.
+  const toolLogCols = (db.prepare('PRAGMA table_info(tool_call_log)').all() as { name: string }[]).map(r => r.name)
+  if (!toolLogCols.includes('agent_id')) db.exec('ALTER TABLE tool_call_log ADD COLUMN agent_id TEXT')
+  if (!toolLogCols.includes('trace_id')) db.exec('ALTER TABLE tool_call_log ADD COLUMN trace_id TEXT')
 
   // --- Skill Usage Log (persistent, no prune -- feeds dream-engine skill health) ---
   db.exec(`
@@ -2407,9 +2411,18 @@ export function revertIdeaFromKanban(kanbanId: string): string | null {
 
 // --- Tool Call Log ---
 
-export function logToolCall(sessionId: string, toolName: string, inputSummary: string | null, success = true): void {
+export function logToolCall(
+  sessionId: string,
+  toolName: string,
+  inputSummary: string | null,
+  success = true,
+  agentId: string | null = null,
+  traceId: string | null = null,
+): void {
   const now = Math.floor(Date.now() / 1000)
-  db.prepare('INSERT INTO tool_call_log (session_id, tool_name, input_summary, success, created_at) VALUES (?, ?, ?, ?, ?)').run(sessionId, toolName, inputSummary, success ? 1 : 0, now)
+  db.prepare(
+    'INSERT INTO tool_call_log (session_id, tool_name, input_summary, success, created_at, agent_id, trace_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  ).run(sessionId, toolName, inputSummary, success ? 1 : 0, now, agentId, traceId)
 }
 
 export interface ToolCallLogRow {
@@ -2419,6 +2432,8 @@ export interface ToolCallLogRow {
   input_summary: string | null
   success: number
   created_at: number
+  agent_id: string | null
+  trace_id: string | null
 }
 
 export interface WorkflowCandidate {

--- a/src/db.ts
+++ b/src/db.ts
@@ -651,8 +651,9 @@ export function initDatabase(dbPathOverride?: string): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tool_log_ts ON tool_call_log(created_at)`)
   // Idempotent column additions -- guard with PRAGMA so second run does not error.
   const toolLogCols = (db.prepare('PRAGMA table_info(tool_call_log)').all() as { name: string }[]).map(r => r.name)
-  if (!toolLogCols.includes('agent_id')) db.exec('ALTER TABLE tool_call_log ADD COLUMN agent_id TEXT')
-  if (!toolLogCols.includes('trace_id')) db.exec('ALTER TABLE tool_call_log ADD COLUMN trace_id TEXT')
+  if (!toolLogCols.includes('agent_id'))    db.exec('ALTER TABLE tool_call_log ADD COLUMN agent_id TEXT')
+  if (!toolLogCols.includes('trace_id'))    db.exec('ALTER TABLE tool_call_log ADD COLUMN trace_id TEXT')
+  if (!toolLogCols.includes('duration_ms')) db.exec('ALTER TABLE tool_call_log ADD COLUMN duration_ms INTEGER')
 
   // --- Skill Usage Log (persistent, no prune -- feeds dream-engine skill health) ---
   db.exec(`
@@ -2418,11 +2419,12 @@ export function logToolCall(
   success = true,
   agentId: string | null = null,
   traceId: string | null = null,
+  durationMs: number | null = null,
 ): void {
   const now = Math.floor(Date.now() / 1000)
   db.prepare(
-    'INSERT INTO tool_call_log (session_id, tool_name, input_summary, success, created_at, agent_id, trace_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
-  ).run(sessionId, toolName, inputSummary, success ? 1 : 0, now, agentId, traceId)
+    'INSERT INTO tool_call_log (session_id, tool_name, input_summary, success, created_at, agent_id, trace_id, duration_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+  ).run(sessionId, toolName, inputSummary, success ? 1 : 0, now, agentId, traceId, durationMs)
 }
 
 export interface ToolCallLogRow {
@@ -2434,6 +2436,7 @@ export interface ToolCallLogRow {
   created_at: number
   agent_id: string | null
   trace_id: string | null
+  duration_ms: number | null
 }
 
 export interface WorkflowCandidate {

--- a/src/web/routes/tool-log.ts
+++ b/src/web/routes/tool-log.ts
@@ -13,9 +13,11 @@ export async function tryHandleToolLog(ctx: RouteContext): Promise<boolean> {
       tool_name: string
       input_summary?: string
       success?: boolean
+      agent_id?: string
+      trace_id?: string
     }
     if (!data.session_id || !data.tool_name) { json(res, { error: 'session_id and tool_name required' }, 400); return true }
-    logToolCall(data.session_id, data.tool_name, data.input_summary ?? null, data.success !== false)
+    logToolCall(data.session_id, data.tool_name, data.input_summary ?? null, data.success !== false, data.agent_id ?? null, data.trace_id ?? null)
     json(res, { ok: true })
     return true
   }

--- a/src/web/routes/tool-log.ts
+++ b/src/web/routes/tool-log.ts
@@ -15,9 +15,10 @@ export async function tryHandleToolLog(ctx: RouteContext): Promise<boolean> {
       success?: boolean
       agent_id?: string
       trace_id?: string
+      duration_ms?: number
     }
     if (!data.session_id || !data.tool_name) { json(res, { error: 'session_id and tool_name required' }, 400); return true }
-    logToolCall(data.session_id, data.tool_name, data.input_summary ?? null, data.success !== false, data.agent_id ?? null, data.trace_id ?? null)
+    logToolCall(data.session_id, data.tool_name, data.input_summary ?? null, data.success !== false, data.agent_id ?? null, data.trace_id ?? null, data.duration_ms ?? null)
     json(res, { ok: true })
     return true
   }


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary
HU: A PostToolUse hook (tool-log-capture.py) mostantól három mezőt csatol a meglévő session_id / tool_name / input_summary / success mellé: agent_id (a session cwd-ből, konzisztensen a skill-usage-capture mintával), trace_id (= a Claude Code natív tool_use_id, nem generált uuid, empirikusan igazoltan stabil és hívásonként egyedi a payloadban) és duration_ms (a CC saját wall-clock mérése, pontosabb mint a hook-oldali időbélyeg-különbség). Mindhárom mező a dashboard DB-be kerül, a modell kontextusán kívül. PreToolUse hook nem szükséges: a CC egyetlen payloadban adja a korrelációs kulcsot és a latenciát. A séma-migráció idempotens (PRAGMA table_info guard), a régi sorok NULL-lal olvashatók maradnak. Első lépés a cross-agent tracing felé.

EN: The PostToolUse hook now attaches three fields alongside the existing session_id / tool_name / input_summary / success: agent_id (from session cwd, consistent with the skill-usage-capture pattern), trace_id (= the Claude Code native tool_use_id, not a generated uuid, empirically verified stable and unique per call in the payload), and duration_ms (CC's own wall-clock measurement, more accurate than hook-side timestamp deltas). All three land in the dashboard DB, outside the model context. No PreToolUse hook is needed: CC provides the correlation key and latency in a single payload. Schema migration is idempotent (PRAGMA table_info guard); old rows remain readable with NULL. First step toward cross-agent tracing.

## Kapcsolódó issue / Related issue
Nincs nyitott issue -- feltáró kártya (kanban #274).

## Ellenőrzőlista / Checklist
- [x] Unit-teszttel igazolt (9 teszt) + a payload-mezőket empirikus debug-hook dumppal is igazoltam; élesben Jónás teszteli a PR előtt.
- [x] docs/ frissítés nem szükséges (a hook-regisztráció nem változik).
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: feat/tool-call-audit-metadata.

Tesztlefedettség: 9 teszt (mezők tárolása, backward-compat NULL, hívásonként külön trace_id, több-ágensű felirat, duration_ms integer). Fix-revert: 4 + 5 piros. Teljes suite 2451/2451.
