### PR TITLE
feat(dashboard): merge Agents and Team screens into one page with vie…

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -351,6 +351,8 @@ function confirmSettingsLeave() {
 }
 
 function switchPage(pageId) {
+  // 'team' is merged into 'agents'; any internal call still passing 'team' redirects.
+  if (pageId === 'team') { _agentsActiveView = 'tree'; pageId = 'agents' }
   // Guard unsaved settings before leaving the settings page
   if (!document.getElementById('settingsPage').hidden && pageId !== 'settings' && !confirmSettingsLeave()) return
   pages.forEach((p) => (p.hidden = p.id !== pageId + 'Page'))
@@ -368,7 +370,7 @@ function switchPage(pageId) {
   if (pageId === 'overview') loadOverview()
   if (pageId === 'kanban') { if (typeof _initGanttViewSwitcher === 'function') _initGanttViewSwitcher(); loadKanban(); startKanbanRefresh() }
   if (pageId === 'tasks') loadSchedules()
-  if (pageId === 'agents') { loadAgents(); startAgentsBusyPoll() }
+  if (pageId === 'agents') { loadAgents().then(() => _setAgentsView(_agentsActiveView || 'grid')); startAgentsBusyPoll() }
   if (pageId === 'memories') { loadMemAgents(); loadMemStats(); loadMemories() }
   if (pageId === 'skills') loadGlobalSkills()
   if (pageId === 'connectors') loadConnectors()
@@ -382,7 +384,7 @@ function switchPage(pageId) {
   if (pageId === 'approvals') loadApprovalsPage()
   if (pageId === 'settings') loadSettings()
   if (pageId === 'updates') loadUpdates()
-  if (pageId === 'team') { loadTeamGraph() }
+  // 'team' page is merged into 'agents' -- redirect for any lingering deep-links
   if (pageId === 'messages') loadMessagesPage()
   if (pageId === 'tokenUsage') loadTokenUsage()
   if (pageId === 'costs') loadCosts()
@@ -10318,7 +10320,7 @@ async function openSkillDetail(skillName, displayLabel, agentId = null) {
   }
 })()
 
-// === Team page ===
+// === Team org-chart (now embedded in Agents page, tree view) ===
 async function loadTeamGraph() {
   const container = document.getElementById('teamGraph')
   if (!container) return
@@ -10509,8 +10511,30 @@ function renderTeamGraph(container, data, opts = {}) {
   }
 }
 
-const refreshTeamBtn = document.getElementById('refreshTeamBtn')
-if (refreshTeamBtn) refreshTeamBtn.addEventListener('click', loadTeamGraph)
+// === Agents page: grid / org-chart view toggle ===
+// Persists the chosen view for the session so navigating away and back keeps
+// the last selection. Defaults to 'grid'.
+let _agentsActiveView = 'grid'
+
+function _setAgentsView(view) {
+  _agentsActiveView = view
+  const gridView = document.getElementById('agentsGridView')
+  const treeView = document.getElementById('agentsTreeView')
+  const gridBtn  = document.getElementById('agentsViewGrid')
+  const treeBtn  = document.getElementById('agentsViewTree')
+  if (!gridView || !treeView) return
+  const showGrid = view === 'grid'
+  gridView.hidden = !showGrid
+  treeView.hidden = showGrid
+  if (gridBtn) gridBtn.classList.toggle('active', showGrid)
+  if (treeBtn) treeBtn.classList.toggle('active', !showGrid)
+  if (!showGrid) loadTeamGraph()
+}
+
+const _agentsViewGridBtn = document.getElementById('agentsViewGrid')
+const _agentsViewTreeBtn = document.getElementById('agentsViewTree')
+if (_agentsViewGridBtn) _agentsViewGridBtn.addEventListener('click', () => _setAgentsView('grid'))
+if (_agentsViewTreeBtn) _agentsViewTreeBtn.addEventListener('click', () => _setAgentsView('tree'))
 
 // === Team: inter-agent message log + compose ===
 // View the /api/messages queue and let the operator send a message to an agent
@@ -14877,6 +14901,8 @@ function wireFederationPage() {
   function routeFromHash() {
     let pageId = decodeURIComponent((location.hash || '').replace(/^#/, ''))
     if (!pageId) pageId = new URLSearchParams(window.location.search).get('page') || ''
+    // 'team' page is merged into 'agents' (org-chart view toggle).
+    if (pageId === 'team') { pageId = 'agents'; _agentsActiveView = 'tree' }
     if (pageId && document.getElementById(pageId + 'Page')) switchPage(pageId)
   }
   window.addEventListener('hashchange', routeFromHash)

--- a/web/index.html
+++ b/web/index.html
@@ -88,10 +88,6 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14"/></svg>
         <span class="sb-label">Aktivitás</span>
       </a>
-      <a href="#" class="sb-link" data-page="team">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="3"/><path d="M12 8v4"/><circle cx="5" cy="18" r="3"/><circle cx="19" cy="18" r="3"/><path d="M12 12l-7 6M12 12l7 6"/></svg>
-        <span class="sb-label">Csapat</span>
-      </a>
       <a href="#" class="sb-link" data-page="messages">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
         <span class="sb-label">Üzenetek</span>
@@ -355,7 +351,7 @@
       <div id="archivedList"></div>
     </div>
 
-    <!-- === Agents Page === -->
+    <!-- === Agents Page (includes org-chart view, replaces separate Team page) === -->
     <div class="page" id="agentsPage" hidden>
       <div class="page-header">
         <div class="page-header-row">
@@ -364,6 +360,16 @@
             <p class="subtitle" data-i18n="agents.page_subtitle">AI csapattagok kezelése</p>
           </div>
           <div class="header-actions">
+            <div class="view-toggle" id="agentsViewToggle" role="group" aria-label="Nézet váltás">
+              <button class="btn-secondary btn-compact view-toggle-btn active" id="agentsViewGrid" data-view="grid" title="Kártyák">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                Kártyák
+              </button>
+              <button class="btn-secondary btn-compact view-toggle-btn" id="agentsViewTree" data-view="tree" title="Org chart">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="3"/><path d="M12 8v4"/><circle cx="5" cy="18" r="3"/><circle cx="19" cy="18" r="3"/><path d="M12 12l-7 6M12 12l7 6"/></svg>
+                Org chart
+              </button>
+            </div>
             <button class="btn-secondary btn-compact" id="exportAllAgentsBtn">Összes exportálása</button>
             <button class="btn-secondary btn-compact" id="importAgentBtn">Ügynök importálása</button>
             <input type="file" id="importAgentFile" accept=".gz,.tgz,application/gzip" hidden>
@@ -372,15 +378,25 @@
         </div>
       </div>
       <div id="agentsModelAnalysis" style="display:none;margin:0 0 16px"></div>
-      <div class="agents-grid" id="agentsGrid">
-        <button class="agent-card add-card" id="addAgentBtn">
-          <div class="add-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
-            </svg>
-          </div>
-          <span data-i18n="agents.page.new_btn">Új ügynök</span>
-        </button>
+      <!-- Grid view -->
+      <div id="agentsGridView">
+        <div class="agents-grid" id="agentsGrid">
+          <button class="agent-card add-card" id="addAgentBtn">
+            <div class="add-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+              </svg>
+            </div>
+            <span data-i18n="agents.page.new_btn">Új ügynök</span>
+          </button>
+        </div>
+      </div>
+      <!-- Tree / org-chart view (merged from separate Team page) -->
+      <div id="agentsTreeView" hidden>
+        <div id="teamGraph" class="team-graph"></div>
+        <p style="color:var(--text-muted);font-size:12px;margin-top:16px">
+          A szerep és a beosztott/vezető kapcsolatok az ügynök részletek &gt; Csapat fülén szerkeszthetők.
+        </p>
       </div>
     </div>
 
@@ -1036,29 +1052,7 @@
       </div>
     </div>
 
-    <!-- === Team Page === -->
-    <div class="page" id="teamPage" hidden>
-      <div class="page-header">
-        <div class="page-header-row">
-          <div>
-            <h1>Csapat</h1>
-            <p class="subtitle" data-i18n="team.page_subtitle">Ki kinek jelent és ki kinek delegál</p>
-          </div>
-          <button class="btn-secondary btn-compact" id="refreshTeamBtn" data-i18n="common.btn.refresh">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
-            </svg>
-            Frissítés
-          </button>
-        </div>
-      </div>
-
-      <div id="teamGraph" class="team-graph"></div>
-      <p style="color:var(--text-muted);font-size:12px;margin-top:16px">
-        A szerep és a beosztott/vezető kapcsolatok az ügynök részletek &gt; Csapat fülén szerkeszthetők.
-      </p>
-
-    </div>
+    <!-- Team page merged into Agents page (view toggle: grid / org-chart) -->
 
     <!-- === Messages Page === -->
     <div class="page" id="messagesPage" hidden>

--- a/web/style.css
+++ b/web/style.css
@@ -1307,6 +1307,19 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  align-items: center;
+}
+
+/* Agents page: grid / org-chart view toggle */
+.view-toggle {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+.view-toggle-btn.active {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
 }
 
 /* === Agent Grid === */


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary
HU: A különálló Csapat (Team) oldal beolvad az Ügynökök (Agents) oldalba. Az Agents oldal fejlécében megjelenik egy Kártyák / Org chart nézet-váltó gomb. Kártyák nézet: a meglévő ügynök-kártyák (alapértelmezett). Org chart nézet: a korábbi Team oldal hierarchikus fája (loadTeamGraph / renderTeamGraph logika változatlan). A #team hash URL és a switchPage('team') hívások az Agents oldal org-chart nézetére irányítanak át. A Csapat menüpont és a különálló teamPage eltávolítva. Nincs backend változás.

EN: The separate Team page (read-only org-chart) is merged into the Agents page behind a Cards / Org chart view toggle. Default is Cards (existing agent grid); toggling to Org chart shows the previous Team page's hierarchy (same loadTeamGraph / renderTeamGraph logic). The #team hash and any switchPage('team') calls redirect to the Agents page org-chart view. The Team sidebar link and the standalone teamPage are removed. No backend changes.

## Kapcsolódó issue / Related issue
Nincs nyitott GitHub issue -- kanban #279.

## Ellenőrzőlista / Checklist
- [x] Frontend-only változás; a nézet-váltó logikát és a redirekteket kód szinten ellenőriztük, a vizuális tesztet a maintainer végzi a dashboardon.
- [x] docs/ frissítés nem szükséges.
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: feat/agents-team-merge.