### PR TITLE
fix(sidebar): remove orphan Autonomy HTML fragment

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -132,9 +132,6 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
         <span class="sb-label">Státusz</span>
       </a>
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-        <span class="sb-label">Autonómia</span>
-      </a>
       <a href="#" class="sb-link" data-page="approvals">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
         <span class="sb-label">Jóváhagyások</span>
@@ -1046,7 +1043,6 @@
       </div>
     </div>
 
-    <!-- === Autonomy Page === -->
 <!-- === Approvals Page === -->
     <div class="page" id="approvalsPage" hidden>
       <div class="page-header">


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Bug fix

## Rövid leírás / Summary
HU: Az Autonómia oldal eltávolítása (#646) után a sidebar-ban árva HTML-töredék maradt: egy pajzs SVG, egy Autonómia felirat és egy lezáró tag nyitó tag nélkül, ami megtörte a HTML-struktúrát. A gyökér-ok: a #644 HITL squash egy a #646 előtti bázisra épült, és visszahozta ezt a töredéket. Töröltem az árva csomópontokat és a hozzá tartozó árva kommentet.

EN: After the Autonomy page was removed (#646), three orphan HTML nodes remained in the sidebar (a shield SVG, an "Autonómia" label, and a dangling closing tag with no opener), breaking the HTML structure. Root cause: the #644 HITL squash was based on a pre-#646 base and reintroduced the fragment. Removed the orphan nodes and the stale related comment.

## Kapcsolódó issue / Related issue
Kanban #280. Nincs nyitott GitHub issue.

## Ellenőrzőlista / Checklist
- [x] Kipróbáltam lokálisan (dashboard) -- a sidebar rendben, az Autonómia elem eltűnt, a Státusz és Jóváhagyások linkek épek.
- [x] docs/ frissítés nem szükséges (HTML-only).
- [x] Nincs beégetett szenzitív adat.
- [x] Saját branch: fix/sidebar-autonomy-orphan.