### PR TITLE
feat(agents): live green Terminal button while an agent is working

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -281,12 +281,15 @@ function switchPage(pageId) {
   // Activity page runs a live poll; stop it whenever we navigate away.
   if (pageId !== 'activity') stopActivityPoll()
   if (pageId === 'activity') startActivityPoll()
+  // Agents page tints each Terminal button green while that agent is working;
+  // same 3s poll + source as Activity. Stop it when we leave the page.
+  if (pageId !== 'agents') stopAgentsBusyPoll()
   // Kanban auto-refresh: start on enter, stop on leave.
   if (pageId !== 'kanban') stopKanbanRefresh()
   if (pageId === 'overview') loadOverview()
   if (pageId === 'kanban') { if (typeof _initGanttViewSwitcher === 'function') _initGanttViewSwitcher(); loadKanban(); startKanbanRefresh() }
   if (pageId === 'tasks') loadSchedules()
-  if (pageId === 'agents') loadAgents()
+  if (pageId === 'agents') { loadAgents(); startAgentsBusyPoll() }
   if (pageId === 'memories') { loadMemAgents(); loadMemStats(); loadMemories() }
   if (pageId === 'skills') loadGlobalSkills()
   if (pageId === 'connectors') loadConnectors()
@@ -2766,6 +2769,46 @@ function renderAgents() {
     agentsGrid.insertBefore(card, addBtn)
   }
   renderFederatedAgentCards(agentsGrid, addBtn)
+  // Re-apply the live busy tint right after a re-render (renderAgents rebuilds
+  // the cards from scratch, dropping the class), so it never blinks off while
+  // the page is open.
+  if (agentsBusyTimer) refreshAgentTerminalBusy()
+}
+
+// === Agents: live "working" tint on Terminal buttons ===
+// Reuse the Activity page's data source (/api/agents/activity, same 3s poll,
+// same working/idle state derived from the tmux pane) to turn an agent card's
+// Terminal button green while that agent is actively working, and clear it when
+// it goes idle or stops. No new backend -- just a second consumer of the same
+// endpoint. The main (Marveen) card matches on mainAgentId(); sub-agent cards
+// match on their data-name.
+let agentsBusyTimer = null
+function startAgentsBusyPoll() {
+  refreshAgentTerminalBusy()
+  if (agentsBusyTimer) clearInterval(agentsBusyTimer)
+  agentsBusyTimer = setInterval(refreshAgentTerminalBusy, 3000)
+}
+function stopAgentsBusyPoll() {
+  if (agentsBusyTimer) { clearInterval(agentsBusyTimer); agentsBusyTimer = null }
+}
+async function refreshAgentTerminalBusy() {
+  if (!agentsGrid) return
+  let entries
+  try {
+    const res = await fetch('/api/agents/activity')
+    if (!res.ok) return
+    entries = await res.json()
+  } catch { return }
+  if (!Array.isArray(entries)) return
+  const stateByName = new Map(entries.map((e) => [e.name, e.state]))
+  const mainId = mainAgentId()
+  agentsGrid.querySelectorAll('.agent-card:not(.add-card)').forEach((card) => {
+    const btn = card.querySelector('.agent-terminal-btn')
+    if (!btn) return
+    const id = card.classList.contains('marveen-card') ? mainId : card.dataset.name
+    const working = !!id && stateByName.get(id) === 'working'
+    btn.classList.toggle('agent-terminal-btn--busy', working)
+  })
 }
 
 // Federated (remote-system) agents from the manifest-poller cache. Kept in a

--- a/web/style.css
+++ b/web/style.css
@@ -6326,6 +6326,16 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
 }
 .activity-tail-empty { margin: 0; font-size: 12px; color: var(--text-muted); font-style: italic; }
 
+/* Live "working" tint on an agent's Terminal button (Agents page). Mirrors the
+   Activity page's green working badge, including the breathe pulse. The SVG uses
+   currentColor, so the icon greens with the label. */
+.agent-terminal-btn.agent-terminal-btn--busy {
+  background: rgba(34,197,94,0.15);
+  color: #16a34a;
+  border-color: #22c55e;
+  animation: badge-breathe 2s ease-in-out infinite;
+}
+
 /* === Messages / Chat page === */
 .chat-layout {
   display: flex;


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary
HU: Az Ügynökök (Agents) oldalon minden agent Terminal gombja zöldre vált (pulzálva), amíg az adott agent éppen dolgozik, és visszaáll amikor idle. Nincs új backend: ugyanazt a `/api/agents/activity` adatforrást és 3 másodperces pollingot használja, mint az Aktivitás oldal (a working/idle állapot a tmux pane tartalmából jön). A poll csak az Agents oldalon fut, kilépéskor leáll, és minden újrarajzolás után visszateszi a színt, hogy ne villogjon. A fő (Marveen) kártya a `mainAgentId()`-vel, a sub-agent kártyák a `data-name`-mel párosítanak. A #671 org-chart/DnD nézetet nem érinti.

EN: On the Agents page each agent's Terminal button turns green (with a breathe pulse) while that agent is actively working, and reverts when it goes idle. No new backend: it reuses the exact same `/api/agents/activity` source and 3-second polling as the Activity page (working/idle state derived from the tmux pane). The poll only runs on the Agents page, stops on leave, and is re-applied after every re-render so it never blinks off. The main (Marveen) card matches on `mainAgentId()`, sub-agent cards on `data-name`. Does not touch the #671 org-chart/DnD view.

## Kapcsolódó issue / Related issue
Nincs nyitott GitHub issue -- kanban kártya alapján, a dashboard Agents oldal UI-fejlesztése.

## Ellenőrzőlista / Checklist
- [x] Frontend: `startAgentsBusyPoll` / `stopAgentsBusyPoll` / `refreshAgentTerminalBusy` (`web/app.js`), a page-switch köti be (start az Agents oldalon, stop kilépéskor).
- [x] CSS: `.agent-terminal-btn--busy` a meglévő working-zöldet (#22c55e / #16a34a) és a `badge-breathe` pulzálást tükrözi (`web/style.css`).
- [x] Adatforrás újrahasznosítva, nem új backend: `/api/agents/activity`, 3s poll (egyezik az Aktivitás oldaléval).
- [x] Kapuk zöldek: `npm run typecheck`, `npm test` (2442/2442), `npm run syntax-check`.
- [x] Playwright vizuális ellenőrzés localhost:3420-on: dolgozó agentek gombja zöld, idle-eké szürke, állapotváltás követve; read-only, nincs mit visszaállítani.
- [x] docs/ frissítés: nem szükséges.
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: feature/agents-terminal-live-busy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
