### PR TITLE
Feat/plugin ids centralize

### DIFF
--- a/src/__tests__/heartbeat-worker-isolation.test.ts
+++ b/src/__tests__/heartbeat-worker-isolation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { CHANNEL_PLUGIN_IDS } from '../web/plugin-ids.js'
 
 // Contract tests for the 2026-06-02 channel-disconnect chain.
 //
@@ -45,11 +46,28 @@ describe('heartbeat worker cwd + CLAUDE_CONFIG_DIR isolation (2026-06-02 inciden
     expect(SRC).toMatch(/HEARTBEAT_CONFIG_SKIP[^)]*settings\.json/s)
   })
 
-  it('writes a fresh settings.json with enabledPlugins:false for telegram/slack/discord', () => {
+  it('writes a fresh settings.json with enabledPlugins:false for all channel plugins', () => {
+    // heartbeat.ts must reference HEARTBEAT_DISABLED_PLUGINS -- the contract
+    // that drives the enabledPlugins loop. The actual ID strings now live in
+    // plugin-ids.ts (single source of truth); this test verifies the import
+    // and that plugin-ids.ts contains the canonical IDs.
     expect(SRC).toMatch(/HEARTBEAT_DISABLED_PLUGINS/)
-    expect(SRC).toMatch(/telegram@claude-plugins-official/)
-    expect(SRC).toMatch(/slack-channel@marveen-marketplace/)
-    expect(SRC).toMatch(/discord@claude-plugins-official/)
+    expect(SRC).toMatch(/CHANNEL_PLUGIN_IDS/)
+    const IDS_SRC = readFileSync(join(__dirname, '../web/plugin-ids.ts'), 'utf-8')
+    expect(IDS_SRC).toMatch(/telegram@claude-plugins-official/)
+    expect(IDS_SRC).toMatch(/slack-channel@marveen-marketplace/)
+    expect(IDS_SRC).toMatch(/discord@claude-plugins-official/)
+    expect(IDS_SRC).toMatch(/googlechat@claude-channel-googlechat/)
+    expect(IDS_SRC).toMatch(/teams@marveen-marketplace/)
+  })
+
+  it('CHANNEL_PLUGIN_IDS covers all five providers (regression: googlechat/teams were missing from heartbeat)', () => {
+    const ids = Object.values(CHANNEL_PLUGIN_IDS)
+    expect(ids).toContain('telegram@claude-plugins-official')
+    expect(ids).toContain('slack-channel@marveen-marketplace')
+    expect(ids).toContain('discord@claude-plugins-official')
+    expect(ids).toContain('googlechat@claude-channel-googlechat')
+    expect(ids).toContain('teams@marveen-marketplace')
   })
 
   it('refuses to read through a settings.json symlink (would import user-scope enabledPlugins)', () => {

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -17,6 +17,7 @@ import { runAgent } from './agent.js'
 import { notifyTelegram } from './notify.js'
 import { logger } from './logger.js'
 import { wrapUntrusted, UNTRUSTED_PREAMBLE } from './prompt-safety.js'
+import { CHANNEL_PLUGIN_IDS } from './web/plugin-ids.js'
 
 // Isolation cwd for the heartbeat sub-agent. Keep this OUT of PROJECT_ROOT
 // so the @anthropic-ai/claude-agent-sdk-spawned headless claude does NOT
@@ -59,11 +60,7 @@ const HEARTBEAT_CONFIG_DIR = join(HEARTBEAT_AGENT_CWD, '.claude-config')
 // its own bun poller against the same bot token -> 409 Conflict -> Marveen
 // channel down by 09:02:45. Project-scope `enabledPlugins: false` overrides
 // the user-scope `true` per Claude Code settings precedence.
-const HEARTBEAT_DISABLED_PLUGINS = [
-  'telegram@claude-plugins-official',
-  'slack-channel@marveen-marketplace',
-  'discord@claude-plugins-official',
-] as const
+const HEARTBEAT_DISABLED_PLUGINS = Object.values(CHANNEL_PLUGIN_IDS)
 
 interface ClaudeSettings {
   enabledPlugins?: Record<string, boolean>

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -62,17 +62,8 @@ export function delay(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms))
 }
 
-// The fleet's channel plugins keyed by provider. A sub-agent must enable ONLY
-// its own provider's plugin; the others are forced off so it cannot spawn a
-// competing poller against the main agent's bot token (the dup-poller / 409
-// Conflict class). Keep in sync with the user-scope enabledPlugins ids.
-export const CHANNEL_PLUGIN_IDS: Record<string, string> = {
-  telegram: 'telegram@claude-plugins-official',
-  slack: 'slack-channel@marveen-marketplace',
-  discord: 'discord@claude-plugins-official',
-  googlechat: 'googlechat@claude-channel-googlechat',
-  teams: 'teams@marveen-marketplace',
-}
+import { CHANNEL_PLUGIN_IDS } from './plugin-ids.js'
+export { CHANNEL_PLUGIN_IDS }
 
 // Pure: compute the enabledPlugins map for a sub-agent so that exactly its own
 // channel plugin is enabled and every other channel plugin is disabled.

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -83,7 +83,7 @@ export function scopeChannelPlugins(
   existing?: Record<string, boolean>,
 ): Record<string, boolean> {
   const out: Record<string, boolean> = { ...(existing ?? {}) }
-  const ownPlugin = explicitProvider ? CHANNEL_PLUGIN_IDS[explicitProvider] : undefined
+  const ownPlugin = explicitProvider ? CHANNEL_PLUGIN_IDS[explicitProvider as keyof typeof CHANNEL_PLUGIN_IDS] : undefined
   for (const pid of Object.values(CHANNEL_PLUGIN_IDS)) {
     out[pid] = pid === ownPlugin
   }

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -48,6 +48,7 @@ import {
 } from '../config.js'
 import { resolveDashboardOrigin } from './agent-scaffold.js'
 import { logger } from '../logger.js'
+import { CHANNEL_PLUGIN_IDS } from './plugin-ids.js'
 
 const HEARTBEAT_AGENT_NAME = 'heartbeat'
 const HEARTBEAT_AGENT_DIR = join(PROJECT_ROOT, 'agents', HEARTBEAT_AGENT_NAME)
@@ -59,11 +60,9 @@ const HEARTBEAT_AGENT_DIR = join(PROJECT_ROOT, 'agents', HEARTBEAT_AGENT_NAME)
 // open its own poller against the OPERATOR's bot token, and race the
 // main agent's poller for the same getUpdates slot -- see
 // agent-process.ts:137 for the same disable baked into startup).
-const CHANNEL_PLUGIN_DISABLES = {
-  'telegram@claude-plugins-official': false,
-  'slack-channel@marveen-marketplace': false,
-  'discord@claude-plugins-official': false,
-}
+const CHANNEL_PLUGIN_DISABLES = Object.fromEntries(
+  Object.values(CHANNEL_PLUGIN_IDS).map(id => [id, false as const])
+)
 
 // Haiku-class model: the heartbeat job is data-formatting (Calendar
 // events + kanban counts + memory + tasks list -> a short structured

--- a/src/web/plugin-ids.ts
+++ b/src/web/plugin-ids.ts
@@ -1,0 +1,12 @@
+// Single source of truth for channel plugin IDs.
+// Add a new provider here and every consumer (agent-process, heartbeat,
+// heartbeat-agent-scaffold, agents route) picks it up automatically.
+export const CHANNEL_PLUGIN_IDS = {
+  telegram: 'telegram@claude-plugins-official',
+  slack: 'slack-channel@marveen-marketplace',
+  discord: 'discord@claude-plugins-official',
+  googlechat: 'googlechat@claude-channel-googlechat',
+  teams: 'teams@marveen-marketplace',
+} as const
+
+export type ChannelPluginId = (typeof CHANNEL_PLUGIN_IDS)[keyof typeof CHANNEL_PLUGIN_IDS]

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -8,6 +8,7 @@ import { createAgentMessage, listPendingChannelRequests, updateChannelRequestSta
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from '../agent-message-wrap.js'
 import { ensureFederationClaudeMdSection } from '../federation/onboarding.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
+import { CHANNEL_PLUGIN_IDS } from '../plugin-ids.js'
 import { getSecret, setSecret, deleteSecret, listSecrets } from '../vault.js'
 import { loadOpenRouterCatalog, fetchAllOpenRouterModels, loadCuratedManual, addCuratedManual, removeCuratedManual } from '../openrouter-models.js'
 import {
@@ -244,14 +245,7 @@ export function setAgentEnabledPlugins(name: string, provider: ChannelProviderTy
     try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
   }
   const plugins = (existing.enabledPlugins ?? {}) as Record<string, boolean>
-  const allPlugins: Record<ChannelProviderType, string> = {
-    telegram: 'telegram@claude-plugins-official',
-    slack: 'slack-channel@marveen-marketplace',
-    discord: 'discord@claude-plugins-official',
-    googlechat: 'googlechat@claude-channel-googlechat',
-    teams: 'teams@marveen-marketplace',
-  }
-  for (const [p, pluginKey] of Object.entries(allPlugins)) {
+  for (const [p, pluginKey] of Object.entries(CHANNEL_PLUGIN_IDS)) {
     plugins[pluginKey] = p === provider
   }
   existing.enabledPlugins = plugins


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Egyéb / Other: refaktoring (karbantarthatóság / maintainability)

## Rövid leírás / Summary

HU: A csatorna plugin ID-k eddig 4 fájlban voltak duplikálva (agent-process.ts, routes/agents.ts, heartbeat.ts, heartbeat-agent-scaffold.ts). Új provider = 4 fájl szinkron frissítése, kihagyásos hiba kockázatával. Megoldás: új src/web/plugin-ids.ts a CHANNEL_PLUGIN_IDS egyetlen forrásaként (as const), a 4 fogyasztó onnan importál. Mellékhatás-javítás: a heartbeat.ts és heartbeat-agent-scaffold.ts eddig csak 3 providert tiltott le (a googlechat és teams kimaradt); most Object.values alapján mind az 5 explicit tiltva.

EN: Channel plugin IDs were duplicated across 4 files, so adding a provider needed 4 in-sync edits (skip-error hazard). New src/web/plugin-ids.ts is the single source of truth (as const); all 4 consumers import from it. Side-effect fix: the heartbeat files were missing googlechat and teams from their disable lists; now all 5 providers are covered via Object.values.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben. / Unit-teszttel és build-del igazolt: npm run build (tsc) tiszta, teljes suite 2443 teszt zöld, nulla regresszió. Élő end-to-end futás nem történt (tiszta refaktor).
- [ ] Frissítettem a docs/ mappát. / Nem szükséges (nincs telepítést vagy architektúrát érintő változás).
- [x] A kód nem tartalmaz beleégetett szenzitív adatot.
- [x] Saját, beszédes nevű branch-ről nyitom (feat/plugin-ids-centralize).

---
This change was authored with AI assistance and reviewed before submission.