### PR TITLE
fix(liveness): retry the ps snapshot once before a verdict of unknown

### DIFF
--- a/src/__tests__/liveness-probe-retry.test.ts
+++ b/src/__tests__/liveness-probe-retry.test.ts
@@ -1,0 +1,52 @@
+// Unit test for `snapshotProcsWithRetry` -- the tiny retry wrapper around the
+// liveness `ps -axww` snapshot. The live probe's `ps` normally returns in ~20ms
+// but throws on a loaded box when it exceeds the fast-path timeout; a single
+// throw used to mean 'unknown' immediately, spamming the log in bursts at load
+// peaks (2026-07-14+ clusters). The wrapper retries once with a longer deadline,
+// so a transient timeout no longer blinds the watchdog. Only a second failure is
+// a genuine "we cannot tell".
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  snapshotProcsWithRetry,
+  PS_PROBE_TIMEOUT_MS,
+  PS_PROBE_RETRY_TIMEOUT_MS,
+} from '../channel-coordinator/liveness.js'
+
+describe('snapshotProcsWithRetry', () => {
+  it('returns the first attempt without retrying on the fast path', () => {
+    const run = vi.fn((_t: number) => 'PS-OUTPUT')
+    const out = snapshotProcsWithRetry(run)
+    expect(out).toBe('PS-OUTPUT')
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(run).toHaveBeenCalledWith(PS_PROBE_TIMEOUT_MS)
+  })
+
+  it('retries once with the longer deadline when the fast path throws', () => {
+    const run = vi.fn((timeoutMs: number) => {
+      if (timeoutMs === PS_PROBE_TIMEOUT_MS) throw new Error('ETIMEDOUT')
+      return 'PS-OUTPUT-RETRY'
+    })
+    const out = snapshotProcsWithRetry(run)
+    expect(out).toBe('PS-OUTPUT-RETRY')
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(run).toHaveBeenNthCalledWith(1, PS_PROBE_TIMEOUT_MS)
+    expect(run).toHaveBeenNthCalledWith(2, PS_PROBE_RETRY_TIMEOUT_MS)
+  })
+
+  it('propagates the error when BOTH attempts throw (verdict stays unknown upstream)', () => {
+    const run = vi.fn((_t: number) => { throw new Error('ETIMEDOUT') })
+    expect(() => snapshotProcsWithRetry(run)).toThrow('ETIMEDOUT')
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry after a successful fast path even if it would have failed later', () => {
+    const run = vi.fn((_t: number) => 'OK')
+    snapshotProcsWithRetry(run)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the retry timeout strictly greater than the fast-path timeout', () => {
+    expect(PS_PROBE_RETRY_TIMEOUT_MS).toBeGreaterThan(PS_PROBE_TIMEOUT_MS)
+  })
+})

--- a/src/channel-coordinator/liveness.ts
+++ b/src/channel-coordinator/liveness.ts
@@ -129,6 +129,31 @@ export function decideHasPluginAlive(ctx: PluginAliveContext): boolean {
   return false
 }
 
+// The liveness snapshot (`ps -axww`) normally returns in ~20ms, but on a heavily
+// loaded box (fleet-wide cold-boots, the 04:00 rebuild) it can exceed the
+// fast-path deadline and THROW. A throw used to mean 'unknown' immediately, which
+// spammed the log in bursts at load peaks (measured 2026-07-14+: clusters of
+// consecutive failures at 04:02, 08:08, 21:00 -- never a real plugin death). The
+// first timeout means "the box is loaded", not "ps is broken", so we retry once
+// with a longer deadline before giving up. Only a second failure is a genuine
+// "we cannot tell". Kept as a tiny pure wrapper so the retry logic is unit-testable
+// without spawning ps.
+export const PS_PROBE_TIMEOUT_MS = 5000
+export const PS_PROBE_RETRY_TIMEOUT_MS = 12_000
+const PS_PROBE_MAX_BUFFER = 8 * 1024 * 1024
+
+export function snapshotProcsWithRetry(
+  run: (timeoutMs: number) => string,
+  timeouts: readonly [number, number] = [PS_PROBE_TIMEOUT_MS, PS_PROBE_RETRY_TIMEOUT_MS],
+): string {
+  try {
+    return run(timeouts[0])
+  } catch (firstErr) {
+    logger.debug({ err: firstErr }, 'Channel-plugin liveness probe: ps snapshot timed out, retrying with a longer deadline')
+    return run(timeouts[1])
+  }
+}
+
 // Tri-state liveness verdict. 'unknown' means the PROBE failed (ps timed out on
 // a loaded box, the state dir was unreadable, ...) -- not that the plugin is
 // down. Collapsing that into 'down' let a hiccup in the monitor's own probe
@@ -146,18 +171,21 @@ export function probeChannelPluginLiveness(
     // Parity with the reaper's snapshotProcs: `-ww` (never truncate a command,
     // the poller match lives deep in a long path), an 8MB buffer (the default
     // 1MB is only ~3x the measured fleet-wide ps output, and blowing it makes
-    // execFileSync THROW) and a 5s timeout. A probe that throws is a probe that
-    // knows nothing -- and knowing nothing used to mean "restart the agent".
+    // execFileSync THROW) and a fast-path timeout with one longer-deadline retry
+    // (see snapshotProcsWithRetry). A probe that throws twice is a probe that
+    // knows nothing -- and knowing nothing must NOT restart the agent.
     // Keep the HEADER form (`-o pid,ppid,command`, not `-o pid=,...`):
     // decideHasPluginAlive drops the first line as the header, so a headerless
     // output would silently lose the first process row.
-    psOutput = execFileSync('/bin/ps', ['-axww', '-o', 'pid,ppid,command'], {
-      timeout: 5000,
-      encoding: 'utf-8',
-      maxBuffer: 8 * 1024 * 1024,
-    })
+    psOutput = snapshotProcsWithRetry((timeoutMs) =>
+      execFileSync('/bin/ps', ['-axww', '-o', 'pid,ppid,command'], {
+        timeout: timeoutMs,
+        encoding: 'utf-8',
+        maxBuffer: PS_PROBE_MAX_BUFFER,
+      }),
+    )
   } catch (err) {
-    logger.warn({ err, claudePid, agentName, providerType }, 'Channel-plugin liveness probe failed (ps) -- verdict unknown, not restarting')
+    logger.warn({ err, claudePid, agentName, providerType }, 'Channel-plugin liveness probe failed (ps, after retry) -- verdict unknown, not restarting')
     return 'unknown'
   }
   try {


### PR DESCRIPTION
## Mit

Card **a23320c8** 3. pontja: "MIÉRT esik le a channel-plugin naponta ~10x". A vizsgálat eredménye: **nem a plugin esik le**, a liveness probe `ps -axww` (teljes rendszer-snapshot) hasal el.

## Gyökér

A probe normál esetben ~20ms alatt visszatér (mérve: 0.02s, 88KB, 513 proc). Terhelés-csúcsban viszont (flotta cold-bootok, a 04:00-ás rebuild) átlépi az 5s fast-path timeoutot és **THROW**-ol. Egyetlen throw azonnal `'unknown'`-t adott, ezért jöttek a burst-ös hamis verdiktek a terhelés-csúcsoknál (2026-07-14+ logban klaszterek: 04:02, 08:08, 21:00 -- a plugin sosem volt valóban halott).

PR #612 óta az `'unknown'` már ártalmatlan (nem indít restartot), szóval ez most **detektálási vakfolt + log-zaj**, nem kill-probléma: minden `'unknown'` ablakban egy valóban halott plugin észrevétlen maradna.

## Fix

Apró tiszta retry-wrapper (`snapshotProcsWithRetry`): a snapshotot az 5s fast-path timeouttal futtatja, throw esetén **egyszer** újrapróbálja 12s deadline-nal, mielőtt feladná. Az első timeout azt jelenti "a gép terhelt", nem "a ps hibás"; csak a második bukás valódi "nem tudjuk". A gyakori út egyetlen ~20ms hívás marad.

- 5 unit teszt (fast path, retry, both-throw propagáció, timeout-sorrend)
- teljes typecheck tiszta, érintett suite 39/39 zöld

## Megjegyzés

A branch feloldotta a `src/platform.ts` beragadt auto-update stash-pop konfliktusát is (a HEAD/#634 verzióra, ami a helyes), de az a commitban nem jelenik meg diffként, mert megegyezik a develop-pal. A dashboard rebuild eddig emiatt is tört volna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)