### PR TITLE
fix(install-linux): ensure curl before nodesource step + npm fallback on bare Debian

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -206,8 +206,33 @@ if [ -n "$MISSING_PKGS" ]; then
   echo -e "  Telepites sudo-val ($PKG_MANAGER)..."
   if [ "$PKG_MANAGER" = "apt" ]; then
     if echo "$MISSING_PKGS" | grep -q nodejs; then
+      # A nodesource setup-script curl-t igenyel, de csupasz VPS-en (Debian
+      # netinst) a curl maga is hianyozhat -- ilyenkor eloszor azt telepitjuk,
+      # kulonben a repo-lepes neman kimarad, a disztro sajat (regebbi) nodejs-e
+      # telepul, es Debianon az npm (kulon csomag) le se jon -> [1/7] fail.
+      if ! command -v curl &>/dev/null; then
+        sudo apt-get update -qq || true
+        sudo apt-get install -y curl -qq || true
+        hash -r
+      fi
       echo -e "  Node.js v22 repo hozzaadasa (nodesource)..."
-      curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - >/dev/null 2>&1
+      # A setup-scriptet valtozoba toltjuk es a curl exit-kodjat kulon nezzuk:
+      # a 'curl | sudo bash -' pipeline exit-kodja a bash-e lenne (ures stdin-en
+      # 0), igy a curl-hiba nem latszana es a fallback sosem aktivalodna.
+      NODESOURCE_OK=false
+      if command -v curl &>/dev/null; then
+        NODESOURCE_SETUP="$(curl -fsSL https://deb.nodesource.com/setup_22.x 2>/dev/null || true)"
+        if [ -n "$NODESOURCE_SETUP" ] && echo "$NODESOURCE_SETUP" | sudo -E bash - >/dev/null 2>&1; then
+          NODESOURCE_OK=true # a nodesource nodejs csomag node+npm-et egyben hozza
+        fi
+      fi
+      if [ "$NODESOURCE_OK" = false ]; then
+        # Fallback: disztro sajat nodejs-e. Debianon az npm kulon csomag,
+        # a nodesource-bundle-lel ellentetben nem jon a nodejs-sel magatol.
+        warn "nodesource repo hozzaadasa sikertelen -- a disztro sajat nodejs + npm csomagjat telepitem."
+        sudo apt-get update -qq
+        MISSING_PKGS="$MISSING_PKGS npm"
+      fi
     else
       sudo apt-get update -qq
     fi


### PR DESCRIPTION
## Problem

On a bare Debian 13 VPS (netinst image, no curl preinstalled) the installer's [1/7] dependency step failed:

1. `curl` is itself in `MISSING_PKGS`, but the nodesource repo step (`curl -fsSL .../setup_22.x | sudo -E bash -`) runs BEFORE the `apt-get install` line that would install it -> `curl: command not found`, the nodesource v22 repo is silently skipped.
2. apt then installs the distro nodejs (v20.19.2 on Debian 13), which on Debian does NOT bundle npm (separate package, not in `MISSING_PKGS`).
3. The hard check `command -v npm || fail` aborts the whole install.

Hit in the field on a live customer VPS install (2026-07-22).

## Fix

- Install curl (with `apt-get update`) before the nodesource setup step when missing.
- Check curl's exit code directly by capturing the setup script into a variable first. The previous `curl | sudo bash -` pipeline returned bash's exit code (0 on empty stdin), so curl failures were invisible -- the fallback below would never have triggered.
- Explicit fallback: if the nodesource repo cannot be added (no curl / network failure), warn and install the distro `nodejs` + `npm` packages instead, so the install proceeds.

## Verify

Mocked bare-Debian-13 harness (PATH-isolated stubs for sudo/apt-get/curl, `set -e` active, same block sourced from this script), three scenarios:

| Scenario | Result |
|---|---|
| bare box, nodesource reachable | curl installed first, nodesource repo added, node v22 + bundled npm |
| curl OK, nodesource unreachable | fallback: distro node v20 + npm, install proceeds |
| curl uninstallable | same fallback, install proceeds |

`bash -n` clean; shellcheck reports only pre-existing warnings outside this block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)