### PR TITLE
fix(fresh-install): first-run gate -- stop scheduled tasks piling up on dialog-parked agents (card 5F37BB84)

### DIFF
--- a/src/__tests__/pane-first-run-gate.test.ts
+++ b/src/__tests__/pane-first-run-gate.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { detectsFirstRunGate, detectPaneState, detectsBlockingMenu } from '../pane-state.js'
+
+// Fresh-install first-run gate detection (card 5F37BB84, Oligo2000 VPS
+// 2026-07-22). A sub-agent session parked on a Claude Code first-run dialog
+// (folder-trust / bypass-permissions acceptance / login picker) has no idle
+// footer and no busy signal, so detectPaneState reads 'unknown' and every
+// scheduled task defers forever -- while a forceSend task typed its prompt
+// blindly into the dialog. detectsFirstRunGate names the blocker so the
+// scheduler can defer with a reasoned retry and the channel-monitor can
+// answer the dialog chain instead of Escape-quitting the TUI.
+
+const TRUST_PANE = [
+  '╭──────────────────────────────────────────────────╮',
+  '│ Do you trust the files in this folder?           │',
+  '│                                                  │',
+  '│ /home/gabor/marveen/agents/nova                  │',
+  '│                                                  │',
+  '│ Claude Code may read, analyze and edit files in  │',
+  '│ this folder.                                     │',
+  '│                                                  │',
+  '│ ❯ 1. Yes, proceed                                │',
+  '│   2. No, exit                                    │',
+  '╰──────────────────────────────────────────────────╯',
+  '   Enter to confirm · Esc to exit',
+].join('\n')
+
+const BYPASS_PANE = [
+  '╭──────────────────────────────────────────────────╮',
+  '│ Bypass Permissions mode                          │',
+  '│                                                  │',
+  '│ In Bypass Permissions mode, Claude Code will not │',
+  '│ ask for your approval before running potentially │',
+  '│ dangerous commands.                              │',
+  '│                                                  │',
+  '│ ❯ 1. No, exit                                    │',
+  '│   2. Yes, I accept                               │',
+  '╰──────────────────────────────────────────────────╯',
+].join('\n')
+
+const LOGIN_PANE = [
+  ' Welcome to Claude Code',
+  '',
+  ' Select login method:',
+  '',
+  ' ❯ 1. Claude account with subscription',
+  '   2. Anthropic Console account',
+  '',
+  '   Enter to confirm',
+].join('\n')
+
+const THEME_PANE = [
+  ' Welcome to Claude Code',
+  '',
+  ' Choose the text style that looks best with your terminal:',
+  '',
+  ' ❯ 1. Dark mode',
+  '   2. Light mode',
+].join('\n')
+
+const WELCOME_TOUR_PANE = [
+  ' Welcome to Claude Code!',
+  '',
+  ' Claude Code is a CLI tool for agentic coding.',
+  '',
+  ' Press Enter to continue',
+].join('\n')
+
+// Normal fresh-session layout: welcome banner + EMPTY input box, footer not
+// yet rendered. This pane is usable (a prompt can land), NOT a gate.
+const FRESH_SESSION_PROMPT_PANE = [
+  ' Welcome to Claude Code',
+  '',
+  ' model: claude-opus-4-8   cwd: /home/gabor/marveen/agents/nova',
+  '',
+  '──────────────────────────────────────────────────',
+  ' ❯ ',
+  '──────────────────────────────────────────────────',
+].join('\n')
+
+// Healthy idle pane whose scrollback QUOTES the trust-dialog phrase (an agent
+// discussing this very bug). The live idle footer proves the prompt is up.
+const IDLE_WITH_QUOTE_PANE = [
+  ' The customer pane showed "Do you trust the files in this folder?" at boot.',
+  '',
+  '──────────────────────────────────────────────────',
+  ' ❯ ',
+  '──────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Busy pane quoting the phrase mid-turn.
+const BUSY_WITH_QUOTE_PANE = [
+  ' Analyzing the report: "Do you trust the files in this folder?" parks agents.',
+  ' Thinking… (12s · ↓ 1.2k tokens · esc to interrupt)',
+].join('\n')
+
+describe('detectsFirstRunGate', () => {
+  it('classifies the folder-trust dialog', () => {
+    expect(detectsFirstRunGate(TRUST_PANE)).toBe('trust')
+  })
+
+  it('classifies the bypass-permissions acceptance dialog', () => {
+    expect(detectsFirstRunGate(BYPASS_PANE)).toBe('bypass-permissions')
+  })
+
+  it('classifies the login picker (wins over the welcome banner it renders under)', () => {
+    expect(detectsFirstRunGate(LOGIN_PANE)).toBe('login')
+  })
+
+  it('classifies the theme picker (wins over the welcome banner)', () => {
+    expect(detectsFirstRunGate(THEME_PANE)).toBe('theme')
+  })
+
+  it('classifies the onboarding welcome/tour screen', () => {
+    expect(detectsFirstRunGate(WELCOME_TOUR_PANE)).toBe('welcome')
+  })
+
+  it('does NOT flag the normal fresh-session prompt under the welcome banner', () => {
+    expect(detectsFirstRunGate(FRESH_SESSION_PROMPT_PANE)).toBeNull()
+  })
+
+  it('does NOT flag an idle pane that merely quotes the dialog text', () => {
+    expect(detectsFirstRunGate(IDLE_WITH_QUOTE_PANE)).toBeNull()
+  })
+
+  it('does NOT flag a busy pane that quotes the dialog text', () => {
+    expect(detectsFirstRunGate(BUSY_WITH_QUOTE_PANE)).toBeNull()
+  })
+
+  it('returns null on empty/whitespace panes', () => {
+    expect(detectsFirstRunGate('')).toBeNull()
+    expect(detectsFirstRunGate('   \n  ')).toBeNull()
+  })
+
+  it('documents WHY the gate is needed: detectPaneState reads these dialogs as unknown', () => {
+    // 'unknown' means isSessionReadyForPrompt stays false forever -- the
+    // scheduled-task pile-up. The gate detector is what names the blocker.
+    expect(detectPaneState(TRUST_PANE)).toBe('unknown')
+    expect(detectPaneState(LOGIN_PANE)).toBe('unknown')
+  })
+
+  it('trust dialog would also read as a generic blocking menu (Escape would QUIT it) -- the first-run check must win', () => {
+    // "Esc to exit" matches the generic menu detector; the monitor's generic
+    // recovery is Escape, which on this dialog selects "No, exit" and quits
+    // the TUI. The call-site ordering (firstRunGate checked first) is pinned
+    // by the source-contract test below.
+    expect(detectsBlockingMenu(TRUST_PANE)).toBe(true)
+  })
+})
+
+// --- source contracts (same style as send-prompt-force-send-gate.test.ts) ---
+
+const SCHEDULE_RUNNER = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+const CHANNEL_MONITOR = readFileSync(join(__dirname, '../web/channel-monitor.ts'), 'utf-8')
+const AGENT_PROCESS = readFileSync(join(__dirname, '../web/agent-process.ts'), 'utf-8')
+
+describe('first-run gate wiring contracts', () => {
+  it('the scheduler forceSend path defers on a first-run gate BEFORE the bypass injects', () => {
+    const gateIdx = SCHEDULE_RUNNER.indexOf('const forceGate = pane != null ? detectsFirstRunGate(pane) : null')
+    const bypassLogIdx = SCHEDULE_RUNNER.indexOf("'forceSend=true, bypassing busy-state check'")
+    expect(gateIdx).toBeGreaterThan(0)
+    expect(bypassLogIdx).toBeGreaterThan(gateIdx)
+    // The deferral routes through the pending-retry queue as 'first-run'.
+    expect(SCHEDULE_RUNNER).toMatch(/if \(forceGate\) \{[\s\S]{0,400}?return 'first-run'/)
+  })
+
+  it("the non-forceSend busy path distinguishes 'first-run' so the retry reason names the blocker", () => {
+    expect(SCHEDULE_RUNNER).toMatch(/const gate = notReadyPane != null \? detectsFirstRunGate\(notReadyPane\) : null/)
+  })
+
+  it("'first-run' is exempt from skipIfBusy (queued like mcp-missing, never dropped)", () => {
+    expect(SCHEDULE_RUNNER).toMatch(/result === 'first-run'[\s\S]{0,700}?insertPendingTaskRetryIfNew\(task\.name, agentName, now, 'first-run'\)/)
+  })
+
+  it('the channel-monitor answers first-run dialogs instead of sending Escape', () => {
+    const gateIdx = CHANNEL_MONITOR.indexOf('const firstRunGate = pane != null ? detectsFirstRunGate(pane) : null')
+    expect(gateIdx).toBeGreaterThan(0)
+    // The Escape recovery must be in the ELSE branch after the first-run
+    // handling, and the login picker must be alert-only (no keystrokes).
+    expect(CHANNEL_MONITOR).toMatch(/if \(firstRunGate === 'login'\) \{[\s\S]{0,600}?no keystrokes sent/)
+    expect(CHANNEL_MONITOR).toMatch(/\} else if \(firstRunGate\) \{[\s\S]{0,400}?await answerFirstRunGates\(t\.session\)/)
+  })
+
+  it('answerFirstRunGates never answers the login picker and never sends Escape', () => {
+    const fnIdx = AGENT_PROCESS.indexOf('export async function answerFirstRunGates(')
+    expect(fnIdx).toBeGreaterThan(0)
+    const fn = AGENT_PROCESS.slice(fnIdx, AGENT_PROCESS.indexOf('// Post-(re)start identity setup', fnIdx))
+    expect(fn).toContain("if (gate === 'login') return 'login'")
+    expect(fn).not.toContain("'Escape'")
+  })
+
+  it('startAgentProcess stamps per-project trust in the config root the session boots from', () => {
+    const stampIdx = AGENT_PROCESS.indexOf('stampProjectTrustForDir(\n      claudeConfigDir')
+    const launchIdx = AGENT_PROCESS.indexOf("runTmux(null, ['new-session', '-d', '-s', session, cmd]")
+    expect(stampIdx).toBeGreaterThan(0)
+    // The stamp must happen BEFORE the tmux session is spawned.
+    expect(launchIdx).toBeGreaterThan(stampIdx)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -404,6 +404,69 @@ export function detectsBlockingMenu(pane: string): boolean {
   return MENU_NAV_RX.test(footerRegion) || MENU_ESC_RX.test(footerRegion)
 }
 
+// Claude Code FIRST-RUN gates: the interactive dialogs a brand-new install
+// parks on before the prompt ever renders -- the per-project "Do you trust the
+// files in this folder?" consent, the --dangerously-skip-permissions "Bypass
+// Permissions mode" acceptance, the "Select login method" picker, the theme
+// picker and the onboarding welcome screen. A sub-agent session stuck on one
+// of these is the fresh-install failure mode behind "scheduled tasks pile up
+// on the agents" (Oligo2000 VPS, 2026-07-22): the pane has no idle footer and
+// no busy signal, so detectPaneState reads 'unknown', isSessionReadyForPrompt
+// stays false forever, every scheduled task defers into pending_task_retries,
+// and a forceSend task types its prompt blindly into the dialog.
+//
+// These gates need their own detector (distinct from detectsBlockingMenu)
+// because the RECOVERY differs: a /mcp-style modal pops back to the prompt on
+// Escape, but on the trust/bypass dialogs Escape means "No, exit" -- it QUITS
+// the TUI and the session respawns straight back into the same dialog. The
+// monitor must answer them the way scripts/channels.sh's startup guard does
+// (trust -> "1" Enter, bypass -> "2" Enter) and must only ALERT on the login
+// picker (nobody can log in on the operator's behalf).
+//
+// Guards against a healthy session that merely quotes the dialog text follow
+// detectsBlockingMenu's discipline: a busy pane is never a gate, and a visible
+// idle footer means the real prompt is live (capture-pane -p sees only the
+// visible screen, so a quoted phrase always coexists with the live footer).
+export type FirstRunGateKind = 'trust' | 'bypass-permissions' | 'login' | 'theme' | 'welcome'
+
+// Ordered: the login picker and theme screen render UNDER the "Welcome to
+// Claude Code" banner, so the more specific matches must win before the
+// generic welcome fallback.
+const FIRST_RUN_GATES: Array<{ kind: FirstRunGateKind; rx: RegExp }> = [
+  { kind: 'trust', rx: /Do you trust the files in this folder\?/ },
+  { kind: 'bypass-permissions', rx: /Bypass Permissions mode/ },
+  { kind: 'login', rx: /Select login method/ },
+  { kind: 'theme', rx: /Choose the text style/ },
+  { kind: 'welcome', rx: /Welcome to Claude Code/ },
+]
+
+/**
+ * Classify the pane as a Claude Code first-run gate, or null when it is a
+ * normal (busy / idle / typing) surface. Pure + dependency-free.
+ */
+export function detectsFirstRunGate(pane: string): FirstRunGateKind | null {
+  if (!pane || !pane.trim()) return null
+  const lines = pane.split('\n')
+  const busyRegion = lines.slice(-BUSY_LIVE_REGION_LINES).join('\n')
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(busyRegion)) return null
+  }
+  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return null
+  if (IDLE_FOOTER_RX.test(pane)) return null
+  for (const g of FIRST_RUN_GATES) {
+    if (!g.rx.test(pane)) continue
+    // The welcome banner also heads the NORMAL fresh-session layout (logo +
+    // model + cwd + empty input box, footer not yet rendered). A ❯ prompt
+    // glyph means an input box exists -- that pane is usable, not a gate.
+    // The trust/bypass/login dialogs use ❯ only as their option selector and
+    // are matched above, before this fallback.
+    if (g.kind === 'welcome' && pane.includes('❯')) continue
+    return g.kind
+  }
+  return null
+}
+
 export interface DetectPaneStateOptions {
   /** If true, the 'typing' state (text parked in input box) is
    * merged into 'busy'. Default false -- callers that care about

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, lstatSync, symlinkSync, rmSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, lstatSync, symlinkSync, rmSync, realpathSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync, execFileSync } from 'node:child_process'
@@ -15,6 +15,8 @@ import {
   stripGhostSuggestion,
   paneShowsContextSaturation,
   idleConsideringDimGhost,
+  detectsFirstRunGate,
+  type FirstRunGateKind,
 } from '../pane-state.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentClaudePlan, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentMemoryIsolation } from './agent-config.js'
 import { resolveAgentConfigDir } from './claude-plans.js'
@@ -544,6 +546,65 @@ export function ensureSharedClaudeOnboarded(dotClaudePath: string = join(homedir
   }
 }
 
+// Pre-accept the PER-PROJECT first-run consent for an agent's working dir in
+// the config root the session will boot from. Claude Code keys the "Do you
+// trust the files in this folder?" dialog on projects[<cwd>].hasTrustDialogAccepted
+// in <config root>/.claude.json -- a GLOBAL hasCompletedOnboarding does not
+// cover it. The main session gets this via the channels.sh startup guard and
+// the generation workers stamp it themselves (agent-worker.ts), but a normal
+// sub-agent launch never did: on the ORIGIN fleet every agents/<name> dir was
+// trusted interactively long ago, so the gap only bites on a FRESH install,
+// where every newly created agent parks on the trust dialog forever and its
+// scheduled tasks pile up as pending retries (Oligo2000 VPS, 2026-07-22).
+//
+// Stamps both the given dir and its realpath (macOS /var vs /private/var,
+// symlinked homes) since Claude Code keys trust by the resolved path. Write is
+// atomic and only performed on actual change, so a live Claude Code process
+// racing us never sees a torn file and an already-stamped launch is a no-op.
+export function stampProjectTrustForDir(dotClaudePath: string, projectDir: string): boolean {
+  try {
+    let data: Record<string, unknown> = {}
+    if (existsSync(dotClaudePath)) {
+      data = JSON.parse(readFileSync(dotClaudePath, 'utf-8')) as Record<string, unknown>
+    }
+    const dirs = new Set<string>([projectDir])
+    try { dirs.add(realpathSync(projectDir)) } catch { /* dir may not resolve yet */ }
+    const projects: Record<string, unknown> =
+      (data.projects && typeof data.projects === 'object' && !Array.isArray(data.projects))
+        ? data.projects as Record<string, unknown>
+        : {}
+    let changed = false
+    if (data.hasCompletedOnboarding !== true) {
+      data.hasCompletedOnboarding = true
+      changed = true
+    }
+    for (const dir of dirs) {
+      const base = (projects[dir] && typeof projects[dir] === 'object')
+        ? projects[dir] as Record<string, unknown>
+        : {}
+      if (base.hasTrustDialogAccepted === true && base.hasCompletedProjectOnboarding === true) continue
+      projects[dir] = {
+        ...base,
+        hasTrustDialogAccepted: true,
+        hasCompletedProjectOnboarding: true,
+        projectOnboardingSeenCount: Math.max(1, Number(base.projectOnboardingSeenCount) || 0),
+      }
+      changed = true
+    }
+    if (!changed) return false
+    data.projects = projects
+    atomicWriteFileSync(dotClaudePath, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 })
+    logger.info({ dotClaudePath, projectDir }, 'project-trust: stamped folder-trust consent for agent dir')
+    return true
+  } catch (err) {
+    // Unparseable/unwritable file: leave it to Claude Code (same policy as
+    // ensureSharedClaudeOnboarded). The scheduler's first-run gate + the
+    // channel-monitor's dialog answering remain the runtime backstop.
+    logger.warn({ err, dotClaudePath, projectDir }, 'project-trust: could not stamp trust flags (agent may park on the folder-trust dialog)')
+    return false
+  }
+}
+
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
   if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord' || perAgent === 'googlechat' || perAgent === 'teams') return perAgent
@@ -992,6 +1053,15 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
         maybeAlertSharedConfigCollision(name)
       }
     }
+    // Per-project trust pre-seed in the config root this session will ACTUALLY
+    // use (isolated CLAUDE_CONFIG_DIR when set, shared ~/.claude.json
+    // otherwise). Without it a fresh install's first launch of each agent
+    // parks on the "Do you trust the files in this folder?" dialog -- see
+    // stampProjectTrustForDir.
+    stampProjectTrustForDir(
+      claudeConfigDir ? join(claudeConfigDir, '.claude.json') : join(homedir(), '.claude.json'),
+      dir,
+    )
     const claudeConfigEnv = claudeConfigDir ? `export CLAUDE_CONFIG_DIR="${claudeConfigDir}" && ` : ''
     // `--continue` requires an existing session; on a brand-new agent the
     // Claude Code projects directory does not yet exist and `claude` exits
@@ -1196,6 +1266,60 @@ export async function dismissResumeSummaryModalIfPresent(session: string, host: 
   } catch (err) {
     logger.warn({ err, session }, 'Failed to probe/dismiss resume-from-summary modal')
   }
+}
+
+// Walk a session out of the Claude Code FIRST-RUN dialog chain (folder-trust,
+// bypass-permissions acceptance, theme picker, welcome screen), answering each
+// dialog exactly the way scripts/channels.sh's startup guard does for the main
+// session: trust -> "1" Enter (Yes, proceed), bypass -> "2" Enter (Yes, I
+// accept), theme/welcome -> Enter (accept default / continue). The login
+// picker is NEVER answered -- nobody can authenticate on the operator's
+// behalf -- so it is returned for the caller to alert on.
+//
+// Escape is deliberately NOT used anywhere here: on the trust/bypass dialogs
+// Escape selects "No, exit" and quits the TUI, which is exactly the
+// respawn-loop failure the channel-monitor's generic menu recovery would cause
+// on these panes (hence the detectsFirstRunGate carve-out at its call site).
+//
+// Bounded walk: the chain is at most a handful of dialogs; each answered
+// dialog gets a settle delay before the re-capture. Returns 'cleared' when at
+// least one dialog was answered and none remains, 'login' when the login
+// picker is (or becomes) the blocker, 'unchanged' when no gate was present.
+const FIRST_RUN_ANSWER_MAX_STEPS = 6
+const FIRST_RUN_ANSWER_SETTLE_MS = 1500
+
+export async function answerFirstRunGates(
+  session: string,
+  host: string | null = null,
+): Promise<'cleared' | 'login' | 'unchanged'> {
+  let acted = false
+  for (let i = 0; i < FIRST_RUN_ANSWER_MAX_STEPS; i++) {
+    const pane = capturePane(session, host)
+    const gate: FirstRunGateKind | null = pane != null ? detectsFirstRunGate(pane) : null
+    if (gate == null) return acted ? 'cleared' : 'unchanged'
+    if (gate === 'login') return 'login'
+    try {
+      if (gate === 'trust') {
+        runTmux(host, ['send-keys', '-t', session, '1'], { timeout: 5000 })
+        await delay(150)
+        runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+      } else if (gate === 'bypass-permissions') {
+        runTmux(host, ['send-keys', '-t', session, '2'], { timeout: 5000 })
+        await delay(150)
+        runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+      } else {
+        // theme / welcome: Enter accepts the highlighted default and moves on.
+        runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+      }
+    } catch (err) {
+      logger.warn({ err, session, gate }, 'first-run gate: answer keystroke failed')
+      return acted ? 'cleared' : 'unchanged'
+    }
+    acted = true
+    logger.info({ session, gate, step: i }, 'first-run gate: answered dialog')
+    await delay(FIRST_RUN_ANSWER_SETTLE_MS)
+  }
+  return acted ? 'cleared' : 'unchanged'
 }
 
 // Post-(re)start identity setup. Every freshly spawned Claude Code session is

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -22,12 +22,13 @@ import {
   ensureSharedClaudeOnboarded,
   hasFleetOauthToken,
   FLEET_OAUTH_TOKEN_PATH,
+  answerFirstRunGates,
 } from './agent-process.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes, collectPollerEvidence } from './channel-poller-reap.js'
 import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { schedulePluginUnlockAfterRespawn, wasPluginConfirmedAbsent, clearPluginAbsent } from './channel-plugin-unlock.js'
 import {
-  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, type PaneErrorAlertState, type PaneState,
+  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
   parkedInputText, shouldClearTruncatedPreamble,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
@@ -1315,7 +1316,16 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
     // never fires and the Escape is not re-sent every tick.
     for (const t of targets) {
       const pane = capturePane(t.session)
-      const inMenu = pane != null && detectsBlockingMenu(pane)
+      // First-run gates (fresh-install folder-trust / bypass acceptance /
+      // login picker) are detected SEPARATELY from generic blocking menus,
+      // because the recovery differs: Escape on the trust/bypass dialogs
+      // selects "No, exit" and QUITS the TUI -- the session respawns straight
+      // back into the same dialog (respawn loop), which is the fresh-install
+      // "scheduled tasks pile up" incident (Oligo2000 VPS, 2026-07-22). These
+      // panes get the channels.sh-style dialog answers instead; only the
+      // login picker is alert-only (nobody can log in on the operator's behalf).
+      const firstRunGate = pane != null ? detectsFirstRunGate(pane) : null
+      const inMenu = firstRunGate != null || (pane != null && detectsBlockingMenu(pane))
       const prev = paneMenuState.get(t.session) ?? { firstSeenAt: null, lastAlertAt: null, lastErrorAt: null }
       const decision = decidePaneErrorAlert(inMenu, prev, Date.now(), {
         confirmMs: MENU_RECOVER_CONFIRM_MS,
@@ -1329,13 +1339,26 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
       }
       if (decision.alert) {
         const label = t.isMarveen ? BOT_NAME : (t.agentName ?? t.session)
-        logger.warn({ session: t.session, agent: label }, 'Session parked in a blocking interactive menu -- sending Escape to recover')
-        try {
-          execFileSync(TMUX, ['send-keys', '-t', t.session, 'Escape'], { timeout: 5000 })
-        } catch (err) {
-          logger.warn({ err, session: t.session }, 'Menu-recovery Escape failed')
+        if (firstRunGate === 'login') {
+          logger.warn({ session: t.session, agent: label }, 'Session parked on the Claude Code login picker -- operator login needed, alerting (no keystrokes sent)')
+          sendAlert(`🔑 A(z) ${label} agentnek Claude-belépés kell (első indítás, "Select login method" képernyő). Lépj be: tmux attach -t ${t.session}, majd válaszd ki a belépési módot. Addig az ütemezett feladatai és üzenetei várakoznak, belépés után maguktól kézbesítődnek.`)
+        } else if (firstRunGate) {
+          logger.warn({ session: t.session, agent: label, gate: firstRunGate }, 'Session parked on a Claude Code first-run dialog -- answering the dialog chain')
+          const res = await answerFirstRunGates(t.session)
+          if (res === 'login') {
+            sendAlert(`🔑 A(z) ${label} agent első-indítási dialogjait továbbléptettem, de Claude-belépés kell ("Select login method"). Lépj be: tmux attach -t ${t.session}. Utána minden várakozó feladat magától kézbesítődik.`)
+          } else {
+            sendAlert(`🧭 A(z) ${label} session a Claude Code első-indítási képernyőjén parkolt (${firstRunGate}); automatikusan továbbléptettem. A várakozó ütemezett feladatok a következő körben kézbesítődnek.`)
+          }
+        } else {
+          logger.warn({ session: t.session, agent: label }, 'Session parked in a blocking interactive menu -- sending Escape to recover')
+          try {
+            execFileSync(TMUX, ['send-keys', '-t', t.session, 'Escape'], { timeout: 5000 })
+          } catch (err) {
+            logger.warn({ err, session: t.session }, 'Menu-recovery Escape failed')
+          }
+          sendAlert(`⌨️ A(z) ${label} session beragadt egy interaktiv menube (pl. /mcp) es nem dolgozott fel uzeneteket. Kikuldtem egy Escape-et, visszateritettem a prompthoz. Ha ismetlodik: tmux attach -t ${t.session}`)
         }
-        sendAlert(`⌨️ A(z) ${label} session beragadt egy interaktiv menube (pl. /mcp) es nem dolgozott fel uzeneteket. Kikuldtem egy Escape-et, visszateritettem a prompthoz. Ha ismetlodik: tmux attach -t ${t.session}`)
       }
     }
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -46,7 +46,7 @@ import {
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
 import { runCommandTask } from './command-task.js'
-import { paneShowsContextSaturation } from '../pane-state.js'
+import { paneShowsContextSaturation, detectsFirstRunGate } from '../pane-state.js'
 
 // How many bare-Enter attempts the post-send resubmit tries before escalating
 // to a clear + re-inject, and the hard cap after which it gives up.
@@ -194,7 +194,7 @@ async function attemptFireTask(
   now: number,
   preCheckPrefix?: string,
   lateCatchUpMs?: number,
-): Promise<'fired' | 'busy' | 'missing' | 'starting' | 'error' | 'mcp-missing'> {
+): Promise<'fired' | 'busy' | 'missing' | 'starting' | 'error' | 'mcp-missing' | 'first-run'> {
   const isMainAgent = agentName === MAIN_AGENT_ID
   // Allow per-task session override via targetSession config field.
   // Falls back to the standard agent session name derivation.
@@ -236,6 +236,18 @@ async function attemptFireTask(
   // retry loop observed when the target session stays busy for hours
   // (275 retries overnight in production).
   if (!task.forceSend && !(await isSessionReadyForPrompt(session, host))) {
+    // Distinguish a first-run gate (fresh-install folder-trust / login picker
+    // parked forever) from an ordinary busy turn: the retry row's reason then
+    // drives a first-run-specific operator alert instead of a generic
+    // "varakozik" -- and 'first-run' is exempt from skipIfBusy in the caller,
+    // because a gated session never frees up on its own the way a busy one
+    // does (recovery is the channel-monitor's dialog answering).
+    const notReadyPane = capturePane(session, host)
+    const gate = notReadyPane != null ? detectsFirstRunGate(notReadyPane) : null
+    if (gate) {
+      logger.warn({ task: task.name, agent: agentName, session, gate }, 'Schedule target session parked on a Claude Code first-run dialog, deferring to retry queue')
+      return 'first-run'
+    }
     logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session busy or has pending input, will retry')
     return 'busy'
   }
@@ -256,6 +268,18 @@ async function attemptFireTask(
     if (pane != null && paneShowsContextSaturation(pane)) {
       logger.warn({ task: task.name, agent: agentName, session }, 'forceSend target session is context-saturated (100%) -- deferring to retry queue instead of injecting into a wedged session')
       return 'busy'
+    }
+    // Same non-negotiable for a first-run gate: a fresh install's agent parked
+    // on the folder-trust dialog / login picker has no input box at all, so a
+    // force-injected prompt is typed blindly into the DIALOG (digits select
+    // options, Enter confirms them) and the prompt is lost -- a silent drop
+    // with extra steps, plus keystroke roulette on a consent dialog. Defer to
+    // the retry queue; the channel-monitor answers the dialogs (or alerts on
+    // the login picker) and the retry lands on the first tick after.
+    const forceGate = pane != null ? detectsFirstRunGate(pane) : null
+    if (forceGate) {
+      logger.warn({ task: task.name, agent: agentName, session, gate: forceGate }, 'forceSend target session is parked on a Claude Code first-run dialog -- deferring to retry queue instead of typing into the dialog')
+      return 'first-run'
     }
     logger.info({ task: task.name, agent: agentName, session }, 'forceSend=true, bypassing busy-state check')
   }
@@ -451,7 +475,7 @@ export async function runScheduledTaskNow(
     // busy session both get a queued retry that lands once the session is
     // ready. We deliberately do NOT consult skipIfBusy here -- that flag trims
     // redundant cron ticks, but an explicit run-now must not be dropped.
-    if (result === 'starting' || result === 'busy' || result === 'mcp-missing') {
+    if (result === 'starting' || result === 'busy' || result === 'mcp-missing' || result === 'first-run') {
       const reason = result === 'mcp-missing' ? mcpMissingReason(task.name, agentName) : result
       insertPendingTaskRetryIfNew(task.name, agentName, now, reason)
     }
@@ -511,11 +535,22 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   const mcpMissing = view.lastReason?.startsWith('mcp-missing')
     ? view.lastReason.slice('mcp-missing:'.length) || 'ismeretlen'
     : null
+  // A first-run-gated session (fresh install: mappa-trust dialog / belépés-
+  // választó) needs the operator to know the ACTUAL blocker: the fix is a
+  // one-time login/consent on the agent session, not waiting for a busy
+  // session to free up.
+  const firstRunStuck = view.lastReason === 'first-run'
   const text = (mcpMissing
     ? [
         `[${BOT_NAME} scheduler] A(z) "${view.taskName}" (${view.agentName}) feladat NEM tud lefutni: a szükséges MCP szerver(ek) nem futnak a cél-sessionben: ${mcpMissing}.`,
         `Első próbálkozás: ${firstAttempt} (${ageMinutes} perce).`,
         'Amint az MCP szerver újra elérhető, a feladat magától lefut; a dashboard /Ütemezések oldalán visszavonható.',
+      ]
+    : firstRunStuck
+    ? [
+        `[${BOT_NAME} scheduler] A(z) "${view.taskName}" (${view.agentName}) feladat NEM tud lefutni: az agent session a Claude Code első-indítási képernyőjén áll (mappa-jóváhagyás vagy belépés szükséges).`,
+        `Első próbálkozás: ${firstAttempt} (${ageMinutes} perce).`,
+        `A rendszer a jóváhagyás-dialogokat magától továbblépteti; ha belépés kell: tmux attach -t agent-${view.agentName}, majd válaszd ki a belépési módot. Utána a feladat magától lefut.`,
       ]
     : [
         `[${BOT_NAME} scheduler] A(z) "${view.taskName}" (${view.agentName}) ütemezett feladat ${ageMinutes} perce várakozik.`,
@@ -749,6 +784,13 @@ export function startScheduleRunner(): NodeJS.Timeout {
           // pre-check exists to eliminate. The retry row keeps the task alive
           // until the server returns, and the alert names the dead server.
           insertPendingTaskRetryIfNew(task.name, agentName, now, mcpMissingReason(task.name, agentName))
+        } else if (result === 'first-run') {
+          // Also exempt from skipIfBusy: a session parked on a first-run
+          // dialog (fresh install) never frees up between ticks the way a
+          // busy one does, so dropping ticks would starve the task with no
+          // trace. The retry row keeps it alive and the aged alert names the
+          // actual blocker instead of a generic "busy".
+          insertPendingTaskRetryIfNew(task.name, agentName, now, 'first-run')
         }
       }
     }


### PR DESCRIPTION
## Incident

Fresh v1.23 install on a customer VPS: scheduled tasks visibly pile up on the sub-agents; not reproducible on the origin fleet. Card 5F37BB84.

## Root cause

Claude Code's **"Do you trust the files in this folder?"** consent is keyed *per project dir* (`projects[cwd].hasTrustDialogAccepted` in `.claude.json`). Three launch paths pre-accept it -- main session (`channels.sh` startup guard), generation workers (`agent-worker.ts:383`), isolated-config seed (copies the shared `.claude.json`) -- but **`startAgentProcess` never stamped it for the agent's own dir**. On the origin fleet every `agents/<name>` dir was trusted interactively months ago, so the gap is invisible there; on a fresh install **every newly created agent parks on the trust dialog at first spawn**.

Cascade:
1. Dialog pane = no idle footer, no busy signal → `detectPaneState` = `'unknown'` → `isSessionReadyForPrompt` false **forever** → every scheduled task defers into `pending_task_retries`, retried every 15s tick, queue grows unbounded (the visible "stuck tasks").
2. `forceSend` tasks bypass the busy check (`waitForIdle:false`) and **type the prompt blindly into the dialog** -- digits select options, Enter confirms them; the prompt is lost.
3. The channel-monitor's generic blocking-menu recovery sends **Escape**, which on the trust/bypass dialogs means "No, exit" → the TUI **quits** → the scheduler auto-restarts the session straight back into the same dialog (respawn loop).

v1.23 amplifier check (asked in the task): #662 saturation-deferral is NOT involved (a fresh agent is not saturated); #602's 15s tick only makes the retry churn 4x faster. Not a code regression -- a long-standing fresh-install state gap, first hit by a real multi-agent customer install.

## Fix (4 layers)

| Layer | Change |
|---|---|
| Prevention | `stampProjectTrustForDir()`: `startAgentProcess` pre-accepts the per-project trust/onboarding flags in the config root the session actually boots from (isolated `CLAUDE_CONFIG_DIR` or shared `~/.claude.json`), atomic + idempotent, before every spawn |
| Detection | `detectsFirstRunGate()` (pure, `pane-state.ts`): classifies trust / bypass-permissions / login-picker / theme / welcome panes; guard discipline mirrors `detectsBlockingMenu` (busy pane or live idle footer → never a gate) |
| Scheduler gate | Both the readiness path and the **forceSend bypass** defer on a first-run gate with a `'first-run'` retry reason (exempt from `skipIfBusy`, like `mcp-missing`); the aged pending-retry alert names the real blocker instead of a generic "busy" |
| Recovery | channel-monitor answers first-run panes channels.sh-style (trust → `1` Enter, bypass → `2` Enter, theme/welcome → Enter) via `answerFirstRunGates()` instead of Escape; the **login picker is alert-only** (nobody can log in on the operator's behalf) with the exact `tmux attach` instruction |

Existing broken installs self-heal on update: the monitor walks parked sessions out of the dialog chain, then the queued retries deliver.

## Verify

- `tsc --noEmit` clean
- Full suite: **178 files / 2464 tests green**, incl. new `pane-first-run-gate.test.ts` (17 tests: pane fixtures for all five gates, quoted-text false-positive negatives, `detectPaneState`-reads-'unknown' rationale, and source contracts pinning the forceSend deferral order, the skipIfBusy exemption, the monitor's Escape carve-out, and the stamp-before-spawn ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)