### PR TITLE
fix(doctor): macOS support -- launchd, BSD stat, all five auth legs, gated heartbeat warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,20 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # MAIN_AGENT_ID=marveen
 # SERVICE_ID=marveen
 
+# Claude hitelesítés. A rendszer ÖT helyen keresi, ebben a sorrendben, és az
+# ELSŐ találat elég -- ezért ezek a kulcsok itt szándékosan ki vannak
+# kommentelve (ld. claudeAuthPresent() a src/web/routes/onboarding.ts-ben):
+#   1. CLAUDE_CODE_OAUTH_TOKEN (.env)  -- hosszú életű setup-token (~1 év)
+#   2. ANTHROPIC_API_KEY (.env)        -- API-kulcsos üzemmód
+#   3. ~/.claude/.credentials.json     -- interaktív login (Linux)
+#   4. store/.claude-oauth-token       -- flotta setup-token (onboarding wizard)
+#   5. macOS Keychain                  -- interaktív login (macOS alapértelmezés)
+# macOS-en tehát egy sima `claude` login után NEM kell ide semmit írni.
+# Fej nélküli (headless) futáshoz -- ütemezett flotta-ágensek saját
+# CLAUDE_CONFIG_DIR-rel -- kell a setup-token: `claude setup-token`, majd:
+# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+# ANTHROPIC_API_KEY=sk-ant-...
+
 # Opcionális:
 # KANBAN_SWIMLANE_DEFAULT_GROUP=assignee   # none (alapért.) | assignee | priority
 # KANBAN_SWIMLANE_SEPARATOR_COLOR=#3d3d3a  # swimlane-ok közti szaggatott elválasztó színe

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -17,13 +17,29 @@ MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"
 
 echo -e "\n${BOLD}Marveen Doctor${RESET}: $(date '+%Y-%m-%d %H:%M:%S')\n"
 
-# --- Systemd services ---
+# --- Services (systemd on Linux, launchd on macOS) ---
 echo -e "${BOLD}Services${RESET}"
-for svc in "${MAIN_AGENT_ID}-channels" "${MAIN_AGENT_ID}-dashboard"; do
-  if systemctl --user is-active "$svc.service" &>/dev/null; then
-    ok "$svc: running"
+for component in channels dashboard; do
+  if [ "$(uname -s)" = "Darwin" ]; then
+    # launchd label convention: com.<MAIN_AGENT_ID>.<component>
+    label="com.${MAIN_AGENT_ID}.${component}"
+    # `launchctl list` prints "PID Status Label"; a literal "-" PID means loaded
+    # but not currently running.
+    pid="$(launchctl list 2>/dev/null | awk -v l="$label" '$3 == l {print $1}')"
+    if [ -n "$pid" ] && [ "$pid" != "-" ]; then
+      ok "$label: running (pid $pid)"
+    elif [ -n "$pid" ]; then
+      fail "$label: loaded but NOT running"
+    else
+      fail "$label: not loaded"
+    fi
   else
-    fail "$svc: NOT running"
+    svc="${MAIN_AGENT_ID}-${component}"
+    if systemctl --user is-active "$svc.service" &>/dev/null; then
+      ok "$svc: running"
+    else
+      fail "$svc: NOT running"
+    fi
   fi
 done
 
@@ -73,7 +89,13 @@ fi
 echo -e "\n${BOLD}Keepalive${RESET}"
 KA_FILE="store/.channel-keepalive"
 if [ -f "$KA_FILE" ]; then
-  KA_AGE=$(( $(date +%s) - $(stat -c "%Y" "$KA_FILE") ))
+  # GNU stat uses -c "%Y", BSD/macOS stat uses -f "%m"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    KA_MTIME=$(stat -f "%m" "$KA_FILE")
+  else
+    KA_MTIME=$(stat -c "%Y" "$KA_FILE")
+  fi
+  KA_AGE=$(( $(date +%s) - KA_MTIME ))
   if [ "$KA_AGE" -lt 600 ]; then
     ok "channel-keepalive: refreshed ${KA_AGE}s ago"
   elif [ "$KA_AGE" -lt 1200 ]; then

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -124,13 +124,25 @@ for key in MAIN_AGENT_ID BOT_NAME TELEGRAM_BOT_TOKEN ALLOWED_CHAT_ID; do
   val=$(grep -E "^${key}=" .env 2>/dev/null | head -1 | cut -d= -f2-)
   if [ -n "$val" ]; then ok "$key: present"; else fail "$key: MISSING"; fi
 done
-# Auth: API key OR OAuth token is enough
+# Auth: mirrors claudeAuthPresent() in src/web/routes/onboarding.ts -- there are
+# five legs, and only the first two live in .env. Checking .env alone reported a
+# perfectly authenticated macOS install (Keychain leg) as broken.
+# The Keychain probe is presence-only (no `-w`), so the secret never leaves it.
 API_KEY=$(grep -E "^ANTHROPIC_API_KEY=" .env 2>/dev/null | head -1 | cut -d= -f2-)
 OAUTH=$(grep -E "^CLAUDE_CODE_OAUTH_TOKEN=" .env 2>/dev/null | head -1 | cut -d= -f2-)
-if [ -n "$API_KEY" ] || [ -n "$OAUTH" ]; then
-  ok "Claude auth: present ($([ -n "$API_KEY" ] && echo 'API key' || echo 'OAuth'))"
+if [ -n "$API_KEY" ]; then
+  ok "Claude auth: present (.env API key)"
+elif [ -n "$OAUTH" ]; then
+  ok "Claude auth: present (.env OAuth token)"
+elif [ -s "$HOME/.claude/.credentials.json" ]; then
+  ok "Claude auth: present (~/.claude/.credentials.json)"
+elif [ -s "store/.claude-oauth-token" ]; then
+  ok "Claude auth: present (fleet setup-token in store/)"
+elif [ "$(uname -s)" = "Darwin" ] && /usr/bin/security find-generic-password \
+     -s "Claude Code-credentials" -a "$(id -un)" >/dev/null 2>&1; then
+  ok "Claude auth: present (macOS Keychain)"
 else
-  fail "Claude auth: neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN"
+  fail "Claude auth: no credential found (env, credentials.json, fleet token, Keychain)"
 fi
 
 # --- Claude headless auth (official: long-lived setup-token) ---
@@ -139,6 +151,9 @@ if grep -qE '^CLAUDE_CODE_OAUTH_TOKEN="?sk-ant-oat01-' .env 2>/dev/null; then
   ok "Headless token: long-lived setup-token configured (CLAUDE_CODE_OAUTH_TOKEN, ~1 year)"
 elif grep -qE '^CLAUDE_CODE_OAUTH_TOKEN=' .env 2>/dev/null; then
   warn "CLAUDE_CODE_OAUTH_TOKEN set, but not sk-ant-oat01- format (may be the wrong type)"
+elif [ "$(uname -s)" = "Darwin" ] && /usr/bin/security find-generic-password \
+     -s "Claude Code-credentials" -a "$(id -un)" >/dev/null 2>&1; then
+  ok "Headless token: not set, but the macOS Keychain holds a Claude login (interactive sessions are fine; only add a setup-token if you run agents headless)"
 else
   warn "CLAUDE_CODE_OAUTH_TOKEN missing -- run: claude setup-token, then put it in .env"
 fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -45,13 +45,30 @@ done
 
 # --- Tmux sessions ---
 echo -e "\n${BOLD}Tmux sessions${RESET}"
-for sess in "${MAIN_AGENT_ID}-channels" "agent-heartbeat"; do
-  if tmux has-session -t "$sess" 2>/dev/null; then
-    ok "$sess: alive"
+if tmux has-session -t "${MAIN_AGENT_ID}-channels" 2>/dev/null; then
+  ok "${MAIN_AGENT_ID}-channels: alive"
+else
+  warn "${MAIN_AGENT_ID}-channels: not running"
+fi
+
+# The heartbeat SUB-AGENT (session agent-heartbeat) is opt-in and OFF by default
+# -- see the HEARTBEAT_AGENT_ENABLED gate in src/index.ts. Warning about a
+# missing session on an install that never asked for it is pure noise, so only
+# complain when it is actually switched on. The flag can come from .env or from
+# the dashboard's store/config-overrides.json.
+HB_AGENT=$(grep -E "^HEARTBEAT_AGENT_ENABLED=" .env 2>/dev/null | head -1 | cut -d= -f2- | tr -d ' "')
+if [ -z "$HB_AGENT" ] && [ -f store/config-overrides.json ]; then
+  HB_AGENT=$(python3 -c "import json,sys;print(json.load(open('store/config-overrides.json')).get('HEARTBEAT_AGENT_ENABLED',''))" 2>/dev/null)
+fi
+if [ "$HB_AGENT" = "1" ]; then
+  if tmux has-session -t "agent-heartbeat" 2>/dev/null; then
+    ok "agent-heartbeat: alive"
   else
-    warn "$sess: not running"
+    warn "agent-heartbeat: enabled but NOT running"
   fi
-done
+else
+  ok "agent-heartbeat: off by design (HEARTBEAT_AGENT_ENABLED not set)"
+fi
 
 # --- Channel health ---
 echo -e "\n${BOLD}Telegram bridge${RESET}"


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A `scripts/doctor.sh` macOS-en (launchd host) négy hamis riasztást ad, és
kettő közülük érdemben rontja a hasznosságát: egy teljesen egészséges telepítés
két piros `NOT running` sorral és nem-nulla kilépési kóddal zárul. Egy health
check, amit meg kell tanulni figyelmen kívül hagyni, rosszabb mint amilyennek
látszik. A PR mind a négyet javítja, a Linux/systemd viselkedés érintetlenül
hagyásával.

1. **Services blokk — `systemctl --user`.** macOS-en nincs `systemctl`, ezért a
   `<agent>-channels` és `<agent>-dashboard` sor MINDIG piros, akkor is ha a két
   szolgáltatás fut. A javítás `uname -s`-re ágazik: Darwin alatt a
   `launchctl list` kimenetéből olvassa a `com.<MAIN_AGENT_ID>.<component>`
   címkét, és a literál `-` PID-et "betöltve, de nem fut"-ként kezeli.

2. **Keepalive blokk — GNU `stat -c "%Y"`.** A BSD `stat` ezt elutasítja, így a
   script a blokk közepén `stat: illegal option -- c`-vel, majd egy bash
   aritmetikai szintaktikai hibával kiszáll, és a szekció többi kimenete elvész.
   Darwin alatt most `stat -f "%m"`.

3. **Claude auth ellenőrzés — csak `.env`.** A `claudeAuthPresent()`
   (`src/web/routes/onboarding.ts`) **öt** hitelesítési forrást fogad el, a
   `doctor.sh` viszont csak kettőt grepelt a `.env`-ből. macOS-en az interaktív
   `claude` login a **Keychain**-be kerül és `~/.claude/.credentials.json`-t nem
   is hoz létre, tehát egy tökéletesen működő telepítésen mind a négy `.env`- és
   fájl-alapú láb üres. Ez a hamis riasztás **aktívan káros**: a hibaüzenet által
   sugallt lépés (`claude setup-token` → `.env`) egy MÁSODIK, önállóan lejáró
   credential-utat hoz létre a működő mellé. A `doctor.sh` most mind az öt lábat
   ismeri, és a Keychain-szonda **jelenlét-ellenőrzés** (`-w` nélkül), pontosan
   úgy ahogy az `onboarding.ts` saját szondája — a titok nem hagyja el a
   Keychaint.

4. **`agent-heartbeat` warning kapuzatlan volt.** Ez a session a heartbeat
   *sub-ágensé*, amit az `src/index.ts` a `HEARTBEAT_AGENT_ENABLED` mögé kapuz és
   alapból KIKAPCSOLVA hagy. A `doctor.sh` minden olyan telepítésen sárgázott,
   amelyik sosem kérte — vagyis a tipikus esetben. Most a flag dönt (`.env`,
   illetve fallbackként a dashboard `store/config-overrides.json`-ja): ha nincs
   bekapcsolva, az "off by design" és zöld.

Mellékesen a `.env.example` kapott egy kommentblokkot, ami dokumentálja az öt
hitelesítési lábat. A fájl eddig **egyik** auth kulcsot sem említette, ezért egy
új telepítőnek nem volt honnan megtudnia, hogy a `.env`-es út csak a fej nélküli
(headless) eset.

**EN:** `scripts/doctor.sh` produces four false alarms on a macOS/launchd host,
two of them severe enough that a completely healthy install ends with two red
`NOT running` lines and a non-zero exit. This PR fixes all four, leaving
Linux/systemd behaviour untouched: `launchctl` instead of `systemctl` on Darwin,
BSD `stat -f "%m"` instead of GNU `stat -c "%Y"`, all five credential sources
from `claudeAuthPresent()` instead of two `.env` greps (Keychain probe is
presence-only, mirroring `onboarding.ts`), and the `agent-heartbeat` warning
gated on `HEARTBEAT_AGENT_ENABLED`. `.env.example` now documents the five auth
legs.

## Kapcsolódó issue / Related issue

Nincs. / None.

Beküldés előtt kerestem rá (`gh search issues`, négy külön megfogalmazással:
`doctor.sh macOS`, `systemctl launchd`, `stat -c macOS`, `doctor health check`,
plusz `macOS` és `darwin`): erről a hibáról nincs nyitott vagy zárt bejelentés.

Rokon, de MÁS eset a már lezárt **#654** (`Onboarding wizard re-nags ... 
claudeAuthPresent ignores FLEET_TOKEN_FILE`): ott ugyanez a "hitelesítés-ellenőrzés
nem ismer minden lábat" hibaosztály jelent meg az onboarding wizardban, és
javítva lett. A `doctor.sh` ugyanezt a tudást nem kapta meg — a 3. pont ezt pótolja.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard),
      az ágensek hiba nélkül kommunikálnak. / Tested locally.
      Élő macOS telepítésen (v1.23.1, launchd, Telegram csatorna): a `doctor.sh`
      a javítás előtt 3 piros + 2 sárga sorral és `exit 1`-gyel futott, utána
      `exit 0`, valódi PID-ekkel a Services blokkban és újra számolt keepalive
      korral. A Telegram csatorna és a dashboard végig működött.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az
      architektúrát. / Updated `docs/` if needed.
      Nem érinti: a `docs/` egyetlen fájlja sem hivatkozik a `doctor.sh`-ra
      (ellenőrizve), a script viselkedése kívülről változatlan, csak megszűnnek a
      hamis riasztások. A `.env.example` viszont bővült a hitelesítési lábak
      magyarázatával.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token,
      személyes adat). / No hardcoded secrets.
      A Keychain-szonda kifejezetten `-w` NÉLKÜL fut, tehát a credential értéke
      nem is kerül a folyamatba.
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). /
      Opened from an own, descriptively named branch.
      Branch: `fix/doctor-macos`, az `upstream/develop` (v1.23.1, `260aaab`)
      tetejéről, három külön commitban.
