### PR TITLE
fix(security): close email-send-gate coverage gap for graph-mail CLI

### DIFF
--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -33,6 +33,13 @@ const SEND_PATTERNS = [
   /\bswaks\b/i,
   /\bsmtplib\b|SMTP\s*\(/i,
   /\bmail\.send\b|\bsendEmail\b/i,
+  // graph-mail.ts (PR #668, M365/Exchange Online client-credentials mailbox):
+  // its CLI is `tsx scripts/graph-mail.ts send ...`, which none of the above
+  // patterns catch (no "sendmail"/"mail.send" substring). Also gate any direct
+  // call to the exported sendMail() (e.g. a one-off `node -e`/`tsx -e` that
+  // imports the module without going through the CLI).
+  /\bgraph-mail\b[^\n]*\bsend\b/i,
+  /\bsendMail\s*\(/i,
 ]
 
 // Pure decision: does this tool call send (or attempt to send) email?

--- a/src/__tests__/email-send-gate.test.ts
+++ b/src/__tests__/email-send-gate.test.ts
@@ -26,6 +26,18 @@ describe('gateDecision', () => {
     expect(bash('swaks --to a@b.c --server smtp').deny).toBe(true)
   })
 
+  it('blocks the graph-mail.ts CLI send path (PR #668) and direct sendMail() calls', () => {
+    const bash = (command: string) => gateDecision('Bash', { command })
+    expect(bash('tsx scripts/graph-mail.ts send --to a@b.hu --subject x --body y').deny).toBe(true)
+    expect(bash('npx tsx scripts/graph-mail.ts send --to a@b.hu --subject x --body y').deny).toBe(true)
+    expect(bash(`node -e "require('./src/graph-mail.js').sendMail({to:'a@b.hu'})"`).deny).toBe(true)
+    // read-only graph-mail subcommands are NOT send-shaped, so they pass through
+    // this gate untouched (they still can't do anything a sub-agent shouldn't:
+    // verify/list only read the scoped mailbox)
+    expect(bash('tsx scripts/graph-mail.ts verify').deny).toBe(false)
+    expect(bash('tsx scripts/graph-mail.ts list --unread').deny).toBe(false)
+  })
+
   it('allows ordinary Bash that does not send mail', () => {
     const bash = (command: string) => gateDecision('Bash', { command })
     expect(bash('git status').deny).toBe(false)


### PR DESCRIPTION
## What

Extends the sub-agent outbound-mail hard-gate (scripts/email-send-gate.mjs) to cover PR #668's scripts/graph-mail.ts CLI dispatch path.

## Why

#668 adds a Microsoft Graph mail module for a single scoped mailbox, with a CLI (tsx scripts/graph-mail.ts <subcommand> --to ...). Its dispatch subcommand is invoked as a plain Bash command. None of the existing SEND_PATTERNS regexes matched that command shape, so a sub-agent running the CLI directly would NOT have been caught by the hard-gate that was built after the Boni incident (2026-06-25: a sub-agent autonomously contacted a fabricated address asking for money in Szabi's name). The governance rule is: sub-agents may never dispatch outbound mail without main-agent (Marveen) approval.

## Fix

Two additional patterns in SEND_PATTERNS:
- the CLI's dispatch-subcommand shape (catches the tsx invocation regardless of an npx prefix)
- a direct call to the module's exported dispatch function (covers a one-off node/tsx -e that imports the module without going through the CLI)

Read-only subcommands (verify/list) are intentionally left ungated -- a sub-agent reading the scoped mailbox is not the governance concern here.

## Verification

- New test cases in email-send-gate.test.ts cover the CLI dispatch path (with and without an npx prefix) and a direct call, plus a negative check that read-only subcommands stay ungated. All pass.
- tsc --noEmit clean.
- Pre-existing note: 3 unrelated injectEmailSendGate tests in the same file already fail on origin/develop before this change (environment-dependent, not touched by this PR) -- confirmed by stashing this diff and re-running.

## Relationship to #668

This is a prerequisite for merging #668 as-is. Recommend merging this first (or together), so the new mailbox module ships with its dispatch path already covered by the existing sub-agent governance gate.

Generated with Claude Code