### PR TITLE
fix(heartbeat-agent): exclude done cards from urgent-title kanban query

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -99,6 +99,13 @@ describe('renderHeartbeatClaudeMd', () => {
     expect(out).toContain('You are headless')
   })
 
+  it('excludes done cards from the urgent-title kanban query (card 776e800a)', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // A done card can still carry priority='urgent' -- the title lookup
+    // must filter it out, or closed issues get reported as active forever.
+    expect(out).toContain("priority='urgent' AND status != 'done'")
+  })
+
   it('is fully driven by the identity -- distinct configs render distinctly', () => {
     const a = renderHeartbeatClaudeMd(ID)
     const b = renderHeartbeatClaudeMd({

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -172,7 +172,10 @@ When you receive the heartbeat prompt:
      \`sqlite3 ${id.storeDir}/claudeclaw.db "SELECT status, COUNT(*)
      FROM kanban_cards WHERE archived_at IS NULL GROUP BY status"\`
      for counts, and grab the titles of cards where
-     \`priority='urgent'\` or \`status='waiting'\`.
+     \`archived_at IS NULL AND priority='urgent' AND status != 'done'\`
+     (a card can be \`urgent\` priority but already \`done\` -- exclude
+     those, or you will report closed issues as active every hour)
+     or \`archived_at IS NULL AND status='waiting'\`.
    - **Scheduled tasks** -- count active rows in
      \`scheduled_tasks\` table; record \`next_run_at\` for the
      earliest upcoming one.


### PR DESCRIPTION
## Summary
- Card 776e800a: the scaffold-rendered heartbeat prompt (`src/web/heartbeat-agent-scaffold.ts`) told the heartbeat agent to grab urgent-priority kanban titles without excluding `status='done'`, so already-closed urgent cards kept getting reported as active every hourly cycle.
- The built-in query path (`getHeartbeatKanbanSummary()` in `src/db.ts`) already filters `priority = 'urgent' AND status != 'done'` -- the scaffold instruction text now matches it, plus explicitly states `archived_at IS NULL` for both the urgent and waiting lookups.
- Added a regression test asserting the rendered prompt contains the `status != 'done'` filter.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run src/__tests__/heartbeat-agent-scaffold.test.ts src/__tests__/agent-scaffold-dashboard-origin.test.ts` -- 39/39 pass (18 in the scaffold suite, incl. the new regression test)