### PR TITLE
fix(fleet): pre-stamp Fable overage consent + answer model-switch dialog (config-vs-active model drift root fix)

### DIFF
--- a/src/__tests__/fable-overage-consent.test.ts
+++ b/src/__tests__/fable-overage-consent.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { stampFableOverageConsent } from '../web/agent-process.js'
+import { detectsModelConsentDialog } from '../pane-state.js'
+
+const ORG = '238d7fa8-0000-4000-8000-000000000000'
+const ACCT = '4039fb28-0000-4000-8000-000000000000'
+
+describe('stampFableOverageConsent', () => {
+  let dir: string
+  let dotClaude: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'fable-consent-'))
+    dotClaude = join(dir, '.claude.json')
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('stamps the org-keyed consent when oauthAccount is present', () => {
+    writeFileSync(dotClaude, JSON.stringify({
+      hasCompletedOnboarding: true,
+      oauthAccount: { organizationUuid: ORG, accountUuid: ACCT },
+    }))
+    expect(stampFableOverageConsent(dotClaude)).toBe(true)
+    const data = JSON.parse(readFileSync(dotClaude, 'utf-8'))
+    expect(data.fableOverageConsentV2[ORG]).toBe(true)
+    expect(data.hasCompletedOnboarding).toBe(true) // other keys preserved
+  })
+
+  it('is a no-op when consent is already stamped', () => {
+    writeFileSync(dotClaude, JSON.stringify({
+      oauthAccount: { organizationUuid: ORG },
+      fableOverageConsentV2: { [ORG]: true },
+    }))
+    expect(stampFableOverageConsent(dotClaude)).toBe(false)
+  })
+
+  it('preserves existing consent entries for other orgs', () => {
+    writeFileSync(dotClaude, JSON.stringify({
+      oauthAccount: { organizationUuid: ORG },
+      fableOverageConsentV2: { 'other-org': true },
+    }))
+    expect(stampFableOverageConsent(dotClaude)).toBe(true)
+    const data = JSON.parse(readFileSync(dotClaude, 'utf-8'))
+    expect(data.fableOverageConsentV2['other-org']).toBe(true)
+    expect(data.fableOverageConsentV2[ORG]).toBe(true)
+  })
+
+  it('falls back to the acct: key when the account has no org', () => {
+    writeFileSync(dotClaude, JSON.stringify({
+      oauthAccount: { accountUuid: ACCT },
+    }))
+    expect(stampFableOverageConsent(dotClaude)).toBe(true)
+    const data = JSON.parse(readFileSync(dotClaude, 'utf-8'))
+    expect(data.fableOverageConsentV2[`acct:${ACCT}`]).toBe(true)
+  })
+
+  it('leaves a config without oauthAccount alone (nothing to key on)', () => {
+    writeFileSync(dotClaude, JSON.stringify({ hasCompletedOnboarding: true }))
+    expect(stampFableOverageConsent(dotClaude)).toBe(false)
+    const data = JSON.parse(readFileSync(dotClaude, 'utf-8'))
+    expect(data.fableOverageConsentV2).toBeUndefined()
+  })
+
+  it('does not create a missing file', () => {
+    expect(stampFableOverageConsent(dotClaude)).toBe(false)
+    expect(existsSync(dotClaude)).toBe(false)
+  })
+
+  it('returns false on unparseable JSON without destroying the file', () => {
+    writeFileSync(dotClaude, '{ not json')
+    expect(stampFableOverageConsent(dotClaude)).toBe(false)
+    expect(readFileSync(dotClaude, 'utf-8')).toBe('{ not json')
+  })
+})
+
+// The dialog as captured live on agent-deeper, 2026-07-23 (abridged chrome).
+const CONSENT_DIALOG_PANE = `
+  Fable 5 now uses usage credits
+  Fable 5 runs on usage credits, purchased separately from your plan.
+  Learn more: https://support.claude.com/en/articles/12429409
+    1. Continue with Fable 5
+  ❯ 2. Switch to Sonnet 5 and continue
+  Enter to confirm · Esc to cancel
+`
+
+describe('detectsModelConsentDialog', () => {
+  it('detects the live usage-credit model-switch dialog', () => {
+    expect(detectsModelConsentDialog(CONSENT_DIALOG_PANE)).toBe(true)
+  })
+
+  it('is model-name agnostic', () => {
+    const pane = CONSENT_DIALOG_PANE.replaceAll('Fable 5', 'Newmodel 7').replaceAll('Sonnet 5', 'Haiku 9')
+    expect(detectsModelConsentDialog(pane)).toBe(true)
+  })
+
+  it('ignores quoted dialog text when the idle prompt is live', () => {
+    const pane = `
+  Message says: "Fable 5 now uses usage credits ... 1. Continue with Fable 5 ... Enter to confirm"
+❯
+  ⏵⏵ bypass permissions on (shift+tab to cycle)
+`
+    expect(detectsModelConsentDialog(pane)).toBe(false)
+  })
+
+  it('ignores quoted dialog text on a busy pane', () => {
+    const pane = `
+  Fable 5 now uses usage credits
+    1. Continue with Fable 5
+  Enter to confirm
+  esc to interrupt
+`
+    expect(detectsModelConsentDialog(pane)).toBe(false)
+  })
+
+  it('requires the confirm hint in the live footer region', () => {
+    const lines = [
+      '  Fable 5 now uses usage credits',
+      '    1. Continue with Fable 5',
+      '  Enter to confirm',
+      ...Array.from({ length: 12 }, () => '  scrollback filler'),
+    ]
+    expect(detectsModelConsentDialog(lines.join('\n'))).toBe(false)
+  })
+
+  it('requires the continue option, not just the title', () => {
+    const pane = `
+  Fable 5 now uses usage credits
+  Enter to confirm · Esc to cancel
+`
+    expect(detectsModelConsentDialog(pane)).toBe(false)
+  })
+
+  it('returns false on empty input', () => {
+    expect(detectsModelConsentDialog('')).toBe(false)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -467,6 +467,47 @@ export function detectsFirstRunGate(pane: string): FirstRunGateKind | null {
   return null
 }
 
+// Claude Code model overage-consent dialog (first observed 2026-07-23; the
+// confirmed root cause of the "agent-config says claude-fable-5 but the
+// session runs Sonnet 5" activeModel drift). When a config root's
+// .claude.json lacks fableOverageConsentV2[<org>], the first Fable 5 turn
+// parks the TUI on:
+//   Fable 5 now uses usage credits
+//     1. Continue with Fable 5
+//   ❯ 2. Switch to Sonnet 5 and continue
+//   Enter to confirm · Esc to cancel
+// with the DEFAULT CURSOR ON THE SWITCH OPTION. Any blind Enter reaching the
+// pane (the post-spawn identity /name, sendPromptToSession's retry-Enter,
+// a human reflex) silently switches the session to Sonnet. The dialog is
+// detected here (pure, unit-testable) and answered in agent-process.ts by
+// actively selecting option 1 ("Continue with <model>") -- never the switch
+// default. Matchers are model-name-agnostic so a future "<other model> now
+// uses usage credits" variant is covered without a new detector.
+//
+// Guards follow detectsFirstRunGate's discipline: a busy pane is never the
+// dialog, and a visible idle footer means the real prompt is live -- so a
+// reply/inter-agent message that merely QUOTES the dialog text (which
+// happened the very day this shipped) can never trigger a keystroke. The
+// confirm hint must sit in the live footer region, not anywhere in the pane.
+const MODEL_CONSENT_TITLE_RX = /(?:now uses|runs on|requires) usage credits/
+const MODEL_CONSENT_CONTINUE_RX = /1\.\s*Continue with /
+const MODEL_CONSENT_CONFIRM_RX = /Enter to confirm/
+
+export function detectsModelConsentDialog(pane: string): boolean {
+  if (!pane || !pane.trim()) return false
+  const lines = pane.split('\n')
+  const busyRegion = lines.slice(-BUSY_LIVE_REGION_LINES).join('\n')
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(busyRegion)) return false
+  }
+  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
+  if (IDLE_FOOTER_RX.test(pane)) return false
+  return MODEL_CONSENT_TITLE_RX.test(pane)
+    && MODEL_CONSENT_CONTINUE_RX.test(pane)
+    && MODEL_CONSENT_CONFIRM_RX.test(footerRegion)
+}
+
 export interface DetectPaneStateOptions {
   /** If true, the 'typing' state (text parked in input box) is
    * merged into 'busy'. Default false -- callers that care about

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -16,6 +16,7 @@ import {
   paneShowsContextSaturation,
   idleConsideringDimGhost,
   detectsFirstRunGate,
+  detectsModelConsentDialog,
   type FirstRunGateKind,
 } from '../pane-state.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentClaudePlan, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentMemoryIsolation } from './agent-config.js'
@@ -605,6 +606,51 @@ export function stampProjectTrustForDir(dotClaudePath: string, projectDir: strin
   }
 }
 
+// Pre-stamp the Fable overage-consent acknowledgment in a config root's
+// .claude.json so the "Fable 5 now uses usage credits" dialog never renders.
+//
+// Root cause chain (2026-07-23, card b71fc541): a config root without
+// fableOverageConsentV2[<orgUuid>] parks the first Fable 5 turn on a TUI
+// dialog whose DEFAULT option is "Switch to Sonnet 5 and continue". The
+// fleet's own blind Enters (identity /name, sendPromptToSession retry-Enter)
+// accept that default, silently switching the session to Sonnet while
+// agent-config still says claude-fable-5 -- the long-unexplained
+// model/activeModel drift. Fleet policy (owner decision 2026-07-23): the
+// fleet stays on Fable 5, so the consent is pre-acknowledged the same way
+// onboarding/trust flags already are (see stampProjectTrustForDir above).
+//
+// Claude Code keys the consent on oauthAccount.organizationUuid (or
+// "acct:<accountUuid>" for org-less accounts) in the SAME .claude.json. A
+// file without an oauthAccount (brand-new config root that has never
+// authenticated) is left alone -- there is nothing to key the consent on;
+// the runtime dialog-answer backstop (dismissModelConsentDialogIfPresent)
+// covers that first session and this stamp catches up on the next launch.
+// Write is atomic and change-only, mirroring ensureSharedClaudeOnboarded.
+export function stampFableOverageConsent(dotClaudePath: string): boolean {
+  try {
+    if (!existsSync(dotClaudePath)) return false
+    const data = JSON.parse(readFileSync(dotClaudePath, 'utf-8')) as Record<string, unknown>
+    const oauth = (data.oauthAccount && typeof data.oauthAccount === 'object' && !Array.isArray(data.oauthAccount))
+      ? data.oauthAccount as Record<string, unknown>
+      : null
+    const orgUuid = typeof oauth?.organizationUuid === 'string' && oauth.organizationUuid ? oauth.organizationUuid : null
+    const acctUuid = typeof oauth?.accountUuid === 'string' && oauth.accountUuid ? oauth.accountUuid : null
+    const key = orgUuid ?? (acctUuid ? `acct:${acctUuid}` : null)
+    if (!key) return false
+    const consent = (data.fableOverageConsentV2 && typeof data.fableOverageConsentV2 === 'object' && !Array.isArray(data.fableOverageConsentV2))
+      ? data.fableOverageConsentV2 as Record<string, unknown>
+      : {}
+    if (consent[key] === true) return false
+    data.fableOverageConsentV2 = { ...consent, [key]: true }
+    atomicWriteFileSync(dotClaudePath, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 })
+    logger.info({ dotClaudePath }, 'fable-consent: pre-stamped fableOverageConsentV2 (prevents the usage-credit model-switch dialog)')
+    return true
+  } catch (err) {
+    logger.warn({ err, dotClaudePath }, 'fable-consent: could not stamp consent (runtime dialog-answer backstop remains)')
+    return false
+  }
+}
+
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
   if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord' || perAgent === 'googlechat' || perAgent === 'teams') return perAgent
@@ -1062,6 +1108,12 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
       claudeConfigDir ? join(claudeConfigDir, '.claude.json') : join(homedir(), '.claude.json'),
       dir,
     )
+    // Same target file: pre-acknowledge the Fable usage-credit consent so the
+    // model-switch dialog (default: Sonnet) never renders -- see
+    // stampFableOverageConsent for the drift root-cause chain.
+    stampFableOverageConsent(
+      claudeConfigDir ? join(claudeConfigDir, '.claude.json') : join(homedir(), '.claude.json'),
+    )
     const claudeConfigEnv = claudeConfigDir ? `export CLAUDE_CONFIG_DIR="${claudeConfigDir}" && ` : ''
     // `--continue` requires an existing session; on a brand-new agent the
     // Claude Code projects directory does not yet exist and `claude` exits
@@ -1268,6 +1320,31 @@ export async function dismissResumeSummaryModalIfPresent(session: string, host: 
   }
 }
 
+// Runtime backstop for the model overage-consent dialog ("Fable 5 now uses
+// usage credits" -- see detectsModelConsentDialog in pane-state.ts for the
+// full anatomy and the drift root cause). The stampFableOverageConsent
+// pre-seed normally prevents the dialog entirely; this handler covers the
+// windows the seed cannot reach (a config root that had no oauthAccount yet,
+// a future consent-key version bump). Unlike the generic dismissals above it
+// must NOT send a bare Enter: the dialog's default option SWITCHES the model
+// to Sonnet. It actively selects option 1 ("Continue with <configured
+// model>") -- number first, then confirm, mirroring answerFirstRunGates. The
+// keystrokes only ever fire when the specific dialog is visibly on screen
+// (pure detector, quoted-text-proof), so this adds no blind-injection surface.
+export async function dismissModelConsentDialogIfPresent(session: string, host: string | null = null): Promise<void> {
+  try {
+    const pane = captureTmux(host, ['capture-pane', '-t', session, '-p'])
+    if (!detectsModelConsentDialog(pane)) return
+    runTmux(host, ['send-keys', '-t', session, '1'], { timeout: 5000 })
+    await delay(150)
+    runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+    await delay(300)
+    logger.info({ session }, 'Answered model usage-credit consent dialog: kept the configured model (option 1, never the switch default)')
+  } catch (err) {
+    logger.warn({ err, session }, 'Failed to probe/answer model usage-credit consent dialog')
+  }
+}
+
 // Walk a session out of the Claude Code FIRST-RUN dialog chain (folder-trust,
 // bypass-permissions acceptance, theme picker, welcome screen), answering each
 // dialog exactly the way scripts/channels.sh's startup guard does for the main
@@ -1349,6 +1426,7 @@ export async function scheduleIdentitySetup(session: string, displayName: string
       try {
         await dismissSurveyModalIfPresent(session, host)
         await dismissResumeSummaryModalIfPresent(session, host)
+        await dismissModelConsentDialogIfPresent(session, host)
       } catch (err) {
         logger.warn({ err, session }, 'Post-restart modal dismiss failed')
       }
@@ -1511,6 +1589,7 @@ export async function sendPromptToSession(
 ): Promise<'sent' | 'aborted-busy'> {
   await dismissSurveyModalIfPresent(session, host)
   await dismissResumeSummaryModalIfPresent(session, host)
+  await dismissModelConsentDialogIfPresent(session, host)
 
   // Pre-flight wait-until-idle (root-cause gate). Placed here -- inside
   // sendPromptToSession, AFTER the modal dismissals (a modal keeps the pane


### PR DESCRIPTION
## Root cause

Fresh agent spawns hit the Claude Code TUI modal "Fable 5 now uses usage credits", whose default option is "Switch to Sonnet 5". The fleet's blind Enter presses (identity /name setup, sendPromptToSession retry-Enter) accept that default, so agents configured for fable-5 silently end up running sonnet-5. This is the verified root cause of the config=fable-5 / activeModel=sonnet-5 drift. Decision: the fleet stays on Fable 5.

## Fix (two layers)

1. Config seed (primary): `stampFableOverageConsent(dotClaudePath)` in `agent-process.ts` stamps `fableOverageConsentV2[<orgUuid>]=true` into the agent's `.claude.json` before spawn (key: `oauthAccount.organizationUuid`, fallback `acct:<accountUuid>`; no-op if there is no oauthAccount). With the consent pre-stamped the modal never appears.
2. Runtime backstop: `detectsModelConsentDialog(pane)` pure detector in `pane-state.ts` + `dismissModelConsentDialogIfPresent()` which sends "1"+Enter (Continue with the current model, never the switch default). Wired into the `sendPromptToSession` pre-flight and `scheduleIdentitySetup`. The backstop only presses keys when the dialog is actually visible.

## Scope note

The fix applies to future spawns; already-drifted sessions need a restart to pick the configured model back up.

## Verify

- tsc clean, build OK
- vitest: 182 files / 2515 tests green, including the 14 new tests in `src/__tests__/fable-overage-consent.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)