### PR TITLE
fix(dashboard): keep main-agent controls consistent

### DIFF
--- a/src/__tests__/dashboard-modal-css-contract.test.ts
+++ b/src/__tests__/dashboard-modal-css-contract.test.ts
@@ -48,4 +48,13 @@ describe('dashboard modal CSS contract', () => {
     ).not.toBeNull()
     expect(body!).toMatch(/width\s*:\s*auto/i)
   })
+
+  it.each(['.btn-compact[hidden]', '.tg-notice[hidden]'])(
+    '%s stays out of layout when hidden',
+    (selector) => {
+      const body = ruleBody(`${selector} {`)
+      expect(body, `missing ${selector} override in web/style.css`).not.toBeNull()
+      expect(body!).toMatch(/display\s*:\s*none/i)
+    },
+  )
 })

--- a/src/__tests__/main-agent-detail-guards.test.ts
+++ b/src/__tests__/main-agent-detail-guards.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
+import { tryHandleAgents } from '../web/routes/agents.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const agentsSource = readFileSync(join(__dirname, '..', 'web', 'routes', 'agents.ts'), 'utf8')
+const appSource = readFileSync(join(__dirname, '..', '..', 'web', 'app.js'), 'utf8')
+
+function sourceBetween(source: string, startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker)
+  const end = source.indexOf(endMarker, start + startMarker.length)
+  if (start < 0 || end < 0) {
+    throw new Error(`Cannot extract source between ${startMarker} and ${endMarker}`)
+  }
+  return source.slice(start, end)
+}
+
+function fakeCtx(path: string, method: string): {
+  ctx: RouteContext
+  out: { status: number; body: Record<string, unknown> | null }
+} {
+  const out: { status: number; body: Record<string, unknown> | null } = { status: 0, body: null }
+  const res = {
+    writeHead(status: number) {
+      out.status = status
+      return res
+    },
+    end(chunk?: string) {
+      if (chunk) out.body = JSON.parse(chunk) as Record<string, unknown>
+    },
+  }
+  const url = new URL(`http://localhost:3420${path}`)
+  const ctx = {
+    req: {} as RouteContext['req'],
+    res,
+    path: url.pathname,
+    method,
+    url,
+  } as RouteContext
+  return { ctx, out }
+}
+
+describe('main-agent detail and lifecycle guards', () => {
+  it.each([
+    [`/api/agents/${MAIN_AGENT_ID}/start`, 'POST'],
+    [`/api/agents/${MAIN_AGENT_ID}/stop`, 'POST'],
+    [`/api/agents/${MAIN_AGENT_ID}`, 'PUT'],
+  ])('rejects %s before entering sub-agent logic', async (path, method) => {
+    const { ctx, out } = fakeCtx(path, method)
+    const handled = await tryHandleAgents(ctx, join(PROJECT_ROOT, 'web'))
+
+    expect(handled).toBe(true)
+    expect(out.status).toBe(400)
+    expect(out.body?.error).toMatch(/Main agent/)
+  })
+
+  it('places lifecycle guards before sub-agent process and desired-state calls', () => {
+    const startBlock = sourceBetween(agentsSource, 'const startMatch', 'const stopMatch')
+    const stopBlock = sourceBetween(agentsSource, 'const stopMatch', '// Main-agent inbox PULL')
+
+    expect(startBlock.indexOf('isMainChannelsAgent(name)')).toBeGreaterThan(-1)
+    expect(startBlock.indexOf('isMainChannelsAgent(name)')).toBeLessThan(startBlock.indexOf('existsSync(agentDir(name))'))
+    expect(startBlock.indexOf('isMainChannelsAgent(name)')).toBeLessThan(startBlock.indexOf('startAgentProcess(name'))
+
+    expect(stopBlock.indexOf('isMainChannelsAgent(name)')).toBeGreaterThan(-1)
+    expect(stopBlock.indexOf('isMainChannelsAgent(name)')).toBeLessThan(stopBlock.indexOf('stopAgentProcess(name)'))
+    expect(stopBlock.indexOf('isMainChannelsAgent(name)')).toBeLessThan(stopBlock.indexOf('removeDesiredAgent(name)'))
+  })
+
+  it('routes the main id to openMarveenDetail before the generic detail fetch', () => {
+    const detailBlock = sourceBetween(appSource, 'async function openAgentDetail(agentName)', 'function populateDetailAvatarGrid')
+    const redirectIndex = detailBlock.indexOf('return openMarveenDetail()')
+    const fetchIndex = detailBlock.indexOf('fetch(`/api/agents/')
+
+    expect(redirectIndex).toBeGreaterThan(-1)
+    expect(redirectIndex).toBeLessThan(fetchIndex)
+    expect(detailBlock).toMatch(/if\s*\(agentName === mainAgentId\(\)\)/)
+  })
+})

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1562,6 +1562,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   const startMatch = path.match(/^\/api\/agents\/([^/]+)\/start$/)
   if (startMatch && method === 'POST') {
     const name = decodeURIComponent(startMatch[1])
+    if (isMainChannelsAgent(name)) {
+      json(res, { error: 'Main agent lifecycle is service-managed; use /api/marveen/restart for recovery' }, 400)
+      return true
+    }
     if (!existsSync(agentDir(name))) { json(res, { error: 'Agent not found' }, 404); return true }
     // Optional { "fresh": true } body -> no `--continue`. Required for channel
     // agents on Claude Code 2.1.193, where a `--continue` resume does not load
@@ -1580,6 +1584,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   const stopMatch = path.match(/^\/api\/agents\/([^/]+)\/stop$/)
   if (stopMatch && method === 'POST') {
     const name = decodeURIComponent(stopMatch[1])
+    if (isMainChannelsAgent(name)) {
+      json(res, { error: 'Main agent lifecycle is service-managed; use /api/marveen/restart for recovery' }, 400)
+      return true
+    }
     const result = stopAgentProcess(name)
     // Explicit stop clears intent so the monitor will not resurrect it.
     removeDesiredAgent(name)
@@ -1807,6 +1815,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   if (agentMatch && method === 'PUT') {
     const name = decodeURIComponent(agentMatch[1])
     if (!isKnownAgent(name)) { json(res, { error: 'Agent not found' }, 404); return true }
+    if (isMainChannelsAgent(name)) {
+      json(res, { error: 'Main agent configuration is read-only through the dashboard API' }, 400)
+      return true
+    }
     const body = await readBody(req)
     const configRoot = agentConfigRoot(name)
     const data = JSON.parse(body.toString()) as {

--- a/web/app.js
+++ b/web/app.js
@@ -2831,6 +2831,10 @@ function openFederatedThread(qualifiedId) {
 
 // === Agent Detail ===
 async function openAgentDetail(agentName) {
+  if (agentName === mainAgentId()) {
+    return openMarveenDetail()
+  }
+
   try {
     const res = await fetch(`/api/agents/${encodeURIComponent(agentName)}`)
     if (!res.ok) throw new Error('Not found')
@@ -3415,8 +3419,8 @@ async function loadAvailableModels() {
     }
     // Browse popup = the curation UI (tick/untick which manual models exist).
     // MAIN AGENT ONLY -- sub-agents just pick from the curated dropdown above.
-    // The main agent opens via openMarveenDetail(), whose currentAgent comes
-    // from window._marveen and has NO `role` field -- so detect it by name too.
+    // Keep the name checks for compatibility with legacy /api/marveen payloads
+    // that predate the explicit role field.
     const mid = (typeof mainAgentId === 'function') ? mainAgentId() : ''
     const isMainAgent = !!currentAgent && (
       currentAgent.role === 'main' ||

--- a/web/style.css
+++ b/web/style.css
@@ -1748,6 +1748,8 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
   color: var(--text-secondary);
   line-height: 1.5;
 }
+/* The class display rule outranks the browser's [hidden] default. */
+.tg-notice[hidden] { display: none; }
 .tg-notice svg { flex-shrink: 0; margin-top: 1px; color: var(--accent); }
 .tg-notice code {
   background: var(--bg-code);
@@ -2282,6 +2284,8 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
   margin-top: 0;
   white-space: nowrap;
 }
+/* Keep compact controls out of layout when JavaScript marks them hidden. */
+.btn-compact[hidden] { display: none; }
 
 .btn-secondary {
   padding: 10px 20px;


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU:
- A `.btn-compact[hidden]` és `.tg-notice[hidden]` explicit CSS szabályok biztosítják, hogy a JavaScript által `hidden` állapotba tett kompakt gombok és csatorna-értesítések valóban kikerüljenek a layoutból. Így a főágens modal nem mutat egyszerre egymásnak ellentmondó vezérlőket és állapotüzeneteket.
- A főágens detail frissítése a dedikált `/api/marveen` nézeten marad, a start/stop és generikus konfigurációs route-ok pedig nem futtatnak sub-agent logikát rajta.
- Regressziós tesztek ellenőrzik a CSS szabályokat, a route-ok viselkedését és a guardok sorrendjét.

EN:
- Explicit `.btn-compact[hidden]` and `.tg-notice[hidden]` CSS rules ensure that compact buttons and channel notices marked `hidden` by JavaScript are actually removed from layout. This prevents contradictory controls and status messages from appearing together in the main-agent modal.
- Main-agent detail refreshes stay on the dedicated `/api/marveen` view, while start/stop and generic configuration routes reject sub-agent lifecycle operations for it.
- Regression tests cover the CSS rules, route behavior, redirect, and guard ordering.

## Kapcsolódó issue / Related issue

N/A. No matching issue or PR was found after searches for the user-visible symptom, lifecycle error, and affected CSS selectors.

## Ellenőrzőlista / Checklist

- [x] Lokálisan ellenőriztem a dashboard főágens-modalját és az API guardokat; a channels session futva maradt. / Verified the main-agent dashboard modal and API guards locally; the channels session remained alive.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. (Not applicable.)
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Test plan

- `npm test` (183 files, 2522 tests)
- `npm run typecheck`
- `npm run syntax-check`
- `npm run build`
- Live Chrome check of the main-agent modal: Start and Stop hidden, Channels restart visible, exactly one running-state notice visible
- Live API guard check: main-agent start, stop, and generic PUT return HTTP 400 without stopping the channels session

Made with [Cursor](https://cursor.com) / ChatGPT 5.6 Sol