### PR TITLE
fix: SOUL.md generator ignores the no em dash formatting rule

### DIFF
--- a/src/__tests__/agent-scaffold-formatting-rules.test.ts
+++ b/src/__tests__/agent-scaffold-formatting-rules.test.ts
@@ -1,0 +1,50 @@
+// Tests for the shared formatting contract of the agent-scaffold generators.
+// Background: generateClaudeMd() instructs the model to write Hungarian with
+// proper accents and to never use an em dash. generateSoulMd() and
+// generateSkillMd() used to omit that block, so the same wizard produced a
+// CLAUDE.md with zero em dashes next to a SOUL.md full of them -- a file that
+// violates the rule its sibling file declares.
+//
+// These are source-level assertions on each prompt body (the same technique as
+// agent-scaffold-dashboard-origin.test.ts): the prompts are template literals
+// built inside the generator, so the source is the only surface testable
+// without invoking a model.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SCAFFOLD_SRC = join(__dirname, '..', 'web', 'agent-scaffold.ts')
+const src = readFileSync(SCAFFOLD_SRC, 'utf-8')
+
+function promptBodyOf(fnName: string, terminator: string): string {
+  const start = src.indexOf(`export async function ${fnName}`)
+  expect(start, `${fnName} not found in source`).toBeGreaterThan(0)
+  const end = terminator ? src.indexOf(terminator, start) : src.length
+  expect(end, `terminator for ${fnName} not found`).toBeGreaterThan(start)
+  return src.slice(start, end)
+}
+
+const GENERATORS: Array<{ name: string; terminator: string }> = [
+  { name: 'generateClaudeMd', terminator: 'export async function generateSoulMd' },
+  { name: 'generateSoulMd', terminator: 'export async function generateSkillMd' },
+  { name: 'generateSkillMd', terminator: '' },
+]
+
+describe.each(GENERATORS)('$name prompt: formatting rules', ({ name, terminator }) => {
+  const body = promptBodyOf(name, terminator)
+
+  it('declares the IMPORTANT FORMATTING RULES block', () => {
+    expect(body).toContain('IMPORTANT FORMATTING RULES:')
+  })
+
+  it('requires proper Hungarian accents', () => {
+    expect(body).toMatch(/proper accents \(á, é, í, ó, ö, ő, ú, ü, ű\)/)
+  })
+
+  it('forbids the em dash and names the simple hyphen as the replacement', () => {
+    expect(body).toMatch(/Never use em dash \(—\), only simple hyphen \(-\)\./)
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -943,6 +943,10 @@ Generate a personality definition that includes:
 - Unique quirks or characteristics
 - What it should avoid
 
+IMPORTANT FORMATTING RULES:
+- Write ALL Hungarian text with proper accents (á, é, í, ó, ö, ő, ú, ü, ű). NEVER write Hungarian without accents.
+- Never use em dash (—), only simple hyphen (-).
+
 Make the personality distinctive but professional.
 Output ONLY the markdown content, no code fences.`
 
@@ -976,6 +980,10 @@ Generate a SKILL.md with this structure:
    - ## Examples - 1-2 concrete examples with Input/Output
    - ## Language rules - Hungarian with ${OWNER_NAME} (the user), English for code/technical
    - ## What to avoid - common pitfalls
+
+IMPORTANT FORMATTING RULES:
+- Write ALL Hungarian text with proper accents (á, é, í, ó, ö, ő, ú, ü, ű). NEVER write Hungarian without accents.
+- Never use em dash (—), only simple hyphen (-).
 
 Keep the body under 200 lines. Be specific and actionable. The owner's name is ${OWNER_NAME}; use only this name when referring to the user.
 Output ONLY the markdown content, no code fences.`


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** Az ágens-létrehozó wizard által generált `SOUL.md` (és `SKILL.md`) tele van em dash karakterrel, miközben ugyanannak a wizardnak a `CLAUDE.md` kimenete explicit tiltja azt. Az ok: az `IMPORTANT FORMATTING RULES` blokk csak a `generateClaudeMd()` promptjában van meg, a `generateSoulMd()` és `generateSkillMd()` promptjából hiányzik. A javítás átmásolja a blokkot mindkét promptba, és regressziós tesztet ad hozzá.

**EN:** The agent-creation wizard emits a `CLAUDE.md` that forbids the em dash, and next to it a `SOUL.md` that is full of them. Root cause: `generateClaudeMd()` ends its prompt with an `IMPORTANT FORMATTING RULES` block (proper Hungarian accents; never use em dash, only a simple hyphen), while `generateSoulMd()` (src/web/agent-scaffold.ts) and `generateSkillMd()` never carried it. The generated persona file therefore breaks the rule its own sibling file declares.

**Measured on a live install** (two agents scaffolded by the wizard):

| generated file | em dashes |
|---|---|
| `CLAUDE.md` (has the rule block) | 0 |
| `SOUL.md` agent A (no rule block) | 18 |
| `SOUL.md` agent B (no rule block) | 19 |

### Fix

Copy the formatting block into the `generateSoulMd()` prompt (before `Make the personality distinctive but professional.`) and into the `generateSkillMd()` prompt (before `Keep the body under 200 lines.`). The `CLAUDE.md`-specific clause (about the agent's first-line description) is intentionally left out; only the two portable rules are carried over:

```
IMPORTANT FORMATTING RULES:
- Write ALL Hungarian text with proper accents (á, é, í, ó, ö, ő, ú, ü, ű). NEVER write Hungarian without accents.
- Never use em dash (—), only simple hyphen (-).
```

### Before / after (generated SOUL.md excerpt)

Before -- em dashes throughout, including the heading:

```markdown
# SOUL.md — <agent name>

A munkám az, hogy egy briefből — akár hiányosból, akár túlírtból — döntésre kész
tervjavaslatot készítsek. A feltételezés nálam nem kockázat, hanem dokumentált
döntés — mindig látszik, mire építettem.
```

After -- same content under the rule the wizard already applies to `CLAUDE.md`:

```markdown
# SOUL.md - <agent name>

A munkám az, hogy egy briefből - akár hiányosból, akár túlírtból - döntésre kész
tervjavaslatot készítsek. A feltételezés nálam nem kockázat, hanem dokumentált
döntés - mindig látszik, mire építettem.
```

### Test

New `src/__tests__/agent-scaffold-formatting-rules.test.ts` asserts source-level that all three generator prompts (`generateClaudeMd`, `generateSoulMd`, `generateSkillMd`) declare the formatting block, the accent rule and the no-em-dash rule. It follows the technique already used by `agent-scaffold-dashboard-origin.test.ts`, since the prompts are template literals with no other observable surface without invoking a model.

Verified that the test is not vacuous: with the `agent-scaffold.ts` change stashed, 6 of its 9 assertions fail (the `generateSoulMd` and `generateSkillMd` groups); with the change applied, all 9 pass.

Full suite: `npm test` -> 2514 passed / 1 failed, the single failure being `channel-monitor-resume-recovery.test.ts` timing out at 5000 ms under full-suite load; it passes in isolation (3.7 s) and is unrelated to this change. `npm run typecheck` is clean.

## Kapcsolódó issue / Related issue

Closes #

<!-- Nincs nyitott issue erre; a prior-art keresés (em dash / SOUL.md / scaffold / formatting) nem talált korábbi bejelentést. -->

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors. <!-- Local checkout: full test suite + typecheck on this branch, and the em-dash counts above were measured on generated files from a live install. The wizard itself was not re-run end to end (that would spend a model call to regenerate a persona file); the change is prompt text only. -->
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. <!-- N/A: prompt-only change, no install or architecture impact -->
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
