### PR TITLE
fix(channels): eliminate main-bot 401 outage (Linux isolated-config + 401-detecting watchdog)

### DIFF
--- a/scripts/__tests__/channels-auth-probe.test.sh
+++ b/scripts/__tests__/channels-auth-probe.test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Contract tests for scripts/channels-auth-probe.mjs (PLAN.md GAP 2b,
+# 2026-07-23 marveen-channels silent outage). Feeds captured-pane fixture text
+# via stdin (no real tmux session, no real Claude process) and asserts exit
+# code + stdout marker per the probe's contract. Fixtures reused from
+# src/__tests__/reauth-detect.test.ts for consistency (same markers the probe
+# dynamically imports and delegates to).
+# Run: bash scripts/__tests__/channels-auth-probe.test.sh
+#
+# Requires a built dist/ (npm run build) -- the probe dynamically imports
+# dist/web/reauth-detect.js, exactly like reauth-healer.ts's own detection path.
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PROBE="$INSTALL_DIR/scripts/channels-auth-probe.mjs"
+NODE_BIN="$(command -v node)"
+
+if [ ! -f "$INSTALL_DIR/dist/web/reauth-detect.js" ]; then
+  echo "SKIP: dist/web/reauth-detect.js not built -- run 'npm run build' first"
+  exit 0
+fi
+
+run_probe() {
+  # $1: pane text (via stdin)
+  printf '%s' "$1" | "$NODE_BIN" "$PROBE"
+}
+
+echo "channels-auth-probe tests"
+echo "=========================="
+
+# ---------------------------------------------------------------------------
+# (a) Healthy pane -> exit 0, no output
+# ---------------------------------------------------------------------------
+echo ""
+echo "(a) Healthy pane"
+
+OUT="$(run_probe '✻ Sautéed for 1m
+❯
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt')"
+CODE=$?
+if [ "$CODE" -eq 0 ] && [ -z "$OUT" ]; then
+  pass "healthy idle pane: exit 0, no output"
+else
+  fail "healthy idle pane: expected exit 0 + empty output, got exit=$CODE output='$OUT'"
+fi
+
+# ---------------------------------------------------------------------------
+# (b) Genuine dead-token markers -> exit 1, "DEAD:<reason>"
+# ---------------------------------------------------------------------------
+echo ""
+echo "(b) Genuine dead-token markers"
+
+OUT="$(run_probe 'Some output
+  Please run /login
+')"
+CODE=$?
+if [ "$CODE" -eq 1 ] && [ "$OUT" = "DEAD:Please run /login" ]; then
+  pass "'Please run /login': exit 1, DEAD:<reason>"
+else
+  fail "'Please run /login': expected exit 1 + 'DEAD:Please run /login', got exit=$CODE output='$OUT'"
+fi
+
+OUT="$(run_probe 'API Error: 401 Invalid authentication credentials')"
+CODE=$?
+if [ "$CODE" -eq 1 ] && [ "$OUT" = "DEAD:Invalid authentication credentials (401)" ]; then
+  pass "401 invalid-credentials: exit 1, DEAD:<reason>"
+else
+  fail "401 invalid-credentials: expected exit 1 + DEAD marker, got exit=$CODE output='$OUT'"
+fi
+
+OUT="$(run_probe 'Your OAuth token has expired.')"
+CODE=$?
+if [ "$CODE" -eq 1 ] && [ "$OUT" = "DEAD:OAuth token expired" ]; then
+  pass "OAuth token expired: exit 1, DEAD:<reason>"
+else
+  fail "OAuth token expired: expected exit 1 + DEAD marker, got exit=$CODE output='$OUT'"
+fi
+
+# ---------------------------------------------------------------------------
+# (c) First-run-gate family -> out of scope, exit 0 (not "dead")
+# ---------------------------------------------------------------------------
+echo ""
+echo "(c) First-run-gate: out of scope for this arm"
+
+OUT="$(run_probe ' Welcome to Claude Code
+
+ Select login method:
+
+ ❯ 1. Claude account with subscription
+   2. Anthropic Console account')"
+CODE=$?
+if [ "$CODE" -eq 0 ] && [ -z "$OUT" ]; then
+  pass "first-run onboarding picker: exit 0 (out of scope, not dead)"
+else
+  fail "first-run onboarding picker: expected exit 0 + empty output, got exit=$CODE output='$OUT'"
+fi
+
+OUT="$(run_probe ' Use the url below to sign in:
+
+ https://claude.ai/oauth/authorize?code=...
+
+ Paste code here if prompted >')"
+CODE=$?
+if [ "$CODE" -eq 0 ] && [ -z "$OUT" ]; then
+  pass "browser sign-in screen (first-run gate): exit 0 (out of scope, not dead)"
+else
+  fail "browser sign-in screen (first-run gate): expected exit 0 + empty output, got exit=$CODE output='$OUT'"
+fi
+
+# ---------------------------------------------------------------------------
+# (d) Does not false-positive on a chat merely discussing the markers
+# ---------------------------------------------------------------------------
+echo ""
+echo "(d) No false positive on scrollback-only mentions"
+
+OUT="$(run_probe '❯ hogyan működik a /login parancs?
+  ⏵⏵ bypass permissions on (shift+tab to cycle)')"
+CODE=$?
+if [ "$CODE" -eq 0 ] && [ -z "$OUT" ]; then
+  pass "chat mentioning /login as a topic: exit 0"
+else
+  fail "chat mentioning /login as a topic: expected exit 0 + empty output, got exit=$CODE output='$OUT'"
+fi
+
+# ---------------------------------------------------------------------------
+# (e) Empty / null-ish stdin -> fail-open, exit 0
+# ---------------------------------------------------------------------------
+echo ""
+echo "(e) Empty stdin (fail-open)"
+
+OUT="$(printf '' | "$NODE_BIN" "$PROBE")"
+CODE=$?
+if [ "$CODE" -eq 0 ] && [ -z "$OUT" ]; then
+  pass "empty stdin: exit 0, no output"
+else
+  fail "empty stdin: expected exit 0 + empty output, got exit=$CODE output='$OUT'"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=========================="
+TOTAL=$((PASS + FAIL))
+echo "Results: $PASS/$TOTAL passed"
+if [ "$FAIL" -gt 0 ]; then echo "FAILED: $FAIL tests"; exit 1; fi
+echo "All tests passed."

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -7,11 +7,29 @@
 # is down. It is the COARSE net (total-pipe-death / session-wedge); the
 # dashboard's userbot inbound-probe handles the finer inbound-only deafness.
 #
-# Signal: store/.channel-keepalive mtime. Two token-free producers keep it
-# fresh: channel-monitor advances it on organic inbound, and the idle-path
-# channel-keepalive-probe.sh timer touches it every ~3 min while the telegram
-# poller is alive under the channels session. A stale file therefore means the
-# session's channel pipe is genuinely down (wedged / deaf), not merely quiet.
+# Two INDEPENDENT detection signals (PLAN.md GAP 2b, 2026-07-23
+# marveen-channels silent outage -- the keepalive signal alone never sees a
+# dead model-API token, since the token-free keepalive probe only exercises
+# the Telegram Bot API, not Claude):
+#   STALE    -- store/.channel-keepalive mtime. Two token-free producers keep
+#               it fresh: channel-monitor advances it on organic inbound, and
+#               the idle-path channel-keepalive-probe.sh timer touches it every
+#               ~3 min while the telegram poller is alive under the channels
+#               session. A stale file means the session's channel pipe is
+#               genuinely down (wedged / deaf), not merely quiet.
+#   AUTHDEAD -- scripts/channels-auth-probe.mjs scans the live pane for the
+#               same dead-token markers reauth-healer.ts already detects
+#               (Please run /login, API Error: 401, OAuth token expired, ...),
+#               ignoring the first-run-gate family (out of scope for this arm).
+#               Requires AUTH_DEAD_THRESHOLD_TICKS consecutive dead ticks
+#               (~10-15min) before acting -- deliberately coarser than
+#               reauth-healer's own ~9-10min confirm cadence, so in the common
+#               case (dashboard alive) reauth-healer wins the race and this
+#               counter resets to 0 on the next tick without ever firing. This
+#               arm only actually fires when reauth-healer couldn't (dashboard
+#               down, or channels.sh itself hung) -- the designed backstop role.
+#
+# Either signal proceeds to the shared grace/backoff/recover step below.
 #
 # Recovery: `tmux respawn-pane` of ONLY the <id>-channels pane -- the precise,
 # fleet-safe restart of just the main channels session. (Historically a
@@ -33,19 +51,26 @@ STORE="$INSTALL_DIR/store"
 KEEPALIVE_FILE="$STORE/.channel-keepalive"
 RESPAWN_STAMP="$STORE/.channel-last-respawn"
 RESPAWN_COUNT_FILE="$STORE/.channel-watchdog-respawns"
+AUTH_DEAD_COUNT_FILE="$STORE/.channel-watchdog-auth-dead-count"
 LOG_TAG="channel-watchdog"
 
-STALE_SECONDS=$(( 15 * 60 ))   # keepalive older than this => wedged/deaf
-GRACE_SECONDS=$(( 15 * 60 ))   # don't respawn again within this window
-MAX_CONSECUTIVE=3              # after this many respawns w/o recovery, back off + alert
+STALE_SECONDS=$(( 15 * 60 ))    # keepalive older than this => wedged/deaf
+GRACE_SECONDS=$(( 15 * 60 ))    # don't respawn again within this window
+MAX_CONSECUTIVE=3               # after this many respawns w/o recovery, back off + alert
+AUTH_DEAD_THRESHOLD_TICKS=3     # consecutive dead-token ticks (~15min @ 5min/tick) before acting
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*"; }
 
-# --- resolve the channels session (launch-order / rename independent) ---
+# --- resolve the channels session + provider (launch-order / rename independent) ---
 MAIN_AGENT_ID="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
 MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"
 MAIN_AGENT_ID="${MAIN_AGENT_ID//[^a-zA-Z0-9_-]/}"
 SESSION="${MAIN_AGENT_ID}-channels"
+# Same helper channels.sh already uses to provision the main-agent isolated
+# config dir (PLAN.md GAP 1) -- needed below to give a watchdog-triggered
+# respawn the same CLAUDE_CONFIG_DIR the main agent is actually running under.
+CHANNEL_PROVIDER="$(grep -E '^CHANNEL_PROVIDER=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
+CHANNEL_PROVIDER="${CHANNEL_PROVIDER:-telegram}"
 
 # NB: use TMUX_BIN, not TMUX -- the latter is tmux's own env var (socket,pid,
 # session); assigning the binary path to it corrupts server-socket detection.
@@ -64,19 +89,47 @@ if ! "$TMUX_BIN" has-session -t "$SESSION" 2>/dev/null; then
   exit 0
 fi
 
-# --- gate 2: keepalive file must exist (a baseline was established) ---
-# If it never existed, the keep-alive task isn't running -- that's a config
-# matter, not deafness; respawning won't help, so do nothing.
+# --- signal 1: STALE (keepalive mtime) -- computed independently, no early exit ---
+STALE=false
+age=0
 if [ ! -f "$KEEPALIVE_FILE" ]; then
-  log "no keepalive file yet ($KEEPALIVE_FILE) -- keep-alive task not established; no-op"
-  exit 0
+  # keep-alive task never established -- not "stale" (that would be a config
+  # matter, respawning won't help it), but AUTHDEAD below is still checked
+  # independently: a genuinely dead token should still recover even when the
+  # keepalive probe itself was never configured.
+  log "no keepalive file yet ($KEEPALIVE_FILE) -- keep-alive task not established, STALE=false"
+else
+  ka_mtime=$(stat -c %Y "$KEEPALIVE_FILE" 2>/dev/null || echo 0)
+  age=$(( now - ka_mtime ))
+  [ "$age" -ge "$STALE_SECONDS" ] && STALE=true
 fi
 
-# --- gate 3: staleness ---
-ka_mtime=$(stat -c %Y "$KEEPALIVE_FILE" 2>/dev/null || echo 0)
-age=$(( now - ka_mtime ))
-if [ "$age" -lt "$STALE_SECONDS" ]; then
-  # Healthy round-trips -> reset the consecutive-respawn counter.
+# --- signal 2: AUTHDEAD (pane auth-marker scan via channels-auth-probe.mjs) ---
+AUTHDEAD=false
+auth_count=$(cat "$AUTH_DEAD_COUNT_FILE" 2>/dev/null || echo 0)
+case "$auth_count" in (*[!0-9]*|'') auth_count=0;; esac
+NODE_BIN="$(command -v node || true)"
+if [ -n "$NODE_BIN" ] && [ -f "$INSTALL_DIR/dist/web/reauth-detect.js" ]; then
+  probe_out="$("$TMUX_BIN" capture-pane -p -t "$SESSION" 2>/dev/null | "$NODE_BIN" "$INSTALL_DIR/scripts/channels-auth-probe.mjs" 2>/dev/null)"
+  probe_exit=$?
+  if [ "$probe_exit" -eq 1 ]; then
+    auth_count=$(( auth_count + 1 ))
+    echo "$auth_count" > "$AUTH_DEAD_COUNT_FILE"
+    if [ "$auth_count" -ge "$AUTH_DEAD_THRESHOLD_TICKS" ]; then
+      AUTHDEAD=true
+      log "auth-dead ($auth_count consecutive ticks): $probe_out"
+    fi
+  else
+    auth_count=0
+    rm -f "$AUTH_DEAD_COUNT_FILE" 2>/dev/null || true
+  fi
+else
+  # Fail-open: no node or no dist build -- treat as healthy, never as dead.
+  auth_count=0
+fi
+
+# --- neither signal fired: healthy, reset the shared backoff counter, done ---
+if [ "$STALE" != true ] && [ "$AUTHDEAD" != true ]; then
   rm -f "$RESPAWN_COUNT_FILE" 2>/dev/null || true
   exit 0
 fi
@@ -85,7 +138,7 @@ fi
 if [ -f "$RESPAWN_STAMP" ]; then
   last=$(stat -c %Y "$RESPAWN_STAMP" 2>/dev/null || echo 0)
   if [ $(( now - last )) -lt "$GRACE_SECONDS" ]; then
-    log "keepalive stale ${age}s but within respawn grace -- deferring"
+    log "problem detected (STALE=$STALE AUTHDEAD=$AUTHDEAD) but within respawn grace -- deferring"
     exit 0
   fi
 fi
@@ -94,7 +147,7 @@ fi
 count=$(cat "$RESPAWN_COUNT_FILE" 2>/dev/null || echo 0)
 case "$count" in (*[!0-9]*|'') count=0;; esac
 if [ "$count" -ge "$MAX_CONSECUTIVE" ]; then
-  log "ALERT: keepalive stale ${age}s after $count respawns without recovery -- backing off (keepalive disabled or systemic issue). Manual check needed: tmux attach -t $SESSION"
+  log "ALERT: problem detected (STALE=$STALE AUTHDEAD=$AUTHDEAD) after $count respawns without recovery -- backing off (keepalive disabled or systemic issue). Manual check needed: tmux attach -t $SESSION"
   exit 0
 fi
 
@@ -106,14 +159,45 @@ fi
 MODEL_FLAG=""
 [ -n "$MAIN_MODEL" ] && MODEL_FLAG="--model '$MAIN_MODEL' "
 
+# Main-agent isolated-config parity (PLAN.md GAP 1 completeness fix): without
+# this, a watchdog-triggered respawn would silently drop the main agent OUT of
+# isolated-config mode and back onto the shared ~/.claude -- reintroducing GAP 1
+# on exactly the recovery path meant to matter most (dashboard down). Mirrors
+# channels.sh's own CFG_ENV construction (channels.sh:254-275) exactly,
+# including reading the fleet token via $(cat ...) at spawn time so the secret
+# never lands in the RESPAWN_CMD string passed to tmux respawn-pane (visible
+# via ps/pane history otherwise).
+CFG_ENV=""
+if [ -n "$NODE_BIN" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
+  _cfg_line="$("$NODE_BIN" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$CHANNEL_PROVIDER" 2>>"$STORE/channels-failures.log" || true)"
+  _cfg_mode="${_cfg_line%%	*}"
+  _cfg_dir="${_cfg_line#*	}"
+  if [ -n "$_cfg_line" ] && [ -d "$_cfg_dir" ]; then
+    if [ "$_cfg_mode" = "explicit" ]; then
+      CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && "
+    else
+      CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && export CLAUDE_CODE_OAUTH_TOKEN=\"\$(cat '$INSTALL_DIR/store/.claude-oauth-token')\" && "
+    fi
+    log "main-agent $_cfg_mode CLAUDE_CONFIG_DIR=$_cfg_dir"
+  fi
+  unset _cfg_line _cfg_mode _cfg_dir
+fi
+
 # Full PATH with .bun/bin -- without it the respawned bun telegram bridge does
 # not come up and the session is channel-less.
-RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && $CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:telegram@claude-plugins-official"
+RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && ${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:telegram@claude-plugins-official"
 
-log "keepalive stale ${age}s (>${STALE_SECONDS}s) and session up -- respawn-pane $SESSION (respawn #$((count+1)))"
+reason="keepalive stale ${age}s"
+[ "$STALE" != true ] && reason=""
+if [ "$AUTHDEAD" = true ]; then
+  if [ -n "$reason" ]; then reason="$reason + auth-dead ($auth_count consecutive ticks)"; else reason="auth-dead ($auth_count consecutive ticks)"; fi
+fi
+
+log "$reason and session up -- respawn-pane $SESSION (respawn #$((count+1)))"
 if "$TMUX_BIN" respawn-pane -k -t "$SESSION" "$RESPAWN_CMD" 2>/dev/null; then
   date +%s > "$RESPAWN_STAMP"
   echo $(( count + 1 )) > "$RESPAWN_COUNT_FILE"
+  rm -f "$AUTH_DEAD_COUNT_FILE" 2>/dev/null || true
   log "respawn-pane issued"
 else
   log "respawn-pane FAILED for $SESSION"

--- a/scripts/channels-auth-probe.mjs
+++ b/scripts/channels-auth-probe.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Independent backstop auth-dead probe for scripts/channel-watchdog.sh (PLAN.md
+// GAP 2b, 2026-07-23 marveen-channels silent outage). Reads captured pane text
+// from stdin (not argv -- pane content can contain shell-hostile characters),
+// dynamically imports dist/web/reauth-detect.js so there is a single source of
+// truth for the marker regexes (reauth-healer.ts uses the same function), and
+// reports whether the pane shows a genuine dead-token marker.
+//
+// Contract (consumed by channel-watchdog.sh):
+//   exit 0, no stdout  -- healthy, OR needsReauth but it's the first-run-gate
+//                          family (out of scope for this arm -- reauth-healer
+//                          escalate-only already owns that case; a respawn here
+//                          would just interrupt the picker mid-flow).
+//   exit 1, stdout "DEAD:<reason>" -- a genuine dead-token marker was found.
+//
+// Fail-open: any internal error (missing dist build, stdin read failure, bad
+// pane text) exits 0. A probe failure must never masquerade as "confirmed
+// dead" and trigger a respawn -- mirrors ensureMainAgentIsolatedConfigDir /
+// provisionIsolatedConfigDir's own best-effort-never-a-launch-failure stance.
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Same first-run-gate family reauth-healer.ts's isFirstRunGate check matches
+// (checkSession(): /onboarding picker|sign-in screen/i against reauth.reason).
+// Out of scope for this arm: PLAN.md GAP 2b explicitly scopes the watchdog's
+// new auth-dead signal to genuine dead-token markers only.
+const FIRST_RUN_GATE_RX = /onboarding picker|sign-in screen/i
+
+async function main() {
+  const __dirname = dirname(fileURLToPath(import.meta.url))
+  const projectRoot = join(__dirname, '..')
+
+  const paneText = await new Promise((resolve) => {
+    let data = ''
+    process.stdin.setEncoding('utf-8')
+    process.stdin.on('data', (chunk) => { data += chunk })
+    process.stdin.on('end', () => resolve(data))
+    process.stdin.on('error', () => resolve(data))
+  })
+
+  const { detectReauthNeeded } = await import(join(projectRoot, 'dist', 'web', 'reauth-detect.js'))
+  const result = detectReauthNeeded(paneText)
+
+  if (!result.needsReauth) return
+  if (FIRST_RUN_GATE_RX.test(result.reason ?? '')) return
+
+  process.stdout.write(`DEAD:${result.reason ?? 'auth failure'}\n`)
+  process.exitCode = 1
+}
+
+main().catch(() => {
+  // Fail-open: never treat an internal error as "confirmed dead".
+  process.exitCode = 0
+})

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -222,15 +222,17 @@ MODEL_FLAG=""
 # tmux command-string round-trip without the inner shell glob-expanding `[1m]`.
 [ -n "$MAIN_MODEL" ] && MODEL_FLAG="--model '$MAIN_MODEL' "
 
-# macOS main-agent config isolation (OPT-IN, default OFF).
+# Main-agent config isolation (OPT-IN, default OFF).
 #
-# By default the main channels agent keeps the shared ~/.claude and, on macOS,
-# authenticates from the ROTATING Keychain OAuth session -- which periodically
-# expires and 401s the main bot ("Please run /login"), while the isolated
-# sub-agents (long-lived fleet setup-token) never do. The helper provisions an
-# isolated CLAUDE_CONFIG_DIR (same code path as the sub-agents, via
-# dist/web/agent-process.js) and authenticates the main agent from the fleet
-# setup-token instead.
+# By default the main channels agent keeps the shared ~/.claude and
+# authenticates from whatever on-process credential refreshes that shared root
+# -- the ROTATING macOS Keychain OAuth session, or (Linux) the shared
+# ~/.claude/.credentials.json -- both periodically expire and 401 the main bot
+# ("Please run /login"), while the isolated sub-agents (long-lived fleet
+# setup-token) never do (confirmed root cause of the 2026-07-23 marveen-channels
+# silent outage). The helper provisions an isolated CLAUDE_CONFIG_DIR (same code
+# path as the sub-agents, via dist/web/agent-process.js) and authenticates the
+# main agent from the fleet setup-token instead.
 #
 # The decision lives ENTIRELY in the helper, which prints "<mode>\t<path>" (or
 # nothing) and covers the two mutually exclusive ways the main agent can get its
@@ -241,10 +243,10 @@ MODEL_FLAG=""
 #     fleet's). That dir carries its own .credentials.json, so we must NOT inject
 #     the fleet token: doing so would authenticate the bot as the fleet. Works on
 #     every platform.
-#   isolated -- MAIN_AGENT_ISOLATED_CONFIG=1 on macOS with a fleet setup-token:
-#     the helper provisions a credential-less dir and we export the fleet token
-#     (same code path as the sub-agents), so the bot stops depending on the
-#     rotating Keychain OAuth session.
+#   isolated -- MAIN_AGENT_ISOLATED_CONFIG=1 (any platform) with a fleet
+#     setup-token: the helper provisions a credential-less dir and we export the
+#     fleet token (same code path as the sub-agents), so the bot stops depending
+#     on the rotating/shared on-disk credential.
 #
 # Both settings resolve through the settings-store (dashboard toggle in
 # store/config-overrides.json OR a hand-set .env key -- resolution override>.env>
@@ -359,9 +361,20 @@ fi
 # never reaches the channels claude -> "Not logged in" until the hourly restart.
 # Setting it -g makes the launch order irrelevant. Safe to share globally: every
 # agent uses the same Claude login (unlike the channel tokens scrubbed above,
-# which DO conflict and are -u'd). `|| true` tolerates "no server yet" -- in that
-# case new-session creates the server from this shell's exported env, which is
-# already correct.
+# which DO conflict and are -u'd).
+#
+# `start-server` first, because the "no server yet -> new-session inherits this
+# shell's env" assumption below is only safe when NOTHING ELSE creates the
+# server in between. At boot it does: systemd starts marveen-channels and
+# marveen-dashboard in the same second, and the dashboard's worker sessions win
+# the race about half the time. Then `set-environment -g` silently no-ops (no
+# server), the dashboard creates the server WITHOUT the token, and our
+# new-session inherits that empty global env instead of this shell's -- the
+# channels claude comes up "Not logged in - Please run /login" and the Telegram
+# plugin dies in a restart loop, on a headless box where /login is impossible.
+# Creating the server ourselves makes set-environment -g always land, which is
+# what the fix intended. start-server is idempotent and cheap.
+$TMUX start-server 2>/dev/null || true
 if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
   $TMUX set-environment -g CLAUDE_CODE_OAUTH_TOKEN "$CLAUDE_CODE_OAUTH_TOKEN" 2>/dev/null || true
 fi

--- a/scripts/main-agent-isolated-config.mjs
+++ b/scripts/main-agent-isolated-config.mjs
@@ -1,17 +1,21 @@
 #!/usr/bin/env node
-// Provision (idempotently) the MAIN channels-agent's isolated CLAUDE_CONFIG_DIR
-// on macOS, then print its path on stdout so scripts/channels.sh can export it.
+// Provision (idempotently) the MAIN channels-agent's isolated CLAUDE_CONFIG_DIR,
+// on any platform once the setting is on and a fleet token exists, then print
+// its path on stdout so scripts/channels.sh can export it.
 //
-// Why: the main agent otherwise keeps the shared ~/.claude and, on macOS,
-// authenticates from the ROTATING Keychain OAuth session -- which periodically
-// expires and 401s the main bot (a manual /login is then needed). An isolated
+// Why: the main agent otherwise keeps the shared ~/.claude and authenticates
+// from whatever on-process credential refreshes that shared root -- the
+// ROTATING macOS Keychain OAuth session, or (Linux) the shared
+// ~/.claude/.credentials.json -- both periodically expire and 401 the main bot
+// (a manual /login is then needed), see the 2026-07-23 outage. An isolated
 // config dir (no .credentials.json) makes it authenticate from the long-lived
 // fleet setup-token via CLAUDE_CODE_OAUTH_TOKEN, exactly like the sub-agents.
 //
-// Prints NOTHING (and exits 0) when isolation is not applicable -- non-macOS, no
-// fleet token (store/.claude-oauth-token), or ~/.claude absent -- so the caller
-// simply keeps the shared root. Mirrors vault-resolve.mjs: dynamic import from
-// the compiled dist so there is a single source of truth (agent-process.ts).
+// Prints NOTHING (and exits 0) when isolation is not applicable -- setting off,
+// no fleet token (store/.claude-oauth-token), or ~/.claude absent -- so the
+// caller simply keeps the shared root. Mirrors vault-resolve.mjs: dynamic
+// import from the compiled dist so there is a single source of truth
+// (agent-process.ts).
 //
 // Usage: node scripts/main-agent-isolated-config.mjs [provider]
 import { join, dirname } from 'node:path'

--- a/src/__tests__/channel-stability-contract.test.ts
+++ b/src/__tests__/channel-stability-contract.test.ts
@@ -114,3 +114,35 @@ describe('P2#5 — dashboard restart routes the main agent through respawn-pane 
     expect(cm).not.toMatch(/systemctl[^\n]*restart/)
   })
 })
+
+describe('P2#6 — channel-watchdog.sh independent auth-dead backstop (GAP 2b)', () => {
+  const sh = read('scripts/channel-watchdog.sh')
+
+  it('still NEVER calls systemctl … restart after the restructuring', () => {
+    expect(stripBashComments(sh)).not.toMatch(/systemctl\s+(--user\s+)?restart/)
+  })
+
+  it('invokes scripts/channels-auth-probe.mjs as the independent auth-dead signal', () => {
+    expect(sh).toMatch(/scripts\/channels-auth-probe\.mjs/)
+  })
+
+  it('computes STALE and AUTHDEAD independently and proceeds to recovery on either', () => {
+    expect(sh).toMatch(/AUTHDEAD=true/)
+    expect(sh).toMatch(/\[\s*"\$STALE"\s*!=\s*true\s*\]\s*&&\s*\[\s*"\$AUTHDEAD"\s*!=\s*true\s*\]/)
+  })
+
+  it('gates AUTHDEAD on AUTH_DEAD_THRESHOLD_TICKS consecutive dead ticks (not a single probe)', () => {
+    expect(sh).toMatch(/AUTH_DEAD_THRESHOLD_TICKS=/)
+  })
+
+  it('RESPAWN_CMD construction references main-agent-isolated-config.mjs (GAP 1 parity fix, 3c)', () => {
+    expect(sh).toMatch(/scripts\/main-agent-isolated-config\.mjs/)
+    // The isolated-mode branch must splice CLAUDE_CONFIG_DIR + the fleet token
+    // (read via $(cat …) at spawn time, never embedded literally) into CFG_ENV,
+    // and RESPAWN_CMD must actually use it -- a completeness gap here would
+    // silently reintroduce GAP 1 on this one recovery path.
+    expect(sh).toMatch(/CFG_ENV="export CLAUDE_CONFIG_DIR=/)
+    expect(sh).toMatch(/CLAUDE_CODE_OAUTH_TOKEN=\\"\\\$\(cat /)
+    expect(sh).toMatch(/RESPAWN_CMD=.*\$\{CFG_ENV\}/)
+  })
+})

--- a/src/__tests__/main-agent-isolated-config.test.ts
+++ b/src/__tests__/main-agent-isolated-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// ensureMainAgentIsolatedConfigDir: extends the already-proven sub-agent
+// isolated-config machinery to the MAIN channels agent, now on ANY platform
+// (PLAN.md GAP 1, 2026-07-23 marveen-channels silent outage) -- the previous
+// `if (platform !== 'darwin') return null` early return left the main bot on
+// Linux depending on the shared, periodically-refreshing
+// ~/.claude/.credentials.json. Mirrors main-agent-config-dir.test.ts's mocking
+// pattern for the sibling MAIN_AGENT_CONFIG_DIR path.
+//
+// PROJECT_ROOT/STORE_DIR are baked into module-level constants at import time
+// (FLEET_OAUTH_TOKEN_PATH = join(STORE_DIR, '.claude-oauth-token')), so this
+// suite uses a SINGLE fixed sandbox for the whole file (created once, mocked
+// once) and resets its mutable contents per test, rather than a fresh
+// mkdtempSync per test like the homedir()-only isolated-channel-config suite.
+const SANDBOX = mkdtempSync(join(tmpdir(), 'mainisocfg-'))
+const PROJECT = join(SANDBOX, 'project')
+const STORE = join(PROJECT, 'store')
+const HOME = join(SANDBOX, 'home')
+const TOKEN_PATH = join(STORE, '.claude-oauth-token')
+
+let SETTING = ''
+
+vi.mock('node:os', async (orig) => {
+  const actual = await orig<typeof import('node:os')>()
+  return { ...actual, homedir: () => HOME }
+})
+vi.mock('../settings-store.js', async (orig) => {
+  const actual = await orig<typeof import('../settings-store.js')>()
+  return {
+    ...actual,
+    getEffectiveSettingValue: (key: string) =>
+      key === 'MAIN_AGENT_ISOLATED_CONFIG' ? SETTING : actual.getEffectiveSettingValue(key),
+  }
+})
+vi.mock('../config.js', async (orig) => {
+  const actual = await orig<typeof import('../config.js')>()
+  return { ...actual, PROJECT_ROOT: PROJECT, STORE_DIR: STORE }
+})
+
+const { ensureMainAgentIsolatedConfigDir } = await import('../web/agent-process.js')
+
+beforeEach(() => {
+  rmSync(PROJECT, { recursive: true, force: true })
+  rmSync(HOME, { recursive: true, force: true })
+  mkdirSync(STORE, { recursive: true })
+  mkdirSync(join(HOME, '.claude'), { recursive: true })
+  writeFileSync(join(HOME, '.claude', 'settings.json'), '{}')
+  writeFileSync(TOKEN_PATH, 'sk-ant-oat01-fake\n')
+  SETTING = '1'
+})
+afterAll(() => {
+  rmSync(SANDBOX, { recursive: true, force: true })
+})
+
+describe('ensureMainAgentIsolatedConfigDir', () => {
+  it('linux + setting on + fleet token present + ~/.claude present -> isolated dir', () => {
+    const dir = ensureMainAgentIsolatedConfigDir(undefined, 'linux')
+    expect(dir).toBe(join(PROJECT, '.channels-config'))
+    expect(existsSync(dir!)).toBe(true)
+  })
+
+  it('linux + setting off (default) -> null (zero behavior change for existing installs)', () => {
+    SETTING = '0'
+    expect(ensureMainAgentIsolatedConfigDir(undefined, 'linux')).toBeNull()
+  })
+
+  it('linux + setting on + no fleet token -> null (hasFleetOauthToken gate still applies)', () => {
+    rmSync(TOKEN_PATH, { force: true })
+    expect(ensureMainAgentIsolatedConfigDir(undefined, 'linux')).toBeNull()
+  })
+
+  it('darwin + setting on + fleet token present -> isolated dir (unchanged, no regression)', () => {
+    const dir = ensureMainAgentIsolatedConfigDir(undefined, 'darwin')
+    expect(dir).toBe(join(PROJECT, '.channels-config'))
+  })
+
+  it('darwin + setting off (default) -> null (unchanged, no regression)', () => {
+    SETTING = '0'
+    expect(ensureMainAgentIsolatedConfigDir(undefined, 'darwin')).toBeNull()
+  })
+})

--- a/src/__tests__/reauth-healer.test.ts
+++ b/src/__tests__/reauth-healer.test.ts
@@ -120,6 +120,7 @@ describe('decideReauthAction: first-run gate', () => {
     const d = decideReauthAction(base({ isFirstRunGate: true, isMain: true, prev: gated }), T)
     expect(d.sendKeys).toBe(false)
     expect(d.restartAgent).toBe(false)
+    expect(d.restartMain).toBe(false)
     expect(d.escalate).toBe(true)
   })
 
@@ -133,5 +134,56 @@ describe('decideReauthAction: first-run gate', () => {
     const d = decideReauthAction(base({ isFirstRunGate: true, prev: NO_REAUTH_STATE }), T)
     expect(d.restartAgent).toBe(false)
     expect(d.escalate).toBe(false)
+  })
+})
+
+// GAP 2a (PLAN.md, 2026-07-23 marveen-channels silent outage): once GAP 1 lands,
+// a dead main-agent token is a legitimate restart target (fresh process either
+// picks the still-good fleet token back up, or the token is quarantined by the
+// escalate branch first) -- decideReauthAction gains restartMain, gated at the
+// exact same fireNow threshold as escalate, for the main agent only, and never
+// on the first-run gate (see the "escalate-only" test above, extended with
+// restartMain === false).
+describe('decideReauthAction: restartMain (main agent dead-token restart)', () => {
+  it('3rd consecutive dead probe fires restartMain for the main agent (not first-run gate)', () => {
+    const d = decideReauthAction(base({ isMain: true, prev: { consecutiveDead: 2, lastActionAtMs: null }, nowMs: 2_000_000 }), T)
+    expect(d.escalate).toBe(true)
+    expect(d.restartMain).toBe(true)
+    expect(d.sendKeys).toBe(false)
+    expect(d.restartAgent).toBe(false)
+  })
+
+  it('debounces: below threshold, restartMain stays false', () => {
+    const p1 = decideReauthAction(base({ isMain: true, prev: NO_REAUTH_STATE }), T)
+    expect(p1.restartMain).toBe(false)
+    const p2 = decideReauthAction(base({ isMain: true, prev: p1.next }), T)
+    expect(p2.restartMain).toBe(false)
+  })
+
+  it('sub-agent never gets restartMain, even at threshold', () => {
+    const d = decideReauthAction(base({ isMain: false, prev: { consecutiveDead: 2, lastActionAtMs: null } }), T)
+    expect(d.restartMain).toBe(false)
+  })
+
+  it('cooldown: still-dead within 30min does not re-fire restartMain', () => {
+    const lastActionAtMs = 1_000_000
+    const d = decideReauthAction(base({
+      isMain: true,
+      prev: { consecutiveDead: 5, lastActionAtMs },
+      nowMs: lastActionAtMs + 10 * 60 * 1000, // 10 min later
+    }), T)
+    expect(d.restartMain).toBe(false)
+    expect(d.escalate).toBe(false)
+  })
+
+  it('cooldown: restartMain re-fires after 30min if still dead (mirrors escalate)', () => {
+    const lastActionAtMs = 1_000_000
+    const d = decideReauthAction(base({
+      isMain: true,
+      prev: { consecutiveDead: 12, lastActionAtMs },
+      nowMs: lastActionAtMs + 31 * 60 * 1000,
+    }), T)
+    expect(d.restartMain).toBe(true)
+    expect(d.escalate).toBe(true)
   })
 })

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -380,7 +380,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     key: 'MAIN_AGENT_ISOLATED_CONFIG',
     type: 'boolean',
     default: '0',
-    description: 'CSAK macOS: a fő channels-agent kapjon-e saját, izolált CLAUDE_CONFIG_DIR-t (mint a sub-agentek). Bekapcsolva a fő agent a hosszú élettartamú fleet setup-tokenből (store/.claude-oauth-token) hitelesít, nem a rotálódó macOS Keychain OAuth-sessionből, ami periodikusan lejár és 401-et ad ("Please run /login"), amitől a bot elnémul. Token hiányában vagy nem-macOS gépen no-op. A módosítás a channels session újraindításakor lép életbe.',
+    description: 'Bármely platformon: a fő channels-agent kapjon-e saját, izolált CLAUDE_CONFIG_DIR-t (mint a sub-agentek). Bekapcsolva a fő agent a hosszú élettartamú fleet setup-tokenből (store/.claude-oauth-token) hitelesít, nem a megosztott, önmagát frissítő session-hitelesítésből (macOS: rotálódó Keychain OAuth-session; Linux: megosztott ~/.claude/.credentials.json) -- mindkettő periodikusan lejár, és a lejárt fájl a Claude Code precedencia miatt akkor is nyer az érvényes env-tokennel szemben, ha az élő token ott van mellette (2026-07-23 kiesés). Token hiányában no-op. A módosítás a channels session újraindításakor lép életbe.',
     module: 'channels',
     secret: false,
     requiresRestart: true,

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -301,25 +301,33 @@ export function ensureIsolatedChannelConfigDir(
 }
 
 // The main channels agent (started by scripts/channels.sh, cwd = PROJECT_ROOT)
-// normally keeps the shared ~/.claude by design. On macOS that means it
-// authenticates from the ROTATING Keychain OAuth session, which periodically
-// expires and 401s the main bot (a manual /login is then needed) -- while the
-// isolated sub-agents, which authenticate from the long-lived fleet setup-token,
-// never do. This gives the main agent the SAME isolated CLAUDE_CONFIG_DIR as the
-// sub-agents so it too authenticates from CLAUDE_CODE_OAUTH_TOKEN and never
-// touches the rotating Keychain.
+// normally keeps the shared ~/.claude by design. That means it authenticates
+// from whatever on-process credential refreshes that shared root -- the
+// ROTATING macOS Keychain OAuth session, or (Linux) the shared
+// ~/.claude/.credentials.json, which self-refreshes on its own ~8h cycle --
+// either way, a periodic-401 risk: the refresh can hit a transient error and
+// never retry, and Claude Code prefers an on-disk .credentials.json over an
+// otherwise-valid CLAUDE_CODE_OAUTH_TOKEN env var (claude-credentials-guard.ts),
+// so a stale file wins even with a live token sitting right next to it
+// (confirmed root cause of the 2026-07-23 marveen-channels silent outage,
+// PLAN.md GAP 1). The isolated sub-agents, which authenticate from the
+// long-lived fleet setup-token via an isolated CLAUDE_CONFIG_DIR carrying no
+// .credentials.json at all, never hit this. This gives the main agent the SAME
+// isolated CLAUDE_CONFIG_DIR as the sub-agents so it too authenticates from
+// CLAUDE_CODE_OAUTH_TOKEN and never touches a rotating on-disk credential.
 //
 // Deliberately narrow and OPT-IN (default OFF), so nothing changes for existing
 // installs unless the operator turns it on:
-//   - macOS only -- on Linux the main agent's rotating credentials.json is
-//     handled by the separate credentials-guard; the Keychain-expiry motive is
-//     macOS-specific. This does NOT touch shouldAlertSharedConfigCollision's
-//     darwin early-return (a different failure mode: plugin-slot collision).
+//   - any platform -- the provisioning itself (provisionIsolatedConfigDir) is
+//     100% filesystem-based and already proven identical on every platform via
+//     the sub-agent path; there is no macOS-specific step here. This does NOT
+//     touch shouldAlertSharedConfigCollision's darwin early-return (a different,
+//     genuinely macOS-specific failure mode: plugin-slot collision).
 //   - gated on the MAIN_AGENT_ISOLATED_CONFIG setting via the settings-store, so
 //     BOTH the dashboard toggle (config-overrides.json) AND a hand-set .env key
 //     take effect (resolution: override > .env > default '0'). channels.sh no
-//     longer parses the flag itself -- it always calls the helper on macOS and
-//     this function is the single gate.
+//     longer parses the flag itself -- it always calls the helper and this
+//     function is the single gate.
 //   - gated on the fleet OAuth token (no token -> no isolation, since the
 //     isolated dir carries no .credentials.json -- identical gate to the
 //     sub-agent path in startAgentProcess);
@@ -328,7 +336,6 @@ export function ensureMainAgentIsolatedConfigDir(
   provider?: string,
   platform: NodeJS.Platform = process.platform,
 ): string | null {
-  if (platform !== 'darwin') return null
   let enabled = false
   try { enabled = String(getEffectiveSettingValue('MAIN_AGENT_ISOLATED_CONFIG')) === '1' } catch { enabled = false }
   if (!enabled) return null

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -75,6 +75,7 @@ export interface ReauthHealerThresholds {
 export interface ReauthHealerDecision {
   sendKeys: boolean   // best-effort autonomous /login (sub-agents only)
   restartAgent: boolean // first-run-gate heal: restart the sub-agent (re-seeds the onboarding flag)
+  restartMain: boolean // GAP 1 landed: a dead-token main respawn now legitimately fixes it (main only)
   escalate: boolean   // notify.sh alert to the owner
   next: ReauthHealerState
 }
@@ -93,7 +94,7 @@ export function decideReauthAction(input: ReauthHealerInput, t: ReauthHealerThre
 
   // Clean / not-applicable: end the spell, allow a fresh alert next time.
   if (!isDeadToken || !sessionAlive) {
-    return { sendKeys: false, restartAgent: false, escalate: false, next: NO_REAUTH_STATE }
+    return { sendKeys: false, restartAgent: false, restartMain: false, escalate: false, next: NO_REAUTH_STATE }
   }
 
   const consecutiveDead = prev.consecutiveDead + 1
@@ -110,8 +111,18 @@ export function decideReauthAction(input: ReauthHealerInput, t: ReauthHealerThre
     sendKeys: fireNow && !isMain && canInteractiveLogin && isFirstRunGate !== true,
     // First-run gate on a sub-agent: a restart heals it (startAgentProcess runs
     // ensureSharedClaudeOnboarded first). Works headless -- no browser step.
-    // The main agent stays escalate-only; its monitored respawn paths re-seed.
     restartAgent: fireNow && !isMain && isFirstRunGate === true,
+    // Main agent, genuine dead-token (not first-run gate): once GAP 1 lands, the
+    // main session authenticates from the long-lived fleet setup-token via an
+    // isolated CLAUDE_CONFIG_DIR, so a fresh process either picks the still-good
+    // token back up or (if the fleet token itself is dead) the quarantine logic
+    // already fired by the `escalate` branch demotes it before the next launch --
+    // either way a restart is now a legitimate fix, not a no-op. No
+    // canInteractiveLogin gate: a main restart never sends /login keys, so the
+    // headless cascade risk that gates sendKeys does not apply here. Stays
+    // escalate-only on the first-run gate (a restart there is handled by the
+    // existing monitored respawn paths, which already re-seed onboarding).
+    restartMain: fireNow && isMain && isFirstRunGate !== true,
     escalate: fireNow,
     next: {
       consecutiveDead,
@@ -296,7 +307,27 @@ function checkSession(label: string, session: string, isMain: boolean, quiet: bo
     // credential there is typically fine.
     if (!isFirstRunGate) {
       quarantineFleetTokenIfDead()
-        .then((r) => { if (r !== 'no-token') logger.warn({ label, result: r }, 'reauth-healer: fleet-token liveness check') })
+        .then((r) => {
+          if (r !== 'no-token') logger.warn({ label, result: r }, 'reauth-healer: fleet-token liveness check')
+          // Restart the main agent AFTER the fleet-token liveness check above has
+          // had a chance to quarantine a proven-dead token -- ordered inside this
+          // .then() per PLAN.md GAP 2a, so a fresh process launched by the restart
+          // cannot re-read a token that is only now being quarantined. Dynamic
+          // import (matches inbound-probe.ts:318) to avoid a circular module
+          // dependency with channel-monitor.ts.
+          if (decision.restartMain) {
+            import('./channel-monitor.js').then(({ hardRestartMarveenChannels, lastMainRespawnAt }) => {
+              const RESPAWN_GRACE_MS = 15 * 60 * 1000 // mirror channel-monitor.ts's KEEPALIVE_RESPAWN_GRACE_MS
+              const now = Date.now()
+              if (lastMainRespawnAt() > 0 && now - lastMainRespawnAt() < RESPAWN_GRACE_MS) {
+                logger.info('reauth-healer: main dead-token restart skipped -- within cross-path respawn grace')
+                return
+              }
+              const r2 = hardRestartMarveenChannels()
+              logger.warn({ ok: r2.ok }, 'reauth-healer: main dead-token restart triggered')
+            }).catch((err) => logger.debug({ err }, 'reauth-healer: main dead-token restart import failed'))
+          }
+        })
         .catch((err) => logger.debug({ err }, 'reauth-healer: fleet-token liveness check failed'))
     }
   }


### PR DESCRIPTION
## Problem

On Linux fleet installs the main channels bot could silently drop into a 401
(`OAuth access token has expired` / `Invalid authentication credentials`) and
stay down: a bare service restart did not recover it because the shared
credentials/config state was not isolated per main-agent, and nothing actively
detected the 401 to trigger re-auth.

## Fix

- **Isolated main-agent config** (`scripts/main-agent-isolated-config.mjs`,
  `src/__tests__/main-agent-isolated-config.test.ts`): the main channels agent
  gets its own `CLAUDE_CONFIG_DIR` so its auth state is not clobbered by other
  agents sharing the box.
- **401-detecting watchdog** (`scripts/channel-watchdog.sh`,
  `scripts/channels-auth-probe.mjs` + probe test): actively probes channel
  auth, recognizes the expired-token / invalid-credentials signature, and
  drives recovery instead of leaving the bot dead.
- **Reauth healer** hookup (`src/web/reauth-healer.ts`) and
  `agent-process.ts` wiring so a detected 401 leads to a real re-auth, not a
  no-op restart loop.
- Adds a channel-stability contract test and a reauth-healer test.

Secrets are always read at spawn time from a token file
(`$(cat store/.claude-oauth-token)`); no credential values are ever written
into logs or committed.

11 files changed, 577 insertions(+), 65 deletions(-). Verified green in the
fleet install this was extracted from (full suite + typecheck).