### PR TITLE
feat(scripts): remote access key enrollment helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,32 @@ ssh macmini "/opt/homebrew/bin/tmux kill-session -t monitor" && \
 
 A script automatikusan felderíti a futó `agent-*` és `marveen-channels` session-öket. A monitor session törlése nem érinti az ágens session-öket -- csak a linked-window referenciákat szünteti meg.
 
+### Remote access key enrollment
+
+A helper that lets an operator enroll a single device's SSH public key with a tightly restricted `authorized_keys` entry, then hands back a copyable connection bundle. Each device carries its own revocation id (`marveen-remote:<uuid>`) so access can be replaced or removed per device.
+
+Run it with the public key line as a single quoted argument:
+
+```bash
+npm run remote-enroll -- "ssh-ed25519 <base64 key> marveen-remote:<uuid>"
+# optional flags:
+npm run remote-enroll -- --host 203.0.113.10 --port 2222 "ssh-ed25519 <base64 key> marveen-remote:<uuid>"
+```
+
+The public key line must be exactly three fields (type, key, comment) with no `authorized_keys` options and no extra fields. Only `ssh-ed25519` keys are accepted, and the comment must be `marveen-remote:<uuid>` (uuid v4).
+
+It appends (or replaces, when the same id is re-enrolled) this restricted line to the invoking user's `~/.ssh/authorized_keys`:
+
+```
+restrict,port-forwarding,permitopen="127.0.0.1:3420",command="/bin/false" ssh-ed25519 <base64 key> marveen-remote:<uuid>
+```
+
+`restrict` disables pty, agent, and X11 forwarding; the forced command is `/bin/false`; and the only endpoint the key may open is `127.0.0.1:3420`. The write is atomic (temp file plus rename) and guarded by an `authorized_keys.lock` file so concurrent runs cannot corrupt the list. `~/.ssh` is created 0700 and `authorized_keys` 0600 when missing; if either already exists with looser permissions the tool warns instead of changing them silently.
+
+After enrolling, it prints a base64 connection bundle between clearly marked delimiters. The bundle carries the host, SSH port and user, the fixed remote port (3420), the device id, and the machine's `ssh-ed25519` host key when readable. When the host key is not readable the field is omitted and the connecting device falls back to a first-use fingerprint confirmation. When `--host` is not given, the tool prints a hint to verify the resolved address is the one the device will reach.
+
+To revoke a device, delete the line whose comment matches its id (`marveen-remote:<uuid>`) from `~/.ssh/authorized_keys`.
+
 ### Frissítés
 ```bash
 ./update.sh

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "tsx src/index.ts",
     "setup": "tsx scripts/setup.ts",
     "status": "tsx scripts/status.ts",
+    "remote-enroll": "tsx scripts/remote-access-enroll.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "syntax-check": "node --check web/app.js web/sw.js",

--- a/scripts/remote-access-enroll.ts
+++ b/scripts/remote-access-enroll.ts
@@ -1,0 +1,150 @@
+// Remote access key enrollment helper.
+//
+// Enrolls a device's SSH public key into the invoking user's authorized_keys
+// with a tightly restricted entry, then prints a base64 connection bundle the
+// operator can hand back to the device.
+//
+// Usage:
+//   npm run remote-enroll -- "ssh-ed25519 <base64 key> marveen-remote:<uuid>"
+//   npm run remote-enroll -- --host 203.0.113.10 --port 2222 "<public key line>"
+
+import { readFileSync } from 'node:fs'
+import { homedir, hostname, userInfo, networkInterfaces } from 'node:os'
+import { join } from 'node:path'
+import {
+  validatePublicKeyLine,
+  buildRestrictedLine,
+  buildBundle,
+  encodeBundle,
+  parseHostKeyPub,
+  RemoteEnrollError,
+  type ConnectionBundleInput,
+} from '../src/remote-enroll-core.js'
+import { enrollAuthorizedKey } from '../src/remote-enroll-fs.js'
+
+const HOST_KEY_PUB_PATH = '/etc/ssh/ssh_host_ed25519_key.pub'
+
+interface Args {
+  keyLine?: string
+  host?: string
+  port: number
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = { port: 22 }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--host') {
+      const v = argv[++i]
+      if (!v) fail('--host requires a value')
+      out.host = v
+    } else if (a === '--port') {
+      const v = argv[++i]
+      if (!v) fail('--port requires a value')
+      const n = Number(v)
+      if (!Number.isInteger(n) || n < 1 || n > 65535) fail('--port must be 1..65535')
+      out.port = n
+    } else if (a.startsWith('--')) {
+      fail(`unknown flag: ${a}`)
+    } else if (out.keyLine === undefined) {
+      out.keyLine = a
+    } else {
+      fail('unexpected extra argument; pass the public key line as a single quoted argument')
+    }
+  }
+  return out
+}
+
+function fail(message: string): never {
+  process.stderr.write(`error: ${message}\n`)
+  process.exit(1)
+}
+
+/** Best-effort primary non-loopback IPv4 address of this machine. */
+function primaryIPv4(): string | null {
+  const ifaces = networkInterfaces()
+  for (const name of Object.keys(ifaces)) {
+    for (const info of ifaces[name] ?? []) {
+      const family = info.family as string | number
+      if ((family === 'IPv4' || family === 4) && !info.internal) {
+        return info.address
+      }
+    }
+  }
+  return null
+}
+
+function readHostKeyBody(): string | null {
+  try {
+    const content = readFileSync(HOST_KEY_PUB_PATH, 'utf8')
+    return parseHostKeyPub(content)
+  } catch {
+    return null
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.keyLine === undefined) {
+    fail('missing public key line. Usage: npm run remote-enroll -- "<public key line>"')
+  }
+
+  let parsed
+  try {
+    parsed = validatePublicKeyLine(args.keyLine)
+  } catch (err) {
+    if (err instanceof RemoteEnrollError) fail(err.message)
+    throw err
+  }
+
+  const restrictedLine = buildRestrictedLine(parsed)
+  const sshDir = join(homedir(), '.ssh')
+
+  const result = await enrollAuthorizedKey({
+    sshDir,
+    restrictedLine,
+    installId: parsed.installId,
+  })
+
+  for (const w of result.warnings) {
+    process.stderr.write(`warning: ${w}\n`)
+  }
+  process.stderr.write(
+    `${result.action === 'replaced' ? 'Replaced' : 'Added'} restricted entry for marveen-remote:${parsed.installId} in ${result.authorizedKeysPath}\n`,
+  )
+
+  // Assemble the connection bundle.
+  const explicitHost = args.host
+  const host = explicitHost ?? primaryIPv4() ?? hostname()
+  const hostKey = readHostKeyBody()
+  if (hostKey === null) {
+    process.stderr.write(
+      `warning: ${HOST_KEY_PUB_PATH} is not readable; the connecting device will fall back to a first-use fingerprint confirmation\n`,
+    )
+  }
+  if (!explicitHost) {
+    process.stderr.write(
+      `hint: host resolved to "${host}". Verify this is the address the device will reach; override with --host if needed.\n`,
+    )
+  }
+
+  const bundleInput: ConnectionBundleInput = {
+    displayName: hostname(),
+    host,
+    sshPort: args.port,
+    sshUser: userInfo().username,
+    installId: parsed.installId,
+  }
+  if (hostKey !== null) bundleInput.hostKey = hostKey
+
+  const encoded = encodeBundle(buildBundle(bundleInput))
+
+  process.stdout.write('----- BEGIN CONNECTION BUNDLE -----\n')
+  process.stdout.write(`${encoded}\n`)
+  process.stdout.write('----- END CONNECTION BUNDLE -----\n')
+}
+
+main().catch((err) => {
+  process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`)
+  process.exit(1)
+})

--- a/src/__tests__/remote-enroll-core.test.ts
+++ b/src/__tests__/remote-enroll-core.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validatePublicKeyLine,
+  buildRestrictedLine,
+  mergeAuthorizedKeys,
+  parseHostKeyPub,
+  buildBundle,
+  encodeBundle,
+  decodeBundle,
+  RemoteEnrollError,
+  RESTRICT_OPTIONS,
+  type ParsedKey,
+} from '../remote-enroll-core.js'
+
+// A real ed25519 public key blob: uint32(11) | "ssh-ed25519" | uint32(32) |
+// 32 key bytes. Built deterministically so the base64 is canonical.
+function makeEd25519Base64(keyByte = 0x42): string {
+  const type = Buffer.from('ssh-ed25519', 'utf8')
+  const key = Buffer.alloc(32, keyByte)
+  const buf = Buffer.concat([
+    u32(type.length),
+    type,
+    u32(key.length),
+    key,
+  ])
+  return buf.toString('base64')
+}
+function u32(n: number): Buffer {
+  const b = Buffer.alloc(4)
+  b.writeUInt32BE(n, 0)
+  return b
+}
+
+const UUID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301'
+const B64 = makeEd25519Base64()
+const VALID_LINE = `ssh-ed25519 ${B64} marveen-remote:${UUID}`
+
+describe('validatePublicKeyLine', () => {
+  it('accepts a well-formed line', () => {
+    const parsed = validatePublicKeyLine(VALID_LINE)
+    expect(parsed.keyType).toBe('ssh-ed25519')
+    expect(parsed.base64).toBe(B64)
+    expect(parsed.comment).toBe(`marveen-remote:${UUID}`)
+    expect(parsed.installId).toBe(UUID)
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(validatePublicKeyLine(`  ${VALID_LINE}  `).installId).toBe(UUID)
+  })
+
+  it('rejects a wrong key type', () => {
+    const line = `ssh-rsa ${B64} marveen-remote:${UUID}`
+    expect(() => validatePublicKeyLine(line)).toThrow(RemoteEnrollError)
+    expect(() => validatePublicKeyLine(line)).toThrow(/key type must be exactly ssh-ed25519/)
+  })
+
+  it('rejects bad base64', () => {
+    const line = `ssh-ed25519 not!valid!base64 marveen-remote:${UUID}`
+    expect(() => validatePublicKeyLine(line)).toThrow(/not valid base64/)
+  })
+
+  it('rejects a blob whose embedded type is not ssh-ed25519', () => {
+    const type = Buffer.from('ssh-rsa4567', 'utf8') // 11 bytes, wrong value
+    const key = Buffer.alloc(32, 1)
+    const b64 = Buffer.concat([u32(type.length), type, u32(32), key]).toString('base64')
+    const line = `ssh-ed25519 ${b64} marveen-remote:${UUID}`
+    expect(() => validatePublicKeyLine(line)).toThrow(/embedded key type/)
+  })
+
+  it('rejects a blob with the wrong key length', () => {
+    const type = Buffer.from('ssh-ed25519', 'utf8')
+    const key = Buffer.alloc(31, 1) // one byte short
+    const b64 = Buffer.concat([u32(type.length), type, u32(31), key]).toString('base64')
+    const line = `ssh-ed25519 ${b64} marveen-remote:${UUID}`
+    expect(() => validatePublicKeyLine(line)).toThrow(/must be 32 bytes/)
+  })
+
+  it('rejects a blob with trailing bytes', () => {
+    const type = Buffer.from('ssh-ed25519', 'utf8')
+    const key = Buffer.alloc(32, 1)
+    const b64 = Buffer.concat([u32(type.length), type, u32(32), key, Buffer.alloc(4)]).toString('base64')
+    const line = `ssh-ed25519 ${b64} marveen-remote:${UUID}`
+    expect(() => validatePublicKeyLine(line)).toThrow(/trailing or missing bytes/)
+  })
+
+  it('rejects a bad comment (missing prefix)', () => {
+    const line = `ssh-ed25519 ${B64} some-other-comment`
+    expect(() => validatePublicKeyLine(line)).toThrow(/must start with/)
+  })
+
+  it('rejects a comment whose id is not a uuid v4', () => {
+    const line = `ssh-ed25519 ${B64} marveen-remote:not-a-uuid`
+    expect(() => validatePublicKeyLine(line)).toThrow(/uuid v4/)
+  })
+
+  it('rejects a line carrying authorized_keys options', () => {
+    const line = `no-pty ssh-ed25519 ${B64} marveen-remote:${UUID}`
+    expect(() => validatePublicKeyLine(line)).toThrow(/exactly three fields/)
+  })
+
+  it('rejects an extra trailing field', () => {
+    const line = `ssh-ed25519 ${B64} marveen-remote:${UUID} extra`
+    expect(() => validatePublicKeyLine(line)).toThrow(/exactly three fields/)
+  })
+
+  it('rejects an empty line', () => {
+    expect(() => validatePublicKeyLine('   ')).toThrow(/empty/)
+  })
+
+  it('rejects a multi-line input', () => {
+    expect(() => validatePublicKeyLine(`${VALID_LINE}\nextra`)).toThrow(RemoteEnrollError)
+  })
+})
+
+describe('buildRestrictedLine', () => {
+  it('produces the verbatim restricted entry', () => {
+    const parsed = validatePublicKeyLine(VALID_LINE)
+    const line = buildRestrictedLine(parsed)
+    expect(line).toBe(
+      `restrict,port-forwarding,permitopen="127.0.0.1:3420",command="/bin/false" ssh-ed25519 ${B64} marveen-remote:${UUID}`,
+    )
+    // Sanity: options segment is exactly as specified.
+    expect(line.startsWith(RESTRICT_OPTIONS + ' ')).toBe(true)
+  })
+})
+
+describe('mergeAuthorizedKeys', () => {
+  const restricted = buildRestrictedLine(validatePublicKeyLine(VALID_LINE))
+
+  it('appends to empty content', () => {
+    const { content, action } = mergeAuthorizedKeys('', restricted, UUID)
+    expect(action).toBe('added')
+    expect(content).toBe(restricted + '\n')
+  })
+
+  it('appends after existing unrelated lines, preserving them byte-for-byte', () => {
+    const existing = 'ssh-rsa AAAA someone@host\nssh-ed25519 BBBB other-comment\n'
+    const { content, action } = mergeAuthorizedKeys(existing, restricted, UUID)
+    expect(action).toBe('added')
+    expect(content).toBe(existing + restricted + '\n')
+  })
+
+  it('replaces exactly the matching id line and preserves others', () => {
+    const otherId = '11111111-2222-4333-8444-555555555555'
+    const stale = `restrict ssh-ed25519 OLDKEY marveen-remote:${UUID}`
+    const keep1 = 'ssh-rsa AAAA someone@host'
+    const keep2 = `restrict ssh-ed25519 KEEP marveen-remote:${otherId}`
+    const existing = `${keep1}\n${stale}\n${keep2}\n`
+    const { content, action } = mergeAuthorizedKeys(existing, restricted, UUID)
+    expect(action).toBe('replaced')
+    expect(content).toBe(`${keep1}\n${restricted}\n${keep2}\n`)
+    // The other marveen-remote id must be untouched.
+    expect(content).toContain(keep2)
+    expect(content).not.toContain('OLDKEY')
+  })
+
+  it('handles content without a trailing newline', () => {
+    const existing = 'ssh-rsa AAAA someone@host'
+    const { content } = mergeAuthorizedKeys(existing, restricted, UUID)
+    expect(content).toBe(`${existing}\n${restricted}\n`)
+  })
+
+  it('preserves blank lines between entries', () => {
+    const existing = 'ssh-rsa AAAA a@h\n\nssh-rsa BBBB b@h\n'
+    const { content } = mergeAuthorizedKeys(existing, restricted, UUID)
+    expect(content).toBe(existing + restricted + '\n')
+  })
+})
+
+describe('parseHostKeyPub', () => {
+  it('extracts the base64 body', () => {
+    const body = makeEd25519Base64(0x11)
+    expect(parseHostKeyPub(`ssh-ed25519 ${body} root@host\n`)).toBe(body)
+  })
+  it('returns null for empty content', () => {
+    expect(parseHostKeyPub('   ')).toBeNull()
+  })
+  it('returns null when the body is not base64', () => {
+    expect(parseHostKeyPub('ssh-ed25519 %%% root@host')).toBeNull()
+  })
+})
+
+describe('bundle', () => {
+  const base: ParsedKey = validatePublicKeyLine(VALID_LINE)
+
+  it('roundtrips with all fields and hostKey present', () => {
+    const bundle = buildBundle({
+      displayName: 'my-host',
+      host: '203.0.113.5',
+      sshPort: 2222,
+      sshUser: 'operator',
+      hostKey: 'HOSTKEYB64',
+      installId: base.installId,
+    })
+    const decoded = decodeBundle(encodeBundle(bundle))
+    expect(decoded).toEqual({
+      format: 'marveen-remote/1',
+      kind: 'connection',
+      displayName: 'my-host',
+      host: '203.0.113.5',
+      sshPort: 2222,
+      sshUser: 'operator',
+      remotePort: 3420,
+      hostKey: 'HOSTKEYB64',
+      installId: base.installId,
+    })
+  })
+
+  it('omits hostKey entirely when absent', () => {
+    const bundle = buildBundle({
+      displayName: 'my-host',
+      host: 'my-host.local',
+      sshPort: 22,
+      sshUser: 'operator',
+      installId: base.installId,
+    })
+    const encoded = encodeBundle(bundle)
+    const decoded = decodeBundle(encoded)
+    expect('hostKey' in decoded).toBe(false)
+    // The raw JSON must not carry a hostKey key at all.
+    const json = Buffer.from(encoded, 'base64').toString('utf8')
+    expect(json).not.toContain('hostKey')
+    expect(decoded.remotePort).toBe(3420)
+  })
+})

--- a/src/__tests__/remote-enroll-fs.test.ts
+++ b/src/__tests__/remote-enroll-fs.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  readdirSync,
+  chmodSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { enrollAuthorizedKey } from '../remote-enroll-fs.js'
+import { buildRestrictedLine, validatePublicKeyLine } from '../remote-enroll-core.js'
+
+const UUID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301'
+
+function ed25519Base64(keyByte = 0x42): string {
+  const type = Buffer.from('ssh-ed25519', 'utf8')
+  const key = Buffer.alloc(32, keyByte)
+  const len = (n: number) => {
+    const b = Buffer.alloc(4)
+    b.writeUInt32BE(n, 0)
+    return b
+  }
+  return Buffer.concat([len(type.length), type, len(32), key]).toString('base64')
+}
+
+const B64 = ed25519Base64()
+const RESTRICTED = buildRestrictedLine(
+  validatePublicKeyLine(`ssh-ed25519 ${B64} marveen-remote:${UUID}`),
+)
+
+describe('enrollAuthorizedKey (filesystem)', () => {
+  let root: string
+  let sshDir: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'remote-enroll-'))
+    sshDir = join(root, '.ssh')
+  })
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('creates .ssh (0700) and authorized_keys (0600) when missing', async () => {
+    const res = await enrollAuthorizedKey({ sshDir, restrictedLine: RESTRICTED, installId: UUID })
+    expect(res.action).toBe('added')
+    expect(statSync(sshDir).mode & 0o777).toBe(0o700)
+    const authPath = join(sshDir, 'authorized_keys')
+    expect(statSync(authPath).mode & 0o777).toBe(0o600)
+    expect(readFileSync(authPath, 'utf8')).toBe(RESTRICTED + '\n')
+    expect(res.warnings).toEqual([])
+  })
+
+  it('appends and preserves an existing unrelated key byte-for-byte', async () => {
+    mkdirSync(sshDir, { mode: 0o700 })
+    const authPath = join(sshDir, 'authorized_keys')
+    const prior = 'ssh-rsa AAAA someone@host\n'
+    writeFileSync(authPath, prior, { mode: 0o600 })
+    const res = await enrollAuthorizedKey({ sshDir, restrictedLine: RESTRICTED, installId: UUID })
+    expect(res.action).toBe('added')
+    expect(readFileSync(authPath, 'utf8')).toBe(prior + RESTRICTED + '\n')
+  })
+
+  it('replaces by id on re-enrollment', async () => {
+    mkdirSync(sshDir, { mode: 0o700 })
+    const authPath = join(sshDir, 'authorized_keys')
+    const stale = `restrict ssh-ed25519 OLDKEY marveen-remote:${UUID}`
+    writeFileSync(authPath, `ssh-rsa AAAA a@h\n${stale}\n`, { mode: 0o600 })
+    const res = await enrollAuthorizedKey({ sshDir, restrictedLine: RESTRICTED, installId: UUID })
+    expect(res.action).toBe('replaced')
+    const content = readFileSync(authPath, 'utf8')
+    expect(content).toBe(`ssh-rsa AAAA a@h\n${RESTRICTED}\n`)
+    expect(content).not.toContain('OLDKEY')
+  })
+
+  it('warns when .ssh permissions are looser than 0700', async () => {
+    mkdirSync(sshDir, { mode: 0o755 })
+    chmodSync(sshDir, 0o755)
+    const res = await enrollAuthorizedKey({ sshDir, restrictedLine: RESTRICTED, installId: UUID })
+    expect(res.warnings.some((w) => w.includes('0755') && w.includes('0700'))).toBe(true)
+  })
+
+  it('warns when existing authorized_keys is looser than 0600 and rewrites 0600', async () => {
+    mkdirSync(sshDir, { mode: 0o700 })
+    const authPath = join(sshDir, 'authorized_keys')
+    writeFileSync(authPath, 'ssh-rsa AAAA a@h\n')
+    chmodSync(authPath, 0o644)
+    const res = await enrollAuthorizedKey({ sshDir, restrictedLine: RESTRICTED, installId: UUID })
+    expect(res.warnings.some((w) => w.includes('0644'))).toBe(true)
+    expect(statSync(authPath).mode & 0o777).toBe(0o600)
+  })
+
+  it('leaves no temp files behind and removes the lockfile', async () => {
+    await enrollAuthorizedKey({ sshDir, restrictedLine: RESTRICTED, installId: UUID })
+    const entries = readdirSync(sshDir)
+    expect(entries).toContain('authorized_keys')
+    expect(entries.some((e) => e.endsWith('.tmp'))).toBe(false)
+    expect(entries).not.toContain('authorized_keys.lock')
+  })
+
+  it('fails fast when a fresh (non-stale) lockfile is held', async () => {
+    mkdirSync(sshDir, { mode: 0o700 })
+    // Simulate a concurrent holder with a current lockfile.
+    writeFileSync(join(sshDir, 'authorized_keys.lock'), '99999\n')
+    await expect(
+      enrollAuthorizedKey({
+        sshDir,
+        restrictedLine: RESTRICTED,
+        installId: UUID,
+        lockRetries: 3,
+        lockRetryDelayMs: 1,
+        staleLockMs: 60000,
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow(/could not acquire/)
+  })
+
+  it('breaks a stale lock and proceeds', async () => {
+    mkdirSync(sshDir, { mode: 0o700 })
+    const lockPath = join(sshDir, 'authorized_keys.lock')
+    writeFileSync(lockPath, 'dead\n')
+    // Force the lock to look old.
+    const past = new Date(Date.now() - 60000)
+    // utimesSync needs seconds; use fs
+    const { utimesSync } = await import('node:fs')
+    utimesSync(lockPath, past, past)
+    const res = await enrollAuthorizedKey({
+      sshDir,
+      restrictedLine: RESTRICTED,
+      installId: UUID,
+      staleLockMs: 1000,
+      sleep: () => Promise.resolve(),
+    })
+    expect(res.action).toBe('added')
+    expect(existsSync(lockPath)).toBe(false)
+  })
+})

--- a/src/remote-enroll-core.ts
+++ b/src/remote-enroll-core.ts
@@ -1,0 +1,273 @@
+// Pure logic for remote access key enrollment.
+//
+// This module holds the side-effect-free parts of the enrollment helper so
+// they can be unit-tested without touching the real home directory or SSH
+// configuration: public-key line validation, restricted authorized_keys line
+// construction, replace-by-id merging, host-key parsing, and connection
+// bundle building. All filesystem work lives in remote-enroll-fs.ts.
+
+/** Fixed loopback endpoint the enrolled key is permitted to open. */
+export const REMOTE_PORT = 3420
+
+/** The only key type accepted for enrollment. */
+export const ACCEPTED_KEY_TYPE = 'ssh-ed25519'
+
+/** Prefix that every per-device comment must carry. The full comment is
+ * `marveen-remote:<uuid>`, where the uuid is the per-device revocation and
+ * replace identifier. */
+export const COMMENT_PREFIX = 'marveen-remote:'
+
+/** Bundle format tag, versioned so the consuming side can evolve safely. */
+export const BUNDLE_FORMAT = 'marveen-remote/1'
+
+/** Raised for any validation failure so the CLI can print a clear message
+ * and exit non-zero without a stack trace. */
+export class RemoteEnrollError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RemoteEnrollError'
+  }
+}
+
+export interface ParsedKey {
+  keyType: typeof ACCEPTED_KEY_TYPE
+  base64: string
+  comment: string
+  /** The uuid extracted from the comment. */
+  installId: string
+}
+
+// UUID v4 shape. The connecting device generates this per install; it is the
+// stable identity used to revoke or replace a single device's access.
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+/**
+ * Verify a string is canonical standard base64: it decodes and re-encodes to
+ * exactly the same text. Buffer.from is lenient (it silently drops invalid
+ * characters), so a plain decode is not enough to reject malformed input.
+ */
+function isCanonicalBase64(s: string): boolean {
+  if (s.length === 0 || s.length % 4 !== 0) return false
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(s)) return false
+  return Buffer.from(s, 'base64').toString('base64') === s
+}
+
+/**
+ * Parse and validate the OpenSSH wire-format blob for an ed25519 public key.
+ * The blob is a sequence of length-prefixed fields:
+ *   uint32 len | "ssh-ed25519" | uint32 len | 32-byte public key
+ * Anything else (wrong embedded type, wrong key length, trailing bytes) is
+ * rejected.
+ */
+function validateEd25519Blob(base64: string): void {
+  if (!isCanonicalBase64(base64)) {
+    throw new RemoteEnrollError('key body is not valid base64')
+  }
+  const buf = Buffer.from(base64, 'base64')
+  let off = 0
+  if (buf.length < 4) throw new RemoteEnrollError('key blob is too short')
+  const typeLen = buf.readUInt32BE(off)
+  off += 4
+  if (typeLen !== ACCEPTED_KEY_TYPE.length || off + typeLen > buf.length) {
+    throw new RemoteEnrollError('key blob has an unexpected type field')
+  }
+  const embeddedType = buf.subarray(off, off + typeLen).toString('utf8')
+  off += typeLen
+  if (embeddedType !== ACCEPTED_KEY_TYPE) {
+    throw new RemoteEnrollError(
+      `embedded key type must be ${ACCEPTED_KEY_TYPE}, found "${embeddedType}"`,
+    )
+  }
+  if (off + 4 > buf.length) throw new RemoteEnrollError('key blob is truncated')
+  const keyLen = buf.readUInt32BE(off)
+  off += 4
+  // ed25519 public keys are exactly 32 bytes.
+  if (keyLen !== 32) {
+    throw new RemoteEnrollError('ed25519 public key must be 32 bytes')
+  }
+  if (off + keyLen !== buf.length) {
+    throw new RemoteEnrollError('key blob has trailing or missing bytes')
+  }
+}
+
+/**
+ * Validate a single OpenSSH public key line of the exact shape
+ *   ssh-ed25519 <base64 key> marveen-remote:<uuid>
+ * The line must contain nothing else: no authorized_keys options, no extra
+ * fields. Returns the parsed pieces or throws RemoteEnrollError.
+ */
+export function validatePublicKeyLine(rawLine: string): ParsedKey {
+  if (typeof rawLine !== 'string') {
+    throw new RemoteEnrollError('public key line is required')
+  }
+  const line = rawLine.trim()
+  if (line.length === 0) {
+    throw new RemoteEnrollError('public key line is empty')
+  }
+  if (line.includes('\n') || line.includes('\r')) {
+    throw new RemoteEnrollError('public key line must be a single line')
+  }
+  const fields = line.split(/\s+/)
+  if (fields.length !== 3) {
+    throw new RemoteEnrollError(
+      'line must contain exactly three fields: type, key, comment (no options, no extra fields)',
+    )
+  }
+  const [keyType, base64, comment] = fields
+  if (keyType !== ACCEPTED_KEY_TYPE) {
+    throw new RemoteEnrollError(`key type must be exactly ${ACCEPTED_KEY_TYPE}`)
+  }
+  validateEd25519Blob(base64)
+  if (!comment.startsWith(COMMENT_PREFIX)) {
+    throw new RemoteEnrollError(`comment must start with "${COMMENT_PREFIX}"`)
+  }
+  const installId = comment.slice(COMMENT_PREFIX.length)
+  if (!UUID_V4.test(installId)) {
+    throw new RemoteEnrollError('comment must be marveen-remote:<uuid v4>')
+  }
+  return { keyType: ACCEPTED_KEY_TYPE, base64, comment, installId }
+}
+
+/** Options string prepended to the enrolled key in authorized_keys. This is
+ * the tight restriction set: no shell (command forced to /bin/false), no
+ * agent/x11/pty, forwarding limited to a single loopback endpoint. */
+export const RESTRICT_OPTIONS =
+  `restrict,port-forwarding,permitopen="127.0.0.1:${REMOTE_PORT}",command="/bin/false"`
+
+/**
+ * Build the exact restricted authorized_keys line for a validated key.
+ * The key material and comment are reproduced verbatim.
+ */
+export function buildRestrictedLine(parsed: ParsedKey): string {
+  return `${RESTRICT_OPTIONS} ${parsed.keyType} ${parsed.base64} ${parsed.comment}`
+}
+
+/** Extract the trailing comment field of an authorized_keys line, or null if
+ * the line is blank. Used to find a prior enrollment by its install id. */
+function lineComment(line: string): string | null {
+  const trimmed = line.trim()
+  if (trimmed.length === 0) return null
+  const fields = trimmed.split(/\s+/)
+  return fields[fields.length - 1]
+}
+
+export type MergeAction = 'added' | 'replaced'
+
+export interface MergeResult {
+  content: string
+  action: MergeAction
+}
+
+/**
+ * Merge a restricted line into existing authorized_keys content by install
+ * id. If a line already carries the same `marveen-remote:<uuid>` comment it
+ * is replaced in place (re-enrollment); every other line is preserved
+ * byte-for-byte. Otherwise the restricted line is appended. The result always
+ * ends with a single trailing newline.
+ */
+export function mergeAuthorizedKeys(
+  existing: string,
+  restrictedLine: string,
+  installId: string,
+): MergeResult {
+  const target = `${COMMENT_PREFIX}${installId}`
+  const lines = existing.length ? existing.split('\n') : []
+  // A file that ends in a newline yields a trailing '' element; drop it so it
+  // does not become a spurious blank line, then re-add exactly one newline.
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop()
+  }
+  let replaced = false
+  const out = lines.map((line) => {
+    if (lineComment(line) === target) {
+      replaced = true
+      return restrictedLine
+    }
+    return line
+  })
+  if (!replaced) out.push(restrictedLine)
+  let content = out.join('\n')
+  if (!content.endsWith('\n')) content += '\n'
+  return { content, action: replaced ? 'replaced' : 'added' }
+}
+
+/**
+ * Extract the base64 body (second whitespace field) of an OpenSSH public key
+ * file such as /etc/ssh/ssh_host_ed25519_key.pub. Returns null when the
+ * content does not look like a public key line.
+ */
+export function parseHostKeyPub(content: string): string | null {
+  const line = content.trim()
+  if (line.length === 0) return null
+  const fields = line.split(/\s+/)
+  if (fields.length < 2) return null
+  const body = fields[1]
+  if (!isCanonicalBase64(body)) return null
+  return body
+}
+
+export interface ConnectionBundleInput {
+  displayName: string
+  host: string
+  sshPort: number
+  sshUser: string
+  /** Omitted from the bundle entirely when undefined. */
+  hostKey?: string
+  installId: string
+}
+
+export interface ConnectionBundle {
+  format: typeof BUNDLE_FORMAT
+  kind: 'connection'
+  displayName: string
+  host: string
+  sshPort: number
+  sshUser: string
+  remotePort: number
+  hostKey?: string
+  installId: string
+}
+
+/**
+ * Build the connection bundle object. The hostKey field is included only when
+ * a host key was available; when absent the connecting device falls back to a
+ * first-use fingerprint confirmation. Field order matches the documented
+ * format.
+ */
+export function buildBundle(input: ConnectionBundleInput): ConnectionBundle {
+  const bundle: ConnectionBundle = {
+    format: BUNDLE_FORMAT,
+    kind: 'connection',
+    displayName: input.displayName,
+    host: input.host,
+    sshPort: input.sshPort,
+    sshUser: input.sshUser,
+    remotePort: REMOTE_PORT,
+    installId: input.installId,
+  }
+  if (input.hostKey !== undefined) {
+    // Insert hostKey before installId to match the documented field order.
+    return {
+      format: bundle.format,
+      kind: bundle.kind,
+      displayName: bundle.displayName,
+      host: bundle.host,
+      sshPort: bundle.sshPort,
+      sshUser: bundle.sshUser,
+      remotePort: bundle.remotePort,
+      hostKey: input.hostKey,
+      installId: bundle.installId,
+    }
+  }
+  return bundle
+}
+
+/** Encode a bundle as a single-line base64 string. */
+export function encodeBundle(bundle: ConnectionBundle): string {
+  return Buffer.from(JSON.stringify(bundle), 'utf8').toString('base64')
+}
+
+/** Decode a base64 bundle back to an object. Exposed for tests and tooling. */
+export function decodeBundle(encoded: string): ConnectionBundle {
+  return JSON.parse(Buffer.from(encoded, 'base64').toString('utf8')) as ConnectionBundle
+}

--- a/src/remote-enroll-fs.ts
+++ b/src/remote-enroll-fs.ts
@@ -1,0 +1,205 @@
+// Filesystem side of remote access key enrollment.
+//
+// Kept separate from the pure logic in remote-enroll-core.ts so the read-
+// modify-write, permission handling, atomic replace, and lockfile behaviour
+// can be tested against a temporary directory instead of the real ~/.ssh.
+
+import {
+  openSync,
+  closeSync,
+  writeSync,
+  fsyncSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  mkdirSync,
+  statSync,
+  existsSync,
+  chmodSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { mergeAuthorizedKeys, type MergeAction } from './remote-enroll-core.js'
+
+const SSH_DIR_MODE = 0o700
+const AUTH_KEYS_MODE = 0o600
+const AUTH_KEYS_NAME = 'authorized_keys'
+const LOCK_NAME = 'authorized_keys.lock'
+
+export interface EnrollOptions {
+  /** Absolute path to the .ssh directory (real one is ~/.ssh; tests override). */
+  sshDir: string
+  /** The exact restricted line to write. */
+  restrictedLine: string
+  /** Install id used to find a prior enrollment to replace. */
+  installId: string
+  /** Max lock acquisition attempts. Default 20. */
+  lockRetries?: number
+  /** Delay between lock attempts in ms. Default 100. */
+  lockRetryDelayMs?: number
+  /** A lockfile older than this (ms) is treated as stale and removed. Default 15000. */
+  staleLockMs?: number
+  /** Sleep implementation; injectable for tests. */
+  sleep?: (ms: number) => Promise<void>
+}
+
+export interface EnrollResult {
+  action: MergeAction
+  authorizedKeysPath: string
+  warnings: string[]
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+/** True when a mode grants any permission beyond the given owner-only mask. */
+function looserThan(mode: number, ownerMask: number): boolean {
+  return (mode & 0o777 & ~ownerMask) !== 0
+}
+
+function fmtMode(mode: number): string {
+  return '0' + (mode & 0o777).toString(8).padStart(3, '0')
+}
+
+/**
+ * Ensure the .ssh directory exists with 0700. If it already exists with looser
+ * permissions, warn but do not change it.
+ */
+function ensureSshDir(sshDir: string, warnings: string[]): void {
+  if (!existsSync(sshDir)) {
+    mkdirSync(sshDir, { recursive: true, mode: SSH_DIR_MODE })
+    // mkdir mode is subject to umask; enforce explicitly.
+    chmodSync(sshDir, SSH_DIR_MODE)
+    return
+  }
+  const st = statSync(sshDir)
+  if (!st.isDirectory()) {
+    throw new Error(`${sshDir} exists but is not a directory`)
+  }
+  if (looserThan(st.mode, SSH_DIR_MODE)) {
+    warnings.push(
+      `${sshDir} permissions are ${fmtMode(st.mode)} (looser than 0700); leaving as-is`,
+    )
+  }
+}
+
+/**
+ * Acquire an exclusive lock via O_EXCL. Retries on contention and removes a
+ * stale lockfile whose mtime is older than staleLockMs. Returns the lock file
+ * descriptor; the caller must releaseLock() it.
+ */
+async function acquireLock(
+  lockPath: string,
+  retries: number,
+  delayMs: number,
+  staleMs: number,
+  sleep: (ms: number) => Promise<void>,
+): Promise<number> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      // 'wx' => O_CREAT | O_EXCL: fails if the file already exists.
+      const fd = openSync(lockPath, 'wx', AUTH_KEYS_MODE)
+      try {
+        writeSync(fd, `${process.pid}\n`)
+      } catch {
+        // Non-fatal: the lock is the file's existence, not its contents.
+      }
+      return fd
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+      // Contended. If the existing lock is stale, remove it and retry now.
+      try {
+        const st = statSync(lockPath)
+        if (Date.now() - st.mtimeMs > staleMs) {
+          unlinkSync(lockPath)
+          continue
+        }
+      } catch {
+        // Lock vanished between open and stat; retry immediately.
+        continue
+      }
+      await sleep(delayMs)
+    }
+  }
+  throw new Error(
+    `could not acquire ${lockPath} after ${retries} attempts; another enrollment may be running`,
+  )
+}
+
+function releaseLock(fd: number, lockPath: string): void {
+  try {
+    closeSync(fd)
+  } catch {
+    /* ignore */
+  }
+  try {
+    unlinkSync(lockPath)
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Enroll (append or replace-by-id) the restricted line into
+ * <sshDir>/authorized_keys with an atomic read-modify-write guarded by an
+ * O_EXCL lockfile. Never reads back or logs other users' keys; only reports
+ * the action taken and any permission warnings.
+ */
+export async function enrollAuthorizedKey(opts: EnrollOptions): Promise<EnrollResult> {
+  const {
+    sshDir,
+    restrictedLine,
+    installId,
+    lockRetries = 20,
+    lockRetryDelayMs = 100,
+    staleLockMs = 15000,
+    sleep = defaultSleep,
+  } = opts
+  const warnings: string[] = []
+  const authPath = join(sshDir, AUTH_KEYS_NAME)
+  const lockPath = join(sshDir, LOCK_NAME)
+
+  ensureSshDir(sshDir, warnings)
+
+  const fd = await acquireLock(lockPath, lockRetries, lockRetryDelayMs, staleLockMs, sleep)
+  try {
+    let existing = ''
+    if (existsSync(authPath)) {
+      const st = statSync(authPath)
+      if (looserThan(st.mode, AUTH_KEYS_MODE)) {
+        warnings.push(
+          `${authPath} permissions were ${fmtMode(st.mode)} (looser than 0600); the rewritten file is 0600`,
+        )
+      }
+      existing = readFileSync(authPath, 'utf8')
+    }
+
+    const { content, action } = mergeAuthorizedKeys(existing, restrictedLine, installId)
+
+    // Atomic write: temp file in the same directory (same filesystem), 0600,
+    // fsync, then rename over the target.
+    const tmpPath = join(sshDir, `.${AUTH_KEYS_NAME}.${process.pid}.${Date.now()}.tmp`)
+    const tfd = openSync(tmpPath, 'wx', AUTH_KEYS_MODE)
+    try {
+      writeSync(tfd, content)
+      fsyncSync(tfd)
+    } finally {
+      closeSync(tfd)
+    }
+    // Enforce mode explicitly in case umask trimmed the create mode.
+    chmodSync(tmpPath, AUTH_KEYS_MODE)
+    try {
+      renameSync(tmpPath, authPath)
+    } catch (err) {
+      try {
+        unlinkSync(tmpPath)
+      } catch {
+        /* ignore */
+      }
+      throw err
+    }
+
+    return { action, authorizedKeysPath: authPath, warnings }
+  } finally {
+    releaseLock(fd, lockPath)
+  }
+}


### PR DESCRIPTION
## Summary
- New `npm run remote-enroll -- "<public key line>"` operator helper that enrolls a single device's SSH public key into the invoking user's `~/.ssh/authorized_keys` with a tightly restricted entry, then prints a base64 connection bundle between clear delimiters.
- Strict validation: exactly three fields (`ssh-ed25519 <base64> marveen-remote:<uuid v4>`), OpenSSH wire-format blob check (embedded type + 32-byte key + no trailing bytes), no options or extra fields accepted.
- Written entry: `restrict,port-forwarding,permitopen="127.0.0.1:3420",command="/bin/false" ...` -- no pty/agent/X11, forced command, single loopback endpoint only.
- Replace-by-id: re-enrolling the same `marveen-remote:<uuid>` replaces that device's line in place; other lines preserved byte-for-byte. Revocation = delete the line with that comment.
- Safe writes: O_EXCL lockfile with stale takeover, temp-file + fsync + rename atomic replace, `.ssh` 0700 / `authorized_keys` 0600 enforced on create, warn-only on pre-existing looser modes.
- Bundle (`marveen-remote/1`) carries host, SSH port/user, fixed remote port 3420, device id, and the machine's ed25519 host key when `/etc/ssh/ssh_host_ed25519_key.pub` is readable (otherwise omitted with a warning; connecting side falls back to first-use fingerprint confirmation).
- Pure logic split into `src/remote-enroll-core.ts` (validation/merge/bundle) and `src/remote-enroll-fs.ts` (lock + atomic write) for testability; README section added.

## Test plan
- [x] `npx vitest run`: 187 files / 2578 tests pass (includes 2 new suites: core validation/merge/bundle, fs lock/atomic/permissions)
- [x] `npx tsc --noEmit` clean
- [x] Functional test against a temp `$HOME`: first enroll writes the exact restricted line with 0700/0600 modes and a decodable bundle; re-enroll with the same id replaces in place (1 line, new key); a second device id appends (2 lines); `ssh-rsa` and option-prefixed lines rejected with clear errors and exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)