### PR TITLE
feat(dashboard): Kutatás oldal -- read-only néző az ágensek research/ mappáihoz

### DIFF
--- a/docs/kutatas.md
+++ b/docs/kutatas.md
@@ -1,0 +1,51 @@
+# Kutatás oldal
+
+Az ágensek a hosszabb kutatási anyagaikat a saját `research/` mappájukba írják: piac- és
+versenytárs-elemzést, landing-teardownt, incidens-diagnózist, bármit ami túl terjedelmes
+ahhoz, hogy csevegésben elférjen. A **Kutatás** oldal ezeket teszi olvashatóvá a
+dashboardon, hogy ne kelljen SSH-zni egy anyagért, amit te magad kértél.
+
+Az oldal **csak olvas**. Nincs benne feltöltés, szerkesztés és törlés.
+
+## Használat
+
+A bal oldali sávban a **Kutatás** menüpontra kattintva a lista ágensenként csoportosítva
+mutatja a dokumentumokat: minden ágens neve fejlécként jelenik meg, alatta a saját
+anyagai. Egy elemre kattintva a jobb oldalon megjelenik a megformázott tartalom, ahonnan
+letöltheted az eredeti Markdown fájlt.
+
+A sorrend a legutóbbi módosítás szerinti, a legfrissebb elöl. Az azonos napon módosított
+anyagok név szerint rendeződnek. Minden elem mellett látszik a módosítás dátuma.
+
+Az a lista, amelyikhez egyetlen anyag sem tartozik, nem jelenik meg -- az üres ágensek
+nem foglalnak helyet a nézetben.
+
+## Honnan olvas
+
+| Ágens | Mappa |
+|-------|-------|
+| Fő ágens | a projekt gyökerében lévő `research/` |
+| Sub-ágensek | `agents/<nev>/research/` |
+
+Csak `.md` kiterjesztésű fájlok jelennek meg. A dokumentum címe az első `#` fejléc a
+fájlban; ha nincs benne fejléc, a fájlnév marad a cím.
+
+Új anyag megjelenítéséhez semmit nem kell beállítani: elég a megfelelő `research/`
+mappába írni egy Markdown fájlt, és a következő betöltésnél már ott lesz.
+
+## Végpontok
+
+Mindkét végpont `GET`, és ugyanaz a Bearer-token védi, mint a többi `/api/*` útvonalat.
+
+| Végpont | Válasz |
+|---------|--------|
+| `/api/research` | `[{agent, docs: [{name, title, updated}]}]` -- ágensenként csoportosított lista |
+| `/api/research/<agent>/<fajlnev>.md` | `{agent, name, title, content}` -- egy dokumentum tartalma |
+
+## Biztonság
+
+- Az útvonal kizárólag olvas: nincs író, törlő vagy feltöltő művelet.
+- A fájlnév mintára van szűrve (`^[A-Za-z0-9._-]+\.md$`), és a `basename` egyezését is
+  ellenőrzi a kód -- a könyvtár-bejárásos próbálkozás (`../`) `400`-zal elszáll.
+- Ismeretlen ágens-név `404`-et ad, nem szivárogtat könyvtár-szerkezetet.
+- A `research/` mappán kívülre az oldal nem lát ki.

--- a/src/__tests__/research-routes.test.ts
+++ b/src/__tests__/research-routes.test.ts
@@ -1,0 +1,94 @@
+// Functional tests for the read-only research viewer (routes/research.ts).
+// Exercises the real handler against temporary fixture dirs, with emphasis on
+// the path-traversal arm: encoded ../ sequences, non-.md names, and unknown
+// agents must all be rejected before any filesystem read happens.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tryHandleResearch } from '../web/routes/research.js'
+import { PROJECT_ROOT, MAIN_AGENT_ID } from '../config.js'
+import { agentDir } from '../web/agent-config.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+function fakeCtx(path: string, method = 'GET'): { ctx: RouteContext; out: { status: number; body: any } } {
+  const out: { status: number; body: any } = { status: 0, body: null }
+  const res: any = {
+    writeHead(status: number) { out.status = status; return res },
+    end(chunk?: string) { if (chunk) out.body = JSON.parse(chunk) },
+  }
+  const url = new URL(`http://localhost:3420${path}`)
+  const ctx = { req: {} as any, res, path: url.pathname, method, url } as RouteContext
+  return { ctx, out }
+}
+
+const SUB_AGENT_ID = 'zz-research-test-sub'
+const SUB_RESEARCH_DIR = join(agentDir(SUB_AGENT_ID), 'research')
+const MAIN_RESEARCH_DIR = join(PROJECT_ROOT, 'research')
+const MAIN_SEED = join(MAIN_RESEARCH_DIR, 'zz-test-main-research.md')
+
+describe('research routes', () => {
+  beforeEach(() => {
+    mkdirSync(SUB_RESEARCH_DIR, { recursive: true })
+    writeFileSync(join(SUB_RESEARCH_DIR, 'alpha.md'), '# Alpha Report\n\nBody\n')
+    mkdirSync(MAIN_RESEARCH_DIR, { recursive: true })
+    writeFileSync(MAIN_SEED, '# Main Research\n\nBody\n')
+  })
+  afterEach(() => {
+    rmSync(agentDir(SUB_AGENT_ID), { recursive: true, force: true })
+    rmSync(MAIN_SEED, { force: true })
+  })
+
+  it('lists seeded docs for sub-agent and main agent', async () => {
+    const { ctx, out } = fakeCtx('/api/research')
+    expect(await tryHandleResearch(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    const sub = out.body.find((a: any) => a.agent === SUB_AGENT_ID)
+    expect(sub?.docs.map((d: any) => d.name)).toContain('alpha.md')
+    expect(sub?.docs.find((d: any) => d.name === 'alpha.md')?.title).toBe('Alpha Report')
+    const main = out.body.find((a: any) => a.agent === MAIN_AGENT_ID)
+    expect(main?.docs.map((d: any) => d.name)).toContain('zz-test-main-research.md')
+  })
+
+  it('serves a single doc with content', async () => {
+    const { ctx, out } = fakeCtx(`/api/research/${SUB_AGENT_ID}/alpha.md`)
+    expect(await tryHandleResearch(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    expect(out.body.content).toContain('Alpha Report')
+  })
+
+  it('rejects encoded path traversal in the file name', async () => {
+    // %2e%2e%2f => "../" after the handler's decodeURIComponent
+    const { ctx, out } = fakeCtx(`/api/research/${SUB_AGENT_ID}/%2e%2e%2f%2e%2e%2fsecret.md`)
+    expect(await tryHandleResearch(ctx)).toBe(true)
+    expect(out.status).toBe(400)
+  })
+
+  it('rejects traversal aimed at dotfiles outside research/', async () => {
+    const { ctx, out } = fakeCtx(`/api/research/${SUB_AGENT_ID}/%2e%2e%2f.env`)
+    expect(await tryHandleResearch(ctx)).toBe(true)
+    expect(out.status).toBe(400)
+  })
+
+  it('rejects non-.md file names', async () => {
+    const { ctx, out } = fakeCtx(`/api/research/${SUB_AGENT_ID}/notes.txt`)
+    expect(await tryHandleResearch(ctx)).toBe(true)
+    expect(out.status).toBe(400)
+  })
+
+  it('rejects unknown agents', async () => {
+    const { ctx, out } = fakeCtx('/api/research/zz-no-such-agent/alpha.md')
+    expect(await tryHandleResearch(ctx)).toBe(true)
+    expect(out.status).toBe(404)
+  })
+
+  it('404s on a missing but well-formed file name', async () => {
+    const { ctx, out } = fakeCtx(`/api/research/${SUB_AGENT_ID}/missing.md`)
+    expect(await tryHandleResearch(ctx)).toBe(true)
+    expect(out.status).toBe(404)
+  })
+
+  it('ignores non-research paths', async () => {
+    const { ctx } = fakeCtx('/api/agents')
+    expect(await tryHandleResearch(ctx)).toBe(false)
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -47,6 +47,7 @@ import { tryHandleKanban } from './web/routes/kanban.js'
 import { tryHandleSchedules } from './web/routes/schedules.js'
 import { tryHandleConnectors } from './web/routes/connectors.js'
 import { tryHandleDocs } from './web/routes/docs.js'
+import { tryHandleResearch } from './web/routes/research.js'
 import { tryHandleConnectorsHu } from './web/routes/connectors-hu.js'
 import { tryHandleAgentsSkills } from './web/routes/agents-skills.js'
 import { tryHandleSkills } from './web/routes/skills.js'
@@ -177,6 +178,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleConnectorsHu(routeCtx)) return
       if (await tryHandleConnectors(routeCtx)) return
       if (await tryHandleDocs(routeCtx)) return
+      if (await tryHandleResearch(routeCtx)) return
       if (await tryHandleAgentsSkills(routeCtx)) return
       if (await tryHandleSkills(routeCtx)) return
       if (await tryHandleAgentTerminal(routeCtx)) return

--- a/src/web/routes/research.ts
+++ b/src/web/routes/research.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, basename } from 'node:path'
+import { MAIN_AGENT_ID } from '../../config.js'
+import { agentConfigRoot, listAgentNames } from '../agent-config.js'
+import { json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+// Read-only viewer for each agent's research/ folder (agents/<name>/research/,
+// or the project root for the main agent). Mirrors routes/docs.ts: everything
+// sits under /api/* (bearer-token gated), nothing is writable, and filenames
+// are allowlisted + basename-checked to block path traversal.
+const NAME_RE = /^[A-Za-z0-9._-]+\.md$/
+
+function titleOf(content: string, fallback: string): string {
+  const m = content.match(/^#\s+(.+)$/m)
+  return m ? m[1].trim() : fallback
+}
+
+function researchDir(agent: string): string {
+  return join(agentConfigRoot(agent), 'research')
+}
+
+export async function tryHandleResearch(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method } = ctx
+
+  if (path === '/api/research' && method === 'GET') {
+    const agents = [MAIN_AGENT_ID, ...listAgentNames()]
+    const result = agents.map(agent => {
+      const dir = researchDir(agent)
+      let files: string[] = []
+      try {
+        files = readdirSync(dir).filter(
+          f => NAME_RE.test(f) && statSync(join(dir, f)).isFile(),
+        )
+      } catch {
+        files = []
+      }
+      const docs = files
+        .map(name => {
+          let title = name
+          let ms = 0
+          try {
+            const file = join(dir, name)
+            title = titleOf(readFileSync(file, 'utf-8'), name)
+            ms = statSync(file).mtimeMs
+          } catch {
+            /* keep filename as title */
+          }
+          return { name, title, ms }
+        })
+        .sort((a, b) => (b.ms - a.ms) || a.name.localeCompare(b.name))
+        .map(({ name, title, ms }) => ({ name, title, updated: new Date(ms).toISOString().slice(0, 10) }))
+      return { agent, docs }
+    }).filter(a => a.docs.length > 0)
+    json(res, result)
+    return true
+  }
+
+  const match = path.match(/^\/api\/research\/([^/]+)\/([^/]+)$/)
+  if (match && method === 'GET') {
+    const agent = decodeURIComponent(match[1])
+    const name = decodeURIComponent(match[2])
+    if (!NAME_RE.test(name) || basename(name) !== name) {
+      json(res, { error: 'Invalid file name' }, 400)
+      return true
+    }
+    const agents = [MAIN_AGENT_ID, ...listAgentNames()]
+    if (!agents.includes(agent)) {
+      json(res, { error: 'Unknown agent' }, 404)
+      return true
+    }
+    const file = join(researchDir(agent), name)
+    if (!existsSync(file) || !statSync(file).isFile()) {
+      json(res, { error: 'Not found' }, 404)
+      return true
+    }
+    const content = readFileSync(file, 'utf-8')
+    json(res, { agent, name, title: titleOf(content, name), content })
+    return true
+  }
+
+  return false
+}

--- a/web/app.js
+++ b/web/app.js
@@ -418,7 +418,7 @@ const NAV_I18N = {
   recall: 'nav.recall', naplo: 'nav.recall', bgTasks: 'nav.bgTasks',
   skills: 'nav.skills', connectors: 'nav.connectors', migrate: 'nav.migrate',
   approvals: 'nav.approvals',
-  docs: 'nav.docs', research: 'nav.research', status: 'nav.status', autonomy: 'nav.autonomy',
+  docs: 'nav.docs', research: 'nav.research', status: 'nav.status',
   settings: 'nav.settings', vault: 'nav.vault', tokenUsage: 'nav.tokenUsage',
   ideas: 'nav.ideas', federation: 'nav.federation', updates: 'nav.updates', costs: 'nav.costs',
 }

--- a/web/app.js
+++ b/web/app.js
@@ -361,6 +361,7 @@ function switchPage(pageId) {
   if (pageId === 'connectors') loadConnectors()
   if (pageId === 'migrate') loadMigrateAgents()
   if (pageId === 'docs') loadDocs()
+  if (pageId === 'research') loadResearch()
   if (pageId === 'status') loadStatus()
   if (pageId === 'recall') loadRecallPage()
   if (pageId === 'bgTasks') loadBgTasksPage()
@@ -417,6 +418,7 @@ const NAV_I18N = {
   recall: 'nav.recall', naplo: 'nav.recall', bgTasks: 'nav.bgTasks',
   skills: 'nav.skills', connectors: 'nav.connectors', migrate: 'nav.migrate',
   approvals: 'nav.approvals',
+  docs: 'nav.docs', research: 'nav.research', status: 'nav.status', autonomy: 'nav.autonomy',
   settings: 'nav.settings', vault: 'nav.vault', tokenUsage: 'nav.tokenUsage',
   ideas: 'nav.ideas', federation: 'nav.federation', updates: 'nav.updates', costs: 'nav.costs',
 }
@@ -451,6 +453,7 @@ const PAGE_HEADER_I18N = {
   connectorsPage: { title: 'connectors.page_title',  sub: 'connectors.page_subtitle' },
   migratePage:    { title: 'migrate.page_title',     sub: 'migrate.page_subtitle' },
   docsPage:       { title: 'docs.page_title',        sub: 'docs.page_subtitle' },
+  researchPage:   { title: 'research.page_title',    sub: 'research.page_subtitle' },
   statusPage:     { title: 'status.page_title',      sub: 'status.page_subtitle' },
   teamPage:       { title: 'team.page_title',        sub: 'team.page_subtitle' },
   messagesPage:   { title: 'messages.page_title',    sub: 'messages.page_subtitle' },
@@ -14833,6 +14836,72 @@ function downloadMarkdown(name, content) {
     setTimeout(() => URL.revokeObjectURL(url), 1000)
   } catch (e) {
     showToast(t('common.toast.download_failed', { msg: String(e && e.message || e) }))
+  }
+}
+
+// === Research (read-only viewer for each agent's research/ folder) ===
+// Mirrors the Docs tab above, but the API groups docs by agent
+// ([{agent, docs:[{name,title,updated}]}]), so the list needs a per-agent
+// header and each item's dataset carries both agent+name for the detail
+// fetch. Reuses escapeHtml/escapeAttr/renderMarkdown/downloadMarkdown as-is.
+async function loadResearch() {
+  const listEl = document.getElementById('researchList')
+  const contentEl = document.getElementById('researchContent')
+  if (!listEl) return
+  listEl.innerHTML = '<p class="muted">' + t('research.loading') + '</p>'
+  let groups = []
+  try {
+    const res = await fetch('/api/research')
+    groups = await res.json()
+    if (!Array.isArray(groups)) groups = []
+  } catch (e) {
+    listEl.innerHTML = '<p class="muted">' + t('research.list_load_error') + ': ' + escapeHtml(String(e.message || e)) + '</p>'
+    return
+  }
+  if (!groups.length) {
+    listEl.innerHTML = '<p class="muted">' + t('research.empty_list') + '</p>'
+    if (contentEl) contentEl.innerHTML = '<p class="muted">' + t('research.empty_content') + '</p>'
+    return
+  }
+  listEl.innerHTML = groups.map(g =>
+    '<div class="docs-list-group-label">' + escapeHtml(g.agent) + '</div>' +
+    g.docs.map(d =>
+      '<a href="#" class="docs-list-item" data-agent="' + escapeAttr(g.agent) + '" data-doc="' + escapeAttr(d.name) + '">' +
+        '<span class="docs-list-title">' + escapeHtml(d.title || d.name) + '</span>' +
+        (d.updated ? '<span class="docs-list-date">' + escapeHtml(d.updated) + '</span>' : '') +
+      '</a>'
+    ).join('')
+  ).join('')
+  listEl.querySelectorAll('.docs-list-item').forEach(a => {
+    a.addEventListener('click', (e) => {
+      e.preventDefault()
+      listEl.querySelectorAll('.docs-list-item').forEach(x => x.classList.remove('active'))
+      a.classList.add('active')
+      openResearchDoc(a.dataset.agent, a.dataset.doc)
+    })
+  })
+  const first = listEl.querySelector('.docs-list-item')
+  if (first) { first.classList.add('active'); openResearchDoc(first.dataset.agent, first.dataset.doc) }
+}
+
+async function openResearchDoc(agent, name) {
+  const contentEl = document.getElementById('researchContent')
+  if (!contentEl) return
+  contentEl.innerHTML = '<p class="muted">' + t('research.loading') + '</p>'
+  try {
+    const res = await fetch('/api/research/' + encodeURIComponent(agent) + '/' + encodeURIComponent(name))
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const doc = await res.json()
+    const content = doc.content || ''
+    contentEl.innerHTML =
+      '<div class="docs-content-toolbar">' +
+        '<button class="btn-secondary btn-compact" id="researchDownloadBtn">' + t('docs.download_btn') + '</button>' +
+      '</div>' +
+      '<div class="docs-rendered markdown-body">' + renderMarkdown(content) + '</div>'
+    const dl = document.getElementById('researchDownloadBtn')
+    if (dl) dl.addEventListener('click', () => downloadMarkdown(name, content))
+  } catch (e) {
+    contentEl.innerHTML = '<p class="muted">' + t('research.open_error') + ': ' + escapeHtml(String(e.message || e)) + '</p>'
   }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -128,6 +128,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
         <span class="sb-label">Dokumentáció</span>
       </a>
+      <a href="#" class="sb-link" data-page="research">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span class="sb-label" data-i18n="nav.research">Kutatás</span>
+      </a>
       <a href="#" class="sb-link" data-page="status">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
         <span class="sb-label">Státusz</span>
@@ -970,6 +974,22 @@
         </aside>
         <article class="docs-content markdown-body" id="docsContent">
           <p class="muted" data-i18n="docs.select_hint">Válassz egy dokumentumot a bal oldali listából.</p>
+        </article>
+      </div>
+    </div>
+
+    <!-- === Research Page === -->
+    <div class="page" id="researchPage" hidden>
+      <div class="page-header">
+        <h1 data-i18n="research.page_title">Kutatás</h1>
+        <p class="subtitle" data-i18n="research.page_subtitle">Ágensek research/ mappái, olvasható formában</p>
+      </div>
+      <div class="docs-layout">
+        <aside class="docs-list" id="researchList">
+          <p class="muted" data-i18n="research.loading">Betöltés...</p>
+        </aside>
+        <article class="docs-content markdown-body" id="researchContent">
+          <p class="muted" data-i18n="research.select_hint">Válassz egy dokumentumot a bal oldali listából.</p>
         </article>
       </div>
     </div>

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -81,6 +81,7 @@ window._i18n.en = {
   'nav.connectors':   'MCP',
   'nav.migrate':      'Migrate',
   'nav.docs':         'Documentation',
+  'nav.research':     'Research',
   'nav.status':       'Status',
   'nav.approvals':    'Approvals',
   'nav.settings':     'Settings',
@@ -581,6 +582,16 @@ window._i18n.en = {
   'docs.empty_content':          'No documents to display.',
   'docs.download_btn':           '⬇ Download .md',
   'docs.open_error':             'Failed to open',
+
+  // --- Research ---
+  'research.page_title':         'Research',
+  'research.page_subtitle':      "Each agent's research/ folder in readable form",
+  'research.loading':            'Loading...',
+  'research.select_hint':        'Select a document from the list on the left.',
+  'research.list_load_error':    'Failed to load the list',
+  'research.empty_list':         'No research documents found.',
+  'research.empty_content':      'No documents to display.',
+  'research.open_error':         'Failed to open',
 
   // --- Status ---
   'status.page_title':           'Status',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -81,6 +81,7 @@ window._i18n.hu = {
   'nav.connectors':   'MCP',
   'nav.migrate':      'Költöztetés',
   'nav.docs':         'Dokumentáció',
+  'nav.research':     'Kutatás',
   'nav.status':       'Státusz',
   'nav.approvals':    'Jóváhagyások',
   'nav.settings':     'Beállítások',
@@ -832,6 +833,16 @@ window._i18n.hu = {
   'docs.empty_content':          'Nincs megjeleníthető dokumentum.',
   'docs.download_btn':           '⬇ .md letöltés',
   'docs.open_error':             'Nem sikerült megnyitni',
+
+  // --- Research ---
+  'research.page_title':         'Kutatás',
+  'research.page_subtitle':      'Ágensek research/ mappái, olvasható formában',
+  'research.loading':            'Betöltés...',
+  'research.select_hint':        'Válassz egy dokumentumot a bal oldali listából.',
+  'research.list_load_error':    'Nem sikerült betölteni a listát',
+  'research.empty_list':         'Nincs kutatási anyag.',
+  'research.empty_content':      'Nincs megjeleníthető dokumentum.',
+  'research.open_error':         'Nem sikerült megnyitni',
 
   // --- Status ---
   'status.page_title':           'Státusz',

--- a/web/style.css
+++ b/web/style.css
@@ -6587,6 +6587,15 @@ main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
   color: var(--text-muted, #888);
   font-variant-numeric: tabular-nums;
 }
+.docs-list-group-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #888);
+  padding: 10px 12px 2px;
+}
+.docs-list-group-label:first-child { padding-top: 0; }
 .docs-list-item:hover { background: var(--surface-2, rgba(127,127,127,0.08)); }
 .docs-list-item.active {
   background: var(--surface-2, rgba(127,127,127,0.12));


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** Az ágensek a hosszabb kutatási anyagaikat a saját `research/` mappájukba írják (piac- és versenytárs-elemzés, teardown, incidens-diagnózis). Ezekhez eddig csak fájlrendszer-hozzáféréssel lehetett hozzáférni: a dashboardon nem látszottak, így a gazdának SSH-znia kellett, hogy elolvasson egy anyagot, amit maga kért.

Ez a PR egy read-only **Kutatás** oldalt ad a dashboardhoz, a meglévő Dokumentáció (Docs) fül mintájára. Az eltérés annyi, hogy az API ágensenként csoportosít (`[{agent, docs:[{name,title,updated}]}]`), így a lista ágens-fejlécet kap, és minden elem `dataset`-je viszi az `agent`+`name` párost a részlet-lekéréshez. A meglévő `escapeHtml` / `escapeAttr` / `renderMarkdown` / `downloadMarkdown` segédfüggvények változatlanul újrahasznosítva -- nincs új renderelő ág.

Az útvonal **csak olvas**: nincs írás, törlés, feltöltés. A fájlnév mintára szűrt (`^[A-Za-z0-9._-]+\.md$`) és `basename`-ellenőrzött a könyvtár-bejárás ellen, ismeretlen ágens `404`-et kap, és a Bearer-token ugyanúgy védi, mint a többi `/api/*` végpontot.

**EN:** Agents write their longer research output into their own `research/` folder (market and competitor analysis, teardowns, incident diagnoses). Until now these were reachable only through the filesystem -- invisible on the dashboard, so the owner had to SSH in to read a document they commissioned themselves.

This PR adds a read-only **Research** page to the dashboard, mirroring the existing Docs tab. The one difference: the API groups documents per agent (`[{agent, docs:[{name,title,updated}]}]`), so the list renders a per-agent header and each item's `dataset` carries both `agent` and `name` for the detail fetch. The existing `escapeHtml` / `escapeAttr` / `renderMarkdown` / `downloadMarkdown` helpers are reused as-is -- no new rendering path.

The route is **read-only**: no writes, deletes or uploads. Filenames are pattern-allowlisted (`^[A-Za-z0-9._-]+\.md$`) and basename-checked against path traversal, unknown agents get a `404`, and it is Bearer-gated like every other `/api/*` endpoint.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
