### PR TITLE
fix(recovery): break the parked-input typing-deadlock that permanently mutes the main channel

### DIFF
--- a/src/__tests__/parked-machine-input.test.ts
+++ b/src/__tests__/parked-machine-input.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parkedScheduledTaskInput,
+  parkedMachineOriginInput,
+  parkedMainInputHasRemedy,
+} from '../pane-state.js'
+
+// 2026-07-25 hermes incident coverage: a multi-row scheduled-task heartbeat
+// parked at the MAIN session's ❯ prompt. detectPaneState reads 'typing', the
+// pre-fix decideStuckInputAction had no move ('hold'), and the blanket
+// 'typing' defer kept both the hard restart and the keepalive respawn away
+// forever -> channel permanently mute. These fixtures mirror the real
+// captured pane (same box-drawing bytes as pane-state.test.ts).
+const SEP = '─'.repeat(80)
+const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+
+const PARKED_SCHEDULED_MULTIROW = [
+  '',
+  SEP,
+  '❯ SCHEDULED TASK NOTICE -- the next <scheduled-task source="..."> ...',
+  '  </scheduled-task> block is one of YOUR OWN scheduled tasks. It was authored',
+  '  by the operator (the task\'s SKILL.md on disk, or the bearer-gated schedule',
+  '  editor) and fired by the local scheduler. <scheduled-task',
+  '  source="scheduled-task:hermes-soak-orszem"> # Hermes VPS develop-soak',
+  '  őrszem ... </scheduled-task>',
+  SEP,
+  FOOTER,
+].join('\n')
+
+const PARKED_BARE_SCHEDULED_TAG = [
+  '',
+  SEP,
+  '❯ <scheduled-task source="scheduled-task:reggeli-napindito"> # Reggeli',
+  '  napindító ... </scheduled-task>',
+  SEP,
+  FOOTER,
+].join('\n')
+
+const PARKED_INTERAGENT = [
+  '',
+  SEP,
+  '❯ [Uzenet @marveen-tol -- trusted team member, msg_id:42]: <trusted-peer',
+  '  source="agent:marveen"> Kérlek nézd át a PR-t. </trusted-peer>',
+  SEP,
+  FOOTER,
+].join('\n')
+
+const PARKED_CHANNEL_COMPLETE = [
+  '',
+  SEP,
+  '❯ <channel source="plugin:telegram" chat_id="123">rövid üzenet</channel>',
+  SEP,
+  FOOTER,
+].join('\n')
+
+// A human's own multi-line draft: no machine wrapper prefix. The recovery
+// stack must leave it alone (no clear, no restart).
+const PARKED_HUMAN_DRAFT = [
+  '',
+  SEP,
+  '❯ Szia Marveen, ezt még átgondolom: a holnapi meetingen szerintem',
+  '  SCHEDULED TASK NOTICE témát is hozzuk fel, meg a soak-ot',
+  SEP,
+  FOOTER,
+].join('\n')
+
+const IDLE = ['', SEP, '❯ ', SEP, FOOTER].join('\n')
+
+describe('parkedScheduledTaskInput', () => {
+  it('detects a parked scheduler wrapper block', () => {
+    expect(parkedScheduledTaskInput(PARKED_SCHEDULED_MULTIROW)).toBe(true)
+  })
+
+  it('detects a bare parked <scheduled-task> block', () => {
+    expect(parkedScheduledTaskInput(PARKED_BARE_SCHEDULED_TAG)).toBe(true)
+  })
+
+  it('ignores an inter-agent message (not a scheduled tick)', () => {
+    expect(parkedScheduledTaskInput(PARKED_INTERAGENT)).toBe(false)
+  })
+
+  it('ignores a human draft that merely QUOTES the wrapper mid-text', () => {
+    expect(parkedScheduledTaskInput(PARKED_HUMAN_DRAFT)).toBe(false)
+  })
+
+  it('ignores an idle pane', () => {
+    expect(parkedScheduledTaskInput(IDLE)).toBe(false)
+  })
+})
+
+describe('parkedMachineOriginInput', () => {
+  it('recognises scheduler, inter-agent and channel wrappers as machine-origin', () => {
+    expect(parkedMachineOriginInput(PARKED_SCHEDULED_MULTIROW)).toBe(true)
+    expect(parkedMachineOriginInput(PARKED_INTERAGENT)).toBe(true)
+    expect(parkedMachineOriginInput(PARKED_CHANNEL_COMPLETE)).toBe(true)
+  })
+
+  it('a human draft is NOT machine-origin, even when it quotes a wrapper', () => {
+    expect(parkedMachineOriginInput(PARKED_HUMAN_DRAFT)).toBe(false)
+  })
+
+  it('an idle pane parks nothing', () => {
+    expect(parkedMachineOriginInput(IDLE)).toBe(false)
+  })
+})
+
+describe('parkedMainInputHasRemedy', () => {
+  it('a parked scheduled-task tick HAS a remedy now (clear-scheduled)', () => {
+    expect(parkedMainInputHasRemedy(PARKED_SCHEDULED_MULTIROW)).toBe(true)
+  })
+
+  it('a complete <channel> block has a remedy (chat_id-safe re-inject)', () => {
+    expect(parkedMainInputHasRemedy(PARKED_CHANNEL_COMPLETE)).toBe(true)
+  })
+
+  it('a multi-row inter-agent block on main has NO soft remedy -> restart carve-out territory', () => {
+    expect(parkedMainInputHasRemedy(PARKED_INTERAGENT)).toBe(false)
+  })
+
+  it('a multi-row human draft has no remedy either -- but the carve-out never restarts it (machineOrigin=false)', () => {
+    expect(parkedMainInputHasRemedy(PARKED_HUMAN_DRAFT)).toBe(false)
+  })
+})

--- a/src/__tests__/stuck-input-action.test.ts
+++ b/src/__tests__/stuck-input-action.test.ts
@@ -49,6 +49,7 @@ function facts(over: Partial<StuckInputActionFacts>): StuckInputActionFacts {
     truncatedPreamble: false,
     allowPlainReinject: false,
     hasPlainText: false,
+    scheduledTaskBlock: false,
     ...over,
   }
 }
@@ -98,6 +99,31 @@ describe('decideStuckInputAction (recovery-decision unit)', () => {
 
   it('single-row default (swallowed Enter) -> bare Enter', () => {
     expect(decideStuckInputAction(facts({ rowCount: 1, escalate: true }))).toBe('enter')
+  })
+
+  // 2026-07-25 hermes incident: a multi-row scheduled-task tick parked on the
+  // MAIN session (no plain re-inject) used to fall into the no-remedy 'hold'
+  // branch forever -> channel permanently mute. Clear-only is the safe move:
+  // the next schedule fire re-delivers, while re-injecting risks TUI mid-text
+  // truncation corrupting the instruction.
+  it('multi-row parked scheduled-task tick on main -> clear-scheduled, not hold', () => {
+    const a = decideStuckInputAction(facts({ rowCount: 6, scheduledTaskBlock: true }))
+    expect(a).toBe('clear-scheduled')
+  })
+
+  it('escalated single-row scheduled-task tick -> clear-scheduled', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, scheduledTaskBlock: true, escalate: true }))).toBe('clear-scheduled')
+  })
+
+  it('single-row scheduled-task tick pre-escalation still tries the harmless Enter', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, scheduledTaskBlock: true, escalate: false }))).toBe('enter')
+  })
+
+  it('sub-agent plain re-inject keeps precedence over clear-scheduled (existing path preserved)', () => {
+    const a = decideStuckInputAction(
+      facts({ rowCount: 3, scheduledTaskBlock: true, allowPlainReinject: true, hasPlainText: true }),
+    )
+    expect(a).toBe('reinject-plain')
   })
 })
 

--- a/src/__tests__/stuck-input-restart.test.ts
+++ b/src/__tests__/stuck-input-restart.test.ts
@@ -85,4 +85,31 @@ describe('applyStuckRestartBusyGuard', () => {
     expect(applyStuckRestartBusyGuard('idle', 'skip')).toBe('skip')
     expect(applyStuckRestartBusyGuard('busy', 'skip')).toBe('skip')
   })
+
+  // Deadlock carve-out (2026-07-25 hermes incident): a parked machine-injected
+  // block with NO soft remedy must not defer forever -- the keepalive backstop
+  // defers on the same 'typing' signal, so the blanket defer muted the channel
+  // permanently. Restart is allowed ONLY for machine-origin + no-remedy.
+  describe('typing deadlock carve-out', () => {
+    it('restarts a machine-origin parked input that soft recovery cannot fix', () => {
+      expect(applyStuckRestartBusyGuard('typing', 'restart', { machineOrigin: true, softRemedy: false })).toBe('restart')
+      expect(applyStuckRestartBusyGuard('typing', 'alert', { machineOrigin: true, softRemedy: false })).toBe('alert')
+    })
+
+    it('keeps deferring while soft recovery still has a move (channel-block re-inject)', () => {
+      expect(applyStuckRestartBusyGuard('typing', 'restart', { machineOrigin: true, softRemedy: true })).toBe('skip')
+    })
+
+    it('keeps deferring for a possibly human draft (not machine-origin)', () => {
+      expect(applyStuckRestartBusyGuard('typing', 'restart', { machineOrigin: false, softRemedy: false })).toBe('skip')
+    })
+
+    it('a busy pane always defers, carve-out or not', () => {
+      expect(applyStuckRestartBusyGuard('busy', 'restart', { machineOrigin: true, softRemedy: false })).toBe('skip')
+    })
+
+    it('without carve-out facts the legacy blanket typing-defer applies', () => {
+      expect(applyStuckRestartBusyGuard('typing', 'restart')).toBe('skip')
+    })
+  })
 })

--- a/src/__tests__/welcome-screen-recovery.test.ts
+++ b/src/__tests__/welcome-screen-recovery.test.ts
@@ -58,6 +58,7 @@ describe('welcome-screen wedge: detection -> recovery decision (real fixture)', 
       truncatedPreamble: false,
       allowPlainReinject: true, // sub-agent box: no human draft
       hasPlainText: parkedInputText(QWEN_WELCOME_WEDGE) != null,
+      scheduledTaskBlock: false,
     })
     expect(action).toBe('reinject-plain')
   })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1125,6 +1125,41 @@ export function parkedInputText(pane: string): string | null {
   return flat.length > 0 ? flat : null
 }
 
+// Machine-origin wrappers the delivery paths prepend to injected prompts.
+// A parked input STARTING with one of these cannot be a human's hand-typed
+// draft, so the recovery stack may act on it (clear a scheduled tick, or
+// hard-restart a wedged pane) without risking a human's work-in-progress.
+// Anchored to the box START on purpose: a human draft that merely QUOTES a
+// wrapper deeper in the text stays protected.
+const MACHINE_ORIGIN_PREFIXES = [
+  /^SCHEDULED TASK NOTICE/,
+  /^<scheduled-task[\s>]/,
+  /^TEAM MEMBER NOTICE/,
+  /^\[Uzenet @/,
+  /^<channel\s+source="plugin:/,
+] as const
+
+// True when the live input box holds parked ('typing') text that is
+// identifiably machine-injected (see MACHINE_ORIGIN_PREFIXES). Pure.
+export function parkedMachineOriginInput(pane: string): boolean {
+  const flat = parkedInputText(pane)
+  if (flat == null) return false
+  return MACHINE_ORIGIN_PREFIXES.some((rx) => rx.test(flat))
+}
+
+// True when the parked text is a scheduled-task injection (the scheduler's
+// wrapper or a bare <scheduled-task> block). Scheduled tasks are (near
+// always) RECURRING: dropping one parked tick is harmless -- the next
+// schedule fire re-delivers the same instruction -- while re-injecting is
+// NOT safe (the TUI truncates long box content mid-text, so the visible
+// capture may be missing lines even when the closing tag is visible).
+// The safe recovery for a parked tick is therefore clear-only.
+export function parkedScheduledTaskInput(pane: string): boolean {
+  const flat = parkedInputText(pane)
+  if (flat == null) return false
+  return /^SCHEDULED TASK NOTICE/.test(flat) || /^<scheduled-task[\s>]/.test(flat)
+}
+
 // How many VISUAL rows the live input box content occupies, ignoring the
 // bare prompt glyph and blank padding. The caller uses this to choose the
 // right submit keystroke: a MULTI-row parked input must NOT be submitted with
@@ -1284,6 +1319,7 @@ export type StuckInputAction =
   | 'reinject-block'   // clear + verbatim re-inject the COMPLETE <channel> block (chat_id-safe)
   | 'reinject-plain'   // clear + re-inject collapsed parked text (sub-agents only)
   | 'clear-preamble'   // clear a truncated/stale safety preamble, never re-inject
+  | 'clear-scheduled'  // clear a parked scheduled-task tick, never re-inject (next fire re-delivers)
   | 'enter'            // a single bare Enter -- ONLY safe at rowCount <= 1
   | 'hold'             // do nothing this tick (multi-row truncated / truncation-guard)
 
@@ -1303,6 +1339,9 @@ export interface StuckInputActionFacts {
   allowPlainReinject: boolean
   /** parkedInputText(pane) != null -- there is collapsed text to re-inject. */
   hasPlainText: boolean
+  /** parkedScheduledTaskInput(pane): a scheduled-task tick is parked. Clear-only
+   * is safe on ANY session (the next schedule fire re-delivers). */
+  scheduledTaskBlock: boolean
 }
 
 /**
@@ -1331,6 +1370,13 @@ export function decideStuckInputAction(f: StuckInputActionFacts): StuckInputActi
   if (f.allowPlainReinject && f.hasPlainText && !f.blockTruncated) {
     return f.escalate || multiRow ? 'reinject-plain' : 'enter'
   }
+  // Parked scheduled-task tick (main session reaches here: no plain re-inject).
+  // Clear-only -- re-injecting risks TUI mid-text truncation corrupting the
+  // instruction, while a dropped tick is re-delivered by the next schedule
+  // fire. Single-row still tries the harmless Enter first.
+  if (f.scheduledTaskBlock) {
+    return f.escalate || multiRow ? 'clear-scheduled' : 'enter'
+  }
   // Truncated safety preamble: clear only (never re-inject a stale preamble).
   if (f.truncatedPreamble && f.escalate) return 'clear-preamble'
   // Truncated <channel> block: hold a multi-row (Enter would corrupt; re-inject
@@ -1338,6 +1384,29 @@ export function decideStuckInputAction(f: StuckInputActionFacts): StuckInputActi
   if (f.blockTruncated) return multiRow ? 'hold' : 'enter'
   // Default swallowed-Enter remedy -- never on multi-row.
   return multiRow ? 'hold' : 'enter'
+}
+
+// Would the soft stuck-input recovery have ANY submitting/clearing move for
+// the MAIN session's parked input at full escalation, or is it wedged in the
+// no-remedy 'hold' branch? Used by the hard-restart busy-guard: a 'typing'
+// pane whose soft recovery still has a move keeps deferring the destructive
+// restart (soft path wins without context loss); a no-remedy hold must NOT
+// defer forever or the channel goes permanently mute (2026-07-25 hermes
+// incident: parked multi-row scheduled-task -> hold + 'typing' deferred both
+// the stuck-input hard restart AND the keepalive-staleness respawn).
+export function parkedMainInputHasRemedy(pane: string): boolean {
+  const block = parkedChannelInput(pane)
+  const facts: StuckInputActionFacts = {
+    escalate: true,
+    rowCount: parkedInputRowCount(pane),
+    blockComplete: block != null && block.complete && block.block != null,
+    blockTruncated: block != null && !block.complete,
+    truncatedPreamble: shouldClearTruncatedPreamble(pane),
+    allowPlainReinject: false,
+    hasPlainText: false,
+    scheduledTaskBlock: parkedScheduledTaskInput(pane),
+  }
+  return decideStuckInputAction(facts) !== 'hold'
 }
 
 // =============================================================================

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -32,6 +32,7 @@ import {
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
   parkedInputText, shouldClearTruncatedPreamble,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
+  parkedScheduledTaskInput, parkedMachineOriginInput, parkedMainInputHasRemedy,
   type StuckInputState, type StuckInputThresholds, type StuckInputAction,
   type StuckInputActionFacts,
 } from '../pane-state.js'
@@ -251,14 +252,29 @@ export function decideStuckInputRestart(
 // actively recovering ('typing') -- give soft recovery time to submit instead
 // of nuking the session. A session that is genuinely DEAD (not even soft-
 // recovering) is still caught by the keepalive-staleness watchdog (~18min), the
-// pre-#452 backstop. This narrows the hard restart to unreadable/error panes and
-// leaves the routine parked-input case to the non-destructive soft path.
-// Reuses shouldDeferKeepaliveRespawn (single source of truth for busy/typing).
+// pre-#452 backstop.
+//
+// DEADLOCK CARVE-OUT (2026-07-25 hermes incident): the blanket 'typing' defer
+// muted the channel PERMANENTLY when the parked text had NO soft remedy (a
+// multi-row non-<channel> block on the main session -> decideStuckInputAction
+// 'hold' forever) -- the keepalive backstop defers on the same 'typing' signal,
+// so nothing ever recovered. A 'typing' pane therefore no longer defers when
+// BOTH hold: (1) the parked text is identifiably machine-injected (a known
+// delivery wrapper prefix -- never a human draft mid-composition), and (2) the
+// soft recovery has no move for it ('hold'). Everything else keeps deferring:
+// genuine 'busy', a human-looking draft, and any parked text soft recovery can
+// still submit/clear on its own.
 export function applyStuckRestartBusyGuard(
   paneState: PaneState | null,
   decision: 'restart' | 'alert' | 'skip',
+  opts?: { machineOrigin: boolean; softRemedy: boolean },
 ): 'restart' | 'alert' | 'skip' {
-  return shouldDeferKeepaliveRespawn(paneState) ? 'skip' : decision
+  if (paneState === 'busy') return 'skip'
+  if (paneState === 'typing') {
+    const unrecoverable = opts != null && opts.machineOrigin && !opts.softRemedy
+    return unrecoverable ? decision : 'skip'
+  }
+  return decision
 }
 
 // Session-agnostic stuck-input recovery: capture the pane, and if a channel
@@ -305,6 +321,7 @@ export async function recoverStuckInputForSession(
       truncatedPreamble: shouldClearTruncatedPreamble(pane),
       allowPlainReinject,
       hasPlainText: allowPlainReinject && parkedInputText(pane) != null,
+      scheduledTaskBlock: parkedScheduledTaskInput(pane),
     }
     const action = decideStuckInputAction(facts)
     await performStuckInputAction(session, action, pane, block, sig, attempt)
@@ -349,6 +366,10 @@ async function performStuckInputAction(
       }
       case 'clear-preamble':
         logger.warn({ session, attempt }, 'Stuck input -- truncated safety preamble, clearing buffer (no re-inject)')
+        await clearInputBuffer(session)
+        break
+      case 'clear-scheduled':
+        logger.warn({ session, attempt }, 'Stuck input -- parked scheduled-task tick, clearing buffer (no re-inject; next schedule fire re-delivers)')
         await clearInputBuffer(session)
         break
       case 'enter':
@@ -919,13 +940,23 @@ function maybeRestartWedgedMainChannel(state: StuckInputState): void {
   // blocks a genuine recovery.
   const paneContent = capturePane(MAIN_CHANNELS_SESSION)
   const paneState = paneContent != null ? detectPaneState(paneContent) : null
+  // Deadlock carve-out facts: read from the ghost-stripped parked view (same
+  // view the soft recovery uses) so a dim autocomplete hint never counts.
+  const parkedView = paneState === 'typing' ? captureParkedInputView(MAIN_CHANNELS_SESSION) : null
+  const machineOrigin = parkedView != null && parkedMachineOriginInput(parkedView)
+  const softRemedy = parkedView != null && parkedMainInputHasRemedy(parkedView)
   const action = applyStuckRestartBusyGuard(paneState, decideStuckInputRestart(
     parked, state.attempts, MAIN_STUCK_THRESHOLDS.maxAttempts,
     Date.now(), lastStuckRestartAt, stuckRestartCount,
     STUCK_RESTART_MIN_INTERVAL_MS, STUCK_RESTART_MAX_CONSECUTIVE,
-  ))
+  ), { machineOrigin, softRemedy })
   if (action === 'skip' && shouldDeferKeepaliveRespawn(paneState)) {
-    logger.info({ paneState, attempts: state.attempts }, 'Stuck-input restart deferred -- main pane is busy (working, not wedged)')
+    logger.info(
+      { paneState, attempts: state.attempts, machineOrigin, softRemedy },
+      paneState === 'busy'
+        ? 'Stuck-input restart deferred -- main pane is busy (working, not wedged)'
+        : 'Stuck-input restart deferred -- parked input still recoverable or possibly a human draft',
+    )
   }
   if (action === 'skip') return
   if (action === 'alert') {


### PR DESCRIPTION
## Incident

2026-07-25 ~02:15, hermes develop-soak box: a multi-row scheduled-task heartbeat got parked at the main session's prompt (swallowed submit-Enter). From there every recovery layer deferred on the same `'typing'` pane state, forever:

1. **Soft recovery had no move** -- a multi-row non-`<channel>` text on the main session falls into `decideStuckInputAction`'s `'hold'` branch (bare Enter corrupts, plain re-inject is sub-agent-only). Log: `Stuck input -- multi-row/truncated, holding` every tick.
2. **Hard restart blocked** -- `applyStuckRestartBusyGuard` skipped on `'typing'` ("still actively recovering" -- false: it was holding with no remedy). Log: `Stuck-input restart deferred -- main pane is busy (working, not wedged)` every minute, while the claude proc idled at 0.4% CPU.
3. **Keepalive backstop blocked** -- `shouldDeferKeepaliveRespawn` defers on the same signal.

Net effect: scheduler ticks dropped (`Schedule target session busy or has pending input, will retry`), channel mute until manual `respawn-pane`. **The deadlock exists on released main (v1.23.2) too** -- latent since the 2026-06-26 #452 busy-guard; the hermes soak surfaced it because hourly scheduled-task injections on a plugin-less (AVX-less) host make the swallowed-Enter trigger likely. The live Mac Mini is exposed to the same class.

## Fix (two independent layers)

**1. `clear-scheduled` soft move** (`pane-state.ts`, `channel-monitor.ts`): parked text starting with the scheduler wrapper (`SCHEDULED TASK NOTICE` / `<scheduled-task`) is machine-origin and recurring -> clear the buffer, never re-inject (the next schedule fire re-delivers; re-injecting risks TUI mid-text truncation corrupting the instruction). Main session gets a move where it had none; sub-agent `reinject-plain` keeps precedence.

**2. Busy-guard deadlock carve-out** (`channel-monitor.ts`): a `'typing'` pane no longer defers the hard restart when the parked text is **identifiably machine-injected** (known wrapper prefix: scheduler / `TEAM MEMBER NOTICE` / `[Uzenet @` / `<channel source="plugin:`) **AND** soft recovery has no move (`parkedMainInputHasRemedy` = false). Genuine `'busy'`, human-looking drafts, and anything soft recovery can still handle keep deferring exactly as before (#452 protection intact). Backward-compatible signature: without carve-out facts the legacy blanket defer applies.

## Verify

- `tsc` clean, build OK
- vitest: 193 files / 2694 tests green (21 new: 12 detector fixture tests incl. the real hermes pane shape + human-draft-quoting-wrapper negative, 5 guard carve-out, 4 action-decision)
- Hermes box recovered manually via `respawn-pane` at 03:30 (evidence preserved in dashboard.log); after merge the develop-soak exercises this path hourly by construction

## Release note

For the gate: the bug is NOT introduced by this week's batch (pre-existing on main), so the regression flag on the soak gate can be lifted once this lands and re-soaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
