### PR TITLE
fix(auth): isolate channel-less Claude-OAuth agents from the rotating shared credential (AUTHISO25)

### DIFF
--- a/src/__tests__/isolated-channel-config.test.ts
+++ b/src/__tests__/isolated-channel-config.test.ts
@@ -111,6 +111,26 @@ describe('ensureIsolatedChannelConfigDir', () => {
     expect(inst.plugins[TG][0].projectPath).toBe(join(SANDBOX, 'agents', 'testagent'))
   })
 
+  it('a CHANNEL-LESS agent (null provider) disables EVERY channel plugin', () => {
+    // AUTHISO25: dani/geri-class agents have no bot token at all. Their
+    // isolated settings.json must not enable any channel plugin -- a loaded
+    // plugin without an own token only fights the fleet over poller slots.
+    const cfg = ensureIsolatedChannelConfigDir('testagent', null)!
+    expect(cfg).toBe(join(SANDBOX, 'agents', 'testagent', '.claude-config'))
+    const s = JSON.parse(readFileSync(join(cfg, 'settings.json'), 'utf-8'))
+    expect(s.enabledPlugins[TG]).toBe(false)
+    expect(s.enabledPlugins[SL]).toBe(false)
+    expect(s.enabledPlugins[DI]).toBe(false)
+    expect(s.hooks).toEqual({ Stop: [] }) // shared non-plugin settings preserved
+  })
+
+  it('channel-less provisioning still carries NO .credentials.json', () => {
+    const cfg = ensureIsolatedChannelConfigDir('testagent', null)!
+    expect(existsSync(join(cfg, '.credentials.json'))).toBe(false)
+    // and the auth-independent parts are intact
+    expect(lstatSync(join(cfg, 'projects')).isSymbolicLink()).toBe(true)
+  })
+
   it('is idempotent: a second call leaves a valid isolated dir', () => {
     const first = ensureIsolatedChannelConfigDir('testagent', 'telegram')
     const second = ensureIsolatedChannelConfigDir('testagent', 'telegram')
@@ -148,5 +168,21 @@ describe('isolated-config launcher wiring', () => {
     // The warning branch keeps the pre-isolation behaviour rather than launching
     // a logged-out sub-agent.
     expect(SRC).toMatch(/no fleet OAuth token/)
+  })
+
+  it('isolates channel-less Claude-OAuth agents too (AUTHISO25), not only channel ones', () => {
+    // The shared root's rotating credential (macOS Keychain /.credentials.json)
+    // wins over a valid CLAUDE_CODE_OAUTH_TOKEN env var, so a shared-root agent
+    // 401s whenever it rotates -- the gate must not be hasChannel-only.
+    expect(SRC).toMatch(/const needsFleetOauth = isClaude && authMode !== 'api'/)
+    expect(SRC).toMatch(/\(hasChannel \|\| needsFleetOauth\) && name !== MAIN_AGENT_ID/)
+  })
+
+  it('passes a null provider for channel-less agents so no plugin gets enabled', () => {
+    expect(SRC).toMatch(/ensureIsolatedChannelConfigDir\(name, hasChannel \? agentProvider : null\)/)
+  })
+
+  it('keeps the plugin-slot collision alert scoped to channel agents', () => {
+    expect(SRC).toMatch(/if \(hasChannel\) maybeAlertSharedConfigCollision\(name\)/)
   })
 })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -295,7 +295,9 @@ const ISOLATED_CONFIG_SKIP = new Set(['settings.json', 'plugins', '.credentials.
 
 export function ensureIsolatedChannelConfigDir(
   name: string,
-  providerType: ChannelProviderType,
+  // null = channel-less agent: provision the isolated dir with EVERY channel
+  // plugin disabled (scopeChannelPlugins(null)) instead of enabling one.
+  providerType: ChannelProviderType | null,
 ): string | null {
   return provisionIsolatedConfigDir(join(agentDir(name), '.claude-config'), agentDir(name), providerType, name)
 }
@@ -382,7 +384,7 @@ export function resolveMainAgentConfigDir(): string | null {
 function provisionIsolatedConfigDir(
   cfg: string,
   cwd: string,
-  providerType: ChannelProviderType,
+  providerType: ChannelProviderType | null,
   name: string,
 ): string | null {
   try {
@@ -1086,12 +1088,26 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     if (!claudeConfigDir && hasFleetOauthToken()) {
       oauthTokenEnv = `export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')" && `
     }
-    if (!claudeConfigDir && hasChannel && name !== MAIN_AGENT_ID) {
+    // Isolation must also cover CHANNEL-LESS Claude-OAuth agents, not just
+    // channel ones. A shared-root agent authenticates from the ROTATING shared
+    // credential (macOS Keychain entry / .credentials.json), which Claude Code
+    // prefers over an otherwise-valid CLAUDE_CODE_OAUTH_TOKEN env var (see the
+    // ensureMainAgentIsolatedConfigDir header) -- so when that credential
+    // rotates or expires, the agent parks on a 401 even though the fleet token
+    // exported right next to it is fine (dani/geri recurring outage,
+    // 2026-07-25). Only agents that never touch Anthropic OAuth stay on the
+    // shared root: local/BYO-endpoint models (Ollama/DeepSeek/OpenRouter) and
+    // per-agent API-key (authMode 'api') agents.
+    const needsFleetOauth = isClaude && authMode !== 'api'
+    if (!claudeConfigDir && (hasChannel || needsFleetOauth) && name !== MAIN_AGENT_ID) {
       if (hasFleetOauthToken()) {
         // Token present -> isolation works; any earlier degradation is resolved,
         // so re-arm the one-shot alert for a future token loss.
         resetSharedConfigCollisionAlert()
-        const isolated = ensureIsolatedChannelConfigDir(name, agentProvider)
+        // A channel-less agent provisions with a null provider so its isolated
+        // settings.json disables EVERY channel plugin -- it has no bot token,
+        // so a loaded plugin could only fight the fleet over poller slots.
+        const isolated = ensureIsolatedChannelConfigDir(name, hasChannel ? agentProvider : null)
         if (isolated) {
           claudeConfigDir = isolated
           // Read the token at launch via $(cat) so the literal secret never
@@ -1102,8 +1118,10 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
       } else {
         logger.warn({ name }, 'isolated-config: no fleet OAuth token (store/.claude-oauth-token); keeping shared ~/.claude. Run `claude setup-token` and store it to enable per-agent isolation.')
         // H1: the WARN above is silent. With >1 channel sub-agent sharing
-        // ~/.claude this is an active plugin-slot collision -> raise a loud alert.
-        maybeAlertSharedConfigCollision(name)
+        // ~/.claude this is an active plugin-slot collision -> raise a loud
+        // alert. Channel-less agents cannot contend for a plugin slot, so they
+        // only get the WARN.
+        if (hasChannel) maybeAlertSharedConfigCollision(name)
       }
     }
     // Per-project trust pre-seed in the config root this session will ACTUALLY


### PR DESCRIPTION
## Problem

Dani and Geri (channel-less sub-agents) recurrently parked on `API Error: 401 OAuth access token has expired`, while the seven isolated agents stayed stable. Root cause (live-measured, see AUTHISO25 brief): they ran on the shared `~/.claude` root because the auto-isolation gate keyed on `hasChannel` only -- and on macOS the shared root authenticates from the ROTATING Keychain entry, which Claude Code prefers over the valid, long-lived `CLAUDE_CODE_OAUTH_TOKEN` exported right next to it. When the Keychain credential rotates/expires, the agent 401s even though the fleet setup-token is fine.

## Fix

- The isolation gate now also admits Claude-model agents with OAuth auth: `needsFleetOauth = isClaude && authMode !== 'api'`, so `(hasChannel || needsFleetOauth)` agents get the same isolated `CLAUDE_CONFIG_DIR` + fleet-token auth as channel agents.
- Channel-less agents provision with a **null provider**: their isolated `settings.json` disables EVERY channel plugin (no own bot token, so a loaded plugin could only fight the fleet over poller slots). `ensureIsolatedChannelConfigDir` / `provisionIsolatedConfigDir` accept `ChannelProviderType | null`; `scopeChannelPlugins(null)` already handled this.
- The plugin-slot collision alert stays scoped to channel agents (channel-less agents cannot contend for a slot).

## Not affected

- Main agent (marveen): untouched, still launches via channels.sh with its own `MAIN_AGENT_CONFIG_DIR` / `MAIN_AGENT_ISOLATED_CONFIG` logic.
- The 7 already-isolated agents: `hasChannel=true` path is byte-identical.
- Local/BYO-endpoint models (Ollama/DeepSeek/OpenRouter, e.g. qwen) and `authMode: 'api'` agents: `needsFleetOauth=false`, keep the shared root.
- No fleet token present: unchanged degraded fallback to shared root (WARN).

## Tests

- 5 new tests (channel-less provisioning disables all plugins, no `.credentials.json`, gate/scope/alert source contracts).
- Full suite: **2699 passed**, tsc clean.

Card: AUTHISO25

🤖 Generated with [Claude Code](https://claude.com/claude-code)