### PR TITLE
fix(updates): check the branch the checkout follows, not a hardcoded main

### DIFF
--- a/src/__tests__/update-checker-branch.test.ts
+++ b/src/__tests__/update-checker-branch.test.ts
@@ -1,0 +1,40 @@
+// Regression test for the update checker's branch selection.
+//
+// The checker used to hardcode `main` while update.sh pulls
+// `origin/<current branch>`. On any checkout that follows another branch
+// (e.g. `develop`) the two disagreed: the dashboard advertised a "new version"
+// the update button could never deliver, and stayed silent about the commits
+// that actually were on the way. trackedBranch() is what keeps the two in sync,
+// so it is pinned here.
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { trackedBranch } from '../web/update-checker.js'
+import { PROJECT_ROOT } from '../config.js'
+
+function gitBranch(): string {
+  return execFileSync('/usr/bin/git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8',
+  }).trim()
+}
+
+describe('update checker branch selection', () => {
+  it('follows the branch the checkout is actually on', () => {
+    const actual = gitBranch()
+    // Detached HEAD reports the literal "HEAD"; the helper substitutes main
+    // there, matching what update.sh tells the operator to check out.
+    const expected = actual && actual !== 'HEAD' ? actual : 'main'
+    expect(trackedBranch()).toBe(expected)
+  })
+
+  it('never returns an empty ref', () => {
+    // An empty branch would produce `origin/` / `commits/` requests that fail
+    // in confusing ways; the fallback must always yield a usable ref.
+    expect(trackedBranch()).toBeTruthy()
+  })
+
+  it('does not silently assume main on a non-main checkout', () => {
+    const actual = gitBranch()
+    if (!actual || actual === 'HEAD' || actual === 'main') return // nothing to prove here
+    expect(trackedBranch()).not.toBe('main')
+  })
+})

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -58,6 +58,21 @@ export function currentGitHead(): string {
   }
 }
 
+// Branch this checkout actually follows. update.sh pulls `origin/<this>`, so
+// the update check must compare against the same ref -- hardcoding `main` made
+// every non-release checkout (e.g. `develop`) report a phantom "new version"
+// that the update button could never deliver, while staying silent about the
+// commits that WERE coming. Falls back to `main` on a detached HEAD, which is
+// also the branch update.sh tells the operator to check out in that state.
+export function trackedBranch(): string {
+  try {
+    const b = execFileSync('/usr/bin/git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+    return b && b !== 'HEAD' ? b : 'main'
+  } catch {
+    return 'main'
+  }
+}
+
 export function parseGitHubRemote(): string {
   try {
     const url = execFileSync('/usr/bin/git', ['config', '--get', 'remote.origin.url'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
@@ -146,14 +161,14 @@ export function groupByRelease(commits: UpdateCommit[], fullMessages: string[]):
   return out.concat(groups)
 }
 
-// Merge-base of local HEAD with the upstream tracking ref (origin/main, which
-// parseGitHubRemote maps to the GitHub remote). For a customised fork this is
+// Merge-base of local HEAD with the upstream tracking ref (origin/<tracked
+// branch>, which parseGitHubRemote maps to the GitHub remote). For a customised fork this is
 // the fork point -- an actual upstream commit -- so it can be compared on
 // GitHub even though the local HEAD itself never landed there. Empty string
 // when there is no local upstream ref.
 function upstreamMergeBase(): string {
   try {
-    return execFileSync('/usr/bin/git', ['merge-base', 'HEAD', 'origin/main'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+    return execFileSync('/usr/bin/git', ['merge-base', 'HEAD', `origin/${trackedBranch()}`], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
   } catch {
     return ''
   }
@@ -176,14 +191,15 @@ export async function refreshUpdateStatus(): Promise<UpdateStatus> {
     return status
   }
   try {
-    // 1) find HEAD of default branch (main) via the commits endpoint
-    const latestRes = await fetch(`https://api.github.com/repos/${remote}/commits/main`, {
+    // 1) find HEAD of the branch this checkout follows via the commits endpoint
+    const branch = trackedBranch()
+    const latestRes = await fetch(`https://api.github.com/repos/${remote}/commits/${encodeURIComponent(branch)}`, {
       headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'marveen-update-check' },
       signal: AbortSignal.timeout(TOOL_TIMEOUTS['github']),
     })
-    if (!latestRes.ok) throw new Error(`GitHub /commits/main -> ${latestRes.status}`)
+    if (!latestRes.ok) throw new Error(`GitHub /commits/${branch} -> ${latestRes.status}`)
     const latestJson = await latestRes.json() as { sha?: string }
-    if (!latestJson.sha) throw new Error('No sha on commits/main response')
+    if (!latestJson.sha) throw new Error(`No sha on commits/${branch} response`)
     status.latest = latestJson.sha
 
     if (status.latest === current) {
@@ -225,7 +241,7 @@ export async function refreshUpdateStatus(): Promise<UpdateStatus> {
   return status
 }
 
-// Polls the GitHub repo's main branch for new commits and compares to the
+// Polls the GitHub branch this checkout follows for new commits and compares to the
 // local HEAD. Lets the dashboard show a "new version available" badge
 // without anyone having to SSH in and run update.sh.
 export function startUpdateChecker(): NodeJS.Timeout {


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A frissítés-figyelő beégetve a `main` ágat kérdezte (`commits/main`, illetve `merge-base HEAD origin/main`), miközben az `update.sh` a `git pull --ff-only origin "$CURRENT_BRANCH"` sorral az AKTUÁLIS ágat húzza. Egy nem-kiadási ágat követő checkouton (pl. `develop`) a kettő nem ugyanarra mutat, és ennek két látható tünete van:

1. **Örök fantom-értesítés**: a dashboard olyan verziót sürget, amit a frissítés gomb sosem hoz be (a pull no-op), tehát a sáv soha nem tűnik el.
2. **Elhallgatott valódi frissítés**: amikor a követett ágra tényleg érkezik commit, a `main` nem mozdul, így a figyelő HALLGAT. Az értesítés nem csak zajos, hanem mindkét irányban megbízhatatlan.

A javítás egy `trackedBranch()` helper, ami egyszer feloldja a követett ágat (`git rev-parse --abbrev-ref HEAD`), és detached HEAD esetén `main`-re esik vissza -- pontosan arra az ágra, amit az `update.sh` is javasol checkoutolni ilyenkor. Az összehasonlítási alap és a GitHub commits-végpont is ezt használja. Új viselkedés csak a nem-`main` ágakon van; `main`-en minden marad a régiben.

**Konkrét eset:** egy `develop` checkout, ami 6 committal ELŐRÉBB járt a `v1.23.2` kiadási pontnál, 15 percenként azt kapta, hogy 2 verzióval le van maradva.

**EN:** The update checker hardcoded `main` (`commits/main` and `merge-base HEAD origin/main`) while `update.sh` pulls `origin/$CURRENT_BRANCH`. On a checkout following any other branch (e.g. `develop`) the two disagree, with two symptoms: a permanent phantom "new version available" the update button can never deliver (the pull is a no-op, so the banner never clears), and silence when commits actually land on the followed branch, because `main` did not move.

`trackedBranch()` resolves the followed branch once (falling back to `main` on a detached HEAD, which is what `update.sh` tells the operator to check out), and both the compare base and the commits endpoint use it. Behaviour changes only on non-`main` checkouts; on `main` everything stays as before.

**Concrete case:** a `develop` checkout sitting 6 commits *ahead* of the `v1.23.2` release tag was told it was 2 versions behind, every 15 minutes.

## Kapcsolódó issue / Related issue

Closes #696

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. *(Nem érinti: belső hibajavítás, se telepítési, se architektúra-változás nincs benne.)*
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

### Tesztelés

Új teszt: `src/__tests__/update-checker-branch.test.ts` (3 eset -- a követett ágra illeszkedés, az üres-ref elleni védelem, és hogy nem-`main` checkouton ne essen vissza `main`-re).

`npx tsc --noEmit` tiszta. A frissítéssel kapcsolatos meglévő tesztek zöldek: `update-preflight` (40), `update-release-grouping` (6), `update-agent-capability` (8), `auto-update-seed-task` (6).
