### PR TITLE
fix(dashboard): let the auth setup banner actually honour [hidden]

### DIFF
--- a/src/__tests__/hidden-attribute-css-contract.test.ts
+++ b/src/__tests__/hidden-attribute-css-contract.test.ts
@@ -1,0 +1,78 @@
+// Contract test for the recurring "[hidden] does nothing" CSS regression.
+//
+// An author rule like `.foo { display: flex }` outranks the UA stylesheet's
+// `[hidden] { display: none }`, so any element that the frontend hides by
+// setting `el.hidden = true` stays on screen unless the class also carries an
+// explicit `[hidden] { display: none }` override. style.css already documents
+// this for .kanban-board / .kanban-col / .page / .tab-panel / .wizard-panel;
+// the auth setup banner shipped without it, so the banner was permanently
+// visible and its close button looked dead (it did set el.hidden = true).
+//
+// House idiom: read the frontend files as strings and assert short,
+// formatting-proof fragments.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const WEB = join(__dirname, '..', '..', 'web')
+// Strip comments so an explanatory comment mentioning a property is never
+// mistaken for a real declaration.
+const css = readFileSync(join(WEB, 'style.css'), 'utf8').replace(/\/\*[\s\S]*?\*\//g, '')
+const html = readFileSync(join(WEB, 'index.html'), 'utf8')
+
+/** Does an unconditional `.cls { ... display: <not none> ... }` rule exist? */
+function hasUnconditionalDisplay(cls: string): boolean {
+  const re = new RegExp(`\\.${cls}\\s*\\{([^}]*)\\}`, 'g')
+  for (const m of css.matchAll(re)) {
+    const decl = /(^|;)\s*display\s*:\s*([a-z-]+)/i.exec(m[1])
+    if (decl && decl[2].toLowerCase() !== 'none') return true
+  }
+  return false
+}
+
+function hasHiddenOverride(cls: string): boolean {
+  return new RegExp(`\\.${cls}\\[hidden\\]\\s*\\{[^}]*display\\s*:\\s*none`).test(css)
+}
+
+// Elements the markup ships with the `hidden` attribute AND styles by class.
+// Extracted from index.html so a newly added hidden container is covered
+// automatically instead of needing a new test.
+function hiddenClassNames(): string[] {
+  const out = new Set<string>()
+  for (const tag of html.matchAll(/<[a-z]+[^>]*\bhidden\b[^>]*>/gi)) {
+    const cls = /class="([^"]+)"/.exec(tag[0])
+    if (!cls) continue
+    for (const c of cls[1].split(/\s+/)) if (c) out.add(c)
+  }
+  return [...out]
+}
+
+describe('[hidden] stays effective for class-styled containers', () => {
+  it('the auth setup banner can actually be hidden', () => {
+    // Regression: without this the dismiss button and initAuthBanner() both
+    // set el.hidden = true with no visible effect.
+    expect(hasUnconditionalDisplay('auth-setup-banner')).toBe(true)
+    expect(hasHiddenOverride('auth-setup-banner')).toBe(true)
+  })
+
+  // Pre-existing offenders found by the sweep when this guard was added. They
+  // are NOT fixed here (each needs its own visual check -- some may never be
+  // toggled via the attribute at all); the allowlist exists so the guard can
+  // ship now and still fail on any NEW one. Shrink it as they get verified.
+  const KNOWN = [
+    'kanban-swimlane-board',
+    'modal-footer',
+    'badge',
+    'skill-detail-agents-coverage',
+    'skill-detail-edit-actions',
+  ]
+
+  it('no NEW hidden-by-default container silently ignores [hidden]', () => {
+    const offenders = hiddenClassNames()
+      .filter((c) => hasUnconditionalDisplay(c) && !hasHiddenOverride(c))
+      .filter((c) => !KNOWN.includes(c))
+    expect(offenders).toEqual([])
+  })
+})

--- a/web/style.css
+++ b/web/style.css
@@ -7104,6 +7104,12 @@ body {
   background: var(--accent-soft);
   font-size: 13px;
 }
+/* The `display: flex` above is an author rule, so it outranks the UA's
+   [hidden] { display: none } -- without this override the banner stays on
+   screen even when initAuthBanner()/the dismiss button set el.hidden = true,
+   making the close button look dead. Same fix as .kanban-board[hidden] etc. */
+.auth-setup-banner[hidden] { display: none; }
+
 .auth-setup-banner-actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A `.auth-setup-banner { display: flex }` szerzői szabály, ezért **felülírja** a böngésző alapértelmezett `[hidden] { display: none }` szabályát. Emiatt a sávot elrejteni akaró mindkét kódág hatástalan volt:

- az `initAuthBanner()`, ami `el.hidden = true`-t állít, ha nincs szükség beállításra, és
- az X gomb, ami szintén `el.hidden = true`-t állít.

A sáv így **akkor is a képernyőn maradt, amikor a belépés már be volt állítva** (`setup_required: false`), az X pedig halottnak látszott: lefutott, `localStorage`-ba is beírt, csak semmi nem történt vizuálisan.

Bejelentő operátornál a dashboard-belépés már létezett, tehát a sávnak meg sem kellett volna jelennie. `Cmd + Shift + R` és privát ablak is reprodukálta, ami kizárta a böngésző-gyorsítótárat; a `/api/auth/status` mind loopbacken, mind a Tailscale-útvonalon `setup_required: false`-t adott vissza.

A `style.css` ezt az override-ot **már tartalmazza** (ugyanezzel a magyarázattal) a `.kanban-board`, `.kanban-col`, `.page`, `.tab-panel`, `.wizard-panel` és `.updates-badge` elemekre -- a tegnap érkezett sáv maradt ki a mintából.

**Teszt:** string-contract teszt a ház bevett formájában (mint a `dashboard-modal-css-contract.test.ts`). A konkrét sáv rögzítésén túl végigsöpri az `index.html`-t: minden olyan konténert megkeres, ami `hidden` attribútummal érkezik ÉS osztályból kap feltétel nélküli `display`-t -- így egy új ilyen nem tud csendben visszacsúszni.

Öt **korábbi** ilyen eset került allowlistre, nem javításra: `kanban-swimlane-board`, `modal-footer`, `badge`, `skill-detail-agents-coverage`, `skill-detail-edit-actions`. Ezek mindegyike külön vizuális ellenőrzést kíván (lehet, hogy némelyiket sosem kapcsolják az attribútummal), ezért nem akartam ebbe a PR-be behúzni őket. Ha hasznos, szívesen megnézem külön.

**EN:** `.auth-setup-banner { display: flex }` is an author rule and therefore outranks the UA stylesheet's `[hidden] { display: none }`. Both code paths that hide the banner -- `initAuthBanner()` when no setup is required, and the dismiss button -- set `el.hidden = true` with no visible effect: the banner stayed on screen and the close button looked dead.

Reported by an operator whose dashboard login already existed, so the banner should never have rendered; a hard refresh and a private window both reproduced it, ruling out browser caching, and `/api/auth/status` returned `setup_required: false` over both loopback and the Tailscale path.

`style.css` already carries this override for `.kanban-board`, `.kanban-col`, `.page`, `.tab-panel`, `.wizard-panel` and `.updates-badge`; the banner shipped without it.

The added string-contract test pins the banner and sweeps `index.html` for any container that ships with `hidden` and is styled by a class with an unconditional `display`, so a new one cannot regress silently. Five pre-existing offenders are allowlisted rather than fixed here.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. *(Nem érinti: egysoros CSS-javítás.)*
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

### Tesztelés

`hidden-attribute-css-contract.test.ts` (2 eset) zöld, a meglévő `dashboard-modal-css-contract` (4) és `auth-routes` (19) is zöld. `node --check web/app.js web/sw.js` rendben.
