### PR TITLE
fix(install): pin --branch main on every branchless marveen clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Minden ágens saját, réteges memóriával rendelkezik (hot / warm / cold / sha
 ### macOS / Linux
 
 ```bash
-git clone https://github.com/Szotasz/marveen.git
+git clone --branch main https://github.com/Szotasz/marveen.git
 cd marveen
 ./install.sh
 ```
@@ -90,7 +90,7 @@ irm https://raw.githubusercontent.com/Szotasz/marveen/main/install-windows.ps1 |
 
 Vagy manuálisan:
 ```powershell
-git clone https://github.com/Szotasz/marveen.git
+git clone --branch main https://github.com/Szotasz/marveen.git
 cd marveen
 .\install-windows.ps1
 ```
@@ -272,7 +272,7 @@ claude setup-token
 
 # 2. A VPS-en:
 export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
-git clone https://github.com/Szotasz/marveen.git
+git clone --branch main https://github.com/Szotasz/marveen.git
 cd marveen
 ./install.sh    # automatikusan install-linux.sh-t futtat
 ```

--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -165,7 +165,7 @@ INSTALL_DIR="$installPath"
 
 # Clone repo
 if [ ! -d "\$INSTALL_DIR" ]; then
-    git clone https://github.com/Szotasz/marveen.git "\$INSTALL_DIR"
+    git clone --branch main https://github.com/Szotasz/marveen.git "\$INSTALL_DIR"
     echo '  ✓ Repó klónozva'
 else
     echo '  ✓ Marveen mappa már létezik'


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

**HU:** A repo GitHub default branch-e a develop, ezért minden branch-flag nélküli `git clone` a kiadatlan develop vonalra teszi a vevői installt -- a README kézi útja (macOS/Linux, Windows manuális, VPS) és az install-windows.ps1 WSL-ága is így klónozott. A branch-agnosztikus update.sh ezután örökre developon tartja őket (a #696-os fantom-frissítés-riasztással együtt). Az install-linux.sh már pinnel; ez a négy klónozási hely most ugyanazt teszi.

**EN:** The repo's GitHub default branch is develop, so any `git clone` without an explicit branch lands customer installs on the unreleased develop line. The README manual path (3 places) and the install-windows.ps1 WSL fallback did this; update.sh (branch-agnostic by design) then keeps them there. install-linux.sh already pins main -- these four clone sites now match.

Kapcsolódó: #696 (fantom update-riasztás developon), LOGINBLACK incidens (vevői install develop-on kapta a kiadatlan login-feature-t).

Megjegyzés: a GitHub default branch main-re állítása (ami a gyökérokot szüntetné meg minden jövőbeli külső clone-ra) tudatosan NEM része ennek a PR-nek -- az strukturális döntés (contributor-PR-ek base-branch hatása), Szabinál van.

🤖 Generated with [Claude Code](https://claude.com/claude-code)