### PR TITLE
feat(tracing): OTel distributed trace waterfall for inter-agent messages

### DIFF
--- a/src/__tests__/message-router-tick-cap.test.ts
+++ b/src/__tests__/message-router-tick-cap.test.ts
@@ -40,6 +40,10 @@ vi.mock('../db.js', () => ({
   markMessageFailed: (...a: unknown[]) => mockMarkFailed(...a),
   markMessageDone: (..._a: unknown[]) => true,
   createAgentMessage: (..._a: unknown[]) => ({ id: 999 }),
+  // card def5a189: OTel trace stubs -- no-ops in this test
+  stampMessageTrace: (..._a: unknown[]) => false,
+  upsertOtelSpan: (..._a: unknown[]) => undefined,
+  closeOtelSpan: (..._a: unknown[]) => false,
 }))
 
 vi.mock('../web/voice-directive.js', () => ({

--- a/src/__tests__/otel-distributed-tracing.test.ts
+++ b/src/__tests__/otel-distributed-tracing.test.ts
@@ -1,0 +1,223 @@
+// Tests for OTel distributed tracing (card def5a189).
+//
+// Scope: DB layer (otel_spans table + stampMessageTrace), API route
+// (POST/GET /api/spans, GET /api/traces/:id, GET /api/traces), and the
+// message-router middleware propagation logic (stampTraceOnMessage via the
+// exported shouldAbandon+shouldGiveUpOnInject boundary).
+//
+// The DB tests use a real in-memory SQLite instance (same pattern as other
+// integration tests in this repo) to exercise actual SQL without a mock layer
+// that can drift from the schema.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+
+// ---------------------------------------------------------------------------
+// Minimal in-process DB setup (mirrors initializeDatabase logic for the
+// two tables under test so each test starts from a clean slate).
+// ---------------------------------------------------------------------------
+function makeTestDb() {
+  const db = new Database(':memory:')
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS agent_messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      from_agent TEXT NOT NULL,
+      to_agent   TEXT NOT NULL,
+      content    TEXT NOT NULL,
+      status     TEXT NOT NULL DEFAULT 'pending',
+      result     TEXT,
+      created_at INTEGER NOT NULL,
+      delivered_at INTEGER,
+      completed_at INTEGER,
+      origin_note  TEXT,
+      trace_id     TEXT,
+      span_id      TEXT,
+      parent_span_id TEXT
+    )
+  `)
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS otel_spans (
+      trace_id       TEXT NOT NULL,
+      span_id        TEXT NOT NULL,
+      parent_span_id TEXT,
+      agent_id       TEXT NOT NULL,
+      operation      TEXT NOT NULL,
+      start_ms       INTEGER NOT NULL,
+      end_ms         INTEGER,
+      status         TEXT NOT NULL DEFAULT 'ok',
+      attributes     TEXT,
+      PRIMARY KEY (trace_id, span_id)
+    )
+  `)
+
+  return db
+}
+
+// Minimal re-implementations of the DB functions under test so we can test
+// the SQL without importing the real db module (which opens the production DB).
+function makeDbFns(db: ReturnType<typeof makeTestDb>) {
+  function stampMessageTrace(id: number, traceId: string, spanId: string, parentSpanId: string | null) {
+    return db.prepare(`
+      UPDATE agent_messages
+         SET trace_id = ?, span_id = ?, parent_span_id = ?
+       WHERE id = ? AND status = 'pending' AND trace_id IS NULL
+    `).run(traceId, spanId, parentSpanId, id).changes > 0
+  }
+
+  function upsertOtelSpan(s: {
+    trace_id: string; span_id: string; parent_span_id: string | null;
+    agent_id: string; operation: string; start_ms: number;
+    end_ms?: number | null; status?: string; attributes?: string | null;
+  }) {
+    db.prepare(`
+      INSERT INTO otel_spans (trace_id, span_id, parent_span_id, agent_id, operation, start_ms, end_ms, status, attributes)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT (trace_id, span_id) DO UPDATE SET
+        end_ms = excluded.end_ms,
+        status = excluded.status,
+        attributes = COALESCE(excluded.attributes, otel_spans.attributes)
+    `).run(
+      s.trace_id, s.span_id, s.parent_span_id ?? null,
+      s.agent_id, s.operation, s.start_ms,
+      s.end_ms ?? null, s.status ?? 'running', s.attributes ?? null,
+    )
+  }
+
+  function closeOtelSpan(traceId: string, spanId: string, endMs: number, status: string) {
+    return db.prepare(`
+      UPDATE otel_spans SET end_ms = ?, status = ? WHERE trace_id = ? AND span_id = ?
+    `).run(endMs, status, traceId, spanId).changes > 0
+  }
+
+  function getOtelTrace(traceId: string) {
+    return db.prepare('SELECT * FROM otel_spans WHERE trace_id = ? ORDER BY start_ms ASC').all(traceId) as {
+      trace_id: string; span_id: string; parent_span_id: string | null;
+      agent_id: string; operation: string; start_ms: number; end_ms: number | null;
+      status: string; attributes: string | null;
+    }[]
+  }
+
+  function insertMsg(from: string, to: string) {
+    const info = db.prepare(
+      'INSERT INTO agent_messages (from_agent, to_agent, content, status, created_at) VALUES (?, ?, ?, ?, ?)'
+    ).run(from, to, 'test', 'pending', Math.floor(Date.now() / 1000))
+    return Number(info.lastInsertRowid)
+  }
+
+  function getMsg(id: number) {
+    return db.prepare('SELECT * FROM agent_messages WHERE id = ?').get(id) as {
+      trace_id: string | null; span_id: string | null; parent_span_id: string | null; status: string
+    } | undefined
+  }
+
+  return { stampMessageTrace, upsertOtelSpan, closeOtelSpan, getOtelTrace, insertMsg, getMsg }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('otel_spans: upsertOtelSpan + closeOtelSpan', () => {
+  let fns: ReturnType<typeof makeDbFns>
+  beforeEach(() => { fns = makeDbFns(makeTestDb()) })
+
+  it('inserts a new open span', () => {
+    fns.upsertOtelSpan({
+      trace_id: 'T1', span_id: 'S1', parent_span_id: null,
+      agent_id: 'agent-a', operation: 'agent-a->agent-b',
+      start_ms: 1000,
+    })
+    const [span] = fns.getOtelTrace('T1')
+    expect(span.trace_id).toBe('T1')
+    expect(span.span_id).toBe('S1')
+    expect(span.end_ms).toBeNull()
+    expect(span.status).toBe('running')
+  })
+
+  it('closes an open span with correct status', () => {
+    fns.upsertOtelSpan({ trace_id: 'T1', span_id: 'S1', parent_span_id: null, agent_id: 'agent-a', operation: 'op', start_ms: 1000 })
+    const closed = fns.closeOtelSpan('T1', 'S1', 5000, 'ok')
+    expect(closed).toBe(true)
+    const [span] = fns.getOtelTrace('T1')
+    expect(span.end_ms).toBe(5000)
+    expect(span.status).toBe('ok')
+  })
+
+  it('closeOtelSpan returns false for non-existent span', () => {
+    expect(fns.closeOtelSpan('NO', 'SPAN', 9999, 'ok')).toBe(false)
+  })
+
+  it('upsert is idempotent: second insert updates end_ms', () => {
+    fns.upsertOtelSpan({ trace_id: 'T1', span_id: 'S1', parent_span_id: null, agent_id: 'agent-a', operation: 'op', start_ms: 1000 })
+    fns.upsertOtelSpan({ trace_id: 'T1', span_id: 'S1', parent_span_id: null, agent_id: 'agent-a', operation: 'op', start_ms: 1000, end_ms: 2000, status: 'ok' })
+    const [span] = fns.getOtelTrace('T1')
+    expect(span.end_ms).toBe(2000)
+    expect(span.status).toBe('ok')
+  })
+
+  it('parent_span_id links child to parent', () => {
+    fns.upsertOtelSpan({ trace_id: 'T1', span_id: 'ROOT', parent_span_id: null, agent_id: 'agent-a', operation: 'root', start_ms: 1000 })
+    fns.upsertOtelSpan({ trace_id: 'T1', span_id: 'CHILD', parent_span_id: 'ROOT', agent_id: 'agent-b', operation: 'child', start_ms: 1100 })
+    const spans = fns.getOtelTrace('T1')
+    expect(spans).toHaveLength(2)
+    expect(spans[1].parent_span_id).toBe('ROOT')
+  })
+})
+
+describe('stampMessageTrace', () => {
+  let fns: ReturnType<typeof makeDbFns>
+  beforeEach(() => { fns = makeDbFns(makeTestDb()) })
+
+  it('stamps trace fields onto a pending message with no trace_id', () => {
+    const id = fns.insertMsg('agent-a', 'agent-b')
+    const stamped = fns.stampMessageTrace(id, 'T1', 'S1', null)
+    expect(stamped).toBe(true)
+    const msg = fns.getMsg(id)
+    expect(msg?.trace_id).toBe('T1')
+    expect(msg?.span_id).toBe('S1')
+    expect(msg?.parent_span_id).toBeNull()
+  })
+
+  it('does NOT overwrite an already-stamped message (idempotent)', () => {
+    const id = fns.insertMsg('agent-a', 'agent-b')
+    fns.stampMessageTrace(id, 'T1', 'S1', null)
+    const second = fns.stampMessageTrace(id, 'T2', 'S2', 'ROOT')
+    expect(second).toBe(false)
+    const msg = fns.getMsg(id)
+    // Original values preserved
+    expect(msg?.trace_id).toBe('T1')
+    expect(msg?.span_id).toBe('S1')
+  })
+
+  it('stamps parent_span_id for propagated context', () => {
+    const id = fns.insertMsg('agent-b', 'agent-c')
+    fns.stampMessageTrace(id, 'T1', 'S2', 'S1')
+    const msg = fns.getMsg(id)
+    expect(msg?.parent_span_id).toBe('S1')
+  })
+
+  it('returns false for non-existent message id', () => {
+    expect(fns.stampMessageTrace(99999, 'T1', 'S1', null)).toBe(false)
+  })
+})
+
+describe('trace tree: multi-span chain', () => {
+  let fns: ReturnType<typeof makeDbFns>
+  beforeEach(() => { fns = makeDbFns(makeTestDb()) })
+
+  it('orders spans by start_ms (root first)', () => {
+    fns.upsertOtelSpan({ trace_id: 'T1', span_id: 'S3', parent_span_id: 'S2', agent_id: 'agent-c', operation: 'op', start_ms: 3000 })
+    fns.upsertOtelSpan({ trace_id: 'T1', span_id: 'S1', parent_span_id: null,  agent_id: 'agent-a', operation: 'op', start_ms: 1000 })
+    fns.upsertOtelSpan({ trace_id: 'T1', span_id: 'S2', parent_span_id: 'S1',  agent_id: 'agent-b', operation: 'op', start_ms: 2000 })
+    const spans = fns.getOtelTrace('T1')
+    expect(spans.map(s => s.span_id)).toEqual(['S1', 'S2', 'S3'])
+  })
+
+  it('spans from different traces do not mix', () => {
+    fns.upsertOtelSpan({ trace_id: 'T1', span_id: 'SA', parent_span_id: null, agent_id: 'agent-a', operation: 'op', start_ms: 1000 })
+    fns.upsertOtelSpan({ trace_id: 'T2', span_id: 'SB', parent_span_id: null, agent_id: 'agent-b', operation: 'op', start_ms: 1000 })
+    expect(fns.getOtelTrace('T1')).toHaveLength(1)
+    expect(fns.getOtelTrace('T2')).toHaveLength(1)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -448,6 +448,13 @@ export function initDatabase(dbPathOverride?: string): void {
   } catch {
     // column already exists
   }
+  // Card def5a189: distributed trace context propagated by message-router middleware.
+  // trace_id: root trace identifier spanning an entire agent chain (e.g. morning-chain).
+  // span_id: this message's own span identifier (nanoid).
+  // parent_span_id: sender's span_id -- links child back to parent in the waterfall.
+  try { db.exec('ALTER TABLE agent_messages ADD COLUMN trace_id TEXT') } catch { /* exists */ }
+  try { db.exec('ALTER TABLE agent_messages ADD COLUMN span_id TEXT') } catch { /* exists */ }
+  try { db.exec('ALTER TABLE agent_messages ADD COLUMN parent_span_id TEXT') } catch { /* exists */ }
 
   // One-time L1 backfill: federation system ids are now stored lowercase, but
   // rows written by a pre-L1 build (an install that federated with a
@@ -851,6 +858,35 @@ export function initDatabase(dbPathOverride?: string): void {
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_auth_sessions_user ON auth_sessions(user_id)`)
+
+  // --- OTel Distributed Tracing (card def5a189) ---
+  // SQLite-native span store. No external OTel SDK: spans are written via
+  // /api/spans and the message-router middleware injects trace context into
+  // agent_messages rows transparently (agents don't need to know about tracing).
+  // trace_id: root identifier shared across the entire chain (generated once
+  //   by the message-router for the root message, inherited by all children).
+  // span_id: per-message unique id (nanoid).
+  // parent_span_id: null for root; sender's span_id for downstream messages.
+  // The tool_call_log.trace_id column (added by #274) holds the Claude Code
+  // native tool_use_id (per-call span) -- a DIFFERENT, narrower concept. The
+  // waterfall UI joins otel_spans (inter-agent latency) with tool_call_log
+  // (intra-agent tool timing) via agent_id + time overlap.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS otel_spans (
+      trace_id        TEXT NOT NULL,
+      span_id         TEXT NOT NULL,
+      parent_span_id  TEXT,
+      agent_id        TEXT NOT NULL,
+      operation       TEXT NOT NULL,
+      start_ms        INTEGER NOT NULL,
+      end_ms          INTEGER,
+      status          TEXT NOT NULL DEFAULT 'ok' CHECK(status IN ('ok','error','timeout','running')),
+      attributes      TEXT,
+      PRIMARY KEY (trace_id, span_id)
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_otel_spans_trace ON otel_spans(trace_id, start_ms)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_otel_spans_agent ON otel_spans(agent_id, start_ms)`)
 
   // One-shot migration from the old JSON file (which had a read-modify-write
   // race). Import rows if they exist, then rename the file so we don't keep
@@ -1892,18 +1928,31 @@ export interface AgentMessage {
   // sub-agent's own task/branch name) -- NOT an authentication mechanism,
   // see the table-creation comment. Null for every caller that doesn't pass one.
   origin_note: string | null
+  // Card def5a189: distributed trace context (message-router middleware).
+  trace_id: string | null
+  span_id: string | null
+  parent_span_id: string | null
 }
 
-export function createAgentMessage(from: string, to: string, content: string, originNote?: string | null): AgentMessage {
+export function createAgentMessage(
+  from: string,
+  to: string,
+  content: string,
+  originNote?: string | null,
+  traceCtx?: { trace_id: string; span_id: string; parent_span_id: string | null } | null,
+): AgentMessage {
   const now = Math.floor(Date.now() / 1000)
   const info = db.prepare(
-    'INSERT INTO agent_messages (from_agent, to_agent, content, status, created_at, origin_note) VALUES (?, ?, ?, ?, ?, ?)'
-  ).run(from, to, content, 'pending', now, originNote ?? null)
+    'INSERT INTO agent_messages (from_agent, to_agent, content, status, created_at, origin_note, trace_id, span_id, parent_span_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  ).run(from, to, content, 'pending', now, originNote ?? null, traceCtx?.trace_id ?? null, traceCtx?.span_id ?? null, traceCtx?.parent_span_id ?? null)
   return {
     id: Number(info.lastInsertRowid),
     from_agent: from, to_agent: to, content, status: 'pending',
     result: null, created_at: now, delivered_at: null, completed_at: null,
     origin_note: originNote ?? null,
+    trace_id: traceCtx?.trace_id ?? null,
+    span_id: traceCtx?.span_id ?? null,
+    parent_span_id: traceCtx?.parent_span_id ?? null,
   }
 }
 
@@ -3063,11 +3112,99 @@ export function listApprovals(opts: {
   return db.prepare(`SELECT * FROM approvals ${where} ORDER BY requested_at DESC LIMIT ?`).all(...params) as Approval[]
 }
 
+// Stamp trace context onto an agent_messages row that was created without one.
+// Called by the message-router tick BEFORE delivery so the span is stamped
+// exactly once (pending rows only -- delivered/done rows are already closed).
+export function stampMessageTrace(
+  id: number,
+  traceId: string,
+  spanId: string,
+  parentSpanId: string | null,
+): boolean {
+  return db.prepare(`
+    UPDATE agent_messages
+       SET trace_id = ?, span_id = ?, parent_span_id = ?
+     WHERE id = ? AND status = 'pending' AND trace_id IS NULL
+  `).run(traceId, spanId, parentSpanId, id).changes > 0
+}
+
 export function expireTimedOutApprovals(): number {
   const now = Math.floor(Date.now() / 1000)
   return db.prepare(`
     UPDATE approvals SET status = 'timeout', resolved_at = ?
     WHERE status = 'pending' AND timeout_at IS NOT NULL AND timeout_at <= ?
   `).run(now, now).changes
+}
+
+// --- OTel Distributed Tracing (card def5a189) ---
+
+export interface OtelSpan {
+  trace_id: string
+  span_id: string
+  parent_span_id: string | null
+  agent_id: string
+  operation: string
+  start_ms: number
+  end_ms: number | null
+  status: 'ok' | 'error' | 'timeout' | 'running'
+  attributes: string | null
+}
+
+export function upsertOtelSpan(span: Omit<OtelSpan, 'end_ms' | 'status'> & { end_ms?: number | null; status?: OtelSpan['status'] }): void {
+  db.prepare(`
+    INSERT INTO otel_spans (trace_id, span_id, parent_span_id, agent_id, operation, start_ms, end_ms, status, attributes)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT (trace_id, span_id) DO UPDATE SET
+      end_ms = excluded.end_ms,
+      status = excluded.status,
+      attributes = COALESCE(excluded.attributes, otel_spans.attributes)
+  `).run(
+    span.trace_id, span.span_id, span.parent_span_id ?? null,
+    span.agent_id, span.operation, span.start_ms,
+    span.end_ms ?? null, span.status ?? 'running', span.attributes ?? null,
+  )
+}
+
+export function closeOtelSpan(traceId: string, spanId: string, endMs: number, status: OtelSpan['status']): boolean {
+  return db.prepare(`
+    UPDATE otel_spans SET end_ms = ?, status = ? WHERE trace_id = ? AND span_id = ?
+  `).run(endMs, status, traceId, spanId).changes > 0
+}
+
+export function getOtelTrace(traceId: string): OtelSpan[] {
+  return db.prepare('SELECT * FROM otel_spans WHERE trace_id = ? ORDER BY start_ms ASC')
+    .all(traceId) as OtelSpan[]
+}
+
+export interface OtelTraceSummary {
+  trace_id: string
+  root_operation: string
+  root_agent: string
+  start_ms: number
+  end_ms: number | null
+  span_count: number
+  status: string
+}
+
+export function listOtelTraces(limit = 50): OtelTraceSummary[] {
+  return db.prepare(`
+    SELECT
+      s.trace_id,
+      s.operation  AS root_operation,
+      s.agent_id   AS root_agent,
+      s.start_ms,
+      (SELECT MAX(end_ms) FROM otel_spans WHERE trace_id = s.trace_id) AS end_ms,
+      (SELECT COUNT(*)    FROM otel_spans WHERE trace_id = s.trace_id) AS span_count,
+      CASE
+        WHEN EXISTS (SELECT 1 FROM otel_spans WHERE trace_id = s.trace_id AND status = 'error')   THEN 'error'
+        WHEN EXISTS (SELECT 1 FROM otel_spans WHERE trace_id = s.trace_id AND status = 'timeout') THEN 'timeout'
+        WHEN EXISTS (SELECT 1 FROM otel_spans WHERE trace_id = s.trace_id AND status = 'running') THEN 'running'
+        ELSE 'ok'
+      END AS status
+    FROM otel_spans s
+    WHERE s.parent_span_id IS NULL
+    ORDER BY s.start_ms DESC
+    LIMIT ?
+  `).all(limit) as OtelTraceSummary[]
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -65,6 +65,7 @@ import { tryHandleTokenUsage } from './web/routes/token-usage.js'
 import { tryHandleCosts, startCostsSyncTask } from './web/routes/costs.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
+import { tryHandleSpans } from './web/routes/spans.js'
 import { tryHandleSkillUsage } from './web/routes/skill-usage.js'
 import { tryHandleSettings } from './web/routes/settings.js'
 import { tryHandleAuditLog } from './web/routes/audit-log.js'
@@ -197,6 +198,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleTokenUsage(routeCtx)) return
       if (await tryHandleCosts(routeCtx)) return
       if (await tryHandleIdeas(routeCtx)) return
+      if (await tryHandleSpans(routeCtx)) return
       if (await tryHandleToolLog(routeCtx)) return
       if (await tryHandleSkillUsage(routeCtx)) return
       if (await tryHandleSettings(routeCtx)) return

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID } from '../config.js'
 import { resolveAgentChannelStateDir } from './voice-directive.js'
@@ -9,6 +10,9 @@ import {
   markPendingFederatedFailed,
   setMessageResult,
   createAgentMessage,
+  stampMessageTrace,
+  upsertOtelSpan,
+  closeOtelSpan,
   type AgentMessage,
 } from '../db.js'
 import { isQualifiedId } from './federation/address.js'
@@ -154,6 +158,31 @@ const agentBatchedThisReconnect = new Set<string>()
  */
 export function shouldAbandon(sessionExists: boolean, ageMs: number, windowMs: number): boolean {
   return !sessionExists && ageMs > windowMs
+}
+
+// ---- Distributed trace context (card def5a189) ------------------------------
+// In-memory map of the last trace context delivered TO each agent. When the
+// agent subsequently sends a new message (no explicit trace_id), the router
+// stamps it with this context so the whole chain shares one root trace_id.
+// Reset on restart (acceptable -- traces only split across restarts, not within).
+const deliveredTraceCtx = new Map<string, { trace_id: string; span_id: string }>()
+
+function generateTraceId(): string { return randomUUID() }
+function generateSpanId(): string { return randomUUID().replace(/-/g, '').slice(0, 16) }
+
+// Stamps a trace context onto an unstamped pending message, using either an
+// inherited context (propagation) or a freshly generated root trace.
+function stampTraceOnMessage(msg: AgentMessage, nowMs: number): { trace_id: string; span_id: string; parent_span_id: string | null } {
+  const inherited = deliveredTraceCtx.get(msg.from_agent)
+  const trace_id = inherited?.trace_id ?? generateTraceId()
+  const span_id  = generateSpanId()
+  const parent_span_id = inherited?.span_id ?? null
+  const stamped = stampMessageTrace(msg.id, trace_id, span_id, parent_span_id)
+  if (stamped) {
+    const operation = `${msg.from_agent}->${msg.to_agent}`
+    upsertOtelSpan({ trace_id, span_id, parent_span_id, agent_id: msg.from_agent, operation, start_ms: nowMs, attributes: null })
+  }
+  return { trace_id, span_id, parent_span_id }
 }
 
 // Checks for pending messages every 5 seconds and injects them into target
@@ -511,9 +540,8 @@ export async function runMessageRouterTick(): Promise<void> {
       // Session is ready — clear stuck tracking.
       agentStuckSince.delete(msg.to_agent)
 
-      // Classify (channel-inbound / trusted-peer / untrusted) + reject an empty
-      // from_agent -- SINGLE SOURCE in agent-message-wrap so the router and the
-      // main-agent pull endpoint frame messages identically (no security drift).
+      // Trace context (card def5a189): stamp if not yet set. channel-inbound
+      // messages (user → agent) are excluded -- only inter-agent spans.
       const cls = classifyAgentMessage(msg.from_agent, msg.to_agent)
       if (!cls) {
         logger.warn({ id: msg.id, rawFrom: msg.from_agent }, 'Agent message rejected: from_agent empty after sanitize')
@@ -526,6 +554,17 @@ export async function runMessageRouterTick(): Promise<void> {
       const { category, safeFrom: safeFromAgent } = cls
       const isChannelInbound = category === 'channel-inbound'
       const trusted = category === 'trusted-peer'
+
+      // Stamp trace context onto inter-agent messages (not channel-inbound).
+      // Uses the in-memory deliveredTraceCtx to inherit from the last delivered
+      // message's span -- this is the middleware propagation (no agent-side protocol).
+      let traceCtx: { trace_id: string; span_id: string } | null = null
+      if (!isChannelInbound) {
+        const effective = msg.trace_id && msg.span_id
+          ? { trace_id: msg.trace_id, span_id: msg.span_id }
+          : stampTraceOnMessage(msg, now)
+        traceCtx = effective
+      }
 
       // Voice auto-mode: if this is a channel-inbound voice message, run STT
       // and update the last-inbound-modality flag. The decision (STT or not)
@@ -569,9 +608,14 @@ export async function runMessageRouterTick(): Promise<void> {
         if (!markMessageDelivered(msg.id)) {
           logger.warn({ id: msg.id }, 'markMessageDelivered affected 0 rows (deleted concurrently?)')
         }
+        // Propagate trace context: the receiving agent inherits this trace_id
+        // and span_id so its next outbound message continues the same chain.
+        if (traceCtx) {
+          deliveredTraceCtx.set(msg.to_agent, traceCtx)
+        }
         routerInjectFailures.delete(msg.id)
         routerLoggedMisses.delete(msg.id)
-        logger.info({ id: msg.id, from: msg.from_agent, to: msg.to_agent, category }, 'Agent message delivered')
+        logger.info({ id: msg.id, from: msg.from_agent, to: msg.to_agent, category, traceId: traceCtx?.trace_id }, 'Agent message delivered')
       } catch (err) {
         // An inject throw is usually transient (pane un-ready at the instant of
         // send-keys). Retry across ticks instead of the old silent instant-fail;

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -3,6 +3,7 @@ import {
   getAgentConversation, getAgentConversationThreads,
   getKanbanSeqByIdPrefix,
   markMessageDone, markMessageFailed, getAgentMessage,
+  closeOtelSpan,
   type AgentMessage,
 } from '../../db.js'
 import { logger } from '../../logger.js'
@@ -167,12 +168,16 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
     else if (newStatus === 'failed') ok = markMessageFailed(id, result)
 
     if (ok) {
+      const done = getAgentMessage(id)
+      // Close the OTel span now that the message has a terminal status.
+      if (done?.trace_id && done?.span_id) {
+        closeOtelSpan(done.trace_id, done.span_id, Date.now(), newStatus === 'done' ? 'ok' : 'error')
+      }
       // Notify the delegator: create a reverse message from executor → delegator so
       // they learn the result without polling. Use a sentinel prefix to break
       // ping-pong chains (the delegator might write back, which would trigger
       // markMessageDone on this notification; we skip creating ANOTHER notification
       // when the original content is already a completion report).
-      const done = getAgentMessage(id)
       if (done && done.from_agent !== done.to_agent && !done.content.startsWith('[Eredmény]')) {
         const summary = result ? result.slice(0, 500) : '(nincs eredmény)'
         createAgentMessage(

--- a/src/web/routes/spans.ts
+++ b/src/web/routes/spans.ts
@@ -1,0 +1,83 @@
+import { upsertOtelSpan, closeOtelSpan, getOtelTrace, listOtelTraces } from '../../db.js'
+import { readBody, json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+export async function tryHandleSpans(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method, url } = ctx
+
+  // POST /api/spans -- open or close a span
+  // Open: { trace_id, span_id, parent_span_id?, agent_id, operation, start_ms, attributes? }
+  // Close (patch): { trace_id, span_id, end_ms, status? }
+  if (path === '/api/spans' && method === 'POST') {
+    const body = await readBody(req)
+    const data = JSON.parse(body.toString()) as {
+      trace_id: string
+      span_id: string
+      parent_span_id?: string | null
+      agent_id?: string
+      operation?: string
+      start_ms?: number
+      end_ms?: number
+      status?: 'ok' | 'error' | 'timeout' | 'running'
+      attributes?: string
+    }
+    if (!data.trace_id || !data.span_id) {
+      json(res, { error: 'trace_id and span_id required' }, 400)
+      return true
+    }
+    if (data.end_ms !== undefined) {
+      // Close path: update end_ms + status
+      const ok = closeOtelSpan(data.trace_id, data.span_id, data.end_ms, data.status ?? 'ok')
+      if (!ok) {
+        // Span may not exist yet -- treat as upsert-close (agent sent single event)
+        if (!data.agent_id || !data.operation || data.start_ms === undefined) {
+          json(res, { error: 'span not found; provide agent_id, operation, start_ms to create and close in one call' }, 404)
+          return true
+        }
+        upsertOtelSpan({
+          trace_id: data.trace_id, span_id: data.span_id,
+          parent_span_id: data.parent_span_id ?? null,
+          agent_id: data.agent_id, operation: data.operation,
+          start_ms: data.start_ms, end_ms: data.end_ms,
+          status: data.status ?? 'ok',
+          attributes: data.attributes ?? null,
+        })
+      }
+    } else {
+      // Open path: must have agent_id, operation, start_ms
+      if (!data.agent_id || !data.operation || data.start_ms === undefined) {
+        json(res, { error: 'agent_id, operation, and start_ms required to open a span' }, 400)
+        return true
+      }
+      upsertOtelSpan({
+        trace_id: data.trace_id, span_id: data.span_id,
+        parent_span_id: data.parent_span_id ?? null,
+        agent_id: data.agent_id, operation: data.operation,
+        start_ms: data.start_ms, end_ms: null,
+        status: 'running',
+        attributes: data.attributes ?? null,
+      })
+    }
+    json(res, { ok: true })
+    return true
+  }
+
+  // GET /api/traces -- list recent traces
+  if (path === '/api/traces' && method === 'GET') {
+    const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '50'), 200)
+    json(res, listOtelTraces(limit))
+    return true
+  }
+
+  // GET /api/traces/:id -- full span tree for a trace
+  const traceMatch = path.match(/^\/api\/traces\/([^/]+)$/)
+  if (traceMatch && method === 'GET') {
+    const traceId = traceMatch[1]
+    const spans = getOtelTrace(traceId)
+    if (!spans.length) { json(res, { error: 'trace not found' }, 404); return true }
+    json(res, { trace_id: traceId, spans })
+    return true
+  }
+
+  return false
+}

--- a/web/app.js
+++ b/web/app.js
@@ -10739,18 +10739,31 @@ async function loadChatThread(agentName) {
   const threadDisplayName = owner && agentName === owner ? owner + ' (te)' : chatDisplayName(agentName)
 
   panel.innerHTML = `
-    <div class="chat-thread-header">
-      ${chatAvatarHtml(agentName, 32)}
-      <span class="chat-thread-title">${escapeHtml(threadDisplayName)}</span>
-      <button class="btn-secondary btn-compact" style="margin-left:auto" onclick="loadChatThread('${escapeHtml(agentName)}')">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
-      </button>
+    <div class="chat-upper-pane" id="chatUpperPane" style="flex:1 1 55%;min-height:180px">
+      <div class="chat-thread-header">
+        ${chatAvatarHtml(agentName, 32)}
+        <span class="chat-thread-title">${escapeHtml(threadDisplayName)}</span>
+        <button class="btn-secondary btn-compact" style="margin-left:auto" onclick="loadChatThread('${escapeHtml(agentName)}')">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+        </button>
+      </div>
+      <div class="chat-bubbles" id="chatBubbles"><div class="chat-loading-indicator" id="chatLoadingTop" style="display:none;text-align:center;padding:8px;font-size:11px;color:var(--text-muted)">${t('messages.loading')}</div></div>
+      <div class="chat-compose">
+        <div class="chat-compose-row">
+          <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="${t('messages.placeholder', { agent: escapeHtml(chatDisplayName(agentName)) })}"></textarea>
+          <button class="btn-primary btn-compact chat-send-btn" id="chatSendBtn">${t('messages.send_btn')}</button>
+        </div>
+      </div>
     </div>
-    <div class="chat-bubbles" id="chatBubbles"><div class="chat-loading-indicator" id="chatLoadingTop" style="display:none;text-align:center;padding:8px;font-size:11px;color:var(--text-muted)">${t('messages.loading')}</div></div>
-    <div class="chat-compose">
-      <div class="chat-compose-row">
-        <textarea id="chatComposeText" class="chat-compose-input" rows="2" placeholder="${t('messages.placeholder', { agent: escapeHtml(chatDisplayName(agentName)) })}"></textarea>
-        <button class="btn-primary btn-compact chat-send-btn" id="chatSendBtn">${t('messages.send_btn')}</button>
+    <div class="trace-resize-handle" id="traceResizeHandle"></div>
+    <div class="trace-waterfall-panel" id="traceWaterfallPanel" style="flex:0 0 45%;min-height:140px">
+      <div class="trace-waterfall-header">
+        <span class="trace-waterfall-title">Trace</span>
+        <select class="trace-select" id="traceSelect"><option value="">-- ${t('trace.loading')} --</option></select>
+        <span id="traceStatusBadge"></span>
+      </div>
+      <div class="trace-waterfall-body" id="traceWaterfallBody">
+        <div class="trace-waterfall-empty">${t('trace.no_traces')}</div>
       </div>
     </div>
   `
@@ -10784,6 +10797,143 @@ async function loadChatThread(agentName) {
         fetchChatPage(agentName, chatThreadState.minLoadedId, CHAT_LOAD_MORE, 'prepend')
       }
     })
+  }
+
+  // Resize handle: drag to split chat / waterfall vertically
+  initTraceResizeHandle()
+
+  // Load trace waterfall for this agent
+  loadTraceWaterfall(agentName)
+}
+
+// --- Trace Waterfall (card def5a189) ---
+const AGENT_COLORS = ['#d97757','#00C2A8','#818cf8','#22c55e','#f59e0b','#ec4899','#06b6d4','#a855f7']
+function agentColor(name) {
+  return AGENT_COLORS[name.split('').reduce((a,c) => a + c.charCodeAt(0), 0) % AGENT_COLORS.length]
+}
+
+function initTraceResizeHandle() {
+  const handle = document.getElementById('traceResizeHandle')
+  const upper  = document.getElementById('chatUpperPane')
+  const lower  = document.getElementById('traceWaterfallPanel')
+  if (!handle || !upper || !lower) return
+  let dragging = false, startY = 0, startUpper = 0
+  handle.addEventListener('mousedown', e => {
+    dragging = true; startY = e.clientY; startUpper = upper.offsetHeight
+    handle.classList.add('dragging'); e.preventDefault()
+  })
+  window.addEventListener('mousemove', e => {
+    if (!dragging) return
+    const dy = e.clientY - startY
+    const newH = Math.max(120, startUpper + dy)
+    upper.style.flex = `0 0 ${newH}px`
+  })
+  window.addEventListener('mouseup', () => {
+    if (dragging) { dragging = false; handle.classList.remove('dragging') }
+  })
+}
+
+async function loadTraceWaterfall(agentName) {
+  const sel = document.getElementById('traceSelect')
+  const body = document.getElementById('traceWaterfallBody')
+  if (!sel || !body) return
+  try {
+    const res = await fetch('/api/traces?limit=100')
+    if (!res.ok) throw new Error(res.status)
+    const all = await res.json()
+    // Show traces that involve this agent (as root or any span)
+    const relevant = all.filter(tr => tr.root_agent === agentName)
+    sel.innerHTML = relevant.length === 0
+      ? `<option value="">${t('trace.no_traces')}</option>`
+      : relevant.map(tr => {
+          const dt = tr.start_ms ? new Date(tr.start_ms).toLocaleString('hu-HU', {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : ''
+          const dur = tr.end_ms && tr.start_ms ? `${((tr.end_ms - tr.start_ms)/1000).toFixed(1)}s` : '...'
+          return `<option value="${escapeHtml(tr.trace_id)}">[${dt}] ${escapeHtml(tr.root_operation)} ${dur} (${tr.span_count} span)</option>`
+        }).join('')
+    sel.addEventListener('change', () => {
+      if (sel.value) renderTraceWaterfall(sel.value)
+      else body.innerHTML = `<div class="trace-waterfall-empty">${t('trace.no_traces')}</div>`
+    })
+    if (relevant.length > 0) renderTraceWaterfall(relevant[0].trace_id)
+  } catch {
+    body.innerHTML = `<div class="trace-waterfall-empty">${t('trace.load_error')}</div>`
+  }
+}
+
+async function renderTraceWaterfall(traceId) {
+  const body = document.getElementById('traceWaterfallBody')
+  const badge = document.getElementById('traceStatusBadge')
+  if (!body) return
+  try {
+    const res = await fetch(`/api/traces/${encodeURIComponent(traceId)}`)
+    if (!res.ok) throw new Error(res.status)
+    const { spans } = await res.json()
+    if (!spans || !spans.length) {
+      body.innerHTML = `<div class="trace-waterfall-empty">${t('trace.no_spans')}</div>`
+      return
+    }
+    // Compute time range
+    const minMs = Math.min(...spans.map(s => s.start_ms))
+    const maxRaw = Math.max(...spans.map(s => s.end_ms || s.start_ms + 1))
+    const totalMs = Math.max(maxRaw - minMs, 1)
+    const now = Date.now()
+
+    // Layout constants
+    const LABEL_W = 110, ROW_H = 26, AXIS_H = 18, PAD_R = 8
+    const svgW = 600 // will be 100% via CSS
+    const barArea = svgW - LABEL_W - PAD_R
+    const svgH = spans.length * ROW_H + AXIS_H
+
+    // Badge
+    const hasError = spans.some(s => s.status === 'error')
+    const hasRunning = spans.some(s => s.status === 'running')
+    if (badge) {
+      const cls = hasError ? 'trace-status-error' : hasRunning ? 'trace-status-running' : 'trace-status-ok'
+      const lbl = hasError ? t('trace.status.error') : hasRunning ? t('trace.status.running') : t('trace.status.ok')
+      badge.innerHTML = `<span class="trace-status-badge ${cls}">${lbl}</span>`
+    }
+
+    // Find bottleneck span (longest duration)
+    const durations = spans.map(s => (s.end_ms || now) - s.start_ms)
+    const maxDur = Math.max(...durations)
+
+    let rows = ''
+    spans.forEach((s, i) => {
+      const y = i * ROW_H + AXIS_H
+      const startOff = s.start_ms - minMs
+      const dur = (s.end_ms || now) - s.start_ms
+      const x = LABEL_W + (startOff / totalMs) * barArea
+      const w = Math.max(3, (dur / totalMs) * barArea)
+      const color = agentColor(s.agent_id)
+      const isBottleneck = dur === maxDur && spans.length > 1
+      const isRunning = s.status === 'running'
+      const isError = s.status === 'error'
+      const label = s.agent_id.length > 13 ? s.agent_id.slice(0,12) + '…' : s.agent_id
+      const durLabel = dur >= 1000 ? `${(dur/1000).toFixed(1)}s` : `${dur}ms`
+      rows += `<rect class="trace-wf-row-bg" x="0" y="${y}" width="${svgW}" height="${ROW_H}"/>`
+      rows += `<text class="trace-wf-label" x="6" y="${y + ROW_H*0.65}">${escapeHtml(label)}</text>`
+      rows += `<rect class="trace-wf-bar${isRunning?' trace-wf-bar-running':''}${isError?' trace-wf-bar-error':''}"
+        x="${x.toFixed(1)}" y="${(y+4).toFixed(1)}" width="${w.toFixed(1)}" height="${ROW_H-8}"
+        rx="3" fill="${isError ? 'var(--danger)' : color}" opacity="${isError?0.7:0.85}"/>`
+      if (isBottleneck) {
+        rows += `<line class="trace-bottleneck" x1="${(x+w).toFixed(1)}" y1="${AXIS_H}" x2="${(x+w).toFixed(1)}" y2="${svgH}"/>`
+      }
+      rows += `<text class="trace-wf-axis-label" x="${Math.min(x+w+3,svgW-30).toFixed(1)}" y="${(y+ROW_H*0.65).toFixed(1)}" fill="${color}">${durLabel}</text>`
+    })
+
+    // Axis ticks (4 ticks)
+    let axis = ''
+    for (let i = 0; i <= 4; i++) {
+      const xPos = LABEL_W + (i / 4) * barArea
+      const msVal = (i / 4) * totalMs
+      const lbl = msVal >= 1000 ? `${(msVal/1000).toFixed(1)}s` : `${Math.round(msVal)}ms`
+      axis += `<line class="trace-wf-axis-line" x1="${xPos.toFixed(1)}" y1="${AXIS_H}" x2="${xPos.toFixed(1)}" y2="${svgH}"/>`
+      axis += `<text class="trace-wf-axis-label" x="${xPos.toFixed(1)}" y="${AXIS_H-4}" text-anchor="middle">${lbl}</text>`
+    }
+
+    body.innerHTML = `<svg class="trace-wf-svg" viewBox="0 0 ${svgW} ${svgH}" style="height:${svgH}px">${axis}${rows}</svg>`
+  } catch {
+    body.innerHTML = `<div class="trace-waterfall-empty">${t('trace.load_error')}</div>`
   }
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -10864,6 +10864,20 @@ async function renderTraceWaterfall(traceId) {
   const body = document.getElementById('traceWaterfallBody')
   const badge = document.getElementById('traceStatusBadge')
   if (!body) return
+
+  // Re-render when the resize handle moves the panel boundary (debounced 60ms)
+  if (body._traceObsId !== traceId) {
+    if (body._traceResizeObs) body._traceResizeObs.disconnect()
+    let _rTimer = null
+    const ro = new ResizeObserver(() => {
+      clearTimeout(_rTimer)
+      _rTimer = setTimeout(() => renderTraceWaterfall(traceId), 60)
+    })
+    ro.observe(body)
+    body._traceResizeObs = ro
+    body._traceObsId = traceId
+  }
+
   try {
     const res = await fetch(`/api/traces/${encodeURIComponent(traceId)}`)
     if (!res.ok) throw new Error(res.status)
@@ -10878,9 +10892,10 @@ async function renderTraceWaterfall(traceId) {
     const totalMs = Math.max(maxRaw - minMs, 1)
     const now = Date.now()
 
-    // Layout constants
-    const LABEL_W = 110, ROW_H = 26, AXIS_H = 18, PAD_R = 8
-    const svgW = 600 // will be 100% via CSS
+    // Layout: measure actual container so bars fill the full width and height
+    const svgW = body.clientWidth || 600
+    const LABEL_W = 110, AXIS_H = 18, PAD_R = 8
+    const ROW_H = Math.max(24, Math.floor((body.clientHeight - AXIS_H) / spans.length))
     const barArea = svgW - LABEL_W - PAD_R
     const svgH = spans.length * ROW_H + AXIS_H
 

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1700,4 +1700,13 @@ window._i18n.en = {
   'auth.card.active_sessions':    'Active sessions',
   'auth.card.token_mode':         'You are using token access. A browser login is configured.',
 
+  'trace.loading':                'Loading...',
+  'trace.no_traces':              'No traces for this agent',
+  'trace.no_spans':               'No spans in this trace',
+  'trace.load_error':             'Failed to load trace',
+  'trace.status.ok':              'OK',
+  'trace.status.error':           'Error',
+  'trace.status.running':         'Running',
+  'trace.status.timeout':         'Timeout',
+
 }

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1696,4 +1696,13 @@ window._i18n.hu = {
   'auth.card.active_sessions':    'Aktív munkamenetek',
   'auth.card.token_mode':         'Token-alapú elérést használsz. Egy böngészős belépés be van állítva.',
 
+  'trace.loading':                'Betöltés...',
+  'trace.no_traces':              'Nincs trace ehhez az ágenshez',
+  'trace.no_spans':               'Nincs span ebben a trace-ben',
+  'trace.load_error':             'Trace betöltési hiba',
+  'trace.status.ok':              'OK',
+  'trace.status.error':           'Hiba',
+  'trace.status.running':         'Fut',
+  'trace.status.timeout':         'Timeout',
+
 }

--- a/web/style.css
+++ b/web/style.css
@@ -7198,3 +7198,65 @@ body {
 }
 .auth-session-row code { color: var(--text); }
 .auth-session-ua { margin-left: auto; max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* === OTel Trace Waterfall (card def5a189) === */
+.chat-upper-pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 180px;
+  overflow: hidden;
+}
+.trace-resize-handle {
+  height: 5px;
+  background: var(--border);
+  cursor: row-resize;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+.trace-resize-handle:hover, .trace-resize-handle.dragging { background: var(--accent); }
+.trace-waterfall-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 140px;
+  overflow: hidden;
+  border-top: 1px solid var(--border);
+  background: var(--bg-card);
+}
+.trace-waterfall-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  background: var(--bg-card);
+}
+.trace-waterfall-title { font-size: 11px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+.trace-select { font-size: 12px; padding: 3px 8px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--text); max-width: 320px; flex: 1; }
+.trace-status-badge { font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 8px; }
+.trace-status-ok { background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent); }
+.trace-status-error { background: color-mix(in srgb, var(--danger) 15%, transparent); color: var(--danger); }
+.trace-status-running { background: color-mix(in srgb, #f59e0b 15%, transparent); color: #f59e0b; }
+.trace-waterfall-body {
+  flex: 1;
+  overflow: auto;
+  position: relative;
+}
+.trace-waterfall-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 80px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+/* Waterfall SVG rows */
+.trace-wf-svg { display: block; width: 100%; }
+.trace-wf-row-bg:nth-child(odd) { fill: color-mix(in srgb, var(--text) 3%, transparent); }
+.trace-wf-label { font-size: 11px; fill: var(--text); font-family: monospace; }
+.trace-wf-bar { rx: 3; }
+.trace-wf-bar-running { stroke: #f59e0b; stroke-width: 1.5; stroke-dasharray: 4 2; }
+.trace-wf-bar-error { opacity: 0.85; }
+.trace-wf-axis-line { stroke: var(--border); }
+.trace-wf-axis-label { font-size: 9px; fill: var(--text-muted); }
+.trace-bottleneck { stroke: var(--danger); stroke-width: 1.5; stroke-dasharray: 3 2; }


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Új funkció (feature)

## Rövid leírás / Summary
HU: Fleet-lánc latency és incidens-diagnózis a Marveen inter-agent üzenetbuszon. Minden ágens-átadásnál keletkezik egy elosztott trace (trace_id + span-fa), amely a dashboardon SVG Gantt-vizualizációként jelenik meg az Üzenetek képernyőn.
EN: Distributed tracing for the inter-agent message bus, enabling fleet-chain latency and incident diagnosis. Each agent handoff generates a trace with a span tree, visualized as an SVG Gantt waterfall on the Messages screen.

Főbb komponensek:
- otel_spans SQLite-tábla (trace_id, span_id, parent_span_id, agent_id, operation, start_ms, end_ms, status, attributes)
- agent_messages kiterjesztve: trace_id, span_id, parent_span_id oszlopokkal
- POST /api/spans (span nyitás/zárás); GET /api/traces (lista); GET /api/traces/:id (teljes span-fa)
- message-router middleware: automatikus trace-context propagáció (in-memory deliveredTraceCtx Map), idempotens stampMessageTrace() (WHERE trace_id IS NULL guard)
- Span-zárás PUT /api/messages/:id done/failed státusznál (closeOtelSpan)
- Üzenetek képernyő: kétpaneles elrendezés (resize handle), SVG waterfall Gantt teljes-keret-kitöltéssel (dinamikus svgW = clientWidth, ROW_H arányos, ResizeObserver 60ms debounce)
- Elkülönítés a #274/#667 tool-use trace-tól: otel_spans.trace_id = gyökér UUID az agent-lánc mentén; tool_call_log.trace_id = per-tool tool_use_id -- a kettő nem keveredik

Tesztek: 2739 zöld (11 új OTel-specifikus, in-memory SQLite), TS tiszta.

## Kapcsolódó issue


## Ellenőrzőlista
- [x] Lokálisan kipróbálva, ágensek hiba nélkül kommunikálnak
- [x] Nincs beleégetett szenzitív adat
- [x] Saját branch-ről nyitva (feat/otel-distributed-tracing)