### PR TITLE
chore(tracing): restore classify security comment + drop orphan closeOtelSpan import

### DIFF
--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -12,7 +12,6 @@ import {
   createAgentMessage,
   stampMessageTrace,
   upsertOtelSpan,
-  closeOtelSpan,
   type AgentMessage,
 } from '../db.js'
 import { isQualifiedId } from './federation/address.js'
@@ -540,6 +539,9 @@ export async function runMessageRouterTick(): Promise<void> {
       // Session is ready — clear stuck tracking.
       agentStuckSince.delete(msg.to_agent)
 
+      // Classify (channel-inbound / trusted-peer / untrusted) + reject an empty
+      // from_agent -- SINGLE SOURCE in agent-message-wrap so the router and the
+      // main-agent pull endpoint frame messages identically (no security drift).
       // Trace context (card def5a189): stamp if not yet set. channel-inbound
       // messages (user → agent) are excluded -- only inter-agent spans.
       const cls = classifyAgentMessage(msg.from_agent, msg.to_agent)


### PR DESCRIPTION
Follow-up to #705 (PR705FIX card), fresh branch off today's develop (c368a6b included).

- Restores the security guardrail comment above `classifyAgentMessage` ("SINGLE SOURCE in agent-message-wrap ... no security drift") that #705 replaced; the trace-context note now sits below it.
- Removes the orphan `closeOtelSpan` import from `message-router.ts` (span closing lives in `routes/messages.ts` and `routes/spans.ts`).

No behavior change. `tsc --noEmit` clean, tick-cap + otel test files green (13/13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)