### PR TITLE
fix(scheduler): report the cron timezone the scheduler actually uses

### DIFF
--- a/src/__tests__/cron.test.ts
+++ b/src/__tests__/cron.test.ts
@@ -23,22 +23,46 @@ const TZ = 'Europe/Budapest' // CEST (UTC+2) on 2026-07-15, no DST transition
 const ms = (utc: string) => Date.parse(utc)
 
 describe('resolveCronTz source precedence', () => {
-  it('prefers SCHEDULER_TZ over TZ', () => {
-    expect(resolveCronTz({ SCHEDULER_TZ: 'Europe/Budapest', TZ: 'UTC' })).toEqual({
+  it('prefers the configured SCHEDULER_TZ over the host zone', () => {
+    expect(resolveCronTz('Europe/Budapest', { TZ: 'UTC' }, 'UTC')).toEqual({
       tz: 'Europe/Budapest',
       source: 'SCHEDULER_TZ',
     })
   })
 
   it('falls back to TZ when SCHEDULER_TZ is absent', () => {
-    expect(resolveCronTz({ TZ: 'Europe/Budapest' })).toEqual({ tz: 'Europe/Budapest', source: 'TZ' })
+    expect(resolveCronTz(undefined, { TZ: 'Europe/Budapest' }, 'Europe/Budapest')).toEqual({
+      tz: 'Europe/Budapest',
+      source: 'TZ',
+    })
   })
 
   it('falls back to the system default when neither SCHEDULER_TZ nor TZ is set', () => {
-    const r = resolveCronTz({})
-    expect(r.source).toBe('system-default')
-    expect(typeof r.tz).toBe('string')
-    expect(r.tz.length).toBeGreaterThan(0)
+    expect(resolveCronTz(undefined, {}, 'UTC')).toEqual({ tz: 'UTC', source: 'system-default' })
+  })
+
+  // The reporter exists to tell the operator whether scheduling is on the
+  // intended zone. Reading process.env alone made it wrong in BOTH directions;
+  // these two lock the fix.
+
+  it('does not cry wolf when SCHEDULER_TZ comes from .env instead of process.env', () => {
+    // config-overrides.json / .env are read by cfg(), never exported into
+    // process.env -- so a correctly configured install used to be told on every
+    // boot that it had "fallen back to UTC" while CRON_TZ was already Budapest.
+    expect(resolveCronTz('Europe/Budapest', {}, 'UTC')).toEqual({
+      tz: 'Europe/Budapest',
+      source: 'SCHEDULER_TZ',
+    })
+  })
+
+  it('still warns when SCHEDULER_TZ is only exported into process.env', () => {
+    // cfg() does not read process.env, so APP_TZ stays on the host zone here.
+    // Reporting 'SCHEDULER_TZ' would suppress the warning on an install whose
+    // scheduling really is running on UTC.
+    expect(resolveCronTz(undefined, { SCHEDULER_TZ: 'Europe/Budapest' }, 'UTC')).toEqual({
+      tz: 'UTC',
+      source: 'system-default',
+    })
   })
 })
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,13 @@ function cfg(key: string): string | undefined {
 // process zone (the TZ env / OS) when unset. Replaces the ~15 hardcoded
 // 'Europe/Budapest' literals -- change the zone in ONE place, and an update that
 // re-introduces a hardcoded literal is caught by a single grep, not a full review.
-export const APP_TZ = cfg('SCHEDULER_TZ') || Intl.DateTimeFormat().resolvedOptions().timeZone
+// Exported separately so the scheduler's startup reporter can tell "an operator
+// pinned this zone" apart from "we fell back to the host zone" -- reading
+// process.env there cannot distinguish the two, because cfg() layers
+// config-overrides.json over .env and neither lands in process.env. See
+// resolveCronTz in web/cron.ts.
+export const SCHEDULER_TZ_CONFIGURED = cfg('SCHEDULER_TZ')
+export const APP_TZ = SCHEDULER_TZ_CONFIGURED || Intl.DateTimeFormat().resolvedOptions().timeZone
 
 export const TELEGRAM_BOT_TOKEN = env['TELEGRAM_BOT_TOKEN'] ?? ''
 export const ALLOWED_CHAT_ID = env['ALLOWED_CHAT_ID'] ?? ''

--- a/src/web/cron.ts
+++ b/src/web/cron.ts
@@ -1,5 +1,5 @@
 import { CronExpressionParser } from 'cron-parser'
-import { APP_TZ } from '../config.js'
+import { APP_TZ, SCHEDULER_TZ_CONFIGURED } from '../config.js'
 
 // All scheduled-task cron expressions (SKILL.md/task-config.json, the
 // dashboard schedule editor) are authored in the operator's own wall-clock
@@ -23,17 +23,49 @@ import { APP_TZ } from '../config.js'
 // startup instead of failing invisibly (see startScheduleRunner).
 export type CronTzSource = 'SCHEDULER_TZ' | 'TZ' | 'system-default'
 
-export function resolveCronTz(env: NodeJS.ProcessEnv = process.env): { tz: string; source: CronTzSource } {
-  if (env.SCHEDULER_TZ) return { tz: env.SCHEDULER_TZ, source: 'SCHEDULER_TZ' }
-  if (env.TZ) return { tz: env.TZ, source: 'TZ' }
-  return { tz: Intl.DateTimeFormat().resolvedOptions().timeZone, source: 'system-default' }
+// The reporter MUST resolve over the same layers APP_TZ does, or it lies about
+// the very thing it exists to surface. The earlier env-only version read
+// process.env directly and so diverged in both directions:
+//
+//  - FALSE ALARM: SCHEDULER_TZ set in .env (or config-overrides.json) never
+//    reaches process.env, so it reported system-default/UTC and fired the
+//    "fell back to UTC" warning while CRON_TZ was already the operator zone.
+//    An operator who had correctly configured the install was told, on every
+//    boot, that scheduling was broken.
+//  - MISSED ALARM: SCHEDULER_TZ exported into process.env is NOT read by
+//    cfg() (which layers config-overrides.json over .env), so APP_TZ stayed on
+//    the host zone -- yet the reporter announced 'SCHEDULER_TZ' and suppressed
+//    the warning, hiding a real misconfiguration.
+//
+// Hence `configuredTz` comes from the config layer (config.SCHEDULER_TZ_CONFIGURED)
+// and the host zone is passed in, mirroring `APP_TZ = cfg('SCHEDULER_TZ') || Intl`
+// branch for branch. Kept pure so both directions are testable without env
+// mutation; effectiveCronTz() below binds the real values.
+export function resolveCronTz(
+  configuredTz: string | undefined,
+  env: NodeJS.ProcessEnv,
+  systemTz: string,
+): { tz: string; source: CronTzSource } {
+  if (configuredTz) return { tz: configuredTz, source: 'SCHEDULER_TZ' }
+  // Below this point APP_TZ is the host zone either way; env.TZ only explains
+  // WHY the host zone is what it is, so the tz reported stays `systemTz`.
+  if (env.TZ) return { tz: systemTz, source: 'TZ' }
+  return { tz: systemTz, source: 'system-default' }
 }
 
 // The effective zone is config.APP_TZ (SCHEDULER_TZ via config-overrides.json >
 // .env > host zone), so a dashboard-set zone is honored and cron/display never
-// diverge; resolveCronTz() above stays as the startup source-reporter (see
+// diverge; effectiveCronTz() below is the startup source-reporter (see
 // startScheduleRunner) so the operator sees which layer won.
 const CRON_TZ = APP_TZ
+
+export function effectiveCronTz(): { tz: string; source: CronTzSource } {
+  return resolveCronTz(
+    SCHEDULER_TZ_CONFIGURED,
+    process.env,
+    Intl.DateTimeFormat().resolvedOptions().timeZone,
+  )
+}
 
 export function computeNextRun(cronExpression: string, tz: string = CRON_TZ): number {
   const expr = CronExpressionParser.parse(cronExpression, { tz })

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -26,7 +26,7 @@ import {
   SCHEDULED_TASK_PREAMBLE,
   wrapScheduledTask,
 } from '../prompt-safety.js'
-import { cronDueBetween, resolveCronTz } from './cron.js'
+import { cronDueBetween, effectiveCronTz } from './cron.js'
 import {
   listScheduledTasks,
   SCHEDULED_TASKS_DIR,
@@ -726,7 +726,7 @@ export function startScheduleRunner(): NodeJS.Timeout {
   // outage that is otherwise invisible until someone notices the missing
   // briefing (2026-07-13..15). Logging the source turns it into a grep-able
   // signal; the warn fires only on the actively-dangerous UTC-by-default case.
-  const { tz: cronTz, source: cronTzSource } = resolveCronTz()
+  const { tz: cronTz, source: cronTzSource } = effectiveCronTz()
   logger.info({ cronTz, cronTzSource }, 'schedule-runner: cron timezone in effect')
   if (cronTzSource === 'system-default' && cronTz === 'UTC') {
     logger.warn(


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** Az ütemező indításkor kiírja, melyik időzónában értelmezi a cron kifejezéseket, és figyelmeztet, ha UTC-re esett vissza. Ez a jelző azonban `process.env`-ből dolgozott, miközben a tényleges ütemezés `APP_TZ`-ből (`cfg('SCHEDULER_TZ')`, azaz `config-overrides.json` a `.env` fölé rétegezve). Két különböző réteg, ezért a log **mindkét irányban** eltérhetett a valóságtól:

- **Hamis riasztás:** a `.env`-ben beállított `SCHEDULER_TZ` soha nem kerül `process.env`-be, így egy helyesen konfigurált install minden indításkor azt kapta, hogy „fell back to UTC" — miközben a `CRON_TZ` már az operátor zónája volt. Ez nemcsak időt visz el, hanem hozzászoktatja az operátort, hogy figyelmen kívül hagyja pont azt a jelzést, aminek egy valódi kiesést kellene elkapnia.
- **Elmaradt riasztás:** a csak `process.env`-be exportált `SCHEDULER_TZ`-t a `cfg()` nem olvassa, tehát `APP_TZ` a host zónáján marad — a jelző viszont `SCHEDULER_TZ`-t jelentett és elnyomta a figyelmeztetést egy olyan installon, ami valóban UTC-ben ütemezett.

**Megközelítés:** a `resolveCronTz` mostantól explicit paraméterként kapja a konfigurált zónát, a környezetet és a host zónát, ágról ágra tükrözve az `APP_TZ = cfg('SCHEDULER_TZ') || Intl` feloldást. A runner az új `effectiveCronTz()`-t hívja, ami a valós értékeket köti be. A függvény tiszta maradt, így mindkét hibairány env-mutálás nélkül tesztelhető.

**Az ütemező viselkedése nem változik, csak amit jelent magáról.**

**EN:** The scheduler's startup timezone reporter resolved over `process.env` while the scheduler itself resolves over `APP_TZ` (`cfg('SCHEDULER_TZ')` = `config-overrides.json` layered over `.env`). Different layers, so the log disagreed with reality in both directions: a `.env`-configured install was warned about a UTC fallback that had not happened, and an install that only exported `SCHEDULER_TZ` into `process.env` had its real UTC fallback silently suppressed. `resolveCronTz` now takes the configured zone, the env and the host zone explicitly, mirroring `APP_TZ` branch for branch; `effectiveCronTz()` binds the real values. Scheduler behaviour is unchanged — only its self-report.

**Hogyan találtuk / How it surfaced:** egy kézi újraindítás `TZ` nélkül indította a folyamatot, amitől minden fix időpontú cron 2 órát csúszott, az intervallumosak viszont pontosak maradtak (ezek tz-invariánsak) — pontosan a `cron.ts` fejlécében leírt részleges kiesés. A `SCHEDULER_TZ` `.env`-be írása megoldotta, de onnantól a WARN hamisan riasztott minden induláskor, ami elrejtette volna a következő valódi esetet.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.

  <sub>Nem érinti: viselkedésbeli változás nincs, csak a startup-log pontossága; a `SCHEDULER_TZ` már dokumentált. / Not applicable: no behavioural change, only startup-log accuracy.</sub>
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Tesztek / Tests

`src/__tests__/cron.test.ts` — a meglévő három precedencia-teszt átállítva az új szignatúrára, plusz két új regressziós teszt, egy-egy hibairányra:

- `does not cry wolf when SCHEDULER_TZ comes from .env instead of process.env`
- `still warns when SCHEDULER_TZ is only exported into process.env`

`npx vitest run src/__tests__/cron.test.ts` → 19/19 zöld. A kapcsolódó `config-registry`, `reauth-quiet-hours`, `schedule-runner-autostart`, `schedule-run-now`, `schedule-runner-precheck` szuitok is futottak (61/61 zöld), `tsc --noEmit` tiszta.
