### PR TITLE
fix(kanban): make cards movable on touch devices

### DIFF
--- a/tests/smoke/kanban-mobile-move.spec.ts
+++ b/tests/smoke/kanban-mobile-move.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Mobile kanban card-move smoke tests.
+ *
+ * Prerequisites: the dashboard must be running and DASHBOARD_TOKEN must be set.
+ *   DASHBOARD_TOKEN=$(cat store/.dashboard-token) npx playwright test tests/smoke/kanban-mobile-move.spec.ts
+ *
+ * What these catch: the board being effectively read-only on a phone. HTML5
+ * drag & drop never fires on touch, so BOTH paths added for mobile are
+ * verified here against a real touch-enabled browser context -- a long-press
+ * drag between columns, and the status dropdown in the card detail modal.
+ *
+ * Each test moves a card and moves it back, so the board ends as it started.
+ *
+ * Note the target statuses: NOT in_progress. /move fires fireKanbanDispatch()
+ * on entry to in_progress, which wakes the card's assigned agent -- a test run
+ * must not page a live agent, and restoring the status afterwards does not
+ * un-send that message.
+ */
+
+import { test, expect, devices, type Page } from '@playwright/test'
+
+const TOKEN = process.env.DASHBOARD_TOKEN || ''
+
+test.use({ ...devices['Pixel 5'] })
+
+type Card = { id: string; title: string; status: string }
+
+async function firstPlannedCard(page: Page): Promise<Card> {
+  const res = await page.request.get('/api/kanban', {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  })
+  expect(res.ok()).toBeTruthy()
+  const body = await res.json()
+  const cards: Card[] = Array.isArray(body) ? body : (body.cards ?? [])
+  const card = cards.find((c) => c.status === 'planned')
+  expect(card, 'needs at least one planned card to move').toBeTruthy()
+  return card as Card
+}
+
+async function statusOf(page: Page, id: string): Promise<string> {
+  const res = await page.request.get('/api/kanban', {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  })
+  const body = await res.json()
+  const cards: Card[] = Array.isArray(body) ? body : (body.cards ?? [])
+  return cards.find((c) => c.id === id)?.status ?? ''
+}
+
+async function restore(page: Page, id: string, status: string) {
+  await page.request.post(`/api/kanban/${encodeURIComponent(id)}/move`, {
+    headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' },
+    data: { status, sort_order: 0 },
+  })
+}
+
+async function openKanban(page: Page) {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(e.message))
+  await page.goto(`/?token=${TOKEN}`)
+  await page.evaluate(() => (window as unknown as { switchPage: (p: string) => void }).switchPage('kanban'))
+  await page.waitForSelector('.kanban-card', { timeout: 10_000 })
+  return errors
+}
+
+test.describe('kanban card move on touch', () => {
+  test('long-press drag moves a card to another column', async ({ page }) => {
+    const card = await firstPlannedCard(page)
+    const errors = await openKanban(page)
+
+    const el = page.locator(`.kanban-card[data-id="${card.id}"]`)
+    await expect(el).toBeVisible()
+    const from = await el.boundingBox()
+    expect(from).toBeTruthy()
+
+    // Long press past TOUCH_DRAG_DELAY_MS, then drag. Movement before the
+    // delay would (correctly) be handed back to the browser as a scroll.
+    const cdp = await page.context().newCDPSession(page)
+    const x0 = from!.x + from!.width / 2
+    const y0 = from!.y + 20
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ x: x0, y: y0 }],
+    })
+    await page.waitForTimeout(400)
+
+    // The drop bar exists only while a drag is committed -- its presence is
+    // itself the proof that the long press was recognised as a drag.
+    const chip = page.locator('.kanban-drop-target[data-status="testing"]')
+    await expect(chip).toBeVisible()
+    const to = await chip.boundingBox()
+    expect(to).toBeTruthy()
+    const tx = to!.x + to!.width / 2
+    const ty = to!.y + to!.height / 2
+
+    for (const f of [0.3, 0.6, 1]) {
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: x0 + (tx - x0) * f, y: y0 + (ty - y0) * f }],
+      })
+      await page.waitForTimeout(60)
+    }
+    await expect(chip).toHaveClass(/drag-over/)
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [{ x: tx, y: ty }] })
+
+    await expect
+      .poll(() => statusOf(page, card.id), { timeout: 8_000 })
+      .toBe('testing')
+
+    expect(errors).toEqual([])
+    await restore(page, card.id, card.status)
+  })
+
+  test('detail modal status dropdown moves a card', async ({ page }) => {
+    const card = await firstPlannedCard(page)
+    const errors = await openKanban(page)
+
+    await page.locator(`.kanban-card[data-id="${card.id}"]`).tap()
+    const statusValue = page.locator('#metaStatusValue')
+    await expect(statusValue).toBeVisible()
+
+    await statusValue.tap()
+    const select = statusValue.locator('select')
+    await expect(select).toBeVisible()
+    await select.selectOption('waiting')
+
+    await expect
+      .poll(() => statusOf(page, card.id), { timeout: 8_000 })
+      .toBe('waiting')
+
+    expect(errors).toEqual([])
+    await restore(page, card.id, card.status)
+  })
+})

--- a/web/app.js
+++ b/web/app.js
@@ -1445,6 +1445,11 @@ function createCardEl(card, embeddedChildren = []) {
   })
   el.addEventListener('dragend', () => el.classList.remove('dragging'))
 
+  // Touch equivalent of the above -- see wireKanbanCardTouchDnD. Wired before
+  // the click listener so its capture-phase guard can swallow the tap that
+  // ends a drag.
+  wireKanbanCardTouchDnD(el, card)
+
   // Click -> detail
   el.addEventListener('click', () => showCardDetail(card))
 
@@ -1501,6 +1506,198 @@ function wireKanbanColumnDnD(col) {
   })
 }
 columns.forEach(wireKanbanColumnDnD)
+
+// === Touch drag & drop (mobile) ===
+// HTML5 drag & drop above never fires on a touch screen -- no dragstart, no
+// drop -- so on a phone the board could only be read, never rearranged. This
+// is a parallel touch path over the same /move call.
+//
+// Why touch events and not Pointer Events + touch-action: a card fills most of
+// the column, so making it permanently untouchable for scrolling (touch-action:
+// none) would break scrolling the board. Instead the gesture stays ambiguous
+// until it resolves: a long press (250ms) means "drag", any earlier movement
+// means "scroll" and hands the gesture straight back to the browser. Only once
+// dragging is committed does touchmove call preventDefault() to hold the page
+// still -- which is why that listener MUST be non-passive.
+const TOUCH_DRAG_DELAY_MS = 250
+const TOUCH_DRAG_SLOP_PX = 10
+let touchDrag = null
+
+function kanbanColBodyAt(x, y) {
+  const el = document.elementFromPoint(x, y)
+  return el ? el.closest('.kanban-col-body') : null
+}
+
+// On a phone the columns stack vertically, so the next column starts ~2000px
+// below the fold -- dragging a card "one column over" would mean dragging it
+// at an invisible target while the page auto-scrolls for several seconds.
+// Instead, committing to a drag raises a fixed bar of status targets over the
+// bottom of the screen: the same gesture, with somewhere to drop. Column
+// hit-testing stays active for viewports where the target column IS visible.
+const KANBAN_TOUCH_STATUSES = ['planned', 'in_progress', 'waiting', 'testing', 'done']
+
+function buildTouchDropBar(currentStatus) {
+  const bar = document.createElement('div')
+  bar.className = 'kanban-touch-dropbar'
+  for (const s of KANBAN_TOUCH_STATUSES) {
+    const chip = document.createElement('div')
+    chip.className = 'kanban-drop-target'
+    chip.dataset.status = s
+    if (s === currentStatus) chip.classList.add('is-current')
+    chip.textContent = t(`kanban.status.${s}`)
+    bar.appendChild(chip)
+  }
+  document.body.appendChild(bar)
+  return bar
+}
+
+function kanbanDropTargetAt(x, y) {
+  const el = document.elementFromPoint(x, y)
+  return el ? el.closest('.kanban-drop-target') : null
+}
+
+function clearTouchDragHighlight() {
+  document.querySelectorAll('.kanban-col-body.drag-over, .kanban-drop-target.drag-over')
+    .forEach((c) => c.classList.remove('drag-over'))
+}
+
+function endTouchDrag() {
+  if (!touchDrag) return
+  clearTimeout(touchDrag.timer)
+  touchDrag.ghost?.remove()
+  touchDrag.dropBar?.remove()
+  touchDrag.el.classList.remove('dragging')
+  clearTouchDragHighlight()
+  document.removeEventListener('touchmove', kanbanTouchMove)
+  document.removeEventListener('touchend', kanbanTouchEnd)
+  document.removeEventListener('touchcancel', endTouchDrag)
+  touchDrag = null
+}
+
+// The ghost is deliberately NOT a full-size copy of the card: at full width it
+// covered three of the five drop targets, so the user could not see what they
+// were aiming at. It rides ABOVE the fingertip (see positionTouchGhost) for the
+// same reason -- the target under the finger has to stay visible.
+const TOUCH_GHOST_MAX_W = 200
+const TOUCH_GHOST_LIFT = 28
+
+function positionTouchGhost(x, y) {
+  const g = touchDrag.ghost
+  const gx = x - g.offsetWidth / 2
+  const gy = y - g.offsetHeight - TOUCH_GHOST_LIFT
+  g.style.transform = `translate(${Math.max(4, gx)}px, ${Math.max(4, gy)}px) rotate(2deg)`
+}
+
+function beginTouchDrag(x, y) {
+  if (!touchDrag) return
+  const el = touchDrag.el
+  const box = el.getBoundingClientRect()
+  const ghost = document.createElement('div')
+  ghost.className = 'kanban-card kanban-card-ghost'
+  ghost.textContent = touchDrag.card.title
+  ghost.style.cssText = `position:fixed; left:0; top:0; width:${Math.min(box.width, TOUCH_GHOST_MAX_W)}px; pointer-events:none; z-index:9999; opacity:.95; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; box-shadow:0 8px 24px rgba(0,0,0,.35)`
+  document.body.appendChild(ghost)
+  touchDrag.ghost = ghost
+  positionTouchGhost(x, y)
+  touchDrag.active = true
+  touchDrag.dropBar = buildTouchDropBar(touchDrag.card.status)
+  el.classList.add('dragging')
+  // Confirm the mode switch on devices that support it -- without a cursor,
+  // the only other signal that a long press "took" is the ghost appearing.
+  navigator.vibrate?.(10)
+}
+
+function kanbanTouchMove(e) {
+  if (!touchDrag || e.touches.length !== 1) return
+  const p = e.touches[0]
+  if (!touchDrag.active) {
+    // Still ambiguous: movement beyond the slop means the user is scrolling.
+    if (Math.abs(p.clientX - touchDrag.startX) > TOUCH_DRAG_SLOP_PX ||
+        Math.abs(p.clientY - touchDrag.startY) > TOUCH_DRAG_SLOP_PX) {
+      endTouchDrag()
+    }
+    return
+  }
+  e.preventDefault()
+  positionTouchGhost(p.clientX, p.clientY)
+  clearTouchDragHighlight()
+  // The drop bar sits above everything, so test it first -- a chip and a
+  // column body can overlap on screen.
+  const chip = kanbanDropTargetAt(p.clientX, p.clientY)
+  if (chip) { chip.classList.add('drag-over'); return }
+  const col = kanbanColBodyAt(p.clientX, p.clientY)
+  if (col) col.classList.add('drag-over')
+}
+
+async function kanbanTouchEnd(e) {
+  if (!touchDrag) return
+  if (!touchDrag.active) { endTouchDrag(); return }
+  const p = e.changedTouches[0]
+  const chip = kanbanDropTargetAt(p.clientX, p.clientY)
+  const col = chip ? null : kanbanColBodyAt(p.clientX, p.clientY)
+  const cardId = touchDrag.card.id
+  // The release that ends a drag would otherwise also register as a tap and
+  // open the detail modal on top of the board the user just rearranged.
+  touchDrag.el.dataset.suppressClick = '1'
+  // Read the drop position BEFORE endTouchDrag drops the .dragging class --
+  // getDragAfterElement excludes .dragging, which is what keeps the card from
+  // counting itself when it is dropped back into its own column.
+  let sortOrder = 0
+  let newStatus = null
+  if (chip) {
+    // Dropped on the status bar: no position information, so append.
+    newStatus = chip.dataset.status
+    sortOrder = document.querySelectorAll(`.kanban-col-body[data-status="${newStatus}"] .kanban-card`).length
+  } else if (col) {
+    newStatus = col.dataset.status
+    const after = getDragAfterElement(col, p.clientY)
+    const others = [...col.querySelectorAll('.kanban-card:not(.dragging)')]
+    sortOrder = after ? others.indexOf(after) : others.length
+  }
+  endTouchDrag()
+  // Released outside any target: treat as a cancelled drag, not a move.
+  // A drop inside a column always posts, even when the status is unchanged --
+  // that is a reorder within the column, which is just as valid a move.
+  if (!newStatus) return
+  try {
+    const r = await fetch(`/api/kanban/${encodeURIComponent(cardId)}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: newStatus, sort_order: sortOrder }),
+    })
+    if (!r.ok) throw new Error('move failed')
+    loadKanban()
+  } catch {
+    showToast(t('kanban.toast.move_error'))
+  }
+}
+
+function wireKanbanCardTouchDnD(el, card) {
+  el.addEventListener('touchstart', (e) => {
+    if (e.touches.length !== 1) return
+    const p = e.touches[0]
+    endTouchDrag()
+    touchDrag = {
+      card, el, ghost: null, active: false,
+      startX: p.clientX, startY: p.clientY,
+      timer: setTimeout(() => beginTouchDrag(p.clientX, p.clientY), TOUCH_DRAG_DELAY_MS),
+    }
+    document.addEventListener('touchmove', kanbanTouchMove, { passive: false })
+    document.addEventListener('touchend', kanbanTouchEnd)
+    document.addEventListener('touchcancel', endTouchDrag)
+  }, { passive: true })
+
+  // A long press that turned into a drag must not also open the detail modal
+  // on release. The click listener in createCardEl fires after touchend, so
+  // the guard flag is read there.
+  el.addEventListener('click', (e) => {
+    if (el.dataset.suppressClick === '1') {
+      delete el.dataset.suppressClick
+      e.stopImmediatePropagation()
+      e.preventDefault()
+    }
+  }, true)
+}
 
 function getDragAfterElement(col, y) {
   const els = [...col.querySelectorAll('.kanban-card:not(.dragging)')]
@@ -1715,7 +1912,7 @@ async function showCardDetail(card) {
     </div>
     <div class="meta-item">
       <span class="meta-label">${t('kanban.meta.status')}</span>
-      <span class="meta-value">${statusLabels[card.status] || card.status}</span>
+      <span class="meta-value meta-value-editable" id="metaStatusValue" data-card-id="${card.id}" title="${t('kanban.meta.edit_tooltip')}">${statusLabels[card.status] || card.status}</span>
     </div>
     <div class="meta-item">
       <span class="meta-label">${t('kanban.meta.assignee')}</span>
@@ -1734,6 +1931,55 @@ async function showCardDetail(card) {
       <span class="meta-value">${card.due_date ? new Date(card.due_date * 1000).toLocaleDateString(_lang === 'en' ? 'en-US' : 'hu-HU') : t('kanban.meta.none')}</span>
     </div>
   `
+
+  // Inline edit for status on detail view. HTML5 drag & drop is the only way to
+  // change a card's column, and it is dead on touch devices (no dragstart is
+  // ever fired), so on a phone the board was effectively read-only. This is the
+  // pointer-independent path: tap the card, pick the new status. Mirrors the
+  // assignee editor below, but POSTs to /move rather than PUT -- /move is what
+  // recomputes sort_order AND fires the in_progress agent dispatch, which a
+  // plain PUT would silently skip.
+  const statusValueEl = document.getElementById('metaStatusValue')
+  statusValueEl.addEventListener('click', () => {
+    if (statusValueEl.querySelector('select')) return
+    const current = card.status
+    const sel = document.createElement('select')
+    sel.style.cssText = 'padding:2px 6px; border-radius:4px; border:1px solid var(--border); background:var(--bg-card); color:var(--text); font-size:inherit'
+    for (const s of ['planned', 'in_progress', 'waiting', 'testing', 'done']) {
+      const opt = document.createElement('option')
+      opt.value = s
+      opt.textContent = statusLabels[s] || s
+      if (s === current) opt.selected = true
+      sel.appendChild(opt)
+    }
+    statusValueEl.innerHTML = ''
+    statusValueEl.appendChild(sel)
+    sel.focus()
+    const restore = (status) => { statusValueEl.textContent = statusLabels[status] || status }
+    const save = async () => {
+      const newVal = sel.value
+      if (newVal === current) { restore(current); return }
+      try {
+        const r = await fetch(`/api/kanban/${encodeURIComponent(card.id)}/move`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: newVal, sort_order: 0 }),
+        })
+        if (!r.ok) throw new Error('move failed')
+        card.status = newVal
+        restore(newVal)
+        showToast(t('kanban.toast.status_updated'))
+        loadKanban && loadKanban()
+      } catch {
+        restore(current)
+        showToast(t('kanban.toast.move_error'))
+      }
+    }
+    sel.addEventListener('change', save)
+    sel.addEventListener('blur', () => {
+      if (statusValueEl.querySelector('select')) restore(card.status)
+    })
+  })
 
   // Inline edit for assignee on detail view
   const assigneeValueEl = document.getElementById('metaAssigneeValue')

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -240,6 +240,7 @@ window._i18n.en = {
   'kanban.toast.subtask_deleted': 'Subtask deleted',
   'kanban.toast.parent_updated': 'Parent updated',
   'kanban.toast.parent_unset':   'Parent removed',
+  'kanban.toast.status_updated': 'Status updated',
   'kanban.toast.assignee_updated': 'Assignee updated',
   'kanban.toast.comment_no_author': 'Select an author for the comment',
   'kanban.toast.comment_failed': 'Comment not saved: {msg}',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -240,6 +240,7 @@ window._i18n.hu = {
   'kanban.toast.subtask_deleted': 'Alfeladat törölve',
   'kanban.toast.parent_updated': 'Szülő módosítva',
   'kanban.toast.parent_unset':   'Szülő leválasztva',
+  'kanban.toast.status_updated': 'Állapot frissítve',
   'kanban.toast.assignee_updated': 'Felelős frissítve',
   'kanban.toast.comment_no_author': 'Válassz szerzőt a megjegyzéshez',
   'kanban.toast.comment_failed': 'Megjegyzés nem mentődött: {msg}',

--- a/web/style.css
+++ b/web/style.css
@@ -717,6 +717,48 @@ main {
   border-radius: var(--radius-sm);
 }
 
+/* Touch drag drop bar. Raised only while a long-press drag is in progress:
+   on a phone the columns stack, so the next column is ~2000px below the fold
+   and there is nothing on screen to drop onto. Fixed to the bottom edge so
+   the drop target is always within thumb reach, whatever the scroll position. */
+.kanban-touch-dropbar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9998; /* under the dragged ghost (9999), over the board */
+  display: flex;
+  gap: 6px;
+  padding: 10px 10px calc(10px + env(safe-area-inset-bottom));
+  background: var(--bg-card);
+  border-top: 1px solid var(--border);
+  box-shadow: 0 -6px 20px rgba(0, 0, 0, .25);
+}
+.kanban-drop-target {
+  flex: 1;
+  min-width: 0;
+  padding: 12px 4px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  text-align: center;
+  font-size: 11px;
+  line-height: 1.2;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* The column the card is already in -- a valid drop (it just reorders), but
+   dimmed so the eye goes to the other four. */
+.kanban-drop-target.is-current {
+  opacity: .5;
+}
+.kanban-drop-target.drag-over {
+  background: var(--accent-soft);
+  border-style: solid;
+  border-color: var(--accent);
+  color: var(--text);
+}
+
 /* === Kanban Card === */
 .kanban-card {
   background: var(--bg-card);


### PR DESCRIPTION
## The bug

The kanban board is effectively **read-only on a phone**. Reported from real use.

A card's column can only be changed by HTML5 drag & drop, which never fires on a touch screen -- no `dragstart`, no `drop`. And the detail modal renders the status as plain text: the assignee right next to it is inline-editable (`meta-value-editable`), the status is not. So on mobile there was no third way to move a card at all.

## Why not just wire touch events to the existing drop zones

That was my first implementation, and measuring it on a real emulated device is what killed it. On a Pixel 5 (393x727) with 19 planned cards the columns stack vertically:

```
planned      y=487   h=1577
in_progress  y=2128  h=60     <- ~2100px below the fold
waiting      y=2252  h=60
```

Dragging a card "one column over" would mean holding a finger at the screen edge while the page auto-scrolls for several seconds toward a target you cannot see. Technically a drag; practically unusable.

## What this does instead

**1. Long-press drag onto a status bar.** A 250ms press commits to a drag and raises a fixed bar of the five statuses over the bottom edge -- the same gesture, with somewhere to drop, always within thumb reach regardless of scroll position. Column hit-testing stays active for viewports where the target column *is* on screen, so nothing changes on a desktop-width board.

**2. Status dropdown in the card detail modal**, mirroring the assignee editor beside it. This is the path that does not depend on a gesture landing.

### Gesture disambiguation

A card fills most of the column, so `touch-action: none` on cards would break scrolling the board. Instead the gesture stays ambiguous until it resolves: movement beyond 10px before the long press hands it straight back to the browser as a scroll; only a committed drag calls `preventDefault()` -- which is why that `touchmove` listener must be non-passive.

### Details worth flagging for review

- Both paths POST to `/move`, not `PUT`. `/move` is what recomputes `sort_order` **and** fires `fireKanbanDispatch()` on entry to `in_progress`; a plain `PUT` would silently skip waking the assigned agent.
- The drag ghost is a compact pill riding *above* the fingertip rather than a full-size clone -- at full card width it covered three of the five drop targets. (First screenshot caught this; second confirmed the fix.)
- The tap that ends a drag is swallowed by a capture-phase guard so it does not also open the detail modal on top of the board you just rearranged.

## Tests

`tests/smoke/kanban-mobile-move.spec.ts` drives a real touch-enabled Pixel 5 context (CDP `Input.dispatchTouchEvent`) through both paths and asserts the card actually changed status server-side, then restores it.

They deliberately target `testing`, never `in_progress`: `/move` wakes the card's assigned agent on entry to `in_progress`, and restoring the status afterwards does not un-send that message. A test run must not page a live agent. (Found the hard way -- an early run of this suite dispatched two real cards.)

11/11 smoke tests green, including the 9 pre-existing ones.