### PR TITLE
fix(watchdog): respawn sub-agents on their own channel provider

### DIFF
--- a/scripts/__tests__/watchdog-provider.test.sh
+++ b/scripts/__tests__/watchdog-provider.test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Contract tests for scripts/watchdog.sh provider resolution.
+#
+# Regression origin (2026-07-26): the sub-agent watchdog read the bot token
+# from .claude/channels/telegram/.env and respawned with plugin:telegram,
+# regardless of the agent's actual channelProvider. A discord-primary agent
+# therefore hit "no bot token, skipping" and was NEVER restarted -- the log
+# line looks routine, so the outage was invisible. Two live agents sat in
+# that state undetected.
+#
+# Driven through `watchdog.sh --resolve-provider <dir>`, which resolves and
+# exits before touching tmux, the dashboard API or the log -- so these run
+# from fixtures with no live agent and no real token.
+# Run: bash scripts/__tests__/watchdog-provider.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 -- got: $2"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+# Overridable so the suite can be pointed at a deliberately-broken copy to
+# confirm it actually fails on the bug (a green test that cannot go red is
+# worse than no test -- it certifies health it never checked).
+WATCHDOG="${WATCHDOG_BIN:-$INSTALL_DIR/scripts/watchdog.sh}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# $1 = fixture name, $2 = agent-config.json content ("" = no file at all)
+make_agent() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir"
+  [ -n "$2" ] && printf '%s' "$2" > "$dir/agent-config.json"
+  echo "$dir"
+}
+
+# $1 = label, $2 = agent dir, $3 = expected full output line
+expect_resolve() {
+  local got
+  got=$(bash "$WATCHDOG" --resolve-provider "$2" 2>&1)
+  if [ "$got" = "$3" ]; then pass "$1"; else fail "$1" "$got"; fi
+}
+
+echo "watchdog provider-resolution tests"
+echo "==================================="
+echo ""
+
+# ---------------------------------------------------------------------------
+# The bug: discord-primary agent must resolve to discord, not telegram.
+# ---------------------------------------------------------------------------
+echo "(a) Explicit providers"
+expect_resolve "discord agent resolves to discord" \
+  "$(make_agent discord '{"channelProvider":"discord","model":"claude-opus-4-8"}')" \
+  "provider=discord token_var=DISCORD_BOT_TOKEN state_env_var=DISCORD_STATE_DIR"
+expect_resolve "slack agent resolves to slack" \
+  "$(make_agent slack '{"channelProvider":"slack"}')" \
+  "provider=slack token_var=SLACK_BOT_TOKEN state_env_var=SLACK_STATE_DIR"
+expect_resolve "teams agent resolves to teams" \
+  "$(make_agent teams '{"channelProvider":"teams"}')" \
+  "provider=teams token_var=TEAMS_BOT_TOKEN state_env_var=TEAMS_STATE_DIR"
+expect_resolve "googlechat agent resolves to googlechat" \
+  "$(make_agent gchat '{"channelProvider":"googlechat"}')" \
+  "provider=googlechat token_var=GOOGLECHAT_BOT_TOKEN state_env_var=GOOGLECHAT_STATE_DIR"
+expect_resolve "telegram agent resolves to telegram" \
+  "$(make_agent tg '{"channelProvider":"telegram"}')" \
+  "provider=telegram token_var=TELEGRAM_BOT_TOKEN state_env_var=TELEGRAM_STATE_DIR"
+
+# ---------------------------------------------------------------------------
+# Back-compat: every degenerate input must still land on telegram, so
+# existing single-channel installs are untouched by this change.
+# ---------------------------------------------------------------------------
+echo ""
+echo "(b) Fallback to telegram"
+TG_LINE="provider=telegram token_var=TELEGRAM_BOT_TOKEN state_env_var=TELEGRAM_STATE_DIR"
+expect_resolve "config without channelProvider" \
+  "$(make_agent noprov '{"model":"claude-haiku-4-5-20251001"}')" "$TG_LINE"
+expect_resolve "no agent-config.json at all" \
+  "$(make_agent nofile '')" "$TG_LINE"
+expect_resolve "malformed JSON" \
+  "$(make_agent badjson '{not valid json')" "$TG_LINE"
+expect_resolve "empty channelProvider string" \
+  "$(make_agent emptyprov '{"channelProvider":""}')" "$TG_LINE"
+expect_resolve "unknown provider name" \
+  "$(make_agent unknown '{"channelProvider":"carrier-pigeon"}')" "$TG_LINE"
+
+# ---------------------------------------------------------------------------
+# The self-test hook must not fire on a normal watchdog run, and must not
+# silently succeed when called wrong.
+# ---------------------------------------------------------------------------
+echo ""
+echo "(c) Hook contract"
+bash "$WATCHDOG" --resolve-provider >/dev/null 2>&1
+if [ $? -eq 2 ]; then pass "missing dir argument exits 2"; else fail "missing dir argument exits 2" "exit=$?"; fi
+
+echo ""
+echo "==================================="
+echo "PASS: $PASS  FAIL: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -12,6 +12,42 @@ WEB_PORT="${WEB_PORT:-3420}"
 
 timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
 
+# Resolve which channel an agent must be respawned on, from its OWN
+# agent-config.json channelProvider -- the same field src/web/agent-process.ts
+# launches from. Sets AGENT_PROVIDER / TOKEN_VAR / STATE_ENV_VAR.
+#
+# Hardcoding telegram here had two failure modes for a non-telegram agent:
+# (a) no TELEGRAM_BOT_TOKEN in its .env, so the loop hit "no bot token,
+# skipping" and the watchdog NEVER restarted it -- precisely the agent the
+# watchdog exists for stayed dead, while the log line looked routine; or
+# (b) it came back on the wrong channel and was mute on its real one.
+#
+# Unknown / missing / malformed provider falls back to telegram, matching
+# the pre-existing default so single-channel telegram installs are unaffected.
+resolve_agent_provider() {
+  local agent_dir="$1"
+  AGENT_PROVIDER=$(python3 -c "import json; d=json.load(open('$agent_dir/agent-config.json')); print(d.get('channelProvider','telegram'))" 2>/dev/null || echo telegram)
+  [ -n "$AGENT_PROVIDER" ] || AGENT_PROVIDER=telegram
+  case "$AGENT_PROVIDER" in
+    slack)      TOKEN_VAR="SLACK_BOT_TOKEN";      STATE_ENV_VAR="SLACK_STATE_DIR" ;;
+    discord)    TOKEN_VAR="DISCORD_BOT_TOKEN";    STATE_ENV_VAR="DISCORD_STATE_DIR" ;;
+    teams)      TOKEN_VAR="TEAMS_BOT_TOKEN";      STATE_ENV_VAR="TEAMS_STATE_DIR" ;;
+    googlechat) TOKEN_VAR="GOOGLECHAT_BOT_TOKEN"; STATE_ENV_VAR="GOOGLECHAT_STATE_DIR" ;;
+    *)          AGENT_PROVIDER=telegram; TOKEN_VAR="TELEGRAM_BOT_TOKEN"; STATE_ENV_VAR="TELEGRAM_STATE_DIR" ;;
+  esac
+}
+
+# Self-test hook: print the resolution for one agent dir and exit, without
+# touching tmux, the dashboard API or the log. Lets the contract be tested
+# from fixtures (scripts/__tests__/watchdog-provider.test.sh) instead of
+# requiring a live agent with a real bot token.
+if [ "${1:-}" = "--resolve-provider" ]; then
+  [ -n "${2:-}" ] || { echo "usage: watchdog.sh --resolve-provider <agent-dir>" >&2; exit 2; }
+  resolve_agent_provider "$2"
+  echo "provider=$AGENT_PROVIDER token_var=$TOKEN_VAR state_env_var=$STATE_ENV_VAR"
+  exit 0
+fi
+
 
 export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
@@ -124,16 +160,18 @@ for AGENT_DIR in "$INSTALL_DIR/agents"/*/; do
 
   echo "$(timestamp) [watchdog] $AGENT_ID missing, restarting..." >> "$LOG"
 
-  CHAN_DIR="$AGENT_DIR/.claude/channels/telegram"
-  BOT_TOKEN=$(grep "TELEGRAM_BOT_TOKEN" "$CHAN_DIR/.env" 2>/dev/null | cut -d= -f2- | head -1)
+  resolve_agent_provider "$AGENT_DIR"
+
+  CHAN_DIR="$AGENT_DIR/.claude/channels/$AGENT_PROVIDER"
+  BOT_TOKEN=$(grep "$TOKEN_VAR" "$CHAN_DIR/.env" 2>/dev/null | cut -d= -f2- | head -1)
   MODEL=$(python3 -c "import json; d=json.load(open('$AGENT_DIR/agent-config.json')); print(d.get('model','claude-haiku-4-5-20251001'))" 2>/dev/null || echo "claude-haiku-4-5-20251001")
 
   if [ -z "$BOT_TOKEN" ]; then
-    echo "$(timestamp) [watchdog] $AGENT_ID: no bot token, skipping" >> "$LOG"
+    echo "$(timestamp) [watchdog] $AGENT_ID: no $AGENT_PROVIDER bot token, skipping" >> "$LOG"
     continue
   fi
 
-  CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:\$PATH\" && unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN && export TELEGRAM_STATE_DIR=\"$CHAN_DIR\" && cd \"$AGENT_DIR\" && ${CLAUDE_BIN} --dangerously-skip-permissions --model '$MODEL' --channels plugin:telegram@claude-plugins-official"
+  CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:\$PATH\" && unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN && export ${STATE_ENV_VAR}=\"$CHAN_DIR\" && cd \"$AGENT_DIR\" && ${CLAUDE_BIN} --dangerously-skip-permissions --model '$MODEL' --channels plugin:${AGENT_PROVIDER}@claude-plugins-official"
 
   tmux new-session -d -s "$SESSION_NAME" "$CMD" 2>/dev/null
   sleep 2


### PR DESCRIPTION
The sub-agent watchdog read the bot token from the telegram channel dir and always respawned with plugin:telegram, ignoring the agent own channelProvider. For a discord/slack/teams-primary agent this meant no token was found and the loop logged "no bot token, skipping" -- the watchdog never restarted precisely the agents it exists to protect, and the log line looks routine so the outage stays invisible.

Resolve the provider from agent-config.json channelProvider, the same field src/web/agent-process.ts already launches from. Unknown, missing or malformed values still fall back to telegram, so single-channel installs are unaffected.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
