### PR TITLE
feat(channels): let one agent listen on multiple channel providers

### DIFF
--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -71,6 +71,20 @@ SESSION="${MAIN_AGENT_ID}-channels"
 # respawn the same CLAUDE_CONFIG_DIR the main agent is actually running under.
 CHANNEL_PROVIDER="$(grep -E '^CHANNEL_PROVIDER=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
 CHANNEL_PROVIDER="${CHANNEL_PROVIDER:-telegram}"
+# Extra co-listen plugins, derived EXACTLY as channels.sh does (see the
+# EXTRA_CHANNELS block there). Without this a watchdog respawn silently drops
+# every secondary provider: the session comes back on the primary channel only,
+# so outbound still works (the MCP tool is loaded) but inbound on the extras is
+# dropped with "server not in --channels list" -- a HALF-mute that looks healthy
+# to any liveness probe watching the primary. Observed in practice: a watchdog
+# respawn dropped the secondary inbound for ~20 minutes while the primary kept
+# working, so neither the probes nor the agent itself noticed.
+CHANNEL_PLUGINS_EXTRA="$(grep -E '^CHANNEL_PLUGINS_EXTRA=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
+EXTRA_CHANNELS=""
+for _p in $CHANNEL_PLUGINS_EXTRA; do
+  [ -n "$_p" ] && EXTRA_CHANNELS="$EXTRA_CHANNELS plugin:$_p"
+done
+unset _p
 
 # NB: use TMUX_BIN, not TMUX -- the latter is tmux's own env var (socket,pid,
 # session); assigning the binary path to it corrupts server-socket detection.
@@ -185,7 +199,7 @@ fi
 
 # Full PATH with .bun/bin -- without it the respawned bun telegram bridge does
 # not come up and the session is channel-less.
-RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && ${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:telegram@claude-plugins-official"
+RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && ${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${CHANNEL_PROVIDER}@claude-plugins-official${EXTRA_CHANNELS}"
 
 reason="keepalive stale ${age}s"
 [ "$STALE" != true ] && reason=""

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -25,6 +25,11 @@ if [ -f "$INSTALL_DIR/.env" ]; then
   MAIN_AGENT_ID="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
   CHANNEL_PROVIDER="$(grep -E '^CHANNEL_PROVIDER=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
   BOT_NAME="$(grep -E '^BOT_NAME=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
+  # Optional extra channel plugins to co-listen alongside the PRIMARY provider
+  # (space-separated plugin IDs, e.g. "discord@claude-plugins-official"). The
+  # primary provider still drives the orphan-reaper + liveness watchdog logic
+  # below unchanged; the extras are best-effort co-listeners on the same session.
+  CHANNEL_PLUGINS_EXTRA="$(grep -E '^CHANNEL_PLUGINS_EXTRA=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
   # Claude Code auth: pass API key or OAuth token so the tmux-spawned
   # claude process can authenticate. These are safe to export -- unlike
   # TELEGRAM_BOT_TOKEN they don't cause cross-session conflicts.
@@ -120,6 +125,19 @@ PYEOF
 }
 _ensure_plugin_enabled "$INSTALL_DIR/.claude/settings.json"
 unset -f _ensure_plugin_enabled
+
+# Build the extra --channels args from CHANNEL_PLUGINS_EXTRA (space-separated
+# plugin IDs). Each becomes an additional `plugin:<id>` token appended to the
+# --channels list. `claude --channels` accepts a space-separated plugin list,
+# so one session can co-listen on several providers (e.g. Telegram + Discord).
+# NOTE: co-listen also requires each extra plugin to be enabled in
+# .claude/settings.json enabledPlugins (true) -- CHANNEL_PLUGINS_EXTRA alone is
+# not enough; Claude Code only starts plugins marked true there.
+EXTRA_CHANNELS=""
+for _p in $CHANNEL_PLUGINS_EXTRA; do
+  [ -n "$_p" ] && EXTRA_CHANNELS="$EXTRA_CHANNELS plugin:$_p"
+done
+unset _p
 
 # ROOT-CAUSE NOTE (kali-linux WSL, claude-code 2.1.152, 2026-05-27):
 # Inbound MCP notifications from the `--channels` plugin go through a SECOND
@@ -405,7 +423,7 @@ $TMUX set-environment -g CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION false 2>/dev/null 
 # otherwise new-session below fails with "duplicate session".
 $TMUX kill-session -t "$SESSION" 2>/dev/null || true
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "${MCP_BATCH_ENV}${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
+  "${MCP_BATCH_ENV}${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}${EXTRA_CHANNELS}"
 
 # Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
 # kulonben a headless session orokre parkolna a prompton es a Telegram plugin
@@ -446,7 +464,7 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
         # entry); see the PR description / card 7EB18437.
         [ -e "$INSTALL_DIR/CLAUDE.md" ] && ln -sf "$INSTALL_DIR/CLAUDE.md" "$_CHANNELS_STARTDIR/CLAUDE.md" 2>/dev/null || true
         $TMUX new-session -d -s "$SESSION" -c "$_CHANNELS_STARTDIR" \
-          "${MCP_BATCH_ENV}${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}"
+          "${MCP_BATCH_ENV}${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}${EXTRA_CHANNELS}"
         unset _CHANNELS_STARTDIR
       fi
       continue

--- a/scripts/verify-channels-health.sh
+++ b/scripts/verify-channels-health.sh
@@ -20,12 +20,42 @@ BOT_PID_FILE="$HOME/.claude/channels/telegram/bot.pid"
 fail=0
 note() { echo "  $1"; }
 
-# Find the channels claude pid: a `claude ... --channels` process whose cwd is
-# the install dir. We match the session's claude by argv + the --channels flag.
-CLAUDE_PID="$(pgrep -af -- '--channels plugin:' | grep -F "$INSTALL_DIR" 2>/dev/null | awk '{print $1}' | head -1)"
-if [ -z "$CLAUDE_PID" ]; then
-  # Fallback: any claude with --channels (single main session on this box).
-  CLAUDE_PID="$(pgrep -af -- '--channels plugin:' | grep -vi 'agent-' | awk '{print $1}' | head -1)"
+# Find the channels claude pid, anchored on OUR tmux pane.
+#
+# The previous argv-grep discovery was wrong in both legs and silently verified
+# the WRONG process: the `grep -F "$INSTALL_DIR"` leg never matches a claude
+# (the install dir is the cwd, not part of argv -- it only matched the grep's
+# own shell wrapper), and the `grep -vi agent-` fallback took `head -1` of
+# every --channels claude on the box, which on a multi-agent host is a sibling
+# agent's session, whose argv may carry an entirely different provider set.
+# Verifying a sibling agent's process makes checks (c) and (d) meaningless.
+#
+# The pane of $SESSION is the only authoritative source. tmux runs the claude as
+# the pane process directly, but tolerate a wrapper shell by walking descendants.
+PANE_PID="$(tmux list-panes -t "$SESSION" -F '#{pane_pid}' 2>/dev/null | head -1)"
+CLAUDE_PID=""
+if [ -n "$PANE_PID" ]; then
+  case "$(ps -p "$PANE_PID" -o args= 2>/dev/null)" in
+    *"--channels plugin:"*) CLAUDE_PID="$PANE_PID" ;;
+    *)
+      _parents="$PANE_PID"
+      for _depth in 1 2 3 4; do
+        _children=""
+        for _p in $_parents; do
+          _children="$_children $(pgrep -P "$_p" 2>/dev/null)" || true
+        done
+        [ -z "$(echo "$_children" | tr -d ' ')" ] && break
+        for _c in $_children; do
+          [ -z "$_c" ] && continue
+          case "$(ps -p "$_c" -o args= 2>/dev/null)" in
+            *"--channels plugin:"*) CLAUDE_PID="$_c"; break 2 ;;
+          esac
+        done
+        _parents="$_children"
+      done
+      unset _parents _children _p _c _depth
+      ;;
+  esac
 fi
 
 echo "verify-channels-health: session=$SESSION"
@@ -86,6 +116,38 @@ if [ -n "$CLAUDE_PID" ] && [ -r "/proc/$CLAUDE_PID/environ" ]; then
   fi
 else
   note "(c) SKIP: cannot read /proc/$CLAUDE_PID/environ"
+fi
+
+# (d) EVERY configured provider is on the live --channels argv (half-mute guard).
+# The three checks above all watch the PRIMARY provider, so a respawn that dropped
+# a secondary plugin passed them cleanly: outbound kept working (the plugin's MCP
+# reply tool is loaded) while inbound was dropped as "server not in --channels
+# list". Note it must read the ARGV, not the environment -- CHANNEL_PLUGINS_EXTRA
+# can be exported and correct while the argv omits the plugin -- that exact
+# combination is how a secondary inbound goes dead while everything else,
+# including the env the operator inspects first, looks correct.
+CHANNEL_PLUGINS_EXTRA="$(grep -E '^CHANNEL_PLUGINS_EXTRA=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
+if [ -z "$CHANNEL_PLUGINS_EXTRA" ]; then
+  note "(d) SKIP: no CHANNEL_PLUGINS_EXTRA configured"
+elif [ -z "$CLAUDE_PID" ]; then
+  note "(d) SKIP: channels claude pid not found"
+else
+  CLAUDE_ARGV="$(ps -p "$CLAUDE_PID" -o args= 2>/dev/null)"
+  _missing=""
+  for _p in $CHANNEL_PLUGINS_EXTRA; do
+    [ -z "$_p" ] && continue
+    case "$CLAUDE_ARGV" in
+      *"plugin:$_p"*) ;;
+      *) _missing="$_missing $_p" ;;
+    esac
+  done
+  if [ -z "$_missing" ]; then
+    note "(d) OK: all extra channel plugins on argv"
+  else
+    note "(d) FAIL: HALF-MUTE -- inbound dropped for:$_missing (outbound still works, so this looks healthy elsewhere)"
+    fail=1
+  fi
+  unset _p _missing CLAUDE_ARGV
 fi
 
 if [ "$fail" -eq 0 ]; then

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -504,6 +504,31 @@ function readConfiguredMainModel(): string {
   }
 }
 
+// Secondary channel plugins the main session co-listens on, read from .env
+// CHANNEL_PLUGINS_EXTRA (space-separated plugin ids) exactly as scripts/channels.sh
+// derives its EXTRA_CHANNELS. Kept OUT of buildMainSessionRespawnCmd so that stays
+// pure for the contract test; every respawn call site must pass the result through.
+//
+// Why this exists: a respawn that omits the extras comes up on the PRIMARY provider
+// only, which is a HALF-mute -- outbound still works (the plugin's MCP reply tool is
+// loaded) while inbound on every secondary provider is silently dropped ("server not
+// in --channels list"). Liveness probes watch the primary, so nothing looks wrong.
+// Observed in practice: a context-saturation hard restart dropped the secondary
+// inbound for ~20 minutes while the primary channel kept working normally.
+export function readExtraChannelPluginIds(projectRoot: string = PROJECT_ROOT): string[] {
+  try {
+    const envPath = join(projectRoot, '.env')
+    if (!existsSync(envPath)) return []
+    const line = readFileSync(envPath, 'utf-8')
+      .split('\n')
+      .find((l) => l.startsWith('CHANNEL_PLUGINS_EXTRA='))
+    if (!line) return []
+    return line.slice('CHANNEL_PLUGINS_EXTRA='.length).trim().split(/\s+/).filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
 // Build the claude command used to (re)spawn the main channels session via
 // `tmux respawn-pane`. Pure + exported so the contract test can LOCK the
 // presence of the `$HOME/.bun/bin` PATH export (without it the respawned bun
@@ -537,6 +562,12 @@ export function buildMainSessionRespawnCmd(opts: {
    * bug 2 latent path). Keeps main + sub-agents on the SAME auth source.
    */
   fleetToken?: boolean
+  /**
+   * Secondary plugin ids to co-listen on alongside `pluginId`, from
+   * readExtraChannelPluginIds(). Omitting them is what silently half-mutes every
+   * non-primary channel after a recovery respawn -- see that helper's comment.
+   */
+  extraPluginIds?: string[]
 }): string {
   return [
     'export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"',
@@ -562,7 +593,7 @@ export function buildMainSessionRespawnCmd(opts: {
     // Single-quote the model id so a value like `claude-opus-4-8[1m]` is not
     // glob-expanded by the shell that tmux respawn-pane spawns the command in.
     ...(opts.model ? ['--model', `'${opts.model}'`] : []),
-    `--channels plugin:${opts.pluginId}`,
+    [`--channels plugin:${opts.pluginId}`, ...(opts.extraPluginIds ?? []).map((p) => `plugin:${p}`)].join(' '),
   ].join(' ')
 }
 
@@ -609,6 +640,7 @@ export async function resumeMarveenSession(): Promise<boolean> {
     const claudeCmd = buildMainSessionRespawnCmd({
       claudePath: CLAUDE,
       pluginId: provider.pluginId,
+      extraPluginIds: readExtraChannelPluginIds(),
       model: readConfiguredMainModel(),
       continueSession: true,
       // Parity with channels.sh: a recovery respawn must also land on the
@@ -814,6 +846,7 @@ function respawnMarveenSessionFresh(): boolean {
     const claudeCmd = buildMainSessionRespawnCmd({
       claudePath: CLAUDE,
       pluginId: provider.pluginId,
+      extraPluginIds: readExtraChannelPluginIds(),
       model: readConfiguredMainModel(),
       continueSession: false,
       // Same channels.sh-bypass concern as resumeMarveenSession: this fresh


### PR DESCRIPTION
Today an agent listens on a single channel. Supporting multiple providers has to be threaded through four separate launch/recovery paths (channels.sh, channel-watchdog.sh, the channel monitor, and the health check). If even one of them is missed, the result is a HALF-MUTE: outbound still works, inbound is dropped, and every naive health check reports HEALTHY.

We got this wrong ourselves first (patched 1 of the 4 paths), which is why the health-check part is not extra -- it is an inseparable part of the feature.

The extra providers are read from CHANNEL_PLUGINS_EXTRA and appended to the primary provider's --channels list on every launch and recovery path, so a respawn can never silently drop a co-listened channel.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
