### PR TITLE
fix(auto-restart): restart the main session on hosts without launchd

### DIFF
--- a/src/__tests__/auto-restart-main-mechanism.test.ts
+++ b/src/__tests__/auto-restart-main-mechanism.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { mainRestartMechanism } from '../auto-restart.js'
+
+// Regression for a restart that never ran, on every non-macOS host.
+//
+// performRestart() exec'd `/bin/launchctl kickstart` for the main agent
+// unconditionally. On Linux that binary does not exist, so the call threw
+// ENOENT on every due slot; the throw left lastRestart unset, so the runner
+// re-tried on the next tick, and the next -- 248 warn lines in one morning on
+// a real install (2026-07-26), and the main agent's scheduled restart had NEVER
+// fired on that host since the feature shipped.
+//
+// The reason it stayed hidden for so long is the shape of the failure, not its
+// size: auto-restart was enabled in the dashboard, the daily time was correct,
+// the sub-agents (a different code path) restarted normally, and the only
+// symptom was a log line nobody reads. Everything a human would check said OK.
+//
+// The predicate is deliberately the launchctl BINARY rather than
+// process.platform. The defect was never "wrong operating system" -- it was
+// "the binary this code invokes is absent here". Asking whether the binary
+// exists answers the question the code actually depends on, and it keeps
+// working for anything launchd-less that is nonetheless not Linux.
+describe('mainRestartMechanism', () => {
+  it('uses launchd when launchctl is present (macOS: unchanged behaviour)', () => {
+    expect(mainRestartMechanism(true)).toBe('launchd')
+  })
+
+  it('falls back to a tmux respawn when launchctl is absent (Linux)', () => {
+    expect(mainRestartMechanism(false)).toBe('tmux-respawn')
+  })
+
+  it('never returns launchd without launchctl -- the ENOENT loop this fixes', () => {
+    expect(mainRestartMechanism(false)).not.toBe('launchd')
+  })
+})

--- a/src/auto-restart.ts
+++ b/src/auto-restart.ts
@@ -15,6 +15,22 @@
 
 export type AutoRestartMode = 'fresh' | 'continue'
 
+/** How the MAIN channels session is restarted on this host. */
+export type MainRestartMechanism = 'launchd' | 'tmux-respawn'
+
+/**
+ * Pick the main-session restart mechanism from what the host actually has.
+ *
+ * The predicate is the launchctl BINARY, not process.platform: the bug this
+ * replaces was not "wrong OS" but "the binary this code exec'd unconditionally
+ * does not exist here", and the binary is what decides whether the call can
+ * work at all. Kept here, in the dependency-free module, so it is unit-testable
+ * without a filesystem -- same reason the due-logic lives here.
+ */
+export function mainRestartMechanism(launchctlPresent: boolean): MainRestartMechanism {
+  return launchctlPresent ? 'launchd' : 'tmux-respawn'
+}
+
 export interface AutoRestartConfig {
   /** Master toggle. When false the agent is never auto-restarted. */
   enabled: boolean

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, SERVICE_ID } from '../config.js'
 import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
@@ -9,9 +10,10 @@ import {
   capturePane,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { respawnMainSessionFresh } from './channel-monitor.js'
 import { paneLooksIdle } from '../pane-state.js'
 import { readAutoRestartConfig } from './auto-restart-store.js'
-import { restartDue, dailyDueAtMs, parseHHMM, type AutoRestartConfig } from '../auto-restart.js'
+import { restartDue, dailyDueAtMs, parseHHMM, mainRestartMechanism, type AutoRestartConfig } from '../auto-restart.js'
 
 // Drives per-agent scheduled restarts (see src/auto-restart.ts for the why and
 // the pure due-logic). Mirrors the other watcher loops: a 60s sweep, started
@@ -62,15 +64,40 @@ function paneIsIdle(session: string, host: string | null): boolean {
   return paneLooksIdle(pane)
 }
 
-function performRestart(name: string, cfg: AutoRestartConfig): void {
-  if (name === MAIN_AGENT_ID) {
-    // The main channels session is launchd-managed and channels.sh always
-    // starts a fresh conversation, so 'continue' is not applicable here -- a
-    // kickstart is always a fresh restart. KeepAlive brings it straight back.
+// The main channels session always comes back as a FRESH conversation, so
+// cfg.mode ('continue') never applies to it -- see buildMainSessionRespawnCmd's
+// continueSession: false below and the launchd kickstart on macOS.
+//
+// Two platforms, two mechanisms. Splitting on the launchctl BINARY rather than
+// process.platform is deliberate: the failure we hit was not "wrong OS" but
+// "the binary this code unconditionally exec'd does not exist here", and the
+// binary check is what actually predicts whether the call can work.
+//
+// Why this mattered: on Linux the launchctl leg threw ENOENT on every due slot.
+// performRestart's throw left lastRestart unset, so the runner retried ~every
+// tick, forever -- 248 WARN lines in one morning (2026-07-26) and, more to the
+// point, the main agent's nightly restart had NEVER run on this host. The
+// symptom was invisible: a log line nobody reads, while the dashboard showed
+// auto-restart as enabled and correctly scheduled.
+function restartMainChannelsSession(): void {
+  if (mainRestartMechanism(existsSync('/bin/launchctl')) === 'launchd') {
     const uid = typeof process.getuid === 'function' ? process.getuid() : ''
     // Label keys off SERVICE_ID (defaults to MAIN_AGENT_ID) so it matches the
-    // launchd label the installer wrote.
+    // launchd label the installer wrote. KeepAlive brings it straight back.
     execFileSync('/bin/launchctl', ['kickstart', '-k', `gui/${uid}/com.${SERVICE_ID}.channels`], { timeout: 10_000 })
+    return
+  }
+  // Linux (and any host without launchd): reuse the SAME respawn path the
+  // channel-deafness recovery uses, rather than a second hand-rolled tmux
+  // command. That helper already carries the MCP startup env, the extra
+  // channel plugins, the isolated config dir, the fleet token and the two
+  // orphan reaps -- a bespoke command here would silently drift from it.
+  respawnMainSessionFresh()
+}
+
+function performRestart(name: string, cfg: AutoRestartConfig): void {
+  if (name === MAIN_AGENT_ID) {
+    restartMainChannelsSession()
   } else {
     restartAgentProcess(name, { fresh: cfg.mode === 'fresh' })
   }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -638,6 +638,14 @@ export function respawnMainSessionFresh(): void {
     fleetToken: hasFleetOauthToken(),
   })
   execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
+  // Stamp IMMEDIATELY after the respawn, before the scheduling follow-ups.
+  // The stamp is a coordination contract, not bookkeeping: five watchers read
+  // lastMainRespawnAt() / store/.channel-last-respawn and suppress themselves
+  // during the grace window -- including the systemd-timer channel-watchdog,
+  // a separate process that can ONLY see the file. Without it, the ~35-90s
+  // cold-boot window while plugins unlock looks to them like a dead session,
+  // and they can respawn on top of one that is still coming up.
+  writeRespawnStamp()
 
   logger.warn({ provider: provider.type }, 'Main session respawned FRESH (scheduled auto-restart)')
   // The respawned claude is a brand-new process: it has neither the /name

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -597,6 +597,57 @@ export function buildMainSessionRespawnCmd(opts: {
   ].join(' ')
 }
 
+// FRESH respawn of the main channels session, for hosts with no launchd.
+//
+// Exported for the scheduled auto-restart (auto-restart-runner.ts), whose macOS
+// leg is `launchctl kickstart`. On Linux that binary does not exist, so before
+// this the main agent's nightly restart threw ENOENT on every due tick and had
+// NEVER run -- silently, because the only symptom was a log line.
+//
+// Deliberately NOT resumeMarveenSession() with a flag: that path is built around
+// --continue (resume-summary modal dismissal, post-resume plugin guard) and none
+// of it applies to a fresh start. What IS shared -- the two reaps, the onboarding
+// re-seed, the respawn command builder, the identity + plugin-unlock follow-ups --
+// is called here too, so the two paths cannot drift on the parts that matter.
+export function respawnMainSessionFresh(): void {
+  const provider = getProvider(getMainAgentProvider())
+  // Same rationale as the resume path: respawn-pane -k kills the parent claude
+  // but leaves grandchild pollers alive, and two pollers on one bot token race
+  // for getUpdates (409). Reap BEFORE respawning, never after.
+  try {
+    reapChannelOrphans(provider.type, PROJECT_ROOT)
+  } catch (err) {
+    logger.warn({ err }, 'respawnMainSessionFresh: pre-respawn reap failed (continuing)')
+  }
+  try {
+    reapDetachedChannelClaudes({ tmuxPath: TMUX })
+  } catch (err) {
+    logger.warn({ err }, 'respawnMainSessionFresh: detached-claude reap failed (continuing)')
+  }
+  ensureSharedClaudeOnboarded()
+
+  const claudeCmd = buildMainSessionRespawnCmd({
+    claudePath: CLAUDE,
+    pluginId: provider.pluginId,
+    extraPluginIds: readExtraChannelPluginIds(),
+    model: readConfiguredMainModel(),
+    // The main session always starts a new conversation -- this is the whole
+    // point of the nightly restart (drop the accumulated context).
+    continueSession: false,
+    isolatedConfigDir: ensureMainAgentIsolatedConfigDir(),
+    fleetToken: hasFleetOauthToken(),
+  })
+  execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
+
+  logger.warn({ provider: provider.type }, 'Main session respawned FRESH (scheduled auto-restart)')
+  // The respawned claude is a brand-new process: it has neither the /name
+  // identity nor a guaranteed-loaded channel plugin. Both follow-ups mirror the
+  // resume path; skipping them is how a restarted session comes back nameless
+  // or with the plugin stuck in `◯ disabled`.
+  void scheduleIdentitySetup(MAIN_CHANNELS_SESSION, BOT_NAME)
+  schedulePluginUnlockAfterRespawn(MAIN_CHANNELS_SESSION, provider.type)
+}
+
 // Exported so the stuck-tool-call-watcher recovers a wedged main session via
 // this respawn-pane path (reap + `tmux respawn-pane -k --continue`) INSTEAD of
 // the launchctl hard-restart. respawn-pane replaces only the claude process in


### PR DESCRIPTION
## A hiba

`performRestart()` a fő ágensnél feltétel nélkül `/bin/launchctl kickstart`-ot hívott. Linuxon ez a bináris nem létezik, így a hívás **minden esedékes időpontban ENOENT-tel dobott**. A dobás miatt a `lastRestart` beállítatlan maradt, ezért a runner a következő tick-en újrapróbálta -- és így tovább, vég nélkül.

Egy éles installon ez **egyetlen délelőtt alatt 248 WARN sor** volt, és ami fontosabb: a fő ágens ütemezett újraindítása **soha nem futott le** azon a hoszton, mióta a funkció létezik.

## Miért maradt észrevétlen

Nem a méret miatt, hanem a hiba *formája* miatt:

- a dashboardon az auto-restart **engedélyezettként** látszott, helyes napi időponttal
- az **al-ágensek** (külön kódút) rendben újraindultak
- az egyetlen tünet egy naplósor volt

Vagyis minden, amit egy ember ellenőrizne, rendben lévőnek mutatta.

## A javítás

A mechanizmust a **launchctl binárisból** választjuk, nem a `process.platform`-ból. A defektus soha nem "rossz operációs rendszer" volt, hanem "az a bináris, amit ez a kód meghív, itt nincs" -- és a bináris megléte pont az a kérdés, amitől a kód ténylegesen függ. macOS-en a viselkedés **változatlan**.

A Linux-ág a **meglévő** `respawn-pane` utat használja újra (új `respawnMainSessionFresh`), nem egy második, kézzel írt tmux-parancsot. Így örökli az árva-poller takarításokat, az MCP indulási env-et, a további csatorna-pluginokat, az izolált config dir-t és a fleet tokent -- egy külön parancs idővel elcsúszna ezektől.

Szándékosan **nem** a `resumeMarveenSession()` kapcsolóval: az az út a `--continue` köré épül (resume-summary modal, post-resume plugin guard), amiből friss indításnál semmi nem érvényes.

## Teszt

A platform-döntés tiszta függvényként a függőségmentes `src/auto-restart.ts`-be került (ahol a due-logika is él, ugyanezért), így fájlrendszer nélkül tesztelhető. 3 teszt, mindkét ág + a regresszió.

```
✓ src/__tests__/auto-restart-main-mechanism.test.ts (3 tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)