### PR TITLE
Feat/dashboard overview redesign

### DIFF
--- a/src/__tests__/overview-api.test.ts
+++ b/src/__tests__/overview-api.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { initDatabase, getDb, createApproval } from '../db.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+vi.mock('../web/agent-config.js', () => ({
+  agentDir: () => '/tmp/agent-a',
+  agentConfigRoot: () => '/tmp',
+  listAgentNames: () => ['agent-a'],
+  readAgentDisplayName: (name: string) => name,
+}))
+
+vi.mock('../web/agent-process.js', () => ({
+  isAgentRunning: () => false,
+}))
+
+vi.mock('../web/agent-team.js', () => ({
+  readAgentTeam: () => ({ role: 'agent' }),
+}))
+
+const { tryHandleOverview } = await import('../web/routes/overview.js')
+
+function fakeCtx(path: string, method = 'GET'): { ctx: RouteContext; out: { status: number; body: any } } {
+  const out: { status: number; body: any } = { status: 0, body: null }
+  const res: any = {
+    writeHead(status: number) { out.status = status; return res },
+    end(chunk?: string) { if (chunk) out.body = JSON.parse(chunk) },
+    setHeader() { return res },
+  }
+  const url = new URL(`http://localhost:3420${path}`)
+  const ctx = { req: { headers: {} } as any, res, path: url.pathname, method, url } as RouteContext
+  return { ctx, out }
+}
+
+beforeEach(() => {
+  initDatabase(':memory:')
+})
+
+// ---------------------------------------------------------------------------
+// Response shape
+// ---------------------------------------------------------------------------
+
+describe('GET /api/overview — response shape', () => {
+  it('returns true and 200 for the overview path', async () => {
+    const { ctx, out } = fakeCtx('/api/overview')
+    const handled = await tryHandleOverview(ctx)
+    expect(handled).toBe(true)
+    expect(out.status).toBe(200)
+  })
+
+  it('returns false for unrelated paths', async () => {
+    const { ctx } = fakeCtx('/api/kanban')
+    expect(await tryHandleOverview(ctx)).toBe(false)
+  })
+
+  it('response includes all required top-level fields', async () => {
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    expect(out.body).toHaveProperty('agents')
+    expect(out.body).toHaveProperty('tasksToday')
+    expect(out.body).toHaveProperty('tasksYesterday')
+    expect(out.body).toHaveProperty('memories')
+    expect(out.body).toHaveProperty('skills')
+    expect(out.body).toHaveProperty('tokensToday')
+    expect(out.body).toHaveProperty('costTodayUsd')
+    expect(out.body).toHaveProperty('pendingApprovals')
+    expect(out.body).toHaveProperty('errors4h')
+    expect(out.body).toHaveProperty('unreadMessages')
+    expect(out.body).toHaveProperty('stuckTasks')
+    expect(out.body).toHaveProperty('activity')
+  })
+
+  it('agents object contains total, running and list', async () => {
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    const agents = out.body.agents
+    expect(agents).toHaveProperty('total')
+    expect(agents).toHaveProperty('running')
+    expect(agents).toHaveProperty('list')
+    expect(Array.isArray(agents.list)).toBe(true)
+  })
+
+  it('each agent in list has lastActive field', async () => {
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    for (const a of out.body.agents.list) {
+      expect(Object.prototype.hasOwnProperty.call(a, 'lastActive')).toBe(true)
+    }
+  })
+
+  // Fix-revert proof: if we remove the activity agent field, this fails.
+  it('each activity item has an agent field', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    getDb().prepare(
+      "INSERT INTO memories (chat_id, agent_id, content, sector, salience, category, keywords, created_at, accessed_at) VALUES ('0','agent-a','test memory','semantic',1.0,'warm','test',?,?)"
+    ).run(now, now)
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    const activityItems = out.body.activity
+    if (activityItems.length > 0) {
+      for (const item of activityItems) {
+        expect(Object.prototype.hasOwnProperty.call(item, 'agent')).toBe(true)
+      }
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// tokensToday and costTodayUsd
+// ---------------------------------------------------------------------------
+
+describe('GET /api/overview — tokensToday and costTodayUsd', () => {
+  it('returns 0 when no token_usage rows exist', async () => {
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    expect(out.body.tokensToday).toBe(0)
+    expect(out.body.costTodayUsd).toBe(0)
+  })
+
+  it('counts tokens from today\'s token_usage rows', async () => {
+    const startOfDay = new Date()
+    startOfDay.setHours(0, 0, 0, 0)
+    const todaySec = Math.floor(startOfDay.getTime() / 1000) + 3600
+
+    getDb().prepare(
+      "INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens) VALUES ('agent-a','s1',?,1000,200,0,0)"
+    ).run(todaySec)
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    // Fix-revert proof: removing the token_usage SELECT in overview.ts would return 0 here.
+    expect(out.body.tokensToday).toBe(1200)
+  })
+
+  it('does not count yesterday\'s token_usage rows in tokensToday', async () => {
+    const startOfDay = new Date()
+    startOfDay.setHours(0, 0, 0, 0)
+    const yesterdaySec = Math.floor(startOfDay.getTime() / 1000) - 3600
+
+    getDb().prepare(
+      "INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens) VALUES ('agent-a','s1',?,500,100,0,0)"
+    ).run(yesterdaySec)
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    expect(out.body.tokensToday).toBe(0)
+  })
+
+  it('estimates costTodayUsd > 0 when tokens are present today', async () => {
+    const startOfDay = new Date()
+    startOfDay.setHours(0, 0, 0, 0)
+    const todaySec = Math.floor(startOfDay.getTime() / 1000) + 3600
+
+    getDb().prepare(
+      "INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, model) VALUES ('agent-a','s1',?,100000,5000,0,0,'claude-sonnet-4')"
+    ).run(todaySec)
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    // Fix-revert proof: removing estimateTokenCostUsd call returns 0.
+    expect(out.body.costTodayUsd).toBeGreaterThan(0)
+  })
+
+  it('assigns higher cost to opus than sonnet for the same token count', async () => {
+    const startOfDay = new Date()
+    startOfDay.setHours(0, 0, 0, 0)
+    const base = Math.floor(startOfDay.getTime() / 1000) + 7200
+
+    const db = getDb()
+    db.prepare(
+      "INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, model) VALUES ('agent-a','s1',?,10000,1000,0,0,'claude-sonnet-4')"
+    ).run(base)
+    const { ctx: ctx1, out: out1 } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx1)
+    const costSonnet = out1.body.costTodayUsd
+
+    // Reset DB and use opus model
+    initDatabase(':memory:')
+    getDb().prepare(
+      "INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, model) VALUES ('agent-a','s2',?,10000,1000,0,0,'claude-opus-4')"
+    ).run(base)
+    const { ctx: ctx2, out: out2 } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx2)
+    const costOpus = out2.body.costTodayUsd
+
+    // Fix-revert proof: without model-based pricing both costs would be equal.
+    expect(costOpus).toBeGreaterThan(costSonnet)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// pendingApprovals
+// ---------------------------------------------------------------------------
+
+describe('GET /api/overview — pendingApprovals', () => {
+  it('returns 0 when no approvals exist', async () => {
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    expect(out.body.pendingApprovals).toBe(0)
+  })
+
+  it('counts only pending approvals', async () => {
+    // Fix-revert proof: removing the pendingApprovals COUNT query returns 0.
+    createApproval({ id: 'ap-1', agent_id: 'agent-a', category: 'test', action_description: 'do something' })
+    createApproval({ id: 'ap-2', agent_id: 'agent-a', category: 'test', action_description: 'do something else' })
+    // Resolve one
+    getDb().prepare("UPDATE approvals SET status='approved', resolved_at=? WHERE id='ap-2'").run(Math.floor(Date.now() / 1000))
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    expect(out.body.pendingApprovals).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// unreadMessages
+// ---------------------------------------------------------------------------
+
+describe('GET /api/overview — unreadMessages', () => {
+  it('returns 0 when no pending messages', async () => {
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    expect(out.body.unreadMessages).toBe(0)
+  })
+
+  it('counts pending agent messages', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    getDb().prepare(
+      "INSERT INTO agent_messages (from_agent, to_agent, content, status, created_at) VALUES ('agent-a','main-agent','hello','pending',?)"
+    ).run(now)
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    // Fix-revert proof: removing the unreadMessages COUNT query returns 0.
+    expect(out.body.unreadMessages).toBe(1)
+  })
+
+  it('does not count delivered messages', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    getDb().prepare(
+      "INSERT INTO agent_messages (from_agent, to_agent, content, status, created_at, delivered_at) VALUES ('agent-a','main-agent','done','delivered',?,?)"
+    ).run(now, now)
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    expect(out.body.unreadMessages).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// activity feed — 4h filter
+// ---------------------------------------------------------------------------
+
+describe('GET /api/overview — activity feed 4h filter', () => {
+  it('includes memories from the last 4h', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const recentSec = now - 3600 // 1h ago
+    getDb().prepare(
+      "INSERT INTO memories (chat_id, agent_id, content, sector, salience, category, keywords, created_at, accessed_at) VALUES ('0','agent-a','recent event','semantic',1.0,'warm','event',?,?)"
+    ).run(recentSec, recentSec)
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    // Fix-revert proof: removing the 4h filter from the WHERE clause would include all memories regardless.
+    const texts = out.body.activity.map((a: any) => a.text)
+    expect(texts.some((t: string) => t.includes('recent event'))).toBe(true)
+  })
+
+  it('excludes memories older than 4h', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const oldSec = now - 5 * 3600 // 5h ago
+    getDb().prepare(
+      "INSERT INTO memories (chat_id, agent_id, content, sector, salience, category, keywords, created_at, accessed_at) VALUES ('0','agent-a','old event','semantic',1.0,'warm','event',?,?)"
+    ).run(oldSec, oldSec)
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    const texts = out.body.activity.map((a: any) => a.text)
+    expect(texts.some((t: string) => t.includes('old event'))).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// lastActive per agent
+// ---------------------------------------------------------------------------
+
+describe('GET /api/overview — agents.list lastActive', () => {
+  it('is null when no token_usage exists for the agent', async () => {
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    const agentA = out.body.agents.list.find((a: any) => a.id === 'agent-a')
+    expect(agentA).toBeDefined()
+    expect(agentA.lastActive).toBeNull()
+  })
+
+  it('reflects the max token_usage timestamp for each agent', async () => {
+    const ts1 = Math.floor(Date.now() / 1000) - 100
+    const ts2 = Math.floor(Date.now() / 1000) - 50
+    const db = getDb()
+    db.prepare(
+      "INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens) VALUES ('agent-a','s1',?,10,5,0,0)"
+    ).run(ts1)
+    db.prepare(
+      "INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens) VALUES ('agent-a','s2',?,10,5,0,0)"
+    ).run(ts2)
+
+    const { ctx, out } = fakeCtx('/api/overview')
+    await tryHandleOverview(ctx)
+    // Fix-revert proof: removing the lastActive MAX query would leave all lastActive as null.
+    const agentA = out.body.agents.list.find((a: any) => a.id === 'agent-a')
+    expect(agentA.lastActive).toBe(ts2)
+  })
+})

--- a/src/web/routes/overview.ts
+++ b/src/web/routes/overview.ts
@@ -8,7 +8,7 @@ import {
 } from '../agent-config.js'
 import { readAgentTeam } from '../agent-team.js'
 import { isAgentRunning } from '../agent-process.js'
-import { json, jsonMaybeGzip } from '../http-helpers.js'
+import { jsonMaybeGzip } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
 
 // Count "real" user turns (operator prompts, Telegram messages) in every
@@ -57,6 +57,23 @@ function countUserTurns(fromMs: number, toMs: number = Number.POSITIVE_INFINITY)
   return total
 }
 
+// Estimate AI token cost in USD from token counts and model name.
+// Uses approximate Anthropic public pricing; returns 0 for unknown models.
+function estimateTokenCostUsd(inputTokens: number, outputTokens: number, model: string | null): number {
+  const m = (model ?? '').toLowerCase()
+  let inRate: number
+  let outRate: number
+  if (m.includes('opus')) {
+    inRate = 15 / 1_000_000; outRate = 75 / 1_000_000
+  } else if (m.includes('haiku')) {
+    inRate = 0.25 / 1_000_000; outRate = 1.25 / 1_000_000
+  } else {
+    // sonnet and unknown models
+    inRate = 3 / 1_000_000; outRate = 15 / 1_000_000
+  }
+  return inputTokens * inRate + outputTokens * outRate
+}
+
 export async function tryHandleOverview(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
 
@@ -69,10 +86,13 @@ export async function tryHandleOverview(ctx: RouteContext): Promise<boolean> {
     const memStats = db0.prepare("SELECT COUNT(*) as c FROM memories").get() as { c: number }
     const memCats = db0.prepare("SELECT COUNT(DISTINCT category) as c FROM memories").get() as { c: number }
 
+    const nowMs = Date.now()
     const startOfDay = new Date()
     startOfDay.setHours(0, 0, 0, 0)
     const startTs = startOfDay.getTime()
     const yesterday = startTs - 24 * 60 * 60 * 1000
+    const fourHoursAgo = nowMs - 4 * 60 * 60 * 1000
+
     const schedToday = countTaskRunsBetween(startTs)
     const schedYesterday = countTaskRunsBetween(yesterday, startTs)
     const userTurns = countUserTurns(startTs)
@@ -96,61 +116,153 @@ export async function tryHandleOverview(ctx: RouteContext): Promise<boolean> {
       }
     }
 
-    const activity: Array<{ icon: string; text: string; at: number }> = []
+    // Per-agent last-active timestamp from token_usage (ms epoch)
+    const lastActiveMap = new Map<string, number>()
     try {
-      const memRows = db0.prepare("SELECT content, created_at, agent_id FROM memories ORDER BY created_at DESC LIMIT 6").all() as { content: string; created_at: number; agent_id: string }[]
+      const rows = db0.prepare(
+        "SELECT agent, MAX(timestamp) as last_active FROM token_usage GROUP BY agent"
+      ).all() as { agent: string; last_active: number }[]
+      for (const r of rows) lastActiveMap.set(r.agent, r.last_active)
+    } catch { /* ignore */ }
+
+    // Daily token count and estimated USD cost from token_usage
+    let tokensToday = 0
+    let costTodayUsd = 0
+    try {
+      const startSec = Math.floor(startTs / 1000)
+      const tokenRows = db0.prepare(
+        "SELECT input_tokens, output_tokens, model FROM token_usage WHERE timestamp >= ?"
+      ).all(startSec) as { input_tokens: number; output_tokens: number; model: string | null }[]
+      for (const r of tokenRows) {
+        tokensToday += r.input_tokens + r.output_tokens
+        costTodayUsd += estimateTokenCostUsd(r.input_tokens, r.output_tokens, r.model)
+      }
+    } catch { /* ignore */ }
+
+    // Pending approvals count
+    let pendingApprovals = 0
+    try {
+      const pa = db0.prepare("SELECT COUNT(*) as c FROM approvals WHERE status='pending'").get() as { c: number }
+      pendingApprovals = pa.c
+    } catch { /* ignore */ }
+
+    // Error/timeout spans in last 4h (start_ms is in milliseconds)
+    let errors4h = 0
+    try {
+      const errRow = db0.prepare(
+        "SELECT COUNT(*) as c FROM otel_spans WHERE status IN ('error','timeout') AND start_ms >= ?"
+      ).get(fourHoursAgo) as { c: number }
+      errors4h = errRow.c
+    } catch { /* ignore */ }
+
+    // Undelivered inter-agent messages (pending = not yet delivered to recipient session)
+    let unreadMessages = 0
+    try {
+      const umRow = db0.prepare("SELECT COUNT(*) as c FROM agent_messages WHERE status='pending'").get() as { c: number }
+      unreadMessages = umRow.c
+    } catch { /* ignore */ }
+
+    // Stuck scheduled tasks: active tasks whose next_run was more than 10 minutes ago
+    let stuckTasks = 0
+    try {
+      const tenMinAgo = Math.floor((nowMs - 10 * 60 * 1000) / 1000)
+      const stRow = db0.prepare(
+        "SELECT COUNT(*) as c FROM scheduled_tasks WHERE status='active' AND next_run < ?"
+      ).get(tenMinAgo) as { c: number }
+      stuckTasks = stRow.c
+    } catch { /* ignore */ }
+
+    // Activity feed: last 4h, include agent_id for frontend filtering
+    const activity: Array<{ icon: string; text: string; at: number; agent: string }> = []
+    try {
+      const fourHAgoSec = Math.floor(fourHoursAgo / 1000)
+      const memRows = db0.prepare(
+        "SELECT content, created_at, agent_id FROM memories WHERE created_at >= ? ORDER BY created_at DESC LIMIT 20"
+      ).all(fourHAgoSec) as { content: string; created_at: number; agent_id: string }[]
       for (const r of memRows) {
         activity.push({
           icon: 'memory',
-          text: `${r.agent_id}: ${r.content.slice(0, 80)}${r.content.length > 80 ? '…' : ''}`,
+          text: `${r.content.slice(0, 80)}${r.content.length > 80 ? '…' : ''}`,
           at: r.created_at * 1000,
+          agent: r.agent_id,
         })
       }
     } catch { /* ignore */ }
     try {
-      const msgRows = db0.prepare("SELECT from_agent, to_agent, content, created_at FROM agent_messages ORDER BY created_at DESC LIMIT 4").all() as { from_agent: string; to_agent: string; content: string; created_at: number }[]
+      const fourHAgoSec = Math.floor(fourHoursAgo / 1000)
+      const msgRows = db0.prepare(
+        "SELECT from_agent, to_agent, content, created_at FROM agent_messages WHERE created_at >= ? ORDER BY created_at DESC LIMIT 15"
+      ).all(fourHAgoSec) as { from_agent: string; to_agent: string; content: string; created_at: number }[]
       for (const r of msgRows) {
         activity.push({
           icon: 'delegate',
-          text: `${r.from_agent} → ${r.to_agent}: ${r.content.slice(0, 60)}${r.content.length > 60 ? '…' : ''}`,
+          text: `→ ${r.to_agent}: ${r.content.slice(0, 60)}${r.content.length > 60 ? '…' : ''}`,
           at: r.created_at * 1000,
+          agent: r.from_agent,
+        })
+      }
+    } catch { /* ignore */ }
+    // Approval events in last 4h
+    try {
+      const fourHAgoSec = Math.floor(fourHoursAgo / 1000)
+      const aprRows = db0.prepare(
+        "SELECT agent_id, action_description, status, created_at FROM approvals WHERE created_at >= ? ORDER BY created_at DESC LIMIT 10"
+      ).all(fourHAgoSec) as { agent_id: string; action_description: string; status: string; created_at: number }[]
+      for (const r of aprRows) {
+        activity.push({
+          icon: 'approval',
+          text: `[${r.status}] ${r.action_description.slice(0, 60)}${r.action_description.length > 60 ? '…' : ''}`,
+          at: r.created_at * 1000,
+          agent: r.agent_id,
         })
       }
     } catch { /* ignore */ }
     activity.sort((a, b) => b.at - a.at)
 
-    const agentsForTeam: Array<{ id: string; label: string; role: string; running: boolean; hasAvatar: boolean; avatarUrl: string }> = []
+    // Build agents list with last_active timestamp
+    const agentsForGrid: Array<{
+      id: string; label: string; role: string; running: boolean;
+      hasAvatar: boolean; avatarUrl: string; lastActive: number | null
+    }> = []
     const mainHasAvatar = [
       join(PROJECT_ROOT, 'store', 'marveen-avatar.png'),
       join(PROJECT_ROOT, 'store', 'marveen-avatar.jpg'),
     ].some(existsSync)
-    agentsForTeam.push({
+    agentsForGrid.push({
       id: MAIN_AGENT_ID,
       label: BOT_NAME,
       role: 'main',
       running: true,
       hasAvatar: mainHasAvatar,
       avatarUrl: `/api/marveen/avatar`,
+      lastActive: lastActiveMap.get(MAIN_AGENT_ID) ?? null,
     })
     for (const a of subAgents) {
       const team = readAgentTeam(a)
-      agentsForTeam.push({
+      agentsForGrid.push({
         id: a,
         label: readAgentDisplayName(a),
         role: team.role,
         running: isAgentRunning(a),
         hasAvatar: existsSync(join(agentDir(a), 'avatar.png')),
         avatarUrl: `/api/agents/${encodeURIComponent(a)}/avatar`,
+        lastActive: lastActiveMap.get(a) ?? null,
       })
     }
+
     jsonMaybeGzip(req, res, {
-      agents: { total, running },
+      agents: { total, running, list: agentsForGrid },
       tasksToday,
       tasksYesterday,
       memories: { count: memStats.c, categories: memCats.c },
       skills: { count: skillCount, today: skillsToday },
-      team: agentsForTeam,
-      activity: activity.slice(0, 8),
+      tokensToday,
+      costTodayUsd: Math.round(costTodayUsd * 10000) / 10000,
+      pendingApprovals,
+      errors4h,
+      unreadMessages,
+      stuckTasks,
+      activity: activity.slice(0, 30),
     })
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -11459,54 +11459,175 @@ function formatRelative(ts) {
   return t('common.time.day_abbr', { n: day })
 }
 
+function fmtTokensShort(n) {
+  if (!n || n === 0) return '0'
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace('.0', '') + 'M'
+  if (n >= 1_000) return Math.round(n / 1000) + 'k'
+  return String(n)
+}
+
+function ovActivityIcon(type) {
+  if (type === 'delegate') return '\u{1F4AC}'
+  if (type === 'approval') return '\u{2705}'
+  return '\u{1F4A1}'
+}
+
+let _ovActiveAgentFilter = null
+
+function _ovRenderActivityFeed() {
+  const feed = document.getElementById('ovActivityFeed')
+  if (!feed) return
+  feed.querySelectorAll('.ov-activity-row').forEach(r => {
+    r.hidden = _ovActiveAgentFilter !== null && r.dataset.agent !== _ovActiveAgentFilter
+  })
+}
+
 async function loadOverview() {
   try {
     const res = await fetch('/api/overview')
     if (!res.ok) throw new Error('HTTP ' + res.status)
     const d = await res.json()
-    // Stats
-    document.getElementById('statAgents').textContent = d.agents.running
-    document.getElementById('statAgentsSub').textContent = t('overview.stat.agents_sub', { n: d.agents.total })
-    document.getElementById('statTasks').textContent = d.tasksToday
-    const taskDiff = d.tasksToday - d.tasksYesterday
-    document.getElementById('statTasksSub').textContent = taskDiff === 0 ? t('overview.stat.same_as_yesterday') : (taskDiff > 0 ? '+' + taskDiff + ' ' + t('overview.stat.change', { n: '' }).trim() : taskDiff + ' ' + t('overview.stat.change', { n: '' }).trim())
-    document.getElementById('statMemories').textContent = d.memories.count.toLocaleString('hu-HU').replace(/,/g, ' ')
-    document.getElementById('statMemoriesSub').textContent = `${t('overview.stat.sub.memories')} · ${d.memories.categories} category`
-    document.getElementById('statSkills').textContent = d.skills.count
-    document.getElementById('statSkillsSub').textContent = d.skills.today > 0 ? t('overview.stat.skills_today', { n: d.skills.today }) : ''
-    // Team: reuse the hierarchy graph renderer so the overview card shows
-    // exactly what the Csapat page does (avatars + reports-to tree).
-    try {
-      const tg = await fetch('/api/team/graph')
-      if (tg.ok) {
-        const graph = await tg.json()
-        renderTeamGraph(document.getElementById('overviewTeamGrid'), graph)
+
+    // === Zone 1: Fleet Health bar ===
+    const running = d.agents.running
+    const total = d.agents.total
+    const pendingApprovals = d.pendingApprovals || 0
+    const errors4h = d.errors4h || 0
+    const unread = d.unreadMessages || 0
+    const stuck = d.stuckTasks || 0
+
+    document.getElementById('fhAgentsText').textContent = running + '/' + total
+    document.getElementById('fhApprovalsText').textContent = pendingApprovals
+    document.getElementById('fhCostText').textContent = d.costTodayUsd > 0 ? '$' + d.costTodayUsd.toFixed(2) : '—'
+    document.getElementById('fhErrorsText').textContent = errors4h
+
+    const bar = document.getElementById('fleetHealthBar')
+    const dot = document.getElementById('fhDot')
+    const alertLevel = errors4h > 0 || stuck > 0 ? 'danger' : pendingApprovals > 0 ? 'warn' : ''
+    bar.className = 'fh-bar' + (alertLevel ? ' fh-' + alertLevel : '')
+    dot.className = 'fh-dot' + (alertLevel ? ' ' + alertLevel : '')
+
+    // === Zone 2: Attention Required ===
+    const attSection = document.getElementById('attentionSection')
+    const attBody = document.getElementById('attentionBody')
+    const attBadge = document.getElementById('attentionBadge')
+    const attItems = []
+
+    if (pendingApprovals > 0) attItems.push({ icon: '⏳', text: pendingApprovals + ' üggő jóváhagyás vár', href: '#approvals', label: 'Megnyitás' })
+    if (unread > 0) attItems.push({ icon: '\u{1F4AC}', text: unread + ' kézbesítetlen inter-agent üzenet', href: '#messages', label: 'Üzenetek' })
+    if (stuck > 0) attItems.push({ icon: '⏰', text: stuck + ' ütemezett feladat elakadt', href: '#tasks', label: 'Feladatok' })
+    if (errors4h > 0) attItems.push({ icon: '⚠', text: errors4h + ' hiba az elmúlt 4 órában', href: '#status', label: 'Státusz' })
+    const stoppedAgents = (d.agents.list || []).filter(function(a) { return !a.running && a.role !== 'main' })
+    if (stoppedAgents.length > 0) attItems.push({ icon: '\u{1F534}', text: stoppedAgents.length + ' ágens nem fut (' + stoppedAgents.map(function(a) { return a.label }).join(', ') + ')', href: '#agents', label: 'Ágensek' })
+
+    if (attItems.length > 0) {
+      attSection.hidden = false
+      attBadge.textContent = attItems.length
+      attBody.innerHTML = attItems.map(function(item) {
+        return '<div class="attention-item"><span>' + escapeHtml(item.icon) + '</span><span>' + escapeHtml(item.text) + '</span><a href="' + escapeHtml(item.href) + '">' + escapeHtml(item.label) + '</a></div>'
+      }).join('')
+      const toggle = document.getElementById('attentionToggle')
+      const header = document.getElementById('attentionHeader')
+      header.onclick = function() {
+        const collapsed = attBody.classList.toggle('collapsed')
+        toggle.classList.toggle('collapsed', collapsed)
       }
-    } catch {}
-    // Activity
-    const act = document.getElementById('overviewActivity')
-    act.innerHTML = ''
-    if (!d.activity || d.activity.length === 0) {
-      act.innerHTML = '<div style="color:var(--text-muted);font-size:13px">' + t('overview.no_activity') + '</div>'
     } else {
-      for (const a of d.activity) {
-        const icon = a.icon === 'delegate'
-          ? '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>'
-          : '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3C7.5 3 4 6.5 4 11v4l-2 3h4v2a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3v-2h4l-2-3v-4c0-4.5-3.5-8-8-8z"/></svg>'
-        const item = document.createElement('div')
-        item.className = 'overview-activity-item'
-        item.innerHTML = `
-          <div class="overview-activity-icon">${icon}</div>
-          <div class="overview-activity-body">
-            <div class="overview-activity-title">${escapeHtml(a.text)}</div>
-            <div class="overview-activity-time">${formatRelative(a.at)}</div>
-          </div>
-        `
-        act.appendChild(item)
+      attSection.hidden = true
+    }
+
+    // === Zone 3: Compact agents grid ===
+    const grid = document.getElementById('agentsMiniGrid')
+    if (grid && d.agents.list) {
+      grid.innerHTML = ''
+      for (const a of d.agents.list) {
+        const card = document.createElement('div')
+        card.className = 'agent-mini-card ' + (a.running ? 'running' : 'stopped')
+        card.title = a.running ? 'Fut' : 'Nem fut'
+        card.onclick = function() { location.hash = 'agents' }
+        // lastActive from backend is epoch seconds from token_usage; convert to ms for formatRelative
+        const lastActiveMs = a.lastActive ? a.lastActive * 1000 : null
+        const lastActiveText = lastActiveMs ? formatRelative(lastActiveMs) : (a.running ? 'fut' : 'inaktív')
+        card.innerHTML = '<div class="agent-mini-avatar"><img src="' + escapeHtml(a.avatarUrl) + '" alt="" onerror="this.style.display=\'none\'"></div>'
+          + '<div class="agent-mini-info">'
+          + '<div class="agent-mini-name">' + escapeHtml(a.label) + '</div>'
+          + '<div class="agent-mini-meta ' + (a.running ? '' : 'stopped') + '"><span class="dot"></span>' + (a.running ? 'fut' : 'áll') + ' &middot; ' + escapeHtml(lastActiveText) + '</div>'
+          + '</div>'
+        grid.appendChild(card)
       }
     }
+
+    // === Zone 4: Activity feed with agent filter pills ===
+    const feed = document.getElementById('ovActivityFeed')
+    const pillsEl = document.getElementById('ovActivityPills')
+    _ovActiveAgentFilter = null
+    if (feed) {
+      feed.innerHTML = ''
+      if (!d.activity || d.activity.length === 0) {
+        feed.innerHTML = '<div class="ov-activity-empty">Nincs aktivitás az elmúlt 4 órában.</div>'
+      } else {
+        const agentSet = new Set()
+        for (const a of d.activity) if (a.agent) agentSet.add(a.agent)
+        const agentList = Array.from(agentSet)
+
+        if (pillsEl && agentList.length > 1) {
+          pillsEl.innerHTML = ''
+          const allPill = document.createElement('button')
+          allPill.className = 'ov-pill active'
+          allPill.textContent = 'Mind'
+          allPill.onclick = function() {
+            _ovActiveAgentFilter = null
+            pillsEl.querySelectorAll('.ov-pill').forEach(function(p) { p.classList.remove('active') })
+            allPill.classList.add('active')
+            _ovRenderActivityFeed()
+          }
+          pillsEl.appendChild(allPill)
+          for (const ag of agentList) {
+            const pill = document.createElement('button')
+            pill.className = 'ov-pill'
+            pill.textContent = ag
+            pill.onclick = function() {
+              _ovActiveAgentFilter = ag
+              pillsEl.querySelectorAll('.ov-pill').forEach(function(p) { p.classList.remove('active') })
+              pill.classList.add('active')
+              _ovRenderActivityFeed()
+            }
+            pillsEl.appendChild(pill)
+          }
+        } else if (pillsEl) {
+          pillsEl.innerHTML = ''
+        }
+
+        for (const a of d.activity) {
+          const row = document.createElement('div')
+          row.className = 'ov-activity-row'
+          row.dataset.agent = a.agent || ''
+          row.innerHTML = '<span class="ov-activity-icon">' + ovActivityIcon(a.icon) + '</span>'
+            + '<span class="ov-activity-agent">' + escapeHtml(a.agent || '') + '</span>'
+            + '<span class="ov-activity-text" title="' + escapeHtml(a.text) + '">' + escapeHtml(a.text) + '</span>'
+            + '<span class="ov-activity-time">' + formatRelative(a.at) + '</span>'
+          feed.appendChild(row)
+        }
+      }
+    }
+
+    // === Zone 5: KPI strip ===
+    const taskDiff = d.tasksToday - d.tasksYesterday
+    document.getElementById('kpiTasks').textContent = d.tasksToday
+    const trendEl = document.getElementById('kpiTasksTrend')
+    if (trendEl) {
+      if (taskDiff > 0) { trendEl.textContent = '+' + taskDiff; trendEl.className = 'kpi-trend up' }
+      else if (taskDiff < 0) { trendEl.textContent = String(taskDiff); trendEl.className = 'kpi-trend down' }
+      else { trendEl.textContent = ''; trendEl.className = 'kpi-trend' }
+    }
+    document.getElementById('kpiCost').textContent = d.costTodayUsd > 0 ? '$' + d.costTodayUsd.toFixed(2) : '—'
+    document.getElementById('kpiMemories').textContent = d.memories.count.toLocaleString('hu-HU').replace(/,/g, ' ')
+    document.getElementById('kpiSkills').textContent = d.skills.count
+    document.getElementById('kpiTokens').textContent = fmtTokensShort(d.tokensToday)
+
   } catch (err) {
-    document.getElementById('overviewActivity').innerHTML = '<div style="color:var(--text-muted);font-size:13px">' + t('overview.error', { msg: escapeHtml(String(err.message || err)) }) + '</div>'
+    const feed = document.getElementById('ovActivityFeed')
+    if (feed) feed.innerHTML = '<div class="ov-activity-empty" style="color:var(--danger)">Hiba: ' + escapeHtml(String(err.message || err)) + '</div>'
   }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -265,7 +265,7 @@
           <span class="kpi-label">Feladatok ma</span>
           <span class="kpi-trend" id="kpiTasksTrend"></span>
         </a>
-        <a class="kpi-item" href="#costs">
+        <a class="kpi-item" href="#tokenUsage">
           <span class="kpi-value" id="kpiCost">—</span>
           <span class="kpi-label">Költség ma</span>
         </a>

--- a/web/index.html
+++ b/web/index.html
@@ -210,43 +210,79 @@
 
     <!-- === Overview Page (default) === -->
     <div class="page" id="overviewPage">
-      <div class="overview-stats">
-        <div class="overview-stat">
-          <div class="overview-stat-label" data-i18n="overview.stat.agents">Aktív ügynökök</div>
-          <div class="overview-stat-value" id="statAgents">—</div>
-          <div class="overview-stat-sub" id="statAgentsSub"></div>
+
+      <!-- Zone 1: Fleet Health bar (sticky, full-width) -->
+      <div class="fh-bar" id="fleetHealthBar">
+        <div class="fh-item" id="fhAgents">
+          <span class="fh-dot" id="fhDot"></span>
+          <span class="fh-value" id="fhAgentsText">—</span>
+          <span class="fh-label">agens</span>
         </div>
-        <div class="overview-stat">
-          <div class="overview-stat-label" data-i18n="overview.stat.tasks">Ma futott feladat</div>
-          <div class="overview-stat-value" id="statTasks">—</div>
-          <div class="overview-stat-sub" id="statTasksSub"></div>
+        <span class="fh-divider"></span>
+        <div class="fh-item" id="fhApprovals">
+          <span class="fh-value" id="fhApprovalsText">—</span>
+          <span class="fh-label">jóváhagyás</span>
         </div>
-        <div class="overview-stat">
-          <div class="overview-stat-label" data-i18n="overview.stat.memories">Memória</div>
-          <div class="overview-stat-value" id="statMemories">—</div>
-          <div class="overview-stat-sub" id="statMemoriesSub"></div>
+        <span class="fh-divider"></span>
+        <div class="fh-item" id="fhCost">
+          <span class="fh-value" id="fhCostText">—</span>
+          <span class="fh-label">cost ma</span>
         </div>
-        <div class="overview-stat">
-          <div class="overview-stat-label" data-i18n="overview.stat.skills">Generált skillek</div>
-          <div class="overview-stat-value" id="statSkills">—</div>
-          <div class="overview-stat-sub" id="statSkillsSub"></div>
-        </div>
-      </div>
-      <div class="overview-grid">
-        <div class="overview-card">
-          <div class="overview-card-head">
-            <h3 data-i18n="overview.card.team">Csapat</h3>
-            <span class="overview-card-meta" id="overviewTeamMeta" data-i18n="overview.meta.live">élő állapot</span>
-          </div>
-          <div class="team-graph overview-team-graph" id="overviewTeamGrid"></div>
-        </div>
-        <div class="overview-card">
-          <div class="overview-card-head">
-            <h3 data-i18n="overview.card.activity">Aktivitás</h3>
-          </div>
-          <div class="overview-activity" id="overviewActivity"></div>
+        <span class="fh-divider"></span>
+        <div class="fh-item" id="fhErrors">
+          <span class="fh-value" id="fhErrorsText">—</span>
+          <span class="fh-label">hiba (4h)</span>
         </div>
       </div>
+
+      <!-- Zone 2: Attention Required (hidden when empty, collapsible) -->
+      <div class="attention-section" id="attentionSection" hidden>
+        <div class="attention-header" id="attentionHeader">
+          <span class="attention-title">Figyelem szükséges</span>
+          <span class="attention-badge" id="attentionBadge">0</span>
+          <button class="attention-toggle" id="attentionToggle" aria-label="Összecsukolás">&#x25B2;</button>
+        </div>
+        <div class="attention-body" id="attentionBody"></div>
+      </div>
+
+      <!-- Zone 3: Compact agent grid -->
+      <div class="ov-section-title">Ágensek</div>
+      <div class="agents-mini-grid" id="agentsMiniGrid"></div>
+
+      <!-- Zone 4: Activity feed with agent filter pills -->
+      <div class="ov-activity-header">
+        <span class="ov-section-title">Aktivitás (utolsó 4h)</span>
+        <div class="ov-activity-pills" id="ovActivityPills"></div>
+      </div>
+      <div class="ov-activity-feed" id="ovActivityFeed">
+        <div class="ov-activity-empty">Nincs aktivitás az elmúlt 4 órában.</div>
+      </div>
+
+      <!-- Zone 5: KPI strip (bottom, compact, clickable links) -->
+      <div class="kpi-strip">
+        <a class="kpi-item" href="#kanban">
+          <span class="kpi-value" id="kpiTasks">—</span>
+          <span class="kpi-label">Feladatok ma</span>
+          <span class="kpi-trend" id="kpiTasksTrend"></span>
+        </a>
+        <a class="kpi-item" href="#costs">
+          <span class="kpi-value" id="kpiCost">—</span>
+          <span class="kpi-label">Költség ma</span>
+        </a>
+        <a class="kpi-item" href="#memories">
+          <span class="kpi-value" id="kpiMemories">—</span>
+          <span class="kpi-label">Memóriák</span>
+        </a>
+        <a class="kpi-item" href="#skills">
+          <span class="kpi-value" id="kpiSkills">—</span>
+          <span class="kpi-label">Skillek</span>
+        </a>
+        <a class="kpi-item" href="#tokenUsage">
+          <span class="kpi-value" id="kpiTokens">—</span>
+          <span class="kpi-label">Token ma</span>
+        </a>
+      </div>
+
     </div>
 
     <!-- === Kanban Page === -->

--- a/web/index.html
+++ b/web/index.html
@@ -211,7 +211,42 @@
     <!-- === Overview Page (default) === -->
     <div class="page" id="overviewPage">
 
-      <!-- Zone 1: Fleet Health bar (sticky, full-width) -->
+      <!-- Zone 1: Attention Required (hidden when empty, collapsible) -->
+      <div class="attention-section" id="attentionSection" hidden>
+        <div class="attention-header" id="attentionHeader">
+          <span class="attention-title">Figyelem szükséges</span>
+          <span class="attention-badge" id="attentionBadge">0</span>
+          <button class="attention-toggle" id="attentionToggle" aria-label="Összecsukolás">&#x25B2;</button>
+        </div>
+        <div class="attention-body" id="attentionBody"></div>
+      </div>
+
+      <!-- Zone 2: KPI strip (5 clickable cards) -->
+      <div class="kpi-strip">
+        <a class="kpi-item" href="#kanban">
+          <span class="kpi-value" id="kpiTasks">—</span>
+          <span class="kpi-label">Feladatok ma</span>
+          <span class="kpi-trend" id="kpiTasksTrend"></span>
+        </a>
+        <a class="kpi-item" href="#tokenUsage">
+          <span class="kpi-value" id="kpiCost">—</span>
+          <span class="kpi-label">Költség ma</span>
+        </a>
+        <a class="kpi-item" href="#memories">
+          <span class="kpi-value" id="kpiMemories">—</span>
+          <span class="kpi-label">Memóriák</span>
+        </a>
+        <a class="kpi-item" href="#skills">
+          <span class="kpi-value" id="kpiSkills">—</span>
+          <span class="kpi-label">Skillek</span>
+        </a>
+        <a class="kpi-item" href="#tokenUsage">
+          <span class="kpi-value" id="kpiTokens">—</span>
+          <span class="kpi-label">Token ma</span>
+        </a>
+      </div>
+
+      <!-- Zone 3: Fleet Health bar (informational strip) -->
       <div class="fh-bar" id="fleetHealthBar">
         <div class="fh-item" id="fhAgents">
           <span class="fh-dot" id="fhDot"></span>
@@ -235,52 +270,17 @@
         </div>
       </div>
 
-      <!-- Zone 2: Attention Required (hidden when empty, collapsible) -->
-      <div class="attention-section" id="attentionSection" hidden>
-        <div class="attention-header" id="attentionHeader">
-          <span class="attention-title">Figyelem szükséges</span>
-          <span class="attention-badge" id="attentionBadge">0</span>
-          <button class="attention-toggle" id="attentionToggle" aria-label="Összecsukolás">&#x25B2;</button>
-        </div>
-        <div class="attention-body" id="attentionBody"></div>
-      </div>
-
-      <!-- Zone 3: Compact agent grid -->
+      <!-- Zone 4: Compact agent grid -->
       <div class="ov-section-title">Ágensek</div>
       <div class="agents-mini-grid" id="agentsMiniGrid"></div>
 
-      <!-- Zone 4: Activity feed with agent filter pills -->
+      <!-- Zone 5: Activity feed with agent filter pills -->
       <div class="ov-activity-header">
         <span class="ov-section-title">Aktivitás (utolsó 4h)</span>
         <div class="ov-activity-pills" id="ovActivityPills"></div>
       </div>
       <div class="ov-activity-feed" id="ovActivityFeed">
         <div class="ov-activity-empty">Nincs aktivitás az elmúlt 4 órában.</div>
-      </div>
-
-      <!-- Zone 5: KPI strip (bottom, compact, clickable links) -->
-      <div class="kpi-strip">
-        <a class="kpi-item" href="#kanban">
-          <span class="kpi-value" id="kpiTasks">—</span>
-          <span class="kpi-label">Feladatok ma</span>
-          <span class="kpi-trend" id="kpiTasksTrend"></span>
-        </a>
-        <a class="kpi-item" href="#tokenUsage">
-          <span class="kpi-value" id="kpiCost">—</span>
-          <span class="kpi-label">Költség ma</span>
-        </a>
-        <a class="kpi-item" href="#memories">
-          <span class="kpi-value" id="kpiMemories">—</span>
-          <span class="kpi-label">Memóriák</span>
-        </a>
-        <a class="kpi-item" href="#skills">
-          <span class="kpi-value" id="kpiSkills">—</span>
-          <span class="kpi-label">Skillek</span>
-        </a>
-        <a class="kpi-item" href="#tokenUsage">
-          <span class="kpi-value" id="kpiTokens">—</span>
-          <span class="kpi-label">Token ma</span>
-        </a>
       </div>
 
     </div>

--- a/web/style.css
+++ b/web/style.css
@@ -7315,3 +7315,280 @@ body {
 .trace-wf-axis-line { stroke: var(--border); }
 .trace-wf-axis-label { font-size: 9px; fill: var(--text-muted); }
 .trace-bottleneck { stroke: var(--danger); stroke-width: 1.5; stroke-dasharray: 3 2; }
+
+/* === Overview redesign: Fleet Health bar, Attention, Agent grid, Activity feed, KPI strip === */
+
+/* Fleet Health bar */
+.fh-bar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  padding: 8px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: var(--shadow-sm);
+}
+.fh-bar.fh-warn { border-color: #f59e0b; background: rgba(245,158,11,0.06); }
+.fh-bar.fh-danger { border-color: var(--danger); background: var(--danger-soft); }
+.fh-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 14px;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.fh-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--success);
+  flex-shrink: 0;
+}
+.fh-dot.warn { background: #f59e0b; }
+.fh-dot.danger { background: var(--danger); }
+.fh-value { font-weight: 600; color: var(--text); }
+.fh-label { color: var(--text-muted); font-size: 11px; }
+.fh-divider { width: 1px; height: 20px; background: var(--border); flex-shrink: 0; }
+
+/* Attention Required section */
+.attention-section {
+  border: 1px solid #f59e0b;
+  border-radius: var(--radius);
+  background: rgba(245,158,11,0.05);
+  margin-bottom: 14px;
+  overflow: hidden;
+}
+.attention-section.danger { border-color: var(--danger); background: var(--danger-soft); }
+.attention-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  cursor: pointer;
+  user-select: none;
+}
+.attention-title { font-weight: 600; font-size: 13px; color: var(--text); flex: 1; }
+.attention-badge {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: #f59e0b;
+  color: #fff;
+}
+.attention-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 10px;
+  color: var(--text-muted);
+  padding: 0 4px;
+  transition: transform var(--transition);
+}
+.attention-toggle.collapsed { transform: rotate(180deg); }
+.attention-body {
+  padding: 0 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.attention-body.collapsed { display: none; }
+.attention-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.attention-item a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+  margin-left: auto;
+  white-space: nowrap;
+}
+.attention-item a:hover { text-decoration: underline; }
+
+/* Section titles */
+.ov-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 10px;
+  margin-top: 4px;
+  display: block;
+}
+
+/* Compact agents mini grid */
+.agents-mini-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.agent-mini-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  cursor: pointer;
+  transition: border-color var(--transition), background var(--transition);
+}
+.agent-mini-card:hover { border-color: var(--accent); background: var(--bg-card-hover); }
+.agent-mini-card.running { border-left: 3px solid var(--success); }
+.agent-mini-card.stopped { border-left: 3px solid var(--border); opacity: 0.75; }
+.agent-mini-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: var(--bg-input);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.agent-mini-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.agent-mini-info { flex: 1; min-width: 0; }
+.agent-mini-name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.agent-mini-meta { font-size: 11px; color: var(--text-muted); margin-top: 1px; }
+.agent-mini-meta .dot {
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--success);
+  margin-right: 4px;
+  vertical-align: middle;
+}
+.agent-mini-meta.stopped .dot { background: #a0a0a0; }
+
+/* Activity feed header + pills */
+.ov-activity-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+.ov-activity-header .ov-section-title { margin: 0; }
+.ov-activity-pills {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.ov-pill {
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+  white-space: nowrap;
+}
+.ov-pill.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.ov-pill:hover:not(.active) { border-color: var(--accent); color: var(--text); }
+
+/* Activity feed */
+.ov-activity-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 20px;
+  min-height: 40px;
+}
+.ov-activity-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  transition: background var(--transition);
+}
+.ov-activity-row:hover { background: var(--bg-card-hover); }
+.ov-activity-icon { font-size: 13px; flex-shrink: 0; }
+.ov-activity-agent { font-weight: 600; color: var(--accent); flex-shrink: 0; min-width: 40px; }
+.ov-activity-text { flex: 1; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ov-activity-time { color: var(--text-muted); font-size: 11px; flex-shrink: 0; white-space: nowrap; }
+.ov-activity-empty { font-size: 13px; color: var(--text-muted); padding: 10px 0; }
+.ov-activity-row[hidden] { display: none; }
+
+/* KPI strip */
+.kpi-strip {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  overflow: hidden;
+  margin-top: 4px;
+}
+.kpi-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 12px 10px;
+  text-decoration: none;
+  color: inherit;
+  border-right: 1px solid var(--border);
+  transition: background var(--transition);
+  gap: 2px;
+}
+.kpi-item:last-child { border-right: none; }
+.kpi-item:hover { background: var(--bg-card-hover); }
+.kpi-value {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  line-height: 1.1;
+}
+.kpi-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.kpi-trend {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.kpi-trend.up { color: var(--success); }
+.kpi-trend.down { color: var(--danger); }
+
+@media (max-width: 700px) {
+  .fh-bar { gap: 0; padding: 6px 8px; }
+  .fh-item { padding: 4px 8px; }
+  .agents-mini-grid { grid-template-columns: 1fr 1fr; }
+  .kpi-strip { flex-wrap: wrap; }
+  .kpi-item { min-width: 45%; border-bottom: 1px solid var(--border); }
+}

--- a/web/style.css
+++ b/web/style.css
@@ -7329,10 +7329,6 @@ body {
   border-radius: var(--radius);
   margin-bottom: 14px;
   flex-wrap: wrap;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  box-shadow: var(--shadow-sm);
 }
 .fh-bar.fh-warn { border-color: #f59e0b; background: rgba(245,158,11,0.06); }
 .fh-bar.fh-danger { border-color: var(--danger); background: var(--danger-soft); }


### PR DESCRIPTION
## Típus
- [x] Új funkció

## Rövid leírás
A fő dashboard (overview) oldal teljes újratervezése. Régi: 4 nagy KPI-csempe + csapat-gráf + aktivitás-kártya. Új: 5 rendezett zóna fentről le:
1. Attention Required -- függő jóváhagyások, kézbesítetlen üzenetek, elakadt feladatok, hibák; üresen összecsukva.
2. KPI strip -- 5 kattintható kártya (Feladatok ma / Költség ma / Memóriák / Skillek / Token ma); a Költség és Token a token_usage forrásból, a Token Monitor bontásra linkel (konzisztens, nem az üres cost_line_items főkönyv).
3. Fleet Health sáv -- info-csík: N/M ágens aktív, váró jóváhagyások, mai AI-költség, 4h hibaszám; színkódolt.
4. Ágensek grid -- kompakt per-ágens kártyák fut/áll + utolsó-aktív idővel.
5. Aktivitás feed -- utolsó 4h eseményei ágens-szűrő pill-ekkel.

Backend (/api/overview): per-ágens lastActive (token_usage MAX), mai token-alapú költség-becslés (modell-specifikus: opus/sonnet/haiku), pending-approval / hiba / stuck-task count-ok, 4h aktivitás-feed + agent mező. Quick Nav nincs.

## Kapcsolódó

## Ellenőrzőlista
- [x] Lokálisan tesztelve (dashboard), ágensek hiba nélkül kommunikálnak
- [x] Nincs beleégetett szenzitív adat
- [x] Saját branch-ről nyitva
Tesztek: 20/20 zöld (overview-api.test.ts)