### PR TITLE
feat(inter-agent): reliable message send (verify HTTP status + id, retry)

### DIFF
--- a/docs/inter-agent-send-reliability.md
+++ b/docs/inter-agent-send-reliability.md
@@ -1,0 +1,35 @@
+# Inter-agent send reliability (verify + retry)
+
+## The problem
+Agents send inter-agent messages with `POST /api/messages`. A common shorthand is a `curl` whose output
+is discarded and success inferred from the shell `&&`:
+
+    curl -s ... -d @- <<HEREDOC >/dev/null && echo sent
+    ...
+    HEREDOC
+
+This is **dangerous**: `curl` exits `0` on a completed HTTP request even when the server **rejected** it
+(401 unauthorized, 400 bad body, 5xx), because `>/dev/null` discards the response and `&&` only checks
+curl's exit code. The agent sees its own `echo sent` and believes the message went out. Result: a **silent
+send failure** — the recipient never gets the message, and two agents can wait on each other indefinitely.
+
+Observed in the field (2026-07): a sub-agent's completion callbacks were silently lost this way, costing
+~30–60 minutes of an idle main+sub deadlock. The `/api/messages` router was healthy the whole time
+(HTTP 200 + a message `id`); the defect was purely sender-side (never checking the result).
+
+## The rule
+**A message counts as sent only when the response returned an `id`** (`{"id":<n>,"status":"pending",...}`
+with HTTP 200). Verify the HTTP status **and** the returned id, and resend if missing.
+
+## The fix
+- `scripts/agent-msg.sh <from> <to> "<content>"` — builds the JSON body with `json.dumps` (no quoting
+  pitfalls), checks HTTP status + `id`, retries up to 3×, logs failures to `store/agent-msg-failures.log`.
+  Large/multi-line content may come from STDIN with a `-` third arg. Base dir is auto-detected, port from
+  `MARVEEN_WEB_PORT` (default 3420), so it runs from any CWD / any install.
+- The generated agent `CLAUDE.md` (from `templates/CLAUDE.md.template`) now documents this rule and points
+  at the helper, so every agent in every fleet verifies its sends by default.
+
+## Belt-and-suspenders
+For delegated tasks, pairing the callback with a **DONE-marker file** (written as the final step) lets the
+orchestrator detect completion by file signal even if a callback is ever lost. But the primary fix is that
+the sender must not treat an unchecked `curl` as success.

--- a/scripts/agent-msg.sh
+++ b/scripts/agent-msg.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# agent-msg.sh -- reliable inter-agent message send for the Marveen fleet.
+#
+# WHY: the common `curl -s ... >/dev/null && echo sent` pattern is DANGEROUS -- curl exits 0 even when
+# the server REJECTED the request (401/400/5xx), producing a SILENT send failure: the recipient never
+# gets the message and two agents can wait on each other forever. The /api/messages router itself is
+# fine (HTTP 200 + a message id); the bug is that the SENDER never checks the result. This helper checks
+# the HTTP status AND the returned message id, and RETRIES on failure. A message counts as sent only
+# when an id came back.
+#
+# Usage:  bash scripts/agent-msg.sh <from> <to> "<content>"
+#   content: plain text (quotes / newlines OK) -- the body is built with json.dumps (no quoting pitfalls).
+#   large / multi-line content may come from STDIN when the 3rd arg is "-":
+#     echo "<long text>" | bash scripts/agent-msg.sh <from> <to> -
+# Output: success -> "OK id=<n>"; failure -> "FAIL <reason>" + a line in store/agent-msg-failures.log, exit 1.
+# Env: MARVEEN_WEB_PORT (default 3420).
+set -uo pipefail
+
+# base dir = the parent of this script's dir (scripts/..), so it works from any CWD / any install
+BASE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${MARVEEN_WEB_PORT:-3420}"
+TOKEN_FILE="$BASE/store/.dashboard-token"
+URL="http://localhost:${PORT}/api/messages"
+LOG="$BASE/store/agent-msg-failures.log"
+
+FROM="${1:?from required}"; TO="${2:?to required}"; C="${3:?content required (or - for STDIN)}"
+[ "$C" = "-" ] && C="$(cat)"
+[ -r "$TOKEN_FILE" ] || { echo "FAIL: no token file at $TOKEN_FILE"; exit 1; }
+TOKEN="$(cat "$TOKEN_FILE")"
+
+BODY="$(FROM="$FROM" TO="$TO" C="$C" python3 -c 'import json,os; print(json.dumps({"from":os.environ["FROM"],"to":os.environ["TO"],"content":os.environ["C"]}))')"
+
+attempt=0; max=3; CODE=""; ID=""
+while [ "$attempt" -lt "$max" ]; do
+  attempt=$((attempt+1))
+  RESP="$(curl -s -X POST "$URL" -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d "$BODY" -w $'\n%{http_code}' 2>/dev/null || true)"
+  CODE="$(printf '%s' "$RESP" | tail -n1)"
+  JSON="$(printf '%s' "$RESP" | sed '$d')"
+  ID="$(printf '%s' "$JSON" | python3 -c 'import sys,json
+try:
+  d=json.load(sys.stdin); print(d.get("id","") if isinstance(d,dict) else "")
+except Exception:
+  print("")' 2>/dev/null)"
+  if { [ "$CODE" = "200" ] || [ "$CODE" = "201" ]; } && [ -n "$ID" ]; then
+    echo "OK id=$ID"; exit 0
+  fi
+  sleep 1
+done
+echo "FAIL from=$FROM to=$TO http=${CODE:-?} id='$ID' (after $max tries)"
+printf '%s\tFAIL\tfrom=%s\tto=%s\thttp=%s\tresp=%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$FROM" "$TO" "${CODE:-?}" "$(printf '%s' "${JSON:-}" | head -c 200)" >> "$LOG" 2>/dev/null || true
+exit 1

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -173,6 +173,13 @@ curl -s -X POST http://localhost:{{WEB_PORT}}/api/messages \
   -d '{"from": "{{MAIN_AGENT_ID}}", "to": "TARGET_AGENT", "content": "Feladat leírása."}'
 ```
 
+**MEGBÍZHATÓ KÜLDÉS (verify + retry) — KÖTELEZŐ:** a gyakori `curl -s ... >/dev/null && echo sent` minta VESZÉLYES: a curl `0`-val tér vissza akkor is, ha a szerver ELUTASÍTOTTA a kérést (401/400/5xx), így NÉMA küldés-hiba keletkezik — a címzett sosem kapja meg az üzenetet, és két ágens végtelenül várhat egymásra. Egy üzenet CSAK akkor számít elküldöttnek, ha a válaszban visszajött egy `id` (`{"id":<n>,"status":"pending",...}` HTTP 200-zal). Vagy használd a `scripts/agent-msg.sh` helpert (HTTP-státusz + `id` ellenőrzés + 3x újraküldés + hiba-napló), vagy nyers curl-nél KÖTELEZŐ ellenőrizni a HTTP-kódot ÉS az `id`-t, és újraküldeni ha nincs:
+
+```bash
+bash scripts/agent-msg.sh {{MAIN_AGENT_ID}} TARGET_AGENT "Feladat leírása."   # -> OK id=<n>  vagy  FAIL
+# nagy/soktoros üzenethez a content jöhet STDIN-en:  echo "..." | bash scripts/agent-msg.sh {{MAIN_AGENT_ID}} TARGET_AGENT -
+```
+
 A rendszer automatikusan:
 1. Beírja az üzenetet a célpont ágens tmux session-jébe
 2. A célpont ágens megkapja mint "[Üzenet @{{MAIN_AGENT_ID}}-tól]: ..." formátumban


### PR DESCRIPTION
## Problem
Agents send inter-agent messages with `POST /api/messages`. A common shorthand discards the response and infers success from the shell `&&`:

    curl -s ... >/dev/null && echo sent

This is dangerous: `curl` exits `0` on a completed HTTP request even when the server **rejected** it (401/400/5xx), because `>/dev/null` drops the body and `&&` only checks curl's exit code. The agent sees its own `echo sent` and believes the message went out. Result: a **silent send failure** — the recipient never gets it, and two agents can deadlock waiting on each other. Observed in the field costing ~30–60 min of an idle main+sub stall. The `/api/messages` router is healthy the whole time (HTTP 200 + a message `id`); the gap is purely sender-side.

## Fix
- **`scripts/agent-msg.sh`** — reliable send helper. Builds the JSON body with `json.dumps` (no quoting pitfalls), checks HTTP status **and** the returned message `id`, retries up to 3×, logs failures to `store/agent-msg-failures.log`. Base dir auto-detected, port via `MARVEEN_WEB_PORT` (default 3420) → runs from any CWD / install. Content via arg or STDIN (`-`).
- **`templates/CLAUDE.md.template`** — documents the rule *"a message counts as sent only when an `id` came back"* in the inter-agent section and points at the helper, so every generated agent verifies its sends by default.
- **`docs/inter-agent-send-reliability.md`** — rationale + a belt-and-suspenders note (pair delegated-task callbacks with a DONE-marker file so completion is detectable even if a callback is ever lost).

## Notes
- Router-side reliability already landed upstream (retry transient inject failures, wake-nudge for idle stuck-inbox sub-agents); this closes the remaining **sender-side** gap.
- Diff is 3 files, +93 lines, based on `origin/develop`. The template addition matches the template's existing Hungarian; the helper and doc are English.
