### PR TITLE
fix(context-guard): stop the calibrated limit from blinding its own t…

### DIFF
--- a/src/__tests__/context-guard.test.ts
+++ b/src/__tests__/context-guard.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeContextGuardConfig,
   contextLimitForModel,
   calibrateLimit,
+  CALIBRATION_OVERSHOOT_TOLERANCE,
   decideGuard,
   DEFAULT_CONTEXT_GUARD,
   INITIAL_GUARD_STATE,
@@ -70,6 +71,68 @@ describe('contextLimitForModel / calibrateLimit', () => {
     expect(calibrateLimit(489_000, 200_000)).toBe(500_000) // tars 2026-07-09
     expect(calibrateLimit(900_000, 200_000)).toBe(1_000_000)
     expect(calibrateLimit(300_000, 1_000_000)).toBe(1_000_000)
+  })
+
+  // A full 200k window is OBSERVED slightly above 200k: the measured quantity is
+  // input+cache_read+cache_creation of the last request, which overshoots the
+  // nominal window. Measured 2026-07-26 across 11 saturated sessions (main agent
+  // + heimdall), the largest overshoot was 213175/200000 = 1.066x. A tolerance
+  // that does not cover that turns a saturated session into a "43% full" one.
+  it('does NOT step up for a merely-overshooting full window (regression)', () => {
+    // The exact production case: the pane showed "100% context used" while the
+    // guard logged pct: 43, because the denominator had jumped to 500k.
+    expect(calibrateLimit(213_175, 200_000)).toBe(200_000)
+    // The whole measured saturation range must stay on the 200k denominator.
+    for (const observed of [194_226, 198_544, 204_082, 207_942, 208_132, 213_175]) {
+      expect(calibrateLimit(observed, 200_000)).toBe(200_000)
+    }
+  })
+
+  it('keeps a saturated session ABOVE the act/hard thresholds', () => {
+    // The property that actually matters: whatever the calibration decides, a
+    // session at genuine exhaustion must not read below the acting thresholds.
+    for (const observed of [180_000, 194_000, 204_082, 213_175]) {
+      const pct = observed / calibrateLimit(observed, 200_000)
+      expect(pct).toBeGreaterThanOrEqual(DEFAULT_CONTEXT_GUARD.actPct)
+    }
+    expect(213_175 / calibrateLimit(213_175, 200_000))
+      .toBeGreaterThanOrEqual(DEFAULT_CONTEXT_GUARD.hardPct)
+  })
+
+  it('still steps up when the observation is too big to be an overshoot', () => {
+    // Counter-example, or the fix would reinstate the nonsense pct > 1 restart
+    // storm the calibration was built for: tars ran at 489k on a model we would
+    // have guessed 200k for -- 2.4x the base, not a 7% accounting overshoot.
+    expect(calibrateLimit(489_000, 200_000)).toBe(500_000)
+    expect(489_000 / calibrateLimit(489_000, 200_000)).toBeLessThanOrEqual(1)
+    expect(calibrateLimit(300_000, 200_000)).toBe(500_000)
+    // A genuine 1M window at 85% must not be forced down onto 500k.
+    expect(calibrateLimit(850_000, 1_000_000)).toBe(1_000_000)
+    expect(calibrateLimit(850_000, 200_000)).toBe(1_000_000)
+  })
+
+  it('pins the step-up boundary (documents the residual, does not hide it)', () => {
+    // The tolerance is a deliberate trade, so its exact edge is pinned here.
+    // Below the edge we keep the smaller denominator -- which means a window
+    // that really IS a tier we did not guess reads as over-full until it grows
+    // past the edge. That is the accepted cost: over-full is loud and
+    // self-correcting, an inflated denominator is silent (see the regression
+    // case above). No fleet model is configured onto a 500k window today.
+    const edge = 200_000 * CALIBRATION_OVERSHOOT_TOLERANCE
+    expect(calibrateLimit(edge, 200_000)).toBe(200_000)
+    expect(calibrateLimit(edge + 1, 200_000)).toBe(500_000)
+    // The edge must sit above every measured full-window overshoot ...
+    expect(edge).toBeGreaterThan(213_175)
+    // ... and stay well below the 200k/500k geometric midpoint, so a step-up is
+    // never a coin flip between two tiers.
+    expect(edge).toBeLessThan(Math.sqrt(200_000 * 500_000))
+  })
+
+  it('leaves the top tier to report pct > 1 (no tier above to step to)', () => {
+    // Above the largest known tier there is nothing to calibrate to, so the
+    // overshoot must surface as pct > 1 and let hardPct fire.
+    expect(calibrateLimit(1_200_000, 1_000_000)).toBe(1_000_000)
+    expect(1_200_000 / calibrateLimit(1_200_000, 1_000_000)).toBeGreaterThan(1)
   })
 })
 

--- a/src/context-guard.ts
+++ b/src/context-guard.ts
@@ -95,17 +95,52 @@ export function contextLimitForModel(model: string | null | undefined): number {
 }
 
 /**
- * If the observed context tokens exceed the assumed limit, the assumption is
- * wrong (e.g. tars ran at 489k on a model we would have guessed 200k for).
- * Step up to the next tier that contains the observation instead of producing
- * a nonsense pct > 1 that would trigger a spurious restart storm.
+ * How far the OBSERVED context may exceed a limit while still being explained by
+ * that limit rather than disproving it.
+ *
+ * The observation is the sum of input + cache_read + cache_creation tokens of a
+ * session's last request, which overshoots the nominal window: measured
+ * 2026-07-26 across 11 sessions that Claude Code itself had flagged "100%
+ * context used" (main agent 194226/204285/207942/208132/213175, heimdall
+ * 178536/179772/182648/188129/191286/198544 -- all on 200k-window models), the
+ * largest overshoot was 213175/200000 = 1.066x. The previous tolerance was
+ * effectively 1.0204x (`limit >= observed * 0.98`), i.e. NARROWER than the real
+ * overshoot, so a genuinely-full 200k session crossed it at 204082 observed
+ * tokens and the denominator jumped to 500k -- reporting 43% for a session the
+ * CLI had just declared full, and putting actPct (0.9) and hardPct (0.97) out of
+ * reach for the rest of that session's life. This value is deliberately ~2x the
+ * measured overshoot so a full window is never mistaken for a bigger one.
+ */
+export const CALIBRATION_OVERSHOOT_TOLERANCE = 1.25
+
+/**
+ * If the observed context tokens exceed the assumed limit by more than an
+ * accounting overshoot can explain, the assumption is wrong (e.g. tars ran at
+ * 489k -- 2.4x -- on a model we would have guessed 200k for). Step up to the
+ * smallest tier that can hold the observation, instead of producing a nonsense
+ * pct > 1 that would trigger a spurious restart storm.
+ *
+ * The tolerance direction is chosen deliberately. Under-estimating the limit
+ * reports a too-high pct and costs at most a premature (but LOUD, logged, and
+ * self-correcting) handoff/restart; over-estimating it goes SILENTLY blind and
+ * costs the whole session with no handoff at all -- which is what happened on
+ * 2026-07-26. When in doubt we keep the smaller denominator.
+ *
+ * Residual, stated rather than hidden: a session whose real window is a tier we
+ * did not guess is measured against the smaller tier until it exceeds it by the
+ * tolerance -- e.g. a genuine 500k window observed in 200000..250000 reads as
+ * over-full and may be restarted once before it grows past the step-up point.
+ * No model in the fleet is configured that way today (every agent resolves to a
+ * 200k window; only the `[1m]` suffix selects a larger one), and `limitTokens`
+ * pins the denominator explicitly when an operator knows better.
  */
 export function calibrateLimit(observedTokens: number, baseLimit: number): number {
+  const explains = (limit: number): boolean =>
+    observedTokens <= limit * CALIBRATION_OVERSHOOT_TOLERANCE
   let limit = baseLimit
   for (const tier of CONTEXT_LIMIT_TIERS) {
-    if (limit >= observedTokens * 0.98) break
+    if (explains(limit)) break
     if (tier > limit) limit = tier
-    if (limit >= observedTokens * 0.98) break
   }
   return limit
 }


### PR DESCRIPTION
…hresholds

calibrateLimit() treated an observation only 2% above the assumed window as proof that the window was bigger, and stepped the denominator 200k -> 500k. That inverts the guard exactly when it is needed: a session Claude Code had just declared "100% context used" was reported at 43% (observed 213175 / 500000), putting actPct (0.90) and hardPct (0.97) permanently out of reach for the rest of that session -- they would have required 450k/485k tokens from a session that dies around 215k. The proactive handoff therefore never fired, and the always-on saturation net was left as the only working rescue.

The measured cause: the observed quantity (input + cache_read + cache_creation of the last request) overshoots the nominal window. Across 11 sessions the CLI itself had flagged as full on 2026-07-26 -- main agent 194226/204285/207942/208132/213175, heimdall
178536/179772/182648/188129/191286/198544, all on 200k-window models -- the largest overshoot was 1.066x. The old tolerance was effectively 1.0204x, i.e. narrower than the real overshoot, so every full 200k session crossed it at 204082 observed tokens. It was not a one-off: the calibration is stateless and recomputed on every five-minute poll.

Raise the tolerance to an explicit, measured, named constant (1.25x, ~2x the observed overshoot and well below the 200k/500k geometric midpoint) and state the chosen failure direction: under-estimating the limit costs at most a loud, self-correcting early restart, while over-estimating it goes silently blind and costs the whole session with no handoff. The tars case the calibration was built for (489k on a presumed-200k model, 2.4x) is unaffected and regression- tested, as is the top-tier pct > 1 fallback.

Tests pin the boundary that had none: the production fixture (213175 must stay on 200k and read >= hardPct), the full measured saturation range, the exact step-up edge, and the residual this trade accepts.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
