### PR TITLE
fix(governance): stop self-pace gate false positives and sub-agent 401s

### DIFF
--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -211,6 +211,27 @@ export function stripGitCommitMessages(command) {
   )
 }
 
+// Normalise two shell-level obfuscations that bash resolves at EXEC time, so an
+// invocation whose SHAPE is a real self-pace cannot dodge the slash-command match
+// with quoting the shell undoes anyway. Measured end-to-end through the gate hook
+// (upstream review, 2026-07-27): `claude \/loop` and `claude$IFS/loop` BOTH run
+// `claude /loop` in bash but slipped the `(?:^|[\s'"])\/loop` match -- the char
+// before `/loop` was `\` and `S` (end of `$IFS`), neither in the [\s'"] class.
+// The fix is NOT to widen that class (that would let more prose through); it is to
+// resolve what the shell resolves before matching: `$IFS`/`${IFS}` word-splits to
+// a space, and a backslash escape `\X` collapses to `X`. Side effect: also closes
+// `claude /lo\op`. Applied ONLY to the self-pace bash patterns below; the
+// scheduler/store/API checks keep the raw segment (upstream measured them clean,
+// and this PR is scoped to these two loop regressions). This cannot introduce a
+// false positive: collapsing escapes / dropping `$IFS` never synthesises the
+// literal `tmux`+send-keys, `nohup`+claude, or `claude`+`/loop` tokens out of
+// prose -- it only removes an evasion.
+export function normalizeShellEvasion(seg) {
+  return String(seg ?? '')
+    .replace(/\$\{IFS\}|\$IFS\b/g, ' ') // $IFS / ${IFS} -> the space it expands to
+    .replace(/\\(.)/g, '$1') // \X -> X (bash unescape of a backslash-escaped char)
+}
+
 // Pure decision: does this tool call set up self-pace / self-injection?
 export function gateDecision(toolName, toolInput) {
   const name = String(toolName ?? '')
@@ -232,7 +253,10 @@ export function gateDecision(toolName, toolInput) {
     // Per-segment so an unrelated token elsewhere in a compound command cannot
     // turn a legit read (store inspection, schedule-API GET) into a false deny.
     for (const seg of splitSegments(safeCommand)) {
-      if (SELF_PACE_BASH_PATTERNS.some((re) => re.test(seg))) return { deny: true }
+      // Match the self-pace bash patterns against the shell-normalised segment so a
+      // `\/loop` / `$IFS/loop` evasion (which bash resolves to `/loop` at exec) is
+      // still caught; the scheduler/store/API checks below use the RAW seg (scoped).
+      if (SELF_PACE_BASH_PATTERNS.some((re) => re.test(normalizeShellEvasion(seg)))) return { deny: true }
       // scheduler binaries: deny the exec/submit forms, allow pure read-listing
       if (SCHEDULER_RX.test(seg) && !SCHEDULER_READ_RX.test(seg)) return { deny: true }
       // self-schedule store: block WRITE only (a read/grep is legit diagnostics)

--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -50,8 +50,18 @@ const SELF_PACE_BASH_PATTERNS = [
   /\btmux\b[\s\S]*\b(send-keys|paste-buffer|run-shell|set-buffer)\b/i,
   // self-backgrounding that relaunches claude (nohup/setsid/disown + claude)
   /\b(nohup|setsid|disown)\b[\s\S]*\bclaude\b/i,
-  // the loop slash-skill driven from a shell
-  /\bclaude\b[\s\S]*\/loop\b/i,
+  // the loop slash-skill driven from a shell. `/loop` must be in SLASH-COMMAND
+  // position -- a standalone token (segment-start / whitespace / quote before it,
+  // whitespace / quote / end after it) -- never a PATH segment. The old
+  // `\/loop\b` fired on any `loop`-prefixed path component whenever `.claude` was
+  // in the same command (\bclaude\b matches the `.claude` in every memory/skill
+  // path), so reading `.../memory/loop-stop-...md` or `~/.claude/skills/loop/...`
+  // was denied (measured 2026-07-26, found by pg: Heli denied a harmless memory
+  // read). Same bug class as the at/batch and launchctl fixes below: a keyword in
+  // a PATH collided with a call pattern; the fix is to match the invocation SHAPE.
+  // Every real form stays denied: `claude /loop 5m`, `claude -p "/loop x"`,
+  // `claude '/loop'`, bare `claude /loop`.
+  /\bclaude\b[\s\S]*(?:^|[\s'"])\/loop(?=[\s'"]|$)/i,
 ]
 
 // OS-level schedulers + delayed exec (cron / launchd / systemd / at / batch): the
@@ -68,7 +78,43 @@ const SCHED_PREFIX = String.raw`(?:(?:[A-Za-z_]\w*=\S*|sudo|env|command|exec|nic
 // (`X=`crontab -r``) is caught too -- both run the enclosed command in a shell
 // context, so a scheduler binary immediately inside either is a real self-pace.
 const SCHED_BOUNDARY = '[;&|(`]'
-const SCHEDULER_RX = new RegExp(String.raw`(^|${SCHED_BOUNDARY}\s*)${SCHED_PREFIX}(crontab|launchctl|systemd-run|batch|at)\b(?!-)(?!\s*=)`, 'i')
+// `at` and `batch` are also ordinary English words, and splitSegments splits on
+// NEWLINES -- so a PROSE line inside a multi-line commit body ("at least 80% of
+// entries", "batch size is 50") lands at a segment start and looked exactly like
+// the at(1)/batch(1) binaries. Measured 2026-07-25 (found by JogAsz): a heredoc
+// commit message was denied for the words "at least"; the identical command
+// passed after rewording that one line. The `-m "$(...)"` form is deliberately
+// NOT blanked by stripGitCommitMessages (a real substitution could hide there),
+// so the body does reach the splitter -- the fix belongs here, not there.
+//
+// For these two words ONLY, also require something that looks like an actual
+// invocation: end of segment (a bare `batch` reads stdin -- still a real vector),
+// a flag, an input redirect, or an at(1) TIMESPEC (which at(1) requires anyway,
+// so a real submit can never omit it). crontab/launchctl/systemd-run keep the
+// plain match: they are not English words, so prose cannot collide with them.
+const AT_INVOCATION = String.raw`(?=\s*$|\s+-|\s*<|\s+(?:now|noon|midnight|teatime|today|tomorrow|next\b|\+\s*\d|\d{1,2}:\d{2}|\d{3,4}\b|\d{1,2}\s*(?:am|pm)\b|\d{1,2}[./]\d{1,2}|(?:mon|tue|wed|thu|fri|sat|sun)|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)))`
+// `launchctl` needed the SAME narrowing, for a different reason than at/batch, and
+// the comment above ("not English words, so prose cannot collide") was measured
+// wrong on 2026-07-26 (found by Hacker). It is not an English word -- but the
+// fleet's own heartbeats ORDER every agent to report `launchctl list | grep
+// com.jarvis.channels` output, so a launchd JOB LABEL appears in prose constantly.
+// splitSegments splits on `;`, so a report line "...; launchctl com.jarvis.channels
+// PID 555" put `launchctl <label>` at a segment start and it read as a real
+// invocation. His status message was denied; the finding is systemic, not his.
+//
+// The narrowing mirrors AT_INVOCATION: instead of enumerating dangerous
+// subcommands (a denylist -- miss one and it is a hole), require the SHAPE of a
+// real invocation. Every launchctl self-pace vector (load/bootstrap/submit/
+// kickstart/start/enable/...) takes a SUBCOMMAND word first, so demand that the
+// next token could be one: a bare lowercase word, no dot and no slash. A job
+// label (`com.jarvis.channels`) and a path both fail that and pass through as
+// prose. End-of-segment and a flag stay DENIED -- a bare `launchctl` is
+// interactive, still a real vector.
+const LAUNCHCTL_SUBCOMMAND = String.raw`(?=\s*$|\s+-|\s+[a-z][a-z-]*(?:\s|$))`
+const SCHEDULER_RX = new RegExp(
+  String.raw`(^|${SCHED_BOUNDARY}\s*)${SCHED_PREFIX}(?:(?:crontab|systemd-run)\b(?!-)(?!\s*=)|launchctl\b(?!-)(?!\s*=)${LAUNCHCTL_SUBCOMMAND}|(?:batch|at)\b(?!-)(?!\s*=)${AT_INVOCATION})`,
+  'i',
+)
 // ...but allow a pure READ-listing of one's own schedule (parity with the store /
 // schedule-API read exemptions): crontab -l, launchctl list/print, atq.
 const SCHEDULER_READ_RX = new RegExp(String.raw`(^|${SCHED_BOUNDARY}\s*)${SCHED_PREFIX}(crontab\s+-l\b|launchctl\s+(?:list|print|dumpstate|blame|examine)\b|atq\b)`, 'i')

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -94,6 +94,24 @@ describe('self-pace-gate gateDecision', () => {
   it('denies a shell-driven /loop', () => {
     expect(selfPaceDecision('Bash', { command: 'claude /loop "keep polling"' }).deny).toBe(true)
   })
+  // Two forms the slash-command-position match regressed on (upstream review,
+  // 2026-07-27): both EXECUTE `claude /loop` in bash but the char before `/loop`
+  // was `\` / end-of-`$IFS`, not in the [\s'"] class. Fixed by normalising the
+  // segment (resolve `\X`->`X`, `$IFS`->space) before the pattern runs.
+  it('denies a /loop hidden by a backslash-escaped slash (claude \\/loop)', () => {
+    expect(selfPaceDecision('Bash', { command: 'claude \\/loop "keep polling"' }).deny).toBe(true)
+  })
+  it('denies a /loop hidden by $IFS word-splitting (claude$IFS/loop)', () => {
+    expect(selfPaceDecision('Bash', { command: 'claude$IFS/loop 5m' }).deny).toBe(true)
+  })
+  it('denies the /lo\\op mid-token backslash form (side effect of the same fix)', () => {
+    expect(selfPaceDecision('Bash', { command: 'claude /lo\\op' }).deny).toBe(true)
+  })
+  it('ALLOWS reading a memory path with a loop- prefix (normalisation keeps prose through)', () => {
+    // `.claude` matches \bclaude\b and the name starts `loop-`, but `/loop` is not
+    // in slash-command position (a `-` follows), so it must still pass.
+    expect(selfPaceDecision('Bash', { command: 'cat ~/.claude/memory/loop-stop-vs-truncation.md' }).deny).toBe(false)
+  })
   it('ALLOWS a normal Bash command', () => {
     expect(selfPaceDecision('Bash', { command: 'git status && ls -la' }).deny).toBe(false)
   })

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -36,6 +36,43 @@ describe('self-pace-gate gateDecision', () => {
   it('does NOT misfire "at" on a substring (netstat / cat)', () => {
     expect(selfPaceDecision('Bash', { command: 'cat file.txt && netstat -an' }).deny).toBe(false)
   })
+  // Regression (2026-07-25, found by JogAsz): splitSegments splits on NEWLINES, so
+  // every prose line of a multi-line commit body became its own "segment". A line
+  // starting with the English words "at" / "batch" then looked like the at(1) /
+  // batch(1) binaries and false-denied a plain `git commit`. The `-m "$(...)"`
+  // form is deliberately NOT blanked by stripGitCommitMessages (a real command
+  // substitution could hide there), so the body does reach the splitter.
+  it('does NOT misfire on PROSE starting with "at"/"batch" in a heredoc commit body', () => {
+    const body = (line: string) => `git commit -m "$(cat <<'EOF'\nfix(lib): parser tweak\n\n${line}\nEOF\n)"`
+    for (const line of [
+      'at least 80% of parsed entries must carry a date',
+      'at most 3 retries before giving up',
+      'at runtime the parser reads the header',
+      'at the same time we clear the cache',
+      'batch size is 50 by default',
+    ]) {
+      expect(selfPaceDecision('Bash', { command: body(line) }).deny).toBe(false)
+    }
+  })
+  it('STILL denies a real at/batch submit (timespec, flag, redirect, bare batch)', () => {
+    for (const cmd of [
+      'at now + 1 minute',
+      'at 14:00',
+      'at tomorrow',
+      'at -f /tmp/x.sh now',
+      'batch',
+      'batch < /tmp/x.sh',
+      'echo hi ; at now + 5 min',
+      '/usr/bin/at now',
+    ]) {
+      expect(selfPaceDecision('Bash', { command: cmd }).deny).toBe(true)
+    }
+  })
+  it('STILL denies a real command substitution hidden in a commit message', () => {
+    expect(selfPaceDecision('Bash', { command: 'git commit -m "$(crontab -r)"' }).deny).toBe(true)
+    // unquoted heredoc delimiter DOES expand -> must stay caught
+    expect(selfPaceDecision('Bash', { command: 'git commit -m "$(cat <<EOF\nfix\n$(at now)\nEOF\n)"' }).deny).toBe(true)
+  })
   it('denies a WRITE to the self-schedule store (redirect)', () => {
     expect(selfPaceDecision('Bash', { command: 'echo "{}" > ~/.claude/scheduled_tasks.json' }).deny).toBe(true)
   })
@@ -178,6 +215,26 @@ describe('self-pace-gate compound-command false-positives', () => {
     expect(selfPaceDecision('Bash', { command: '(crontab -l; echo job) | crontab -' }).deny).toBe(true)
     expect(selfPaceDecision('Bash', { command: 'crontab -r' }).deny).toBe(true)
     expect(selfPaceDecision('Bash', { command: 'launchctl submit -l self -- node x.mjs' }).deny).toBe(true)
+  })
+  // Measured false positive, 2026-07-26 (found by Hacker): the heartbeats ORDER every
+  // agent to report `launchctl list | grep com.jarvis.channels` output, so a launchd
+  // job LABEL shows up in prose constantly. splitSegments splits on `;`, which put
+  // `launchctl <label>` at a segment start and it read as a real invocation -- a status
+  // report was denied. Same shape as the at/batch "at least" case, different binary.
+  // The narrowing requires the SHAPE of an invocation (a bare lowercase subcommand
+  // word), not a denylist of subcommands.
+  it('does NOT deny a launchd job LABEL appearing in prose (no subcommand follows)', () => {
+    expect(selfPaceDecision('Bash', { command: 'echo hello; launchctl com.jarvis.channels PID 555' }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: 'launchctl com.marveen.dashboard is up' }).deny).toBe(false)
+  })
+  it('STILL denies every real launchctl form after that narrowing', () => {
+    // a subcommand word follows -> real invocation
+    expect(selfPaceDecision('Bash', { command: 'launchctl load ~/Library/LaunchAgents/x.plist' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'launchctl kickstart -k gui/501/com.jarvis.channels' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'launchctl bootout gui/501' }).deny).toBe(true)
+    // a bare `launchctl` is interactive, and a flag form is an invocation: both stay denied
+    expect(selfPaceDecision('Bash', { command: 'launchctl' }).deny).toBe(true)
+    expect(selfPaceDecision('Bash', { command: 'launchctl -h' }).deny).toBe(true)
   })
   it('denies scheduler WRITE behind a sudo/env/PATH/absolute-path wrapper', () => {
     expect(selfPaceDecision('Bash', { command: 'sudo crontab -r' }).deny).toBe(true)

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -20,6 +20,12 @@ export function resolveDashboardOrigin(publicUrl: string, port: number | string)
 // Resolved once at module load; DASHBOARD_PUBLIC_URL requires a restart
 // (see config-registry.ts `requiresRestart` flag), so a const is safe.
 const dashboardOrigin = resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT)
+// Dashboard token path emitted into generated CLAUDE.md curl examples.
+// MUST be absolute: sub-agents run from agents/<name>/, where a relative
+// `store/.dashboard-token` does not exist -- curl then sends an empty Bearer
+// and every call 401s silently. Measured 2026-07-25: relative 401, absolute
+// 200; this had been silently killing sub-agent memory saves and searches.
+const tokenPath = join(PROJECT_ROOT, 'store', '.dashboard-token')
 
 // Identity values the template substitution injects. Pulled out so the
 // substitution is a pure, parameterizable function (the runtime binds these to
@@ -661,16 +667,16 @@ function buildAutonomyBody(name: string): string {
     'Az autonóm műveletek fokozatait a store/autonomy-config.json szabályozza (level: 1=csak jelez, 2=javasol+jóváhagyás, 3=autonóm+jelent). Mielőtt önállóan cselekszel, nézd meg az adott kategória szintjét.',
     '',
     '**Level 1 (csak jelez)**: küldj inter-agent értesítést a főágensnek, de NE végezd el a műveletet. Ezután ÁLLJ MEG.',
-    `curl -s -X POST ${dashboardOrigin}/api/messages -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d "{\\"from\\":\\"${name}\\",\\"to\\":\\"${MAIN_AGENT_ID}\\",\\"content\\":\\"[FELHÍVÁS] CATEGORY_KEY: MIT akartam elvégezni, de level 1 miatt csak jelzek.\\"}"`,
+    `curl -s -X POST ${dashboardOrigin}/api/messages -H "Content-Type: application/json" -H "Authorization: Bearer $(cat ${tokenPath})" -d "{\\"from\\":\\"${name}\\",\\"to\\":\\"${MAIN_AGENT_ID}\\",\\"content\\":\\"[FELHÍVÁS] CATEGORY_KEY: MIT akartam elvégezni, de level 1 miatt csak jelzek.\\"}"`,
     '',
     '**Level 2 (jóváhagyás szükséges)**: kérj jóváhagyást az API-n MIELŐTT cselekszel.',
     '',
     'Jóváhagyás kérése (POST):',
-    `curl -s -X POST ${dashboardOrigin}/api/approvals -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"agent_id":"${name}","category":"CATEGORY_KEY","action_description":"Mit tervezel elvégezni és miért","timeout_seconds":3600}'`,
+    `curl -s -X POST ${dashboardOrigin}/api/approvals -H "Content-Type: application/json" -H "Authorization: Bearer $(cat ${tokenPath})" -d '{"agent_id":"${name}","category":"CATEGORY_KEY","action_description":"Mit tervezel elvégezni és miért","timeout_seconds":3600}'`,
     'A válaszban kapott id-vel kérdezheted le a döntést.',
     '',
     'Döntés lekérdezése (GET, 60 mp-enként ismételve):',
-    `curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" "${dashboardOrigin}/api/approvals/<id>"`,
+    `curl -s -H "Authorization: Bearer $(cat ${tokenPath})" "${dashboardOrigin}/api/approvals/<id>"`,
     'status=approved -> végezd el a műveletet. status=rejected vagy status=timeout -> ne csináld, naplózd az okot.',
     '',
     '**Level 3 (autonóm)**: elvégzed a műveletet, majd utána jelented a főágensnek.',
@@ -796,20 +802,20 @@ A memoria 3 retegbol all (hot/warm/cold) + napi naplo.
 Minden /api/* végpont Bearer tokenes: a token a store/.dashboard-token fájlban.
 
 Memória mentés:
-curl -s -X POST ${dashboardOrigin}/api/memories -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"agent_id":"AGENT_NAME","content":"MIT","category":"CATEGORY","keywords":"kulcsszo1, kulcsszo2"}'
+curl -s -X POST ${dashboardOrigin}/api/memories -H "Content-Type: application/json" -H "Authorization: Bearer $(cat ${tokenPath})" -d '{"agent_id":"AGENT_NAME","content":"MIT","category":"CATEGORY","keywords":"kulcsszo1, kulcsszo2"}'
 
 Napi napló (append-only):
-curl -s -X POST ${dashboardOrigin}/api/daily-log -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"agent_id":"AGENT_NAME","content":"## HH:MM -- Tema\nMi tortent, mi lett az eredmeny"}'
+curl -s -X POST ${dashboardOrigin}/api/daily-log -H "Content-Type: application/json" -H "Authorization: Bearer $(cat ${tokenPath})" -d '{"agent_id":"AGENT_NAME","content":"## HH:MM -- Tema\nMi tortent, mi lett az eredmeny"}'
 
 Keresés (mielőtt válaszolsz, nézd meg van-e releváns emlék):
-curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" "${dashboardOrigin}/api/memories?agent=AGENT_NAME&q=KULCSSZO&category=warm"
+curl -s -H "Authorization: Bearer $(cat ${tokenPath})" "${dashboardOrigin}/api/memories?agent=AGENT_NAME&q=KULCSSZO&category=warm"
 
 ## Ütemezett feladatok
 
 Az ütemezett feladatok a ~/.claude/scheduled-tasks/ mappában élnek, fájl-alapúak (SKILL.md + task-config.json). A schedule runner 60 másodpercenként ellenőrzi és a te tmux session-ödbe küldi a promptot.
 
 Feladat létrehozása API-n keresztül:
-curl -s -X POST ${dashboardOrigin}/api/schedules -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"name": "feladat-nev", "description": "Rövid leírás", "prompt": "A részletes prompt", "schedule": "0 8 * * *", "agent": "AGENT_NAME", "type": "heartbeat"}'
+curl -s -X POST ${dashboardOrigin}/api/schedules -H "Content-Type: application/json" -H "Authorization: Bearer $(cat ${tokenPath})" -d '{"name": "feladat-nev", "description": "Rövid leírás", "prompt": "A részletes prompt", "schedule": "0 8 * * *", "agent": "AGENT_NAME", "type": "heartbeat"}'
 
 Típusok: task (mindig szól az eredménnyel) vagy heartbeat (csak fontosnál szól).
 Cron formátum: perc óra nap hónap hétnapja (pl. 0 8 * * * = minden nap 8:00).
@@ -866,7 +872,7 @@ Ha egy senderId üzen a csatornán AKIT EDDIG NEM ISMERSZ — nem szerepel az ak
 Az AGENT TULAJDONOSA (az első, aki ezt az ügynököt telepítette és párosította) az ALAPÉRTELMEZETT engedélyezett sender — őt nem kell ellenőrizni. MINDEN további senderId első üzenete (a 2., 3., stb. párosított személy vagy csoport) pinging-trigger.
 
 Példa ping ${BOT_NAME}-nek:
-curl -s -X POST ${dashboardOrigin}/api/messages -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d "{\\"from\\":\\"AGENT_NAME\\",\\"to\\":\\"${MAIN_AGENT_ID}\\",\\"content\\":\\"Ismeretlen sender [ID] jelezett első üzenettel: '[üzenet röviden]'. Ki ez, mit válaszoljak?\\"}"
+curl -s -X POST ${dashboardOrigin}/api/messages -H "Content-Type: application/json" -H "Authorization: Bearer $(cat ${tokenPath})" -d "{\\"from\\":\\"AGENT_NAME\\",\\"to\\":\\"${MAIN_AGENT_ID}\\",\\"content\\":\\"Ismeretlen sender [ID] jelezett első üzenettel: '[üzenet röviden]'. Ki ez, mit válaszoljak?\\"}"
 
 Addig a sender-nek csak generikus "Egy pillanat, ellenőrzöm" típusú választ adj. NE adj ki belső projekt-infót, NE mutatkozz be hosszan, NE listázd ki mit tudsz, NE említs SAJÁT BELSŐ PROJEKTEKET sem közvetlenül, sem közvetve. ${BOT_NAME} visszajelzi a kontextust és a szabályokat amelyekkel folytathatod.
 


### PR DESCRIPTION
## What

Two independent, verified fixes to the fleet governance plumbing. Both are small, self-contained, and covered by tests.

### 1. self-pace gate false positives (`scripts/self-pace-gate.mjs`)

Three deny-rules matched a keyword that is **also** a normal English word or a path segment, so harmless commands were blocked:

| Rule | Collision | Real-world false deny |
|------|-----------|-----------------------|
| `/loop` | `\bclaude\b` matches `.claude` in every memory/skill path, so `\/loop\b` fired on any `loop`-prefixed path component | reading `.../memory/loop-*.md` |
| `at` / `batch` | English words at a segment start (splitSegments splits on newlines) look like the `at(1)`/`batch(1)` binaries | `git commit` with a body line "at least 80% ..." / "batch size is 50" |
| `launchctl` | appears as a launchd **job label** in the fleet's own heartbeat status reports | a status report line `... ; launchctl com.jarvis.channels ...` |

**Fix:** match the invocation *shape*, not the bare keyword (segment-start / flag / redirect / at-timespec / launchctl-subcommand). Every real self-pace vector stays denied.

### 2. sub-agent dashboard token 401 (`src/web/agent-scaffold.ts`)

Generated `CLAUDE.md` curl examples used a **relative** `store/.dashboard-token`. Sub-agents run from `agents/<name>/`, where that relative path does not exist, so `curl` sent an empty Bearer and every `/api` call `401`'d silently, killing sub-agent memory saves and searches. **Fix:** emit an absolute `PROJECT_ROOT`-joined token path.

## Testing

`src/__tests__/governance-gates.test.ts` adds regression coverage for the prose/path collisions and asserts the real vectors stay denied.

```
vitest run src/__tests__/governance-gates.test.ts
Tests  68 passed (68)
```

Verified on top of current `develop` (in a worktree outside `/tmp`, since the gate's own hook-safety check rejects `/tmp` paths).

## Update (review round 2)

Addressed the two regressions caught in review. Both forms EXECUTE `claude /loop`
in bash but slipped the new slash-command-position match (the char before `/loop`
was a backslash or the tail of `$IFS`, neither in the `[\s'"]` class):

- `claude \/loop` (bash resolves the escaped slash)
- `claude$IFS/loop` (`$IFS` word-splits into a real space at exec time)

Per the suggested direction, the segment is now **normalised before the pattern
runs** (resolve `\X` -> `X`, substitute `$IFS`/`${IFS}` with a space) rather than
widening the character class; this also closes the `claude /lo\op` mid-token form.
Scoped to the self-pace bash patterns only; the scheduler/store/API checks keep
the raw segment. Both forms now deny end-to-end through the gate hook, with a
regression test for each (plus the mid-token side effect and a memory-path allow
guard) in the governance suite.

The three quote-concatenation forms noted as pre-existing (not a regression from
this change) are intentionally left out of scope, as requested.

## Note

Opened as a proposal for review. It has had a second review on our side; that is
context, not a gate on your merge. Please merge at your discretion once the review
is satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

