### PR TITLE
security(vault): MCP titkok vault-védelme a connectors telepítésnél és remote headereknél

### DIFF
--- a/scripts/vault-headers-helper.mjs
+++ b/scripts/vault-headers-helper.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Resolve vault-backed MCP request headers at connection time.
+//
+// Claude Code runs a remote MCP server's `headersHelper` fresh on every
+// connection (and again on 401/403) and uses the JSON object printed to stdout
+// as the request headers. This is the remote-server analogue of
+// vault-env-wrapper.sh: the secret is resolved from the Vault at connection
+// time and NEVER written to .mcp.json -- only the vault secret id is on disk.
+//
+// Args: one per header, in the form  HeaderName=Scheme:::vaultSecretId
+//   - Scheme is optional (may be empty); when present the header value becomes
+//     "Scheme <secret>" (e.g. "Bearer <token>"), otherwise the raw secret.
+//   - The ":::" separator keeps every argument free of spaces so the string is
+//     safe when Claude Code passes headersHelper through a shell.
+// Output: a JSON object {HeaderName: "value", ...} on stdout.
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const projectRoot = join(__dirname, '..')
+
+// Same pattern as vault-resolve.mjs: import the compiled vault module.
+const { getSecret } = await import(join(projectRoot, 'dist', 'web', 'vault.js'))
+
+const headers = {}
+for (const arg of process.argv.slice(2)) {
+  const eq = arg.indexOf('=')
+  if (eq < 0) continue
+  const headerName = arg.slice(0, eq)
+  const rest = arg.slice(eq + 1)
+  const sep = rest.indexOf(':::')
+  const scheme = sep >= 0 ? rest.slice(0, sep) : ''
+  const vaultId = sep >= 0 ? rest.slice(sep + 3) : rest
+  if (!headerName || !vaultId) continue
+  const secret = getSecret(vaultId)
+  if (secret === null) {
+    process.stderr.write(`vault-headers-helper: vault secret "${vaultId}" not found\n`)
+    continue
+  }
+  headers[headerName] = scheme ? `${scheme} ${secret}` : secret
+}
+
+process.stdout.write(JSON.stringify(headers))

--- a/scripts/vault-headers-helper.sh
+++ b/scripts/vault-headers-helper.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# headersHelper shim for remote MCP servers: find node (GUI/nvm PATH is not
+# guaranteed when Claude Code launches the helper), then run the resolver.
+# Claude Code passes the "HeaderName=Scheme:::vaultSecretId" args through here.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+NODE=""
+for candidate in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+  if [ -x "$candidate" ]; then NODE="$candidate"; break; fi
+done
+if [ -z "$NODE" ]; then
+  NODE="$(command -v node 2>/dev/null || true)"
+fi
+# nvm installs live outside PATH when launched from a GUI context.
+if [ -z "$NODE" ] && [ -d "$HOME/.nvm/versions/node" ]; then
+  for candidate in $(ls -1 "$HOME/.nvm/versions/node" 2>/dev/null | sort -V -r); do
+    if [ -x "$HOME/.nvm/versions/node/$candidate/bin/node" ]; then
+      NODE="$HOME/.nvm/versions/node/$candidate/bin/node"
+      break
+    fi
+  done
+fi
+if [ -z "$NODE" ]; then
+  echo "vault-headers-helper: node not found" >&2
+  exit 1
+fi
+
+exec "$NODE" "$PROJECT_ROOT/scripts/vault-headers-helper.mjs" "$@"

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -716,12 +716,19 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
     const body = await readBody(req)
     const data = JSON.parse(body.toString()) as {
       vaultSecretId: string
-      envVar: string
+      envVar?: string
       serverName?: string
       targets?: Array<{ mcpFilePath: string, serverName: string }>
+      // Remote-server header binding: the secret is injected into the request
+      // header (e.g. Authorization) via headersHelper instead of an env var.
+      headerName?: string
+      headerScheme?: string
     }
-    if (!data.vaultSecretId || !data.envVar) {
-      json(res, { error: 'vaultSecretId and envVar required' }, 400)
+    // A binding is either env-var based (local/stdio servers) or header based
+    // (remote http/sse servers). Header bindings key on the header name.
+    const bindingKey = data.headerName?.trim() || data.envVar?.trim()
+    if (!data.vaultSecretId || !bindingKey) {
+      json(res, { error: 'vaultSecretId and (envVar or headerName) required' }, 400)
       return true
     }
 
@@ -760,7 +767,12 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
       json(res, { error: 'No targets found for this server' }, 400)
       return true
     }
-    addBinding({ vaultSecretId: data.vaultSecretId, envVar: data.envVar, targets })
+    const binding: any = { vaultSecretId: data.vaultSecretId, envVar: bindingKey, targets }
+    if (data.headerName?.trim()) {
+      binding.headerName = data.headerName.trim()
+      binding.headerScheme = data.headerScheme?.trim() ?? 'Bearer'
+    }
+    addBinding(binding)
     const syncResult = syncSecret(data.vaultSecretId)
     json(res, { ok: true, synced: syncResult.updated, errors: syncResult.errors })
     return true

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -96,6 +96,36 @@ function upsertLocalCatalogEntry(entry: any): void {
   atomicWriteFileSync(localCatalogPath(), JSON.stringify(local, null, 2) + '\n')
 }
 
+// Move install-time env secrets out of plaintext: store each in the Vault and
+// bind it so the target config (~/.claude.json or .mcp.json) holds only a
+// `vault:` ref plus the resolver wrapper -- never the raw value. This is what
+// the install modal already promises ("titkosítva a Vault-ba kerülnek").
+//
+// Fail-closed: on any vault/bind/sync error we throw. The server was already
+// registered by `claude mcp add` WITHOUT the secret, so it stands non-functional
+// but leaks nothing; the caller surfaces the error and the user re-adds the
+// secret from the Vault page.
+export function vaultAndBindEnvSecrets(
+  serverName: string,
+  mcpFilePath: string,
+  envSecrets: Record<string, string>,
+): void {
+  for (const [key, value] of Object.entries(envSecrets)) {
+    if (!value) continue
+    const vaultId = `${slugifyMcp(serverName)}-${key.toLowerCase()}`
+    setSecret(vaultId, `${key} (${serverName})`, value)
+    addBinding({ vaultSecretId: vaultId, envVar: key, targets: [{ mcpFilePath, serverName }] })
+    const result = syncSecret(vaultId)
+    if (result.errors.length) {
+      throw new Error(
+        `A(z) "${key}" titkot nem sikerult a configba kotni: ${result.errors.join('; ')}. ` +
+        `A szerver telepitve van, de a kulcs NELKUL (nem mukodik, de nem is szivarog plaintextben). ` +
+        `Add meg ujra a kulcsot a Vault oldalon.`,
+      )
+    }
+  }
+}
+
 export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
 
@@ -400,14 +430,22 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
         catalogEntry.url = data.url
         catalogEntry.transport = transport
       } else if (data.type === 'stdio' && data.command) {
-        const envFlags = data.env ? Object.entries(data.env).map(([k, v]) => `-e ${shellEscape(k)}=${shellEscape(v)}`).join(' ') : ''
+        // User-typed env values are secrets: register the server WITHOUT -e, then
+        // vault + bind below so the config holds only vault refs, never plaintext.
+        const userSecrets = Object.fromEntries(
+          Object.entries(data.env || {}).filter(([, v]) => v !== ''),
+        ) as Record<string, string>
         const argsStr = data.args ? data.args.split(/\s+/).filter(Boolean).map(a => shellEscape(a)).join(' ') : ''
-        execSync(`claude mcp add ${scopeFlag} ${shellEscape(sanitizedName)} ${envFlags} -- ${shellEscape(data.command)} ${argsStr} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
+        execSync(`claude mcp add ${scopeFlag} ${shellEscape(sanitizedName)} -- ${shellEscape(data.command)} ${argsStr} 2>&1`, { timeout: 15000, encoding: 'utf-8' })
         catalogEntry.type = 'local'
         catalogEntry.command = data.command
         catalogEntry.args = data.args ? data.args.split(/\s+/).filter(Boolean) : []
         // Store only env var names with blank values -- never the secrets.
         catalogEntry.env = Object.fromEntries(Object.keys(data.env || {}).map(k => [k, '']))
+        if (Object.keys(userSecrets).length) {
+          const mcpFile = data.scope === 'project' ? join(PROJECT_ROOT, '.mcp.json') : join(homedir(), '.claude.json')
+          vaultAndBindEnvSecrets(sanitizedName, mcpFile, userSecrets)
+        }
       } else {
         json(res, { error: 'URL (http/sse) or command (stdio) required' }, 400)
         return true
@@ -612,19 +650,33 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
       const cliName = item.id
 
       if (item.type === 'local') {
-        const allEnv = { ...item.env, ...envData }
-        const envFlags = Object.entries(allEnv)
-          .filter(([, v]) => v !== '')
+        // Values typed into the "API kulcsok megadása" modal are secrets: vault
+        // them so they never hit ~/.claude.json in plaintext (the modal already
+        // promises this). Non-empty catalog defaults are non-secret config and
+        // stay as -e flags.
+        const userSecrets = Object.fromEntries(
+          Object.entries(envData).filter(([, v]) => v !== ''),
+        ) as Record<string, string>
+        const defaultEnv = Object.fromEntries(
+          Object.entries(item.env || {}).filter(([k, v]) => v !== '' && !(k in userSecrets)),
+        ) as Record<string, string>
+        const envFlags = Object.entries(defaultEnv)
           .map(([k, v]) => `-e ${shellEscape(k)}=${shellEscape(v as string)}`)
           .join(' ')
 
         const argsStr = (item.args || []).map((a: string) => shellEscape(a)).join(' ')
         const cmd = `claude mcp add --scope user ${shellEscape(cliName)} ${envFlags} -- ${shellEscape(item.command)} ${argsStr} 2>&1`
         execSync(cmd, { timeout: 30000, encoding: 'utf-8' })
+        if (Object.keys(userSecrets).length) {
+          vaultAndBindEnvSecrets(cliName, join(homedir(), '.claude.json'), userSecrets)
+        }
       } else if (item.type === 'remote') {
         const url = item.url
         if (!url) { json(res, { error: 'Remote item has no URL' }, 400); return true }
-        execSync(`claude mcp add --transport sse --scope user ${shellEscape(cliName)} ${shellEscape(url)} 2>&1`, { timeout: 30000, encoding: 'utf-8' })
+        // Respect the catalog item's transport (http/sse) instead of forcing sse,
+        // so one-click remote installs can use streamable-http (e.g. n8n).
+        const transport = item.transport === 'http' ? 'http' : 'sse'
+        execSync(`claude mcp add --transport ${transport} --scope user ${shellEscape(cliName)} ${shellEscape(url)} 2>&1`, { timeout: 30000, encoding: 'utf-8' })
       }
 
       let message = 'Telepítve'

--- a/src/web/vault-bindings.ts
+++ b/src/web/vault-bindings.ts
@@ -6,10 +6,12 @@ import { atomicWriteFileSync } from './atomic-write.js'
 import { readFileOr, AGENTS_BASE_DIR, listAgentNames } from './agent-config.js'
 import { getSecret, listSecrets } from './vault.js'
 import { getExternalProjectPaths } from './dashboard-settings.js'
+import { shellEscape } from './sanitize.js'
 import { logger } from '../logger.js'
 
 const BINDINGS_PATH = join(PROJECT_ROOT, 'store', 'vault-bindings.json')
 const VAULT_WRAPPER_PATH = join(PROJECT_ROOT, 'scripts', 'vault-env-wrapper.sh')
+const VAULT_HEADERS_HELPER_PATH = join(PROJECT_ROOT, 'scripts', 'vault-headers-helper.sh')
 
 export interface VaultBindingTarget {
   mcpFilePath: string
@@ -20,6 +22,13 @@ export interface VaultBinding {
   vaultSecretId: string
   envVar: string
   targets: VaultBindingTarget[]
+  // When set, this is a REMOTE-server header binding rather than an env binding.
+  // The secret is injected into request headers at connection time via the
+  // headersHelper script -- the plaintext token never lands in .mcp.json.
+  headerName?: string
+  // Auth scheme prefix for the header value, e.g. "Bearer" -> "Bearer <secret>".
+  // Empty/undefined means the raw secret is used as the header value.
+  headerScheme?: string
 }
 
 interface BindingsStore {
@@ -95,19 +104,30 @@ export function removeBinding(vaultSecretId: string, envVar: string): boolean {
 export function removeBindingsForSecret(vaultSecretId: string): void {
   const store = readBindings()
   const toRemove = store.bindings.filter(b => b.vaultSecretId === vaultSecretId)
+  const remaining = store.bindings.filter(b => b.vaultSecretId !== vaultSecretId)
   for (const binding of toRemove) {
     for (const target of binding.targets) {
       try {
         const content = JSON.parse(readFileOr(target.mcpFilePath, '{}'))
         const serverCfg = content.mcpServers?.[target.serverName]
-        if (!serverCfg?.env) continue
-        delete serverCfg.env[binding.envVar]
-        if (!serverHasVaultRefs(serverCfg.env)) unwrapCommand(serverCfg)
+        if (!serverCfg) continue
+        if (binding.headerName) {
+          // Rebuild the server's headersHelper from the header bindings that
+          // survive this secret's removal.
+          applyHeadersHelper(
+            serverCfg,
+            headerBindingsForServer(target.mcpFilePath, target.serverName, remaining),
+          )
+        } else {
+          if (!serverCfg.env) continue
+          delete serverCfg.env[binding.envVar]
+          if (!serverHasVaultRefs(serverCfg.env)) unwrapCommand(serverCfg)
+        }
         atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
       } catch { /* skip */ }
     }
   }
-  store.bindings = store.bindings.filter(b => b.vaultSecretId !== vaultSecretId)
+  store.bindings = remaining
   writeBindings(store)
 }
 
@@ -217,6 +237,37 @@ function serverHasVaultRefs(env: Record<string, string> | undefined): boolean {
   return Object.values(env).some(v => typeof v === 'string' && v.startsWith('vault:'))
 }
 
+// All header bindings (across every secret) that target one server in one file.
+// The headersHelper for a server must carry EVERY header the vault manages for
+// it, so syncing one secret must not drop another secret's header.
+function headerBindingsForServer(
+  mcpFilePath: string,
+  serverName: string,
+  all: VaultBinding[] = getBindings(),
+): VaultBinding[] {
+  return all.filter(
+    b => b.headerName && b.targets.some(t => t.mcpFilePath === mcpFilePath && t.serverName === serverName),
+  )
+}
+
+// Rebuild (or clear) a remote server's headersHelper from the given header
+// bindings, and strip any managed plaintext headers so the token only ever
+// exists as a vault id on disk. Claude Code runs the helper per connection.
+function applyHeadersHelper(serverCfg: any, headerBindings: VaultBinding[]): void {
+  for (const b of headerBindings) {
+    if (serverCfg.headers && b.headerName) delete serverCfg.headers[b.headerName]
+  }
+  if (headerBindings.length === 0) {
+    delete serverCfg.headersHelper
+  } else {
+    const args = headerBindings.map(
+      b => `${b.headerName}=${b.headerScheme ?? 'Bearer'}:::${b.vaultSecretId}`,
+    )
+    serverCfg.headersHelper = [VAULT_HEADERS_HELPER_PATH, ...args].map(shellEscape).join(' ')
+  }
+  if (serverCfg.headers && Object.keys(serverCfg.headers).length === 0) delete serverCfg.headers
+}
+
 export function syncSecret(vaultSecretId: string): SyncResult {
   const bindings = getBindings().filter(b => b.vaultSecretId === vaultSecretId)
   if (bindings.length === 0) return { updated: 0, errors: [] }
@@ -236,9 +287,18 @@ export function syncSecret(vaultSecretId: string): SyncResult {
           errors.push(`Server "${target.serverName}" not found in ${target.mcpFilePath}`)
           continue
         }
-        if (!serverCfg.env) serverCfg.env = {}
-        serverCfg.env[binding.envVar] = `vault:${vaultSecretId}`
-        if (serverCfg.command && !serverCfg.url) wrapCommand(serverCfg)
+        if (binding.headerName) {
+          // Remote header binding: wire the headersHelper (rebuilt from ALL
+          // header bindings for this server) and strip any plaintext header.
+          applyHeadersHelper(
+            serverCfg,
+            headerBindingsForServer(target.mcpFilePath, target.serverName),
+          )
+        } else {
+          if (!serverCfg.env) serverCfg.env = {}
+          serverCfg.env[binding.envVar] = `vault:${vaultSecretId}`
+          if (serverCfg.command && !serverCfg.url) wrapCommand(serverCfg)
+        }
         atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
         updated++
       } catch (err: any) {
@@ -252,17 +312,31 @@ export function syncSecret(vaultSecretId: string): SyncResult {
 }
 
 export function unsyncBinding(vaultSecretId: string, envVar: string): void {
-  const bindings = getBindings().filter(
+  const all = getBindings()
+  const bindings = all.filter(
     b => b.vaultSecretId === vaultSecretId && b.envVar === envVar,
+  )
+  // Header bindings are rebuilt from the set that survives this removal (the
+  // binding is still in the store here; removeBinding runs afterwards).
+  const remaining = all.filter(
+    b => !(b.vaultSecretId === vaultSecretId && b.envVar === envVar),
   )
   for (const binding of bindings) {
     for (const target of binding.targets) {
       try {
         const content = JSON.parse(readFileOr(target.mcpFilePath, '{}'))
         const serverCfg = content.mcpServers?.[target.serverName]
-        if (!serverCfg?.env) continue
-        delete serverCfg.env[envVar]
-        if (!serverHasVaultRefs(serverCfg.env)) unwrapCommand(serverCfg)
+        if (!serverCfg) continue
+        if (binding.headerName) {
+          applyHeadersHelper(
+            serverCfg,
+            headerBindingsForServer(target.mcpFilePath, target.serverName, remaining),
+          )
+        } else {
+          if (!serverCfg.env) continue
+          delete serverCfg.env[envVar]
+          if (!serverHasVaultRefs(serverCfg.env)) unwrapCommand(serverCfg)
+        }
         atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
       } catch { /* skip */ }
     }


### PR DESCRIPTION
Két biztonsági javítás a marveen vault-integrációjához (Balkányi Zoltán telepítésén élesben futnak és teszteltek):

**1. \`feat(vault): support remote MCP header secrets via headersHelper\`**
A remote (URL-transportos) MCP szerverek header-titkai (pl. \`Authorization: Bearer <token>\`) eddig nem tudtak vault-hivatkozásként működni. Új \`scripts/vault-headers-helper.mjs\` + \`.sh\`: a headert indításkor oldja fel a vaultból, így a token nem kerül plaintextben a configba.

**2. \`fix(connectors): vault install-time secrets (Flag A) + honor remote transport (Flag C)\`**
- Flag A: a dashboard Connectors telepítő modálja a megadott API-kulcsokat eddig PLAINTEXTBEN írta a \`.claude.json\`-ba. Mostantól a vaultba kerülnek, a config csak \`vault:<id>\` hivatkozást kap.
- Flag C: a katalógusban remote transportúként megjelölt MCP-k telepítéskor tényleg remote-ként kerülnek bekötésre (eddig local commandra esett vissza).

Füst-teszt: telepítés után \`grep\` a nyers titokra a configokban = 0 találat, a szerverek vault-feloldással indulnak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)