### PR TITLE
fix(auth): explicit credential-kind allowlists on access-granting endpoints

### DIFF
--- a/src/__tests__/auth-routes.test.ts
+++ b/src/__tests__/auth-routes.test.ts
@@ -72,6 +72,10 @@ function cookieToken(res: MockRes): string {
 }
 
 const TOKEN_AUTH: RouteContext['auth'] = { kind: 'token' }
+// Simulates a FUTURE credential kind (e.g. per-device keys) that the AuthResult
+// union does not carry yet: the allowlists must default-deny it everywhere.
+const DEVICE_AUTH = { kind: 'device' } as unknown as RouteContext['auth']
+const FEDERATION_AUTH: RouteContext['auth'] = { kind: 'federation', peer: 'test-peer' }
 const GOOD_PW = 'super-secret-pw'
 
 async function seedUser(username: string, password = GOOD_PW): Promise<void> {
@@ -279,5 +283,53 @@ describe('users CRUD', () => {
     expect(del.res.statusCode).toBe(200)
     expect(getDashboardUser('alice')).toBeUndefined()
     expect(resolveSession(token)).toBeNull()
+  })
+
+  it('still allows a SESSION principal to manage users (existing behavior)', async () => {
+    await seedUser('alice')
+    const SESSION_AUTH: RouteContext['auth'] = { kind: 'session', user: 'alice' }
+    const created = await call('POST', '/api/auth/users', { auth: SESSION_AUTH, body: { username: 'bob', password: GOOD_PW } })
+    expect(created.res.statusCode).toBe(201)
+    const list = await call('GET', '/api/auth/users', { auth: SESSION_AUTH })
+    expect((list.json().users as unknown[]).length).toBe(2)
+    const del = await call('DELETE', '/api/auth/users/bob', { auth: SESSION_AUTH })
+    expect(del.res.statusCode).toBe(200)
+  })
+})
+
+describe('credential-kind allowlists (default-deny for future kinds)', () => {
+  // The access-granting endpoints must reject every kind that is not
+  // explicitly listed. 'device' stands in for any future AuthResult kind;
+  // 'federation' is path-scoped in resolveAuth and can never reach these
+  // routes, but the handler must not rely on that (defence in depth).
+  const deniedKinds: Array<{ name: string; auth: RouteContext['auth'] }> = [
+    { name: 'future device kind', auth: DEVICE_AUTH },
+    { name: 'federation kind', auth: FEDERATION_AUTH },
+    { name: 'missing principal', auth: undefined },
+  ]
+
+  for (const { name, auth } of deniedKinds) {
+    it(`denies ${name} on users GET/POST/DELETE and break-glass password reset`, async () => {
+      await seedUser('alice')
+      const list = await call('GET', '/api/auth/users', { auth })
+      expect(list.res.statusCode).toBe(403)
+      const create = await call('POST', '/api/auth/users', { auth, body: { username: 'mallory', password: GOOD_PW } })
+      expect(create.res.statusCode).toBe(403)
+      expect(getDashboardUser('mallory')).toBeUndefined()
+      const del = await call('DELETE', '/api/auth/users/alice', { auth })
+      expect(del.res.statusCode).toBe(403)
+      expect(getDashboardUser('alice')).toBeDefined()
+      const reset = await call('POST', '/api/auth/password', { auth, body: { username: 'alice', new_password: 'stolen-reset-pw' } })
+      expect(reset.res.statusCode).toBe(403)
+      // the old password must still work after the denied reset attempt
+      const login = await call('POST', '/api/auth/login', { body: { username: 'alice', password: GOOD_PW } })
+      expect(login.res.statusCode).toBe(200)
+    })
+  }
+
+  it('keeps the token break-glass reset working (allowlist did not over-tighten)', async () => {
+    await seedUser('alice')
+    const reset = await call('POST', '/api/auth/password', { auth: TOKEN_AUTH, body: { username: 'alice', new_password: 'legit-reset-pw' } })
+    expect(reset.res.statusCode).toBe(200)
   })
 })

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -9,6 +9,14 @@
 // and resetting a password are reachable with a valid bearer, so there is never
 // an unauthenticated first-run setup page (which would be a claim-the-admin race
 // on loopback).
+//
+// Principal discipline: every handler that grants or removes access checks the
+// caller's auth kind against an EXPLICIT allowlist. Only 'token' and 'session'
+// can reach these paths today (federation tokens are endpoint-scoped inside
+// resolveAuth and never resolve here), but the allowlists exist so any future
+// AuthResult kind -- e.g. per-device keys -- is denied by default. What a new
+// credential type may do here must be a review decision, not the accident of
+// an else-branch.
 
 import type http from 'node:http'
 import { readBody, json } from '../http-helpers.js'
@@ -76,6 +84,19 @@ async function parseJsonBody(req: http.IncomingMessage): Promise<Record<string, 
 function str(v: unknown): string {
   return typeof v === 'string' ? v : ''
 }
+
+// Explicit principal allowlist. Compares on the kind string so tests can
+// exercise kinds the AuthResult union does not carry yet; anything not listed
+// (including undefined auth, which the gate should have 401'd already) fails.
+function kindAllowed(auth: RouteContext['auth'], kinds: readonly string[]): boolean {
+  return auth !== undefined && kinds.includes(auth.kind)
+}
+
+const FORBIDDEN_KIND = { error: 'Forbidden for this credential type' }
+
+// Who may manage dashboard users (list/create/delete). 'session' is included
+// deliberately: a logged-in operator managing users is the existing behavior.
+const USER_ADMIN_KINDS = ['token', 'session'] as const
 
 // { authenticated, method, user, login_available, setup_required }.
 // authenticated keeps its exact old meaning for token callers (existing probes
@@ -209,14 +230,19 @@ export async function tryHandleAuth(ctx: RouteContext): Promise<boolean> {
         json(res, INVALID_CREDENTIALS, 401)
         return true
       }
-    } else {
+    } else if (auth?.kind === 'token') {
       // Bearer break-glass: may omit current_password but must name the target.
+      // EXPLICITLY token-only -- a reset without the current password is the
+      // strongest action here and must never leak to weaker credential kinds.
       const username = str(body.username)
       user = username ? getDashboardUser(username) : undefined
       if (!user) {
         json(res, { error: 'User not found' }, 404)
         return true
       }
+    } else {
+      json(res, FORBIDDEN_KIND, 403)
+      return true
     }
 
     try {
@@ -235,11 +261,19 @@ export async function tryHandleAuth(ctx: RouteContext): Promise<boolean> {
   }
 
   if (path === '/api/auth/users' && method === 'GET') {
+    if (!kindAllowed(auth, USER_ADMIN_KINDS)) {
+      json(res, FORBIDDEN_KIND, 403)
+      return true
+    }
     json(res, { users: listDashboardUsers() })
     return true
   }
 
   if (path === '/api/auth/users' && method === 'POST') {
+    if (!kindAllowed(auth, USER_ADMIN_KINDS)) {
+      json(res, FORBIDDEN_KIND, 403)
+      return true
+    }
     let body: Record<string, unknown>
     try {
       body = await parseJsonBody(req)
@@ -272,6 +306,10 @@ export async function tryHandleAuth(ctx: RouteContext): Promise<boolean> {
 
   const delMatch = /^\/api\/auth\/users\/([^/]+)$/.exec(path)
   if (delMatch && method === 'DELETE') {
+    if (!kindAllowed(auth, USER_ADMIN_KINDS)) {
+      json(res, FORBIDDEN_KIND, 403)
+      return true
+    }
     const username = decodeURIComponent(delMatch[1]!)
     const user = getDashboardUser(username)
     if (!user) {


### PR DESCRIPTION
## What

Prerequisite #0 of the Security section work (AUTHPLAN1, SECURITY-BRIEF).

The break-glass password reset was the `else` branch of the session check, and the user CRUD endpoints (`GET/POST /api/auth/users`, `DELETE /api/auth/users/:name`) had **no credential-kind check at all**. This is safe today only because `resolveAuth` can deliver just `token` or `session` to these paths -- but any future `AuthResult` kind (the upcoming per-device keys) would have silently inherited user-creation and password-reset powers.

## Changes

- Break-glass reset (no `current_password`) is now explicitly `kind === 'token'`.
- User list/create/delete check an explicit allowlist (`token`, `session` -- both already had this power, so this is behavior-preserving).
- Every other kind, including a missing principal, gets 403 with no side effects.

## Tests

- New `credential-kind allowlists` suite simulates a future `device` kind, a `federation` principal, and a missing principal: 403 asserted on users GET/POST/DELETE + break-glass reset, with no state change (user not created/deleted, old password still valid).
- Existing token break-glass and session flows re-asserted.
- Full suite: 202 files, 2781 tests green; tsc clean.

## Why merge-safe for foreign installs

No schema change, no new settings, no default flips. Only requests that were impossible until a new credential kind exists change outcome (plus the defence-in-depth 403 on principals the gate should already have rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)