### PR TITLE
feat(settings): Security tab hosting the auth card + AUTHCOPY1 copy fix

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -12845,7 +12845,7 @@ window.addEventListener('beforeunload', (e) => {
 // entry never requires a frontend change just to render a sane heading.
 function settingsModuleLabel(mod) {
   const key = `settings.module.${mod}`
-  const known = { kanban: true, system: true, heartbeat: true, audit: true, ideabox: true, channels: true }
+  const known = { kanban: true, system: true, heartbeat: true, audit: true, ideabox: true, channels: true, security: true, autonomy: true }
   return known[mod] ? t(key) : (mod.charAt(0).toUpperCase() + mod.slice(1))
 }
 
@@ -13116,6 +13116,8 @@ function wireAuthBanner() {
     banner.hidden = true
   })
   if (go) go.addEventListener('click', () => {
+    // Land on the Security tab, where the auth card lives now.
+    try { localStorage.setItem(SETTINGS_ACTIVE_TAB_KEY, 'security') } catch { /* storage blocked */ }
     if (typeof switchPage === 'function') switchPage('settings')
     const link = document.querySelector('.sb-link[data-page="settings"]')
     if (link) { document.querySelectorAll('.sb-link').forEach((l) => l.classList.remove('active')); link.classList.add('active') }
@@ -13132,6 +13134,15 @@ async function loadSettings() {
   const tabNav = document.getElementById('settingsTabNav')
   const tabPanels = document.getElementById('settingsTabPanels')
   if (!tabNav || !tabPanels) return
+
+  // Park the auth card back outside the panels before wiping them: a previous
+  // loadSettings run moved it INTO the Security panel, and clearing
+  // tabPanels.innerHTML with the card still inside would destroy the node.
+  const parkedAuthCard = document.getElementById('authCard')
+  if (parkedAuthCard) {
+    parkedAuthCard.hidden = true
+    tabNav.parentElement.insertBefore(parkedAuthCard, tabNav)
+  }
 
   tabNav.innerHTML = `<span style="color:var(--text-muted);font-size:13px;padding:12px 0;display:inline-block">${t('settings.loading')}</span>`
   tabPanels.innerHTML = ''
@@ -13156,10 +13167,19 @@ async function loadSettings() {
 
     if (byModule.size === 0) {
       tabPanels.innerHTML = `<p style="padding:24px;color:var(--text-muted);font-size:13px">${t('settings.empty')}</p>`
+      // No tabs to host the Security panel: fall back to showing the auth card
+      // in its static spot above the (empty) tab area.
+      const orphanAuthCard = document.getElementById('authCard')
+      if (orphanAuthCard) orphanAuthCard.hidden = false
       return
     }
 
-    const allModules = [...byModule.keys(), 'autonomy']
+    // Registry keys declared with module:'security' render inside the synthetic
+    // Security tab (below the auth card) instead of getting their own tab.
+    const securityDefs = byModule.get('security') ?? []
+    byModule.delete('security')
+
+    const allModules = [...byModule.keys(), 'security', 'autonomy']
     const savedTab = localStorage.getItem(SETTINGS_ACTIVE_TAB_KEY) || allModules[0]
     const activeTab = allModules.includes(savedTab) ? savedTab : allModules[0]
 
@@ -13183,6 +13203,40 @@ async function loadSettings() {
         group.appendChild(buildSettingRow(def))
       }
       panel.appendChild(group)
+      tabPanels.appendChild(panel)
+    }
+
+    // Security tab (synthetic, like autonomy: exists even with zero registry
+    // entries). Hosts the auth card -- browser login, password change, device
+    // keys -- plus any module:'security' registry keys.
+    {
+      const mod = 'security'
+      const btn = document.createElement('button')
+      btn.className = 'tab-btn' + (mod === activeTab ? ' active' : '')
+      btn.dataset.tab = mod
+      btn.textContent = settingsModuleLabel(mod)
+      btn.addEventListener('click', () => activateSettingsTab(mod))
+      tabNav.appendChild(btn)
+
+      const panel = document.createElement('div')
+      panel.className = 'tab-panel'
+      panel.id = `settings-panel-${mod}`
+      panel.hidden = mod !== activeTab
+
+      const authCard = document.getElementById('authCard')
+      if (authCard) {
+        panel.appendChild(authCard)
+        authCard.hidden = false
+      }
+
+      if (securityDefs.length) {
+        const group = document.createElement('div')
+        group.className = 'settings-group'
+        for (const def of securityDefs) {
+          group.appendChild(buildSettingRow(def))
+        }
+        panel.appendChild(group)
+      }
       tabPanels.appendChild(panel)
     }
 

--- a/web/index.html
+++ b/web/index.html
@@ -1152,8 +1152,10 @@
 
       <!-- Dashboard browser login (optional). Rendered by renderAuthCard():
            create the first login when none exists, else change password + list
-           active sessions and log out. -->
-      <div class="card auth-card" id="authCard" style="margin-bottom:16px">
+           active sessions and log out. Starts hidden; loadSettings() moves it
+           into the Security tab panel and unhides it there (it stays here,
+           unhidden in place, only in the empty-registry fallback). -->
+      <div class="card auth-card" id="authCard" style="margin-bottom:16px" hidden>
         <h3 data-i18n="auth.card.title">Dashboard login</h3>
         <div id="authCardBody"></div>
       </div>

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -730,6 +730,7 @@ window._i18n.en = {
   'settings.module.audit':       'Audit',
   'settings.module.channels':    'Channels',
   'settings.module.autonomy':    'Autonomy',
+  'settings.module.security':    'Security',
   'settings.col.key':            'Key',
   'settings.col.value':          'Value',
   'settings.col.description':    'Description',
@@ -1699,7 +1700,7 @@ window._i18n.en = {
   'auth.card.logout_all':         'Log out everywhere',
   'auth.card.logout':             'Log out',
   'auth.card.active_sessions':    'Active sessions',
-  'auth.card.token_mode':         'You are using token access. A browser login is configured.',
+  'auth.card.token_mode':         'This session signed in with the access token (the Bridge and fleet tools open with their own key, so they never ask for a password). Your password login is still active and works: use it any time on the browser sign-in page.',
 
   'auth.devices.title':            'Device keys',
   'auth.devices.desc':             'A per-device key for the Bridge or a phone: revocable on its own, the shared token stays unchanged. The key is shown only at creation.',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1026,6 +1026,7 @@ window._i18n.hu = {
   'settings.module.audit':       'Audit',
   'settings.module.channels':    'Csatornák',
   'settings.module.autonomy':    'Autonómia',
+  'settings.module.security':    'Biztonság',
   'settings.col.key':            'Kulcs',
   'settings.col.value':          'Érték',
   'settings.col.description':    'Leírás',
@@ -1695,7 +1696,7 @@ window._i18n.hu = {
   'auth.card.logout_all':         'Kilépés mindenhonnan',
   'auth.card.logout':             'Kilépés',
   'auth.card.active_sessions':    'Aktív munkamenetek',
-  'auth.card.token_mode':         'Token-alapú elérést használsz. Egy böngészős belépés be van állítva.',
+  'auth.card.token_mode':         'Ez a munkamenet a hozzáférési tokennel lépett be (a Bridge és a flotta-eszközök saját kulccsal nyitnak, ezért sosem kérnek jelszót). A jelszavas belépésed ettől függetlenül él és működik: böngészőből a bejelentkező oldalon bármikor használhatod.',
 
   'auth.devices.title':            'Eszközkulcsok',
   'auth.devices.desc':             'Eszközönkénti kulcs a Bridge-hez vagy telefonhoz: külön visszavonható, a közös token nem változik. A kulcs csak a létrehozáskor látható.',


### PR DESCRIPTION
## What

AUTHPLAN1 #3 (Security section). Frontend-only: the Settings page gets a **Security tab** and the auth card moves into it; the token-mode copy is reworded per AUTHCOPY1.

## Changes

- Synthetic **Security tab** (like Autonomy: exists even with zero registry entries) hosting the auth card (browser login, password change, sessions, device keys). Registry keys declared `module:'security'` render below the card instead of getting their own tab -- registry-driven, no frontend change needed for future keys.
- The auth card is **parked back outside the panels before every rebuild**: `loadSettings()` clears `tabPanels.innerHTML`, which would destroy the moved card node. A leave-and-return browser test locks this.
- The auth setup banner's *Set up login* button lands directly on the Security tab.
- `settingsModuleLabel` known-map: `security` added, and `autonomy` fixed (it was missing, so the tab showed the capitalised fallback 'Autonomy' even in the Hungarian UI -- pre-existing one-word i18n bug).
- **AUTHCOPY1 copy fix**: the token-mode text no longer implies the password is broken. New copy states the password login is active and where it works (browser sign-in page), and why token sessions (Bridge, fleet tools) never ask for a password. hu+en.

## Why merge-safe for foreign installs

No backend change, no schema, no new settings, no default flips. Empty-registry installs fall back to showing the auth card in its old static spot.

## Tests

- `node --check` on app.js + both lang files.
- Playwright e2e on an isolated worktree instance: Security tab present with correct label; auth card visible only inside the tab; **card survives settings-page rebuilds** (leave + return); active-tab persisted across reload; AUTHCOPY1 copy asserted in token mode with a user present; device-keys section renders inside the tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)