### PR TITLE
feat(auth): recovery paths -- security:reset CLI, break-glass audit + channel alert

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Minden lap két szemszögből mutatja be a funkciót:
 | [Skool CLI](skool-cli.md) | Közösségi platform kezelése parancssorból (API nélkül) |
 | [connectors.hu](connectors-hu.md) | Üzleti API-átjáró (NAV, Billingo, Wise, fal.ai) MCP-n |
 | [Vault & titkosítás](vault.md) | Titkosított titok-tár (AES-256-GCM) OS-kulcstárral |
+| [Belépés-visszaút & vészreset](dashboard-auth-recovery.md) | Elfelejtett jelszó, kizárás, `security:reset` pánikgomb -- HTTP-független break-glass CLI |
 | [Dream-engine](dream-engine.md) | Éjszakai tudás-konszolidáció + reggeli prioritás-javaslatok |
 | [Proaktív hírszerző (intel registry)](intel-registry.md) | Óránkénti gyűjtő + napi brief közös SQLite tény-registry-vel, dedup + tény-életciklus |
 | [Háttér-feladatok](background-tasks.md) | Leválasztott, hosszú feladatok futtatása + értesítés |

--- a/docs/dashboard-auth-recovery.md
+++ b/docs/dashboard-auth-recovery.md
@@ -1,0 +1,56 @@
+# Dashboard belépés: visszaút és vészhelyzeti reset
+
+Mi történik, ha elfelejtetted a jelszót, kizártad magad, vagy egy kiadott
+hitelesítő adat (eszközkulcs, böngésző-session) rossz kézbe került? Ez a doksi
+a visszautakat írja le. Alapelv: **aki a gazdagépen parancsot tud futtatni, az
+a gyökér-hitelesítő** -- minden visszaút erre épül, és egyik sem függ a webes
+kaputól vagy a Telegramtól.
+
+## `npm run dashboard-user` -- a break-glass eszköz
+
+A CLI közvetlenül az SQLite-ot írja (nincs HTTP, nincs auth-kapu), ezért akkor
+is működik, ha a webes belépés félre van konfigurálva, throttlingol, vagy el
+sem érhető:
+
+```bash
+npm run dashboard-user -- list                          # kik léteznek
+npm run dashboard-user -- reset-password <felhasznalo>  # új jelszó (elfelejtett jelszó után)
+npm run dashboard-user -- remove <felhasznalo>          # user törlése; az utolsó user törlése = vissza token-only módba
+npm run dashboard-user -- sessions:clear [<felhasznalo>] # böngésző-sessionök törlése
+npm run dashboard-user -- security:reset                # VÉSZHELYZETI RESET (lásd lent)
+```
+
+A `reset-password` nem kéri a régi jelszót (ez a lényege), ezért minden
+futásáról audit-bejegyzés készül és -- ha van bekötött csatorna -- Telegram-
+értesítés megy a gazdának. Csatorna nélküli installon az értesítés csendben
+kimarad; a visszaút sosem függ tőle.
+
+## `security:reset` -- a pánikgomb
+
+Egy lépésben:
+
+- **minden eszközkulcsot visszavon** (Bridge, telefon -- újra kell párosítani),
+- **minden böngésző-munkamenetet töröl** (mindenki újra jelentkezik be),
+- a jövőbeli belépés-kényszerítő kapcsolókat (ha lesznek) alaphelyzetbe állítja.
+
+Amihez NEM nyúl: a jelszavak és a userek megmaradnak, és a dashboard-token
+továbbra is működik. Ez tehát nem gyári visszaállítás, hanem a "kiadott
+hozzáférések közül valamelyik elszabadult, vágjuk el MOST mindet" kar.
+
+A futó szerver legfeljebb 60 másodpercen belül érvényesíti a resetet (a
+hitelesítő-cache a következő használatnál észleli a törölt sort); restart nem
+szükséges.
+
+## HTTP break-glass (token birtokában)
+
+A dashboard-token birtokosa a `POST /api/auth/password` végponton
+`current_password` nélkül, `username` megadásával állíthat át jelszót. Ez is
+auditált (`security.break_glass_password_reset`) és csatorna-értesítést küld.
+Csak `token` hitelesítéssel érhető el -- session, eszközkulcs vagy federation
+principal 403-at kap.
+
+## Audit
+
+Minden fenti művelet a `config_change_log` táblába ír (`security.*` kulcsokkal,
+kizárólag metaadat: felhasználónév és darabszámok, sosem hitelesítő anyag), és
+a dashboard Audit nézetében a `config` forrás alatt kereshető.

--- a/scripts/dashboard-user.ts
+++ b/scripts/dashboard-user.ts
@@ -6,16 +6,28 @@
 //   npm run dashboard-user -- list
 //   npm run dashboard-user -- remove <username>
 //   npm run dashboard-user -- sessions:clear [<username>]
+//   npm run dashboard-user -- security:reset
 //
-// The operator can always run commands on the machine hosting the install, so
-// this doubles as the forgot-password recovery path. Passwords are read interactively (twice, muted)
+// THIS IS THE BREAK-GLASS PATH. It talks to SQLite directly -- no HTTP, no
+// auth gate -- so it works even when the web login is misconfigured, throttled
+// or unreachable. The operator can always run commands on the machine hosting
+// the install, so "I can run this CLI" is the root credential.
+//
+// security:reset is the panic lever: it revokes EVERY device key and clears
+// EVERY browser session in one step (future login-enforcement toggles will be
+// cleared here too). Passwords and users are untouched; the bearer token keeps
+// working. See docs/dashboard-auth-recovery.md.
+//
+// Passwords are read interactively (twice, muted)
 // or from stdin with --password-stdin for automation. No new dependencies:
 // node:readline for the prompt, the app's own db + password-hash modules.
 
 import { createInterface } from 'node:readline'
-import { initDatabase, getDb, createDashboardUser, getDashboardUser, listDashboardUsers, deleteDashboardUser, updateDashboardUserPassword } from '../src/db.js'
+import { initDatabase, getDb, createDashboardUser, getDashboardUser, listDashboardUsers, deleteDashboardUser, updateDashboardUserPassword, logConfigChange } from '../src/db.js'
 import { hashPassword, assertPasswordPolicy, PasswordPolicyError } from '../src/web/password-hash.js'
 import { revokeAllForUser } from '../src/web/auth-sessions.js'
+import { securityReset } from '../src/web/security-reset.js'
+import { notifySecurityEvent } from '../src/notify.js'
 
 function usage(): never {
   process.stderr.write(
@@ -24,7 +36,8 @@ function usage(): never {
     '  dashboard-user reset-password <username> [--password-stdin]\n' +
     '  dashboard-user list\n' +
     '  dashboard-user remove <username>\n' +
-    '  dashboard-user sessions:clear [<username>]\n',
+    '  dashboard-user sessions:clear [<username>]\n' +
+    '  dashboard-user security:reset      # revoke ALL device keys + clear ALL browser sessions\n',
   )
   process.exit(2)
 }
@@ -113,6 +126,10 @@ async function main(): Promise<void> {
       const hash = await hashPassword(pw)
       updateDashboardUserPassword(user.id, hash)
       revokeAllForUser(user.id)
+      // Same audit + channel ping as the HTTP break-glass: a password reset
+      // that skipped the current-password proof must always leave a trace.
+      logConfigChange('security.break_glass_password_reset', null, user.username, 'cli')
+      await notifySecurityEvent(`🔑 Jelszó-reset a dashboard CLI-ből (break-glass): "${user.username}". Ha nem te voltál, a gépen fut valami a nevedben.`)
       process.stdout.write(`Password reset for "${username}"; all their sessions were revoked.\n`)
       break
     }
@@ -140,6 +157,15 @@ async function main(): Promise<void> {
       deleteDashboardUser(username)
       const remaining = listDashboardUsers().length
       process.stdout.write(`Removed "${username}".${remaining === 0 ? ' No users left -- back to token-only mode.' : ''}\n`)
+      break
+    }
+    case 'security:reset': {
+      const r = securityReset('cli')
+      await notifySecurityEvent(`🚨 Biztonsági reset futott a dashboard CLI-ből: ${r.deviceKeysRevoked} eszközkulcs visszavonva, ${r.sessionsCleared} böngésző-munkamenet törölve. A hozzáférési token és a jelszavak változatlanok.`)
+      process.stdout.write(
+        `Security reset done: ${r.deviceKeysRevoked} device key(s) revoked, ${r.sessionsCleared} browser session(s) cleared.\n` +
+        'Passwords and the dashboard token are untouched. Devices must be re-enrolled with new keys.\n',
+      )
       break
     }
     case 'sessions:clear': {

--- a/src/__tests__/auth-recovery.test.ts
+++ b/src/__tests__/auth-recovery.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import type http from 'node:http'
+import { Readable } from 'node:stream'
+import { initDatabase, getDb, createDashboardUser } from '../db.js'
+import { tryHandleAuth } from '../web/routes/auth.js'
+import { securityReset } from '../web/security-reset.js'
+import {
+  createDeviceKey,
+  resolveDeviceKey,
+  listDeviceKeys,
+  _clearDeviceKeyCacheForTest,
+} from '../web/auth-device-keys.js'
+import {
+  createSession,
+  resolveSession,
+  _clearSessionCacheForTest,
+} from '../web/auth-sessions.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+// AUTHPLAN1 #5 -- recovery paths. Contract under test:
+//   - securityReset revokes every device key AND every browser session in one
+//     step, leaves users/passwords in place, and writes an audit row;
+//   - the HTTP break-glass password reset (token, no current_password) writes
+//     an audit row carrying the target username, never the password;
+//   - out-of-band revocation (a different process deleting rows, as the CLI
+//     does) is honored by a LIVE process's cache within the 60s debounce:
+//     the debounced write doubles as an existence check.
+
+function mkRes() {
+  return {
+    statusCode: 0,
+    headers: {} as Record<string, unknown>,
+    body: '',
+    writeHead(status: number, headers?: Record<string, unknown>) {
+      this.statusCode = status
+      if (headers) Object.assign(this.headers, headers)
+      return this
+    },
+    setHeader(k: string, v: string) {
+      this.headers[k] = v
+    },
+    end(data?: string) {
+      if (data !== undefined) this.body += data
+    },
+  }
+}
+
+async function call(
+  method: string,
+  path: string,
+  opts: { body?: unknown; auth?: RouteContext['auth'] } = {},
+): Promise<{ statusCode: number; body: string }> {
+  const payload = opts.body === undefined ? [] : [Buffer.from(JSON.stringify(opts.body))]
+  const req = Readable.from(payload) as unknown as http.IncomingMessage & Record<string, unknown>
+  req.headers = {}
+  const res = mkRes()
+  await tryHandleAuth({
+    req: req as http.IncomingMessage,
+    res: res as unknown as http.ServerResponse,
+    path,
+    method,
+    url: new URL(`http://127.0.0.1:3420${path}`),
+    auth: opts.auth,
+  })
+  return { statusCode: res.statusCode, body: res.body }
+}
+
+const GOOD_PW = 'super-secret-pw-123'
+
+function auditRows(key: string): Array<{ key: string; new_value: string | null; actor: string }> {
+  return getDb()
+    .prepare('SELECT key, new_value, actor FROM config_change_log WHERE key = ? ORDER BY id')
+    .all(key) as Array<{ key: string; new_value: string | null; actor: string }>
+}
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test'
+  initDatabase(':memory:')
+})
+
+beforeEach(() => {
+  _clearDeviceKeyCacheForTest()
+  _clearSessionCacheForTest()
+  const db = getDb()
+  db.prepare('DELETE FROM device_keys').run()
+  db.prepare('DELETE FROM auth_sessions').run()
+  db.prepare('DELETE FROM dashboard_users').run()
+  db.prepare('DELETE FROM config_change_log').run()
+})
+
+describe('securityReset', () => {
+  it('revokes all device keys and sessions, keeps users, audits the counts', async () => {
+    const u = createDashboardUser('op', '$scrypt$ln=16,r=8,p=1$c2FsdA==$a2V5')
+    const key = createDeviceKey('phone')
+    const cookie = createSession({ userId: u.id, username: u.username })
+    expect(resolveDeviceKey(key.key)).not.toBeNull()
+    expect(resolveSession(cookie)).not.toBeNull()
+
+    const r = securityReset('test')
+    expect(r).toEqual({ deviceKeysRevoked: 1, sessionsCleared: 1 })
+    expect(resolveDeviceKey(key.key)).toBeNull()
+    expect(resolveSession(cookie)).toBeNull()
+    expect(listDeviceKeys()).toHaveLength(0)
+    // The user (and their password hash) survive: this is not a factory reset.
+    expect(getDb().prepare('SELECT COUNT(*) AS c FROM dashboard_users').get()).toEqual({ c: 1 })
+
+    const rows = auditRows('security.reset')
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.actor).toBe('test')
+    expect(rows[0]!.new_value).toBe('device_keys=1 sessions=1')
+  })
+
+  it('is a safe no-op on an empty install', () => {
+    expect(securityReset('test')).toEqual({ deviceKeysRevoked: 0, sessionsCleared: 0 })
+  })
+})
+
+describe('HTTP break-glass password reset audit', () => {
+  it('writes an audit row with the target username on the token path', async () => {
+    const mk = await call('POST', '/api/auth/users', { auth: { kind: 'token' }, body: { username: 'alice', password: GOOD_PW } })
+    expect(mk.statusCode).toBe(201)
+    const r = await call('POST', '/api/auth/password', { auth: { kind: 'token' }, body: { username: 'alice', new_password: GOOD_PW + 'x' } })
+    expect(r.statusCode).toBe(200)
+    const rows = auditRows('security.break_glass_password_reset')
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!).toEqual({ key: 'security.break_glass_password_reset', new_value: 'alice', actor: 'token' })
+    // Never credential material in the trail.
+    const all = JSON.stringify(getDb().prepare('SELECT * FROM config_change_log').all())
+    expect(all).not.toContain(GOOD_PW)
+  })
+
+  it('does NOT audit a normal session-path password change as break-glass', async () => {
+    await call('POST', '/api/auth/users', { auth: { kind: 'token' }, body: { username: 'bob', password: GOOD_PW } })
+    getDb().prepare('DELETE FROM config_change_log').run()
+    const r = await call('POST', '/api/auth/password', {
+      auth: { kind: 'session', user: 'bob' },
+      body: { current_password: GOOD_PW, new_password: GOOD_PW + 'y' },
+    })
+    expect(r.statusCode).toBe(200)
+    expect(auditRows('security.break_glass_password_reset')).toHaveLength(0)
+  })
+})
+
+describe('out-of-band revocation reaches a live cache (CLI -> running server)', () => {
+  it('a cached device key stops resolving once its row is gone and the debounce fires', () => {
+    const minted = createDeviceKey('phone')
+    expect(resolveDeviceKey(minted.key)).not.toBeNull() // cached, last_used stamped
+
+    // Simulate the CLI process: delete the row directly, bypassing the cache.
+    getDb().prepare('DELETE FROM device_keys').run()
+
+    // Age the cached last_used past the debounce so the next resolve writes --
+    // and the write's 0-changes result must evict + reject.
+    getDb() // (cache holds lastUsedAt=now; rewind it via the test seam below)
+    // No seam for the cache timestamp: emulate the >=60s gap by clearing the
+    // cache's knowledge of the stamp through a fresh entry -- a cache MISS also
+    // goes to the DB and must reject.
+    _clearDeviceKeyCacheForTest()
+    expect(resolveDeviceKey(minted.key)).toBeNull()
+  })
+
+  it('a WARM cache entry is evicted by the debounced existence check (no restart, no cache clear)', () => {
+    const minted = createDeviceKey('phone')
+    expect(resolveDeviceKey(minted.key)).not.toBeNull() // cache warm, last_used stamped now
+    // Out-of-band delete with the cache warm and its stamp fresh...
+    getDb().prepare('DELETE FROM device_keys').run()
+    // ...a resolve within the debounce window still serves the cache (the documented <=60s staleness):
+    expect(resolveDeviceKey(minted.key)).not.toBeNull()
+    // ...but once the stamp is old enough that the debounced write fires, the
+    // 0-changes result must evict and reject:
+    ageDeviceKeyCacheStamp(minted.key, 120)
+    expect(resolveDeviceKey(minted.key)).toBeNull()
+    expect(resolveDeviceKey(minted.key)).toBeNull() // stays evicted
+  })
+
+  it('a cached session stops resolving after its row is deleted out-of-band', () => {
+    const u = createDashboardUser('op2', '$scrypt$ln=16,r=8,p=1$c2FsdA==$a2V5')
+    const cookie = createSession({ userId: u.id, username: u.username })
+    expect(resolveSession(cookie)).not.toBeNull()
+    getDb().prepare('DELETE FROM auth_sessions').run()
+    ageSessionCacheStamp(cookie, 120)
+    expect(resolveSession(cookie)).toBeNull()
+  })
+})
+
+// --- helpers reaching into the modules' storage representation ---
+
+import { createHash } from 'node:crypto'
+function sha256hexOf(v: string): string {
+  return createHash('sha256').update(v).digest('hex')
+}
+
+// Age an in-memory cache stamp so the next resolve crosses the 60s debounce
+// without sleeping, via the modules' exported cache seams.
+import { _cacheForTest as deviceKeyCache } from '../web/auth-device-keys.js'
+import { _cacheForTest as sessionCache } from '../web/auth-sessions.js'
+
+function ageDeviceKeyCacheStamp(rawKey: string, seconds: number): void {
+  const e = deviceKeyCache.get(sha256hexOf(rawKey))
+  if (!e) throw new Error('device key not in cache')
+  if (e.lastUsedAt !== null) e.lastUsedAt -= seconds
+}
+
+function ageSessionCacheStamp(cookie: string, seconds: number): void {
+  const e = sessionCache.get(sha256hexOf(cookie))
+  if (!e) throw new Error('session not in cache')
+  e.lastSeenAt -= seconds
+}

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -26,3 +26,16 @@ export async function notifyChannel(text: string): Promise<void> {
 
 // Backward-compatible alias
 export const notifyTelegram = notifyChannel
+
+// Security-event notification (break-glass password reset, security:reset).
+// Unlike notifyChannel, a missing channel config is an EXPECTED state here
+// (fresh installs, channel-less deployments), so it stays fully silent -- the
+// recovery path must never depend on, or be noisy about, Telegram being wired.
+export async function notifySecurityEvent(text: string): Promise<void> {
+  if (!CHANNEL_TOKEN || !CHANNEL_CHAT_ID) return
+  try {
+    await notifyChannel(text)
+  } catch {
+    /* never let a notification failure break the recovery action itself */
+  }
+}

--- a/src/web/auth-device-keys.ts
+++ b/src/web/auth-device-keys.ts
@@ -107,7 +107,16 @@ export function resolveDeviceKey(raw: string): DeviceKeyPrincipal | null {
   }
   if (entry.lastUsedAt === null || now - entry.lastUsedAt >= LAST_USED_DEBOUNCE_SEC) {
     entry.lastUsedAt = now
-    getDb().prepare('UPDATE device_keys SET last_used_at = ? WHERE key_hash = ?').run(now, keyHash)
+    const res = getDb().prepare('UPDATE device_keys SET last_used_at = ? WHERE key_hash = ?').run(now, keyHash)
+    // The debounced write doubles as an existence check: zero changed rows
+    // means the key was revoked OUTSIDE this process (dashboard-user
+    // security:reset runs in its own process and cannot reach this cache), so
+    // an out-of-band revocation takes effect here within <=60s instead of
+    // lingering until the next restart.
+    if (res.changes === 0) {
+      cache.delete(keyHash)
+      return null
+    }
   }
   return { id: entry.id, name: entry.name }
 }
@@ -153,3 +162,7 @@ export function sweepExpiredDeviceKeys(): number {
 export function _clearDeviceKeyCacheForTest(): void {
   cache.clear()
 }
+
+// Test seam: direct cache access, so tests can age a last_used stamp across
+// the debounce window without sleeping.
+export const _cacheForTest = cache

--- a/src/web/auth-sessions.ts
+++ b/src/web/auth-sessions.ts
@@ -100,7 +100,15 @@ export function resolveSession(cookieValue: string): ResolvedSession | null {
   }
   if (now - entry.lastSeenAt >= LAST_SEEN_DEBOUNCE_SEC) {
     entry.lastSeenAt = now
-    getDb().prepare('UPDATE auth_sessions SET last_seen_at = ? WHERE id_hash = ?').run(now, idHash)
+    const res = getDb().prepare('UPDATE auth_sessions SET last_seen_at = ? WHERE id_hash = ?').run(now, idHash)
+    // Zero changed rows = the session row was deleted OUTSIDE this process
+    // (dashboard-user sessions:clear / security:reset run in their own process
+    // and cannot reach this cache). Honor the revocation within <=60s instead
+    // of serving the cached session until the next restart.
+    if (res.changes === 0) {
+      cache.delete(idHash)
+      return null
+    }
   }
   return { userId: entry.userId, username: entry.username }
 }
@@ -122,6 +130,14 @@ export function revokeAllForUser(userId: number, exceptCookieValue?: string | nu
   } else {
     getDb().prepare('DELETE FROM auth_sessions WHERE user_id = ?').run(userId)
   }
+}
+
+// Revoke EVERY browser session at once (break-glass security reset). Cache and
+// table go together -- a DB-only delete would leave cached sessions resolving
+// until the next restart.
+export function revokeAllSessions(): number {
+  cache.clear()
+  return getDb().prepare('DELETE FROM auth_sessions').run().changes
 }
 
 export function listUserSessions(userId: number): UserSessionInfo[] {
@@ -151,3 +167,7 @@ export function sweepExpiredSessions(): number {
 export function _clearSessionCacheForTest(): void {
   cache.clear()
 }
+
+// Test seam: direct cache access, so tests can age a last_seen stamp across
+// the debounce window without sleeping.
+export const _cacheForTest = cache

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -52,7 +52,9 @@ import {
   countDashboardUsers,
   updateDashboardUserPassword,
   deleteDashboardUser,
+  logConfigChange,
 } from '../../db.js'
+import { notifySecurityEvent } from '../../notify.js'
 import type { RouteContext } from './types.js'
 
 const LOGIN_BODY_MAX_BYTES = 8 * 1024
@@ -272,6 +274,16 @@ export async function tryHandleAuth(ctx: RouteContext): Promise<boolean> {
     // Revoke every other session of this user; keep the caller's own if present.
     const presented = parseCookies(req.headers.cookie)[SESSION_COOKIE_NAME]
     revokeAllForUser(user.id, presented ?? undefined)
+    if (auth?.kind === 'token') {
+      // Break-glass reset (no current_password proven): leave a durable audit
+      // row and ping the operator's channel. Only the username goes into the
+      // trail, never credential material. Fire-and-forget: the reset must
+      // succeed with or without a wired channel (notifySecurityEvent is
+      // silent when none is configured).
+      logConfigChange('security.break_glass_password_reset', null, user.username, 'token')
+      logger.warn({ username: user.username }, 'break-glass password reset via bearer token')
+      void notifySecurityEvent(`🔑 Break-glass jelszó-reset a dashboardon: "${user.username}" jelszavát a hozzáférési tokennel állították át. Ha nem te voltál, futtasd: npm run dashboard-user -- security:reset`)
+    }
     json(res, { ok: true })
     return true
   }

--- a/src/web/security-reset.ts
+++ b/src/web/security-reset.ts
@@ -1,0 +1,31 @@
+// Break-glass security reset (AUTHPLAN1 #5).
+//
+// One operation that returns dashboard access to its baseline: every device
+// key revoked, every browser session cleared. Passwords and users are NOT
+// touched (use dashboard-user reset-password/remove for those) and the bearer
+// token keeps working -- this is the "some credential I handed out is loose,
+// cut them all NOW" lever, not a factory reset.
+//
+// Future login-enforcement toggles (deferred to the next release) must be
+// cleared here too, so a reset can never leave the operator locked out by a
+// half-configured policy.
+//
+// Lives outside the CLI so the logic is unit-testable and reusable; the CLI
+// (scripts/dashboard-user.ts security:reset) is a thin wrapper.
+
+import { logConfigChange } from '../db.js'
+import { revokeAllDeviceKeys } from './auth-device-keys.js'
+import { revokeAllSessions } from './auth-sessions.js'
+
+export interface SecurityResetResult {
+  deviceKeysRevoked: number
+  sessionsCleared: number
+}
+
+export function securityReset(actor: string): SecurityResetResult {
+  const deviceKeysRevoked = revokeAllDeviceKeys()
+  const sessionsCleared = revokeAllSessions()
+  // Counts only -- never credential material -- into the audit trail.
+  logConfigChange('security.reset', null, `device_keys=${deviceKeysRevoked} sessions=${sessionsCleared}`, actor)
+  return { deviceKeysRevoked, sessionsCleared }
+}


### PR DESCRIPTION
## What

AUTHPLAN1 #5 (non-2FA recovery branch). Ground rule made explicit: **whoever can run commands on the host is the root credential** -- every recovery path builds on that, and none depends on the web gate or Telegram being functional.

## Changes

- **`dashboard-user security:reset`** (new subcommand): revokes EVERY device key and clears EVERY browser session in one step; future login-enforcement toggles will reset here too. Passwords, users and the bearer token are untouched -- a panic lever, not a factory reset. Core logic in `src/web/security-reset.ts` (unit-testable, reusable).
- **Break-glass audit + alert**: the token-path HTTP password reset AND the CLI `reset-password` now write a `config_change_log` row (`security.*` keys -- metadata only, never credential material; visible in the Audit view under the `config` source) and ping the operator's channel via the new `notifySecurityEvent()`, which is **fully silent when no channel is wired** (fresh installs, channel-less deployments).
- **Out-of-band revocation reaches a LIVE server**: the CLI runs in its own process and cannot touch the server's in-memory credential caches -- without this, a revoked key/session would keep resolving until restart. The debounced `last_used`/`last_seen` write now doubles as an existence check: 0 changed rows evicts the cache entry and rejects. A CLI reset takes effect on a running server within <=60s, no restart needed.
- **docs/dashboard-auth-recovery.md**: forgot-password, lockout, and panic-reset paths documented; linked from the docs index.

## Why merge-safe for foreign installs

No schema change, no new settings, no default flips. The alert path is a silent no-op without a wired channel. The cache existence-check only changes behavior for rows deleted out-of-band -- exactly the rows that must stop authenticating.

## Tests

- New `auth-recovery` suite (7 tests): securityReset counts + audit row + users/passwords survive; break-glass audit on the token path ONLY (session-path change is not break-glass), with an assertion that no password material lands in the trail; warm-cache eviction across the debounce for both device keys and sessions.
- Full suite: 2799 passed; the same 13 known /tmp-worktree path-environment failures as #724 (hook-path-guard, email-send-gate, governance-gates -- untouched by this diff, green on a normal checkout). tsc clean.
- Live e2e on an isolated instance: HTTP break-glass -> audit row visible via `/api/audit-log`; real `npm run dashboard-user -- security:reset` run -> `1 device key(s) revoked, 1 browser session(s) cleared`, audit row `actor=cli`, user survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)