### PR TITLE
fix(channels): repair stale /mcp plugin-row matcher that left the channel mute

### DIFF
--- a/scripts/__tests__/channels-mcp-unlock.test.sh
+++ b/scripts/__tests__/channels-mcp-unlock.test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Contract tests for the /mcp post-init unlock detector in scripts/channels.sh.
+#
+# Regression origin (2026-07-27): the detector was a literal case-glob,
+# `*"plugin:telegram@"*"✗ Failed"*`. Claude Code 2.1.220 renders the row as
+# `plugin:telegram:telegram · ✘ failed` -- a different server id AND a
+# different glyph (U+2718, lowercase). Neither alternative matched, so the
+# unlock logged "no Failed plugin row ... check manually" and returned on
+# exactly the boots where the plugin HAD failed. The bun poller never started,
+# nobody long-polled Telegram, and inbound messages piled up server-side with
+# the channel silently mute (5 pending updates before a human noticed).
+#
+# Both directions matter and both are covered here:
+#   - a failed row MUST fire the unlock (the regression), and
+#   - a connected/disabled row MUST NOT (firing Up+Enter+Enter on a healthy
+#     plugin lands on "Disable" and takes the channel down by hand).
+#
+# Driven through `channels.sh --classify-mcp-pane <provider>`, which reads a
+# pane on stdin and exits before touching tmux, .env or the store.
+# Run: bash scripts/__tests__/channels-mcp-unlock.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 -- expected: $2, got: $3"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+# Overridable so the suite can be pointed at a deliberately-broken copy to
+# confirm it actually fails on the bug (a green test that cannot go red is
+# worse than no test -- it certifies health it never checked).
+CHANNELS="${CHANNELS_BIN:-$INSTALL_DIR/scripts/channels.sh}"
+
+# $1 = label, $2 = provider, $3 = expected (failed|ok), $4 = pane text
+expect_classify() {
+  local got
+  got="$(printf '%s' "$4" | bash "$CHANNELS" --classify-mcp-pane "$2" 2>/dev/null)"
+  if [ "$got" = "$3" ]; then pass "$1"; else fail "$1" "$3" "$got"; fi
+}
+
+echo "channels.sh /mcp unlock detector"
+
+# --- the regression: Claude Code 2.1.220 label + glyph ------------------------
+# Verbatim capture from the 2026-07-27 incident (turing-channels).
+PANE_2_1_220_FAILED='   Manage MCP servers
+   7 servers
+
+     User MCPs (/home/ubuntu/.claude.json)
+   ❯ gmail · ✔ connected · 14 tools
+     google-calendar · ✔ connected · 13 tools
+
+     Built-in MCPs (always available)
+     plugin:telegram:telegram · ✘ failed
+
+   ※ Run claude --debug to see error logs'
+expect_classify "2.1.220 failed row (✘ failed) fires unlock" telegram failed "$PANE_2_1_220_FAILED"
+
+# --- backward compatibility: the 2.1.159 label + glyph the old glob expected --
+PANE_2_1_159_FAILED='   Manage MCP servers
+
+     plugin:telegram@claude-plugins-official · ✗ Failed'
+expect_classify "2.1.159 failed row (✗ Failed) still fires unlock" telegram failed "$PANE_2_1_159_FAILED"
+
+# --- healthy rows must never fire (Up+Enter+Enter would hit "Disable") --------
+PANE_CONNECTED='   Manage MCP servers
+
+     plugin:telegram:telegram · ✔ connected · 8 tools'
+expect_classify "connected row does not fire" telegram ok "$PANE_CONNECTED"
+
+PANE_DISABLED='   Manage MCP servers
+
+     plugin:telegram:telegram (disabled)'
+expect_classify "disabled row does not fire" telegram ok "$PANE_DISABLED"
+
+# A pane with no plugin row at all (capture failed, menu never opened) is
+# inconclusive, not a failure -- the dashboard health monitor owns that case.
+expect_classify "pane without a plugin row does not fire" telegram ok "   Manage MCP servers
+   0 servers"
+expect_classify "empty pane does not fire" telegram ok ""
+
+# --- a scrollback mention of the plugin id is not the /mcp row ----------------
+# The launch banner names the plugin, and an unrelated error elsewhere in the
+# pane must not combine with it into a false positive.
+PANE_BANNER_ONLY='  Listening for channel messages from: plugin:telegram@claude-plugins-official
+  ⎿  Error: some unrelated tool call failed
+
+     plugin:telegram:telegram · ✔ connected · 8 tools'
+expect_classify "banner + unrelated error, plugin connected: does not fire" telegram ok "$PANE_BANNER_ONLY"
+
+# --- other providers resolve their own pane id -------------------------------
+# Keep in sync with pluginPaneId in src/channel-provider.ts.
+expect_classify "slack failed row fires unlock" slack failed \
+  '     plugin:slack-channel:marveen-marketplace · ✘ failed'
+expect_classify "discord failed row fires unlock" discord failed \
+  '     plugin:discord:discord · ✘ failed'
+expect_classify "telegram detector ignores a failed slack row" telegram ok \
+  '     plugin:slack-channel:marveen-marketplace · ✘ failed'
+
+# --- other failure vocabulary (mirrors PLUGIN_FAILED_RX) ---------------------
+expect_classify "disconnected row fires unlock" telegram failed \
+  '     plugin:telegram:telegram · ✘ disconnected'
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -50,14 +50,64 @@ fi
 CHANNEL_PROVIDER="${CHANNEL_PROVIDER:-telegram}"
 SESSION="${MAIN_AGENT_ID:-marveen}-channels"
 
-# Resolve plugin ID from provider
-case "$CHANNEL_PROVIDER" in
-  slack)    PLUGIN_ID="slack-channel@marveen-marketplace" ;;
-  whatsapp) PLUGIN_ID="whatsapp@marveen-marketplace" ;;
-  teams)    PLUGIN_ID="teams@marveen-marketplace" ;;
-  discord)  PLUGIN_ID="discord@claude-plugins-official" ;;
-  *)        PLUGIN_ID="telegram@claude-plugins-official" ;;
-esac
+# Resolve plugin ID from provider.
+#
+# PLUGIN_ID is the marketplace-qualified id the `--channels` flag takes.
+# PLUGIN_PANE_ID is the *MCP server* id the /mcp TUI renders, which is a
+# DIFFERENT string (`plugin:<plugin>:<mcp-server>`). Keep this map in sync with
+# `pluginPaneId` in src/channel-provider.ts -- the post-init unlock below greps
+# the /mcp pane for it.
+resolve_plugin_ids() {
+  case "$1" in
+    slack)    PLUGIN_ID="slack-channel@marveen-marketplace"; PLUGIN_PANE_ID="plugin:slack-channel:marveen-marketplace" ;;
+    whatsapp) PLUGIN_ID="whatsapp@marveen-marketplace";      PLUGIN_PANE_ID="plugin:whatsapp:marveen-marketplace" ;;
+    teams)    PLUGIN_ID="teams@marveen-marketplace";         PLUGIN_PANE_ID="plugin:teams:marveen-marketplace" ;;
+    discord)  PLUGIN_ID="discord@claude-plugins-official";   PLUGIN_PANE_ID="plugin:discord:discord" ;;
+    *)        PLUGIN_ID="telegram@claude-plugins-official";  PLUGIN_PANE_ID="plugin:telegram:telegram" ;;
+  esac
+}
+resolve_plugin_ids "$CHANNEL_PROVIDER"
+
+# --- pure classifier for the /mcp pane ----------------------------------------
+# Takes a captured pane as $1 and sets MCP_PLUGIN_STATE (failed|ok) plus the row
+# it judged in MCP_PLUGIN_ROW for logging. Assigns rather than prints so the
+# caller keeps the row without a subshell. Extracted so it is testable without a
+# live tmux session (see scripts/__tests__/channels-mcp-unlock.test.sh) -- the
+# previous inline matcher went stale against a Claude Code TUI change and no
+# test could have caught it.
+#
+# Only the plugin's OWN row is considered, and only the status word decides:
+#   - The row label is the MCP server id, not the marketplace id. Claude Code
+#     2.1.159 rendered `plugin:telegram@claude-plugins-official`, 2.1.220
+#     renders `plugin:telegram:telegram`. Both are accepted.
+#   - The failure marker moved from `✗ Failed` (U+2717, capitalised) to
+#     `✘ failed` (U+2718, lowercase), so the glyph is not matched at all. The
+#     status vocabulary mirrors PLUGIN_FAILED_RX in
+#     src/web/channel-health-monitor.ts.
+# The status-marker pre-filter keeps a scrollback mention of the plugin id (the
+# "Listening for channel messages from:" banner) from being read as the /mcp
+# row; `tail -1` prefers the menu, which renders at the bottom of the pane.
+MCP_PLUGIN_ROW=""
+MCP_PLUGIN_STATE="ok"
+classify_mcp_plugin_row() {
+  MCP_PLUGIN_ROW="$(printf '%s\n' "$1" \
+    | grep -F -e "$PLUGIN_PANE_ID" -e "plugin:$PLUGIN_ID" \
+    | grep -iE 'failed|error|disconnected|connected|disabled' \
+    | tail -1)"
+  case "$(printf '%s' "$MCP_PLUGIN_ROW" | tr '[:upper:]' '[:lower:]')" in
+    *failed*|*error*|*disconnected*) MCP_PLUGIN_STATE="failed" ;;
+    *)                               MCP_PLUGIN_STATE="ok" ;;
+  esac
+}
+
+# Test hook: classify a pane from stdin and exit before anything touches tmux,
+# the store or a live session.
+if [ "${1:-}" = "--classify-mcp-pane" ]; then
+  resolve_plugin_ids "${2:-$CHANNEL_PROVIDER}"
+  classify_mcp_plugin_row "$(cat)"
+  echo "$MCP_PLUGIN_STATE"
+  exit 0
+fi
 
 # Self-healing guard: ensure PLUGIN_ID is enabled in the PROJECT settings.json
 # before launch. A PR review-reset or branch-switch that reverts
@@ -532,7 +582,7 @@ date +%s > "$INSTALL_DIR/store/.channel-last-respawn"
 #      poller" even when one is running. A direct child-of-claude pgrep is the
 #      authoritative signal.
 #
-#   2. capture-pane after `/mcp` shows the plugin row marked with "✗ Failed".
+#   2. capture-pane after `/mcp` shows the plugin's own row in a failed state.
 #      Connected/Enabled rows must NOT trigger the keystroke sequence, because
 #      then `Up`+`Enter`+`Enter` would land on "Disable" in the submenu and
 #      disable the plugin instead of reconnecting it (Szabi msg 427).
@@ -554,19 +604,21 @@ date +%s > "$INSTALL_DIR/store/.channel-last-respawn"
     exit 0
   fi
 
-  # Check 2: TUI confirmation that the plugin shows ✗ Failed. The /mcp view
-  # also shows "(disabled)" markers; we only fire on Failed, never on disabled
-  # (Enable-only submenu has no Reconnect, the Up+Enter+Enter sequence would
-  # land somewhere unsafe).
+  # Check 2: TUI confirmation that the plugin's row is in a failed state. The
+  # /mcp view also shows "(disabled)" markers; we only fire on failed, never on
+  # disabled (Enable-only submenu has no Reconnect, the Up+Enter+Enter sequence
+  # would land somewhere unsafe). See classify_mcp_plugin_row above for why the
+  # matching is row-scoped and glyph-agnostic.
   $TMUX send-keys -t "$SESSION" Escape
   sleep 1
   $TMUX send-keys -t "$SESSION" "/mcp" Enter
   sleep 3
   PANE="$($TMUX capture-pane -t "$SESSION" -p 2>/dev/null || true)"
 
-  case "$PANE" in
-    *"plugin:telegram@"*"✗ Failed"*|*"plugin:telegram@"*"✗ failed"*)
-      echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh post-init: telegram plugin in ✗ Failed state, firing /mcp Up+Enter+Enter unlock" >> "$INSTALL_DIR/store/channels-failures.log"
+  classify_mcp_plugin_row "$PANE"
+  case "$MCP_PLUGIN_STATE" in
+    failed)
+      echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh post-init: $CHANNEL_PROVIDER plugin row failed, firing /mcp Up+Enter+Enter unlock -- row: $MCP_PLUGIN_ROW" >> "$INSTALL_DIR/store/channels-failures.log"
       $TMUX send-keys -t "$SESSION" Up
       sleep 1
       $TMUX send-keys -t "$SESSION" Enter
@@ -580,7 +632,8 @@ date +%s > "$INSTALL_DIR/store/.channel-last-respawn"
       # out safely. If the plugin row literally doesn't appear in the /mcp
       # listing (truly unreachable), the dashboard's channel-monitor will
       # detect down and run its own recovery ladder; we don't second-guess.
-      echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh post-init: no Failed plugin row in /mcp pane, skipping unlock (bun child absent but plugin not failed - check manually)" >> "$INSTALL_DIR/store/channels-failures.log"
+      # Log the row we DID see -- a stale matcher is invisible without it.
+      echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh post-init: no failed plugin row in /mcp pane, skipping unlock (bun child absent but plugin not failed - check manually) -- looked for '$PLUGIN_PANE_ID', row: ${MCP_PLUGIN_ROW:-<none>}" >> "$INSTALL_DIR/store/channels-failures.log"
       $TMUX send-keys -t "$SESSION" Escape
       ;;
   esac


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU** — A `channels.sh` post-init unlock egy literál case-glob-bal ismerte fel a halott channel plugint:

```
*"plugin:telegram@"*"✗ Failed"*|*"plugin:telegram@"*"✗ failed"*
```

Mindkét fele egy konkrét Claude Code build-hez volt kötve, és mindkettő elavult:

| | 2.1.159 | 2.1.220 |
|---|---|---|
| sor-címke | `plugin:telegram@claude-plugins-official` | `plugin:telegram:telegram` |
| hibajelölő | `✗ Failed` (U+2717, nagybetű) | `✘ failed` (U+2718, kisbetű) |

A `/mcp` sor az MCP **server** id-t mutatja, nem a marketplace id-t — a script a rossz azonosítót kereste. 2.1.220-on egyik ág sem illeszkedett, így az unlock a biztonságos fallback ágra esett és `no Failed plugin row ... check manually`-t logolt **pont azokon a boot-okon, ahol a plugin tényleg failed volt**. A bun poller nem indult el, senki nem long-pollozta a Telegramot, a csatorna némán elhallgatott.

Élesben 2026-07-27-én jött elő: a `turing-channels` session `/mcp`-je `plugin:telegram:telegram · ✘ failed`-et mutatott, bun gyerekprocessz nélkül, 5 üzenet állt a Telegram szerver-oldali sorában (`pending_update_count: 5`), amíg valaki kézzel meg nem nyomta a Reconnect-et. A `channels-failures.log` szerint minden rendben volt.

**Technikai megközelítés**

- `PLUGIN_PANE_ID` bevezetése a `PLUGIN_ID` mellé, a `src/channel-provider.ts` `pluginPaneId` mezőjét tükrözve. A kettő különböző string; a TS oldal már a helyeset ismerte, csak a shell nem.
- `classify_mcp_plugin_row()` kiemelése: a plugin **saját sorát** grep-eli, és a **státusz-szó** dönt, nem a glyph — ugyanaz a szókészlet, mint a `PLUGIN_FAILED_RX` a `src/web/channel-health-monitor.ts`-ben. A régi, marketplace-qualified címke továbbra is elfogadott, így a korábbi Claude Code build-ek működnek.
- Csak státusz-jelölőt tartalmazó sorok számítanak, és az utolsó találat nyer, így a scrollback-ben lévő `Listening for channel messages from: plugin:telegram@...` banner nem téveszthető össze a `/mcp` sorral.
- Mindkét ág logolja a ténylegesen látott sort. A régi skip-üzenet nem nevezett meg sort — ezért volt láthatatlan az elavult matcher.
- Új `--classify-mcp-pane <provider>` teszt-hook + `scripts/__tests__/channels-mcp-unlock.test.sh`.

**Viselkedés egészséges pluginnál változatlan**: az `Up+Enter+Enter` szekvencia továbbra is kizárólag failed soron fut le, connected/disabled soron soha (az utóbbi a submenüben a "Disable"-re esne és kézzel lőné le a csatornát).

**EN** — The post-init `/mcp` unlock in `channels.sh` matched a hardcoded plugin label and failure glyph, both of which changed in Claude Code 2.1.220 (`plugin:telegram:telegram · ✘ failed` vs `plugin:telegram@claude-plugins-official · ✗ Failed`). The matcher silently no-op'd on exactly the boots where the plugin had failed, leaving the channel mute. Fixed by matching the plugin's own row via a provider-resolved `PLUGIN_PANE_ID` (mirroring `pluginPaneId` in `src/channel-provider.ts`) and keying on the status word rather than the glyph, with the legacy label still accepted.

## Kapcsolódó issue / Related issue

Closes #

## Tesztelés / Testing

`scripts/__tests__/channels-mcp-unlock.test.sh`, 11 eset, mindkét irány lefedve (failed sornak tüzelnie KELL; connected/disabled sornak NEM szabad):

```
$ bash scripts/__tests__/channels-mcp-unlock.test.sh
  PASS: 2.1.220 failed row (✘ failed) fires unlock
  PASS: 2.1.159 failed row (✗ Failed) still fires unlock
  PASS: connected row does not fire
  PASS: disabled row does not fire
  PASS: pane without a plugin row does not fire
  PASS: empty pane does not fire
  PASS: banner + unrelated error, plugin connected: does not fire
  PASS: slack failed row fires unlock
  PASS: discord failed row fires unlock
  PASS: telegram detector ignores a failed slack row
  PASS: disconnected row fires unlock

  11 passed, 0 failed
```

A suite pirosra tud menni: a `CHANNELS_BIN` override-dal a fix ELŐTTI matcher-re irányítva 4 teszt bukik, köztük az inciddens esete —

```
$ CHANNELS_BIN=/tmp/channels-pre-fix.sh bash scripts/__tests__/channels-mcp-unlock.test.sh
  FAIL: 2.1.220 failed row (✘ failed) fires unlock -- expected: failed, got: ok
  ...
  7 passed, 4 failed
```

A 2.1.220-as pane-fixture szó szerinti `capture-pane` másolat az inciddensből.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. — nem érinti, belső recovery-útvonal / not applicable, internal recovery path only
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
