### PR TITLE
docs(auth): revocation vs live tunnel semantics in the recovery guide

### DIFF
--- a/docs/dashboard-auth-recovery.md
+++ b/docs/dashboard-auth-recovery.md
@@ -46,7 +46,12 @@ szükséges.
 A Biztonság fülön párosított Bridge-eszköz kulcsának visszavonása
 (`Visszavonás` gomb, vagy `DELETE /api/auth/device-keys/<id>`) EGYBEN vonja
 vissza a két hozzáférés-felet: az eszközkulcsot ÉS az `authorized_keys`-ből az
-eszköz SSH-sorát. Az eszköz ettől nem "kizárt felhasználó": újra-párosítással
+eszköz SSH-sorát. A visszavonás az ÚJ kapcsolatokra azonnali: új alagút a
+törölt sorral már nem nyitható, és az eszközkulcs is azonnal érvénytelen. Egy
+MÁR FELÉPÜLT alagút viszont a következő bontásig (app-újraindítás,
+hálózatváltás, alvás) életben maradhat, mert az SSH a futó kapcsolatokat nem
+ellenőrzi újra. Ha azonnali elvágás kell, állítsd le a Bridge appot az
+eszközön, vagy zárd le a szerveren az eszköz élő SSH-kapcsolatát. Az eszköz ettől nem "kizárt felhasználó": újra-párosítással
 (új kulcs-sor beillesztése) bármikor visszahozható. A `security:reset` a
 párosított kulcsokat is visszavonja, de az SSH-sorokat nem bántja -- azok a
 kulcs nélkül csak egy zárt alagutat adnak, és a következő párosítás


### PR DESCRIPTION
One-paragraph addition to the Bridge-parositas visszavonasa section of docs/dashboard-auth-recovery.md: a revoke blocks NEW tunnels and kills the device key instantly, but an already-established tunnel can linger until its next reconnect; for an immediate hard cut, stop the Bridge app or kill the live sshd session.

Measured live during the AUTHPLAN1 (1) e2e pairing test against hermes (2026-07-27): after a UI revoke the established tunnel stayed up for 30+ seconds with no reconnect prompt, while new connections and dashboard API access were already dead. Same disclosure class as the documented 60-second credential-cache window.

Docs-only, no code change. Card: FE650E27 tracks the (separate, post-promote) question of whether the server should force-kill the live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)