### PR TITLE
docs(auth): revoke section polish -- device-key-first framing + manual removal path

### DIFF
--- a/docs/dashboard-auth-recovery.md
+++ b/docs/dashboard-auth-recovery.md
@@ -46,13 +46,18 @@ szükséges.
 A Biztonság fülön párosított Bridge-eszköz kulcsának visszavonása
 (`Visszavonás` gomb, vagy `DELETE /api/auth/device-keys/<id>`) EGYBEN vonja
 vissza a két hozzáférés-felet: az eszközkulcsot ÉS az `authorized_keys`-ből az
-eszköz SSH-sorát. A visszavonás az ÚJ kapcsolatokra azonnali: új alagút a
-törölt sorral már nem nyitható, és az eszközkulcs is azonnal érvénytelen. Egy
-MÁR FELÉPÜLT alagút viszont a következő bontásig (app-újraindítás,
-hálózatváltás, alvás) életben maradhat, mert az SSH a futó kapcsolatokat nem
-ellenőrzi újra. Ha azonnali elvágás kell, állítsd le a Bridge appot az
-eszközön, vagy zárd le a szerveren az eszköz élő SSH-kapcsolatát. Az eszköz ettől nem "kizárt felhasználó": újra-párosítással
-(új kulcs-sor beillesztése) bármikor visszahozható. A `security:reset` a
+eszköz SSH-sorát. Az eszközkulcs AZONNAL megszűnik, tehát a
+dashboard-hozzáférés rögtön záródik; a törölt SSH-sorral új alagút sem
+nyitható. Egy MÁR FELÉPÜLT ssh-alagút viszont a következő bontásig
+(app-újraindítás, hálózatváltás, alvás) életben maradhat, mert az sshd a futó
+kapcsolatokat nem ellenőrzi újra. Ha azonnali vágás kell, állítsd le a Bridge
+appot az eszközön, vagy zárd le a szerveren az eszköz élő SSH-kapcsolatát.
+Ha az SSH-sor törlése hibára fut, a felület külön figyelmeztetést mutat --
+ilyenkor a sort kézzel töröld: a Marveent futtató user
+`~/.ssh/authorized_keys` fájljából vedd ki az eszköz
+`marveen-remote:<install-id>` kommentű sorát. Az eszköz ettől nem "kizárt
+felhasználó": újra-párosítással (új kulcs-sor beillesztése) bármikor
+visszahozható. A `security:reset` a
 párosított kulcsokat is visszavonja, de az SSH-sorokat nem bántja -- azok a
 kulcs nélkül csak egy zárt alagutat adnak, és a következő párosítás
 install-id alapján felülírja őket.


### PR DESCRIPTION
Docs-only follow-up to #731, applying the three review notes from msg 6883 that crossed with the merge:

- Reordered emphasis: the paragraph now leads with what is instant (device key dead, dashboard access closed), then the caveat (an already-open tunnel can linger until its next reconnect), then the hard-cut instruction.
- Added the ssh_removed:false path: if the UI shows the removal warning, the doc now tells the operator how to remove the authorized_keys line manually (grep the marveen-remote:<install-id> comment).
- Fixed the jagged line wrap introduced in #731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)