### PR TITLE
fix(morning-briefing): stop restart-churn from multiplying the daily briefing

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1333,10 +1333,16 @@ ${TZ_LINE}
 EOF
 
 # ${MORN_UNIT}.timer
+# NO Requires=/Wants= on the service here: a [Unit] dependency on the
+# triggered service makes EVERY activation of the timer unit (each systemd
+# user-manager start, not just the 07:27 elapse) queue an immediate start of
+# the briefing service. Under user-manager restart churn that multiplied the
+# morning briefing (customer report 2026-07-26: 5 deliveries in one day).
+# The [Timer] section binds to ${MORN_UNIT}.service by name on elapse, which
+# is the only coupling a timer needs.
 cat >"$SYSTEMD_DIR/${MORN_UNIT}.timer" <<EOF
 [Unit]
 Description=${BOT_NAME} Reggeli Napindito Timer
-Requires=${MORN_UNIT}.service
 
 [Timer]
 OnCalendar=*-*-* 07:27:00

--- a/scripts/morning-briefing.sh
+++ b/scripts/morning-briefing.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Marveen - Reggeli napindító
-# LaunchAgent hívja minden nap 7:27-kor
+# Trigger: systemd user timer (Linux, <agent>-morning.timer) vagy LaunchAgent
+# (macOS), naponta 7:27-kor. Naponta legfeljebb egyszer küld (lásd a guardot).
 
 export PATH="$HOME/.local/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
@@ -17,11 +18,22 @@ fi
 CHAT_ID="${ALLOWED_CHAT_ID:-0}"
 CALENDAR_ID="${HEARTBEAT_CALENDAR_ID:-primary}"
 
+# Same-day dedup guard: the briefing must go out at most once per calendar
+# day no matter how many times the trigger fires (a timer-unit re-activation
+# on a systemd user-manager restart, a Persistent= catch-up, or a manual
+# re-run). MORNING_FORCE=1 bypasses the guard for deliberate re-sends.
+STAMP="$INSTALL_DIR/store/.morning-last-sent"
+TODAY="$(date +%F)"
+if [ "${MORNING_FORCE:-0}" != "1" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$TODAY" ]; then
+  echo "=== Reggeli napindító $(date) -- SKIP: ma már elküldve (guard: $STAMP) ===" >> "$LOG"
+  exit 0
+fi
+
 echo "=== Reggeli napindító $(date) ===" >> "$LOG"
 
 cd "$INSTALL_DIR"
 
-$CLAUDE --dangerously-skip-permissions \
+if $CLAUDE --dangerously-skip-permissions \
   --channels plugin:telegram@claude-plugins-official \
   -p "Reggeli napindító - készítsd el és küld el Telegramra (chat_id: $CHAT_ID).
 
@@ -30,6 +42,8 @@ $CLAUDE --dangerously-skip-permissions \
 3. AI hírek: WebSearch \"AI news [tegnapi dátum]\"
 4. Küld el Telegramra a reply tool-lal (chat_id: $CHAT_ID)
 
-Tömör, lényegre törő. Ékezetesen írj magyarul." >> "$LOG" 2>&1
+Tömör, lényegre törő. Ékezetesen írj magyarul." >> "$LOG" 2>&1; then
+  echo "$TODAY" > "$STAMP"
+fi
 
 echo "=== Kész $(date) ===" >> "$LOG"

--- a/update.sh
+++ b/update.sh
@@ -472,6 +472,23 @@ if [ -x "$INSTALL_DIR/scripts/sync-hooks.sh" ]; then
   bash "$INSTALL_DIR/scripts/sync-hooks.sh" || echo -e "  FIGYELEM: sync-hooks.sh nem-nulla exit; manualisan ellenorizd."
 fi
 
+# Morning-timer unit repair (Linux only). Earlier installers wrote
+# Requires=<unit>.service into the timer's [Unit] section, which makes every
+# activation of the timer unit (each systemd user-manager start, not just the
+# 07:27 elapse) start the briefing service immediately -- restart churn then
+# multiplies the morning briefing (customer report 2026-07-26: 5 deliveries in
+# one day). Idempotent: strips the line wherever it is still present.
+if [ -d "$HOME/.config/systemd/user" ]; then
+  for morn_timer in "$HOME/.config/systemd/user/"*-morning.timer; do
+    [ -f "$morn_timer" ] || continue
+    if grep -q '^Requires=.*-morning\.service' "$morn_timer"; then
+      sed -i.marveen-bak '/^Requires=.*-morning\.service/d' "$morn_timer" && rm -f "${morn_timer}.marveen-bak"
+      systemctl --user daemon-reload 2>/dev/null || true
+      echo -e "  Reggeli-napindito timer javitva (Requires= a [Unit]-bol eltavolitva): $(basename "$morn_timer")"
+    fi
+  done
+fi
+
 # Seed skills & scheduled tasks (idempotent: skip existing)
 # Source .env for template variables needed by seed-scheduled-tasks
 MAIN_AGENT_ID=""


### PR DESCRIPTION
## Customer bug report (2026-07-26, v1.23.2, WSL2 + systemd user services)

The `reggeli-napindito` morning briefing was delivered **5x on one day** during a session/user-manager restart loop, while `store/schedule-last-run.json` kept the 07:30 timestamp.

## Diagnosis: the in-app schedule-runner is NOT the culprit

The reporter's hypothesis (last-run stuck at the slot value, catch-up runs not writing it, missing daily dedup in the runner) does not hold against the source:

1. `attemptFireTask` writes `scheduleLastRun.set(task.name, now)` + persist **after every successful injection**, on the normal, catch-up and retry paths alike (`src/web/schedule-runner.ts`). The stuck value `1785043801593` = 07:30:01.593 -- that is the **actual** fire time of the single legitimate on-time fire (tick granularity), not a slot value.
2. The runner's catch-up window is 30 min, contiguous, and `cronDueBetween` uses `prev()` (at most one occurrence). A dashboard restart at noon scans 11:32-12:02 -- a `30 7 * * *` cron is simply not due there. The runner **cannot** have produced the 12:02-16:18 deliveries. (Identical logic on v1.23.2 and develop.)

## Actual root cause: the parallel systemd path

`morning.log`'s `=== Reggeli napindító ... ===` entries are written exclusively by `scripts/morning-briefing.sh` -- a standalone `claude -p` run with only the telegram plugin (matching the observed "fresh session, Telegram MCP only" symptom). It is triggered by the systemd user timer that `install-linux.sh` generates -- and that timer carried:

```
[Unit]
Requires=<unit>-morning.service
```

A `Requires=` on the triggered service in a **timer's [Unit] section** makes every activation of the timer unit -- i.e. every systemd user-manager start, not just the 07:27 elapse -- queue an immediate start of the oneshot service. Under restart churn: one briefing per churn cycle, which matches the observed same-second correlation between service starts and deliveries. `schedule-last-run.json` is untouched because this path never goes through the runner.

Also explains the reporter's environment note: disabling `task-config.json` does **not** disable this timer (separate subsystem), so their current mitigation is incomplete -- the update-path repair below fixes their box.

## Fix (3 layers, no runtime/TS code touched)

- **install-linux.sh**: drop `Requires=` from the generated timer ([Timer] already binds to the service by name on elapse) + explanatory comment.
- **update.sh**: idempotent repair for existing installs -- strips the line from any `*-morning.timer` + `daemon-reload`. Runs in the post-build sync phase, Linux-gated, no-op elsewhere.
- **scripts/morning-briefing.sh**: same-day dedup guard (`store/.morning-last-sent` stamp, written only on successful send; `MORNING_FORCE=1` bypass) as defense-in-depth against any trigger multiplication, incl. `Persistent=` catch-up edges.

## Impact scope

Linux/WSL installs only (macOS install generates no morning LaunchAgent; legacy plists are in `.disabled`). Latent on every Linux install; manifests under user-manager restart churn.

## Verification

- `bash -n` on all three scripts.
- Stub-claude functional test of the guard: first run sends + stamps; second run skips; `MORNING_FORCE=1` sends; stale (yesterday) stamp sends. All pass.
- Migration block tested against a fake `$HOME`: strips `Requires=` from `marveen-morning.timer`, idempotent on re-run, leaves non-matching timers untouched.

## Follow-up (not in this PR)

The dual scheduling design (systemd timer at 07:27 + optional in-app runner-side daily briefing entry + a dead legacy copy under `<install>/scheduled-tasks/`) is a two-sources-of-truth smell -- worth consolidating to the runner in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
