### PR TITLE
fix(notify): [TESZT] prefix on every test-run message at the outbound chokepoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marveen",
-  "version": "1.19.0",
+  "version": "1.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marveen",
-      "version": "1.19.0",
+      "version": "1.23.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",

--- a/src/__tests__/notify-test-guard.test.ts
+++ b/src/__tests__/notify-test-guard.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+// The regression this covers: a vitest run drove the break-glass audit path,
+// which paged the owner with a real-looking security alert. Owner decision:
+// test-run messages may go out, but must be unmistakably marked ([TESZT]
+// prefix) at every outbound chokepoint, with the env-emptying kill-switch
+// (CHANNEL_TOKEN= CHANNEL_CHAT_ID=) for long debug cycles.
+
+vi.mock('../config.js', () => ({
+  CHANNEL_PROVIDER: 'telegram',
+  CHANNEL_TOKEN: 'live-looking-token',
+  CHANNEL_CHAT_ID: '123456789',
+}))
+vi.mock('../logger.js', () => ({ logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }))
+vi.mock('../channel-provider.js', () => ({ getProvider: vi.fn() }))
+
+import { isTestRun, markTestRun, TEST_RUN_PREFIX, notifyChannel, notifySecurityEvent } from '../notify.js'
+import { getProvider } from '../channel-provider.js'
+
+describe('isTestRun', () => {
+  it('is false for a plain runtime env', () => {
+    expect(isTestRun({})).toBe(false)
+    expect(isTestRun({ NODE_ENV: 'production' })).toBe(false)
+  })
+
+  it('is true when vitest or NODE_ENV=test marks the process', () => {
+    expect(isTestRun({ VITEST: 'true' })).toBe(true)
+    expect(isTestRun({ NODE_ENV: 'test' })).toBe(true)
+  })
+
+  it('detects THIS process as a test run (the property everything below relies on)', () => {
+    expect(isTestRun()).toBe(true)
+  })
+})
+
+describe('markTestRun', () => {
+  it('prefixes in a test env and leaves runtime messages untouched', () => {
+    expect(markTestRun('riasztas', { VITEST: 'true' })).toBe(TEST_RUN_PREFIX + 'riasztas')
+    expect(markTestRun('riasztas', {})).toBe('riasztas')
+  })
+
+  it('is idempotent -- no stacked prefix across two chokepoints', () => {
+    const once = markTestRun('riasztas', { VITEST: 'true' })
+    expect(markTestRun(once, { VITEST: 'true' })).toBe(once)
+  })
+})
+
+describe('outbound chokepoints under a test run', () => {
+  function providerSpy() {
+    const sendMessage = vi.fn(async (..._args: unknown[]) => {})
+    vi.mocked(getProvider).mockReturnValue({
+      formatMessage: (t: string) => t,
+      splitMessage: (t: string) => [t],
+      sendMessage,
+    } as never)
+    return sendMessage
+  }
+
+  it('notifyChannel still sends, but with the [TESZT] prefix', async () => {
+    const sendMessage = providerSpy()
+    await notifyChannel('fake security alert')
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage.mock.calls[0]![2]).toBe(TEST_RUN_PREFIX + 'fake security alert')
+  })
+
+  it('notifySecurityEvent (the break-glass regression path) is marked too', async () => {
+    const sendMessage = providerSpy()
+    await notifySecurityEvent("Break-glass jelszo-reset: 'alice'")
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(String(sendMessage.mock.calls[0]![2])).toMatch(/^\[TESZT\] /)
+  })
+})
+
+describe('every outbound sender carries the mark (source contract)', () => {
+  const read = (p: string) => readFileSync(new URL(p, import.meta.url), 'utf-8')
+
+  it.each([
+    ['../web/telegram.ts', ['sendTelegramMessage', 'sendTelegramPhoto']],
+    ['../channel-coordinator.ts', ['function sendAlert']],
+    ['../web/reauth-healer.ts', ['function sendNotify']],
+  ] as const)('%s marks its sender(s)', (file, fns) => {
+    const src = read(file)
+    for (const fn of fns) {
+      const idx = src.indexOf(fn)
+      expect(idx, `${fn} missing from ${file}`).toBeGreaterThan(-1)
+      const body = src.slice(idx, idx + 300)
+      expect(body, `${fn} in ${file} lacks the markTestRun() stamp`).toContain('markTestRun(')
+    }
+  })
+})

--- a/src/channel-coordinator.ts
+++ b/src/channel-coordinator.ts
@@ -32,6 +32,7 @@ import { homedir } from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { execFile } from 'node:child_process'
 import { logger } from './logger.js'
+import { markTestRun } from './notify.js'
 import { PROJECT_ROOT, MAIN_AGENT_ID, CHANNEL_PROVIDER, BOT_NAME } from './config.js'
 import { getUpdates, probeHighWater, mapUpdate, TelegramApiError } from './channel-coordinator/telegram-client.js'
 import { probeNativeChannelDown } from './channel-coordinator/liveness.js'
@@ -168,6 +169,7 @@ function releaseLock(): void {
 // uses the project's own token+chat). Used for fatal (401) only -- a 409 here
 // is the EXPECTED "native is back" signal, not an error worth alerting.
 function sendAlert(message: string): void {
+  message = markTestRun(message)
   const script = join(PROJECT_ROOT, 'scripts', 'notify.sh')
   execFile('/bin/bash', [script, message], { timeout: 10_000 }, (err) => {
     if (err) logger.warn({ err }, 'channel-coordinator: notify.sh alert failed')

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -2,7 +2,29 @@ import { CHANNEL_PROVIDER, CHANNEL_TOKEN, CHANNEL_CHAT_ID } from './config.js'
 import { getProvider } from './channel-provider.js'
 import { logger } from './logger.js'
 
+// Messages sent from a test run must be DISTINGUISHABLE, not suppressed
+// (owner decision, 2026-07-27): on a wired host the env holds a live bot token
+// and the owner's chat id, so a test-driven code path (e.g. the break-glass
+// audit suite) reaches the owner's phone. A real-looking fake security alert
+// trains the owner to ignore the real one -- so every outbound chokepoint
+// stamps a [TESZT] prefix instead. Kill-switch for long debug cycles: start
+// the run with the channel env emptied (CHANNEL_TOKEN= CHANNEL_CHAT_ID=),
+// which the existing token/chat guards already treat as "do not send".
+export function isTestRun(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.VITEST !== undefined || env.NODE_ENV === 'test'
+}
+
+export const TEST_RUN_PREFIX = '[TESZT] '
+
+// Idempotent: a message that crosses two chokepoints (build -> send) must not
+// end up with a stacked "[TESZT] [TESZT]".
+export function markTestRun(text: string, env: NodeJS.ProcessEnv = process.env): string {
+  if (!isTestRun(env) || text.startsWith(TEST_RUN_PREFIX)) return text
+  return TEST_RUN_PREFIX + text
+}
+
 export async function notifyChannel(text: string): Promise<void> {
+  text = markTestRun(text)
   if (!CHANNEL_TOKEN || !CHANNEL_CHAT_ID) {
     logger.warn('Channel ertesites kihagyva: token vagy chat ID hianyzik')
     return

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process'
 import { join } from 'node:path'
 import { logger } from '../logger.js'
+import { markTestRun } from '../notify.js'
 import { MAIN_AGENT_ID, PROJECT_ROOT, RESPAWN_ENABLED, APP_TZ } from '../config.js'
 import { resolveFromPath } from '../platform.js'
 import { listAgentNames } from './agent-config.js'
@@ -256,6 +257,7 @@ export function flushQuietSummary(
 }
 
 function sendNotify(msg: string): void {
+  msg = markTestRun(msg)
   execFile('/bin/bash', [NOTIFY_SCRIPT, msg], { timeout: 10_000 }, (err) => {
     if (err) logger.warn({ err }, 'reauth-healer: notify.sh escalation failed')
   })

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { PROJECT_ROOT, ALLOWED_CHAT_ID } from '../config.js'
 import { logger } from '../logger.js'
+import { markTestRun } from '../notify.js'
 import { agentDir, readFileOr, findAvatarForAgent } from './agent-config.js'
 import { TOOL_TIMEOUTS } from '../tool-timeouts.js'
 
@@ -109,6 +110,7 @@ export async function refreshMarveenBotUsername(): Promise<void> {
 }
 
 export async function sendTelegramMessage(token: string, chatId: string, text: string): Promise<void> {
+  text = markTestRun(text)
   const resp = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -126,6 +128,7 @@ export async function sendTelegramMessage(token: string, chatId: string, text: s
 }
 
 export async function sendTelegramPhoto(token: string, chatId: string, photoPath: string, caption: string): Promise<void> {
+  caption = markTestRun(caption)
   const fileData = readFileSync(photoPath)
   const boundary = '----FormBoundary' + Date.now()
   const parts: Buffer[] = []


### PR DESCRIPTION
## Mi tortent (P0)

A ma reggeli host-frissiteshez futtatott vitest tobbszor VALODI Telegram-riasztast kuldott a tulajdonosnak ("Break-glass jelszo-reset ... 'alice'"). Lanc: `src/__tests__/auth-recovery.test.ts` -> `POST /api/auth/password` (token-ag) -> `src/web/routes/auth.ts` `notifySecurityEvent(...)` -> `src/notify.ts`, ahol az EGYETLEN kapu a `CHANNEL_TOKEN`+`CHANNEL_CHAT_ID` meglete volt -- egy bekotott hoston ezek elesek.

Egy valodinak kinezo hamis biztonsagi riasztas pont azt a reflexet oli meg, amiert a break-glass ertesites keszult.

## Tulajdonosi dontes (2026-07-27)

NEM elnyomas, hanem megkulonboztethetoseg: teszt-uzenet mehet, de egyertelmuen jelolve.

## A valtozas

- `src/notify.ts`: `isTestRun()` (`VITEST` / `NODE_ENV=test`) + idempotens `markTestRun()` ami `[TESZT] ` prefixet uti a szovegre. A `notifyChannel` tetejen fut -- ez fedi a `notifySecurityEvent`-et es minden notify.ts-hivot (uj hivo automatikusan orokli).
- `src/web/telegram.ts`: prefix a `sendTelegramMessage` + `sendTelegramPhoto` (direkt Bot API ut) elejen.
- `src/channel-coordinator.ts` (`sendAlert`) es `src/web/reauth-healer.ts` (`sendNotify`): prefix a `notify.sh` exec elott.
- Kill-switch hosszu debug-ciklusra: `CHANNEL_TOKEN= CHANNEL_CHAT_ID= npx vitest run ...` -- a meglevo ures-config guardok ilyenkor egyaltalan nem kuldenek.
- Uj teszt: `src/__tests__/notify-test-guard.test.ts` -- egyseg (isTestRun/markTestRun + idempotencia), chokepoint-viselkedes (mockolt provider, prefixelt kuldes), es source-contract check hogy mind a 4 kulso sender hordozza a jelolest.
- `package-lock.json`: 2 soros legit sync (a lockfile `version` mezoje 1.19.0-n ragadt, package.json 1.23.1).

## Kimeno-ut audit (teljes src)

- `provider.sendMessage`-t kizarolag `src/notify.ts` hivja (chokepoint fedve).
- Direkt `api.telegram.org` send: csak `src/web/telegram.ts` (fedve); a tobbi elofordulas read-only (`getMe`, `getUpdates`).
- `notify.sh` exec: channel-coordinator + reauth-healer (mindketto fedve).
- Tesztbol meghajthato email/webhook kuldes src alatt: nincs.

## Teszt

- `tsc` OK.
- `CHANNEL_TOKEN= CHANNEL_CHAT_ID= npx vitest run --dir src`: 206 fajl, 2834 teszt, mind zold (az uj fajllal egyutt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
