### PR TITLE
feat(notify): [TESZT] label on test-run notifications (P0 3C266994)

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -59,6 +59,15 @@ if [ -n "$SENDER" ] && [ "$SENDER" != "$MAIN_AGENT_ID" ]; then
 ${MESSAGE}"
 fi
 
+# Test-run marker: a test runner (vitest exports VITEST to every child
+# process; NODE_ENV=test for other runners) that reaches this script sends a
+# REAL message with the production token read from .env -- so it must be
+# labelled, not suppressed (the owner wants proof the alert path works).
+# Mirrors src/test-run-marker.ts.
+if [ -n "${VITEST:-}" ] || [ "${NODE_ENV:-}" = "test" ]; then
+  MESSAGE="[TESZT] ${MESSAGE}"
+fi
+
 curl -s -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \
   -d "chat_id=${CHAT_ID}" \
   -d "text=${MESSAGE}" \

--- a/src/__tests__/test-run-marker.test.ts
+++ b/src/__tests__/test-run-marker.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Regression guard for 2026-07-27: the auth-recovery suite drove a REAL
+// break-glass alert to the owner, indistinguishable from production. The
+// requirement is labelling, not suppression: under a test runner every
+// outbound owner notification carries a leading [TESZT] marker; in production
+// it must NOT.
+
+// Wire a fake channel so notifyChannel actually sends (config reads env at
+// module load, and the work rule blanks CHANNEL_TOKEN/CHANNEL_CHAT_ID).
+vi.mock('../config.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../config.js')>()
+  return { ...real, CHANNEL_PROVIDER: 'telegram', CHANNEL_TOKEN: 'fake-token', CHANNEL_CHAT_ID: '42' }
+})
+
+const sent: string[] = []
+vi.mock('../channel-provider.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../channel-provider.js')>()
+  return {
+    ...real,
+    getProvider: () => ({
+      formatMessage: (t: string) => t,
+      splitMessage: (t: string) => [t],
+      sendMessage: async (_token: string, _chatId: string, text: string) => { sent.push(text) },
+    }),
+  }
+})
+
+import { markIfTestRun, TEST_RUN_PREFIX } from '../test-run-marker.js'
+import { notifyChannel, notifySecurityEvent } from '../notify.js'
+import { sendTelegramMessage } from '../web/telegram.js'
+
+const savedVitest = process.env['VITEST']
+const savedNodeEnv = process.env['NODE_ENV']
+
+function enterProductionEnv(): void {
+  delete process.env['VITEST']
+  delete process.env['NODE_ENV']
+}
+
+function restoreEnv(): void {
+  if (savedVitest === undefined) delete process.env['VITEST']
+  else process.env['VITEST'] = savedVitest
+  if (savedNodeEnv === undefined) delete process.env['NODE_ENV']
+  else process.env['NODE_ENV'] = savedNodeEnv
+}
+
+beforeEach(() => { sent.length = 0 })
+afterEach(() => { restoreEnv(); vi.unstubAllGlobals() })
+
+describe('markIfTestRun', () => {
+  it('prefixes under a test runner and is idempotent', () => {
+    expect(markIfTestRun('riasztas')).toBe(`${TEST_RUN_PREFIX}riasztas`)
+    expect(markIfTestRun(`${TEST_RUN_PREFIX}riasztas`)).toBe(`${TEST_RUN_PREFIX}riasztas`)
+  })
+
+  it('does not prefix in production (no VITEST, no NODE_ENV=test)', () => {
+    enterProductionEnv()
+    expect(markIfTestRun('riasztas')).toBe('riasztas')
+  })
+})
+
+describe('notifyChannel / notifySecurityEvent funnel', () => {
+  it('sends the message WITH the [TESZT] prefix under a test runner', async () => {
+    await notifyChannel('valami esemeny')
+    expect(sent).toEqual([`${TEST_RUN_PREFIX}valami esemeny`])
+  })
+
+  it('security events (break-glass reset path) are prefixed too', async () => {
+    await notifySecurityEvent('Break-glass jelszo-reset: "alice"')
+    expect(sent).toEqual([`${TEST_RUN_PREFIX}Break-glass jelszo-reset: "alice"`])
+  })
+
+  it('sends WITHOUT prefix in production', async () => {
+    enterProductionEnv()
+    await notifyChannel('eles riasztas')
+    expect(sent).toEqual(['eles riasztas'])
+  })
+})
+
+describe('getProvider wrapper (every provider send, not only notifyChannel)', () => {
+  // Uses the REAL getProvider (vi.importActual bypasses the mock above) with a
+  // stubbed fetch: agent-process / channel-monitor / agent routes all send
+  // through providers directly, so the marking must live at this level too.
+  it('marks provider.sendMessage under a test runner', async () => {
+    const real = await vi.importActual<typeof import('../channel-provider.js')>('../channel-provider.js')
+    const bodies: any[] = []
+    vi.stubGlobal('fetch', async (_url: string, init?: { body?: string }) => {
+      bodies.push(JSON.parse(init?.body ?? '{}'))
+      return { ok: true, json: async () => ({ ok: true }), text: async () => '' }
+    })
+    await real.getProvider('slack').sendMessage('fake-token', 'C123', 'provider szintu uzenet')
+    expect(bodies[0].text).toBe(`${TEST_RUN_PREFIX}provider szintu uzenet`)
+  })
+
+  it('does not mark provider.sendMessage in production', async () => {
+    enterProductionEnv()
+    const real = await vi.importActual<typeof import('../channel-provider.js')>('../channel-provider.js')
+    const bodies: any[] = []
+    vi.stubGlobal('fetch', async (_url: string, init?: { body?: string }) => {
+      bodies.push(JSON.parse(init?.body ?? '{}'))
+      return { ok: true, json: async () => ({ ok: true }), text: async () => '' }
+    })
+    await real.getProvider('slack').sendMessage('fake-token', 'C123', 'eles uzenet')
+    expect(bodies[0].text).toBe('eles uzenet')
+  })
+})
+
+describe('sendTelegramMessage direct Bot API funnel (schedule-runner path)', () => {
+  // This path reads its token from .env FILES, so blanking the channel env
+  // does not stop it -- the marker must be applied here independently.
+  function stubFetch(): { bodies: any[] } {
+    const captured: { bodies: any[] } = { bodies: [] }
+    vi.stubGlobal('fetch', async (_url: string, init?: { body?: string }) => {
+      captured.bodies.push(JSON.parse(init?.body ?? '{}'))
+      return { ok: true, text: async () => '' }
+    })
+    return captured
+  }
+
+  it('prefixes under a test runner', async () => {
+    const captured = stubFetch()
+    await sendTelegramMessage('fake-token', '42', 'scheduler riasztas')
+    expect(captured.bodies[0].text).toBe(`${TEST_RUN_PREFIX}scheduler riasztas`)
+  })
+
+  it('does not prefix in production', async () => {
+    enterProductionEnv()
+    const captured = stubFetch()
+    await sendTelegramMessage('fake-token', '42', 'scheduler riasztas')
+    expect(captured.bodies[0].text).toBe('scheduler riasztas')
+  })
+})

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { logger } from './logger.js'
 import { formatForTelegram, splitMessage } from './format.js'
+import { markIfTestRun } from './test-run-marker.js'
 
 export type ChannelProviderType = 'telegram' | 'slack' | 'discord' | 'googlechat' | 'teams'
 
@@ -481,8 +482,31 @@ const providers: Record<ChannelProviderType, ChannelProvider> = {
   teams: teamsProvider,
 }
 
+// Every provider send is routed through the test-run marker: getProvider has
+// many callers beyond notifyChannel (agent-process, channel-monitor, agent
+// routes), and any of them reached from a test run must label its outbound
+// message. markIfTestRun is a no-op in production and idempotent, so the
+// wrapper is safe to layer under callers that already mark.
+function withTestRunMarking(provider: ChannelProvider): ChannelProvider {
+  return {
+    ...provider,
+    sendMessage: (token, chatId, text, parseMode) =>
+      provider.sendMessage(token, chatId, markIfTestRun(text), parseMode),
+    sendPhoto: (token, chatId, photoPath, caption) =>
+      provider.sendPhoto(token, chatId, photoPath, markIfTestRun(caption)),
+  }
+}
+
+const markedProviders: Record<ChannelProviderType, ChannelProvider> = {
+  telegram: withTestRunMarking(telegramProvider),
+  slack: withTestRunMarking(slackProvider),
+  discord: withTestRunMarking(discordProvider),
+  googlechat: withTestRunMarking(googlechatProvider),
+  teams: withTestRunMarking(teamsProvider),
+}
+
 export function getProvider(type: ChannelProviderType): ChannelProvider {
-  return providers[type]
+  return markedProviders[type]
 }
 
 export function getProviderType(envValue: string | undefined): ChannelProviderType {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,6 +1,7 @@
 import { CHANNEL_PROVIDER, CHANNEL_TOKEN, CHANNEL_CHAT_ID } from './config.js'
 import { getProvider } from './channel-provider.js'
 import { logger } from './logger.js'
+import { markIfTestRun } from './test-run-marker.js'
 
 export async function notifyChannel(text: string): Promise<void> {
   if (!CHANNEL_TOKEN || !CHANNEL_CHAT_ID) {
@@ -8,8 +9,11 @@ export async function notifyChannel(text: string): Promise<void> {
     return
   }
 
+  // Marked here at the funnel, NOT at call sites -- a new caller must not be
+  // able to leak an unmarked message from a test run.
+  const outbound = markIfTestRun(text)
   const provider = getProvider(CHANNEL_PROVIDER)
-  const formatted = provider.formatMessage(text)
+  const formatted = provider.formatMessage(outbound)
   const chunks = provider.splitMessage(formatted)
 
   for (const chunk of chunks) {
@@ -18,7 +22,7 @@ export async function notifyChannel(text: string): Promise<void> {
       await provider.sendMessage(CHANNEL_TOKEN, CHANNEL_CHAT_ID, chunk, parseMode)
     } catch {
       try {
-        await provider.sendMessage(CHANNEL_TOKEN, CHANNEL_CHAT_ID, text.slice(0, 4096))
+        await provider.sendMessage(CHANNEL_TOKEN, CHANNEL_CHAT_ID, outbound.slice(0, 4096))
       } catch { /* last resort, give up */ }
     }
   }

--- a/src/test-run-marker.ts
+++ b/src/test-run-marker.ts
@@ -1,0 +1,27 @@
+// Outbound owner notifications fired from inside a test runner must stay
+// distinguishable from production alerts. The message still goes out -- the
+// owner explicitly wants to SEE that the real alert path works -- but it
+// carries a leading [TESZT] marker so a real alert is never mistaken for a
+// test one (2026-07-27: the auth-recovery suite's break-glass reset repeatedly
+// alerted the owner with a production-identical message).
+//
+// Detection: vitest exports VITEST to every worker process; NODE_ENV=test
+// covers other runners. Both propagate through child processes, so anything a
+// test spawns (including scripts/notify.sh, which mirrors this check) inherits
+// the marking.
+//
+// To fully SILENCE channel notifications during long debug loops, blank the
+// channel env instead of relying on this marker:
+//   CHANNEL_TOKEN= CHANNEL_CHAT_ID= npx vitest run <file>
+export const TEST_RUN_PREFIX = '[TESZT] '
+
+export function isTestRun(): boolean {
+  return process.env['VITEST'] !== undefined || process.env['NODE_ENV'] === 'test'
+}
+
+// Idempotent: senders may layer (notifyChannel -> provider -> Bot API), so a
+// message that already carries the marker is not marked twice.
+export function markIfTestRun(text: string): string {
+  if (!isTestRun() || text.startsWith(TEST_RUN_PREFIX)) return text
+  return TEST_RUN_PREFIX + text
+}

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -5,6 +5,7 @@ import { PROJECT_ROOT, ALLOWED_CHAT_ID } from '../config.js'
 import { logger } from '../logger.js'
 import { agentDir, readFileOr, findAvatarForAgent } from './agent-config.js'
 import { TOOL_TIMEOUTS } from '../tool-timeouts.js'
+import { markIfTestRun } from '../test-run-marker.js'
 
 export function readAgentTelegramConfig(name: string): { hasTelegram: boolean; botUsername?: string } {
   const envPath = join(agentDir(name), '.claude', 'channels', 'telegram', '.env')
@@ -109,10 +110,13 @@ export async function refreshMarveenBotUsername(): Promise<void> {
 }
 
 export async function sendTelegramMessage(token: string, chatId: string, text: string): Promise<void> {
+  // Test-run marking happens HERE too, not only in notifyChannel: this path
+  // reads its token from .env FILES (schedule-runner alerts), so blanking
+  // CHANNEL_TOKEN/CHANNEL_CHAT_ID in a test's environment does not stop it.
   const resp = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ chat_id: chatId, text }),
+    body: JSON.stringify({ chat_id: chatId, text: markIfTestRun(text) }),
     signal: AbortSignal.timeout(TOOL_TIMEOUTS['telegram']),
   })
   // fetch does not throw on 4xx -- a wrong chat_id or revoked token resolves
@@ -130,7 +134,7 @@ export async function sendTelegramPhoto(token: string, chatId: string, photoPath
   const boundary = '----FormBoundary' + Date.now()
   const parts: Buffer[] = []
   parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="chat_id"\r\n\r\n${chatId}\r\n`))
-  parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="caption"\r\n\r\n${caption}\r\n`))
+  parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="caption"\r\n\r\n${markIfTestRun(caption)}\r\n`))
   parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="photo"; filename="avatar.png"\r\nContent-Type: image/png\r\n\r\n`))
   parts.push(fileData)
   parts.push(Buffer.from(`\r\n--${boundary}--\r\n`))


### PR DESCRIPTION
## Problem

The test suite sent a REAL, production-identical security alert to the owner on every run (`auth-recovery.test.ts` alice reset -> `routes/auth.ts:287` -> `notifySecurityEvent`, which has no test guard).

Requirement (owner, 2026-07-27): do NOT suppress -- test messages may go out, but must be recognizably labelled, so the real alert path stays provable.

## Change

New `src/test-run-marker.ts`: `markIfTestRun()` prepends `[TESZT] ` when `VITEST` or `NODE_ENV=test` is set. Idempotent, no-op in production. Applied at every outbound funnel (never at call sites, so new callers can't leak unmarked):

1. `notifyChannel` in `src/notify.ts` -- covers `notifySecurityEvent` + all direct callers
2. `getProvider()` wrapper in `src/channel-provider.ts` -- covers agent-process, channel-monitor, agent routes (sendMessage + sendPhoto caption)
3. `sendTelegramMessage`/`sendTelegramPhoto` in `src/web/telegram.ts` -- the schedule-runner alerts read their token from .env FILES, so blanking channel env vars does not stop this path
4. `scripts/notify.sh` -- VITEST/NODE_ENV propagate to child processes; marker applied after sender attribution so `[TESZT]` is the first thing the reader sees

## Explicit off-switch for long debug loops

The existing env-blank remains the documented full-silence mechanism (no new flag added -- it works and is already in use):

```
CHANNEL_TOKEN= CHANNEL_CHAT_ID= npx vitest run <file>
```

Documented in `src/test-run-marker.ts`. Note it does NOT cover the schedule-runner file-read path -- which is exactly why funnel #3 exists.

## Audit of other outbound paths

- systemd/cron/hook scripts (`disk-space-guard.sh`, `host-restart-watchdog.sh`, `unit-fail-notify.sh`, `telegram_*.py` hooks): not reachable from a test run -- intentionally left unchanged
- `channel-coordinator` tests: stub `fetch`, no live sends
- No mailer/webhook sender in `src/` reachable from tests

## Tests

`src/__tests__/test-run-marker.test.ts` -- 9 cases: prefixed under a test runner / unprefixed in production for all three src funnels + idempotency. `tsc --noEmit` clean; `auth-recovery`, `approvals-notify`, `channel-provider` suites pass (run with blanked channel env per the work rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)