### PR TITLE
fix(dashboard): correct the token-usage cost table

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -13623,21 +13623,48 @@ let tuChartState = null
 
 // Model pricing in USD per million tokens (input / output / cache-write / cache-read).
 // Fallback row is used when model is unknown or not yet captured.
+// cache-write is 1.25x input, cache-read is 0.1x input -- keep the derived
+// columns consistent with `in` when editing a row.
+// Sonnet 5 launched on introductory pricing (2 / 10) that ends 2026-08-31;
+// the standard rate (3 / 15) applies from 2026-09-01. Resolved by date at load
+// time instead of pinned to one of the two, so the table neither understates
+// spend today nor silently overstates it the morning the intro rate expires.
+const TU_SONNET5_INTRO_END = Date.parse('2026-09-01T00:00:00Z')
+const TU_SONNET5_PRICE = Date.now() < TU_SONNET5_INTRO_END
+  ? { in: 2.0, out: 10.0, cw: 2.50, cr: 0.20 }
+  : { in: 3.0, out: 15.0, cw: 3.75, cr: 0.30 }
+
 const TU_MODEL_PRICING = {
+  // INFERRED, not from the published catalogue: Opus 5 is not listed in the
+  // model reference this table was checked against. The value follows the rest
+  // of the current Opus tier (4.6/4.7/4.8 at 5 / 25); treat it as an estimate
+  // until a published rate confirms it.
+  'claude-opus-5':       { in: 5.0,   out: 25.0,  cw: 6.25,  cr: 0.50 },
+  'claude-opus-4-8':     { in: 5.0,   out: 25.0,  cw: 6.25,  cr: 0.50 },
+  'claude-opus-4-7':     { in: 5.0,   out: 25.0,  cw: 6.25,  cr: 0.50 },
+  'claude-opus-4-6':     { in: 5.0,   out: 25.0,  cw: 6.25,  cr: 0.50 },
+  // Opus 4.0 / 4.1 -- the last generation still on the old Opus pricing.
+  'claude-opus-4':       { in: 15.0,  out: 75.0,  cw: 18.75, cr: 1.50 },
+  'claude-sonnet-5':     TU_SONNET5_PRICE,
   'claude-sonnet-4-6':   { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
   'claude-sonnet-4-5':   { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
-  'claude-sonnet-5':     { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
-  'claude-opus-4':       { in: 15.0,  out: 75.0,  cw: 18.75, cr: 1.50 },
-  'claude-opus-4-8':     { in: 15.0,  out: 75.0,  cw: 18.75, cr: 1.50 },
-  'claude-haiku-4-5':    { in: 0.80,  out: 4.0,   cw: 1.00,  cr: 0.08 },
-  'claude-fable-5':      { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
+  'claude-fable-5':      { in: 10.0,  out: 50.0,  cw: 12.50, cr: 1.00 },
+  'claude-mythos-5':     { in: 10.0,  out: 50.0,  cw: 12.50, cr: 1.00 },
+  'claude-haiku-4-5':    { in: 1.0,   out: 5.0,   cw: 1.25,  cr: 0.10 },
   default:               { in: 3.0,   out: 15.0,  cw: 3.75,  cr: 0.30 },
 }
 
+// Longest-prefix wins. A plain first-match loop is order-dependent and silently
+// wrong here: 'claude-opus-4-8' also startsWith 'claude-opus-4', so whichever
+// key the object happens to list first decides the price -- that is how Opus 4.8
+// was billed at the Opus 4.1 rate even once it had its own row.
 function tuPriceForModel(model) {
   if (!model) return TU_MODEL_PRICING.default
-  for (const key of Object.keys(TU_MODEL_PRICING)) {
-    if (key !== 'default' && model.startsWith(key)) return TU_MODEL_PRICING[key]
+  const keys = Object.keys(TU_MODEL_PRICING)
+    .filter((k) => k !== 'default')
+    .sort((a, b) => b.length - a.length)
+  for (const key of keys) {
+    if (model.startsWith(key)) return TU_MODEL_PRICING[key]
   }
   return TU_MODEL_PRICING.default
 }


### PR DESCRIPTION
Two spots assumed things about Claude model ids that stopped being true with Opus 5. Both fail **silently**, which is what makes them worth fixing.

## 1. Context guard treated Opus 5 as a 200k model

`contextLimitForModel()` inferred the window purely from the `[1m]` suffix, so anything without the tag fell through to 200k. Opus 5 is 1M by default *and* maximum, and carries no suffix.

The consequence is not cosmetic: the guard computes `pct` against a fifth of the real window, so a perfectly healthy session crosses the act threshold and gets a handoff request plus a forced restart it never needed. A restart discards the live working context, which costs far more than the check was protecting.

Replaced the suffix-only check with an explicit prefix list of the models that are 1M by default (Opus 5/4.8/4.7/4.6, Sonnet 5/4.6, Fable 5, Mythos 5). The `[1m]` suffix still works as an override for models where 200k is the default. Unknown ids stay conservative at 200k, and `calibrateLimit` steps them up on evidence exactly as before.

## 2. Cost table had no Opus 5 row, and prefix matching was order-dependent

`tuPriceForModel` returned the **first** key whose prefix matched. Since `claude-opus-4-8` also `startsWith('claude-opus-4')`, whichever key the object happened to list first decided the price — Opus 4.8 was billed at the Opus 4.1 rate (15/75 instead of 5/25).

Switched to longest-prefix-wins so the result no longer depends on object key order. Added the missing rows (Opus 5, 4.7, 4.6, Mythos 5) and corrected the stale ones: Opus 4.8 → 5/25, Fable 5 → 10/50, Haiku 4.5 → 1/5. Old-generation Opus 4.0/4.1 keeps 15/75.

Cache columns follow the usual derivation (write 1.25x input, read 0.1x input); noted in a comment so the columns stay consistent when a row is edited.

## Verification

- `src/__tests__/context-guard.test.ts` extended: suffix-free 1M models, case-insensitivity, dated and redundant-suffix variants, and that unknown ids still fall back to 200k. 38 tests pass.
- Pricing lookup checked against a table of ids including `claude-opus-4-8[1m]`, `claude-opus-5-fast` and `claude-opus-4-20250514`; the old-generation and unknown fallbacks still resolve correctly.
- Both changes have been running on a live Linux install since the fix was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)