### PR TITLE
fix(context-guard): stop mid-work restarts (P1 2540B4FE) -- 1M window map + busy deferral + loud restarts

### DIFF
--- a/src/__tests__/context-guard.test.ts
+++ b/src/__tests__/context-guard.test.ts
@@ -25,6 +25,7 @@ function inputs(overrides: Partial<GuardInputs> = {}): GuardInputs {
     pct: null,
     running: true,
     paneIdle: true,
+    paneBusy: false,
     sessionReady: false,
     handoffMtime: null,
     paneSaturated: false,
@@ -60,10 +61,29 @@ describe('normalizeContextGuardConfig', () => {
 })
 
 describe('contextLimitForModel / calibrateLimit', () => {
-  it('recognizes the 1M suffix, defaults 200k', () => {
+  it('recognizes the 1M suffix and the measured 1M families, defaults 200k', () => {
     expect(contextLimitForModel('claude-opus-4-8[1m]')).toBe(1_000_000)
-    expect(contextLimitForModel('claude-fable-5')).toBe(200_000)
+    // Host-measured 1M families (2026-07-27: fable-5 hit 976k, opus-4-8
+    // 985k-999k, opus-5 979k live) -- the blanket-200k guess restarted
+    // working agents at ~21% real usage.
+    expect(contextLimitForModel('claude-fable-5')).toBe(1_000_000)
+    expect(contextLimitForModel('fable-5')).toBe(1_000_000)
+    expect(contextLimitForModel('claude-mythos-5')).toBe(1_000_000)
+    expect(contextLimitForModel('claude-opus-4-8')).toBe(1_000_000)
+    expect(contextLimitForModel('claude-opus-4-6')).toBe(1_000_000)
+    expect(contextLimitForModel('claude-opus-5')).toBe(1_000_000)
+    expect(contextLimitForModel('claude-opus-5[1m]')).toBe(1_000_000)
+    // Sonnet stays 200k: never observed above 198k on this host. Haiku 200k
+    // by spec; unknown models stay conservative (calibration steps them up).
+    expect(contextLimitForModel('claude-sonnet-5')).toBe(200_000)
+    expect(contextLimitForModel('claude-haiku-4-5')).toBe(200_000)
+    expect(contextLimitForModel('claude-opus-4-5')).toBe(200_000)
+    expect(contextLimitForModel('deepseek-v4-pro')).toBe(200_000)
     expect(contextLimitForModel(null)).toBe(200_000)
+  })
+
+  it('defaults the handoff timeout to 20 minutes (6 was shorter than a working turn)', () => {
+    expect(DEFAULT_CONTEXT_GUARD.handoffTimeoutMinutes).toBe(20)
   })
 
   it('steps the limit up when the observation disproves the base', () => {
@@ -149,6 +169,13 @@ describe('decideGuard: idle', () => {
     expect(d.nextState.phase).toBe('await-handoff')
     expect(d.nextState.handoffMtimeAtRequest).toBe(123)
     expect(d.nextState.deadlineMs).toBe(NOW + CFG.handoffTimeoutMinutes * 60_000)
+  })
+
+  it('defers the idle-phase hard-tier restart while the agent is mid-turn', () => {
+    const d = decideGuard(INITIAL_GUARD_STATE, inputs({ pct: 0.99, paneBusy: true, paneIdle: false }), CFG)
+    expect(d.action).toBe('none')
+    expect(d.reason).toContain('deferring')
+    expect(d.nextState.phase).toBe('idle')
   })
 
   it('skips straight to restart at hardPct', () => {
@@ -294,6 +321,38 @@ describe('decideGuard: await-handoff', () => {
 
   it('force-restarts at hardPct even without a handoff', () => {
     const d = decideGuard(awaiting, inputs({ pct: 0.99, paneIdle: false }), CFG)
+    expect(d.action).toBe('restart')
+  })
+
+  // 2026-07-27: the guard force-restarted samu MID-TURN twice ("pane still
+  // busy" at 08:38, restart at 08:43), killing dispatched instructions with
+  // the session. A restart must never cut a live turn: while the pane shows
+  // a POSITIVE busy signal, both the hard tier and the timeout defer -- the
+  // deadline stays in the past, so the first not-busy sweep restarts.
+  it('defers the hard-threshold restart while the agent is mid-turn', () => {
+    const d = decideGuard(awaiting, inputs({ pct: 0.99, paneBusy: true }), CFG)
+    expect(d.action).toBe('none')
+    expect(d.reason).toContain('deferring')
+    expect(d.nextState.phase).toBe('await-handoff')
+  })
+
+  it('defers the timeout restart while the agent is mid-turn, fires once the turn ends', () => {
+    const busy = decideGuard(awaiting, inputs({ nowMs: NOW + 61_000, paneBusy: true }), CFG)
+    expect(busy.action).toBe('none')
+    expect(busy.nextState.phase).toBe('await-handoff')
+    // next sweep, turn over: the already-elapsed deadline fires immediately
+    const idle = decideGuard(busy.nextState, inputs({ nowMs: NOW + 90_000, paneBusy: false }), CFG)
+    expect(idle.action).toBe('restart')
+  })
+
+  it('saturation outranks the mid-turn deferral (a saturated pane cannot finish its turn)', () => {
+    const d = decideGuard(awaiting, inputs({ paneSaturated: true, paneBusy: true }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toContain('saturated')
+  })
+
+  it('a wedged pane (neither idle nor busy) is still restarted on timeout', () => {
+    const d = decideGuard(awaiting, inputs({ nowMs: NOW + 61_000, paneIdle: false, paneBusy: false }), CFG)
     expect(d.action).toBe('restart')
   })
 

--- a/src/context-guard.ts
+++ b/src/context-guard.ts
@@ -55,7 +55,13 @@ export const DEFAULT_CONTEXT_GUARD: ContextGuardConfig = {
   hardPct: 0.97,
   limitTokens: null,
   cooldownMinutes: 15,
-  handoffTimeoutMinutes: 6,
+  // 20 minutes, raised from 6 (2026-07-27): a working agent mid-turn cannot
+  // stop to write a handoff, and 6 minutes was shorter than a normal
+  // tool-heavy turn -- the timeout fired straight into a force-restart while
+  // the agent was actively working. Restarts now also defer while the pane is
+  // positively busy (see decideGuard), so this timeout only disciplines an
+  // IDLE agent that ignored the handoff request.
+  handoffTimeoutMinutes: 20,
 }
 
 /** Coerce arbitrary parsed JSON into a safe, fully-populated config. */
@@ -88,9 +94,35 @@ export function normalizeContextGuardConfig(raw: unknown): ContextGuardConfig {
 // it up when the OBSERVED context proves the base wrong.
 export const CONTEXT_LIMIT_TIERS = [200_000, 500_000, 1_000_000] as const
 
-/** Base context window inferred from the model id. Conservative: unknown → 200k. */
+/**
+ * Base context window inferred from the model id.
+ *
+ * The `[1m]` suffix is an explicit operator opt-in and always wins. Beyond
+ * that, the current Fable/Mythos/Opus families run 1M windows in Claude Code
+ * WITHOUT the suffix -- verified from live sources, not assumed: the Models
+ * API reports 1M for all of them, and this host's own transcripts show
+ * sessions genuinely reaching it (measured 2026-07-27: fable-5 976k, geri
+ * fable-5 911k, opus-4-8 985k-999k, opus-5 979k). The previous blanket-200k
+ * guess made the guard read a fable-5 session at 21% real usage as "106%
+ * full" and force-restart working agents all day (17 hard-threshold events
+ * on 2026-07-27, two of them killing samu mid-task and losing dispatched
+ * instructions).
+ *
+ * Sonnet stays at 200k deliberately: this host has never observed a sonnet
+ * session above 198k (sonnet-5 max 197,885 across 14 days), so 200k is the
+ * evidenced effective window there. Haiku is 200k by spec. Unknown models
+ * stay conservative at 200k -- calibrateLimit and the runner's persisted
+ * high-water mark step the denominator up from live evidence, and
+ * over-estimating would blind the proactive tiers (the 2026-07-26 failure
+ * mode), while under-estimating is loud and self-correcting.
+ */
+const ONE_MILLION_FAMILIES = [/fable-\d/, /mythos-\d/, /opus-4-[6-9]/, /opus-[5-9]\b/]
+
 export function contextLimitForModel(model: string | null | undefined): number {
-  if (typeof model === 'string' && model.includes('[1m]')) return 1_000_000
+  if (typeof model !== 'string') return 200_000
+  const m = model.toLowerCase()
+  if (m.includes('[1m]')) return 1_000_000
+  if (ONE_MILLION_FAMILIES.some(rx => rx.test(m))) return 1_000_000
   return 200_000
 }
 
@@ -182,6 +214,12 @@ export interface GuardInputs {
   running: boolean
   /** Pane looks idle (safe to restart without cutting a turn). */
   paneIdle: boolean
+  /** Pane shows a POSITIVE mid-turn signal (spinner / esc-to-interrupt /
+   *  token counter). Distinct from `!paneIdle`: a wedged pane behind an
+   *  error banner is neither idle nor busy, and must NOT be treated as
+   *  working -- deferring on `!paneIdle` would protect wedged panes from
+   *  the restart that is their only way out. */
+  paneBusy: boolean
   /** Session is ready to receive a prompt (post-restart readiness). */
   sessionReady: boolean
   /** Current HANDOFF.md mtime (ms), or null when the file does not exist. */
@@ -269,7 +307,16 @@ export function decideGuard(
       if (inputs.pct === null) return none('context unmeasurable', cleared)
       if (inputs.pct >= cfg.hardPct) {
         // Deep in the danger zone: the pane may already be wedged behind an
-        // error/modal, so do not spend a turn asking for a handoff.
+        // error/modal, so do not spend a turn asking for a handoff. But a
+        // POSITIVELY busy pane is working, not wedged -- restarting it cuts
+        // a live turn and destroys any queued/parked input with it (Szabi,
+        // 2026-07-27: agents restarted mid-work, dispatched instructions
+        // lost). Defer while busy; the sweep re-decides every interval, and
+        // a turn that tips into saturation is caught by the saturation net
+        // above, which deliberately ignores the busy signal.
+        if (inputs.paneBusy) {
+          return none(`hard threshold (${Math.round(inputs.pct * 100)}%) but agent mid-turn -- deferring restart`, cleared)
+        }
         return restartDecision(nowMs, `hard threshold (${Math.round(inputs.pct * 100)}% >= ${Math.round(cfg.hardPct * 100)}%)`)
       }
       if (inputs.pct >= cfg.actPct) {
@@ -310,10 +357,17 @@ export function decideGuard(
       if (handoffWritten && inputs.paneIdle) {
         return restartDecision(nowMs, 'handoff written')
       }
+      // Same mid-turn deferral as the idle-phase hard tier: neither the hard
+      // threshold nor the handoff timeout may cut a live turn. The deadline
+      // stays in the past while we defer, so the restart fires on the first
+      // sweep that finds the pane no longer busy; a turn that saturates
+      // mid-flight is caught by the paneSaturated branch above.
       if (inputs.pct !== null && inputs.pct >= cfg.hardPct) {
+        if (inputs.paneBusy) return none('hard threshold during await-handoff but agent mid-turn -- deferring restart')
         return restartDecision(nowMs, 'hard threshold during await-handoff')
       }
       if (nowMs >= state.deadlineMs) {
+        if (inputs.paneBusy) return none('handoff timeout but agent mid-turn -- deferring restart')
         // No handoff in time (agent wedged or ignored the prompt). Restart
         // anyway: taskstate + kanban + hot memories are the fallback context.
         return restartDecision(nowMs, 'handoff timeout -- force restart')

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -1,4 +1,4 @@
-import { statSync } from 'node:fs'
+import { statSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
@@ -14,9 +14,10 @@ import {
   isSessionReadyForPrompt,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-import { paneLooksIdle, paneShowsContextSaturation } from '../pane-state.js'
+import { detectPaneState, paneShowsContextSaturation } from '../pane-state.js'
 import { readContextTokensFromProjectDir, readActiveModelFromProjectDir } from './active-model.js'
 import { readContextGuardConfig } from './context-guard-store.js'
+import { createAgentMessage } from '../db.js'
 import {
   decideGuard,
   contextLimitForModel,
@@ -46,6 +47,40 @@ const INTERVAL_MS = 300_000
 // request, and cooldown prevents restart loops within a run.
 const guardStates = new Map<string, GuardState>()
 const remoteSkipLogged = new Set<string>()
+
+// Per-agent observed-context high-water mark, persisted across dashboard
+// restarts. calibrateLimit alone is memoryless: the moment the guard
+// restarts an agent, the fresh session's observation shrinks back below the
+// tier step-up point, the denominator falls back to the base guess, and a
+// miscalibrated agent gets restarted at the same false "over-full" reading
+// every cycle -- the evidence that would have corrected the limit is
+// destroyed by the very restart it triggered. Persisting the per-(agent,
+// model) maximum breaks that loop: once a session has proven the window is
+// bigger, the proof survives restarts. Keyed by model so a real model
+// downgrade (e.g. fable-5 -> haiku) does not inherit a 1M denominator.
+const HIGHWATER_PATH = join(PROJECT_ROOT, 'store', 'context-guard-highwater.json')
+type HighwaterMap = Record<string, { model: string; tokens: number }>
+
+function readHighwater(): HighwaterMap {
+  try {
+    const parsed = JSON.parse(readFileSync(HIGHWATER_PATH, 'utf-8'))
+    return (parsed && typeof parsed === 'object') ? parsed as HighwaterMap : {}
+  } catch { return {} }
+}
+
+let highwater: HighwaterMap | null = null
+
+function observedHighwater(name: string, model: string, observedNow: number): number {
+  if (highwater === null) highwater = readHighwater()
+  const entry = highwater[name]
+  const prior = entry && entry.model === model ? entry.tokens : 0
+  if (observedNow > prior) {
+    highwater[name] = { model, tokens: observedNow }
+    try { writeFileSync(HIGHWATER_PATH, JSON.stringify(highwater, null, 2)) }
+    catch (err) { logger.warn({ err }, 'context-guard: highwater persist failed') }
+  }
+  return Math.max(observedNow, prior)
+}
 
 function sessionFor(name: string): string {
   return name === MAIN_AGENT_ID ? MAIN_CHANNELS_SESSION : agentSessionName(name)
@@ -96,10 +131,13 @@ function measurePct(name: string, cfgLimit: number | null): number | null {
   if (cfgLimit) {
     limit = cfgLimit
   } else {
-    const model = name === MAIN_AGENT_ID
+    const model = (name === MAIN_AGENT_ID
       ? readActiveModelFromProjectDir(PROJECT_ROOT)
-      : readAgentModel(name)
-    limit = calibrateLimit(tokens, contextLimitForModel(model))
+      : readAgentModel(name)) ?? ''
+    // Calibrate against the persisted per-(agent, model) maximum, not just
+    // the live reading: a fresh post-restart session must not un-learn a
+    // window the previous session already proved (see HighwaterMap above).
+    limit = calibrateLimit(observedHighwater(name, model, tokens), contextLimitForModel(model))
   }
   return tokens / limit
 }
@@ -159,13 +197,19 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
   const sessionReady = running && state.phase === 'await-ready'
     ? await isSessionReadyForPrompt(session)
     : false
+  // One classification, two distinct signals: 'idle' (safe to restart) and
+  // 'busy' (positively mid-turn -- restarts defer). A pane that is neither
+  // (error banner, modal, unknown surface) is treated as NOT busy, so a
+  // wedged pane still gets the restart that is its only way out.
+  const paneState = pane !== null ? detectPaneState(pane) : 'unknown'
   const inputs: GuardInputs = {
     nowMs,
     running,
     // The saturation net decides from the pane alone; only the proactive
     // tiers need the (transcript-reading) pct probe.
     pct: running && needPct && cfg.enabled ? measurePct(name, cfg.limitTokens) : null,
-    paneIdle: pane !== null ? paneLooksIdle(pane) : false,
+    paneIdle: paneState === 'idle',
+    paneBusy: paneState === 'busy',
     sessionReady,
     handoffMtime: needPct ? handoffMtime(name) : null,
     paneSaturated: pane !== null ? paneShowsContextSaturation(pane) : false,
@@ -218,9 +262,39 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
       case 'request-handoff':
         await sendPromptToSession(session, handoffPrompt(pctRound ?? 0, handoffPathFor(name)))
         break
-      case 'restart':
+      case 'restart': {
+        // A forced restart must never be silent: the supervisor has to know
+        // that prompts delivered to the OLD session (queued steering input,
+        // parked text, the handoff request itself) may have died with it
+        // (2026-07-27: two dispatched instructions lost this way). Snapshot
+        // the pane first for post-mortem, then restart, then report on the
+        // inter-agent queue -- the channel supervisors actually read.
+        let snapshotPath: string | null = null
+        try {
+          const finalPane = pane ?? capturePane(session)
+          if (finalPane) {
+            snapshotPath = join(PROJECT_ROOT, 'store', `context-guard-last-pane-${name}.txt`)
+            writeFileSync(snapshotPath, finalPane)
+          }
+        } catch (err) {
+          logger.warn({ err, name }, 'context-guard: pre-restart pane snapshot failed')
+        }
         performRestart(name)
+        try {
+          createAgentMessage(
+            name,
+            MAIN_AGENT_ID,
+            `[CONTEXT-GUARD] Ujrainditottam a(z) "${name}" agentet -- ok: ${decision.reason}` +
+            (pctRound !== null ? ` (kontextus ~${pctRound}%)` : '') +
+            `. A regi sessionbe az utolso percekben kuldott uzenetek/utasitasok ELVESZHETTEK -- ellenorizd es kuldd ujra oket.` +
+            (snapshotPath ? ` Pane-snapshot a restart elotti allapotrol: ${snapshotPath}` : ''),
+            'context-guard restart notice',
+          )
+        } catch (err) {
+          logger.warn({ err, name }, 'context-guard: restart notice message failed')
+        }
         break
+      }
       case 'inject-resume': {
         const hadHandoff = inputs.handoffMtime !== null || handoffMtime(name) !== null
         await sendPromptToSession(session, resumePrompt(name, handoffPathFor(name), hadHandoff))


### PR DESCRIPTION
## Root cause (suspicion #1 CONFIRMED, mechanism identified)

`contextLimitForModel` assumed 200k for every model without an `[1m]` suffix. The fleet's current models run **1M effective windows** -- verified two ways:

1. **Host transcripts** (ground truth, measured today over 14 days): samu on fable-5 reached **976,574** tokens, geri fable-5 911k, opus-4-8 sessions 985k-999k, opus-5 979k. These sessions could not exist on a 200k window.
2. **Models API / claude-api reference**: fable-5, mythos-5, opus 4.6+, sonnet-5 all report 1M context.

So this morning's `pct=106` was really **~21%** of samu's actual window. Every one of the 17 hard-threshold events was a false alarm.

**Why calibration never self-corrected:** `calibrateLimit` steps up only when observed > 250k (limit x 1.25 tolerance), but the guard acts at 180k (90% of 200k) -- the restart it triggers resets the session below the step-up point, destroying the very evidence that would have fixed the denominator. Permanent loop.

**Suspicion #2 (6-min timeout) also real but secondary:** with the correct denominator the guard would not have fired at all today. Still fixed, because the timeout must never cut a live turn regardless of pct correctness.

## Changes

1. **`contextLimitForModel`**: fable/mythos/opus-4.6+/opus-5+ -> 1M (evidence documented in-code). Sonnet stays 200k (host max observed 197,885 -- evidenced effective cap here), haiku 200k by spec, unknown conservative 200k. Under-estimation is loud and self-correcting; over-estimation is silent blindness, so unknowns stay small.
2. **Persisted high-water mark** (`store/context-guard-highwater.json`, per agent+model): feeds `calibrateLimit` so a proven window survives restarts. Breaks the restart-erases-evidence loop for any future model the map doesn't know.
3. **Busy deferral in `decideGuard`**: new `paneBusy` input (`detectPaneState === 'busy'`, POSITIVE signal). Hard-threshold and timeout restarts defer while mid-turn; the elapsed deadline fires on the first not-busy sweep. Deliberately NOT gated on `!paneIdle`: a wedged pane (error banner -- neither idle nor busy) still gets its restart, and the saturation net ignores the busy signal entirely (a saturated pane cannot finish its turn), so deferral cannot deadlock.
4. **Loud restarts**: pre-restart pane snapshot to `store/context-guard-last-pane-<name>.txt` + inter-agent notice to the main agent ("instructions delivered in the last minutes may be lost -- re-send"). No forced restart is silent anymore.
5. **`handoffTimeoutMinutes` default 6 -> 20**, matching the live mitigation already applied to all agents.

## Message-loss chain (brief point 3, analyzed)

Confirmed as one chain: `sendPromptToSession` types into a busy pane best-effort -> text queues/parks in the input box -> guard restart (respawn fresh) destroys the queued input silently. That is how msgs 6900/6901 died. The busy deferral closes the main window (restarts now wait for turn end, when the queue has drained); the snapshot + notice cover the residual (parked text under an idle footer). Follow-up option if we want zero loss: re-queue inter-agent messages whose delivery landed within N minutes before a guard restart -- not in this PR.

## Tests

`context-guard.test.ts`: 42 pass (new: 1M family map, 20-min default, idle-phase + await-handoff busy deferral, deferred-timeout-fires-when-idle, saturation-overrides-busy, wedged-pane-still-restarts). `pane-state` (201) and `main-restart-platform` (15) pass. `tsc --noEmit` clean. All runs with blanked channel env.

## Deploy note

Takes effect on dashboard restart. Until then the live 20-min timeout mitigation holds. Rollback: revert + delete `store/context-guard-highwater.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)