### PR TITLE
feat(dashboard): menu restructure -- 1. lepes: Archivaltak gomb a Kanban fejlecben

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -16470,6 +16470,12 @@ async function openResearchDoc(agent, name) {
     boardBtn.addEventListener('click', activateBoard)
     ganttBtn.addEventListener('click', activateGantt)
 
+    // Archived button: navigates AWAY to the archived page (its sidebar entry
+    // was removed -- this button is now the entry point). It never takes the
+    // 'active' state here because leaving the kanban page hides the row.
+    const archivedBtn = document.getElementById('kanbanViewArchived')
+    if (archivedBtn) archivedBtn.addEventListener('click', () => switchPage('archived'))
+
     // Period buttons
     document.querySelectorAll('#kanbanGanttFilters [data-period]').forEach(btn => {
       btn.addEventListener('click', () => {

--- a/web/index.html
+++ b/web/index.html
@@ -76,10 +76,6 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="5" height="16" rx="1"/><rect x="10" y="4" width="5" height="10" rx="1"/><rect x="17" y="4" width="4" height="13" rx="1"/></svg>
         <span class="sb-label">Kanban</span>
       </a>
-      <a href="#" class="sb-link" data-page="archived">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5" rx="1"/><line x1="10" y1="12" x2="14" y2="12"/></svg>
-        <span class="sb-label">Archivált</span>
-      </a>
       <a href="#" class="sb-link" data-page="agents">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
         <span class="sb-label">Ügynökök</span>
@@ -255,6 +251,7 @@
       <div style="display:flex;align-items:center;gap:6px;margin-bottom:10px;">
         <button class="view-btn active" id="kanbanViewBoard" style="width:auto;padding:0 12px;" data-i18n="kanban.view.board">Tábla</button>
         <button class="view-btn" id="kanbanViewGantt" style="width:auto;padding:0 12px;" data-i18n="kanban.view.gantt">Idővonal</button>
+        <button class="view-btn" id="kanbanViewArchived" style="width:auto;padding:0 12px;margin-left:auto;" data-i18n="kanban.view.archived">Archiváltak</button>
       </div>
 
       <!-- Board-specific filter row (hidden when gantt active) -->

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1568,6 +1568,7 @@ window._i18n.en = {
   // --- Kanban Gantt/timeline view ---
   'kanban.view.board':              'Board',
   'kanban.view.gantt':              'Timeline',
+  'kanban.view.archived':           'Archived',
   'kanban.gantt.filter.period_week':    'This week',
   'kanban.gantt.filter.period_month':   'Month',
   'kanban.gantt.filter.period_quarter': 'Quarter',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1565,6 +1565,7 @@ window._i18n.hu = {
   // --- Kanban Gantt/idővonal nézet ---
   'kanban.view.board':              'Tábla',
   'kanban.view.gantt':              'Idővonal',
+  'kanban.view.archived':           'Archiváltak',
   'kanban.gantt.filter.period_week':    'Ezen hét',
   'kanban.gantt.filter.period_month':   'Hónap',
   'kanban.gantt.filter.period_quarter': 'Negyedév',


### PR DESCRIPTION
## Szabi kerese (szo szerint, 1. lepes)

> a Kanban-nal a 'Tabla' es 'idovonal' gombbal egy vonalba, de a jobb szelre rakd be az 'Archivaltak' gombot, es a menubol ezt vegyuk ki.

## Valtozas

1. Uj `kanbanViewArchived` gomb a nezetvalto sorban, `margin-left:auto`-val a jobb szelen (nincs uj sor/kontener).
2. Az oldalsav `data-page=archived` menupontja kikerult.
3. A gomb `switchPage('archived')`-et hiv -- a lap, a `loadArchivedPage()` es a kereso UI a menupont nelkul is mukodik.
4. Uj i18n kulcs: `kanban.view.archived` (hu: Archivaltak, en: Archived) -- mindket nyelvi fajlban.

## Bongeszo-verifikacio (kotelezo, megtortent)

Playwright route-override az elo origin ellen (worktree-UI minta, prod nem lett restartolva). Eredmenyek: sidebar-link eltunt; gomb lathato a sor jobb szelen a Tabla/Idovonal mellett; katt utan az archivedPage aktiv es a kereso UI el, a kanbanPage rejtett; vissza-ut az oldalsav Kanban linkjevel mukodik; HU 'Archivaltak' / EN 'Archived' felirat helyes; 0 page error. Em-dash a diffben: 0.

## Jelzes a PM-nek (nem javitottam, mert nem volt ra keres)

- Az Archivaltak lapon allva mostantol NINCS kiemelt oldalsav-menupont (eddig az Archivalt elem hordozta az active allapotot). A vissza-ut letezik (oldalsav Kanban), uj gombot szandekosan nem talaltam ki.
- Apro perem-eset: az archivalt lapon allva nyelvvaltasnal a lap TARTALMA csak uj navigacio utan render-elodik ujra (a setLang az aktiv sb-linkbol triggereli a page-re-rendert, ami itt nincs) -- a statikus feliratok (data-i18n sweep) viszont azonnal valtanak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)