### PR TITLE
feat(config): make the default agent model configurable (DEFAULT_AGENT_MODEL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # KANBAN_SWIMLANE_SEPARATOR_COLOR=#3d3d3a  # swimlane-ok közti szaggatott elválasztó színe
 # KANBAN_LABEL_COLORS=#3b82f6,#0ea5e9,#10b981,#14b8a6,#8b5cf6,#64748b  # kártya-címkék választható színpalettája
 # WEB_PORT=3420
+# Az új ügynökök alapértelmezett modellje + a háttér-worker sessionök modellje.
+# Meglévő ügynökök NEM változnak tőle (az agent-config.json-jukban lévő konkrét
+# modell marad). Újraindítás után lép életbe. Alapérték: claude-opus-4-8[1m]
+# DEFAULT_AGENT_MODEL=claude-opus-5
 # WEB_HOST=127.0.0.1       # FONTOS: 0.0.0.0-val a dashboard elérhető a hálózatról. Használj DASHBOARD_TOKEN-t!
 # OLLAMA_URL=http://localhost:11434
 # MARVEEN_ENV=linux-server  # platform override: macos | linux-server | linux-gui

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marveen",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src/__tests__/default-agent-model.test.ts
+++ b/src/__tests__/default-agent-model.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SETTINGS_REGISTRY,
+  getSettingDefinition,
+  validateSettingValue,
+  DISTRIBUTION_DEFAULT_AGENT_MODEL,
+} from '../config-registry.js'
+import { DEFAULT_AGENT_MODEL } from '../config.js'
+import { DEFAULT_MODEL, MODEL_ALIASES, resolveModelId } from '../web/agent-config.js'
+import { defaultChainForInstall } from '../web/model-fallback-store.js'
+import { DEFAULT_MODEL_CHAIN } from '../model-fallback.js'
+
+// Every assertion here is RELATIONAL, never "the default is <some model id>":
+// these tests run both on a fresh checkout (no .env -> distribution default)
+// and on a configured install (DEFAULT_AGENT_MODEL set -> that model), and must
+// pass in both.
+describe('DEFAULT_AGENT_MODEL', () => {
+  it('is registered as a restart-scoped, non-secret agents setting', () => {
+    const def = getSettingDefinition('DEFAULT_AGENT_MODEL')
+    expect(def).toBeDefined()
+    expect(def!.type).toBe('string')
+    expect(def!.module).toBe('agents')
+    expect(def!.secret).toBe(false)
+    // Consumed at import time by config.ts, so a change cannot hot-reload.
+    expect(def!.requiresRestart).toBe(true)
+    expect(SETTINGS_REGISTRY.filter((s) => s.key === 'DEFAULT_AGENT_MODEL')).toHaveLength(1)
+  })
+
+  it('keeps the registry default and the boot constant on one literal', () => {
+    // The whole point of DISTRIBUTION_DEFAULT_AGENT_MODEL living in the
+    // zero-import registry module: these two can never drift.
+    expect(getSettingDefinition('DEFAULT_AGENT_MODEL')!.default).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
+  })
+
+  it('offers the distribution default among the selectable values', () => {
+    const def = getSettingDefinition('DEFAULT_AGENT_MODEL')!
+    expect(def.valueSet).toBeDefined()
+    expect(def.valueSet).toContain(DISTRIBUTION_DEFAULT_AGENT_MODEL)
+    expect(def.valueSet).toContain('claude-opus-5')
+    // The worker drives the `claude` CLI, so only Claude ids are admissible.
+    expect(def.valueSet!.every((m) => m.startsWith('claude-'))).toBe(true)
+  })
+
+  it('validates against the value set', () => {
+    const def = getSettingDefinition('DEFAULT_AGENT_MODEL')!
+    expect(validateSettingValue(def, 'claude-opus-5')).toEqual({ ok: true, value: 'claude-opus-5' })
+    expect(validateSettingValue(def, 'gpt-4').ok).toBe(false)
+  })
+
+  it('resolves to the configured value, defaulting to the distribution literal', () => {
+    const def = getSettingDefinition('DEFAULT_AGENT_MODEL')!
+    // Either an operator set it (then it must be a selectable id), or it fell
+    // through to the distribution default.
+    expect(def.valueSet).toContain(DEFAULT_AGENT_MODEL)
+  })
+})
+
+describe('agent-config default wiring', () => {
+  it('re-exports the install default under the historical DEFAULT_MODEL name', () => {
+    expect(DEFAULT_MODEL).toBe(DEFAULT_AGENT_MODEL)
+  })
+
+  it("resolves the 'inherit' alias to the install default", () => {
+    expect(resolveModelId('inherit')).toBe(DEFAULT_AGENT_MODEL)
+  })
+
+  it("leaves the bare 'opus' alias pinned to 4.8", () => {
+    // Deliberate upstream decision (v1.23.2): raising the install default must
+    // not silently reconfigure agents whose config says the generic 'opus'.
+    expect(MODEL_ALIASES['opus']).toBe('claude-opus-4-8[1m]')
+    expect(resolveModelId('opus')).toBe('claude-opus-4-8[1m]')
+  })
+})
+
+describe('defaultChainForInstall', () => {
+  it('puts the install default first so a revert lands on the model actually run', () => {
+    expect(defaultChainForInstall()[0]).toBe(DEFAULT_AGENT_MODEL)
+  })
+
+  it('never repeats a model, even when the default is already on the ladder', () => {
+    const chain = defaultChainForInstall()
+    expect(new Set(chain).size).toBe(chain.length)
+  })
+
+  it('keeps a usable ladder: primary plus at least one downgrade target', () => {
+    const chain = defaultChainForInstall()
+    // normalizeModelFallbackConfig() ignores any chain shorter than 2.
+    expect(chain.length).toBeGreaterThanOrEqual(2)
+    // Every distribution rung except the promoted primary survives, in order.
+    expect(chain.slice(1)).toEqual(DEFAULT_MODEL_CHAIN.filter((m) => m !== DEFAULT_AGENT_MODEL))
+  })
+})

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -9,6 +9,12 @@
 // array is how a future setting becomes editable from the UI -- no route or
 // frontend change needed beyond what already reads the registry.
 
+// The model a fresh install runs when DEFAULT_AGENT_MODEL is unset. Kept here
+// (a zero-import module) so the registry default and the boot-time constant in
+// config.ts cannot drift apart -- bumping the distribution default is a
+// one-line change in exactly one place.
+export const DISTRIBUTION_DEFAULT_AGENT_MODEL = 'claude-opus-4-8[1m]'
+
 export type SettingType = 'int' | 'string' | 'color' | 'boolean'
 
 export interface SettingDefinition {
@@ -404,6 +410,23 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: false,
     requiresRestart: true,
     valueSet: ['Europe/London', 'Europe/Budapest', 'UTC', 'Europe/Dublin', 'Europe/Berlin', 'Europe/Bucharest', 'America/New_York'],
+  },
+  {
+    key: 'DEFAULT_AGENT_MODEL',
+    type: 'string',
+    default: DISTRIBUTION_DEFAULT_AGENT_MODEL,
+    description: 'Az új ügynökök alapértelmezett modellje, egyben a háttér-worker sessionök modellje. Meglévő ügynökök NEM változnak: akinek az agent-config.json-jában konkrét modell van, az marad. A módosítás a szolgáltatás újraindításakor lép életbe.',
+    module: 'agents',
+    secret: false,
+    requiresRestart: true,
+    valueSet: [
+      'claude-opus-5',
+      'claude-sonnet-5',
+      'claude-fable-5',
+      'claude-opus-4-8[1m]',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5-20251001',
+    ],
   },
 ]
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { readEnvFile } from './env.js'
+import { DISTRIBUTION_DEFAULT_AGENT_MODEL } from './config-registry.js'
 import { getProviderType, getChannelToken, getChannelChatId, type ChannelProviderType } from './channel-provider.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -47,6 +48,15 @@ function cfg(key: string): string | undefined {
 // 'Europe/Budapest' literals -- change the zone in ONE place, and an update that
 // re-introduces a hardcoded literal is caught by a single grep, not a full review.
 export const APP_TZ = cfg('SCHEDULER_TZ') || Intl.DateTimeFormat().resolvedOptions().timeZone
+
+// The model new agents are scaffolded with, and the model the background worker
+// sessions run. One key so an install that standardises on a newer model does
+// not have to patch three separate literals in src/ (which an update would then
+// clobber). Deliberately NOT applied to existing agents: agent-config.json keeps
+// whatever model it was created with, so raising this never silently
+// reconfigures a running fleet.
+export const DEFAULT_AGENT_MODEL =
+  cfg('DEFAULT_AGENT_MODEL') || DISTRIBUTION_DEFAULT_AGENT_MODEL
 
 export const TELEGRAM_BOT_TOKEN = env['TELEGRAM_BOT_TOKEN'] ?? ''
 export const ALLOWED_CHAT_ID = env['ALLOWED_CHAT_ID'] ?? ''

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -15,6 +15,8 @@ export const MODEL_ALIASES: Record<string, string> = {
   'sonnet': 'claude-sonnet-4-6',
   'sonnet-5': 'claude-sonnet-5',
   'sonnet5': 'claude-sonnet-5',
+  'opus-5': 'claude-opus-5',
+  'opus5': 'claude-opus-5',
   'haiku': 'claude-haiku-4-5-20251001',
   'inherit': DEFAULT_MODEL,
 }

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -1,13 +1,16 @@
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { PROJECT_ROOT, MAIN_AGENT_ID } from '../config.js'
+import { PROJECT_ROOT, MAIN_AGENT_ID, DEFAULT_AGENT_MODEL } from '../config.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { safeJoin } from './sanitize.js'
 
 export const AGENTS_BASE_DIR = join(PROJECT_ROOT, 'agents')
 
-export const DEFAULT_MODEL = 'claude-opus-4-8[1m]'
+// Install-wide default (DEFAULT_AGENT_MODEL: config-overrides.json > .env >
+// distribution default). Re-exported under the historical name so the many
+// call sites -- and the 'inherit' alias below -- keep working unchanged.
+export const DEFAULT_MODEL = DEFAULT_AGENT_MODEL
 
 // Map short model names to full Claude model IDs (backwards compat with old configs)
 export const MODEL_ALIASES: Record<string, string> = {

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -5,7 +5,7 @@ import { homedir, userInfo } from 'node:os'
 import { createHash } from 'node:crypto'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
-import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
+import { MAIN_AGENT_ID, PROJECT_ROOT, DEFAULT_AGENT_MODEL } from '../config.js'
 import {
   capturePane,
   isSessionReadyForPrompt,
@@ -42,7 +42,11 @@ import { notifyChannel } from '../notify.js'
 
 const TMUX = resolveFromPath('tmux')
 
-const WORKER_MODEL = process.env.MARVEEN_WORKER_MODEL || 'claude-opus-4-8[1m]'
+// MARVEEN_WORKER_MODEL stays a process-level escape hatch (systemd
+// `Environment=`), but the .env-backed DEFAULT_AGENT_MODEL is what an operator
+// can actually set: readEnvFile() returns a plain object and never populates
+// process.env, so a MARVEEN_WORKER_MODEL line in .env was silently ignored.
+const WORKER_MODEL = process.env.MARVEEN_WORKER_MODEL || DEFAULT_AGENT_MODEL
 
 // How long to wait for a freshly launched worker to reach an idle prompt.
 const WORKER_BOOT_TIMEOUT_MS = 90_000

--- a/src/web/model-fallback-store.ts
+++ b/src/web/model-fallback-store.ts
@@ -1,10 +1,11 @@
 import { join } from 'node:path'
 import { readFileSync } from 'node:fs'
-import { PROJECT_ROOT } from '../config.js'
+import { PROJECT_ROOT, DEFAULT_AGENT_MODEL } from '../config.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import {
   normalizeModelFallbackConfig,
   DEFAULT_MODEL_FALLBACK,
+  DEFAULT_MODEL_CHAIN,
   type ModelFallbackConfig,
 } from '../model-fallback.js'
 
@@ -13,13 +14,37 @@ import {
 // so an upgrade is inert until the operator turns it on from the dashboard.
 const STORE_PATH = join(PROJECT_ROOT, 'store', 'model-fallback.json')
 
+// chain[0] is what the runner reverts UP to, so it has to be the model this
+// install actually runs -- not the distribution literal in model-fallback.ts
+// (kept zero-import there so the decision logic stays trivially testable).
+// Without this, an install on a non-default DEFAULT_AGENT_MODEL would "revert"
+// onto a model it never ran. Filtered first so a default that already sits
+// further down the ladder cannot end up in the chain twice.
+export function defaultChainForInstall(): string[] {
+  return [DEFAULT_AGENT_MODEL, ...DEFAULT_MODEL_CHAIN.filter((m) => m !== DEFAULT_AGENT_MODEL)]
+}
+
+/** True when the stored JSON carries a chain normalize() would actually honour. */
+function hasExplicitChain(parsed: unknown): boolean {
+  const raw = (parsed && typeof parsed === 'object')
+    ? (parsed as Record<string, unknown>).chain
+    : undefined
+  if (!Array.isArray(raw)) return false
+  return raw.filter((m) => typeof m === 'string' && m.trim().length > 0).length >= 2
+}
+
 export function readModelFallbackConfig(): ModelFallbackConfig {
+  let parsed: unknown
   try {
-    const parsed = JSON.parse(readFileSync(STORE_PATH, 'utf-8'))
-    return normalizeModelFallbackConfig(parsed)
+    parsed = JSON.parse(readFileSync(STORE_PATH, 'utf-8'))
   } catch {
-    return { ...DEFAULT_MODEL_FALLBACK, chain: [...DEFAULT_MODEL_FALLBACK.chain] }
+    return { ...DEFAULT_MODEL_FALLBACK, chain: defaultChainForInstall() }
   }
+  const cfg = normalizeModelFallbackConfig(parsed)
+  // normalize() substitutes the module's literal chain whenever the stored one
+  // is missing or too short; swap in the install chain for exactly that case,
+  // so an operator-configured chain is still never overridden.
+  return hasExplicitChain(parsed) ? cfg : { ...cfg, chain: defaultChainForInstall() }
 }
 
 export function writeModelFallbackConfig(cfg: Partial<ModelFallbackConfig>): ModelFallbackConfig {

--- a/src/web/model-suggest.ts
+++ b/src/web/model-suggest.ts
@@ -6,6 +6,7 @@ export type ModelId =
   | 'claude-sonnet-4-6'
   | 'claude-sonnet-5'
   | 'claude-opus-4-8[1m]'
+  | 'claude-opus-5'
   | 'claude-fable-5'
   | string
 
@@ -65,6 +66,7 @@ const HAIKU_KEYWORDS = [
 // Approximate input-token cost in USD per 1M tokens (mid-2026 pricing).
 const MODEL_COST_PER_M: Record<string, number> = {
   'claude-opus-4-8': 15,
+  'claude-opus-5': 15,
   'claude-fable-5': 15,
   'claude-sonnet-5': 3,
   'claude-sonnet-4-6': 3,

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -467,8 +467,14 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   // Claude IDs are static. DeepSeek is gated behind a vault secret because
   // the agent-process launcher reads the key from there at start time --
   // surfacing the option in the UI without the key would let the operator
-  // pick a model that 401s on first prompt. The frontend renders this list
-  // both in the "new agent" wizard and the agent edit panel.
+  // pick a model that 401s on first prompt.
+  //
+  // NOTE: loadAvailableModels() in web/app.js consumes only `deepseek` and
+  // `openrouter` from this payload -- the Claude options are static <option>
+  // elements in web/index.html (wizard + edit panel). The `claude` array is
+  // therefore an API-only listing today; keep it in sync with those options so
+  // a client that does read it (or a future refactor that drops the static
+  // markup) does not silently offer a stale set.
   if (path === '/api/models/available' && method === 'GET') {
     const hasDeepseek = getSecret('DEEPSEEK_API_KEY') !== null
     // OpenRouter is gated behind the vault key, same as DeepSeek: surfacing the
@@ -477,8 +483,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const orCatalog = loadOpenRouterCatalog()
     json(res, {
       claude: [
-        { id: 'claude-fable-5', label: 'Fable 5 (legújabb)' },
-        { id: 'claude-opus-4-8[1m]', label: 'Opus 4.8 (1M kontextus, alapértelmezett)' },
+        { id: 'claude-opus-5', label: 'Opus 5 (legújabb Opus)' },
+        { id: 'claude-sonnet-5', label: 'Sonnet 5' },
+        { id: 'claude-fable-5', label: 'Fable 5' },
+        { id: 'claude-opus-4-8[1m]', label: 'Opus 4.8 (1M kontextus)' },
         { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
         { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5 (leggyorsabb)' },
       ],

--- a/web/index.html
+++ b/web/index.html
@@ -2117,6 +2117,7 @@
               <option value="inherit" data-i18n="agents.model.inherit">Öröklött (alapértelmezett)</option>
               <optgroup label="☁️ Claude (felhő)">
                 <option value="claude-fable-5" data-i18n="agents.model.fable5">Fable 5 (legújabb)</option>
+                <option value="claude-opus-5" data-i18n="agents.model.opus5">Opus 5 (legújabb Opus)</option>
                 <option value="claude-opus-4-8[1m]" data-i18n="agents.model.opus48">Opus 4.8 (1M kontextus, alapértelmezett)</option>
                 <option value="claude-sonnet-5" data-i18n="agents.model.sonnet5">Sonnet 5 (legújabb Sonnet, Opus-közeli)</option>
                 <option value="claude-sonnet-4-6" data-i18n="agents.model.sonnet46">Sonnet 4.6 (gyors és okos)</option>
@@ -2276,6 +2277,7 @@
             <select id="editAgentModel">
               <optgroup label="☁️ Claude (felhő)">
                 <option value="claude-fable-5" data-i18n="agents.model.fable5">Fable 5 (legújabb)</option>
+                <option value="claude-opus-5" data-i18n="agents.model.opus5">Opus 5 (legújabb Opus)</option>
                 <option value="claude-opus-4-8[1m]" data-i18n="agents.model.opus48">Opus 4.8 (1M kontextus, alapértelmezett)</option>
                 <option value="claude-sonnet-5" data-i18n="agents.model.sonnet5">Sonnet 5 (legújabb Sonnet, Opus-közeli)</option>
                 <option value="claude-sonnet-4-6" data-i18n="agents.model.sonnet46">Sonnet 4.6 (gyors és okos)</option>

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -946,6 +946,7 @@ window._i18n.en = {
   'agents.wizard.gen_hint':      'This may take a few seconds',
   'agents.model.inherit':        'Inherited (default)',
   'agents.model.fable5':         'Fable 5 (latest)',
+  'agents.model.opus5':          'Opus 5 (newest Opus)',
   'agents.model.opus48':         'Opus 4.8 (1M context, default)',
   'agents.model.sonnet5':        'Sonnet 5 (newest Sonnet, near-Opus)',
   'agents.model.sonnet46':       'Sonnet 4.6 (fast and smart)',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -370,6 +370,7 @@ window._i18n.hu = {
   'agents.wizard.gen_hint':      'Ez néhány másodpercig tarthat',
   'agents.model.inherit':        'Öröklött (alapértelmezett)',
   'agents.model.fable5':         'Fable 5 (legújabb)',
+  'agents.model.opus5':          'Opus 5 (legújabb Opus)',
   'agents.model.opus48':         'Opus 4.8 (1M kontextus, alapértelmezett)',
   'agents.model.sonnet5':        'Sonnet 5 (legújabb Sonnet, Opus-közeli)',
   'agents.model.sonnet46':       'Sonnet 4.6 (gyors és okos)',


### PR DESCRIPTION
## Miért

Az új ügynökök alapértelmezett modellje, a háttér-worker sessionök modellje, és a model-fallback lánc primary-je három külön hardcode-olt literál a `src/`-ben. Egy telepítés, ami újabb modellre áll (nálunk Opus 5), mindhármat patchelni kényszerül — és a következő `git pull` + build visszaírja mindet. A `dist/` felülíródik, a példány csendben visszaesik a régi modellre.

Ez a PR nem a disztribúció alapértékét mozdítja el (az marad `claude-opus-4-8[1m]`), hanem **konfigurálhatóvá teszi**.

## Mi változik

Egy új registry-kulcs, `DEFAULT_AGENT_MODEL`, a megszokott feloldással (`config-overrides.json` > `.env` > disztribúciós alapérték), három fogyasztóval:

| Fogyasztó | Mire hat |
|---|---|
| `agent-config.ts` `DEFAULT_MODEL` | új ügynökök + az `'inherit'` alias |
| `agent-worker.ts` `WORKER_MODEL` | a két háttér-worker session |
| `model-fallback-store.ts` `chain[0]` | amire egy revert visszakapaszkodik |

A disztribúciós alapérték egyetlen literálon él (`DISTRIBUTION_DEFAULT_AGENT_MODEL`, a zero-import `config-registry` modulban), így a registry default és a `config.ts` boot-konstans nem tud szétcsúszni.

## Amit szándékosan NEM csinál

Meglévő ügynököket nem konfigurál át. Akinek az `agent-config.json`-jában konkrét modell van, az marad; a csupasz `'opus'` alias pedig 4.8-on marad — ugyanaz az érvelés, mint 3743952-ben (*"General 'opus' alias left on 4.8 to avoid silently reconfiguring existing agents"*). A kulcs emelése sosem írhat át futó flottát.

## Két hiba, ami közben kijött

**1. A `.env`-ben lévő `MARVEEN_WORKER_MODEL` sor némán hatástalan volt.** A `readEnvFile()` sima objektumot ad vissza, a `process.env`-et nem tölti fel, a worker viszont `process.env.MARVEEN_WORKER_MODEL`-t olvas. Vagyis a dokumentáltnak tűnő env-kulcsot csak systemd `Environment=` sorral lehetett beállítani. Process-szintű escape hatch-ként megmarad, de az új kulcson át a `.env` most már tényleg működik.

**2. Nem-alapértelmezett modellen a fallback lánc rossz modellre kapaszkodott vissza.** A `chain[0]` a disztribúciós literál maradt, tehát egy revert olyan modellre állította volna az ügynököt, amit az a telepítés soha nem futtatott. A `defaultChainForInstall()` beülteti a primary-t, és kiszűri a maradék fokokból, hogy ne szerepelhessen kétszer. Operátor által beállított láncot továbbra sem ír felül — csak azt az esetet érinti, amikor a `normalize()` amúgy is a modul-literálra esne vissza.

A `model-fallback.ts` megtartja a literál láncát és az import-mentességét (hogy a döntési logika triviálisan tesztelhető maradjon); a telepítés-specifikus érték a store I/O-határán kerül be.

## A második commit

Külön, kisebb dolog: az `/api/models/available` `claude:` tömbje nem tartalmazta az Opus 5-öt — 3743952 a `web/index.html`-hez adta hozzá, ide nem. A két lista most egyezik (Opus 5 + Sonnet 5 felvéve).

Menet közben javítottam a fölötte lévő kommentet is: azt állította, hogy *"The frontend renders this list both in the new agent wizard and the agent edit panel"*, ami a `claude` tömbre nem igaz — a `loadAvailableModels()` (`web/app.js`) csak a `deepseek` és `openrouter` mezőket olvassa, a Claude-opciók statikus markup az `index.html`-ben. Nem kötöttem be dinamikusra (az nagyobb változás, mint egy elavult lista javítása), de a komment most megmondja, melyik melyik, hogy a következő olvasó ne higgye: elég egy helyen szerkeszteni.

## Teszt

`src/__tests__/default-agent-model.test.ts`, 11 teszt. Minden állítás **relációs**, sosem "az alapérték X" — így friss checkouton (nincs `.env`, disztribúciós alapérték) és beállított telepítésen is ugyanúgy lefut. Lefedi a registry-bejegyzés alakját, a default/boot-konstans egyezését, a valueSet-validációt, az `'inherit'` és `'opus'` alias-viselkedést, és a `defaultChainForInstall()` három invariánsát (primary elöl, nincs duplikátum, marad használható létra).

Teljes suite: **179 fájl / 2474 teszt zöld**, `tsc --noEmit` tiszta.

## Használat

```
# .env
DEFAULT_AGENT_MODEL=claude-opus-5
```

vagy a dashboard Beállítások lapján (module: `agents`, `requiresRestart: true`).