### PR TITLE
feat(dashboard): menu restructure -- 2. lepes C: vissza-gomb az Archivaltak oldalon

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -16051,6 +16051,10 @@ async function openResearchDoc(agent, name) {
       document.getElementById('archivedSearchBtn').addEventListener('click', doArchivedSearch)
       document.getElementById('archivedRefreshBtn').addEventListener('click', doArchivedSearch)
       document.getElementById('archivedQ').addEventListener('keydown', e => { if (e.key === 'Enter') doArchivedSearch() })
+      // Back button mirrors the kanban row's Archivaltak entry point; explicit
+      // switchPage (not history.back) so it works on direct-link arrivals too.
+      const backBtn = document.getElementById('archivedBackToKanban')
+      if (backBtn) backBtn.addEventListener('click', () => switchPage('kanban'))
       const adOverlay = document.getElementById('archivedDetailOverlay')
       document.getElementById('archivedDetailClose').addEventListener('click', () => closeModal(adOverlay))
       adOverlay.addEventListener('click', e => { if (e.target === adOverlay) closeModal(adOverlay) })

--- a/web/index.html
+++ b/web/index.html
@@ -330,6 +330,10 @@
 
     <!-- === Archived Cards Page === -->
     <div class="page" id="archivedPage" hidden>
+      <!-- View switcher row (mirrors the kanban page's row that leads here) -->
+      <div style="display:flex;align-items:center;gap:6px;margin-bottom:10px;">
+        <button class="view-btn" id="archivedBackToKanban" style="width:auto;padding:0 12px;" data-i18n="archived.backToKanban">Vissza a Kanbanra</button>
+      </div>
       <div class="page-header" style="margin-bottom:16px;">
         <h2 style="margin:0;font-size:18px;" data-i18n="archived.page_title">Archivált kártyák</h2>
       </div>

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -262,6 +262,7 @@ window._i18n.en = {
   'kanban.status.waiting_short': 'Wait',
 
   // --- Archived cards ---
+  'archived.backToKanban':       'Back to Kanban',
   'archived.page_title':         'Archived cards',
   'archived.search_placeholder': 'Search (title, project, assignee)...',
   'archived.filter.all_projects': 'All projects',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -262,6 +262,7 @@ window._i18n.hu = {
   'kanban.status.waiting_short': 'Vár',
 
   // --- Archived cards ---
+  'archived.backToKanban':       'Vissza a Kanbanra',
   'archived.page_title':         'Archivált kártyák',
   'archived.search_placeholder': 'Keresés (cím, projekt, felelős)...',
   'archived.filter.all_projects': 'Minden projekt',


### PR DESCRIPTION
Szabi kerese: az Archivaltak oldalrol legyen visszalepes a Kanbanra. Sorozat-kartya: 6395A8CC, kartya: D02FB069.

## Valtozasok

- `web/index.html`: view-switcher sor az `archivedPage` tetejen (az 1. lepes kanban-sor mintaja), benne egy `view-btn` stilusu gomb (`archivedBackToKanban`), `data-i18n="archived.backToKanban"`.
- `web/app.js`: bekotes a `loadArchivedPage()` `archivedInit` agaban, `switchPage('kanban')` hivassal (NEM history.back, igy kozvetlen linkkel/frissitessel erkezonel is mukodik).
- `web/lang/hu.js` + `web/lang/en.js`: `archived.backToKanban` = "Vissza a Kanbanra" / "Back to Kanban".

Scope: csak az archivedPage regio + a lang-fajlok archived-blokkja (Geri sidebar-regiojat nem erinti).

## Bongeszo-teszt (elo origin :3420 + route-override a worktree fajlokkal, headless chromium)

- PASS gomb lathato az Archivaltak oldalon, a lap tetejen
- PASS view-btn stilus (class=view-btn)
- PASS HU felirat: "Vissza a Kanbanra"
- PASS a gomb-sor az archivedPage elso eleme
- PASS katt -> kanbanPage aktiv
- PASS katt -> archivedPage rejtett
- PASS kozvetlen erkezes (reload utan rogton switchPage('archived')): gomb lathato
- PASS kozvetlen erkezes: katt mukodik
- PASS setLang('en') -> felirat "Back to Kanban"
- PASS pageerror lista ures

`node --check` OK mindharom JS-fajlra; em-dash a diffben: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)