### PR TITLE
feat(dashboard): menu restructure -- 2. lepes A+B: oldalsav-csoportok

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -426,11 +426,34 @@ navLinks.forEach((link) => {
 // array of open group keys. Missing or corrupt state means everything starts
 // collapsed -- that is the designed default, not an error.
 const SIDEBAR_GROUPS_LS_KEY = 'marveen.sidebarGroups'
+// Declarative single source of truth for the group -> pages mapping. The markup
+// order is only the default snapshot: at boot the static links are re-parented
+// into their group containers per this map, so regrouping a page (say, moving
+// naplo under system) or relabeling a group is a one-line change right here.
+const SIDEBAR_GROUPS = [
+  { key: 'team',        labelKey: 'nav.group.team',        pages: ['agents', 'activity', 'messages', 'tasks', 'bgTasks'] },
+  { key: 'knowledge',   labelKey: 'nav.group.knowledge',   pages: ['memories', 'naplo', 'skills', 'research', 'ideas'] },
+  { key: 'stats',       labelKey: 'nav.group.stats',       pages: ['costs', 'tokenUsage'] },
+  { key: 'system',      labelKey: 'nav.group.system',      pages: ['status', 'updates', 'settings', 'vault'] },
+  { key: 'connections', labelKey: 'nav.group.connections', pages: ['connectors', 'federation', 'migrate'] },
+]
 const sidebarGroupEls = document.querySelectorAll('.sb-group[data-group]')
-// data-page -> group key, derived from the markup so the two never drift.
+// data-page -> group key, derived from the map (not the DOM) so the map wins.
 const PAGE_SIDEBAR_GROUP = {}
-sidebarGroupEls.forEach((g) => {
-  g.querySelectorAll('.sb-link[data-page]').forEach((l) => { PAGE_SIDEBAR_GROUP[l.dataset.page] = g.dataset.group })
+SIDEBAR_GROUPS.forEach((def) => def.pages.forEach((p) => { PAGE_SIDEBAR_GROUP[p] = def.key }))
+// Re-parent the 23 static links to match the map. Moving an existing DOM node
+// does not invalidate the navLinks refs captured by querySelectorAll at boot.
+SIDEBAR_GROUPS.forEach((def) => {
+  const group = document.querySelector(`.sb-group[data-group="${def.key}"]`)
+  if (!group) return
+  const label = group.querySelector('.sb-group-label')
+  if (label) label.dataset.i18n = def.labelKey
+  const items = group.querySelector('.sb-group-items')
+  if (!items) return
+  def.pages.forEach((p) => {
+    const link = document.querySelector(`.sb-link[data-page="${p}"]`)
+    if (link) items.appendChild(link)
+  })
 })
 
 function loadSidebarGroupState() {

--- a/web/app.js
+++ b/web/app.js
@@ -481,7 +481,10 @@ function openSidebarGroupForPage(pageId) {
   const key = PAGE_SIDEBAR_GROUP[pageId]
   if (!key) return
   sidebarGroupEls.forEach((g) => {
-    if (g.dataset.group === key && !g.classList.contains('open')) setSidebarGroupOpen(g, true)
+    // persist=false: only user clicks may be remembered. Persisting the
+    // auto-open would let everyday navigation accumulate all 5 groups as
+    // saved-open and quietly bring back the flat 23-item menu.
+    if (g.dataset.group === key && !g.classList.contains('open')) setSidebarGroupOpen(g, true, false)
   })
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -357,6 +357,7 @@ function switchPage(pageId) {
   if (!document.getElementById('settingsPage').hidden && pageId !== 'settings' && !confirmSettingsLeave()) return
   pages.forEach((p) => (p.hidden = p.id !== pageId + 'Page'))
   navLinks.forEach((l) => l.classList.toggle('active', l.dataset.page === pageId))
+  openSidebarGroupForPage(pageId)
   // Kanban needs full-width layout (overrides main's max-width: 1200px)
   document.querySelector('main').classList.toggle('kanban-active', pageId === 'kanban')
   // Activity page runs a live poll; stop it whenever we navigate away.
@@ -418,6 +419,56 @@ navLinks.forEach((link) => {
     else location.hash = pageId
     setSidebarOpen(false) // close the drawer after navigating on mobile
   })
+})
+
+// === Collapsible sidebar groups ===
+// Open/closed state lives in localStorage (marveen.sidebarGroups) as a JSON
+// array of open group keys. Missing or corrupt state means everything starts
+// collapsed -- that is the designed default, not an error.
+const SIDEBAR_GROUPS_LS_KEY = 'marveen.sidebarGroups'
+const sidebarGroupEls = document.querySelectorAll('.sb-group[data-group]')
+// data-page -> group key, derived from the markup so the two never drift.
+const PAGE_SIDEBAR_GROUP = {}
+sidebarGroupEls.forEach((g) => {
+  g.querySelectorAll('.sb-link[data-page]').forEach((l) => { PAGE_SIDEBAR_GROUP[l.dataset.page] = g.dataset.group })
+})
+
+function loadSidebarGroupState() {
+  try {
+    const arr = JSON.parse(localStorage.getItem(SIDEBAR_GROUPS_LS_KEY))
+    return Array.isArray(arr) ? arr.filter((k) => typeof k === 'string') : []
+  } catch { return [] }
+}
+
+function setSidebarGroupOpen(groupEl, open, persist = true) {
+  groupEl.classList.toggle('open', open)
+  const btn = groupEl.querySelector('.sb-group-header')
+  if (btn) btn.setAttribute('aria-expanded', open ? 'true' : 'false')
+  if (persist) {
+    const key = groupEl.dataset.group
+    const state = loadSidebarGroupState().filter((k) => k !== key)
+    if (open) state.push(key)
+    try { localStorage.setItem(SIDEBAR_GROUPS_LS_KEY, JSON.stringify(state)) } catch {}
+  }
+}
+
+// Called from switchPage: the active page's group must always be visible so the
+// "where am I" highlight is never hidden inside a collapsed group.
+function openSidebarGroupForPage(pageId) {
+  const key = PAGE_SIDEBAR_GROUP[pageId]
+  if (!key) return
+  sidebarGroupEls.forEach((g) => {
+    if (g.dataset.group === key && !g.classList.contains('open')) setSidebarGroupOpen(g, true)
+  })
+}
+
+{
+  const openKeys = loadSidebarGroupState()
+  sidebarGroupEls.forEach((g) => setSidebarGroupOpen(g, openKeys.includes(g.dataset.group), false))
+}
+sidebarGroupEls.forEach((g) => {
+  const btn = g.querySelector('.sb-group-header')
+  if (btn) btn.addEventListener('click', () => setSidebarGroupOpen(g, !g.classList.contains('open')))
 })
 
 

--- a/web/index.html
+++ b/web/index.html
@@ -76,91 +76,131 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="5" height="16" rx="1"/><rect x="10" y="4" width="5" height="10" rx="1"/><rect x="17" y="4" width="4" height="13" rx="1"/></svg>
         <span class="sb-label">Kanban</span>
       </a>
-      <a href="#" class="sb-link" data-page="agents">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-        <span class="sb-label">Ügynökök</span>
-      </a>
-      <a href="#" class="sb-link" data-page="activity">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14"/></svg>
-        <span class="sb-label">Aktivitás</span>
-      </a>
-      <a href="#" class="sb-link" data-page="messages">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-        <span class="sb-label">Üzenetek</span>
-      </a>
-      <a href="#" class="sb-link" data-page="tasks">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
-        <span class="sb-label">Ütemezések</span>
-      </a>
-      <a href="#" class="sb-link" data-page="memories">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3C7.5 3 4 6.5 4 11v4l-2 3h4v2a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v0a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v-2h4l-2-3v-4c0-4.5-3.5-8-8-8z"/></svg>
-        <span class="sb-label">Memória</span>
-      </a>
-      <a href="#" class="sb-link" data-page="naplo">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-        <span class="sb-label">Napló</span>
-      </a>
-      <a href="#" class="sb-link" data-page="bgTasks">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
-        <span class="sb-label">Háttér</span>
-      </a>
-      <a href="#" class="sb-link" data-page="skills">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15 8.5 22 9.3 17 14.2 18.2 21 12 17.8 5.8 21 7 14.2 2 9.3 9 8.5"/></svg>
-        <span class="sb-label">Skillek</span>
-      </a>
-      <a href="#" class="sb-link" data-page="connectors">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>
-        <span class="sb-label">MCP</span>
-      </a>
-      <a href="#" class="sb-link" data-page="migrate">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/><polyline points="7 10 12 5 17 10"/><line x1="12" y1="5" x2="12" y2="17"/></svg>
-        <span class="sb-label">Költöztetés</span>
-      </a>
-      <a href="#" class="sb-link" data-page="docs">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
-        <span class="sb-label">Dokumentáció</span>
-      </a>
-      <a href="#" class="sb-link" data-page="research">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-        <span class="sb-label" data-i18n="nav.research">Kutatás</span>
-      </a>
-      <a href="#" class="sb-link" data-page="status">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-        <span class="sb-label">Státusz</span>
-      </a>
       <a href="#" class="sb-link" data-page="approvals">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
         <span class="sb-label">Jóváhagyások</span>
         <span class="approvals-pending-badge sb-badge" id="approvalsPendingBadge" hidden></span>
       </a>
-      <a href="#" class="sb-link" data-page="settings">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-        <span class="sb-label">Beállítások</span>
-      </a>
-      <a href="#" class="sb-link" data-page="vault">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/><circle cx="12" cy="16" r="1"/></svg>
-        <span class="sb-label">Vault</span>
-      </a>
-      <a href="#" class="sb-link" data-page="tokenUsage">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20V10"/><path d="M18 20V4"/><path d="M6 20v-4"/></svg>
-        <span class="sb-label">Token Monitor</span>
-      </a>
-      <a href="#" class="sb-link" data-page="costs">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
-        <span class="sb-label">Költségek</span>
-      </a>
-      <a href="#" class="sb-link" data-page="ideas">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4"/><path d="M12 16h.01"/></svg>
-        <span class="sb-label">Ötletláda</span>
-      </a>
-      <a href="#" class="sb-link" data-page="federation">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="12" r="3"/><circle cx="19" cy="12" r="3"/><path d="M8 12h8"/><path d="M12 9v-3"/><path d="M12 15v3"/></svg>
-        <span class="sb-label">Föderáció</span>
-      </a>
-      <a href="#" class="sb-link" data-page="updates">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
-        <span class="sb-label">Frissítések</span>
-        <span class="updates-badge sb-badge" id="updatesBadge" hidden></span>
+      <div class="sb-group" data-group="team">
+        <button type="button" class="sb-group-header" aria-expanded="false" aria-controls="sbGroupTeam">
+          <span class="sb-group-label" data-i18n="nav.group.team">CSAPAT</span>
+          <svg class="sb-group-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+        <div class="sb-group-items" id="sbGroupTeam">
+          <a href="#" class="sb-link" data-page="agents">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+            <span class="sb-label">Ügynökök</span>
+          </a>
+          <a href="#" class="sb-link" data-page="activity">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 0 1 0 8.49M7.76 16.24a6 6 0 0 1 0-8.49M19.07 4.93a10 10 0 0 1 0 14.14M4.93 19.07a10 10 0 0 1 0-14.14"/></svg>
+            <span class="sb-label">Aktivitás</span>
+          </a>
+          <a href="#" class="sb-link" data-page="messages">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+            <span class="sb-label">Üzenetek</span>
+          </a>
+          <a href="#" class="sb-link" data-page="tasks">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+            <span class="sb-label">Ütemezések</span>
+          </a>
+          <a href="#" class="sb-link" data-page="bgTasks">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            <span class="sb-label">Háttér</span>
+          </a>
+        </div>
+      </div>
+      <div class="sb-group" data-group="knowledge">
+        <button type="button" class="sb-group-header" aria-expanded="false" aria-controls="sbGroupKnowledge">
+          <span class="sb-group-label" data-i18n="nav.group.knowledge">TUDÁS</span>
+          <svg class="sb-group-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+        <div class="sb-group-items" id="sbGroupKnowledge">
+          <a href="#" class="sb-link" data-page="memories">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3C7.5 3 4 6.5 4 11v4l-2 3h4v2a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v0a3 3 0 0 0 3 3h1a3 3 0 0 0 3-3v-2h4l-2-3v-4c0-4.5-3.5-8-8-8z"/></svg>
+            <span class="sb-label">Memória</span>
+          </a>
+          <a href="#" class="sb-link" data-page="naplo">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+            <span class="sb-label">Napló</span>
+          </a>
+          <a href="#" class="sb-link" data-page="skills">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15 8.5 22 9.3 17 14.2 18.2 21 12 17.8 5.8 21 7 14.2 2 9.3 9 8.5"/></svg>
+            <span class="sb-label">Skillek</span>
+          </a>
+          <a href="#" class="sb-link" data-page="research">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <span class="sb-label" data-i18n="nav.research">Kutatás</span>
+          </a>
+          <a href="#" class="sb-link" data-page="ideas">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4"/><path d="M12 16h.01"/></svg>
+            <span class="sb-label">Ötletláda</span>
+          </a>
+        </div>
+      </div>
+      <div class="sb-group" data-group="stats">
+        <button type="button" class="sb-group-header" aria-expanded="false" aria-controls="sbGroupStats">
+          <span class="sb-group-label" data-i18n="nav.group.stats">STATISZTIKÁK</span>
+          <svg class="sb-group-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+        <div class="sb-group-items" id="sbGroupStats">
+          <a href="#" class="sb-link" data-page="costs">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+            <span class="sb-label">Költségek</span>
+          </a>
+          <a href="#" class="sb-link" data-page="tokenUsage">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20V10"/><path d="M18 20V4"/><path d="M6 20v-4"/></svg>
+            <span class="sb-label">Token Monitor</span>
+          </a>
+        </div>
+      </div>
+      <div class="sb-group" data-group="system">
+        <button type="button" class="sb-group-header" aria-expanded="false" aria-controls="sbGroupSystem">
+          <span class="sb-group-label" data-i18n="nav.group.system">RENDSZER</span>
+          <svg class="sb-group-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+        <div class="sb-group-items" id="sbGroupSystem">
+          <a href="#" class="sb-link" data-page="status">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+            <span class="sb-label">Státusz</span>
+          </a>
+          <a href="#" class="sb-link" data-page="updates">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+            <span class="sb-label">Frissítések</span>
+            <span class="updates-badge sb-badge" id="updatesBadge" hidden></span>
+          </a>
+          <a href="#" class="sb-link" data-page="settings">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+            <span class="sb-label">Beállítások</span>
+          </a>
+          <a href="#" class="sb-link" data-page="vault">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/><circle cx="12" cy="16" r="1"/></svg>
+            <span class="sb-label">Vault</span>
+          </a>
+        </div>
+      </div>
+      <div class="sb-group" data-group="connections">
+        <button type="button" class="sb-group-header" aria-expanded="false" aria-controls="sbGroupConnections">
+          <span class="sb-group-label" data-i18n="nav.group.connections">KAPCSOLATOK</span>
+          <svg class="sb-group-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+        <div class="sb-group-items" id="sbGroupConnections">
+          <a href="#" class="sb-link" data-page="connectors">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>
+            <span class="sb-label">MCP</span>
+          </a>
+          <a href="#" class="sb-link" data-page="federation">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="12" r="3"/><circle cx="19" cy="12" r="3"/><path d="M8 12h8"/><path d="M12 9v-3"/><path d="M12 15v3"/></svg>
+            <span class="sb-label">Föderáció</span>
+          </a>
+          <a href="#" class="sb-link" data-page="migrate">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/><polyline points="7 10 12 5 17 10"/><line x1="12" y1="5" x2="12" y2="17"/></svg>
+            <span class="sb-label">Költöztetés</span>
+          </a>
+        </div>
+      </div>
+      <a href="#" class="sb-link" data-page="docs">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+        <span class="sb-label">Dokumentáció</span>
       </a>
     </nav>
     <div class="sidebar-footer">

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -88,6 +88,11 @@ window._i18n.en = {
   'nav.vault':        'Vault',
   'nav.tokenUsage':   'Token Monitor',
   'nav.ideas':        'Ideas',
+  'nav.group.team':        'Team',
+  'nav.group.knowledge':   'Knowledge',
+  'nav.group.stats':       'Statistics',
+  'nav.group.system':      'System',
+  'nav.group.connections': 'Connections',
   // --- Federation ---
   'nav.federation':                    'Federation',
   'federation.page_title':             'Federation',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -88,6 +88,11 @@ window._i18n.hu = {
   'nav.vault':        'Vault',
   'nav.tokenUsage':   'Token Monitor',
   'nav.ideas':        'Ötletláda',
+  'nav.group.team':        'Csapat',
+  'nav.group.knowledge':   'Tudás',
+  'nav.group.stats':       'Statisztikák',
+  'nav.group.system':      'Rendszer',
+  'nav.group.connections': 'Kapcsolatok',
   // --- Federation ---
   'nav.federation':                    'Föderáció',
   'federation.page_title':             'Föderáció',

--- a/web/style.css
+++ b/web/style.css
@@ -248,6 +248,34 @@ body {
 .sb-link.active { color: var(--text); background: var(--accent-soft); }
 .sb-link.active svg { color: var(--accent); }
 .sb-badge { margin-left: auto; }
+
+/* === Collapsible sidebar groups === */
+.sb-group { display: flex; flex-direction: column; gap: 2px; margin-top: 6px; }
+.sb-group-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-align: left;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+.sb-group-header:hover { color: var(--text); background: var(--accent-soft); }
+.sb-group-label { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.sb-group-chevron { flex-shrink: 0; transition: transform var(--transition); }
+.sb-group.open .sb-group-chevron { transform: rotate(90deg); }
+.sb-group-items { display: flex; flex-direction: column; gap: 2px; }
+.sb-group:not(.open) .sb-group-items { display: none; }
 .sidebar-footer {
   padding-top: 12px;
   border-top: 1px solid var(--border);


### PR DESCRIPTION
## Mit csinal

A 23 oldalsav-link atrendezese Szabi jovahagyott specje szerint:

- FENT csoport nelkul: Attekintes, Kanban, Jovahagyasok
- **CSAPAT**: Ugynokok, Aktivitas, Uzenetek, Utemezesek, Hatter
- **TUDAS**: Memoria, Naplo, Skillek, Kutatas, Otletlada
- **STATISZTIKAK**: Koltsegek, Token Monitor
- **RENDSZER**: Statusz, Frissitesek, Beallitasok, Vault
- **KAPCSOLATOK**: MCP, Foderacio, Koltoztetes
- LENT csoport nelkul: Dokumentacio

Viselkedes: alapbol minden csoport csukva; az aktiv lap csoportja automatikusan nyilik (switchPage-bol hajtva, deep-link bootnal is); a nyitott csoportokat localStorage jegyzi meg (`marveen.sidebarGroups`, serult allapot = minden csukva); a fejlecek valodi `<button>`-ok `aria-expanded` + `aria-controls` attributumokkal; a cimkek i18n-kulcsok (`nav.group.*`) mindket nyelvi fajlban.

A 23 link statikus markup maradt (csak csoport-kontenerekbe kerult), igy a boot-kori `navLinks` querySelectorAll tovabbra is latja mindet. A mobil off-canvas ugyanezt a markupot hasznalja, kulon kod nem kellett.

## Bongeszo-teszt (Playwright, elo origin + worktree route-override, sw block) -- 29/29 PASS

Struktura:
1. 23 sb-link jelen van (ellenorzo osszeg stimmel)
2. 5 csoport, sorrend: team > knowledge > stats > system > connections
3. Csoport nelkuli linkek: overview, kanban, approvals fent + docs lent
4. Csoporttagsag mind az 5 csoportban pontosan a spec szerinti data-page lista

Viselkedes:
5. Ures localStorage: mind az 5 csoport csukva, aria-expanded=false mindenhol
6. Csukott csoport linkjei nem lathatok
7. Mind az 5 csoport kattintasra nyilik es csukodik, aria-expanded kovet
8. aria-controls a csoport item-listajara mutat (mind az 5-nel)
9. team+system nyitva hagyva -> reload utan is nyitva, a tobbi csukva
10. Serult localStorage ('{not json') -> minden csukva, nincs crash
11. switchPage('vault'): RENDSZER auto-nyilik, Vault kiemelt es lathato, csak a system nyitott
12. Deep-link boot (#costs friss betoltessel): STATISZTIKAK nyitva + costs aktiv
13. Billentyuzet: fejlecen Enter nyit, Space csuk (nativ button)
14. Csoporton beluli linkre kattintas navigal + active highlight
15. Nyelvvaltas EN: fejlecek "Team|Knowledge|Statistics|System|Connections", vissza HU: "Csapat|Tudas|Statisztikak|Rendszer|Kapcsolatok" (data-i18n sweep)
16. Mobil (390x844): hamburger nyitja a drawert, csoport-toggle mukodik benne, navigalas utan a drawer csukodik
17. pageerror lista ures a teljes futas alatt

QA: `node --check` mindharom JS fajlra zold; em-dash a diffben: 0.

Szandekosan nem resze a PR-nek: a Playwright teszt-script es a screenshotok (nem repo-artefaktum); semmilyen scope-bovites nincs, csak a sidebar-regio + lang nav.* blokk valtozott (Dani archivedPage regiojahoz nem nyultam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)