### PR TITLE
feat(dashboard): menu restructure -- 3. lepes: naplo a RENDSZER ala

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -432,9 +432,9 @@ const SIDEBAR_GROUPS_LS_KEY = 'marveen.sidebarGroups'
 // naplo under system) or relabeling a group is a one-line change right here.
 const SIDEBAR_GROUPS = [
   { key: 'team',        labelKey: 'nav.group.team',        pages: ['agents', 'activity', 'messages', 'tasks', 'bgTasks'] },
-  { key: 'knowledge',   labelKey: 'nav.group.knowledge',   pages: ['memories', 'naplo', 'skills', 'research', 'ideas'] },
+  { key: 'knowledge',   labelKey: 'nav.group.knowledge',   pages: ['memories', 'skills', 'research', 'ideas'] },
   { key: 'stats',       labelKey: 'nav.group.stats',       pages: ['costs', 'tokenUsage'] },
-  { key: 'system',      labelKey: 'nav.group.system',      pages: ['status', 'updates', 'settings', 'vault'] },
+  { key: 'system',      labelKey: 'nav.group.system',      pages: ['status', 'naplo', 'updates', 'settings', 'vault'] },
   { key: 'connections', labelKey: 'nav.group.connections', pages: ['connectors', 'federation', 'migrate'] },
 ]
 const sidebarGroupEls = document.querySelectorAll('.sb-group[data-group]')


### PR DESCRIPTION
## Mit csinal

Szabi javitasa: a Naplo oldal rendszer-audit idovonal, nem napi naplo, ezert a TUDAS helyett a RENDSZER csoportba valo. A valtozas pontosan a ket SIDEBAR_GROUPS tomb-sor az app.js-ben:

- `naplo` KI a knowledge.pages-bol -> TUDAS: memories, skills, research, ideas (4 elem)
- `naplo` BE a system.pages-be -> RENDSZER: status, **naplo**, updates, settings, vault (5 elem)

Semmi markup-, i18n- vagy CSS-valtozas: a boot-kori re-parenting a terkep szerint helyezi a linket. Ez volt a #742-es deklarativ terkep deklaralt celja, es igazolodott: az atsorolas tenyleg ketsoros diff.

## Celzott bongeszo-verify (elo origin, CSAK az app.js override-olva -- tehat az ELES, mergelt markuppal, ahol a naplo link meg a TUDAS kontenerben ul) -- 8/8 PASS

1. RENDSZER kinyitva: Statusz, Naplo, Frissitesek, Beallitasok, Vault -- pont ebben a sorrendben
2. TUDAS: Memoria, Skillek, Kutatas, Otletlada -- 4 elem, Naplo nincs
3. switchPage('naplo'): CSAK a RENDSZER nyilik (nem a TUDAS) + Naplo kiemelt es lathato
4. Osszesen 23 link
5. Persist-eset valtozatlan: csukva -> naplo -> overview -> reload -> RENDSZER csukva, localStorage ures
6. pageerror lista ures

A 2. pontban emlitett elrendezes kulon bizonyitja, hogy a terkep felulirja a markupot: az eles index.html-ben a naplo link a knowledge kontenerben van, a re-parenting mozgatta at a system ala.

🤖 Generated with [Claude Code](https://claude.com/claude-code)