### PR TITLE
fix(scheduler): utemezett feladatok chat_id feloldasa prompt-epiteskor (a chat_id: 0 sentinel halott a hivatalos plugin alatt)

### DIFF
--- a/src/__tests__/schedule-runner-bound-chatid.test.ts
+++ b/src/__tests__/schedule-runner-bound-chatid.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { chatIdFromAccessConfig } from '../web/schedule-runner.js'
+
+// Regression guard for 2026-07-27 (Zara report, Marveen diagnosis): the
+// scheduled-task prompt prefix carried a "chat_id: 0" sentinel from a
+// pre-plugin channel implementation. The official Telegram plugin rejects it
+// (assertAllowedChat: "0" is never allowlisted), so every non-heartbeat
+// scheduled task threw at delivery. The fix resolves the agent's own bound
+// chat from its channel access.json at prompt-build time.
+
+describe('chatIdFromAccessConfig (pure core)', () => {
+  it('returns the first DM allowlist entry', () => {
+    expect(chatIdFromAccessConfig({ allowFrom: ['1268077055'], groups: {} })).toBe('1268077055')
+    expect(chatIdFromAccessConfig({ allowFrom: ['111', '222'] })).toBe('111')
+  })
+
+  it('accepts numeric entries and trims strings', () => {
+    expect(chatIdFromAccessConfig({ allowFrom: [1268077055] })).toBe('1268077055')
+    expect(chatIdFromAccessConfig({ allowFrom: [' 42 '] })).toBe('42')
+  })
+
+  it('falls back to the first allowed group when no DM entry exists', () => {
+    expect(chatIdFromAccessConfig({ allowFrom: [], groups: { '-100123': {} } })).toBe('-100123')
+  })
+
+  it('returns null for missing/empty/corrupt bindings (config gap, not a default)', () => {
+    expect(chatIdFromAccessConfig(null)).toBeNull()
+    expect(chatIdFromAccessConfig('nope')).toBeNull()
+    expect(chatIdFromAccessConfig({})).toBeNull()
+    expect(chatIdFromAccessConfig({ allowFrom: [], groups: {} })).toBeNull()
+    expect(chatIdFromAccessConfig({ allowFrom: [''] })).toBeNull()
+  })
+})
+
+describe('schedule-runner source contract (sentinel removed)', () => {
+  const src = readFileSync(join(__dirname, '..', 'web', 'schedule-runner.ts'), 'utf-8')
+
+  it('no prompt prefix carries the dead chat_id: 0 sentinel anymore', () => {
+    expect(src).not.toMatch(/chat_id:\s*0[,)]/)
+  })
+
+  it('the no-binding branch omits the Telegram instruction instead of guessing a chat', () => {
+    // The fallback prefix must be the bare task tag -- no Telegram mention, no
+    // ALLOWED_CHAT_ID leak into a sub-agent prompt.
+    expect(src).toContain('prompt omits the Telegram delivery instruction')
+    expect(src).toMatch(/prefix = `\[Utemezett feladat: \$\{task\.name\}\] `/)
+  })
+
+  it('resolution reads the same access.json the plugin enforces', () => {
+    expect(src).toContain("channelStateDir('telegram'")
+    expect(src).toContain('chatIdFromAccessConfig')
+  })
+})

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -33,7 +33,8 @@ import {
   SCHEDULED_TASKS_DIR,
   type ScheduledTask,
 } from './scheduled-tasks-io.js'
-import { listAgentNames, readFileOr, readAgentRemoteHost } from './agent-config.js'
+import { listAgentNames, readFileOr, readAgentRemoteHost, agentDir } from './agent-config.js'
+import { channelStateDir } from '../channel-provider.js'
 import {
   agentSessionName,
   isAgentRunning,
@@ -203,6 +204,50 @@ function persistScheduleLastRun(): void {
 //   exit 0, stdout non-empty → run LLM with stdout as context prefix
 //   exit 0, stdout empty     → run LLM normally
 //   non-zero exit            → log warning, run LLM anyway (fail-open)
+// --- Bound-channel chat id resolution for scheduled-task prompts ---
+//
+// The prompt prefix used to carry a "chat_id: 0" sentinel meaning "the running
+// agent's own bound channel". The convention belonged to an earlier channel
+// implementation; the official Telegram plugin (0.0.6) knows nothing about it:
+// its reply tool calls assertAllowedChat(chat_id) first, "0" is never on the
+// allowlist, so every non-heartbeat scheduled task threw at delivery time
+// (Zara, 2026-07-27; all 32 task-configs affected -- none carries a chat_id).
+// The sentinel's INTENT stays correct (a sub-agent's result must go to its own
+// owner, never the boss's chat), so the fix resolves the concrete chat id at
+// prompt-build time from the same place the plugin enforces it: the agent's
+// own channel access.json allowlist.
+
+/** Pure core: first DM allowlist entry, else first allowed group, else null. */
+export function chatIdFromAccessConfig(raw: unknown): string | null {
+  if (!raw || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  if (Array.isArray(o.allowFrom) && o.allowFrom.length > 0) {
+    const first = o.allowFrom[0]
+    if (typeof first === 'string' && first.trim()) return first.trim()
+    if (typeof first === 'number') return String(first)
+  }
+  if (o.groups && typeof o.groups === 'object') {
+    const keys = Object.keys(o.groups as Record<string, unknown>)
+    if (keys.length > 0) return keys[0]
+  }
+  return null
+}
+
+/** The agent's own bound Telegram chat, or null when no binding exists.
+ *  Reads <agent channels dir>/telegram/access.json -- the exact file the
+ *  plugin's assertAllowedChat enforces, so a resolved id is deliverable by
+ *  construction. Deliberately NOT falling back to ALLOWED_CHAT_ID: that is
+ *  the boss's chat, and pointing a sub-agent's result there is the precise
+ *  bug the old sentinel existed to avoid. */
+export function resolveBoundChatId(agentName: string): string | null {
+  const dir = agentName === MAIN_AGENT_ID
+    ? channelStateDir('telegram')
+    : channelStateDir('telegram', agentDir(agentName))
+  try {
+    return chatIdFromAccessConfig(JSON.parse(readFileSync(join(dir, 'access.json'), 'utf-8')))
+  } catch { return null }
+}
+
 export function runPreCheck(task: ScheduledTask): { skip: boolean; prefix?: string } {
   if (!task.preCheck) return { skip: false }
   const scriptPath = isAbsolute(task.preCheck)
@@ -401,14 +446,24 @@ async function attemptFireTask(
       // heartbeat prompts.
       prefix = `[Heartbeat: ${task.name}] `
     } else {
-      // Target the RUNNING agent's own bound channel (chat_id: 0), NOT the
-      // global ALLOWED_CHAT_ID. The latter is the main/admin chat; injecting it
-      // here pointed every sub-agent's task result at the boss's chat instead of
-      // its own owner (e.g. attilamarveenja -> Papp Attila). chat_id: 0 is the
-      // established "bound channel" convention (template-identity-hygiene), so it
-      // resolves per-agent and stays correct for the main agent too. The
-      // system-level pending-retry alert below still uses ALLOWED_CHAT_ID.
-      prefix = `[Utemezett feladat: ${task.name}] Az eredmenyt kuldd el Telegramon (chat_id: 0, reply tool). `
+      // Target the RUNNING agent's own bound channel, NOT the global
+      // ALLOWED_CHAT_ID. The latter is the main/admin chat; injecting it here
+      // pointed every sub-agent's task result at the boss's chat instead of its
+      // own owner (e.g. attilamarveenja -> Papp Attila). The old "chat_id: 0"
+      // sentinel encoded the same intent, but the official Telegram plugin
+      // rejects it (assertAllowedChat: "0" is never allowlisted), so the
+      // binding is resolved to a CONCRETE id here at prompt-build time. No
+      // binding -> no Telegram instruction at all: better to skip delivery
+      // than to deliver to the wrong chat, and the warn below makes the
+      // config gap visible. The system-level pending-retry alert further
+      // down still uses ALLOWED_CHAT_ID by design.
+      const boundChatId = resolveBoundChatId(agentName)
+      if (boundChatId) {
+        prefix = `[Utemezett feladat: ${task.name}] Az eredmenyt kuldd el Telegramon (chat_id: ${boundChatId}, reply tool). `
+      } else {
+        logger.warn({ task: task.name, agent: agentName }, 'scheduled task: agent has no bound telegram chat (access.json missing/empty) -- prompt omits the Telegram delivery instruction')
+        prefix = `[Utemezett feladat: ${task.name}] `
+      }
     }
     // A scheduled task body is the agent's OWN task, authored by the operator
     // (SKILL.md on disk, or the bearer-gated /api/schedules editor -- both


### PR DESCRIPTION
## A hiba (Zara-jelentes + Marveen-diagnozis, 6994, fuggetlenul verifikalva)

A nem-heartbeat utemezett feladatok prompt-prefixe `chat_id: 0` sentinelt hordozott ('a futo agens sajat bekototott csatornaja'). A konvencio egy korabbi csatorna-implementaciohoz keszult; a hivatalos Telegram plugin (0.0.6) reply toolja elso lepesben `assertAllowedChat(chat_id)`-t hiv, a '0' sosincs az allowliston -> minden ilyen task kivetellel bukott a kezbesitesnel. Mind a 32 task-config erintett volt (egyikben sincs chat_id mezo). A sentinel SZANDEKA helyes volt es marad is: a sub-agent eredmenye a SAJAT gazdajahoz menjen, sose a fonok chatjebe.

## A fix

1. `resolveBoundChatId(agentName)`: a launcher mar prompt-epiteskor feloldja az agens sajat bekototott chatjet a `<channels>/telegram/access.json`-bol -- PONT abbol a fajlbol, amit a plugin assertAllowedChat-je kikenyszerit, tehat a feloldott id konstrukcio szerint kezbesitheto. Pure core: allowFrom[0], kulonben elso engedelyezett group, kulonben null.
2. Van kotes -> konkret `chat_id: <id>` a prefixben. Nincs kotes -> a prefix EGYALTALAN nem emlit Telegramot (inkabb ne kuldjon, mint rossz helyre), es warn-log teszi lathatova a konfig-hianyt.
3. SZANDEKOSAN nincs ALLOWED_CHAT_ID-fallback sub-agentnek: az a fonok chatje -- pont az a hiba, ami ellen a regi sentinel vedett. Terjesztes-biztos: semmi hardcode, friss install a sajat gazdaja koteset oldja fel.

## Marveen 3. kerdesere (van-e per-agens tarolt kotes)

VAN: `<agentDir>/.claude/channels/telegram/access.json` (allowFrom/groups) -- nem kellett uj tarolot kitalalni, a plugin sajat enforcement-fajlja a ground truth.

## Verifikacio

- Pure-core tesztek + forras-kontrakt teszt (a sentinel eltunt; a no-binding ag csupasz tag, se Telegram-emlites, se ALLOWED_CHAT_ID-szivargas).
- Mind a 10 scheduler-suite zold: 83 teszt. `tsc --noEmit` tiszta. Minden futas nullazott channel-envvel.
- Elo kotes-feloldas kezzel ellenorizve ezen a hoston: samu access.json allowFrom[0] = a gazda chatje.

🤖 Generated with [Claude Code](https://claude.com/claude-code)