### PR TITLE
fix(scheduler): warn ambivalens bound-chat feloldasnal (tobb-elemu allowlist) -- #744 follow-up

### DIFF
--- a/src/__tests__/schedule-runner-bound-chatid.test.ts
+++ b/src/__tests__/schedule-runner-bound-chatid.test.ts
@@ -48,6 +48,13 @@ describe('schedule-runner source contract (sentinel removed)', () => {
     expect(src).toMatch(/prefix = `\[Utemezett feladat: \$\{task\.name\}\] `/)
   })
 
+  it('multi-entry allowlists produce an ambiguity warn (heuristic made visible)', () => {
+    // Behaviour stays first-entry; the warn exists so a reordered allowlist
+    // (2+ entries: zara/iris) cannot silently redirect task results.
+    expect(src).toContain('bound-chat resolution is ambiguous')
+    expect(src).toMatch(/candidates > 1/)
+  })
+
   it('resolution reads the same access.json the plugin enforces', () => {
     expect(src).toContain("channelStateDir('telegram'")
     expect(src).toContain('chatIdFromAccessConfig')

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -244,7 +244,19 @@ export function resolveBoundChatId(agentName: string): string | null {
     ? channelStateDir('telegram')
     : channelStateDir('telegram', agentDir(agentName))
   try {
-    return chatIdFromAccessConfig(JSON.parse(readFileSync(join(dir, 'access.json'), 'utf-8')))
+    const raw = JSON.parse(readFileSync(join(dir, 'access.json'), 'utf-8')) as Record<string, unknown>
+    const chosen = chatIdFromAccessConfig(raw)
+    // "First allowlist entry" is a HEURISTIC, not a stated fact: access.json
+    // has no owner field, so with 2+ entries (zara/iris today) a reordering
+    // would silently redirect scheduled-task results to another person -- the
+    // exact failure class the old sentinel guarded against, now throw-free and
+    // thus invisible. The warn turns a silent misdirection into a searchable
+    // log line; behaviour is unchanged (Marveen, msg 7002).
+    const candidates = Array.isArray(raw?.allowFrom) ? raw.allowFrom.length : 0
+    if (chosen && candidates > 1) {
+      logger.warn({ agent: agentName, candidates, chosen }, 'bound-chat resolution is ambiguous: multiple DM allowlist entries, using the first')
+    }
+    return chosen
   } catch { return null }
 }
 


### PR DESCRIPTION
Marveen review-kerese a #744-hez (msg 7002): az allowFrom[0] heurisztika, nem tenyadat — 2+ bejegyzesnel (zara/iris ma) egy atrendezodes csendben masik emberhez iranyitana az utemezett feladatok eredmenyet. A warn (agent + jelolt-szam + valasztott id) keresheto naplobejegyzesse teszi a ketertelmuseget; a viselkedes valtozatlan (tovabbra is az elso bejegyzes nyer).

Teszt: forras-kontrakt eset a warn letezesere + a viselkedes-valtozatlansag a meglevo pure-core teszteken (8/8 zold). tsc tiszta.

A 'hol mondjuk ki explicit a gazdat' kerdesre kulon kartya keszult javaslattal (nem ebben a PR-ben).

🤖 Generated with [Claude Code](https://claude.com/claude-code)