### PR TITLE
feat(dashboard): menu restructure -- 4. lepes: Dokumentacio fixen az oldalsav aljan

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -198,11 +198,13 @@
           </a>
         </div>
       </div>
+    </nav>
+    <div class="sidebar-docs">
       <a href="#" class="sb-link" data-page="docs">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
         <span class="sb-label">Dokumentáció</span>
       </a>
-    </nav>
+    </div>
     <div class="sidebar-footer">
       <button class="theme-toggle" id="langToggle" title="Language / Nyelv">HU</button>
       <button class="theme-toggle" id="mobileLoginBtn" title="Mobil belépés (QR)">

--- a/web/style.css
+++ b/web/style.css
@@ -276,6 +276,18 @@ body {
 .sb-group.open .sb-group-chevron { transform: rotate(90deg); }
 .sb-group-items { display: flex; flex-direction: column; gap: 2px; }
 .sb-group:not(.open) .sb-group-items { display: none; }
+/* Docs pinned to the sidebar bottom, just above the lang/theme row. Sits
+ * outside the scrolling .sidebar-nav (flex:1), so it stays visible however
+ * long the open group list gets. Separator reuses the .sidebar-footer
+ * border-top pattern. */
+.sidebar-docs {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  margin-top: 8px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+}
 .sidebar-footer {
   padding-top: 12px;
   border-top: 1px solid var(--border);


### PR DESCRIPTION
## Mit csinal

Szabi kerese: a Dokumentacio fixen az oldalsav aljan uljon, kozvetlenul a nyelv/tema gombsor folott, elvalasztassal. A docs link kikerult a gorgo `.sidebar-nav`-bol egy uj `.sidebar-docs` konteberbe a nav es a footer koze. A `.sidebar` mar flex-oszlop es a nav mar `flex:1 + overflow-y:auto`, igy a csoportlista gorog, a docs + gombsor pedig mindig latszik -- semmi position:fixed. Az elvalaszto a meglevo `.sidebar-footer` border-top mintaja, uj vizualis nyelv nincs.

app.js NEM valtozott: a navLinks query dokumentum-szintu, a SIDEBAR_GROUPS re-parenting pedig csak a terkepben felsorolt oldalakat mozgatja, a docs nincs benne -- ezt bongeszoben is igazoltam (boot utan a docs a .sidebar-docs-ban marad).

## Celzott bongeszo-verify (Marveen 6 pontja) -- 17/17 PASS

1. Minden csoport CSUKVA: docs a sav aljan (docsBottom==footerTop, geometriaval merve), a viewport also savjaban, 1px border-top elvalasztoval -- nem a KAPCSOLATOK alatt lebeg
2. Minden csoport NYITVA: docs pozicioja pixelre azonos (docsTop 769 -> 769), tovabbra is a footer folott
3. Alacsony ablak (700px, minden csoport nyitva): a csoportlista gorgetheto, a docs link es a teljes gombsor latszik, a nav gorgetesevel az utolso csoport-elem (Koltoztetes) elerheto
4. Docs-linkre katt: docs oldal nyilik, link active
5. 23 link osszesen, csoport-tagsag valtozatlan (naplo a RENDSZER-ben a #743 szerint)
6. Mobil drawer (390x844, kulon friss context): nyilik, docs latszik alul, csoport-toggle mukodik, docs-katt navigal es csukja a drawert
+ pageerror lista ures mindket contextben; em-dash a diffben 0; boot re-parent check: docs helyben marad

Screenshotok keszultek csukott/nyitott/700px/mobil allapotrol, vizualisan is ellenorizve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)