### PR TITLE
fix(token-usage): agents with a hyphen or digit in their name were invisible to the monitor

### DIFF
--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -32,7 +32,11 @@ function discoverAgentSources(): AgentTranscriptSource[] {
     try { stat = statSync(full) } catch { continue }
     if (!stat.isDirectory()) continue
 
-    const agentMatch = entry.match(/-agents-([a-z]+)$/)
+    // sanitizeAgentName() allows [a-z0-9-], so the old /([a-z]+)$/ silently
+    // skipped every agent with a digit or a hyphen in its name -- the whole
+    // per-project worker fleet (davinci-ocura, vermeer-fressa, ...) never
+    // appeared in the token monitor at all. Not zero usage: no rows.
+    const agentMatch = entry.match(/-agents-([a-z0-9-]+)$/)
     if (agentMatch) {
       sources.push({ agent: agentMatch[1], projectDir: full })
     } else if (entry === mainDirName) {


### PR DESCRIPTION
## The bug

Agent discovery in `src/web/token-usage.ts` matched `-agents-([a-z]+)$`, but
`sanitizeAgentName()` allows `[a-z0-9-]`. Any agent whose name contains a digit
or a hyphen was skipped during discovery, so it produced **no token_usage rows
at all**.

On an install with per-project workers (`davinci-ocura`, `vermeer-fressa`,
`michelangelo-gubanc-palko`, …) that is the entire worker fleet — 20 agents in
our case.

## Why it matters more than a missing row

The failure is silent and reads as the opposite of what it is. The dashboard
model breakdown simply had no Fable in it, which looks like *"the planner never
ran"* rather than *"the monitor cannot see the planner"*. The owner noticed the
gap and asked whether the planner was really running on Fable — it was: 36
assistant messages in its transcript carry `claude-fable-5`.

## The fix

```diff
-const agentMatch = entry.match(/-agents-([a-z]+)$/)
+const agentMatch = entry.match(/-agents-([a-z0-9-]+)$/)
```

Matches the charset `sanitizeAgentName()` actually produces.

## Verification

```
-agents-newton                     -> newton
-agents-davinci-ocura              -> davinci-ocura
-agents-vermeer-fressa             -> vermeer-fressa
-agents-michelangelo-gubanc-palko  -> michelangelo-gubanc-palko
```

`tsc --noEmit` clean, `npm run build` clean.

Note for anyone hitting this: the fix is not retroactive by itself, but the
per-file cursor means the collector re-reads those transcripts as soon as the
directory is recognised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)