### PR TITLE
fix(voice): pin Telegram STT lookups to IPv4 -- voice messages silently arrived untranscribed

### DIFF
--- a/scripts/voice/_vtools.py
+++ b/scripts/voice/_vtools.py
@@ -40,14 +40,23 @@ import urllib.parse
 # which only 5.5s was CPU. That silently blew the dashboard's 60s STT timeout, so
 # /api/voice/directive returned transcript=null and voice messages reached the agent
 # untranscribed -- a failure with no error anywhere, just a missing transcript.
+# PREFER IPv4, do not EXCLUDE IPv6: an AF_INET-only override would turn a working
+# IPv6-only host into a dead one (ENETUNREACH -> transcript=null), which is the same
+# silent failure this patch exists to remove, just relocated. Ordering keeps the whole
+# measured benefit -- the stalling AAAA attempt no longer comes first -- while a host
+# with no IPv4 route still resolves and connects. The caller's own `family` argument is
+# passed through untouched, so an explicit AF_INET6 lookup still gets what it asked for.
 _orig_getaddrinfo = socket.getaddrinfo
 
 
-def _getaddrinfo_ipv4(host, port, family=0, *args, **kwargs):
-    return _orig_getaddrinfo(host, port, socket.AF_INET, *args, **kwargs)
+def _getaddrinfo_ipv4_first(host, port, family=0, *args, **kwargs):
+    results = _orig_getaddrinfo(host, port, family, *args, **kwargs)
+    # Stable sort: AF_INET entries move to the front, every other family keeps the
+    # relative order the resolver returned.
+    return sorted(results, key=lambda entry: 0 if entry[0] == socket.AF_INET else 1)
 
 
-socket.getaddrinfo = _getaddrinfo_ipv4
+socket.getaddrinfo = _getaddrinfo_ipv4_first
 # urlretrieve() takes no timeout kwarg -- bound it here so a stalled download can never
 # hang unbounded again.
 socket.setdefaulttimeout(60)

--- a/scripts/voice/_vtools.py
+++ b/scripts/voice/_vtools.py
@@ -27,10 +27,30 @@ import os
 import re
 import sys
 import json
+import socket
 import subprocess
 import tempfile
 import urllib.request
 import urllib.parse
+
+# api.telegram.org publishes an AAAA record that is not routable from every host, and
+# Python's urllib has no happy-eyeballs fallback: each fresh connection stalls on the
+# IPv6 attempt before dropping to IPv4. MEASURED 2026-07-27 on the Marveen box: getFile
+# took 25.1s with IPv6 allowed vs 0.0s IPv4-only, and a full transcribe ran 2m43s of
+# which only 5.5s was CPU. That silently blew the dashboard's 60s STT timeout, so
+# /api/voice/directive returned transcript=null and voice messages reached the agent
+# untranscribed -- a failure with no error anywhere, just a missing transcript.
+_orig_getaddrinfo = socket.getaddrinfo
+
+
+def _getaddrinfo_ipv4(host, port, family=0, *args, **kwargs):
+    return _orig_getaddrinfo(host, port, socket.AF_INET, *args, **kwargs)
+
+
+socket.getaddrinfo = _getaddrinfo_ipv4
+# urlretrieve() takes no timeout kwarg -- bound it here so a stalled download can never
+# hang unbounded again.
+socket.setdefaulttimeout(60)
 
 # Resolved relative to this file so PREFIX-based installs work correctly.
 VENV_PY = os.path.join(os.path.dirname(os.path.abspath(__file__)), "venv", "bin", "python")
@@ -44,7 +64,20 @@ def _token(state_dir):
     return m.group(1).strip().strip('"').strip("'")
 
 
+def _whisper(path):
+    from faster_whisper import WhisperModel
+    m = WhisperModel("small", device="cpu", compute_type="int8")
+    segs, _ = m.transcribe(path, language="hu", beam_size=5)
+    print(" ".join(s.text.strip() for s in segs).strip())
+
+
 def transcribe(file_id, state_dir):
+    # Accept an already-downloaded local file as well as a Telegram file_id: the channel
+    # plugin's download_attachment tool hands back a PATH, and feeding that to getFile as
+    # a file_id fails with HTTP 400 (hit live 2026-07-27).
+    if os.path.isfile(file_id):
+        _whisper(file_id)
+        return
     token = _token(state_dir)
     d = json.load(urllib.request.urlopen(
         f"https://api.telegram.org/bot{token}/getFile?file_id={urllib.parse.quote(file_id)}",
@@ -54,10 +87,7 @@ def transcribe(file_id, state_dir):
     os.close(fd)
     try:
         urllib.request.urlretrieve(f"https://api.telegram.org/file/bot{token}/{fp}", out)
-        from faster_whisper import WhisperModel
-        m = WhisperModel("small", device="cpu", compute_type="int8")
-        segs, _ = m.transcribe(out, language="hu", beam_size=5)
-        print(" ".join(s.text.strip() for s in segs).strip())
+        _whisper(out)
     finally:
         try:
             os.unlink(out)


### PR DESCRIPTION
## The bug

Voice messages reached the agent **untranscribed**, with no error anywhere.

`_vtools.py transcribe` downloads the audio from `api.telegram.org` before running
faster-whisper. That host publishes an AAAA record (`2001:67c:4e8:f004::9`) which is
not routable from every host, and Python's `urllib` has **no happy-eyeballs
fallback** -- so every fresh connection waits out the full IPv6 attempt before
dropping to IPv4.

Measured on an affected box:

| | IPv6 allowed | IPv4 only |
|---|---|---|
| `getFile` | **25.1s** | **0.0s** |
| full `transcribe` | **2m43s** (of which only **5.5s** CPU) | **~10s** |

`/api/voice/directive` runs the subprocess with `timeoutMs: 60_000`, so the call was
killed every time. The route is fail-safe by design (`transcript: null` on STT
error), `voice-reply-directive.py` injects nothing when `transcript` is empty, and
the prompt goes through unchanged.

## Why it went unnoticed

Every layer looked healthy, and each one was individually right to stay quiet:

- **No error was logged.** The route's `logger.warn` only fires on a non-zero exit
  code; a killed-by-timeout subprocess took the same silent path as "voice not
  installed".
- **The hook is deliberately fail-safe** -- it `exit(0)`s on any exception so a
  broken transcript can never block a user's prompt. Correct behaviour, but it means
  the failure has no user-visible symptom other than a missing field.
- **The stack self-tests clean.** `_vtools.py canary` synthesizes and transcribes
  locally with no network involved, so it passes while the Telegram-facing path is
  dead.
- **Running the tool by hand looked fine**, just "a bit slow" -- and the slowness is
  invisible unless you compare `user` to `real`. 2m43s wall clock with 5.5s CPU is
  the only tell.
- **Other components on the same box are fast** against the same host, because the
  node/bun channel plugin does have happy-eyeballs. That makes "Telegram is slow" a
  tempting and wrong conclusion.

Net effect: an agent silently loses voice input on any host without working IPv6.

## The fix

Pin `socket.getaddrinfo` to `AF_INET` for this module, and set
`socket.setdefaulttimeout(60)` -- `urlretrieve()` accepts no `timeout` kwarg, so
without it a stalled download can hang unbounded.

**On a host with working IPv6 nothing changes in behaviour**: the same IPv4 address
is reachable there too, only the AAAA candidate is skipped. The tool talks to exactly
one host (`api.telegram.org`), which has stable A records, so the narrowing is
contained to this script and does not touch the dashboard or any other component.

Also in this commit: `transcribe()` now accepts an already-downloaded local file, not
only a Telegram `file_id`. The channel plugin's `download_attachment` tool returns a
**path**, and feeding that to `getFile` fails with HTTP 400 -- which is what an agent
hits the moment it tries to transcribe an attachment it already has on disk.

## Why this shape

The alternative -- raising the 60s timeout in `voice.ts` -- would only paper over it:
the request would still burn 20-25s per connection on a dead code path, and the
dashboard would hold a subprocess for minutes per voice message. Fixing the resolver
choice removes the wait instead of tolerating it.

## Test

No automated test: the repo's suite is vitest/TypeScript, there is no Python test
runner, and the behaviour under test is a network-stack property that a unit test
cannot observe without real DNS. Verified by measurement instead, on the affected
box, before and after:

```
# before
$ time python _vtools.py transcribe <file_id> ~/.claude/channels/telegram
real 2m43.217s   user 0m5.576s   sys 0m2.280s

# isolating the cause
IPv6 allowed  getFile: 25.1s
IPv4 only     getFile:  0.0s

# after
$ time python _vtools.py transcribe <file_id> ~/.claude/channels/telegram
real 0m10.932s   user 0m5.715s   sys 0m2.138s

# end to end, the path the hook actually uses
$ time curl -s ".../api/voice/directive?agent=X&chat=Y&file=<file_id>"
{"directive":null,"transcript":"..."}
real 0m10.548s
```

Also re-checked after the change: the `file_id` path, the new local-path branch, and
`_vtools.py canary` (unaffected -- it never touches the network).


## Second, deliberate behaviour change: local audio paths

`transcribe()` also accepts an already-downloaded local file. The channel plugin's `download_attachment` tool returns a filesystem path, and passing that as a `file_id` fails with HTTP 400. The branch is gated by `SAFE_FILE_ID_RE`, so a path can never arrive over HTTP -- stating it here so the next reader does not have to derive it.

## Update after review

The IPv4 pin is now a preference, not an exclusion: `_getaddrinfo_ipv4_first` sorts A records ahead of AAAA and passes the caller's `family` through untouched, so an IPv6-only host still resolves and connects instead of failing with ENETUNREACH.