### PR TITLE
fix(onboarding): restart the unauthenticated channels session after the first Claude auth save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marveen",
-  "version": "1.19.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marveen",
-      "version": "1.19.0",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -220,6 +220,13 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
     if (token && !/^sk-ant-oat/.test(token)) { json(res, { error: 'A setup-token formatuma nem stimmel (sk-ant-oat...).', reason: 'bad-token' }, 400); return true }
     if (apiKey && !/^sk-ant-/.test(apiKey)) { json(res, { error: 'Az API-kulcs formatuma nem stimmel (sk-ant-...).', reason: 'bad-key' }, 400); return true }
 
+    // Read BEFORE persisting: on a fresh install the channels session is
+    // booted by the installer/service unit with NO credentials, so if the
+    // install had no auth at this point, a running session is unauthenticated
+    // by construction. That is the one case where this endpoint must restart
+    // it after the save -- a running process never picks up new env.
+    const hadAuthBefore = claudeAuthPresent()
+
     // Verify BEFORE persisting, with a REAL probe. 2026-07-15 bootcamp bug 3:
     // the old persist-then-verify order stored a mistyped/revoked token into
     // .env + the fleet token file and still returned ok:true -- and since
@@ -255,8 +262,25 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
       json(res, { error: 'Nem sikerult elmenteni az .env-be.', reason: 'write-failed' }, 500)
       return true
     }
-    logger.info({ verified, mode: token ? 'oauth' : 'apikey' }, 'onboarding: Claude auth stored')
-    json(res, { ok: true, verified })
+    // BK bootcamp 2026-07-28: the wizard's /launch guards on agentsRunning()
+    // and short-circuits when the (unauthenticated) session already exists, so
+    // the token saved here never reached the running process and the install
+    // stayed logged-out. Restart here, in exactly the case where it is both
+    // needed and safe: the install had NO auth before this save, so the
+    // running session cannot be an authenticated live agent -- bouncing it
+    // loses nothing. Re-pasting a token on an already-authenticated install
+    // keeps today's behaviour (no implicit restart of a working fleet).
+    let restarted = false
+    let restartError: string | null = null
+    if (!hadAuthBefore && agentsRunning()) {
+      const r = hardRestartMarveenChannels()
+      restarted = r.ok
+      if (!r.ok) restartError = r.error || 'restart failed'
+      if (r.ok) logger.info('onboarding: channels restarted so the fresh auth is picked up')
+      else logger.error({ error: restartError }, 'onboarding: channels restart after first auth FAILED')
+    }
+    logger.info({ verified, restarted, mode: token ? 'oauth' : 'apikey' }, 'onboarding: Claude auth stored')
+    json(res, restartError ? { ok: true, verified, restarted, restartError } : { ok: true, verified, restarted })
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -11921,6 +11921,12 @@ function wireOnboarding(step) {
         const res = await fetch('/api/onboarding/claude-auth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ token }) })
         const d = await res.json().catch(() => ({}))
         if (!res.ok) { authBtn.disabled = false; onbMsg(d.error || t('onboarding.error'), true); return }
+        // Fresh-install path: the server restarts the (previously
+        // unauthenticated) channels session right after the first auth save --
+        // surface that, and on failure show the manual restart step instead of
+        // silently advancing.
+        if (d.restartError) { authBtn.disabled = false; onbMsg(t('onboarding.step1.saved_restart_failed'), true); setTimeout(refreshOnboarding, 6000); return }
+        if (d.restarted) { onbMsg(t('onboarding.step1.saved_restarted')); setTimeout(refreshOnboarding, 2500); return }
         onbMsg(d.verified ? t('onboarding.step1.saved_verified') : t('onboarding.step1.saved_unverified'))
         await refreshOnboarding()
       } catch (e) { authBtn.disabled = false; onbMsg((e && e.message) || t('onboarding.error'), true) }

--- a/web/app.js
+++ b/web/app.js
@@ -11844,6 +11844,11 @@ function renderOnboarding(s) {
     el.classList.toggle('active', n === step)
     el.classList.toggle('done', n < step)
   })
+  // The steps build on each other and the system only comes alive at the end
+  // of step 4 -- say so, or a fresh installer reads step 2's "saved" as "done"
+  // and every later "bot token not found" as a failure (BK bootcamp, 07-28).
+  const flowNote = document.getElementById('onbFlowNote')
+  if (flowNote) flowNote.textContent = step === 4 ? t('onboarding.flow_note_last') : t('onboarding.flow_note')
   const body = document.getElementById('onboardingBody')
   if (step === 1) body.innerHTML = onbIdentityHtml(s)
   else if (step === 2) body.innerHTML = onbStep1Html(s)

--- a/web/index.html
+++ b/web/index.html
@@ -48,6 +48,7 @@
         <div class="onboarding-step" data-ostep="3"><span class="onb-num">3</span> <span data-i18n="onboarding.step2.tab">Telegram bot</span></div>
         <div class="onboarding-step" data-ostep="4"><span class="onb-num">4</span> <span data-i18n="onboarding.step3.tab">Párosítás</span></div>
       </div>
+      <p class="onb-flow-note" id="onbFlowNote"></p>
       <div id="onboardingBody" class="onboarding-body"></div>
     </div>
   </div>

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1510,6 +1510,8 @@ window._i18n.en = {
   'onboarding.step1.token_empty':'Paste the token.',
   'onboarding.step1.saved_verified':   'Token saved and verified.',
   'onboarding.step1.saved_unverified': 'Token saved (verification did not run, it may still be valid).',
+  'onboarding.flow_note': 'The four steps build on each other: the system starts and begins responding after step 4 (pairing). Until then, messages about missing steps are normal.',
+  'onboarding.flow_note_last': 'This is the last step: after pairing, the system goes live.',
   'onboarding.step1.saved_restarted': 'Token saved, the agent restarted with the new credentials.',
   'onboarding.step1.saved_restart_failed': 'Token saved, but restarting the agent failed. Restart it manually (Linux: systemctl --user restart marveen-channels), then come back here.',
   'onboarding.step1.launching':  'Launching...',

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1510,6 +1510,8 @@ window._i18n.en = {
   'onboarding.step1.token_empty':'Paste the token.',
   'onboarding.step1.saved_verified':   'Token saved and verified.',
   'onboarding.step1.saved_unverified': 'Token saved (verification did not run, it may still be valid).',
+  'onboarding.step1.saved_restarted': 'Token saved, the agent restarted with the new credentials.',
+  'onboarding.step1.saved_restart_failed': 'Token saved, but restarting the agent failed. Restart it manually (Linux: systemctl --user restart marveen-channels), then come back here.',
   'onboarding.step1.launching':  'Launching...',
   'onboarding.step1.launched':   'Agents are starting...',
   'onboarding.step2.tab':        'Telegram bot',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1507,6 +1507,8 @@ window._i18n.hu = {
   'onboarding.step1.token_empty':'Illeszd be a tokent.',
   'onboarding.step1.saved_verified':   'Token elmentve és ellenőrizve.',
   'onboarding.step1.saved_unverified': 'Token elmentve (az ellenőrzés nem futott le, ettől még jó lehet).',
+  'onboarding.step1.saved_restarted': 'Token elmentve, az ügynök újraindult az új hitelesítéssel.',
+  'onboarding.step1.saved_restart_failed': 'A token elmentve, de az ügynök újraindítása nem sikerült. Indítsd újra kézzel (Linux: systemctl --user restart marveen-channels), aztán térj vissza ide.',
   'onboarding.step1.launching':  'Indítás...',
   'onboarding.step1.launched':   'Ügynökök indítása folyamatban...',
   'onboarding.step2.tab':        'Telegram bot',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1507,6 +1507,8 @@ window._i18n.hu = {
   'onboarding.step1.token_empty':'Illeszd be a tokent.',
   'onboarding.step1.saved_verified':   'Token elmentve és ellenőrizve.',
   'onboarding.step1.saved_unverified': 'Token elmentve (az ellenőrzés nem futott le, ettől még jó lehet).',
+  'onboarding.flow_note': 'A négy lépés egymásra épül: a rendszer a 4. lépés (párosítás) után indul el és kezd válaszolni. Addig a hiányzó lépésekre hivatkozó üzenetek normálisak.',
+  'onboarding.flow_note_last': 'Ez az utolsó lépés: a párosítás után a rendszer élesben elindul.',
   'onboarding.step1.saved_restarted': 'Token elmentve, az ügynök újraindult az új hitelesítéssel.',
   'onboarding.step1.saved_restart_failed': 'A token elmentve, de az ügynök újraindítása nem sikerült. Indítsd újra kézzel (Linux: systemctl --user restart marveen-channels), aztán térj vissza ide.',
   'onboarding.step1.launching':  'Indítás...',

--- a/web/style.css
+++ b/web/style.css
@@ -7093,7 +7093,12 @@ body {
 .updates-version-details .updates-commit-list { padding: 10px 0 2px; }
 /* First-run onboarding wizard */
 .onboarding-overlay { z-index: 10000; }
-.onboarding-modal { max-width: 540px; width: 92%; position: relative; }
+/* The base .modal ships zero padding (other modals pad via .modal-header /
+   .modal-body); the onboarding wizard renders its content directly, so it
+   needs its own inner padding -- without it the title and inputs sit flush
+   against the modal edge (first screen every fresh install sees). */
+.onboarding-modal { max-width: 540px; width: 92%; position: relative; padding: 24px 26px 22px; }
+@media (max-width: 600px) { .onboarding-modal { padding: 18px 16px 16px; } }
 .onboarding-modal .modal-close { position: absolute; top: 12px; right: 12px; }
 .onboarding-modal h2 { margin: 0 0 4px; }
 .onb-sub { color: var(--text-muted); font-size: 13px; margin: 0 0 16px; }

--- a/web/style.css
+++ b/web/style.css
@@ -7102,7 +7102,8 @@ body {
 .onboarding-modal .modal-close { position: absolute; top: 12px; right: 12px; }
 .onboarding-modal h2 { margin: 0 0 4px; }
 .onb-sub { color: var(--text-muted); font-size: 13px; margin: 0 0 16px; }
-.onboarding-steps { display: flex; gap: 8px; margin-bottom: 18px; }
+.onboarding-steps { display: flex; gap: 8px; margin-bottom: 10px; }
+.onb-flow-note { font-size: 12px; color: var(--text-muted); background: var(--bg-input); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; margin: 0 0 14px; }
 .onboarding-step { flex: 1; display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-muted); padding: 6px 8px; border-radius: 8px; background: var(--bg-input); border: 1px solid var(--border); }
 .onboarding-step.active { color: var(--text); border-color: var(--accent); }
 .onboarding-step.done { opacity: 0.55; }


### PR DESCRIPTION
## Root cause (measured, not assumed)

Fresh installs boot the channels session (installer / service unit) **before** any Claude credential exists. `/api/onboarding/launch` guards on `agentsRunning()` and short-circuits with `alreadyRunning` when the session exists -- so the token saved in wizard step 2 never reached the already-running process (a running process cannot pick up new env), and the install stayed logged out. Hit live at the BK bootcamp on 2026-07-28 morning.

## Fix

- `/api/onboarding/claude-auth` captures `hadAuthBefore` **before** persisting. After a successful save, if the install had **no** auth before and a session is running, that session is unauthenticated by construction -- it gets `hardRestartMarveenChannels()` (respawn-pane on Linux, so only the main channels pane is touched, never the tmux server). Response carries `restarted` / `restartError`.
- Re-pasting a token on an **already authenticated** install keeps today's behaviour: no implicit restart of a working fleet.
- Wizard UI surfaces the restart result (new hu/en strings); on restart failure it shows the manual-restart step instead of silently advancing.
- The onboarding modal rendered directly into the padding-less `.modal` base -- it now has its own inner padding (this is the first screen every fresh install sees).

## Verification (real fresh-install simulation, isolated sandbox on the reference VPS)

Sandbox: fresh clone of this branch, own `.env` (identity set, **no auth**, own `MAIN_AGENT_ID`/port), isolated `$HOME`, and a pre-started unauthenticated `onbtest-channels` tmux session -- exactly the field state.

1. **Fresh case:** POST claude-auth -> `{"ok":true,"verified":false,"restarted":true}`, session pane PID changed (1190813 -> 1191302). PASS
2. **Control case:** second POST (install now authenticated) -> `restarted:false`, no restart. PASS
3. `.env` received the token; `/launch` keeps its role unchanged.
4. Modal padding verified in a real browser over the sandbox dashboard (computed padding `24px 26px 22px`, screenshot checked).
5. `tsc` build clean, `node --check` clean on app.js / sw.js / lang files.

Note for reviewers: the sandbox run also surfaced that a second dashboard instance on the same host SIGTERMs the incumbent via the port-lock takeover unless `WEB_PORT` is set in the sandbox `.env` -- known second-instance footgun, documented in the fleet memory; no change made to that behaviour here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)