### PR TITLE
fix(monitor): never let a blind recovery keystroke reach the model consent dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marveen",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marveen",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",

--- a/src/__tests__/fable-overage-consent.test.ts
+++ b/src/__tests__/fable-overage-consent.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'no
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { stampFableOverageConsent } from '../web/agent-process.js'
-import { detectsModelConsentDialog } from '../pane-state.js'
+import { detectsBlockingMenu, detectsModelConsentDialog } from '../pane-state.js'
 
 const ORG = '238d7fa8-0000-4000-8000-000000000000'
 const ACCT = '4039fb28-0000-4000-8000-000000000000'
@@ -90,6 +90,20 @@ const CONSENT_DIALOG_PANE = `
 
 describe('detectsModelConsentDialog', () => {
   it('detects the live usage-credit model-switch dialog', () => {
+    expect(detectsModelConsentDialog(CONSENT_DIALOG_PANE)).toBe(true)
+  })
+
+  // FABLEFALL1 regression anchor: the consent dialog ALSO satisfies the generic
+  // stuck-menu detector (its footer says "Esc to cancel"), so any recovery
+  // branch keyed on detectsBlockingMenu alone WILL reach it with a blind
+  // keystroke. This test pins the shadowing itself: if it ever fails because
+  // detectsBlockingMenu stops matching, the ordering guards in
+  // channel-monitor can be simplified -- until then, every blind-keystroke
+  // branch must probe detectsModelConsentDialog FIRST (measured field impact:
+  // 12 customer events + 5 local events, choice:"cancelled", session continued
+  // on the fallback model).
+  it('is shadowed by detectsBlockingMenu -- guards must check consent first', () => {
+    expect(detectsBlockingMenu(CONSENT_DIALOG_PANE)).toBe(true)
     expect(detectsModelConsentDialog(CONSENT_DIALOG_PANE)).toBe(true)
   })
 

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -651,6 +651,28 @@ export function stampFableOverageConsent(dotClaudePath: string): boolean {
   }
 }
 
+// FABLEFALL1: the per-agent stamp above only runs on the startAgentProcess
+// spawn path. The MAIN channels session (spawned by channels.sh / launchd)
+// and the interactive workers' shared roots never pass through it, so those
+// roots never self-heal -- and the main session is exactly the long-running
+// process the menu-recovery keystrokes hit (silent Fable->Sonnet drift,
+// measured on 2026-07-28: 5 events, 514 post-fallback Sonnet turns here, 12
+// events at a customer). Called at dashboard boot and before every hard
+// restart of the channels session. Worker dir resolution mirrors
+// agent-worker.ts (env override + fixed default); change-only writes.
+export function stampFableOverageConsentSharedRoots(): void {
+  const mainDir = ensureMainAgentIsolatedConfigDir()
+  const candidates = [
+    mainDir ? join(mainDir, '.claude.json') : null,
+    join(homedir(), '.claude.json'),
+    join(process.env.MARVEEN_WORKER_DIR || join(homedir(), '.marveen-worker'), '.claude-config', '.claude.json'),
+    join(process.env.MARVEEN_WORKER_DIR_FAST || join(homedir(), '.marveen-worker-fast'), '.claude-config', '.claude.json'),
+  ]
+  for (const p of candidates) {
+    if (p && existsSync(p)) stampFableOverageConsent(p)
+  }
+}
+
 function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
   if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord' || perAgent === 'googlechat' || perAgent === 'teams') return perAgent

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -13,6 +13,8 @@ import {
   captureParkedInputView,
   clearInputBuffer,
   dismissResumeSummaryModalIfPresent,
+  dismissModelConsentDialogIfPresent,
+  stampFableOverageConsentSharedRoots,
   isAgentRunning,
   sendPromptToSession,
   startAgentProcess,
@@ -28,7 +30,7 @@ import { reapChannelOrphans, reapDetachedChannelClaudes, collectPollerEvidence }
 import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { schedulePluginUnlockAfterRespawn, wasPluginConfirmedAbsent, clearPluginAbsent } from './channel-plugin-unlock.js'
 import {
-  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, type PaneErrorAlertState, type PaneState,
+  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, detectsModelConsentDialog, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
   parkedInputText, shouldClearTruncatedPreamble,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
@@ -359,6 +361,11 @@ async function performStuckInputAction(
           await clearInputBuffer(session)
           await sendPromptToSession(session, text)
         } else {
+          // FABLEFALL1: a bare Enter on the model consent dialog confirms its
+          // DEFAULT option, which switches the model. Answer the dialog safely
+          // first (no-op when absent); an Enter on the then-idle prompt is
+          // harmless.
+          await dismissModelConsentDialogIfPresent(session)
           execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
         }
         submitted = true
@@ -373,6 +380,10 @@ async function performStuckInputAction(
         await clearInputBuffer(session)
         break
       case 'enter':
+        // FABLEFALL1: same guard as the reinject-plain fallback above -- a bare
+        // Enter must never reach the model consent dialog (its default SWITCHES
+        // the model). No-op when the dialog is absent.
+        await dismissModelConsentDialogIfPresent(session)
         execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
         submitted = true
         break
@@ -979,6 +990,11 @@ function schedulePostResumePluginGuard(provider: ChannelProviderType): void {
 }
 
 export function hardRestartMarveenChannels(): { ok: boolean; error?: string } {
+  // FABLEFALL1: the restarted session boots from the main/worker shared config
+  // roots, which the per-agent spawn-time stamp never covers -- stamp them now
+  // so the model consent dialog cannot render on the fresh boot (change-only,
+  // no-op when already stamped).
+  try { stampFableOverageConsentSharedRoots() } catch { /* backstop handlers remain */ }
   // macOS: bounce the launchd job when the plist exists. If the channels session
   // is NOT managed by launchd on this install (plist absent -- only
   // com.jarvis.dashboard exists), fall through to the respawn-pane path below.
@@ -1369,6 +1385,10 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
     logger.info({ host: hostname() }, 'Channel plugin monitor disabled (respawn is production-only)')
     return null
   }
+  // FABLEFALL1 boot pass: stamp the main/worker shared config roots that the
+  // per-agent spawn path never reaches, so an already-running unstamped install
+  // heals on the next dashboard boot instead of never.
+  try { stampFableOverageConsentSharedRoots() } catch { /* backstop handlers remain */ }
 
   const mainProvider = getMainAgentProvider()
 
@@ -1474,13 +1494,28 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
             sendAlert(`🧭 A(z) ${label} session a Claude Code első-indítási képernyőjén parkolt (${firstRunGate}); automatikusan továbbléptettem. A várakozó ütemezett feladatok a következő körben kézbesítődnek.`)
           }
         } else {
-          logger.warn({ session: t.session, agent: label }, 'Session parked in a blocking interactive menu -- sending Escape to recover')
-          try {
-            execFileSync(TMUX, ['send-keys', '-t', t.session, 'Escape'], { timeout: 5000 })
-          } catch (err) {
-            logger.warn({ err, session: t.session }, 'Menu-recovery Escape failed')
+          // FABLEFALL1: the model usage-credit consent dialog is indistinguishable
+          // from a stuck menu out here -- its footer says "Esc to cancel", so
+          // detectsBlockingMenu matches it. But Escape on that dialog is recorded
+          // as choice:"cancelled" and the CLI still continues on the FALLBACK
+          // model (measured: 59 ms Escape->fallback-record at a customer; 5 events
+          // and 514 silent Sonnet turns on this install). Probe for the dialog
+          // first and answer it safely (option 1, keep the configured model);
+          // only a genuine menu gets the blind Escape.
+          const paneNow = capturePane(t.session)
+          if (paneNow != null && detectsModelConsentDialog(paneNow)) {
+            logger.warn({ session: t.session, agent: label }, 'Blocking "menu" is the model usage-credit consent dialog -- answering it safely instead of Escape')
+            await dismissModelConsentDialogIfPresent(t.session)
+            sendAlert(`🎛️ A(z) ${label} session a modell-hozzájárulás dialóguson parkolt; az 1-es opcióval (a beállított modell megtartása) továbbléptettem. Modellváltás NEM történt.`)
+          } else {
+            logger.warn({ session: t.session, agent: label }, 'Session parked in a blocking interactive menu -- sending Escape to recover')
+            try {
+              execFileSync(TMUX, ['send-keys', '-t', t.session, 'Escape'], { timeout: 5000 })
+            } catch (err) {
+              logger.warn({ err, session: t.session }, 'Menu-recovery Escape failed')
+            }
+            sendAlert(`⌨️ A(z) ${label} session beragadt egy interaktiv menube (pl. /mcp) es nem dolgozott fel uzeneteket. Kikuldtem egy Escape-et, visszateritettem a prompthoz. Ha ismetlodik: tmux attach -t ${t.session}`)
           }
-          sendAlert(`⌨️ A(z) ${label} session beragadt egy interaktiv menube (pl. /mcp) es nem dolgozott fel uzeneteket. Kikuldtem egy Escape-et, visszateritettem a prompthoz. Ha ismetlodik: tmux attach -t ${t.session}`)
         }
       }
     }


### PR DESCRIPTION
Card: FABLEFALL1. **Reframed per Marveen msg 7216: the primary fix here is that the recovery stack must never press blind keystrokes into a modal it has not identified -- the Fable consent dialog is only today's instance of that class.**

## The class problem (ours, regardless of any upstream fix)

`detectsBlockingMenu` keys on a footer phrase ("Esc to cancel"). ANY dialog -- today's Fable usage-credit consent, or any future modal that uses the same phrase -- satisfies it, and three recovery branches then press blind keystrokes into it: the menu-recovery Escape and two direct stuck-input Enters that bypass the `sendKeysToSession` pre-flight. On the consent dialog specifically this was measured to cause silent model drift (customer: 12 events, 59 ms PID-pinned Escape->fallback proof; this install: 5 events, 514 silent Sonnet turns) -- but the defect is the blind press, not the dialog.

## Change

**(i)+(ii) -- the standalone fix:**
- Menu-recovery branch: fresh capture + `detectsModelConsentDialog` probe BEFORE the blind Escape; on match, `dismissModelConsentDialogIfPresent` answers safely (option 1, keeps the configured model) with a distinct alert. Genuine menus keep today's Escape.
- The two direct Enter sites (`reinject-plain` fallback, `enter` case): the same no-op-when-absent safe handler runs first.
- Deliberately NO blanket wrapper: three targeted guards keep the recovery stack auditable. A regression-anchor test pins the shadowing itself (the consent pane also matches `detectsBlockingMenu`), so the ordering cannot be silently "simplified" away while the shadowing holds -- and if a future unknown modal appears, the guard pattern (identify first, then act) is the precedent.

**(iii) -- UPSTREAM-DEPENDENT, TRIVIALLY REMOVABLE (marked for exit):**
- `stampFableOverageConsentSharedRoots()`: stamps the main isolated root + `~/.claude.json` + both worker roots at monitor boot and before hard restarts (the per-agent stamp only runs on the `startAgentProcess` spawn path, which these roots never traverse). This is a workaround that keeps the dialog from rendering at all. **If Anthropic fixes/removes the dialog upstream, this part becomes dead code: remove ONE function (`agent-process.ts`) and its TWO call sites (`channel-monitor.ts`) -- nothing else depends on it.** No periodic re-stamper or further mechanism was built on top, per the upstream-pending decision.

**What is deliberately NOT here:** no model-restore logic (detecting a fallback and switching the model back) -- that would take over the CLI's job. The separate CLI-level issue (`choice:"cancelled"` yet the session continues on the fallback model; version-independent 2.1.196/2.1.217; variable fallback target; no structured reason field) is reported upward independently.

## Verify

`tsc` clean; full suite 2859/2860 (single failure = known pre-existing `federation-ui-contract` ordering, TESTPREEX1, fails identically on plain develop); 216 pane/consent tests green incl. the new shadowing anchor. Live one-shot mitigation (all 14 roots stamped with per-write parse/consent/oauth-survival verification) already applied under Marveen's GO, independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)