### PR TITLE
fix(scheduler): never judge a working session stuck -- identify before any recovery keystroke

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marveen",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marveen",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",

--- a/src/__tests__/scheduled-resubmit-stuck.test.ts
+++ b/src/__tests__/scheduled-resubmit-stuck.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { isScheduledPromptStuck, decideScheduledResubmitAction } from '../web/schedule-runner.js'
+
+const MARKER = '[Utemezett feladat: deli-kutatas]'
+
+// The measured 2026-07-28 12:00 field case: the prompt was SUBMITTED and the
+// session was actively working on it (WebSearch running). The marker is
+// visible in the transcript echo, the pane is busy, and the input box is
+// empty. The old busy-blind check judged this stuck and pressed keystrokes
+// into a working session.
+const WORKING_PANE = `
+  ${MARKER}
+  Vegezd el a deli kutatast a szokasos forrasokbol.
+  ✻ Baking… (12s · esc to interrupt)
+─────────────────────────────────────────────
+❯
+─────────────────────────────────────────────
+  ⏵⏵ bypass permissions on (shift+tab to cycle)
+`
+
+// The genuine swallowed-Enter case the ladder exists for: OUR prompt text is
+// parked IN the input box (marker at/after the last ❯), session idle.
+const PARKED_PANE = `
+  Previous turn output above.
+─────────────────────────────────────────────
+❯ ${MARKER} Vegezd el a deli kutatast.
+─────────────────────────────────────────────
+  ⏵⏵ bypass permissions on (shift+tab to cycle)
+`
+
+// Input-pollution scenario (the harm class SCHEDDUP1 is really about): some
+// OTHER message parked in the input box while our submitted prompt's echo is
+// still on screen above. A bare Enter here would submit a message nobody
+// meant to send. The marker is NOT in the input region -> no keystroke.
+const OTHER_PARKED_PANE = `
+  ${MARKER}
+  Vegezd el a deli kutatast a szokasos forrasokbol.
+─────────────────────────────────────────────
+❯ [Uzenet @marveen-tol]: fontos kerdes, ne kuldd el veletlenul
+─────────────────────────────────────────────
+  ⏵⏵ bypass permissions on (shift+tab to cycle)
+`
+
+describe('isScheduledPromptStuck (SCHEDDUP1 invariants)', () => {
+  // INVARIANT 1: a busy pane is NEVER stuck. If this test starts failing
+  // because the busy exclusion was "simplified" away, the recovery ladder is
+  // back to pressing keystrokes into working sessions -- do not remove the
+  // guard, fix the detector.
+  it('busy pane is never stuck, even with the marker on screen', () => {
+    expect(isScheduledPromptStuck(WORKING_PANE, MARKER)).toBe(false)
+  })
+
+  // INVARIANT 2: the marker must be IN the input region (at/after the last
+  // prompt box), not merely anywhere in the pane. Scrollback echo of a
+  // submitted prompt is the running/finished case, not the parked case.
+  it('marker only in scrollback is not stuck (the measured noon case shape)', () => {
+    const idleEcho = WORKING_PANE.replace('✻ Baking… (12s · esc to interrupt)\n', '')
+    expect(isScheduledPromptStuck(idleEcho, MARKER)).toBe(false)
+  })
+
+  // INVARIANT 3 -- the bare-Enter safety argument: an UNRELATED parked
+  // message never triggers the ladder, so the ladder's Enter can only ever
+  // submit our own scheduled prompt.
+  it('an unrelated parked message never counts as stuck', () => {
+    expect(isScheduledPromptStuck(OTHER_PARKED_PANE, MARKER)).toBe(false)
+  })
+
+  it('detects the genuine parked-own-prompt case', () => {
+    expect(isScheduledPromptStuck(PARKED_PANE, MARKER)).toBe(true)
+  })
+
+  it('null and empty panes are not stuck', () => {
+    expect(isScheduledPromptStuck(null, MARKER)).toBe(false)
+    expect(isScheduledPromptStuck('', MARKER)).toBe(false)
+    expect(isScheduledPromptStuck('   \n  ', MARKER)).toBe(false)
+  })
+
+  it('a pane with no prompt box is not stuck', () => {
+    expect(isScheduledPromptStuck(`  ${MARKER}\n  some output`, MARKER)).toBe(false)
+  })
+})
+
+describe('decideScheduledResubmitAction ladder (unchanged semantics)', () => {
+  it('not stuck -> none at any attempt', () => {
+    for (const a of [0, 1, 2, 5, 6, 10]) expect(decideScheduledResubmitAction(a, false)).toBe('none')
+  })
+  it('escalates enter -> reinject -> giveup', () => {
+    expect(decideScheduledResubmitAction(0, true)).toBe('enter')
+    expect(decideScheduledResubmitAction(1, true)).toBe('enter')
+    expect(decideScheduledResubmitAction(2, true)).toBe('reinject')
+    expect(decideScheduledResubmitAction(5, true)).toBe('reinject')
+    expect(decideScheduledResubmitAction(6, true)).toBe('giveup')
+  })
+})

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -154,6 +154,32 @@ export function decideScheduledResubmitAction(
   return attempt < RESUBMIT_BARE_ENTER_ATTEMPTS ? 'enter' : 'reinject'
 }
 
+// SCHEDDUP1: is OUR scheduled prompt actually parked in the input box? The
+// previous inline check (`/❯\s+\S/.test(pane) && pane.includes(marker)`) was
+// busy-blind and matched the marker ANYWHERE in the pane -- so a session that
+// had already submitted the prompt and was ACTIVELY WORKING on it (marker
+// visible in the transcript echo, anything on the input line) was judged
+// stuck, and the recovery ladder pressed keystrokes into a working session
+// (measured 2026-07-28 12:00: 20 s after injection, mid-WebSearch, task
+// completed fine). Two narrowings, both invariants pinned by unit tests:
+//   1. BUSY EXCLUSION: a busy pane is never stuck -- the prompt is running,
+//      not parked. Same identify-before-act rule as the FABLEFALL1 guards.
+//   2. MARKER IN THE INPUT REGION ONLY: the marker must sit at/after the LAST
+//      prompt box (❯), i.e. be the parked text itself -- a marker in the
+//      scrollback above is the running/finished case. This also makes the
+//      ladder's bare Enter safe by construction: it can only ever submit OUR
+//      OWN scheduled prompt, never an unrelated message that happened to park
+//      (an unrelated parked message has no marker in the input region, so no
+//      keystroke fires at all).
+export function isScheduledPromptStuck(pane: string | null, marker: string): boolean {
+  if (!pane || !pane.trim()) return false
+  if (detectPaneState(pane) === 'busy') return false
+  const idx = pane.lastIndexOf('❯')
+  if (idx < 0) return false
+  const inputRegion = pane.slice(idx)
+  return /❯\s+\S/.test(inputRegion) && inputRegion.includes(marker)
+}
+
 // --- Schedule Runner ---
 // Checks every minute if any scheduled task is due and injects the prompt
 // into the agent's tmux session.
@@ -550,7 +576,7 @@ async function attemptFireTask(
         // Host-aware so a remote agent's post-send stuck-check + recovery Enter
         // hit the laptop session, not a (nonexistent) local one.
         const pane = capturePane(session, host)
-        const stuck = pane != null && /❯\s+\S/.test(pane) && pane.includes(marker)
+        const stuck = isScheduledPromptStuck(pane, marker)
         const action = decideScheduledResubmitAction(attempt, stuck)
         if (action === 'none') return
         if (action === 'giveup') {


### PR DESCRIPTION
Card: SCHEDDUP1. **HOLD: merge TOMORROW with full verify (Marveen msg 7240) -- the scheduler touches every scheduled task and today is bootcamp day.**

## The class problem (same habit as FABLEFALL1, second site)

The post-send resubmit ladder acted before identifying: its stuck check (`/❯\s+\S/.test(pane) && pane.includes(marker)`) consulted no busy state and matched the marker anywhere in the pane. A session that had submitted the prompt and was ACTIVELY WORKING on it was judged stuck 20 s after injection (measured live 2026-07-28 12:00, mid-WebSearch; the task completed fine) and received recovery keystrokes. The worst case is not duplication but **input pollution**: the ladder's bare Enter can submit an UNRELATED message that parked meanwhile -- outward-facing, the phantom-injection family.

## Change (the CONDITION is the fix, not the patience)

`isScheduledPromptStuck(pane, marker)` -- pure, exported, replaces the inline check. Two narrowings:
1. **Busy exclusion:** `detectPaneState(pane) === 'busy'` is never stuck -- the prompt is running, not parked.
2. **Marker in the input region only:** the marker must sit at/after the LAST prompt box (the parked text itself); scrollback echo is the running/finished case.

**The bare-Enter question answered (per review request):** it STAYS, because the narrowed condition makes it safe by construction -- the ladder only fires when OUR OWN prompt is the parked input, so its Enter can only ever submit our own scheduled prompt. An unrelated parked message has no marker in the input region, so no keystroke fires at all (pinned by a dedicated test). Removing it would leave the genuine swallowed-Enter case -- the ladder's original purpose -- unhealed.

Ladder semantics (`enter -> reinject -> giveup`, thresholds) unchanged. `skipIfBusy` configs untouched (separate question, deliberately not mixed in).

## Structural tests (invariants pinned, not happy-path)

New `scheduled-resubmit-stuck.test.ts` (8 tests): (i) busy pane is NEVER stuck even with the marker on screen -- a later "simplification" collides with this test instead of silently regressing; (ii) marker-only-in-scrollback is not stuck (the measured noon case shape); (iii) an unrelated parked message never triggers the ladder (the bare-Enter safety argument as a test); (iv) the genuine parked-own-prompt case still detects; plus ladder-semantics regression cases.

## Verify

`tsc` clean; new tests 8/8; full suite 2866/2867 -- the single failure is the known pre-existing `federation-ui-contract` ordering (TESTPREEX1, fails identically on plain develop). Real-data probe round agreed for post-merge verify: observation window on a long-running scheduled WebSearch task (owner volunteered), no intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)