### PR TITLE
feat(installer): headless mode for install-linux.sh -- non-interactive + JSON progress + auto-enroll (INSTWIZ1)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -23,6 +23,119 @@ warn() { echo -e "  ${ORANGE}!${NC} $*"; }
 
 INSTALL_STEP="init"
 
+# --- INSTWIZ1 headless-install helpers (contract) BEGIN ---
+# Non-interactive mode: MARVEEN_NONINTERACTIVE=1 skips EVERY stdin prompt and
+# takes the value from a MARVEEN_* preset env var (when one is defined for the
+# prompt) or from the documented default -- no `read` may ever touch stdin in
+# this mode (a bare read would EOF-abort a curl|ssh bootstrap).
+# Machine progress: MARVEEN_JSON_PROGRESS=1 emits one
+#   MARVEEN_PROGRESS {"step":"<id>","status":"start|ok|fail","detail":"..."}
+# line per step transition on stdout, and exactly one closing
+#   MARVEEN_RESULT {"ok":...,"dashboardPort":...,"enrollBundle":...}
+# line at the end (success AND failure paths -- fail()/ERR trap/EXIT trap).
+# Secrets (tokens, passwords, dashboard-token URLs) must NEVER appear in a
+# MARVEEN_PROGRESS line; emit_progress scrubs suspicious detail strings.
+
+# prompt_or_preset VAR "prompt" "noninteractive-default" ["PRESET_ENV"] ["noraw"]
+# Interactive mode is byte-identical to the read -rp / read -p it replaces
+# (any post-read `VAR=${VAR:-default}` line at the call site stays as-is and
+# keeps applying the interactive default).
+prompt_or_preset() {
+  local __var="$1" __prompt="$2" __ni_default="$3" __preset_env="${4:-}" __readmode="${5:-raw}"
+  if [ "${MARVEEN_NONINTERACTIVE:-0}" = "1" ]; then
+    local __val=""
+    if [ -n "$__preset_env" ]; then
+      __val="${!__preset_env:-}"
+    fi
+    if [ -z "$__val" ]; then
+      __val="$__ni_default"
+    fi
+    printf -v "$__var" '%s' "$__val"
+    return 0
+  fi
+  if [ "$__readmode" = "noraw" ]; then
+    read -p "$__prompt" "$__var"
+  else
+    read -rp "$__prompt" "$__var"
+  fi
+}
+
+# Minimal JSON string escaping for progress lines (backslash, double quote;
+# newlines/tabs flattened to spaces, CR dropped).
+json_escape() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/ }
+  s=${s//$'\r'/}
+  s=${s//$'\t'/ }
+  printf '%s' "$s"
+}
+
+# Redact anything that even smells like a credential before it can reach a
+# progress/result line. Over-redaction is fine; leaking is not.
+scrub_secretish() {
+  local s="$1"
+  case "$s" in
+    *sk-ant-*|*token=*|*TOKEN=*|*password*|*Password*|*jelszo*) printf '[redacted]' ;;
+    *) printf '%s' "$s" ;;
+  esac
+}
+
+emit_progress() {
+  if [ "${MARVEEN_JSON_PROGRESS:-0}" != "1" ]; then return 0; fi
+  local step="$1" status="$2" detail="${3:-}"
+  detail="$(scrub_secretish "$detail")"
+  if [ -n "$detail" ]; then
+    printf 'MARVEEN_PROGRESS {"step":"%s","status":"%s","detail":"%s"}\n' \
+      "$(json_escape "$step")" "$(json_escape "$status")" "$(json_escape "$detail")"
+  else
+    printf 'MARVEEN_PROGRESS {"step":"%s","status":"%s"}\n' \
+      "$(json_escape "$step")" "$(json_escape "$status")"
+  fi
+}
+
+MARVEEN_RESULT_EMITTED=0
+# emit_result <true|false> [error-message] [enrollBundle]
+# Emits at most ONE MARVEEN_RESULT line per install run (first caller wins).
+emit_result() {
+  if [ "${MARVEEN_JSON_PROGRESS:-0}" != "1" ]; then return 0; fi
+  if [ "$MARVEEN_RESULT_EMITTED" = "1" ]; then return 0; fi
+  MARVEEN_RESULT_EMITTED=1
+  local ok="$1" err="${2:-}" bundle="${3:-}" port="${WEB_PORT:-3420}" bundle_json="null"
+  if ! [[ "$port" =~ ^[0-9]+$ ]]; then port=3420; fi
+  if [ -n "$bundle" ]; then bundle_json="\"$(json_escape "$bundle")\""; fi
+  if [ "$ok" = "true" ]; then
+    printf 'MARVEEN_RESULT {"ok":true,"dashboardPort":%s,"enrollBundle":%s}\n' "$port" "$bundle_json"
+  else
+    err="$(scrub_secretish "$err")"
+    printf 'MARVEEN_RESULT {"ok":false,"dashboardPort":%s,"enrollBundle":%s,"error":"%s"}\n' \
+      "$port" "$bundle_json" "$(json_escape "$err")"
+  fi
+}
+
+# Step transition: close the previous step (ok) and open the new one (start).
+set_step() {
+  if [ -n "${INSTALL_STEP:-}" ] && [ "$INSTALL_STEP" != "init" ] && [ "$INSTALL_STEP" != "$1" ]; then
+    emit_progress "$INSTALL_STEP" ok
+  fi
+  INSTALL_STEP="$1"
+  emit_progress "$INSTALL_STEP" start
+}
+
+# Safety net: any exit path that did not already emit a MARVEEN_RESULT line
+# (e.g. a stray `exit 1` outside fail()/on_error()) still closes the protocol.
+# A successful `exec` (repo re-bootstrap) does not run the EXIT trap, which is
+# correct -- the re-executed installer owns the protocol from there.
+on_exit_emit_result() {
+  local __code=$?
+  if [ "$__code" -ne 0 ]; then
+    emit_result false "installer exited with code ${__code} at step ${INSTALL_STEP}"
+  fi
+}
+trap on_exit_emit_result EXIT
+# --- INSTWIZ1 headless-install helpers (contract) END ---
+
 # shellcheck source=install-lang.sh
 source "$(dirname "$0")/install-lang.sh"
 
@@ -35,7 +148,7 @@ offer_claude_fallback() {
   echo -e "${ORANGE}Claude Code elerheto a gepen.${NC}"
   local prompt="Marveen installer failed at step \"${step}\". Error: ${err_msg}. Script: install-linux.sh${line_info}. Repo: https://github.com/Szotasz/marveen. OS: $(lsb_release -ds 2>/dev/null || cat /etc/os-release 2>/dev/null | head -1 || echo Linux). Node: $(node -v 2>/dev/null || echo missing). Dir: ${INSTALL_DIR}. Your task: diagnose this Marveen installer failure. The install scripts are install.sh (macOS) and install-linux.sh. Read the relevant section, check for missing dependencies or permission issues, and suggest concrete shell commands to fix."
   if [ -t 0 ]; then
-    read -rp "$(_t prompt_open_claude)" OPEN_CLAUDE
+    prompt_or_preset OPEN_CLAUDE "$(_t prompt_open_claude)" "n"
     OPEN_CLAUDE=${OPEN_CLAUDE:-n}
     if [[ "$OPEN_CLAUDE" == "i" || "$OPEN_CLAUDE" == "y" ]]; then
       # `claude` az inicialis promptot pozicionalis argumentumkent veszi.
@@ -50,6 +163,8 @@ offer_claude_fallback() {
 
 fail() {
   echo -e "  ${RED}✗${NC} $*"
+  emit_progress "$INSTALL_STEP" fail "$*"
+  emit_result false "step ${INSTALL_STEP}: $*"
   offer_claude_fallback "$INSTALL_STEP" "$*" "${BASH_LINENO[0]}"
   exit 1
 }
@@ -57,6 +172,8 @@ fail() {
 on_error() {
   echo ""
   echo -e "${RED}Varatlan hiba a(z) '${INSTALL_STEP}' lepesben (sor: $1).${NC}"
+  emit_progress "$INSTALL_STEP" fail "Unexpected error at line $1"
+  emit_result false "unexpected error at line $1 (step ${INSTALL_STEP})"
   offer_claude_fallback "$INSTALL_STEP" "Unexpected error at line $1" "$1"
   exit 1
 }
@@ -120,7 +237,7 @@ echo ""
 echo -e "${DIM}  Telepito wizard - Linux (Ubuntu/Debian)${NC}"
 echo ""
 
-INSTALL_STEP="prerequisites"
+set_step "prerequisites"
 # ─────────────────────────────────────────────
 # [1/7] Elofeltetelek
 # ─────────────────────────────────────────────
@@ -149,7 +266,7 @@ if command -v free &>/dev/null; then
     warn "$(_t linux.low_ram_prefix) ${TOTAL_RAM_MB} MB RAM + ${TOTAL_SWAP_MB} MB swap = ${TOTAL_AVAIL} MB"
     echo -e "  ${ORANGE}Az npm build legalabb 2 GB memoriat igenyel.${NC}"
     if [ "$TOTAL_SWAP_MB" -lt 1024 ]; then
-      read -rp "$(_t prompt_swap)" CREATE_SWAP
+      prompt_or_preset CREATE_SWAP "$(_t prompt_swap)" "i"
       CREATE_SWAP=${CREATE_SWAP:-i}
       if [ "$CREATE_SWAP" = "i" ]; then
         echo -e "  Swap letrehozasa (sudo szukseges)..."
@@ -300,7 +417,7 @@ if [ ! -f "$INSTALL_DIR/package.json" ]; then
   exec bash "$TARGET_DIR/install-linux.sh"
 fi
 
-INSTALL_STEP="claude-bun-install"
+set_step "claude-bun-install"
 # ─────────────────────────────────────────────
 # [2/7] Claude Code + Bun telepitese
 # ─────────────────────────────────────────────
@@ -417,7 +534,7 @@ fi
 ensure_in_rc 'BUN_INSTALL' 'export BUN_INSTALL="$HOME/.bun"'
 ensure_in_rc '.bun/bin' 'export PATH="$BUN_INSTALL/bin:$PATH"'
 
-INSTALL_STEP="claude-auth"
+set_step "claude-auth"
 # ─────────────────────────────────────────────
 # [3/7] Claude bejelentkezes
 # ─────────────────────────────────────────────
@@ -447,17 +564,17 @@ else
   echo -e "  ${BOLD}3.${NC} Kihagyas ${DIM}(kesobb allitod be)${NC}"
   echo ""
   if [ "$IS_HEADLESS" = "true" ]; then
-    read -rp "$(_t prompt_auth_mode)" AUTH_MODE
+    prompt_or_preset AUTH_MODE "$(_t prompt_auth_mode)" "3" "MARVEEN_AUTH_MODE"
     AUTH_MODE=${AUTH_MODE:-2}
   else
-    read -rp "$(_t prompt_auth_mode)" AUTH_MODE
+    prompt_or_preset AUTH_MODE "$(_t prompt_auth_mode)" "3" "MARVEEN_AUTH_MODE"
     AUTH_MODE=${AUTH_MODE:-3}
   fi
 
   if [ "$AUTH_MODE" = "1" ]; then
     echo ""
     echo -e "  ${DIM}API kulcsot itt talalod: https://console.anthropic.com/settings/keys${NC}"
-    read -p "  ANTHROPIC_API_KEY (sk-ant-...): " ANTHROPIC_API_KEY_INPUT
+    prompt_or_preset ANTHROPIC_API_KEY_INPUT "  ANTHROPIC_API_KEY (sk-ant-...): " "" "MARVEEN_API_KEY" noraw
     if [ -n "$ANTHROPIC_API_KEY_INPUT" ]; then
       export ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY_INPUT"
       ensure_in_rc 'ANTHROPIC_API_KEY' "export ANTHROPIC_API_KEY=\"$ANTHROPIC_API_KEY_INPUT\""
@@ -475,7 +592,7 @@ else
     echo -e "  ${BOLD}3.${NC} A bongeszo megnyilik, jelentkezz be a Claude fiokoddal"
     echo -e "  ${BOLD}4.${NC} Masold vissza ide a kiirt tokent:"
     echo ""
-    read -p "  OAuth token: " OAUTH_TOKEN_INPUT
+    prompt_or_preset OAUTH_TOKEN_INPUT "  OAuth token: " "" "MARVEEN_OAUTH_TOKEN" noraw
     if [ -n "$OAUTH_TOKEN_INPUT" ]; then
       export CLAUDE_CODE_OAUTH_TOKEN="$OAUTH_TOKEN_INPUT"
       ensure_in_rc 'CLAUDE_CODE_OAUTH_TOKEN' "export CLAUDE_CODE_OAUTH_TOKEN=\"$OAUTH_TOKEN_INPUT\""
@@ -573,13 +690,13 @@ except Exception:
 PYEOF
 echo -e "  ${GREEN}✓${NC} Claude Code first-run beallitas kesz"
 
-INSTALL_STEP="personal-info"
+set_step "personal-info"
 # ─────────────────────────────────────────────
 # [4/7] Szemelyes beallitasok
 # ─────────────────────────────────────────────
 echo ""
 echo -e "${BOLD}$(_t section_4_linux)${NC}"
-read -rp "$(_t prompt_your_name)" OWNER_NAME
+prompt_or_preset OWNER_NAME "$(_t prompt_your_name)" "Owner" "MARVEEN_OWNER_NAME"
 # Chat ID is NOT asked here -- the user doesn't know it yet.
 # It will be set automatically during the Telegram pairing flow.
 CHAT_ID="0"
@@ -596,7 +713,9 @@ if [ "$IS_HEADLESS" = "true" ]; then
   echo -e "  ${BOLD}Javasoljuk:${NC} lepj be a claude.ai Settings oldalara es"
   echo -e "  tiltsd le a felesleges MCP-ket telepites elott."
   echo -e "${ORANGE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-  read -rp "$(_t prompt_vps_continue)" CONTINUE_MCP
+  # Non-interactive: ALWAYS "i" (no preset env on purpose) -- a headless
+  # bootstrap must never abort here.
+  prompt_or_preset CONTINUE_MCP "$(_t prompt_vps_continue)" "i"
   CONTINUE_MCP=${CONTINUE_MCP:-i}
   if [ "$CONTINUE_MCP" != "i" ]; then
     echo -e "  ${DIM}Telepites megszakitva. Tiltsd le a felesleges MCP-ket, majd futtasd ujra.${NC}"
@@ -612,7 +731,7 @@ echo -e "  ${BOLD}1.${NC} Telegram (alapertelmezett)"
 echo -e "  ${BOLD}2.${NC} Slack"
 echo -e "  ${BOLD}3.${NC} Discord"
 echo ""
-read -rp "$(_t prompt_channel_select_linux)" PROVIDER_CHOICE
+prompt_or_preset PROVIDER_CHOICE "$(_t prompt_channel_select_linux)" "1" "MARVEEN_PROVIDER"
 PROVIDER_CHOICE=${PROVIDER_CHOICE:-1}
 if [ "$PROVIDER_CHOICE" = "2" ]; then
   CHANNEL_PROVIDER="slack"
@@ -638,7 +757,7 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   echo -e "${DIM}  3. Adj nevet a botodnak${NC}"
   echo -e "${DIM}  4. Masold ide a kapott tokent:${NC}"
   echo ""
-  read -rp "$(_t prompt_telegram_token)" BOT_TOKEN
+  prompt_or_preset BOT_TOKEN "$(_t prompt_telegram_token)" "" "MARVEEN_BOT_TOKEN"
 elif [ "$CHANNEL_PROVIDER" = "discord" ]; then
   echo ""
   echo -e "${DIM}  Az AI asszisztensed Discordon kommunikal veled.${NC}"
@@ -649,12 +768,12 @@ elif [ "$CHANNEL_PROVIDER" = "discord" ]; then
   echo -e "${DIM}  5. Masold ki a csatorna ID-jet (Developer Mode > jobb klikk > Copy Channel ID)${NC}"
   echo -e "${DIM}  6. Sajat (operator) user ID: jobb klikk a nevedre > Copy User ID${NC}"
   echo ""
-  read -rp "$(_t prompt_discord_bot_token)" DISCORD_BOT_TOKEN
-  read -rp "$(_t prompt_discord_channel_id)" DISCORD_CHANNEL_ID
+  prompt_or_preset DISCORD_BOT_TOKEN "$(_t prompt_discord_bot_token)" "" "MARVEEN_DISCORD_BOT_TOKEN"
+  prompt_or_preset DISCORD_CHANNEL_ID "$(_t prompt_discord_channel_id)" "" "MARVEEN_DISCORD_CHANNEL_ID"
   echo ""
   echo -e "${DIM}  Az operator user ID-re a parositashoz kell: amikor egy uj felhasznalo${NC}"
   echo -e "${DIM}  DM-et ir a botnak, a bot ezen az ID-n ertesit teged jovahagyasert.${NC}"
-  read -rp "$(_t prompt_discord_user_id)" OPERATOR_DISCORD_USER_ID
+  prompt_or_preset OPERATOR_DISCORD_USER_ID "$(_t prompt_discord_user_id)" "" "MARVEEN_DISCORD_USER_ID"
 else
   echo ""
   echo -e "${DIM}  Az AI asszisztensed Slack-en kommunikal veled.${NC}"
@@ -668,11 +787,11 @@ else
   echo -e "${DIM}     app_mention, message.channels, message.groups, message.im${NC}"
   echo -e "${DIM}  5. Installald a workspace-be${NC}"
   echo ""
-  read -rp "$(_t prompt_slack_bot_token)" SLACK_BOT_TOKEN
-  read -rp "$(_t prompt_slack_app_token)" SLACK_APP_TOKEN
+  prompt_or_preset SLACK_BOT_TOKEN "$(_t prompt_slack_bot_token)" "" "MARVEEN_SLACK_BOT_TOKEN"
+  prompt_or_preset SLACK_APP_TOKEN "$(_t prompt_slack_app_token)" "" "MARVEEN_SLACK_APP_TOKEN"
 fi
 
-read -rp "$(_t prompt_bot_name)" BOT_NAME
+prompt_or_preset BOT_NAME "$(_t prompt_bot_name)" "Marveen" "MARVEEN_BOT_NAME"
 BOT_NAME=${BOT_NAME:-"Marveen"}
 
 # Derive the ASCII slug the backend uses everywhere (tmux sessions, systemd
@@ -699,7 +818,7 @@ fi
 BRAND_NAME="$BOT_NAME"
 SERVICE_ID="$MAIN_AGENT_ID"
 
-INSTALL_STEP="npm-install"
+set_step "npm-install"
 # ─────────────────────────────────────────────
 # [5/7] Fuggosegek telepitese + konfiguracic
 # ─────────────────────────────────────────────
@@ -713,7 +832,7 @@ if ! (npm ci --loglevel warn 2>/dev/null || npm install --loglevel warn); then
 fi
 ok "npm csomagok telepitve"
 
-INSTALL_STEP="typescript-build"
+set_step "typescript-build"
 echo -e "  TypeScript forditas..."
 if ! npm run build --loglevel warn; then
   fail "TypeScript forditas sikertelen. Ellenorizd a hibauzeneteket fentebb."
@@ -737,7 +856,7 @@ mkdir -p "$INSTALL_DIR/store"
 mkdir -p "$INSTALL_DIR/agents"
 ok "Konyvtarak letrehozva"
 
-INSTALL_STEP="configuration"
+set_step "configuration"
 # .env letrehozasa
 echo ""
 echo -e "${BOLD}  Konfiguracio letrehozasa...${NC}"
@@ -1029,7 +1148,7 @@ if [ -d "$SEED_SKILLS_DIR" ]; then
   fi
 fi
 
-INSTALL_STEP="ollama-whisper"
+set_step "ollama-whisper"
 # ─────────────────────────────────────────────
 # [6/7] Ollama + Whisper
 # ─────────────────────────────────────────────
@@ -1101,7 +1220,7 @@ echo -e "  Whisper telepites (beszed -> szoveg leirat, opcionalis)..."
 if command -v whisper &>/dev/null; then
   ok "whisper mar telepitve"
 else
-  read -rp "$(_t prompt_whisper)" DO_WHISPER
+  prompt_or_preset DO_WHISPER "$(_t prompt_whisper)" "n"
   DO_WHISPER=${DO_WHISPER:-n}
   if [ "$DO_WHISPER" = "i" ]; then
     pipx install openai-whisper 2>/dev/null &&
@@ -1112,7 +1231,7 @@ else
   fi
 fi
 
-INSTALL_STEP="bumblebee"
+set_step "bumblebee"
 # ─────────────────────────────────────────────
 # Go + bumblebee (supply-chain scanner)
 # ─────────────────────────────────────────────
@@ -1207,7 +1326,7 @@ else
   echo -e "  ${DIM}  Kezzel: sudo snap install go --classic && git clone https://github.com/perplexityai/bumblebee /tmp/bb && (cd /tmp/bb && go build -o ~/.local/bin/bumblebee ./cmd/bumblebee)${NC}"
 fi
 
-INSTALL_STEP="systemd"
+set_step "systemd"
 # ─────────────────────────────────────────────
 # [7/7] Automatikus inditas (systemd)
 # ─────────────────────────────────────────────
@@ -1521,7 +1640,7 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ] && [ -n "$BOT_TOKEN" ]; then
     echo -e "  ${BOLD}2.${NC} A bot valaszol egy parosito kodot"
     echo -e "  ${BOLD}3.${NC} Masold ide a kapott kodot:"
     echo ""
-    read -rp "$(_t prompt_pair_code)" PAIR_CODE
+    prompt_or_preset PAIR_CODE "$(_t prompt_pair_code)" ""
 
     if [ -n "$PAIR_CODE" ]; then
       if [ ! -f "$ACCESS_FILE" ]; then
@@ -1582,7 +1701,7 @@ fi
 echo ""
 echo -e "${BOLD}Korabbi rendszer koltoztetese${NC}"
 echo -e "${DIM}  Ha volt korabbi AI asszisztensed (OpenClaw, egyeni bot), atmigralhato a memoriai.${NC}"
-read -rp "$(_t prompt_migrate)" DO_MIGRATE
+prompt_or_preset DO_MIGRATE "$(_t prompt_migrate)" "n"
 DO_MIGRATE=${DO_MIGRATE:-n}
 if [ "$DO_MIGRATE" = "i" ]; then
   if [ -f "$INSTALL_DIR/scripts/migrate.sh" ]; then
@@ -1605,6 +1724,35 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ] && [ "$CHAT_ID" = "0" ]; then
   echo -e "  2. Masold a kapott parosito kodot"
   echo -e "  3. Futtasd: ${BOLD}claude${NC}, majd ${BOLD}/telegram:access pair AKOD${NC}"
   echo -e "${ORANGE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+fi
+
+# ─────────────────────────────────────────────
+# Auto-enroll (Bridge headless provisioning) -- INSTWIZ1 contract point 3
+# ─────────────────────────────────────────────
+# When MARVEEN_ENROLL_PUBKEY is set, enroll that SSH public key via the
+# existing remote-enroll flow and surface the base64 connection bundle in the
+# MARVEEN_RESULT line. remote-access-enroll.ts prints the bundle between
+# "----- BEGIN/END CONNECTION BUNDLE -----" marker lines on stdout; all
+# diagnostics go to stderr (captured to store/enroll.stderr.log). The bundle
+# is a secret by design (it may carry the dashboard token) -- it goes ONLY
+# into the MARVEEN_RESULT enrollBundle field, never into a progress line.
+ENROLL_BUNDLE=""
+if [ -n "${MARVEEN_ENROLL_PUBKEY:-}" ]; then
+  set_step "enroll"
+  echo ""
+  echo -e "${BOLD}Remote eszkoz enroll (Bridge)${NC}"
+  ENROLL_OUT="$(cd "$INSTALL_DIR" && npm run --silent remote-enroll -- "$MARVEEN_ENROLL_PUBKEY" 2>"$INSTALL_DIR/store/enroll.stderr.log")" || ENROLL_OUT=""
+  ENROLL_BUNDLE="$(printf '%s\n' "$ENROLL_OUT" | awk '/^----- BEGIN CONNECTION BUNDLE -----$/{f=1;next} /^----- END CONNECTION BUNDLE -----$/{f=0} f{printf "%s",$0}')"
+  if [ -n "$ENROLL_BUNDLE" ]; then
+    ok "Remote enroll kesz (connection bundle generalva)"
+  else
+    warn "Remote enroll sikertelen -- reszletek: $INSTALL_DIR/store/enroll.stderr.log"
+    emit_progress "enroll" fail "remote-enroll produced no bundle"
+    # The install itself completed, but the caller asked for an enroll bundle
+    # and did not get one -- report failure so the Bridge can offer a retry
+    # instead of silently proceeding without a way to connect.
+    emit_result false "remote-enroll failed: MARVEEN_ENROLL_PUBKEY was set but no connection bundle was produced (see store/enroll.stderr.log on the host)"
+  fi
 fi
 
 # ─────────────────────────────────────────────
@@ -1647,3 +1795,8 @@ echo -e "  ${DIM}  ./scripts/start.sh${NC}                           $(_t linux.
 echo -e "  ${DIM}  ./scripts/stop.sh${NC}                            -- leallitas"
 echo ""
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+# INSTWIZ1: close the machine progress protocol. emit_result is once-only, so
+# if the enroll leg above already reported a failure this stays a no-op.
+emit_progress "$INSTALL_STEP" ok
+emit_result true "" "$ENROLL_BUNDLE"

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -131,6 +131,13 @@ on_exit_emit_result() {
   local __code=$?
   if [ "$__code" -ne 0 ]; then
     emit_result false "installer exited with code ${__code} at step ${INSTALL_STEP}"
+  else
+    # Code 0 but no result yet = an early exit that never reached the normal
+    # completion (e.g. --help, or an aborted MCP prompt that exits 0). The
+    # normal success path emits `true` before returning, so the once-only guard
+    # makes this a no-op there; here it guarantees the machine consumer still
+    # gets exactly one closing MARVEEN_RESULT on every exit path.
+    emit_result false "installer exited early without completing (step ${INSTALL_STEP})"
   fi
 }
 trap on_exit_emit_result EXIT
@@ -422,7 +429,11 @@ if [ ! -f "$INSTALL_DIR/package.json" ]; then
     ok "Repo klonozva: $TARGET_DIR ($CLONE_REF)"
   fi
   echo -e "  Telepito ujrainditasa a checkoutbol..."
-  exec bash "$TARGET_DIR/install-linux.sh"
+  # Forward argv so a direct CLI run keeps its flags across the reclone. The
+  # headless/provision path passes WEB_PORT (and the other knobs) as ENV, which
+  # survives exec regardless -- this is belt-and-suspenders for interactive
+  # `--port` callers.
+  exec bash "$TARGET_DIR/install-linux.sh" "$@"
 fi
 
 set_step "claude-bun-install"
@@ -1758,8 +1769,13 @@ if [ -n "${MARVEEN_ENROLL_PUBKEY:-}" ]; then
     emit_progress "enroll" fail "remote-enroll produced no bundle"
     # The install itself completed, but the caller asked for an enroll bundle
     # and did not get one -- report failure so the Bridge can offer a retry
-    # instead of silently proceeding without a way to connect.
+    # instead of silently proceeding without a way to connect. EXIT here so the
+    # run does not fall through to the success banner and a trailing
+    # `emit_progress "$INSTALL_STEP" ok` that would repaint the failed enroll
+    # step green (the MARVEEN_RESULT is already false and the once-only guard
+    # keeps it authoritative).
     emit_result false "remote-enroll failed: MARVEEN_ENROLL_PUBKEY was set but no connection bundle was produced (see store/enroll.stderr.log on the host)"
+    exit 1
   fi
 fi
 

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -402,16 +402,24 @@ ok "unzip" $(unzip -v | awk 'NR==1 {print $2}')
 if [ ! -f "$INSTALL_DIR/package.json" ]; then
   warn "A telepito a repon kivulrol fut (nincs package.json itt: $INSTALL_DIR)."
   TARGET_DIR="$HOME/marveen"
+  # A repo default branch-e a develop, de a publikus telepito main-rol fut
+  # (a Windows/WSL wrapper is main-rol fetcheli a scriptet) -> a default main.
+  # A GUI-telepito (provision) MARVEEN_INSTALL_REF-fel adja meg, hogy a
+  # self-reclone UGYANARROL a ref-rol tortenjen, amirol a bootstrap-script jott
+  # -- kulonben egy nem-main ref-rol curl-olt script itt main-t klonozna es a
+  # sajat modjai (pl. headless mode) elveszne az exec-nel.
+  CLONE_REF="${MARVEEN_INSTALL_REF:-main}"
   if [ -f "$TARGET_DIR/package.json" ]; then
     ok "Meglevo checkout: $TARGET_DIR -- frissites..."
-    git -C "$TARGET_DIR" pull --ff-only 2>/dev/null || warn "git pull kihagyva (helyi valtozasok lehetnek)."
+    git -C "$TARGET_DIR" fetch --depth 1 origin "$CLONE_REF" 2>/dev/null \
+      && git -C "$TARGET_DIR" checkout -q FETCH_HEAD 2>/dev/null \
+      || git -C "$TARGET_DIR" pull --ff-only 2>/dev/null \
+      || warn "git frissites kihagyva (helyi valtozasok lehetnek)."
   else
-    echo -e "  Repo klonozasa -> ${TARGET_DIR} ..."
-    # A repo default branch-e a develop, de a publikus telepito main-rol fut
-    # (a Windows/WSL wrapper is main-rol fetcheli a scriptet) -> pineljuk a main-t.
-    git clone --depth 1 --branch main https://github.com/Szotasz/marveen.git "$TARGET_DIR" \
-      || fail "git clone sikertelen: https://github.com/Szotasz/marveen.git (main branch)"
-    ok "Repo klonozva: $TARGET_DIR"
+    echo -e "  Repo klonozasa (${CLONE_REF}) -> ${TARGET_DIR} ..."
+    git clone --depth 1 --branch "$CLONE_REF" https://github.com/Szotasz/marveen.git "$TARGET_DIR" \
+      || fail "git clone sikertelen: https://github.com/Szotasz/marveen.git ($CLONE_REF)"
+    ok "Repo klonozva: $TARGET_DIR ($CLONE_REF)"
   fi
   echo -e "  Telepito ujrainditasa a checkoutbol..."
   exec bash "$TARGET_DIR/install-linux.sh"

--- a/tests/headless-install-contract.sh
+++ b/tests/headless-install-contract.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# INSTWIZ1 headless-install contract tests for install-linux.sh.
+#
+# Sources ONLY the helper block (between the INSTWIZ1 BEGIN/END markers, minus
+# the EXIT trap) from install-linux.sh and verifies the preset/default logic,
+# the MARVEEN_PROGRESS / MARVEEN_RESULT protocol, and secret redaction.
+# Run: bash tests/headless-install-contract.sh
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALLER="$SCRIPT_DIR/../install-linux.sh"
+HELPERS="$(mktemp)"
+trap 'rm -f "$HELPERS"' EXIT
+
+# Extract the helper block; drop the trap line (tests manage their own exits).
+sed -n '/INSTWIZ1 headless-install helpers (contract) BEGIN/,/INSTWIZ1 headless-install helpers (contract) END/p' \
+  "$INSTALLER" | grep -v '^trap on_exit_emit_result EXIT$' > "$HELPERS"
+
+[ -s "$HELPERS" ] || { echo "FAIL: helper block not found in install-linux.sh"; exit 1; }
+
+PASS=0
+FAIL=0
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "ok   - $name"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL - $name"
+    echo "       expected: $(printf '%q' "$expected")"
+    echo "       actual:   $(printf '%q' "$actual")"
+  fi
+}
+
+# Helper: run a snippet in a fresh bash with the helpers sourced.
+run_case() { # env-assignments... -- snippet
+  local envs=()
+  while [ "$1" != "--" ]; do envs+=("$1"); shift; done
+  shift
+  env -i PATH="$PATH" ${envs[@]+"${envs[@]}"} bash -c "source '$HELPERS'; $1" 2>&1
+}
+
+# 1) Non-interactive, no preset env -> the documented default is used,
+#    even with stdin CLOSED (the EOF-abort case the contract exists for).
+out="$(run_case MARVEEN_NONINTERACTIVE=1 -- '
+  prompt_or_preset OWNER_NAME "Neved: " "Owner" "MARVEEN_OWNER_NAME"
+  printf "%s" "$OWNER_NAME"
+' </dev/null)"
+check "noninteractive default (OWNER_NAME=Owner, stdin closed)" "Owner" "$out"
+
+# 2) Non-interactive, preset env set -> preset wins over default.
+out="$(run_case MARVEEN_NONINTERACTIVE=1 MARVEEN_OWNER_NAME="Teszt Elek" -- '
+  prompt_or_preset OWNER_NAME "Neved: " "Owner" "MARVEEN_OWNER_NAME"
+  printf "%s" "$OWNER_NAME"
+' </dev/null)"
+check "noninteractive preset wins (MARVEEN_OWNER_NAME)" "Teszt Elek" "$out"
+
+# 3) Non-interactive, empty default, no preset -> empty value (BOT_TOKEN skip).
+out="$(run_case MARVEEN_NONINTERACTIVE=1 -- '
+  prompt_or_preset BOT_TOKEN "Token: " "" "MARVEEN_BOT_TOKEN"
+  printf "[%s]" "$BOT_TOKEN"
+' </dev/null)"
+check "noninteractive empty default (BOT_TOKEN skip)" "[]" "$out"
+
+# 4) Non-interactive CONTINUE_MCP has no preset env and always resolves to
+#    "i" -> the MCP warning branch can never exit the installer headless.
+out="$(run_case MARVEEN_NONINTERACTIVE=1 -- '
+  prompt_or_preset CONTINUE_MCP "Folytatod? " "i"
+  if [ "$CONTINUE_MCP" != "i" ]; then echo WOULD_EXIT; else echo CONTINUES; fi
+' </dev/null)"
+check "noninteractive CONTINUE_MCP never exits" "CONTINUES" "$out"
+
+# 5) Interactive mode (no MARVEEN_NONINTERACTIVE) -> falls back to read, the
+#    typed value wins and the preset env is IGNORED.
+out="$(printf 'gepelt-ertek\n' | run_case MARVEEN_BOT_NAME="PresetNev" -- '
+  prompt_or_preset BOT_NAME "Nev: " "Marveen" "MARVEEN_BOT_NAME"
+  printf "%s" "$BOT_NAME"
+')"
+check "interactive read wins, preset ignored" "gepelt-ertek" "$out"
+
+# 6) Interactive empty input + call-site default pattern (VAR=${VAR:-def})
+#    behaves exactly like the pre-change script.
+out="$(printf '\n' | run_case -- '
+  prompt_or_preset AUTH_MODE "Mod: " "3" "MARVEEN_AUTH_MODE"
+  AUTH_MODE=${AUTH_MODE:-2}
+  printf "%s" "$AUTH_MODE"
+')"
+check "interactive empty input -> call-site default applies" "2" "$out"
+
+# 7) emit_progress is silent without MARVEEN_JSON_PROGRESS=1.
+out="$(run_case MARVEEN_NONINTERACTIVE=1 -- 'emit_progress prerequisites start')"
+check "emit_progress silent when JSON progress off" "" "$out"
+
+# 8) emit_progress emits the contract line shape.
+out="$(run_case MARVEEN_JSON_PROGRESS=1 -- 'emit_progress prerequisites start')"
+check "emit_progress line shape" \
+  'MARVEEN_PROGRESS {"step":"prerequisites","status":"start"}' "$out"
+
+# 9) emit_progress detail is JSON-escaped.
+out="$(run_case MARVEEN_JSON_PROGRESS=1 -- 'emit_progress build fail "quote \" and back\\slash"')"
+check "emit_progress detail JSON-escaped" \
+  'MARVEEN_PROGRESS {"step":"build","status":"fail","detail":"quote \" and back\\slash"}' "$out"
+
+# 10) Secret-looking detail is redacted (sk-ant token must never leak).
+out="$(run_case MARVEEN_JSON_PROGRESS=1 -- 'emit_progress claude-auth fail "bad key sk-ant-oat01-abc123"')"
+check "emit_progress redacts sk-ant" \
+  'MARVEEN_PROGRESS {"step":"claude-auth","status":"fail","detail":"[redacted]"}' "$out"
+
+# 11) emit_result success with bundle + WEB_PORT.
+out="$(run_case MARVEEN_JSON_PROGRESS=1 WEB_PORT=3421 -- 'emit_result true "" "QkFTRTY0"')"
+check "emit_result ok with bundle" \
+  'MARVEEN_RESULT {"ok":true,"dashboardPort":3421,"enrollBundle":"QkFTRTY0"}' "$out"
+
+# 12) emit_result success without bundle -> enrollBundle is JSON null.
+out="$(run_case MARVEEN_JSON_PROGRESS=1 -- 'emit_result true')"
+check "emit_result ok, enrollBundle null, default port" \
+  'MARVEEN_RESULT {"ok":true,"dashboardPort":3420,"enrollBundle":null}' "$out"
+
+# 13) emit_result failure carries the error and is once-only (second call is
+#     a no-op, so fail() + EXIT trap can never double-emit).
+out="$(run_case MARVEEN_JSON_PROGRESS=1 -- '
+  emit_result false "step npm-install: npm install sikertelen"
+  emit_result true "" "SHOULD_NOT_APPEAR"
+')"
+check "emit_result fail + once-only" \
+  'MARVEEN_RESULT {"ok":false,"dashboardPort":3420,"enrollBundle":null,"error":"step npm-install: npm install sikertelen"}' "$out"
+
+# 14) set_step closes the previous step with ok and opens the next with start.
+out="$(run_case MARVEEN_JSON_PROGRESS=1 -- '
+  INSTALL_STEP="init"
+  set_step prerequisites
+  set_step npm-install
+')"
+expected='MARVEEN_PROGRESS {"step":"prerequisites","status":"start"}
+MARVEEN_PROGRESS {"step":"prerequisites","status":"ok"}
+MARVEEN_PROGRESS {"step":"npm-install","status":"start"}'
+check "set_step transition protocol (init not closed)" "$expected" "$out"
+
+# 15) Static regression guard: every wizard prompt goes through the helper --
+#     no bare read -rp/-p prompt may remain outside the helper definition.
+stray="$(grep -nE '^\s*read -r?p ' "$INSTALLER" | grep -cv '"\$__prompt"')"
+check "no bare read prompts outside prompt_or_preset" "0" "$stray"
+
+echo ""
+echo "passed: $PASS, failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/headless-install-contract.sh
+++ b/tests/headless-install-contract.sh
@@ -142,6 +142,32 @@ check "set_step transition protocol (init not closed)" "$expected" "$out"
 stray="$(grep -nE '^\s*read -r?p ' "$INSTALLER" | grep -cv '"\$__prompt"')"
 check "no bare read prompts outside prompt_or_preset" "0" "$stray"
 
+# 16) The EXIT trap closes the protocol on a code-0 early exit (e.g. --help or
+#     an aborted MCP prompt) so the machine consumer always gets exactly one
+#     MARVEEN_RESULT -- not zero.
+out="$(run_case MARVEEN_JSON_PROGRESS=1 -- '
+  trap on_exit_emit_result EXIT
+  INSTALL_STEP="init"
+  exit 0
+')"
+n="$(printf '%s\n' "$out" | grep -c "^MARVEEN_RESULT ")"
+check "exit-0 early path emits exactly one RESULT" "1" "$n"
+case "$out" in *'"ok":false'*) ok=yes;; *) ok=no;; esac
+check "exit-0 early path reports ok:false (did not complete)" "yes" "$ok"
+
+# 17) The EXIT trap is a no-op once a result was already emitted (the normal
+#     success path emits true before returning) -- exactly one RESULT, ok:true.
+out="$(run_case MARVEEN_JSON_PROGRESS=1 -- '
+  trap on_exit_emit_result EXIT
+  INSTALL_STEP="start"
+  emit_result true
+  exit 0
+')"
+n="$(printf '%s\n' "$out" | grep -c "^MARVEEN_RESULT ")"
+check "trap no-op after a prior result (single RESULT)" "1" "$n"
+case "$out" in *'"ok":true'*) ok=yes;; *) ok=no;; esac
+check "prior result wins (ok:true preserved)" "yes" "$ok"
+
 echo ""
 echo "passed: $PASS, failed: $FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
INSTWIZ1 (1/2): a GUI-telepítő gépi oldala. Ez a PR a Bridge távoli-telepítő képernyőjének a szerveroldali fele (a UI a marveen-bridge feat/remote-installer PR-ben).

## Mit ad

`MARVEEN_NONINTERACTIVE=1` mellett az `install-linux.sh` MINDEN `read` promptja kimarad, az érték preset-env-ből vagy a mai defaultból jön -- így egy GUI SSH-n át, terminál nélkül vezérelheti a telepítést. A csupasz `read`-ek EOF-abortja (a fő ok, amiért a script eddig nem volt yes-pipe-olható) megszűnik.

- **`prompt_or_preset` helper**: mind a ~13 prompt (OPEN_CLAUDE, CREATE_SWAP, AUTH_MODE, API-key, OAuth, OWNER_NAME, CONTINUE_MCP, PROVIDER, BOT_TOKEN, discord/slack, BOT_NAME, DO_WHISPER, PAIR_CODE, DO_MIGRATE) ezen megy át. Interaktív módban a viselkedés **bájtra azonos** a régivel (a helper interaktív ága maga a `read -rp`).
- **Gépi progress** (`MARVEEN_JSON_PROGRESS=1`): soronként `MARVEEN_PROGRESS {"step","status"}`, záráskor pontosan egy `MARVEEN_RESULT {"ok","dashboardPort","enrollBundle"[,"error"]}` -- ERR és EXIT trap safety-nettel, once-only guarddal. Titok (token, jelszó, `?token=`) soha nem kerül progress-sorba (scrub + JSON-escape).
- **Auto-enroll**: `MARVEEN_ENROLL_PUBKEY` esetén a telepítés végén lefut a `remote-enroll`, a bundle a `MARVEEN_RESULT.enrollBundle`-be kerül (a Bridge ezt importálja, és magától csatlakozik).
- `CONTINUE_MCP` nem-interaktív ágban SOHA nem lép ki.

## Biztonság

A preset-env csak a promptokat helyettesíti; a `.env`-írás a meglévő `setEnvKey` merge-safe úton megy (nem a destruktív `cat >` regeneráció). A re-run/.env-merge teljes kezelése a #754-gyel érkezik; ez a PR a **friss-install** utat fedi.

## Verifikáció

- `bash -n` OK; 15/15 kontraktus-teszt zöld (`tests/headless-install-contract.sh`).
- Interaktív-mód regresszió: grid-del bizonyítva, hogy csupasz `read` prompt csak a helperben maradt.
- Fail-path élő próba macOS-en: start→fail progress + egyetlen valid-JSON `MARVEEN_RESULT ok:false`, stdin zárva, nem akadt meg.
- **Nyitott merge-gate**: a teljes happy-path (Linux VPS-en végigfutó install + enroll) éles e2e-je a vps47-en van folyamatban; a `bare-distro-install-script-verify` skill szimulációs köre is javasolt merge előtt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)