### PR TITLE
fix(installer): forward argv across the self-reclone exec

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -297,7 +297,9 @@ if [ ! -f "$INSTALL_DIR/package.json" ]; then
     ok "Repo klonozva: $TARGET_DIR"
   fi
   echo -e "  Telepito ujrainditasa a checkoutbol..."
-  exec bash "$TARGET_DIR/install-linux.sh"
+  # Forward argv so a run from outside the repo (curl bootstrap, or an explicit
+  # `install-linux.sh --port N`) keeps its flags across the self-reclone exec.
+  exec bash "$TARGET_DIR/install-linux.sh" "$@"
 fi
 
 INSTALL_STEP="claude-bun-install"


### PR DESCRIPTION
A publikus install-linux.sh curl-bootstrapja (vagy egy explicit `install-linux.sh --port N` a repón kívülről) self-reclone-ol és `exec bash .../install-linux.sh`-sal újraindítja magát a checkoutból — de argv nélkül, így a `--port` elveszett a self-exec-nél. Ez `"$@"`-t forward-ol.

Általános telepítő-fix, független bármely headless/provision úttól. Ez a #759-ből **kiválasztott publikus-értékű rész** (a headless gépi-kontraktus külön, a fizetős úton kezelve — Szabi 07-28 termék-döntése: a telepítés kényelme a fizetős érték, a telepített kód nyílt marad).

`bash -n` OK; a diff egyetlen sor (`"$@"`), headless-gépezet nincs benne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)