### PR TITLE
fix(dashboard): allow owner as message sender + suppress phantom marveen thread

### DIFF
--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -10,6 +10,7 @@ import { logger } from '../../logger.js'
 import { COORDINATOR_AGENT_ID } from '../../channel-coordinator/ingest.js'
 import { sanitizeAgentIdent } from '../../prompt-safety.js'
 import { isKnownAgent } from '../agent-config.js'
+import { OWNER_NAME } from '../../config.js'
 import { readBody, json, jsonMaybeGzip } from '../http-helpers.js'
 import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
 import { parseQualifiedId, formatQualifiedId } from '../federation/address.js'
@@ -65,7 +66,15 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
     // filesystem (agents/<id>/ directory, or MAIN_AGENT_ID). This is not
     // impersonation-proof between fleet agents (they share the same token) but
     // it closes the "unknown sender" injection path without per-agent secrets.
-    if (!isKnownAgent(sanitizeAgentIdent(from))) {
+    //
+    // The human OWNER is a legitimate sender too: the dashboard "Messages" page
+    // composes with from=OWNER_NAME (resolveOwnerName -> the owner assignee), so
+    // without this exemption the operator's own dashboard messages 403 with
+    // "unknown agent". The owner is not a fleet agent (no agents/<id>/ dir), so
+    // isKnownAgent alone rejects it. Match on the router's normalization to stay
+    // symmetric with the other guards above.
+    const isOwnerSender = sanitizeAgentIdent(from) === sanitizeAgentIdent(OWNER_NAME)
+    if (!isOwnerSender && !isKnownAgent(sanitizeAgentIdent(from))) {
       logger.warn({ from: from.trim(), to: to.trim() }, 'Rejected /api/messages POST from unregistered agent')
       json(res, { error: `unknown agent '${from.trim()}' -- from must be a registered fleet agent id` }, 403)
       return true

--- a/web/app.js
+++ b/web/app.js
@@ -10920,7 +10920,22 @@ function chatAvatarHtml(agentName, size = 32) {
   return `<img class="chat-avatar" src="${src}" width="${size}" height="${size}" alt="${escapeHtml(agentName)}" data-agent-name="${escapeHtml(agentName)}" onerror="chatImgError(this)">`
 }
 
+// Guard against the boot race: the Messages page can be opened before the
+// initial /api/marveen fetch resolves window._marveen. Until it does,
+// mainAgentId() returns the literal 'marveen' FALLBACK, which is a real agent
+// id on no install here -- composing to it creates a phantom "marveen" thread
+// that sits pending forever and shows up as a duplicate of the true main agent
+// (torpapa). Resolve _marveen before rendering any chat target.
+async function ensureMarveenLoaded() {
+  if (window._marveen?.agentId) return
+  try {
+    const r = await fetch('/api/marveen')
+    if (r.ok) window._marveen = { ...(window._marveen || {}), ...(await r.json()) }
+  } catch { /* sidebar falls back to the literal id -- best effort */ }
+}
+
 async function loadMessagesPage() {
+  await ensureMarveenLoaded()
   await loadChatAgentList()
 }
 
@@ -11001,8 +11016,12 @@ async function loadChatAgentList() {
     for (const t of threads) {
       if (t.agent) threadIndex.set(t.agent, { lastMsg: t.lastMessage, count: t.count || 0 })
     }
-    // Also include thread agents not in fleet (e.g. the owner's own direct msgs)
+    // Also include thread agents not in fleet (e.g. the owner's own direct msgs).
+    // Suppress the literal 'marveen' fallback id when it is NOT the real main
+    // agent: a stale phantom thread (from the boot-race bug) would otherwise
+    // render as a duplicate of the true main agent.
     for (const t of threads) {
+      if (t.agent === 'marveen' && mainAgentId() !== 'marveen') continue
       if (t.agent && !fleetNames.includes(t.agent) && !CHAT_SYSTEM_AGENTS.has(t.agent)) {
         fleetNames.push(t.agent)
       }


### PR DESCRIPTION
## Mit javít

Két hibát a dashboard **Üzenetek** oldalán:

1. **A tulajdonos nem tudott üzenetet küldeni (403).** A `POST /api/messages` a feladót az `isKnownAgent` ellenőrzésen buktatta el: a tulajdonos (OWNER_NAME) nem flotta-ágens (nincs `agents/<id>/` mappája), így "unknown agent" hibával elutasította a saját dashboardról indított üzeneteit. A javítás a router-normalizálással szimmetrikus owner-kivételt ad a guard elé (`src/web/routes/messages.ts`).

2. **Fantom "marveen" szál a listában.** Az Üzenetek oldal megnyitható, mielőtt a `/api/marveen` fetch feloldaná a `window._marveen`-t; addig a `mainAgentId()` a literál `marveen` fallbacket adja vissza, és az erre komponált üzenet egy örökké függő, duplikált fantom-szálat hoz létre a valódi fő-ágens (nálunk: torpapa) mellett. A javítás a chat-célpont renderelése előtt bevárja a `_marveen` feloldását (`web/app.js`, `ensureMarveenLoaded`).

## Hogyan teszteltük

Éles telepítésen (macOS, 13 ágenses flotta): a tulajdonos üzenetküldése a dashboardról 403 helyett kézbesítésre kerül, a fantom-szál nem jön létre újra. A javítás v1.23.2-től v1.25.0+-ig (e626ff3) minden általunk futtatott verzión konfliktus nélkül működött.

🤖 Generated with [Claude Code](https://claude.com/claude-code)