### PR TITLE
test(federation): assert the sidebar group mechanism, not raw markup offsets

### DIFF
--- a/src/__tests__/federation-ui-contract.test.ts
+++ b/src/__tests__/federation-ui-contract.test.ts
@@ -15,12 +15,23 @@ const HTML = readFileSync(join(__dirname, '../../web/index.html'), 'utf-8')
 const CSS = readFileSync(join(__dirname, '../../web/style.css'), 'utf-8')
 
 describe('federation UI wiring', () => {
-  it('sidebar has the federation nav item AFTER the ideabox item', () => {
-    const ideas = HTML.indexOf('data-page="ideas"')
+  it('sidebar: federation lives in the connections group between connectors and migrate', () => {
+    // Since the sidebar-group re-parenting (#742) the rendered order is defined
+    // by the declarative SIDEBAR_GROUPS map in app.js, not by the raw markup
+    // order; the markup is only the default snapshot the map re-parents at
+    // boot. Assert the mechanism that is true today (browser-verified
+    // 2026-07-29: rendered DOM matches the map): the map places federation
+    // inside connections between connectors and migrate, and the markup
+    // snapshot already keeps the three links inside the connections container.
+    expect(APP).toMatch(/key: 'connections',[^\n]*pages: \['connectors', 'federation', 'migrate'\]/)
+    const connectionsGroup = HTML.indexOf('data-group="connections"')
+    const connectors = HTML.indexOf('data-page="connectors"')
     const federation = HTML.indexOf('data-page="federation"')
-    const updates = HTML.indexOf('data-page="updates"')
-    expect(federation).toBeGreaterThan(ideas)
-    expect(federation).toBeLessThan(updates)
+    const migrate = HTML.indexOf('data-page="migrate"')
+    expect(connectionsGroup).toBeGreaterThan(-1)
+    expect(connectors).toBeGreaterThan(connectionsGroup)
+    expect(federation).toBeGreaterThan(connectors)
+    expect(migrate).toBeGreaterThan(federation)
   })
 
   it('page div, router dispatch and hoisted loader exist', () => {


### PR DESCRIPTION
## What
The `federation-ui-contract.test.ts` assertion "sidebar has the federation nav item AFTER the ideabox item" asserted raw `index.html` source offsets. Since the sidebar-group re-parenting (#742) the rendered order is defined by the declarative `SIDEBAR_GROUPS` map in `app.js` (the markup is only the boot-time default snapshot), and the menu restructure moved the federation link into the connections group container. Result: the suite is red on develop AND main (`expected 14716 to be less than 12044`) while the rendered UI is correct.

## Verification order (per Marveen's request: measure the rendered UI FIRST, only then touch the test)
1. **Browser-verified the rendered sidebar** against the live backend (Playwright route-interception serving develop's `index.html`/`app.js`/`style.css`, every `/api/*` hitting the real dashboard): federation renders inside the `connections` group between `connectors` and `migrate`; group order `team, knowledge, stats, system, connections`; 23 links, no duplicates, no orphan groups, zero console/page errors. The UI is NOT broken; the test premise is stale.
2. **Rewrote the assertion to guard the mechanism that is true today**: (a) the `SIDEBAR_GROUPS` map places federation in connections between connectors and migrate; (b) the markup snapshot keeps the three links inside the `data-group="connections"` container.
3. **Adversarial probes on the new assertions** (must-fail cases all fail): federation removed from the map; map order swapped; federation link deleted from markup; federation moved outside the group container.

## Gates
- `tsc --noEmit` clean
- Full suite: **211 files, 2883/2883 passed** (develop goes back to green)
- No em-dash in added lines, no hardcoded owner/path/chat-id

## Attribution
- Test born 2026-07-15 with the federation feature (#557), when the sidebar was flat.
- Premise broken by the menu restructure (#742, 2026-07-27), which is already on main (v1.25.0), so main is red the same way. This is contract staleness, not a UI regression, and not caused by #749/#750.

Fixes the promote gate blocker (SIDEBARTEST1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)