### PR TITLE
fix(worker): derive worker home from MAIN_AGENT_ID + WEB_ONLY-gate every session start

### DIFF
--- a/src/__tests__/agent-worker.test.ts
+++ b/src/__tests__/agent-worker.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { buildWorkerPrompt, decidePoll, configDirKeychainService } from '../web/agent-worker.js'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { buildWorkerPrompt, decidePoll, configDirKeychainService, workerHomeFor, workerStartAllowed } from '../web/agent-worker.js'
 
 // Pure-logic tests for the interactive-tmux worker that backs runAgent on the
 // subscription (jun.15 migration). The live-session orchestration is exercised
@@ -72,5 +75,60 @@ describe('configDirKeychainService', () => {
     const b = configDirKeychainService('/tmp/some-other-config')
     expect(a).not.toBe(b)
     expect(b.startsWith('Claude Code-credentials-')).toBe(true)
+  })
+})
+
+describe('workerHomeFor (WORKERHOME1: worker home derives from MAIN_AGENT_ID)', () => {
+  it('default install keeps the historical paths -- zero migration, unchanged Keychain hash', () => {
+    expect(workerHomeFor('marveen', 'slow').endsWith('/.marveen-worker')).toBe(true)
+    expect(workerHomeFor('marveen', 'fast').endsWith('/.marveen-worker-fast')).toBe(true)
+  })
+
+  it('a non-default id derives its own isolated dirs (sandbox/renamed install)', () => {
+    expect(workerHomeFor('jarvis', 'slow').endsWith('/.jarvis-worker')).toBe(true)
+    expect(workerHomeFor('jarvis', 'fast').endsWith('/.jarvis-worker-fast')).toBe(true)
+  })
+
+  it('never collides with the default install dir for a different id', () => {
+    expect(workerHomeFor('jarvis', 'slow')).not.toBe(workerHomeFor('marveen', 'slow'))
+    expect(workerHomeFor('jarvis', 'fast')).not.toBe(workerHomeFor('marveen', 'fast'))
+  })
+
+  it('slow and fast variants of the same id never share a home', () => {
+    expect(workerHomeFor('marveen', 'slow')).not.toBe(workerHomeFor('marveen', 'fast'))
+  })
+})
+
+describe('workerStartAllowed (WORKERHOME1: WEB_ONLY must suppress every worker start)', () => {
+  it('blocks in WEB_ONLY staging', () => {
+    expect(workerStartAllowed({ WEB_ONLY: 'true' })).toBe(false)
+  })
+
+  it('allows on a normal install (unset or explicit false)', () => {
+    expect(workerStartAllowed({})).toBe(true)
+    expect(workerStartAllowed({ WEB_ONLY: 'false' })).toBe(true)
+    expect(workerStartAllowed({ WEB_ONLY: '' })).toBe(true)
+  })
+
+  // String-contract wiring guard (house idiom: the pure predicate alone cannot
+  // prove the choke points consult it). Every function that creates, kills or
+  // configures a live worker session must check the gate: the lazy-start path
+  // (startWorkerSessionFor covers ensureWorkerCwd + tmux new-session), the
+  // readiness poll (ensureWorkerReady would otherwise spin 90s then page the
+  // LIVE channel via alertWorkerStuck from a staging instance) and the restart
+  // path (kill-session against a live worker). This is exactly how the
+  // 2026-07-28 sandbox boot wrote into the live worker config dir.
+  it('the three session-lifecycle choke points are wired to the gate', () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(join(__dirname, '../web/agent-worker.ts'), 'utf-8')
+    const gated = (fnName: string) => {
+      const start = src.indexOf(`function ${fnName}(`)
+      expect(start, `${fnName} not found`).toBeGreaterThan(-1)
+      const body = src.slice(start, start + 700)
+      return body.includes('workerStartAllowed()')
+    }
+    expect(gated('startWorkerSessionFor')).toBe(true)
+    expect(gated('ensureWorkerReady')).toBe(true)
+    expect(gated('restartWorkerSession')).toBe(true)
   })
 })

--- a/src/__tests__/agent-worker.test.ts
+++ b/src/__tests__/agent-worker.test.ts
@@ -131,4 +131,15 @@ describe('workerStartAllowed (WORKERHOME1: WEB_ONLY must suppress every worker s
     expect(gated('ensureWorkerReady')).toBe(true)
     expect(gated('restartWorkerSession')).toBe(true)
   })
+
+  // The worker launch line must invoke claude by RESOLVED path, never by bare
+  // name: `bash -lc` login shells on stock Debian/Ubuntu roots lack
+  // ~/.local/bin (the native installer target), which killed the worker within
+  // seconds of every boot on such installs (vps47 cold-start probe, WORKERHOME1).
+  it('the tmux launch line resolves the claude binary instead of relying on login-shell PATH', () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(join(__dirname, '../web/agent-worker.ts'), 'utf-8')
+    expect(src).toContain("tryResolveFromPath('claude')")
+    expect(src).not.toMatch(/`claude --dangerously-skip-permissions/)
+  })
 })

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync
 import { join } from 'node:path'
 import { homedir, userInfo } from 'node:os'
 import { createHash } from 'node:crypto'
-import { resolveFromPath } from '../platform.js'
+import { resolveFromPath, tryResolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, PROJECT_ROOT, DEFAULT_AGENT_MODEL } from '../config.js'
 import {
@@ -471,11 +471,20 @@ function startWorkerSessionFor(ctx: WorkerCtx): void {
   // Fleet setup-token (when present) via $(cat) at launch so the secret never
   // lands in argv/`ps` -- same pattern as startAgentProcess. Keeps the worker
   // on the stable token instead of the shared rotating credentials file.
+  // Launch claude by RESOLVED absolute path, not by bare name: `bash -lc` gets
+  // the login-shell PATH, which on stock Debian/Ubuntu roots does NOT include
+  // ~/.local/bin (the native installer's default target). The channels session
+  // launcher already compensates; the bare `claude` here made the worker die
+  // within seconds of every boot on such Linux installs (command not found,
+  // measured on vps47 during the WORKERHOME1 cold-start probe: session created,
+  // gone before the first 5s poll). tryResolveFromPath probes the known install
+  // dirs; fall back to the bare name so an exotic layout keeps the old behavior.
+  const claudeLaunchBin = tryResolveFromPath('claude') ?? 'claude'
   const launch =
     (hasFleetOauthToken() ? `export CLAUDE_CODE_OAUTH_TOKEN="$(cat ${shArg(FLEET_OAUTH_TOKEN_PATH)})"; ` : '') +
     `export CLAUDE_CONFIG_DIR=${shArg(ctx.configDir)}; ` +
     `cd ${shArg(ctx.home)} && ` +
-    `claude --dangerously-skip-permissions --model ${shArg(WORKER_MODEL)}`
+    `${shArg(claudeLaunchBin)} --dangerously-skip-permissions --model ${shArg(WORKER_MODEL)}`
   execFileSync(TMUX, ['new-session', '-d', '-s', ctx.session, '-c', ctx.home, 'bash', '-lc', launch], { timeout: 8000 })
   logger.info({ session: ctx.session, cwd: ctx.home }, 'agent-worker: launched interactive worker session')
   logWorkerClaudeVersion(ctx)

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -87,20 +87,48 @@ export function makeWorkerCtx(session: string, homeDir: string): WorkerCtx {
   }
 }
 
+/**
+ * Default worker home for an agent id. Derived from MAIN_AGENT_ID exactly like
+ * the session name (WORKERHOME1): a sandbox or renamed install booted with its
+ * own MAIN_AGENT_ID must never resolve to -- and write into -- the default
+ * install's live worker config dir (the 2026-07-28 same-host sandbox boot
+ * seeded credentials into the live ~/.marveen-worker/.claude-config this way).
+ * The default id 'marveen' keeps the historical .marveen-worker path, so
+ * existing installs see no migration and their Keychain path-hash
+ * (configDirKeychainService) is unchanged; any other id derives its own dir,
+ * which hashes to its own Keychain service automatically.
+ */
+export function workerHomeFor(agentId: string, variant: 'slow' | 'fast'): string {
+  return join(homedir(), `.${agentId}-worker${variant === 'fast' ? '-fast' : ''}`)
+}
+
+/**
+ * WEB_ONLY=true marks a staging/preview instance that must not touch the live
+ * fleet. The boot-time pre-start in web.ts is already gated, but the worker
+ * also LAZY-starts from runViaWorker (scaffold generation, heartbeat, digest),
+ * which is how a WEB_ONLY sandbox still created live tmux sessions and wrote
+ * into worker config dirs (WORKERHOME1). Read at call time, pure, so the gate
+ * is unit-testable and follows env changes in tests.
+ */
+export function workerStartAllowed(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env['WEB_ONLY'] !== 'true'
+}
+
 // Slow session: long-running tasks (analysis, reports, search). The original
-// worker -- all existing callers default to this. Session name keys off
-// MAIN_AGENT_ID (per #611) so notify.sh's "${MAIN_AGENT_ID}-worker" branch
-// matches on renamed installs; default installs stay "marveen-worker". The
-// WORKER_DIR stays fixed (.marveen-worker) -- the config-dir hash depends on it.
+// worker -- all existing callers default to this. Session name AND worker home
+// key off MAIN_AGENT_ID (per #611 + WORKERHOME1) so notify.sh's
+// "${MAIN_AGENT_ID}-worker" branch matches on renamed installs and a non-default
+// id gets its own isolated home; default installs stay "marveen-worker" /
+// ~/.marveen-worker (byte-identical to the historical fixed path).
 const ctxSlow = makeWorkerCtx(
   process.env.MARVEEN_WORKER_SESSION || `${MAIN_AGENT_ID}-worker`,
-  process.env.MARVEEN_WORKER_DIR || join(homedir(), '.marveen-worker'),
+  process.env.MARVEEN_WORKER_DIR || workerHomeFor(MAIN_AGENT_ID, 'slow'),
 )
 // Fast session: short, conversational tasks (< 300 chars, no analysis keywords).
 // Separate home + config dir eliminates any shared state with the slow session.
 const ctxFast = makeWorkerCtx(
   process.env.MARVEEN_WORKER_SESSION_FAST || `${MAIN_AGENT_ID}-worker-fast`,
-  process.env.MARVEEN_WORKER_DIR_FAST || join(homedir(), '.marveen-worker-fast'),
+  process.env.MARVEEN_WORKER_DIR_FAST || workerHomeFor(MAIN_AGENT_ID, 'fast'),
 )
 
 // --- Message priority routing -------------------------------------------------
@@ -430,6 +458,12 @@ function sleepMs(ms: number): Promise<void> {
  * the Write-to-scratch capture works. Idempotent.
  */
 function startWorkerSessionFor(ctx: WorkerCtx): void {
+  // Gate BEFORE any side effect: in WEB_ONLY staging neither the tmux session
+  // nor the ensureWorkerCwd config-dir writes may happen (WORKERHOME1).
+  if (!workerStartAllowed()) {
+    logger.warn({ session: ctx.session }, 'agent-worker: WEB_ONLY mode -- refusing to start a worker session or write its config dir')
+    return
+  }
   if (workerSessionExists(ctx)) return
   ensureWorkerCwd(ctx)
   // Detached session; launch claude via a login shell so PATH + the config-dir
@@ -530,6 +564,13 @@ function alertWorkerStuck(ctx: WorkerCtx, paneTail: string): void {
 }
 
 async function ensureWorkerReady(ctx: WorkerCtx): Promise<boolean> {
+  // Fail fast in WEB_ONLY: without this the 90s readiness poll would spin on a
+  // session that the gated start never created, then alertWorkerStuck would
+  // notifyChannel the LIVE channel from a staging instance.
+  if (!workerStartAllowed()) {
+    logger.warn({ session: ctx.session }, 'agent-worker: WEB_ONLY mode -- worker disabled, failing the request fast')
+    return false
+  }
   startWorkerSessionFor(ctx)
   const start = Date.now()
   const deadline = start + WORKER_BOOT_TIMEOUT_MS
@@ -548,6 +589,13 @@ async function ensureWorkerReady(ctx: WorkerCtx): Promise<boolean> {
 }
 
 function restartWorkerSession(ctx: WorkerCtx): void {
+  // Defense-in-depth (WORKERHOME1): every WEB_ONLY-reachable path is already
+  // gated upstream, but a restart here would kill-session a LIVE worker from a
+  // staging instance -- never do that.
+  if (!workerStartAllowed()) {
+    logger.warn({ session: ctx.session }, 'agent-worker: WEB_ONLY mode -- refusing to restart (kill) a worker session')
+    return
+  }
   try { execFileSync(TMUX, ['kill-session', '-t', ctx.session], { timeout: 5000 }) } catch { /* not running */ }
   try { startWorkerSessionFor(ctx) } catch (err) { logger.warn({ err, session: ctx.session }, 'agent-worker: restart failed') }
 }


### PR DESCRIPTION
## What (card WORKERHOME1)
The 2026-07-28 same-host sandbox incident: a WEB_ONLY sandbox boot created `<MAIN_AGENT_ID>-worker(-fast)` tmux sessions with live claude AND wrote credentials into the LIVE worker's config dir. Two independent holes, both fixed here (either alone is insufficient, per the card):

1. **Worker home was hardcoded** (`~/.marveen-worker`): a sandbox with its own `MAIN_AGENT_ID` still resolved to the live install's worker config dir. Now `workerHomeFor(agentId, variant)` derives it from `MAIN_AGENT_ID` exactly like the session name (#611). **Back-compat:** the default id `marveen` yields the byte-identical historical path, so every existing default install sees zero migration and an unchanged Keychain path-hash (`configDirKeychainService`); a renamed/sandbox id gets its own isolated dir. `MARVEEN_WORKER_DIR*` env overrides keep precedence.
2. **WEB_ONLY did not suppress the lazy start**: only the boot-time pre-start in `web.ts` was gated; `runViaWorker -> ensureWorkerReady -> startWorkerSessionFor` was not. New pure gate `workerStartAllowed(env)` now refuses at the three session-lifecycle choke points BEFORE any side effect:
   - `startWorkerSessionFor` (covers the `ensureWorkerCwd` config-dir writes + `tmux new-session`),
   - `ensureWorkerReady` (fails fast; otherwise a 90s poll would end in `alertWorkerStuck` paging the LIVE channel from a staging instance),
   - `restartWorkerSession` (defense-in-depth: it `kill-session`s a live worker).

## Tests
- Pure vectors: default id keeps `.marveen-worker`/`.marveen-worker-fast`; `jarvis` derives isolated dirs; no collision across ids; slow/fast never share a home.
- Gate vectors: `WEB_ONLY=true` blocks; unset/`false`/empty allow.
- **String-contract wiring guard**: fails if any of the three choke points loses its `workerStartAllowed()` check. Adversarially verified: removing the `restartWorkerSession` gate makes exactly this test fail.

## Gates
- `tsc --noEmit` clean; suite **2889/2890** (the 1 failure is the pre-existing `federation-ui-contract` develop breakage, fixed separately in #764, unrelated).
- Em-dash clean on added lines; no hardcoded owner/chat-id/user path (the derivation removes one).

## Out of scope / follow-up
Cold-start probe from the current disk state (expired access token + valid refresh token: does the worker come up after a restart?) runs on the VPS per the standing rule and will be reported on the card, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)