### PR TITLE
fix(channels): let the main agent's model come from .env, not a tracked file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,9 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # tokenekkel). Kezelés: a dashboard Föderáció menüpontja (curl-fallback:
 # PUT /api/federation/peers, dashboard-token szükséges). Alapból kikapcsolva,
 # fail-closed. Részletek: docs/federation.md
+
+# Model for the MAIN agent's channel session. Optional: when unset, the launcher
+# falls back to `.model` in .claude/settings.json. Set it here rather than in
+# settings.json -- that file is tracked, so a local edit blocks the update
+# preflight and is reverted by the next update.
+# MAIN_AGENT_MODEL=claude-opus-5

--- a/scripts/__tests__/channels-main-model.test.sh
+++ b/scripts/__tests__/channels-main-model.test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Contract tests for main-agent model resolution in scripts/channels.sh.
+#
+# Why this exists (2026-07-29): the model was read ONLY from
+# .claude/settings.json, which is a TRACKED file. An install that wants a
+# different model than the repository ships had to edit that file, and then:
+#   - the update preflight refused to run ("dirty tree"), so the dashboard's
+#     update button was permanently blocked on that install, and
+#   - checking out the release branch silently restored the repository's model,
+#     so the next restart came up on a different model than the operator chose.
+#     Silent, because nothing fails -- the agent just answers as another model.
+#
+# MAIN_AGENT_MODEL in .env (per-install, gitignored) now takes precedence, and
+# settings.json remains the shipped default.
+#
+# Driven through `channels.sh --resolve-main-model`, which prints the resolved
+# model and exits before touching tmux, the store or the network.
+# Run: bash scripts/__tests__/channels-main-model.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 -- expected: $2, got: $3"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SRC="${CHANNELS_BIN:-$INSTALL_DIR/scripts/channels.sh}"
+
+# Each case runs the script from a throwaway install root, so INSTALL_DIR (which
+# the script derives from its own path) points at fixture files, not the repo.
+# $1 = label, $2 = .env body, $3 = settings.json body, $4 = expected model
+expect_model() {
+  local label="$1" env_body="$2" settings_body="$3" want="$4"
+  local root got
+  root="$(mktemp -d)"
+  mkdir -p "$root/scripts" "$root/.claude"
+  cp "$SRC" "$root/scripts/channels.sh"
+  [ -n "$env_body" ] && printf '%s\n' "$env_body" > "$root/.env"
+  [ -n "$settings_body" ] && printf '%s\n' "$settings_body" > "$root/.claude/settings.json"
+  got="$(bash "$root/scripts/channels.sh" --resolve-main-model 2>/dev/null | head -1)"
+  rm -rf "$root"
+  if [ "$got" = "$want" ]; then pass "$label"; else fail "$label" "$want" "$got"; fi
+}
+
+echo "channels.sh main-model resolution"
+
+expect_model "settings.json alone is still honoured (shipped default)" \
+  "" '{"model":"claude-opus-4-8[1m]"}' 'claude-opus-4-8[1m]'
+
+expect_model ".env wins over settings.json (the whole point)" \
+  'MAIN_AGENT_MODEL=claude-opus-5' '{"model":"claude-opus-4-8[1m]"}' 'claude-opus-5'
+
+expect_model ".env alone works with no settings.json" \
+  'MAIN_AGENT_MODEL=claude-sonnet-5' '' 'claude-sonnet-5'
+
+expect_model "neither present -> empty, launcher omits --model" \
+  "" '' ''
+
+expect_model "an empty MAIN_AGENT_MODEL does not shadow settings.json" \
+  'MAIN_AGENT_MODEL=' '{"model":"claude-opus-5"}' 'claude-opus-5'
+
+# A model id with a bracketed suffix must survive verbatim: the launcher
+# single-quotes it, and an unquoted `[1m]` would glob-expand in the tmux shell.
+expect_model "bracketed suffix survives the .env route" \
+  'MAIN_AGENT_MODEL=claude-opus-5[1m]' '' 'claude-opus-5[1m]'
+
+# .env carries other keys too; the matcher must be anchored, not a substring.
+expect_model "a similarly named key does not leak in" \
+  'NOT_MAIN_AGENT_MODEL=wrong-model
+MAIN_AGENT_MODEL=claude-haiku-4-5' '' 'claude-haiku-4-5'
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -30,6 +30,12 @@ if [ -f "$INSTALL_DIR/.env" ]; then
   # primary provider still drives the orphan-reaper + liveness watchdog logic
   # below unchanged; the extras are best-effort co-listeners on the same session.
   CHANNEL_PLUGINS_EXTRA="$(grep -E '^CHANNEL_PLUGINS_EXTRA=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
+  # Optional per-install model override for the MAIN agent. Lives here rather
+  # than in .claude/settings.json because that file is TRACKED: an install that
+  # writes its model choice there carries a permanent local diff, which blocks
+  # the update preflight's clean-tree check and silently reverts to the
+  # repository's value on the next update. .env is per-install and gitignored.
+  MAIN_AGENT_MODEL="$(grep -E '^MAIN_AGENT_MODEL=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2-)"
   # Claude Code auth: pass API key or OAuth token so the tmux-spawned
   # claude process can authenticate. These are safe to export -- unlike
   # TELEGRAM_BOT_TOKEN they don't cause cross-session conflicts.
@@ -102,6 +108,31 @@ classify_mcp_plugin_row() {
 
 # Test hook: classify a pane from stdin and exit before anything touches tmux,
 # the store or a live session.
+# Resolve the main agent's model. Precedence: MAIN_AGENT_MODEL from .env
+# (per-install, gitignored) over .claude/settings.json (tracked, shipped with
+# the repo). Without the .env route an install that wants a different model has
+# to edit a tracked file, which then blocks the update preflight's clean-tree
+# check and gets reverted by the next update.
+#
+# Kept as a function so `--resolve-main-model` can exercise exactly the code
+# the launch path uses, with no tmux, store or network involved.
+resolve_main_model() {
+  if [ -n "${MAIN_AGENT_MODEL:-}" ]; then
+    printf '%s' "$MAIN_AGENT_MODEL"
+    return 0
+  fi
+  if [ -f "$INSTALL_DIR/.claude/settings.json" ] && command -v jq >/dev/null 2>&1; then
+    jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null
+  fi
+}
+
+# Test seam: print the resolved model and exit before any side effect.
+if [ "${1:-}" = "--resolve-main-model" ]; then
+  resolve_main_model
+  echo
+  exit 0
+fi
+
 if [ "${1:-}" = "--classify-mcp-pane" ]; then
   resolve_plugin_ids "${2:-$CHANNEL_PROVIDER}"
   classify_mcp_plugin_row "$(cat)"
@@ -277,14 +308,16 @@ TMUX="$(command -v tmux)"
 # too closes the gap end-to-end). Parity with the sub-agent launch.
 MCP_BATCH_ENV="export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false MCP_SERVER_CONNECTION_BATCH_SIZE=10 MCP_CONNECTION_NONBLOCKING=1 MCP_TIMEOUT=60000 && "
 
-# Read the main agent's default model from .claude/settings.json so we can
-# pass --model explicitly. Without --model claude-code falls back to its
-# built-in default, which can drift across versions. Passing the flag makes
-# the choice deterministic and visible in `ps`.
-MAIN_MODEL=""
-if [ -f "$INSTALL_DIR/.claude/settings.json" ] && command -v jq >/dev/null 2>&1; then
-  MAIN_MODEL="$(jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null)"
-fi
+# Resolve the main agent's model so we can pass --model explicitly. Without
+# --model claude-code falls back to its built-in default, which can drift
+# across versions. Passing the flag makes the choice deterministic and visible
+# in `ps`.
+#
+# Precedence: MAIN_AGENT_MODEL from .env (per-install, gitignored) wins over
+# .claude/settings.json (tracked, shipped with the repo). Without the .env
+# route an install that wants a different model has to edit a tracked file,
+# which then blocks the update preflight and gets reverted by the next update.
+MAIN_MODEL="$(resolve_main_model)"
 MODEL_FLAG=""
 # Single-quote the model id so values like `claude-opus-4-8[1m]` survive the
 # tmux command-string round-trip without the inner shell glob-expanding `[1m]`.


### PR DESCRIPTION
The launcher read the main agent's model only from `.claude/settings.json`, a
tracked file. An install that wants a different model than the repository ships
had to edit it, and paid for that twice:

- the update preflight refuses to run on a dirty tree, so the dashboard's
  update button stayed blocked on that install; and
- checking out the release branch restored the repository's model, so the next
  restart came up on a different model than the operator chose. Nothing fails
  in that case -- the agent just answers as another model, which is the kind of
  drift nobody notices for weeks.

`MAIN_AGENT_MODEL` in `.env` (per-install, gitignored) now wins; settings.json
stays the shipped default. The resolution moved into a function so the new
`--resolve-main-model` seam exercises exactly the launch path, with no tmux,
store or network involved -- same pattern as `--classify-mcp-pane`.

Tests: `scripts/__tests__/channels-main-model.test.sh`, seven cases covering
precedence both ways, an empty override that must not shadow settings.json, a
bracketed model id (`claude-opus-5[1m]` must survive the tmux round-trip
verbatim), and an anchored key match so `NOT_MAIN_AGENT_MODEL=` cannot leak in.
Verified the suite goes red on a copy with the `.env` branch removed: four of
the seven fail, the rest stay green. The existing channels test suite is
unaffected (11/11).
