### PR TITLE
fix(bridge): prefer the tailnet address when pairing -- the LAN default died off-network

### DIFF
--- a/src/__tests__/bridge-enroll-host.test.ts
+++ b/src/__tests__/bridge-enroll-host.test.ts
@@ -1,0 +1,93 @@
+// BRIDGEHOST1 -- enroll host selection. The Bridge exists for REMOTE access,
+// so the default host must prefer the tailnet (CGNAT 100.64.0.0/10) address
+// over interface-order luck. The live failure this guards: the fleet host's
+// en0 (192.168.0.246, LAN) preceded utun4 (100.115.9.11, Tailscale) in
+// interface order, the bundle shipped the LAN address, and the Bridge died
+// with a handshake timeout the moment the laptop left the home network.
+import { describe, it, expect } from 'vitest'
+import { isTailnetIPv4, selectEnrollHost } from '../web/bridge-enroll.js'
+
+type Iface = { address: string; family: string | number; internal: boolean }
+const v4 = (address: string, internal = false): Iface => ({ address, family: 'IPv4', internal })
+const v6 = (address: string): Iface => ({ address, family: 'IPv6', internal: false })
+
+describe('isTailnetIPv4 (CGNAT 100.64.0.0/10 boundaries)', () => {
+  it('accepts the range, including both edges', () => {
+    expect(isTailnetIPv4('100.64.0.0')).toBe(true)
+    expect(isTailnetIPv4('100.115.9.11')).toBe(true)
+    expect(isTailnetIPv4('100.127.255.255')).toBe(true)
+  })
+  it('rejects 100.x addresses OUTSIDE the /10', () => {
+    expect(isTailnetIPv4('100.63.255.255')).toBe(false)
+    expect(isTailnetIPv4('100.128.0.0')).toBe(false)
+  })
+  it('rejects non-100 and non-IPv4 shapes', () => {
+    expect(isTailnetIPv4('192.168.0.246')).toBe(false)
+    expect(isTailnetIPv4('10.64.0.1')).toBe(false)
+    expect(isTailnetIPv4('fd7a:115c::1')).toBe(false)
+    expect(isTailnetIPv4('')).toBe(false)
+  })
+})
+
+describe('selectEnrollHost', () => {
+  it('THE LIVE CASE: tailnet wins even when it is NOT the first interface', () => {
+    // Mirror of the fleet host's real interface order on 2026-07-29.
+    const host = selectEnrollHost({
+      en0: [v4('192.168.0.246')],
+      en1: [v4('192.168.0.101')],
+      utun4: [v4('100.115.9.11')],
+    })
+    expect(host).toBe('100.115.9.11')
+  })
+
+  it('no tailnet present: first non-loopback IPv4 wins (pre-PR behavior unchanged)', () => {
+    const host = selectEnrollHost({
+      en0: [v4('192.168.0.246')],
+      en1: [v4('10.0.0.5')],
+    })
+    expect(host).toBe('192.168.0.246')
+  })
+
+  it('multiple tailnet-like addresses: the first tailnet in order, deterministically', () => {
+    const host = selectEnrollHost({
+      utun3: [v4('100.99.1.1')],
+      utun4: [v4('100.115.9.11')],
+    })
+    expect(host).toBe('100.99.1.1')
+  })
+
+  it('internal and IPv6 entries never win', () => {
+    const host = selectEnrollHost({
+      lo0: [v4('127.0.0.1', true)],
+      en0: [v6('fe80::1'), v4('192.168.1.2')],
+    })
+    expect(host).toBe('192.168.1.2')
+  })
+
+  it('numeric family (Node >=18 shape) is honored the same way', () => {
+    const host = selectEnrollHost({
+      en0: [{ address: '192.168.1.2', family: 4, internal: false }],
+      utun0: [{ address: '100.70.1.1', family: 4, internal: false }],
+    })
+    expect(host).toBe('100.70.1.1')
+  })
+
+  it('returns null when nothing usable exists', () => {
+    expect(selectEnrollHost({ lo0: [v4('127.0.0.1', true)] })).toBe(null)
+    expect(selectEnrollHost({})).toBe(null)
+  })
+
+  // Backward compatibility is structural: the selector runs ONLY at enroll
+  // time inside bridgeEnroll (host = input.host ?? primaryIPv4() ?? hostname),
+  // an existing bundle is never re-derived, and an explicit input.host always
+  // wins before the selector is even consulted. The explicit-host precedence
+  // is covered end-to-end in bridge-enroll.test.ts; this file pins the
+  // source-level ordering so a refactor cannot silently demote it.
+  it('explicit input.host stays ahead of the selector in the enroll path', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { join, dirname } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../web/bridge-enroll.ts'), 'utf-8')
+    expect(src).toMatch(/input\.host \?\? primaryIPv4\(\) \?\? hostname\(\)/)
+  })
+})

--- a/src/web/bridge-enroll.ts
+++ b/src/web/bridge-enroll.ts
@@ -115,18 +115,49 @@ export function defaultBridgeEnrollDeps(): BridgeEnrollDeps {
   }
 }
 
-/** Best-effort primary non-loopback IPv4 address of this machine. */
-function primaryIPv4(): string | null {
-  const ifaces = networkInterfaces()
+/** True for the CGNAT range 100.64.0.0/10, which Tailscale uses for tailnet
+ * addresses. Second octet 64..127; 100.63.x and 100.128.x are OUTSIDE. */
+export function isTailnetIPv4(addr: string): boolean {
+  const m = /^100\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/.exec(addr)
+  if (!m) return false
+  const second = Number(m[1])
+  return second >= 64 && second <= 127
+}
+
+/** Pick the default enroll host from an interface map. The Bridge exists for
+ * REMOTE access, so a LAN address is a structurally wrong default: the first
+ * non-loopback IPv4 in interface order used to win (BRIDGEHOST1: en0's
+ * 192.168.x beat utun4's tailnet address, and the bundle died the moment the
+ * laptop left the home network). Prefer the first tailnet (CGNAT) address
+ * when one exists; otherwise keep the pre-existing first-IPv4 behavior so
+ * hosts without Tailscale see no change. Pure over the interface map so the
+ * order-sensitive cases are unit-testable. */
+export interface EnrollIfaceInfo {
+  address: string
+  family: string | number
+  internal: boolean
+}
+
+export function selectEnrollHost(
+  ifaces: Record<string, EnrollIfaceInfo[] | undefined>,
+): string | null {
+  let first: string | null = null
   for (const name of Object.keys(ifaces)) {
     for (const info of ifaces[name] ?? []) {
       const family = info.family as string | number
       if ((family === 'IPv4' || family === 4) && !info.internal) {
-        return info.address
+        if (isTailnetIPv4(info.address)) return info.address
+        if (first === null) first = info.address
       }
     }
   }
-  return null
+  return first
+}
+
+/** Best-effort default host of this machine: tailnet-preferred, else the
+ * first non-loopback IPv4. */
+function primaryIPv4(): string | null {
+  return selectEnrollHost(networkInterfaces())
 }
 
 export async function bridgeEnroll(

--- a/web/app.js
+++ b/web/app.js
@@ -12887,6 +12887,7 @@ function renderBridgeEnrollSection(body) {
     `<div class="auth-form">` +
       `<input id="authBridgeKeyLine" type="text" autocapitalize="off" spellcheck="false" placeholder="${t('auth.bridge.key_placeholder')}">` +
       `<input id="authBridgeName" type="text" autocapitalize="off" spellcheck="false" maxlength="64" placeholder="${t('auth.bridge.name_placeholder')}">` +
+      `<input id="authBridgeHost" type="text" autocapitalize="off" spellcheck="false" maxlength="253" placeholder="${t('auth.bridge.host_placeholder')}">` +
       `<button class="btn-secondary" id="authBridgeEnrollBtn">${t('auth.bridge.enroll')}</button>` +
       `<div class="auth-form-msg" id="authBridgeMsg"></div>` +
       `<div id="authBridgeBundle" hidden></div>` +
@@ -12900,6 +12901,7 @@ async function bridgeEnrollFromUi() {
   const out = document.getElementById('authBridgeBundle')
   const keyLine = (document.getElementById('authBridgeKeyLine').value || '').trim()
   const name = (document.getElementById('authBridgeName').value || '').trim()
+  const hostOverride = (document.getElementById('authBridgeHost').value || '').trim()
   msg.className = 'auth-form-msg'
   msg.textContent = ''
   out.hidden = true
@@ -12910,7 +12912,7 @@ async function bridgeEnrollFromUi() {
   try {
     const r = await fetch('/api/security/bridge-enroll', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ key_line: keyLine, name }),
+      body: JSON.stringify(hostOverride ? { key_line: keyLine, name, host: hostOverride } : { key_line: keyLine, name }),
     })
     const data = await r.json().catch(() => ({}))
     if (!r.ok) { msg.classList.add('err'); msg.textContent = data.error || t('auth.card.err_generic'); return }
@@ -12919,6 +12921,7 @@ async function bridgeEnrollFromUi() {
       (data.warnings && data.warnings.length ? ` (${data.warnings.join('; ')})` : '')
     document.getElementById('authBridgeKeyLine').value = ''
     document.getElementById('authBridgeName').value = ''
+    document.getElementById('authBridgeHost').value = ''
     out.hidden = false
     out.innerHTML =
       `<p class="auth-muted">${t('auth.bridge.bundle_hint', { host: escapeHtml(data.host || '') })}</p>` +

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1741,6 +1741,7 @@ window._i18n.en = {
   'auth.bridge.desc':              'Paste the key line shown by the Bridge app (ssh-ed25519 ... marveen-remote:...), name the device, then copy the returned bundle back into the Bridge. The device gets its own, individually revocable key.',
   'auth.bridge.key_placeholder':   'ssh-ed25519 ... marveen-remote:...',
   'auth.bridge.name_placeholder':  'Device name (e.g. work laptop)',
+  'auth.bridge.host_placeholder':  'Host address (optional -- default: Tailscale address if present, else LAN)',
   'auth.bridge.enroll':            'Pair device',
   'auth.bridge.confirm':           'Pair "{name}"? It will get SSH-tunnel + its own device-key access to the dashboard.',
   'auth.bridge.working':           'Pairing...',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1737,6 +1737,7 @@ window._i18n.hu = {
   'auth.bridge.desc':              'Illeszd be a Bridge alkalmazásban megjelenő kulcs-sort (ssh-ed25519 ... marveen-remote:...), adj nevet az eszköznek, és a kapott csomagot másold vissza a Bridge-be. Az eszköz saját, külön visszavonható kulcsot kap.',
   'auth.bridge.key_placeholder':   'ssh-ed25519 ... marveen-remote:...',
   'auth.bridge.name_placeholder':  'Eszköz neve (pl. Szabi laptopja)',
+  'auth.bridge.host_placeholder':  'Cél-cím (opcionális -- alapértelmezés: Tailscale-cím ha van, különben LAN)',
   'auth.bridge.enroll':            'Párosítás',
   'auth.bridge.confirm':           'Párosítod "{name}" eszközt? SSH-alagút + saját eszközkulcs hozzáférést kap a dashboardhoz.',
   'auth.bridge.working':           'Párosítás folyamatban...',


### PR DESCRIPTION
## What (card BRIDGEHOST1, Szabi's 12:52 request)
`primaryIPv4()` returned the FIRST non-loopback IPv4 in interface order, so the enroll bundle shipped the home LAN address (en0 beat utun4) and the Bridge could only connect from the home network -- off-network it hit ssh2's handshake timeout in an endless retry loop (today's bootcamp incident; Marveen re-paired by hand with the tailnet address at 12:50).

- **`selectEnrollHost()`**: prefers the first CGNAT address (100.64.0.0/10, Tailscale) and falls back to the exact pre-PR first-IPv4 behavior when no tailnet address exists. Pure over the interface map so order-sensitive cases are unit-testable.
- **Backward compatibility (Marveen's condition 1)**: an explicit `input.host` still wins BEFORE the selector is consulted (source-pinned by test); an already-issued bundle is never re-derived; hosts without Tailscale get byte-identical behavior.
- **UI**: the pairing form gains an optional host-override field; the route already accepted `host` and echoed the chosen value -- now the UI can send it, and the result hint keeps displaying the chosen address so the operator SEES what the bundle targets.

## Tests (Marveen's condition 2: not just the happy branch)
- CGNAT boundary vectors: 100.64.0.0 and 100.127.255.255 IN; 100.63.x and 100.128.x OUT
- **The live case: tailnet NOT the first interface -> tailnet wins** (mirror of the fleet host's real interface order)
- No tailnet -> first IPv4, unchanged pre-PR behavior
- Multiple tailnet-like addresses -> deterministic first
- internal/IPv6 exclusion, numeric-family shape, empty map -> null
- Source-pin: `input.host ?? primaryIPv4() ?? hostname()` ordering cannot silently change

## Gates
- `tsc --noEmit` clean, `node --check web/app.js` clean, full suite **2901/2901**
- **Browser-verified** against the live dashboard (Playwright route interception, enroll POST mocked -- no live pairing): the field renders with the HU placeholder, the override is included in the request body, the chosen host renders in the result hint, the field clears on success, zero console errors
- Em-dash clean; no hardcoded addresses in code (the live IPs appear only as test-fixture mirrors of the incident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)