### PR TITLE
fix(governance): the three agent gates, split out of #767

### DIFF
--- a/scripts/readonly-repo-gate.mjs
+++ b/scripts/readonly-repo-gate.mjs
@@ -48,7 +48,14 @@ function isArtifactPath(p) {
 
 // Package managers only ever write artifacts (node_modules, lockfile refresh),
 // so they are allowed wholesale rather than path-checked.
-const INSTALL_RX = /\b(npm\s+(ci|install|i)\b|pnpm\s+(install|i)\b|yarn\s+(install)?\b|pip\s+install\b|poetry\s+install\b|bundle\s+install\b)/
+// Every branch REQUIRES its subcommand. The yarn branch used to read
+// `yarn\s+(install)?\b`, and the optional group made the pattern match bare
+// `yarn ` + anything -- `yarn add`, `yarn exec`, `yarn dlx` all skipped the
+// gate's inspection, which is the opposite of what an install-only exemption
+// is for. (Found in review on #770, 2026-09-03.) Bare `yarn` (Yarn 1's
+// implicit install) is no longer exempted either: it carries no redirect and
+// no mutating verb, so it passes on its own merits rather than by blanket skip.
+const INSTALL_RX = /\b(npm\s+(ci|install|i)\b|pnpm\s+(install|i)\b|yarn\s+install\b|pip\s+install\b|poetry\s+install\b|bundle\s+install\b)/
 
 // Branch movement is not a source edit -- a QA worker needs it for baseline
 // comparison. `git checkout -- <path>` / `git restore <path>` IS a working-tree

--- a/scripts/readonly-repo-gate.mjs
+++ b/scripts/readonly-repo-gate.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// PreToolUse hard-gate: a worker may READ the project repos but never WRITE them.
+//
+// Why a hook and not a permissions deny-list. The two permission modes each
+// fail one half of the requirement:
+//
+//   - strict:     path denies are enforced, but Claude Code prompts on things
+//                 an allow-list cannot pre-approve (notably the `cd X && git …`
+//                 compound, which trips the cd-guard). An UNATTENDED worker
+//                 cannot answer a prompt, so it simply hangs -- observed twice
+//                 on davinci-ocura and vermeer-ocura.
+//   - permissive: nothing prompts, but the launcher passes
+//                 --dangerously-skip-permissions, which BYPASSES allow/deny.
+//                 A `Write(/home/ubuntu/projects/**)` deny is then decorative.
+//
+// Hooks run regardless of permission mode. So the worker runs permissive (never
+// hangs) and this gate provides the actual enforcement.
+//
+// Scope comes from READONLY_REPO_ROOTS (colon-separated). The default is
+// <home>/projects, derived at runtime -- a shipped script must not carry one
+// install's absolute home path.
+
+import { readFileSync, realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { homedir } from 'node:os'
+import { resolve, join } from 'node:path'
+
+const ROOTS = (process.env.READONLY_REPO_ROOTS || join(homedir(), 'projects'))
+  .split(':').map(s => s.trim()).filter(Boolean)
+
+const WRITE_TOOLS = new Set(['Write', 'Edit', 'NotebookEdit'])
+
+// The rule is "do not change the SOURCE", not "do not touch the filesystem".
+// Dependency and build output live inside the repo but are not source: a QA
+// worker that cannot run `npm ci` in a fresh worktree is not a QA worker.
+// (Learned the hard way: blocking installs pushed a worker onto `npx prisma`,
+// which fetched the registry's latest instead of the pinned version and made it
+// diagnose a config problem that did not exist.)
+const ARTIFACT_SEGMENTS = new Set([
+  'node_modules', '.next', 'dist', 'build', 'out', 'coverage', '.turbo',
+  '.cache', '.venv', '__pycache__', 'target', '.pytest_cache', '.nuxt',
+  '.svelte-kit', '.output', 'tmp', '.parcel-cache',
+])
+
+function isArtifactPath(p) {
+  return String(p || '').split('/').some(seg => ARTIFACT_SEGMENTS.has(seg))
+}
+
+// Package managers only ever write artifacts (node_modules, lockfile refresh),
+// so they are allowed wholesale rather than path-checked.
+const INSTALL_RX = /\b(npm\s+(ci|install|i)\b|pnpm\s+(install|i)\b|yarn\s+(install)?\b|pip\s+install\b|poetry\s+install\b|bundle\s+install\b)/
+
+// Branch movement is not a source edit -- a QA worker needs it for baseline
+// comparison. `git checkout -- <path>` / `git restore <path>` IS a working-tree
+// mutation, so those stay blocked.
+const GIT_SAFE_RX = /\bgit\s+(checkout|switch)\s+(?!.*(--\s|--\s*$))[^\s-][^\s]*\s*$|\bgit\s+(switch|checkout)\s+-b\b|\bgit\s+worktree\s+(add|list|prune)\b/
+
+function underRoot(p) {
+  if (!p) return false
+  let abs
+  try { abs = resolve(String(p)) } catch { return false }
+  return ROOTS.some(r => abs === r || abs.startsWith(r.endsWith('/') ? r : r + '/'))
+}
+
+// Bash is the wide-open route: a redirect or an in-place edit reaches the repo
+// without ever touching the Write tool. Checked per segment so a read command
+// in one half of a compound is not judged by the other half.
+function splitSegments(cmd) {
+  return String(cmd || '').split(/&&|\|\||;|\n|\|/).map(s => s.trim()).filter(Boolean)
+}
+
+const MUTATING_RX = [
+  /\bsed\s+[^|]*-i\b/,                       // in-place edit
+  /\b(rm|mv|cp|install|truncate|chmod|chown)\b/,
+  /\btee\b/,
+  /\bgit\s+(commit|push|reset|restore|clean|rm|mv|apply|stash)\b/,
+  /\bgit\s+checkout\s+.*--\s/,
+  /\bnpm\s+publish\b/,
+  /\b(pnpm|yarn)\s+(add|remove)\b/,
+  /\bmkdir\b/,
+  /\btouch\b/,
+]
+
+// `> file` / `>> file` -- capture the target so we only object when it lands in
+// a protected root. `2>/dev/null` and friends are not file writes we care about.
+const REDIRECT_RX = /(?<!\d)>>?\s*("[^"]+"|'[^']+'|[^\s;|&]+)/g
+
+function bashViolation(cmd) {
+  // The cwd carries ACROSS segments: `cd /repo && echo x > src/a.ts` puts the
+  // redirect in a later segment than the cd, so judging segments in isolation
+  // would wave it through. Track it.
+  let cwd = null
+  for (const seg of splitSegments(cmd)) {
+    const cd = seg.match(/\bcd\s+("[^"]+"|'[^']+'|[^\s;|&]+)/)
+    if (cd) cwd = cd[1].replace(/^["']|["']$/g, '')
+
+    const inRoot = (p) => underRoot(p) || (cwd && !String(p).startsWith('/') && underRoot(cwd))
+
+    if (INSTALL_RX.test(seg) || GIT_SAFE_RX.test(seg)) continue
+
+    for (const m of seg.matchAll(REDIRECT_RX)) {
+      const target = m[1].replace(/^["']|["']$/g, '')
+      if (target === '/dev/null' || isArtifactPath(target)) continue
+      if (inRoot(target)) {
+        const shown = target.startsWith('/') ? target : `${cwd}/${target}`
+        return `átirányítás a repóba: ${shown}`
+      }
+    }
+
+    for (const rx of MUTATING_RX) {
+      if (!rx.test(seg)) continue
+      const touchesRoot = ROOTS.some(r => seg.includes(r)) || (cwd && underRoot(cwd))
+      if (touchesRoot && !isArtifactPath(seg)) return `módosító parancs a repóban: ${seg.slice(0, 120)}`
+    }
+  }
+  return null
+}
+
+const GATE_MSG = (detail) =>
+  `Írás a projekt repóba TILTOTT (readonly-repo-gate). ${detail}. ` +
+  'A szereped olvasó: elemzel, tesztelsz, jelentesz -- a kódot nem te módosítod. ' +
+  'Ha a feladathoz tényleg írni kellene, azt az orchestratorodnak jelezd, és ő ' +
+  'vagy átadja a végrehajtónak, vagy bemásolja amit készítettél. Írni szabadon ' +
+  'tudsz a saját agent-mappádba és a /tmp alá -- oda dolgozz.'
+
+function allow() { process.exit(0) }
+
+function deny(reason) {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  }))
+  process.exit(0)
+}
+
+function isInvokedDirectly() {
+  try {
+    const self = realpathSync(fileURLToPath(import.meta.url))
+    const entry = process.argv[1] ? realpathSync(process.argv[1]) : ''
+    return self === entry
+  } catch {
+    return false
+  }
+}
+
+if (isInvokedDirectly()) {
+  let payload
+  try { payload = JSON.parse(readFileSync(0, 'utf-8')) } catch { allow() }
+
+  const tool = payload?.tool_name
+  const input = payload?.tool_input || {}
+
+  if (WRITE_TOOLS.has(tool)) {
+    const target = input.file_path || input.notebook_path || input.path
+    if (underRoot(target) && !isArtifactPath(target)) deny(GATE_MSG(`${tool} -> ${target}`))
+  }
+
+  if (tool === 'Bash') {
+    const v = bashViolation(input.command)
+    if (v) deny(GATE_MSG(v))
+  }
+
+  allow()
+}
+
+export { bashViolation, underRoot, isArtifactPath }

--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -301,7 +301,14 @@ export function maskInertLiterals(command) {
 const PROSE_FLAGS = String.raw`--body|--message|--notes|--title|--subject|-b|-m|-t`
 
 export function stripProseArguments(seg) {
-  return String(seg ?? '').replace(
+  const s = String(seg ?? '')
+  // Scoped to the tools these prose flags were written for: gh, git, glab (a PR
+  // body, a PR comment, a release note). A short flag means different things to
+  // different binaries (`tar -t`, `cut -b`, `sort -t`), so blanking it on an
+  // unrelated tool would hide real data from the gate (PR #770 review, Szotasz).
+  // Same coarse command-word guard as stripGitCommitMessages just below.
+  if (!/\b(?:gh|git|glab)\b/i.test(s)) return s
+  return s.replace(
     new RegExp(String.raw`((?:^|\s)(?:${PROSE_FLAGS})(?:\s+|=))('[^']*'|\$'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")`, 'gi'),
     (full, flag, arg) => {
       const dq = arg.startsWith('"')
@@ -355,14 +362,45 @@ export function stripDataPayloads(seg) {
 // stripGitCommitMessages and stripProseArguments all leave a double-quoted
 // value alone when it contains `$(` or a backtick. An unquoted heredoc is the
 // same category; it was simply missing the guard. Reported on PR #770.
+// Whether the command word owning a heredoc redirect EXECUTES the body. The
+// shell-literal guard above is not enough: a quoted marker (<<'EOF') is literal
+// to the SHELL, so blanking looks safe, but `bash <<'EOF'`, `sh`, `ssh box`,
+// `python - <<'EOF'` feed the body to an interpreter that runs it -- blanking
+// would hide a live scheduler command from the gate (PR #770 review, Szotasz).
+// `git commit -F - <<'EOF'` feeds the body to git as DATA, so that stays safe to
+// blank. So: keep the body visible when its redirect owner is an interpreter or
+// remote/container executor.
+const HEREDOC_INTERPRETER_RX = /^(?:bash|sh|zsh|dash|ksh|ash|python[0-9.]*|node|nodejs|ruby|perl|php|ssh)$/
+
+function heredocOwnerRunsBody(before) {
+  // `before` is the command text up to the << redirect; the owner is the first
+  // word of the last command segment.
+  const seg = before.split(/\n|;|\|\|?|&&?|\(|\{/).pop() ?? ''
+  const tokens = seg.trim().split(/\s+/).filter(Boolean)
+  // Pass-through prefixes that do not change what runs the body.
+  while (tokens.length && (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0]) ||
+    ['sudo', 'env', 'nice', 'time', 'exec', 'command', 'nohup', 'stdbuf'].includes(tokens[0]))) {
+    tokens.shift()
+  }
+  if (!tokens.length) return false
+  const word = tokens[0].split('/').pop()
+  if (HEREDOC_INTERPRETER_RX.test(word)) return true
+  // docker/podman/kubectl exec run the body through a shell in the target.
+  if (['docker', 'podman', 'kubectl'].includes(word) && tokens.slice(1).includes('exec')) return true
+  return false
+}
+
 export function stripHeredocBodies(command) {
   const cmd = String(command ?? '')
   if (!/<<-?\s*['"]?[A-Za-z_][A-Za-z0-9_]*/.test(cmd)) return cmd
   return cmd.replace(
     /(<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2)([\s\S]*?)(^\s*\3\s*$)/gm,
-    (full, open, quote, _marker, body, close) => {
+    (full, open, quote, _marker, body, close, offset, string) => {
       const literal = quote === "'" || quote === '"'
       if (!literal && (body.includes('$(') || body.includes('`'))) return full
+      // A quoted body the shell will not expand is still executed when an
+      // interpreter/remote-executor owns the redirect -- keep it visible then.
+      if (heredocOwnerRunsBody(string.slice(0, offset))) return full
       return `${open}\n${close}`
     },
   )

--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -335,15 +335,36 @@ export function stripDataPayloads(seg) {
 // Heredoc bodies are DATA, not commands. A worker writing a real commit message
 // through `git commit -F - <<EOF … EOF` had the turn denied because one prose
 // line happened to start with "at " -- which SCHEDULER_RX reads as the `at`
-// scheduler at a segment start. The body never reaches a shell as commands, so
-// blank it before any pattern runs. Quoted (<<'EOF') and unquoted markers both,
-// and <<- for tab-indented bodies.
+// scheduler at a segment start. A heredoc body is data, so blank it before any
+// pattern runs. Handles <<- for tab-indented bodies.
+//
+// EXCEPT when the body can still run something. A QUOTED marker (<<'EOF' or
+// <<"EOF") is literal: the shell performs no expansion inside it, so blanking is
+// safe. An UNQUOTED marker (<<EOF) is not -- the shell expands $(...) and
+// backticks in that body at exec time, so blanking one would hide a live
+// command substitution from SCHEDULER_RX and the gate would stop seeing
+// something that really runs:
+//
+//     git commit -m "$(cat <<EOF
+//     fix
+//     $(at now)
+//     EOF
+//     )"
+//
+// This is the same rule the other strippers already apply: stripDataPayloads,
+// stripGitCommitMessages and stripProseArguments all leave a double-quoted
+// value alone when it contains `$(` or a backtick. An unquoted heredoc is the
+// same category; it was simply missing the guard. Reported on PR #770.
 export function stripHeredocBodies(command) {
   const cmd = String(command ?? '')
   if (!/<<-?\s*['"]?[A-Za-z_][A-Za-z0-9_]*/.test(cmd)) return cmd
   return cmd.replace(
     /(<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2)([\s\S]*?)(^\s*\3\s*$)/gm,
-    (_full, open, _q, _marker, _body, close) => `${open}\n${close}`,
+    (full, open, quote, _marker, body, close) => {
+      const literal = quote === "'" || quote === '"'
+      if (!literal && (body.includes('$(') || body.includes('`'))) return full
+      return `${open}\n${close}`
+    },
   )
 }
 

--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -291,6 +291,26 @@ export function maskInertLiterals(command) {
 // blank the out-of-band `; crontab -r` and let a real self-pace command slip.
 // ANSI-C $'...' DOES process \', so that branch keeps the \\. escape form; "..."
 // keeps it too (backslash is special inside bash double quotes).
+// Human prose in a command-argument position is DATA, not commands. The heredoc
+// fix closed one wrapper; this closes the rest of the family: a PR body, a PR
+// comment, a release note. The failure mode is identical -- a sentence like
+// "runs at the same time" reads as the `at` scheduler at a segment start, and
+// the better the prose, the likelier it contains words like at / cron /
+// schedule. Same literal-only rule as the other strippers: a double-quoted
+// value with $( or ` may substitute, so it is left alone.
+const PROSE_FLAGS = String.raw`--body|--message|--notes|--title|--subject|-b|-m|-t`
+
+export function stripProseArguments(seg) {
+  return String(seg ?? '').replace(
+    new RegExp(String.raw`((?:^|\s)(?:${PROSE_FLAGS})(?:\s+|=))('[^']*'|\$'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")`, 'gi'),
+    (full, flag, arg) => {
+      const dq = arg.startsWith('"')
+      if (dq && (arg.includes('$(') || arg.includes('`'))) return full
+      return flag + (dq ? '""' : "''")
+    },
+  )
+}
+
 export function stripDataPayloads(seg) {
   return String(seg ?? '').replace(
     /((?:^|\s)(?:-d|--data(?:-(?:raw|binary|ascii|urlencode))?)(?:\s+|=))('[^']*'|\$'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")/gi,
@@ -378,7 +398,7 @@ export function gateDecision(toolName, toolInput) {
     // it), so the URL/method args still match but the body text never does. A
     // separator OUTSIDE the payload still splits, so `curl -d '' x ; crontab -r`
     // is still caught.
-    const safeCommand = stripDataPayloads(stripGitCommitMessages(stripHeredocBodies(String(toolInput?.command ?? ''))))
+    const safeCommand = stripProseArguments(stripDataPayloads(stripGitCommitMessages(stripHeredocBodies(String(toolInput?.command ?? '')))))
     // Per-segment so an unrelated token elsewhere in a compound command cannot
     // turn a legit read (store inspection, schedule-API GET) into a false deny.
     const naiveSegs = splitSegments(safeCommand)

--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -312,6 +312,21 @@ export function stripDataPayloads(seg) {
 // double-quoted message that CAN command-substitute (`git commit -m "$(crontab
 // -r)"`) is left intact so SCHEDULER_RX still catches the real substitution.
 // Scoped to git commit/tag/stash so a `-m` on an unrelated binary is untouched.
+// Heredoc bodies are DATA, not commands. A worker writing a real commit message
+// through `git commit -F - <<EOF … EOF` had the turn denied because one prose
+// line happened to start with "at " -- which SCHEDULER_RX reads as the `at`
+// scheduler at a segment start. The body never reaches a shell as commands, so
+// blank it before any pattern runs. Quoted (<<'EOF') and unquoted markers both,
+// and <<- for tab-indented bodies.
+export function stripHeredocBodies(command) {
+  const cmd = String(command ?? '')
+  if (!/<<-?\s*['"]?[A-Za-z_][A-Za-z0-9_]*/.test(cmd)) return cmd
+  return cmd.replace(
+    /(<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2)([\s\S]*?)(^\s*\3\s*$)/gm,
+    (_full, open, _q, _marker, _body, close) => `${open}\n${close}`,
+  )
+}
+
 export function stripGitCommitMessages(command) {
   const cmd = String(command ?? '')
   if (!/\bgit\b[\s\S]*\b(commit|tag|stash)\b/i.test(cmd)) return cmd
@@ -363,7 +378,7 @@ export function gateDecision(toolName, toolInput) {
     // it), so the URL/method args still match but the body text never does. A
     // separator OUTSIDE the payload still splits, so `curl -d '' x ; crontab -r`
     // is still caught.
-    const safeCommand = stripDataPayloads(stripGitCommitMessages(String(toolInput?.command ?? '')))
+    const safeCommand = stripDataPayloads(stripGitCommitMessages(stripHeredocBodies(String(toolInput?.command ?? ''))))
     // Per-segment so an unrelated token elsewhere in a compound command cannot
     // turn a legit read (store inspection, schedule-API GET) into a false deny.
     const naiveSegs = splitSegments(safeCommand)

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect } from 'vitest'
 // @ts-expect-error -- plain .mjs hook script, no types
 import { gateDecision as selfPaceDecision, stripDataPayloads, stripGitCommitMessages, stripHeredocBodies, stripProseArguments } from '../../scripts/self-pace-gate.mjs'
+// @ts-expect-error -- plain .mjs hook script, no types
+import { bashViolation } from '../../scripts/readonly-repo-gate.mjs'
 import {
   agentGetsGovernanceGates,
+  agentGetsReadonlyRepoGate,
+  injectReadonlyRepoGate,
   injectSelfPaceGate,
 } from '../web/agent-scaffold.js'
 import { MAIN_AGENT_ID } from '../config.js'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
 // --- self-pace-gate: blocks the agent from scheduling its own future turns ---
 describe('self-pace-gate gateDecision', () => {
@@ -518,5 +524,77 @@ describe('self-pace-gate: quoted prose cannot fake a command position', () => {
   it('fails CLOSED on an UNQUOTED heredoc tag whose body substitutes', () => {
     // <<PY (no quotes) expands the body, so its contents are not inert.
     expect(selfPaceDecision('Bash', { command: 'cat <<PY\n$(crontab -r)\nPY' }).deny).toBe(true)
+  })
+})
+
+// --- readonly-repo-gate: the install exemption must exempt installs ONLY ---
+//
+// INSTALL_RX marks a segment as "this is a dependency install, do not inspect
+// it" -- package managers only ever write artifacts. The yarn branch used to
+// read `yarn\s+(install)?\b`: the optional group plus the word boundary made
+// it match `yarn ` + anything, so `yarn add`, `yarn exec` and `yarn dlx`
+// inherited a blanket skip that was never meant for them. Found in review on
+// #770 (2026-09-03). The other five branches all require their subcommand,
+// which is why only yarn slipped.
+describe('readonly-repo-gate: INSTALL_RX exempts installs, not every yarn call', () => {
+  // ROOTS defaults to <home>/projects, resolved when the module loads.
+  const repoFile = join(homedir(), 'projects', 'app', 'install.log')
+
+  it('still exempts the real installs, per package manager', () => {
+    for (const cmd of [
+      `npm ci > ${repoFile}`,
+      `npm install > ${repoFile}`,
+      `pnpm install > ${repoFile}`,
+      `yarn install > ${repoFile}`,
+      `pip install -r requirements.txt > ${repoFile}`,
+      `poetry install > ${repoFile}`,
+      `bundle install > ${repoFile}`,
+    ]) {
+      expect(bashViolation(cmd), cmd).toBeNull()
+    }
+  })
+
+  it('no longer waves through a non-install yarn subcommand (the regression)', () => {
+    for (const cmd of [
+      `yarn add left-pad > ${repoFile}`,
+      `yarn exec tsx build.ts > ${repoFile}`,
+      `yarn dlx some-codemod > ${repoFile}`,
+      `yarn run build > ${repoFile}`,
+    ]) {
+      expect(bashViolation(cmd), cmd).not.toBeNull()
+    }
+  })
+
+  it('the exemption is per-segment, so a chained non-install is still judged', () => {
+    expect(bashViolation(`yarn install && yarn add left-pad > ${repoFile}`)).not.toBeNull()
+  })
+})
+
+// --- readonly-repo-gate wiring: opt-in by profile FLAG, not by profile name ---
+describe('agentGetsReadonlyRepoGate', () => {
+  it('wires only for a profile that opts in', () => {
+    expect(agentGetsReadonlyRepoGate({ readonlyRepo: true })).toBe(true)
+    expect(agentGetsReadonlyRepoGate({ readonlyRepo: false })).toBe(false)
+    expect(agentGetsReadonlyRepoGate({})).toBe(false)
+  })
+
+  it('injects one PreToolUse entry and stays idempotent', () => {
+    const settings: Record<string, unknown> = {}
+    injectReadonlyRepoGate(settings)
+    injectReadonlyRepoGate(settings)
+    const pre = (settings.hooks as Record<string, unknown>).PreToolUse as unknown[]
+    const mine = pre.filter((e) => JSON.stringify(e).includes('readonly-repo-gate.mjs'))
+    expect(mine).toHaveLength(1)
+    expect(JSON.stringify(mine[0])).toContain('Bash|Write|Edit|NotebookEdit')
+  })
+
+  it('preserves unrelated PreToolUse entries', () => {
+    const settings: Record<string, unknown> = {
+      hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'node other.mjs' }] }] },
+    }
+    injectReadonlyRepoGate(settings)
+    const pre = (settings.hooks as Record<string, unknown>).PreToolUse as unknown[]
+    expect(pre).toHaveLength(2)
+    expect(JSON.stringify(pre[0])).toContain('other.mjs')
   })
 })

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 // @ts-expect-error -- plain .mjs hook script, no types
-import { gateDecision as selfPaceDecision, stripDataPayloads, stripGitCommitMessages } from '../../scripts/self-pace-gate.mjs'
+import { gateDecision as selfPaceDecision, stripDataPayloads, stripGitCommitMessages, stripHeredocBodies } from '../../scripts/self-pace-gate.mjs'
 import {
   agentGetsGovernanceGates,
   injectSelfPaceGate,
@@ -128,6 +128,51 @@ describe('self-pace-gate gateDecision', () => {
 // a shell invocation, so a trigger token INSIDE the payload must not false-deny a
 // legit dispatch. Only provably-literal payloads are blanked; a payload that can
 // command-substitute ($(...)/backtick) is kept so a real substitution still trips. ---
+describe('self-pace-gate stripHeredocBodies (quoted vs unquoted marker)', () => {
+  // A heredoc body is data -- unless the shell will expand it. A quoted marker
+  // is literal, an unquoted one is not, and blanking an unquoted body would
+  // hide a live command substitution from the scheduler patterns. Reported on
+  // PR #770; the gate-level assertion for the same hole lives above.
+  const PROSE = 'at the same time we fixed the parser'
+
+  it('blanks a QUOTED heredoc body (the false positive this strip exists for)', () => {
+    const cmd = `git commit -F - <<'EOF'\n${PROSE}\nEOF`
+    expect(stripHeredocBodies(cmd)).not.toContain(PROSE)
+  })
+
+  it('blanks a double-quoted marker too', () => {
+    const cmd = `git commit -F - <<"EOF"\n${PROSE}\nEOF`
+    expect(stripHeredocBodies(cmd)).not.toContain(PROSE)
+  })
+
+  it('blanks an UNQUOTED body that has nothing to expand', () => {
+    const cmd = `git commit -F - <<EOF\n${PROSE}\nEOF`
+    expect(stripHeredocBodies(cmd)).not.toContain(PROSE)
+  })
+
+  it('KEEPS an unquoted body containing $( ) -- the shell would run it', () => {
+    const cmd = 'git commit -m "$(cat <<EOF\nfix\n$(at now)\nEOF\n)"'
+    expect(stripHeredocBodies(cmd)).toContain('$(at now)')
+  })
+
+  it('KEEPS an unquoted body containing a backtick', () => {
+    const cmd = 'git commit -F - <<EOF\nfix `at now`\nEOF'
+    expect(stripHeredocBodies(cmd)).toContain('`at now`')
+  })
+
+  it('still blanks a QUOTED body that merely mentions $( ) as text', () => {
+    // Quoted marker: the shell does not expand, so the text is data even when
+    // it looks like a substitution.
+    const cmd = "git commit -F - <<'EOF'\nwe replaced $(at now) with cron\nEOF"
+    expect(stripHeredocBodies(cmd)).not.toContain('$(at now)')
+  })
+
+  it('the <<- variant follows the same rule', () => {
+    expect(stripHeredocBodies(`git commit -F - <<-'EOF'\n\t${PROSE}\n\tEOF`)).not.toContain(PROSE)
+    expect(stripHeredocBodies('git commit -F - <<-EOF\n\t$(at now)\n\tEOF')).toContain('$(at now)')
+  })
+})
+
 describe('self-pace-gate stripDataPayloads (data-payload false-positive guard)', () => {
   it('blanks a single-quoted -d payload but keeps the flag', () => {
     expect(stripDataPayloads(`curl -d '{"x":"/api/schedules"}' u`)).toBe(`curl -d '' u`)

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 // @ts-expect-error -- plain .mjs hook script, no types
-import { gateDecision as selfPaceDecision, stripDataPayloads, stripGitCommitMessages, stripHeredocBodies } from '../../scripts/self-pace-gate.mjs'
+import { gateDecision as selfPaceDecision, stripDataPayloads, stripGitCommitMessages, stripHeredocBodies, stripProseArguments } from '../../scripts/self-pace-gate.mjs'
 import {
   agentGetsGovernanceGates,
   injectSelfPaceGate,
@@ -170,6 +170,53 @@ describe('self-pace-gate stripHeredocBodies (quoted vs unquoted marker)', () => 
   it('the <<- variant follows the same rule', () => {
     expect(stripHeredocBodies(`git commit -F - <<-'EOF'\n\t${PROSE}\n\tEOF`)).not.toContain(PROSE)
     expect(stripHeredocBodies('git commit -F - <<-EOF\n\t$(at now)\n\tEOF')).toContain('$(at now)')
+  })
+
+  // PR #770 review (Szotasz): a QUOTED body is literal to the SHELL, but an
+  // interpreter/remote-executor that OWNS the redirect runs it -- blanking would
+  // hide a live scheduler command. Keep the body visible for those owners.
+  const RUNS = 'crontab -r; at now'
+
+  it('KEEPS a quoted heredoc body owned by bash (it executes the body)', () => {
+    expect(stripHeredocBodies(`bash <<'EOF'\n${RUNS}\nEOF`)).toContain(RUNS)
+  })
+
+  it('KEEPS a quoted heredoc body owned by sh / bash -s', () => {
+    expect(stripHeredocBodies(`sh <<"EOF"\n${RUNS}\nEOF`)).toContain(RUNS)
+    expect(stripHeredocBodies(`bash -s <<'EOF'\n${RUNS}\nEOF`)).toContain(RUNS)
+  })
+
+  it('KEEPS a quoted heredoc body owned by ssh / python / docker exec', () => {
+    expect(stripHeredocBodies(`ssh box <<'EOF'\n${RUNS}\nEOF`)).toContain(RUNS)
+    expect(stripHeredocBodies(`python3 - <<'EOF'\n${RUNS}\nEOF`)).toContain(RUNS)
+    expect(stripHeredocBodies(`docker exec c bash <<'EOF'\n${RUNS}\nEOF`)).toContain(RUNS)
+  })
+
+  it('sees through a sudo/env prefix to the interpreter owner', () => {
+    expect(stripHeredocBodies(`sudo bash <<'EOF'\n${RUNS}\nEOF`)).toContain(RUNS)
+  })
+
+  it('still blanks when a non-interpreter (git/tee) owns the redirect', () => {
+    expect(stripHeredocBodies(`git commit -F - <<'EOF'\n${RUNS}\nEOF`)).not.toContain(RUNS)
+    expect(stripHeredocBodies(`tee f <<'EOF'\n${RUNS}\nEOF`)).not.toContain(RUNS)
+  })
+})
+
+describe('self-pace-gate stripProseArguments (scoped to gh/git/glab)', () => {
+  // PR #770 review (Szotasz): the prose-flag blanking is for a PR/issue body or
+  // release note, so it must be scoped to gh/git/glab. A short flag means
+  // something else to other tools, and blanking it there hides real data.
+  it('blanks a prose flag on gh', () => {
+    expect(stripProseArguments("gh pr create --body 'runs at midnight, cron style'"))
+      .not.toContain('midnight')
+  })
+
+  it('leaves a same-named flag on an unrelated tool alone', () => {
+    // tar -t is "list", cut -b is "bytes" -- not prose, must not be blanked.
+    const tar = "tar -t 'archive at now.tar'"
+    expect(stripProseArguments(tar)).toBe(tar)
+    const cut = "cut -b '1-3 at now'"
+    expect(stripProseArguments(cut)).toBe(cut)
   })
 })
 

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -483,6 +483,7 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
   // actual incident vector -- an agent answering its OWN posed question -- is
   // covered by the self-pace block + the #0 CLAUDE.md doctrine.
   if (agentGetsEmailGate(name)) injectEmailSendGate(existing)
+  if (agentGetsReadonlyRepoGate(profile)) injectReadonlyRepoGate(existing)
   if (agentGetsGovernanceGates(name)) injectSelfPaceGate(existing)
   if (agentGetsKanbanWriteGate(name)) {
     injectKanbanWriteGate(existing)
@@ -558,6 +559,41 @@ const SELF_PACE_TOOL_DENY = ['ScheduleWakeup', 'CronCreate', 'CronDelete', 'Cron
 // so the main-exempt guarantee is unit-testable.
 export function agentGetsGovernanceGates(name: string): boolean {
   return name !== MAIN_AGENT_ID
+}
+
+// Read-only-repo gate. Roles that analyse or test a repo but must not change it
+// cannot be held to that by permissions alone: a strict profile enforces the
+// deny but PROMPTS on things like `cd repo && git ...` (the cd-guard), and an
+// unattended worker hangs on a prompt instead of working. A permissive profile
+// never prompts but launches with --dangerously-skip-permissions, which
+// bypasses allow/deny entirely. Hooks run in both modes, so the enforcement
+// lives here and the profile stays permissive.
+//
+// Keyed on a profile FLAG, not on profile ids: which roles are read-only is a
+// property of the role, and no shipped profile should have to be named in this
+// file for the mechanism to work.
+export function agentGetsReadonlyRepoGate(profile: Pick<ProfileTemplate, 'readonlyRepo'>): boolean {
+  return profile.readonlyRepo === true
+}
+
+export function injectReadonlyRepoGate(existing: Record<string, unknown>): void {
+  const hooks = (existing.hooks && typeof existing.hooks === 'object'
+    ? existing.hooks
+    : (existing.hooks = {})) as Record<string, unknown>
+  // hookCommand(), not a bare `node <path>`: develop since landed the rule that
+  // an injected hook must carry a quoted absolute interpreter, so a PATH-less
+  // launchd/systemd environment cannot turn the gate into a silent 127.
+  const command = hookCommand(join(PROJECT_ROOT, 'scripts', 'readonly-repo-gate.mjs'))
+  if (isUnsafeHookCommand(command)) return
+  const entry = {
+    matcher: 'Bash|Write|Edit|NotebookEdit',
+    hooks: [{ type: 'command', command, timeout: 10 }],
+  }
+  const prev = Array.isArray(hooks.PreToolUse) ? (hooks.PreToolUse as unknown[]) : []
+  hooks.PreToolUse = [
+    ...prev.filter((e) => !JSON.stringify(e).includes('readonly-repo-gate.mjs')),
+    entry,
+  ]
 }
 
 // Idempotently wire the self-pace-gate PreToolUse hook (blocks ScheduleWakeup /

--- a/src/web/profiles.ts
+++ b/src/web/profiles.ts
@@ -14,6 +14,11 @@ export interface ProfileTemplate {
   description: string
   permissionMode: 'strict' | 'permissive'
   filesystem: { allow: string[]; deny: string[] }
+  // Opt-in: this role analyses or tests a repo but must never change its
+  // source, so the readonly-repo-gate PreToolUse hook is wired for agents
+  // scaffolded from it. A flag rather than a hardcoded id list, so the
+  // enforcement is not tied to the profile names of any one install.
+  readonlyRepo?: boolean
 }
 
 export const PROFILES_DIR = join(PROJECT_ROOT, 'templates', 'profiles')


### PR DESCRIPTION
The 2026-08-14 split, done, plus the yarn finding from the 2026-09-03 verify.
Rebased onto current `develop`.

**What is in the PR now: two gates and their tests.**

| file | why |
|---|---|
| `scripts/readonly-repo-gate.mjs` | the gate |
| `scripts/self-pace-gate.mjs` | two false-positive fixes |
| `src/__tests__/governance-gates.test.ts` | cases for both |
| `src/web/agent-scaffold.ts`, `src/web/profiles.ts` | the gate's wiring (see below) |

**What is gone:** `templates/profiles/planner.json`, `templates/profiles/qa-runner.json` and `scripts/host-guard.py`. The profiles wait on your product decision, and I am not opening a PR for them until you say the decision went that way. `host-guard.py` I am not carrying further: you were right that in the shipped form it described my install, and generalising it is not worth a review round on your side. Both are recoverable from `6847314` and `11de187` if you ever want them.

**Why the wiring stayed, and why it changed shape.** The gate has to be injected by something, and that wiring travelled with the profiles when I moved them out of #767. As written it keyed on the ids `planner` and `qa-runner`, so on this repo it was a hook that could never fire, named after two profiles this repo does not have -- the same defect you named on `host-guard.py`. `ProfileTemplate` now carries an opt-in `readonlyRepo` flag instead, and no profile is named in the scaffold. No shipped profile sets it yet, so the gate is inert here until a role opts in; if you would rather the wiring wait for the profiles too, say so and I will strip it to the bare script.

**The yarn finding.** Fixed as prescribed: `yarn\s+(install)?\b` -> `yarn\s+install\b`. The optional group plus the word boundary matched `yarn ` + anything, so `yarn add`, `yarn exec`, `yarn dlx` and `yarn run` all inherited an exemption meant for dependency installs. Bare `yarn` (Yarn 1's implicit install) loses the exemption with it, which is right: it carries no redirect and no mutating verb, so it now passes on its own merits instead of by blanket skip.

**What the gates do**

`readonly-repo-gate.mjs` -- writes to repository *source* are denied; build and dependency paths (`node_modules`, `.next`, `dist`, `coverage`, `__pycache__`, `.venv`, `target` ...), package-manager installs and branch movement (`git checkout/switch`, `git worktree add`) are allowed. Still denied inside the roots: `Write`/`Edit`/`NotebookEdit`, shell redirects, `sed -i`, `rm`/`mv`/`cp`/`chmod`/`chown`, `tee`, `mkdir`, `touch`, and `git commit/push/reset/restore/clean/rm/mv/apply/stash` plus `git checkout -- <path>`. Scope is `READONLY_REPO_ROOTS`, default `<home>/projects` derived at runtime.

Why a hook and not permissions: under `strict` the denies hold but Claude Code prompts on the `cd X && git ...` compound, and an unattended worker cannot answer a prompt, it hangs (seen twice on real workers). Under `permissive` nothing prompts, but the launcher passes `--dangerously-skip-permissions`, which bypasses allow/deny. Hooks run in both modes.

Why the install allowance is not a loosening: with `npm ci` blocked the QA worker could not install, could not run the suite, and still produced a confident diagnosis -- of a problem that did not exist, because the block had pushed it onto `npx prisma`, which fetched the registry's latest instead of the pinned version.

`self-pace-gate.mjs` -- two false-positive fixes, both narrowing what counts as a self-scheduling attempt; neither widens what an agent may schedule. A heredoc body is blanked before matching (quoted, unquoted and `<<-`), because it is data and never reaches a shell as commands, so a commit message or a PR description beginning "at the same time ..." is no longer read as the `at` scheduler. The real vectors stay blocked, including a command that hides a heredoc and then chains `tmux send-keys`.

**Verification**

- `npx tsc --noEmit` clean; full suite on this branch: **352 files, 4610 passed, 1 skipped, 0 failed**.
- The yarn regression is pinned three ways: every package manager's real install still exempt, four non-install yarn subcommands now judged, and `yarn install && yarn add x > <repo>/file` denied on the second segment.
- The wiring is covered for opt-in/opt-out, idempotency across a respawn, and survival of unrelated `PreToolUse` entries.
- The injected command now goes through `hookCommand()`, matching the quoted-absolute-interpreter rule that landed on `develop` after this branch was opened.

#767 no longer depends on this PR: the profiles that needed the gate are not in either PR any more.
