### PR TITLE
fix(heartbeat): name kanban cards by bracketed id and forbid invented explanations

### DIFF
--- a/src/__tests__/heartbeat-card-labels.test.ts
+++ b/src/__tests__/heartbeat-card-labels.test.ts
@@ -1,0 +1,45 @@
+// HBNAME1 -- the heartbeat misnamed urgent cards and invented explanations.
+// Root cause: the prompt carried bare card TITLES, our titles routinely
+// reference OTHER cards by name, and the summarizing model picked an
+// id-looking token out of the wrong title, then explained a disappeared item
+// with a reason the data never contained ("completed or deprioritized").
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { formatHeartbeatCardLabel } from '../heartbeat.js'
+
+describe('formatHeartbeatCardLabel', () => {
+  it('leads with the bracketed id, the one authoritative handle', () => {
+    expect(formatHeartbeatCardLabel({ id: '8290FF71', title: 'Installer re-run .env karositas' }))
+      .toBe('[8290FF71] Installer re-run .env karositas')
+  })
+
+  it('truncates long titles so cross-referenced card names drop out of view', () => {
+    const title = 'A'.repeat(70) + ' lasd meg INSTWIZ1 es ONBAUTH1 kartyakat reszletesen'
+    const label = formatHeartbeatCardLabel({ id: 'X1', title })
+    expect(label.startsWith('[X1] ')).toBe(true)
+    expect(label.length).toBe('[X1] '.length + 80 + 3)
+    expect(label).not.toContain('ONBAUTH1')
+    expect(label.endsWith('...')).toBe(true)
+  })
+
+  it('keeps short titles verbatim, no ellipsis', () => {
+    expect(formatHeartbeatCardLabel({ id: 'Y2', title: 'rovid cim' })).toBe('[Y2] rovid cim')
+  })
+})
+
+describe('heartbeat prompt contract (source-pinned)', () => {
+  const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../heartbeat.ts'), 'utf-8')
+
+  it('the kanban section instructs report-only, id-only naming', () => {
+    expect(src).toContain('KIZAROLAG a szogletes zarojeles ID-javal nevezz meg')
+    expect(src).toContain('eltunt tetelre okot ne kovetkeztess')
+  })
+
+  it('the prompt is fed labeled cards, not bare titles', () => {
+    expect(src).toContain('urgentLabels.join')
+    expect(src).toContain('waitingLabels.join')
+    expect(src).toContain('summary.urgent.map(formatHeartbeatCardLabel)')
+  })
+})

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -291,7 +291,7 @@ interface SystemInfo {
 interface HeartbeatData {
   timestamp: Date
   calendar: CalendarEvent[]
-  kanban: { urgent: number; in_progress: number; waiting: number; urgentTitles: string[]; waitingTitles: string[] }
+  kanban: { urgent: number; in_progress: number; waiting: number; urgentLabels: string[]; waitingLabels: string[] }
   system: SystemInfo
   tasks: { count: number; nextRun: number | null }
 }
@@ -309,6 +309,18 @@ async function collectCalendar(): Promise<CalendarEvent[]> {
   }
 }
 
+/** Label a card for the heartbeat prompt: `[ID] title`, title truncated.
+ * HBNAME1: the prompt used to carry bare titles, and because our titles
+ * routinely REFERENCE other cards by name, the summarizing model picked an
+ * id-looking token out of the wrong title ("urgent: 2 (INSTWIZ1, ...)" while
+ * the actual urgent card was 8290FF71). The bracketed id is the one
+ * authoritative handle; the truncation keeps cross-references out of view. */
+export function formatHeartbeatCardLabel(card: { id: string; title: string }): string {
+  const max = 80
+  const title = card.title.length > max ? card.title.slice(0, max) + '...' : card.title
+  return `[${card.id}] ${title}`
+}
+
 function collectKanban(): HeartbeatData['kanban'] {
   try {
     const summary = getHeartbeatKanbanSummary()
@@ -316,12 +328,12 @@ function collectKanban(): HeartbeatData['kanban'] {
       urgent: summary.urgent.length,
       in_progress: summary.in_progress.length,
       waiting: summary.waiting.length,
-      urgentTitles: summary.urgent.map((c) => c.title),
-      waitingTitles: summary.waiting.map((c) => c.title),
+      urgentLabels: summary.urgent.map(formatHeartbeatCardLabel),
+      waitingLabels: summary.waiting.map(formatHeartbeatCardLabel),
     }
   } catch (err) {
     logger.error({ err }, 'Heartbeat: kanban fetch failed')
-    return { urgent: 0, in_progress: 0, waiting: 0, urgentTitles: [], waitingTitles: [] }
+    return { urgent: 0, in_progress: 0, waiting: 0, urgentLabels: [], waitingLabels: [] }
   }
 }
 
@@ -408,15 +420,16 @@ function buildAgentPrompt(data: HeartbeatData): string {
   // Kanban -- card titles are operator-authored today, but a future Kanban-sync
   // integration could bring them from third parties. Wrap defensively.
   prompt += `## Kanban\n`
+  prompt += `A kanban-sor KESZ TENYLISTA: kartyat KIZAROLAG a szogletes zarojeles ID-javal nevezz meg (a cimben mas kartyak nevei is szerepelhetnek, azok NEM azonositok). CSAK jelentsd a listat -- valtozast ne magyarazz, eltunt tetelre okot ne kovetkeztess: amit az adat nem mond ki, azt nem tudhatod.\n`
   prompt += `- In Progress: ${data.kanban.in_progress}\n`
   prompt += `- Urgent: ${data.kanban.urgent}`
-  if (data.kanban.urgentTitles.length > 0) {
-    prompt += ` ${wrapUntrusted('kanban-urgent-titles', data.kanban.urgentTitles.join(', '))}`
+  if (data.kanban.urgentLabels.length > 0) {
+    prompt += ` ${wrapUntrusted('kanban-urgent-titles', data.kanban.urgentLabels.join(', '))}`
   }
   prompt += '\n'
   prompt += `- Waiting: ${data.kanban.waiting}`
-  if (data.kanban.waitingTitles.length > 0) {
-    prompt += ` ${wrapUntrusted('kanban-waiting-titles', data.kanban.waitingTitles.join(', '))}`
+  if (data.kanban.waitingLabels.length > 0) {
+    prompt += ` ${wrapUntrusted('kanban-waiting-titles', data.kanban.waitingLabels.join(', '))}`
   }
   prompt += '\n\n'
 


### PR DESCRIPTION
## What (card HBNAME1, Marveen's evidence from msgs 7521/7529)
Two consecutive heartbeats misreported the urgent list: 13:00 named **INSTWIZI1** as urgent while the actual urgent card was **8290FF71** (whose title merely *mentions* INSTWIZ1); 14:00 explained the empty list with *'completed or deprioritized'* -- pure invention, the data contained no reason. The count query (db.ts getHeartbeatKanbanSummary) was always correct; the failure was in the prompt: bare titles, no ids, and our card titles routinely reference other cards by name.

## Fix (Marveen's three suggestions, all three)
- **(a) ids in the prompt**: `formatHeartbeatCardLabel` renders `[ID] title` -- the bracketed id is the one authoritative handle.
- **(b) report, don't explain**: the kanban section now instructs the model to name cards ONLY by bracketed id and to report the list without explaining changes or inferring reasons for disappeared items ("amit az adat nem mond ki, azt nem tudhatod").
- **(c) title truncation**: 80 chars, so cross-referenced card names drop out of view (the exact mechanism of the 13:00 misattribution).

## Tests
Label vectors (id leads; truncation hides a cross-referenced card name -- the live failure shape; short titles verbatim) + source-pinned contract (prompt carries labels + the report-only instruction). Full suite **2906/2906**, tsc clean, em-dash clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)