### PR TITLE
fix(progress): the "working on it" placeholder should not ring the phone

### DIFF
--- a/scripts/hooks/telegram_progress.py
+++ b/scripts/hooks/telegram_progress.py
@@ -118,7 +118,7 @@ def main():
         # placeholder already signals receipt, so a reaction would be redundant
         # (per user preference 2026-06-07).
         try:
-            resp = api(tok, "sendMessage", {"chat_id": chat_id, "text": PLACEHOLDER})
+            resp = api(tok, "sendMessage", {"chat_id": chat_id, "text": PLACEHOLDER, "disable_notification": True})
             pmid = resp.get("result", {}).get("message_id")
             if pmid:
                 entry = {"chat_id": chat_id, "message_id": pmid}


### PR DESCRIPTION
One line, one field.

`telegram_progress.py` posts a "Dolgozom rajta…" placeholder the moment an
inbound message lands, so the owner can see it arrived. It went out as a normal
notifying message, which means every message the owner sent came straight back
at him as a push notification -- and then the real answer arrived as a second
one. Two pings per turn, one of them carrying no information he did not already
have.

`disable_notification: true` on that send only. The placeholder still appears in
the chat, still gets edited and cleared by the existing Stop-hook path; only the
push is gone. The actual reply is untouched -- that is the one the phone should
ring for.

Found while chasing a "why is this pinging me" report on a live install. Worth
saying which part was NOT the cause, since it is the obvious suspect: the live
progress indicator (#767) already sends with `disable_notification`, on both of
its send paths. This placeholder was the one that did not.