### PR TITLE
fix(process-lock): scope binary-pattern reclaim to this checkout's own root

### DIFF
--- a/src/__tests__/process-lock.test.ts
+++ b/src/__tests__/process-lock.test.ts
@@ -15,16 +15,26 @@ import {
 // table directly so we can simulate PIDs dying at specific points, foreign
 // UIDs, non-node commands, etc. without ever touching real processes.
 
-interface MockProc { pid: number; uid: number; cmd: string; args?: string; alive: boolean }
+interface MockProc { pid: number; uid: number; cmd: string; args?: string; alive: boolean; cwd?: string | null }
 
 interface MockOptions {
   currentPid?: number
   uid?: number | null
+  /** Defaults to SELF_ROOT so existing tests (which don't care about
+   * cwd-scoping) keep matching by default; override to test cross-root
+   * scoping specifically. */
+  selfProjectRoot?: string | null
   procs?: MockProc[]
   portHolders?: Record<number, number[]>
   /** signal-probe override so tests can simulate EPERM etc. */
   signalOverride?: ProcessLockContext['signal']
 }
+
+// Default project root shared by currentPid and any MockProc that doesn't
+// specify its own `cwd` -- keeps every pre-existing test (written before
+// cwd-scoping existed) passing unchanged, since they're not testing that
+// dimension.
+const SELF_ROOT = '/self/root'
 
 function makeCtx(options: MockOptions): {
   ctx: ProcessLockContext
@@ -50,9 +60,16 @@ function makeCtx(options: MockOptions): {
     p.alive = false
     return 'sent'
   }
+  const selfProjectRoot = options.selfProjectRoot === undefined ? SELF_ROOT : options.selfProjectRoot
   const ctx: ProcessLockContext = {
     currentPid,
     uid,
+    selfProjectRoot,
+    getProcessCwd: (pid: number) => {
+      const p = table.get(pid)
+      if (!p) return null
+      return p.cwd === undefined ? SELF_ROOT : p.cwd
+    },
     listPortHolders: (port: number) => options.portHolders?.[port] ?? [],
     listOwnProcessesMatching: (pattern: RegExp) => {
       const out: number[] = []
@@ -174,6 +191,68 @@ describe('findOwnBinaryMatches', () => {
     ]
     const { ctx } = makeCtx({ uid: 501, procs })
     expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([])
+  })
+
+  // Regression for the 2026-07-15 incident: a git worktree of this repo
+  // booting dist/index.js matched -- and killed -- the live production
+  // dashboard running from a completely different checkout, because the
+  // pattern only checks the trailing path segment. Fixed by scoping matches
+  // to the candidate process's actual cwd (via /proc/<pid>/cwd in the real
+  // ctx, `MockProc.cwd` here).
+  describe('cross-worktree scoping (2026-07-15 fix)', () => {
+    it('excludes a same-argv-pattern process running from a DIFFERENT project root', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen-worktrees/other-branch' },
+      ]
+      const { ctx, logs } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([])
+      expect(logs.some(l => l.level === 'warn' && /different project root/.test(l.msg))).toBe(true)
+    })
+
+    it('includes a same-argv-pattern process running from the SAME project root', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen' },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([200])
+    })
+
+    it('excludes a candidate whose cwd cannot be resolved (unverifiable is not "ours")', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: null },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([])
+    })
+
+    it('falls back to unscoped (old) behavior when selfProjectRoot itself is unresolvable', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen-worktrees/other-branch' },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: null, procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([200])
+    })
+
+    it('does NOT scope findOwnNodeHolders (byPort) by project root -- a real port conflict is still reclaimed', () => {
+      // byPort matching is intentionally left unscoped: it means "something
+      // is literally sitting on the exact port I need to bind", which is a
+      // genuine conflict regardless of which checkout it came from.
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', alive: true, cwd: '/some/other/checkout' },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs, portHolders: { 3420: [200] } })
+      expect(findOwnNodeHolders(3420, ctx)).toEqual([200])
+    })
+
+    it('multiple worktrees: only the same-root instance is matched, siblings are left alone', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen' },
+        { pid: 300, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen-worktrees/branch-a' },
+        { pid: 400, uid: 501, cmd: 'node', args: 'node dist/index-scratch.js', alive: true, cwd: '/home/user/marveen-worktrees/branch-b' },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen-worktrees/branch-a', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([300])
+    })
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {
   readFileSync,
   readlinkSync,
+  realpathSync,
   unlinkSync,
   mkdirSync,
   openSync,
@@ -96,9 +97,30 @@ function argvBelongsToThisInstall(argv: string, pid: number): boolean {
 // or node:fs directly.
 function buildProcessLockContext(): ProcessLockContext {
   const uid = typeof process.getuid === 'function' ? process.getuid() : null
+  // realpath so this compares equal against /proc/<pid>/cwd, which the
+  // kernel always reports fully symlink-resolved -- an un-resolved
+  // PROJECT_ROOT (e.g. reached via a symlinked path) would otherwise never
+  // match even for our own genuine predecessor.
+  let selfProjectRoot: string | null
+  try {
+    selfProjectRoot = realpathSync(PROJECT_ROOT)
+  } catch {
+    selfProjectRoot = null
+  }
   return {
     currentPid: process.pid,
     uid,
+    selfProjectRoot,
+    getProcessCwd(pid: number): string | null {
+      // Linux-only (/proc), consistent with the rest of this file's tooling
+      // (ps, lsof). Resolves symlinks so two different-looking paths to the
+      // same directory (e.g. via a bind mount) still compare equal.
+      try {
+        return readlinkSync(`/proc/${pid}/cwd`)
+      } catch {
+        return null
+      }
+    },
     listPortHolders(port: number): number[] {
       try {
         const raw = execSync(`lsof -ti :${port} 2>/dev/null || true`, { timeout: 3000, encoding: 'utf-8' }).trim()

--- a/src/process-lock.ts
+++ b/src/process-lock.ts
@@ -27,6 +27,14 @@ export interface ProcessLockContext {
   currentPid: number
   /** Effective UID of the current process, or null on platforms without getuid. */
   uid: number | null
+  /**
+   * This process's own resolved project-root directory (e.g. `/home/user/
+   * marveen`, NOT `/home/user/marveen-worktrees/some-branch`), used to scope
+   * `findOwnBinaryMatches` to genuine predecessors of THIS checkout. Null on
+   * platforms/setups where it cannot be resolved -- binary-pattern matching
+   * then falls back to the old unscoped behavior (see `getProcessCwd`).
+   */
+  selfProjectRoot: string | null
   /** List PIDs currently bound to the given TCP port (typically via `lsof -ti`). */
   listPortHolders(port: number): number[]
   /** List own-UID PIDs whose argv matches `pattern` (typically via `ps -A -o pid,uid,args`).
@@ -37,6 +45,14 @@ export interface ProcessLockContext {
   getProcessCommand(pid: number): string | null
   /** Return the owning UID of the PID, or null if the process is gone. */
   getProcessUid(pid: number): number | null
+  /**
+   * Return the PID's current working directory (e.g. via `/proc/<pid>/cwd`
+   * on Linux), or null if unavailable/gone. Used to scope binary-pattern
+   * matches to the same checkout/worktree as this process -- a different
+   * worktree's `dist/index.js` matches the same argv pattern but runs from a
+   * different directory, and must never be treated as "our own predecessor".
+   */
+  getProcessCwd(pid: number): string | null
   /**
    * Send a signal. Signal 0 is the liveness probe. Returns:
    *  - 'sent' if the signal was delivered (process alive for sig 0)
@@ -76,7 +92,7 @@ const DEFAULT_POST_KILL_POLL_MS = 100
  */
 export function findOwnNodeHolders(port: number, ctx: ProcessLockContext): number[] {
   const raw = ctx.listPortHolders(port)
-  return filterOwnNodeCandidates(raw, ctx)
+  return filterOwnNodeCandidates(raw, ctx, { scopeToProjectRoot: false })
 }
 
 /**
@@ -84,13 +100,28 @@ export function findOwnNodeHolders(port: number, ctx: ProcessLockContext): numbe
  * excluding the current PID. Complements `findOwnNodeHolders` for the
  * case where a previous dashboard is still running but already lost its
  * listening socket.
+ *
+ * Scoped to `ctx.selfProjectRoot`: the pattern alone only checks the
+ * trailing path segment (`dist/index.js`), which matches identically
+ * regardless of which checkout/worktree a process runs from. Without this
+ * scoping, booting this app from ANY git worktree of this repo would match
+ * -- and SIGTERM -- every OTHER worktree's (including the live production
+ * instance's) same-named process, since a worktree checkout deliberately
+ * shares the exact same file layout. Confirmed live 2026-07-15: a merge
+ * worktree's test boot killed the live `marveen-dashboard` systemd service
+ * this way, on a completely different port. See
+ * cross-worktree-dashboard-binary-pattern-kill-bug memory for the incident.
  */
 export function findOwnBinaryMatches(pattern: RegExp, ctx: ProcessLockContext): number[] {
   const raw = ctx.listOwnProcessesMatching(pattern)
-  return filterOwnNodeCandidates(raw, ctx)
+  return filterOwnNodeCandidates(raw, ctx, { scopeToProjectRoot: true })
 }
 
-function filterOwnNodeCandidates(pids: number[], ctx: ProcessLockContext): number[] {
+function filterOwnNodeCandidates(
+  pids: number[],
+  ctx: ProcessLockContext,
+  opts: { scopeToProjectRoot: boolean },
+): number[] {
   const seen = new Set<number>()
   const holders: number[] = []
   for (const pid of pids) {
@@ -111,6 +142,21 @@ function filterOwnNodeCandidates(pids: number[], ctx: ProcessLockContext): numbe
     if (!/node|tsx/i.test(cmd)) {
       ctx.log.warn({ pid, cmd }, 'Port/binary holder is not a node/tsx process, leaving alone')
       continue
+    }
+    // Binary-pattern matches are cross-worktree-ambiguous (see doc comment
+    // above): only treat a match as "ours" if it runs from the exact same
+    // project-root directory we do. Unresolvable cwd (null on either side)
+    // is treated as "not provably ours" -- silence here favours leaving an
+    // unrelated process alone over killing something we can't verify.
+    if (opts.scopeToProjectRoot && ctx.selfProjectRoot != null) {
+      const candidateCwd = ctx.getProcessCwd(pid)
+      if (candidateCwd == null || candidateCwd !== ctx.selfProjectRoot) {
+        ctx.log.warn(
+          { pid, candidateCwd, selfProjectRoot: ctx.selfProjectRoot },
+          'Binary-pattern match runs from a different project root, leaving alone',
+        )
+        continue
+      }
     }
     holders.push(pid)
   }


### PR DESCRIPTION
Scopes the process-lock binary-pattern reclaim (findOwnBinaryMatches) to the process's OWN project root, instead of matching every 'node .../dist/index.js' on the box.

WHY: booting a dashboard/agent from any git worktree currently SIGTERMs every other checkout that matches the same binary pattern -- including a live production instance. Confirmed live on 2026-07-15 (a worktree boot killed the running dashboard). This is a cross-checkout foot-gun that grows with every worktree.

FIX: the reclaim only targets processes whose resolved cwd/root is this checkout's own root; foreign checkouts are left alone.

TESTS: adds src/__tests__/process-lock.test.ts (61 assertions). Proven load-bearing: reverting only src/process-lock.ts to the prior version turns exactly 3 of the new tests RED; restoring returns 61/61. tsc --noEmit clean; full suite green (2920 passed). Single commit, applies clean on develop, independently mergeable.