### PR TITLE
feat(models): behaviour-neutral modelProfile layer

### DIFF
--- a/config-examples/model-profile-map.example.json
+++ b/config-examples/model-profile-map.example.json
@@ -1,0 +1,19 @@
+{
+  "_comment": [
+    "EXAMPLE ONLY. Copy to store/model-profile-map.json and edit for THIS deployment.",
+    "store/ is gitignored, so the concrete model and account mapping never leaves the machine.",
+    "The four profile ids are fixed and ALL FOUR must be present - a partial map is rejected,",
+    "because a missing entry would silently resolve an agent to the install default model.",
+    "Phase 1 intent is ABSTRACTION, not re-tiering: build the first map from the models the",
+    "fleet ALREADY runs, so switching an agent to a profile changes nothing observable.",
+    "Two profiles MAY point at the same concrete model - that is expected in a first map.",
+    "Precedence: an agent's explicit `model` always wins over its `modelProfile`."
+  ],
+  "version": "example-1",
+  "profiles": {
+    "premium_reasoning": "claude-opus-5",
+    "build_strong": "claude-sonnet-5",
+    "analysis_efficient": "deepseek-v4-pro",
+    "routine_lowcost": "deepseek-v4-pro"
+  }
+}

--- a/docs/optimization/lean-optimization-phase-1-as-built.md
+++ b/docs/optimization/lean-optimization-phase-1-as-built.md
@@ -1,0 +1,276 @@
+# Lean Optimization Phase 1 — as built
+
+Card: c755f4b2. Branch: `feat/lean-opt-phase1-gate` (worktree `/home/iszzu/marveen-wt/lean-opt-phase1`), based on `2ad7e91` (v1.25.1).
+Built by fullstackfejleszto, 2026-07-29. Gated by marveen.
+
+This document records what was actually built, including the parts that were
+scoped OUT mid-build. It is not a plan.
+
+## Scope as it ended up
+
+Phase 1 started as two blocks. Partway through, Istvan removed the privacy
+enforcement half from active scope.
+
+| Block | Intended | Actual outcome |
+|---|---|---|
+| A — data-sensitivity gate | build + flip to ENFORCE | **Built, PARKED at observe-only.** Not merged, not deployed, ENFORCE never flipped. |
+| B — neutral model profiles | build + canary | **Built and accepted**, additive, resolved-model diff empty. |
+
+Reason for the Block A change (owner decision, 2026-07-29): no customer PII is
+handled during development, and the primary operator input path is
+plugin-injected and cannot be observed from Node (see Known limitations). The
+work is parked and resumable, not discarded and not falsely closed.
+
+---
+
+## Block A — data-sensitivity gate (PARKED, observe-only)
+
+Commit `1f762e7`. Mode remains `observe-only` in `store/data-sensitivity-gate.json`.
+Nothing in this block blocks a dispatch today.
+
+### Starting state (verified in source, not from the 07-17 audit)
+
+The 07-17 audit's G4 finding was stale — the gate had shipped after it. What
+actually existed on `2ad7e91`:
+
+- `src/data-sensitivity-gate.ts`: three categories, 33 regex patterns, pure logic.
+- `src/web/data-sensitivity-gate-runner.ts`: config read, env-based provider
+  trust, audit write, liveness check.
+- `sensitivity_audit_log`: already hash-only, so the "no PII in logs"
+  requirement was already satisfied before Phase 1.
+- One call site, in `message-router.ts`.
+
+### Deltas found against the audit, and what was done
+
+| Finding | Was | Now |
+|---|---|---|
+| Categories | 3 (`public`/`internal`/`restricted`) | 4, with `unknown` as its own state |
+| `classifyContent` on no-match | returned `public` — **fail-open** | returns `unknown`; only explicit metadata or a policy may declare something public |
+| `evaluateDispatch` on a trusted provider | short-circuited and wrote a **false `public`** category to the audit | always classifies; the audit records the real category |
+| Verdicts | `allow`/`would_block`/`block` | `pass`/`ask`/`block`, recorded as `would_*` in observe mode |
+| Provider trust | `TRUSTED_PROVIDERS` env prefix list, defaulting to `{claude}` | deployment-local, default-DENY per-provider level map |
+| Coverage | 1 of 5 content-bearing dispatch paths | all of them, at one choke point |
+| Audit CHECK constraint | rejected `unknown` | widened idempotently; historical rows preserved, no backfill |
+
+### Architecture
+
+Classification is metadata-first, detector-second:
+
+```
+explicit dispatch metadata          (precedence 1)
+  -> explicit kanban card metadata  (precedence 2)
+  -> predefined workflow policy     (precedence 3)
+  -> deterministic regex detector   (precedence 4, ESCALATE-ONLY)
+  -> unknown
+```
+
+The detector is a second layer with three hard constraints enforced in code,
+not by convention: it can never lower an explicit level, it can never declare
+content public, and it emits reason codes rather than matched values. An
+explicit `public` label combined with a restricted signal is a *conflict*, not
+a quiet escalation, and a conflict is never a silent pass — not even to the
+trusted runtime.
+
+`unknown` is its own state in classification and in the audit, so a genuine
+restricted hit is distinguishable from "we could not tell". For provider
+*eligibility* only, `unknown` is treated fail-closed: it requires a provider
+cleared for `restricted`.
+
+### The choke point (the F1 fix)
+
+The gate previously ran at exactly one caller, `message-router.ts`. Merge
+`14023f0` rewrote that file and deleted the call. Every test stayed green,
+because a never-called gate and an always-passing gate emit the same thing:
+silence.
+
+The gate now runs inside `sendPromptToSession` (`src/web/agent-process.ts`),
+the single function every dispatch path funnels through — message router,
+schedule runner, channel monitor, agent worker, context guard, nudges. All 13
+call sites declare what they send. Three things keep it there:
+
+- a `LOCAL-FORK SEAM` marker comment, the convention that let CostOps survive
+  the same merge;
+- structural tests that fail if the call moves, disappears, or is ordered after
+  the first keystroke;
+- an hourly PASS beacon in the audit log, so the liveness check reads a real
+  signal instead of interpreting silence.
+
+### Provider trust
+
+`store/provider-trust-map.json` — deployment-local, gitignored, no secrets,
+policy only. Schema and semantics in `config-examples/provider-trust-map.example.json`.
+Keys are lowercased model prefixes, longest match wins; a provider with no
+entry is untrusted. Missing or malformed map is fail-closed for every category,
+logged at error level, and reported by `GET /api/security/gate-health`.
+
+`unknown` is deliberately not grantable: eligibility for unclassified content
+is derived from the `restricted` grant, so only a provider already cleared for
+restricted content can receive something the gate could not classify.
+
+### Metadata data path
+
+`kanban_cards.data_sensitivity` and `agent_messages.data_sensitivity`, both
+nullable, both without backfill. Guessing a level for hundreds of legacy cards
+would manufacture classifications nobody made; absent means unknown, never
+public. A card dispatch inherits the card's value and may escalate it, never
+relax it. A bad value is a 400 at the API, never a silent fallback.
+
+### Audit log
+
+Metadata only. Beyond the pre-existing fields the table now records decision
+provenance: source, explicit and detector categories, conflict flag, attended
+flag, reason codes, call site, resolved provider, and config version. It never
+stores a prompt, an excerpt, PII, a credential, or the concrete value a pattern
+matched. `content_hash` is a SHA-256 for correlation only.
+
+### Evidence
+
+- 51 unit tests, including the false-positive regression set (TAJ/tax-id
+  context windows, ISO dates vs card numbers, prod DB names).
+- 9 structural wiring guards.
+- 19 canaries C1–C4, run against the **real runner** with a fixture non-trusted
+  provider: C1 public research passes with zero false positives; C2 restricted
+  legal blocks, and the same task passes to the trusted runtime — proving the
+  block is about the provider, not about legal work; C3 conflict blocks
+  unattended and asks when attended; C4 unattended unknown blocks. Mode
+  round-trip and fail-closed trust map covered.
+- Both guard families proven able to fail: neutering the eligibility check
+  fails 11 tests; removing the gate call fails 3 wiring tests.
+
+---
+
+## Block B — behaviour-neutral model profiles (ACCEPTED)
+
+### Conflict pre-check
+
+`templates/profiles/*.json` and `src/web/profiles.ts` already use the word
+"profile", but the evidence is unambiguous that they mean something else: a
+`ProfileTemplate` carries `permissionMode` and a filesystem allow/deny list for
+Claude Code's permissions engine. It has no model field and no relationship to
+model selection. Overloading it would couple two unrelated axes, so per spec
+5.1 this is a **separate** `modelProfile` concept with its own map.
+
+### Design
+
+`src/model-profiles.ts` is pure: no fs, no env, no imports from this fork's
+config layer. It knows the four profile ids and the resolver; the concrete
+mapping is deployment-local. That is what makes it portable upstream.
+
+Resolver precedence: **explicit `model` → `modelProfile` → install default.**
+
+The failure semantics matter more than the happy path. An unknown profile id, a
+missing map, or an unusable map must not silently fall through to the default
+model — that would move an agent onto a different provider without anyone
+choosing it. Those cases resolve to the default *and* carry an `error` that
+surfaces in `/api/agents` (`modelProfileError`) and at the API on write (400).
+
+The layer is strictly **additive**. `src/config-registry.ts` and
+`src/web/model-suggest.ts` are untouched, and `MODEL_ALIASES` remains the single
+alias table — the resolver receives `resolveModelId` as a hook rather than
+reimplementing aliasing. Tests assert all of this so a later refactor cannot
+quietly turn the addition into a replacement.
+
+### The map
+
+`store/model-profile-map.json`, deployment-local and gitignored; schema in
+`config-examples/model-profile-map.example.json`. All four ids must be present —
+a partial map is rejected, because a missing entry would resolve that profile to
+the install default.
+
+Built from the live fleet snapshot of 2026-07-29 (post-reassignment: 12 agents
+on `deepseek-v4-pro`, 7 on `claude-sonnet-5`, 2 on `claude-opus-5`):
+
+| Profile | Resolves to |
+|---|---|
+| `premium_reasoning` | `claude-opus-5` |
+| `build_strong` | `claude-sonnet-5` |
+| `analysis_efficient` | `deepseek-v4-pro` |
+| `routine_lowcost` | `deepseek-v4-pro` |
+
+Two profiles pointing at the same model is intentional. Phase 1 abstracts; it
+does not re-tier.
+
+### Canary result
+
+`buildfejleszto → build_strong` and `research → analysis_efficient`, applied
+**additively**: both keep their explicit `model`, so by precedence the profile
+is inert and the change is a no-op on the running old build as well as on the
+new one.
+
+| | before | after |
+|---|---|---|
+| buildfejleszto resolved model | `claude-sonnet-5` | `claude-sonnet-5` |
+| research resolved model | `deepseek-v4-pro` | `deepseek-v4-pro` |
+| `/api/agents` resolved-model diff, all 22 agents | — | **EMPTY** |
+| account / `claudeConfigDir` | `/home/iszzu/.claude-personal` | unchanged |
+| provider routing | unchanged | unchanged |
+
+Verified twice: against the live dashboard running the old build (which ignores
+the new field entirely), and against the new resolver reading the real live
+configs and the real map. Both diffs empty across all 22 agents.
+
+The profile-only cutover — removing the explicit `model` so resolution actually
+goes through the map — was **not** performed. It resolves to the identical model
+(proven in test), but it would be a real behaviour change on the currently
+deployed build, which has no profile support. It is marveen's flip after deploy.
+
+### Evidence
+
+30 tests: 21 unit (map validation, precedence, failure semantics, neutrality)
+and 9 wiring tests through the real agent-config fs layer, including explicit
+assertions that the existing selector is untouched.
+
+---
+
+## Known limitations
+
+1. **Operator-inbound content is not gated, and cannot be from this repo.**
+   Inbound Telegram/Slack messages are written into the tmux pane by the channel
+   plugin, not through Node — verified independently in `stuck-input-watcher.ts`
+   and `pane-state.ts`. Even with ENFORCE on, the gate would close the Node-side
+   paths only. Istvan's scope decision (no customer PII during development)
+   resolved this as an accepted limitation rather than a blocker. Any future
+   claim that the P0 privacy hole is "closed" must exclude this path or be false.
+2. **Owner-typed terminal input is outside the gate.** The interactive
+   agent-terminal route types directly into a pane via `tmux-keys.ts`. This is
+   the owner typing into their own agent, but it is a content path and it is not
+   gated. Recorded as an audited exemption in the wiring test rather than left
+   implicit.
+3. **Block A is parked, not shipped.** Observe-only, unmerged. The privacy hole
+   the gate was built to close is still open.
+4. **The PASS beacon is hourly.** The liveness check can be up to an hour stale
+   on a quiet fleet.
+
+## Rollback
+
+- Block A: not deployed, so rollback is "do not merge". If merged: set `mode`
+  to `observe-only`, then `off`, in `store/data-sensitivity-gate.json`. No
+  source edit, no restart of the gate module required. Both new columns are
+  additive and nullable, so no lossy schema downgrade exists to reverse.
+- Block B: delete `modelProfile` from the two canary configs. Their explicit
+  `model` is untouched, so resolution returns to exactly today's answer.
+  Deleting `store/model-profile-map.json` is also safe while every agent names
+  an explicit model.
+
+## Upstream boundary
+
+No issue or PR opened. Local evidence first, and a separate owner GO is
+required before publishing.
+
+**Upstream candidates** (generic, no local policy): the `modelProfile` field and
+`src/model-profiles.ts` resolver; the generic sensitivity metadata vocabulary;
+the dispatch-guard interface and reason codes; a provider-agnostic trust-policy
+adapter. Block B is the cleaner candidate of the two — it is pure, additive, and
+carries no deployment policy. Check #517 (provider-agnostic routing) for overlap
+before proposing.
+
+**Stays local**: the concrete provider trust map, the concrete profile→model
+map, accounts, the privacy policy, and the feature-flag state.
+
+## Phase 2 prerequisites
+
+Out of scope here and not started: dynamic per-task routing, automatic provider
+fallback, a capacity-state registry, sticky card→runtime routing, CostOps schema
+extension, `cost_per_accepted_task`, plan-change advice, market screening.
+Phase 2 should not begin until Block A's park/ship question is decided, because
+routing decisions and privacy decisions share the same dispatch path.

--- a/docs/optimization/marveen-lean-optimization-audit-2026-07-17-addendum.md
+++ b/docs/optimization/marveen-lean-optimization-audit-2026-07-17-addendum.md
@@ -1,0 +1,48 @@
+# Addendum to the 2026-07-17 Lean Optimization audit
+
+This is an addendum, not a revision. `marveen-lean-optimization-audit-2026-07-17.md`
+is left exactly as written — it is a record of what was believed on 2026-07-17,
+and rewriting it would destroy the evidence of how the picture changed.
+
+Status as of 2026-07-29, after Phase 1 (card c755f4b2, as-built:
+`lean-optimization-phase-1-as-built.md`).
+
+## Corrections to the audit's findings
+
+**G4 "data-sensitivity gate MISSING" was already stale when the audit was
+written.** The gate shipped in commits `0e9759d` + `97aaf3c` on 2026-07-18, and
+Istvan's ruling is that this was not a deliberate reversal — the audit simply
+predated it. G4 should be read as "present but incomplete", and the specifics
+the audit could not have known are:
+
+- the gate was wired at exactly one of five content-bearing dispatch paths, and
+  that one call site was later deleted by merge `14023f0`;
+- `classifyContent` returned `public` when no pattern matched, which is
+  fail-open;
+- `evaluateDispatch` short-circuited on a trusted provider and wrote a false
+  `public` category into the audit log;
+- the audit table was already hash-only, so the audit's "no PII in logs" concern
+  was already satisfied.
+
+## Gap status after Phase 1
+
+| Gap | Status |
+|---|---|
+| G1 (extent) | IMPLEMENTED |
+| G4 (data-sensitivity gate) | **BUILT, PARKED at observe-only.** Not "implemented" — it is not enforcing, not merged, not deployed. |
+| Neutral model-profile layer | IMPLEMENTED and accepted (Block B), additive, behaviour-neutral |
+
+G4 is deliberately **not** marked implemented. Istvan removed privacy
+enforcement from active Phase 1 scope on 2026-07-29 (no customer PII during
+development; the primary operator input path is plugin-injected and unobservable
+from Node). The gate exists and is tested, but it changes no dispatch decision
+today. Recording it as implemented would be the exact false-green this
+programme was meant to eliminate.
+
+## Deferred
+
+- Privacy enforcement (OBSERVE → ENFORCE) — deferred, resumable from commit
+  `1f762e7`.
+- Gating the channel-plugin input path — structurally outside this repo. See
+  the as-built doc's Known limitations.
+- Everything the audit assigned to Phase 2/3/4 — untouched, not started.

--- a/src/__tests__/model-profiles-wiring.test.ts
+++ b/src/__tests__/model-profiles-wiring.test.ts
@@ -1,0 +1,130 @@
+// Block B wiring: the profile layer must be ADDITIVE over the existing model
+// selection, not a replacement for it (marveen acceptance criterion,
+// 2026-07-29). That additivity is also what makes it upstream-committable.
+//
+// Exercised through the real agent-config fs layer, not the pure resolver, so
+// this covers the part the unit tests cannot: that readAgentModel still answers
+// what it always answered.
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  readAgentModel,
+  resolveAgentModelDetailed,
+  invalidateModelProfileMapCache,
+  AGENTS_BASE_DIR,
+} from '../web/agent-config.js';
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PROJECT_ROOT = join(SRC, '..');
+const MAP_PATH = join(PROJECT_ROOT, 'store', 'model-profile-map.json');
+
+const MAP = {
+  version: 'wiring-test-1',
+  profiles: {
+    premium_reasoning: 'claude-opus-5',
+    build_strong: 'claude-sonnet-5',
+    analysis_efficient: 'deepseek-v4-pro',
+    routine_lowcost: 'deepseek-v4-pro',
+  },
+};
+
+// Fixtures mirror the two real canary agents' post-reassignment configs.
+const FIXTURES: Record<string, Record<string, unknown>> = {
+  'mp-legacy-explicit': { model: 'claude-sonnet-5' },
+  'mp-canary-build': { model: 'claude-sonnet-5', modelProfile: 'build_strong' },
+  'mp-canary-research': { model: 'deepseek-v4-pro', modelProfile: 'analysis_efficient' },
+  'mp-profile-only': { modelProfile: 'analysis_efficient' },
+  'mp-bad-profile': { modelProfile: 'turbo' },
+};
+
+let createdStore = false;
+
+beforeAll(() => {
+  createdStore = !existsSync(join(PROJECT_ROOT, 'store'));
+  mkdirSync(join(PROJECT_ROOT, 'store'), { recursive: true });
+  writeFileSync(MAP_PATH, JSON.stringify(MAP, null, 2));
+  invalidateModelProfileMapCache();
+  for (const [name, cfg] of Object.entries(FIXTURES)) {
+    mkdirSync(join(AGENTS_BASE_DIR, name), { recursive: true });
+    writeFileSync(join(AGENTS_BASE_DIR, name, 'agent-config.json'), JSON.stringify(cfg));
+  }
+});
+
+afterAll(() => {
+  for (const name of Object.keys(FIXTURES)) rmSync(join(AGENTS_BASE_DIR, name), { recursive: true, force: true });
+  rmSync(MAP_PATH, { force: true });
+  if (createdStore) rmSync(join(PROJECT_ROOT, 'store'), { recursive: true, force: true });
+  invalidateModelProfileMapCache();
+});
+
+describe('additive over the existing selector', () => {
+  it('an agent with only a legacy explicit model resolves exactly as before', () => {
+    expect(readAgentModel('mp-legacy-explicit')).toBe('claude-sonnet-5');
+    expect(resolveAgentModelDetailed('mp-legacy-explicit').source).toBe('explicit_model');
+  });
+
+  it('ADDING modelProfile to a canary agent does not change its resolved model', () => {
+    // This is the Block B acceptance criterion in one assertion: the two live
+    // canary agents keep their explicit model AND gain a profile, and the
+    // resolved-model diff is empty.
+    expect(readAgentModel('mp-canary-build')).toBe('claude-sonnet-5');
+    expect(readAgentModel('mp-canary-research')).toBe('deepseek-v4-pro');
+    expect(resolveAgentModelDetailed('mp-canary-build').source).toBe('explicit_model');
+    expect(resolveAgentModelDetailed('mp-canary-research').source).toBe('explicit_model');
+  });
+
+  it('an agent with ONLY a profile resolves through the map', () => {
+    const r = resolveAgentModelDetailed('mp-profile-only');
+    expect(r.model).toBe('deepseek-v4-pro');
+    expect(r.source).toBe('model_profile');
+  });
+
+  it('an unknown profile id surfaces an error instead of silently switching models', () => {
+    const r = resolveAgentModelDetailed('mp-bad-profile');
+    expect(r.source).toBe('default');
+    expect(r.error).toContain('unknown_model_profile');
+  });
+
+  it('an agent with no config at all still gets the install default', () => {
+    expect(typeof readAgentModel('mp-does-not-exist')).toBe('string');
+    expect(readAgentModel('mp-does-not-exist').length).toBeGreaterThan(0);
+  });
+});
+
+describe('the existing model selector is untouched', () => {
+  // marveen: "Do NOT rip out or replace the existing opus5/sonnet5 selection."
+  // These assert the pre-existing machinery is still whole, so a later
+  // refactor cannot quietly turn the additive layer into a replacement.
+  it('config-registry still owns the distribution default', () => {
+    const registry = readFileSync(join(SRC, 'config-registry.ts'), 'utf-8');
+    expect(registry).toContain('DISTRIBUTION_DEFAULT_AGENT_MODEL');
+    expect(registry).not.toContain('modelProfile');
+  });
+
+  it('model-suggest still exists and knows nothing about profiles', () => {
+    const suggest = readFileSync(join(SRC, 'web', 'model-suggest.ts'), 'utf-8');
+    expect(suggest.length).toBeGreaterThan(0);
+    expect(suggest).not.toContain('modelProfile');
+  });
+
+  it('the legacy alias table is still applied and still owns the short names', () => {
+    const cfg = readFileSync(join(SRC, 'web', 'agent-config.ts'), 'utf-8');
+    expect(cfg).toContain('export const MODEL_ALIASES');
+    expect(cfg).toContain("'sonnet': 'claude-sonnet-5'");
+    // The resolver receives resolveModelId as its alias hook rather than
+    // reimplementing aliasing, so there is exactly one alias table.
+    expect(cfg).toContain('resolveAgentModelFromConfig(config, readModelProfileMap(), DEFAULT_MODEL, resolveModelId)');
+  });
+
+  it('the profile module does not import the existing selector', () => {
+    const profiles = readFileSync(join(SRC, 'model-profiles.ts'), 'utf-8');
+    expect(profiles).not.toContain('config-registry');
+    expect(profiles).not.toContain('model-suggest');
+    // Pure: no fs/env, so it is portable as an upstream contribution.
+    expect(profiles).not.toContain("from 'node:fs'");
+    expect(profiles).not.toContain('process.env');
+  });
+});

--- a/src/__tests__/model-profiles.test.ts
+++ b/src/__tests__/model-profiles.test.ts
@@ -1,0 +1,196 @@
+// Block B: behaviour-neutral model profiles (card c755f4b2, spec 5.6).
+//
+// The whole point of Phase 1's profile layer is that it changes NOTHING. These
+// tests are therefore mostly about what must not happen: an explicit model
+// never loses, a bad profile never silently relocates an agent to a different
+// model, and a missing map never rewrites anybody's model.
+
+import { describe, expect, it } from 'vitest';
+import {
+  MODEL_PROFILE_IDS,
+  isModelProfileId,
+  resolveAgentModelFromConfig,
+  validateModelProfileMap,
+  type ModelProfileMapState,
+} from '../model-profiles.js';
+
+const DEFAULT_MODEL = 'claude-opus-5';
+const ALIASES: Record<string, string> = { sonnet: 'claude-sonnet-5', 'sonnet-5': 'claude-sonnet-5' };
+const alias = (raw: string) => ALIASES[raw] ?? raw;
+
+// Mirrors the shape shipped in config-examples/model-profile-map.example.json.
+const GOOD_MAP_STATE = validateModelProfileMap({
+  version: 'test-1',
+  profiles: {
+    premium_reasoning: 'claude-opus-5',
+    build_strong: 'claude-sonnet-5',
+    analysis_efficient: 'deepseek-v4-pro',
+    routine_lowcost: 'deepseek-v4-pro',
+  },
+}) as Extract<ModelProfileMapState, { ok: true }>;
+
+describe('model profile map validation', () => {
+  it('accepts a complete map', () => {
+    expect(GOOD_MAP_STATE.ok).toBe(true);
+    expect(GOOD_MAP_STATE.map.profiles.build_strong).toBe('claude-sonnet-5');
+  });
+
+  it('rejects a PARTIAL map instead of filling the gap with a default', () => {
+    // A missing entry would resolve that profile to the install default, i.e.
+    // move an agent onto a different model without anyone choosing it.
+    const state = validateModelProfileMap({
+      profiles: { premium_reasoning: 'claude-opus-5', build_strong: 'claude-sonnet-5' },
+    });
+    expect(state.ok).toBe(false);
+    if (!state.ok) expect(state.error).toContain('analysis_efficient');
+  });
+
+  it('rejects an empty model string', () => {
+    const state = validateModelProfileMap({
+      profiles: {
+        premium_reasoning: 'claude-opus-5',
+        build_strong: '   ',
+        analysis_efficient: 'deepseek-v4-pro',
+        routine_lowcost: 'deepseek-v4-pro',
+      },
+    });
+    expect(state.ok).toBe(false);
+  });
+
+  it('rejects an unknown profile id in the map', () => {
+    const state = validateModelProfileMap({
+      profiles: {
+        premium_reasoning: 'a', build_strong: 'b', analysis_efficient: 'c', routine_lowcost: 'd',
+        cheap_and_cheerful: 'e',
+      },
+    });
+    expect(state.ok).toBe(false);
+    if (!state.ok) expect(state.error).toContain('cheap_and_cheerful');
+  });
+
+  it('rejects non-objects, arrays and a missing profiles key', () => {
+    expect(validateModelProfileMap(null).ok).toBe(false);
+    expect(validateModelProfileMap([]).ok).toBe(false);
+    expect(validateModelProfileMap({ version: 'v1' }).ok).toBe(false);
+  });
+
+  it('exposes exactly the four Phase 1 profile ids', () => {
+    expect([...MODEL_PROFILE_IDS]).toEqual([
+      'premium_reasoning', 'build_strong', 'analysis_efficient', 'routine_lowcost',
+    ]);
+    expect(isModelProfileId('build_strong')).toBe(true);
+    expect(isModelProfileId('turbo')).toBe(false);
+  });
+});
+
+describe('resolver precedence', () => {
+  it('a legacy explicit model still resolves exactly as before', () => {
+    const r = resolveAgentModelFromConfig({ model: 'claude-sonnet-5' }, GOOD_MAP_STATE, DEFAULT_MODEL, alias);
+    expect(r.model).toBe('claude-sonnet-5');
+    expect(r.source).toBe('explicit_model');
+  });
+
+  it('still applies the legacy alias table to an explicit model', () => {
+    const r = resolveAgentModelFromConfig({ model: 'sonnet' }, GOOD_MAP_STATE, DEFAULT_MODEL, alias);
+    expect(r.model).toBe('claude-sonnet-5');
+  });
+
+  it('resolves a modelProfile when no explicit model is set', () => {
+    const r = resolveAgentModelFromConfig({ modelProfile: 'build_strong' }, GOOD_MAP_STATE, DEFAULT_MODEL, alias);
+    expect(r.model).toBe('claude-sonnet-5');
+    expect(r.source).toBe('model_profile');
+  });
+
+  it('an explicit model BEATS a modelProfile', () => {
+    const r = resolveAgentModelFromConfig(
+      { model: 'deepseek-v4-pro', modelProfile: 'premium_reasoning' },
+      GOOD_MAP_STATE, DEFAULT_MODEL, alias,
+    );
+    expect(r.model).toBe('deepseek-v4-pro');
+    expect(r.source).toBe('explicit_model');
+  });
+
+  it('falls back to the install default when neither is configured', () => {
+    const r = resolveAgentModelFromConfig({}, GOOD_MAP_STATE, DEFAULT_MODEL, alias);
+    expect(r.model).toBe(DEFAULT_MODEL);
+    expect(r.source).toBe('default');
+  });
+});
+
+describe('failure semantics -- no silent model change', () => {
+  it('an unknown profile id reports an error rather than passing silently', () => {
+    const r = resolveAgentModelFromConfig({ modelProfile: 'turbo' }, GOOD_MAP_STATE, DEFAULT_MODEL, alias);
+    expect(r.source).toBe('default');
+    expect(r.error).toContain('unknown_model_profile');
+  });
+
+  it('a missing map with a legacy explicit model changes nothing and raises nothing', () => {
+    const r = resolveAgentModelFromConfig({ model: 'claude-sonnet-5' }, null, DEFAULT_MODEL, alias);
+    expect(r.model).toBe('claude-sonnet-5');
+    expect(r.error).toBe(undefined);
+  });
+
+  it('a missing map with ONLY a modelProfile is a surfaced error, not a quiet default', () => {
+    const r = resolveAgentModelFromConfig({ modelProfile: 'build_strong' }, null, DEFAULT_MODEL, alias);
+    expect(r.source).toBe('default');
+    expect(r.error).toBe('model_profile_map_missing');
+  });
+
+  it('a broken map with ONLY a modelProfile carries the map error forward', () => {
+    const r = resolveAgentModelFromConfig(
+      { modelProfile: 'build_strong' },
+      { ok: false, error: 'profile_map_unparseable' },
+      DEFAULT_MODEL, alias,
+    );
+    expect(r.source).toBe('default');
+    expect(r.error).toBe('profile_map_unparseable');
+  });
+
+  it('a broken map does NOT disturb an agent that names an explicit model', () => {
+    const r = resolveAgentModelFromConfig(
+      { model: 'deepseek-v4-pro', modelProfile: 'build_strong' },
+      { ok: false, error: 'profile_map_unparseable' },
+      DEFAULT_MODEL, alias,
+    );
+    expect(r.model).toBe('deepseek-v4-pro');
+    expect(r.error).toBe(undefined);
+  });
+});
+
+describe('behaviour neutrality (spec 5.5 acceptance)', () => {
+  // The live fleet snapshot recorded at build time, 2026-07-29.
+  const LIVE_SNAPSHOT: Array<{ agent: string; model: string; profile: string }> = [
+    { agent: 'buildfejleszto', model: 'claude-sonnet-5', profile: 'build_strong' },
+    { agent: 'research', model: 'deepseek-v4-pro', profile: 'analysis_efficient' },
+  ];
+
+  it.each(LIVE_SNAPSHOT)(
+    'the canary agent $agent resolves to the SAME model through its profile as through its explicit model',
+    ({ model, profile }) => {
+      const before = resolveAgentModelFromConfig({ model }, GOOD_MAP_STATE, DEFAULT_MODEL, alias);
+      const after = resolveAgentModelFromConfig({ modelProfile: profile }, GOOD_MAP_STATE, DEFAULT_MODEL, alias);
+      // This equality IS the acceptance criterion: switching a canary agent to
+      // a neutral profile must produce an EMPTY resolved-model diff.
+      expect(after.model).toBe(before.model);
+      expect(after.model).toBe(model);
+    },
+  );
+
+  it('every profile in the shipped map resolves to a model the fleet already runs', () => {
+    const live = new Set(['claude-opus-5', 'claude-sonnet-5', 'deepseek-v4-pro']);
+    for (const id of MODEL_PROFILE_IDS) {
+      expect(live.has(GOOD_MAP_STATE.map.profiles[id])).toBe(true);
+    }
+  });
+
+  it('two profiles pointing at the same model is valid -- Phase 1 abstracts, it does not re-tier', () => {
+    expect(GOOD_MAP_STATE.map.profiles.analysis_efficient).toBe(GOOD_MAP_STATE.map.profiles.routine_lowcost);
+  });
+
+  it('resolution touches only the model -- account and config-dir are not part of this layer', () => {
+    // Guards against scope creep: if a later change makes the profile carry an
+    // account or CLAUDE_CONFIG_DIR, this assertion is where it surfaces.
+    const r = resolveAgentModelFromConfig({ modelProfile: 'build_strong' }, GOOD_MAP_STATE, DEFAULT_MODEL, alias);
+    expect(Object.keys(r).sort()).toEqual(['model', 'source']);
+  });
+});

--- a/src/model-profiles.ts
+++ b/src/model-profiles.ts
@@ -1,0 +1,124 @@
+// Behaviour-neutral model profiles (card c755f4b2, Phase 1 Block B).
+//
+// The point of this layer is ABSTRACTION, not re-tiering. An agent config can
+// name a generic capability tier instead of a concrete vendor model id, and the
+// concrete mapping lives in a deployment-local file. Phase 1 ships a map whose
+// answers are byte-identical to the models the fleet already runs, so turning
+// this on changes nothing observable.
+//
+// Deliberately NOT the same concept as templates/profiles/*.json: that
+// `profile` field is a Claude Code PERMISSIONS template (filesystem allow/deny,
+// permissionMode) and has nothing to do with model selection. Overloading it
+// would couple two unrelated axes, so `modelProfile` is a separate field with
+// its own map (spec 5.1).
+//
+// Pure logic: no fs, no env, no I/O. The runner reads the map.
+
+export const MODEL_PROFILE_IDS = [
+  'premium_reasoning',
+  'build_strong',
+  'analysis_efficient',
+  'routine_lowcost',
+] as const;
+
+export type ModelProfileId = (typeof MODEL_PROFILE_IDS)[number];
+
+export function isModelProfileId(v: unknown): v is ModelProfileId {
+  return typeof v === 'string' && (MODEL_PROFILE_IDS as readonly string[]).includes(v);
+}
+
+export interface ModelProfileMap {
+  // Every profile id must be present. A partial map is rejected rather than
+  // silently falling back per-profile, because a missing entry would resolve
+  // to the install default and quietly move an agent to a different model.
+  profiles: Record<ModelProfileId, string>;
+  version?: string;
+}
+
+export type ModelProfileMapState =
+  | { ok: true; map: ModelProfileMap }
+  | { ok: false; error: string };
+
+export function validateModelProfileMap(raw: unknown): ModelProfileMapState {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'profile_map_not_an_object' };
+  }
+  const o = raw as Record<string, unknown>;
+  if (!o.profiles || typeof o.profiles !== 'object' || Array.isArray(o.profiles)) {
+    return { ok: false, error: 'profile_map_missing_profiles' };
+  }
+  const src = o.profiles as Record<string, unknown>;
+  const profiles = {} as Record<ModelProfileId, string>;
+  for (const id of MODEL_PROFILE_IDS) {
+    const value = src[id];
+    if (typeof value !== 'string' || !value.trim()) {
+      return { ok: false, error: `profile_map_missing_or_empty:${id}` };
+    }
+    profiles[id] = value.trim();
+  }
+  for (const key of Object.keys(src)) {
+    if (!isModelProfileId(key)) return { ok: false, error: `profile_map_unknown_profile:${key}` };
+  }
+  return {
+    ok: true,
+    map: { profiles, version: typeof o.version === 'string' ? o.version : undefined },
+  };
+}
+
+export type ModelResolutionSource = 'explicit_model' | 'model_profile' | 'default';
+
+export interface ModelResolution {
+  model: string;
+  source: ModelResolutionSource;
+  // Set when the config named a profile that could not be honoured. The caller
+  // decides how loud to be; resolution itself never throws.
+  error?: string;
+}
+
+export interface AgentModelConfig {
+  // Legacy and still highest precedence: a concrete model id or alias.
+  model?: unknown;
+  // Optional generic tier.
+  modelProfile?: unknown;
+}
+
+/**
+ * Resolver precedence (spec 5.3): explicit model > modelProfile > install default.
+ *
+ * Failure semantics matter more than the happy path here. An unknown profile id
+ * or an unusable map must NOT silently fall through to the default model -- that
+ * is exactly the "no silent model change" the acceptance criteria forbid, since
+ * it would move an agent onto a different provider without anyone asking. Those
+ * cases resolve to the default AND carry an `error`, so the caller surfaces the
+ * misconfiguration instead of running on a model nobody chose.
+ *
+ * `aliasResolver` is injected so this module stays free of agent-config imports.
+ */
+export function resolveAgentModelFromConfig(
+  config: AgentModelConfig,
+  mapState: ModelProfileMapState | null,
+  defaultModel: string,
+  aliasResolver: (raw: string) => string,
+): ModelResolution {
+  // 1. Explicit model always wins, exactly as before this layer existed.
+  if (typeof config.model === 'string' && config.model.trim()) {
+    return { model: aliasResolver(config.model.trim()), source: 'explicit_model' };
+  }
+
+  // 2. modelProfile, when one is configured.
+  if (config.modelProfile !== undefined && config.modelProfile !== null && config.modelProfile !== '') {
+    if (!isModelProfileId(config.modelProfile)) {
+      return { model: defaultModel, source: 'default', error: `unknown_model_profile:${String(config.modelProfile).slice(0, 40)}` };
+    }
+    if (!mapState) {
+      return { model: defaultModel, source: 'default', error: 'model_profile_map_missing' };
+    }
+    if (!mapState.ok) {
+      return { model: defaultModel, source: 'default', error: mapState.error };
+    }
+    return { model: aliasResolver(mapState.map.profiles[config.modelProfile]), source: 'model_profile' };
+  }
+
+  // 3. Install default.
+  return { model: defaultModel, source: 'default' };
+}

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -4,6 +4,13 @@ import { homedir } from 'node:os'
 import { PROJECT_ROOT, MAIN_AGENT_ID, DEFAULT_AGENT_MODEL } from '../config.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { safeJoin } from './sanitize.js'
+import {
+  resolveAgentModelFromConfig,
+  validateModelProfileMap,
+  type AgentModelConfig,
+  type ModelProfileMapState,
+  type ModelResolution,
+} from '../model-profiles.js'
 
 export const AGENTS_BASE_DIR = join(PROJECT_ROOT, 'agents')
 
@@ -61,14 +68,68 @@ export function resolveModelId(raw: string): string {
   return MODEL_ALIASES[raw] || raw
 }
 
-export function readAgentModel(name: string): string {
-  const configPath = join(agentDir(name), 'agent-config.json')
+// ---- model-profile map (deployment-local, card c755f4b2 Block B) -------------
+//
+// store/ is gitignored, so the concrete profile -> model mapping never leaves
+// the machine. config-examples/model-profile-map.example.json documents the
+// shape. A missing map is FINE: every agent that names a concrete `model`
+// keeps working untouched, which is every agent today.
+const MODEL_PROFILE_MAP_PATH = join(PROJECT_ROOT, 'store', 'model-profile-map.json')
+
+let cachedProfileMap: { state: ModelProfileMapState; mtimeMs: number } | null = null
+
+export function readModelProfileMap(): ModelProfileMapState | null {
   try {
-    const config = JSON.parse(readFileOr(configPath, '{}'))
-    return resolveModelId(config.model || DEFAULT_MODEL)
+    if (!existsSync(MODEL_PROFILE_MAP_PATH)) return null
+    const mtimeMs = statSync(MODEL_PROFILE_MAP_PATH).mtimeMs
+    if (cachedProfileMap && cachedProfileMap.mtimeMs === mtimeMs) return cachedProfileMap.state
+    let state: ModelProfileMapState
+    try {
+      state = validateModelProfileMap(JSON.parse(readFileSync(MODEL_PROFILE_MAP_PATH, 'utf-8')))
+    } catch {
+      state = { ok: false, error: 'profile_map_unparseable' }
+    }
+    cachedProfileMap = { state, mtimeMs }
+    return state
   } catch {
-    return DEFAULT_MODEL
+    return { ok: false, error: 'profile_map_read_error' }
   }
+}
+
+export function invalidateModelProfileMapCache(): void {
+  cachedProfileMap = null
+}
+
+// Full resolution result, for callers that need to show or log WHY an agent is
+// on a given model (the /api/agents payload, the profile canary).
+export function resolveAgentModelDetailed(name: string): ModelResolution {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  let config: AgentModelConfig
+  try {
+    config = JSON.parse(readFileOr(configPath, '{}')) as AgentModelConfig
+  } catch {
+    return { model: DEFAULT_MODEL, source: 'default' }
+  }
+  return resolveAgentModelFromConfig(config, readModelProfileMap(), DEFAULT_MODEL, resolveModelId)
+}
+
+// Unchanged contract: the concrete model id this agent runs on. For every
+// config that names a `model` -- which is all of them today -- this returns
+// byte-identically what it returned before Block B existed.
+export function readAgentModel(name: string): string {
+  return resolveAgentModelDetailed(name).model
+}
+
+// Card c755f4b2 Block B. Passing null REMOVES the key rather than writing a
+// null: an absent field and an explicit null must not become two ways of
+// saying the same thing in a config a human also edits by hand.
+export function writeAgentModelProfile(name: string, profile: string | null): void {
+  const configPath = join(agentDir(name), 'agent-config.json')
+  let config: Record<string, unknown> = {}
+  try { config = JSON.parse(readFileOr(configPath, '{}')) } catch { /* start fresh */ }
+  if (profile === null) delete config.modelProfile
+  else config.modelProfile = profile
+  atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
 export function writeAgentModel(name: string, model: string): void {

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -3,6 +3,7 @@ import { join, extname, dirname } from 'node:path'
 import { homedir, platform, tmpdir } from 'node:os'
 import { execSync } from 'node:child_process'
 import { logger } from '../../logger.js'
+import { isModelProfileId, MODEL_PROFILE_IDS } from '../../model-profiles.js'
 import { MAIN_AGENT_ID, currentBotName, PROJECT_ROOT } from '../../config.js'
 import { createAgentMessage, listPendingChannelRequests, updateChannelRequestStatus, getDb, claimPendingForAgent, markMessageFailed } from '../../db.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from '../agent-message-wrap.js'
@@ -20,6 +21,9 @@ import {
   findAvatarForAgent,
   resolveModelId,
   readAgentModel,
+  resolveAgentModelDetailed,
+  readModelProfileMap,
+  writeAgentModelProfile,
   writeAgentModel,
   readAgentDisplayName,
   writeAgentDisplayName,
@@ -314,7 +318,14 @@ interface AgentSummary {
   name: string
   displayName: string
   description: string
+  /** The concrete model id this agent resolves to. Unchanged meaning: for a
+   *  config that names a `model`, this is exactly what it always was. */
   model: string
+  /** Card c755f4b2 Block B: how `model` was arrived at. Metadata only -- it
+   *  reports the existing resolution, it does not change it. */
+  modelProfile: string | null
+  modelSource: 'explicit_model' | 'model_profile' | 'default'
+  modelProfileError: string | null
   activeModel: string | null
   runningSince: number | null
   authMode: AuthMode
@@ -368,6 +379,11 @@ function getAgentSummary(name: string): AgentSummary {
   const tc = readAgentTeamsConfig(name)
   const hasClaudeMd = claudeMd.trim().length > 0
   const hasSoulMd = soulMd.trim().length > 0
+  // Card c755f4b2 Block B: resolve once and report both the answer and how it
+  // was reached, so "configured" and "resolved" are never conflated in the API.
+  let agentModelConfig: { model?: unknown; modelProfile?: unknown } = {}
+  try { agentModelConfig = JSON.parse(readFileOr(join(dir, 'agent-config.json'), '{}')) } catch { /* defaults */ }
+  const modelResolution = resolveAgentModelDetailed(name)
 
   // Resolve run state through the cache (remote agents) so listing the fleet
   // never blocks on a sleeping laptop's ssh timeout. `running` is derived from
@@ -387,7 +403,10 @@ function getAgentSummary(name: string): AgentSummary {
     name,
     displayName: readAgentDisplayName(name),
     description: extractDescriptionFromClaudeMd(claudeMd),
-    model: readAgentModel(name),
+    model: modelResolution.model,
+    modelProfile: typeof agentModelConfig.modelProfile === 'string' ? agentModelConfig.modelProfile : null,
+    modelSource: modelResolution.source,
+    modelProfileError: modelResolution.error ?? null,
     activeModel: running ? readActiveModelFromProjectDir(dir, runningSince ?? undefined, resolveAgentConfigDir(name).configDir ?? undefined) : null,
     runningSince,
     authMode: readAgentAuthMode(name),
@@ -1840,6 +1859,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const data = JSON.parse(body.toString()) as {
       claudeMd?: string; soulMd?: string; mcpJson?: string; model?: string
       authMode?: AuthMode; apiKey?: string; claudePlan?: string; memoryIsolation?: boolean
+      modelProfile?: string | null
     }
     if (data.memoryIsolation !== undefined) {
       // The main agent's cwd IS the install repo root, which is already a git
@@ -1862,6 +1882,29 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (data.soulMd !== undefined) atomicWriteFileSync(join(agentDir(name), 'SOUL.md'), data.soulMd)
     if (data.mcpJson !== undefined) atomicWriteFileSync(join(agentDir(name), '.mcp.json'), data.mcpJson)
     if (data.model !== undefined) writeAgentModel(name, data.model)
+    // Card c755f4b2 Block B: optional generic capability tier. An unknown id
+    // is a 400, never a persisted value -- storing one would leave the UI
+    // showing a profile while resolution silently fell back to the install
+    // default, i.e. a model change nobody asked for. Empty string clears it.
+    if (data.modelProfile !== undefined) {
+      if (data.modelProfile === '' || data.modelProfile === null) {
+        writeAgentModelProfile(name, null)
+      } else if (isModelProfileId(data.modelProfile)) {
+        const mapState = readModelProfileMap()
+        if (!mapState) {
+          json(res, { error: 'No model-profile map is provisioned on this deployment; a modelProfile cannot be honoured yet.' }, 400)
+          return true
+        }
+        if (!mapState.ok) {
+          json(res, { error: `Model-profile map is unusable: ${mapState.error}` }, 400)
+          return true
+        }
+        writeAgentModelProfile(name, data.modelProfile)
+      } else {
+        json(res, { error: `modelProfile must be one of ${MODEL_PROFILE_IDS.join('|')}` }, 400)
+        return true
+      }
+    }
     if (data.authMode !== undefined) {
       writeAgentAuthMode(name, data.authMode)
       if (data.authMode === 'api' && typeof data.apiKey === 'string' && data.apiKey.trim()) {


### PR DESCRIPTION
## What

Adds a behaviour-neutral `modelProfile` layer: an agent can declare a coarse
capability profile (`premium_reasoning`, `build_strong`, `analysis_efficient`,
`routine_lowcost`) instead of pinning a concrete model id, and a
deployment-local map resolves the profile to a concrete model at read time.

## Why

Decouples "what kind of model this agent needs" from "which exact model id runs
here", so a deployment can re-map a whole tier in one place instead of editing
every agent config. The concrete map lives in `store/` (gitignored), so the
model/account mapping never leaves the machine; a committed
`config-examples/model-profile-map.example.json` documents the shape.

## Design

- **Purely additive.** The existing model selector is untouched; this sits on
  top of it. New pure module `src/model-profiles.ts` (no fs / no env / no
  imports) does the resolution; wired through `agent-config.ts` and the
  `/api/agents` payload only.
- **Precedence:** explicit `model` wins → else `modelProfile` → else install
  default. An unknown profile id resolves to the default **and surfaces an
  error** rather than silently switching models.
- **Behaviour-neutral by construction.** The first map is built from the models
  the fleet already runs, so attaching a profile changes nothing observable.

## Tests

`src/__tests__/model-profiles.test.ts` (21) + `model-profiles-wiring.test.ts`
(9): precedence, the loud-error path for a partial/unknown map, and that adding
a profile to an agent that keeps an explicit model does not change its resolved
model. Typecheck clean.
