### PR TITLE
fix(enroll): permitopen + bundle follow the actual WEB_PORT (INSTUX1 root cause)

### DIFF
--- a/scripts/remote-access-enroll.ts
+++ b/scripts/remote-access-enroll.ts
@@ -40,6 +40,7 @@ import {
   type ConnectionBundleInput,
 } from '../src/remote-enroll-core.js'
 import { enrollAuthorizedKey } from '../src/remote-enroll-fs.js'
+import { WEB_PORT as ENV_WEB_PORT } from '../src/config.js'
 
 interface Args {
   keyLine?: string
@@ -49,11 +50,13 @@ interface Args {
   includeDashboardToken: boolean
 }
 
-/** Dashboard port default: WEB_PORT from the environment (the install writes it
- * into .env, which the service loads), falling back to REMOTE_PORT. */
+/** Dashboard port default: the install's actual WEB_PORT, read from the same
+ * .env the service loads (config resolves config-overrides.json > .env), so a
+ * manual `remote-enroll` with no --web-port still targets the real port instead
+ * of the 3420 default. Explicit --web-port overrides. Falls back to REMOTE_PORT
+ * only when .env carries no WEB_PORT (config already applies that default). */
 function defaultWebPort(): number {
-  const raw = process.env['WEB_PORT']
-  const n = raw !== undefined ? Number(raw) : NaN
+  const n = ENV_WEB_PORT
   return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : REMOTE_PORT
 }
 

--- a/scripts/remote-access-enroll.ts
+++ b/scripts/remote-access-enroll.ts
@@ -7,7 +7,15 @@
 // Usage:
 //   npm run remote-enroll -- "ssh-ed25519 <base64 key> marveen-remote:<uuid>"
 //   npm run remote-enroll -- --host 203.0.113.10 --port 2222 "<public key line>"
+//   npm run remote-enroll -- --web-port 3421 "<public key line>"
 //   npm run remote-enroll -- --no-dashboard-token "<public key line>"
+//
+// --port is the SSH port; --web-port is the dashboard port the enrolled key may
+// tunnel to (permitopen) AND the port encoded in the bundle. It defaults to the
+// WEB_PORT env / .env value, falling back to REMOTE_PORT. A mismatch between the
+// permitopen and the actual dashboard port silently locks the device out
+// (INSTUX1): the tunnel opens a dead port and the app reports "dashboard not
+// running" forever.
 //
 // The bundle includes the dashboard bearer token (store/.dashboard-token) by
 // default so the connecting app can authenticate against the dashboard. Such a
@@ -28,6 +36,7 @@ import {
   resolveHostKey,
   HOST_KEY_PUB_CANDIDATES,
   RemoteEnrollError,
+  REMOTE_PORT,
   type ConnectionBundleInput,
 } from '../src/remote-enroll-core.js'
 import { enrollAuthorizedKey } from '../src/remote-enroll-fs.js'
@@ -36,11 +45,20 @@ interface Args {
   keyLine?: string
   host?: string
   port: number
+  webPort: number
   includeDashboardToken: boolean
 }
 
+/** Dashboard port default: WEB_PORT from the environment (the install writes it
+ * into .env, which the service loads), falling back to REMOTE_PORT. */
+function defaultWebPort(): number {
+  const raw = process.env['WEB_PORT']
+  const n = raw !== undefined ? Number(raw) : NaN
+  return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : REMOTE_PORT
+}
+
 function parseArgs(argv: string[]): Args {
-  const out: Args = { port: 22, includeDashboardToken: true }
+  const out: Args = { port: 22, webPort: defaultWebPort(), includeDashboardToken: true }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--host') {
@@ -55,6 +73,12 @@ function parseArgs(argv: string[]): Args {
       const n = Number(v)
       if (!Number.isInteger(n) || n < 1 || n > 65535) fail('--port must be 1..65535')
       out.port = n
+    } else if (a === '--web-port') {
+      const v = argv[++i]
+      if (!v) fail('--web-port requires a value')
+      const n = Number(v)
+      if (!Number.isInteger(n) || n < 1 || n > 65535) fail('--web-port must be 1..65535')
+      out.webPort = n
     } else if (a.startsWith('--')) {
       fail(`unknown flag: ${a}`)
     } else if (out.keyLine === undefined) {
@@ -146,7 +170,7 @@ async function main(): Promise<void> {
     throw err
   }
 
-  const restrictedLine = buildRestrictedLine(parsed)
+  const restrictedLine = buildRestrictedLine(parsed, args.webPort)
   const sshDir = join(homedir(), '.ssh')
 
   const result = await enrollAuthorizedKey({
@@ -190,6 +214,7 @@ async function main(): Promise<void> {
     sshUser: userInfo().username,
     installId: parsed.installId,
     hostKey: resolved.body,
+    webPort: args.webPort,
   }
 
   if (args.includeDashboardToken) {

--- a/src/__tests__/remote-enroll-core.test.ts
+++ b/src/__tests__/remote-enroll-core.test.ts
@@ -9,6 +9,7 @@ import {
   decodeBundle,
   RemoteEnrollError,
   RESTRICT_OPTIONS,
+  restrictOptions,
   parseKeyscanEd25519,
   resolveHostKey,
   HOST_KEY_PUB_CANDIDATES,
@@ -125,6 +126,29 @@ describe('buildRestrictedLine', () => {
     // Sanity: options segment is exactly as specified.
     expect(line.startsWith(RESTRICT_OPTIONS + ' ')).toBe(true)
   })
+
+  // INSTUX1: the permitopen MUST follow the actual dashboard port. Verifying on
+  // the default (3420) proves nothing -- that case worked before the bug too.
+  it('threads a NON-DEFAULT dashboard port into the permitopen, keeping it narrow', () => {
+    const parsed = validatePublicKeyLine(VALID_LINE)
+    const line = buildRestrictedLine(parsed, 3421)
+    expect(line).toBe(
+      `restrict,port-forwarding,permitopen="127.0.0.1:3421",command="/bin/false" ssh-ed25519 ${B64} marveen-remote:${UUID}`,
+    )
+    // Security narrowing preserved: exactly one loopback port, no wildcard/range,
+    // restrict + forced command intact.
+    expect(line).toContain('restrict,')
+    expect(line).toContain('command="/bin/false"')
+    expect(line).not.toContain('permitopen="127.0.0.1:*"')
+    expect((line.match(/permitopen=/g) ?? []).length).toBe(1)
+  })
+
+  it('restrictOptions defaults to REMOTE_PORT and narrows to the given port', () => {
+    expect(restrictOptions()).toBe(RESTRICT_OPTIONS)
+    expect(restrictOptions(3421)).toBe(
+      'restrict,port-forwarding,permitopen="127.0.0.1:3421",command="/bin/false"',
+    )
+  })
 })
 
 describe('mergeAuthorizedKeys', () => {
@@ -229,6 +253,32 @@ describe('bundle', () => {
     const json = Buffer.from(encoded, 'base64').toString('utf8')
     expect(json).not.toContain('hostKey')
     expect(decoded.remotePort).toBe(3420)
+  })
+
+  it('encodes a NON-DEFAULT webPort as the bundle remotePort (tunnel target)', () => {
+    const bundle = buildBundle({
+      displayName: 'my-host',
+      host: '203.0.113.5',
+      sshPort: 22,
+      sshUser: 'operator',
+      hostKey: 'HOSTKEYB64',
+      installId: base.installId,
+      webPort: 3421,
+    })
+    expect(bundle.remotePort).toBe(3421)
+    expect(decodeBundle(encodeBundle(bundle)).remotePort).toBe(3421)
+  })
+
+  it('falls back to REMOTE_PORT when no webPort is given', () => {
+    const bundle = buildBundle({
+      displayName: 'my-host',
+      host: '203.0.113.5',
+      sshPort: 22,
+      sshUser: 'operator',
+      hostKey: 'HOSTKEYB64',
+      installId: base.installId,
+    })
+    expect(bundle.remotePort).toBe(3420)
   })
 
   it('carries dashboardToken as the last field when provided', () => {

--- a/src/remote-enroll-core.ts
+++ b/src/remote-enroll-core.ts
@@ -6,7 +6,12 @@
 // construction, replace-by-id merging, host-key parsing, and connection
 // bundle building. All filesystem work lives in remote-enroll-fs.ts.
 
-/** Fixed loopback endpoint the enrolled key is permitted to open. */
+/** Default loopback dashboard port. The enrolled key's permitopen and the
+ * connection bundle both target the ACTUAL dashboard port (WEB_PORT); this is
+ * only the fallback when a caller does not supply one. A hardcoded value here
+ * silently broke any install whose dashboard ran on a non-default port
+ * (INSTUX1): the permitopen stayed 3420 while the dashboard moved, so the
+ * tunnel hit a dead port. The port is now threaded through from the caller. */
 export const REMOTE_PORT = 3420
 
 /** The only key type accepted for enrollment. */
@@ -131,15 +136,26 @@ export function validatePublicKeyLine(rawLine: string): ParsedKey {
 /** Options string prepended to the enrolled key in authorized_keys. This is
  * the tight restriction set: no shell (command forced to /bin/false), no
  * agent/x11/pty, forwarding limited to a single loopback endpoint. */
-export const RESTRICT_OPTIONS =
-  `restrict,port-forwarding,permitopen="127.0.0.1:${REMOTE_PORT}",command="/bin/false"`
+/** The tight restriction set for a given dashboard port. The permitopen stays
+ * a SINGLE loopback endpoint (never a wildcard or a range), and the forced
+ * `command="/bin/false"` plus `restrict` are unchanged -- widening any of these
+ * would turn the enrolled key into a general port-forward grant on the server.
+ * Only the port follows the caller's WEB_PORT. */
+export function restrictOptions(webPort: number = REMOTE_PORT): string {
+  return `restrict,port-forwarding,permitopen="127.0.0.1:${webPort}",command="/bin/false"`
+}
+
+/** The default-port restriction string. Retained for callers/tests that assert
+ * the default shape; port-aware callers use restrictOptions(webPort). */
+export const RESTRICT_OPTIONS = restrictOptions(REMOTE_PORT)
 
 /**
  * Build the exact restricted authorized_keys line for a validated key.
- * The key material and comment are reproduced verbatim.
+ * The key material and comment are reproduced verbatim. `webPort` is the actual
+ * dashboard port the key may tunnel to (defaults to REMOTE_PORT).
  */
-export function buildRestrictedLine(parsed: ParsedKey): string {
-  return `${RESTRICT_OPTIONS} ${parsed.keyType} ${parsed.base64} ${parsed.comment}`
+export function buildRestrictedLine(parsed: ParsedKey, webPort: number = REMOTE_PORT): string {
+  return `${restrictOptions(webPort)} ${parsed.keyType} ${parsed.base64} ${parsed.comment}`
 }
 
 /** Extract the trailing comment field of an authorized_keys line, or null if
@@ -313,6 +329,10 @@ export interface ConnectionBundleInput {
    * field is a SECRET: it grants dashboard access to anyone holding it, so it
    * must be transported over a private channel, never email or chat logs. */
   dashboardToken?: string
+  /** Actual dashboard port the tunnel targets. Defaults to REMOTE_PORT. Must
+   * match the permitopen written by buildRestrictedLine, or the tunnel opens a
+   * dead port (INSTUX1). */
+  webPort?: number
 }
 
 export interface ConnectionBundle {
@@ -342,7 +362,7 @@ export function buildBundle(input: ConnectionBundleInput): ConnectionBundle {
     host: input.host,
     sshPort: input.sshPort,
     sshUser: input.sshUser,
-    remotePort: REMOTE_PORT,
+    remotePort: input.webPort ?? REMOTE_PORT,
     ...(input.hostKey !== undefined ? { hostKey: input.hostKey } : {}),
     installId: input.installId,
     ...(input.dashboardToken !== undefined ? { dashboardToken: input.dashboardToken } : {}),

--- a/src/web/bridge-enroll.ts
+++ b/src/web/bridge-enroll.ts
@@ -26,6 +26,7 @@ import { execFile } from 'node:child_process'
 import { homedir, hostname, userInfo, networkInterfaces } from 'node:os'
 import { join } from 'node:path'
 import { logger } from '../logger.js'
+import { WEB_PORT } from '../config.js'
 import {
   validatePublicKeyLine,
   buildRestrictedLine,
@@ -182,7 +183,9 @@ export async function bridgeEnroll(
 
   const enrollResult = await enrollAuthorizedKey({
     sshDir: deps.sshDir,
-    restrictedLine: buildRestrictedLine(parsed),
+    // permitopen must target the actual dashboard port, not a hardcoded 3420
+    // (INSTUX1) -- the tunnel opens exactly this endpoint.
+    restrictedLine: buildRestrictedLine(parsed, WEB_PORT),
     installId: parsed.installId,
   })
 
@@ -202,6 +205,7 @@ export async function bridgeEnroll(
       installId: parsed.installId,
       hostKey: resolved.body,
       dashboardToken: minted.key,
+      webPort: WEB_PORT,
     }),
   )
 


### PR DESCRIPTION
## What (INSTUX1 root cause)

The enrolled key's `permitopen` and the connection bundle's `remotePort` both came from a hardcoded `REMOTE_PORT = 3420`, ignoring the install's actual `WEB_PORT`. The installer wizard now lets the user choose the dashboard port; the first owner to pick a non-default port (3421) got a `permitopen` locked to 3420 while the dashboard listened on 3421 — the Bridge tunnel opened a dead port and the app reported *"Server reachable, Marveen dashboard is not running"* permanently. No existing customer is affected (the port field is new with the wizard); default-port installs coincidentally worked.

## Fix — the port follows WEB_PORT, the narrowing is unchanged

- `restrictOptions(webPort)` + `buildRestrictedLine(parsed, webPort)` build the permitopen for the actual port; `buildBundle` uses `input.webPort` for `remotePort`.
- `bridge-enroll` (dashboard API) and `remote-access-enroll` (CLI, new `--web-port`, distinct from the SSH `--port`) thread the port through. The CLI now defaults to the `.env` `WEB_PORT` via config (not `process.env`, which is empty standalone) — so a **manual** `remote-enroll` with no flag also targets the real port.
- **Narrowing preserved and asserted:** exactly one loopback port, no wildcard/range, `restrict` + `command="/bin/false"` intact.

## Verify — end-to-end on a NON-DEFAULT port (3421), owner-login-free

Fresh install at `WEB_PORT=3421`: `permitopen="127.0.0.1:3421"`, bundle `remotePort: 3421`, real tunnel with the enrolled restricted key reaches the dashboard (**HTTP 200**), and the **negative control** — same key forwarding to 3420 — is `administratively prohibited: open failed` (the permitopen is narrow: 3421 and *only* 3421). Unit tests on the non-default port; 52 passing, `tsc` clean.

## Release path

**Base: `develop`.** Ships with the Tuesday promote — NOT a tonight hotfix. Pairs with installer PR #13 (`--web-port` passthrough) and marveen-bridge PR #7 (the display/docs line). The installer must NOT ship `--web-port` before this reaches `main`, or the old `remote-enroll` would `fail("unknown flag")` and break every install; the three land together on the same promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
