### PR TITLE
fix(onboarding): create the channels session when absent instead of respawn-pane (ONBTMUX1)

### DIFF
--- a/src/__tests__/channel-monitor-session-recreate.test.ts
+++ b/src/__tests__/channel-monitor-session-recreate.test.ts
@@ -111,3 +111,39 @@ describe("channel-monitor: self-healing vanished main session", () => {
     expect(createIdx).toBeLessThan(downIdx)
   })
 })
+
+describe("channel-monitor: createMainChannelsSession discriminated result (PR #779 review)", () => {
+  // A boolean return collapsed "already kicked, still booting" (benign) and
+  // "channels.sh missing/unlaunchable" (broken install) into the same false,
+  // which the onboarding launch endpoint then reported as a silent success.
+  // The result type must keep the two failure classes apart.
+
+  it("returns 'grace' | 'script-missing' | 'started' | 'spawn-failed' instead of booleans", () => {
+    const fn = sliceFn("createMainChannelsSession")
+    expect(fn).toContain("MainSessionCreateResult")
+    expect(fn).toContain("return 'grace'")
+    expect(fn).toContain("return 'script-missing'")
+    expect(fn).toContain("return 'started'")
+    expect(fn).toContain("return 'spawn-failed'")
+    expect(fn).not.toContain("return true")
+    expect(fn).not.toContain("return false")
+  })
+
+  it("monitor loop only clears the down state on an actual 'started'", () => {
+    expect(src).toContain("createMainChannelsSession() === 'started'")
+  })
+
+  it("onboarding launch maps the broken-install results to a 500, not starting:true", () => {
+    const ONBOARDING_PATH = join(__dirname, "..", "web", "routes", "onboarding.ts")
+    const onb = readFileSync(ONBOARDING_PATH, "utf-8")
+    const errIdx = onb.indexOf("created === 'script-missing' || created === 'spawn-failed'")
+    expect(errIdx, "broken-install guard missing from launch handler").toBeGreaterThan(0)
+    const startingIdx = onb.indexOf("starting: true")
+    expect(startingIdx, "starting:true response not found").toBeGreaterThan(0)
+    // The hard-error branch must be decided BEFORE the starting:true response.
+    expect(errIdx).toBeLessThan(startingIdx)
+    // And it must surface a nameable reason for the UI.
+    expect(onb).toContain("'channels-script-missing'")
+    expect(onb).toContain("'channels-spawn-failed'")
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -870,14 +870,21 @@ export function mainChannelsSessionExists(): boolean {
   }
 }
 
-export function createMainChannelsSession(): boolean {
+// Discriminated result instead of a boolean: 'grace' (already kicked, session
+// is booting -- benign) and 'script-missing'/'spawn-failed' (the install is
+// broken) must NOT look alike to callers. The onboarding launch endpoint
+// reports the former as "starting" and the latter as a hard error; a boolean
+// collapsed both into a silent false success (PR #779 review).
+export type MainSessionCreateResult = 'started' | 'grace' | 'script-missing' | 'spawn-failed'
+
+export function createMainChannelsSession(): MainSessionCreateResult {
   const now = Date.now()
   if (marveenLastSessionCreate && now - marveenLastSessionCreate < MAIN_SESSION_CREATE_GRACE_MS) {
-    return false
+    return 'grace'
   }
   if (!existsSync(CHANNELS_SCRIPT)) {
     logger.error({ script: CHANNELS_SCRIPT }, 'Cannot recreate main channels session: channels.sh missing')
-    return false
+    return 'script-missing'
   }
   try {
     // Detached + unref'd: channels.sh is a long-lived supervisor (it tails the
@@ -896,10 +903,10 @@ export function createMainChannelsSession(): boolean {
     writeRespawnStamp()
     logger.warn({ session: MAIN_CHANNELS_SESSION }, 'Main channels session absent -- recreating via channels.sh')
     sendAlert(`♻️ A ${MAIN_CHANNELS_SESSION} session eltunt -- ujrainditom (channels.sh). Enelkul minden utemezett feladat csendben kimaradna.`)
-    return true
+    return 'started'
   } catch (err) {
     logger.error({ err }, 'Failed to recreate main channels session via channels.sh')
-    return false
+    return 'spawn-failed'
   }
 }
 
@@ -1561,7 +1568,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // with no supervising service, and every scheduled main-agent task
           // silently skips (scheduler !sessionExists branch).
           if (!mainChannelsSessionExists()) {
-            if (shouldEscalateMarveenDown() && createMainChannelsSession()) {
+            if (shouldEscalateMarveenDown() && createMainChannelsSession() === 'started') {
               marveenDownState = null
               marveenSuspectFirstSeen = null
             }

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -357,11 +357,20 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
     // session that EXISTS but is wedged should be respawn-paned.
     if (!mainChannelsSessionExists()) {
       // createMainChannelsSession kicks channels.sh detached (a ~minutes cold
-      // start). It returns false when already kicked within its grace window
-      // (session is booting) as well as when channels.sh is missing; either way
-      // the session is not up yet, so report "starting" and let the status poll
-      // flip to running rather than surfacing a hard error.
+      // start). 'started' and 'grace' (already kicked, still booting) are both
+      // healthy "starting" states for the wizard's status poll. A missing or
+      // unlaunchable channels.sh is a BROKEN INSTALL: reporting it as
+      // "starting" would show the customer a success message over a fleet that
+      // can never come up, so it must be a hard error the UI can name.
       const created = createMainChannelsSession()
+      if (created === 'script-missing' || created === 'spawn-failed') {
+        logger.error({ created }, 'onboarding: channels session absent and channels.sh could not be launched')
+        json(res, {
+          error: 'Az ugynokok inditasa nem sikerult: a channels.sh nem futtathato. A telepites serult lehet -- futtasd ujra a telepitot, vagy nezd meg a store/channels-failures.log-ot.',
+          reason: created === 'script-missing' ? 'channels-script-missing' : 'channels-spawn-failed',
+        }, 500)
+        return true
+      }
       logger.info({ created }, 'onboarding: channels session absent -- creating via channels.sh')
       json(res, { ok: true, starting: true })
       return true

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -366,7 +366,7 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
       if (created === 'script-missing' || created === 'spawn-failed') {
         logger.error({ created }, 'onboarding: channels session absent and channels.sh could not be launched')
         json(res, {
-          error: 'Az ugynokok inditasa nem sikerult: a channels.sh nem futtathato. A telepites serult lehet -- futtasd ujra a telepitot, vagy nezd meg a store/channels-failures.log-ot.',
+          error: 'Az ügynökök indítása nem sikerült: a channels.sh nem futtatható. A telepítés sérült lehet -- futtasd újra a telepítőt, vagy nézd meg a store/channels-failures.log-ot.',
           reason: created === 'script-missing' ? 'channels-script-missing' : 'channels-spawn-failed',
         }, 500)
         return true

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -9,7 +9,11 @@ import { atomicWriteFileSync } from '../atomic-write.js'
 import { channelStateDir, readChannelToken } from '../../channel-provider.js'
 import { sessionExistsOnHost } from '../agent-process.js'
 import { MAIN_CHANNELS_SESSION } from '../main-agent.js'
-import { hardRestartMarveenChannels } from '../channel-monitor.js'
+import {
+  hardRestartMarveenChannels,
+  mainChannelsSessionExists,
+  createMainChannelsSession,
+} from '../channel-monitor.js'
 import { liveProbeAuth, stampTokenVerified } from '../claude-credentials-guard.js'
 import { json, readBody } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
@@ -344,6 +348,24 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
   if (path === '/api/onboarding/launch' && method === 'POST') {
     if (agentsRunning()) { json(res, { ok: true, alreadyRunning: true }); return true }
     if (!claudeAuthPresent()) { json(res, { error: 'Eloszor allitsd be a Claude-autentikaciot.', reason: 'no-auth' }, 409); return true }
+    // ONBTMUX1: on a fresh install the channels session does NOT exist yet, and
+    // `tmux respawn-pane` (what hardRestartMarveenChannels does on Linux) cannot
+    // bring back a session that was never there -- it fails with "respawn-pane
+    // failed" and the wizard's step 2 dead-ends. When the session is ABSENT the
+    // correct action is to CREATE it via channels.sh (createMainChannelsSession),
+    // the same path the keep-alive monitor uses for a vanished session. Only a
+    // session that EXISTS but is wedged should be respawn-paned.
+    if (!mainChannelsSessionExists()) {
+      // createMainChannelsSession kicks channels.sh detached (a ~minutes cold
+      // start). It returns false when already kicked within its grace window
+      // (session is booting) as well as when channels.sh is missing; either way
+      // the session is not up yet, so report "starting" and let the status poll
+      // flip to running rather than surfacing a hard error.
+      const created = createMainChannelsSession()
+      logger.info({ created }, 'onboarding: channels session absent -- creating via channels.sh')
+      json(res, { ok: true, starting: true })
+      return true
+    }
     const r = hardRestartMarveenChannels()
     if (!r.ok) { json(res, { error: r.error || 'Nem sikerult eletre kelteni az agenteket.', reason: 'launch-failed' }, 500); return true }
     logger.info('onboarding: fleet launched (channels session)')

--- a/web/app.js
+++ b/web/app.js
@@ -11971,7 +11971,11 @@ function wireOnboarding(step) {
           if (st && st.agentsRunning) { up = true; break }
         }
         if (up) { await refreshOnboarding() }
-        else { launchBtn.disabled = false; onbMsg(t('onboarding.step1.launched')) }
+        // Timeout is NOT success: on a slow machine the cold start can outlast
+        // the 2-min bound while still being healthy, so the message must say
+        // "still starting, check back / refresh" -- repeating the launched
+        // message here would also mask a genuinely dead start (PR #779 review).
+        else { launchBtn.disabled = false; onbMsg(t('onboarding.step1.launch_slow'), true) }
       } catch (e) { launchBtn.disabled = false; onbMsg((e && e.message) || t('onboarding.error'), true) }
     })
   } else if (step === 3) {

--- a/web/app.js
+++ b/web/app.js
@@ -11959,7 +11959,19 @@ function wireOnboarding(step) {
         const d = await res.json().catch(() => ({}))
         if (!res.ok) { launchBtn.disabled = false; onbMsg(d.error || t('onboarding.error'), true); return }
         onbMsg(t('onboarding.step1.launched'))
-        setTimeout(refreshOnboarding, 2500)
+        // On a fresh install the session is CREATED here (ONBTMUX1) and takes a
+        // ~minute cold start via channels.sh. Poll until it is up so the wizard
+        // advances on its own instead of stranding the user on step 2 after a
+        // single 2.5s re-check. Bounded so a genuinely failed start still hands
+        // control back rather than spinning forever.
+        let up = false
+        for (let i = 0; i < 40 && !up; i++) {  // ~40 x 3s = 2 min
+          await new Promise((r) => setTimeout(r, 3000))
+          const st = await fetchOnboardingStatus()
+          if (st && st.agentsRunning) { up = true; break }
+        }
+        if (up) { await refreshOnboarding() }
+        else { launchBtn.disabled = false; onbMsg(t('onboarding.step1.launched')) }
       } catch (e) { launchBtn.disabled = false; onbMsg((e && e.message) || t('onboarding.error'), true) }
     })
   } else if (step === 3) {

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1522,6 +1522,7 @@ window._i18n.en = {
   'onboarding.step1.saved_restart_failed': 'Token saved, but restarting the agent failed. Restart it manually (Linux: systemctl --user restart marveen-channels), then come back here.',
   'onboarding.step1.launching':  'Launching...',
   'onboarding.step1.launched':   'Agents are starting...',
+  'onboarding.step1.launch_slow':'The agents have not come up within the expected window. On a slower machine the cold start can take a few minutes: wait a bit, then refresh this page. If nothing changes after 10 minutes, check the store/channels-failures.log file.',
   'onboarding.step2.tab':        'Telegram bot',
   'onboarding.step2.desc':       'Provide your Telegram bot token (from BotFather).',
   'onboarding.step2.token_label':'Telegram bot token',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1519,6 +1519,7 @@ window._i18n.hu = {
   'onboarding.step1.saved_restart_failed': 'A token elmentve, de az ügynök újraindítása nem sikerült. Indítsd újra kézzel (Linux: systemctl --user restart marveen-channels), aztán térj vissza ide.',
   'onboarding.step1.launching':  'Indítás...',
   'onboarding.step1.launched':   'Ügynökök indítása folyamatban...',
+  'onboarding.step1.launch_slow':'Az ügynökök még nem álltak fel a várt időn belül. Lassabb gépen a hidegindítás pár percig is eltarthat: várj egy kicsit, majd frissítsd az oldalt. Ha 10 perc után sincs változás, nézd meg a store/channels-failures.log fájlt.',
   'onboarding.step2.tab':        'Telegram bot',
   'onboarding.step2.desc':       'Add meg a Telegram bot tokenjét (a BotFather-től).',
   'onboarding.step2.token_label':'Telegram bot token',


### PR DESCRIPTION
## Mit javit (ONBTMUX1, P1)

Friss telepitesen a varazslo 2. lepese ("Ugynokok eletre keltese") a `POST /api/onboarding/launch`-nal elhalt: `hard restart failed: tmux respawn-pane failed`. Ok: amikor a `marveen-channels` session MEG NEM LETEZIK (friss install race: a launch a channels.sh session-boot elott tuzel), a handler `hardRestartMarveenChannels()`-t hivott, ami Linuxon kizarolag `tmux respawn-pane` -- az pedig nem tud nem-letezo sessiont letrehozni. Elo P1 a tulajdonosi installon (vps47), 2026-07-29 22:30.

## A fix

- `src/web/routes/onboarding.ts`: az absent-session agon `mainChannelsSessionExists()` check -> ha absent -> `createMainChannelsSession()` (channels.sh, LETREHOZZA a sessiont; ugyanaz az ut, amit a keep-alive monitor mar helyesen hasznal eltunt sessionre). Valasz: `{ok:true, starting:true}`. A respawn-pane megmarad a letezo-de-wedged esetre.
- `web/app.js` (launch-gomb handler): `starting` valaszra bounded poll (~40x3s) `agentsRunning`-ig, majd `refreshOnboarding()` -- a wizard a cold-start alatt magatol tovabblep, nem ragad a 2. lepesen.

Scope SZUK: csak ez a ket valtozas. A #778 / #13 / #7 port-ag NEM resze ennek a PR-nak (kompatibilitasi csapda tartja vissza, keddi promote-tal megy).

## Verifikacio (hatarokkal)

A session-CREATION igazolva. Az agent-boot NEM igazolva (AVX-hiany a verify-hoston).

Hermes light-verify (2026-07-29 23:13, eldobhato checkout a branch fejerol `6411393`, dashboard WEB_ONLY=true a 3599-es porton, `MAIN_AGENT_ID=onbhtest`, placeholder tokennel -- valodi credential nem kerult a scratch-be):
- Precondicio: `onbhtest-channels` session ABSENT.
- `POST /api/onboarding/launch` -> `{"ok":true,"starting":true}` HTTP 200 (nem 500, nincs respawn-pane hiba).
- A session ~6 mp mulva LETREJOTT (`tmux has-session` zold; dash.log: "Main channels session absent -- recreating via channels.sh").
- Re-POST boot kozben: ismet `starting:true` (grace-window ag OK).
- WEB_ONLY worker-suppression: nincs kiszivargott worker-session.
- Teardown teljes; a hermes soak-install erintetlen (session created-time valtozatlan, 3420 HTTP 200).

Emellett: tsc + `npm run build` + `node --check web/app.js` zold.

## Merge-kapu

Marveen diff-review + reggeli teljes e2e (Szabi-engedelyes eldobhato VPS-en) UTAN mergelheto. NEM self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
