### PR TITLE
fix(voice): a document attachment is not a voice message

### DIFF
--- a/scripts/hooks/voice-reply-directive.py
+++ b/scripts/hooks/voice-reply-directive.py
@@ -93,10 +93,15 @@ def main():
         sys.exit(0)
     chat_id = m.group(1)
 
-    # Extract attachment_file_id if present (only set for voice attachments).
-    # Passed to the endpoint so STT runs server-side when a voice file is attached.
+    # Extract attachment_file_id AND attachment_kind. The kind matters: the
+    # Telegram plugin sets attachment_file_id for every attachment type, so the
+    # id alone does not mean "voice message". Without the kind the endpoint
+    # cannot tell a PDF from a voice note, and an agent in `auto` mode answered
+    # a document with a synthesized voice message (2026-07-29).
     m_file = re.search(r'\battachment_file_id="([^"]+)"', prompt)
     file_id = m_file.group(1) if m_file else None
+    m_kind = re.search(r'\battachment_kind="([a-z_]+)"', prompt)
+    kind = m_kind.group(1) if m_kind else None
 
     agent_id = _agent_id(payload.get("cwd"))
     if not agent_id:
@@ -110,6 +115,8 @@ def main():
     url = "http://localhost:%s/api/voice/directive?agent=%s&chat=%s" % (port, agent_id, chat_id)
     if file_id:
         url += "&file=" + urllib.parse.quote(file_id, safe="")
+        if kind:
+            url += "&kind=" + urllib.parse.quote(kind, safe="")
 
     try:
         req = urllib.request.Request(url)

--- a/src/__tests__/voice-inbound-audio.test.ts
+++ b/src/__tests__/voice-inbound-audio.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { inboundIsAudio } from '../web/voice-directive.js'
+
+// The single decision behind "should this agent answer with speech": was the
+// inbound attachment audio? Getting it wrong is not cosmetic -- in `auto` voice
+// mode a false positive makes the agent answer a document with a synthesized
+// voice message, and pushes that file through speech-to-text.
+describe('inboundIsAudio', () => {
+  it('accepts the kinds Telegram uses for audio', () => {
+    for (const kind of ['voice', 'audio', 'video_note']) {
+      expect(inboundIsAudio(kind, 'BQACAgQAAxkBAAIDSWpqdaVDcIjs')).toBe(true)
+    }
+  })
+
+  it('rejects a document attachment -- the 2026-07-29 regression', () => {
+    // An 826 kB PDF arrived with a perfectly valid file id; the old code read
+    // the id alone as proof of a voice message.
+    expect(inboundIsAudio('document', 'BQACAgQAAxkBAAIDSWpqdaVDcIjs')).toBe(false)
+  })
+
+  it('rejects the other non-audio attachment kinds', () => {
+    for (const kind of ['photo', 'video', 'sticker', 'animation']) {
+      expect(inboundIsAudio(kind, 'BQACAgQAAxkBAAIDSWpqdaVDcIjs')).toBe(false)
+    }
+  })
+
+  it('treats a missing or empty kind as NOT audio', () => {
+    // Conservative direction: a wrong "speak" is a wrong-format answer to the
+    // owner, a wrong "stay quiet" only loses the audio nicety.
+    expect(inboundIsAudio(null, 'BQACAgQAAxkBAAIDSWpqdaVDcIjs')).toBe(false)
+    expect(inboundIsAudio(undefined, 'BQACAgQAAxkBAAIDSWpqdaVDcIjs')).toBe(false)
+    expect(inboundIsAudio('', 'BQACAgQAAxkBAAIDSWpqdaVDcIjs')).toBe(false)
+  })
+
+  it('is case and whitespace tolerant on the kind', () => {
+    expect(inboundIsAudio(' Voice ', 'BQACAgQAAxkBAAIDSWpqdaVDcIjs')).toBe(true)
+    expect(inboundIsAudio('VIDEO_NOTE', 'BQACAgQAAxkBAAIDSWpqdaVDcIjs')).toBe(true)
+  })
+
+  it('needs a file id: a kind alone is not an attachment', () => {
+    expect(inboundIsAudio('voice', null)).toBe(false)
+    expect(inboundIsAudio('voice', '')).toBe(false)
+    expect(inboundIsAudio('voice', undefined)).toBe(false)
+  })
+})

--- a/src/web/routes/voice.ts
+++ b/src/web/routes/voice.ts
@@ -22,7 +22,7 @@ import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
 import { KNOWN_VOICE_MODELS, AGENTS_BASE_DIR, readAgentVoiceConfig } from '../agent-config.js'
 import { getLastInboundModality, setLastInboundModality } from '../voice-modality.js'
-import { buildTtsDirective, resolveAgentChannelStateDir } from '../voice-directive.js'
+import { buildTtsDirective, resolveAgentChannelStateDir, inboundIsAudio } from '../voice-directive.js'
 import { PROJECT_ROOT } from '../../config.js'
 import type { RouteContext } from './types.js'
 
@@ -116,9 +116,11 @@ export async function tryHandleVoice(ctx: RouteContext): Promise<boolean> {
   // directive semantics by responseMode:
   //   text  -> null (never speaks)
   //   voice -> always buildTtsDirective (speaks even for plain-text input)
-  //   auto  -> buildTtsDirective only when a voice file_id is present (speaks only if user sent audio)
-  // transcript: STT result when `file` is provided and valid (mode-independent -- even text-mode
-  //   agents can benefit from knowing what a voice message said).
+  //   auto  -> buildTtsDirective only when the inbound attachment kind is audio
+  //            (voice/audio/video_note). A document or photo attachment does NOT speak.
+  // transcript: STT result when the attachment is audio and the id is valid (mode-independent --
+  //   even text-mode agents benefit from knowing what a voice message said). Non-audio
+  //   attachments are never pushed through speech-to-text.
   // fail-safe: STT errors set transcript=null; directive is always attempted independently.
   if (path === '/api/voice/directive' && method === 'GET') {
     const agentId = ctx.url.searchParams.get('agent') ?? ''
@@ -128,15 +130,19 @@ export async function tryHandleVoice(ctx: RouteContext): Promise<boolean> {
     if (!chatId || !/^\d+$/.test(chatId)) { json(res, { error: 'Invalid chat_id' }, 400); return true }
     const voiceCfg = readAgentVoiceConfig(agentId)
     const stateDir = resolveAgentChannelStateDir(agentId, 'telegram')
-    const fileIsVoice = !!fileParam && SAFE_FILE_ID_RE.test(fileParam)
+    const kindParam = ctx.url.searchParams.get('kind') ?? ''
+    const fileIdOk = !!fileParam && SAFE_FILE_ID_RE.test(fileParam)
+    // Audio is decided by the declared attachment kind, never by the mere
+    // presence of a file id -- a document attachment is not a voice message.
+    const inboundWasAudio = fileIdOk && inboundIsAudio(kindParam, fileParam)
     const ttsParams = { chatId, stateDir, voiceModel: voiceCfg.voiceModel ?? 'hu_HU-imre-medium' }
     const directive = voiceCfg.responseMode === 'text' ? null
       : voiceCfg.responseMode === 'voice' ? buildTtsDirective(ttsParams)
-      : fileIsVoice ? buildTtsDirective(ttsParams)  // auto: only when inbound was audio
+      : inboundWasAudio ? buildTtsDirective(ttsParams)  // auto: only when inbound was audio
       : null
 
     let transcript: string | null = null
-    if (fileParam && SAFE_FILE_ID_RE.test(fileParam) && isVoiceInstalled()) {
+    if (inboundWasAudio && isVoiceInstalled()) {
       const sttResult = await runProc(VENV_PY, [VTOOLS_PY, 'transcribe', fileParam, stateDir], { timeoutMs: 60_000 })
       if (sttResult.code === 0) {
         transcript = sttResult.stdout.trim() || null

--- a/src/web/voice-directive.ts
+++ b/src/web/voice-directive.ts
@@ -18,6 +18,26 @@ export function resolveAgentChannelStateDir(agentId: string, provider: string): 
   return candidates.find((d) => existsSync(join(d, '.env'))) ?? candidates[candidates.length - 1]
 }
 
+// Which inbound attachment kinds are actually audio.
+//
+// The channel tag carries attachment_kind, and the Telegram plugin uses it for
+// EVERY attachment type -- "document", "photo" and so on, not just audio. The
+// directive endpoint used to decide "was this a voice message?" from the mere
+// PRESENCE of an attachment_file_id, so sending a PDF to an agent in `auto`
+// voice mode made it answer a document with a synthesized voice message (and
+// pushed the PDF through speech-to-text). Observed 2026-07-29 with an 826 kB
+// PDF attachment.
+const AUDIO_KINDS = new Set(['voice', 'audio', 'video_note'])
+
+// True only when the inbound attachment is known to be audio. An absent or
+// unrecognised kind counts as NOT audio: the conservative direction is to stay
+// in text, because a wrong "speak" is a wrong-format answer to the owner, while
+// a wrong "stay quiet" only loses the audio nicety.
+export function inboundIsAudio(kind: string | null | undefined, fileId: string | null | undefined): boolean {
+  if (!fileId) return false
+  return AUDIO_KINDS.has(String(kind ?? '').trim().toLowerCase())
+}
+
 // Build a ready-to-run TTS directive block injected after the STT transcript.
 // Returns null if the dashboard token cannot be read.
 export function buildTtsDirective(opts: {


### PR DESCRIPTION
An agent in `auto` voice mode decided "was the inbound a voice message?" from the mere presence of an `attachment_file_id`. The Telegram plugin sets that id for every attachment type, so a PDF was read as audio: the endpoint returned a TTS directive (whose own text says "do not send a text reply") and pushed the document through speech-to-text.

Observed today on a live install with an 826 kB PDF the owner wanted analysed in writing. Nothing crashed -- the transcript came back empty -- which is what makes it worth fixing: the failure mode is a confidently wrong output format, not an error.

**The fix.** The kind travels end to end. `scripts/hooks/voice-reply-directive.py` reads `attachment_kind` from the channel tag and passes it; `/api/voice/directive` speaks only for `voice`, `audio`, `video_note`, and only then runs STT. An absent or unrecognised kind counts as NOT audio -- a wrong "speak" hands the owner the wrong format, a wrong "stay quiet" only loses the audio nicety. The flag was also called `fileIsVoice` while checking nothing but the id's character set; it is now `inboundWasAudio`.

**Tests.** The decision is a pure function (`inboundIsAudio`) so the tests drive the endpoint's own branch: three audio kinds, the document regression, other non-audio kinds, missing kind, case/whitespace tolerance, kind-without-id. Verified red on a copy with the old logic (3 of 6 fail).

**Verification.** Build clean. Full suite: 2907 passed, 1 skipped, 13 failed -- those 13 fail for *any* commit in a `/tmp`-rooted worktree, because the hook-path guards reject `/tmp`-rooted hook paths by design; outside `/tmp` they pass.

**Compatibility note worth a second opinion:** if some other channel path emits `attachment_file_id` for a real voice note *without* `attachment_kind`, that path stops speaking in `auto` mode until it sets the kind. Our own coordinator always sets it, and this direction fails safe, but you may prefer a plugin-name allowlist instead.