### PR TITLE
fix(scheduler): execute occurrences missed while the scheduler was down

### DIFF
--- a/src/__tests__/schedule-catchup.test.ts
+++ b/src/__tests__/schedule-catchup.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  DEFAULT_CATCHUP_MAX_AGE_MIN,
+  LATE_CATCHUP_THRESHOLD_MS,
+  SCHEDULE_COLD_START_CATCHUP_MS,
+  SCHEDULE_MAX_CATCHUP_MS,
+  catchUpMaxAgeMs,
+  computeCatchUpStart,
+  decideCatchUp,
+} from '../web/schedule-runner.js'
+import { cronDueBetween, cronPrevOccurrence } from '../web/cron.js'
+
+// 2026-07-29 incident: the host died at dawn and came back mid-afternoon. The
+// scan window on start was a flat `now - 30 min`, so every occurrence missed
+// during the outage (the weekly LLM research, the fleet research run, the
+// morning briefing) fell outside it and was dropped WITHOUT a fire, a retry row
+// or an alert -- the gap surfaced only because the operator asked hours later.
+//
+// The policy under test: seed the window from a persisted liveness stamp so it
+// covers the real downtime (capped), then decide each missed occurrence on its
+// own staleness -- run it if it is still useful, record + report it as 'missed'
+// if it is not. Silence is the one outcome that is no longer possible.
+
+const SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+const MIN = 60_000
+const HOUR = 60 * MIN
+
+describe('computeCatchUpStart: the window covers the actual downtime', () => {
+  const now = 1_700_000_000_000
+
+  it('falls back to the cold-start window when no stamp exists', () => {
+    expect(computeCatchUpStart(null, now)).toBe(now - SCHEDULE_COLD_START_CATCHUP_MS)
+  })
+
+  it('ignores a non-finite stamp', () => {
+    expect(computeCatchUpStart(NaN, now)).toBe(now - SCHEDULE_COLD_START_CATCHUP_MS)
+  })
+
+  it('scans the real gap when the process was down for hours', () => {
+    const downSince = now - 9 * HOUR
+    expect(computeCatchUpStart(downSince, now)).toBe(downSince)
+  })
+
+  it('caps a multi-day outage instead of replaying a week of crons', () => {
+    expect(computeCatchUpStart(now - 7 * 24 * HOUR, now)).toBe(now - SCHEDULE_MAX_CATCHUP_MS)
+  })
+
+  it('rejects a future stamp (clock jumped backwards) rather than scanning a negative window', () => {
+    // Trusting it would make fromMs > now, so cronPrevOccurrence returns null
+    // for everything and the tick silently scans nothing.
+    const start = computeCatchUpStart(now + 3 * HOUR, now)
+    expect(start).toBeLessThan(now)
+    expect(start).toBe(now - SCHEDULE_COLD_START_CATCHUP_MS)
+  })
+
+  it('keeps a normal restart window tight', () => {
+    expect(computeCatchUpStart(now - 40_000, now)).toBe(now - 40_000)
+  })
+})
+
+describe('decideCatchUp: run it, or say it was missed -- never neither', () => {
+  const task = { type: 'task' as const }
+
+  it('treats an occurrence inside the tick window as an ordinary on-time fire', () => {
+    expect(decideCatchUp(task, 10_000)).toBe('on-time')
+    expect(decideCatchUp(task, LATE_CATCHUP_THRESHOLD_MS)).toBe('on-time')
+  })
+
+  it('catches up a task missed by a couple of hours', () => {
+    expect(decideCatchUp(task, 2 * HOUR)).toBe('catch-up')
+  })
+
+  it('declares a task missed once it is past its staleness budget', () => {
+    // The morning briefing at 06:40, first tick after boot at 20:00: firing it
+    // would be worse than not firing it, but it must still be reported.
+    expect(decideCatchUp(task, 13 * HOUR)).toBe('stale')
+  })
+
+  it('gives heartbeats a short budget -- the next tick is already on its way', () => {
+    expect(decideCatchUp({ type: 'heartbeat' }, 20 * MIN)).toBe('catch-up')
+    expect(decideCatchUp({ type: 'heartbeat' }, 3 * HOUR)).toBe('stale')
+  })
+
+  it('gives cheap command monitors a long budget (the silent Gmail-refresh death)', () => {
+    expect(decideCatchUp({ type: 'command' }, 10 * HOUR)).toBe('catch-up')
+  })
+
+  it('honours a per-task override', () => {
+    expect(decideCatchUp({ type: 'task', catchUpMaxAgeMinutes: 30 }, 2 * HOUR)).toBe('stale')
+    expect(decideCatchUp({ type: 'task', catchUpMaxAgeMinutes: 720 }, 10 * HOUR)).toBe('catch-up')
+  })
+
+  it('catchUpMaxAgeMinutes: 0 disables catch-up without disabling the schedule', () => {
+    expect(decideCatchUp({ type: 'task', catchUpMaxAgeMinutes: 0 }, 5 * MIN)).toBe('stale')
+    expect(decideCatchUp({ type: 'task', catchUpMaxAgeMinutes: 0 }, 10_000)).toBe('on-time')
+  })
+
+  it('a negative override means always catch up, however late', () => {
+    expect(catchUpMaxAgeMs({ type: 'task', catchUpMaxAgeMinutes: -1 })).toBe(Infinity)
+    expect(decideCatchUp({ type: 'task', catchUpMaxAgeMinutes: -1 }, 20 * HOUR)).toBe('catch-up')
+  })
+
+  it('an unknown task type falls back to the task budget, not to NaN', () => {
+    // The live install runs a `type: "dream-engine"` schedule; task-config.json's
+    // type is cast, never validated. An undefined lookup would make every
+    // comparison NaN and declare each occurrence stale forever.
+    const exotic = { type: 'dream-engine' } as unknown as Parameters<typeof catchUpMaxAgeMs>[0]
+    expect(catchUpMaxAgeMs(exotic)).toBe(DEFAULT_CATCHUP_MAX_AGE_MIN.task * MIN)
+    expect(decideCatchUp(exotic, 2 * HOUR)).toBe('catch-up')
+  })
+
+  it('a malformed override falls back to the type default instead of disabling catch-up', () => {
+    expect(catchUpMaxAgeMs({ type: 'task', catchUpMaxAgeMinutes: NaN }))
+      .toBe(DEFAULT_CATCHUP_MAX_AGE_MIN.task * MIN)
+    expect(catchUpMaxAgeMs({ catchUpMaxAgeMinutes: undefined }))
+      .toBe(DEFAULT_CATCHUP_MAX_AGE_MIN.task * MIN)
+  })
+})
+
+describe('cronPrevOccurrence: the age the decision is made on', () => {
+  // 2026-07-29 08:40 local, a Wednesday -- one occurrence of "40 6 * * *" is in
+  // the window (06:40 that morning), and it is 2h late.
+  const at = (iso: string) => new Date(iso).getTime()
+
+  it('returns the occurrence time inside the half-open window', () => {
+    const from = at('2026-07-29T00:00:00+02:00')
+    const to = at('2026-07-29T08:40:00+02:00')
+    const occ = cronPrevOccurrence('40 6 * * *', from, to, 'Europe/Budapest')
+    expect(occ).toBe(at('2026-07-29T06:40:00+02:00'))
+    expect(to - (occ as number)).toBe(2 * HOUR)
+  })
+
+  it('returns null when nothing is due, and agrees with cronDueBetween', () => {
+    const from = at('2026-07-29T07:00:00+02:00')
+    const to = at('2026-07-29T08:00:00+02:00')
+    expect(cronPrevOccurrence('40 6 * * *', from, to, 'Europe/Budapest')).toBeNull()
+    expect(cronDueBetween('40 6 * * *', from, to, 'Europe/Budapest')).toBe(false)
+  })
+
+  it('yields at most one occurrence for a long window -- no burst on boot', () => {
+    const from = at('2026-07-23T00:00:00+02:00')
+    const to = at('2026-07-29T08:00:00+02:00')
+    const occ = cronPrevOccurrence('*/30 * * * *', from, to, 'Europe/Budapest')
+    expect(occ).toBe(at('2026-07-29T08:00:00+02:00'))
+  })
+
+  it('an unparseable expression is null, not a throw', () => {
+    expect(cronPrevOccurrence('not a cron', 0, 1_000_000)).toBeNull()
+  })
+})
+
+describe('the runner wires the policy in', () => {
+  it('seeds the scan window from the persisted liveness stamp', () => {
+    expect(SRC).toMatch(/let lastCheckMs = computeCatchUpStart\(persistedTickMs, Date\.now\(\)\)/)
+    expect(SRC).not.toMatch(/let lastCheckMs = Date\.now\(\) - 30 \* 60000/)
+  })
+
+  it('persists the stamp AFTER the scan, so a mid-tick crash re-scans that tick', () => {
+    const persistIdx = SRC.indexOf('persistLastTickMs(now)')
+    const advanceIdx = SRC.indexOf('lastCheckMs = now')
+    expect(persistIdx).toBeGreaterThan(advanceIdx)
+  })
+
+  it('records a stale occurrence as a missed run instead of dropping it', () => {
+    const idx = SRC.indexOf("if (decision === 'stale')")
+    expect(idx).toBeGreaterThan(0)
+    const branch = SRC.slice(idx, idx + 900)
+    expect(branch).toMatch(/appendTaskRun\(task\.name, agentName, 'missed'\)/)
+    expect(branch).toMatch(/staleThisTick\.push/)
+  })
+
+  it('reports both halves of the gap in one line', () => {
+    expect(SRC).toMatch(/sendCatchUpSummary\(caughtUpThisTick, staleThisTick/)
+  })
+
+  it('stays silent on a tick that caught nothing up', () => {
+    expect(SRC).toMatch(/if \(caughtUpThisTick\.length \|\| staleThisTick\.length\) \{/)
+  })
+})

--- a/src/web/cron.ts
+++ b/src/web/cron.ts
@@ -105,6 +105,15 @@ export function isValidCronShape(cron: unknown): cron is string {
 // most recent occurrence, so a long outage yields at most one catch-up fire,
 // never a burst.
 export function cronDueBetween(cron: string, fromMs: number, toMs: number, tz: string = CRON_TZ): boolean {
+  return cronPrevOccurrence(cron, fromMs, toMs, tz) != null
+}
+
+// The occurrence time itself, or null when none falls in (fromMs, toMs]. The
+// boolean form above answers "is it due"; the catch-up path additionally needs
+// "HOW LATE is it" -- an occurrence missed 4 minutes ago (a dropped tick) and
+// one missed 9 hours ago (the host was powered off) are the same `true` but
+// call for opposite decisions, see decideCatchUp in schedule-runner.
+export function cronPrevOccurrence(cron: string, fromMs: number, toMs: number, tz: string = CRON_TZ): number | null {
   try {
     // `toMs + 1`: cron-parser's prev() returns the last occurrence STRICTLY
     // before currentDate, so an occurrence landing exactly on the tick boundary
@@ -113,9 +122,10 @@ export function cronDueBetween(cron: string, fromMs: number, toMs: number, tz: s
     // currentDate one ms past toMs makes the window a true half-open (fromMs,
     // toMs], so a boundary occurrence fires exactly once, never twice.
     const expr = CronExpressionParser.parse(cron, { tz, currentDate: new Date(toMs + 1) })
-    return expr.prev().getTime() > fromMs
+    const prev = expr.prev().getTime()
+    return prev > fromMs ? prev : null
   } catch {
-    return false
+    return null
   }
 }
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -27,7 +27,7 @@ import {
   SCHEDULED_TASK_PREAMBLE,
   wrapScheduledTask,
 } from '../prompt-safety.js'
-import { cronDueBetween, effectiveCronTz } from './cron.js'
+import { cronPrevOccurrence, effectiveCronTz } from './cron.js'
 import {
   listScheduledTasks,
   SCHEDULED_TASKS_DIR,
@@ -219,6 +219,113 @@ function persistScheduleLastRun(): void {
     atomicWriteFileSync(SCHEDULE_LAST_RUN_PATH, JSON.stringify(Object.fromEntries(scheduleLastRun), null, 2))
   } catch (err) {
     logger.warn({ err }, 'schedule-runner: failed to persist last-run map')
+  }
+}
+
+// --- Downtime catch-up ---
+//
+// The scan window's left edge used to be a flat `now - 30 min` on startup, so
+// anything the scheduler missed while the process was down for longer than
+// that was lost WITHOUT A TRACE: no fire, no retry row, no alert (2026-07-29,
+// a dawn host crash swallowed the weekly research task, Ford's research run
+// and the morning briefing; nobody learned of it until the operator asked).
+// Rather than widening the flat window -- which would re-fire day-old crons at
+// random hours -- the runner now records when it was last alive, so the window
+// covers the ACTUAL downtime, and each missed occurrence is decided on its own
+// staleness (decideCatchUp): still-useful ones are executed as catch-ups, the
+// rest are recorded as 'missed' runs and reported. The one thing that never
+// happens again is silence.
+const SCHEDULE_TICK_STATE_PATH = join(PROJECT_ROOT, 'store', 'schedule-tick-state.json')
+
+// Hard ceiling on the catch-up window. Beyond this the downtime is an outage,
+// not a hiccup: replaying a week of crons on boot would be a burst of stale
+// work, so the window is capped and everything older is simply out of scope.
+export const SCHEDULE_MAX_CATCHUP_MS = 24 * 60 * 60_000
+// Used when no liveness stamp exists (fresh install, or the store file was
+// wiped). Same value the runner has always used, so first-boot behaviour is
+// unchanged.
+export const SCHEDULE_COLD_START_CATCHUP_MS = 30 * 60_000
+// Writing the stamp on every 15 s tick would be 5.7k atomic writes a day for
+// no benefit; at 60 s the worst case is a 60 s-too-wide window on the next
+// boot, and a too-wide window is harmless (the per-task lastRun guard rejects
+// occurrences that already fired).
+const TICK_STATE_PERSIST_INTERVAL_MS = 60_000
+// An occurrence younger than this was scanned by the tick it belongs to --
+// normal operation. Anything older means the tick that should have caught it
+// never ran (process down, dropped tick), i.e. this is a catch-up.
+export const LATE_CATCHUP_THRESHOLD_MS = 90_000
+
+// Per-type staleness defaults, in minutes, for a MISSED occurrence:
+//   task      -- operator-facing work (briefings, reports). Useful for a few
+//                hours, absurd the next evening.
+//   heartbeat -- short-cadence background checks. The next tick is already on
+//                its way, so only a very recent miss is worth replaying.
+//   command   -- cheap, idempotent shell monitors (token refresh, disk check).
+//                Running one late costs nothing and NOT running it is exactly
+//                how the Gmail token refresher died silently for four days.
+// Custom types exist in the wild: task-config.json's `type` is cast, not
+// validated, so the live install runs a `type: "dream-engine"` task. An unknown
+// key must fall back to the 'task' budget -- an undefined lookup would make the
+// comparison NaN and silently declare EVERY occurrence of that task stale,
+// which is the exact failure this whole path exists to remove.
+export const DEFAULT_CATCHUP_MAX_AGE_MIN: Record<'task' | 'heartbeat' | 'command', number> = {
+  task: 180,
+  heartbeat: 30,
+  command: 1440,
+}
+
+export type CatchUpDecision = 'on-time' | 'catch-up' | 'stale'
+
+/** Resolved staleness budget for a task, in ms (Infinity = always catch up). */
+export function catchUpMaxAgeMs(task: Pick<ScheduledTask, 'type' | 'catchUpMaxAgeMinutes'>): number {
+  const configured = task.catchUpMaxAgeMinutes
+  if (typeof configured === 'number' && Number.isFinite(configured)) {
+    return configured < 0 ? Infinity : configured * 60_000
+  }
+  const perType = DEFAULT_CATCHUP_MAX_AGE_MIN[task.type as 'task'] ?? DEFAULT_CATCHUP_MAX_AGE_MIN.task
+  return perType * 60_000
+}
+
+// Pure: given how late a due occurrence is, decide whether to run it normally,
+// run it as a catch-up, or record it as missed. Exported so the policy is unit-
+// tested without touching cron, tmux or the clock.
+export function decideCatchUp(
+  task: Pick<ScheduledTask, 'type' | 'catchUpMaxAgeMinutes'>,
+  ageMs: number,
+  lateThresholdMs: number = LATE_CATCHUP_THRESHOLD_MS,
+): CatchUpDecision {
+  if (ageMs <= lateThresholdMs) return 'on-time'
+  return ageMs <= catchUpMaxAgeMs(task) ? 'catch-up' : 'stale'
+}
+
+/** Pure: where the first post-start scan window begins. */
+export function computeCatchUpStart(
+  persistedTickMs: number | null,
+  now: number,
+  maxCatchUpMs: number = SCHEDULE_MAX_CATCHUP_MS,
+  coldStartMs: number = SCHEDULE_COLD_START_CATCHUP_MS,
+): number {
+  // No stamp, or a stamp from the future (the host clock jumped backwards --
+  // trusting it would produce a negative-length window and scan nothing):
+  // fall back to the historical cold-start window.
+  if (persistedTickMs == null || !Number.isFinite(persistedTickMs) || persistedTickMs > now) {
+    return now - coldStartMs
+  }
+  return Math.max(persistedTickMs, now - maxCatchUpMs)
+}
+
+function loadLastTickMs(): number | null {
+  try {
+    const raw = JSON.parse(readFileSync(SCHEDULE_TICK_STATE_PATH, 'utf-8')) as { lastTickMs?: unknown }
+    return typeof raw?.lastTickMs === 'number' && Number.isFinite(raw.lastTickMs) ? raw.lastTickMs : null
+  } catch { return null }
+}
+
+function persistLastTickMs(nowMs: number): void {
+  try {
+    atomicWriteFileSync(SCHEDULE_TICK_STATE_PATH, JSON.stringify({ lastTickMs: nowMs }, null, 2))
+  } catch (err) {
+    logger.warn({ err }, 'schedule-runner: failed to persist tick liveness stamp')
   }
 }
 
@@ -674,6 +781,61 @@ export async function runScheduledTaskNow(
 // silently suppress every future alert on this row. Net semantics:
 // exactly-one stamp per delivery attempt, at-least-once delivery with a
 // 60s retry cadence until success.
+// Bot token for the system-level scheduler alerts (pending-retry, task-timeout,
+// catch-up summary). Since the channels migration the token lives in the
+// telegram plugin's env, not marveen/.env (2026-07-08: every scheduler alert
+// was silently suppressed on such hosts), so both locations are tried -- same
+// fallback order as scripts/notify.sh.
+function resolveSchedulerAlertToken(): string | undefined {
+  const envContent = readFileOr(join(PROJECT_ROOT, '.env'), '')
+  const token = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)?.[1]?.trim()
+  if (token) return token
+  const channelEnv = readFileOr(join(homedir(), '.claude', 'channels', 'telegram', '.env'), '')
+  return channelEnv.match(/TELEGRAM_BOT_TOKEN=(.+)/)?.[1]?.trim()
+}
+
+// One line about what the scheduler missed while it was down: which tasks it
+// caught up, and which were too stale to be worth running. Sent once per tick
+// that produced any such entry -- in normal operation that is never, so the
+// channel stays quiet. This is the reporting half of the catch-up policy: a
+// missed occurrence either runs or gets named, never both and never neither.
+function sendCatchUpSummary(
+  caughtUp: Array<{ task: string; ageMs: number }>,
+  stale: Array<{ task: string; ageMs: number }>,
+  gapMs: number,
+): void {
+  const token = resolveSchedulerAlertToken()
+  if (!token) {
+    logger.warn('catch-up summary suppressed: no TELEGRAM_BOT_TOKEN (config error)')
+    return
+  }
+  if (!ALLOWED_CHAT_ID.trim()) {
+    logger.warn('catch-up summary suppressed: empty ALLOWED_CHAT_ID (config error)')
+    return
+  }
+  const mins = (ms: number) => `${Math.round(ms / 60000)} perc`
+  const lines = [`[${BOT_NAME} scheduler] Kimaradt ütemezés (${mins(gapMs)} kiesés).`]
+  if (caughtUp.length) {
+    // "elindítva", not "lefutott": a catch-up injection can still land in the
+    // pending-retry queue if the target session is busy. It will run; it may
+    // not have run yet at the moment this line is sent.
+    lines.push(`Pótlás elindítva: ${caughtUp.map(e => `${e.task} (${mins(e.ageMs)} késés)`).join(', ')}`)
+  }
+  if (stale.length) {
+    lines.push(`Nem pótolva, mert elavult: ${stale.map(e => `${e.task} (${mins(e.ageMs)})`).join(', ')}`)
+    lines.push('Ezek a dashboard /Ütemezések oldalán kézzel indíthatók.')
+  }
+  const text = lines.join('\n')
+  ;(async () => {
+    try {
+      await sendTelegramMessage(token, ALLOWED_CHAT_ID, text)
+      logger.info({ caughtUp: caughtUp.length, stale: stale.length }, 'catch-up summary Telegram alert sent')
+    } catch (err) {
+      logger.warn({ err }, 'catch-up summary delivery failed')
+    }
+  })()
+}
+
 function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   // Stamp first. If another tick raced us, markPendingTaskRetryAlert
   // returns false (the WHERE alert_sent_at IS NULL guards it) and we
@@ -690,17 +852,7 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   // the stamp in place (it acts as the throttle) and log once so the
   // operator sees the config gap without the spin. The scheduled task
   // itself keeps retrying regardless -- only this alert is suppressed.
-  const envPath = join(PROJECT_ROOT, '.env')
-  const envContent = readFileOr(envPath, '')
-  const tokenMatch = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)
-  let token = tokenMatch?.[1]?.trim()
-  if (!token) {
-    // Since the channels migration the bot token lives in the telegram channel
-    // plugin's env, not marveen/.env (2026-07-08: every scheduler alert was
-    // silently suppressed on such hosts). Same fallback as scripts/notify.sh.
-    const channelEnv = readFileOr(join(homedir(), '.claude', 'channels', 'telegram', '.env'), '')
-    token = channelEnv.match(/TELEGRAM_BOT_TOKEN=(.+)/)?.[1]?.trim()
-  }
+  const token = resolveSchedulerAlertToken()
   if (!token) {
     logger.warn({ task: view.taskName, agent: view.agentName }, 'Pending-retry alert suppressed: no TELEGRAM_BOT_TOKEN (config error, stamp kept to avoid 60s spin)')
     return
@@ -766,14 +918,7 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
 // scheduler alert, not a per-agent channel notification.
 function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void {
   const ageMinutes = Math.floor(elapsedMs / 60000)
-  const envPath = join(PROJECT_ROOT, '.env')
-  const envContent = readFileOr(envPath, '')
-  const tokenMatch = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)
-  let token = tokenMatch?.[1]?.trim()
-  if (!token) {
-    const channelEnv = readFileOr(join(homedir(), '.claude', 'channels', 'telegram', '.env'), '')
-    token = channelEnv.match(/TELEGRAM_BOT_TOKEN=(.+)/)?.[1]?.trim()
-  }
+  const token = resolveSchedulerAlertToken()
   if (!token) {
     logger.warn({ task: entry.taskName, agent: entry.agentName }, 'task-timeout alert suppressed: no TELEGRAM_BOT_TOKEN (config error)')
     return
@@ -844,11 +989,25 @@ export function startScheduleRunner(): NodeJS.Timeout {
     )
   }
 
-  // Start of the window the next tick will scan. Seeded 30 min in the past so
-  // the first tick after a (re)start catches anything missed while the process
-  // was down; thereafter each tick advances it to its own `now`, so the scan
-  // windows are contiguous and non-overlapping -- see cronDueBetween.
-  let lastCheckMs = Date.now() - 30 * 60000
+  // Start of the window the next tick will scan. Seeded from the liveness stamp
+  // the previous run left behind, so the first tick after a (re)start scans the
+  // ACTUAL downtime instead of a flat 30 min (capped, see computeCatchUpStart);
+  // thereafter each tick advances it to its own `now`, so the scan windows are
+  // contiguous and non-overlapping -- see cronDueBetween.
+  const persistedTickMs = loadLastTickMs()
+  let lastCheckMs = computeCatchUpStart(persistedTickMs, Date.now())
+  const startupGapMs = Date.now() - lastCheckMs
+  if (persistedTickMs != null && startupGapMs > SCHEDULE_COLD_START_CATCHUP_MS) {
+    logger.warn(
+      { downtimeMinutes: Math.round(startupGapMs / 60000), cappedAtHours: SCHEDULE_MAX_CATCHUP_MS / 3_600_000 },
+      'schedule-runner: scheduler was down longer than a tick -- scanning the downtime window for missed occurrences',
+    )
+  }
+  // The window the FIRST tick scans, so that tick can report its catch-ups as
+  // downtime recovery. Zeroed after the first tick; later gaps (a dropped tick)
+  // are reported against the tick interval instead.
+  let pendingStartupGapMs = persistedTickMs != null ? startupGapMs : 0
+  let lastPersistedTickMs = 0
 
   let tickRunning = false
   async function runCheck() {
@@ -870,6 +1029,10 @@ export function startScheduleRunner(): NodeJS.Timeout {
     // first tick), not a fixed 60s window -- a late/dropped tick must not let a
     // sparse daily cron's single occurrence slip through a gap unscanned (#621).
     const fromMs = lastCheckMs
+    // Catch-up bookkeeping for this tick's one-line report (see below). Empty
+    // on every normal tick, so the operator only ever hears about real gaps.
+    const caughtUpThisTick: Array<{ task: string; ageMs: number }> = []
+    const staleThisTick: Array<{ task: string; ageMs: number }> = []
 
     // Post-fire timeout watchdog sweep: check every tracked in-flight injection
     // to see if the target session is still busy. If so past TASK_FIRE_TIMEOUT_MS,
@@ -953,7 +1116,8 @@ export function startScheduleRunner(): NodeJS.Timeout {
     tasks.sort((a, b) => taskInjectionRank(a) - taskInjectionRank(b))
     for (const task of tasks) {
       if (!task.enabled) continue
-      if (!cronDueBetween(task.schedule, fromMs, now)) continue
+      const occurrenceMs = cronPrevOccurrence(task.schedule, fromMs, now)
+      if (occurrenceMs == null) continue
 
       // Prevent double-firing across a restart: skip if the task already ran at
       // or after the start of this scan window (its occurrence is already
@@ -961,13 +1125,29 @@ export function startScheduleRunner(): NodeJS.Timeout {
       const lastRun = scheduleLastRun.get(task.name) || 0
       if (lastRun >= fromMs) continue
 
-      // If the occurrence is NOT within a single normal tick of `now`, this tick
-      // is firing it late as a catch-up (process was down/restarting or a tick
-      // was dropped). Recorded via attemptFireTask's lateCatchUpMs param so the
-      // run-history flags it as a late fire rather than an on-time one.
-      const lateCatchUpMs = !cronDueBetween(task.schedule, now - 60000, now)
-        ? now - fromMs
-        : undefined
+      // How late is this occurrence, and is it still worth running? An
+      // occurrence the owning tick never scanned (process down, dropped tick)
+      // is executed as a catch-up while it is still useful, and recorded as
+      // 'missed' + reported once it is not -- the previous code fired anything
+      // inside the flat window regardless of age and dropped everything older
+      // without a word. Age is measured from the tick's own `now`, captured
+      // before any injection, so a slow tick cannot inflate it.
+      const ageMs = now - occurrenceMs
+      const decision = decideCatchUp(task, ageMs)
+      if (decision === 'stale') {
+        logger.warn(
+          { task: task.name, ageMinutes: Math.round(ageMs / 60000), maxAgeMinutes: catchUpMaxAgeMs(task) / 60000 },
+          'Scheduled occurrence missed while the scheduler was down and is too stale to catch up -- recording as missed',
+        )
+        staleThisTick.push({ task: task.name, ageMs })
+        const missedTargets = task.agent === 'all'
+          ? [MAIN_AGENT_ID, ...listAgentNames().filter(a => isAgentRunning(a))]
+          : [task.agent || MAIN_AGENT_ID]
+        for (const agentName of missedTargets) appendTaskRun(task.name, agentName, 'missed')
+        continue
+      }
+      const lateCatchUpMs = decision === 'catch-up' ? ageMs : undefined
+      if (lateCatchUpMs != null) caughtUpThisTick.push({ task: task.name, ageMs })
 
       // type='command' tasks run a raw shell command directly -- no LLM, no
       // tmux, no target agent. They self-manage failure streaks + Telegram
@@ -1054,11 +1234,26 @@ export function startScheduleRunner(): NodeJS.Timeout {
       }
     }
 
+    // Tell the operator, in one line, what the gap cost. Only fires when this
+    // tick actually caught something up or declared something too stale, which
+    // in steady state is never.
+    if (caughtUpThisTick.length || staleThisTick.length) {
+      sendCatchUpSummary(caughtUpThisTick, staleThisTick, pendingStartupGapMs || (now - fromMs))
+    }
+    pendingStartupGapMs = 0
+
     // Advance the scan window so the next tick starts exactly where this one
     // ended. Unconditional (even on busy-skip/error, which the pending-retry
     // queue owns) so the windows stay contiguous and no occurrence is scanned
     // twice or skipped.
     lastCheckMs = now
+    // Liveness stamp for the NEXT process start's catch-up window. Written
+    // after the scan so a crash mid-tick leaves the older (wider) stamp behind
+    // and the occurrences of the crashed tick get re-scanned rather than lost.
+    if (now - lastPersistedTickMs >= TICK_STATE_PERSIST_INTERVAL_MS) {
+      persistLastTickMs(now)
+      lastPersistedTickMs = now
+    }
     } finally {
       tickRunning = false
     }

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -53,6 +53,13 @@ export interface ScheduledTask {
   //   exit 0 + empty stdout  → run LLM normally
   //   non-zero exit          → log warning, run LLM anyway (fail-open)
   preCheck?: string
+  // How stale a MISSED occurrence may be and still be executed as a catch-up
+  // after the scheduler was down (host powered off, dashboard restart). Unset
+  // uses the per-type default in DEFAULT_CATCHUP_MAX_AGE_MIN; 0 disables
+  // catch-up for this task entirely (only on-time ticks run it); a negative
+  // value means "always catch up, however late". Occurrences older than the
+  // limit are recorded as a 'missed' run and reported, never silently dropped.
+  catchUpMaxAgeMinutes?: number
   // Manifest-style requirements (Roitman 22.5). When mcp_servers is set, the
   // runner pre-checks each named MCP server has a live process under the
   // target session before injecting the prompt; a dead server defers the task
@@ -90,7 +97,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const skillContent = hasSkill ? readFileOr(skillPath, '') : ''
   const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; requires?: { mcp_servers?: unknown } } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: unknown; requires?: { mcp_servers?: unknown } } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
@@ -111,8 +118,16 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
     timeoutMs: config.timeoutMs,
     failThreshold: config.failThreshold,
     preCheck: config.preCheck,
+    catchUpMaxAgeMinutes: parseCatchUpMaxAge(config.catchUpMaxAgeMinutes),
     requires: parseRequires(config.requires),
   }
+}
+
+// Only a finite number is a policy; anything else (string, null, NaN) is
+// treated as absent so a malformed config falls back to the per-type default
+// instead of disabling catch-up by accident.
+export function parseCatchUpMaxAge(raw: unknown): number | undefined {
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined
 }
 
 // Accept only a string array for requires.mcp_servers; anything else is
@@ -138,7 +153,7 @@ export function listScheduledTasks(): ScheduledTask[] {
 
 export function writeScheduledTask(
   taskName: string,
-  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string },
+  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: number },
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
@@ -169,6 +184,7 @@ export function writeScheduledTask(
   if (data.timeoutMs !== undefined) config.timeoutMs = data.timeoutMs
   if (data.failThreshold !== undefined) config.failThreshold = data.failThreshold
   if (data.preCheck !== undefined) config.preCheck = data.preCheck
+  if (data.catchUpMaxAgeMinutes !== undefined) config.catchUpMaxAgeMinutes = data.catchUpMaxAgeMinutes
   if (data.description !== undefined) config.description = data.description
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))


### PR DESCRIPTION
The startup scan window was a flat `now - 30 min`, so an outage longer than that dropped every occurrence inside it **without a fire, a retry row or an alert**. On 2026-07-29 a dawn host crash swallowed a weekly research task, a fleet research run and the morning briefing here; the gap surfaced only because the operator asked hours later. The same class of silence had already killed a `type: command` token refresher for four days.

Widening the flat window is not the fix -- that just replays day-old crons at random hours. This is two parts:

**1. The window covers the actual downtime.** The runner stamps its liveness to `store/schedule-tick-state.json` (throttled to 60s) and seeds the first scan window from it, capped at 24h. A missing stamp falls back to the historical 30 min, so first boot is unchanged. A stamp from the future (clock jumped back) is rejected rather than producing a negative-length window that scans nothing. The stamp is written *after* the scan, so a crash mid-tick leaves the wider stamp behind and that tick is re-scanned rather than lost.

**2. Each missed occurrence is decided on its own staleness.** `decideCatchUp` returns `on-time` / `catch-up` / `stale`. Budgets are per type -- 3h for operator-facing tasks, 30 min for short-cadence heartbeats (the next tick is already on its way), 24h for cheap idempotent `command` monitors -- and overridable per task with `catchUpMaxAgeMinutes` (`0` disables catch-up without disabling the schedule, negative means always). A `stale` occurrence is recorded as a `missed` run and named in the report; it is never silently dropped.

Either way the operator gets one line naming what was caught up and what was too stale to run. A tick that caught nothing up sends nothing, so steady state is unchanged.

`cronPrevOccurrence` is new in `cron.ts` and returns the occurrence time; `cronDueBetween` delegates to it. "Is it due" and "how late is it" are different questions and the old boolean could not answer the second.

One subtlety worth flagging: `DEFAULT_CATCHUP_MAX_AGE_MIN` falls back to the `task` budget for an unknown type. `task-config.json`s `type` is cast, not validated, and this install runs a `type: "dream-engine"` schedule -- an undefined lookup would make every comparison `NaN` and declare that task stale forever, recreating the exact bug being fixed.

**Verification.** 25 new unit tests covering the window seeding, the staleness policy and the occurrence math, plus the existing scheduler suites (111 tests) green. Verified live: with a 2h liveness stamp, a schedule due 1h earlier executed as a catch-up and the summary was delivered, while every real schedule with a recent `lastRun` was correctly left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)