### PR TITLE
fix(taskstate): replay the handover record after a crash restart, and for the main agent

### DIFF
--- a/scripts/hooks/taskstate-replay.py
+++ b/scripts/hooks/taskstate-replay.py
@@ -51,15 +51,41 @@ def _token():
         return ""
 
 
+def _main_agent_id():
+    """MAIN_AGENT_ID from env, else .env, else the upstream default."""
+    v = os.environ.get("MAIN_AGENT_ID")
+    if v and v.strip():
+        return v.strip()
+    try:
+        with open(os.path.join(_project_root(), ".env")) as f:
+            for line in f:
+                if line.startswith("MAIN_AGENT_ID="):
+                    return line.split("=", 1)[1].strip().strip('"')
+    except Exception:
+        pass
+    return "marveen"
+
+
 def _agent_id_from_cwd(cwd):
-    # agents/<name>/... -> <name>; the main agent runs from the project root.
+    # agents/<name>/... -> <name>; the project root -> the MAIN agent.
+    #
+    # The main agent used to return None here, i.e. it silently never got its
+    # task-state back (2026-07-27). That was never a deliberate exclusion: the
+    # record is written per agent_id and the main agent writes one exactly like
+    # a sub-agent does, so there was nothing to protect against -- only a
+    # missing branch. It matters most for the main agent, which is the one
+    # holding the owner-facing threads when a respawn hits.
     if not cwd:
         return None
-    parts = os.path.normpath(cwd).split(os.sep)
+    root = os.path.normpath(_project_root())
+    norm = os.path.normpath(cwd)
+    parts = norm.split(os.sep)
     if "agents" in parts:
         i = parts.index("agents")
         if i + 1 < len(parts):
             return parts[i + 1]
+    if norm == root:
+        return _main_agent_id()
     return None
 
 

--- a/src/__tests__/agent-taskstate.test.ts
+++ b/src/__tests__/agent-taskstate.test.ts
@@ -33,8 +33,20 @@ describe('shouldReplayTaskState', () => {
   it('replays on resume too', () => {
     expect(shouldReplayTaskState(rec(), 'resume', NOW + 1000)).toBe(true)
   })
-  it('does NOT replay on cold startup', () => {
-    expect(shouldReplayTaskState(rec(), 'startup', NOW + 1000)).toBe(false)
+  // A crash/watchdog respawn mid-task arrives as source=startup, so withholding
+  // the record there defeated the feature's whole purpose (2026-07-27).
+  it('replays on startup too (crash respawn mid-task)', () => {
+    expect(shouldReplayTaskState(rec(), 'startup', NOW + 1000)).toBe(true)
+  })
+  it('does NOT replay an unknown source', () => {
+    expect(shouldReplayTaskState(rec(), 'clear', NOW + 1000)).toBe(false)
+  })
+  it('does NOT replay an empty record on startup either', () => {
+    const empty = rec({ doneSteps: [], alreadyDelegated: [], nextAction: '', pendingDecision: '', summary: 'idle' })
+    expect(shouldReplayTaskState(empty, 'startup', NOW + 1000)).toBe(false)
+  })
+  it('does NOT replay a consumed record on startup either', () => {
+    expect(shouldReplayTaskState(rec({ consumed: true }), 'startup', NOW + 1000)).toBe(false)
   })
   it('does NOT replay a consumed record', () => {
     expect(shouldReplayTaskState(rec({ consumed: true }), 'compact', NOW + 1000)).toBe(false)

--- a/src/web/agent-taskstate.ts
+++ b/src/web/agent-taskstate.ts
@@ -23,9 +23,21 @@ const STORE_DIR = join(PROJECT_ROOT, 'store', 'agent-taskstate')
 // truly abandoned record without risking dropping a real long-running task.
 export const TASKSTATE_TTL_MS = 12 * 60 * 60 * 1000
 
-// SessionStart sources we replay on. NOT 'startup' (a cold start has no
-// in-flight task to resume) -- only an in-place compact or a resume/respawn.
-const REPLAY_SOURCES = new Set(['compact', 'resume'])
+// SessionStart sources we replay on. 'startup' IS included (2026-07-27): the
+// original exclusion assumed a cold start is always a PLANNED one with no
+// in-flight task. That holds for an operator restart, and is exactly wrong for
+// the case this feature exists for -- a crash/watchdog respawn mid-task, which
+// the harness also reports as source=startup. Observed: bigme hard-restarted at
+// 07:31 in the middle of an update+debug thread and came back with only the
+// channel-ledger replay (time-ordered chat turns), because the structured
+// task-state was withheld on exactly the start that needed it most.
+//
+// Nothing else loosens: an unconsumed, non-empty, within-TTL record is still
+// required, and the consumed flag still guarantees a single replay -- so a
+// planned restart right after finishing work replays nothing (the record was
+// either consumed or is empty), and at worst a stale-but-unconsumed record
+// costs one short injected block that the agent can discard.
+const REPLAY_SOURCES = new Set(['compact', 'resume', 'startup'])
 
 export interface AgentTaskState {
   agent: string
@@ -91,7 +103,10 @@ const SENTINEL = '=== TASK-FOLYTATAS (NEM uj feladat) ==='
 export function buildTaskStateInjection(r: AgentTaskState): string {
   const lines: string[] = [
     SENTINEL,
-    'A kontextusod tomoritodott egy FOLYAMATBAN LEVO feladat kozben. Ez NEM uj feladat -- FOLYTASD onnan ahol abbamaradt. NE INDITSD ujra a mar kesz lepeseket, es NE delegald ujra amit mar atadtal.',
+    // Source-neutral wording: the same record is replayed after a compact, a
+    // resume AND a crash respawn (source=startup, added 2026-07-27), so it must
+    // not claim a compact happened.
+    'A sessiond ujraindult egy FOLYAMATBAN LEVO feladat kozben (tomorites, resume vagy osszeomlas utani ujraindulas). Ez NEM uj feladat -- FOLYTASD onnan ahol abbamaradt. NE INDITSD ujra a mar kesz lepeseket, es NE delegald ujra amit mar atadtal.',
   ]
   if (r.summary.trim()) lines.push(`FELADAT: ${r.summary.trim()}`)
   if (r.doneSteps.length) lines.push('MAR KESZ (NE ismeteld meg):\n' + r.doneSteps.map((s) => `  - ${s}`).join('\n'))


### PR DESCRIPTION
The agent task-state record exists so a session that dies mid-task comes back knowing what it was doing. Two gaps meant it did not fire in the case it was built for.

**It was withheld on `source=startup`.** `REPLAY_SOURCES` was `{compact, resume}`, on the assumption that a cold start has no in-flight task. That holds for a planned operator restart and is exactly wrong for a crash or watchdog respawn, which the harness also reports as `source=startup`. Observed here: the main agent hard-restarted mid-thread and came back with only the channel ledger (time-ordered chat turns), because the structured task-state was suppressed on precisely the start that needed it.

Nothing else loosens: an unconsumed, non-empty, within-TTL record is still required, and the consumed flag still guarantees a single replay. A planned restart right after finishing work replays nothing (the record is consumed or empty). Worst case is one short injected block the agent can discard.

**The main agent never got a replay at all.** `_agent_id_from_cwd()` mapped `agents/<name>/...` to `<name>` and returned `None` everywhere else, so the project root -- where the main agent runs -- resolved to no agent id. That is a missing branch, not a deliberate exclusion: the record is written per agent id and the main agent writes one exactly like a sub-agent does. It matters most there, since the main agent holds the owner-facing threads when a respawn hits. The root now maps to `MAIN_AGENT_ID` (env, then `.env`, then the upstream default), so a renamed install resolves to its own id instead of a hardcoded name.

The injected header no longer claims a compact happened, since the same record is now replayed after a compact, a resume and a crash respawn.

**Verification.** `src/__tests__/agent-taskstate.test.ts` extended and green (19 tests), `tsc --noEmit` clean, hook compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)