### PR TITLE
fix(memory): raise the Ollama embedding timeout to 90s so large memories vectorize

### DIFF
--- a/src/tool-timeouts.ts
+++ b/src/tool-timeouts.ts
@@ -7,5 +7,8 @@ export const TOOL_TIMEOUTS = {
   'telegram':        10_000,
   'github':          10_000,
   'slack':           10_000,
-  'ollama-embedding': 30_000,
+  // CPU-only Ollama embeds a ~1500-char memory in 40-60s, which overran the
+  // former 30s deadline and left large memories permanently un-vectorized
+  // (search silently fell back to FTS). 90s covers the slow CPU path.
+  'ollama-embedding': 90_000,
 } as const


### PR DESCRIPTION
On a CPU-only host, embedding a ~1500-character memory takes 40-60s. The 30s deadline cut those calls off, and the failure is silent in the worst way: the memory is stored, the embedding is not, and semantic search quietly falls back to FTS for exactly the long, content-rich memories it would have helped most with. The backfill endpoint then keeps reporting work done while rows with a NULL embedding persist, because every retry hits the same wall.

90s covers the slow CPU path with margin. Hosts with a GPU are unaffected: the timeout is a ceiling, not a delay.

One line plus the reasoning as a comment, so the next person does not tighten it back without knowing what it costs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)