### PR TITLE
fix(dashboard): hide the Team tab on the main agent panel

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2969,7 +2969,24 @@ async function openMarveenDetail() {
   openModal(agentDetailOverlay)
 }
 
+// `readOnly` is really "this modal is showing the MAIN agent" -- it is called
+// with true from openMarveenDetail and false from openAgentDetail, which makes
+// it the one hook both open-paths share. Anything that must differ for the main
+// agent belongs here; putting it in openAgentDetail alone silently no-ops for
+// the main agent, whose panel never runs that function.
 function applyMarveenReadonlyMode(readOnly) {
+  // The Team tab describes a SUB-agent's place in the hierarchy: role
+  // (leader | member), who it reports to, who it delegates to. None of it
+  // applies to the main agent, which has no team record and cannot have one.
+  // Its role is 'main', a tier ABOVE leader, and it is an implicit trusted peer
+  // of every agent (see isTrustedPeer), so there is nothing to configure. Shown
+  // anyway, the tab printed the literal fallback "member" and invited the
+  // operator to promote the main agent to 'leader' -- a demotion, and one that
+  // cannot be saved either way: the PUT targets /api/agents/<main>/team, which
+  // 404s because no agents/<main>/ directory exists. Hide the whole tab, same
+  // reasoning as claudePlanGroup.
+  const teamTabBtn = document.querySelector('#agentTabNav .tab-btn[data-tab="team"]')
+  if (teamTabBtn) teamTabBtn.hidden = readOnly
   const textareaIds = ['editClaudeMd', 'editSoulMd', 'editMcpJson']
   // saveModelBtn stays VISIBLE but disabled for Marveen, so the settings tab
   // doesn't look like the row is missing -- the other save buttons (tied to


### PR DESCRIPTION
The Team tab configures a **sub-agent** s place in the hierarchy: role (`leader` | `member`), who it reports to, who it delegates to, who it trusts. None of it applies to the main agent, and the panel said otherwise.

`openMarveenDetail` reuses the agent-detail modal, but the identity payload it builds `currentAgent` from carries no `team` object. The tab therefore rendered its literal fallback and displayed the main agent as **member** -- inviting the operator to promote it to `leader`, which is a *demotion*: `/api/team/graph` gives the main agent the role `main`, a tier above `leader`, and `isTrustedPeer` already treats it as an implicit trusted peer of every agent. There is nothing to configure.

The setting could not be applied either. Saving PUTs to `/api/agents/<main>/team`, which 404s on `existsSync(agentDir(name))` because the main agent has no directory under `agents/` -- it is not profile-managed (see the note on `resolveSecurityProfileId`). So the operator was offered a control that misstated the current state, proposed a downgrade, and failed on save. That is how it was found here: the owner tried to set the main agent to `leader` and could not.

Hiding the tab is the same treatment `claudePlanGroup` already gets a few lines below, for the same reason.

**Where the fix goes matters.** It is in `applyMarveenReadonlyMode`, not `openAgentDetail`: that function is the only hook both open-paths share (`true` from `openMarveenDetail`, `false` from `openAgentDetail`). Placing it in `openAgentDetail` looks right and silently no-ops, because the main agent panel never runs that function. The first attempt landed there and changed nothing in the browser.

**Verification.** Checked live over CDP in a real browser, not just by reading: sub-agent open -> tab present; main agent open -> `teamTabHidden: true`; reopening a sub-agent -> tab back (no sticky hide). `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)