### PR TITLE
fix(scheduler): make the stuck-task threshold per task, not one global number

### DIFF
--- a/src/__tests__/schedule-task-timeout.test.ts
+++ b/src/__tests__/schedule-task-timeout.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { decideTaskTimeout, TASK_FIRE_GRACE_MS, TASK_FIRE_TIMEOUT_MS } from '../web/schedule-runner.js'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { decideTaskTimeout, resolveStuckTimeoutMs, TASK_FIRE_GRACE_MS, TASK_FIRE_TIMEOUT_MS } from '../web/schedule-runner.js'
 import type { TaskInflightEntry } from '../web/schedule-runner.js'
 
 // Tests for the post-fire timeout watchdog.
@@ -156,5 +158,57 @@ describe('fix-revert guard: alert case is load-bearing', () => {
     // this assertion would fail: that is the correct behaviour.
     expect(result).toBe('alert')
     expect(result).not.toBe('hold')
+  })
+})
+
+// --- Per-task stuck threshold ---
+//
+// TASK_FIRE_TIMEOUT_MS is one global number. It is the right default for the
+// common case (a short-cadence heartbeat still busy after 5 minutes IS a real
+// signal) and wrong for a task whose whole job is to think for a while: a
+// nightly analysis run was declared a "possible hang" five minutes in, on
+// 2026-07-30 at 02:12, and finished normally at 02:18. The operator got a
+// false alarm about a task doing exactly what it was written to do.
+describe('resolveStuckTimeoutMs: the threshold is per task', () => {
+  const MIN = 60_000
+
+  it('falls back to the global default when unset', () => {
+    expect(resolveStuckTimeoutMs({})).toBe(TASK_FIRE_TIMEOUT_MS)
+  })
+
+  it('honours an explicit longer budget (the nightly analysis case)', () => {
+    expect(resolveStuckTimeoutMs({ stuckAfterMinutes: 20 })).toBe(20 * MIN)
+  })
+
+  it('a malformed or non-positive value falls back to the default, never to NaN', () => {
+    expect(resolveStuckTimeoutMs({ stuckAfterMinutes: NaN })).toBe(TASK_FIRE_TIMEOUT_MS)
+    expect(resolveStuckTimeoutMs({ stuckAfterMinutes: 0 })).toBe(TASK_FIRE_TIMEOUT_MS)
+    expect(resolveStuckTimeoutMs({ stuckAfterMinutes: -5 })).toBe(TASK_FIRE_TIMEOUT_MS)
+    expect(resolveStuckTimeoutMs({ stuckAfterMinutes: 'twenty' as unknown as number })).toBe(TASK_FIRE_TIMEOUT_MS)
+  })
+
+  it('clamps below one minute so the alert cannot fire inside startup noise', () => {
+    expect(resolveStuckTimeoutMs({ stuckAfterMinutes: 0.1 })).toBe(MIN)
+  })
+
+  it('clamps to the tracking window, so a huge value cannot silently disable the alert', () => {
+    // Entries are evicted at maxTrackMs regardless, so anything above it would
+    // mean "never alert" while still looking like a threshold.
+    expect(resolveStuckTimeoutMs({ stuckAfterMinutes: 60 * 24 })).toBe(MAX_TRACK)
+  })
+
+  it('the resolved budget actually drives the decision', () => {
+    const at6min = 6 * MIN
+    const opts = { graceMs: GRACE, maxTrackMs: MAX_TRACK }
+    // Default budget: 6 minutes of continuous busy is a hang.
+    expect(decideTaskTimeout(makeEntry(), 'busy', at6min, { ...opts, timeoutMs: resolveStuckTimeoutMs({}) })).toBe('alert')
+    // 20-minute budget: the same 6 minutes is just work in progress.
+    expect(decideTaskTimeout(makeEntry(), 'busy', at6min, { ...opts, timeoutMs: resolveStuckTimeoutMs({ stuckAfterMinutes: 20 }) })).toBe('hold')
+  })
+
+  it('the sweep uses the entry budget, not the global constant (fix-revert guard)', () => {
+    const src = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+    expect(src).toMatch(/timeoutMs: entry\.timeoutMs,/)
+    expect(src).toMatch(/timeoutMs: resolveStuckTimeoutMs\(task\),/)
   })
 })

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -92,6 +92,38 @@ export interface TaskInflightEntry {
   host: string | null
   injectedAt: number
   alerted: boolean
+  // Per-task stuck threshold, resolved at injection time from the task config
+  // (see resolveStuckTimeoutMs). Captured on the entry rather than looked up
+  // during the sweep so an edit to the schedule mid-run cannot move the
+  // goalposts under an already-running injection.
+  timeoutMs: number
+}
+
+// How long a fired task may stay busy before the watchdog calls it stuck.
+// TASK_FIRE_TIMEOUT_MS is the right default for the common case -- a
+// short-cadence heartbeat still running after 5 minutes is a real signal --
+// but it is wrong for a task whose whole job is to think for a while. The
+// nightly analysis run tripped it at 02:12 on 2026-07-30 while working
+// normally and finished fine six minutes later: a false "possible hang" alert
+// on a task doing exactly what it was written to do. Per-task override:
+//
+//   stuckAfterMinutes unset / malformed -> TASK_FIRE_TIMEOUT_MS
+//   positive                            -> that many minutes
+//
+// Clamped at both ends. Below one minute the alert would fire inside the
+// normal startup noise; above TASK_FIRE_MAX_TRACK_MS the entry is evicted
+// before the threshold could ever be reached, so a larger value would silently
+// mean "never alert" -- exactly the kind of quiet disable this codebase keeps
+// getting bitten by. An operator who truly wants no alert should say so in a
+// way that is visible, not by writing a big number.
+export function resolveStuckTimeoutMs(
+  task: Pick<ScheduledTask, 'stuckAfterMinutes'>,
+  defaultMs: number = TASK_FIRE_TIMEOUT_MS,
+  maxMs: number = TASK_FIRE_MAX_TRACK_MS,
+): number {
+  const configured = task.stuckAfterMinutes
+  if (typeof configured !== 'number' || !Number.isFinite(configured) || configured <= 0) return defaultMs
+  return Math.min(Math.max(configured * 60_000, 60_000), maxMs)
 }
 
 // Active task/heartbeat injections keyed by `${taskName}@${agentName}`.
@@ -667,6 +699,7 @@ async function attemptFireTask(
       host,
       injectedAt: now,
       alerted: false,
+      timeoutMs: resolveStuckTimeoutMs(task),
     })
 
     // Post-send verify: if the agent started a new turn during our chunk
@@ -935,8 +968,13 @@ function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void
     logger.info({ task: entry.taskName, agent: entry.agentName, cardId: movedCardId }, 'task-timeout: matching kanban card moved to waiting')
   }
 
+  // Naming the threshold turns "possible hang" into something the operator can
+  // judge: a long-running analysis task that legitimately needs more time is
+  // then one config line away, instead of a recurring 3am mystery.
+  const thresholdMinutes = Math.round(entry.timeoutMs / 60000)
   const text = [
     `[${BOT_NAME} scheduler] A(z) "${entry.taskName}" (${entry.agentName}) ütemezett feladat ${ageMinutes} perce fut -- lehetséges beakadás.`,
+    `A riasztási küszöb ennél a feladatnál ${thresholdMinutes} perc; ha ez a feladat jogosan fut ennél tovább, allitsd a task-config.json "stuckAfterMinutes" mezojet.`,
     'Az ágensben megtekintheted; a dashboard /Ütemezések oldalán visszavonható ha kell.',
   ].join('\n')
   ;(async () => {
@@ -1043,7 +1081,7 @@ export function startScheduleRunner(): NodeJS.Timeout {
       const state = pane != null ? detectPaneState(pane) : null
       const decision = decideTaskTimeout(entry, state, now, {
         graceMs: TASK_FIRE_GRACE_MS,
-        timeoutMs: TASK_FIRE_TIMEOUT_MS,
+        timeoutMs: entry.timeoutMs,
         maxTrackMs: TASK_FIRE_MAX_TRACK_MS,
       })
       if (decision === 'clear') {

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -60,6 +60,13 @@ export interface ScheduledTask {
   // value means "always catch up, however late". Occurrences older than the
   // limit are recorded as a 'missed' run and reported, never silently dropped.
   catchUpMaxAgeMinutes?: number
+  // How long this task may run before the post-fire watchdog calls it stuck and
+  // alerts the operator. Unset uses the global TASK_FIRE_TIMEOUT_MS (5 min),
+  // which is right for a short-cadence heartbeat and wrong for a task whose job
+  // is to think for a while. Clamped at both ends, see resolveStuckTimeoutMs.
+  // DISTINCT from catchUpMaxAgeMinutes: that one judges a MISSED occurrence's
+  // staleness before firing; this one judges a RUNNING injection's age.
+  stuckAfterMinutes?: number
   // Manifest-style requirements (Roitman 22.5). When mcp_servers is set, the
   // runner pre-checks each named MCP server has a live process under the
   // target session before injecting the prompt; a dead server defers the task
@@ -97,7 +104,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const skillContent = hasSkill ? readFileOr(skillPath, '') : ''
   const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: unknown; requires?: { mcp_servers?: unknown } } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: unknown; stuckAfterMinutes?: unknown; requires?: { mcp_servers?: unknown } } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
@@ -119,15 +126,23 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
     failThreshold: config.failThreshold,
     preCheck: config.preCheck,
     catchUpMaxAgeMinutes: parseCatchUpMaxAge(config.catchUpMaxAgeMinutes),
+    stuckAfterMinutes: parseFiniteMinutes(config.stuckAfterMinutes),
     requires: parseRequires(config.requires),
   }
 }
 
 // Only a finite number is a policy; anything else (string, null, NaN) is
-// treated as absent so a malformed config falls back to the per-type default
-// instead of disabling catch-up by accident.
-export function parseCatchUpMaxAge(raw: unknown): number | undefined {
+// treated as absent so a malformed config falls back to the built-in default
+// instead of disabling a guard by accident.
+export function parseFiniteMinutes(raw: unknown): number | undefined {
   return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined
+}
+
+// Same acceptance rule, kept as a named export because the catch-up call sites
+// and tests predate the generic helper (range semantics live downstream in
+// catchUpMaxAgeMs / resolveStuckTimeoutMs, not here).
+export function parseCatchUpMaxAge(raw: unknown): number | undefined {
+  return parseFiniteMinutes(raw)
 }
 
 // Accept only a string array for requires.mcp_servers; anything else is
@@ -153,7 +168,7 @@ export function listScheduledTasks(): ScheduledTask[] {
 
 export function writeScheduledTask(
   taskName: string,
-  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: number },
+  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: number; stuckAfterMinutes?: number },
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
@@ -185,6 +200,7 @@ export function writeScheduledTask(
   if (data.failThreshold !== undefined) config.failThreshold = data.failThreshold
   if (data.preCheck !== undefined) config.preCheck = data.preCheck
   if (data.catchUpMaxAgeMinutes !== undefined) config.catchUpMaxAgeMinutes = data.catchUpMaxAgeMinutes
+  if (data.stuckAfterMinutes !== undefined) config.stuckAfterMinutes = data.stuckAfterMinutes
   if (data.description !== undefined) config.description = data.description
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))


### PR DESCRIPTION
The post-fire watchdog alerts when an injected task stays busy past `TASK_FIRE_TIMEOUT_MS` (5 min). That is the right default for the common case -- a 30-minute-cadence heartbeat still running after five minutes **is** a real signal -- but it is applied to every task equally, including ones whose entire purpose is to run long.

**2026-07-30 02:12:** a nightly analysis task was reported to the operator as a "possible hang" five minutes into a run that completed normally at 02:18. Nothing was wrong: the task was reading the database, checking the board and doing a web search, exactly as written. The first alert this watchdog ever sent on this install was a false one, which is the fastest way to teach an operator to ignore it.

**The change.** New optional `stuckAfterMinutes` in `task-config.json`, resolved at injection time and captured on the in-flight entry -- so editing the schedule mid-run cannot move the goalposts under an already-running injection. Unset keeps today s behaviour exactly.

The value is clamped at both ends:

- below one minute the alert would fire inside normal startup noise;
- above `TASK_FIRE_MAX_TRACK_MS` the entry is evicted before the threshold could ever be reached, so a large number would silently mean *never alert* while still looking like a threshold. That quiet-disable shape is the failure mode this file has been bitten by before, so an operator who wants no alert has to say so visibly rather than by writing a big number.

The alert text now names the threshold in effect and points at the config field, so the next false positive carries its own fix instead of being a recurring 3am mystery.

**Verification.** `resolveStuckTimeoutMs` is pure and covered by 7 new cases in the existing `schedule-task-timeout` suite (default, explicit budget, malformed/non-positive, both clamps, and that the resolved budget actually flips `decideTaskTimeout` from `alert` to `hold` at the same 6-minute mark). Includes a fix-revert guard asserting the sweep reads `entry.timeoutMs` rather than the global constant. Neighbouring scheduler suites green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)