### PR TITLE
fix(alerts): stop re-alerting the owner every 30 minutes about a still-dead agent

### DIFF
--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -177,7 +177,9 @@ const AGENT_BUSY_DEFER_MAX_MS = 30 * 60 * 1000 // 30m
 // fresh (re-stamped by each post-respawn probe, cleared on recovery).
 const PLUGIN_ABSENT_MAX_RESTART_ATTEMPTS = 1
 const PLUGIN_ABSENT_TTL_MS = 15 * 60 * 1000
-const PLUGIN_ALERT_DEDUP_MS = 30 * 60 * 1000
+// Re-alert cadence while the main plugin is STILL down. The first alert is the
+// informative one; keep repeats to a few hours (owner request 2026-07-30).
+const PLUGIN_ALERT_DEDUP_MS = 3 * 60 * 60 * 1000
 
 // Stuck channel-input recovery (MAIN session only). A channel notification
 // delivered while Boss is busy can be parked as plain text at the ❯ prompt
@@ -441,7 +443,7 @@ const paneErrorState: Map<string, PaneErrorAlertState> = new Map()
 // spell alive across brief non-error blips (null capture, mid-flight
 // busy) so a flapping but genuinely wedged session still alerts.
 const PANE_ERROR_CONFIRM_MS = 120_000
-const PANE_ERROR_DEDUP_MS = 30 * 60 * 1000
+const PANE_ERROR_DEDUP_MS = 3 * 60 * 60 * 1000
 const PANE_ERROR_CLEAR_MS = 5 * 60 * 1000
 
 // Per-session tracking for a session parked in a blocking interactive menu

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -35,7 +35,11 @@ const NOTIFY_SCRIPT = join(PROJECT_ROOT, 'scripts', 'notify.sh')
 const PROBE_INTERVAL_MS = 3 * 60 * 1000 // 3 min
 const INITIAL_DELAY_MS = 90_000         // after boot-grace, offset from other watchers
 const DEAD_PROBE_THRESHOLD = 3          // ~9 min of consecutive dead-token probes before acting
-const ESCALATION_COOLDOWN_MS = 30 * 60 * 1000 // 1 alert / agent / 30 min (re-alerts if still dead)
+// Repeat-alert cadence for a still-dead token. The first escalation is what
+// matters; every re-alert after it carries no new information, so keep it rare
+// (owner request 2026-07-30: "elég pár óránként jelezni" -- a 30 min cadence
+// produced ~10 identical alerts in one morning).
+const ESCALATION_COOLDOWN_MS = 3 * 60 * 60 * 1000 // 1 alert / agent / 3h (re-alerts if still dead)
 
 export interface ReauthHealerState {
   consecutiveDead: number


### PR DESCRIPTION
## Problem

Three watchers re-alert the owner on a 30 minute cooldown for as long as the broken state persists:

- `reauth-healer.ts` `ESCALATION_COOLDOWN_MS` -- dead OAuth token on a live session
- `channel-monitor.ts` `PLUGIN_ALERT_DEDUP_MS` -- main channel plugin still down
- `channel-monitor.ts` `PANE_ERROR_DEDUP_MS` -- session wedged on a thinking-block API error

On 2026-07-30 one agent's dead token produced ~10 identical Telegram alerts in a single morning (`dashboard.log`: `reauth-healer: dead OAuth token on live session -- escalating to owner`). The owner asked for a few hours between repeats.

## Change

All three repeat cooldowns 30 min -> 3 h. Detection is untouched: `PANE_ERROR_CONFIRM_MS`, `DEAD_PROBE_THRESHOLD`, `AGENT_DOWN_CONFIRM_MS` and the first escalation of a down-spell keep their current timing, so a genuine outage is still reported as promptly as before. Only the informationless repeats get rarer.

Not touched: the `alert-busy` and max-restart-attempts branches in `channel-monitor.ts` already fire once per down-spell (`agentBusyDeferAlerted`), and the auto-restart WARN logs never reach Telegram.

## Test

`npm run build` clean; no test hardcodes the three constants (`grep -rn` over `src/`). Verified live on the Jarvis install: dashboard restarted, health 200, `dist/` carries the new values.