### PR TITLE
fix(install): wait out the apt/dpkg lock instead of dying on it (APTLOCK1)

### DIFF
--- a/install-lang.sh
+++ b/install-lang.sh
@@ -244,6 +244,25 @@ _t() {
     # ── Linux-specific ───────────────────────────────────────────────
     en:linux.low_ram_prefix) echo "Low RAM:" ;;
     hu:linux.low_ram_prefix) echo "Kevés memória:" ;;
+    # APTLOCK1: dpkg/apt lock waiting (fresh Ubuntu/WSL: apt-daily holds it briefly)
+    en:linux.apt_lock_waiting_prefix) echo "The package manager is busy (another process holds the dpkg lock):" ;;
+    hu:linux.apt_lock_waiting_prefix) echo "A csomagkezelő foglalt (egy másik folyamat fogja a dpkg zárolást):" ;;
+    en:linux.apt_lock_transient_hint) echo "On a fresh system this is usually the automatic update (apt-daily/unattended-upgrades) and clears on its own -- waiting up to 5 minutes..." ;;
+    hu:linux.apt_lock_transient_hint) echo "Friss rendszeren ez általában az automatikus frissítés (apt-daily/unattended-upgrades), magától elenged -- várakozás legfeljebb 5 percig..." ;;
+    en:linux.apt_lock_still_prefix) echo "still held by:" ;;
+    hu:linux.apt_lock_still_prefix) echo "még mindig fogja:" ;;
+    en:linux.apt_lock_freed_prefix) echo "Package manager lock released after" ;;
+    hu:linux.apt_lock_freed_prefix) echo "A csomagkezelő zárolás felszabadult" ;;
+    en:linux.apt_lock_unknown) echo "Cannot check who holds the package-manager lock (fuser not installed) -- if it is busy, apt itself will wait up to 3 minutes." ;;
+    hu:linux.apt_lock_unknown) echo "Nem tudom megnézni, ki fogja a csomagkezelő zárolást (nincs fuser) -- ha foglalt, az apt maga vár rá legfeljebb 3 percig." ;;
+    en:linux.apt_lock_timeout_head) echo "The package-manager lock is STILL held after 5 minutes by:" ;;
+    hu:linux.apt_lock_timeout_head) echo "A csomagkezelő zárolást 5 perc után is fogja:" ;;
+    en:linux.apt_lock_timeout_body1) echo "This is no longer the usual transient auto-update. Check what it is: sudo lsof /var/lib/dpkg/lock-frontend" ;;
+    hu:linux.apt_lock_timeout_body1) echo "Ez már nem a szokásos átmeneti auto-frissítés. Nézd meg, mi az: sudo lsof /var/lib/dpkg/lock-frontend" ;;
+    en:linux.apt_lock_timeout_body2) echo "If it is unattended-upgrades, let it finish (sudo systemctl status unattended-upgrades), then re-run this installer. Do NOT kill a running dpkg." ;;
+    hu:linux.apt_lock_timeout_body2) echo "Ha az unattended-upgrades az, várd meg amíg végez (sudo systemctl status unattended-upgrades), majd indítsd újra ezt a telepítőt. Futó dpkg-t NE lőj ki." ;;
+    en:linux.apt_lock_timeout_fail) echo "Package manager is locked by another process -- re-run the installer once it finished." ;;
+    hu:linux.apt_lock_timeout_fail) echo "A csomagkezelőt egy másik folyamat zárolja -- ha végzett, indítsd újra a telepítőt." ;;
     en:linux.tg_channel_configured) echo "Telegram channel configured" ;;
     hu:linux.tg_channel_configured) echo "Telegram csatorna konfigurálva" ;;
     en:linux.slack_channel_configured) echo "Slack channel configured" ;;

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -140,6 +140,69 @@ if [ -z "$PKG_MANAGER" ]; then
   fail "Nem tamogatott csomagkezelo. Ez a telepito apt-get (Debian/Ubuntu) vagy dnf/yum (Fedora/Nobara/RHEL) rendszert var."
 fi
 
+# ── apt lock kezeles (APTLOCK1) ──────────────────────────────────────
+# Friss Ubuntun/WSL-en az apt-daily / unattended-upgrades az elso percekben
+# MAGATOL elindul es fogja a dpkg zarolast, majd perceken belul elengedi. Ez
+# ATMENETI allapot: a helyes viselkedes a lathato varakozas, nem a hibauzenet
+# (2026-07-30, workshop: "Could not get lock /var/lib/dpkg/lock-frontend...
+# It is held by process 6250" -> "Varatlan hiba... (sor: 240)"). A harom
+# allapotot szethuzzuk: atmeneti (var), vegleges (lejart cap, nevesitett
+# holderrel), ismeretlen (nincs fuser -- kimondjuk, es a DPkg::Lock::Timeout
+# vedohalora hagyatkozunk).
+APT_LOCK_FILES="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock"
+APT_LOCK_WAIT_CAP=300   # 5 perc -- az apt-daily ennyi alatt tipikusan vegez
+# Vedohalo minden apt-get hivasra: az apt sajat, fcntl-szintu varakozasa arra
+# az esetre, ha a pre-flight utan, de a parancs elott ugrik be egy uj holder.
+APT_OPTS="-o DPkg::Lock::Timeout=180"
+
+# stdout: "<pid> <procnev>" ha valaki fogja barmelyik lockot; ures + exit 1 ha
+# szabad. fuser nelkul exit 2 = NEM TUDJUK megallapitani (ismeretlen allapot).
+apt_lock_holder() {
+  command -v fuser &>/dev/null || return 2
+  local l pid name
+  for l in $APT_LOCK_FILES; do
+    [ -e "$l" ] || continue
+    pid=$(sudo fuser "$l" 2>/dev/null | tr -s ' ' '\n' | grep -m1 '[0-9]' || true)
+    if [ -n "$pid" ]; then
+      name=$(ps -o comm= -p "$pid" 2>/dev/null || true)
+      echo "$pid ${name:-?}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+wait_for_apt_lock() {
+  local holder rc waited=0 interval=5
+  holder=$(apt_lock_holder); rc=$?
+  if [ "$rc" -eq 2 ]; then
+    # fuser nincs (minimal image) -- nem tudjuk MEGNEZNI, ki fogja a lockot.
+    # Ezt kimondjuk, es az APT_OPTS timeout-ja kezeli, ha tenyleg fogott.
+    echo -e "  ${DIM}$(_t linux.apt_lock_unknown)${NC}"
+    return 0
+  fi
+  [ "$rc" -ne 0 ] && return 0   # szabad
+  warn "$(_t linux.apt_lock_waiting_prefix) ${holder}"
+  echo -e "  ${DIM}$(_t linux.apt_lock_transient_hint)${NC}"
+  while [ "$waited" -lt "$APT_LOCK_WAIT_CAP" ]; do
+    sleep "$interval"; waited=$((waited + interval))
+    holder=$(apt_lock_holder); rc=$?
+    if [ "$rc" -ne 0 ]; then
+      ok "$(_t linux.apt_lock_freed_prefix) ${waited}s"
+      return 0
+    fi
+    if [ $((waited % 30)) -eq 0 ]; then
+      echo -e "  ${DIM}$(_t linux.apt_lock_still_prefix) ${holder} -- ${waited}s / ${APT_LOCK_WAIT_CAP}s${NC}"
+    fi
+  done
+  # Lejart a cap: ez mar nem "varjunk meg egy kicsit" -- nevesitett holderrel
+  # es kiuttal allunk meg, nem sorszammal.
+  echo -e "${RED}$(_t linux.apt_lock_timeout_head) ${holder}${NC}"
+  echo -e "  $(_t linux.apt_lock_timeout_body1)"
+  echo -e "  $(_t linux.apt_lock_timeout_body2)"
+  fail "$(_t linux.apt_lock_timeout_fail)"
+}
+
 # RAM check: npm build can fail on low-memory instances (e.g. t3.micro)
 if command -v free &>/dev/null; then
   TOTAL_RAM_MB=$(free -m | awk '/^Mem:/ {print $2}')
@@ -205,14 +268,15 @@ if [ -n "$MISSING_PKGS" ]; then
   warn "Hianyzo csomagok:$MISSING_PKGS"
   echo -e "  Telepites sudo-val ($PKG_MANAGER)..."
   if [ "$PKG_MANAGER" = "apt" ]; then
+    wait_for_apt_lock
     if echo "$MISSING_PKGS" | grep -q nodejs; then
       # A nodesource setup-script curl-t igenyel, de csupasz VPS-en (Debian
       # netinst) a curl maga is hianyozhat -- ilyenkor eloszor azt telepitjuk,
       # kulonben a repo-lepes neman kimarad, a disztro sajat (regebbi) nodejs-e
       # telepul, es Debianon az npm (kulon csomag) le se jon -> [1/7] fail.
       if ! command -v curl &>/dev/null; then
-        sudo apt-get update -qq || true
-        sudo apt-get install -y curl -qq || true
+        sudo apt-get $APT_OPTS update -qq || true
+        sudo apt-get $APT_OPTS install -y curl -qq || true
         hash -r
       fi
       echo -e "  Node.js v22 repo hozzaadasa (nodesource)..."
@@ -230,14 +294,14 @@ if [ -n "$MISSING_PKGS" ]; then
         # Fallback: disztro sajat nodejs-e. Debianon az npm kulon csomag,
         # a nodesource-bundle-lel ellentetben nem jon a nodejs-sel magatol.
         warn "nodesource repo hozzaadasa sikertelen -- a disztro sajat nodejs + npm csomagjat telepitem."
-        sudo apt-get update -qq
+        sudo apt-get $APT_OPTS update -qq
         MISSING_PKGS="$MISSING_PKGS npm"
       fi
     else
-      sudo apt-get update -qq
+      sudo apt-get $APT_OPTS update -qq
     fi
     # shellcheck disable=SC2086
-    sudo apt-get install -y $MISSING_PKGS -qq
+    sudo apt-get $APT_OPTS install -y $MISSING_PKGS -qq
   else
     # dnf/yum (Fedora/Nobara/RHEL). A disztro nodejs csomagja v20+ az aktualis
     # kiadasokon, es az npm-et is tartalmazza -- nincs szukseg kulso repora.


### PR DESCRIPTION
## APTLOCK1: az apt/dpkg zarolast ki kell varni, nem elhalni rajta

Eles workshop-lelet (2026-07-30): friss WSL-Ubuntun az apt-daily/unattended-upgrades az elso percekben magatol fogja a dpkg lockot -> a telepito "Could not get lock /var/lib/dpkg/lock-frontend... held by process 6250" + "Varatlan hiba a(z) prerequisites lepesben (sor: 240)" hibaval halt el egy ATMENETI allapoton.

## Viselkedes (harom allapot, oszinten szethuzva)

- **Atmeneti**: `wait_for_apt_lock` legfeljebb 5 percig var, a holdert NEVESITVE (pid + comm, fuser), 30 mp-enkent lathato progresszel; felszabadulaskor "felszabadult Ns utan" es megy tovabb.
- **Vegleges** (cap lejart): megallas a holder NEVEVEL es kiuttal (lsof a lockra; unattended-upgrades-t kivarni; ujrainditani a telepitot; futo dpkg-t NEM kilonni) -- nem csupasz sorszam.
- **Ismeretlen** (nincs fuser a minimal image-en): kimondjuk hogy nem tudjuk megnezni, es az apt sajat `-o DPkg::Lock::Timeout=180`-ja a vedohalo -- ez MINDEN apt-get hivasra rakerult (masodik halo arra az esetre is, ha a probe utan ugrik be uj holder).

dnf/yum ag erintetlen. Uzenetek az install-lang.sh-n at (hu+en), mindket nyelven futtatva ellenorizve.

## Verifikacio

- `bash -n` mindket fajlra zold; shellcheck -S error tiszta.
- Viselkedesi harness (mockolt fuser/sudo/ps/sleep, a telepito TENYLEGES fuggvenyei sed-del kiemelve): (A) 2 probe utan felszabadulo lock -> return 0 + freed-uzenet; (B) soha-fel-nem-szabadulo lock rovid cappel -> a timeout-ag fut, fail() a nevesitett holderrel; (C) fuser nelkul -> unknown-uzenet + tovabbmenetel. Mindharom zold.
- A workshopon latott "[sudo: authenticate] Password:" KULON megvizsgalva: NEM okozott bukast -- a lock-hibat maga az apt adta, ami csak sikeres sudo-auth utan futhatott; a ketto csak egyutt jelent meg. A sudo-viselkedeshez nem nyultam.

Develop-re megy, a keddi promote szallitja (Marveen 7759 kikotese szerint; a mai resztvevoknek a keruloutja: par perc varakozas + ujrainditas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
