### PR TITLE
fix(install): macOS version pre-flight before relying on Homebrew (MACOSOLD1)

### DIFF
--- a/install-lang.sh
+++ b/install-lang.sh
@@ -263,6 +263,25 @@ _t() {
     hu:linux.apt_lock_timeout_body2) echo "Ha az unattended-upgrades az, várd meg amíg végez (sudo systemctl status unattended-upgrades), majd indítsd újra ezt a telepítőt. Futó dpkg-t NE lőj ki." ;;
     en:linux.apt_lock_timeout_fail) echo "Package manager is locked by another process -- re-run the installer once it finished." ;;
     hu:linux.apt_lock_timeout_fail) echo "A csomagkezelőt egy másik folyamat zárolja -- ha végzett, indítsd újra a telepítőt." ;;
+    # MACOSOLD1: macOS version pre-flight before relying on Homebrew
+    en:macos.ver_unknown) echo "Could not determine the macOS version (sw_vers failed) -- continuing, but if Homebrew fails, that may be why." ;;
+    hu:macos.ver_unknown) echo "Nem sikerült megállapítani a macOS verziót (sw_vers hiba) -- folytatom, de ha a Homebrew elhasal, ez lehet az oka." ;;
+    en:macos.ver_too_old_head) echo "This Mac runs macOS" ;;
+    hu:macos.ver_too_old_head) echo "Ezen a gépen macOS" ;;
+    en:macos.ver_too_old_body1) echo "Homebrew (which installs the dependencies) does not run on macOS older than 10.15, so installation cannot continue on this machine." ;;
+    hu:macos.ver_too_old_body1) echo "fut, a Homebrew (ami a függőségeket telepítené) viszont 10.15-nél régebbi macOS-en nem indul el -- ezen a gépen a telepítés nem tud továbbmenni." ;;
+    en:macos.ver_too_old_body2) echo "Two ways out: (1) update macOS on this machine, or (2) use the REMOTE install (a VPS) -- this Mac is perfectly enough to log in from." ;;
+    hu:macos.ver_too_old_body2) echo "Két kiút: (1) frissítsd ezen a gépen a macOS-t, vagy (2) válaszd a TÁVOLI telepítést (VPS) -- ehhez ez a gép is bőven elég, csak bejelentkezni kell róla." ;;
+    en:macos.ver_too_old_fail) echo "macOS below Homebrew's minimum (10.15) -- update macOS or use the remote install." ;;
+    hu:macos.ver_too_old_fail) echo "A macOS a Homebrew minimuma (10.15) alatt van -- frissíts macOS-t, vagy használd a távoli telepítést." ;;
+    en:macos.ver_unsupported_head) echo "Homebrew no longer supports this macOS version:" ;;
+    hu:macos.ver_unsupported_head) echo "Ezt a macOS verziót a Homebrew már nem támogatja:" ;;
+    en:macos.ver_unsupported_body) echo "It usually still works, but dependency installs may break (best-effort support below macOS 14). If it fails, the remote install (VPS) works from this machine too." ;;
+    hu:macos.ver_unsupported_body) echo "Általában még működik, de a függőség-telepítés eltörhet (macOS 14 alatt best-effort a támogatás). Ha elhasal, a távoli telepítés (VPS) erről a gépről is megy." ;;
+    en:macos.ver_unsupported_prompt) echo "Continue anyway? (y = yes / n = stop) [y]: " ;;
+    hu:macos.ver_unsupported_prompt) echo "Folytassam így? (i = igen / n = megállok) [i]: " ;;
+    en:macos.ver_unsupported_abort) echo "Stopped at your request -- consider the remote install, or update macOS and re-run." ;;
+    hu:macos.ver_unsupported_abort) echo "Kérésedre megálltam -- érdemes a távoli telepítést választani, vagy macOS-frissítés után újrafuttatni." ;;
     en:linux.tg_channel_configured) echo "Telegram channel configured" ;;
     hu:linux.tg_channel_configured) echo "Telegram csatorna konfigurálva" ;;
     en:linux.slack_channel_configured) echo "Slack channel configured" ;;

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -103,6 +103,58 @@ echo ""
 INSTALL_STEP="prerequisites"
 echo -e "${BOLD}$(_t section_1)${NC}"
 
+# ── macOS verzio pre-flight (MACOSOLD1) ──────────────────────────────
+# A fuggosegeket a Homebrew-ra bizzuk, a brew-nak viszont sajat macOS-
+# minimumai vannak. Regi gepen a brew portable-ruby-ja dyld-hibaval hal
+# (____chkstk_darwin, "your system version is too old"), es a felhasznalo
+# egy Ruby-linker hibat lat egy sorszammal (2026-07-30, eles workshop).
+# Itt, a legelso lepesben derul ki, ERTHETO mondattal es KIUTTAL.
+#
+# A kuszobok a Homebrew SAJAT deklaralt minimumai (brew.sh, Homebrew
+# 6.0.13, kiolvasva 2026-07-30):
+#   HOMEBREW_MACOS_OLDEST_ALLOWED="10.15"  -- ez alatt a brew el sem indul
+#   HOMEBREW_MACOS_OLDEST_SUPPORTED="14"   -- ez alatt "unsupported/best effort"
+# Uj brew-kiadasnal ezek valtozhatnak; a forras a brew repo brew.sh fajlja.
+BREW_OLDEST_ALLOWED="10.15"
+BREW_OLDEST_SUPPORTED="14"
+
+# major[.minor] numerikus osszehasonlitas: 0 ha $1 < $2 (sort -V nelkul,
+# a BSD sort -V viselkedesere nem epitunk).
+macos_version_lt() {
+  local a1 b1 a2 b2
+  a1=${1%%.*}; b1=${2%%.*}
+  a2=${1#*.}; [ "$a2" = "$1" ] && a2=0; a2=${a2%%.*}
+  b2=${2#*.}; [ "$b2" = "$2" ] && b2=0; b2=${b2%%.*}
+  [ "$a1" -lt "$b1" ] || { [ "$a1" -eq "$b1" ] && [ "$a2" -lt "$b2" ]; }
+}
+
+MACOS_VER=$(sw_vers -productVersion 2>/dev/null || echo "")
+if [ -z "$MACOS_VER" ]; then
+  # Ismeretlen allapot: kimondjuk, nem talalgatunk -- a telepites megy
+  # tovabb, es ha a brew bukik, a hibauzenete legalabb valodi lesz.
+  echo -e "  ${DIM}$(_t macos.ver_unknown)${NC}"
+elif macos_version_lt "$MACOS_VER" "$BREW_OLDEST_ALLOWED"; then
+  # VEGLEGES akadaly ezen a gepen: a Homebrew el sem indul ilyen regi
+  # macOS-en -- azonnal, ertheto mondattal allunk meg, kiuttal.
+  echo -e "${RED}$(_t macos.ver_too_old_head) ${MACOS_VER}${NC}"
+  echo -e "  $(_t macos.ver_too_old_body1)"
+  echo -e "  $(_t macos.ver_too_old_body2)"
+  fail "$(_t macos.ver_too_old_fail)"
+elif macos_version_lt "$MACOS_VER" "$BREW_OLDEST_SUPPORTED"; then
+  # Szurke sav: a brew "unsupported / best effort" -- tipikusan mukodik,
+  # de torhet. Nem hazudunk sem sikert, sem bukast: figyelmeztetunk, es a
+  # felhasznalo dont.
+  warn "$(_t macos.ver_unsupported_head) ${MACOS_VER}"
+  echo -e "  $(_t macos.ver_unsupported_body)"
+  read -rp "$(_t macos.ver_unsupported_prompt)" CONT_OLD_MACOS
+  CONT_OLD_MACOS=${CONT_OLD_MACOS:-i}
+  # hu prompt: i/n, en prompt: y/n -- mindket igen-alak elfogadva.
+  case "$CONT_OLD_MACOS" in
+    i|I|y|Y) : ;;
+    *) fail "$(_t macos.ver_unsupported_abort)" ;;
+  esac
+fi
+
 check_cmd() {
   if command -v "$1" &>/dev/null; then
     echo -e "  ${GREEN}✓${NC} $2"


### PR DESCRIPTION
## MACOSOLD1: macOS verzio pre-flight, mielott a brew-ra biznank barmit

Eles workshop-lelet (2026-07-30): regi MacBook Airen a Homebrew portable-ruby-ja dyld-hibaval hal (____chkstk_darwin, "your system version is too old"), a felhasznalo egy Ruby-linker hibat es egy sorszamot lat a prerequisites lepesbol. A gyokerok a Homebrew sajat macOS-padloja, de a hibakep a mienk.

## Viselkedes

`sw_vers` pre-flight a prerequisites LEGELEJEN. A kuszobok a Homebrew SAJAT deklaralt minimumai (brew.sh, Homebrew 6.0.13, kiolvasva 2026-07-30 -- forras-kommentben rogzitve), nem talalgatas:

- **< 10.15 (HOMEBREW_MACOS_OLDEST_ALLOWED)**: a brew el sem indul -> AZONNALI megallas magyar mondattal es KET kiuttal: macOS-frissites, VAGY tavoli telepites (VPS) -- "ehhez ez a gep is boven eleg, csak bejelentkezni kell rola".
- **10.15 <= v < 14 (HOMEBREW_MACOS_OLDEST_SUPPORTED)**: best-effort sav -- oszinte figyelmeztetes (mukodhet, de torhet) + a felhasznalo dont (hu 'i' es en 'y' is elfogadva).
- **sw_vers olvashatatlan**: kimondott ISMERETLEN allapot, tovabbmenetel -- igy egy kesobbi brew-bukas legalabb a valodi uzenetet viszi.

Tiszta-bash major.minor komparator (BSD `sort -V`-re nem epitunk). i18n hu+en az install-lang.sh-ban.

## Verifikacio

- `bash -n` zold mindket fajlra.
- Harness: a komparator 8 hataresete (10.14<10.15, 10.15>=10.15, 13.6<14, 14>=14, 14.5>=14, 15>=10.15, 10.15<14, 12<14) + 6 sav-eset (hard stop 10.13-on; folytatas i-vel es y-nal; abort n-nel; modern gep nema atmenes; ures sw_vers unknown-uzenettel atmenes) -- mind zold. A komparator sed-del a TENYLEGES scriptbol kiemelve fut a harnessben; a sav-logika tukrozott masolat.
- NYITOTT TENY (Marveen 7759): a resztvevo pontos macOS-verzioja meg nem ismert. Ez a fix MINDEN savot helyesen kezel -- ha kiderul hogy a gep 10.15+, es a brew megis torott, az KULON hibakep es kulon fix (a pre-flight akkor a warn-savban engedi tovabb, a brew valodi hibaja pedig latszani fog).

Develop-re megy, keddi promote szallitja. KULON PR az APTLOCK1-tol (#788), Marveen 7759/2. kikotese szerint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
