### PR TITLE
chore(install): suggested commands on their own copyable line (NPMPERM1 follow-up)

### DIFF
--- a/install-lang.sh
+++ b/install-lang.sh
@@ -257,10 +257,10 @@ _t() {
     hu:linux.apt_lock_unknown) echo "Nem tudom megnézni, ki fogja a csomagkezelő zárolást (nincs fuser) -- ha foglalt, az apt maga vár rá legfeljebb 3 percig." ;;
     en:linux.apt_lock_timeout_head) echo "The package-manager lock is STILL held after 5 minutes by:" ;;
     hu:linux.apt_lock_timeout_head) echo "A csomagkezelő zárolást 5 perc után is fogja:" ;;
-    en:linux.apt_lock_timeout_body1) echo "This is no longer the usual transient auto-update. Check what it is: sudo lsof /var/lib/dpkg/lock-frontend" ;;
-    hu:linux.apt_lock_timeout_body1) echo "Ez már nem a szokásos átmeneti auto-frissítés. Nézd meg, mi az: sudo lsof /var/lib/dpkg/lock-frontend" ;;
-    en:linux.apt_lock_timeout_body2) echo "If it is unattended-upgrades, let it finish (sudo systemctl status unattended-upgrades), then re-run this installer. Do NOT kill a running dpkg." ;;
-    hu:linux.apt_lock_timeout_body2) echo "Ha az unattended-upgrades az, várd meg amíg végez (sudo systemctl status unattended-upgrades), majd indítsd újra ezt a telepítőt. Futó dpkg-t NE lőj ki." ;;
+    en:linux.apt_lock_timeout_body1) printf '%s\n    sudo lsof /var/lib/dpkg/lock-frontend' "This is no longer the usual transient auto-update. Check what holds it (copy the line below):" ;;
+    hu:linux.apt_lock_timeout_body1) printf '%s\n    sudo lsof /var/lib/dpkg/lock-frontend' "Ez már nem a szokásos átmeneti auto-frissítés. Nézd meg, mi fogja (másold az alábbi sort):" ;;
+    en:linux.apt_lock_timeout_body2) printf '%s\n    sudo systemctl status unattended-upgrades\n%s' "If it is unattended-upgrades, let it finish -- status (copy the line below):" "  then re-run this installer. Do NOT kill a running dpkg." ;;
+    hu:linux.apt_lock_timeout_body2) printf '%s\n    sudo systemctl status unattended-upgrades\n%s' "Ha az unattended-upgrades az, várd meg amíg végez -- állapot (másold az alábbi sort):" "  majd indítsd újra ezt a telepítőt. Futó dpkg-t NE lőj ki." ;;
     en:linux.apt_lock_timeout_fail) echo "Package manager is locked by another process -- re-run the installer once it finished." ;;
     hu:linux.apt_lock_timeout_fail) echo "A csomagkezelőt egy másik folyamat zárolja -- ha végzett, indítsd újra a telepítőt." ;;
     en:linux.tg_channel_configured) echo "Telegram channel configured" ;;

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -431,9 +431,11 @@ else
   else
     echo -e "  ${RED}HIBA:${NC} claude telepitve, de nem indul (valoszinuleg AVX-hianyos CPU + Bun-binary)."
     if command -v npm >/dev/null 2>&1; then
-      echo -e "  ${DIM}Probald manualisan: npm install -g @anthropic-ai/claude-code@${CLAUDE_PIN}${NC}"
+      echo -e "  ${DIM}Probald manualisan (masold ki az alabbi sort):${NC}"
+      echo "    npm install -g @anthropic-ai/claude-code@${CLAUDE_PIN}"
     else
-      echo -e "  ${DIM}Telepits nvm+node-ot, majd: npm install -g @anthropic-ai/claude-code@${CLAUDE_PIN}${NC}"
+      echo -e "  ${DIM}Telepits nvm+node-ot, majd (masold ki az alabbi sort):${NC}"
+      echo "    npm install -g @anthropic-ai/claude-code@${CLAUDE_PIN}"
     fi
   fi
 fi

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -184,7 +184,11 @@ if ! command -v claude &>/dev/null; then
       npm install -g @anthropic-ai/claude-code
     fi
   else
-    fail "Claude Code CLI szukseges a futtatashoz. Telepitsd: npm install -g @anthropic-ai/claude-code"
+    # A javasolt parancs KULON, masolhato sorban -- egy workshop-resztvevo
+    # kezzel gepelte at es egyetlen karakteren (@ = AltGr) elbukott.
+    echo -e "  ${DIM}Telepitsd (masold ki az alabbi sort):${NC}"
+    echo "    npm install -g @anthropic-ai/claude-code"
+    fail "Claude Code CLI szukseges a futtatashoz."
   fi
 fi
 echo -e "  ${GREEN}✓${NC} Claude Code CLI"


### PR DESCRIPTION
A 7762-es lelet: magyar billentyuzeten a kezzel atgepelt javasolt parancs egyetlen karakteren elbukott (@ = AltGr). Minden javasolt parancs mostantol KULON, behuzott, masolhato sorban all: apt-lock timeout hintek (lsof, systemctl), macOS claude-install hint, linux manualis-install hintek. bash -n + hu/en runtime render + a #788-as aptlock-harness ujrafuttatva (3/3 ag zold -- a timeout-ag az uj tobbsoros formatummal). Kis, szoveg-fokuszu PR; a #788/#790 mar mergelt stringjeit igazitja, ezert kulon agon (stacked-footgun szabaly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)