### PR TITLE
fix(install): clone into the Linux home, not the Windows mount (WSLMNT1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Minden ágens saját, réteges memóriával rendelkezik (hot / warm / cold / sha
 ### macOS / Linux
 
 ```bash
+cd ~
 git clone --branch main https://github.com/Szotasz/marveen.git
 cd marveen
 ./install.sh
@@ -99,7 +100,7 @@ A Windows telepítő automatikusan beállítja a WSL-t (Windows Subsystem for Li
 
 > **Ha a PowerShell ablak bezárul / a telepítő nem jut túl a WSL+Ubuntu lépésen:** nyisd meg az Ubuntu-t (Start menü → Ubuntu), majd a WSL Ubuntu shellben futtasd közvetlenül a Linux-telepítőt (a PowerShell wrapper megkerülése):
 > ```bash
-> curl -fsSL https://raw.githubusercontent.com/Szotasz/marveen/main/install-linux.sh -o install.sh && bash install.sh
+> cd ~ && curl -fsSL https://raw.githubusercontent.com/Szotasz/marveen/main/install-linux.sh -o install.sh && bash install.sh
 > ```
 > Ez a megbízható út, ha a `wsl.exe`/Windows-claude környezet összeakad.
 
@@ -272,6 +273,7 @@ claude setup-token
 
 # 2. A VPS-en:
 export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+cd ~
 git clone --branch main https://github.com/Szotasz/marveen.git
 cd marveen
 ./install.sh    # automatikusan install-linux.sh-t futtat

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -122,6 +122,25 @@ echo ""
 echo -e "${DIM}  Telepito wizard - Linux (Ubuntu/Debian)${NC}"
 echo ""
 
+# ── WSLMNT1 vedohalo: /mnt/ ala klonozott repo ──────────────────────
+# WSL-ben a terminal gyakran a Windows-mappaban (/mnt/c/...) nyilik, es az
+# oda klonozott repon a git/npm chmod-muveletei "Operation not permitted"
+# hibakkal halnak (drvfs nem POSIX). A leggyakoribb elakadas MEG a klonnal
+# tortenik (a script el sem indul -- azt a README `cd ~`-ja fedi); ez a
+# check a MASODIK esetet fogja: a klon valahogy letrejott /mnt/ alatt, es
+# a telepito onnan indult. Ertheto mondat + masolhato kiut, sorszam helyett.
+case "$INSTALL_DIR" in
+  /mnt/*)
+    echo -e "${RED}A telepito a Windows-fajlrendszerrol fut (${INSTALL_DIR}).${NC}"
+    echo -e "  A /mnt/ alatti mappakon a git es az npm jogosultsag-muveletei nem mukodnek (WSL/drvfs) -- a telepites itt elhalna."
+    echo -e "  ${DIM}Kiut: klonozd a Linux home-ba, es onnan futtasd (masold az alabbi sorokat):${NC}"
+    echo "    cd ~"
+    echo "    git clone --branch main https://github.com/Szotasz/marveen.git"
+    echo "    cd marveen && ./install.sh"
+    exit 1
+    ;;
+esac
+
 INSTALL_STEP="prerequisites"
 # ─────────────────────────────────────────────
 # [1/7] Elofeltetelek


### PR DESCRIPTION
WSLMNT1 (Marveen 7764): a resztvevo /mnt/c alol klonozott, a klon MEG a script elott elhalt (drvfs chmod). (a) FO FIX -- doksi: mindharom masolhato README-blokk `cd ~`-val kezdodik (quickstart, WSL-fallback egysoros, VPS-flow); a ps1 defaultja (~/marveen) mar biztonsagos volt. (b) vedohalo -- install-linux.sh korai /mnt/-check ertheto mondattal + masolhato kiuttal (a #791-es konvencio szerint kulon sorokon); viselkedes-teszt: /mnt-rol exit 1 + uzenet, /root-rol nema atmenes. A (b) tudottan a MASODIK elofordulast fedi, a mai esetet az (a) szunteti meg -- sulyozas a 7764 szerint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)