### PR TITLE
feat(ops): ship the operator ops scripts, portable instead of install-bound

### DIFF
--- a/scripts/__tests__/ops-scripts-portable.test.sh
+++ b/scripts/__tests__/ops-scripts-portable.test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Portability contract for the operator-side ops scripts.
+# Run: bash scripts/__tests__/ops-scripts-portable.test.sh
+#
+# These four scripts were written against one install and carried its values in
+# the source: an absolute home path, one tmux session name, one chat id, one
+# GitHub slug. Anyone else cloning the repo got scripts that silently watched
+# the wrong things. The tests below pin the rule that replaced them -- every
+# install-specific value is resolved at runtime -- so the next edit cannot
+# quietly bake a local value back in.
+
+set -u
+
+PASS=0; FAIL=0
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPTS="
+scripts/limit-monitor.sh
+scripts/pre-modify-backup.sh
+scripts/github-pr-monitor.sh
+scripts/hooks/telegram-ack.py
+"
+
+echo "ops-scripts portability tests"
+echo "============================="
+
+# ---------------------------------------------------------------------------
+# (a) No install-specific literals anywhere in the sources
+# ---------------------------------------------------------------------------
+echo ""
+echo "(a) No baked-in install values"
+# An absolute /home/<user> path, a bare numeric chat id assignment, or a
+# hardcoded owner/repo slug are the three shapes that broke portability.
+for rel in $SCRIPTS; do
+  f="$INSTALL_DIR/$rel"
+  [ -f "$f" ] || { fail "$rel exists"; continue; }
+  if grep -qE '/home/[a-z]+/' "$f"; then
+    fail "$rel: absolute /home path"
+  elif grep -qE '^[[:space:]]*(CHAT_ID|ALLOWED_CHAT_ID)=["'"'"']?[0-9]{6,}' "$f"; then
+    fail "$rel: hardcoded chat id"
+  elif grep -qE '^[[:space:]]*REPO=["'"'"'][A-Za-z0-9_-]+/[A-Za-z0-9_.-]+["'"'"']' "$f"; then
+    fail "$rel: hardcoded GitHub slug"
+  else
+    pass "$rel: no baked-in install values"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# (b) The session name follows a renamed install
+# ---------------------------------------------------------------------------
+# A rename changes MAIN_AGENT_ID, and the channels tmux session is named after
+# it. A monitor still grepping the old session name reads an empty pane forever
+# and reports "healthy" -- the worst failure mode for a guard.
+echo ""
+echo "(b) limit-monitor follows MAIN_AGENT_ID"
+CASE="$TMPDIR_BASE/rename"; mkdir -p "$CASE/scripts" "$CASE/store"
+cp "$INSTALL_DIR/scripts/limit-monitor.sh" "$CASE/scripts/"
+printf 'MAIN_AGENT_ID=renamedbot\nALLOWED_CHAT_ID=111222333\n' > "$CASE/.env"
+OUT="$(cd "$CASE" && bash -x scripts/limit-monitor.sh 2>&1 | grep -E "SESSION=|tmux capture-pane" | head -3)"
+case "$OUT" in
+  *renamedbot-channels*) pass "session resolves to renamedbot-channels" ;;
+  *) fail "session did not follow MAIN_AGENT_ID (got: ${OUT:-empty})" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# (c) No owner chat -> stay silent, do not guess
+# ---------------------------------------------------------------------------
+# A fresh install has no ALLOWED_CHAT_ID yet. Alerting somewhere anyway would
+# mean sending this install's quota warnings to a stranger's chat.
+echo ""
+echo "(c) limit-monitor without ALLOWED_CHAT_ID"
+CASE="$TMPDIR_BASE/nochat"; mkdir -p "$CASE/scripts" "$CASE/store"
+cp "$INSTALL_DIR/scripts/limit-monitor.sh" "$CASE/scripts/"
+printf 'MAIN_AGENT_ID=somebot\n' > "$CASE/.env"
+(cd "$CASE" && bash scripts/limit-monitor.sh >/dev/null 2>&1)
+if grep -q "no ALLOWED_CHAT_ID" "$CASE/store/limit-monitor.log" 2>/dev/null; then
+  pass "exits with a logged reason instead of guessing a chat"
+else
+  fail "no explanatory log line for the missing chat id"
+fi
+
+# ---------------------------------------------------------------------------
+# (d) pre-modify-backup resolves its own repo root
+# ---------------------------------------------------------------------------
+# It used to hold one absolute path, so a second checkout backed up the FIRST
+# install's database while reporting success.
+echo ""
+echo "(d) pre-modify-backup uses its own location"
+CASE="$TMPDIR_BASE/backup"; mkdir -p "$CASE/scripts" "$CASE/store"
+cp "$INSTALL_DIR/scripts/pre-modify-backup.sh" "$CASE/scripts/"
+echo "sentinel" > "$CASE/store/.dashboard-token"
+(cd "$CASE" && bash scripts/pre-modify-backup.sh testlabel >/dev/null 2>&1)
+if find "$CASE/store/backups" -name '.dashboard-token' 2>/dev/null | grep -q .; then
+  pass "snapshot landed under its own store/, not another install's"
+else
+  fail "no snapshot in this checkout's store/backups"
+fi
+
+echo ""
+echo "======================="
+echo "PASS: $PASS  FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/github-pr-monitor.sh
+++ b/scripts/github-pr-monitor.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Token-free GitHub PR reaction monitor.
+# Polls our own open PRs on the configured repo and sends a Telegram
+# alert (Bot API, NO Claude tokens) whenever a PR's state changes: new review,
+# new comment, review decision, or merge/close. Baselines silently on first run.
+#
+# Runs under a systemd --user timer. gh auth via GH_TOKEN from the fleet PAT so
+# it does not depend on the interactive keyring.
+set -euo pipefail
+
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$INSTALL_DIR"
+
+# Upstream repo and the PRs to watch are both derived, not hardcoded: a fork
+# has a different slug, and a fixed PR list goes stale the moment one merges.
+# GITHUB_PR_MONITOR_REPO / _PRS override either, for a fork watching upstream.
+REPO="${GITHUB_PR_MONITOR_REPO:-}"
+if [ -z "$REPO" ]; then
+  REPO="$(git -C "$INSTALL_DIR" config --get remote.upstream.url 2>/dev/null \
+       || git -C "$INSTALL_DIR" config --get remote.origin.url 2>/dev/null || true)"
+  # git@host:owner/repo.git and https://host/owner/repo.git both reduce to owner/repo
+  REPO="$(printf '%s' "$REPO" | sed -E 's#^.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')"
+fi
+STATE_FILE="store/.github-pr-monitor-state"
+
+# --- creds ---------------------------------------------------------------
+# GH_TOKEN from the encrypted vault (software rule: secrets live in the vault,
+# not in plaintext token files). Resolved in-memory via vault-resolve.mjs; the
+# value is never written to disk or logged.
+# PATH first (a systemd --user timer inherits a thin PATH, hence the fallbacks;
+# ~/.local/bin covers the nvm-less per-user install this runs under).
+NODE_BIN="$(command -v node 2>/dev/null || true)"
+if [ -z "$NODE_BIN" ]; then
+  for candidate in "$HOME/.local/bin/node" /usr/local/bin/node /usr/bin/node /opt/homebrew/bin/node; do
+    if [ -x "$candidate" ]; then NODE_BIN="$candidate"; break; fi
+  done
+fi
+if [ -n "$NODE_BIN" ]; then
+  GH_TOKEN="$(printf 'GH_TOKEN=github-fleet-token\n' | "$NODE_BIN" "$INSTALL_DIR/scripts/vault-resolve.mjs" 2>/dev/null | cut -d= -f2- || true)"
+fi
+# Legacy fallback: the plaintext file, if the vault could not resolve (e.g. dist
+# not built or node missing). Safe to keep even after the loose file is removed.
+if [ -z "${GH_TOKEN:-}" ] && [ -f store/.github-fleet-token ]; then
+  GH_TOKEN="$(cat store/.github-fleet-token)"
+fi
+[ -n "${GH_TOKEN:-}" ] && export GH_TOKEN || echo "WARN: no GH_TOKEN (vault+file both empty), gh calls may fail" >&2
+BOT_TOKEN="$(grep -E '^TELEGRAM_BOT_TOKEN=' .env | cut -d= -f2- | tr -d '"'"'"' ')"
+CHAT_ID="$(grep -E '^ALLOWED_CHAT_ID=' .env | cut -d= -f2- | tr -d '"'"'"' ')"
+
+send_telegram() {
+  local text="$1"
+  [ -n "${BOT_TOKEN:-}" ] && [ -n "${CHAT_ID:-}" ] || return 0
+  curl -s -m 20 -o /dev/null \
+    -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+    --data-urlencode "chat_id=${CHAT_ID}" \
+    --data-urlencode "text=${text}" \
+    --data-urlencode "disable_web_page_preview=true" || true
+}
+
+# --- fetch current signatures -------------------------------------------
+# Signature per PR: state|reviewDecision|#reviews|#comments|lastActor
+CUR=""
+# Watch whatever of ours is actually open right now. A hardcoded list stops
+# covering new PRs the day it is written, and keeps polling merged ones forever.
+PRS="${GITHUB_PR_MONITOR_PRS:-}"
+if [ -z "$PRS" ]; then
+  PRS="$(gh pr list --repo "$REPO" --author "@me" --state open --limit 30 \
+         --json number --jq '.[].number' 2>/dev/null | tr '\n' ' ')"
+fi
+if [ -z "${PRS// /}" ]; then
+  echo "no open PRs of ours on $REPO, nothing to watch"
+  exit 0
+fi
+
+for pr in $PRS; do
+  json="$(gh pr view "$pr" --repo "$REPO" \
+      --json state,reviewDecision,reviews,comments,title 2>/dev/null || echo '{}')"
+  line="$(printf '%s' "$json" | python3 -c '
+import json,sys
+try: d=json.load(sys.stdin)
+except Exception: d={}
+if not d: print("ERR||||"); sys.exit()
+reviews=d.get("reviews") or []
+comments=d.get("comments") or []
+last=""
+acts=[(r.get("submittedAt",""),r["author"]["login"]+":"+r.get("state","")) for r in reviews] \
+     +[(c.get("createdAt",""),c["author"]["login"]+":comment") for c in comments]
+acts=[a for a in acts if a[0]]
+if acts: last=sorted(acts)[-1][1]
+print("|".join([d.get("state","?"),str(d.get("reviewDecision") or "none"),str(len(reviews)),str(len(comments)),last]))
+' 2>/dev/null || echo "ERR||||")"
+  CUR="${CUR}${pr}	${line}
+"
+done
+
+# --- baseline on first run ----------------------------------------------
+if [ ! -f "$STATE_FILE" ]; then
+  printf '%s' "$CUR" > "$STATE_FILE"
+  echo "baseline written"
+  exit 0
+fi
+
+# --- diff & alert --------------------------------------------------------
+CHANGES=""
+while IFS=$'\t' read -r pr sig; do
+  [ -n "$pr" ] || continue
+  [ "${sig%%|*}" = "ERR" ] && continue   # skip transient fetch failure
+  old="$(grep -P "^${pr}\t" "$STATE_FILE" 2>/dev/null | head -1 | cut -f2-)"
+  if [ -n "$old" ] && [ "$old" != "$sig" ]; then
+    IFS='|' read -r st rd nrev ncom last <<< "$sig"
+    CHANGES="${CHANGES}- PR #${pr}: state=${st}, review=${rd}, reviews=${nrev}, comments=${ncom}${last:+, utolso: ${last}}
+"
+  fi
+done <<< "$CUR"
+
+if [ -n "$CHANGES" ]; then
+  send_telegram "GitHub PR valtozas (reagalt valaki?):
+${CHANGES}
+https://github.com/${REPO}/pulls"
+  echo "change detected, alerted"
+fi
+
+# always persist the freshest non-error snapshot
+printf '%s' "$CUR" > "$STATE_FILE"

--- a/scripts/hooks/telegram-ack.py
+++ b/scripts/hooks/telegram-ack.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: Telegram receipt acknowledgement (👍).
+
+When an inbound Telegram message arrives, the sender gets an immediate 👍
+reaction confirming the agent received it -- BEFORE the model even processes
+the turn. This runs as a hook (harness-executed), so it is:
+  - reliable (fires on every prompt submit, not model-dependent),
+  - token-free (pure Bot API call, no Claude turn),
+  - fleet-wide (lives in ~/.claude/settings.json; each agent reads its OWN
+    channel bot token, so every agent acks on its own bot).
+
+Mechanism: parse each <channel source="...telegram..." chat_id="X" message_id="Y">
+tag from the submitted prompt and POST setMessageReaction 👍 to the Bot API.
+Dedups on chat_id:message_id so the same message is never re-acked (e.g. if the
+same prompt is re-submitted after a restart/backfill).
+
+NEVER blocks the prompt (always exit 0) and stays silent. Best-effort: any failure
+(no token, network error, non-telegram channel) is swallowed.
+"""
+import sys
+import os
+import re
+import json
+import urllib.request
+
+CHANNEL_RX = re.compile(r'<channel\s+([^>]*)>', re.DOTALL)
+ATTR_RX = re.compile(r'(\w+)="([^"]*)"')
+STATE_FILE = os.path.expanduser("~/.claude/.telegram-ack-state")
+MAX_STATE = 500  # keep the last N acked keys, bounded
+TOKEN_ENV = os.path.expanduser("~/.claude/channels/telegram/.env")
+TOKEN_RX = re.compile(r'[0-9]+:[A-Za-z0-9_-]+')
+
+
+def load_state():
+    try:
+        with open(STATE_FILE) as f:
+            return [ln.strip() for ln in f if ln.strip()]
+    except OSError:
+        return []
+
+
+def save_state(keys):
+    keys = keys[-MAX_STATE:]
+    try:
+        with open(STATE_FILE, "w") as f:
+            f.write("\n".join(keys) + "\n")
+    except OSError:
+        pass
+
+
+def bot_token():
+    try:
+        with open(TOKEN_ENV) as f:
+            m = TOKEN_RX.search(f.read())
+            return m.group(0) if m else None
+    except OSError:
+        return None
+
+
+def react(token, chat_id, message_id):
+    url = f"https://api.telegram.org/bot{token}/setMessageReaction"
+    body = json.dumps({
+        "chat_id": chat_id,
+        "message_id": int(message_id),
+        "reaction": [{"type": "emoji", "emoji": "\U0001F44D"}],
+    }).encode()
+    req = urllib.request.Request(url, data=body,
+                                headers={"Content-Type": "application/json"})
+    try:
+        urllib.request.urlopen(req, timeout=8).read()
+    except Exception:
+        pass  # best-effort; never surface
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return
+    prompt = payload.get("prompt") or ""
+    if "telegram" not in prompt:
+        return
+    token = bot_token()
+    if not token:
+        return
+    state = load_state()
+    seen = set(state)
+    changed = False
+    for attrs_str in CHANNEL_RX.findall(prompt):
+        attrs = dict(ATTR_RX.findall(attrs_str))
+        src = attrs.get("source", "")
+        if "telegram" not in src:
+            continue
+        chat_id = attrs.get("chat_id", "")
+        message_id = attrs.get("message_id", "")
+        if not chat_id or not message_id or not message_id.isdigit():
+            continue
+        key = f"{chat_id}:{message_id}"
+        if key in seen:
+            continue
+        react(token, chat_id, message_id)
+        state.append(key)
+        seen.add(key)
+        changed = True
+    if changed:
+        save_state(state)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/limit-monitor.sh
+++ b/scripts/limit-monitor.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Claude usage-limit monitor (token-free, systemd --user timer).
+#
+# WHY bash and not a Claude scheduled-task: a Claude agent invocation itself
+# consumes the very quota we're guarding. This runs as a plain shell script,
+# greps for limit signals, and alerts the owner via the Telegram Bot API.
+# Zero Claude tokens.
+#
+# Signals: rate-limit / usage-limit / 429 / "resets at" in the channels+dashboard
+# logs AND in the live channels tmux pane (where Claude Code prints the limit msg).
+# Dedupes via a state hash so the same event isn't re-alerted.
+
+set -u
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+STORE="$INSTALL_DIR/store"
+STATE="$STORE/.limit-monitor-state"
+LOG="$STORE/limit-monitor.log"
+
+log(){ echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOG"; }
+
+# Install-specific values come from .env, never hardcoded: a renamed install
+# (BOT_NAME/MAIN_AGENT_ID) has a differently named tmux session, and every
+# install has its own owner chat. Resolved the same way as
+# channel-keepalive-probe.sh so a rename moves both together.
+env_val() { grep -E "^$1=" "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' '; }
+
+MAIN_AGENT_ID="$(env_val MAIN_AGENT_ID)"
+MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"
+MAIN_AGENT_ID="${MAIN_AGENT_ID//[^a-zA-Z0-9_-]/}"
+SESSION="${MAIN_AGENT_ID}-channels"
+
+BOT_NAME="$(env_val BOT_NAME)"
+BOT_NAME="${BOT_NAME:-$MAIN_AGENT_ID}"
+
+CHAT_ID="$(env_val ALLOWED_CHAT_ID)"
+if [ -z "$CHAT_ID" ]; then
+  # No owner chat configured: there is nobody to alert, and guessing one would
+  # send a quota warning to a stranger. Stay silent rather than misdeliver.
+  log "no ALLOWED_CHAT_ID in .env, monitor cannot alert -- exiting"
+  exit 0
+fi
+
+# Collect candidate text: recent log lines + live tmux pane
+CANDIDATE="$(
+  { tail -n 200 "$STORE/channels.log" "$STORE/channels.error.log" "$STORE/dashboard.log" 2>/dev/null;
+    tmux capture-pane -t "$SESSION" -p 2>/dev/null;
+  } | grep -iE "usage limit reached|reached your (usage|plan|weekly) limit|your limit will reset|approaching your usage limit|rate_limit_error|429 too many requests|quota exceeded|out of (usage|credits)" \
+    | grep -viE "rate.?limit.?error class|no rate|within limit|limit-monitor|LIMIT-FIGYELMEZT|email/nap|req/nap|/nap free|kérés/hó|/hó\b|approaching\.\*limit"
+)"
+
+if [ -z "$CANDIDATE" ]; then
+  # healthy: no signal. Touch a heartbeat so we know the monitor ran.
+  echo "ok $(date +%s)" > "$STORE/.limit-monitor-heartbeat"
+  exit 0
+fi
+
+# Dedupe: hash the signal; only alert if new
+HASH="$(printf '%s' "$CANDIDATE" | md5sum | awk '{print $1}')"
+PREV="$(cat "$STATE" 2>/dev/null)"
+if [ "$HASH" = "$PREV" ]; then
+  log "signal unchanged, already alerted ($HASH)"
+  exit 0
+fi
+echo "$HASH" > "$STATE"
+
+# Alert the owner via Bot API (token-free path; no Claude invocation)
+TOKEN="$(grep -oE '[0-9]+:[A-Za-z0-9_-]+' "$HOME/.claude/channels/telegram/.env" 2>/dev/null | head -1)"
+SNIP="$(printf '%s' "$CANDIDATE" | head -3)"
+MSG="⚠️ LIMIT-FIGYELMEZTETÉS ($BOT_NAME monitor)
+A logokban/sessionben limit-jel jelent meg:
+
+$SNIP
+
+Lehet hogy közeledünk vagy elértük a Claude előfizetés keretét. Ha kell, ritkítom a heartbeatet vagy szünetet tartok. Nézd meg a sessiont ha tudod."
+if [ -n "$TOKEN" ]; then
+  curl -s -m 15 "https://api.telegram.org/bot$TOKEN/sendMessage" \
+    --data-urlencode "chat_id=$CHAT_ID" \
+    --data-urlencode "text=$MSG" \
+    --data-urlencode "disable_web_page_preview=true" -o /dev/null
+  log "ALERT sent to $CHAT_ID: $HASH"
+else
+  log "ALERT wanted but no bot token found: $HASH"
+fi

--- a/scripts/pre-modify-backup.sh
+++ b/scripts/pre-modify-backup.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Pre-modification backup.
+#
+# RULE: before ANY system modification (schema change,
+# feature deploy, config edit that the live service reads), snapshot the
+# critical mutable state first. Code is already safe in git; this captures the
+# state git does NOT track: the SQLite DB, the vault, and runtime config.
+#
+# Rolling retention: keep the newest $KEEP snapshots, prune the rest.
+# Usage: scripts/pre-modify-backup.sh [label]
+#   label is an optional short tag for the snapshot dir (e.g. "openrouter-ui").
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+STORE="$REPO/store"
+BKDIR="$STORE/backups"
+KEEP=10
+LABEL="${1:-manual}"
+TS="$(date +%Y%m%d-%H%M%S)"
+DEST="$BKDIR/${TS}-${LABEL}"
+
+mkdir -p "$DEST"
+
+# Consistent SQLite snapshot (NOT a raw cp -- the live dashboard may be mid-write).
+if [ -f "$STORE/claudeclaw.db" ]; then
+  sqlite3 "$STORE/claudeclaw.db" ".backup '$DEST/claudeclaw.db'" \
+    && echo "  db: consistent snapshot ok" \
+    || echo "  db: WARNING snapshot failed"
+fi
+
+# Small critical state git does not track. Explicit list -- store/ also holds
+# ~1.7G of large/regenerable data we deliberately do NOT copy.
+for f in vault.json .vault-key .dashboard-token \
+         openrouter-models.json agents-desired.json autonomy-config.json \
+         auto-restart.json command-task-health.json schedule-last-run.json; do
+  [ -f "$STORE/$f" ] && cp -p "$STORE/$f" "$DEST/" 2>/dev/null
+done
+
+# Personal, untracked scripts -- the ones git will NOT bring back.
+#
+# These hold install-specific data (chat ids, absolute home paths, account-bound
+# token refreshers), so they are deliberately never pushed upstream -- which
+# means git can never restore them, and this folder is the ONLY copy. On
+# 2026-07-26 a branch switch silently deleted pre-modify-backup.sh itself (it
+# lived only on a feature branch); nothing errored, it was simply gone.
+#
+# WHICH files count as personal is per-install, so the list is data, not code:
+# store/personal-scripts.txt, one repo-relative path per line (# comments and
+# blank lines ignored). With no such file we fall back to every untracked,
+# executable script git already knows nothing about -- which is exactly the set
+# at risk. Either way the manifest makes the post-update check possible: compare
+# the live tree against personal-scripts/MANIFEST.txt after any update or
+# branch switch.
+PERSONAL_DIR="$DEST/personal-scripts"
+PERSONAL_LIST="$STORE/personal-scripts.txt"
+mkdir -p "$PERSONAL_DIR"
+: > "$PERSONAL_DIR/MANIFEST.txt"
+PERSONAL_MISSING=0
+PERSONAL_SAVED=0
+
+if [ -f "$PERSONAL_LIST" ]; then
+  PERSONAL_FILES="$(grep -vE '^\s*(#|$)' "$PERSONAL_LIST")"
+else
+  # Untracked files under scripts/ are by definition the ones git cannot restore.
+  PERSONAL_FILES="$(git -C "$REPO" ls-files --others --exclude-standard -- scripts/ 2>/dev/null)"
+fi
+
+for rel in $PERSONAL_FILES; do
+  if [ -f "$REPO/$rel" ]; then
+    mkdir -p "$PERSONAL_DIR/$(dirname "$rel")"
+    cp -p "$REPO/$rel" "$PERSONAL_DIR/$rel" 2>/dev/null
+    printf '%s  %s\n' "$(sha256sum "$REPO/$rel" | cut -d' ' -f1)" "$rel" >> "$PERSONAL_DIR/MANIFEST.txt"
+    PERSONAL_SAVED=$((PERSONAL_SAVED + 1))
+  else
+    # Only reachable via an explicit list: a named file that is already gone is
+    # the exact loss this backup exists to catch, so say so loudly.
+    printf 'MISSING  %s\n' "$rel" >> "$PERSONAL_DIR/MANIFEST.txt"
+    PERSONAL_MISSING=$((PERSONAL_MISSING + 1))
+  fi
+done
+if [ "$PERSONAL_MISSING" -gt 0 ]; then
+  echo "  personal-scripts: WARNING $PERSONAL_MISSING file(s) ALREADY MISSING from the live tree ($PERSONAL_SAVED saved)"
+else
+  echo "  personal-scripts: $PERSONAL_SAVED saved + manifest"
+fi
+
+# Code rollback reference (the code itself lives in git).
+git -C "$REPO" rev-parse HEAD          > "$DEST/git-HEAD.txt"    2>/dev/null
+git -C "$REPO" branch --show-current   > "$DEST/git-branch.txt"  2>/dev/null
+
+# Rotate: keep the newest $KEEP snapshot dirs, remove older ones.
+if [ -d "$BKDIR" ]; then
+  ls -1dt "$BKDIR"/*/ 2>/dev/null | tail -n +$((KEEP + 1)) | while read -r old; do
+    rm -rf "$old" && echo "  pruned old snapshot: $(basename "$old")"
+  done
+fi
+
+SIZE="$(du -sh "$DEST" 2>/dev/null | cut -f1)"
+echo "backup ok: $DEST ($SIZE, retain newest $KEEP)"


### PR DESCRIPTION
Four scripts have kept this install running for weeks but never made it into the repo, because each carried the install inside it: an absolute `/home` path, one tmux session name, one Telegram chat id, one GitHub slug, one node path. Useful tools, unusable by anyone else. This resolves every such value at runtime.

**What each one does, and what was baked in**

- **`limit-monitor.sh`** watches for Claude usage-limit signals in the logs and in the live channels pane, then alerts over the Bot API -- deliberately not a scheduled Claude task, since that would spend the quota it guards. The session name was the literal `bigme-channels`; it now derives from `MAIN_AGENT_ID` exactly as `channel-keepalive-probe.sh` does. That one mattered more than it looks: after a rename it grepped a session that no longer existed, found nothing, and reported healthy forever. With no `ALLOWED_CHAT_ID` it now logs why and exits instead of alerting a chat it guessed.
- **`pre-modify-backup.sh`** snapshots the state git does not track (SQLite via `.backup`, vault, runtime config) before a risky change. The repo root was one absolute path, so a second checkout would back up the *first* install's database and report success. It now resolves its own location. Which untracked scripts count as "personal" is per-install, so that list became data (`store/personal-scripts.txt`), falling back to whatever `git ls-files --others` reports under `scripts/` -- exactly the set git cannot restore.
- **`github-pr-monitor.sh`** polls our open PRs and alerts on state changes, token-free. The slug now derives from the `upstream`/`origin` remote, and the watched PRs come from `gh pr list --author @me --state open` instead of a fixed three-number list that went stale the day it was written. `GITHUB_PR_MONITOR_REPO` / `_PRS` override both, for a fork watching upstream. `node` resolves via PATH first, with the previous absolute paths kept as fallbacks for the thin PATH a systemd --user timer inherits.
- **`hooks/telegram-ack.py`** posts a 👍 reaction the moment an inbound message arrives, before the model processes the turn -- fleet-wide, each agent on its own bot token. This one was already install-neutral; only the docstring named one operator.

**Test**

`scripts/__tests__/ops-scripts-portable.test.sh` pins the rule rather than the code: no absolute home path, no literal chat id, no literal repo slug, the session name follows a renamed install, a missing owner chat stays silent, and a backup lands in its own checkout. I verified it fails when a literal is put back (both the slug check and the silent-exit check trip).

**Shipping is not enabling**

Merging this makes the four scripts available, not active. Nothing in the repo wires any of them up: `templates/settings.json.template` lists its hooks by name and `telegram-ack.py` is not among them, and the three shell scripts need a cron entry or a hand run before they do anything. That is deliberate for anything that can post to the channel path -- an operator opts in per script. The title reads the other way, so to be unambiguous: after this merge, nothing new starts running on anyone's install.

Operator-facing docs for the four (what each watches, the cron line or settings entry each needs) are not in this PR; tracked as a follow-up.

**Note on adoption**

These land as tracked files, so an install already running untracked copies under the same names will hit a pull conflict once. Removing the local copy is the whole fix -- the tracked version reads the same values from `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
