### PR TITLE
fix(install): give the SERVICES an auth credential, and fail closed if they have none

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -64,6 +64,27 @@ on_error() {
 }
 trap 'on_error $LINENO' ERR
 
+# Does the INSTALL carry an auth credential the SERVICES can read?
+#
+# This is deliberately NOT `claude auth status`. That command answers a
+# different question -- "can the operator's current shell talk to Claude?" --
+# and the two answers diverge in the exact case that broke every affected
+# install: the services (systemd units) read ONLY <install>/.env and
+# <install>/store/.claude-oauth-token. They never see ~/.claude/.credentials.json,
+# the macOS Keychain, or a CLAUDE_CODE_OAUTH_TOKEN exported from ~/.bashrc.
+#
+# Measured on a live host 2026-07-30, same host, same command:
+#   non-interactive shell (how systemd starts a unit):  claude auth status -> FAILS
+#   interactive shell     (how this installer runs):    claude auth status -> SUCCEEDS
+# because a previous install had written `export CLAUDE_CODE_OAUTH_TOKEN=...`
+# into ~/.bashrc. The installer therefore believed auth was done, skipped the
+# token capture, and left the services with nothing.
+service_auth_present() {
+  grep -qE '^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=.+' "$INSTALL_DIR/.env" 2>/dev/null && return 0
+  [ -s "$INSTALL_DIR/store/.claude-oauth-token" ] && return 0
+  return 1
+}
+
 # Ha a <marker> szoveg nem talalhato az rc fajlban, hozzaadja a <sort>.
 # Mindket fajlt kezeli (.bashrc, .zshrc) ha leteznek.
 # Hasznalat: ensure_in_rc "keres_minta" "hozzaadando sor"
@@ -525,10 +546,20 @@ if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
   IS_HEADLESS=true
 fi
 
-if claude auth status &>/dev/null; then
-  ok "Claude mar be van jelentkezve"
+# Skip the prompt only when THIS INSTALL already carries a credential the
+# services can read (a re-run, or the dashboard wizard got there first).
+# Gating on `claude auth status` here is what silently skipped token capture
+# for operators who had followed step 2 below and run `claude setup-token`
+# first -- the correct user behaviour triggered the bug.
+if service_auth_present; then
+  ok "A telepites mar hordoz auth kulcsot (.env / store/.claude-oauth-token)"
 else
-  echo -e "  ${ORANGE}Nincs aktiv Claude bejelentkezes.${NC}"
+  if claude auth status &>/dev/null; then
+    echo -e "  ${ORANGE}A terminalod be van jelentkezve, de a SZOLGALTATASOK ehhez nem ferenek hozza.${NC}"
+    echo -e "  ${DIM}A systemd unitok csak a .env-et es a store/.claude-oauth-token-t olvassak.${NC}"
+  else
+    echo -e "  ${ORANGE}Nincs aktiv Claude bejelentkezes.${NC}"
+  fi
   if [ "$IS_HEADLESS" = "true" ]; then
     echo ""
     echo -e "  ${BLUE}Headless szerver detektalva (nincs DISPLAY).${NC}"
@@ -601,10 +632,17 @@ fi
 # front of the install script.
 echo ""
 echo -e "  ${DIM}Headless Claude Code teszt...${NC}"
-CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1 | head -c 200)
+# The exit status here used to be `head`'s, not claude's: `VAR=$(cmd | head)`
+# reports the LAST pipeline element, so a failing claude looked like success.
+# PIPESTATUS does NOT help either -- after an assignment it describes the
+# assignment, not the pipeline inside the substitution (measured). Dropping the
+# pipe entirely is the only form that reports claude's own status; the output is
+# truncated afterwards in the shell.
+CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1)
 CLAUDE_PROBE_EXIT=$?
+CLAUDE_PROBE_OUT=${CLAUDE_PROBE_OUT:0:200}
 if [ "$CLAUDE_PROBE_EXIT" -eq 0 ] && [ -n "$CLAUDE_PROBE_OUT" ]; then
-  ok "Headless Claude Code futtathato (\`claude --print\` valaszolt)"
+  ok "Az OPERATOR shelljebol futtathato a Claude Code (\`claude --print\` valaszolt)"
 else
   warn "Headless Claude Code probe SIKERTELEN. Az agent-letrehozas KESOBB EL fog hasalni."
   echo -e "    ${DIM}Kimenet: ${CLAUDE_PROBE_OUT:-<ures>}${NC}"
@@ -921,6 +959,81 @@ if [ -n "${OAUTH_TOKEN_INPUT:-}" ] && printf '%s' "$OAUTH_TOKEN_INPUT" | grep -E
   ok "Fleet setup-token eltarolva (store/.claude-oauth-token) -- per-agent izolacio aktiv"
 fi
 ok ".env letrehozva (chmod 600)"
+
+# ── Fail-closed auth gate ────────────────────────────────────────────────────
+# Until now nothing verified that the AGENTS will actually be able to log in.
+# A skipped/empty token prompt produced a fully "successful" install whose main
+# agent then sat at "Not logged in" and re-tried forever (2026-07-30: 26 healer
+# escalations and 12 pointless restarts over six hours on one host).
+#
+# Three states, and the failure branches must never print the success text:
+#   OK       -- the services carry a credential AND it answers a live query
+#   BROKEN   -- no credential, or a credential that does not work
+#   UNKNOWN  -- the probe could not run (no claude binary, no network)
+INSTALL_AUTH_STATE="BROKEN"
+_svc_token=""
+if [ -s "$INSTALL_DIR/store/.claude-oauth-token" ]; then
+  _svc_token="$(cat "$INSTALL_DIR/store/.claude-oauth-token" 2>/dev/null || true)"
+fi
+if [ -z "$_svc_token" ]; then
+  _svc_token="$(grep -E '^CLAUDE_CODE_OAUTH_TOKEN=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+fi
+_svc_apikey="$(grep -E '^ANTHROPIC_API_KEY=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+
+if ! service_auth_present; then
+  INSTALL_AUTH_STATE="BROKEN"
+else
+  # Probe the way a SERVICE will run: an isolated config dir (so ~/.claude and
+  # the operator's shell exports cannot make a broken install look healthy)
+  # carrying ONLY the credential the units will actually get.
+  _probe_cfg="$(mktemp -d 2>/dev/null || echo /tmp/marveen-authprobe.$$)"
+  _probe_out=""
+  _probe_rc=1
+  if command -v claude >/dev/null 2>&1; then
+    if [ -n "$_svc_token" ]; then
+      _probe_out="$(env -i PATH="$PATH" HOME="$HOME" CLAUDE_CONFIG_DIR="$_probe_cfg" \
+        CLAUDE_CODE_OAUTH_TOKEN="$_svc_token" \
+        claude --print "ping" 2>&1)"
+      _probe_rc=$?
+    else
+      _probe_out="$(env -i PATH="$PATH" HOME="$HOME" CLAUDE_CONFIG_DIR="$_probe_cfg" \
+        ANTHROPIC_API_KEY="$_svc_apikey" \
+        claude --print "ping" 2>&1)"
+      _probe_rc=$?
+    fi
+    _probe_out=${_probe_out:0:200}
+    _probe_out=${_probe_out:0:200}
+  if [ "$_probe_rc" -eq 0 ] && [ -n "$_probe_out" ]; then
+      INSTALL_AUTH_STATE="OK"
+    else
+      INSTALL_AUTH_STATE="BROKEN"
+    fi
+  else
+    INSTALL_AUTH_STATE="UNKNOWN"
+  fi
+  rm -rf "$_probe_cfg" 2>/dev/null || true
+fi
+unset _svc_token _svc_apikey
+
+case "$INSTALL_AUTH_STATE" in
+  OK)
+    ok "Auth ellenorizve a SZOLGALTATASOK utjan (izolalt konfig + a unitok hitelesitoje)"
+    ;;
+  UNKNOWN)
+    warn "Az auth-ot NEM tudtam ellenorizni (nincs futtathato claude vagy nincs halozat)."
+    echo -e "    ${DIM}A telepites folytatodik, de az ugynokok indulasa nincs igazolva.${NC}"
+    echo -e "    ${DIM}Ellenorzes kesobb: ${BLUE}bash \"$INSTALL_DIR/scripts/doctor.sh\"${NC}"
+    ;;
+  *)
+    warn "AZ UGYNOKOK IGY NEM FOGNAK ELINDULNI: a telepites nem hordoz mukodo auth kulcsot."
+    echo -e "    ${DIM}A szolgaltatasok CSAK ezt a ket helyet olvassak:${NC}"
+    echo -e "    ${DIM}  - $INSTALL_DIR/.env  (CLAUDE_CODE_OAUTH_TOKEN vagy ANTHROPIC_API_KEY)${NC}"
+    echo -e "    ${DIM}  - $INSTALL_DIR/store/.claude-oauth-token${NC}"
+    echo -e "    ${DIM}Ha a terminalodban mukodik a claude, az NEM eleg: a systemd unit${NC}"
+    echo -e "    ${DIM}nem olvassa a ~/.bashrc-t es a ~/.claude credentialt.${NC}"
+    echo -e "    ${BOLD}Javitas most: ${BLUE}bash \"$INSTALL_DIR/scripts/auth.sh\"${NC}"
+    ;;
+esac
 
 # CLAUDE.md generalasa template-bol
 if [ -f "$INSTALL_DIR/templates/CLAUDE.md.template" ]; then
@@ -1784,3 +1897,19 @@ echo -e "  ${DIM}  ./scripts/start.sh${NC}                           $(_t linux.
 echo -e "  ${DIM}  ./scripts/stop.sh${NC}                            -- leallitas"
 echo ""
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+# The auth verdict is repeated LAST, because the "next steps" above tell the
+# user the bot will answer -- which is false when the services have no working
+# credential. A green frame must not be the final thing a broken install says.
+if [ "${INSTALL_AUTH_STATE:-UNKNOWN}" != "OK" ]; then
+  echo ""
+  if [ "${INSTALL_AUTH_STATE:-}" = "UNKNOWN" ]; then
+    echo -e "  ${ORANGE}! FIGYELEM: az auth-ot nem sikerult ellenoriznunk.${NC}"
+    echo -e "  ${DIM}  Lehet hogy mukodik, de nem igazoltuk. Ha a bot nem valaszol:${NC}"
+  else
+    echo -e "  ${RED}✗ AZ UGYNOKOK MEG NEM FOGNAK VALASZOLNI: hianyzik a mukodo auth kulcs.${NC}"
+    echo -e "  ${DIM}  A fenti 2. lepes (\"irj a botodnak\") addig NEM fog mukodni.${NC}"
+  fi
+  echo -e "  ${BOLD}  Javitas: ${BLUE}bash \"$INSTALL_DIR/scripts/auth.sh\"${NC}${BOLD} majd ${BLUE}bash \"$INSTALL_DIR/scripts/channels.sh\" restart${NC}"
+  echo ""
+fi

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1002,8 +1002,7 @@ else
       _probe_rc=$?
     fi
     _probe_out=${_probe_out:0:200}
-    _probe_out=${_probe_out:0:200}
-  if [ "$_probe_rc" -eq 0 ] && [ -n "$_probe_out" ]; then
+    if [ "$_probe_rc" -eq 0 ] && [ -n "$_probe_out" ]; then
       INSTALL_AUTH_STATE="OK"
     else
       INSTALL_AUTH_STATE="BROKEN"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -44,6 +44,18 @@ INSTALL_ERRLOG=$(mktemp "${TMPDIR:-/tmp}/marveen-install-stderr.XXXXXX")
 exec 2> >(tee -a "$INSTALL_ERRLOG" >&2)
 
 ok() { echo -e "  ${GREEN}✓${NC} $*"; }
+
+# Does the INSTALL carry an auth credential the SERVICES can read?
+# NOT the same question as `claude auth status` / a Keychain login: the launchd
+# units read ONLY <install>/.env and <install>/store/.claude-oauth-token. On
+# macOS `claude auth login` fills the KEYCHAIN and nothing else, so before this
+# change the services were never given a credential at all -- the operator's
+# terminal worked and the agents sat at "Not logged in".
+service_auth_present() {
+  grep -qE '^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=.+' "$INSTALL_DIR/.env" 2>/dev/null && return 0
+  [ -s "$INSTALL_DIR/store/.claude-oauth-token" ] && return 0
+  return 1
+}
 warn() { echo -e "  ${ORANGE}!${NC} $*"; }
 
 offer_claude_fallback() {
@@ -312,6 +324,32 @@ if [[ "$DO_AUTH" == "i" || "$DO_AUTH" == "y" ]]; then
 fi
 echo -e "  ${GREEN}✓${NC} $(_t macos.firstrun_done)"
 
+# Service-side credential. `claude auth login` above authenticates the OPERATOR
+# (Keychain); the launchd units cannot use that. They read .env and
+# store/.claude-oauth-token, so ask for a setup-token unless this install
+# already carries one (re-run, or the dashboard wizard got there first).
+MACOS_OAUTH_TOKEN_INPUT=""
+if service_auth_present; then
+  ok "A telepites mar hordoz auth kulcsot (.env / store/.claude-oauth-token)"
+else
+  echo ""
+  echo -e "  ${BOLD}Az ugynokok kulon hitelesitot igenyelnek.${NC}"
+  echo -e "  ${DIM}A fenti bejelentkezes a Te termnaljadnak szol (Keychain);${NC}"
+  echo -e "  ${DIM}a hatterszolgaltatasok ahhoz nem ferenek hozza.${NC}"
+  echo -e "  ${BOLD}1.${NC} Futtasd egy terminalban: ${BLUE}claude setup-token${NC}"
+  echo -e "  ${BOLD}2.${NC} Masold ide a kiirt tokent (Enter = kihagyas):"
+  read -rp "  OAuth token: " MACOS_OAUTH_TOKEN_INPUT
+  if [ -n "$MACOS_OAUTH_TOKEN_INPUT" ]; then
+    if printf '%s' "$MACOS_OAUTH_TOKEN_INPUT" | grep -Eq '^sk-ant-oat01-[A-Za-z0-9_-]{40,}$'; then
+      ok "Token formailag rendben, elmentjuk a szolgaltatasoknak"
+    else
+      warn "A beirt ertek nem setup-token alaku (sk-ant-oat01-...). Elmentjuk, de ellenorizd."
+    fi
+  else
+    warn "Token nem lett megadva -- az ugynokok igy nem fognak elindulni."
+  fi
+fi
+
 # Pre-flight headless probe — Issue #179.
 # `claude auth login` may exit 0 even when the resulting token is unusable for
 # headless queries (browser flow interrupted, stale cached state, etc.). The
@@ -320,8 +358,14 @@ echo -e "  ${GREEN}✓${NC} $(_t macos.firstrun_done)"
 echo ""
 echo -e "  ${DIM}$(_t macos.headless_test)${NC}"
 set +e
-CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1 | head -c 200)
+# The exit status here used to be `head`'s, not claude's: `VAR=$(cmd | head)`
+# reports the LAST pipeline element, so a failing claude looked like success.
+# PIPESTATUS does NOT help either -- after an assignment it describes the
+# assignment, not the pipeline inside the substitution (measured). Dropping the
+# pipe entirely is the only form that reports claude's own status.
+CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1)
 CLAUDE_PROBE_EXIT=$?
+CLAUDE_PROBE_OUT=${CLAUDE_PROBE_OUT:0:200}
 set -e
 if [ "$CLAUDE_PROBE_EXIT" -eq 0 ] && [ -n "$CLAUDE_PROBE_OUT" ]; then
   echo -e "  ${GREEN}✓${NC} $(_t macos.headless_ok)"
@@ -562,6 +606,75 @@ echo -e "  ${GREEN}✓${NC} $(_t macos.env_created)"
 # Create store directory
 mkdir -p "$INSTALL_DIR/store"
 mkdir -p "$INSTALL_DIR/agents"
+
+# Persist the service-side credential captured in the auth step. Both sinks are
+# needed: .env is what channels.sh exports for the MAIN agent, and the fleet
+# token file is what per-agent config-dir isolation reads for SUB-agents.
+if [ -n "${MACOS_OAUTH_TOKEN_INPUT:-}" ]; then
+  env_merge_key CLAUDE_CODE_OAUTH_TOKEN "$MACOS_OAUTH_TOKEN_INPUT"
+  chmod 600 "$INSTALL_DIR/.env"
+  if printf '%s' "$MACOS_OAUTH_TOKEN_INPUT" | grep -Eq '^sk-ant-oat01-[A-Za-z0-9_-]{40,}$'; then
+    (umask 077 && printf '%s' "$MACOS_OAUTH_TOKEN_INPUT" > "$INSTALL_DIR/store/.claude-oauth-token")
+    ok "Fleet setup-token eltarolva (store/.claude-oauth-token) -- per-agent izolacio aktiv"
+  fi
+fi
+
+# ── Fail-closed auth gate ────────────────────────────────────────────────────
+# Three states; the failure branches must never print the success text.
+INSTALL_AUTH_STATE="BROKEN"
+_svc_token=""
+if [ -s "$INSTALL_DIR/store/.claude-oauth-token" ]; then
+  _svc_token="$(cat "$INSTALL_DIR/store/.claude-oauth-token" 2>/dev/null || true)"
+fi
+if [ -z "$_svc_token" ]; then
+  _svc_token="$(grep -E '^CLAUDE_CODE_OAUTH_TOKEN=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+fi
+_svc_apikey="$(grep -E '^ANTHROPIC_API_KEY=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+
+if ! service_auth_present; then
+  INSTALL_AUTH_STATE="BROKEN"
+elif ! command -v claude >/dev/null 2>&1; then
+  INSTALL_AUTH_STATE="UNKNOWN"
+else
+  # Probe the way a SERVICE runs: isolated config dir (so the Keychain and the
+  # operator's shell cannot make a broken install look healthy) carrying ONLY
+  # the credential the launchd units will get.
+  _probe_cfg="$(mktemp -d 2>/dev/null || echo /tmp/marveen-authprobe.$$)"
+  if [ -n "$_svc_token" ]; then
+    _probe_out="$(env -i PATH="$PATH" HOME="$HOME" CLAUDE_CONFIG_DIR="$_probe_cfg" \
+      CLAUDE_CODE_OAUTH_TOKEN="$_svc_token" claude --print "ping" 2>&1)"
+  else
+    _probe_out="$(env -i PATH="$PATH" HOME="$HOME" CLAUDE_CONFIG_DIR="$_probe_cfg" \
+      ANTHROPIC_API_KEY="$_svc_apikey" claude --print "ping" 2>&1)"
+  fi
+  _probe_rc=$?
+  _probe_out=${_probe_out:0:200}
+  if [ "$_probe_rc" -eq 0 ] && [ -n "$_probe_out" ]; then
+    INSTALL_AUTH_STATE="OK"
+  else
+    INSTALL_AUTH_STATE="BROKEN"
+  fi
+  rm -rf "$_probe_cfg" 2>/dev/null || true
+fi
+unset _svc_token _svc_apikey
+
+case "$INSTALL_AUTH_STATE" in
+  OK)
+    ok "Auth ellenorizve a SZOLGALTATASOK utjan (izolalt konfig + a unitok hitelesitoje)"
+    ;;
+  UNKNOWN)
+    warn "Az auth-ot NEM tudtam ellenorizni (nincs futtathato claude vagy nincs halozat)."
+    echo -e "    ${DIM}A telepites folytatodik, de az ugynokok indulasa nincs igazolva.${NC}"
+    ;;
+  *)
+    warn "AZ UGYNOKOK IGY NEM FOGNAK ELINDULNI: a telepites nem hordoz mukodo auth kulcsot."
+    echo -e "    ${DIM}A szolgaltatasok CSAK ezt a ket helyet olvassak:${NC}"
+    echo -e "    ${DIM}  - $INSTALL_DIR/.env  (CLAUDE_CODE_OAUTH_TOKEN vagy ANTHROPIC_API_KEY)${NC}"
+    echo -e "    ${DIM}  - $INSTALL_DIR/store/.claude-oauth-token${NC}"
+    echo -e "    ${DIM}A Keychain-bejelentkezes (claude auth login) ehhez NEM eleg.${NC}"
+    echo -e "    ${BOLD}Javitas most: ${BLUE}bash \"$INSTALL_DIR/scripts/auth.sh\"${NC}"
+    ;;
+esac
 echo -e "  ${GREEN}✓${NC} $(_t macos.dirs_created)"
 
 # Generate CLAUDE.md from template
@@ -1160,3 +1273,16 @@ echo -e "  ${DIM}Frissites: ./update.sh${NC}"
 echo -e "  ${DIM}Leallitas: ./scripts/stop.sh${NC}"
 echo ""
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+# The auth verdict is repeated LAST: the closing "next steps" tell the user the
+# bot will answer, which is false when the services have no working credential.
+if [ "${INSTALL_AUTH_STATE:-UNKNOWN}" != "OK" ]; then
+  echo ""
+  if [ "${INSTALL_AUTH_STATE:-}" = "UNKNOWN" ]; then
+    echo -e "  ${ORANGE}! FIGYELEM: az auth-ot nem sikerult ellenoriznunk.${NC}"
+  else
+    echo -e "  ${RED}✗ AZ UGYNOKOK MEG NEM FOGNAK VALASZOLNI: hianyzik a mukodo auth kulcs.${NC}"
+  fi
+  echo -e "  ${BOLD}  Javitas: ${BLUE}bash \"$INSTALL_DIR/scripts/auth.sh\"${NC}${BOLD} majd ${BLUE}bash \"$INSTALL_DIR/scripts/channels.sh\" restart${NC}"
+  echo ""
+fi

--- a/src/__tests__/installer-service-auth-gate.test.ts
+++ b/src/__tests__/installer-service-auth-gate.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// The 2026-07-30 bug: every affected install completed "successfully" while the
+// agents sat at "Not logged in" forever. Root cause, measured on a live host:
+// the installer gated its whole auth block on `claude auth status`, which
+// answers "can the OPERATOR's shell reach Claude?" -- and that succeeded
+// because a previous run had exported a (stale) CLAUDE_CODE_OAUTH_TOKEN from
+// ~/.bashrc. The SERVICES read only <install>/.env and
+// <install>/store/.claude-oauth-token, so they got nothing.
+//
+// Same host, same command:
+//   non-interactive shell (how systemd starts a unit): auth status -> FAILS
+//   interactive shell     (how the installer runs):    auth status -> SUCCEEDS
+
+const ROOT = join(__dirname, '..', '..')
+const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+const MACOS = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
+
+/** Pull one shell function out of a script so it can be executed for real. */
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+  if (start < 0) throw new Error(`function ${name}() not found`)
+  const end = src.indexOf('\n}', start)
+  if (end < 0) throw new Error(`unterminated ${name}()`)
+  return src.slice(start, end + 2)
+}
+
+/** Run service_auth_present against a real directory; return its exit status. */
+function runServiceAuthPresent(src: string, installDir: string): boolean {
+  const fn = sliceShellFn(src, 'service_auth_present')
+  const script = `INSTALL_DIR="${installDir}"\n${fn}\nif service_auth_present; then exit 0; else exit 1; fi\n`
+  try {
+    execFileSync('bash', ['-c', script], { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe.each([
+  ['install-linux.sh', LINUX],
+  ['install-macos.sh', MACOS],
+])('%s -- service-side auth gate', (_name, SRC) => {
+  let dir: string
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'svcauth-'))
+    mkdirSync(join(dir, 'store'), { recursive: true })
+  })
+  afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+  // --- behavioural: the helper is EXECUTED, not pattern-matched -------------
+
+  it('is FALSE on a bare install (no .env, no fleet token)', () => {
+    rmSync(join(dir, '.env'), { force: true })
+    rmSync(join(dir, 'store', '.claude-oauth-token'), { force: true })
+    expect(runServiceAuthPresent(SRC, dir)).toBe(false)
+  })
+
+  it('is FALSE when .env exists but carries no auth key', () => {
+    writeFileSync(join(dir, '.env'), 'OWNER_NAME=Teszt\nWEB_PORT=3420\n')
+    expect(runServiceAuthPresent(SRC, dir)).toBe(false)
+  })
+
+  it('is FALSE when the auth key is present but EMPTY (the skipped-prompt case)', () => {
+    writeFileSync(join(dir, '.env'), 'CLAUDE_CODE_OAUTH_TOKEN=\n')
+    expect(runServiceAuthPresent(SRC, dir)).toBe(false)
+  })
+
+  it('is TRUE when .env carries an OAuth token', () => {
+    writeFileSync(join(dir, '.env'), 'CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-' + 'x'.repeat(44) + '\n')
+    expect(runServiceAuthPresent(SRC, dir)).toBe(true)
+  })
+
+  it('is TRUE when .env carries an API key instead', () => {
+    writeFileSync(join(dir, '.env'), 'ANTHROPIC_API_KEY=sk-ant-api03-something\n')
+    expect(runServiceAuthPresent(SRC, dir)).toBe(true)
+  })
+
+  it('is TRUE on the fleet token file alone (sub-agent isolation path)', () => {
+    writeFileSync(join(dir, '.env'), 'OWNER_NAME=Teszt\n')
+    writeFileSync(join(dir, 'store', '.claude-oauth-token'), 'sk-ant-oat01-' + 'y'.repeat(44))
+    expect(runServiceAuthPresent(SRC, dir)).toBe(true)
+  })
+
+  it('is FALSE when the fleet token file exists but is EMPTY', () => {
+    writeFileSync(join(dir, '.env'), 'OWNER_NAME=Teszt\n')
+    writeFileSync(join(dir, 'store', '.claude-oauth-token'), '')
+    expect(runServiceAuthPresent(SRC, dir)).toBe(false)
+  })
+
+  // --- the credential the OPERATOR has must not count ----------------------
+
+  it('never consults ~/.claude, the Keychain, or an exported env token', () => {
+    const fn = sliceShellFn(SRC, 'service_auth_present')
+    expect(fn).not.toMatch(/claude auth status/)
+    expect(fn).not.toMatch(/\.credentials\.json/)
+    expect(fn).not.toMatch(/security find-generic-password/)
+    // reading $CLAUDE_CODE_OAUTH_TOKEN from the environment would reintroduce
+    // the exact ~/.bashrc contamination that caused the bug
+    expect(fn).not.toMatch(/\$\{?CLAUDE_CODE_OAUTH_TOKEN\}?[^=]/)
+  })
+
+  // --- fail-closed: a broken install must not read as success --------------
+
+  it('declares a three-state auth verdict and defaults to BROKEN', () => {
+    expect(SRC).toContain('INSTALL_AUTH_STATE="BROKEN"')
+    expect(SRC).toContain('INSTALL_AUTH_STATE="OK"')
+    expect(SRC).toContain('INSTALL_AUTH_STATE="UNKNOWN"')
+    // the default assignment must come before the probe can set OK
+    expect(SRC.indexOf('INSTALL_AUTH_STATE="BROKEN"'))
+      .toBeLessThan(SRC.indexOf('INSTALL_AUTH_STATE="OK"'))
+  })
+
+  it('probes with an ISOLATED config dir so ambient credentials cannot fake health', () => {
+    expect(SRC).toContain('CLAUDE_CONFIG_DIR="$_probe_cfg"')
+    expect(SRC).toMatch(/env -i /)
+  })
+
+  it('repeats the verdict at the very end when auth is not OK', () => {
+    const guard = SRC.lastIndexOf('${INSTALL_AUTH_STATE:-UNKNOWN}" != "OK"')
+    expect(guard).toBeGreaterThan(0)
+    // nothing but the closing banner may follow -- it must be the last word
+    expect(SRC.slice(guard)).not.toContain('Kovetkezo lepesek')
+  })
+
+  // --- the pipeline-exit trap ---------------------------------------------
+
+  it('captures the probe exit WITHOUT a pipe, so it is claude\'s own status', () => {
+    // `VAR=$(claude ... | head)` reports head's status, and PIPESTATUS does not
+    // rescue it either (after an assignment PIPESTATUS describes the
+    // assignment, not the pipeline inside the substitution). The only correct
+    // form is no pipe at all -- truncate afterwards in the shell.
+    for (const l of SRC.split('\n')) {
+      if (l.includes('claude --print "ping"')) expect(l).not.toContain('| head')
+    }
+    expect(SRC).toMatch(/CLAUDE_PROBE_OUT=\$\{CLAUDE_PROBE_OUT:0:200\}/)
+  })
+})
+
+describe('the PIPESTATUS trap is real (guards the premise of the test above)', () => {
+  it('$? after `VAR=$(cmd | head)` reports head -- and PIPESTATUS does NOT rescue it', () => {
+    const sh = (script: string) =>
+      execFileSync('bash', ['-c', script], { encoding: 'utf-8' }).trim()
+
+    // the original bug: a failing command reads as success
+    expect(sh('out=$(false | head -c 10); echo $?')).toBe('0')
+
+    // the tempting "fix" that does nothing: after an ASSIGNMENT, PIPESTATUS
+    // describes the assignment, not the pipeline inside the substitution
+    expect(sh('out=$(false | head -c 10); echo ${PIPESTATUS[0]}')).toBe('0')
+
+    // PIPESTATUS only works on a BARE pipeline (no assignment) -- which is not
+    // the shape the installer needs, because it wants the output too
+    expect(sh('false | head -c 10 >/dev/null; echo ${PIPESTATUS[0]}')).toBe('1')
+
+    // the form actually shipped: no pipe, truncate afterwards
+    expect(sh('out=$(false 2>&1); rc=$?; out=${out:0:200}; echo $rc')).toBe('1')
+    expect(sh('out=$(echo hi 2>&1); rc=$?; out=${out:0:200}; echo "$rc:$out"')).toBe('0:hi')
+  })
+})
+
+describe('both installers stay parseable', () => {
+  it.each(['install-linux.sh', 'install-macos.sh'])('bash -n %s', (f) => {
+    expect(() => execFileSync('bash', ['-n', join(ROOT, f)], { stdio: 'pipe' })).not.toThrow()
+  })
+})


### PR DESCRIPTION
## ⏰ Ez a soron következő main-promote célja

Ez a fix a soron következő main-promote célja: új telepítések a **main**-ről indulnak, ezért amíg a fix csak a developen van, minden friss telepítés ebbe fut bele. **Kérlek ne bővítsd a scope-ját**: ami mellékesen előkerült, azt lent follow-upként jelöltem, nem javítottam bele.

## A hiba

Minden érintett telepítés "sikeresen" lefutott, miközben a fő ügynök `Not logged in` állapotban ült, és a reauth-healer határidő nélkül újrapróbált (egy gépen 26 eszkaláció és 12 értelmetlen restart hat óra alatt).

> **Pontosítás a riasztás-számhoz.** Az a gép egy korábbi kiadáson futott, még a fél órás eszkalációs kadenciával. A `main` azóta 1 riasztás / ágens / 3 óra korlátot és egy hármas dead-probe küszöböt tartalmaz, tehát a 26-os szám a **régi** viselkedést dokumentálja, nem a jelenlegit. Amit ez a PR megold, az nem a riasztás-gyakoriság, hanem hogy az állapot egyáltalán létrejön: a fail-closed kapu a telepítéskor mondja ki, hogy nem lesz hitelesítő.

**A gyökérok élő gépen mérve, nem következtetve.** Az `install-linux.sh` a TELJES auth-blokkot az `claude auth status`-ra kapuzta. Az viszont más kérdésre felel: "el tudja-e érni az operátor aktuális shellje a Claude-ot?": és ugyanazon a gépen, ugyanazzal a paranccsal:

| shell | `claude auth status` |
|---|---|
| nem-interaktív (így indít a systemd egy unitot) | **BUKIK** |
| interaktív (így fut a telepítő) | **SIKERÜL** |

mert egy korábbi telepítés `export CLAUDE_CODE_OAUTH_TOKEN=...` sort írt a `~/.bashrc`-be. A kapu tehát átengedett, a blokk kimaradt, a `CLAUDE_AUTH_ENV_LINE` és az `OAUTH_TOKEN_INPUT` sosem állt be, így a rájuk épülő két őrző sem a `.env` auth-sorát, sem a `store/.claude-oauth-token`-t nem írta ki: a script viszont kiírta, hogy `.env letrehozva`.

### A mérés, ami eldönti, hogy miért nem elég a kaput "megjavítani"

Egyetlen parancs, két környezet, ugyanazon a gépen, **credential-fájl nélkül**:

```
$ env -i PATH=... HOME=/root claude auth status     # ahogy a systemd indít egy unitot
  -> BUKIK

$ bash -lic 'claude auth status'                    # ahogy a telepítő fut
  -> SIKERÜL

$ ls ~/.claude/.credentials.json
  -> No such file or directory
```

A különbség maga a bizonyíték: nincs hitelesítő a lemezen, a `~/.bashrc` mégis exportál egy 108 karakteres, szabályos alakú `sk-ant-oat01-...` tokent egy korábbi telepítésből. A telepítő tehát **egy másik környezetben kérdez, mint amelyikben a szolgáltatás futni fog**: és pont ezért nem elég a kaput „pontosabbá" tenni: a kérdést kell lecserélni. Ezt csinálja a `service_auth_present()`.

(A szennyezés a mérés után a teszt-gépről eltávolítva, backuppal; azóta az interaktív shell is BUKIK, mint a nem-interaktív.)

**A hiba alakja a lehető legrosszabb:** a telepítő saját 2. lépése mondja, hogy futtasd a `claude setup-token`-t, és épp ettől sikerül a kapu. Aki követi az útmutatást, az bukik.

Az `install-macos.sh` ugyanoda ért más úton: ott a `claude auth login` a **Keychainbe** ír, és a script szolgáltatás-oldali hitelesítőt egyáltalán nem képzett.

## Mit változtat

### A fő védelem: fail-closed záró kapu

Ez nem egy javítás a lista végén, hanem **a fő védelem**, és szándékosan áll elöl. A többi pont a most ismert utat zárja le; ez a kapu a **jövőbeli, még nem ismert utakat is fogja**, mert nem azt kérdezi, hogyan jutottunk ide, hanem hogy a végén van-e működő hitelesítő.

A `.env` létrehozása után három állapot (`OK` / `BROKEN` / `UNKNOWN`, alapértelmezés `BROKEN`). A hiba-ágak soha nem írják ki a siker-szöveget, és a verdikt **utoljára megismétlődik**: a záró "következő lépések" azt mondja, hogy a bot válaszolni fog, ami auth nélkül hazugság. Ha ebből a PR-ből csak egyetlen dolgot lehetne bevinni, ez legyen az.

A próba pedig úgy fut, ahogy egy **szolgáltatás** fut: `env -i` + izolált `CLAUDE_CONFIG_DIR`, kizárólag azzal a hitelesítővel, amit a unitok kapnak. Így az operátor ambiens credentialja nem tud egészségesnek mutatni egy törött telepítést. (Eddig a próba a rossz fát mérte: pont abban az esetben volt zöld, amikor a szolgáltatások el voltak vágva.)

### A most ismert út lezárása

- **`service_auth_present()`**: az egyetlen releváns kérdést teszi fel: hordoz-e EZ A TELEPÍTÉS olyan hitelesítőt, amit a unitok olvasni tudnak (`.env` auth-kulcs, vagy nem üres `store/.claude-oauth-token`). Szándékosan **soha** nem néz a `~/.claude`-ba, a Keychainbe, sem exportált env-tokenbe.
- A prompt mostantól **erre** kapuzódik, nem az `claude auth status`-ra. Ha az operátor shellje be van jelentkezve, de a telepítés nem, azt kimondjuk.
- **macOS:** a Keychain-login után bekérjük a szolgáltatások tokenjét, és mindkét helyre kiírjuk (`.env` a fő ügynöknek, fleet-token fájl a sub-agentek config-dir izolációjához).
- **Próba exit-kód.** A `VAR=$(claude ... | head -c 200)` a `head` státuszát adta, nem a claude-ét. **A `PIPESTATUS` sem javítja**: értékadás után az az értékadást írja le, nem a substitutionön belüli pipeline-t. Ezt megmértem (az első próbálkozásom no-op volt, a saját tesztem buktatta el), ezért a pipe-ot elhagytam, és a shellben vágok.

## Teszt

`src/__tests__/installer-service-auth-gate.test.ts`: 27 teszt, `describe.each` mindkét telepítőre.

A `service_auth_present()`-et **ténylegesen FUTTATJA** valódi temp-könyvtárak ellen, nem szöveget egyeztet: hét eset, köztük a "kulcs jelen van de ÜRES" (ez a kihagyott-prompt esete) és az "üres fleet-token fájl". A `PIPESTATUS`-csapdát mind a négy alakban lefuttatja, hogy a fenti állítás premisszája is bizonyított legyen.

**Negatív kontroll** (a mérőeszköz igazolása):
- a helper visszaolvassa a környezeti tokent → `never consults ~/.claude...` PIROS
- visszateszem a `| head -c 200`-at → `captures the probe exit WITHOUT a pipe` PIROS
- visszaállítás → 27/27 zöld

## Verify

- `tsc --noEmit`: 0 hiba
- teljes suite: **221 fájl / 3050 teszt zöld** (baseline 3023 + 27 új)
- `bash -n` mindkét telepítőre: OK
- `shellcheck -S warning`: **változatlan** (6 linux / 1 macOS, mind meglévő sor)
- em-dash az added sorokban: nincs

## Follow-up: NEM ebben a PR-ben

1. **A szennyezés forrása.** Az `ensure_in_rc 'CLAUDE_CODE_OAUTH_TOKEN' ...` maga írja a tokent a felhasználó `~/.bashrc`-jébe, ahonnan senki nem takarítja ki: és a marker-grep miatt egy elavult sor még az új, helyes tokent is elnyeli. Ez viselkedés-változás, külön PR-t érdemel. Ez a fix úgy készült, hogy a szennyezés jelenlétében is helyes eredményt ad.
2. **A lánc másik fele.** A riasztás-gyakoriságot a `main` már korlátozza (1 / 3 óra). Ami nyitott: a healer sosem mond ki **terminális** állapotot, tehát egy véglegesen halott telepítésen határidő nélkül újrapróbál. Ugyanaz a három-állapot elv kellene, mint fent. Külön kör, mert a recovery-stacket érinti, és előbb mérni kell, hogy egyáltalán javítandó-e.
3. **Nyelv.** Az új telepítő-szövegek ékezet nélküli magyarok, a fájlok meglévő konvenciója szerint (`install-lang.sh` is így van); az `_t` kulcsok kiterjesztése EN-re külön feladat. A repo ékezet-szabálya az ügyfél-facing **dashboard** szövegekre vonatkozik, azokhoz itt nem nyúltam.

Scope tartva: a `scripts/channels.sh`-hoz nem nyúltam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




