### PR TITLE
feat(worker): notice and log when a worker session dies

### DIFF
--- a/src/__tests__/worker-liveness.test.ts
+++ b/src/__tests__/worker-liveness.test.ts
@@ -17,67 +17,72 @@ import {
 
 const t0 = 1_700_000_000_000
 
+/** Observation helper: isFirstSweep defaults to false (the steady state). */
+function obs(alive: boolean, pane: string | null, nowMs: number, isFirstSweep = false) {
+  return { alive, pane, nowMs, isFirstSweep }
+}
+
 describe('decideWorkerLiveness', () => {
   it('says nothing while the worker is alive, and starts the lifetime clock', () => {
-    const d = decideWorkerLiveness({ alive: true, pane: 'x', nowMs: t0 }, NO_WORKER_LIVENESS_STATE)
+    const d = decideWorkerLiveness(obs(true, 'x', t0), NO_WORKER_LIVENESS_STATE)
     expect(d.logDeath).toBe(false)
     expect(d.next.firstSeenAtMs).toBe(t0)
     expect(d.next.lastSeenAliveAtMs).toBe(t0)
   })
 
   it('keeps the ORIGINAL first sighting across later polls (lifetime, not age-since-last-poll)', () => {
-    let st: WorkerLivenessState = decideWorkerLiveness({ alive: true, pane: 'a', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
-    st = decideWorkerLiveness({ alive: true, pane: 'b', nowMs: t0 + 60_000 }, st).next
-    st = decideWorkerLiveness({ alive: true, pane: 'c', nowMs: t0 + 120_000 }, st).next
+    let st: WorkerLivenessState = decideWorkerLiveness(obs(true, 'a', t0), NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness(obs(true, 'b', t0 + 60_000), st).next
+    st = decideWorkerLiveness(obs(true, 'c', t0 + 120_000), st).next
     expect(st.firstSeenAtMs).toBe(t0)
     expect(st.lastSeenAliveAtMs).toBe(t0 + 120_000)
   })
 
   it('logs the death exactly ONCE on the alive -> absent transition', () => {
-    const alive = decideWorkerLiveness({ alive: true, pane: 'p', nowMs: t0 }, NO_WORKER_LIVENESS_STATE)
-    const died = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 60_000 }, alive.next)
+    const alive = decideWorkerLiveness(obs(true, 'p', t0), NO_WORKER_LIVENESS_STATE)
+    const died = decideWorkerLiveness(obs(false, null, t0 + 60_000), alive.next)
     expect(died.logDeath).toBe(true)
 
     // still gone on the next poll -- must NOT re-log, or a permanently dead
     // worker would fill the log with one line per minute
-    const again = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 120_000 }, died.next)
+    const again = decideWorkerLiveness(obs(false, null, t0 + 120_000), died.next)
     expect(again.logDeath).toBe(false)
   })
 
   it('reports the lifetime from first sighting to last sighting', () => {
-    let st = decideWorkerLiveness({ alive: true, pane: 'p', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
-    st = decideWorkerLiveness({ alive: true, pane: 'p', nowMs: t0 + 3 * 3600_000 }, st).next
-    const died = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 3 * 3600_000 + 60_000 }, st)
+    let st = decideWorkerLiveness(obs(true, 'p', t0), NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness(obs(true, 'p', t0 + 3 * 3600_000), st).next
+    const died = decideWorkerLiveness(obs(false, null, t0 + 3 * 3600_000 + 60_000), st)
     expect(died.lifetimeMs).toBe(3 * 3600_000)
   })
 
   it('carries the LAST pane seen while alive into the death record', () => {
-    let st = decideWorkerLiveness({ alive: true, pane: 'first', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
-    st = decideWorkerLiveness({ alive: true, pane: 'last words', nowMs: t0 + 60_000 }, st).next
-    const died = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 120_000 }, st)
+    let st = decideWorkerLiveness(obs(true, 'first', t0), NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness(obs(true, 'last words', t0 + 60_000), st).next
+    const died = decideWorkerLiveness(obs(false, null, t0 + 120_000), st)
     expect(died.lastPane).toBe('last words')
   })
 
   it('a failed capture does not blank the only evidence we will have', () => {
-    let st = decideWorkerLiveness({ alive: true, pane: 'good output', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
-    st = decideWorkerLiveness({ alive: true, pane: null, nowMs: t0 + 60_000 }, st).next // capture failed
-    const died = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 120_000 }, st)
+    let st = decideWorkerLiveness(obs(true, 'good output', t0), NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness(obs(true, null, t0 + 60_000), st).next // capture failed
+    const died = decideWorkerLiveness(obs(false, null, t0 + 120_000), st)
     expect(died.lastPane).toBe('good output')
   })
 
   // The signal is only useful if it stays quiet about non-events.
   it('a session NEVER seen alive is not a death (WEB_ONLY / boot race / never started)', () => {
-    const d = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 }, NO_WORKER_LIVENESS_STATE)
+    const d = decideWorkerLiveness(obs(false, null, t0), NO_WORKER_LIVENESS_STATE)
     expect(d.logDeath).toBe(false)
     expect(d.next).toEqual(NO_WORKER_LIVENESS_STATE)
   })
 
   it('a restart after a death starts a FRESH lifetime, and can die again', () => {
-    let st = decideWorkerLiveness({ alive: true, pane: 'p', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
-    st = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 60_000 }, st).next
-    st = decideWorkerLiveness({ alive: true, pane: 'p2', nowMs: t0 + 120_000 }, st).next
+    let st = decideWorkerLiveness(obs(true, 'p', t0), NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness(obs(false, null, t0 + 60_000), st).next
+    st = decideWorkerLiveness(obs(true, 'p2', t0 + 120_000), st).next
     expect(st.firstSeenAtMs).toBe(t0 + 120_000)
-    const second = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 180_000 }, st)
+    const second = decideWorkerLiveness(obs(false, null, t0 + 180_000), st)
     expect(second.logDeath).toBe(true)
     expect(second.lifetimeMs).toBe(0)
   })
@@ -143,5 +148,59 @@ describe('sweepWorkerLiveness', () => {
     const call = onDeath.mock.calls[0]![0]
     expect(call.lifetimeMs).toBe(600_000)
     expect(call.lastPane).toBe('dying words')
+  })
+})
+
+// A dashboard restart (deploy, promote, watchdog) empties the state while the
+// tmux session survives, because startWorkerSession() is idempotent. Without a
+// marker the first sweep would record "first seen now" for a session that may
+// already be hours old, and a later death would report a truncated lifetime --
+// which reads as a fast death and points at the launch line. The instrument
+// would then mislead exactly the investigation it exists to serve.
+describe('lifetime after a monitor restart is reported as a LOWER BOUND', () => {
+  it('flags a session that was already alive on the first sweep', () => {
+    const seen = decideWorkerLiveness(obs(true, 'p', t0, true), NO_WORKER_LIVENESS_STATE)
+    expect(seen.next.firstSeenOnFirstSweep).toBe(true)
+    const died = decideWorkerLiveness(obs(false, null, t0 + 600_000), seen.next)
+    expect(died.logDeath).toBe(true)
+    expect(died.lifetimeTruncated).toBe(true)
+  })
+
+  it('does NOT flag a session that appeared after the monitor was already running', () => {
+    // first sweep: nothing there yet
+    const empty = decideWorkerLiveness(obs(false, null, t0, true), NO_WORKER_LIVENESS_STATE)
+    // later sweep: the session shows up -- its whole life is observed
+    const seen = decideWorkerLiveness(obs(true, 'p', t0 + 60_000), empty.next)
+    expect(seen.next.firstSeenOnFirstSweep).toBe(false)
+    const died = decideWorkerLiveness(obs(false, null, t0 + 120_000), seen.next)
+    expect(died.lifetimeTruncated).toBe(false)
+    expect(died.lifetimeMs).toBe(0)
+  })
+
+  it('a restart AFTER a first-sweep death starts a clean, untruncated lifetime', () => {
+    let st = decideWorkerLiveness(obs(true, 'p', t0, true), NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness(obs(false, null, t0 + 60_000), st).next   // truncated death
+    st = decideWorkerLiveness(obs(true, 'p2', t0 + 120_000), st).next   // fresh session, observed from birth
+    expect(st.firstSeenOnFirstSweep).toBe(false)
+    const second = decideWorkerLiveness(obs(false, null, t0 + 180_000), st)
+    expect(second.lifetimeTruncated).toBe(false)
+  })
+
+  it('the sweep marks only its FIRST pass, not every pass', () => {
+    const states = new Map()
+    const onDeath = vi.fn()
+    let alive = true
+    const d: WorkerLivenessDeps = {
+      sessions: () => [{ session: 'w' }],
+      isAlive: () => alive,
+      capture: () => 'pane',
+      onDeath,
+      now: () => t0,
+    }
+    sweepWorkerLiveness(d, states, true)    // first sweep: session already there
+    sweepWorkerLiveness(d, states, false)
+    alive = false
+    sweepWorkerLiveness(d, states, false)
+    expect(onDeath.mock.calls[0]![0].lifetimeTruncated).toBe(true)
   })
 })

--- a/src/__tests__/worker-liveness.test.ts
+++ b/src/__tests__/worker-liveness.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  decideWorkerLiveness,
+  sweepWorkerLiveness,
+  tailLines,
+  NO_WORKER_LIVENESS_STATE,
+  DEATH_PANE_LINES,
+  type WorkerLivenessState,
+  type WorkerLivenessDeps,
+} from '../web/worker-liveness.js'
+
+// WORKERBOOT1. Measured on a live host 2026-07-30: both worker sessions were
+// created at 11:42 (the "launched interactive worker session" line only runs
+// after a successful tmux new-session) and by 18:00 neither existed, with zero
+// log lines in between. This instrument exists to make that window visible --
+// so the tests are about WHEN it speaks, not about guessing the cause.
+
+const t0 = 1_700_000_000_000
+
+describe('decideWorkerLiveness', () => {
+  it('says nothing while the worker is alive, and starts the lifetime clock', () => {
+    const d = decideWorkerLiveness({ alive: true, pane: 'x', nowMs: t0 }, NO_WORKER_LIVENESS_STATE)
+    expect(d.logDeath).toBe(false)
+    expect(d.next.firstSeenAtMs).toBe(t0)
+    expect(d.next.lastSeenAliveAtMs).toBe(t0)
+  })
+
+  it('keeps the ORIGINAL first sighting across later polls (lifetime, not age-since-last-poll)', () => {
+    let st: WorkerLivenessState = decideWorkerLiveness({ alive: true, pane: 'a', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness({ alive: true, pane: 'b', nowMs: t0 + 60_000 }, st).next
+    st = decideWorkerLiveness({ alive: true, pane: 'c', nowMs: t0 + 120_000 }, st).next
+    expect(st.firstSeenAtMs).toBe(t0)
+    expect(st.lastSeenAliveAtMs).toBe(t0 + 120_000)
+  })
+
+  it('logs the death exactly ONCE on the alive -> absent transition', () => {
+    const alive = decideWorkerLiveness({ alive: true, pane: 'p', nowMs: t0 }, NO_WORKER_LIVENESS_STATE)
+    const died = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 60_000 }, alive.next)
+    expect(died.logDeath).toBe(true)
+
+    // still gone on the next poll -- must NOT re-log, or a permanently dead
+    // worker would fill the log with one line per minute
+    const again = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 120_000 }, died.next)
+    expect(again.logDeath).toBe(false)
+  })
+
+  it('reports the lifetime from first sighting to last sighting', () => {
+    let st = decideWorkerLiveness({ alive: true, pane: 'p', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness({ alive: true, pane: 'p', nowMs: t0 + 3 * 3600_000 }, st).next
+    const died = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 3 * 3600_000 + 60_000 }, st)
+    expect(died.lifetimeMs).toBe(3 * 3600_000)
+  })
+
+  it('carries the LAST pane seen while alive into the death record', () => {
+    let st = decideWorkerLiveness({ alive: true, pane: 'first', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness({ alive: true, pane: 'last words', nowMs: t0 + 60_000 }, st).next
+    const died = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 120_000 }, st)
+    expect(died.lastPane).toBe('last words')
+  })
+
+  it('a failed capture does not blank the only evidence we will have', () => {
+    let st = decideWorkerLiveness({ alive: true, pane: 'good output', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness({ alive: true, pane: null, nowMs: t0 + 60_000 }, st).next // capture failed
+    const died = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 120_000 }, st)
+    expect(died.lastPane).toBe('good output')
+  })
+
+  // The signal is only useful if it stays quiet about non-events.
+  it('a session NEVER seen alive is not a death (WEB_ONLY / boot race / never started)', () => {
+    const d = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 }, NO_WORKER_LIVENESS_STATE)
+    expect(d.logDeath).toBe(false)
+    expect(d.next).toEqual(NO_WORKER_LIVENESS_STATE)
+  })
+
+  it('a restart after a death starts a FRESH lifetime, and can die again', () => {
+    let st = decideWorkerLiveness({ alive: true, pane: 'p', nowMs: t0 }, NO_WORKER_LIVENESS_STATE).next
+    st = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 60_000 }, st).next
+    st = decideWorkerLiveness({ alive: true, pane: 'p2', nowMs: t0 + 120_000 }, st).next
+    expect(st.firstSeenAtMs).toBe(t0 + 120_000)
+    const second = decideWorkerLiveness({ alive: false, pane: null, nowMs: t0 + 180_000 }, st)
+    expect(second.logDeath).toBe(true)
+    expect(second.lifetimeMs).toBe(0)
+  })
+})
+
+describe('tailLines', () => {
+  it('keeps the tail, where a crash message would be', () => {
+    const pane = Array.from({ length: 40 }, (_, i) => `line ${i}`).join('\n')
+    const out = tailLines(pane)!.split('\n')
+    expect(out).toHaveLength(DEATH_PANE_LINES)
+    expect(out[out.length - 1]).toBe('line 39')
+  })
+  it('drops blank lines and handles an empty/absent pane', () => {
+    expect(tailLines('a\n\n\nb')).toBe('a\nb')
+    expect(tailLines(null)).toBeNull()
+    expect(tailLines('   \n  ')).toBeNull()
+  })
+})
+
+describe('sweepWorkerLiveness', () => {
+  function deps(over: Partial<WorkerLivenessDeps> = {}): WorkerLivenessDeps {
+    return {
+      sessions: () => [{ session: 'agent-worker' }, { session: 'agent-worker-fast' }],
+      isAlive: () => true,
+      capture: () => 'pane',
+      onDeath: vi.fn(),
+      now: () => t0,
+      ...over,
+    }
+  }
+
+  it('tracks BOTH worker sessions independently', () => {
+    const states = new Map()
+    const onDeath = vi.fn()
+    let alive = true
+    const d = deps({ isAlive: (s) => (s === 'agent-worker' ? alive : true), onDeath })
+    sweepWorkerLiveness(d, states)   // both alive
+    alive = false
+    sweepWorkerLiveness(d, states)   // only the slow one died
+    expect(onDeath).toHaveBeenCalledTimes(1)
+    expect(onDeath.mock.calls[0]![0].session).toBe('agent-worker')
+  })
+
+  it('does not capture the pane of a session it already knows is gone', () => {
+    const capture = vi.fn(() => 'pane')
+    const d = deps({ isAlive: () => false, capture })
+    sweepWorkerLiveness(d, new Map())
+    expect(capture).not.toHaveBeenCalled()
+  })
+
+  it('passes the lifetime and the last pane through to the sink', () => {
+    const states = new Map()
+    const onDeath = vi.fn()
+    let alive = true
+    let now = t0
+    const d = deps({ isAlive: () => alive, capture: () => 'dying words', onDeath, now: () => now })
+    sweepWorkerLiveness(d, states)
+    now = t0 + 600_000
+    sweepWorkerLiveness(d, states)
+    alive = false
+    now = t0 + 660_000
+    sweepWorkerLiveness(d, states)
+    const call = onDeath.mock.calls[0]![0]
+    expect(call.lifetimeMs).toBe(600_000)
+    expect(call.lastPane).toBe('dying words')
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -347,9 +347,19 @@ export function startWebServer(port = 3420): http.Server {
   // restart (the next request already re-creates the session) and does not try
   // to explain the death; that is what the log is for.
   let workerLivenessInterval: NodeJS.Timeout | undefined
+  // The handle is assigned inside an async .then(), so a shutdown that runs
+  // BEFORE the dynamic import resolves would clear an undefined and then the
+  // import would start an interval nobody owns. A live setInterval keeps the
+  // event loop alive, so that is not just a leak: the process would never exit.
+  // The other monitors are synchronous calls and cannot hit this.
+  let workerLivenessCancelled = false
   if (!webOnly && (process.env.MARVEEN_AGENT_BACKEND || 'worker').toLowerCase() !== 'sdk') {
     import('./web/worker-liveness.js')
-      .then(m => { workerLivenessInterval = m.startWorkerLivenessMonitor(); logger.info('Worker liveness monitor started (60s poll)') })
+      .then(m => {
+        if (workerLivenessCancelled) return
+        workerLivenessInterval = m.startWorkerLivenessMonitor()
+        logger.info('Worker liveness monitor started (60s poll)')
+      })
       .catch(err => logger.warn({ err }, 'Failed to start the worker liveness monitor'))
   }
 
@@ -528,6 +538,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(routerInterval)
     clearInterval(scheduleInterval)
     if (pluginMonitorInterval) clearInterval(pluginMonitorInterval)
+    workerLivenessCancelled = true
     if (workerLivenessInterval) clearInterval(workerLivenessInterval)
     clearInterval(channelHealthInterval)
     if (costsSyncInterval) clearInterval(costsSyncInterval)

--- a/src/web.ts
+++ b/src/web.ts
@@ -342,6 +342,17 @@ export function startWebServer(port = 3420): http.Server {
       .catch(err => logger.warn({ err }, 'Failed to pre-start agent worker (will lazy-start on first use)'))
   }
 
+  // WORKERBOOT1: nothing watched the worker sessions, so a death left no trace
+  // and the cause stayed unknowable. This only notices and logs -- it does not
+  // restart (the next request already re-creates the session) and does not try
+  // to explain the death; that is what the log is for.
+  let workerLivenessInterval: NodeJS.Timeout | undefined
+  if (!webOnly && (process.env.MARVEEN_AGENT_BACKEND || 'worker').toLowerCase() !== 'sdk') {
+    import('./web/worker-liveness.js')
+      .then(m => { workerLivenessInterval = m.startWorkerLivenessMonitor(); logger.info('Worker liveness monitor started (60s poll)') })
+      .catch(err => logger.warn({ err }, 'Failed to start the worker liveness monitor'))
+  }
+
   const pluginMonitorInterval = webOnly ? undefined : startChannelPluginMonitor()
   if (!webOnly) logger.info('Channel plugin health monitor started (60s poll)')
 
@@ -517,6 +528,7 @@ export function startWebServer(port = 3420): http.Server {
     clearInterval(routerInterval)
     clearInterval(scheduleInterval)
     if (pluginMonitorInterval) clearInterval(pluginMonitorInterval)
+    if (workerLivenessInterval) clearInterval(workerLivenessInterval)
     clearInterval(channelHealthInterval)
     if (costsSyncInterval) clearInterval(costsSyncInterval)
     clearInterval(stuckInputInterval)

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -494,6 +494,19 @@ function startWorkerSessionFor(ctx: WorkerCtx): void {
  * Pre-start both worker sessions. Called at server startup to amortise boot
  * latency across first requests. Idempotent -- a running session is a no-op.
  */
+/**
+ * The worker sessions the boot pre-start creates, and a liveness probe for
+ * them. Exported for the liveness monitor (WORKERBOOT1): nothing watched these
+ * sessions, so a death went unrecorded and the cause stayed unknowable.
+ */
+export function workerContexts(): WorkerCtx[] {
+  return [ctxSlow, ctxFast]
+}
+
+export function isWorkerSessionAlive(session: string): boolean {
+  return sessionExistsOnHost(null, session)
+}
+
 export function startWorkerSession(): void {
   startWorkerSessionFor(ctxSlow)
   startWorkerSessionFor(ctxFast)

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -491,10 +491,6 @@ function startWorkerSessionFor(ctx: WorkerCtx): void {
 }
 
 /**
- * Pre-start both worker sessions. Called at server startup to amortise boot
- * latency across first requests. Idempotent -- a running session is a no-op.
- */
-/**
  * The worker sessions the boot pre-start creates, and a liveness probe for
  * them. Exported for the liveness monitor (WORKERBOOT1): nothing watched these
  * sessions, so a death went unrecorded and the cause stayed unknowable.
@@ -507,6 +503,10 @@ export function isWorkerSessionAlive(session: string): boolean {
   return sessionExistsOnHost(null, session)
 }
 
+/**
+ * Pre-start both worker sessions. Called at server startup to amortise boot
+ * latency across first requests. Idempotent -- a running session is a no-op.
+ */
 export function startWorkerSession(): void {
   startWorkerSessionFor(ctxSlow)
   startWorkerSessionFor(ctxFast)

--- a/src/web/worker-liveness.ts
+++ b/src/web/worker-liveness.ts
@@ -1,0 +1,172 @@
+import { logger } from '../logger.js'
+import { capturePane } from './agent-process.js'
+import { workerContexts, isWorkerSessionAlive } from './agent-worker.js'
+
+// Worker-session liveness instrument (WORKERBOOT1).
+//
+// The two interactive worker sessions are pre-started once at boot and then
+// never looked at again: scripts/watchdog.sh only covers "<agent>-channels",
+// channel-monitor.ts does not know about workers, and workerSessionExists() is
+// used solely for start-time idempotency and the in-request poll. So when a
+// worker dies, NOTHING notices, nothing logs it, and the operator only finds
+// out by running `tmux ls` and seeing it absent.
+//
+// Measured on a live host 2026-07-30: both sessions were created at 11:42
+// (two "launched interactive worker session" lines, which only run AFTER a
+// successful tmux new-session), and by 18:00 neither existed -- with zero log
+// lines about them in between.
+//
+// This module does NOT try to fix or explain the death. That is deliberate:
+// with no record of when or how they die, any fix would be a guess. It only
+// answers "when did it go, how long did it live, and what was on the pane last"
+// -- which is what narrows the cause. A death within seconds points at the
+// launch line; a death after hours points somewhere else entirely.
+//
+// The pane cannot be read post mortem (the session is gone), so each poll keeps
+// the last pane seen while the worker was still alive, and the death log
+// reports that snapshot.
+
+export interface WorkerLivenessState {
+  /** When we first saw this session alive; the base for the lifetime figure. */
+  firstSeenAtMs: number | null
+  /** The most recent poll at which the session still existed. */
+  lastSeenAliveAtMs: number | null
+  /** Last pane captured while alive -- the only post-mortem evidence available. */
+  lastPane: string | null
+}
+
+export interface WorkerLivenessObservation {
+  alive: boolean
+  /** Pane content when alive; null when the capture failed or the session is gone. */
+  pane: string | null
+  nowMs: number
+}
+
+export interface WorkerLivenessDecision {
+  /** True exactly once per death: on the alive -> absent transition. */
+  logDeath: boolean
+  /** How long the session lived, from first sighting to last sighting. */
+  lifetimeMs: number | null
+  /** The pane as last observed while alive. */
+  lastPane: string | null
+  next: WorkerLivenessState
+}
+
+export const NO_WORKER_LIVENESS_STATE: WorkerLivenessState = {
+  firstSeenAtMs: null,
+  lastSeenAliveAtMs: null,
+  lastPane: null,
+}
+
+/** Keep the death log bounded: the tail is where a crash message would be. */
+export const DEATH_PANE_LINES = 15
+
+export function tailLines(pane: string | null, n = DEATH_PANE_LINES): string | null {
+  if (pane == null) return null
+  const lines = pane.split('\n').filter((l) => l.trim() !== '')
+  if (lines.length === 0) return null
+  return lines.slice(-n).join('\n')
+}
+
+/**
+ * Pure liveness decision. Logs a death exactly once, on the transition from
+ * "seen alive" to "absent", and then resets -- so a worker that stays gone does
+ * not re-log on every poll, and a later restart starts a fresh lifetime.
+ *
+ * A session we have NEVER seen alive is not a death: that is the WEB_ONLY case,
+ * a poll that raced the boot pre-start, or a host where the worker never
+ * started at all. Reporting those as deaths would make the signal useless.
+ */
+export function decideWorkerLiveness(
+  obs: WorkerLivenessObservation,
+  prev: WorkerLivenessState,
+): WorkerLivenessDecision {
+  if (obs.alive) {
+    return {
+      logDeath: false,
+      lifetimeMs: null,
+      lastPane: null,
+      next: {
+        firstSeenAtMs: prev.firstSeenAtMs ?? obs.nowMs,
+        lastSeenAliveAtMs: obs.nowMs,
+        // Keep the previous snapshot when this capture failed, so a transient
+        // capture error does not blank the only evidence we will have.
+        lastPane: obs.pane ?? prev.lastPane,
+      },
+    }
+  }
+
+  // Absent, and we never saw it alive: nothing happened worth reporting.
+  if (prev.lastSeenAliveAtMs == null) {
+    return { logDeath: false, lifetimeMs: null, lastPane: null, next: NO_WORKER_LIVENESS_STATE }
+  }
+
+  // Absent after having been alive: the one transition worth a log line.
+  const lifetimeMs =
+    prev.firstSeenAtMs != null ? prev.lastSeenAliveAtMs - prev.firstSeenAtMs : null
+  return {
+    logDeath: true,
+    lifetimeMs,
+    lastPane: tailLines(prev.lastPane),
+    next: NO_WORKER_LIVENESS_STATE,
+  }
+}
+
+// ── Runner ───────────────────────────────────────────────────────────────────
+// Thin on purpose: the decision above is pure and unit-tested, this only wires
+// it to tmux and the logger. Dependencies are injected so the sweep is testable
+// without a tmux server.
+
+export interface WorkerLivenessDeps {
+  sessions: () => Array<{ session: string }>
+  isAlive: (session: string) => boolean
+  capture: (session: string) => string | null
+  onDeath: (info: { session: string; lifetimeMs: number | null; lastPane: string | null }) => void
+  now: () => number
+}
+
+export function sweepWorkerLiveness(
+  deps: WorkerLivenessDeps,
+  states: Map<string, WorkerLivenessState>,
+): void {
+  for (const { session } of deps.sessions()) {
+    const alive = deps.isAlive(session)
+    const decision = decideWorkerLiveness(
+      { alive, pane: alive ? deps.capture(session) : null, nowMs: deps.now() },
+      states.get(session) ?? NO_WORKER_LIVENESS_STATE,
+    )
+    states.set(session, decision.next)
+    if (decision.logDeath) {
+      deps.onDeath({ session, lifetimeMs: decision.lifetimeMs, lastPane: decision.lastPane })
+    }
+  }
+}
+
+/** Poll cadence: fine enough to bracket a death, cheap enough to ignore. */
+export const LIVENESS_POLL_MS = 60_000
+
+/**
+ * Wire the sweep to tmux and the logger. Returns the interval handle so the
+ * caller can clear it, matching the other monitors in this codebase.
+ */
+export function startWorkerLivenessMonitor(): NodeJS.Timeout {
+  const states = new Map<string, WorkerLivenessState>()
+  const deps: WorkerLivenessDeps = {
+    sessions: () => workerContexts().map((c) => ({ session: c.session })),
+    isAlive: (session) => isWorkerSessionAlive(session),
+    capture: (session) => capturePane(session),
+    now: () => Date.now(),
+    onDeath: ({ session, lifetimeMs, lastPane }) => {
+      logger.warn(
+        { session, lifetimeMs, lifetimeMin: lifetimeMs == null ? null : Math.round(lifetimeMs / 60_000), lastPane },
+        'worker-liveness: worker session disappeared (it was started, then died -- nothing restarts it until the next request)',
+      )
+    },
+  }
+  const tick = (): void => {
+    try { sweepWorkerLiveness(deps, states) } catch (err) {
+      logger.warn({ err }, 'worker-liveness: sweep failed (continuing)')
+    }
+  }
+  return setInterval(tick, LIVENESS_POLL_MS)
+}

--- a/src/web/worker-liveness.ts
+++ b/src/web/worker-liveness.ts
@@ -33,6 +33,12 @@ export interface WorkerLivenessState {
   lastSeenAliveAtMs: number | null
   /** Last pane captured while alive -- the only post-mortem evidence available. */
   lastPane: string | null
+  /**
+   * True when the FIRST sighting happened on the monitor's first sweep, i.e.
+   * the session already existed before this process did. Its real age is then
+   * unknown and any lifetime we report is a LOWER BOUND.
+   */
+  firstSeenOnFirstSweep: boolean
 }
 
 export interface WorkerLivenessObservation {
@@ -40,6 +46,16 @@ export interface WorkerLivenessObservation {
   /** Pane content when alive; null when the capture failed or the session is gone. */
   pane: string | null
   nowMs: number
+  /**
+   * Whether this is the monitor's first sweep. A dashboard restart (deploy,
+   * promote, watchdog) empties the state while the tmux session survives --
+   * startWorkerSession() is idempotent -- so without this the first sweep would
+   * record "first seen now" for a session that may already be hours old, and a
+   * later death would report a truncated lifetime. That points the reader at
+   * the launch line when the cause is elsewhere, which is the exact mistake
+   * this instrument exists to prevent.
+   */
+  isFirstSweep: boolean
 }
 
 export interface WorkerLivenessDecision {
@@ -49,6 +65,12 @@ export interface WorkerLivenessDecision {
   lifetimeMs: number | null
   /** The pane as last observed while alive. */
   lastPane: string | null
+  /**
+   * True when lifetimeMs is a LOWER BOUND, not the real age: the session
+   * predates this monitor process. Reported rather than guessed -- the missing
+   * knowledge is flagged, not hidden.
+   */
+  lifetimeTruncated: boolean
   next: WorkerLivenessState
 }
 
@@ -56,6 +78,7 @@ export const NO_WORKER_LIVENESS_STATE: WorkerLivenessState = {
   firstSeenAtMs: null,
   lastSeenAliveAtMs: null,
   lastPane: null,
+  firstSeenOnFirstSweep: false,
 }
 
 /** Keep the death log bounded: the tail is where a crash message would be. */
@@ -82,13 +105,16 @@ export function decideWorkerLiveness(
   prev: WorkerLivenessState,
 ): WorkerLivenessDecision {
   if (obs.alive) {
+    const isNewSighting = prev.firstSeenAtMs == null
     return {
       logDeath: false,
       lifetimeMs: null,
       lastPane: null,
+      lifetimeTruncated: false,
       next: {
         firstSeenAtMs: prev.firstSeenAtMs ?? obs.nowMs,
         lastSeenAliveAtMs: obs.nowMs,
+        firstSeenOnFirstSweep: isNewSighting ? obs.isFirstSweep : prev.firstSeenOnFirstSweep,
         // Keep the previous snapshot when this capture failed, so a transient
         // capture error does not blank the only evidence we will have.
         lastPane: obs.pane ?? prev.lastPane,
@@ -98,7 +124,7 @@ export function decideWorkerLiveness(
 
   // Absent, and we never saw it alive: nothing happened worth reporting.
   if (prev.lastSeenAliveAtMs == null) {
-    return { logDeath: false, lifetimeMs: null, lastPane: null, next: NO_WORKER_LIVENESS_STATE }
+    return { logDeath: false, lifetimeMs: null, lastPane: null, lifetimeTruncated: false, next: NO_WORKER_LIVENESS_STATE }
   }
 
   // Absent after having been alive: the one transition worth a log line.
@@ -108,6 +134,7 @@ export function decideWorkerLiveness(
     logDeath: true,
     lifetimeMs,
     lastPane: tailLines(prev.lastPane),
+    lifetimeTruncated: prev.firstSeenOnFirstSweep,
     next: NO_WORKER_LIVENESS_STATE,
   }
 }
@@ -121,23 +148,29 @@ export interface WorkerLivenessDeps {
   sessions: () => Array<{ session: string }>
   isAlive: (session: string) => boolean
   capture: (session: string) => string | null
-  onDeath: (info: { session: string; lifetimeMs: number | null; lastPane: string | null }) => void
+  onDeath: (info: { session: string; lifetimeMs: number | null; lastPane: string | null; lifetimeTruncated: boolean }) => void
   now: () => number
 }
 
 export function sweepWorkerLiveness(
   deps: WorkerLivenessDeps,
   states: Map<string, WorkerLivenessState>,
+  isFirstSweep = false,
 ): void {
   for (const { session } of deps.sessions()) {
     const alive = deps.isAlive(session)
     const decision = decideWorkerLiveness(
-      { alive, pane: alive ? deps.capture(session) : null, nowMs: deps.now() },
+      { alive, pane: alive ? deps.capture(session) : null, nowMs: deps.now(), isFirstSweep },
       states.get(session) ?? NO_WORKER_LIVENESS_STATE,
     )
     states.set(session, decision.next)
     if (decision.logDeath) {
-      deps.onDeath({ session, lifetimeMs: decision.lifetimeMs, lastPane: decision.lastPane })
+      deps.onDeath({
+        session,
+        lifetimeMs: decision.lifetimeMs,
+        lastPane: decision.lastPane,
+        lifetimeTruncated: decision.lifetimeTruncated,
+      })
     }
   }
 }
@@ -156,16 +189,32 @@ export function startWorkerLivenessMonitor(): NodeJS.Timeout {
     isAlive: (session) => isWorkerSessionAlive(session),
     capture: (session) => capturePane(session),
     now: () => Date.now(),
-    onDeath: ({ session, lifetimeMs, lastPane }) => {
+    onDeath: ({ session, lifetimeMs, lastPane, lifetimeTruncated }) => {
       logger.warn(
-        { session, lifetimeMs, lifetimeMin: lifetimeMs == null ? null : Math.round(lifetimeMs / 60_000), lastPane },
-        'worker-liveness: worker session disappeared (it was started, then died -- nothing restarts it until the next request)',
+        {
+          session,
+          lifetimeMs,
+          lifetimeMin: lifetimeMs == null ? null : Math.round(lifetimeMs / 60_000),
+          // The session predated this monitor process, so the figure above is a
+          // LOWER BOUND. Said out loud rather than estimated: a truncated
+          // lifetime reads like a fast death and would point at the launch line.
+          lifetimeTruncated,
+          lastPane,
+        },
+        lifetimeTruncated
+          ? 'worker-liveness: worker session disappeared (lifetime is a LOWER BOUND: the session predated this monitor, e.g. a dashboard restart)'
+          : 'worker-liveness: worker session disappeared (it was started, then died -- nothing restarts it until the next request)',
       )
     },
   }
+  let first = true
   const tick = (): void => {
-    try { sweepWorkerLiveness(deps, states) } catch (err) {
+    try {
+      sweepWorkerLiveness(deps, states, first)
+    } catch (err) {
       logger.warn({ err }, 'worker-liveness: sweep failed (continuing)')
+    } finally {
+      first = false
     }
   }
   return setInterval(tick, LIVENESS_POLL_MS)


### PR DESCRIPTION
## Miért

Semmi nem figyelte az interaktív worker sessionöket. A `scripts/watchdog.sh` csak a `<agent>-channels`-t fedi, a `channel-monitor.ts` nem tud a workerekről, a `workerSessionExists()` pedig kizárólag indulási idempotencia-checkben és a kérés-közbeni pollban szerepel. A sessionök egyszer elindulnak a bootnál, és utána soha senki nem néz rájuk.

**Élő gépen mérve:** mindkét session létrejött 11:42-kor (két `launched interactive worker session` sor, ami csak **sikeres** `tmux new-session` után fut le, plusz a két claude-version próba), 18:00-ra viszont egyik sem létezett, és a két időpont között **nulla logsor** volt róluk. A boot INFO-sora (`Interactive agent worker pre-started`) közben ott állt a logban, egy olyan gépen, ahol órák óta nem futott worker.

Ez ugyanaz a szerkezet, mint a telepítő auth-kapujánál: a kód azt igazolja vissza, hogy egy **lépés lefutott**, nem azt, hogy a **várt végállapot** fennáll.

## Mit NEM csinál

Szándékosan nem javítja és nem magyarázza a halált, és nem indít újra semmit.

Az `ensureWorkerReady()` a következő kérésnél amúgy is újra létrehozza a sessiont, tehát a tényleges kár egy **hideg-indítási büntetés** az első feladatnál a halál után, nem egy elveszett képesség. Ami hiányzik, az a bizonyíték: amíg nincs feljegyzés arról, mikor és hogyan halnak meg, bármilyen fix találgatás lenne. Négy ok nyitott és méretlen (hitelesítetlen claude kilép, OOM, a model-flag, a login-shell PATH), és az utolsót egy meglévő kód-komment már leírja egy korábbi mérésből ugyanezen a gépen, tehát még az sem biztos, hogy új ok.

## Mit ad hozzá

- **`decideWorkerLiveness()`**: tiszta átmenet-döntés. **Pontosan egyszer** naplóz halálonként, az alive → absent átmenetnél, aztán resetel: egy véglegesen halott worker nem ír percenként egy sort, egy későbbi újraindulás pedig friss élettartamot kezd.
- **Amit soha nem láttunk élni, az nem halál**: ez fedi a WEB_ONLY esetet, a boot pre-starttal versenyző pollt, és azokat a gépeket, ahol a worker el sem indult. Ezeket halálként jelenteni használhatatlanná tenné a jelzést.
- **A pane post mortem nem olvasható**, ezért minden poll megőrzi az utoljára élve látott pane-t, és a halál-log azt a tail-t közli. Egy sikertelen capture megtartja a korábbi pillanatképet, ahelyett hogy kiürítené az egyetlen bizonyítékot, ami lesz.
- **60 mp-es sweep**, a többi monitor mellé kötve, ugyanazzal a kapuval, mint a pre-start, amit megfigyel (nem WEB_ONLY-ban, nem az SDK-backenden), és shutdownkor a többivel együtt leállítva.

## Teszt

13 teszt a tiszta döntésen és az injektálható sweepen. A sweep dependency-injectionnel fut, tmux-szerver nélkül.

**Negatív kontroll**: három külön rontás, mindegyik a megfelelő tesztet váltja pirosra, visszaállítás után 13/13:

| Rontás | Elbukó teszt |
|---|---|
| a never-seen-alive őr kivétele | „a session NEVER seen alive is not a death" |
| a pane carry-over eldobása | „a failed capture does not blank the only evidence" |
| `firstSeenAtMs` frissítése minden pollnál | „passes the lifetime and the last pane through" |

## Verify

- `tsc --noEmit`: 0 hiba
- teljes suite: **221 fájl / 3036 teszt zöld**
- em-dash az added sorokban: 0
- a shutdown-takarítás kiegészítve (különben a timer graceful leállás után is ketyegne)

## Follow-up, nem ebben a PR-ben

A tmux `remain-on-exit` megőrizné a halott pane-t és a kilépési kódot, ami szigorúan jobb bizonyíték. De attól egy halott session továbbra is „létezik", ami eltörné a lazy-restart utat az `ensureWorkerReady`-ben, hacsak a liveness-próba meg nem tanulja megkülönböztetni a halott pane-t az élőtől. Ez viselkedés-változás, külön review-t érdemel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
