### PR TITLE
fix(onboarding): resolve the real agent id before asking for pending pairings

### DIFF
--- a/src/__tests__/wizard-pending-agent-id.test.ts
+++ b/src/__tests__/wizard-pending-agent-id.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// PAIRAPPROVE1. On a renamed install the onboarding wizard showed "no pending
+// pairing" while the agent's Channel view listed the very same request.
+//
+// Cause, traced through the code: the wizard asks mainAgentId(), which falls
+// back to the literal 'marveen' until /api/marveen has populated
+// window._marveen. On a renamed install that literal is NOT the main agent, so
+// the backend takes its sub-agent branch (agents.ts: name !== MAIN_AGENT_ID &&
+// !existsSync(agentDir(name))) and answers 404 -- which the wizard then parsed
+// as a body and turned into an empty list. The Channel view uses the selected
+// agent, so it was unaffected.
+//
+// The same boot race is already documented and guarded for the Messages page
+// (ensureMarveenLoaded). This change applies that existing guard at the second
+// call site; it deliberately does NOT remove the mainAgentId() fallback, which
+// other call sites rely on.
+//
+// The wizard step is not unit-mountable, so these are structural assertions
+// over the source -- the convention this repo already uses for installer and
+// template invariants. What they lock is ORDER and PRESENCE, which is exactly
+// what a later refactor would silently drop.
+
+const APP = readFileSync(join(__dirname, '..', '..', 'web', 'app.js'), 'utf-8')
+
+/** The wizard's step-4 pending loader. */
+function loadPendingBlock(): string {
+  const start = APP.indexOf('const loadPending = async () => {')
+  expect(start, 'loadPending not found').toBeGreaterThan(0)
+  return APP.slice(start, start + 2000)
+}
+
+describe('PAIRAPPROVE1: the wizard resolves the real agent id before asking', () => {
+  it('the boot-race guard still exists and is what we reuse', () => {
+    expect(APP).toContain('async function ensureMarveenLoaded()')
+    // it must remain a no-op once the id is known, or every poll refetches
+    expect(APP).toMatch(/async function ensureMarveenLoaded\(\)\s*\{\s*\n\s*if \(window\._marveen\?\.agentId\) return/)
+  })
+
+  it('awaits the guard BEFORE fetching pending (order is the whole fix)', () => {
+    const blk = loadPendingBlock()
+    const guard = blk.indexOf('await ensureMarveenLoaded()')
+    const fetchAt = blk.indexOf('await fetch(')
+    expect(guard, 'guard not called in loadPending').toBeGreaterThan(-1)
+    expect(fetchAt).toBeGreaterThan(-1)
+    expect(guard).toBeLessThan(fetchAt)
+  })
+
+  it('checks res.ok and shows the error instead of an empty list', () => {
+    const blk = loadPendingBlock()
+    expect(blk).toContain('if (!res.ok)')
+    // the failure branch must render something, not fall through to the
+    // "no pending" hint -- that was the silent-empty defect
+    const bad = blk.indexOf('if (!res.ok)')
+    const noPending = blk.indexOf('onboarding.step3.no_pending')
+    expect(bad).toBeLessThan(noPending)
+    expect(blk.slice(bad, noPending)).toMatch(/onbPending/)
+  })
+
+  it('does NOT parse the response before knowing it succeeded', () => {
+    const blk = loadPendingBlock()
+    // The original bug shape: `await (await fetch(...)).json()` in one go, which
+    // parses a 404 body as if it were the payload.
+    // NOTE: a `[^)]*` inner pattern does NOT work here -- the URL itself
+    // contains `encodeURIComponent(...)`, so the class stops at the first
+    // paren and the assertion silently passes on the buggy form. Match
+    // non-greedily across parens instead. (Caught by a negative control that
+    // failed only one test where it should have failed two.)
+    expect(blk).not.toMatch(/await \(await fetch\([\s\S]*?\)\.json\(\)/)
+  })
+
+  it('leaves the mainAgentId fallback alone (other call sites depend on it)', () => {
+    expect(APP).toMatch(/return window\._marveen\?\.agentId \|\| 'marveen'/)
+  })
+
+  it('keeps the expiry filter, which is correct (the plugin writes ms)', () => {
+    // measured in the telegram plugin source: expiresAt = now + 60*60*1000
+    const blk = loadPendingBlock()
+    expect(blk).toMatch(/x\.expiresAt > now/)
+  })
+})

--- a/src/__tests__/wizard-pending-agent-id.test.ts
+++ b/src/__tests__/wizard-pending-agent-id.test.ts
@@ -25,11 +25,25 @@ import { join } from 'node:path'
 
 const APP = readFileSync(join(__dirname, '..', '..', 'web', 'app.js'), 'utf-8')
 
-/** The wizard's step-4 pending loader. */
+/**
+ * The wizard's step-4 pending loader, sliced to its ACTUAL end.
+ *
+ * A fixed-width window was the first version, and it was 116 characters from
+ * overflowing: two of the assertions below are NEGATIVE (`not.toMatch`), and a
+ * negative assertion over a truncated haystack passes silently when the pattern
+ * it is meant to exclude simply falls outside the window. That is the same
+ * failure as the over-narrow `[^)]*` in this file, one level up: the instrument
+ * stops measuring what you think it measures. Anchor on the closing catch
+ * instead, and fail loudly if the anchor is missing.
+ */
+const BLOCK_END_ANCHOR = 'showPendingError((e && e.message)'
+
 function loadPendingBlock(): string {
   const start = APP.indexOf('const loadPending = async () => {')
   expect(start, 'loadPending not found').toBeGreaterThan(0)
-  return APP.slice(start, start + 2000)
+  const end = APP.indexOf(BLOCK_END_ANCHOR, start)
+  expect(end, 'loadPending end anchor not found -- the slice would be truncated and the negative assertions meaningless').toBeGreaterThan(start)
+  return APP.slice(start, end + BLOCK_END_ANCHOR.length)
 }
 
 describe('PAIRAPPROVE1: the wizard resolves the real agent id before asking', () => {
@@ -79,5 +93,29 @@ describe('PAIRAPPROVE1: the wizard resolves the real agent id before asking', ()
     // measured in the telegram plugin source: expiresAt = now + 60*60*1000
     const blk = loadPendingBlock()
     expect(blk).toMatch(/x\.expiresAt > now/)
+  })
+})
+
+// The two failure paths must BOTH reach the user. res.ok covers a 404 or an
+// auth error; a network failure rejects the fetch and only the outer catch sees
+// it. Covering one and not the other would leave the comment claiming more than
+// the code does.
+describe('both failure paths surface, and they look different from "no pending"', () => {
+  it('routes the !res.ok branch through the shared error sink', () => {
+    expect(loadPendingBlock()).toMatch(/if \(!res\.ok\)[\s\S]*?showPendingError\(/)
+  })
+
+  it('the outer catch is no longer silent', () => {
+    const blk = loadPendingBlock()
+    expect(blk).not.toMatch(/catch \{ \/\* ignore \*\/ \}/)
+    expect(blk).toMatch(/catch \(e\)[\s\S]*?showPendingError\(/)
+  })
+
+  it('the error sink also uses onbMsg, not just the muted hint slot', () => {
+    // the box alone renders in the same onb-hint style as "no pending", so the
+    // distinction this fix is about would stay invisible
+    const sink = APP.slice(APP.indexOf('const showPendingError ='), APP.indexOf('const loadPending ='))
+    expect(sink).toMatch(/onbPending/)
+    expect(sink).toMatch(/onbMsg\(msg, true\)/)
   })
 })

--- a/web/app.js
+++ b/web/app.js
@@ -12044,6 +12044,16 @@ function wireOnboarding(step) {
     })
   } else if (step === 4) {
     const refreshBtn = document.getElementById('onbRefreshBtn')
+    // One sink for both failure paths. The box alone was not enough: it renders
+    // in the same muted onb-hint slot as "no pending", so the very distinction
+    // this fix is about -- "nobody is waiting" vs "I could not ask" -- stayed
+    // invisible. onbMsg is the error channel this function already uses for the
+    // approve step a few lines below.
+    const showPendingError = (msg) => {
+      const box = document.getElementById('onbPending')
+      if (box) box.innerHTML = `<span class="onb-hint">${escapeHtml(msg)}</span>`
+      onbMsg(msg, true)
+    }
     const loadPending = async () => {
       try {
         // Same boot race the Messages page already guards against (see
@@ -12056,13 +12066,14 @@ function wireOnboarding(step) {
         await ensureMarveenLoaded()
         const res = await fetch(`/api/agents/${encodeURIComponent(mainAgentId())}/channels/telegram/pending`)
         // Surface the failure instead of rendering it as an empty list. This is
-        // a separate defect from the id race: without it ANY error (404, auth,
-        // network) reads as "nobody is waiting for approval", which is the one
-        // answer the user cannot act on.
+        // a separate defect from the id race: without it a 404 or an auth error
+        // reads as "nobody is waiting for approval", which is the one answer the
+        // user cannot act on. A NETWORK failure does not land here at all -- the
+        // fetch rejects -- so the outer catch carries the same message; see the
+        // end of this function. The two together are what make the comment true.
         if (!res.ok) {
-          const box = document.getElementById('onbPending')
           const d = await res.json().catch(() => ({}))
-          if (box) box.innerHTML = `<span class="onb-hint">${escapeHtml(d.error || t('onboarding.error'))}</span>`
+          showPendingError(d.error || t('onboarding.error'))
           return
         }
         const p = await res.json()
@@ -12089,7 +12100,12 @@ function wireOnboarding(step) {
             setTimeout(refreshOnboarding, 1500)
           } catch (e) { b.disabled = false; onbMsg((e && e.message) || t('onboarding.error'), true) }
         }))
-      } catch { /* ignore */ }
+      } catch (e) {
+        // Network-level failure: the fetch rejected, so the !res.ok branch never
+        // ran. Without this the box stays empty and the user reads it as "nobody
+        // is waiting" -- the exact defect this change is about.
+        showPendingError((e && e.message) || t('onboarding.error'))
+      }
     }
     if (refreshBtn) refreshBtn.addEventListener('click', () => { refreshOnboarding() })
     loadPending()

--- a/web/app.js
+++ b/web/app.js
@@ -12046,7 +12046,26 @@ function wireOnboarding(step) {
     const refreshBtn = document.getElementById('onbRefreshBtn')
     const loadPending = async () => {
       try {
-        const p = await (await fetch(`/api/agents/${encodeURIComponent(mainAgentId())}/channels/telegram/pending`)).json()
+        // Same boot race the Messages page already guards against (see
+        // ensureMarveenLoaded): until /api/marveen resolves window._marveen,
+        // mainAgentId() returns the literal 'marveen' fallback. On a renamed
+        // install that is not the main agent, so the backend takes the
+        // sub-agent branch, finds no such agent dir and answers 404 -- and the
+        // wizard rendered that as "no pending pairing" while the Channel view,
+        // which uses the selected agent, listed the very same request.
+        await ensureMarveenLoaded()
+        const res = await fetch(`/api/agents/${encodeURIComponent(mainAgentId())}/channels/telegram/pending`)
+        // Surface the failure instead of rendering it as an empty list. This is
+        // a separate defect from the id race: without it ANY error (404, auth,
+        // network) reads as "nobody is waiting for approval", which is the one
+        // answer the user cannot act on.
+        if (!res.ok) {
+          const box = document.getElementById('onbPending')
+          const d = await res.json().catch(() => ({}))
+          if (box) box.innerHTML = `<span class="onb-hint">${escapeHtml(d.error || t('onboarding.error'))}</span>`
+          return
+        }
+        const p = await res.json()
         // Backend contract: [{code, senderId, chatId, createdAt, expiresAt}].
         // `code` is the approve key (the same code the bot sent the user) --
         // POSTing anything else gets a 400 and the pairing never completes.


### PR DESCRIPTION
## ⚠️ Verify-hiány, kimondva

**A friss-telepítés-úti verify NEM történt meg.** A változás egy létező guard-mintát alkalmaz egy második hívási helyre, és a teljes suite zöld, de azt az utat, amiről a fix szól (friss telepítés varázslója átnevezett ágens-idvel), nem láttuk futni. A verify a következő friss telepítésen esedékes.

Ez nem szépítőkendő: aki ezt fél év múlva olvassa, tudja meg, mi van igazolva és mi nincs.

## A hiba

Átnevezett telepítésen a varázsló azt írta, hogy „nincs függőben lévő párosítás", miközben az ágens saját Csatorna-nézete listázta ugyanazt a kérést. Az operátor csak úgy tudta befejezni a párosítást, ha kilépett a varázslóból.

A két olvasási út összevetése adta meg az okot:

| Út | Kit kérdez | Eredmény |
|---|---|---|
| Csatorna-nézet | a **kiválasztott** ágenst (`currentAgent.name`) | a helyes `access.json` |
| Varázsló | `mainAgentId()` | a literál `'marveen'`, amíg a `window._marveen` be nem töltött |

Átnevezett telepítésen az a literál **nem** a fő ágens, ezért a backend a sub-agent ágra megy (`name !== MAIN_AGENT_ID && !existsSync(agentDir(name))`) és **404**-et ad. A varázsló ezt a 404 testét payloadként parse-olta, és a `p.pending || []` üres listává alakította. **Némán**: nincs hibaüzenet, csak „senki nem vár jóváhagyásra".

**A boot-race nem új és nem elméleti:** az Üzenetek-oldalon már egyszer bekövetkezett, dokumentálva van, és akkor készült rá a guard (`ensureMarveenLoaded`). Az a guard **létezett, de egyetlen hívási helyen volt bekötve.** Ez a PR a másodikra is alkalmazza.

## Mit változtat

Két sor, mindkettő létező mintát követ:

1. `await ensureMarveenLoaded()` a pending-fetch előtt
2. `res.ok` ellenőrzés, és hiba esetén **látható üzenet** a „nincs pending" hint helyett

A második **önálló defekt**, és akkor is bent marad, ha az első megoldja az ismert esetet: nélküle bármilyen hiba (auth, hálózat, egy jövőbeli 404) továbbra is úgy jelenne meg, hogy „senki nem vár jóváhagyásra" - ez az egyetlen válasz, amire a felhasználó nem tud reagálni. A guard ráadásul szándékosan best-effort (elnyeli a saját fetch-hibáját), tehát maradék verseny lehetséges; ez teszi láthatóvá némán bukás helyett.

## Amihez szándékosan nem nyúltam

A `mainAgentId()` fallbackja marad. Más hívási helyek támaszkodnak rá, és a saját dokumentált guardjánál lévő komment szándékos átmeneti állapotként írja le. A guard a helyes válasz, nem a fallback kivétele.

**Mérve és kizárva**, hogy ne induljon el rajta senki: a varázsló `expiresAt`-szűrője **nem** egység-eltérés. A Telegram plugin ezredmásodpercben ír (`now + 60*60*1000`, és a saját skillje is `<ms>`-t dokumentál), tehát a szűrő helyes és marad.

## Teszt

6 strukturális állítás a varázsló forrása felett (a lépés nem mountolható egységben; ugyanaz a konvenció, amit a telepítő- és template-invariánsok használnak). **Sorrendet és jelenlétet** rögzítenek: a guard megelőzi a fetchet, a `res.ok` a „nincs pending" ág előtt dől el, az egylépéses `await (await fetch(...)).json()` alak eltűnt, és a fallback a helyén van.

**Negatív kontroll:** a guard-hívás kivétele, a fetch mögé mozgatása, és a régi egylépéses parse visszatétele mind pirosra váltja a megfelelő teszteket.

A harmadik kontroll először **csak egy** tesztet buktatott, pedig kettőt kellett volna: az állítás `[^)]*` része megállt az `encodeURIComponent(...)` zárójelénél, így átment a hibás alakon. A mintát kiszélesítettem, és a kontroll most mindkettőt bukja. A megjegyzés bent maradt a tesztben.

## Verify

- `tsc --noEmit`: 0 hiba
- `node --check web/app.js`: OK
- teljes suite: **221 fájl / 3029 teszt zöld**
- em-dash az added sorokban: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
