### PR TITLE
docs(dashboard): keep the boot-race comment install-agnostic, and fix its inverted claim

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -10950,11 +10950,11 @@ function chatAvatarHtml(agentName, size = 32) {
 
 // Guard against the boot race: the Messages page can be opened before the
 // initial /api/marveen fetch resolves window._marveen. Until it does,
-// mainAgentId() returns the literal 'marveen' FALLBACK, which is a real agent
-// id on no install here -- composing to it creates a phantom "marveen" thread
-// that sits pending forever and shows up as a duplicate of the true main agent
-// (whatever id this install actually uses). Resolve _marveen before rendering
-// any chat target.
+// mainAgentId() returns the literal 'marveen' FALLBACK, which IS a real agent
+// id on a default install but is NOT one wherever the main agent was renamed
+// -- composing to it creates a phantom "marveen" thread that sits pending
+// forever and shows up as a duplicate of the true main agent (whatever id this
+// install actually uses). Resolve _marveen before rendering any chat target.
 async function ensureMarveenLoaded() {
   if (window._marveen?.agentId) return
   try {

--- a/web/app.js
+++ b/web/app.js
@@ -10953,7 +10953,8 @@ function chatAvatarHtml(agentName, size = 32) {
 // mainAgentId() returns the literal 'marveen' FALLBACK, which is a real agent
 // id on no install here -- composing to it creates a phantom "marveen" thread
 // that sits pending forever and shows up as a duplicate of the true main agent
-// (torpapa). Resolve _marveen before rendering any chat target.
+// (whatever id this install actually uses). Resolve _marveen before rendering
+// any chat target.
 async function ensureMarveenLoaded() {
   if (window._marveen?.agentId) return
   try {


### PR DESCRIPTION
## What

Two fixes to one comment block in `web/app.js`, the boot-race note above `ensureMarveenLoaded()`.

1. **It named one specific install's main agent id** as its worked example. The guard is generic, so the comment now says "whatever id this install actually uses".

2. **It stated the opposite of what the guard is for.** The old line read:

   > the literal `'marveen'` FALLBACK, which is a real agent id on no install here

   That suggests the fallback is never a real id. The point is the other way round: it **is** the real id on a default install, and is **not** one wherever the main agent was renamed. That second case is exactly when composing to the fallback produces the phantom thread, so the sentence was hiding the reason the guard exists.

Comment text only. No code path, no behavior change.

## Verify

- `node --check web/app.js` passes
- the old id is gone from every tracked file (`git grep -i` finds nothing), and the same pattern still matches on the pre-change revision, so the search itself works rather than silently returning empty
- no em-dash in the touched lines

## Provenance of the wording bug

The whole comment block landed in one commit in #763, so the inverted sentence is an original typo, not the residue of an earlier scrub pass. Worth knowing before assuming something was rewritten.
