### PR TITLE
feat(costops): price token usage as a list-price equivalent (v0.2)

### DIFF
--- a/src/__tests__/costops-api.test.ts
+++ b/src/__tests__/costops-api.test.ts
@@ -41,14 +41,42 @@ describe('costops API (route smoke)', () => {
     expect(out.body).toHaveProperty('breakdown')
     expect(out.body).toHaveProperty('budget')
     expect(out.body).toHaveProperty('token_usage')
-    // token usage reported as VOLUME
+    // token usage reported as VOLUME, plus a labelled list-price equivalent
     expect(out.body.token_usage.input_tokens).toBe(1234)
     expect(out.body.token_usage.output_tokens).toBe(5678)
-    expect(out.body.token_usage.note).toContain('not priced')
+    expect(out.body.token_usage.note).toContain('LIST-PRICE EQUIVALENT')
+    expect(out.body.token_usage.list_price_equivalent.basis).toBe('list_price_equivalent')
+    expect(out.body.token_usage.list_price_equivalent.currency).toBe('USD')
     // money never derived from tokens (config amounts are 0 placeholders)
     expect(typeof out.body.current_spend).toBe('number')
     // no secret / account id leaks into the response
     expect(JSON.stringify(out.body)).not.toMatch(/secret|api[_-]?key|password|token=/i)
+  })
+
+  it('GET /api/costs/tokens prices a rolling window and labels its basis', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    getDb().prepare("INSERT INTO token_usage (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens,model) VALUES ('marveen','s',?,0,1000000,0,0,'claude-opus-5')").run(now - 3600)
+    const { ctx, out } = fakeCtx('/api/costs/tokens?days=7')
+    expect(await tryHandleCosts(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    expect(out.body.basis).toBe('list_price_equivalent')
+    expect(out.body.currency).toBe('USD')
+    expect(out.body.total).toBeCloseTo(25, 6) // 1M output tokens at $25/1M
+    expect(out.body.by_model[0].model).toBe('claude-opus-5')
+  })
+
+  it('GET /api/costs/tokens clamps an absurd or unparseable days parameter', async () => {
+    // The window is attacker-visible input on a bearer-gated route; an
+    // unbounded lookback would turn a read into a full-table scan.
+    const now = Math.floor(Date.now() / 1000)
+    for (const [q, maxDays] of [['days=99999', 400], ['days=abc', 7], ['days=-5', 1]] as const) {
+      const { ctx, out } = fakeCtx(`/api/costs/tokens?${q}`)
+      expect(await tryHandleCosts(ctx)).toBe(true)
+      expect(out.status).toBe(200)
+      const spanDays = (out.body.window.end - out.body.window.start) / 86400
+      expect(spanDays, `${q} produced a ${spanDays}-day window`).toBeLessThanOrEqual(maxDays)
+      expect(out.body.window.end).toBeGreaterThanOrEqual(now - 5)
+    }
   })
 
   it('GET /api/costs/sources returns an array', async () => {

--- a/src/__tests__/costops-ledger.test.ts
+++ b/src/__tests__/costops-ledger.test.ts
@@ -185,7 +185,7 @@ describe('costops ledger + summary', () => {
     expect(s.breakdown.estimate).toBe(1450)
   })
 
-  it('reports token_usage as VOLUME only, never priced', () => {
+  it('reports token_usage volume, and never lets it contribute to money', () => {
     const db = getDb()
     const w = monthWindow(NOW)
     const ins = db.prepare("INSERT INTO token_usage (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens) VALUES (?,?,?,?,?,?,?)")
@@ -197,8 +197,11 @@ describe('costops ledger + summary', () => {
     expect(s.token_usage.agents).toBe(2)
     expect(s.token_usage.input_tokens).toBe(1500)
     expect(s.token_usage.output_tokens).toBe(7000)
-    expect(s.token_usage.note).toContain('not priced')
     // token usage must NOT contribute to money
     expect(s.current_spend).toBe(0)
+    // These rows carry no model, so v0.2 cannot price them -- and says so
+    // rather than reporting a confident $0.
+    expect(s.token_usage.list_price_equivalent.total).toBe(0)
+    expect(s.token_usage.list_price_equivalent.unpriced_calls).toBe(2)
   })
 })

--- a/src/__tests__/costops-pricing.test.ts
+++ b/src/__tests__/costops-pricing.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  PRICE_MAP,
+  PRICE_MAP_VERSION,
+  CACHE_READ_MULTIPLIER,
+  CACHE_WRITE_MULTIPLIER,
+  isPriced,
+  priceTokens,
+  dayKey,
+} from '../costops/pricing.js'
+import { getTokenCostReport, getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+// 2026-07-15T12:00:00Z, matching the v0.1 ledger tests.
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+const OPUS = 'claude-opus-5' // $5 in / $25 out per 1M
+
+function cfg(over: Partial<CostOpsConfig> = {}): CostOpsConfig {
+  return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [], ...over }
+}
+
+function insertUsage(
+  db: ReturnType<typeof getDb>,
+  row: { agent?: string; session?: string; ts: number; model: string | null; i?: number; o?: number; cr?: number; cw?: number },
+) {
+  db.prepare(`INSERT INTO token_usage
+    (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens,model)
+    VALUES (?,?,?,?,?,?,?,?)`).run(
+    row.agent ?? 'marveen', row.session ?? 's1', row.ts,
+    row.i ?? 0, row.o ?? 0, row.cr ?? 0, row.cw ?? 0, row.model,
+  )
+}
+
+describe('token pricing arithmetic', () => {
+  it('prices every component, with cache weighted at its own multiplier', () => {
+    const c = priceTokens(OPUS, {
+      input_tokens: 1_000, output_tokens: 2_000,
+      cache_read_tokens: 1_000_000, cache_creation_tokens: 100_000,
+    })!
+    expect(c.input).toBeCloseTo(0.005, 10)       // 1e3 * 5 / 1e6
+    expect(c.output).toBeCloseTo(0.05, 10)       // 2e3 * 25 / 1e6
+    expect(c.cache_read).toBeCloseTo(0.5, 10)    // 1e6 * 5 * 0.10 / 1e6
+    expect(c.cache_write).toBeCloseTo(0.625, 10) // 1e5 * 5 * 1.25 / 1e6
+    expect(c.total).toBeCloseTo(1.18, 10)
+  })
+
+  it('would understate by ~21x on this row if only input+output were counted', () => {
+    // The discriminating assertion for the whole module. Fleet-wide, cache_read
+    // is 82.9% of spend and output 7.6%; the obvious input+output formula sees
+    // a small fraction of the real figure. If someone drops the cache terms,
+    // the arithmetic test above still fails -- but this one says why it matters.
+    const counts = {
+      input_tokens: 1_000, output_tokens: 2_000,
+      cache_read_tokens: 1_000_000, cache_creation_tokens: 100_000,
+    }
+    const c = priceTokens(OPUS, counts)!
+    const inputOutputOnly = c.input + c.output
+    expect(c.total / inputOutputOnly).toBeGreaterThan(20)
+  })
+
+  it('components sum to the reported total', () => {
+    const c = priceTokens('claude-fable-5', {
+      input_tokens: 137, output_tokens: 9_311,
+      cache_read_tokens: 4_200_000, cache_creation_tokens: 55_555,
+    })!
+    expect(c.input + c.output + c.cache_read + c.cache_write).toBeCloseTo(c.total, 12)
+  })
+
+  it('scales linearly with each model rate', () => {
+    const counts = { input_tokens: 0, output_tokens: 1_000_000, cache_read_tokens: 0, cache_creation_tokens: 0 }
+    expect(priceTokens('claude-opus-5', counts)!.total).toBeCloseTo(25, 10)
+    expect(priceTokens('claude-fable-5', counts)!.total).toBeCloseTo(50, 10)
+    expect(priceTokens('claude-haiku-4-5', counts)!.total).toBeCloseTo(5, 10)
+  })
+
+  it('pins the cache multipliers, which are the load-bearing constants', () => {
+    expect(CACHE_READ_MULTIPLIER).toBe(0.1)
+    expect(CACHE_WRITE_MULTIPLIER).toBe(1.25)
+  })
+
+  it('carries a version so a stored figure is traceable to its rates', () => {
+    expect(PRICE_MAP_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('prices every model the fleet has actually run', () => {
+    // Observed in token_usage across the whole table on 2026-07-31. A model in
+    // production with no rate is an invisible gap in every total.
+    for (const m of ['claude-fable-5', 'claude-opus-5', 'claude-opus-4-8', 'claude-sonnet-5', 'claude-sonnet-4-6']) {
+      expect(isPriced(m), `${m} has no published rate`).toBe(true)
+      expect(PRICE_MAP[m].output).toBeGreaterThan(PRICE_MAP[m].input)
+    }
+  })
+})
+
+describe('unknown models are a gap, not a zero', () => {
+  it('returns null rather than a $0 cost', () => {
+    // A silent $0 is the failure mode this subsystem exists to prevent: the
+    // total still looks like a total while quietly missing the traffic.
+    expect(priceTokens('<synthetic>', { input_tokens: 1e6, output_tokens: 1e6, cache_read_tokens: 0, cache_creation_tokens: 0 })).toBeNull()
+    expect(priceTokens(null, { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 })).toBeNull()
+    expect(isPriced('gpt-5')).toBe(false)
+  })
+
+  it('is not fooled by inherited Object properties', () => {
+    expect(isPriced('constructor')).toBe(false)
+    expect(isPriced('toString')).toBe(false)
+  })
+})
+
+describe('day bucketing', () => {
+  // 2026-07-15T23:30:00Z is already 2026-07-16 in Budapest (CEST, UTC+2).
+  const lateEvening = Math.floor(Date.UTC(2026, 6, 15, 23, 30, 0) / 1000)
+
+  it('buckets by install-local wall clock, not UTC', () => {
+    expect(dayKey(lateEvening, 'Europe/Budapest')).toBe('2026-07-16')
+  })
+
+  it('the timezone argument actually applies (control)', () => {
+    // Without this, the assertion above would pass even if the parameter were
+    // ignored and the machine happened to sit in a UTC+2 zone.
+    expect(dayKey(lateEvening, 'UTC')).toBe('2026-07-15')
+  })
+
+  it('handles the winter offset too', () => {
+    const winter = Math.floor(Date.UTC(2026, 0, 15, 23, 30, 0) / 1000) // CET, UTC+1
+    expect(dayKey(winter, 'Europe/Budapest')).toBe('2026-01-16')
+  })
+
+  it('produces lexicographically sortable keys', () => {
+    const days = [
+      dayKey(Math.floor(Date.UTC(2026, 9, 3, 10) / 1000), 'UTC'),
+      dayKey(Math.floor(Date.UTC(2026, 0, 20, 10) / 1000), 'UTC'),
+    ]
+    expect([...days].sort()).toEqual(['2026-01-20', '2026-10-03'])
+  })
+})
+
+describe('token cost report', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('aggregates by model, agent and day, and respects the window', () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    insertUsage(db, { ts: w.start + 100, model: OPUS, agent: 'marveen', o: 1_000_000 })          // $25
+    insertUsage(db, { ts: w.start + 200, model: 'claude-haiku-4-5', agent: 'prisma', o: 1_000_000 }) // $5
+    insertUsage(db, { ts: w.end + 100, model: OPUS, agent: 'marveen', o: 1_000_000 })            // outside window
+    const r = getTokenCostReport(db, { start: w.start, end: w.end, timeZone: 'UTC' })
+
+    expect(r.total).toBeCloseTo(30, 6)
+    expect(r.by_model[0]).toMatchObject({ model: OPUS, calls: 1 })
+    expect(r.by_model.map(m => m.model)).toEqual([OPUS, 'claude-haiku-4-5']) // sorted by cost desc
+    expect(r.by_agent.map(a => a.agent)).toEqual(['marveen', 'prisma'])
+    expect(r.by_day).toHaveLength(1)
+    expect(r.by_day[0].cost).toBeCloseTo(30, 6)
+  })
+
+  it('labels its basis and currency on every report', () => {
+    // marveen's standing instruction: the figure is a list-price equivalent and
+    // must be labelled as one wherever it surfaces, because no invoice matches it.
+    const r = getTokenCostReport(getDb(), { start: 0, end: NOW })
+    expect(r.basis).toBe('list_price_equivalent')
+    expect(r.currency).toBe('USD')
+    expect(r.price_map_version).toBe(PRICE_MAP_VERSION)
+  })
+
+  it('counts unpriced rows separately instead of folding them in as zero', () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    insertUsage(db, { ts: w.start + 10, model: OPUS, o: 1_000_000 })
+    insertUsage(db, { ts: w.start + 20, model: '<synthetic>', o: 1_000_000 })
+    insertUsage(db, { ts: w.start + 30, model: null, o: 1_000_000 })
+    const r = getTokenCostReport(db, { start: w.start, end: w.end })
+
+    expect(r.total).toBeCloseTo(25, 6)               // only the priced row
+    expect(r.unpriced.calls).toBe(2)
+    expect(r.unpriced.models).toEqual(['(null)', '<synthetic>'])
+    expect(r.by_model).toHaveLength(1)               // unpriced never enters the breakdown
+  })
+
+  it('reports zeroes, not a crash, on an empty window', () => {
+    const r = getTokenCostReport(getDb(), { start: NOW, end: NOW + 86400 })
+    expect(r.total).toBe(0)
+    expect(r.by_model).toEqual([])
+    expect(r.unpriced.calls).toBe(0)
+  })
+
+  it('splits a session across days at the local boundary', () => {
+    const db = getDb()
+    const beforeMidnight = Math.floor(Date.UTC(2026, 6, 15, 21, 0, 0) / 1000) // 23:00 Budapest
+    const afterMidnight = Math.floor(Date.UTC(2026, 6, 15, 23, 0, 0) / 1000)  // 01:00 Budapest, next day
+    insertUsage(db, { ts: beforeMidnight, model: OPUS, o: 1_000_000 })
+    insertUsage(db, { ts: afterMidnight, model: OPUS, o: 1_000_000 })
+    const r = getTokenCostReport(db, { start: beforeMidnight - 10, end: afterMidnight + 10, timeZone: 'Europe/Budapest' })
+    expect(r.by_day.map(d => d.day)).toEqual(['2026-07-15', '2026-07-16'])
+  })
+})
+
+describe('the money ledger and the list-price equivalent stay separate', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('never adds token cost into current_spend', () => {
+    // The double-counting guard. The operator pays a subscription, which is
+    // already a fixed cost in current_spend; adding what the same traffic would
+    // have cost at API rates on top would bill it twice.
+    const db = getDb()
+    const w = monthWindow(NOW)
+    insertUsage(db, { ts: w.start + 100, model: OPUS, o: 1_000_000, cr: 100_000_000 })
+    const c = cfg({
+      fixed_costs: [{ source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 22000, period: 'monthly', confidence: 'manual', currency: 'HUF' }],
+    })
+    const s = getCostSummary(db, c, NOW)
+
+    expect(s.token_usage.list_price_equivalent.total).toBeGreaterThan(50)
+    expect(s.current_spend).toBe(0)          // nothing synced to the ledger yet
+    expect(s.breakdown.estimate).toBe(0)     // and it did not leak into a bucket
+    expect(s.forecast_month_end).toBe(0)
+  })
+
+  it('reports the equivalent in USD even though the ledger is in HUF', () => {
+    // Two different currencies on purpose. No FX rate is invented here; mixing
+    // them into one number would need a rate we do not have.
+    const db = getDb()
+    const w = monthWindow(NOW)
+    insertUsage(db, { ts: w.start + 100, model: OPUS, o: 1_000_000 })
+    const s = getCostSummary(db, cfg({ currency: 'HUF' }), NOW)
+    expect(s.currency).toBe('HUF')
+    expect(s.token_usage.list_price_equivalent.currency).toBe('USD')
+    expect(s.token_usage.list_price_equivalent.total).toBeCloseTo(25, 6)
+  })
+
+  it('says in the note that it is not money owed', () => {
+    const s = getCostSummary(getDb(), cfg(), NOW)
+    expect(s.token_usage.note).toContain('LIST-PRICE EQUIVALENT')
+    expect(s.token_usage.note).toContain('never added to current_spend')
+  })
+})

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -9,6 +9,13 @@
 import type Database from 'better-sqlite3'
 import { createHash } from 'node:crypto'
 import type { CostOpsConfig, CostConfidence } from './config.js'
+import {
+  PRICE_MAP_VERSION,
+  ZERO_COMPONENTS,
+  priceTokens,
+  dayKey,
+  type TokenCostComponents,
+} from './pricing.js'
 
 // ---- month math (UTC, deterministic given `now`) ---------------------------
 
@@ -152,6 +159,20 @@ export interface CostSummary {
     output_tokens: number
     cache_read_tokens: number
     cache_creation_tokens: number
+    /**
+     * What this token volume would cost at published API rates. Reported
+     * alongside the money ledger, never summed into it: the operator is on a
+     * subscription that already appears in current_spend as a fixed cost, so
+     * adding this on top would double-count.
+     */
+    list_price_equivalent: {
+      basis: 'list_price_equivalent'
+      currency: 'USD'
+      total: number
+      components: TokenCostComponents
+      price_map_version: string
+      unpriced_calls: number
+    }
   }
   data_freshness: number | null
   config_present: boolean
@@ -239,7 +260,9 @@ export function getCostSummary(
     }
   }
 
-  // token_usage: VOLUME/ACTIVITY only -- NOT priced in v0.1 (no model column).
+  // token_usage volume, plus (v0.2) its list-price equivalent. The two are
+  // reported side by side but kept out of current_spend on purpose -- see the
+  // field doc on CostSummary.token_usage.
   const tu = db.prepare(`
     SELECT COUNT(*) as calls, COUNT(DISTINCT agent) as agents,
       COALESCE(SUM(input_tokens),0) as input_tokens,
@@ -252,6 +275,8 @@ export function getCostSummary(
     cache_read_tokens: number; cache_creation_tokens: number
   }
 
+  const tokenCost = getTokenCostReport(db, { start: win.start, end: win.end })
+
   return {
     month: win.key,
     currency: config.currency,
@@ -263,15 +288,132 @@ export function getCostSummary(
     breakdown: { fixed_manual: round2(breakdown.fixed_manual), provider: round2(breakdown.provider), estimate: round2(breakdown.estimate) },
     budget,
     token_usage: {
-      note: 'volume/activity only -- not priced in v0.1 (token_usage has no model column; token->cost mapping lands in v0.2 after model/session enrichment)',
+      note: 'volume plus a LIST-PRICE EQUIVALENT (v0.2): what this token volume would cost at published API rates. Not money owed and never added to current_spend -- the subscription is already counted there as a fixed cost.',
       calls: tu.calls, agents: tu.agents,
       input_tokens: tu.input_tokens, output_tokens: tu.output_tokens,
       cache_read_tokens: tu.cache_read_tokens, cache_creation_tokens: tu.cache_creation_tokens,
+      list_price_equivalent: {
+        basis: 'list_price_equivalent',
+        currency: 'USD',
+        total: tokenCost.total,
+        components: tokenCost.components,
+        price_map_version: tokenCost.price_map_version,
+        unpriced_calls: tokenCost.unpriced.calls,
+      },
     },
     data_freshness: latestFreshness,
     config_present: opts.configExists ?? true,
     config_errors: opts.configErrors ?? [],
     generated_at: now,
+  }
+}
+
+// ---- read path: token list-price equivalent (CostOps v0.2) -----------------
+
+export interface TokenCostReport {
+  /** Always this literal. Not money owed -- see pricing.ts for why. */
+  basis: 'list_price_equivalent'
+  currency: 'USD'
+  price_map_version: string
+  window: { start: number; end: number; timezone: string }
+  total: number
+  components: TokenCostComponents
+  by_model: Array<{ model: string; calls: number; cost: number }>
+  by_agent: Array<{ agent: string; calls: number; cost: number }>
+  by_day: Array<{ day: string; cost: number }>
+  /**
+   * Rows we hold no published rate for. Surfaced rather than folded into the
+   * total as zero, so an unrecognised model shows up as a gap instead of
+   * quietly shrinking the figure.
+   */
+  unpriced: { calls: number; models: string[] }
+}
+
+interface UsageRow {
+  model: string | null
+  agent: string
+  timestamp: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+}
+
+/**
+ * List-price-equivalent token cost over an epoch-second window, [start, end).
+ *
+ * Rows are aggregated in JS rather than SQL because the day bucketing needs a
+ * named timezone that SQLite cannot apply deterministically under test. The
+ * window is indexed (idx_token_usage_ts) and a month of fleet traffic is a few
+ * thousand rows, so the read stays cheap; revisit if the retention window grows
+ * by orders of magnitude.
+ */
+export function getTokenCostReport(
+  db: Database.Database,
+  opts: { start: number; end: number; timeZone?: string },
+): TokenCostReport {
+  const timeZone = opts.timeZone ?? 'Europe/Budapest'
+  const rows = db.prepare(`
+    SELECT model, agent, timestamp, input_tokens, output_tokens,
+           cache_read_tokens, cache_creation_tokens
+    FROM token_usage
+    WHERE timestamp >= @start AND timestamp < @end
+  `).all({ start: opts.start, end: opts.end }) as UsageRow[]
+
+  const components: TokenCostComponents = { ...ZERO_COMPONENTS }
+  const perModel = new Map<string, { calls: number; cost: number }>()
+  const perAgent = new Map<string, { calls: number; cost: number }>()
+  const perDay = new Map<string, number>()
+  const unpricedModels = new Set<string>()
+  let unpricedCalls = 0
+
+  for (const r of rows) {
+    const priced = priceTokens(r.model, r)
+    if (!priced) {
+      unpricedCalls++
+      unpricedModels.add(r.model ?? '(null)')
+      continue
+    }
+    components.input += priced.input
+    components.output += priced.output
+    components.cache_read += priced.cache_read
+    components.cache_write += priced.cache_write
+    components.total += priced.total
+
+    const model = r.model as string
+    const m = perModel.get(model) ?? { calls: 0, cost: 0 }
+    m.calls++; m.cost += priced.total; perModel.set(model, m)
+
+    const a = perAgent.get(r.agent) ?? { calls: 0, cost: 0 }
+    a.calls++; a.cost += priced.total; perAgent.set(r.agent, a)
+
+    const d = dayKey(r.timestamp, timeZone)
+    perDay.set(d, (perDay.get(d) ?? 0) + priced.total)
+  }
+
+  return {
+    basis: 'list_price_equivalent',
+    currency: 'USD',
+    price_map_version: PRICE_MAP_VERSION,
+    window: { start: opts.start, end: opts.end, timezone: timeZone },
+    total: round4(components.total),
+    components: {
+      input: round4(components.input),
+      output: round4(components.output),
+      cache_read: round4(components.cache_read),
+      cache_write: round4(components.cache_write),
+      total: round4(components.total),
+    },
+    by_model: [...perModel.entries()]
+      .map(([model, v]) => ({ model, calls: v.calls, cost: round4(v.cost) }))
+      .sort((a, b) => b.cost - a.cost),
+    by_agent: [...perAgent.entries()]
+      .map(([agent, v]) => ({ agent, calls: v.calls, cost: round4(v.cost) }))
+      .sort((a, b) => b.cost - a.cost),
+    by_day: [...perDay.entries()]
+      .map(([day, cost]) => ({ day, cost: round4(cost) }))
+      .sort((a, b) => a.day.localeCompare(b.day)),
+    unpriced: { calls: unpricedCalls, models: [...unpricedModels].sort() },
   }
 }
 

--- a/src/costops/pricing.ts
+++ b/src/costops/pricing.ts
@@ -1,0 +1,132 @@
+// CostOps v0.2 -- token -> list-price-equivalent mapping.
+//
+// v0.1 deliberately left token_usage unpriced, with the note "token_usage has
+// no model column; token->cost mapping lands in v0.2 after model/session
+// enrichment". That enrichment has since happened: `model` is now populated on
+// every row (9309/9309 as of 2026-07-31, no NULLs anywhere in the table), so
+// the stated precondition holds and pricing is unblocked.
+//
+// WHAT THIS IS NOT: money owed. The operator runs on a Claude subscription, not
+// API billing, so no invoice corresponds to these numbers. Every figure this
+// module produces is a LIST-PRICE EQUIVALENT -- what the same token volume
+// would cost at published first-party API rates. It is a usage yardstick for
+// budgeting and routing decisions, and it is labelled as such on every output.
+// It must never be added to the money ledger's current_spend: the subscription
+// is already counted there as a fixed cost, so summing the two double-counts.
+//
+// Pure arithmetic. No network, no LLM, no secrets.
+
+/**
+ * Published first-party API rates, USD per 1M tokens, as [input, output].
+ *
+ * Source: the `claude-api` skill's pricing table (cached 2026-06-24). Taken
+ * from documentation rather than recalled, because a wrong constant here is
+ * invisible -- it produces a plausible number that is silently wrong.
+ *
+ * Bump PRICE_MAP_VERSION on any edit so a stored figure can be traced back to
+ * the rates that produced it.
+ */
+export const PRICE_MAP_VERSION = '2026-06-24'
+
+export interface ModelRate {
+  /** USD per 1M input tokens. */
+  input: number
+  /** USD per 1M output tokens. */
+  output: number
+}
+
+export const PRICE_MAP: Readonly<Record<string, ModelRate>> = Object.freeze({
+  'claude-fable-5': { input: 10, output: 50 },
+  'claude-mythos-5': { input: 10, output: 50 },
+  'claude-opus-5': { input: 5, output: 25 },
+  'claude-opus-4-8': { input: 5, output: 25 },
+  'claude-opus-4-7': { input: 5, output: 25 },
+  'claude-opus-4-6': { input: 5, output: 25 },
+  // Sonnet 5 carries a lower introductory rate ($2/$10) through 2026-08-31.
+  // We price it at the standard rate on purpose: for a spend ceiling, erring
+  // high is the safe direction, and date-dependent rates would make every
+  // stored figure depend on when it was computed. Sonnet is ~2.4% of fleet
+  // spend, so the resulting overstatement is well under 1% of the total.
+  'claude-sonnet-5': { input: 3, output: 15 },
+  'claude-sonnet-4-6': { input: 3, output: 15 },
+  'claude-haiku-4-5': { input: 1, output: 5 },
+})
+
+/**
+ * Cache tokens are billed as multiples of the model's input rate: reads at
+ * ~0.1x, 5-minute writes at ~1.25x. These are not incidental.
+ *
+ * Measured over the fleet's 7 days to 2026-07-31: cache_read is 82.9% of total
+ * list-price-equivalent spend, cache_write 9.5%, output 7.6%, input 0.0%. A
+ * cost formula that counts only input+output -- the obvious one to write -- sees
+ * 7.6% of the real figure and understates by roughly 13x. That is the single
+ * error this module exists to prevent, which is why these two multipliers are
+ * named constants rather than inline numbers.
+ */
+export const CACHE_READ_MULTIPLIER = 0.1
+export const CACHE_WRITE_MULTIPLIER = 1.25
+
+/** The token counters a usage row contributes to cost. */
+export interface TokenCounts {
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+}
+
+/** Per-component USD breakdown; components sum to `total`. */
+export interface TokenCostComponents {
+  input: number
+  output: number
+  cache_read: number
+  cache_write: number
+  total: number
+}
+
+export const ZERO_COMPONENTS: Readonly<TokenCostComponents> = Object.freeze({
+  input: 0, output: 0, cache_read: 0, cache_write: 0, total: 0,
+})
+
+/** True if we hold a published rate for this model id. */
+export function isPriced(model: string | null | undefined): boolean {
+  return typeof model === 'string' && Object.hasOwn(PRICE_MAP, model)
+}
+
+/**
+ * List-price-equivalent USD for one row's token counts.
+ *
+ * Returns null -- never a zero cost -- for a model with no published rate
+ * (an unrecognised id, or a sentinel like `<synthetic>`). Charging an unknown
+ * model $0 would be a silent no-op of exactly the kind this subsystem is meant
+ * to surface: the total would still look like a total, quietly missing whatever
+ * the unpriced traffic was worth. Callers must account for the null explicitly.
+ */
+export function priceTokens(
+  model: string | null | undefined,
+  counts: TokenCounts,
+): TokenCostComponents | null {
+  if (!isPriced(model)) return null
+  const rate = PRICE_MAP[model as string]
+  const input = (counts.input_tokens * rate.input) / 1e6
+  const output = (counts.output_tokens * rate.output) / 1e6
+  const cache_read = (counts.cache_read_tokens * rate.input * CACHE_READ_MULTIPLIER) / 1e6
+  const cache_write = (counts.cache_creation_tokens * rate.input * CACHE_WRITE_MULTIPLIER) / 1e6
+  return { input, output, cache_read, cache_write, total: input + output + cache_read + cache_write }
+}
+
+/**
+ * Calendar-day key for an epoch-second timestamp in a named IANA zone.
+ *
+ * The zone is an explicit parameter rather than the process default so tests
+ * are deterministic regardless of the machine's TZ. It defaults to the install
+ * timezone because a "daily cap" is a wall-clock concept for the operator:
+ * bucketing by UTC would move the boundary to 01:00 or 02:00 local and quietly
+ * split a working evening across two days. Note this differs from the money
+ * ledger's monthWindow(), which is UTC by design -- the two are not interchangeable.
+ */
+export function dayKey(epochSeconds: number, timeZone = 'Europe/Budapest'): string {
+  // 'en-CA' formats as YYYY-MM-DD, which sorts lexicographically.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone, year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date(epochSeconds * 1000))
+}

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -8,7 +8,7 @@ import { json } from '../http-helpers.js'
 import { logger } from '../../logger.js'
 import { getDb } from '../../db.js'
 import { loadCostopsConfig } from '../../costops/config.js'
-import { syncFixedCostsToLedger, getCostSummary, getCostSources } from '../../costops/ledger.js'
+import { syncFixedCostsToLedger, getCostSummary, getCostSources, getTokenCostReport } from '../../costops/ledger.js'
 import type { RouteContext } from './types.js'
 
 // Runs the fixed-cost -> ledger reflection once immediately (so the summary is
@@ -57,6 +57,22 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     } catch (err) {
       logger.error({ err }, 'CostOps sources failed')
       json(res, { error: 'Cost sources failed' }, 500)
+    }
+    return true
+  }
+
+  // Token list-price equivalent over a rolling window. `days` (default 7,
+  // max 400) is a rolling lookback rather than a calendar month so a daily
+  // ceiling can be evaluated without a month-boundary special case.
+  if (path === '/api/costs/tokens' && method === 'GET') {
+    try {
+      const raw = Number(url.searchParams.get('days') ?? '7')
+      const days = Number.isFinite(raw) ? Math.min(Math.max(Math.trunc(raw), 1), 400) : 7
+      const now = Math.floor(Date.now() / 1000)
+      json(res, getTokenCostReport(getDb(), { start: now - days * 86400, end: now }))
+    } catch (err) {
+      logger.error({ err }, 'CostOps token cost failed')
+      json(res, { error: 'Token cost failed' }, 500)
     }
     return true
   }


### PR DESCRIPTION
CostOps **v0.2**: the token→cost mapping that v0.1 explicitly deferred. Read-only, no schema change, nothing switched. Kanban **#132 (F1)**.

## Why now

`ledger.ts` carried this note:

> `volume/activity only -- not priced in v0.1 (token_usage has no model column; token->cost mapping lands in v0.2 after model/session enrichment)`

That precondition now holds: `model` is populated on **9309/9309** rows, no NULLs anywhere in the table. So this implements the slot v0.1 designed rather than adding a parallel path.

## Two things measurement changed

**1. Cache tokens dominate.** Over the fleet's 7 days to 2026-07-31:

| component | share |
|---|---|
| `cache_read` | **82.9%** |
| `cache_write` | 9.5% |
| `output` | 7.6% |
| `input` | 0.0% |

The obvious `input + output` formula sees **7.6%** of the real figure — a ~13x understatement. The two cache multipliers are therefore named constants with the measurement recorded beside them, and a test asserts the ratio rather than just the arithmetic.

**2. An unknown model is a gap, not a zero.** `priceTokens()` returns `null` for an unrecognised id (e.g. the `<synthetic>` sentinel, 19 calls in the window) and the report counts those separately. Charging $0 would leave the total looking like a total while quietly missing that traffic.

## List-price equivalent, not money owed

The operator runs on a subscription, so **no invoice corresponds to these numbers**. Every output carries `basis: "list_price_equivalent"` and `currency: "USD"`. It sits beside the money ledger and is **never summed into `current_spend`** — the subscription already appears there as a fixed cost, so adding both double-counts. A test pins that separation; the money path is untouched apart from comments.

## Day bucketing

`dayKey()` takes an explicit IANA zone, defaulting to `Europe/Budapest`, so a daily ceiling follows the operator's wall clock instead of splitting a working evening at 01:00 local. This deliberately differs from the money ledger's UTC `monthWindow()`; both ends say so. The zone is a parameter so tests don't depend on the machine's `TZ`.

## What's here

- `src/costops/pricing.ts` (new) — versioned price map, `priceTokens()`, `dayKey()`
- `src/costops/ledger.ts` — `getTokenCostReport()`; summary gains a labelled `list_price_equivalent` block
- `src/web/routes/costs.ts` — `GET /api/costs/tokens?days=N` (rolling window, clamped 1–400)

## Verification

- **42 costops tests pass**; `tsc --noEmit` clean.
- **Controls run.** Zeroing the cache multipliers fails 4 tests; making an unknown model cost $0 instead of `null` fails 2. The tests discriminate.
- **Cross-checked against the live database.** This implementation and an independent Python computation agree to the cent per model: fable-5 $1158.64, opus-5 $561.69, sonnet-5 $51.84, sonnet-4-6 $10.55. (Totals differ by 0.2% only because the rolling window slid ~19 min between runs.)
- **Full suite green on a fresh upstream base: 3120 pass, 0 failures.**

> **Correction to an earlier revision of this description.** It reported 13 failures in `governance-gates` / `hook-path-guard` / `email-send-gate` as "pre-existing". They were not. They were caused by running the suite from a worktree under `/tmp`: `isUnsafeHookCommand` rejects `/tmp`-prefixed hook commands, so the gate tests fail there and only there. My control had reverted my diff while holding the location fixed, which proved my changes were not the cause but did not license the word "pre-existing". Re-run from `~/.cache`, all three files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
