### PR TITLE
feat(token-usage): attribute spend to the scheduled task that caused it

### DIFF
--- a/src/__tests__/token-usage-task-labelling.test.ts
+++ b/src/__tests__/token-usage-task-labelling.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { parseScheduledTaskMarker, userTurnText, collapseByMessageId } from '../web/token-usage.js'
+
+/**
+ * R0 (kanban #134): attribute token spend to the scheduled task that caused it.
+ *
+ * Nothing labelled the rows before this: task_title and project were 0%
+ * populated across all 9309 of them, so "what did the morning briefing cost
+ * last month" had no answer, and a model router could be neither trained nor
+ * evaluated.
+ *
+ * The label comes off the provenance wrapper the schedule runner puts around
+ * every injected prompt. Measured across all 95 transcripts on 2026-07-31:
+ * 1149 scheduled prompts, 13 distinct tasks, and the structured tag and the
+ * bracket prefix always appear together (1149/1149).
+ */
+
+// Shape of a real wrapped scheduled prompt: safety preamble, bracket prefix,
+// then the structured tag. The markers are mid-string, never at the head.
+function wrapped(kind: 'Heartbeat' | 'Utemezett feladat', name: string): string {
+  return (
+    'The wrapper marks provenance, not distrust. ' +
+    `[${kind}: ${name}] ` +
+    `<scheduled-task source="scheduled-task:${name}">\nDo the thing.\n</scheduled-task>`
+  )
+}
+
+describe('reading the scheduled-task marker', () => {
+  it('finds the task in a wrapped heartbeat prompt', () => {
+    expect(parseScheduledTaskMarker(wrapped('Heartbeat', 'memoria-heartbeat'))).toBe('memoria-heartbeat')
+  })
+
+  it('finds the task in a wrapped scheduled-task prompt', () => {
+    expect(parseScheduledTaskMarker(wrapped('Utemezett feladat', 'reggeli-teteles-lista'))).toBe('reggeli-teteles-lista')
+  })
+
+  it('does not require the marker at the start of the message', () => {
+    // The safety preamble always precedes it. An anchored ^ match finds
+    // nothing -- which is exactly how this was mismeasured once already.
+    const text = wrapped('Heartbeat', 'kanban-audit')
+    expect(text.startsWith('<scheduled-task')).toBe(false)
+    expect(parseScheduledTaskMarker(text)).toBe('kanban-audit')
+  })
+
+  it('returns null for an ordinary interactive prompt', () => {
+    expect(parseScheduledTaskMarker('szia, nezd meg a #132-t')).toBeNull()
+    expect(parseScheduledTaskMarker('')).toBeNull()
+  })
+
+  it('handles every task name the fleet actually schedules', () => {
+    for (const name of [
+      'memoria-heartbeat', 'support-inbox-figyeles', 'kanban-flow-watchdog',
+      'kanban-audit', 'reggeli-napindito', 'dream-engine', 'reggeli-teteles-lista',
+      'idea-scout', 'heti-osszefoglalo', 'vercel-metrikak-atnezes',
+      'post-rollback-diagnose', 'negativ-review-banyaszat-elso', 'hetfoi-legal-osszerakas',
+    ]) {
+      expect(parseScheduledTaskMarker(wrapped('Heartbeat', name)), name).toBe(name)
+    }
+  })
+
+  it('is not fooled by a user quoting the human-readable prefix', () => {
+    // The bracket form can appear in ordinary prose (someone pasting a log
+    // line). The structured tag is the anchor precisely because it cannot.
+    expect(parseScheduledTaskMarker('miert futott le a [Heartbeat: kanban-audit] ketszer?')).toBeNull()
+  })
+})
+
+describe('telling a person apart from a tool result', () => {
+  it('reads a plain string user turn', () => {
+    expect(userTurnText('szia')).toBe('szia')
+  })
+
+  it('reads text blocks', () => {
+    expect(userTurnText([{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }])).toBe('ab')
+  })
+
+  it('rejects a tool-result turn outright', () => {
+    // 8270 of 10579 user lines across the fleet's transcripts are tool results.
+    // Treating one as a person would clear the label on the first tool call of
+    // a scheduled run -- so every task would look like it cost one API call.
+    expect(userTurnText([{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }])).toBeNull()
+  })
+
+  it('rejects a mixed turn containing a tool result', () => {
+    expect(userTurnText([{ type: 'text', text: 'hi' }, { type: 'tool_result', content: 'ok' }])).toBeNull()
+  })
+
+  it('ignores shapes it does not understand', () => {
+    expect(userTurnText(null)).toBeNull()
+    expect(userTurnText(undefined)).toBeNull()
+    expect(userTurnText(42)).toBeNull()
+    expect(userTurnText([{ type: 'image' }])).toBe('')
+  })
+})
+
+describe('the label survives a collapse of one assistant turn', () => {
+  const base = {
+    agent: 'marveen', sessionId: 's', timestamp: 1,
+    inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0,
+    thinkingTokens: 0, model: 'claude-opus-5', contentPreview: '', toolName: null,
+  }
+
+  it('keeps the task when the text line carries it and the tool line does not', () => {
+    const out = collapseByMessageId([
+      { ...base, taskTitle: 'kanban-audit', messageId: 'msg_1' },
+      { ...base, taskTitle: null, messageId: 'msg_1', toolName: 'Bash' },
+    ] as never)
+    expect(out).toHaveLength(1)
+    expect((out[0] as { taskTitle: string | null }).taskTitle).toBe('kanban-audit')
+  })
+
+  it('leaves interactive turns unlabelled', () => {
+    const out = collapseByMessageId([
+      { ...base, taskTitle: null, messageId: 'msg_2' },
+    ] as never)
+    expect((out[0] as { taskTitle: string | null }).taskTitle).toBeNull()
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -626,6 +626,12 @@ export function initDatabase(dbPathOverride?: string): void {
       last_size INTEGER NOT NULL DEFAULT 0
     )
   `)
+  // The scheduled task a transcript was last working on. Transcript parsing
+  // resumes mid-file from last_line, so the marker that names the task can sit
+  // in an already-consumed chunk; without carrying it across, every row after
+  // the first resume would lose its label and the attribution would be silently
+  // partial rather than obviously broken.
+  try { db.exec('ALTER TABLE token_usage_cursors ADD COLUMN last_task_title TEXT') } catch { /* already exists */ }
 
   // --- Idea Box ---
   db.exec(`

--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -71,6 +71,51 @@ function findJsonlFiles(dir: string): string[] {
   return files
 }
 
+/**
+ * The scheduled task a prompt belongs to, read off the provenance wrapper the
+ * schedule runner puts around every injected prompt.
+ *
+ * Two markers ride along, and measurement across all 95 transcripts on
+ * 2026-07-31 found them on all 1149 scheduled prompts together, never one
+ * without the other: a structured `<scheduled-task source="scheduled-task:X">`
+ * tag and a human-readable `[Heartbeat: X]` / `[Utemezett feladat: X]` prefix.
+ * We anchor on the structured tag -- it is machine-intended, quoted, and cannot
+ * be confused with a user quoting the bracket form in prose.
+ *
+ * Neither marker sits at the start of the message: the safety wrapper's
+ * preamble comes first, so this searches rather than matching from the head.
+ */
+const SCHEDULED_TASK_TAG = /<scheduled-task source="scheduled-task:([^"]+)"/
+
+/** Schedule name for a prompt, or null if this is not a scheduled run. */
+export function parseScheduledTaskMarker(text: string): string | null {
+  const m = SCHEDULED_TASK_TAG.exec(text)
+  return m ? m[1] : null
+}
+
+/**
+ * Text carried by a transcript `user` line, or null when the line is not a
+ * real user turn.
+ *
+ * Tool results arrive as `user` lines too -- 8270 of 10579 across the fleet's
+ * transcripts -- and they must be distinguished from a person typing. If a
+ * tool result counted as a user turn, the label would be cleared on the very
+ * first tool call of a scheduled run, which is to say almost immediately, and
+ * the task would appear to cost a single API call.
+ */
+export function userTurnText(content: unknown): string | null {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return null
+  let text = ''
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue
+    const b = block as { type?: string; text?: string }
+    if (b.type === 'tool_result') return null // a tool result, not a person
+    if (b.type === 'text' && typeof b.text === 'string') text += b.text
+  }
+  return text
+}
+
 interface ParsedCall {
   agent: string
   sessionId: string
@@ -83,6 +128,10 @@ interface ParsedCall {
   thinkingTokens: number
   /** Model identifier from the API response, e.g. "claude-sonnet-5". */
   model: string | null
+  /** Scheduled task this turn belongs to, or null for interactive work. Only
+   *  the schedule NAME is stored: its kind (task vs heartbeat) already lives in
+   *  the schedule's own task-config.json and would go stale if duplicated here. */
+  taskTitle: string | null
   contentPreview: string
   toolName: string | null
   /** The API message id (msg_...). One assistant turn that calls a tool is
@@ -122,6 +171,7 @@ export function collapseByMessageId(calls: ParsedCall[]): ParsedCall[] {
     ex.cacheCreationTokens = Math.max(ex.cacheCreationTokens, c.cacheCreationTokens)
     ex.thinkingTokens = Math.max(ex.thinkingTokens, c.thinkingTokens)
     if (!ex.model && c.model) ex.model = c.model
+    if (!ex.taskTitle && c.taskTitle) ex.taskTitle = c.taskTitle
     if (!ex.toolName && c.toolName) ex.toolName = c.toolName
     if (!ex.contentPreview && c.contentPreview) ex.contentPreview = c.contentPreview
   }
@@ -132,10 +182,14 @@ async function parseJsonlFile(
   filePath: string,
   agent: string,
   fromLine: number,
-): Promise<{ calls: ParsedCall[]; linesRead: number }> {
+  carriedTask: string | null = null,
+): Promise<{ calls: ParsedCall[]; linesRead: number; endTask: string | null }> {
   const calls: ParsedCall[] = []
   let lineNum = 0
   let sessionId = ''
+  // Survives across resumes via the cursor -- see the token_usage_cursors
+  // migration in db.ts for why dropping it would corrupt attribution quietly.
+  let currentTask: string | null = carriedTask
 
   const rl = createInterface({
     input: createReadStream(filePath, { encoding: 'utf-8' }),
@@ -152,6 +206,15 @@ async function parseJsonlFile(
 
     if (obj.sessionId) {
       sessionId = obj.sessionId
+    }
+
+    // A real user turn either starts a scheduled run or ends one. An
+    // unmarked turn means a person took over, so the previous task's label
+    // must stop here rather than bleeding onto unrelated later work.
+    if (obj.type === 'user') {
+      const text = userTurnText(obj.message?.content)
+      if (text !== null) currentTask = parseScheduledTaskMarker(text)
+      continue
     }
 
     if (obj.type !== 'assistant' || !obj.message?.usage) continue
@@ -197,6 +260,7 @@ async function parseJsonlFile(
       cacheCreationTokens: (u.cache_creation_input_tokens || 0),
       thinkingTokens,
       model: obj.message?.model || null,
+      taskTitle: currentTask,
       contentPreview: preview,
       toolName,
       messageId: obj.message?.id || null,
@@ -205,7 +269,7 @@ async function parseJsonlFile(
 
   // Collapse the multi-line tool-turn rows (same message id, repeated usage)
   // before they reach the DB -- this is the fix for the ~2x token inflation.
-  return { calls: collapseByMessageId(calls), linesRead: lineNum }
+  return { calls: collapseByMessageId(calls), linesRead: lineNum, endTask: currentTask }
 }
 
 export async function collectTokenUsage(): Promise<{ inserted: number; files: number }> {
@@ -214,14 +278,17 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
   let totalInserted = 0
   let totalFiles = 0
 
-  const getCursor = db.prepare('SELECT last_line, last_size FROM token_usage_cursors WHERE file_path = ?')
-  const setCursor = db.prepare('INSERT OR REPLACE INTO token_usage_cursors (file_path, last_line, last_size) VALUES (?, ?, ?)')
+  const getCursor = db.prepare('SELECT last_line, last_size, last_task_title FROM token_usage_cursors WHERE file_path = ?')
+  const setCursor = db.prepare('INSERT OR REPLACE INTO token_usage_cursors (file_path, last_line, last_size, last_task_title) VALUES (?, ?, ?, ?)')
   const insertCall = db.prepare(`
     INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens,
-      cache_read_tokens, cache_creation_tokens, thinking_tokens, model, content_preview, tool_name)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      cache_read_tokens, cache_creation_tokens, thinking_tokens, model, content_preview, tool_name, task_title)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent, session_id, timestamp, input_tokens, output_tokens) DO UPDATE SET
       model = CASE WHEN token_usage.model IS NULL AND excluded.model IS NOT NULL THEN excluded.model ELSE token_usage.model END,
+      -- Fills in on a re-scan but never overwrites an existing label, so a
+      -- deliberate backfill can label history without rewriting good rows.
+      task_title = CASE WHEN token_usage.task_title IS NULL AND excluded.task_title IS NOT NULL THEN excluded.task_title ELSE token_usage.task_title END,
       thinking_tokens = CASE WHEN (token_usage.thinking_tokens IS NULL OR token_usage.thinking_tokens = 0) AND excluded.thinking_tokens > 0 THEN excluded.thinking_tokens ELSE token_usage.thinking_tokens END
   `)
 
@@ -231,13 +298,18 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
       let fileSize: number
       try { fileSize = statSync(file).size } catch { continue }
 
-      const cursor = getCursor.get(file) as { last_line: number; last_size: number } | undefined
+      const cursor = getCursor.get(file) as { last_line: number; last_size: number; last_task_title: string | null } | undefined
       if (cursor && cursor.last_size === fileSize) continue
 
       const fromLine = (cursor && cursor.last_size <= fileSize) ? cursor.last_line : 0
 
       try {
-        const { calls, linesRead } = await parseJsonlFile(file, source.agent, fromLine)
+        // Resuming mid-file means the marker naming the current task may be
+        // behind us; the cursor carries it forward. A full re-read (fromLine 0)
+        // starts clean so a stale label cannot survive a deliberate rescan.
+        const { calls, linesRead, endTask } = await parseJsonlFile(
+          file, source.agent, fromLine, fromLine > 0 ? (cursor?.last_task_title ?? null) : null,
+        )
 
         if (calls.length > 0) {
           const tx = db.transaction(() => {
@@ -247,15 +319,15 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
                 c.inputTokens, c.outputTokens,
                 c.cacheReadTokens, c.cacheCreationTokens,
                 c.thinkingTokens, c.model,
-                c.contentPreview || null, c.toolName,
+                c.contentPreview || null, c.toolName, c.taskTitle,
               )
             }
-            setCursor.run(file, linesRead, fileSize)
+            setCursor.run(file, linesRead, fileSize, endTask)
           })
           tx()
           totalInserted += calls.length
         } else {
-          setCursor.run(file, linesRead, fileSize)
+          setCursor.run(file, linesRead, fileSize, endTask)
         }
         totalFiles++
       } catch (err) {


### PR DESCRIPTION
**R0** for kanban #134, and the missing input for #132's routing decisions.

## The gap

`task_title` and `project` were **0% populated** across all 9309 rows. "What did the morning briefing cost last month" had no answer, so a model router could be neither trained nor evaluated — and no amount of later work recovers a day that went by unlabelled.

## The anchor

The schedule runner already wraps every injected prompt in a provenance wrapper carrying two markers. Measured across all 95 transcripts on 2026-07-31: **1149 scheduled prompts, 13 distinct tasks**, with the structured `<scheduled-task source="scheduled-task:X">` tag and the human-readable `[Heartbeat: X]` / `[Utemezett feladat: X]` prefix appearing **together on all 1149 and never apart**.

We anchor on the structured tag: a person can quote the bracket form in prose, but not the tag. A test pins that.

Neither marker sits at the head of the message — the safety preamble comes first. An `^`-anchored match finds nothing, which is how I mismeasured this once before concluding the markers were absent entirely.

## Three ways this would have been silently wrong

| Trap | Consequence if missed |
|---|---|
| **Tool results are `user` lines** (8270 of 10579) | Treating one as a person clears the label on a scheduled run's *first tool call* — every task appears to cost one API call |
| **An unmarked user turn must clear the label** | Otherwise one prompt's name bleeds onto every later turn in a long interactive session, wildly overstating that task |
| **Parsing resumes mid-file from the cursor** | The marker naming the current task usually sits in an already-consumed chunk; without carrying it, attribution goes quietly partial after the first resume |

The cursor gains `last_task_title` for the third. A full re-read (`fromLine 0`) starts clean, so a stale label cannot survive a deliberate rescan.

## Scope

Only the schedule **name** is stored. Its kind (`task` vs `heartbeat`) already lives in the schedule's own `task-config.json` and would go stale if duplicated per row. The upsert fills `task_title` when absent but **never overwrites**, so a backfill can label history without rewriting good rows. `project` is deliberately left alone rather than filled with an invented meaning.

## Verification

- **13 new tests + 23 existing token-usage tests pass**; `tsc --noEmit` clean.
- **Full suite green on a fresh upstream base: 3110 pass, 0 failures.** (An earlier revision of this description reported 13 failures as "pre-existing"; they were an artifact of running the suite from a worktree under `/tmp`, which `isUnsafeHookCommand` rejects. Re-run from `~/.cache`, everything passes.)
- **Verified end-to-end against the real transcripts** with an in-memory DB (the live database was never opened): **2412/9528 rows labelled across exactly the 13 distinct tasks** an independent count found. The unlabelled 75% is interactive work, which correctly has no task.

## What it already answers

With labelling in place, the previously unanswerable split falls out — scheduled work is **32.3%** of list-price-equivalent spend, interactive **67.7%**; and the three costliest scheduled tasks are all heartbeats (26.5% of total between them). That reframes where routing can and cannot help; detail on the #134 card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
