### PR TITLE
feat(token-usage): record which writer set task_title

### DIFF
--- a/src/__tests__/token-usage-task-labelling.test.ts
+++ b/src/__tests__/token-usage-task-labelling.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { parseScheduledTaskMarker, userTurnText, collapseByMessageId } from '../web/token-usage.js'
+
+/**
+ * R0 (kanban #134): attribute token spend to the scheduled task that caused it.
+ *
+ * Nothing labelled the rows before this: task_title and project were 0%
+ * populated across all 9309 of them, so "what did the morning briefing cost
+ * last month" had no answer, and a model router could be neither trained nor
+ * evaluated.
+ *
+ * The label comes off the provenance wrapper the schedule runner puts around
+ * every injected prompt. Measured across all 95 transcripts on 2026-07-31:
+ * 1149 scheduled prompts, 13 distinct tasks, and the structured tag and the
+ * bracket prefix always appear together (1149/1149).
+ */
+
+// Shape of a real wrapped scheduled prompt: safety preamble, bracket prefix,
+// then the structured tag. The markers are mid-string, never at the head.
+function wrapped(kind: 'Heartbeat' | 'Utemezett feladat', name: string): string {
+  return (
+    'The wrapper marks provenance, not distrust. ' +
+    `[${kind}: ${name}] ` +
+    `<scheduled-task source="scheduled-task:${name}">\nDo the thing.\n</scheduled-task>`
+  )
+}
+
+describe('reading the scheduled-task marker', () => {
+  it('finds the task in a wrapped heartbeat prompt', () => {
+    expect(parseScheduledTaskMarker(wrapped('Heartbeat', 'memoria-heartbeat'))).toBe('memoria-heartbeat')
+  })
+
+  it('finds the task in a wrapped scheduled-task prompt', () => {
+    expect(parseScheduledTaskMarker(wrapped('Utemezett feladat', 'reggeli-teteles-lista'))).toBe('reggeli-teteles-lista')
+  })
+
+  it('does not require the marker at the start of the message', () => {
+    // The safety preamble always precedes it. An anchored ^ match finds
+    // nothing -- which is exactly how this was mismeasured once already.
+    const text = wrapped('Heartbeat', 'kanban-audit')
+    expect(text.startsWith('<scheduled-task')).toBe(false)
+    expect(parseScheduledTaskMarker(text)).toBe('kanban-audit')
+  })
+
+  it('returns null for an ordinary interactive prompt', () => {
+    expect(parseScheduledTaskMarker('szia, nezd meg a #132-t')).toBeNull()
+    expect(parseScheduledTaskMarker('')).toBeNull()
+  })
+
+  it('handles every task name the fleet actually schedules', () => {
+    for (const name of [
+      'memoria-heartbeat', 'support-inbox-figyeles', 'kanban-flow-watchdog',
+      'kanban-audit', 'reggeli-napindito', 'dream-engine', 'reggeli-teteles-lista',
+      'idea-scout', 'heti-osszefoglalo', 'vercel-metrikak-atnezes',
+      'post-rollback-diagnose', 'negativ-review-banyaszat-elso', 'hetfoi-legal-osszerakas',
+    ]) {
+      expect(parseScheduledTaskMarker(wrapped('Heartbeat', name)), name).toBe(name)
+    }
+  })
+
+  it('is not fooled by a user quoting the human-readable prefix', () => {
+    // The bracket form can appear in ordinary prose (someone pasting a log
+    // line). The structured tag is the anchor precisely because it cannot.
+    expect(parseScheduledTaskMarker('miert futott le a [Heartbeat: kanban-audit] ketszer?')).toBeNull()
+  })
+})
+
+describe('telling a person apart from a tool result', () => {
+  it('reads a plain string user turn', () => {
+    expect(userTurnText('szia')).toBe('szia')
+  })
+
+  it('reads text blocks', () => {
+    expect(userTurnText([{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }])).toBe('ab')
+  })
+
+  it('rejects a tool-result turn outright', () => {
+    // 8270 of 10579 user lines across the fleet's transcripts are tool results.
+    // Treating one as a person would clear the label on the first tool call of
+    // a scheduled run -- so every task would look like it cost one API call.
+    expect(userTurnText([{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }])).toBeNull()
+  })
+
+  it('rejects a mixed turn containing a tool result', () => {
+    expect(userTurnText([{ type: 'text', text: 'hi' }, { type: 'tool_result', content: 'ok' }])).toBeNull()
+  })
+
+  it('ignores shapes it does not understand', () => {
+    expect(userTurnText(null)).toBeNull()
+    expect(userTurnText(undefined)).toBeNull()
+    expect(userTurnText(42)).toBeNull()
+    expect(userTurnText([{ type: 'image' }])).toBe('')
+  })
+})
+
+describe('the label survives a collapse of one assistant turn', () => {
+  const base = {
+    agent: 'marveen', sessionId: 's', timestamp: 1,
+    inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0,
+    thinkingTokens: 0, model: 'claude-opus-5', contentPreview: '', toolName: null,
+  }
+
+  it('keeps the task when the text line carries it and the tool line does not', () => {
+    const out = collapseByMessageId([
+      { ...base, taskTitle: 'kanban-audit', messageId: 'msg_1' },
+      { ...base, taskTitle: null, messageId: 'msg_1', toolName: 'Bash' },
+    ] as never)
+    expect(out).toHaveLength(1)
+    expect((out[0] as { taskTitle: string | null }).taskTitle).toBe('kanban-audit')
+  })
+
+  it('leaves interactive turns unlabelled', () => {
+    const out = collapseByMessageId([
+      { ...base, taskTitle: null, messageId: 'msg_2' },
+    ] as never)
+    expect((out[0] as { taskTitle: string | null }).taskTitle).toBeNull()
+  })
+})

--- a/src/__tests__/token-usage-task-source.test.ts
+++ b/src/__tests__/token-usage-task-source.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import { correlateWithKanban } from '../web/token-usage.js'
+
+/**
+ * `task_title` is written by two things with very different reliability.
+ *
+ * The transcript parser reads a marker the runner puts into the prompt, so it
+ * states what the run was. correlateWithKanban() attributes by time window:
+ * every row in a span gets whatever card moved during it, whether or not the
+ * work concerned that card. Both land in one column, and a reader cannot tell
+ * an exact attribution from a guess -- which is how a heuristic figure ends up
+ * inside a cost report presented as fact.
+ *
+ * `task_source` records which one wrote the label.
+ */
+
+const T0 = 1_780_000_000
+
+/**
+ * initDatabase(':memory:') does not reliably hand back an empty database when
+ * called repeatedly in one process, so rows survive into the next case. That
+ * made these tests pass alone and fail together -- the worst failure mode,
+ * because it looks like flakiness rather than a setup bug.
+ */
+function freshDb() {
+  initDatabase(':memory:')
+  getDb().exec('DELETE FROM token_usage; DELETE FROM kanban_cards;')
+}
+
+function insertUsage(over: {
+  agent?: string; session?: string; ts?: number; title?: string | null; source?: string | null
+} = {}) {
+  getDb().prepare(`INSERT INTO token_usage
+    (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens,model,task_title,task_source)
+    VALUES (?,?,?,1,1,0,0,'claude-opus-5',?,?)`).run(
+    over.agent ?? 'marveen', over.session ?? 's1', over.ts ?? T0,
+    over.title ?? null, over.source ?? null)
+}
+
+function insertCard(over: { title: string; assignee?: string; updated?: number; project?: string | null }) {
+  getDb().prepare(`INSERT INTO kanban_cards (id,title,status,assignee,project,created_at,updated_at)
+    VALUES (?,?,'in_progress',?,?,?,?)`).run(
+    `c${Math.random().toString(36).slice(2, 9)}`, over.title,
+    over.assignee ?? 'marveen', over.project ?? null, over.updated ?? T0, over.updated ?? T0)
+}
+
+describe('the column exists and starts empty', () => {
+  beforeEach(freshDb)
+
+  it('is added to token_usage', () => {
+    const cols = getDb().prepare('PRAGMA table_info(token_usage)').all() as Array<{ name: string }>
+    expect(cols.map(c => c.name)).toContain('task_source')
+  })
+
+  it('is null for a row nobody has attributed', () => {
+    insertUsage()
+    const r = getDb().prepare('SELECT task_source FROM token_usage').get() as { task_source: string | null }
+    expect(r.task_source).toBeNull()
+  })
+})
+
+describe('kanban correlation stamps its own provenance', () => {
+  beforeEach(freshDb)
+
+  it('marks the rows it labels as a correlation, not as fact', () => {
+    // The card must move inside the span of the agent's usage rows, or
+    // correlateWithKanban() finds no candidate and the test proves nothing.
+    insertUsage({ session: 'x', ts: T0 + 10 })
+    insertCard({ title: 'Some card', updated: T0 + 10 })
+    correlateWithKanban()
+    // Scoped to this row: an unscoped .get() picks whichever row is first and
+    // would report a leftover from another case instead of this one.
+    const r = getDb().prepare("SELECT task_title, task_source FROM token_usage WHERE session_id='x'").get() as
+      { task_title: string | null; task_source: string | null }
+    expect(r.task_title).toBe('Some card')
+    expect(r.task_source).toBe('kanban_correlation')
+  })
+
+  it('leaves a marker-labelled row completely alone', () => {
+    // Its WHERE already guards on task_title IS NULL. Pinned because losing
+    // that guard would let a time-window guess overwrite an exact label, and
+    // the row would still look attributed.
+    // A second, unlabelled row is needed so the correlation actually runs --
+    // otherwise the agent has no uncorrelated span, no card is even fetched,
+    // and the assertion would pass without exercising anything.
+    insertUsage({ session: 'a', ts: T0 + 10, title: 'memoria-heartbeat', source: 'schedule_marker' })
+    insertUsage({ session: 'b', ts: T0 + 20 })
+    // The card must move inside the span of the UNLABELLED rows: that span is
+    // what correlateWithKanban() computes its candidate window from.
+    insertCard({ title: 'Some card', updated: T0 + 20 })
+    correlateWithKanban()
+
+    const marker = getDb().prepare("SELECT task_title, task_source FROM token_usage WHERE session_id='a'").get() as
+      { task_title: string; task_source: string }
+    expect(marker.task_title).toBe('memoria-heartbeat')
+    expect(marker.task_source).toBe('schedule_marker')
+    // and the correlation did fire on the row that was free to take it
+    const other = getDb().prepare("SELECT task_source FROM token_usage WHERE session_id='b'").get() as
+      { task_source: string }
+    expect(other.task_source, 'the correlation never ran, so this proved nothing').toBe('kanban_correlation')
+  })
+
+  it('makes the two kinds separable without matching on task names', () => {
+    // The point of the column: before it, telling them apart meant checking
+    // whether a title happened to be one of the schedule directory names --
+    // which silently misfiles any card that shares a name with a schedule.
+    insertUsage({ session: 'a', ts: T0 + 10, title: 'memoria-heartbeat', source: 'schedule_marker' })
+    insertUsage({ session: 'b', ts: T0 + 20 })
+    insertCard({ title: 'memoria-heartbeat', updated: T0 + 20 })
+    correlateWithKanban()
+    const rows = getDb().prepare(
+      "SELECT task_source, COUNT(*) n FROM token_usage WHERE session_id IN ('a','b') GROUP BY task_source ORDER BY task_source").all() as
+      Array<{ task_source: string; n: number }>
+    expect(rows).toEqual([
+      { task_source: 'kanban_correlation', n: 1 },
+      { task_source: 'schedule_marker', n: 1 },
+    ])
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -605,6 +605,15 @@ export function initDatabase(dbPathOverride?: string): void {
   // Migrations for columns added after initial release
   try { db.exec('ALTER TABLE token_usage ADD COLUMN thinking_tokens INTEGER NOT NULL DEFAULT 0') } catch { /* already exists */ }
   try { db.exec('ALTER TABLE token_usage ADD COLUMN model TEXT') } catch { /* already exists */ }
+  // How task_title got its value. Two writers fill that one column with very
+  // different reliability: the transcript parser reads a marker the runner puts
+  // in the prompt (exact -- the prompt names the task), while
+  // correlateWithKanban() attributes by time window (a guess: every row in a
+  // span gets whatever card moved then). Indistinguishable in one column, they
+  // let a heuristic attribution be read as an exact one.
+  // NULL means the provenance predates this column, not that it is unknown
+  // forever: a rescan stamps the marker rows via the upsert below.
+  try { db.exec('ALTER TABLE token_usage ADD COLUMN task_source TEXT') } catch { /* already exists */ }
 
   // Deduplicate existing rows before creating unique index
   try {

--- a/src/db.ts
+++ b/src/db.ts
@@ -626,6 +626,12 @@ export function initDatabase(dbPathOverride?: string): void {
       last_size INTEGER NOT NULL DEFAULT 0
     )
   `)
+  // The scheduled task a transcript was last working on. Transcript parsing
+  // resumes mid-file from last_line, so the marker that names the task can sit
+  // in an already-consumed chunk; without carrying it across, every row after
+  // the first resume would lose its label and the attribution would be silently
+  // partial rather than obviously broken.
+  try { db.exec('ALTER TABLE token_usage_cursors ADD COLUMN last_task_title TEXT') } catch { /* already exists */ }
 
   // --- Idea Box ---
   db.exec(`

--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -282,13 +282,16 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
   const setCursor = db.prepare('INSERT OR REPLACE INTO token_usage_cursors (file_path, last_line, last_size, last_task_title) VALUES (?, ?, ?, ?)')
   const insertCall = db.prepare(`
     INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens,
-      cache_read_tokens, cache_creation_tokens, thinking_tokens, model, content_preview, tool_name, task_title)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      cache_read_tokens, cache_creation_tokens, thinking_tokens, model, content_preview, tool_name, task_title, task_source)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent, session_id, timestamp, input_tokens, output_tokens) DO UPDATE SET
       model = CASE WHEN token_usage.model IS NULL AND excluded.model IS NOT NULL THEN excluded.model ELSE token_usage.model END,
       -- Fills in on a re-scan but never overwrites an existing label, so a
       -- deliberate backfill can label history without rewriting good rows.
       task_title = CASE WHEN token_usage.task_title IS NULL AND excluded.task_title IS NOT NULL THEN excluded.task_title ELSE token_usage.task_title END,
+      -- Fills provenance on a rescan for rows labelled before this column
+      -- existed, without ever relabelling a row that already has a source.
+      task_source = CASE WHEN token_usage.task_source IS NULL AND excluded.task_source IS NOT NULL THEN excluded.task_source ELSE token_usage.task_source END,
       thinking_tokens = CASE WHEN (token_usage.thinking_tokens IS NULL OR token_usage.thinking_tokens = 0) AND excluded.thinking_tokens > 0 THEN excluded.thinking_tokens ELSE token_usage.thinking_tokens END
   `)
 
@@ -320,6 +323,7 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
                 c.cacheReadTokens, c.cacheCreationTokens,
                 c.thinkingTokens, c.model,
                 c.contentPreview || null, c.toolName, c.taskTitle,
+                c.taskTitle ? 'schedule_marker' : null,
               )
             }
             setCursor.run(file, linesRead, fileSize, endTask)
@@ -582,7 +586,7 @@ export function correlateWithKanban(): void {
 
       db.prepare(`
         UPDATE token_usage
-        SET task_title = ?, project = ?
+        SET task_title = ?, project = ?, task_source = 'kanban_correlation'
         WHERE agent = ? AND timestamp BETWEEN ? AND ? AND task_title IS NULL
       `).run(card.title, card.project || null, row.agent, card.updated_at, endTs)
     }

--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -71,6 +71,51 @@ function findJsonlFiles(dir: string): string[] {
   return files
 }
 
+/**
+ * The scheduled task a prompt belongs to, read off the provenance wrapper the
+ * schedule runner puts around every injected prompt.
+ *
+ * Two markers ride along, and measurement across all 95 transcripts on
+ * 2026-07-31 found them on all 1149 scheduled prompts together, never one
+ * without the other: a structured `<scheduled-task source="scheduled-task:X">`
+ * tag and a human-readable `[Heartbeat: X]` / `[Utemezett feladat: X]` prefix.
+ * We anchor on the structured tag -- it is machine-intended, quoted, and cannot
+ * be confused with a user quoting the bracket form in prose.
+ *
+ * Neither marker sits at the start of the message: the safety wrapper's
+ * preamble comes first, so this searches rather than matching from the head.
+ */
+const SCHEDULED_TASK_TAG = /<scheduled-task source="scheduled-task:([^"]+)"/
+
+/** Schedule name for a prompt, or null if this is not a scheduled run. */
+export function parseScheduledTaskMarker(text: string): string | null {
+  const m = SCHEDULED_TASK_TAG.exec(text)
+  return m ? m[1] : null
+}
+
+/**
+ * Text carried by a transcript `user` line, or null when the line is not a
+ * real user turn.
+ *
+ * Tool results arrive as `user` lines too -- 8270 of 10579 across the fleet's
+ * transcripts -- and they must be distinguished from a person typing. If a
+ * tool result counted as a user turn, the label would be cleared on the very
+ * first tool call of a scheduled run, which is to say almost immediately, and
+ * the task would appear to cost a single API call.
+ */
+export function userTurnText(content: unknown): string | null {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return null
+  let text = ''
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue
+    const b = block as { type?: string; text?: string }
+    if (b.type === 'tool_result') return null // a tool result, not a person
+    if (b.type === 'text' && typeof b.text === 'string') text += b.text
+  }
+  return text
+}
+
 interface ParsedCall {
   agent: string
   sessionId: string
@@ -83,6 +128,10 @@ interface ParsedCall {
   thinkingTokens: number
   /** Model identifier from the API response, e.g. "claude-sonnet-5". */
   model: string | null
+  /** Scheduled task this turn belongs to, or null for interactive work. Only
+   *  the schedule NAME is stored: its kind (task vs heartbeat) already lives in
+   *  the schedule's own task-config.json and would go stale if duplicated here. */
+  taskTitle: string | null
   contentPreview: string
   toolName: string | null
   /** The API message id (msg_...). One assistant turn that calls a tool is
@@ -122,6 +171,7 @@ export function collapseByMessageId(calls: ParsedCall[]): ParsedCall[] {
     ex.cacheCreationTokens = Math.max(ex.cacheCreationTokens, c.cacheCreationTokens)
     ex.thinkingTokens = Math.max(ex.thinkingTokens, c.thinkingTokens)
     if (!ex.model && c.model) ex.model = c.model
+    if (!ex.taskTitle && c.taskTitle) ex.taskTitle = c.taskTitle
     if (!ex.toolName && c.toolName) ex.toolName = c.toolName
     if (!ex.contentPreview && c.contentPreview) ex.contentPreview = c.contentPreview
   }
@@ -132,10 +182,14 @@ async function parseJsonlFile(
   filePath: string,
   agent: string,
   fromLine: number,
-): Promise<{ calls: ParsedCall[]; linesRead: number }> {
+  carriedTask: string | null = null,
+): Promise<{ calls: ParsedCall[]; linesRead: number; endTask: string | null }> {
   const calls: ParsedCall[] = []
   let lineNum = 0
   let sessionId = ''
+  // Survives across resumes via the cursor -- see the token_usage_cursors
+  // migration in db.ts for why dropping it would corrupt attribution quietly.
+  let currentTask: string | null = carriedTask
 
   const rl = createInterface({
     input: createReadStream(filePath, { encoding: 'utf-8' }),
@@ -152,6 +206,15 @@ async function parseJsonlFile(
 
     if (obj.sessionId) {
       sessionId = obj.sessionId
+    }
+
+    // A real user turn either starts a scheduled run or ends one. An
+    // unmarked turn means a person took over, so the previous task's label
+    // must stop here rather than bleeding onto unrelated later work.
+    if (obj.type === 'user') {
+      const text = userTurnText(obj.message?.content)
+      if (text !== null) currentTask = parseScheduledTaskMarker(text)
+      continue
     }
 
     if (obj.type !== 'assistant' || !obj.message?.usage) continue
@@ -197,6 +260,7 @@ async function parseJsonlFile(
       cacheCreationTokens: (u.cache_creation_input_tokens || 0),
       thinkingTokens,
       model: obj.message?.model || null,
+      taskTitle: currentTask,
       contentPreview: preview,
       toolName,
       messageId: obj.message?.id || null,
@@ -205,7 +269,7 @@ async function parseJsonlFile(
 
   // Collapse the multi-line tool-turn rows (same message id, repeated usage)
   // before they reach the DB -- this is the fix for the ~2x token inflation.
-  return { calls: collapseByMessageId(calls), linesRead: lineNum }
+  return { calls: collapseByMessageId(calls), linesRead: lineNum, endTask: currentTask }
 }
 
 export async function collectTokenUsage(): Promise<{ inserted: number; files: number }> {
@@ -214,14 +278,17 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
   let totalInserted = 0
   let totalFiles = 0
 
-  const getCursor = db.prepare('SELECT last_line, last_size FROM token_usage_cursors WHERE file_path = ?')
-  const setCursor = db.prepare('INSERT OR REPLACE INTO token_usage_cursors (file_path, last_line, last_size) VALUES (?, ?, ?)')
+  const getCursor = db.prepare('SELECT last_line, last_size, last_task_title FROM token_usage_cursors WHERE file_path = ?')
+  const setCursor = db.prepare('INSERT OR REPLACE INTO token_usage_cursors (file_path, last_line, last_size, last_task_title) VALUES (?, ?, ?, ?)')
   const insertCall = db.prepare(`
     INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens,
-      cache_read_tokens, cache_creation_tokens, thinking_tokens, model, content_preview, tool_name)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      cache_read_tokens, cache_creation_tokens, thinking_tokens, model, content_preview, tool_name, task_title)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent, session_id, timestamp, input_tokens, output_tokens) DO UPDATE SET
       model = CASE WHEN token_usage.model IS NULL AND excluded.model IS NOT NULL THEN excluded.model ELSE token_usage.model END,
+      -- Fills in on a re-scan but never overwrites an existing label, so a
+      -- deliberate backfill can label history without rewriting good rows.
+      task_title = CASE WHEN token_usage.task_title IS NULL AND excluded.task_title IS NOT NULL THEN excluded.task_title ELSE token_usage.task_title END,
       thinking_tokens = CASE WHEN (token_usage.thinking_tokens IS NULL OR token_usage.thinking_tokens = 0) AND excluded.thinking_tokens > 0 THEN excluded.thinking_tokens ELSE token_usage.thinking_tokens END
   `)
 
@@ -231,13 +298,18 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
       let fileSize: number
       try { fileSize = statSync(file).size } catch { continue }
 
-      const cursor = getCursor.get(file) as { last_line: number; last_size: number } | undefined
+      const cursor = getCursor.get(file) as { last_line: number; last_size: number; last_task_title: string | null } | undefined
       if (cursor && cursor.last_size === fileSize) continue
 
       const fromLine = (cursor && cursor.last_size <= fileSize) ? cursor.last_line : 0
 
       try {
-        const { calls, linesRead } = await parseJsonlFile(file, source.agent, fromLine)
+        // Resuming mid-file means the marker naming the current task may be
+        // behind us; the cursor carries it forward. A full re-read (fromLine 0)
+        // starts clean so a stale label cannot survive a deliberate rescan.
+        const { calls, linesRead, endTask } = await parseJsonlFile(
+          file, source.agent, fromLine, fromLine > 0 ? (cursor?.last_task_title ?? null) : null,
+        )
 
         if (calls.length > 0) {
           const tx = db.transaction(() => {
@@ -247,15 +319,15 @@ export async function collectTokenUsage(): Promise<{ inserted: number; files: nu
                 c.inputTokens, c.outputTokens,
                 c.cacheReadTokens, c.cacheCreationTokens,
                 c.thinkingTokens, c.model,
-                c.contentPreview || null, c.toolName,
+                c.contentPreview || null, c.toolName, c.taskTitle,
               )
             }
-            setCursor.run(file, linesRead, fileSize)
+            setCursor.run(file, linesRead, fileSize, endTask)
           })
           tx()
           totalInserted += calls.length
         } else {
-          setCursor.run(file, linesRead, fileSize)
+          setCursor.run(file, linesRead, fileSize, endTask)
         }
         totalFiles++
       } catch (err) {


### PR DESCRIPTION
> ⚠️ **Stacked on #807.** Two commits: the R0 labelling commit (#807) and the provenance commit below, which stamps the column R0's parser writes. Merge **#807 first**; this then reduces to a single commit.

## The problem

`task_title` is written by two things with very different reliability:

| writer | how it attributes | trustworthy? |
|---|---|---|
| transcript parser (R0) | reads a marker the runner puts **into the prompt** | exact — the prompt names the task |
| `correlateWithKanban()` | **time window** — every row in a span gets whatever card moved during it | a guess |

In one column they are indistinguishable, so a reader cannot tell an exact attribution from a heuristic one. That is how a guess ends up inside a cost report presented as fact — and it is not hypothetical: after the recent backfill the live table holds 2 418 marker rows and 6 855 correlated ones, side by side.

Until now the only way to separate them was to check whether a title happened to match a directory name under `scheduled-tasks/`. That misfiles any card sharing a name with a schedule, and breaks silently when either side is renamed.

## What this adds

`task_source` records which writer set the label: `'schedule_marker'` or `'kanban_correlation'`.

- The parser's upsert fills it **on a rescan** for rows labelled before the column existed, and **never relabels** a row that already has a source.
- `NULL` means the provenance predates the column — stated rather than guessed.
- No behaviour change to either writer beyond the stamp.

## Verification

- 5 new tests, `tsc --noEmit` clean, full suite **2947 pass, 0 failures**.
- **Sabotage control:** dropping the stamp from the correlation `UPDATE` fails 3 of the 5.
- One of the tests pins that `correlateWithKanban()` leaves a marker-labelled row alone — its `task_title IS NULL` guard is what protects exact labels from being overwritten by a time-window guess, and nothing was covering it.

## A test-setup note worth keeping

`initDatabase(':memory:')` does not reliably return an empty database when called repeatedly in one process, so these cases clear both tables explicitly. Without that they passed alone and failed together, which reads as flakiness rather than a setup bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
