### PR TITLE
feat(costops): subscription quota guard -- warn at 70%, eco mode at 85%

### DIFF
--- a/src/__tests__/costops-api.test.ts
+++ b/src/__tests__/costops-api.test.ts
@@ -41,14 +41,42 @@ describe('costops API (route smoke)', () => {
     expect(out.body).toHaveProperty('breakdown')
     expect(out.body).toHaveProperty('budget')
     expect(out.body).toHaveProperty('token_usage')
-    // token usage reported as VOLUME
+    // token usage reported as VOLUME, plus a labelled list-price equivalent
     expect(out.body.token_usage.input_tokens).toBe(1234)
     expect(out.body.token_usage.output_tokens).toBe(5678)
-    expect(out.body.token_usage.note).toContain('not priced')
+    expect(out.body.token_usage.note).toContain('LIST-PRICE EQUIVALENT')
+    expect(out.body.token_usage.list_price_equivalent.basis).toBe('list_price_equivalent')
+    expect(out.body.token_usage.list_price_equivalent.currency).toBe('USD')
     // money never derived from tokens (config amounts are 0 placeholders)
     expect(typeof out.body.current_spend).toBe('number')
     // no secret / account id leaks into the response
     expect(JSON.stringify(out.body)).not.toMatch(/secret|api[_-]?key|password|token=/i)
+  })
+
+  it('GET /api/costs/tokens prices a rolling window and labels its basis', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    getDb().prepare("INSERT INTO token_usage (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens,model) VALUES ('marveen','s',?,0,1000000,0,0,'claude-opus-5')").run(now - 3600)
+    const { ctx, out } = fakeCtx('/api/costs/tokens?days=7')
+    expect(await tryHandleCosts(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    expect(out.body.basis).toBe('list_price_equivalent')
+    expect(out.body.currency).toBe('USD')
+    expect(out.body.total).toBeCloseTo(25, 6) // 1M output tokens at $25/1M
+    expect(out.body.by_model[0].model).toBe('claude-opus-5')
+  })
+
+  it('GET /api/costs/tokens clamps an absurd or unparseable days parameter', async () => {
+    // The window is attacker-visible input on a bearer-gated route; an
+    // unbounded lookback would turn a read into a full-table scan.
+    const now = Math.floor(Date.now() / 1000)
+    for (const [q, maxDays] of [['days=99999', 400], ['days=abc', 7], ['days=-5', 1]] as const) {
+      const { ctx, out } = fakeCtx(`/api/costs/tokens?${q}`)
+      expect(await tryHandleCosts(ctx)).toBe(true)
+      expect(out.status).toBe(200)
+      const spanDays = (out.body.window.end - out.body.window.start) / 86400
+      expect(spanDays, `${q} produced a ${spanDays}-day window`).toBeLessThanOrEqual(maxDays)
+      expect(out.body.window.end).toBeGreaterThanOrEqual(now - 5)
+    }
   })
 
   it('GET /api/costs/sources returns an array', async () => {

--- a/src/__tests__/costops-context-attribution.test.ts
+++ b/src/__tests__/costops-context-attribution.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  splitRuns,
+  decomposeRun,
+  freshSessionCost,
+  getContextAttribution,
+  SESSION_STARTUP_TOKENS,
+  RUN_GAP_SECONDS,
+  type UsageRow,
+} from '../costops/context-attribution.js'
+
+/**
+ * R1-A (kanban #134): a scheduled task's cost is mostly a fact about the
+ * session it landed in, not about the task. These tests pin the decomposition
+ * and, more importantly, pin the honesty of the fresh-session comparison.
+ */
+
+const OPUS = 'claude-opus-5' // $5 in / $25 out per 1M
+const T0 = 1_780_000_000
+
+function row(over: Partial<UsageRow> = {}): UsageRow {
+  return {
+    task_title: 'demo', session_id: 's1', model: OPUS, timestamp: T0,
+    input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0,
+    ...over,
+  }
+}
+
+describe('splitting a task into runs', () => {
+  it('splits on a gap longer than the threshold', () => {
+    const runs = splitRuns([
+      row({ timestamp: T0 }),
+      row({ timestamp: T0 + 5 }),
+      row({ timestamp: T0 + RUN_GAP_SECONDS + 60 }),
+    ])
+    expect(runs.map(r => r.length)).toEqual([2, 1])
+  })
+
+  it('keeps calls seconds apart in one run', () => {
+    expect(splitRuns([row({ timestamp: T0 }), row({ timestamp: T0 + 30 })])).toHaveLength(1)
+  })
+
+  it('would undercount runs if bucketed by clock hour instead', () => {
+    // A quarter-hourly heartbeat fires up to 4 times an hour. Hour-bucketing
+    // would call that one run and quadruple every per-run figure.
+    const quarterly = [0, 900, 1800, 2700].map(d => row({ timestamp: T0 + d }))
+    expect(splitRuns(quarterly)).toHaveLength(4)
+  })
+
+  it('handles an empty input', () => {
+    expect(splitRuns([])).toEqual([])
+  })
+})
+
+describe('separating inherited context from own work', () => {
+  it('charges the first call\'s cache_read to inherited, the excess to own', () => {
+    const c = decomposeRun([
+      row({ cache_read_tokens: 1_000_000 }),                          // baseline
+      row({ cache_read_tokens: 1_200_000, output_tokens: 1_000 }),    // +200k own
+    ])!
+    // inherited = 2 x 1M x $5 x 0.1 / 1M = $1.00
+    expect(c.inherited).toBeCloseTo(1.0, 6)
+    // own = 200k cache at 0.1x ($0.10) + 1k output at $25/1M ($0.025)
+    expect(c.own).toBeCloseTo(0.125, 6)
+    expect(c.total).toBeCloseTo(c.inherited + c.own, 10)
+  })
+
+  it('attributes nothing to inherited when the session started empty', () => {
+    const c = decomposeRun([row({ cache_read_tokens: 0, output_tokens: 1_000_000 })])!
+    expect(c.inherited).toBe(0)
+    expect(c.own).toBeCloseTo(25, 6)
+  })
+
+  it('never charges a shrinking context as negative own work', () => {
+    // Context can shrink across a run when compaction fires mid-task.
+    const c = decomposeRun([
+      row({ cache_read_tokens: 1_000_000 }),
+      row({ cache_read_tokens: 200_000 }),
+    ])!
+    expect(c.own).toBeGreaterThanOrEqual(0)
+  })
+
+  it('returns null for an unpriced model rather than a zero cost', () => {
+    expect(decomposeRun([row({ model: '<synthetic>' })])).toBeNull()
+    expect(decomposeRun([])).toBeNull()
+  })
+})
+
+describe('the fresh-session alternative is not free', () => {
+  const own = { inherited: 10, own: 2, total: 12, calls: 1 }
+
+  it('charges the startup preamble as a cache WRITE on the first call', () => {
+    const cost = freshSessionCost(own, OPUS)
+    // 41,224 x $5 x 1.25 / 1M = $0.2577, plus the unchanged own work
+    expect(cost).toBeCloseTo((SESSION_STARTUP_TOKENS * 5 * 1.25) / 1e6 + 2, 6)
+  })
+
+  it('charges a re-read of that preamble on every later call', () => {
+    const one = freshSessionCost({ ...own, calls: 1 }, OPUS)
+    const five = freshSessionCost({ ...own, calls: 5 }, OPUS)
+    expect(five).toBeGreaterThan(one)
+    expect(five - one).toBeCloseTo((4 * SESSION_STARTUP_TOKENS * 5 * 0.1) / 1e6, 6)
+  })
+
+  it('keeps the task\'s own work unchanged -- only the inherited context goes', () => {
+    expect(freshSessionCost({ inherited: 100, own: 3, total: 103, calls: 1 }, OPUS))
+      .toBeCloseTo(freshSessionCost({ inherited: 0, own: 3, total: 3, calls: 1 }, OPUS), 10)
+  })
+
+  it('can come out MORE expensive, and says so', () => {
+    // The honesty test. If a run inherited almost nothing, paying to load a
+    // fresh preamble is a loss. A model that always favoured fresh sessions
+    // would be rigged, and every saving it reported would be suspect.
+    const cheapHost = { inherited: 0.001, own: 0.01, total: 0.011, calls: 1 }
+    expect(freshSessionCost(cheapHost, OPUS)).toBeGreaterThan(cheapHost.total)
+  })
+})
+
+describe('the report over real-shaped rows', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  function insert(r: Partial<UsageRow> & { task_title: string }) {
+    const f = row(r as Partial<UsageRow>)
+    getDb().prepare(`INSERT INTO token_usage
+      (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens,model,task_title)
+      VALUES ('marveen',?,?,?,?,?,?,?,?)`).run(
+      f.session_id, f.timestamp, f.input_tokens, f.output_tokens,
+      f.cache_read_tokens, f.cache_creation_tokens, f.model, f.task_title)
+  }
+
+  it('only counts the tasks it was asked for', () => {
+    // token_usage.task_title also holds kanban card titles written by
+    // correlateWithKanban() -- a time-window guess. Letting those into a cost
+    // figure would mix exact attribution with a heuristic one.
+    insert({ task_title: 'memoria-heartbeat', session_id: 'a', cache_read_tokens: 1_000_000 })
+    insert({ task_title: 'Some kanban card title', session_id: 'b', cache_read_tokens: 9_000_000 })
+    const r = getContextAttribution(getDb(), { start: 0, end: T0 + 999, tasks: ['memoria-heartbeat'] })
+    expect(r.tasks).toHaveLength(1)
+    expect(r.tasks[0].task).toBe('memoria-heartbeat')
+    expect(r.totals.inherited_cost).toBeCloseTo(0.5, 6)
+  })
+
+  it('returns an empty report rather than everything when given no task list', () => {
+    insert({ task_title: 'memoria-heartbeat', cache_read_tokens: 1_000_000 })
+    const r = getContextAttribution(getDb(), { start: 0, end: T0 + 999, tasks: [] })
+    expect(r.tasks).toEqual([])
+    expect(r.totals.total_cost).toBe(0)
+  })
+
+  it('splits two firings of the same task into two runs', () => {
+    insert({ task_title: 'kanban-audit', timestamp: T0, cache_read_tokens: 500_000 })
+    insert({ task_title: 'kanban-audit', timestamp: T0 + 3600, cache_read_tokens: 500_001 })
+    const r = getContextAttribution(getDb(), { start: 0, end: T0 + 99999, tasks: ['kanban-audit'] })
+    expect(r.tasks[0].runs).toBe(2)
+  })
+
+  it('reports the within/between variance instead of asserting it', () => {
+    // The report carries the evidence for its own caveat: if one task's runs
+    // vary more than the tasks differ, cost cannot signal complexity.
+    // Distinct sessions per task: the dedup index is keyed on
+    // (agent, session_id, timestamp, input, output), so two tasks sharing a
+    // session and a timestamp would collide rather than both being stored.
+    for (const [i, cr] of [10_000, 5_000_000, 20_000, 8_000_000].entries())
+      insert({ task_title: 'memoria-heartbeat', session_id: 'hb', timestamp: T0 + i * 3600, cache_read_tokens: cr })
+    for (const [i, cr] of [1_000_000, 1_100_000, 1_050_000, 1_020_000].entries())
+      insert({ task_title: 'kanban-audit', session_id: 'ka', timestamp: T0 + i * 3600, cache_read_tokens: cr })
+    const r = getContextAttribution(getDb(), { start: 0, end: T0 + 999999, tasks: ['memoria-heartbeat', 'kanban-audit'] })
+    expect(r.complexity_signal.within_task_ratio_median).toBeGreaterThan(r.complexity_signal.between_task_ratio)
+    expect(r.complexity_signal.verdict).toContain('cannot discriminate')
+  })
+
+  it('labels its basis and states its assumption', () => {
+    const r = getContextAttribution(getDb(), { start: 0, end: T0, tasks: [] })
+    expect(r.basis).toBe('list_price_equivalent')
+    expect(r.currency).toBe('USD')
+    expect(r.assumption).toContain('upper bound')
+  })
+
+  it('counts unpriced runs separately', () => {
+    insert({ task_title: 'kanban-audit', model: '<synthetic>', cache_read_tokens: 1_000_000 })
+    const r = getContextAttribution(getDb(), { start: 0, end: T0 + 999, tasks: ['kanban-audit'] })
+    expect(r.unpriced_runs).toBe(1)
+    expect(r.tasks).toEqual([])
+  })
+})

--- a/src/__tests__/costops-eco-api.test.ts
+++ b/src/__tests__/costops-eco-api.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { Readable } from 'node:stream'
+import { readFileSync } from 'node:fs'
+import { tryHandleCosts } from '../web/routes/costs.js'
+import { MAIN_AGENT_SETTINGS_PATH, DEFAULT_ECO_MODEL } from '../costops/eco-mode.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+/**
+ * HTTP wiring for the eco switch. Every case here is deliberately
+ * non-mutating: GET, a rejected target, and an explicit dry run. The write
+ * path is covered against temp files in costops-eco-mode.test.ts, so this
+ * suite never rewrites a tracked config to prove a point.
+ */
+
+function fakeCtx(path: string, method = 'GET', body?: unknown) {
+  const out: { status: number; body: any } = { status: 200, body: null }
+  const res: any = {
+    writeHead(status: number) { out.status = status; return res },
+    end(chunk?: string) { if (chunk) out.body = JSON.parse(chunk) },
+  }
+  const req: any = body === undefined
+    ? Readable.from([])
+    : Readable.from([Buffer.from(JSON.stringify(body))])
+  const url = new URL(`http://localhost:3420${path}`)
+  return { ctx: { req, res, path: url.pathname, method, url } as RouteContext, out }
+}
+
+function settingsSnapshot() {
+  return readFileSync(MAIN_AGENT_SETTINGS_PATH, 'utf-8')
+}
+
+describe('GET /api/costs/eco', () => {
+  it('reports the current state and a preview', async () => {
+    const { ctx, out } = fakeCtx('/api/costs/eco')
+    expect(await tryHandleCosts(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    expect(out.body.state).toHaveProperty('enabled')
+    expect(out.body.preview.plan).toHaveProperty('changes')
+  })
+
+  it('always says a restart is still required', async () => {
+    // The whole point of F2: config only. Anything reading this response must
+    // be told the change has not taken effect yet.
+    const { ctx, out } = fakeCtx('/api/costs/eco')
+    await tryHandleCosts(ctx)
+    expect(out.body.preview.restart_required).toBe(true)
+    expect(out.body.preview.note).toContain('does not perform')
+  })
+
+  it('writes nothing', async () => {
+    const before = settingsSnapshot()
+    const { ctx } = fakeCtx('/api/costs/eco')
+    await tryHandleCosts(ctx)
+    expect(settingsSnapshot()).toBe(before)
+  })
+})
+
+describe('POST /api/costs/eco', () => {
+  it('refuses an unknown target model instead of writing it', async () => {
+    // A model string with no published rate is not a harmless typo: the
+    // agent's next launch fails on it. The skill's naming gotcha in practice.
+    const before = settingsSnapshot()
+    const { ctx, out } = fakeCtx('/api/costs/eco', 'POST', { enabled: true, target: 'claude-sonnet-4-8' })
+    expect(await tryHandleCosts(ctx)).toBe(true)
+    expect(out.status).toBe(400)
+    expect(out.body.error).toContain('claude-sonnet-4-8')
+    expect(out.body.known).toContain(DEFAULT_ECO_MODEL)
+    expect(settingsSnapshot(), 'a bad target reached the config file').toBe(before)
+  })
+
+  it('accepts a suffixed form of a known model', async () => {
+    const { ctx, out } = fakeCtx('/api/costs/eco', 'POST', { enabled: true, target: 'claude-sonnet-5[1m]', dry_run: true })
+    await tryHandleCosts(ctx)
+    expect(out.status).toBe(200)
+    expect(out.body.plan.target).toBe('claude-sonnet-5[1m]')
+  })
+
+  it('dry run returns a plan and changes nothing', async () => {
+    const before = settingsSnapshot()
+    const { ctx, out } = fakeCtx('/api/costs/eco', 'POST', { enabled: true, dry_run: true })
+    await tryHandleCosts(ctx)
+    expect(out.status).toBe(200)
+    expect(out.body.applied).toEqual([])
+    expect(out.body.restart_required).toBe(true)
+    expect(settingsSnapshot()).toBe(before)
+  })
+})

--- a/src/__tests__/costops-eco-mode.test.ts
+++ b/src/__tests__/costops-eco-mode.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  baseModelId,
+  modelExpense,
+  planEcoEnable,
+  planEcoDisable,
+  nextSavedOriginals,
+  writeAgentModel,
+  EMPTY_ECO_STATE,
+  type AgentModel,
+  type EcoModeState,
+} from '../costops/eco-mode.js'
+
+/**
+ * F2 (kanban #132): one switch that moves the fleet to a cheap model.
+ *
+ * It writes configuration and never restarts anything -- a model change only
+ * takes effect on the next restart, and that is an operator decision.
+ */
+
+const ECO = 'claude-sonnet-5' // $3/1M in
+function fleet(...rows: Array<[string, string | null]>): AgentModel[] {
+  return rows.map(([agent, model]) => ({ agent, model, path: `/fake/${agent}.json` }))
+}
+
+describe('model identity and expense', () => {
+  it('strips the context-variant suffix', () => {
+    // Agent configs carry `[1m]`; PRICE_MAP is keyed on the bare id the API
+    // reports. Without this every suffixed agent would look unpriced.
+    expect(baseModelId('claude-opus-5[1m]')).toBe('claude-opus-5')
+    expect(baseModelId('claude-opus-5')).toBe('claude-opus-5')
+  })
+
+  it('prices a suffixed model the same as a bare one', () => {
+    expect(modelExpense('claude-opus-5[1m]')).toBe(modelExpense('claude-opus-5'))
+  })
+
+  it('orders the models the fleet actually runs', () => {
+    expect(modelExpense('claude-fable-5')).toBeGreaterThan(modelExpense('claude-opus-5')!)
+    expect(modelExpense('claude-opus-5')).toBeGreaterThan(modelExpense('claude-sonnet-5')!)
+    expect(modelExpense('claude-sonnet-5')).toBeGreaterThan(modelExpense('claude-haiku-4-5')!)
+  })
+
+  it('returns null for a model with no published rate', () => {
+    expect(modelExpense('some-local-llm')).toBeNull()
+    expect(modelExpense(null)).toBeNull()
+  })
+})
+
+describe('switching eco mode on', () => {
+  it('moves the expensive agents to the target', () => {
+    const plan = planEcoEnable(fleet(['(main)', 'claude-fable-5'], ['prisma', 'claude-opus-5[1m]']), ECO)
+    expect(plan.changes.map(c => c.agent).sort()).toEqual(['(main)', 'prisma'])
+    expect(plan.changes.every(c => c.to === ECO)).toBe(true)
+  })
+
+  it('does NOT upgrade an agent that is already cheaper', () => {
+    // The trap in "switch everything to X": an agent on haiku would be moved
+    // UP to sonnet and cost more, which is the opposite of the point.
+    const plan = planEcoEnable(fleet(['cheap', 'claude-haiku-4-5']), ECO)
+    expect(plan.changes).toHaveLength(0)
+    expect(plan.unchanged[0].reason).toBe('already_cheaper_or_equal')
+  })
+
+  it('leaves an agent already at the target alone, suffix or not', () => {
+    const plan = planEcoEnable(fleet(['a', 'claude-sonnet-5'], ['b', 'claude-sonnet-5[1m]']), ECO)
+    expect(plan.changes).toHaveLength(0)
+    expect(plan.unchanged.map(u => u.reason)).toEqual(['already_at_target', 'already_at_target'])
+  })
+
+  it('leaves an unpriced model alone and says so', () => {
+    // A change we cannot price is a change we cannot justify. Reported, not
+    // silently skipped, so an unrecognised model shows up as a gap.
+    const plan = planEcoEnable(fleet(['odd', 'some-local-llm']), ECO)
+    expect(plan.changes).toHaveLength(0)
+    expect(plan.unchanged[0].reason).toBe('unpriced_model_left_alone')
+  })
+
+  it('treats a missing model field as eligible', () => {
+    // No explicit field means the agent follows DEFAULT_MODEL, which we cannot
+    // assume is cheap.
+    const plan = planEcoEnable(fleet(['noconf', null]), ECO)
+    expect(plan.changes).toHaveLength(1)
+    expect(plan.changes[0]).toMatchObject({ from: null, to: ECO, reason: 'switched_to_eco' })
+  })
+
+  it('lists exactly the changed agents as needing a restart', () => {
+    const plan = planEcoEnable(fleet(['(main)', 'claude-fable-5'], ['cheap', 'claude-haiku-4-5']), ECO)
+    expect(plan.needsRestart).toEqual(['(main)'])
+  })
+})
+
+describe('remembering the originals', () => {
+  it('records what each changed agent was set to', () => {
+    const current = fleet(['(main)', 'claude-fable-5'], ['prisma', 'claude-opus-5[1m]'])
+    const plan = planEcoEnable(current, ECO)
+    expect(nextSavedOriginals(plan, current, EMPTY_ECO_STATE)).toEqual({
+      '(main)': 'claude-fable-5',
+      prisma: 'claude-opus-5[1m]',
+    })
+  })
+
+  it('records an absent model field as null, not as the default', () => {
+    // null and absent are different states. Restoring an absent field by
+    // writing today's DEFAULT_MODEL would pin the agent to whatever the
+    // default happened to be, and stop it tracking future changes.
+    const current = fleet(['noconf', null])
+    const saved = nextSavedOriginals(planEcoEnable(current, ECO), current, EMPTY_ECO_STATE)
+    expect(saved).toHaveProperty('noconf')
+    expect(saved.noconf).toBeNull()
+  })
+
+  it('does not re-save when eco mode is already on', () => {
+    // The one-way-door bug: running enable twice would otherwise overwrite the
+    // originals with the eco model, and disable could never restore anything.
+    const already: EcoModeState = {
+      enabled: true, since: 1, target: ECO, saved: { '(main)': 'claude-fable-5' },
+    }
+    const current = fleet(['(main)', ECO]) // already switched
+    expect(nextSavedOriginals(planEcoEnable(current, ECO), current, already)).toEqual({
+      '(main)': 'claude-fable-5',
+    })
+  })
+})
+
+describe('switching eco mode off', () => {
+  const state: EcoModeState = {
+    enabled: true, since: 1, target: ECO,
+    saved: { '(main)': 'claude-fable-5', noconf: null },
+  }
+
+  it('restores each agent to exactly what it was', () => {
+    const plan = planEcoDisable(fleet(['(main)', ECO]), state)
+    expect(plan.changes[0]).toMatchObject({ agent: '(main)', to: 'claude-fable-5', reason: 'restored' })
+  })
+
+  it('restores an originally-absent field by removing it, not by writing a model', () => {
+    const plan = planEcoDisable(fleet(['noconf', ECO]), state)
+    expect(plan.changes).toHaveLength(1)
+    expect(plan.changes[0].to).toBeNull()
+  })
+
+  it('leaves an agent it never touched alone', () => {
+    const plan = planEcoDisable(fleet(['stranger', 'claude-opus-5']), state)
+    expect(plan.changes).toHaveLength(0)
+    expect(plan.unchanged[0].reason).toBe('nothing_saved_to_restore')
+  })
+
+  it('round-trips: on then off returns the fleet to its exact starting point', () => {
+    const start = fleet(['(main)', 'claude-fable-5'], ['prisma', 'claude-opus-5[1m]'], ['noconf', null], ['cheap', 'claude-haiku-4-5'])
+    const onPlan = planEcoEnable(start, ECO)
+    const saved = nextSavedOriginals(onPlan, start, EMPTY_ECO_STATE)
+
+    const changed = new Map(onPlan.changes.map(c => [c.agent, c.to]))
+    const after = start.map(a => ({ ...a, model: changed.has(a.agent) ? changed.get(a.agent)! : a.model }))
+
+    const offPlan = planEcoDisable(after, { enabled: true, since: 1, target: ECO, saved })
+    const restored = new Map(offPlan.changes.map(c => [c.agent, c.to]))
+    const final = after.map(a => ({ agent: a.agent, model: restored.has(a.agent) ? restored.get(a.agent)! : a.model }))
+
+    expect(final).toEqual(start.map(a => ({ agent: a.agent, model: a.model })))
+  })
+})
+
+describe('writing a config file', () => {
+  let dir: string
+  let path: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'eco-'))
+    path = join(dir, 'agent-config.json')
+    writeFileSync(path, JSON.stringify({ model: 'claude-opus-5[1m]', voice: 'x', hooks: { a: 1 } }, null, 2))
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('changes only the model and preserves everything else', () => {
+    // These configs carry hooks, plugins and per-agent settings this module
+    // knows nothing about; rewriting them from a typed shape would drop them.
+    expect(writeAgentModel(path, ECO)).toBe(true)
+    const cfg = JSON.parse(readFileSync(path, 'utf-8'))
+    expect(cfg.model).toBe(ECO)
+    expect(cfg.voice).toBe('x')
+    expect(cfg.hooks).toEqual({ a: 1 })
+  })
+
+  it('removes the field entirely when given null', () => {
+    expect(writeAgentModel(path, null)).toBe(true)
+    const cfg = JSON.parse(readFileSync(path, 'utf-8'))
+    expect(Object.hasOwn(cfg, 'model')).toBe(false)
+    expect(cfg.voice).toBe('x')
+  })
+
+  it('leaves no temp file behind', () => {
+    writeAgentModel(path, ECO)
+    expect(() => readFileSync(`${path}.eco-tmp`, 'utf-8')).toThrow()
+  })
+
+  it('reports failure instead of throwing on a missing file', () => {
+    expect(writeAgentModel(join(dir, 'nope.json'), ECO)).toBe(false)
+  })
+})

--- a/src/__tests__/costops-ledger.test.ts
+++ b/src/__tests__/costops-ledger.test.ts
@@ -185,7 +185,7 @@ describe('costops ledger + summary', () => {
     expect(s.breakdown.estimate).toBe(1450)
   })
 
-  it('reports token_usage as VOLUME only, never priced', () => {
+  it('reports token_usage volume, and never lets it contribute to money', () => {
     const db = getDb()
     const w = monthWindow(NOW)
     const ins = db.prepare("INSERT INTO token_usage (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens) VALUES (?,?,?,?,?,?,?)")
@@ -197,8 +197,11 @@ describe('costops ledger + summary', () => {
     expect(s.token_usage.agents).toBe(2)
     expect(s.token_usage.input_tokens).toBe(1500)
     expect(s.token_usage.output_tokens).toBe(7000)
-    expect(s.token_usage.note).toContain('not priced')
     // token usage must NOT contribute to money
     expect(s.current_spend).toBe(0)
+    // These rows carry no model, so v0.2 cannot price them -- and says so
+    // rather than reporting a confident $0.
+    expect(s.token_usage.list_price_equivalent.total).toBe(0)
+    expect(s.token_usage.list_price_equivalent.unpriced_calls).toBe(2)
   })
 })

--- a/src/__tests__/costops-pricing.test.ts
+++ b/src/__tests__/costops-pricing.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  PRICE_MAP,
+  PRICE_MAP_VERSION,
+  CACHE_READ_MULTIPLIER,
+  CACHE_WRITE_MULTIPLIER,
+  isPriced,
+  priceTokens,
+  dayKey,
+} from '../costops/pricing.js'
+import { getTokenCostReport, getCostSummary, monthWindow } from '../costops/ledger.js'
+import type { CostOpsConfig } from '../costops/config.js'
+
+// 2026-07-15T12:00:00Z, matching the v0.1 ledger tests.
+const NOW = Math.floor(Date.UTC(2026, 6, 15, 12, 0, 0) / 1000)
+
+const OPUS = 'claude-opus-5' // $5 in / $25 out per 1M
+
+function cfg(over: Partial<CostOpsConfig> = {}): CostOpsConfig {
+  return { version: 1, currency: 'HUF', fixed_costs: [], budgets: [], ...over }
+}
+
+function insertUsage(
+  db: ReturnType<typeof getDb>,
+  row: { agent?: string; session?: string; ts: number; model: string | null; i?: number; o?: number; cr?: number; cw?: number },
+) {
+  db.prepare(`INSERT INTO token_usage
+    (agent,session_id,timestamp,input_tokens,output_tokens,cache_read_tokens,cache_creation_tokens,model)
+    VALUES (?,?,?,?,?,?,?,?)`).run(
+    row.agent ?? 'marveen', row.session ?? 's1', row.ts,
+    row.i ?? 0, row.o ?? 0, row.cr ?? 0, row.cw ?? 0, row.model,
+  )
+}
+
+describe('token pricing arithmetic', () => {
+  it('prices every component, with cache weighted at its own multiplier', () => {
+    const c = priceTokens(OPUS, {
+      input_tokens: 1_000, output_tokens: 2_000,
+      cache_read_tokens: 1_000_000, cache_creation_tokens: 100_000,
+    })!
+    expect(c.input).toBeCloseTo(0.005, 10)       // 1e3 * 5 / 1e6
+    expect(c.output).toBeCloseTo(0.05, 10)       // 2e3 * 25 / 1e6
+    expect(c.cache_read).toBeCloseTo(0.5, 10)    // 1e6 * 5 * 0.10 / 1e6
+    expect(c.cache_write).toBeCloseTo(0.625, 10) // 1e5 * 5 * 1.25 / 1e6
+    expect(c.total).toBeCloseTo(1.18, 10)
+  })
+
+  it('would understate by ~21x on this row if only input+output were counted', () => {
+    // The discriminating assertion for the whole module. Fleet-wide, cache_read
+    // is 82.9% of spend and output 7.6%; the obvious input+output formula sees
+    // a small fraction of the real figure. If someone drops the cache terms,
+    // the arithmetic test above still fails -- but this one says why it matters.
+    const counts = {
+      input_tokens: 1_000, output_tokens: 2_000,
+      cache_read_tokens: 1_000_000, cache_creation_tokens: 100_000,
+    }
+    const c = priceTokens(OPUS, counts)!
+    const inputOutputOnly = c.input + c.output
+    expect(c.total / inputOutputOnly).toBeGreaterThan(20)
+  })
+
+  it('components sum to the reported total', () => {
+    const c = priceTokens('claude-fable-5', {
+      input_tokens: 137, output_tokens: 9_311,
+      cache_read_tokens: 4_200_000, cache_creation_tokens: 55_555,
+    })!
+    expect(c.input + c.output + c.cache_read + c.cache_write).toBeCloseTo(c.total, 12)
+  })
+
+  it('scales linearly with each model rate', () => {
+    const counts = { input_tokens: 0, output_tokens: 1_000_000, cache_read_tokens: 0, cache_creation_tokens: 0 }
+    expect(priceTokens('claude-opus-5', counts)!.total).toBeCloseTo(25, 10)
+    expect(priceTokens('claude-fable-5', counts)!.total).toBeCloseTo(50, 10)
+    expect(priceTokens('claude-haiku-4-5', counts)!.total).toBeCloseTo(5, 10)
+  })
+
+  it('pins the cache multipliers, which are the load-bearing constants', () => {
+    expect(CACHE_READ_MULTIPLIER).toBe(0.1)
+    expect(CACHE_WRITE_MULTIPLIER).toBe(1.25)
+  })
+
+  it('carries a version so a stored figure is traceable to its rates', () => {
+    expect(PRICE_MAP_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('prices every model the fleet has actually run', () => {
+    // Observed in token_usage across the whole table on 2026-07-31. A model in
+    // production with no rate is an invisible gap in every total.
+    for (const m of ['claude-fable-5', 'claude-opus-5', 'claude-opus-4-8', 'claude-sonnet-5', 'claude-sonnet-4-6']) {
+      expect(isPriced(m), `${m} has no published rate`).toBe(true)
+      expect(PRICE_MAP[m].output).toBeGreaterThan(PRICE_MAP[m].input)
+    }
+  })
+})
+
+describe('unknown models are a gap, not a zero', () => {
+  it('returns null rather than a $0 cost', () => {
+    // A silent $0 is the failure mode this subsystem exists to prevent: the
+    // total still looks like a total while quietly missing the traffic.
+    expect(priceTokens('<synthetic>', { input_tokens: 1e6, output_tokens: 1e6, cache_read_tokens: 0, cache_creation_tokens: 0 })).toBeNull()
+    expect(priceTokens(null, { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 })).toBeNull()
+    expect(isPriced('gpt-5')).toBe(false)
+  })
+
+  it('is not fooled by inherited Object properties', () => {
+    expect(isPriced('constructor')).toBe(false)
+    expect(isPriced('toString')).toBe(false)
+  })
+})
+
+describe('day bucketing', () => {
+  // 2026-07-15T23:30:00Z is already 2026-07-16 in Budapest (CEST, UTC+2).
+  const lateEvening = Math.floor(Date.UTC(2026, 6, 15, 23, 30, 0) / 1000)
+
+  it('buckets by install-local wall clock, not UTC', () => {
+    expect(dayKey(lateEvening, 'Europe/Budapest')).toBe('2026-07-16')
+  })
+
+  it('the timezone argument actually applies (control)', () => {
+    // Without this, the assertion above would pass even if the parameter were
+    // ignored and the machine happened to sit in a UTC+2 zone.
+    expect(dayKey(lateEvening, 'UTC')).toBe('2026-07-15')
+  })
+
+  it('handles the winter offset too', () => {
+    const winter = Math.floor(Date.UTC(2026, 0, 15, 23, 30, 0) / 1000) // CET, UTC+1
+    expect(dayKey(winter, 'Europe/Budapest')).toBe('2026-01-16')
+  })
+
+  it('produces lexicographically sortable keys', () => {
+    const days = [
+      dayKey(Math.floor(Date.UTC(2026, 9, 3, 10) / 1000), 'UTC'),
+      dayKey(Math.floor(Date.UTC(2026, 0, 20, 10) / 1000), 'UTC'),
+    ]
+    expect([...days].sort()).toEqual(['2026-01-20', '2026-10-03'])
+  })
+})
+
+describe('token cost report', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('aggregates by model, agent and day, and respects the window', () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    insertUsage(db, { ts: w.start + 100, model: OPUS, agent: 'marveen', o: 1_000_000 })          // $25
+    insertUsage(db, { ts: w.start + 200, model: 'claude-haiku-4-5', agent: 'prisma', o: 1_000_000 }) // $5
+    insertUsage(db, { ts: w.end + 100, model: OPUS, agent: 'marveen', o: 1_000_000 })            // outside window
+    const r = getTokenCostReport(db, { start: w.start, end: w.end, timeZone: 'UTC' })
+
+    expect(r.total).toBeCloseTo(30, 6)
+    expect(r.by_model[0]).toMatchObject({ model: OPUS, calls: 1 })
+    expect(r.by_model.map(m => m.model)).toEqual([OPUS, 'claude-haiku-4-5']) // sorted by cost desc
+    expect(r.by_agent.map(a => a.agent)).toEqual(['marveen', 'prisma'])
+    expect(r.by_day).toHaveLength(1)
+    expect(r.by_day[0].cost).toBeCloseTo(30, 6)
+  })
+
+  it('labels its basis and currency on every report', () => {
+    // marveen's standing instruction: the figure is a list-price equivalent and
+    // must be labelled as one wherever it surfaces, because no invoice matches it.
+    const r = getTokenCostReport(getDb(), { start: 0, end: NOW })
+    expect(r.basis).toBe('list_price_equivalent')
+    expect(r.currency).toBe('USD')
+    expect(r.price_map_version).toBe(PRICE_MAP_VERSION)
+  })
+
+  it('counts unpriced rows separately instead of folding them in as zero', () => {
+    const db = getDb()
+    const w = monthWindow(NOW)
+    insertUsage(db, { ts: w.start + 10, model: OPUS, o: 1_000_000 })
+    insertUsage(db, { ts: w.start + 20, model: '<synthetic>', o: 1_000_000 })
+    insertUsage(db, { ts: w.start + 30, model: null, o: 1_000_000 })
+    const r = getTokenCostReport(db, { start: w.start, end: w.end })
+
+    expect(r.total).toBeCloseTo(25, 6)               // only the priced row
+    expect(r.unpriced.calls).toBe(2)
+    expect(r.unpriced.models).toEqual(['(null)', '<synthetic>'])
+    expect(r.by_model).toHaveLength(1)               // unpriced never enters the breakdown
+  })
+
+  it('reports zeroes, not a crash, on an empty window', () => {
+    const r = getTokenCostReport(getDb(), { start: NOW, end: NOW + 86400 })
+    expect(r.total).toBe(0)
+    expect(r.by_model).toEqual([])
+    expect(r.unpriced.calls).toBe(0)
+  })
+
+  it('splits a session across days at the local boundary', () => {
+    const db = getDb()
+    const beforeMidnight = Math.floor(Date.UTC(2026, 6, 15, 21, 0, 0) / 1000) // 23:00 Budapest
+    const afterMidnight = Math.floor(Date.UTC(2026, 6, 15, 23, 0, 0) / 1000)  // 01:00 Budapest, next day
+    insertUsage(db, { ts: beforeMidnight, model: OPUS, o: 1_000_000 })
+    insertUsage(db, { ts: afterMidnight, model: OPUS, o: 1_000_000 })
+    const r = getTokenCostReport(db, { start: beforeMidnight - 10, end: afterMidnight + 10, timeZone: 'Europe/Budapest' })
+    expect(r.by_day.map(d => d.day)).toEqual(['2026-07-15', '2026-07-16'])
+  })
+})
+
+describe('the money ledger and the list-price equivalent stay separate', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('never adds token cost into current_spend', () => {
+    // The double-counting guard. The operator pays a subscription, which is
+    // already a fixed cost in current_spend; adding what the same traffic would
+    // have cost at API rates on top would bill it twice.
+    const db = getDb()
+    const w = monthWindow(NOW)
+    insertUsage(db, { ts: w.start + 100, model: OPUS, o: 1_000_000, cr: 100_000_000 })
+    const c = cfg({
+      fixed_costs: [{ source_id: 'anthropic-max', name: 'Claude Max', provider: 'anthropic', source_type: 'subscription', amount: 22000, period: 'monthly', confidence: 'manual', currency: 'HUF' }],
+    })
+    const s = getCostSummary(db, c, NOW)
+
+    expect(s.token_usage.list_price_equivalent.total).toBeGreaterThan(50)
+    expect(s.current_spend).toBe(0)          // nothing synced to the ledger yet
+    expect(s.breakdown.estimate).toBe(0)     // and it did not leak into a bucket
+    expect(s.forecast_month_end).toBe(0)
+  })
+
+  it('reports the equivalent in USD even though the ledger is in HUF', () => {
+    // Two different currencies on purpose. No FX rate is invented here; mixing
+    // them into one number would need a rate we do not have.
+    const db = getDb()
+    const w = monthWindow(NOW)
+    insertUsage(db, { ts: w.start + 100, model: OPUS, o: 1_000_000 })
+    const s = getCostSummary(db, cfg({ currency: 'HUF' }), NOW)
+    expect(s.currency).toBe('HUF')
+    expect(s.token_usage.list_price_equivalent.currency).toBe('USD')
+    expect(s.token_usage.list_price_equivalent.total).toBeCloseTo(25, 6)
+  })
+
+  it('says in the note that it is not money owed', () => {
+    const s = getCostSummary(getDb(), cfg(), NOW)
+    expect(s.token_usage.note).toContain('LIST-PRICE EQUIVALENT')
+    expect(s.token_usage.note).toContain('never added to current_spend')
+  })
+})

--- a/src/__tests__/costops-quota-guard.test.ts
+++ b/src/__tests__/costops-quota-guard.test.ts
@@ -16,6 +16,9 @@ import {
   CRITICAL_THRESHOLD,
   ALERT_COOLDOWN_SECONDS,
   EMPTY_QUOTA_STATE,
+  FAILURE_ALERT_THRESHOLD,
+  isMeasurementStale,
+  CHECK_INTERVAL_MS,
   type QuotaGuardState,
   type QuotaUsage,
 } from '../costops/quota-guard.js'
@@ -184,7 +187,7 @@ describe('not shouting every cycle', () => {
     // At a 15-minute cadence a steady 72% would otherwise alert 96 times a day,
     // and noise is how a real alert gets ignored.
     const notify = vi.fn()
-    const state: QuotaGuardState = { last_alert_level: 'warning', last_alert_at: NOW - 60 }
+    const state: QuotaGuardState = { ...EMPTY_QUOTA_STATE, last_alert_level: 'warning', last_alert_at: NOW - 60 }
     const r = await runQuotaGuard(deps({ fetch: async () => usage(0.72), notify, readState: () => state }))
     expect(notify).not.toHaveBeenCalled()
     expect(r.alerted).toBe(false)
@@ -192,23 +195,31 @@ describe('not shouting every cycle', () => {
 
   it('speaks again once the cooldown has passed', async () => {
     const notify = vi.fn()
-    const state: QuotaGuardState = { last_alert_level: 'warning', last_alert_at: NOW - ALERT_COOLDOWN_SECONDS - 1 }
+    const state: QuotaGuardState = { ...EMPTY_QUOTA_STATE, last_alert_level: 'warning', last_alert_at: NOW - ALERT_COOLDOWN_SECONDS - 1 }
     await runQuotaGuard(deps({ fetch: async () => usage(0.72), notify, readState: () => state }))
     expect(notify).toHaveBeenCalledTimes(1)
   })
 
   it('speaks immediately when the level gets worse, cooldown or not', async () => {
     const notify = vi.fn()
-    const state: QuotaGuardState = { last_alert_level: 'warning', last_alert_at: NOW - 60 }
+    const state: QuotaGuardState = { ...EMPTY_QUOTA_STATE, last_alert_level: 'warning', last_alert_at: NOW - 60 }
     await runQuotaGuard(deps({ fetch: async () => usage(0.9), notify, readState: () => state }))
     expect(notify).toHaveBeenCalledTimes(1)
   })
 
   it('clears the latch after recovery so the next crossing alerts', async () => {
+    // The assertion used to be `toHaveBeenCalledWith(EMPTY_QUOTA_STATE)` --
+    // the whole state blanked. That is no longer right, and the change is the
+    // point of #225: the ALERT latch is about alerting, the success trace is
+    // about liveness, and clearing one must not erase the other. Blanking both
+    // would make the guard look dead on the cycle right after it recovered.
     const writeState = vi.fn()
-    const state: QuotaGuardState = { last_alert_level: 'critical', last_alert_at: NOW - 60 }
+    const state: QuotaGuardState = { ...EMPTY_QUOTA_STATE, last_alert_level: 'critical', last_alert_at: NOW - 60 }
     await runQuotaGuard(deps({ fetch: async () => usage(0.2), writeState, readState: () => state }))
-    expect(writeState).toHaveBeenCalledWith(EMPTY_QUOTA_STATE)
+    const written = writeState.mock.calls.at(-1)?.[0] as QuotaGuardState
+    expect(written.last_alert_level).toBeNull()
+    expect(written.last_alert_at).toBeNull()
+    expect(written.last_success_at).toBe(NOW)
   })
 })
 
@@ -292,5 +303,152 @@ describe('failing safe', () => {
     expect(sent).not.toContain(TOKEN)
     expect(sent).toContain('90%')
     expect(sent).toContain('does not perform')
+  })
+})
+
+// The guard used to log only failures. That made "running and fine"
+// indistinguishable from "not running at all" -- both were silence, and only
+// one of them was good news. Three failed reads at 03:09/03:29/03:49 on
+// 2026-08-02 woke nobody, which is what this section exists to prevent.
+/** A guard run that reads successfully at the given utilization. */
+function okDeps(utilization: number) {
+  return deps({ fetch: async () => usage(utilization), act: true })
+}
+
+describe('a successful check leaves a trace', () => {
+  it('records the time and the reading on every success, not just on alerts', () => {
+    // A quiet 36% is exactly the case that used to write nothing at all.
+    const writes: QuotaGuardState[] = []
+    return runQuotaGuard({
+      ...okDeps(0.36),
+      readState: () => ({ ...EMPTY_QUOTA_STATE }),
+      writeState: (s) => writes.push(s),
+      now: NOW,
+    }).then((result) => {
+      expect(result.ok).toBe(true)
+      expect(writes.length).toBeGreaterThan(0)
+      expect(writes[0].last_success_at).toBe(NOW)
+      expect(writes[0].last_utilization).toBeCloseTo(0.36, 4)
+      expect(writes[0].consecutive_failures).toBe(0)
+    })
+  })
+
+  it('does not blank the success trace when it also alerts', async () => {
+    // The alert write used to replace the whole object. Spreading matters:
+    // losing last_success_at here would make the very next cycle report the
+    // guard as dead, on a cycle that demonstrably ran.
+    const writes: QuotaGuardState[] = []
+    await runQuotaGuard({
+      ...okDeps(0.9),
+      readState: () => ({ ...EMPTY_QUOTA_STATE }),
+      writeState: (s) => writes.push(s),
+      now: NOW,
+    })
+    const last = writes[writes.length - 1]
+    expect(last.last_alert_level).toBe('critical')
+    expect(last.last_success_at).toBe(NOW)
+    expect(last.last_utilization).toBeCloseTo(0.9, 4)
+  })
+
+  it('keeps the success trace when the alert latch is cleared on recovery', async () => {
+    const writes: QuotaGuardState[] = []
+    await runQuotaGuard({
+      ...okDeps(0.2),
+      readState: () => ({ ...EMPTY_QUOTA_STATE, last_alert_level: 'warning', last_alert_at: NOW - 100 }),
+      writeState: (s) => writes.push(s),
+      now: NOW,
+    })
+    const last = writes[writes.length - 1]
+    expect(last.last_alert_level).toBeNull()
+    expect(last.last_success_at).toBe(NOW)
+  })
+})
+
+describe('repeated failures become their own alert', () => {
+  const failingDeps = () => ({
+    readToken: () => 'token',
+    fetch: async () => null,
+    notify: () => {},
+    act: true,
+  })
+
+  it('counts consecutive failures instead of only logging them', async () => {
+    const writes: QuotaGuardState[] = []
+    await runQuotaGuard({
+      ...failingDeps(),
+      readState: () => ({ ...EMPTY_QUOTA_STATE, consecutive_failures: 1 }),
+      writeState: (s) => writes.push(s),
+      now: NOW,
+    })
+    expect(writes[0].consecutive_failures).toBe(2)
+  })
+
+  it('stays quiet for a single blip', async () => {
+    // One miss is ordinary: a token refresh, a moment of endpoint trouble.
+    const notified: string[] = []
+    const result = await runQuotaGuard({
+      ...failingDeps(),
+      notify: (t) => notified.push(t),
+      readState: () => ({ ...EMPTY_QUOTA_STATE }),
+      writeState: () => {},
+      now: NOW,
+    })
+    expect(notified).toHaveLength(0)
+    expect(result.alerted).toBe(false)
+  })
+
+  it('alerts once the silence is long enough, and says the quota is unwatched', async () => {
+    const notified: string[] = []
+    const result = await runQuotaGuard({
+      ...failingDeps(),
+      notify: (t) => notified.push(t),
+      readState: () => ({ ...EMPTY_QUOTA_STATE, consecutive_failures: FAILURE_ALERT_THRESHOLD - 1, last_success_at: NOW - 3600 }),
+      writeState: () => {},
+      now: NOW,
+    })
+    expect(result.alerted).toBe(true)
+    expect(notified[0]).toMatch(/NOT being watched/)
+    // The message has to carry HOW LONG we have been blind, otherwise the
+    // reader cannot tell a blip from an outage.
+    expect(notified[0]).toMatch(/60 minutes ago/)
+  })
+
+  it('alerts once, not every cycle, while the endpoint stays down', async () => {
+    const notified: string[] = []
+    await runQuotaGuard({
+      ...failingDeps(),
+      notify: (t) => notified.push(t),
+      readState: () => ({ ...EMPTY_QUOTA_STATE, consecutive_failures: 9, last_failure_alert_at: NOW - 600 }),
+      writeState: () => {},
+      now: NOW,
+    })
+    expect(notified).toHaveLength(0)
+  })
+
+  it('resets the failure counter after a success', async () => {
+    const writes: QuotaGuardState[] = []
+    await runQuotaGuard({
+      ...okDeps(0.3),
+      readState: () => ({ ...EMPTY_QUOTA_STATE, consecutive_failures: 5 }),
+      writeState: (s) => writes.push(s),
+      now: NOW,
+    })
+    expect(writes[0].consecutive_failures).toBe(0)
+  })
+})
+
+describe('staleness is answerable without re-deriving it', () => {
+  it('calls a guard with no successful reading stale', () => {
+    expect(isMeasurementStale({ ...EMPTY_QUOTA_STATE }, NOW)).toBe(true)
+  })
+
+  it('accepts a reading from within two intervals', () => {
+    const recent = { ...EMPTY_QUOTA_STATE, last_success_at: NOW - 60 }
+    expect(isMeasurementStale(recent, NOW)).toBe(false)
+  })
+
+  it('flags a reading older than two intervals -- the guard is presumed dead', () => {
+    const old = { ...EMPTY_QUOTA_STATE, last_success_at: NOW - 3 * (CHECK_INTERVAL_MS / 1000) }
+    expect(isMeasurementStale(old, NOW)).toBe(true)
   })
 })

--- a/src/__tests__/costops-quota-guard.test.ts
+++ b/src/__tests__/costops-quota-guard.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import {
+  readAccessToken,
+  parseWindow,
+  parseUsage,
+  fetchUsage,
+  classify,
+  elapsedFraction,
+  forecastText,
+  runQuotaGuard,
+  WARN_THRESHOLD,
+  CRITICAL_THRESHOLD,
+  ALERT_COOLDOWN_SECONDS,
+  EMPTY_QUOTA_STATE,
+  type QuotaGuardState,
+  type QuotaUsage,
+} from '../costops/quota-guard.js'
+
+/**
+ * F3 (kanban #132): act on the subscription's rolling quota.
+ *
+ * The absolute ladder (70% warn / 85% eco mode) is deliberate. A
+ * "consumption ahead of elapsed time" rule fires almost always at the start of
+ * a seven-day window -- one hour in, elapsed is 0.6% -- and almost never at the
+ * end. The pace comparison survives only as forecast text.
+ */
+
+const NOW = 1_785_000_000
+const TOKEN = 'sk-ant-oat01-SECRET-TOKEN-VALUE-do-not-log'
+
+function usage(sevenDayPct: number, resetsAt: number | null = NOW + 3 * 86400): QuotaUsage {
+  return {
+    five_hour: { utilization: 0.18, resets_at: null },
+    seven_day: { utilization: sevenDayPct, resets_at: resetsAt },
+  }
+}
+
+function deps(over: Parameters<typeof runQuotaGuard>[0] = {}) {
+  return {
+    readToken: () => TOKEN,
+    fetch: async () => usage(0.5),
+    enableEco: () => ({ ok: true, enabled: true, plan: { target: 'claude-sonnet-5', changes: [], unchanged: [], needsRestart: [] }, applied: ['(main)'], failed: [], restart_required: true, note: 'x' }),
+    ecoAlreadyOn: () => false,
+    notify: () => {},
+    readState: () => ({ ...EMPTY_QUOTA_STATE }),
+    writeState: () => {},
+    now: NOW,
+    ...over,
+  }
+}
+
+describe('reading the token', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'qg-')) })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('reads the OAuth access token', () => {
+    const p = join(dir, 'creds.json')
+    writeFileSync(p, JSON.stringify({ claudeAiOauth: { accessToken: TOKEN, refreshToken: 'other' } }))
+    expect(readAccessToken(p)).toBe(TOKEN)
+  })
+
+  it('returns null instead of throwing when the file is missing or malformed', () => {
+    expect(readAccessToken(join(dir, 'nope.json'))).toBeNull()
+    const bad = join(dir, 'bad.json')
+    writeFileSync(bad, '{ not json')
+    expect(readAccessToken(bad)).toBeNull()
+  })
+
+  it('does not put the file contents into the log when parsing fails', () => {
+    // A JSON parse error quotes the offending region -- which is the token.
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+    const bad = join(dir, 'bad2.json')
+    writeFileSync(bad, `{"claudeAiOauth":{"accessToken":"${TOKEN}"` )
+    readAccessToken(bad)
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(TOKEN)
+    warn.mockRestore()
+  })
+})
+
+describe('parsing an undocumented payload', () => {
+  it('converts a 0-100 percentage to a fraction', () => {
+    expect(parseWindow({ utilization: 42, resets_at: NOW })).toEqual({ utilization: 0.42, resets_at: NOW })
+  })
+
+  it('accepts an ISO reset time', () => {
+    const w = parseWindow({ utilization: 10, resets_at: '2026-08-01T00:00:00Z' })!
+    expect(w.resets_at).toBe(Math.floor(Date.parse('2026-08-01T00:00:00Z') / 1000))
+  })
+
+  it('rejects a shape it does not recognise rather than reading it as zero', () => {
+    // A guard that silently reads 0% would run the fleet straight through a cap.
+    expect(parseWindow({ utilization: 'lots' })).toBeNull()
+    expect(parseWindow({ utilization: -1 })).toBeNull()
+    expect(parseWindow({ utilization: 101 })).toBeNull()
+    expect(parseWindow(null)).toBeNull()
+    expect(parseUsage({ five_hour: { utilization: 5 } })).toBeNull() // no seven_day
+    expect(parseUsage('nope')).toBeNull()
+  })
+
+  it('tolerates a missing five_hour window', () => {
+    expect(parseUsage({ seven_day: { utilization: 20 } })?.seven_day?.utilization).toBe(0.2)
+  })
+})
+
+describe('fetching', () => {
+  it('never logs the token or the response body', async () => {
+    // The sabotage target: if either reaches a log line, this fails.
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+    const body = { secret_echo: TOKEN }
+    const res = await fetchUsage(TOKEN, (async () => ({
+      ok: false, status: 401, json: async () => body,
+    })) as unknown as typeof fetch)
+    expect(res).toBeNull()
+    const logged = JSON.stringify(warn.mock.calls)
+    expect(logged, 'the token reached a log line').not.toContain(TOKEN)
+    warn.mockRestore()
+  })
+
+  it('is loud in the log when the endpoint fails', async () => {
+    // Silent to users, loud to the log. A failure that looks like "checked and
+    // fine" is the exact silent no-op this whole subsystem exists to avoid.
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+    await fetchUsage(TOKEN, (async () => { throw new Error('network down') }) as unknown as typeof fetch)
+    expect(warn).toHaveBeenCalled()
+    expect(JSON.stringify(warn.mock.calls)).toContain('quota_fetch_error')
+    warn.mockRestore()
+  })
+
+  it('reports an unexpected payload shape rather than passing it on', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+    const r = await fetchUsage(TOKEN, (async () => ({ ok: true, status: 200, json: async () => ({ nonsense: 1 }) })) as unknown as typeof fetch)
+    expect(r).toBeNull()
+    expect(JSON.stringify(warn.mock.calls)).toContain('quota_shape_unexpected')
+    warn.mockRestore()
+  })
+})
+
+describe('the absolute ladder', () => {
+  it('classifies at the agreed thresholds', () => {
+    expect(classify(0.69)).toBe('ok')
+    expect(classify(WARN_THRESHOLD)).toBe('warning')
+    expect(classify(0.84)).toBe('warning')
+    expect(classify(CRITICAL_THRESHOLD)).toBe('critical')
+    expect(classify(1)).toBe('critical')
+  })
+
+  it('warns without touching any config', async () => {
+    const enableEco = vi.fn()
+    const r = await runQuotaGuard(deps({ fetch: async () => usage(0.72), enableEco }))
+    expect(r.level).toBe('warning')
+    expect(r.alerted).toBe(true)
+    expect(enableEco).not.toHaveBeenCalled()
+    expect(r.eco_enabled).toBe(false)
+  })
+
+  it('switches eco mode on at the critical threshold', async () => {
+    const enableEco = vi.fn(() => deps().enableEco())
+    const r = await runQuotaGuard(deps({ fetch: async () => usage(0.9), enableEco }))
+    expect(r.level).toBe('critical')
+    expect(enableEco).toHaveBeenCalledTimes(1)
+    expect(r.eco_enabled).toBe(true)
+  })
+
+  it('does not re-enable eco mode that is already on', async () => {
+    const enableEco = vi.fn()
+    const r = await runQuotaGuard(deps({ fetch: async () => usage(0.9), enableEco, ecoAlreadyOn: () => true }))
+    expect(enableEco).not.toHaveBeenCalled()
+    expect(r.eco_enabled).toBe(false)
+  })
+
+  it('never restarts an agent', async () => {
+    const r = await runQuotaGuard(deps({ fetch: async () => usage(0.9) }))
+    expect(r.restart_required).toBe(true)
+  })
+})
+
+describe('not shouting every cycle', () => {
+  it('stays quiet at a steady level inside the cooldown', async () => {
+    // At a 15-minute cadence a steady 72% would otherwise alert 96 times a day,
+    // and noise is how a real alert gets ignored.
+    const notify = vi.fn()
+    const state: QuotaGuardState = { last_alert_level: 'warning', last_alert_at: NOW - 60 }
+    const r = await runQuotaGuard(deps({ fetch: async () => usage(0.72), notify, readState: () => state }))
+    expect(notify).not.toHaveBeenCalled()
+    expect(r.alerted).toBe(false)
+  })
+
+  it('speaks again once the cooldown has passed', async () => {
+    const notify = vi.fn()
+    const state: QuotaGuardState = { last_alert_level: 'warning', last_alert_at: NOW - ALERT_COOLDOWN_SECONDS - 1 }
+    await runQuotaGuard(deps({ fetch: async () => usage(0.72), notify, readState: () => state }))
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  it('speaks immediately when the level gets worse, cooldown or not', async () => {
+    const notify = vi.fn()
+    const state: QuotaGuardState = { last_alert_level: 'warning', last_alert_at: NOW - 60 }
+    await runQuotaGuard(deps({ fetch: async () => usage(0.9), notify, readState: () => state }))
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the latch after recovery so the next crossing alerts', async () => {
+    const writeState = vi.fn()
+    const state: QuotaGuardState = { last_alert_level: 'critical', last_alert_at: NOW - 60 }
+    await runQuotaGuard(deps({ fetch: async () => usage(0.2), writeState, readState: () => state }))
+    expect(writeState).toHaveBeenCalledWith(EMPTY_QUOTA_STATE)
+  })
+})
+
+describe('the pace comparison is forecast, never a trigger', () => {
+  it('does not alert early in a window just because consumption is ahead', async () => {
+    // One hour into seven days: 0.6% elapsed, 15% used -- 25x "ahead", and far
+    // past any plausible margin. A time-proportional rule fires here every
+    // cycle; the absolute ladder correctly says nothing, because 15% of a
+    // seven-day quota is not a problem.
+    const notify = vi.fn()
+    const r = await runQuotaGuard(deps({
+      fetch: async () => usage(0.15, NOW + 7 * 86400 - 3600),
+      notify,
+    }))
+    expect(r.level).toBe('ok')
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('describes running ahead in the alert text', () => {
+    expect(forecastText(0.8, 0.4)).toContain('ahead')
+    expect(forecastText(0.8, 0.4)).toContain('Forecast only')
+  })
+
+  it('describes running behind, and says so is only a forecast', () => {
+    expect(forecastText(0.2, 0.9)).toContain('behind')
+    expect(forecastText(0.2, 0.9)).toContain('Forecast only')
+  })
+
+  it('says plainly when there is no reset time to reason from', () => {
+    expect(forecastText(0.8, null)).toContain('No reset time')
+  })
+
+  it('computes elapsed fraction from the reset time', () => {
+    expect(elapsedFraction(NOW + 7 * 86400, NOW)).toBeCloseTo(0, 6)
+    expect(elapsedFraction(NOW, NOW)).toBeCloseTo(1, 6)
+    expect(elapsedFraction(null, NOW)).toBeNull()
+  })
+})
+
+describe('report-only mode', () => {
+  it('classifies without switching eco mode or alerting', async () => {
+    // The read-only endpoint uses this. A dashboard refresh must never be able
+    // to trip the fleet into eco mode.
+    const enableEco = vi.fn()
+    const notify = vi.fn()
+    const r = await runQuotaGuard(deps({ fetch: async () => usage(0.95), enableEco, notify, act: false }))
+    expect(r.level).toBe('critical')
+    expect(r.reason).toBe('reported')
+    expect(enableEco).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+    expect(r.alerted).toBe(false)
+  })
+})
+
+describe('failing safe', () => {
+  it('does nothing and says why when there are no credentials', async () => {
+    const enableEco = vi.fn()
+    const r = await runQuotaGuard(deps({ readToken: () => null, enableEco }))
+    expect(r).toMatchObject({ ok: false, reason: 'no_credentials', eco_enabled: false })
+    expect(enableEco).not.toHaveBeenCalled()
+  })
+
+  it('does nothing and says why when usage is unavailable', async () => {
+    // Critically: it must NOT read an unavailable quota as a low one.
+    const enableEco = vi.fn()
+    const r = await runQuotaGuard(deps({ fetch: async () => null, enableEco }))
+    expect(r).toMatchObject({ ok: false, reason: 'usage_unavailable' })
+    expect(r.level).toBeNull()
+    expect(enableEco).not.toHaveBeenCalled()
+  })
+
+  it('never throws into its scheduler', async () => {
+    const r = await runQuotaGuard(deps({ fetch: async () => { throw new Error('boom') } }))
+    expect(r.reason).toBe('error')
+    expect(r.ok).toBe(false)
+  })
+
+  it('keeps the token out of the alert text', async () => {
+    let sent = ''
+    await runQuotaGuard(deps({ fetch: async () => usage(0.9), notify: (t) => { sent = t } }))
+    expect(sent).not.toContain(TOKEN)
+    expect(sent).toContain('90%')
+    expect(sent).toContain('does not perform')
+  })
+})

--- a/src/costops/context-attribution.ts
+++ b/src/costops/context-attribution.ts
@@ -1,0 +1,308 @@
+// CostOps -- R1-A: what a scheduled task actually pays for.
+//
+// The router this was originally meant to shadow assumed the model is the
+// dominant cost variable for a scheduled task. Measurement says otherwise:
+// across the 13 labelled tasks, the spread WITHIN one task (11x median) is
+// larger than the spread BETWEEN tasks (5.9x), and memoria-heartbeat alone
+// ranges from $0.05 to $11.44 for identical work -- a 249x range tracking
+// cache_read per call almost exactly ($11.44 at 730k, $0.05 at 47k).
+//
+// The reason is structural: the schedule runner injects into an already-running
+// session, so a task pays to re-read whatever context that session had
+// accumulated. What it costs is mostly a fact about its host, not about itself.
+//
+// So this module decomposes a task's spend into context it INHERITED and work
+// it actually DID, and prices the alternative of running it in a fresh session.
+// Read-only: it computes, stores nothing, changes nothing.
+
+import type Database from 'better-sqlite3'
+import { PRICE_MAP, CACHE_READ_MULTIPLIER, CACHE_WRITE_MULTIPLIER, isPriced } from './pricing.js'
+
+/**
+ * Context a fresh session loads before doing any work: system prompt, CLAUDE.md
+ * and skill headers.
+ *
+ * Measured, not assumed: across the 40 sessions in token_usage with a usable
+ * first call, the first call's input + cache_read + cache_write has a median of
+ * 41,224 tokens (quartiles 36.3k / 43.5k, max 49.5k). Tight enough that a
+ * single constant models it honestly; exported so a caller can override it if
+ * the fleet's preamble grows.
+ */
+export const SESSION_STARTUP_TOKENS = 41_224
+
+/**
+ * Gap after which two calls of the same task in the same session are treated as
+ * separate runs. The busiest schedule fires every 15-30 minutes, and a single
+ * run's calls are seconds apart, so anything in between separates runs cleanly.
+ */
+export const RUN_GAP_SECONDS = 10 * 60
+
+export interface UsageRow {
+  task_title: string
+  session_id: string
+  model: string | null
+  timestamp: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+}
+
+/**
+ * Split one task's rows into runs on a time gap.
+ *
+ * Rows must be ordered by timestamp. Grouping by clock hour instead would merge
+ * a quarter-hourly heartbeat's separate firings into one "run" and understate
+ * the run count by up to 4x, which would flow into every per-run figure.
+ */
+export function splitRuns(rows: UsageRow[], gapSeconds = RUN_GAP_SECONDS): UsageRow[][] {
+  const runs: UsageRow[][] = []
+  let current: UsageRow[] = []
+  let last: number | null = null
+  for (const r of rows) {
+    if (last !== null && r.timestamp - last > gapSeconds) {
+      runs.push(current)
+      current = []
+    }
+    current.push(r)
+    last = r.timestamp
+  }
+  if (current.length) runs.push(current)
+  return runs
+}
+
+export interface RunCost {
+  /** Paid to re-read context the host session already carried. */
+  inherited: number
+  /** The task's own tokens: its reasoning, its tool results, its output. */
+  own: number
+  total: number
+  calls: number
+}
+
+/**
+ * Split one run's cost into inherited context and own work.
+ *
+ * The run's first call's cache_read is the context that already existed when
+ * the task started -- the task did not create it and would not pay for it in a
+ * fresh session. Every later call re-reads that same baseline plus whatever the
+ * task itself added, so the baseline is charged to `inherited` and the excess
+ * to `own`.
+ *
+ * Returns null when the run's model has no published rate: a run we cannot
+ * price is left out of the totals rather than counted as zero.
+ */
+export function decomposeRun(run: UsageRow[]): RunCost | null {
+  if (!run.length) return null
+  const model = run[0].model
+  if (!isPriced(model)) return null
+  const { input, output } = PRICE_MAP[model as string]
+  const baseline = run[0].cache_read_tokens
+
+  let inherited = 0
+  let own = 0
+  for (const r of run) {
+    const inheritedTokens = Math.min(r.cache_read_tokens, baseline)
+    const ownCacheTokens = Math.max(0, r.cache_read_tokens - baseline)
+    inherited += (inheritedTokens * input * CACHE_READ_MULTIPLIER) / 1e6
+    own +=
+      (ownCacheTokens * input * CACHE_READ_MULTIPLIER) / 1e6 +
+      (r.cache_creation_tokens * input * CACHE_WRITE_MULTIPLIER) / 1e6 +
+      (r.input_tokens * input) / 1e6 +
+      (r.output_tokens * output) / 1e6
+  }
+  return { inherited, own, total: inherited + own, calls: run.length }
+}
+
+/**
+ * What the same run would cost started fresh.
+ *
+ * A fresh session is NOT free, and pretending otherwise would overstate every
+ * saving in this report. It writes its own preamble into cache once (at the
+ * 1.25x write multiplier) and re-reads it on every later call (at 0.1x). Only
+ * the inherited host context disappears; the task's own work is unchanged.
+ */
+export function freshSessionCost(
+  run: RunCost,
+  model: string,
+  startupTokens = SESSION_STARTUP_TOKENS,
+): number {
+  const { input } = PRICE_MAP[model]
+  const write = (startupTokens * input * CACHE_WRITE_MULTIPLIER) / 1e6
+  const reads = (Math.max(0, run.calls - 1) * startupTokens * input * CACHE_READ_MULTIPLIER) / 1e6
+  return write + reads + run.own
+}
+
+export interface TaskAttribution {
+  task: string
+  runs: number
+  calls: number
+  inherited_cost: number
+  own_cost: number
+  total_cost: number
+  fresh_session_cost: number
+  saving: number
+  saving_pct: number
+  /** Median cost of one run, the figure a per-run ceiling would use. */
+  median_run_cost: number
+  /** Cheapest and dearest run of the SAME task -- the variance this all rests on. */
+  min_run_cost: number
+  max_run_cost: number
+}
+
+export interface ComplexitySignal {
+  /**
+   * Why a complexity heuristic built on observed cost cannot work here.
+   * Both figures are computed from the data rather than asserted, so the
+   * report carries its own evidence.
+   */
+  within_task_ratio_median: number
+  between_task_ratio: number
+  verdict: string
+}
+
+export interface ContextAttributionReport {
+  basis: 'list_price_equivalent'
+  currency: 'USD'
+  startup_tokens: number
+  assumption: string
+  tasks: TaskAttribution[]
+  totals: { inherited_cost: number; own_cost: number; total_cost: number; fresh_session_cost: number; saving: number }
+  complexity_signal: ComplexitySignal
+  unpriced_runs: number
+}
+
+const ASSUMPTION =
+  'Assumes a scheduled task does not need the host session\'s conversation history -- it reads state from the database, the API or disk. That holds for the heartbeats and report builders measured here; it does NOT hold for interactive work, which is excluded. Savings are an upper bound: a fresh session also loses any warm knowledge the host had, and a task that turns out to need it would pay to rebuild it.'
+
+function median(xs: number[]): number {
+  if (!xs.length) return 0
+  const s = [...xs].sort((a, b) => a - b)
+  const mid = s.length >> 1
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2
+}
+
+/**
+ * Decompose every labelled scheduled task in a window.
+ *
+ * `tasks` restricts the analysis to marker-labelled schedule names. That filter
+ * is not optional: token_usage.task_title also carries kanban card titles
+ * written by correlateWithKanban(), which are a time-window guess rather than a
+ * statement of what the run was doing. Mixing the two would put unreliable
+ * attribution into a cost figure.
+ */
+export function getContextAttribution(
+  db: Database.Database,
+  opts: { start: number; end: number; tasks: string[]; startupTokens?: number },
+): ContextAttributionReport {
+  const startupTokens = opts.startupTokens ?? SESSION_STARTUP_TOKENS
+  const placeholders = opts.tasks.map(() => '?').join(',')
+  const rows = (opts.tasks.length
+    ? db.prepare(`
+        SELECT task_title, session_id, model, timestamp, input_tokens, output_tokens,
+               cache_read_tokens, cache_creation_tokens
+        FROM token_usage
+        WHERE timestamp >= ? AND timestamp < ? AND task_title IN (${placeholders})
+        ORDER BY task_title, session_id, timestamp
+      `).all(opts.start, opts.end, ...opts.tasks)
+    : []) as UsageRow[]
+
+  // Nested rather than one joined string key: any separator that can occur in a
+  // task name or a session id would silently merge two groups into one run.
+  const byTask = new Map<string, Map<string, UsageRow[]>>()
+  for (const r of rows) {
+    let sessions = byTask.get(r.task_title)
+    if (!sessions) { sessions = new Map(); byTask.set(r.task_title, sessions) }
+    const list = sessions.get(r.session_id)
+    if (list) list.push(r)
+    else sessions.set(r.session_id, [r])
+  }
+
+  const perTask = new Map<string, { costs: number[]; inherited: number; own: number; fresh: number; calls: number }>()
+  let unpricedRuns = 0
+
+  for (const [task, sessions] of byTask) {
+    for (const list of sessions.values()) {
+      for (const run of splitRuns(list)) {
+      const cost = decomposeRun(run)
+      if (!cost) { unpricedRuns++; continue }
+      const fresh = freshSessionCost(cost, run[0].model as string, startupTokens)
+      const agg = perTask.get(task) ?? { costs: [], inherited: 0, own: 0, fresh: 0, calls: 0 }
+      agg.costs.push(cost.total)
+      agg.inherited += cost.inherited
+      agg.own += cost.own
+      agg.fresh += fresh
+      agg.calls += cost.calls
+      perTask.set(task, agg)
+    }
+    }
+  }
+
+  const tasks: TaskAttribution[] = [...perTask.entries()]
+    .map(([task, a]) => {
+      const total = a.inherited + a.own
+      return {
+        task,
+        runs: a.costs.length,
+        calls: a.calls,
+        inherited_cost: round4(a.inherited),
+        own_cost: round4(a.own),
+        total_cost: round4(total),
+        fresh_session_cost: round4(a.fresh),
+        saving: round4(total - a.fresh),
+        saving_pct: total > 0 ? round4((total - a.fresh) / total) : 0,
+        median_run_cost: round4(median(a.costs)),
+        min_run_cost: round4(Math.min(...a.costs)),
+        max_run_cost: round4(Math.max(...a.costs)),
+      }
+    })
+    .sort((x, y) => y.total_cost - x.total_cost)
+
+  // The complexity signal, computed rather than claimed: how much one task's
+  // runs vary against how much the tasks vary from each other. Only tasks with
+  // enough runs to have a spread at all are counted.
+  const withRuns = [...perTask.values()].filter(a => a.costs.length >= 4)
+  const withinRatios = withRuns.map(a => {
+    const s = [...a.costs].sort((p, q) => p - q)
+    return s[s.length - 1] / Math.max(s[0], 1e-6)
+  })
+  const medians = withRuns.map(a => median(a.costs)).filter(m => m > 0)
+  const between = medians.length ? Math.max(...medians) / Math.min(...medians) : 0
+  const within = median(withinRatios)
+
+  const totals = tasks.reduce(
+    (acc, t) => ({
+      inherited_cost: acc.inherited_cost + t.inherited_cost,
+      own_cost: acc.own_cost + t.own_cost,
+      total_cost: acc.total_cost + t.total_cost,
+      fresh_session_cost: acc.fresh_session_cost + t.fresh_session_cost,
+      saving: acc.saving + t.saving,
+    }),
+    { inherited_cost: 0, own_cost: 0, total_cost: 0, fresh_session_cost: 0, saving: 0 },
+  )
+
+  return {
+    basis: 'list_price_equivalent',
+    currency: 'USD',
+    startup_tokens: startupTokens,
+    assumption: ASSUMPTION,
+    tasks,
+    totals: {
+      inherited_cost: round4(totals.inherited_cost),
+      own_cost: round4(totals.own_cost),
+      total_cost: round4(totals.total_cost),
+      fresh_session_cost: round4(totals.fresh_session_cost),
+      saving: round4(totals.saving),
+    },
+    complexity_signal: {
+      within_task_ratio_median: round4(within),
+      between_task_ratio: round4(between),
+      verdict: within > between
+        ? 'A cost-based complexity heuristic cannot discriminate here: the same task varies more between its own runs than the tasks vary from each other, so observed cost measures the host session rather than the task.'
+        : 'Tasks differ from each other more than each varies internally; a cost-based complexity signal may be usable.',
+    },
+    unpriced_runs: unpricedRuns,
+  }
+}
+
+function round4(n: number): number { return Math.round(n * 10000) / 10000 }

--- a/src/costops/eco-mode.ts
+++ b/src/costops/eco-mode.ts
@@ -1,0 +1,344 @@
+// CostOps v0.2 -- eco mode: one switch that moves the fleet to a cheap model.
+//
+// This module PLANS and WRITES configuration. It never restarts anything: a
+// model change only takes effect on the next agent restart, and restarting is
+// an operator decision (the main agent in particular cannot restart itself
+// without dropping its own session and the channel with it). Callers get the
+// list of agents whose restart is still pending and decide what to do with it.
+//
+// Pure planning is separated from I/O so the interesting decisions -- what to
+// change, what to leave alone, what to restore -- are testable without touching
+// a config file.
+
+import { readFileSync, writeFileSync, existsSync, renameSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+import { logger } from '../logger.js'
+import { PRICE_MAP } from './pricing.js'
+
+export const ECO_STATE_PATH = join(PROJECT_ROOT, 'store', 'eco-mode.json')
+export const MAIN_AGENT_SETTINGS_PATH = join(PROJECT_ROOT, '.claude', 'settings.json')
+export const AGENTS_BASE_DIR = join(PROJECT_ROOT, 'agents')
+
+/** Sentinel for the main agent, whose model lives in .claude/settings.json. */
+export const MAIN_AGENT_KEY = '(main)'
+
+/**
+ * Default model eco mode switches to.
+ *
+ * Sonnet 5 rather than Haiku: it halves the fleet's most expensive model
+ * (fable-5, $10 -> $3 per 1M input) and cuts opus-5 by 40%, while staying in
+ * the tier the fleet's paid work already runs on. Haiku is a bigger saving and
+ * a bigger capability drop, so it is a deliberate choice rather than a default
+ * -- pass `target` explicitly for it.
+ */
+export const DEFAULT_ECO_MODEL = 'claude-sonnet-5'
+
+/**
+ * Strip the harness's context-variant suffix: `claude-opus-5[1m]` names the
+ * same priced model as `claude-opus-5`. Agent configs carry the suffix; the
+ * API reports the bare id, which is what PRICE_MAP is keyed on.
+ */
+export function baseModelId(model: string): string {
+  const i = model.indexOf('[')
+  return i === -1 ? model : model.slice(0, i)
+}
+
+/**
+ * Relative expense of a model, as its input rate in USD per 1M tokens.
+ *
+ * Input rate rather than a blended figure because every other component is
+ * priced as a multiple of it (cache reads at 0.1x, writes at 1.25x), so it
+ * orders models identically while needing no assumption about token mix.
+ * Unknown models return null and are then left alone -- moving a model we
+ * cannot price is a change we cannot justify.
+ */
+export function modelExpense(model: string | null): number | null {
+  if (!model) return null
+  const rate = PRICE_MAP[baseModelId(model)]
+  return rate ? rate.input : null
+}
+
+export interface EcoModeState {
+  enabled: boolean
+  /** Epoch seconds when eco mode was last switched on, else null. */
+  since: number | null
+  /** The model eco mode last switched the fleet to, else null. */
+  target: string | null
+  /**
+   * What each agent was set to before eco mode touched it.
+   *
+   * `null` is meaningful and distinct from absent: it records that the agent
+   * had NO explicit model field and was following DEFAULT_MODEL. Restoring
+   * such an agent must DELETE the field again, not write today's default --
+   * writing it would silently pin the agent to whatever the default happened
+   * to be on the day eco mode ran, and it would stop tracking future changes.
+   */
+  saved: Record<string, string | null>
+}
+
+export const EMPTY_ECO_STATE: EcoModeState = { enabled: false, since: null, target: null, saved: {} }
+
+/** One agent's configured model. `model: null` = no explicit field. */
+export interface AgentModel {
+  agent: string
+  model: string | null
+  /** Absolute path of the JSON file the model field lives in. */
+  path: string
+}
+
+export type ChangeReason =
+  | 'switched_to_eco'
+  | 'restored'
+  | 'already_cheaper_or_equal'
+  | 'unpriced_model_left_alone'
+  | 'nothing_saved_to_restore'
+  | 'already_at_target'
+
+export interface PlannedChange {
+  agent: string
+  from: string | null
+  /** Target value; `null` means the explicit model field should be removed. */
+  to: string | null
+  reason: ChangeReason
+}
+
+export interface EcoPlan {
+  target: string | null
+  changes: PlannedChange[]
+  unchanged: PlannedChange[]
+  /**
+   * Agents whose config now differs from what their running process was
+   * started with. A config edit alone changes nothing until a restart, and
+   * this module deliberately performs none.
+   */
+  needsRestart: string[]
+}
+
+/**
+ * Decide what switching eco mode ON would change.
+ *
+ * Two agents are deliberately left alone. One already at or below the target's
+ * price -- "move everything to X" would otherwise UPGRADE a cheaper agent and
+ * raise the bill, which is the opposite of the point. One whose model has no
+ * published rate, because a change we cannot price is a change we cannot
+ * justify; it is reported rather than silently skipped.
+ */
+export function planEcoEnable(current: AgentModel[], target: string): EcoPlan {
+  const targetExpense = modelExpense(target)
+  const changes: PlannedChange[] = []
+  const unchanged: PlannedChange[] = []
+
+  for (const a of current) {
+    const add = (to: string | null, reason: ChangeReason) => {
+      const row = { agent: a.agent, from: a.model, to, reason }
+      ;(reason === 'switched_to_eco' ? changes : unchanged).push(row)
+    }
+    if (a.model !== null && baseModelId(a.model) === baseModelId(target)) {
+      add(a.model, 'already_at_target')
+      continue
+    }
+    const expense = modelExpense(a.model)
+    if (a.model !== null && expense === null) {
+      add(a.model, 'unpriced_model_left_alone')
+      continue
+    }
+    // A missing model field follows DEFAULT_MODEL, which we cannot assume is
+    // cheap, so it is eligible; an explicitly cheaper model is not.
+    if (expense !== null && targetExpense !== null && expense <= targetExpense) {
+      add(a.model, 'already_cheaper_or_equal')
+      continue
+    }
+    add(target, 'switched_to_eco')
+  }
+
+  return { target, changes, unchanged, needsRestart: changes.map(c => c.agent) }
+}
+
+/** Decide what switching eco mode OFF would restore, from the saved originals. */
+export function planEcoDisable(current: AgentModel[], state: EcoModeState): EcoPlan {
+  const changes: PlannedChange[] = []
+  const unchanged: PlannedChange[] = []
+
+  for (const a of current) {
+    if (!Object.hasOwn(state.saved, a.agent)) {
+      unchanged.push({ agent: a.agent, from: a.model, to: a.model, reason: 'nothing_saved_to_restore' })
+      continue
+    }
+    const saved = state.saved[a.agent]
+    if (saved === a.model) {
+      unchanged.push({ agent: a.agent, from: a.model, to: a.model, reason: 'already_at_target' })
+      continue
+    }
+    changes.push({ agent: a.agent, from: a.model, to: saved, reason: 'restored' })
+  }
+
+  return { target: null, changes, unchanged, needsRestart: changes.map(c => c.agent) }
+}
+
+/**
+ * Originals to remember when enabling.
+ *
+ * Only for agents we are actually changing, and only when eco mode was OFF.
+ * Re-running an enable while already on must NOT overwrite the saved originals
+ * with the eco model itself -- that would make the switch a one-way door.
+ */
+export function nextSavedOriginals(
+  plan: EcoPlan,
+  current: AgentModel[],
+  state: EcoModeState,
+): Record<string, string | null> {
+  if (state.enabled) return state.saved
+  const byAgent = new Map(current.map(a => [a.agent, a.model]))
+  const saved: Record<string, string | null> = {}
+  for (const c of plan.changes) saved[c.agent] = byAgent.get(c.agent) ?? null
+  return saved
+}
+
+// ---- I/O ------------------------------------------------------------------
+
+function readJson(path: string): Record<string, unknown> | null {
+  try {
+    if (!existsSync(path)) return null
+    return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>
+  } catch (err) {
+    logger.warn({ err, path }, 'eco-mode: unreadable JSON config')
+    return null
+  }
+}
+
+/**
+ * Write JSON via a temp file and a rename.
+ *
+ * `.claude/settings.json` is the live main-agent config; a half-written file
+ * there would break the agent's next start. rename(2) is atomic within a
+ * filesystem, so a reader sees either the old file or the new one.
+ */
+function writeJsonAtomic(path: string, data: unknown): void {
+  const tmp = `${path}.eco-tmp`
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+  renameSync(tmp, path)
+}
+
+/** Current model of every agent, main agent first. */
+export function readFleetModels(): AgentModel[] {
+  const out: AgentModel[] = []
+  const main = readJson(MAIN_AGENT_SETTINGS_PATH)
+  if (main) {
+    out.push({
+      agent: MAIN_AGENT_KEY,
+      model: typeof main.model === 'string' ? main.model : null,
+      path: MAIN_AGENT_SETTINGS_PATH,
+    })
+  }
+  let entries: string[] = []
+  try { entries = readdirSync(AGENTS_BASE_DIR) } catch { entries = [] }
+  for (const name of entries.sort()) {
+    const path = join(AGENTS_BASE_DIR, name, 'agent-config.json')
+    const cfg = readJson(path)
+    if (!cfg) continue
+    out.push({ agent: name, model: typeof cfg.model === 'string' ? cfg.model : null, path })
+  }
+  return out
+}
+
+/**
+ * Set (or, with `null`, remove) one agent's model field.
+ *
+ * The file is read, one key is changed, and everything else is written back
+ * untouched -- these configs carry hooks, plugins and per-agent settings this
+ * module knows nothing about, and rewriting them from a typed shape would
+ * quietly drop whatever it failed to model.
+ */
+export function writeAgentModel(path: string, model: string | null): boolean {
+  const cfg = readJson(path)
+  if (!cfg) return false
+  if (model === null) delete cfg.model
+  else cfg.model = model
+  try {
+    writeJsonAtomic(path, cfg)
+    return true
+  } catch (err) {
+    logger.error({ err, path }, 'eco-mode: failed to write config')
+    return false
+  }
+}
+
+export function readEcoState(): EcoModeState {
+  const raw = readJson(ECO_STATE_PATH)
+  if (!raw) return { ...EMPTY_ECO_STATE }
+  return {
+    enabled: raw.enabled === true,
+    since: typeof raw.since === 'number' ? raw.since : null,
+    target: typeof raw.target === 'string' ? raw.target : null,
+    saved: (raw.saved && typeof raw.saved === 'object') ? raw.saved as Record<string, string | null> : {},
+  }
+}
+
+export function writeEcoState(state: EcoModeState): void {
+  writeJsonAtomic(ECO_STATE_PATH, state)
+}
+
+export interface EcoApplyResult {
+  ok: boolean
+  enabled: boolean
+  plan: EcoPlan
+  applied: string[]
+  failed: string[]
+  /** Always true: this module never restarts an agent. */
+  restart_required: boolean
+  note: string
+}
+
+const NEVER_RESTARTS =
+  'Config only. A model change takes effect on the next agent restart, which this endpoint deliberately does not perform -- restarting is an operator decision, and the main agent cannot restart itself without dropping its own session.'
+
+/**
+ * Switch eco mode on or off: plan, write the configs, persist the state.
+ * Never restarts. `dryRun` returns the plan with nothing written.
+ */
+export function applyEcoMode(
+  enable: boolean,
+  target: string,
+  opts: { dryRun?: boolean; now?: number } = {},
+): EcoApplyResult {
+  const now = opts.now ?? Math.floor(Date.now() / 1000)
+  const state = readEcoState()
+  const current = readFleetModels()
+  const plan = enable ? planEcoEnable(current, target) : planEcoDisable(current, state)
+
+  if (opts.dryRun) {
+    return { ok: true, enabled: state.enabled, plan, applied: [], failed: [], restart_required: true, note: NEVER_RESTARTS }
+  }
+
+  const saved = enable ? nextSavedOriginals(plan, current, state) : state.saved
+  const byAgent = new Map(current.map(a => [a.agent, a]))
+  const applied: string[] = []
+  const failed: string[] = []
+  for (const c of plan.changes) {
+    const entry = byAgent.get(c.agent)
+    if (entry && writeAgentModel(entry.path, c.to)) applied.push(c.agent)
+    else failed.push(c.agent)
+  }
+
+  writeEcoState(
+    enable
+      ? { enabled: true, since: state.enabled ? state.since : now, target, saved }
+      : { enabled: false, since: null, target: null, saved: {} },
+  )
+
+  logger.warn(
+    { context: { action: enable ? 'eco_mode_enabled' : 'eco_mode_disabled', target, applied, failed } },
+    `Eco mode ${enable ? 'enabled' : 'disabled'}: ${applied.length} config(s) rewritten, restart still pending`,
+  )
+
+  return {
+    ok: failed.length === 0,
+    enabled: enable,
+    plan,
+    applied,
+    failed,
+    restart_required: true,
+    note: NEVER_RESTARTS,
+  }
+}

--- a/src/costops/ledger.ts
+++ b/src/costops/ledger.ts
@@ -9,6 +9,13 @@
 import type Database from 'better-sqlite3'
 import { createHash } from 'node:crypto'
 import type { CostOpsConfig, CostConfidence } from './config.js'
+import {
+  PRICE_MAP_VERSION,
+  ZERO_COMPONENTS,
+  priceTokens,
+  dayKey,
+  type TokenCostComponents,
+} from './pricing.js'
 
 // ---- month math (UTC, deterministic given `now`) ---------------------------
 
@@ -152,6 +159,20 @@ export interface CostSummary {
     output_tokens: number
     cache_read_tokens: number
     cache_creation_tokens: number
+    /**
+     * What this token volume would cost at published API rates. Reported
+     * alongside the money ledger, never summed into it: the operator is on a
+     * subscription that already appears in current_spend as a fixed cost, so
+     * adding this on top would double-count.
+     */
+    list_price_equivalent: {
+      basis: 'list_price_equivalent'
+      currency: 'USD'
+      total: number
+      components: TokenCostComponents
+      price_map_version: string
+      unpriced_calls: number
+    }
   }
   data_freshness: number | null
   config_present: boolean
@@ -239,7 +260,9 @@ export function getCostSummary(
     }
   }
 
-  // token_usage: VOLUME/ACTIVITY only -- NOT priced in v0.1 (no model column).
+  // token_usage volume, plus (v0.2) its list-price equivalent. The two are
+  // reported side by side but kept out of current_spend on purpose -- see the
+  // field doc on CostSummary.token_usage.
   const tu = db.prepare(`
     SELECT COUNT(*) as calls, COUNT(DISTINCT agent) as agents,
       COALESCE(SUM(input_tokens),0) as input_tokens,
@@ -252,6 +275,8 @@ export function getCostSummary(
     cache_read_tokens: number; cache_creation_tokens: number
   }
 
+  const tokenCost = getTokenCostReport(db, { start: win.start, end: win.end })
+
   return {
     month: win.key,
     currency: config.currency,
@@ -263,15 +288,132 @@ export function getCostSummary(
     breakdown: { fixed_manual: round2(breakdown.fixed_manual), provider: round2(breakdown.provider), estimate: round2(breakdown.estimate) },
     budget,
     token_usage: {
-      note: 'volume/activity only -- not priced in v0.1 (token_usage has no model column; token->cost mapping lands in v0.2 after model/session enrichment)',
+      note: 'volume plus a LIST-PRICE EQUIVALENT (v0.2): what this token volume would cost at published API rates. Not money owed and never added to current_spend -- the subscription is already counted there as a fixed cost.',
       calls: tu.calls, agents: tu.agents,
       input_tokens: tu.input_tokens, output_tokens: tu.output_tokens,
       cache_read_tokens: tu.cache_read_tokens, cache_creation_tokens: tu.cache_creation_tokens,
+      list_price_equivalent: {
+        basis: 'list_price_equivalent',
+        currency: 'USD',
+        total: tokenCost.total,
+        components: tokenCost.components,
+        price_map_version: tokenCost.price_map_version,
+        unpriced_calls: tokenCost.unpriced.calls,
+      },
     },
     data_freshness: latestFreshness,
     config_present: opts.configExists ?? true,
     config_errors: opts.configErrors ?? [],
     generated_at: now,
+  }
+}
+
+// ---- read path: token list-price equivalent (CostOps v0.2) -----------------
+
+export interface TokenCostReport {
+  /** Always this literal. Not money owed -- see pricing.ts for why. */
+  basis: 'list_price_equivalent'
+  currency: 'USD'
+  price_map_version: string
+  window: { start: number; end: number; timezone: string }
+  total: number
+  components: TokenCostComponents
+  by_model: Array<{ model: string; calls: number; cost: number }>
+  by_agent: Array<{ agent: string; calls: number; cost: number }>
+  by_day: Array<{ day: string; cost: number }>
+  /**
+   * Rows we hold no published rate for. Surfaced rather than folded into the
+   * total as zero, so an unrecognised model shows up as a gap instead of
+   * quietly shrinking the figure.
+   */
+  unpriced: { calls: number; models: string[] }
+}
+
+interface UsageRow {
+  model: string | null
+  agent: string
+  timestamp: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+}
+
+/**
+ * List-price-equivalent token cost over an epoch-second window, [start, end).
+ *
+ * Rows are aggregated in JS rather than SQL because the day bucketing needs a
+ * named timezone that SQLite cannot apply deterministically under test. The
+ * window is indexed (idx_token_usage_ts) and a month of fleet traffic is a few
+ * thousand rows, so the read stays cheap; revisit if the retention window grows
+ * by orders of magnitude.
+ */
+export function getTokenCostReport(
+  db: Database.Database,
+  opts: { start: number; end: number; timeZone?: string },
+): TokenCostReport {
+  const timeZone = opts.timeZone ?? 'Europe/Budapest'
+  const rows = db.prepare(`
+    SELECT model, agent, timestamp, input_tokens, output_tokens,
+           cache_read_tokens, cache_creation_tokens
+    FROM token_usage
+    WHERE timestamp >= @start AND timestamp < @end
+  `).all({ start: opts.start, end: opts.end }) as UsageRow[]
+
+  const components: TokenCostComponents = { ...ZERO_COMPONENTS }
+  const perModel = new Map<string, { calls: number; cost: number }>()
+  const perAgent = new Map<string, { calls: number; cost: number }>()
+  const perDay = new Map<string, number>()
+  const unpricedModels = new Set<string>()
+  let unpricedCalls = 0
+
+  for (const r of rows) {
+    const priced = priceTokens(r.model, r)
+    if (!priced) {
+      unpricedCalls++
+      unpricedModels.add(r.model ?? '(null)')
+      continue
+    }
+    components.input += priced.input
+    components.output += priced.output
+    components.cache_read += priced.cache_read
+    components.cache_write += priced.cache_write
+    components.total += priced.total
+
+    const model = r.model as string
+    const m = perModel.get(model) ?? { calls: 0, cost: 0 }
+    m.calls++; m.cost += priced.total; perModel.set(model, m)
+
+    const a = perAgent.get(r.agent) ?? { calls: 0, cost: 0 }
+    a.calls++; a.cost += priced.total; perAgent.set(r.agent, a)
+
+    const d = dayKey(r.timestamp, timeZone)
+    perDay.set(d, (perDay.get(d) ?? 0) + priced.total)
+  }
+
+  return {
+    basis: 'list_price_equivalent',
+    currency: 'USD',
+    price_map_version: PRICE_MAP_VERSION,
+    window: { start: opts.start, end: opts.end, timezone: timeZone },
+    total: round4(components.total),
+    components: {
+      input: round4(components.input),
+      output: round4(components.output),
+      cache_read: round4(components.cache_read),
+      cache_write: round4(components.cache_write),
+      total: round4(components.total),
+    },
+    by_model: [...perModel.entries()]
+      .map(([model, v]) => ({ model, calls: v.calls, cost: round4(v.cost) }))
+      .sort((a, b) => b.cost - a.cost),
+    by_agent: [...perAgent.entries()]
+      .map(([agent, v]) => ({ agent, calls: v.calls, cost: round4(v.cost) }))
+      .sort((a, b) => b.cost - a.cost),
+    by_day: [...perDay.entries()]
+      .map(([day, cost]) => ({ day, cost: round4(cost) }))
+      .sort((a, b) => a.day.localeCompare(b.day)),
+    unpriced: { calls: unpricedCalls, models: [...unpricedModels].sort() },
   }
 }
 

--- a/src/costops/pricing.ts
+++ b/src/costops/pricing.ts
@@ -1,0 +1,132 @@
+// CostOps v0.2 -- token -> list-price-equivalent mapping.
+//
+// v0.1 deliberately left token_usage unpriced, with the note "token_usage has
+// no model column; token->cost mapping lands in v0.2 after model/session
+// enrichment". That enrichment has since happened: `model` is now populated on
+// every row (9309/9309 as of 2026-07-31, no NULLs anywhere in the table), so
+// the stated precondition holds and pricing is unblocked.
+//
+// WHAT THIS IS NOT: money owed. The operator runs on a Claude subscription, not
+// API billing, so no invoice corresponds to these numbers. Every figure this
+// module produces is a LIST-PRICE EQUIVALENT -- what the same token volume
+// would cost at published first-party API rates. It is a usage yardstick for
+// budgeting and routing decisions, and it is labelled as such on every output.
+// It must never be added to the money ledger's current_spend: the subscription
+// is already counted there as a fixed cost, so summing the two double-counts.
+//
+// Pure arithmetic. No network, no LLM, no secrets.
+
+/**
+ * Published first-party API rates, USD per 1M tokens, as [input, output].
+ *
+ * Source: the `claude-api` skill's pricing table (cached 2026-06-24). Taken
+ * from documentation rather than recalled, because a wrong constant here is
+ * invisible -- it produces a plausible number that is silently wrong.
+ *
+ * Bump PRICE_MAP_VERSION on any edit so a stored figure can be traced back to
+ * the rates that produced it.
+ */
+export const PRICE_MAP_VERSION = '2026-06-24'
+
+export interface ModelRate {
+  /** USD per 1M input tokens. */
+  input: number
+  /** USD per 1M output tokens. */
+  output: number
+}
+
+export const PRICE_MAP: Readonly<Record<string, ModelRate>> = Object.freeze({
+  'claude-fable-5': { input: 10, output: 50 },
+  'claude-mythos-5': { input: 10, output: 50 },
+  'claude-opus-5': { input: 5, output: 25 },
+  'claude-opus-4-8': { input: 5, output: 25 },
+  'claude-opus-4-7': { input: 5, output: 25 },
+  'claude-opus-4-6': { input: 5, output: 25 },
+  // Sonnet 5 carries a lower introductory rate ($2/$10) through 2026-08-31.
+  // We price it at the standard rate on purpose: for a spend ceiling, erring
+  // high is the safe direction, and date-dependent rates would make every
+  // stored figure depend on when it was computed. Sonnet is ~2.4% of fleet
+  // spend, so the resulting overstatement is well under 1% of the total.
+  'claude-sonnet-5': { input: 3, output: 15 },
+  'claude-sonnet-4-6': { input: 3, output: 15 },
+  'claude-haiku-4-5': { input: 1, output: 5 },
+})
+
+/**
+ * Cache tokens are billed as multiples of the model's input rate: reads at
+ * ~0.1x, 5-minute writes at ~1.25x. These are not incidental.
+ *
+ * Measured over the fleet's 7 days to 2026-07-31: cache_read is 82.9% of total
+ * list-price-equivalent spend, cache_write 9.5%, output 7.6%, input 0.0%. A
+ * cost formula that counts only input+output -- the obvious one to write -- sees
+ * 7.6% of the real figure and understates by roughly 13x. That is the single
+ * error this module exists to prevent, which is why these two multipliers are
+ * named constants rather than inline numbers.
+ */
+export const CACHE_READ_MULTIPLIER = 0.1
+export const CACHE_WRITE_MULTIPLIER = 1.25
+
+/** The token counters a usage row contributes to cost. */
+export interface TokenCounts {
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+}
+
+/** Per-component USD breakdown; components sum to `total`. */
+export interface TokenCostComponents {
+  input: number
+  output: number
+  cache_read: number
+  cache_write: number
+  total: number
+}
+
+export const ZERO_COMPONENTS: Readonly<TokenCostComponents> = Object.freeze({
+  input: 0, output: 0, cache_read: 0, cache_write: 0, total: 0,
+})
+
+/** True if we hold a published rate for this model id. */
+export function isPriced(model: string | null | undefined): boolean {
+  return typeof model === 'string' && Object.hasOwn(PRICE_MAP, model)
+}
+
+/**
+ * List-price-equivalent USD for one row's token counts.
+ *
+ * Returns null -- never a zero cost -- for a model with no published rate
+ * (an unrecognised id, or a sentinel like `<synthetic>`). Charging an unknown
+ * model $0 would be a silent no-op of exactly the kind this subsystem is meant
+ * to surface: the total would still look like a total, quietly missing whatever
+ * the unpriced traffic was worth. Callers must account for the null explicitly.
+ */
+export function priceTokens(
+  model: string | null | undefined,
+  counts: TokenCounts,
+): TokenCostComponents | null {
+  if (!isPriced(model)) return null
+  const rate = PRICE_MAP[model as string]
+  const input = (counts.input_tokens * rate.input) / 1e6
+  const output = (counts.output_tokens * rate.output) / 1e6
+  const cache_read = (counts.cache_read_tokens * rate.input * CACHE_READ_MULTIPLIER) / 1e6
+  const cache_write = (counts.cache_creation_tokens * rate.input * CACHE_WRITE_MULTIPLIER) / 1e6
+  return { input, output, cache_read, cache_write, total: input + output + cache_read + cache_write }
+}
+
+/**
+ * Calendar-day key for an epoch-second timestamp in a named IANA zone.
+ *
+ * The zone is an explicit parameter rather than the process default so tests
+ * are deterministic regardless of the machine's TZ. It defaults to the install
+ * timezone because a "daily cap" is a wall-clock concept for the operator:
+ * bucketing by UTC would move the boundary to 01:00 or 02:00 local and quietly
+ * split a working evening across two days. Note this differs from the money
+ * ledger's monthWindow(), which is UTC by design -- the two are not interchangeable.
+ */
+export function dayKey(epochSeconds: number, timeZone = 'Europe/Budapest'): string {
+  // 'en-CA' formats as YYYY-MM-DD, which sorts lexicographically.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone, year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date(epochSeconds * 1000))
+}

--- a/src/costops/quota-guard.ts
+++ b/src/costops/quota-guard.ts
@@ -1,0 +1,346 @@
+// CostOps F3 -- subscription quota guard.
+//
+// The fleet runs on a Claude subscription, so there is no invoice to cap and
+// the list-price-equivalent figures elsewhere in CostOps are a yardstick, not
+// money owed. What actually runs out is the subscription's rolling quota, and
+// that is readable directly: the OAuth usage endpoint reports how much of the
+// five-hour and seven-day windows has been consumed.
+//
+// This watches the seven-day figure and acts on an ABSOLUTE ladder: warn at
+// 70%, switch the fleet to eco mode at 85%.
+//
+// It deliberately does NOT trigger on "consumption is ahead of elapsed time".
+// That rule fires almost always at the start of a window and almost never at
+// the end: one hour into seven days, elapsed is 0.6%, so any real work is
+// already "ahead". The time comparison is kept, but only as forecast text in
+// the alert, where being early is informative rather than actionable.
+//
+// It writes configuration and never restarts an agent: a model change lands on
+// the next restart, and scheduling those is an operator decision.
+
+import { readFileSync, writeFileSync, renameSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { logger } from '../logger.js'
+import { PROJECT_ROOT, MAIN_AGENT_ID } from '../config.js'
+import { createAgentMessage } from '../db.js'
+import { applyEcoMode, readEcoState, DEFAULT_ECO_MODEL, type EcoApplyResult } from './eco-mode.js'
+
+export const CREDENTIALS_PATH = join(homedir(), '.claude', '.credentials.json')
+export const USAGE_ENDPOINT = 'https://api.anthropic.com/api/oauth/usage'
+export const QUOTA_STATE_PATH = join(PROJECT_ROOT, 'store', 'quota-guard.json')
+
+/**
+ * How often to check. The seven-day window moves slowly, so a tighter cadence
+ * buys nothing and only adds calls to an undocumented endpoint.
+ */
+export const CHECK_INTERVAL_MS = 20 * 60 * 1000
+
+/** Warn here; still just a message. */
+export const WARN_THRESHOLD = 0.70
+/** Switch the fleet to eco mode here. */
+export const CRITICAL_THRESHOLD = 0.85
+
+/** Don't repeat the same-level alert more often than this. */
+export const ALERT_COOLDOWN_SECONDS = 6 * 3600
+
+const SEVEN_DAYS_SECONDS = 7 * 24 * 3600
+
+export type QuotaLevel = 'ok' | 'warning' | 'critical'
+
+export interface QuotaWindow {
+  /** Fraction consumed, 0..1. */
+  utilization: number
+  /** Epoch seconds when the window resets, or null if not reported. */
+  resets_at: number | null
+}
+
+export interface QuotaUsage {
+  five_hour: QuotaWindow | null
+  seven_day: QuotaWindow | null
+}
+
+export interface QuotaGuardState {
+  /** Level of the last alert sent, so a steady 72% does not alert every cycle. */
+  last_alert_level: QuotaLevel | null
+  last_alert_at: number | null
+}
+
+export const EMPTY_QUOTA_STATE: QuotaGuardState = { last_alert_level: null, last_alert_at: null }
+
+/**
+ * OAuth access token for the usage endpoint.
+ *
+ * Returns the token or null; it is never logged, never included in an error,
+ * and never returned inside a result object. A failure here says only that the
+ * credentials were unreadable.
+ */
+export function readAccessToken(path = CREDENTIALS_PATH): string | null {
+  try {
+    if (!existsSync(path)) return null
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as { claudeAiOauth?: { accessToken?: unknown } }
+    const token = raw?.claudeAiOauth?.accessToken
+    return typeof token === 'string' && token.length > 0 ? token : null
+  } catch {
+    // Deliberately not logging the error object: a JSON parse error can quote
+    // the offending region of the file, which is the token.
+    logger.warn({ context: { action: 'quota_credentials_unreadable' } }, 'Quota guard: credentials unreadable')
+    return null
+  }
+}
+
+/**
+ * Normalise one window from the endpoint's payload.
+ *
+ * The endpoint is undocumented, so the shape may change without notice. Anything
+ * unexpected yields null rather than a plausible-looking zero -- a quota guard
+ * that silently reads 0% would keep the fleet running straight through a cap.
+ * Percentages arrive as 0-100; anything outside that is rejected.
+ */
+export function parseWindow(raw: unknown): QuotaWindow | null {
+  if (!raw || typeof raw !== 'object') return null
+  const w = raw as { utilization?: unknown; resets_at?: unknown }
+  const u = typeof w.utilization === 'number' ? w.utilization : NaN
+  if (!Number.isFinite(u) || u < 0 || u > 100) return null
+  const resets = typeof w.resets_at === 'number'
+    ? w.resets_at
+    : typeof w.resets_at === 'string' ? Math.floor(Date.parse(w.resets_at) / 1000) : NaN
+  return { utilization: u / 100, resets_at: Number.isFinite(resets) ? resets : null }
+}
+
+export function parseUsage(raw: unknown): QuotaUsage | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as { five_hour?: unknown; seven_day?: unknown }
+  const seven = parseWindow(r.seven_day)
+  const five = parseWindow(r.five_hour)
+  // seven_day drives every decision; without it there is nothing to act on.
+  if (!seven) return null
+  return { five_hour: five, seven_day: seven }
+}
+
+/**
+ * Fetch current usage. Returns null on any failure, having logged it.
+ *
+ * Loud in the log, silent to the caller's users: an undocumented endpoint will
+ * eventually change or go away, and the failure must not be mistaken for "we
+ * checked and everything is fine". Neither the token nor the response body is
+ * logged -- a body can echo request headers.
+ */
+export async function fetchUsage(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<QuotaUsage | null> {
+  try {
+    const res = await fetchImpl(USAGE_ENDPOINT, {
+      headers: { Authorization: `Bearer ${token}`, 'anthropic-beta': 'oauth-2025-04-20' },
+    })
+    if (!res.ok) {
+      logger.warn(
+        { context: { action: 'quota_fetch_failed', status: res.status } },
+        'Quota guard: usage endpoint returned a non-OK status',
+      )
+      return null
+    }
+    const parsed = parseUsage(await res.json())
+    if (!parsed) {
+      logger.warn(
+        { context: { action: 'quota_shape_unexpected' } },
+        'Quota guard: usage payload did not match the expected shape -- the endpoint is undocumented and may have changed',
+      )
+    }
+    return parsed
+  } catch {
+    // The error object is not logged: a fetch error can carry the request,
+    // including the Authorization header.
+    logger.warn({ context: { action: 'quota_fetch_error' } }, 'Quota guard: usage endpoint unreachable')
+    return null
+  }
+}
+
+export function classify(utilization: number): QuotaLevel {
+  if (utilization >= CRITICAL_THRESHOLD) return 'critical'
+  if (utilization >= WARN_THRESHOLD) return 'warning'
+  return 'ok'
+}
+
+/**
+ * How far through the window we are, from its reset time. Null when the
+ * endpoint did not report one.
+ */
+export function elapsedFraction(resetsAt: number | null, now: number): number | null {
+  if (resetsAt === null) return null
+  const remaining = resetsAt - now
+  if (!Number.isFinite(remaining)) return null
+  const elapsed = SEVEN_DAYS_SECONDS - remaining
+  if (elapsed < 0 || elapsed > SEVEN_DAYS_SECONDS) return null
+  return elapsed / SEVEN_DAYS_SECONDS
+}
+
+/**
+ * Advisory sentence comparing consumption to elapsed time.
+ *
+ * Forecast only, never a trigger -- see the note at the top of the file for why
+ * the comparison is unusable as a threshold.
+ */
+export function forecastText(utilization: number, elapsed: number | null): string {
+  if (elapsed === null || elapsed <= 0) return 'No reset time reported, so no pace estimate.'
+  const pace = utilization / elapsed
+  const pct = (n: number) => `${Math.round(n * 100)}%`
+  if (pace > 1.05) {
+    return `Pace: ${pct(utilization)} used with ${pct(elapsed)} of the window elapsed -- running ahead, projected ${pct(Math.min(pace, 9.99))} of quota by reset. Forecast only, not the trigger.`
+  }
+  if (pace < 0.95) {
+    return `Pace: ${pct(utilization)} used with ${pct(elapsed)} elapsed -- running behind, on track to finish the window under quota. Forecast only.`
+  }
+  return `Pace: ${pct(utilization)} used with ${pct(elapsed)} elapsed -- roughly on track. Forecast only.`
+}
+
+export interface QuotaGuardResult {
+  ok: boolean
+  level: QuotaLevel | null
+  utilization: number | null
+  /** True when this run switched eco mode on. */
+  eco_enabled: boolean
+  /** True when a message was sent (suppressed by cooldown otherwise). */
+  alerted: boolean
+  eco: EcoApplyResult | null
+  reason: string
+  /** Always true: this guard never restarts an agent. */
+  restart_required: boolean
+}
+
+export interface QuotaGuardDeps {
+  readToken?: () => string | null
+  fetch?: (token: string) => Promise<QuotaUsage | null>
+  enableEco?: () => EcoApplyResult
+  ecoAlreadyOn?: () => boolean
+  notify?: (text: string) => void
+  readState?: () => QuotaGuardState
+  writeState?: (s: QuotaGuardState) => void
+  now?: number
+  /** false = report only: classify but neither switch eco mode nor notify. */
+  act?: boolean
+}
+
+/**
+ * One check cycle. Never throws: this runs on a timer, and a guard that can
+ * take down its scheduler is worse than no guard.
+ */
+export async function runQuotaGuard(deps: QuotaGuardDeps = {}): Promise<QuotaGuardResult> {
+  const now = deps.now ?? Math.floor(Date.now() / 1000)
+  const base: QuotaGuardResult = {
+    ok: false, level: null, utilization: null, eco_enabled: false,
+    alerted: false, eco: null, reason: '', restart_required: true,
+  }
+  try {
+    const token = (deps.readToken ?? readAccessToken)()
+    if (!token) return { ...base, reason: 'no_credentials' }
+
+    const usage = await (deps.fetch ?? ((t: string) => fetchUsage(t)))(token)
+    if (!usage?.seven_day) return { ...base, reason: 'usage_unavailable' }
+
+    const utilization = usage.seven_day.utilization
+    const level = classify(utilization)
+    const state = (deps.readState ?? (() => ({ ...EMPTY_QUOTA_STATE })))()
+
+    // Alert on a level change, or once the cooldown has passed at the same
+    // level. A steady 72% must not produce a message every 15 minutes: noise is
+    // how a real alert gets ignored.
+    const levelChanged = state.last_alert_level !== level
+    const cooledDown = state.last_alert_at === null || now - state.last_alert_at >= ALERT_COOLDOWN_SECONDS
+    const shouldAlert = level !== 'ok' && (levelChanged || cooledDown)
+
+    const act = deps.act !== false
+
+    let eco: EcoApplyResult | null = null
+    let ecoEnabled = false
+    if (act && level === 'critical') {
+      const alreadyOn = (deps.ecoAlreadyOn ?? (() => readEcoState().enabled))()
+      if (!alreadyOn) {
+        eco = (deps.enableEco ?? (() => applyEcoMode(true, DEFAULT_ECO_MODEL)))()
+        ecoEnabled = true
+      }
+    }
+
+    if (act && shouldAlert) {
+      const pct = Math.round(utilization * 100)
+      const forecast = forecastText(utilization, elapsedFraction(usage.seven_day.resets_at, now))
+      const head = level === 'critical'
+        ? `Subscription quota at ${pct}% of the seven-day window (threshold ${Math.round(CRITICAL_THRESHOLD * 100)}%).`
+        : `Subscription quota at ${pct}% of the seven-day window (warning threshold ${Math.round(WARN_THRESHOLD * 100)}%).`
+      const action = level === 'critical'
+        ? ecoEnabled
+          ? ` Eco mode switched on: ${eco?.applied.length ?? 0} agent config(s) rewritten. The change takes effect on each agent's next restart, which this guard does not perform -- scheduling those is yours.`
+          : ' Eco mode was already on; nothing changed.'
+        : ' No action taken.'
+      ;(deps.notify ?? defaultNotify)(`${head}${action} ${forecast}`)
+      ;(deps.writeState ?? (() => {}))({ last_alert_level: level, last_alert_at: now })
+    } else if (act && level === 'ok' && state.last_alert_level !== null) {
+      // Recovered: clear the latch so the next crossing alerts again.
+      ;(deps.writeState ?? (() => {}))({ ...EMPTY_QUOTA_STATE })
+    }
+
+    return {
+      ok: true, level, utilization, eco_enabled: ecoEnabled,
+      alerted: act && shouldAlert, eco, reason: act ? 'checked' : 'reported', restart_required: true,
+    }
+  } catch (err) {
+    logger.error(
+      { context: { action: 'quota_guard_failed' }, err: err instanceof Error ? err.message : 'unknown' },
+      'Quota guard cycle failed',
+    )
+    return { ...base, reason: 'error' }
+  }
+}
+
+function defaultNotify(text: string): void {
+  logger.warn({ context: { action: 'quota_alert' } }, text)
+  try {
+    // Routed to the main agent, who relays to the operator. The guard has no
+    // channel of its own and should not grow one.
+    createAgentMessage('costops', MAIN_AGENT_ID, `[quota-guard] ${text}`)
+  } catch (err) {
+    logger.error(
+      { context: { action: 'quota_alert_undeliverable' }, err: err instanceof Error ? err.message : 'unknown' },
+      'Quota guard: alert could not be queued for the main agent',
+    )
+  }
+}
+
+export function readQuotaState(path = QUOTA_STATE_PATH): QuotaGuardState {
+  try {
+    if (!existsSync(path)) return { ...EMPTY_QUOTA_STATE }
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as Partial<QuotaGuardState>
+    return {
+      last_alert_level: raw.last_alert_level ?? null,
+      last_alert_at: typeof raw.last_alert_at === 'number' ? raw.last_alert_at : null,
+    }
+  } catch {
+    return { ...EMPTY_QUOTA_STATE }
+  }
+}
+
+export function writeQuotaState(state: QuotaGuardState, path = QUOTA_STATE_PATH): void {
+  try {
+    const tmp = `${path}.tmp`
+    writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', 'utf-8')
+    renameSync(tmp, path)
+  } catch (err) {
+    logger.warn(
+      { context: { action: 'quota_state_write_failed' }, err: err instanceof Error ? err.message : 'unknown' },
+      'Quota guard: could not persist alert state (it will re-alert next cycle)',
+    )
+  }
+}
+
+/**
+ * Periodic check. Runs once at boot and then on the interval; failures are
+ * contained by runQuotaGuard, which never throws.
+ */
+export function startQuotaGuardTask(intervalMs = CHECK_INTERVAL_MS): NodeJS.Timeout {
+  const tick = () => {
+    void runQuotaGuard({ readState: () => readQuotaState(), writeState: (s) => writeQuotaState(s) })
+  }
+  tick()
+  return setInterval(tick, intervalMs).unref()
+}

--- a/src/costops/quota-guard.ts
+++ b/src/costops/quota-guard.ts
@@ -64,9 +64,56 @@ export interface QuotaGuardState {
   /** Level of the last alert sent, so a steady 72% does not alert every cycle. */
   last_alert_level: QuotaLevel | null
   last_alert_at: number | null
+  /**
+   * When the guard last SUCCEEDED at reading usage, and what it read.
+   *
+   * Recorded on every successful cycle, not only on alerts. Without it the log
+   * cannot distinguish "running and fine" from "not running at all" -- both
+   * look like silence, and only one of them is good news. That is the same
+   * false-green shape we hunt elsewhere, in our own code.
+   */
+  last_success_at: number | null
+  last_utilization: number | null
+  /** Consecutive failed reads. Reset to 0 by any success. */
+  consecutive_failures: number
+  /** When we last alerted about failures, so a dead endpoint alerts once. */
+  last_failure_alert_at: number | null
 }
 
-export const EMPTY_QUOTA_STATE: QuotaGuardState = { last_alert_level: null, last_alert_at: null }
+export const EMPTY_QUOTA_STATE: QuotaGuardState = {
+  last_alert_level: null,
+  last_alert_at: null,
+  last_success_at: null,
+  last_utilization: null,
+  consecutive_failures: 0,
+  last_failure_alert_at: null,
+}
+
+/**
+ * Failed reads in a row before the silence itself becomes the alert.
+ *
+ * Three, because a single miss is ordinary (token refresh, a blip at the
+ * endpoint) and 2026-08-02 saw exactly three in a row at 03:09/03:29/03:49
+ * that woke nobody. At a 20-minute interval this fires about an hour into a
+ * real outage, which is soon enough for a guard whose whole job is to notice.
+ */
+export const FAILURE_ALERT_THRESHOLD = 3
+
+/**
+ * How stale a successful reading may be before the guard is presumed dead.
+ *
+ * Two intervals: one missed cycle is a blip, two means it has not completed a
+ * check in over 40 minutes. Exported so a health check can ask the question
+ * without re-deriving the arithmetic.
+ */
+export function isMeasurementStale(
+  state: QuotaGuardState,
+  now: number,
+  intervalMs = CHECK_INTERVAL_MS,
+): boolean {
+  if (state.last_success_at === null) return true
+  return now - state.last_success_at > (2 * intervalMs) / 1000
+}
 
 /**
  * OAuth access token for the usage endpoint.
@@ -233,15 +280,22 @@ export async function runQuotaGuard(deps: QuotaGuardDeps = {}): Promise<QuotaGua
     alerted: false, eco: null, reason: '', restart_required: true,
   }
   try {
+    const readState = deps.readState ?? (() => ({ ...EMPTY_QUOTA_STATE }))
+    const writeState = deps.writeState ?? (() => {})
+    const state = readState()
+
     const token = (deps.readToken ?? readAccessToken)()
-    if (!token) return { ...base, reason: 'no_credentials' }
+    if (!token) {
+      return { ...base, ...recordFailure(state, now, deps, 'no_credentials'), reason: 'no_credentials' }
+    }
 
     const usage = await (deps.fetch ?? ((t: string) => fetchUsage(t)))(token)
-    if (!usage?.seven_day) return { ...base, reason: 'usage_unavailable' }
+    if (!usage?.seven_day) {
+      return { ...base, ...recordFailure(state, now, deps, 'usage_unavailable'), reason: 'usage_unavailable' }
+    }
 
     const utilization = usage.seven_day.utilization
     const level = classify(utilization)
-    const state = (deps.readState ?? (() => ({ ...EMPTY_QUOTA_STATE })))()
 
     // Alert on a level change, or once the cooldown has passed at the same
     // level. A steady 72% must not produce a message every 15 minutes: noise is
@@ -262,6 +316,29 @@ export async function runQuotaGuard(deps: QuotaGuardDeps = {}): Promise<QuotaGua
       }
     }
 
+    // A successful reading is recorded whether or not it alerts. This is the
+    // point of the card: silence must mean "not running", never "running and
+    // fine". Written before the alert branch so a notify failure cannot lose
+    // the evidence that the check happened.
+    const successState: QuotaGuardState = {
+      ...state,
+      last_success_at: now,
+      last_utilization: utilization,
+      consecutive_failures: 0,
+    }
+    writeState(successState)
+    logger.info(
+      {
+        context: {
+          action: 'quota_check_ok',
+          utilization: Math.round(utilization * 1000) / 1000,
+          level,
+          resets_at: usage.seven_day.resets_at,
+        },
+      },
+      'Quota guard: usage read successfully',
+    )
+
     if (act && shouldAlert) {
       const pct = Math.round(utilization * 100)
       const forecast = forecastText(utilization, elapsedFraction(usage.seven_day.resets_at, now))
@@ -274,10 +351,14 @@ export async function runQuotaGuard(deps: QuotaGuardDeps = {}): Promise<QuotaGua
           : ' Eco mode was already on; nothing changed.'
         : ' No action taken.'
       ;(deps.notify ?? defaultNotify)(`${head}${action} ${forecast}`)
-      ;(deps.writeState ?? (() => {}))({ last_alert_level: level, last_alert_at: now })
+      // Spread over successState, never a fresh object: writing only the alert
+      // fields would blank the success trace we just recorded, and the next
+      // cycle would report the guard as stale.
+      writeState({ ...successState, last_alert_level: level, last_alert_at: now })
     } else if (act && level === 'ok' && state.last_alert_level !== null) {
-      // Recovered: clear the latch so the next crossing alerts again.
-      ;(deps.writeState ?? (() => {}))({ ...EMPTY_QUOTA_STATE })
+      // Recovered: clear the alert latch so the next crossing alerts again --
+      // but keep the success trace, which is about liveness, not alerting.
+      writeState({ ...successState, last_alert_level: null, last_alert_at: null })
     }
 
     return {
@@ -291,6 +372,53 @@ export async function runQuotaGuard(deps: QuotaGuardDeps = {}): Promise<QuotaGua
     )
     return { ...base, reason: 'error' }
   }
+}
+
+/**
+ * A failed read: count it, and once the count crosses the threshold, say so.
+ *
+ * The failure alert is latched on `last_failure_alert_at` so a dead endpoint
+ * produces ONE message rather than one every twenty minutes -- the same reason
+ * the utilization alert has a cooldown. Recovery clears the counter, and the
+ * next outage alerts again.
+ *
+ * Returns the partial result fields the caller merges in, so the failure path
+ * reports what it did rather than looking identical to a silent return.
+ */
+function recordFailure(
+  state: QuotaGuardState,
+  now: number,
+  deps: QuotaGuardDeps,
+  cause: string,
+): { alerted: boolean } {
+  const writeState = deps.writeState ?? (() => {})
+  const failures = (state.consecutive_failures ?? 0) + 1
+  const alreadyAlerted = state.last_failure_alert_at !== null
+  const shouldAlert = deps.act !== false && failures >= FAILURE_ALERT_THRESHOLD && !alreadyAlerted
+
+  writeState({
+    ...state,
+    consecutive_failures: failures,
+    last_failure_alert_at: shouldAlert ? now : state.last_failure_alert_at,
+  })
+
+  logger.warn(
+    { context: { action: 'quota_check_failed', cause, consecutive_failures: failures } },
+    'Quota guard: usage read failed',
+  )
+
+  if (shouldAlert) {
+    const lastSuccess = state.last_success_at
+    const since = lastSuccess === null
+      ? 'there has been no successful reading at all'
+      : `the last successful reading was ${Math.round((now - lastSuccess) / 60)} minutes ago`
+    ;(deps.notify ?? defaultNotify)(
+      `Subscription quota guard has failed ${failures} checks in a row (${cause}); ${since}. ` +
+      'The quota is NOT being watched until this clears -- the guard cannot tell you it is fine, only that it cannot look.',
+    )
+  }
+
+  return { alerted: shouldAlert }
 }
 
 function defaultNotify(text: string): void {
@@ -314,6 +442,10 @@ export function readQuotaState(path = QUOTA_STATE_PATH): QuotaGuardState {
     return {
       last_alert_level: raw.last_alert_level ?? null,
       last_alert_at: typeof raw.last_alert_at === 'number' ? raw.last_alert_at : null,
+      last_success_at: typeof raw.last_success_at === 'number' ? raw.last_success_at : null,
+      last_utilization: typeof raw.last_utilization === 'number' ? raw.last_utilization : null,
+      consecutive_failures: typeof raw.consecutive_failures === 'number' ? raw.consecutive_failures : 0,
+      last_failure_alert_at: typeof raw.last_failure_alert_at === 'number' ? raw.last_failure_alert_at : null,
     }
   } catch {
     return { ...EMPTY_QUOTA_STATE }

--- a/src/web.ts
+++ b/src/web.ts
@@ -65,6 +65,7 @@ import { tryHandleAutonomy } from './web/routes/autonomy.js'
 import { tryHandleApprovals, startApprovalTimeoutSweeper } from './web/routes/approvals.js'
 import { tryHandleTokenUsage } from './web/routes/token-usage.js'
 import { tryHandleCosts, startCostsSyncTask } from './web/routes/costs.js'
+import { startQuotaGuardTask } from './costops/quota-guard.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
 import { tryHandleToolLog } from './web/routes/tool-log.js'
 import { tryHandleSpans } from './web/routes/spans.js'
@@ -384,6 +385,10 @@ export function startWebServer(port = 3420): http.Server {
   // 10 minutes. Deliberately NOT done inside the GET /api/costs/summary handler -- a read
   // endpoint must not write (was flagged in review); this is the one place that does.
   const costsSyncInterval = webOnly ? undefined : startCostsSyncTask()
+  // Subscription quota guard: warns at 70% of the seven-day window, switches
+  // the fleet to eco mode at 85%. Writes config only -- scheduling the agent
+  // restarts that make a model change effective stays an operator decision.
+  const quotaGuardInterval = webOnly ? undefined : startQuotaGuardTask()
   if (!webOnly) logger.info('CostOps fixed-cost sync started (10min poll + startup)')
 
   const stuckInputInterval = webOnly ? undefined : startStuckInputWatcher()

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -11,6 +11,10 @@ import { loadCostopsConfig } from '../../costops/config.js'
 import { syncFixedCostsToLedger, getCostSummary, getCostSources, getTokenCostReport } from '../../costops/ledger.js'
 import { PRICE_MAP, isPriced } from '../../costops/pricing.js'
 import { applyEcoMode, readEcoState, baseModelId, DEFAULT_ECO_MODEL } from '../../costops/eco-mode.js'
+import { getContextAttribution } from '../../costops/context-attribution.js'
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
 import type { RouteContext } from './types.js'
 
 // Runs the fixed-cost -> ledger reflection once immediately (so the summary is
@@ -111,6 +115,26 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     } catch (err) {
       logger.error({ err }, 'CostOps eco apply failed')
       json(res, { error: 'Eco apply failed' }, 500)
+    }
+    return true
+  }
+
+  // What a scheduled task pays for: context inherited from its host session
+  // versus its own work, plus the priced fresh-session alternative.
+  if (path === '/api/costs/context-attribution' && method === 'GET') {
+    try {
+      const raw = Number(url.searchParams.get('days') ?? '30')
+      const days = Number.isFinite(raw) ? Math.min(Math.max(Math.trunc(raw), 1), 400) : 30
+      // The schedule directory is the authoritative list of marker-labelled
+      // task names. Filtering by it keeps correlateWithKanban()'s time-window
+      // card titles -- a guess, not an attribution -- out of the cost figures.
+      let tasks: string[] = []
+      try { tasks = readdirSync(join(homedir(), '.claude', 'scheduled-tasks')) } catch { tasks = [] }
+      const now = Math.floor(Date.now() / 1000)
+      json(res, getContextAttribution(getDb(), { start: now - days * 86400, end: now, tasks }))
+    } catch (err) {
+      logger.error({ err }, 'CostOps context attribution failed')
+      json(res, { error: 'Context attribution failed' }, 500)
     }
     return true
   }

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -4,11 +4,13 @@
 // startCostsSyncTask() below (called once at server boot), not as a side effect
 // of a client request. No LLM, no provider API, no secrets in the response.
 
-import { json } from '../http-helpers.js'
+import { json, readBody } from '../http-helpers.js'
 import { logger } from '../../logger.js'
 import { getDb } from '../../db.js'
 import { loadCostopsConfig } from '../../costops/config.js'
 import { syncFixedCostsToLedger, getCostSummary, getCostSources, getTokenCostReport } from '../../costops/ledger.js'
+import { PRICE_MAP, isPriced } from '../../costops/pricing.js'
+import { applyEcoMode, readEcoState, baseModelId, DEFAULT_ECO_MODEL } from '../../costops/eco-mode.js'
 import type { RouteContext } from './types.js'
 
 // Runs the fixed-cost -> ledger reflection once immediately (so the summary is
@@ -33,7 +35,7 @@ export function startCostsSyncTask(intervalMs = SYNC_INTERVAL_MS): NodeJS.Timeou
 }
 
 export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
-  const { res, path, method, url } = ctx
+  const { req, res, path, method, url } = ctx
 
   if (path === '/api/costs/summary' && method === 'GET') {
     try {
@@ -73,6 +75,42 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     } catch (err) {
       logger.error({ err }, 'CostOps token cost failed')
       json(res, { error: 'Token cost failed' }, 500)
+    }
+    return true
+  }
+
+  // Eco mode. GET previews, POST applies. Neither restarts an agent: a model
+  // change only lands on the next restart, and that stays an operator call.
+  if (path === '/api/costs/eco' && method === 'GET') {
+    try {
+      const state = readEcoState()
+      const target = url.searchParams.get('target') || DEFAULT_ECO_MODEL
+      json(res, {
+        state,
+        preview: applyEcoMode(!state.enabled, target, { dryRun: true }),
+      })
+    } catch (err) {
+      logger.error({ err }, 'CostOps eco preview failed')
+      json(res, { error: 'Eco preview failed' }, 500)
+    }
+    return true
+  }
+
+  if (path === '/api/costs/eco' && method === 'POST') {
+    try {
+      const body = JSON.parse((await readBody(req)).toString() || '{}')
+      const enable = body.enabled === true
+      const target = typeof body.target === 'string' && body.target ? body.target : DEFAULT_ECO_MODEL
+      // An unrecognised model string is not a harmless typo: the agent's next
+      // launch fails on it. Refuse rather than write one into a live config.
+      if (enable && !isPriced(baseModelId(target))) {
+        json(res, { error: `Unknown eco target model: ${target}`, known: Object.keys(PRICE_MAP) }, 400)
+        return true
+      }
+      json(res, applyEcoMode(enable, target, { dryRun: body.dry_run === true }))
+    } catch (err) {
+      logger.error({ err }, 'CostOps eco apply failed')
+      json(res, { error: 'Eco apply failed' }, 500)
     }
     return true
   }

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -8,7 +8,7 @@ import { json } from '../http-helpers.js'
 import { logger } from '../../logger.js'
 import { getDb } from '../../db.js'
 import { loadCostopsConfig } from '../../costops/config.js'
-import { syncFixedCostsToLedger, getCostSummary, getCostSources } from '../../costops/ledger.js'
+import { syncFixedCostsToLedger, getCostSummary, getCostSources, getTokenCostReport } from '../../costops/ledger.js'
 import type { RouteContext } from './types.js'
 
 // Runs the fixed-cost -> ledger reflection once immediately (so the summary is
@@ -57,6 +57,22 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     } catch (err) {
       logger.error({ err }, 'CostOps sources failed')
       json(res, { error: 'Cost sources failed' }, 500)
+    }
+    return true
+  }
+
+  // Token list-price equivalent over a rolling window. `days` (default 7,
+  // max 400) is a rolling lookback rather than a calendar month so a daily
+  // ceiling can be evaluated without a month-boundary special case.
+  if (path === '/api/costs/tokens' && method === 'GET') {
+    try {
+      const raw = Number(url.searchParams.get('days') ?? '7')
+      const days = Number.isFinite(raw) ? Math.min(Math.max(Math.trunc(raw), 1), 400) : 7
+      const now = Math.floor(Date.now() / 1000)
+      json(res, getTokenCostReport(getDb(), { start: now - days * 86400, end: now }))
+    } catch (err) {
+      logger.error({ err }, 'CostOps token cost failed')
+      json(res, { error: 'Token cost failed' }, 500)
     }
     return true
   }

--- a/src/web/routes/costs.ts
+++ b/src/web/routes/costs.ts
@@ -12,6 +12,7 @@ import { syncFixedCostsToLedger, getCostSummary, getCostSources, getTokenCostRep
 import { PRICE_MAP, isPriced } from '../../costops/pricing.js'
 import { applyEcoMode, readEcoState, baseModelId, DEFAULT_ECO_MODEL } from '../../costops/eco-mode.js'
 import { getContextAttribution } from '../../costops/context-attribution.js'
+import { runQuotaGuard, readQuotaState, WARN_THRESHOLD, CRITICAL_THRESHOLD } from '../../costops/quota-guard.js'
 import { readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
@@ -135,6 +136,24 @@ export async function tryHandleCosts(ctx: RouteContext): Promise<boolean> {
     } catch (err) {
       logger.error({ err }, 'CostOps context attribution failed')
       json(res, { error: 'Context attribution failed' }, 500)
+    }
+    return true
+  }
+
+  // Subscription quota. Report only: this GET classifies but never switches
+  // eco mode or sends an alert -- acting is the periodic guard's job, so a
+  // dashboard refresh cannot trip the fleet into eco mode.
+  if (path === '/api/costs/quota' && method === 'GET') {
+    try {
+      const result = await runQuotaGuard({ act: false, readState: () => readQuotaState() })
+      json(res, {
+        ...result,
+        thresholds: { warning: WARN_THRESHOLD, critical: CRITICAL_THRESHOLD },
+        state: readQuotaState(),
+      })
+    } catch (err) {
+      logger.error({ err }, 'CostOps quota read failed')
+      json(res, { error: 'Quota read failed' }, 500)
     }
     return true
   }


### PR DESCRIPTION
> ⚠️ **Stacked on #806, #808 and #809.** Four commits: F1 pricing (#806), F2 eco mode (#808), R1-A attribution (#809), and the guard below. Merge **#806 → #808 → #809 → this**; it then reduces to a single commit.

**F3** for kanban #132, spec from #135.

## Why the quota, not a dollar cap

The fleet runs on a subscription, so there is no invoice to cap and CostOps' list-price figures are a yardstick, not money owed. What actually runs out is the rolling quota — and it is readable: the OAuth usage endpoint reports consumption of the five-hour and seven-day windows.

## The trigger is an absolute ladder

| seven-day utilization | action |
|---|---|
| ≥ 70% | warning message to the main agent |
| ≥ 85% | eco mode switched on + alert |

It is deliberately **not** "consumption is ahead of elapsed time". That rule fires almost always at the *start* of a window and almost never at the *end*: one hour into seven days, elapsed is **0.6%**, so any real work is already far ahead. No margin fixes it — the asymmetry is structural. The pace comparison survives as **forecast text** in the alert, where being early is informative rather than actionable. A test pins that 15% used at 0.6% elapsed stays quiet.

## Secret handling

The token is the sharpest edge here. It is read from `~/.claude/.credentials.json` and **never** logged, never put in an error, never returned in a result, never in the alert text.

The catch blocks deliberately **discard the error object**: a JSON parse error quotes the offending region of the file — which is the token — and a fetch error can carry the request including its `Authorization` header. Two tests assert the token reaches no log line.

## Failure is treated as failure

The endpoint is undocumented, so an unreadable or unrecognised payload yields `null`, **never a plausible 0%**. A guard that silently read 0% would run the fleet straight through a cap while looking like it had checked. Failures are **silent to users and loud in the log** — the opposite arrangement is exactly the silent no-op this subsystem exists to catch.

## Not shouting

A steady 72% must not speak every cycle (96 times a day at this cadence — noise is how a real alert gets ignored). Alerts fire on a **level change** or after a **six-hour cooldown**, and the latch clears on recovery. Alerts go to the main agent as an inter-agent message; the guard has no channel of its own and should not grow one.

## Config only

It never restarts an agent, and every result says so. The read-only `GET /api/costs/quota` classifies **without acting**, so a dashboard refresh cannot trip the fleet into eco mode. Cadence is 20 minutes, inside the agreed 15–30 range.

## Verification

- 29 new tests, `tsc --noEmit` clean, full suite **2994 pass, 0 failures**.
- **Three sabotage controls, each asserted to have applied**: logging the token fails 1 test; reading an unknown payload as 0% fails 1; making the pace comparison a trigger fails 3.
- That third control initially caught only **2** — the early-window test used a value that happened to sit under the sabotage's margin. It was strengthened to 15% at 0.6% elapsed (25x ahead, unambiguous), and now the control catches it. A control that passes by luck is not a control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
