### PR TITLE
feat(costops): shadow-evaluate the first eco-worker run

### DIFF
--- a/src/__tests__/costops-shadow-eval.test.ts
+++ b/src/__tests__/costops-shadow-eval.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+import {
+  groundTruthCards,
+  extractNotifyMessages,
+  evaluateCoverage,
+  evaluateRun,
+} from '../costops/shadow-eval.js'
+
+/**
+ * Shadow evaluation of the first eco-worker task.
+ *
+ * The move is a methodology proof, not a saving: reggeli-teteles-lista is 0.7%
+ * of fleet spend. What has to be proved is that a cheap, small-context worker
+ * still produces a CORRECT report -- which is checkable, because the task reads
+ * the kanban database and the database is still there to check against.
+ *
+ * Cost alone would be a trap: a worker that reports nothing is very cheap.
+ */
+
+const T0 = 1_785_000_000
+const WINDOW = { start: T0 - 10 * 3600, end: T0 }
+
+function freshDb() {
+  initDatabase(':memory:')
+  getDb().exec('DELETE FROM kanban_cards; DELETE FROM kanban_comments;')
+}
+
+function card(id: string, title: string, updated: number) {
+  getDb().prepare(`INSERT INTO kanban_cards (id,title,status,assignee,created_at,updated_at)
+    VALUES (?,?,'in_progress','marveen',?,?)`).run(id, title, updated, updated)
+}
+
+function comment(id: number, cardId: string, created: number) {
+  getDb().prepare(`INSERT INTO kanban_comments (id,card_id,author,content,created_at)
+    VALUES (?,?,'marveen','x',?)`).run(id, cardId, created)
+}
+
+function toolLine(command: string): string {
+  return JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: { command } }] } })
+}
+
+describe('what actually moved', () => {
+  beforeEach(freshDb)
+
+  it('collects cards changed in the window', () => {
+    card('aaaa1111', 'Lightweight shipping calculator', T0 - 3600)
+    card('bbbb2222', 'Outside the window entirely', T0 - 40 * 3600)
+    const moved = groundTruthCards(getDb(), WINDOW.start, WINDOW.end)
+    expect(moved.map(m => m.id)).toEqual(['aaaa1111'])
+  })
+
+  it('counts a card whose only event was a comment', () => {
+    // The task reports "new comment" as movement, so a card with nothing but a
+    // comment is still something the report was supposed to mention.
+    card('cccc3333', 'Quiet card with a fresh comment', T0 - 40 * 3600)
+    comment(1, 'cccc3333', T0 - 1800)
+    const moved = groundTruthCards(getDb(), WINDOW.start, WINDOW.end)
+    expect(moved).toEqual([{ id: 'cccc3333', title: 'Quiet card with a fresh comment', via: 'comment' }])
+  })
+
+  it('does not count the same card twice', () => {
+    card('dddd4444', 'Moved and commented', T0 - 3600)
+    comment(2, 'dddd4444', T0 - 1800)
+    expect(groundTruthCards(getDb(), WINDOW.start, WINDOW.end)).toHaveLength(1)
+  })
+})
+
+describe('what the worker actually sent', () => {
+  it('recovers the message from a notify.sh call', () => {
+    const lines = [toolLine(`/home/viktor/Projects/marveen/scripts/notify.sh "Attekinto: 3 kartya mozdult"`)]
+    expect(extractNotifyMessages(lines)).toEqual(['Attekinto: 3 kartya mozdult'])
+  })
+
+  it('recovers one message per call, which is the per-topic format', () => {
+    const lines = [
+      toolLine(`scripts/notify.sh 'elso tema'`),
+      toolLine(`scripts/notify.sh 'masodik tema'`),
+    ]
+    expect(extractNotifyMessages(lines)).toEqual(['elso tema', 'masodik tema'])
+  })
+
+  it('ignores unrelated tool calls and unparseable lines', () => {
+    const lines = [toolLine('git status'), 'not json at all', toolLine('sqlite3 db "SELECT 1"')]
+    expect(extractNotifyMessages(lines)).toEqual([])
+  })
+
+  it('reads what was sent, not what was planned', () => {
+    // A line that merely mentions notify.sh in prose is not a send.
+    const lines = [JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'I will use notify.sh next' }] } })]
+    expect(extractNotifyMessages(lines)).toEqual([])
+  })
+})
+
+describe('coverage', () => {
+  const moved = [
+    { id: 'aaaa1111', title: 'Lightweight shipping calculator', via: 'card' as const },
+    { id: 'bbbb2222', title: 'GDPR data request review', via: 'card' as const },
+  ]
+
+  it('credits a card named by title', () => {
+    const c = evaluateCoverage(['Mozdult: Lightweight shipping calculator', 'GDPR data request review lezarva'], moved)
+    expect(c.recall).toBe(1)
+    expect(c.missed).toEqual([])
+  })
+
+  it('credits a card named by id', () => {
+    const c = evaluateCoverage(['aaaa1111 status valtozott', 'bbbb2222 komment'], moved)
+    expect(c.mentioned).toBe(2)
+  })
+
+  it('reports what was omitted, which is the whole point', () => {
+    const c = evaluateCoverage(['Csak a Lightweight shipping calculator mozdult'], moved)
+    expect(c.recall).toBe(0.5)
+    expect(c.missed.map(m => m.id)).toEqual(['bbbb2222'])
+  })
+
+  it('does not credit a title too short to be evidence', () => {
+    const short = [{ id: 'x', title: 'fix', via: 'card' as const }]
+    expect(evaluateCoverage(['we fixed things'], short).missed).toHaveLength(1)
+  })
+
+  it('treats an empty window as nothing to miss', () => {
+    expect(evaluateCoverage(['anything'], []).recall).toBe(1)
+  })
+})
+
+describe('the verdict', () => {
+  const moved = [{ id: 'aaaa1111', title: 'Lightweight shipping calculator', via: 'card' as const }]
+
+  it('passes when everything that moved was named', () => {
+    const e = evaluateRun(['Lightweight shipping calculator mozdult'], moved, WINDOW)
+    expect(e.verdict).toBe('pass')
+    expect(e.note).toContain('weak evidence')
+  })
+
+  it('flags omissions as suspect and points at the missed list', () => {
+    const e = evaluateRun(['semmi erdemi'], moved, WINDOW)
+    expect(e.verdict).toBe('suspect')
+    expect(e.coverage.missed).toHaveLength(1)
+    expect(e.note).toContain('inspect the missed list')
+  })
+
+  it('calls silence a failure, not a quiet night', () => {
+    // This task's own skill forbids silence: it must print a line even when a
+    // thread had no activity. So no output is a failure, and folding it into a
+    // recall of 0 would hide that it has a different cause.
+    const e = evaluateRun([], moved, WINDOW)
+    expect(e.verdict).toBe('no_output')
+    expect(e.note).toContain('forbids silence')
+  })
+
+  it('refuses to call an empty window a pass', () => {
+    const e = evaluateRun(['attekinto'], [], WINDOW)
+    expect(e.verdict).toBe('no_data')
+    expect(e.note).toContain('Not a pass')
+  })
+
+  it('says out loud that the metric is generous', () => {
+    // Title substring matching over-credits. A high recall must not be read as
+    // proof the worker did well; a low one is solid evidence it did not.
+    expect(evaluateRun(['Lightweight shipping calculator'], moved, WINDOW).note).toContain('over-credit')
+  })
+})

--- a/src/costops/shadow-eval.ts
+++ b/src/costops/shadow-eval.ts
@@ -1,0 +1,149 @@
+// CostOps -- shadow evaluation of the first eco-worker task.
+//
+// Moving reggeli-teteles-lista to the eco-worker is meant to be a methodology
+// proof, not a saving: the task is 0.7% of fleet spend. What it has to prove is
+// that a cheap, small-context worker still produces a CORRECT report, and that
+// is checkable here because the task reads the kanban database and the database
+// is still there to check against.
+//
+// Two halves, and the second is the one that matters:
+//
+//   cost      -- what the run cost on the worker, and what the same work would
+//                have cost inherited into the main session
+//   coverage  -- of the cards that actually moved, how many the report named
+//
+// Cost alone would be a trap. A worker that reports nothing is extremely cheap.
+
+import type Database from 'better-sqlite3'
+
+/** A card that genuinely changed in the window: the report should mention it. */
+export interface MovedCard {
+  id: string
+  title: string
+  /** 'card' = the row itself changed, 'comment' = a comment was added. */
+  via: 'card' | 'comment'
+}
+
+/**
+ * Cards that moved in a window, from the same tables the task reads.
+ *
+ * Comments count as movement because the task explicitly reports "new comment"
+ * as a change; a card whose only event was a comment is still something the
+ * report was supposed to mention.
+ */
+export function groundTruthCards(db: Database.Database, start: number, end: number): MovedCard[] {
+  const byId = new Map<string, MovedCard>()
+  for (const r of db.prepare(`
+    SELECT id, title FROM kanban_cards WHERE updated_at >= ? AND updated_at < ?
+  `).all(start, end) as Array<{ id: string; title: string }>) {
+    byId.set(r.id, { id: r.id, title: r.title, via: 'card' })
+  }
+  for (const r of db.prepare(`
+    SELECT c.id AS id, c.title AS title
+    FROM kanban_comments m JOIN kanban_cards c ON c.id = m.card_id
+    WHERE m.created_at >= ? AND m.created_at < ?
+  `).all(start, end) as Array<{ id: string; title: string }>) {
+    if (!byId.has(r.id)) byId.set(r.id, { id: r.id, title: r.title, via: 'comment' })
+  }
+  return [...byId.values()]
+}
+
+/**
+ * Pull the messages the worker actually sent.
+ *
+ * The eco-worker has no channel: its user-facing output goes through
+ * scripts/notify.sh, so the sent text is the argument of those bash calls in
+ * the transcript. Reading the transcript rather than a log is deliberate --
+ * it is what was really sent, not what something claims was sent.
+ */
+export function extractNotifyMessages(transcriptLines: string[]): string[] {
+  const out: string[] = []
+  for (const line of transcriptLines) {
+    if (!line.includes('notify.sh')) continue
+    let obj: unknown
+    try { obj = JSON.parse(line) } catch { continue }
+    const content = (obj as { message?: { content?: unknown } })?.message?.content
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      const b = block as { type?: string; input?: { command?: unknown } }
+      if (b?.type !== 'tool_use') continue
+      const cmd = b.input?.command
+      if (typeof cmd !== 'string' || !cmd.includes('notify.sh')) continue
+      const m = /notify\.sh\s+(['"])([\s\S]*?)\1/.exec(cmd)
+      if (m) out.push(m[2])
+    }
+  }
+  return out
+}
+
+export interface Coverage {
+  moved: number
+  mentioned: number
+  missed: MovedCard[]
+  /** moved-and-mentioned / moved. 1 when nothing moved (nothing to miss). */
+  recall: number
+  messages: number
+}
+
+/**
+ * Did the report name the things that actually moved?
+ *
+ * Matching is by card id first, then by title, because the report is prose and
+ * may reference either. Title matching is normalised (case, whitespace) and is
+ * approximate by nature -- a card whose title is a common phrase can match a
+ * sentence that was not about it. That inflates recall, so this metric errs
+ * towards saying the worker did FINE. Treat a low recall as solid evidence and
+ * a high recall as weak evidence; the asymmetry is deliberate, because the
+ * failure we care about is a report that quietly omits things.
+ */
+export function evaluateCoverage(messages: string[], moved: MovedCard[]): Coverage {
+  const haystack = messages.join('\n').toLowerCase().replace(/\s+/g, ' ')
+  const missed: MovedCard[] = []
+  let mentioned = 0
+  for (const card of moved) {
+    const idHit = card.id.length >= 6 && haystack.includes(card.id.toLowerCase())
+    const title = card.title.toLowerCase().replace(/\s+/g, ' ').trim()
+    // Very short titles are not evidence of anything.
+    const titleHit = title.length >= 12 && haystack.includes(title)
+    if (idHit || titleHit) mentioned++
+    else missed.push(card)
+  }
+  return {
+    moved: moved.length,
+    mentioned,
+    missed,
+    recall: moved.length === 0 ? 1 : mentioned / moved.length,
+    messages: messages.length,
+  }
+}
+
+export type Verdict = 'pass' | 'suspect' | 'no_output' | 'no_data'
+
+export interface ShadowEvaluation {
+  window: { start: number; end: number }
+  coverage: Coverage
+  verdict: Verdict
+  note: string
+}
+
+const NOTES: Record<Verdict, string> = {
+  pass: 'The report named every card that moved. Note the metric is generous by construction: title matching can over-credit, so this is weak evidence of correctness and strong evidence only against gross omission.',
+  suspect: 'The report omitted cards that actually moved. This is the failure mode the move to a cheap worker was meant to be tested for -- inspect the missed list before extending the rollout.',
+  no_output: 'The worker sent nothing. A silent run is indistinguishable from a run that found nothing, EXCEPT that this task forbids silence: its own skill requires a line even when a thread had no activity. Treat as a failure, not as a quiet night.',
+  no_data: 'Nothing moved in the window, so the run cannot be judged either way. Not a pass.',
+}
+
+/**
+ * Verdict for one run.
+ *
+ * `no_output` is called out separately rather than folded into a recall of 0,
+ * because the two have different causes and only one of them is ambiguous.
+ */
+export function evaluateRun(messages: string[], moved: MovedCard[], window: { start: number; end: number }): ShadowEvaluation {
+  const coverage = evaluateCoverage(messages, moved)
+  let verdict: Verdict
+  if (messages.length === 0) verdict = 'no_output'
+  else if (moved.length === 0) verdict = 'no_data'
+  else verdict = coverage.missed.length === 0 ? 'pass' : 'suspect'
+  return { window, coverage, verdict, note: NOTES[verdict] }
+}


### PR DESCRIPTION
> ✅ **Not stacked** — a single commit on current upstream. It depends on no other CostOps module.

Shadow evaluation for the first eco-worker task. Kanban #134 (R2) / #139.

## What it measures, and why not cost

Moving `reggeli-teteles-lista` to the eco-worker is a **methodology proof, not a saving**: the task is 0.7% of fleet spend. What it has to prove is that a cheap, small-context worker still produces a **correct** report — and that is checkable, because the task reads the kanban database and the database is still there to check against.

**Cost alone would be a trap.** A worker that reports nothing is extremely cheap, and on a cost dashboard it looks like a triumph. So the metric is coverage: of the cards that actually moved, how many did the report name.

## Three judgements made deliberately

| case | verdict | why not the obvious thing |
|---|---|---|
| worker sent nothing | `no_output` | This task's own skill **forbids silence** — it must print a line even for a thread with no activity. Folding it into a recall of 0 would hide that it has a different cause. |
| nothing moved in the window | `no_data` | Calling that a pass would let a broken worker accumulate green days. |
| everything named | `pass`, with a caveat | See below. |

## The metric is generous, and says so

Title substring matching can credit a report for a sentence that was not about that card, which inflates recall. **That asymmetry is chosen:** a low recall is solid evidence the worker omitted things; a high one is weak evidence it did well. The failure worth catching is the quiet omission, so the metric errs towards saying the worker did fine — and the note in the output says exactly that, so nobody reads a green number as proof.

Messages are read from the **transcript**, not a log, so what is evaluated is what was actually sent. A line that merely mentions `notify.sh` in prose is not a send, and a test pins that.

## Honest gap

**Not yet validated against a real run** — the first eco-worker execution is tomorrow at 07:45. Extraction is covered with synthetic transcripts until then, and closing that gap is the point of running it.

## Verification

- 17 tests, `tsc --noEmit` clean, full suite **3032 pass, 0 failures**.
- **Three sabotage controls, each asserted to have applied**: treating silence as a pass fails 1; dropping comments from ground truth fails 1; calling an empty window a pass fails 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
