### PR TITLE
feat(scheduler): make the runner's direct alerts visible to the main agent

### DIFF
--- a/src/__tests__/scheduler-alert-visibility.test.ts
+++ b/src/__tests__/scheduler-alert-visibility.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { initDatabase, getDb } from '../db.js'
+import { recordSchedulerAlert } from '../web/schedule-runner.js'
+import { PROJECT_ROOT, MAIN_AGENT_ID } from '../config.js'
+
+/**
+ * Scheduler alerts leave through the bot directly, bypassing the main agent's
+ * session. On 2026-07-29 that produced an exchange where the operator asked
+ * about an alert and the agent truthfully denied sending it -- it had no record
+ * the message existed. The agent was not wrong; it was uninformed, which is
+ * worse, because a confident denial reads as fact.
+ *
+ * Two traces close it: a conversation_log row so the alert is in the agent's
+ * own history, and an inter-agent message so the agent is told rather than
+ * left to notice.
+ */
+
+const CHAT = '1061406155'
+const TEXT = '[marveen scheduler] A(z) "kanban-audit" feladat 40 perce fut -- lehetseges beakadas.'
+const NOW = 1_785_000_000
+
+function freshDb() {
+  initDatabase(':memory:')
+  getDb().exec('DELETE FROM conversation_log; DELETE FROM agent_messages;')
+}
+
+const convRows = () => getDb().prepare('SELECT * FROM conversation_log').all() as Array<Record<string, unknown>>
+const msgRows = () => getDb().prepare('SELECT * FROM agent_messages').all() as Array<Record<string, unknown>>
+
+describe('recording an alert that went out', () => {
+  beforeEach(freshDb)
+
+  it('writes it to the conversation log as outbound', () => {
+    recordSchedulerAlert(CHAT, TEXT, NOW)
+    const rows = convRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      agent_id: MAIN_AGENT_ID, chat_id: CHAT, direction: 'out', text: TEXT, created_at: NOW,
+    })
+  })
+
+  it('writes ts in the same ISO-8601 shape as every other row', () => {
+    // ledger_lib.py writes an ISO string here and epoch seconds in created_at.
+    // Putting the epoch in ts stores "1785000000.0" under TEXT affinity: a
+    // silent format drift that only breaks whoever parses ts as a date.
+    recordSchedulerAlert(CHAT, TEXT, NOW)
+    expect(convRows()[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+  })
+
+  it('leaves message_id null, because the send does not return one', () => {
+    // sendTelegramMessage resolves void. Inventing an id would be worse than
+    // admitting we do not have it, and NULLs stay distinct under the table's
+    // UNIQUE(agent_id, chat_id, direction, message_id).
+    recordSchedulerAlert(CHAT, TEXT, NOW)
+    expect(convRows()[0].message_id).toBeNull()
+  })
+
+  it('does not collide when the same alert repeats', () => {
+    recordSchedulerAlert(CHAT, TEXT, NOW)
+    recordSchedulerAlert(CHAT, TEXT, NOW + 60)
+    expect(convRows()).toHaveLength(2)
+  })
+
+  it('queues a copy for the main agent', () => {
+    recordSchedulerAlert(CHAT, TEXT, NOW)
+    const msgs = msgRows()
+    expect(msgs).toHaveLength(1)
+    expect(msgs[0].to_agent).toBe(MAIN_AGENT_ID)
+    expect(String(msgs[0].content)).toContain(TEXT)
+  })
+
+  it('says in the copy that it already went out', () => {
+    // Without this the agent could read the copy as a request to send it,
+    // and the operator would get the same alert twice.
+    recordSchedulerAlert(CHAT, TEXT, NOW)
+    expect(String(msgRows()[0].content)).toContain('mar kiment')
+  })
+})
+
+describe('recording never breaks alerting', () => {
+  beforeEach(freshDb)
+
+  it('still queues the agent copy when the log write fails', () => {
+    const db = getDb()
+    const spy = vi.spyOn(db, 'prepare')
+    spy.mockImplementationOnce(() => { throw new Error('table is locked') })
+    expect(() => recordSchedulerAlert(CHAT, TEXT, NOW)).not.toThrow()
+    spy.mockRestore()
+    expect(msgRows()).toHaveLength(1)
+  })
+
+  it('does not throw out to the alerting path', () => {
+    getDb().exec('DROP TABLE conversation_log')
+    expect(() => recordSchedulerAlert(CHAT, TEXT, NOW)).not.toThrow()
+  })
+})
+
+describe('it is wired into both places that send an alert', () => {
+  // The point of the card is that these two sends were invisible. A helper
+  // that exists but is called from neither would leave the bug exactly where
+  // it was, and no logic test would notice.
+  const src = readFileSync(join(PROJECT_ROOT, 'src', 'web', 'schedule-runner.ts'), 'utf-8')
+
+  it('is called after every sendTelegramMessage in the runner', () => {
+    const sends = src.match(/await sendTelegramMessage\(token, ALLOWED_CHAT_ID, text\)\n\s*recordSchedulerAlert\(/g) ?? []
+    const allSends = src.match(/await sendTelegramMessage\(/g) ?? []
+    expect(allSends.length).toBeGreaterThan(0)
+    expect(sends.length, 'a scheduler send exists that records nothing').toBe(allSends.length)
+  })
+
+  it('records only after the send, never before', () => {
+    // Recording first would log an alert that may never have gone out -- the
+    // same confident-but-wrong record this change removes.
+    expect(src).not.toMatch(/recordSchedulerAlert\([^)]*\)\n\s*await sendTelegramMessage/)
+  })
+})

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -21,6 +21,8 @@ import {
   markPendingTaskRetryAlert,
   clearPendingTaskRetryAlert,
   markScheduledTaskKanbanWaiting,
+  createAgentMessage,
+  getDb,
 } from '../db.js'
 import { toPendingRetryView, classifyTelegramSendError, type PendingRetryView } from '../pending-retries.js'
 import {
@@ -927,6 +929,7 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   ;(async () => {
     try {
       await sendTelegramMessage(token, ALLOWED_CHAT_ID, text)
+      recordSchedulerAlert(ALLOWED_CHAT_ID, text)
       logger.info({ task: view.taskName, agent: view.agentName, ageMinutes }, 'Pending-retry Telegram alert sent')
     } catch (err) {
       // Distinguish a transient failure (network blip, 429, 5xx) from a
@@ -980,11 +983,56 @@ function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void
   ;(async () => {
     try {
       await sendTelegramMessage(token, ALLOWED_CHAT_ID, text)
+      recordSchedulerAlert(ALLOWED_CHAT_ID, text)
       logger.info({ task: entry.taskName, agent: entry.agentName, ageMinutes }, 'task-timeout Telegram alert sent')
     } catch (err) {
       logger.warn({ err, task: entry.taskName, agent: entry.agentName }, 'task-timeout alert delivery failed')
     }
   })()
+}
+
+/**
+ * Record a scheduler alert that has already gone out, so the main agent knows
+ * it exists.
+ *
+ * These alerts leave through the bot directly, bypassing the main agent's
+ * session. On 2026-07-29 that produced an exchange where the operator asked
+ * about an alert and the agent truthfully denied sending it -- it had no record
+ * that the message existed at all. Two traces fix that: a conversation_log row,
+ * so the alert appears in the agent's own history, and an inter-agent message,
+ * so the agent is actually told rather than left to notice.
+ *
+ * Called only AFTER a successful send. Recording an alert that failed to go out
+ * would put a false "out" row in the ledger -- the same kind of confident,
+ * wrong record this card exists to remove.
+ *
+ * Both traces are best-effort and separately isolated: alerting is the point,
+ * and neither trace failing may take the other down or surface to the caller.
+ */
+export function recordSchedulerAlert(chatId: string, text: string, now = Math.floor(Date.now() / 1000)): void {
+  try {
+    // `ts` is an ISO-8601 UTC string and `created_at` epoch seconds -- the
+    // shape ledger_lib.py writes for every other row. Putting the epoch in
+    // both would store "1785000000.0" under TEXT affinity and quietly break
+    // anything that parses ts as a date.
+    getDb().prepare(
+      `INSERT INTO conversation_log (agent_id, chat_id, direction, message_id, text, ts, created_at)
+       VALUES (?, ?, 'out', NULL, ?, ?, ?)`,
+    ).run(MAIN_AGENT_ID, chatId, text, new Date(now * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z'), now)
+  } catch (err) {
+    logger.warn(
+      { context: { action: 'scheduler_alert_log_failed' }, err: err instanceof Error ? err.message : 'unknown' },
+      'Scheduler alert could not be written to the conversation log',
+    )
+  }
+  try {
+    createAgentMessage('scheduler', MAIN_AGENT_ID, `[scheduler-alert, mar kiment Telegramra]\n${text}`)
+  } catch (err) {
+    logger.warn(
+      { context: { action: 'scheduler_alert_copy_failed' }, err: err instanceof Error ? err.message : 'unknown' },
+      'Scheduler alert copy could not be queued for the main agent',
+    )
+  }
 }
 
 // Tick interval for the schedule runner. 15 s gives 4x faster inter-agent


### PR DESCRIPTION
> ✅ **Not stacked** — a single commit on current upstream.

Kanban #122.

## The incident

The schedule runner sends stuck-task and pending-retry alerts through the bot **directly**, bypassing the main agent's session and the conversation ledger.

On 2026-07-29 that produced an exchange where the operator asked about an alert and the agent **denied sending it**. The agent was not lying and not wrong — it was *uninformed*, which is worse, because a confident denial reads as fact.

## The fix

Every alert now leaves two traces:

- a **`conversation_log` row**, so it appears in the agent's own history
- an **inter-agent message**, so the agent is *told* rather than left to notice

The copy states the alert has already gone out — otherwise the agent could read it as a request and send it a second time.

**Recorded only after a successful send.** Recording first would put a confident `out` row in the ledger for a message that never left: the same species of wrong record this change removes.

## A convention I got wrong first

The row shape follows `ledger_lib.py`, which writes every other row in that table: an **ISO-8601 string** in `ts`, **epoch seconds** in `created_at`.

My first version put the epoch in both. It looked right and stored `"1785000000.0"` under TEXT affinity — a silent format drift that would only surface for whoever parsed `ts` as a date. A test now pins the shape.

## Verification

- 10 tests, `tsc --noEmit` clean, full suite **3042 pass, 0 failures**.
- **Two sabotage controls**: removing the call from one of the two send sites fails the wiring test *by name* (`a scheduler send exists that records nothing`); putting the epoch back in `ts` fails the format test.
- The wiring test **counts call sites** rather than trusting that a helper is used. A helper called from neither site would leave the bug exactly where it was, and no logic test would notice — a lesson from earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
