### PR TITLE
fix(agents): never delete the agent directory when personality generation fails

### DIFF
--- a/src/__tests__/agent-create-no-destructive-rollback.test.ts
+++ b/src/__tests__/agent-create-no-destructive-rollback.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Reported by a user, 2026-07-31. Their agent's card was on the dashboard,
+// the terminal answered "Agent not found", and restarting could not help because
+// there was nothing left to start.
+//
+// Cause: the POST /api/agents handler wrapped personality generation in a try
+// whose catch ran
+//     rmSync(agentDir(name), { recursive: true, force: true })
+// so ANY failure of the LLM step -- timeout, missing auth, CLI error, network --
+// deleted the whole agent directory that scaffoldAgentDir() had just built
+// correctly. A slow generation became silent data loss.
+//
+// Worse, the team-notification loop sat INSIDE the same try, after the
+// "Agent created successfully" log, so a failing greeting could delete a fully
+// created agent too.
+//
+// These assertions are source-level, matching the idiom of
+// main-restart-platform.test.ts. The handler is an HTTP route that awaits real
+// Claude Code CLI calls and writes to the live agents directory; a runtime
+// harness here would either mock the very thing under test or risk touching the
+// real fleet. What must be guaranteed is a property of the code path, and that
+// is what is asserted.
+
+const SRC = join(import.meta.dirname, '..')
+const FILE = 'web/routes/agents.ts'
+
+function read(): string {
+  return readFileSync(join(SRC, FILE), 'utf8')
+}
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+// The create handler: from the scaffold call to the success response.
+function createHandlerBody(code: string): string {
+  const start = code.indexOf('scaffoldAgentDir(name)')
+  expect(start, 'scaffoldAgentDir call not found').toBeGreaterThan(-1)
+  const end = code.indexOf("json(res, { ok: true, name })", start)
+  expect(end, 'create-handler success response not found').toBeGreaterThan(-1)
+  return code.slice(start, end)
+}
+
+describe('agent creation never deletes the agent directory on failure', () => {
+  it('the create handler does not rmSync the agent dir', () => {
+    // THE load-bearing assertion. On the pre-fix code this line existed
+    // verbatim in the catch and this test goes red.
+    const body = createHandlerBody(stripComments(read()))
+    expect(body).not.toMatch(/rmSync\(\s*agentDir\(/)
+  })
+
+  it('the failure path writes fallback personality files instead', () => {
+    const body = createHandlerBody(stripComments(read()))
+    expect(body).toMatch(/fallbackClaudeMd\(/)
+    expect(body).toMatch(/fallbackSoulMd\(/)
+  })
+
+  it('the failure path marks the agent as awaiting regeneration', () => {
+    // Without the sentinel a template silently becomes the agent's identity and
+    // nobody ever learns the personality was never generated.
+    const body = createHandlerBody(stripComments(read()))
+    expect(body).toMatch(/PERSONALITY_PENDING_SENTINEL/)
+  })
+
+  it('a failed generation still reports the agent as created, with a warning', () => {
+    // The caller must not be told "creation failed" for an agent that exists and
+    // works -- that is what drove the user to restart something that was fine.
+    const body = createHandlerBody(stripComments(read()))
+    expect(body).toMatch(/personalityPending:\s*true/)
+  })
+
+  it('team notification sits OUTSIDE the generation try/catch', () => {
+    // It used to be inside, after the success log, so a failed greeting ran the
+    // destructive catch. Assert ordering: the catch closes before the notify.
+    const code = stripComments(read())
+    const body = createHandlerBody(code)
+    const catchIdx = body.indexOf('} catch (err) {')
+    const notifyIdx = body.indexOf('createAgentMessage(')
+    expect(catchIdx, 'generation catch not found').toBeGreaterThan(-1)
+    expect(notifyIdx, 'notification call not found').toBeGreaterThan(-1)
+    expect(notifyIdx, 'notification must come after the generation catch block')
+      .toBeGreaterThan(catchIdx)
+    // ...and it must have its own guard, so a notify failure cannot bubble.
+    const afterCatch = body.slice(catchIdx)
+    expect(afterCatch).toMatch(/try\s*\{[\s\S]*createAgentMessage\([\s\S]*?\}\s*catch/)
+  })
+})

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -139,6 +139,53 @@ import { listScheduledTasks } from '../scheduled-tasks-io.js'
 
 const VALID_PROVIDERS = new Set<ChannelProviderType>(['telegram', 'slack', 'discord', 'googlechat', 'teams'])
 
+// Dropped into the agent dir when personality generation failed and the agent was
+// kept on a template instead of being deleted. Its presence means "this agent
+// works, but its CLAUDE.md/SOUL.md are placeholders awaiting regeneration".
+export const PERSONALITY_PENDING_SENTINEL = '.personality-pending'
+
+// Minimal placeholders used when generateClaudeMd/generateSoulMd fail. Hungarian
+// with accents, because that is what they stand in for: the generators produce
+// Hungarian agent personalities (see agent-scaffold.ts, whose SOUL prompt states
+// "Write ALL Hungarian text with proper accents"). Deliberately NOT an imitation
+// of a generated personality -- the first line says it is a template, so a
+// stand-in never silently becomes the agent's identity.
+function fallbackClaudeMd(name: string, description: string, model: string): string {
+  return `# ${name}
+
+> **FIGYELEM: ez egy SABLON.** Az ágens személyiségének generálása nem sikerült a
+> létrehozáskor, ezért ez a fájl helyőrző. Az ágens használható, de a saját
+> CLAUDE.md-je még nem készült el. Újragenerálásig ez marad érvényben.
+
+## Szerepkör
+
+${description}
+
+## Alapelvek
+
+- Végrehajtás. Ne magyarázd el, mit fogsz csinálni, csak csináld.
+- Tömör válaszok, lényegre törően.
+- Ha nem tudsz valamit, mondd meg egyszerűen.
+- Kód, kommentek, technikai dokumentáció angolul; a felhasználóval magyarul.
+
+## Modell
+
+${model}
+`
+}
+
+function fallbackSoulMd(name: string, description: string): string {
+  return `# ${name} - SOUL
+
+> **FIGYELEM: ez egy SABLON.** A generálás nem sikerült, ez helyőrző szöveg.
+
+${description}
+
+Alapértelmezett hangnem: tömör, pontos, túlzás nélkül. A részletes személyiség az
+újrageneráláskor kerül ide.
+`
+}
+
 // Short-TTL caches so the synchronous, frequently-polled status endpoints
 // (`/api/agents` on load, `/api/agents/activity` every 3s) don't issue a fresh
 // blocking ssh call per remote agent per request. Only remote agents are cached;
@@ -776,22 +823,54 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       atomicWriteFileSync(join(agentDir(name), 'CLAUDE.md'), claudeMd)
       atomicWriteFileSync(join(agentDir(name), 'SOUL.md'), soulMd)
       logger.info({ name }, 'Agent created successfully')
+    } catch (err) {
+      // NO DESTRUCTIVE ROLLBACK. This used to be
+      //   rmSync(agentDir(name), { recursive: true, force: true })
+      // which deleted the WHOLE agent directory when personality generation
+      // failed. Reported by a user whose agent card showed on the dashboard
+      // while the terminal answered "Agent not found" and restarting could not
+      // help, because there was nothing left to start.
+      //
+      // Deleting was disproportionate. By this point scaffoldAgentDir() has
+      // already produced a COMPLETE, valid agent -- .claude/{skills,hooks,
+      // agents}, the channel state dir, memory/MEMORY.md, .mcp.json, the
+      // quarantine-reader sub-agent -- and the model, security profile,
+      // settings and display name are all written. The only thing missing is
+      // the two PERSONALITY files, produced by the single most failure-prone
+      // step: an LLM call that can time out, hit missing auth, a CLI error or a
+      // network fault. Throwing away everything that succeeded because the
+      // least essential part failed turns a slow generation into silent data
+      // loss.
+      //
+      // So fall back to a minimal template and keep the agent usable. The
+      // sentinel marks it for regeneration; the response says so explicitly.
+      const detail = err instanceof Error ? err.message : 'Unknown error'
+      logger.error({ err, name }, 'Agent personality generation failed -- falling back to template, agent kept')
+      try {
+        atomicWriteFileSync(join(agentDir(name), 'CLAUDE.md'), fallbackClaudeMd(name, description, model))
+        atomicWriteFileSync(join(agentDir(name), 'SOUL.md'), fallbackSoulMd(name, description))
+        atomicWriteFileSync(join(agentDir(name), PERSONALITY_PENDING_SENTINEL), `${new Date().toISOString()}\n${detail}\n`)
+      } catch (fallbackErr) {
+        // Even the template write failed (disk full, permissions). Still do NOT
+        // delete: a half-built agent an operator can inspect beats a vanished
+        // one they cannot.
+        logger.error({ err: fallbackErr, name }, 'Fallback template write failed; agent left in place for inspection')
+      }
+      json(res, { ok: true, name, personalityPending: true, warning: 'Agent created, but its personality came from a template because generation failed. It is queued for regeneration.', detail }, 200)
+      return true
+    }
 
-      const allAgents = listAgentNames()
-      const runningAgents = allAgents.filter(a => a !== name && isAgentRunning(a))
-      const notifyTargets = [MAIN_AGENT_ID, ...runningAgents]
-      for (const target of notifyTargets) {
+    // Notifications are deliberately OUTSIDE the try above. They used to sit
+    // inside it, after the "Agent created successfully" log, so a failure here
+    // (DB busy, a dead target session) ran the catch and deleted a fully
+    // created agent. A greeting that does not go out must never cost the agent.
+    try {
+      const runningAgents = listAgentNames().filter(a => a !== name && isAgentRunning(a))
+      for (const target of [MAIN_AGENT_ID, ...runningAgents]) {
         createAgentMessage('system', target, `Uj csapattag erkezett: ${name}. Leirasa: ${description}. Udv neki ha legkozelebb beszeltek!`)
       }
     } catch (err) {
-      rmSync(agentDir(name), { recursive: true, force: true })
-      logger.error({ err, name }, 'Failed to generate agent files')
-      // Propagate the underlying message so the dashboard surfaces the actual
-      // cause (auth not configured, Claude Code CLI missing, etc.) instead of
-      // the previous opaque "Failed to generate agent files" — Issue #179.
-      const detail = err instanceof Error ? err.message : 'Unknown error'
-      json(res, { error: 'Failed to generate agent files', detail }, 500)
-      return true
+      logger.warn({ err, name }, 'Agent created, but the team notification failed')
     }
 
     json(res, { ok: true, name })

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -815,6 +815,11 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (rawName && rawName !== name) writeAgentDisplayName(name, rawName)
 
     logger.info({ name, description }, 'Generating agent CLAUDE.md and SOUL.md...')
+    // Set when the personality fell back to a template. The response is deferred
+    // to after the notification block so that BOTH outcomes announce the agent:
+    // a template-personality agent exists and is usable, so the fleet has to hear
+    // about it for the same reason a fully generated one does.
+    let personalityPendingDetail: string | null = null
     try {
       const [claudeMd, soulMd] = await Promise.all([
         generateClaudeMd(name, description, model),
@@ -856,14 +861,19 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
         // one they cannot.
         logger.error({ err: fallbackErr, name }, 'Fallback template write failed; agent left in place for inspection')
       }
-      json(res, { ok: true, name, personalityPending: true, warning: 'Agent created, but its personality came from a template because generation failed. It is queued for regeneration.', detail }, 200)
-      return true
+      personalityPendingDetail = detail
     }
 
     // Notifications are deliberately OUTSIDE the try above. They used to sit
     // inside it, after the "Agent created successfully" log, so a failure here
     // (DB busy, a dead target session) ran the catch and deleted a fully
     // created agent. A greeting that does not go out must never cost the agent.
+    //
+    // This also runs on the template-fallback path, deliberately, and with the
+    // SAME text. The agent exists and works either way, so a silent creation
+    // would be a second silent outcome in the same handler. That the personality
+    // is a placeholder is the response's job to say, not the greeting's: the
+    // other agents are being told who joined, not how well it went.
     try {
       const runningAgents = listAgentNames().filter(a => a !== name && isAgentRunning(a))
       for (const target of [MAIN_AGENT_ID, ...runningAgents]) {
@@ -871,6 +881,11 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       }
     } catch (err) {
       logger.warn({ err, name }, 'Agent created, but the team notification failed')
+    }
+
+    if (personalityPendingDetail !== null) {
+      json(res, { ok: true, name, personalityPending: true, warning: 'Agent created, but its personality came from a template because generation failed. It is queued for regeneration.', detail: personalityPendingDetail }, 200)
+      return true
     }
 
     json(res, { ok: true, name })


### PR DESCRIPTION
Az ágens-létrehozás hibaága törölte a teljes ágens-mappát. Külső bejelentés, éles adatvesztés, benne a ma kiadott v1.27.0-ban is.

## A hiba

A `POST /api/agents` a személyiség-generálást `try`-ba zárta, a `catch` pedig ezt futtatta:

```
rmSync(agentDir(name), { recursive: true, force: true })
```

Vagyis ha a generálás bármitől elszállt (időtúllépés, hiányzó auth, CLI-hiba, hálózat), törlődött az egész ágens-mappa. A felületen ott maradt a kártya, a terminál viszont azt mondta, hogy nincs ilyen ágens, és az újraindítás sem segített, mert nem volt mit indítani.

Ez aránytalan volt. Amikor a `catch` lefut, a `scaffoldAgentDir()` már felépített egy teljes, érvényes ágenst, és megvan a modell, a biztonsági profil, a beállítások meg a megjelenített név. Egyedül a két személyiség-fájl hiányzik, amit a folyamat legtörékenyebb lépése állít elő. Újragenerálni bármikor lehet, visszahozni a törölt mappát nem.

Második hiba ugyanabban a blokkban: az új-csapattag értesítés a `try`-on **belül** ült, a siker-log után, tehát egy elszálló üdvözlés is lefuttatta a destruktív `catch`-et, és egy teljesen kész ágenst törölt.

## Mi változik

Törlés helyett sablon-visszaesés: az ágens megmarad, kap egy minimális `CLAUDE.md`-t és `SOUL.md`-t, plusz egy `.personality-pending` jelölőt a hiba okával, a válasz pedig 200 `personalityPending: true`. A sablonok első sora kimondja, hogy sablonok, tehát helyőrző soha nem válik észrevétlenül az ágens személyiségévé. Az értesítés kikerül a `try`-ból, saját őrzéssel.

## A három commit

Az első kettő **külső hozzájárulás**, a Kreatív Kontroll AI-asszisztensétől (Lead), változatlan szerzőséggel, `git am`-mel átvéve. A harmadik a miénk, és a review kedvéért van külön:

1. `fix(agents)` -- a javítás maga
2. `test(agents)` -- a regressziós teszt, öt állítással
3. `fix(agents): announce the agent on the template path too` -- **a mi kiegészítésünk**

A harmadik azért kellett, mert a beküldött javítás a `catch`-en belülről válaszolt és `return`-ölt, tehát a sablon-ág teljesen kihagyta a csapat-értesítést. Így a handlerben egy második néma kimenet keletkezett volna: egy ágens, ami létezik, működik, ott van a felületen, és amiről senki nem kap hírt. A válasz mostantól az értesítő blokk után dől el, tehát **mindkét ág** bejelenti az új ágenst, **ugyanazzal a szöveggel**. A többi ágensnek azt mondjuk meg, hogy ki érkezett, nem azt, hogy mennyire sikerült; hogy a személyiség helyőrző, azt a válasz és a jelölő-fájl mondja meg.

## Mérés a mi hostunkon

A beküldő saját mérését nem vettük készpénznek, magunk futtattuk le.

| Mit | Eredmény |
|---|---|
| `git apply --check` mindkét patchre | exit 0 |
| A regressziós teszt a **javítatlan** fán | **5 / 5 bukik** |
| A regressziós teszt a javítással | **5 / 5 zöld** |
| `tsc --noEmit` | exit 0 |
| Teljes készlet, javítatlan alapvonal (489b35a) | 224 fájl / 3098 teszt, **nulla bukás** |
| Teljes készlet, a két beküldött committal | 225 fájl / 3103 teszt, **nulla bukás** |
| Teljes készlet, ezen az ágon (a harmadik committal, develop bázison) | 226 fájl / 3124 teszt, **nulla bukás** |

Vagyis a teszt tényleg a hibát méri (a javítás nélkül piros), és a változás nulla regressziót hoz.

**Egy pontosítás a beküldő méréséhez:** a levelükben szereplő "mindkét állapotban ugyanaz a 16 bukás" **a küldő környezetének sajátja**, nálunk nem reprodukálódik. A javítatlan alapvonalon is nulla bukást mértünk. Ennek gyakorlati következménye van: ha nálunk később felbukkan 16 bukás, az **új jelenség** lesz, nem ennek a változásnak az öröksége.

## Ami szándékosan NEM része ennek a PR-nek

- **A felület nem jelzi, hogy sablont kapott az ágens.** A válasz 500-ról 200-ra vált, a varázsló pedig `if (!res.ok) throw`-ot csinál, a `personalityPending` és `warning` mezőre pedig nincs kezelés a `web/app.js`-ben. Tehát a felhasználó normál sikeres varázslót lát; az egyetlen jel a sablon első sora, amit az előnézetben olvashat. Ez látszó, vevő felé ható viselkedés, külön döntés és külön PR tárgya.
- **A teszt forrás-szintű**, és a siker-válasz betű szerinti alakjáig vág. Ha a válasz valaha új mezőt kap, mind az öt állítás elbukik egy ehhez a hibához nem kapcsolódó változás miatt. Külön kártyán van, ebben a PR-ben szándékosan nem nyúlunk hozzá.
