### PR TITLE
fix(install): stop reporting installer steps that were never verified

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -638,8 +638,10 @@ echo -e "  ${DIM}Headless Claude Code teszt...${NC}"
 # assignment, not the pipeline inside the substitution (measured). Dropping the
 # pipe entirely is the only form that reports claude's own status; the output is
 # truncated afterwards in the shell.
-CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1)
-CLAUDE_PROBE_EXIT=$?
+# The `&& ... || ...` guard is what keeps a failing probe out of the ERR trap:
+# the trap fires regardless of the errexit setting and on_error() exits 1, so an
+# unguarded capture aborted the installer instead of reaching the branch below.
+CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1) && CLAUDE_PROBE_EXIT=0 || CLAUDE_PROBE_EXIT=$?
 CLAUDE_PROBE_OUT=${CLAUDE_PROBE_OUT:0:200}
 if [ "$CLAUDE_PROBE_EXIT" -eq 0 ] && [ -n "$CLAUDE_PROBE_OUT" ]; then
   ok "Az OPERATOR shelljebol futtathato a Claude Code (\`claude --print\` valaszolt)"
@@ -990,16 +992,16 @@ else
   _probe_out=""
   _probe_rc=1
   if command -v claude >/dev/null 2>&1; then
+    # A 401 here is the VERDICT this gate exists to report, not an installer
+    # error -- see the guard rationale above the operator-shell probe.
     if [ -n "$_svc_token" ]; then
       _probe_out="$(env -i PATH="$PATH" HOME="$HOME" CLAUDE_CONFIG_DIR="$_probe_cfg" \
         CLAUDE_CODE_OAUTH_TOKEN="$_svc_token" \
-        claude --print "ping" 2>&1)"
-      _probe_rc=$?
+        claude --print "ping" 2>&1)" && _probe_rc=0 || _probe_rc=$?
     else
       _probe_out="$(env -i PATH="$PATH" HOME="$HOME" CLAUDE_CONFIG_DIR="$_probe_cfg" \
         ANTHROPIC_API_KEY="$_svc_apikey" \
-        claude --print "ping" 2>&1)"
-      _probe_rc=$?
+        claude --print "ping" 2>&1)" && _probe_rc=0 || _probe_rc=$?
     fi
     _probe_out=${_probe_out:0:200}
     if [ "$_probe_rc" -eq 0 ] && [ -n "$_probe_out" ]; then

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1198,7 +1198,11 @@ CHANNELS_PID="$(start_launchd_unit "$CHANNELS_PLIST")"
 if [ -n "$DASHBOARD_PID" ] && [ -n "$CHANNELS_PID" ]; then
   echo -e "  ${GREEN}✓${NC} Szolgaltatasok elinditva (dashboard pid $DASHBOARD_PID, channels pid $CHANNELS_PID)"
 else
-  warn "A SZOLGALTATASOK NEM INDULTAK EL -- a bot igy senkinek nem fog valaszolni."
+  # "nem igazolt", not "nem indultak el": this branch fires when EITHER pid is
+  # missing, so the plural claim was false whenever one unit came up. It also
+  # says only what was measured -- the verification did not succeed -- instead of
+  # asserting a consequence nobody checked.
+  warn "A SZOLGALTATASOK INDULASA NEM IGAZOLT"
   # `if` rather than `[ ... ] && echo`: when the unit DID come up the test
   # returns 1, the && list returns 1, and the ERR trap would abort right here --
   # the very defect this block reports on.
@@ -1208,7 +1212,7 @@ else
   # time needs three things from this screen, in this order: the install itself
   # finished, nothing is lost, and there is something to do about it. The
   # launchd sentence below is accurate but is an explanation, not an answer.
-  echo -e "    A telepites befejezodott, de a ket szolgaltatas nem indult el. Ez javithato, a lentiek bemasolasaval."
+  echo -e "    A telepites befejezodott. Ami nem indult el, azt fent latod, es a lentiekkel elindithatod."
   echo -e "    ${DIM}A launchd betoltotte a unitokat, de nem inditotta el oket.${NC}"
   echo -e "    ${BOLD}Javitas most:${NC}"
   echo -e "    ${BLUE}launchctl kickstart -p gui/$(id -u)/${DASHBOARD_PLIST}${NC}"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -70,12 +70,15 @@ offer_claude_fallback() {
     read -rp "$(_t prompt_open_claude)" OPEN_CLAUDE
     OPEN_CLAUDE=${OPEN_CLAUDE:-n}
     if [[ "$OPEN_CLAUDE" == "i" || "$OPEN_CLAUDE" == "y" ]]; then
-      claude --prompt "$prompt"
+      # `claude` takes the initial prompt as a POSITIONAL argument. The old
+      # `--prompt` flag no longer exists (unknown option '--prompt'), so the
+      # offer died at the exact moment the operator asked for help.
+      claude "$prompt"
       return
     fi
   fi
   echo -e "  ${DIM}$(_t macos.fallback_manual)${NC}"
-  echo -e "  ${DIM}claude --prompt \"$(echo "$prompt" | sed 's/"/\\"/g')\"${NC}"
+  echo -e "  ${DIM}claude \"$(echo "$prompt" | sed 's/"/\\"/g')\"${NC}"
 }
 
 fail() {
@@ -313,10 +316,12 @@ echo -e "${DIM}$(_t macos.auth_hint_2)${NC}"
 echo -e "${DIM}$(_t macos.auth_hint_3)${NC}"
 read -rp "$(_t prompt_login)" DO_AUTH
 if [[ "$DO_AUTH" == "i" || "$DO_AUTH" == "y" ]]; then
-  set +e
-  claude auth login
-  AUTH_RC=$?
-  set -e
+  # `&& ... || ...` rather than a `set +e` window: a `trap ... ERR` fires
+  # regardless of the errexit setting, and on_error() above EXITS, so a window
+  # never protected the branch below -- only keeping the command out of the
+  # trap's reach does. Only the FINAL command of an && / || list is subject to
+  # errexit and the ERR trap, so this captures the status instead of aborting.
+  claude auth login && AUTH_RC=0 || AUTH_RC=$?
   if [ "$AUTH_RC" -ne 0 ]; then
     echo -e "  ${ORANGE}⚠${NC} Auth login nem fejezodott be sikeresen (exit $AUTH_RC)."
     echo -e "  ${DIM}$(_t macos.auth_later)${NC}"
@@ -357,16 +362,16 @@ fi
 # here while the user is still at the install prompt.
 echo ""
 echo -e "  ${DIM}$(_t macos.headless_test)${NC}"
-set +e
 # The exit status here used to be `head`'s, not claude's: `VAR=$(cmd | head)`
 # reports the LAST pipeline element, so a failing claude looked like success.
 # PIPESTATUS does NOT help either -- after an assignment it describes the
 # assignment, not the pipeline inside the substitution (measured). Dropping the
 # pipe entirely is the only form that reports claude's own status.
-CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1)
-CLAUDE_PROBE_EXIT=$?
+# The `&& ... || ...` guard replaces the `set +e` window that used to wrap this:
+# the ERR trap fires regardless of errexit and on_error() exits, so the window
+# was decorative -- a failing probe still killed the installer here.
+CLAUDE_PROBE_OUT=$(claude --print "ping" 2>&1) && CLAUDE_PROBE_EXIT=0 || CLAUDE_PROBE_EXIT=$?
 CLAUDE_PROBE_OUT=${CLAUDE_PROBE_OUT:0:200}
-set -e
 if [ "$CLAUDE_PROBE_EXIT" -eq 0 ] && [ -n "$CLAUDE_PROBE_OUT" ]; then
   echo -e "  ${GREEN}✓${NC} $(_t macos.headless_ok)"
 else
@@ -640,14 +645,19 @@ else
   # operator's shell cannot make a broken install look healthy) carrying ONLY
   # the credential the launchd units will get.
   _probe_cfg="$(mktemp -d 2>/dev/null || echo /tmp/marveen-authprobe.$$)"
+  # A 401 here is the VERDICT this gate exists to report, not an installer
+  # error. Unguarded, the capture reached the ERR trap and on_error() exited 1 --
+  # blaming the enclosing `fi` -- so the BROKEN branch below (and its
+  # `scripts/auth.sh` hint) was unreachable in exactly the case it was written
+  # for. `&& ... || ...` keeps the failure out of the trap and preserves rc.
+  _probe_rc=0
   if [ -n "$_svc_token" ]; then
     _probe_out="$(env -i PATH="$PATH" HOME="$HOME" CLAUDE_CONFIG_DIR="$_probe_cfg" \
-      CLAUDE_CODE_OAUTH_TOKEN="$_svc_token" claude --print "ping" 2>&1)"
+      CLAUDE_CODE_OAUTH_TOKEN="$_svc_token" claude --print "ping" 2>&1)" && _probe_rc=0 || _probe_rc=$?
   else
     _probe_out="$(env -i PATH="$PATH" HOME="$HOME" CLAUDE_CONFIG_DIR="$_probe_cfg" \
-      ANTHROPIC_API_KEY="$_svc_apikey" claude --print "ping" 2>&1)"
+      ANTHROPIC_API_KEY="$_svc_apikey" claude --print "ping" 2>&1)" && _probe_rc=0 || _probe_rc=$?
   fi
-  _probe_rc=$?
   _probe_out=${_probe_out:0:200}
   if [ "$_probe_rc" -eq 0 ] && [ -n "$_probe_out" ]; then
     INSTALL_AUTH_STATE="OK"
@@ -1134,10 +1144,72 @@ PLISTEOF
 
 echo -e "  ${GREEN}✓${NC} $(_t macos.launchagents_created)"
 
-# Load LaunchAgents
-launchctl load "$PLIST_DIR/${DASHBOARD_PLIST}.plist" 2>/dev/null || true
-launchctl load "$PLIST_DIR/${CHANNELS_PLIST}.plist" 2>/dev/null || true
-echo -e "  ${GREEN}✓${NC} Szolgaltatasok elinditva"
+# Load AND START the LaunchAgents -- loading is not starting.
+#
+# `launchctl load` only PENDS a RunAtLoad spawn on modern macOS. Measured on
+# 26.5.1 with a throwaway agent carrying RunAtLoad=true + KeepAlive=true:
+#
+#   launchctl load <plist>              -> rc=0, runs = 0, never starts
+#   launchctl bootstrap gui/$UID <p>    -> rc=0, runs = 0, never starts
+#   launchctl print gui/$UID/<label>    -> "pended nondemand spawn = speculative"
+#                                          still `state = not running` after 30s
+#   launchctl kickstart gui/$UID/<label> -> starts immediately, runs = 1
+#
+# The old two lines swallowed every error (`2>/dev/null || true`) and then
+# printed "Szolgaltatasok elinditva" unconditionally, so a fresh install ended
+# with two units that had NEVER run while the operator was told they were up --
+# the bot answered nobody and there was no signal anywhere to explain it.
+start_launchd_unit() {
+  # start_launchd_unit LABEL -- bootstrap/load, kickstart, then VERIFY.
+  # Echoes the running pid, or nothing at all when the unit never came up.
+  _slu_label="$1"
+  _slu_domain="gui/$(id -u)"
+  launchctl bootstrap "$_slu_domain" "$PLIST_DIR/${_slu_label}.plist" 2>/dev/null \
+    || launchctl load "$PLIST_DIR/${_slu_label}.plist" 2>/dev/null \
+    || true
+  launchctl kickstart "$_slu_domain/${_slu_label}" >/dev/null 2>&1 || true
+  _slu_pid=""
+  _slu_try=0
+  while [ "$_slu_try" -lt "${LAUNCHD_START_TRIES:-10}" ]; do
+    _slu_pid="$(launchctl print "$_slu_domain/${_slu_label}" 2>/dev/null \
+      | awk '/^\tpid = /{print $3; exit}')"
+    # NOT `[ -n "$_slu_pid" ] && break`: as the last command of the loop body
+    # that list would return 1 on the final miss and abort the installer.
+    if [ -n "$_slu_pid" ]; then break; fi
+    _slu_try=$((_slu_try + 1))
+    sleep 1
+  done
+  # A first pid is not proof the unit STAYED up. Measured on 26.5.1 with a unit
+  # whose program does not exist: launchd reports a transient `state = xpcproxy`
+  # pid for about a second, and only two seconds on does it read
+  # `state = spawn scheduled`, no pid, `last exit code = 78: EX_CONFIG`. Confirm
+  # after a settle so a crash-looping unit is not counted as started.
+  if [ -n "$_slu_pid" ]; then
+    sleep 2
+    _slu_pid="$(launchctl print "$_slu_domain/${_slu_label}" 2>/dev/null \
+      | awk '/^\tpid = /{print $3; exit}')"
+  fi
+  printf '%s' "$_slu_pid"
+  unset _slu_label _slu_domain _slu_try
+}
+
+DASHBOARD_PID="$(start_launchd_unit "$DASHBOARD_PLIST")"
+CHANNELS_PID="$(start_launchd_unit "$CHANNELS_PLIST")"
+if [ -n "$DASHBOARD_PID" ] && [ -n "$CHANNELS_PID" ]; then
+  echo -e "  ${GREEN}✓${NC} Szolgaltatasok elinditva (dashboard pid $DASHBOARD_PID, channels pid $CHANNELS_PID)"
+else
+  warn "A SZOLGALTATASOK NEM INDULTAK EL -- a bot igy senkinek nem fog valaszolni."
+  # `if` rather than `[ ... ] && echo`: when the unit DID come up the test
+  # returns 1, the && list returns 1, and the ERR trap would abort right here --
+  # the very defect this block reports on.
+  if [ -z "$DASHBOARD_PID" ]; then echo -e "    ${DIM}  - ${DASHBOARD_PLIST}: nem fut${NC}"; fi
+  if [ -z "$CHANNELS_PID" ]; then echo -e "    ${DIM}  - ${CHANNELS_PLIST}: nem fut${NC}"; fi
+  echo -e "    ${DIM}A launchd betoltotte a unitokat, de nem inditotta el oket.${NC}"
+  echo -e "    ${BOLD}Javitas most:${NC}"
+  echo -e "    ${BLUE}launchctl kickstart -p gui/$(id -u)/${DASHBOARD_PLIST}${NC}"
+  echo -e "    ${BLUE}launchctl kickstart -p gui/$(id -u)/${CHANNELS_PLIST}${NC}"
+  echo -e "    ${DIM}Ellenorzes: launchctl print gui/$(id -u)/${CHANNELS_PLIST} | grep -E 'state|pid'${NC}"
+fi
 
 # Verify channel plugin is working
 sleep 3

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1204,6 +1204,11 @@ else
   # the very defect this block reports on.
   if [ -z "$DASHBOARD_PID" ]; then echo -e "    ${DIM}  - ${DASHBOARD_PLIST}: nem fut${NC}"; fi
   if [ -z "$CHANNELS_PID" ]; then echo -e "    ${DIM}  - ${CHANNELS_PLIST}: nem fut${NC}"; fi
+  # Reassurance BEFORE the technical cause. Whoever is installing for the first
+  # time needs three things from this screen, in this order: the install itself
+  # finished, nothing is lost, and there is something to do about it. The
+  # launchd sentence below is accurate but is an explanation, not an answer.
+  echo -e "    A telepites befejezodott, de a ket szolgaltatas nem indult el. Ez javithato, a lentiek bemasolasaval."
   echo -e "    ${DIM}A launchd betoltotte a unitokat, de nem inditotta el oket.${NC}"
   echo -e "    ${BOLD}Javitas most:${NC}"
   echo -e "    ${BLUE}launchctl kickstart -p gui/$(id -u)/${DASHBOARD_PLIST}${NC}"

--- a/src/__tests__/installer-start-and-fallback.test.ts
+++ b/src/__tests__/installer-start-and-fallback.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+/** Run a real script FILE (not `bash -c`) and return its output + exit code.
+ *  The distinction matters: $LINENO inside an ERR trap numbers a file the way
+ *  the installer is numbered, while `bash -c` numbers the -c string. */
+function runScriptFile(lines: string[]): { out: string; code: number } {
+  const dir = mkdtempSync(join(tmpdir(), 'errtrap-'))
+  try {
+    const p = join(dir, 'probe.sh')
+    writeFileSync(p, lines.join('\n') + '\n')
+    try {
+      return { out: execFileSync('bash', [p], { encoding: 'utf-8' }).trim(), code: 0 }
+    } catch (e) {
+      const err = e as { stdout?: string; status?: number }
+      return { out: String(err.stdout ?? '').trim(), code: err.status ?? -1 }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+// Three installer defects that share one shape: the installer REPORTS a step it
+// never verified, so a broken install reads as a healthy one and the outage only
+// surfaces once the bot has already been answering nobody for hours.
+//
+//   1. the fail-closed auth gate aborts instead of failing closed -- the probe
+//      runs under `set -e`, so a 401 kills the script at the enclosing `fi`
+//      before the BROKEN branch (and its `scripts/auth.sh` hint) can run;
+//   2. `claude --prompt` -- the flag does not exist, so the "shall I open Claude
+//      Code to diagnose this?" offer dies with `unknown option '--prompt'` at
+//      the exact moment the operator asked for help. install-linux.sh already
+//      fixed this; install-macos.sh was missed;
+//   3. `launchctl load` only PENDS a RunAtLoad spawn on modern macOS. Measured
+//      on 26.5.1 with a throwaway agent (RunAtLoad=true, KeepAlive=true):
+//
+//          launchctl load <plist>            -> rc=0, runs = 0, never starts
+//          launchctl bootstrap gui/$UID ...  -> rc=0, runs = 0, never starts
+//          launchctl print ...               -> "pended nondemand spawn = speculative"
+//          launchctl kickstart -p gui/$UID/L -> starts immediately, runs = 1
+//
+//      still `state = not running` after 30s. The installer swallowed that
+//      (`2>/dev/null || true`) and printed "Szolgaltatasok elinditva" over two
+//      units that had never run.
+
+const ROOT = join(__dirname, '..', '..')
+const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+const MACOS = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
+
+/** Pull one shell function out of a script so it can be executed for real. */
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+  if (start < 0) throw new Error(`function ${name}() not found`)
+  const end = src.indexOf('\n}', start)
+  if (end < 0) throw new Error(`unterminated ${name}()`)
+  return src.slice(start, end + 2)
+}
+
+/** Join backslash-continued lines so a probe spanning several source lines is
+ *  examined as the single logical command bash actually executes. */
+function logicalLines(src: string): string[] {
+  const out: string[] = []
+  let acc = ''
+  for (const line of src.split('\n')) {
+    acc += acc === '' ? line : ' ' + line.trim()
+    if (/\\$/.test(acc.trimEnd())) acc = acc.trimEnd().replace(/\\$/, '')
+    else {
+      out.push(acc)
+      acc = ''
+    }
+  }
+  if (acc !== '') out.push(acc)
+  return out
+}
+
+/** The only guard that keeps a failing capture away from the ERR trap while
+ *  still preserving its exit status. `set +e` does NOT (see the premise tests). */
+const STATUS_GUARD = /&&\s*\w+=0\s*\|\|\s*\w+=\$\?/
+
+describe.each([
+  ['install-linux.sh', LINUX],
+  ['install-macos.sh', MACOS],
+])('%s -- a failing probe must not abort the installer', (_name, SRC) => {
+  // The whole point of the three-state auth gate is to REPORT a broken
+  // credential. An unguarded capture lets the ERR trap fire on the 401 and
+  // exit(1) before INSTALL_AUTH_STATE is ever consulted, so the operator gets
+  // "Varatlan hiba ... (sor: <the closing fi>)" instead of the diagnosis.
+  it('guards every `claude --print "ping"` capture so its failure stays DATA', () => {
+    const offenders = logicalLines(SRC)
+      .filter((l) => l.includes('claude --print "ping"'))
+      .filter((l) => !STATUS_GUARD.test(l))
+    expect(offenders).toEqual([])
+  })
+
+  it('still declares the BROKEN verdict the probe is supposed to produce', () => {
+    expect(SRC).toContain('INSTALL_AUTH_STATE="BROKEN"')
+  })
+})
+
+describe('the ERR-trap abort is real (guards the premise of the tests above)', () => {
+  const TRAP = [
+    'set -e',
+    'on_error() { echo "TRAP:$1"; exit 9; }',
+    "trap 'on_error $LINENO' ERR",
+  ]
+
+  // Same shape as the installer's auth gate: an assignment whose command
+  // substitution fails, inside the `then` branch of an `if`. bash blames the
+  // enclosing `fi`, which is why the installer reported line 658 for a command
+  // that lives on line 644.
+  it('an unguarded capture aborts, and bash blames the enclosing `fi`', () => {
+    const r = runScriptFile([...TRAP, 'if [ -n "x" ]; then', '  out="$(false)"', 'fi', 'echo REACHED'])
+    expect(r.out).toBe('TRAP:6')
+    expect(r.out).not.toContain('REACHED')
+    expect(r.code).toBe(9)
+  })
+
+  // The tempting fix that does NOTHING here. A `trap ... ERR` fires regardless
+  // of the errexit setting, and this installer's handler exits 1 -- so every
+  // `set +e` window in it is a false safeguard against an aborting trap.
+  it('a `set +e` window does NOT stop an ERR trap that exits', () => {
+    const r = runScriptFile([...TRAP, 'set +e', 'out="$(false)"', 'set -e', 'echo REACHED'])
+    expect(r.out).toMatch(/^TRAP:/)
+    expect(r.out).not.toContain('REACHED')
+  })
+
+  // The form actually shipped: the capture becomes part of an && / || list, and
+  // only the FINAL command of such a list is subject to errexit and the ERR trap.
+  it('the `&& rc=0 || rc=$?` guard survives AND keeps the real exit status', () => {
+    const r = runScriptFile([
+      ...TRAP,
+      `out="$(sh -c 'echo boom >&2; exit 7' 2>&1)" && rc=0 || rc=$?`,
+      'echo "REACHED:$rc:$out"',
+    ])
+    expect(r.out).toBe('REACHED:7:boom')
+    expect(r.code).toBe(0)
+  })
+
+  it('the same guard reports success unchanged', () => {
+    const r = runScriptFile([...TRAP, 'out="$(echo ok)" && rc=0 || rc=$?', 'echo "REACHED:$rc:$out"'])
+    expect(r.out).toBe('REACHED:0:ok')
+  })
+})
+
+describe.each([
+  ['install-linux.sh', LINUX],
+  ['install-macos.sh', MACOS],
+])('%s -- the diagnose-with-Claude offer must be runnable', (_name, SRC) => {
+  it('never invokes the non-existent `--prompt` flag', () => {
+    const offenders = SRC.split('\n')
+      .map((line, i) => ({ line, n: i + 1 }))
+      .filter(({ line }) => /claude\s+(\\)?["']?--prompt/.test(line))
+      .map(({ n }) => n)
+    expect(offenders).toEqual([])
+  })
+
+  it('passes the prompt positionally, the way the CLI accepts it', () => {
+    const fn = sliceShellFn(SRC, 'offer_claude_fallback')
+    expect(fn).toMatch(/claude "\$prompt"/)
+  })
+})
+
+describe('install-macos.sh -- launchd units must be verified, not assumed', () => {
+  const FN = 'start_launchd_unit'
+
+  /**
+   * Run start_launchd_unit() against a stub `launchctl` and return both what the
+   * function printed (the pid, or nothing) and which subcommands it invoked.
+   *
+   * The three modes are the three behaviours measured on macOS 26.5.1:
+   *   healthy   -- load/bootstrap pend; only kickstart starts it; pid persists
+   *   pended    -- `pended nondemand spawn = speculative`, no pid, ever
+   *   crashloop -- a transient `xpcproxy` pid, then `spawn scheduled`, no pid,
+   *                `last exit code = 78: EX_CONFIG` (program missing)
+   */
+  function runStart(mode: 'healthy' | 'pended' | 'crashloop'): { pid: string; calls: string[] } {
+    const dir = mkdtempSync(join(tmpdir(), 'launchd-'))
+    try {
+      const calls = join(dir, 'calls')
+      const prints = join(dir, 'prints')
+      const stub = join(dir, 'launchctl')
+      writeFileSync(
+        stub,
+        [
+          '#!/bin/bash',
+          `echo "$1" >> "${calls}"`,
+          // load/bootstrap "succeed" while starting nothing -- the real trap
+          'case "$1" in',
+          '  load|bootstrap) exit 0 ;;',
+          '  kickstart) exit 0 ;;',
+          '  print)',
+          `    echo x >> "${prints}"`,
+          `    n=$(wc -l < "${prints}")`,
+          `    mode="${mode}"`,
+          `    up=0`,
+          `    if grep -q kickstart "${calls}"; then`,
+          '      case "$mode" in',
+          '        healthy) up=1 ;;',
+          // the transient pid appears on the FIRST print and is gone by the
+          // confirming re-read after the settle
+          '        crashloop) if [ "$n" -le 1 ]; then up=1; fi ;;',
+          '      esac',
+          '    fi',
+          '    if [ "$up" = "1" ]; then',
+          '      printf "\\tstate = running\\n\\tpid = 4242\\n"',
+          '    else',
+          '      printf "\\tstate = spawn scheduled\\n\\truns = 1\\n"',
+          '    fi',
+          '    exit 0 ;;',
+          'esac',
+          'exit 0',
+        ].join('\n'),
+      )
+      chmodSync(stub, 0o755)
+      const script = [
+        'set -e',
+        'on_error() { echo "ABORTED:$1"; exit 9; }',
+        "trap 'on_error $LINENO' ERR",
+        `export PATH="${dir}:$PATH"`,
+        'PLIST_DIR=/tmp',
+        'LAUNCHD_START_TRIES=2',
+        sliceShellFn(MACOS, FN),
+        `printf 'PID=%s' "$(${FN} com.example.unit)"`,
+      ].join('\n')
+      const out = execFileSync('bash', ['-c', script], { encoding: 'utf-8' })
+      const pid = /PID=(\d*)/.exec(out)?.[1] ?? ''
+      const recorded = (() => {
+        try {
+          return readFileSync(calls, 'utf-8').trim().split('\n').filter(Boolean)
+        } catch {
+          return []
+        }
+      })()
+      return { pid, calls: recorded }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  it('never trusts load/bootstrap alone -- it always kickstarts', () => {
+    expect(runStart('healthy').calls).toContain('kickstart')
+  })
+
+  it('returns the pid once the unit is actually up', () => {
+    expect(runStart('healthy').pid).toBe('4242')
+  })
+
+  it('returns NOTHING when the spawn stays pended, so the caller can fail loudly', () => {
+    expect(runStart('pended').pid).toBe('')
+  })
+
+  it('returns NOTHING for a crash-looping unit whose first pid was transient', () => {
+    // launchd hands out an xpcproxy pid before the exec fails, so a single read
+    // would report a dead unit as started.
+    expect(runStart('crashloop').pid).toBe('')
+  })
+
+  it('does not abort the installer when launchd refuses to start the unit', () => {
+    // `set -e` is live here too: a bare `[ -n "$pid" ] && break` in the poll loop
+    // would exit(1) the whole installer on the very last iteration.
+    expect(() => runStart('pended')).not.toThrow()
+  })
+
+  it('gates the success banner on the verified pids, not on the load call', () => {
+    const started = MACOS.indexOf(`${FN}() {`)
+    expect(started).toBeGreaterThan(0)
+    const tail = MACOS.slice(started)
+    // the old code printed this unconditionally, one line after `launchctl load`
+    const banner = /Szolgaltatasok elinditva/.exec(tail)
+    expect(banner).not.toBeNull()
+    const before = tail.slice(0, banner!.index)
+    expect(before).toMatch(new RegExp(`${FN}\\s`))
+    expect(before).toMatch(/if \[ -n "\$DASHBOARD_PID" \] && \[ -n "\$CHANNELS_PID" \]/)
+    // and there must be a loud else-branch for the failure the operator hit
+    expect(tail.slice(banner!.index)).toMatch(/launchctl kickstart/)
+  })
+})
+
+describe('both installers stay parseable', () => {
+  it.each(['install-linux.sh', 'install-macos.sh'])('bash -n %s', (f) => {
+    expect(() => execFileSync('bash', ['-n', join(ROOT, f)], { stdio: 'pipe' })).not.toThrow()
+  })
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** Három telepítő-hiba, közös alakkal: a telepítő olyan lépést jelent késznek, amit nem ellenőrzött, így egy törött telepítés egészségesnek látszik.

1. **A fail-closed auth-kapu abortált fail-close helyett.** A `claude --print "ping"` capture őrizetlen volt, így a 401 elérte az ERR trap-et, az `on_error()` `exit 1`-et hívott és a befoglaló `fi`-t jelentette (658. sor egy 644-en lévő parancsra). Emiatt a `INSTALL_AUTH_STATE="BROKEN"` ág és a `scripts/auth.sh` hint pontosan abban az esetben volt elérhetetlen, amire íródott. **Mérve: a `set +e` nem véd** — a `trap ... ERR` az errexit beállításától függetlenül lefut, és ez a handler kilép. A működő alak `out="$(cmd 2>&1)" && rc=0 || rc=$?`, mert `&&`/`||` listából csak az utolsó parancs esik errexit/ERR alá; ez a kilépési kódot is megőrzi. Az `install-macos.sh` két meglévő `set +e` ablaka ugyanez a látszatvédelem volt, ezért azok is a garantált alakra cserélődtek.
2. **`claude --prompt` nem létezik** (`unknown option '--prompt'`), így a „megnyissam a Claude Code-ot a diagnózishoz?" ajánlat pont akkor halt el, amikor a felhasználó segítséget kért. Az `install-linux.sh` ezt már pozicionálisan adja át; a macOS változatból kimaradt, a kimásolható kézi parancsból is.
3. **A `launchctl load` nem indít.** macOS 26.5.1-en `RunAtLoad=true` + `KeepAlive=true` mellett a `load` és a `bootstrap` is `pended nondemand spawn = speculative` / `runs = 0` állapotban hagyja a unitot, 30 s után is; csak a `kickstart` indítja el. A régi kód minden hibát elnyelt és feltétel nélkül kiírta a `✓ Szolgaltatasok elinditva`-t, így egy friss telepítés két soha nem futott unittal ért véget, miközben az üzemeltető azt olvasta, hogy elindultak. Az új `start_launchd_unit()` bootstrapol, kickstartol, majd **ellenőrzi a pid-et**, mielőtt bármit állítana; a bukó ág kiírja a javító parancsokat. Egy első pid sem elég: hiányzó program esetén a launchd ~1 s-ig `xpcproxy` pid-et mutat, és csak utána olvasható `spawn scheduled` / `last exit code = 78: EX_CONFIG` — ezért a pid egy rövid megállapodási idő után megerősítésre kerül.

**EN.** Three installer defects sharing one shape: the installer reports a step it never verified, so a broken install reads as a healthy one. (1) The fail-closed auth gate aborted under the ERR trap instead of failing closed; a `set +e` window does not help because the trap fires regardless of errexit and this handler exits, so the capture is now guarded with `&& rc=0 || rc=$?`, which also preserves the status. (2) `claude --prompt` does not exist; the prompt is now passed positionally, matching `install-linux.sh`. (3) `launchctl load` only pends a `RunAtLoad` spawn on macOS 26.5.1, so the units are now bootstrapped, kickstarted and verified by pid before any success is printed, with a loud failure branch carrying the repair commands.

**Tesztelés / Testing.** A tesztek valódi shellt futtatnak, nem mintát illesztenek: az ERR-trap viselkedés (és az, hogy a `set +e` nem állítja meg a kilépő trap-et) script-fájlokkal bizonyított, a `start_launchd_unit()` pedig stub `launchctl` ellen fut, ami a healthy / pended / crash-looping esetet modellezi. Emellett end-to-end is ellenőrizve valódi launchd ellen: ép unit visszaadja a pid-jét, crash-loopoló üresen tér vissza, és egyik sem állítja le a telepítőt.

## Kapcsolódó issue / Related issue

Closes #825

Kapcsolódik a #815-höz: ugyanaz a terület (macOS launchd), de más kiváltó ok — ott a plistek `RunAtLoad=false` / `KeepAlive=false` beállítással készültek, ahol a nem-indulás várt viselkedés. Itt mindkettő `true` volt, és a unitok akkor sem indultak el. / Related to #815: same area, different trigger.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

<sub>Megjegyzés a 2. ponthoz: a `docs/` nem módosult, mert a változás nem érinti a telepítés menetét vagy az architektúrát — a meglévő lépések ugyanazok, csak ellenőrzötten futnak. A `why` a kódban, a commit-üzenetben és a #825-ben van dokumentálva. / Note on checklist item 2: `docs/` is unchanged because the install flow and architecture are unchanged; only the verification of existing steps was added.</sub>
