### PR TITLE
fix(start): verify the launchd units in scripts/start.sh too, via a shared helper

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1144,54 +1144,10 @@ PLISTEOF
 
 echo -e "  ${GREEN}✓${NC} $(_t macos.launchagents_created)"
 
-# Load AND START the LaunchAgents -- loading is not starting.
-#
-# `launchctl load` only PENDS a RunAtLoad spawn on modern macOS. Measured on
-# 26.5.1 with a throwaway agent carrying RunAtLoad=true + KeepAlive=true:
-#
-#   launchctl load <plist>              -> rc=0, runs = 0, never starts
-#   launchctl bootstrap gui/$UID <p>    -> rc=0, runs = 0, never starts
-#   launchctl print gui/$UID/<label>    -> "pended nondemand spawn = speculative"
-#                                          still `state = not running` after 30s
-#   launchctl kickstart gui/$UID/<label> -> starts immediately, runs = 1
-#
-# The old two lines swallowed every error (`2>/dev/null || true`) and then
-# printed "Szolgaltatasok elinditva" unconditionally, so a fresh install ended
-# with two units that had NEVER run while the operator was told they were up --
-# the bot answered nobody and there was no signal anywhere to explain it.
-start_launchd_unit() {
-  # start_launchd_unit LABEL -- bootstrap/load, kickstart, then VERIFY.
-  # Echoes the running pid, or nothing at all when the unit never came up.
-  _slu_label="$1"
-  _slu_domain="gui/$(id -u)"
-  launchctl bootstrap "$_slu_domain" "$PLIST_DIR/${_slu_label}.plist" 2>/dev/null \
-    || launchctl load "$PLIST_DIR/${_slu_label}.plist" 2>/dev/null \
-    || true
-  launchctl kickstart "$_slu_domain/${_slu_label}" >/dev/null 2>&1 || true
-  _slu_pid=""
-  _slu_try=0
-  while [ "$_slu_try" -lt "${LAUNCHD_START_TRIES:-10}" ]; do
-    _slu_pid="$(launchctl print "$_slu_domain/${_slu_label}" 2>/dev/null \
-      | awk '/^\tpid = /{print $3; exit}')"
-    # NOT `[ -n "$_slu_pid" ] && break`: as the last command of the loop body
-    # that list would return 1 on the final miss and abort the installer.
-    if [ -n "$_slu_pid" ]; then break; fi
-    _slu_try=$((_slu_try + 1))
-    sleep 1
-  done
-  # A first pid is not proof the unit STAYED up. Measured on 26.5.1 with a unit
-  # whose program does not exist: launchd reports a transient `state = xpcproxy`
-  # pid for about a second, and only two seconds on does it read
-  # `state = spawn scheduled`, no pid, `last exit code = 78: EX_CONFIG`. Confirm
-  # after a settle so a crash-looping unit is not counted as started.
-  if [ -n "$_slu_pid" ]; then
-    sleep 2
-    _slu_pid="$(launchctl print "$_slu_domain/${_slu_label}" 2>/dev/null \
-      | awk '/^\tpid = /{print $3; exit}')"
-  fi
-  printf '%s' "$_slu_pid"
-  unset _slu_label _slu_domain _slu_try
-}
+# Load AND START the LaunchAgents -- loading is not starting. The rationale and
+# the measurements live in the shared helper, which scripts/start.sh uses too so
+# both entry points behave identically.
+. "$INSTALL_DIR/scripts/launchd-unit.sh"
 
 DASHBOARD_PID="$(start_launchd_unit "$DASHBOARD_PLIST")"
 CHANNELS_PID="$(start_launchd_unit "$CHANNELS_PLIST")"

--- a/scripts/launchd-unit.sh
+++ b/scripts/launchd-unit.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Shared launchd starter for the macOS entry points (install-macos.sh and
+# scripts/start.sh). Sourced, never executed.
+#
+# `launchctl load` is not `launchctl start`. It only PENDS a RunAtLoad spawn on
+# modern macOS. Measured on 26.5.1 with a throwaway agent carrying
+# RunAtLoad=true + KeepAlive=true:
+#
+#   launchctl load <plist>                rc=0, runs = 0, never starts
+#   launchctl bootstrap gui/$UID <plist>  rc=0, runs = 0, never starts
+#   launchctl print gui/$UID/<label>      "pended nondemand spawn = speculative",
+#                                         still `state = not running` after 30s
+#   launchctl kickstart gui/$UID/<label>  starts immediately, runs = 1
+#
+# Both call sites used to `launchctl load ... 2>/dev/null || true` and then print
+# a success line unconditionally, so an install (or a manual start) ended with
+# two units that had NEVER run while the operator was told they were up -- the
+# bot answered nobody and nothing anywhere explained why.
+#
+# Safe to source into a script running with `set -e` and an exiting ERR trap:
+# no bare `cmd && cmd` list is the last command of any construct here.
+
+# start_launchd_unit LABEL -- bootstrap/load, kickstart, then VERIFY.
+# Echoes the running pid, or nothing at all when the unit never came up.
+# PLIST_DIR defaults to the user LaunchAgents directory.
+start_launchd_unit() {
+  _slu_label="$1"
+  _slu_dir="${PLIST_DIR:-$HOME/Library/LaunchAgents}"
+  _slu_domain="gui/$(id -u)"
+  launchctl bootstrap "$_slu_domain" "$_slu_dir/${_slu_label}.plist" 2>/dev/null \
+    || launchctl load "$_slu_dir/${_slu_label}.plist" 2>/dev/null \
+    || true
+  launchctl kickstart "$_slu_domain/${_slu_label}" >/dev/null 2>&1 || true
+  _slu_pid=""
+  _slu_try=0
+  while [ "$_slu_try" -lt "${LAUNCHD_START_TRIES:-10}" ]; do
+    _slu_pid="$(launchctl print "$_slu_domain/${_slu_label}" 2>/dev/null \
+      | awk '/^\tpid = /{print $3; exit}')"
+    # NOT `[ -n "$_slu_pid" ] && break`: as the last command of the loop body
+    # that list would return 1 on the final miss and abort an errexit caller.
+    if [ -n "$_slu_pid" ]; then break; fi
+    _slu_try=$((_slu_try + 1))
+    sleep 1
+  done
+  # A first pid is not proof the unit STAYED up. Measured with a unit whose
+  # program does not exist: launchd reports a transient `state = xpcproxy` pid
+  # for about a second, and only two seconds on does it read
+  # `state = spawn scheduled`, no pid, `last exit code = 78: EX_CONFIG`. Confirm
+  # after a settle so a crash-looping unit is not counted as started.
+  if [ -n "$_slu_pid" ]; then
+    sleep 2
+    _slu_pid="$(launchctl print "$_slu_domain/${_slu_label}" 2>/dev/null \
+      | awk '/^\tpid = /{print $3; exit}')"
+  fi
+  printf '%s' "$_slu_pid"
+  unset _slu_label _slu_dir _slu_domain _slu_try
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -32,9 +32,19 @@ INSTALL_DIR="$INSTALL_DIR" python3 "${INSTALL_DIR}/scripts/boot-hook-prune.py" 2
 
 echo "${BOT_NAME:-Marveen} $(_t start.starting)"
 OS="$(uname -s)"
+LAUNCHD_FAILED=""
 if [ "$OS" = "Darwin" ]; then
-  launchctl load "$HOME/Library/LaunchAgents/com.${SLUG}.dashboard.plist" 2>/dev/null || true
-  launchctl load "$HOME/Library/LaunchAgents/com.${SLUG}.channels.plist" 2>/dev/null || true
+  # `launchctl load` alone leaves a RunAtLoad job pended on modern macOS, so
+  # this script used to print the dashboard URL and "channel started" over two
+  # units that never ran. Same helper as install-macos.sh: load, kickstart,
+  # verify.
+  . "${INSTALL_DIR}/scripts/launchd-unit.sh"
+  for _svc in dashboard channels; do
+    if [ -z "$(start_launchd_unit "com.${SLUG}.${_svc}")" ]; then
+      LAUNCHD_FAILED="${LAUNCHD_FAILED}${_svc} "
+    fi
+  done
+  unset _svc
 elif [ "$OS" = "Linux" ]; then
   if pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
     systemctl --user start "${SLUG}-dashboard" "${SLUG}-channels"
@@ -64,5 +74,16 @@ elif [ "$OS" = "Linux" ]; then
   fi
 fi
 
+if [ -n "$LAUNCHD_FAILED" ]; then
+  # "nem igazolt", not "nem indult el", and no claim about what that means for
+  # the bot: this reports what the verification established, nothing beyond it.
+  echo "✗ A szolgaltatas indulasa nem igazolt: ${LAUNCHD_FAILED}" >&2
+  for _svc in $LAUNCHD_FAILED; do
+    echo "  Ujraprobalas: launchctl kickstart -p gui/$(id -u)/com.${SLUG}.${_svc}" >&2
+    echo "  Ellenorzes:   launchctl print gui/$(id -u)/com.${SLUG}.${_svc} | grep -E 'state|pid'" >&2
+  done
+  unset _svc
+  exit 1
+fi
 echo "✓ Dashboard: http://localhost:${WEB_PORT:-3420}"
 echo "$(_t start.channel_started)"

--- a/src/__tests__/installer-start-and-fallback.test.ts
+++ b/src/__tests__/installer-start-and-fallback.test.ts
@@ -49,6 +49,8 @@ function runScriptFile(lines: string[]): { out: string; code: number } {
 const ROOT = join(__dirname, '..', '..')
 const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
 const MACOS = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
+const HELPER = readFileSync(join(ROOT, 'scripts', 'launchd-unit.sh'), 'utf-8')
+const START = readFileSync(join(ROOT, 'scripts', 'start.sh'), 'utf-8')
 
 /** Pull one shell function out of a script so it can be executed for real. */
 function sliceShellFn(src: string, name: string): string {
@@ -222,7 +224,7 @@ describe('install-macos.sh -- launchd units must be verified, not assumed', () =
         `export PATH="${dir}:$PATH"`,
         'PLIST_DIR=/tmp',
         'LAUNCHD_START_TRIES=2',
-        sliceShellFn(MACOS, FN),
+        sliceShellFn(HELPER, FN),
         `printf 'PID=%s' "$(${FN} com.example.unit)"`,
       ].join('\n')
       const out = execFileSync('bash', ['-c', script], { encoding: 'utf-8' })
@@ -264,10 +266,10 @@ describe('install-macos.sh -- launchd units must be verified, not assumed', () =
     expect(() => runStart('pended')).not.toThrow()
   })
 
-  it('gates the success banner on the verified pids, not on the load call', () => {
-    const started = MACOS.indexOf(`${FN}() {`)
-    expect(started).toBeGreaterThan(0)
-    const tail = MACOS.slice(started)
+  it('install-macos.sh gates the success banner on the verified pids', () => {
+    const sourced = MACOS.indexOf('scripts/launchd-unit.sh')
+    expect(sourced).toBeGreaterThan(0)
+    const tail = MACOS.slice(sourced)
     // the old code printed this unconditionally, one line after `launchctl load`
     const banner = /Szolgaltatasok elinditva/.exec(tail)
     expect(banner).not.toBeNull()
@@ -277,10 +279,32 @@ describe('install-macos.sh -- launchd units must be verified, not assumed', () =
     // and there must be a loud else-branch for the failure the operator hit
     expect(tail.slice(banner!.index)).toMatch(/launchctl kickstart/)
   })
+
+  // scripts/start.sh carried the identical defect: measured live on 26.5.1 it
+  // printed "Dashboard: http://localhost:3420" and "Csatorna inditva" while
+  // `launchctl print` reported `state = not running` for BOTH units.
+  it('scripts/start.sh uses the same verified starter, not a bare load', () => {
+    expect(START).toContain('scripts/launchd-unit.sh')
+    expect(START).toMatch(new RegExp(`${FN}\\s`))
+    const bareLoad = START.split('\n').filter((l) => /^\s*launchctl load /.test(l))
+    expect(bareLoad).toEqual([])
+  })
+
+  it('scripts/start.sh refuses to report success when a unit did not come up', () => {
+    const banner = START.indexOf('✓ Dashboard: http://localhost')
+    expect(banner).toBeGreaterThan(0)
+    // the guard must come BEFORE the success line, and must not fall through
+    const before = START.slice(0, banner)
+    expect(before).toMatch(/if \[ -n "\$LAUNCHD_FAILED" \]/)
+    expect(before).toMatch(/exit 1/)
+  })
 })
 
-describe('both installers stay parseable', () => {
-  it.each(['install-linux.sh', 'install-macos.sh'])('bash -n %s', (f) => {
-    expect(() => execFileSync('bash', ['-n', join(ROOT, f)], { stdio: 'pipe' })).not.toThrow()
-  })
+describe('every touched shell entry point stays parseable', () => {
+  it.each(['install-linux.sh', 'install-macos.sh', 'scripts/start.sh', 'scripts/launchd-unit.sh'])(
+    'bash -n %s',
+    (f) => {
+      expect(() => execFileSync('bash', ['-n', join(ROOT, f)], { stdio: 'pipe' })).not.toThrow()
+    },
+  )
 })


### PR DESCRIPTION
Követő PR a #826-hoz. Ugyanaz a hiba, egy lefedetlen belépési ponton.

## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** A `scripts/start.sh` ugyanazt a hibát hordozta, amit a #826 az `install-macos.sh`-ban javított: `launchctl load ... 2>/dev/null || true`, majd feltétel nélküli siker-üzenet. Élesben mérve, macOS 26.5.1-en, közvetlenül egy ágváltás és újrabuildelés után:

```
$ ./scripts/start.sh
Marveen inditas...
✓ Dashboard: http://localhost:<port>
✓ Csatorna inditva

$ launchctl print gui/$UID/com.marveen.dashboard | grep state
    state = not running
$ launchctl print gui/$UID/com.marveen.channels  | grep state
    state = not running
```

Mindkét unit csak egy explicit `launchctl kickstart` után indult el. Vagyis az üzemeltető felé néző „indítsd újra" út pontosan ugyanúgy képes volt futó flottát jelenteni egy nem futó flotta felett, mint a telepítő.

A `start_launchd_unit()` átkerül a `scripts/launchd-unit.sh`-ba, hogy egy implementáció és egy helyen tárolt indoklás legyen belőle; az `install-macos.sh` és a `scripts/start.sh` is ezt tölti be. A helper biztonságosan `source`-olható `set -e` + kilépő ERR trap alatt futó scriptbe is — nincs benne olyan konstrukció, aminek az utolsó parancsa csupasz `cmd && cmd` lista lenne.

A `start.sh` hibaága a #826-ban elfogadott megfogalmazást követi: **„indulasa nem igazolt"**, nem „nem indult el", és nem állít semmit arról, hogy ez mit jelent a botra nézve — csak azt mondja ki, amit az ellenőrzés megállapított, és unitonként kiírja az újrapróbáló + ellenőrző parancsot. Siker helyett nem-nulla kóddal lép ki.

**EN.** `scripts/start.sh` carried the identical defect #826 fixed in `install-macos.sh`: a bare `launchctl load` followed by an unconditional success line, measured live printing success while both units read `state = not running`. `start_launchd_unit()` moves to `scripts/launchd-unit.sh` so both entry points share one implementation; `start.sh` now exits non-zero with per-unit repair commands, using the "indulasa nem igazolt" wording agreed in #826 rather than claiming an unverified consequence.

## Kapcsolódó issue / Related issue

Closes #825 harmadik pontjának lefedetlen része / the remaining entry point of item 3 in #825. Követi: #826.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch.

<sub>A 2. ponthoz: a `docs/` nem módosult, mert a telepítés menete és az architektúra változatlan — csak a meglévő lépések ellenőrzése került be. A helper `scripts/launchd-unit.sh` fejléce hordozza a méréseket. / `docs/` unchanged: the flow is the same, only its verification was added; the measurements live in the helper's header.</sub>
