### PR TITLE
fix(install): the cause line must claim only what was measured

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1208,12 +1208,17 @@ else
   # the very defect this block reports on.
   if [ -z "$DASHBOARD_PID" ]; then echo -e "    ${DIM}  - ${DASHBOARD_PLIST}: nem fut${NC}"; fi
   if [ -z "$CHANNELS_PID" ]; then echo -e "    ${DIM}  - ${CHANNELS_PLIST}: nem fut${NC}"; fi
-  # Reassurance BEFORE the technical cause. Whoever is installing for the first
-  # time needs three things from this screen, in this order: the install itself
-  # finished, nothing is lost, and there is something to do about it. The
-  # launchd sentence below is accurate but is an explanation, not an answer.
+  # Reassurance BEFORE the detail. Whoever is installing for the first time needs
+  # three things from this screen, in this order: the install itself finished,
+  # nothing is lost, and there is something to do about it.
   echo -e "    A telepites befejezodott. Ami nem indult el, azt fent latod, es a lentiekkel elindithatod."
-  echo -e "    ${DIM}A launchd betoltotte a unitokat, de nem inditotta el oket.${NC}"
+  # The detail line states only the two things this code actually knows: it wrote
+  # the plist files itself, and `launchctl print` reported no pid. It must NOT
+  # claim the units were loaded: in start_launchd_unit the whole
+  # bootstrap-or-load chain ends in `|| true`, and so does the kickstart, so no
+  # return value is ever inspected. "Loaded but not started" was a diagnosis
+  # nobody measured -- the same defect as the banner above it.
+  echo -e "    ${DIM}A unit-fajlok a helyukon vannak, de futo folyamatot nem talaltunk.${NC}"
   echo -e "    ${BOLD}Javitas most:${NC}"
   echo -e "    ${BLUE}launchctl kickstart -p gui/$(id -u)/${DASHBOARD_PLIST}${NC}"
   echo -e "    ${BLUE}launchctl kickstart -p gui/$(id -u)/${CHANNELS_PLIST}${NC}"


### PR DESCRIPTION
A telepítő hibaága egy olyan okot nevezett meg, amit soha nem mért meg. Ez a harmadik és utolsó példány ugyanabból a hibából ebben a blokkban; a bannert és a megnyugtató sort az előző PR javította.

## A mondat, ami nem volt igaz

```
A launchd betoltotte a unitokat, de nem inditotta el oket.
```

Egyik fele sem volt megállapítva. A `start_launchd_unit` függvényben a teljes bootstrap-vagy-load lánc `|| true`-ra végződik, és az utána következő kickstart is:

```sh
launchctl bootstrap "$_slu_domain" "$PLIST_DIR/${_slu_label}.plist" 2>/dev/null \
  || launchctl load "$PLIST_DIR/${_slu_label}.plist" 2>/dev/null \
  || true
launchctl kickstart "$_slu_domain/${_slu_label}" >/dev/null 2>&1 || true
```

Vagyis **egyetlen visszatérési értéket sem néz meg senki**. A szkript tehát ugyanannyira nem tudja, hogy a unitok betöltődtek, mint azt, hogy miért nem futnak. A "betöltötte, de nem indította el" egy **diagnózis volt, amit senki nem mért** -- kiírva pont azon a képernyőn, aminek az egész célja az, hogy a telepítő ne állítson ellenőrizetlen dolgokat.

## Amit helyette mond

```
A unit-fajlok a helyukon vannak, de futo folyamatot nem talaltunk.
```

Ez a két tény, amit a kód valóban birtokol: a plist fájlokat **ő maga írta ki**, és a `launchctl print` **nem adott vissza pid-et**.

Van egy második haszna is. A régi mondat egy konkrét mechanizmust állított, ami **nem minden gépen áll fenn**: a verifikáló gépen a `launchctl load` egy `RunAtLoad=true` agentet **azonnal elindít** (mérve: `state = running`, `runs = 1`, tíz másodperc múlva is). Az eredeti bejelentő gépén ugyanez `runs = 0`-t adott. Az új mondat mindkét esetben igaz, mert nem a mechanizmusról beszél, hanem a megfigyelésről.

## Mérés

- `bash -n install-macos.sh` és `bash -n install-linux.sh`: **OK** (valódi shell-parser)
- `src/__tests__/installer-start-and-fallback.test.ts`: **20 / 20 zöld**
- `tsc --noEmit`: exit 0
- A régi mondat a repóban: **nulla előfordulás**, mindkét telepítő-szkriptben
- Em dash a hozzáadott sorokon: nulla

Fogalmi keresés is történt, nem csak a mondatra: a `install-linux.sh` a `systemctl --user start` után `is-active`-val, a nohup-ágon `kill -0`-val **ellenőriz**, mielőtt sikert állítana, tehát ott ez a hiba nincs meg.
