### PR TITLE
fix(install): the green tick for enabling units must depend on the enable

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1691,7 +1691,13 @@ if pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; the
     ok "systemd unitok generalva es engedelyezve"
   else
     warn "A unit-fajlok elkeszultek, de az engedelyezesuk nem sikerult -- ujrainditas utan a szolgaltatasok nem indulnak el maguktol."
-    echo -e "  ${DIM}Javitas most: systemctl --user enable ${DASH_UNIT} ${CHAN_UNIT}${NC}"
+    # ALL FOUR units the enable above covers, not just the two services. A
+    # command that silently drops the timer and the watchdog would leave them
+    # disabled while the operator sees no error and believes the fix worked --
+    # an incomplete instruction ends the same way as a false claim.
+    echo -e "  ${DIM}Javitas most: systemctl --user enable \\${NC}"
+    echo -e "  ${DIM}    ${DASH_UNIT} ${CHAN_UNIT} \\${NC}"
+    echo -e "  ${DIM}    ${MORN_UNIT}.timer ${SERVICE_ID}-host-watchdog.service${NC}"
   fi
   systemctl --user start "${DASH_UNIT}" "${CHAN_UNIT}" 2>/dev/null || true
   sleep 2

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1682,8 +1682,17 @@ fi
 SVCFAIL=0
 if pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
   systemctl --user daemon-reload
-  systemctl --user enable "${DASH_UNIT}" "${CHAN_UNIT}" "${MORN_UNIT}.timer" "${SERVICE_ID}-host-watchdog.service" 2>/dev/null || true
-  ok "systemd unitok generalva es engedelyezve"
+  # The green tick used to print unconditionally after a `|| true`, so a failed
+  # enable was reported as success -- the visible version of the same defect the
+  # macOS branch had. `if` rather than `&&`: a failing enable inside an if
+  # CONDITION is exempt from errexit and from the ERR trap, so the installer
+  # reports it instead of dying on it.
+  if systemctl --user enable "${DASH_UNIT}" "${CHAN_UNIT}" "${MORN_UNIT}.timer" "${SERVICE_ID}-host-watchdog.service" 2>/dev/null; then
+    ok "systemd unitok generalva es engedelyezve"
+  else
+    warn "A unit-fajlok elkeszultek, de az engedelyezesuk nem sikerult -- ujrainditas utan a szolgaltatasok nem indulnak el maguktol."
+    echo -e "  ${DIM}Javitas most: systemctl --user enable ${DASH_UNIT} ${CHAN_UNIT}${NC}"
+  fi
   systemctl --user start "${DASH_UNIT}" "${CHAN_UNIT}" 2>/dev/null || true
   sleep 2
   for svc in "${DASH_UNIT}" "${CHAN_UNIT}"; do

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1695,7 +1695,15 @@ if pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; the
     # command that silently drops the timer and the watchdog would leave them
     # disabled while the operator sees no error and believes the fix worked --
     # an incomplete instruction ends the same way as a false claim.
-    echo -e "  ${DIM}Javitas most: systemctl --user enable \\${NC}"
+    # The label gets its own line. With "Javitas most:" in front of the command,
+    # the backslashes join all three printed lines into ONE command whose first
+    # token is `Javitas`, so a pasted block fails with "Javitas: command not
+    # found" and enables nothing. Measured by rendering the block and running it.
+    # `bash -n` does NOT catch this: the pasted text is valid shell, just a
+    # different command than the one we meant to offer. Same shape as
+    # install-macos.sh, where the label is already on its own line.
+    echo -e "  ${DIM}Javitas most:${NC}"
+    echo -e "  ${DIM}systemctl --user enable \\${NC}"
     echo -e "  ${DIM}    ${DASH_UNIT} ${CHAN_UNIT} \\${NC}"
     echo -e "  ${DIM}    ${MORN_UNIT}.timer ${SERVICE_ID}-host-watchdog.service${NC}"
   fi


### PR DESCRIPTION
A negyedik és utolsó példány ugyanabból a hibából, és a legláthatóbb: itt nem egy halvány magyarázó sor állított valótlant, hanem **maga a zöld pipa**.

## Ami volt

```sh
systemctl --user enable "${DASH_UNIT}" ... 2>/dev/null || true
ok "systemd unitok generalva es engedelyezve"
```

A `|| true` elnyeli az `enable` visszatérési értékét, a következő sor pedig **feltétel nélkül** kiírja a sikert. Ha az engedélyezés elszáll, a telepítő zöld pipával jelenti késznek -- és a következmény csak jóval később derül ki: a szolgáltatások **újraindítás után nem jönnek fel maguktól**.

## Ami lett

A pipa a siker-ágba került. A hibaágon a telepítő azt mondja, amit tud (a unit-fájlok elkészültek, az engedélyezésük nem sikerült), kimondja, hogy ez mibe kerül az üzemeltetőnek, és kiírja az egy parancsot, amivel javítható.

**`if`, nem `&&`.** Egy if-**feltételben** álló parancs mentesül az errexit és az ERR trap alól, tehát egy bukó `enable` jelentődik, nem pedig megöli a telepítőt. Ez nem feltételezés, hanem mérve:

```
$ bash -c 'set -e; trap "echo MEGHALNA; exit 1" ERR
           if false; then echo ok-ag; else echo "else-ag lefutott, a script EL"; fi
           echo "tovabb fut"'
else-ag lefutott, a script EL
tovabb fut
```

## A blokk többi része rendben van

Fogalmi kereséssel, nem a mondatra: a `Mindket szolgaltatas fut` sor `SVCFAIL`-hez van kötve, az pedig `is-active`-ból jön, a nohup-ág pedig `kill -0`-val ellenőriz, mielőtt pid-et állítana. Ezek mérnek, tehát nem tartoznak ebbe a hibaosztályba.

## Mérés

- `bash -n install-linux.sh` és `bash -n install-macos.sh`: **OK**
- `tsc --noEmit`: exit 0
- Teljes készlet: **227 fájl / 3144 teszt, nulla bukás**
- Em dash a hozzáadott sorokon: nulla

## Miért külön PR

A változtatás eredetileg a #829-re ment volna, de az addigra mergelődött az első committal, tehát ez a commit a már lezárt ágon maradt volna. Változatlan tartalommal került át egy friss `develop`-ról nyitott ágra.
