### PR TITLE
fix(heartbeat): the report is a measurement, not a memory

### DIFF
--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -208,6 +208,16 @@ When you receive the heartbeat prompt:
    - warnings: <none | comma-separated>
    \`\`\`
 
+   Every line above is a MEASUREMENT of this round, never a memory of
+   an earlier one. Run the queries again and report what they return
+   now, even when you are sure nothing changed -- especially then.
+   A warning belongs on that last line only if THIS round's query
+   still returns it: a card that has since become \`done\` or archived
+   drops off, and so does a deadline that has been closed. Carrying
+   one over makes the line constant, and a line that always says the
+   same thing stops being read -- at which point a real warning looks
+   exactly like the two dead ones next to it.
+
 3. **Send** that string to the main agent via the dashboard API:
 
    \`\`\`bash
@@ -235,6 +245,16 @@ When you receive the heartbeat prompt:
 - If a data source raises, record the failure reason in that
   section's body and CONTINUE -- partial output is fine, silence is
   not.
+- **NEVER** copy a value from an earlier round's report, and never
+  fill a field from what you remember saying last time. Every number,
+  title, timestamp and warning comes from a query you ran in THIS
+  round. If a query fails, say it failed -- do not substitute the
+  previous answer, because a stale value is indistinguishable from a
+  fresh one once it is in the message.
+  This applies to the whole report, not only to \`warnings\`: the
+  urgent titles, the task counts, \`next:\`, the DB size and the
+  one-hour hot-memory count are all measurements with a timestamp,
+  and every one of them is wrong the moment it is reused.
 
 ## You are headless
 


### PR DESCRIPTION
Két egymást követő heartbeat ugyanazt a két figyelmeztetést hozta -- `SMARTHAT730 deadline passed; TOKREVOKE730 part2 pending` -- miközben mindkét kártya `done` és rég lezárt. A `warnings` sor tehát megszűnt bármit is követni: minden órában ugyanazt mondta, és ez az az állapot, amelyben egy **valódi** figyelmeztetés láthatatlanná válik, mert pontosan úgy néz ki, mint a két halott mellette.

## Miért nem elég a kanban-lekérdezést javítani

A scaffold már eddig is szólt arról, hogy az `urgent`-de-`done` kártyákat ki kell hagyni. Ez nem segített, és az ok érdemi: **a beragadt figyelmeztetések nem a lekérdezésből jöttek**, hanem egy korábbi körből öröklődtek tovább. Egy olyan értékhez, ami sosem lekérdezésből származott, semmilyen lekérdezés-javítás nem ér el.

## Amit a prompt mostantól kimond

A jelentés minden sora **a mostani kör mérése**. Egy figyelmeztetés csak akkor kerülhet a sorba, ha **ennek a körnek** a lekérdezése is visszaadja; ami azóta `done` vagy archivált, kiesik. És a hard-rule-ok közé bekerült, hogy korábbi kör értékét átmásolni tilos, hibás lekérdezésnél pedig a hibát kell jelenteni, nem az előző választ.

**Az egész jelentésre kimondva, nem csak a `warnings`-ra.** Az urgent címek, a task-számok, a `next:`, a DB-méret és az egyórás hot-memória-szám mind időbélyeges mérés, és mindegyik hibássá válik abban a pillanatban, hogy újrahasznosítjuk. Ha csak azt a sort javítanánk, amelyik elromlott, ugyanez a hiba nyitva maradna az öt szomszédjának.

## Mérés

Nem a `.ts` fájlban kerestem a szöveget, hanem a **renderelt promptban** -- abban, amit az `ensureHeartbeatAgent()` a heartbeat ágens `CLAUDE.md`-jébe ír:

| állítás a renderelt prompton | |
|---|---|
| a „measurement of this round" kikötés benne van | OK |
| kimondja, hogy `done`/archivált kártya kiesik | OK |
| indokolja, miért (a konstans sor vaksághoz vezet) | OK |
| a hard-rule tiltja a korábbi körből másolást | OK |
| a fogalmat általánosítja, nem csak a `warnings`-ra | OK |
| nevesíti a többi átvihetőt is (`next:`, DB size) | OK |

`tsc --noEmit`: exit 0. Teljes készlet: **228 fájl / 3157 teszt, nulla bukás**. Em dash a hozzáadott sorokon: nulla.

## Ami ehhez tudni kell a hatályba lépésről

A `renderHeartbeatClaudeMd()` kimenetét egyedül az `ensureHeartbeatAgent()` írja ki, és azt **kizárólag a `src/index.ts` hívja, boot-kor**. A jelenlegi élő prompt fájl-ideje pontosan a futó dashboard indulási ideje. Vagyis ez a változás **nem lép hatályba magától**: kell hozzá deploy és egy dashboard-indulás, ami újraírja a prompt-fájlt.
