### PR TITLE
fix(settings): the restart badge described a state, not a property

### DIFF
--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1152,7 +1152,7 @@ window._i18n.en = {
   'settings.empty':			'No registered settings.',
   'settings.error':			'Failed to load settings.',
   'settings.loading':			'Loading...',
-  'settings.restart_badge':			'Restart required',
+  'settings.restart_badge':			'Takes effect after restart',
   'settings.save_btn.save':			'Save',
   'settings.save_btn.saving':			'Saving...',
   'tasks.agent_all':			'All agents',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1008,7 +1008,7 @@ window._i18n.hu = {
   'settings.loading':            'Betöltés...',
   'settings.empty':              'Nincs regisztrált beállítás.',
   'settings.error':              'Nem sikerült betölteni a beállításokat.',
-  'settings.restart_badge':      'Újraindítást igényel',
+  'settings.restart_badge':      'Újraindítás után lép életbe',
   'settings.save_btn.saving':    'Mentés...',
   'settings.save_btn.save':      'Mentés',
   'settings.btn.refresh':        'Frissítés',


### PR DESCRIPTION
Closes #836.

The `settings.restart_badge` label read as "a restart is pending right now", while the badge is actually a static property of the setting: it renders unconditionally from `def.requiresRestart` (`web/app.js:13488`), a boolean field of the config registry carried by nine keys. A fresh install therefore shows what looks like an outstanding chore before anything has been changed.

The genuine live signal already exists and works: `data.requiresRestart` from the save response (`web/app.js:13592`) lights up only when such a key was actually modified.

## Change

Copy only, two keys. No code, no render condition, no registry change.

| file | before | after |
|---|---|---|
| `web/lang/hu.js:1011` | Újraindítást igényel | Újraindítás után lép életbe |
| `web/lang/en.js:1155` | Restart required | Takes effect after restart |

## Why this is not cosmetic

The reporter restarted the services before looking into it. A channels restart drops the main agent's session, so misreading the badge has a real cost.

## Measurements

- Diff is exactly 2 files, 1 line each. `git diff --stat`: 2 insertions, 2 deletions.
- `node --check` passes on both language files.
- Hungarian value read back from disk with full accents: `Újraindítás után lép életbe`.
- Em/en dash on added lines: 0, checked with a Python scan whose positive control passes (a naive `grep` for these characters silently returns 0 in this shell).