### PR TITLE
fix(agents): an MCP server added later never reached existing isolated config dirs

### DIFF
--- a/src/__tests__/isolated-config-mcp-reconcile.test.ts
+++ b/src/__tests__/isolated-config-mcp-reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, readdirSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, readdirSync, chmodSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -116,6 +116,39 @@ describe('isolated config dir: mcpServers reconcile', () => {
     expect(after.projects).toEqual({ '/some/path': { hasTrustDialogAccepted: true } })
     expect(after.hasCompletedOnboarding).toBe(true)
     expect(Object.keys(after.mcpServers as object).sort()).toEqual(['extra', 'gmail'])
+  })
+
+  it('keeps an 0600 config at 0600 across a reconcile', () => {
+    // tmp + rename replaces the inode, so without an explicit mode the new file
+    // takes the umask default and a 0600 config silently relaxes to 0644. The
+    // mcpServers entries carry env blocks with credentials, and this reconcile
+    // is the path that rewrites the file regularly.
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    chmodSync(isolatedDotClaude(), 0o600)
+    expect(statSync(isolatedDotClaude()).mode & 0o777).toBe(0o600)
+
+    writeShared({ gmail: { command: 'npx', args: ['gmail-mcp'] }, 'google-drive': { command: 'npx' } })
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+
+    // The reconcile really did run (otherwise the mode assertion proves nothing).
+    expect(Object.keys(servers()).sort()).toEqual(['gmail', 'google-drive'])
+    expect(statSync(isolatedDotClaude()).mode & 0o777).toBe(0o600)
+  })
+
+  it('preserves a deliberately wider mode too, rather than forcing 0600', () => {
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    chmodSync(isolatedDotClaude(), 0o644)
+    writeShared({ gmail: { command: 'npx', args: ['gmail-mcp'] }, extra: { command: 'x' } })
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    expect(Object.keys(servers()).sort()).toEqual(['extra', 'gmail'])
+    expect(statSync(isolatedDotClaude()).mode & 0o777).toBe(0o644)
+  })
+
+  it('creates a brand new isolated config owner-only, not at the umask default', () => {
+    // First provision: no target existed, so the fallback decides. It must be
+    // 0600 rather than whatever the umask happens to be on the host.
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    expect(statSync(isolatedDotClaude()).mode & 0o777).toBe(0o600)
   })
 
   it('leaves no staging file behind (atomic write)', () => {

--- a/src/__tests__/isolated-config-mcp-reconcile.test.ts
+++ b/src/__tests__/isolated-config-mcp-reconcile.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Same sandbox shape as isolated-channel-config.test.ts: homedir() and
+// agentDir() are redirected into a throwaway temp tree, so nothing here can
+// read or write the real ~/.claude of the machine running the suite.
+let SANDBOX = ''
+vi.mock('node:os', async (orig) => {
+  const actual = await orig<typeof import('node:os')>()
+  return { ...actual, homedir: () => join(SANDBOX, 'home') }
+})
+vi.mock('../web/agent-config.js', async (orig) => {
+  const actual = await orig<typeof import('../web/agent-config.js')>()
+  return { ...actual, agentDir: (name: string) => join(SANDBOX, 'agents', name) }
+})
+
+const { ensureIsolatedChannelConfigDir } = await import('../web/agent-process.js')
+
+const AGENT = 'testagent'
+
+function sharedDotClaude(): string { return join(SANDBOX, 'home', '.claude.json') }
+function isolatedDotClaude(): string {
+  return join(SANDBOX, 'agents', AGENT, '.claude-config', '.claude.json')
+}
+function writeShared(servers: Record<string, unknown>): void {
+  writeFileSync(sharedDotClaude(), JSON.stringify({ hasCompletedOnboarding: true, mcpServers: servers }, null, 2))
+}
+function readIsolated(): Record<string, unknown> {
+  return JSON.parse(readFileSync(isolatedDotClaude(), 'utf-8')) as Record<string, unknown>
+}
+function servers(): Record<string, unknown> {
+  return (readIsolated().mcpServers ?? {}) as Record<string, unknown>
+}
+
+beforeEach(() => {
+  SANDBOX = mkdtempSync(join(tmpdir(), 'mcpseed-'))
+  const claude = join(SANDBOX, 'home', '.claude')
+  mkdirSync(claude, { recursive: true })
+  writeFileSync(join(claude, 'settings.json'), JSON.stringify({ enabledPlugins: {} }))
+  mkdirSync(join(SANDBOX, 'agents', AGENT), { recursive: true })
+  writeShared({ gmail: { command: 'npx', args: ['gmail-mcp'] } })
+})
+afterEach(() => { rmSync(SANDBOX, { recursive: true, force: true }) })
+
+describe('isolated config dir: mcpServers reconcile', () => {
+  it('propagates a server added to the shared config AFTER the dir was provisioned', () => {
+    // First provision: the isolated dir is seeded from the shared config.
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    expect(Object.keys(servers())).toEqual(['gmail'])
+
+    // The operator adds a second server to the shared config, as when rolling
+    // one out to a running fleet.
+    writeShared({
+      gmail: { command: 'npx', args: ['gmail-mcp'] },
+      'google-drive': { command: 'npx', args: ['gdrive-mcp'] },
+    })
+
+    // Re-provision, i.e. the agent restarts. THIS is the regression from #834:
+    // before the fix the new server never arrived here.
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    expect(Object.keys(servers()).sort()).toEqual(['gmail', 'google-drive'])
+    expect(servers()['google-drive']).toEqual({ command: 'npx', args: ['gdrive-mcp'] })
+  })
+
+  it('never overwrites an entry that already exists in the isolated config', () => {
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+
+    // Claude Code (or a deliberate per-agent scoping decision) evolves the
+    // entry: same key, different definition.
+    const cur = readIsolated()
+    cur.mcpServers = { gmail: { command: 'npx', args: ['gmail-mcp'], env: { SCOPE: 'agent-local' } } }
+    writeFileSync(isolatedDotClaude(), JSON.stringify(cur, null, 2))
+
+    // The shared config still carries its own, different definition of `gmail`.
+    writeShared({
+      gmail: { command: 'npx', args: ['gmail-mcp'] },
+      'google-drive': { command: 'npx', args: ['gdrive-mcp'] },
+    })
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+
+    // The evolved entry survives untouched, and the genuinely missing one is added.
+    expect(servers().gmail).toEqual({ command: 'npx', args: ['gmail-mcp'], env: { SCOPE: 'agent-local' } })
+    expect(servers()['google-drive']).toEqual({ command: 'npx', args: ['gdrive-mcp'] })
+  })
+
+  it('leaves a server removed from the shared config in place (additive only)', () => {
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    writeShared({})
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    expect(Object.keys(servers())).toEqual(['gmail'])
+  })
+
+  it('does not touch a non-object mcpServers instead of repairing it', () => {
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    const cur = readIsolated()
+    cur.mcpServers = 'corrupted-by-something-else'
+    writeFileSync(isolatedDotClaude(), JSON.stringify(cur, null, 2))
+
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    expect(readIsolated().mcpServers).toBe('corrupted-by-something-else')
+  })
+
+  it('preserves unrelated keys and keeps hasCompletedOnboarding set', () => {
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    const cur = readIsolated()
+    cur.projects = { '/some/path': { hasTrustDialogAccepted: true } }
+    cur.hasCompletedOnboarding = false
+    writeFileSync(isolatedDotClaude(), JSON.stringify(cur, null, 2))
+
+    writeShared({ gmail: { command: 'npx', args: ['gmail-mcp'] }, extra: { command: 'x' } })
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+
+    const after = readIsolated()
+    expect(after.projects).toEqual({ '/some/path': { hasTrustDialogAccepted: true } })
+    expect(after.hasCompletedOnboarding).toBe(true)
+    expect(Object.keys(after.mcpServers as object).sort()).toEqual(['extra', 'gmail'])
+  })
+
+  it('leaves no staging file behind (atomic write)', () => {
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    writeShared({ gmail: { command: 'npx', args: ['gmail-mcp'] }, extra: { command: 'x' } })
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+
+    const stray = readdirSync(join(SANDBOX, 'agents', AGENT, '.claude-config'))
+      .filter((f) => f.includes('.tmp-'))
+    expect(stray).toEqual([])
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, lstatSync, symlinkSync, rmSync, realpathSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, lstatSync, symlinkSync, rmSync, realpathSync, renameSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync, execFileSync } from 'node:child_process'
@@ -372,6 +372,67 @@ export function resolveMainAgentConfigDir(): string | null {
 // two can never diverge. `cfg` is the isolated CLAUDE_CONFIG_DIR to create; `cwd`
 // is the agent's project dir stamped into its own installed_plugins.json; `name`
 // is used for logs only.
+// Write JSON through a temp file + rename, so a Claude Code process reading
+// the file concurrently sees either the old content or the new one, never a
+// half-written one. The temp name carries the pid so two provisions racing on
+// the same dir cannot truncate each other's staging file.
+function writeJsonAtomic(path: string, value: unknown): void {
+  const tmp = `${path}.tmp-${process.pid}`
+  writeFileSync(tmp, JSON.stringify(value, null, 2) + '\n')
+  renameSync(tmp, path)
+}
+
+// Fill mcpServers gaps in an ALREADY provisioned isolated .claude.json from the
+// shared ~/.claude.json.
+//
+// Why this exists (issue #834): the isolated .claude.json is seeded from a full
+// copy of the shared one ONLY on first provision. Every later spawn just makes
+// sure hasCompletedOnboarding stays set, so the server list is frozen at its
+// first-seed snapshot -- an MCP server added to ~/.claude.json afterwards
+// reaches brand-new agents but never an existing one, silently: the agent just
+// lacks the tool, with no error anywhere. Rolling one out to a running fleet
+// then needs a manual per-agent backfill, and that only fixes the current set.
+//
+// ADDITIVE ONLY, deliberately. This is a gap-fill, not a two-way sync:
+//   - a server missing from the isolated file is copied in,
+//   - an entry that already exists is NEVER overwritten -- Claude Code owns its
+//     evolved state, and a per-agent scoping decision must survive,
+//   - a server removed from the shared config is left in place,
+//   - a non-object mcpServers on either side means we do not touch it at all,
+//     because we cannot merge what we do not understand.
+// Returns true if the caller should persist `cur`.
+function reconcileMcpServers(
+  cur: Record<string, unknown>,
+  sharedDot: string,
+  name: string,
+): boolean {
+  if (!existsSync(sharedDot)) return false
+  let shared: Record<string, unknown>
+  try { shared = JSON.parse(readFileSync(sharedDot, 'utf-8')) as Record<string, unknown> }
+  catch { return false } // unparseable shared config -> leave the isolated one alone
+  if (!isPlainObject(shared.mcpServers)) return false
+  // An existing but non-object mcpServers is not ours to repair.
+  if ('mcpServers' in cur && !isPlainObject(cur.mcpServers)) {
+    logger.warn({ name }, 'isolated-config: mcpServers is not an object, skipping reconcile')
+    return false
+  }
+  const own = isPlainObject(cur.mcpServers) ? cur.mcpServers : {}
+  const added: string[] = []
+  for (const [key, def] of Object.entries(shared.mcpServers)) {
+    if (key in own) continue
+    own[key] = def
+    added.push(key)
+  }
+  if (added.length === 0) return false
+  cur.mcpServers = own
+  logger.info({ name, added }, 'isolated-config: added missing MCP servers from the shared config')
+  return true
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
 function provisionIsolatedConfigDir(
   cfg: string,
   cwd: string,
@@ -490,14 +551,17 @@ function provisionIsolatedConfigDir(
           try { seed = JSON.parse(readFileSync(sharedDot, 'utf-8')) as Record<string, unknown> } catch { /* keep minimal */ }
         }
         seed.hasCompletedOnboarding = true
-        writeFileSync(dotClaude, JSON.stringify(seed, null, 2) + '\n')
+        writeJsonAtomic(dotClaude, seed)
       } else {
         try {
           const cur = JSON.parse(readFileSync(dotClaude, 'utf-8')) as Record<string, unknown>
+          let dirty = false
           if (cur.hasCompletedOnboarding !== true) {
             cur.hasCompletedOnboarding = true
-            writeFileSync(dotClaude, JSON.stringify(cur, null, 2) + '\n')
+            dirty = true
           }
+          if (reconcileMcpServers(cur, sharedDot, name)) dirty = true
+          if (dirty) writeJsonAtomic(dotClaude, cur)
         } catch { /* unparseable -> leave for Claude Code to recreate */ }
       }
     } catch (err) {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, lstatSync, symlinkSync, rmSync, realpathSync, renameSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, lstatSync, symlinkSync, rmSync, realpathSync, renameSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync, execFileSync } from 'node:child_process'
@@ -376,9 +376,20 @@ export function resolveMainAgentConfigDir(): string | null {
 // the file concurrently sees either the old content or the new one, never a
 // half-written one. The temp name carries the pid so two provisions racing on
 // the same dir cannot truncate each other's staging file.
+//
+// The mode is carried over deliberately. A plain writeFileSync writes THROUGH
+// the existing inode and keeps its permissions; tmp + rename replaces the file
+// with a NEW inode, which would silently take the umask default and relax an
+// 0600 config to 0644. That matters here: some isolated .claude.json files are
+// 0600, and their mcpServers entries carry env blocks with credentials -- and
+// this reconcile is exactly the path that starts rewriting the file regularly.
+// Fall back to 0600 (not the umask) when the target does not exist yet, since
+// the content class is the same either way.
 function writeJsonAtomic(path: string, value: unknown): void {
+  let mode = 0o600
+  try { mode = statSync(path).mode & 0o777 } catch { /* new file -> owner-only */ }
   const tmp = `${path}.tmp-${process.pid}`
-  writeFileSync(tmp, JSON.stringify(value, null, 2) + '\n')
+  writeFileSync(tmp, JSON.stringify(value, null, 2) + '\n', { mode })
   renameSync(tmp, path)
 }
 


### PR DESCRIPTION
Closes #834.

`provisionIsolatedConfigDir` seeded the isolated `.claude.json` from a full copy of the shared `~/.claude.json` **only when the file was absent**. On every later spawn it touched that file solely to keep `hasCompletedOnboarding` set, so `mcpServers` stayed frozen at its first-seed snapshot. A server added to `~/.claude.json` afterwards reached brand-new agents and no existing one, silently: a missing server produces no error, the tool simply never appears in that agent's list.

This is not theoretical for us. It is what happened when the google-drive MCP server was rolled out across the running fleet: a manual per-agent backfill worked, but only for the set as it stood that day.

## Change

Provision now gap-fills `mcpServers` additively, and the writes go through temp file + `rename`.

Deliberately one-way:

- a server missing from the isolated file is copied in;
- an entry that already exists is **never** overwritten, so Claude Code's evolved state and any per-agent scoping decision survive;
- a server removed from the shared config is left in place;
- a non-object `mcpServers` on either side is not touched at all, because we cannot merge what we do not understand.

## Measurements

Everything below runs in a `mkdtemp` sandbox with `homedir()` and `agentDir()` redirected into it. No live fleet agent and no real `~/.claude` is read or written by the tests.

**Positive control first — the bug is real on the current code.** The new test file was run against the *unfixed* `agent-process.ts` before measuring the fix. Exactly the three propagation assertions fail:

```
× propagates a server added to the shared config AFTER the dir was provisioned
× never overwrites an entry that already exists in the isolated config
× preserves unrelated keys and keeps hasCompletedOnboarding set
Tests  3 failed | 3 passed (6)
```

Worth stating plainly: the other three still pass on the unfixed code, and that is not a contradiction. The old code wrote nothing, so "additive only" and "does not touch a corrupt value" hold trivially. They only become evidence of an implemented guarantee when they pass *together with* propagation, which is the state after the fix.

**The no-overwrite guarantee is shown, not asserted from the code.** The test hand-writes an evolved `gmail` entry (`env: { SCOPE: 'agent-local' }`) into the target file, puts a different `gmail` definition plus a genuinely new server in the shared config, re-provisions, and reads the target back: the evolved entry is byte-identical afterwards and only `google-drive` was added.

**Everything else:**

- New tests: 6 passed on the fixed code.
- Adjacent existing suites (`isolated-channel-config`, `main-agent-isolated-config`, `main-agent-config-dir`, `claude-config-dir`): 72 passed.
- Full suite: 229 files, 3163 tests, all passing.
- `tsc --noEmit`: clean.
- Em/en dash on added lines: 0, with a positive control confirming the scanner detects one when present.
- Atomicity is covered by an assertion that no `.tmp-*` staging file survives a provision.

## Not covered

The tests exercise the reconcile through `ensureIsolatedChannelConfigDir`, the real entry point, but they do not launch an actual Claude Code process. That a newly propagated server then appears in that agent's tool list is inherited from how the config file is consumed and is not measured here.