### PR TITLE
fix(install): every default install was wired to the rotating shared credential

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -914,6 +914,14 @@ env_keep_or_set() {
   if [ -z "$2" ] && [ -n "$_eks_existing" ]; then return 0; fi
   env_merge_key "$1" "$2"
 }
+env_set_if_absent() {
+  # env_set_if_absent KEY VALUE -- write only when the KEY line does not exist
+  # at all. Used for a default the installer proposes rather than enforces: an
+  # operator who deliberately set KEY=0 keeps that decision across re-runs, and
+  # an explicitly set KEY=1 is not rewritten either.
+  if grep -q "^$1=" "$INSTALL_DIR/.env" 2>/dev/null; then return 0; fi
+  env_merge_key "$1" "$2"
+}
 (umask 077 && touch "$INSTALL_DIR/.env")
 chmod 600 "$INSTALL_DIR/.env"
 [ -s "$INSTALL_DIR/.env" ] || printf '# Main agent konfiguracio\n' >> "$INSTALL_DIR/.env"
@@ -959,6 +967,21 @@ if [ -n "${OAUTH_TOKEN_INPUT:-}" ] && printf '%s' "$OAUTH_TOKEN_INPUT" | grep -E
   mkdir -p "$INSTALL_DIR/store"
   (umask 077 && printf '%s' "$OAUTH_TOKEN_INPUT" > "$INSTALL_DIR/store/.claude-oauth-token")
   ok "Fleet setup-token eltarolva (store/.claude-oauth-token) -- per-agent izolacio aktiv"
+  # Point the MAIN agent at an isolated config dir too, not just the
+  # sub-agents. Without this the main bot keeps the shared ~/.claude and
+  # authenticates from whatever refreshes that root -- on Linux the shared
+  # ~/.claude/.credentials.json -- which periodically expires and 401s the bot
+  # into a parked TUI that the router reads as busy, so the channel goes silent
+  # with no error (the confirmed root cause of the 2026-07-23 marveen-channels
+  # outage). The setting existed but nothing ever turned it on, so every
+  # default install was wired to that failure mode.
+  #
+  # Only in THIS branch, i.e. only when the installer just captured the fleet
+  # token itself in this same run: the operator handed it over moments ago, so
+  # the identity the main bot will run under is not a surprise. An install that
+  # already carried auth keeps whatever it had. env_set_if_absent, so a
+  # deliberate MAIN_AGENT_ISOLATED_CONFIG=0 stands.
+  env_set_if_absent MAIN_AGENT_ISOLATED_CONFIG 1
 fi
 ok ".env letrehozva (chmod 600)"
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -583,6 +583,14 @@ env_keep_or_set() {
   if [ -z "$2" ] && [ -n "$_eks_existing" ]; then return 0; fi
   env_merge_key "$1" "$2"
 }
+env_set_if_absent() {
+  # env_set_if_absent KEY VALUE -- write only when the KEY line does not exist
+  # at all. Used for a default the installer proposes rather than enforces: an
+  # operator who deliberately set KEY=0 keeps that decision across re-runs, and
+  # an explicitly set KEY=1 is not rewritten either.
+  if grep -q "^$1=" "$INSTALL_DIR/.env" 2>/dev/null; then return 0; fi
+  env_merge_key "$1" "$2"
+}
 (umask 077 && touch "$INSTALL_DIR/.env")
 chmod 600 "$INSTALL_DIR/.env"
 [ -s "$INSTALL_DIR/.env" ] || printf '# Main agent konfiguracio\n' >> "$INSTALL_DIR/.env"
@@ -621,6 +629,21 @@ if [ -n "${MACOS_OAUTH_TOKEN_INPUT:-}" ]; then
   if printf '%s' "$MACOS_OAUTH_TOKEN_INPUT" | grep -Eq '^sk-ant-oat01-[A-Za-z0-9_-]{40,}$'; then
     (umask 077 && printf '%s' "$MACOS_OAUTH_TOKEN_INPUT" > "$INSTALL_DIR/store/.claude-oauth-token")
     ok "Fleet setup-token eltarolva (store/.claude-oauth-token) -- per-agent izolacio aktiv"
+    # Point the MAIN agent at an isolated config dir too, not just the
+    # sub-agents. Without this the main bot keeps the shared ~/.claude and
+    # authenticates from whatever refreshes that root -- the ROTATING macOS
+    # Keychain OAuth session -- which periodically expires and 401s the bot
+    # into a parked TUI that the router reads as busy, so the channel goes
+    # silent with no error (the confirmed root cause of the 2026-07-23
+    # marveen-channels outage). The setting existed but nothing ever turned
+    # it on, so every default install was wired to that failure mode.
+    #
+    # Only in THIS branch, i.e. only when the installer just captured the
+    # fleet token itself in this same run: the operator handed it over
+    # moments ago, so the identity the main bot will run under is not a
+    # surprise. An install that already carried auth keeps whatever it had.
+    # env_set_if_absent, so a deliberate MAIN_AGENT_ISOLATED_CONFIG=0 stands.
+    env_set_if_absent MAIN_AGENT_ISOLATED_CONFIG 1
   fi
 fi
 

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -382,6 +382,26 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
   # Surface it at START time instead: a failures-log line plus a best-effort
   # inter-agent message to the main agent. Installs that never ran isolated have
   # no .channels-config dir and stay quiet, so default setups see no new noise.
+  # Second trigger, and the one that covers a FRESH install. The condition above
+  # needs a .channels-config dir, which only exists once an isolated boot has
+  # already happened -- so on an install that NEVER ran isolated the guard was
+  # structurally silent, which is exactly the install shape issue #835 is about.
+  # A fleet setup-token with an empty resolution is suspicious on its own: the
+  # token is the thing isolation is gated on, so carrying one and still landing
+  # on the shared ~/.claude means the setting is missing, not that isolation was
+  # declined. Installs with no fleet token at all stay quiet, as before.
+  if [ -z "$CFG_ENV" ] && [ ! -d "$INSTALL_DIR/.channels-config" ] && [ -s "$INSTALL_DIR/store/.claude-oauth-token" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: WARN main-agent starting on SHARED ~/.claude although a fleet setup-token exists (store/.claude-oauth-token) -- MAIN_AGENT_ISOLATED_CONFIG is unset, so the main bot authenticates from the rotating shared credential and can 401 into a silent channel." >> "$INSTALL_DIR/store/channels-failures.log"
+    if [ -f "$INSTALL_DIR/store/.dashboard-token" ]; then
+      _guard_port="$(grep -E '^WEB_PORT=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
+      curl -s --max-time 5 -X POST "http://localhost:${_guard_port:-3420}/api/messages" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $(cat "$INSTALL_DIR/store/.dashboard-token")" \
+        -d "{\"from\":\"channels-sh-guard\",\"to\":\"${MAIN_AGENT_ID:-marveen}\",\"content\":\"[GUARD] A fo agens a KOZOS ~/.claude alol indult, pedig van flotta setup-token (store/.claude-oauth-token). A MAIN_AGENT_ISOLATED_CONFIG nincs beallitva, ezert az auth a rotalodo megosztott credentialbol megy: ez lejarhat, 401-be all a TUI, es a csatorna NEMAN elerhetetlen lesz. Teendo: MAIN_AGENT_ISOLATED_CONFIG=1 beallitasa, majd channels session restart.\"}" \
+        >/dev/null 2>&1 || true
+      unset _guard_port
+    fi
+  fi
   if [ -z "$CFG_ENV" ] && [ -d "$INSTALL_DIR/.channels-config" ]; then
     echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: WARN main-agent starting on SHARED ~/.claude although isolated dir $INSTALL_DIR/.channels-config exists -- MAIN_AGENT_ISOLATED_CONFIG resolution came back empty (overrides/.env key lost?). Auth rides the rotating shared session and can 401." >> "$INSTALL_DIR/store/channels-failures.log"
     if [ -f "$INSTALL_DIR/store/.dashboard-token" ]; then


### PR DESCRIPTION
Addresses #835.

## Merged

The owner gave the GO ("mehet alapbol") for new installs to get this by default. Merged after the verify below. Follow-up #841 corrects a comment this change made false.

## What was wrong

`MAIN_AGENT_ISOLATED_CONFIG` has existed for a while and nothing ever set it. Both installers mention the key exactly once each, in a comment, as an example of an "operator-added key" (`install-macos.sh:567`, `install-linux.sh:898`). On a default install the main agent therefore kept the shared `~/.claude` and authenticated from whatever refreshes that root: the rotating macOS Keychain session, or the shared `.credentials.json` on Linux. Both expire. When they do the agent parks on a 401 TUI that the router reads as busy, so the channel goes silent with no error anywhere. `scripts/main-agent-isolated-config.mjs` and `src/web/agent-process.ts:305` already name this as the confirmed root cause of the 2026-07-23 outage.

The reporter titled this as macOS, but the gap is in both installers. On Linux the rotating source is the shared `.credentials.json`, which the same header documents as expiring.

Not a theoretical fix: this host has run in isolated mode since 2026-07-22 (`.env` + `config-overrides.json`), and the main agent has been in that mode for the last ten days.

## What changed

**1. The installers propose the setting, once, in the right branch.** `env_set_if_absent MAIN_AGENT_ISOLATED_CONFIG 1` is called only inside the branch where the installer just wrote the fleet setup-token itself in this same run. Then the identity the main bot runs under is the one the operator handed over moments earlier. An install that already carried auth (the "already carries an auth key" path) never reaches this branch and keeps whatever it had.

**2. A new `env_set_if_absent` helper**, identical text in both installers: it writes only when the key line is absent, so a deliberate `MAIN_AGENT_ISOLATED_CONFIG=0` survives a re-run and an existing `=1` is not duplicated.

**3. The start-time guard gets a second trigger.** The existing one requires a `.channels-config` dir, which only exists after an isolated boot has already happened — so on an install that never ran isolated it was structurally silent, which is exactly the install shape this issue is about. The new trigger fires when a fleet token exists but the resolution came back empty; that combination is suspicious on its own, because the token is what isolation is gated on. Installs with no fleet token stay quiet, so existing default setups get no new noise.

## Measurements

**`env_set_if_absent`, tested on the shipped text.** The function body was extracted from `install-macos.sh` with `sed` and sourced, rather than retyped into the test — the first version of this check re-declared the function by hand, which would have measured my transcription instead of the file.

```
A absent      -> MAIN_AGENT_ISOLATED_CONFIG=1
B explicit 0  -> MAIN_AGENT_ISOLATED_CONFIG=0   (deliberate 0 stands)
C already 1   -> 1 line, unrelated keys kept    (no duplicate)
```

The `env_set_if_absent` block is byte-identical in both installers (`diff` of the two extracted bodies is empty).

**Guard condition truth table**, and the condition string used in the test was byte-compared against the shipped line at `scripts/channels.sh:393` before drawing conclusions:

```
cfgdir=no  token=yes -> FIRES     (fresh install, setting missing: the case #835 is about)
cfgdir=no  token=no  -> silent    (no fleet token: no new noise)
cfgdir=yes token=yes -> silent    (existing guard's territory)
cfgdir=yes token=no  -> silent
```

**Everything else:** `bash -n` clean on all three files; full suite 228 files / 3157 tests passing; em/en dash on added lines 0, with a positive control confirming the scanner detects one when present.

## Not measured

No end-to-end fresh install was run on a clean machine. The behaviour is verified at the level of the helper, the branch it sits in, and the guard condition — not by watching a real installer run write the key and a main agent then boot isolated. If that is wanted before merge, it needs a throwaway host.