### PR TITLE
docs(channels): the guard comment promised a quiet default that no longer holds

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -380,8 +380,10 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
   # shared credential session, which is exactly how the 2026-07-27 evening 401
   # outage started and was only noticed hours later when the owner got no replies.
   # Surface it at START time instead: a failures-log line plus a best-effort
-  # inter-agent message to the main agent. Installs that never ran isolated have
-  # no .channels-config dir and stay quiet, so default setups see no new noise.
+  # inter-agent message to the main agent. THIS trigger needs the dir, so it
+  # stays quiet on an install that never ran isolated -- which is why the second
+  # trigger below exists. What is quiet overall is an install carrying no fleet
+  # setup-token: neither trigger fires there.
   # Second trigger, and the one that covers a FRESH install. The condition above
   # needs a .channels-config dir, which only exists once an isolated boot has
   # already happened -- so on an install that NEVER ran isolated the guard was


### PR DESCRIPTION
A #839 (merge `c421914b`) második guard-triggert adott hozzá, ami friss telepítésen is megszólal, ha van flotta setup-token de üres a `MAIN_AGENT_ISOLATED_CONFIG`. Ezzel viszont hamissá vált a fölötte álló, korábbi komment zárómondata:

> Installs that never ran isolated have no .channels-config dir and stay quiet, so default setups see no new noise.

Ez a mondat mostantól pont azokra a telepítésekre nem igaz, amelyek flotta-tokent hordoznak: ők kapnak failures-log sort és inter-agent üzenetet. Ami valóban néma marad, az a token nélküli telepítés.

A javítás az első trigger saját feltételét mondja ki egy általános ígéret helyett, hogy a következő olvasó ne egy megszűnt garanciát olvasson ki belőle.

Csak komment, viselkedés nem változik, `bash -n` tiszta. Azért külön PR, mert a #839 már mergelve volt, mire a review odaért (keresztező üzenetek), a mergelt ág pedig halott.
