### PR TITLE
docs(channels): the guard comment claimed a silence the code no longer has

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -373,23 +373,22 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
     fi
     echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: main-agent $_cfg_mode CLAUDE_CONFIG_DIR=$_cfg_dir" >> "$INSTALL_DIR/store/channels-failures.log"
   fi
-  # LOUD REGRESSION GUARD: an isolated main-agent config dir on disk (provisioned
-  # by an earlier isolated boot) combined with THIS boot resolving to the shared
-  # ~/.claude means the isolation setting was lost -- e.g. store/config-overrides.json
-  # deleted with no .env key backing it. The silent fallback rides the rotating
-  # shared credential session, which is exactly how the 2026-07-27 evening 401
-  # outage started and was only noticed hours later when the owner got no replies.
-  # Surface it at START time instead: a failures-log line plus a best-effort
-  # inter-agent message to the main agent. Installs that never ran isolated have
-  # no .channels-config dir and stay quiet, so default setups see no new noise.
-  # Second trigger, and the one that covers a FRESH install. The condition above
-  # needs a .channels-config dir, which only exists once an isolated boot has
-  # already happened -- so on an install that NEVER ran isolated the guard was
-  # structurally silent, which is exactly the install shape issue #835 is about.
-  # A fleet setup-token with an empty resolution is suspicious on its own: the
-  # token is the thing isolation is gated on, so carrying one and still landing
-  # on the shared ~/.claude means the setting is missing, not that isolation was
-  # declined. Installs with no fleet token at all stay quiet, as before.
+  # LOUD REGRESSION GUARD, in two triggers. Both mean the same thing: this boot
+  # resolved to the shared ~/.claude, so the main agent rides the rotating
+  # shared credential session -- exactly how the 2026-07-27 evening 401 outage
+  # started, unnoticed for hours because the owner simply got no replies. Both
+  # surface it at START time: a failures-log line plus a best-effort inter-agent
+  # message. Measured, not assumed: the only combination silent on BOTH is an
+  # install that never ran isolated AND carries no fleet setup-token -- which is
+  # the plain default setup, so that one still sees no new noise. Note trigger 2
+  # does fire without a token when the .channels-config dir is there, which is
+  # correct: that dir means isolation once worked here.
+  #
+  # Trigger 1 (below): a FRESH install. A fleet setup-token exists while the
+  # resolution came back empty. The token is the thing isolation is gated on, so
+  # carrying one and still landing on the shared root means the setting is
+  # missing, not that isolation was declined. This is the shape issue #835 is
+  # about, and trigger 2 is structurally blind to it.
   if [ -z "$CFG_ENV" ] && [ ! -d "$INSTALL_DIR/.channels-config" ] && [ -s "$INSTALL_DIR/store/.claude-oauth-token" ]; then
     echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: WARN main-agent starting on SHARED ~/.claude although a fleet setup-token exists (store/.claude-oauth-token) -- MAIN_AGENT_ISOLATED_CONFIG is unset, so the main bot authenticates from the rotating shared credential and can 401 into a silent channel." >> "$INSTALL_DIR/store/channels-failures.log"
     if [ -f "$INSTALL_DIR/store/.dashboard-token" ]; then
@@ -402,6 +401,11 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
       unset _guard_port
     fi
   fi
+  # Trigger 2 (below): an install that HAS run isolated before. Its
+  # .channels-config dir is still on disk, yet this boot resolved to the shared
+  # root -- so the isolation setting was LOST, e.g. store/config-overrides.json
+  # deleted with no .env key backing it. Needing that dir is what makes this
+  # trigger blind on a fresh install, hence trigger 1.
   if [ -z "$CFG_ENV" ] && [ -d "$INSTALL_DIR/.channels-config" ]; then
     echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: WARN main-agent starting on SHARED ~/.claude although isolated dir $INSTALL_DIR/.channels-config exists -- MAIN_AGENT_ISOLATED_CONFIG resolution came back empty (overrides/.env key lost?). Auth rides the rotating shared session and can 401." >> "$INSTALL_DIR/store/channels-failures.log"
     if [ -f "$INSTALL_DIR/store/.dashboard-token" ]; then


### PR DESCRIPTION
Follow-up to #839, which is already merged (`c421914`), so the review nit lands as its own PR.

## What was wrong

Adding the fresh-install trigger made the last sentence of the existing comment false:

> Installs that never ran isolated have no `.channels-config` dir and stay quiet, so default setups see no new noise.

That no longer holds for an install carrying a fleet setup-token, which is exactly the case the new trigger exists to catch.

**Measuring it turned up a second, larger problem the wording hid.** The new block had been inserted *between* the `LOUD REGRESSION GUARD` comment and the `if` it describes, so that comment sat above someone else's condition. A reader would have matched the wrong text to the wrong guard. Each trigger now carries its own comment directly above its own `if`.

**The replacement claim was wrong on the first attempt as well.** I wrote "an install with no fleet setup-token stays quiet on both". The sweep says otherwise: trigger 2 fires without a token whenever `.channels-config` is present — and that is correct behaviour, because the dir means isolation once worked on this install. The comment now states what the measurement shows.

## Measurements

Per-guard, each block extracted from the shipped file and run against a throwaway `INSTALL_DIR`:

```
trigger 1 (fresh install)     cfgdir=no  token=no  -> 0
                              cfgdir=yes token=no  -> 0
                              cfgdir=no  token=yes -> 1   <- the #835 shape
                              cfgdir=yes token=yes -> 0

trigger 2 (lost setting)      cfgdir=no  token=no  -> 0
                              cfgdir=yes token=no  -> 1
                              cfgdir=no  token=yes -> 0
                              cfgdir=yes token=yes -> 1
```

Combined, the only silent-on-both combination is `cfgdir=no, token=no` — the plain default setup. That is what the comment now says, and nothing more.

`bash -n` clean. Em/en dash on added lines: 0. Comment-only change; no condition, no message text, no behaviour is touched.

## A note on the harness

The first two sweeps I ran were broken and both produced all-zeros, which looks exactly like "everything is silent". The first passed a multi-line block through `bash -c` inside a command substitution and executed nothing; the second attributed both guards' output to one log without checking that each block contained its own `if`. Neither number was used. The table above comes from the third run, where each extracted block is confirmed to carry exactly one condition and is executed from a file.