### PR TITLE
fix(agents): stop the tmux session on delete so no orphan ghost returns

### DIFF
--- a/src/__tests__/agent-delete-stops-session.test.ts
+++ b/src/__tests__/agent-delete-stops-session.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Reported by a user, 2026-08-01. They deleted a RUNNING agent from the
+// dashboard; its card vanished from /api/agents, but minutes later the agent
+// "returned" as an empty draft (CLAUDE.md and SOUL.md both empty) that still
+// showed running=true, with the model reset to the default.
+//
+// Cause: the DELETE /api/agents/:name handler removed the agent directory
+// (rmSync) and cleaned team references, but never stopped the running tmux
+// session. The orphaned session survived the delete, and -- because a live
+// Claude Code session rewrites its own config dir -- it recreated a minimal
+// .claude-config under agents/<name>/. That partial dir made the name "known"
+// again: no persona files -> draft, live session -> running=true, and the model
+// fell back to the default because the real agent-config.json was gone.
+//
+// Fix: stop the session BEFORE removing the dir. stopAgentProcess() reads config
+// from the dir (remote host, channel provider) for its orphan reap, so the order
+// matters -- stop while the dir still exists, then rmSync.
+//
+// Source-level assertions, matching the idiom of
+// agent-create-no-destructive-rollback.test.ts: the handler is an HTTP route that
+// drives tmux and touches the live agents directory, so a runtime harness would
+// either mock the very thing under test or risk killing a real fleet session.
+// What must be guaranteed is a property of the code path, and that is asserted.
+
+const SRC = join(import.meta.dirname, '..')
+const FILE = 'web/routes/agents.ts'
+
+function read(): string {
+  return readFileSync(join(SRC, FILE), 'utf8')
+}
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+// The DELETE handler body: from the method match to just past its success path.
+function deleteHandlerBody(code: string): string {
+  const start = code.indexOf("agentMatch && method === 'DELETE'")
+  expect(start, 'DELETE agent handler not found').toBeGreaterThan(-1)
+  const teamIdx = code.indexOf('cleanupTeamReferences(name)', start)
+  expect(teamIdx, 'cleanupTeamReferences not found in DELETE handler').toBeGreaterThan(start)
+  const end = code.indexOf('return true', teamIdx)
+  expect(end, 'DELETE handler end not found').toBeGreaterThan(teamIdx)
+  return code.slice(start, end)
+}
+
+describe('deleting an agent stops its running session (no orphan ghost)', () => {
+  it('the delete handler stops the session before removing the dir', () => {
+    const body = deleteHandlerBody(stripComments(read()))
+    const stopIdx = body.indexOf('stopAgentProcess(')
+    const rmIdx = body.indexOf('rmSync(')
+    // THE load-bearing assertion. On the pre-fix code stopAgentProcess is absent
+    // from the handler and this goes red.
+    expect(stopIdx, 'DELETE handler must call stopAgentProcess').toBeGreaterThan(-1)
+    expect(rmIdx, 'DELETE handler must rmSync the dir').toBeGreaterThan(-1)
+    // Order matters: stopAgentProcess reads config from the dir, so it must run
+    // BEFORE rmSync removes it.
+    expect(stopIdx, 'stopAgentProcess must run before rmSync').toBeLessThan(rmIdx)
+  })
+
+  it('the stop is guarded by isAgentRunning', () => {
+    const body = deleteHandlerBody(stripComments(read()))
+    expect(body).toMatch(/isAgentRunning\(/)
+  })
+})

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -2077,6 +2077,13 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const name = decodeURIComponent(agentMatch[1])
     const dir = agentDir(name)
     if (!existsSync(dir)) { json(res, { error: 'Agent not found' }, 404); return true }
+    // Stop the running tmux session BEFORE removing the dir. Otherwise the
+    // orphaned session survives the delete, rewrites a minimal .claude-config
+    // under agents/<name>/, and the agent "returns" as an empty draft (persona
+    // gone) that still reports running=true, with the model reset to the default.
+    // stopAgentProcess() reads config from the dir (remote host, channel
+    // provider) for its orphan reap, so it must run while the dir still exists.
+    if (isAgentRunning(name)) stopAgentProcess(name)
     rmSync(dir, { recursive: true, force: true })
     cleanupTeamReferences(name)
     json(res, { ok: true })


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A `DELETE /api/agents/:name` (a dashboard "Törlés" gombja) eddig csak eltávolította az ágens mappáját (`rmSync`) és kitakarította a team-hivatkozásokat, de a futó tmux sessiont **nem** állította le. Ha egy FUTÓ ágenst töröltél, az árva session túlélte a törlést, és mivel egy élő Claude Code session újraírja a saját config-mappáját, újragyártott egy minimális `.claude-config`-ot az `agents/<name>/` alatt. Ettől a név újra "ismertté" vált: persona fájlok nélkül `draft`, élő sessionnel `running=true`, a modell pedig a defaultra esett vissza (mert az igazi `agent-config.json` törlődött). Így az ágens üres `CLAUDE.md`/`SOUL.md`-vel "visszatért".

Javítás: a mappa törlése **előtt** `stopAgentProcess(name)` leállítja a sessiont, ha fut. A sorrend számít: a `stopAgentProcess()` a mappából olvas configot (remote host, channel provider) az orphan-reaphez, ezért előbb `stop`, aztán `rmSync`.

**EN:** `DELETE /api/agents/:name` (the dashboard "Delete" button) only removed the agent directory (`rmSync`) and cleaned team references, but never stopped the running tmux session. Deleting a RUNNING agent left the session orphaned; because a live Claude Code session rewrites its own config dir, it recreated a minimal `.claude-config` under `agents/<name>/`. That made the name "known" again: no persona files means `draft`, a live session means `running=true`, and the model reset to the default (the real `agent-config.json` was gone). The agent "returned" with empty `CLAUDE.md`/`SOUL.md`.

Fix: stop the session before removing the dir when the agent is running. Order matters: `stopAgentProcess()` reads dir config (remote host, channel provider) for its orphan reap, so stop-then-`rmSync`.

**Teszt / Test:** új forrás-szintű teszt (`src/__tests__/agent-delete-stops-session.test.ts`) a meglévő `agent-create-no-destructive-rollback.test.ts` idiómája szerint (a handler valós tmux-ot vezérel és az élő flottát érinti, ezért a kód-útvonal tulajdonságát ellenőrizzük, nem futtatunk runtime harness-t). RED a javítás előtt (a handlerben nincs `stopAgentProcess`), GREEN utána.

## Kapcsolódó issue / Related issue

Nincs külön issue, Telegramon jelentett hiba. / No separate issue, reported via Telegram.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. — Az automata teszt-suite-tal igazoltam (RED→GREEN, 61 agent-teszt zöld, `tsc --noEmit` tiszta), **nem** éles dashboard-törléssel: az élesítés (dist rebuild + szolgáltatás-restart) függőben, a frissítés a normál update-úton jön vissza. / Verified via the automated test suite (RED→GREEN, 61 agent tests green, clean typecheck), **not** via a live dashboard delete: deployment (dist rebuild + service restart) is pending.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. — Nem érinti, viselkedésbeli hibajavítás. / Not affected, behavioral bug fix.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (`fix/delete-stops-session`), nem közvetlenül `develop`-ra. / Opened from an own, descriptively named branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
