### PR TITLE
fix(parked input): a front-truncated tick is unrecognisable, and clearing it deleted in the wrong direction

### DIFF
--- a/src/__tests__/parked-clear-sequence.test.ts
+++ b/src/__tests__/parked-clear-sequence.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parkedClearSequence } from '../pane-state.js'
+
+// 2026-08-01, measured on a wedged MAIN pane that had accumulated 489 characters
+// of scheduled-task text over 7 visible rows.
+//
+// The old sequence was `C-u` x3, then `C-a` + `C-k`, then `C-u` x3 again, and it
+// removed NOTHING across repeated runs. The reason is the cursor position: a
+// literal string sent with tmux send-keys lands in FRONT of the parked text
+//
+//     before:  len=489  "the user if it looks wrong. The wrapper marks prov"
+//     +MARKER: len=498  "MARKER123the user if it looks wrong. The wrapper m"
+//     after C-u: len=489 "the user if it looks wrong. The wrapper marks prov"
+//
+// so the cursor sits at OFFSET 0. `C-u` kills BACKWARDS to the start of the
+// line, finds nothing before the cursor, and is a no-op on every round -- it
+// only ever removed the marker that had just been typed in front of it. The
+// single `C-a` + `C-k` escalation then clears exactly ONE line, so a multi-line
+// box could never be emptied: with PARKED_CLEAR_MAX = 3 the whole cascade could
+// remove at most one line and then failed its own verification.
+//
+// Forward deletion drains it: `C-k` kills to end of line, `Delete` eats the
+// newline joining the next one. The live box took 20 such rounds to reach zero.
+
+const ROOT = join(__dirname, '..', '..')
+const AGENT_PROCESS = readFileSync(join(ROOT, 'src', 'web', 'agent-process.ts'), 'utf-8')
+
+describe('parkedClearSequence', () => {
+  it('starts at the beginning of the buffer so the first kill has something ahead of it', () => {
+    expect(parkedClearSequence(1)[0]).toBe('C-a')
+  })
+
+  it('deletes FORWARD -- C-u is a no-op with the cursor at offset 0', () => {
+    const seq = parkedClearSequence(7)
+    expect(seq).toContain('C-k')
+    expect(seq).toContain('Delete')
+    expect(seq).not.toContain('C-u')
+  })
+
+  it('pairs every kill with a newline-eating Delete', () => {
+    const seq = parkedClearSequence(4)
+    expect(seq.filter((k) => k === 'C-k').length).toBe(seq.filter((k) => k === 'Delete').length)
+  })
+
+  it('scales past the measured need: a 7-row box drained in 20 rounds', () => {
+    expect(parkedClearSequence(7).filter((k) => k === 'C-k').length).toBeGreaterThanOrEqual(20)
+  })
+
+  it('keeps a workable floor for a single-row box', () => {
+    expect(parkedClearSequence(1).filter((k) => k === 'C-k').length).toBeGreaterThanOrEqual(8)
+  })
+
+  it('never returns an unbounded sequence for an absurd row count', () => {
+    expect(parkedClearSequence(9999).length).toBeLessThan(600)
+  })
+})
+
+describe('clearStaleParkedInput uses the sequence instead of the old C-u cascade', () => {
+  // Source-level: the function drives real tmux against a live session, so the
+  // behaviour that matters is which keystrokes it emits, not what tmux does.
+  it('drives its keystrokes from parkedClearSequence', () => {
+    expect(AGENT_PROCESS).toContain('parkedClearSequence')
+  })
+
+  it('no longer sends a bare C-u round anywhere in the module', () => {
+    const offenders = AGENT_PROCESS.split('\n')
+      .map((line, i) => ({ line, n: i + 1 }))
+      .filter(({ line }) => /send-keys'[^\n]*'C-u'/.test(line))
+      .map(({ n }) => n)
+    expect(offenders).toEqual([])
+  })
+
+  // The pre-flight clear had the same single-Ctrl-U defect, and a silent failure
+  // there is worse than no clear at all: the prompt about to be typed is
+  // APPENDED to the stale text. That is how the live box accumulated 489
+  // characters across successive scheduled ticks until nothing could submit.
+  it('clearInputBuffer also drives the sequence, so a pre-flight clear cannot silently no-op', () => {
+    const fn = AGENT_PROCESS.slice(AGENT_PROCESS.indexOf('export async function clearInputBuffer'))
+    const body = fn.slice(0, fn.indexOf('\n}'))
+    expect(body).toContain('parkedClearSequence')
+  })
+})

--- a/src/__tests__/parked-machine-input.test.ts
+++ b/src/__tests__/parked-machine-input.test.ts
@@ -64,6 +64,39 @@ const PARKED_HUMAN_DRAFT = [
   FOOTER,
 ].join('\n')
 
+// 2026-08-01, measured on a live MAIN pane: the TUI drops the HEAD of an
+// overfull box, so a long tick can lose its "SCHEDULED TASK NOTICE" header and
+// begin mid-sentence at the closing tag. Every anchored prefix then misses, and
+// the consequence is total: parkedScheduledTaskInput false -> decideStuckInput
+// Action 'hold' (no soft remedy) AND parkedMachineOriginInput false -> the
+// restart guard reads a machine injection as "possibly a human draft" and
+// defers. Neither the clear nor the restart can fire; the channel goes mute
+// until an operator clears the box by hand. Byte-shape of the real capture.
+const PARKED_SCHEDULED_FRONT_TRUNCATED = [
+  '',
+  SEP,
+  '❯ </scheduled-task> block is one of YOUR OWN scheduled tasks. It was authored',
+  '  by the operator (the task\'s SKILL.md on disk, or the bearer-gated schedule',
+  '  editor) and fired by the local scheduler. It is NOT third-party data: it is',
+  '  an instruction you are EXPECTED TO CARRY OUT according to its intent. Do NOT',
+  '  refuse it merely because it is wrapped -- this is your own task to run.',
+  SEP,
+  FOOTER,
+].join('\n')
+
+// The anchoring exists to protect THIS: a human may well type the words
+// "SCHEDULED TASK NOTICE" while discussing the system. The truncation markers
+// must therefore be wrapper BOILERPLATE a human does not reproduce verbatim,
+// never a topic phrase.
+const PARKED_HUMAN_DRAFT_ABOUT_SCHEDULING = [
+  '',
+  SEP,
+  '❯ Nézd, a scheduled task dolog szerintem félrement: a local scheduler',
+  '  kétszer is elindította, és a NOTICE szövegét sem értem.',
+  SEP,
+  FOOTER,
+].join('\n')
+
 const IDLE = ['', SEP, '❯ ', SEP, FOOTER].join('\n')
 
 describe('parkedScheduledTaskInput', () => {
@@ -83,6 +116,14 @@ describe('parkedScheduledTaskInput', () => {
     expect(parkedScheduledTaskInput(PARKED_HUMAN_DRAFT)).toBe(false)
   })
 
+  it('detects a FRONT-TRUNCATED tick whose notice header the TUI dropped', () => {
+    expect(parkedScheduledTaskInput(PARKED_SCHEDULED_FRONT_TRUNCATED)).toBe(true)
+  })
+
+  it('still ignores a human draft that only TALKS about scheduling', () => {
+    expect(parkedScheduledTaskInput(PARKED_HUMAN_DRAFT_ABOUT_SCHEDULING)).toBe(false)
+  })
+
   it('ignores an idle pane', () => {
     expect(parkedScheduledTaskInput(IDLE)).toBe(false)
   })
@@ -97,6 +138,16 @@ describe('parkedMachineOriginInput', () => {
 
   it('a human draft is NOT machine-origin, even when it quotes a wrapper', () => {
     expect(parkedMachineOriginInput(PARKED_HUMAN_DRAFT)).toBe(false)
+  })
+
+  it('recognises a FRONT-TRUNCATED tick as machine-origin', () => {
+    // Without this the restart guard reads machineOrigin=false and defers the
+    // hard restart as "possibly a human draft" -- the second half of the mute.
+    expect(parkedMachineOriginInput(PARKED_SCHEDULED_FRONT_TRUNCATED)).toBe(true)
+  })
+
+  it('a human draft that only TALKS about scheduling is still not machine-origin', () => {
+    expect(parkedMachineOriginInput(PARKED_HUMAN_DRAFT_ABOUT_SCHEDULING)).toBe(false)
   })
 
   it('an idle pane parks nothing', () => {
@@ -119,5 +170,11 @@ describe('parkedMainInputHasRemedy', () => {
 
   it('a multi-row human draft has no remedy either -- but the carve-out never restarts it (machineOrigin=false)', () => {
     expect(parkedMainInputHasRemedy(PARKED_HUMAN_DRAFT)).toBe(false)
+  })
+
+  it('a FRONT-TRUNCATED tick has the same clear-only remedy as an intact one', () => {
+    // This is the fact that decides between a self-healing clear and a
+    // permanently mute channel.
+    expect(parkedMainInputHasRemedy(PARKED_SCHEDULED_FRONT_TRUNCATED)).toBe(true)
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1179,12 +1179,36 @@ const MACHINE_ORIGIN_PREFIXES = [
   /^<channel\s+source="plugin:/,
 ] as const
 
+// A long injection can lose its HEAD: the TUI drops the leading rows of an
+// overfull input box, so every anchored prefix above misses while unmistakable
+// wrapper text survives further in. Measured 2026-08-01 on a live MAIN pane
+// whose box began mid-sentence at "</scheduled-task> block is one of YOUR OWN
+// scheduled tasks." -- and the consequence was total: parkedScheduledTaskInput
+// read false so decideStuckInputAction fell through to 'hold' (no soft remedy),
+// AND parkedMachineOriginInput read false so the restart guard treated a
+// machine injection as "possibly a human draft" and deferred. Neither the clear
+// nor the restart could fire; the channel stayed mute until the box was cleared
+// by hand.
+//
+// These markers must stay BOILERPLATE a human does not reproduce verbatim --
+// wrapper syntax and the scheduler's own fixed sentences, never a topic phrase
+// like "SCHEDULED TASK NOTICE", which someone may legitimately type while
+// discussing the system. That distinction is why the list above is anchored and
+// this one is not; the human-draft fixtures in parked-machine-input.test.ts
+// guard it.
+const MACHINE_ORIGIN_TRUNCATED_MARKERS = [
+  /<\/scheduled-task>/,
+  /is one of YOUR OWN scheduled tasks/,
+  /fired by the local scheduler/,
+] as const
+
 // True when the live input box holds parked ('typing') text that is
 // identifiably machine-injected (see MACHINE_ORIGIN_PREFIXES). Pure.
 export function parkedMachineOriginInput(pane: string): boolean {
   const flat = parkedInputText(pane)
   if (flat == null) return false
   return MACHINE_ORIGIN_PREFIXES.some((rx) => rx.test(flat))
+    || MACHINE_ORIGIN_TRUNCATED_MARKERS.some((rx) => rx.test(flat))
 }
 
 // True when the parked text is a scheduled-task injection (the scheduler's
@@ -1197,7 +1221,11 @@ export function parkedMachineOriginInput(pane: string): boolean {
 export function parkedScheduledTaskInput(pane: string): boolean {
   const flat = parkedInputText(pane)
   if (flat == null) return false
-  return /^SCHEDULED TASK NOTICE/.test(flat) || /^<scheduled-task[\s>]/.test(flat)
+  if (/^SCHEDULED TASK NOTICE/.test(flat) || /^<scheduled-task[\s>]/.test(flat)) return true
+  // Head dropped by the TUI -- see MACHINE_ORIGIN_TRUNCATED_MARKERS. Clear-only
+  // is exactly as safe here as for an intact tick: the instruction is already
+  // corrupted by the truncation, and the next schedule fire re-delivers it.
+  return MACHINE_ORIGIN_TRUNCATED_MARKERS.some((rx) => rx.test(flat))
 }
 
 // How many VISUAL rows the live input box content occupies, ignoring the

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1228,6 +1228,46 @@ export function parkedScheduledTaskInput(pane: string): boolean {
   return MACHINE_ORIGIN_TRUNCATED_MARKERS.some((rx) => rx.test(flat))
 }
 
+// Keystrokes that actually EMPTY a parked input box.
+//
+// Measured 2026-08-01 on a wedged MAIN pane holding 489 characters over 7
+// visible rows. The previous cascade (`C-u` x3, then `C-a` + `C-k`, then `C-u`
+// x3) removed nothing at all across repeated runs, and the cursor position is
+// why: a literal string sent with tmux send-keys lands in FRONT of the parked
+// text, so the cursor sits at OFFSET 0.
+//
+//   before      len=489  "the user if it looks wrong. The wrapper marks prov"
+//   +MARKER123  len=498  "MARKER123the user if it looks wrong. The wrapper m"
+//   after C-u   len=489  "the user if it looks wrong. The wrapper marks prov"
+//
+// `C-u` kills BACKWARDS to the start of the line. With nothing before the
+// cursor it is a no-op every round -- it only ever removed a marker typed in
+// front of it. The lone `C-a` + `C-k` escalation clears exactly ONE line, so
+// with PARKED_CLEAR_MAX = 3 the whole cascade could strip at most one line off
+// a multi-line box and then failed its own emptiness check.
+//
+// Forward deletion is what drains it: `C-k` kills to end of line and `Delete`
+// eats the newline joining the next one. The live box needed 20 such rounds, so
+// the budget scales with the visible row count (the buffer is usually longer
+// than the box shows) and is clamped at both ends: a floor for a single-row box
+// whose buffer still wraps, and a ceiling so a bogus row count cannot turn into
+// an unbounded keystroke storm against a live session.
+const PARKED_CLEAR_ROUNDS_PER_ROW = 4
+const PARKED_CLEAR_ROUNDS_MIN = 12
+const PARKED_CLEAR_ROUNDS_MAX = 240
+
+export function parkedClearSequence(rowCount: number): string[] {
+  const rounds = Math.min(
+    PARKED_CLEAR_ROUNDS_MAX,
+    Math.max(PARKED_CLEAR_ROUNDS_MIN, Math.max(0, rowCount) * PARKED_CLEAR_ROUNDS_PER_ROW),
+  )
+  // Home first: the first kill must start at the beginning even when the cursor
+  // was left mid-buffer by an earlier attempt.
+  const keys = ['C-a']
+  for (let i = 0; i < rounds; i++) keys.push('C-k', 'Delete')
+  return keys
+}
+
 // How many VISUAL rows the live input box content occupies, ignoring the
 // bare prompt glyph and blank padding. The caller uses this to choose the
 // right submit keystroke: a MULTI-row parked input must NOT be submitted with

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -12,6 +12,8 @@ import {
   detectsPastePlaceholder,
   detectPaneState,
   parkedInputText,
+  parkedInputRowCount,
+  parkedClearSequence,
   stripGhostSuggestion,
   paneShowsContextSaturation,
   idleConsideringDimGhost,
@@ -1623,14 +1625,22 @@ export async function waitForPaneIdle(
   }
 }
 
-// Buffer-clear (Ctrl-U) used pre-flight when shouldClearTruncatedPreamble
-// flags a stale preamble. Sent as a single key name (no `-l` literal
-// flag) so tmux interprets it as the control sequence.
+// Pre-flight buffer clear, used when shouldClearTruncatedPreamble flags a stale
+// preamble. This used to send a single Ctrl-U, which is a no-op whenever the
+// cursor sits at offset 0 of the buffer -- the normal state for text that
+// arrived via send-keys (see parkedClearSequence). A failed pre-flight clear is
+// worse than none: the prompt about to be typed is APPENDED to the stale text
+// instead of replacing it, which is how a box accumulates tick after tick until
+// nothing can be submitted at all. Keys are sent by name (no `-l` literal flag)
+// so tmux interprets them as control sequences.
 export async function clearInputBuffer(session: string, host: string | null = null): Promise<void> {
   try {
-    runTmux(host, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
+    const pane = capturePane(session, host)
+    for (const key of parkedClearSequence(pane != null ? parkedInputRowCount(pane) : 0)) {
+      runTmux(host, ['send-keys', '-t', session, key], { timeout: 5000 })
+    }
     // Settle briefly so the next send-keys lands in the freshly cleared
-    // buffer rather than racing the Ctrl-U.
+    // buffer rather than racing the clear.
     await delay(100)
   } catch (err) {
     logger.warn({ err, session }, 'Failed to clear pane input buffer before send')
@@ -1947,10 +1957,13 @@ export async function isSessionReadyForPrompt(session: string, host: string | nu
 // the input box is STUCK (stale) vs being actively typed. Identical parked text
 // across this gap means nobody is typing -> it is a stranded artifact.
 const PARKED_STABLE_CONFIRM_MS = 2000
-// Settle after a Ctrl-U so the next capture reflects the cleared box.
+// Settle after a batch of clearing keystrokes so the next capture reflects the
+// emptied box.
 const PARKED_CLEAR_SETTLE_MS = 300
-// Bound the Ctrl-U presses for a (possibly multi-line) stale parked input.
-const PARKED_CLEAR_MAX = 3
+// How often to re-capture while working through parkedClearSequence(): often
+// enough that a box which empties early stops right away, rarely enough that the
+// settle delay is not paid per keystroke.
+const PARKED_CLEAR_RECHECK_EVERY = 8
 // A parked input that resists clearing must NOT be retried on every router tick:
 // each attempt awaits ~PARKED_STABLE_CONFIRM_MS on the settle
 // delay, so a permanently-stuck box would otherwise starve the loop, stall the HTTP server
@@ -2025,26 +2038,22 @@ export async function clearStaleParkedInput(session: string, host: string | null
     return false
   }
 
-  for (let i = 0; i < PARKED_CLEAR_MAX; i++) {
-    runTmux(host, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
-    await delay(PARKED_CLEAR_SETTLE_MS)
-    const after = capturePane(session, host)
-    if (after == null || detectPaneState(after) !== 'typing') break
-  }
-
-  // Escalation: if Ctrl-U alone did not empty a multi-row box, send Home (C-a)
-  // then kill-to-end (C-k) and one more Ctrl-U round before giving up.
-  let post = capturePane(session, host)
-  if (post != null && detectPaneState(post) === 'typing' && parkedInputText(post) === parked) {
-    runTmux(host, ['send-keys', '-t', session, 'C-a'], { timeout: 5000 })
-    runTmux(host, ['send-keys', '-t', session, 'C-k'], { timeout: 5000 })
-    for (let i = 0; i < PARKED_CLEAR_MAX; i++) {
-      runTmux(host, ['send-keys', '-t', session, 'C-u'], { timeout: 5000 })
+  // Forward deletion, budgeted by the visible row count -- see the rationale and
+  // the 2026-08-01 measurement above parkedClearSequence(). The cursor sits at
+  // offset 0 of the buffer, so the previous Ctrl-U rounds were no-ops and the
+  // single C-a + C-k escalation could only ever strip ONE line off a multi-line
+  // box. Re-check every few keystrokes so a box that empties early stops
+  // immediately instead of spending the whole budget.
+  const sequence = parkedClearSequence(parkedInputRowCount(a))
+  for (let i = 0; i < sequence.length; i++) {
+    runTmux(host, ['send-keys', '-t', session, sequence[i]], { timeout: 5000 })
+    if (i % PARKED_CLEAR_RECHECK_EVERY === PARKED_CLEAR_RECHECK_EVERY - 1) {
       await delay(PARKED_CLEAR_SETTLE_MS)
-      post = capturePane(session, host)
-      if (post == null || detectPaneState(post) !== 'typing') break
+      const after = capturePane(session, host)
+      if (after == null || detectPaneState(after) !== 'typing') break
     }
   }
+  await delay(PARKED_CLEAR_SETTLE_MS)
 
   // Verify the box is ACTUALLY empty before claiming success: only then is the
   // pending message safe to deliver next tick. Otherwise record the failure so


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** Élő macOS-telepítésen a fő ügynök **több mint egy órán át néma volt**, parkolt többsoros ütemezett feladattal a promptján — és a recovery-verem egyetlen ága sem tudott lépni.

A TUI levágja a túlcsordult input-box **elejét**, így a tick elvesztette a `SCHEDULED TASK NOTICE` fejlécét, és a box mondat közepén kezdődött:

```
❯ </scheduled-task> block is one of YOUR OWN scheduled tasks. It was authored
  by the operator (the task's SKILL.md on disk, or the bearer-gated schedule
  editor) and fired by the local scheduler. ...
```

A `MACHINE_ORIGIN_PREFIXES` és a `parkedScheduledTaskInput` minden mintája `^`-horgonyos, tehát mindkettő elvétette — és a két tévesztés **összeadódik**:

| detektor | eredmény | következmény |
|---|---|---|
| `parkedScheduledTaskInput` | `false` | a `decideStuckInputAction` átesik a `scheduledTaskBlock` ágon a **`hold`**-ra: nincs lágy remedy |
| `parkedMachineOriginInput` | `false` | az `applyStuckRestartBusyGuard` `machineOrigin=false`-t lát, és „lehet emberi piszkozat" címén **elhalasztja a kemény restartot** |

Se takarítás, se újraindítás. A fő ügynök boxát tervezetten soha nem tisztítja automatika, így a csatorna néma marad, amíg valaki kézzel ki nem törli — ez a 2026-07-25-i hermes-kimenetel, csak másik ajtón át.

Mért tények a valódi panelen, előtte/utána:

```
scheduledTaskBlock   false -> true
machineOrigin        false -> true
decideStuckInputAction  hold -> clear-scheduled
parkedMainInputHasRemedy false -> true
```

**A horgonyzás szándékos, és marad.** Egy ember simán leírhatja azt, hogy „SCHEDULED TASK NOTICE", miközben a rendszerről beszél — erre van a meglévő `PARKED_HUMAN_DRAFT` fixture. Az új, horgony nélküli jelölők ezért kizárólag olyan **wrapper-boilerplate**, amit ember nem ír le szó szerint: a záró tag és a scheduler saját preambulumának két rögzített mondata. Új fixture is került be, ami azt őrzi, hogy egy ütemezésről *beszélgető* emberi piszkozat továbbra se tick, se machine-origin.

A clear-only egy csonkolt ticknél pontosan olyan biztonságos, mint egy épnél: az utasítást a csonkolás már megrontotta, a következő ütemezés pedig újra kézbesíti.

**EN.** On a live macOS install the main agent stayed mute for over an hour with a parked multi-row scheduled tick, because the TUI dropped the head of the overfull box and every `^`-anchored pattern missed. The two misses compound: `parkedScheduledTaskInput` false sends `decideStuckInputAction` to `hold` (no soft remedy), and `parkedMachineOriginInput` false makes the restart guard defer as "possibly a human draft" — so neither the clear nor the restart can fire, and the main box is never auto-cleared by design. The fix adds unanchored markers that are wrapper boilerplate only (the closing tag and two fixed preamble sentences), never a topic phrase a human might type; the existing and one new human-draft fixture guard that line.

## Kapcsolódó issue / Related issue

Closes #

Ugyanaz a kimenetel, mint a 2026-07-25-i hermes-eset, más csonkolással. / Same outcome as the 2026-07-25 hermes incident, reached by a different truncation.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally; the fixed detectors were run against the actual wedged pane on the affected machine (table above).
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch.

<sub>A 2. ponthoz: a `docs/` nem módosult — se a telepítés menete, se az architektúra nem változik, csak két detektor felismerési tartománya. Az indoklás és a mérés a kódkommentben és a teszt-fixture fejlécében van. / `docs/` unchanged: no install or architecture change, only the recognition range of two detectors.</sub>
