### PR TITLE
fix(agents): purge inter-agent messages on delete so no phantom lingers

### DIFF
--- a/src/__tests__/agent-delete-purges-messages.test.ts
+++ b/src/__tests__/agent-delete-purges-messages.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  initDatabase,
+  createAgentMessage,
+  deleteAgentMessages,
+  getAgentConversation,
+} from '../db.js'
+
+// Reported by a user, 2026-08-01. They deleted the "quantumae" agent, but it
+// stayed visible in the dashboard Messages view. DELETE /api/agents/:name
+// removed the agent dir and cleaned team references, but never purged the
+// agent_messages rows the agent had sent or received. Those orphaned rows kept
+// the deleted agent alive as a phantom conversation partner.
+//
+// Fix: the handler calls deleteAgentMessages(name). The behavior of the purge
+// is tested directly against an in-memory DB (idiom of agent-conversation.test.ts,
+// never touching store/claudeclaw.db); the handler wiring is asserted at the
+// source level (idiom of agent-create-no-destructive-rollback.test.ts, because
+// the route drives tmux and the live agents dir and cannot be run in a harness).
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test'
+  initDatabase(':memory:')
+})
+
+describe('deleteAgentMessages purges a removed agent from inter-agent messages', () => {
+  it('removes every row the agent sent or received, and nothing else', () => {
+    createAgentMessage('system', 'tdel-ghost', 'welcome')        // received
+    createAgentMessage('tdel-ghost', 'marveen', 'i did a thing') // sent
+    createAgentMessage('someone', 'tdel-other', 'unrelated')     // noise, must survive
+
+    const removed = deleteAgentMessages('tdel-ghost')
+
+    expect(removed).toBe(2)
+    expect(getAgentConversation('tdel-ghost', 50).length).toBe(0)
+    // A different agent's traffic must be untouched.
+    expect(getAgentConversation('tdel-other', 50).length).toBe(1)
+  })
+
+  it('is a no-op (0 removed) for an agent with no messages', () => {
+    expect(deleteAgentMessages('tdel-nobody')).toBe(0)
+  })
+})
+
+describe('the DELETE /api/agents/:name handler wires in the message purge', () => {
+  const SRC = join(import.meta.dirname, '..')
+
+  function deleteHandlerBody(): string {
+    const code = readFileSync(join(SRC, 'web/routes/agents.ts'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+    const start = code.indexOf("agentMatch && method === 'DELETE'")
+    expect(start, 'DELETE agent handler not found').toBeGreaterThan(-1)
+    const end = code.indexOf('return true', code.indexOf('cleanupTeamReferences(name)', start))
+    expect(end, 'DELETE handler end not found').toBeGreaterThan(start)
+    return code.slice(start, end)
+  }
+
+  it('the delete handler calls deleteAgentMessages', () => {
+    // Without this the purge exists but never runs on delete, and the ghost returns.
+    expect(deleteHandlerBody()).toMatch(/deleteAgentMessages\(/)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -2049,6 +2049,15 @@ export function getPendingMessages(toAgent?: string): AgentMessage[] {
     .all() as AgentMessage[]
 }
 
+// Purge every inter-agent message a removed agent sent or received. The
+// DELETE /api/agents/:name handler calls this so a deleted agent leaves no
+// orphaned agent_messages rows -- otherwise it lingers in the dashboard
+// Messages view as a phantom conversation partner (reported 2026-08-01, the
+// ghost of a deleted "quantumae"). Returns the number of rows removed.
+export function deleteAgentMessages(name: string): number {
+  return db.prepare('DELETE FROM agent_messages WHERE from_agent = ? OR to_agent = ?').run(name, name).changes
+}
+
 // Status-guarded (pending only): the federation removal path bulk-fails
 // pending rows CONCURRENTLY with an in-flight bridge send -- an unguarded
 // UPDATE would flip such a row failed->delivered after the fact. If the row

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -5,7 +5,7 @@ import { execSync } from 'node:child_process'
 import { logger } from '../../logger.js'
 import { isModelProfileId, MODEL_PROFILE_IDS } from '../../model-profiles.js'
 import { MAIN_AGENT_ID, currentBotName, PROJECT_ROOT } from '../../config.js'
-import { createAgentMessage, listPendingChannelRequests, updateChannelRequestStatus, getDb, claimPendingForAgent, markMessageFailed } from '../../db.js'
+import { createAgentMessage, deleteAgentMessages, listPendingChannelRequests, updateChannelRequestStatus, getDb, claimPendingForAgent, markMessageFailed } from '../../db.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from '../agent-message-wrap.js'
 import { ensureFederationClaudeMdSection } from '../federation/onboarding.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
@@ -2079,6 +2079,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (!existsSync(dir)) { json(res, { error: 'Agent not found' }, 404); return true }
     rmSync(dir, { recursive: true, force: true })
     cleanupTeamReferences(name)
+    // Purge the agent's inter-agent messages too, otherwise the removed agent
+    // lingers in the dashboard Messages view as a phantom conversation partner
+    // (orphaned agent_messages rows survive the delete).
+    deleteAgentMessages(name)
     json(res, { ok: true })
     return true
   }


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A `DELETE /api/agents/:name` eddig eltávolította az ágens mappáját (`rmSync`) és kitakarította a team-hivatkozásokat (`cleanupTeamReferences`), de a törölt ágens `agent_messages` sorait (ahol `from_agent` vagy `to_agent` = név) **nem** törölte. Az árva üzenet-sorok miatt a törölt ágens fantomként ottmaradt a dashboard "Üzenetek" nézetében (egy törölt "quantumae" kapcsán jelentve).

Javítás: új `deleteAgentMessages(name)` db-függvény (`DELETE FROM agent_messages WHERE from_agent = ? OR to_agent = ?`), amit a DELETE handler a `cleanupTeamReferences` után meghív.

**EN:** `DELETE /api/agents/:name` removed the agent directory (`rmSync`) and cleaned team references (`cleanupTeamReferences`), but never purged the deleted agent's `agent_messages` rows (where `from_agent` or `to_agent` = name). Those orphaned rows left the removed agent as a phantom conversation partner in the dashboard Messages view (reported for a deleted "quantumae").

Fix: a new `deleteAgentMessages(name)` db function, called by the DELETE handler after `cleanupTeamReferences`.

**Teszt / Test:** behavioral teszt in-memory DB-vel (`agent-conversation.test.ts` idiómája: purge csak a cél ágens sorait viszi, a többit nem, no-op ha nincs sor), plusz forrás-szintű assertion hogy a handler tényleg hívja a purge-öt. Node 22-vel futtatva (a `better-sqlite3` natív binding ahhoz fordult). RED→GREEN.

**Megjegyzés / Note:** Ez ugyanannak az incomplete-delete gyökér-hibának a másik fele, mint a session-leállítás; külön PR-ként, kérésre. / This is the other half of the same incomplete-delete root cause as the session-stop fix; a separate PR, by request.

## Kapcsolódó issue / Related issue

Nincs külön issue, Telegramon jelentett hiba. / No separate issue, reported via Telegram.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. — Az automata teszt-suite-tal igazoltam (RED→GREEN, behavioral + forrás-szintű, node 22), **nem** éles dashboard-törléssel: az élesítés (dist rebuild + szolgáltatás-restart) függőben. / Verified via the automated test suite (RED→GREEN, behavioral + source-level, node 22), **not** via a live dashboard delete; deployment is pending.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. — Nem érinti, viselkedésbeli hibajavítás. / Not affected, behavioral bug fix.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (`fix/delete-purges-messages`), nem közvetlenül `develop`-ra. / Opened from an own, descriptively named branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
