### PR TITLE
fix(pane-state): strip trailing /rename session-title banner before classification

### DIFF
--- a/src/__tests__/session-title-banner.test.ts
+++ b/src/__tests__/session-title-banner.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  stripSessionTitleBanner,
+  stripAllAnsi,
+  detectPaneState,
+} from '../pane-state.js'
+
+const ESC = '\x1b'
+// A full-width highlighted session-name bar line (fg 256-colour 16 on bg 256-colour 37),
+// exactly how Claude Code renders a /rename banner at the bottom of the pane.
+const banner = (text: string) => `${ESC}[38;5;16m${ESC}[48;5;37m ${text} ${ESC}[39m${ESC}[49m`
+
+describe('stripAllAnsi', () => {
+  it('removes every SGR/CSI code, keeps all visible characters', () => {
+    expect(stripAllAnsi(`${ESC}[38;5;253mhello${ESC}[39m world`)).toBe('hello world')
+    expect(stripAllAnsi(`${ESC}[2mdim${ESC}[22m kept`)).toBe('dim kept')
+  })
+  it('is byte-for-byte the plain text of a coloured capture', () => {
+    const plain = 'line one\n  ❯ input\nbypass permissions on (shift+tab to cycle)'
+    const coloured = `${ESC}[1mline one${ESC}[0m\n  ❯ input\n${ESC}[2mbypass permissions on (shift+tab to cycle)${ESC}[0m`
+    expect(stripAllAnsi(coloured)).toBe(plain)
+  })
+})
+
+describe('stripSessionTitleBanner', () => {
+  it('removes a multi-line trailing rename banner, keeps content above', () => {
+    const pane = [
+      '· esc to interrupt',
+      '',
+      banner('MarveenSCHEDULED TASK NOTICE -- the next <scheduled-task'),
+      banner('source="..."> block is one of YOUR OWN scheduled tasks.'),
+      banner('[Heartbeat: msiw-sentinel-watch]  <scheduled-task'),
+    ].join('\n')
+    const out = stripSessionTitleBanner(pane)
+    expect(out).toBe('· esc to interrupt\n')
+    expect(out).not.toContain('scheduled-task')
+  })
+
+  it('is a no-op when there is no trailing background-filled banner', () => {
+    const pane = '· esc to interrupt\n  ❯ \nbypass permissions on (shift+tab to cycle)'
+    expect(stripSessionTitleBanner(pane)).toBe(pane)
+  })
+
+  it('does NOT treat a foreground 256-colour index of 7 as a background fill', () => {
+    // 38;5;7 is a FOREGROUND colour; it must not be misread as SGR 7 (reverse video).
+    const fgOnly = `${ESC}[38;5;7mplain foreground text${ESC}[39m`
+    expect(stripSessionTitleBanner(`content\n${fgOnly}`)).toBe(`content\n${fgOnly}`)
+  })
+})
+
+describe('detectPaneState with a rename banner (capturePane pipeline)', () => {
+  // Reproduces the 2026-08-01 incident: a long rename banner pushes the live
+  // busy signal out of the bottom region, so the raw pane reads 'unknown'.
+  const busyLine = '✻ Working… (· esc to interrupt)'
+  const bannerBlock = Array.from({ length: 8 }, (_, i) => banner(`renamed session name wrap line ${i}`)).join('\n')
+  const coloured = `${busyLine}\n${bannerBlock}`
+
+  it('raw (banner intact) misclassifies a busy pane as unknown', () => {
+    expect(detectPaneState(stripAllAnsi(coloured))).toBe('unknown')
+  })
+
+  it('after stripping the banner the busy signal classifies correctly', () => {
+    // This is exactly what capturePane now does: strip banner, then strip ANSI.
+    const cleaned = stripAllAnsi(stripSessionTitleBanner(coloured))
+    expect(detectPaneState(cleaned)).toBe('busy')
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -292,6 +292,71 @@ export function stripGhostSuggestion(coloredPane: string): string {
   return out
 }
 
+// Strip every ANSI escape sequence, leaving plain text. Unlike
+// stripGhostSuggestion this drops NO visible characters -- it only removes the
+// SGR/CSI codes -- so stripAllAnsi(`capture-pane -e -p`) equals `capture-pane -p`.
+export function stripAllAnsi(s: string): string {
+  let out = ''
+  let i = 0
+  const n = s.length
+  while (i < n) {
+    const ch = s[i]
+    if (ch === '\x1b') {
+      if (s[i + 1] !== '[') { i++; continue } // drop lone ESC / non-CSI
+      let j = i + 2
+      while (j < n && (s[j] < '@' || s[j] > '~')) j++
+      i = j < n ? j + 1 : n // skip the whole CSI sequence
+      continue
+    }
+    out += ch
+    i++
+  }
+  return out
+}
+
+// A pane line carries a background fill (highlight bar) when its SGR codes SET a
+// non-default background: 256/truecolor bg (48;5;.. / 48;2;..), the basic/bright
+// bg ranges (40-47 / 100-107), or reverse-video (7). The 38/48 colour specs are
+// skipped by mode so a *foreground* 256-colour index (e.g. 38;5;7) is never
+// misread as SGR 7. Foreground-only styling returns false.
+function lineHasBackgroundFill(line: string): boolean {
+  const seqs = line.match(/\x1b\[([0-9;]*)m/g)
+  if (!seqs) return false
+  for (const seq of seqs) {
+    const params = seq.slice(2, -1).split(';').map(x => (x === '' ? 0 : Number(x)))
+    let k = 0
+    while (k < params.length) {
+      const c = params[k]
+      if (c === 48) return true // any background colour set (256/truecolor)
+      if (c === 38) { const mode = params[k + 1]; k += mode === 5 ? 3 : mode === 2 ? 5 : 1; continue }
+      if (c === 7) return true // reverse video
+      if ((c >= 40 && c <= 47) || (c >= 100 && c <= 107)) return true // basic / bright bg
+      k++
+    }
+  }
+  return false
+}
+
+// Claude Code renders a custom session name (set via /rename) as a full-width
+// highlighted bar pinned to the BOTTOM of the pane, below the input box / idle
+// footer. A pathological name -- e.g. a whole <scheduled-task> block that a
+// /rename accidentally swallowed as its argument -- wraps to many lines and
+// pushes the live footer/spinner out of detectPaneState's bottom "live region",
+// so the pane classifies as 'unknown'. 'unknown' blocks BOTH the scheduler and
+// inter-agent delivery (2026-08-01: a rename-banner pinned the main agent
+// 'unknown' and stalled a queued inter-agent message). This strips that trailing
+// banner from a COLOURED capture so the real footer/spinner classifies normally.
+// The idle footer, input box and spinner never carry a background fill, and the
+// name bar is the bottom-most element, so trailing background-filled lines are
+// the banner; non-banner content is left untouched (no-op when absent).
+export function stripSessionTitleBanner(coloredPane: string): string {
+  const lines = coloredPane.split('\n')
+  let end = lines.length
+  while (end > 0 && lineHasBackgroundFill(lines[end - 1])) end--
+  if (end === lines.length) return coloredPane
+  return lines.slice(0, end).join('\n')
+}
+
 // Persistent Anthropic thinking-block API error. When an assistant turn
 // ends with a 400 about thinking/redacted_thinking blocks that "cannot
 // be modified", the session is wedged: every subsequent prompt re-sends

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -13,6 +13,8 @@ import {
   detectPaneState,
   parkedInputText,
   stripGhostSuggestion,
+  stripSessionTitleBanner,
+  stripAllAnsi,
   paneShowsContextSaturation,
   idleConsideringDimGhost,
   detectsFirstRunGate,
@@ -1865,7 +1867,13 @@ export function sendEnterToSession(session: string, host: string | null = null):
 // the caller can treat "capture failed" as "not ready".
 export function capturePane(session: string, host: string | null = null): string | null {
   try {
-    return captureTmux(host, ['capture-pane', '-t', session, '-p'])
+    // Capture WITH colour, strip a trailing /rename session-title banner, then
+    // remove all remaining ANSI. For a pane without a banner this is byte-for-byte
+    // the old `capture-pane -p` output; when a pathological rename-banner is pinned
+    // to the bottom it is removed so the live footer/spinner classifies normally
+    // (a banner otherwise pins detectPaneState 'unknown', blocking scheduler +
+    // inter-agent delivery). See stripSessionTitleBanner.
+    return stripAllAnsi(stripSessionTitleBanner(captureTmux(host, ['capture-pane', '-t', session, '-e', '-p'])))
   } catch {
     return null
   }


### PR DESCRIPTION
## Problem

A custom session name set via `/rename` renders as a full-width highlighted bar pinned to the **bottom** of the pane, below the input box / idle footer. A pathological name -- e.g. a whole `<scheduled-task>` block that `/rename` accidentally swallowed as its argument -- wraps to many lines and pushes the live footer/spinner out of `detectPaneState`'s bottom live region, so the pane classifies as `'unknown'`.

`'unknown'` blocks **both** the scheduler and the inter-agent delivery gate, so the affected agent's status sticks on unknown and queued messages to it stall. Observed 2026-08-01 on the main channels agent: a rename-banner pinned it `'unknown'` and stalled a queued inter-agent message; the status card also showed the banner text in its body.

## Fix (defense-in-depth)

`/rename` itself is upstream Claude Code, so the guard lives in our capture layer:

- `stripSessionTitleBanner(coloredPane)` -- removes trailing contiguous lines that carry a non-default background fill (the name bar). The idle footer, input box and spinner never carry a background fill and the bar is the bottom-most element, so trailing background-filled lines are the banner; non-banner content is untouched (no-op when absent).
- `stripAllAnsi(s)` -- plain ANSI stripper that drops no visible characters.
- `capturePane` now captures **with** colour, strips the banner, then strips ANSI. For a pane without a banner this is byte-for-byte the old `capture-pane -p` output -- zero behaviour change for healthy panes.

Background-fill detection skips the 38/48 colour-spec parameters by mode, so a foreground 256-colour index of 7 is never misread as SGR 7 (reverse video).

## Tests

7 new tests (strip units + a before/after `detectPaneState` reproduction of the incident: banner intact -> `unknown`, banner stripped -> `busy`). Green on this base; no regression (232 pane-state tests pass).