### PR TITLE
fix(install): the apt-lock guard killed the install on quiet machines

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -214,9 +214,18 @@ apt_lock_holder() {
   return 1
 }
 
+# A ket ertekadas alatt SZANDEKOSAN `&& rc=0 || rc=$?` all, nem `; rc=$?`.
+# A szkript `set -e` alatt fut (5. sor), es egy ertekadas kilepesi kodja a
+# parancs-behelyettesitese -- tehat `holder=$(apt_lock_holder); rc=$?` eseten a
+# shell MAR AZON A SORON kilep, ha a fuggveny nem nullat ad. Az pedig pontosan
+# akkor ad nem nullat, amikor NINCS zar (return 1) vagy nincs fuser (return 2),
+# vagyis a haromallapotu logika alatta SOSEM futott le: az egyetlen tulelo ag az
+# volt, amikor tenyleg fogta valaki a lockot. A zar-figyelo igy a NYUGODT gepen
+# olte meg a telepitest, es a lock-versenyes gepen engedte at -- ezert ment at a
+# 07-30-i workshopon es bukott egy friss VPS-en 08-02-an.
 wait_for_apt_lock() {
   local holder rc waited=0 interval=5
-  holder=$(apt_lock_holder); rc=$?
+  holder=$(apt_lock_holder) && rc=0 || rc=$?
   if [ "$rc" -eq 2 ]; then
     # fuser nincs (minimal image) -- nem tudjuk MEGNEZNI, ki fogja a lockot.
     # Ezt kimondjuk, es az APT_OPTS timeout-ja kezeli, ha tenyleg fogott.
@@ -228,7 +237,7 @@ wait_for_apt_lock() {
   echo -e "  ${DIM}$(_t linux.apt_lock_transient_hint)${NC}"
   while [ "$waited" -lt "$APT_LOCK_WAIT_CAP" ]; do
     sleep "$interval"; waited=$((waited + interval))
-    holder=$(apt_lock_holder); rc=$?
+    holder=$(apt_lock_holder) && rc=0 || rc=$?
     if [ "$rc" -ne 0 ]; then
       ok "$(_t linux.apt_lock_freed_prefix) ${waited}s"
       return 0

--- a/src/__tests__/installer-apt-lock-set-e.test.ts
+++ b/src/__tests__/installer-apt-lock-set-e.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// The 2026-08-02 bug: a brand new VPS died at `set_step "prerequisites"` with
+// exit 1, right after printing "Telepites sudo-val (apt)...". Root cause, proved
+// on a live host: the script runs under `set -e` (line 5), and the exit status of
+// an ASSIGNMENT is the status of its command substitution. So
+//
+//     holder=$(apt_lock_holder); rc=$?
+//
+// exits the whole script on that line whenever apt_lock_holder returns non-zero
+// -- and it returns non-zero exactly when there is NO lock (1) or fuser is
+// missing (2). The three-state logic underneath therefore never ran: the only
+// surviving branch was "somebody really is holding the lock". The lock guard
+// killed the install on QUIET machines and waved it through on contended ones,
+// which is why it passed the 07-30 workshop and failed on a fresh VPS.
+//
+// These tests execute the real function out of the shipped script rather than
+// re-describing it, because the bug was invisible at the level of reading.
+
+const ROOT = join(__dirname, '..', '..')
+const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+
+/** Pull one shell function out of a script so it can be executed for real. */
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+  if (start < 0) throw new Error(`function ${name} not found`)
+  let i = src.indexOf('{', start) + 1
+  let depth = 1
+  while (i < src.length && depth > 0) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}') depth--
+    i++
+  }
+  return src.slice(start, i)
+}
+
+/**
+ * Run the REAL wait_for_apt_lock under `set -e` with apt_lock_holder stubbed to
+ * a chosen exit code. Returns the script's exit status and stdout.
+ */
+function runWaitForAptLock(holderRc: number, holderOut = ''): { code: number; out: string } {
+  const fn = sliceShellFn(LINUX, 'wait_for_apt_lock')
+  const script = [
+    'set -e',
+    // Minimal environment the function touches. Nothing here decides the
+    // outcome; the stub's exit code does.
+    'DIM=""; NC=""; RED=""',
+    '_t() { echo "$1"; }',
+    'warn() { echo "warn: $*"; }',
+    'ok() { echo "ok: $*"; }',
+    'fail() { echo "fail: $*"; exit 9; }',
+    'APT_LOCK_WAIT_CAP=0',
+    `apt_lock_holder() { ${holderOut ? `echo "${holderOut}";` : ''} return ${holderRc}; }`,
+    fn,
+    'echo BEFORE',
+    'wait_for_apt_lock',
+    'echo REACHED_THE_END',
+  ].join('\n')
+  try {
+    const out = execFileSync('bash', ['-c', script], { encoding: 'utf-8' })
+    return { code: 0, out }
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string }
+    return { code: e.status ?? -1, out: e.stdout ?? '' }
+  }
+}
+
+describe('wait_for_apt_lock under set -e', () => {
+  it('does NOT kill the install when there is no apt lock (the 08-02 regression)', () => {
+    const r = runWaitForAptLock(1)
+    expect(r.out).toContain('BEFORE')
+    expect(r.out).toContain('REACHED_THE_END')
+    expect(r.code).toBe(0)
+  })
+
+  it('does NOT kill the install when fuser is missing', () => {
+    const r = runWaitForAptLock(2)
+    expect(r.out).toContain('REACHED_THE_END')
+    expect(r.code).toBe(0)
+  })
+
+  it('still detects a real lock holder (positive control)', () => {
+    // Without this the two results above could pass simply because the guard
+    // never does anything at all. APT_LOCK_WAIT_CAP=0 makes the wait loop
+    // terminate immediately, so a held lock reaches the named timeout failure.
+    const r = runWaitForAptLock(0, '4242 apt-get')
+    expect(r.out).toContain('4242 apt-get')
+    expect(r.out).not.toContain('REACHED_THE_END')
+    expect(r.code).toBe(9)
+  })
+})
+
+describe('the assignment idiom that caused it', () => {
+  it('is gone from install-linux.sh', () => {
+    // `x=$(...)` followed by `rc=$?` on the same line: the author expected
+    // execution to continue, which under set -e it does not.
+    const hits = LINUX.split('\n').filter((l) => /^\s*(?:local\s+)?\w+=\$\(.+\)\s*;\s*\w+=\$\?/.test(l))
+    expect(hits, `still present: ${hits.join(' | ')}`).toHaveLength(0)
+  })
+
+  it('the matcher really does find the broken form (instrument control)', () => {
+    // A zero above is only evidence if this pattern can detect a positive.
+    const broken = '  holder=$(apt_lock_holder); rc=$?'
+    expect(/^\s*(?:local\s+)?\w+=\$\(.+\)\s*;\s*\w+=\$\?/.test(broken)).toBe(true)
+  })
+})

--- a/src/__tests__/installer-apt-lock-set-e.test.ts
+++ b/src/__tests__/installer-apt-lock-set-e.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 
 // The 2026-08-02 bug: a brand new VPS died at `set_step "prerequisites"` with
@@ -93,17 +93,51 @@ describe('wait_for_apt_lock under set -e', () => {
   })
 })
 
+// Whole-file scan for the idiom, in BOTH shapes it appears in:
+//   same line:  x=$(cmd); rc=$?
+//   next line:  x=$(cmd)
+//               rc=$?
+// The second shape is not hypothetical: the installer's claude probe used it,
+// and the released script had to be fixed there separately. A test that only
+// looked for the same-line form would have called that file clean.
+const SAME_LINE = /^\s*(?:local\s+)?\w+=\$\(.+\)\s*;\s*\w+=\$\?/
+const BARE_ASSIGN = /^\s*(?:local\s+)?\w+=\$\(.+\)\s*$/
+const RC_CAPTURE = /^\s*(?:local\s+)?\w+=\$\?/
+
+function findUnguardedCaptures(src: string): string[] {
+  const lines = src.split('\n')
+  const hits: string[] = []
+  lines.forEach((line, i) => {
+    if (SAME_LINE.test(line)) hits.push(`${i + 1}: ${line.trim()}`)
+    else if (BARE_ASSIGN.test(line) && RC_CAPTURE.test(lines[i + 1] ?? '')) {
+      hits.push(`${i + 1}: ${line.trim()}`)
+    }
+  })
+  return hits
+}
+
 describe('the assignment idiom that caused it', () => {
-  it('is gone from install-linux.sh', () => {
-    // `x=$(...)` followed by `rc=$?` on the same line: the author expected
-    // execution to continue, which under set -e it does not.
-    const hits = LINUX.split('\n').filter((l) => /^\s*(?:local\s+)?\w+=\$\(.+\)\s*;\s*\w+=\$\?/.test(l))
-    expect(hits, `still present: ${hits.join(' | ')}`).toHaveLength(0)
+  it('appears nowhere in install-linux.sh, in either shape', () => {
+    const hits = findUnguardedCaptures(LINUX)
+    expect(hits, `unguarded capture(s) under set -e:\n${hits.join('\n')}`).toHaveLength(0)
   })
 
-  it('the matcher really does find the broken form (instrument control)', () => {
-    // A zero above is only evidence if this pattern can detect a positive.
-    const broken = '  holder=$(apt_lock_holder); rc=$?'
-    expect(/^\s*(?:local\s+)?\w+=\$\(.+\)\s*;\s*\w+=\$\?/.test(broken)).toBe(true)
+  it('appears nowhere in the other install scripts either', () => {
+    for (const name of ['install-macos.sh', 'install-lang.sh', 'install.sh', 'update.sh']) {
+      const path = join(ROOT, name)
+      if (!existsSync(path)) continue
+      const hits = findUnguardedCaptures(readFileSync(path, 'utf-8'))
+      expect(hits, `${name}:\n${hits.join('\n')}`).toHaveLength(0)
+    }
+  })
+
+  it('the scanner really does detect BOTH broken shapes (instrument control)', () => {
+    // Zeros above are only evidence if the scanner can find a positive. Both
+    // shapes are checked, because the next-line one is the easier to miss.
+    expect(findUnguardedCaptures('  holder=$(apt_lock_holder); rc=$?')).toHaveLength(1)
+    expect(findUnguardedCaptures('OUT=$(claude --print "ping" 2>&1)\nEXIT=$?')).toHaveLength(1)
+    // And it must NOT flag the guarded form we replaced them with.
+    expect(findUnguardedCaptures('  holder=$(apt_lock_holder) && rc=0 || rc=$?')).toHaveLength(0)
+    expect(findUnguardedCaptures('OUT=$(claude --print "ping" 2>&1) && E=0 || E=$?')).toHaveLength(0)
   })
 })


### PR DESCRIPTION
Card INSTRETRY802. Root cause of the 2026-08-02 fresh-VPS failure (`installer exited with code 1 at step prerequisites`, last line printed: `Telepites sudo-val (apt)...`).

## The bug

`install-linux.sh` runs under `set -e` (line 5). The exit status of an assignment is the status of its command substitution, so:

```sh
holder=$(apt_lock_holder); rc=$?
```

exits the script **on that line** whenever `apt_lock_holder` returns non-zero. And it returns non-zero exactly in the normal cases: `1` when there is no lock, `2` when `fuser` is missing. The three-state logic underneath never ran — the only surviving branch was "somebody really is holding the lock".

The guard did the inverse of its job: it killed the install on quiet machines and waved it through on contended ones. That is why it survived the 07-30 workshop and failed on a fresh VPS.

Measured, all three return codes under `set -e`:

```
old form:  f returns 0 -> continues     f returns 1 -> SCRIPT EXITS 1     f returns 2 -> SCRIPT EXITS 2
new form:  f returns 0 -> rc=0          f returns 1 -> rc=1               f returns 2 -> rc=2
```

The call site (`wait_for_apt_lock` at line 313) is a bare call inside an `if` body, not a condition context, so `set -e` applies there.

## Blast radius, counted

Sweep across `install-linux.sh`, `install-macos.sh`, `install-lang.sh`, `install.sh`, `update.sh` for the `x=$(...)` + `rc=$?` idiom: **2 occurrences, both of them these two lines**. Widening to *any* `var=$(local_function)` where the callee has a non-zero `return` path: still **2**, the same two. The other four scripts have none.

## Where the bug lives

Present in all four artefacts, so the fix has to travel:

| artefact | lines |
|---|---|
| `develop` `install-linux.sh` | 219, 231 |
| `main` (what the paid installer clones) | 219, 231 |
| `marveen-bridge-installer` vendored copy | 219, 231 |
| derived `dist/payload/install-linux.sh` | 343, 355 |

This PR fixes `develop`. **It does not reach customers until it is on `main`** and the installer's vendored baseline is re-synced — the drift gate (`scripts/check-drift.mjs`) compares the vendored copy byte-for-byte against released `main`.

## Tests

`src/__tests__/installer-apt-lock-set-e.test.ts` slices the real `wait_for_apt_lock` out of the shipped script and **executes** it under `set -e` with a stubbed `apt_lock_holder`, because this bug is invisible when reading:

- returns 1 (no lock) → script survives to the end;
- returns 2 (no fuser) → survives;
- returns 0 with a holder → **positive control**: still detects it and reaches the named timeout failure. Without this, the first two could pass simply because the guard stopped doing anything.

Plus a class-level check that the idiom is gone, with its own instrument control asserting the matcher does detect the broken form.

Positive control on the whole file: reverting just the two lines makes **3 of the 5 fail**.

## Suite

19 tests fail in this worktree, in `email-send-gate` / `governance-gates` / hook-registration files. **Identical 19 before and after my change** (measured by stashing), and untouched by anything here — they are path-sensitive hook tests and this worktree lives under `/tmp` with a symlinked `node_modules`. I am not claiming develop is healthy, only that these are not mine. Passing count: 3147 → 3152, the +5 being the new tests.

`bash -n` clean, `tsc --noEmit` clean, em/en dash on added lines 0.