### PR TITLE
test(install): a comment between the two lines must not hide the pair

### DIFF
--- a/src/__tests__/installer-apt-lock-set-e.test.ts
+++ b/src/__tests__/installer-apt-lock-set-e.test.ts
@@ -104,12 +104,21 @@ const SAME_LINE = /^\s*(?:local\s+)?\w+=\$\(.+\)\s*;\s*\w+=\$\?/
 const BARE_ASSIGN = /^\s*(?:local\s+)?\w+=\$\(.+\)\s*$/
 const RC_CAPTURE = /^\s*(?:local\s+)?\w+=\$\?/
 
+/** Next line that carries code: blanks and comments do not break the pair. */
+function nextCodeLine(lines: string[], from: number): string {
+  for (let i = from; i < lines.length; i++) {
+    const t = (lines[i] ?? '').trim()
+    if (t !== '' && !t.startsWith('#')) return lines[i] as string
+  }
+  return ''
+}
+
 function findUnguardedCaptures(src: string): string[] {
   const lines = src.split('\n')
   const hits: string[] = []
   lines.forEach((line, i) => {
     if (SAME_LINE.test(line)) hits.push(`${i + 1}: ${line.trim()}`)
-    else if (BARE_ASSIGN.test(line) && RC_CAPTURE.test(lines[i + 1] ?? '')) {
+    else if (BARE_ASSIGN.test(line) && RC_CAPTURE.test(nextCodeLine(lines, i + 1))) {
       hits.push(`${i + 1}: ${line.trim()}`)
     }
   })
@@ -136,6 +145,10 @@ describe('the assignment idiom that caused it', () => {
     // shapes are checked, because the next-line one is the easier to miss.
     expect(findUnguardedCaptures('  holder=$(apt_lock_holder); rc=$?')).toHaveLength(1)
     expect(findUnguardedCaptures('OUT=$(claude --print "ping" 2>&1)\nEXIT=$?')).toHaveLength(1)
+    // A comment or a blank line between the two must not hide the pair: that is
+    // how the shape would slip back in after someone documents it.
+    expect(findUnguardedCaptures('OUT=$(cmd)\n# why we capture it\nEXIT=$?')).toHaveLength(1)
+    expect(findUnguardedCaptures('OUT=$(cmd)\n\nEXIT=$?')).toHaveLength(1)
     // And it must NOT flag the guarded form we replaced them with.
     expect(findUnguardedCaptures('  holder=$(apt_lock_holder) && rc=0 || rc=$?')).toHaveLength(0)
     expect(findUnguardedCaptures('OUT=$(claude --print "ping" 2>&1) && E=0 || E=$?')).toHaveLength(0)


### PR DESCRIPTION
Follow-up to #847. The change was pushed while #847 was being merged, so it landed on a branch that was already closed; it comes back as its own PR rather than as a push to a dead branch.

## What it closes

The two-line scan added in #847 looked only at the **immediately** following line. A comment or a blank line between the two would have hidden the pair:

```sh
OUT=$(cmd)
# why we capture it
EXIT=$?
```

That is a realistic way for the shape to come back: someone re-adds the capture and documents it, and the net says clean.

The matcher now walks to the next line that carries code, skipping blanks and comments. Instrument controls cover both variants, alongside the existing ones for the same-line and two-line forms and for the guarded replacement (which must **not** be flagged).

## Measurement

Re-scanned all five install scripts with the stricter matcher: **still zero**. So this adds no new finding, it only closes a hole in the net. Had it found anything, that would have gone to Marveen as a new lead rather than being quietly fixed here.

6 tests pass.