### PR TITLE
fix(heartbeat): the report reads a clock, a tool and the live registry

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -122,6 +122,66 @@ describe('renderHeartbeatClaudeMd', () => {
     expect(b).toContain('/data/store/claudeclaw.db')
     expect(b).toContain('http://localhost:9000/api/messages')
   })
+
+  // 2026-08-02 (HBTZ802). The first report after a fresh restart carried
+  // "09:00 (Europe/Budapest)" at 11:06 local. The transcript shows the agent
+  // ran `date -u` and formatted with datetime.now(timezone.utc): the label was
+  // a template constant, the number was UTC. The environment was never at
+  // fault -- the spawn command is identical apart from `--continue`, no agent
+  // gets a TZ var either way, and a process spawned by the same tmux server
+  // prints correct local time. So the instructions must name the measurement.
+  it('tells the agent to measure local time in the configured zone', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toMatch(/TZ=\S+ date \+'%Y-%m-%d %H:%M'/)
+  })
+
+  it('forbids the UTC clocks that produced the mislabelled header', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('date -u')
+    expect(out).toContain('datetime.now(timezone.utc)')
+    expect(out).toMatch(/Never `date -u`/)
+  })
+
+  it('does not leave a bare HH:MM placeholder in the header template', () => {
+    // A literal `HH:MM` next to a zone label is what let the agent fill the
+    // slot from whatever clock it happened to reach for.
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).not.toContain('## Heartbeat YYYY-MM-DD HH:MM')
+  })
+
+  it('requires the calendar MCP to be called as a tool, never from a subprocess', () => {
+    // Same round: the agent tried to reach the MCP server from a python
+    // subprocess and reported "not accessible in subprocess context" while the
+    // server was a live child of its own session.
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('Call it as a TOOL, directly.')
+    expect(out).toMatch(/Do not try to reach an MCP server\s+from Bash, python, curl or any other subprocess/)
+  })
+
+  it('separates "tool absent" from "call failed" so the two are not reported alike', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('calendar tool not available in this session')
+    expect(out).toContain('calendar fetch failed: <reason>')
+  })
+
+  // Same investigation: the Tasks section read the `scheduled_tasks` table,
+  // which holds 0 rows on this deployment while /api/schedules lists 25
+  // enabled entries -- so every report said "active: 0, next: (none
+  // scheduled)". A line that is always the same stops being read, which is
+  // the failure this file already warns about elsewhere.
+  it('reads the schedule count from the live registry, not the empty table', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('http://localhost:3420/api/schedules')
+    expect(out).not.toContain('count active rows in')
+    expect(out).not.toContain('next_run_at')
+  })
+
+  it('compares task_runs.ts in milliseconds', () => {
+    // ts is epoch MILLISECONDS; a seconds comparison matches every row and
+    // silently turns "last hour" into "since the beginning".
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('(unixepoch()-3600)*1000')
+  })
 })
 
 describe('shouldBootHeartbeatAgent', () => {

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -159,10 +159,32 @@ loop entirely.
 
 When you receive the heartbeat prompt:
 
+0. **Read the clock.** Every timestamp you print is local time in
+   ${APP_TZ}, and you have no clock of your own -- so measure it:
+
+   \`\`\`bash
+   TZ=${APP_TZ} date +'%Y-%m-%d %H:%M'
+   \`\`\`
+
+   Use THAT string in the header. Never \`date -u\`, never
+   \`datetime.now(timezone.utc)\`, never the hour the schedule was
+   supposed to fire. UTC printed under a \`${APP_TZ}\` label is worse
+   than no timestamp: every window in this report ("next 2h", "last
+   1h") is read against it, so an hour of drift silently moves the
+   window as well as the label.
+
 1. **Collect** the four data sources:
    - **Calendar (next 2 hours)** -- use the
      \`mcp__server-google-calendar-mcp__list-events\` tool
      ${calendarTarget}, timeMin=now, timeMax=now+2h.
+     Call it as a TOOL, directly. Do not try to reach an MCP server
+     from Bash, python, curl or any other subprocess: MCP tools exist
+     only in your own tool list, so a subprocess will always come back
+     empty and that emptiness says nothing about the server. If the
+     tool is genuinely absent from your tool list, say
+     "calendar tool not available in this session" -- that is a
+     different fact from a failed call, and only the tool itself can
+     produce the latter.
      If the call fails (token revoked / 401), record the failure
      reason rather than the events; the main agent can act on the
      failure.
@@ -175,9 +197,22 @@ When you receive the heartbeat prompt:
      (a card can be \`urgent\` priority but already \`done\` -- exclude
      those, or you will report closed issues as active every hour)
      or \`archived_at IS NULL AND status='waiting'\`.
-   - **Scheduled tasks** -- count active rows in
-     \`scheduled_tasks\` table; record \`next_run_at\` for the
-     earliest upcoming one.
+   - **Scheduled tasks** -- the live registry is the dashboard API, NOT
+     the \`scheduled_tasks\` table (that table is empty on this
+     deployment, and a count taken from it reports 0 forever):
+
+     \`\`\`bash
+     curl -s -H "Authorization: Bearer $(cat ${id.storeDir}/.dashboard-token)" \\
+       ${id.dashboardOrigin}/api/schedules \\
+       | python3 -c "import json,sys; r=json.load(sys.stdin); print(sum(1 for x in r if x.get('enabled')))"
+     \`\`\`
+
+     For what actually ran, query \`task_runs\`. Its \`ts\` column is in
+     MILLISECONDS, so the one-hour cutoff is \`(unixepoch()-3600)*1000\`
+     -- with a seconds comparison every row matches and the count is
+     the whole table:
+     \`sqlite3 ${id.storeDir}/claudeclaw.db "SELECT status, COUNT(*) FROM
+     task_runs WHERE ts > (unixepoch()-3600)*1000 GROUP BY status"\`.
    - **Memory + system** -- DB file size, any \`category='hot'\`
      memories newer than 1 hour, plus presence of any
      \`status='warning'\` entries in the memory log.
@@ -185,7 +220,7 @@ When you receive the heartbeat prompt:
 2. **Format** the result as a single inter-agent message:
 
    \`\`\`
-   ## Heartbeat YYYY-MM-DD HH:MM (${APP_TZ})
+   ## Heartbeat <the string step 0 measured> (${APP_TZ})
 
    ### Calendar (next 2h)
    - HH:MM -- <summary> (<attendees>)
@@ -199,8 +234,8 @@ When you receive the heartbeat prompt:
    - planned: <N>
 
    ### Tasks
-   - active: <N>
-   - next: <task name @ YYYY-MM-DD HH:MM>
+   - enabled schedules: <N>
+   - last hour: <N fired, N skipped>
 
    ### Memory / system
    - DB size: <X> MB


### PR DESCRIPTION
Card **HBTZ802**. Marveen's measurement, 2026-08-02 11:06: the first heartbeat after a fresh restart carried the header `## Heartbeat 2026-08-02 09:00 (Europe/Budapest)` at 11:06 local time, and the calendar line read *"calendar MCP not accessible in subprocess context"*.

## The question was: does the `fresh` spawn path hand out a poorer environment than `--continue`?

Measured first, before touching anything. **No, it does not.**

| measurement | result |
|---|---|
| launch command, `fresh` vs `--continue` | identical apart from the `--continue ` flag (`agent-process.ts:1253` and the `cmd` string below it) |
| `TZ` in the running fresh-spawned heartbeat (pid 60999) vs a `--continue`-spawned agent | absent from both; every agent inherits the same tmux server env |
| a process spawned by that same tmux server | `2026-08-02 11:34 CEST`, i.e. correct local time is available to anything that asks |
| calendar MCP for the session that called it unreachable | `npm exec @cocal/google-calendar-mcp` was a **live child process of that session**; `claude mcp list` from its cwd + config connects all six servers |

## What actually happened

The transcript of the post-restart round says it plainly:

- `09:00:20 Bash: date -u +"%Y-%m-%d %H:%M"`, and the report was formatted with `datetime.now(timezone.utc)`. The zone label is a constant in the scaffold, the number came from a UTC clock the agent chose itself.
- `09:00:51 "Let me use the MCP tool"` followed by a python subprocess that tried to reach the MCP server, then `"The calendar tool is not available in subprocess context"`. The tool was never called.

The pre-restart session (same model, same scaffold, same config, running since 07-28) called `mcp__server-google-calendar-mcp__list-events` **60 times** and never ran `date` at all. The fresh restart degraded nothing; it dropped the five-day conversation whose precedent had been carrying the behaviour, leaving the instructions to carry it alone. They did not.

## The change

- **Step 0, read the clock**: `TZ=<zone> date +'%Y-%m-%d %H:%M'`, and the header placeholder is now *the string step 0 measured* rather than a bare `HH:MM` next to a zone label. `date -u` and `datetime.now(timezone.utc)` are named and forbidden, with the reason: every window in the report ("next 2h", "last 1h") is read against that timestamp, so an hour of drift moves the windows too.
- **Calendar**: call it as a tool, directly; never from Bash, python or curl, because MCP tools exist only in the agent's own tool list and a subprocess always comes back empty. "Tool absent from my list" and "the call failed" are now separate reportable facts.

## A third defect, found while measuring

The Tasks section counted rows in `scheduled_tasks`. That table holds **0 rows** on this deployment while the dashboard schedule registry lists **25 enabled** entries, so every heartbeat has been reporting `active: 0, next: (none scheduled)`. It now reads the live registry, and reports what ran from `task_runs` -- whose `ts` is in **milliseconds**, so the hour cutoff must be `(unixepoch()-3600)*1000`; with a seconds comparison every row matches and "last hour" silently becomes all time (measured: 8 vs 5823).

This one is separable from the two card symptoms if you would rather split it.

## Verification

Suite **3179/3179**, `tsc --noEmit` clean, em dash 0. The five new contract assertions were run against the previous scaffold and **all five fail** there.

The scaffold is rewritten on every dashboard boot (`ALWAYS_WRITE`), so this reaches the running heartbeat agent at the next restart, with no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
