### PR TITLE
fix(telegram): reinject dropped quote-reply metadata (issue #929 workaround)

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1226,6 +1226,7 @@ resolve_service_node
 # operator picked a distinct brand above.
 DASHBOARD_PLIST="com.${SERVICE_ID}.dashboard"
 CHANNELS_PLIST="com.${SERVICE_ID}.channels"
+REPLY_PATCH_PLIST="com.${SERVICE_ID}.reply-to-patch"
 
 # Dashboard service
 cat > "$PLIST_DIR/${DASHBOARD_PLIST}.plist" << PLISTEOF
@@ -1281,7 +1282,21 @@ cat > "$PLIST_DIR/${CHANNELS_PLIST}.plist" << PLISTEOF
   <string>${CHANNELS_PLIST}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${INSTALL_DIR}/scripts/channels.sh</string>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <!-- ExecStartPre-equivalent: launchd has no ExecStartPre, so wrap the start.
+         Reapply the local Telegram reply-to patch (upstream issue #929 workaround)
+         BEFORE channels.sh comes up, so a channel (re)start right after a plugin
+         update serves the patched server.ts instead of waiting for the periodic
+         reply-to-patch job. node is invoked by its resolved absolute path (not the
+         shebang) so an nvm/PATH gap can't make it silently skip. Best-effort: the
+         '|| true' mirrors the systemd unit's leading '-' so a patch hiccup never
+         blocks the channel bridge from starting. exec hands the process slot to
+         channels.sh so launchd's KeepAlive keeps tracking the bridge, not the shell.
+         No shell redirection here on purpose: '2>&1' would be invalid raw XML in a
+         plist string; the patcher inherits fd 1/2, so launchd routes its output to
+         this service's StandardOut/ErrorPath (store/channels*.log) automatically. -->
+    <string>"${NODE_PATH}" "${INSTALL_DIR}/scripts/patch-telegram-reply-to.mjs" || true; exec "${INSTALL_DIR}/scripts/channels.sh"</string>
   </array>
   <key>WorkingDirectory</key>
   <string>${INSTALL_DIR}</string>
@@ -1312,6 +1327,49 @@ cat > "$PLIST_DIR/${CHANNELS_PLIST}.plist" << PLISTEOF
 </plist>
 PLISTEOF
 
+# Reply-to patch reapply service (macOS analog of the Linux channel-watchdog
+# every-tick reapply). A plugin update writes a fresh, unpatched server.ts; this
+# periodic job re-runs the idempotent patcher so the reply-to fix is restored
+# without a channel restart. We run ONLY the patcher here (not the whole
+# channel-watchdog.sh, which uses GNU `stat -c` and other Linux-isms) -- the patch
+# is the sole cross-platform concern that needs periodic reapply on macOS. Paired
+# with the channels-plist wrapper above, this mirrors the Linux ExecStartPre +
+# systemd-timer pair: start-time reapply AND periodic reapply. node is pinned to
+# its absolute path so an nvm/PATH gap can't silently skip the patch.
+cat > "$PLIST_DIR/${REPLY_PATCH_PLIST}.plist" << PLISTEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${REPLY_PATCH_PLIST}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${NODE_PATH}</string>
+    <string>${INSTALL_DIR}/scripts/patch-telegram-reply-to.mjs</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${INSTALL_DIR}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <!-- Every 5 min, matching the Linux channel-watchdog cadence. -->
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>StandardOutPath</key>
+  <string>${INSTALL_DIR}/store/reply-to-patch.log</string>
+  <key>StandardErrorPath</key>
+  <string>${INSTALL_DIR}/store/reply-to-patch.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${NODE_BIN_DIR}:${HOME}/.local/bin:/opt/homebrew/bin:${HOME}/.bun/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key>
+    <string>${HOME}</string>
+  </dict>
+</dict>
+</plist>
+PLISTEOF
+
 echo -e "  ${GREEN}✓${NC} $(_t macos.launchagents_created)"
 
 # Load AND START the LaunchAgents -- loading is not starting. The rationale and
@@ -1321,6 +1379,17 @@ echo -e "  ${GREEN}✓${NC} $(_t macos.launchagents_created)"
 
 DASHBOARD_PID="$(start_launchd_unit "$DASHBOARD_PLIST")"
 CHANNELS_PID="$(start_launchd_unit "$CHANNELS_PLIST")"
+
+# The reply-to patch unit is a periodic RunAtLoad job (StartInterval 300), not a
+# long-running service: it applies the patch and exits, so start_launchd_unit's
+# persistent-pid verify would count it as failed. Register it the modern way
+# (bootstrap, since `launchctl load` alone leaves a RunAtLoad job merely pended
+# on current macOS -- see launchd-unit.sh) and kickstart the first run; no pid
+# check, because a healthy run has no lasting pid.
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DIR/${REPLY_PATCH_PLIST}.plist" 2>/dev/null \
+  || launchctl load "$PLIST_DIR/${REPLY_PATCH_PLIST}.plist" 2>/dev/null \
+  || true
+launchctl kickstart "gui/$(id -u)/${REPLY_PATCH_PLIST}" >/dev/null 2>&1 || true
 if [ -n "$DASHBOARD_PID" ] && [ -n "$CHANNELS_PID" ]; then
   echo -e "  ${GREEN}✓${NC} Szolgaltatasok elinditva (dashboard pid $DASHBOARD_PID, channels pid $CHANNELS_PID)"
 else

--- a/scripts/__tests__/patch-telegram-reply-to.test.sh
+++ b/scripts/__tests__/patch-telegram-reply-to.test.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Contract tests for scripts/patch-telegram-reply-to.mjs -- the idempotent local
+# patch that reinjects Telegram quote-reply metadata the upstream plugin drops
+# (issue #929 workaround). No real plugin is touched: the patcher's --self-test
+# runs against a hermetic temp fixture, and the wiring checks below read source.
+# Run: bash scripts/__tests__/patch-telegram-reply-to.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PATCHER="$INSTALL_DIR/scripts/patch-telegram-reply-to.mjs"
+WATCHDOG="$INSTALL_DIR/scripts/channel-watchdog.sh"
+SERVICE="$INSTALL_DIR/scripts/systemd/marveen-channels.service"
+
+RUNNER="node"
+command -v node >/dev/null 2>&1 || RUNNER="bun"
+
+echo "patch-telegram-reply-to tests"
+echo "============================="
+
+# (1) The patcher's own hermetic self-test (patch -> idempotent re-run -> no-anchor).
+echo ""
+echo "(1) patcher self-test"
+if "$RUNNER" "$PATCHER" --self-test; then
+  pass "self-test exits 0"
+else
+  fail "self-test exits 0"
+fi
+
+# (2) Idempotency + correct injection against a fixture that mirrors the real
+#     plugin meta block, driven through --file (the path the watchdog uses).
+echo ""
+echo "(2) --file patch on a plugin-shaped fixture"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FIX="$TMP/server.ts"
+cat > "$FIX" <<'EOF'
+  mcp.notification({
+    method: 'notifications/claude/channel',
+    params: {
+      content: text,
+      meta: {
+        chat_id,
+        ...(msgId != null ? { message_id: String(msgId) } : {}),
+        user: from.username ?? String(from.id),
+        ts: new Date((ctx.message?.date ?? 0) * 1000).toISOString(),
+        ...(imagePath ? { image_path: imagePath } : {}),
+      },
+    },
+  })
+EOF
+
+OUT1="$("$RUNNER" "$PATCHER" --file "$FIX" 2>&1)"
+if echo "$OUT1" | grep -q "patched"; then pass "first --file run reports patched"; else fail "first --file run reports patched ($OUT1)"; fi
+if grep -q "reply_to_message_id: String(ctx.message.reply_to_message.message_id)" "$FIX"; then
+  pass "reply_to_message_id injected"
+else
+  fail "reply_to_message_id injected"
+fi
+if grep -q "reply_to_text:" "$FIX"; then pass "reply_to_text injected"; else fail "reply_to_text injected"; fi
+# Injection must sit between the ts anchor and the image_path spread, indented to 8 spaces.
+if grep -qE '^        \.\.\.\(ctx\.message\?\.reply_to_message \? \{' "$FIX"; then
+  pass "injected spread at 8-space indent"
+else
+  fail "injected spread at 8-space indent"
+fi
+
+SUM1="$(cksum "$FIX")"
+OUT2="$("$RUNNER" "$PATCHER" --file "$FIX" 2>&1)"
+SUM2="$(cksum "$FIX")"
+if echo "$OUT2" | grep -q "already"; then pass "second --file run is a no-op (already)"; else fail "second --file run is a no-op ($OUT2)"; fi
+if [ "$SUM1" = "$SUM2" ]; then pass "idempotent: file byte-identical on re-run"; else fail "idempotent: file byte-identical on re-run"; fi
+MARK_COUNT="$(grep -c "marveen-patch:reply-to" "$FIX")"
+if [ "$MARK_COUNT" = "1" ]; then pass "exactly one patch marker after two runs"; else fail "exactly one patch marker (got $MARK_COUNT)"; fi
+
+# (3) no-anchor path: a reshaped meta block must NOT be corrupted.
+echo ""
+echo "(3) reshaped anchor is left untouched"
+FIX2="$TMP/reshaped.ts"
+sed 's/ts: new Date/timestamp: new Date/' "$TMP/server.ts" >/dev/null 2>&1 || true
+cat > "$FIX2" <<'EOF'
+      meta: {
+        chat_id,
+        timestamp: new Date((ctx.message?.date ?? 0) * 1000).toISOString(),
+      },
+EOF
+BEFORE="$(cksum "$FIX2")"
+OUT3="$("$RUNNER" "$PATCHER" --file "$FIX2" 2>&1)"
+AFTER="$(cksum "$FIX2")"
+if echo "$OUT3" | grep -q "no-anchor"; then pass "reshaped block reports no-anchor"; else fail "reshaped block reports no-anchor ($OUT3)"; fi
+if [ "$BEFORE" = "$AFTER" ]; then pass "no-anchor leaves file untouched"; else fail "no-anchor leaves file untouched"; fi
+
+# (4) Auto-reapply is wired into the existing heartbeat + channel start.
+echo ""
+echo "(4) auto-reapply wiring"
+if grep -q "patch-telegram-reply-to.mjs" "$WATCHDOG"; then
+  pass "channel-watchdog.sh invokes the patcher (heartbeat reapply)"
+else
+  fail "channel-watchdog.sh invokes the patcher"
+fi
+if grep -q "patch-telegram-reply-to.mjs" "$SERVICE"; then
+  pass "marveen-channels.service reapplies on start (ExecStartPre)"
+else
+  fail "marveen-channels.service reapplies on start"
+fi
+
+# (5) Portability: no baked-in home path or hardcoded plugin version.
+echo ""
+echo "(5) portability"
+if grep -qE '/home/[a-z]+/' "$PATCHER"; then
+  fail "patcher has an absolute /home path"
+else
+  pass "patcher resolves paths at runtime (no /home literal)"
+fi
+if grep -qE "telegram/0\.0\.[0-9]" "$PATCHER"; then
+  fail "patcher hardcodes a plugin version"
+else
+  pass "patcher does not hardcode a plugin version"
+fi
+
+echo ""
+echo "-----------------------------------------"
+echo "patch-telegram-reply-to: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/__tests__/patch-telegram-reply-to.test.sh
+++ b/scripts/__tests__/patch-telegram-reply-to.test.sh
@@ -15,6 +15,7 @@ INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 PATCHER="$INSTALL_DIR/scripts/patch-telegram-reply-to.mjs"
 WATCHDOG="$INSTALL_DIR/scripts/channel-watchdog.sh"
 SERVICE="$INSTALL_DIR/scripts/systemd/marveen-channels.service"
+MACOS_INSTALL="$INSTALL_DIR/install-macos.sh"
 
 RUNNER="node"
 command -v node >/dev/null 2>&1 || RUNNER="bun"
@@ -106,6 +107,35 @@ if grep -q "patch-telegram-reply-to.mjs" "$SERVICE"; then
   pass "marveen-channels.service reapplies on start (ExecStartPre)"
 else
   fail "marveen-channels.service reapplies on start"
+fi
+# macOS has no ExecStartPre/systemd-timer, so the same two reapply paths live in
+# install-macos.sh's launchd plists: (a) the channels plist wraps channels.sh so
+# the patcher runs before the bridge starts, and (b) a periodic reply-to-patch
+# plist re-runs it on an interval. Both must invoke the patcher.
+if grep -qE 'patch-telegram-reply-to\.mjs.*exec.*channels\.sh' "$MACOS_INSTALL"; then
+  pass "install-macos.sh channels plist runs the patcher before channels.sh (start-time reapply)"
+else
+  fail "install-macos.sh channels plist runs the patcher before channels.sh"
+fi
+if grep -q 'com.${SERVICE_ID}.reply-to-patch' "$MACOS_INSTALL" && grep -q 'StartInterval' "$MACOS_INSTALL"; then
+  pass "install-macos.sh installs the periodic reply-to-patch launchd job (watchdog-cycle reapply)"
+else
+  fail "install-macos.sh installs the periodic reply-to-patch launchd job"
+fi
+if grep -q 'launchctl load "$PLIST_DIR/${REPLY_PATCH_PLIST}.plist"' "$MACOS_INSTALL"; then
+  pass "install-macos.sh loads the reply-to-patch launchd job"
+else
+  fail "install-macos.sh loads the reply-to-patch launchd job"
+fi
+
+# (4b) The watchdog reapply must be observable when it CANNOT run (no node/bun),
+#      not silent -- the nvm/minimal-PATH failure mode (review #3).
+echo ""
+echo "(4b) watchdog logs a skipped patcher"
+if grep -qE 'reply-to patch: SKIPPED' "$WATCHDOG"; then
+  pass "channel-watchdog.sh logs when no runner is found (patcher did not start)"
+else
+  fail "channel-watchdog.sh logs when no runner is found"
 fi
 
 # (5) Portability: no baked-in home path or hardcoded plugin version.

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -77,6 +77,13 @@ if [ -f "$REPLY_PATCH" ]; then
   if [ -n "$REPLY_RUNNER" ]; then
     REPLY_OUT="$("$REPLY_RUNNER" "$REPLY_PATCH" 2>&1)" || true
     [ -n "$REPLY_OUT" ] && log "reply-to patch: $REPLY_OUT"
+  else
+    # No node/bun on PATH -- the patcher could not even start. This is the exact
+    # silent-failure mode of an nvm-installed node under a minimal service PATH
+    # (systemd ExecStartPre's leading '-' or launchd's default PATH would swallow
+    # it): the patch just never runs and quote-replies keep getting dropped with
+    # no trace. Log it here so a reverted patch is visible instead of silent.
+    log "reply-to patch: SKIPPED -- no node/bun on PATH, patcher did not start ($REPLY_PATCH)"
   fi
 fi
 

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -61,6 +61,25 @@ AUTH_DEAD_THRESHOLD_TICKS=3     # consecutive dead-token ticks (~15min @ 5min/ti
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*"; }
 
+# --- auto-reapply the local Telegram reply-to patch (issue #929 workaround) ---
+# The upstream telegram plugin drops quote-reply metadata; scripts/patch-telegram-
+# reply-to.mjs injects it back. A plugin update writes a fresh, unpatched
+# server.ts, so we re-run the (idempotent, cheap) patcher every tick here -- this
+# is the heartbeat that notices a reverted patch and reapplies it. The patcher is
+# silent unless it actually changes something, so this only logs on (re)apply.
+# Best-effort: never let a patch hiccup block the health checks below.
+REPLY_PATCH="$INSTALL_DIR/scripts/patch-telegram-reply-to.mjs"
+if [ -f "$REPLY_PATCH" ]; then
+  REPLY_RUNNER=""
+  if command -v node >/dev/null 2>&1; then REPLY_RUNNER="node"
+  elif command -v bun >/dev/null 2>&1; then REPLY_RUNNER="bun"
+  fi
+  if [ -n "$REPLY_RUNNER" ]; then
+    REPLY_OUT="$("$REPLY_RUNNER" "$REPLY_PATCH" 2>&1)" || true
+    [ -n "$REPLY_OUT" ] && log "reply-to patch: $REPLY_OUT"
+  fi
+fi
+
 # --- resolve the channels session + provider (launch-order / rename independent) ---
 MAIN_AGENT_ID="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
 MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"

--- a/scripts/patch-telegram-reply-to.mjs
+++ b/scripts/patch-telegram-reply-to.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+// Idempotent local patch for the Telegram channel plugin's dropped quote-reply
+// metadata.
+//
+// WHY: the upstream anthropics/claude-plugins-official telegram plugin builds
+// the inbound `meta` object in handleInbound() (server.ts, the
+// `mcp.notification({ method: 'notifications/claude/channel' ... })` block) with
+// chat_id / message_id / user / ts / attachment_* -- but nothing from
+// `ctx.message.reply_to_message`. So when a user quote-replies to an earlier
+// message, the agent never sees WHICH message was quoted. The data is already
+// on `ctx.message.reply_to_message` (the plugin uses it elsewhere, e.g. the
+// implicit-mention check), it just never reaches the notification meta.
+//
+// Upstream fix is stuck: ~10 community PRs closed without merge, issues #929
+// and #988 still open. So we patch the installed plugin in place, idempotently,
+// and re-apply after any plugin update reverts it (see channel-watchdog.sh,
+// which runs this every tick, and the marveen-channels.service ExecStartPre).
+//
+// UPSTREAM: github.com/anthropics/claude-plugins-official issue #929. If that
+// ever merges, delete this script + its callers and drop the injected block.
+//
+// Usage:
+//   node scripts/patch-telegram-reply-to.mjs            # discover + patch all installed versions (quiet unless it changes something)
+//   node scripts/patch-telegram-reply-to.mjs --verbose  # also log no-op / already-patched
+//   node scripts/patch-telegram-reply-to.mjs --file P   # patch exactly one server.ts (used by tests)
+//   node scripts/patch-telegram-reply-to.mjs --self-test # hermetic self-check, no real plugin touched
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const INSTALL_DIR = path.resolve(__dirname, '..')
+const STATE_FILE = path.join(INSTALL_DIR, 'store', '.telegram-reply-to-patch.json')
+
+// A stable marker the plugin source never contains on its own. Presence == already patched.
+const MARKER = 'marveen-patch:reply-to'
+
+// The anchor is the `ts:` line inside the notification meta object. It is the
+// most stable line in that block (chat_id/message_id are conditional spreads;
+// ts is unconditional). We insert our conditional spread right after it, at the
+// same indentation. If upstream ever renames or reshapes this line the anchor
+// stops matching and we report 'no-anchor' loudly rather than corrupting the file.
+const ANCHOR_RE =
+  /^([ \t]*)ts: new Date\(\(ctx\.message\?\.date \?\? 0\) \* 1000\)\.toISOString\(\),[ \t]*$/m
+
+// Build the injected block at the anchor's indentation. Kept as a plain object
+// spread so it disappears entirely when there is no reply_to_message.
+// reply_to_text is truncated to 500 chars to stay a lightweight hint, not a
+// full message copy.
+function injectedBlock(indent) {
+  const rt = 'ctx.message.reply_to_message.text ?? ctx.message.reply_to_message.caption'
+  return [
+    `${indent}// ${MARKER}: surface Telegram quote-reply metadata the upstream`,
+    `${indent}// plugin drops (see scripts/patch-telegram-reply-to.mjs, issue #929).`,
+    `${indent}...(ctx.message?.reply_to_message ? {`,
+    `${indent}  reply_to_message_id: String(ctx.message.reply_to_message.message_id),`,
+    `${indent}  ...((${rt}) ? { reply_to_text: (${rt}).slice(0, 500) } : {}),`,
+    `${indent}} : {}),`,
+  ].join('\n')
+}
+
+function sha256(s) {
+  return crypto.createHash('sha256').update(s).digest('hex')
+}
+
+// Patch a single server.ts. Returns one of:
+//   { status: 'already' }    -- marker present, nothing to do
+//   { status: 'patched', sha } -- inserted the block, file rewritten
+//   { status: 'no-anchor' }  -- anchor line not found (upstream shape changed)
+function patchFile(serverPath) {
+  const src = fs.readFileSync(serverPath, 'utf8')
+  if (src.includes(MARKER)) return { status: 'already' }
+  const m = ANCHOR_RE.exec(src)
+  if (!m) return { status: 'no-anchor' }
+  const indent = m[1]
+  const block = injectedBlock(indent)
+  const patched = src.replace(ANCHOR_RE, `${m[0]}\n${block}`)
+  // Atomic-ish write: temp file in the same dir, then rename.
+  const tmp = `${serverPath}.marveen-tmp-${process.pid}`
+  fs.writeFileSync(tmp, patched, 'utf8')
+  fs.renameSync(tmp, serverPath)
+  return { status: 'patched', sha: sha256(patched) }
+}
+
+// Discover every installed telegram plugin server.ts. We deliberately glob ALL
+// version directories (not just the current one) and never hardcode a version:
+// a plugin update lands a new version dir with a fresh, unpatched server.ts,
+// and this is exactly how the auto-reapply notices it -- next run finds a
+// server.ts without the marker and patches it.
+function findServers() {
+  const roots = new Set()
+  roots.add(path.join(os.homedir(), '.claude', 'plugins', 'cache', 'claude-plugins-official', 'telegram'))
+  // Derive the telegram root from CLAUDE_PLUGIN_ROOT if the plugin exported it
+  // (it points at .../telegram/<version>), so a non-default plugin cache still resolves.
+  const pr = process.env.CLAUDE_PLUGIN_ROOT
+  if (pr) {
+    const marker = `${path.sep}telegram${path.sep}`
+    const idx = pr.lastIndexOf(marker)
+    if (idx !== -1) roots.add(pr.slice(0, idx + `${path.sep}telegram`.length))
+    else if (path.basename(path.dirname(pr)) === 'telegram') roots.add(path.dirname(pr))
+  }
+  const servers = new Set()
+  for (const root of roots) {
+    let entries
+    try {
+      entries = fs.readdirSync(root, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      if (!e.isDirectory()) continue
+      const sp = path.join(root, e.name, 'server.ts')
+      if (fs.existsSync(sp)) servers.add(sp)
+    }
+  }
+  return [...servers]
+}
+
+function writeState(results) {
+  const state = {
+    marker: MARKER,
+    patchedAt: new Date().toISOString(),
+    servers: results.map(r => ({ path: r.path, status: r.status, sha256: r.sha ?? null })),
+  }
+  try {
+    fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true })
+    fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2) + '\n', 'utf8')
+  } catch {
+    // store/ not writable in this context (e.g. a bare test run) -- state is
+    // observability only, so a failure here must not fail the patch.
+  }
+}
+
+function runAll({ verbose }) {
+  const servers = findServers()
+  if (servers.length === 0) {
+    if (verbose) console.log('patch-telegram-reply-to: no telegram plugin server.ts found')
+    return 0
+  }
+  const results = []
+  let changed = 0
+  let noAnchor = 0
+  for (const sp of servers) {
+    let res
+    try {
+      res = patchFile(sp)
+    } catch (err) {
+      console.error(`patch-telegram-reply-to: ERROR patching ${sp}: ${err.message}`)
+      results.push({ path: sp, status: 'error' })
+      continue
+    }
+    results.push({ path: sp, ...res })
+    if (res.status === 'patched') {
+      changed++
+      console.log(`patch-telegram-reply-to: applied to ${sp}`)
+    } else if (res.status === 'no-anchor') {
+      noAnchor++
+      console.error(`patch-telegram-reply-to: WARNING anchor not found in ${sp} -- upstream shape changed, skipped`)
+    } else if (verbose) {
+      console.log(`patch-telegram-reply-to: already patched ${sp}`)
+    }
+  }
+  writeState(results)
+  // Exit non-zero only when we found a plugin but could not patch it at all
+  // (anchor gone everywhere), so ExecStartPre/tests surface a real regression.
+  if (noAnchor > 0 && changed === 0 && !results.some(r => r.status === 'already')) return 2
+  return 0
+}
+
+// -------------------------------------------------------------------- self-test
+function selfTest() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reply-to-patch-'))
+  const fixture = path.join(tmpDir, 'server.ts')
+  // Minimal fixture reproducing the meta block shape.
+  const original = [
+    'mcp.notification({',
+    "  method: 'notifications/claude/channel',",
+    '  params: {',
+    '    content: text,',
+    '    meta: {',
+    '      chat_id,',
+    '      user: from.username ?? String(from.id),',
+    '      ts: new Date((ctx.message?.date ?? 0) * 1000).toISOString(),',
+    '    },',
+    '  },',
+    '})',
+    '',
+  ].join('\n')
+  fs.writeFileSync(fixture, original, 'utf8')
+
+  const checks = []
+  const ok = (name, cond) => checks.push({ name, cond: !!cond })
+
+  const first = patchFile(fixture)
+  ok('first run patches', first.status === 'patched')
+  let after = fs.readFileSync(fixture, 'utf8')
+  ok('marker inserted', after.includes(MARKER))
+  ok('reply_to_message_id inserted', after.includes('reply_to_message_id: String(ctx.message.reply_to_message.message_id)'))
+  ok('reply_to_text inserted', after.includes('reply_to_text:'))
+  ok('anchor line preserved', after.includes('ts: new Date((ctx.message?.date ?? 0) * 1000).toISOString(),'))
+
+  const second = patchFile(fixture)
+  ok('second run is a no-op', second.status === 'already')
+  const afterSecond = fs.readFileSync(fixture, 'utf8')
+  ok('idempotent: file unchanged on re-run', afterSecond === after)
+  ok('exactly one marker', afterSecond.split(MARKER).length - 1 === 1)
+
+  // A fresh (unpatched) fixture with a reshaped anchor -> no-anchor, no corruption.
+  const reshaped = path.join(tmpDir, 'reshaped.ts')
+  fs.writeFileSync(reshaped, original.replace('ts: new Date', 'timestamp: new Date'), 'utf8')
+  const na = patchFile(reshaped)
+  ok('no-anchor when anchor line changed', na.status === 'no-anchor')
+  ok('no-anchor leaves file untouched', fs.readFileSync(reshaped, 'utf8') === original.replace('ts: new Date', 'timestamp: new Date'))
+
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+
+  let failed = 0
+  for (const c of checks) {
+    console.log(`  ${c.cond ? 'PASS' : 'FAIL'}: ${c.name}`)
+    if (!c.cond) failed++
+  }
+  console.log(failed === 0 ? 'self-test: OK' : `self-test: ${failed} FAILED`)
+  return failed === 0 ? 0 : 1
+}
+
+// ------------------------------------------------------------------------- main
+const args = process.argv.slice(2)
+if (args.includes('--self-test')) {
+  process.exit(selfTest())
+} else if (args.includes('--file')) {
+  const p = args[args.indexOf('--file') + 1]
+  if (!p) {
+    console.error('patch-telegram-reply-to: --file requires a path')
+    process.exit(1)
+  }
+  const res = patchFile(path.resolve(p))
+  console.log(`patch-telegram-reply-to: ${p} -> ${res.status}`)
+  process.exit(res.status === 'no-anchor' ? 2 : 0)
+} else {
+  process.exit(runAll({ verbose: args.includes('--verbose') }))
+}

--- a/scripts/systemd/marveen-channels.service
+++ b/scripts/systemd/marveen-channels.service
@@ -22,6 +22,11 @@ WorkingDirectory=/path/to/marveen
 # ABI before starting. Prevents the "Could not locate the bindings file"
 # crash-loop after an npm install / Node upgrade (root-caused 2026-07-03).
 ExecStartPre=/path/to/marveen/scripts/ensure-native-modules.sh
+# Reapply the local Telegram reply-to patch (upstream issue #929 workaround) so a
+# channel (re)start immediately after a plugin update runs the patched server.ts,
+# instead of waiting up to a watchdog tick. Idempotent + best-effort: the leading
+# '-' means a patch failure never blocks the channel bridge from starting.
+ExecStartPre=-/path/to/marveen/scripts/patch-telegram-reply-to.mjs
 ExecStart=/path/to/marveen/scripts/channels.sh
 # P1 FIX: always (not on-failure). channels.sh exits 0 when the tmux session
 # dies normally, which on-failure did NOT restart -> the bridge was dead for


### PR DESCRIPTION
## Probléma

Az upstream `anthropics/claude-plugins-official` telegram plugin (v0.0.6) a `handleInbound()` notification `meta` objektumába (`server.ts`, a `mcp.notification({ method: 'notifications/claude/channel' ... })` blokk) beteszi a `chat_id`/`message_id`/`user`/`ts`/`attachment_*` mezőket, de a `ctx.message.reply_to_message`-ből semmit. Így amikor a felhasználó egy korábbi üzenetre **idézve válaszol** (quote-reply), az ágens sosem látja, MELYIK üzenetre. Az adat elérhető (`ctx.message.reply_to_message`, a plugin máshol már használja), csak nem jut el a meta-ba.

Upstream zsákutca: ~10 community PR merge nélkül closed, #929 és #988 nyitott. Ezért a telepített plugint patcheljük helyben, idempotensen, és minden plugin-update után automatikusan újra-alkalmazzuk.

## Megoldás

**`scripts/patch-telegram-reply-to.mjs`** - idempotens patcher:
- Az összes telepített telegram plugin `server.ts`-ét glob-bal deríti ki (`~/.claude/plugins/cache/claude-plugins-official/telegram/*/server.ts` + `CLAUDE_PLUGIN_ROOT`-ból származtatva), **nem hardcode-olja a 0.0.6-ot**.
- A `ts:` sor utáni horgonyponthoz szúrja be a feltételes spread-et: `reply_to_message_id` (String) + `reply_to_text` (a text/caption első 500 karaktere), csak ha `ctx.message?.reply_to_message` létezik.
- Marker-őrzött (`marveen-patch:reply-to`) - újra-futtatva no-op. Atomikus write (temp + rename).
- Ha az upstream átalakítja a blokkot (horgony eltűnik), `no-anchor`-t jelent és **nem rontja el a fájlt**.
- Van hermetikus `--self-test`.

**Auto-reapply guard (verzió/hash-váltás kezelése):**
- `channel-watchdog.sh` - a meglévő 5 perces systemd-timer heartbeat minden tickben lefuttatja a (olcsó, csak-változáskor-beszélő) patchert. Ez veszi észre, ha egy plugin-update visszaírta az eredetit, és újra-alkalmaz. Best-effort, sosem blokkolja a health-check-eket.
- `marveen-channels.service` - `ExecStartPre` reapply (leading `-`, best-effort), hogy egy update utáni channel-(re)start azonnal a patchelt `server.ts`-t futtassa, ne csak a következő watchdog-tickre.

**Teszt:** `scripts/__tests__/patch-telegram-reply-to.test.sh` - patch/idempotencia/no-anchor/wiring/portability (14 assertion, mind zöld).

## Verifikáció

- Patcher `--self-test`: OK.
- Patch egy **másolaton** az éles 0.0.6 `server.ts`-ről: a beszúrás pontosan a `ts:` sor után, 8-szóköz indent, majd `image_path` - `bun build --external '*'` exit 0, ugyanúgy fordul mint az eredeti. Re-run: `already` (idempotens).
- `bash -n scripts/channel-watchdog.sh`: OK.
- `src/__tests__/channel-stability-contract.test.ts` (git worktree-ben): **19/19 pass** - a `.service`/watchdog edit semmit nem tör.
- Az **éles plugin ÉRINTETLEN** ebben a PR-ben; aktiválás merge + deploy után a watchdog/ExecStartPre végzi.

## Megjegyzés

Ha az upstream #929 valaha mergelődik: töröld a scriptet + a két hívóját (watchdog blokk, ExecStartPre sor) és a beszúrt blokkot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)