### PR TITLE
fix(install): the Linux installer can no longer stop on a dialog nobody can see

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -197,6 +197,51 @@ APT_LOCK_WAIT_CAP=300   # 5 perc -- az apt-daily ennyi alatt tipikusan vegez
 # az esetre, ha a pre-flight utan, de a parancs elott ugrik be egy uj holder.
 APT_OPTS="-o DPkg::Lock::Timeout=180"
 
+# ── interaktiv dialogusok kizarasa (APTPROMPT802) ────────────────────
+# 2026-08-02, eles gepen merve: az elso VALODI elso-telepitesnel a
+#   sudo apt-get install -y nodejs
+# elakadt egy whiptail ablakon ("Pending kernel upgrade"), amit a needrestart
+# apt-hookja nyitott (apt-pinvoke -m u). A telepito a Marveen appbol fut, ahol
+# nincs terminal es nincs stdin -- a dialogus tehat nem elnyomhato, a telepites
+# ott all, amig valaki kezzel ki nem lovi. A naplo elso jele: "dpkg-preconfigure:
+# unable to re-open stdin". Eddig azert nem jott elo, mert a teszt-gepeken a node
+# mar fent volt a korabbi korokbol, es ez a lepes kimaradt.
+#
+# HAROM retegben zarjuk ki, mert egy reteg sem eleg onmagaban:
+#   1. DEBIAN_FRONTEND=noninteractive -- a debconf keresek ellen.
+#   2. NEEDRESTART_MODE=a + NEEDRESTART_SUSPEND=1 -- a needrestart apt-hookja
+#      ellen; ez az, ami a konkret gepet megfogta, es amit a frontend NEM fed.
+#   3. </dev/null minden hivason -- ha egy hook megis kerdez, azonnal EOF-ot kap
+#      a helyett, hogy a telepito sajat stdinjere varna.
+#
+# MIERT INLINE ATADAS ES NEM CSAK export: a sudo alapertelmezesben env_reset-tel
+# fut, tehat az exportalt valtozo NEM jut at. Debian 13-on megmerve:
+#   export DEBIAN_FRONTEND=... ; sudo printenv DEBIAN_FRONTEND -> URES
+#   sudo DEBIAN_FRONTEND=... printenv DEBIAN_FRONTEND        -> noninteractive
+#   sudo -E printenv DEBIAN_FRONTEND                          -> noninteractive
+# Ezert a sudo-s hivasoknal a valtozok a parancs ele kerulnek, es az export CSAK
+# a `sudo -E`-vel indulo gyerekek (nodesource setup-script) miatt marad meg.
+NONINTERACTIVE_ENV="DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a NEEDRESTART_SUSPEND=1"
+export DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a NEEDRESTART_SUSPEND=1
+# A meglevo config-fajlokat megtartjuk, ujat nem kerdezunk: a "melyik verziot
+# tartsam meg?" dpkg-prompt ugyanugy megallitana a telepitest, mint a needrestart.
+DPKG_KEEP_CONF="-o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef"
+
+# MINDEN apt-get hivas ezen a fuggvenyen megy at. Egy hely, ahol a fenti harom
+# reteg egyutt van -- egy uj hivas hozzaadasakor nem lehet elfelejteni az
+# egyiket, es a teszt ezt a fuggvenyt futtatja, nem a leirasat.
+apt_run() {
+  # shellcheck disable=SC2086
+  sudo $NONINTERACTIVE_ENV apt-get $APT_OPTS $DPKG_KEEP_CONF "$@" </dev/null
+}
+
+# dnf/yum: a -y a csomag- es GPG-kulcs-kerdeseket is elfogadja, needrestart ott
+# nincs; a stdin-lezaras viszont ugyanugy kell, es a valtozok atadasa artalmatlan.
+pkg_install_noninteractive() {
+  # shellcheck disable=SC2086
+  sudo $NONINTERACTIVE_ENV "$PKG_MANAGER" install -y "$@" </dev/null
+}
+
 # stdout: "<pid> <procnev>" ha valaki fogja barmelyik lockot; ures + exit 1 ha
 # szabad. fuser nelkul exit 2 = NEM TUDJUK megallapitani (ismeretlen allapot).
 apt_lock_holder() {
@@ -326,8 +371,8 @@ if [ -n "$MISSING_PKGS" ]; then
       # kulonben a repo-lepes neman kimarad, a disztro sajat (regebbi) nodejs-e
       # telepul, es Debianon az npm (kulon csomag) le se jon -> [1/7] fail.
       if ! command -v curl &>/dev/null; then
-        sudo apt-get $APT_OPTS update -qq || true
-        sudo apt-get $APT_OPTS install -y curl -qq || true
+        apt_run update -qq || true
+        apt_run install -y curl -qq || true
         hash -r
       fi
       echo -e "  Node.js v22 repo hozzaadasa (nodesource)..."
@@ -337,7 +382,7 @@ if [ -n "$MISSING_PKGS" ]; then
       NODESOURCE_OK=false
       if command -v curl &>/dev/null; then
         NODESOURCE_SETUP="$(curl -fsSL https://deb.nodesource.com/setup_22.x 2>/dev/null || true)"
-        if [ -n "$NODESOURCE_SETUP" ] && echo "$NODESOURCE_SETUP" | sudo -E bash - >/dev/null 2>&1; then
+        if [ -n "$NODESOURCE_SETUP" ] && echo "$NODESOURCE_SETUP" | sudo -E $NONINTERACTIVE_ENV bash - >/dev/null 2>&1; then
           NODESOURCE_OK=true # a nodesource nodejs csomag node+npm-et egyben hozza
         fi
       fi
@@ -345,14 +390,14 @@ if [ -n "$MISSING_PKGS" ]; then
         # Fallback: disztro sajat nodejs-e. Debianon az npm kulon csomag,
         # a nodesource-bundle-lel ellentetben nem jon a nodejs-sel magatol.
         warn "nodesource repo hozzaadasa sikertelen -- a disztro sajat nodejs + npm csomagjat telepitem."
-        sudo apt-get $APT_OPTS update -qq
+        apt_run update -qq
         MISSING_PKGS="$MISSING_PKGS npm"
       fi
     else
-      sudo apt-get $APT_OPTS update -qq
+      apt_run update -qq
     fi
     # shellcheck disable=SC2086
-    sudo apt-get $APT_OPTS install -y $MISSING_PKGS -qq
+    apt_run install -y $MISSING_PKGS -qq
   else
     # dnf/yum (Fedora/Nobara/RHEL). A disztro nodejs csomagja v20+ az aktualis
     # kiadasokon, es az npm-et is tartalmazza -- nincs szukseg kulso repora.
@@ -360,7 +405,7 @@ if [ -n "$MISSING_PKGS" ]; then
     # python3/pipx/unzip/nodejs). Az ffmpeg-hez Fedoran az RPM Fusion repo
     # kellhet; ha mar engedelyezve van, a csomag elerheto.
     # shellcheck disable=SC2086
-    sudo "$PKG_MANAGER" install -y $MISSING_PKGS
+    pkg_install_noninteractive $MISSING_PKGS
   fi
 fi
 

--- a/src/__tests__/installer-noninteractive-apt.test.ts
+++ b/src/__tests__/installer-noninteractive-apt.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// APTPROMPT802, measured on a live host during a real first install:
+//
+//   bash install-linux.sh
+//     -> sudo apt-get $APT_OPTS install -y nodejs -qq
+//       -> sh -c "/usr/lib/needrestart/apt-pinvoke -m u"
+//         -> whiptail --msgbox "Pending kernel upgrade"      <-- install stops here
+//
+// The customer installs from the Marveen app: no terminal, no stdin, nothing to
+// dismiss the dialog with. It appears on any machine with a pending kernel
+// upgrade or a service needing restart. It had been hidden until now because the
+// test machines already had node from earlier rounds, so this apt-install step
+// never ran.
+//
+// Three layers are needed and none is sufficient alone:
+//   DEBIAN_FRONTEND=noninteractive  -- debconf prompts
+//   NEEDRESTART_MODE=a + SUSPEND=1  -- the needrestart apt hook, which the
+//                                      frontend variable does NOT cover
+//   </dev/null                      -- so a hook that still asks gets EOF
+//                                      instead of the installer's own stdin
+//
+// And the delivery matters as much as the values: `sudo` runs with env_reset by
+// default, so an exported variable never reaches apt-get. Measured on Debian 13:
+//   export DEBIAN_FRONTEND=... ; sudo printenv DEBIAN_FRONTEND -> empty
+//   sudo DEBIAN_FRONTEND=... printenv DEBIAN_FRONTEND          -> noninteractive
+// The wrappers therefore pass the variables INLINE. These tests execute the real
+// wrappers out of the shipped script with `sudo` stubbed, because "the script
+// says noninteractive somewhere" is exactly the check that would have passed on
+// the broken version.
+
+const ROOT = join(__dirname, '..', '..')
+const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+
+/** Pull one shell function out of the script so it can be executed for real. */
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+  if (start < 0) throw new Error(`function ${name} not found`)
+  let i = src.indexOf('{', start) + 1
+  let depth = 1
+  while (i < src.length && depth > 0) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}') depth--
+    i++
+  }
+  return src.slice(start, i)
+}
+
+/**
+ * Stub `sudo` that stands in for the whole apt chain. It reports what it was
+ * handed, and -- the point of the exercise -- whether a needrestart-style hook
+ * COULD have opened a dialog: that happens when the suspend/mode variables are
+ * absent AND stdin still has something to read (a tty, or in this harness the
+ * parent's pipe). With the fix both conditions fail.
+ */
+function stubDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'aptprompt-'))
+  const sudo = join(dir, 'sudo')
+  writeFileSync(
+    sudo,
+    [
+      '#!/usr/bin/env bash',
+      'ARGV="$*"',
+      '# Leading VAR=value assignments are how sudo receives environment.',
+      'HAS_FRONTEND=no; HAS_MODE=no; HAS_SUSPEND=no',
+      'case "$ARGV" in *DEBIAN_FRONTEND=noninteractive*) HAS_FRONTEND=yes ;; esac',
+      'case "$ARGV" in *NEEDRESTART_MODE=a*) HAS_MODE=yes ;; esac',
+      'case "$ARGV" in *NEEDRESTART_SUSPEND=1*) HAS_SUSPEND=yes ;; esac',
+      '# Anything left on stdin? A prompting hook would read it and wait.',
+      'STDIN_DATA=$(head -c 16 2>/dev/null || true)',
+      'if [ -n "$STDIN_DATA" ]; then HAS_STDIN=yes; else HAS_STDIN=no; fi',
+      'if [ "$HAS_SUSPEND" = no ] && [ "$HAS_MODE" = no ] && [ "$HAS_STDIN" = yes ]; then',
+      '  echo "DIALOG_OPENED"',
+      'fi',
+      'echo "ARGV=$ARGV"',
+      'echo "FRONTEND=$HAS_FRONTEND MODE=$HAS_MODE SUSPEND=$HAS_SUSPEND STDIN=$HAS_STDIN"',
+    ].join('\n'),
+    'utf-8',
+  )
+  chmodSync(sudo, 0o755)
+  return dir
+}
+
+/**
+ * Run a shell snippet with the real wrapper definitions in scope and `sudo`
+ * stubbed. The parent stdin deliberately CARRIES DATA, so a missing </dev/null
+ * shows up as STDIN=yes rather than as a silent pass.
+ */
+function runWithStub(snippet: string, defs: string): string {
+  const dir = stubDir()
+  const script = [
+    'set -e',
+    'APT_OPTS="-o DPkg::Lock::Timeout=180"',
+    'NONINTERACTIVE_ENV="DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a NEEDRESTART_SUSPEND=1"',
+    'DPKG_KEEP_CONF="-o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef"',
+    'PKG_MANAGER=dnf',
+    defs,
+    snippet,
+  ].join('\n')
+  return execFileSync('bash', ['-c', script], {
+    encoding: 'utf-8',
+    input: 'PROMPT-ANSWER\n'.repeat(4),
+    env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+  })
+}
+
+// Sliced lazily, per test. Doing it at module load would turn a DELETED wrapper
+// into a collection error ("no tests"), and a run that reports nothing is the
+// worst outcome for a guard: it looks like an infrastructure problem rather
+// than the regression it is. Lazily, each test fails with the missing name.
+const aptRun = () => sliceShellFn(LINUX, 'apt_run')
+const pkgInstall = () => sliceShellFn(LINUX, 'pkg_install_noninteractive')
+
+describe('APTPROMPT802: the Linux installer can never stop on a dialog', () => {
+  it('apt_run hands apt-get all three non-interactive signals, inline through sudo', () => {
+    const out = runWithStub('apt_run install -y nodejs -qq', aptRun())
+    expect(out).toContain('FRONTEND=yes MODE=yes SUSPEND=yes')
+    // Inline, i.e. before the command: an exported variable would not survive
+    // sudo's env_reset, which is the whole reason this is not just an export.
+    expect(out).toMatch(/ARGV=.*DEBIAN_FRONTEND=noninteractive.*apt-get/)
+  })
+
+  it('apt_run closes stdin, so a hook that still asks gets EOF', () => {
+    const out = runWithStub('apt_run update -qq', aptRun())
+    expect(out).toContain('STDIN=no')
+    expect(out).not.toContain('DIALOG_OPENED')
+  })
+
+  it('apt_run keeps existing config files instead of asking which to keep', () => {
+    const out = runWithStub('apt_run install -y nodejs -qq', aptRun())
+    expect(out).toContain('--force-confold')
+    expect(out).toContain('--force-confdef')
+  })
+
+  it('the dnf/yum path is closed the same way', () => {
+    const out = runWithStub('pkg_install_noninteractive ffmpeg git', pkgInstall())
+    expect(out).toMatch(/ARGV=.*dnf install -y ffmpeg git/)
+    expect(out).toContain('STDIN=no')
+    expect(out).not.toContain('DIALOG_OPENED')
+  })
+
+  // The instrument control. Without it the four tests above could be green
+  // against a script that never changed: they must FAIL on the pre-fix form.
+  it('CONTROL: the pre-fix call shape opens the dialog and is seen doing it', () => {
+    const preFix = 'legacy_apt() { sudo apt-get $APT_OPTS "$@"; }'
+    const out = runWithStub('legacy_apt install -y nodejs -qq', preFix)
+    expect(out).toContain('DIALOG_OPENED')
+    expect(out).toContain('FRONTEND=no MODE=no SUSPEND=no STDIN=yes')
+    expect(out).not.toContain('--force-confold')
+  })
+
+  it('no package-manager call bypasses the wrappers', () => {
+    // A hint string printed for a human at a terminal is not an invocation; an
+    // executed one always begins the line (possibly indented).
+    const executed = LINUX.split('\n').filter((l) =>
+      /^\s*(sudo\s+apt-get|sudo\s+"?\$PKG_MANAGER"?\s+install|sudo\s+dnf|sudo\s+yum)\b/.test(l),
+    )
+    expect(executed).toEqual([])
+  })
+
+  it('the nodesource setup script inherits the same signals', () => {
+    // It runs its own apt-get update/install inside, so it can hit the very same
+    // needrestart hook. `sudo -E` alone would depend on sudoers policy.
+    const line = LINUX.split('\n').find((l) => l.includes('sudo -E') && l.includes('bash -'))
+    expect(line).toBeDefined()
+    expect(line).toContain('$NONINTERACTIVE_ENV')
+  })
+})


### PR DESCRIPTION
Card **APTPROMPT802**. Blocking for tomorrow's live customer install.

Measured on a live host during a real first install:

```
sudo apt-get $APT_OPTS install -y nodejs -qq
  -> sh -c "/usr/lib/needrestart/apt-pinvoke -m u"
    -> whiptail --msgbox "Pending kernel upgrade"     <-- the install stops here
```

and it sat there until someone killed the whiptail by hand. First sign in the log: `dpkg-preconfigure: unable to re-open stdin`. The customer installs **from the Marveen app**: no terminal, no stdin, nothing to dismiss the dialog with. It appears on any machine with a pending kernel upgrade or a service needing restart.

Not a new regression -- the test machines already had node from earlier rounds, so this apt-install step never ran. The first genuinely-first install exposed it.

## The fix

Three layers, because the one that actually bit is not covered by the obvious one:

| layer | covers |
|---|---|
| `DEBIAN_FRONTEND=noninteractive` | debconf prompts |
| `NEEDRESTART_MODE=a` + `NEEDRESTART_SUSPEND=1` | the needrestart apt hook -- **this** is what stopped the install, and the frontend variable does not touch it |
| `</dev/null` | a hook that still asks gets EOF instead of the installer's own stdin |

Plus `-o Dpkg::Options::=--force-confold/--force-confdef`, because "which config file do you want to keep?" would stop the install exactly the same way.

### One deviation from the requested recipe, and it is the crux

The request was to `export` the three variables. **Measured on Debian 13 before choosing the form:**

```
export DEBIAN_FRONTEND=... ; sudo printenv DEBIAN_FRONTEND  -> EMPTY   (env_reset strips it)
sudo DEBIAN_FRONTEND=... printenv DEBIAN_FRONTEND           -> noninteractive
sudo -E printenv DEBIAN_FRONTEND                            -> noninteractive
```

`sudo` runs with `env_reset` by default, so an exported variable **never reaches apt-get** -- the export alone would have been a silent no-op fix, which is the failure family we have been chasing all day. The variables are therefore passed **inline** through sudo; the export is kept only for the `sudo -E` child (the nodesource setup script, which runs its own `apt-get update/install` and can hit the very same hook).

### Pattern, not instance

Every package-manager call now goes through `apt_run` / `pkg_install_noninteractive` instead of being patched one site at a time -- the lesson from this morning's `set -e` / apt-lock bug. A new call site cannot forget one of the three layers, and the test executes the wrapper rather than describing it.

Rewired: the curl bootstrap pair, both `update` calls, the `MISSING_PKGS` install, the dnf/yum install, and the nodesource `sudo -E bash -`.

## Tests (7 new)

The real wrappers are sliced out of the shipped script and run with `sudo` stubbed. The stub reports what it received and whether a needrestart-style hook **could** have opened a dialog -- suspend/mode absent AND stdin still readable. The harness feeds the parent stdin with data on purpose, so a missing `</dev/null` shows up as `STDIN=yes` instead of a silent pass.

**Instrument control, run:** against the pre-fix `install-linux.sh`, **six of the seven fail**; the seventh is the control itself, which asserts the old shape *does* open the dialog. Slicing is lazy, so a deleted wrapper fails each test by name rather than collapsing the file into "no tests" -- a run that reports nothing is the worst outcome for a guard.

Suite **3179/3179**, `tsc` clean, `bash -n` clean, em dash 0.

## Does it reach the customer? Dry run says yes, after the re-vendor

The app SFTPs a script *derived* from `installer/vendor/public-install-linux.sh` in the bridge-installer repo. I ran the whole chain against this commit as a dry run: vendored the fixed baseline, pinned the SHA, `npm run build` (the derive drift asserts pass), installer suite **109/109**, and the derived payload is `bash -n` clean and carries the wrappers at its own line numbers. So the re-vendor after merge is mechanical -- nothing in the transform trips on the new shape.

## What I did NOT reach (asked for explicitly)

| line | call | why it is out |
|---|---|---|
| 1378 | `curl -fsSL https://ollama.com/install.sh \| sh` | third-party script running its own `sudo`; our inline variables do not reach it. It installs from a tarball rather than apt, so no debconf/needrestart hook -- but it is genuinely outside the wrappers. |
| 508 | `sudo npm install -g @anthropic-ai/claude-code@...` | npm has no debconf/needrestart path. |
| 315, 1375, 1392 | `sudo fallocate/chmod/mkswap/swapon`, `sudo -v`, `sudo systemctl enable --now ollama` | no package transaction, so no prompting hook. |
| 1435 | `pipx install openai-whisper` | user-scope, non-interactive. |
| 416 | `NODE_FIX_HINT="sudo apt-get install nodejs"` | a hint string printed for a human at a terminal, not an invocation. |

`install-macos.sh` is untouched: brew/pipx/npm, no debconf and no needrestart.

## Base branch

Opened against **develop**, following #847 (the apt-lock fix this morning), which went to develop and reached the customer via the promote. If tonight's release has to go straight from main, say so and I will retarget or cherry-pick -- that is a release decision, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
