### PR TITLE
fix(install): the needrestart fallback lists, it does not restart

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -209,8 +209,33 @@ APT_OPTS="-o DPkg::Lock::Timeout=180"
 #
 # HAROM retegben zarjuk ki, mert egy reteg sem eleg onmagaban:
 #   1. DEBIAN_FRONTEND=noninteractive -- a debconf keresek ellen.
-#   2. NEEDRESTART_MODE=a + NEEDRESTART_SUSPEND=1 -- a needrestart apt-hookja
-#      ellen; ez az, ami a konkret gepet megfogta, es amit a frontend NEM fed.
+#   2. NEEDRESTART_SUSPEND=1 (+ NEEDRESTART_MODE=l tartalek) -- a needrestart
+#      apt-hookja ellen; ez az, ami a konkret gepet megfogta, es amit a frontend
+#      NEM fed.
+#
+#      MIERT "l" ES NEM "a", holott az "a" is elnemitja a kerdest (merve az eles
+#      gepen, needrestart 3.11 / Ubuntu 26.04, 2026-08-02):
+#        - /usr/lib/needrestart/apt-pinvoke 43-46. sor: ha NEEDRESTART_SUSPEND
+#          nem ures, kiir egy sort es `exit 0` -- az `exec needrestart` CSAK
+#          ezutan, az 49. sorban jon. Tehat SUSPEND mellett a needrestart EL SEM
+#          INDUL: sem dialogus, sem ujrainditas. A MODE azon az uton sosem jut
+#          ervenyre.
+#        - A MODE tehat TARTALEK: azokra a (regebbi) verziokra, amelyek hookja
+#          esetleg nem nezi a SUSPEND-et. Es ha a tartalek lep ervenybe, akkor
+#          szamit, MELYIK erteket adtuk: a needrestart -r modjai l = list only,
+#          i = interactive, a = automatically restart.
+#        - Az "a" tehat ujrainditana a varakozo szolgaltatasokat A TELEPITES
+#          KOZBEN. A cel-gepen ez negy szolgaltatast jelentett (dbus,
+#          networkd-dispatcher, serial-getty@ttyS0, systemd-logind), es a
+#          telepito KESOBB epit a felhasznaloi session-buszra (XDG_RUNTIME_DIR /
+#          DBUS_SESSION_BUS_ADDRESS), majd meg kesobb user-unitokat allit be. Egy
+#          dbus/logind restart a csomag-lepesben tehat egy MASIK, kesobbi lepest
+#          buktathatna el -- olyan hibat, ami semmivel nem utal vissza az aptra.
+#        - Az "l" ugyanugy nem kerdez, de nem is indit ujra semmit: a fuggo
+#          szolgaltatasok a kovetkezo rebootig a regi konyvtarakkal futnak, ami
+#          egy friss telepitesnel rendben van.
+#      NE ALLITSD VISSZA "a"-ra azzal, hogy "az alaposabb" -- itt epp az a
+#      kockazat, hogy a tartalek TOBBET csinal, mint amit kertunk tole.
 #   3. </dev/null minden hivason -- ha egy hook megis kerdez, azonnal EOF-ot kap
 #      a helyett, hogy a telepito sajat stdinjere varna.
 #
@@ -221,8 +246,8 @@ APT_OPTS="-o DPkg::Lock::Timeout=180"
 #   sudo -E printenv DEBIAN_FRONTEND                          -> noninteractive
 # Ezert a sudo-s hivasoknal a valtozok a parancs ele kerulnek, es az export CSAK
 # a `sudo -E`-vel indulo gyerekek (nodesource setup-script) miatt marad meg.
-NONINTERACTIVE_ENV="DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a NEEDRESTART_SUSPEND=1"
-export DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a NEEDRESTART_SUSPEND=1
+NONINTERACTIVE_ENV="DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l NEEDRESTART_SUSPEND=1"
+export DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l NEEDRESTART_SUSPEND=1
 # A meglevo config-fajlokat megtartjuk, ujat nem kerdezunk: a "melyik verziot
 # tartsam meg?" dpkg-prompt ugyanugy megallitana a telepitest, mint a needrestart.
 DPKG_KEEP_CONF="-o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef"

--- a/src/__tests__/installer-noninteractive-apt.test.ts
+++ b/src/__tests__/installer-noninteractive-apt.test.ts
@@ -19,8 +19,18 @@ import { join } from 'node:path'
 //
 // Three layers are needed and none is sufficient alone:
 //   DEBIAN_FRONTEND=noninteractive  -- debconf prompts
-//   NEEDRESTART_MODE=a + SUSPEND=1  -- the needrestart apt hook, which the
-//                                      frontend variable does NOT cover
+//   NEEDRESTART_SUSPEND=1           -- the needrestart apt hook, which the
+//                                      frontend variable does NOT cover. Its
+//                                      pinvoke wrapper exits BEFORE exec'ing
+//                                      needrestart when this is set, so nothing
+//                                      prompts and nothing restarts.
+//   NEEDRESTART_MODE=l              -- the fallback for older hooks that may
+//                                      not honour SUSPEND. "l" is list-only on
+//                                      purpose: "a" would silently RESTART the
+//                                      pending services mid-install (dbus and
+//                                      systemd-logind were both pending on the
+//                                      target host), and this installer depends
+//                                      on the user session bus later on.
 //   </dev/null                      -- so a hook that still asks gets EOF
 //                                      instead of the installer's own stdin
 //
@@ -68,7 +78,7 @@ function stubDir(): string {
       '# Leading VAR=value assignments are how sudo receives environment.',
       'HAS_FRONTEND=no; HAS_MODE=no; HAS_SUSPEND=no',
       'case "$ARGV" in *DEBIAN_FRONTEND=noninteractive*) HAS_FRONTEND=yes ;; esac',
-      'case "$ARGV" in *NEEDRESTART_MODE=a*) HAS_MODE=yes ;; esac',
+      'case "$ARGV" in *NEEDRESTART_MODE=l*) HAS_MODE=yes ;; esac',
       'case "$ARGV" in *NEEDRESTART_SUSPEND=1*) HAS_SUSPEND=yes ;; esac',
       '# Anything left on stdin? A prompting hook would read it and wait.',
       'STDIN_DATA=$(head -c 16 2>/dev/null || true)',
@@ -95,7 +105,7 @@ function runWithStub(snippet: string, defs: string): string {
   const script = [
     'set -e',
     'APT_OPTS="-o DPkg::Lock::Timeout=180"',
-    'NONINTERACTIVE_ENV="DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a NEEDRESTART_SUSPEND=1"',
+    'NONINTERACTIVE_ENV="DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l NEEDRESTART_SUSPEND=1"',
     'DPKG_KEEP_CONF="-o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef"',
     'PKG_MANAGER=dnf',
     defs,
@@ -134,6 +144,16 @@ describe('APTPROMPT802: the Linux installer can never stop on a dialog', () => {
     const out = runWithStub('apt_run install -y nodejs -qq', aptRun())
     expect(out).toContain('--force-confold')
     expect(out).toContain('--force-confdef')
+  })
+
+  it('the fallback mode is list-only, so it can never restart a service mid-install', () => {
+    // Read from the shipped script, not from the harness constant: the harness
+    // could keep passing while the script drifted back to "a".
+    const line = LINUX.split('\n').find((l) => l.startsWith('NONINTERACTIVE_ENV='))
+    expect(line).toBeDefined()
+    expect(line).toContain('NEEDRESTART_MODE=l')
+    expect(line).not.toContain('NEEDRESTART_MODE=a')
+    expect(LINUX).not.toContain('NEEDRESTART_MODE=a')
   })
 
   it('the dnf/yum path is closed the same way', () => {


### PR DESCRIPTION
Follow-up to **v1.28.2** (APTPROMPT802). Not urgent, not for tonight's release -- the 0.3.1 installer is already built and out, and this changes nothing about the dialog it fixes.

## What the measurement showed

That fix passes `NEEDRESTART_MODE=a` alongside `NEEDRESTART_SUSPEND=1`. Both silence the dialog; they do not do the same thing. Measured on the target host (needrestart 3.11, Ubuntu 26.04):

```
/usr/lib/needrestart/apt-pinvoke:43-46   NEEDRESTART_SUSPEND set -> print a line, exit 0
                            :49          exec needrestart "$@"   -- only reached otherwise
```

With `SUSPEND` set the needrestart binary **never starts**: nothing prompts and nothing restarts, and `MODE` never takes effect on that path.

So `MODE` is a **fallback**, for older hooks that may not honour `SUSPEND` -- and a customer's machine can be any vintage. When the fallback does take effect, the value matters:

| `-r` mode | behaviour |
|---|---|
| `l` | list only |
| `i` | interactive (the dialog we are fixing) |
| `a` | **automatically restart** the pending services |

## Why `a` is the wrong fallback here

On the target host four services were pending: `dbus`, `networkd-dispatcher`, `serial-getty@ttyS0`, `systemd-logind`. With `a`, those get restarted **during the package step** -- and this installer depends on the user session bus 150 lines later (`XDG_RUNTIME_DIR` / `DBUS_SESSION_BUS_ADDRESS`, `install-linux.sh:553-568`) and configures user units 1100 lines later (`:1538`).

A `dbus` or `logind` restart in the package step could therefore break a much later step, and nothing in that failure would point back at apt. That is a worse bug than the one we fixed, because it is not reproducible by looking at the failing step.

`l` is silent in exactly the same way and restarts nothing: the pending services keep their old libraries until the next reboot, which is fine on a fresh install.

## Guard

The reasoning sits next to the constant, because `a` reads like the more thorough option and would otherwise come back in three weeks. The risk here is the opposite of thoroughness: a fallback that does **more** than it was asked to.

The new assertion reads the value out of the **shipped script**, not the harness constant, so the test cannot stay green while the script drifts back.

**Control:** against the released v1.28.2 form, exactly that one test fails and the other seven still pass -- the released form is non-interactive, it just does more than asked.

Suite **3180/3180**, `tsc` clean, `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
