### PR TITLE
fix(install): a whisper hiba nem állíthatja meg a telepítést (macOS, bash 3.2 ERR trap)

### DIFF
--- a/install-lang.sh
+++ b/install-lang.sh
@@ -194,6 +194,10 @@ _t() {
     hu:macos.mlx_whisper_installed) echo "  mlx-whisper már telepítve (Apple Silicon optimalizált)" ;;
     en:macos.whisper_installed) echo "  whisper already installed" ;;
     hu:macos.whisper_installed) echo "  whisper már telepítve" ;;
+    en:macos.whisper_skipped) echo "whisper could not be installed -- video transcription is skipped, everything else works." ;;
+    hu:macos.whisper_skipped) echo "whisper nem telepíthető -- a videó-átirat kimarad, minden más működik." ;;
+    en:macos.whisper_skipped_hint) echo "Later, by hand: pipx install openai-whisper   (or: brew install openai-whisper)" ;;
+    hu:macos.whisper_skipped_hint) echo "Később kézzel: pipx install openai-whisper   (vagy: brew install openai-whisper)" ;;
     en:macos.ffmpeg_installing) echo "  Installing ffmpeg..." ;;
     hu:macos.ffmpeg_installing) echo "  ffmpeg telepítés..." ;;
     en:macos.ffmpeg_done) echo "  ffmpeg ready" ;;

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -959,26 +959,76 @@ if ! ollama list 2>/dev/null | grep -q "nomic-embed-text"; then
 fi
 echo -e "$(_t macos.ollama_done)"
 
-# Whisper (speech-to-text for video transcription)
+# Whisper (speech-to-text for video transcription) -- OPTIONAL.
+#
+# This block used to end the install. On an Intel Mac the operator saw only
+# "Varatlan hiba a(z) 'configuration' lepesben (sor: 982)" -- 982 being the
+# CLOSING `fi`, where nothing runs. Three defects, all fixed here:
+#
+#  1. macOS ships bash 3.2, where a command that fails inside a `{ ... }` group
+#     on the RHS of `||` STILL reaches the ERR trap, and $LINENO blames the
+#     enclosing `fi`. Same trap-vs-`fi` class as the `claude --print` probe and
+#     the service-auth probe above; same cure: call the work through a function
+#     in an `&& rc=0 || rc=$?` list, which keeps the failure out of the trap and
+#     preserves the status. An OPTIONAL dependency must never abort the install.
+#  2. `2>/dev/null` on every installer hid the reason. The real message here was
+#     "pipx needs uv>=0.9.17, but ... reports 0.5.9" -- actionable, and never
+#     shown. Let stderr through; it is captured in $INSTALL_ERRLOG too.
+#  3. mlx-whisper is MLX-based, i.e. Apple Silicon ONLY. On Intel it can never
+#     install, so the first attempt was guaranteed to fail there. Gate it on the
+#     architecture and fall back to openai-whisper, which runs everywhere.
+#
+# The old fallback also printed "openai-whisper telepítve" unconditionally --
+# after a `brew install` whose status it had just discarded. Each success line
+# now follows the command that actually succeeded.
 echo ""
 echo -e "$(_t macos.whisper_installing)"
-if command -v mlx_whisper &>/dev/null || [ -f "$HOME/.local/bin/mlx_whisper" ]; then
-  echo -e "  ${GREEN}✓${NC} $(_t macos.mlx_whisper_installed)"
-elif command -v whisper &>/dev/null; then
-  echo -e "  ${GREEN}✓${NC} $(_t macos.whisper_installed)"
-  echo -e "  ${DIM}  Tipp: pipx install mlx-whisper gyorsabb Apple Silicon-on${NC}"
-else
-  if command -v pipx &>/dev/null; then
-    pipx install mlx-whisper 2>/dev/null && echo -e "  ${GREEN}✓${NC} mlx-whisper telepítve" || {
-      brew install openai-whisper 2>/dev/null
-      echo -e "  ${GREEN}✓${NC} openai-whisper telepítve"
-    }
-  else
-    brew install pipx 2>/dev/null && pipx install mlx-whisper 2>/dev/null && echo -e "  ${GREEN}✓${NC} mlx-whisper telepítve" || {
-      brew install openai-whisper 2>/dev/null
-      echo -e "  ${GREEN}✓${NC} openai-whisper telepítve"
-    }
+
+install_whisper() {
+  if command -v mlx_whisper &>/dev/null || [ -f "$HOME/.local/bin/mlx_whisper" ]; then
+    echo -e "  ${GREEN}✓${NC} $(_t macos.mlx_whisper_installed)"
+    return 0
   fi
+
+  if command -v whisper &>/dev/null; then
+    echo -e "  ${GREEN}✓${NC} $(_t macos.whisper_installed)"
+    return 0
+  fi
+
+  if ! command -v pipx &>/dev/null; then
+    command -v brew &>/dev/null && brew install pipx
+  fi
+
+  if [ "$(uname -m)" = "arm64" ] && command -v pipx &>/dev/null; then
+    if pipx install mlx-whisper; then
+      echo -e "  ${GREEN}✓${NC} mlx-whisper telepítve"
+      return 0
+    fi
+  fi
+
+  if command -v pipx &>/dev/null; then
+    if pipx install openai-whisper; then
+      echo -e "  ${GREEN}✓${NC} openai-whisper telepítve (pipx)"
+      return 0
+    fi
+  fi
+
+  if command -v brew &>/dev/null; then
+    if brew install openai-whisper; then
+      echo -e "  ${GREEN}✓${NC} openai-whisper telepítve (brew)"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+WHISPER_RC=0
+install_whisper || WHISPER_RC=$?
+
+if [ "$WHISPER_RC" -ne 0 ]; then
+  warn "$(_t macos.whisper_skipped)"
+  echo -e "    ${DIM}$(_t macos.whisper_skipped_hint)${NC}"
 fi
 
 # ffmpeg (audio/video processing)

--- a/src/__tests__/installer-whisper-optional.test.ts
+++ b/src/__tests__/installer-whisper-optional.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// The 2026-08-03 bug: the macOS installer died with
+//
+//     Varatlan hiba a(z) 'configuration' lepesben (sor: 982).
+//
+// Line 982 is the CLOSING `fi` of the whisper block -- nothing fails there.
+// Whisper is an OPTIONAL dependency (video transcription); on an Intel Mac
+// `pipx install mlx-whisper` cannot work at all (MLX is Apple-Silicon only) and
+// the `brew install openai-whisper` fallback is a long source-ish build that can
+// fail for a dozen unrelated reasons. Either way the install ended there.
+//
+// Two defects, both already seen elsewhere in this script (the `claude --print`
+// probe at ~line 371 and the service-auth probe at ~line 672 carry the same
+// comment: "blaming the enclosing `fi`"):
+//
+//   1. macOS ships bash 3.2, where a command that fails inside a `{ ... }` group
+//      on the RHS of `||` STILL reaches the ERR trap, and $LINENO reports the
+//      enclosing `fi`. So an optional dependency killed a mandatory install.
+//   2. Every install command in the block was silenced with `2>/dev/null`, so
+//      the operator was shown a line number and nothing else -- the actual
+//      upstream error ("pipx needs uv>=0.9.17") never reached the screen or the
+//      installer's own stderr log.
+//
+// The behavioural test below executes the REAL block out of the shipped script
+// with every installer stubbed to fail, under the REAL ERR trap. The install
+// must survive and continue.
+
+const ROOT = join(__dirname, '..', '..')
+const MACOS = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
+
+/** Pull the whisper section out of the script so it can be executed for real. */
+function whisperBlock(src: string): string {
+  const start = src.indexOf('# Whisper (speech-to-text')
+  const end = src.indexOf('# ffmpeg (audio/video processing)')
+
+  if (start < 0 || end < 0 || end <= start) throw new Error('whisper block not found')
+
+  return src.slice(start, end)
+}
+
+/**
+ * Run the REAL whisper block under `set -e` + the REAL ERR trap, with pipx and
+ * brew stubbed to the chosen exit code. Returns the script's status and output.
+ */
+function runWhisperBlock(installerRc: number, stderrMsg = ''): { code: number; out: string } {
+  const script = [
+    'set -e',
+    // The installer's own trap, verbatim in spirit: report and abort.
+    'on_error() { echo "TRAP_FIRED line $1"; exit 1; }',
+    'trap \'on_error $LINENO\' ERR',
+    'GREEN=""; ORANGE=""; RED=""; NC=""; DIM=""',
+    '_t() { echo "$1"; }',
+    'ok() { echo "ok: $*"; }',
+    'warn() { echo "warn: $*"; }',
+    // No whisper is installed; pipx/brew exist but every attempt fails. A
+    // `command` function shadows the builtin, so this holds whatever the test
+    // machine happens to have on its PATH.
+    'HOME="$(mktemp -d)"',
+    'command() {',
+    '  if [ "$1" = "-v" ]; then',
+    '    case "$2" in mlx_whisper|whisper) return 1 ;; pipx|brew) return 0 ;; esac',
+    '  fi',
+    '  builtin command "$@"',
+    '}',
+    `pipx() { ${stderrMsg ? `echo "${stderrMsg}" >&2;` : ''} return ${installerRc}; }`,
+    `brew() { ${stderrMsg ? `echo "${stderrMsg}" >&2;` : ''} return ${installerRc}; }`,
+    whisperBlock(MACOS),
+    'echo REACHED_THE_END',
+  ].join('\n')
+
+  const file = join(mkdtempSync(join(tmpdir(), 'marveen-whisper-')), 'block.sh')
+  writeFileSync(file, script)
+
+  try {
+    // /bin/bash deliberately: that is bash 3.2 on macOS, the shell the shipped
+    // installer actually runs under and the only one that shows defect (1).
+    const out = execFileSync('/bin/bash', [file], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] })
+    return { code: 0, out }
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: string; stderr?: string }
+    return { code: err.status ?? -1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` }
+  }
+}
+
+describe('install-macos.sh: whisper is an optional dependency', () => {
+  it('continues the install when every whisper installer fails', () => {
+    const { code, out } = runWhisperBlock(1, 'pipx needs uv>=0.9.17')
+
+    expect(out).not.toContain('TRAP_FIRED')
+    expect(out).toContain('REACHED_THE_END')
+    expect(code).toBe(0)
+  })
+
+  it('tells the operator whisper was skipped instead of failing silently', () => {
+    const { out } = runWhisperBlock(1)
+
+    expect(out.toLowerCase()).toMatch(/whisper/)
+    expect(out).toContain('warn:')
+  })
+
+  it('does not swallow the installer error that explains the skip', () => {
+    // `2>/dev/null` on the pipx/brew calls is what reduced a real, actionable
+    // upstream message to a bare line number.
+    const code = whisperBlock(MACOS)
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('#'))
+
+    expect(code.filter((l) => l.includes('2>/dev/null'))).toEqual([])
+  })
+
+  it('still reports success when an installer works', () => {
+    const { code, out } = runWhisperBlock(0)
+
+    expect(out).toContain('REACHED_THE_END')
+    expect(out).toContain('✓')
+    expect(out).not.toContain('warn:')
+    expect(code).toBe(0)
+  })
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** Egy friss macOS telepítés a `configuration` lépésben elszállt:

```
Varatlan hiba a(z) 'configuration' lepesben (sor: 982).
```

A 982. sor a whisper-blokk záró `fi`-je, ahol semmi nem fut. A whisper **opcionális** függőség (videó-átirat), mégis megölte a kötelező telepítést. Három hiba:

1. **A trap a `fi`-t hibáztatja.** A macOS `/bin/bash` a **3.2.57**. Ebben a `||` jobb oldalán álló `{ ... }` csoporton belül bukott parancs is elsüti az `ERR` trap-et, és a `$LINENO` a külső `fi`-t jelenti. Ugyanaz az osztály, mint a `claude --print` probe (~371. sor) és a service-auth probe (~672. sor) -- mindkettő komment már most is azt írja, hogy *"blaming the enclosing `fi`"*. Ugyanaz a gyógymód: a munka egy függvénybe kerül, és `install_whisper || WHISPER_RC=$?` alakban hívjuk, ami kiveszi a hibát a trap alól és megőrzi a státuszt.
2. **`2>/dev/null` minden telepítő-híváson.** A valódi, közvetlenül orvosolható üzenet (`pipx needs uv>=0.9.17, but ... reports 0.5.9`) sosem jutott el a képernyőre, sem az `$INSTALL_ERRLOG`-ba. Az operátor egy puszta sorszámot kapott. A csendesítés megszűnt.
3. **`mlx-whisper` Apple Silicon-only.** MLX-alapú, tehát Intel Macen az *első* kísérlet garantáltan bukott, és onnan már csak a hosszú, törékeny `brew install openai-whisper` build maradt. Most `uname -m` alapján dől el, és Intelen egyből az `openai-whisper` jön.

Ráadás: a régi fallback akkor is kiírta, hogy `✓ openai-whisper telepítve`, ha a `brew install` épp elszállt (a státuszát eldobta). Most minden siker-sor a ténylegesen sikeres parancs után jön, és ha egyik út sem működik, a telepítő `warn`-nal jelzi, hogy a videó-átirat kimarad, plusz megadja a kézi parancsot.

**EN.** A fresh macOS install aborted at step `configuration` with "Unexpected error at line 982" -- the closing `fi` of the whisper block, where nothing runs. Whisper is an OPTIONAL dependency (video transcription) yet it killed a mandatory install. Three defects: (1) macOS bash 3.2 still fires the `ERR` trap for a command failing inside a `{ ... }` group on the RHS of `||`, blaming the enclosing `fi` -- same class and same cure as the two probes above it; (2) `2>/dev/null` swallowed the actionable upstream error; (3) mlx-whisper is Apple-Silicon only, so on Intel the first attempt could never succeed. The old fallback also printed a success line after a `brew install` whose status it had discarded.

### Teszt / Tests

Új: `src/__tests__/installer-whisper-optional.test.ts`. A meglévő installer-teszt idiómát követi (`installer-apt-lock-set-e.test.ts`): kivágja a **valódi** whisper-blokkot a leszállított scriptből, és lefuttatja `/bin/bash` alatt `set -e` + valódi `ERR` trap mellett, `pipx`/`brew` stubbal.

- RED a javítás előtt: `TRAP_FIRED line 37` (a blokk záró `fi`-je) -- pontosan a produkciós hiba.
- GREEN utána: 4/4, a telepítés eléri a `REACHED_THE_END`-et, `warn`-nal jelzi a kihagyást.
- Regresszió: a 4 meglévő installer teszt zöld (64 teszt), `tsc --noEmit` exit 0, `bash -n` mindkét scripten OK.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
      <!-- Nem futott le teljes éles újratelepítés: a változás kizárólag az install-macos.sh whisper-blokkját érinti, ami a futó ágenseket/dashboardot nem befolyásolja. A blokk viselkedése automata teszttel van lefedve (valódi kód, valódi bash 3.2, valódi ERR trap), plusz a hibás `pipx install mlx-whisper` kézzel reprodukálva Intel Macen. / No full live reinstall was run: the change touches only the whisper block of install-macos.sh, which does not affect running agents or the dashboard. The block is covered by an automated test that executes the real code under the real bash 3.2 and the real ERR trap, and the failing `pipx install mlx-whisper` was reproduced by hand on an Intel Mac. -->
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
      <!-- Nem szükséges: a telepítés dokumentált felülete és lépései változatlanok. / Not needed: the documented install surface and steps are unchanged. -->
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
