### PR TITLE
fix(install): a natív modul a SZOLGÁLTATÁS node-jára forduljon (macOS, better-sqlite3 ABI)

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -524,12 +524,61 @@ fi
 BRAND_NAME="$BOT_NAME"
 SERVICE_ID="$MAIN_AGENT_ID"
 
+# Resolve the Node the launchd SERVICES will run, and pin the whole install to
+# it. Idempotent: sets NODE_PATH / NODE_BIN_DIR once, both the npm step below and
+# the launchagent step later call it.
+#
+# This used to live only in the launchagent step, ~600 lines further down -- long
+# AFTER `npm rebuild better-sqlite3`. So the install compiled the native module
+# against whatever generic `node` was on the operator's PATH (v25/v26, ABI 141)
+# and THEN handed the services node@22 (ABI 127). The pin worked exactly as
+# designed and the module was still built for the wrong runtime:
+#
+#   better_sqlite3.node was compiled against NODE_MODULE_VERSION 141.
+#   This version of Node.js requires NODE_MODULE_VERSION 127.
+#
+# `channels` survived (it touches no DB); the dashboard died on its first
+# require, so store/.dashboard-token -- written on first successful boot -- was
+# never created, and the installer still printed "sikeresen telepitve".
+resolve_service_node() {
+  [ -n "${NODE_PATH:-}" ] && [ -x "${NODE_PATH:-}" ] && return 0
+
+  # Homebrew's generic `node` symlink auto-upgrades to new majors whose ABI
+  # breaks the prebuilt better-sqlite3. node@22 is keg-only, so a generic `node`
+  # of any major can coexist -- pin to its keg path.
+  local prefix
+  prefix="$(brew --prefix node@22 2>/dev/null || true)"
+
+  if { [ -z "$prefix" ] || [ ! -x "$prefix/bin/node" ]; } && command -v brew &>/dev/null; then
+    echo -e "  ${ORANGE}node@22 telepitese a launchd szolgaltatasokhoz (ABI-stabil better-sqlite3)...${NC}"
+    brew install node@22 || true
+    prefix="$(brew --prefix node@22 2>/dev/null || true)"
+  fi
+
+  if [ -n "$prefix" ] && [ -x "$prefix/bin/node" ]; then
+    NODE_PATH="$prefix/bin/node"
+  else
+    # Last-resort fallback: node@22 could not be installed (e.g. no brew). The
+    # services may still break on an ABI-incompatible node -- warn loudly.
+    NODE_PATH="$(which node)"
+    echo -e "  ${RED}Figyelem:${NC} node@22 nem elerheto, a szolgaltatasok ${NODE_PATH}-ra allnak. ABI-hiba eseten telepitsd: brew install node@22"
+  fi
+
+  NODE_BIN_DIR="$(dirname "$NODE_PATH")"
+}
+
 # Step 5: Install dependencies
 INSTALL_STEP="npm-install"
 echo ""
 echo -e "${BOLD}$(_t section_5)${NC}"
 cd "$INSTALL_DIR"
-if ! npm install --loglevel warn || ! npm rebuild better-sqlite3 --build-from-source; then
+resolve_service_node
+# Prepending NODE_BIN_DIR is what makes the rebuild target the SERVICE runtime:
+# npm resolves `node` through PATH, and node-gyp compiles against the node that
+# resolves. Same reason `npm install` runs here too -- it can fetch or build
+# native prebuilds of its own.
+if ! PATH="$NODE_BIN_DIR:$PATH" npm install --loglevel warn \
+  || ! PATH="$NODE_BIN_DIR:$PATH" npm rebuild better-sqlite3 --build-from-source; then
   fail "npm install sikertelen. Ellenorizd a hibauzeneteket fentebb."
 fi
 ok "$(_t macos.npm_done)"
@@ -1053,27 +1102,10 @@ echo -e "${BOLD}$(_t section_7)${NC}"
 PLIST_DIR="$HOME/Library/LaunchAgents"
 mkdir -p "$PLIST_DIR"
 
-# Pin launchd services to a stable Node 22 (brew node@22). Homebrew's generic
-# `node` symlink auto-upgrades to new majors (e.g. 26) whose ABI breaks the
-# prebuilt better-sqlite3 binary, preventing the dashboard from starting and the
-# dashboard token from ever being created. node@22 is keg-only, so a generic
-# `node` of any major can coexist -- we ensure node@22 is present and pin the
-# services directly to its keg path.
-NODE22_PREFIX="$(brew --prefix node@22 2>/dev/null || true)"
-if { [ -z "$NODE22_PREFIX" ] || [ ! -x "$NODE22_PREFIX/bin/node" ]; } && command -v brew &>/dev/null; then
-  echo -e "  ${ORANGE}node@22 telepitese a launchd szolgaltatasokhoz (ABI-stabil better-sqlite3)...${NC}"
-  brew install node@22 || true
-  NODE22_PREFIX="$(brew --prefix node@22 2>/dev/null || true)"
-fi
-if [ -n "$NODE22_PREFIX" ] && [ -x "$NODE22_PREFIX/bin/node" ]; then
-  NODE_PATH="$NODE22_PREFIX/bin/node"
-else
-  # Last-resort fallback: node@22 could not be installed (e.g. no brew). The
-  # services may still break on an ABI-incompatible node -- warn loudly.
-  NODE_PATH="$(which node)"
-  echo -e "  ${RED}Figyelem:${NC} node@22 nem elerheto, a szolgaltatasok ${NODE_PATH}-ra allnak. ABI-hiba eseten telepitsd: brew install node@22"
-fi
-NODE_BIN_DIR="$(dirname "$NODE_PATH")"
+# Pin launchd services to the SAME Node the native module was just compiled
+# against (see resolve_service_node above, called from the npm-install step).
+# The resolution used to live here, which is why the two disagreed.
+resolve_service_node
 # Launchd labels key off SERVICE_ID. SERVICE_ID == MAIN_AGENT_ID for a
 # brand-unaware (default) install, so these labels are unchanged unless the
 # operator picked a distinct brand above.

--- a/src/__tests__/installer-node22-abi.test.ts
+++ b/src/__tests__/installer-node22-abi.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, chmodSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// The 2026-08-03 bug: `install.sh` printed "Marveen sikeresen telepitve!" and the
+// dashboard never came up. `launchctl list` showed com.marveen.dashboard with no
+// pid and last exit status 1; store/dashboard.error.log was EMPTY and the real
+// cause sat in the stdout log:
+//
+//   better_sqlite3.node was compiled against NODE_MODULE_VERSION 141.
+//   This version of Node.js requires NODE_MODULE_VERSION 127.
+//
+// Two steps of the same script disagreed about which Node this install targets:
+//
+//   * step "npm-install" (~line 528) runs `npm install` + `npm rebuild
+//     better-sqlite3 --build-from-source` under WHATEVER `node` is on the
+//     operator's PATH -- v25/v26 on a current machine, ABI 141.
+//   * step "launchagent" (~line 1106) then deliberately pins the launchd units
+//     to brew node@22 (ABI 127), for the documented reason that the generic
+//     `node` symlink auto-upgrades and breaks the prebuilt better-sqlite3.
+//
+// So the pin worked exactly as designed and the native module was built for the
+// wrong runtime anyway -- the services got a Node the module was never compiled
+// for. `channels` survived (no DB), the dashboard died on first require, and
+// because the token file is written on first successful boot, store/
+// .dashboard-token was never created either.
+//
+// The resolution of the service Node must therefore happen BEFORE the native
+// module is built, and the build must run under that Node.
+
+const ROOT = join(__dirname, '..', '..')
+const MACOS = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
+
+/**
+ * Pull a shell function out of the script. Returns '' when absent, so the
+ * harness reproduces the pre-fix script rather than blowing up on it.
+ */
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+
+  if (start < 0) return ''
+
+  let i = src.indexOf('{', start) + 1
+  let depth = 1
+
+  while (i < src.length && depth > 0) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}') depth--
+    i++
+  }
+
+  return src.slice(start, i)
+}
+
+function stepBlock(src: string, step: string, nextStep: string): string {
+  const start = src.indexOf(`INSTALL_STEP="${step}"`)
+  const end = src.indexOf(`INSTALL_STEP="${nextStep}"`)
+
+  if (start < 0 || end < 0 || end <= start) throw new Error(`step ${step} not found`)
+
+  return src.slice(start, end)
+}
+
+/**
+ * Run the REAL npm-install step with `npm` stubbed by a script that records the
+ * `node` it would resolve. Returns whichever node each npm invocation saw.
+ */
+function runNpmInstallStep(): { code: number; out: string; nodes: string[] } {
+  const dir = mkdtempSync(join(tmpdir(), 'marveen-nodeabi-'))
+  const log = join(dir, 'resolved-node.log')
+
+  // A fake `node@22` keg and a fake generic `node`, both on PATH. The generic
+  // one comes FIRST, exactly like an operator with a current Node installed.
+  const keg = join(dir, 'opt', 'node@22', 'bin')
+  const generic = join(dir, 'generic', 'bin')
+  mkdirSync(keg, { recursive: true })
+  mkdirSync(generic, { recursive: true })
+
+  for (const [d, label] of [[keg, 'node22'], [generic, 'generic-node26']] as const) {
+    const p = join(d, 'node')
+    writeFileSync(p, `#!/bin/bash\necho ${label}\n`)
+    chmodSync(p, 0o755)
+  }
+
+  // `npm` records which node it resolves through the PATH it was handed --
+  // that is precisely the runtime the native module gets compiled against.
+  const npm = join(generic, 'npm')
+  writeFileSync(npm, `#!/bin/bash\necho "$* -> $(node)" >> ${log}\nexit 0\n`)
+  chmodSync(npm, 0o755)
+
+  const script = [
+    'set -e',
+    'on_error() { echo "TRAP_FIRED line $1"; exit 1; }',
+    'trap \'on_error $LINENO\' ERR',
+    'GREEN=""; ORANGE=""; RED=""; NC=""; DIM=""; BOLD=""',
+    '_t() { echo "$1"; }',
+    'ok() { echo "ok: $*"; }',
+    'warn() { echo "warn: $*"; }',
+    'fail() { echo "fail: $*"; exit 9; }',
+    `INSTALL_DIR="${dir}"`,
+    `PATH="${generic}:/usr/bin:/bin"`,
+    // brew reports the fake keg, the way it does on a machine that has node@22.
+    `brew() { if [ "$1" = "--prefix" ] && [ "$2" = "node@22" ]; then echo "${join(dir, 'opt', 'node@22')}"; return 0; fi; return 0; }`,
+    'git() { echo 0000000000000000000000000000000000000000; }',
+    // The helper lives just above the step in the script; the slice starts at
+    // the step marker, so carry it in explicitly.
+    sliceShellFn(MACOS, 'resolve_service_node'),
+    stepBlock(MACOS, 'npm-install', 'configuration'),
+    'echo REACHED_THE_END',
+  ].join('\n')
+
+  const file = join(dir, 'step.sh')
+  writeFileSync(file, script)
+
+  let code = 0
+  let out = ''
+
+  try {
+    out = execFileSync('/bin/bash', [file], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] })
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: string; stderr?: string }
+    code = err.status ?? -1
+    out = `${err.stdout ?? ''}${err.stderr ?? ''}`
+  }
+
+  let nodes: string[] = []
+  try {
+    nodes = readFileSync(log, 'utf-8').trim().split('\n').filter(Boolean)
+  } catch {
+    nodes = []
+  }
+
+  return { code, out, nodes }
+}
+
+describe('install-macos.sh: the native module must be built for the SERVICE node', () => {
+  it('builds better-sqlite3 under node@22, not the generic node on PATH', () => {
+    const { nodes } = runNpmInstallStep()
+
+    const rebuild = nodes.find((l) => l.includes('rebuild') && l.includes('better-sqlite3'))
+
+    expect(rebuild, `npm rebuild never ran; saw: ${JSON.stringify(nodes)}`).toBeDefined()
+    expect(rebuild).toContain('node22')
+  })
+
+  it('installs dependencies under the same node the services will run', () => {
+    const { nodes } = runNpmInstallStep()
+
+    const install = nodes.find((l) => l.startsWith('install'))
+
+    expect(install, `npm install never ran; saw: ${JSON.stringify(nodes)}`).toBeDefined()
+    expect(install).toContain('node22')
+  })
+
+  it('completes the step without tripping the ERR trap', () => {
+    const { code, out } = runNpmInstallStep()
+
+    expect(out).not.toContain('TRAP_FIRED')
+    expect(out).toContain('REACHED_THE_END')
+    expect(code).toBe(0)
+  })
+
+  it('resolves the service node BEFORE it compiles the native module', () => {
+    // Source-level guard on the ordering itself: the launchagent step already
+    // pins the units to node@22, and that pin is worthless if the module was
+    // compiled earlier against something else.
+    const resolve = MACOS.indexOf('resolve_service_node() {')
+    const rebuild = MACOS.indexOf('npm rebuild better-sqlite3 --build-from-source')
+
+    expect(resolve, 'no resolve_service_node helper').toBeGreaterThan(-1)
+    expect(rebuild).toBeGreaterThan(-1)
+    expect(resolve).toBeLessThan(rebuild)
+  })
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** A telepítő kiírta, hogy

```
✓ Marveen sikeresen telepítve!
Dashboard: http://localhost:3420
```

majd az URL-en nem jött be semmi. `launchctl list`: a `com.marveen.dashboard` unitnak nincs pid-je, utolsó kilépési kódja **1**. A `channels` közben vidáman futott. A `store/dashboard.error.log` **üres** volt, a valódi ok a stdout logba ment:

```
better_sqlite3.node was compiled against NODE_MODULE_VERSION 141.
This version of Node.js requires NODE_MODULE_VERSION 127.
```

A script két lépése nem ugyanarra a Node-ra gondolt:

| lépés | mit csinál | melyik node |
|---|---|---|
| `npm-install` (~528. sor) | `npm install` + `npm rebuild better-sqlite3 --build-from-source` | ami épp a PATH-on van (v25/v26 → **ABI 141**) |
| `launchagent` (~1106. sor) | a launchd unitokat `node@22`-re pineli | **ABI 127** |

A pin pontosan úgy működött, ahogy tervezték — a kommentje szó szerint leírja, miért kell (a generikus `node` symlink automatikusan új major-re ugrik, és eltöri a prebuilt `better-sqlite3`-at). Csak épp a natív modul **600 sorral korábban**, egy másik runtime-ra fordult már le. A `channels` túlélte (nem nyúl DB-hez), a dashboard az első `require`-ön meghalt, és mivel a `.dashboard-token` az első sikeres induláskor íródik ki, az sem jött létre soha. Az operátor egy „sikeresen telepítve" üzenetet és egy néma URL-t kapott.

A javítás: a node-feloldás kikerült egy idempotens `resolve_service_node()` függvénybe, ami az `npm-install` lépés **előtt** fut, és az npm-hívások a service node bin-jével a PATH elején mennek (a `node-gyp` a PATH-on feloldott node ellen fordít). A `launchagent` lépés ugyanezt a függvényt hívja, így a kettő nem tud szétcsúszni — az eredeti duplikált blokk törölve.

`install-linux.sh` nem érintett: ott `NODE_PATH="$(which node)"`, vagyis a unit ugyanazt a node-ot kapja, amivel az `npm install` futott. Nincs pin, nincs eltérés.

**EN.** The installer reported success while the dashboard never started: no pid, exit 1, an EMPTY `dashboard.error.log`, and the real cause in the stdout log -- `better_sqlite3.node` built for `NODE_MODULE_VERSION 141` against a runtime requiring 127. The `npm-install` step compiled the native module under whatever generic node was on PATH; the `launchagent` step ~600 lines later pinned the units to node@22. The pin worked as designed and the module was still built for the wrong runtime. Node resolution now lives in an idempotent `resolve_service_node()`, runs BEFORE the native build, and both steps call it. `install-linux.sh` is unaffected (`NODE_PATH="$(which node)"` -- same node either way).

### Teszt / Tests

Új: `src/__tests__/installer-node22-abi.test.ts`, a meglévő installer-teszt idiómát követve (`installer-apt-lock-set-e.test.ts`): kivágja a **valódi** `npm-install` lépést a leszállított scriptből, és lefuttatja egy hamis `node@22` keggel plusz egy generikus `node`-dal a PATH-on (a generikus **elöl**, ahogy egy mai gépen). Az `npm` stub feljegyzi, melyik node-ot oldotta fel — pontosan az a runtime, ami ellen a modul fordulna.

- RED a javítás előtt: `rebuild better-sqlite3 --build-from-source -> generic-node26`
- GREEN utána: 4/4, mindkét npm-hívás `node22`-t lát
- Regresszió: az 5 installer teszt zöld (68 teszt), `tsc --noEmit` exit 0, `bash -n` OK

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
      <!-- Részben: a bug élesben reprodukálva (dashboard down, ABI 141 vs 127), és a javítás lényegi lépése -- npm rebuild better-sqlite3 node@22 alatt -- élesben elvégezve, utána a dashboard elindult, a /api/agents 200-at ad, a .dashboard-token létrejött. Teljes újratelepítést nem futtattam. / Partly: the bug was reproduced on a live install and the substantive repair (rebuilding better-sqlite3 under node@22) was applied there -- the dashboard then started, /api/agents returns 200 and .dashboard-token was created. A full reinstall was not run. -->
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
      <!-- Nem szükséges: a telepítés dokumentált felülete és lépései változatlanok. / Not needed: the documented install surface and steps are unchanged. -->
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
