### PR TITLE
feat(telegram): enforce reply-tool with a Stop hook + directive

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,11 +7,15 @@
   "hooks": {
     "UserPromptSubmit": [
       { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-capture.py\"", "timeout": 15 } ] },
-      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/inbox-drain.py\"", "timeout": 15 } ] }
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/inbox-drain.py\"", "timeout": 15 } ] },
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-reply-directive.py\"", "timeout": 10 } ] }
     ],
     "PostToolUse": [
-      { "matcher": "mcp__plugin.telegram.telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-outbound.py\"", "timeout": 15 } ] },
+      { "matcher": "mcp__plugin_telegram_telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-outbound.py\"", "timeout": 15 } ] },
       { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/tool-log-capture.py\"", "timeout": 5 } ] }
+    ],
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-reply-guard.py\"", "timeout": 10 } ] }
     ],
     "SessionStart": [
       { "matcher": "startup|resume|clear", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-replay.py\"", "timeout": 15 } ] }

--- a/docs/telegram-reply-enforcement-2026-08-02.md
+++ b/docs/telegram-reply-enforcement-2026-08-02.md
@@ -1,0 +1,84 @@
+# Telegram-reply enforcement — 2026-08-02
+
+## Symptom
+
+A recurring failure: when Zoltán writes on Telegram, the agent sometimes answers
+as plain assistant text (which only lands in the tmux session) instead of through
+the `mcp__plugin_telegram_telegram__reply` tool, so Zoltán — who reads Telegram,
+not tmux — sees nothing and has to re-prompt ("miért nem telegramra válaszolsz?").
+
+This had recurred **11 times** by 2026-08-02 (10 prior incidents are catalogued in
+the `feedback_always_use_telegram` memory).
+
+## Root cause
+
+The rule lived **only as passive context**: `CLAUDE.md` plus several memory files.
+Nothing mechanically enforced it, so compliance depended on the model choosing the
+reply tool on every turn. It reliably lapsed when attention drifted — classically
+during long runs of plain-text scheduled-heartbeat turns, whose momentum carried
+into a plain-text answer when a real Telegram message arrived mid-stream.
+
+Concrete gaps found:
+
+1. **No `Stop` hook anywhere.** The harness never checked, at end-of-turn, whether
+   a Telegram message had actually been answered via the reply tool.
+2. **Voice was protected, text was not.** `voice-reply-directive.py` already
+   injected a reply directive for *voice* messages on `UserPromptSubmit`; there was
+   no equivalent for plain-text Telegram messages.
+3. **Cosmetic matcher bug.** The `PostToolUse` matcher for the outbound-ledger hook
+   was written with dots (`mcp__plugin.telegram.telegram__reply`) instead of
+   underscores. It matched by accident (matcher is regex, `.` matches `_`), so
+   outbound replies *were* logged — but the pattern was misleading and fragile.
+
+## Fix (implemented)
+
+Move the rule from *documented* to *enforced*, reusing the existing
+`conversation_log` ledger (no new state model):
+
+- **`scripts/hooks/telegram-reply-guard.py`** — a `Stop` hook. On every stop it
+  calls `ledger_lib.open_question_with_age(agent_id)` (the most recent inbound with
+  no later outbound). If an unanswered Telegram message exists it **blocks** the
+  stop with a directive to send the reply via the reply tool. Guards against
+  false-blocks and loops:
+  - pure acknowledgements ("ok", "köszi 👍", emoji-only) → allow;
+  - inbound older than `TG_GUARD_STALE_SECONDS` (default 30 min) → allow;
+  - after `TG_GUARD_MAX_BLOCKS` (default 3) blocks on the same message → allow
+    (hard backstop so a wedged model is never trapped);
+  - any error → allow (a guard hook must never wedge the session).
+- **`scripts/hooks/telegram-reply-directive.py`** — a `UserPromptSubmit` hook that
+  injects a reply-tool reminder at the top of the turn whenever an inbound Telegram
+  text message is present (the text-message twin of `voice-reply-directive.py`), so
+  the model rarely reaches the Stop-hook block at all.
+- **Matcher fix** in `.claude/settings.json`: dots → underscores for the
+  `ledger-outbound.py` `PostToolUse` matcher.
+
+Wiring lives in the version-controlled project `.claude/settings.json` (`Stop` +
+`UserPromptSubmit` blocks). Note: `boot-hook-prune.py` scans only user/agent
+settings, not the project settings, so it will not prune these hooks.
+
+## Verification
+
+`scripts/__tests__/telegram-reply-guard.test.py` drives the hook against an
+isolated ledger DB (`LEDGER_DB_PATH`) and asserts the decision for each scenario:
+unanswered question → block; answered (outbound logged) → allow; acknowledgement →
+allow; stale → allow; max-block backstop → allow; no-inbound (heartbeat-only turn)
+→ allow. All pass.
+
+## Re-sync regression check (upstream)
+
+This fix is being submitted upstream (Szotasz/marveen). When a later update
+re-syncs it back, verify it did not break:
+
+1. `python3 scripts/__tests__/telegram-reply-guard.test.py` still exits 0.
+2. `.claude/settings.json` still contains the `Stop` →
+   `telegram-reply-guard.py` entry and the underscore matcher.
+3. Live check: send a Telegram message, answer as plain text on purpose, confirm
+   the Stop hook blocks and forces the reply tool.
+
+Tracked on the kanban board (project `marveen`) so the upstream-sync flow revisits
+it on merge-back.
+
+## Activation note
+
+Hooks are loaded at session start, so the guard becomes active on the next
+`channels.sh` / session restart after this change is deployed.

--- a/docs/telegram-reply-enforcement-2026-08-02.md
+++ b/docs/telegram-reply-enforcement-2026-08-02.md
@@ -1,11 +1,11 @@
-# Telegram-reply enforcement — 2026-08-02
+# Telegram-reply enforcement (2026-08-02)
 
 ## Symptom
 
-A recurring failure: when Zoltán writes on Telegram, the agent sometimes answers
+A recurring failure: when the owner writes on Telegram, the agent sometimes answers
 as plain assistant text (which only lands in the tmux session) instead of through
-the `mcp__plugin_telegram_telegram__reply` tool, so Zoltán — who reads Telegram,
-not tmux — sees nothing and has to re-prompt ("miért nem telegramra válaszolsz?").
+the `mcp__plugin_telegram_telegram__reply` tool, so the owner, who reads Telegram
+and not tmux, sees nothing and has to re-prompt ("miért nem telegramra válaszolsz?").
 
 This had recurred **11 times** by 2026-08-02 (10 prior incidents are catalogued in
 the `feedback_always_use_telegram` memory).
@@ -14,7 +14,7 @@ the `feedback_always_use_telegram` memory).
 
 The rule lived **only as passive context**: `CLAUDE.md` plus several memory files.
 Nothing mechanically enforced it, so compliance depended on the model choosing the
-reply tool on every turn. It reliably lapsed when attention drifted — classically
+reply tool on every turn. It reliably lapsed when attention drifted, classically
 during long runs of plain-text scheduled-heartbeat turns, whose momentum carried
 into a plain-text answer when a real Telegram message arrived mid-stream.
 
@@ -28,14 +28,14 @@ Concrete gaps found:
 3. **Cosmetic matcher bug.** The `PostToolUse` matcher for the outbound-ledger hook
    was written with dots (`mcp__plugin.telegram.telegram__reply`) instead of
    underscores. It matched by accident (matcher is regex, `.` matches `_`), so
-   outbound replies *were* logged — but the pattern was misleading and fragile.
+   outbound replies *were* logged, but the pattern was misleading and fragile.
 
 ## Fix (implemented)
 
 Move the rule from *documented* to *enforced*, reusing the existing
 `conversation_log` ledger (no new state model):
 
-- **`scripts/hooks/telegram-reply-guard.py`** — a `Stop` hook. On every stop it
+- **`scripts/hooks/telegram-reply-guard.py`**: a `Stop` hook. On every stop it
   calls `ledger_lib.open_question_with_age(agent_id)` (the most recent inbound with
   no later outbound). If an unanswered Telegram message exists it **blocks** the
   stop with a directive to send the reply via the reply tool. Guards against
@@ -45,7 +45,7 @@ Move the rule from *documented* to *enforced*, reusing the existing
   - after `TG_GUARD_MAX_BLOCKS` (default 3) blocks on the same message → allow
     (hard backstop so a wedged model is never trapped);
   - any error → allow (a guard hook must never wedge the session).
-- **`scripts/hooks/telegram-reply-directive.py`** — a `UserPromptSubmit` hook that
+- **`scripts/hooks/telegram-reply-directive.py`**: a `UserPromptSubmit` hook that
   injects a reply-tool reminder at the top of the turn whenever an inbound Telegram
   text message is present (the text-message twin of `voice-reply-directive.py`), so
   the model rarely reaches the Stop-hook block at all.

--- a/scripts/__tests__/telegram-reply-guard.test.py
+++ b/scripts/__tests__/telegram-reply-guard.test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Test the Telegram-reply Stop hook (scripts/hooks/telegram-reply-guard.py).
+
+Drives the hook as a subprocess against an isolated ledger DB (LEDGER_DB_PATH),
+asserting the block/allow decision for each scenario. Run:  python3 <thisfile>
+Exit 0 = all pass; non-zero = a failure (message on stderr).
+"""
+import os
+import sys
+import json
+import time
+import tempfile
+import subprocess
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HOOKS = os.path.join(os.path.dirname(HERE), "hooks")
+HOOK = os.path.join(HOOKS, "telegram-reply-guard.py")
+sys.path.insert(0, HOOKS)
+
+
+def run_hook(db_path, cwd="/Users/edgar/marveen", extra_env=None):
+    env = dict(os.environ)
+    env["LEDGER_DB_PATH"] = db_path
+    if extra_env:
+        env.update(extra_env)
+    p = subprocess.run(
+        [sys.executable, HOOK],
+        input=json.dumps({"cwd": cwd, "stop_hook_active": False}),
+        capture_output=True, text=True, env=env, timeout=20,
+    )
+    out = p.stdout.strip()
+    decision = None
+    if out:
+        try:
+            decision = json.loads(out).get("decision")
+        except Exception:
+            decision = "PARSE_ERROR:" + out
+    return decision, p.returncode
+
+
+def fresh_db():
+    fd, path = tempfile.mkstemp(suffix=".db", prefix="tgguard-")
+    os.close(fd)
+    # remove any stale statefile from a previous run in the same tmpdir
+    for f in os.listdir(os.path.dirname(path)):
+        if f.startswith(".tg-reply-guard-"):
+            try:
+                os.remove(os.path.join(os.path.dirname(path), f))
+            except Exception:
+                pass
+    return path
+
+
+def load_lib(db_path):
+    os.environ["LEDGER_DB_PATH"] = db_path
+    import importlib
+    import ledger_lib
+    importlib.reload(ledger_lib)
+    return ledger_lib
+
+
+FAILS = []
+
+
+def check(name, got, want):
+    ok = got == want
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}: got={got!r} want={want!r}")
+    if not ok:
+        FAILS.append(name)
+
+
+def main():
+    # 1. Unanswered real question -> BLOCK
+    db = fresh_db()
+    lib = load_lib(db)
+    lib.log_inbound("marveen", "8695313113", "1001", "mennyi 2+2?", "2026-08-02T22:00:00.000Z")
+    d, _ = run_hook(db)
+    check("unanswered question blocks", d, "block")
+
+    # 2. Same question, but answered via reply-tool (outbound logged) -> ALLOW
+    lib.log_outbound("marveen", "8695313113", "4")
+    d, _ = run_hook(db)
+    check("answered question allows", d, None)
+
+    # 3. Pure acknowledgement -> ALLOW (no reply owed)
+    db = fresh_db()
+    lib = load_lib(db)
+    lib.log_inbound("marveen", "8695313113", "1002", "köszi 👍", "2026-08-02T22:05:00.000Z")
+    d, _ = run_hook(db)
+    check("ack allows", d, None)
+
+    # 4. Stale (older than STALE_SECONDS) unanswered question -> ALLOW
+    db = fresh_db()
+    lib = load_lib(db)
+    lib.log_inbound("marveen", "8695313113", "1003", "regi kerdes", "2026-08-01T00:00:00.000Z")
+    # backdate created_at directly
+    con = lib.connect()
+    con.execute("UPDATE conversation_log SET created_at=? WHERE message_id='1003'",
+                (int(time.time()) - 4000,))
+    con.commit(); con.close()
+    d, _ = run_hook(db)
+    check("stale question allows", d, None)
+
+    # 5. Max-block backstop: after MAX_BLOCKS blocks on the same id -> ALLOW
+    db = fresh_db()
+    lib = load_lib(db)
+    lib.log_inbound("marveen", "8695313113", "1004", "makacs kerdes", "2026-08-02T22:10:00.000Z")
+    env = {"TG_GUARD_MAX_BLOCKS": "2"}
+    d1, _ = run_hook(db, extra_env=env)   # block 1
+    d2, _ = run_hook(db, extra_env=env)   # block 2
+    d3, _ = run_hook(db, extra_env=env)   # now over the cap -> allow
+    check("maxblock #1 blocks", d1, "block")
+    check("maxblock #2 blocks", d2, "block")
+    check("maxblock #3 allows (backstop)", d3, None)
+
+    # 6. No inbound at all (e.g. a heartbeat-only turn) -> ALLOW
+    db = fresh_db()
+    load_lib(db)
+    d, _ = run_hook(db)
+    check("no inbound allows", d, None)
+
+    if FAILS:
+        print(f"\n{len(FAILS)} FAILED: {FAILS}", file=sys.stderr)
+        sys.exit(1)
+    print("\nAll telegram-reply-guard tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/telegram-reply-directive.py
+++ b/scripts/hooks/telegram-reply-directive.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: inject a reply-tool directive whenever an inbound
+Telegram TEXT message arrives.
+
+This is the salience half of the Telegram-reply enforcement (the Stop hook
+telegram-reply-guard.py is the guarantee half). It mirrors the existing
+voice-reply-directive.py -- voice messages already got a hook-injected directive,
+plain text messages did not. Injecting the reminder at the TOP of the turn means
+the model rarely reaches the Stop-hook block at all.
+
+Claude Code injects a UserPromptSubmit hook's stdout directly into the model
+prompt (plain text, no JSON wrapper). This hook is silent for any prompt that
+does not carry a Telegram channel tag, so it never disturbs non-channel turns
+(e.g. scheduled heartbeats). Never blocks: any error -> silent exit(0).
+"""
+import sys
+import os
+import json
+import re
+
+CHANNEL_RX = re.compile(
+    r'<channel\s+source="plugin:telegram:telegram"([^>]*)>',
+    re.DOTALL,
+)
+
+
+def _attr(attrs, name):
+    m = re.search(name + r'="([^"]*)"', attrs)
+    return m.group(1) if m else None
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    prompt = payload.get("prompt") or ""
+    m = CHANNEL_RX.search(prompt)
+    if not m:
+        sys.exit(0)  # not a Telegram message -> stay silent
+    chat_id = _attr(m.group(1), "chat_id") or "<a bejövő chat_id>"
+    sys.stdout.write(
+        f"[TELEGRAM-DIREKTÍVA] Ez az üzenet a Telegram csatornáról érkezett "
+        f"(chat_id={chat_id}). A válaszod KÖTELEZŐEN a "
+        f"mcp__plugin_telegram_telegram__reply toolon keresztül menjen ki "
+        f"(chat_id={chat_id}) -- a sima assistant-szöveg NEM jut el hozzá, csak a "
+        f"tmux-ba. Ha csak nyugtázás kell (ok/köszi), akkor sem baj, de érdemi "
+        f"választ MINDIG a reply toollal küldj.\n"
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/telegram-reply-guard.py
+++ b/scripts/hooks/telegram-reply-guard.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Stop hook: ENFORCE that an inbound Telegram message is answered through the
+reply tool before the turn ends.
+
+Root cause this fixes: the "always reply on Telegram, never as plain tmux text"
+rule lived only as passive context (CLAUDE.md + memory). Nothing MECHANICALLY
+enforced it, so it recurred whenever the model's attention lapsed (classically
+during long runs of plain-text heartbeat turns). This hook moves the rule from
+"documented" to "enforced": the harness runs it on every Stop and blocks the
+turn from ending while an inbound Telegram message is still unanswered.
+
+How it decides (all data comes from the existing conversation_log ledger, so this
+hook adds NO new state model -- it reuses ledger_lib.open_question_with_age):
+  - open_question_with_age(agent_id) returns the most recent inbound that has NO
+    later outbound (i.e. an unanswered message). ledger-outbound.py logs an
+    'out' row on every reply-tool call, so a reply flips this to None.
+  - If there is no open question -> allow the stop (exit 0, silent).
+  - If the open inbound is a pure acknowledgement ("ok", "köszi", 👍, ...) -> allow;
+    per the standing rule a bare ack needs no reply.
+  - If the open inbound is older than STALE_SECONDS -> allow; never nag forever on
+    an abandoned/old message (prevents an endless block loop).
+  - If this same message_id has already been blocked MAX_BLOCKS times -> allow;
+    a hard backstop so a wedged model can never be trapped in an infinite loop.
+  - Otherwise -> BLOCK with a directive telling the model to send the reply via
+    mcp__plugin_telegram_telegram__reply(chat_id=...) before stopping.
+
+Safety: any error -> allow the stop (exit 0). A guard hook must never wedge the
+session. agent_id is derived from the session cwd, so it is generic across all
+channel agents and never cross-contaminates.
+"""
+import sys
+import os
+import time
+import json
+import re
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ledger_lib  # noqa: E402
+
+# Tunables (overridable via env for tests / ops).
+STALE_SECONDS = int(os.environ.get("TG_GUARD_STALE_SECONDS", "1800"))  # 30 min
+MAX_BLOCKS = int(os.environ.get("TG_GUARD_MAX_BLOCKS", "3"))
+
+# Pure acknowledgements that do NOT require a reply (standing rule #9). Kept
+# deliberately conservative so a short real question is never swallowed.
+_ACK_WORDS = (
+    "ok", "oke", "okk", "okés", "okes", "rendben", "rdb", "köszi", "koszi",
+    "kösz", "kosz", "köszönöm", "koszonom", "thx", "thanks", "ty", "thank you",
+    "szuper", "super", "remek", "tökéletes", "tokeletes", "jó", "jo", "oksa",
+)
+_EMOJI_ACK = ("👍", "🙏", "👌", "❤️", "👏", "🎉", "✅", "🆗", "+1")
+
+
+def _is_ack(text):
+    raw = (text or "").strip()
+    if not raw:
+        # An empty/attachment-only inbound (e.g. a bare photo) is not a question
+        # this guard should block on; the agent handles media on its own terms.
+        return True
+    # Strip emoji-ack glyphs and punctuation, then require EVERY remaining word to
+    # be an acknowledgement word. This catches "köszi 👍", "ok köszi", "👍", etc.,
+    # while still treating "ok de miért?" (a real question) as non-ack.
+    t = raw.lower()
+    for e in _EMOJI_ACK:
+        t = t.replace(e, " ")
+    for ch in ".!?…,":
+        t = t.replace(ch, " ")
+    tokens = t.split()
+    if not tokens:
+        return True  # emoji-only acknowledgement
+    return all(tok in _ACK_WORDS for tok in tokens)
+
+
+def _statefile(agent_id):
+    safe = "".join(c if (c.isalnum() or c in "-_") else "_" for c in str(agent_id))
+    return os.path.join(os.path.dirname(ledger_lib.db_path()), f".tg-reply-guard-{safe}")
+
+
+def _block_count(path, message_id):
+    """How many times this exact message_id has already been blocked."""
+    try:
+        with open(path) as f:
+            mid, n = f.read().strip().split("\t", 1)
+        return int(n) if mid == str(message_id) else 0
+    except Exception:
+        return 0
+
+
+def _record_block(path, message_id, count):
+    try:
+        with open(path, "w") as f:
+            f.write(f"{message_id}\t{count}")
+    except Exception:
+        pass
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    agent_id = ledger_lib.agent_id_from_cwd(payload.get("cwd"))
+
+    try:
+        oq = ledger_lib.open_question_with_age(agent_id)
+    except Exception:
+        sys.exit(0)  # ledger unavailable -> never wedge the stop
+    if not oq:
+        sys.exit(0)  # nothing open, or already answered by a reply-tool call
+
+    chat_id, message_id, text, ts, created_at = oq
+
+    # Pure acknowledgement -> no reply owed.
+    if _is_ack(text):
+        sys.exit(0)
+
+    # Too old -> don't nag forever (abandoned / deliberately-unanswered message).
+    try:
+        if created_at is not None and (int(time.time()) - int(created_at)) > STALE_SECONDS:
+            sys.exit(0)
+    except Exception:
+        sys.exit(0)
+
+    # Hard backstop against an infinite block loop.
+    path = _statefile(agent_id)
+    count = _block_count(path, message_id)
+    if count >= MAX_BLOCKS:
+        sys.exit(0)
+
+    _record_block(path, message_id, count + 1)
+
+    snippet = (text or "").strip().replace("\n", " ")
+    if len(snippet) > 160:
+        snippet = snippet[:157] + "..."
+
+    reason = (
+        f"⚠️ VÁLASZOLATLAN TELEGRAM-ÜZENET (chat_id={chat_id}): \"{snippet}\"\n"
+        f"A fordulót NEM zárhatod le, amíg NEM küldtél Telegram-választ a "
+        f"mcp__plugin_telegram_telegram__reply toolon keresztül (chat_id={chat_id}). "
+        f"A sima szöveges (assistant text) kimenet NEM jut el a felhasználóhoz -- "
+        f"ő csak a Telegramot látja. Küldd el a választ a reply toollal MOST, "
+        f"utána zárhatod a fordulót."
+    )
+    print(json.dumps({"decision": "block", "reason": reason}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The 'always answer Telegram via the reply tool, never as plain tmux text' rule lived only as passive context (CLAUDE.md + memory) and recurred 11x because nothing enforced it. Move it from documented to enforced:

- scripts/hooks/telegram-reply-guard.py: Stop hook that blocks the turn while an inbound Telegram message is unanswered (reuses the existing conversation_log ledger via open_question_with_age). Ack/stale/max-block backstops so it can never wedge the session.
- scripts/hooks/telegram-reply-directive.py: UserPromptSubmit reminder for inbound text messages (the text twin of voice-reply-directive.py).
- .claude/settings.json: wire both hooks; fix the ledger-outbound PostToolUse matcher (dots -> underscores).
- scripts/__tests__/telegram-reply-guard.test.py: 6-scenario suite, all pass.
- docs/telegram-reply-enforcement-2026-08-02.md: root cause, fix, re-sync check.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [x] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A "mindig a Telegram reply-toollal válaszolj, sose sima tmux-szövegként" szabály eddig csak passzív kontextusban élt (CLAUDE.md + memória), semmi nem kényszerítette ki, ezért ismételten megsérült (11 dokumentált eset). Ez a PR gépi kikényszerítéssé alakítja, a meglévő infrastruktúrára építve, új állapotmodell nélkül:
- egy **Stop hook** a forduló végén blokkol, amíg egy bejövő Telegram-üzenet válaszolatlan (a `conversation_log` ledger `open_question_with_age()` függvényét használja);
- egy **UserPromptSubmit direktíva-hook** a forduló elején emlékeztet (a `voice-reply-directive.py` szöveges párja; eddig csak a hangüzenet volt védve).
A Stop hook ack / stale / max-block fékeket tartalmaz, hogy sose ragadjon be a session (bármely hiba esetén átenged). Ráadásként javítja a `ledger-outbound` PostToolUse matchert (pont → aláhúzás).

**EN:** The rule "always answer Telegram via the reply tool, never as plain tmux text" previously lived only as passive context (CLAUDE.md + memory) with nothing enforcing it, so it recurred (11 documented incidents). This PR turns it into mechanical enforcement, reusing existing infrastructure with no new state model:
- a **Stop hook** blocks end-of-turn while an inbound Telegram message is unanswered (built on the `conversation_log` ledger's `open_question_with_age()`);
- a **UserPromptSubmit directive hook** reminds at the start of the turn (the text twin of `voice-reply-directive.py`; only voice was protected before).
The Stop hook has ack / stale / max-block backstops so it can never wedge the session (any error → allow). It also fixes the `ledger-outbound` PostToolUse matcher (dots → underscores).

**Érintett fájlok / Changed files:**
- `scripts/hooks/telegram-reply-guard.py` — Stop hook (open_question_with_age; ack/stale/max-block backstops).
- `scripts/hooks/telegram-reply-directive.py` — UserPromptSubmit reminder (text twin of voice-reply-directive.py).
- `.claude/settings.json` — wire both hooks; fix the ledger-outbound matcher (dots → underscores).
- `scripts/__tests__/telegram-reply-guard.test.py` — 6-scenario suite (8 assertions), all pass.
- `docs/telegram-reply-enforcement-2026-08-02.md` — root cause, fix, re-sync check.

## Kapcsolódó issue / Related issue

N/A (nincs kapcsolódó upstream issue; fork-oldali visszatérő probléma. / No related upstream issue; fork-side recurring problem.)

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors. (automated suite + smoke; live activation on next restart)
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).