### PR TITLE
fix(agents): deleting an agent must clear its desired run-state

### DIFF
--- a/src/__tests__/agent-delete-clears-desired.test.ts
+++ b/src/__tests__/agent-delete-clears-desired.test.ts
@@ -1,0 +1,107 @@
+// Deleting an agent must clear its desired run-state.
+//
+// Found by reading the code during the #842 verify, 2026-08-03: routes/agents.ts
+// has exactly three Desired call sites -- the import, addDesiredAgent in the
+// START branch, removeDesiredAgent in the STOP branch. The DELETE branch has
+// neither. So the name outlives the directory in agents-desired.json.
+//
+// What that costs, precisely (startAgentProcess returns 'Agent not found' on a
+// missing dir, so the deleted agent is NOT resurrected while it stays deleted):
+//   1. the reconciler retries the name on every pass and logs an error-level
+//      line forever, for a machine that is behaving correctly;
+//   2. the sharper one -- create an agent with the SAME NAME later and the
+//      stale entry starts it immediately, without anyone asking for it.
+//
+// Measured on the live host the same day: agents-desired.json held 9 names and
+// all 9 had a directory, so the defect had not fired there yet. This test is
+// what keeps it from firing.
+import { existsSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PROJECT_ROOT, STORE_DIR } from '../config.js'
+import { agentDir } from '../web/agent-config.js'
+import { addDesiredAgent, getDesiredAgents, removeDesiredAgent } from '../web/agent-desired-state.js'
+import { tryHandleAgents } from '../web/routes/agents.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+// A name no live fleet member can collide with. The card is explicit about
+// this: prove it with a throwaway name, never with a running fleet agent.
+const THROWAWAY = 'zz-desired-state-probe'
+
+function fakeCtx(path: string, method: string): {
+  ctx: RouteContext
+  out: { status: number; body: Record<string, unknown> | null }
+} {
+  const out: { status: number; body: Record<string, unknown> | null } = { status: 0, body: null }
+  const res = {
+    writeHead(status: number) {
+      out.status = status
+      return res
+    },
+    end(chunk?: string) {
+      if (chunk) out.body = JSON.parse(chunk) as Record<string, unknown>
+    },
+  }
+  const url = new URL(`http://localhost:3420${path}`)
+  return {
+    ctx: { req: {} as RouteContext['req'], res, path: url.pathname, method, url } as RouteContext,
+    out,
+  }
+}
+
+afterEach(() => {
+  rmSync(agentDir(THROWAWAY), { recursive: true, force: true })
+  removeDesiredAgent(THROWAWAY)
+})
+
+describe('DELETE /api/agents/:name and the desired run-state', () => {
+  it('removes the name from agents-desired.json, not just the directory', async () => {
+    mkdirSync(agentDir(THROWAWAY), { recursive: true })
+    mkdirSync(STORE_DIR, { recursive: true })
+    addDesiredAgent(THROWAWAY)
+
+    // Positive control on the instrument itself: if the desired-state file did
+    // not hold the name to begin with, the assertion below would pass on a
+    // machine where the write silently failed, and prove nothing.
+    expect(getDesiredAgents().has(THROWAWAY)).toBe(true)
+
+    const { ctx, out } = fakeCtx(`/api/agents/${THROWAWAY}`, 'DELETE')
+    const handled = await tryHandleAgents(ctx, join(PROJECT_ROOT, 'web'))
+
+    expect(handled).toBe(true)
+    expect(out.body?.ok).toBe(true)
+    expect(existsSync(agentDir(THROWAWAY))).toBe(false)
+    expect(getDesiredAgents().has(THROWAWAY)).toBe(false)
+  })
+
+  it('leaves other agents alone', async () => {
+    const bystander = 'zz-desired-state-bystander'
+    mkdirSync(agentDir(THROWAWAY), { recursive: true })
+    mkdirSync(STORE_DIR, { recursive: true })
+    addDesiredAgent(THROWAWAY)
+    addDesiredAgent(bystander)
+    try {
+      const { ctx } = fakeCtx(`/api/agents/${THROWAWAY}`, 'DELETE')
+      await tryHandleAgents(ctx, join(PROJECT_ROOT, 'web'))
+      // The delete must be surgical: clearing the whole file would "pass" the
+      // test above while silently un-desiring the entire fleet.
+      expect(getDesiredAgents().has(bystander)).toBe(true)
+    } finally {
+      removeDesiredAgent(bystander)
+    }
+  })
+
+  it('does not touch the desired state when the agent does not exist', async () => {
+    mkdirSync(STORE_DIR, { recursive: true })
+    addDesiredAgent(THROWAWAY)
+
+    // 404 path: no directory to delete, so nothing was decided about intent.
+    // Clearing here would let a stray DELETE of a mistyped name knock a running
+    // agent out of the desired set.
+    const { ctx, out } = fakeCtx(`/api/agents/${THROWAWAY}`, 'DELETE')
+    await tryHandleAgents(ctx, join(PROJECT_ROOT, 'web'))
+
+    expect(out.status).toBe(404)
+    expect(getDesiredAgents().has(THROWAWAY)).toBe(true)
+  })
+})

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -2079,6 +2079,14 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (!existsSync(dir)) { json(res, { error: 'Agent not found' }, 404); return true }
     rmSync(dir, { recursive: true, force: true })
     cleanupTeamReferences(name)
+    // Deleting an agent is at least as strong a statement of intent as stopping
+    // one, so it must clear the desired run-state the same way /stop does.
+    // Without this the name outlives its directory in agents-desired.json, and
+    // the reconciler keeps trying to start something that no longer exists --
+    // a permanent error-level log line for a machine that is behaving
+    // correctly. The sharper hazard is later: create an agent with the same
+    // name again and the stale entry starts it immediately, unasked.
+    removeDesiredAgent(name)
     json(res, { ok: true })
     return true
   }


### PR DESCRIPTION
Closes the second half of what the #842 verify turned up. #842 closed the orphan tmux-session path; this is the other one, and it was never carded as a symptom because nobody has hit it yet.

**NE MERGELD MA.** Same repo as #853, and the hold reason is the same: a live customer install is running today, the shipping chain stays frozen, and a possible hotfix-promote must keep a predictable scope. Merge with that group, when Marveen says the hold is lifted.

## What is wrong

`routes/agents.ts` has exactly three Desired call sites: the import, `addDesiredAgent` in the START branch, `removeDesiredAgent` in the STOP branch. The DELETE branch has neither, so a deleted agent's name outlives its directory in `agents-desired.json`.

**Stated precisely, because "the reconciler brings the deleted agent back" is not quite what happens.** `startAgentProcess` returns `Agent not found` on a missing directory, so a deleted agent is *not* resurrected while it stays deleted. Two things follow instead:

1. `reconcileDesiredAgents` retries the name on every pass and logs at **error** level -- a permanent failure line for a machine that is behaving correctly. Constant signal goes blind: the next real reconcile failure reads as more of the same.
2. The sharper one: create an agent with the **same name** later, and the stale entry starts it immediately, unasked. Delete is at least as strong a statement of intent as stop, and it was the only one not recorded.

## Measured before writing the fix

Live host, `agents-desired.json`: 9 names, all 9 have a directory -- **the defect has not fired here**. Positive control on that measurement: an injected fake name *is* reported as missing, so the empty result came from a working instrument rather than a broken one. Latent defect; the fix is preventive.

## The test

Drives the real DELETE route (`tryHandleAgents`), not the source text, with a throwaway name (`zz-desired-state-probe`) -- never a live fleet member. It covers the two ways a fix can be wrong as well as the one way it can be absent:

| case | asserts |
|---|---|
| delete a desired agent | the name is gone from the desired set |
| bystander | another desired name is **not** touched -- clearing the whole file would pass the first check while silently un-desiring the fleet |
| 404 delete | the desired set is untouched -- a stray DELETE of a mistyped name must not knock a running agent out of it |

**Controls, each against a wrong shape:**

| control | result |
|---|---|
| `removeDesiredAgent` call removed | first test fails, on the desired-set assertion |
| fix made over-broad (clear whole set) | bystander test fails |

Typecheck clean. Suite **3182/3182** from `/Users/marvin/ClaudeClaw-wt/desired842`. Note for whoever verifies: run it from a **non-/tmp** checkout. A `/tmp`-rooted worktree fails 19 tests in 4 hook-guard files on unchanged, correct code -- the hook-path guard rejects `/tmp`-rooted hook paths by design. See the `marveen-suite-tmp-false-red` skill.

Related: **RESPAWNDEDUP1** touches the same file region for the two main-session respawn paths; if that lands separately the desired-state calls there want the same look.
