### PR TITLE
fix(bridge): refuse a pairing target address that cannot be a host

### DIFF
--- a/scripts/remote-access-enroll.ts
+++ b/scripts/remote-access-enroll.ts
@@ -28,10 +28,12 @@ import { execFileSync } from 'node:child_process'
 import { homedir, hostname, userInfo, networkInterfaces } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isIP } from 'node:net'
 import {
   validatePublicKeyLine,
   buildRestrictedLine,
   buildBundle,
+  checkEnrollHost,
   encodeBundle,
   resolveHostKey,
   HOST_KEY_PUB_CANDIDATES,
@@ -67,6 +69,11 @@ function parseArgs(argv: string[]): Args {
     if (a === '--host') {
       const v = argv[++i]
       if (!v) fail('--host requires a value')
+      // Same check as the dashboard route: this is the SECOND way a target
+      // address enters a bundle, and leaving it open would mean the next
+      // person has to find the same bug twice.
+      const checked = checkEnrollHost(v, isIP)
+      if (!checked.ok) fail(`--host: ${checked.reason}`)
       out.host = v
     } else if (a === '--no-dashboard-token') {
       out.includeDashboardToken = false

--- a/src/__tests__/bridge-enroll-host-validation.test.ts
+++ b/src/__tests__/bridge-enroll-host-validation.test.ts
@@ -1,0 +1,79 @@
+// JANKBRIDGE803 -- the pairing target address must be a host, not any string.
+//
+// A customer typed the email address of his Tailscale ACCOUNT into the field.
+// Nothing objected: the bundle was built with it, the Bridge imported it, and
+// the failure surfaced only at connect as `getaddrinfo EAI_FAIL <email>`.
+// Measured on the shipped Bridge before this fix: parseBundle accepted an
+// email, whitespace, a URL, an embedded newline and 400 characters -- only the
+// empty string was refused, while the PORT field beside it was fully checked.
+//
+// The trap this test also exists to hold shut: the codebase ALREADY has a host
+// check (agent-config.ts REMOTE_HOST_ALLOWED), and it ACCEPTS this email,
+// because it is an ssh DESTINATION charset where `user@host` is legitimate.
+// Anyone "reusing the existing validator" ships a change that looks like a fix
+// and lets the reported case straight through. The email case is therefore
+// asserted by name, not merely as "some invalid input".
+import { isIP } from 'node:net'
+import { describe, expect, it } from 'vitest'
+import { checkEnrollHost } from '../remote-enroll-core.js'
+
+const REPORTED = 'jaequas2605@gmail.com'
+
+describe('checkEnrollHost', () => {
+  it('accepts what a real target address looks like', () => {
+    // Positive control first. A validator that rejects everything would pass
+    // every rejection test below and be worse than no validator at all.
+    for (const host of [
+      '100.124.123.12', // the tailnet address the customer should have used
+      '192.168.0.10',
+      'mac-mini',
+      'mac-mini.local',
+      'host.tail1234.ts.net',
+      'fe80::1',
+      '::1',
+      'my_server', // underscore: not RFC 1123, but real machines carry it
+      'example.com.', // trailing dot: a legitimately written FQDN
+    ]) {
+      expect(checkEnrollHost(host, isIP), `${host} must be accepted`).toEqual({ ok: true, host })
+    }
+  })
+
+  it('rejects the reported email address, and says why in words that correct the belief', () => {
+    const r = checkEnrollHost(REPORTED, isIP)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    // "Invalid host" alone would be correct and useless: the customer believed
+    // the field wanted his Tailscale identity. The message must fix the belief.
+    expect(r.reason).toContain(REPORTED)
+    expect(r.reason).toMatch(/email/i)
+    expect(r.reason).toMatch(/100/)
+    expect(r.reason).toMatch(/Tailscale/)
+  })
+
+  it('rejects the other shapes the shipped Bridge waved through', () => {
+    for (const host of [
+      'my host name',
+      'https://example.com/x',
+      'example.com; rm -rf /',
+      'a.com\nb.com',
+      '   ',
+      '',
+    ]) {
+      expect(checkEnrollHost(host, isIP).ok, `${JSON.stringify(host)} must be rejected`).toBe(false)
+    }
+    expect(checkEnrollHost('a'.repeat(400), isIP).ok).toBe(false)
+  })
+
+  it('trims, so a pasted address with stray whitespace still works', () => {
+    expect(checkEnrollHost('  100.124.123.12  ', isIP)).toEqual({ ok: true, host: '100.124.123.12' })
+  })
+
+  it('is NOT satisfied by the remote-agent host charset', () => {
+    // The measurement that justifies a separate validator: agent-config.ts's
+    // REMOTE_HOST_ALLOWED accepts the reported email. If someone later swaps
+    // checkEnrollHost for that regex, this test is the one that objects.
+    const REMOTE_HOST_ALLOWED = /^[A-Za-z0-9_.@-]+$/
+    expect(REMOTE_HOST_ALLOWED.test(REPORTED), 'the ssh-destination charset accepts the email').toBe(true)
+    expect(checkEnrollHost(REPORTED, isIP).ok, 'ours must not').toBe(false)
+  })
+})

--- a/src/__tests__/bridge-enroll.test.ts
+++ b/src/__tests__/bridge-enroll.test.ts
@@ -222,6 +222,31 @@ describe('POST /api/security/bridge-enroll (HTTP)', () => {
     expect(listDeviceKeys()).toHaveLength(0)
   })
 
+  it('400s on a target address that cannot be a host, before any side effect (JANKBRIDGE803)', async () => {
+    // The reported case: the customer typed his Tailscale ACCOUNT email. It
+    // used to reach the bundle untouched and fail only at connect time with
+    // `getaddrinfo EAI_FAIL <email>`. The refusal must happen here, at the
+    // door, and it must leave nothing behind -- a half-enrolled device key
+    // would be worse than the original bug.
+    const { line } = makeKeyLine()
+    const r = await call(tryHandleSecurity, 'POST', '/api/security/bridge-enroll', {
+      auth: { kind: 'token' },
+      body: { key_line: line, name: 'Route Phone', host: 'jaequas2605@gmail.com' },
+    })
+    expect(r.statusCode).toBe(400)
+    expect(String(r.json().error)).toMatch(/email/i)
+    expect(listDeviceKeys()).toHaveLength(0)
+
+    // Positive control on the same route: a well-formed address must NOT be
+    // refused by this check. Without it a validator that rejects everything
+    // would pass the assertion above and quietly break every pairing.
+    const ok = await call(tryHandleSecurity, 'POST', '/api/security/bridge-enroll', {
+      auth: { kind: 'token' },
+      body: { key_line: line, name: 'Route Phone', host: '100.124.123.12' },
+    })
+    expect(String(ok.json().error ?? '')).not.toMatch(/Invalid host/)
+  })
+
   it('enrolls end-to-end over the route (MARVEEN_SSH_DIR seam) and audits', async () => {
     process.env.MARVEEN_SSH_DIR = sshDir
     // The route uses default deps; loopback keyscan may fail in CI, so give it

--- a/src/remote-enroll-core.ts
+++ b/src/remote-enroll-core.ts
@@ -17,6 +17,67 @@ export const REMOTE_PORT = 3420
 /** The only key type accepted for enrollment. */
 export const ACCEPTED_KEY_TYPE = 'ssh-ed25519'
 
+/**
+ * Shape check for the pairing target address (JANKBRIDGE803).
+ *
+ * A customer typed the email address of his Tailscale ACCOUNT here. Nothing in
+ * the chain objected: the bundle was built with it, the Bridge imported it, and
+ * the failure surfaced only at connect time as `getaddrinfo EAI_FAIL <email>`.
+ * Measured on the shipped Bridge before writing this: parseBundle accepted an
+ * email, whitespace, a URL, an embedded newline and a 400-character string --
+ * only the empty string was rejected, while the PORT field next to it was fully
+ * validated. The asymmetry, not the customer, produced the incident.
+ *
+ * NOT reusable from the remote-AGENT host check (agent-config.ts
+ * REMOTE_HOST_ALLOWED). That one is an ssh DESTINATION charset, where `user@host`
+ * is legitimate, so it accepts `someone@gmail.com` -- measured. Reusing it here
+ * would look like a fix and would let this exact report through again.
+ *
+ * Deliberately permissive about hostname purity: `_` is accepted because real
+ * machines carry it, and a trailing dot is accepted because an FQDN may be
+ * written that way. The job is to reject what CANNOT be a host (an address with
+ * `@`, spaces, a URL, control characters), not to enforce RFC 1123.
+ */
+const HOSTNAME_LABEL = '[A-Za-z0-9_](?:[A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?'
+const HOSTNAME_RE = new RegExp(`^${HOSTNAME_LABEL}(?:\\.${HOSTNAME_LABEL})*\\.?$`)
+
+export type HostCheck = { ok: true; host: string } | { ok: false; reason: string }
+
+/**
+ * Validate a user-supplied target address. `isIP` covers IPv4 and IPv6
+ * literals; anything else must look like a hostname.
+ *
+ * The email case gets its OWN message on purpose. "Invalid host" would be
+ * technically correct and useless: the reporter believed the field wanted his
+ * Tailscale identity, so the message has to correct the belief, not the syntax.
+ */
+export function checkEnrollHost(raw: string, isIP: (s: string) => number): HostCheck {
+  const host = raw.trim()
+  if (!host) return { ok: false, reason: 'target address is empty' }
+  // Quote back at most 60 characters: enough to recognise what was typed,
+  // short enough that a pasted blob does not become the whole message.
+  const seen = host.length > 60 ? `${host.slice(0, 60)}...` : host
+  if (host.length > 253) {
+    return { ok: false, reason: `target address is too long (${host.length} characters, maximum 253)` }
+  }
+  if (isIP(host) !== 0) return { ok: true, host }
+  if (host.includes('@')) {
+    return {
+      ok: false,
+      reason:
+        `"${seen}" looks like an email address. The target address is the machine's IP address or ` +
+        'hostname; with Tailscale it is the address starting with 100, not the email address of the Tailscale account.',
+    }
+  }
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(host)) {
+    return { ok: false, reason: `"${seen}" is a URL. Enter only the address, without http:// or a path.` }
+  }
+  if (!HOSTNAME_RE.test(host)) {
+    return { ok: false, reason: `"${seen}" is not a valid IP address or hostname.` }
+  }
+  return { ok: true, host }
+}
+
 /** Prefix that every per-device comment must carry. The full comment is
  * `marveen-remote:<uuid>`, where the uuid is the per-device revocation and
  * replace identifier. */

--- a/src/web/routes/security.ts
+++ b/src/web/routes/security.ts
@@ -16,6 +16,8 @@ import { logger } from '../../logger.js'
 import { logConfigChange } from '../../db.js'
 import { notifySecurityEvent } from '../../notify.js'
 import { bridgeEnroll, sshDirOverride, RemoteEnrollError } from '../bridge-enroll.js'
+import { checkEnrollHost } from '../../remote-enroll-core.js'
+import { isIP } from 'node:net'
 import type { RouteContext } from './types.js'
 
 const BODY_MAX_BYTES = 8 * 1024
@@ -56,7 +58,17 @@ export async function tryHandleSecurity(ctx: RouteContext): Promise<boolean> {
     json(res, { error: 'Invalid device name (1-64 chars: letters, digits, space, . _ -)' }, 400)
     return true
   }
+  // Empty stays empty: the field is optional and bridgeEnroll then fills in the
+  // machine's own address. Note that this `|| undefined` is load-bearing --
+  // bridgeEnroll's fallback uses `??`, which does NOT catch an empty string.
   const host = str(body.host).trim() || undefined
+  if (host !== undefined) {
+    const checked = checkEnrollHost(host, isIP)
+    if (!checked.ok) {
+      json(res, { error: `Invalid host: ${checked.reason}` }, 400)
+      return true
+    }
+  }
   let sshPort: number | undefined
   if (body.ssh_port !== undefined && body.ssh_port !== null && body.ssh_port !== '') {
     const n = Number(body.ssh_port)


### PR DESCRIPTION
**Slice 2 of 5** for JANKBRIDGE803 (measurement report: `agents/samu/BUGREPORT-bridge-host-mezo-MERES.md`). This is the **dashboard side** of one contract; the **Bridge side** (`parseBundle`) is the companion PR in `Szotasz/marveen-bridge` and they should land together.

## What happened

A customer typed the email address of his Tailscale **account** into the pairing target-address field. Nothing objected: the bundle was built with it, the Bridge imported it and reported success, and the failure surfaced only at connect time as `getaddrinfo EAI_FAIL <his email>`.

Measured on the shipped Bridge before writing the fix -- `parseBundle` accepted:

| input | result |
|---|---|
| `jaequas2605@gmail.com` | passed |
| `my host name` | passed |
| `https://example.com/x` | passed |
| `"   "` (whitespace) | passed |
| `example.com; rm -rf /` | passed |
| 400 characters | passed |
| `""` (empty) | refused |

…while the **port** field beside it was fully validated (0, 70000, `"22"`, 22.5 all refused). The asymmetry produced the incident, not the customer.

## ⚠️ The trap this PR had to avoid -- read before "simplifying" it

This repo **already has** a host check: `REMOTE_HOST_ALLOWED` in `agent-config.ts`. It **accepts `someone@gmail.com`** -- measured. It is an ssh **destination** charset, where `user@host` is deliberately legitimate. Reusing it here would look exactly like a fix, let the reported case straight through, and leave everyone believing the case was covered.

That is why `checkEnrollHost` is a new function, and why a test asserts the difference directly. If someone later swaps it for that regex, **4 tests fail**, including the route test.

## What changed

- `checkEnrollHost` in `remote-enroll-core.ts`: IP literal via `isIP` (v4/v6), otherwise a hostname shape. Permissive on purpose about `_` and a trailing dot -- the job is rejecting what *cannot* be a host, not enforcing RFC 1123.
- Wired into **both** entry points: the dashboard route and the enroll CLI. Leaving one open means the next person finds this bug a second time.
- The email refusal does **not** say "invalid host". The customer believed the field wanted his Tailscale identity, so the message corrects the belief: IP or hostname, and with Tailscale the one starting with `100`, not the account email.
- The **empty** field is untouched and still means "decide for me". A comment now marks that `|| undefined` as load-bearing: `bridgeEnroll`'s fallback uses `??`, which does **not** catch an empty string.

## Verification

Positive control first -- a validator that refuses everything would pass every rejection assertion and silently break all pairing.

| control (against a wrong shape) | result |
|---|---|
| route check removed | route test fails |
| "reuse `REMOTE_HOST_ALLOWED`" | 4 tests fail, incl. route test |
| validator rejects everything | both positive-control tests fail |

Typecheck clean, build clean, suite **3185/3185** from a non-`/tmp` checkout (a `/tmp`-rooted worktree gives a known false red in the hook-guard files -- see the `marveen-suite-tmp-false-red` skill).

## Not in scope

The connect-time error text (slice 4) and the reconnect classification (slice 5). **Slice 5 carries a measurement that argues against the obvious form of it** -- on macOS a permanently wrong address and a "tailnet not up yet" name produce the *same* `ENOTFOUND` code, so "make it fatal" would break the case it is meant to protect. Details in the report.

⚠️ **Do not merge today.** Goes with the group (`#853`, installer `#23`, installer `#24`, `#857`, `#858`) after today's live customer install.
