### PR TITLE
test(schedule): stop asserting the global default's value

### DIFF
--- a/src/__tests__/schedule-task-timeout.test.ts
+++ b/src/__tests__/schedule-task-timeout.test.ts
@@ -200,8 +200,14 @@ describe('resolveStuckTimeoutMs: the threshold is per task', () => {
   it('the resolved budget actually drives the decision', () => {
     const at6min = 6 * MIN
     const opts = { graceMs: GRACE, maxTrackMs: MAX_TRACK }
-    // Default budget: 6 minutes of continuous busy is a hang.
-    expect(decideTaskTimeout(makeEntry(), 'busy', at6min, { ...opts, timeoutMs: resolveStuckTimeoutMs({}) })).toBe('alert')
+    // Both budgets are stated EXPLICITLY rather than leaning on the global
+    // default. The claim under test is "the resolved budget drives the
+    // decision", which says nothing about what the default happens to be --
+    // and the default is install-configurable (TASK_STALL_TIMEOUT_MS), so an
+    // install that raises it to 10 minutes would have failed this test on a
+    // point it never meant to assert.
+    // 5-minute budget: 6 minutes of continuous busy is a hang.
+    expect(decideTaskTimeout(makeEntry(), 'busy', at6min, { ...opts, timeoutMs: resolveStuckTimeoutMs({ stuckAfterMinutes: 5 }) })).toBe('alert')
     // 20-minute budget: the same 6 minutes is just work in progress.
     expect(decideTaskTimeout(makeEntry(), 'busy', at6min, { ...opts, timeoutMs: resolveStuckTimeoutMs({ stuckAfterMinutes: 20 }) })).toBe('hold')
   })


### PR DESCRIPTION

**File:** `src/__tests__/schedule-task-timeout.test.ts`
**Behaviour change:** none. Test-only.

## What

`resolveStuckTimeoutMs: the resolved budget actually drives the decision` used the GLOBAL default
(`resolveStuckTimeoutMs({})`) as one of its two budgets and expected `alert` at 6 minutes.

The name states the claim: *the resolved budget drives the decision*. That claim says nothing about
what the default happens to be -- but by using the default as the "small" budget, the test also
silently asserts `TASK_FIRE_TIMEOUT_MS < 6 min`. Any install or future change that raises the
default turns this into a failure on a point the test never meant to make.

## Fix

Both budgets are stated explicitly (5 and 20 minutes). The assertion under test is unchanged.

## Why separately

It stands on its own, and it is worth landing whether or not the follow-up (a configurable
default) is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)