### PR TITLE
feat(schedule): make the stall-alert threshold configurable per install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,14 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # settings.json -- that file is tracked, so a local edit blocks the update
 # preflight and is reverted by the next update.
 # MAIN_AGENT_MODEL=claude-opus-5
+
+# Mennyi ideig futhat egy elinditott utemezett feladat, mielott az orjarat
+# beragadtnak minositi es riaszt (ms). Alapertelmezes: 300000 (5 perc).
+# Feladatonkent a task-config.json `stuckAfterMinutes` kulcsa irja felul.
+# Also hatar 60000 (1 perc): ez alatt a riasztas meg az indulasi zajba esne.
+# Felso hatar 6 ora: a nyilvantartas ennyi ido utan amugy is eldobja a
+# bejegyzest, tehat egy nagyobb ertek nem "kesobbi riasztast" jelentene, hanem
+# azt, hogy a riasztas SOHA nem szolal meg. Ezert a kod levagja -- a
+# kikapcsolast mondd ki, ne egy nagy szammal erd el.
+# Ervenytelen vagy tartomanyon kivuli ertek eseten az alapertelmezes lep eletbe.
+# TASK_STALL_TIMEOUT_MS=600000

--- a/src/__tests__/schedule-task-timeout.test.ts
+++ b/src/__tests__/schedule-task-timeout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { decideTaskTimeout, resolveStuckTimeoutMs, TASK_FIRE_GRACE_MS, TASK_FIRE_TIMEOUT_MS } from '../web/schedule-runner.js'
@@ -195,6 +195,30 @@ describe('resolveStuckTimeoutMs: the threshold is per task', () => {
     // Entries are evicted at maxTrackMs regardless, so anything above it would
     // mean "never alert" while still looking like a threshold.
     expect(resolveStuckTimeoutMs({ stuckAfterMinutes: 60 * 24 })).toBe(MAX_TRACK)
+  })
+
+  // The clamp above only covers the PER-TASK branch. The default branch returns
+  // defaultMs untouched, which was safe while that was a literal 300_000 -- but
+  // this value now comes from .env, so an operator writing a big number would
+  // get exactly the quiet disable the per-task branch refuses: above the
+  // eviction age the entry is gone before the timeout can elapse, and nothing
+  // reports it. Mocking the config (rather than asserting on the constant as
+  // loaded) is what makes this measure the clamp: without it the test would
+  // pass on the unclamped code too, because the default .env sets nothing.
+  it('a GLOBAL value above the tracking window is clamped too, not just the per-task one', async () => {
+    vi.resetModules()
+    vi.doMock('../config.js', async () => ({
+      ...(await vi.importActual<typeof import('../config.js')>('../config.js')),
+      TASK_STALL_TIMEOUT_MS: 7 * 60 * 60_000,   // 7h, past the 6h eviction age
+    }))
+    try {
+      const mod = await import('../web/schedule-runner.js')
+      expect(mod.TASK_FIRE_TIMEOUT_MS).toBe(MAX_TRACK)
+      expect(mod.resolveStuckTimeoutMs({})).toBe(MAX_TRACK)
+    } finally {
+      vi.doUnmock('../config.js')
+      vi.resetModules()
+    }
   })
 
   it('the resolved budget actually drives the decision', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -254,6 +254,25 @@ export const WEB_PORT = parseInt(env['WEB_PORT'] ?? '3420', 10)
 
 export const WEB_HOST = env['WEB_HOST'] ?? '127.0.0.1'
 
+// How long a fired scheduled task may stay busy before the watchdog calls it
+// stuck (default 5 minutes; `stuckAfterMinutes` still overrides it per task).
+//
+// A key rather than a literal for the same reason as DEFAULT_AGENT_MODEL: this
+// number is an OPERATOR judgement, not an engineering constant. Whether "still
+// running after N minutes" means trouble depends on what the install's tasks
+// do, and an install that raises it has to keep raising it after every update
+// if the only way to say so is patching src/. That is not hypothetical -- one
+// install set 10 minutes because 5 produced false "possible hang" alerts, and
+// lost the setting to an update, silently: alerts simply got eager again.
+// .env survives updates, src/ does not.
+export const TASK_STALL_TIMEOUT_MS = (() => {
+  const parsed = parseInt(env['TASK_STALL_TIMEOUT_MS'] ?? '', 10)
+  // A malformed or absurd value must not disable the watchdog outright, so an
+  // out-of-range setting falls back to the default instead of being clamped
+  // into silence.
+  return Number.isFinite(parsed) && parsed >= 60_000 ? parsed : 300_000
+})()
+
 // Kanban card aging visual thresholds (hours since last update) and colours.
 // Override per-install via .env; defaults match the design spec (24/72/168h).
 export const KANBAN_AGING_WARN_H = parseInt(env['KANBAN_AGING_WARN_H'] ?? '24', 10)

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -11,6 +11,7 @@ import {
   ALLOWED_CHAT_ID,
   BOT_NAME,
   APP_TZ_INVALID,
+  TASK_STALL_TIMEOUT_MS,
 } from '../config.js'
 import {
   appendTaskRun,
@@ -82,7 +83,7 @@ const RESUBMIT_MAX_ATTEMPTS = 6
 // Maximum tracking age: entries that age past TASK_FIRE_MAX_TRACK_MS are
 // evicted regardless, so a permanently stuck agent does not accumulate entries.
 export const TASK_FIRE_GRACE_MS = 30_000
-export const TASK_FIRE_TIMEOUT_MS = 300_000
+export const TASK_FIRE_TIMEOUT_MS = TASK_STALL_TIMEOUT_MS
 const TASK_FIRE_MAX_TRACK_MS = 6 * 60 * 60_000
 
 export interface TaskInflightEntry {

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -83,8 +83,17 @@ const RESUBMIT_MAX_ATTEMPTS = 6
 // Maximum tracking age: entries that age past TASK_FIRE_MAX_TRACK_MS are
 // evicted regardless, so a permanently stuck agent does not accumulate entries.
 export const TASK_FIRE_GRACE_MS = 30_000
-export const TASK_FIRE_TIMEOUT_MS = TASK_STALL_TIMEOUT_MS
+// Declared BEFORE TASK_FIRE_TIMEOUT_MS because that one now reads it (a later
+// declaration would be a TDZ error at module load, not a type error).
 const TASK_FIRE_MAX_TRACK_MS = 6 * 60 * 60_000
+// Clamped to the eviction age on purpose. The per-task branch of
+// resolveStuckTimeoutMs already clamps to maxMs, but the DEFAULT branch returns
+// defaultMs untouched -- harmless while this was a fixed 300_000, a silent
+// disable now that .env can set it. Above TASK_FIRE_MAX_TRACK_MS the entry is
+// evicted before the timeout can ever elapse, so the alert would simply never
+// fire and nothing would say so: the exact quiet-disable this file's comment
+// above refuses to allow.
+export const TASK_FIRE_TIMEOUT_MS = Math.min(TASK_STALL_TIMEOUT_MS, TASK_FIRE_MAX_TRACK_MS)
 
 export interface TaskInflightEntry {
   taskName: string


### PR DESCRIPTION

**Files:** `src/config.ts`, `src/web/schedule-runner.ts`

## What

New `TASK_STALL_TIMEOUT_MS` key (default unchanged: 300000). `TASK_FIRE_TIMEOUT_MS` reads it.
A malformed or below-60s value falls back to the default rather than being clamped into silence.

## Why not just `stuckAfterMinutes`

The per-task override already exists and is the right tool for a task whose job is to think for a
while. It does not cover this case:

- NEW tasks start from the global default again, so the setting has to be re-applied forever
- on an install with 31 scheduled tasks, an operator-wide judgement becomes 31 places to maintain
- the value is not an engineering constant but an operator judgement: whether "still busy after N
  minutes" means trouble depends on what that install's tasks do

## Why a key and not a patched literal

This is a decision that was already made and then silently lost. Our operator raised the threshold
to 10 minutes on 2026-07-27 because 5 produced false "possible hang" alerts; the change lived as a
local patch in `src/`, an update replaced it, and the alerts simply got eager again with nothing to
show that a decision had been reverted. `.env` survives updates, `src/` does not.

This PR does not ask upstream to change its default. It asks that the default be overridable.

## Scope check

`TASK_FIRE_TIMEOUT_MS` has exactly one behavioural consumer today: `resolveStuckTimeoutMs` ->
`decideTaskTimeout` -> the `alert` branch. Entry eviction is `TASK_FIRE_MAX_TRACK_MS`, the
early-check guard is `TASK_FIRE_GRACE_MS`, and no retry or failure marking depends on it. So the
key tunes the operator-facing alert only -- it does not widen into fire-timeout semantics.

## Note

Best read after the test-only fix that stops `schedule-task-timeout.test.ts` from asserting the
default's value; without it, an install that sets the override fails a test on a point it never
meant to assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)