### PR TITLE
feat(install): record "set Claude up later" as a choice, not as missing credentials

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -697,6 +697,14 @@ else
     fi
 
   else
+    # Record that skipping was a CHOICE, here, at the moment it is made
+    # (INSTDEAD803). Without this the only later evidence is the ABSENCE of
+    # credentials, and absence cannot tell "the operator decided to set this up
+    # later" apart from "the sign-in broke halfway" -- which is exactly the
+    # dead end a bootcamp host hit on 2026-08-03. The installer app reads this
+    # flag to decide whether an install is finished or unfinished. It is not a
+    # renunciation: completing the sign-in later stays available on request.
+    CLAUDE_AUTH_DEFERRED=1
     echo -e "  ${DIM}Kihagyva. Kesobb allitsd be:${NC}"
     echo -e "  ${DIM}  export ANTHROPIC_API_KEY=sk-ant-...${NC}"
     echo -e "  ${DIM}  vagy: claude setup-token (boengeszos gepen), majd export CLAUDE_CODE_OAUTH_TOKEN=...${NC}"
@@ -1027,6 +1035,16 @@ else
   env_keep_or_set SLACK_BOT_TOKEN "${SLACK_BOT_TOKEN}"
   env_keep_or_set SLACK_APP_TOKEN "${SLACK_APP_TOKEN}"
 fi
+# The operator's deliberate "set auth up later" choice, persisted next to the
+# rest of the configuration. Written only when the skip branch above set it, so
+# it is a record of a decision and never an inference from missing credentials.
+# If the run dies before this point the flag is simply absent, which reads as
+# "unfinished" -- the safe direction, since that offers help rather than
+# assuming the operator wanted no auth.
+if [ "${CLAUDE_AUTH_DEFERRED:-}" = "1" ]; then
+  env_merge_key CLAUDE_AUTH_DEFERRED 1
+fi
+
 # Claude auth credentials (API key or OAuth token) -- channels.sh reads
 # these selectively so the tmux-spawned claude process can authenticate.
 # Merged by key, so an auth line saved by a previous run (or the dashboard

--- a/src/__tests__/installer-auth-deferred-marker.test.ts
+++ b/src/__tests__/installer-auth-deferred-marker.test.ts
@@ -1,0 +1,88 @@
+// INSTDEAD803 -- "I will set up Claude later" must be recorded as a CHOICE.
+//
+// A bootcamp host on 2026-08-03 ended up unusable and un-reinstallable: the
+// install script had finished (store/, .env, five systemd units, live
+// dashboard) but the Claude sign-in broke off afterwards, so there were no
+// credentials. The installer's guard saw the data markers, called it "already
+// installed", and offered nothing but a disabled button.
+//
+// The fix distinguishes a finished install from an unfinished one by asking
+// whether the host has any way to authenticate. That leaves one case the
+// question alone gets wrong: an operator who DELIBERATELY skipped auth ("set it
+// up later") also has no credentials, and would be told forever that the
+// install is unfinished. Absence cannot tell a decision apart from a failure --
+// so the decision is written down where it is made, and never inferred later.
+//
+// The safe direction if the flag is missing is "unfinished": that offers help,
+// whereas assuming the operator wanted no auth would hide a broken install.
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { PROJECT_ROOT } from '../config.js'
+
+const script = readFileSync(join(PROJECT_ROOT, 'install-linux.sh'), 'utf8')
+
+/** Run a shell snippet and return its stdout. */
+const sh = (code: string): string =>
+  execFileSync('/bin/bash', ['-c', code], { encoding: 'utf8' }).trim()
+
+describe('deliberate auth skip is recorded, not inferred', () => {
+  it('sets the flag in the SKIP branch, not anywhere else', () => {
+    // It must sit in the branch the operator lands on by choosing to skip --
+    // not next to the credential handling, where a failed attempt also passes.
+    const skipBranch = script.slice(
+      script.indexOf('Kihagyva. Kesobb allitsd be'),
+      script.indexOf('Pre-flight headless probe'),
+    )
+    expect(skipBranch.length).toBeGreaterThan(0)
+    const assignments = script.match(/^\s*CLAUDE_AUTH_DEFERRED=1$/gm) ?? []
+    expect(assignments, 'exactly one place may declare the deferral').toHaveLength(1)
+    // And that one place is above the skip message, inside the same branch.
+    const assignIdx = script.indexOf('    CLAUDE_AUTH_DEFERRED=1')
+    const msgIdx = script.indexOf('Kihagyva. Kesobb allitsd be')
+    expect(assignIdx).toBeGreaterThan(0)
+    expect(assignIdx).toBeLessThan(msgIdx)
+  })
+
+  it('persists the flag AFTER the decision, and only when it was made', () => {
+    const decide = script.indexOf('    CLAUDE_AUTH_DEFERRED=1')
+    const persist = script.indexOf('env_merge_key CLAUDE_AUTH_DEFERRED 1')
+    expect(persist, 'the flag must be written to .env').toBeGreaterThan(0)
+    expect(decide, 'the decision must come before it is persisted').toBeLessThan(persist)
+
+    // The persist step is conditional -- run the real condition both ways.
+    const cond = 'if [ "${CLAUDE_AUTH_DEFERRED:-}" = "1" ]; then echo WRITE; else echo SKIP; fi'
+    expect(sh(`CLAUDE_AUTH_DEFERRED=1; ${cond}`)).toBe('WRITE')
+    expect(sh(`unset CLAUDE_AUTH_DEFERRED; ${cond}`)).toBe('SKIP')
+    expect(sh(`CLAUDE_AUTH_DEFERRED=0; ${cond}`)).toBe('SKIP')
+  })
+
+  it('is never derived from missing credentials', () => {
+    // The failure mode this whole flag exists to prevent: someone "simplifying"
+    // it into a check for absent auth would recreate the exact false positive.
+    const persistBlock = script.slice(
+      script.indexOf('if [ "${CLAUDE_AUTH_DEFERRED:-}" = "1" ]'),
+      script.indexOf('env_merge_key CLAUDE_AUTH_DEFERRED 1') + 60,
+    )
+    expect(persistBlock).not.toMatch(/CLAUDE_CODE_OAUTH_TOKEN/)
+    expect(persistBlock).not.toMatch(/ANTHROPIC_API_KEY/)
+    expect(persistBlock).not.toMatch(/-z /)
+  })
+
+  it('a failed token attempt does NOT set the flag', () => {
+    // The branch that warns "Token nem lett megadva, kihagyas." is a FAILED
+    // attempt inside the OAuth path, not a decision to skip. If it set the
+    // flag, a broken sign-in would be filed as "the operator wanted it this
+    // way" -- the reported bug, with a nicer label.
+    // The slice must stop where that branch closes. A first version of this
+    // test ran to the skip MESSAGE and so spanned the `fi` and the `else`,
+    // swallowing the neighbouring branch and failing on correct code -- the
+    // instrument was wrong, not the script.
+    const start = script.indexOf('Token nem lett megadva, kihagyas.')
+    const failedAttempt = script.slice(start, script.indexOf('\n  else', start))
+    expect(failedAttempt.length).toBeGreaterThan(0)
+    expect(failedAttempt, 'the slice must stay inside the failed-attempt branch').not.toMatch(/Kihagyva/)
+    expect(failedAttempt).not.toMatch(/CLAUDE_AUTH_DEFERRED/)
+  })
+})


### PR DESCRIPTION
**INSTDEAD803**, the `marveen` half of a two-repo change. The installer-app half is the companion PR in `Szotasz/marveen-bridge-installer` (three-state guard) — they belong together.

## What happened

26 machines installed, 25 cleanly. On the 26th the Claude sign-in failed and the user closed the window. Reopening the installer offered **only** a reinstall, and the reinstall **refused**, because it saw that "a Marveen already exists".

Measured on that host before it was wiped: v1.28.2 unpacked, five systemd units, dashboard live on 3420, **no Claude credentials at all**. Complete enough to trip the guard, too incomplete to run. The user got a disabled button and no route.

## Why this PR exists

The app now separates *finished* from *unfinished* by asking whether the host has any way to authenticate. That question gets exactly **one** case wrong: an operator who **deliberately** skipped auth also has no credentials, and would be told forever that the install is unfinished.

**Absence cannot tell a decision apart from a failure.** So the decision is written where it is made: choosing "skip, I will set it up later" sets `CLAUDE_AUTH_DEFERRED=1`, and the configuration step persists it to `.env`. Nothing infers it afterwards from missing credentials — that inference *is* the false positive.

## Two properties that are easy to break later

- **The failed attempt does not set it.** The branch warning `"Token nem lett megadva, kihagyas."` sits inside the OAuth path and means the attempt produced no token. Filing that as "the operator wanted it this way" would reproduce the reported bug with a friendlier label.
- **A missing flag means UNFINISHED, and that is the safe direction.** If the run dies between the decision and the persist step, the flag is absent and the installer offers help. Assuming "no auth was wanted" would hide a broken install instead.

## Tests (4) — the shell condition is executed, not described

Exactly one declaration, in the skip branch; persist comes after the decision and fires only when set (run with the value set, unset, and `0`); the persist block never mentions credentials; the failed-attempt branch does not carry the flag.

**A note on that last test:** its first version sliced from the failure warning to the skip *message*, which spans the `fi` and the `else` and swallowed the neighbouring branch — it failed on correct code. The instrument was wrong, not the script. The slice now stops where the branch closes, and asserts that it did.

| control (against a wrong shape) | result |
|---|---|
| declaration removed from the skip branch | placement test fails |
| declaration moved into the failed-attempt branch | 2 tests fail |

Typecheck clean, suite **3200/3200** from a non-`/tmp` checkout.

⚠️ **Not to be merged on my say-so** — the installer chain's release is the owner's call.
