### PR TITLE
fix(channels): a watchdog exit left the Linux channel dead for good

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1674,7 +1674,17 @@ WorkingDirectory=$INSTALL_DIR
 # load for the current Node ABI before starting (2026-07-03 crash-loop fix).
 ExecStartPre=$INSTALL_DIR/scripts/ensure-native-modules.sh
 ExecStart=$INSTALL_DIR/scripts/channels.sh
-Restart=on-failure
+# Restart=always, NOT on-failure. channels.sh has watchdog branches that exit ON
+# PURPOSE to be restarted (sustained plugin death, plugin never started), and
+# under on-failure a zero exit read as "service finished" and the channel stayed
+# dead for good -- silently, with no failed unit to notice. macOS never showed
+# this because the launchd plist uses KeepAlive=true, which restarts regardless
+# of exit code; this line is what makes the Linux side symmetric with it.
+# Observed on a live v1.27.0 install 2026-08-04: unit inactive/dead after
+# ExecMainStatus=0, ten minutes before anyone looked.
+# Restart churn stays bounded by StartLimitIntervalSec/StartLimitBurst in
+# [Unit] above plus channels.sh's own rapid-failure backoff (sleep 60/300).
+Restart=always
 RestartSec=10
 StandardOutput=append:$INSTALL_DIR/store/channels.log
 StandardError=append:$INSTALL_DIR/store/channels.error.log

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -5,11 +5,15 @@
 # from CHANNEL_PROVIDER in .env; when absent, defaults to "telegram" for
 # full backward compatibility.
 #
-# A LaunchAgent hívja. Működés:
+# A LaunchAgent (macOS) vagy a systemd user unit (Linux) hívja. Működés:
 # 1. Tmux session indul a claude processzel
 # 2. A script vár amíg a session él
 # 3. Ha a claude kilép, a tmux session záródik, a script is kilép
-# 4. A launchd KeepAlive újraindítja
+# 4. A launchd KeepAlive újraindítja -- kilépési kódtól függetlenül.
+#    A systemd oldalon ez NEM volt igaz: a unit Restart=always nélkül a nulla
+#    kilépési kódot "kész, nem kell újraindítani"-ként olvasta, így a csatorna
+#    némán, véglegesen leállt. Ezért ad a watchdog-ág mostantól nem-nulla kódot,
+#    és ezért Restart=always a unit -- a két platform szemantikája így egyezik.
 #
 # Kézzel rácsatlakozás: tmux attach -t <MAIN_AGENT_ID>-channels (pl. marveen-channels)
 
@@ -753,6 +757,13 @@ PLUGIN_NEVER_STARTED_DEADLINE=$((START_TS + 600))
 PLUGIN_DEAD_GRACE=180
 PLUGIN_SEEN_ONCE=false
 PLUGIN_DEAD_SINCE=0
+# Set to 1 when the watchdog below breaks out ON PURPOSE to be restarted. The
+# exit status has to carry that intent: a watchdog exit is not a normal one, and
+# a unit still carrying the old Restart=on-failure would read exit 0 as "this
+# service is done" and never bring the channel back. Measured on a live install
+# 2026-08-04: channels.sh logged "exiting for service-manager restart", exited 0,
+# and the unit stayed inactive/dead for the next ten minutes.
+RESTART_REQUESTED=0
 
 # Várakozás amíg a session él
 while $TMUX has-session -t "$SESSION" 2>/dev/null; do
@@ -790,6 +801,7 @@ while $TMUX has-session -t "$SESSION" 2>/dev/null; do
       echo "WARN: $CHANNEL_PROVIDER plugin (bot.pid) disappeared -- ${PLUGIN_DEAD_GRACE}s grace before restart" >&2
     elif [ "$((NOW - PLUGIN_DEAD_SINCE))" -ge "$PLUGIN_DEAD_GRACE" ]; then
       echo "WARN: $CHANNEL_PROVIDER plugin dead for $((NOW - PLUGIN_DEAD_SINCE))s -- exiting for service-manager restart" >&2
+      RESTART_REQUESTED=1
       break
     fi
   else
@@ -797,6 +809,7 @@ while $TMUX has-session -t "$SESSION" 2>/dev/null; do
     # --channels). Give it the full cold-start budget, then restart.
     if [ "$NOW" -ge "$PLUGIN_NEVER_STARTED_DEADLINE" ]; then
       echo "WARN: $CHANNEL_PROVIDER plugin never started within $((PLUGIN_NEVER_STARTED_DEADLINE - START_TS))s -- exiting for service-manager restart" >&2
+      RESTART_REQUESTED=1
       break
     fi
   fi
@@ -820,4 +833,11 @@ fi
 
 # Normal exit: clear failure log
 rm -f "$INSTALL_DIR/store/channels-failures.log"
+
+# A watchdog exit asked for a restart, so it must NOT look like a clean finish.
+# Written as an if (not `[ ] && exit 1`) so a future `set -e` cannot turn the
+# false branch into an accidental non-zero exit of the whole script.
+if [ "$RESTART_REQUESTED" = "1" ]; then
+  exit 1
+fi
 exit 0

--- a/src/__tests__/channels-unit-restart-policy.test.ts
+++ b/src/__tests__/channels-unit-restart-policy.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// The channel could die silently and stay dead, on Linux only.
+//
+// channels.sh has watchdog branches that exit ON PURPOSE ("plugin dead for Ns
+// -- exiting for service-manager restart"), then fall through to `exit 0` for
+// any run longer than 30s. The systemd unit carried Restart=on-failure, and
+// systemd does not consider a zero exit a failure -- so the unit went
+// inactive/dead and nothing brought the channel back. No failed unit, no
+// crash-loop, no alert: the bot simply stops answering.
+//
+// Measured on a live install (vps47, v1.27.0, 2026-08-04 06:51:43):
+//   ExecMainStatus=0, ActiveState=inactive, SubState=dead, NRestarts=0
+//   channels.error.log: "telegram plugin dead for 180s -- exiting for
+//   service-manager restart"
+// and it was still dead ten minutes later, until started by hand.
+//
+// macOS was immune the whole time, which is why the fleet never saw it: the
+// launchd plist uses KeepAlive=true, which restarts regardless of exit code.
+//
+// Three things have to hold, and they are three separate failure modes:
+//   1. the shipped tail of channels.sh must report a watchdog exit as non-zero
+//      (so even an un-migrated old unit restarts it),
+//   2. the installer template must write Restart=always for the channels unit
+//      (symmetry with launchd KeepAlive),
+//   3. update.sh must migrate ALREADY INSTALLED units -- the template alone
+//      reaches new installs only, and the machines that have this bug today are
+//      exactly the already-installed ones.
+
+const ROOT = join(__dirname, '..', '..')
+const CHANNELS = readFileSync(join(ROOT, 'scripts', 'channels.sh'), 'utf-8')
+const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+const MACOS = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
+const UPDATE = readFileSync(join(ROOT, 'update.sh'), 'utf-8')
+
+/** Slice a region [from marker .. end marker]. The end is searched FROM the
+ *  start offset, never from 0 -- an earlier match would silently return a
+ *  neighbouring block that happens to pass. */
+function sliceBetween(src: string, startMarker: string, endMarker: string): string {
+  const start = src.indexOf(startMarker)
+  if (start < 0) throw new Error(`start marker not found: ${startMarker}`)
+  const end = src.indexOf(endMarker, start + startMarker.length)
+  if (end < 0) throw new Error(`end marker not found after start: ${endMarker}`)
+  return src.slice(start, end + endMarker.length)
+}
+
+/** Pull one shell function out of a script so it can be executed for real. */
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+  if (start < 0) throw new Error(`function ${name}() not found`)
+  const end = src.indexOf('\n}', start)
+  if (end < 0) throw new Error(`unterminated ${name}()`)
+  return src.slice(start, end + 2)
+}
+
+function runScript(body: string, env: Record<string, string> = {}): { out: string; code: number } {
+  const dir = mkdtempSync(join(tmpdir(), 'chanrestart-'))
+  try {
+    const p = join(dir, 'probe.sh')
+    writeFileSync(p, body + '\n')
+    try {
+      const out = execFileSync('bash', [p], { encoding: 'utf-8', env: { ...process.env, ...env } })
+      return { out: out.trim(), code: 0 }
+    } catch (e) {
+      const err = e as { stdout?: string; stderr?: string; status?: number }
+      return { out: `${String(err.stdout ?? '')}${String(err.stderr ?? '')}`.trim(), code: err.status ?? -1 }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('channels.sh watchdog exit status', () => {
+  // The tail of the REAL script is executed here, not a re-typed copy of it.
+  const tail = CHANNELS.slice(CHANNELS.indexOf('ELAPSED=$(( $(date +%s) - START_TS ))'))
+
+  it('exits non-zero when a watchdog branch asked for the restart', () => {
+    const store = mkdtempSync(join(tmpdir(), 'chanstore-'))
+    try {
+      const r = runScript(
+        `INSTALL_DIR="${store}"\nmkdir -p "$INSTALL_DIR/store"\nSTART_TS=$(( $(date +%s) - 600 ))\nRESTART_REQUESTED=1\n` + tail,
+      )
+      expect(r.code).toBe(1)
+    } finally {
+      rmSync(store, { recursive: true, force: true })
+    }
+  })
+
+  it('still exits zero on a genuinely normal end (no watchdog request)', () => {
+    const store = mkdtempSync(join(tmpdir(), 'chanstore-'))
+    try {
+      const r = runScript(
+        `INSTALL_DIR="${store}"\nmkdir -p "$INSTALL_DIR/store"\nSTART_TS=$(( $(date +%s) - 600 ))\nRESTART_REQUESTED=0\n` + tail,
+      )
+      expect(r.code).toBe(0)
+    } finally {
+      rmSync(store, { recursive: true, force: true })
+    }
+  })
+
+  it('sets the flag in BOTH watchdog branches, not just the one that was observed', () => {
+    const sustained = sliceBetween(CHANNELS, 'plugin dead for $((NOW - PLUGIN_DEAD_SINCE))s', 'break')
+    const neverStarted = sliceBetween(CHANNELS, 'plugin never started within', 'break')
+    expect(sustained).toContain('RESTART_REQUESTED=1')
+    expect(neverStarted).toContain('RESTART_REQUESTED=1')
+  })
+})
+
+describe('installer unit template', () => {
+  const chanUnit = sliceBetween(LINUX, 'cat >"$SYSTEMD_DIR/${CHAN_UNIT}.service" <<EOF', '\nEOF')
+
+  it('writes Restart=always for the channels unit', () => {
+    expect(chanUnit).toMatch(/^Restart=always$/m)
+    expect(chanUnit).not.toMatch(/^Restart=on-failure$/m)
+  })
+
+  it('keeps the crash-loop throttle that bounds the new restart policy', () => {
+    expect(chanUnit).toMatch(/StartLimitIntervalSec=\d+/)
+    expect(chanUnit).toMatch(/StartLimitBurst=\d+/)
+  })
+
+  it('leaves the dashboard unit policy alone (scope pin)', () => {
+    const dashUnit = sliceBetween(LINUX, 'cat >"$SYSTEMD_DIR/${DASH_UNIT}.service" <<EOF', '\nEOF')
+    expect(dashUnit).toMatch(/^Restart=on-failure$/m)
+  })
+
+  it('the macOS side already restarts regardless of exit code -- this is the symmetry being restored', () => {
+    expect(MACOS).toContain('<key>KeepAlive</key>')
+  })
+})
+
+describe('update.sh migration for already-installed machines', () => {
+  const fn = sliceShellFn(UPDATE, 'migrate_channels_restart')
+
+  function runMigration(unitsDir: string): { out: string; code: number } {
+    return runScript(`${fn}\nmigrate_channels_restart "${unitsDir}"`)
+  }
+
+  const OLD_UNIT = [
+    '[Unit]',
+    'Description=Marveen Channels (Telegram bridge)',
+    'StartLimitIntervalSec=300',
+    'StartLimitBurst=5',
+    '',
+    '[Service]',
+    'Type=simple',
+    'ExecStart=/root/marveen/scripts/channels.sh',
+    'Restart=on-failure',
+    'RestartSec=10',
+    '',
+    '[Install]',
+    'WantedBy=default.target',
+    '',
+  ].join('\n')
+
+  it('rewrites an existing on-failure channels unit and leaves no backup file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'units-'))
+    try {
+      const unit = join(dir, 'marveen-channels.service')
+      writeFileSync(unit, OLD_UNIT)
+      const r = runMigration(dir)
+      expect(r.code).toBe(0)
+      const after = readFileSync(unit, 'utf-8')
+      expect(after).toMatch(/^Restart=always$/m)
+      expect(after).not.toMatch(/^Restart=on-failure$/m)
+      // everything else must survive verbatim
+      expect(after).toContain('ExecStart=/root/marveen/scripts/channels.sh')
+      expect(after).toContain('StartLimitBurst=5')
+      expect(readdirSync(dir).filter((f) => f.includes('marveen-bak'))).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('is idempotent: a second run changes nothing and reports nothing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'units-'))
+    try {
+      const unit = join(dir, 'marveen-channels.service')
+      writeFileSync(unit, OLD_UNIT)
+      runMigration(dir)
+      const firstPass = readFileSync(unit, 'utf-8')
+      const second = runMigration(dir)
+      expect(second.code).toBe(0)
+      expect(second.out).not.toContain('Csatorna-unit javitva')
+      expect(readFileSync(unit, 'utf-8')).toBe(firstPass)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('migrates a renamed install too (unit name derives from the bot name)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'units-'))
+    try {
+      const unit = join(dir, 'hermes-channels.service')
+      writeFileSync(unit, OLD_UNIT)
+      runMigration(dir)
+      expect(readFileSync(unit, 'utf-8')).toMatch(/^Restart=always$/m)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not touch the dashboard unit in the same directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'units-'))
+    try {
+      const dash = join(dir, 'marveen-dashboard.service')
+      writeFileSync(dash, OLD_UNIT.replace('channels.sh', 'start-dashboard.sh'))
+      runMigration(dir)
+      expect(readFileSync(dash, 'utf-8')).toMatch(/^Restart=on-failure$/m)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('survives a directory with no units at all (fresh macOS host)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'units-'))
+    try {
+      expect(runMigration(dir).code).toBe(0)
+      expect(runMigration(join(dir, 'does-not-exist')).code).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('is actually called by update.sh, not merely defined', () => {
+    const afterDefinition = UPDATE.slice(UPDATE.indexOf('migrate_channels_restart() {') + 1)
+    expect(afterDefinition).toMatch(/^migrate_channels_restart$/m)
+  })
+})

--- a/update.sh
+++ b/update.sh
@@ -489,6 +489,36 @@ if [ -d "$HOME/.config/systemd/user" ]; then
   done
 fi
 
+# Channels-unit restart-policy migration (Linux only). The installer template is
+# the only place that writes the unit file, and update.sh does NOT re-run the
+# installer -- so a fix to the template reaches new installs only. Every machine
+# installed before this change keeps Restart=on-failure, under which channels.sh
+# exiting zero from its own watchdog leaves the unit inactive/dead forever (seen
+# live 2026-08-04). This migration is what actually lands the fix on those hosts.
+# Idempotent: it only touches units that still carry the old value.
+migrate_channels_restart() {
+  units_dir="${1:-$HOME/.config/systemd/user}"
+  [ -d "$units_dir" ] || return 0
+  _patched=0
+  for chan_unit in "$units_dir/"*-channels.service; do
+    [ -f "$chan_unit" ] || continue
+    if grep -q '^Restart=on-failure[[:space:]]*$' "$chan_unit"; then
+      if sed -i.marveen-bak 's/^Restart=on-failure[[:space:]]*$/Restart=always/' "$chan_unit" 2>/dev/null; then
+        rm -f "${chan_unit}.marveen-bak"
+        _patched=1
+        echo -e "  Csatorna-unit javitva (Restart=on-failure -> always): $(basename "$chan_unit")"
+      else
+        echo -e "  FIGYELEM: a csatorna-unit nem volt irhato: $chan_unit"
+      fi
+    fi
+  done
+  if [ "$_patched" = "1" ]; then
+    systemctl --user daemon-reload 2>/dev/null || true
+  fi
+  return 0
+}
+migrate_channels_restart
+
 # Seed skills & scheduled tasks (idempotent: skip existing)
 # Source .env for template variables needed by seed-scheduled-tasks
 MAIN_AGENT_ID=""


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Kapcsolódó issue / Related issue

Nincs issue; élő telepítésen mért hiba (2026-08-04). / No issue; measured on a live install on 2026-08-04.

## Ellenőrzőlista / Checklist

- [ ] **Nem teljesen:** a teljes vitest suite zöld (237 fájl / 3216 teszt), `typecheck` és `syntax-check` tiszta, és a migráció egy éles gépről vett igazi unit-fájlon is lefutott. Amit NEM próbáltam ki: valódi Telegram/Slack csatorna-halál utáni systemd-újraindítás élő Linux hoston. Lásd a "Not covered" szakaszt. / Full suite, typecheck and syntax-check are green and the migration was run against a real deployed unit file, but the end-to-end systemd restart was not exercised on a live Linux host.
- [x] `docs/` nem érintett: a mappa nem dokumentálja a unit restart-szabályát (`grep -rl "Restart=" docs/` nem ad találatot). / `docs/` untouched: it does not document the unit restart policy.
- [x] Nincs beleégetett szenzitív adat; a leírás sem tartalmaz gépnevet, IP-t vagy tokent. / No hardcoded secrets; the description carries no host name, IP or token either.
- [x] Saját branchről nyitva: `fix/channels-unit-never-restarts` -> `develop`.

---

## What breaks today

`scripts/channels.sh` has two watchdog branches that quit **on purpose** to be restarted:

- `plugin dead for 180s -- exiting for service-manager restart`
- `plugin never started within Ns -- exiting for service-manager restart`

Both `break` out of the loop and then fall through to `exit 0` (`channels.sh:823`). The systemd unit is written with `Restart=on-failure` (`install-linux.sh:1677`), and systemd does not treat a zero exit as a failure. The service that asked to be restarted is the one systemd is configured never to restart.

Result on Linux: the unit goes `inactive/dead`, the channel stops, and nothing brings it back. There is no failed unit, no crash loop and no alert — the bot just stops answering.

Only the `<30s` rapid-exit branch returns `exit 1`, so **exactly the sustained-death case the branch was written for is the one that is orphaned.**

## Evidence (observed, not inferred)

Seen on a live install on 2026-08-04:

```
ExecMainStatus=0  ActiveState=inactive  SubState=dead  NRestarts=0
channels.error.log: WARN: telegram plugin dead for 180s -- exiting for service-manager restart
```

Still dead ten minutes later; it came back only when started by hand.

## Why nobody noticed

macOS is immune. The launchd plist uses `KeepAlive` `true` (`install-macos.sh`), which restarts regardless of exit code. Our own host is macOS, so the failure mode was structurally invisible to us and hits Linux installs only.

`channels.sh`'s own header documented the assumption all along: *"A launchd KeepAlive újraindítja"*. The systemd side never mirrored it.

## The fix, in three parts

The bug has three independent ways of surviving a partial fix, so all three are here:

| # | File | Change |
|---|---|---|
| 1 | `scripts/channels.sh` | a watchdog exit now returns a non-zero status, so even a host still carrying the old `Restart=on-failure` recovers. Both branches set the flag, not just the observed one. |
| 2 | `install-linux.sh` | the channels unit template writes `Restart=always`, symmetric with launchd `KeepAlive`. |
| 3 | `update.sh` | migrates machines that are **already installed**. |

**Part 3 is the one that matters for the fleet in the field.** `update.sh` does not re-run the installer, so a template-only fix would land on new installs and nobody else — every host installed before this PR would keep the broken policy forever. The migration rewrites `Restart=on-failure` to `Restart=always` in `*-channels.service`, reloads the user manager, is idempotent, and leaves the dashboard unit alone.

Restart churn stays bounded by the existing `StartLimitIntervalSec=300` / `StartLimitBurst=5` in `[Unit]` and by `channels.sh`'s own rapid-failure backoff (`sleep 60/300`).

The dashboard unit is deliberately left on `Restart=on-failure`: it has no self-requested clean exit. That scope decision is pinned by a test, so a later change has to be deliberate.

## Tests

`src/__tests__/channels-unit-restart-policy.test.ts` — 13 tests, full suite green (237 files / 3216 tests), `typecheck` and `syntax-check` clean.

The tests execute the shipped code rather than a re-typed copy of it:

- the exit-status tests run **the real tail of `channels.sh`** with the watchdog flag set and unset;
- the migration tests run **the function sliced out of `update.sh`** against unit files in a temp dir (fresh install, renamed install, idempotency, dashboard untouched, missing directory).

**Mutation controls** — each guard was verified to catch its own defect, with the named failing test recorded:

| mutation | failing test |
|---|---|
| unit template back to `Restart=on-failure` | `writes Restart=always for the channels unit` |
| drop the flag in the sustained-death branch | `sets the flag in BOTH watchdog branches...` |
| remove the exit-status block from `channels.sh` | `exits non-zero when a watchdog branch asked for the restart` |
| define the migration but never call it | `is actually called by update.sh, not merely defined` |
| neuter the migration's `sed` | the three migration behaviour tests |

The migration was additionally run against an **actual deployed unit file** taken from a live host: exactly one line changed, no backup residue, every other line byte-identical.

## Not covered

No test asserts end-to-end systemd behaviour — a real plugin death followed by a real systemd restart. That needs a live Linux host and is the next measurement, not something this PR proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
