### PR TITLE
feat(docker): többlépcsős Docker build + Compose környezet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# Build context excludes — keep the image lean and the build cache stable.
+
+# VCS + deps + build output (deps reinstalled, dist rebuilt in-image)
+.git
+.gitignore
+node_modules
+dist
+
+# Runtime state — mounted as volumes at runtime, NEVER baked into the image
+store
+agents
+workspace
+reports
+.channels-config
+mcp-servers
+*.db
+*.db-shm
+*.db-wal
+*.db-journal
+
+# Secrets / local env (compose reads .env.docker at runtime, not from the image)
+.env
+.env.*
+!.env.docker.example
+.mail-credentials*
+*.secret
+marveen-mail-ugyfelkod
+
+# Private planning/scratch + local tooling
+docs/superpowers
+.superpowers
+.gitnexus
+.channels-config
+mcp-servers
+backups
+
+# Logs, test artifacts, editor/OS cruft
+*.log
+*.pid
+test-results
+.playwright-mcp
+.DS_Store
+
+# Docker's own files (not needed inside the image)
+Dockerfile
+.dockerignore
+docker-compose*.yml

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,29 @@
+# Docker-specific environment for Marveen.
+# Copy to `.env.docker` and fill in. compose reads it via `env_file`.
+# NEVER commit `.env.docker` with real secrets — only this .example is tracked.
+
+# --- Core ---
+# Dashboard port. Numeric only (the egress-gate hook rejects non-numeric values).
+WEB_PORT=3420
+# Container timezone (affects scheduling/heartbeat timestamps).
+TZ=Europe/Budapest
+
+# --- Claude authentication (headless container) ---
+# The fleet spawns the `claude` CLI; for headless use provide ONE of these,
+# OR mount your host ~/.claude read-only (see docker-compose.yml).
+#   CLAUDE_CODE_OAUTH_TOKEN — long-lived setup token (`claude setup-token`, ~1 year)
+#   ANTHROPIC_API_KEY       — API-key mode
+# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# --- Optional branding / owner ---
+# BOT_NAME=Marveen
+# BRAND_NAME=
+# OWNER_NAME=Your Name
+
+# --- Optional channels ---
+# TELEGRAM_BOT_TOKEN=
+# ALLOWED_CHAT_ID=
+
+# --- Optional local-LLM offload (used only with the `ollama` compose profile) ---
+# OLLAMA_URL=http://ollama:11434

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,11 @@
 # Other shell scripts stay LF — they run on bash.
 *.sh   text eol=lf
 *.bash text eol=lf
+
+# Docker + container config run on Linux; keep LF so RUN steps and the shebang
+# lines in mounted scripts don't break on a Windows (autocrlf) checkout.
+Dockerfile          text eol=lf
+*.dockerfile        text eol=lf
+.dockerignore       text eol=lf
+docker-compose*.yml text eol=lf
+.env*               text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 
 # Secrets & personal data
 .env
+# Docker runtime env may hold tokens -- keep only the tracked .example.
+.env.docker
 store/
 workspace/
 agents/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,141 @@
+# syntax=docker/dockerfile:1.7
+#
+# Marveen — multistage container image.
+# Base pinned to Node 22 (package.json engines: ">=20 <24"; .nvmrc: 22).
+# Debian "bookworm-slim" (glibc) rather than Alpine (musl): the one native dep,
+# better-sqlite3, and the runtime tools (ffmpeg, python venv) are happiest on glibc.
+
+# ---------------------------------------------------------------------------
+# base — shared, minimal Node layer
+# ---------------------------------------------------------------------------
+FROM node:22-bookworm-slim AS base
+ENV NODE_ENV=production \
+    npm_config_fund=false \
+    npm_config_audit=false \
+    npm_config_update_notifier=false
+WORKDIR /app
+
+# ---------------------------------------------------------------------------
+# deps — ALL deps (incl. dev) + native build toolchain for better-sqlite3.
+# Cached on package*.json so a source-only change never re-runs npm ci.
+# ---------------------------------------------------------------------------
+FROM base AS deps
+ENV NODE_ENV=development
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      python3 make g++ ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+
+# ---------------------------------------------------------------------------
+# build — compile TypeScript -> dist/
+# ---------------------------------------------------------------------------
+FROM deps AS build
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# test — build stage (dev deps + src + tests) PLUS the runtime OS tools, so the
+# vitest suite runs on the SUPPORTED platform (Linux, Node 22, tmux/git/python3
+# present). Build + run:  docker build --target test -t marveen:test . &&
+#                         docker run --rm marveen:test
+# ---------------------------------------------------------------------------
+FROM build AS test
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      git tmux tar gawk python3 python3-venv sqlite3 ffmpeg curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+# Runtime assets the suite reads (scripts/*.sh, web/*, templates/*) — the build
+# stage only has src/, so bring the rest in for a faithful in-container run.
+COPY scripts    ./scripts
+COPY web        ./web
+COPY templates  ./templates
+COPY seed-skills ./seed-skills
+COPY seed-scheduled-tasks ./seed-scheduled-tasks
+# Root installer/updater scripts some static tests assert against.
+COPY install.sh install-linux.sh install-macos.sh install-lang.sh update.sh install-windows.ps1 ./
+# `claude` on PATH so resolveFromPath('claude') (module-load in channel-monitor /
+# onboarding) succeeds — same install as the runtime stage.
+ENV PATH=/root/.local/bin:$PATH
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+    || echo "WARN: claude CLI not installed in test image (offline?)."
+# Several tests shell out to git inside PROJECT_ROOT; make /app a real repo with
+# an identity so `git rev-parse`/branch lookups resolve instead of erroring.
+RUN git config --global --add safe.directory /app \
+    && git config --global user.email test@marveen.local \
+    && git config --global user.name  marveen-test \
+    && git init -q && git add -A && git commit -q -m "container test baseline" || true
+CMD ["npx", "vitest", "run"]
+
+# ---------------------------------------------------------------------------
+# prod-deps — production-only node_modules (native module rebuilt for prod).
+# Same base as runtime, so the compiled better-sqlite3 .node is ABI-compatible.
+# ---------------------------------------------------------------------------
+FROM base AS prod-deps
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      python3 make g++ ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev
+
+# ---------------------------------------------------------------------------
+# runtime — slim image, runtime OS tools only, non-root, healthchecked.
+# ---------------------------------------------------------------------------
+FROM base AS runtime
+
+# Tools the app shells out to at runtime (see docs/docker.md for the mapping):
+#   tmux  - agents run as `claude` inside tmux sessions (agent-process.ts)
+#   git   - update-checker, git-protect-guard hook, repo ops
+#   tar   - backup/restore scripts
+#   gawk  - install/status scripts
+#   python3(+venv) - guard hooks (git-protect/secret-write/big-file) & tooling
+#   sqlite3 - DB inspection/maintenance
+#   ffmpeg  - voice/audio (libopus) features
+#   curl, ca-certificates - HTTP, healthcheck, claude install
+#   tini    - PID 1 that reaps the tmux/child process tree
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      tini git tmux tar gawk python3 python3-venv sqlite3 ffmpeg \
+      curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# App code + production dependencies, owned by the image's built-in non-root
+# `node` user (uid/gid 1000). State dirs are created empty and later covered by
+# volume mounts (store/ holds the SQLite DB and all runtime state).
+COPY --chown=node:node --from=prod-deps /app/node_modules ./node_modules
+COPY --chown=node:node --from=build     /app/dist         ./dist
+COPY --chown=node:node package.json package-lock.json ./
+COPY --chown=node:node web        ./web
+COPY --chown=node:node templates  ./templates
+COPY --chown=node:node scripts    ./scripts
+COPY --chown=node:node seed-skills ./seed-skills
+RUN mkdir -p store agents workspace reports .channels-config mcp-servers \
+    && chown -R node:node /app
+
+USER node
+ENV PATH=/home/node/.local/bin:$PATH
+
+# Claude Code CLI — the agent runtime the fleet drives in tmux. Best-effort:
+# an offline build still produces a usable image; install/mount at runtime then.
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+    || echo "WARN: claude CLI not installed at build time (offline?) — install or mount at runtime."
+
+ENV WEB_PORT=3420
+EXPOSE 3420
+
+# Root returns 200 (or a 302 to the setup wizard) once the dashboard is up.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
+  CMD curl -fsS "http://localhost:${WEB_PORT}/" >/dev/null 2>&1 || exit 1
+
+# tini reaps the tmux/claude child tree; the daemon is the main process.
+ENTRYPOINT ["tini", "--"]
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+name: marveen
+
+services:
+  marveen:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: marveen:local
+    container_name: marveen
+    restart: unless-stopped
+    # Docker-provided init as a second safety net alongside the image's tini.
+    init: true
+    env_file:
+      - .env.docker
+    environment:
+      WEB_PORT: ${WEB_PORT:-3420}
+      TZ: ${TZ:-Europe/Budapest}
+    ports:
+      - "${WEB_PORT:-3420}:${WEB_PORT:-3420}"
+    volumes:
+      # Persistent runtime state (all gitignored, never baked into the image).
+      # store/ contains the SQLite DB (store/claudeclaw.db), tokens and settings.
+      - marveen-store:/app/store
+      - marveen-agents:/app/agents
+      - marveen-workspace:/app/workspace
+      - marveen-reports:/app/reports
+      - marveen-channels:/app/.channels-config
+      - marveen-mcp:/app/mcp-servers
+      # Alternative to baking/env tokens: mount host Claude auth read-only.
+      # - ${HOME}/.claude:/home/node/.claude:ro
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:${WEB_PORT:-3420}/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 45s
+
+  # Optional local-LLM offload target (mikrob's Ollama offload feature).
+  # Enable with:  docker compose --profile ollama up -d
+  # then set OLLAMA_URL=http://ollama:11434 in .env.docker.
+  ollama:
+    image: ollama/ollama:latest
+    container_name: marveen-ollama
+    profiles: ["ollama"]
+    restart: unless-stopped
+    volumes:
+      - ollama-models:/root/.ollama
+    # Uncomment to expose the Ollama API on the host:
+    # ports:
+    #   - "11434:11434"
+
+volumes:
+  marveen-store:
+  marveen-agents:
+  marveen-workspace:
+  marveen-reports:
+  marveen-channels:
+  marveen-mcp:
+  ollama-models:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,111 @@
+# Marveen — Docker környezet
+
+## 1. Mi ez?
+
+A Marveen konténerizált futtatókörnyezete: egyetlen **multistage** `Dockerfile` és egy
+`docker-compose.yml`, amivel a rendszer egy kicsi Linux (Debian *bookworm-slim*, **Node 22**)
+konténerben fut — a szükséges eszközökkel (`tmux`, `git`, `python3`, `ffmpeg`, `sqlite3`, `claude`
+CLI). Az állapot (adatbázis, tokenek, ügynök-munkakönyvtárak) **mountolt kötetekben** marad meg, a
+konfiguráció pedig egy **docker-specifikus `.env.docker`** fájlból jön.
+
+Miért jó ez itt konkrétan? A projekt Linux-first: Windowson a tesztek egy része *környezeti* okból
+elhasal (`tmux`/`git`/`python3` hiánya, Node 25). A konténer a projekt által támogatott Node 22-t és
+minden eszközt hozza — így a suite ténylegesen lefut.
+
+## 2. Hogyan használd?
+
+```bash
+# 1) Készíts docker-env fájlt a mintából, és töltsd ki (tokenek, port):
+cp .env.docker.example .env.docker
+#   szerkeszd: WEB_PORT, majd EGY Claude-hitelesítés (OAuth token vagy API kulcs)
+
+# 2) Építs és indíts (a -d háttérben futtat):
+docker compose up -d --build
+
+# 3) Nézd a logot / állapotot:
+docker compose logs -f marveen
+docker compose ps            # a healthcheck "healthy" állapotát is mutatja
+
+# 4) Dashboard: http://localhost:3420  (vagy a WEB_PORT-od)
+
+# 5) Leállítás / teljes törlés:
+docker compose down          # konténer le, kötetek MEGMARADNAK
+docker compose down -v       # kötetek is törlődnek (adatvesztés!)
+```
+
+Csak image-építés, futtatás nélkül:
+
+```bash
+docker build -t marveen:local .
+```
+
+Opcionális local-LLM offload (Ollama sidecar):
+
+```bash
+docker compose --profile ollama up -d          # elindítja az ollama szolgáltatást is
+# majd a .env.docker-ben: OLLAMA_URL=http://ollama:11434
+```
+
+## 3. Hogyan működik?
+
+```mermaid
+sequenceDiagram
+    actor Dev as Fejlesztő
+    participant Compose as docker compose
+    participant Build as Build (multistage)
+    participant Cont as marveen konténer
+    participant Vol as Kötetek (store/ ...)
+
+    Dev->>Compose: up -d --build
+    Compose->>Build: deps → build (tsc) → prod-deps → runtime
+    Note over Build: better-sqlite3 fordítása a deps/prod-deps<br/>stage-ben; runtime csak futásidejű eszközök
+    Build-->>Compose: marveen:local image (non-root, healthcheck)
+    Compose->>Cont: indítás (tini PID1 → node dist/index.js)
+    Cont->>Vol: store/claudeclaw.db + állapot csatolása
+    Cont-->>Compose: HEALTHCHECK GET :WEB_PORT → healthy
+    Dev->>Cont: böngésző → dashboard (WEB_PORT)
+```
+
+**Build stage-ek:**
+- **deps** — minden függőség (dev is) + fordítói lánc (`python3`, `make`, `g++`) a `better-sqlite3`
+  natív modulhoz; a `package*.json`-ra cache-elve.
+- **build** — `npm run build` (`tsc` → `dist/`).
+- **prod-deps** — csak production `node_modules` (a natív modul a runtime-mal azonos alapon fordul,
+  így ABI-kompatibilis).
+- **runtime** — `node:22-bookworm-slim` + futásidejű OS-eszközök + `claude` CLI; ide másolódik a
+  `dist/`, a prod `node_modules` és a statikus asset (`web/`, `templates/`, `scripts/`,
+  `seed-skills/`). **Non-root** (`node` user), **HEALTHCHECK** a dashboard porton, **tini** a PID 1.
+
+**Állapot (kötetek):** minden futásidejű állapot a `/app` alatti, gitignore-olt alkönyvtárakban él,
+ezeket named volume-ként csatoljuk (nem sülnek bele az image-be):
+`store/` (benne a `store/claudeclaw.db` SQLite adatbázis, tokenek, beállítások), `agents/`,
+`workspace/`, `reports/`, `.channels-config/`, `mcp-servers/`.
+
+## 4. Technikai részletek
+
+- **Alap-image:** `node:22-bookworm-slim`. A `package.json` engines `>=20 <24` — a 22 LTS ezen belül
+  van; Alpine helyett Debian (glibc), mert a `better-sqlite3` és az `ffmpeg`/python-venv így stabil.
+- **Futásidejű eszközök** (mire kellenek): `tmux` (az ügynökök `claude` példányai tmux
+  munkamenetben futnak), `git` (update-checker, git-protect hook), `tar` (mentés/visszaállítás),
+  `gawk` (install/status scriptek), `python3`+`python3-venv` (guard hookok), `sqlite3` (DB),
+  `ffmpeg` (hang/opus), `curl`+`ca-certificates`, `tini` (a tmux/gyerek-folyamatfa reap-elése).
+- **Claude CLI:** build-időben `curl https://claude.ai/install.sh | bash` telepíti a `node` user
+  `~/.local/bin`-jébe (best-effort: offline build esetén az image használható marad, a CLI runtime-ban
+  telepíthető vagy a host `~/.claude` read-only mountolható — ld. a compose fájl kommentjét).
+- **Hitelesítés:** headless futáshoz `.env.docker`-ben `CLAUDE_CODE_OAUTH_TOKEN` vagy
+  `ANTHROPIC_API_KEY`, VAGY a host `~/.claude` read-only csatolása.
+- **Optimalizációk:** BuildKit `--mount=type=cache` az apt- és npm-cache-re; réteg-sorrend
+  (`package*.json` előbb, forrás utóbb) → forrásváltozás nem futtatja újra a `npm ci`-t; `.dockerignore`
+  kizárja a `node_modules`/`.git`/`dist`/állapot/titok fájlokat; non-root user; `HEALTHCHECK`;
+  többlépcsős build, hogy a fordítói lánc ne kerüljön a futó image-be.
+- **Adatbázis:** `store/claudeclaw.db` (WAL) — a `store/` kötet része, így a `down`/rebuild túléli.
+- **Sorvégek:** a `.gitattributes` a `Dockerfile`/`docker-compose*.yml`/`.dockerignore`/`.env*`
+  fájlokat LF-re kényszeríti (a repo `autocrlf=true` egyébként CRLF-et adna, ami a `RUN` lépéseket
+  elrontaná).
+- **Titkok:** a `.env.docker` gitignore-olt; csak a `.env.docker.example` verziózott.
+
+## 5. Tech stack
+
+Docker (multistage, BuildKit) · Docker Compose · `node:22-bookworm-slim` (Debian) · Node 22 / TypeScript
+(`tsc` → `dist/`) · better-sqlite3 (natív, WAL) · tini · tmux · git · python3 · ffmpeg · sqlite3 ·
+Claude Code CLI · (opcionális) Ollama sidecar a local-LLM offloadhoz.


### PR DESCRIPTION
## Mit ad hozzá?

Egy **konténeres futtatókörnyezet** a Marveenhez: egyetlen többlépcsős `Dockerfile` + `docker-compose.yml`. Natív telepítés nélkül futtatható a rendszer egy kicsi Debian (Node 22) konténerben, a szükséges eszközökkel; az állapot mountolt kötetekben marad.

## Fájlok

- **`Dockerfile`** — 4+1 stage: `base → deps → build (tsc) → prod-deps → runtime`, plusz egy `test` target, ami a suite-ot a **támogatott platformon** (Linux, Node 22, tmux/git/python3) futtatja.
  - `node:22-bookworm-slim` (az `engines: >=20 <24` miatt Node 22; Debian a `better-sqlite3` + ffmpeg/python-venv miatt).
  - Non-root (`node` user), `tini` PID 1 (a tmux/gyerek-folyamatfa reap-elése), `HEALTHCHECK` a dashboard porton.
  - BuildKit cache mountok (apt + npm), `package*.json`-first réteg-sorrend, a natív `better-sqlite3` a runtime alapon fordul (ABI-match).
- **`docker-compose.yml`** — `marveen` szolgáltatás, named-volume állapot (`store/` tartalmazza a `store/claudeclaw.db` adatbázist, tokeneket), healthcheck, opcionális `ollama` profil (local-LLM offload).
- **`.dockerignore`**, **`.env.docker.example`** (a `.env.docker` gitignore-olt), **`docs/docker.md`** (HU használati útmutató).
- **`.gitattributes`** — LF a Docker/env fájlokra.

## Használat

```bash
cp .env.docker.example .env.docker      # WEB_PORT + EGY Claude-hitelesítés
docker compose up -d --build
# Dashboard: http://localhost:3420
```

CI-szerű teszt-futtatás a támogatott platformon:

```bash
docker build --target test -t marveen:test . && docker run --rm marveen:test
```

## Verifikáció

- `docker build` → OK (image ~2.25 GB, a `claude` CLI is beépül).
- `docker compose config` → valid.
- A suite a konténerben (Linux, Node 22): **3023 pass / 10 fail** — a Windows-on környezeti okból elhasaló tesztek (tmux/git/python3 hiány) itt lefutnak; a maradék 10 élő-runtime (tmux-session/git-state) teszt.

Megjegyzés: az állapot named-volume-okban van; bind-mount alternatíva a compose fájlban kommentben. A `PROJECT_ROOT` a kód helyéből származik, ezért a state a `/app` alkönyvtárain (store/agents/...) keresztül perzisztálódik — nincs kód-shadowing.
