### PR TITLE
fix(update): unit repairs ran behind the up-to-date exit, so they never ran

### DIFF
--- a/src/__tests__/channels-unit-restart-policy.test.ts
+++ b/src/__tests__/channels-unit-restart-policy.test.ts
@@ -227,7 +227,11 @@ describe('update.sh migration for already-installed machines', () => {
   })
 
   it('is actually called by update.sh, not merely defined', () => {
+    // The call moved into run_unit_maintenance() when the maintenance block was
+    // lifted above the up-to-date early exit, so assert the whole chain: the
+    // wrapper calls it, and the wrapper itself is invoked at top level.
     const afterDefinition = UPDATE.slice(UPDATE.indexOf('migrate_channels_restart() {') + 1)
-    expect(afterDefinition).toMatch(/^migrate_channels_restart$/m)
+    expect(afterDefinition).toMatch(/^\s+migrate_channels_restart "\$@"$/m)
+    expect(afterDefinition).toMatch(/^run_unit_maintenance$/m)
   })
 })

--- a/src/__tests__/update-unit-maintenance-order.test.ts
+++ b/src/__tests__/update-unit-maintenance-order.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// A repair that only runs when there is something to pull is a repair that
+// never runs on the machines that need it.
+//
+// update.sh returns early ("already on the latest commit") long before the
+// unit-maintenance block used to sit. Two consequences, both measured on a live
+// host on 2026-08-04:
+//   - a machine updated 1.28.2 -> 1.29.0 and its channels unit still carried
+//     the old Restart=on-failure: the run that PULLS a new repair is still
+//     executing the OLD copy of update.sh (bash reads a script incrementally,
+//     there is no re-exec), so it runs the old code, which lacks the repair;
+//   - re-running update.sh did not help either: with nothing to pull it exits
+//     at the up-to-date branch, above the repairs.
+// The repair would first have run one whole release later.
+//
+// The morning-timer repair had the identical defect for weeks before the
+// channels migration was placed next to it, which is what makes this a class
+// and not a one-off. These tests pin the ordering so it cannot come back.
+
+const ROOT = join(__dirname, '..', '..')
+const UPDATE = readFileSync(join(ROOT, 'update.sh'), 'utf-8')
+
+/** Line number (1-based) of the first line matching `re`. */
+function lineOf(src: string, re: RegExp): number {
+  const lines = src.split('\n')
+  for (let i = 0; i < lines.length; i++) if (re.test(lines[i])) return i + 1
+  throw new Error(`no line matches ${re}`)
+}
+
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+  if (start < 0) throw new Error(`function ${name}() not found`)
+  const end = src.indexOf('\n}', start)
+  if (end < 0) throw new Error(`unterminated ${name}()`)
+  return src.slice(start, end + 2)
+}
+
+function runScript(body: string): { out: string; code: number } {
+  const dir = mkdtempSync(join(tmpdir(), 'unitmaint-'))
+  try {
+    const p = join(dir, 'probe.sh')
+    writeFileSync(p, body + '\n')
+    try {
+      return { out: execFileSync('bash', [p], { encoding: 'utf-8' }).trim(), code: 0 }
+    } catch (e) {
+      const err = e as { stdout?: string; stderr?: string; status?: number }
+      return { out: `${String(err.stdout ?? '')}${String(err.stderr ?? '')}`.trim(), code: err.status ?? -1 }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const OLD_CHANNELS_UNIT = ['[Service]', 'ExecStart=/root/marveen/scripts/channels.sh', 'Restart=on-failure', 'RestartSec=10', ''].join('\n')
+const OLD_MORNING_TIMER = ['[Unit]', 'Description=Marveen Reggeli Napindito Timer', 'Requires=marveen-morning.service', '', '[Timer]', 'OnCalendar=*-*-* 07:27:00', ''].join('\n')
+
+describe('unit maintenance runs before the up-to-date early exit', () => {
+  it('the maintenance call precedes the early exit in file order', () => {
+    const call = lineOf(UPDATE, /^run_unit_maintenance$/)
+    const upToDateBranch = lineOf(UPDATE, /OLD_VERSION" = "\$NEW_VERSION/)
+    expect(call).toBeLessThan(upToDateBranch)
+  })
+
+  it('no unit repair is left below the early exit', () => {
+    const upToDateIdx = UPDATE.indexOf('if [ "$OLD_VERSION" = "$NEW_VERSION" ]')
+    const below = UPDATE.slice(upToDateIdx)
+    // definitions and calls must all be above; below there may only be the
+    // breadcrumb comment that says so.
+    expect(below).not.toMatch(/^migrate_channels_restart\b/m)
+    expect(below).not.toMatch(/^repair_morning_timer\b/m)
+    expect(below).not.toMatch(/^\s*sed -i\.marveen-bak .*-morning\.service/m)
+  })
+
+  it('both repairs are wired into the single maintenance entry point', () => {
+    const wrapper = sliceShellFn(UPDATE, 'run_unit_maintenance')
+    expect(wrapper).toMatch(/repair_morning_timer "\$@"/)
+    expect(wrapper).toMatch(/migrate_channels_restart "\$@"/)
+    expect(UPDATE).toMatch(/^run_unit_maintenance$/m)
+  })
+})
+
+describe('the maintenance itself, executed for real', () => {
+  const body = [
+    sliceShellFn(UPDATE, 'repair_morning_timer'),
+    sliceShellFn(UPDATE, 'migrate_channels_restart'),
+    sliceShellFn(UPDATE, 'run_unit_maintenance'),
+  ].join('\n')
+
+  function run(dir: string) {
+    return runScript(`${body}\nrun_unit_maintenance "${dir}"`)
+  }
+
+  it('repairs BOTH unit kinds in one pass', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'units-'))
+    try {
+      writeFileSync(join(dir, 'marveen-channels.service'), OLD_CHANNELS_UNIT)
+      writeFileSync(join(dir, 'marveen-morning.timer'), OLD_MORNING_TIMER)
+      const r = run(dir)
+      expect(r.code).toBe(0)
+      expect(readFileSync(join(dir, 'marveen-channels.service'), 'utf-8')).toMatch(/^Restart=always$/m)
+      expect(readFileSync(join(dir, 'marveen-morning.timer'), 'utf-8')).not.toMatch(/^Requires=/m)
+      // the rest of the timer must survive
+      expect(readFileSync(join(dir, 'marveen-morning.timer'), 'utf-8')).toContain('OnCalendar=*-*-* 07:27:00')
+      expect(readdirSync(dir).filter((f) => f.includes('marveen-bak'))).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('is idempotent: the second pass changes nothing and says nothing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'units-'))
+    try {
+      writeFileSync(join(dir, 'marveen-channels.service'), OLD_CHANNELS_UNIT)
+      writeFileSync(join(dir, 'marveen-morning.timer'), OLD_MORNING_TIMER)
+      run(dir)
+      const after1 = [
+        readFileSync(join(dir, 'marveen-channels.service'), 'utf-8'),
+        readFileSync(join(dir, 'marveen-morning.timer'), 'utf-8'),
+      ]
+      const second = run(dir)
+      expect(second.code).toBe(0)
+      expect(second.out).not.toContain('javitva')
+      expect(readFileSync(join(dir, 'marveen-channels.service'), 'utf-8')).toBe(after1[0])
+      expect(readFileSync(join(dir, 'marveen-morning.timer'), 'utf-8')).toBe(after1[1])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('survives a machine with no unit directory at all (macOS)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'units-'))
+    try {
+      expect(run(join(dir, 'nope')).code).toBe(0)
+      expect(run(dir).code).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/update.sh
+++ b/update.sh
@@ -331,6 +331,87 @@ NEW_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 NEW_VERSION_FULL=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILT_COMMIT_FILE="$INSTALL_DIR/dist/.built-commit"
 
+# ─────────────────────────────────────────────────────────────────────────────
+# UNIT MAINTENANCE -- and its position in this file is the fix, not a detail.
+#
+# These repairs used to live ~150 lines further down, BEHIND the "already on the
+# latest commit" `exit 0` below. That made them unreachable exactly when they
+# were needed: an update that has nothing to pull returns before them, and the
+# update that DOES pull them is still running the OLD copy of this script (bash
+# reads a script incrementally and there is no re-exec), so it runs the old code
+# that does not contain them either. Measured on a live host on 2026-08-04: a
+# machine went 1.28.2 -> 1.29.0 and its channels unit still carried the old
+# Restart=on-failure; re-running update.sh did not help, because the second run
+# exited at the up-to-date branch. The repair would first have run one whole
+# release later.
+#
+# THE BUG CLASS, so the next person does not re-create it: unit maintenance must
+# NOT be placed after the up-to-date early exit. Anything that repairs on-disk
+# state of an ALREADY INSTALLED machine belongs here, above that exit -- the
+# repairs are idempotent and cost a directory scan. The morning-timer repair had
+# the same defect for weeks before the channels migration joined it.
+#
+# What this placement does NOT solve: the run that pulls a NEW repair still
+# cannot execute it (no re-exec). It lands on the next update.sh run of any kind
+# -- including a "nothing to pull" one, which is the common case via the
+# dashboard button and the seeded auto-update task.
+
+# Morning-timer unit repair (Linux only). Earlier installers wrote
+# Requires=<unit>.service into the timer's [Unit] section, which makes every
+# activation of the timer unit (each systemd user-manager start, not just the
+# 07:27 elapse) start the briefing service immediately -- restart churn then
+# multiplies the morning briefing (customer report 2026-07-26: 5 deliveries in
+# one day). Idempotent: strips the line wherever it is still present.
+repair_morning_timer() {
+  units_dir="${1:-$HOME/.config/systemd/user}"
+  [ -d "$units_dir" ] || return 0
+  for morn_timer in "$units_dir/"*-morning.timer; do
+    [ -f "$morn_timer" ] || continue
+    if grep -q '^Requires=.*-morning\.service' "$morn_timer"; then
+      sed -i.marveen-bak '/^Requires=.*-morning\.service/d' "$morn_timer" && rm -f "${morn_timer}.marveen-bak"
+      systemctl --user daemon-reload 2>/dev/null || true
+      echo -e "  Reggeli-napindito timer javitva (Requires= a [Unit]-bol eltavolitva): $(basename "$morn_timer")"
+    fi
+  done
+  return 0
+}
+
+# Channels-unit restart-policy migration (Linux only). The installer template is
+# the only place that writes the unit file, and update.sh does NOT re-run the
+# installer -- so a fix to the template reaches new installs only. Every machine
+# installed before that change keeps Restart=on-failure, under which channels.sh
+# exiting zero from its own watchdog leaves the unit inactive/dead forever (seen
+# live 2026-08-04). This migration is what actually lands the fix on those hosts.
+# Idempotent: it only touches units that still carry the old value.
+migrate_channels_restart() {
+  units_dir="${1:-$HOME/.config/systemd/user}"
+  [ -d "$units_dir" ] || return 0
+  _patched=0
+  for chan_unit in "$units_dir/"*-channels.service; do
+    [ -f "$chan_unit" ] || continue
+    if grep -q '^Restart=on-failure[[:space:]]*$' "$chan_unit"; then
+      if sed -i.marveen-bak 's/^Restart=on-failure[[:space:]]*$/Restart=always/' "$chan_unit" 2>/dev/null; then
+        rm -f "${chan_unit}.marveen-bak"
+        _patched=1
+        echo -e "  Csatorna-unit javitva (Restart=on-failure -> always): $(basename "$chan_unit")"
+      else
+        echo -e "  FIGYELEM: a csatorna-unit nem volt irhato: $chan_unit"
+      fi
+    fi
+  done
+  if [ "$_patched" = "1" ]; then
+    systemctl --user daemon-reload 2>/dev/null || true
+  fi
+  return 0
+}
+
+run_unit_maintenance() {
+  repair_morning_timer "$@"
+  migrate_channels_restart "$@"
+  return 0
+}
+run_unit_maintenance
+
 if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
   # Already on the latest commit -- but "no new commits" does NOT guarantee the
   # compiled dist/ matches the source. A prior update can pull new source and
@@ -472,52 +553,11 @@ if [ -x "$INSTALL_DIR/scripts/sync-hooks.sh" ]; then
   bash "$INSTALL_DIR/scripts/sync-hooks.sh" || echo -e "  FIGYELEM: sync-hooks.sh nem-nulla exit; manualisan ellenorizd."
 fi
 
-# Morning-timer unit repair (Linux only). Earlier installers wrote
-# Requires=<unit>.service into the timer's [Unit] section, which makes every
-# activation of the timer unit (each systemd user-manager start, not just the
-# 07:27 elapse) start the briefing service immediately -- restart churn then
-# multiplies the morning briefing (customer report 2026-07-26: 5 deliveries in
-# one day). Idempotent: strips the line wherever it is still present.
-if [ -d "$HOME/.config/systemd/user" ]; then
-  for morn_timer in "$HOME/.config/systemd/user/"*-morning.timer; do
-    [ -f "$morn_timer" ] || continue
-    if grep -q '^Requires=.*-morning\.service' "$morn_timer"; then
-      sed -i.marveen-bak '/^Requires=.*-morning\.service/d' "$morn_timer" && rm -f "${morn_timer}.marveen-bak"
-      systemctl --user daemon-reload 2>/dev/null || true
-      echo -e "  Reggeli-napindito timer javitva (Requires= a [Unit]-bol eltavolitva): $(basename "$morn_timer")"
-    fi
-  done
-fi
-
-# Channels-unit restart-policy migration (Linux only). The installer template is
-# the only place that writes the unit file, and update.sh does NOT re-run the
-# installer -- so a fix to the template reaches new installs only. Every machine
-# installed before this change keeps Restart=on-failure, under which channels.sh
-# exiting zero from its own watchdog leaves the unit inactive/dead forever (seen
-# live 2026-08-04). This migration is what actually lands the fix on those hosts.
-# Idempotent: it only touches units that still carry the old value.
-migrate_channels_restart() {
-  units_dir="${1:-$HOME/.config/systemd/user}"
-  [ -d "$units_dir" ] || return 0
-  _patched=0
-  for chan_unit in "$units_dir/"*-channels.service; do
-    [ -f "$chan_unit" ] || continue
-    if grep -q '^Restart=on-failure[[:space:]]*$' "$chan_unit"; then
-      if sed -i.marveen-bak 's/^Restart=on-failure[[:space:]]*$/Restart=always/' "$chan_unit" 2>/dev/null; then
-        rm -f "${chan_unit}.marveen-bak"
-        _patched=1
-        echo -e "  Csatorna-unit javitva (Restart=on-failure -> always): $(basename "$chan_unit")"
-      else
-        echo -e "  FIGYELEM: a csatorna-unit nem volt irhato: $chan_unit"
-      fi
-    fi
-  done
-  if [ "$_patched" = "1" ]; then
-    systemctl --user daemon-reload 2>/dev/null || true
-  fi
-  return 0
-}
-migrate_channels_restart
+# Unit maintenance (morning-timer repair + channels restart-policy migration)
+# deliberately does NOT live here any more. It ran from this spot for weeks and
+# was unreachable on an already-current machine, because the up-to-date branch
+# exits ~150 lines above. It now runs before that exit -- see the block above
+# the OLD_VERSION check. Do not move repairs back down here.
 
 # Seed skills & scheduled tasks (idempotent: skip existing)
 # Source .env for template variables needed by seed-scheduled-tasks


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Kapcsolódó issue / Related issue

Nincs issue; élő gépen mért hiba (2026-08-04), a #865 utókövetése. / No issue; measured on a live host on 2026-08-04, follow-up to #865.

## Ellenőrzőlista / Checklist

- [ ] **Nem teljesen:** teljes suite zöld (238 fájl / 3222 teszt), `typecheck` + `syntax-check` tiszta, a karbantartás valódi, élő gépről vett unit-fájlokon is lefuttatva. Amit NEM próbáltam: egy teljes `update.sh` futás élő Linux hoston EZZEL a változtatással (a mérés, ami a hibát megtalálta, a régi kóddal futott). / Full suite, typecheck and syntax-check green and the maintenance was run against real unit files from a live host, but a full update.sh run on a live host with THIS change was not performed.
- [x] `docs/` nem érintett.
- [x] Nincs beleégetett szenzitív adat; a leírásban nincs gépnév, IP vagy token.
- [x] Saját branchről: `fix/unit-maintenance-before-early-exit` -> `develop`.

---

## A hiba

`update.sh` korán kilép, ha nincs mit húzni. **Mindkét unit-javítás ~150 sorral az `exit 0` ALATT volt**, vagyis pont azokon a gépeken volt elérhetetlen, amelyekért létezik.

Élő gépen mérve (2026-08-04), nem kódolvasásból:

| lépés | eredmény |
|---|---|
| gép frissítve 1.28.2 -> 1.29.0 | a channels unit **maradt** `Restart=on-failure` |
| `update.sh` újrafuttatva | *"Már a legfrissebb verzión vagy"* -> kilép a javítások **felett** |

Az ok mérve, nem feltételezve: a futás, amelyik **lehúzza** az új javítást, még a **régi** `update.sh`-t hajtja végre (a bash inkrementálisan olvas, nincs re-exec), tehát a régi kódot futtatja, amiben a javítás nincs benne. A javítás így először **egy teljes kiadással később** futott volna le.

## Ez osztály, nem egyedi eset

A **morning-timer javítás** (2026-07-26-án szállítva, mert egy ügyfél egy nap alatt öt reggeli napindítót kapott) **hetek óta ugyanebben a helyzetben volt**, mielőtt a channels-migráció mellé került. Ezért mozdul mindkettő, és ezért marad morzsa-komment a régi helyen.

## Mi változott

- mindkét javítás függvény lett, felülírható unit-könyvtárral, egy `run_unit_maintenance` belépési pont mögött;
- ez a belépési pont **a fetch után, az up-to-date ág ELŐTT** hívódik. **A korai kilépés maga változatlan** -- csak a karbantartás került elé;
- a régi helyen komment marad arról, hogy oda javítást tenni miért hiba.

## Amit ez NEM old meg

A **pulling** futás továbbra sem tudja végrehajtani a saját frissen lehúzott karbantartását (ahhoz re-exec kellene, az külön változtatás és külön kockázat). A javítás **a következő `update.sh` futáskor** landol -- **beleértve egy "nincs mit húzni" futást is**, ami a dashboard-gomb és a seedelt auto-update task miatt a gyakori eset.

## Tesztek

`src/__tests__/update-unit-maintenance-order.test.ts` (6) + a meglévő channels-migrációs teszt frissítve a mozgatott hívási helyre (13). Teljes suite zöld: **238 fájl / 3222 teszt**, `typecheck` és `syntax-check` tiszta.

A tesztek a szállított kódot futtatják: a karbantartó függvényeket az `update.sh`-ból szeletelik ki és valódi unit-fájlokon futtatják temp könyvtárban (friss gép, átnevezett install, idempotencia, hiányzó könyvtár).

**Mutációs kontroll** -- minden őr a saját hibáját fogja meg, a bukott teszt nevével:

| mutáció | bukó teszt |
|---|---|
| a hívás vissza a korai kilépés alá (a hibaosztály visszatér) | `the maintenance call precedes the early exit in file order` |
| a wrapper nem hívja a morning-timer javítást | `both repairs are wired into the single maintenance entry point` + `repairs BOTH unit kinds in one pass` |
| a wrapper nem hívja a channels-migrációt | ugyanezek + `is actually called by update.sh, not merely defined` |
| a morning-timer `sed`-je üresre állítva | `repairs BOTH unit kinds in one pass` + `is idempotent...` |
| a channels-migráció `sed`-je üresre állítva | a fenti kettő + a három channels-migrációs viselkedési teszt |

**Valódi fájlokon is:** egy élő gépről vett `*-morning.timer` és `*-channels.service` ellen futtatva -- az egészséges timer bájtra változatlan marad, a történeti `Requires=` sorral rontott változat javul, a channels unit migrál, backup-maradvány nincs.

## Nem fedett

- Nincs teljes `update.sh` futás élő hoston ezzel a változtatással; az élő bizonyíték a régi kódról szól, ez a PR a következtetést javítja.
- Az élő mérések egy **többször újrahasznált** teszt-gépen készültek, amely ezért eltérhet egy friss ügyfélgéptől.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
