### PR TITLE
fix(channels): the never-started watchdog restarted forever on a host that cannot recover

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -751,7 +751,49 @@ MAIN_BOT_PID_FILE="$HOME/.claude/channels/$CHANNEL_PROVIDER/bot.pid"
 # Never-started budget: generous so a slow cold-start (WSL first-run, MCP
 # handshake + /mcp unlock retries) is never killed prematurely. The plugin
 # normally writes bot.pid within ~1-2 min; 10 min is a safe ceiling.
-PLUGIN_NEVER_STARTED_DEADLINE=$((START_TS + 600))
+#
+# The budget GROWS across consecutive restarts, and that is the point. On a host
+# where the plugin cannot start at all -- AVX-less box, broken plugin cache,
+# Claude auth deferred at install -- a fixed 10-minute budget becomes a
+# ten-minute restart cycle that never ends. Each restart kill-sessions and
+# recreates the agent's tmux session, so on a machine where Claude itself works
+# and only the plugin is dead, the main agent loses its context every ten
+# minutes. Measured on a live host on 2026-08-04: exit 1 at 08:23:52, systemd
+# restart at 08:24:03, fresh session at 08:24:04, and the same again one budget
+# later. Before the watchdog exited non-zero that host simply kept a working
+# agent with a dead channel -- so an unbounded cycle would be a regression for
+# that population, not an improvement.
+#
+# What is deliberately NOT damped: the signal. The warning still goes to the log
+# and the exit is still non-zero, so the service manager still restarts the unit
+# and OnFailure= still fires. We slow the churn down; we do not silence the
+# symptom. A host that recovers resets the streak, so a healthy machine keeps
+# the original fast watchdog.
+NEVER_STARTED_BASE=600
+NEVER_STARTED_CAP=2400
+NEVER_STARTED_STREAK_FILE="$INSTALL_DIR/store/.channel-neverstart-streak"
+
+# Budget for the Nth consecutive never-started exit: 600 -> 1200 -> 2400, capped.
+never_started_budget() {
+  _streak="${1:-0}"
+  case "$_streak" in ''|*[!0-9]*) _streak=0 ;; esac
+  _budget=$NEVER_STARTED_BASE
+  _i=0
+  while [ "$_i" -lt "$_streak" ]; do
+    _budget=$((_budget * 2))
+    if [ "$_budget" -ge "$NEVER_STARTED_CAP" ]; then
+      _budget=$NEVER_STARTED_CAP
+      break
+    fi
+    _i=$((_i + 1))
+  done
+  echo "$_budget"
+}
+
+NEVER_STARTED_STREAK="$(cat "$NEVER_STARTED_STREAK_FILE" 2>/dev/null | tr -d '[:space:]')"
+case "$NEVER_STARTED_STREAK" in ''|*[!0-9]*) NEVER_STARTED_STREAK=0 ;; esac
+PLUGIN_NEVER_STARTED_BUDGET="$(never_started_budget "$NEVER_STARTED_STREAK")"
+PLUGIN_NEVER_STARTED_DEADLINE=$((START_TS + PLUGIN_NEVER_STARTED_BUDGET))
 # Died-after-up budget: once we have seen the plugin alive, a continuous
 # disappearance this long means it crashed and is not self-recovering.
 PLUGIN_DEAD_GRACE=180
@@ -793,6 +835,13 @@ while $TMUX has-session -t "$SESSION" 2>/dev/null; do
   if [ "$_plugin_alive" = "true" ]; then
     PLUGIN_SEEN_ONCE=true
     PLUGIN_DEAD_SINCE=0
+    # The plugin came up, so this host is not in the never-starting state:
+    # drop the streak so the next cold start gets the fast 10-minute watchdog
+    # again instead of inheriting a 40-minute budget from an old outage.
+    if [ "$NEVER_STARTED_STREAK" != "0" ]; then
+      rm -f "$NEVER_STARTED_STREAK_FILE" 2>/dev/null || true
+      NEVER_STARTED_STREAK=0
+    fi
   elif [ "$PLUGIN_SEEN_ONCE" = "true" ]; then
     # Was up, now gone -- start/continue the dead-grace timer (a transient
     # gap that recovers resets it, so only a sustained death triggers exit).
@@ -808,7 +857,12 @@ while $TMUX has-session -t "$SESSION" 2>/dev/null; do
     # Never came up at all (e.g. a Claude Code build that silently disables
     # --channels). Give it the full cold-start budget, then restart.
     if [ "$NOW" -ge "$PLUGIN_NEVER_STARTED_DEADLINE" ]; then
-      echo "WARN: $CHANNEL_PROVIDER plugin never started within $((PLUGIN_NEVER_STARTED_DEADLINE - START_TS))s -- exiting for service-manager restart" >&2
+      # Persist the streak BEFORE exiting: the next process start reads it and
+      # waits longer. Written first so a kill between the write and the exit
+      # still leaves the counter advanced rather than stuck at the fast budget.
+      _next_streak=$((NEVER_STARTED_STREAK + 1))
+      echo "$_next_streak" > "$NEVER_STARTED_STREAK_FILE" 2>/dev/null || true
+      echo "WARN: $CHANNEL_PROVIDER plugin never started within ${PLUGIN_NEVER_STARTED_BUDGET}s -- exiting for service-manager restart (consecutive: $_next_streak, next budget: $(never_started_budget "$_next_streak")s)" >&2
       RESTART_REQUESTED=1
       break
     fi

--- a/src/__tests__/channels-never-started-backoff.test.ts
+++ b/src/__tests__/channels-never-started-backoff.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -157,5 +157,121 @@ describe('the signal is NOT damped -- only the churn is', () => {
     expect(CHANNELS).toMatch(/^PLUGIN_DEAD_GRACE=180$/m)
     const deadBranch = sliceBetween(CHANNELS, 'plugin dead for', 'break')
     expect(deadBranch).not.toMatch(/NEVER_STARTED/)
+  })
+})
+
+// ── The one assertion that must not be text-level ────────────────────────────
+// The streak WRITE is the silent-failure point of this whole change: if it
+// quietly fails (bad path, unwritable store/, a quoting slip), the streak never
+// grows, the budget stays at 600s, and the backoff does nothing while looking
+// exactly like it works. Every other claim here fails loudly; this one fails
+// mute. So it gets a real run: execute the shipped decision chain and READ THE
+// FILE BACK afterwards -- the temp dir is deliberately kept alive until the
+// assertions are done.
+//
+// The harness supplies only the environment (elapsed time, "is the plugin
+// alive"), never the answer: the branch logic, the arithmetic and the write are
+// all sliced out of scripts/channels.sh unmodified.
+function constantsBlock(): string {
+  return sliceBetween(CHANNELS, 'NEVER_STARTED_BASE=600', 'PLUGIN_NEVER_STARTED_DEADLINE=$((START_TS + PLUGIN_NEVER_STARTED_BUDGET))')
+}
+
+/** The plugin-alive / died-after-up / never-started decision chain, verbatim. */
+function decisionChain(): string {
+  const start = CHANNELS.indexOf('  if [ "$_plugin_alive" = "true" ]; then')
+  if (start < 0) throw new Error('decision chain not found')
+  const end = CHANNELS.indexOf('\ndone', start)
+  if (end < 0) throw new Error('unterminated decision chain')
+  return CHANNELS.slice(start, end)
+}
+
+function runChain(dir: string, opts: { ageSeconds: number; pluginAlive: boolean }): { out: string; code: number } {
+  const body = [
+    'set -u',
+    // the shipped warnings go to stderr; merge the streams so the assertions
+    // can see the real message instead of a re-typed copy of it
+    'exec 2>&1',
+    `INSTALL_DIR="${dir}"`,
+    'mkdir -p "$INSTALL_DIR/store"',
+    'CHANNEL_PROVIDER=telegram',
+    `START_TS=$(( $(date +%s) - ${opts.ageSeconds} ))`,
+    constantsBlock(),
+    'PLUGIN_SEEN_ONCE=false',
+    'PLUGIN_DEAD_SINCE=0',
+    'PLUGIN_DEAD_GRACE=180',
+    'RESTART_REQUESTED=0',
+    'NOW=$(date +%s)',
+    `_plugin_alive=${opts.pluginAlive ? 'true' : 'false'}`,
+    // `break` is meaningful only inside a loop; one iteration keeps the shipped
+    // control flow honest without re-typing it.
+    'for _once in 1; do',
+    decisionChain(),
+    'done',
+    'echo "RESULT restart_requested=$RESTART_REQUESTED budget=$PLUGIN_NEVER_STARTED_BUDGET"',
+  ].join('\n')
+  const p = join(dir, 'chain.sh')
+  writeFileSync(p, body + '\n')
+  try {
+    return { out: execFileSync('bash', [p], { encoding: 'utf-8' }).trim(), code: 0 }
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; status?: number }
+    return { out: `${String(err.stdout ?? '')}${String(err.stderr ?? '')}`.trim(), code: err.status ?? -1 }
+  }
+}
+
+describe('the streak file, executed for real and read back', () => {
+  it('counts up across consecutive never-started exits and clears on recovery', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'streak-'))
+    const streakFile = join(dir, 'store', '.channel-neverstart-streak')
+    try {
+      // 1st exit: no counter yet, budget 600, elapsed 700 -> deadline passed
+      const r1 = runChain(dir, { ageSeconds: 700, pluginAlive: false })
+      expect(r1.code).toBe(0)
+      expect(r1.out).toContain('budget=600')
+      expect(r1.out).toContain('restart_requested=1')
+      expect(r1.out).toMatch(/never started within 600s/)
+      expect(readFileSync(streakFile, 'utf-8').trim()).toBe('1')
+
+      // 2nd exit: counter 1 -> budget 1200, so 700s is NOT enough any more
+      const rShort = runChain(dir, { ageSeconds: 700, pluginAlive: false })
+      expect(rShort.out).toContain('budget=1200')
+      expect(rShort.out).toContain('restart_requested=0')
+      expect(readFileSync(streakFile, 'utf-8').trim()).toBe('1')
+
+      // ... and with 1300s elapsed it fires and the counter reaches 2
+      const r2 = runChain(dir, { ageSeconds: 1300, pluginAlive: false })
+      expect(r2.out).toContain('budget=1200')
+      expect(r2.out).toContain('restart_requested=1')
+      expect(readFileSync(streakFile, 'utf-8').trim()).toBe('2')
+
+      // recovery: the plugin comes up -> the file is gone
+      const r3 = runChain(dir, { ageSeconds: 10, pluginAlive: true })
+      expect(r3.code).toBe(0)
+      expect(existsSync(streakFile)).toBe(false)
+
+      // and after recovery the next cold start is back on the fast budget
+      const r4 = runChain(dir, { ageSeconds: 700, pluginAlive: false })
+      expect(r4.out).toContain('budget=600')
+      expect(readFileSync(streakFile, 'utf-8').trim()).toBe('1')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('an unwritable store/ does not fake success: the counter stays put and the exit still happens', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'streak-ro-'))
+    try {
+      const storeDir = join(dir, 'store')
+      execFileSync('mkdir', ['-p', storeDir])
+      execFileSync('chmod', ['500', storeDir])
+      const r = runChain(dir, { ageSeconds: 700, pluginAlive: false })
+      // the watchdog still asks for the restart -- the signal survives a
+      // failed write, which is the behaviour we want on a broken host
+      expect(r.out).toContain('restart_requested=1')
+      expect(existsSync(join(storeDir, '.channel-neverstart-streak'))).toBe(false)
+    } finally {
+      execFileSync('chmod', ['700', join(dir, 'store')])
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/__tests__/channels-never-started-backoff.test.ts
+++ b/src/__tests__/channels-never-started-backoff.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// A watchdog that cannot be satisfied must not run at full speed forever.
+//
+// On a host where the channel plugin CANNOT start -- AVX-less box, broken
+// plugin cache, Claude auth deferred at install -- the never-started branch
+// fires every 600s, exits non-zero, and the service manager restarts the unit.
+// Each restart kill-sessions and recreates the agent's tmux session, so on a
+// machine where Claude itself works and only the plugin is dead, the main agent
+// loses its context every ten minutes. Measured live on 2026-08-04:
+//   08:23:52 status=1/FAILURE -> 08:24:03 scheduled restart -> 08:24:04 new session
+// Before the watchdog exited non-zero, that same host simply kept a working
+// agent with a dead channel. So an unbounded cycle is a REGRESSION for that
+// population, and the budget has to grow.
+//
+// The line that must not be crossed: we damp the CHURN, never the SIGNAL. The
+// warning still goes to the log and the exit stays non-zero, so systemd still
+// restarts and OnFailure= still fires. These tests pin both halves.
+
+const ROOT = join(__dirname, '..', '..')
+const CHANNELS = readFileSync(join(ROOT, 'scripts', 'channels.sh'), 'utf-8')
+
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+  if (start < 0) throw new Error(`function ${name}() not found`)
+  const end = src.indexOf('\n}', start)
+  if (end < 0) throw new Error(`unterminated ${name}()`)
+  return src.slice(start, end + 2)
+}
+
+/** Slice from a start marker to an end marker searched FROM the start offset. */
+function sliceBetween(src: string, startMarker: string, endMarker: string): string {
+  const start = src.indexOf(startMarker)
+  if (start < 0) throw new Error(`start marker not found: ${startMarker}`)
+  const end = src.indexOf(endMarker, start + startMarker.length)
+  if (end < 0) throw new Error(`end marker not found after start: ${endMarker}`)
+  return src.slice(start, end + endMarker.length)
+}
+
+/** The whole never-started branch: from its own `if` down to its `break`.
+ *  Anchoring on the warning text alone starts the slice INSIDE the echo line and
+ *  silently drops everything above it -- which is how the first version of these
+ *  tests failed on correct code. */
+function neverStartedBranch(): string {
+  return sliceBetween(CHANNELS, 'if [ "$NOW" -ge "$PLUGIN_NEVER_STARTED_DEADLINE" ]; then', 'break')
+}
+
+function runScript(body: string): { out: string; code: number } {
+  const dir = mkdtempSync(join(tmpdir(), 'neverstart-'))
+  try {
+    const p = join(dir, 'probe.sh')
+    writeFileSync(p, body + '\n')
+    try {
+      return { out: execFileSync('bash', [p], { encoding: 'utf-8' }).trim(), code: 0 }
+    } catch (e) {
+      const err = e as { stdout?: string; stderr?: string; status?: number }
+      return { out: `${String(err.stdout ?? '')}${String(err.stderr ?? '')}`.trim(), code: err.status ?? -1 }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+/** Run the SHIPPED budget function for a list of streak values. */
+function budgets(streaks: number[]): number[] {
+  const consts = [
+    CHANNELS.match(/^NEVER_STARTED_BASE=\d+$/m)?.[0],
+    CHANNELS.match(/^NEVER_STARTED_CAP=\d+$/m)?.[0],
+  ]
+  if (consts.some((c) => !c)) throw new Error('budget constants not found in channels.sh')
+  const body = [consts.join('\n'), sliceShellFn(CHANNELS, 'never_started_budget'),
+    streaks.map((s) => `never_started_budget ${s}`).join('\n')].join('\n')
+  const r = runScript(body)
+  expect(r.code).toBe(0)
+  return r.out.split('\n').map((n) => parseInt(n.trim(), 10))
+}
+
+describe('never-started budget backoff', () => {
+  it('starts at the original 10 minutes, so a healthy cold start is unaffected', () => {
+    expect(budgets([0])[0]).toBe(600)
+  })
+
+  it('grows on consecutive failures', () => {
+    const [b0, b1, b2] = budgets([0, 1, 2])
+    expect(b1).toBeGreaterThan(b0)
+    expect(b2).toBeGreaterThan(b1)
+    expect([b0, b1, b2]).toEqual([600, 1200, 2400])
+  })
+
+  it('is capped -- it never grows without bound', () => {
+    const long = budgets([0, 1, 2, 3, 4, 8, 20, 99])
+    const cap = parseInt(CHANNELS.match(/^NEVER_STARTED_CAP=(\d+)$/m)![1], 10)
+    for (const b of long) expect(b).toBeLessThanOrEqual(cap)
+    expect(long[long.length - 1]).toBe(cap)
+    // and monotonic non-decreasing all the way
+    for (let i = 1; i < long.length; i++) expect(long[i]).toBeGreaterThanOrEqual(long[i - 1])
+  })
+
+  it('treats a garbage or missing streak file as zero (no accidental 40-minute start)', () => {
+    expect(budgets([0])[0]).toBe(600)
+    const body = [
+      CHANNELS.match(/^NEVER_STARTED_BASE=\d+$/m)![0],
+      CHANNELS.match(/^NEVER_STARTED_CAP=\d+$/m)![0],
+      sliceShellFn(CHANNELS, 'never_started_budget'),
+      'never_started_budget ""',
+      'never_started_budget "not-a-number"',
+    ].join('\n')
+    const r = runScript(body)
+    expect(r.code).toBe(0)
+    expect(r.out.split('\n').map((n) => parseInt(n, 10))).toEqual([600, 600])
+  })
+})
+
+describe('the streak is persisted and cleared in the right places', () => {
+  it('the never-started exit writes the incremented streak BEFORE exiting', () => {
+    const branch = neverStartedBranch()
+    expect(branch).toMatch(/_next_streak=\$\(\(NEVER_STARTED_STREAK \+ 1\)\)/)
+    // the WRITE is the thing that survives the process exit -- assert the
+    // redirect itself, not just that the value was computed (a first version of
+    // this test only checked the arithmetic and passed with the write deleted).
+    const write = branch.match(/echo "\$_next_streak" > "\$NEVER_STARTED_STREAK_FILE"/)
+    expect(write).not.toBeNull()
+    expect(branch.indexOf(write![0])).toBeGreaterThan(-1)
+    expect(branch.indexOf(write![0])).toBeLessThan(branch.indexOf('RESTART_REQUESTED=1'))
+  })
+
+  it('a plugin that comes up clears the streak, so recovery restores the fast watchdog', () => {
+    const aliveBranch = sliceBetween(CHANNELS, 'if [ "$_plugin_alive" = "true" ]; then', 'elif')
+    expect(aliveBranch).toMatch(/rm -f "\$NEVER_STARTED_STREAK_FILE"/)
+    expect(aliveBranch).toMatch(/NEVER_STARTED_STREAK=0/)
+  })
+
+  it('the streak file lives in store/, next to the other channel state', () => {
+    expect(CHANNELS).toMatch(/NEVER_STARTED_STREAK_FILE="\$INSTALL_DIR\/store\/\.channel-neverstart-streak"/)
+  })
+})
+
+describe('the signal is NOT damped -- only the churn is', () => {
+  it('still warns on every never-started exit', () => {
+    const branch = neverStartedBranch()
+    expect(branch).toMatch(/echo "WARN:/)
+    expect(branch).toMatch(/exiting for service-manager restart/)
+  })
+
+  it('still exits non-zero, so the unit restarts and OnFailure= fires', () => {
+    const branch = neverStartedBranch()
+    expect(branch).toMatch(/RESTART_REQUESTED=1/)
+    // and the tail still turns that flag into a non-zero status
+    expect(CHANNELS).toMatch(/if \[ "\$RESTART_REQUESTED" = "1" \]; then\n\s+exit 1/)
+  })
+
+  it('leaves the died-after-up branch on its unchanged 180s grace (scope pin)', () => {
+    expect(CHANNELS).toMatch(/^PLUGIN_DEAD_GRACE=180$/m)
+    const deadBranch = sliceBetween(CHANNELS, 'plugin dead for', 'break')
+    expect(deadBranch).not.toMatch(/NEVER_STARTED/)
+  })
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Kapcsolódó issue / Related issue

Nincs issue; élő gépen mért viselkedés (2026-08-04), a #865 utókövetése. Párja: #868 (a karbantartás a korai kilépés elé). / No issue; measured live on 2026-08-04, follow-up to #865. Sibling PR: #868.

## Ellenőrzőlista / Checklist

- [ ] **Nem teljesen:** teljes suite zöld (3226 teszt), `typecheck` + `syntax-check` tiszta, a költségvetés-számítás a **szállított** shell-függvény futtatásával mérve. Amit NEM próbáltam: egy több órás élő futás, amely végigmegy a 10 -> 20 -> 40 perces lépcsőn. / Full suite, typecheck and syntax-check green, budgets measured by executing the shipped shell function; a multi-hour live run through the whole ladder was not performed.
- [x] `docs/` nem érintett.
- [x] Nincs beleégetett szenzitív adat.
- [x] Saját branchről: `fix/never-started-backoff` -> `develop`.

---

## Két külön ok, ne mosódjon össze

Ez a PR **nem** a #868 folytatása. A #868 szerkezeti hiba (a karbantartás elérhetetlen helyen volt). Ez itt **viselkedési** hiba: egy olyan újrapróbálkozás, amelyet a gép soha nem tud teljesíteni.

## A hiba

Ahol a plugin **nem tud elindulni** -- AVX-mentes gép, sérült plugin-cache, telepítéskor halasztott Claude-auth -- ott a never-started ág fix 600 másodperc után tüzel, nem-nulla kóddal kilép, a service manager újraindít. Tíz perc múlva ugyanez. Végtelenül: a unit `StartLimitBurst=5/300s` sosem lép be, mert a körök tíz percre vannak egymástól.

Minden ilyen újraindítás **kill-session-öli és újra létrehozza az ágens tmux sessionjét**. Vagyis olyan gépen, ahol a Claude működik és csak a plugin halott, **a fő ágens tízpercenként elveszti a kontextusát**.

Élő gépen mérve (2026-08-04):

```
08:23:52  Main process exited, code=exited, status=1/FAILURE
08:24:03  Scheduled restart job, restart counter is at 1
08:24:04  új tmux session
```

Ez a populáció külön nevet érdemel: **mielőtt** a watchdog nem-nulla kóddal kezdett kilépni, ezek a gépek egy **működő ágenst** tartottak, csak halott csatornával -- a saját soak-boxunk húsz napig pontosan így állt. A "működő ágens, halott csatorna" -> "tízpercenként kinyírt ágens" átmenet nekik **romlás**, nem javulás.

## A javítás

- a költségvetés **nő** minden egymást követő never-started kilépéssel: **10 -> 20 -> 40 perc, 40-nél plafonnal**;
- a számláló a `store/.channel-neverstart-streak` fájlban él, tehát **túléli az újraindítást**;
- **nullázódik, amint a plugin feláll** -> egy felépülő gép visszakapja a gyors watchdogot;
- hiányzó vagy hibás számláló = nulla, tehát friss telepítés **soha nem indul 40 perces költségvetéssel**.

## Amit szándékosan NEM csillapítunk: a jelzést

A figyelmeztetés **minden** kilépéskor kimegy a logba, és a kilépés **továbbra is nem-nulla**, tehát a unit újraindul és az `OnFailure=` is tüzel. A **pergést** fékezzük, nem a tünetet némítjuk el. Ezt két teszt külön rögzíti.

A died-after-up ág (180 mp türelem, olyan pluginra, amely már élt és elszállt) **változatlan**, és ezt is teszt rögzíti -- egy egyszer már működött plugin más helyzet, mint egy sosem elindult.

## Tesztek

`src/__tests__/channels-never-started-backoff.test.ts` (10). A költségvetés-tesztek a **szállított** shell-függvényt futtatják, nem újraimplementálják; a többi a `scripts/channels.sh` valódi ágára horgonyzik. Teljes suite zöld (3226 teszt).

**Mutációs kontroll:**

| mutáció | bukó teszt |
|---|---|
| a költségvetés nem nő | `grows on consecutive failures` + `is capped` |
| a plafon eltávolítva | `is capped -- it never grows without bound` |
| a streak-írás törölve | `the never-started exit writes the incremented streak BEFORE exiting` |
| a felépüléskori nullázás törölve | `a plugin that comes up clears the streak...` |
| a figyelmeztetés elnémítva | `still warns on every never-started exit` |
| a nem-nulla kilépés visszavéve | `still exits non-zero...` + két másik |

**Egy őrt menet közben javítani kellett:** a persistence-teszt első változata **átment** akkor is, amikor a fájlba írást töröltem -- csak az aritmetikát ellenőrizte, a átirányítást nem. A rés bezárva, a kontroll újrafuttatva, most nevesített tesztet buktat.

## Nem fedett

Nincs több órás élő futás, amely végigmegy a teljes 10 -> 20 -> 40 perces lépcsőn; az élő bizonyíték az első lépcsőfokról szól.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
