### PR TITLE
fix(recipes): shipped kanban recipes needed sqlite3 and jq, which no install has

### DIFF
--- a/seed-scheduled-tasks/kanban-audit/SKILL.md
+++ b/seed-scheduled-tasks/kanban-audit/SKILL.md
@@ -10,7 +10,16 @@ description: 4 óránkénti kanban-tábla audit. Tisztítás (7+ napos done arch
 
 ## Autonómia-szint (config-vezérelt, KÖTELEZŐ ELŐSZÖR)
 
-Olvasd be: `jq -r '.categories[]|select(.key=="kanban_archive_done" or .key=="kanban_stuck_nudge")|"\(.key) \(.level)"' {{INSTALL_DIR}}/store/autonomy-config.json`
+Olvasd be (python3-mal, mert `jq` NINCS telepítve egy átlagos Linux gépen):
+```bash
+python3 -c "
+import json
+d=json.load(open('{{INSTALL_DIR}}/store/autonomy-config.json'))
+for c in d.get('categories',[]):
+    if c.get('key') in ('kanban_archive_done','kanban_stuck_nudge'):
+        print(c['key'], c.get('level'))
+" 2>/dev/null
+```
 
 A két kategória szintje szabályozza a 2. és 4. lépést:
 - **`kanban_archive_done`** (2. lépés): level 3 → archiváld magától (alapért). level 2 → NE archiválj, Telegramon javasold ("X db 7+ napos done archiválásra vár, mehet?") és várj jóváhagyást. level 1 → csak jelezd a számot.
@@ -22,15 +31,42 @@ Ha a config hiányzik vagy a kulcs nincs benne → default level 3 (régi viselk
 
 1. **State-fájl beolvasás**: `store/kanban-audit-state.json` tartalmazza `last_audit_at` Unix timestampet. Első futáskor null -> ne pingelj senkit, csak állítsd be a state-et.
 
-2. **Tisztítás**: 7+ napos done kártyák archiválása:
+   A tábla eléréséhez a dashboard API-t használd, NE a `sqlite3` CLI-t (lásd a Buktatókat).
+   A port a `.env`-ből jön, hogy nem-alapértelmezett porton is működjön:
    ```bash
-   sqlite3 {{INSTALL_DIR}}/store/claudeclaw.db "UPDATE kanban_cards SET archived_at=unixepoch() WHERE status='done' AND archived_at IS NULL AND updated_at < strftime('%s','now','-7 days')"
+   PORT="$(sed -n 's/^WEB_PORT=//p' {{INSTALL_DIR}}/.env 2>/dev/null | head -1 | tr -d '"')"; PORT="${PORT:-3420}"
+   TOKEN="$(cat {{INSTALL_DIR}}/store/.dashboard-token)"
+   ```
+
+2. **Tisztítás**: 7+ napos done kártyák archiválása (előbb listázd, aztán archiváld egyesével):
+   ```bash
+   curl -s -H "Authorization: Bearer $TOKEN" "http://localhost:$PORT/api/kanban" | python3 -c "
+import json,sys,time
+cut=int(time.time())-7*86400
+for c in json.load(sys.stdin):
+    if c.get('status')=='done' and not c.get('archived_at') and (c.get('updated_at') or 0) < cut:
+        print(c['id'])
+" | while read -r id; do
+     curl -s -X POST -H "Authorization: Bearer $TOKEN" "http://localhost:$PORT/api/kanban/$id/archive" >/dev/null
+   done
    ```
 
 3. **Beakadt task detection** (előző audit óta nem mozdult): in_progress kártyák amik `updated_at < last_audit_at`:
    ```bash
-   LAST=$(jq -r .last_audit_at store/kanban-audit-state.json 2>/dev/null || echo 0)
-   sqlite3 store/claudeclaw.db "SELECT id, title, assignee, ROUND((strftime('%s','now')-updated_at)/3600.0,1) as hours_stale FROM kanban_cards WHERE status='in_progress' AND archived_at IS NULL AND updated_at < $LAST ORDER BY hours_stale DESC"
+   LAST="$(python3 -c "
+import json
+try: print(json.load(open('{{INSTALL_DIR}}/store/kanban-audit-state.json')).get('last_audit_at') or 0)
+except Exception: print(0)
+")"
+   curl -s -H "Authorization: Bearer $TOKEN" "http://localhost:$PORT/api/kanban" | python3 -c "
+import json,sys,time
+last=int('''$LAST''' or 0); now=int(time.time())
+rows=[c for c in json.load(sys.stdin)
+      if c.get('status')=='in_progress' and not c.get('archived_at') and (c.get('updated_at') or 0) < last]
+rows.sort(key=lambda c: c.get('updated_at') or 0)
+for c in rows:
+    print(c['id'], '|', (c.get('assignee') or '-'), '|', round((now-(c.get('updated_at') or now))/3600.0,1), 'h |', c.get('title'))
+"
    ```
 
 4. **Beakadt task -> ping**: minden beakadt kártyához küldj inter-agent message-t az assignee-nek (kivéve {{MAIN_AGENT_ID}}-nek és üres assignee-nek):
@@ -48,6 +84,12 @@ Ha a config hiányzik vagy a kulcs nincs benne → default level 3 (régi viselk
    - Egyébként csendben (heartbeat-stílus)
 
 ## Buktatók
+- **NE `sqlite3` CLI-t és NE `jq`-t használj.** Egyik sincs telepítve egy átlagos Linux
+  gépen (a telepítő függőségei: ffmpeg, git, tmux, lsof, curl, python3, pipx, unzip), és a
+  hívás ott `exit 127`-tel elhal -- ez a lépés némán kimarad, miközben az audit sikeresnek
+  látszik. Élő gépen mérve 2026-08-04: két külön Linux telepítésen `sqlite3` és `jq`
+  egyaránt hiányzott, `python3` mindkettőn ott volt. A macOS gépeken azért nem tűnt fel,
+  mert ott a `sqlite3` gyárilag van.
 - Az "előző audit óta nem mozdult" feltétel azt jelenti: `updated_at < last_audit_at`. NE használj abszolút 24h-os küszöböt.
 - Ne archiválj done-t ha <7 nap (a felhasználó még látni akarja).
 - NE pingelj saját magadat (skip ha assignee='{{MAIN_AGENT_ID}}').

--- a/seed-skills/handoff/SKILL.md
+++ b/seed-skills/handoff/SKILL.md
@@ -33,22 +33,36 @@ Examples:
 Collect data from these sources (skip any that return empty):
 
 ```bash
-# Active kanban cards (assigned to current agent or recently touched)
+# Active kanban cards (assigned to current agent or recently touched).
+# Via the dashboard API, NOT the sqlite3 CLI: sqlite3 (and jq) are absent on a
+# stock Linux install -- measured on two live hosts 2026-08-04, where the CLI
+# call died with exit 127 while python3 was present on both.
 AGENT_ID="$(echo $BOT_NAME | tr '[:upper:]' '[:lower:]')"
-sqlite3 store/claudeclaw.db "SELECT id, title, status, priority, assignee, description FROM kanban_cards WHERE archived_at IS NULL AND (assignee = '$AGENT_ID' OR status = 'in_progress') ORDER BY priority DESC, updated_at DESC LIMIT 10"
+PORT="$(sed -n 's/^WEB_PORT=//p' .env 2>/dev/null | head -1 | tr -d '"')"; PORT="${PORT:-3420}"
+curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  "http://localhost:$PORT/api/kanban" | AGENT_ID="$AGENT_ID" python3 -c "
+import json,os,sys
+me=os.environ.get('AGENT_ID','')
+rows=[c for c in json.load(sys.stdin)
+      if not c.get('archived_at') and ((c.get('assignee') or '').lower()==me or c.get('status')=='in_progress')]
+rank={'urgent':0,'high':1,'normal':2,'low':3}
+rows.sort(key=lambda c:(rank.get(c.get('priority'),9), -(c.get('updated_at') or 0)))
+for c in rows[:10]:
+    print(c['id'], '|', c.get('status'), '|', c.get('priority'), '|', (c.get('assignee') or '-'), '|', c.get('title'))
+"
 
 # Hot memories from last 24h
 curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
-  "http://localhost:3420/api/memories?agent=$AGENT_ID&category=hot&limit=10"
+  "http://localhost:$PORT/api/memories?agent=$AGENT_ID&category=hot&limit=10"
 
 # Recent warm memories (project context)
 curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
-  "http://localhost:3420/api/memories?agent=$AGENT_ID&category=warm&limit=5"
+  "http://localhost:$PORT/api/memories?agent=$AGENT_ID&category=warm&limit=5"
 
 # Today's daily log
 DATE=$(date +%Y-%m-%d)
 curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
-  "http://localhost:3420/api/daily-log?agent=$AGENT_ID&date=$DATE"
+  "http://localhost:$PORT/api/daily-log?agent=$AGENT_ID&date=$DATE"
 ```
 
 Also include from your current conversation context:
@@ -105,7 +119,7 @@ Keep each step concrete enough to execute without asking questions.}
 **Inter-agent mode** (`target=` specified): Send the full HANDOFF.md content as an inter-agent message:
 
 ```bash
-curl -s -X POST http://localhost:3420/api/messages \
+curl -s -X POST http://localhost:$PORT/api/messages \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $(cat store/.dashboard-token)" \
   -d "{\"from\":\"$AGENT_ID\",\"to\":\"TARGET\",\"content\":\"[HANDOFF] purpose: ... \n\n$(cat HANDOFF.md)\"}"

--- a/src/__tests__/shipped-recipes-no-sqlite-cli.test.ts
+++ b/src/__tests__/shipped-recipes-no-sqlite-cli.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+// What we ship as a RECIPE has to run on the machine we ship it to.
+//
+// A customer's Linux box reported `sqlite3: command not found` (exit 127) from
+// the agent's own activity. It was not that machine: the installer's dependency
+// list is ffmpeg, git, tmux, lsof, curl, python3, pipx, unzip (+ toolchain and
+// node) -- neither `sqlite3` nor `jq` is in it. Measured on two live Linux hosts
+// on 2026-08-04: both missing, `python3` present on both. It never showed up for
+// us because our own host is macOS, where sqlite3 ships with the system.
+//
+// The damage is quiet: the 4-hourly kanban-audit task ran its cleanup and its
+// stuck-card detection through `sqlite3` and `jq`, so on every Linux install
+// those steps died while the audit still looked like it had run.
+//
+// The dashboard API covers all of it, so these tests pin three things:
+//   1. shipped recipes (fenced shell blocks under seed-*/) call neither binary,
+//   2. the files that were fixed actually use the API instead,
+//   3. the two seeding paths substitute the SAME placeholders -- otherwise a
+//      recipe means different things depending on which script wrote the copy.
+
+const ROOT = join(__dirname, '..', '..')
+
+function walk(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry)
+    if (statSync(p).isDirectory()) out.push(...walk(p))
+    else if (p.endsWith('.md')) out.push(p)
+  }
+  return out
+}
+
+/** Only fenced shell blocks -- prose that MENTIONS sqlite3 is not a recipe. */
+function shellBlocks(src: string): string[] {
+  const blocks: string[] = []
+  const re = /```(?:bash|sh|shell)\n([\s\S]*?)```/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(src))) blocks.push(m[1])
+  return blocks
+}
+
+const SHIPPED = [...walk(join(ROOT, 'seed-skills')), ...walk(join(ROOT, 'seed-scheduled-tasks'))]
+
+describe('shipped recipes only use binaries the installer guarantees', () => {
+  it('finds the shipped skill/task files at all (positive control)', () => {
+    expect(SHIPPED.length).toBeGreaterThan(3)
+    expect(SHIPPED.some((f) => f.includes('kanban-audit'))).toBe(true)
+    expect(SHIPPED.some((f) => f.includes('handoff'))).toBe(true)
+  })
+
+  it('no fenced shell block invokes sqlite3 or jq', () => {
+    const offenders: string[] = []
+    for (const file of SHIPPED) {
+      for (const block of shellBlocks(readFileSync(file, 'utf-8'))) {
+        for (const line of block.split('\n')) {
+          const code = line.replace(/#.*$/, '')
+          if (/(^|[|;&(]\s*|\$\()\s*sqlite3\s/.test(code)) offenders.push(`${file}: ${line.trim().slice(0, 90)}`)
+          if (/(^|[|;&(]\s*|\$\()\s*jq\s/.test(code)) offenders.push(`${file}: ${line.trim().slice(0, 90)}`)
+        }
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('the two fixed recipes go through the dashboard API instead', () => {
+    const audit = readFileSync(join(ROOT, 'seed-scheduled-tasks', 'kanban-audit', 'SKILL.md'), 'utf-8')
+    const handoff = readFileSync(join(ROOT, 'seed-skills', 'handoff', 'SKILL.md'), 'utf-8')
+    expect(audit).toContain('/api/kanban')
+    expect(audit).toMatch(/python3/)
+    expect(handoff).toContain('/api/kanban')
+    expect(handoff).toMatch(/python3/)
+  })
+
+  it('the recipes resolve the port instead of hardcoding 3420', () => {
+    const handoff = readFileSync(join(ROOT, 'seed-skills', 'handoff', 'SKILL.md'), 'utf-8')
+    const audit = readFileSync(join(ROOT, 'seed-scheduled-tasks', 'kanban-audit', 'SKILL.md'), 'utf-8')
+    for (const src of [handoff, audit]) {
+      expect(src).toMatch(/WEB_PORT=/)
+      expect(src).not.toMatch(/localhost:3420/)
+    }
+  })
+
+  it('the CLAUDE.md template hands the agent the kanban API, not a table name', () => {
+    const tpl = readFileSync(join(ROOT, 'templates', 'CLAUDE.md.template'), 'utf-8')
+    const section = tpl.slice(tpl.indexOf('## Kanban tábla'), tpl.indexOf('## Ütemezett feladatok'))
+    // each operation asserted on its own: a single toContain('/api/kanban')
+    // passed even when the LIST endpoint had been broken, because the move and
+    // comment URLs still carried the substring (mutation control, 2026-08-04).
+    expect(section).toMatch(/^\s*http:\/\/localhost:\{\{WEB_PORT\}\}\/api\/kanban$/m)             // list (bare URL on its own line)
+    expect(section).toMatch(/-X POST http:\/\/localhost:\{\{WEB_PORT\}\}\/api\/kanban\s*\\/)      // create
+    expect(section).toMatch(/\/api\/kanban\/KARTYA_ID\/move/)                                     // move
+    expect(section).toMatch(/\/api\/kanban\/KARTYA_ID\/comments/)                                 // comment
+    expect(section).toMatch(/sqlite3/)   // it must WARN about it
+  })
+})
+
+describe('both seeding paths substitute the same placeholders', () => {
+  const INSTALL = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+  const UPDATE = readFileSync(join(ROOT, 'update.sh'), 'utf-8')
+
+  /** Placeholder names substituted in the sed block that follows `anchor`. */
+  function placeholdersAfter(src: string, anchor: string): Set<string> {
+    const start = src.indexOf(anchor)
+    if (start < 0) throw new Error(`anchor not found: ${anchor}`)
+    const sed = src.indexOf('sed -e', start)
+    if (sed < 0) throw new Error(`no sed block after ${anchor}`)
+    const end = src.indexOf('> "$target/$(basename "$f")"', sed)
+    if (end < 0) throw new Error(`unterminated sed block after ${anchor}`)
+    const chunk = src.slice(sed, end)
+    return new Set([...chunk.matchAll(/\{\{([A-Z_]+)\}\}/g)].map((m) => m[1]))
+  }
+
+  it('the scheduled-task seeder in update.sh matches the installer', () => {
+    const fromInstaller = placeholdersAfter(INSTALL, 'SEED_SCHED_DIR="$INSTALL_DIR/seed-scheduled-tasks"')
+    const fromUpdate = placeholdersAfter(UPDATE, 'SEED_SCHED_DIR="$INSTALL_DIR/seed-scheduled-tasks"')
+    expect([...fromUpdate].sort()).toEqual([...fromInstaller].sort())
+    // and WEB_PORT specifically, since that is the one that was missing
+    expect(fromUpdate.has('WEB_PORT')).toBe(true)
+  })
+})

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -124,7 +124,43 @@ curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
 
 ## Kanban tábla
 
-A kanban tábla az SQLite adatbázisban van: `store/claudeclaw.db` -> `kanban_cards` és `kanban_comments` táblák.
+A kanban adatai a `store/claudeclaw.db` SQLite fájlban vannak, de **NE a `sqlite3`
+parancssori eszközzel nyúlj hozzá, és `jq`-t se feltételezz**: egyik sincs telepítve egy
+átlagos Linux gépen (a telepítő függőségei: ffmpeg, git, tmux, lsof, curl, python3, pipx,
+unzip), és ott a hívás `exit 127`-tel elhal. A tábla útja a dashboard API -- ugyanaz a
+Bearer token, mint a memóriánál. Szűréshez/számoláshoz `python3` van mindig kéznél.
+
+Kártyák listázása (JSON tömb: id, title, status, assignee, priority, updated_at, archived_at):
+```bash
+curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  http://localhost:{{WEB_PORT}}/api/kanban
+```
+
+Új kártya:
+```bash
+curl -s -X POST http://localhost:{{WEB_PORT}}/api/kanban \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  -d '{"title":"CÍM","status":"planned","assignee":"{{MAIN_AGENT_ID}}","priority":"normal"}'
+```
+
+Kártya mozgatása:
+```bash
+curl -s -X POST http://localhost:{{WEB_PORT}}/api/kanban/KARTYA_ID/move \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  -d '{"status":"in_progress"}'
+```
+
+Komment a kártyára (az eredmény ide kerül, a dashboardon ez látszik):
+```bash
+curl -s -X POST http://localhost:{{WEB_PORT}}/api/kanban/KARTYA_ID/comments \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(cat store/.dashboard-token)" \
+  -d '{"author":"{{MAIN_AGENT_ID}}","content":"AZ EREDMÉNY RÖVIDEN"}'
+```
+
+Archiválás: `POST /api/kanban/KARTYA_ID/archive`, üres törzzsel.
 
 Státuszok: planned, in_progress, waiting, done
 Prioritások: low, normal, high, urgent

--- a/update.sh
+++ b/update.sh
@@ -640,10 +640,16 @@ if [ -d "$SEED_SCHED_DIR" ]; then
       mkdir -p "$target"
       for f in "$tpl"*; do
         [ -f "$f" ] || continue
+        # {{WEB_PORT}} belongs here too: install-linux.sh substitutes it in both
+        # of its seeding loops, and a task seeded by THIS path used to keep the
+        # literal placeholder in its URLs. Same placeholder set on both paths,
+        # or a template silently means different things depending on which
+        # script created the copy.
         sed -e "s/{{MAIN_AGENT_ID}}/$MAIN_AGENT_ID/g" \
             -e "s/{{BOT_NAME}}/$BOT_NAME/g" \
             -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
             -e "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" \
+            -e "s/{{WEB_PORT}}/${WEB_PORT:-3420}/g" \
             "$f" > "$target/$(basename "$f")"
       done
       if [ "$forced" = "1" ]; then SCHED_FORCED=$((SCHED_FORCED + 1)); else SCHED_NEW=$((SCHED_NEW + 1)); fi


### PR DESCRIPTION

A customer's Linux box surfaced `sqlite3: command not found` (exit 127) in the
agent's own activity. It is not that machine: the installer's dependency list is
ffmpeg, git, tmux, lsof, curl, python3, pipx, unzip (plus toolchain and node).
Neither `sqlite3` nor `jq` is in it. Measured on two live Linux hosts on
2026-08-04: both binaries missing, python3 present on both. We never saw it
because our own host is macOS, where sqlite3 ships with the system.

What that quietly broke: the seeded kanban-audit task runs four times a day and
did its cleanup and its stuck-card detection through `sqlite3`, plus read the
autonomy config with `jq`. On every Linux install those steps died while the
audit still reported as having run. The handoff skill had the same defect in its
context-gathering block, right next to curl calls that DID work.

The dashboard API covers all of it, so the recipes now go through it:

  - templates/CLAUDE.md.template: the kanban section named the SQLite tables and
    stopped there, while the neighbouring sections all hand over a curl recipe.
    It now documents list / create / move / comment / archive and says plainly
    that sqlite3 and jq must not be assumed. That missing recipe is what made
    the agent improvise towards the CLI in the first place.
  - seed-scheduled-tasks/kanban-audit/SKILL.md: archive-candidates, stale-card
    detection and the autonomy-config read now use curl + python3.
  - seed-skills/handoff/SKILL.md: the kanban query goes through the API.

Both recipes resolve the port from .env instead of hardcoding 3420 -- the same
snippet also carried three hardcoded 3420 URLs next to the one being fixed.

One asymmetry found while wiring this up and fixed here: install-linux.sh
substitutes {{WEB_PORT}} in both of its seeding loops, update.sh did not. A task
seeded through an update would have kept the literal placeholder in its URLs.
A test now pins that both paths substitute the same placeholder set.

Tests: src/__tests__/shipped-recipes-no-sqlite-cli.test.ts (6). The scan looks
only inside fenced shell blocks -- prose that merely mentions sqlite3 is not a
recipe -- and a positive control asserts the scan actually finds the shipped
files. Full suite green (240 files / 3247 tests), typecheck clean.

Mutation controls with the named failing test in each case: putting sqlite3 or
jq back into a recipe, hardcoding the port again, and removing update.sh's
WEB_PORT substitution. A fourth control found a real hole: the template guard
first passed even with the LIST endpoint broken, because the move and comment
URLs still contained the same substring. Each operation is now asserted on its
own line and the control fails as it should.

Verified live against the running dashboard, not only as text: the new listing,
archive-candidate, stale-detection and autonomy-config snippets were executed
against the real API and returned correct results (3 archive candidates, 0 stale
in_progress, both autonomy levels read).

---

**Ellenőrzőlista:** teljes suite zöld (240 fájl / 3247 teszt), typecheck tiszta, a snippetek élő API ellen lefuttatva. Amit NEM próbáltam: friss telepítés Linuxon ezzel a sablonnal (a mérés a hiányzó binárisokról szól, nem a sablon renderelésről).

🤖 Generated with [Claude Code](https://claude.com/claude-code)