### PR TITLE
feat(update): refresh a shipped skill/task only while it is provably untouched

### DIFF
--- a/src/__tests__/seed-refresh-untouched-only.test.ts
+++ b/src/__tests__/seed-refresh-untouched-only.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Refreshing a shipped file on an existing machine is a WRITE into someone
+// else's install, so the rule that makes it acceptable has to hold under test.
+//
+// Why the refresh exists: seeding is skip-if-exists, so a fix to a file we ship
+// reaches new installs only. That is how the kanban-audit task kept calling
+// sqlite3/jq -- absent on a stock Linux box -- four times a day on every
+// existing machine, with two of its steps dying silently.
+//
+// The rule: refresh ONLY a copy that is byte-identical to SOME version we
+// shipped (any point in that path's history, not just the newest), because then
+// the operator provably never edited it. The direction that matters most is the
+// NEGATIVE one: a locally modified file must survive untouched. Its failure
+// would be silent -- the operator's edit would simply be gone -- so it gets the
+// most explicit assertions here.
+
+const ROOT = join(__dirname, '..', '..')
+const UPDATE = readFileSync(join(ROOT, 'update.sh'), 'utf-8')
+
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+  if (start < 0) throw new Error(`function ${name}() not found`)
+  const end = src.indexOf('\n}', start)
+  if (end < 0) throw new Error(`unterminated ${name}()`)
+  return src.slice(start, end + 2)
+}
+
+const FUNCS = ['render_seed_template', 'seed_copy_is_untouched', 'refresh_untouched_seeds', 'run_seed_refresh']
+  .map((n) => sliceShellFn(UPDATE, n))
+  .join('\n')
+
+function git(dir: string, args: string[]): void {
+  execFileSync('git', ['-C', dir, ...args], { stdio: 'pipe' })
+}
+
+/** A throwaway install: a git repo with a seed history, plus a ~/.claude tree. */
+function makeFixture() {
+  const base = mkdtempSync(join(tmpdir(), 'seedrefresh-'))
+  const install = join(base, 'install')
+  const home = join(base, 'home')
+  mkdirSync(join(install, 'seed-skills', 'demo'), { recursive: true })
+  mkdirSync(join(install, 'seed-scheduled-tasks', 'demo-task'), { recursive: true })
+  mkdirSync(join(home, '.claude', 'skills'), { recursive: true })
+  mkdirSync(join(home, '.claude', 'scheduled-tasks'), { recursive: true })
+  writeFileSync(join(install, '.env'), 'MAIN_AGENT_ID=marveen\nBOT_NAME=Marveen\nOWNER_NAME=Szabolcs\nWEB_PORT=3420\n')
+
+  git(install, ['init', '-q'])
+  git(install, ['config', 'user.email', 'test@example.invalid'])
+  git(install, ['config', 'user.name', 'test'])
+
+  const skill = join(install, 'seed-skills', 'demo', 'SKILL.md')
+  const task = join(install, 'seed-scheduled-tasks', 'demo-task', 'SKILL.md')
+  const versions = ['v1 shipped\n', 'v2 shipped\n', 'v3 shipped (current)\n']
+  const taskVersions = ['task v1 {{MAIN_AGENT_ID}}\n', 'task v2 {{MAIN_AGENT_ID}}\n', 'task v3 {{MAIN_AGENT_ID}}\n']
+  for (let i = 0; i < versions.length; i++) {
+    writeFileSync(skill, versions[i])
+    writeFileSync(task, taskVersions[i])
+    git(install, ['add', 'seed-skills/demo/SKILL.md', 'seed-scheduled-tasks/demo-task/SKILL.md'])
+    git(install, ['commit', '-q', '-m', `v${i + 1}`])
+  }
+  return { base, install, home, versions, taskVersions }
+}
+
+function runRefresh(install: string, home: string): { out: string; code: number } {
+  const script = join(install, 'probe.sh')
+  writeFileSync(script, [
+    'set -u',
+    'GREEN=""; NC=""',
+    `INSTALL_DIR="${install}"`,
+    `HOME="${home}"`,
+    'MAIN_AGENT_ID=""; BOT_NAME=""; OWNER_NAME=""; WEB_PORT=""',
+    FUNCS,
+    'run_seed_refresh',
+  ].join('\n') + '\n')
+  try {
+    return { out: execFileSync('bash', [script], { encoding: 'utf-8' }).trim(), code: 0 }
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; status?: number }
+    return { out: `${String(err.stdout ?? '')}${String(err.stderr ?? '')}`.trim(), code: err.status ?? -1 }
+  }
+}
+
+describe('seed refresh touches only provably untouched copies', () => {
+  it('refreshes a copy that matches the CURRENT shipped version', () => {
+    const f = makeFixture()
+    try {
+      const dir = join(f.home, '.claude', 'skills', 'demo')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'SKILL.md'), f.versions[2])
+      expect(runRefresh(f.install, f.home).code).toBe(0)
+      expect(readFileSync(join(dir, 'SKILL.md'), 'utf-8')).toBe(f.versions[2])
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('refreshes a copy that matches an OLDER shipped version (two releases behind)', () => {
+    const f = makeFixture()
+    try {
+      const dir = join(f.home, '.claude', 'skills', 'demo')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'SKILL.md'), f.versions[0])   // untouched, but ancient
+      const r = runRefresh(f.install, f.home)
+      expect(r.code).toBe(0)
+      expect(readFileSync(join(dir, 'SKILL.md'), 'utf-8')).toBe(f.versions[2])
+      expect(r.out).toMatch(/frissitve: 1/)
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('NEVER overwrites a locally modified copy -- the failure that would be silent', () => {
+    const f = makeFixture()
+    try {
+      const dir = join(f.home, '.claude', 'skills', 'demo')
+      mkdirSync(dir, { recursive: true })
+      const edited = f.versions[1] + '# the operator added this line\n'
+      writeFileSync(join(dir, 'SKILL.md'), edited)
+      const r = runRefresh(f.install, f.home)
+      expect(r.code).toBe(0)
+      expect(readFileSync(join(dir, 'SKILL.md'), 'utf-8')).toBe(edited)   // byte-for-byte
+      expect(r.out).not.toMatch(/frissitve: [1-9]/)
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('a one-character edit is enough to be left alone', () => {
+    const f = makeFixture()
+    try {
+      const dir = join(f.home, '.claude', 'skills', 'demo')
+      mkdirSync(dir, { recursive: true })
+      const edited = f.versions[2].replace('current', 'currenT')
+      writeFileSync(join(dir, 'SKILL.md'), edited)
+      runRefresh(f.install, f.home)
+      expect(readFileSync(join(dir, 'SKILL.md'), 'utf-8')).toBe(edited)
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('handles the TEMPLATED task copies in rendered form', () => {
+    const f = makeFixture()
+    try {
+      const dir = join(f.home, '.claude', 'scheduled-tasks', 'demo-task')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'SKILL.md'), 'task v1 marveen\n')          // rendered v1, untouched
+      runRefresh(f.install, f.home)
+      expect(readFileSync(join(dir, 'SKILL.md'), 'utf-8')).toBe('task v3 marveen\n')
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves a modified TEMPLATED copy alone too', () => {
+    const f = makeFixture()
+    try {
+      const dir = join(f.home, '.claude', 'scheduled-tasks', 'demo-task')
+      mkdirSync(dir, { recursive: true })
+      const edited = 'task v1 marveen\n# operator note\n'
+      writeFileSync(join(dir, 'SKILL.md'), edited)
+      runRefresh(f.install, f.home)
+      expect(readFileSync(join(dir, 'SKILL.md'), 'utf-8')).toBe(edited)
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('never visits a skill the operator authored (no seed source)', () => {
+    const f = makeFixture()
+    try {
+      const mine = join(f.home, '.claude', 'skills', 'my-own-skill')
+      mkdirSync(mine, { recursive: true })
+      writeFileSync(join(mine, 'SKILL.md'), 'my own content\n')
+      runRefresh(f.install, f.home)
+      expect(readFileSync(join(mine, 'SKILL.md'), 'utf-8')).toBe('my own content\n')
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('does not create a directory that was never seeded here', () => {
+    const f = makeFixture()
+    try {
+      runRefresh(f.install, f.home)   // no demo/ in the target at all
+      // assert on the DIRECTORY, not just the file: a mutation that mkdir -p'd
+      // the target still left the file absent, so a file-only check passed
+      // while the guard was gone (mutation control, 2026-08-04).
+      expect(existsSync(join(f.home, '.claude', 'skills', 'demo'))).toBe(false)
+      expect(existsSync(join(f.home, '.claude', 'skills', 'demo', 'SKILL.md'))).toBe(false)
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('is idempotent: a second pass changes nothing and reports nothing', () => {
+    const f = makeFixture()
+    try {
+      const dir = join(f.home, '.claude', 'skills', 'demo')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'SKILL.md'), f.versions[0])
+      runRefresh(f.install, f.home)
+      const after1 = readFileSync(join(dir, 'SKILL.md'), 'utf-8')
+      const second = runRefresh(f.install, f.home)
+      expect(readFileSync(join(dir, 'SKILL.md'), 'utf-8')).toBe(after1)
+      expect(second.out).not.toMatch(/frissitve: [1-9]/)
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('the refresh runs where it can reach an already-current machine', () => {
+  it('is called before the up-to-date early exit', () => {
+    const lines = UPDATE.split('\n')
+    const call = lines.findIndex((l) => /^run_seed_refresh$/.test(l)) + 1
+    const branch = lines.findIndex((l) => l.includes('if [ "$OLD_VERSION" = "$NEW_VERSION" ]')) + 1
+    expect(call).toBeGreaterThan(0)
+    expect(call).toBeLessThan(branch)
+  })
+
+  it('does not touch CLAUDE.md -- that refresh stays behind its own flag', () => {
+    const fn = sliceShellFn(UPDATE, 'run_seed_refresh') + sliceShellFn(UPDATE, 'refresh_untouched_seeds')
+    expect(fn).not.toMatch(/CLAUDE\.md/)
+    expect(UPDATE).toMatch(/REGEN_CLAUDEMD/)   // the flag still exists, unchanged
+  })
+})

--- a/update.sh
+++ b/update.sh
@@ -412,6 +412,135 @@ run_unit_maintenance() {
 }
 run_unit_maintenance
 
+# ─────────────────────────────────────────────────────────────────────────────
+# SEED REFRESH -- update a shipped skill/task copy ONLY while it is provably
+# untouched, and sits here (above the up-to-date exit) for the same reason the
+# unit maintenance does.
+#
+# The problem it solves: seeding is skip-if-exists, so a fix to a file we ship
+# reaches new installs only. That is how a broken recipe survived on every
+# existing machine (the kanban-audit task called sqlite3/jq, absent on a stock
+# Linux box, so two of its steps died silently four times a day). --reseed-fleet
+# fixes it, but somebody has to run it.
+#
+# The safety rule, and the only reason this is allowed to write at all: a file is
+# refreshed ONLY if its current bytes match SOME version we ourselves shipped.
+# Then the operator demonstrably never edited it, and the worst case of a wrong
+# call is that a modified file stays old -- which --reseed-fleet still handles by
+# hand. An edited file is never overwritten behind the operator's back.
+#
+# "Some version we shipped" is the whole history of that path in this checkout,
+# not just the current one: a machine carrying an untouched copy from two
+# releases ago is just as entitled to the fix.
+#
+# Scheduled tasks are TEMPLATED at seed time, so a historical blob is compared
+# in RENDERED form, with this install's own values. If the operator renamed the
+# bot after seeding, nothing matches and we leave the file alone -- conservative
+# in the safe direction.
+#
+# NOT touched here: the operator's own skills/tasks (they have no seed source, so
+# the loop never visits them) and CLAUDE.md (its refresh stays behind the
+# explicit --regen-claudemd flag, because that file is the operator's text).
+SEED_REFRESH_UPDATED=0
+SEED_REFRESH_KEPT=0
+
+# Render a template stream the same way the seeder does. Keep in sync with the
+# sed blocks in the seeding loops below and in install-linux.sh.
+render_seed_template() {
+  sed -e "s/{{MAIN_AGENT_ID}}/${MAIN_AGENT_ID:-}/g" \
+      -e "s/{{BOT_NAME}}/${BOT_NAME:-}/g" \
+      -e "s/{{OWNER_NAME}}/${OWNER_NAME:-}/g" \
+      -e "s|{{INSTALL_DIR}}|${INSTALL_DIR}|g" \
+      -e "s/{{WEB_PORT}}/${WEB_PORT:-3420}/g"
+}
+
+# True (0) iff $1 (an installed file) is byte-identical to ANY historical version
+# of $2 (a repo-relative path), rendered when $3 = "template".
+seed_copy_is_untouched() {
+  installed="$1"; rel="$2"; mode="${3:-verbatim}"
+  [ -f "$installed" ] || return 1
+  cur="$(shasum -a 256 <"$installed" 2>/dev/null | awk '{print $1}')"
+  [ -n "$cur" ] || return 1
+  # Newest first, capped: a file we shipped 25+ revisions ago and never fixed
+  # since is not worth the extra git calls.
+  for blob in $(git -C "$INSTALL_DIR" log --format=%H -n 25 -- "$rel" 2>/dev/null); do
+    if [ "$mode" = "template" ]; then
+      candidate="$(git -C "$INSTALL_DIR" show "$blob:$rel" 2>/dev/null | render_seed_template | shasum -a 256 | awk '{print $1}')"
+    else
+      candidate="$(git -C "$INSTALL_DIR" show "$blob:$rel" 2>/dev/null | shasum -a 256 | awk '{print $1}')"
+    fi
+    [ "$cur" = "$candidate" ] && return 0
+  done
+  return 1
+}
+
+# Refresh one seeded directory tree. $1 = repo source dir (relative), $2 = target
+# root, $3 = verbatim|template.
+refresh_untouched_seeds() {
+  src_rel="$1"; target_root="$2"; mode="${3:-verbatim}"
+  [ -d "$INSTALL_DIR/$src_rel" ] || return 0
+  [ -d "$target_root" ] || return 0
+  for d in "$INSTALL_DIR/$src_rel"/*/; do
+    [ -d "$d" ] || continue
+    name="$(basename "$d")"
+    [ -d "$target_root/$name" ] || continue     # not seeded here -> not ours to add
+    for f in "$d"*; do
+      [ -f "$f" ] || continue
+      base="$(basename "$f")"
+      installed="$target_root/$name/$base"
+      [ -f "$installed" ] || continue           # never add files to an existing dir
+      rel="$src_rel/$name/$base"
+      # Already identical to what we would write -> not an update. Without this
+      # the run is not idempotent: it would rewrite the same bytes and report a
+      # refresh on every single update, which is exactly the kind of constant
+      # signal that stops being read.
+      if [ "$mode" = "template" ]; then
+        want="$(render_seed_template <"$f" | shasum -a 256 | awk '{print $1}')"
+      else
+        want="$(shasum -a 256 <"$f" | awk '{print $1}')"
+      fi
+      have="$(shasum -a 256 <"$installed" 2>/dev/null | awk '{print $1}')"
+      [ "$want" = "$have" ] && continue
+      if seed_copy_is_untouched "$installed" "$rel" "$mode"; then
+        if [ "$mode" = "template" ]; then
+          render_seed_template <"$f" >"$installed.seedtmp" && mv "$installed.seedtmp" "$installed"
+        else
+          cp "$f" "$installed"
+        fi
+        SEED_REFRESH_UPDATED=$((SEED_REFRESH_UPDATED + 1))
+      else
+        SEED_REFRESH_KEPT=$((SEED_REFRESH_KEPT + 1))
+      fi
+    done
+  done
+  return 0
+}
+
+run_seed_refresh() {
+  # Self-initialising counters: the function must not depend on a caller having
+  # set them, or it dies under `set -u` the moment it is called from anywhere
+  # else (a test harness found exactly that).
+  SEED_REFRESH_UPDATED="${SEED_REFRESH_UPDATED:-0}"
+  SEED_REFRESH_KEPT="${SEED_REFRESH_KEPT:-0}"
+  # .env values feed the template rendering; without MAIN_AGENT_ID a rendered
+  # comparison would be meaningless, so templated tasks are skipped then.
+  if [ -f "$INSTALL_DIR/.env" ]; then
+    MAIN_AGENT_ID="${MAIN_AGENT_ID:-$(sed -n 's/^MAIN_AGENT_ID=//p' "$INSTALL_DIR/.env" | head -1 | tr -d '"')}"
+    BOT_NAME="${BOT_NAME:-$(sed -n 's/^BOT_NAME=//p' "$INSTALL_DIR/.env" | head -1 | tr -d '"')}"
+    OWNER_NAME="${OWNER_NAME:-$(sed -n 's/^OWNER_NAME=//p' "$INSTALL_DIR/.env" | head -1 | tr -d '"')}"
+    WEB_PORT="${WEB_PORT:-$(sed -n 's/^WEB_PORT=//p' "$INSTALL_DIR/.env" | head -1 | tr -d '"')}"
+  fi
+  refresh_untouched_seeds "seed-skills" "$HOME/.claude/skills" "verbatim"
+  if [ -n "${MAIN_AGENT_ID:-}" ]; then
+    refresh_untouched_seeds "seed-scheduled-tasks" "$HOME/.claude/scheduled-tasks" "template"
+  fi
+  if [ "$SEED_REFRESH_UPDATED" -gt 0 ]; then
+    echo -e "  ${GREEN}✓${NC} Szallitott skill/feladat frissitve: ${SEED_REFRESH_UPDATED} (erintetlen masolat); megtartva: ${SEED_REFRESH_KEPT} (helyben modositott)"
+  fi
+  return 0
+}
+run_seed_refresh
+
 if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
   # Already on the latest commit -- but "no new commits" does NOT guarantee the
   # compiled dist/ matches the source. A prior update can pull new source and


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix
- [x] Új funkció (szűk, biztonsági korláttal) / New feature (narrow, with a safety rule)
- [ ] Dokumentáció
- [ ] Egyéb

## Kapcsolódó issue / Related issue

Nincs issue; a #870 lelet következménye (a szállított recept javítása magától nem ér el a már telepített gépekre). Marveen rendelte meg, a saját feltételemmel.

## Ellenőrzőlista / Checklist

- [ ] **Nem teljesen:** teljes suite zöld (241 fájl / 3258 teszt), typecheck tiszta, a függvények valódi git-repo fixture ellen futnak. Amit NEM próbáltam: éles gépen végigfutó `update.sh`, amely ténylegesen frissít egy érintetlen szállított fájlt.
- [x] `docs/` nem érintett.
- [x] Nincs beleégetett szenzitív adat.
- [x] Saját branchről: `feat/refresh-untouched-seeds` -> `develop`.

---

feat(update): refresh a shipped skill/task only while it is provably untouched

Seeding is skip-if-exists, so a fix to a file we ship reaches new installs and
nobody else. That is how the kanban-audit task kept calling sqlite3 and jq --
neither of which exists on a stock Linux box -- four times a day on every
existing machine, with two of its steps dying silently while the audit still
reported as having run (#870). `--reseed-fleet` fixes it, but somebody has to
run it, and nobody does.

This refreshes such a file automatically, under one rule that is the only reason
it is allowed to write into an existing install at all:

  a file is refreshed ONLY if its current bytes match SOME version we ourselves
  shipped.

Then the operator provably never edited it. The worst case of a wrong call is
that a modified file stays old -- which --reseed-fleet still handles by hand --
and never that an operator's edit disappears behind their back.

"Some version we shipped" means the whole history of that path in the checkout,
not just the newest: a machine carrying an untouched copy from two releases ago
is just as entitled to the fix. Scheduled tasks are templated at seed time, so a
historical blob is compared in RENDERED form with this install's own values; if
the operator renamed the bot after seeding, nothing matches and the file is left
alone -- conservative in the safe direction.

Boundaries kept deliberately: the operator's own skills and tasks are never
visited (they have no seed source), no directory is created that was not seeded
here, no file is added to an existing directory, and CLAUDE.md is untouched --
its refresh stays behind the explicit --regen-claudemd flag, because that file
is the operator's text.

It runs above the up-to-date early exit, for the same reason the unit
maintenance does (#868): a machine with nothing to pull is exactly the machine
that needs the repair.

Tests: src/__tests__/seed-refresh-untouched-only.test.ts (11). They build a
throwaway install -- a real git repo with three shipped versions of a seeded
file -- and execute the functions sliced out of update.sh against it. Both
directions are covered, with the NEGATIVE one weighted: a locally modified copy
survives byte-for-byte, and a single changed character is enough to be left
alone. Full suite green (241 files / 3258 tests), typecheck clean.

Mutation controls, each with the named failing test: removing the untouched
check (the dangerous direction), accepting only the newest shipped version,
comparing templated files without rendering, and moving the call back below the
early exit. A fifth control found a real hole -- the "never creates a directory"
test asserted only the file, so a mutation that mkdir -p'd the target still
passed; it now asserts the directory and the control fails as it should.

Two fixes came out of the tests rather than from review: the counters are now
self-initialising (the functions died under `set -u` when called from anywhere
that had not set them), and a file already identical to what would be written is
skipped, so a run is idempotent instead of reporting a refresh every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
