### PR TITLE
fix(scheduler): csak a némán kihagyott feladatról értesíts, a sikeres pótlásról ne

### DIFF
--- a/src/__tests__/schedule-catchup.test.ts
+++ b/src/__tests__/schedule-catchup.test.ts
@@ -9,6 +9,7 @@ import {
   catchUpMaxAgeMs,
   computeCatchUpStart,
   decideCatchUp,
+  shouldReportCatchUp,
 } from '../web/schedule-runner.js'
 import { cronDueBetween, cronPrevOccurrence } from '../web/cron.js'
 
@@ -119,6 +120,28 @@ describe('decideCatchUp: run it, or say it was missed -- never neither', () => {
   })
 })
 
+describe('shouldReportCatchUp: a successful catch-up is silent, only a missed run pings', () => {
+  // 2026-08-04 operator request (#2): the "[scheduler] Kimaradt ütemezés / Pótlás
+  // elindítva" line on every downtime was noise -- a successful catch-up needs no
+  // ping. Only a STALE occurrence (silently skipped, needs manual attention on the
+  // dashboard) is worth interrupting the operator for.
+  it('stays silent when the gap only caught tasks up', () => {
+    expect(shouldReportCatchUp(3, 0)).toBe(false)
+  })
+
+  it('pings when an occurrence was too stale to run (silently skipped)', () => {
+    expect(shouldReportCatchUp(0, 1)).toBe(true)
+  })
+
+  it('pings -- and the summary still names the caught-up half -- when both happened', () => {
+    expect(shouldReportCatchUp(2, 1)).toBe(true)
+  })
+
+  it('stays silent on an empty gap', () => {
+    expect(shouldReportCatchUp(0, 0)).toBe(false)
+  })
+})
+
 describe('cronPrevOccurrence: the age the decision is made on', () => {
   // 2026-07-29 08:40 local, a Wednesday -- one occurrence of "40 6 * * *" is in
   // the window (06:40 that morning), and it is 2h late.
@@ -175,7 +198,10 @@ describe('the runner wires the policy in', () => {
     expect(SRC).toMatch(/sendCatchUpSummary\(caughtUpThisTick, staleThisTick/)
   })
 
-  it('stays silent on a tick that caught nothing up', () => {
-    expect(SRC).toMatch(/if \(caughtUpThisTick\.length \|\| staleThisTick\.length\) \{/)
+  it('reports only when something was missed, via shouldReportCatchUp', () => {
+    // #2 policy: a successful-only catch-up is silent; the summary fires only when
+    // staleThisTick is non-empty. The guard delegates to the pure predicate.
+    expect(SRC).toMatch(/if \(shouldReportCatchUp\(caughtUpThisTick\.length, staleThisTick\.length\)\) \{/)
+    expect(SRC).not.toMatch(/if \(caughtUpThisTick\.length \|\| staleThisTick\.length\) \{/)
   })
 })

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -330,6 +330,18 @@ export function decideCatchUp(
   return ageMs <= catchUpMaxAgeMs(task) ? 'catch-up' : 'stale'
 }
 
+// Pure: whether a downtime gap is worth a Telegram ping. Policy (2026-08-04,
+// operator request): a successful catch-up runs silently -- the operator does
+// not need to know a scheduled task fired a few minutes late. Only a STALE
+// occurrence -- one too old to run, therefore silently skipped -- warrants the
+// alert, because it needs manual attention on the dashboard /Ütemezések page.
+// The caughtUp count is deliberately ignored: its presence never forces a ping,
+// but when a stale one does fire the summary still names both halves.
+export function shouldReportCatchUp(caughtUpCount: number, staleCount: number): boolean {
+  void caughtUpCount
+  return staleCount > 0
+}
+
 /** Pure: where the first post-start scan window begins. */
 export function computeCatchUpStart(
   persistedTickMs: number | null,
@@ -828,10 +840,11 @@ function resolveSchedulerAlertToken(): string | undefined {
 }
 
 // One line about what the scheduler missed while it was down: which tasks it
-// caught up, and which were too stale to be worth running. Sent once per tick
-// that produced any such entry -- in normal operation that is never, so the
-// channel stays quiet. This is the reporting half of the catch-up policy: a
-// missed occurrence either runs or gets named, never both and never neither.
+// caught up, and which were too stale to be worth running. Called only when a
+// stale (silently-skipped) occurrence exists -- see shouldReportCatchUp; a gap
+// that merely caught tasks up stays quiet (2026-08-04 policy). This is the
+// reporting half of the catch-up policy: a missed occurrence either runs or
+// gets named, never both and never neither.
 function sendCatchUpSummary(
   caughtUp: Array<{ task: string; ageMs: number }>,
   stale: Array<{ task: string; ageMs: number }>,
@@ -1272,10 +1285,10 @@ export function startScheduleRunner(): NodeJS.Timeout {
       }
     }
 
-    // Tell the operator, in one line, what the gap cost. Only fires when this
-    // tick actually caught something up or declared something too stale, which
-    // in steady state is never.
-    if (caughtUpThisTick.length || staleThisTick.length) {
+    // Tell the operator, in one line, what the gap cost -- but only when a missed
+    // occurrence was too stale to run (silently skipped, needs manual attention).
+    // A gap that merely caught tasks up stays quiet: see shouldReportCatchUp.
+    if (shouldReportCatchUp(caughtUpThisTick.length, staleThisTick.length)) {
       sendCatchUpSummary(caughtUpThisTick, staleThisTick, pendingStartupGapMs || (now - fromMs))
     }
     pendingStartupGapMs = 0


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: A downtime utáni catch-up összefoglaló (`[<bot> scheduler] Kimaradt ütemezés / Pótlás elindítva`) eddig MINDEN kiesésnél kiment a Telegramra — a sikeres pótlásnál is —, ami zaj volt: egy néhány perces késéssel pótolt ütemezésről a felhasználónak nem kell tudnia. Mostantól az összefoglaló csak akkor szól, ha volt túl elavult, némán KIHAGYOTT (`stale`) ütemezés, ami kézi indítást igényel a dashboard /Ütemezések oldalán. A sikeres pótlás csendes. A döntést egy új, tiszta és unit-tesztelt `shouldReportCatchUp(caughtUpCount, staleCount)` predikátum hozza (a meglévő `decideCatchUp` / `catchUpMaxAgeMs` policy-mintája szerint); a tick guard-ja erre delegál. Ha az értesítés mégis kimegy (van stale), az összefoglaló továbbra is megnevezi a pótolt felet is.

EN: The post-downtime catch-up summary used to fire on every gap — including a purely successful catch-up — which was noise. It now alerts only when a stale (silently skipped) occurrence exists, one that needs manual attention on the dashboard. A successful catch-up stays silent. The decision lives in a new pure, unit-tested `shouldReportCatchUp()` predicate; the runner guard delegates to it. When it does fire, the summary still names the caught-up half.

Változott / Changed:
- `src/web/schedule-runner.ts`: új `shouldReportCatchUp()` export + a tick guard átkötése + a doc-kommentek összhangba hozása.
- `src/__tests__/schedule-catchup.test.ts`: 4 behavioral teszt a predikátumra + a „wires the policy in" forrás-szintű teszt frissítése az új guard-ra.

## Kapcsolódó issue / Related issue

Nincs GitHub issue — a kérés Telegramon érkezett (a downtime-értesítés minden kiesésnél zajolt).

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard) — **automata teszttel igazoltam, nem éles Telegram-értesítéssel**: `vitest run` RED→GREEN (schedule-catchup: 29 teszt, ebből 5 új/frissített), regresszió zöld (schedule-runner-bound-chatid, heartbeat-prefix), `tsc --noEmit` exit 0. Node 22 alatt futtatva (a repo better-sqlite3 ABI-ja miatt).
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Nem érinti — belső értesítési policy, nincs docs-változás.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (`fix/catchup-report-only-missed`, nem közvetlenül `develop`-ra). / Opened from an own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
