### PR TITLE
feat(security): agent guard hookok (opt-in PreToolUse) — git-protect / secret-write / big-file

### DIFF
--- a/docs/guard-hooks.md
+++ b/docs/guard-hooks.md
@@ -1,0 +1,127 @@
+# Agent guard hookok (opt-in PreToolUse védelmek)
+
+## Mi ez?
+
+Három **PreToolUse** hook, amelyek egy megosztott, több-ügynökös munkafában (shared
+checkout) a leggyakoribb, dokumentált footgunoktól védenek — még **azelőtt**, hogy az
+ügynök Bash/Write hívása lefutna. Mindhárom **fail-open** (hiba esetén enged, sosem
+akasztja meg a flottát), és **alapból KI van kapcsolva**: opt-in módon kell bekötni.
+
+| Hook | Melyik toolt őrzi (`matcher`) | Mit blokkol (exit 2) |
+|------|-------------------------------|----------------------|
+| `git-protect-guard.py` | `Bash` | `git add -A`/`.`/`--all`; force-push egy védett ágra (`main`/`master`/`develop`), ha az explicit meg van nevezve; a contended lockfile (`pnpm-lock.yaml`/`package-lock.json`) stage-elése; destruktív egész-fa műveletek (`git reset --hard`, `git clean -f`, `git checkout .`, csupasz `git stash`) |
+| `secret-write-guard.py` | `Write`/`Edit`/`MultiEdit` | Egy fájlba írandó **literál titok** (privát kulcs-blokk, vagy egyértelmű előtagú provider-token: Anthropic/OpenAI/GitHub/Slack/AWS). Csak VALÓDI értékre üt, referenciára (`$(cat ...)`, `process.env.X`, `.env.example` placeholder) nem |
+| `big-file-guard.py` | `Write` | Egyetlen `Write`, amelynek tartalma túllépi a `HOOK_MAX_WRITE_BYTES` (alap: 2 MB) korlátot — a „bundle/blob a forrásfába" hibát fogja |
+
+> Miért opt-in? A `git-protect-guard` git-posztúra-döntés: blokkolna olyan parancsokat
+> is (`git add -A`, `git reset --hard`), amelyekre egyes munkafolyamatoknak szükségük
+> lehet. Ezért nem kötjük be automatikusan — a telepítő tudatosan, felülvizsgálva
+> kapcsolja be. (A repo külön, git-szintű `install-git-guard-hook.sh` pre-push hookja
+> ettől független: az csak a force-pusht tiltja natív git szinten.)
+
+## Hogyan használd?
+
+A hookok bekötése az ügynök `.claude/settings.json` fájljának `hooks.PreToolUse`
+tömbjébe történik — ugyanabban az alakban, ahogy az `egress-gate` és a többi hook. Vedd
+fel a kívánt bejegyzéseket (a `{{PROJECT_ROOT}}` a telepítéskor behelyettesítődik, vagy
+add meg az abszolút utat):
+
+```jsonc
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/git-protect-guard.py", "timeout": 10 }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/secret-write-guard.py", "timeout": 10 }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          { "type": "command", "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/big-file-guard.py", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Csak azt vedd fel, amelyikre szükséged van — a három egymástól független. A
+`big-file-guard` küszöbe környezeti változóval hangolható:
+
+```bash
+# Emeld 5 MB-ra (pl. ha nagyobb generált fájlok is legitimek):
+export HOOK_MAX_WRITE_BYTES=5000000
+```
+
+Önteszt (a git-guard 81 esete):
+
+```bash
+python3 scripts/hooks/git-protect-guard.selftest.py
+# -> "All 81 cases pass." és exit 0
+```
+
+## Hogyan működik?
+
+A Claude Code minden tool-hívás **előtt** meghívja a `matcher`-re illő PreToolUse
+hookokat, a tool bemenetét JSON-ként a hook stdin-jére adva. A hook **exit kódja**
+dönt: `2` = a hívás blokkolva (a stderr-re írt indoklással), bármi más (`0`) = enged.
+
+```mermaid
+sequenceDiagram
+    participant A as Ügynök (LLM)
+    participant CC as Claude Code
+    participant H as guard hook (PreToolUse)
+    participant T as Tool (Bash/Write/Edit)
+
+    A->>CC: tool-hívás (pl. Bash "git add -A")
+    CC->>H: PreToolUse — stdin: {tool_name, tool_input}
+    alt egyértelmű footgun
+        H-->>CC: exit 2 + indoklás a stderr-re
+        CC-->>A: BLOKKOLVA (a tool nem fut le)
+    else biztonságos VAGY nem értelmezhető (fail-open)
+        H-->>CC: exit 0
+        CC->>T: a tool lefut
+        T-->>A: eredmény
+    end
+```
+
+- **`git-protect-guard`** kibontja a parancsot (beleértve egy szint `bash -c`/`eval`
+  csomagolást is), és csak világos egyezésre üt. „Fail toward allow": egy force-push,
+  amely nem nevez meg védett ágat (pl. egy feature-ágra), **átmegy** — a védett ág
+  (`main`/`master`/`develop`) explicit megnevezése a blokkolt eset.
+- **`secret-write-guard`** a `Write`/`Edit`/`MultiEdit` tartalmát vizsgálja, és csak
+  **nagy biztonságú** literál titokra üt (kulcs-blokk vagy félreérthetetlen token-előtag).
+  Amit nem tud értelmezni → enged (fail-open).
+- **`big-file-guard`** csak a `Write` toolra vonatkozik (ez hordozza a teljes tartalmat);
+  az `Edit`/`MultiEdit` deltákat nem méri.
+
+## Technikai részletek
+
+- **Fail-open, mindig.** Minden hiba-ág (nem-parseolható payload, kivétel, hiányzó mező)
+  `exit 0` — egy összeomló őr sosem akaszthatja meg a flottát. A védelem szándékosan
+  **szűk**: inkább átenged egy határesetet, mint hogy valódi munkát blokkoljon.
+- **Nincs perzisztens állapot, nincs titok a fájlokban.** A hookok tisztán a stdin
+  payloadból dolgoznak.
+- **PreToolUse kontraktus.** A payload `tool_name` és `tool_input` mezőket tartalmaz; a
+  hook a `matcher`-hez tartozó toolokra fut. Blokkoláshoz `exit 2` + indoklás a stderr-re.
+- **Önteszt.** A `git-protect-guard.selftest.py` 81 BLOCK/ALLOW esetet futtat a guard
+  logikáján (útvonal-független fixture-ökkel), és `exit 0`-val zöld.
+- **Küszöb.** `big-file-guard`: `HOOK_MAX_WRITE_BYTES` (alap `2_000_000`).
+- **Protected ágak.** `git-protect-guard`: `main`, `master`, `develop`.
+
+## Tech stack
+
+- **Python 3** (nincs külső függőség; a repo többi hookjával azonos futtatás:
+  `python3 {{PROJECT_ROOT}}/scripts/hooks/<hook>.py`).
+- **Claude Code PreToolUse hook** mechanizmus (stdin JSON payload, `exit 2` = block).
+- Bekötés az ügynök `.claude/settings.json` `hooks.PreToolUse` tömbjén keresztül
+  (ugyanaz az alak, mint az `egress-gate` és a `templates/settings.json.template`
+  bejegyzései).

--- a/scripts/hooks/big-file-guard.py
+++ b/scripts/hooks/big-file-guard.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block writing an absurdly large single file.
+
+An agent occasionally tries to Write a minified bundle, a generated data blob, or
+a pasted artifact straight into the source tree -- which then risks being
+committed and bloating the shared checkout. No legitimate hand-authored source
+file is multiple megabytes. This guard blocks (exit 2) a single Write whose
+content exceeds MAX_BYTES; everything smaller passes untouched.
+
+Deliberately narrow / fail-open:
+  - Only the Write tool (which carries full file content). Edit/MultiEdit deltas
+    are not size-capped here.
+  - Threshold is high (2 MB) so it never trips on real source; it catches the
+    blob-into-source mistake, not normal work.
+  - Any parse error -> exit 0. A guard bug must never block legitimate writes.
+"""
+import sys
+import os
+import json
+
+DEFAULT_MAX_BYTES = 2_000_000  # 2 MB; override with HOOK_MAX_WRITE_BYTES
+
+
+def _limit():
+    raw = os.environ.get("HOOK_MAX_WRITE_BYTES")
+    if raw:
+        try:
+            v = int(raw)
+            if v > 0:
+                return v
+        except Exception:
+            pass
+    return DEFAULT_MAX_BYTES
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    if (payload.get("tool_name") or "") != "Write":
+        sys.exit(0)
+
+    ti = payload.get("tool_input") or {}
+    content = ti.get("content") if isinstance(ti, dict) else None
+    if not isinstance(content, str):
+        sys.exit(0)
+
+    try:
+        size = len(content.encode("utf-8", errors="ignore"))
+    except Exception:
+        sys.exit(0)
+
+    limit = _limit()
+    if size > limit:
+        mb = size / 1_000_000
+        sys.stderr.write(
+            f"BIG-FILE-GUARD: {mb:.1f} MB-os fajl irasa blokkolva (limit "
+            f"{limit/1_000_000:.1f} MB). Ekkora fajl szinte biztosan generalt blob / "
+            "minified bundle / beillesztett artifact -- ne kerüljon a forrasfaba. "
+            "Ha tenyleg kell, generald build-lepesben, vagy tedd git-ignoralt utvonalra."
+        )
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/git-protect-guard.py
+++ b/scripts/hooks/git-protect-guard.py
@@ -77,7 +77,7 @@ LOCKFILES = ("pnpm-lock.yaml", "package-lock.json", "yarn.lock")
 _ENV_PREFIX = r"(?:[A-Za-z_][A-Za-z0-9_]*=[^\s;&|]*\s+)*"
 # Git GLOBAL options, which may sit BETWEEN `git` and the subcommand (Cybersec/QA NO-GO on c9e4b5d).
 # `git -C <path> reset --hard` is not an evasion -- it is the NORMAL way to operate on a repo you are
-# not cd'd into, i.e. exactly how an agent working from the shared repo root touches the shared CleanCore
+# not cd'd into, i.e. exactly how an agent working from the shared repo root touches the shared checkout
 # checkout. Missing it meant the guard missed its own primary scenario. Options that take a SEPARATE
 # argument (-C, -c) must consume that argument too, or the subcommand match lands on the wrong token.
 _GIT_GLOBAL = (

--- a/scripts/hooks/git-protect-guard.py
+++ b/scripts/hooks/git-protect-guard.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: protect the shared git checkout from documented footguns.
+
+Multiple agents share one working tree (see the shared-checkout rule). These git
+moves reliably corrupt a shared checkout or a protected branch, and every one of
+them has already bitten this fleet at least once:
+
+  1. `git add -A` / `git add .` / `git add --all` -- stages OTHER agents' unrelated
+     changes into your commit. The rule is: stage only your own files/hunks.
+  2. force-push (`git push --force` / `-f` / `--force-with-lease`) to a protected
+     branch (main / develop) -- rewrites shared history.
+  3. `git add`-ing the contended lockfile (pnpm-lock.yaml / package-lock.json) --
+     A koordinátor batches dependency changes; agents never touch the lockfile.
+  4. DESTRUCTIVE WHOLE-TREE ops (card 6b532950) -- `git reset --hard`,
+     `git checkout .` / `git checkout -- .`, `git restore .`, `git stash` (bare),
+     `git clean -fd`. These do not just affect YOUR files: in a shared checkout
+     they silently delete every other agent's uncommitted work. Real incident:
+     a hard-reset wiped backend's uncommitted 21a34658 WIP right after another
+     agent's commit (see memories uncommitted-edits-wiped-in-shared-tree and
+     gate-agent-stashes-active-wip).
+
+This guard parses the Bash command and blocks (exit 2) ONLY on a clear match of
+one of the above. It is intentionally conservative -- the cost of a false block
+is a wedged agent, so every rule below is scoped to the WHOLE-TREE form and the
+targeted//safe forms stay allowed:
+
+  - It only inspects Bash tool calls; everything else is allowed.
+  - `git add -p` / `git add <specific-path>` -> allowed (the correct pattern).
+  - A protected-branch force-push is blocked; a force-push to a private feature
+    branch is allowed (that is a legitimate agent workflow).
+  - `git reset <file>` / bare `git reset` / `--soft` / `--mixed` -> allowed: they
+    move HEAD and/or the index but NEVER discard working-tree edits. Only
+    `--hard` (and `--merge`/`--keep`, which also overwrite the tree) is blocked.
+  - `git checkout <branch>` / `git checkout -b` / `git checkout <ref> -- <path>`
+    -> allowed. Only the whole-tree `.`/`--all` form is blocked; a targeted
+    single-file restore is a legitimate, reviewable operation.
+  - `git stash pop|apply|list|show|drop|branch` -> allowed (those RESTORE or
+    inspect). Only a bare `git stash` / `git stash push` with no pathspec is
+    blocked -- that is the form that hides a peer's in-flight work.
+  - `git clean -n` / `--dry-run` -> allowed. Only an actually-deleting `-f` is
+    blocked.
+  - Any parse error -> FAIL-OPEN (exit 0). Never wedge the fleet on a guard bug.
+
+WHAT THIS IS NOT (be honest with anyone reading this before trusting it): this is a
+regex over the command STRING, so it stops ACCIDENTS, not a determined actor. It
+does not survive variable indirection (`g=git; $g reset --hard`), string splitting
+(`git rese""t --hard`), a command written to a file and executed, or TWO levels of
+wrapper nesting (`bash -c "bash -c '...'"` -- one level is unwrapped, deliberately:
+at two levels a caller is evading, not phrasing, and no string matcher wins that
+race). Closing those would need real shell parsing or an allowlist, which would cost
+far more false positives than the footguns are worth. Treat it as a seatbelt for
+tired agents, NOT as a security boundary -- the actual protection against losing work
+is committing early (shared-checkout rule).
+
+WHAT IS COVERED that a naive matcher misses (added after the c9e4b5d gate): git's
+GLOBAL options and env prefixes before the subcommand -- `git -C <path> reset --hard`,
+`git --git-dir=... reset --hard`, `GIT_DIR=... git reset --hard`. These are not
+evasions but the normal cross-repo idiom, so missing them left the guard blind in
+exactly its primary scenario. Heredoc BODIES are stripped before scanning, so writing
+a doc or fixture that quotes a destructive command is not refused.
+"""
+import sys
+import re
+import json
+
+PROTECTED_BRANCHES = ("main", "master", "develop")
+LOCKFILES = ("pnpm-lock.yaml", "package-lock.json", "yarn.lock")
+
+# A git invocation only counts when it sits at a COMMAND boundary (start of the
+# command, or right after a shell separator), optionally behind `sudo`/`time`.
+# This is what stops the frequent false positive: the literal string "git add -A"
+# embedded in a QUOTED argument to another command (a curl -d payload, an echo, a
+# log line that documents the rule) is NOT at a boundary, so it is not matched.
+# Backtick is deliberately NOT a boundary here -- inside single quotes it is a
+# literal char in docs far more often than a real command substitution.
+# Leading environment assignments (`GIT_DIR=.git git ...`, `FOO=1 git ...`).
+_ENV_PREFIX = r"(?:[A-Za-z_][A-Za-z0-9_]*=[^\s;&|]*\s+)*"
+# Git GLOBAL options, which may sit BETWEEN `git` and the subcommand (Cybersec/QA NO-GO on c9e4b5d).
+# `git -C <path> reset --hard` is not an evasion -- it is the NORMAL way to operate on a repo you are
+# not cd'd into, i.e. exactly how an agent working from the shared repo root touches the shared CleanCore
+# checkout. Missing it meant the guard missed its own primary scenario. Options that take a SEPARATE
+# argument (-C, -c) must consume that argument too, or the subcommand match lands on the wrong token.
+_GIT_GLOBAL = (
+    r"(?:"
+    r"(?:-C|-c)\s+[^\s;&|]+\s+"                                   # -C <path>, -c <key=val>
+    r"|--(?:git-dir|work-tree|namespace|exec-path)(?:=[^\s;&|]*\s+|\s+[^\s;&|]+\s+)"
+    r"|--(?:no-pager|paginate|bare|literal-pathspecs|icase-pathspecs|no-replace-objects)\s+"
+    r"|-[pP]\s+"
+    r")*"
+)
+_CMD = (
+    r"(?:^|[\n;&|(])\s*" + _ENV_PREFIX + r"(?:sudo\s+)?(?:time\s+)?git\s+" + _GIT_GLOBAL
+)
+# `git add` with a stage-everything flag (-A, --all, or a bare `.`).
+ADD_ALL_RX = re.compile(_CMD + r"add\b[^\n&|;]*?(?:(?<!\S)-A\b|--all\b|(?<!\S)\.(?:\s|$))")
+# `git commit -a`/`-am`/`--all` -- the OTHER swallow vector (card 42a2f45d). `-a` stages EVERY
+# modified tracked file at commit time, so on a shared checkout it sweeps a peer's in-flight tracked
+# edits into your commit exactly like `git add -A` -- and the guard did not cover it, so it was the
+# path the swallow kept happening through after `git add -A` was blocked. Matches a short-flag cluster
+# containing `a` (`-a`, `-am`, `-ap`) and `--all`; `--amend` and `-m` alone (no `a`) stay allowed.
+COMMIT_ALL_RX = re.compile(
+    _CMD + r"commit\b[^\n&|;]*?(?:--all\b|(?<!\S)-[A-Za-z]*a[A-Za-z]*\b)"
+)
+# `git add` naming a lockfile explicitly.
+ADD_LOCK_RX = re.compile(
+    _CMD + r"add\b[^\n&|;]*?(?:" + "|".join(re.escape(f) for f in LOCKFILES) + r")"
+)
+# force-push in any argument order.
+FORCE_PUSH_RX = re.compile(_CMD + r"push\b[^\n&|;]*?(?:--force(?:-with-lease)?\b|(?<!\S)-f\b)")
+
+# --- destructive whole-tree ops (card 6b532950) ------------------------------------------------
+# `git reset --hard|--merge|--keep` -- the modes that OVERWRITE the working tree. `--soft`/`--mixed`
+# (and a bare `git reset` / `git reset <file>`) only touch HEAD/index and are deliberately allowed.
+RESET_HARD_RX = re.compile(_CMD + r"reset\b[^\n&|;]*?--(?:hard|merge|keep)\b")
+
+# `git checkout -f|--force` -- a forced branch switch OVERWRITES uncommitted local changes, so in a
+# shared tree it is as destructive as `checkout .` even though it names a branch.
+CHECKOUT_FORCE_RX = re.compile(_CMD + r"checkout\b[^\n&|;]*?(?:--force\b|(?<!\S)-f\b)")
+
+# `git checkout .` / `git checkout -- .` / `git checkout --all`, and the same shapes for the modern
+# `git restore`. A trailing `.` (or `*`) as the PATHSPEC means "throw away the whole tree".
+# `git restore --staged .` is NOT matched: that only unstages, it does not touch the working tree.
+_WHOLE_TREE_PATHSPEC = r"(?:(?<!\S)\.(?:\s|$)|(?<!\S)\*(?:\s|$)|--all\b)"
+CHECKOUT_ALL_RX = re.compile(_CMD + r"checkout\b(?:(?!\bHEAD\b|[\n&|;])[^\n&|;])*?" + _WHOLE_TREE_PATHSPEC)
+RESTORE_ALL_RX = re.compile(
+    _CMD + r"restore\b(?![^\n&|;]*--staged\b)[^\n&|;]*?" + _WHOLE_TREE_PATHSPEC
+)
+
+# Bare `git stash` / `git stash push` with NO pathspec -- stashes the WHOLE tree, including every
+# other agent's uncommitted work. The restoring/inspecting subcommands are explicitly allowed.
+STASH_SAFE_SUB = r"(?:pop|apply|list|show|drop|branch|clear)\b"
+STASH_ALL_RX = re.compile(_CMD + r"stash\b(?:\s+(?:push|save)\b)?\s*(?:-[uak]\b\s*)*(?:$|[\n;&|])")
+
+# `git clean` that actually deletes (-f/--force), excluding an explicit dry run.
+CLEAN_FORCE_RX = re.compile(
+    _CMD + r"clean\b(?![^\n&|;]*(?:--dry-run\b|(?<!\S)-n\b))[^\n&|;]*?(?:--force\b|(?<!\S)-[a-eg-mo-z]*f)"
+)
+
+
+_SHARED_TREE_NOTE = (
+    " KOZOS CHECKOUT: ez nem csak a TE valtozasaidat torli -- minden mas agent "
+    "commitolatlan munkajat is. Ha tenyleg kell, elobb commitold a sajatodat, es "
+    "hasznalj CELZOTT format (pl. `git checkout <ref> -- <fajl>`), vagy kerd a koordinatort."
+)
+
+_DESTRUCTIVE_RULES = (
+    (
+        RESET_HARD_RX,
+        "`git reset --hard/--merge/--keep` blokkolva -- felulirja a munkafat." + _SHARED_TREE_NOTE
+        + " Unstage-hez hasznald: `git reset <fajl>` (ez engedelyezett).",
+    ),
+    (
+        CHECKOUT_ALL_RX,
+        "`git checkout .` / `-- .` blokkolva -- eldobja az EGESZ munkafa valtozasait."
+        + _SHARED_TREE_NOTE,
+    ),
+    (
+        CHECKOUT_FORCE_RX,
+        "`git checkout -f/--force` blokkolva -- a kenyszeritett branch-valtas felulirja a "
+        "commitolatlan valtozasokat." + _SHARED_TREE_NOTE
+        + " Kapcsolo nelkul (`git checkout <branch>`) engedelyezett: az fail-closed, ha utkozne.",
+    ),
+    (
+        RESTORE_ALL_RX,
+        "`git restore .` blokkolva -- eldobja az EGESZ munkafa valtozasait."
+        + _SHARED_TREE_NOTE
+        + " (`git restore --staged .` engedelyezett: az csak unstage-el.)",
+    ),
+    (
+        STASH_ALL_RX,
+        "Csupasz `git stash` blokkolva -- elrejti az EGESZ fat, benne mas agentek "
+        "eppen futo munkajat (volt mar ra eset)." + _SHARED_TREE_NOTE
+        + " A `git stash pop|apply|list|show|drop` engedelyezett.",
+    ),
+    (
+        CLEAN_FORCE_RX,
+        "`git clean -f` blokkolva -- torli a nem-kovetett fajlokat, koztuk mas agentek "
+        "meg nem commitolt uj fajljait." + _SHARED_TREE_NOTE
+        + " Szarazon futtatva (`git clean -n`) engedelyezett.",
+    ),
+)
+
+
+# A single level of shell-wrapper indirection: `bash -c "..."`, `sh -c '...'`, `eval "..."`.
+# An agent writing `bash -c "git reset --hard"` is PHRASING, not evading -- unwrapping one level
+# catches that accident. Deliberately ONE level and only these three forms: this is a footgun guard,
+# not a sandbox (see the module docstring's honesty note about what it cannot catch).
+_WRAPPER_RX = re.compile(
+    r"(?:^|[\n;&|(])\s*(?:bash|sh|zsh)\s+-c\s+(['\"])(.*?)\1|(?:^|[\n;&|(])\s*eval\s+(['\"])(.*?)\3",
+    re.S,
+)
+
+
+def _unwrapped_variants(cmd):
+    """The command itself, plus the contents of any one-level bash -c / eval wrapper."""
+    out = [cmd]
+    for m in _WRAPPER_RX.finditer(cmd):
+        inner = m.group(2) if m.group(2) is not None else m.group(4)
+        if inner:
+            out.append(inner)
+    return out
+
+
+# A heredoc BODY is data being written, not a command being run (Cybersec/QA LOW on c9e4b5d).
+# Writing a doc, a test fixture or a guard probe whose CONTENT quotes `git reset --hard` must not be
+# refused -- the fleet writes exactly such files (this guard's own selftest is one). Quoted mentions
+# (echo '...', curl -d '{...}') were already exempt via the command-boundary rule; a raw heredoc body
+# was not, because its lines DO start at a line boundary. Strip those bodies before scanning.
+_HEREDOC_RX = re.compile(
+    r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1.*?^\s*\2\s*$",
+    re.S | re.M,
+)
+
+
+def _strip_heredoc_bodies(cmd):
+    """Blank out `<<EOF ... EOF` / `<<'EOF' ... EOF` bodies so their CONTENT is not scanned."""
+    return _HEREDOC_RX.sub("<<HEREDOC-BODY-STRIPPED", cmd)
+
+
+# The CONTENT of a quoted argument is DATA, not shell syntax (card 42a2f45d). The command-boundary
+# rule (_CMD) already exempts a quoted `git add -A` that has no inner separator -- but a `;`/`|`/`&`/
+# newline INSIDE the quotes (a JSON payload, a curl body, a commit message, an inter-agent message
+# that documents the rule) was still read as a real command boundary, so `curl -d '...; git add -A'`
+# false-blocked. Blanking quoted spans (keeping the quote chars, so token structure is intact) removes
+# that whole false-positive class. A REAL destructive command is never inside quotes; a `bash -c "..."`
+# / `eval "..."` wrapper is handled separately by _unwrapped_variants (which reads the RAW, un-stripped
+# command), so a genuinely-wrapped destructive op is still caught.
+_QUOTED_RX = re.compile(r"'[^']*'|\"(?:\\.|[^\"\\])*\"", re.S)
+
+
+def _strip_quoted_literals(cmd):
+    """Replace the CONTENT of single-/double-quoted spans with an empty quote of the same kind, left
+    to right (so a `"` inside a `'...'` span is treated as the literal it is in a shell)."""
+    return _QUOTED_RX.sub(lambda m: "''" if m.group(0)[0] == "'" else '""', cmd)
+
+
+def _pushes_protected(cmd):
+    """True only if a force-push EXPLICITLY names a protected branch. We fail
+    toward allow: a force-push with no protected-branch token (e.g. to a feature
+    branch, or current branch) is permitted -- blocking those would break the
+    legitimate agent workflow. Naming main/master/develop in a force-push is the
+    unambiguous footgun we stop."""
+    m = FORCE_PUSH_RX.search(cmd)
+    if not m:
+        return False
+    seg = cmd[m.start():]
+    return any(
+        re.search(r"(?<![\w./-])" + re.escape(b) + r"(?:\s|$|:)", seg)
+        for b in PROTECTED_BRANCHES
+    )
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    if (payload.get("tool_name") or "") != "Bash":
+        sys.exit(0)
+
+    ti = payload.get("tool_input") or {}
+    cmd = ti.get("command") if isinstance(ti, dict) else None
+    if not isinstance(cmd, str) or "git" not in cmd:
+        sys.exit(0)
+
+    try:
+        # A heredoc body is DATA being written, not a command -- never scan its contents.
+        cmd = _strip_heredoc_bodies(cmd)
+
+        # Scan the command AND one level of bash -c / eval unwrapping (from the RAW command, so a
+        # genuinely-wrapped destructive op is still seen), and within each variant blank quoted spans
+        # so a separator inside a quoted payload is not read as a real command boundary (card 42a2f45d).
+        for variant in (_strip_quoted_literals(v) for v in _unwrapped_variants(cmd)):
+            # `git add -p` is the sanctioned staging path; never block it.
+            if ADD_ALL_RX.search(variant) and not re.search(r"\bgit\s+add\s+-p\b", variant):
+                sys.stderr.write(
+                    "GIT-PROTECT-GUARD: `git add -A/./--all` blokkolva -- kozos "
+                    "checkout-on ez mas agentek valtozasait is stage-eli. Csak a SAJAT "
+                    "fajljaidat/hunkjaidat add hozza: `git add <path>` vagy `git add -p`."
+                )
+                sys.exit(2)
+
+            if COMMIT_ALL_RX.search(variant):
+                sys.stderr.write(
+                    "GIT-PROTECT-GUARD: `git commit -a/-am/--all` blokkolva -- kozos "
+                    "checkout-on ez MINDEN modositott kovetett fajlt stage-el commit kozben, "
+                    "beleertve mas agentek eppen futo valtozasait. Stage-eld es commitold a "
+                    "SAJAT fajljaidat: `git add <fajl> && git commit ...` vagy `git commit <fajl>`. "
+                    "(`git commit -m` es `git commit --amend` -a nelkul engedelyezett.)"
+                )
+                sys.exit(2)
+
+            if ADD_LOCK_RX.search(variant):
+                sys.stderr.write(
+                    "GIT-PROTECT-GUARD: lockfile (pnpm-lock.yaml / package-lock.json) "
+                    "git add-je blokkolva -- a fuggosegeket a koordinator batcheli, agent nem "
+                    "nyul a lockfile-hoz. Hagyd ki a lockfile-t a commitbol."
+                )
+                sys.exit(2)
+
+            if _pushes_protected(variant):
+                sys.stderr.write(
+                    "GIT-PROTECT-GUARD: force-push vedett branchre (main/master/develop) "
+                    "blokkolva -- ez kozos historiat ir felul. Pushold feature branchre, "
+                    "vagy nyiss PR-t. Force-push privat feature branchre engedelyezett."
+                )
+                sys.exit(2)
+
+            # --- destructive whole-tree ops (card 6b532950) -----------------------------------
+            for rx, msg in _DESTRUCTIVE_RULES:
+                if rx.search(variant):
+                    sys.stderr.write("GIT-PROTECT-GUARD: " + msg)
+                    sys.exit(2)
+    except Exception:
+        sys.exit(0)  # any guard error -> fail open
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/git-protect-guard.selftest.py
+++ b/scripts/hooks/git-protect-guard.selftest.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Self-test for git-protect-guard.py (card 6b532950).
+
+Run:  python3 scripts/hooks/git-protect-guard.selftest.py
+Exit: 0 = all pass, 1 = at least one case wrong.
+
+The FALSE-POSITIVE half matters as much as the block half: a guard that wedges a
+legitimate `git reset <file>` or `git checkout <branch>` costs the fleet more than
+the footgun it prevents. Every ALLOW case below is a command an agent really runs.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+GUARD = str(Path(__file__).with_name("git-protect-guard.py"))
+
+BLOCK = "block"
+ALLOW = "allow"
+
+CASES = [
+    # ---- pre-existing rules (regression: extending the guard must not break them) ----
+    (BLOCK, "git add -A"),
+    (BLOCK, "git add ."),
+    (BLOCK, "git add --all"),
+    (BLOCK, "git add pnpm-lock.yaml"),
+    (BLOCK, "git push --force origin main"),
+    (ALLOW, "git add src/foo.ts"),
+    (ALLOW, "git add -p"),
+    (ALLOW, "git push origin main"),
+    (ALLOW, "git push --force origin my-feature-branch"),
+    # the documented false positive: the rule text quoted inside another command
+    (ALLOW, "curl -d '{\"content\":\"never run git add -A here\"}' http://x"),
+
+    # ---- NEW: git commit -a swallow vector (card 42a2f45d) ----
+    (BLOCK, "git commit -a"),
+    (BLOCK, 'git commit -am "wip"'),
+    (BLOCK, "git commit --all"),
+    (BLOCK, 'git commit -a -m "wip"'),
+    (BLOCK, 'git commit -v -a -m "x"'),
+    (BLOCK, 'git -C /mnt/h/LM_Studio_Workdir/CleanCore commit -am "x"'),
+    (BLOCK, 'bash -c "git commit -am wip"'),
+    # ...but a targeted / message-only / amend commit stays allowed
+    (ALLOW, 'git commit -m "a proper message"'),
+    (ALLOW, "git commit --amend --no-edit"),
+    (ALLOW, "git commit apps/api/src/server.ts"),
+    (ALLOW, 'git -c user.name=x commit -m "msg"'),
+    (ALLOW, 'git commit -m "document the -a / --all footgun"'),  # -a only inside the message
+
+    # ---- NEW: false boundary INSIDE a quoted payload must not false-block (card 42a2f45d) ----
+    (ALLOW, "curl -d '{\"note\":\"do not run; git add -A here\"}' http://x"),
+    (ALLOW, 'echo "step 1; git reset --hard step 2"'),
+    (ALLOW, "curl -d '{\"content\":\"first; then git commit -am done\"}' http://x"),
+    (ALLOW, "curl -d \"{\\\"c\\\":\\\"a; git clean -fd b\\\"}\" http://x"),
+
+    # ---- NEW: destructive whole-tree ops (card 6b532950) ----
+    (BLOCK, "git reset --hard"),
+    (BLOCK, "git reset --hard HEAD~1"),
+    (BLOCK, "git reset --hard origin/main"),
+    (BLOCK, "cd /repo && git reset --hard"),
+    (BLOCK, "git checkout ."),
+    (BLOCK, "git checkout -- ."),
+    (BLOCK, "git restore ."),
+    (BLOCK, "git stash"),
+    (BLOCK, "git stash push"),
+    (BLOCK, "git stash -u"),
+    (BLOCK, "git clean -fd"),
+    (BLOCK, "git clean -f"),
+    (BLOCK, "git clean -fdx"),
+
+    # ---- NEW: the safe forms MUST keep working ----
+    (ALLOW, "git reset src/foo.ts"),           # unstage one file
+    (ALLOW, "git reset"),                       # unstage all -- tree untouched
+    (ALLOW, "git reset --soft HEAD~1"),         # keeps tree + index
+    (ALLOW, "git reset --mixed HEAD~1"),        # keeps tree
+    (ALLOW, "git checkout main"),               # switch branch
+    (ALLOW, "git checkout -b feature/x"),       # new branch
+    (ALLOW, "git checkout HEAD~1 -- apps/api/src/server.ts"),  # targeted restore (used in real work)
+    (ALLOW, "git restore --staged ."),          # unstage only -- does NOT touch the tree
+    (ALLOW, "git stash pop"),
+    (ALLOW, "git stash apply"),
+    (ALLOW, "git stash list"),
+    (ALLOW, "git stash show -p"),
+    (ALLOW, "git stash drop"),
+    (BLOCK, "git checkout -f main"),            # forced switch overwrites local edits
+    (BLOCK, "git checkout --force main"),
+    (BLOCK, 'bash -c "git reset --hard"'),      # one-level wrapper unwrap
+    (BLOCK, "sh -c 'git clean -fd'"),
+    (BLOCK, 'eval "git reset --hard"'),
+    # ---- Cybersec NO-GO + QA FAIL on c9e4b5d: git GLOBAL options / env prefix ----
+    # `git -C <path> <sub>` is the NORMAL cross-repo form -- the guard's own primary scenario.
+    (BLOCK, "git -C /mnt/h/LM_Studio_Workdir/CleanCore reset --hard"),
+    (BLOCK, "git --git-dir=.git reset --hard"),
+    (BLOCK, "GIT_DIR=.git git reset --hard"),
+    (BLOCK, "git -C /mnt/h/CleanCore stash"),
+    (BLOCK, "git -C /repo checkout ."),
+    (BLOCK, "git --work-tree=/repo clean -fd"),
+    (BLOCK, "git -c user.name=x -C /repo reset --hard"),
+    (BLOCK, "GIT_DIR=.git GIT_WORK_TREE=. git clean -fd"),
+    (BLOCK, "git -C /repo add -A"),             # the PRE-EXISTING rules were equally bypassable
+    # ALLOW controls: the global-option skip must not overreach into legitimate commands.
+    (ALLOW, "git -C /mnt/h/LM_Studio_Workdir/CleanCore status"),
+    (ALLOW, "git -c user.name=x commit -m 'msg'"),
+    (ALLOW, "git -C /repo log --oneline -5"),
+    (ALLOW, "git -C /repo reset src/foo.ts"),
+    (ALLOW, "git --no-pager diff"),
+    # ---- Cybersec/QA LOW: a heredoc BODY is data, not a command ----
+    (ALLOW, "cat > t.sh <<'EOF'\ngit checkout .\ngit reset --hard\nEOF"),
+    (ALLOW, "cat > doc.md <<EOF\nNe hasznalj git clean -fd-t a kozos fan!\nEOF"),
+    # ...but a REAL destructive command after a heredoc still blocks
+    (BLOCK, "cat > t.sh <<'EOF'\nharmless\nEOF\ngit reset --hard"),
+    (ALLOW, "git clean -n"),                    # dry run
+    (ALLOW, "git clean --dry-run -d"),
+    (ALLOW, "git status"),
+    (ALLOW, "git diff"),
+    (ALLOW, "git log --oneline -5"),
+    # quoted mentions must not trip the new rules either
+    (ALLOW, "echo 'do not use git reset --hard in a shared checkout'"),
+    (ALLOW, "curl -d '{\"note\":\"git clean -fd wiped the tree\"}' http://x"),
+]
+
+
+def verdict(cmd):
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}})
+    p = subprocess.run(
+        [sys.executable, GUARD], input=payload, capture_output=True, text=True
+    )
+    return (BLOCK if p.returncode == 2 else ALLOW), (p.stderr or "").strip()
+
+
+def main():
+    failures = []
+    for expected, cmd in CASES:
+        got, msg = verdict(cmd)
+        mark = "ok " if got == expected else "FAIL"
+        if got != expected:
+            failures.append((cmd, expected, got, msg))
+        print(f"  [{mark}] {expected:5} {cmd}")
+    print()
+    if failures:
+        print(f"{len(failures)} FAILED:")
+        for cmd, exp, got, msg in failures:
+            print(f"  - {cmd!r}: expected {exp}, got {got}. stderr={msg[:120]}")
+        return 1
+    print(f"All {len(CASES)} cases pass.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/git-protect-guard.selftest.py
+++ b/scripts/hooks/git-protect-guard.selftest.py
@@ -38,7 +38,7 @@ CASES = [
     (BLOCK, "git commit --all"),
     (BLOCK, 'git commit -a -m "wip"'),
     (BLOCK, 'git commit -v -a -m "x"'),
-    (BLOCK, 'git -C /mnt/h/LM_Studio_Workdir/CleanCore commit -am "x"'),
+    (BLOCK, 'git -C /srv/marveen commit -am "x"'),
     (BLOCK, 'bash -c "git commit -am wip"'),
     # ...but a targeted / message-only / amend commit stays allowed
     (ALLOW, 'git commit -m "a proper message"'),
@@ -89,17 +89,17 @@ CASES = [
     (BLOCK, 'eval "git reset --hard"'),
     # ---- Cybersec NO-GO + QA FAIL on c9e4b5d: git GLOBAL options / env prefix ----
     # `git -C <path> <sub>` is the NORMAL cross-repo form -- the guard's own primary scenario.
-    (BLOCK, "git -C /mnt/h/LM_Studio_Workdir/CleanCore reset --hard"),
+    (BLOCK, "git -C /srv/marveen reset --hard"),
     (BLOCK, "git --git-dir=.git reset --hard"),
     (BLOCK, "GIT_DIR=.git git reset --hard"),
-    (BLOCK, "git -C /mnt/h/CleanCore stash"),
+    (BLOCK, "git -C /srv/marveen stash"),
     (BLOCK, "git -C /repo checkout ."),
     (BLOCK, "git --work-tree=/repo clean -fd"),
     (BLOCK, "git -c user.name=x -C /repo reset --hard"),
     (BLOCK, "GIT_DIR=.git GIT_WORK_TREE=. git clean -fd"),
     (BLOCK, "git -C /repo add -A"),             # the PRE-EXISTING rules were equally bypassable
     # ALLOW controls: the global-option skip must not overreach into legitimate commands.
-    (ALLOW, "git -C /mnt/h/LM_Studio_Workdir/CleanCore status"),
+    (ALLOW, "git -C /srv/marveen status"),
     (ALLOW, "git -c user.name=x commit -m 'msg'"),
     (ALLOW, "git -C /repo log --oneline -5"),
     (ALLOW, "git -C /repo reset src/foo.ts"),

--- a/scripts/hooks/secret-write-guard.py
+++ b/scripts/hooks/secret-write-guard.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block writing a LITERAL secret value into a file.
+
+An agent that pastes a real credential into source (a leaked private key, an AWS
+access key, an Anthropic/OpenAI/GitHub/Slack token) is one `git add` away from
+committing it. This guard inspects the CONTENT an agent is about to Write/Edit and
+blocks (exit 2) only on a HIGH-CONFIDENCE literal secret -- a key block or a
+provider token with an unmistakable prefix. It is deliberately narrow:
+
+  - It matches secret VALUES, never references. `cat store/.dashboard-token`,
+    `Bearer $(...)`, `process.env.X`, a `.env.example` placeholder -> NOT a match.
+  - Anything it cannot parse -> FAIL-OPEN (exit 0). A guard that crashes must
+    never wedge the fleet, so every error path allows the write.
+
+Only Write / Edit / MultiEdit carry file content; other tools are ignored. On a
+match it prints the offending pattern name to stderr (shown to the agent) and
+exits 2 so the write is denied and the agent can route the secret to a real
+secret store or reference it by env/id instead.
+"""
+import sys
+import os
+import re
+import json
+
+# High-confidence literal-secret signatures. Each is specific enough that a match
+# is almost never a false positive. Order/name is what the agent sees on block.
+PATTERNS = [
+    ("private key block", re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----")),
+    ("AWS access key id", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("Anthropic API key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}")),
+    ("OpenAI API key", re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9]{40,}")),
+    ("GitHub token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,}")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[0-9A-Za-z-]{10,}")),
+    ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b")),
+    ("Stripe live secret key", re.compile(r"\bsk_live_[0-9A-Za-z]{24,}")),
+]
+
+# Placeholder / example values that legitimately look secret-ish. If the matched
+# span is one of these, it is not a real leak -> allow.
+PLACEHOLDER_RX = re.compile(r"(?:EXAMPLE|XXXX|PLACEHOLDER|YOUR[_-]?|\.\.\.|<[^>]+>)", re.IGNORECASE)
+
+
+def _content_from(tool_name, tool_input):
+    """Extract the text this tool would write into a file, or '' if none."""
+    if not isinstance(tool_input, dict):
+        return ""
+    parts = []
+    # Write
+    if isinstance(tool_input.get("content"), str):
+        parts.append(tool_input["content"])
+    # Edit: the replacement is what lands on disk
+    if isinstance(tool_input.get("new_string"), str):
+        parts.append(tool_input["new_string"])
+    # MultiEdit
+    edits = tool_input.get("edits")
+    if isinstance(edits, list):
+        for e in edits:
+            if isinstance(e, dict) and isinstance(e.get("new_string"), str):
+                parts.append(e["new_string"])
+    return "\n".join(parts)
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # unparseable -> fail open
+
+    tool = payload.get("tool_name") or ""
+    if tool not in ("Write", "Edit", "MultiEdit"):
+        sys.exit(0)
+
+    try:
+        content = _content_from(tool, payload.get("tool_input"))
+    except Exception:
+        sys.exit(0)
+    if not content:
+        sys.exit(0)
+
+    for name, rx in PATTERNS:
+        m = rx.search(content)
+        if not m:
+            continue
+        span = m.group(0)
+        # Skip obvious placeholders/examples.
+        window = content[max(0, m.start() - 20): m.end() + 20]
+        if PLACEHOLDER_RX.search(window):
+            continue
+        sys.stderr.write(
+            "SECRET-WRITE-GUARD: a beirni kivant tartalom valodinak tuno titkot "
+            f"tartalmaz ({name}). A muvelet blokkolva. Ne irj literal kredencialt "
+            "fajlba: hasznalj kornyezeti valtozot / secret store-t, vagy hivatkozz "
+            "id-vel (pl. $(cat store/.dashboard-token)). Ha ez szandekos teszt-adat, "
+            "tedd .env.example-be placeholderrel."
+        )
+        sys.exit(2)  # block
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A #866 kéréstek szerint a három általános guard hookot külön PR-be emeltem ki, **opt-in** formában.

## Mi van benne

Három **PreToolUse** hook egy megosztott, több-ügynökös munkafa dokumentált footgunjaira, mindegyik **fail-open**:

| Hook | `matcher` | Mit blokkol (exit 2) |
|------|-----------|----------------------|
| `git-protect-guard.py` | `Bash` | `git add -A`/`.`; force-push explicit megnevezett védett ágra (`main`/`master`/`develop`); lockfile stage-elése; destruktív egész-fa műveletek (`reset --hard`, `clean -f`, `checkout .`, csupasz `stash`) |
| `secret-write-guard.py` | `Write`/`Edit`/`MultiEdit` | Írásba kerülő **literál** titok (kulcs-blokk / egyértelmű token-előtag). Referenciára (`$(cat ...)`, `process.env.X`, `.env.example`) nem üt |
| `big-file-guard.py` | `Write` | Egyetlen `Write` > `HOOK_MAX_WRITE_BYTES` (alap 2 MB) |

## Miért opt-in (a felvetésetekre)

Jeleztétek, hogy a hookok jelenleg sehol nincsenek bekötve, így „ma szállított, de holt kód" lennének, amit egy későbbi hozzájárulás újra-review nélkül kapcsolhatna be. Ezért:

- **NEM kötöm be automatikusan** (nincs `agent-scaffold`/`sync-hooks` drótozás). A `git-protect-guard` posztúra-döntés (blokkolná pl. a `git add -A`-t, `git reset --hard`-ot), ezt nem erőltetem rá minden telepítésre.
- A bekötés **dokumentált és itt felülvizsgált**: a `docs/guard-hooks.md` pontosan megadja a `.claude/settings.json` `PreToolUse` bejegyzéseket (ugyanabban az alakban, mint az `egress-gate`). Alapból KI, tudatosan kapcsolható BE.

Így az „engedélyezés review nélkül később" nem áll fenn: az enable-út most átmegy a reviewn, de a viselkedés nem változik senkinél alapból.

## Bizonyíték

- `git-protect-guard.selftest.py` → **All 81 cases pass** (exit 0), útvonal-független fixture-ökkel.
- `python -m py_compile` mind a négy fájlra tiszta.
- A hookok tisztán stdin-payloadból dolgoznak, nincs perzisztens állapot és nincs titok a fájlokban; minden hiba-ág fail-open.

## Megjegyzés

A repo meglévő `install-git-guard-hook.sh` (natív git pre-push, force-push tiltás) ettől **független** réteg — az git-szinten véd, ezek a hookok pedig az ügynök tool-hívását fogják el, még a végrehajtás előtt.
