### PR TITLE
fix(channels): the respawn path must read the model from the same place the launch path does

### DIFF
--- a/src/__tests__/main-model-env-precedence.test.ts
+++ b/src/__tests__/main-model-env-precedence.test.ts
@@ -1,0 +1,124 @@
+// Regression tests for the split-brain between the LAUNCH and the RESPAWN path
+// when resolving the main agent's model.
+//
+// Background (2026-08-04): scripts/channels.sh resolves the main model from
+// `.env MAIN_AGENT_MODEL` first and only then from `.claude/settings.json` --
+// deliberately, because .env is gitignored while settings.json is tracked, so an
+// install that wants its own model can set it without dirtying a tracked file
+// (which would otherwise block the update preflight and be reverted by the next
+// update). `readConfiguredMainModel()` in channel-monitor.ts read ONLY
+// settings.json, so the two paths agreed just as long as someone kept both files
+// in sync by hand.
+//
+// Why that is worse than a plain inconsistency: the tracked settings.json ships a
+// model of its own. An update reverts local edits to tracked files, so the very
+// next respawn can hand the main session a DIFFERENT model than the one it
+// launched with -- silently, with no dialog, no error and no log line, while the
+// launch path keeps reporting the intended value.
+//
+// The asserts below lock BOTH sides: the TS behaviour, and the shell function it
+// is supposed to mirror. A future edit that flips the precedence in channels.sh
+// alone would otherwise re-open exactly the same gap from the other direction.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { readConfiguredMainModel, readExtraChannelPluginIds } from '../web/channel-monitor.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CHANNELS_SH = join(__dirname, '..', '..', 'scripts', 'channels.sh')
+
+let root: string
+
+function writeEnv(contents: string): void {
+  writeFileSync(join(root, '.env'), contents)
+}
+
+function writeSettings(obj: unknown): void {
+  mkdirSync(join(root, '.claude'), { recursive: true })
+  writeFileSync(join(root, '.claude', 'settings.json'), JSON.stringify(obj, null, 2))
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'main-model-precedence-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('readConfiguredMainModel', () => {
+  it('prefers .env MAIN_AGENT_MODEL over the tracked .claude/settings.json', () => {
+    writeEnv('SOMETHING_ELSE=1\nMAIN_AGENT_MODEL=claude-opus-5\n')
+    writeSettings({ model: 'claude-opus-4-8[1m]' })
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+
+  it('falls back to settings.json when .env has no MAIN_AGENT_MODEL', () => {
+    writeEnv('CHANNEL_PLUGINS_EXTRA=slack-channel@marveen-marketplace\n')
+    writeSettings({ model: 'claude-opus-4-8[1m]' })
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-4-8[1m]')
+  })
+
+  it('falls back to settings.json when .env is absent entirely', () => {
+    writeSettings({ model: 'claude-opus-5' })
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+
+  // An EMPTY value must not win: `MAIN_AGENT_MODEL=` is how a half-edited .env
+  // looks, and treating it as a real answer would drop the --model flag and hand
+  // the session to claude-code's built-in default -- the drift this function
+  // exists to prevent.
+  it('ignores an empty MAIN_AGENT_MODEL and falls through', () => {
+    writeEnv('MAIN_AGENT_MODEL=\n')
+    writeSettings({ model: 'claude-opus-5' })
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+
+  it('returns empty string when neither source names a model', () => {
+    writeEnv('MAIN_AGENT_MODEL_SOMETHINGELSE=x\n')
+    writeSettings({ enabledPlugins: {} })
+    expect(readConfiguredMainModel(root)).toBe('')
+  })
+
+  it('survives an unparseable settings.json', () => {
+    writeEnv('MAIN_AGENT_MODEL=claude-opus-5\n')
+    mkdirSync(join(root, '.claude'), { recursive: true })
+    writeFileSync(join(root, '.claude', 'settings.json'), '{ not json')
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+})
+
+describe('readExtraChannelPluginIds (shares the same .env reader)', () => {
+  it('still splits a space-separated list', () => {
+    writeEnv('CHANNEL_PLUGINS_EXTRA=slack-channel@marveen-marketplace  discord@x\n')
+    expect(readExtraChannelPluginIds(root)).toEqual([
+      'slack-channel@marveen-marketplace',
+      'discord@x',
+    ])
+  })
+
+  it('returns [] when unset, absent or empty', () => {
+    writeEnv('MAIN_AGENT_MODEL=claude-opus-5\n')
+    expect(readExtraChannelPluginIds(root)).toEqual([])
+  })
+})
+
+describe('scripts/channels.sh resolve_main_model (the path this must mirror)', () => {
+  const sh = readFileSync(CHANNELS_SH, 'utf-8')
+  const fn = sh.slice(sh.indexOf('resolve_main_model() {'))
+
+  it('checks MAIN_AGENT_MODEL before .claude/settings.json', () => {
+    const envIdx = fn.indexOf('MAIN_AGENT_MODEL')
+    const settingsIdx = fn.indexOf('.claude/settings.json')
+    expect(envIdx).toBeGreaterThan(-1)
+    expect(settingsIdx).toBeGreaterThan(-1)
+    expect(envIdx).toBeLessThan(settingsIdx)
+  })
+
+  it('still sources MAIN_AGENT_MODEL from .env', () => {
+    expect(sh).toMatch(/\^MAIN_AGENT_MODEL=.*\$INSTALL_DIR\/\.env/)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -502,13 +502,47 @@ async function triggerMarveenMemorySave(): Promise<void> {
   }
 }
 
-// Read the main agent's configured model from .claude/settings.json so a
-// soft resume passes --model explicitly, mirroring scripts/channels.sh. Without
-// it the respawned session falls back to claude-code's built-in default and
-// silently drifts off the model the user picked. Returns '' when unset.
-function readConfiguredMainModel(): string {
+// Single `KEY=value` lookup in the install's .env, used by the readers below.
+// Deliberately dumb (first matching line, trimmed): it mirrors the `grep -E
+// '^KEY=' | head -1 | cut -d= -f2-` that scripts/channels.sh already does, so
+// both sides read the same file the same way.
+function readEnvValue(projectRoot: string, key: string): string {
   try {
-    const settingsPath = join(PROJECT_ROOT, '.claude', 'settings.json')
+    const envPath = join(projectRoot, '.env')
+    if (!existsSync(envPath)) return ''
+    const line = readFileSync(envPath, 'utf-8')
+      .split('\n')
+      .find((l) => l.startsWith(`${key}=`))
+    return line ? line.slice(key.length + 1).trim() : ''
+  } catch {
+    return ''
+  }
+}
+
+// Read the main agent's configured model so a soft resume passes --model
+// explicitly, mirroring scripts/channels.sh. Without it the respawned session
+// falls back to claude-code's built-in default and silently drifts off the model
+// the user picked. Returns '' when unset.
+//
+// PRECEDENCE MUST MATCH channels.sh resolve_main_model(): .env MAIN_AGENT_MODEL
+// (per-install, gitignored) wins over .claude/settings.json (tracked, shipped
+// with the repo). Reading ONLY settings.json here was a silent split-brain: an
+// install that sets its model the documented way -- in .env, precisely so the
+// tracked file stays clean for the update preflight -- got that choice honoured
+// on the LAUNCH path and ignored on the RESPAWN path. The two only agreed while
+// someone kept both files in sync by hand, and nothing detected the drift.
+//
+// The failure is not hypothetical and not symmetric: the tracked settings.json
+// ships a model of its own, so a respawn after an update (which reverts local
+// edits to tracked files) can silently move the main agent to a DIFFERENT model
+// than the one it launched with -- below the operator's required floor, with no
+// dialog, no error and no log line. The launch path would keep saying the right
+// thing, which is exactly what makes it hard to see.
+export function readConfiguredMainModel(projectRoot: string = PROJECT_ROOT): string {
+  const fromEnv = readEnvValue(projectRoot, 'MAIN_AGENT_MODEL')
+  if (fromEnv) return fromEnv
+  try {
+    const settingsPath = join(projectRoot, '.claude', 'settings.json')
     if (!existsSync(settingsPath)) return ''
     const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'))
     const model = parsed?.model
@@ -530,17 +564,7 @@ function readConfiguredMainModel(): string {
 // Observed in practice: a context-saturation hard restart dropped the secondary
 // inbound for ~20 minutes while the primary channel kept working normally.
 export function readExtraChannelPluginIds(projectRoot: string = PROJECT_ROOT): string[] {
-  try {
-    const envPath = join(projectRoot, '.env')
-    if (!existsSync(envPath)) return []
-    const line = readFileSync(envPath, 'utf-8')
-      .split('\n')
-      .find((l) => l.startsWith('CHANNEL_PLUGINS_EXTRA='))
-    if (!line) return []
-    return line.slice('CHANNEL_PLUGINS_EXTRA='.length).trim().split(/\s+/).filter(Boolean)
-  } catch {
-    return []
-  }
+  return readEnvValue(projectRoot, 'CHANNEL_PLUGINS_EXTRA').split(/\s+/).filter(Boolean)
 }
 
 // Build the claude command used to (re)spawn the main channels session via


### PR DESCRIPTION
## What

`readConfiguredMainModel()` (channel-monitor.ts) now mirrors the precedence that `scripts/channels.sh resolve_main_model()` already uses: `.env MAIN_AGENT_MODEL` wins over the tracked `.claude/settings.json`.

## Why

The two paths disagreed, and the disagreement was silent.

`.env` is gitignored precisely so an install can choose its own main-agent model without dirtying a tracked file (a dirty tracked file blocks the update preflight's clean-tree check and gets reverted by the next update). The launch path honours that. The respawn path did not: it read `settings.json` only, so the two agreed exactly as long as somebody kept both files in sync by hand.

That is worse than a plain inconsistency, because the tracked `settings.json` ships a model of its own and an update reverts local edits to tracked files. The next soft resume can then hand the main session a **different model than the one it launched with** -- no dialog, no error, no log line -- while the launch path keeps reporting the intended value. An operator who requires a minimum model tier is moved below it by a routine update, and nothing in the system says so.

Observed on a live install on 2026-08-04: `.env` named one model, the running session had been started from it, and the tracked `settings.json` still carried the repo default from an earlier release. Nothing had broken yet only because no soft resume had happened since the edit.

## How

- new `readEnvValue(projectRoot, key)` helper, parsing the same way channels.sh does (`grep '^KEY=' | head -1 | cut -d= -f2-`)
- `readConfiguredMainModel()` checks `.env MAIN_AGENT_MODEL` first, then falls back to `settings.json` as before
- `readExtraChannelPluginIds()` reuses the helper (same file, same rule, less duplication)
- an empty `MAIN_AGENT_MODEL=` deliberately does **not** win: a half-edited `.env` would otherwise drop the `--model` flag entirely and hand the session to the CLI's built-in default, which is the drift this function exists to prevent

## Tests

`src/__tests__/main-model-env-precedence.test.ts`, 10 cases. They lock **both** sides -- the TS precedence and the shell function it mirrors -- so flipping the order in `channels.sh` alone re-opens the gap loudly instead of silently.

Verified as a real regression guard, not just green: with the `.env` branch removed the suite fails 2/10 in exactly the intended places, and passes 10/10 with it.

`npx tsc --noEmit` clean.

Note on the wider suite: on this branch `npx vitest run` reports 19 failures in 4 files (`email-send-gate`, `governance-gates`, `hook-command-quoting`, `hook-path-guard`). I measured a pristine `origin/develop` checkout at the same commit (8df36ff) and it reports the **same 19 failures in the same 4 files**, so they are pre-existing and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)