### PR TITLE
fix(pane-state): a session with queued messages is busy, not idle

### DIFF
--- a/src/__tests__/queued-messages-not-idle.test.ts
+++ b/src/__tests__/queued-messages-not-idle.test.ts
@@ -1,0 +1,107 @@
+// Regression tests for the 2026-08-04 "queued messages read as idle" misread.
+//
+// Claude Code holds prompts typed during a running turn in a QUEUE: the queued
+// lines render above the input box and the box itself shows the DIM hint
+// "Press up to edit queued messages". Before this fix that shape classified as
+// 'typing' (parked text), and idleConsideringDimGhost -- which exists to
+// tolerate the dim autocomplete ghost -- stripped the hint and rescued the pane
+// to 'idle'. Every writer (inbox-nudge watcher, scheduler, router, keepalive)
+// then treated a session with unprocessed input as free and typed another line
+// into the same queue.
+//
+// Observed: the main agent ran a single 32-minute turn while three inbox nudges
+// were "sent" into it five minutes apart. All three queued unprocessed, and the
+// watcher escalated to the OWNER claiming a broken drain hook / wedged session.
+// Nothing was broken and no message was lost -- the session was simply busy.
+//
+// The captures below are trimmed from the real pane.
+
+import { describe, it, expect } from 'vitest'
+import { detectPaneState, paneLooksIdle, idleConsideringDimGhost } from '../pane-state.js'
+
+// Live turn + one queued message. Note where the spinner sits: with the queued
+// block rendered it is pushed up, which is why the busy-spinner check alone
+// cannot be relied on to catch this state.
+const QUEUED_WHILE_BUSY = [
+  '           őségét mérlegelnéd. Amit így kaptam: 25 nyitott Lieferschein',
+  '',
+  '❯ [inbox-wakeup: pending inter-agent messages]',
+  '',
+  '  Running 1 shell command…',
+  '',
+  '✳ Forming… (32m 37s · ↓ 76.1k tokens)',
+  '  ⎿  Tip: Use /clear to start fresh when switching topics and free up context',
+  '',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '❯ Press up to edit queued messages',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  Opus 5 · ctx 406k/1.0M · 41%',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents',
+].join('\n')
+
+// Same shape with the spinner scrolled out of the busy window entirely -- the
+// state must still be busy on the strength of the queue hint alone.
+const QUEUED_NO_SPINNER = [
+  '  ⎿  … tool output …',
+  '',
+  '❯ [inbox-wakeup: pending inter-agent messages]',
+  '',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '❯ Press up to edit queued messages',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  Opus 5 · ctx 406k/1.0M · 41%',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents',
+].join('\n')
+
+const GENUINELY_IDLE = [
+  '  ⎿  … tool output …',
+  '',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '❯ ',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  Opus 5 · ctx 406k/1.0M · 41%',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents',
+].join('\n')
+
+// SELF-CONTAMINATION control: an incident report (or this very test file, or a
+// chat log) quoting the hint lands in the scrollback of some agent's pane. That
+// pane is idle and MUST stay idle -- the check is box-scoped for this reason.
+const IDLE_WITH_HINT_QUOTED_IN_SCROLLBACK = [
+  '  ⎿  jelentes: a doboz ilyenkor a "Press up to edit queued messages"',
+  '     szoveget mutatja, ezert olvasta tetlennek a felugyelo.',
+  '',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '❯ ',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  Opus 5 · ctx 406k/1.0M · 41%',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents',
+].join('\n')
+
+describe('queued messages are not idle', () => {
+  it('classifies a live turn with a queued message as busy', () => {
+    expect(detectPaneState(QUEUED_WHILE_BUSY)).toBe('busy')
+    expect(paneLooksIdle(QUEUED_WHILE_BUSY)).toBe(false)
+  })
+
+  it('stays busy even when the spinner is out of the busy window', () => {
+    expect(detectPaneState(QUEUED_NO_SPINNER)).toBe('busy')
+  })
+
+  // The heart of the bug: the hint is dim, so the ghost-tolerant readiness
+  // check used to strip it and call the session ready. Passing an
+  // already-stripped view must NOT rescue a queued pane.
+  it('is not rescued by the dim-ghost tolerance', () => {
+    const dimStripped = QUEUED_NO_SPINNER.replace('❯ Press up to edit queued messages', '❯ ')
+    expect(idleConsideringDimGhost(QUEUED_NO_SPINNER, dimStripped)).toBe(false)
+  })
+
+  it('leaves a genuinely idle pane idle', () => {
+    expect(detectPaneState(GENUINELY_IDLE)).toBe('idle')
+    expect(idleConsideringDimGhost(GENUINELY_IDLE, null)).toBe(true)
+  })
+
+  it('does not pin a pane busy because the hint appears in scrollback', () => {
+    expect(detectPaneState(IDLE_WITH_HINT_QUOTED_IN_SCROLLBACK)).toBe('idle')
+    expect(idleConsideringDimGhost(IDLE_WITH_HINT_QUOTED_IN_SCROLLBACK, null)).toBe(true)
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -237,6 +237,28 @@ const BOX_SEP_RX = /^─{10,}/
 // admitting the NBSP and any other horizontal Unicode space the TUI emits.
 const PARKED_INPUT_RX = /❯[^\S\r\n]+\S/
 
+// QUEUED MESSAGES: Claude Code holds prompts typed during a running turn in a
+// queue and renders them ABOVE the box, putting this hint INSIDE the (otherwise
+// empty) live input box. The hint is DIM, exactly like the autocomplete ghost,
+// so idleConsideringDimGhost strips it and the pane reads 'idle' -- while the
+// session in fact has unprocessed input waiting. Every writer (nudge watcher,
+// scheduler, router, keepalive) then believes the session is free and types
+// ANOTHER line, which just joins the queue.
+//
+// Observed 2026-08-04: the main agent ran one 32-minute turn; three inbox
+// nudges were "sent" into it 5 minutes apart, all three queued unprocessed,
+// and the watcher escalated to the owner claiming a broken drain hook -- while
+// nothing was broken and no message was lost. The second half of the misread
+// is that with the queued block rendered, the busy spinner is pushed to the
+// edge of (and sometimes past) the BUSY_LIVE_REGION_LINES window, so the
+// spinner check cannot be relied on to catch this state either.
+//
+// MUST stay scoped to the live input box, never whole-pane: an incident report
+// or a chat log quoting this very sentence would otherwise pin an idle session
+// busy forever (the same self-contamination that made the `esc to interrupt`
+// check region-scoped above).
+const QUEUED_MESSAGES_HINT_RX = /Press up to edit queued messages/
+
 // Strip Claude Code's DIM (SGR 2) "ghost suggestion" autocomplete from a
 // COLOURED pane capture (`tmux capture-pane -e -p`), then remove every
 // remaining ANSI escape, yielding plain text equivalent to `capture-pane -p`
@@ -639,6 +661,12 @@ export function detectPaneState(
     }
     if (topSep >= 0 && bottomSep > topSep) {
       const inputLines = lines.slice(topSep + 1, bottomSep)
+      // Queued messages first: the hint lives in the box and would otherwise
+      // read as parked text ('typing'), which idleConsideringDimGhost then
+      // rescues to 'idle' because the hint is dim -- the exact false-ready
+      // path this guards. 'busy' is the honest answer: input IS waiting, it
+      // just isn't ours to submit. See QUEUED_MESSAGES_HINT_RX.
+      if (inputLines.some(l => QUEUED_MESSAGES_HINT_RX.test(l))) return 'busy'
       if (inputLines.some(l => PARKED_INPUT_RX.test(l))) {
         return opts.mergeTypingAsBusy ? 'busy' : 'typing'
       }


### PR DESCRIPTION
## What

`detectPaneState` now returns `busy` when the live input box shows Claude Code's queued-message hint, instead of letting the dim-ghost tolerance rescue that pane to `idle`.

## Why

Claude Code queues prompts typed during a running turn: the queued lines render above the box, and the box itself shows the dim hint `Press up to edit queued messages`.

That shape classified as `typing` (parked text), and `idleConsideringDimGhost` -- which exists to tolerate the dim autocomplete ghost -- stripped the hint and rescued it to `idle`. A session with unprocessed input waiting therefore read as **free**, so every writer (inbox-nudge watcher, scheduler, router, keepalive) typed another line into the same queue. The busy-spinner check does not catch it either: with the queued block rendered, the spinner is pushed to the edge of the `BUSY_LIVE_REGION_LINES` window.

Observed on a live install on 2026-08-04. The main agent ran a single **32-minute** turn (a GUI automation run) while three inbox nudges were "sent" into it five minutes apart. All three queued unprocessed, and the nudge watcher escalated to the **owner**, naming a broken drain hook, an install path mismatch or a wedged session as likely causes. All three were wrong: nothing was broken, nothing was lost, and the pending mail drained by itself when the turn ended. The owner got an alarm for an agent doing exactly what it had been asked to do.

Note the alarm is not silenced by this change -- its false cause is removed. A genuinely wedged drain still escalates.

## How

One box-scoped check placed before the parked-text branch, so the dim-ghost rescue never runs on this shape. `busy` is the honest answer: input **is** waiting, it just isn't ours to submit.

The check must stay scoped to the live input box, never whole-pane: an incident report or a chat log quoting the hint (this PR body does) would otherwise pin an idle session busy forever -- the same self-contamination that made the `esc to interrupt` check region-scoped.

## Tests

`src/__tests__/queued-messages-not-idle.test.ts`, 5 cases: the real captured pane, a variant with the spinner outside the busy window, an explicit assert that the dim-ghost tolerance does not rescue it, a genuinely idle control, and a self-contamination control proving the hint quoted in **scrollback** leaves an idle pane idle.

Verified as a real regression guard, not just green: without the fix 3 of the 5 fail.

`npx tsc --noEmit` clean. The wider suite reports the same 19 pre-existing failures in 4 files (`email-send-gate`, `governance-gates`, `hook-command-quoting`, `hook-path-guard`) that a pristine `origin/develop` checkout at 8df36ff reports; untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)