### PR TITLE
fix(kanban): an agent picking up its own card got the task dispatched back at it

### DIFF
--- a/src/__tests__/kanban-dispatch-instructions.test.ts
+++ b/src/__tests__/kanban-dispatch-instructions.test.ts
@@ -20,6 +20,15 @@ describe('kanbanMoveInstructions', () => {
     expect(out).not.toContain('húzd "done"-ra')
   })
 
+  // Without an actor the board cannot tell a self-pickup from an assignment, so
+  // every move curl the agent is handed names the agent as the mover -- including
+  // the in_progress self-pickup, which is the one the dispatcher used to echo back.
+  it('names the agent as the actor on every move it is told to make', () => {
+    const out = kanbanMoveInstructions('abc123', 'cody')
+    expect(out).toContain('"status":"done","actor":"cody"')
+    expect(out).toContain('"status":"in_progress","actor":"cody"')
+  })
+
   it('keeps the bearer token out of the message (reads it at run time)', () => {
     const out = kanbanMoveInstructions('abc123', 'cody')
     expect(out).toContain('$(cat ')

--- a/src/__tests__/kanban-dispatch.test.ts
+++ b/src/__tests__/kanban-dispatch.test.ts
@@ -46,4 +46,38 @@ describe('resolveKanbanDispatchTarget', () => {
   it('returns null for an unknown assignee name', () => {
     expect(resolveKanbanDispatchTarget('SomebodyElse', base)).toBeNull()
   })
+
+  // The echo bug: an agent that moves its own card to in_progress got the task
+  // dispatched back at it as a fresh assignment, indistinguishable from real work.
+  describe('self-move', () => {
+    it('does not dispatch when the mover is the assignee', () => {
+      expect(resolveKanbanDispatchTarget('tuskohopkins', { ...base, actor: 'tuskohopkins' })).toBeNull()
+      expect(resolveKanbanDispatchTarget('GorcsevIvan', { ...base, actor: 'gorcsevivan' })).toBeNull()
+    })
+
+    it('matches the mover against the assignee across name forms and casing', () => {
+      // display name vs canonical id, and either side upper/lower cased
+      expect(resolveKanbanDispatchTarget('gorcsevivan', { ...base, actor: 'GorcsevIvan' })).toBeNull()
+      expect(resolveKanbanDispatchTarget('TuskoHopkins', { ...base, actor: 'tuskohopkins' })).toBeNull()
+    })
+
+    it('still dispatches when somebody else moved the card', () => {
+      expect(resolveKanbanDispatchTarget('tuskohopkins', { ...base, actor: 'Gábor' })).toBe('tuskohopkins')
+      expect(resolveKanbanDispatchTarget('tuskohopkins', { ...base, actor: 'gorcsevivan' })).toBe('tuskohopkins')
+    })
+
+    it('dispatches as before when the mover is unknown or not reported', () => {
+      // Legacy callers send no actor at all -- the rule must be inert, not blocking.
+      expect(resolveKanbanDispatchTarget('tuskohopkins', base)).toBe('tuskohopkins')
+      expect(resolveKanbanDispatchTarget('tuskohopkins', { ...base, actor: null })).toBe('tuskohopkins')
+      expect(resolveKanbanDispatchTarget('tuskohopkins', { ...base, actor: '  ' })).toBe('tuskohopkins')
+      expect(resolveKanbanDispatchTarget('tuskohopkins', { ...base, actor: 'SomebodyElse' })).toBe('tuskohopkins')
+    })
+
+    // A stopped sub-agent moving its own card is still a self-move: the
+    // no-dispatch decision must not hinge on whether the session happens to be up.
+    it('recognises a self-move even when the agent session is not running', () => {
+      expect(resolveKanbanDispatchTarget('sentinel', { ...base, actor: 'sentinel' })).toBeNull()
+    })
+  })
 })

--- a/src/kanban-dispatch.ts
+++ b/src/kanban-dispatch.ts
@@ -13,6 +13,14 @@
 //   - a sub-agent, ONLY if its session is running -> that agent's id
 //     (a non-running sub-agent is a silent no-op; the card just stays in
 //      in_progress rather than queuing a message for a session that isn't up)
+//   - the mover IS the assignee (self-move) -> null (no echo)
+//
+// The self-move rule exists because an agent that picks up its own card does
+// not need to be told to start what it just started: the dispatch would arrive
+// as a fresh "[Kanban feladat #...]" assignment for work already in flight, and
+// an agent has no way to tell that echo apart from a real, new assignment. The
+// mover's identity travels as `actor` on POST /api/kanban/:id/move; when the
+// caller does not send one the rule is inert and dispatch behaves as before.
 
 export interface DispatchResolveOpts {
   ownerName: string
@@ -20,27 +28,41 @@ export interface DispatchResolveOpts {
   mainAgentId: string
   agentNames: string[]
   isRunning: (name: string) => boolean
+  /** Who moved the card (kanban_card_events.actor). Omitted -> no self-move check. */
+  actor?: string | null
+}
+
+// Map any human-typed reference (display name, canonical id, any casing) onto
+// the id the dispatcher works with, or null when it names nobody dispatchable.
+// Deliberately ignores isRunning: this answers "who is this", not "can we reach
+// them" -- a self-move must be recognised as such whether or not the session is up.
+function canonicalAgentId(
+  ref: string | null | undefined,
+  opts: DispatchResolveOpts,
+): string | null {
+  const a = (ref ?? '').trim()
+  if (!a) return null
+  const lower = a.toLowerCase()
+  if (a === opts.ownerName) return null
+  if (lower === opts.botName.toLowerCase() || lower === opts.mainAgentId.toLowerCase()) {
+    return opts.mainAgentId
+  }
+  return opts.agentNames.find((n) => n.toLowerCase() === lower) ?? null
 }
 
 export function resolveKanbanDispatchTarget(
   assignee: string | null | undefined,
   opts: DispatchResolveOpts,
 ): string | null {
-  const a = (assignee ?? '').trim()
-  if (!a) return null
-  const lower = a.toLowerCase()
+  const target = canonicalAgentId(assignee, opts)
+  if (!target) return null
 
-  // Human owner never triggers an agent.
-  if (a === opts.ownerName) return null
+  // Self-move: the agent that moved the card is the one we would wake.
+  const mover = canonicalAgentId(opts.actor, opts)
+  if (mover && mover === target) return null
 
-  // Bot / main agent (matched by display name or canonical id) -> main session.
-  if (lower === opts.botName.toLowerCase() || lower === opts.mainAgentId.toLowerCase()) {
-    return opts.mainAgentId
-  }
-
-  // Sub-agent: case-insensitive name match, dispatched only if it is running.
-  const match = opts.agentNames.find((n) => n.toLowerCase() === lower)
-  if (match && opts.isRunning(match)) return match
-
-  return null
+  // The main agent always has a session; a sub-agent is dispatched only if its
+  // session is running (otherwise the card just stays in in_progress).
+  if (target === opts.mainAgentId) return target
+  return opts.isRunning(target) ? target : null
 }

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -60,7 +60,17 @@ export function kanbanMoveInstructions(id: string, target: string): string {
     `  curl -s -X POST ${moveUrl} \\`,
     `    ${auth} \\`,
     `    -H 'Content-Type: application/json' \\`,
-    `    -d '{"status":"done"}'`,
+    `    -d '{"status":"done","actor":"${target}"}'`,
+    '',
+    // The "actor" field is not decoration: it is what tells the board WHO moved
+    // the card. Without it a self-pickup (agent -> in_progress on its own card)
+    // is indistinguishable from an assignment, and the dispatcher echoes the
+    // task back at the agent that just started it.
+    `Az "actor":"${target}" mezőt MINDEN mozgatásnál küldd el (ez mondja meg a táblának, hogy te mozgattad). Ha te magad veszed fel a kártyát in_progress-re, ott is:`,
+    `  curl -s -X POST ${moveUrl} \\`,
+    `    ${auth} \\`,
+    `    -H 'Content-Type: application/json' \\`,
+    `    -d '{"status":"in_progress","actor":"${target}"}'`,
     '',
     `Ha elakadtál / ${escalateTo} döntésére/lépésére vársz: NE csak status="waiting"-et állíts be. HÁROM lépés kell EGYÜTT:`,
     `  a) Írj egy kommentet ami KÖZVETLENÜL ${escalateTo}-hez szól, egyértelműen megfogalmazva mit kell eldöntenie/megtennie (NE a saját belső elemzésedet írd oda) -- ugyanaz a comments hívás mint fent, "content" mezőben.`,
@@ -81,7 +91,9 @@ export function kanbanMoveInstructions(id: string, target: string): string {
 // assigned agent once via the inter-agent message router (createAgentMessage),
 // which gives retry / dedup / trust-wrapping / busy-receiver handling for free.
 // dispatched_at is the once-only guard; errors never block the card move.
-function fireKanbanDispatch(id: string): void {
+// `actor` is the mover reported by the caller: an agent that moves its own card
+// to in_progress must not be woken with an assignment for work it just started.
+function fireKanbanDispatch(id: string, actor?: string | null): void {
   try {
     const card = getKanbanCard(id)
     if (!card || card.dispatched_at) return
@@ -91,6 +103,7 @@ function fireKanbanDispatch(id: string): void {
       mainAgentId: MAIN_AGENT_ID,
       agentNames: listAgentNames(),
       isRunning: isAgentRunning,
+      actor,
     })
     if (!target) return
     const desc = (card.description ?? '').trim()
@@ -272,8 +285,9 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
     const body = await readBody(req)
     const { status, sort_order, actor } = JSON.parse(body.toString())
     if (moveKanbanCard(id, status, sort_order ?? 0, actor)) {
-      // Wake the assigned agent once when the card enters in_progress.
-      if (status === 'in_progress') fireKanbanDispatch(id)
+      // Wake the assigned agent once when the card enters in_progress -- unless
+      // that agent is the one who moved it (self-pickup needs no wake-up).
+      if (status === 'in_progress') fireKanbanDispatch(id, actor)
       json(res, { ok: true })
       return true
     }

--- a/web/app.js
+++ b/web/app.js
@@ -1544,6 +1544,14 @@ function createCardEl(card, embeddedChildren = []) {
   return el
 }
 
+// Every move made from this dashboard is made by the human at the keyboard, so
+// each /move call names the owner as `actor`. That is what lets the backend tell
+// an assignment ("the owner dragged this onto you") apart from a self-pickup ("the
+// agent moved its own card"), and only wake the agent in the first case. Falls
+// back to undefined until /api/marveen has loaded -- an unnamed mover means the
+// backend dispatches as it always did, never the opposite.
+function kanbanMoveActor() { return window._marveen?.ownerName || undefined }
+
 // === Drag & Drop ===
 // Wires the drag/drop handlers for one column-body element. Used for the
 // 4 static flat-board columns at load time, and again for every swimlane
@@ -1585,7 +1593,7 @@ function wireKanbanColumnDnD(col) {
       await fetch(`/api/kanban/${encodeURIComponent(cardId)}/move`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: newStatus, sort_order: sortOrder }),
+        body: JSON.stringify({ status: newStatus, sort_order: sortOrder, actor: kanbanMoveActor() }),
       })
       loadKanban()
     } catch {
@@ -1751,7 +1759,7 @@ async function kanbanTouchEnd(e) {
     const r = await fetch(`/api/kanban/${encodeURIComponent(cardId)}/move`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status: newStatus, sort_order: sortOrder }),
+      body: JSON.stringify({ status: newStatus, sort_order: sortOrder, actor: kanbanMoveActor() }),
     })
     if (!r.ok) throw new Error('move failed')
     loadKanban()
@@ -2051,7 +2059,7 @@ async function showCardDetail(card) {
         const r = await fetch(`/api/kanban/${encodeURIComponent(card.id)}/move`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ status: newVal, sort_order: 0 }),
+          body: JSON.stringify({ status: newVal, sort_order: 0, actor: kanbanMoveActor() }),
         })
         if (!r.ok) throw new Error('move failed')
         card.status = newVal


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

**HU.** Amikor egy kártya `in_progress`-re kerül, a dashboard felébreszti a felelős ágenst egy `[Kanban feladat #...]` üzenettel. Eddig semmi nem nézte meg, KI mozgatta a kártyát -- így az az ágens, amelyik maga vette fel a saját kártyáját, kapott egy kiosztást a már elkezdett munkára. Az ágens ezt nem tudja megkülönböztetni egy valódi, új kiosztástól. Az elmúlt 7 napban 7-szer sült el, és egy esetben fél óra munkát vitt rossz irányba.

A `kanban_card_events.actor` mező már létezett és rögzült is, de **egyetlen hívó sem töltötte ki**: a dashboard mindhárom mozgatási útvonala és az ágensnek adott parancs is üresen hagyta (7 nap: 95 üres sor, 13 kitöltött -- és a 13 mind egyetlen mellékes hívótól jött). A mező tehát addig nem lehetett megkülönböztető jel, amíg valóban ki nem töltjük.

A javítás három rétegű:

- `resolveKanbanDispatchTarget` megkapja a mozgatót, és önmozgatásnál `null`-t ad. A megjelenített név és a kanonikus azonosító egymásnak megfeleltetve, kis-nagybetűtől függetlenül. Az `isRunning` szándékosan nem játszik bele: egy leállt ágens önmozgatása is önmozgatás.
- Az ágensnek adott move-utasítás minden hívásnál megnevezi az ágenst `actor`-ként, beleértve az `in_progress` önfelvételt -- pont azt, amelyik a visszhangot okozta.
- A dashboard mindhárom mozgatási útvonala (asztali drop, érintés-drop, részlet-nézet státusz-választó) a tulajdonost küldi mozgatóként.

Visszafelé kompatibilis: ismeretlen vagy nem küldött `actor` esetén a viselkedés pontosan a régi. Egy hiányzó adat nem némíthat el egy valódi kiosztást.

**EN.** Moving a card to `in_progress` wakes the assigned agent. Nothing checked who did the moving, so an agent picking up its own card was woken with an assignment for work already in flight -- indistinguishable from a real one (7 echoes in 7 days, one of which sent half an hour of work in the wrong direction). `kanban_card_events.actor` already existed but no caller filled it (95 empty rows vs 13 filled, all 13 from one incidental caller), so it could not act as the discriminator until it was actually populated. The fix populates it in all three dashboard paths and in the agent's own move instructions, and makes the dispatcher skip a self-move. Unknown or unreported movers dispatch exactly as before.

## Kapcsolódó issue / Related issue

Nincs / none.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

### Mérés / Measurements

- Teljes tesztcsomag (külön worktree, node@22): `origin/develop` alap **19 bukás / 3269 zöld** -> javítással **19 bukás / 3275 zöld**. A 19 előre létező és hook-útvonal jellegű (`email-send-gate`, `governance-gates`, `hook-command-quoting`, `hook-path-guard`), nincs köze a kanbanhoz; a +6 az új teszt.
- `npx tsc --noEmit` és `npm run syntax-check`: tiszta.
- Élő dashboard, részlet-nézet státusz-választó: a mozgatás után `kanban_card_events` sora `actor = Zoltán` (korábban `NULL`). A `docs/` nem érintett: a változás sem a telepítést, sem az architektúrát nem módosítja.
