### PR TITLE
feat(desktop-lock): make the "I am driving the screen" lock something the scheduler can see

### DIFF
--- a/src/__tests__/desktop-lock-gate.test.ts
+++ b/src/__tests__/desktop-lock-gate.test.ts
@@ -25,6 +25,7 @@ import {
   decideDesktopGate, lockExpiresAt, readDesktopLock, writeDesktopLock, clearDesktopLock,
   recordDesktopSkip, TTL_GRACE_MS, DEFAULT_ESTIMATE_MS, type DesktopLock, type DesktopSkipRecord,
 } from '../web/desktop-lock.js'
+import { parseLockBody } from '../web/routes/desktop-lock.js'
 
 const NOW = 1_785_855_000_000
 
@@ -207,6 +208,51 @@ describe('broadcast marker shape', () => {
 //
 // Locked by a test rather than by line numbers in a runbook: the numbers drift the
 // first time someone edits the file, and a drifted reference reads as fact.
+describe('POST body keys: a misspelled key must not pass silently', () => {
+  // The real incident, 2026-08-05: `estimateMinutes` (no "d") was accepted, the
+  // key fell out of the typeof test, and the lock went out with the 30-minute
+  // DEFAULT for a round estimated at 2 minutes. The cost is skipped
+  // screen-requiring rounds, so this is the case the fix exists for.
+  it('flags the estimateMinutes -> estimatedMinutes slip as a typo', () => {
+    const r = parseLockBody({ owner: 'janna', estimateMinutes: 2 })
+    expect(r.typo).toEqual({ sent: 'estimateMinutes', meant: 'estimatedMinutes' })
+    expect(r.minutes).toBeNull() // still dropped -- which is exactly why we refuse
+  })
+
+  it('catches a case-only slip too', () => {
+    expect(parseLockBody({ owner: 'janna', estimatedminutes: 2 }).typo?.meant)
+      .toBe('estimatedMinutes')
+  })
+
+  // NEGATIVE CONTROL: without it, a rule that flags everything would pass the
+  // test above while making the endpoint unusable.
+  it('accepts the correctly spelled body with no typo and no unknown keys', () => {
+    const r = parseLockBody({ owner: 'janna', estimatedMinutes: 2, note: 'WAWI' })
+    expect(r.typo).toBeUndefined()
+    expect(r.unknownKeys).toEqual([])
+    expect(r.minutes).toBe(2)
+    expect(r.note).toBe('WAWI')
+  })
+
+  it('reports an unrelated extra key but does NOT call it a typo', () => {
+    // A caller sending a harmless extra field must not be locked out of the
+    // screen -- but the key must not be invisible either.
+    const r = parseLockBody({ owner: 'janna', estimatedMinutes: 5, requestId: 'abc' })
+    expect(r.typo).toBeUndefined()
+    expect(r.unknownKeys).toEqual(['requestId'])
+    expect(r.minutes).toBe(5)
+  })
+
+  it('every key the four lock skills send is a known key', () => {
+    // The docs were right and the caller was wrong (janna wrote the key from
+    // memory). This pins the docs' side so a later rename cannot drift.
+    for (const k of ['owner', 'note', 'estimatedMinutes']) {
+      expect(parseLockBody({ owner: 'x', [k]: k === 'estimatedMinutes' ? 1 : 'v' }).unknownKeys)
+        .toEqual([])
+    }
+  })
+})
+
 describe('state-before-broadcast ordering', () => {
   const src = readFileSync(
     join(__dirname, '..', 'web', 'routes', 'desktop-lock.ts'), 'utf-8',

--- a/src/__tests__/desktop-lock-gate.test.ts
+++ b/src/__tests__/desktop-lock-gate.test.ts
@@ -17,6 +17,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 import {
   decideDesktopGate, lockExpiresAt, readDesktopLock, writeDesktopLock, clearDesktopLock,
   recordDesktopSkip, TTL_GRACE_MS, DEFAULT_ESTIMATE_MS, type DesktopLock, type DesktopSkipRecord,
@@ -151,5 +155,42 @@ describe('skip records', () => {
   it('never throws on an unwritable path -- losing the trail beats losing the run loop', () => {
     expect(() => recordDesktopSkip(rec(), join(dir, 'no', 'such', 'dir', 'x.json'))).not.toThrow()
     expect(existsSync(join(dir, 'no'))).toBe(false)
+  })
+})
+
+// The broadcast marker must stay BARE: `[DESKTOP-LOCK]` / `[DESKTOP-FREE]` with any
+// qualifier AFTER the closing bracket. Peers scan for these with a start-anchored
+// `content LIKE '[DESKTOP-LOCK...'`, and a qualifier moved INSIDE the brackets silently
+// defeats the bracket-closing variant of that pattern.
+//
+// Measured on 2026-08-04: a lock announced as `[DESKTOP-LOCK -- on behalf of the owner]`
+// returned ZERO hits from a peer's `LIKE '[DESKTOP-LOCK]%'` check. The strictest lock of
+// the day was the one the detector could not see, and the peer nearly started a browser
+// round on top of the human owner's live session.
+//
+// A static source assert, mirroring the other structural-invariant tests in this suite:
+// the shape has to hold for every message the route can emit, and enumerating them
+// through the HTTP handler would test less for more setup.
+describe('broadcast marker shape', () => {
+  const src = readFileSync(
+    join(__dirname, '..', 'web', 'routes', 'desktop-lock.ts'), 'utf-8',
+  )
+
+  it('never puts a qualifier inside the marker brackets', () => {
+    // Scan CODE only: the comment above the constant quotes the broken shape on
+    // purpose (that is what makes the comment useful), and a scan that cannot
+    // tell code from prose would either fail forever or force the explanation out.
+    const code = src
+      .split('\n')
+      .filter(l => !l.trimStart().startsWith('//') && !l.trimStart().startsWith('*'))
+      .join('\n')
+    const bad = [...code.matchAll(/\[DESKTOP-(LOCK|FREE)(?!\])/g)]
+      .map(m => code.slice(m.index, (m.index ?? 0) + 60))
+    expect(bad).toEqual([])
+  })
+
+  it('still emits both markers', () => {
+    expect(src).toContain('[DESKTOP-LOCK]')
+    expect(src).toContain('[DESKTOP-FREE]')
   })
 })

--- a/src/__tests__/desktop-lock-gate.test.ts
+++ b/src/__tests__/desktop-lock-gate.test.ts
@@ -1,0 +1,155 @@
+// Desktop-lock gate: only screen-driving rounds wait, the skip is recorded,
+// and the lock expires.
+//
+// Background: the fleet's "I am driving the screen" lock was a convention --
+// a broadcast the other agents were expected to respect. The scheduler could
+// not respect anything, so it fired GUI rounds into a session already driving
+// the same screen. Making it machine-readable brought three requirements, and
+// each one has a test below:
+//
+//   1. Only tasks that NEED the desktop wait. A blanket suspension would
+//      produce blanket silence, and silence is what nobody questions.
+//   2. A skipped round is never silent -- an untraced dropped tick looks
+//      exactly like "there was nothing to do".
+//   3. The lock expires, or one dead holder parks the fleet indefinitely.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  decideDesktopGate, lockExpiresAt, readDesktopLock, writeDesktopLock, clearDesktopLock,
+  recordDesktopSkip, TTL_GRACE_MS, DEFAULT_ESTIMATE_MS, type DesktopLock, type DesktopSkipRecord,
+} from '../web/desktop-lock.js'
+
+const NOW = 1_785_855_000_000
+
+function lock(over: Partial<DesktopLock> = {}): DesktopLock {
+  return {
+    owner: 'janna',
+    acquiredAt: NOW,
+    estimatedEndAt: NOW + 20 * 60_000,
+    estimateProvided: true,
+    ...over,
+  }
+}
+
+let dir: string
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'desktop-lock-')) })
+afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+describe('decideDesktopGate', () => {
+  it('lets a task that does not need the screen run under a live lock', () => {
+    const d = decideDesktopGate({ requiresDesktop: false, lock: lock(), now: NOW + 60_000, agent: 'taric' })
+    expect(d.action).toBe('run')
+  })
+
+  it('runs when nobody holds the lock', () => {
+    expect(decideDesktopGate({ requiresDesktop: true, lock: null, now: NOW, agent: 'taric' }).action).toBe('run')
+  })
+
+  it('skips a screen-driving task while someone else holds the lock', () => {
+    const d = decideDesktopGate({ requiresDesktop: true, lock: lock(), now: NOW + 60_000, agent: 'taric' })
+    expect(d.action).toBe('skip')
+    expect(d.lockOwner).toBe('janna')
+    // The reason is written verbatim into the skip record, so it has to carry
+    // the two facts a later reader needs: who, and for how long.
+    expect(d.reason).toContain('janna')
+    expect(d.reason).toMatch(/\d+ more min/)
+  })
+
+  // The holder must not be blocked by its own lock -- that would deadlock the
+  // very round the lock was taken for.
+  it('does not gate the holder against itself', () => {
+    const d = decideDesktopGate({ requiresDesktop: true, lock: lock(), now: NOW + 60_000, agent: 'janna' })
+    expect(d.action).toBe('run')
+  })
+
+  it('opens the gate once the lock expires, and says so', () => {
+    const l = lock()
+    const d = decideDesktopGate({ requiresDesktop: true, lock: l, now: lockExpiresAt(l) + 60_000, agent: 'taric' })
+    expect(d.action).toBe('run-lock-expired')
+    expect(d.reason).toContain('expired')
+    expect(d.reason).toContain('janna')
+  })
+
+  it('still holds during the grace period, not only until the estimate', () => {
+    const l = lock()
+    const justAfterEstimate = (l.estimatedEndAt as number) + 60_000
+    expect(decideDesktopGate({ requiresDesktop: true, lock: l, now: justAfterEstimate, agent: 'taric' }).action)
+      .toBe('skip')
+  })
+
+  // A missing estimate is itself worth seeing: the protocol asks for one so
+  // peers can plan, and its absence means someone skipped the step.
+  it('falls back to the default estimate and says it did', () => {
+    const l = lock({ estimatedEndAt: null, estimateProvided: false })
+    expect(lockExpiresAt(l)).toBe(NOW + DEFAULT_ESTIMATE_MS + TTL_GRACE_MS)
+    const d = decideDesktopGate({ requiresDesktop: true, lock: l, now: NOW + 60_000, agent: 'taric' })
+    expect(d.action).toBe('skip')
+    expect(d.reason).toContain('no estimate given')
+  })
+})
+
+describe('lock state IO', () => {
+  it('round-trips and clears', () => {
+    const p = join(dir, 'desktop-lock.json')
+    writeDesktopLock(lock({ note: 'Hendi kor' }), p)
+    const back = readDesktopLock(p)
+    expect(back?.owner).toBe('janna')
+    expect(back?.note).toBe('Hendi kor')
+    clearDesktopLock(p)
+    expect(readDesktopLock(p)).toBeNull()
+  })
+
+  it('treats an unreadable lock file as unlocked rather than wedging the fleet', () => {
+    const p = join(dir, 'broken.json')
+    writeDesktopLock(lock(), p)
+    // corrupt it
+    const fs = require('node:fs') as typeof import('node:fs')
+    fs.writeFileSync(p, '{ not json')
+    expect(readDesktopLock(p)).toBeNull()
+  })
+
+  it('ignores a lock row with no owner (half-written state is not a lock)', () => {
+    const p = join(dir, 'noowner.json')
+    const fs = require('node:fs') as typeof import('node:fs')
+    fs.writeFileSync(p, JSON.stringify({ acquiredAt: NOW }))
+    expect(readDesktopLock(p)).toBeNull()
+  })
+})
+
+describe('skip records', () => {
+  const rec = (over: Partial<DesktopSkipRecord> = {}): DesktopSkipRecord => ({
+    task: 'whatsapp-figyeles', agent: 'janna', at: NOW,
+    lockOwner: 'janna', lockedUntil: NOW + 3_000_000, reason: 'desktop locked by janna', ...over,
+  })
+
+  it('appends, so consecutive skips are all visible', () => {
+    const p = join(dir, 'skips.json')
+    recordDesktopSkip(rec({ at: NOW }), p)
+    recordDesktopSkip(rec({ at: NOW + 1800_000 }), p)
+    const list = JSON.parse(readFileSync(p, 'utf-8')) as DesktopSkipRecord[]
+    // Two consecutive skipped rounds is exactly the case that went unnoticed
+    // before this existed -- one record overwriting the other would hide it.
+    expect(list).toHaveLength(2)
+    expect(list[0].at).toBe(NOW)
+    expect(list[1].at).toBe(NOW + 1800_000)
+    expect(list[1].task).toBe('whatsapp-figyeles')
+    expect(list[1].lockOwner).toBe('janna')
+  })
+
+  it('bounds the file instead of growing forever', () => {
+    const p = join(dir, 'many.json')
+    for (let i = 0; i < 210; i++) recordDesktopSkip(rec({ at: NOW + i }), p)
+    const list = JSON.parse(readFileSync(p, 'utf-8')) as DesktopSkipRecord[]
+    expect(list).toHaveLength(200)
+    // the NEWEST are kept: an old trail is worth less than the current one
+    expect(list[list.length - 1].at).toBe(NOW + 209)
+  })
+
+  it('never throws on an unwritable path -- losing the trail beats losing the run loop', () => {
+    expect(() => recordDesktopSkip(rec(), join(dir, 'no', 'such', 'dir', 'x.json'))).not.toThrow()
+    expect(existsSync(join(dir, 'no'))).toBe(false)
+  })
+})

--- a/src/__tests__/desktop-lock-gate.test.ts
+++ b/src/__tests__/desktop-lock-gate.test.ts
@@ -194,3 +194,46 @@ describe('broadcast marker shape', () => {
     expect(src).toContain('[DESKTOP-FREE]')
   })
 })
+
+// ORDERING INVARIANT: in every branch the STATE write happens before the broadcast,
+// and a failing broadcast never rolls the state back.
+//
+// This is a deliberate asymmetry, not an oversight: the gate reads the STATE, the
+// message is only how humans and agents hear about it. If a message-queue error
+// could undo the lock, then the ERROR would open the gate -- the worst direction.
+// The consequence worth knowing when reading a half-applied deploy: "state set,
+// nobody told" is possible (safe: the gate holds, quietly), while "told, no state"
+// is NOT reachable through this route at all.
+//
+// Locked by a test rather than by line numbers in a runbook: the numbers drift the
+// first time someone edits the file, and a drifted reference reads as fact.
+describe('state-before-broadcast ordering', () => {
+  const src = readFileSync(
+    join(__dirname, '..', 'web', 'routes', 'desktop-lock.ts'), 'utf-8',
+  )
+  const code = src
+    .split('\n')
+    .filter(l => !l.trimStart().startsWith('//') && !l.trimStart().startsWith('*'))
+    .join('\n')
+
+  // Each entry: the state call that must come first, then the notification after it.
+  const branches: Array<[string, RegExp]> = [
+    ['writeDesktopLock(lock)', /broadcast\(owner,/],
+    ['clearDesktopLock()', /broadcast\(lock\.owner,/],
+  ]
+
+  for (const [stateCall, notifyRx] of branches) {
+    it(`${stateCall} precedes its broadcast`, () => {
+      const stateIdx = code.indexOf(stateCall)
+      expect(stateIdx).toBeGreaterThan(-1)
+      const notifyIdx = code.slice(stateIdx).search(notifyRx)
+      expect(notifyIdx).toBeGreaterThan(-1)
+    })
+  }
+
+  it('never rolls the state back when a broadcast fails', () => {
+    // the per-target catch logs and continues; it must not call the state writers
+    const helper = code.slice(code.indexOf('function broadcast('), code.indexOf('function hu('))
+    expect(helper).not.toMatch(/clearDesktopLock|writeDesktopLock/)
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -63,6 +63,7 @@ import { tryHandleOnboarding } from './web/routes/onboarding.js'
 import { tryHandleStatus } from './web/routes/status.js'
 import { tryHandleAutonomy } from './web/routes/autonomy.js'
 import { tryHandleApprovals, startApprovalTimeoutSweeper } from './web/routes/approvals.js'
+import { tryHandleDesktopLock, sweepExpiredDesktopLock } from './web/routes/desktop-lock.js'
 import { tryHandleTokenUsage } from './web/routes/token-usage.js'
 import { tryHandleCosts, startCostsSyncTask } from './web/routes/costs.js'
 import { tryHandleIdeas } from './web/routes/ideas.js'
@@ -199,6 +200,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleStatus(routeCtx)) return
       if (await tryHandleAutonomy(routeCtx)) return
       if (await tryHandleApprovals(routeCtx)) return
+      if (await tryHandleDesktopLock(routeCtx)) return
       if (await tryHandleTokenUsage(routeCtx)) return
       if (await tryHandleCosts(routeCtx)) return
       if (await tryHandleIdeas(routeCtx)) return
@@ -420,6 +422,10 @@ export function startWebServer(port = 3420): http.Server {
   // token estimates stay fresh without requiring a manual dashboard visit.
   // Sweep timed-out pending approvals every minute
   const approvalTimeoutInterval = startApprovalTimeoutSweeper()
+// Desktop-lock TTL sweeper. Independent of the schedule gate on purpose: an
+// abandoned lock must expire (and be reported) even on a day when no
+// desktop-driving round happens to be due.
+setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the loop */ } }, 60_000).unref?.()
 
   // Hourly sweep of expired browser-login sessions (7d idle / 30d absolute).
   // Runs regardless of WEB_ONLY -- it is a cheap indexed delete on the shared DB

--- a/src/web/desktop-lock.ts
+++ b/src/web/desktop-lock.ts
@@ -1,0 +1,194 @@
+// Desktop lock: ONE piece of state behind ONE call, so the fleet's "I am
+// driving the screen" convention becomes something a machine can gate on.
+//
+// Until now the lock was a convention only: the holder broadcast [DESKTOP-LOCK]
+// to the other agents and everyone was expected to keep their hands off. That
+// works for agents reading their inbox, and not at all for the scheduler, which
+// happily fires a GUI round into a session already driving the same screen.
+//
+// WHY THE BROADCAST IS SENT BY THE SAME CALL THAT SETS THE STATE (and not by
+// the caller, next to it): two mechanisms with no shared state are not two
+// protections, they are one extra failure path. A holder who broadcasts and
+// forgets the state call leaves the gate OPEN while the fleet believes the
+// screen is taken; the reverse leaves the gate CLOSED while everyone believes
+// it is free -- and neither divergence produces an error message. One call
+// cannot drift from itself.
+//
+// The gate deliberately does NOT stop everything. Only the rounds that need the
+// screen wait; email, kanban, memory and the watchdogs keep running. A blanket
+// suspension would produce blanket silence, and silence is what nobody
+// questions.
+import { existsSync, readFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROJECT_ROOT } from '../config.js'
+import { logger } from '../logger.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+
+export const DESKTOP_LOCK_PATH = join(PROJECT_ROOT, 'store', 'desktop-lock.json')
+
+/** Grace added to the holder's own estimate before the lock is considered
+ *  abandoned. Generous on purpose: a GUI round that runs long is normal, a
+ *  holder that died is not, and only the second one should open the gate. */
+export const TTL_GRACE_MS = 30 * 60_000
+
+/** Used when the holder gave no estimate. The gate records that it fell back
+ *  to this, because a missing estimate is itself worth seeing: the protocol
+ *  asks for one so peers can plan, and its absence means someone skipped it. */
+export const DEFAULT_ESTIMATE_MS = 30 * 60_000
+
+export interface DesktopLock {
+  owner: string
+  /** epoch ms */
+  acquiredAt: number
+  /** epoch ms; null when the holder gave no estimate (see estimateProvided) */
+  estimatedEndAt: number | null
+  /** false => estimatedEndAt was derived from DEFAULT_ESTIMATE_MS */
+  estimateProvided: boolean
+  /** epoch ms of the most recent extension, if the holder re-locked */
+  extendedAt?: number
+  /** how many times the holder extended -- an estimate that needed three
+   *  extensions is a better planning signal than the original number */
+  extensions?: number
+  note?: string
+}
+
+export function readDesktopLock(path: string = DESKTOP_LOCK_PATH): DesktopLock | null {
+  try {
+    if (!existsSync(path)) return null
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<DesktopLock>
+    if (!parsed || typeof parsed.owner !== 'string' || !parsed.owner) return null
+    if (typeof parsed.acquiredAt !== 'number') return null
+    return {
+      owner: parsed.owner,
+      acquiredAt: parsed.acquiredAt,
+      estimatedEndAt: typeof parsed.estimatedEndAt === 'number' ? parsed.estimatedEndAt : null,
+      estimateProvided: parsed.estimateProvided === true,
+      extendedAt: typeof parsed.extendedAt === 'number' ? parsed.extendedAt : undefined,
+      extensions: typeof parsed.extensions === 'number' ? parsed.extensions : undefined,
+      note: typeof parsed.note === 'string' ? parsed.note : undefined,
+    }
+  } catch (err) {
+    // An unreadable lock file must not wedge the fleet: treat it as no lock and
+    // say so loudly. The alternative (fail closed) would stop every GUI round
+    // until a human noticed a JSON typo.
+    logger.warn({ err, path }, 'desktop-lock: unreadable lock file, treating as unlocked')
+    return null
+  }
+}
+
+export function writeDesktopLock(lock: DesktopLock, path: string = DESKTOP_LOCK_PATH): void {
+  atomicWriteFileSync(path, JSON.stringify(lock, null, 2) + '\n')
+}
+
+export function clearDesktopLock(path: string = DESKTOP_LOCK_PATH): void {
+  try { if (existsSync(path)) unlinkSync(path) } catch { /* best effort */ }
+}
+
+/** When the lock stops being believed, in epoch ms. */
+export function lockExpiresAt(lock: DesktopLock): number {
+  const end = lock.estimatedEndAt ?? lock.acquiredAt + DEFAULT_ESTIMATE_MS
+  return end + TTL_GRACE_MS
+}
+
+export type DesktopGateAction = 'run' | 'skip' | 'run-lock-expired'
+
+export interface DesktopGateDecision {
+  action: DesktopGateAction
+  /** Human-readable reason, written to the skip record / log verbatim so the
+   *  decision is auditable without re-deriving it. */
+  reason: string
+  lockOwner?: string
+  /** epoch ms, present when a live lock is what caused a skip */
+  lockedUntil?: number
+}
+
+/**
+ * Pure gate decision. Kept free of IO so the interesting cases (expiry, own
+ * lock, missing estimate) are testable without a filesystem or a clock.
+ *
+ * `requiresDesktop` comes from the task's own config, never from a hard-coded
+ * list of task names here: a hand-maintained list is a blind spot the day
+ * someone adds a GUI round and forgets this file.
+ *
+ * A holder is never gated against ITSELF -- the lock exists to keep OTHERS off
+ * the screen, and a holder blocked by its own lock would deadlock its own
+ * round.
+ */
+export function decideDesktopGate(facts: {
+  requiresDesktop: boolean
+  lock: DesktopLock | null
+  now: number
+  /** the agent whose round is about to run */
+  agent?: string | null
+}): DesktopGateDecision {
+  const { requiresDesktop, lock, now, agent } = facts
+  if (!requiresDesktop) return { action: 'run', reason: 'task does not need the desktop' }
+  if (!lock) return { action: 'run', reason: 'no desktop lock held' }
+
+  const expiresAt = lockExpiresAt(lock)
+  if (now >= expiresAt) {
+    // Expiry is a FINDING, not routine: either the estimate was wrong or the
+    // holder died. The caller reports it; we make sure the wording carries
+    // which of the two shapes it looks like.
+    const overdueMin = Math.round((now - expiresAt) / 60_000)
+    return {
+      action: 'run-lock-expired',
+      reason: `desktop lock held by ${lock.owner} expired ${overdueMin} min ago `
+        + `(${lock.estimateProvided ? 'own estimate' : 'DEFAULT estimate -- none was given'} + grace); gate opened`,
+      lockOwner: lock.owner,
+      lockedUntil: expiresAt,
+    }
+  }
+
+  if (agent && agent === lock.owner) {
+    return { action: 'run', reason: `${agent} holds the desktop lock itself`, lockOwner: lock.owner }
+  }
+
+  const remainingMin = Math.max(0, Math.round((expiresAt - now) / 60_000))
+  return {
+    action: 'skip',
+    reason: `desktop locked by ${lock.owner} for up to ${remainingMin} more min`
+      + (lock.estimateProvided ? '' : ' (no estimate given, default used)'),
+    lockOwner: lock.owner,
+    lockedUntil: expiresAt,
+  }
+}
+
+export const DESKTOP_SKIPS_PATH = join(PROJECT_ROOT, 'store', 'desktop-lock-skips.json')
+/** Bound the file: this is an operational trail, not an archive. */
+const MAX_SKIP_RECORDS = 200
+
+export interface DesktopSkipRecord {
+  task: string
+  agent: string
+  /** epoch ms */
+  at: number
+  lockOwner: string | null
+  /** epoch ms the lock was believed to hold until */
+  lockedUntil: number | null
+  reason: string
+}
+
+/**
+ * Record a skipped round. A dropped tick that leaves no trace is
+ * indistinguishable from "there was nothing to do" -- and that is exactly how
+ * a missed customer message disappears. The record answers the three questions
+ * a later reader has: WHICH round, WHEN, and HOW LONG the screen was taken.
+ *
+ * Failure to write must not break the schedule tick: losing the trail is bad,
+ * losing the run loop is worse.
+ */
+export function recordDesktopSkip(rec: DesktopSkipRecord, path: string = DESKTOP_SKIPS_PATH): void {
+  try {
+    let list: DesktopSkipRecord[] = []
+    if (existsSync(path)) {
+      const parsed = JSON.parse(readFileSync(path, 'utf-8'))
+      if (Array.isArray(parsed)) list = parsed as DesktopSkipRecord[]
+    }
+    list.push(rec)
+    if (list.length > MAX_SKIP_RECORDS) list = list.slice(-MAX_SKIP_RECORDS)
+    atomicWriteFileSync(path, JSON.stringify(list, null, 2) + '\n')
+  } catch (err) {
+    logger.warn({ err, task: rec.task }, 'desktop-lock: could not record skipped round')
+  }
+}

--- a/src/web/routes/desktop-lock.ts
+++ b/src/web/routes/desktop-lock.ts
@@ -16,6 +16,19 @@ import type { RouteContext } from './types.js'
 // and the holder would answer the wrong party.
 const LOCK_SENDER = 'desktop-lock'
 
+// MARKER SHAPE: every broadcast starts with the BARE marker -- `[DESKTOP-LOCK]` or
+// `[DESKTOP-FREE]` -- and any qualifier (extension, expiry) follows AFTER the closing
+// bracket. Readers scan for these markers with a start-anchored `content LIKE
+// '[DESKTOP-LOCK...'`, and a qualifier placed INSIDE the brackets silently defeats the
+// bracket-closing variant of that pattern.
+//
+// Measured on 2026-08-04: a lock announced as `[DESKTOP-LOCK -- on behalf of the owner]`
+// returned ZERO hits from a peer's `LIKE '[DESKTOP-LOCK]%'` check -- so the STRICTEST lock
+// of the day (taken because the human owner was working on the screen) was the one the
+// detector could not see, and the peer nearly started a browser round on top of it. The
+// pattern was fixed too, but a message shape that only works with the fixed pattern would
+// re-open the same hole for the next reader who writes the obvious one.
+
 /** Everyone who must keep their hands off, minus the holder. Derived from the
  *  agent registry, never a hand-written list -- a new agent joins the fleet
  *  and is covered without anyone remembering this file. */
@@ -93,7 +106,7 @@ export async function tryHandleDesktopLock(ctx: RouteContext): Promise<boolean> 
 
     const until = hu(lock.estimatedEndAt as number)
     const head = isExtension
-      ? `[DESKTOP-LOCK MEGHOSSZABBITVA] ${owner}: a kepernyo tovabbra is foglalt, uj becsult vege ${until}.`
+      ? `[DESKTOP-LOCK] MEGHOSSZABBITVA -- ${owner}: a kepernyo tovabbra is foglalt, uj becsult vege ${until}.`
       : `[DESKTOP-LOCK] ${owner}: a kepernyo foglalt, becsult vege ${until}.`
     const estimateNote = lock.estimateProvided
       ? ''
@@ -154,7 +167,7 @@ export function sweepExpiredDesktopLock(now: number = Date.now()): boolean {
 
   try {
     createAgentMessage(LOCK_SENDER, lock.owner,
-      `[DESKTOP-LOCK LEJART] A te lockod lejart (${heldMin} perc utan; ${detail}), a kapu KINYITOTT.`
+      `[DESKTOP-LOCK] LEJART -- a te lockod lejart (${heldMin} perc utan; ${detail}), a kapu KINYITOTT.`
       + ' Ha meg a kepernyon dolgozol, AZONNAL nyiss ujat (POST /api/desktop-lock), kulonben masik'
       + ' ugynok is hozzanyulhat. Ha vegeztel, ezt hagyd figyelmen kivul -- de akkor a FREE-t'
       + ' legkozelebb kuldd el, mert enelkul a kapu csak lejaratra nyilik.')
@@ -162,7 +175,7 @@ export function sweepExpiredDesktopLock(now: number = Date.now()): boolean {
     logger.warn({ err, owner: lock.owner }, 'desktop-lock: could not notify holder about expiry')
   }
   broadcast(LOCK_SENDER, broadcastTargets(lock.owner),
-    `[DESKTOP-FREE / LEJARAT] ${lock.owner} lockja LEJART (${heldMin} perc, ${detail}).`
+    `[DESKTOP-FREE] LEJARAT -- ${lock.owner} lockja lejart (${heldMin} perc, ${detail}).`
     + ' A kepernyo szabad, DE a tulaj nem zarta le rendesen -- lehet, hogy meg ott dolgozik.'
     + ' Mielott hozzanyulsz, gyozodj meg rola.')
   return true

--- a/src/web/routes/desktop-lock.ts
+++ b/src/web/routes/desktop-lock.ts
@@ -55,6 +55,79 @@ function hu(dtMs: number): string {
   return new Date(dtMs).toLocaleTimeString('hu-HU', { hour: '2-digit', minute: '2-digit' })
 }
 
+/** The keys a POST body may carry. Anything else is either a caller bug or a
+ *  field this endpoint does not know about -- and the two need DIFFERENT
+ *  answers, which is what parseLockBody below decides. */
+const KNOWN_LOCK_KEYS = ['owner', 'note', 'estimatedMinutes'] as const
+
+function editDistance(a: string, b: string): number {
+  // Levenshtein, iterative single-row. Only ever run on short JSON key names.
+  let prev = [...Array(b.length + 1).keys()]
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i]
+    for (let j = 1; j <= b.length; j++) {
+      row[j] = Math.min(
+        prev[j] + 1,
+        row[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      )
+    }
+    prev = row
+  }
+  return prev[b.length]
+}
+
+export type LockBody = {
+  owner: string
+  note?: string
+  minutes: number | null
+  /** Keys we do not know. Reported back so the caller sees them immediately. */
+  unknownKeys: string[]
+  /** An unknown key that is one or two edits from a known one -- almost
+   *  certainly a typo, and the reason this function exists. */
+  typo?: { sent: string, meant: string }
+}
+
+/**
+ * Read the POST body, and REFUSE to silently ignore a misspelled key.
+ *
+ * Why this is not over-engineering (measured 2026-08-05, found by janna): a
+ * POST that said `estimateMinutes` instead of `estimatedMinutes` was accepted
+ * without a word. The unknown key fell out of the `typeof` test, `minutes`
+ * became null, and the lock was announced with the 30-minute DEFAULT -- for a
+ * round the holder had estimated at 2 minutes. Nothing in the response, the
+ * log, or the broadcast said a key had been dropped; the only symptom was an
+ * end time that looked plausible, just wrong. The cost is real work, not
+ * cosmetics: every screen-requiring round in that window is skipped, and the
+ * skip is correct behaviour for a lock the system believes lasts 30 minutes.
+ *
+ * A typo therefore gets a 400 naming the intended key -- a near-miss changes
+ * behaviour, so it must not pass. An unrelated extra key does NOT fail the
+ * request (a caller sending a harmless extra field should not be locked out of
+ * the screen), but it comes back in `unknownKeys` so it cannot stay invisible.
+ */
+export function parseLockBody(data: Record<string, unknown>): LockBody {
+  const owner = typeof data.owner === 'string' ? data.owner.trim() : ''
+  const note = typeof data.note === 'string' ? data.note.trim() : undefined
+  const minutes = typeof data.estimatedMinutes === 'number' && data.estimatedMinutes > 0
+    ? data.estimatedMinutes
+    : null
+
+  const unknownKeys = Object.keys(data).filter(
+    k => !(KNOWN_LOCK_KEYS as readonly string[]).includes(k),
+  )
+  let typo: LockBody['typo']
+  for (const sent of unknownKeys) {
+    // Case-insensitive: `estimatedminutes` is the same mistake as a one-letter
+    // slip, and both silently change the announced end time.
+    const meant = KNOWN_LOCK_KEYS.find(
+      known => editDistance(sent.toLowerCase(), known.toLowerCase()) <= 2,
+    )
+    if (meant) { typo = { sent, meant }; break }
+  }
+  return { owner, note, minutes, unknownKeys, typo }
+}
+
 export async function tryHandleDesktopLock(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
   if (path !== '/api/desktop-lock') return false
@@ -69,15 +142,25 @@ export async function tryHandleDesktopLock(ctx: RouteContext): Promise<boolean> 
     const body = await readBody(req)
     let data: Record<string, unknown> = {}
     try { data = JSON.parse(body.toString() || '{}') } catch { /* handled below */ }
-    const owner = typeof data.owner === 'string' ? data.owner.trim() : ''
+    const { owner, note, minutes, unknownKeys, typo } = parseLockBody(data)
     if (!owner) {
       json(res, { error: 'owner is required' }, 400)
       return true
     }
-    const note = typeof data.note === 'string' ? data.note.trim() : undefined
-    const minutes = typeof data.estimatedMinutes === 'number' && data.estimatedMinutes > 0
-      ? data.estimatedMinutes
-      : null
+    if (typo) {
+      // Refuse rather than lock with a silently defaulted estimate -- see
+      // parseLockBody. The caller gets the key it meant, so the retry is one edit.
+      logger.warn({ owner, sent: typo.sent, meant: typo.meant }, 'desktop-lock: misspelled body key')
+      json(res, {
+        error: `unknown key "${typo.sent}" -- did you mean "${typo.meant}"?`,
+        hint: 'a misspelled key would be ignored and the lock announced with the 30-minute default',
+        knownKeys: KNOWN_LOCK_KEYS,
+      }, 400)
+      return true
+    }
+    if (unknownKeys.length) {
+      logger.warn({ owner, unknownKeys }, 'desktop-lock: ignoring unknown body keys')
+    }
 
     const now = Date.now()
     const existing = readDesktopLock()
@@ -117,7 +200,10 @@ export async function tryHandleDesktopLock(ctx: RouteContext): Promise<boolean> 
       + ' [DESKTOP-FREE] megy, amint a tulaj felszabaditja.')
 
     logger.info({ owner, isExtension, estimateProvided: lock.estimateProvided }, 'desktop-lock: acquired')
-    json(res, { ok: true, lock, expiresAt: lockExpiresAt(lock) })
+    json(res, {
+      ok: true, lock, expiresAt: lockExpiresAt(lock),
+      ...(unknownKeys.length ? { unknownKeys } : {}),
+    })
     return true
   }
 

--- a/src/web/routes/desktop-lock.ts
+++ b/src/web/routes/desktop-lock.ts
@@ -1,0 +1,169 @@
+// Desktop-lock API. ONE call sets the state AND tells the fleet -- see
+// src/web/desktop-lock.ts for why the broadcast is not left to the caller.
+import { MAIN_AGENT_ID } from '../../config.js'
+import { createAgentMessage } from '../../db.js'
+import { logger } from '../../logger.js'
+import { listAgentNames } from '../agent-config.js'
+import {
+  readDesktopLock, writeDesktopLock, clearDesktopLock, lockExpiresAt,
+  DEFAULT_ESTIMATE_MS, type DesktopLock,
+} from '../desktop-lock.js'
+import { readBody, json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+// Sender label for lock traffic. Deliberately NOT the main agent's id: an
+// expiry notice attributed to a colleague reads as that colleague's opinion,
+// and the holder would answer the wrong party.
+const LOCK_SENDER = 'desktop-lock'
+
+/** Everyone who must keep their hands off, minus the holder. Derived from the
+ *  agent registry, never a hand-written list -- a new agent joins the fleet
+ *  and is covered without anyone remembering this file. */
+function broadcastTargets(owner: string): string[] {
+  const all = new Set<string>([MAIN_AGENT_ID, ...listAgentNames()])
+  all.delete(owner)
+  return [...all]
+}
+
+function broadcast(from: string, targets: string[], content: string): void {
+  for (const to of targets) {
+    try {
+      createAgentMessage(from, to, content)
+    } catch (err) {
+      // One undeliverable peer must not abort the rest of the broadcast, and
+      // must not fail the lock itself: the STATE is what the gate reads, the
+      // message is only how humans and agents hear about it.
+      logger.warn({ err, to }, 'desktop-lock: broadcast to one target failed')
+    }
+  }
+}
+
+function hu(dtMs: number): string {
+  return new Date(dtMs).toLocaleTimeString('hu-HU', { hour: '2-digit', minute: '2-digit' })
+}
+
+export async function tryHandleDesktopLock(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method } = ctx
+  if (path !== '/api/desktop-lock') return false
+
+  if (method === 'GET') {
+    const lock = readDesktopLock()
+    json(res, lock ? { locked: true, lock, expiresAt: lockExpiresAt(lock) } : { locked: false })
+    return true
+  }
+
+  if (method === 'POST') {
+    const body = await readBody(req)
+    let data: Record<string, unknown> = {}
+    try { data = JSON.parse(body.toString() || '{}') } catch { /* handled below */ }
+    const owner = typeof data.owner === 'string' ? data.owner.trim() : ''
+    if (!owner) {
+      json(res, { error: 'owner is required' }, 400)
+      return true
+    }
+    const note = typeof data.note === 'string' ? data.note.trim() : undefined
+    const minutes = typeof data.estimatedMinutes === 'number' && data.estimatedMinutes > 0
+      ? data.estimatedMinutes
+      : null
+
+    const now = Date.now()
+    const existing = readDesktopLock()
+    // A second POST by the same holder EXTENDS rather than conflicts: a round
+    // that grows (the operator hands over another job mid-run) is the normal
+    // case, and forcing an up-front over-estimate would park the fleet for
+    // longer than the work actually takes.
+    const isExtension = existing != null && existing.owner === owner
+    if (existing && !isExtension) {
+      json(res, {
+        error: `desktop is locked by ${existing.owner} until ${new Date(lockExpiresAt(existing)).toISOString()}`,
+        lock: existing,
+      }, 409)
+      return true
+    }
+
+    const lock: DesktopLock = {
+      owner,
+      acquiredAt: existing?.acquiredAt ?? now,
+      estimatedEndAt: minutes != null ? now + minutes * 60_000 : now + DEFAULT_ESTIMATE_MS,
+      estimateProvided: minutes != null,
+      note: note ?? existing?.note,
+      ...(isExtension ? { extendedAt: now, extensions: (existing?.extensions ?? 0) + 1 } : {}),
+    }
+    writeDesktopLock(lock)
+
+    const until = hu(lock.estimatedEndAt as number)
+    const head = isExtension
+      ? `[DESKTOP-LOCK MEGHOSSZABBITVA] ${owner}: a kepernyo tovabbra is foglalt, uj becsult vege ${until}.`
+      : `[DESKTOP-LOCK] ${owner}: a kepernyo foglalt, becsult vege ${until}.`
+    const estimateNote = lock.estimateProvided
+      ? ''
+      : ' FIGYELEM: becsult ido NEM erkezett, ezert a rendszer 30 perces alapertelmezest hasznal.'
+    broadcast(owner, broadcastTargets(owner),
+      `${head}${note ? ` ${note}` : ''}${estimateNote}`
+      + ' A kepernyot igenylo utemezett korok addig kimaradnak, es a kihagyas rekordot kap.'
+      + ' [DESKTOP-FREE] megy, amint a tulaj felszabaditja.')
+
+    logger.info({ owner, isExtension, estimateProvided: lock.estimateProvided }, 'desktop-lock: acquired')
+    json(res, { ok: true, lock, expiresAt: lockExpiresAt(lock) })
+    return true
+  }
+
+  if (method === 'DELETE') {
+    const lock = readDesktopLock()
+    if (!lock) {
+      json(res, { ok: true, wasLocked: false })
+      return true
+    }
+    clearDesktopLock()
+    const heldMin = Math.round((Date.now() - lock.acquiredAt) / 60_000)
+    broadcast(lock.owner, broadcastTargets(lock.owner),
+      `[DESKTOP-FREE] ${lock.owner}: a kepernyo szabad (${heldMin} perc utan).`)
+    logger.info({ owner: lock.owner, heldMin }, 'desktop-lock: released')
+    json(res, { ok: true, wasLocked: true, heldMinutes: heldMin })
+    return true
+  }
+
+  return false
+}
+
+/**
+ * TTL sweeper. An expired lock is opened AND reported -- to the fleet, to the
+ * log, and to the HOLDER, because the holder is the one party that may still
+ * be standing at the screen. Learning about it only when two agents collide
+ * would be the worst of the three outcomes.
+ *
+ * The wording distinguishes the two shapes an expiry can have (a bad estimate
+ * vs. an agent that died) by naming how long the lock ran past its own number:
+ * expiry is a finding, not routine, and a flat "lock expired" line would read
+ * as maintenance noise.
+ */
+export function sweepExpiredDesktopLock(now: number = Date.now()): boolean {
+  const lock = readDesktopLock()
+  if (!lock) return false
+  const expiresAt = lockExpiresAt(lock)
+  if (now < expiresAt) return false
+
+  clearDesktopLock()
+  const overdueMin = Math.round((now - expiresAt) / 60_000)
+  const heldMin = Math.round((now - lock.acquiredAt) / 60_000)
+  const detail = lock.estimateProvided
+    ? `a sajat becslesenel ${overdueMin} perccel tovabb allt`
+    : `becsult ido NEM volt megadva, ezert a 30 perces alapertelmezes + turelmi ido jart le`
+  logger.warn({ owner: lock.owner, heldMin, overdueMin, estimateProvided: lock.estimateProvided },
+    'desktop-lock: TTL expired, gate opened')
+
+  try {
+    createAgentMessage(LOCK_SENDER, lock.owner,
+      `[DESKTOP-LOCK LEJART] A te lockod lejart (${heldMin} perc utan; ${detail}), a kapu KINYITOTT.`
+      + ' Ha meg a kepernyon dolgozol, AZONNAL nyiss ujat (POST /api/desktop-lock), kulonben masik'
+      + ' ugynok is hozzanyulhat. Ha vegeztel, ezt hagyd figyelmen kivul -- de akkor a FREE-t'
+      + ' legkozelebb kuldd el, mert enelkul a kapu csak lejaratra nyilik.')
+  } catch (err) {
+    logger.warn({ err, owner: lock.owner }, 'desktop-lock: could not notify holder about expiry')
+  }
+  broadcast(LOCK_SENDER, broadcastTargets(lock.owner),
+    `[DESKTOP-FREE / LEJARAT] ${lock.owner} lockja LEJART (${heldMin} perc, ${detail}).`
+    + ' A kepernyo szabad, DE a tulaj nem zarta le rendesen -- lehet, hogy meg ott dolgozik.'
+    + ' Mielott hozzanyulsz, gyozodj meg rola.')
+  return true
+}

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { logger } from '../logger.js'
+import { decideDesktopGate, readDesktopLock, recordDesktopSkip } from './desktop-lock.js'
 import {
   PROJECT_ROOT,
   MAIN_AGENT_ID,
@@ -1221,6 +1222,47 @@ export function startScheduleRunner(): NodeJS.Timeout {
           appendTaskRun(task.name, agentName, 'skipped')
         }
         continue
+      }
+
+      // DESKTOP GATE. Only rounds that drive the screen wait for the lock;
+      // everything else (email, kanban, memory, watchdogs) keeps running. A
+      // blanket suspension would produce blanket silence, and silence is what
+      // nobody questions.
+      //
+      // The skip is RECORDED, never silent: a dropped tick with no trace is
+      // indistinguishable from "there was nothing to do", which is exactly how
+      // a missed customer message disappears. Observed the day this was built:
+      // two consecutive WhatsApp rounds were lost behind two GUI rounds and
+      // only a human noticing the gap brought them back.
+      if (task.requiresDesktop) {
+        const gate = decideDesktopGate({
+          requiresDesktop: true,
+          lock: readDesktopLock(),
+          now,
+          agent: task.agent === 'all' ? null : (task.agent || MAIN_AGENT_ID),
+        })
+        if (gate.action === 'skip') {
+          logger.info({ task: task.name, reason: gate.reason }, 'Schedule skipped: desktop locked')
+          scheduleLastRun.set(task.name, now)
+          persistScheduleLastRun()
+          for (const agentName of targetAgents) {
+            appendTaskRun(task.name, agentName, 'skipped-desktop-lock')
+            recordDesktopSkip({
+              task: task.name,
+              agent: agentName,
+              at: now,
+              lockOwner: gate.lockOwner ?? null,
+              lockedUntil: gate.lockedUntil ?? null,
+              reason: gate.reason,
+            })
+          }
+          continue
+        }
+        if (gate.action === 'run-lock-expired') {
+          // Not a skip: we run. But an expired lock is a finding (bad estimate
+          // or a holder that died), so it is never passed over quietly.
+          logger.warn({ task: task.name, reason: gate.reason }, 'Schedule ran through an EXPIRED desktop lock')
+        }
       }
 
       for (const agentName of targetAgents) {

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -29,6 +29,12 @@ export interface ScheduledTask {
   // skipIfBusy false (default) so the queue + alert path catches a
   // long-running busy state and nothing business-critical is lost.
   skipIfBusy?: boolean
+  // When true, this task drives the shared desktop (GUI automation,
+  // computer-use). While another agent holds the desktop lock, its ticks are
+  // skipped -- and the skip is RECORDED, never silent. Marked per task rather
+  // than matched against a list of task names in the runner: a hand-kept list
+  // is a blind spot the day someone adds a GUI round and forgets it.
+  requiresDesktop?: boolean
   // When true, skip the busy-state check entirely and inject the prompt
   // via tmux send-keys regardless. The Claude session will process it at
   // the next idle slot. Useful for critical tasks that must never be
@@ -104,7 +110,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const skillContent = hasSkill ? readFileOr(skillPath, '') : ''
   const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: unknown; stuckAfterMinutes?: unknown; requires?: { mcp_servers?: unknown } } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; requiresDesktop?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: unknown; stuckAfterMinutes?: unknown; requires?: { mcp_servers?: unknown } } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
@@ -119,6 +125,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
     createdAt: config.createdAt || 0,
     type: (config.type as 'task' | 'heartbeat' | 'command') || 'task',
     skipIfBusy: config.skipIfBusy === true,
+    requiresDesktop: config.requiresDesktop === true,
     forceSend: config.forceSend === true,
     targetSession: config.targetSession || undefined,
     command: config.command,


### PR DESCRIPTION
## What

Turns the fleet's desktop-lock convention into state a machine can gate on: `POST/DELETE/GET /api/desktop-lock`, a `requiresDesktop` flag on scheduled tasks, a recorded skip, and a TTL sweeper.

## Why

The lock already existed as a convention -- the agent about to drive the GUI broadcast `[DESKTOP-LOCK]` and its peers kept their hands off. That works for agents reading their inbox, and not at all for the scheduler, which fires a GUI round into a session already driving the same screen.

## Four decisions worth reviewing

**One call, not two.** `POST` sets the state **and** sends the broadcast. The obvious alternative -- let the holder call the API next to its existing broadcast -- is two mechanisms with no shared state, which is not two protections but one extra failure path: broadcast without the call leaves the gate open while the fleet believes the screen is taken; the reverse leaves it closed while everyone believes it is free. Neither divergence produces an error message.

**The gate is narrow.** Only tasks marked `requiresDesktop` in their own `task-config.json` wait. Email, kanban, memory and the watchdogs keep running -- a blanket suspension produces blanket silence, and silence is what nobody questions. The flag lives on the task, not in a list of task names in the runner, so a GUI round added later is covered without anyone remembering this file.

**A skipped round is never silent.** Each gated tick writes a `skipped-desktop-lock` task_run plus a record naming the round, the time, the holder and how long the screen is expected to stay taken. An untraced dropped tick is indistinguishable from "there was nothing to do" -- which is how a missed customer message disappears. Observed the day this was written: two consecutive WhatsApp rounds were lost behind two GUI rounds, and only a human noticing the gap brought them back.

**Expiry is a finding, not routine.** Estimate + 30 min grace (30 min default if no estimate was given, and the gate says it fell back -- a missing estimate means someone skipped a step the protocol asks for). A second `POST` by the same holder **extends** rather than conflicts, so a round that grows mid-run does not force an up-front over-estimate. On expiry the sweeper opens the gate, logs it, tells the fleet, and tells the **holder** -- the one party that may still be at the screen and would otherwise learn about it from a collision.

## Tests

`src/__tests__/desktop-lock-gate.test.ts`, 13 cases: every gate branch (non-desktop task runs, holder not gated against itself, grace period, default-estimate wording, expiry), state IO (a corrupt or half-written lock file reads as unlocked rather than wedging the fleet), and the skip trail (two consecutive skips both survive, the file is bounded, an unwritable path never throws -- losing the trail beats losing the run loop).

Verified as a real guard, not just green: with the gate short-circuited 4 of the 13 fail.

`npx tsc --noEmit` clean. The wider suite shows the same 19 pre-existing failures in 4 files (`email-send-gate`, `governance-gates`, `hook-command-quoting`, `hook-path-guard`) that a pristine `origin/develop` at 8df36ff shows; untouched here.

## Follow-up (not in this PR)

The holders' own runbooks need the one-line call added where they broadcast today, and the three screen-driving tasks need `requiresDesktop: true`. Both are install-side config, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)